### PR TITLE
fix(shortcuts): prevent database error message leakage in HTTP response

### DIFF
--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -16,6 +16,7 @@ reinhardt-urls = { workspace = true, features = ["routers"] }
 
 bytes = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 hyper = { workspace = true }


### PR DESCRIPTION
## Summary

- Prevent database error message leakage in HTTP response body
- Replace raw error messages with generic "Internal server error"
- Log full error details server-side using `tracing::error!`

## Problem

Database error messages contained sensitive information that was being exposed directly in HTTP response bodies:

- Table names and column names
- SQL query fragments
- Database connection parameters
- Internal schema details

This allowed any client receiving an error response to enumerate internal database structure.

## Solution

- Database errors now return a generic "Internal server error" message to clients
- Full error details are logged server-side using `tracing::error!` for debugging
- Updated all tests to verify that sensitive information is NOT exposed in responses

## Test Plan

- [x] `cargo test --package reinhardt-shortcuts --all-features` - all tests pass
- [x] `cargo clippy --package reinhardt-shortcuts --all-features -- -D warnings` - no warnings
- [x] `cargo fmt --package reinhardt-shortcuts -- --check` - formatting correct

Fixes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)