### PR TITLE
fix(urls): eliminate use-after-unlock unsoundness in LazyLoaded::get()

### DIFF
--- a/crates/reinhardt-urls/src/proxy/loading.rs
+++ b/crates/reinhardt-urls/src/proxy/loading.rs
@@ -316,6 +316,63 @@ mod tests {
 		assert_eq!(config.relationships, vec!["posts", "comments"]);
 	}
 
+	#[tokio::test]
+	async fn test_lazy_loaded_get_returns_owned_clone() {
+		// Arrange
+		let lazy = LazyLoaded::new(|| Box::pin(async { Ok(vec![10, 20, 30]) }));
+
+		// Act - get() loads and returns owned T via clone
+		let data = lazy.get().await.unwrap();
+
+		// Assert
+		assert_eq!(data, vec![10, 20, 30]);
+		assert!(lazy.is_loaded());
+	}
+
+	#[tokio::test]
+	async fn test_lazy_loaded_get_if_loaded_returns_none_when_not_loaded() {
+		// Arrange
+		let lazy = LazyLoaded::new(|| Box::pin(async { Ok(42) }));
+
+		// Act
+		let result = lazy.get_if_loaded();
+
+		// Assert
+		assert_eq!(result, None);
+	}
+
+	#[tokio::test]
+	async fn test_lazy_loaded_get_if_loaded_returns_cloned_value() {
+		// Arrange
+		let lazy = LazyLoaded::preloaded(String::from("hello"), || {
+			Box::pin(async { Ok(String::from("world")) })
+		});
+
+		// Act
+		let result = lazy.get_if_loaded();
+
+		// Assert
+		assert_eq!(result, Some(String::from("hello")));
+	}
+
+	#[tokio::test]
+	async fn test_lazy_loaded_reset_forces_reload() {
+		// Arrange
+		let lazy = LazyLoaded::preloaded(vec![1], || Box::pin(async { Ok(vec![2]) }));
+		assert!(lazy.is_loaded());
+
+		// Act
+		lazy.reset();
+
+		// Assert
+		assert!(!lazy.is_loaded());
+		assert_eq!(lazy.get_if_loaded(), None);
+
+		// Reload
+		let data = lazy.get().await.unwrap();
+		assert_eq!(data, vec![2]);
+	}
+
 	#[test]
 	fn test_relationship_cache() {
 		let cache = RelationshipCache::new();


### PR DESCRIPTION
## Summary

This PR addresses:

- Eliminate use-after-unlock unsoundness in `LazyLoaded::get()` and `get_if_loaded()` where an `RwLock` read guard was dropped while a reference derived from a raw pointer still outlived it

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

- `LazyLoaded::get()` and `get_if_loaded()` acquired an `RwLock` read guard, extracted a raw pointer to the inner data, then dropped the guard while returning a reference derived from that pointer. Under concurrent access, a writer could modify or deallocate the data while a reader holds a dangling reference, causing undefined behavior.

Fixes #1657

Related to: #1449

## How Was This Tested?

- `cargo nextest run --package reinhardt-urls` (291 tests passed)
- `cargo check --workspace --all --all-features`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Breaking Changes

- `LazyLoaded::get()` now returns `ProxyResult<T>` (owned value) instead of `ProxyResult<&T>`
- `LazyLoaded::get_if_loaded()` now returns `Option<T>` (owned value) instead of `Option<&T>`
- `LazyLoaded<T, F>` now requires `T: Clone`
- `LazyLoadable` trait's `Data` associated type now requires `Clone` bound

**Migration Guide:**

- If you call `.get()` or `.get_if_loaded()`, the return value is now an owned `T` instead of `&T`. Remove any explicit borrows or adjust lifetime annotations accordingly.
- Ensure your data type `T` implements `Clone`.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- #1657 (use-after-unlock unsoundness)
- #1449 (related safety audit)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `routing` - URL routing, path matching

### Priority Label
- [x] `high` - Important fix or feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)