### PR TITLE
fix(release): revert unpublished crate versions to pre-release state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,41 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-alpha.6...reinhardt-web@v0.1.0-alpha.7) - 2026-02-09
-
-### Fixed
-
-- *(db)* remove unused reinhardt-test dev-dependency
-- *(auth)* remove unused reinhardt-test dev-dependency
-- *(core)* replace reinhardt-test with local poll_until helper
-- *(server)* replace reinhardt-test with local poll_until helper
-- *(utils)* break circular publish dependency with reinhardt-test
-- *(rest)* move tests to integration crate to break circular publish chain
-- *(views)* move tests to integration crate to break circular publish chain
-- *(di)* move unit tests to integration crate to break circular publish chain
-- *(http)* move integration tests to tests crate to break circular publish chain
-- *(admin)* move database tests to integration crate to break circular publish chain
-- *(utils)* use fully qualified Result type in poll_until helpers
-- *(utils)* fix integration test imports and remove private field access
-- *(di)* fix compilation errors in migrated unit tests
-- *(admin)* fix User model id type to Option<i64> for impl_test_model macro
-- *(di)* implement deep clone for InjectionContext request scope
-- *(ci)* remove version from reinhardt-test workspace dep to avoid cargo 1.84+ resolution failure
-
-### Maintenance
-
-- *(websockets)* remove manual CHANGELOG entries for release-plz
-
-### Reverted
-
-- undo release PR [[#215](https://github.com/kent8192/reinhardt-web/issues/215)](https://github.com/kent8192/reinhardt-web/issues/215) version bumps
-- undo PR [[#219](https://github.com/kent8192/reinhardt-web/issues/219)](https://github.com/kent8192/reinhardt-web/issues/219) version bumps for unpublished crates
-
-### Styling
-
-- apply formatting to migrated test files and modified source files
-- apply formatting to di and utils integration tests
-
 ## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-alpha.5...reinhardt-web@v0.1.0-alpha.6) - 2026-02-07
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.6"
 edition.workspace = true
 license.workspace = true
 description = "A full-stack API framework for Rust, inspired by Django and Django REST Framework"
@@ -253,7 +253,7 @@ reinhardt-db = { workspace = true, optional = true }
 
 # External crates re-exported for macros
 inventory = { workspace = true, optional = true }
-reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-alpha.8", optional = true }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-alpha.7", optional = true }
 reinhardt-rest = { workspace = true, optional = true }
 reinhardt-auth = { workspace = true, optional = true }
 
@@ -363,20 +363,20 @@ authors = ["kent8192 <51869472+kent8192@users.noreply.github.com>"]
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-alpha.7" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-alpha.6" }
 
 # Internal crates
-reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0-alpha.5" }
+reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0-alpha.4" }
 reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.1.0-alpha.7" }
 reinhardt-settings-cli = { path = "crates/reinhardt-conf/crates/settings-cli", version = "0.1.0-alpha.1" }
 reinhardt-core = { path = "crates/reinhardt-core", version = "0.1.0-alpha.4" }
 reinhardt-di = { path = "crates/reinhardt-di", version = "0.1.0-alpha.5" }
 reinhardt-http = { path = "crates/reinhardt-http", version = "0.1.0-alpha.6" }
 reinhardt-server = { path = "crates/reinhardt-server", version = "0.1.0-alpha.5" }
-reinhardt-views = { path = "crates/reinhardt-views", version = "0.1.0-alpha.5" }
-reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.1.0-alpha.5" }
-reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.1.0-alpha.5" }
-reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.0-alpha.8" }
+reinhardt-views = { path = "crates/reinhardt-views", version = "0.1.0-alpha.4" }
+reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.1.0-alpha.4" }
+reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.1.0-alpha.4" }
+reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.0-alpha.7" }
 reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.1.0-alpha.5" }
 reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.0-alpha.3" }
 reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.1.0-alpha.1" }
@@ -384,26 +384,26 @@ reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.0-alpha.5" }
 reinhardt-test = { path = "crates/reinhardt-test" }
 reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.0-alpha.3" }
 reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.0-alpha.8" }
-reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-alpha.8" }
+reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-alpha.7" }
 reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.0-alpha.2" }
-reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0-alpha.5" }
-reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0-alpha.5" }
-reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-alpha.7" }
-reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-alpha.5" }
+reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0-alpha.4" }
+reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0-alpha.4" }
+reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-alpha.6" }
+reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-alpha.4" }
 reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0-alpha.1" }
 reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0-alpha.2" }
-reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-alpha.10" }
-reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0-alpha.7" }
+reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-alpha.9" }
+reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0-alpha.6" }
 reinhardt-postgres = { path = "crates/reinhardt-postgres", version = "0.1.0-alpha.1" }
 reinhardt-events = { path = "crates/reinhardt-events", version = "0.1.0-alpha.1" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-alpha.6" }
-reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-alpha.5" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-alpha.6" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-alpha.5" }
+reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-alpha.4" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-alpha.5" }
 reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0-alpha.4" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-alpha.5" }
-reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0-alpha.5" }
-reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0-alpha.5" }
-reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-alpha.6" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-alpha.4" }
+reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0-alpha.4" }
+reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0-alpha.4" }
+reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-alpha.5" }
 
 # Core subcrates
 reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.0-alpha.2" }

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.0-alpha.6...reinhardt-admin-cli@v0.1.0-alpha.7) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-commands, reinhardt-pages, reinhardt-dentdelion
-
 ## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.0-alpha.5...reinhardt-admin-cli@v0.1.0-alpha.6) - 2026-02-07
 
 ### Other

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin-cli"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-admin/CHANGELOG.md
+++ b/crates/reinhardt-admin/CHANGELOG.md
@@ -8,16 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- release-plz-separator -->
 <!-- Entries below this line were created before release-plz adoption -->
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin@v0.1.0-alpha.4...reinhardt-admin@v0.1.0-alpha.5) - 2026-02-09
-
-### Fixed
-
-- *(admin)* move database tests to integration crate to break circular publish chain
-
-### Reverted
-
-- undo PR [[#219](https://github.com/kent8192/reinhardt-web/issues/219)](https://github.com/kent8192/reinhardt-web/issues/219) version bumps for unpublished crates
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin@v0.1.0-alpha.3...reinhardt-admin@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-apps/CHANGELOG.md
+++ b/crates/reinhardt-apps/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-apps@v0.1.0-alpha.4...reinhardt-apps@v0.1.0-alpha.5) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-server
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-apps@v0.1.0-alpha.3...reinhardt-apps@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-apps/Cargo.toml
+++ b/crates/reinhardt-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-apps"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 description = "Application registry and management for Reinhardt framework"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-auth/CHANGELOG.md
+++ b/crates/reinhardt-auth/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-auth@v0.1.0-alpha.4...reinhardt-auth@v0.1.0-alpha.5) - 2026-02-09
-
-### Fixed
-
-- *(auth)* remove unused reinhardt-test dev-dependency
-
-### Reverted
-
-- undo PR [[#219](https://github.com/kent8192/reinhardt-web/issues/219)](https://github.com/kent8192/reinhardt-web/issues/219) version bumps for unpublished crates
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-auth@v0.1.0-alpha.3...reinhardt-auth@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 description = "Authentication and authorization system"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-commands/CHANGELOG.md
+++ b/crates/reinhardt-commands/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.10](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0-alpha.9...reinhardt-commands@v0.1.0-alpha.10) - 2026-02-09
-
-### Fixed
-
-- *(ci)* remove version from reinhardt-test workspace dep to avoid cargo 1.84+ resolution failure
-
 ## [0.1.0-alpha.9](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0-alpha.8...reinhardt-commands@v0.1.0-alpha.9) - 2026-02-07
 
 ### Other

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-commands"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,7 +14,7 @@ reinhardt-conf = { workspace = true }
 reinhardt-dentdelion = { workspace = true, features = ["cli"], optional = true }
 reinhardt-urls = { workspace = true, features = ["routers", "database"], optional = true }
 reinhardt-db = { workspace = true, features = ["migrations", "backends-settings", "orm", "settings"], optional = true }
-reinhardt-test = { path = "../reinhardt-test", version = "0.1.0-alpha.8", optional = true }
+reinhardt-test = { path = "../reinhardt-test", version = "0.1.0-alpha.7", optional = true }
 reinhardt-di = { workspace = true, optional = true }
 reinhardt-http = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }

