### PR TITLE
fix(release): roll back unpublished crate versions after partial release failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.18](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-alpha.17...reinhardt-web@v0.1.0-alpha.18) - 2026-02-23
-
-### Maintenance
-
-- *(license)* migrate from MIT/Apache-2.0 to BSD 3-Clause
-- *(workspace)* remove workspace dependency entries for nonexistent crates
-- *(workspace)* remove unpublished reinhardt-settings-cli and fix stale references
-
 ## [0.1.0-alpha.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-alpha.15...reinhardt-web@v0.1.0-alpha.16) - 2026-02-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.1.0-alpha.18"
+version = "0.1.0-alpha.17"
 edition.workspace = true
 license.workspace = true
 description = "A full-stack API framework for Rust, inspired by Django and Django REST Framework"
@@ -362,7 +362,7 @@ authors = ["kent8192 <51869472+kent8192@users.noreply.github.com>"]
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-alpha.18" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-alpha.17" }
 
 # Internal crates
 reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0-alpha.12" }
@@ -389,19 +389,19 @@ reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0-alpha.16" 
 reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-alpha.17" }
 reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-alpha.7" }
 reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0-alpha.3" }
-reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0-alpha.4" }
+reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0-alpha.3" }
 reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-alpha.20" }
 reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0-alpha.16" }
 reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.1.0-alpha.2" }
 reinhardt-query = { path = "crates/reinhardt-query", version = "0.1.0-alpha.5" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-alpha.14" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-alpha.13" }
 reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-alpha.13" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-alpha.7" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-alpha.6" }
 reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0-alpha.12" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-alpha.7" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-alpha.6" }
 reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0-alpha.15" }
 reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0-alpha.14" }
-reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.0-alpha.5" }
+reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.0-alpha.4" }
 reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-alpha.16" }
 
 # Query subcrates

--- a/crates/reinhardt-deeplink/CHANGELOG.md
+++ b/crates/reinhardt-deeplink/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-deeplink@v0.1.0-alpha.4...reinhardt-deeplink@v0.1.0-alpha.5) - 2026-02-23
-
-### Maintenance
-
-- *(license)* migrate from MIT/Apache-2.0 to BSD 3-Clause
-
 ## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-deeplink@v0.1.0-alpha.3...reinhardt-deeplink@v0.1.0-alpha.4) - 2026-02-16
 
 ### Maintenance

--- a/crates/reinhardt-deeplink/Cargo.toml
+++ b/crates/reinhardt-deeplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-deeplink"
-version.workspace = true
+version = "0.1.0-alpha.4"
 edition.workspace = true
 license.workspace = true
 description = "Mobile app deep linking with iOS Universal Links, Android App Links, and custom URL schemes"

--- a/crates/reinhardt-graphql/CHANGELOG.md
+++ b/crates/reinhardt-graphql/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.1.0-alpha.6...reinhardt-graphql@v0.1.0-alpha.7) - 2026-02-23
-
-### Maintenance
-
-- *(license)* migrate from MIT/Apache-2.0 to BSD 3-Clause
-
 ## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.1.0-alpha.5...reinhardt-graphql@v0.1.0-alpha.6) - 2026-02-21
 
 ### Fixed

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.6"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-graphql/macros/CHANGELOG.md
+++ b/crates/reinhardt-graphql/macros/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.4](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql-macros@v0.1.0-alpha.3...reinhardt-graphql-macros@v0.1.0-alpha.4) - 2026-02-23
-
-### Maintenance
-
-- *(license)* migrate from MIT/Apache-2.0 to BSD 3-Clause
-
 ## [0.1.0-alpha.3](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql-macros@v0.1.0-alpha.2...reinhardt-graphql-macros@v0.1.0-alpha.3) - 2026-02-21
 
 ### Fixed

