### PR TITLE
ci(test-examples): run only on PRs instead of push/schedule

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -1,10 +1,8 @@
 name: Test Examples
 
 on:
-  push:
-    branches: [main]
-  schedule:
-    - cron: '0 9 * * *'  # 09:00 UTC daily
+  pull_request:
+  workflow_dispatch:
 
 env:
   RUST_BACKTRACE: 1
@@ -91,25 +89,3 @@ jobs:
       - name: Doc Test
         working-directory: examples/${{ matrix.example }}
         run: cargo test --doc --all-features
-
-  compatibility-report:
-    name: Compatibility Report
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
-    needs: [test-local-examples]
-    steps:
-      - name: Report Success
-        run: echo "✅ All examples compatible"
-
-      - name: Create Issue on Failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: 'Daily Compatibility Check Failed',
-              body: `Daily compatibility check failed. Please investigate.\n\nWorkflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`,
-              labels: ['compatibility', 'bug']
-            })


### PR DESCRIPTION
## Summary

- Replace `push: main` and `schedule` triggers with `pull_request` and `workflow_dispatch`
- Remove `compatibility-report` job (was schedule-only and no longer needed)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] CI/CD improvement

## Motivation and Context

The test-examples workflow was running on every push to main branch after PR merges, which was unnecessary since examples are already tested during PR review. This change makes the workflow only run during PRs and allows manual execution when needed.

## How Was This Tested

- Workflow syntax validated by push pre-check hooks
- Will be verified by this PR's CI run

## Checklist

- [x] Code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Labels to Apply

- ci-cd

🤖 Generated with [Claude Code](https://claude.com/claude-code)