### PR TITLE
fix(release): recover from partial release failure in PR #250

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,38 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.11](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-alpha.10...reinhardt-web@v0.1.0-alpha.11) - 2026-02-14
-
-### Changed
-
-- *(query)* replace super::super:: with crate:: absolute paths in query submodules
-- *(query)* replace super::super:: with crate:: absolute paths in dcl tests
-- *(db)* replace super::super:: with crate:: absolute paths in migrations
-- *(rest)* remove unused sea-orm dependency
-- *(query)* remove unused backend imports in drop role and drop user tests
-- *(db)* fix unused variable assignments in migration operation tests
-- *(query)* move DML integration tests to integration test crate
-
-### Fixed
-
-- *(query)* add missing DropBehavior import in revoke statement tests
-- *(query)* add Table variant special handling in Iden derive macro
-- *(query)* add missing code fence markers in alter_type doc example
-- *(ci)* migrate publish check to cargo publish --workspace
-- *(query)* add explicit path attributes to DML test module declarations
-- *(query)* add Meta::List support to Iden derive macro attribute parsing
-- *(query)* read iden attribute from struct-level instead of first field
-- *(db)* bind insert values in many-to-many manager instead of discarding
-- *(query)* reject whitespace-only names in CreateUser and GrantRole validation
-
-### Maintenance
-
-- increase test partition counts for faster CI execution
-
-### Styling
-
-- *(query)* format Iden derive macro code
-
 ## [0.1.0-alpha.10](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-alpha.9...reinhardt-web@v0.1.0-alpha.10) - 2026-02-12
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.10"
 edition.workspace = true
 license.workspace = true
 description = "A full-stack API framework for Rust, inspired by Django and Django REST Framework"
@@ -370,7 +370,7 @@ authors = ["kent8192 <51869472+kent8192@users.noreply.github.com>"]
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-alpha.11" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-alpha.10" }
 
 # Internal crates
 reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0-alpha.6" }
@@ -395,20 +395,20 @@ reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-alpha.10" }
 reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.0-alpha.2" }
 reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0-alpha.7" }
 reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0-alpha.8" }
-reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-alpha.10" }
-reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-alpha.6" }
+reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-alpha.9" }
+reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-alpha.5" }
 reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0-alpha.1" }
 reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0-alpha.2" }
-reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-alpha.13" }
+reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-alpha.12" }
 reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0-alpha.9" }
 reinhardt-query = { path = "crates/reinhardt-query", version = "0.1.0-alpha.1" }
 reinhardt-postgres = { path = "crates/reinhardt-postgres", version = "0.1.0-alpha.1" }
 reinhardt-events = { path = "crates/reinhardt-events", version = "0.1.0-alpha.1" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-alpha.7" }
-reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-alpha.6" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-alpha.6" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-alpha.6" }
+reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-alpha.5" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-alpha.5" }
 reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0-alpha.6" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-alpha.6" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-alpha.5" }
 reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0-alpha.7" }
 reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0-alpha.7" }
 reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-alpha.8" }

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin-cli"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-commands/CHANGELOG.md
+++ b/crates/reinhardt-commands/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.13](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0-alpha.12...reinhardt-commands@v0.1.0-alpha.13) - 2026-02-14
-
-### Maintenance
-
-- updated the following local packages: reinhardt-conf, reinhardt-di, reinhardt-db, reinhardt-rest, reinhardt-pages, reinhardt-test, reinhardt-server, reinhardt-apps, reinhardt-mail, reinhardt-middleware, reinhardt-urls, reinhardt-dentdelion, reinhardt-openapi
-
 ## [0.1.0-alpha.12](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0-alpha.11...reinhardt-commands@v0.1.0-alpha.12) - 2026-02-12
 
 ### Fixed

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-commands"
-version = "0.1.0-alpha.13"
+version = "0.1.0-alpha.12"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-dispatch/CHANGELOG.md
+++ b/crates/reinhardt-dispatch/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dispatch@v0.1.0-alpha.5...reinhardt-dispatch@v0.1.0-alpha.6) - 2026-02-14
-
-### Maintenance
-
-- updated the following local packages: reinhardt-views, reinhardt-middleware, reinhardt-urls
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dispatch@v0.1.0-alpha.4...reinhardt-dispatch@v0.1.0-alpha.5) - 2026-02-10
 
 ### Maintenance

