### PR TITLE
security(i18n): apply validate_locale uniformly across all entry points

### DIFF
--- a/crates/reinhardt-i18n/src/lazy.rs
+++ b/crates/reinhardt-i18n/src/lazy.rs
@@ -19,7 +19,7 @@ use std::fmt;
 /// let mut ctx = TranslationContext::new("fr", "en-US");
 /// let mut catalog = MessageCatalog::new("fr");
 /// catalog.add_translation("Welcome", "Bienvenue");
-/// ctx.add_catalog("fr", catalog);
+/// ctx.add_catalog("fr", catalog).unwrap();
 ///
 /// let _guard = set_active_translation(Arc::new(ctx));
 ///
@@ -100,7 +100,7 @@ mod tests {
 		let mut ctx = TranslationContext::new("zh", "en-US");
 		let mut catalog = MessageCatalog::new("zh");
 		catalog.add_translation("Hello", "你好");
-		ctx.add_catalog("zh", catalog);
+		ctx.add_catalog("zh", catalog).unwrap();
 
 		let _guard = set_active_translation(Arc::new(ctx));
 
@@ -115,7 +115,7 @@ mod tests {
 		let mut ctx = TranslationContext::new("ru", "en-US");
 		let mut catalog = MessageCatalog::new("ru");
 		catalog.add_plural_str("cat", "cats", vec!["кошка", "кошки"]);
-		ctx.add_catalog("ru", catalog);
+		ctx.add_catalog("ru", catalog).unwrap();
 
 		let _guard = set_active_translation(Arc::new(ctx));
 

--- a/crates/reinhardt-i18n/src/locale.rs
+++ b/crates/reinhardt-i18n/src/locale.rs
@@ -10,7 +10,7 @@ use crate::{
 use std::sync::Arc;
 
 /// Validate locale string format
-fn validate_locale(locale: &str) -> Result<(), I18nError> {
+pub(crate) fn validate_locale(locale: &str) -> Result<(), I18nError> {
 	// Basic validation: locale should contain only alphanumeric characters, hyphens, and underscores
 	if locale.is_empty() {
 		return Err(I18nError::InvalidLocale(
@@ -46,7 +46,7 @@ fn validate_locale(locale: &str) -> Result<(), I18nError> {
 /// let mut ctx = TranslationContext::new("es", "en-US");
 /// let mut catalog = MessageCatalog::new("es");
 /// catalog.add_translation("Welcome", "Bienvenido");
-/// ctx.add_catalog("es", catalog);
+/// ctx.add_catalog("es", catalog).unwrap();
 ///
 /// let _guard = set_active_translation(Arc::new(ctx));
 /// assert_eq!(gettext("Welcome"), "Bienvenido");
@@ -59,7 +59,8 @@ pub fn activate(locale: &str) -> Result<(), I18nError> {
 		.map(|arc| (*arc).clone())
 		.unwrap_or_else(|| TranslationContext::new("en-US", "en-US"));
 
-	ctx.set_locale(locale);
+	// Already validated above, safe to unwrap
+	ctx.set_locale(locale).expect("locale already validated");
 
 	// Set the new context permanently (no guard, no memory leak)
 	// In new code, users should use set_active_translation() directly
@@ -85,22 +86,28 @@ pub fn activate(locale: &str) -> Result<(), I18nError> {
 /// let mut ctx = TranslationContext::new("es", "en-US");
 /// let mut catalog = MessageCatalog::new("es");
 /// catalog.add_translation("Welcome", "Bienvenido");
-/// ctx.add_catalog("es", catalog);
+/// ctx.add_catalog("es", catalog).unwrap();
 ///
 /// let _guard = set_active_translation(Arc::new(ctx));
 /// assert_eq!(gettext("Welcome"), "Bienvenido");
 /// ```
-pub fn activate_with_catalog(locale: &str, catalog: MessageCatalog) {
+pub fn activate_with_catalog(locale: &str, catalog: MessageCatalog) -> Result<(), I18nError> {
+	validate_locale(locale)?;
+
 	// Get current context or create new one
 	let mut ctx = get_active_translation()
 		.map(|arc| (*arc).clone())
 		.unwrap_or_else(|| TranslationContext::new("en-US", "en-US"));
 
-	ctx.set_locale(locale);
-	ctx.add_catalog(locale, catalog);
+	// Already validated above, safe to unwrap
+	ctx.set_locale(locale).expect("locale already validated");
+	ctx.add_catalog(locale, catalog)
+		.expect("locale already validated");
 
 	// Set the new context permanently (no guard, no memory leak)
 	set_active_translation_permanent(Arc::new(ctx));
+
+	Ok(())
 }
 
 /// Deactivate the current locale and revert to English
@@ -116,7 +123,7 @@ pub fn activate_with_catalog(locale: &str, catalog: MessageCatalog) {
 /// let mut ctx = TranslationContext::new("de", "en-US");
 /// let mut catalog = MessageCatalog::new("de");
 /// catalog.add_translation("Hello", "Hallo");
-/// ctx.add_catalog("de", catalog);
+/// ctx.add_catalog("de", catalog).unwrap();
 ///
 /// let _guard = set_active_translation(Arc::new(ctx));
 /// assert_eq!(gettext("Hello"), "Hallo");
@@ -128,7 +135,9 @@ pub fn deactivate() {
 	// Get current context and reset locale to empty
 	if let Some(arc) = get_active_translation() {
 		let mut ctx = (*arc).clone();
-		ctx.set_locale("");
+		// Empty string is allowed for deactivation (reset to default)
+		ctx.set_locale("")
+			.expect("empty string is always valid for deactivation");
 
 		// Set the new context permanently (no guard, no memory leak)
 		set_active_translation_permanent(Arc::new(ctx));
@@ -171,7 +180,7 @@ mod tests {
 		// Arrange
 		let mut ctx = TranslationContext::new("pt", "en-US");
 		let catalog = MessageCatalog::new("pt");
-		ctx.add_catalog("pt", catalog);
+		ctx.add_catalog("pt", catalog).unwrap();
 		let _guard = set_active_translation(Arc::new(ctx));
 
 		// Act
@@ -187,7 +196,7 @@ mod tests {
 		// Arrange
 		let mut ctx = TranslationContext::new("fr", "en-US");
 		let catalog = MessageCatalog::new("fr");
-		ctx.add_catalog("fr", catalog);
+		ctx.add_catalog("fr", catalog).unwrap();
 		let _guard = set_active_translation(Arc::new(ctx));
 		assert_eq!(get_locale(), "fr");
 
@@ -224,7 +233,7 @@ mod tests {
 
 		// Act: activate_with_catalog replaces the context without leaking
 		let catalog = MessageCatalog::new("es");
-		activate_with_catalog("es", catalog);
+		activate_with_catalog("es", catalog).unwrap();
 
 		// Assert: original Arc has only one strong reference (this scope)
 		assert_eq!(Arc::strong_count(&ctx), 1);
@@ -236,7 +245,7 @@ mod tests {
 		// Arrange
 		let mut ctx = TranslationContext::new("ko", "en-US");
 		let catalog = MessageCatalog::new("ko");
-		ctx.add_catalog("ko", catalog);
+		ctx.add_catalog("ko", catalog).unwrap();
 		let shared = Arc::new(ctx);
 		set_active_translation_permanent(Arc::clone(&shared));
 
@@ -256,5 +265,77 @@ mod tests {
 		assert!(activate("en US").is_err());
 		assert!(activate("en-US").is_ok());
 		assert!(activate("ja").is_ok());
+	}
+
+	#[rstest]
+	#[serial(i18n)]
+	fn test_activate_with_catalog_validates_locale() {
+		// Arrange
+		let catalog = MessageCatalog::new("valid");
+
+		// Act & Assert: invalid locales are rejected
+		assert!(activate_with_catalog("", catalog).is_err());
+
+		let catalog = MessageCatalog::new("valid");
+		assert!(activate_with_catalog("en/US", catalog).is_err());
+
+		let catalog = MessageCatalog::new("valid");
+		assert!(activate_with_catalog("en US", catalog).is_err());
+
+		// Act & Assert: valid locales are accepted
+		let catalog = MessageCatalog::new("es");
+		assert!(activate_with_catalog("es", catalog).is_ok());
+	}
+
+	#[rstest]
+	fn test_set_locale_validates_locale() {
+		// Arrange
+		let mut ctx = TranslationContext::new("en-US", "en-US");
+
+		// Act & Assert: invalid locales are rejected
+		assert!(ctx.set_locale("en/US").is_err());
+		assert!(ctx.set_locale("en US").is_err());
+		assert!(ctx.set_locale("../etc/passwd").is_err());
+
+		// Act & Assert: valid locales are accepted
+		assert!(ctx.set_locale("ja").is_ok());
+		assert!(ctx.set_locale("en-US").is_ok());
+
+		// Act & Assert: empty string is allowed for deactivation
+		assert!(ctx.set_locale("").is_ok());
+	}
+
+	#[rstest]
+	fn test_set_fallback_locale_validates_locale() {
+		// Arrange
+		let mut ctx = TranslationContext::new("en-US", "en-US");
+
+		// Act & Assert: invalid locales are rejected
+		assert!(ctx.set_fallback_locale("en/US").is_err());
+		assert!(ctx.set_fallback_locale("../etc/passwd").is_err());
+
+		// Act & Assert: valid locales are accepted
+		assert!(ctx.set_fallback_locale("fr").is_ok());
+		assert!(ctx.set_fallback_locale("en-US").is_ok());
+	}
+
+	#[rstest]
+	fn test_add_catalog_validates_locale() {
+		// Arrange
+		let mut ctx = TranslationContext::new("en-US", "en-US");
+
+		// Act & Assert: invalid locales are rejected
+		let catalog = MessageCatalog::new("test");
+		assert!(ctx.add_catalog("", catalog).is_err());
+
+		let catalog = MessageCatalog::new("test");
+		assert!(ctx.add_catalog("en/US", catalog).is_err());
+
+		let catalog = MessageCatalog::new("test");
+		assert!(ctx.add_catalog("../etc", catalog).is_err());
+
+		// Act & Assert: valid locales are accepted
+		let catalog = MessageCatalog::new("ja");
+		assert!(ctx.add_catalog("ja", catalog).is_ok());
 	}
 }

--- a/crates/reinhardt-i18n/src/translation.rs
+++ b/crates/reinhardt-i18n/src/translation.rs
@@ -23,7 +23,7 @@ use crate::{LazyString, get_active_translation};
 /// let mut ctx = TranslationContext::new("ja", "en-US");
 /// let mut catalog = MessageCatalog::new("ja");
 /// catalog.add_translation("Hello, world!", "こんにちは、世界！");
-/// ctx.add_catalog("ja", catalog);
+/// ctx.add_catalog("ja", catalog).unwrap();
 ///
 /// let _guard = set_active_translation(Arc::new(ctx));
 /// let msg = gettext("Hello, world!");
@@ -53,7 +53,7 @@ pub fn gettext(message: &str) -> String {
 /// let mut ctx = TranslationContext::new("de", "en-US");
 /// let mut catalog = MessageCatalog::new("de");
 /// catalog.add_plural_str("item", "items", vec!["Artikel", "Artikel"]);
-/// ctx.add_catalog("de", catalog);
+/// ctx.add_catalog("de", catalog).unwrap();
 ///
 /// let _guard = set_active_translation(Arc::new(ctx));
 ///
@@ -94,7 +94,7 @@ pub fn ngettext(singular: &str, plural: &str, count: usize) -> String {
 /// let mut catalog = MessageCatalog::new("ja");
 /// catalog.add_context("menu".to_string(), "File".to_string(), "ファイル".to_string());
 /// catalog.add_context("verb".to_string(), "File".to_string(), "提出する".to_string());
-/// ctx.add_catalog("ja", catalog);
+/// ctx.add_catalog("ja", catalog).unwrap();
 ///
 /// let _guard = set_active_translation(Arc::new(ctx));
 ///
@@ -130,7 +130,7 @@ pub fn pgettext(context: &str, message: &str) -> String {
 /// let mut catalog = MessageCatalog::new("es");
 /// catalog.add_context_plural("email", "message", "messages", vec!["mensaje", "mensajes"]);
 /// catalog.add_context_plural("notification", "message", "messages", vec!["notificación", "notificaciones"]);
-/// ctx.add_catalog("es", catalog);
+/// ctx.add_catalog("es", catalog).unwrap();
 ///
 /// let _guard = set_active_translation(Arc::new(ctx));
 ///
@@ -172,7 +172,7 @@ pub fn npgettext(context: &str, singular: &str, plural: &str, count: usize) -> S
 /// let mut ctx = TranslationContext::new("ko", "en-US");
 /// let mut catalog = MessageCatalog::new("ko");
 /// catalog.add_translation("Good morning", "좋은 아침");
-/// ctx.add_catalog("ko", catalog);
+/// ctx.add_catalog("ko", catalog).unwrap();
 ///
 /// let _guard = set_active_translation(Arc::new(ctx));
 ///
@@ -200,7 +200,7 @@ pub fn gettext_lazy(message: &str) -> LazyString {
 /// let mut ctx = TranslationContext::new("pl", "en-US");
 /// let mut catalog = MessageCatalog::new("pl");
 /// catalog.add_plural_str("apple", "apples", vec!["jabłko", "jabłka"]);
-/// ctx.add_catalog("pl", catalog);
+/// ctx.add_catalog("pl", catalog).unwrap();
 ///
 /// let _guard = set_active_translation(Arc::new(ctx));
 ///

--- a/crates/reinhardt-i18n/tests/lazy_translation_tests.rs
+++ b/crates/reinhardt-i18n/tests/lazy_translation_tests.rs
@@ -23,7 +23,7 @@ fn create_test_context(locale: &str) -> TranslationContext {
 			"%(count)d éléments".to_string(),
 		],
 	);
-	ctx.add_catalog("fr-FR", fr_catalog);
+	ctx.add_catalog("fr-FR", fr_catalog).unwrap();
 
 	// Setup German catalog
 	let mut de_catalog = MessageCatalog::new("de-DE");
@@ -39,13 +39,13 @@ fn create_test_context(locale: &str) -> TranslationContext {
 			"%(count)d Artikel".to_string(),
 		],
 	);
-	ctx.add_catalog("de-DE", de_catalog);
+	ctx.add_catalog("de-DE", de_catalog).unwrap();
 
 	// Setup Polish catalog
 	let mut pl_catalog = MessageCatalog::new("pl-PL");
 	pl_catalog.add("Add %(name)s".to_string(), "Dodaj %(name)s".to_string());
 	pl_catalog.add("Hello".to_string(), "Witaj".to_string());
-	ctx.add_catalog("pl-PL", pl_catalog);
+	ctx.add_catalog("pl-PL", pl_catalog).unwrap();
 
 	ctx
 }


### PR DESCRIPTION
## Summary
- Apply `validate_locale()` validation at all locale entry points (#720)
- Make `validate_locale()` `pub(crate)` so it can be reused across modules
- Add validation to `activate_with_catalog()`, `TranslationContext::set_locale()`, `set_fallback_locale()`, and `add_catalog()`
- Add comprehensive tests for validation at each entry point

## Test plan
- [x] `cargo nextest run -p reinhardt-i18n --all-features` passes (75/75)
- [x] `cargo test --doc -p reinhardt-i18n --all-features` passes (23/23)

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)