### PR TITLE
fix(grpc-macros): prevent information disclosure in DI errors

### DIFF
--- a/crates/reinhardt-grpc/macros/src/grpc_handler.rs
+++ b/crates/reinhardt-grpc/macros/src/grpc_handler.rs
@@ -197,13 +197,13 @@ pub(crate) fn expand_grpc_handler(input: ItemFn) -> Result<TokenStream> {
 	let grpc_crate = get_reinhardt_grpc_crate();
 
 	// Generate DI extraction code
+	// Fixes #820: Return generic error message, log details server-side
 	let di_context_extraction = quote! {
 		let __di_ctx = #request_pat
 			.get_di_context::<::std::sync::Arc<#di_crate::InjectionContext>>()
 			.ok_or_else(|| {
-				::tonic::Status::internal(
-					"DI context not set. Ensure the request extensions contain InjectionContext"
-				)
+				::tracing::error!("DI context not found in request extensions");
+				::tonic::Status::internal("Internal server error")
 			})?;
 	};
 
@@ -215,22 +215,25 @@ pub(crate) fn expand_grpc_handler(input: ItemFn) -> Result<TokenStream> {
 			let ty = &param.ty;
 			let use_cache = param.use_cache;
 
+			// Fixes #820
 			if use_cache {
 				quote! {
 					let #pat: #ty = #di_crate::Injected::<#ty>::resolve(&__di_ctx)
 						.await
-						.map_err(|e| ::tonic::Status::internal(
-							format!("Dependency injection failed for {}: {:?}", stringify!(#ty), e)
-						))?
+						.map_err(|e| {
+							::tracing::error!("DI resolution failed for {}: {:?}", stringify!(#ty), e);
+							::tonic::Status::internal("Internal server error")
+						})?
 						.into_inner();
 				}
 			} else {
 				quote! {
 					let #pat: #ty = #di_crate::Injected::<#ty>::resolve_uncached(&__di_ctx)
 						.await
-						.map_err(|e| ::tonic::Status::internal(
-							format!("Dependency injection failed for {}: {:?}", stringify!(#ty), e)
-						))?
+						.map_err(|e| {
+							::tracing::error!("DI resolution failed for {}: {:?}", stringify!(#ty), e);
+							::tonic::Status::internal("Internal server error")
+						})?
 						.into_inner();
 				}
 			}


### PR DESCRIPTION
## Summary
- Return generic errors to gRPC clients instead of exposing internal types
- Log actual error details server-side using tracing

## Issues Fixed
- Fixes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)