### PR TITLE
fix(reinhardt-urls): add memory-bounded eviction to LRU route cache

### DIFF
--- a/crates/reinhardt-urls/src/routers/cache.rs
+++ b/crates/reinhardt-urls/src/routers/cache.rs
@@ -40,6 +40,13 @@ pub type RouteCacheEntry = (String, HashMap<String, String>);
 /// This cache stores the results of path matching operations to avoid
 /// redundant regex matching and parameter extraction.
 ///
+/// # Memory Considerations
+///
+/// By default, the cache only enforces an entry count limit. If cached values
+/// vary significantly in size, actual memory consumption may exceed expectations.
+/// Use `with_max_memory` to set an additional memory byte limit that triggers
+/// eviction when the estimated total size exceeds the threshold.
+///
 /// # Thread Safety
 ///
 /// `RouteCache` uses a `Mutex` internally, making it safe to share
@@ -84,7 +91,30 @@ impl RouteCache {
 	/// ```
 	pub fn new(capacity: usize) -> Self {
 		Self {
-			inner: Arc::new(Mutex::new(LruCache::new(capacity))),
+			inner: Arc::new(Mutex::new(LruCache::new(capacity, None))),
+		}
+	}
+
+	/// Create a new route cache with entry count and memory byte limits
+	///
+	/// Entries are evicted when either the entry count or memory limit is exceeded.
+	///
+	/// # Arguments
+	///
+	/// * `capacity` - Maximum number of entries to cache
+	/// * `max_memory_bytes` - Maximum estimated memory usage in bytes
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use reinhardt_urls::routers::cache::RouteCache;
+	///
+	/// // Allow at most 1000 entries and ~1 MB of estimated memory
+	/// let cache = RouteCache::with_max_memory(1000, 1024 * 1024);
+	/// ```
+	pub fn with_max_memory(capacity: usize, max_memory_bytes: usize) -> Self {
+		Self {
+			inner: Arc::new(Mutex::new(LruCache::new(capacity, Some(max_memory_bytes)))),
 		}
 	}
 
@@ -198,6 +228,28 @@ impl RouteCache {
 		let inner = self.inner.lock().unwrap();
 		inner.capacity()
 	}
+
+	/// Get the estimated memory usage of cached entries in bytes
+	///
+	/// This is an approximation based on the string lengths of keys and values
+	/// stored in cache entries. It does not account for allocator overhead.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use reinhardt_urls::routers::cache::RouteCache;
+	/// use std::collections::HashMap;
+	///
+	/// let cache = RouteCache::new(100);
+	/// assert_eq!(cache.estimated_memory(), 0);
+	///
+	/// cache.put("/users/", ("users".to_string(), HashMap::new()));
+	/// assert!(cache.estimated_memory() > 0);
+	/// ```
+	pub fn estimated_memory(&self) -> usize {
+		let inner = self.inner.lock().unwrap();
+		inner.estimated_memory
+	}
 }
 
 impl std::fmt::Debug for RouteCache {
@@ -205,6 +257,7 @@ impl std::fmt::Debug for RouteCache {
 		f.debug_struct("RouteCache")
 			.field("capacity", &self.capacity())
 			.field("len", &self.len())
+			.field("estimated_memory", &self.estimated_memory())
 			.finish()
 	}
 }
