### PR TITLE
fix(shortcuts): fix data integrity in render_to_string and sanitize 404 errors

### DIFF
--- a/crates/reinhardt-shortcuts/src/lib.rs
+++ b/crates/reinhardt-shortcuts/src/lib.rs
@@ -11,9 +11,9 @@
 //! use reinhardt_shortcuts::{render_json, render_html, render_text};
 //! use serde_json::json;
 //!
-//! // Render JSON response
+//! // Render JSON response (returns Result to ensure atomic output on error)
 //! let data = json!({"status": "success"});
-//! let response = render_json(&data);
+//! let response = render_json(&data).unwrap();
 //!
 //! // Render HTML response
 //! let response = render_html("<h1>Hello</h1>");

--- a/crates/reinhardt-shortcuts/src/orm.rs
+++ b/crates/reinhardt-shortcuts/src/orm.rs
@@ -56,7 +56,8 @@ where
 
 	// Execute the query - await the async result
 	let results = queryset.all().await.map_err(|e| {
-		eprintln!("Database query error in get_object_or_404: {:?}", e);
+		// Log the full error server-side only; never expose it in the HTTP response
+		tracing::error!("Database query error in get_object_or_404: {:?}", e);
 		Response::internal_server_error()
 	})?;
 
@@ -111,7 +112,8 @@ where
 {
 	// Execute the query - await the async result
 	let results = queryset.all().await.map_err(|e| {
-		eprintln!("Database query error in get_list_or_404: {:?}", e);
+		// Log the full error server-side only; never expose it in the HTTP response
+		tracing::error!("Database query error in get_list_or_404: {:?}", e);
 		Response::internal_server_error()
 	})?;
 

--- a/crates/reinhardt-shortcuts/src/render.rs
+++ b/crates/reinhardt-shortcuts/src/render.rs
@@ -6,10 +6,13 @@ use bytes::Bytes;
 use reinhardt_http::Response;
 use serde::Serialize;
 
-/// Render data as JSON and return an HTTP 200 response
+/// Render data as JSON and return an HTTP 200 response, or an error if serialization fails
 ///
 /// This is a convenient shortcut for creating JSON responses without needing
 /// to manually create Response objects and set headers.
+///
+/// Returns an error instead of partial output if serialization fails, ensuring
+/// the caller always receives either a fully valid response or a clear error.
 ///
 /// # Examples
 ///
@@ -22,7 +25,7 @@ use serde::Serialize;
 ///     "message": "Hello, world!"
 /// });
 ///
-/// let response = render_json(&data);
+/// let response = render_json(&data).unwrap();
 /// ```
 ///
 /// # Arguments
@@ -31,9 +34,14 @@ use serde::Serialize;
 ///
 /// # Returns
 ///
-/// A `Response` with HTTP 200 status, JSON content-type, and the serialized data as body.
-pub fn render_json<T: Serialize>(data: &T) -> Response {
-	let json_string = serde_json::to_string(data).unwrap_or_else(|_| "{}".to_string());
+/// Either a `Response` with HTTP 200 status, JSON content-type, and the serialized data as body,
+/// or a `serde_json::Error` if serialization fails.
+///
+/// # Errors
+///
+/// Returns `Err(serde_json::Error)` if the data cannot be serialized to JSON.
+pub fn render_json<T: Serialize>(data: &T) -> Result<Response, serde_json::Error> {
+	let json_string = serde_json::to_string(data)?;
 
 	let mut response = Response::ok();
 	response.body = Bytes::from(json_string);
@@ -41,12 +49,15 @@ pub fn render_json<T: Serialize>(data: &T) -> Response {
 		.headers
 		.insert("content-type", "application/json".parse().unwrap());
 
-	response
+	Ok(response)
 }
 
-/// Render data as JSON with pretty printing and return an HTTP 200 response
+/// Render data as JSON with pretty printing and return an HTTP 200 response, or an error if serialization fails
 ///
 /// Same as `render_json` but with pretty-printed output (indented).
+///
+/// Returns an error instead of partial output if serialization fails, ensuring
+/// the caller always receives either a fully valid response or a clear error.
 ///
 /// # Examples
 ///
@@ -55,10 +66,14 @@ pub fn render_json<T: Serialize>(data: &T) -> Response {
 /// use serde_json::json;
 ///
 /// let data = json!({"key": "value"});
-/// let response = render_json_pretty(&data);
+/// let response = render_json_pretty(&data).unwrap();
 /// ```
-pub fn render_json_pretty<T: Serialize>(data: &T) -> Response {
-	let json_string = serde_json::to_string_pretty(data).unwrap_or_else(|_| "{}".to_string());
+///
+/// # Errors
+///
+/// Returns `Err(serde_json::Error)` if the data cannot be serialized to JSON.
+pub fn render_json_pretty<T: Serialize>(data: &T) -> Result<Response, serde_json::Error> {
+	let json_string = serde_json::to_string_pretty(data)?;
 
 	let mut response = Response::ok();
 	response.body = Bytes::from(json_string);
@@ -66,7 +81,7 @@ pub fn render_json_pretty<T: Serialize>(data: &T) -> Response {
 		.headers
 		.insert("content-type", "application/json".parse().unwrap());
 
-	response
+	Ok(response)
 }
 
 /// Render a simple HTML string and return an HTTP 200 response
@@ -133,13 +148,18 @@ pub fn render_text(text: impl Into<String>) -> Response {
 mod tests {
 	use super::*;
 	use hyper::StatusCode;
+	use rstest::rstest;
 	use serde_json::json;
 
-	#[test]
+	#[rstest]
 	fn test_render_json() {
+		// Arrange
 		let data = json!({"name": "test", "value": 123});
-		let response = render_json(&data);
 
+		// Act
+		let response = render_json(&data).expect("render_json should succeed for valid data");
+
+		// Assert
 		assert_eq!(response.status, StatusCode::OK);
 		assert_eq!(
 			response
@@ -150,29 +170,85 @@ mod tests {
 				.unwrap(),
 			"application/json"
 		);
-
 		let body_str = String::from_utf8(response.body.to_vec()).unwrap();
 		assert!(body_str.contains("test"));
 		assert!(body_str.contains("123"));
 	}
 
-	#[test]
+	#[rstest]
 	fn test_render_json_pretty() {
+		// Arrange
 		let data = json!({"name": "test"});
-		let response = render_json_pretty(&data);
 
+		// Act
+		let response =
+			render_json_pretty(&data).expect("render_json_pretty should succeed for valid data");
+
+		// Assert
 		assert_eq!(response.status, StatusCode::OK);
 		let body_str = String::from_utf8(response.body.to_vec()).unwrap();
-
 		// Pretty printed JSON should have newlines
 		assert!(body_str.contains('\n'));
 	}
 
-	#[test]
+	#[rstest]
+	fn test_render_json_returns_err_on_unserializable_value() {
+		// Arrange - serde_json::Value::Number with f64::INFINITY cannot be serialized
+		let data = serde_json::Value::Number(
+			serde_json::Number::from_f64(f64::INFINITY).unwrap_or(serde_json::Number::from(0)),
+		);
+		// f64::INFINITY cannot be represented in JSON; fall back to a known-unserializable type
+		// by using a custom struct that fails serialization
+		struct AlwaysFails;
+		impl serde::Serialize for AlwaysFails {
+			fn serialize<S: serde::Serializer>(&self, _: S) -> Result<S::Ok, S::Error> {
+				Err(serde::ser::Error::custom("intentional failure"))
+			}
+		}
+		let bad_data = AlwaysFails;
+
+		// Act
+		let result = render_json(&bad_data);
+
+		// Assert - error is returned, no partial output is produced
+		assert!(
+			result.is_err(),
+			"render_json must return Err for unserializable data, not partial output"
+		);
+		// Suppress unused variable warning
+		let _ = data;
+	}
+
+	#[rstest]
+	fn test_render_json_pretty_returns_err_on_unserializable_value() {
+		// Arrange
+		struct AlwaysFails;
+		impl serde::Serialize for AlwaysFails {
+			fn serialize<S: serde::Serializer>(&self, _: S) -> Result<S::Ok, S::Error> {
+				Err(serde::ser::Error::custom("intentional failure"))
+			}
+		}
+		let bad_data = AlwaysFails;
+
+		// Act
+		let result = render_json_pretty(&bad_data);
+
+		// Assert - error is returned, no partial output is produced
+		assert!(
+			result.is_err(),
+			"render_json_pretty must return Err for unserializable data, not partial output"
+		);
+	}
+
+	#[rstest]
 	fn test_render_html() {
+		// Arrange
 		let html = "<h1>Title</h1><p>Content</p>";
+
+		// Act
 		let response = render_html(html);
 
+		// Assert
 		assert_eq!(response.status, StatusCode::OK);
 		assert_eq!(
 			response
@@ -183,16 +259,19 @@ mod tests {
 				.unwrap(),
 			"text/html; charset=utf-8"
 		);
-
 		let body_str = String::from_utf8(response.body.to_vec()).unwrap();
 		assert_eq!(body_str, "<h1>Title</h1><p>Content</p>");
 	}
 
-	#[test]
+	#[rstest]
 	fn test_render_text() {
+		// Arrange
 		let text = "Plain text content";
+
+		// Act
 		let response = render_text(text);
 
+		// Assert
 		assert_eq!(response.status, StatusCode::OK);
 		assert_eq!(
 			response
@@ -203,27 +282,28 @@ mod tests {
 				.unwrap(),
 			"text/plain; charset=utf-8"
 		);
-
 		let body_str = String::from_utf8(response.body.to_vec()).unwrap();
 		assert_eq!(body_str, "Plain text content");
 	}
 
-	#[test]
+	#[rstest]
 	fn test_render_json_with_custom_struct() {
+		// Arrange
 		#[derive(serde::Serialize)]
 		struct User {
 			name: String,
 			age: u32,
 		}
-
 		let user = User {
 			name: "Alice".to_string(),
 			age: 30,
 		};
 
-		let response = render_json(&user);
+		// Act
+		let response = render_json(&user).expect("render_json should succeed for User struct");
 		let body_str = String::from_utf8(response.body.to_vec()).unwrap();
 
+		// Assert
 		assert!(body_str.contains("Alice"));
 		assert!(body_str.contains("30"));
 	}


### PR DESCRIPTION
## Summary
- Ensure `render_json` and `render_json_pretty` return atomic output (no partial results on error) by returning `Result<Response, serde_json::Error>` instead of silently swallowing serialization errors with a fallback `{}`
- Sanitize `get_object_or_404` and `get_list_or_404` error responses by replacing `eprintln!` with `tracing::error!` so internal database error details are properly routed to structured server-side logs instead of stderr

Closes #727, closes #728

## Test plan
- [x] Existing tests pass (55/55)
- [x] New tests added for `render_json`/`render_json_pretty` error path verifying `Err` is returned for unserializable data
- [x] clippy clean
- [x] fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>