### PR TITLE
ci: add concurrency to auto-cancel outdated PR workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     # Run CI on PRs targeting any branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -6,6 +6,10 @@ on:
       - main
     types: [opened, synchronize, reopened, labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Summary
- Add `concurrency` configuration to CI workflows to automatically cancel in-progress runs when a new push is made to the same PR branch
- Reduces CI resource usage by stopping obsolete workflow runs
- Affects: `ci.yml`, `publish-dry-run.yml`, `publish-on-merge.yml`

## Test plan
- [ ] Create a PR and push multiple commits in quick succession
- [ ] Verify that older workflow runs are cancelled in GitHub Actions tab
- [ ] Verify that only the latest push's workflow runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)