### PR TITLE
fix(ci): use Cargo native workspace publishing for dependency ordering

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -60,12 +60,10 @@ jobs:
           sudo apt-get install -y protobuf-compiler
 
       - name: Check release (dry-run)
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          dry_run: true
+        run: |
+          # Use Cargo native workspace publishing dry-run
+          cargo publish --workspace --dry-run
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:
@@ -155,7 +153,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
-      - name: Run release-plz release
+      - name: Publish to crates.io (native workspace publishing)
+        run: |
+          # Use Cargo 1.90+ native workspace publishing to handle dependency ordering
+          # This uses registry overlay to verify all crates before uploading
+          cargo publish --workspace
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Create Git tags and GitHub releases
         uses: release-plz/action@v0.5
         with:
           command: release


### PR DESCRIPTION
## Summary
Replace release-plz's publish functionality with Cargo 1.90+ native workspace publishing to fix dependency ordering issues.

## Background
Release-plz was attempting to publish `reinhardt-core` before `reinhardt-http` was available on crates.io, causing verification failures:
```
failed to select a version for the requirement `reinhardt-http = "^0.1.0-alpha.4"`
```

## Root Cause
- release-plz publishes crates individually with `cargo publish`
- It doesn't properly leverage Cargo 1.90+'s registry overlay mechanism
- Result: Dependent crates fail verification when their dependencies aren't yet indexed

## Solution
Use `cargo publish --workspace` which:
1. Creates a virtual registry overlay
2. Verifies all crates against the overlay (not live crates.io)
3. Uploads in correct dependency order after all verification passes

## Changes
- Replace `release-plz release` publish step with `cargo publish --workspace`
- Replace dry-run validation with `cargo publish --workspace --dry-run`
- Keep `release-plz release` for Git tags and GitHub releases only

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger workflow with `force_release: true`
- [ ] Verify all crates publish successfully in correct order

🤖 Generated with [Claude Code](https://claude.com/claude-code)