### PR TITLE
security(pages-macros): add URL scheme and path validation for forms and head components

### DIFF
--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -258,6 +258,11 @@ impl ServerFnInfo {
 		let nested: Vec<NestedMeta> = args.into_iter().map(NestedMeta::Meta).collect();
 		let options = ServerFnOptions::from_list(&nested)?;
 
+		// Validate endpoint path if explicitly specified
+		if let Some(ref endpoint) = options.endpoint {
+			validate_endpoint_path(endpoint)?;
+		}
+
 		Ok(Self { func, options })
 	}
 
@@ -290,6 +295,46 @@ impl ServerFnInfo {
 	fn use_inject(&self) -> bool {
 		self.options.use_inject
 	}
+}
+
+/// Validate server_fn endpoint path.
+///
+/// The endpoint path must:
+/// - Start with `/`
+/// - Not contain path traversal sequences (`..`)
+/// - Not contain query strings (`?`)
+/// - Not contain fragment identifiers (`#`)
+/// - Not be a full URL (e.g. `http://` or `https://`)
+fn validate_endpoint_path(path: &str) -> Result<(), darling::Error> {
+	if path.starts_with("http://") || path.starts_with("https://") {
+		return Err(darling::Error::custom(
+			"endpoint must be a relative path starting with '/', not a full URL",
+		));
+	}
+
+	if !path.starts_with('/') {
+		return Err(darling::Error::custom("endpoint path must start with '/'"));
+	}
+
+	if path.contains("..") {
+		return Err(darling::Error::custom(
+			"endpoint path must not contain path traversal sequences ('..')",
+		));
+	}
+
+	if path.contains('?') {
+		return Err(darling::Error::custom(
+			"endpoint path must not contain query strings ('?')",
+		));
+	}
+
+	if path.contains('#') {
+		return Err(darling::Error::custom(
+			"endpoint path must not contain fragment identifiers ('#')",
+		));
+	}
+
+	Ok(())
 }
 
 /// Main entry point for `#[server_fn]` macro
@@ -945,5 +990,55 @@ mod tests {
 		assert_eq!(options.use_inject, true);
 		assert_eq!(options.endpoint, Some("/custom".to_string()));
 		assert_eq!(options.codec, "json");
+	}
+
+	#[test]
+	fn test_validate_endpoint_valid_path() {
+		assert!(validate_endpoint_path("/api/users").is_ok());
+		assert!(validate_endpoint_path("/api/server_fn/create_user").is_ok());
+		assert!(validate_endpoint_path("/").is_ok());
+	}
+
+	#[test]
+	fn test_validate_endpoint_rejects_no_leading_slash() {
+		let result = validate_endpoint_path("api/users");
+		assert!(result.is_err());
+		let err = result.unwrap_err().to_string();
+		assert!(err.contains("must start with '/'"));
+	}
+
+	#[test]
+	fn test_validate_endpoint_rejects_full_url() {
+		let result = validate_endpoint_path("http://example.com/api");
+		assert!(result.is_err());
+		let err = result.unwrap_err().to_string();
+		assert!(err.contains("not a full URL"));
+
+		let result = validate_endpoint_path("https://example.com/api");
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_validate_endpoint_rejects_traversal() {
+		let result = validate_endpoint_path("/api/../secret");
+		assert!(result.is_err());
+		let err = result.unwrap_err().to_string();
+		assert!(err.contains("path traversal"));
+	}
+
+	#[test]
+	fn test_validate_endpoint_rejects_query_string() {
+		let result = validate_endpoint_path("/api/users?admin=true");
+		assert!(result.is_err());
+		let err = result.unwrap_err().to_string();
+		assert!(err.contains("query strings"));
+	}
+
+	#[test]
+	fn test_validate_endpoint_rejects_fragment() {
+		let result = validate_endpoint_path("/api/users#section");
+		assert!(result.is_err());
+		let err = result.unwrap_err().to_string();
+		assert!(err.contains("fragment identifiers"));
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses:
- Reject insecure HTTP redirect URLs in `redirect_on_success` attribute to prevent credential leakage
- Validate `server_fn` endpoint paths: reject path traversal sequences (`..`), query strings, fragment identifiers, and full URLs
- Reject dangerous URL schemes (`javascript:`, `data:`, `vbscript:`) in head link/script components at compile time

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

This change is necessary to prevent multiple security vulnerabilities in the Pages macro system:
1. HTTP redirect URLs can leak credentials through Referer headers
2. Malformed `server_fn` paths could enable path traversal or bypass routing controls
3. Dangerous URL schemes in head components can lead to XSS attacks

Fixes #858
Fixes #847
Fixes #846

Related to: #

## How Was This Tested?

- `cargo nextest run -p reinhardt-pages-macros --all-features` passes (257 tests)
- `cargo clippy -p reinhardt-pages-macros --all-features -- -D warnings` passes
- `rustfmt` check passes for modified files
- HTTP redirect URLs produce compile error
- Malformed server_fn endpoints produce compile error
- Dangerous URL schemes in head produce compile error
- Case-insensitive scheme detection works

## Performance Impact

N/A - This is a security fix with minimal performance overhead (string validation at compile time).

## Breaking Changes

None - This is a conservative security fix that only rejects previously-unsafe inputs.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

Closes #858
Closes #847
Closes #846

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [x] `low` - Minor fix or enhancement

### Additional Labels
- `security` - Security vulnerabilities or concerns

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)