### PR TITLE
ci: use GitHub PR Files API to detect changed files in PR context

### DIFF
--- a/.github/scripts/detect-affected-packages.sh
+++ b/.github/scripts/detect-affected-packages.sh
@@ -3,24 +3,32 @@ set -euo pipefail
 
 BASE_REF="${1:-origin/main}"
 
-# Collect changed files by comparing the merge base of BASE_REF and COMPARE_REF.
-# We use 'git diff --name-only BASE...COMPARE' (three-dot) so that only files
-# that differ in the final state are considered. This avoids false positives from
-# commits that add then revert a file within the same branch.
+# In a PR context (PR_NUMBER and GITHUB_REPOSITORY are set), use the GitHub
+# REST API to get the list of changed files. This is immune to the issue where
+# git diff returns empty after update-branch has merged the base branch into
+# the PR branch, making the three-dot merge base equal to the current base
+# branch tip. Issue #1836.
 #
-# In a PR context, the HEAD_REF env var contains the PR branch name. We use
-# 'origin/$HEAD_REF' (the actual PR branch ref) rather than 'HEAD', because in
-# GitHub Actions the checkout ref is a synthetic merge commit (refs/pull/N/merge).
-# The origin/$HEAD_REF approach (Issue #1822) makes git diff safe to use here;
-# previously git log was needed to work around the synthetic merge ref, but that
-# caused false RUN_ALL=true for add-then-revert patterns (Issue #1833).
-if [[ -n "${HEAD_REF:-}" ]]; then
-  COMPARE_REF="origin/$HEAD_REF"
+# In a non-PR context (push to main, manual trigger, etc.), fall back to
+# git diff three-dot notation. The HEAD_REF env var contains the PR branch
+# name when available; we use 'origin/$HEAD_REF' rather than 'HEAD', because
+# in GitHub Actions the checkout ref is a synthetic merge commit
+# (refs/pull/N/merge). Issue #1822.
+if [[ -n "${PR_NUMBER:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+  CHANGED_FILES=$(gh api \
+    "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+    --paginate \
+    --jq '.[].filename' \
+    2>/dev/null | grep -v '^$' | sort -u || true)
 else
-  COMPARE_REF="HEAD"
+  if [[ -n "${HEAD_REF:-}" ]]; then
+    COMPARE_REF="origin/$HEAD_REF"
+  else
+    COMPARE_REF="HEAD"
+  fi
+  CHANGED_FILES=$(git diff --name-only "$BASE_REF...$COMPARE_REF" \
+    | grep -v '^$' | sort -u || true)
 fi
-CHANGED_FILES=$(git diff --name-only "$BASE_REF...$COMPARE_REF" \
-  | grep -v '^$' | sort -u || true)
 
 if [[ -z "$CHANGED_FILES" ]]; then
   echo "run-all=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/detect-affected-packages.yml
+++ b/.github/workflows/detect-affected-packages.yml
@@ -41,6 +41,8 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [[ "$HEAD_REF" == release-plz-* ]]; then
             echo "Release PR detected — running all tests"
@@ -59,21 +61,32 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
           RUN_ALL: ${{ steps.detect.outputs.run-all }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Issue #1828: run-examples is true when run-all is true (covers release-plz branches
-          # and global file changes), or when examples/** files changed in this PR
+          # and global file changes), or when examples/** files changed in this PR.
+          # In a PR context, use GitHub API for reliable file detection.
+          # git diff / git log may return empty after update-branch (Issue #1836).
           if [[ "$RUN_ALL" == "true" ]]; then
             echo "run-examples=true" >> "$GITHUB_OUTPUT"
           else
-            if [[ -n "${HEAD_REF:-}" ]]; then
-              COMPARE_REF="origin/$HEAD_REF"
+            if [[ -n "${PR_NUMBER:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+              CHANGED=$(gh api \
+                "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+                --paginate --jq '.[].filename' 2>/dev/null \
+                | grep '^examples/' | head -1 || true)
             else
-              COMPARE_REF="HEAD"
+              if [[ -n "${HEAD_REF:-}" ]]; then
+                COMPARE_REF="origin/$HEAD_REF"
+              else
+                COMPARE_REF="HEAD"
+              fi
+              BASE_REF_VAL="${BASE_REF:-main}"
+              CHANGED=$(git diff --name-only \
+                "origin/$BASE_REF_VAL...$COMPARE_REF" \
+                | grep -v '^$' | grep '^examples/' | head -1 || true)
             fi
-            BASE_REF_VAL="${BASE_REF:-main}"
-            CHANGED=$(git log --name-only --format="" --no-merges \
-              "origin/$BASE_REF_VAL..$COMPARE_REF" \
-              | grep -v '^$' | grep '^examples/' | head -1 || true)
             if [[ -n "$CHANGED" ]]; then
               echo "run-examples=true" >> "$GITHUB_OUTPUT"
             else


### PR DESCRIPTION
## Summary

- Replace `git diff` three-dot notation with GitHub PR Files API for changed file detection in PR context
- Fix `HAS_AFFECTED=false` regression that occurs after `update-branch` merges the base branch into a PR branch
- Also fix `detect-examples` step: replace `git log` (Issue #1833 regression) with `git diff` for non-PR fallback, and use PR Files API in PR context

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

After `update-branch` (GitHub's feature that merges the base branch into the PR head branch), the three-dot `git diff origin/main...PR-tip` returns empty because `origin/main` becomes an ancestor of the PR branch tip. The three-dot merge base is then `origin/main` itself, so only commits after the merge are shown (the empty CI re-trigger commit). This caused `HAS_AFFECTED=false` even when the PR contained real Rust source changes.

Root cause demonstrated on PR #1806:
- `git diff origin/main...origin/feature/issue-1800-apply-update` → empty (8 Rust files NOT detected)  
- `gh api repos/.../pulls/1806/files` → 8 Rust files correctly detected

The GitHub PR Files API uses its own algorithm (immune to git history shape) to identify files changed by a PR.

Fixes #1836
Refs #1822, #1833

## How Was This Tested?

- Verified PR #1806 via `gh api repos/.../pulls/1806/files` returns 8 correct Rust source files even after `update-branch` collapsed the merge base
- Pre-push: `cargo make fmt-check` and `cargo make clippy-check` passed

## Checklist

- [x] All pre-push checks pass (`cargo make fmt-check`, `cargo make clippy-check`)
- [x] No new `todo!()`, `// TODO`, or `// FIXME` comments added
- [x] Labels applied

## Labels to Apply

- `bug`: Fixes incorrect behavior
- `ci-cd`: CI/CD workflow change

🤖 Generated with [Claude Code](https://claude.com/claude-code)