### PR TITLE
fix(ci): fix YAML syntax error in release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -60,7 +60,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     # Only run when Release PR is merged (commit message starts with "chore: release")
-    if: startsWith(github.event.head_commit.message, 'chore: release')
+    if: ${{ startsWith(github.event.head_commit.message, 'chore: release') }}
     steps:
       - name: Generate GitHub token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
## Summary

Fix YAML syntax error on line 63 of release-plz.yml

## Problem

The `if` condition contained a colon (`:`) in the string `'chore: release'` which caused YAML parsing to fail.

```yaml
# Before (invalid)
if: startsWith(github.event.head_commit.message, 'chore: release')
```

## Solution

Wrap the expression with `${{ }}` to properly escape the value:

```yaml
# After (valid)
if: ${{ startsWith(github.event.head_commit.message, 'chore: release') }}
```

## Test plan

- [ ] Merge this PR
- [ ] Verify release-plz workflow runs successfully
- [ ] Verify Release PR is created

🤖 Generated with [Claude Code](https://claude.ai/claude-code)