### PR TITLE
chore(admin): fix contradictory unimplemented!() messages in export handler

### DIFF
--- a/crates/reinhardt-admin/src/server/export.rs
+++ b/crates/reinhardt-admin/src/server/export.rs
@@ -102,11 +102,11 @@ pub async fn export_data(
 		// Allow: Excel/XML exports are permanently excluded features
 		#[allow(clippy::unimplemented)]
 		ExportFormat::Excel => {
-			unimplemented!("Excel export is not yet implemented")
+			unimplemented!("Excel export is permanently excluded")
 		}
 		#[allow(clippy::unimplemented)]
 		ExportFormat::XML => {
-			unimplemented!("XML export is not yet implemented")
+			unimplemented!("XML export is permanently excluded")
 		}
 	};
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix contradictory `unimplemented!()` messages in export handler where the comment says "permanently excluded features" but the messages say "not yet implemented"

## Type of Change

- [x] Code quality improvements

## Motivation and Context

The `unimplemented!()` macro messages in `crates/reinhardt-admin/src/server/export.rs` contradicted the surrounding comment. The comment correctly states these are "permanently excluded features", but the macro messages said "not yet implemented", implying they would be implemented in the future.

Fixes #303

## How Was This Tested?

- `cargo check --workspace --all --all-features`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `code-quality` - Code quality improvements

### Priority Label
- [x] `low` - Minor fix or enhancement

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)