### PR TITLE
ci(release): add mandatory crates.io version status check before publish dry-run

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -90,6 +90,85 @@ jobs:
           echo "$CHANGED_OUTPUT"
           echo "has_changes=true" >> $GITHUB_OUTPUT
 
+      - name: Check crates.io version status
+        if: steps.detect-crates.outputs.has_changes == 'true'
+        run: |
+          echo "::group::Checking crates.io version status"
+
+          HAS_CONFLICT=false
+
+          # Get changed crates
+          CHANGED_CRATES=$(cargo ws changed 2>&1 | grep -v "^$" || true)
+
+          for CRATE_NAME in $CHANGED_CRATES; do
+            # Get proposed version from cargo metadata
+            PROPOSED_VERSION=$(cargo metadata --format-version 1 --no-deps \
+              | jq -r --arg name "$CRATE_NAME" '.packages[] | select(.name == $name) | .version')
+
+            if [ -z "$PROPOSED_VERSION" ]; then
+              echo "⚠️ Could not determine version for $CRATE_NAME, skipping"
+              continue
+            fi
+
+            echo "Checking $CRATE_NAME v$PROPOSED_VERSION on crates.io..."
+
+            # Query crates.io API with required User-Agent header
+            HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -H "User-Agent: reinhardt-ci (https://github.com/kent8192/reinhardt-rs)" \
+              "https://crates.io/api/v1/crates/$CRATE_NAME")
+
+            HTTP_BODY=$(echo "$HTTP_RESPONSE" | head -n -1)
+            HTTP_STATUS=$(echo "$HTTP_RESPONSE" | tail -n 1)
+
+            if [ "$HTTP_STATUS" = "404" ]; then
+              echo "  ℹ️ $CRATE_NAME: Not yet published on crates.io (new crate) - OK"
+              sleep 1
+              continue
+            fi
+
+            if [ "$HTTP_STATUS" != "200" ]; then
+              echo "  ⚠️ $CRATE_NAME: crates.io API returned HTTP $HTTP_STATUS, skipping check"
+              sleep 1
+              continue
+            fi
+
+            # Extract published versions
+            PUBLISHED_MAX=$(echo "$HTTP_BODY" | jq -r '.crate.max_version // empty')
+            VERSION_EXISTS=$(echo "$HTTP_BODY" | jq -r \
+              --arg ver "$PROPOSED_VERSION" \
+              '[.versions[]? | select(.num == $ver)] | length > 0')
+
+            if [ "$VERSION_EXISTS" = "true" ]; then
+              echo "  ❌ $CRATE_NAME: Version $PROPOSED_VERSION is ALREADY PUBLISHED on crates.io!"
+              echo "::error::$CRATE_NAME v$PROPOSED_VERSION is already published on crates.io. Bump the version before publishing."
+              HAS_CONFLICT=true
+            else
+              echo "  ✅ $CRATE_NAME: Version $PROPOSED_VERSION is available"
+              # Warn about unnatural version jumps
+              if [ -n "$PUBLISHED_MAX" ] && [ "$PUBLISHED_MAX" != "null" ]; then
+                echo "     Current max on crates.io: $PUBLISHED_MAX → Proposed: $PROPOSED_VERSION"
+              fi
+            fi
+
+            # Rate limit: 1 second between API calls (crates.io policy)
+            sleep 1
+          done
+
+          echo "::endgroup::"
+
+          if [ "$HAS_CONFLICT" = "true" ]; then
+            echo "=========================================="
+            echo "❌ Version conflict detected!"
+            echo "=========================================="
+            echo "One or more crates have versions already published on crates.io."
+            echo "Please bump the version(s) before proceeding."
+            exit 1
+          fi
+
+          echo "=========================================="
+          echo "✅ crates.io version status check passed"
+          echo "=========================================="
+
       - name: Run publish dry-run for changed crates
         if: steps.detect-crates.outputs.has_changes == 'true'
         run: |
@@ -176,6 +255,7 @@ jobs:
             echo ""
             echo "### Verification Performed"
             echo "- ✅ Workspace build check (\`cargo check --workspace --all-features\`)"
+            echo "- ✅ crates.io version conflict check"
             echo "- ✅ Publish dry-run (\`cargo ws publish --dry-run\`)"
             echo "- ✅ Packaging, dependency resolution, and manifest validation"
             echo "- ✅ Output analysis for error detection"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,16 +160,17 @@ See docs/COMMIT_GUIDELINE.md for detailed commit guidelines including:
 - Push commits and tags AFTER successful publish
 
 **Publishing Workflow:**
