### PR TITLE
fix(core): use character count instead of byte length in CharField validation

### DIFF
--- a/crates/reinhardt-core/src/serializers/fields.rs
+++ b/crates/reinhardt-core/src/serializers/fields.rs
@@ -202,14 +202,16 @@ impl CharField {
 			return Err(FieldError::Required);
 		}
 
+		let char_count = value.chars().count();
+
 		if let Some(min) = self.min_length
-			&& value.len() < min
+			&& char_count < min
 		{
 			return Err(FieldError::TooShort(min));
 		}
 
 		if let Some(max) = self.max_length
-			&& value.len() > max
+			&& char_count > max
 		{
 			return Err(FieldError::TooLong(max));
 		}
@@ -1137,6 +1139,7 @@ impl Default for DateTimeField {
 mod tests {
 	use super::*;
 	use chrono::{Datelike, Timelike};
+	use rstest::rstest;
 
 	#[test]
 	fn test_char_field_valid() {
@@ -1154,6 +1157,48 @@ mod tests {
 	fn test_char_field_too_long() {
 		let field = CharField::new().max_length(5);
 		assert_eq!(field.validate("hello world"), Err(FieldError::TooLong(5)));
+	}
+
+	#[rstest]
+	#[case::cjk_within_max("こんにちは世", 10, true)]
+	#[case::cjk_exceeding_max("こんにちはこんにちはあ", 10, false)]
+	#[case::emoji_within_max("🎉🎊🎈", 5, true)]
+	#[case::emoji_exceeding_max("🎉🎊🎈🎁🎀🎆", 5, false)]
+	#[case::mixed_ascii_cjk("hello世界", 10, true)]
+	#[case::boundary_exact_max("あいうえお", 5, true)]
+	#[case::boundary_one_over_max("あいうえおか", 5, false)]
+	fn test_char_field_unicode_max_length(
+		#[case] input: &str,
+		#[case] max_length: usize,
+		#[case] should_pass: bool,
+	) {
+		// Arrange
+		let field = CharField::new().max_length(max_length);
+
+		// Act
+		let result = field.validate(input);
+
+		// Assert
+		assert_eq!(result.is_ok(), should_pass);
+	}
+
+	#[rstest]
+	#[case::cjk_meets_min("こんにちは", 5, true)]
+	#[case::cjk_below_min("こん", 5, false)]
+	#[case::boundary_exact_min("あいう", 3, true)]
+	fn test_char_field_unicode_min_length(
+		#[case] input: &str,
+		#[case] min_length: usize,
+		#[case] should_pass: bool,
+	) {
+		// Arrange
+		let field = CharField::new().min_length(min_length);
+
+		// Act
+		let result = field.validate(input);
+
+		// Assert
+		assert_eq!(result.is_ok(), should_pass);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

- Fix `CharField::validate()` to use `chars().count()` instead of `len()` for length validation
- Add Unicode-aware tests (CJK, emoji, mixed strings, boundary values)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`CharField` validation used byte length (`len()`) instead of character count for `min_length`/`max_length` checks. This caused incorrect rejection of valid multi-byte Unicode strings (CJK, emoji, etc.).

Fixes #1773

Related to: #564

## How Was This Tested?

- `cargo nextest run --package reinhardt-core -E 'test(char_field)'`
- Added tests for CJK characters, emoji, mixed strings, and boundary values

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `api` - REST API, serializers, views

🤖 Generated with [Claude Code](https://claude.com/claude-code)