### PR TITLE
fix(ci): use git log to detect changed files when base branch is merged into PR

### DIFF
--- a/.github/scripts/detect-affected-packages.sh
+++ b/.github/scripts/detect-affected-packages.sh
@@ -2,8 +2,14 @@
 set -euo pipefail
 
 BASE_REF="${1:-origin/main}"
-MERGE_BASE=$(git merge-base HEAD "$BASE_REF")
-CHANGED_FILES=$(git diff --name-only "$MERGE_BASE"...HEAD)
+
+# Collect changed files from non-merge commits unique to this branch.
+# Using 'git log --no-merges BASE_REF..HEAD' is more reliable than
+# 'git diff MERGE_BASE...HEAD' when the base branch has been merged into
+# the PR branch: in GitHub Actions' synthetic-merge-ref environment the
+# three-dot diff can return empty even when the PR has real changes. # Issue #1822
+CHANGED_FILES=$(git log --name-only --format="" --no-merges "$BASE_REF..HEAD" \
+  | grep -v '^$' | sort -u || true)
 
 if [[ -z "$CHANGED_FILES" ]]; then
   echo "run-all=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Replace `git diff MERGE_BASE...HEAD` with `git log --name-only --format="" --no-merges BASE_REF..HEAD` in `detect-affected-packages.sh`
- Fixes `HAS_AFFECTED: false` (test jobs skipped) when `main` is merged into PR branch

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

When `main` is merged into a PR branch, GitHub Actions checks out a synthetic merge commit (`refs/pull/{N}/merge`). In this environment, `git diff MERGE_BASE...HEAD` returns empty even though the PR has real file changes. This caused `detect-affected-packages.sh` to output `HAS_AFFECTED: false`, skipping all test jobs.

The new approach (`git log --no-merges BASE_REF..HEAD`) lists files from non-merge commits unique to the PR branch, which is unaffected by merge topology and works correctly with GitHub Actions' synthetic merge ref.

## How Was This Tested

- Verified locally by checking out the synthetic merge commit SHA from PR #1806's CI run (`02c069e6ea700f4904c4b764d8019f8003a7349a`) and confirming:
  - Old approach: `git diff MERGE_BASE...HEAD` → works locally but fails in CI
  - New approach: `git log --no-merges origin/main..HEAD` → returns correct file list in both environments

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added comments to hard-to-understand areas

## Labels to Apply

- `bug` — fixes incorrect behavior (`HAS_AFFECTED: false` when it should be `true`)
- `ci-cd` — CI/CD infrastructure change

Fixes #1822
Fixes #1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)