### PR TITLE
security(reinhardt-query): escape single quotes in Value::Char SQL literal

### DIFF
--- a/crates/reinhardt-query/src/value/core.rs
+++ b/crates/reinhardt-query/src/value/core.rs
@@ -221,7 +221,14 @@ impl Value {
 			Self::Float(None) => "NULL".to_string(),
 			Self::Double(Some(v)) => v.to_string(),
 			Self::Double(None) => "NULL".to_string(),
-			Self::Char(Some(v)) => format!("'{}'", v),
+			Self::Char(Some(v)) => {
+				// Escape single quotes by doubling them
+				if *v == '\'' {
+					"''''".to_string()
+				} else {
+					format!("'{}'", v)
+				}
+			}
 			Self::Char(None) => "NULL".to_string(),
 			Self::String(Some(v)) => {
 				// Escape single quotes by doubling them


### PR DESCRIPTION
## Summary
- Fix `Value::Char(Some(v))` in `to_sql_literal()` to escape single-quote characters by doubling them (`'` → `''`), consistent with the existing `Value::String` escaping behavior

## Closes
Closes #336

---
*Generated by [Claude Code](https://claude.ai/claude-code)*