### PR TITLE
fix(ci): correct rust-toolchain action version in publish-dry-run workflow

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0  # Full history for cargo-workspaces
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.91.1
 
       - name: Install protoc
         run: |


### PR DESCRIPTION
## Summary

- Fix incorrect `dtolnay/rust-toolchain` action version (1.100.0 → 1.91.1)
- Version 1.100.0 does not exist, causing workflow failure

## Test plan

- [ ] GitHub Actions workflow runs successfully
- [ ] Rust toolchain installation completes without errors