### PR TITLE
fix(ci): use release-plz dry-run and label-based release trigger

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize]
+    types: [opened, synchronize, closed]
   workflow_dispatch:
     inputs:
       force_release:
@@ -60,10 +60,12 @@ jobs:
           sudo apt-get install -y protobuf-compiler
 
       - name: Check release (dry-run)
-        run: |
-          # Use Cargo native workspace publishing dry-run
-          cargo publish --workspace --dry-run
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+          args: --dry-run
         env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:
@@ -117,9 +119,16 @@ jobs:
   release-plz-release:
     name: Release
     runs-on: ubuntu-latest
-    # Run when Release PR is merged OR when manually triggered with force_release
+    # Run when Release PR (with 'release' + 'automated' labels) is merged
+    # OR when manually triggered with force_release
     if: >-
-      startsWith(github.event.head_commit.message, 'chore: release') ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.labels.*.name, 'release') &&
+        contains(github.event.pull_request.labels.*.name, 'automated')
+      ) ||
       (github.event_name == 'workflow_dispatch' && inputs.force_release == true)
     steps:
       - name: Generate GitHub token


### PR DESCRIPTION
## Summary

Fixes two issues with the release workflow:

### Issue 1: Validation failure with workspace dependencies (PR #178)

`cargo publish --workspace --dry-run` fails when workspace crates depend on bumped versions not yet published to crates.io.

**Solution:** Replace with `release-plz release --dry-run` which properly handles workspace dependency resolution.

### Issue 2: Release not triggered with "Merge commit" strategy

The previous trigger `startsWith(github.event.head_commit.message, 'chore: release')` only works with "Squash and merge" strategy.

**Solution:** Use PR labels (`release` + `automated`) as trigger condition, which works with any merge strategy.

## Changes

| Before | After |
|--------|-------|
| `cargo publish --workspace --dry-run` | `release-plz release --dry-run` |
| Commit message check | PR labels check (`release` + `automated`) |

## Test plan

- [ ] This PR passes CI
- [ ] After merge, manually trigger release with `force_release=true`
- [ ] Future Release PRs will auto-trigger on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)