### PR TITLE
chore(changelog): remove obsolete [0.1.0] sections

### DIFF
--- a/crates/reinhardt-auth/CHANGELOG.md
+++ b/crates/reinhardt-auth/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with authentication and authorization system with JWT, Token, Session, and Basic auth support

--- a/crates/reinhardt-commands/CHANGELOG.md
+++ b/crates/reinhardt-commands/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with management command framework for custom CLI tools and database migrations

--- a/crates/reinhardt-conf/CHANGELOG.md
+++ b/crates/reinhardt-conf/CHANGELOG.md
@@ -34,7 +34,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with configuration management with environment-based settings and type-safe access

--- a/crates/reinhardt-core/CHANGELOG.md
+++ b/crates/reinhardt-core/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with core framework components including types, validators, signals, and security utilities

--- a/crates/reinhardt-db/CHANGELOG.md
+++ b/crates/reinhardt-db/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with database abstraction layer with ORM, migrations, and multi-backend support

--- a/crates/reinhardt-di/CHANGELOG.md
+++ b/crates/reinhardt-di/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with dependency injection system for managing application dependencies and lifecycle

--- a/crates/reinhardt-dispatch/CHANGELOG.md
+++ b/crates/reinhardt-dispatch/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with event dispatching system for decoupled component communication

--- a/crates/reinhardt-forms/CHANGELOG.md
+++ b/crates/reinhardt-forms/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with form handling and validation with automatic HTML generation

--- a/crates/reinhardt-graphql/CHANGELOG.md
+++ b/crates/reinhardt-graphql/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with graphQL API support with schema generation and subscription capabilities

--- a/crates/reinhardt-graphql/macros/CHANGELOG.md
+++ b/crates/reinhardt-graphql/macros/CHANGELOG.md
@@ -27,7 +27,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with procedural macros for GraphQL schema definition and code generation

--- a/crates/reinhardt-grpc/CHANGELOG.md
+++ b/crates/reinhardt-grpc/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with gRPC server support for high-performance RPC communication

--- a/crates/reinhardt-http/CHANGELOG.md
+++ b/crates/reinhardt-http/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with hTTP primitives including Request, Response, and middleware types

--- a/crates/reinhardt-i18n/CHANGELOG.md
+++ b/crates/reinhardt-i18n/CHANGELOG.md
@@ -19,7 +19,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with internationalization support with translation catalogs and locale management

--- a/crates/reinhardt-mail/CHANGELOG.md
+++ b/crates/reinhardt-mail/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with email sending capabilities with template support and multiple backends

--- a/crates/reinhardt-middleware/CHANGELOG.md
+++ b/crates/reinhardt-middleware/CHANGELOG.md
@@ -34,7 +34,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with request/response processing pipeline with built-in middleware components

--- a/crates/reinhardt-server/CHANGELOG.md
+++ b/crates/reinhardt-server/CHANGELOG.md
@@ -34,7 +34,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with hTTP server implementation with async request handling and connection management

--- a/crates/reinhardt-shortcuts/CHANGELOG.md
+++ b/crates/reinhardt-shortcuts/CHANGELOG.md
@@ -19,7 +19,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with utility functions for common operations like render, redirect, and get_object_or_404

--- a/crates/reinhardt-tasks/CHANGELOG.md
+++ b/crates/reinhardt-tasks/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with background task execution with scheduling and queue management

--- a/crates/reinhardt-test/CHANGELOG.md
+++ b/crates/reinhardt-test/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with testing utilities including fixtures, test client, and database helpers

--- a/crates/reinhardt-urls/CHANGELOG.md
+++ b/crates/reinhardt-urls/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with uRL routing system with pattern matching and reverse URL resolution

--- a/crates/reinhardt-utils/CHANGELOG.md
+++ b/crates/reinhardt-utils/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with shared utilities including caching, logging, static files, and storage backends

--- a/crates/reinhardt-views/CHANGELOG.md
+++ b/crates/reinhardt-views/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with view layer with function-based and class-based views, viewsets, and generic views

--- a/crates/reinhardt-websockets/CHANGELOG.md
+++ b/crates/reinhardt-websockets/CHANGELOG.md
@@ -33,7 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial crates.io release
 
-## [0.1.0] - 2025-11-16
-
-### Added
-- Initial release with webSocket support for real-time bidirectional communication with rooms and authentication


### PR DESCRIPTION
## Summary

Remove obsolete `## [0.1.0]` sections from 23 CHANGELOG.md files across the codebase.

## Background

These sections are no longer needed as the project uses `0.1.0-alpha.x` versioning scheme for the initial release. The `## [0.1.0]` sections were leftover from the initial documentation structure and are now redundant.

## Changes

- **Modified 23 CHANGELOG.md files**:
  - reinhardt-auth, reinhardt-commands, reinhardt-conf, reinhardt-core
  - reinhardt-db, reinhardt-di, reinhardt-dispatch
  - reinhardt-forms, reinhardt-graphql, reinhardt-graphql/macros
  - reinhardt-grpc, reinhardt-http, reinhardt-i18n
  - reinhardt-mail, reinhardt-middleware, reinhardt-server
  - reinhardt-shortcuts, reinhardt-tasks, reinhardt-test
  - reinhardt-urls, reinhardt-utils, reinhardt-views, reinhardt-websockets

## Test Plan

- [x] Verified `## [0.1.0]` sections are removed from all CHANGELOG.md files
- [x] Verified `## [0.1.0-alpha.x]` sections remain intact
- [x] No grep matches for `## [0.1.0]` in crates/*/CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)