### PR TITLE
fix(auth): use deterministic UUID for RemoteUserAuthentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -473,7 +473,7 @@ rand = "0.8"
 rand_core = "0.6"
 getrandom = { version = "0.2", features = ["js"] }  # WASM support with js feature
 jsonwebtoken = { version = "10.2.0", features = ["aws_lc_rs"] }
-uuid = { version = "1.18.1", features = ["v4", "serde"] }
+uuid = { version = "1.18.1", features = ["v4", "v5", "serde"] }
 
 # GraphQL
 async-graphql = "7.0"

--- a/crates/reinhardt-auth/src/remote_user.rs
+++ b/crates/reinhardt-auth/src/remote_user.rs
@@ -114,7 +114,7 @@ impl AuthenticationBackend for RemoteUserAuthentication {
 			Some(username) if !username.is_empty() => {
 				// Create user from header
 				Ok(Some(Box::new(SimpleUser {
-					id: Uuid::new_v4(),
+					id: Uuid::new_v5(&Uuid::NAMESPACE_OID, username.as_bytes()),
 					username: username.to_string(),
 					email: format!("{}@example.com", username),
 					is_active: true,


### PR DESCRIPTION
## Summary

- Replace `Uuid::new_v4()` with `Uuid::new_v5()` using `NAMESPACE_OID` and username bytes for consistent user identity across requests

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`RemoteUserAuthentication` generates a random UUID for each request via `Uuid::new_v4()`, making the same user appear as different users across requests. Using `Uuid::new_v5()` derives a deterministic UUID from the username, ensuring consistent identity.

Fixes #1562

## How Was This Tested?

- `cargo nextest run -p reinhardt-auth --all-features`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `auth` - Authentication, authorization, sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)