### PR TITLE
fix(di): handle RwLock poisoning gracefully in scope and override registry

### DIFF
--- a/crates/reinhardt-di/src/override_registry.rs
+++ b/crates/reinhardt-di/src/override_registry.rs
@@ -6,7 +6,7 @@
 
 use std::any::Any;
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, PoisonError, RwLock};
 
 /// Override registry for dependency injection.
 ///
@@ -78,7 +78,7 @@ impl OverrideRegistry {
 	pub fn set<O: Clone + Send + Sync + 'static>(&self, func_ptr: usize, value: O) {
 		self.overrides
 			.write()
-			.unwrap()
+			.unwrap_or_else(PoisonError::into_inner)
 			.insert(func_ptr, Arc::new(value));
 	}
 
@@ -105,7 +105,7 @@ impl OverrideRegistry {
 	pub fn get<O: Clone + 'static>(&self, func_ptr: usize) -> Option<O> {
 		self.overrides
 			.read()
-			.unwrap()
+			.unwrap_or_else(PoisonError::into_inner)
 			.get(&func_ptr)
 			.and_then(|arc| arc.downcast_ref::<O>().cloned())
 	}
@@ -130,7 +130,10 @@ impl OverrideRegistry {
 	/// assert!(value.is_none());
 	/// ```
 	pub fn remove(&self, func_ptr: usize) {
-		self.overrides.write().unwrap().remove(&func_ptr);
+		self.overrides
+			.write()
+			.unwrap_or_else(PoisonError::into_inner)
+			.remove(&func_ptr);
 	}
 
 	/// Clears all overrides from the registry.
@@ -154,7 +157,10 @@ impl OverrideRegistry {
 	/// assert!(v2.is_none());
 	/// ```
 	pub fn clear(&self) {
-		self.overrides.write().unwrap().clear();
+		self.overrides
+			.write()
+			.unwrap_or_else(PoisonError::into_inner)
+			.clear();
 	}
 
 	/// Checks if an override exists for the given function pointer.
@@ -176,7 +182,10 @@ impl OverrideRegistry {
 	/// assert!(registry.has(my_factory as usize));
 	/// ```
 	pub fn has(&self, func_ptr: usize) -> bool {
-		self.overrides.read().unwrap().contains_key(&func_ptr)
+		self.overrides
+			.read()
+			.unwrap_or_else(PoisonError::into_inner)
+			.contains_key(&func_ptr)
 	}
 
 	/// Returns the number of overrides in the registry.
@@ -194,7 +203,10 @@ impl OverrideRegistry {
 	/// assert_eq!(registry.len(), 1);
 	/// ```
 	pub fn len(&self) -> usize {
-		self.overrides.read().unwrap().len()
+		self.overrides
+			.read()
+			.unwrap_or_else(PoisonError::into_inner)
+			.len()
 	}
 
 	/// Returns true if the registry contains no overrides.
@@ -212,7 +224,10 @@ impl OverrideRegistry {
 	/// assert!(!registry.is_empty());
 	/// ```
 	pub fn is_empty(&self) -> bool {
-		self.overrides.read().unwrap().is_empty()
+		self.overrides
+			.read()
+			.unwrap_or_else(PoisonError::into_inner)
+			.is_empty()
 	}
 }
 

--- a/crates/reinhardt-di/src/scope.rs
+++ b/crates/reinhardt-di/src/scope.rs
@@ -2,7 +2,7 @@
 
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, PoisonError, RwLock};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Scope {
@@ -46,7 +46,7 @@ impl RequestScope {
 	/// assert_eq!(*value, 42);
 	/// ```
 	pub fn get<T: Any + Send + Sync>(&self) -> Option<Arc<T>> {
-		let cache = self.cache.read().unwrap();
+		let cache = self.cache.read().unwrap_or_else(PoisonError::into_inner);
 		let type_id = TypeId::of::<T>();
 		cache
 			.get(&type_id)
@@ -69,7 +69,7 @@ impl RequestScope {
 	/// assert_eq!(*scope.get::<String>().unwrap(), "hello");
 	/// ```
 	pub fn set<T: Any + Send + Sync>(&self, value: T) {
-		let mut cache = self.cache.write().unwrap();
+		let mut cache = self.cache.write().unwrap_or_else(PoisonError::into_inner);
 		let type_id = TypeId::of::<T>();
 		cache.insert(type_id, Arc::new(value));
 	}
@@ -81,7 +81,7 @@ impl RequestScope {
 	/// The cloned scope contains the same cached entries as the original,
 	/// but modifications to either scope will not affect the other.
 	pub fn deep_clone(&self) -> Self {
-		let cache = self.cache.read().unwrap();
+		let cache = self.cache.read().unwrap_or_else(PoisonError::into_inner);
 		Self {
 			cache: Arc::new(RwLock::new(cache.clone())),
 		}
@@ -129,7 +129,7 @@ impl SingletonScope {
 	/// assert_eq!(*value, 100);
 	/// ```
 	pub fn get<T: Any + Send + Sync>(&self) -> Option<Arc<T>> {
-		let cache = self.cache.read().unwrap();
+		let cache = self.cache.read().unwrap_or_else(PoisonError::into_inner);
 		let type_id = TypeId::of::<T>();
 		cache
 			.get(&type_id)
@@ -153,7 +153,7 @@ impl SingletonScope {
 	/// assert_eq!(*val1, *val2);
 	/// ```
 	pub fn set<T: Any + Send + Sync>(&self, value: T) {
-		let mut cache = self.cache.write().unwrap();
+		let mut cache = self.cache.write().unwrap_or_else(PoisonError::into_inner);
 		let type_id = TypeId::of::<T>();
 		cache.insert(type_id, Arc::new(value));
 	}


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` on `RwLock` read/write operations with `.unwrap_or_else(PoisonError::into_inner)` in `reinhardt-di` scope and override registry
- Prevents cascading panics when a thread panics while holding a lock

## Changes
- `crates/reinhardt-di/src/scope.rs`: Fix all `RwLock` accesses in `RequestScope` and `SingletonScope`
- `crates/reinhardt-di/src/override_registry.rs`: Fix all `RwLock` accesses in `OverrideRegistry`

Closes #451

## Test plan
- [x] All 217 existing reinhardt-di tests pass
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)