### PR TITLE
fix(ci): correct rust-toolchain action reference in publish-on-merge

### DIFF
--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -48,7 +48,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91.1
 
       - name: Install protoc
         run: |


### PR DESCRIPTION
## Summary

- Fix `dtolnay/rust-toolchain@1.100.0` incorrect action reference that caused publish workflow to fail

## Problem

The `publish-on-merge.yml` workflow failed with:
```
error: could not download nonexistent rust version `1.100.0-x86_64-unknown-linux-gnu`
```

The action reference was treating `1.100.0` as a Git ref in the action's repository, not as a Rust version.

## Changes

```diff
- uses: dtolnay/rust-toolchain@1.100.0
+ uses: dtolnay/rust-toolchain@master
+   with:
+     toolchain: 1.91.1
```

## Context

This is the same fix as PR #74 which was accidentally merged to `feature/nosql-odm` instead of `main`.

Reference: https://github.com/kent8192/reinhardt-web/actions/runs/21436376849/job/61728005879

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Merge and confirm publish workflow succeeds on next release PR

🤖 Generated with [Claude Code](https://claude.ai/claude-code)