### PR TITLE
fix(release): bump reinhardt-query-macros to v0.1.0-alpha.4 to skip yanked alpha.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -410,7 +410,7 @@ reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.0-alph
 reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-alpha.14" }
 
 # Query subcrates
-reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.1.0-alpha.3" }
+reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.1.0-alpha.4" }
 
 # Core subcrates
 reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.0-alpha.4" }

--- a/crates/reinhardt-query/macros/CHANGELOG.md
+++ b/crates/reinhardt-query/macros/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.3](https://github.com/kent8192/reinhardt-web/compare/reinhardt-query-macros@v0.1.0-alpha.2...reinhardt-query-macros@v0.1.0-alpha.3) - 2026-02-21
+## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-query-macros@v0.1.0-alpha.3...reinhardt-query-macros@v0.1.0-alpha.4) - 2026-02-23
+
+### Fixed
+
+- *(release)* advance version to skip yanked alpha.3 and restore publish capability for dependents
+
+## [0.1.0-alpha.3](https://github.com/kent8192/reinhardt-web/compare/reinhardt-query-macros@v0.1.0-alpha.2...reinhardt-query-macros@v0.1.0-alpha.3) - 2026-02-21 [YANKED]
+
+This release was yanked shortly after publication. Use v0.1.0-alpha.4 instead.
 
 ### Fixed
 

--- a/crates/reinhardt-query/macros/Cargo.toml
+++ b/crates/reinhardt-query/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query-macros"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Procedural macros for reinhardt-query SQL identifier derivation"


### PR DESCRIPTION
## Summary

- Bump `reinhardt-query-macros` from v0.1.0-alpha.3 to v0.1.0-alpha.4 to skip yanked version
- Mark alpha.3 as `[YANKED]` in CHANGELOG.md and add alpha.4 release entry
- Apply RP-1 (Partial Release Failure Recovery) procedure

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

CI run [22292903191](https://github.com/kent8192/reinhardt-web/actions/runs/22292903191) failed after merging PR #1315. The release job successfully published 31 crates but hit a **429 Too Many Requests** rate limit when attempting to publish `reinhardt-query-macros`. The retry step executed without delay, failing before the rate limit window expired.

`reinhardt-query-macros v0.1.0-alpha.3` was previously published and yanked on crates.io. Since yanked versions cannot be re-published, and future `reinhardt-query` releases requiring `reinhardt-query-macros = "^0.1.0-alpha.3"` would fail to resolve, this is a **KI-3 (Partial Release Failure Deadlock)** scenario.

Per RP-1 recovery procedure, we advance to alpha.4 to provide a non-yanked version that `release-plz release` can publish.

Fixes #1316

Related to: #1313, #1315

## How Was This Tested?

- [x] `cargo check --workspace --all --all-features` passes
- [x] `cargo make fmt-check` passes (0 errors, 2421 unchanged)
- [x] `cargo make clippy-check` passes
- [x] Pre-push hooks (fmt-check + clippy-check) pass

No code changes — only version bump and CHANGELOG update.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

Fixes #1316
Refs #1313, #1315

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

**Files changed:**
- `crates/reinhardt-query/macros/Cargo.toml`: version 0.1.0-alpha.3 → 0.1.0-alpha.4
- `Cargo.toml` (root): `reinhardt-query-macros` workspace dependency version 0.1.0-alpha.3 → 0.1.0-alpha.4
- `crates/reinhardt-query/macros/CHANGELOG.md`: Added alpha.4 entry, marked alpha.3 as [YANKED]

**Expected post-merge behavior:**
1. `release-plz release` detects local=alpha.4 vs crates.io max=alpha.3(yanked)
2. Publishes `reinhardt-query-macros v0.1.0-alpha.4` (non-yanked)
3. Creates tag `reinhardt-query-macros@v0.1.0-alpha.4`
4. Other 31 crates already published — skipped (no rate limit risk)
5. Release PR job also self-resolves (reinhardt-rest alpha.16 tag now exists)

**Precedent:** Same RP-1 recovery pattern as PR #1313 (reinhardt-macros) and PR #1315 (reinhardt-di-macros).

🤖 Generated with [Claude Code](https://claude.com/claude-code)