### PR TITLE
docs(test): add SAFETY comments to unsafe Send/Sync implementations

### DIFF
--- a/crates/reinhardt-test/src/fixtures/mock.rs
+++ b/crates/reinhardt-test/src/fixtures/mock.rs
@@ -76,8 +76,15 @@ mock! {
 	}
 }
 
-// Mock backend is Send + Sync by design (all expectations are stored safely)
+// SAFETY: MockDatabaseBackend is Send-safe because all internal state
+// (mockall expectations) is stored in thread-safe containers. The mock
+// is designed for single-threaded test usage with tokio's async runtime,
+// and expectations are set before any concurrent access occurs.
 unsafe impl Send for MockDatabaseBackend {}
+// SAFETY: MockDatabaseBackend is Sync-safe because all expectation
+// matching in mockall uses internal synchronization. The mock backend
+// is accessed through Arc<MockDatabaseBackend> in test fixtures, and
+// concurrent read access to expectations is safe.
 unsafe impl Sync for MockDatabaseBackend {}
 
 // ============================================================================


### PR DESCRIPTION
## Summary

This PR addresses:

- Add proper `// SAFETY:` comments to `unsafe impl Send` and `unsafe impl Sync` for `MockDatabaseBackend`

## Type of Change

- [x] Documentation update

## Motivation and Context

The `unsafe impl Send/Sync` for `MockDatabaseBackend` in `crates/reinhardt-test/src/fixtures/mock.rs` had a generic comment but lacked the standard Rust `// SAFETY:` documentation explaining why the unsafe implementations are sound. Each implementation now has a detailed SAFETY comment explaining the thread-safety guarantees.

Fixes #308

## How Was This Tested?

- `cargo check --workspace --all --all-features`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `documentation` - Documentation update

### Priority Label
- [x] `low` - Minor fix or enhancement

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)