### PR TITLE
docs: add version cascade and CHANGELOG update rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ See docs/TESTING_STANDARDS.md for comprehensive testing standards including:
 - Planned features go in `lib.rs` header, NOT in README.md
 - Test all code examples
 - Verify all links are valid
+- **ALWAYS** update crate's `CHANGELOG.md` when `Cargo.toml` version changes (same commit)
+- **CHANGELOG.md MUST be written in English** (no exceptions)
 - **NEVER** document user requests or AI assistant interactions in project documentation
   - Documentation must describe technical reasons, design decisions, and implementation details
   - Avoid phrases like "User requested...", "As requested by...", "User asked..."
@@ -158,6 +160,11 @@ See docs/COMMIT_GUIDELINE.md for detailed commit guidelines including:
   - `cargo publish --dry-run -p <crate-name>`
 - Commit version bump and CHANGELOG updates BEFORE creating tag
 - Push commits and tags AFTER successful publish
+
+**Version Cascade Policy:**
+- When a sub-crate's version changes, the main crate (`reinhardt-web`) version MUST also be updated appropriately
+- The main crate's CHANGELOG.md MUST reference the sub-crate changes
+- Version bump level follows SemVer: sub-crate breaking change → main crate breaking change
 
 **Publishing Workflow:**
 1. Update crate version in `Cargo.toml`
@@ -337,6 +344,8 @@ Before submitting code:
 - Verify with `--dry-run` before publishing to crates.io
 - Commit version bump before creating tags
 - Update crate's CHANGELOG.md with version changes
+- Write CHANGELOG.md in English (no exceptions)
+- Update main crate (`reinhardt-web`) version when any sub-crate version changes
 - Use GitHub CLI (`gh`) for all GitHub operations (PR, issues, releases)
 - Use `rstest` for ALL test cases (no plain `#[test]`)
 - Use `reinhardt-test` fixtures for test setup/teardown
@@ -370,6 +379,8 @@ Before submitting code:
 - Publish to crates.io without explicit user authorization
 - Create Git tags before committing version changes
 - Skip `--dry-run` verification before publishing
+- Update sub-crate version without updating main crate version
+- Change `Cargo.toml` version without updating corresponding CHANGELOG.md
 - Make breaking changes without MAJOR version bump
 - Start commit description with uppercase letter
 - End commit description with a period

--- a/docs/DOCUMENTATION_STANDARDS.md
+++ b/docs/DOCUMENTATION_STANDARDS.md
@@ -690,6 +690,11 @@ let conn = connect("postgres://localhost")?;
 ```
 
 **3. CHANGELOG.md:**
+
+**Language Requirement:**
+- **MUST be written in English** (no exceptions)
+- All entries, descriptions, and migration guides must use English
+
 ```markdown
 ## [0.2.0] - 2025-01-XX
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -412,6 +412,11 @@ impl Pool {
 - [ ] CHANGELOG.md prepared
 - [ ] Code examples tested: `cargo test --doc`
 
+### Version Cascade
+
+- [ ] Main crate (`reinhardt-web`) version updated if sub-crate version changed
+- [ ] Main crate CHANGELOG.md references sub-crate changes
+
 ### Metadata
 
 - [ ] `description`, `license`, `repository` fields present


### PR DESCRIPTION
## Summary
- Add version cascade rules to CLAUDE.md
- Add CHANGELOG update guidelines to DOCUMENTATION_STANDARDS.md
- Add version cascade procedures to RELEASE_PROCESS.md

## Test plan
- [x] Verify documentation formatting
- [x] No code changes, documentation only