### PR TITLE
fix(ci): configure example packages to prevent release-plz warnings

### DIFF
--- a/examples/local/examples-github-issues/Cargo.toml
+++ b/examples/local/examples-github-issues/Cargo.toml
@@ -2,6 +2,7 @@
 name = "examples-github-issues"
 version = "0.1.0-alpha.1"
 edition = "2024"
+publish = false
 default-run = "examples-github-issues"
 
 [[bin]]

--- a/examples/local/examples-twitter/Cargo.toml
+++ b/examples/local/examples-twitter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "examples-twitter"
 version = "0.1.0-alpha.1"
 edition = "2024"
+publish = false
 default-run = "examples-twitter"
 
 [lib]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -76,15 +76,5 @@ name = "reinhardt-settings-cli"
 release = false
 publish = false
 
-[[package]]
-name = "example-common"
-release = false
-publish = false
-
-[[package]]
-name = "example-test-macros"
-release = false
-publish = false
-
 [changelog]
 protect_breaking_commits = true


### PR DESCRIPTION
## Summary

- Add `publish = false` to `examples-twitter` and `examples-github-issues` packages
- Remove unnecessary entries from release-plz exclusion list

## Problem

The release-plz workflow was generating warnings because some example packages were not properly configured:

```
WARN cannot read package metadata of reinhardt-apps in /tmp/.tmp4DPuj7/reinhardt-web/crates/reinhardt-apps: cannot read Cargo.toml
```

## Solution

1. Added `publish = false` to:
   - `examples/local/examples-twitter/Cargo.toml`
   - `examples/local/examples-github-issues/Cargo.toml`

2. Removed `example-common` and `example-test-macros` from `release-plz.toml`:
   - These packages are located in `examples/remote/` which is already excluded via directory pattern

## Test plan

- [ ] Merge and verify release-plz workflow runs without cargo metadata warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)