### PR TITLE
fix(query): preserve subquery parameter values in FROM clause

### DIFF
--- a/crates/reinhardt-query/src/backend/sqlite.rs
+++ b/crates/reinhardt-query/src/backend/sqlite.rs
@@ -118,13 +118,18 @@ impl SqliteQueryBuilder {
 				writer.push_identifier(&alias.to_string(), |s| self.escape_iden(s));
 			}
 			TableRef::SubQuery(query, alias) => {
-				let (sql, _) = self.build_select(query);
+				let (subquery_sql, subquery_values) = self.build_select(query);
+
+				// SQLite uses ? placeholders, no adjustment needed
 				writer.push("(");
-				writer.push(&sql);
+				writer.push(&subquery_sql);
 				writer.push(")");
 				writer.push_keyword("AS");
 				writer.push_space();
 				writer.push_identifier(&alias.to_string(), |s| self.escape_iden(s));
+
+				// Merge the values from the subquery
+				writer.append_values(&subquery_values);
 			}
 		}
 	}
@@ -1912,7 +1917,7 @@ mod tests {
 	use crate::{
 		expr::{Expr, ExprTrait},
 		query::Query,
-		types::IntoIden,
+		types::{Alias, IntoIden},
 	};
 
 	#[test]
@@ -2640,6 +2645,34 @@ mod tests {
 		assert!(sql.contains(r#""status" = ?"#));
 		assert!(sql.contains(r#""active" = ?"#));
 		assert_eq!(values.len(), 4); // 0, "main", "available", true
+	}
+
+	#[test]
+	fn test_from_subquery_preserves_parameter_values() {
+		let builder = SqliteQueryBuilder::new();
+
+		// Arrange
+		let mut subquery = Query::select();
+		subquery
+			.column("id")
+			.column("name")
+			.from("users")
+			.and_where(Expr::col("active").eq(true))
+			.and_where(Expr::col("role").eq("admin"));
+
+		let mut stmt = Query::select();
+		stmt.column("name")
+			.from_subquery(subquery, Alias::new("active_admins"))
+			.and_where(Expr::col("name").like("A%"));
+
+		// Act
+		let (sql, values) = builder.build_select(&stmt);
+
+		// Assert
+		assert!(sql.contains("(SELECT"));
+		assert!(sql.contains(r#") AS "active_admins""#));
+		// Subquery params (true, "admin") + outer param ("A%") = 3 values
+		assert_eq!(values.len(), 3);
 	}
 
 	// --- Phase 5: NULL Handling Tests ---


### PR DESCRIPTION
## Summary

This PR addresses:

- `TableRef::SubQuery` handling fixed in all three backends (PostgreSQL, MySQL, SQLite) where subquery parameter values were silently discarded
- Apply the same value-merging pattern already used by `SimpleExpr::SubQuery`: capture values and merge via `writer.append_values()`
- PostgreSQL backend additionally adjusts `$N` placeholder numbering for parent query parameters

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

When using `from_subquery()` in query building, parameter values from the subquery were silently discarded via `let (sql, _) = self.build_select(query)`. This caused runtime parameter count mismatch errors, making subqueries in FROM clauses unreliable.

The bug pattern was identical across all backends:
- `crates/reinhardt-query/src/backend/postgres.rs` (line 112-120)
- `crates/reinhardt-query/src/backend/mysql.rs` (line 138-146)
- `crates/reinhardt-query/src/backend/sqlite.rs` (line 120-128)

Fixes #327

## How Was This Tested?

- `test_from_subquery_preserves_parameter_values` for PostgreSQL, MySQL, SQLite
- `test_from_subquery_postgres_placeholder_renumbering` for PostgreSQL-specific `$N` adjustment
- `cargo check --workspace --all --all-features`
- `cargo nextest run --package reinhardt-query --all-features`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Part of Phase 1 Critical Security Fixes batch

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [x] `orm` - ORM layer, models, query builder

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

The fix follows the existing pattern used by `SimpleExpr::SubQuery` which was already correctly capturing and merging parameter values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)