### PR TITLE
fix(deps): resolve circular dependency and dev-dependency version conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -379,7 +379,7 @@ reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.0-alpha.6" }
 reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.1.0-alpha.4" }
 reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.0-alpha.2" }
 reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.0-alpha.5" }
-reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-alpha.6" }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-alpha.5" }
 reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.0-alpha.3" }
 reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.0-alpha.6" }
 reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-alpha.6" }

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -130,6 +130,5 @@ bytes = "1.0"
 hyper = "1.0"
 tokio-test = "0.4"
 serial_test = { workspace = true }
-reinhardt-http = { workspace = true }
 reinhardt-test = { workspace = true }
 rstest = { workspace = true }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -21,6 +21,9 @@ semver_check = false
 publish_timeout = "10m"
 dependencies_update = false
 
+# Skip cargo publish verification (dev-dependencies may reference unpublished workspace crates)
+publish_no_verify = true
+
 # Non-published packages (tests, examples, internal tools)
 [[package]]
 name = "reinhardt-test-support"


### PR DESCRIPTION
## Summary

- Remove `reinhardt-http` from `reinhardt-core` dev-dependencies to break circular dependency
- Update `reinhardt-test` workspace version to `0.1.0-alpha.5` to match crates.io published version
- Add `publish_no_verify = true` to `release-plz.toml` to skip cargo publish verification (dev-dependencies may reference unpublished workspace crates)

## Test plan

- [ ] Verify CI passes (build, test, lint)
- [ ] Verify `cargo publish --dry-run` succeeds for affected crates
- [ ] Verify release-plz can create release PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)