### PR TITLE
fix(ci): resolve jq context reference bug in affected package detection

### DIFF
--- a/.github/scripts/detect-affected-packages.sh
+++ b/.github/scripts/detect-affected-packages.sh
@@ -33,6 +33,9 @@ else
     | grep -v '^$' | sort -u || true)
 fi
 
+FILE_COUNT=$(echo "$CHANGED_FILES" | wc -l | tr -d ' ')
+echo "::notice::Changed files ($FILE_COUNT total): $(echo "$CHANGED_FILES" | head -5 | tr '\n' ', ')"
+
 if [[ -z "$CHANGED_FILES" ]]; then
   echo "run-all=false" >> "$GITHUB_OUTPUT"
   echo "has-affected=false" >> "$GITHUB_OUTPUT"
@@ -65,7 +68,10 @@ fi
 # set -e in bash — the assignment itself succeeds even when the subshell fails.
 # Fall back to a full test run if cargo metadata is unavailable or returns
 # empty output. # Issue #1819
-WORKSPACE_ROOT=$(pwd)
+# Resolve symlinks in workspace root so paths match cargo metadata's
+# manifest_path (which always uses the canonical path). This matters on
+# macOS where /tmp -> /private/tmp.
+WORKSPACE_ROOT=$(cd "$(pwd)" && pwd -P)
 if ! METADATA=$(cargo metadata --format-version 1 --no-deps) \
     || [[ -z "$METADATA" ]]; then
   echo "run-all=true" >> "$GITHUB_OUTPUT"
@@ -75,24 +81,35 @@ if ! METADATA=$(cargo metadata --format-version 1 --no-deps) \
   exit 0
 fi
 
+PKG_COUNT=$(echo "$METADATA" | jq '.packages | length')
+echo "::notice::Workspace packages: $PKG_COUNT"
+
 declare -A AFFECTED_MAP
 while IFS= read -r file; do
   ABS_FILE="$WORKSPACE_ROOT/$file"
-  # Use try-catch in jq so that a single malformed package entry does not abort
-  # the entire scan. # Issue #1819
+  # Map file to the most specific (longest path match) workspace package.
+  # Bind the package object to $pkg so that .manifest_path resolves correctly
+  # inside the startswith() call. Issue #1843
   PKG=$(echo "$METADATA" | jq -r --arg f "$ABS_FILE" '
-    .packages[]
+    [.packages[]
+    | . as $pkg
+    | ($pkg.manifest_path | rtrimstr("/Cargo.toml")) as $dir
     | select(
-        try ($f | startswith((.manifest_path | rtrimstr("/Cargo.toml"))))
+        try ($f | startswith($dir))
         catch false
       )
-    | .name' 2>/dev/null | head -1 || true)
+    | {name: $pkg.name, dirlen: ($dir | length)}]
+    | sort_by(-.dirlen)
+    | .[0].name // empty' || true)
+  echo "::notice::File mapping: $file -> ${PKG:-<no match>}"
   if [[ -n "$PKG" && "$PKG" != "null" ]]; then
     AFFECTED_MAP["$PKG"]=1
   fi
 done <<< "$CHANGED_FILES"
 
 AFFECTED_PKGS=(${!AFFECTED_MAP[@]})
+
+echo "::notice::Affected packages (${#AFFECTED_PKGS[@]}): ${AFFECTED_PKGS[*]}"
 
 if [[ ${#AFFECTED_PKGS[@]} -eq 0 ]]; then
   echo "run-all=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix jq context reference bug in `detect-affected-packages.sh` that caused `HAS_AFFECTED=false` for all PRs modifying only crate source files
- Add `::notice::` CI annotations for debugging visibility
- Resolve symlink paths for macOS compatibility (`/tmp` -> `/private/tmp`)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The jq query on line 86 used `.manifest_path` inside a `startswith()` call where `.` was bound to the file string (`$f`), not the package object from `.packages[]`. This caused all file-to-package mappings to silently fail due to `try/catch false` + `2>/dev/null` double suppression, resulting in `HAS_AFFECTED=false` and skipped tests for every PR.

Previous PRs addressed symptoms but not this root cause:
- PR #1837: Switched git diff to GitHub PR Files API
- PR #1839: Added `pull-requests: read` permission
- PR #1841: Removed error suppression on `gh api` calls

Fixes #1843

Related to: #1836, #1806

## How Was This Tested?

- Local execution of the script with PR #1806 context (`PR_NUMBER=1806 GITHUB_REPOSITORY=kent8192/reinhardt-web`)
- Verified all 8 changed files correctly map to their workspace packages:
  - `crates/reinhardt-core/macros/src/*` -> `reinhardt-macros`
  - `crates/reinhardt-core/src/*` -> `reinhardt-core`
  - `src/lib.rs` -> `reinhardt-web`
  - `tests/integration/src/*` -> `reinhardt-integration-tests`
- Confirmed `has-affected=true` and correct `nextest-filter` expression in output

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- #1843 (root cause)
- #1836 (original issue)
- #1806 (affected PR)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label
- [x] `high` - Important fix or feature

---

**Additional Context:**

The fix involves three changes to `.github/scripts/detect-affected-packages.sh`:

1. **Root cause fix**: Bind the package object to `$pkg` variable (`. as $pkg`) so `.manifest_path` resolves against the package, not the file string
2. **Accuracy improvement**: Use longest-path matching (`sort_by(-.dirlen)`) to return the most specific package for nested crate structures
3. **Robustness**: Resolve symlinks in workspace root (`pwd -P`) for macOS compatibility, and remove residual `2>/dev/null` stderr suppression

🤖 Generated with [Claude Code](https://claude.com/claude-code)