### PR TITLE
security(websockets): sanitize error messages to prevent internal state leakage

### DIFF
--- a/crates/reinhardt-websockets/src/auth.rs
+++ b/crates/reinhardt-websockets/src/auth.rs
@@ -320,7 +320,7 @@ impl AuthenticatedConnection {
 		policy
 			.authorize(self.user.as_ref(), "send_message", None)
 			.await
-			.map_err(|e| WebSocketError::Protocol(e.to_string()))?;
+			.map_err(|_| WebSocketError::Protocol("authorization failed".to_string()))?;
 
 		self.connection.send(message).await
 	}

--- a/crates/reinhardt-websockets/src/compression.rs
+++ b/crates/reinhardt-websockets/src/compression.rs
@@ -68,10 +68,9 @@ impl std::str::FromStr for CompressionCodec {
 			"gzip" => Ok(Self::Gzip),
 			"deflate" => Ok(Self::Deflate),
 			"br" | "brotli" => Ok(Self::Brotli),
-			_ => Err(WebSocketError::Protocol(format!(
-				"Unknown compression codec: {}",
-				s
-			))),
+			_ => Err(WebSocketError::Protocol(
+				"unsupported compression codec".to_string(),
+			)),
 		}
 	}
 }
@@ -169,10 +168,10 @@ fn compress_gzip(data: &[u8]) -> WebSocketResult<Vec<u8>> {
 	let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
 	encoder
 		.write_all(data)
-		.map_err(|e| WebSocketError::Protocol(format!("Gzip compression failed: {}", e)))?;
+		.map_err(|_| WebSocketError::Protocol("compression failed".to_string()))?;
 	encoder
 		.finish()
-		.map_err(|e| WebSocketError::Protocol(format!("Gzip compression failed: {}", e)))
+		.map_err(|_| WebSocketError::Protocol("compression failed".to_string()))
 }
 
 #[cfg(feature = "compression")]
@@ -184,7 +183,7 @@ fn decompress_gzip(data: &[u8]) -> WebSocketResult<Vec<u8>> {
 	let mut decompressed = Vec::new();
 	decoder
 		.read_to_end(&mut decompressed)
-		.map_err(|e| WebSocketError::Protocol(format!("Gzip decompression failed: {}", e)))?;
+		.map_err(|_| WebSocketError::Protocol("decompression failed".to_string()))?;
 	Ok(decompressed)
 }
 
@@ -197,10 +196,10 @@ fn compress_deflate(data: &[u8]) -> WebSocketResult<Vec<u8>> {
 	let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
 	encoder
 		.write_all(data)
-		.map_err(|e| WebSocketError::Protocol(format!("Deflate compression failed: {}", e)))?;
+		.map_err(|_| WebSocketError::Protocol("compression failed".to_string()))?;
 	encoder
 		.finish()
-		.map_err(|e| WebSocketError::Protocol(format!("Deflate compression failed: {}", e)))
+		.map_err(|_| WebSocketError::Protocol("compression failed".to_string()))
 }
 
 #[cfg(feature = "compression")]
@@ -212,7 +211,7 @@ fn decompress_deflate(data: &[u8]) -> WebSocketResult<Vec<u8>> {
 	let mut decompressed = Vec::new();
 	decoder
 		.read_to_end(&mut decompressed)
-		.map_err(|e| WebSocketError::Protocol(format!("Deflate decompression failed: {}", e)))?;
+		.map_err(|_| WebSocketError::Protocol("decompression failed".to_string()))?;
 	Ok(decompressed)
 }
 
@@ -224,10 +223,10 @@ fn compress_brotli(data: &[u8]) -> WebSocketResult<Vec<u8>> {
 	let mut compressor = brotli::CompressorWriter::new(&mut compressed, 4096, 11, 22);
 	compressor
 		.write_all(data)
-		.map_err(|e| WebSocketError::Protocol(format!("Brotli compression failed: {}", e)))?;
+		.map_err(|_| WebSocketError::Protocol("compression failed".to_string()))?;
 	compressor
 		.flush()
-		.map_err(|e| WebSocketError::Protocol(format!("Brotli compression failed: {}", e)))?;
+		.map_err(|_| WebSocketError::Protocol("compression failed".to_string()))?;
 	drop(compressor);
 	Ok(compressed)
 }
@@ -240,7 +239,7 @@ fn decompress_brotli(data: &[u8]) -> WebSocketResult<Vec<u8>> {
 	let mut decompressed = Vec::new();
 	decompressor
 		.read_to_end(&mut decompressed)
-		.map_err(|e| WebSocketError::Protocol(format!("Brotli decompression failed: {}", e)))?;
+		.map_err(|_| WebSocketError::Protocol("decompression failed".to_string()))?;
 	Ok(decompressed)
 }
 