-1. Update crate version in `Cargo.toml`
-2. Update crate's `CHANGELOG.md`
-3. Run all verification commands
-4. Commit version changes (see docs/COMMIT_GUIDELINE.md CE-5)
-5. Wait for explicit user authorization to proceed
-6. Run `cargo publish --dry-run -p <crate-name>`
-7. Wait for user confirmation after dry-run
-8. Run `cargo publish -p <crate-name>`
-9. Create and push tag: `git tag [crate-name]@v[version] -m "Release [crate-name] v[version]"`
-10. Push: `git push && git push --tags`
+1. Check crates.io for current published version: `curl -s "https://crates.io/api/v1/crates/<crate-name>" | jq '.crate.max_version'`
+2. Update crate version in `Cargo.toml`
+3. Update crate's `CHANGELOG.md`
+4. Run all verification commands
+5. Commit version changes (see docs/COMMIT_GUIDELINE.md CE-5)
+6. Wait for explicit user authorization to proceed
+7. Run `cargo publish --dry-run -p <crate-name>`
+8. Wait for user confirmation after dry-run
+9. Run `cargo publish -p <crate-name>`
+10. Create and push tag: `git tag [crate-name]@v[version] -m "Release [crate-name] v[version]"`
+11. Push: `git push && git push --tags`
 
 **Why This Approach:**
 - **Traceability**: Git tag enables complete restoration of specific crate version state
@@ -333,6 +334,7 @@ Before submitting code:
 - Start commit description with lowercase letter (e.g., `feat: add feature`)
 - Use `!` notation for breaking changes (e.g., `feat!:` or `feat(scope)!:`)
 - Follow Semantic Versioning 2.0.0 strictly for all crates
+- Check crates.io for current published version before updating crate versions
 - Use `[crate-name]@v[version]` format for Git tags
 - Verify with `--dry-run` before publishing to crates.io
 - Commit version bump before creating tags
@@ -373,6 +375,7 @@ Before submitting code:
 - Create batch commits without user confirmation
 - Use relative paths beyond `../`
 - Publish to crates.io without explicit user authorization
+- Update crate versions without checking crates.io for current published status
 - Create Git tags before committing version changes
 - Skip `--dry-run` verification before publishing
 - Make breaking changes without MAJOR version bump

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -125,6 +125,15 @@ impl Pool {
 - [ ] Main crate (`reinhardt-web`) version updated if sub-crate version changed
 - [ ] Main crate CHANGELOG.md references sub-crate changes
 
+### Crates.io Version Status
+
+- [ ] Current published version checked:
+  ```bash
+  curl -s "https://crates.io/api/v1/crates/<crate-name>" | jq '.crate.max_version'
+  ```
+- [ ] Proposed version not already published on crates.io
+- [ ] Version increment is appropriate (MAJOR/MINOR/PATCH)
+
 ### Metadata
 
 - [ ] `description`, `license`, `repository` fields present
@@ -190,6 +199,22 @@ Create `release` label:
 
 ### Publishing Workflow
 
+#### Step 0: Check crates.io Version Status
+
+Before making any version changes, verify the current published state:
+
+```bash
+# Check current published version
+curl -s "https://crates.io/api/v1/crates/<crate-name>" | jq '.crate.max_version'
+
+# Verify proposed version is not already published
+curl -s "https://crates.io/api/v1/crates/<crate-name>" | jq '.versions[].num'
+```
+
+**Ensure**:
+- The proposed version is **not** already published
+- The version increment is appropriate relative to the current published version
+
 #### Step 1: Create PR with Version Changes
 
 ```bash
@@ -233,6 +258,7 @@ git push origin feature/update-reinhardt-orm
 **Workflow actions**:
 
 - Detects changed crates (`cargo ws changed`)
+- Checks crates.io for version conflicts (fails if proposed version already published)
 - Runs `cargo ws publish --dry-run`
 - Reports results in PR checks
 
@@ -708,7 +734,18 @@ git reset --hard HEAD~1  # If not pushed
 **Dry-run Failed**: Add missing metadata fields (`description`, `license`,
 `repository`) to `Cargo.toml`
 
-**Version Already Published**: Increment version and retry
+**Version Already Published**: The crates.io version check step will catch this
+automatically. To investigate manually:
+
+```bash
+# Check current published version
+curl -s "https://crates.io/api/v1/crates/<crate-name>" | jq '.crate.max_version'
+
+# List all published versions
+curl -s "https://crates.io/api/v1/crates/<crate-name>" | jq '.versions[].num'
+```
+
+Increment the version in `Cargo.toml` and retry
 
 **No Crates Detected**: Verify version changes in `Cargo.toml` files
 
@@ -746,6 +783,7 @@ git reset --hard HEAD~1  # If not pushed
 ### Verification Checklist
 
 - [ ] Version follows SemVer
+- [ ] Proposed version not already published on crates.io
 - [ ] CHANGELOG updated
 - [ ] Tests pass
 - [ ] Dry-run succeeds


### PR DESCRIPTION
## Summary

- Add automated crates.io version conflict detection step to `publish-dry-run.yml` workflow, preventing version collisions before they reach the publish step
- Update `docs/RELEASE_PROCESS.md` with crates.io version check in pre-release checklist, publishing workflow (Step 0), troubleshooting, and verification checklist
- Update `CLAUDE.md` publishing workflow (10 → 11 steps) and quick reference sections with crates.io check requirements

## Test plan

- [ ] Verify `publish-dry-run.yml` YAML syntax is valid
- [ ] Verify workflow step order: Detect changed crates → Check crates.io version status → Run publish dry-run
- [ ] Verify CLAUDE.md publishing workflow step numbers are sequential (1-11)
- [ ] Verify RELEASE_PROCESS.md links and references are consistent
- [ ] Create a test PR with `release` label to validate the new crates.io check step runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)