### PR TITLE
security(grpc): add built-in DoS protection mechanisms

### DIFF
--- a/crates/reinhardt-grpc/src/lib.rs
+++ b/crates/reinhardt-grpc/src/lib.rs
@@ -8,7 +8,7 @@
 //! - GraphQL over gRPC types (GraphQLRequest, GraphQLResponse, SubscriptionEvent)
 //! - gRPC error handling with production-safe error sanitization
 //! - gRPC service adapter trait
-//! - Server configuration with message size limits
+//! - Server configuration with message size limits, request timeouts, and connection limits
 //! - Protobuf message nesting depth limits
 //! - Protobuf field constraint validation
 //! - Dependency injection support (with `di` feature)


### PR DESCRIPTION
## Summary
- Add `request_timeout` (default 30s) and `max_concurrent_connections` (default 1000) to `GrpcServerConfig`
- Add `max_message_size()` convenience accessor aliasing `max_decoding_message_size()`
- Add `max_message_size()` builder method that sets both encoding and decoding limits
- Document tower middleware integration for applying timeouts via `TimeoutLayer` and concurrency limits via `ConcurrencyLimitLayer`

## Test plan
- [x] All 114 existing tests pass with `--all-features`
- [x] New tests for default timeout (30s) and connection limit (1000)
- [x] Test `max_message_size` alias returns decoding size
- [x] Test builder sets all custom values independently
- [x] Test `max_message_size()` builder sets both encoding and decoding
- [x] Test clone preserves all new fields
- [x] Test builder defaults match config defaults for new fields

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)