### PR TITLE
fix(deps): align dependency versions to workspace definitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -469,9 +469,8 @@ native-tls = "=0.2.14"
 # Authentication & Security
 argon2 = { version = "0.5", features = ["std"] }
 password-hash = "0.5"
-rand = "0.8"
-rand_core = "0.6"
-getrandom = { version = "0.2", features = ["js"] }  # WASM support with js feature
+rand = "0.9"
+getrandom = { version = "0.3", features = ["wasm_js"] }  # WASM support with wasm_js feature
 jsonwebtoken = { version = "10.2.0", features = ["aws_lc_rs"] }
 uuid = { version = "1.18.1", features = ["v4", "v5", "serde"] }
 
@@ -565,7 +564,7 @@ scopeguard = "1.2.0"
 tempfile = "3.15.0"
 trybuild = "1.0.114"
 url = "2.5.4"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.6", features = ["html_reports"] }
 
 # SQL Query Builder
 sea-query = { version = "1.0.0-rc.29", features = [

--- a/crates/reinhardt-admin/src/server/security.rs
+++ b/crates/reinhardt-admin/src/server/security.rs
@@ -237,7 +237,7 @@ pub fn generate_csrf_token() -> String {
 	use base64::Engine;
 	let mut bytes = vec![0u8; CSRF_TOKEN_BYTES];
 	// Use getrandom for cryptographically secure randomness
-	getrandom::getrandom(&mut bytes).expect("Failed to generate random bytes for CSRF token");
+	getrandom::fill(&mut bytes).expect("Failed to generate random bytes for CSRF token");
 	base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&bytes)
 }
 

--- a/crates/reinhardt-auth/src/social/backend.rs
+++ b/crates/reinhardt-auth/src/social/backend.rs
@@ -163,8 +163,8 @@ impl Default for SocialAuthBackend {
 /// Generates a random alphanumeric string of the specified length
 fn generate_random_string(length: usize) -> String {
 	use rand::Rng;
-	rand::thread_rng()
-		.sample_iter(&rand::distributions::Alphanumeric)
+	rand::rng()
+		.sample_iter(&rand::distr::Alphanumeric)
 		.take(length)
 		.map(char::from)
 		.collect()

--- a/crates/reinhardt-auth/src/social/flow/pkce.rs
+++ b/crates/reinhardt-auth/src/social/flow/pkce.rs
@@ -3,7 +3,7 @@
 //! Implements RFC 7636 for secure authorization code flow.
 
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
-use rand::{Rng, distributions::Alphanumeric, thread_rng};
+use rand::{Rng, distr::Alphanumeric};
 use sha2::{Digest, Sha256};
 
 /// Code verifier for PKCE flow
@@ -94,7 +94,7 @@ impl PkceFlow {
 	/// ```
 	pub fn generate() -> (CodeVerifier, CodeChallenge) {
 		// Generate verifier: 128 random alphanumeric characters
-		let verifier_str: String = thread_rng()
+		let verifier_str: String = rand::rng()
 			.sample_iter(&Alphanumeric)
 			.take(128)
 			.map(char::from)

--- a/crates/reinhardt-commands/src/bin/runserver.rs
+++ b/crates/reinhardt-commands/src/bin/runserver.rs
@@ -378,8 +378,8 @@ fn generate_random_secret_key() -> String {
 	use rand::Rng;
 	use std::fmt::Write;
 
-	let mut rng = rand::thread_rng();
-	let bytes: [u8; 25] = rng.r#gen();
+	let mut rng = rand::rng();
+	let bytes: [u8; 25] = rng.random();
 	let mut hex_string = String::with_capacity(50);
 	for b in bytes {
 		let _ = write!(hex_string, "{:02x}", b);

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -823,8 +823,8 @@ fn generate_random_secret_key() -> String {
 	use rand::Rng;
 	use std::fmt::Write;
 
-	let mut rng = rand::thread_rng();
-	let bytes: [u8; 25] = rng.r#gen();
+	let mut rng = rand::rng();
+	let bytes: [u8; 25] = rng.random();
 	let mut hex_string = String::with_capacity(50);
 	for b in bytes {
 		let _ = write!(hex_string, "{:02x}", b);

--- a/crates/reinhardt-commands/src/template.rs
+++ b/crates/reinhardt-commands/src/template.rs
@@ -353,10 +353,10 @@ pub fn generate_secret_key() -> String {
                              ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                              0123456789\
                              !@#$%^&*(-_=+)";
-	let mut rng = rand::thread_rng();
+	let mut rng = rand::rng();
 	(0..50)
 		.map(|_| {
-			let idx = rng.gen_range(0..CHARSET.len());
+			let idx = rng.random_range(0..CHARSET.len());
 			CHARSET[idx] as char
 		})
 		.collect()

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -37,7 +37,7 @@ redis = { version = "0.32.7", features = [
 sqlx = { workspace = true, features = ["any", "runtime-tokio", "tls-rustls", "postgres", "mysql"], optional = true }
 reinhardt-query = { workspace = true, optional = true }
 reqwest = { version = "0.12", features = ["json"], optional = true }
-rand = { version = "0.9.2", optional = true }
+rand = { workspace = true, optional = true }
 aws-config = { version = "1.5", optional = true }
 aws-sdk-secretsmanager = { version = "1.52", optional = true }
 aws-smithy-runtime = { version = "1.9", optional = true }
@@ -80,7 +80,7 @@ anyhow = { workspace = true }
 hex = "0.4"
 colored = "3.0.0"
 mockito = "1.5"
-mockall = "0.13"
+mockall = { workspace = true }
 rstest = "0.26.1"
 wiremock = "0.6"
 serial_test = { workspace = true }

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -44,7 +44,7 @@ aquamarine = { workspace = true }
 sha2 = "0.10"
 hmac = "0.12"
 hex = "0.4"
-rand = "0.9"
+rand = { workspace = true }
 ipnet = "2.10"
 regex = "1.11"
 chrono = { workspace = true }

--- a/crates/reinhardt-db/src/orm/type_decorator.rs
+++ b/crates/reinhardt-db/src/orm/type_decorator.rs
@@ -78,7 +78,7 @@ impl EncryptedString {
 
 		// Generate a random 12-byte nonce
 		let mut nonce_bytes = [0u8; 12];
-		rand::thread_rng().fill_bytes(&mut nonce_bytes);
+		rand::rng().fill_bytes(&mut nonce_bytes);
 		let nonce = Nonce::from(nonce_bytes);
 
 		// Encrypt the data

--- a/crates/reinhardt-middleware/src/csp.rs
+++ b/crates/reinhardt-middleware/src/csp.rs
@@ -251,7 +251,7 @@ impl CspMiddleware {
 		use rand::RngCore;
 
 		let mut bytes = [0u8; 16];
-		rand::rngs::OsRng.fill_bytes(&mut bytes);
+		rand::rng().fill_bytes(&mut bytes);
 		base64::engine::general_purpose::STANDARD.encode(bytes)
 	}
 

--- a/crates/reinhardt-middleware/src/csrf.rs
+++ b/crates/reinhardt-middleware/src/csrf.rs
@@ -142,7 +142,7 @@ impl CsrfMiddleware {
 		// which are attacker-controlled.
 		use rand::RngCore;
 		let mut random_bytes = [0u8; 32];
-		rand::thread_rng().fill_bytes(&mut random_bytes);
+		rand::rng().fill_bytes(&mut random_bytes);
 		hex::encode(random_bytes)
 	}
 

--- a/crates/reinhardt-tasks/src/load_balancer.rs
+++ b/crates/reinhardt-tasks/src/load_balancer.rs
@@ -338,13 +338,13 @@ impl LoadBalancer {
 			.map(|w| weights.get(&w.id).copied().unwrap_or(w.weight))
 			.sum();
 
-		// Guard against zero total weight to prevent panic in gen_range(0..0)
+		// Guard against zero total weight to prevent panic in random_range(0..0)
 		if total_weight == 0 {
 			return workers[0].clone();
 		}
 
-		let mut rng = rand::thread_rng();
-		let mut random = rng.gen_range(0..total_weight);
+		let mut rng = rand::rng();
+		let mut random = rng.random_range(0..total_weight);
 		for worker in workers {
 			let weight = weights.get(&worker.id).copied().unwrap_or(worker.weight);
 			if random < weight {
@@ -359,8 +359,8 @@ impl LoadBalancer {
 	/// Random selection
 	fn select_random(&self, workers: &[Arc<WorkerInfo>]) -> Arc<WorkerInfo> {
 		use rand::Rng;
-		let mut rng = rand::thread_rng();
-		let index = rng.gen_range(0..workers.len());
+		let mut rng = rand::rng();
+		let index = rng.random_range(0..workers.len());
 		workers[index].clone()
 	}
 

--- a/crates/reinhardt-tasks/src/webhook.rs
+++ b/crates/reinhardt-tasks/src/webhook.rs
@@ -616,8 +616,8 @@ impl HttpWebhookSender {
 			* retry_config.backoff_multiplier.powi(retry_count as i32);
 
 		// Add jitter (±25%)
-		let mut rng = rand::thread_rng();
-		let jitter = rng.gen_range(-0.25..=0.25);
+		let mut rng = rand::rng();
+		let jitter = rng.random_range(-0.25..=0.25);
 		let backoff_with_jitter = backoff_ms * (1.0 + jitter);
 
 		// Cap at max backoff (AFTER jitter)

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -30,7 +30,7 @@ redis = { version = "0.32.7", features = [
 deadpool-redis = { version = "0.22.0", optional = true }
 memcache-async = { version = "0.9.0", optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
-rand = "0.9.2"
+rand = { workspace = true }
 anyhow = { workspace = true }
 once_cell = { workspace = true, optional = false }
 http = "1.0"


### PR DESCRIPTION
## Summary

- Upgrade workspace `rand` from 0.8 to 0.9 and update all API calls (`thread_rng`→`rng`, `gen_range`→`random_range`, `distributions`→`distr`, `r#gen`→`random`)
- Upgrade workspace `getrandom` from 0.2 to 0.3 and update API (`getrandom::getrandom`→`getrandom::fill`, `js`→`wasm_js` feature)
- Upgrade workspace `criterion` from 0.5 to 0.6
- Change reinhardt-core, reinhardt-utils, reinhardt-conf `rand` to use `{ workspace = true }` instead of direct version pinning
- Change reinhardt-conf `mockall` from direct 0.13 to `{ workspace = true }` (0.14.0)
- Remove unused `rand_core` workspace dependency

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Multiple crates bypassed workspace dependency definitions, causing version inconsistencies and potentially compiling multiple incompatible versions of the same crate.

Fixes #1596, fixes #1592, fixes #1527

## How Was This Tested?

- [x] `cargo check --workspace --all-features` passes with no errors or warnings
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Priority Label
- [x] `low` - Minor fix or enhancement

🤖 Generated with [Claude Code](https://claude.com/claude-code)