### PR TITLE
fix(ci): use GitHub App token for release-plz to trigger CI workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,6 +17,13 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
         with:
@@ -46,13 +53,20 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-release:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
         with:
@@ -82,5 +96,5 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Use GitHub App token instead of `GITHUB_TOKEN` for release-plz workflow
- This allows release-plz PRs to trigger CI workflows

## Problem

GitHub's security measure prevents workflows triggered by `GITHUB_TOKEN` from triggering other workflows (to avoid infinite loops). As a result, release-plz PRs (like #170) cannot be merged because CI checks don't run.

## Solution

Use `actions/create-github-app-token` to generate a token from a GitHub App. PRs created with this token will trigger CI workflows.

Required secrets (already configured):
- `RELEASE_PLZ_APP_ID`: GitHub App ID
- `RELEASE_PLZ_APP_PRIVATE_KEY`: GitHub App private key

## Test plan

- [ ] Merge this PR to main
- [ ] Wait for release-plz to create/update the release PR
- [ ] Verify CI checks run on the release PR

## References

- https://release-plz.dev/docs/github/token
- https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

🤖 Generated with [Claude Code](https://claude.ai/claude-code)