### PR TITLE
fix(ci): use release-plz dry-run instead of cargo publish dry-run

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -60,10 +60,12 @@ jobs:
           sudo apt-get install -y protobuf-compiler
 
       - name: Check release (dry-run)
-        run: |
-          # Use Cargo native workspace publishing dry-run
-          cargo publish --workspace --dry-run
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+          args: --dry-run
         env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:


### PR DESCRIPTION
## Summary

Fixes validation failure in Release PR (#178).

### Problem

`cargo publish --workspace --dry-run` fails when workspace crates depend on other workspace crates with bumped versions that are not yet published to crates.io:

```
error: failed to select a version for the requirement `reinhardt-core = "^0.1.0-alpha.3"`
candidate versions found which didn't match: 0.1.0-alpha.2, 0.1.0-alpha.1
location searched: crates.io index
```

This is because `--dry-run` mode only checks against the crates.io index without using the registry overlay that handles workspace dependencies.

### Solution

Replace `cargo publish --workspace --dry-run` with `release-plz release --dry-run` which properly handles workspace dependency resolution during validation.

## Test plan

- [ ] Merge this PR first
- [ ] Verify PR #178 passes validation after this fix is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)