### PR TITLE
fix(tasks): add SSRF protection for webhook URLs

### DIFF
--- a/crates/reinhardt-tasks/Cargo.toml
+++ b/crates/reinhardt-tasks/Cargo.toml
@@ -19,6 +19,8 @@ uuid = { workspace = true }
 cron = "0.15.0"
 rand = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
+url = { workspace = true }
+ipnet = "2.0"
 
 # Redis backend (optional)
 redis = { workspace = true, optional = true }

--- a/crates/reinhardt-tasks/src/lib.rs
+++ b/crates/reinhardt-tasks/src/lib.rs
@@ -126,7 +126,7 @@ pub use task::{
 };
 pub use webhook::{
 	HttpWebhookSender, RetryConfig, TaskStatus as WebhookTaskStatus, WebhookConfig, WebhookError,
-	WebhookEvent, WebhookSender,
+	WebhookEvent, WebhookSender, is_blocked_ip, validate_resolved_ips, validate_webhook_url,
 };
 pub use worker::{Worker, WorkerConfig};
 


### PR DESCRIPTION
## Summary
- Add comprehensive SSRF protection for webhook URL validation in `reinhardt-tasks` crate
- Block dangerous IP ranges including loopback, private, link-local, and cloud metadata endpoints
- Enforce HTTPS-only scheme for webhook URLs
- Fix IPv6 address parsing issue (`host_str()` returns bracketed format)
- Perform DNS resolution validation for hostname-based URLs

## Test plan
- [x] All 166 unit tests pass including 53 webhook-specific tests
- [x] SSRF protection tests cover all blocked IP ranges
- [x] IPv6 address validation tests pass
- [x] Cloud metadata endpoint blocking verified
- [x] HTTP scheme rejection verified

Fixes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)