### PR TITLE
security(auth): use server secret as HMAC key material in session auth hash

### DIFF
--- a/tests/integration/tests/auth/base_user_integration.rs
+++ b/tests/integration/tests/auth/base_user_integration.rs
@@ -32,9 +32,10 @@ async fn test_default_user_with_password() {
 	assert!(!user.check_password("wrongpass").unwrap());
 
 	// Test session auth hash
-	let hash1 = user.get_session_auth_hash();
+	let secret = "test-server-secret-key";
+	let hash1 = user.get_session_auth_hash(secret);
 	user.set_password("newpassword").unwrap();
-	let hash2 = user.get_session_auth_hash();
+	let hash2 = user.get_session_auth_hash(secret);
 	assert_ne!(hash1, hash2);
 }
 


### PR DESCRIPTION
## Summary
- Changed `get_session_auth_hash()` to require a `secret` parameter instead of using predictable username-based HMAC key material
- HMAC key now uses a server-side secret (e.g., `SECRET_KEY`) combined with a domain separator (`reinhardt.auth.session_hash:`)
- Updated integration tests to pass the secret parameter

## Motivation
The previous implementation used `username_field:username` as the HMAC key, which is predictable if an attacker knows the username. This made session auth hashes vulnerable to forgery. Django's equivalent uses `settings.SECRET_KEY` as HMAC key material.

## Breaking Change
`get_session_auth_hash()` now requires a `&str` secret parameter. Callers must update to provide their server secret key.

Closes #352

## Test plan
- [x] `cargo nextest run -p reinhardt-auth --all-features` (793 tests passed)
- [x] Integration tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)