### PR TITLE
fix(ci): quote job-level if expression for YAML parsing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -60,7 +60,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     # Only run when Release PR is merged (commit message starts with "chore: release")
-    if: ${{ startsWith(github.event.head_commit.message, 'chore: release') }}
+    if: "startsWith(github.event.head_commit.message, 'chore: release')"
     steps:
       - name: Generate GitHub token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
## Summary
- Wrap job-level `if` condition in double quotes to fix YAML syntax error
- Resolve parsing conflict caused by colon in the inner string `'chore: release'`

## Test plan
- [ ] Verify workflow file passes GitHub Actions validation
- [ ] Confirm release-plz PR job runs correctly on push to main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)