### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Crates.io](https://img.shields.io/crates/v/reinhardt-web.svg)](https://crates.io/crates/reinhardt-web)
 [![Documentation](https://docs.rs/reinhardt-web/badge.svg)](https://docs.rs/reinhardt-web)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kent8192/reinhardt-web)
 
 </div>
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Add DeepWiki badge to README.md for AI-powered documentation exploration

## Type of Change

- [x] Documentation update

## Motivation and Context

DeepWiki provides AI-powered documentation exploration capabilities. Adding this badge allows users to easily access DeepWiki's features for understanding the Reinhardt codebase.

## How Was This Tested?

- Verified markdown syntax is correct
- Verified badge URL points to correct repository

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

---

🤖 Generated with [Claude Code](https://claude.ai/code)