### PR TITLE
fix!: implement MySQL user@host parsing for DCL statements

### DIFF
--- a/crates/reinhardt-query/src/backend/mysql.rs
+++ b/crates/reinhardt-query/src/backend/mysql.rs
@@ -45,6 +45,25 @@ use crate::{
 #[derive(Debug, Clone, Default)]
 pub struct MySqlQueryBuilder;
 
+/// Parse a MySQL user identifier into (user, host) parts.
+///
+/// If no `@` is present, defaults host to `%`.
+fn parse_user_host(user_name: &str) -> (String, String) {
+	let parts: Vec<&str> = user_name.splitn(2, '@').collect();
+	if parts.len() == 2 {
+		let host = parts[1].trim_matches('\'');
+		(parts[0].to_string(), host.to_string())
+	} else {
+		(user_name.to_string(), "%".to_string())
+	}
+}
+
+/// Format a MySQL user identifier as `'user'@'host'`.
+fn format_mysql_user(user_name: &str) -> String {
+	let (user, host) = parse_user_host(user_name);
+	format!("'{}'@'{}'", user, host)
+}
+
 impl MySqlQueryBuilder {
 	/// Create a new MySQL query builder
 	pub fn new() -> Self {
@@ -2404,7 +2423,7 @@ impl QueryBuilder for MySqlQueryBuilder {
 		}
 
 		// User name (with optional @host)
-		writer.push_identifier(&stmt.user_name, |s| self.escape_iden(s));
+		writer.push(&format_mysql_user(&stmt.user_name));
 
 		// User options (same as CREATE ROLE)
 		for option in &stmt.options {
@@ -2530,7 +2549,7 @@ impl QueryBuilder for MySqlQueryBuilder {
 
 		// User names (comma-separated)
 		writer.push_list(&stmt.user_names, ", ", |w, user| {
-			w.push_identifier(user, |s| self.escape_iden(s));
+			w.push(&format_mysql_user(user));
 		});
 
 		writer.finish()
@@ -2553,7 +2572,7 @@ impl QueryBuilder for MySqlQueryBuilder {
 		}
 
 		// User name (with optional @host)
-		writer.push_identifier(&stmt.user_name, |s| self.escape_iden(s));
+		writer.push(&format_mysql_user(&stmt.user_name));
 
 		// User options (same as ALTER ROLE)
 		for option in &stmt.options {
@@ -2673,11 +2692,11 @@ impl QueryBuilder for MySqlQueryBuilder {
 
 		// Rename pairs (comma-separated)
 		writer.push_list(&stmt.renames, ", ", |w, (old, new)| {
-			w.push_identifier(old, |s| self.escape_iden(s));
+			w.push(&format_mysql_user(old));
 			w.push_space();
 			w.push("TO");
 			w.push_space();
-			w.push_identifier(new, |s| self.escape_iden(s));
+			w.push(&format_mysql_user(new));
 		});
 
 		writer.finish()
@@ -2757,7 +2776,7 @@ impl QueryBuilder for MySqlQueryBuilder {
 
 		// User names (comma-separated)
 		writer.push_list(&stmt.user_names, ", ", |w, user| {
-			w.push_identifier(user, |s| self.escape_iden(s));
+			w.push(&format_mysql_user(user));
 		});
 
 		writer.finish()
@@ -7153,7 +7172,7 @@ mod tests {
 		let stmt = CreateUserStatement::new().user("app_user@localhost");
 
 		let (sql, values) = builder.build_create_user(&stmt);
-		assert_eq!(sql, "CREATE USER `app_user@localhost`");
+		assert_eq!(sql, "CREATE USER 'app_user'@'localhost'");
 		assert!(values.is_empty());
 	}
 
@@ -7167,7 +7186,7 @@ mod tests {
 			.if_not_exists(true);
 
 		let (sql, values) = builder.build_create_user(&stmt);
-		assert_eq!(sql, "CREATE USER IF NOT EXISTS `app_user`");
+		assert_eq!(sql, "CREATE USER IF NOT EXISTS 'app_user'@'%'");
 		assert!(values.is_empty());
 	}
 
@@ -7182,7 +7201,7 @@ mod tests {
 			.option(UserOption::Password("secret".to_string()));
 
 		let (sql, values) = builder.build_create_user(&stmt);
-		assert_eq!(sql, "CREATE USER `app_user` IDENTIFIED BY ?");
+		assert_eq!(sql, "CREATE USER 'app_user'@'%' IDENTIFIED BY ?");
 		assert_eq!(values.len(), 1);
 		assert_eq!(
 			values[0],
@@ -7200,7 +7219,7 @@ mod tests {
 			.default_role(vec!["app_role".to_string()]);
 
 		let (sql, values) = builder.build_create_user(&stmt);
-		assert_eq!(sql, "CREATE USER `app_user` DEFAULT ROLE `app_role`");
+		assert_eq!(sql, "CREATE USER 'app_user'@'%' DEFAULT ROLE `app_role`");
 		assert!(values.is_empty());
 	}
 
@@ -7213,7 +7232,7 @@ mod tests {
 		let stmt = DropUserStatement::new().user("app_user@localhost");
 
 		let (sql, values) = builder.build_drop_user(&stmt);
-		assert_eq!(sql, "DROP USER `app_user@localhost`");
+		assert_eq!(sql, "DROP USER 'app_user'@'localhost'");
 		assert!(values.is_empty());
 	}
 
@@ -7225,7 +7244,7 @@ mod tests {
 		let stmt = DropUserStatement::new().user("app_user").if_exists(true);
 
 		let (sql, values) = builder.build_drop_user(&stmt);
-		assert_eq!(sql, "DROP USER IF EXISTS `app_user`");
+		assert_eq!(sql, "DROP USER IF EXISTS 'app_user'@'%'");
 		assert!(values.is_empty());
 	}
 
@@ -7240,7 +7259,7 @@ mod tests {
 			.option(UserOption::AccountUnlock);
 
 		let (sql, values) = builder.build_alter_user(&stmt);
-		assert_eq!(sql, "ALTER USER `app_user` ACCOUNT UNLOCK");
+		assert_eq!(sql, "ALTER USER 'app_user'@'%' ACCOUNT UNLOCK");
 		assert!(values.is_empty());
 	}
 
@@ -7254,7 +7273,7 @@ mod tests {
 			.default_role(vec!["app_role".to_string()]);
 
 		let (sql, values) = builder.build_alter_user(&stmt);
-		assert_eq!(sql, "ALTER USER `app_user` DEFAULT ROLE `app_role`");
+		assert_eq!(sql, "ALTER USER 'app_user'@'%' DEFAULT ROLE `app_role`");
 		assert!(values.is_empty());
 	}
 
@@ -7269,7 +7288,7 @@ mod tests {
 		let (sql, values) = builder.build_rename_user(&stmt);
 		assert_eq!(
 			sql,
-			"RENAME USER `old_user@localhost` TO `new_user@localhost`"
+			"RENAME USER 'old_user'@'localhost' TO 'new_user'@'localhost'"
 		);
 		assert!(values.is_empty());
 	}
@@ -7286,7 +7305,7 @@ mod tests {
 		let (sql, values) = builder.build_rename_user(&stmt);
 		assert_eq!(
 			sql,
-			"RENAME USER `user1` TO `renamed1`, `user2` TO `renamed2`"
+			"RENAME USER 'user1'@'%' TO 'renamed1'@'%', 'user2'@'%' TO 'renamed2'@'%'"
 		);
 		assert!(values.is_empty());
 	}
@@ -7364,7 +7383,7 @@ mod tests {
 			.user("app_user@localhost");
 
 		let (sql, values) = builder.build_set_default_role(&stmt);
-		assert_eq!(sql, "SET DEFAULT ROLE ALL TO `app_user@localhost`");
+		assert_eq!(sql, "SET DEFAULT ROLE ALL TO 'app_user'@'localhost'");
 		assert!(values.is_empty());
 	}
 
@@ -7378,7 +7397,7 @@ mod tests {
 			.user("app_user");
 
 		let (sql, values) = builder.build_set_default_role(&stmt);
-		assert_eq!(sql, "SET DEFAULT ROLE NONE TO `app_user`");
+		assert_eq!(sql, "SET DEFAULT ROLE NONE TO 'app_user'@'%'");
 		assert!(values.is_empty());
 	}
 
@@ -7395,7 +7414,7 @@ mod tests {
 			.user("app_user");
 
 		let (sql, values) = builder.build_set_default_role(&stmt);
-		assert_eq!(sql, "SET DEFAULT ROLE `role1`, `role2` TO `app_user`");
+		assert_eq!(sql, "SET DEFAULT ROLE `role1`, `role2` TO 'app_user'@'%'");
 		assert!(values.is_empty());
 	}
 }

--- a/crates/reinhardt-query/src/dcl/alter_user_tests.rs
+++ b/crates/reinhardt-query/src/dcl/alter_user_tests.rs
@@ -397,7 +397,6 @@ fn test_postgres_alter_user_with_password() {
 // ============================================================================
 
 #[rstest]
-#[ignore = "Requires implementation of user@host syntax in MySQL ALTER USER backend"]
 fn test_mysql_alter_user_with_option() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = AlterUserStatement::new()
@@ -406,13 +405,12 @@ fn test_mysql_alter_user_with_option() {
 
 	let (sql, values) = builder.build_alter_user(&stmt);
 
-	assert!(sql.contains(r#"ALTER USER 'test_user'@"#));
+	assert!(sql.contains("ALTER USER 'test_user'@'%'"));
 	assert!(sql.contains("ACCOUNT LOCK"));
 	assert!(values.is_empty());
 }
 
 #[rstest]
-#[ignore = "Requires implementation of DEFAULT ROLE clause in MySQL ALTER USER backend"]
 fn test_mysql_alter_user_with_default_role() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = AlterUserStatement::new()
@@ -421,13 +419,12 @@ fn test_mysql_alter_user_with_default_role() {
 
 	let (sql, values) = builder.build_alter_user(&stmt);
 
-	assert!(sql.contains(r#"ALTER USER 'test_user'@"#));
+	assert!(sql.contains("ALTER USER 'test_user'@'%'"));
 	assert!(sql.contains(r#"DEFAULT ROLE `app_role`"#));
 	assert!(values.is_empty());
 }
 
 #[rstest]
-#[ignore = "Requires implementation of proper user@host parsing and quoting in MySQL backend"]
 fn test_mysql_alter_user_at_host() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = AlterUserStatement::new()

--- a/crates/reinhardt-query/src/dcl/create_user_tests.rs
+++ b/crates/reinhardt-query/src/dcl/create_user_tests.rs
@@ -428,19 +428,17 @@ fn test_postgres_create_user_with_password() {
 // ============================================================================
 
 #[rstest]
-#[ignore = "Requires implementation of user@host syntax in MySQL CREATE USER backend"]
 fn test_mysql_create_user_basic() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = CreateUserStatement::new().user("test_user");
 
 	let (sql, values) = builder.build_create_user(&stmt);
 
-	assert_eq!(sql, r#"CREATE USER 'test_user'@"#);
+	assert_eq!(sql, "CREATE USER 'test_user'@'%'");
 	assert!(values.is_empty());
 }
 
 #[rstest]
-#[ignore = "Requires implementation of proper user@host parsing in MySQL CREATE USER backend"]
 fn test_mysql_create_user_at_host() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = CreateUserStatement::new().user("app_user@localhost");

--- a/crates/reinhardt-query/src/dcl/rename_user_tests.rs
+++ b/crates/reinhardt-query/src/dcl/rename_user_tests.rs
@@ -247,7 +247,6 @@ fn test_postgres_panic_message() {
 // ============================================================================
 
 #[rstest]
-#[ignore = "Requires implementation of user@host parsing in MySQL RENAME USER backend"]
 fn test_mysql_rename_single_user() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = RenameUserStatement::new().rename("old_user@localhost", "new_user@localhost");
@@ -262,7 +261,6 @@ fn test_mysql_rename_single_user() {
 }
 
 #[rstest]
-#[ignore = "Requires implementation of user@host parsing in MySQL RENAME USER backend"]
 fn test_mysql_rename_multiple_users() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = RenameUserStatement::new()
@@ -280,7 +278,6 @@ fn test_mysql_rename_multiple_users() {
 }
 
 #[rstest]
-#[ignore = "Requires implementation of user@host parsing in MySQL RENAME USER backend"]
 fn test_mysql_rename_with_ip_host() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = RenameUserStatement::new().rename("user@'192.168.1.1'", "new_user@'192.168.1.1'");

--- a/crates/reinhardt-query/src/dcl/set_default_role_tests.rs
+++ b/crates/reinhardt-query/src/dcl/set_default_role_tests.rs
@@ -269,7 +269,6 @@ fn test_sqlite_panic_message() {
 // ============================================================================
 
 #[rstest]
-#[ignore = "Requires implementation of user@host parsing in MySQL SET DEFAULT ROLE backend"]
 fn test_mysql_role_list() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = SetDefaultRoleStatement::new()
@@ -288,7 +287,6 @@ fn test_mysql_role_list() {
 }
 
 #[rstest]
-#[ignore = "Requires implementation of user@host parsing in MySQL SET DEFAULT ROLE backend"]
 fn test_mysql_role_all() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = SetDefaultRoleStatement::new()
@@ -302,7 +300,6 @@ fn test_mysql_role_all() {
 }
 
 #[rstest]
-#[ignore = "Requires implementation of user@host parsing in MySQL SET DEFAULT ROLE backend"]
 fn test_mysql_role_none() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = SetDefaultRoleStatement::new()
@@ -316,7 +313,6 @@ fn test_mysql_role_none() {
 }
 
 #[rstest]
-#[ignore = "Requires implementation of user@host parsing in MySQL SET DEFAULT ROLE backend"]
 fn test_mysql_multiple_users() {
 	let builder = MySqlQueryBuilder::new();
 	let stmt = SetDefaultRoleStatement::new()


### PR DESCRIPTION
## Summary

- Add helper functions to properly format MySQL user identifiers as `'user'@'host'` instead of incorrectly backtick-quoting them
- When no host is specified, defaults to `'%'` (any host), following MySQL convention
- Fixes all affected DCL statements: CREATE USER, ALTER USER, DROP USER, RENAME USER, SET DEFAULT ROLE
- Re-enables previously ignored tests in `set_default_role_tests.rs`

**BREAKING CHANGE**: MySQL DCL statements now generate `'user'@'host'` syntax instead of backtick-quoted identifiers. This changes the SQL output format for all MySQL user-related DCL operations.

Closes #41

## Conflict Resolution

This PR resolves conflicts with PR #268 (password parameterization):
- User name format: `'user'@'host'` (this PR)
- Password parameterization: `?` (PR #268)

Both changes are now integrated.

## Test plan

- [x] All 546 tests in `reinhardt-query` pass
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes
- [ ] CI pipeline passes
- [ ] Verify previously ignored tests in `set_default_role_tests.rs` now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)