### PR TITLE
fix(graphql): remove test-database feature referencing dev-dependency

### DIFF
--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -27,7 +27,6 @@ subscription = [
 di = ["dep:reinhardt-di", "dep:reinhardt-graphql-macros"]
 # All features enabled
 full = ["graphql-grpc", "subscription", "di"]
-test-database = ["reinhardt-test/testcontainers"]
 
 [dependencies]
 # Core dependencies (merged from graphql-core)


### PR DESCRIPTION
## Summary

- `reinhardt-graphql` の `test-database` feature が dev-dependency の `reinhardt-test` を参照しており、`cargo publish` 時にエラーとなる問題を修正
- この feature はソースコード内で未使用であり、テスト時は dev-dependencies で直接 testcontainers が有効化されているため、削除のみで対応

## Test plan

- [x] `cargo check -p reinhardt-graphql --all-features` が成功すること
- [x] `test-database` feature 削除後も既存テストが影響を受けないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)