### PR TITLE
fix: add singular .example.tfvars exception to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ infra/**/*.tfstate
 infra/**/*.tfstate.backup
 infra/**/.terraform.tfstate.lock.info
 infra/**/*.tfvars
+!infra/**/*.example.tfvars
 !infra/**/*.examples.tfvars
 infra/**/backend.tfvars
 infra/github-runners/lambdas/*.zip


### PR DESCRIPTION
## Summary

- Add `!infra/**/*.example.tfvars` (singular) exception pattern to `.gitignore`
- Fixes release-plz `release-pr` job failure caused by `terraform.example.tfvars` being both committed and gitignored

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The release-plz `release-pr` job failed ([Run #22521983550](https://github.com/kent8192/reinhardt/actions/runs/22521983550)) because `infra/website/terraform.example.tfvars` was both committed to the repository and matched by `.gitignore`.

The `.gitignore` had `infra/**/*.tfvars` to ignore all tfvars files, with an exception `!infra/**/*.examples.tfvars` (plural). However, the committed file uses the singular form `terraform.example.tfvars`, which did not match the plural exception pattern.

Fixes #1442

## How Was This Tested?

- Verified with `git ls-files -ci --exclude-standard` returning empty output (no committed+ignored files)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)