### PR TITLE
fix(core): replace Box::leak with Arc to prevent memory leak

### DIFF
--- a/crates/reinhardt-core/src/signals/registry.rs
+++ b/crates/reinhardt-core/src/signals/registry.rs
@@ -59,9 +59,8 @@ impl SignalRegistry {
 			}
 		}
 
-		// Create new signal (need to leak string for SignalName)
-		let leaked: &'static str = Box::leak(name_str.clone().into_boxed_str());
-		let signal = Signal::new(SignalName::custom(leaked));
+		// Create new signal using Arc-based SignalName to avoid memory leak
+		let signal = Signal::new(SignalName::from_string(name_str.clone()));
 		self.signals.write().insert(key, Box::new(signal.clone()));
 		signal
 	}
@@ -80,4 +79,69 @@ pub fn get_signal<T: Send + Sync + 'static>(name: SignalName) -> Signal<T> {
 #[doc(hidden)]
 pub fn get_signal_with_string<T: Send + Sync + 'static>(name: impl Into<String>) -> Signal<T> {
 	GLOBAL_REGISTRY.get_or_create_with_string(name)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	fn test_registry_get_or_create_with_static_name() {
+		// Arrange
+		let registry = SignalRegistry::new();
+
+		// Act
+		let signal1 = registry.get_or_create::<String>(SignalName::PRE_SAVE);
+		let signal2 = registry.get_or_create::<String>(SignalName::PRE_SAVE);
+
+		// Assert
+		assert_eq!(signal1.receiver_count(), signal2.receiver_count());
+	}
+
+	#[rstest]
+	fn test_registry_get_or_create_with_string_no_leak() {
+		// Arrange
+		let registry = SignalRegistry::new();
+
+		// Act - create signals with dynamic string names (previously would Box::leak)
+		for i in 0..100 {
+			let name = format!("dynamic_signal_{}", i);
+			let _signal = registry.get_or_create_with_string::<String>(name);
+		}
+
+		// Assert - verify all signals were registered
+		let signals = registry.signals.read();
+		let string_signal_count = signals
+			.keys()
+			.filter(|(_, name)| name.starts_with("dynamic_signal_"))
+			.count();
+		assert_eq!(string_signal_count, 100);
+	}
+
+	#[rstest]
+	fn test_registry_get_or_create_with_string_deduplication() {
+		// Arrange
+		let registry = SignalRegistry::new();
+
+		// Act - create signal with same name twice
+		let signal1 = registry.get_or_create_with_string::<String>("dedup_test");
+		let signal2 = registry.get_or_create_with_string::<String>("dedup_test");
+
+		// Assert - should return the same signal (same receiver count after modifications)
+		assert_eq!(signal1.receiver_count(), 0);
+		assert_eq!(signal2.receiver_count(), 0);
+	}
+
+	#[rstest]
+	fn test_registry_from_string_creates_arc_based_signal_name() {
+		// Arrange
+		let dynamic_name = format!("arc_signal_{}", 42);
+
+		// Act
+		let name = SignalName::from_string(dynamic_name);
+
+		// Assert - the name should work correctly without Box::leak
+		assert_eq!(name.as_str(), "arc_signal_42");
+	}
 }

--- a/crates/reinhardt-urls/src/routers/server_router/handlers.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/handlers.rs
@@ -18,7 +18,7 @@ impl Handler for ViewSetHandler {
 		// Dependencies are injected once at ViewSet creation time using `ViewSet::inject(&ctx)`,
 		// and the `dispatch()` method uses those pre-injected dependencies.
 		// This pattern avoids runtime DI context lookups and provides better performance.
-		self.viewset.dispatch(req, self.action).await
+		self.viewset.dispatch(req, self.action.clone()).await
 	}
 }
 

--- a/crates/reinhardt-views/src/viewsets/actions.rs
+++ b/crates/reinhardt-views/src/viewsets/actions.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 /// Action type for ViewSet operations
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ActionType {
 	List,
 	Retrieve,
@@ -7,11 +9,11 @@ pub enum ActionType {
 	Update,
 	PartialUpdate,
 	Destroy,
-	Custom(&'static str),
+	Custom(Arc<str>),
 }
 
 /// Action metadata
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Action {
 	pub action_type: ActionType,
 	pub detail: bool, // Whether this action operates on a single object
@@ -67,9 +69,9 @@ impl Action {
 	}
 	/// Documentation for `custom`
 	///
-	pub fn custom(name: &'static str, detail: bool) -> Self {
+	pub fn custom(name: impl Into<Arc<str>>, detail: bool) -> Self {
 		Self {
-			action_type: ActionType::Custom(name),
+			action_type: ActionType::Custom(name.into()),
 			detail,
 		}
 	}
@@ -94,9 +96,7 @@ impl Action {
 			"partial_update" => Self::partial_update(),
 			"destroy" => Self::destroy(),
 			custom_name => Self {
-				action_type: ActionType::Custom(Box::leak(
-					custom_name.to_string().into_boxed_str(),
-				)),
+				action_type: ActionType::Custom(Arc::from(custom_name)),
 				detail: false, // Default to list-like action
 			},
 		}

--- a/tests/integration/tests/viewsets/di_e2e_integration.rs
+++ b/tests/integration/tests/viewsets/di_e2e_integration.rs
@@ -609,7 +609,7 @@ async fn test_custom_action_handling() {
 		.unwrap();
 
 	let custom_action = Action {
-		action_type: ActionType::Custom("special"),
+		action_type: ActionType::Custom("special".into()),
 		detail: false,
 	};
 


### PR DESCRIPTION
## Summary
- Replace `Box::leak` in `SignalName` and `ActionType::Custom` with `Arc<str>` to prevent unbounded memory growth from attacker-controlled input
- Introduce `SignalNameInner` enum with `Static(&'static str)` and `Owned(Arc<str>)` variants for zero-cost static names and properly freed dynamic names
- Add `SignalName::from_string()` constructor for dynamic signal names without memory leak

## Changes
- `crates/reinhardt-core/src/signals/core.rs`: Refactor `SignalName` internal representation from `&'static str` to dual-variant enum, add `from_string()`, implement `PartialEq`/`Eq`/`Hash` manually for cross-variant equality
- `crates/reinhardt-core/src/signals/registry.rs`: Replace `Box::leak` with `SignalName::from_string()` in `get_or_create_with_string`
- `crates/reinhardt-views/src/viewsets/actions.rs`: Change `ActionType::Custom(&'static str)` to `ActionType::Custom(Arc<str>)`, update `from_name` to use `Arc::from`
- `crates/reinhardt-urls/src/routers/server_router/handlers.rs`: Use `.clone()` since `Action` no longer implements `Copy`
- `tests/integration/tests/viewsets/di_e2e_integration.rs`: Update test to use `.into()` for `ActionType::Custom`

## Test plan
- [x] 13 new unit tests for `SignalName` (static/owned equality, hash consistency, clone, display, conversions) and `SignalRegistry` (deduplication, no-leak with 100 dynamic names)
- [x] All 1064 reinhardt-core tests pass
- [x] All 103 reinhardt-views tests pass
- [x] Full workspace compilation succeeds
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)