### PR TITLE
fix(ci): filter cargo ws changed output correctly

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -98,7 +98,9 @@ jobs:
           HAS_CONFLICT=false
 
           # Get changed crates
-          CHANGED_CRATES=$(cargo ws changed 2>&1 | grep -v "^$" || true)
+          # Filter out info messages (e.g., "info looking for changes since...")
+          # and keep only valid crate names (starting with "reinhardt-")
+          CHANGED_CRATES=$(cargo ws changed 2>&1 | grep -v "^info" | grep -v "^$" | grep -E "^reinhardt-" || true)
 
           for CRATE_NAME in $CHANGED_CRATES; do
             # Get proposed version from cargo metadata


### PR DESCRIPTION
## Summary

- Fix `cargo ws changed` output parsing in publish-dry-run workflow
- The command outputs info messages (e.g., "info looking for changes since...") which were incorrectly being parsed as crate names
- This caused the version status check step to fail when querying crates.io for non-existent crates named "info", "looking", "for", etc.

## Changes

- Filter out info messages starting with "info"
- Filter out empty lines  
- Keep only valid crate names (starting with "reinhardt-")

## Test plan

- [ ] Run `cargo ws changed 2>&1 | grep -v "^info" | grep -v "^$" | grep -E "^reinhardt-"` locally to verify filtering works
- [ ] Verify CI passes on this PR

Fixes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)