### PR TITLE
security(dentdelion): validate plugin names to prevent path traversal and log injection

### DIFF
--- a/crates/reinhardt-dentdelion/src/metadata.rs
+++ b/crates/reinhardt-dentdelion/src/metadata.rs
@@ -88,14 +88,12 @@ impl PluginMetadata {
 		PluginMetadataBuilder::new(name, version)
 	}
 
+	/// Maximum allowed length for plugin names.
+	const MAX_NAME_LENGTH: usize = 128;
+
 	/// Validates the metadata.
 	pub fn validate(&self) -> PluginResult<()> {
-		// Validate name format (recommended: xxx-delion)
-		if self.name.is_empty() {
-			return Err(PluginError::InvalidManifest(
-				"plugin name cannot be empty".to_string(),
-			));
-		}
+		Self::validate_plugin_name(&self.name)?;
 
 		// Warn if not following naming convention (but don't error)
 		if !self.name.ends_with("-delion") {
@@ -103,6 +101,60 @@ impl PluginMetadata {
 				"plugin '{}' does not follow the recommended naming convention (xxx-delion)",
 				self.name
 			);
+		}
+
+		Ok(())
+	}
+
+	/// Validates a plugin name to prevent path traversal and log injection.
+	///
+	/// Valid plugin names contain only ASCII alphanumeric characters, hyphens,
+	/// and underscores. They must not be empty, must not exceed
+	/// [`Self::MAX_NAME_LENGTH`] characters, and must not contain path
+	/// separators or control characters.
+	pub(crate) fn validate_plugin_name(name: &str) -> PluginResult<()> {
+		if name.is_empty() {
+			return Err(PluginError::InvalidManifest(
+				"plugin name cannot be empty".to_string(),
+			));
+		}
+
+		if name.len() > Self::MAX_NAME_LENGTH {
+			return Err(PluginError::InvalidManifest(format!(
+				"plugin name exceeds maximum length of {} characters",
+				Self::MAX_NAME_LENGTH,
+			)));
+		}
+
+		// Reject names containing path separators to prevent path traversal
+		if name.contains('/') || name.contains('\\') || name.contains("..") {
+			return Err(PluginError::InvalidManifest(
+				"plugin name must not contain path separators or traversal sequences".to_string(),
+			));
+		}
+
+		// Reject names containing null bytes
+		if name.contains('\0') {
+			return Err(PluginError::InvalidManifest(
+				"plugin name must not contain null bytes".to_string(),
+			));
+		}
+
+		// Reject control characters (prevents log injection via newlines, tabs, etc.)
+		if name.chars().any(|c| c.is_control()) {
+			return Err(PluginError::InvalidManifest(
+				"plugin name must not contain control characters".to_string(),
+			));
+		}
+
+		// Only allow ASCII alphanumeric, hyphens, and underscores
+		if !name
+			.chars()
+			.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+		{
+			return Err(PluginError::InvalidManifest(
+				"plugin name must contain only ASCII alphanumeric characters, hyphens, and underscores".to_string(),
+			));
 		}
 
 		Ok(())
@@ -136,8 +188,10 @@ pub struct PluginDependency {
 impl PluginDependency {
 	/// Creates a new required dependency.
 	pub fn new(name: impl Into<String>, version_req: impl AsRef<str>) -> PluginResult<Self> {
+		let name = name.into();
+		PluginMetadata::validate_plugin_name(&name)?;
 		Ok(Self {
-			name: name.into(),
+			name,
 			version_req: VersionReq::parse(version_req.as_ref())
 				.map_err(|e| PluginError::InvalidVersionReq(e.to_string()))?,
 			optional: false,
@@ -350,10 +404,16 @@ mod version_req_serde {
 mod tests {
 	use super::*;
 	use crate::capability::PluginCapability;
+	use rstest::rstest;
 
-	#[test]
+	#[rstest]
 	fn test_metadata_builder() {
-		let metadata = PluginMetadata::builder("auth-delion", "1.0.0")
+		// Arrange
+		let name = "auth-delion";
+		let version = "1.0.0";
+
+		// Act
+		let metadata = PluginMetadata::builder(name, version)
 			.description("JWT authentication plugin")
 			.author("Test Author")
 			.license("MIT")
@@ -363,6 +423,7 @@ mod tests {
 			.build()
 			.unwrap();
 
+		// Assert
 		assert_eq!(metadata.name, "auth-delion");
 		assert_eq!(metadata.version.to_string(), "1.0.0");
 		assert_eq!(metadata.description, "JWT authentication plugin");
@@ -372,21 +433,156 @@ mod tests {
 		assert_eq!(metadata.dependencies.len(), 1);
 	}
 
-	#[test]
+	#[rstest]
 	fn test_dependency_matches() {
+		// Arrange
 		let dep = PluginDependency::new("test-delion", "^1.0.0").unwrap();
 
+		// Act & Assert
 		assert!(dep.matches(&Version::parse("1.0.0").unwrap()));
 		assert!(dep.matches(&Version::parse("1.5.0").unwrap()));
 		assert!(!dep.matches(&Version::parse("2.0.0").unwrap()));
 		assert!(!dep.matches(&Version::parse("0.9.0").unwrap()));
 	}
 
-	#[test]
+	#[rstest]
 	fn test_qualified_name() {
+		// Arrange
 		let metadata = PluginMetadata::builder("test-delion", "2.1.0")
 			.build()
 			.unwrap();
-		assert_eq!(metadata.qualified_name(), "test-delion@2.1.0");
+
+		// Act
+		let qualified = metadata.qualified_name();
+
+		// Assert
+		assert_eq!(qualified, "test-delion@2.1.0");
+	}
+
+	// ==========================================================================
+	// Plugin Name Validation Tests
+	// ==========================================================================
+
+	#[rstest]
+	#[case("auth-delion")]
+	#[case("my_plugin")]
+	#[case("plugin123")]
+	#[case("a")]
+	#[case("A-B_c-123")]
+	fn test_validate_plugin_name_accepts_valid_names(#[case] name: &str) {
+		// Act
+		let result = PluginMetadata::validate_plugin_name(name);
+
+		// Assert
+		assert!(result.is_ok(), "expected valid name: {name}");
+	}
+
+	#[rstest]
+	fn test_validate_plugin_name_rejects_empty() {
+		// Act
+		let result = PluginMetadata::validate_plugin_name("");
+
+		// Assert
+		let err = result.unwrap_err();
+		assert_eq!(
+			err.to_string(),
+			"invalid manifest format: plugin name cannot be empty"
+		);
+	}
+
+	#[rstest]
+	fn test_validate_plugin_name_rejects_exceeding_max_length() {
+		// Arrange
+		let long_name = "a".repeat(PluginMetadata::MAX_NAME_LENGTH + 1);
+
+		// Act
+		let result = PluginMetadata::validate_plugin_name(&long_name);
+
+		// Assert
+		let err = result.unwrap_err();
+		assert!(err.to_string().contains("exceeds maximum length"));
+	}
+
+	#[rstest]
+	fn test_validate_plugin_name_accepts_max_length() {
+		// Arrange
+		let name = "a".repeat(PluginMetadata::MAX_NAME_LENGTH);
+
+		// Act
+		let result = PluginMetadata::validate_plugin_name(&name);
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	#[case("../etc/passwd", "path separators")]
+	#[case("plugin/evil", "path separators")]
+	#[case("plugin\\evil", "path separators")]
+	#[case("..%2f..%2fetc", "path separators")]
+	fn test_validate_plugin_name_rejects_path_traversal(
+		#[case] name: &str,
+		#[case] expected_msg: &str,
+	) {
+		// Act
+		let result = PluginMetadata::validate_plugin_name(name);
+
+		// Assert
+		let err = result.unwrap_err();
+		assert!(
+			err.to_string().contains(expected_msg),
+			"expected error containing '{expected_msg}', got: {err}"
+		);
+	}
+
+	#[rstest]
+	#[case("plugin\nnewline", "control characters")]
+	#[case("plugin\rcarriage", "control characters")]
+	#[case("plugin\ttab", "control characters")]
+	#[case("plugin\0null", "null bytes")]
+	fn test_validate_plugin_name_rejects_control_chars(
+		#[case] name: &str,
+		#[case] expected_msg: &str,
+	) {
+		// Act
+		let result = PluginMetadata::validate_plugin_name(name);
+
+		// Assert
+		let err = result.unwrap_err();
+		assert!(
+			err.to_string().contains(expected_msg),
+			"expected error containing '{expected_msg}', got: {err}"
+		);
+	}
+
+	#[rstest]
+	#[case("plugin name")]
+	#[case("plugin@1.0")]
+	#[case("plugin.exe")]
+	#[case("プラグイン")]
+	fn test_validate_plugin_name_rejects_invalid_chars(#[case] name: &str) {
+		// Act
+		let result = PluginMetadata::validate_plugin_name(name);
+
+		// Assert
+		assert!(result.is_err(), "expected invalid name: {name}");
+	}
+
+	#[rstest]
+	fn test_builder_rejects_invalid_plugin_name() {
+		// Act
+		let result = PluginMetadata::builder("../evil", "1.0.0").build();
+
+		// Assert
+		assert!(result.is_err());
+	}
+
+	#[rstest]
+	fn test_dependency_rejects_invalid_plugin_name() {
+		// Act
+		let result = PluginDependency::new("../evil\ninjection", "^1.0.0");
+
+		// Assert
+		assert!(result.is_err());
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses:
- Add plugin name validation to prevent path traversal attacks
- Reject path separators and control characters in plugin names
- Enforce alphanumeric, hyphen, and underscore characters only

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

This change is necessary to prevent security vulnerabilities in the Dentdelion plugin system:
1. Path traversal sequences in plugin names could allow unauthorized file access
2. Control characters could cause log injection or parsing issues
3. Restricting to safe characters prevents these attack vectors

Fixes #692

Related to: #

## How Was This Tested?

- `cargo nextest run -p reinhardt-dentdelion --all-features` passes
- `cargo make fmt-check` passes

## Performance Impact

N/A - This is a security fix with minimal performance overhead (string validation).

## Breaking Changes

None - This is a conservative security fix that only rejects previously-unsafe inputs.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

## Related Issues

Closes #692

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [x] `low` - Minor fix or enhancement

### Additional Labels
- `security` - Security vulnerabilities or concerns

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)