### PR TITLE
security(reinhardt-db): document raw SQL injection surface in query builder APIs

### DIFF
--- a/crates/reinhardt-db/src/backends/query_builder.rs
+++ b/crates/reinhardt-db/src/backends/query_builder.rs
@@ -217,6 +217,17 @@ impl OnConflictClause {
 	///
 	/// * `condition` - SQL condition expression
 	///
+	/// # Safety
+	///
+	/// This method embeds the `condition` string directly into the generated SQL
+	/// without any escaping or parameterization. The caller **must** ensure that
+	/// the input is trusted and not derived from user-controlled data.
+	///
+	/// # SQL Injection Risk
+	///
+	/// Passing unsanitized user input to this method will result in a SQL injection
+	/// vulnerability. Always use hardcoded or application-controlled expressions.
+	///
 	/// # Example
 	///
 	/// ```rust,ignore

--- a/crates/reinhardt-db/src/hybrid/expression.rs
+++ b/crates/reinhardt-db/src/hybrid/expression.rs
@@ -11,6 +11,18 @@ pub struct SqlExpression {
 impl SqlExpression {
 	/// Creates a new SQL expression from a string
 	///
+	/// # Safety
+	///
+	/// This method embeds the `sql` string directly into generated SQL without
+	/// any escaping or parameterization. The caller **must** ensure that the
+	/// input is trusted and not derived from user-controlled data.
+	///
+	/// # SQL Injection Risk
+	///
+	/// Passing unsanitized user input to this method will result in a SQL
+	/// injection vulnerability. Always use hardcoded or application-controlled
+	/// expressions.
+	///
 	/// # Examples
 	///
 	/// ```
@@ -27,6 +39,17 @@ impl SqlExpression {
 		Self { sql: sql.into() }
 	}
 	/// Creates a CONCAT SQL expression from multiple parts
+	///
+	/// # Safety
+	///
+	/// Each element in `parts` is embedded directly into the generated SQL
+	/// without escaping. The caller **must** ensure all parts are trusted
+	/// column names or SQL literals, not user-controlled data.
+	///
+	/// # SQL Injection Risk
+	///
+	/// Passing unsanitized user input in any element of `parts` will result
+	/// in a SQL injection vulnerability.
 	///
 	/// # Examples
 	///
@@ -47,6 +70,17 @@ impl SqlExpression {
 	}
 	/// Creates a LOWER SQL expression for case-insensitive operations
 	///
+	/// # Safety
+	///
+	/// The `column` argument is embedded directly into the generated SQL
+	/// without escaping. The caller **must** ensure it is a trusted column
+	/// name, not user-controlled data.
+	///
+	/// # SQL Injection Risk
+	///
+	/// Passing unsanitized user input as `column` will result in a SQL
+	/// injection vulnerability.
+	///
 	/// # Examples
 	///
 	/// ```
@@ -62,6 +96,17 @@ impl SqlExpression {
 	}
 	/// Creates an UPPER SQL expression for case-insensitive operations
 	///
+	/// # Safety
+	///
+	/// The `column` argument is embedded directly into the generated SQL
+	/// without escaping. The caller **must** ensure it is a trusted column
+	/// name, not user-controlled data.
+	///
+	/// # SQL Injection Risk
+	///
+	/// Passing unsanitized user input as `column` will result in a SQL
+	/// injection vulnerability.
+	///
 	/// # Examples
 	///
 	/// ```
@@ -76,6 +121,17 @@ impl SqlExpression {
 		}
 	}
 	/// Creates a COALESCE SQL expression to handle NULL values
+	///
+	/// # Safety
+	///
+	/// Both `column` and `default` are embedded directly into the generated SQL
+	/// without escaping. The caller **must** ensure both arguments are trusted
+	/// column names or SQL literals, not user-controlled data.
+	///
+	/// # SQL Injection Risk
+	///
+	/// Passing unsanitized user input as either argument will result in a SQL
+	/// injection vulnerability.
 	///
 	/// # Examples
 	///


### PR DESCRIPTION
## Summary
- Add explicit SQL injection risk warnings to `OnConflictClause::where_clause()` and `SqlExpression` raw methods
- Document that these APIs embed their string arguments directly into generated SQL and require trusted (non-user-controlled) input
- Add `# Safety` and `# SQL Injection Risk` doc sections to affected methods

## Closes
Closes #348

---
*Generated by [Claude Code](https://claude.ai/claude-code)*