### PR TITLE
ci: add debug output to diagnose detect-affected-packages issue 1822

### DIFF
--- a/.github/scripts/detect-affected-packages.sh
+++ b/.github/scripts/detect-affected-packages.sh
@@ -15,6 +15,17 @@ if [[ -n "${HEAD_REF:-}" ]]; then
 else
   COMPARE_REF="HEAD"
 fi
+
+# Debug: log refs and git state for diagnosing Issue #1822
+echo "[debug] BASE_REF=$BASE_REF" >&2
+echo "[debug] COMPARE_REF=$COMPARE_REF" >&2
+echo "[debug] HEAD=$(git rev-parse HEAD 2>/dev/null || echo 'unknown')" >&2
+echo "[debug] BASE_REF sha=$(git rev-parse "$BASE_REF" 2>/dev/null || echo 'unknown')" >&2
+echo "[debug] COMPARE_REF sha=$(git rev-parse "$COMPARE_REF" 2>/dev/null || echo 'unknown')" >&2
+RAW_LOG=$(git log --name-only --format="%H" --no-merges "$BASE_REF..$COMPARE_REF" 2>/dev/null || true)
+echo "[debug] RAW_LOG (first 20 lines):" >&2
+echo "$RAW_LOG" | head -20 >&2
+
 CHANGED_FILES=$(git log --name-only --format="" --no-merges "$BASE_REF..$COMPARE_REF" \
   | grep -v '^$' | sort -u || true)
 


### PR DESCRIPTION
## Summary

- Add temporary debug output to `.github/scripts/detect-affected-packages.sh` to diagnose why HAS_AFFECTED is false
- Prints BASE_REF, COMPARE_REF, HEAD sha, and raw git log output to stderr

## Test plan

- [ ] Check CI logs for debug output to identify root cause

Refs #1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)