### PR TITLE
security(admin-cli): fix file safety issues

### DIFF
--- a/crates/reinhardt-admin-cli/src/formatter.rs
+++ b/crates/reinhardt-admin-cli/src/formatter.rs
@@ -46,8 +46,16 @@ pub(crate) fn collect_rust_files(path: &PathBuf) -> Result<Vec<PathBuf>, String>
 		for entry in WalkDir::new(path)
 			.follow_links(false) // Do not follow symlinks to prevent symlink attacks
 			.into_iter()
-			.filter_map(|e| e.ok())
-		{
+			.filter_map(|result| match result {
+				Ok(entry) => Some(entry),
+				Err(e) => {
+					eprintln!(
+						"Warning: skipping directory entry due to error: {}",
+						e
+					);
+					None
+				}
+			}) {
 			let entry_path = entry.path();
 
 			// Skip symlinks entirely


### PR DESCRIPTION
## Summary

- Replace `Path::exists()` with `std::fs::metadata`/`symlink_metadata` for atomic checks in `find_project_root`, `find_rustfmt_config`, and `validate_config_path` (TOCTOU mitigation)
- Replace `filter_map(|e| e.ok())` with explicit error logging in directory walk to surface skipped entries
- Replace fragile `is_err()`+`unwrap()` with idiomatic `match` in cargo fmt result handling
- Move `.rs.bak` backup files from source directory to `/tmp` with restrictive `0o600` permissions via `create_secure_backup`
- Verified existing `check_file_size` guards already prevent DoS via oversized files

## Test plan

- [x] `cargo check -p reinhardt-admin-cli --all-features` passes
- [x] `cargo nextest run -p reinhardt-admin-cli` -- 70/70 tests pass
- [x] `cargo clippy -p reinhardt-admin-cli --all-features -- -D warnings` passes
- [x] Format check passes

Closes #639, #613, #612, #611, #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)