### PR TITLE
fix(di): prevent Arc::try_unwrap panic and DependencyStream element consumption

### DIFF
--- a/crates/reinhardt-di/src/scope.rs
+++ b/crates/reinhardt-di/src/scope.rs
@@ -73,6 +73,30 @@ impl RequestScope {
 		let type_id = TypeId::of::<T>();
 		cache.insert(type_id, Arc::new(value));
 	}
+
+	/// Stores a pre-wrapped `Arc<T>` in the request scope cache.
+	///
+	/// Unlike `set`, this method accepts an already-wrapped Arc value,
+	/// avoiding the need to unwrap and re-wrap. This is useful when
+	/// the value is produced by a factory that returns `Arc<T>`.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use reinhardt_di::RequestScope;
+	/// use std::sync::Arc;
+	///
+	/// let scope = RequestScope::new();
+	/// let value = Arc::new(42i32);
+	/// scope.set_arc(value);
+	///
+	/// assert_eq!(*scope.get::<i32>().unwrap(), 42);
+	/// ```
+	pub fn set_arc<T: Any + Send + Sync>(&self, value: Arc<T>) {
+		let mut cache = self.cache.write().unwrap_or_else(PoisonError::into_inner);
+		let type_id = TypeId::of::<T>();
+		cache.insert(type_id, value);
+	}
 }
 
 impl RequestScope {
@@ -156,6 +180,30 @@ impl SingletonScope {
 		let mut cache = self.cache.write().unwrap_or_else(PoisonError::into_inner);
 		let type_id = TypeId::of::<T>();
 		cache.insert(type_id, Arc::new(value));
+	}
+
+	/// Stores a pre-wrapped `Arc<T>` in the singleton scope cache.
+	///
+	/// Unlike `set`, this method accepts an already-wrapped Arc value,
+	/// avoiding the need to unwrap and re-wrap. This is useful when
+	/// the value is produced by a factory that returns `Arc<T>`.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use reinhardt_di::SingletonScope;
+	/// use std::sync::Arc;
+	///
+	/// let scope = SingletonScope::new();
+	/// let value = Arc::new(42i32);
+	/// scope.set_arc(value);
+	///
+	/// assert_eq!(*scope.get::<i32>().unwrap(), 42);
+	/// ```
+	pub fn set_arc<T: Any + Send + Sync>(&self, value: Arc<T>) {
+		let mut cache = self.cache.write().unwrap_or_else(PoisonError::into_inner);
+		let type_id = TypeId::of::<T>();
+		cache.insert(type_id, value);
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `set_arc()` methods to `RequestScope` and `SingletonScope` that accept `Arc<T>` directly, avoiding the need to unwrap Arc values returned by factories that may retain additional Arc references
- Use `set_arc()` in `resolve_internal()` instead of `Arc::try_unwrap` which panics when factories hold Arc clones (#454)
- Fix `DependencyStream::is_empty()` consuming elements by implementing peek-based buffering that preserves values for subsequent `next()` calls (#453)

## Test plan

- [x] All 221 reinhardt-di tests pass
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes
- [x] New tests verify `is_empty()` does not consume elements
- [x] New tests verify `is_empty()` on exhausted streams
- [x] New tests verify `is_empty()` after partial consumption
- [x] New tests verify multiple `is_empty()` calls are idempotent

Fixes #454, #453

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>