### PR TITLE
fix(throttling): validate refill interval and use wall clock for hour calculation

### DIFF
--- a/crates/reinhardt-throttling/Cargo.toml
+++ b/crates/reinhardt-throttling/Cargo.toml
@@ -25,3 +25,4 @@ maxminddb = { version = "0.26", optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
 tokio-test = { workspace = true }
+rstest = { workspace = true }

--- a/crates/reinhardt-throttling/src/throttle.rs
+++ b/crates/reinhardt-throttling/src/throttle.rs
@@ -7,6 +7,8 @@ pub enum ThrottleError {
 	RateLimitExceeded,
 	#[error("Throttle error: {0}")]
 	ThrottleError(String),
+	#[error("Invalid configuration: {0}")]
+	InvalidConfig(String),
 }
 
 pub type ThrottleResult<T> = Result<T, ThrottleError>;

--- a/crates/reinhardt-throttling/src/time_of_day.rs
+++ b/crates/reinhardt-throttling/src/time_of_day.rs
@@ -168,17 +168,9 @@ impl<B: ThrottleBackend, T: TimeProvider> TimeOfDayThrottle<B, T> {
 		}
 	}
 
-	/// Get current hour (0-23)
+	/// Get current hour (0-23) using wall clock time
 	fn get_current_hour(&self) -> u8 {
-		// Get current time from provider
-		let now = self.time_provider.now();
-
-		// Calculate hour from elapsed time since epoch
-		// This is a simplified implementation for testing
-		// In production, you'd want to use chrono or time crate for proper timezone handling
-		let duration_since_epoch = now.elapsed();
-		let total_hours = duration_since_epoch.as_secs() / 3600;
-		(total_hours % 24) as u8
+		self.time_provider.wall_clock_hour()
 	}
 
 	/// Get the appropriate rate for current time
