### PR TITLE
docs: add PR conflict resolution strategy and GitHub Discussions references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,18 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 - When merging branches and resolving conflicts, execute immediately without entering Plan Mode
 - Before creating branches, verify names don't conflict with existing ones using `git worktree list` and `git branch -a`
 
+**PR Conflict Resolution:**
+- **MUST** use worktree-based merge strategy for resolving PR conflicts (NOT rebase or force-push)
+- Procedure:
+  1. Create a local worktree for the PR source branch
+  2. Merge the target branch (e.g., `main`) into the source branch within the worktree
+  3. Resolve conflicts in the worktree
+  4. Commit the merge resolution
+  5. Push the source branch to remote
+  6. Clean up the worktree
+- **NEVER** use `git rebase` or `git push --force` to resolve PR conflicts
+- This preserves commit history and avoids force-push risks
+
 **GitHub Integration:**
 - **MUST** use GitHub CLI (`gh`) for all GitHub operations
 - Use `gh pr create` for creating pull requests
@@ -136,6 +148,9 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 - Use `gh issue create` for creating issues
 - Use `gh issue view` for viewing issue details
 - Use `gh api` for accessing GitHub API
+- Use `gh discussion list` for viewing discussions
+- Use `gh discussion create` for creating discussions
+- For usage questions, prefer GitHub Discussions over Issues
 - **NEVER** use raw `curl` or web browser for GitHub operations when `gh` is available
 - When GitHub MCP tools return errors (e.g., 404), immediately fall back to `gh` CLI instead of retrying
 
@@ -481,6 +496,7 @@ Before submitting code:
 - Check known CI failure patterns before deep investigation
 - Run `cargo doc --no-deps` locally before pushing doc-related fixes
 - Execute merge/conflict resolution and straightforward operations immediately without Plan Mode
+- Use worktree-based merge strategy for PR conflict resolution (NOT rebase/force-push)
 - Apply `agent-suspect` label to all agent-detected bug Issues
 - Verify agent-detected bugs independently before removing `agent-suspect` label
 - Use independent context (separate agent session) for agent re-evaluation of `agent-suspect` Issues
@@ -540,6 +556,7 @@ Before submitting code:
 - Enter Plan Mode for merge operations, branch deletion, or worktree cleanup
 - Retry GitHub MCP tools after errors instead of falling back to `gh` CLI
 - Create branches without checking for name conflicts
+- Use rebase or force-push to resolve PR conflicts (use worktree merge instead)
 - Remove `agent-suspect` label without independent verification (separate agent or human)
 - Count `agent-suspect` labeled Issues toward stability timer reset (SC-2a)
 - Use the same agent context for both detection and verification of a bug
@@ -558,6 +575,7 @@ For comprehensive guidelines, see:
 - **Issues**: instructions/ISSUE_GUIDELINES.md
 - **Issue Handling**: instructions/ISSUE_HANDLING.md
 - **GitHub Interactions**: instructions/GITHUB_INTERACTION.md
+- **GitHub Discussions**: https://github.com/kent8192/reinhardt-web/discussions
 - **Security Policy**: SECURITY.md
 - **Code of Conduct**: CODE_OF_CONDUCT.md
 - **Label Definitions**: .github/labels.yml

--- a/instructions/GITHUB_INTERACTION.md
+++ b/instructions/GITHUB_INTERACTION.md
@@ -241,6 +241,33 @@ When providing implementation context for issue discussion:
 
 ---
 
+## GitHub Discussions
+
+### GD-1 (SHOULD): Discussions vs Issues
+
+Use GitHub Discussions for:
+- Usage questions and how-to inquiries
+- Ideas and brainstorming
+- General community discussion
+- Show and tell (sharing projects built with Reinhardt)
+
+Use Issues for:
+- Bug reports with reproduction steps
+- Feature requests with clear requirements
+- Documentation errors
+- Performance issues with benchmarks
+
+**Discussion URL:** https://github.com/kent8192/reinhardt-web/discussions
+
+### GD-2 (SHOULD): Redirecting Questions
+
+When encountering question-type Issues that are better suited for Discussions:
+- Politely suggest GitHub Discussions as a more appropriate venue
+- Provide the Discussions URL
+- Follow PP-1 authorization policy before posting redirect comments
+
+---
+
 ## Agent Context Provision
 
 ### AC-1 (SHOULD): Structured Context for Coding Agents

