### PR TITLE
chore(examples): bump dependency versions to 0.1.0-rc.2

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,10 +21,10 @@ members = [
 
 [workspace.dependencies]
 # Reinhardt framework (crates.io published versions)
-reinhardt = { version = "0.1.0-rc.1", package = "reinhardt-web" }
-reinhardt-query = { version = "0.1.0-rc.1" }
-reinhardt-websockets = { version = "0.1.0-rc.1" }
-reinhardt-auth = { version = "0.1.0-rc.1" }
+reinhardt = { version = "0.1.0-rc.2", package = "reinhardt-web" }
+reinhardt-query = { version = "0.1.0-rc.2" }
+reinhardt-websockets = { version = "0.1.0-rc.2" }
+reinhardt-auth = { version = "0.1.0-rc.2" }
 
 # Testing
 testcontainers = { version = "0.26.3", features = ["blocking"] }


### PR DESCRIPTION
## Summary

- Bump all Reinhardt workspace dependency versions in `examples/Cargo.toml` from `0.1.0-rc.1` to `0.1.0-rc.2`

## Type of Change

- [x] Other (please describe): Dependency version bump for examples workspace

## Motivation and Context

All main crates have been released as `0.1.0-rc.2`, but the `examples/` workspace still references `0.1.0-rc.1`. This update aligns examples with the latest published versions.

## How Was This Tested?

- [x] Verified `examples/Cargo.toml` contains correct version strings
- [x] Pre-push checks (fmt-check, clippy-check, cargo check) passed

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `dependencies` - Dependency version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)