### PR TITLE
refactor(urls): remove incorrect dead_code annotations from proxy fields

### DIFF
--- a/crates/reinhardt-urls/src/proxy/collection/aggregations.rs
+++ b/crates/reinhardt-urls/src/proxy/collection/aggregations.rs
@@ -7,7 +7,6 @@ use crate::proxy::ScalarValue;
 /// Aggregation operations on collections
 #[derive(Debug, Clone)]
 pub struct CollectionAggregations {
-	#[allow(dead_code)]
 	proxy: CollectionProxy,
 }
 

--- a/crates/reinhardt-urls/src/proxy/collection/operations.rs
+++ b/crates/reinhardt-urls/src/proxy/collection/operations.rs
@@ -7,7 +7,6 @@ use crate::proxy::ScalarValue;
 /// Collection operations for filtering and transforming
 #[derive(Debug, Clone)]
 pub struct CollectionOperations {
-	#[allow(dead_code)]
 	proxy: CollectionProxy,
 }
 


### PR DESCRIPTION
## Summary
- Remove `#[allow(dead_code)]` from `proxy` field in `CollectionOperations` and `CollectionAggregations`
- The `proxy` field is actively used by methods like `filter()`, `map()`, `sort()`, `distinct()`, `sum()`, `avg()`, `min()`, `max()`
- The annotations were incorrectly applied and suppress legitimate compiler analysis

Closes #306

## Test plan
- [x] `cargo check --package reinhardt-urls --all-features` passes (no dead_code warnings)
- [x] `cargo nextest run --package reinhardt-urls` passes (242 tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --package reinhardt-urls --all-features -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)