### PR TITLE
fix(middleware): validate host header against allowed hosts in HTTPS redirect

### DIFF
--- a/crates/reinhardt-middleware/src/https_redirect.rs
+++ b/crates/reinhardt-middleware/src/https_redirect.rs
@@ -102,7 +102,7 @@ impl HttpsRedirectMiddleware {
 	///
 	/// ```
 	/// use std::sync::Arc;
-	/// use reinhardt_middleware::HttpsRedirectMiddleware;
+	/// use reinhardt_middleware::{HttpsRedirectConfig, HttpsRedirectMiddleware};
 	/// use reinhardt_http::{Handler, Middleware, Request, Response};
 	/// use hyper::{StatusCode, Method, Version, HeaderMap};
 	/// use bytes::Bytes;


### PR DESCRIPTION
## Summary

- Add `allowed_hosts` field to `HttpsRedirectConfig` for host header validation
- Validate HOST header against allowed hosts list before building redirect URL
- Reject requests with invalid, disallowed, or missing host headers with 400 Bad Request
- Prevent host header injection attacks in HTTPS redirect middleware

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The HTTPS redirect middleware used the HOST header directly in the redirect URL without any validation, allowing host header injection attacks. An attacker could manipulate the HOST header to redirect users to malicious sites.

Fixes #1513

## How Was This Tested?

- [x] `cargo nextest run -p reinhardt-middleware --lib https_redirect` - 9 tests pass
- [x] `cargo make fmt-check` passes
- [x] `cargo check -p reinhardt-middleware --all-features` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix
- [x] `security` - Security fix

### Scope Label
- [x] `http` - HTTP layer, handlers, middleware

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)