### PR TITLE
fix(forms): escape user input in Widget::render_html to prevent XSS

### DIFF
--- a/crates/reinhardt-forms/src/field.rs
+++ b/crates/reinhardt-forms/src/field.rs
@@ -1,6 +1,46 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Escapes special HTML characters to prevent XSS attacks.
+///
+/// This function converts the following characters to their HTML entity equivalents:
+/// - `&` → `&amp;`
+/// - `<` → `&lt;`
+/// - `>` → `&gt;`
+/// - `"` → `&quot;`
+/// - `'` → `&#x27;`
+///
+/// # Examples
+///
+/// ```
+/// use reinhardt_forms::field::html_escape;
+///
+/// assert_eq!(html_escape("<script>"), "&lt;script&gt;");
+/// assert_eq!(html_escape("a & b"), "a &amp; b");
+/// assert_eq!(html_escape("\"quoted\""), "&quot;quoted&quot;");
+/// ```
+pub fn html_escape(s: &str) -> String {
+	s.replace('&', "&amp;")
+		.replace('<', "&lt;")
+		.replace('>', "&gt;")
+		.replace('"', "&quot;")
+		.replace('\'', "&#x27;")
+}
+
+/// Escapes a value for use in an HTML attribute context.
+/// This is an alias for [`html_escape`] as the escaping rules are the same.
+///
+/// # Examples
+///
+/// ```
+/// use reinhardt_forms::field::escape_attribute;
+///
+/// assert_eq!(escape_attribute("on\"click"), "on&quot;click");
+/// ```
+pub fn escape_attribute(s: &str) -> String {
+	html_escape(s)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ErrorType {
 	Required,
@@ -93,7 +133,10 @@ pub enum Widget {
 }
 
 impl Widget {
-	/// Renders the widget as HTML
+	/// Renders the widget as HTML with XSS protection.
+	///
+	/// All user-controlled values (name, value, attributes, choices) are
+	/// HTML-escaped to prevent Cross-Site Scripting (XSS) attacks.
 	///
 	/// # Examples
 	///
@@ -107,6 +150,18 @@ impl Widget {
 	/// assert!(html.contains("name=\"username\""));
 	/// assert!(html.contains("value=\"john_doe\""));
 	/// ```
+	///
+	/// # XSS Protection
+	///
+	/// ```
+	/// use reinhardt_forms::Widget;
+	///
+	/// let widget = Widget::TextInput;
+	/// // Malicious input is escaped
+	/// let html = widget.render_html("field", Some("<script>alert('xss')</script>"), None);
+	/// assert!(!html.contains("<script>"));
+	/// assert!(html.contains("&lt;script&gt;"));
+	/// ```
 	pub fn render_html(
 		&self,
 		name: &str,
@@ -117,74 +172,88 @@ impl Widget {
 		let default_attrs = HashMap::new();
 		let attrs = attrs.unwrap_or(&default_attrs);
 
-		// Build common attributes
+		// Escape name for use in attributes
+		let escaped_name = escape_attribute(name);
+
+		// Build common attributes with escaping
 		let mut common_attrs = String::new();
 		for (key, val) in attrs {
-			common_attrs.push_str(&format!(" {}=\"{}\"", key, val));
+			common_attrs.push_str(&format!(
+				" {}=\"{}\"",
+				escape_attribute(key),
+				escape_attribute(val)
+			));
 		}
 
 		match self {
 			Widget::TextInput => {
 				html.push_str(&format!(
 					"<input type=\"text\" name=\"{}\" value=\"{}\"{}",
-					name,
-					value.unwrap_or(""),
+					escaped_name,
+					escape_attribute(value.unwrap_or("")),
 					common_attrs
 				));
 				if !attrs.contains_key("id") {
-					html.push_str(&format!(" id=\"id_{}\"", name));
+					html.push_str(&format!(" id=\"id_{}\"", escaped_name));
 				}
 				html.push_str(" />");
 			}
 			Widget::PasswordInput => {
 				html.push_str(&format!(
 					"<input type=\"password\" name=\"{}\" value=\"{}\"{}",
-					name,
-					value.unwrap_or(""),
+					escaped_name,
+					escape_attribute(value.unwrap_or("")),
 					common_attrs
 				));
 				if !attrs.contains_key("id") {
-					html.push_str(&format!(" id=\"id_{}\"", name));
+					html.push_str(&format!(" id=\"id_{}\"", escaped_name));
 				}
 				html.push_str(" />");
 			}
 			Widget::EmailInput => {
 				html.push_str(&format!(
 					"<input type=\"email\" name=\"{}\" value=\"{}\"{}",
-					name,
-					value.unwrap_or(""),
+					escaped_name,
+					escape_attribute(value.unwrap_or("")),
 					common_attrs
 				));
 				if !attrs.contains_key("id") {
-					html.push_str(&format!(" id=\"id_{}\"", name));
+					html.push_str(&format!(" id=\"id_{}\"", escaped_name));
 				}
 				html.push_str(" />");
 			}
 			Widget::NumberInput => {
 				html.push_str(&format!(
 					"<input type=\"number\" name=\"{}\" value=\"{}\"{}",
-					name,
-					value.unwrap_or(""),
+					escaped_name,
+					escape_attribute(value.unwrap_or("")),
 					common_attrs
 				));
 				if !attrs.contains_key("id") {
-					html.push_str(&format!(" id=\"id_{}\"", name));
+					html.push_str(&format!(" id=\"id_{}\"", escaped_name));
 				}
 				html.push_str(" />");
 			}
 			Widget::TextArea => {
-				html.push_str(&format!("<textarea name=\"{}\"{}", name, common_attrs));
+				html.push_str(&format!(
+					"<textarea name=\"{}\"{}",
+					escaped_name, common_attrs
+				));
 				if !attrs.contains_key("id") {
-					html.push_str(&format!(" id=\"id_{}\"", name));
+					html.push_str(&format!(" id=\"id_{}\"", escaped_name));
 				}
 				html.push('>');
-				html.push_str(value.unwrap_or(""));
+				// TextArea content is in HTML body context - must escape
+				html.push_str(&html_escape(value.unwrap_or("")));
 				html.push_str("</textarea>");
 			}
 			Widget::Select { choices } => {
-				html.push_str(&format!("<select name=\"{}\"{}", name, common_attrs));
+				html.push_str(&format!(
+					"<select name=\"{}\"{}",
+					escaped_name, common_attrs
+				));
 				if !attrs.contains_key("id") {
-					html.push_str(&format!(" id=\"id_{}\"", name));
+					html.push_str(&format!(" id=\"id_{}\"", escaped_name));
 				}
 				html.push('>');
 				for (choice_value, choice_label) in choices {
@@ -195,19 +264,24 @@ impl Widget {
 					};
 					html.push_str(&format!(
 						"<option value=\"{}\"{}>{}</option>",
-						choice_value, selected, choice_label
+						escape_attribute(choice_value),
+						selected,
+						html_escape(choice_label)
 					));
 				}
 				html.push_str("</select>");
 			}
 			Widget::CheckboxInput => {
-				html.push_str(&format!("<input type=\"checkbox\" name=\"{}\"", name));
+				html.push_str(&format!(
+					"<input type=\"checkbox\" name=\"{}\"",
+					escaped_name
+				));
 				if value == Some("true") || value == Some("on") {
 					html.push_str(" checked");
 				}
 				html.push_str(&common_attrs);
 				if !attrs.contains_key("id") {
-					html.push_str(&format!(" id=\"id_{}\"", name));
+					html.push_str(&format!(" id=\"id_{}\"", escaped_name));
 				}
 				html.push_str(" />");
 			}
@@ -220,53 +294,60 @@ impl Widget {
 					};
 					html.push_str(&format!(
 						"<input type=\"radio\" name=\"{}\" value=\"{}\" id=\"id_{}_{}\"{}{} />",
-						name, choice_value, name, i, checked, common_attrs
+						escaped_name,
+						escape_attribute(choice_value),
+						escaped_name,
+						i,
+						checked,
+						common_attrs
 					));
 					html.push_str(&format!(
 						"<label for=\"id_{}_{}\">{}</label>",
-						name, i, choice_label
+						escaped_name,
+						i,
+						html_escape(choice_label)
 					));
 				}
 			}
 			Widget::DateInput => {
 				html.push_str(&format!(
 					"<input type=\"date\" name=\"{}\" value=\"{}\"{}",
-					name,
-					value.unwrap_or(""),
+					escaped_name,
+					escape_attribute(value.unwrap_or("")),
 					common_attrs
 				));
 				if !attrs.contains_key("id") {
-					html.push_str(&format!(" id=\"id_{}\"", name));
+					html.push_str(&format!(" id=\"id_{}\"", escaped_name));
 				}
 				html.push_str(" />");
 			}
 			Widget::DateTimeInput => {
 				html.push_str(&format!(
 					"<input type=\"datetime-local\" name=\"{}\" value=\"{}\"{}",
-					name,
-					value.unwrap_or(""),
+					escaped_name,
+					escape_attribute(value.unwrap_or("")),
 					common_attrs
 				));
 				if !attrs.contains_key("id") {
-					html.push_str(&format!(" id=\"id_{}\"", name));
+					html.push_str(&format!(" id=\"id_{}\"", escaped_name));
 				}
 				html.push_str(" />");
 			}
 			Widget::FileInput => {
 				html.push_str(&format!(
 					"<input type=\"file\" name=\"{}\"{}",
-					name, common_attrs
+					escaped_name, common_attrs
 				));
 				if !attrs.contains_key("id") {
-					html.push_str(&format!(" id=\"id_{}\"", name));
+					html.push_str(&format!(" id=\"id_{}\"", escaped_name));
 				}
 				html.push_str(" />");
 			}
 			Widget::HiddenInput => {
 				html.push_str(&format!(
 					"<input type=\"hidden\" name=\"{}\" value=\"{}\" />",
-					name,
-					value.unwrap_or("")
+					escaped_name,
+					escape_attribute(value.unwrap_or(""))
 				));
 			}
 		}
@@ -351,5 +432,190 @@ mod tests {
 
 		// Default implementation returns empty HashMap
 		assert!(field.error_messages().is_empty());
+	}
+
+	// ============================================================================
+	// XSS Prevention Tests (Issue #547)
+	// ============================================================================
+
+	#[test]
+	fn test_html_escape_basic() {
+		assert_eq!(html_escape("<script>"), "&lt;script&gt;");
+		assert_eq!(html_escape("a & b"), "a &amp; b");
+		assert_eq!(html_escape("\"quoted\""), "&quot;quoted&quot;");
+		assert_eq!(html_escape("'single'"), "&#x27;single&#x27;");
+	}
+
+	#[test]
+	fn test_html_escape_all_special_chars() {
+		let input = "<script>alert('xss')&\"</script>";
+		let expected = "&lt;script&gt;alert(&#x27;xss&#x27;)&amp;&quot;&lt;/script&gt;";
+		assert_eq!(html_escape(input), expected);
+	}
+
+	#[test]
+	fn test_html_escape_no_special_chars() {
+		assert_eq!(html_escape("normal text"), "normal text");
+		assert_eq!(html_escape(""), "");
+	}
+
+	#[test]
+	fn test_escape_attribute() {
+		assert_eq!(escape_attribute("on\"click"), "on&quot;click");
+		assert_eq!(
+			escape_attribute("javascript:alert('xss')"),
+			"javascript:alert(&#x27;xss&#x27;)"
+		);
+	}
+
+	#[test]
+	fn test_widget_render_html_escapes_value_in_text_input() {
+		let widget = Widget::TextInput;
+		let xss_payload = "\"><script>alert('xss')</script>";
+		let html = widget.render_html("field", Some(xss_payload), None);
+
+		// Should NOT contain raw script tag
+		assert!(!html.contains("<script>"));
+		// Should contain escaped version
+		assert!(html.contains("&lt;script&gt;"));
+		assert!(html.contains("&quot;"));
+	}
+
+	#[test]
+	fn test_widget_render_html_escapes_name() {
+		let widget = Widget::TextInput;
+		let xss_name = "field\"><script>alert('xss')</script>";
+		let html = widget.render_html(xss_name, Some("value"), None);
+
+		// Should NOT contain raw script tag
+		assert!(!html.contains("<script>"));
+		// Should contain escaped version
+		assert!(html.contains("&lt;script&gt;"));
+	}
+
+	#[test]
+	fn test_widget_render_html_escapes_textarea_content() {
+		let widget = Widget::TextArea;
+		let xss_content = "</textarea><script>alert('xss')</script>";
+		let html = widget.render_html("comment", Some(xss_content), None);
+
+		// Should NOT contain raw script tag
+		assert!(!html.contains("<script>"));
+		// Should contain escaped version
+		assert!(html.contains("&lt;script&gt;"));
+		// Raw </textarea> should be escaped
+		assert!(!html.contains("</textarea><"));
+	}
+
+	#[test]
+	fn test_widget_render_html_escapes_select_choices() {
+		let widget = Widget::Select {
+			choices: vec![
+				(
+					"value\"><script>alert('xss')</script>".to_string(),
+					"Label".to_string(),
+				),
+				(
+					"safe_value".to_string(),
+					"</option><script>alert('xss')</script>".to_string(),
+				),
+			],
+		};
+
+		let html = widget.render_html("choice", Some("safe_value"), None);
+
+		// Should NOT contain raw script tags
+		assert!(!html.contains("<script>"));
+		// Should contain escaped versions
+		assert!(html.contains("&lt;script&gt;"));
+		// The malicious </option> in the label should be escaped
+		assert!(html.contains("&lt;/option&gt;"));
+	}
+
+	#[test]
+	fn test_widget_render_html_escapes_radio_choices() {
+		let widget = Widget::RadioSelect {
+			choices: vec![(
+				"value\"><script>alert('xss')</script>".to_string(),
+				"</label><script>alert('xss')</script>".to_string(),
+			)],
+		};
+
+		let html = widget.render_html("radio", None, None);
+
+		// Should NOT contain raw script tags
+		assert!(!html.contains("<script>"));
+		// Should contain escaped versions
+		assert!(html.contains("&lt;script&gt;"));
+	}
+
+	#[test]
+	fn test_widget_render_html_escapes_attributes() {
+		let widget = Widget::TextInput;
+		let mut attrs = HashMap::new();
+		attrs.insert("class".to_string(), "\" onclick=\"alert('xss')".to_string());
+		attrs.insert(
+			"data-evil".to_string(),
+			"\"><script>alert('xss')</script>".to_string(),
+		);
+
+		let html = widget.render_html("field", Some("value"), Some(&attrs));
+
+		// Should NOT contain raw script tags or unescaped quotes that could break out
+		assert!(!html.contains("<script>"));
+		assert!(html.contains("&lt;script&gt;"));
+		assert!(html.contains("&quot;"));
+	}
+
+	#[test]
+	fn test_widget_render_html_all_widget_types_escape_value() {
+		let xss_payload = "\"><script>alert('xss')</script>";
+
+		// Test all widget types that accept a value
+		let widgets: Vec<Widget> = vec![
+			Widget::TextInput,
+			Widget::PasswordInput,
+			Widget::EmailInput,
+			Widget::NumberInput,
+			Widget::TextArea,
+			Widget::DateInput,
+			Widget::DateTimeInput,
+			Widget::HiddenInput,
+		];
+
+		for widget in widgets {
+			let html = widget.render_html("field", Some(xss_payload), None);
+			assert!(
+				!html.contains("<script>"),
+				"Widget {:?} did not escape XSS payload",
+				widget
+			);
+			assert!(
+				html.contains("&lt;script&gt;"),
+				"Widget {:?} did not encode < and > characters",
+				widget
+			);
+		}
+	}
+
+	#[test]
+	fn test_widget_render_html_normal_values_preserved() {
+		let widget = Widget::TextInput;
+		let html = widget.render_html("username", Some("john_doe"), None);
+
+		// Normal values should work correctly
+		assert!(html.contains("name=\"username\""));
+		assert!(html.contains("value=\"john_doe\""));
+	}
+
+	#[test]
+	fn test_widget_render_html_ampersand_escaped_first() {
+		// Critical test: & must be escaped FIRST to prevent double-encoding
+		// e.g., if we escape < first, & becomes &amp;, then if we escape & again,
+		// it becomes &amp;amp;
+		let input = "&lt;"; // This is already an entity
+		let result = html_escape(input);
+		// Should become &amp;lt; (the & is escaped, not the <)
+		assert_eq!(result, "&amp;lt;");
 	}
 }

--- a/crates/reinhardt-forms/src/lib.rs
+++ b/crates/reinhardt-forms/src/lib.rs
@@ -137,6 +137,8 @@ pub use field::{
 	FormField as Field, // Alias for compatibility
 	FormField,
 	Widget,
+	escape_attribute,
+	html_escape,
 };
 pub use fields::{
 	BooleanField, CharField, ChoiceField, ColorField, ComboField, DateField, DateTimeField,


### PR DESCRIPTION
## Summary

Add HTML entity escaping in `Widget::render_html` to prevent XSS through form widget attribute values and content.

This PR addresses:
- XSS vulnerability in form widget HTML rendering
- User-controlled attribute values and content were not properly escaped before being embedded in HTML output

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Form widgets rendered user-controlled data directly into HTML without escaping, allowing XSS attacks through form field values, placeholder text, or widget attributes. This fix adds HTML entity escaping at the widget rendering layer.

Fixes #547

## How Was This Tested?

- Existing unit tests continue to pass
- `cargo check --workspace --all --all-features`
- `cargo make clippy-check`
- `cargo make fmt-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)