### PR TITLE
fix(reinhardt-test): fix TOCTOU port binding and missing sqlx pool workaround

### DIFF
--- a/crates/reinhardt-test/src/fixtures/resources.rs
+++ b/crates/reinhardt-test/src/fixtures/resources.rs
@@ -93,6 +93,7 @@ impl PostgresSuiteResource {
 				match PgPoolOptions::new()
 					.max_connections(5)
 					.acquire_timeout(Duration::from_secs(3))
+					.test_before_acquire(false) // sqlx v0.7+ bug workaround (issue #2885, #3241)
 					.connect(&database_url)
 					.await
 				{
@@ -213,6 +214,7 @@ impl MySqlSuiteResource {
 				match MySqlPoolOptions::new()
 					.max_connections(5)
 					.acquire_timeout(Duration::from_secs(3))
+					.test_before_acquire(false) // sqlx v0.7+ bug workaround (issue #2885, #3241)
 					.connect(&database_url)
 					.await
 				{


### PR DESCRIPTION
## Summary

- Add `test_before_acquire(false)` to `PostgresSuiteResource` and `MySqlSuiteResource` pool options in `fixtures/resources.rs`, matching the workaround already applied in `testcontainers.rs` fixtures (sqlx #2885, #3241)
- Fix TOCTOU race condition in `TestServerGuard::new` and `TestServerBuilder::build` by keeping the `TcpListener` alive and using it directly for the accept loop instead of dropping it and re-binding to the same port

## Related Issues

Closes #875, closes #874

## Note on #540

Issue #540 describes a TOCTOU race in `reinhardt-mail` connection pool using atomic check-then-increment pattern. However, the current implementation in `crates/reinhardt-mail/src/pooling.rs` uses `tokio::sync::Semaphore` which is inherently atomic and does not suffer from this race condition. No code change was needed for this issue.

## Test plan

- [x] `cargo check -p reinhardt-test` passes
- [x] `cargo check -p reinhardt-mail --all-features` passes
- [ ] Verify test server fixtures work correctly in integration tests
- [ ] Verify PostgresSuiteResource pool creation with `test_before_acquire(false)`