### PR TITLE
fix(release): bump reinhardt-di-macros to v0.1.0-alpha.3 to skip yanked alpha.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -416,7 +416,7 @@ reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.
 reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.0-alpha.4" }
 
 # DI subcrates
-reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.1.0-alpha.2" }
+reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.1.0-alpha.3" }
 
 # REST subcrates
 reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.1.0-alpha.5" }

--- a/crates/reinhardt-di/macros/CHANGELOG.md
+++ b/crates/reinhardt-di/macros/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.2](https://github.com/kent8192/reinhardt-web/compare/reinhardt-di-macros@v0.1.0-alpha.1...reinhardt-di-macros@v0.1.0-alpha.2) - 2026-02-21
+## [0.1.0-alpha.3](https://github.com/kent8192/reinhardt-web/compare/reinhardt-di-macros@v0.1.0-alpha.2...reinhardt-di-macros@v0.1.0-alpha.3) - 2026-02-23
+
+### Fixed
+
+- *(release)* advance version to skip yanked alpha.2 and restore publish capability for dependents
+
+## [0.1.0-alpha.2](https://github.com/kent8192/reinhardt-web/compare/reinhardt-di-macros@v0.1.0-alpha.1...reinhardt-di-macros@v0.1.0-alpha.2) - 2026-02-21 [YANKED]
+
+This release was yanked shortly after publication. Use v0.1.0-alpha.3 instead.
 
 ### Fixed
 

--- a/crates/reinhardt-di/macros/Cargo.toml
+++ b/crates/reinhardt-di/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-di-macros"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Procedural macros for Reinhardt dependency injection"


### PR DESCRIPTION
## Summary

This PR addresses:

- Advance `reinhardt-di-macros` from `v0.1.0-alpha.2` (yanked) to `v0.1.0-alpha.3` to restore the Release CI pipeline

**Version Changes:**
- `crates/reinhardt-di/macros/Cargo.toml`: version `0.1.0-alpha.2` → `0.1.0-alpha.3`
- `Cargo.toml` (workspace): `reinhardt-di-macros` version `0.1.0-alpha.2` → `0.1.0-alpha.3`
- `crates/reinhardt-di/macros/CHANGELOG.md`: Add `alpha.3` entry and mark `alpha.2` as `[YANKED]`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

`reinhardt-di-macros v0.1.0-alpha.2` was published and then yanked from crates.io. This created a deadlock (KI-3 pattern):

- `reinhardt-di v0.1.0-alpha.8` requires `reinhardt-di-macros = "^0.1.0-alpha.2"`
- cargo cannot resolve this requirement because the only matching version (`alpha.2`) is yanked
- The Release CI job fails permanently with: `version 0.1.0-alpha.2 is yanked`

Per `docs/RELEASE_PROCESS.md §RP-1`, the recovery procedure is to advance the local version to `alpha.3`, skipping the unusable yanked version. This is the same pattern applied for `reinhardt-macros alpha.3` in PR #1313.

Fixes #1314
Related to: #1312

## How Was This Tested?

- `cargo check --workspace --all --all-features` passes
- `cargo make fmt-check` passes (0 files would be formatted)
- `cargo make clippy-check` passes (no warnings)
- Pre-push hooks passed successfully

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Fixes #1314
- Refs #1312 (original release failure issue)
- Refs #1313 (same RP-1 fix for `reinhardt-macros`)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label
- [x] `high` - Important fix or feature

## Additional Context

### Post-Fix Expected Behavior

After merging this PR, `release-plz release` will:

1. Detect `reinhardt-di-macros` local=`alpha.3`, crates.io max=`alpha.2` (yanked)
2. Publish `reinhardt-di-macros v0.1.0-alpha.3` (non-yanked) via `release_always = true`
3. `reinhardt-di alpha.8` can then be published successfully
4. The Release PR job comparison error (rand duplicate key) will self-resolve once `reinhardt-rest alpha.16` is published

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)