@@ -215,19 +268,32 @@ impl std::fmt::Debug for RouteCache {
 /// for efficient O(log n) LRU eviction tracking.
 struct LruCache {
 	capacity: usize,
+	max_memory_bytes: Option<usize>,
+	estimated_memory: usize,
 	map: HashMap<String, (RouteCacheEntry, usize)>, // (entry, access_order)
 	heap: BinaryHeap<Reverse<(usize, String)>>,     // min-heap of (access_order, key)
 	access_counter: usize,
 }
 
 impl LruCache {
-	fn new(capacity: usize) -> Self {
+	fn new(capacity: usize, max_memory_bytes: Option<usize>) -> Self {
 		Self {
 			capacity,
+			max_memory_bytes,
+			estimated_memory: 0,
 			map: HashMap::new(),
 			heap: BinaryHeap::new(),
 			access_counter: 0,
 		}
+	}
+
+	/// Estimate the memory size of a cache entry (key + handler_id + params)
+	fn estimate_entry_size(key: &str, entry: &RouteCacheEntry) -> usize {
+		let mut size = key.len() + entry.0.len();
+		for (k, v) in &entry.1 {
+			size += k.len() + v.len();
+		}
+		size
 	}
 
 	fn get(&mut self, path: &str) -> Option<RouteCacheEntry> {
@@ -245,12 +311,25 @@ impl LruCache {
 	}
 
 	fn put(&mut self, path: String, entry: RouteCacheEntry) {
-		// If we're at capacity, evict the least recently used entry
-		if self.map.len() >= self.capacity && !self.map.contains_key(&path) {
+		let new_entry_size = Self::estimate_entry_size(&path, &entry);
+
+		// Remove old entry's memory contribution if overwriting
+		if let Some((old_entry, _)) = self.map.get(&path) {
+			self.estimated_memory -= Self::estimate_entry_size(&path, old_entry);
+		}
+
+		// Evict entries until we're within both count and memory limits
+		while !self.map.contains_key(&path) && self.map.len() >= self.capacity {
 			self.evict_lru();
+		}
+		if let Some(max_bytes) = self.max_memory_bytes {
+			while self.estimated_memory + new_entry_size > max_bytes && !self.map.is_empty() {
+				self.evict_lru();
+			}
 		}
 
 		self.access_counter += 1;
+		self.estimated_memory += new_entry_size;
 		self.heap.push(Reverse((self.access_counter, path.clone())));
 		self.map.insert(path, (entry, self.access_counter));
 	}
@@ -266,8 +345,10 @@ impl LruCache {
 			if let Some((_, current_access_time)) = self.map.get(&key)
 				&& *current_access_time == access_time
 			{
-				// This is the true LRU entry
-				self.map.remove(&key);
+				// This is the true LRU entry — subtract its memory before removing
+				if let Some((entry, _)) = self.map.remove(&key) {
+					self.estimated_memory -= Self::estimate_entry_size(&key, &entry);
+				}
 				return;
 			}
 			// Otherwise, this is a stale heap entry, continue to next
@@ -278,6 +359,7 @@ impl LruCache {
 		self.map.clear();
 		self.heap.clear();
 		self.access_counter = 0;
+		self.estimated_memory = 0;
 	}
 
 	fn len(&self) -> usize {
@@ -390,6 +472,44 @@ mod tests {
 		assert_eq!(cache.len(), 2);
 		assert!(cache.get("/users/").is_some());
 		assert!(cache.get("/posts/").is_some());
+	}
+
+	#[test]
+	fn test_route_cache_memory_bound_eviction() {
+		// Arrange - create a cache with a very small memory limit
+		let cache = RouteCache::with_max_memory(100, 50);
+
+		// Act - insert entries that exceed memory limit
+		let mut params = HashMap::new();
+		params.insert("long_key".to_string(), "long_value_data".to_string());
+		cache.put("/route1/", ("handler1".to_string(), params.clone()));
+		cache.put("/route2/", ("handler2".to_string(), params.clone()));
+
+		// Assert - the cache should have evicted the first entry to stay within memory
+		assert!(cache.len() <= 2);
+		assert!(cache.estimated_memory() <= 50 || cache.len() == 1);
+	}
+
+	#[test]
+	fn test_route_cache_estimated_memory_tracking() {
+		// Arrange
+		let cache = RouteCache::new(100);
+
+		// Assert - initially zero
+		assert_eq!(cache.estimated_memory(), 0);
+
+		// Act
+		cache.put("/users/", ("users".to_string(), HashMap::new()));
+		let mem_after_first = cache.estimated_memory();
+		assert!(mem_after_first > 0);
+
+		// Act - add another entry
+		cache.put("/posts/", ("posts".to_string(), HashMap::new()));
+		assert!(cache.estimated_memory() > mem_after_first);
+
+		// Act - clear
+		cache.clear();
+		assert_eq!(cache.estimated_memory(), 0);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary
- Add estimated memory tracking to `LruCache` with `estimated_memory` field
- Add `RouteCache::with_max_memory` constructor to set optional memory byte limit
- Evict additional LRU entries when estimated memory exceeds the configured limit
- Add `RouteCache::estimated_memory()` method for monitoring cache memory usage
- Document memory considerations in `RouteCache` struct docs

## Closes
Closes #433

---
*Generated by [Claude Code](https://claude.ai/claude-code)*