### PR TITLE
docs(badge): fix crates.io and docs.rs badge links to point to reinhardt-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   <p>Build with <em>all</em> the power of Django's batteries-included philosophy,<br/>
   or compose <em>only</em> what you need—your choice, your way.</p>
 
-[![Crates.io](https://img.shields.io/crates/v/reinhardt.svg)](https://crates.io/crates/reinhardt)
-[![Documentation](https://docs.rs/reinhardt/badge.svg)](https://docs.rs/reinhardt)
+[![Crates.io](https://img.shields.io/crates/v/reinhardt-web.svg)](https://crates.io/crates/reinhardt-web)
+[![Documentation](https://docs.rs/reinhardt-web/badge.svg)](https://docs.rs/reinhardt-web)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE)
 
 </div>
@@ -25,7 +25,7 @@ You may be looking for:
 - 📦 [Installation Options](#installation) - Choose your flavor: Micro, Standard, or Full
 - 📚 [Getting Started Guide](docs/GETTING_STARTED.md) - Step-by-step tutorial
 - 🎛️ [Feature Flags](docs/FEATURE_FLAGS.md) - Fine-tune your build
-- 📖 [API Documentation](https://docs.rs/reinhardt) - Complete API reference
+- 📖 [API Documentation](https://docs.rs/reinhardt-web) - Complete API reference
 - 💬 [Community & Support](#getting-help) - Get help from the community
 
 ## Why Reinhardt?


### PR DESCRIPTION
## Summary

Fixes #85

The badges in README.md were incorrectly linking to `reinhardt` instead of `reinhardt-web`, causing users to be directed to non-existent crates.io and docs.rs pages.

## Changes

- Updated Crates.io badge link and image URL from `reinhardt` to `reinhardt-web`
- Updated Documentation badge link and image URL from `reinhardt` to `reinhardt-web`
- Updated API Documentation link from `reinhardt` to `reinhardt-web`

## Test plan

- [x] Verified all badge links now point to correct URLs
- [x] Verified README.md renders correctly

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)