### PR TITLE
fix(throttling): check window expiration in get_count to prevent false denials

### DIFF
--- a/crates/reinhardt-throttling/src/backend.rs
+++ b/crates/reinhardt-throttling/src/backend.rs
@@ -29,9 +29,17 @@ pub trait ThrottleBackend: Send + Sync {
 	}
 }
 
+/// Entry stored per rate-limit key in memory backend
+#[derive(Clone)]
+struct WindowEntry {
+	count: usize,
+	window_start: Instant,
+	window_secs: u64,
+}
+
 #[derive(Clone)]
 pub struct MemoryBackend<T: TimeProvider = SystemTimeProvider> {
-	storage: Arc<RwLock<HashMap<String, (usize, Instant)>>>,
+	storage: Arc<RwLock<HashMap<String, WindowEntry>>>,
 	time_provider: Arc<T>,
 }
 
@@ -75,18 +83,39 @@ impl<T: TimeProvider> ThrottleBackend for MemoryBackend<T> {
 	async fn increment(&self, key: &str, window_secs: u64) -> Result<usize, String> {
 		let mut storage = self.storage.write().await;
 		let now = self.time_provider.now();
-		let entry = storage.entry(key.to_string()).or_insert((0, now));
-		if now.duration_since(entry.1) > Duration::from_secs(window_secs) {
-			*entry = (1, now);
+		let entry = storage.entry(key.to_string()).or_insert(WindowEntry {
+			count: 0,
+			window_start: now,
+			window_secs,
+		});
+		if now.duration_since(entry.window_start) > Duration::from_secs(window_secs) {
+			*entry = WindowEntry {
+				count: 1,
+				window_start: now,
+				window_secs,
+			};
 			Ok(1)
 		} else {
-			entry.0 += 1;
-			Ok(entry.0)
+			entry.count += 1;
+			// Update the stored window duration in case it changed
+			entry.window_secs = window_secs;
+			Ok(entry.count)
 		}
 	}
 	async fn get_count(&self, key: &str) -> Result<usize, String> {
 		let storage = self.storage.read().await;
-		Ok(storage.get(key).map(|(count, _)| *count).unwrap_or(0))
+		match storage.get(key) {
+			Some(entry) => {
+				let now = self.time_provider.now();
+				// Return 0 if the window has expired
+				if now.duration_since(entry.window_start) > Duration::from_secs(entry.window_secs) {
+					Ok(0)
+				} else {
+					Ok(entry.count)
+				}
+			}
+			None => Ok(0),
+		}
 	}
 }
 
@@ -158,12 +187,17 @@ impl ThrottleBackend for RedisThrottleBackend {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::time_provider::MockTimeProvider;
+	use rstest::rstest;
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_memory_backend_increment() {
+		// Arrange
 		let backend = MemoryBackend::new();
 		let key = "test_key";
 
+		// Act & Assert
 		let count1 = backend.increment(key, 60).await.unwrap();
 		assert_eq!(count1, 1);
 
@@ -174,52 +208,148 @@ mod tests {
 		assert_eq!(count3, 3);
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_memory_backend_get_count() {
+		// Arrange
 		let backend = MemoryBackend::new();
 		let key = "test_key";
 
+		// Assert - initial count
 		let initial_count = backend.get_count(key).await.unwrap();
 		assert_eq!(initial_count, 0);
 
+		// Act
 		backend.increment(key, 60).await.unwrap();
 		backend.increment(key, 60).await.unwrap();
 
+		// Assert
 		let count = backend.get_count(key).await.unwrap();
 		assert_eq!(count, 2);
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_memory_backend_increment_duration() {
+		// Arrange
 		let backend = MemoryBackend::new();
 		let key = "test_key";
 
+		// Act
 		let count = backend
 			.increment_duration(key, Duration::from_secs(60))
 			.await
 			.unwrap();
+
+		// Assert
 		assert_eq!(count, 1);
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_memory_backend_separate_keys() {
+		// Arrange
 		let backend = MemoryBackend::new();
 
+		// Act
 		backend.increment("key1", 60).await.unwrap();
 		backend.increment("key1", 60).await.unwrap();
 		backend.increment("key2", 60).await.unwrap();
 
+		// Assert
 		let count1 = backend.get_count("key1").await.unwrap();
 		let count2 = backend.get_count("key2").await.unwrap();
-
 		assert_eq!(count1, 2);
 		assert_eq!(count2, 1);
 	}
 
+	#[rstest]
 	#[tokio::test]
 	async fn test_memory_backend_default() {
+		// Arrange
 		let backend = MemoryBackend::default();
+
+		// Act
 		let count = backend.increment("test", 60).await.unwrap();
+
+		// Assert
 		assert_eq!(count, 1);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_get_count_returns_zero_after_window_expiry() {
+		// Arrange
+		use tokio::time::Instant;
+		let time_provider = Arc::new(MockTimeProvider::new(Instant::now()));
+		let backend = MemoryBackend::with_time_provider(time_provider.clone());
+		let key = "test_key";
+		let window_secs = 5;
+
+		// Act - increment within window
+		backend.increment(key, window_secs).await.unwrap();
+		backend.increment(key, window_secs).await.unwrap();
+		backend.increment(key, window_secs).await.unwrap();
+
+		// Assert - count should be 3 within window
+		let count = backend.get_count(key).await.unwrap();
+		assert_eq!(count, 3);
+
+		// Act - advance time past the window
+		time_provider.advance(std::time::Duration::from_secs(6));
+
+		// Assert - count should be 0 after window expiry
+		let count_after = backend.get_count(key).await.unwrap();
+		assert_eq!(count_after, 0);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_get_count_returns_count_within_window() {
+		// Arrange
+		use tokio::time::Instant;
+		let time_provider = Arc::new(MockTimeProvider::new(Instant::now()));
+		let backend = MemoryBackend::with_time_provider(time_provider.clone());
+		let key = "test_key";
+		let window_secs = 60;
+
+		// Act
+		backend.increment(key, window_secs).await.unwrap();
+		backend.increment(key, window_secs).await.unwrap();
+
+		// Advance time but stay within window
+		time_provider.advance(std::time::Duration::from_secs(30));
+
+		// Assert - count should still be valid
+		let count = backend.get_count(key).await.unwrap();
+		assert_eq!(count, 2);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_increment_resets_after_window_expiry() {
+		// Arrange
+		use tokio::time::Instant;
+		let time_provider = Arc::new(MockTimeProvider::new(Instant::now()));
+		let backend = MemoryBackend::with_time_provider(time_provider.clone());
+		let key = "test_key";
+		let window_secs = 5;
+
+		// Act - fill up counter
+		backend.increment(key, window_secs).await.unwrap();
+		backend.increment(key, window_secs).await.unwrap();
+		backend.increment(key, window_secs).await.unwrap();
+		assert_eq!(backend.get_count(key).await.unwrap(), 3);
+
+		// Act - advance time past window
+		time_provider.advance(std::time::Duration::from_secs(6));
+
+		// Assert - get_count should return 0 (expired)
+		assert_eq!(backend.get_count(key).await.unwrap(), 0);
+
+		// Act - new increment should reset counter
+		let count = backend.increment(key, window_secs).await.unwrap();
+		assert_eq!(count, 1);
+		assert_eq!(backend.get_count(key).await.unwrap(), 1);
 	}
 }


### PR DESCRIPTION
## Summary

- Store window duration alongside count and start time in `MemoryBackend` so `get_count` can check if the window has expired (#418)
- Previously, `get_count` returned stale counts from expired windows, causing `wait_time` methods to falsely report that rate limits were exceeded
- Introduce `WindowEntry` struct to replace the `(usize, Instant, u64)` tuple, improving code readability and satisfying `clippy::type_complexity`
- Convert existing backend tests to `#[rstest]` with AAA pattern and add window expiry tests

Closes #418

## Test plan

- [x] All 120 reinhardt-throttling tests pass
- [x] Clippy clean for reinhardt-throttling
- [x] Formatting clean for reinhardt-throttling
- [x] New test: `test_get_count_returns_zero_after_window_expiry` verifies count returns 0 after window expires
- [x] New test: `test_get_count_returns_count_within_window` verifies count is preserved within window
- [x] New test: `test_increment_resets_after_window_expiry` verifies increment resets counter after window expires