### PR TITLE
docs: add multilingual README translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kent8192/reinhardt-web)
 
+🌐 **English** | [日本語](docs/readme-langs/README_JA.md) | [简体中文](docs/readme-langs/README_ZH_CN.md) | [繁體中文](docs/readme-langs/README_ZH_TW.md) | [Русский](docs/readme-langs/README_RU.md) | [Українська](docs/readme-langs/README_UK.md) | [فارسی](docs/readme-langs/README_FA.md) | [العربية](docs/readme-langs/README_AR.md)
+
 </div>
 
 ---

--- a/docs/readme-langs/README_AR.md
+++ b/docs/readme-langs/README_AR.md
@@ -1,0 +1,1061 @@
+<div align="center">
+  <img src="../../branding/logo.png" alt="Reinhardt Logo" width="200"/>
+
+  <h1>Reinhardt</h1>
+
+  <h3>🦀 إطار عمل متعدد البنى مع بطاريات مضمنة</h3>
+
+  <p><strong>إطار عمل API متكامل وقابل للتركيب لـ Rust</strong></p>
+  <p>ابنِ بـ<em>كامل</em> قوة فلسفة Django "البطاريات مضمنة"،<br/>
+  أو ركّب <em>فقط</em> ما تحتاجه—اختيارك، طريقتك.</p>
+
+🌐 [English](../../README.md) | [日本語](README_JA.md) | [简体中文](README_ZH_CN.md) | [繁體中文](README_ZH_TW.md) | [Русский](README_RU.md) | [Українська](README_UK.md) | [فارسی](README_FA.md) | **العربية**
+
+[![Crates.io](https://img.shields.io/crates/v/reinhardt-web.svg)](https://crates.io/crates/reinhardt-web)
+[![Documentation](https://docs.rs/reinhardt-web/badge.svg)](https://docs.rs/reinhardt-web)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](../../LICENSE.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kent8192/reinhardt-web)
+
+</div>
+
+---
+
+## 📍 التنقل السريع
+
+قد تبحث عن:
+
+- 🚀 [البداية السريعة](#البداية-السريعة) - ابدأ في 5 دقائق
+- 📦 [خيارات التثبيت](#التثبيت) - اختر نوعك: Micro أو Standard أو Full
+- 📚 [دليل البدء](../GETTING_STARTED.md) - دروس خطوة بخطوة
+- 🎛️ [أعلام الميزات](../FEATURE_FLAGS.md) - ضبط دقيق للبناء
+- 📖 [وثائق API](https://docs.rs/reinhardt-web) - مرجع API الكامل
+- 💬 [المجتمع والدعم](#الحصول-على-المساعدة) - احصل على مساعدة من المجتمع
+
+## لماذا Reinhardt؟
+
+**Polylithic = Poly (متعدد) + Lithic (كتل بناء)**
+على عكس الأطر الأحادية التي تجبرك على استخدام كل شيء، يتيح لك Reinhardt تركيب مكدسك المثالي من مكونات مستقلة ومختبرة جيداً.
+
+Reinhardt يجمع أفضل ما في ثلاثة عوالم:
+
+| الإلهام            | ما اقتبسناه                                            | ما حسّناه                                           |
+|--------------------|--------------------------------------------------------|------------------------------------------------------|
+| 🐍 **Django**      | فلسفة البطاريات المضمنة، تصميم ORM، لوحة الإدارة        | أعلام الميزات للبناء القابل للتركيب، سلامة أنواع Rust |
+| 🎯 **Django REST** | المسلسلات، ViewSets، الأذونات                          | التحقق في وقت الترجمة، تجريدات بدون تكلفة            |
+| ⚡ **FastAPI**      | نظام DI، OpenAPI التلقائي                               | أداء Rust الأصلي، بدون عبء وقت التشغيل              |
+| 🗄️ **SQLAlchemy** | أنماط QuerySet، معالجة العلاقات                         | منشئ استعلامات آمن النوع، التحقق في وقت الترجمة      |
+
+**النتيجة**: إطار عمل مألوف لمطوري Python، ولكن مع أداء وضمانات سلامة Rust.
+
+## ✨ الميزات الرئيسية
+
+- **ORM آمن النوع** مع التحقق في وقت الترجمة (SeaQuery v1.0.0-rc)
+- **مسلسلات قوية** مع التحقق التلقائي (serde + validator)
+- **DI بأسلوب FastAPI** مع حقن التبعية الآمن النوع والتخزين المؤقت
+- **ViewSets** للتطوير السريع لـ CRUD API
+- **مصادقة متعددة** (JWT، Token، Session، Basic) مع سمات BaseUser/FullUser
+- **لوحة إدارة** مع واجهة إدارة النماذج المولدة تلقائياً
+- **أوامر الإدارة** للترحيل والملفات الثابتة والمزيد
+- **دعم GraphQL و WebSocket** للتطبيقات الفورية
+- **الترقيم، التصفية، تحديد المعدل** مدمج
+- **الإشارات** للبنية المعتمدة على الأحداث
+
+انظر القائمة الكاملة في [المكونات المتاحة](#المكونات-المتاحة) والأمثلة في [دليل البدء](../GETTING_STARTED.md).
+
+## التثبيت
+
+Reinhardt إطار عمل معياري. اختر نقطة البداية:
+
+**ملاحظة حول تسمية الصناديق:**
+صندوق Reinhardt الرئيسي منشور على crates.io باسم `reinhardt-web`، لكنك تستورده كـ `reinhardt` في كودك باستخدام سمة `package`.
+
+### الافتراضي: كامل الميزات (البطاريات مضمنة) ⚠️ الافتراضي الجديد
+
+كل الميزات بدون تهيئة:
+
+```toml
+[dependencies]
+# يُستورد كـ 'reinhardt'، منشور كـ 'reinhardt-web'
+# الافتراضي يُفعّل كل الميزات (الحزمة الكاملة)
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web" }
+```
+
+**يشمل:** Database، Auth، REST API، Admin، GraphQL، WebSockets، Cache، i18n، Mail، Sessions، Static Files، Storage
+
+**الثنائي**: ~50+ ميجابايت | **الترجمة**: أبطأ، لكن كل شيء يعمل فوراً
+
+ثم استخدم في الكود:
+```rust
+use reinhardt::prelude::*;
+use reinhardt::{Request, Response, StatusCode};
+```
+
+### الخيار 1: الإعداد القياسي (متوازن)
+
+لمعظم المشاريع التي لا تحتاج كل الميزات:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["standard"] }
+```
+
+**يشمل:** Core، Database (PostgreSQL)، REST API، Auth، Middleware، Pages (واجهة WASM مع SSR)
+
+**الثنائي**: ~20-30 ميجابايت | **الترجمة**: متوسطة
+
+### الخيار 2: الخدمات المصغرة (الإعداد الأدنى)
+
+خفيف وسريع، مثالي لـ APIs البسيطة:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+```
+
+**يشمل:** HTTP، التوجيه، DI، استخراج المعاملات، الخادم
+
+**الثنائي**: ~5-10 ميجابايت | **الترجمة**: سريعة جداً
+
+### الخيار 3: ابنِ مكدسك المخصص
+
+ثبّت فقط المكونات المطلوبة:
+
+```toml
+[dependencies]
+# المكونات الأساسية
+reinhardt-http = "0.1.0-alpha.1"
+reinhardt-urls = "0.1.0-alpha.1"
+
+# اختياري: قاعدة البيانات
+reinhardt-db = "0.1.0-alpha.1"
+
+# اختياري: المصادقة
+reinhardt-auth = "0.1.0-alpha.1"
+
+# اختياري: ميزات REST API
+reinhardt-rest = "0.1.0-alpha.1"
+
+# اختياري: لوحة الإدارة
+reinhardt-admin = "0.1.0-alpha.1"
+
+# اختياري: الميزات المتقدمة
+reinhardt-graphql = "0.1.0-alpha.1"
+reinhardt-websockets = "0.1.0-alpha.1"
+```
+
+**📖 للقائمة الكاملة للصناديق وأعلام الميزات المتاحة، انظر [دليل أعلام الميزات](../FEATURE_FLAGS.md).**
+
+## البداية السريعة
+
+### 1. ثبّت أداة Reinhardt Admin
+
+```bash
+cargo install reinhardt-admin-cli
+```
+
+### 2. أنشئ مشروعاً جديداً
+
+```bash
+# إنشاء مشروع RESTful API (الافتراضي)
+reinhardt-admin startproject my-api
+cd my-api
+```
+
+هذا يُولّد هيكل المشروع الكامل:
+
+```
+my-api/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   ├── config.rs
+│   ├── apps.rs
+│   ├── config/
+│   │   ├── settings.rs
+│   │   ├── settings/
+│   │   │   ├── base.rs
+│   │   │   ├── local.rs
+│   │   │   ├── staging.rs
+│   │   │   └── production.rs
+│   │   ├── urls.rs
+│   │   └── apps.rs
+│   └── bin/
+│       └── manage.rs
+└── README.md
+```
+
+**البديل: إنشاء مشروع reinhardt-pages (WASM + SSR)**
+
+لواجهة WASM حديثة مع SSR:
+
+```bash
+# إنشاء مشروع pages
+reinhardt-admin startproject my-app --with-pages
+cd my-app
+
+# تثبيت أدوات بناء WASM (المرة الأولى فقط)
+cargo make install-wasm-tools
+
+# بناء WASM وتشغيل خادم التطوير
+cargo make dev
+# زُر http://127.0.0.1:8000/
+```
+
+### 3. شغّل خادم التطوير
+
+```bash
+# باستخدام أمر manage
+cargo run --bin manage runserver
+
+# الخادم سيبدأ على http://127.0.0.1:8000
+```
+
+**دعم إعادة التحميل التلقائي:**
+
+لإعادة التحميل التلقائي عند تغيير الكود (يتطلب bacon):
+
+```bash
+# تثبيت bacon
+cargo install --locked bacon
+
+# التشغيل مع إعادة التحميل التلقائي
+bacon runserver
+
+# أو استخدم cargo make
+cargo make watch
+
+# للاختبارات
+bacon test
+```
+
+### 4. أنشئ تطبيقك الأول
+
+```bash
+# إنشاء تطبيق RESTful API (الافتراضي)
+cargo run --bin manage startapp users
+
+# أو حدد النوع صراحةً
+cargo run --bin manage startapp users --restful
+
+# إنشاء تطبيق Pages (WASM + SSR)
+cargo run --bin manage startapp dashboard --with-pages
+```
+
+هذا يُنشئ هيكل التطبيق:
+
+```
+users/
+├── lib.rs
+├── models.rs
+├── models/
+├── views.rs
+├── views/
+├── serializers.rs
+├── serializers/
+├── admin.rs
+├── urls.rs
+└── tests.rs
+```
+
+### 5. سجّل المسارات
+
+عدّل `urls.rs` لتطبيقك:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::list_users)
+		.endpoint(views::get_user)
+		.endpoint(views::create_user)
+}
+```
+
+ضمّنه في `src/config/urls.rs`:
+
+```rust
+// src/config/urls.rs
+use reinhardt::prelude::*;
+use reinhardt::routes;
+
+#[routes]
+pub fn routes() -> ServerRouter {
+	ServerRouter::new()
+		.mount("/api/", users::urls::url_patterns())
+}
+```
+
+ماكرو السمة `#[routes]` يسجّل هذه الدالة تلقائياً مع الإطار للاكتشاف عبر صندوق `inventory`.
+
+**ملاحظة:** `reinhardt::prelude` يتضمن الأنواع شائعة الاستخدام. التصديرات الرئيسية:
+
+**متاحة دائماً:**
+- التوجيه والعروض الأساسية: `Router`، `DefaultRouter`، `ServerRouter`، `View`، `ListView`، `DetailView`
+- ViewSets: `ViewSet`، `ModelViewSet`، `ReadOnlyModelViewSet`
+- HTTP: `StatusCode`
+
+**معتمدة على الميزات:**
+- **ميزة `core`**: `Request`، `Response`، `Handler`، `Middleware`، الإشارات (`post_save`، `pre_save`، إلخ)
+- **ميزة `database`**: `Model`، `DatabaseConnection`، `F`، `Q`، `Transaction`، `atomic`، دوال قاعدة البيانات (`Concat`، `Upper`، `Lower`، `Now`، `CurrentDate`)، دوال النوافذ (`Window`، `RowNumber`، `Rank`، `DenseRank`)، القيود (`UniqueConstraint`، `CheckConstraint`، `ForeignKeyConstraint`)
+- **ميزة `auth`**: `User`، `UserManager`، `GroupManager`، `Permission`، `ObjectPermission`
+- **ميزات `minimal` أو `standard` أو `di`**: `Body`، `Cookie`، `Header`، `Json`، `Path`، `Query`
+- **ميزة `rest`**: المسلسلات، المحللات، الترقيم، التحكم بالمعدل، إصدار النسخ
+- **ميزة `admin`**: مكونات لوحة الإدارة
+- **ميزة `cache`**: `Cache`، `InMemoryCache`
+- **ميزة `sessions`**: `Session`، `AuthenticationMiddleware`
+
+انظر القائمة الكاملة في [دليل أعلام الميزات](../FEATURE_FLAGS.md).
+
+للدليل الكامل خطوة بخطوة، انظر [دليل البدء](../GETTING_STARTED.md).
+
+## 🎓 تعلم بالأمثلة
+
+### مع قاعدة البيانات
+
+هيّئ قاعدة البيانات في `settings/base.toml`:
+
+```toml
+debug = true
+secret_key = "your-secret-key-for-development"
+
+[database]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "mydb"
+user = "postgres"
+password = "postgres"
+```
+
+الإعدادات تُحمّل تلقائياً في `src/config/settings.rs`:
+
+```rust
+// src/config/settings.rs
+use reinhardt::conf::settings::builder::SettingsBuilder;
+use reinhardt::conf::settings::profile::Profile;
+use reinhardt::conf::settings::sources::{DefaultSource, LowPriorityEnvSource, TomlFileSource};
+use reinhardt::core::Settings;
+use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub fn get_settings() -> Settings {
+	let profile_str = env::var("REINHARDT_ENV").unwrap_or_else(|_| "local".to_string());
+	let profile = Profile::from_str(&profile_str).unwrap_or(Profile::Development);
+
+	let base_dir = env::current_dir().expect("Failed to get current directory");
+	let settings_dir = base_dir.join("settings");
+
+	let merged = SettingsBuilder::new()
+		.profile(profile)
+		.add_source(
+			DefaultSource::new()
+				.with_value("debug", serde_json::Value::Bool(false))
+				.with_value("language_code", serde_json::Value::String("en-us".to_string()))
+				.with_value("time_zone", serde_json::Value::String("UTC".to_string()))
+		)
+		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
+		.add_source(TomlFileSource::new(settings_dir.join(format!("{}.toml", profile_str))))
+		.build()
+		.expect("Failed to build settings");
+
+	merged.into_typed().expect("Failed to convert settings to Settings struct")
+}
+```
+
+**مصادر متغيرات البيئة:**
+
+Reinhardt يوفر نوعين من مصادر متغيرات البيئة بأولويات مختلفة:
+
+- **`EnvSource`** (الأولوية: 100) - متغيرات بيئة عالية الأولوية تتجاوز ملفات TOML
+  ```rust
+  .add_source(EnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+- **`LowPriorityEnvSource`** (الأولوية: 40) - متغيرات بيئة منخفضة الأولوية تعود لملفات TOML
+  ```rust
+  .add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+**ترتيب الأولوية**:
+- مع `EnvSource`: متغيرات البيئة > `{profile}.toml` > `base.toml` > الافتراضيات
+- مع `LowPriorityEnvSource` (موضح أعلاه): `{profile}.toml` > `base.toml` > متغيرات البيئة > الافتراضيات
+
+اختر `EnvSource` عندما يجب أن تكون متغيرات البيئة دائماً لها الأولوية (مثل نشر الإنتاج).
+اختر `LowPriorityEnvSource` عندما يجب أن تكون ملفات TOML المصدر الرئيسي للتهيئة (مثل التطوير).
+
+انظر [وثائق الإعدادات](../SETTINGS_DOCUMENT.md) للتفاصيل.
+
+**استخدام DefaultUser المدمج:**
+
+Reinhardt يوفر تنفيذ `DefaultUser` جاهز للاستخدام (يتطلب ميزة `argon2-hasher`):
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// أعد تصدير DefaultUser كـ User لتطبيقك
+pub type User = DefaultUser;
+
+// DefaultUser يتضمن:
+// - id: Uuid (المفتاح الأساسي)
+// - username: String
+// - email: String
+// - password_hash: Option<String>
+// - first_name: String
+// - last_name: String
+// - is_active: bool
+// - is_staff: bool
+// - is_superuser: bool
+// - last_login: Option<DateTime<Utc>>
+// - date_joined: DateTime<Utc>
+
+// DefaultUser ينفذ:
+// - سمة BaseUser (طرق المصادقة)
+// - سمة FullUser (معلومات المستخدم الكاملة)
+// - سمة PermissionsMixin (إدارة الأذونات)
+// - سمة Model (عمليات قاعدة البيانات)
+```
+
+**تعريف نماذج مستخدم مخصصة:**
+
+إذا كنت بحاجة لحقول مخصصة، عرّف نموذجك الخاص:
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Utc};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: i64,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	#[field(max_length = 100)]
+	pub username: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(auto_now_add = true)]
+	pub created_at: DateTime<Utc>,
+
+	// إضافة حقول مخصصة
+	#[field(max_length = 50, null = true)]
+	pub phone_number: Option<String>,
+}
+```
+
+**ماكرو سمة Model:**
+
+سمة `#[model(...)]` تولد تلقائياً:
+- تنفيذ سمة `Model` (يتضمن وظائف `#[derive(Model)]`)
+- موصلات حقول آمنة النوع: `User::field_email()`، `User::field_username()`، إلخ
+- التسجيل في سجل النماذج العام
+- دعم المفاتيح الأساسية المركبة
+
+**ملاحظة:** عند استخدام `#[model(...)]`، لا تحتاج لإضافة `#[derive(Model)]` بشكل منفصل،
+حيث يُطبق تلقائياً بواسطة سمة `#[model(...)]`.
+
+**سمات الحقول:**
+- `#[field(primary_key = true)]` - وضع علامة كمفتاح أساسي
+- `#[field(max_length = 255)]` - تعيين الحد الأقصى للطول لحقول النصوص
+- `#[field(default = value)]` - تعيين قيمة افتراضية
+- `#[field(auto_now_add = true)]` - ملء timestamp تلقائياً عند الإنشاء
+- `#[field(auto_now = true)]` - تحديث timestamp تلقائياً عند الحفظ
+- `#[field(null = true)]` - السماح بقيم NULL
+- `#[field(unique = true)]` - فرض قيد التفرد
+
+للقائمة الكاملة لسمات الحقول، انظر [دليل سمات الحقول](../field_attributes.md).
+
+موصلات الحقول المولدة تمكن الإشارة الآمنة للحقول في الاستعلامات:
+
+```rust
+// مولد بواسطة #[model(...)] لـ DefaultUser
+impl DefaultUser {
+	pub const fn field_id() -> FieldRef<DefaultUser, Uuid> { FieldRef::new("id") }
+	pub const fn field_username() -> FieldRef<DefaultUser, String> { FieldRef::new("username") }
+	pub const fn field_email() -> FieldRef<DefaultUser, String> { FieldRef::new("email") }
+	pub const fn field_is_active() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_active") }
+	pub const fn field_is_staff() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_staff") }
+	pub const fn field_date_joined() -> FieldRef<DefaultUser, DateTime<Utc>> { FieldRef::new("date_joined") }
+	// ... حقول أخرى
+}
+```
+
+**أمثلة استعلامات متقدمة:**
+
+```rust
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// استعلامات كائنات F/Q بأسلوب Django مع إشارات حقول آمنة النوع
+async fn complex_user_query() -> Result<Vec<DefaultUser>, Box<dyn std::error::Error>> {
+	// كائنات Q مع إشارات حقول آمنة النوع (باستخدام موصلات الحقول المولدة)
+	let active_query = Q::new()
+		.field("is_active").eq(true)
+		.and(Q::new().field("date_joined").gte(Now::new()));
+
+	// دوال قاعدة البيانات مع إشارات حقول آمنة النوع
+	let email_lower = Lower::new(DefaultUser::field_email().into());
+	let username_upper = Upper::new(DefaultUser::field_username().into());
+
+	// التجميعات باستخدام موصلات الحقول
+	let user_count = Aggregate::count(DefaultUser::field_id().into());
+	let latest_joined = Aggregate::max(DefaultUser::field_date_joined().into());
+
+	// دوال النوافذ للترتيب
+	let rank_by_join_date = Window::new()
+		.partition_by(vec![DefaultUser::field_is_active().into()])
+		.order_by(vec![(DefaultUser::field_date_joined().into(), "DESC")])
+		.function(RowNumber::new());
+
+	todo!("Execute query with these components")
+}
+
+// دعم المعاملات
+async fn create_user_with_transaction(
+	conn: &DatabaseConnection,
+	user_data: CreateUserRequest
+) -> Result<User, Box<dyn std::error::Error>> {
+	// معاملة مع تراجع تلقائي عند الخطأ
+	transaction(conn, |_tx| async move {
+		let user = User::create(user_data).await?;
+		log_user_creation(&user).await?;
+		Ok(user)
+	}).await
+}
+```
+
+**ملاحظة**: Reinhardt يستخدم [SeaQuery v1.0.0-rc](https://crates.io/crates/sea-query) لعمليات SQL. ماكرو `#[derive(Model)]` يولد تلقائياً تنفيذات سمة Model، وموصلات حقول آمنة النوع، والتسجيل في سجل النماذج العام.
+
+سجّل في `src/config/apps.rs`:
+
+```rust
+// src/config/apps.rs
+use reinhardt::installed_apps;
+
+// ماكرو installed_apps! يولد:
+// - enum InstalledApp مع متغيرات لكل تطبيق
+// - تنفيذ سمات التحويل (From، Into، Display)
+// - سجل لتهيئة واكتشاف التطبيقات
+//
+// ملاحظة: على عكس INSTALLED_APPS في Django، هذا الماكرو لتطبيقات المستخدم فقط.
+// ميزات الإطار المدمجة (auth، sessions، admin، إلخ) تُفعّل عبر
+// أعلام ميزات Cargo، وليس عبر installed_apps!.
+//
+// مثال:
+// [dependencies]
+// reinhardt = { version = "0.1", features = ["auth", "sessions", "admin"] }
+//
+// هذا يُفعّل:
+// - اكتشاف التطبيقات التلقائي للترحيلات، لوحة الإدارة، إلخ
+// - إشارات تطبيقات آمنة النوع في كودك
+// - تهيئة تطبيقات مركزية
+installed_apps! {
+	users: "users",
+}
+
+pub fn get_installed_apps() -> Vec<String> {
+	InstalledApp::all_apps()
+}
+```
+
+### مع المصادقة
+
+Reinhardt يوفر نماذج مستخدمين بأسلوب Django مع سمات `BaseUser` و `FullUser`، بالإضافة إلى إدارة مستخدمين شاملة عبر `UserManager`.
+
+**ملاحظة:** Reinhardt يتضمن تنفيذ `DefaultUser` مدمج. يمكنك استخدامه مباشرة أو تعريف نموذج المستخدم الخاص بك كما هو موضح أدناه.
+
+**مثال إدارة المستخدمين:**
+
+```rust
+use reinhardt::prelude::*;
+
+// إنشاء وإدارة المستخدمين مع UserManager
+async fn manage_users() -> Result<(), Box<dyn std::error::Error>> {
+	let hasher = Argon2Hasher::new();
+	let user_manager = UserManager::new(hasher);
+
+	// إنشاء مستخدم جديد
+	let user = user_manager.create_user(CreateUserData {
+		username: "alice".to_string(),
+		email: "alice@example.com".to_string(),
+		password: "secure_password".to_string(),
+		first_name: Some("Alice".to_string()),
+		last_name: Some("Smith".to_string()),
+	}).await?;
+
+	// تحديث معلومات المستخدم
+	user_manager.update_user(user.id, UpdateUserData {
+		email: Some("alice.smith@example.com".to_string()),
+		is_active: Some(true),
+		..Default::default()
+	}).await?;
+
+	// إدارة المجموعات والأذونات
+	let group_manager = GroupManager::new();
+	let editors = group_manager.create_group(CreateGroupData {
+		name: "editors".to_string(),
+	}).await?;
+
+	// تعيين أذونات على مستوى الكائن
+	let permission = ObjectPermission::new("edit", user.id, article.id);
+	let perm_checker = ObjectPermissionChecker::new();
+	if perm_checker.has_permission(&user, "edit", &article).await? {
+		// المستخدم يمكنه تحرير المقالة
+	}
+
+	Ok(())
+}
+```
+
+استخدم `DefaultUser` المدمج في `users/models.rs`:
+
+```rust
+// users/models.rs
+use reinhardt::DefaultUser;
+
+// أعد تصدير DefaultUser كنوع User الخاص بك
+pub type User = DefaultUser;
+
+// DefaultUser ينفذ بالفعل:
+// - سمة BaseUser (طرق المصادقة)
+// - سمة FullUser (username، email، first_name، last_name، إلخ)
+// - سمة PermissionsMixin (إدارة الأذونات)
+// - سمة Model (عمليات قاعدة البيانات)
+```
+
+**لنماذج المستخدم المخصصة:**
+
+إذا كنت بحاجة لحقول إضافية تتجاوز DefaultUser، عرّف الخاص بك:
+
+```rust
+// users/models.rs
+use reinhardt::auth::{BaseUser, FullUser, PermissionsMixin};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+use serde::{Serialize, Deserialize};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: Uuid,
+
+	#[field(max_length = 150)]
+	pub username: String,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	pub password_hash: Option<String>,
+
+	#[field(max_length = 150)]
+	pub first_name: String,
+
+	#[field(max_length = 150)]
+	pub last_name: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(default = false)]
+	pub is_staff: bool,
+
+	#[field(default = false)]
+	pub is_superuser: bool,
+
+	pub last_login: Option<DateTime<Utc>>,
+
+	#[field(auto_now_add = true)]
+	pub date_joined: DateTime<Utc>,
+
+	// حقول مخصصة
+	#[field(max_length = 20, null = true)]
+	pub phone_number: Option<String>,
+}
+
+impl BaseUser for CustomUser {
+	type PrimaryKey = Uuid;
+
+	fn get_username_field() -> &'static str { "username" }
+	fn get_username(&self) -> &str { &self.username }
+	fn password_hash(&self) -> Option<&str> { self.password_hash.as_deref() }
+	fn set_password_hash(&mut self, hash: String) { self.password_hash = Some(hash); }
+	fn last_login(&self) -> Option<DateTime<Utc>> { self.last_login }
+	fn set_last_login(&mut self, time: DateTime<Utc>) { self.last_login = Some(time); }
+	fn is_active(&self) -> bool { self.is_active }
+}
+
+impl FullUser for CustomUser {
+	fn username(&self) -> &str { &self.username }
+	fn email(&self) -> &str { &self.email }
+	fn first_name(&self) -> &str { &self.first_name }
+	fn last_name(&self) -> &str { &self.last_name }
+	fn is_staff(&self) -> bool { self.is_staff }
+	fn is_superuser(&self) -> bool { self.is_superuser }
+	fn date_joined(&self) -> DateTime<Utc> { self.date_joined }
+}
+```
+
+استخدم مصادقة JWT في `views/profile.rs` لتطبيقك:
+
+```rust
+// users/views/profile.rs
+use reinhardt::auth::{JwtAuth, BaseUser};
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+use crate::models::User;
+
+#[get("/profile", name = "get_profile")]
+pub async fn get_profile(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// استخراج رمز JWT من رأس Authorization
+	let auth_header = req.headers.get("authorization")
+		.and_then(|h| h.to_str().ok())
+		.ok_or("Missing Authorization header")?;
+
+	let token = auth_header.strip_prefix("Bearer ")
+		.ok_or("Invalid Authorization header format")?;
+
+	// التحقق من الرمز والحصول على معرف المستخدم
+	let jwt_auth = JwtAuth::new(b"your-secret-key");
+	let claims = jwt_auth.verify_token(token)?;
+
+	// تحميل المستخدم من قاعدة البيانات باستخدام claims.user_id
+	let user = User::find_by_id(&db, &claims.user_id).await?;
+
+	// التحقق من أن المستخدم نشط
+	if !user.is_active() {
+		return Err("User account is inactive".into());
+	}
+
+	// إرجاع ملف المستخدم كـ JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+### تعريف نقاط النهاية
+
+Reinhardt يستخدم مزينات طرق HTTP لتعريف نقاط النهاية:
+
+#### مزينات طرق HTTP
+
+استخدم `#[get]`، `#[post]`، `#[put]`، `#[delete]` لتعريف المسارات:
+
+```rust
+use reinhardt::{get, post, Request, Response, ViewResult};
+use serde_json::json;
+
+#[get("/")]
+pub async fn hello(_req: Request) -> ViewResult<Response> {
+	Ok(Response::ok().with_body("Hello, World!"))
+}
+
+#[post("/users")]
+pub async fn create_user(_req: Request) -> ViewResult<Response> {
+	let body = json!({"status": "created"});
+	Response::ok().with_json(&body).map_err(Into::into)
+}
+```
+
+**الميزات:**
+- التحقق من المسار في وقت الترجمة
+- بناء جملة موجز
+- ربط طريقة HTTP تلقائي
+- دعم حقن التبعية عبر `#[inject]`
+
+#### استخدام حقن التبعية
+
+ادمج مزينات طرق HTTP مع `#[inject]` لحقن التبعية التلقائي:
+
+```rust
+use reinhardt::{get, Request, Response, StatusCode, ViewResult};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,  // يُحقن تلقائياً
+) -> ViewResult<Response> {
+	let id = req.path_params.get("id")
+		.ok_or("Missing id")?
+		.parse::<i64>()?;
+
+	// استخدام اتصال قاعدة البيانات المحقون
+	let user = db.query("SELECT * FROM users WHERE id = $1")
+		.bind(id)
+		.fetch_one()
+		.await?;
+
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+**ميزات حقن التبعية:**
+- حقن التبعية التلقائي عبر سمة `#[inject]`
+- التحكم في التخزين المؤقت مع `#[inject(cache = false)]`
+- نظام حقن تبعية مستوحى من FastAPI
+- يعمل بسلاسة مع مزينات طرق HTTP
+
+**نوع الإرجاع:**
+
+كل دوال العرض تستخدم `ViewResult<T>` كنوع إرجاع:
+
+```rust
+use reinhardt::ViewResult;  // نوع نتيجة معرف مسبقاً
+```
+
+### مع استخراج المعاملات
+
+في `views/user.rs` لتطبيقك:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// استخراج معامل المسار من الطلب
+	let id = req.path_params.get("id")
+		.ok_or("Missing id parameter")?
+		.parse::<i64>()
+		.map_err(|_| "Invalid id format")?;
+
+	// استخراج معاملات الاستعلام (مثلاً ?include_inactive=true)
+	let include_inactive = req.query_params.get("include_inactive")
+		.and_then(|v| v.parse::<bool>().ok())
+		.unwrap_or(false);
+
+	// جلب المستخدم من قاعدة البيانات باستخدام الاتصال المحقون
+	let user = User::find_by_id(&db, id).await?;
+
+	// التحقق من حالة النشاط إذا لزم الأمر
+	if !include_inactive && !user.is_active {
+		return Err("User is inactive".into());
+	}
+
+	// إرجاع كـ JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+سجّل المسار مع معامل المسار في `urls.rs`:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::get_user)  // المسار معرف في #[get("/users/{id}/")]
+}
+```
+
+### مع المسلسلات والتحقق
+
+في `serializers/user.rs` لتطبيقك:
+
+```rust
+// users/serializers/user.rs
+use serde::{Serialize, Deserialize};
+use validator::Validate;
+
+#[derive(Serialize, Deserialize, Validate)]
+pub struct CreateUserRequest {
+	#[validate(email)]
+	pub email: String,
+	#[validate(length(min = 3, max = 50))]
+	pub username: String,
+	#[validate(length(min = 8))]
+	pub password: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserResponse {
+	pub id: i64,
+	pub username: String,
+	pub email: String,
+	pub is_active: bool,
+}
+
+impl From<User> for UserResponse {
+	fn from(user: User) -> Self {
+		UserResponse {
+			id: user.id,
+			username: user.username,
+			email: user.email,
+			is_active: user.is_active,
+		}
+	}
+}
+```
+
+في `views/user.rs` لتطبيقك:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, post};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use crate::serializers::{CreateUserRequest, UserResponse};
+use validator::Validate;
+use std::sync::Arc;
+
+#[post("/users", name = "create_user")]
+pub async fn create_user(
+	mut req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// تحليل جسم الطلب
+	let body_bytes = std::mem::take(&mut req.body);
+	let create_req: CreateUserRequest = serde_json::from_slice(&body_bytes)?;
+
+	// التحقق من الطلب
+	create_req.validate()?;
+
+	// إنشاء المستخدم
+	let mut user = User {
+		id: 0, // سيُعيّن بواسطة قاعدة البيانات
+		username: create_req.username,
+		email: create_req.email,
+		password_hash: None,
+		is_active: true,
+		created_at: Utc::now(),
+	};
+
+	// تجزئة كلمة المرور باستخدام سمة BaseUser
+	user.set_password(&create_req.password)?;
+
+	// الحفظ في قاعدة البيانات باستخدام الاتصال المحقون
+	user.save(&db).await?;
+
+	// التحويل للاستجابة
+	let response_data = UserResponse::from(user);
+	let json = serde_json::to_string(&response_data)?;
+
+	Ok(Response::new(StatusCode::CREATED)
+		.with_body(json))
+}
+```
+
+## المكونات المتاحة
+
+Reinhardt يقدم مكونات معيارية قابلة للمزج:
+
+| المكون              | اسم الصندوق               | الميزات                                     |
+|---------------------|---------------------------|---------------------------------------------|
+| **النواة**           |                           |                                             |
+| الأنواع الأساسية     | `reinhardt-core`          | السمات والأنواع والماكرو الأساسية (Model، endpoint)|
+| HTTP والتوجيه       | `reinhardt-http`          | Request/Response، معالجة HTTP               |
+| توجيه URL           | `reinhardt-urls`          | مسارات قائمة على الدوال والفئات            |
+| الخادم              | `reinhardt-server`        | تنفيذ خادم HTTP                             |
+| Middleware          | `reinhardt-dispatch`      | سلسلة Middleware، إرسال الإشارات           |
+| التهيئة             | `reinhardt-conf`          | إدارة الإعدادات، تحميل البيئة              |
+| الأوامر             | `reinhardt-commands`      | أدوات CLI للإدارة (startproject، إلخ)      |
+| الاختصارات          | `reinhardt-shortcuts`     | دوال مساعدة شائعة                          |
+| **قاعدة البيانات**   |                           |                                             |
+| ORM                 | `reinhardt-db`            | تكامل SeaQuery v1.0.0-rc                   |
+| **المصادقة**        |                           |                                             |
+| Auth                | `reinhardt-auth`          | JWT، Token، Session، Basic auth، نماذج User|
+| **REST API**        |                           |                                             |
+| المسلسلات           | `reinhardt-rest`          | تكامل serde/validator، ViewSets             |
+| **النماذج**          |                           |                                             |
+| النماذج             | `reinhardt-forms`         | معالجة النماذج والتحقق                      |
+| **متقدم**           |                           |                                             |
+| لوحة الإدارة        | `reinhardt-admin`         | واجهة إدارة بأسلوب Django                   |
+| نظام الإضافات       | `reinhardt-dentdelion`    | دعم إضافات ثابتة و WASM، إدارة CLI         |
+| المهام الخلفية       | `reinhardt-tasks`         | طوابير المهام (Redis، RabbitMQ، SQLite)    |
+| GraphQL             | `reinhardt-graphql`       | توليد المخطط، الاشتراكات                    |
+| WebSockets          | `reinhardt-websockets`    | الاتصال الفوري                              |
+| i18n                | `reinhardt-i18n`          | دعم تعدد اللغات                             |
+| **الاختبار**         |                           |                                             |
+| أدوات الاختبار      | `reinhardt-test`          | مساعدات الاختبار، التثبيتات، TestContainers |
+
+**لأعلام الميزات التفصيلية في كل صندوق، انظر [دليل أعلام الميزات](../FEATURE_FLAGS.md).**
+
+---
+
+## الوثائق
+
+- 📚 [دليل البدء](../GETTING_STARTED.md) - دروس خطوة بخطوة للمبتدئين
+- 🎛️ [دليل أعلام الميزات](../FEATURE_FLAGS.md) - تحسين البناء بالتحكم الدقيق بالميزات
+- 📖 [مرجع API](https://docs.rs/reinhardt) (قريباً)
+- 📝 [الدروس التعليمية](../tutorials/) - تعلم ببناء تطبيقات حقيقية
+
+**لمساعدي AI**: انظر [CLAUDE.md](../../CLAUDE.md) لمعايير البرمجة الخاصة بالمشروع وإرشادات الاختبار واتفاقيات التطوير.
+
+## 💬 الحصول على المساعدة
+
+Reinhardt مشروع يقوده المجتمع. إليك أين تحصل على المساعدة:
+
+- 💬 **Discord**: انضم إلى خادم Discord للدردشة الفورية (قريباً)
+- 💭 **GitHub Discussions**: [اطرح أسئلة وشارك الأفكار](https://github.com/kent8192/reinhardt-rs/discussions)
+- 🐛 **Issues**: [أبلغ عن الأخطاء](https://github.com/kent8192/reinhardt-rs/issues)
+- 📖 **الوثائق**: [اقرأ الأدلة](../)
+
+قبل السؤال، يرجى التحقق من:
+
+- ✅ [دليل البدء](../GETTING_STARTED.md)
+- ✅ [الأمثلة](../../examples/)
+- ✅ Issues و Discussions الموجودة على GitHub
+
+## 🤝 المساهمة
+
+نحب المساهمات! يرجى قراءة [دليل المساهمة](../../CONTRIBUTING.md) للبدء.
+
+**روابط سريعة**:
+
+- [إعداد التطوير](../../CONTRIBUTING.md#development-setup)
+- [إرشادات الاختبار](../../CONTRIBUTING.md#testing-guidelines)
+- [إرشادات الإيداع](../../CONTRIBUTING.md#commit-guidelines)
+
+## الترخيص
+
+مرخص بموجب أي من:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) أو http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) أو http://opensource.org/licenses/MIT)
+
+باختيارك.
+
+### إسناد الطرف الثالث
+
+هذا المشروع مستوحى من:
+
+- [Django](https://www.djangoproject.com/) (ترخيص BSD 3-Clause)
+- [Django REST Framework](https://www.django-rest-framework.org/) (ترخيص BSD 3-Clause)
+- [FastAPI](https://fastapi.tiangolo.com/) (ترخيص MIT)
+- [SQLAlchemy](https://www.sqlalchemy.org/) (ترخيص MIT)
+
+انظر الإسناد الكامل في [THIRD-PARTY-NOTICES](../../THIRD-PARTY-NOTICES).
+
+**ملاحظة:** هذا المشروع غير تابع أو معتمد من Django Software Foundation أو Encode OSS Ltd. أو Sebastián Ramírez (مؤلف FastAPI) أو Michael Bayer (مؤلف SQLAlchemy).

--- a/docs/readme-langs/README_FA.md
+++ b/docs/readme-langs/README_FA.md
@@ -1,0 +1,1059 @@
+<div align="center">
+  <img src="../../branding/logo.png" alt="Reinhardt Logo" width="200"/>
+
+  <h1>Reinhardt</h1>
+
+  <h3>🦀 فریم‌ورک چندلیتیک با باتری‌های کامل</h3>
+
+  <p><strong>یک فریم‌ورک API تمام‌پشته قابل ترکیب برای Rust</strong></p>
+  <p>با <em>تمام</em> قدرت فلسفه "باتری‌های کامل" Django بسازید،<br/>
+  یا <em>فقط</em> آنچه نیاز دارید را ترکیب کنید—انتخاب شما، راه شما.</p>
+
+🌐 [English](../../README.md) | [日本語](README_JA.md) | [简体中文](README_ZH_CN.md) | [繁體中文](README_ZH_TW.md) | [Русский](README_RU.md) | [Українська](README_UK.md) | **فارسی** | [العربية](README_AR.md)
+
+[![Crates.io](https://img.shields.io/crates/v/reinhardt-web.svg)](https://crates.io/crates/reinhardt-web)
+[![Documentation](https://docs.rs/reinhardt-web/badge.svg)](https://docs.rs/reinhardt-web)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](../../LICENSE.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kent8192/reinhardt-web)
+
+</div>
+
+---
+
+## 📍 ناوبری سریع
+
+شاید به دنبال این موارد باشید:
+
+- 🚀 [شروع سریع](#شروع-سریع) - راه‌اندازی در ۵ دقیقه
+- 📦 [گزینه‌های نصب](#نصب) - نوع خود را انتخاب کنید: Micro، Standard یا Full
+- 📚 [راهنمای شروع کار](../GETTING_STARTED.md) - آموزش گام به گام
+- 🎛️ [پرچم‌های ویژگی](../FEATURE_FLAGS.md) - تنظیم دقیق ساخت
+- 📖 [مستندات API](https://docs.rs/reinhardt-web) - مرجع کامل API
+- 💬 [انجمن و پشتیبانی](#دریافت-کمک) - از انجمن کمک بگیرید
+
+## چرا Reinhardt؟
+
+**Polylithic = Poly (بسیار) + Lithic (بلوک‌های ساختمانی)**
+برخلاف فریم‌ورک‌های یکپارچه که شما را مجبور به استفاده از همه چیز می‌کنند، Reinhardt به شما اجازه می‌دهد پشته کامل خود را از اجزای مستقل و به خوبی تست شده بسازید.
+
+Reinhardt بهترین‌ها را از سه دنیا گرد هم می‌آورد:
+
+| الهام‌بخش          | چه چیزی قرض گرفتیم                                     | چه چیزی بهبود دادیم                                  |
+|--------------------|--------------------------------------------------------|------------------------------------------------------|
+| 🐍 **Django**      | فلسفه باتری‌های کامل، طراحی ORM، پنل مدیریت            | پرچم‌های ویژگی برای ساخت‌های قابل ترکیب، ایمنی نوع Rust |
+| 🎯 **Django REST** | سریال‌سازها، ViewSets، مجوزها                           | اعتبارسنجی زمان کامپایل، انتزاع‌های بدون هزینه        |
+| ⚡ **FastAPI**      | سیستم DI، OpenAPI خودکار                               | عملکرد بومی Rust، بدون سربار زمان اجرا               |
+| 🗄️ **SQLAlchemy** | الگوهای QuerySet، مدیریت روابط                          | سازنده کوئری ایمن از نظر نوع، اعتبارسنجی زمان کامپایل |
+
+**نتیجه**: فریم‌ورکی آشنا برای توسعه‌دهندگان Python، اما با عملکرد و تضمین‌های امنیتی Rust.
+
+## ✨ ویژگی‌های کلیدی
+
+- **ORM ایمن از نظر نوع** با اعتبارسنجی زمان کامپایل (SeaQuery v1.0.0-rc)
+- **سریال‌سازهای قدرتمند** با اعتبارسنجی خودکار (serde + validator)
+- **DI به سبک FastAPI** با تزریق وابستگی ایمن از نظر نوع و کش
+- **ViewSets** برای توسعه سریع CRUD API
+- **احراز هویت چندگانه** (JWT، Token، Session، Basic) با صفات BaseUser/FullUser
+- **پنل مدیریت** با رابط مدیریت مدل خودکار
+- **دستورات مدیریت** برای مهاجرت، فایل‌های استاتیک و موارد دیگر
+- **پشتیبانی GraphQL و WebSocket** برای برنامه‌های بلادرنگ
+- **صفحه‌بندی، فیلتر، محدودیت نرخ** داخلی
+- **سیگنال‌ها** برای معماری رویداد‌محور
+
+لیست کامل را در [اجزای موجود](#اجزای-موجود) و نمونه‌ها را در [راهنمای شروع کار](../GETTING_STARTED.md) ببینید.
+
+## نصب
+
+Reinhardt یک فریم‌ورک ماژولار است. نقطه شروع خود را انتخاب کنید:
+
+**نکته درباره نام‌گذاری کریت:**
+کریت اصلی Reinhardt در crates.io با نام `reinhardt-web` منتشر شده است، اما شما آن را با استفاده از ویژگی `package` به عنوان `reinhardt` در کد خود وارد می‌کنید.
+
+### پیش‌فرض: کامل‌ویژگی (باتری‌های کامل) ⚠️ پیش‌فرض جدید
+
+همه ویژگی‌ها بدون تنظیمات:
+
+```toml
+[dependencies]
+# به عنوان 'reinhardt' وارد می‌شود، با نام 'reinhardt-web' منتشر شده
+# پیش‌فرض همه ویژگی‌ها را فعال می‌کند (بسته کامل)
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web" }
+```
+
+**شامل:** Database، Auth، REST API، Admin، GraphQL، WebSockets، Cache، i18n، Mail، Sessions، Static Files، Storage
+
+**باینری**: ~50+ مگابایت | **کامپایل**: کندتر، اما همه چیز از جعبه کار می‌کند
+
+سپس در کد استفاده کنید:
+```rust
+use reinhardt::prelude::*;
+use reinhardt::{Request, Response, StatusCode};
+```
+
+### گزینه ۱: راه‌اندازی استاندارد (متعادل)
+
+برای اکثر پروژه‌هایی که به همه ویژگی‌ها نیاز ندارند:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["standard"] }
+```
+
+**شامل:** Core، Database (PostgreSQL)، REST API، Auth، Middleware، Pages (فرانت‌اند WASM با SSR)
+
+**باینری**: ~20-30 مگابایت | **کامپایل**: متوسط
+
+### گزینه ۲: میکروسرویس‌ها (راه‌اندازی حداقلی)
+
+سبک و سریع، مناسب برای APIهای ساده:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+```
+
+**شامل:** HTTP، مسیریابی، DI، استخراج پارامتر، سرور
+
+**باینری**: ~5-10 مگابایت | **کامپایل**: بسیار سریع
+
+### گزینه ۳: پشته سفارشی خود را بسازید
+
+فقط اجزای مورد نیاز را نصب کنید:
+
+```toml
+[dependencies]
+# اجزای اصلی
+reinhardt-http = "0.1.0-alpha.1"
+reinhardt-urls = "0.1.0-alpha.1"
+
+# اختیاری: پایگاه داده
+reinhardt-db = "0.1.0-alpha.1"
+
+# اختیاری: احراز هویت
+reinhardt-auth = "0.1.0-alpha.1"
+
+# اختیاری: ویژگی‌های REST API
+reinhardt-rest = "0.1.0-alpha.1"
+
+# اختیاری: پنل مدیریت
+reinhardt-admin = "0.1.0-alpha.1"
+
+# اختیاری: ویژگی‌های پیشرفته
+reinhardt-graphql = "0.1.0-alpha.1"
+reinhardt-websockets = "0.1.0-alpha.1"
+```
+
+**📖 برای لیست کامل کریت‌ها و پرچم‌های ویژگی موجود، [راهنمای پرچم‌های ویژگی](../FEATURE_FLAGS.md) را ببینید.**
+
+## شروع سریع
+
+### ۱. ابزار Reinhardt Admin را نصب کنید
+
+```bash
+cargo install reinhardt-admin-cli
+```
+
+### ۲. پروژه جدید ایجاد کنید
+
+```bash
+# ایجاد پروژه RESTful API (پیش‌فرض)
+reinhardt-admin startproject my-api
+cd my-api
+```
+
+این ساختار کامل پروژه را تولید می‌کند:
+
+```
+my-api/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   ├── config.rs
+│   ├── apps.rs
+│   ├── config/
+│   │   ├── settings.rs
+│   │   ├── settings/
+│   │   │   ├── base.rs
+│   │   │   ├── local.rs
+│   │   │   ├── staging.rs
+│   │   │   └── production.rs
+│   │   ├── urls.rs
+│   │   └── apps.rs
+│   └── bin/
+│       └── manage.rs
+└── README.md
+```
+
+**جایگزین: ایجاد پروژه reinhardt-pages (WASM + SSR)**
+
+برای فرانت‌اند مدرن WASM با SSR:
+
+```bash
+# ایجاد پروژه pages
+reinhardt-admin startproject my-app --with-pages
+cd my-app
+
+# نصب ابزارهای ساخت WASM (فقط بار اول)
+cargo make install-wasm-tools
+
+# ساخت WASM و راه‌اندازی سرور توسعه
+cargo make dev
+# به http://127.0.0.1:8000/ مراجعه کنید
+```
+
+### ۳. سرور توسعه را اجرا کنید
+
+```bash
+# با استفاده از دستور manage
+cargo run --bin manage runserver
+
+# سرور در http://127.0.0.1:8000 شروع به کار می‌کند
+```
+
+**پشتیبانی از بارگذاری مجدد خودکار:**
+
+برای بارگذاری مجدد خودکار هنگام تغییر کد (نیاز به bacon):
+
+```bash
+# نصب bacon
+cargo install --locked bacon
+
+# اجرا با بارگذاری مجدد خودکار
+bacon runserver
+
+# یا از cargo make استفاده کنید
+cargo make watch
+
+# برای تست‌ها
+bacon test
+```
+
+### ۴. اولین برنامه خود را ایجاد کنید
+
+```bash
+# ایجاد برنامه RESTful API (پیش‌فرض)
+cargo run --bin manage startapp users
+
+# یا نوع را به صراحت مشخص کنید
+cargo run --bin manage startapp users --restful
+
+# ایجاد برنامه Pages (WASM + SSR)
+cargo run --bin manage startapp dashboard --with-pages
+```
+
+این ساختار برنامه را ایجاد می‌کند:
+
+```
+users/
+├── lib.rs
+├── models.rs
+├── models/
+├── views.rs
+├── views/
+├── serializers.rs
+├── serializers/
+├── admin.rs
+├── urls.rs
+└── tests.rs
+```
+
+### ۵. مسیرها را ثبت کنید
+
+`urls.rs` برنامه خود را ویرایش کنید:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::list_users)
+		.endpoint(views::get_user)
+		.endpoint(views::create_user)
+}
+```
+
+در `src/config/urls.rs` شامل کنید:
+
+```rust
+// src/config/urls.rs
+use reinhardt::prelude::*;
+use reinhardt::routes;
+
+#[routes]
+pub fn routes() -> ServerRouter {
+	ServerRouter::new()
+		.mount("/api/", users::urls::url_patterns())
+}
+```
+
+ماکرو ویژگی `#[routes]` به طور خودکار این تابع را با فریم‌ورک برای کشف از طریق کریت `inventory` ثبت می‌کند.
+
+**نکته:** `reinhardt::prelude` شامل انواع متداول است. صادرات‌های اصلی:
+
+**همیشه موجود:**
+- مسیریابی و نماهای اصلی: `Router`، `DefaultRouter`، `ServerRouter`، `View`، `ListView`، `DetailView`
+- ViewSets: `ViewSet`، `ModelViewSet`، `ReadOnlyModelViewSet`
+- HTTP: `StatusCode`
+
+**وابسته به ویژگی:**
+- **ویژگی `core`**: `Request`، `Response`، `Handler`، `Middleware`، سیگنال‌ها (`post_save`، `pre_save` و غیره)
+- **ویژگی `database`**: `Model`، `DatabaseConnection`، `F`، `Q`، `Transaction`، `atomic`، توابع پایگاه داده (`Concat`، `Upper`، `Lower`، `Now`، `CurrentDate`)، توابع پنجره‌ای (`Window`، `RowNumber`، `Rank`، `DenseRank`)، محدودیت‌ها (`UniqueConstraint`، `CheckConstraint`، `ForeignKeyConstraint`)
+- **ویژگی `auth`**: `User`، `UserManager`، `GroupManager`، `Permission`، `ObjectPermission`
+- **ویژگی‌های `minimal`، `standard` یا `di`**: `Body`، `Cookie`، `Header`، `Json`، `Path`، `Query`
+- **ویژگی `rest`**: سریال‌سازها، پارسرها، صفحه‌بندی، محدودیت نرخ، نسخه‌بندی
+- **ویژگی `admin`**: اجزای پنل مدیریت
+- **ویژگی `cache`**: `Cache`، `InMemoryCache`
+- **ویژگی `sessions`**: `Session`، `AuthenticationMiddleware`
+
+لیست کامل را در [راهنمای پرچم‌های ویژگی](../FEATURE_FLAGS.md) ببینید.
+
+راهنمای کامل گام به گام را در [راهنمای شروع کار](../GETTING_STARTED.md) ببینید.
+
+## 🎓 با مثال یاد بگیرید
+
+### با پایگاه داده
+
+پایگاه داده را در `settings/base.toml` تنظیم کنید:
+
+```toml
+debug = true
+secret_key = "your-secret-key-for-development"
+
+[database]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "mydb"
+user = "postgres"
+password = "postgres"
+```
+
+تنظیمات به طور خودکار در `src/config/settings.rs` بارگذاری می‌شوند:
+
+```rust
+// src/config/settings.rs
+use reinhardt::conf::settings::builder::SettingsBuilder;
+use reinhardt::conf::settings::profile::Profile;
+use reinhardt::conf::settings::sources::{DefaultSource, LowPriorityEnvSource, TomlFileSource};
+use reinhardt::core::Settings;
+use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub fn get_settings() -> Settings {
+	let profile_str = env::var("REINHARDT_ENV").unwrap_or_else(|_| "local".to_string());
+	let profile = Profile::from_str(&profile_str).unwrap_or(Profile::Development);
+
+	let base_dir = env::current_dir().expect("Failed to get current directory");
+	let settings_dir = base_dir.join("settings");
+
+	let merged = SettingsBuilder::new()
+		.profile(profile)
+		.add_source(
+			DefaultSource::new()
+				.with_value("debug", serde_json::Value::Bool(false))
+				.with_value("language_code", serde_json::Value::String("en-us".to_string()))
+				.with_value("time_zone", serde_json::Value::String("UTC".to_string()))
+		)
+		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
+		.add_source(TomlFileSource::new(settings_dir.join(format!("{}.toml", profile_str))))
+		.build()
+		.expect("Failed to build settings");
+
+	merged.into_typed().expect("Failed to convert settings to Settings struct")
+}
+```
+
+**منابع متغیر محیطی:**
+
+Reinhardt دو نوع منبع متغیر محیطی با اولویت‌های مختلف ارائه می‌دهد:
+
+- **`EnvSource`** (اولویت: 100) - متغیرهای محیطی با اولویت بالا که فایل‌های TOML را لغو می‌کنند
+  ```rust
+  .add_source(EnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+- **`LowPriorityEnvSource`** (اولویت: 40) - متغیرهای محیطی با اولویت پایین که به فایل‌های TOML بازمی‌گردند
+  ```rust
+  .add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+**ترتیب اولویت**:
+- با `EnvSource`: متغیرهای محیطی > `{profile}.toml` > `base.toml` > پیش‌فرض‌ها
+- با `LowPriorityEnvSource` (نشان داده شده در بالا): `{profile}.toml` > `base.toml` > متغیرهای محیطی > پیش‌فرض‌ها
+
+وقتی متغیرهای محیطی باید همیشه اولویت داشته باشند `EnvSource` را انتخاب کنید (مثلاً استقرار production).
+وقتی فایل‌های TOML باید منبع اصلی پیکربندی باشند `LowPriorityEnvSource` را انتخاب کنید (مثلاً توسعه).
+
+برای جزئیات بیشتر [مستندات تنظیمات](../SETTINGS_DOCUMENT.md) را ببینید.
+
+**استفاده از DefaultUser داخلی:**
+
+Reinhardt یک پیاده‌سازی `DefaultUser` آماده استفاده ارائه می‌دهد (نیاز به ویژگی `argon2-hasher`):
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// DefaultUser را به عنوان User برنامه خود صادر مجدد کنید
+pub type User = DefaultUser;
+
+// DefaultUser شامل:
+// - id: Uuid (کلید اصلی)
+// - username: String
+// - email: String
+// - password_hash: Option<String>
+// - first_name: String
+// - last_name: String
+// - is_active: bool
+// - is_staff: bool
+// - is_superuser: bool
+// - last_login: Option<DateTime<Utc>>
+// - date_joined: DateTime<Utc>
+
+// DefaultUser پیاده‌سازی می‌کند:
+// - صفت BaseUser (متدهای احراز هویت)
+// - صفت FullUser (اطلاعات کامل کاربر)
+// - صفت PermissionsMixin (مدیریت مجوزها)
+// - صفت Model (عملیات پایگاه داده)
+```
+
+**تعریف مدل‌های کاربر سفارشی:**
+
+اگر به فیلدهای سفارشی نیاز دارید، مدل خود را تعریف کنید:
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Utc};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: i64,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	#[field(max_length = 100)]
+	pub username: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(auto_now_add = true)]
+	pub created_at: DateTime<Utc>,
+
+	// اضافه کردن فیلدهای سفارشی
+	#[field(max_length = 50, null = true)]
+	pub phone_number: Option<String>,
+}
+```
+
+**ماکرو ویژگی Model:**
+
+ویژگی `#[model(...)]` به طور خودکار تولید می‌کند:
+- پیاده‌سازی صفت `Model` (شامل قابلیت `#[derive(Model)]`)
+- دسترسی‌دهنده‌های فیلد ایمن از نظر نوع: `User::field_email()`، `User::field_username()` و غیره
+- ثبت در رجیستری مدل جهانی
+- پشتیبانی از کلیدهای اصلی ترکیبی
+
+**نکته:** هنگام استفاده از `#[model(...)]`، نیازی به اضافه کردن جداگانه `#[derive(Model)]` ندارید،
+زیرا به طور خودکار توسط ویژگی `#[model(...)]` اعمال می‌شود.
+
+**ویژگی‌های فیلد:**
+- `#[field(primary_key = true)]` - علامت‌گذاری به عنوان کلید اصلی
+- `#[field(max_length = 255)]` - تنظیم حداکثر طول برای فیلدهای رشته‌ای
+- `#[field(default = value)]` - تنظیم مقدار پیش‌فرض
+- `#[field(auto_now_add = true)]` - پر کردن خودکار timestamp هنگام ایجاد
+- `#[field(auto_now = true)]` - به‌روزرسانی خودکار timestamp هنگام ذخیره
+- `#[field(null = true)]` - اجازه مقادیر NULL
+- `#[field(unique = true)]` - اعمال محدودیت یکتایی
+
+لیست کامل ویژگی‌های فیلد را در [راهنمای ویژگی‌های فیلد](../field_attributes.md) ببینید.
+
+دسترسی‌دهنده‌های فیلد تولید شده امکان ارجاع ایمن از نظر نوع به فیلدها در کوئری‌ها را فراهم می‌کنند:
+
+```rust
+// تولید شده توسط #[model(...)] برای DefaultUser
+impl DefaultUser {
+	pub const fn field_id() -> FieldRef<DefaultUser, Uuid> { FieldRef::new("id") }
+	pub const fn field_username() -> FieldRef<DefaultUser, String> { FieldRef::new("username") }
+	pub const fn field_email() -> FieldRef<DefaultUser, String> { FieldRef::new("email") }
+	pub const fn field_is_active() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_active") }
+	pub const fn field_is_staff() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_staff") }
+	pub const fn field_date_joined() -> FieldRef<DefaultUser, DateTime<Utc>> { FieldRef::new("date_joined") }
+	// ... سایر فیلدها
+}
+```
+
+**نمونه‌های کوئری پیشرفته:**
+
+```rust
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// کوئری‌های اشیاء F/Q به سبک Django با ارجاعات فیلد ایمن از نظر نوع
+async fn complex_user_query() -> Result<Vec<DefaultUser>, Box<dyn std::error::Error>> {
+	// اشیاء Q با ارجاعات فیلد ایمن از نظر نوع (با استفاده از دسترسی‌دهنده‌های فیلد تولید شده)
+	let active_query = Q::new()
+		.field("is_active").eq(true)
+		.and(Q::new().field("date_joined").gte(Now::new()));
+
+	// توابع پایگاه داده با ارجاعات فیلد ایمن از نظر نوع
+	let email_lower = Lower::new(DefaultUser::field_email().into());
+	let username_upper = Upper::new(DefaultUser::field_username().into());
+
+	// تجمیع‌ها با استفاده از دسترسی‌دهنده‌های فیلد
+	let user_count = Aggregate::count(DefaultUser::field_id().into());
+	let latest_joined = Aggregate::max(DefaultUser::field_date_joined().into());
+
+	// توابع پنجره‌ای برای رتبه‌بندی
+	let rank_by_join_date = Window::new()
+		.partition_by(vec![DefaultUser::field_is_active().into()])
+		.order_by(vec![(DefaultUser::field_date_joined().into(), "DESC")])
+		.function(RowNumber::new());
+
+	todo!("Execute query with these components")
+}
+
+// پشتیبانی از تراکنش
+async fn create_user_with_transaction(
+	conn: &DatabaseConnection,
+	user_data: CreateUserRequest
+) -> Result<User, Box<dyn std::error::Error>> {
+	// تراکنش با بازگشت خودکار در صورت خطا
+	transaction(conn, |_tx| async move {
+		let user = User::create(user_data).await?;
+		log_user_creation(&user).await?;
+		Ok(user)
+	}).await
+}
+```
+
+**نکته**: Reinhardt از [SeaQuery v1.0.0-rc](https://crates.io/crates/sea-query) برای عملیات SQL استفاده می‌کند. ماکرو `#[derive(Model)]` به طور خودکار پیاده‌سازی‌های صفت Model، دسترسی‌دهنده‌های فیلد ایمن از نظر نوع و ثبت در رجیستری مدل جهانی را تولید می‌کند.
+
+در `src/config/apps.rs` ثبت کنید:
+
+```rust
+// src/config/apps.rs
+use reinhardt::installed_apps;
+
+// ماکرو installed_apps! تولید می‌کند:
+// - یک enum InstalledApp با واریانت‌هایی برای هر برنامه
+// - پیاده‌سازی صفات تبدیل (From، Into، Display)
+// - یک رجیستری برای پیکربندی و کشف برنامه
+//
+// نکته: برخلاف INSTALLED_APPS در Django، این ماکرو فقط برای برنامه‌های کاربر است.
+// ویژگی‌های داخلی فریم‌ورک (auth، sessions، admin و غیره) از طریق
+// پرچم‌های ویژگی Cargo فعال می‌شوند، نه از طریق installed_apps!.
+//
+// مثال:
+// [dependencies]
+// reinhardt = { version = "0.1", features = ["auth", "sessions", "admin"] }
+//
+// این فعال می‌کند:
+// - کشف خودکار برنامه برای مهاجرت‌ها، پنل مدیریت و غیره
+// - ارجاعات برنامه ایمن از نظر نوع در سراسر کد شما
+// - پیکربندی متمرکز برنامه
+installed_apps! {
+	users: "users",
+}
+
+pub fn get_installed_apps() -> Vec<String> {
+	InstalledApp::all_apps()
+}
+```
+
+### با احراز هویت
+
+Reinhardt مدل‌های کاربر به سبک Django با صفات `BaseUser` و `FullUser`، همراه با مدیریت جامع کاربر از طریق `UserManager` ارائه می‌دهد.
+
+**نکته:** Reinhardt شامل یک پیاده‌سازی `DefaultUser` داخلی است. می‌توانید مستقیماً از آن استفاده کنید یا مدل کاربر خود را مطابق شکل زیر تعریف کنید.
+
+**نمونه مدیریت کاربر:**
+
+```rust
+use reinhardt::prelude::*;
+
+// ایجاد و مدیریت کاربران با UserManager
+async fn manage_users() -> Result<(), Box<dyn std::error::Error>> {
+	let hasher = Argon2Hasher::new();
+	let user_manager = UserManager::new(hasher);
+
+	// ایجاد یک کاربر جدید
+	let user = user_manager.create_user(CreateUserData {
+		username: "alice".to_string(),
+		email: "alice@example.com".to_string(),
+		password: "secure_password".to_string(),
+		first_name: Some("Alice".to_string()),
+		last_name: Some("Smith".to_string()),
+	}).await?;
+
+	// به‌روزرسانی اطلاعات کاربر
+	user_manager.update_user(user.id, UpdateUserData {
+		email: Some("alice.smith@example.com".to_string()),
+		is_active: Some(true),
+		..Default::default()
+	}).await?;
+
+	// مدیریت گروه‌ها و مجوزها
+	let group_manager = GroupManager::new();
+	let editors = group_manager.create_group(CreateGroupData {
+		name: "editors".to_string(),
+	}).await?;
+
+	// تخصیص مجوزهای سطح شیء
+	let permission = ObjectPermission::new("edit", user.id, article.id);
+	let perm_checker = ObjectPermissionChecker::new();
+	if perm_checker.has_permission(&user, "edit", &article).await? {
+		// کاربر می‌تواند مقاله را ویرایش کند
+	}
+
+	Ok(())
+}
+```
+
+از `DefaultUser` داخلی در `users/models.rs` استفاده کنید:
+
+```rust
+// users/models.rs
+use reinhardt::DefaultUser;
+
+// DefaultUser را به عنوان نوع User خود صادر مجدد کنید
+pub type User = DefaultUser;
+
+// DefaultUser قبلاً پیاده‌سازی کرده است:
+// - صفت BaseUser (متدهای احراز هویت)
+// - صفت FullUser (username، email، first_name، last_name و غیره)
+// - صفت PermissionsMixin (مدیریت مجوزها)
+// - صفت Model (عملیات پایگاه داده)
+```
+
+**برای مدل‌های کاربر سفارشی:**
+
+اگر به فیلدهای اضافی فراتر از DefaultUser نیاز دارید، خودتان تعریف کنید:
+
+```rust
+// users/models.rs
+use reinhardt::auth::{BaseUser, FullUser, PermissionsMixin};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+use serde::{Serialize, Deserialize};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: Uuid,
+
+	#[field(max_length = 150)]
+	pub username: String,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	pub password_hash: Option<String>,
+
+	#[field(max_length = 150)]
+	pub first_name: String,
+
+	#[field(max_length = 150)]
+	pub last_name: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(default = false)]
+	pub is_staff: bool,
+
+	#[field(default = false)]
+	pub is_superuser: bool,
+
+	pub last_login: Option<DateTime<Utc>>,
+
+	#[field(auto_now_add = true)]
+	pub date_joined: DateTime<Utc>,
+
+	// فیلدهای سفارشی
+	#[field(max_length = 20, null = true)]
+	pub phone_number: Option<String>,
+}
+
+impl BaseUser for CustomUser {
+	type PrimaryKey = Uuid;
+
+	fn get_username_field() -> &'static str { "username" }
+	fn get_username(&self) -> &str { &self.username }
+	fn password_hash(&self) -> Option<&str> { self.password_hash.as_deref() }
+	fn set_password_hash(&mut self, hash: String) { self.password_hash = Some(hash); }
+	fn last_login(&self) -> Option<DateTime<Utc>> { self.last_login }
+	fn set_last_login(&mut self, time: DateTime<Utc>) { self.last_login = Some(time); }
+	fn is_active(&self) -> bool { self.is_active }
+}
+
+impl FullUser for CustomUser {
+	fn username(&self) -> &str { &self.username }
+	fn email(&self) -> &str { &self.email }
+	fn first_name(&self) -> &str { &self.first_name }
+	fn last_name(&self) -> &str { &self.last_name }
+	fn is_staff(&self) -> bool { self.is_staff }
+	fn is_superuser(&self) -> bool { self.is_superuser }
+	fn date_joined(&self) -> DateTime<Utc> { self.date_joined }
+}
+```
+
+از احراز هویت JWT در `views/profile.rs` برنامه خود استفاده کنید:
+
+```rust
+// users/views/profile.rs
+use reinhardt::auth::{JwtAuth, BaseUser};
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+use crate::models::User;
+
+#[get("/profile", name = "get_profile")]
+pub async fn get_profile(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// استخراج توکن JWT از هدر Authorization
+	let auth_header = req.headers.get("authorization")
+		.and_then(|h| h.to_str().ok())
+		.ok_or("Missing Authorization header")?;
+
+	let token = auth_header.strip_prefix("Bearer ")
+		.ok_or("Invalid Authorization header format")?;
+
+	// تأیید توکن و دریافت شناسه کاربر
+	let jwt_auth = JwtAuth::new(b"your-secret-key");
+	let claims = jwt_auth.verify_token(token)?;
+
+	// بارگذاری کاربر از پایگاه داده با استفاده از claims.user_id
+	let user = User::find_by_id(&db, &claims.user_id).await?;
+
+	// بررسی فعال بودن کاربر
+	if !user.is_active() {
+		return Err("User account is inactive".into());
+	}
+
+	// بازگشت پروفایل کاربر به صورت JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+### تعریف نقطه پایانی
+
+Reinhardt از دکوراتورهای متد HTTP برای تعریف نقاط پایانی استفاده می‌کند:
+
+#### دکوراتورهای متد HTTP
+
+از `#[get]`، `#[post]`، `#[put]`، `#[delete]` برای تعریف مسیرها استفاده کنید:
+
+```rust
+use reinhardt::{get, post, Request, Response, ViewResult};
+use serde_json::json;
+
+#[get("/")]
+pub async fn hello(_req: Request) -> ViewResult<Response> {
+	Ok(Response::ok().with_body("Hello, World!"))
+}
+
+#[post("/users")]
+pub async fn create_user(_req: Request) -> ViewResult<Response> {
+	let body = json!({"status": "created"});
+	Response::ok().with_json(&body).map_err(Into::into)
+}
+```
+
+**ویژگی‌ها:**
+- اعتبارسنجی مسیر در زمان کامپایل
+- نحو مختصر
+- اتصال خودکار متد HTTP
+- پشتیبانی از تزریق وابستگی از طریق `#[inject]`
+
+#### استفاده از تزریق وابستگی
+
+دکوراتورهای متد HTTP را با `#[inject]` برای تزریق وابستگی خودکار ترکیب کنید:
+
+```rust
+use reinhardt::{get, Request, Response, StatusCode, ViewResult};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,  // به طور خودکار تزریق می‌شود
+) -> ViewResult<Response> {
+	let id = req.path_params.get("id")
+		.ok_or("Missing id")?
+		.parse::<i64>()?;
+
+	// استفاده از اتصال پایگاه داده تزریق شده
+	let user = db.query("SELECT * FROM users WHERE id = $1")
+		.bind(id)
+		.fetch_one()
+		.await?;
+
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+**ویژگی‌های تزریق وابستگی:**
+- تزریق وابستگی خودکار از طریق ویژگی `#[inject]`
+- کنترل کش با `#[inject(cache = false)]`
+- سیستم تزریق وابستگی الهام گرفته از FastAPI
+- کار یکپارچه با دکوراتورهای متد HTTP
+
+**نوع بازگشتی:**
+
+همه توابع view از `ViewResult<T>` به عنوان نوع بازگشتی استفاده می‌کنند:
+
+```rust
+use reinhardt::ViewResult;  // نوع نتیجه از پیش تعریف شده
+```
+
+### با استخراج پارامتر
+
+در `views/user.rs` برنامه خود:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// استخراج پارامتر مسیر از درخواست
+	let id = req.path_params.get("id")
+		.ok_or("Missing id parameter")?
+		.parse::<i64>()
+		.map_err(|_| "Invalid id format")?;
+
+	// استخراج پارامترهای query (مثلاً ?include_inactive=true)
+	let include_inactive = req.query_params.get("include_inactive")
+		.and_then(|v| v.parse::<bool>().ok())
+		.unwrap_or(false);
+
+	// دریافت کاربر از پایگاه داده با استفاده از اتصال تزریق شده
+	let user = User::find_by_id(&db, id).await?;
+
+	// بررسی وضعیت فعال در صورت نیاز
+	if !include_inactive && !user.is_active {
+		return Err("User is inactive".into());
+	}
+
+	// بازگشت به صورت JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+مسیر با پارامتر مسیر را در `urls.rs` ثبت کنید:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::get_user)  // مسیر در #[get("/users/{id}/")] تعریف شده
+}
+```
+
+### با سریال‌سازها و اعتبارسنجی
+
+در `serializers/user.rs` برنامه خود:
+
+```rust
+// users/serializers/user.rs
+use serde::{Serialize, Deserialize};
+use validator::Validate;
+
+#[derive(Serialize, Deserialize, Validate)]
+pub struct CreateUserRequest {
+	#[validate(email)]
+	pub email: String,
+	#[validate(length(min = 3, max = 50))]
+	pub username: String,
+	#[validate(length(min = 8))]
+	pub password: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserResponse {
+	pub id: i64,
+	pub username: String,
+	pub email: String,
+	pub is_active: bool,
+}
+
+impl From<User> for UserResponse {
+	fn from(user: User) -> Self {
+		UserResponse {
+			id: user.id,
+			username: user.username,
+			email: user.email,
+			is_active: user.is_active,
+		}
+	}
+}
+```
+
+در `views/user.rs` برنامه خود:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, post};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use crate::serializers::{CreateUserRequest, UserResponse};
+use validator::Validate;
+use std::sync::Arc;
+
+#[post("/users", name = "create_user")]
+pub async fn create_user(
+	mut req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// تجزیه بدنه درخواست
+	let body_bytes = std::mem::take(&mut req.body);
+	let create_req: CreateUserRequest = serde_json::from_slice(&body_bytes)?;
+
+	// اعتبارسنجی درخواست
+	create_req.validate()?;
+
+	// ایجاد کاربر
+	let mut user = User {
+		id: 0, // توسط پایگاه داده تنظیم می‌شود
+		username: create_req.username,
+		email: create_req.email,
+		password_hash: None,
+		is_active: true,
+		created_at: Utc::now(),
+	};
+
+	// هش کردن رمز عبور با استفاده از صفت BaseUser
+	user.set_password(&create_req.password)?;
+
+	// ذخیره در پایگاه داده با استفاده از اتصال تزریق شده
+	user.save(&db).await?;
+
+	// تبدیل به پاسخ
+	let response_data = UserResponse::from(user);
+	let json = serde_json::to_string(&response_data)?;
+
+	Ok(Response::new(StatusCode::CREATED)
+		.with_body(json))
+}
+```
+
+## اجزای موجود
+
+Reinhardt اجزای ماژولار قابل ترکیب ارائه می‌دهد:
+
+| جزء                | نام کریت                   | ویژگی‌ها                                    |
+|---------------------|---------------------------|---------------------------------------------|
+| **هسته**            |                           |                                             |
+| انواع اصلی          | `reinhardt-core`          | صفات، انواع، ماکروهای اصلی (Model، endpoint)|
+| HTTP و مسیریابی     | `reinhardt-http`          | Request/Response، مدیریت HTTP               |
+| مسیریابی URL        | `reinhardt-urls`          | مسیرهای مبتنی بر تابع و کلاس               |
+| سرور               | `reinhardt-server`        | پیاده‌سازی سرور HTTP                        |
+| Middleware         | `reinhardt-dispatch`      | زنجیره Middleware، ارسال سیگنال            |
+| پیکربندی           | `reinhardt-conf`          | مدیریت تنظیمات، بارگذاری محیط              |
+| دستورات            | `reinhardt-commands`      | ابزارهای CLI مدیریت (startproject و غیره)  |
+| میانبرها           | `reinhardt-shortcuts`     | توابع کمکی رایج                            |
+| **پایگاه داده**     |                           |                                             |
+| ORM                | `reinhardt-db`            | یکپارچگی SeaQuery v1.0.0-rc                |
+| **احراز هویت**      |                           |                                             |
+| Auth               | `reinhardt-auth`          | JWT، Token، Session، Basic auth، مدل‌های User|
+| **REST API**       |                           |                                             |
+| سریال‌سازها         | `reinhardt-rest`          | یکپارچگی serde/validator، ViewSets          |
+| **فرم‌ها**          |                           |                                             |
+| فرم‌ها              | `reinhardt-forms`         | مدیریت و اعتبارسنجی فرم                    |
+| **پیشرفته**         |                           |                                             |
+| پنل مدیریت         | `reinhardt-admin`         | رابط مدیریت به سبک Django                   |
+| سیستم پلاگین       | `reinhardt-dentdelion`    | پشتیبانی پلاگین استاتیک و WASM، مدیریت CLI |
+| وظایف پس‌زمینه      | `reinhardt-tasks`         | صف وظایف (Redis، RabbitMQ، SQLite)         |
+| GraphQL            | `reinhardt-graphql`       | تولید اسکیما، اشتراک‌ها                     |
+| WebSockets         | `reinhardt-websockets`    | ارتباط بلادرنگ                              |
+| i18n               | `reinhardt-i18n`          | پشتیبانی چندزبانه                           |
+| **تست**            |                           |                                             |
+| ابزارهای تست       | `reinhardt-test`          | کمک‌کننده‌های تست، فیکسچرها، TestContainers |
+
+**برای پرچم‌های ویژگی دقیق در هر کریت، [راهنمای پرچم‌های ویژگی](../FEATURE_FLAGS.md) را ببینید.**
+
+---
+
+## مستندات
+
+- 📚 [راهنمای شروع کار](../GETTING_STARTED.md) - آموزش گام به گام برای مبتدیان
+- 🎛️ [راهنمای پرچم‌های ویژگی](../FEATURE_FLAGS.md) - بهینه‌سازی ساخت با کنترل دقیق ویژگی
+- 📖 [مرجع API](https://docs.rs/reinhardt) (به زودی)
+- 📝 [آموزش‌ها](../tutorials/) - یادگیری با ساخت برنامه‌های واقعی
+
+**برای دستیاران AI**: [CLAUDE.md](../../CLAUDE.md) را برای استانداردهای کدنویسی خاص پروژه، راهنماهای تست و قراردادهای توسعه ببینید.
+
+## 💬 دریافت کمک
+
+Reinhardt یک پروژه مبتنی بر انجمن است. اینجا می‌توانید کمک بگیرید:
+
+- 💬 **Discord**: به سرور Discord ما برای چت بلادرنگ بپیوندید (به زودی)
+- 💭 **GitHub Discussions**: [سوال بپرسید و ایده‌ها را به اشتراک بگذارید](https://github.com/kent8192/reinhardt-rs/discussions)
+- 🐛 **Issues**: [گزارش باگ](https://github.com/kent8192/reinhardt-rs/issues)
+- 📖 **مستندات**: [راهنماها را بخوانید](../)
+
+قبل از پرسیدن، لطفاً بررسی کنید:
+
+- ✅ [راهنمای شروع کار](../GETTING_STARTED.md)
+- ✅ [مثال‌ها](../../examples/)
+- ✅ Issues و Discussions موجود در GitHub
+
+## 🤝 مشارکت
+
+ما مشارکت‌ها را دوست داریم! لطفاً [راهنمای مشارکت](../../CONTRIBUTING.md) را برای شروع بخوانید.
+
+**لینک‌های سریع**:
+
+- [راه‌اندازی توسعه](../../CONTRIBUTING.md#development-setup)
+- [راهنمای تست](../../CONTRIBUTING.md#testing-guidelines)
+- [راهنمای کامیت](../../CONTRIBUTING.md#commit-guidelines)
+
+## مجوز
+
+تحت یکی از مجوزهای زیر به انتخاب شما:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) یا http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) یا http://opensource.org/licenses/MIT)
+
+### اعتبار طرف سوم
+
+این پروژه از موارد زیر الهام گرفته است:
+
+- [Django](https://www.djangoproject.com/) (مجوز BSD 3-Clause)
+- [Django REST Framework](https://www.django-rest-framework.org/) (مجوز BSD 3-Clause)
+- [FastAPI](https://fastapi.tiangolo.com/) (مجوز MIT)
+- [SQLAlchemy](https://www.sqlalchemy.org/) (مجوز MIT)
+
+اعتبار کامل را در [THIRD-PARTY-NOTICES](../../THIRD-PARTY-NOTICES) ببینید.
+
+**نکته:** این پروژه وابسته یا تأیید شده توسط Django Software Foundation، Encode OSS Ltd.، Sebastián Ramírez (نویسنده FastAPI) یا Michael Bayer (نویسنده SQLAlchemy) نیست.

--- a/docs/readme-langs/README_JA.md
+++ b/docs/readme-langs/README_JA.md
@@ -1,0 +1,1061 @@
+<div align="center">
+  <img src="../../branding/logo.png" alt="Reinhardt Logo" width="200"/>
+
+  <h1>Reinhardt</h1>
+
+  <h3>🦀 ポリリシック・バッテリー同梱</h3>
+
+  <p><strong>Rust向けコンポーザブルフルスタックAPIフレームワーク</strong></p>
+  <p>Djangoの「バッテリー同梱」哲学の<em>すべて</em>のパワーで構築するか、<br/>
+  必要なものだけを<em>組み合わせる</em>か—あなたの選択、あなたの方法で。</p>
+
+🌐 [English](../../README.md) | **日本語** | [简体中文](README_ZH_CN.md) | [繁體中文](README_ZH_TW.md) | [Русский](README_RU.md) | [Українська](README_UK.md) | [فارسی](README_FA.md) | [العربية](README_AR.md)
+
+[![Crates.io](https://img.shields.io/crates/v/reinhardt-web.svg)](https://crates.io/crates/reinhardt-web)
+[![Documentation](https://docs.rs/reinhardt-web/badge.svg)](https://docs.rs/reinhardt-web)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](../../LICENSE.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kent8192/reinhardt-web)
+
+</div>
+
+---
+
+## 📍 クイックナビゲーション
+
+お探しの情報:
+
+- 🚀 [クイックスタート](#クイックスタート) - 5分で起動
+- 📦 [インストールオプション](#インストール) - フレーバーを選択: Micro、Standard、Full
+- 📚 [はじめに](../GETTING_STARTED.md) - ステップバイステップチュートリアル
+- 🎛️ [機能フラグ](../FEATURE_FLAGS.md) - ビルドを最適化
+- 📖 [APIドキュメント](https://docs.rs/reinhardt-web) - 完全なAPIリファレンス
+- 💬 [コミュニティ＆サポート](#ヘルプを得る) - コミュニティからサポートを受ける
+
+## なぜReinhardtか?
+
+**Polylithic = Poly（多数）+ Lithic（構成要素）**
+すべてを使用することを強制するモノリシックフレームワークとは異なり、Reinhardtは独立した、十分にテストされたコンポーネントから完璧なスタックを構成できます。
+
+Reinhardtは3つの世界のベストを統合しています:
+
+| インスピレーション    | 借用したもの                                         | 改善したもの                                      |
+|--------------------|--------------------------------------------------------|------------------------------------------------------|
+| 🐍 **Django**      | バッテリー同梱哲学、ORM設計、管理パネル                   | コンポーザブルビルドのための機能フラグ、Rustの型安全性     |
+| 🎯 **Django REST** | シリアライザー、ViewSets、パーミッション                   | コンパイル時検証、ゼロコスト抽象化                      |
+| ⚡ **FastAPI**      | DIシステム、自動OpenAPI                                 | ネイティブRustパフォーマンス、ランタイムオーバーヘッドなし   |
+| 🗄️ **SQLAlchemy** | QuerySetパターン、リレーションシップ処理                   | 型安全なクエリビルダー、コンパイル時検証                 |
+
+**結果**: Pythonデベロッパーに馴染みやすく、Rustのパフォーマンスと安全性保証を持つフレームワーク。
+
+## ✨ 主な機能
+
+- **型安全なORM** コンパイル時検証付き（SeaQuery v1.0.0-rc）
+- **強力なシリアライザー** 自動検証付き（serde + validator）
+- **FastAPIスタイルのDI** 型安全な依存性注入とキャッシング
+- **ViewSets** 迅速なCRUD API開発用
+- **マルチ認証**（JWT、Token、Session、Basic）BaseUser/FullUserトレイト付き
+- **管理パネル** 自動生成されたモデル管理インターフェース
+- **管理コマンド** マイグレーション、静的ファイルなど
+- **GraphQL＆WebSocket** リアルタイムアプリケーション対応
+- **ページネーション、フィルタリング、レート制限** 組み込み
+- **シグナル** イベント駆動アーキテクチャ用
+
+完全なリストは[利用可能なコンポーネント](#利用可能なコンポーネント)を、例は[はじめに](../GETTING_STARTED.md)を参照してください。
+
+## インストール
+
+Reinhardtはモジュラーフレームワークです。出発点を選択してください:
+
+**クレート命名に関する注意:**
+メインのReinhardtクレートはcrates.ioに`reinhardt-web`として公開されていますが、`package`属性を使用してコード内では`reinhardt`としてインポートします。
+
+### デフォルト: フル機能（バッテリー同梱）⚠️ 新しいデフォルト
+
+設定不要ですべての機能を取得:
+
+```toml
+[dependencies]
+# 'reinhardt'としてインポート、'reinhardt-web'として公開
+# デフォルトですべての機能を有効化（フルバンドル）
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web" }
+```
+
+**含まれるもの:** Database、Auth、REST API、Admin、GraphQL、WebSockets、Cache、i18n、Mail、Sessions、Static Files、Storage
+
+**バイナリ**: ~50+ MB | **コンパイル**: 遅いが、すべてがすぐに動作
+
+コードでの使用:
+```rust
+use reinhardt::prelude::*;
+use reinhardt::{Request, Response, StatusCode};
+```
+
+### オプション1: 標準セットアップ（バランス型）
+
+すべての機能が必要ないほとんどのプロジェクト向け:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["standard"] }
+```
+
+**含まれるもの:** Core、Database（PostgreSQL）、REST API、Auth、Middleware、Pages（SSR付きWASMフロントエンド）
+
+**バイナリ**: ~20-30 MB | **コンパイル**: 中程度
+
+### オプション2: マイクロサービス（最小セットアップ）
+
+軽量で高速、シンプルなAPI向け:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+```
+
+**含まれるもの:** HTTP、ルーティング、DI、パラメータ抽出、サーバー
+
+**バイナリ**: ~5-10 MB | **コンパイル**: 非常に高速
+
+### オプション3: カスタムスタックを構築
+
+必要なコンポーネントのみをインストール:
+
+```toml
+[dependencies]
+# コアコンポーネント
+reinhardt-http = "0.1.0-alpha.1"
+reinhardt-urls = "0.1.0-alpha.1"
+
+# オプション: データベース
+reinhardt-db = "0.1.0-alpha.1"
+
+# オプション: 認証
+reinhardt-auth = "0.1.0-alpha.1"
+
+# オプション: REST API機能
+reinhardt-rest = "0.1.0-alpha.1"
+
+# オプション: 管理パネル
+reinhardt-admin = "0.1.0-alpha.1"
+
+# オプション: 高度な機能
+reinhardt-graphql = "0.1.0-alpha.1"
+reinhardt-websockets = "0.1.0-alpha.1"
+```
+
+**📖 利用可能なクレートと機能フラグの完全なリストは、[機能フラグガイド](../FEATURE_FLAGS.md)を参照してください。**
+
+## クイックスタート
+
+### 1. Reinhardt管理ツールをインストール
+
+```bash
+cargo install reinhardt-admin-cli
+```
+
+### 2. 新しいプロジェクトを作成
+
+```bash
+# RESTful APIプロジェクトを作成（デフォルト）
+reinhardt-admin startproject my-api
+cd my-api
+```
+
+これにより完全なプロジェクト構造が生成されます:
+
+```
+my-api/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   ├── config.rs
+│   ├── apps.rs
+│   ├── config/
+│   │   ├── settings.rs
+│   │   ├── settings/
+│   │   │   ├── base.rs
+│   │   │   ├── local.rs
+│   │   │   ├── staging.rs
+│   │   │   └── production.rs
+│   │   ├── urls.rs
+│   │   └── apps.rs
+│   └── bin/
+│       └── manage.rs
+└── README.md
+```
+
+**代替: reinhardt-pagesプロジェクトを作成（WASM + SSR）**
+
+SSR付きのモダンなWASMベースのフロントエンド向け:
+
+```bash
+# pagesプロジェクトを作成
+reinhardt-admin startproject my-app --with-pages
+cd my-app
+
+# WASMビルドツールをインストール（初回のみ）
+cargo make install-wasm-tools
+
+# WASMをビルドして開発サーバーを起動
+cargo make dev
+# http://127.0.0.1:8000/ にアクセス
+```
+
+### 3. 開発サーバーを実行
+
+```bash
+# manageコマンドを使用
+cargo run --bin manage runserver
+
+# サーバーは http://127.0.0.1:8000 で起動
+```
+
+**自動リロードサポート:**
+
+コード変更時の自動リロード（baconが必要）:
+
+```bash
+# baconをインストール
+cargo install --locked bacon
+
+# 自動リロードで実行
+bacon runserver
+
+# またはcargo makeを使用
+cargo make watch
+
+# テスト用
+bacon test
+```
+
+### 4. 最初のアプリを作成
+
+```bash
+# RESTful APIアプリを作成（デフォルト）
+cargo run --bin manage startapp users
+
+# または明示的にタイプを指定
+cargo run --bin manage startapp users --restful
+
+# Pagesアプリを作成（WASM + SSR）
+cargo run --bin manage startapp dashboard --with-pages
+```
+
+これによりアプリ構造が作成されます:
+
+```
+users/
+├── lib.rs
+├── models.rs
+├── models/
+├── views.rs
+├── views/
+├── serializers.rs
+├── serializers/
+├── admin.rs
+├── urls.rs
+└── tests.rs
+```
+
+### 5. ルートを登録
+
+アプリの`urls.rs`を編集:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::list_users)
+		.endpoint(views::get_user)
+		.endpoint(views::create_user)
+}
+```
+
+`src/config/urls.rs`にインクルード:
+
+```rust
+// src/config/urls.rs
+use reinhardt::prelude::*;
+use reinhardt::routes;
+
+#[routes]
+pub fn routes() -> ServerRouter {
+	ServerRouter::new()
+		.mount("/api/", users::urls::url_patterns())
+}
+```
+
+`#[routes]`属性マクロは、`inventory`クレートを介したフレームワークによる検出のために、この関数を自動的に登録します。
+
+**注意:** `reinhardt::prelude`には一般的に使用される型が含まれています。主なエクスポート:
+
+**常に利用可能:**
+- コアルーティングとビュー: `Router`、`DefaultRouter`、`ServerRouter`、`View`、`ListView`、`DetailView`
+- ViewSets: `ViewSet`、`ModelViewSet`、`ReadOnlyModelViewSet`
+- HTTP: `StatusCode`
+
+**機能依存:**
+- **`core`機能**: `Request`、`Response`、`Handler`、`Middleware`、シグナル（`post_save`、`pre_save`など）
+- **`database`機能**: `Model`、`DatabaseConnection`、`F`、`Q`、`Transaction`、`atomic`、データベース関数（`Concat`、`Upper`、`Lower`、`Now`、`CurrentDate`）、ウィンドウ関数（`Window`、`RowNumber`、`Rank`、`DenseRank`）、制約（`UniqueConstraint`、`CheckConstraint`、`ForeignKeyConstraint`）
+- **`auth`機能**: `User`、`UserManager`、`GroupManager`、`Permission`、`ObjectPermission`
+- **`minimal`、`standard`、または`di`機能**: `Body`、`Cookie`、`Header`、`Json`、`Path`、`Query`
+- **`rest`機能**: シリアライザー、パーサー、ページネーション、スロットリング、バージョニング
+- **`admin`機能**: 管理パネルコンポーネント
+- **`cache`機能**: `Cache`、`InMemoryCache`
+- **`sessions`機能**: `Session`、`AuthenticationMiddleware`
+
+完全なリストは[機能フラグガイド](../FEATURE_FLAGS.md)を参照してください。
+
+完全なステップバイステップガイドは[はじめに](../GETTING_STARTED.md)を参照してください。
+
+## 🎓 例で学ぶ
+
+### データベース使用時
+
+`settings/base.toml`でデータベースを設定:
+
+```toml
+debug = true
+secret_key = "your-secret-key-for-development"
+
+[database]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "mydb"
+user = "postgres"
+password = "postgres"
+```
+
+設定は`src/config/settings.rs`で自動的に読み込まれます:
+
+```rust
+// src/config/settings.rs
+use reinhardt::conf::settings::builder::SettingsBuilder;
+use reinhardt::conf::settings::profile::Profile;
+use reinhardt::conf::settings::sources::{DefaultSource, LowPriorityEnvSource, TomlFileSource};
+use reinhardt::core::Settings;
+use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub fn get_settings() -> Settings {
+	let profile_str = env::var("REINHARDT_ENV").unwrap_or_else(|_| "local".to_string());
+	let profile = Profile::from_str(&profile_str).unwrap_or(Profile::Development);
+
+	let base_dir = env::current_dir().expect("Failed to get current directory");
+	let settings_dir = base_dir.join("settings");
+
+	let merged = SettingsBuilder::new()
+		.profile(profile)
+		.add_source(
+			DefaultSource::new()
+				.with_value("debug", serde_json::Value::Bool(false))
+				.with_value("language_code", serde_json::Value::String("en-us".to_string()))
+				.with_value("time_zone", serde_json::Value::String("UTC".to_string()))
+		)
+		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
+		.add_source(TomlFileSource::new(settings_dir.join(format!("{}.toml", profile_str))))
+		.build()
+		.expect("Failed to build settings");
+
+	merged.into_typed().expect("Failed to convert settings to Settings struct")
+}
+```
+
+**環境変数ソース:**
+
+Reinhardtは異なる優先度を持つ2種類の環境変数ソースを提供します:
+
+- **`EnvSource`**（優先度: 100）- TOMLファイルを上書きする高優先度環境変数
+  ```rust
+  .add_source(EnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+- **`LowPriorityEnvSource`**（優先度: 40）- TOMLファイルにフォールバックする低優先度環境変数
+  ```rust
+  .add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+**優先順位**:
+- `EnvSource`使用時: 環境変数 > `{profile}.toml` > `base.toml` > デフォルト
+- `LowPriorityEnvSource`使用時（上記表示）: `{profile}.toml` > `base.toml` > 環境変数 > デフォルト
+
+環境変数を常に優先させたい場合（本番デプロイなど）は`EnvSource`を選択してください。
+TOMLファイルを主要な設定ソースにしたい場合（開発など）は`LowPriorityEnvSource`を選択してください。
+
+詳細は[設定ドキュメント](../SETTINGS_DOCUMENT.md)を参照してください。
+
+**組み込みDefaultUserの使用:**
+
+Reinhardtはすぐに使える`DefaultUser`実装を提供します（`argon2-hasher`機能が必要）:
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// DefaultUserをアプリのUserとして再エクスポート
+pub type User = DefaultUser;
+
+// DefaultUserには以下が含まれます:
+// - id: Uuid（主キー）
+// - username: String
+// - email: String
+// - password_hash: Option<String>
+// - first_name: String
+// - last_name: String
+// - is_active: bool
+// - is_staff: bool
+// - is_superuser: bool
+// - last_login: Option<DateTime<Utc>>
+// - date_joined: DateTime<Utc>
+
+// DefaultUserは以下を実装しています:
+// - BaseUserトレイト（認証メソッド）
+// - FullUserトレイト（完全なユーザー情報）
+// - PermissionsMixinトレイト（権限管理）
+// - Modelトレイト（データベース操作）
+```
+
+**カスタムユーザーモデルの定義:**
+
+カスタムフィールドが必要な場合は、独自のモデルを定義:
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Utc};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: i64,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	#[field(max_length = 100)]
+	pub username: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(auto_now_add = true)]
+	pub created_at: DateTime<Utc>,
+
+	// カスタムフィールドを追加
+	#[field(max_length = 50, null = true)]
+	pub phone_number: Option<String>,
+}
+```
+
+**Modelアトリビュートマクロ:**
+
+`#[model(...)]`属性は以下を自動生成します:
+- `Model`トレイトの実装（`#[derive(Model)]`機能を含む）
+- 型安全なフィールドアクセサー: `User::field_email()`、`User::field_username()`など
+- グローバルモデルレジストリ登録
+- 複合主キーのサポート
+
+**注意:** `#[model(...)]`を使用する場合、`#[derive(Model)]`を別途追加する必要はありません。
+`#[model(...)]`属性によって自動的に適用されます。
+
+**フィールド属性:**
+- `#[field(primary_key = true)]` - 主キーとしてマーク
+- `#[field(max_length = 255)]` - 文字列フィールドの最大長を設定
+- `#[field(default = value)]` - デフォルト値を設定
+- `#[field(auto_now_add = true)]` - 作成時にタイムスタンプを自動設定
+- `#[field(auto_now = true)]` - 保存時にタイムスタンプを自動更新
+- `#[field(null = true)]` - NULL値を許可
+- `#[field(unique = true)]` - 一意性制約を強制
+
+フィールド属性の完全なリストは[フィールド属性ガイド](../field_attributes.md)を参照してください。
+
+生成されたフィールドアクセサーにより、クエリで型安全なフィールド参照が可能になります:
+
+```rust
+// #[model(...)]によってDefaultUserに生成
+impl DefaultUser {
+	pub const fn field_id() -> FieldRef<DefaultUser, Uuid> { FieldRef::new("id") }
+	pub const fn field_username() -> FieldRef<DefaultUser, String> { FieldRef::new("username") }
+	pub const fn field_email() -> FieldRef<DefaultUser, String> { FieldRef::new("email") }
+	pub const fn field_is_active() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_active") }
+	pub const fn field_is_staff() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_staff") }
+	pub const fn field_date_joined() -> FieldRef<DefaultUser, DateTime<Utc>> { FieldRef::new("date_joined") }
+	// ... その他のフィールド
+}
+```
+
+**高度なクエリ例:**
+
+```rust
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// 型安全なフィールド参照を使用したDjangoスタイルのF/Qオブジェクトクエリ
+async fn complex_user_query() -> Result<Vec<DefaultUser>, Box<dyn std::error::Error>> {
+	// 型安全なフィールド参照を使用したQオブジェクト（生成されたフィールドアクセサーを使用）
+	let active_query = Q::new()
+		.field("is_active").eq(true)
+		.and(Q::new().field("date_joined").gte(Now::new()));
+
+	// 型安全なフィールド参照を使用したデータベース関数
+	let email_lower = Lower::new(DefaultUser::field_email().into());
+	let username_upper = Upper::new(DefaultUser::field_username().into());
+
+	// フィールドアクセサーを使用した集計
+	let user_count = Aggregate::count(DefaultUser::field_id().into());
+	let latest_joined = Aggregate::max(DefaultUser::field_date_joined().into());
+
+	// ランキング用ウィンドウ関数
+	let rank_by_join_date = Window::new()
+		.partition_by(vec![DefaultUser::field_is_active().into()])
+		.order_by(vec![(DefaultUser::field_date_joined().into(), "DESC")])
+		.function(RowNumber::new());
+
+	todo!("Execute query with these components")
+}
+
+// トランザクションサポート
+async fn create_user_with_transaction(
+	conn: &DatabaseConnection,
+	user_data: CreateUserRequest
+) -> Result<User, Box<dyn std::error::Error>> {
+	// エラー時に自動ロールバックするトランザクション
+	transaction(conn, |_tx| async move {
+		let user = User::create(user_data).await?;
+		log_user_creation(&user).await?;
+		Ok(user)
+	}).await
+}
+```
+
+**注意**: ReinhardtはSQL操作に[SeaQuery v1.0.0-rc](https://crates.io/crates/sea-query)を使用しています。`#[derive(Model)]`マクロはModelトレイト実装、型安全なフィールドアクセサー、グローバルモデルレジストリ登録を自動生成します。
+
+`src/config/apps.rs`で登録:
+
+```rust
+// src/config/apps.rs
+use reinhardt::installed_apps;
+
+// installed_apps!マクロは以下を生成します:
+// - 各アプリのバリアントを持つInstalledApp列挙型
+// - 変換トレイトの実装（From、Into、Display）
+// - アプリ設定と検出のためのレジストリ
+//
+// 注意: DjangoのINSTALLED_APPSとは異なり、このマクロはユーザーアプリのみ用です。
+// 組み込みフレームワーク機能（auth、sessions、adminなど）は
+// installed_apps!ではなくCargoの機能フラグで有効化します。
+//
+// 例:
+// [dependencies]
+// reinhardt = { version = "0.1", features = ["auth", "sessions", "admin"] }
+//
+// これにより以下が有効になります:
+// - マイグレーション、管理パネルなどの自動アプリ検出
+// - コード全体での型安全なアプリ参照
+// - 一元化されたアプリ設定
+installed_apps! {
+	users: "users",
+}
+
+pub fn get_installed_apps() -> Vec<String> {
+	InstalledApp::all_apps()
+}
+```
+
+### 認証使用時
+
+ReinhardtはDjangoスタイルの`BaseUser`と`FullUser`トレイトを持つユーザーモデルと、`UserManager`による包括的なユーザー管理を提供します。
+
+**注意:** Reinhardtには組み込みの`DefaultUser`実装が含まれています。直接使用するか、以下に示すように独自のユーザーモデルを定義できます。
+
+**ユーザー管理例:**
+
+```rust
+use reinhardt::prelude::*;
+
+// UserManagerでユーザーを作成・管理
+async fn manage_users() -> Result<(), Box<dyn std::error::Error>> {
+	let hasher = Argon2Hasher::new();
+	let user_manager = UserManager::new(hasher);
+
+	// 新しいユーザーを作成
+	let user = user_manager.create_user(CreateUserData {
+		username: "alice".to_string(),
+		email: "alice@example.com".to_string(),
+		password: "secure_password".to_string(),
+		first_name: Some("Alice".to_string()),
+		last_name: Some("Smith".to_string()),
+	}).await?;
+
+	// ユーザー情報を更新
+	user_manager.update_user(user.id, UpdateUserData {
+		email: Some("alice.smith@example.com".to_string()),
+		is_active: Some(true),
+		..Default::default()
+	}).await?;
+
+	// グループと権限を管理
+	let group_manager = GroupManager::new();
+	let editors = group_manager.create_group(CreateGroupData {
+		name: "editors".to_string(),
+	}).await?;
+
+	// オブジェクトレベルの権限を割り当て
+	let permission = ObjectPermission::new("edit", user.id, article.id);
+	let perm_checker = ObjectPermissionChecker::new();
+	if perm_checker.has_permission(&user, "edit", &article).await? {
+		// ユーザーは記事を編集可能
+	}
+
+	Ok(())
+}
+```
+
+`users/models.rs`で組み込みの`DefaultUser`を使用:
+
+```rust
+// users/models.rs
+use reinhardt::DefaultUser;
+
+// DefaultUserをUserタイプとして再エクスポート
+pub type User = DefaultUser;
+
+// DefaultUserは以下を既に実装しています:
+// - BaseUserトレイト（認証メソッド）
+// - FullUserトレイト（username、email、first_name、last_nameなど）
+// - PermissionsMixinトレイト（権限管理）
+// - Modelトレイト（データベース操作）
+```
+
+**カスタムユーザーモデルの場合:**
+
+DefaultUserを超える追加フィールドが必要な場合は、独自に定義:
+
+```rust
+// users/models.rs
+use reinhardt::auth::{BaseUser, FullUser, PermissionsMixin};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+use serde::{Serialize, Deserialize};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: Uuid,
+
+	#[field(max_length = 150)]
+	pub username: String,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	pub password_hash: Option<String>,
+
+	#[field(max_length = 150)]
+	pub first_name: String,
+
+	#[field(max_length = 150)]
+	pub last_name: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(default = false)]
+	pub is_staff: bool,
+
+	#[field(default = false)]
+	pub is_superuser: bool,
+
+	pub last_login: Option<DateTime<Utc>>,
+
+	#[field(auto_now_add = true)]
+	pub date_joined: DateTime<Utc>,
+
+	// カスタムフィールド
+	#[field(max_length = 20, null = true)]
+	pub phone_number: Option<String>,
+}
+
+impl BaseUser for CustomUser {
+	type PrimaryKey = Uuid;
+
+	fn get_username_field() -> &'static str { "username" }
+	fn get_username(&self) -> &str { &self.username }
+	fn password_hash(&self) -> Option<&str> { self.password_hash.as_deref() }
+	fn set_password_hash(&mut self, hash: String) { self.password_hash = Some(hash); }
+	fn last_login(&self) -> Option<DateTime<Utc>> { self.last_login }
+	fn set_last_login(&mut self, time: DateTime<Utc>) { self.last_login = Some(time); }
+	fn is_active(&self) -> bool { self.is_active }
+}
+
+impl FullUser for CustomUser {
+	fn username(&self) -> &str { &self.username }
+	fn email(&self) -> &str { &self.email }
+	fn first_name(&self) -> &str { &self.first_name }
+	fn last_name(&self) -> &str { &self.last_name }
+	fn is_staff(&self) -> bool { self.is_staff }
+	fn is_superuser(&self) -> bool { self.is_superuser }
+	fn date_joined(&self) -> DateTime<Utc> { self.date_joined }
+}
+```
+
+アプリの`views/profile.rs`でJWT認証を使用:
+
+```rust
+// users/views/profile.rs
+use reinhardt::auth::{JwtAuth, BaseUser};
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+use crate::models::User;
+
+#[get("/profile", name = "get_profile")]
+pub async fn get_profile(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// AuthorizationヘッダーからJWTトークンを抽出
+	let auth_header = req.headers.get("authorization")
+		.and_then(|h| h.to_str().ok())
+		.ok_or("Missing Authorization header")?;
+
+	let token = auth_header.strip_prefix("Bearer ")
+		.ok_or("Invalid Authorization header format")?;
+
+	// トークンを検証してユーザーIDを取得
+	let jwt_auth = JwtAuth::new(b"your-secret-key");
+	let claims = jwt_auth.verify_token(token)?;
+
+	// claims.user_idを使用してデータベースからユーザーを読み込み
+	let user = User::find_by_id(&db, &claims.user_id).await?;
+
+	// ユーザーがアクティブかチェック
+	if !user.is_active() {
+		return Err("User account is inactive".into());
+	}
+
+	// ユーザープロファイルをJSONとして返す
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+### エンドポイント定義
+
+ReinhardtはHTTPメソッドデコレーターを使用してエンドポイントを定義します:
+
+#### HTTPメソッドデコレーター
+
+`#[get]`、`#[post]`、`#[put]`、`#[delete]`を使用してルートを定義:
+
+```rust
+use reinhardt::{get, post, Request, Response, ViewResult};
+use serde_json::json;
+
+#[get("/")]
+pub async fn hello(_req: Request) -> ViewResult<Response> {
+	Ok(Response::ok().with_body("Hello, World!"))
+}
+
+#[post("/users")]
+pub async fn create_user(_req: Request) -> ViewResult<Response> {
+	let body = json!({"status": "created"});
+	Response::ok().with_json(&body).map_err(Into::into)
+}
+```
+
+**機能:**
+- コンパイル時パス検証
+- 簡潔な構文
+- 自動HTTPメソッドバインディング
+- `#[inject]`による依存性注入のサポート
+
+#### 依存性注入の使用
+
+HTTPメソッドデコレーターと`#[inject]`を組み合わせて自動依存性注入:
+
+```rust
+use reinhardt::{get, Request, Response, StatusCode, ViewResult};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,  // 自動的に注入
+) -> ViewResult<Response> {
+	let id = req.path_params.get("id")
+		.ok_or("Missing id")?
+		.parse::<i64>()?;
+
+	// 注入されたデータベース接続を使用
+	let user = db.query("SELECT * FROM users WHERE id = $1")
+		.bind(id)
+		.fetch_one()
+		.await?;
+
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+**依存性注入の機能:**
+- `#[inject]`属性による自動依存性注入
+- `#[inject(cache = false)]`によるキャッシュ制御
+- FastAPIにインスパイアされた依存性注入システム
+- HTTPメソッドデコレーターとシームレスに連携
+
+**戻り値の型:**
+
+すべてのビュー関数は`ViewResult<T>`を戻り値の型として使用:
+
+```rust
+use reinhardt::ViewResult;  // 事前定義された結果型
+```
+
+### パラメータ抽出使用時
+
+アプリの`views/user.rs`で:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// リクエストからパスパラメータを抽出
+	let id = req.path_params.get("id")
+		.ok_or("Missing id parameter")?
+		.parse::<i64>()
+		.map_err(|_| "Invalid id format")?;
+
+	// クエリパラメータを抽出（例: ?include_inactive=true）
+	let include_inactive = req.query_params.get("include_inactive")
+		.and_then(|v| v.parse::<bool>().ok())
+		.unwrap_or(false);
+
+	// 注入された接続を使用してデータベースからユーザーを取得
+	let user = User::find_by_id(&db, id).await?;
+
+	// 必要に応じてアクティブステータスをチェック
+	if !include_inactive && !user.is_active {
+		return Err("User is inactive".into());
+	}
+
+	// JSONとして返す
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+`urls.rs`でパスパラメータ付きルートを登録:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::get_user)  // パスは#[get("/users/{id}/")]で定義
+}
+```
+
+### シリアライザーと検証使用時
+
+アプリの`serializers/user.rs`で:
+
+```rust
+// users/serializers/user.rs
+use serde::{Serialize, Deserialize};
+use validator::Validate;
+
+#[derive(Serialize, Deserialize, Validate)]
+pub struct CreateUserRequest {
+	#[validate(email)]
+	pub email: String,
+	#[validate(length(min = 3, max = 50))]
+	pub username: String,
+	#[validate(length(min = 8))]
+	pub password: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserResponse {
+	pub id: i64,
+	pub username: String,
+	pub email: String,
+	pub is_active: bool,
+}
+
+impl From<User> for UserResponse {
+	fn from(user: User) -> Self {
+		UserResponse {
+			id: user.id,
+			username: user.username,
+			email: user.email,
+			is_active: user.is_active,
+		}
+	}
+}
+```
+
+アプリの`views/user.rs`で:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, post};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use crate::serializers::{CreateUserRequest, UserResponse};
+use validator::Validate;
+use std::sync::Arc;
+
+#[post("/users", name = "create_user")]
+pub async fn create_user(
+	mut req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// リクエストボディをパース
+	let body_bytes = std::mem::take(&mut req.body);
+	let create_req: CreateUserRequest = serde_json::from_slice(&body_bytes)?;
+
+	// リクエストを検証
+	create_req.validate()?;
+
+	// ユーザーを作成
+	let mut user = User {
+		id: 0, // データベースによって設定される
+		username: create_req.username,
+		email: create_req.email,
+		password_hash: None,
+		is_active: true,
+		created_at: Utc::now(),
+	};
+
+	// BaseUserトレイトを使用してパスワードをハッシュ化
+	user.set_password(&create_req.password)?;
+
+	// 注入された接続を使用してデータベースに保存
+	user.save(&db).await?;
+
+	// レスポンスに変換
+	let response_data = UserResponse::from(user);
+	let json = serde_json::to_string(&response_data)?;
+
+	Ok(Response::new(StatusCode::CREATED)
+		.with_body(json))
+}
+```
+
+## 利用可能なコンポーネント
+
+Reinhardtは組み合わせ可能なモジュラーコンポーネントを提供します:
+
+| コンポーネント       | クレート名                 | 機能                                        |
+|---------------------|---------------------------|---------------------------------------------|
+| **コア**            |                           |                                             |
+| コアタイプ          | `reinhardt-core`          | コアトレイト、型、マクロ（Model、endpoint） |
+| HTTP＆ルーティング  | `reinhardt-http`          | Request/Response、HTTP処理                  |
+| URLルーティング     | `reinhardt-urls`          | 関数ベースおよびクラスベースのルート        |
+| サーバー            | `reinhardt-server`        | HTTPサーバー実装                            |
+| ミドルウェア        | `reinhardt-dispatch`      | ミドルウェアチェーン、シグナルディスパッチ  |
+| 設定                | `reinhardt-conf`          | 設定管理、環境読み込み                      |
+| コマンド            | `reinhardt-commands`      | 管理CLIツール（startprojectなど）           |
+| ショートカット      | `reinhardt-shortcuts`     | 一般的なユーティリティ関数                  |
+| **データベース**    |                           |                                             |
+| ORM                 | `reinhardt-db`            | SeaQuery v1.0.0-rc統合                      |
+| **認証**            |                           |                                             |
+| Auth                | `reinhardt-auth`          | JWT、Token、Session、Basic認証、Userモデル |
+| **REST API**        |                           |                                             |
+| シリアライザー      | `reinhardt-rest`          | serde/validator統合、ViewSets               |
+| **フォーム**        |                           |                                             |
+| フォーム            | `reinhardt-forms`         | フォーム処理と検証                          |
+| **高度な機能**      |                           |                                             |
+| 管理パネル          | `reinhardt-admin`         | Djangoスタイルの管理インターフェース        |
+| プラグインシステム  | `reinhardt-dentdelion`    | 静的＆WASMプラグインサポート、CLI管理       |
+| バックグラウンドタスク | `reinhardt-tasks`      | タスクキュー（Redis、RabbitMQ、SQLite）     |
+| GraphQL             | `reinhardt-graphql`       | スキーマ生成、サブスクリプション            |
+| WebSockets          | `reinhardt-websockets`    | リアルタイム通信                            |
+| i18n                | `reinhardt-i18n`          | 多言語サポート                              |
+| **テスト**          |                           |                                             |
+| テストユーティリティ | `reinhardt-test`         | テストヘルパー、フィクスチャ、TestContainers |
+
+**各クレート内の詳細な機能フラグについては、[機能フラグガイド](../FEATURE_FLAGS.md)を参照してください。**
+
+---
+
+## ドキュメント
+
+- 📚 [はじめに](../GETTING_STARTED.md) - 初心者向けステップバイステップチュートリアル
+- 🎛️ [機能フラグガイド](../FEATURE_FLAGS.md) - 詳細な機能制御でビルドを最適化
+- 📖 [APIリファレンス](https://docs.rs/reinhardt)（近日公開）
+- 📝 [チュートリアル](../tutorials/) - 実際のアプリケーションを構築して学ぶ
+
+**AIアシスタント向け**: プロジェクト固有のコーディング標準、テストガイドライン、開発規約については[CLAUDE.md](../../CLAUDE.md)を参照してください。
+
+## 💬 ヘルプを得る
+
+Reinhardtはコミュニティ駆動のプロジェクトです。ヘルプが必要な場合:
+
+- 💬 **Discord**: Discordサーバーでリアルタイムチャット（近日公開）
+- 💭 **GitHub Discussions**: [質問やアイデアを共有](https://github.com/kent8192/reinhardt-rs/discussions)
+- 🐛 **Issues**: [バグを報告](https://github.com/kent8192/reinhardt-rs/issues)
+- 📖 **ドキュメント**: [ガイドを読む](../)
+
+質問する前に、以下を確認してください:
+
+- ✅ [はじめに](../GETTING_STARTED.md)
+- ✅ [Examples](../../examples/)
+- ✅ 既存のGitHub IssuesとDiscussions
+
+## 🤝 コントリビューション
+
+コントリビューションを歓迎します！始めるには[コントリビューティングガイド](../../CONTRIBUTING.md)をお読みください。
+
+**クイックリンク**:
+
+- [開発セットアップ](../../CONTRIBUTING.md#development-setup)
+- [テストガイドライン](../../CONTRIBUTING.md#testing-guidelines)
+- [コミットガイドライン](../../CONTRIBUTING.md#commit-guidelines)
+
+## ライセンス
+
+以下のいずれかのライセンスの下でライセンスされています:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+お好みで選択できます。
+
+### サードパーティ帰属
+
+このプロジェクトは以下からインスピレーションを受けています:
+
+- [Django](https://www.djangoproject.com/)（BSD 3-Clauseライセンス）
+- [Django REST Framework](https://www.django-rest-framework.org/)（BSD 3-Clauseライセンス）
+- [FastAPI](https://fastapi.tiangolo.com/)（MITライセンス）
+- [SQLAlchemy](https://www.sqlalchemy.org/)（MITライセンス）
+
+完全な帰属については[THIRD-PARTY-NOTICES](../../THIRD-PARTY-NOTICES)を参照してください。
+
+**注意:** このプロジェクトはDjango Software Foundation、Encode OSS Ltd.、Sebastián Ramírez（FastAPI作者）、またはMichael Bayer（SQLAlchemy作者）と提携または承認されているわけではありません。

--- a/docs/readme-langs/README_RU.md
+++ b/docs/readme-langs/README_RU.md
@@ -1,0 +1,1059 @@
+<div align="center">
+  <img src="../../branding/logo.png" alt="Reinhardt Logo" width="200"/>
+
+  <h1>Reinhardt</h1>
+
+  <h3>🦀 Полилитический фреймворк с батарейками</h3>
+
+  <p><strong>Компонуемый полнофункциональный API-фреймворк для Rust</strong></p>
+  <p>Стройте со <em>всей</em> мощью философии Django "батарейки в комплекте",<br/>
+  или компонуйте <em>только</em> то, что вам нужно — ваш выбор, ваш путь.</p>
+
+🌐 [English](../../README.md) | [日本語](README_JA.md) | [简体中文](README_ZH_CN.md) | [繁體中文](README_ZH_TW.md) | **Русский** | [Українська](README_UK.md) | [فارسی](README_FA.md) | [العربية](README_AR.md)
+
+[![Crates.io](https://img.shields.io/crates/v/reinhardt-web.svg)](https://crates.io/crates/reinhardt-web)
+[![Documentation](https://docs.rs/reinhardt-web/badge.svg)](https://docs.rs/reinhardt-web)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](../../LICENSE.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kent8192/reinhardt-web)
+
+</div>
+
+---
+
+## 📍 Быстрая навигация
+
+Возможно, вы ищете:
+
+- 🚀 [Быстрый старт](#быстрый-старт) - Запуск за 5 минут
+- 📦 [Варианты установки](#установка) - Выберите свой вариант: Micro, Standard или Full
+- 📚 [Руководство по началу работы](../GETTING_STARTED.md) - Пошаговое руководство
+- 🎛️ [Флаги функций](../FEATURE_FLAGS.md) - Тонкая настройка сборки
+- 📖 [API документация](https://docs.rs/reinhardt-web) - Полный справочник API
+- 💬 [Сообщество и поддержка](#получение-помощи) - Получите помощь от сообщества
+
+## Почему Reinhardt?
+
+**Polylithic = Poly (много) + Lithic (строительные блоки)**
+В отличие от монолитных фреймворков, которые заставляют вас использовать всё, Reinhardt позволяет компоновать идеальный стек из независимых, хорошо протестированных компонентов.
+
+Reinhardt объединяет лучшее из трёх миров:
+
+| Вдохновение        | Что мы позаимствовали                                  | Что мы улучшили                                     |
+|--------------------|--------------------------------------------------------|------------------------------------------------------|
+| 🐍 **Django**      | Философия "батарейки в комплекте", дизайн ORM, админка | Флаги функций для компонуемых сборок, типобезопасность Rust |
+| 🎯 **Django REST** | Сериализаторы, ViewSets, разрешения                    | Проверка во время компиляции, абстракции с нулевой стоимостью |
+| ⚡ **FastAPI**      | DI система, автоматический OpenAPI                      | Нативная производительность Rust, без накладных расходов во время выполнения |
+| 🗄️ **SQLAlchemy** | Паттерны QuerySet, обработка связей                     | Типобезопасный конструктор запросов, проверка во время компиляции |
+
+**Результат**: Фреймворк, знакомый Python-разработчикам, но с производительностью и гарантиями безопасности Rust.
+
+## ✨ Ключевые функции
+
+- **Типобезопасная ORM** с проверкой во время компиляции (SeaQuery v1.0.0-rc)
+- **Мощные сериализаторы** с автоматической валидацией (serde + validator)
+- **DI в стиле FastAPI** с типобезопасным внедрением зависимостей и кэшированием
+- **ViewSets** для быстрой разработки CRUD API
+- **Множественная аутентификация** (JWT, Token, Session, Basic) с трейтами BaseUser/FullUser
+- **Админ-панель** с автоматически генерируемым интерфейсом управления моделями
+- **Команды управления** для миграций, статических файлов и прочего
+- **GraphQL и WebSocket** поддержка для приложений реального времени
+- **Пагинация, фильтрация, ограничение скорости** встроены
+- **Сигналы** для событийно-ориентированной архитектуры
+
+Полный список см. в [Доступные компоненты](#доступные-компоненты), примеры в [Руководстве по началу работы](../GETTING_STARTED.md).
+
+## Установка
+
+Reinhardt — модульный фреймворк. Выберите точку старта:
+
+**Примечание о названии крейтов:**
+Основной крейт Reinhardt опубликован на crates.io как `reinhardt-web`, но вы импортируете его как `reinhardt` в коде, используя атрибут `package`.
+
+### По умолчанию: Полнофункциональный (Батарейки в комплекте) ⚠️ Новый default
+
+Все функции без настройки:
+
+```toml
+[dependencies]
+# Импортируется как 'reinhardt', опубликован как 'reinhardt-web'
+# По умолчанию включены ВСЕ функции (полный комплект)
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web" }
+```
+
+**Включает:** Database, Auth, REST API, Admin, GraphQL, WebSockets, Cache, i18n, Mail, Sessions, Static Files, Storage
+
+**Бинарник**: ~50+ МБ | **Компиляция**: Медленнее, но всё работает из коробки
+
+Затем используйте в коде:
+```rust
+use reinhardt::prelude::*;
+use reinhardt::{Request, Response, StatusCode};
+```
+
+### Вариант 1: Стандартная установка (Сбалансированный)
+
+Для большинства проектов, которым не нужны все функции:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["standard"] }
+```
+
+**Включает:** Core, Database (PostgreSQL), REST API, Auth, Middleware, Pages (WASM фронтенд с SSR)
+
+**Бинарник**: ~20-30 МБ | **Компиляция**: Средняя
+
+### Вариант 2: Микросервисы (Минимальная установка)
+
+Лёгкий и быстрый, идеален для простых API:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+```
+
+**Включает:** HTTP, маршрутизация, DI, извлечение параметров, сервер
+
+**Бинарник**: ~5-10 МБ | **Компиляция**: Очень быстрая
+
+### Вариант 3: Создайте свой стек
+
+Устанавливайте только нужные компоненты:
+
+```toml
+[dependencies]
+# Основные компоненты
+reinhardt-http = "0.1.0-alpha.1"
+reinhardt-urls = "0.1.0-alpha.1"
+
+# Опционально: База данных
+reinhardt-db = "0.1.0-alpha.1"
+
+# Опционально: Аутентификация
+reinhardt-auth = "0.1.0-alpha.1"
+
+# Опционально: REST API функции
+reinhardt-rest = "0.1.0-alpha.1"
+
+# Опционально: Админ-панель
+reinhardt-admin = "0.1.0-alpha.1"
+
+# Опционально: Расширенные функции
+reinhardt-graphql = "0.1.0-alpha.1"
+reinhardt-websockets = "0.1.0-alpha.1"
+```
+
+**📖 Полный список доступных крейтов и флагов функций см. в [Руководстве по флагам функций](../FEATURE_FLAGS.md).**
+
+## Быстрый старт
+
+### 1. Установите Reinhardt Admin Tool
+
+```bash
+cargo install reinhardt-admin-cli
+```
+
+### 2. Создайте новый проект
+
+```bash
+# Создание RESTful API проекта (по умолчанию)
+reinhardt-admin startproject my-api
+cd my-api
+```
+
+Это создаст полную структуру проекта:
+
+```
+my-api/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   ├── config.rs
+│   ├── apps.rs
+│   ├── config/
+│   │   ├── settings.rs
+│   │   ├── settings/
+│   │   │   ├── base.rs
+│   │   │   ├── local.rs
+│   │   │   ├── staging.rs
+│   │   │   └── production.rs
+│   │   ├── urls.rs
+│   │   └── apps.rs
+│   └── bin/
+│       └── manage.rs
+└── README.md
+```
+
+**Альтернатива: Создание reinhardt-pages проекта (WASM + SSR)**
+
+Для современного WASM-фронтенда с SSR:
+
+```bash
+# Создание pages проекта
+reinhardt-admin startproject my-app --with-pages
+cd my-app
+
+# Установка WASM инструментов сборки (только первый раз)
+cargo make install-wasm-tools
+
+# Сборка WASM и запуск сервера разработки
+cargo make dev
+# Откройте http://127.0.0.1:8000/
+```
+
+### 3. Запустите сервер разработки
+
+```bash
+# Используя команду manage
+cargo run --bin manage runserver
+
+# Сервер запустится на http://127.0.0.1:8000
+```
+
+**Поддержка автоперезагрузки:**
+
+Для автоматической перезагрузки при изменении кода (требуется bacon):
+
+```bash
+# Установка bacon
+cargo install --locked bacon
+
+# Запуск с автоперезагрузкой
+bacon runserver
+
+# Или используйте cargo make
+cargo make watch
+
+# Для тестов
+bacon test
+```
+
+### 4. Создайте первое приложение
+
+```bash
+# Создание RESTful API приложения (по умолчанию)
+cargo run --bin manage startapp users
+
+# Или явно укажите тип
+cargo run --bin manage startapp users --restful
+
+# Создание Pages приложения (WASM + SSR)
+cargo run --bin manage startapp dashboard --with-pages
+```
+
+Это создаст структуру приложения:
+
+```
+users/
+├── lib.rs
+├── models.rs
+├── models/
+├── views.rs
+├── views/
+├── serializers.rs
+├── serializers/
+├── admin.rs
+├── urls.rs
+└── tests.rs
+```
+
+### 5. Зарегистрируйте маршруты
+
+Отредактируйте `urls.rs` вашего приложения:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::list_users)
+		.endpoint(views::get_user)
+		.endpoint(views::create_user)
+}
+```
+
+Включите в `src/config/urls.rs`:
+
+```rust
+// src/config/urls.rs
+use reinhardt::prelude::*;
+use reinhardt::routes;
+
+#[routes]
+pub fn routes() -> ServerRouter {
+	ServerRouter::new()
+		.mount("/api/", users::urls::url_patterns())
+}
+```
+
+Атрибутный макрос `#[routes]` автоматически регистрирует эту функцию во фреймворке для обнаружения через крейт `inventory`.
+
+**Примечание:** `reinhardt::prelude` включает часто используемые типы. Основные экспорты:
+
+**Всегда доступны:**
+- Базовая маршрутизация и представления: `Router`, `DefaultRouter`, `ServerRouter`, `View`, `ListView`, `DetailView`
+- ViewSets: `ViewSet`, `ModelViewSet`, `ReadOnlyModelViewSet`
+- HTTP: `StatusCode`
+
+**Зависят от функций:**
+- **Функция `core`**: `Request`, `Response`, `Handler`, `Middleware`, Сигналы (`post_save`, `pre_save` и др.)
+- **Функция `database`**: `Model`, `DatabaseConnection`, `F`, `Q`, `Transaction`, `atomic`, Функции БД (`Concat`, `Upper`, `Lower`, `Now`, `CurrentDate`), Оконные функции (`Window`, `RowNumber`, `Rank`, `DenseRank`), Ограничения (`UniqueConstraint`, `CheckConstraint`, `ForeignKeyConstraint`)
+- **Функция `auth`**: `User`, `UserManager`, `GroupManager`, `Permission`, `ObjectPermission`
+- **Функции `minimal`, `standard` или `di`**: `Body`, `Cookie`, `Header`, `Json`, `Path`, `Query`
+- **Функция `rest`**: Сериализаторы, Парсеры, Пагинация, Троттлинг, Версионирование
+- **Функция `admin`**: Компоненты админ-панели
+- **Функция `cache`**: `Cache`, `InMemoryCache`
+- **Функция `sessions`**: `Session`, `AuthenticationMiddleware`
+
+Полный список см. в [Руководстве по флагам функций](../FEATURE_FLAGS.md).
+
+Полное пошаговое руководство см. в [Руководстве по началу работы](../GETTING_STARTED.md).
+
+## 🎓 Учитесь на примерах
+
+### С базой данных
+
+Настройте базу данных в `settings/base.toml`:
+
+```toml
+debug = true
+secret_key = "your-secret-key-for-development"
+
+[database]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "mydb"
+user = "postgres"
+password = "postgres"
+```
+
+Настройки автоматически загружаются в `src/config/settings.rs`:
+
+```rust
+// src/config/settings.rs
+use reinhardt::conf::settings::builder::SettingsBuilder;
+use reinhardt::conf::settings::profile::Profile;
+use reinhardt::conf::settings::sources::{DefaultSource, LowPriorityEnvSource, TomlFileSource};
+use reinhardt::core::Settings;
+use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub fn get_settings() -> Settings {
+	let profile_str = env::var("REINHARDT_ENV").unwrap_or_else(|_| "local".to_string());
+	let profile = Profile::from_str(&profile_str).unwrap_or(Profile::Development);
+
+	let base_dir = env::current_dir().expect("Failed to get current directory");
+	let settings_dir = base_dir.join("settings");
+
+	let merged = SettingsBuilder::new()
+		.profile(profile)
+		.add_source(
+			DefaultSource::new()
+				.with_value("debug", serde_json::Value::Bool(false))
+				.with_value("language_code", serde_json::Value::String("en-us".to_string()))
+				.with_value("time_zone", serde_json::Value::String("UTC".to_string()))
+		)
+		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
+		.add_source(TomlFileSource::new(settings_dir.join(format!("{}.toml", profile_str))))
+		.build()
+		.expect("Failed to build settings");
+
+	merged.into_typed().expect("Failed to convert settings to Settings struct")
+}
+```
+
+**Источники переменных окружения:**
+
+Reinhardt предоставляет два типа источников переменных окружения с разными приоритетами:
+
+- **`EnvSource`** (приоритет: 100) - Высокоприоритетные переменные окружения, которые переопределяют TOML файлы
+  ```rust
+  .add_source(EnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+- **`LowPriorityEnvSource`** (приоритет: 40) - Низкоприоритетные переменные окружения, которые используются как запасной вариант
+  ```rust
+  .add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+**Порядок приоритетов**:
+- С `EnvSource`: Переменные окружения > `{profile}.toml` > `base.toml` > Значения по умолчанию
+- С `LowPriorityEnvSource` (показано выше): `{profile}.toml` > `base.toml` > Переменные окружения > Значения по умолчанию
+
+Выбирайте `EnvSource`, когда переменные окружения всегда должны иметь приоритет (например, production).
+Выбирайте `LowPriorityEnvSource`, когда TOML файлы должны быть основным источником конфигурации (например, разработка).
+
+См. [Документацию по настройкам](../SETTINGS_DOCUMENT.md) для деталей.
+
+**Использование встроенного DefaultUser:**
+
+Reinhardt предоставляет готовую реализацию `DefaultUser` (требуется функция `argon2-hasher`):
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// Реэкспортируйте DefaultUser как User для вашего приложения
+pub type User = DefaultUser;
+
+// DefaultUser включает:
+// - id: Uuid (первичный ключ)
+// - username: String
+// - email: String
+// - password_hash: Option<String>
+// - first_name: String
+// - last_name: String
+// - is_active: bool
+// - is_staff: bool
+// - is_superuser: bool
+// - last_login: Option<DateTime<Utc>>
+// - date_joined: DateTime<Utc>
+
+// DefaultUser реализует:
+// - Трейт BaseUser (методы аутентификации)
+// - Трейт FullUser (полная информация о пользователе)
+// - Трейт PermissionsMixin (управление разрешениями)
+// - Трейт Model (операции с БД)
+```
+
+**Определение пользовательских моделей:**
+
+Если нужны дополнительные поля, определите свою модель:
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Utc};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: i64,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	#[field(max_length = 100)]
+	pub username: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(auto_now_add = true)]
+	pub created_at: DateTime<Utc>,
+
+	// Добавьте пользовательские поля
+	#[field(max_length = 50, null = true)]
+	pub phone_number: Option<String>,
+}
+```
+
+**Атрибутный макрос Model:**
+
+Атрибут `#[model(...)]` автоматически генерирует:
+- Реализацию трейта `Model` (включает функциональность `#[derive(Model)]`)
+- Типобезопасные аксессоры полей: `User::field_email()`, `User::field_username()` и др.
+- Регистрацию в глобальном реестре моделей
+- Поддержку составных первичных ключей
+
+**Примечание:** При использовании `#[model(...)]` НЕ нужно добавлять `#[derive(Model)]` отдельно,
+так как он автоматически применяется атрибутом `#[model(...)]`.
+
+**Атрибуты полей:**
+- `#[field(primary_key = true)]` - Отметить как первичный ключ
+- `#[field(max_length = 255)]` - Установить максимальную длину для строковых полей
+- `#[field(default = value)]` - Установить значение по умолчанию
+- `#[field(auto_now_add = true)]` - Автозаполнение timestamp при создании
+- `#[field(auto_now = true)]` - Автообновление timestamp при сохранении
+- `#[field(null = true)]` - Разрешить NULL значения
+- `#[field(unique = true)]` - Применить ограничение уникальности
+
+Полный список атрибутов полей см. в [Руководстве по атрибутам полей](../field_attributes.md).
+
+Сгенерированные аксессоры полей позволяют типобезопасно ссылаться на поля в запросах:
+
+```rust
+// Сгенерировано #[model(...)] для DefaultUser
+impl DefaultUser {
+	pub const fn field_id() -> FieldRef<DefaultUser, Uuid> { FieldRef::new("id") }
+	pub const fn field_username() -> FieldRef<DefaultUser, String> { FieldRef::new("username") }
+	pub const fn field_email() -> FieldRef<DefaultUser, String> { FieldRef::new("email") }
+	pub const fn field_is_active() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_active") }
+	pub const fn field_is_staff() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_staff") }
+	pub const fn field_date_joined() -> FieldRef<DefaultUser, DateTime<Utc>> { FieldRef::new("date_joined") }
+	// ... другие поля
+}
+```
+
+**Примеры расширенных запросов:**
+
+```rust
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// Django-стиль F/Q объектных запросов с типобезопасными ссылками на поля
+async fn complex_user_query() -> Result<Vec<DefaultUser>, Box<dyn std::error::Error>> {
+	// Q объекты с типобезопасными ссылками на поля (используя сгенерированные аксессоры)
+	let active_query = Q::new()
+		.field("is_active").eq(true)
+		.and(Q::new().field("date_joined").gte(Now::new()));
+
+	// Функции БД с типобезопасными ссылками на поля
+	let email_lower = Lower::new(DefaultUser::field_email().into());
+	let username_upper = Upper::new(DefaultUser::field_username().into());
+
+	// Агрегации используя аксессоры полей
+	let user_count = Aggregate::count(DefaultUser::field_id().into());
+	let latest_joined = Aggregate::max(DefaultUser::field_date_joined().into());
+
+	// Оконные функции для ранжирования
+	let rank_by_join_date = Window::new()
+		.partition_by(vec![DefaultUser::field_is_active().into()])
+		.order_by(vec![(DefaultUser::field_date_joined().into(), "DESC")])
+		.function(RowNumber::new());
+
+	todo!("Execute query with these components")
+}
+
+// Поддержка транзакций
+async fn create_user_with_transaction(
+	conn: &DatabaseConnection,
+	user_data: CreateUserRequest
+) -> Result<User, Box<dyn std::error::Error>> {
+	// Транзакция с автоматическим откатом при ошибке
+	transaction(conn, |_tx| async move {
+		let user = User::create(user_data).await?;
+		log_user_creation(&user).await?;
+		Ok(user)
+	}).await
+}
+```
+
+**Примечание**: Reinhardt использует [SeaQuery v1.0.0-rc](https://crates.io/crates/sea-query) для SQL операций. Макрос `#[derive(Model)]` автоматически генерирует реализации трейта Model, типобезопасные аксессоры полей и регистрацию в глобальном реестре моделей.
+
+Зарегистрируйте в `src/config/apps.rs`:
+
+```rust
+// src/config/apps.rs
+use reinhardt::installed_apps;
+
+// Макрос installed_apps! генерирует:
+// - Enum InstalledApp с вариантами для каждого приложения
+// - Реализацию конверсионных трейтов (From, Into, Display)
+// - Реестр для конфигурации и обнаружения приложений
+//
+// Примечание: В отличие от INSTALLED_APPS Django, этот макрос только для пользовательских приложений.
+// Встроенные функции фреймворка (auth, sessions, admin и др.) включаются через
+// флаги функций Cargo, а не через installed_apps!.
+//
+// Пример:
+// [dependencies]
+// reinhardt = { version = "0.1", features = ["auth", "sessions", "admin"] }
+//
+// Это включает:
+// - Автоматическое обнаружение приложений для миграций, админ-панели и др.
+// - Типобезопасные ссылки на приложения в коде
+// - Централизованную конфигурацию приложений
+installed_apps! {
+	users: "users",
+}
+
+pub fn get_installed_apps() -> Vec<String> {
+	InstalledApp::all_apps()
+}
+```
+
+### С аутентификацией
+
+Reinhardt предоставляет Django-стиль модели пользователей с трейтами `BaseUser` и `FullUser`, а также комплексное управление пользователями через `UserManager`.
+
+**Примечание:** Reinhardt включает встроенную реализацию `DefaultUser`. Вы можете использовать её напрямую или определить свою модель пользователя, как показано ниже.
+
+**Пример управления пользователями:**
+
+```rust
+use reinhardt::prelude::*;
+
+// Создание и управление пользователями с UserManager
+async fn manage_users() -> Result<(), Box<dyn std::error::Error>> {
+	let hasher = Argon2Hasher::new();
+	let user_manager = UserManager::new(hasher);
+
+	// Создание нового пользователя
+	let user = user_manager.create_user(CreateUserData {
+		username: "alice".to_string(),
+		email: "alice@example.com".to_string(),
+		password: "secure_password".to_string(),
+		first_name: Some("Alice".to_string()),
+		last_name: Some("Smith".to_string()),
+	}).await?;
+
+	// Обновление информации о пользователе
+	user_manager.update_user(user.id, UpdateUserData {
+		email: Some("alice.smith@example.com".to_string()),
+		is_active: Some(true),
+		..Default::default()
+	}).await?;
+
+	// Управление группами и разрешениями
+	let group_manager = GroupManager::new();
+	let editors = group_manager.create_group(CreateGroupData {
+		name: "editors".to_string(),
+	}).await?;
+
+	// Назначение разрешений на уровне объектов
+	let permission = ObjectPermission::new("edit", user.id, article.id);
+	let perm_checker = ObjectPermissionChecker::new();
+	if perm_checker.has_permission(&user, "edit", &article).await? {
+		// Пользователь может редактировать статью
+	}
+
+	Ok(())
+}
+```
+
+Используйте встроенный `DefaultUser` в `users/models.rs`:
+
+```rust
+// users/models.rs
+use reinhardt::DefaultUser;
+
+// Реэкспортируйте DefaultUser как ваш тип User
+pub type User = DefaultUser;
+
+// DefaultUser уже реализует:
+// - Трейт BaseUser (методы аутентификации)
+// - Трейт FullUser (username, email, first_name, last_name и др.)
+// - Трейт PermissionsMixin (управление разрешениями)
+// - Трейт Model (операции с БД)
+```
+
+**Для пользовательских моделей:**
+
+Если нужны дополнительные поля помимо DefaultUser, определите свою:
+
+```rust
+// users/models.rs
+use reinhardt::auth::{BaseUser, FullUser, PermissionsMixin};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+use serde::{Serialize, Deserialize};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: Uuid,
+
+	#[field(max_length = 150)]
+	pub username: String,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	pub password_hash: Option<String>,
+
+	#[field(max_length = 150)]
+	pub first_name: String,
+
+	#[field(max_length = 150)]
+	pub last_name: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(default = false)]
+	pub is_staff: bool,
+
+	#[field(default = false)]
+	pub is_superuser: bool,
+
+	pub last_login: Option<DateTime<Utc>>,
+
+	#[field(auto_now_add = true)]
+	pub date_joined: DateTime<Utc>,
+
+	// Пользовательские поля
+	#[field(max_length = 20, null = true)]
+	pub phone_number: Option<String>,
+}
+
+impl BaseUser for CustomUser {
+	type PrimaryKey = Uuid;
+
+	fn get_username_field() -> &'static str { "username" }
+	fn get_username(&self) -> &str { &self.username }
+	fn password_hash(&self) -> Option<&str> { self.password_hash.as_deref() }
+	fn set_password_hash(&mut self, hash: String) { self.password_hash = Some(hash); }
+	fn last_login(&self) -> Option<DateTime<Utc>> { self.last_login }
+	fn set_last_login(&mut self, time: DateTime<Utc>) { self.last_login = Some(time); }
+	fn is_active(&self) -> bool { self.is_active }
+}
+
+impl FullUser for CustomUser {
+	fn username(&self) -> &str { &self.username }
+	fn email(&self) -> &str { &self.email }
+	fn first_name(&self) -> &str { &self.first_name }
+	fn last_name(&self) -> &str { &self.last_name }
+	fn is_staff(&self) -> bool { self.is_staff }
+	fn is_superuser(&self) -> bool { self.is_superuser }
+	fn date_joined(&self) -> DateTime<Utc> { self.date_joined }
+}
+```
+
+Используйте JWT аутентификацию в `views/profile.rs` вашего приложения:
+
+```rust
+// users/views/profile.rs
+use reinhardt::auth::{JwtAuth, BaseUser};
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+use crate::models::User;
+
+#[get("/profile", name = "get_profile")]
+pub async fn get_profile(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// Извлечение JWT токена из заголовка Authorization
+	let auth_header = req.headers.get("authorization")
+		.and_then(|h| h.to_str().ok())
+		.ok_or("Missing Authorization header")?;
+
+	let token = auth_header.strip_prefix("Bearer ")
+		.ok_or("Invalid Authorization header format")?;
+
+	// Проверка токена и получение ID пользователя
+	let jwt_auth = JwtAuth::new(b"your-secret-key");
+	let claims = jwt_auth.verify_token(token)?;
+
+	// Загрузка пользователя из БД по claims.user_id
+	let user = User::find_by_id(&db, &claims.user_id).await?;
+
+	// Проверка активности пользователя
+	if !user.is_active() {
+		return Err("User account is inactive".into());
+	}
+
+	// Возврат профиля пользователя как JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+### Определение эндпоинтов
+
+Reinhardt использует декораторы HTTP-методов для определения эндпоинтов:
+
+#### Декораторы HTTP-методов
+
+Используйте `#[get]`, `#[post]`, `#[put]`, `#[delete]` для определения маршрутов:
+
+```rust
+use reinhardt::{get, post, Request, Response, ViewResult};
+use serde_json::json;
+
+#[get("/")]
+pub async fn hello(_req: Request) -> ViewResult<Response> {
+	Ok(Response::ok().with_body("Hello, World!"))
+}
+
+#[post("/users")]
+pub async fn create_user(_req: Request) -> ViewResult<Response> {
+	let body = json!({"status": "created"});
+	Response::ok().with_json(&body).map_err(Into::into)
+}
+```
+
+**Возможности:**
+- Проверка пути во время компиляции
+- Лаконичный синтаксис
+- Автоматическая привязка HTTP-методов
+- Поддержка внедрения зависимостей через `#[inject]`
+
+#### Использование внедрения зависимостей
+
+Комбинируйте декораторы HTTP-методов с `#[inject]` для автоматического внедрения зависимостей:
+
+```rust
+use reinhardt::{get, Request, Response, StatusCode, ViewResult};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,  // Автоматически внедряется
+) -> ViewResult<Response> {
+	let id = req.path_params.get("id")
+		.ok_or("Missing id")?
+		.parse::<i64>()?;
+
+	// Использование внедрённого соединения с БД
+	let user = db.query("SELECT * FROM users WHERE id = $1")
+		.bind(id)
+		.fetch_one()
+		.await?;
+
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+**Возможности внедрения зависимостей:**
+- Автоматическое внедрение зависимостей через атрибут `#[inject]`
+- Управление кэшем через `#[inject(cache = false)]`
+- Система внедрения зависимостей, вдохновлённая FastAPI
+- Бесшовная работа с декораторами HTTP-методов
+
+**Тип возвращаемого значения:**
+
+Все функции представления используют `ViewResult<T>` как тип возвращаемого значения:
+
+```rust
+use reinhardt::ViewResult;  // Предопределённый тип результата
+```
+
+### С извлечением параметров
+
+В `views/user.rs` вашего приложения:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// Извлечение параметра пути из запроса
+	let id = req.path_params.get("id")
+		.ok_or("Missing id parameter")?
+		.parse::<i64>()
+		.map_err(|_| "Invalid id format")?;
+
+	// Извлечение query параметров (например, ?include_inactive=true)
+	let include_inactive = req.query_params.get("include_inactive")
+		.and_then(|v| v.parse::<bool>().ok())
+		.unwrap_or(false);
+
+	// Получение пользователя из БД с использованием внедрённого соединения
+	let user = User::find_by_id(&db, id).await?;
+
+	// Проверка статуса активности при необходимости
+	if !include_inactive && !user.is_active {
+		return Err("User is inactive".into());
+	}
+
+	// Возврат как JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+Зарегистрируйте маршрут с параметром пути в `urls.rs`:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::get_user)  // Путь определён в #[get("/users/{id}/")]
+}
+```
+
+### С сериализаторами и валидацией
+
+В `serializers/user.rs` вашего приложения:
+
+```rust
+// users/serializers/user.rs
+use serde::{Serialize, Deserialize};
+use validator::Validate;
+
+#[derive(Serialize, Deserialize, Validate)]
+pub struct CreateUserRequest {
+	#[validate(email)]
+	pub email: String,
+	#[validate(length(min = 3, max = 50))]
+	pub username: String,
+	#[validate(length(min = 8))]
+	pub password: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserResponse {
+	pub id: i64,
+	pub username: String,
+	pub email: String,
+	pub is_active: bool,
+}
+
+impl From<User> for UserResponse {
+	fn from(user: User) -> Self {
+		UserResponse {
+			id: user.id,
+			username: user.username,
+			email: user.email,
+			is_active: user.is_active,
+		}
+	}
+}
+```
+
+В `views/user.rs` вашего приложения:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, post};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use crate::serializers::{CreateUserRequest, UserResponse};
+use validator::Validate;
+use std::sync::Arc;
+
+#[post("/users", name = "create_user")]
+pub async fn create_user(
+	mut req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// Парсинг тела запроса
+	let body_bytes = std::mem::take(&mut req.body);
+	let create_req: CreateUserRequest = serde_json::from_slice(&body_bytes)?;
+
+	// Валидация запроса
+	create_req.validate()?;
+
+	// Создание пользователя
+	let mut user = User {
+		id: 0, // Будет установлен БД
+		username: create_req.username,
+		email: create_req.email,
+		password_hash: None,
+		is_active: true,
+		created_at: Utc::now(),
+	};
+
+	// Хэширование пароля с использованием трейта BaseUser
+	user.set_password(&create_req.password)?;
+
+	// Сохранение в БД с использованием внедрённого соединения
+	user.save(&db).await?;
+
+	// Преобразование в ответ
+	let response_data = UserResponse::from(user);
+	let json = serde_json::to_string(&response_data)?;
+
+	Ok(Response::new(StatusCode::CREATED)
+		.with_body(json))
+}
+```
+
+## Доступные компоненты
+
+Reinhardt предлагает модульные компоненты для комбинирования:
+
+| Компонент            | Название крейта            | Функции                                     |
+|---------------------|---------------------------|---------------------------------------------|
+| **Ядро**            |                           |                                             |
+| Основные типы       | `reinhardt-core`          | Основные трейты, типы, макросы (Model, endpoint)|
+| HTTP и маршрутизация| `reinhardt-http`          | Request/Response, обработка HTTP            |
+| URL маршрутизация   | `reinhardt-urls`          | Функциональные и классовые маршруты         |
+| Сервер              | `reinhardt-server`        | Реализация HTTP сервера                     |
+| Middleware          | `reinhardt-dispatch`      | Цепочка middleware, диспетчеризация сигналов|
+| Конфигурация        | `reinhardt-conf`          | Управление настройками, загрузка окружения  |
+| Команды             | `reinhardt-commands`      | CLI инструменты управления (startproject и др.)|
+| Шорткаты            | `reinhardt-shortcuts`     | Общие утилитарные функции                   |
+| **База данных**     |                           |                                             |
+| ORM                 | `reinhardt-db`            | Интеграция SeaQuery v1.0.0-rc               |
+| **Аутентификация**  |                           |                                             |
+| Auth                | `reinhardt-auth`          | JWT, Token, Session, Basic auth, модели User|
+| **REST API**        |                           |                                             |
+| Сериализаторы       | `reinhardt-rest`          | Интеграция serde/validator, ViewSets        |
+| **Формы**           |                           |                                             |
+| Формы               | `reinhardt-forms`         | Обработка и валидация форм                  |
+| **Расширенные**     |                           |                                             |
+| Админ-панель        | `reinhardt-admin`         | Интерфейс администрирования в стиле Django  |
+| Система плагинов    | `reinhardt-dentdelion`    | Статические и WASM плагины, CLI управление  |
+| Фоновые задачи      | `reinhardt-tasks`         | Очереди задач (Redis, RabbitMQ, SQLite)     |
+| GraphQL             | `reinhardt-graphql`       | Генерация схем, подписки                    |
+| WebSockets          | `reinhardt-websockets`    | Коммуникация в реальном времени             |
+| i18n                | `reinhardt-i18n`          | Поддержка многоязычности                    |
+| **Тестирование**    |                           |                                             |
+| Утилиты тестирования| `reinhardt-test`          | Хелперы тестирования, фикстуры, TestContainers|
+
+**Детальные флаги функций в каждом крейте см. в [Руководстве по флагам функций](../FEATURE_FLAGS.md).**
+
+---
+
+## Документация
+
+- 📚 [Руководство по началу работы](../GETTING_STARTED.md) - Пошаговое руководство для начинающих
+- 🎛️ [Руководство по флагам функций](../FEATURE_FLAGS.md) - Оптимизация сборки с гранулярным контролем функций
+- 📖 [Справочник API](https://docs.rs/reinhardt) (Скоро)
+- 📝 [Учебники](../tutorials/) - Обучение на реальных приложениях
+
+**Для AI ассистентов**: См. [CLAUDE.md](../../CLAUDE.md) для специфичных стандартов кодирования, рекомендаций по тестированию и соглашений разработки.
+
+## 💬 Получение помощи
+
+Reinhardt — проект, управляемый сообществом. Вот где можно получить помощь:
+
+- 💬 **Discord**: Присоединяйтесь к нашему Discord серверу для общения в реальном времени (скоро)
+- 💭 **GitHub Discussions**: [Задавайте вопросы и делитесь идеями](https://github.com/kent8192/reinhardt-rs/discussions)
+- 🐛 **Issues**: [Сообщайте об ошибках](https://github.com/kent8192/reinhardt-rs/issues)
+- 📖 **Документация**: [Читайте руководства](../)
+
+Перед тем как задать вопрос, проверьте:
+
+- ✅ [Руководство по началу работы](../GETTING_STARTED.md)
+- ✅ [Примеры](../../examples/)
+- ✅ Существующие GitHub Issues и Discussions
+
+## 🤝 Вклад в проект
+
+Мы любим вклады! Прочитайте [Руководство по вкладу](../../CONTRIBUTING.md) для начала.
+
+**Быстрые ссылки**:
+
+- [Настройка разработки](../../CONTRIBUTING.md#development-setup)
+- [Руководство по тестированию](../../CONTRIBUTING.md#testing-guidelines)
+- [Руководство по коммитам](../../CONTRIBUTING.md#commit-guidelines)
+
+## Лицензия
+
+Лицензировано по одной из следующих лицензий на ваш выбор:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) или http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) или http://opensource.org/licenses/MIT)
+
+### Атрибуция третьих сторон
+
+Этот проект вдохновлён:
+
+- [Django](https://www.djangoproject.com/) (Лицензия BSD 3-Clause)
+- [Django REST Framework](https://www.django-rest-framework.org/) (Лицензия BSD 3-Clause)
+- [FastAPI](https://fastapi.tiangolo.com/) (Лицензия MIT)
+- [SQLAlchemy](https://www.sqlalchemy.org/) (Лицензия MIT)
+
+Полную атрибуцию см. в [THIRD-PARTY-NOTICES](../../THIRD-PARTY-NOTICES).
+
+**Примечание:** Этот проект не связан и не одобрен Django Software Foundation, Encode OSS Ltd., Sebastián Ramírez (автор FastAPI) или Michael Bayer (автор SQLAlchemy).

--- a/docs/readme-langs/README_UK.md
+++ b/docs/readme-langs/README_UK.md
@@ -1,0 +1,1059 @@
+<div align="center">
+  <img src="../../branding/logo.png" alt="Reinhardt Logo" width="200"/>
+
+  <h1>Reinhardt</h1>
+
+  <h3>🦀 Полілітичний фреймворк з батарейками</h3>
+
+  <p><strong>Компонований повнофункціональний API-фреймворк для Rust</strong></p>
+  <p>Будуйте з <em>усією</em> потужністю філософії Django "батарейки в комплекті",<br/>
+  або компонуйте <em>тільки</em> те, що вам потрібно — ваш вибір, ваш шлях.</p>
+
+🌐 [English](../../README.md) | [日本語](README_JA.md) | [简体中文](README_ZH_CN.md) | [繁體中文](README_ZH_TW.md) | [Русский](README_RU.md) | **Українська** | [فارسی](README_FA.md) | [العربية](README_AR.md)
+
+[![Crates.io](https://img.shields.io/crates/v/reinhardt-web.svg)](https://crates.io/crates/reinhardt-web)
+[![Documentation](https://docs.rs/reinhardt-web/badge.svg)](https://docs.rs/reinhardt-web)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](../../LICENSE.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kent8192/reinhardt-web)
+
+</div>
+
+---
+
+## 📍 Швидка навігація
+
+Можливо, ви шукаєте:
+
+- 🚀 [Швидкий старт](#швидкий-старт) - Запуск за 5 хвилин
+- 📦 [Варіанти встановлення](#встановлення) - Оберіть свій варіант: Micro, Standard або Full
+- 📚 [Посібник початківця](../GETTING_STARTED.md) - Покрокове керівництво
+- 🎛️ [Прапорці функцій](../FEATURE_FLAGS.md) - Тонке налаштування збірки
+- 📖 [API документація](https://docs.rs/reinhardt-web) - Повний довідник API
+- 💬 [Спільнота та підтримка](#отримання-допомоги) - Отримайте допомогу від спільноти
+
+## Чому Reinhardt?
+
+**Polylithic = Poly (багато) + Lithic (будівельні блоки)**
+На відміну від монолітних фреймворків, які змушують вас використовувати все, Reinhardt дозволяє компонувати ідеальний стек з незалежних, добре протестованих компонентів.
+
+Reinhardt об'єднує найкраще з трьох світів:
+
+| Натхнення          | Що ми запозичили                                       | Що ми покращили                                     |
+|--------------------|--------------------------------------------------------|------------------------------------------------------|
+| 🐍 **Django**      | Філософія "батарейки в комплекті", дизайн ORM, адмінка | Прапорці функцій для компонованих збірок, типобезпека Rust |
+| 🎯 **Django REST** | Серіалізатори, ViewSets, дозволи                       | Перевірка під час компіляції, абстракції з нульовою вартістю |
+| ⚡ **FastAPI**      | DI система, автоматичний OpenAPI                        | Нативна продуктивність Rust, без накладних витрат під час виконання |
+| 🗄️ **SQLAlchemy** | Патерни QuerySet, обробка зв'язків                      | Типобезпечний конструктор запитів, перевірка під час компіляції |
+
+**Результат**: Фреймворк, знайомий Python-розробникам, але з продуктивністю та гарантіями безпеки Rust.
+
+## ✨ Ключові функції
+
+- **Типобезпечна ORM** з перевіркою під час компіляції (SeaQuery v1.0.0-rc)
+- **Потужні серіалізатори** з автоматичною валідацією (serde + validator)
+- **DI у стилі FastAPI** з типобезпечним впровадженням залежностей та кешуванням
+- **ViewSets** для швидкої розробки CRUD API
+- **Множинна автентифікація** (JWT, Token, Session, Basic) з трейтами BaseUser/FullUser
+- **Адмін-панель** з автоматично генерованим інтерфейсом управління моделями
+- **Команди управління** для міграцій, статичних файлів тощо
+- **GraphQL та WebSocket** підтримка для застосунків реального часу
+- **Пагінація, фільтрація, обмеження швидкості** вбудовані
+- **Сигнали** для подієво-орієнтованої архітектури
+
+Повний список див. у [Доступні компоненти](#доступні-компоненти), приклади у [Посібнику початківця](../GETTING_STARTED.md).
+
+## Встановлення
+
+Reinhardt — модульний фреймворк. Оберіть точку старту:
+
+**Примітка щодо назви крейтів:**
+Основний крейт Reinhardt опублікований на crates.io як `reinhardt-web`, але ви імпортуєте його як `reinhardt` у коді, використовуючи атрибут `package`.
+
+### За замовчуванням: Повнофункціональний (Батарейки в комплекті) ⚠️ Новий default
+
+Усі функції без налаштування:
+
+```toml
+[dependencies]
+# Імпортується як 'reinhardt', опублікований як 'reinhardt-web'
+# За замовчуванням увімкнені ВСІ функції (повний комплект)
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web" }
+```
+
+**Включає:** Database, Auth, REST API, Admin, GraphQL, WebSockets, Cache, i18n, Mail, Sessions, Static Files, Storage
+
+**Бінарник**: ~50+ МБ | **Компіляція**: Повільніше, але все працює з коробки
+
+Потім використовуйте в коді:
+```rust
+use reinhardt::prelude::*;
+use reinhardt::{Request, Response, StatusCode};
+```
+
+### Варіант 1: Стандартне встановлення (Збалансований)
+
+Для більшості проєктів, яким не потрібні всі функції:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["standard"] }
+```
+
+**Включає:** Core, Database (PostgreSQL), REST API, Auth, Middleware, Pages (WASM фронтенд з SSR)
+
+**Бінарник**: ~20-30 МБ | **Компіляція**: Середня
+
+### Варіант 2: Мікросервіси (Мінімальне встановлення)
+
+Легкий та швидкий, ідеальний для простих API:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+```
+
+**Включає:** HTTP, маршрутизація, DI, вилучення параметрів, сервер
+
+**Бінарник**: ~5-10 МБ | **Компіляція**: Дуже швидка
+
+### Варіант 3: Створіть свій стек
+
+Встановлюйте лише потрібні компоненти:
+
+```toml
+[dependencies]
+# Основні компоненти
+reinhardt-http = "0.1.0-alpha.1"
+reinhardt-urls = "0.1.0-alpha.1"
+
+# Опціонально: База даних
+reinhardt-db = "0.1.0-alpha.1"
+
+# Опціонально: Автентифікація
+reinhardt-auth = "0.1.0-alpha.1"
+
+# Опціонально: REST API функції
+reinhardt-rest = "0.1.0-alpha.1"
+
+# Опціонально: Адмін-панель
+reinhardt-admin = "0.1.0-alpha.1"
+
+# Опціонально: Розширені функції
+reinhardt-graphql = "0.1.0-alpha.1"
+reinhardt-websockets = "0.1.0-alpha.1"
+```
+
+**📖 Повний список доступних крейтів та прапорців функцій див. у [Посібнику з прапорців функцій](../FEATURE_FLAGS.md).**
+
+## Швидкий старт
+
+### 1. Встановіть Reinhardt Admin Tool
+
+```bash
+cargo install reinhardt-admin-cli
+```
+
+### 2. Створіть новий проєкт
+
+```bash
+# Створення RESTful API проєкту (за замовчуванням)
+reinhardt-admin startproject my-api
+cd my-api
+```
+
+Це створить повну структуру проєкту:
+
+```
+my-api/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   ├── config.rs
+│   ├── apps.rs
+│   ├── config/
+│   │   ├── settings.rs
+│   │   ├── settings/
+│   │   │   ├── base.rs
+│   │   │   ├── local.rs
+│   │   │   ├── staging.rs
+│   │   │   └── production.rs
+│   │   ├── urls.rs
+│   │   └── apps.rs
+│   └── bin/
+│       └── manage.rs
+└── README.md
+```
+
+**Альтернатива: Створення reinhardt-pages проєкту (WASM + SSR)**
+
+Для сучасного WASM-фронтенду з SSR:
+
+```bash
+# Створення pages проєкту
+reinhardt-admin startproject my-app --with-pages
+cd my-app
+
+# Встановлення WASM інструментів збірки (тільки перший раз)
+cargo make install-wasm-tools
+
+# Збірка WASM та запуск сервера розробки
+cargo make dev
+# Відкрийте http://127.0.0.1:8000/
+```
+
+### 3. Запустіть сервер розробки
+
+```bash
+# Використовуючи команду manage
+cargo run --bin manage runserver
+
+# Сервер запуститься на http://127.0.0.1:8000
+```
+
+**Підтримка автоперезавантаження:**
+
+Для автоматичного перезавантаження при зміні коду (потрібен bacon):
+
+```bash
+# Встановлення bacon
+cargo install --locked bacon
+
+# Запуск з автоперезавантаженням
+bacon runserver
+
+# Або використовуйте cargo make
+cargo make watch
+
+# Для тестів
+bacon test
+```
+
+### 4. Створіть перший застосунок
+
+```bash
+# Створення RESTful API застосунку (за замовчуванням)
+cargo run --bin manage startapp users
+
+# Або явно вкажіть тип
+cargo run --bin manage startapp users --restful
+
+# Створення Pages застосунку (WASM + SSR)
+cargo run --bin manage startapp dashboard --with-pages
+```
+
+Це створить структуру застосунку:
+
+```
+users/
+├── lib.rs
+├── models.rs
+├── models/
+├── views.rs
+├── views/
+├── serializers.rs
+├── serializers/
+├── admin.rs
+├── urls.rs
+└── tests.rs
+```
+
+### 5. Зареєструйте маршрути
+
+Відредагуйте `urls.rs` вашого застосунку:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::list_users)
+		.endpoint(views::get_user)
+		.endpoint(views::create_user)
+}
+```
+
+Включіть у `src/config/urls.rs`:
+
+```rust
+// src/config/urls.rs
+use reinhardt::prelude::*;
+use reinhardt::routes;
+
+#[routes]
+pub fn routes() -> ServerRouter {
+	ServerRouter::new()
+		.mount("/api/", users::urls::url_patterns())
+}
+```
+
+Атрибутний макрос `#[routes]` автоматично реєструє цю функцію у фреймворку для виявлення через крейт `inventory`.
+
+**Примітка:** `reinhardt::prelude` включає часто використовувані типи. Основні експорти:
+
+**Завжди доступні:**
+- Базова маршрутизація та представлення: `Router`, `DefaultRouter`, `ServerRouter`, `View`, `ListView`, `DetailView`
+- ViewSets: `ViewSet`, `ModelViewSet`, `ReadOnlyModelViewSet`
+- HTTP: `StatusCode`
+
+**Залежать від функцій:**
+- **Функція `core`**: `Request`, `Response`, `Handler`, `Middleware`, Сигнали (`post_save`, `pre_save` та ін.)
+- **Функція `database`**: `Model`, `DatabaseConnection`, `F`, `Q`, `Transaction`, `atomic`, Функції БД (`Concat`, `Upper`, `Lower`, `Now`, `CurrentDate`), Віконні функції (`Window`, `RowNumber`, `Rank`, `DenseRank`), Обмеження (`UniqueConstraint`, `CheckConstraint`, `ForeignKeyConstraint`)
+- **Функція `auth`**: `User`, `UserManager`, `GroupManager`, `Permission`, `ObjectPermission`
+- **Функції `minimal`, `standard` або `di`**: `Body`, `Cookie`, `Header`, `Json`, `Path`, `Query`
+- **Функція `rest`**: Серіалізатори, Парсери, Пагінація, Тротлінг, Версіонування
+- **Функція `admin`**: Компоненти адмін-панелі
+- **Функція `cache`**: `Cache`, `InMemoryCache`
+- **Функція `sessions`**: `Session`, `AuthenticationMiddleware`
+
+Повний список див. у [Посібнику з прапорців функцій](../FEATURE_FLAGS.md).
+
+Повне покрокове керівництво див. у [Посібнику початківця](../GETTING_STARTED.md).
+
+## 🎓 Вчіться на прикладах
+
+### З базою даних
+
+Налаштуйте базу даних у `settings/base.toml`:
+
+```toml
+debug = true
+secret_key = "your-secret-key-for-development"
+
+[database]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "mydb"
+user = "postgres"
+password = "postgres"
+```
+
+Налаштування автоматично завантажуються в `src/config/settings.rs`:
+
+```rust
+// src/config/settings.rs
+use reinhardt::conf::settings::builder::SettingsBuilder;
+use reinhardt::conf::settings::profile::Profile;
+use reinhardt::conf::settings::sources::{DefaultSource, LowPriorityEnvSource, TomlFileSource};
+use reinhardt::core::Settings;
+use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub fn get_settings() -> Settings {
+	let profile_str = env::var("REINHARDT_ENV").unwrap_or_else(|_| "local".to_string());
+	let profile = Profile::from_str(&profile_str).unwrap_or(Profile::Development);
+
+	let base_dir = env::current_dir().expect("Failed to get current directory");
+	let settings_dir = base_dir.join("settings");
+
+	let merged = SettingsBuilder::new()
+		.profile(profile)
+		.add_source(
+			DefaultSource::new()
+				.with_value("debug", serde_json::Value::Bool(false))
+				.with_value("language_code", serde_json::Value::String("en-us".to_string()))
+				.with_value("time_zone", serde_json::Value::String("UTC".to_string()))
+		)
+		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
+		.add_source(TomlFileSource::new(settings_dir.join(format!("{}.toml", profile_str))))
+		.build()
+		.expect("Failed to build settings");
+
+	merged.into_typed().expect("Failed to convert settings to Settings struct")
+}
+```
+
+**Джерела змінних середовища:**
+
+Reinhardt надає два типи джерел змінних середовища з різними пріоритетами:
+
+- **`EnvSource`** (пріоритет: 100) - Високопріоритетні змінні середовища, які перевизначають TOML файли
+  ```rust
+  .add_source(EnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+- **`LowPriorityEnvSource`** (пріоритет: 40) - Низькопріоритетні змінні середовища, які використовуються як запасний варіант
+  ```rust
+  .add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+**Порядок пріоритетів**:
+- З `EnvSource`: Змінні середовища > `{profile}.toml` > `base.toml` > Значення за замовчуванням
+- З `LowPriorityEnvSource` (показано вище): `{profile}.toml` > `base.toml` > Змінні середовища > Значення за замовчуванням
+
+Обирайте `EnvSource`, коли змінні середовища завжди повинні мати пріоритет (наприклад, production).
+Обирайте `LowPriorityEnvSource`, коли TOML файли повинні бути основним джерелом конфігурації (наприклад, розробка).
+
+Див. [Документацію з налаштувань](../SETTINGS_DOCUMENT.md) для деталей.
+
+**Використання вбудованого DefaultUser:**
+
+Reinhardt надає готову реалізацію `DefaultUser` (потрібна функція `argon2-hasher`):
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// Реекспортуйте DefaultUser як User для вашого застосунку
+pub type User = DefaultUser;
+
+// DefaultUser включає:
+// - id: Uuid (первинний ключ)
+// - username: String
+// - email: String
+// - password_hash: Option<String>
+// - first_name: String
+// - last_name: String
+// - is_active: bool
+// - is_staff: bool
+// - is_superuser: bool
+// - last_login: Option<DateTime<Utc>>
+// - date_joined: DateTime<Utc>
+
+// DefaultUser реалізує:
+// - Трейт BaseUser (методи автентифікації)
+// - Трейт FullUser (повна інформація про користувача)
+// - Трейт PermissionsMixin (управління дозволами)
+// - Трейт Model (операції з БД)
+```
+
+**Визначення користувацьких моделей:**
+
+Якщо потрібні додаткові поля, визначте свою модель:
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Utc};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: i64,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	#[field(max_length = 100)]
+	pub username: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(auto_now_add = true)]
+	pub created_at: DateTime<Utc>,
+
+	// Додайте користувацькі поля
+	#[field(max_length = 50, null = true)]
+	pub phone_number: Option<String>,
+}
+```
+
+**Атрибутний макрос Model:**
+
+Атрибут `#[model(...)]` автоматично генерує:
+- Реалізацію трейта `Model` (включає функціональність `#[derive(Model)]`)
+- Типобезпечні аксесори полів: `User::field_email()`, `User::field_username()` та ін.
+- Реєстрацію в глобальному реєстрі моделей
+- Підтримку складених первинних ключів
+
+**Примітка:** При використанні `#[model(...)]` НЕ потрібно додавати `#[derive(Model)]` окремо,
+оскільки він автоматично застосовується атрибутом `#[model(...)]`.
+
+**Атрибути полів:**
+- `#[field(primary_key = true)]` - Позначити як первинний ключ
+- `#[field(max_length = 255)]` - Встановити максимальну довжину для рядкових полів
+- `#[field(default = value)]` - Встановити значення за замовчуванням
+- `#[field(auto_now_add = true)]` - Автозаповнення timestamp при створенні
+- `#[field(auto_now = true)]` - Автооновлення timestamp при збереженні
+- `#[field(null = true)]` - Дозволити NULL значення
+- `#[field(unique = true)]` - Застосувати обмеження унікальності
+
+Повний список атрибутів полів див. у [Посібнику з атрибутів полів](../field_attributes.md).
+
+Згенеровані аксесори полів дозволяють типобезпечно посилатися на поля в запитах:
+
+```rust
+// Згенеровано #[model(...)] для DefaultUser
+impl DefaultUser {
+	pub const fn field_id() -> FieldRef<DefaultUser, Uuid> { FieldRef::new("id") }
+	pub const fn field_username() -> FieldRef<DefaultUser, String> { FieldRef::new("username") }
+	pub const fn field_email() -> FieldRef<DefaultUser, String> { FieldRef::new("email") }
+	pub const fn field_is_active() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_active") }
+	pub const fn field_is_staff() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_staff") }
+	pub const fn field_date_joined() -> FieldRef<DefaultUser, DateTime<Utc>> { FieldRef::new("date_joined") }
+	// ... інші поля
+}
+```
+
+**Приклади розширених запитів:**
+
+```rust
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// Django-стиль F/Q об'єктних запитів з типобезпечними посиланнями на поля
+async fn complex_user_query() -> Result<Vec<DefaultUser>, Box<dyn std::error::Error>> {
+	// Q об'єкти з типобезпечними посиланнями на поля (використовуючи згенеровані аксесори)
+	let active_query = Q::new()
+		.field("is_active").eq(true)
+		.and(Q::new().field("date_joined").gte(Now::new()));
+
+	// Функції БД з типобезпечними посиланнями на поля
+	let email_lower = Lower::new(DefaultUser::field_email().into());
+	let username_upper = Upper::new(DefaultUser::field_username().into());
+
+	// Агрегації використовуючи аксесори полів
+	let user_count = Aggregate::count(DefaultUser::field_id().into());
+	let latest_joined = Aggregate::max(DefaultUser::field_date_joined().into());
+
+	// Віконні функції для ранжування
+	let rank_by_join_date = Window::new()
+		.partition_by(vec![DefaultUser::field_is_active().into()])
+		.order_by(vec![(DefaultUser::field_date_joined().into(), "DESC")])
+		.function(RowNumber::new());
+
+	todo!("Execute query with these components")
+}
+
+// Підтримка транзакцій
+async fn create_user_with_transaction(
+	conn: &DatabaseConnection,
+	user_data: CreateUserRequest
+) -> Result<User, Box<dyn std::error::Error>> {
+	// Транзакція з автоматичним відкатом при помилці
+	transaction(conn, |_tx| async move {
+		let user = User::create(user_data).await?;
+		log_user_creation(&user).await?;
+		Ok(user)
+	}).await
+}
+```
+
+**Примітка**: Reinhardt використовує [SeaQuery v1.0.0-rc](https://crates.io/crates/sea-query) для SQL операцій. Макрос `#[derive(Model)]` автоматично генерує реалізації трейта Model, типобезпечні аксесори полів та реєстрацію в глобальному реєстрі моделей.
+
+Зареєструйте в `src/config/apps.rs`:
+
+```rust
+// src/config/apps.rs
+use reinhardt::installed_apps;
+
+// Макрос installed_apps! генерує:
+// - Enum InstalledApp з варіантами для кожного застосунку
+// - Реалізацію конверсійних трейтів (From, Into, Display)
+// - Реєстр для конфігурації та виявлення застосунків
+//
+// Примітка: На відміну від INSTALLED_APPS Django, цей макрос тільки для користувацьких застосунків.
+// Вбудовані функції фреймворку (auth, sessions, admin та ін.) вмикаються через
+// прапорці функцій Cargo, а не через installed_apps!.
+//
+// Приклад:
+// [dependencies]
+// reinhardt = { version = "0.1", features = ["auth", "sessions", "admin"] }
+//
+// Це вмикає:
+// - Автоматичне виявлення застосунків для міграцій, адмін-панелі та ін.
+// - Типобезпечні посилання на застосунки в коді
+// - Централізовану конфігурацію застосунків
+installed_apps! {
+	users: "users",
+}
+
+pub fn get_installed_apps() -> Vec<String> {
+	InstalledApp::all_apps()
+}
+```
+
+### З автентифікацією
+
+Reinhardt надає Django-стиль моделі користувачів з трейтами `BaseUser` та `FullUser`, а також комплексне управління користувачами через `UserManager`.
+
+**Примітка:** Reinhardt включає вбудовану реалізацію `DefaultUser`. Ви можете використовувати її напряму або визначити свою модель користувача, як показано нижче.
+
+**Приклад управління користувачами:**
+
+```rust
+use reinhardt::prelude::*;
+
+// Створення та управління користувачами з UserManager
+async fn manage_users() -> Result<(), Box<dyn std::error::Error>> {
+	let hasher = Argon2Hasher::new();
+	let user_manager = UserManager::new(hasher);
+
+	// Створення нового користувача
+	let user = user_manager.create_user(CreateUserData {
+		username: "alice".to_string(),
+		email: "alice@example.com".to_string(),
+		password: "secure_password".to_string(),
+		first_name: Some("Alice".to_string()),
+		last_name: Some("Smith".to_string()),
+	}).await?;
+
+	// Оновлення інформації про користувача
+	user_manager.update_user(user.id, UpdateUserData {
+		email: Some("alice.smith@example.com".to_string()),
+		is_active: Some(true),
+		..Default::default()
+	}).await?;
+
+	// Управління групами та дозволами
+	let group_manager = GroupManager::new();
+	let editors = group_manager.create_group(CreateGroupData {
+		name: "editors".to_string(),
+	}).await?;
+
+	// Призначення дозволів на рівні об'єктів
+	let permission = ObjectPermission::new("edit", user.id, article.id);
+	let perm_checker = ObjectPermissionChecker::new();
+	if perm_checker.has_permission(&user, "edit", &article).await? {
+		// Користувач може редагувати статтю
+	}
+
+	Ok(())
+}
+```
+
+Використовуйте вбудований `DefaultUser` у `users/models.rs`:
+
+```rust
+// users/models.rs
+use reinhardt::DefaultUser;
+
+// Реекспортуйте DefaultUser як ваш тип User
+pub type User = DefaultUser;
+
+// DefaultUser вже реалізує:
+// - Трейт BaseUser (методи автентифікації)
+// - Трейт FullUser (username, email, first_name, last_name та ін.)
+// - Трейт PermissionsMixin (управління дозволами)
+// - Трейт Model (операції з БД)
+```
+
+**Для користувацьких моделей:**
+
+Якщо потрібні додаткові поля крім DefaultUser, визначте свою:
+
+```rust
+// users/models.rs
+use reinhardt::auth::{BaseUser, FullUser, PermissionsMixin};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+use serde::{Serialize, Deserialize};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: Uuid,
+
+	#[field(max_length = 150)]
+	pub username: String,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	pub password_hash: Option<String>,
+
+	#[field(max_length = 150)]
+	pub first_name: String,
+
+	#[field(max_length = 150)]
+	pub last_name: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(default = false)]
+	pub is_staff: bool,
+
+	#[field(default = false)]
+	pub is_superuser: bool,
+
+	pub last_login: Option<DateTime<Utc>>,
+
+	#[field(auto_now_add = true)]
+	pub date_joined: DateTime<Utc>,
+
+	// Користувацькі поля
+	#[field(max_length = 20, null = true)]
+	pub phone_number: Option<String>,
+}
+
+impl BaseUser for CustomUser {
+	type PrimaryKey = Uuid;
+
+	fn get_username_field() -> &'static str { "username" }
+	fn get_username(&self) -> &str { &self.username }
+	fn password_hash(&self) -> Option<&str> { self.password_hash.as_deref() }
+	fn set_password_hash(&mut self, hash: String) { self.password_hash = Some(hash); }
+	fn last_login(&self) -> Option<DateTime<Utc>> { self.last_login }
+	fn set_last_login(&mut self, time: DateTime<Utc>) { self.last_login = Some(time); }
+	fn is_active(&self) -> bool { self.is_active }
+}
+
+impl FullUser for CustomUser {
+	fn username(&self) -> &str { &self.username }
+	fn email(&self) -> &str { &self.email }
+	fn first_name(&self) -> &str { &self.first_name }
+	fn last_name(&self) -> &str { &self.last_name }
+	fn is_staff(&self) -> bool { self.is_staff }
+	fn is_superuser(&self) -> bool { self.is_superuser }
+	fn date_joined(&self) -> DateTime<Utc> { self.date_joined }
+}
+```
+
+Використовуйте JWT автентифікацію у `views/profile.rs` вашого застосунку:
+
+```rust
+// users/views/profile.rs
+use reinhardt::auth::{JwtAuth, BaseUser};
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+use crate::models::User;
+
+#[get("/profile", name = "get_profile")]
+pub async fn get_profile(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// Вилучення JWT токена з заголовка Authorization
+	let auth_header = req.headers.get("authorization")
+		.and_then(|h| h.to_str().ok())
+		.ok_or("Missing Authorization header")?;
+
+	let token = auth_header.strip_prefix("Bearer ")
+		.ok_or("Invalid Authorization header format")?;
+
+	// Перевірка токена та отримання ID користувача
+	let jwt_auth = JwtAuth::new(b"your-secret-key");
+	let claims = jwt_auth.verify_token(token)?;
+
+	// Завантаження користувача з БД за claims.user_id
+	let user = User::find_by_id(&db, &claims.user_id).await?;
+
+	// Перевірка активності користувача
+	if !user.is_active() {
+		return Err("User account is inactive".into());
+	}
+
+	// Повернення профілю користувача як JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+### Визначення ендпоінтів
+
+Reinhardt використовує декоратори HTTP-методів для визначення ендпоінтів:
+
+#### Декоратори HTTP-методів
+
+Використовуйте `#[get]`, `#[post]`, `#[put]`, `#[delete]` для визначення маршрутів:
+
+```rust
+use reinhardt::{get, post, Request, Response, ViewResult};
+use serde_json::json;
+
+#[get("/")]
+pub async fn hello(_req: Request) -> ViewResult<Response> {
+	Ok(Response::ok().with_body("Hello, World!"))
+}
+
+#[post("/users")]
+pub async fn create_user(_req: Request) -> ViewResult<Response> {
+	let body = json!({"status": "created"});
+	Response::ok().with_json(&body).map_err(Into::into)
+}
+```
+
+**Можливості:**
+- Перевірка шляху під час компіляції
+- Лаконічний синтаксис
+- Автоматична прив'язка HTTP-методів
+- Підтримка впровадження залежностей через `#[inject]`
+
+#### Використання впровадження залежностей
+
+Комбінуйте декоратори HTTP-методів з `#[inject]` для автоматичного впровадження залежностей:
+
+```rust
+use reinhardt::{get, Request, Response, StatusCode, ViewResult};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,  // Автоматично впроваджується
+) -> ViewResult<Response> {
+	let id = req.path_params.get("id")
+		.ok_or("Missing id")?
+		.parse::<i64>()?;
+
+	// Використання впровадженого з'єднання з БД
+	let user = db.query("SELECT * FROM users WHERE id = $1")
+		.bind(id)
+		.fetch_one()
+		.await?;
+
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+**Можливості впровадження залежностей:**
+- Автоматичне впровадження залежностей через атрибут `#[inject]`
+- Управління кешем через `#[inject(cache = false)]`
+- Система впровадження залежностей, натхненна FastAPI
+- Безшовна робота з декораторами HTTP-методів
+
+**Тип значення, що повертається:**
+
+Усі функції представлення використовують `ViewResult<T>` як тип значення, що повертається:
+
+```rust
+use reinhardt::ViewResult;  // Попередньо визначений тип результату
+```
+
+### З вилученням параметрів
+
+У `views/user.rs` вашого застосунку:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// Вилучення параметра шляху із запиту
+	let id = req.path_params.get("id")
+		.ok_or("Missing id parameter")?
+		.parse::<i64>()
+		.map_err(|_| "Invalid id format")?;
+
+	// Вилучення query параметрів (наприклад, ?include_inactive=true)
+	let include_inactive = req.query_params.get("include_inactive")
+		.and_then(|v| v.parse::<bool>().ok())
+		.unwrap_or(false);
+
+	// Отримання користувача з БД з використанням впровадженого з'єднання
+	let user = User::find_by_id(&db, id).await?;
+
+	// Перевірка статусу активності за потреби
+	if !include_inactive && !user.is_active {
+		return Err("User is inactive".into());
+	}
+
+	// Повернення як JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+Зареєструйте маршрут з параметром шляху в `urls.rs`:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::get_user)  // Шлях визначений у #[get("/users/{id}/")]
+}
+```
+
+### З серіалізаторами та валідацією
+
+У `serializers/user.rs` вашого застосунку:
+
+```rust
+// users/serializers/user.rs
+use serde::{Serialize, Deserialize};
+use validator::Validate;
+
+#[derive(Serialize, Deserialize, Validate)]
+pub struct CreateUserRequest {
+	#[validate(email)]
+	pub email: String,
+	#[validate(length(min = 3, max = 50))]
+	pub username: String,
+	#[validate(length(min = 8))]
+	pub password: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserResponse {
+	pub id: i64,
+	pub username: String,
+	pub email: String,
+	pub is_active: bool,
+}
+
+impl From<User> for UserResponse {
+	fn from(user: User) -> Self {
+		UserResponse {
+			id: user.id,
+			username: user.username,
+			email: user.email,
+			is_active: user.is_active,
+		}
+	}
+}
+```
+
+У `views/user.rs` вашого застосунку:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, post};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use crate::serializers::{CreateUserRequest, UserResponse};
+use validator::Validate;
+use std::sync::Arc;
+
+#[post("/users", name = "create_user")]
+pub async fn create_user(
+	mut req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// Парсинг тіла запиту
+	let body_bytes = std::mem::take(&mut req.body);
+	let create_req: CreateUserRequest = serde_json::from_slice(&body_bytes)?;
+
+	// Валідація запиту
+	create_req.validate()?;
+
+	// Створення користувача
+	let mut user = User {
+		id: 0, // Буде встановлено БД
+		username: create_req.username,
+		email: create_req.email,
+		password_hash: None,
+		is_active: true,
+		created_at: Utc::now(),
+	};
+
+	// Хешування пароля з використанням трейта BaseUser
+	user.set_password(&create_req.password)?;
+
+	// Збереження в БД з використанням впровадженого з'єднання
+	user.save(&db).await?;
+
+	// Перетворення у відповідь
+	let response_data = UserResponse::from(user);
+	let json = serde_json::to_string(&response_data)?;
+
+	Ok(Response::new(StatusCode::CREATED)
+		.with_body(json))
+}
+```
+
+## Доступні компоненти
+
+Reinhardt пропонує модульні компоненти для комбінування:
+
+| Компонент            | Назва крейта              | Функції                                     |
+|---------------------|---------------------------|---------------------------------------------|
+| **Ядро**            |                           |                                             |
+| Основні типи        | `reinhardt-core`          | Основні трейти, типи, макроси (Model, endpoint)|
+| HTTP та маршрутизація| `reinhardt-http`         | Request/Response, обробка HTTP              |
+| URL маршрутизація   | `reinhardt-urls`          | Функціональні та класові маршрути           |
+| Сервер              | `reinhardt-server`        | Реалізація HTTP сервера                     |
+| Middleware          | `reinhardt-dispatch`      | Ланцюжок middleware, диспетчеризація сигналів|
+| Конфігурація        | `reinhardt-conf`          | Управління налаштуваннями, завантаження середовища|
+| Команди             | `reinhardt-commands`      | CLI інструменти управління (startproject та ін.)|
+| Шорткати            | `reinhardt-shortcuts`     | Загальні утилітарні функції                 |
+| **База даних**      |                           |                                             |
+| ORM                 | `reinhardt-db`            | Інтеграція SeaQuery v1.0.0-rc               |
+| **Автентифікація**  |                           |                                             |
+| Auth                | `reinhardt-auth`          | JWT, Token, Session, Basic auth, моделі User|
+| **REST API**        |                           |                                             |
+| Серіалізатори       | `reinhardt-rest`          | Інтеграція serde/validator, ViewSets        |
+| **Форми**           |                           |                                             |
+| Форми               | `reinhardt-forms`         | Обробка та валідація форм                   |
+| **Розширені**       |                           |                                             |
+| Адмін-панель        | `reinhardt-admin`         | Інтерфейс адміністрування у стилі Django    |
+| Система плагінів    | `reinhardt-dentdelion`    | Статичні та WASM плагіни, CLI управління    |
+| Фонові завдання     | `reinhardt-tasks`         | Черги завдань (Redis, RabbitMQ, SQLite)     |
+| GraphQL             | `reinhardt-graphql`       | Генерація схем, підписки                    |
+| WebSockets          | `reinhardt-websockets`    | Комунікація в реальному часі                |
+| i18n                | `reinhardt-i18n`          | Підтримка багатомовності                    |
+| **Тестування**      |                           |                                             |
+| Утиліти тестування  | `reinhardt-test`          | Хелпери тестування, фікстури, TestContainers|
+
+**Детальні прапорці функцій у кожному крейті див. у [Посібнику з прапорців функцій](../FEATURE_FLAGS.md).**
+
+---
+
+## Документація
+
+- 📚 [Посібник початківця](../GETTING_STARTED.md) - Покрокове керівництво для початківців
+- 🎛️ [Посібник з прапорців функцій](../FEATURE_FLAGS.md) - Оптимізація збірки з гранулярним контролем функцій
+- 📖 [Довідник API](https://docs.rs/reinhardt) (Скоро)
+- 📝 [Підручники](../tutorials/) - Навчання на реальних застосунках
+
+**Для AI асистентів**: Див. [CLAUDE.md](../../CLAUDE.md) для специфічних стандартів кодування, рекомендацій з тестування та угод розробки.
+
+## 💬 Отримання допомоги
+
+Reinhardt — проєкт, керований спільнотою. Ось де можна отримати допомогу:
+
+- 💬 **Discord**: Приєднуйтесь до нашого Discord сервера для спілкування в реальному часі (скоро)
+- 💭 **GitHub Discussions**: [Ставте запитання та діліться ідеями](https://github.com/kent8192/reinhardt-rs/discussions)
+- 🐛 **Issues**: [Повідомляйте про помилки](https://github.com/kent8192/reinhardt-rs/issues)
+- 📖 **Документація**: [Читайте керівництва](../)
+
+Перед тим як поставити запитання, перевірте:
+
+- ✅ [Посібник початківця](../GETTING_STARTED.md)
+- ✅ [Приклади](../../examples/)
+- ✅ Існуючі GitHub Issues та Discussions
+
+## 🤝 Внесок у проєкт
+
+Ми любимо внески! Прочитайте [Посібник з внеску](../../CONTRIBUTING.md) для початку.
+
+**Швидкі посилання**:
+
+- [Налаштування розробки](../../CONTRIBUTING.md#development-setup)
+- [Керівництво з тестування](../../CONTRIBUTING.md#testing-guidelines)
+- [Керівництво з комітів](../../CONTRIBUTING.md#commit-guidelines)
+
+## Ліцензія
+
+Ліцензовано за однією з наступних ліцензій на ваш вибір:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) або http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) або http://opensource.org/licenses/MIT)
+
+### Атрибуція третіх сторін
+
+Цей проєкт натхненний:
+
+- [Django](https://www.djangoproject.com/) (Ліцензія BSD 3-Clause)
+- [Django REST Framework](https://www.django-rest-framework.org/) (Ліцензія BSD 3-Clause)
+- [FastAPI](https://fastapi.tiangolo.com/) (Ліцензія MIT)
+- [SQLAlchemy](https://www.sqlalchemy.org/) (Ліцензія MIT)
+
+Повну атрибуцію див. у [THIRD-PARTY-NOTICES](../../THIRD-PARTY-NOTICES).
+
+**Примітка:** Цей проєкт не пов'язаний і не схвалений Django Software Foundation, Encode OSS Ltd., Sebastián Ramírez (автор FastAPI) або Michael Bayer (автор SQLAlchemy).

--- a/docs/readme-langs/README_ZH_CN.md
+++ b/docs/readme-langs/README_ZH_CN.md
@@ -1,0 +1,1061 @@
+<div align="center">
+  <img src="../../branding/logo.png" alt="Reinhardt Logo" width="200"/>
+
+  <h1>Reinhardt</h1>
+
+  <h3>🦀 多石化电池内置</h3>
+
+  <p><strong>Rust的可组合全栈API框架</strong></p>
+  <p>使用Django的"电池内置"哲学的<em>全部</em>力量构建，<br/>
+  或只组合<em>你需要的</em>——你的选择，你的方式。</p>
+
+🌐 [English](../../README.md) | [日本語](README_JA.md) | **简体中文** | [繁體中文](README_ZH_TW.md) | [Русский](README_RU.md) | [Українська](README_UK.md) | [فارسی](README_FA.md) | [العربية](README_AR.md)
+
+[![Crates.io](https://img.shields.io/crates/v/reinhardt-web.svg)](https://crates.io/crates/reinhardt-web)
+[![Documentation](https://docs.rs/reinhardt-web/badge.svg)](https://docs.rs/reinhardt-web)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](../../LICENSE.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kent8192/reinhardt-web)
+
+</div>
+
+---
+
+## 📍 快速导航
+
+您可能在找:
+
+- 🚀 [快速开始](#快速开始) - 5分钟启动运行
+- 📦 [安装选项](#安装) - 选择你的风格: Micro、Standard 或 Full
+- 📚 [入门指南](../GETTING_STARTED.md) - 分步教程
+- 🎛️ [功能标志](../FEATURE_FLAGS.md) - 微调你的构建
+- 📖 [API文档](https://docs.rs/reinhardt-web) - 完整API参考
+- 💬 [社区与支持](#获取帮助) - 从社区获取帮助
+
+## 为什么选择Reinhardt?
+
+**Polylithic = Poly（多）+ Lithic（构建块）**
+与强迫你使用所有功能的单体框架不同，Reinhardt让你从独立的、经过良好测试的组件中组合你的完美技术栈。
+
+Reinhardt汇集了三个世界的精华:
+
+| 灵感来源           | 我们借鉴了什么                                         | 我们改进了什么                                      |
+|--------------------|--------------------------------------------------------|------------------------------------------------------|
+| 🐍 **Django**      | 电池内置哲学、ORM设计、管理面板                         | 可组合构建的功能标志、Rust的类型安全                  |
+| 🎯 **Django REST** | 序列化器、ViewSets、权限                                | 编译时验证、零成本抽象                               |
+| ⚡ **FastAPI**      | DI系统、自动OpenAPI                                     | 原生Rust性能、无运行时开销                           |
+| 🗄️ **SQLAlchemy** | QuerySet模式、关系处理                                  | 类型安全的查询构建器、编译时验证                      |
+
+**结果**: 一个Python开发者熟悉的框架，但拥有Rust的性能和安全保证。
+
+## ✨ 主要功能
+
+- **类型安全的ORM** 带编译时验证（SeaQuery v1.0.0-rc）
+- **强大的序列化器** 带自动验证（serde + validator）
+- **FastAPI风格的DI** 带类型安全的依赖注入和缓存
+- **ViewSets** 用于快速CRUD API开发
+- **多重认证**（JWT、Token、Session、Basic）带BaseUser/FullUser traits
+- **管理面板** 自动生成的模型管理界面
+- **管理命令** 用于迁移、静态文件等
+- **GraphQL和WebSocket** 支持实时应用
+- **分页、过滤、速率限制** 内置
+- **信号** 用于事件驱动架构
+
+完整列表请参阅[可用组件](#可用组件)，示例请参阅[入门指南](../GETTING_STARTED.md)。
+
+## 安装
+
+Reinhardt是一个模块化框架。选择你的起点:
+
+**关于Crate命名的说明:**
+主Reinhardt crate在crates.io上发布为`reinhardt-web`，但你在代码中使用`package`属性将其导入为`reinhardt`。
+
+### 默认: 全功能（电池内置）⚠️ 新默认
+
+零配置获取所有功能:
+
+```toml
+[dependencies]
+# 导入为'reinhardt'，发布为'reinhardt-web'
+# 默认启用所有功能（完整捆绑包）
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web" }
+```
+
+**包含:** Database、Auth、REST API、Admin、GraphQL、WebSockets、Cache、i18n、Mail、Sessions、Static Files、Storage
+
+**二进制大小**: ~50+ MB | **编译**: 较慢，但一切开箱即用
+
+然后在代码中使用:
+```rust
+use reinhardt::prelude::*;
+use reinhardt::{Request, Response, StatusCode};
+```
+
+### 选项1: 标准设置（平衡型）
+
+适用于不需要所有功能的大多数项目:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["standard"] }
+```
+
+**包含:** Core、Database（PostgreSQL）、REST API、Auth、Middleware、Pages（带SSR的WASM前端）
+
+**二进制大小**: ~20-30 MB | **编译**: 中等
+
+### 选项2: 微服务（最小设置）
+
+轻量快速，适合简单API:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+```
+
+**包含:** HTTP、路由、DI、参数提取、服务器
+
+**二进制大小**: ~5-10 MB | **编译**: 非常快
+
+### 选项3: 构建你的自定义技术栈
+
+只安装你需要的组件:
+
+```toml
+[dependencies]
+# 核心组件
+reinhardt-http = "0.1.0-alpha.1"
+reinhardt-urls = "0.1.0-alpha.1"
+
+# 可选: 数据库
+reinhardt-db = "0.1.0-alpha.1"
+
+# 可选: 认证
+reinhardt-auth = "0.1.0-alpha.1"
+
+# 可选: REST API功能
+reinhardt-rest = "0.1.0-alpha.1"
+
+# 可选: 管理面板
+reinhardt-admin = "0.1.0-alpha.1"
+
+# 可选: 高级功能
+reinhardt-graphql = "0.1.0-alpha.1"
+reinhardt-websockets = "0.1.0-alpha.1"
+```
+
+**📖 完整的可用crates和功能标志列表，请参阅[功能标志指南](../FEATURE_FLAGS.md)。**
+
+## 快速开始
+
+### 1. 安装Reinhardt管理工具
+
+```bash
+cargo install reinhardt-admin-cli
+```
+
+### 2. 创建新项目
+
+```bash
+# 创建RESTful API项目（默认）
+reinhardt-admin startproject my-api
+cd my-api
+```
+
+这将生成完整的项目结构:
+
+```
+my-api/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   ├── config.rs
+│   ├── apps.rs
+│   ├── config/
+│   │   ├── settings.rs
+│   │   ├── settings/
+│   │   │   ├── base.rs
+│   │   │   ├── local.rs
+│   │   │   ├── staging.rs
+│   │   │   └── production.rs
+│   │   ├── urls.rs
+│   │   └── apps.rs
+│   └── bin/
+│       └── manage.rs
+└── README.md
+```
+
+**备选方案: 创建reinhardt-pages项目（WASM + SSR）**
+
+用于带SSR的现代WASM前端:
+
+```bash
+# 创建pages项目
+reinhardt-admin startproject my-app --with-pages
+cd my-app
+
+# 安装WASM构建工具（仅首次）
+cargo make install-wasm-tools
+
+# 构建WASM并启动开发服务器
+cargo make dev
+# 访问 http://127.0.0.1:8000/
+```
+
+### 3. 运行开发服务器
+
+```bash
+# 使用manage命令
+cargo run --bin manage runserver
+
+# 服务器将在 http://127.0.0.1:8000 启动
+```
+
+**自动重载支持:**
+
+代码更改时自动重载（需要bacon）:
+
+```bash
+# 安装bacon
+cargo install --locked bacon
+
+# 带自动重载运行
+bacon runserver
+
+# 或使用cargo make
+cargo make watch
+
+# 用于测试
+bacon test
+```
+
+### 4. 创建你的第一个App
+
+```bash
+# 创建RESTful API app（默认）
+cargo run --bin manage startapp users
+
+# 或明确指定类型
+cargo run --bin manage startapp users --restful
+
+# 创建Pages app（WASM + SSR）
+cargo run --bin manage startapp dashboard --with-pages
+```
+
+这将创建app结构:
+
+```
+users/
+├── lib.rs
+├── models.rs
+├── models/
+├── views.rs
+├── views/
+├── serializers.rs
+├── serializers/
+├── admin.rs
+├── urls.rs
+└── tests.rs
+```
+
+### 5. 注册路由
+
+编辑你的app的`urls.rs`:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::list_users)
+		.endpoint(views::get_user)
+		.endpoint(views::create_user)
+}
+```
+
+在`src/config/urls.rs`中包含:
+
+```rust
+// src/config/urls.rs
+use reinhardt::prelude::*;
+use reinhardt::routes;
+
+#[routes]
+pub fn routes() -> ServerRouter {
+	ServerRouter::new()
+		.mount("/api/", users::urls::url_patterns())
+}
+```
+
+`#[routes]`属性宏通过`inventory` crate自动向框架注册此函数以供发现。
+
+**注意:** `reinhardt::prelude`包含常用类型。主要导出包括:
+
+**始终可用:**
+- 核心路由和视图: `Router`、`DefaultRouter`、`ServerRouter`、`View`、`ListView`、`DetailView`
+- ViewSets: `ViewSet`、`ModelViewSet`、`ReadOnlyModelViewSet`
+- HTTP: `StatusCode`
+
+**功能依赖:**
+- **`core`功能**: `Request`、`Response`、`Handler`、`Middleware`、信号（`post_save`、`pre_save`等）
+- **`database`功能**: `Model`、`DatabaseConnection`、`F`、`Q`、`Transaction`、`atomic`、数据库函数（`Concat`、`Upper`、`Lower`、`Now`、`CurrentDate`）、窗口函数（`Window`、`RowNumber`、`Rank`、`DenseRank`）、约束（`UniqueConstraint`、`CheckConstraint`、`ForeignKeyConstraint`）
+- **`auth`功能**: `User`、`UserManager`、`GroupManager`、`Permission`、`ObjectPermission`
+- **`minimal`、`standard`或`di`功能**: `Body`、`Cookie`、`Header`、`Json`、`Path`、`Query`
+- **`rest`功能**: 序列化器、解析器、分页、限流、版本控制
+- **`admin`功能**: 管理面板组件
+- **`cache`功能**: `Cache`、`InMemoryCache`
+- **`sessions`功能**: `Session`、`AuthenticationMiddleware`
+
+完整列表请参阅[功能标志指南](../FEATURE_FLAGS.md)。
+
+完整的分步指南请参阅[入门指南](../GETTING_STARTED.md)。
+
+## 🎓 通过示例学习
+
+### 使用数据库
+
+在`settings/base.toml`中配置数据库:
+
+```toml
+debug = true
+secret_key = "your-secret-key-for-development"
+
+[database]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "mydb"
+user = "postgres"
+password = "postgres"
+```
+
+设置在`src/config/settings.rs`中自动加载:
+
+```rust
+// src/config/settings.rs
+use reinhardt::conf::settings::builder::SettingsBuilder;
+use reinhardt::conf::settings::profile::Profile;
+use reinhardt::conf::settings::sources::{DefaultSource, LowPriorityEnvSource, TomlFileSource};
+use reinhardt::core::Settings;
+use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub fn get_settings() -> Settings {
+	let profile_str = env::var("REINHARDT_ENV").unwrap_or_else(|_| "local".to_string());
+	let profile = Profile::from_str(&profile_str).unwrap_or(Profile::Development);
+
+	let base_dir = env::current_dir().expect("Failed to get current directory");
+	let settings_dir = base_dir.join("settings");
+
+	let merged = SettingsBuilder::new()
+		.profile(profile)
+		.add_source(
+			DefaultSource::new()
+				.with_value("debug", serde_json::Value::Bool(false))
+				.with_value("language_code", serde_json::Value::String("en-us".to_string()))
+				.with_value("time_zone", serde_json::Value::String("UTC".to_string()))
+		)
+		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
+		.add_source(TomlFileSource::new(settings_dir.join(format!("{}.toml", profile_str))))
+		.build()
+		.expect("Failed to build settings");
+
+	merged.into_typed().expect("Failed to convert settings to Settings struct")
+}
+```
+
+**环境变量源:**
+
+Reinhardt提供两种具有不同优先级的环境变量源:
+
+- **`EnvSource`**（优先级: 100）- 覆盖TOML文件的高优先级环境变量
+  ```rust
+  .add_source(EnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+- **`LowPriorityEnvSource`**（优先级: 40）- 回退到TOML文件的低优先级环境变量
+  ```rust
+  .add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+**优先级顺序**:
+- 使用`EnvSource`: 环境变量 > `{profile}.toml` > `base.toml` > 默认值
+- 使用`LowPriorityEnvSource`（如上所示）: `{profile}.toml` > `base.toml` > 环境变量 > 默认值
+
+当环境变量应始终优先时选择`EnvSource`（例如生产部署）。
+当TOML文件应为主要配置源时选择`LowPriorityEnvSource`（例如开发）。
+
+详情请参阅[设置文档](../SETTINGS_DOCUMENT.md)。
+
+**使用内置DefaultUser:**
+
+Reinhardt提供即用型`DefaultUser`实现（需要`argon2-hasher`功能）:
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// 将DefaultUser重新导出为你的app的User
+pub type User = DefaultUser;
+
+// DefaultUser包含:
+// - id: Uuid（主键）
+// - username: String
+// - email: String
+// - password_hash: Option<String>
+// - first_name: String
+// - last_name: String
+// - is_active: bool
+// - is_staff: bool
+// - is_superuser: bool
+// - last_login: Option<DateTime<Utc>>
+// - date_joined: DateTime<Utc>
+
+// DefaultUser实现:
+// - BaseUser trait（认证方法）
+// - FullUser trait（完整用户信息）
+// - PermissionsMixin trait（权限管理）
+// - Model trait（数据库操作）
+```
+
+**定义自定义用户模型:**
+
+如果需要自定义字段，定义你自己的模型:
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Utc};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: i64,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	#[field(max_length = 100)]
+	pub username: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(auto_now_add = true)]
+	pub created_at: DateTime<Utc>,
+
+	// 添加自定义字段
+	#[field(max_length = 50, null = true)]
+	pub phone_number: Option<String>,
+}
+```
+
+**Model属性宏:**
+
+`#[model(...)]`属性自动生成:
+- `Model` trait的实现（包含`#[derive(Model)]`功能）
+- 类型安全的字段访问器: `User::field_email()`、`User::field_username()`等
+- 全局模型注册表注册
+- 复合主键支持
+
+**注意:** 使用`#[model(...)]`时，不需要单独添加`#[derive(Model)]`，
+它由`#[model(...)]`属性自动应用。
+
+**字段属性:**
+- `#[field(primary_key = true)]` - 标记为主键
+- `#[field(max_length = 255)]` - 设置字符串字段的最大长度
+- `#[field(default = value)]` - 设置默认值
+- `#[field(auto_now_add = true)]` - 创建时自动填充时间戳
+- `#[field(auto_now = true)]` - 保存时自动更新时间戳
+- `#[field(null = true)]` - 允许NULL值
+- `#[field(unique = true)]` - 强制唯一性约束
+
+完整的字段属性列表请参阅[字段属性指南](../field_attributes.md)。
+
+生成的字段访问器在查询中启用类型安全的字段引用:
+
+```rust
+// 由#[model(...)]为DefaultUser生成
+impl DefaultUser {
+	pub const fn field_id() -> FieldRef<DefaultUser, Uuid> { FieldRef::new("id") }
+	pub const fn field_username() -> FieldRef<DefaultUser, String> { FieldRef::new("username") }
+	pub const fn field_email() -> FieldRef<DefaultUser, String> { FieldRef::new("email") }
+	pub const fn field_is_active() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_active") }
+	pub const fn field_is_staff() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_staff") }
+	pub const fn field_date_joined() -> FieldRef<DefaultUser, DateTime<Utc>> { FieldRef::new("date_joined") }
+	// ... 其他字段
+}
+```
+
+**高级查询示例:**
+
+```rust
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// 使用类型安全字段引用的Django风格F/Q对象查询
+async fn complex_user_query() -> Result<Vec<DefaultUser>, Box<dyn std::error::Error>> {
+	// 使用类型安全字段引用的Q对象（使用生成的字段访问器）
+	let active_query = Q::new()
+		.field("is_active").eq(true)
+		.and(Q::new().field("date_joined").gte(Now::new()));
+
+	// 使用类型安全字段引用的数据库函数
+	let email_lower = Lower::new(DefaultUser::field_email().into());
+	let username_upper = Upper::new(DefaultUser::field_username().into());
+
+	// 使用字段访问器的聚合
+	let user_count = Aggregate::count(DefaultUser::field_id().into());
+	let latest_joined = Aggregate::max(DefaultUser::field_date_joined().into());
+
+	// 用于排名的窗口函数
+	let rank_by_join_date = Window::new()
+		.partition_by(vec![DefaultUser::field_is_active().into()])
+		.order_by(vec![(DefaultUser::field_date_joined().into(), "DESC")])
+		.function(RowNumber::new());
+
+	todo!("Execute query with these components")
+}
+
+// 事务支持
+async fn create_user_with_transaction(
+	conn: &DatabaseConnection,
+	user_data: CreateUserRequest
+) -> Result<User, Box<dyn std::error::Error>> {
+	// 出错时自动回滚的事务
+	transaction(conn, |_tx| async move {
+		let user = User::create(user_data).await?;
+		log_user_creation(&user).await?;
+		Ok(user)
+	}).await
+}
+```
+
+**注意**: Reinhardt使用[SeaQuery v1.0.0-rc](https://crates.io/crates/sea-query)进行SQL操作。`#[derive(Model)]`宏自动生成Model trait实现、类型安全的字段访问器和全局模型注册表注册。
+
+在`src/config/apps.rs`中注册:
+
+```rust
+// src/config/apps.rs
+use reinhardt::installed_apps;
+
+// installed_apps!宏生成:
+// - 每个app变体的InstalledApp枚举
+// - 转换trait的实现（From、Into、Display）
+// - app配置和发现的注册表
+//
+// 注意: 与Django的INSTALLED_APPS不同，此宏仅用于用户apps。
+// 内置框架功能（auth、sessions、admin等）通过
+// Cargo功能标志启用，而不是通过installed_apps!。
+//
+// 示例:
+// [dependencies]
+// reinhardt = { version = "0.1", features = ["auth", "sessions", "admin"] }
+//
+// 这启用:
+// - 迁移、管理面板等的自动app发现
+// - 代码中的类型安全app引用
+// - 集中的app配置
+installed_apps! {
+	users: "users",
+}
+
+pub fn get_installed_apps() -> Vec<String> {
+	InstalledApp::all_apps()
+}
+```
+
+### 使用认证
+
+Reinhardt提供Django风格的用户模型，带有`BaseUser`和`FullUser` traits，以及通过`UserManager`的全面用户管理。
+
+**注意:** Reinhardt包含内置的`DefaultUser`实现。你可以直接使用它或如下所示定义自己的用户模型。
+
+**用户管理示例:**
+
+```rust
+use reinhardt::prelude::*;
+
+// 使用UserManager创建和管理用户
+async fn manage_users() -> Result<(), Box<dyn std::error::Error>> {
+	let hasher = Argon2Hasher::new();
+	let user_manager = UserManager::new(hasher);
+
+	// 创建新用户
+	let user = user_manager.create_user(CreateUserData {
+		username: "alice".to_string(),
+		email: "alice@example.com".to_string(),
+		password: "secure_password".to_string(),
+		first_name: Some("Alice".to_string()),
+		last_name: Some("Smith".to_string()),
+	}).await?;
+
+	// 更新用户信息
+	user_manager.update_user(user.id, UpdateUserData {
+		email: Some("alice.smith@example.com".to_string()),
+		is_active: Some(true),
+		..Default::default()
+	}).await?;
+
+	// 管理组和权限
+	let group_manager = GroupManager::new();
+	let editors = group_manager.create_group(CreateGroupData {
+		name: "editors".to_string(),
+	}).await?;
+
+	// 分配对象级权限
+	let permission = ObjectPermission::new("edit", user.id, article.id);
+	let perm_checker = ObjectPermissionChecker::new();
+	if perm_checker.has_permission(&user, "edit", &article).await? {
+		// 用户可以编辑文章
+	}
+
+	Ok(())
+}
+```
+
+在`users/models.rs`中使用内置的`DefaultUser`:
+
+```rust
+// users/models.rs
+use reinhardt::DefaultUser;
+
+// 将DefaultUser重新导出为你的User类型
+pub type User = DefaultUser;
+
+// DefaultUser已实现:
+// - BaseUser trait（认证方法）
+// - FullUser trait（username、email、first_name、last_name等）
+// - PermissionsMixin trait（权限管理）
+// - Model trait（数据库操作）
+```
+
+**对于自定义用户模型:**
+
+如果需要超出DefaultUser的额外字段，定义你自己的:
+
+```rust
+// users/models.rs
+use reinhardt::auth::{BaseUser, FullUser, PermissionsMixin};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+use serde::{Serialize, Deserialize};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: Uuid,
+
+	#[field(max_length = 150)]
+	pub username: String,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	pub password_hash: Option<String>,
+
+	#[field(max_length = 150)]
+	pub first_name: String,
+
+	#[field(max_length = 150)]
+	pub last_name: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(default = false)]
+	pub is_staff: bool,
+
+	#[field(default = false)]
+	pub is_superuser: bool,
+
+	pub last_login: Option<DateTime<Utc>>,
+
+	#[field(auto_now_add = true)]
+	pub date_joined: DateTime<Utc>,
+
+	// 自定义字段
+	#[field(max_length = 20, null = true)]
+	pub phone_number: Option<String>,
+}
+
+impl BaseUser for CustomUser {
+	type PrimaryKey = Uuid;
+
+	fn get_username_field() -> &'static str { "username" }
+	fn get_username(&self) -> &str { &self.username }
+	fn password_hash(&self) -> Option<&str> { self.password_hash.as_deref() }
+	fn set_password_hash(&mut self, hash: String) { self.password_hash = Some(hash); }
+	fn last_login(&self) -> Option<DateTime<Utc>> { self.last_login }
+	fn set_last_login(&mut self, time: DateTime<Utc>) { self.last_login = Some(time); }
+	fn is_active(&self) -> bool { self.is_active }
+}
+
+impl FullUser for CustomUser {
+	fn username(&self) -> &str { &self.username }
+	fn email(&self) -> &str { &self.email }
+	fn first_name(&self) -> &str { &self.first_name }
+	fn last_name(&self) -> &str { &self.last_name }
+	fn is_staff(&self) -> bool { self.is_staff }
+	fn is_superuser(&self) -> bool { self.is_superuser }
+	fn date_joined(&self) -> DateTime<Utc> { self.date_joined }
+}
+```
+
+在app的`views/profile.rs`中使用JWT认证:
+
+```rust
+// users/views/profile.rs
+use reinhardt::auth::{JwtAuth, BaseUser};
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+use crate::models::User;
+
+#[get("/profile", name = "get_profile")]
+pub async fn get_profile(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// 从Authorization头提取JWT令牌
+	let auth_header = req.headers.get("authorization")
+		.and_then(|h| h.to_str().ok())
+		.ok_or("Missing Authorization header")?;
+
+	let token = auth_header.strip_prefix("Bearer ")
+		.ok_or("Invalid Authorization header format")?;
+
+	// 验证令牌并获取用户ID
+	let jwt_auth = JwtAuth::new(b"your-secret-key");
+	let claims = jwt_auth.verify_token(token)?;
+
+	// 使用claims.user_id从数据库加载用户
+	let user = User::find_by_id(&db, &claims.user_id).await?;
+
+	// 检查用户是否活跃
+	if !user.is_active() {
+		return Err("User account is inactive".into());
+	}
+
+	// 返回用户配置文件为JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+### 端点定义
+
+Reinhardt使用HTTP方法装饰器定义端点:
+
+#### HTTP方法装饰器
+
+使用`#[get]`、`#[post]`、`#[put]`、`#[delete]`定义路由:
+
+```rust
+use reinhardt::{get, post, Request, Response, ViewResult};
+use serde_json::json;
+
+#[get("/")]
+pub async fn hello(_req: Request) -> ViewResult<Response> {
+	Ok(Response::ok().with_body("Hello, World!"))
+}
+
+#[post("/users")]
+pub async fn create_user(_req: Request) -> ViewResult<Response> {
+	let body = json!({"status": "created"});
+	Response::ok().with_json(&body).map_err(Into::into)
+}
+```
+
+**功能:**
+- 编译时路径验证
+- 简洁语法
+- 自动HTTP方法绑定
+- 通过`#[inject]`支持依赖注入
+
+#### 使用依赖注入
+
+将HTTP方法装饰器与`#[inject]`结合进行自动依赖注入:
+
+```rust
+use reinhardt::{get, Request, Response, StatusCode, ViewResult};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,  // 自动注入
+) -> ViewResult<Response> {
+	let id = req.path_params.get("id")
+		.ok_or("Missing id")?
+		.parse::<i64>()?;
+
+	// 使用注入的数据库连接
+	let user = db.query("SELECT * FROM users WHERE id = $1")
+		.bind(id)
+		.fetch_one()
+		.await?;
+
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+**依赖注入功能:**
+- 通过`#[inject]`属性自动依赖注入
+- 通过`#[inject(cache = false)]`控制缓存
+- FastAPI启发的依赖注入系统
+- 与HTTP方法装饰器无缝协作
+
+**返回类型:**
+
+所有视图函数使用`ViewResult<T>`作为返回类型:
+
+```rust
+use reinhardt::ViewResult;  // 预定义结果类型
+```
+
+### 使用参数提取
+
+在app的`views/user.rs`中:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// 从请求提取路径参数
+	let id = req.path_params.get("id")
+		.ok_or("Missing id parameter")?
+		.parse::<i64>()
+		.map_err(|_| "Invalid id format")?;
+
+	// 提取查询参数（例如 ?include_inactive=true）
+	let include_inactive = req.query_params.get("include_inactive")
+		.and_then(|v| v.parse::<bool>().ok())
+		.unwrap_or(false);
+
+	// 使用注入的连接从数据库获取用户
+	let user = User::find_by_id(&db, id).await?;
+
+	// 如需检查活跃状态
+	if !include_inactive && !user.is_active {
+		return Err("User is inactive".into());
+	}
+
+	// 返回JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+在`urls.rs`中注册带路径参数的路由:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::get_user)  // 路径在#[get("/users/{id}/")]中定义
+}
+```
+
+### 使用序列化器和验证
+
+在app的`serializers/user.rs`中:
+
+```rust
+// users/serializers/user.rs
+use serde::{Serialize, Deserialize};
+use validator::Validate;
+
+#[derive(Serialize, Deserialize, Validate)]
+pub struct CreateUserRequest {
+	#[validate(email)]
+	pub email: String,
+	#[validate(length(min = 3, max = 50))]
+	pub username: String,
+	#[validate(length(min = 8))]
+	pub password: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserResponse {
+	pub id: i64,
+	pub username: String,
+	pub email: String,
+	pub is_active: bool,
+}
+
+impl From<User> for UserResponse {
+	fn from(user: User) -> Self {
+		UserResponse {
+			id: user.id,
+			username: user.username,
+			email: user.email,
+			is_active: user.is_active,
+		}
+	}
+}
+```
+
+在app的`views/user.rs`中:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, post};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use crate::serializers::{CreateUserRequest, UserResponse};
+use validator::Validate;
+use std::sync::Arc;
+
+#[post("/users", name = "create_user")]
+pub async fn create_user(
+	mut req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// 解析请求体
+	let body_bytes = std::mem::take(&mut req.body);
+	let create_req: CreateUserRequest = serde_json::from_slice(&body_bytes)?;
+
+	// 验证请求
+	create_req.validate()?;
+
+	// 创建用户
+	let mut user = User {
+		id: 0, // 将由数据库设置
+		username: create_req.username,
+		email: create_req.email,
+		password_hash: None,
+		is_active: true,
+		created_at: Utc::now(),
+	};
+
+	// 使用BaseUser trait哈希密码
+	user.set_password(&create_req.password)?;
+
+	// 使用注入的连接保存到数据库
+	user.save(&db).await?;
+
+	// 转换为响应
+	let response_data = UserResponse::from(user);
+	let json = serde_json::to_string(&response_data)?;
+
+	Ok(Response::new(StatusCode::CREATED)
+		.with_body(json))
+}
+```
+
+## 可用组件
+
+Reinhardt提供可混合搭配的模块化组件:
+
+| 组件               | Crate名称                  | 功能                                        |
+|---------------------|---------------------------|---------------------------------------------|
+| **核心**            |                           |                                             |
+| 核心类型            | `reinhardt-core`          | 核心traits、类型、宏（Model、endpoint）     |
+| HTTP和路由          | `reinhardt-http`          | Request/Response、HTTP处理                  |
+| URL路由             | `reinhardt-urls`          | 函数式和类式路由                            |
+| 服务器              | `reinhardt-server`        | HTTP服务器实现                              |
+| 中间件              | `reinhardt-dispatch`      | 中间件链、信号分发                          |
+| 配置                | `reinhardt-conf`          | 设置管理、环境加载                          |
+| 命令                | `reinhardt-commands`      | 管理CLI工具（startproject等）               |
+| 快捷方式            | `reinhardt-shortcuts`     | 常用工具函数                                |
+| **数据库**          |                           |                                             |
+| ORM                 | `reinhardt-db`            | SeaQuery v1.0.0-rc集成                      |
+| **认证**            |                           |                                             |
+| Auth                | `reinhardt-auth`          | JWT、Token、Session、Basic认证、用户模型   |
+| **REST API**        |                           |                                             |
+| 序列化器            | `reinhardt-rest`          | serde/validator集成、ViewSets               |
+| **表单**            |                           |                                             |
+| 表单                | `reinhardt-forms`         | 表单处理和验证                              |
+| **高级功能**        |                           |                                             |
+| 管理面板            | `reinhardt-admin`         | Django风格管理界面                          |
+| 插件系统            | `reinhardt-dentdelion`    | 静态和WASM插件支持、CLI管理                 |
+| 后台任务            | `reinhardt-tasks`         | 任务队列（Redis、RabbitMQ、SQLite）         |
+| GraphQL             | `reinhardt-graphql`       | Schema生成、订阅                            |
+| WebSockets          | `reinhardt-websockets`    | 实时通信                                    |
+| i18n                | `reinhardt-i18n`          | 多语言支持                                  |
+| **测试**            |                           |                                             |
+| 测试工具            | `reinhardt-test`          | 测试助手、fixtures、TestContainers          |
+
+**各crate内的详细功能标志，请参阅[功能标志指南](../FEATURE_FLAGS.md)。**
+
+---
+
+## 文档
+
+- 📚 [入门指南](../GETTING_STARTED.md) - 初学者分步教程
+- 🎛️ [功能标志指南](../FEATURE_FLAGS.md) - 通过细粒度功能控制优化构建
+- 📖 [API参考](https://docs.rs/reinhardt)（即将推出）
+- 📝 [教程](../tutorials/) - 通过构建真实应用学习
+
+**AI助手请参阅**: 项目特定的编码标准、测试指南和开发约定请参阅[CLAUDE.md](../../CLAUDE.md)。
+
+## 💬 获取帮助
+
+Reinhardt是一个社区驱动的项目。以下是获取帮助的途径:
+
+- 💬 **Discord**: 加入我们的Discord服务器进行实时聊天（即将推出）
+- 💭 **GitHub Discussions**: [提问和分享想法](https://github.com/kent8192/reinhardt-rs/discussions)
+- 🐛 **Issues**: [报告bug](https://github.com/kent8192/reinhardt-rs/issues)
+- 📖 **文档**: [阅读指南](../)
+
+提问前，请查看:
+
+- ✅ [入门指南](../GETTING_STARTED.md)
+- ✅ [Examples](../../examples/)
+- ✅ 现有的GitHub Issues和Discussions
+
+## 🤝 贡献
+
+我们欢迎贡献！请阅读[贡献指南](../../CONTRIBUTING.md)开始。
+
+**快速链接**:
+
+- [开发设置](../../CONTRIBUTING.md#development-setup)
+- [测试指南](../../CONTRIBUTING.md#testing-guidelines)
+- [提交指南](../../CONTRIBUTING.md#commit-guidelines)
+
+## 许可证
+
+双重许可，可选择以下之一:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+由您选择。
+
+### 第三方归属
+
+本项目受以下项目启发:
+
+- [Django](https://www.djangoproject.com/)（BSD 3-Clause许可证）
+- [Django REST Framework](https://www.django-rest-framework.org/)（BSD 3-Clause许可证）
+- [FastAPI](https://fastapi.tiangolo.com/)（MIT许可证）
+- [SQLAlchemy](https://www.sqlalchemy.org/)（MIT许可证）
+
+完整归属请参阅[THIRD-PARTY-NOTICES](../../THIRD-PARTY-NOTICES)。
+
+**注意:** 本项目不隶属于Django Software Foundation、Encode OSS Ltd.、Sebastián Ramírez（FastAPI作者）或Michael Bayer（SQLAlchemy作者），也未获得其认可。

--- a/docs/readme-langs/README_ZH_TW.md
+++ b/docs/readme-langs/README_ZH_TW.md
@@ -1,0 +1,1061 @@
+<div align="center">
+  <img src="../../branding/logo.png" alt="Reinhardt Logo" width="200"/>
+
+  <h1>Reinhardt</h1>
+
+  <h3>🦀 多石化電池內建</h3>
+
+  <p><strong>Rust的可組合全端API框架</strong></p>
+  <p>使用Django的「電池內建」哲學的<em>全部</em>力量構建，<br/>
+  或只組合<em>你需要的</em>——你的選擇，你的方式。</p>
+
+🌐 [English](../../README.md) | [日本語](README_JA.md) | [简体中文](README_ZH_CN.md) | **繁體中文** | [Русский](README_RU.md) | [Українська](README_UK.md) | [فارسی](README_FA.md) | [العربية](README_AR.md)
+
+[![Crates.io](https://img.shields.io/crates/v/reinhardt-web.svg)](https://crates.io/crates/reinhardt-web)
+[![Documentation](https://docs.rs/reinhardt-web/badge.svg)](https://docs.rs/reinhardt-web)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](../../LICENSE.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kent8192/reinhardt-web)
+
+</div>
+
+---
+
+## 📍 快速導航
+
+您可能在找:
+
+- 🚀 [快速開始](#快速開始) - 5分鐘啟動運行
+- 📦 [安裝選項](#安裝) - 選擇你的風格: Micro、Standard 或 Full
+- 📚 [入門指南](../GETTING_STARTED.md) - 分步教學
+- 🎛️ [功能旗標](../FEATURE_FLAGS.md) - 微調你的構建
+- 📖 [API文檔](https://docs.rs/reinhardt-web) - 完整API參考
+- 💬 [社群與支援](#取得幫助) - 從社群獲取幫助
+
+## 為什麼選擇Reinhardt?
+
+**Polylithic = Poly（多）+ Lithic（構建塊）**
+與強迫你使用所有功能的單體框架不同，Reinhardt讓你從獨立的、經過良好測試的元件中組合你的完美技術棧。
+
+Reinhardt匯集了三個世界的精華:
+
+| 靈感來源           | 我們借鑒了什麼                                         | 我們改進了什麼                                      |
+|--------------------|--------------------------------------------------------|------------------------------------------------------|
+| 🐍 **Django**      | 電池內建哲學、ORM設計、管理面板                         | 可組合構建的功能旗標、Rust的型別安全                  |
+| 🎯 **Django REST** | 序列化器、ViewSets、權限                                | 編譯時驗證、零成本抽象                               |
+| ⚡ **FastAPI**      | DI系統、自動OpenAPI                                     | 原生Rust效能、無執行時開銷                           |
+| 🗄️ **SQLAlchemy** | QuerySet模式、關聯處理                                  | 型別安全的查詢建構器、編譯時驗證                      |
+
+**結果**: 一個Python開發者熟悉的框架，但擁有Rust的效能和安全保證。
+
+## ✨ 主要功能
+
+- **型別安全的ORM** 帶編譯時驗證（SeaQuery v1.0.0-rc）
+- **強大的序列化器** 帶自動驗證（serde + validator）
+- **FastAPI風格的DI** 帶型別安全的依賴注入和快取
+- **ViewSets** 用於快速CRUD API開發
+- **多重認證**（JWT、Token、Session、Basic）帶BaseUser/FullUser traits
+- **管理面板** 自動生成的模型管理介面
+- **管理命令** 用於遷移、靜態檔案等
+- **GraphQL和WebSocket** 支援即時應用
+- **分頁、過濾、速率限制** 內建
+- **訊號** 用於事件驅動架構
+
+完整列表請參閱[可用元件](#可用元件)，範例請參閱[入門指南](../GETTING_STARTED.md)。
+
+## 安裝
+
+Reinhardt是一個模組化框架。選擇你的起點:
+
+**關於Crate命名的說明:**
+主Reinhardt crate在crates.io上發布為`reinhardt-web`，但你在程式碼中使用`package`屬性將其匯入為`reinhardt`。
+
+### 預設: 全功能（電池內建）⚠️ 新預設
+
+零配置獲取所有功能:
+
+```toml
+[dependencies]
+# 匯入為'reinhardt'，發布為'reinhardt-web'
+# 預設啟用所有功能（完整套裝）
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web" }
+```
+
+**包含:** Database、Auth、REST API、Admin、GraphQL、WebSockets、Cache、i18n、Mail、Sessions、Static Files、Storage
+
+**二進位大小**: ~50+ MB | **編譯**: 較慢，但一切開箱即用
+
+然後在程式碼中使用:
+```rust
+use reinhardt::prelude::*;
+use reinhardt::{Request, Response, StatusCode};
+```
+
+### 選項1: 標準設定（平衡型）
+
+適用於不需要所有功能的大多數專案:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["standard"] }
+```
+
+**包含:** Core、Database（PostgreSQL）、REST API、Auth、Middleware、Pages（帶SSR的WASM前端）
+
+**二進位大小**: ~20-30 MB | **編譯**: 中等
+
+### 選項2: 微服務（最小設定）
+
+輕量快速，適合簡單API:
+
+```toml
+[dependencies]
+reinhardt = { version = "0.1.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+```
+
+**包含:** HTTP、路由、DI、參數提取、伺服器
+
+**二進位大小**: ~5-10 MB | **編譯**: 非常快
+
+### 選項3: 構建你的自訂技術棧
+
+只安裝你需要的元件:
+
+```toml
+[dependencies]
+# 核心元件
+reinhardt-http = "0.1.0-alpha.1"
+reinhardt-urls = "0.1.0-alpha.1"
+
+# 可選: 資料庫
+reinhardt-db = "0.1.0-alpha.1"
+
+# 可選: 認證
+reinhardt-auth = "0.1.0-alpha.1"
+
+# 可選: REST API功能
+reinhardt-rest = "0.1.0-alpha.1"
+
+# 可選: 管理面板
+reinhardt-admin = "0.1.0-alpha.1"
+
+# 可選: 進階功能
+reinhardt-graphql = "0.1.0-alpha.1"
+reinhardt-websockets = "0.1.0-alpha.1"
+```
+
+**📖 完整的可用crates和功能旗標列表，請參閱[功能旗標指南](../FEATURE_FLAGS.md)。**
+
+## 快速開始
+
+### 1. 安裝Reinhardt管理工具
+
+```bash
+cargo install reinhardt-admin-cli
+```
+
+### 2. 建立新專案
+
+```bash
+# 建立RESTful API專案（預設）
+reinhardt-admin startproject my-api
+cd my-api
+```
+
+這將生成完整的專案結構:
+
+```
+my-api/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   ├── config.rs
+│   ├── apps.rs
+│   ├── config/
+│   │   ├── settings.rs
+│   │   ├── settings/
+│   │   │   ├── base.rs
+│   │   │   ├── local.rs
+│   │   │   ├── staging.rs
+│   │   │   └── production.rs
+│   │   ├── urls.rs
+│   │   └── apps.rs
+│   └── bin/
+│       └── manage.rs
+└── README.md
+```
+
+**備選方案: 建立reinhardt-pages專案（WASM + SSR）**
+
+用於帶SSR的現代WASM前端:
+
+```bash
+# 建立pages專案
+reinhardt-admin startproject my-app --with-pages
+cd my-app
+
+# 安裝WASM構建工具（僅首次）
+cargo make install-wasm-tools
+
+# 構建WASM並啟動開發伺服器
+cargo make dev
+# 訪問 http://127.0.0.1:8000/
+```
+
+### 3. 執行開發伺服器
+
+```bash
+# 使用manage命令
+cargo run --bin manage runserver
+
+# 伺服器將在 http://127.0.0.1:8000 啟動
+```
+
+**自動重載支援:**
+
+程式碼變更時自動重載（需要bacon）:
+
+```bash
+# 安裝bacon
+cargo install --locked bacon
+
+# 帶自動重載執行
+bacon runserver
+
+# 或使用cargo make
+cargo make watch
+
+# 用於測試
+bacon test
+```
+
+### 4. 建立你的第一個App
+
+```bash
+# 建立RESTful API app（預設）
+cargo run --bin manage startapp users
+
+# 或明確指定類型
+cargo run --bin manage startapp users --restful
+
+# 建立Pages app（WASM + SSR）
+cargo run --bin manage startapp dashboard --with-pages
+```
+
+這將建立app結構:
+
+```
+users/
+├── lib.rs
+├── models.rs
+├── models/
+├── views.rs
+├── views/
+├── serializers.rs
+├── serializers/
+├── admin.rs
+├── urls.rs
+└── tests.rs
+```
+
+### 5. 註冊路由
+
+編輯你的app的`urls.rs`:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::list_users)
+		.endpoint(views::get_user)
+		.endpoint(views::create_user)
+}
+```
+
+在`src/config/urls.rs`中包含:
+
+```rust
+// src/config/urls.rs
+use reinhardt::prelude::*;
+use reinhardt::routes;
+
+#[routes]
+pub fn routes() -> ServerRouter {
+	ServerRouter::new()
+		.mount("/api/", users::urls::url_patterns())
+}
+```
+
+`#[routes]`屬性巨集透過`inventory` crate自動向框架註冊此函數以供發現。
+
+**注意:** `reinhardt::prelude`包含常用型別。主要匯出包括:
+
+**始終可用:**
+- 核心路由和視圖: `Router`、`DefaultRouter`、`ServerRouter`、`View`、`ListView`、`DetailView`
+- ViewSets: `ViewSet`、`ModelViewSet`、`ReadOnlyModelViewSet`
+- HTTP: `StatusCode`
+
+**功能依賴:**
+- **`core`功能**: `Request`、`Response`、`Handler`、`Middleware`、訊號（`post_save`、`pre_save`等）
+- **`database`功能**: `Model`、`DatabaseConnection`、`F`、`Q`、`Transaction`、`atomic`、資料庫函數（`Concat`、`Upper`、`Lower`、`Now`、`CurrentDate`）、視窗函數（`Window`、`RowNumber`、`Rank`、`DenseRank`）、約束（`UniqueConstraint`、`CheckConstraint`、`ForeignKeyConstraint`）
+- **`auth`功能**: `User`、`UserManager`、`GroupManager`、`Permission`、`ObjectPermission`
+- **`minimal`、`standard`或`di`功能**: `Body`、`Cookie`、`Header`、`Json`、`Path`、`Query`
+- **`rest`功能**: 序列化器、解析器、分頁、限流、版本控制
+- **`admin`功能**: 管理面板元件
+- **`cache`功能**: `Cache`、`InMemoryCache`
+- **`sessions`功能**: `Session`、`AuthenticationMiddleware`
+
+完整列表請參閱[功能旗標指南](../FEATURE_FLAGS.md)。
+
+完整的分步指南請參閱[入門指南](../GETTING_STARTED.md)。
+
+## 🎓 透過範例學習
+
+### 使用資料庫
+
+在`settings/base.toml`中配置資料庫:
+
+```toml
+debug = true
+secret_key = "your-secret-key-for-development"
+
+[database]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "mydb"
+user = "postgres"
+password = "postgres"
+```
+
+設定在`src/config/settings.rs`中自動載入:
+
+```rust
+// src/config/settings.rs
+use reinhardt::conf::settings::builder::SettingsBuilder;
+use reinhardt::conf::settings::profile::Profile;
+use reinhardt::conf::settings::sources::{DefaultSource, LowPriorityEnvSource, TomlFileSource};
+use reinhardt::core::Settings;
+use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub fn get_settings() -> Settings {
+	let profile_str = env::var("REINHARDT_ENV").unwrap_or_else(|_| "local".to_string());
+	let profile = Profile::from_str(&profile_str).unwrap_or(Profile::Development);
+
+	let base_dir = env::current_dir().expect("Failed to get current directory");
+	let settings_dir = base_dir.join("settings");
+
+	let merged = SettingsBuilder::new()
+		.profile(profile)
+		.add_source(
+			DefaultSource::new()
+				.with_value("debug", serde_json::Value::Bool(false))
+				.with_value("language_code", serde_json::Value::String("en-us".to_string()))
+				.with_value("time_zone", serde_json::Value::String("UTC".to_string()))
+		)
+		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
+		.add_source(TomlFileSource::new(settings_dir.join(format!("{}.toml", profile_str))))
+		.build()
+		.expect("Failed to build settings");
+
+	merged.into_typed().expect("Failed to convert settings to Settings struct")
+}
+```
+
+**環境變數來源:**
+
+Reinhardt提供兩種具有不同優先級的環境變數來源:
+
+- **`EnvSource`**（優先級: 100）- 覆蓋TOML檔案的高優先級環境變數
+  ```rust
+  .add_source(EnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+- **`LowPriorityEnvSource`**（優先級: 40）- 回退到TOML檔案的低優先級環境變數
+  ```rust
+  .add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
+  ```
+
+**優先級順序**:
+- 使用`EnvSource`: 環境變數 > `{profile}.toml` > `base.toml` > 預設值
+- 使用`LowPriorityEnvSource`（如上所示）: `{profile}.toml` > `base.toml` > 環境變數 > 預設值
+
+當環境變數應始終優先時選擇`EnvSource`（例如生產部署）。
+當TOML檔案應為主要配置來源時選擇`LowPriorityEnvSource`（例如開發）。
+
+詳情請參閱[設定文檔](../SETTINGS_DOCUMENT.md)。
+
+**使用內建DefaultUser:**
+
+Reinhardt提供即用型`DefaultUser`實作（需要`argon2-hasher`功能）:
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// 將DefaultUser重新匯出為你的app的User
+pub type User = DefaultUser;
+
+// DefaultUser包含:
+// - id: Uuid（主鍵）
+// - username: String
+// - email: String
+// - password_hash: Option<String>
+// - first_name: String
+// - last_name: String
+// - is_active: bool
+// - is_staff: bool
+// - is_superuser: bool
+// - last_login: Option<DateTime<Utc>>
+// - date_joined: DateTime<Utc>
+
+// DefaultUser實作:
+// - BaseUser trait（認證方法）
+// - FullUser trait（完整使用者資訊）
+// - PermissionsMixin trait（權限管理）
+// - Model trait（資料庫操作）
+```
+
+**定義自訂使用者模型:**
+
+如果需要自訂欄位，定義你自己的模型:
+
+```rust
+// users/models.rs
+use reinhardt::prelude::*;
+use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Utc};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: i64,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	#[field(max_length = 100)]
+	pub username: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(auto_now_add = true)]
+	pub created_at: DateTime<Utc>,
+
+	// 添加自訂欄位
+	#[field(max_length = 50, null = true)]
+	pub phone_number: Option<String>,
+}
+```
+
+**Model屬性巨集:**
+
+`#[model(...)]`屬性自動生成:
+- `Model` trait的實作（包含`#[derive(Model)]`功能）
+- 型別安全的欄位存取器: `User::field_email()`、`User::field_username()`等
+- 全域模型註冊表註冊
+- 複合主鍵支援
+
+**注意:** 使用`#[model(...)]`時，不需要單獨添加`#[derive(Model)]`，
+它由`#[model(...)]`屬性自動應用。
+
+**欄位屬性:**
+- `#[field(primary_key = true)]` - 標記為主鍵
+- `#[field(max_length = 255)]` - 設定字串欄位的最大長度
+- `#[field(default = value)]` - 設定預設值
+- `#[field(auto_now_add = true)]` - 建立時自動填充時間戳
+- `#[field(auto_now = true)]` - 儲存時自動更新時間戳
+- `#[field(null = true)]` - 允許NULL值
+- `#[field(unique = true)]` - 強制唯一性約束
+
+完整的欄位屬性列表請參閱[欄位屬性指南](../field_attributes.md)。
+
+生成的欄位存取器在查詢中啟用型別安全的欄位引用:
+
+```rust
+// 由#[model(...)]為DefaultUser生成
+impl DefaultUser {
+	pub const fn field_id() -> FieldRef<DefaultUser, Uuid> { FieldRef::new("id") }
+	pub const fn field_username() -> FieldRef<DefaultUser, String> { FieldRef::new("username") }
+	pub const fn field_email() -> FieldRef<DefaultUser, String> { FieldRef::new("email") }
+	pub const fn field_is_active() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_active") }
+	pub const fn field_is_staff() -> FieldRef<DefaultUser, bool> { FieldRef::new("is_staff") }
+	pub const fn field_date_joined() -> FieldRef<DefaultUser, DateTime<Utc>> { FieldRef::new("date_joined") }
+	// ... 其他欄位
+}
+```
+
+**進階查詢範例:**
+
+```rust
+use reinhardt::prelude::*;
+use reinhardt::DefaultUser;
+
+// 使用型別安全欄位引用的Django風格F/Q物件查詢
+async fn complex_user_query() -> Result<Vec<DefaultUser>, Box<dyn std::error::Error>> {
+	// 使用型別安全欄位引用的Q物件（使用生成的欄位存取器）
+	let active_query = Q::new()
+		.field("is_active").eq(true)
+		.and(Q::new().field("date_joined").gte(Now::new()));
+
+	// 使用型別安全欄位引用的資料庫函數
+	let email_lower = Lower::new(DefaultUser::field_email().into());
+	let username_upper = Upper::new(DefaultUser::field_username().into());
+
+	// 使用欄位存取器的聚合
+	let user_count = Aggregate::count(DefaultUser::field_id().into());
+	let latest_joined = Aggregate::max(DefaultUser::field_date_joined().into());
+
+	// 用於排名的視窗函數
+	let rank_by_join_date = Window::new()
+		.partition_by(vec![DefaultUser::field_is_active().into()])
+		.order_by(vec![(DefaultUser::field_date_joined().into(), "DESC")])
+		.function(RowNumber::new());
+
+	todo!("Execute query with these components")
+}
+
+// 交易支援
+async fn create_user_with_transaction(
+	conn: &DatabaseConnection,
+	user_data: CreateUserRequest
+) -> Result<User, Box<dyn std::error::Error>> {
+	// 出錯時自動回滾的交易
+	transaction(conn, |_tx| async move {
+		let user = User::create(user_data).await?;
+		log_user_creation(&user).await?;
+		Ok(user)
+	}).await
+}
+```
+
+**注意**: Reinhardt使用[SeaQuery v1.0.0-rc](https://crates.io/crates/sea-query)進行SQL操作。`#[derive(Model)]`巨集自動生成Model trait實作、型別安全的欄位存取器和全域模型註冊表註冊。
+
+在`src/config/apps.rs`中註冊:
+
+```rust
+// src/config/apps.rs
+use reinhardt::installed_apps;
+
+// installed_apps!巨集生成:
+// - 每個app變體的InstalledApp列舉
+// - 轉換trait的實作（From、Into、Display）
+// - app配置和發現的註冊表
+//
+// 注意: 與Django的INSTALLED_APPS不同，此巨集僅用於使用者apps。
+// 內建框架功能（auth、sessions、admin等）透過
+// Cargo功能旗標啟用，而不是透過installed_apps!。
+//
+// 範例:
+// [dependencies]
+// reinhardt = { version = "0.1", features = ["auth", "sessions", "admin"] }
+//
+// 這啟用:
+// - 遷移、管理面板等的自動app發現
+// - 程式碼中的型別安全app引用
+// - 集中的app配置
+installed_apps! {
+	users: "users",
+}
+
+pub fn get_installed_apps() -> Vec<String> {
+	InstalledApp::all_apps()
+}
+```
+
+### 使用認證
+
+Reinhardt提供Django風格的使用者模型，帶有`BaseUser`和`FullUser` traits，以及透過`UserManager`的全面使用者管理。
+
+**注意:** Reinhardt包含內建的`DefaultUser`實作。你可以直接使用它或如下所示定義自己的使用者模型。
+
+**使用者管理範例:**
+
+```rust
+use reinhardt::prelude::*;
+
+// 使用UserManager建立和管理使用者
+async fn manage_users() -> Result<(), Box<dyn std::error::Error>> {
+	let hasher = Argon2Hasher::new();
+	let user_manager = UserManager::new(hasher);
+
+	// 建立新使用者
+	let user = user_manager.create_user(CreateUserData {
+		username: "alice".to_string(),
+		email: "alice@example.com".to_string(),
+		password: "secure_password".to_string(),
+		first_name: Some("Alice".to_string()),
+		last_name: Some("Smith".to_string()),
+	}).await?;
+
+	// 更新使用者資訊
+	user_manager.update_user(user.id, UpdateUserData {
+		email: Some("alice.smith@example.com".to_string()),
+		is_active: Some(true),
+		..Default::default()
+	}).await?;
+
+	// 管理群組和權限
+	let group_manager = GroupManager::new();
+	let editors = group_manager.create_group(CreateGroupData {
+		name: "editors".to_string(),
+	}).await?;
+
+	// 分配物件級權限
+	let permission = ObjectPermission::new("edit", user.id, article.id);
+	let perm_checker = ObjectPermissionChecker::new();
+	if perm_checker.has_permission(&user, "edit", &article).await? {
+		// 使用者可以編輯文章
+	}
+
+	Ok(())
+}
+```
+
+在`users/models.rs`中使用內建的`DefaultUser`:
+
+```rust
+// users/models.rs
+use reinhardt::DefaultUser;
+
+// 將DefaultUser重新匯出為你的User型別
+pub type User = DefaultUser;
+
+// DefaultUser已實作:
+// - BaseUser trait（認證方法）
+// - FullUser trait（username、email、first_name、last_name等）
+// - PermissionsMixin trait（權限管理）
+// - Model trait（資料庫操作）
+```
+
+**對於自訂使用者模型:**
+
+如果需要超出DefaultUser的額外欄位，定義你自己的:
+
+```rust
+// users/models.rs
+use reinhardt::auth::{BaseUser, FullUser, PermissionsMixin};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+use serde::{Serialize, Deserialize};
+
+#[model(app_label = "users", table_name = "users")]
+pub struct CustomUser {
+	#[field(primary_key = true)]
+	pub id: Uuid,
+
+	#[field(max_length = 150)]
+	pub username: String,
+
+	#[field(max_length = 255)]
+	pub email: String,
+
+	pub password_hash: Option<String>,
+
+	#[field(max_length = 150)]
+	pub first_name: String,
+
+	#[field(max_length = 150)]
+	pub last_name: String,
+
+	#[field(default = true)]
+	pub is_active: bool,
+
+	#[field(default = false)]
+	pub is_staff: bool,
+
+	#[field(default = false)]
+	pub is_superuser: bool,
+
+	pub last_login: Option<DateTime<Utc>>,
+
+	#[field(auto_now_add = true)]
+	pub date_joined: DateTime<Utc>,
+
+	// 自訂欄位
+	#[field(max_length = 20, null = true)]
+	pub phone_number: Option<String>,
+}
+
+impl BaseUser for CustomUser {
+	type PrimaryKey = Uuid;
+
+	fn get_username_field() -> &'static str { "username" }
+	fn get_username(&self) -> &str { &self.username }
+	fn password_hash(&self) -> Option<&str> { self.password_hash.as_deref() }
+	fn set_password_hash(&mut self, hash: String) { self.password_hash = Some(hash); }
+	fn last_login(&self) -> Option<DateTime<Utc>> { self.last_login }
+	fn set_last_login(&mut self, time: DateTime<Utc>) { self.last_login = Some(time); }
+	fn is_active(&self) -> bool { self.is_active }
+}
+
+impl FullUser for CustomUser {
+	fn username(&self) -> &str { &self.username }
+	fn email(&self) -> &str { &self.email }
+	fn first_name(&self) -> &str { &self.first_name }
+	fn last_name(&self) -> &str { &self.last_name }
+	fn is_staff(&self) -> bool { self.is_staff }
+	fn is_superuser(&self) -> bool { self.is_superuser }
+	fn date_joined(&self) -> DateTime<Utc> { self.date_joined }
+}
+```
+
+在app的`views/profile.rs`中使用JWT認證:
+
+```rust
+// users/views/profile.rs
+use reinhardt::auth::{JwtAuth, BaseUser};
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+use crate::models::User;
+
+#[get("/profile", name = "get_profile")]
+pub async fn get_profile(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// 從Authorization標頭提取JWT令牌
+	let auth_header = req.headers.get("authorization")
+		.and_then(|h| h.to_str().ok())
+		.ok_or("Missing Authorization header")?;
+
+	let token = auth_header.strip_prefix("Bearer ")
+		.ok_or("Invalid Authorization header format")?;
+
+	// 驗證令牌並獲取使用者ID
+	let jwt_auth = JwtAuth::new(b"your-secret-key");
+	let claims = jwt_auth.verify_token(token)?;
+
+	// 使用claims.user_id從資料庫載入使用者
+	let user = User::find_by_id(&db, &claims.user_id).await?;
+
+	// 檢查使用者是否活躍
+	if !user.is_active() {
+		return Err("User account is inactive".into());
+	}
+
+	// 返回使用者設定檔為JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+### 端點定義
+
+Reinhardt使用HTTP方法裝飾器定義端點:
+
+#### HTTP方法裝飾器
+
+使用`#[get]`、`#[post]`、`#[put]`、`#[delete]`定義路由:
+
+```rust
+use reinhardt::{get, post, Request, Response, ViewResult};
+use serde_json::json;
+
+#[get("/")]
+pub async fn hello(_req: Request) -> ViewResult<Response> {
+	Ok(Response::ok().with_body("Hello, World!"))
+}
+
+#[post("/users")]
+pub async fn create_user(_req: Request) -> ViewResult<Response> {
+	let body = json!({"status": "created"});
+	Response::ok().with_json(&body).map_err(Into::into)
+}
+```
+
+**功能:**
+- 編譯時路徑驗證
+- 簡潔語法
+- 自動HTTP方法綁定
+- 透過`#[inject]`支援依賴注入
+
+#### 使用依賴注入
+
+將HTTP方法裝飾器與`#[inject]`結合進行自動依賴注入:
+
+```rust
+use reinhardt::{get, Request, Response, StatusCode, ViewResult};
+use reinhardt::db::DatabaseConnection;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,  // 自動注入
+) -> ViewResult<Response> {
+	let id = req.path_params.get("id")
+		.ok_or("Missing id")?
+		.parse::<i64>()?;
+
+	// 使用注入的資料庫連線
+	let user = db.query("SELECT * FROM users WHERE id = $1")
+		.bind(id)
+		.fetch_one()
+		.await?;
+
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+**依賴注入功能:**
+- 透過`#[inject]`屬性自動依賴注入
+- 透過`#[inject(cache = false)]`控制快取
+- FastAPI啟發的依賴注入系統
+- 與HTTP方法裝飾器無縫協作
+
+**回傳型別:**
+
+所有視圖函數使用`ViewResult<T>`作為回傳型別:
+
+```rust
+use reinhardt::ViewResult;  // 預定義結果型別
+```
+
+### 使用參數提取
+
+在app的`views/user.rs`中:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, get};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use std::sync::Arc;
+
+#[get("/users/{id}/", name = "get_user")]
+pub async fn get_user(
+	req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// 從請求提取路徑參數
+	let id = req.path_params.get("id")
+		.ok_or("Missing id parameter")?
+		.parse::<i64>()
+		.map_err(|_| "Invalid id format")?;
+
+	// 提取查詢參數（例如 ?include_inactive=true）
+	let include_inactive = req.query_params.get("include_inactive")
+		.and_then(|v| v.parse::<bool>().ok())
+		.unwrap_or(false);
+
+	// 使用注入的連線從資料庫獲取使用者
+	let user = User::find_by_id(&db, id).await?;
+
+	// 如需檢查活躍狀態
+	if !include_inactive && !user.is_active {
+		return Err("User is inactive".into());
+	}
+
+	// 回傳JSON
+	let json = serde_json::to_string(&user)?;
+	Ok(Response::new(StatusCode::OK)
+		.with_body(json))
+}
+```
+
+在`urls.rs`中註冊帶路徑參數的路由:
+
+```rust
+// users/urls.rs
+use reinhardt::ServerRouter;
+
+use super::views;
+
+pub fn url_patterns() -> ServerRouter {
+	ServerRouter::new()
+		.endpoint(views::get_user)  // 路徑在#[get("/users/{id}/")]中定義
+}
+```
+
+### 使用序列化器和驗證
+
+在app的`serializers/user.rs`中:
+
+```rust
+// users/serializers/user.rs
+use serde::{Serialize, Deserialize};
+use validator::Validate;
+
+#[derive(Serialize, Deserialize, Validate)]
+pub struct CreateUserRequest {
+	#[validate(email)]
+	pub email: String,
+	#[validate(length(min = 3, max = 50))]
+	pub username: String,
+	#[validate(length(min = 8))]
+	pub password: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserResponse {
+	pub id: i64,
+	pub username: String,
+	pub email: String,
+	pub is_active: bool,
+}
+
+impl From<User> for UserResponse {
+	fn from(user: User) -> Self {
+		UserResponse {
+			id: user.id,
+			username: user.username,
+			email: user.email,
+			is_active: user.is_active,
+		}
+	}
+}
+```
+
+在app的`views/user.rs`中:
+
+```rust
+// users/views/user.rs
+use reinhardt::{Request, Response, StatusCode, ViewResult, post};
+use reinhardt::db::DatabaseConnection;
+use crate::models::User;
+use crate::serializers::{CreateUserRequest, UserResponse};
+use validator::Validate;
+use std::sync::Arc;
+
+#[post("/users", name = "create_user")]
+pub async fn create_user(
+	mut req: Request,
+	#[inject] db: Arc<DatabaseConnection>,
+) -> ViewResult<Response> {
+	// 解析請求本體
+	let body_bytes = std::mem::take(&mut req.body);
+	let create_req: CreateUserRequest = serde_json::from_slice(&body_bytes)?;
+
+	// 驗證請求
+	create_req.validate()?;
+
+	// 建立使用者
+	let mut user = User {
+		id: 0, // 將由資料庫設定
+		username: create_req.username,
+		email: create_req.email,
+		password_hash: None,
+		is_active: true,
+		created_at: Utc::now(),
+	};
+
+	// 使用BaseUser trait雜湊密碼
+	user.set_password(&create_req.password)?;
+
+	// 使用注入的連線儲存到資料庫
+	user.save(&db).await?;
+
+	// 轉換為回應
+	let response_data = UserResponse::from(user);
+	let json = serde_json::to_string(&response_data)?;
+
+	Ok(Response::new(StatusCode::CREATED)
+		.with_body(json))
+}
+```
+
+## 可用元件
+
+Reinhardt提供可混合搭配的模組化元件:
+
+| 元件               | Crate名稱                  | 功能                                        |
+|---------------------|---------------------------|---------------------------------------------|
+| **核心**            |                           |                                             |
+| 核心型別            | `reinhardt-core`          | 核心traits、型別、巨集（Model、endpoint）   |
+| HTTP和路由          | `reinhardt-http`          | Request/Response、HTTP處理                  |
+| URL路由             | `reinhardt-urls`          | 函數式和類別式路由                          |
+| 伺服器              | `reinhardt-server`        | HTTP伺服器實作                              |
+| 中介軟體            | `reinhardt-dispatch`      | 中介軟體鏈、訊號分發                        |
+| 配置                | `reinhardt-conf`          | 設定管理、環境載入                          |
+| 命令                | `reinhardt-commands`      | 管理CLI工具（startproject等）               |
+| 捷徑                | `reinhardt-shortcuts`     | 常用工具函數                                |
+| **資料庫**          |                           |                                             |
+| ORM                 | `reinhardt-db`            | SeaQuery v1.0.0-rc整合                      |
+| **認證**            |                           |                                             |
+| Auth                | `reinhardt-auth`          | JWT、Token、Session、Basic認證、使用者模型 |
+| **REST API**        |                           |                                             |
+| 序列化器            | `reinhardt-rest`          | serde/validator整合、ViewSets               |
+| **表單**            |                           |                                             |
+| 表單                | `reinhardt-forms`         | 表單處理和驗證                              |
+| **進階功能**        |                           |                                             |
+| 管理面板            | `reinhardt-admin`         | Django風格管理介面                          |
+| 外掛系統            | `reinhardt-dentdelion`    | 靜態和WASM外掛支援、CLI管理                 |
+| 背景任務            | `reinhardt-tasks`         | 任務佇列（Redis、RabbitMQ、SQLite）         |
+| GraphQL             | `reinhardt-graphql`       | Schema生成、訂閱                            |
+| WebSockets          | `reinhardt-websockets`    | 即時通訊                                    |
+| i18n                | `reinhardt-i18n`          | 多語言支援                                  |
+| **測試**            |                           |                                             |
+| 測試工具            | `reinhardt-test`          | 測試輔助、fixtures、TestContainers          |
+
+**各crate內的詳細功能旗標，請參閱[功能旗標指南](../FEATURE_FLAGS.md)。**
+
+---
+
+## 文檔
+
+- 📚 [入門指南](../GETTING_STARTED.md) - 初學者分步教學
+- 🎛️ [功能旗標指南](../FEATURE_FLAGS.md) - 透過細粒度功能控制最佳化構建
+- 📖 [API參考](https://docs.rs/reinhardt)（即將推出）
+- 📝 [教學](../tutorials/) - 透過構建真實應用學習
+
+**AI助手請參閱**: 專案特定的編碼標準、測試指南和開發慣例請參閱[CLAUDE.md](../../CLAUDE.md)。
+
+## 💬 取得幫助
+
+Reinhardt是一個社群驅動的專案。以下是取得幫助的途徑:
+
+- 💬 **Discord**: 加入我們的Discord伺服器進行即時聊天（即將推出）
+- 💭 **GitHub Discussions**: [提問和分享想法](https://github.com/kent8192/reinhardt-rs/discussions)
+- 🐛 **Issues**: [報告bug](https://github.com/kent8192/reinhardt-rs/issues)
+- 📖 **文檔**: [閱讀指南](../)
+
+提問前，請查看:
+
+- ✅ [入門指南](../GETTING_STARTED.md)
+- ✅ [Examples](../../examples/)
+- ✅ 現有的GitHub Issues和Discussions
+
+## 🤝 貢獻
+
+我們歡迎貢獻！請閱讀[貢獻指南](../../CONTRIBUTING.md)開始。
+
+**快速連結**:
+
+- [開發設定](../../CONTRIBUTING.md#development-setup)
+- [測試指南](../../CONTRIBUTING.md#testing-guidelines)
+- [提交指南](../../CONTRIBUTING.md#commit-guidelines)
+
+## 授權
+
+雙重授權，可選擇以下之一:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+由您選擇。
+
+### 第三方歸屬
+
+本專案受以下專案啟發:
+
+- [Django](https://www.djangoproject.com/)（BSD 3-Clause授權）
+- [Django REST Framework](https://www.django-rest-framework.org/)（BSD 3-Clause授權）
+- [FastAPI](https://fastapi.tiangolo.com/)（MIT授權）
+- [SQLAlchemy](https://www.sqlalchemy.org/)（MIT授權）
+
+完整歸屬請參閱[THIRD-PARTY-NOTICES](../../THIRD-PARTY-NOTICES)。
+
+**注意:** 本專案不隸屬於Django Software Foundation、Encode OSS Ltd.、Sebastián Ramírez（FastAPI作者）或Michael Bayer（SQLAlchemy作者），也未獲得其認可。


### PR DESCRIPTION
## Summary

- Add multilingual README translations to expand project accessibility
- Add language selector to main README.md

## Languages Added

| Language | File |
|----------|------|
| Japanese (日本語) | `docs/readme-langs/README_JA.md` |
| Simplified Chinese (简体中文) | `docs/readme-langs/README_ZH_CN.md` |
| Traditional Chinese (繁體中文) | `docs/readme-langs/README_ZH_TW.md` |
| Russian (Русский) | `docs/readme-langs/README_RU.md` |
| Ukrainian (Українська) | `docs/readme-langs/README_UK.md` |
| Persian (فارسی) | `docs/readme-langs/README_FA.md` |
| Arabic (العربية) | `docs/readme-langs/README_AR.md` |

## Changes from Previous PR (#140)

- ✅ Renamed directory from `readmeLangs` to `readme-langs` (kebab-case)
- ✅ Separated `llms.txt` into a different scope (not included in this PR)

## Test Plan

- [x] Verify all translation files have complete content
- [x] Verify all internal links use correct relative paths
- [x] Verify language selector links work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)