@@ -229,12 +221,15 @@ mod tests {
 	use super::*;
 	use crate::backend::MemoryBackend;
 	use crate::time_provider::MockTimeProvider;
+	use rstest::rstest;
 	use tokio::time::Instant;
 
-	#[test]
+	#[rstest]
 	fn test_time_range_normal() {
-		let range = TimeRange::new(9, 17); // 9 AM to 5 PM
+		// Arrange
+		let range = TimeRange::new(9, 17);
 
+		// Assert
 		assert!(range.contains(9));
 		assert!(range.contains(12));
 		assert!(range.contains(17));
@@ -242,10 +237,12 @@ mod tests {
 		assert!(!range.contains(18));
 	}
 
-	#[test]
+	#[rstest]
 	fn test_time_range_wrapping() {
-		let range = TimeRange::new(22, 2); // 10 PM to 2 AM
+		// Arrange
+		let range = TimeRange::new(22, 2);
 
+		// Assert
 		assert!(range.contains(22));
 		assert!(range.contains(23));
 		assert!(range.contains(0));
@@ -255,76 +252,143 @@ mod tests {
 		assert!(!range.contains(21));
 	}
 
-	#[test]
+	#[rstest]
 	fn test_time_of_day_config_get_rate() {
+		// Arrange
 		let config = TimeOfDayConfig::new(TimeRange::new(9, 17), (50, 60), (100, 60));
 
-		// Peak hours
+		// Assert - peak hours
 		assert_eq!(config.get_rate(9), (50, 60));
 		assert_eq!(config.get_rate(12), (50, 60));
 		assert_eq!(config.get_rate(17), (50, 60));
 
-		// Off-peak hours
+		// Assert - off-peak hours
 		assert_eq!(config.get_rate(8), (100, 60));
 		assert_eq!(config.get_rate(18), (100, 60));
 		assert_eq!(config.get_rate(0), (100, 60));
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_time_of_day_throttle_basic() {
+		// Arrange
 		let backend = Arc::new(MemoryBackend::new());
 		let config = TimeOfDayConfig::new(TimeRange::new(9, 17), (5, 60), (10, 60));
 		let throttle = TimeOfDayThrottle::new(backend, config);
 
-		// Test basic throttling
+		// Act
 		let current_rate = throttle.get_current_rate().await;
 		let (limit, _) = current_rate;
 
-		// Should allow up to limit
+		// Assert - should allow up to limit
 		for _ in 0..limit {
 			assert!(throttle.allow_request("test_key").await.unwrap());
 		}
 
-		// Next request should fail
+		// Assert - next request should fail
 		assert!(!throttle.allow_request("test_key").await.unwrap());
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_time_of_day_throttle_with_mock_time() {
+		// Arrange
 		let time_provider = Arc::new(MockTimeProvider::new(Instant::now()));
 		let backend = Arc::new(MemoryBackend::with_time_provider(time_provider.clone()));
 		let config = TimeOfDayConfig::new(TimeRange::new(9, 17), (5, 60), (10, 60));
 		let throttle = TimeOfDayThrottle::with_time_provider(backend, config, time_provider);
 
-		// Test with mock time
+		// Act
 		let (limit, _) = throttle.get_current_rate().await;
 
+		// Assert
 		for _ in 0..limit {
 			assert!(throttle.allow_request("test_key").await.unwrap());
 		}
-
 		assert!(!throttle.allow_request("test_key").await.unwrap());
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_time_of_day_throttle_get_rate() {
+		// Arrange
 		let backend = Arc::new(MemoryBackend::new());
 		let config = TimeOfDayConfig::new(TimeRange::new(9, 17), (50, 60), (100, 60));
 		let throttle = TimeOfDayThrottle::new(backend, config);
 
-		// Should return peak rate as default
+		// Assert - should return peak rate as default
 		assert_eq!(throttle.get_rate(), (50, 60));
 	}
 
-	#[test]
+	#[rstest]
 	#[should_panic(expected = "start_hour must be 0-23")]
 	fn test_time_range_invalid_start() {
 		TimeRange::new(24, 10);
 	}
 
-	#[test]
+	#[rstest]
 	#[should_panic(expected = "end_hour must be 0-23")]
 	fn test_time_range_invalid_end() {
 		TimeRange::new(10, 24);
+	}
+
+	#[rstest]
+	#[case::peak_hour(12, (5, 60))]
+	#[case::off_peak_hour(3, (10, 60))]
+	#[tokio::test]
+	async fn test_wall_clock_hour_selects_correct_rate(
+		#[case] mock_hour: u8,
+		#[case] expected_rate: (usize, u64),
+	) {
+		// Arrange
+		let time_provider = Arc::new(MockTimeProvider::new(Instant::now()));
+		time_provider.set_wall_clock_hour(mock_hour);
+		let backend = Arc::new(MemoryBackend::with_time_provider(time_provider.clone()));
+		let config = TimeOfDayConfig::new(TimeRange::new(9, 17), (5, 60), (10, 60));
+		let throttle = TimeOfDayThrottle::with_time_provider(backend, config, time_provider);
+
+		// Act
+		let rate = throttle.get_current_rate().await;
+
+		// Assert
+		assert_eq!(rate, expected_rate);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_wall_clock_peak_enforces_lower_limit() {
+		// Arrange - set to peak hour (12 noon)
+		let time_provider = Arc::new(MockTimeProvider::new(Instant::now()));
+		time_provider.set_wall_clock_hour(12);
+		let backend = Arc::new(MemoryBackend::with_time_provider(time_provider.clone()));
+		let config = TimeOfDayConfig::new(TimeRange::new(9, 17), (3, 60), (10, 60));
+		let throttle = TimeOfDayThrottle::with_time_provider(backend, config, time_provider);
+
+		// Act - should allow 3 requests (peak limit)
+		for _ in 0..3 {
+			assert!(throttle.allow_request("user").await.unwrap());
+		}
+
+		// Assert - 4th request should be denied
+		assert!(!throttle.allow_request("user").await.unwrap());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_wall_clock_off_peak_allows_higher_limit() {
+		// Arrange - set to off-peak hour (3 AM)
+		let time_provider = Arc::new(MockTimeProvider::new(Instant::now()));
+		time_provider.set_wall_clock_hour(3);
+		let backend = Arc::new(MemoryBackend::with_time_provider(time_provider.clone()));
+		let config = TimeOfDayConfig::new(TimeRange::new(9, 17), (3, 60), (10, 60));
+		let throttle = TimeOfDayThrottle::with_time_provider(backend, config, time_provider);
+
+		// Act - should allow 10 requests (off-peak limit)
+		for _ in 0..10 {
+			assert!(throttle.allow_request("user").await.unwrap());
+		}
+
+		// Assert - 11th request should be denied
+		assert!(!throttle.allow_request("user").await.unwrap());
 	}
 }

--- a/crates/reinhardt-throttling/src/time_provider.rs
+++ b/crates/reinhardt-throttling/src/time_provider.rs
@@ -8,6 +8,20 @@ use tokio::time::Instant;
 #[async_trait]
 pub trait TimeProvider: Send + Sync {
 	fn now(&self) -> Instant;
+
+	/// Returns the current hour of the day (0-23) from wall clock time.
+	///
+	/// Monotonic clocks (`Instant`) have an arbitrary epoch and cannot be used
+	/// for wall clock calculations. This method uses `SystemTime` by default
+	/// to derive the actual hour of the day (UTC).
+	fn wall_clock_hour(&self) -> u8 {
+		use std::time::{SystemTime, UNIX_EPOCH};
+		let secs = SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.expect("system clock is before UNIX epoch")
+			.as_secs();
+		((secs % 86400) / 3600) as u8
+	}
 }
 
 /// System time provider that uses the actual system clock.
@@ -31,12 +45,14 @@ impl TimeProvider for SystemTimeProvider {
 #[derive(Clone)]
 pub struct MockTimeProvider {
 	current_time: Arc<RwLock<Instant>>,
+	mock_hour: Arc<RwLock<Option<u8>>>,
 }
 
 impl MockTimeProvider {
 	pub fn new(start_time: Instant) -> Self {
 		Self {
 			current_time: Arc::new(RwLock::new(start_time)),
+			mock_hour: Arc::new(RwLock::new(None)),
 		}
 	}
 
@@ -48,6 +64,13 @@ impl MockTimeProvider {
 	pub fn set_time(&self, time: Instant) {
 		let mut current = self.current_time.write();
 		*current = time;
+	}
+
+	/// Set a fixed wall clock hour for testing time-of-day throttling
+	pub fn set_wall_clock_hour(&self, hour: u8) {
+		assert!(hour < 24, "hour must be 0-23");
+		let mut mock_hour = self.mock_hour.write();
+		*mock_hour = Some(hour);
 	}
 }
 
@@ -62,40 +85,106 @@ impl TimeProvider for MockTimeProvider {
 	fn now(&self) -> Instant {
 		*self.current_time.read()
 	}
+
+	fn wall_clock_hour(&self) -> u8 {
+		self.mock_hour.read().unwrap_or_else(|| {
+			// Fall back to actual wall clock if no mock hour is set
+			use std::time::{SystemTime, UNIX_EPOCH};
+			let secs = SystemTime::now()
+				.duration_since(UNIX_EPOCH)
+				.expect("system clock is before UNIX epoch")
+				.as_secs();
+			((secs % 86400) / 3600) as u8
+		})
+	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::rstest;
 	use std::time::Duration;
 
-	#[test]
+	#[rstest]
 	fn test_system_time_provider_returns_current_time() {
+		// Arrange
 		let provider = SystemTimeProvider::new();
+
+		// Act
 		let time1 = provider.now();
 		std::thread::sleep(Duration::from_millis(10));
 		let time2 = provider.now();
+
+		// Assert
 		assert!(time2 > time1);
 	}
 
-	#[test]
+	#[rstest]
 	fn test_mock_time_provider_allows_time_control() {
+		// Arrange
 		let start = Instant::now();
 		let provider = MockTimeProvider::new(start);
 
+		// Act & Assert
 		let time1 = provider.now();
 		assert_eq!(time1, start);
 
+		// Act
 		provider.advance(Duration::from_secs(60));
 		let time2 = provider.now();
+
+		// Assert
 		assert_eq!(time2, start + Duration::from_secs(60));
 	}
 
-	#[test]
+	#[rstest]
 	fn test_mock_time_provider_set_time() {
+		// Arrange
 		let provider = MockTimeProvider::new(Instant::now());
 		let new_time = Instant::now() + Duration::from_secs(100);
+
+		// Act
 		provider.set_time(new_time);
+
+		// Assert
 		assert_eq!(provider.now(), new_time);
+	}
+
+	#[rstest]
+	fn test_system_time_provider_wall_clock_hour_returns_valid_range() {
+		// Arrange
+		let provider = SystemTimeProvider::new();
+
+		// Act
+		let hour = provider.wall_clock_hour();
+
+		// Assert
+		assert!(hour < 24);
+	}
+
+	#[rstest]
+	#[case::midnight(0)]
+	#[case::noon(12)]
+	#[case::evening(23)]
+	fn test_mock_wall_clock_hour(#[case] expected_hour: u8) {
+		// Arrange
+		let provider = MockTimeProvider::new(Instant::now());
+		provider.set_wall_clock_hour(expected_hour);
+
+		// Act
+		let hour = provider.wall_clock_hour();
+
+		// Assert
+		assert_eq!(hour, expected_hour);
+	}
+
+	#[rstest]
+	#[should_panic(expected = "hour must be 0-23")]
+	fn test_mock_wall_clock_hour_rejects_invalid() {
+		// Arrange
+		let provider = MockTimeProvider::new(Instant::now());
+
+		// Act - should panic
+		provider.set_wall_clock_hour(24);
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- **#416**: `TokenBucketConfig` allows zero `refill_interval`, causing division by zero panic at runtime
- **#415**: `get_current_hour()` uses monotonic `Instant` instead of wall clock time, making time-of-day rate limiting non-functional

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

**#416**: `TokenBucketConfig::new()` accepted zero `refill_interval` without validation. When rate limiting was evaluated, `elapsed.as_secs() / self.config.refill_interval` caused an unrecoverable division by zero panic, crashing the application. Any misconfiguration or programmatic error could trigger a denial of service.

**#415**: `get_current_hour()` used `self.time_provider.now()` which returns a monotonic `Instant` with an arbitrary epoch. Calculating hours from `Instant::elapsed()` produces meaningless values that do not correspond to actual wall clock time, making time-of-day based rate limiting (peak/off-peak hours) completely non-functional.

Fixes #416
Fixes #415

## How Was This Tested?

- Added `test_new_rejects_zero_refill_interval` - verifies `TokenBucketConfig::new()` returns `Err(InvalidConfig)` for zero interval
- Added `test_builder_rejects_zero_refill_interval` - verifies builder rejects zero interval
- Added `test_builder_rejects_missing_refill_interval` - verifies builder rejects missing interval
- Added `test_builder_rejects_missing_capacity` - verifies builder rejects missing capacity
- Added `test_builder_rejects_missing_refill_rate` - verifies builder rejects missing refill rate
- Added `test_wall_clock_hour_selects_correct_rate` - parameterized test verifying peak (hour 12) and off-peak (hour 3) rate selection with mock wall clock
- Added `test_wall_clock_peak_enforces_lower_limit` - verifies peak hour enforces lower rate limit
- Added `test_wall_clock_off_peak_allows_higher_limit` - verifies off-peak hour allows higher rate limit
- Added `test_system_time_provider_wall_clock_hour_returns_valid_range` - verifies wall clock hour is 0-23
- Added `test_mock_wall_clock_hour` - parameterized test for mock hour control (midnight, noon, evening)
- Added `test_mock_wall_clock_hour_rejects_invalid` - verifies invalid hour (24) is rejected
- All 80 tests pass: `cargo nextest run --package reinhardt-throttling --all-features`
- All 39 doc-tests pass: `cargo test --doc --package reinhardt-throttling --all-features`
- Full workspace check passes: `cargo check --workspace --all --all-features`
- Formatting check passes: `cargo make fmt-check`
- Clippy check passes: `cargo make clippy-check`

## Breaking Changes

- `TokenBucketConfig::new()` now returns `ThrottleResult<Self>` instead of `Self`
- `TokenBucketConfigBuilder::build()` now returns `ThrottleResult<TokenBucketConfig>` instead of `TokenBucketConfig`
- `ThrottleError` has a new `InvalidConfig(String)` variant
- `TimeProvider` trait has a new `wall_clock_hour()` method with a default implementation

**Migration Guide:**

1. Update `TokenBucketConfig::new()` calls to handle `Result`:
   ```rust
   // Before
   let config = TokenBucketConfig::new(100, 100, 60, 1);
   // After
   let config = TokenBucketConfig::new(100, 100, 60, 1)?;
   // or
   let config = TokenBucketConfig::new(100, 100, 60, 1).unwrap();
   ```

2. Update `TokenBucketConfigBuilder::build()` calls:
   ```rust
   // Before
   let config = TokenBucketConfig::builder().capacity(50).refill_rate(10).refill_interval(1).build();
   // After
   let config = TokenBucketConfig::builder().capacity(50).refill_rate(10).refill_interval(1).build()?;
   ```

3. Custom `TimeProvider` implementations get `wall_clock_hour()` for free via the default implementation using `SystemTime`. Override only if custom behavior is needed.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- #416 - Division by zero panic with zero `refill_interval` in `TokenBucket`
- #415 - `get_current_hour()` uses monotonic clock instead of wall clock

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [x] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes