### PR TITLE
fix(dentdelion): enforce trust level check before js execution

### DIFF
--- a/crates/reinhardt-dentdelion/src/capability.rs
+++ b/crates/reinhardt-dentdelion/src/capability.rs
@@ -584,6 +584,14 @@ impl TrustLevel {
 	pub fn is_safe_for_third_party(&self) -> bool {
 		matches!(self, Self::Untrusted | Self::Verified)
 	}
+
+	/// Returns whether this trust level allows arbitrary JavaScript execution.
+	///
+	/// Only `Trusted` plugins can execute arbitrary JavaScript code via `eval_js`,
+	/// as this provides unrestricted access to the JavaScript runtime.
+	pub fn allows_js_execution(&self) -> bool {
+		matches!(self, Self::Trusted)
+	}
 }
 
 impl fmt::Display for TrustLevel {
@@ -894,5 +902,12 @@ mod tests {
 		assert!(all.contains(&TrustLevel::Untrusted));
 		assert!(all.contains(&TrustLevel::Verified));
 		assert!(all.contains(&TrustLevel::Trusted));
+	}
+
+	#[test]
+	fn test_trust_level_js_execution() {
+		assert!(!TrustLevel::Untrusted.allows_js_execution());
+		assert!(!TrustLevel::Verified.allows_js_execution());
+		assert!(TrustLevel::Trusted.allows_js_execution());
 	}
 }

--- a/crates/reinhardt-dentdelion/src/wasm/ssr.rs
+++ b/crates/reinhardt-dentdelion/src/wasm/ssr.rs
@@ -86,6 +86,10 @@ pub enum SsrError {
 	/// JavaScript evaluation failed
 	#[error("JavaScript evaluation failed: {0}")]
 	EvalFailed(String),
+
+	/// Permission denied due to insufficient trust level
+	#[error("Permission denied: {0}")]
+	PermissionDenied(String),
 }
 
 #[cfg(feature = "ts")]
@@ -665,6 +669,10 @@ mod tests {
 
 		let err = SsrError::RenderFailed("syntax error".to_string());
 		assert!(err.to_string().contains("syntax error"));
+
+		let err = SsrError::PermissionDenied("insufficient trust level".to_string());
+		assert!(err.to_string().contains("Permission denied"));
+		assert!(err.to_string().contains("insufficient trust level"));
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

Enforce trust level check before JavaScript execution in WASM plugins.

This PR addresses:
- Added `allows_js_execution()` method to `TrustLevel` enum (only `Trusted` returns true)
- Added `trust_level` field to `HostState` with builder support (default: `Untrusted`)
- Enforced trust level check at beginning of `eval_js()` - returns `PermissionDenied` for non-Trusted plugins
- Added `PermissionDenied` variant to `SsrError`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `eval_js` function was exposed to all WASM plugins without any trust level enforcement, allowing untrusted plugins to execute arbitrary JavaScript in the host runtime. This fix restricts `eval_js` to only `Trusted` plugins.

Fixes #675

Related to: #677

> **Merge order note**: This PR should be merged before #903 as both modify the same files (capability.rs, host.rs, ssr.rs).

## How Was This Tested?

- 5 new tests: default trust level, builder trust level, denied for untrusted, denied for verified, allowed for trusted
- 281/281 tests passing
- `cargo check --workspace --all --all-features`
- `cargo make clippy-check`
- `cargo make fmt-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)