### PR TITLE
fix(ci): add API token fallback for unpublished crates

### DIFF
--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -76,9 +76,56 @@ jobs:
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces
 
-      - name: Authenticate to crates.io with OIDC
-        uses: rust-lang/crates-io-auth-action@v1
+      - name: Authenticate to crates.io
         id: auth
+        env:
+          FALLBACK_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          # Try Trusted Publishing (OIDC) first
+          echo "Attempting Trusted Publishing authentication..."
+
+          # Get OIDC token from GitHub
+          OIDC_TOKEN=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=crates.io" | jq -r '.value')
+
+          if [ -n "$OIDC_TOKEN" ] && [ "$OIDC_TOKEN" != "null" ]; then
+            # Exchange OIDC token for crates.io token
+            RESPONSE=$(curl -sS -X POST "https://crates.io/api/v1/trusted_publishing/tokens" \
+              -H "Content-Type: application/json" \
+              -d "{\"jwt\": \"$OIDC_TOKEN\"}" 2>&1)
+
+            TOKEN=$(echo "$RESPONSE" | jq -r '.token // empty')
+
+            if [ -n "$TOKEN" ]; then
+              echo "✅ Trusted Publishing authentication successful"
+              echo "token=$TOKEN" >> $GITHUB_OUTPUT
+              echo "auth_method=trusted_publishing" >> $GITHUB_OUTPUT
+              exit 0
+            else
+              echo "⚠️ Trusted Publishing token exchange failed"
+              echo "Response: $RESPONSE"
+            fi
+          else
+            echo "⚠️ Failed to get OIDC token from GitHub"
+          fi
+
+          # Fallback to API token
+          echo "Falling back to API token authentication..."
+          if [ -n "$FALLBACK_TOKEN" ]; then
+            echo "✅ Using API token for authentication"
+            echo "token=$FALLBACK_TOKEN" >> $GITHUB_OUTPUT
+            echo "auth_method=api_token" >> $GITHUB_OUTPUT
+          else
+            echo "❌ No authentication method available"
+            echo "Please either:"
+            echo "  1. Configure Trusted Publishing on crates.io for this repository"
+            echo "  2. Set CARGO_REGISTRY_TOKEN secret in GitHub repository settings"
+            exit 1
+          fi
+
+      - name: Display authentication method
+        run: |
+          echo "Authentication method: ${{ steps.auth.outputs.auth_method }}"
 
       - name: Detect crates to publish
         id: detect-crates


### PR DESCRIPTION
## Summary

- Add fallback authentication mechanism for crates.io publishing
- Try Trusted Publishing (OIDC) first, then fall back to API token if unavailable

## Context

Trusted Publishing requires crates to already be published on crates.io before it can be configured. This creates a chicken-and-egg problem for new crates: they can't use Trusted Publishing for their initial publish.

This change implements a hybrid authentication approach:
1. **Primary**: Attempt Trusted Publishing (OIDC) authentication
2. **Fallback**: Use `CARGO_REGISTRY_TOKEN` secret if Trusted Publishing fails

## Benefits

- New crates can be published automatically via CI
- Existing crates continue using the more secure Trusted Publishing
- After initial publish, Trusted Publishing can be configured on crates.io for enhanced security

## Required Setup

Add `CARGO_REGISTRY_TOKEN` secret in repository Settings > Secrets and variables > Actions:
- Generate token at: https://crates.io/settings/tokens

## Related

- Failed run: https://github.com/kent8192/reinhardt-web/actions/runs/21437331703
- Error: `No Trusted Publishing config found for repository kent8192/reinhardt-web`

## Test plan

- [ ] Set `CARGO_REGISTRY_TOKEN` secret in repository settings
- [ ] Merge this PR with `release` label
- [ ] Verify publish workflow completes successfully
- [ ] Check logs show correct authentication method used

🤖 Generated with [Claude Code](https://claude.ai/claude-code)