### PR TITLE
fix(ci): enforce semver-check during RC phase instead of skipping

### DIFF
--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -83,24 +83,45 @@ jobs:
             --all-features \
             --baseline-rev "${BASELINE_REV:-HEAD~1}"
 
-      # Check if any workspace crate has a pre-release version (e.g. -rc, -alpha, -beta).
-      # Per SemVer spec, pre-release versions have no API stability guarantees,
-      # so semver-checks are skipped entirely for pre-release crates.
-      - name: Detect pre-release versions
+      # Detect pre-release phase to determine the appropriate semver-check behavior:
+      # - Alpha (0.x.y-alpha.N): No API stability guarantees → skip semver-check
+      # - RC (0.x.y-rc.N): API frozen, bug fixes only → enforce semver-check
+      # - Stable (0.x.y): Full SemVer guarantees → enforce semver-check
+      - name: Detect pre-release phase
         if: ${{ !startsWith(github.head_ref || github.ref_name, 'release-plz-') }}
         id: detect-prerelease
         run: |
-          if grep -rqP '^version\s*=\s*"[^"]*-' crates/*/Cargo.toml; then
-            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Pre-release version detected. Skipping semver-check (no API stability guarantee)."
+          if grep -rqP '^version\s*=\s*"[^"]*-alpha' crates/*/Cargo.toml; then
+            echo "phase=alpha" >> "$GITHUB_OUTPUT"
+            echo "::notice::Alpha version detected. Skipping semver-check (no API stability guarantee during alpha)."
+          elif grep -rqP '^version\s*=\s*"[^"]*-rc' crates/*/Cargo.toml; then
+            echo "phase=rc" >> "$GITHUB_OUTPUT"
+            echo "::notice::RC version detected. Enforcing semver-check (API frozen during RC phase)."
           else
-            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "phase=stable" >> "$GITHUB_OUTPUT"
+            echo "::notice::Stable version detected. Enforcing semver-check (full SemVer guarantees)."
           fi
+
+      # On normal PRs with RC versions, enforce minor release type to block
+      # breaking changes. Per stability policy (SP-1), the API surface is frozen
+      # during RC -- only bug fixes and deprecation-alias renames are permitted.
+      - name: Run cargo-semver-checks (normal PR - RC versions)
+        if: ${{ !startsWith(github.head_ref || github.ref_name, 'release-plz-') && steps.detect-prerelease.outputs.phase == 'rc' }}
+        env:
+          BASELINE_REV: ${{ github.event.pull_request.base.sha }}
+        run: |
+          cargo semver-checks check-release \
+            --workspace \
+            --exclude reinhardt-web \
+            --exclude reinhardt-pages \
+            --all-features \
+            --release-type minor \
+            --baseline-rev "${BASELINE_REV:-HEAD~1}"
 
       # On normal PRs with stable versions, enforce minor release type to block
       # breaking changes from being merged into main.
-      - name: Run cargo-semver-checks (normal PR - stable versions only)
-        if: ${{ !startsWith(github.head_ref || github.ref_name, 'release-plz-') && steps.detect-prerelease.outputs.is_prerelease != 'true' }}
+      - name: Run cargo-semver-checks (normal PR - stable versions)
+        if: ${{ !startsWith(github.head_ref || github.ref_name, 'release-plz-') && steps.detect-prerelease.outputs.phase == 'stable' }}
         env:
           BASELINE_REV: ${{ github.event.pull_request.base.sha }}
         run: |


### PR DESCRIPTION
## Summary

- Distinguish between alpha and RC pre-release phases in the semver-check workflow
- Alpha versions: skip semver-check (no API stability guarantees per AP-1)
- RC versions: enforce semver-check with `--release-type minor` (API frozen per SP-1)
- Stable versions: enforce semver-check (unchanged behavior)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The previous implementation treated all pre-release versions (`-alpha`, `-rc`, `-beta`) identically, skipping the semver-check for all of them. This contradicted the stability policy (SP-1) which requires API freeze during the RC phase.

Per the stability policy:
- **Alpha**: APIs may change freely → semver-check should be skipped
- **RC**: API frozen, only bug fixes and deprecation-alias renames permitted → semver-check should enforce no breaking changes
- **Stable**: Full SemVer guarantees → semver-check should enforce no breaking changes

The `--release-type minor` flag correctly blocks breaking changes (which would require a major bump) while allowing non-breaking changes like deprecation aliases.

## How Was This Tested?

- [x] Reviewed `cargo-semver-checks` documentation to confirm `--release-type minor` behavior
- [x] Verified grep patterns correctly distinguish `-alpha` from `-rc` suffixes
- [x] Confirmed workflow YAML syntax is valid
- [x] Verified `--baseline-rev` usage is compatible with pre-release crates (not published on crates.io)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)