### PR TITLE
fix: replace panic with error handling in ModelForm::save (#560)

### DIFF
--- a/crates/reinhardt-forms/src/form.rs
+++ b/crates/reinhardt-forms/src/form.rs
@@ -10,6 +10,8 @@ pub enum FormError {
 	Field { field: String, error: FieldError },
 	#[error("Validation error: {0}")]
 	Validation(String),
+	#[error("No model instance available for save operation")]
+	NoInstance,
 }
 
 pub type FormResult<T> = Result<T, FormError>;
@@ -226,6 +228,12 @@ impl Form {
 							.entry(ALL_FIELDS_KEY.to_string())
 							.or_default()
 							.push(msg);
+					}
+					FormError::NoInstance => {
+						self.errors
+							.entry(ALL_FIELDS_KEY.to_string())
+							.or_default()
+							.push(e.to_string());
 					}
 				}
 			}

--- a/crates/reinhardt-forms/src/model_form.rs
+++ b/crates/reinhardt-forms/src/model_form.rs
@@ -376,6 +376,8 @@ impl<T: FormModel> ModelForm<T> {
 	}
 	/// Save the form data to the model instance
 	///
+	/// Returns `FormError::NoInstance` if no model instance is available.
+	///
 	/// # Examples
 	///
 	/// ```ignore
@@ -383,19 +385,16 @@ impl<T: FormModel> ModelForm<T> {
 	///
 	/// let config = ModelFormConfig::new();
 	/// let mut form = ModelForm::<MyModel>::empty(config);
-	// Will panic without an instance, but shows the API
-	// let result = form.save();
+	/// // Returns Err(FormError::NoInstance) without an instance
+	/// assert!(form.save().is_err());
 	/// ```
 	pub fn save(&mut self) -> Result<T, FormError> {
 		if !self.is_valid() {
 			return Err(FormError::Validation("Form is not valid".to_string()));
 		}
 
-		// Get or create instance
-		let mut instance = self.instance.take().unwrap_or_else(|| {
-			// This would require Model to implement Default or have a constructor
-			panic!("Cannot create new instance without existing instance")
-		});
+		// Get existing instance or return error
+		let mut instance = self.instance.take().ok_or(FormError::NoInstance)?;
 
 		// Set field values from form's cleaned_data
 		let cleaned_data = self.form.cleaned_data();
@@ -484,8 +483,10 @@ impl<T: FormModel> Default for ModelFormBuilder<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::rstest;
 
 	// Mock model for testing
+	#[derive(Debug)]
 	struct TestModel {
 		id: i32,
 		name: String,
@@ -553,12 +554,14 @@ mod tests {
 		}
 	}
 
-	#[test]
+	#[rstest]
 	fn test_model_form_config() {
+		// Arrange
 		let config = ModelFormConfig::new()
 			.fields(vec!["name".to_string(), "email".to_string()])
 			.exclude(vec!["id".to_string()]);
 
+		// Assert
 		assert_eq!(
 			config.fields,
 			Some(vec!["name".to_string(), "email".to_string()])
@@ -566,27 +569,51 @@ mod tests {
 		assert_eq!(config.exclude, vec!["id".to_string()]);
 	}
 
-	#[test]
+	#[rstest]
 	fn test_model_form_builder() {
+		// Arrange
 		let instance = TestModel {
 			id: 1,
 			name: "John".to_string(),
 			email: "john@example.com".to_string(),
 		};
 
+		// Act
 		let form = ModelFormBuilder::<TestModel>::new()
 			.fields(vec!["name".to_string(), "email".to_string()])
 			.build(Some(instance));
 
+		// Assert
 		assert!(form.instance().is_some());
 	}
 
-	#[test]
+	#[rstest]
 	fn test_model_field_names() {
+		// Act
 		let fields = TestModel::field_names();
+
+		// Assert
 		assert_eq!(
 			fields,
 			vec!["id".to_string(), "name".to_string(), "email".to_string()]
+		);
+	}
+
+	#[rstest]
+	fn test_save_without_instance_returns_no_instance_error() {
+		// Arrange
+		let config = ModelFormConfig::new();
+		let mut form = ModelForm::<TestModel>::empty(config);
+
+		// Act
+		let result = form.save();
+
+		// Assert
+		assert!(result.is_err());
+		let err = result.unwrap_err();
+		assert!(
+			matches!(err, FormError::NoInstance),
+			"Expected FormError::NoInstance, got: {err}"
 		);
 	}
 }


### PR DESCRIPTION
## Summary
- Replace panic in ModelForm::save() with proper error handling
- Add FormError::NoInstance variant for when instance is not set
- Update error handling throughout the form module

Fixes #560

## Test plan
- [ ] Verify ModelForm::save() returns error instead of panicking when no instance
- [ ] cargo test --package reinhardt-forms --all-features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>