### PR TITLE
fix(views): replace std RwLock with parking_lot to prevent poisoning panics

### DIFF
--- a/crates/reinhardt-views/src/viewsets/handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler.rs
@@ -30,9 +30,9 @@ pub struct ViewSetHandler<V: ViewSet> {
 	has_handled_request: RwLock<bool>,
 }
 
-// SAFETY: parking_lot::RwLock does not use poisoning, so ViewSetHandler
+// parking_lot::RwLock does not use poisoning, so ViewSetHandler
 // remains safe to use across unwind boundaries.
-unsafe impl<V: ViewSet> std::panic::RefUnwindSafe for ViewSetHandler<V> {}
+impl<V: ViewSet> std::panic::RefUnwindSafe for ViewSetHandler<V> {}
 
 impl<V: ViewSet> ViewSetHandler<V> {
 	pub fn new(


### PR DESCRIPTION
## Summary

- Replace `std::sync::RwLock` with `parking_lot::RwLock` in `ViewSetHandler` to eliminate panics caused by lock poisoning
- Remove all `.unwrap()` calls on `read()`/`write()` since `parking_lot::RwLock` returns guards directly without `Result` wrapping
- Add unit tests verifying non-poisoning behavior and concurrent read access

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`ViewSetHandler` uses `std::sync::RwLock` which poisons the lock when a thread panics while holding it. Subsequent attempts to acquire the lock call `.unwrap()` on the poisoned `Result`, causing cascading panics that crash the entire application. `parking_lot::RwLock` does not implement lock poisoning, making it immune to this failure mode.

Fixes #1481

## How Was This Tested?

- `cargo nextest run --package reinhardt-views --all-features` - all 105 tests pass
- `cargo make fmt-check` - passes
- `cargo make clippy-check` - passes
- Added `test_parking_lot_rwlock_does_not_poison_after_panic` verifying lock remains usable after a panic
- Added `test_rwlock_concurrent_read_access` verifying multiple concurrent readers

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

Fixes #1481

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `api` - REST API, serializers, views

🤖 Generated with [Claude Code](https://claude.com/claude-code)