### PR TITLE
security(http): add safe error response builder to prevent info leakage

### DIFF
--- a/crates/reinhardt-http/Cargo.toml
+++ b/crates/reinhardt-http/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = "0.1"
 tokio = { version = "1.0", features = ["sync"] }
 percent-encoding = "2.3"
 reinhardt-core = {workspace = true, features = ["exception"]}
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/reinhardt-http/src/lib.rs
+++ b/crates/reinhardt-http/src/lib.rs
@@ -56,7 +56,7 @@ pub use extensions::Extensions;
 pub use messages_middleware::MessagesMiddleware;
 pub use middleware::{Handler, Middleware, MiddlewareChain};
 pub use request::{Request, RequestBuilder, TrustedProxies};
-pub use response::{Response, StreamBody, StreamingResponse};
+pub use response::{Response, SafeErrorResponse, StreamBody, StreamingResponse};
 pub use upload::{FileUploadError, FileUploadHandler, MemoryFileUpload, TemporaryFileUpload};
 
 // Re-export error types from reinhardt-exception for consistency across the framework

--- a/crates/reinhardt-http/src/response.rs
+++ b/crates/reinhardt-http/src/response.rs
@@ -4,6 +4,186 @@ use hyper::{HeaderMap, StatusCode};
 use serde::Serialize;
 use std::pin::Pin;
 
