### PR TITLE
fix(release): roll back unpublished crate versions and enable release_always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.10](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-alpha.9...reinhardt-web@v0.1.0-alpha.10) - 2026-02-12
-
-### Changed
-
-- convert relative paths to absolute paths
-- *(db)* convert relative paths to absolute paths in orm execution
-- restore single-level super:: paths preserved by convention
-
-### Fixed
-
-- correct incorrect path conversions in test imports
-
-### Maintenance
-
-- *(todo-check)* add clippy todo lint job to TODO Check workflow
-
-### Reverted
-
-- undo unintended visibility and formatting changes
-
 ## [0.1.0-alpha.9](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-alpha.8...reinhardt-web@v0.1.0-alpha.9) - 2026-02-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 license.workspace = true
 description = "A full-stack API framework for Rust, inspired by Django and Django REST Framework"
@@ -368,7 +368,7 @@ authors = ["kent8192 <51869472+kent8192@users.noreply.github.com>"]
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-alpha.10" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-alpha.9" }
 
 # Internal crates
 reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0-alpha.5" }
@@ -393,19 +393,19 @@ reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-alpha.9" }
 reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.0-alpha.2" }
 reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0-alpha.6" }
 reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0-alpha.7" }
-reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-alpha.9" }
-reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-alpha.6" }
+reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-alpha.8" }
+reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-alpha.5" }
 reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0-alpha.1" }
 reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0-alpha.2" }
-reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-alpha.12" }
+reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-alpha.11" }
 reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0-alpha.8" }
 reinhardt-postgres = { path = "crates/reinhardt-postgres", version = "0.1.0-alpha.1" }
 reinhardt-events = { path = "crates/reinhardt-events", version = "0.1.0-alpha.1" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-alpha.7" }
-reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-alpha.6" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-alpha.6" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-alpha.6" }
+reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-alpha.5" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-alpha.5" }
 reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0-alpha.5" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-alpha.6" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-alpha.5" }
 reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0-alpha.6" }
 reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0-alpha.6" }
 reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-alpha.7" }

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.9](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.0-alpha.8...reinhardt-admin-cli@v0.1.0-alpha.9) - 2026-02-12
-
-### Maintenance
-
-- updated the following local packages: reinhardt-pages, reinhardt-dentdelion, reinhardt-commands
-
 ## [0.1.0-alpha.8](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.0-alpha.7...reinhardt-admin-cli@v0.1.0-alpha.8) - 2026-02-10
 
 ### Maintenance

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin-cli"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.8"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-commands/CHANGELOG.md
+++ b/crates/reinhardt-commands/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.12](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0-alpha.11...reinhardt-commands@v0.1.0-alpha.12) - 2026-02-12
-
-### Maintenance
-
-- updated the following local packages: reinhardt-utils, reinhardt-conf, reinhardt-db, reinhardt-urls, reinhardt-pages, reinhardt-http, reinhardt-di, reinhardt-server, reinhardt-apps, reinhardt-mail, reinhardt-middleware, reinhardt-rest, reinhardt-test, reinhardt-dentdelion, reinhardt-openapi
-
 ## [0.1.0-alpha.11](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0-alpha.10...reinhardt-commands@v0.1.0-alpha.11) - 2026-02-10
 
 ### Maintenance

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-commands"
-version = "0.1.0-alpha.12"
+version = "0.1.0-alpha.11"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-dispatch/CHANGELOG.md
+++ b/crates/reinhardt-dispatch/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dispatch@v0.1.0-alpha.5...reinhardt-dispatch@v0.1.0-alpha.6) - 2026-02-12
-
-### Maintenance
-
-- updated the following local packages: reinhardt-core, reinhardt-urls, reinhardt-http, reinhardt-middleware, reinhardt-views
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dispatch@v0.1.0-alpha.4...reinhardt-dispatch@v0.1.0-alpha.5) - 2026-02-10
 
 ### Maintenance

