### PR TITLE
fix(http): prevent panics from lock poisoning, query parsing, and input validation

### DIFF
--- a/crates/reinhardt-http/src/request.rs
+++ b/crates/reinhardt-http/src/request.rs
@@ -880,7 +880,9 @@ impl Request {
 			.map(|(k, v)| (k.clone(), v.clone()))
 			.collect();
 
-		serde_urlencoded::from_str(&serde_urlencoded::to_string(&params).unwrap())
+		let encoded = serde_urlencoded::to_string(&params)
+			.map_err(|e| crate::Error::Http(format!("Failed to encode query parameters: {}", e)))?;
+		serde_urlencoded::from_str(&encoded)
 			.map_err(|e| crate::Error::Http(format!("Failed to parse query parameters: {}", e)))
 	}
 }


### PR DESCRIPTION
## Summary

- Replace `Mutex::lock().unwrap()` with `unwrap_or_else(PoisonError::into_inner)` to recover from lock poisoning instead of panicking (#376)
- Replace `serde_urlencoded::to_string(&params).unwrap()` with proper `?` error propagation in `query_as()` (#363)
- Fix query parameter parsing to use `splitn(2, '=')` preserving `=` characters in values like Base64 (#362)
- Validate `chunk_size > 0` in `ChunkedUploadSession::new()` to prevent division by zero (#359)
- Make `with_header()` silently ignore invalid headers instead of panicking, and add `try_with_header()` for explicit error handling (#357)

## Test plan

- [x] All 165 reinhardt-http tests pass
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes
- [x] New tests for zero chunk_size validation
- [x] New tests for `with_header()` and `try_with_header()` behavior
- [x] New tests for query parameter `=` preservation

Fixes #376, #363, #362, #359, #357

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>