--- a/crates/reinhardt-dispatch/Cargo.toml
+++ b/crates/reinhardt-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dispatch"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-graphql/CHANGELOG.md
+++ b/crates/reinhardt-graphql/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.1.0-alpha.5...reinhardt-graphql@v0.1.0-alpha.6) - 2026-02-14
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-grpc
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.1.0-alpha.4...reinhardt-graphql@v0.1.0-alpha.5) - 2026-02-10
 
 ### Maintenance

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-grpc/CHANGELOG.md
+++ b/crates/reinhardt-grpc/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.1.0-alpha.5...reinhardt-grpc@v0.1.0-alpha.6) - 2026-02-14
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.1.0-alpha.4...reinhardt-grpc@v0.1.0-alpha.5) - 2026-02-10
 
 ### Maintenance

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 description = "gRPC support for building RPC services"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-i18n/CHANGELOG.md
+++ b/crates/reinhardt-i18n/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.1.0-alpha.5...reinhardt-i18n@v0.1.0-alpha.6) - 2026-02-14
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-di
-
 ## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.1.0-alpha.4...reinhardt-i18n@v0.1.0-alpha.5) - 2026-02-06
 
 ### Other

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.5"
 description = "Internationalization and localization support"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-shortcuts/CHANGELOG.md
+++ b/crates/reinhardt-shortcuts/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.1.0-alpha.6...reinhardt-shortcuts@v0.1.0-alpha.7) - 2026-02-14
-
-### Maintenance
-
-- updated the following local packages: reinhardt-db, reinhardt-views, reinhardt-urls
-
 ## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.1.0-alpha.5...reinhardt-shortcuts@v0.1.0-alpha.6) - 2026-02-10
 
 ### Maintenance

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

- Remove unused `reinhardt-i18n` dev-dependency from `reinhardt-commands` (KI-1 violation fix)
- Roll back versions and CHANGELOGs of 8 unpublished crates to their last published versions (RP-1 procedure)

## Root Cause

PR #250 merge triggered a partial release failure: 32+ crates published successfully, but 8 failed. `reinhardt-commands` had `reinhardt-i18n` in `[dev-dependencies]`, and `cargo publish` packaging tried to resolve `reinhardt-i18n = "^0.1.0-alpha.6"` from crates.io before it was published. `publish_no_verify = true` only skips build verification, not dependency resolution during packaging.

## Affected Crates (rolled back)

| Crate | Rolled back from | Rolled back to |
|-------|------------------|----------------|
| `reinhardt-web` (root) | 0.1.0-alpha.11 | 0.1.0-alpha.10 |
| `reinhardt-i18n` | 0.1.0-alpha.6 | 0.1.0-alpha.5 |
| `reinhardt-commands` | 0.1.0-alpha.13 | 0.1.0-alpha.12 |
| `reinhardt-admin-cli` | 0.1.0-alpha.10 | 0.1.0-alpha.9 |
| `reinhardt-grpc` | 0.1.0-alpha.6 | 0.1.0-alpha.5 |
| `reinhardt-dispatch` | 0.1.0-alpha.6 | 0.1.0-alpha.5 |
| `reinhardt-shortcuts` | 0.1.0-alpha.7 | 0.1.0-alpha.6 |
| `reinhardt-graphql` | 0.1.0-alpha.6 | 0.1.0-alpha.5 |

## Test plan

- [x] `cargo check --workspace --all --all-features` passes
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes
- [ ] After merge, release-plz generates a new Release PR with correct version bumps
- [ ] After Release PR merge, all 8 crates are published to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)