### PR TITLE
fix(ci): migrate to official release-plz action

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,25 +1,23 @@
 name: Release-plz
 
 permissions:
-  pull-requests: write
   contents: write
-  id-token: write
+  pull-requests: write
 
 on:
   push:
     branches:
       - main
 
-concurrency:
-  group: release-plz-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  release-plz:
-    name: Release-plz
+  release-plz-pr:
+    name: Release PR
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
     steps:
-      - name: Free Disk Space (Ubuntu)
+      - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -42,40 +40,47 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
-          protoc --version
-
-      - name: Install release-plz
-        run: |
-          curl -sSfL https://github.com/release-plz/release-plz/releases/latest/download/release-plz-x86_64-unknown-linux-gnu.tar.gz | tar xz
-          sudo mv release-plz /usr/local/bin/
-          release-plz --version
-
-      - name: Setup release reference
-        id: release-ref
-        run: |
-          # Get the latest release tag if it exists
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-
-          if [ -n "$LATEST_TAG" ]; then
-            echo "Using latest tag: $LATEST_TAG"
-            echo "ref=$LATEST_TAG" >> $GITHUB_OUTPUT
-          else
-            # No tags exist yet - use the commit where reinhardt-micro was removed
-            # This is a workaround for the workspace member issue in published packages
-            # After the first successful release, tags will be available
-            FALLBACK_REF="4cc0ac9"
-            echo "No tags found, using fallback ref: $FALLBACK_REF"
-            echo "ref=$FALLBACK_REF" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout release reference
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.release-ref.outputs.ref }}
-          path: release-ref
 
       - name: Run release-plz release-pr
-        run: release-plz release-pr --registry-manifest-path release-ref/Cargo.toml
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Run release-plz release
+        uses: release-plz/action@v0.5
+        with:
+          command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace manual CLI installation with `release-plz/action@v0.5`
- Add `release` job for automatic publishing on PR merge
- Remove obsolete `registry-manifest-path` workaround (tags now exist)
- Split into separate `release-pr` and `release` jobs

## Changes

| Before | After |
|--------|-------|
| Manual CLI installation via curl | Official GitHub Action |
| Single `release-pr` job only | Two jobs: `release-pr` and `release` |
| `registry-manifest-path` workaround | Direct execution (no workaround needed) |
| Release job missing | Auto-publish on Release PR merge |

## Test plan

- [ ] Verify workflow syntax is valid (GitHub Actions validation)
- [ ] Merge to main and confirm Release PR is created
- [ ] After merging Release PR, confirm crates are published to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)