### PR TITLE
fix(urls): convert path-type parameters to matchit catch-all syntax in RadixTree mode

### DIFF
--- a/crates/reinhardt-urls/src/routers/pattern.rs
+++ b/crates/reinhardt-urls/src/routers/pattern.rs
@@ -1453,9 +1453,7 @@ mod tests {
 			"RadixTree mode should reject directory traversal in path params"
 		);
 		assert!(
-			matcher
-				.match_path("/files/foo/../../etc/passwd")
-				.is_none(),
+			matcher.match_path("/files/foo/../../etc/passwd").is_none(),
 			"RadixTree mode should reject embedded directory traversal"
 		);
 
@@ -1464,10 +1462,7 @@ mod tests {
 		assert!(result.is_some());
 		let (handler_id, params) = result.unwrap();
 		assert_eq!(handler_id, "serve_file");
-		assert_eq!(
-			params.get("filepath"),
-			Some(&"css/style.css".to_string())
-		);
+		assert_eq!(params.get("filepath"), Some(&"css/style.css".to_string()));
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

- Fix RadixRouter pattern conversion for path-type parameters (`{<path:name>}`)
- Add `to_matchit_pattern()` to convert Django-style path parameters to matchit's catch-all syntax (`{*name}`)
- Add RadixTree-mode-specific directory traversal rejection tests

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`PathMatcher` was passing Django-style `{<path:filepath>}` patterns directly to matchit's `RadixRouter`, which expects `{*filepath}` for catch-all parameters. This caused pattern insertion to silently fail (errors suppressed by `let _ =`), making RadixTree mode unable to match path-type routes entirely. While `validate_path_param()` was called in the RadixTree code path, it was never reached because matchit couldn't match the malformed patterns, effectively bypassing directory traversal validation.

Fixes #1661

Related to: #1449

## How Was This Tested?

- `cargo test --package reinhardt-urls` (318 passed)
- Added `test_radix_tree_mode_rejects_traversal` - verifies `..` traversal rejection in RadixTree mode
- Added `test_radix_tree_mode_rejects_encoded_traversal` - verifies percent-encoded traversal and null byte rejection
- `cargo make fmt-check` passes
- `cargo make clippy-check` passes
- `cargo check --workspace --all --all-features` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `security` - Security-related fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)