### PR TITLE
fix(conf): add database URL scheme validation before connection attempts

### DIFF
--- a/crates/reinhardt-conf/src/settings/audit/backends/database.rs
+++ b/crates/reinhardt-conf/src/settings/audit/backends/database.rs
@@ -3,6 +3,7 @@
 //! This backend stores audit logs in a SQL database.
 
 use crate::settings::audit::{AuditBackend, AuditEvent, ChangeRecord, EventFilter, EventType};
+use crate::settings::database_config::validate_database_url_scheme;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use reinhardt_query::prelude::{
@@ -40,6 +41,8 @@ impl DatabaseAuditBackend {
 	/// # }
 	/// ```
 	pub async fn new(database_url: &str) -> Result<Self, String> {
+		validate_database_url_scheme(database_url)?;
+
 		let pool = AnyPool::connect(database_url)
 			.await
 			.map_err(|e| format!("Database connection failed: {}", e))?;

--- a/crates/reinhardt-conf/src/settings/backends/database.rs
+++ b/crates/reinhardt-conf/src/settings/backends/database.rs
@@ -63,6 +63,8 @@ use crate::settings::dynamic::{DynamicBackend, DynamicError, DynamicResult};
 #[cfg(feature = "dynamic-database")]
 use async_trait::async_trait;
 
+use crate::settings::database_config::validate_database_url_scheme;
+
 /// Database backend for runtime configuration changes
 ///
 /// This backend allows dynamic settings to be stored in and retrieved from SQL databases,
@@ -128,6 +130,8 @@ impl DatabaseBackend {
 	/// ```
 	#[cfg(feature = "dynamic-database")]
 	pub async fn new(connection_url: &str) -> Result<Self, String> {
+		validate_database_url_scheme(connection_url)?;
+
 		let pool = AnyPool::connect(connection_url)
 			.await
 			.map_err(|e| format!("Database connection error: {}", e))?;

--- a/crates/reinhardt-conf/src/settings/env_parser.rs
+++ b/crates/reinhardt-conf/src/settings/env_parser.rs
@@ -141,7 +141,7 @@ pub fn parse_database_url(url_str: &str) -> Result<DatabaseUrl, String> {
 	let scheme = url.scheme();
 	let engine = match scheme {
 		"postgresql" | "postgres" => "reinhardt.db.backends.postgresql",
-		"mysql" => "reinhardt.db.backends.mysql",
+		"mysql" | "mariadb" => "reinhardt.db.backends.mysql",
 		"sqlite" => "reinhardt.db.backends.sqlite3",
 		other => return Err(format!("Unsupported database scheme: {}", other)),
 	};
@@ -337,6 +337,17 @@ mod tests {
 	#[test]
 	fn test_parse_mysql() {
 		let db = parse_database_url("mysql://root:secret@127.0.0.1:3306/testdb").unwrap();
+		assert_eq!(db.engine, "reinhardt.db.backends.mysql");
+		assert_eq!(db.name, "testdb");
+		assert_eq!(db.user.unwrap(), "root");
+		assert_eq!(db.password.unwrap(), "secret");
+		assert_eq!(db.host.unwrap(), "127.0.0.1");
+		assert_eq!(db.port.unwrap(), 3306);
+	}
+
+	#[test]
+	fn test_parse_mariadb() {
+		let db = parse_database_url("mariadb://root:secret@127.0.0.1:3306/testdb").unwrap();
 		assert_eq!(db.engine, "reinhardt.db.backends.mysql");
 		assert_eq!(db.name, "testdb");
 		assert_eq!(db.user.unwrap(), "root");


### PR DESCRIPTION
## Summary
- Add `validate_database_url_scheme()` in `database_config.rs` to reject unrecognized URL schemes early
- Call validation in both `DatabaseBackend::new()` and `DatabaseAuditBackend::new()` before attempting connection
- Add `mariadb://` support to `parse_database_url()` in `env_parser.rs`
- Add 12 new tests (11 URL scheme validation + 1 mariadb parsing)

Closes #485

## Test plan
- [x] 11 parametrized tests for valid/invalid URL schemes pass
- [x] 1 new mariadb parsing test passes
- [x] All 116 reinhardt-conf tests pass