### PR TITLE
fix(ci): revert actions/checkout from v6 to v4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -28,7 +28,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Rust with clippy
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -35,7 +35,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: ./.github/actions/docker-login

--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -28,7 +28,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: ./.github/actions/docker-login

--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -30,7 +30,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: ./.github/actions/docker-login

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Rust with rustfmt
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -35,7 +35,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: ./.github/actions/docker-login

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -35,7 +35,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: ./.github/actions/docker-login

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: ./.github/actions/docker-login


### PR DESCRIPTION
## Summary

- Revert actions/checkout from v6 to v4 in all workflow files

## Type of Change

- [x] CI/CD changes

## Motivation and Context

- actions/checkout v6 causes compatibility issues
- Reverting to v4 for stability

Related to: #117

## How Was This Tested?

- CI checks pass on the fix branch

## Checklist

- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)