### PR TITLE
fix(ci): add permissions block and coverage to ci-success needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     # Run CI on PRs targeting any branch
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -103,6 +107,7 @@ jobs:
       - doc-test
       - examples-test
       - ui-test
+      - coverage
     steps:
       - name: Verify all required checks passed
         run: |
@@ -118,6 +123,7 @@ jobs:
             "${{ needs.doc-test.result }}"
             "${{ needs.examples-test.result }}"
             "${{ needs.ui-test.result }}"
+            "${{ needs.coverage.result }}"
           )
           for result in "${required_results[@]}"; do
             if [[ "$result" != "success" ]]; then


### PR DESCRIPTION
## Summary

- Add workflow-level permissions block (`contents: read`, `id-token: write`) to resolve startup_failure
- Add `coverage` job to `ci-success` needs list and verification script

## Motivation and Context

Since 2026-02-20, all CI workflows have been failing with `startup_failure`. Investigation revealed:

1. The repository's Actions permissions are set to "Read repository contents permission" (read-only)
2. The workflow uses `secrets: inherit` with jobs that access `secrets.DOCKERHUB_USERNAME`
3. GitHub Actions validates secret access permissions at startup
4. The read-only permissions block secret access, causing immediate failure

Adding explicit permissions at the workflow level allows proper secret access validation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Was This Tested

- Verified YAML syntax with actionlint (no errors)
- This PR itself will test if the fix resolves the startup_failure

## Related Issues

Refs #1260 (previous fix attempt that removed branch-up-to-date job)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)