--- a/crates/reinhardt-db/CHANGELOG.md
+++ b/crates/reinhardt-db/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db@v0.1.0-alpha.6...reinhardt-db@v0.1.0-alpha.7) - 2026-02-09
-
-### Fixed
-
-- *(db)* remove unused reinhardt-test dev-dependency
-
-### Reverted
-
-- undo PR [[#219](https://github.com/kent8192/reinhardt-web/issues/219)](https://github.com/kent8192/reinhardt-web/issues/219) version bumps for unpublished crates
-
 ## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db@v0.1.0-alpha.5...reinhardt-db@v0.1.0-alpha.6) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-db/Cargo.toml
+++ b/crates/reinhardt-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-dentdelion/CHANGELOG.md
+++ b/crates/reinhardt-dentdelion/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dentdelion@v0.1.0-alpha.4...reinhardt-dentdelion@v0.1.0-alpha.5) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-db
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dentdelion@v0.1.0-alpha.3...reinhardt-dentdelion@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-dentdelion/Cargo.toml
+++ b/crates/reinhardt-dentdelion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dentdelion"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-dispatch/CHANGELOG.md
+++ b/crates/reinhardt-dispatch/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dispatch@v0.1.0-alpha.4...reinhardt-dispatch@v0.1.0-alpha.5) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-views, reinhardt-middleware, reinhardt-urls
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dispatch@v0.1.0-alpha.3...reinhardt-dispatch@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-dispatch/Cargo.toml
+++ b/crates/reinhardt-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dispatch"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-graphql/CHANGELOG.md
+++ b/crates/reinhardt-graphql/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.1.0-alpha.4...reinhardt-graphql@v0.1.0-alpha.5) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-grpc
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.1.0-alpha.3...reinhardt-graphql@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-grpc/CHANGELOG.md
+++ b/crates/reinhardt-grpc/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.1.0-alpha.4...reinhardt-grpc@v0.1.0-alpha.5) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.1.0-alpha.3...reinhardt-grpc@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 description = "gRPC support for building RPC services"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-i18n/CHANGELOG.md
+++ b/crates/reinhardt-i18n/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.1.0-alpha.5...reinhardt-i18n@v0.1.0-alpha.6) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-di
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.1.0-alpha.4...reinhardt-i18n@v0.1.0-alpha.5) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 description = "Internationalization and localization support"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-middleware/CHANGELOG.md
+++ b/crates/reinhardt-middleware/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-middleware@v0.1.0-alpha.4...reinhardt-middleware@v0.1.0-alpha.5) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-auth
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-middleware@v0.1.0-alpha.3...reinhardt-middleware@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-middleware"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 description = "Middleware system for request/response processing pipeline"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-openapi/CHANGELOG.md
+++ b/crates/reinhardt-openapi/CHANGELOG.md
@@ -8,12 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- release-plz-separator -->
 <!-- Entries below this line were created before release-plz adoption -->
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-openapi@v0.1.0-alpha.5...reinhardt-openapi@v0.1.0-alpha.6) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-rest, reinhardt-urls
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-openapi@v0.1.0-alpha.4...reinhardt-openapi@v0.1.0-alpha.5) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-openapi/Cargo.toml
+++ b/crates/reinhardt-openapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.8](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.1.0-alpha.7...reinhardt-pages@v0.1.0-alpha.8) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-server, reinhardt-middleware, reinhardt-urls
-
 ## [0.1.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.1.0-alpha.6...reinhardt-pages@v0.1.0-alpha.7) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.7"
 edition = "2024"
 authors = ["Reinhardt Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/reinhardt-rest/CHANGELOG.md
+++ b/crates/reinhardt-rest/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.8](https://github.com/kent8192/reinhardt-web/compare/reinhardt-rest@v0.1.0-alpha.7...reinhardt-rest@v0.1.0-alpha.8) - 2026-02-09
-
-### Fixed
-
-- *(rest)* move tests to integration crate to break circular publish chain
-
-### Reverted
-
-- undo PR [[#219](https://github.com/kent8192/reinhardt-web/issues/219)](https://github.com/kent8192/reinhardt-web/issues/219) version bumps for unpublished crates
-
-### Styling
-
-- apply formatting to migrated test files and modified source files
-
 ## [0.1.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-rest@v0.1.0-alpha.6...reinhardt-rest@v0.1.0-alpha.7) - 2026-02-06
 
 ### Fixed

--- a/crates/reinhardt-rest/Cargo.toml
+++ b/crates/reinhardt-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-rest"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.7"
 description = "REST API framework aggregator for Reinhardt"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-shortcuts/CHANGELOG.md
+++ b/crates/reinhardt-shortcuts/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.1.0-alpha.5...reinhardt-shortcuts@v0.1.0-alpha.6) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-db, reinhardt-views, reinhardt-urls
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.1.0-alpha.4...reinhardt-shortcuts@v0.1.0-alpha.5) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-test/CHANGELOG.md
+++ b/crates/reinhardt-test/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.8](https://github.com/kent8192/reinhardt-web/compare/reinhardt-test@v0.1.0-alpha.7...reinhardt-test@v0.1.0-alpha.8) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-server, reinhardt-db, reinhardt-auth, reinhardt-rest, reinhardt-views, reinhardt-admin, reinhardt-websockets, reinhardt-urls, reinhardt-pages
-
 ## [0.1.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-test@v0.1.0-alpha.6...reinhardt-test@v0.1.0-alpha.7) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-test"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.7"
 edition = "2024"
 description = "Testing utilities and helpers for Reinhardt framework"
 license.workspace = true

--- a/crates/reinhardt-urls/CHANGELOG.md
+++ b/crates/reinhardt-urls/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-urls@v0.1.0-alpha.4...reinhardt-urls@v0.1.0-alpha.5) - 2026-02-09
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-db, reinhardt-views, reinhardt-middleware
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-urls@v0.1.0-alpha.3...reinhardt-urls@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-urls"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kent8192/reinhardt"

