### PR TITLE
security(websockets): add origin header validation

### DIFF
--- a/crates/reinhardt-websockets/src/lib.rs
+++ b/crates/reinhardt-websockets/src/lib.rs
@@ -154,6 +154,7 @@ pub mod handler;
 pub mod integration;
 pub mod metrics;
 pub mod middleware;
+pub mod origin;
 pub mod protocol;
 pub mod reconnection;
 #[cfg(feature = "redis-channel")]
@@ -190,6 +191,9 @@ pub use middleware::{
 	ConnectionContext, ConnectionMiddleware, IpFilterMiddleware, LoggingMiddleware,
 	MessageMiddleware, MessageSizeLimitMiddleware, MiddlewareChain, MiddlewareError,
 	MiddlewareResult,
+};
+pub use origin::{
+	OriginPolicy, OriginValidationConfig, OriginValidationMiddleware, validate_origin,
 };
 pub use protocol::default_websocket_config;
 pub use reconnection::{ReconnectionConfig, ReconnectionStrategy};

--- a/crates/reinhardt-websockets/src/origin.rs
+++ b/crates/reinhardt-websockets/src/origin.rs
@@ -1,0 +1,479 @@
+//! Origin header validation for WebSocket handshake
+//!
+//! This module provides Origin header validation to prevent Cross-Site WebSocket
+//! Hijacking (CSWSH) attacks. It validates the `Origin` header sent during the
+//! WebSocket handshake against a configurable list of allowed origins.
+//!
+//! # Usage
+//!
+//! ```
+//! use reinhardt_websockets::origin::{OriginValidationMiddleware, OriginPolicy};
+//!
+//! // Require Origin and only allow specific origins
+//! let middleware = OriginValidationMiddleware::new(
+//!     OriginPolicy::AllowList(vec![
+//!         "https://example.com".to_string(),
+//!         "https://app.example.com".to_string(),
+//!     ]),
+//! );
+//! ```
+
+use crate::connection::WebSocketConnection;
+use crate::middleware::{
+	ConnectionContext, ConnectionMiddleware, MiddlewareError, MiddlewareResult,
+};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// Header name for Origin
+const ORIGIN_HEADER: &str = "origin";
+
+/// Policy for Origin header validation
+#[derive(Debug, Clone)]
+pub enum OriginPolicy {
+	/// Allow only specific origins
+	AllowList(Vec<String>),
+	/// Allow all origins (disables validation, not recommended for production)
+	AllowAll,
+}
+
+/// Configuration for Origin validation behavior
+#[derive(Debug, Clone)]
+pub struct OriginValidationConfig {
+	/// The origin policy to apply
+	pub policy: OriginPolicy,
+	/// Whether to reject connections with a missing Origin header.
+	/// Default: true (reject missing Origin)
+	pub reject_missing_origin: bool,
+}
+
+impl Default for OriginValidationConfig {
+	fn default() -> Self {
+		Self {
+			policy: OriginPolicy::AllowList(Vec::new()),
+			reject_missing_origin: true,
+		}
+	}
+}
+
+impl OriginValidationConfig {
+	/// Create a new config with the given policy
+	pub fn new(policy: OriginPolicy) -> Self {
+		Self {
+			policy,
+			reject_missing_origin: true,
+		}
+	}
+
+	/// Set whether to reject connections with missing Origin header
+	pub fn with_reject_missing_origin(mut self, reject: bool) -> Self {
+		self.reject_missing_origin = reject;
+		self
+	}
+}
+
+/// Middleware that validates the Origin header during WebSocket handshake
+///
+/// This middleware checks the `Origin` header in the connection context headers
+/// against the configured policy and rejects connections from unauthorized origins.
+///
+/// # Examples
+///
+/// ```
+/// use reinhardt_websockets::origin::{OriginValidationMiddleware, OriginPolicy};
+/// use reinhardt_websockets::middleware::{ConnectionMiddleware, ConnectionContext};
+///
+/// # tokio_test::block_on(async {
+/// let middleware = OriginValidationMiddleware::new(
+///     OriginPolicy::AllowList(vec!["https://example.com".to_string()]),
+/// );
+///
+/// // Valid origin
+/// let mut context = ConnectionContext::new("192.168.1.1".to_string())
+///     .with_header("origin".to_string(), "https://example.com".to_string());
+/// assert!(middleware.on_connect(&mut context).await.is_ok());
+///
+/// // Invalid origin
+/// let mut context = ConnectionContext::new("192.168.1.1".to_string())
+///     .with_header("origin".to_string(), "https://evil.com".to_string());
+/// assert!(middleware.on_connect(&mut context).await.is_err());
+/// # });
+/// ```
+pub struct OriginValidationMiddleware {
+	config: OriginValidationConfig,
+}
+
+impl OriginValidationMiddleware {
+	/// Create a new Origin validation middleware with the given policy
+	pub fn new(policy: OriginPolicy) -> Self {
+		Self {
+			config: OriginValidationConfig::new(policy),
+		}
+	}
+
+	/// Create a new Origin validation middleware with full configuration
+	pub fn with_config(config: OriginValidationConfig) -> Self {
+		Self { config }
+	}
+}
+
+/// Shared Origin validation function for use across WebSocket entry points
+///
+/// This function can be called directly from any WebSocket connection handler
+/// (including pages integration) to validate the Origin header.
+///
+/// # Arguments
+///
+/// * `origin` - The Origin header value, or `None` if not present
+/// * `config` - The Origin validation configuration
+///
+/// # Returns
+///
+/// Returns `Ok(())` if the Origin is valid, or an error if rejected.
+pub fn validate_origin(
+	origin: Option<&str>,
+	config: &OriginValidationConfig,
+) -> MiddlewareResult<()> {
+	match origin {
+		Some(origin_value) => {
+			let origin_value = origin_value.trim();
+			if origin_value.is_empty() {
+				if config.reject_missing_origin {
+					return Err(MiddlewareError::ConnectionRejected(
+						"Empty Origin header".to_string(),
+					));
+				}
+				return Ok(());
+			}
+
+			match &config.policy {
+				OriginPolicy::AllowAll => Ok(()),
+				OriginPolicy::AllowList(allowed) => {
+					let normalized = origin_value.to_lowercase();
+					let normalized = normalized.trim_end_matches('/');
+					let is_allowed = allowed.iter().any(|allowed_origin| {
+						let allowed_normalized = allowed_origin.trim().to_lowercase();
+						let allowed_normalized = allowed_normalized.trim_end_matches('/');
+						normalized == allowed_normalized
+					});
+
+					if is_allowed {
+						Ok(())
+					} else {
+						Err(MiddlewareError::ConnectionRejected(format!(
+							"Origin not allowed: {}",
+							origin_value
+						)))
+					}
+				}
+			}
+		}
+		None => {
+			if config.reject_missing_origin {
+				Err(MiddlewareError::ConnectionRejected(
+					"Missing Origin header".to_string(),
+				))
+			} else {
+				Ok(())
+			}
+		}
+	}
+}
+
+#[async_trait]
+impl ConnectionMiddleware for OriginValidationMiddleware {
+	async fn on_connect(&self, context: &mut ConnectionContext) -> MiddlewareResult<()> {
+		let origin = context.headers.get(ORIGIN_HEADER).cloned();
+		validate_origin(origin.as_deref(), &self.config)
+	}
+
+	async fn on_disconnect(&self, _connection: &Arc<WebSocketConnection>) -> MiddlewareResult<()> {
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	// -- OriginValidationMiddleware tests --
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_allow_list_accepts_valid_origin() {
+		// Arrange
+		let middleware = OriginValidationMiddleware::new(OriginPolicy::AllowList(vec![
+			"https://example.com".to_string(),
+		]));
+		let mut context = ConnectionContext::new("192.168.1.1".to_string())
+			.with_header("origin".to_string(), "https://example.com".to_string());
+
+		// Act
+		let result = middleware.on_connect(&mut context).await;
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_allow_list_rejects_invalid_origin() {
+		// Arrange
+		let middleware = OriginValidationMiddleware::new(OriginPolicy::AllowList(vec![
+			"https://example.com".to_string(),
+		]));
+		let mut context = ConnectionContext::new("192.168.1.1".to_string())
+			.with_header("origin".to_string(), "https://evil.com".to_string());
+
+		// Act
+		let result = middleware.on_connect(&mut context).await;
+
+		// Assert
+		assert!(result.is_err());
+		assert!(matches!(
+			result.unwrap_err(),
+			MiddlewareError::ConnectionRejected(msg) if msg.contains("Origin not allowed")
+		));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_rejects_missing_origin_by_default() {
+		// Arrange
+		let middleware = OriginValidationMiddleware::new(OriginPolicy::AllowList(vec![
+			"https://example.com".to_string(),
+		]));
+		let mut context = ConnectionContext::new("192.168.1.1".to_string());
+
+		// Act
+		let result = middleware.on_connect(&mut context).await;
+
+		// Assert
+		assert!(result.is_err());
+		assert!(matches!(
+			result.unwrap_err(),
+			MiddlewareError::ConnectionRejected(msg) if msg.contains("Missing Origin header")
+		));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_allows_missing_origin_when_configured() {
+		// Arrange
+		let config = OriginValidationConfig::new(OriginPolicy::AllowList(vec![
+			"https://example.com".to_string(),
+		]))
+		.with_reject_missing_origin(false);
+		let middleware = OriginValidationMiddleware::with_config(config);
+		let mut context = ConnectionContext::new("192.168.1.1".to_string());
+
+		// Act
+		let result = middleware.on_connect(&mut context).await;
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_allow_all_policy_accepts_any_origin() {
+		// Arrange
+		let middleware = OriginValidationMiddleware::new(OriginPolicy::AllowAll);
+		let mut context = ConnectionContext::new("192.168.1.1".to_string())
+			.with_header("origin".to_string(), "https://any-origin.com".to_string());
+
+		// Act
+		let result = middleware.on_connect(&mut context).await;
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_case_insensitive_origin_comparison() {
+		// Arrange
+		let middleware = OriginValidationMiddleware::new(OriginPolicy::AllowList(vec![
+			"https://Example.COM".to_string(),
+		]));
+		let mut context = ConnectionContext::new("192.168.1.1".to_string())
+			.with_header("origin".to_string(), "https://example.com".to_string());
+
+		// Act
+		let result = middleware.on_connect(&mut context).await;
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_trailing_slash_normalization() {
+		// Arrange
+		let middleware = OriginValidationMiddleware::new(OriginPolicy::AllowList(vec![
+			"https://example.com".to_string(),
+		]));
+		let mut context = ConnectionContext::new("192.168.1.1".to_string())
+			.with_header("origin".to_string(), "https://example.com/".to_string());
+
+		// Act
+		let result = middleware.on_connect(&mut context).await;
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_multiple_allowed_origins() {
+		// Arrange
+		let middleware = OriginValidationMiddleware::new(OriginPolicy::AllowList(vec![
+			"https://app.example.com".to_string(),
+			"https://admin.example.com".to_string(),
+			"http://localhost:3000".to_string(),
+		]));
+
+		// Act & Assert - each allowed origin should be accepted
+		for origin in [
+			"https://app.example.com",
+			"https://admin.example.com",
+			"http://localhost:3000",
+		] {
+			let mut context = ConnectionContext::new("192.168.1.1".to_string())
+				.with_header("origin".to_string(), origin.to_string());
+			assert!(
+				middleware.on_connect(&mut context).await.is_ok(),
+				"Expected origin '{}' to be accepted",
+				origin
+			);
+		}
+
+		// Unlisted origin should be rejected
+		let mut context = ConnectionContext::new("192.168.1.1".to_string())
+			.with_header("origin".to_string(), "https://evil.com".to_string());
+		assert!(middleware.on_connect(&mut context).await.is_err());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_empty_allow_list_rejects_all_origins() {
+		// Arrange
+		let middleware = OriginValidationMiddleware::new(OriginPolicy::AllowList(vec![]));
+		let mut context = ConnectionContext::new("192.168.1.1".to_string())
+			.with_header("origin".to_string(), "https://example.com".to_string());
+
+		// Act
+		let result = middleware.on_connect(&mut context).await;
+
+		// Assert
+		assert!(result.is_err());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_empty_origin_header_rejected_when_required() {
+		// Arrange
+		let middleware = OriginValidationMiddleware::new(OriginPolicy::AllowList(vec![
+			"https://example.com".to_string(),
+		]));
+		let mut context = ConnectionContext::new("192.168.1.1".to_string())
+			.with_header("origin".to_string(), "".to_string());
+
+		// Act
+		let result = middleware.on_connect(&mut context).await;
+
+		// Assert
+		assert!(result.is_err());
+		assert!(matches!(
+			result.unwrap_err(),
+			MiddlewareError::ConnectionRejected(msg) if msg.contains("Empty Origin header")
+		));
+	}
+
+	// -- Shared validate_origin function tests --
+
+	#[rstest]
+	fn test_validate_origin_function_valid() {
+		// Arrange
+		let config = OriginValidationConfig::new(OriginPolicy::AllowList(vec![
+			"https://example.com".to_string(),
+		]));
+
+		// Act
+		let result = validate_origin(Some("https://example.com"), &config);
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	fn test_validate_origin_function_missing_rejected() {
+		// Arrange
+		let config = OriginValidationConfig::new(OriginPolicy::AllowList(vec![
+			"https://example.com".to_string(),
+		]));
+
+		// Act
+		let result = validate_origin(None, &config);
+
+		// Assert
+		assert!(result.is_err());
+	}
+
+	#[rstest]
+	fn test_validate_origin_function_missing_allowed() {
+		// Arrange
+		let config = OriginValidationConfig::new(OriginPolicy::AllowList(vec![
+			"https://example.com".to_string(),
+		]))
+		.with_reject_missing_origin(false);
+
+		// Act
+		let result = validate_origin(None, &config);
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	fn test_validate_origin_function_invalid() {
+		// Arrange
+		let config = OriginValidationConfig::new(OriginPolicy::AllowList(vec![
+			"https://example.com".to_string(),
+		]));
+
+		// Act
+		let result = validate_origin(Some("https://evil.com"), &config);
+
+		// Assert
+		assert!(result.is_err());
+	}
+
+	#[rstest]
+	fn test_validate_origin_function_allow_all() {
+		// Arrange
+		let config = OriginValidationConfig::new(OriginPolicy::AllowAll);
+
+		// Act
+		let result = validate_origin(Some("https://any.com"), &config);
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_on_disconnect_always_succeeds() {
+		// Arrange
+		let middleware = OriginValidationMiddleware::new(OriginPolicy::AllowList(vec![]));
+		let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+		let conn = Arc::new(WebSocketConnection::new("test".to_string(), tx));
+
+		// Act
+		let result = middleware.on_disconnect(&conn).await;
+
+		// Assert
+		assert!(result.is_ok());
+	}
+}


### PR DESCRIPTION
## Summary
This PR addresses:
- Add `OriginValidationMiddleware` as a `ConnectionMiddleware` to validate Origin headers during WebSocket handshake
- Prevent Cross-Site WebSocket Hijacking (CSWSH) attacks by enforcing Origin-based access control
- Provide shared `validate_origin()` function for reuse across all WebSocket entry points (including pages integration)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (if applicable)
- [ ] Refactoring / Documentation / Performance / Code quality / CI/CD / Other

## Motivation and Context
The pages WebSocket integration (`pages.rs`) and core WebSocket handshake lack Origin header validation, making them vulnerable to Cross-Site WebSocket Hijacking (CSWSH) attacks. An attacker can trick a user's browser into opening a WebSocket connection to the application from a malicious origin, potentially accessing sensitive page state or manipulating real-time data.

This middleware validates the `Origin` header against a configurable allow list, rejecting connections from unauthorized origins.

Fixes #514

Related to: SEC-WS-001, SEC-WS-006

## How Was This Tested?
- Valid origins accepted with AllowList policy
- Invalid origins rejected with AllowList policy
- Missing Origin header rejected by default
- Missing Origin header allowed when configured (`reject_missing_origin: false`)
- AllowAll policy accepts any origin
- Case-insensitive comparison works correctly
- Trailing slash normalization works
- Multiple allowed origins tested
- Empty allow list rejects all origins
- Empty Origin header value rejected when required
- Shared `validate_origin()` function tested independently
- `on_disconnect` always succeeds
- All 208 tests pass
- cargo make fmt-check clean
- cargo make clippy-check clean

## Breaking Changes (if applicable)
None. This is a new middleware that must be explicitly added to the middleware chain.

## Checklist
- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues
- Part of Phase 2 Security Fixes batch

## Labels to Apply
### Type Label (select one)
- [x] `security` - Security vulnerability fix
### Scope Label (select all that apply)
- [x] `websockets`
### Priority Label
- [x] `high` - Important fix

---
**Additional Context:**

### New public API:
- `OriginPolicy` enum: `AllowList(Vec<String>)`, `AllowAll`
- `OriginValidationConfig`: policy + `reject_missing_origin` flag
- `OriginValidationMiddleware`: implements `ConnectionMiddleware`
- `validate_origin()`: shared function for direct use in any WebSocket handler

### Files changed:
- `crates/reinhardt-websockets/src/origin.rs` (new)
- `crates/reinhardt-websockets/src/lib.rs` (register module, re-exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)