### PR TITLE
chore(admin): fix misleading table_name() default implementation doc

### DIFF
--- a/crates/reinhardt-admin/src/core/model_admin.rs
+++ b/crates/reinhardt-admin/src/core/model_admin.rs
@@ -14,7 +14,8 @@ pub trait ModelAdmin: Send + Sync {
 
 	/// Get the database table name
 	///
-	/// By default, returns the model name in lowercase.
+	/// By default, returns an empty string as a placeholder.
+	/// Implementors should override this to return the actual table name.
 	fn table_name(&self) -> &str {
 		// Default implementation returns empty string
 		// Override in implementations to return actual table name


### PR DESCRIPTION
## Summary
- Fix the doc comment for `table_name()` in `ModelAdmin` trait to accurately describe the default behavior
- The previous doc comment was misleading about how the default table name is derived
- Now clearly states it returns an empty string as a placeholder

Closes #313

## Test plan
- [x] `cargo make fmt-check` passes (verified via pre-push hook)
- [ ] `cargo nextest run --package reinhardt-admin` passes
- [ ] `cargo make clippy-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)