### PR TITLE
security(macros): replace eprintln with tracing to prevent type info leakage

### DIFF
--- a/crates/reinhardt-core/macros/src/injectable_fn.rs
+++ b/crates/reinhardt-core/macros/src/injectable_fn.rs
@@ -123,7 +123,10 @@ pub(crate) fn injectable_fn_impl(_args: TokenStream, input: ItemFn) -> Result<To
 									#di_crate::Injected::<#ty>::resolve_uncached(__di_ctx).await
 								}
 								.map_err(|e| {
-									eprintln!("Injectable function dependency failed for {}: {:?}", stringify!(#ty), e);
+									tracing::debug!(
+										dependency_type = stringify!(#ty),
+										"injectable function dependency resolution failed"
+									);
 									e
 								})?;
 								let value = (*__injected).clone();
@@ -142,7 +145,10 @@ pub(crate) fn injectable_fn_impl(_args: TokenStream, input: ItemFn) -> Result<To
 								#di_crate::Injected::<#ty>::resolve_uncached(__di_ctx).await
 							}
 							.map_err(|e| {
-								eprintln!("Injectable function dependency failed for {}: {:?}", stringify!(#ty), e);
+								tracing::debug!(
+									dependency_type = stringify!(#ty),
+									"injectable function dependency resolution failed"
+								);
 								e
 							})?;
 							(*__injected).clone()

--- a/crates/reinhardt-core/macros/src/injectable_struct.rs
+++ b/crates/reinhardt-core/macros/src/injectable_struct.rs
@@ -138,8 +138,11 @@ pub(crate) fn injectable_struct_impl(mut input: DeriveInput) -> Result<TokenStre
 									#di_crate::Injected::<#ty>::resolve_uncached(__di_ctx).await
 								}
 								.map_err(|e| {
-									eprintln!("Dependency injection failed for {} in {}: {:?}",
-										stringify!(#name), stringify!(#struct_name), e);
+									tracing::debug!(
+										field = stringify!(#name),
+										target_type = stringify!(#struct_name),
+										"dependency injection resolution failed"
+									);
 									e
 								})?;
 								let value = (*__injected).clone();

--- a/crates/reinhardt-core/macros/src/use_inject.rs
+++ b/crates/reinhardt-core/macros/src/use_inject.rs
@@ -216,9 +216,12 @@ pub(crate) fn use_inject_impl(_args: TokenStream, input: ItemFn) -> Result<Token
 				let #pat: #ty = #di_crate::Injected::<#ty>::resolve(&__di_ctx)
 					.await
 					.map_err(|e| {
-						eprintln!("Dependency injection failed for {}: {:?}", stringify!(#ty), e);
+						tracing::debug!(
+							dependency_type = stringify!(#ty),
+							"dependency injection resolution failed"
+						);
 						#core_crate::exception::Error::Internal(
-							format!("Dependency injection failed for {}: {:?}", stringify!(#ty), e)
+							format!("Dependency injection failed: {:?}", e)
 						)
 					})?
 					.into_inner();
@@ -228,9 +231,12 @@ pub(crate) fn use_inject_impl(_args: TokenStream, input: ItemFn) -> Result<Token
 				let #pat: #ty = #di_crate::Injected::<#ty>::resolve_uncached(&__di_ctx)
 					.await
 					.map_err(|e| {
-						eprintln!("Dependency injection failed for {}: {:?}", stringify!(#ty), e);
+						tracing::debug!(
+							dependency_type = stringify!(#ty),
+							"dependency injection resolution failed"
+						);
 						#core_crate::exception::Error::Internal(
-							format!("Dependency injection failed for {}: {:?}", stringify!(#ty), e)
+							format!("Dependency injection failed: {:?}", e)
 						)
 					})?
 					.into_inner();


### PR DESCRIPTION
## Summary
- Remove `eprintln!` calls in DI generated code that leak internal type names (#805)
- Replace with `tracing::debug!` for development-only visibility

## Test plan
- [x] `cargo check -p reinhardt-macros --all-features` passes
- [ ] `cargo make clippy-check` passes

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)