--- a/crates/reinhardt-dispatch/Cargo.toml
+++ b/crates/reinhardt-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dispatch"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-graphql/CHANGELOG.md
+++ b/crates/reinhardt-graphql/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.1.0-alpha.5...reinhardt-graphql@v0.1.0-alpha.6) - 2026-02-12
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-grpc
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.1.0-alpha.4...reinhardt-graphql@v0.1.0-alpha.5) - 2026-02-10
 
 ### Maintenance

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-grpc/CHANGELOG.md
+++ b/crates/reinhardt-grpc/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.1.0-alpha.5...reinhardt-grpc@v0.1.0-alpha.6) - 2026-02-12
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.1.0-alpha.4...reinhardt-grpc@v0.1.0-alpha.5) - 2026-02-10
 
 ### Maintenance

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 description = "gRPC support for building RPC services"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-i18n/CHANGELOG.md
+++ b/crates/reinhardt-i18n/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.1.0-alpha.5...reinhardt-i18n@v0.1.0-alpha.6) - 2026-02-12
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-di
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.1.0-alpha.4...reinhardt-i18n@v0.1.0-alpha.5) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 description = "Internationalization and localization support"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-shortcuts/CHANGELOG.md
+++ b/crates/reinhardt-shortcuts/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.1.0-alpha.6...reinhardt-shortcuts@v0.1.0-alpha.7) - 2026-02-12
-
-### Maintenance
-
-- updated the following local packages: reinhardt-core, reinhardt-db, reinhardt-urls, reinhardt-http, reinhardt-views
-
 ## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.1.0-alpha.5...reinhardt-shortcuts@v0.1.0-alpha.6) - 2026-02-10
 
 ### Maintenance

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -29,11 +29,13 @@ dependencies_update = true
 # - Stage 1: Push to main → `release-plz release-pr` creates Release PR (branch: release-plz-*)
 # - Stage 2: Merge Release PR → `release-plz release` detects commit from release-plz-* branch and publishes
 #
-# With release_always = false:
-# - release-plz only publishes when the commit is from a merged release-plz-* branch PR
-# - This gives maintainers control over when releases happen (must merge the Release PR)
+# With release_always = true:
+# - release-plz publishes ALL crates whose local version differs from crates.io
+# - This prevents phantom version bumps from `dependencies_update = true` (see KI-5 in RELEASE_PROCESS.md)
+# - Normal code pushes are unaffected since versions match crates.io
+# - Only after Release PR merge will version differences trigger publishing
 # See: https://release-plz.ieni.dev/docs/config#the-release_always-field
-release_always = false
+release_always = true
 
 # Skip cargo publish verification (dev-dependencies may reference unpublished workspace crates)
 publish_no_verify = true


### PR DESCRIPTION
## Summary

- Roll back versions and CHANGELOGs for 8 crates that were version-bumped in Release PR #246 but not published to crates.io
- Set `release_always = true` in `release-plz.toml` to prevent recurring phantom version issue
- Document KI-5 (Phantom Version Bumps from `dependencies_update`) in RELEASE_PROCESS.md

## Context

Release PR #246 merged and `release-plz release` ran, but only 22/30 crates were published. 5 crates were skipped because they had dependency-only version bumps (no code changes), and 3 downstream crates failed because their dependencies weren't on crates.io.

**Root cause**: `release_always = false` causes `release-plz release` to skip crates with no actual code changes, even when `dependencies_update = true` bumped their versions. For pre-release semver (`0.x.y-alpha.N`), `^` ranges require exact match, so downstream crates fail.

**Fix**: `release_always = true` ensures all version-bumped crates are published. Normal pushes are unaffected since versions match crates.io.

### Rolled back crates

| Crate | Rolled back from | Rolled back to | Reason |
|-------|-----------------|----------------|--------|
| reinhardt-i18n | 0.1.0-alpha.6 | 0.1.0-alpha.5 | Skipped (dep-only) |
| reinhardt-grpc | 0.1.0-alpha.6 | 0.1.0-alpha.5 | Skipped (dep-only) |
| reinhardt-dispatch | 0.1.0-alpha.6 | 0.1.0-alpha.5 | Skipped (dep-only) |
| reinhardt-shortcuts | 0.1.0-alpha.7 | 0.1.0-alpha.6 | Skipped (dep-only) |
| reinhardt-graphql | 0.1.0-alpha.6 | 0.1.0-alpha.5 | Skipped (dep-only) |
| reinhardt-commands | 0.1.0-alpha.12 | 0.1.0-alpha.11 | Failed (i18n missing) |
| reinhardt-admin-cli | 0.1.0-alpha.9 | 0.1.0-alpha.8 | Unreached |
| reinhardt-web | 0.1.0-alpha.10 | 0.1.0-alpha.9 | Unreached |

## Test plan

- [x] `cargo check --workspace --all --all-features` passes
- [ ] After merge, verify `release-plz release-pr` creates new Release PR with all 8 crates
- [ ] After Release PR merge, verify all 8 crates are published to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)