### PR TITLE
fix(utils): remove unused dev-dependencies to break circular publish chain

### DIFF
--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -114,8 +114,6 @@ serial_test = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
 reinhardt-test = { workspace = true, features = ["static", "testcontainers"] }
-reinhardt-db = { workspace = true, features = ["backends"] }
 uuid = { workspace = true }
 tokio-test = "0.4"
-sqlx = { workspace = true }
 tempfile = "3.8"


### PR DESCRIPTION
## Summary

This PR addresses:

- Remove unused `reinhardt-db` and `sqlx` from `reinhardt-utils` dev-dependencies to break the circular publish dependency chain that caused the release-plz publish job to fail

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The release-plz Release job ([GitHub Actions Run #21752797503](https://github.com/kent8192/reinhardt-web/actions/runs/21752797503)) failed when attempting to publish `reinhardt-utils v0.1.0-alpha.7` to crates.io. The root cause was a circular publish dependency:

```
reinhardt-utils v0.1.0-alpha.7
    └──(dev-dep)──→ reinhardt-db ^0.1.0-alpha.6 (not yet on crates.io)
                        └──(normal)──→ reinhardt-conf ^0.1.0-alpha.7
                                          └──(normal)──→ reinhardt-utils ^0.1.0-alpha.7
```

Since `reinhardt-db` and `sqlx` are not actually used in any `.rs` files under `crates/reinhardt-utils/`, removing them safely breaks the cycle without affecting functionality.

## How Was This Tested?

- `cargo check --workspace --all --all-features` — passes
- `cargo nextest run --package reinhardt-utils` — 424 tests all pass
- `cargo make fmt-check` — passes
- `cargo make clippy-check` — passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Priority Label (for maintainers)
- [x] `critical` - Blocks release or major functionality

---

**Additional Context:**

After this fix is merged, the publish order will be resolved correctly by release-plz:

1. `reinhardt-di`, `reinhardt-utils` (no longer depends on `reinhardt-db`)
2. `reinhardt-conf` (depends on `reinhardt-utils`)
3. `reinhardt-db` (depends on `reinhardt-conf`)
4. Remaining crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)