--- a/crates/reinhardt-graphql/macros/Cargo.toml
+++ b/crates/reinhardt-graphql/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql-macros"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.3"
 description = "Procedural macros for GraphQL schema generation"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-i18n/CHANGELOG.md
+++ b/crates/reinhardt-i18n/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.1.0-alpha.6...reinhardt-i18n@v0.1.0-alpha.7) - 2026-02-23
-
-### Maintenance
-
-- updated the following local packages: reinhardt-di, reinhardt-di, reinhardt-utils
-
 ## [0.1.0-alpha.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.1.0-alpha.5...reinhardt-i18n@v0.1.0-alpha.6) - 2026-02-21
 
 ### Fixed

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.6"
 description = "Internationalization and localization support"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-shortcuts/CHANGELOG.md
+++ b/crates/reinhardt-shortcuts/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.14](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.1.0-alpha.13...reinhardt-shortcuts@v0.1.0-alpha.14) - 2026-02-23
-
-### Maintenance
-
-- *(license)* migrate from MIT/Apache-2.0 to BSD 3-Clause
-
 ## [0.1.0-alpha.13](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.1.0-alpha.12...reinhardt-shortcuts@v0.1.0-alpha.13) - 2026-02-23
 
 ### Maintenance

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.1.0-alpha.14"
+version = "0.1.0-alpha.13"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

Roll back 6 crate versions to match their published crates.io versions after release-plz publish failed with HTTP 429 (Too Many Requests). This follows the RP-1 (Partial Release Failure Recovery) procedure.

- Roll back version fields in Cargo.toml for 6 unpublished crates
- Remove unpublished CHANGELOG entries for 6 crates
- Update workspace dependency versions in root Cargo.toml
- Change reinhardt-deeplink from `version.workspace` to explicit version (reinhardt-query shares `workspace.package.version` and was successfully published)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

Release-plz workflow run #22300180397 failed with HTTP 429 (Too Many Requests) during the publication step after merging Release PR #1329. This left 6 crates with bumped versions in main but unpublished on crates.io, creating a KI-3 (Partial Release Failure Deadlock).

| Crate | Rolled Back From | Rolled Back To (crates.io) |
|-------|-----------------|---------------------------|
| `reinhardt-shortcuts` | 0.1.0-alpha.14 | 0.1.0-alpha.13 |
| `reinhardt-i18n` | 0.1.0-alpha.7 | 0.1.0-alpha.6 |
| `reinhardt-graphql-macros` | 0.1.0-alpha.4 | 0.1.0-alpha.3 |
| `reinhardt-graphql` | 0.1.0-alpha.7 | 0.1.0-alpha.6 |
| `reinhardt-deeplink` | 0.1.0-alpha.5 | 0.1.0-alpha.4 |
| `reinhardt-web` | 0.1.0-alpha.18 | 0.1.0-alpha.17 |

Fixes #1337

Related to: #1329, #1296

## How Was This Tested?

- [x] `cargo check --workspace --all --all-features` passes
- [x] All version fields match crates.io published versions
- [x] `reinhardt-deeplink` correctly resolves to 0.1.0-alpha.4

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/docs/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- #1337 - Partial release failure due to crates.io 429 rate limiting (KI-3)
- #1329 - Release PR that triggered the partial failure
- #1296 - Feature PR blocked by Release Dry-Run Check failure

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label
- [x] `critical` - Blocks release or major functionality

---

**Additional Context:**

This PR follows the RP-1 recovery procedure documented in `instructions/RELEASE_PROCESS.md`. After this PR is merged, release-plz will automatically detect the version discrepancies and create a new Release PR containing only the 6 unpublished crates with correct dependency versions.

Note: `reinhardt-deeplink` was changed from `version.workspace = true` to an explicit `version = "0.1.0-alpha.4"` because `reinhardt-query` (which also uses `version.workspace = true`) was successfully published at 0.1.0-alpha.5. Rolling back `[workspace.package].version` would have broken `reinhardt-query`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)