### PR TITLE
docs(rest): update CHANGELOG.md for v0.1.0-alpha.1 and v0.1.0-alpha.2

### DIFF
--- a/crates/reinhardt-rest/CHANGELOG.md
+++ b/crates/reinhardt-rest/CHANGELOG.md
@@ -6,28 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- N/A
 
-### Added
-- Work in progress features (not yet released)
-
-### Changed
-- N/A
-
-### Deprecated
-- N/A
-
-### Removed
-- N/A
+## [0.1.0-alpha.2] - 2026-01-23
 
 ### Fixed
-- N/A
 
-### Security
-- N/A
+- Embed branding assets within crate for crates.io compatibility
 
-
-## [0.1.0] - 2025-11-16
+## [0.1.0-alpha.1] - 2026-01-23
 
 ### Added
-- Initial release with rESTful API framework with serializers, viewsets, and browsable API interface
+
+- Initial release with RESTful API framework with serializers, viewsets, and browsable API interface


### PR DESCRIPTION
## Summary
- Condense and update CHANGELOG.md entries for reinhardt-rest v0.1.0-alpha.1 and v0.1.0-alpha.2

## Test plan
- [x] Verify CHANGELOG.md formatting is correct
- [x] No code changes, documentation only