### PR TITLE
security(commands): replace hardcoded default secret key with random generation

### DIFF
--- a/crates/reinhardt-commands/src/bin/runserver.rs
+++ b/crates/reinhardt-commands/src/bin/runserver.rs
@@ -161,7 +161,7 @@ fn load_settings() -> Settings {
 				.with_value("debug", serde_json::json!(true))
 				.with_value(
 					"secret_key",
-					serde_json::json!("insecure-dev-key-change-in-production"),
+					serde_json::json!(generate_random_secret_key()),
 				)
 				.with_value("allowed_hosts", serde_json::json!([]))
 				.with_value("installed_apps", serde_json::json!([]))
@@ -367,6 +367,24 @@ fn generate_self_signed_cert() -> Result<
 		vec![rustls::pki_types::CertificateDer::from(cert_der)],
 		rustls::pki_types::PrivateKeyDer::try_from(key_der)?,
 	))
+}
+
+/// Generate a cryptographically random secret key for fallback use.
+///
+/// Produces a 50-character hex string (200 bits of entropy). This is used
+/// as the default `SECRET_KEY` when no explicit key is configured, ensuring
+/// that each process gets a unique key rather than a shared hardcoded value.
+fn generate_random_secret_key() -> String {
+	use rand::Rng;
+	use std::fmt::Write;
+
+	let mut rng = rand::thread_rng();
+	let bytes: [u8; 25] = rng.r#gen();
+	let mut hex_string = String::with_capacity(50);
+	for b in bytes {
+		let _ = write!(hex_string, "{:02x}", b);
+	}
+	hex_string
 }
 
 #[tokio::main]

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -510,6 +510,10 @@ async fn execute_collectstatic(
 	let base_dir = env::current_dir().expect("Failed to get current directory");
 	let settings_dir = base_dir.join("settings");
 
+	// Generate a random secret key for the default to avoid shipping a
+	// hardcoded value that could be reused across deployments.
+	let default_secret_key = generate_random_secret_key();
+
 	let merged = SettingsBuilder::new()
 		.profile(profile)
 		.add_source(
@@ -526,7 +530,7 @@ async fn execute_collectstatic(
 				.with_value("debug", Value::Bool(true))
 				.with_value(
 					"secret_key",
-					Value::String("insecure-dev-key-change-in-production".to_string()),
+					Value::String(default_secret_key),
 				)
 				.with_value("allowed_hosts", Value::Array(vec![]))
 				.with_value("installed_apps", Value::Array(vec![]))
@@ -795,4 +799,22 @@ async fn auto_register_router() -> Result<(), Box<dyn std::error::Error>> {
 async fn auto_register_router() -> Result<(), Box<dyn std::error::Error>> {
 	// No router registration needed when routers feature is disabled
 	Ok(())
+}
+
+/// Generate a cryptographically random secret key for fallback use.
+///
+/// Produces a 50-character hex string (200 bits of entropy). This is used
+/// as the default `SECRET_KEY` when no explicit key is configured, ensuring
+/// that each process gets a unique key rather than a shared hardcoded value.
+fn generate_random_secret_key() -> String {
+	use rand::Rng;
+	use std::fmt::Write;
+
+	let mut rng = rand::thread_rng();
+	let bytes: [u8; 25] = rng.r#gen();
+	let mut hex_string = String::with_capacity(50);
+	for b in bytes {
+		let _ = write!(hex_string, "{:02x}", b);
+	}
+	hex_string
 }


### PR DESCRIPTION
## Summary
- Replaced hardcoded `"insecure-dev-key-change-in-production"` default `SECRET_KEY` with a cryptographically random key generated at startup
- Applied to both `cli.rs` (collectstatic command) and `runserver.rs` (development server)
- Each process now generates a unique 200-bit random key (50 hex characters) when no explicit key is configured

## Motivation
The hardcoded default secret key meant all deployments without explicit configuration shared the same key. If this default was accidentally left in production, attackers could forge session cookies, CSRF tokens, or other cryptographic signatures.

Closes #384

## Test plan
- [x] `cargo nextest run -p reinhardt-commands --all-features` (767 tests passed)
- [x] `cargo check -p reinhardt-commands --all-features` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)