### PR TITLE
security(http): use cryptographic random for CSRF fallback secret

### DIFF
--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -42,6 +42,7 @@ flate2 = { workspace = true }
 brotli = "8.0.2"
 sha2 = { workspace = true }
 hex = "0.4"
+rand = { workspace = true }
 httpdate = "1.0"
 bytes = { workspace = true }
 sqlx = { workspace = true, optional = true }

--- a/crates/reinhardt-middleware/src/csrf.rs
+++ b/crates/reinhardt-middleware/src/csrf.rs
@@ -133,19 +133,14 @@ impl CsrfMiddleware {
 			}
 		}
 
-		// Fallback: generate from request metadata
-		// This is not ideal but ensures CSRF protection works without sessions
-		use sha2::{Digest, Sha256};
-		let mut hasher = Sha256::new();
-		hasher.update(request.uri.to_string().as_bytes());
-		hasher.update(
-			request
-				.headers
-				.get("User-Agent")
-				.map(|v| v.as_bytes())
-				.unwrap_or(b""),
-		);
-		hex::encode(hasher.finalize())
+		// Fallback: generate a cryptographically random session ID.
+		// Using a CSPRNG ensures the secret cannot be predicted by an attacker,
+		// unlike the previous approach of hashing request metadata (URI, User-Agent)
+		// which are attacker-controlled.
+		use rand::RngCore;
+		let mut random_bytes = [0u8; 32];
+		rand::thread_rng().fill_bytes(&mut random_bytes);
+		hex::encode(random_bytes)
 	}
 
 	/// Create new CSRF middleware with default configuration
@@ -905,5 +900,74 @@ mod tests {
 			.to_str()
 			.unwrap();
 		assert!(cookie.contains("Secure"));
+	}
+
+	// =================================================================
+	// CSRF fallback secret hardening tests (Issue #361)
+	// =================================================================
+
+	#[rstest::rstest]
+	#[tokio::test]
+	async fn test_csrf_fallback_secret_has_sufficient_entropy() {
+		// Arrange - request with no session ID in extensions or cookies
+		let request = Request::builder()
+			.method(Method::GET)
+			.uri("/test")
+			.version(Version::HTTP_11)
+			.headers(HeaderMap::new())
+			.body(Bytes::new())
+			.build()
+			.unwrap();
+
+		// Act
+		let session_id = CsrfMiddleware::get_session_id(&request);
+
+		// Assert - should be 64 hex chars (32 bytes encoded)
+		assert_eq!(
+			session_id.len(),
+			64,
+			"Fallback session ID should be 64 hex characters (32 random bytes)"
+		);
+		assert!(
+			session_id.chars().all(|c| c.is_ascii_hexdigit()),
+			"Fallback session ID should only contain hex characters"
+		);
+	}
+
+	#[rstest::rstest]
+	#[tokio::test]
+	async fn test_csrf_fallback_secret_is_not_deterministic() {
+		// Arrange - two identical requests with same URI and User-Agent
+		let mut headers = HeaderMap::new();
+		headers.insert("User-Agent", "Mozilla/5.0".parse().unwrap());
+
+		let request1 = Request::builder()
+			.method(Method::GET)
+			.uri("/test")
+			.version(Version::HTTP_11)
+			.headers(headers.clone())
+			.body(Bytes::new())
+			.build()
+			.unwrap();
+
+		let request2 = Request::builder()
+			.method(Method::GET)
+			.uri("/test")
+			.version(Version::HTTP_11)
+			.headers(headers)
+			.body(Bytes::new())
+			.build()
+			.unwrap();
+
+		// Act
+		let session_id1 = CsrfMiddleware::get_session_id(&request1);
+		let session_id2 = CsrfMiddleware::get_session_id(&request2);
+
+		// Assert - two calls should produce different values since they use CSPRNG
+		assert_ne!(
+			session_id1, session_id2,
+			"Fallback session IDs should differ because they use random generation, \
+			not deterministic derivation from request metadata"
+		);
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- CSRF fallback session ID derivation replaced: previously hashed attacker-controlled inputs (request URI, User-Agent header), now uses cryptographically secure random bytes via `rand::thread_rng().fill_bytes()`
- `rand` dependency added to `reinhardt-middleware` for CSPRNG access

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The CSRF middleware fallback secret was derived by hashing the request URI and User-Agent header. Since both are attacker-controlled, an attacker could predict or influence the fallback secret, weakening CSRF protection for sessions without an established session ID.

Fixes #361

## How Was This Tested?

- Fallback secret has 64 hex characters (32 random bytes) — sufficient entropy
- Fallback secret is non-deterministic (two identical requests produce different secrets)
- Existing CSRF middleware behavior unchanged for session-based and cookie-based flows
- All 714 reinhardt-middleware tests pass
- `cargo make fmt-check` clean
- `cargo make clippy-check` clean

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Part of Phase 1 Critical Security Fixes batch

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `http` - HTTP layer, handlers, middleware

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

The fix ensures CSRF protection remains effective even when no session is established, by using cryptographic randomness rather than attacker-influenced inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)