### PR TITLE
feat(ci): add manual trigger and dry-run validation for release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,11 +8,71 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      force_release:
+        description: 'Force run release job (publish to crates.io)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
+  release-plz-validate:
+    name: Validate Release
+    runs-on: ubuntu-latest
+    # Only run for PRs from release/ branches
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')
+    steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Check release (dry-run)
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+          dry_run: true
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   release-plz-pr:
     name: Release PR
     runs-on: ubuntu-latest
+    # Only run on push to main
+    if: github.event_name == 'push'
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
@@ -59,8 +119,10 @@ jobs:
   release-plz-release:
     name: Release
     runs-on: ubuntu-latest
-    # Only run when Release PR is merged (commit message starts with "chore: release")
-    if: "startsWith(github.event.head_commit.message, 'chore: release')"
+    # Run when Release PR is merged OR when manually triggered with force_release
+    if: >-
+      startsWith(github.event.head_commit.message, 'chore: release') ||
+      (github.event_name == 'workflow_dispatch' && inputs.force_release == true)
     steps:
       - name: Generate GitHub token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` with `force_release` option for manual release retry
- Add `pull_request` trigger for release/ branch PRs
- Add `release-plz-validate` job to dry-run release before merge
- Update `release-plz-pr` to only run on push events
- Update `release-plz-release` to support manual trigger

## Background
Release PR #172 was merged but the Release job failed due to dependency ordering issues. Currently there's no way to retry the release manually.

## Changes

### 1. Manual Release Trigger
```yaml
workflow_dispatch:
  inputs:
    force_release:
      description: 'Force run release job (publish to crates.io)'
      type: boolean
```
Allows manual retry of failed releases via GitHub Actions UI.

### 2. Dry-Run Validation
```yaml
release-plz-validate:
  name: Validate Release
  if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')
```
Runs `release --dry_run` on Release PRs before merge to catch issues early.

## Test plan
- [ ] Merge this PR
- [ ] Run workflow manually with `force_release: true` to retry the failed release
- [ ] Verify next Release PR triggers validation job

🤖 Generated with [Claude Code](https://claude.com/claude-code)