### PR TITLE
ci: switch detect-affected-packages from git log to git diff

### DIFF
--- a/.github/scripts/detect-affected-packages.sh
+++ b/.github/scripts/detect-affected-packages.sh
@@ -3,19 +3,23 @@ set -euo pipefail
 
 BASE_REF="${1:-origin/main}"
 
-# Collect changed files from non-merge commits unique to this branch.
+# Collect changed files by comparing the merge base of BASE_REF and COMPARE_REF.
+# We use 'git diff --name-only BASE...COMPARE' (three-dot) so that only files
+# that differ in the final state are considered. This avoids false positives from
+# commits that add then revert a file within the same branch.
+#
 # In a PR context, the HEAD_REF env var contains the PR branch name. We use
 # 'origin/$HEAD_REF' (the actual PR branch ref) rather than 'HEAD', because in
-# GitHub Actions the checkout ref is a synthetic merge commit (refs/pull/N/merge)
-# that makes 'git log BASE..HEAD' return empty even when the PR has real changes.
-# This is especially reproducible when the base branch has been merged into the
-# PR branch via update-branch. # Issue #1822
+# GitHub Actions the checkout ref is a synthetic merge commit (refs/pull/N/merge).
+# The origin/$HEAD_REF approach (Issue #1822) makes git diff safe to use here;
+# previously git log was needed to work around the synthetic merge ref, but that
+# caused false RUN_ALL=true for add-then-revert patterns (Issue #1833).
 if [[ -n "${HEAD_REF:-}" ]]; then
   COMPARE_REF="origin/$HEAD_REF"
 else
   COMPARE_REF="HEAD"
 fi
-CHANGED_FILES=$(git log --name-only --format="" --no-merges "$BASE_REF..$COMPARE_REF" \
+CHANGED_FILES=$(git diff --name-only "$BASE_REF...$COMPARE_REF" \
   | grep -v '^$' | sort -u || true)
 
 if [[ -z "$CHANGED_FILES" ]]; then


### PR DESCRIPTION
## Summary

- Switch CHANGED_FILES detection from `git log --name-only --no-merges` to `git diff --name-only` (three-dot merge-base comparison)
- This ensures only files that differ in the **final state** are considered, avoiding false `RUN_ALL=true` for add-then-revert commit patterns

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The previous implementation used `git log --name-only --no-merges` to collect changed files, which traverses commit history.
This caused false positives: if a branch added a file (e.g., `.github/scripts/detect-affected-packages.sh`) and then reverted it in a later commit, `git log` would still list the file as changed, triggering `RUN_ALL=true` even though the final diff against `main` contains no such change.

The fix uses `git diff --name-only BASE...COMPARE` (three-dot syntax), which compares against the merge base. This reports only files that actually differ in the final state, eliminating the false positive.

This is safe to do because Issue #1822 (PR #1826) already switched `COMPARE_REF` to `origin/$HEAD_REF` instead of `HEAD`. That change makes `git diff` reliable in GitHub Actions PRs where `HEAD` is a synthetic merge commit (`refs/pull/N/merge`).

Fixes #1833
Related to: #1822

## How Was This Tested?

- CI on this PR should show `RUN_ALL=false` (only `.github/scripts/detect-affected-packages.sh` changed → triggers `RUN_ALL=true`, but no Rust source changed)
- Verified the script logic manually: three-dot `git diff` uses merge-base, so add-then-revert yields no diff output

## Checklist

- [x] My code follows the code style of this project
- [x] My change requires no documentation update
- [x] I have checked that no new TODO/FIXME comments were introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)