### PR TITLE
fix(test): update rand 0.9 API usage in auth integration tests

### DIFF
--- a/crates/reinhardt-auth/tests/helpers/test_fixtures.rs
+++ b/crates/reinhardt-auth/tests/helpers/test_fixtures.rs
@@ -224,8 +224,8 @@ impl TestFixtures {
 	/// Generate random state string
 	pub fn random_state() -> String {
 		use rand::Rng;
-		rand::thread_rng()
-			.sample_iter(&rand::distributions::Alphanumeric)
+		rand::rng()
+			.sample_iter(&rand::distr::Alphanumeric)
 			.take(32)
 			.map(char::from)
 			.collect()
@@ -234,8 +234,8 @@ impl TestFixtures {
 	/// Generate random nonce string
 	pub fn random_nonce() -> String {
 		use rand::Rng;
-		rand::thread_rng()
-			.sample_iter(&rand::distributions::Alphanumeric)
+		rand::rng()
+			.sample_iter(&rand::distr::Alphanumeric)
 			.take(32)
 			.map(char::from)
 			.collect()


### PR DESCRIPTION
## Summary

- Fix deprecated rand 0.8 API usage in `reinhardt-auth` test fixtures
- Replace `rand::thread_rng()` with `rand::rng()` and `rand::distributions::Alphanumeric` with `rand::distr::Alphanumeric`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

All 16 open PRs are failing `Cargo Check` CI because `crates/reinhardt-auth/tests/helpers/test_fixtures.rs` uses deprecated rand 0.8 APIs incompatible with rand 0.9.

PR #1752 fixed the same issue in csrf tests but missed this file.

Related to: #1752

## How Was This Tested?

- [x] `cargo check -p reinhardt-auth --all-features` passes
- [x] `cargo make fmt-check` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `auth` - Authentication, authorization, sessions
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)