### PR TITLE
security(deeplink): replace unwrap with expect for better panic diagnostics

### DIFF
--- a/crates/reinhardt-deeplink/src/endpoints/aasa.rs
+++ b/crates/reinhardt-deeplink/src/endpoints/aasa.rs
@@ -69,8 +69,8 @@ impl AasaHandler {
 
 	/// Returns the cached JSON content as a string slice.
 	pub fn json(&self) -> &str {
-		// SAFETY: JSON serialization always produces valid UTF-8
-		std::str::from_utf8(&self.cached_json).unwrap()
+		std::str::from_utf8(&self.cached_json)
+			.expect("cached_json was serialized from valid UTF-8 strings and cannot be invalid UTF-8")
 	}
 }
 

--- a/crates/reinhardt-deeplink/src/endpoints/assetlinks.rs
+++ b/crates/reinhardt-deeplink/src/endpoints/assetlinks.rs
@@ -69,8 +69,8 @@ impl AssetLinksHandler {
 
 	/// Returns the cached JSON content as a string slice.
 	pub fn json(&self) -> &str {
-		// SAFETY: JSON serialization always produces valid UTF-8
-		std::str::from_utf8(&self.cached_json).unwrap()
+		std::str::from_utf8(&self.cached_json)
+			.expect("cached_json was serialized from valid UTF-8 strings and cannot be invalid UTF-8")
 	}
 }
 

--- a/crates/reinhardt-deeplink/src/error.rs
+++ b/crates/reinhardt-deeplink/src/error.rs
@@ -116,7 +116,8 @@ pub fn validate_package_name(name: &str) -> Result<(), DeeplinkError> {
 		}
 
 		// Each segment must start with a letter
-		let first_char = segment.chars().next().unwrap();
+		let first_char = segment.chars().next()
+			.expect("segment is non-empty after the emptiness check above");
 		if !first_char.is_ascii_alphabetic() {
 			return Err(DeeplinkError::InvalidPackageName(name.to_string()));
 		}


### PR DESCRIPTION
## Summary
- Replace bare `.unwrap()` calls with `.expect()` containing descriptive invariant messages in `reinhardt-deeplink` non-test library code
- `AasaHandler::json()` and `AssetLinksHandler::json()`: explain that `cached_json` was serialized from valid UTF-8 strings
- `validate_package_name()` in `error.rs`: explain that the segment is guaranteed non-empty by the preceding check

## Test plan
- [x] `cargo check -p reinhardt-deeplink --all-features` passes
- [x] `cargo nextest run -p reinhardt-deeplink` passes (204/204 tests)
- [x] No new `todo!()` or `// TODO:` introduced

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)