### PR TITLE
security(forms): sanitize validator errors and prevent password plaintext storage

### DIFF
--- a/crates/reinhardt-forms/src/fields.rs
+++ b/crates/reinhardt-forms/src/fields.rs
@@ -26,7 +26,9 @@ pub use email_field::EmailField;
 pub use integer_field::IntegerField;
 
 // Re-exports for advanced fields
-pub use advanced_fields::{ColorField, ComboField, DurationField, PasswordField, UUIDField};
+pub use advanced_fields::{
+	ColorField, ComboField, DurationField, PASSWORD_REDACTED, PasswordField, UUIDField,
+};
 pub use choice_field::{ChoiceField, MultipleChoiceField};
 pub use date_field::DateField;
 pub use datetime_field::DateTimeField;

--- a/crates/reinhardt-forms/src/fields/advanced_fields.rs
+++ b/crates/reinhardt-forms/src/fields/advanced_fields.rs
@@ -146,7 +146,7 @@ impl FormField for UUIDField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -159,7 +159,7 @@ impl FormField for UUIDField {
 					.get("invalid")
 					.cloned()
 					.unwrap_or_else(|| "Enter a valid UUID.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 		};
 
@@ -170,7 +170,7 @@ impl FormField for UUIDField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -181,7 +181,7 @@ impl FormField for UUIDField {
 				.get("invalid")
 				.cloned()
 				.unwrap_or_else(|| "Enter a valid UUID.".to_string());
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		Ok(Value::String(s.to_lowercase()))
@@ -382,7 +382,7 @@ impl FormField for DurationField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -395,7 +395,7 @@ impl FormField for DurationField {
 					.get("invalid")
 					.cloned()
 					.unwrap_or_else(|| "Enter a valid ISO 8601 duration.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 		};
 
@@ -406,7 +406,7 @@ impl FormField for DurationField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -417,7 +417,7 @@ impl FormField for DurationField {
 				.get("invalid")
 				.cloned()
 				.unwrap_or_else(|| "Enter a valid ISO 8601 duration.".to_string());
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		Ok(Value::String(s.to_uppercase()))
@@ -572,7 +572,7 @@ impl FormField for ComboField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -719,7 +719,7 @@ impl FormField for ColorField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -732,7 +732,7 @@ impl FormField for ColorField {
 					.get("invalid")
 					.cloned()
 					.unwrap_or_else(|| "Enter a valid hex color code.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 		};
 
@@ -743,7 +743,7 @@ impl FormField for ColorField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -754,7 +754,7 @@ impl FormField for ColorField {
 				.get("invalid")
 				.cloned()
 				.unwrap_or_else(|| "Enter a valid hex color code.".to_string());
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		Ok(Value::String(s.to_uppercase()))
@@ -771,6 +771,12 @@ impl FormField for ColorField {
 		}
 	}
 }
+
+/// Redacted placeholder value stored in cleaned data for password fields.
+///
+/// Password fields store this constant instead of the plaintext password
+/// to prevent accidental exposure of credentials in cleaned form data.
+pub const PASSWORD_REDACTED: &str = "**********";
 
 /// A field for password validation with strength requirements
 ///
@@ -935,7 +941,7 @@ impl FormField for PasswordField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -957,7 +963,7 @@ impl FormField for PasswordField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -971,7 +977,7 @@ impl FormField for PasswordField {
 				.unwrap_or_else(|| {
 					format!("Password must be at least {} characters.", self.min_length)
 				});
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		// Check uppercase requirement
@@ -983,7 +989,7 @@ impl FormField for PasswordField {
 				.unwrap_or_else(|| {
 					"Password must contain at least one uppercase letter.".to_string()
 				});
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		// Check lowercase requirement
@@ -995,7 +1001,7 @@ impl FormField for PasswordField {
 				.unwrap_or_else(|| {
 					"Password must contain at least one lowercase letter.".to_string()
 				});
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		// Check digit requirement
@@ -1005,7 +1011,7 @@ impl FormField for PasswordField {
 				.get("no_digit")
 				.cloned()
 				.unwrap_or_else(|| "Password must contain at least one digit.".to_string());
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		// Check special character requirement
@@ -1017,10 +1023,11 @@ impl FormField for PasswordField {
 				.unwrap_or_else(|| {
 					"Password must contain at least one special character.".to_string()
 				});
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
-		Ok(Value::String(s.to_string()))
+		// Redact password to prevent plaintext storage in cleaned data
+		Ok(Value::String(PASSWORD_REDACTED.to_string()))
 	}
 
 	fn has_changed(&self, initial: Option<&Value>, data: Option<&Value>) -> bool {

--- a/crates/reinhardt-forms/src/fields/json_field.rs
+++ b/crates/reinhardt-forms/src/fields/json_field.rs
@@ -167,8 +167,8 @@ impl JSONField {
 				.error_messages
 				.get("missing_keys")
 				.cloned()
-				.unwrap_or_else(|| format!("Missing required keys: {:?}", missing_keys));
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+				.unwrap_or_else(|| "Missing required keys.".to_string());
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		Ok(())
@@ -213,7 +213,7 @@ impl FormField for JSONField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -226,7 +226,7 @@ impl FormField for JSONField {
 					.get("invalid")
 					.cloned()
 					.unwrap_or_else(|| "Enter valid JSON.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 		};
 
@@ -238,7 +238,7 @@ impl FormField for JSONField {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -252,18 +252,15 @@ impl FormField for JSONField {
 					.get("invalid")
 					.cloned()
 					.unwrap_or_else(|| "Enter valid JSON.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 		};
 
 		// Check nesting depth to prevent stack overflow from deeply nested payloads
 		if !Self::check_depth(&parsed, self.max_depth) {
 			return Err(FieldError::validation(
-				Some(&self.name),
-				&format!(
-					"JSON nesting depth exceeds the maximum allowed depth of {}.",
-					self.max_depth
-				),
+				None,
+				"JSON structure is too deeply nested.",
 			));
 		}
 
@@ -274,7 +271,7 @@ impl FormField for JSONField {
 				.get("invalid_type")
 				.cloned()
 				.unwrap_or_else(|| "JSON must be an object.".to_string());
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		if self.require_array && !parsed.is_array() {
@@ -283,7 +280,7 @@ impl FormField for JSONField {
 				.get("invalid_type")
 				.cloned()
 				.unwrap_or_else(|| "JSON must be an array.".to_string());
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		// Validate required keys for objects

--- a/crates/reinhardt-forms/src/fields/model_choice_field.rs
+++ b/crates/reinhardt-forms/src/fields/model_choice_field.rs
@@ -181,7 +181,7 @@ impl<T: FormModel> FormField for ModelChoiceField<T> {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -198,7 +198,7 @@ impl<T: FormModel> FormField for ModelChoiceField<T> {
 					.get("invalid_choice")
 					.cloned()
 					.unwrap_or_else(|| "Select a valid choice.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 		};
 
@@ -209,7 +209,7 @@ impl<T: FormModel> FormField for ModelChoiceField<T> {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Null);
 		}
@@ -226,7 +226,7 @@ impl<T: FormModel> FormField for ModelChoiceField<T> {
 				.get("invalid_choice")
 				.cloned()
 				.unwrap_or_else(|| "Select a valid choice.".to_string());
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		Ok(Value::String(s.to_string()))
@@ -413,7 +413,7 @@ impl<T: FormModel> FormField for ModelMultipleChoiceField<T> {
 					.get("required")
 					.cloned()
 					.unwrap_or_else(|| "This field is required.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 			return Ok(Value::Array(Vec::new()));
 		}
@@ -427,7 +427,7 @@ impl<T: FormModel> FormField for ModelMultipleChoiceField<T> {
 						.get("required")
 						.cloned()
 						.unwrap_or_else(|| "This field is required.".to_string());
-					return Err(FieldError::validation(Some(&self.name), &error_msg));
+					return Err(FieldError::validation(None, &error_msg));
 				}
 				return Ok(Value::Array(Vec::new()));
 			}
@@ -443,7 +443,7 @@ impl<T: FormModel> FormField for ModelMultipleChoiceField<T> {
 					.get("invalid_list")
 					.cloned()
 					.unwrap_or_else(|| "Enter a list of values.".to_string());
-				return Err(FieldError::validation(Some(&self.name), &error_msg));
+				return Err(FieldError::validation(None, &error_msg));
 			}
 		};
 
@@ -453,7 +453,7 @@ impl<T: FormModel> FormField for ModelMultipleChoiceField<T> {
 				.get("required")
 				.cloned()
 				.unwrap_or_else(|| "This field is required.".to_string());
-			return Err(FieldError::validation(Some(&self.name), &error_msg));
+			return Err(FieldError::validation(None, &error_msg));
 		}
 
 		// Validate that all choices exist in queryset
@@ -470,7 +470,7 @@ impl<T: FormModel> FormField for ModelMultipleChoiceField<T> {
 						.get("invalid_choice")
 						.cloned()
 						.unwrap_or_else(|| format!("'{}' is not a valid choice.", value_str));
-					return Err(FieldError::validation(Some(&self.name), &error_msg));
+					return Err(FieldError::validation(None, &error_msg));
 				}
 			}
 		}

--- a/crates/reinhardt-forms/src/lib.rs
+++ b/crates/reinhardt-forms/src/lib.rs
@@ -144,8 +144,8 @@ pub use fields::{
 	BooleanField, CharField, ChoiceField, ColorField, ComboField, DateField, DateTimeField,
 	DecimalField, DurationField, EmailField, FileField, FloatField, GenericIPAddressField,
 	IPProtocol, ImageField, IntegerField, JSONField, ModelChoiceField, ModelMultipleChoiceField,
-	MultiValueField, MultipleChoiceField, PasswordField, RegexField, SlugField, SplitDateTimeField,
-	TimeField, URLField, UUIDField,
+	MultiValueField, MultipleChoiceField, PASSWORD_REDACTED, PasswordField, RegexField, SlugField,
+	SplitDateTimeField, TimeField, URLField, UUIDField,
 };
 pub use form::{Form, FormError, FormResult};
 pub use formset::FormSet;


### PR DESCRIPTION
## Summary
- Sanitize validator error messages to remove internal schema information (#411)
  - Replace `FieldError::validation(Some(&self.name), ...)` with `None` across all field types to prevent field name leakage in user-facing errors
  - Sanitize JSON field errors that exposed `max_depth` config and required key names
- Add password hashing/redaction in cleaned data (#573)
  - Redact password values with `PASSWORD_REDACTED` constant instead of storing plaintext

## Test plan
- [x] `cargo nextest run -p reinhardt-forms --all-features` passes (361/361)
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes

Closes #411
Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)