--- a/crates/reinhardt-views/CHANGELOG.md
+++ b/crates/reinhardt-views/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-views@v0.1.0-alpha.4...reinhardt-views@v0.1.0-alpha.5) - 2026-02-09
-
-### Fixed
-
-- *(views)* move tests to integration crate to break circular publish chain
-
-### Reverted
-
-- undo PR [[#219](https://github.com/kent8192/reinhardt-web/issues/219)](https://github.com/kent8192/reinhardt-web/issues/219) version bumps for unpublished crates
-
-### Styling
-
-- apply formatting to migrated test files and modified source files
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-views@v0.1.0-alpha.3...reinhardt-views@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-views/Cargo.toml
+++ b/crates/reinhardt-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-views"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 description = "View layer aggregator for viewsets and views-core"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-websockets/CHANGELOG.md
+++ b/crates/reinhardt-websockets/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-websockets@v0.1.0-alpha.4...reinhardt-websockets@v0.1.0-alpha.5) - 2026-02-09
-
-### Maintenance
-
-- *(websockets)* remove manual CHANGELOG entries for release-plz
-
-### Reverted
-
-- undo release PR [[#215](https://github.com/kent8192/reinhardt-web/issues/215)](https://github.com/kent8192/reinhardt-web/issues/215) version bumps
-- undo PR [[#219](https://github.com/kent8192/reinhardt-web/issues/219)](https://github.com/kent8192/reinhardt-web/issues/219) version bumps for unpublished crates
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-websockets@v0.1.0-alpha.3...reinhardt-websockets@v0.1.0-alpha.4) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-websockets/Cargo.toml
+++ b/crates/reinhardt-websockets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-websockets"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.4"
 description = "WebSocket support for real-time bidirectional communication"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

This PR addresses:

- Reverting unpublished crate versions and CHANGELOGs to their pre-release state after a partial publish failure

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Release PR #224 was merged, but `release-plz release` failed due to a gix overflow error. Only `reinhardt-di` and `reinhardt-server` were successfully published at `0.1.0-alpha.5`. The remaining 20 crates had their versions and CHANGELOGs updated but were never published to crates.io.

Because release-plz sees these crates as "already up-to-date" (versions match the release commit), it won't generate a new Release PR. This revert restores unpublished crate versions to their pre-release state so release-plz can detect the changes and create a fresh Release PR.

Related to: #224, #225

## How Was This Tested?

- `cargo check --workspace --all --all-features` passes
- `git diff` confirms `reinhardt-di` and `reinhardt-server` (published crates) are unchanged
- 42 files reverted: 20 sub-crate `Cargo.toml` + 20 `CHANGELOG.md` + root `Cargo.toml` + root `CHANGELOG.md`
- Root `Cargo.toml` workspace deps for `reinhardt-di` and `reinhardt-server` updated to `0.1.0-alpha.5` (published version)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

---

**Additional Context:**

Protected crates (NOT reverted):
- `reinhardt-di@0.1.0-alpha.5` — published to crates.io
- `reinhardt-server@0.1.0-alpha.5` — published to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)