### PR TITLE
fix(security): fix form validation bypasses (#552, #554, #556)

### DIFF
--- a/crates/reinhardt-forms/src/fields/file_field.rs
+++ b/crates/reinhardt-forms/src/fields/file_field.rs
@@ -148,6 +148,27 @@ impl ImageField {
 			.map(|ext| valid_extensions.contains(&ext.to_lowercase().as_str()))
 			.unwrap_or(false)
 	}
+
+	/// Validates that file content magic bytes match the claimed extension (#556).
+	///
+	/// Returns `true` if magic bytes are consistent with the extension.
+	/// Returns `false` if magic bytes indicate a different file type.
+	fn validate_magic_bytes(extension: &str, bytes: &[u8]) -> bool {
+		match extension.to_lowercase().as_str() {
+			"jpg" | "jpeg" => bytes.len() >= 3 && bytes[..3] == [0xFF, 0xD8, 0xFF],
+			"png" => {
+				bytes.len() >= 8 && bytes[..8] == [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+			}
+			"gif" => bytes.len() >= 4 && bytes[..4] == [0x47, 0x49, 0x46, 0x38],
+			"webp" => {
+				bytes.len() >= 12
+					&& bytes[..4] == [0x52, 0x49, 0x46, 0x46]
+					&& bytes[8..12] == [0x57, 0x45, 0x42, 0x50]
+			}
+			"bmp" => bytes.len() >= 2 && bytes[..2] == [0x42, 0x4D],
+			_ => false,
+		}
+	}
 }
 
 impl FormField for ImageField {
@@ -199,8 +220,27 @@ impl FormField for ImageField {
 				// Validate image extension
 				if !Self::is_valid_image_extension(filename) {
 					return Err(FieldError::Validation(
-                        "Upload a valid image. The file you uploaded was either not an image or a corrupted image".to_string(),
-                    ));
+						"Upload a valid image. The file you uploaded was either not an image or a corrupted image".to_string(),
+					));
+				}
+
+				// Validate file content magic bytes if available (#556).
+				// When content_bytes is provided, verify the actual file type
+				// matches the claimed extension to prevent MIME type bypass attacks.
+				if let Some(content_bytes) = obj.get("content_bytes").and_then(|v| v.as_array()) {
+					let bytes: Vec<u8> = content_bytes
+						.iter()
+						.filter_map(|v| v.as_u64().map(|n| n as u8))
+						.collect();
+
+					if !bytes.is_empty() {
+						let extension = filename.rsplit('.').next().unwrap_or("");
+						if !Self::validate_magic_bytes(extension, &bytes) {
+							return Err(FieldError::Validation(
+								"Upload a valid image. The file content does not match the file extension".to_string(),
+							));
+						}
+					}
 				}
 
 				// Check filename length
@@ -232,74 +272,270 @@ impl FormField for ImageField {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::rstest;
 
-	#[test]
+	#[rstest]
 	fn test_filefield_valid() {
+		// Arrange
 		let field = FileField::new("document".to_string());
-
 		let file = serde_json::json!({
 			"filename": "test.pdf",
 			"size": 1024
 		});
 
-		assert!(field.clean(Some(&file)).is_ok());
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(result.is_ok());
 	}
 
-	#[test]
+	#[rstest]
 	fn test_filefield_empty() {
+		// Arrange
 		let field = FileField::new("document".to_string());
-
 		let file = serde_json::json!({
 			"filename": "test.pdf",
 			"size": 0
 		});
 
-		assert!(matches!(
-			field.clean(Some(&file)),
-			Err(FieldError::Validation(_))
-		));
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(matches!(result, Err(FieldError::Validation(_))));
 	}
 
-	#[test]
+	#[rstest]
 	fn test_imagefield_valid() {
+		// Arrange
 		let field = ImageField::new("photo".to_string());
-
 		let file = serde_json::json!({
 			"filename": "test.jpg",
 			"size": 1024
 		});
 
-		assert!(field.clean(Some(&file)).is_ok());
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(result.is_ok());
 	}
 
-	#[test]
+	#[rstest]
 	fn test_imagefield_invalid_extension() {
+		// Arrange
 		let field = ImageField::new("photo".to_string());
-
 		let file = serde_json::json!({
 			"filename": "test.pdf",
 			"size": 1024
 		});
 
-		assert!(matches!(
-			field.clean(Some(&file)),
-			Err(FieldError::Validation(_))
-		));
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(matches!(result, Err(FieldError::Validation(_))));
 	}
 
-	#[test]
+	#[rstest]
 	fn test_imagefield_rejects_svg_for_xss_prevention() {
+		// Arrange
 		let field = ImageField::new("photo".to_string());
-
-		// SVG files are rejected due to Stored XSS vulnerability risk
 		let svg_file = serde_json::json!({
 			"filename": "malicious.svg",
 			"size": 1024
 		});
 
+		// Act
+		let result = field.clean(Some(&svg_file));
+
+		// Assert
 		assert!(
-			matches!(field.clean(Some(&svg_file)), Err(FieldError::Validation(_))),
+			matches!(result, Err(FieldError::Validation(_))),
 			"SVG files should be rejected to prevent Stored XSS attacks"
+		);
+	}
+
+	// ============================================================================
+	// Magic Bytes Validation Tests (#556)
+	// ============================================================================
+
+	#[rstest]
+	fn test_imagefield_valid_png_magic_bytes() {
+		// Arrange
+		let field = ImageField::new("photo".to_string());
+		let png_header: Vec<u8> = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+		let file = serde_json::json!({
+			"filename": "image.png",
+			"size": 1024,
+			"content_bytes": png_header
+		});
+
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	fn test_imagefield_valid_jpeg_magic_bytes() {
+		// Arrange
+		let field = ImageField::new("photo".to_string());
+		let jpeg_header: Vec<u8> = vec![0xFF, 0xD8, 0xFF, 0xE0];
+		let file = serde_json::json!({
+			"filename": "photo.jpg",
+			"size": 2048,
+			"content_bytes": jpeg_header
+		});
+
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	fn test_imagefield_valid_gif_magic_bytes() {
+		// Arrange
+		let field = ImageField::new("photo".to_string());
+		// GIF89a header
+		let gif_header: Vec<u8> = vec![0x47, 0x49, 0x46, 0x38, 0x39, 0x61];
+		let file = serde_json::json!({
+			"filename": "animation.gif",
+			"size": 512,
+			"content_bytes": gif_header
+		});
+
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	fn test_imagefield_valid_webp_magic_bytes() {
+		// Arrange
+		let field = ImageField::new("photo".to_string());
+		// RIFF....WEBP header
+		let webp_header: Vec<u8> = vec![
+			0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+		];
+		let file = serde_json::json!({
+			"filename": "photo.webp",
+			"size": 4096,
+			"content_bytes": webp_header
+		});
+
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	fn test_imagefield_valid_bmp_magic_bytes() {
+		// Arrange
+		let field = ImageField::new("photo".to_string());
+		let bmp_header: Vec<u8> = vec![0x42, 0x4D, 0x00, 0x00];
+		let file = serde_json::json!({
+			"filename": "bitmap.bmp",
+			"size": 8192,
+			"content_bytes": bmp_header
+		});
+
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	fn test_imagefield_rejects_html_disguised_as_png() {
+		// Arrange: attacker renames malicious HTML file to .png
+		let field = ImageField::new("photo".to_string());
+		let html_content = b"<html><script>alert('xss')</script></html>";
+		let content_bytes: Vec<u8> = html_content.to_vec();
+		let file = serde_json::json!({
+			"filename": "payload.png",
+			"size": html_content.len(),
+			"content_bytes": content_bytes
+		});
+
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(
+			matches!(result, Err(FieldError::Validation(ref msg)) if msg.contains("content does not match")),
+			"HTML content disguised as PNG should be rejected"
+		);
+	}
+
+	#[rstest]
+	fn test_imagefield_rejects_exe_disguised_as_jpg() {
+		// Arrange: attacker renames executable to .jpg
+		let field = ImageField::new("photo".to_string());
+		// MZ header (PE executable)
+		let exe_content: Vec<u8> = vec![0x4D, 0x5A, 0x90, 0x00];
+		let file = serde_json::json!({
+			"filename": "malware.jpg",
+			"size": 4096,
+			"content_bytes": exe_content
+		});
+
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(
+			matches!(result, Err(FieldError::Validation(ref msg)) if msg.contains("content does not match")),
+			"EXE content disguised as JPG should be rejected"
+		);
+	}
+
+	#[rstest]
+	fn test_imagefield_rejects_mismatched_extension_and_magic_bytes() {
+		// Arrange: PNG magic bytes with .jpg extension
+		let field = ImageField::new("photo".to_string());
+		let png_header: Vec<u8> = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+		let file = serde_json::json!({
+			"filename": "actually_png.jpg",
+			"size": 1024,
+			"content_bytes": png_header
+		});
+
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(
+			matches!(result, Err(FieldError::Validation(ref msg)) if msg.contains("content does not match")),
+			"PNG content with .jpg extension should be rejected"
+		);
+	}
+
+	#[rstest]
+	fn test_imagefield_allows_no_content_bytes_for_backward_compatibility() {
+		// Arrange: no content_bytes field (backward compatible)
+		let field = ImageField::new("photo".to_string());
+		let file = serde_json::json!({
+			"filename": "photo.jpg",
+			"size": 1024
+		});
+
+		// Act
+		let result = field.clean(Some(&file));
+
+		// Assert
+		assert!(
+			result.is_ok(),
+			"Files without content_bytes should still pass extension-only validation"
 		);
 	}
 }


### PR DESCRIPTION
## Summary

- **#552**: `ModelForm::is_valid()` now calls `self.form.is_valid()` first to enforce field-level validation rules (min/max length, required, etc.) before model-level validation
- **#554**: `Form::cleaned_data()` now returns only declared form fields to prevent mass assignment vulnerabilities from extra submitted fields
- **#556**: `ImageField` now validates file content magic bytes to prevent MIME type bypass attacks (HTML/EXE disguised as images)

## Security Impact

- **#552 (High)**: Previously, all field-level validation was bypassed in ModelForm, allowing invalid or malicious data to reach the model layer
- **#554 (High)**: Previously, extra fields submitted by attackers (e.g., `is_admin=true`) remained accessible in cleaned_data, potentially leading to mass assignment vulnerabilities
- **#556 (High)**: Previously, attackers could upload arbitrary file types (HTML, EXE) by simply renaming them with image extensions, leading to stored XSS or code execution risks

## Changes

### model_form.rs
- Modified `is_valid()` to call `self.form.is_valid()` before model-level validation
- Aggregates errors from both validation layers
- Added tests for field-level validation enforcement

### form.rs
- Added `cleaned` field to store only validated declared fields
- Modified `is_valid()` to populate `cleaned` with only declared field values
- Modified `cleaned_data()` to return filtered `cleaned` instead of raw `data`
- Added test for extra field filtering

### file_field.rs
- Added `validate_magic_bytes()` function for JPEG, PNG, GIF, WebP, BMP detection
- Modified `ImageField::clean()` to validate magic bytes when `content_bytes` is provided
- Added tests for magic bytes validation and attack vectors
- SVG files remain blocked (stored XSS risk)

## Test Plan

- [x] All existing tests pass
- [x] New tests for #552 verify field-level validation is called
- [x] New tests for #554 verify extra fields are excluded from cleaned_data
- [x] New tests for #556 verify magic bytes detection for all image types
- [x] New tests for #556 verify rejection of disguised HTML/EXE files

🤖 Generated with [Claude Code](https://claude.com/claude-code)