@@ -253,7 +252,7 @@ fn decompress_brotli(data: &[u8]) -> WebSocketResult<Vec<u8>> {
 #[cfg(not(feature = "compression"))]
 pub fn compress_message(_message: &Message, _codec: CompressionCodec) -> WebSocketResult<Message> {
 	Err(WebSocketError::Protocol(
-		"Compression feature not enabled. Add 'compression' feature to Cargo.toml.".to_string(),
+		"compression not available".to_string(),
 	))
 }
 
@@ -269,7 +268,7 @@ pub fn decompress_message(
 	_codec: CompressionCodec,
 ) -> WebSocketResult<Message> {
 	Err(WebSocketError::Protocol(
-		"Compression feature not enabled. Add 'compression' feature to Cargo.toml.".to_string(),
+		"compression not available".to_string(),
 	))
 }
 

--- a/crates/reinhardt-websockets/src/connection.rs
+++ b/crates/reinhardt-websockets/src/connection.rs
@@ -250,20 +250,54 @@ impl ConnectionConfig {
 
 #[derive(Debug, thiserror::Error)]
 pub enum WebSocketError {
-	#[error("Connection error: {0}")]
+	#[error("Connection error")]
 	Connection(String),
-	#[error("Send error: {0}")]
+	#[error("Send failed")]
 	Send(String),
-	#[error("Receive error: {0}")]
+	#[error("Receive failed")]
 	Receive(String),
-	#[error("Protocol error: {0}")]
+	#[error("Protocol error")]
 	Protocol(String),
-	#[error("Internal error: {0}")]
+	#[error("Internal error")]
 	Internal(String),
-	#[error("Connection timeout: idle for {0:?}")]
+	#[error("Connection timed out")]
 	Timeout(Duration),
-	#[error("Reconnection failed after {0} attempts")]
+	#[error("Reconnection failed")]
 	ReconnectFailed(u32),
+}
+
+impl WebSocketError {
+	/// Returns a sanitized error message safe for client-facing communication.
+	///
+	/// Internal details (buffer sizes, queue depths, connection state, type names)
+	/// are stripped to prevent information leakage.
+	pub fn client_message(&self) -> &'static str {
+		match self {
+			Self::Connection(_) => "Connection error",
+			Self::Send(_) => "Failed to send message",
+			Self::Receive(_) => "Failed to receive message",
+			Self::Protocol(_) => "Protocol error",
+			Self::Internal(_) => "Internal server error",
+			Self::Timeout(_) => "Connection timed out",
+			Self::ReconnectFailed(_) => "Reconnection failed",
+		}
+	}
+
+	/// Returns the internal detail message for logging purposes.
+	///
+	/// This MUST NOT be sent to clients as it may contain sensitive
+	/// internal state information.
+	pub fn internal_detail(&self) -> String {
+		match self {
+			Self::Connection(msg) => format!("Connection error: {}", msg),
+			Self::Send(msg) => format!("Send error: {}", msg),
+			Self::Receive(msg) => format!("Receive error: {}", msg),
+			Self::Protocol(msg) => format!("Protocol error: {}", msg),
+			Self::Internal(msg) => format!("Internal error: {}", msg),
+			Self::Timeout(d) => format!("Connection timeout: idle for {:?}", d),
+			Self::ReconnectFailed(n) => format!("Reconnection failed after {} attempts", n),
+		}
+	}
 }
 
 pub type WebSocketResult<T> = Result<T, WebSocketError>;
@@ -846,10 +880,9 @@ impl ConnectionTimeoutMonitor {
 		if let Some(max) = self.config.max_connections
 			&& connections.len() >= max
 		{
-			return Err(WebSocketError::Connection(format!(
-				"maximum connection limit reached ({})",
-				max
-			)));
+			return Err(WebSocketError::Connection(
+				"maximum connection limit reached".to_string(),
+			));
 		}
 
 		connections.insert(connection.id().to_string(), connection);

--- a/crates/reinhardt-websockets/src/consumers.rs
+++ b/crates/reinhardt-websockets/src/consumers.rs
@@ -158,21 +158,13 @@ impl ConsumerContext {
 		T: Injectable + Clone + Send + Sync + 'static,
 	{
 		let ctx = self.di_context.as_ref().ok_or_else(|| {
-			WebSocketError::Internal(
-				"DI context not set. Ensure the WebSocket router is configured with DI".to_string(),
-			)
+			WebSocketError::Internal("DI context not available".to_string())
 		})?;
 
 		Injected::<T>::resolve(ctx)
 			.await
 			.map(|injected| injected.into_inner())
-			.map_err(|e| {
-				WebSocketError::Internal(format!(
-					"Dependency injection failed for {}: {:?}",
-					std::any::type_name::<T>(),
-					e
-				))
-			})
+			.map_err(|_| WebSocketError::Internal("dependency resolution failed".to_string()))
 	}
 
 	/// Resolve a dependency without caching
@@ -197,21 +189,13 @@ impl ConsumerContext {
 		T: Injectable + Clone + Send + Sync + 'static,
 	{
 		let ctx = self.di_context.as_ref().ok_or_else(|| {
-			WebSocketError::Internal(
-				"DI context not set. Ensure the WebSocket router is configured with DI".to_string(),
-			)
+			WebSocketError::Internal("DI context not available".to_string())
 		})?;
 
 		Injected::<T>::resolve_uncached(ctx)
 			.await
 			.map(|injected| injected.into_inner())
-			.map_err(|e| {
-				WebSocketError::Internal(format!(
-					"Dependency injection failed for {}: {:?}",
-					std::any::type_name::<T>(),
-					e
-				))
-			})
+			.map_err(|_| WebSocketError::Internal("dependency resolution failed".to_string()))
 	}
 
 	/// Try to resolve a dependency, returning None if DI context is not available

--- a/crates/reinhardt-websockets/src/middleware.rs
+++ b/crates/reinhardt-websockets/src/middleware.rs
@@ -13,11 +13,11 @@ pub type MiddlewareResult<T> = Result<T, MiddlewareError>;
 /// Middleware errors
 #[derive(Debug, thiserror::Error)]
 pub enum MiddlewareError {
-	#[error("Connection rejected: {0}")]
+	#[error("Connection rejected")]
 	ConnectionRejected(String),
-	#[error("Message rejected: {0}")]
+	#[error("Message rejected")]
 	MessageRejected(String),
-	#[error("Middleware error: {0}")]
+	#[error("Middleware error")]
 	Error(String),
 }
 

--- a/crates/reinhardt-websockets/src/room.rs
+++ b/crates/reinhardt-websockets/src/room.rs
@@ -12,15 +12,15 @@ use tokio::sync::RwLock;
 /// Error types for room operations
 #[derive(Debug, thiserror::Error)]
 pub enum RoomError {
-	#[error("Client not found: {0}")]
+	#[error("Client not found")]
 	ClientNotFound(String),
-	#[error("Room not found: {0}")]
+	#[error("Room not found")]
 	RoomNotFound(String),
-	#[error("Client already exists: {0}")]
+	#[error("Client already exists")]
 	ClientAlreadyExists(String),
-	#[error("WebSocket error: {0}")]
+	#[error("WebSocket error")]
 	WebSocket(#[from] WebSocketError),
-	#[error("Metadata error: {0}")]
+	#[error("Metadata error")]
 	Metadata(String),
 }
 

--- a/crates/reinhardt-websockets/src/routing.rs
+++ b/crates/reinhardt-websockets/src/routing.rs
@@ -16,11 +16,11 @@ pub type RouteResult = Result<(), RouteError>;
 /// Routing errors
 #[derive(Debug, thiserror::Error)]
 pub enum RouteError {
-	#[error("Route not found: {0}")]
+	#[error("Route not found")]
 	NotFound(String),
-	#[error("Route already exists: {0}")]
+	#[error("Route already exists")]
 	AlreadyExists(String),
-	#[error("Invalid route pattern: {0}")]
+	#[error("Invalid route pattern")]
 	InvalidPattern(String),
 }
 

--- a/crates/reinhardt-websockets/src/throttling.rs
+++ b/crates/reinhardt-websockets/src/throttling.rs
@@ -31,11 +31,11 @@ use tokio::sync::RwLock;
 /// Throttling errors
 #[derive(Debug, thiserror::Error)]
 pub enum ThrottleError {
-	#[error("Rate limit exceeded: {0}")]
+	#[error("Rate limit exceeded")]
 	RateLimitExceeded(String),
-	#[error("Too many connections from {0}")]
+	#[error("Too many connections")]
 	TooManyConnections(String),
-	#[error("Connection rate exceeded for {0}")]
+	#[error("Connection rate exceeded")]
 	ConnectionRateExceeded(String),
 }
 


### PR DESCRIPTION
## Summary
- Sanitize WebSocket error messages to remove internal state information (#537)
- Replace implementation details with generic, safe descriptions in all error type Display impls
- Add `client_message()` / `internal_detail()` methods to `WebSocketError` for safe client-facing vs logging separation
- Remove internal details from compression, DI, connection manager, and routing errors

## Test plan
- [x] `cargo check -p reinhardt-websockets --all-features` passes
- [x] `cargo nextest run -p reinhardt-websockets --all-features` passes (262/262)

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)