### PR TITLE
security(http): use cryptographically random filenames for uploads

### DIFF
--- a/crates/reinhardt-http/Cargo.toml
+++ b/crates/reinhardt-http/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1.0", features = ["sync"] }
 percent-encoding = "2.3"
 reinhardt-core = {workspace = true, features = ["exception"]}
 tracing = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/reinhardt-http/src/upload.rs
+++ b/crates/reinhardt-http/src/upload.rs
@@ -395,15 +395,14 @@ impl FileUploadHandler {
 		self.handle_upload(field_name, filename, content)
 	}
 
-	/// Generate a unique filename
+	/// Generate a unique filename using a cryptographically random UUID v4
 	///
 	/// Extracts only the file extension from the original filename,
 	/// discarding the original name to prevent path traversal.
+	/// Uses UUID v4 (CSPRNG-based) instead of timestamps to prevent
+	/// predictable filename enumeration.
 	fn generate_unique_filename(&self, field_name: &str, original_filename: &str) -> String {
-		let timestamp = std::time::SystemTime::now()
-			.duration_since(std::time::UNIX_EPOCH)
-			.unwrap()
-			.as_secs();
+		let unique_id = uuid::Uuid::new_v4();
 
 		// Extract only the extension from the basename (strip any directory components)
 		let basename = Path::new(original_filename)
@@ -417,9 +416,9 @@ impl FileUploadHandler {
 			.unwrap_or("");
 
 		if extension.is_empty() {
-			format!("{}_{}", field_name, timestamp)
+			format!("{}_{}", field_name, unique_id)
 		} else {
-			format!("{}_{}.{}", field_name, timestamp, extension)
+			format!("{}_{}.{}", field_name, unique_id, extension)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Replace predictable timestamp-based filenames with UUID v4 (CSPRNG-based) in `FileUploadHandler::generate_unique_filename`
- Prevents filename enumeration attacks where an attacker could guess uploaded file paths based on timestamp patterns

## Changes
- `crates/reinhardt-http/src/upload.rs`: Replace `SystemTime` timestamp with `uuid::Uuid::new_v4()` for filename generation
- `crates/reinhardt-http/Cargo.toml`: Add `uuid` workspace dependency

Closes #386

## Test plan
- [x] `cargo check -p reinhardt-http --all-features` passes
- [x] `cargo nextest run -p reinhardt-http --all-features` passes (165 tests)
- [ ] Verify generated filenames contain UUID v4 format instead of timestamps