### PR TITLE
fix(release): add version to reinhardt-test workspace dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ This project uses [release-plz](https://release-plz.ieni.dev/) for automated rel
 
 **Key Warnings (Lessons Learned):**
 - **NEVER** create circular publish dependency chains (functional crates must not dev-depend on other Reinhardt crates)
-- **NEVER** add `version` field to `reinhardt-test` workspace dependency (causes publish failure; see cargo#15151)
+- **MUST** include `version` field in `reinhardt-test` workspace dependency (same as other published crates)
 - **MUST** follow RP-1 recovery procedure for partial release failures (see instructions/RELEASE_PROCESS.md)
 - **NEVER** change `pr_branch_prefix` from `"release-plz-"` (breaks two-step release workflow)
 - `publish_no_verify = true` is required because dev-dependencies reference unpublished workspace crates
@@ -461,7 +461,7 @@ Before submitting code:
 - Use `deprecated` type for marking features/APIs as deprecated (dedicated CHANGELOG section)
 - Review Release PRs created by release-plz before merging
 - Verify no circular dev-dependency chains exist before publishing (functional crates must not dev-depend on other Reinhardt crates)
-- Keep `reinhardt-test` workspace dependency without `version` field (unpublished crate; cargo#15151)
+- Include `version` field in `reinhardt-test` workspace dependency (published crate, same as others)
 - Follow RP-1 procedure in instructions/RELEASE_PROCESS.md for partial release failures
 - Use GitHub CLI (`gh`) for all GitHub operations (PR, issues, releases)
 - Search existing issues before creating new ones
@@ -521,7 +521,7 @@ Before submitting code:
 - Create release tags manually (release-plz creates them automatically)
 - Skip reviewing Release PRs before merging
 - Add `reinhardt-test` to functional crate `[dev-dependencies]` (creates circular publish dependency)
-- Add `version` field to `reinhardt-test` workspace dependency (breaks cargo publish; cargo#15151)
+- Omit `version` field from `reinhardt-test` workspace dependency (causes publish failure for dependents)
 - Change `pr_branch_prefix` from `"release-plz-"` (breaks two-step release workflow)
 - Merge Release PR without rolling back unpublished crate versions after partial release failure
 - Write vague commit descriptions that are unclear as CHANGELOG entries (e.g., "fix issue", "update code")

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ reinhardt-db = { workspace = true, optional = true }
 
 # External crates re-exported for macros
 inventory = { workspace = true, optional = true }
-reinhardt-test = { path = "crates/reinhardt-test", optional = true }
+reinhardt-test = { workspace = true, optional = true }
 reinhardt-rest = { workspace = true, optional = true }
 reinhardt-auth = { workspace = true, optional = true }
 
@@ -390,7 +390,7 @@ reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.
 reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.0-rc.2" }
 reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.1.0-rc.2" }
 reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.0-rc.2" }
-reinhardt-test = { path = "crates/reinhardt-test" }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-rc.2" }
 reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.0-rc.2" }
 reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.0-rc.2" }
 reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-rc.2" }

--- a/instructions/RELEASE_PROCESS.md
+++ b/instructions/RELEASE_PROCESS.md
@@ -273,9 +273,9 @@ Enables release-plz to automatically update explicit `version` fields in workspa
 
 Ensures `release-plz release` publishes ALL crates whose local version differs from crates.io, not just those with actual code changes. This prevents the phantom version issue described in [KI-5](#ki-5-phantom-version-bumps-from-dependencies_update): when `dependencies_update = true` bumps versions for dependency-only changes, `release_always = false` would skip publishing those crates, creating versions in git that don't exist on crates.io. Normal code pushes are unaffected since local versions match crates.io; only after a Release PR merge will version differences trigger publishing. (Ref: [#185](https://github.com/kent8192/reinhardt-web/pull/185), [#186](https://github.com/kent8192/reinhardt-web/pull/186), [#246](https://github.com/kent8192/reinhardt-web/issues/246))
 
-**`reinhardt-test` workspace dependency without `version` field**
+**`reinhardt-test` workspace dependency with `version` field**
 
-The `reinhardt-test` crate (`publish = false`) is used as a workspace dependency by publishable crates. Its workspace dependency entry in the root `Cargo.toml` intentionally omits the `version` field. Adding a `version` field would cause `cargo publish` to attempt resolving `reinhardt-test` from crates.io (where it does not exist), breaking the publish of any crate that depends on it via dev-dependencies. This is related to a Cargo regression tracked in [cargo#15151](https://github.com/rust-lang/cargo/issues/15151). (Ref: [#185](https://github.com/kent8192/reinhardt-web/pull/185), [#223](https://github.com/kent8192/reinhardt-web/pull/223))
+The `reinhardt-test` crate is published on crates.io and its workspace dependency entry in the root `Cargo.toml` **must** include the `version` field, same as all other published workspace crates. Previously, the `version` field was intentionally omitted as a workaround for [cargo#15151](https://github.com/rust-lang/cargo/issues/15151) when `reinhardt-test` was not yet published. Since `reinhardt-test` is now published on crates.io, the workaround is no longer needed and omitting the `version` field causes publish failures for crates that depend on it (e.g., `reinhardt-web`). (Ref: [#185](https://github.com/kent8192/reinhardt-web/pull/185), [#223](https://github.com/kent8192/reinhardt-web/pull/223))
 
 ---
 
@@ -293,11 +293,13 @@ The `reinhardt-test` crate (`publish = false`) is used as a workspace dependency
 
 (Ref: [#181](https://github.com/kent8192/reinhardt-web/pull/181), [#199](https://github.com/kent8192/reinhardt-web/pull/199), [#203](https://github.com/kent8192/reinhardt-web/pull/203), [#216](https://github.com/kent8192/reinhardt-web/pull/216))
 
-### KI-2: Cargo 1.84+ Dev-Dependency Resolution Regression
+### KI-2: Cargo 1.84+ Dev-Dependency Resolution Regression (Resolved)
 
 **Problem**: Starting with Cargo 1.84, `cargo publish` attempts to resolve workspace dev-dependencies from crates.io even when they are marked `publish = false`. If the workspace dependency entry includes a `version` field, Cargo tries to find that version on crates.io and fails when the crate does not exist there.
 
-**Workaround**: Ensure that unpublished workspace crates (e.g., `reinhardt-test`) do **not** have a `version` field in their `[workspace.dependencies]` entry. The `publish_no_verify = true` setting provides additional protection by skipping the verification build.
+**Previous Workaround**: Ensured that unpublished workspace crates (e.g., `reinhardt-test`) did **not** have a `version` field in their `[workspace.dependencies]` entry. The `publish_no_verify = true` setting provided additional protection by skipping the verification build.
+
+**Current Status**: This workaround is **no longer needed** for `reinhardt-test` because it is now published on crates.io (v0.1.0-rc.2). All workspace dependency entries, including `reinhardt-test`, should include a `version` field. The workaround remains relevant only for truly unpublished crates (those with `publish = false`).
 
 **Tracking**: [cargo#15151](https://github.com/rust-lang/cargo/issues/15151)
 
@@ -466,28 +468,24 @@ gh workflow run release-plz.yml
 
 (Ref: [#225](https://github.com/kent8192/reinhardt-web/pull/225))
 
-### RP-4: reinhardt-test Version Reintroduced
+### RP-4: reinhardt-test Version Missing (Obsolete)
 
-Use this procedure when a `version` field is accidentally added to the `reinhardt-test` workspace dependency.
+**Note**: This recovery procedure is **obsolete** as of March 2026. The `reinhardt-test` crate is now published on crates.io and **must** have a `version` field in its workspace dependency entry, same as all other published crates. The original workaround of omitting the `version` field was needed only when `reinhardt-test` was not published.
 
-**Detection**: `cargo publish --dry-run` fails for crates that dev-depend on `reinhardt-test`, with errors indicating that `reinhardt-test` cannot be found on crates.io.
-
-**Step 1: Remove the version field**
-
-In the root `Cargo.toml`, locate the `[workspace.dependencies]` section and remove the `version` field from the `reinhardt-test` entry:
+**If `version` is accidentally removed**, add it back:
 
 ```toml
-# Before (broken)
-reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0" }
+# Before (broken - missing version)
+reinhardt-test = { path = "crates/reinhardt-test" }
 
 # After (correct)
-reinhardt-test = { path = "crates/reinhardt-test" }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-rc.2" }
 ```
 
-**Step 2: Verify**
+**Verify:**
 
 ```bash
-cargo publish --dry-run -p reinhardt-orm  # or any crate that dev-depends on reinhardt-test
+cargo publish --dry-run -p reinhardt-web  # root crate depends on reinhardt-test
 ```
 
 (Ref: [#185](https://github.com/kent8192/reinhardt-web/pull/185), [#223](https://github.com/kent8192/reinhardt-web/pull/223))


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix `reinhardt-web` crates.io publish failure caused by missing `version` field in `reinhardt-test` workspace dependency
- Update obsolete workaround documentation (KI-2, RP-4, Configuration Rationale in RELEASE_PROCESS.md)
- Update CLAUDE.md rules to reflect `reinhardt-test` as a published crate

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Motivation and Context

The release-plz Release job ([run #22673668203](https://github.com/kent8192/reinhardt-web/actions/runs/22673668203/job/65725970310)) failed to publish `reinhardt-web` after merging PR #1850 (`chore: release`). The error:

```
dependency `reinhardt-test` does not specify a version
```

The `version` field was intentionally omitted as a workaround for [cargo#15151](https://github.com/rust-lang/cargo/issues/15151) when `reinhardt-test` was not yet published on crates.io. Since `reinhardt-test` is now published (v0.1.0-rc.2), this workaround is no longer needed and actively prevents `reinhardt-web` from being published.

Fixes #1851

## How Was This Tested?

- [x] `cargo check --workspace --all --all-features` passes
- [x] `cargo publish --dry-run --allow-dirty -p reinhardt-web` succeeds (no version error)
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Fixes #1851
- Related to: PR #1850 (release that triggered the failure)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Priority Label
- [x] `critical` - Blocks release

🤖 Generated with [Claude Code](https://claude.com/claude-code)