### PR TITLE
fix: handle partial failure in room broadcast (#511)

### DIFF
--- a/crates/reinhardt-websockets/src/consumers.rs
+++ b/crates/reinhardt-websockets/src/consumers.rs
@@ -412,10 +412,13 @@ impl WebSocketConsumer for BroadcastConsumer {
 		_context: &mut ConsumerContext,
 		message: Message,
 	) -> WebSocketResult<()> {
-		self.room.broadcast(message).await.map_err(|e| match e {
-			crate::room::RoomError::WebSocket(ws_err) => ws_err,
-			_ => crate::connection::WebSocketError::Send(e.to_string()),
-		})
+		let result = self.room.broadcast(message).await;
+		if result.is_complete_failure() {
+			return Err(crate::connection::WebSocketError::Send(
+				"broadcast failed for all clients".to_string(),
+			));
+		}
+		Ok(())
 	}
 
 	async fn on_disconnect(&self, context: &mut ConsumerContext) -> WebSocketResult<()> {

--- a/crates/reinhardt-websockets/src/lib.rs
+++ b/crates/reinhardt-websockets/src/lib.rs
@@ -192,7 +192,7 @@ pub use protocol::default_websocket_config;
 pub use reconnection::{ReconnectionConfig, ReconnectionStrategy};
 #[cfg(feature = "redis-channel")]
 pub use redis_channel::{RedisChannelLayer, RedisConfig};
-pub use room::{Room, RoomError, RoomManager, RoomResult};
+pub use room::{BroadcastResult, Room, RoomError, RoomManager, RoomResult};
 pub use routing::{
 	RouteError, RouteResult, WebSocketRoute, WebSocketRouter, clear_websocket_router,
 	get_websocket_router, register_websocket_router, reverse_websocket_url,

--- a/crates/reinhardt-websockets/src/tests.rs
+++ b/crates/reinhardt-websockets/src/tests.rs
@@ -228,8 +228,7 @@ async fn test_websocket_multiple_clients_with_room() {
 	room.broadcast(Message::text(
 		"Client #1234 says: Hello from 1234".to_string(),
 	))
-	.await
-	.unwrap();
+	.await;
 
 	// Verify broadcast received by all clients
 	let result = timeout(Duration::from_millis(100), async {
@@ -268,8 +267,7 @@ async fn test_websocket_handle_disconnection() {
 
 	// Broadcast disconnect message
 	room.broadcast(Message::text("Client #5678 left the chat".to_string()))
-		.await
-		.unwrap();
+		.await;
 
 	// Verify disconnect message received
 	let msg = rx1.try_recv().unwrap();
@@ -382,7 +380,7 @@ async fn test_broadcast_to_all_rooms() {
 	let broadcast_msg = Message::text("Global announcement".to_string());
 	for room_id in manager.room_ids().await {
 		if let Some(room) = manager.get_room(&room_id).await {
-			room.broadcast(broadcast_msg.clone()).await.unwrap();
+			room.broadcast(broadcast_msg.clone()).await;
 		}
 	}
 


### PR DESCRIPTION
Fixes #511\n\nHandle partial failures properly in room broadcast (collect errors, report which sends failed).\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>