### PR TITLE
security(conf): add redacted Debug for sensitive config types

### DIFF
--- a/crates/reinhardt-conf/src/settings/redact.rs
+++ b/crates/reinhardt-conf/src/settings/redact.rs
@@ -1,0 +1,123 @@
+//! Credential redaction utilities for safe logging and debug output
+
+/// Redacts credentials from a URL string for safe display in logs and debug output.
+///
+/// Handles common database URL formats:
+/// - `postgres://user:password@host:5432/db` -> `postgres://***:***@host:5432/db`
+/// - `mysql://root:secret@localhost/mydb` -> `mysql://***:***@localhost/mydb`
+/// - URLs without credentials are returned unchanged
+///
+/// # Examples
+///
+/// ```
+/// use reinhardt_conf::settings::redact::redact_url_credentials;
+///
+/// assert_eq!(
+///     redact_url_credentials("postgres://user:pass@localhost/db"),
+///     "postgres://***:***@localhost/db"
+/// );
+///
+/// assert_eq!(
+///     redact_url_credentials("postgres://localhost/db"),
+///     "postgres://localhost/db"
+/// );
+///
+/// // Non-URL strings are returned as [REDACTED]
+/// assert_eq!(
+///     redact_url_credentials("not-a-url"),
+///     "[REDACTED]"
+/// );
+/// ```
+pub fn redact_url_credentials(url: &str) -> String {
+	// Try to find the scheme separator
+	let Some(scheme_end) = url.find("://") else {
+		return "[REDACTED]".to_string();
+	};
+
+	let after_scheme = &url[scheme_end + 3..];
+
+	// Find the @ separator (credentials end here)
+	let Some(at_pos) = after_scheme.find('@') else {
+		// No credentials in URL
+		return url.to_string();
+	};
+
+	let scheme_part = &url[..scheme_end + 3];
+	let host_part = &after_scheme[at_pos..]; // includes the @
+
+	format!("{scheme_part}***:***{host_part}")
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	#[case(
+		"postgres://user:password@localhost:5432/mydb",
+		"postgres://***:***@localhost:5432/mydb"
+	)]
+	#[case(
+		"mysql://root:secret@127.0.0.1:3306/app",
+		"mysql://***:***@127.0.0.1:3306/app"
+	)]
+	#[case(
+		"postgresql://admin:p%40ssw0rd@db.example.com/prod",
+		"postgresql://***:***@db.example.com/prod"
+	)]
+	fn redact_url_with_credentials(#[case] input: &str, #[case] expected: &str) {
+		// Arrange
+		// (input provided via rstest parameters)
+
+		// Act
+		let result = redact_url_credentials(input);
+
+		// Assert
+		assert_eq!(result, expected);
+	}
+
+	#[rstest]
+	#[case("postgres://localhost:5432/mydb", "postgres://localhost:5432/mydb")]
+	#[case("sqlite:///path/to/db.sqlite3", "sqlite:///path/to/db.sqlite3")]
+	fn redact_url_without_credentials_returns_unchanged(
+		#[case] input: &str,
+		#[case] expected: &str,
+	) {
+		// Arrange
+		// (input provided via rstest parameters)
+
+		// Act
+		let result = redact_url_credentials(input);
+
+		// Assert
+		assert_eq!(result, expected);
+	}
+
+	#[rstest]
+	#[case("not-a-url", "[REDACTED]")]
+	#[case("plain-string", "[REDACTED]")]
+	#[case("", "[REDACTED]")]
+	fn redact_non_url_returns_redacted(#[case] input: &str, #[case] expected: &str) {
+		// Arrange
+		// (input provided via rstest parameters)
+
+		// Act
+		let result = redact_url_credentials(input);
+
+		// Assert
+		assert_eq!(result, expected);
+	}
+
+	#[rstest]
+	fn redact_url_with_only_user() {
+		// Arrange
+		let url = "postgres://user@localhost/db";
+
+		// Act
+		let result = redact_url_credentials(url);
+
+		// Assert
+		assert_eq!(result, "postgres://***:***@localhost/db");
+	}
+}

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -54,7 +54,6 @@ url = "2.5"
 uuid = { workspace = true }
 tokio = { workspace = true }
 colored = "3.0"
-rand = { workspace = true }
 base64 = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

This PR addresses:

- Replace derived `Debug` on `ApplicationDatabaseConfig` with manual impl that redacts database URL credentials (#487)
- Replace derived `Debug` on `Settings` with manual impl that redacts `secret_key`
- Add `redact_url_credentials()` utility for safe URL logging
- Fix missing `media_root` field in `Settings::new` initializer
- Fix duplicate `rand` key in `reinhardt-middleware` `Cargo.toml`

Follows existing patterns established by `SecretString`, `DatabaseConfig`, and `ConfigEncryptor` custom Debug implementations.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Sensitive configuration data was being exposed in debug logs through derived `Debug` implementations. This created an information leakage vulnerability where database credentials and secret keys could be accidentally logged.

Fixes #487

## How Was This Tested?

- [x] `cargo nextest run -p reinhardt-apps --all-features` passes (92 tests)
- [x] `cargo nextest run -p reinhardt-conf --features settings` passes (107 tests)
- [x] `cargo test --doc -p reinhardt-conf --features settings` passes (91 doc tests)
- [x] `cargo check -p reinhardt-conf --features settings` passes
- [x] `cargo check -p reinhardt-apps --all-features` passes
- [x] `cargo clippy -p reinhardt-conf --features settings -- -D warnings` passes
- [x] `cargo clippy -p reinhardt-apps --all-features -- -D warnings` passes
- [x] Changed files pass `rustfmt --check`
- [x] Debug output of `ApplicationDatabaseConfig` redacts URL credentials
- [x] Debug output of `Settings` redacts `secret_key`

## Performance Impact

N/A - This is not a performance-related change.

## Breaking Changes

None.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Closes #487
- Part of Phase 2 Security Fixes batch

## Labels to Apply

### Type Label (select one)
- [x] `code-quality` - Code quality improvements

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label
- [x] `low` - Minor fix or enhancement

---

**Additional Context:**

This change follows the established pattern used by `SecretString`, `DatabaseConfig`, and `ConfigEncryptor` for redacting sensitive information in debug output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)