### PR TITLE
fix(test): sync user state and add wildcard permission support

### DIFF
--- a/crates/reinhardt-test/src/server_fn/context.rs
+++ b/crates/reinhardt-test/src/server_fn/context.rs
@@ -377,10 +377,11 @@ impl ServerFnTestEnv {
 	}
 
 	/// Check if the user has a specific permission.
+	// Fixes #864
 	pub fn has_permission(&self, permission: &str) -> bool {
 		self.test_user
 			.as_ref()
-			.is_some_and(|u| u.permissions.iter().any(|p| p == permission))
+			.is_some_and(|u| u.has_permission(permission))
 	}
 
 	/// Check if the user has a specific role.


### PR DESCRIPTION
## Summary
- Fix state desynchronization between `test_user` and `mock_session.user` when updating permissions/roles via `with_permissions()` and `with_roles()` methods
- Delegate `ServerFnTestEnv::has_permission()` to `TestUser::has_permission()` to support wildcard (`*`) permissions

## Changes
- **Fixes #868**: `with_permissions()` and `with_roles()` now synchronize the embedded user in `mock_session` when updating `test_user`
- **Fixes #864**: `ServerFnTestEnv::has_permission()` now delegates to `TestUser::has_permission()` which properly checks for wildcard permissions

## Test plan
- [x] `cargo check --package reinhardt-test --all-features` passes
- [x] `cargo make fmt-fix` passes with no changes needed
- [x] Existing tests continue to pass (no test modifications required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)