### PR TITLE
fix(whitenoise): fix test module path and remove unused import

### DIFF
--- a/crates/reinhardt-whitenoise/tests/compression_tests.rs
+++ b/crates/reinhardt-whitenoise/tests/compression_tests.rs
@@ -1,6 +1,5 @@
 //! Compression module tests
 
-use reinhardt_whitenoise::cache::CompressedVariants;
 use reinhardt_whitenoise::compression::parse_accept_encoding;
 use reinhardt_whitenoise::compression::{FileScanner, WhiteNoiseCompressor};
 use reinhardt_whitenoise::config::WhiteNoiseConfig;

--- a/crates/reinhardt-whitenoise/tests/fixtures.rs
+++ b/crates/reinhardt-whitenoise/tests/fixtures.rs
@@ -3,6 +3,7 @@
 //! This module provides fixtures that wrap generic reinhardt-test fixtures
 //! with whitenoise-specific test data.
 
+#[path = "fixtures/test_fixtures.rs"]
 mod test_fixtures;
 
 // Re-export public fixture functions


### PR DESCRIPTION
## Summary

- Fix test module path and remove unused import

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

- Resolve CI check failures in qa/whitenoise branch

Related to: #118

## How Was This Tested?

- CI checks pass on the fix branch

## Checklist

- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)