### PR TITLE
ci: skip release dry-run on release-plz branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
 
   release-dry-run:
     name: Release Dry-Run
+    if: ${{ !startsWith(github.head_ref || '', 'release-plz-') }}
     uses: ./.github/workflows/release-plz-dry-run.yml
 
   # All tests run in parallel after lightweight checks
@@ -84,6 +85,7 @@ jobs:
   # All jobs must pass
   ci-success:
     name: CI Success
+    if: always()
     runs-on: ubuntu-latest
     needs:
       - check
@@ -99,5 +101,31 @@ jobs:
       - examples-test
       - ui-test
     steps:
-      - name: Mark CI as successful
-        run: echo "All CI checks passed!"
+      - name: Verify all required checks passed
+        run: |
+          required_results=(
+            "${{ needs.check.result }}"
+            "${{ needs.fmt.result }}"
+            "${{ needs.clippy.result }}"
+            "${{ needs.publish-check.result }}"
+            "${{ needs.todo-check.result }}"
+            "${{ needs.unit-test.result }}"
+            "${{ needs.intra-crate-integration-test.result }}"
+            "${{ needs.cross-crate-integration-test.result }}"
+            "${{ needs.doc-test.result }}"
+            "${{ needs.examples-test.result }}"
+            "${{ needs.ui-test.result }}"
+          )
+          for result in "${required_results[@]}"; do
+            if [[ "$result" != "success" ]]; then
+              echo "::error::Required CI check failed: $result"
+              exit 1
+            fi
+          done
+          # release-dry-run is skipped on release-plz branches (expected)
+          dry_run="${{ needs.release-dry-run.result }}"
+          if [[ "$dry_run" != "success" && "$dry_run" != "skipped" ]]; then
+            echo "::error::Release dry-run failed: $dry_run"
+            exit 1
+          fi
+          echo "All CI checks passed!"


### PR DESCRIPTION
## Summary

- Skip `release-dry-run` CI job on Release PRs (branches prefixed with `release-plz-`)
- Update `ci-success` job to explicitly verify all required checks while allowing `release-dry-run` to be skipped

## Root Cause

`release-plz release --dry-run` always fails on Release PRs because version-bumped crates haven't been published to crates.io yet. The dry-run locally "publishes" crates but downstream crates still try to resolve the new versions from crates.io, causing dependency resolution errors. This is a structural limitation of the dry-run approach on release branches.

## Fix

1. Added `if: ${{ !startsWith(github.head_ref || '', 'release-plz-') }}` to skip `release-dry-run` on Release PRs
2. Updated `ci-success` to use `if: always()` with explicit result checking, allowing `release-dry-run` to have `skipped` status on Release PRs while requiring `success` on all other PRs

## Test plan

- [ ] CI passes on this PR (non-release branch, dry-run runs normally)
- [ ] Release PR CI will skip dry-run and still report success
- [ ] All other CI checks remain enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)