### PR TITLE
ci: add semgrep rule and pre-commit hook for formatter placeholder detection

### DIFF
--- a/.semgrep/placeholder-check.yml
+++ b/.semgrep/placeholder-check.yml
@@ -1,0 +1,16 @@
+rules:
+  - id: rust-reinhardt-placeholder-macro
+    patterns:
+      - pattern-regex: "__reinhardt_placeholder__!\\("
+    message: >-
+      Formatter placeholder macro __reinhardt_placeholder__! found in source code.
+      This is an internal marker used by reinhardt-admin-cli during page! macro formatting.
+      The formatter should restore page!(...) calls before committing.
+      Run `cargo make fmt-page-only` to restore the original macros.
+    languages: [generic]
+    severity: ERROR
+    paths:
+      include:
+        - "*.rs"
+      exclude:
+        - "**/crates/reinhardt-admin-cli/**"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,12 @@ docker run --rm -v "$(pwd):/src" semgrep/semgrep semgrep scan --config .semgrep/
 docker run --rm -v "$(pwd):/src" semgrep/semgrep semgrep scan --config .semgrep/ --baseline-commit origin/main --error --metrics off
 ```
 
+**Placeholder Check (formatter artifact detection):**
+```bash
+# Check for __reinhardt_placeholder__! left in source files after page! macro formatting
+cargo make placeholder-check
+```
+
 **Database Tests:**
 ```bash
 # Database tests use TestContainers automatically (no external database needed)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -103,6 +103,16 @@ args = [
   "-D", "clippy::dbg_macro",
 ]
 
+[tasks.placeholder-check]
+description = "Check for formatter placeholder macros left in source files"
+script_runner = "sh"
+script = '''
+set -e
+echo "Scanning for __reinhardt_placeholder__! in source files..."
+docker run --rm -v "$(pwd):/src" semgrep/semgrep \
+  semgrep scan --config /src/.semgrep/placeholder-check.yml --error --metrics off /src
+'''
+
 [tasks.fmt-page-only]
 description = "Format page! macro DSL only (without rustfmt)"
 command = "cargo"

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Reinhardt pre-commit hook
+# Checks that formatter placeholder macros are not left in committed source files
+
+set -e
+
+# Check for __reinhardt_placeholder__! in staged Rust files (excluding reinhardt-admin-cli)
+STAGED_RS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.rs$' | grep -v '^crates/reinhardt-admin-cli/' || true)
+
+if [ -n "$STAGED_RS_FILES" ]; then
+    PLACEHOLDER_FILES=$(echo "$STAGED_RS_FILES" | xargs grep -l "__reinhardt_placeholder__!" 2>/dev/null || true)
+    if [ -n "$PLACEHOLDER_FILES" ]; then
+        echo ""
+        echo "❌ Formatter placeholder macro found in staged files!"
+        echo ""
+        echo "The following files contain __reinhardt_placeholder__!(...):"
+        echo "$PLACEHOLDER_FILES" | sed 's/^/  /'
+        echo ""
+        echo "This is an internal marker used by reinhardt-admin-cli during page! macro formatting."
+        echo "The formatter should restore page!(...) calls before committing."
+        echo "Run \`cargo make fmt-page-only\` to restore the original macros."
+        echo ""
+        exit 1
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Add semgrep rule to detect `__reinhardt_placeholder__!` macros left in source files after `page!` macro formatting
- Add pre-commit hook to prevent committing files containing the placeholder macro
- Add `cargo make placeholder-check` task for manual scanning
- Update `CLAUDE.md` with documentation for the new check command

## Type of Change

- [x] CI/CD changes

## Motivation and Context

The `reinhardt-admin-cli` formatter uses `__reinhardt_placeholder__!` internally to protect `page!(...)` macro calls during `rustfmt` processing. In rare cases (e.g., the formatter exits unexpectedly), these placeholders can remain in source files and be committed.

This change adds multiple layers of defense:
1. **Pre-commit hook**: Catches placeholder macros before they enter the git history
2. **Semgrep CI rule**: Detects any placeholder macros that slip through in PRs
3. **Manual check**: `cargo make placeholder-check` for on-demand scanning

Fixes #1297

## How Was This Tested?

- Verified semgrep rule correctly reports 0 findings on clean source files
- Pre-commit hook tested against staged files with and without placeholder macros
- `placeholder-check.yml` pattern validated with `semgrep --test`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Closes #1297

## Labels to Apply

### Type Label
- [x] `ci-cd` - CI/CD workflow changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)