### PR TITLE
fix(graphql-macros): prevent error exposure and replace eprintln with tracing

### DIFF
--- a/crates/reinhardt-graphql/macros/src/subscription.rs
+++ b/crates/reinhardt-graphql/macros/src/subscription.rs
@@ -177,7 +177,8 @@ pub(crate) fn expand_derive(input: DeriveInput) -> Result<TokenStream> {
 				let stream = match client.#method_name(Default::default()).await {
 					Ok(response) => response.into_inner(),
 					Err(e) => {
-						eprintln!("gRPC call failed: {:?}", e);
+						// Fixes #815: use structured logging instead of eprintln
+						::tracing::error!("gRPC call failed: {:?}", e);
 						return Box::pin(tokio_stream::empty());
 					}
 				};
@@ -192,7 +193,8 @@ pub(crate) fn expand_derive(input: DeriveInput) -> Result<TokenStream> {
 								Some(graphql_event)
 							}
 							Err(e) => {
-								eprintln!("Stream error: {:?}", e);
+								// Fixes #815: use structured logging instead of eprintln
+								::tracing::warn!("gRPC stream error: {:?}", e);
 								None
 							}
 						}


### PR DESCRIPTION
## Summary
- Prevent internal type names and DI details from being exposed in GraphQL error responses
- Replace hardcoded `eprintln!` calls with structured `tracing` macros

## Fixes
- Fixes #817: DI error messages expose internal types to GraphQL clients
- Fixes #815: eprintln! in generated code leaks internal gRPC details

## Changes

### Issue #817: DI Error Exposure
Modified `graphql_handler.rs` to:
- Return generic "Internal server error" message to clients
- Log detailed error information server-side using `tracing::error!`
- Prevents exposure of internal Rust type names and DI framework details

### Issue #815: eprintln Leak in Subscriptions
Modified `subscription.rs` to:
- Replace `eprintln!("gRPC call failed: {:?}", e)` with `tracing::error!`
- Replace `eprintln!("Stream error: {:?}", e)` with `tracing::warn!`
- Enables proper log level control through the application's logging framework

## Test Plan
- [x] `cargo check --package reinhardt-graphql-macros --all-features` passes
- [x] `cargo make fmt-fix` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)