### PR TITLE
security(dispatch): add middleware chain depth limit

### DIFF
--- a/crates/reinhardt-dispatch/src/lib.rs
+++ b/crates/reinhardt-dispatch/src/lib.rs
@@ -117,6 +117,7 @@
 //! // Wrap with middleware
 //! let handler = MiddlewareChain::new(base_handler)
 //!     .add_middleware(Arc::new(LoggingMiddleware))
+//!     .expect("Failed to add middleware")
 //!     .build();
 //!
 //! // Use the handler

--- a/crates/reinhardt-dispatch/src/middleware.rs
+++ b/crates/reinhardt-dispatch/src/middleware.rs
@@ -1,14 +1,19 @@
 //! Middleware system for request/response processing pipeline.
 
-use reinhardt_core::exception::Result;
+use reinhardt_core::exception::{Error, Result};
 use reinhardt_http::{Handler, Request, Response};
 use reinhardt_middleware::Middleware;
 use std::sync::Arc;
+
+/// Default maximum number of middleware components in a chain.
+const DEFAULT_MAX_MIDDLEWARE_DEPTH: usize = 256;
 
 /// A middleware chain that composes multiple middleware components with a handler.
 pub struct MiddlewareChain {
 	handler: Arc<dyn Handler>,
 	middlewares: Vec<Arc<dyn Middleware>>,
+	/// Maximum number of middleware components allowed in the chain.
+	max_depth: usize,
 }
 
 impl MiddlewareChain {
@@ -17,13 +22,28 @@ impl MiddlewareChain {
 		Self {
 			handler,
 			middlewares: Vec::new(),
+			max_depth: DEFAULT_MAX_MIDDLEWARE_DEPTH,
 		}
 	}
 
-	/// Adds a middleware to the chain.
-	pub fn add_middleware(mut self, middleware: Arc<dyn Middleware>) -> Self {
-		self.middlewares.push(middleware);
+	/// Sets the maximum number of middleware components allowed in the chain.
+	pub fn with_max_depth(mut self, max_depth: usize) -> Self {
+		self.max_depth = max_depth;
 		self
+	}
+
+	/// Adds a middleware to the chain.
+	///
+	/// Returns an error if adding the middleware would exceed the maximum depth.
+	pub fn add_middleware(mut self, middleware: Arc<dyn Middleware>) -> Result<Self> {
+		if self.middlewares.len() >= self.max_depth {
+			return Err(Error::ImproperlyConfigured(format!(
+				"middleware chain depth limit exceeded (max: {})",
+				self.max_depth
+			)));
+		}
+		self.middlewares.push(middleware);
+		Ok(self)
 	}
 
 	/// Builds the final handler by composing all middleware.


### PR DESCRIPTION
## Summary

- Add a configurable maximum depth limit (default: 256) to `MiddlewareChain` to prevent unbounded middleware chain growth that could lead to stack overflow
- `add_middleware` now returns `Result` and rejects additions exceeding the limit with `Error::ImproperlyConfigured`
- Added `with_max_depth` builder method for custom depth configuration
- Updated all existing integration tests and doc examples for the new `Result` return type

## Test plan

- [x] All existing 34 tests pass
- [x] 3 new tests: depth limit enforcement, default limit (256), custom limit
- [x] Doc tests pass
- [x] `cargo check --package reinhardt-dispatch --all-features` passes

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)