### PR TITLE
security(throttling): fix overflow, division-by-zero, and missing input validation

### DIFF
--- a/crates/reinhardt-throttling/src/anon.rs
+++ b/crates/reinhardt-throttling/src/anon.rs
@@ -1,6 +1,6 @@
 use super::backend::{MemoryBackend, ThrottleBackend};
 use super::key_validation::validate_key_component;
-use super::{Throttle, ThrottleResult};
+use super::{Throttle, ThrottleError, ThrottleResult};
 use async_trait::async_trait;
 
 pub struct AnonRateThrottle<B: ThrottleBackend = MemoryBackend> {
@@ -14,25 +14,39 @@ impl AnonRateThrottle<MemoryBackend> {
 	///
 	/// # Arguments
 	///
-	/// * `rate` - Maximum number of requests allowed
-	/// * `window_secs` - Time window in seconds
+	/// * `rate` - Maximum number of requests allowed (must be non-zero)
+	/// * `window_secs` - Time window in seconds (must be non-zero)
+	///
+	/// # Errors
+	///
+	/// Returns [`ThrottleError::InvalidConfig`] if `rate` or `window_secs` is zero.
 	///
 	/// # Examples
 	///
 	/// ```
 	/// use reinhardt_throttling::AnonRateThrottle;
 	///
-	// Allow 60 requests per hour for anonymous users
-	/// let throttle = AnonRateThrottle::new(60, 3600);
+	/// // Allow 60 requests per hour for anonymous users
+	/// let throttle = AnonRateThrottle::new(60, 3600).unwrap();
 	/// assert_eq!(throttle.rate, 60);
 	/// assert_eq!(throttle.window_secs, 3600);
 	/// ```
-	pub fn new(rate: usize, window_secs: u64) -> Self {
-		Self {
+	pub fn new(rate: usize, window_secs: u64) -> ThrottleResult<Self> {
+		if rate == 0 {
+			return Err(ThrottleError::InvalidConfig(
+				"rate must be non-zero".to_string(),
+			));
+		}
+		if window_secs == 0 {
+			return Err(ThrottleError::InvalidConfig(
+				"window_secs must be non-zero".to_string(),
+			));
+		}
+		Ok(Self {
 			rate,
 			window_secs,
 			backend: MemoryBackend::new(),
-		}
+		})
 	}
 }
 
@@ -41,9 +55,13 @@ impl<B: ThrottleBackend> AnonRateThrottle<B> {
 	///
 	/// # Arguments
 	///
-	/// * `rate` - Maximum number of requests allowed
-	/// * `window_secs` - Time window in seconds
+	/// * `rate` - Maximum number of requests allowed (must be non-zero)
+	/// * `window_secs` - Time window in seconds (must be non-zero)
 	/// * `backend` - Custom throttle backend
+	///
+	/// # Errors
+	///
+	/// Returns [`ThrottleError::InvalidConfig`] if `rate` or `window_secs` is zero.
 	///
 	/// # Examples
 	///
@@ -51,16 +69,26 @@ impl<B: ThrottleBackend> AnonRateThrottle<B> {
 	/// use reinhardt_throttling::{AnonRateThrottle, MemoryBackend};
 	///
 	/// let backend = MemoryBackend::new();
-	/// let throttle = AnonRateThrottle::with_backend(60, 3600, backend);
+	/// let throttle = AnonRateThrottle::with_backend(60, 3600, backend).unwrap();
 	/// assert_eq!(throttle.rate, 60);
 	/// assert_eq!(throttle.window_secs, 3600);
 	/// ```
-	pub fn with_backend(rate: usize, window_secs: u64, backend: B) -> Self {
-		Self {
+	pub fn with_backend(rate: usize, window_secs: u64, backend: B) -> ThrottleResult<Self> {
+		if rate == 0 {
+			return Err(ThrottleError::InvalidConfig(
+				"rate must be non-zero".to_string(),
+			));
+		}
+		if window_secs == 0 {
+			return Err(ThrottleError::InvalidConfig(
+				"window_secs must be non-zero".to_string(),
+			));
+		}
+		Ok(Self {
 			rate,
 			window_secs,
 			backend,
-		}
+		})
 	}
 }
 
@@ -98,59 +126,125 @@ impl<B: ThrottleBackend> Throttle for AnonRateThrottle<B> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::rstest;
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_anon_throttle() {
-		let throttle = AnonRateThrottle::new(5, 60);
+		// Arrange
+		let throttle = AnonRateThrottle::new(5, 60).unwrap();
+
+		// Act & Assert
 		for _ in 0..5 {
 			assert!(throttle.allow_request("192.168.1.1").await.unwrap());
 		}
 		assert!(!throttle.allow_request("192.168.1.1").await.unwrap());
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_authenticated_user_not_affected() {
-		// In the context of anon throttle, we test that different IPs are tracked separately
-		let throttle = AnonRateThrottle::new(3, 60);
+		// Arrange
+		let throttle = AnonRateThrottle::new(3, 60).unwrap();
 
-		// Fill up the limit for one IP
+		// Act - fill up the limit for one IP
 		for _ in 0..3 {
 			assert!(throttle.allow_request("192.168.1.1").await.unwrap());
 		}
 		assert!(!throttle.allow_request("192.168.1.1").await.unwrap());
 
-		// Different IP should not be affected
+		// Assert - different IP should not be affected
 		assert!(throttle.allow_request("192.168.1.2").await.unwrap());
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_get_cache_key_returns_correct_value() {
-		let throttle = AnonRateThrottle::new(10, 60);
-
-		// Test that requests are tracked properly by IP
+		// Arrange
+		let throttle = AnonRateThrottle::new(10, 60).unwrap();
 		let ip1 = "10.0.0.1";
 		let ip2 = "10.0.0.2";
 
-		// Make requests from ip1
+		// Act - make requests from ip1
 		for _ in 0..10 {
 			assert!(throttle.allow_request(ip1).await.unwrap());
 		}
-		assert!(!throttle.allow_request(ip1).await.unwrap());
 
-		// ip2 should still work
+		// Assert
+		assert!(!throttle.allow_request(ip1).await.unwrap());
 		assert!(throttle.allow_request(ip2).await.unwrap());
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_accepts_request_under_limit() {
-		let throttle = AnonRateThrottle::new(1, 86400); // 1 per day
+		// Arrange
+		let throttle = AnonRateThrottle::new(1, 86400).unwrap();
+
+		// Act & Assert
 		assert!(throttle.allow_request("3.3.3.3").await.unwrap());
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_denies_request_over_limit() {
-		let throttle = AnonRateThrottle::new(1, 86400); // 1 per day
+		// Arrange
+		let throttle = AnonRateThrottle::new(1, 86400).unwrap();
+
+		// Act & Assert
 		assert!(throttle.allow_request("3.3.3.3").await.unwrap());
 		assert!(!throttle.allow_request("3.3.3.3").await.unwrap());
+	}
+
+	#[rstest]
+	fn test_new_rejects_zero_rate() {
+		// Arrange & Act
+		let result = AnonRateThrottle::new(0, 60);
+
+		// Assert
+		assert!(result.is_err());
+		assert!(matches!(
+			result.err().unwrap(),
+			ThrottleError::InvalidConfig(_)
+		));
+	}
+
+	#[rstest]
+	fn test_new_rejects_zero_window() {
+		// Arrange & Act
+		let result = AnonRateThrottle::new(10, 0);
+
+		// Assert
+		assert!(result.is_err());
+		assert!(matches!(
+			result.err().unwrap(),
+			ThrottleError::InvalidConfig(_)
+		));
+	}
+
+	#[rstest]
+	fn test_with_backend_rejects_zero_rate() {
+		// Arrange & Act
+		let result = AnonRateThrottle::with_backend(0, 60, MemoryBackend::new());
+
+		// Assert
+		assert!(result.is_err());
+		assert!(matches!(
+			result.err().unwrap(),
+			ThrottleError::InvalidConfig(_)
+		));
+	}
+
+	#[rstest]
+	fn test_with_backend_rejects_zero_window() {
+		// Arrange & Act
+		let result = AnonRateThrottle::with_backend(10, 0, MemoryBackend::new());
+
+		// Assert
+		assert!(result.is_err());
+		assert!(matches!(
+			result.err().unwrap(),
+			ThrottleError::InvalidConfig(_)
+		));
 	}
 }


### PR DESCRIPTION
## Summary

- Fix integer overflow in Redis EXPIRE by using `i64::try_from()` with `i64::MAX` fallback when casting u64 window to i64 (#420)
- Validate `leak_rate > 0.0` and `capacity > 0` in `LeakyBucketConfig` constructors, returning `ThrottleError::InvalidConfig` to prevent division by zero in `wait_time` calculation (#419)
- Add input validation (rate > 0, window > 0) to `UserRateThrottle` and `AnonRateThrottle` constructors, returning `ThrottleError::InvalidConfig` for invalid parameters (#421)
- Convert all tests to use `#[rstest]` with AAA pattern

Closes #420, closes #419, closes #421

## Test plan

- [x] All 132 reinhardt-throttling tests pass
- [x] Clippy clean for reinhardt-throttling
- [x] Formatting clean for reinhardt-throttling
- [x] Validation tests for zero leak_rate, negative, NaN, infinity
- [x] Validation tests for zero rate/window in UserRateThrottle and AnonRateThrottle