--- a/instructions/ISSUE_GUIDELINES.md
+++ b/instructions/ISSUE_GUIDELINES.md
@@ -302,7 +302,11 @@ Issues created by LLM agent bug discovery MUST include the `agent-suspect` label
 - Clarifying API behavior
 - General usage questions
 
-**Note:** For usage questions, consider GitHub Discussions first.
+**Note:** For usage questions, prefer GitHub Discussions first:
+https://github.com/kent8192/reinhardt-web/discussions
+
+Issues should be reserved for actionable items (bugs, feature requests, etc.).
+Questions posted as Issues may be redirected to Discussions.
 
 **Label Applied:** `question`
 

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -390,6 +390,52 @@ cargo make clippy-check
 
 ---
 
+## PR Conflict Resolution
+
+### CR-1 (MUST): Worktree-Based Merge Strategy
+
+PR conflicts MUST be resolved using a worktree-based merge strategy. Rebase and force-push are NOT allowed for conflict resolution.
+
+**Procedure:**
+
+1. Create a worktree for the source branch:
+   ```bash
+   git worktree add /tmp/<worktree-name> <source-branch>
+   ```
+2. In the worktree, merge the target branch:
+   ```bash
+   cd /tmp/<worktree-name>
+   git merge <target-branch>
+   ```
+3. Resolve conflicts and commit:
+   ```bash
+   # Resolve conflicts in files
+   git add <resolved-files>
+   git commit
+   ```
+4. Push and clean up:
+   ```bash
+   git push origin <source-branch>
+   cd -
+   git worktree remove /tmp/<worktree-name>
+   ```
+
+**Rationale:**
+- Preserves complete commit history
+- Avoids force-push risks (overwriting upstream changes)
+- Merge commits clearly document conflict resolution
+- Worktree isolation prevents interference with current work
+
+### CR-2 (NEVER): Prohibited Approaches
+
+- **NEVER** use `git rebase` to resolve PR conflicts
+- **NEVER** use `git push --force` or `git push --force-with-lease` for conflict resolution
+- **NEVER** use `git reset --hard` as part of conflict resolution workflow
+
+**Exception:** Rebase may be used ONLY when explicitly requested by the user, with clear understanding of the implications.
+
+---
+
 ## PR Merge Policy
 
 ### MP-1 (MUST): Merge Requirements
@@ -522,6 +568,7 @@ docs(readme): add installation instructions
 - Merge with failing CI checks
 - Leave unresolved review comments
 - Force push after review has started (unless explicitly requested)
+- Use rebase or force-push to resolve PR conflicts (use worktree merge instead)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add worktree-based merge strategy for PR conflict resolution (CR-1, CR-2) to PR_GUIDELINE.md
- Add GitHub Discussions guidelines (GD-1, GD-2) to GITHUB_INTERACTION.md
- Strengthen GitHub Discussions reference in ISSUE_GUIDELINES.md Question section
- Update CLAUDE.md with conflict resolution rules, GitHub Discussions CLI commands, and Quick Reference entries

## Type of Change

- [x] Documentation update

## Motivation and Context

CLAUDE.md lacked an explicit PR conflict resolution strategy. While "No merge conflicts with base branch" was required (MP-1), there was no defined procedure for resolving conflicts. This could lead to risky approaches like rebase/force-push that overwrite commit history.

Additionally, GitHub Discussions references were insufficient across CLAUDE.md and instruction files, making the distinction between question-type Issues and Discussions unclear.

## How Was This Tested?

- [x] Verified cross-references between all modified files are consistent
- [x] Verified CLAUDE.md Quick Reference reflects new rules in both MUST DO and NEVER DO sections
- [x] Verified Detailed Standards section includes new GitHub Discussions link

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)