### PR TITLE
fix(pages): store WebSocket closures in handle instead of leaking via forget()

### DIFF
--- a/crates/reinhardt-pages/src/component/into_page.rs
+++ b/crates/reinhardt-pages/src/component/into_page.rs
@@ -99,7 +99,11 @@ fn mount_inner(page: Page, parent: &Element) -> Result<(), MountError> {
 					)
 					.expect("Failed to add event listener");
 
-				// Prevent the closure from being dropped (memory leak, but intentional for app lifetime)
+				// Intentional memory leak: the closure must outlive the element's DOM
+			// lifetime. Since mount_inner creates closures in a recursive loop
+			// with no parent struct to store them, forget() is the practical
+			// choice here. For components with frequent mount/unmount cycles,
+			// consider using a lifecycle-managed approach instead.
 				closure.forget();
 			}
 


### PR DESCRIPTION
## Summary

- Store WebSocket event listener closures (`onopen`, `onmessage`, `onclose`, `onerror`) in a `WsClosures` struct held by `WebSocketHandle` instead of leaking them via `Closure::forget()`
- Closures are now properly dropped when the last `WebSocketHandle` clone is dropped, preventing memory leaks in long-running SPAs
- Retain `Closure::forget()` in `into_page.rs` mount logic with improved documentation explaining why it is necessary there (recursive loop with no parent struct)

## Test plan

- [x] Compilation check passed (`cargo check -p reinhardt-pages --all-features`)
- [x] All 4 websocket tests pass (`cargo nextest run -p reinhardt-pages`)
- [x] SSR no-op, connection state clone, message clone, and options default tests verified

Closes #604

---
*Generated with [Claude Code](https://claude.ai/code)*

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>