### PR TITLE
security(websockets): add authentication support for Redis channel layer

### DIFF
--- a/crates/reinhardt-websockets/Cargo.toml
+++ b/crates/reinhardt-websockets/Cargo.toml
@@ -52,6 +52,9 @@ redis = { version = "0.32.7", features = [
 # Metrics
 metrics = { version = "0.24", optional = true }
 
+# Logging
+tracing = { workspace = true }
+
 [dev-dependencies]
 tokio-test = "0.4"
 futures = { workspace = true }

--- a/crates/reinhardt-websockets/src/channels.rs
+++ b/crates/reinhardt-websockets/src/channels.rs
@@ -26,6 +26,8 @@ pub enum ChannelError {
 	GroupNotFound(String),
 	#[error("Serialization error: {0}")]
 	SerializationError(String),
+	#[error("Authentication required for Redis connection")]
+	AuthenticationRequired,
 }
 
 /// Channel message for distributed communication


### PR DESCRIPTION
## Summary

- Add Redis authentication configuration to prevent unauthorized access to the pub/sub channel layer in distributed WebSocket systems
- Add `password`, `username`, `tls`, and `require_auth` fields to `RedisConfig`
- Require authentication by default for security (`require_auth: true`)
- Add `ChannelError::AuthenticationRequired` variant
- Add warning logs for missing credentials at startup

## Changes

### `RedisConfig` Authentication Fields
- `password: Option<String>` - Redis password for authentication
- `username: Option<String>` - Redis username (Redis 6+ ACL)
- `tls: bool` - Enable TLS for secure connection
- `require_auth: bool` - Require authentication (default: true)

### Builder Methods
- `with_password(password: String)`
- `with_username(username: String)`
- `with_tls()`
- `with_require_auth(require: bool)`

### Validation
- `validate_auth()` method validates auth config before connecting
- Logs warning if auth is required but no password is configured
- Returns `ChannelError::AuthenticationRequired` error

## Security Impact

This change addresses the security vulnerability (SEC-WS-008) where unauthorized clients could connect to Redis and:
- Subscribe to WebSocket message channels
- Read messages from any channel
- Publish malicious messages to WebSocket consumers

Resolves: #520

## Test Plan

- [x] Unit tests for authentication validation
- [x] Unit tests for builder methods
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)