### PR TITLE
fix(security): fix email validation and field access control (#512, #515, #517)

### DIFF
--- a/crates/reinhardt-mail/src/message.rs
+++ b/crates/reinhardt-mail/src/message.rs
@@ -276,21 +276,22 @@ impl Attachment {
 
 /// Represents an email message with validated addresses.
 ///
-/// Fields are not publicly accessible to enforce validation through the builder.
+/// All fields are private to enforce validation through the builder.
 /// Use getter methods for read access and the builder for construction.
+/// Direct field assignment is not possible, preventing bypass of validation.
 #[derive(Debug, Clone)]
 pub struct EmailMessage {
-	pub(crate) subject: String,
-	pub(crate) body: String,
-	pub(crate) from_email: String,
-	pub(crate) to: Vec<String>,
-	pub(crate) cc: Vec<String>,
-	pub(crate) bcc: Vec<String>,
-	pub(crate) reply_to: Vec<String>,
-	pub(crate) html_body: Option<String>,
-	pub(crate) alternatives: Vec<Alternative>,
-	pub(crate) attachments: Vec<Attachment>,
-	pub(crate) headers: Vec<(String, String)>,
+	subject: String,
+	body: String,
+	from_email: String,
+	to: Vec<String>,
+	cc: Vec<String>,
+	bcc: Vec<String>,
+	reply_to: Vec<String>,
+	html_body: Option<String>,
+	alternatives: Vec<Alternative>,
+	attachments: Vec<Attachment>,
+	headers: Vec<(String, String)>,
 }
 
 impl EmailMessage {
@@ -451,10 +452,11 @@ impl EmailMessageBuilder {
 
 	/// Build the email message with validation.
 	///
-	/// Validates all email addresses using `validate_email()` before
-	/// constructing the message. Returns an error if any address is invalid.
+	/// Validates all email addresses using `validate_email()` and checks
+	/// subject/header values for header injection attacks before
+	/// constructing the message. Returns an error if any validation fails.
 	pub fn build(self) -> crate::EmailResult<EmailMessage> {
-		use crate::validation::{validate_email, validate_email_list};
+		use crate::validation::{check_header_injection, validate_email, validate_email_list};
 
 		// Validate from_email if provided
 		if !self.from_email.is_empty() {
@@ -466,6 +468,15 @@ impl EmailMessageBuilder {
 		validate_email_list(&self.cc)?;
 		validate_email_list(&self.bcc)?;
 		validate_email_list(&self.reply_to)?;
+
+		// Validate subject for header injection
+		check_header_injection(&self.subject)?;
+
+		// Validate custom header values for header injection
+		for (name, value) in &self.headers {
+			check_header_injection(name)?;
+			check_header_injection(value)?;
+		}
 
 		Ok(EmailMessage {
 			subject: self.subject,

--- a/crates/reinhardt-mail/src/templates.rs
+++ b/crates/reinhardt-mail/src/templates.rs
@@ -255,8 +255,8 @@ mod tests {
 			.build()
 			.unwrap();
 
-		assert_eq!(email.subject, "Order 12345 Confirmation");
-		assert_eq!(email.body, "Hello Bob, your order 12345 is confirmed.");
+		assert_eq!(email.subject(), "Order 12345 Confirmation");
+		assert_eq!(email.body(), "Hello Bob, your order 12345 is confirmed.");
 	}
 
 	#[test]
@@ -274,11 +274,8 @@ mod tests {
 			.build()
 			.unwrap();
 
-		assert_eq!(email.subject, "Welcome Charlie");
-		assert_eq!(
-			email.html_body,
-			Some("<h1>Welcome Charlie</h1>".to_string())
-		);
+		assert_eq!(email.subject(), "Welcome Charlie");
+		assert_eq!(email.html_body(), Some("<h1>Welcome Charlie</h1>"));
 	}
 
 	#[test]
@@ -293,7 +290,7 @@ mod tests {
 			.build()
 			.unwrap();
 
-		assert_eq!(email.subject, "Test Value1");
-		assert_eq!(email.body, "Body Value2");
+		assert_eq!(email.subject(), "Test Value1");
+		assert_eq!(email.body(), "Body Value2");
 	}
 }


### PR DESCRIPTION
Fixes #512\nFixes #515\nFixes #517\n\n- Make fields private with validated setter methods\n- Add email address format validation\n- Only lowercase domain part, preserve local part case\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>