### PR TITLE
docs(conf): wrap bare URL in backticks in azure provider doc comment

### DIFF
--- a/crates/reinhardt-conf/src/settings/secrets/providers/azure.rs
+++ b/crates/reinhardt-conf/src/settings/secrets/providers/azure.rs
@@ -42,7 +42,7 @@ impl AzureKeyVaultProvider {
 	///
 	/// # Arguments
 	///
-	/// * `vault_url` - The URL of the Azure Key Vault (e.g., "https://myvault.vault.azure.net")
+	/// * `vault_url` - The URL of the Azure Key Vault (e.g., `"https://myvault.vault.azure.net"`)
 	///
 	/// # Example
 	///


### PR DESCRIPTION
## Summary

This PR addresses:

- Wrap bare URL in backticks in azure provider doc comment to prevent rustdoc warnings

## Type of Change

- [x] Documentation update

## Motivation and Context

The doc comment at `crates/reinhardt-conf/src/settings/secrets/providers/azure.rs:45` contained a bare URL (`https://myvault.vault.azure.net`) that should be wrapped in backticks per project coding standards. Lines 27 and 54 are inside code blocks and were left unchanged.

Fixes #316

## How Was This Tested?

- `cargo check --workspace --all --all-features`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `documentation` - Documentation update

### Priority Label
- [x] `low` - Minor fix or enhancement

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)