### PR TITLE
fix(ci): allow publish-check to be skipped on release-plz branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,6 @@ jobs:
             "${{ needs.check.result }}"
             "${{ needs.fmt.result }}"
             "${{ needs.clippy.result }}"
-            "${{ needs.publish-check.result }}"
             "${{ needs.todo-check.result }}"
             "${{ needs.semver-check.result }}"
             "${{ needs.unit-test.result }}"
@@ -319,6 +318,12 @@ jobs:
               exit 1
             fi
           done
+          # publish-check is skipped on release-plz and fix/release-plz branches (expected)
+          publish_check="${{ needs.publish-check.result }}"
+          if [[ "$publish_check" != "success" && "$publish_check" != "skipped" ]]; then
+            echo "::error::Publish check failed: $publish_check"
+            exit 1
+          fi
           # release-dry-run is skipped on release-plz branches (expected)
           dry_run="${{ needs.release-dry-run.result }}"
           if [[ "$dry_run" != "success" && "$dry_run" != "skipped" ]]; then


### PR DESCRIPTION
## Summary

- Move `publish-check` out of the strict `required_results` array in the CI Success job
- Add separate validation that accepts both "success" and "skipped" for `publish-check`, matching existing `release-dry-run` handling

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The `publish-check` workflow is intentionally skipped on `release-plz-*` and `fix/release-plz*` branches because crate versions may not yet be published to crates.io. However, the CI Success job only accepted "success" for all required results, causing it to fail when `publish-check` was skipped. This blocked release PRs (e.g., #1757) from merging.

The `release-dry-run` job already had this skip-tolerant handling, but `publish-check` was missing it.

Fixes #1757

## How Was This Tested?

- [x] Verified that PR #1757 (`release-plz-*` branch) had `publish-check` skipped and CI Success failed
- [x] Confirmed `release-dry-run` already uses the same skip-tolerant pattern
- [x] Reviewed workflow logic to ensure no other jobs need similar treatment

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

The fix mirrors the existing pattern used for `release-dry-run` on line 322-327 of ci.yml.

Generated with [Claude Code](https://claude.com/claude-code)