### PR TITLE
refactor(shortcuts): add security headers helper function

### DIFF
--- a/crates/reinhardt-shortcuts/src/lib.rs
+++ b/crates/reinhardt-shortcuts/src/lib.rs
@@ -66,17 +66,29 @@
 //! let html = renderer.render_page(&my_component);
 //! ```
 //!
+//! ### Security Headers
+//!
+//! ```
+//! use reinhardt_shortcuts::{render_html, security_headers};
+//!
+//! // Apply common security headers to any response
+//! let response = render_html("<h1>Hello</h1>");
+//! let response = security_headers(response);
+//! ```
+//!
 //! ## Implemented Features
 //!
 //! - ✅ JSON/HTML/Text response rendering
 //! - ✅ Redirect shortcuts (302, 301)
 //! - ✅ URL utilities
 //! - ✅ Database shortcuts (get_object_or_404, get_list_or_404)
+//! - ✅ Security headers helper (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, X-XSS-Protection)
 
 pub mod context;
 pub mod get_or_404;
 pub mod redirect;
 pub mod render;
+pub mod security_headers;
 pub mod url;
 
 // ORM integration (feature-gated)
@@ -91,6 +103,7 @@ pub use get_or_404::{
 pub use redirect::{redirect, redirect_permanent, redirect_permanent_to, redirect_to};
 pub use reinhardt_core::security::redirect::RedirectValidationError;
 pub use render::{render_html, render_json, render_json_pretty, render_text};
+pub use security_headers::security_headers;
 pub use url::{Url, UrlError};
 
 // Re-export ORM functions (feature-gated)

--- a/crates/reinhardt-shortcuts/src/security_headers.rs
+++ b/crates/reinhardt-shortcuts/src/security_headers.rs
@@ -1,0 +1,245 @@
+//! Security headers shortcut functions
+//!
+//! Provides a convenient function for applying common security-related HTTP response headers.
+//! These headers help protect against common web vulnerabilities such as MIME sniffing,
+//! clickjacking, and cross-site scripting.
+
+use reinhardt_http::Response;
+
+/// Apply common security headers to an HTTP response.
+///
+/// Sets the following headers on the response:
+///
+/// - `X-Content-Type-Options: nosniff` — Prevents MIME type sniffing, ensuring the browser
+///   respects the declared `Content-Type`.
+/// - `X-Frame-Options: DENY` — Blocks the response from being embedded in `<frame>`,
+///   `<iframe>`, or `<object>` elements, protecting against clickjacking attacks.
+/// - `Referrer-Policy: strict-origin-when-cross-origin` — Sends the full URL as the
+///   `Referer` header for same-origin requests, but only the origin for cross-origin
+///   requests. No `Referer` is sent for downgrades (HTTPS -> HTTP).
+/// - `X-XSS-Protection: 1; mode=block` — Enables the legacy XSS filter in older browsers
+///   and instructs them to block rather than sanitize detected attacks.
+///
+/// # Examples
+///
+/// ```
+/// use reinhardt_shortcuts::{render_html, security_headers};
+///
+/// let response = render_html("<h1>Hello</h1>");
+/// let response = security_headers(response);
+///
+/// assert_eq!(
+///     response.headers.get("x-content-type-options").unwrap().to_str().unwrap(),
+///     "nosniff"
+/// );
+/// assert_eq!(
+///     response.headers.get("x-frame-options").unwrap().to_str().unwrap(),
+///     "DENY"
+/// );
+/// assert_eq!(
+///     response.headers.get("referrer-policy").unwrap().to_str().unwrap(),
+///     "strict-origin-when-cross-origin"
+/// );
+/// assert_eq!(
+///     response.headers.get("x-xss-protection").unwrap().to_str().unwrap(),
+///     "1; mode=block"
+/// );
+/// ```
+///
+/// # Arguments
+///
+/// * `response` - The HTTP response to add security headers to.
+///
+/// # Returns
+///
+/// The same `Response` with security headers applied.
+pub fn security_headers(mut response: Response) -> Response {
+	response
+		.headers
+		.insert("x-content-type-options", "nosniff".parse().unwrap());
+	response
+		.headers
+		.insert("x-frame-options", "DENY".parse().unwrap());
+	response.headers.insert(
+		"referrer-policy",
+		"strict-origin-when-cross-origin".parse().unwrap(),
+	);
+	response
+		.headers
+		.insert("x-xss-protection", "1; mode=block".parse().unwrap());
+	response
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use hyper::StatusCode;
+	use rstest::rstest;
+
+	#[rstest]
+	fn test_security_headers_x_content_type_options() {
+		// Arrange
+		let response = Response::ok();
+
+		// Act
+		let response = security_headers(response);
+
+		// Assert
+		assert_eq!(
+			response
+				.headers
+				.get("x-content-type-options")
+				.unwrap()
+				.to_str()
+				.unwrap(),
+			"nosniff"
+		);
+	}
+
+	#[rstest]
+	fn test_security_headers_x_frame_options() {
+		// Arrange
+		let response = Response::ok();
+
+		// Act
+		let response = security_headers(response);
+
+		// Assert
+		assert_eq!(
+			response
+				.headers
+				.get("x-frame-options")
+				.unwrap()
+				.to_str()
+				.unwrap(),
+			"DENY"
+		);
+	}
+
+	#[rstest]
+	fn test_security_headers_referrer_policy() {
+		// Arrange
+		let response = Response::ok();
+
+		// Act
+		let response = security_headers(response);
+
+		// Assert
+		assert_eq!(
+			response
+				.headers
+				.get("referrer-policy")
+				.unwrap()
+				.to_str()
+				.unwrap(),
+			"strict-origin-when-cross-origin"
+		);
+	}
+
+	#[rstest]
+	fn test_security_headers_x_xss_protection() {
+		// Arrange
+		let response = Response::ok();
+
+		// Act
+		let response = security_headers(response);
+
+		// Assert
+		assert_eq!(
+			response
+				.headers
+				.get("x-xss-protection")
+				.unwrap()
+				.to_str()
+				.unwrap(),
+			"1; mode=block"
+		);
+	}
+
+	#[rstest]
+	fn test_security_headers_preserves_status_code() {
+		// Arrange
+		let response = Response::not_found();
+
+		// Act
+		let response = security_headers(response);
+
+		// Assert
+		assert_eq!(response.status, StatusCode::NOT_FOUND);
+	}
+
+	#[rstest]
+	fn test_security_headers_preserves_existing_headers() {
+		// Arrange
+		let mut response = Response::ok();
+		response
+			.headers
+			.insert("content-type", "text/html; charset=utf-8".parse().unwrap());
+
+		// Act
+		let response = security_headers(response);
+
+		// Assert
+		assert_eq!(
+			response
+				.headers
+				.get("content-type")
+				.unwrap()
+				.to_str()
+				.unwrap(),
+			"text/html; charset=utf-8"
+		);
+		// Security headers must also be present
+		assert!(response.headers.get("x-content-type-options").is_some());
+		assert!(response.headers.get("x-frame-options").is_some());
+		assert!(response.headers.get("referrer-policy").is_some());
+		assert!(response.headers.get("x-xss-protection").is_some());
+	}
+
+	#[rstest]
+	fn test_security_headers_all_four_headers_present() {
+		// Arrange
+		let response = Response::ok();
+
+		// Act
+		let response = security_headers(response);
+
+		// Assert - verify all four security headers are set
+		assert_eq!(
+			response
+				.headers
+				.get("x-content-type-options")
+				.unwrap()
+				.to_str()
+				.unwrap(),
+			"nosniff"
+		);
+		assert_eq!(
+			response
+				.headers
+				.get("x-frame-options")
+				.unwrap()
+				.to_str()
+				.unwrap(),
+			"DENY"
+		);
+		assert_eq!(
+			response
+				.headers
+				.get("referrer-policy")
+				.unwrap()
+				.to_str()
+				.unwrap(),
+			"strict-origin-when-cross-origin"
+		);
+		assert_eq!(
+			response
+				.headers
+				.get("x-xss-protection")
+				.unwrap()
+				.to_str()
+				.unwrap(),
+			"1; mode=block"
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Add `security_headers()` helper function to set common security response headers
- Sets X-Content-Type-Options: nosniff, X-Frame-Options: DENY, Referrer-Policy, and X-XSS-Protection
- Properly exported from the crate public API

Closes #733

## Test plan
- [x] New tests verify header values
- [x] clippy clean
- [x] fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>