### PR TITLE
fix(deps): pin native-tls to =0.2.14 to fix CI build failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -456,6 +456,10 @@ sqlx = { version = "0.8", features = [
   "rust_decimal",
 ] }
 
+# TLS
+# Pin to avoid build failure in native-tls 0.2.17 (non-exhaustive pattern in openssl.rs)
+native-tls = "=0.2.14"
+
 # Authentication & Security
 argon2 = { version = "0.5", features = ["std"] }
 password-hash = "0.5"

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -81,3 +81,5 @@ tokio-test = { workspace = true }
 rstest = { workspace = true }
 wasm-bindgen-test = "0.3.56"
 sqlx = { workspace = true, features = ["postgres", "runtime-tokio-native-tls"] }
+# Pin to avoid build failure in native-tls 0.2.17 (non-exhaustive pattern in openssl.rs)
+native-tls = { workspace = true }

--- a/crates/reinhardt-mail/Cargo.toml
+++ b/crates/reinhardt-mail/Cargo.toml
@@ -22,6 +22,8 @@ lettre = { version = "0.11", features = [
   "smtp-transport",
   "hostname",
 ] }
+# Pin to avoid build failure in native-tls 0.2.17 (non-exhaustive pattern in openssl.rs)
+native-tls = { workspace = true }
 mime = "0.3"
 mime_guess = "2.0"
 chrono = { workspace = true }


### PR DESCRIPTION
## Summary

- `native-tls 0.2.17` introduced a non-exhaustive pattern error in `openssl.rs` that prevents compilation with Rust 1.91.1
- Since `Cargo.lock` is gitignored (library crate), each CI run resolves to the latest `native-tls` version
- This fix pins `native-tls = "=0.2.14"` in the workspace to avoid the broken 0.2.17 version

## Affected crates

- `reinhardt-mail`: directly depends on `lettre` with `tokio1-native-tls` feature
- `reinhardt-admin`: dev-dependency on `sqlx` with `runtime-tokio-native-tls` feature

## Test plan

- [x] `cargo check -p reinhardt-mail` passes locally
- [x] Pre-push checks (fmt + check) pass
- [ ] CI confirms all 62 BEHIND PRs can now compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)