### PR TITLE
ci(workflows): add Docker Hub authentication to avoid rate limits

### DIFF
--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -1,0 +1,20 @@
+name: Docker Login
+description: Login to Docker Hub to avoid rate limits
+
+inputs:
+  username:
+    description: Docker Hub username
+    required: false
+  token:
+    description: Docker Hub access token
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Login to Docker Hub
+      if: inputs.username != '' && inputs.token != ''
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.username }}
+        password: ${{ inputs.token }}

--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Login to Docker Hub
+        uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Login to Docker Hub
+        uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Login to Docker Hub
+        uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:

--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Login to Docker Hub
+        uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Login to Docker Hub
+        uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Login to Docker Hub
+        uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
 


### PR DESCRIPTION
## Summary

- Add `docker-login` composite action for Docker Hub authentication
- Integrate Docker Hub login into all test workflows to increase pull rate limit from 100/6h to 200/6h
- Authentication is optional (workflows run without secrets in forks)

## Background

GitHub CI environment hit Docker Hub's unauthenticated pull rate limit (100 pulls/6h per IP), causing TestContainers to fail when starting PostgreSQL containers:

```
toomanyrequests: You have reached your unauthenticated pull rate limit.
```

## Changes

**New file:**
- `.github/actions/docker-login/action.yml` - Composite action for Docker Hub authentication

**Modified workflows:**
- `unit-test.yml`
- `intra-crate-integration-test.yml`
- `cross-crate-integration-test.yml`
- `examples-test.yml`
- `doc-test.yml`
- `ui-test.yml`

## Required Setup

After merging, add the following secrets to the repository (Settings > Secrets and variables > Actions):

| Secret | Value |
|--------|-------|
| `DOCKERHUB_USERNAME` | Docker Hub username |
| `DOCKERHUB_TOKEN` | Docker Hub Access Token (Read-only) |

**Creating Docker Hub Access Token:**
1. Visit https://hub.docker.com/settings/security
2. Click "New Access Token"
3. Description: `github-actions-reinhardt`
4. Access permissions: `Read-only`
5. Click "Generate" and copy the token

## Test plan

- [ ] Verify CI passes (authentication is optional, so it should work even without secrets)
- [ ] After adding secrets, verify Docker pulls succeed in all test workflows
- [ ] Verify forks can still run CI (without authentication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)