### PR TITLE
ci: skip publish-check for release-plz branches

### DIFF
--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -12,6 +12,8 @@ jobs:
   publish-check:
     name: Publish Dry-Run Check
     runs-on: ubuntu-latest
+    # Skip for release-plz branches - new versions not yet on crates.io
+    if: ${{ !startsWith(github.head_ref || github.ref_name, 'release-plz-') }}
     steps:
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main


### PR DESCRIPTION
## Summary

- Skip `publish-check` workflow for branches matching `release-plz-*` pattern
- This fixes false CI failures on release-plz PRs (e.g., #200)

## Problem

Release-plz branches bump versions of interdependent crates simultaneously. When `cargo publish --dry-run` runs, it tries to resolve dependencies from crates.io, but the new versions don't exist yet, causing resolution failures.

Example error:
```
error: failed to select a version for the requirement `reinhardt-utils = "^0.1.0-alpha.7"`
candidate versions found which didn't match: 0.1.0-alpha.6, 0.1.0-alpha.5, ...
```

## Why This is Safe

1. **Circular dependency checks already run** on development PRs before merge
2. **release-plz only bumps versions** - it doesn't introduce new dependency relationships
3. **Actual publishing succeeds** because release-plz publishes crates in dependency order
4. **The check is designed for development PRs** that might introduce circular dependencies

## Test Plan

- [ ] PR #200 CI should pass after this change is merged and release-plz branch is rebased
- [ ] New development PRs should still run publish-check
- [ ] Main branch pushes should still run publish-check

Fixes #200 CI failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)