+/// Returns a safe, client-facing error message based on the HTTP status code.
+///
+/// For 5xx errors, always returns a generic message to prevent information leakage.
+/// For 4xx errors, returns a descriptive but safe category message.
+/// Internal details are never exposed to clients.
+fn safe_error_message(status: StatusCode) -> &'static str {
+	match status.as_u16() {
+		400 => "Bad Request",
+		401 => "Unauthorized",
+		403 => "Forbidden",
+		404 => "Not Found",
+		405 => "Method Not Allowed",
+		406 => "Not Acceptable",
+		408 => "Request Timeout",
+		409 => "Conflict",
+		410 => "Gone",
+		413 => "Payload Too Large",
+		415 => "Unsupported Media Type",
+		422 => "Unprocessable Entity",
+		429 => "Too Many Requests",
+		// All 5xx errors get generic messages
+		500 => "Internal Server Error",
+		502 => "Bad Gateway",
+		503 => "Service Unavailable",
+		504 => "Gateway Timeout",
+		_ if status.is_client_error() => "Client Error",
+		_ if status.is_server_error() => "Server Error",
+		_ => "Error",
+	}
+}
+
+/// Extract a safe, client-facing detail message from an error.
+///
+/// Returns `None` if no safe detail can be extracted.
+/// Only extracts details from error variants where the message is
+/// controlled by application code and safe for client exposure.
+fn safe_client_error_detail(error: &crate::Error) -> Option<String> {
+	use crate::Error;
+	match error {
+		Error::Validation(msg) => Some(msg.clone()),
+		Error::ParseError(_) => Some("Invalid request format".to_string()),
+		Error::BodyAlreadyConsumed => Some("Request body has already been consumed".to_string()),
+		Error::MissingContentType => Some("Missing Content-Type header".to_string()),
+		Error::InvalidPage(msg) => Some(format!("Invalid page: {}", msg)),
+		Error::InvalidCursor(_) => Some("Invalid cursor value".to_string()),
+		Error::InvalidLimit(msg) => Some(format!("Invalid limit: {}", msg)),
+		Error::MissingParameter(name) => Some(format!("Missing parameter: {}", name)),
+		Error::ParamValidation(ctx) => {
+			Some(format!("{} parameter extraction failed", ctx.param_type))
+		}
+		// For other client errors, return generic message
+		_ => None,
+	}
+}
+
+/// Builder for creating error responses that prevent information leakage.
+///
+/// In production mode (default), error responses contain only safe,
+/// generic messages. In debug mode, full error details are included.
+///
+/// # Examples
+///
+/// ```
+/// use reinhardt_http::response::SafeErrorResponse;
+/// use hyper::StatusCode;
+///
+/// // Production-safe response
+/// let response = SafeErrorResponse::new(StatusCode::INTERNAL_SERVER_ERROR)
+///     .build();
+///
+/// // Debug response with details
+/// let response = SafeErrorResponse::new(StatusCode::BAD_REQUEST)
+///     .with_detail("Missing required field: name")
+///     .build();
+/// ```
+pub struct SafeErrorResponse {
+	status: StatusCode,
+	detail: Option<String>,
+	debug_info: Option<String>,
+	debug_mode: bool,
+}
+
+impl SafeErrorResponse {
+	/// Create a new `SafeErrorResponse` with the given HTTP status code.
+	pub fn new(status: StatusCode) -> Self {
+		Self {
+			status,
+			detail: None,
+			debug_info: None,
+			debug_mode: false,
+		}
+	}
+
+	/// Add a safe, client-facing detail message.
+	///
+	/// Only included for 4xx errors. Ignored for 5xx errors to prevent
+	/// accidental information leakage.
+	pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+		self.detail = Some(detail.into());
+		self
+	}
+
+	/// Add debug information (only included when debug_mode is true).
+	///
+	/// WARNING: Only use in development environments.
+	pub fn with_debug_info(mut self, info: impl Into<String>) -> Self {
+		self.debug_info = Some(info.into());
+		self
+	}
+
+	/// Enable debug mode to include full error details in responses.
+	///
+	/// WARNING: Only use in development environments. Debug mode exposes
+	/// internal error details that may leak sensitive information.
+	pub fn with_debug_mode(mut self, debug: bool) -> Self {
+		self.debug_mode = debug;
+		self
+	}
+
+	/// Build the `Response` with safe error content.
+	pub fn build(self) -> Response {
+		let message = safe_error_message(self.status);
+		let mut body = serde_json::json!({
+			"error": message,
+		});
+
+		// Only include detail for 4xx errors to prevent info leakage on 5xx
+		if self.status.is_client_error()
+			&& let Some(detail) = &self.detail
+		{
+			body["detail"] = serde_json::Value::String(detail.clone());
+		}
+
+		// Include debug info only when explicitly enabled
+		if self.debug_mode {
+			if let Some(debug_info) = &self.debug_info {
+				body["debug"] = serde_json::Value::String(debug_info.clone());
+			}
+			// In debug mode, include detail even for 5xx
+			if self.status.is_server_error()
+				&& let Some(detail) = &self.detail
+			{
+				body["detail"] = serde_json::Value::String(detail.clone());
+			}
+		}
+
+		Response::new(self.status)
+			.with_json(&body)
+			.unwrap_or_else(|_| Response::internal_server_error())
+	}
+}
+
+/// Truncate a string for safe inclusion in log messages.
+///
+/// Prevents oversized values from consuming log storage and
+/// limits exposure of sensitive data in error contexts.
+///
+/// # Examples
+///
+/// ```
+/// use reinhardt_http::response::truncate_for_log;
+///
+/// let short = truncate_for_log("hello", 10);
+/// assert_eq!(short, "hello");
+///
+/// let long = truncate_for_log("a]".repeat(100).as_str(), 10);
+/// assert!(long.contains("...[truncated"));
+/// ```
+pub fn truncate_for_log(input: &str, max_length: usize) -> String {
+	if input.len() <= max_length {
+		input.to_string()
+	} else {
+		format!(
+			"{}...[truncated, {} total bytes]",
+			&input[..max_length],
+			input.len()
+		)
+	}
+}
+
 /// HTTP Response representation
 #[derive(Debug)]
 pub struct Response {
@@ -409,13 +589,25 @@ impl From<crate::Error> for Response {
 	fn from(error: crate::Error) -> Self {
 		let status =
 			StatusCode::from_u16(error.status_code()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-		let body = serde_json::json!({
-			"error": error.to_string(),
-		});
 
-		Response::new(status)
-			.with_json(&body)
-			.unwrap_or_else(|_| Response::internal_server_error())
+		// Log the full error for server-side debugging
+		tracing::error!(
+			status = status.as_u16(),
+			error = %error,
+			"Request error"
+		);
+
+		let mut response = SafeErrorResponse::new(status);
+
+		// For 4xx client errors, include a safe detail message
+		// that doesn't expose internal implementation details
+		if status.is_client_error()
+			&& let Some(detail) = safe_client_error_detail(&error)
+		{
+			response = response.with_detail(detail);
+		}
+
+		response.build()
 	}
 }
 
@@ -568,5 +760,300 @@ impl<S> StreamingResponse<S> {
 	/// ```
 	pub fn into_stream(self) -> S {
 		self.stream
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	#[case(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error")]
+	#[case(StatusCode::BAD_GATEWAY, "Bad Gateway")]
+	#[case(StatusCode::SERVICE_UNAVAILABLE, "Service Unavailable")]
+	#[case(StatusCode::GATEWAY_TIMEOUT, "Gateway Timeout")]
+	fn test_5xx_errors_never_include_internal_details(
+		#[case] status: StatusCode,
+		#[case] expected_message: &str,
+	) {
+		// Arrange
+		let sensitive_detail = "Internal path /src/db/connection.rs:42 failed";
+
+		// Act
+		let response = SafeErrorResponse::new(status)
+			.with_detail(sensitive_detail)
+			.build();
+
+		// Assert
+		let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+		assert_eq!(body["error"], expected_message);
+		// Detail must NOT be included for 5xx errors
+		assert!(body.get("detail").is_none());
+		assert_eq!(response.status, status);
+	}
+
+	#[rstest]
+	#[case(StatusCode::BAD_REQUEST, "Bad Request")]
+	#[case(StatusCode::UNAUTHORIZED, "Unauthorized")]
+	#[case(StatusCode::FORBIDDEN, "Forbidden")]
+	#[case(StatusCode::NOT_FOUND, "Not Found")]
+	#[case(StatusCode::METHOD_NOT_ALLOWED, "Method Not Allowed")]
+	#[case(StatusCode::CONFLICT, "Conflict")]
+	fn test_4xx_errors_include_safe_detail(
+		#[case] status: StatusCode,
+		#[case] expected_message: &str,
+	) {
+		// Arrange
+		let detail = "Missing required field: name";
+
+		// Act
+		let response = SafeErrorResponse::new(status).with_detail(detail).build();
+
+		// Assert
+		let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+		assert_eq!(body["error"], expected_message);
+		assert_eq!(body["detail"], detail);
+		assert_eq!(response.status, status);
+	}
+
+	#[rstest]
+	fn test_debug_mode_includes_full_error_info() {
+		// Arrange
+		let debug_info = "Error at src/handlers/user.rs:42: column 'email' not found";
+
+		// Act
+		let response = SafeErrorResponse::new(StatusCode::INTERNAL_SERVER_ERROR)
+			.with_detail("Database query failed")
+			.with_debug_info(debug_info)
+			.with_debug_mode(true)
+			.build();
+
+		// Assert
+		let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+		assert_eq!(body["error"], "Internal Server Error");
+		// In debug mode, detail is included even for 5xx
+		assert_eq!(body["detail"], "Database query failed");
+		assert_eq!(body["debug"], debug_info);
+	}
+
+	#[rstest]
+	fn test_debug_mode_disabled_excludes_debug_info() {
+		// Arrange
+		let debug_info = "Sensitive internal detail";
+
+		// Act
+		let response = SafeErrorResponse::new(StatusCode::INTERNAL_SERVER_ERROR)
+			.with_debug_info(debug_info)
+			.with_debug_mode(false)
+			.build();
+
+		// Assert
+		let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+		assert!(body.get("debug").is_none());
+	}
+
+	#[rstest]
+	#[case(StatusCode::BAD_REQUEST, "Bad Request")]
+	#[case(StatusCode::UNAUTHORIZED, "Unauthorized")]
+	#[case(StatusCode::FORBIDDEN, "Forbidden")]
+	#[case(StatusCode::NOT_FOUND, "Not Found")]
+	#[case(StatusCode::METHOD_NOT_ALLOWED, "Method Not Allowed")]
+	#[case(StatusCode::NOT_ACCEPTABLE, "Not Acceptable")]
+	#[case(StatusCode::REQUEST_TIMEOUT, "Request Timeout")]
+	#[case(StatusCode::CONFLICT, "Conflict")]
+	#[case(StatusCode::GONE, "Gone")]
+	#[case(StatusCode::PAYLOAD_TOO_LARGE, "Payload Too Large")]
+	#[case(StatusCode::UNSUPPORTED_MEDIA_TYPE, "Unsupported Media Type")]
+	#[case(StatusCode::UNPROCESSABLE_ENTITY, "Unprocessable Entity")]
+	#[case(StatusCode::TOO_MANY_REQUESTS, "Too Many Requests")]
+	#[case(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error")]
+	#[case(StatusCode::BAD_GATEWAY, "Bad Gateway")]
+	#[case(StatusCode::SERVICE_UNAVAILABLE, "Service Unavailable")]
+	#[case(StatusCode::GATEWAY_TIMEOUT, "Gateway Timeout")]
+	fn test_safe_error_message_returns_correct_messages(
+		#[case] status: StatusCode,
+		#[case] expected: &str,
+	) {
+		// Arrange / Act
+		let message = safe_error_message(status);
+
+		// Assert
+		assert_eq!(message, expected);
+	}
+
+	#[rstest]
+	fn test_safe_error_message_fallback_client_error() {
+		// Arrange
+		// 418 I'm a Teapot (not explicitly mapped)
+		let status = StatusCode::IM_A_TEAPOT;
+
+		// Act
+		let message = safe_error_message(status);
+
+		// Assert
+		assert_eq!(message, "Client Error");
+	}
+
+	#[rstest]
+	fn test_safe_error_message_fallback_server_error() {
+		// Arrange
+		// 505 HTTP Version Not Supported (not explicitly mapped)
+		let status = StatusCode::HTTP_VERSION_NOT_SUPPORTED;
+
+		// Act
+		let message = safe_error_message(status);
+
+		// Assert
+		assert_eq!(message, "Server Error");
+	}
+
+	#[rstest]
+	fn test_truncate_for_log_short_string() {
+		// Arrange
+		let input = "hello";
+
+		// Act
+		let result = truncate_for_log(input, 10);
+
+		// Assert
+		assert_eq!(result, "hello");
+	}
+
+	#[rstest]
+	fn test_truncate_for_log_long_string() {
+		// Arrange
+		let input = "a".repeat(100);
+
+		// Act
+		let result = truncate_for_log(&input, 10);
+
+		// Assert
+		assert!(result.starts_with("aaaaaaaaaa"));
+		assert!(result.contains("...[truncated, 100 total bytes]"));
+	}
+
+	#[rstest]
+	fn test_truncate_for_log_exact_length() {
+		// Arrange
+		let input = "abcde";
+
+		// Act
+		let result = truncate_for_log(input, 5);
+
+		// Assert
+		assert_eq!(result, "abcde");
+	}
+
+	#[rstest]
+	fn test_from_error_produces_safe_output_for_5xx() {
+		// Arrange
+		let error = crate::Error::Database(
+			"Connection to postgres://user:pass@db:5432/mydb failed".to_string(),
+		);
+
+		// Act
+		let response: Response = error.into();
+
+		// Assert
+		assert_eq!(response.status, StatusCode::INTERNAL_SERVER_ERROR);
+		let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+		assert_eq!(body["error"], "Internal Server Error");
+		// Must NOT contain internal connection details
+		let body_str = String::from_utf8_lossy(&response.body);
+		assert!(!body_str.contains("postgres://"));
+		assert!(!body_str.contains("user:pass"));
+		assert!(body.get("detail").is_none());
+	}
+
+	#[rstest]
+	fn test_from_error_produces_safe_output_for_4xx_validation() {
+		// Arrange
+		let error = crate::Error::Validation("Email format is invalid".to_string());
+
+		// Act
+		let response: Response = error.into();
+
+		// Assert
+		assert_eq!(response.status, StatusCode::BAD_REQUEST);
+		let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+		assert_eq!(body["error"], "Bad Request");
+		assert_eq!(body["detail"], "Email format is invalid");
+	}
+
+	#[rstest]
+	fn test_from_error_produces_safe_output_for_4xx_parse() {
+		// Arrange
+		let error = crate::Error::ParseError(
+			"invalid digit found in string at src/parser.rs:42".to_string(),
+		);
+
+		// Act
+		let response: Response = error.into();
+
+		// Assert
+		assert_eq!(response.status, StatusCode::BAD_REQUEST);
+		let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+		assert_eq!(body["error"], "Bad Request");
+		// Must NOT expose the internal path from the original error
+		assert_eq!(body["detail"], "Invalid request format");
+		let body_str = String::from_utf8_lossy(&response.body);
+		assert!(!body_str.contains("src/parser.rs"));
+	}
+
+	#[rstest]
+	fn test_from_error_body_already_consumed() {
+		// Arrange
+		let error = crate::Error::BodyAlreadyConsumed;
+
+		// Act
+		let response: Response = error.into();
+
+		// Assert
+		assert_eq!(response.status, StatusCode::BAD_REQUEST);
+		let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+		assert_eq!(body["detail"], "Request body has already been consumed");
+	}
+
+	#[rstest]
+	fn test_from_error_internal_error_hides_details() {
+		// Arrange
+		let error =
+			crate::Error::Internal("panic at /Users/dev/projects/app/src/main.rs:10".to_string());
+
+		// Act
+		let response: Response = error.into();
+
+		// Assert
+		assert_eq!(response.status, StatusCode::INTERNAL_SERVER_ERROR);
+		let body_str = String::from_utf8_lossy(&response.body);
+		assert!(!body_str.contains("/Users/dev"));
+		assert!(!body_str.contains("main.rs"));
+	}
+
+	#[rstest]
+	fn test_safe_error_response_no_detail_set() {
+		// Arrange / Act
+		let response = SafeErrorResponse::new(StatusCode::BAD_REQUEST).build();
+
+		// Assert
+		let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+		assert_eq!(body["error"], "Bad Request");
+		assert!(body.get("detail").is_none());
+	}
+
+	#[rstest]
+	fn test_safe_error_response_content_type_is_json() {
+		// Arrange / Act
+		let response = SafeErrorResponse::new(StatusCode::NOT_FOUND).build();
+
+		// Assert
+		let content_type = response
+			.headers
+			.get("content-type")
+			.unwrap()
+			.to_str()
+			.unwrap();
+		assert_eq!(content_type, "application/json");
 	}
 }


### PR DESCRIPTION
## Summary
- Add `SafeErrorResponse` builder that prevents information disclosure in error responses
- Complements #1120 (dispatch info disclosure prevention)
- Rebased from #1090 to resolve merge conflicts

## Test plan
- [x] Unit tests for safe error response builder
- [x] Rebased cleanly on latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)