### PR TITLE
ci: add pull-requests: read permission to enable PR Files API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary

Add `pull-requests: read` permission to `ci.yml` to enable the GitHub PR Files API in the `detect-affected-packages` workflow.

- Add `pull-requests: read` to the `permissions` block in `.github/workflows/ci.yml`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

PR #1837 (Issue #1836) added GitHub PR Files API support to `detect-affected-packages.sh` to detect changed files reliably after `update-branch`. However, the fix was incomplete: the GitHub token used in `workflow_call` inherits permissions from the caller (`ci.yml`), and `ci.yml` only granted `contents: read` and `id-token: write`.

The PR Files API endpoint (`/repos/{owner}/{repo}/pulls/{n}/files`) requires `pull-requests: read` permission. Without this permission, `gh api` silently fails (due to `2>/dev/null`), causing `CHANGED_FILES` to be empty and `HAS_AFFECTED=false`, which skips all test jobs.

This was confirmed by examining the CI logs for PR #1806, which showed:
```
GITHUB_TOKEN Permissions:
  Contents: read
  Metadata: read
```

The `pull-requests: read` permission was missing.

Fixes #1836 (follow-up to PR #1837)

## How Was This Tested?

- The fix will be verified by PR #1806's CI after this PR is merged and update-branch is run on #1806
- Expected: `HAS_AFFECTED=true` and all test jobs execute (not skipped)

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are focused and minimal
- [x] CI/CD changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)