### PR TITLE
security(server,core): add request body size limits and decompression bomb prevention

### DIFF
--- a/crates/reinhardt-server/src/server/http2.rs
+++ b/crates/reinhardt-server/src/server/http2.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
+use hyper::StatusCode;
 use hyper::body::Incoming;
 use hyper::server::conn::http2;
 use hyper::service::Service;
@@ -205,7 +206,10 @@ impl Http2Server {
 		handler: Arc<dyn Handler>,
 	) -> Result<(), Box<dyn std::error::Error>> {
 		let io = TokioIo::new(stream);
-		let service = RequestService { handler };
+		let service = RequestService {
+			handler,
+			max_body_size: DEFAULT_MAX_BODY_SIZE,
+		};
 
 		http2::Builder::new(hyper_util::rt::TokioExecutor::new())
 			.serve_connection(io, service)
@@ -215,9 +219,13 @@ impl Http2Server {
 	}
 }
 
+/// Default maximum request body size (10 MB)
+const DEFAULT_MAX_BODY_SIZE: u64 = 10 * 1024 * 1024;
+
 /// Service implementation for hyper
 struct RequestService {
 	handler: Arc<dyn Handler>,
+	max_body_size: u64,
 }
 
 impl Service<hyper::Request<Incoming>> for RequestService {
@@ -227,13 +235,35 @@ impl Service<hyper::Request<Incoming>> for RequestService {
 
 	fn call(&self, req: hyper::Request<Incoming>) -> Self::Future {
 		let handler = self.handler.clone();
+		let max_body_size = self.max_body_size;
 
 		Box::pin(async move {
+			// Check Content-Length before reading body
+			if let Some(content_length) = req.headers().get(hyper::header::CONTENT_LENGTH)
+				&& let Ok(len_str) = content_length.to_str()
+				&& let Ok(len) = len_str.parse::<u64>()
+				&& len > max_body_size
+			{
+				return Ok(hyper::Response::builder()
+					.status(StatusCode::PAYLOAD_TOO_LARGE)
+					.body(Full::new(Bytes::from("Request body too large")))
+					.expect("Failed to build 413 response"));
+			}
+
 			// Extract request parts
 			let (parts, body) = req.into_parts();
 
-			// Read body
-			let body_bytes = body.collect().await?.to_bytes();
+			// Read body with size limit
+			let body_bytes = http_body_util::Limited::new(body, max_body_size as usize)
+				.collect()
+				.await
+				.map_err(|_| {
+					Box::new(std::io::Error::new(
+						std::io::ErrorKind::InvalidData,
+						"Request body exceeds size limit",
+					)) as Box<dyn std::error::Error + Send + Sync>
+				})?
+				.to_bytes();
 
 			// Create reinhardt Request
 			let request = Request::builder()


### PR DESCRIPTION
## Summary
This PR addresses:
- Add `DEFAULT_MAX_BODY_SIZE` (10 MB) request body limit to HTTP/1.1 and HTTP/2 servers
- Add Content-Length pre-check returning 413 Payload Too Large before reading body
- Add `http_body_util::Limited` streaming body size enforcement as a second layer of protection
- Add `DEFAULT_MAX_OUTPUT_SIZE` (100 MB) decompression output limit to compressed parser
- Add `decompress_with_limit()` method using `Read::take()` to prevent decompression bomb attacks

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (if applicable)
- [ ] Refactoring / Documentation / Performance / Code quality / CI/CD / Other

## Motivation and Context
Without request body size limits, an attacker can send arbitrarily large payloads to exhaust server memory. Without decompression output limits, a small compressed payload (decompression bomb) can expand to gigabytes of data. Both are critical resource exhaustion vulnerabilities.

Fixes #358
Fixes #457

## How Was This Tested?
- All 18 compression tests pass (reinhardt-core)
- All 26 server tests pass (reinhardt-server)
- `cargo make fmt-check` clean
- `cargo make clippy-check` clean (workspace-wide)

## Breaking Changes (if applicable)
N/A - Default limits are applied transparently. Existing valid requests under 10 MB body / 100 MB decompressed output are unaffected.

## Checklist
- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues
- Part of Phase 2 Security Fixes batch

## Labels to Apply
### Type Label (select one)
- [x] `security` - Security vulnerability fix
### Scope Label (select all that apply)
- [x] `http` - HTTP layer / server changes
- [x] `core` - Core parser changes
### Priority Label
- [x] `high` - Important security fix

---
**Additional Context:**
This is PR-2.6 in the Phase 2 Security Fixes batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)