### PR TITLE
docs: prefer GitHub MCP tools over gh CLI when available

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,13 +120,26 @@ See docs/DOCUMENTATION_STANDARDS.md for comprehensive documentation standards.
 - **NEVER** execute batch commits without user confirmation
 
 **GitHub Integration:**
-- **MUST** use GitHub CLI (`gh`) for all GitHub operations
-- Use `gh pr create` for creating pull requests
-- Use `gh pr view` for viewing PR details
-- Use `gh issue create` for creating issues
-- Use `gh issue view` for viewing issue details
-- Use `gh api` for accessing GitHub API
-- **NEVER** use raw `curl` or web browser for GitHub operations when `gh` is available
+- **MUST** prefer GitHub MCP tools when available for all GitHub operations
+- **Fallback**: Use GitHub CLI (`gh`) when GitHub MCP is not available
+- **Priority order**: GitHub MCP > GitHub CLI (`gh`) > raw API
+- **NEVER** use raw `curl` or web browser for GitHub operations when MCP or `gh` is available
+
+**GitHub MCP Tool Mapping:**
+
+| Operation | GitHub MCP Tool | gh CLI Fallback |
+|-----------|----------------|-----------------|
+| Create PR | `create_pull_request` | `gh pr create` |
+| View PR | `pull_request_read` (method: get) | `gh pr view` |
+| List PRs | `list_pull_requests` | `gh pr list` |
+| Create Issue | `issue_write` (method: create) | `gh issue create` |
+| View Issue | `issue_read` (method: get) | `gh issue view` |
+| List Issues | `list_issues` | `gh issue list` |
+| Search Code | `search_code` | `gh api search/code` |
+| Get File | `get_file_contents` | `gh api repos/.../contents` |
+| Create Branch | `create_branch` | `gh api refs` |
+| List Commits | `list_commits` | `gh api commits` |
+| List Releases | `list_releases` | `gh release list` |
 - **MUST** write all PR titles and descriptions in English
 - **MUST** write all issue titles and descriptions in English
 
@@ -238,7 +251,12 @@ docker ps
 # Docker daemon should be running automatically on most systems
 ```
 
-**GitHub Operations (using GitHub CLI):**
+**GitHub Operations:**
+
+When GitHub MCP is available, use MCP tools directly (preferred).
+When unavailable, fall back to GitHub CLI.
+
+**GitHub CLI Fallback:**
 ```bash
 # Pull Requests
 gh pr create --title "feat: Add feature" --body "Description" --label enhancement
@@ -354,7 +372,7 @@ Before submitting code:
 - Update crate's CHANGELOG.md with version changes
 - Write CHANGELOG.md in English (no exceptions)
 - Update main crate (`reinhardt-web`) version when any sub-crate version changes
-- Use GitHub CLI (`gh`) for all GitHub operations (PR, issues, releases)
+- Prefer GitHub MCP tools when available; fall back to `gh` CLI otherwise
 - Write all PR titles and descriptions in English
 - Write all issue titles and descriptions in English
 - Add appropriate labels to every PR (`enhancement`, `bug`, `documentation`, etc.)

--- a/docs/PR_GUIDELINE.md
+++ b/docs/PR_GUIDELINE.md
@@ -25,11 +25,12 @@ This file defines the pull request (PR) policy for the Reinhardt project. These 
 
 ## PR Creation Policy
 
-### PC-1 (MUST): Use GitHub CLI
+### PC-1 (MUST): Use GitHub MCP or CLI
 
-- **MUST** use GitHub CLI (`gh`) for creating pull requests
-- **NEVER** use web browser UI for PR creation when CLI is available
-- CLI ensures consistency and can be automated
+- **MUST** prefer GitHub MCP tools (`create_pull_request`) for creating pull requests when available
+- **Fallback**: Use GitHub CLI (`gh pr create`) when GitHub MCP is not available
+- **NEVER** use web browser UI for PR creation when MCP or CLI is available
+- MCP and CLI both ensure consistency and can be automated
 
 **Example:**
 ```bash
@@ -84,7 +85,7 @@ gh pr create --draft --title "feat(auth): add JWT validation (WIP)"
 
 - **MUST** add appropriate labels to every PR
 - Labels help categorize, prioritize, and track PRs
-- Use GitHub CLI or web UI to add labels
+- Use GitHub MCP (`update_pull_request`), GitHub CLI, or web UI to add labels
 
 **Required Labels by PR Type:**
 
@@ -499,7 +500,7 @@ docs(readme): add installation instructions
 
 ### ✅ MUST DO
 - Write all PR content in English
-- Use `gh pr create` for creating PRs
+- Use GitHub MCP (`create_pull_request`) or `gh pr create` for creating PRs
 - Follow Conventional Commits format for titles
 - Include Summary and Test plan sections
 - Run all checks before requesting review
@@ -521,4 +522,5 @@ docs(readme): add installation instructions
 - **Main Quick Reference**: @CLAUDE.md (see Quick Reference section)
 - **Commit Guidelines**: @docs/COMMIT_GUIDELINE.md
 - **Release Process**: @docs/RELEASE_PROCESS.md
-- **GitHub CLI Documentation**: https://cli.github.com/manual/
+- **GitHub MCP Tools**: Available when GitHub MCP server is configured
+- **GitHub CLI Documentation (fallback)**: https://cli.github.com/manual/

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -643,7 +643,7 @@ For **each published crate**, configure Trusted Publisher on crates.io:
 **Efficiency Tips**:
 
 - Start with core crates: `reinhardt-macros`, `reinhardt-core`, `reinhardt-orm`
-- Can use GitHub CLI or API for batch configuration
+- Can use GitHub MCP tools, GitHub CLI, or API for batch configuration
 - Only published crates need configuration (unpublished crates skip this)
 
 #### Step 2: Create GitHub Environment


### PR DESCRIPTION
## Summary

- Add priority order for GitHub operations: GitHub MCP > GitHub CLI (`gh`) > raw API
- Add GitHub MCP Tool Mapping table in CLAUDE.md for quick reference
- Update PR_GUIDELINE.md and RELEASE_PROCESS.md to reflect MCP preference

## Test plan

- [ ] Verify markdown renders correctly (tables, formatting)
- [ ] Confirm no broken links in documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)