### PR TITLE
refactor(conf): remove unused media_root field from Settings

### DIFF
--- a/crates/reinhardt-commands/src/bin/runserver.rs
+++ b/crates/reinhardt-commands/src/bin/runserver.rs
@@ -180,7 +180,6 @@ fn load_settings() -> Settings {
 				.with_value("static_root", serde_json::json!(null))
 				.with_value("staticfiles_dirs", serde_json::json!([]))
 				.with_value("media_url", serde_json::json!("/media/"))
-				.with_value("media_root", serde_json::json!(null))
 				// Internationalization
 				.with_value("language_code", serde_json::json!("en-us"))
 				.with_value("time_zone", serde_json::json!("UTC"))

--- a/crates/reinhardt-conf/src/settings.rs
+++ b/crates/reinhardt-conf/src/settings.rs
@@ -131,9 +131,6 @@ pub struct Settings {
 	/// Media files URL prefix
 	pub media_url: String,
 
-	/// Media files root directory
-	pub media_root: Option<PathBuf>,
-
 	/// Language code
 	pub language_code: String,
 
@@ -238,7 +235,6 @@ impl Settings {
 			static_root: None,
 			staticfiles_dirs: vec![],
 			media_url: "/media/".to_string(),
-			media_root: None,
 			language_code: "en-us".to_string(),
 			time_zone: "UTC".to_string(),
 			use_i18n: true,

--- a/tests/integration/tests/settings/settings_system_integration.rs
+++ b/tests/integration/tests/settings/settings_system_integration.rs
@@ -181,7 +181,6 @@ fn test_settings_deserialization() {
         "static_root": null,
         "staticfiles_dirs": [],
         "media_url": "/media/",
-        "media_root": null,
         "language_code": "en",
         "time_zone": "UTC",
         "use_i18n": true,


### PR DESCRIPTION
## Summary
- Remove unused `media_root: Option<PathBuf>` field from `Settings` struct
- Remove `media_root` initialization from `Settings::new()`
- Remove `media_root` default value setting from `runserver.rs`
- Update integration test JSON to remove `media_root` entry
- Note: `media_url` is intentionally kept as it is used in `get_static_config()`

Closes #291

## Test plan
- [ ] `cargo check --workspace --all --all-features` passes
- [ ] `cargo nextest run --workspace --all-features` passes
- [ ] `cargo make fmt-check` passes
- [ ] `cargo make clippy-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)