### PR TITLE
fix(openapi): return Result from OpenApiRouter::wrap instead of panicking

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1262,7 +1262,13 @@ impl RunServerCommand {
 		let router = if !no_docs {
 			use reinhardt_http::Handler;
 			use reinhardt_openapi::OpenApiRouter;
-			std::sync::Arc::new(OpenApiRouter::wrap(base_router)) as std::sync::Arc<dyn Handler>
+			let wrapped = OpenApiRouter::wrap(base_router).map_err(|e| {
+				crate::CommandError::ExecutionError(format!(
+					"Failed to initialize OpenAPI router: {}",
+					e
+				))
+			})?;
+			std::sync::Arc::new(wrapped) as std::sync::Arc<dyn Handler>
 		} else {
 			base_router
 		};

--- a/crates/reinhardt-openapi/src/lib.rs
+++ b/crates/reinhardt-openapi/src/lib.rs
@@ -14,17 +14,18 @@
 //! use reinhardt_openapi::OpenApiRouter;
 //! use reinhardt_urls::routers::BasicRouter;
 //!
-//! fn main() {
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create your existing router
 //!     let router = BasicRouter::new();
 //!
 //!     // Wrap with OpenAPI endpoints
-//!     let wrapped = OpenApiRouter::wrap(router);
+//!     let wrapped = OpenApiRouter::wrap(router)?;
 //!
 //!     // The wrapped router now serves:
 //!     // - /api/openapi.json (OpenAPI spec)
 //!     // - /api/docs (Swagger UI)
 //!     // - /api/redoc (Redoc UI)
+//!     Ok(())
 //! }
 //! ```
 //!
@@ -48,4 +49,5 @@
 
 mod router_wrapper;
 
+pub use reinhardt_rest::openapi::SchemaError;
 pub use router_wrapper::OpenApiRouter;


### PR DESCRIPTION
## Summary
- Replace `.expect()` calls with `?` operator in `OpenApiRouter::wrap()` (Fixes #827)

## Test plan
- [x] cargo check passes
- [x] Formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)