### PR TITLE
ci: add auto-close parent issue workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -172,3 +172,8 @@
 - name: automated
   color: "ededed"
   description: "Automated PR (release-plz)"
+
+# Automation Labels
+- name: auto-closed
+  color: c5def5
+  description: Automatically closed when all sub-issues were completed

--- a/.github/workflows/auto-close-parent-issue.yml
+++ b/.github/workflows/auto-close-parent-issue.yml
@@ -1,0 +1,230 @@
+name: Auto-Close Parent Issue
+
+on:
+  issues:
+    types: [closed, reopened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  auto-close-parent:
+    name: Auto-Close Parent Issue
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check and close parent issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const MAX_DEPTH = 5;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            async function getParent(issueNumber) {
+              try {
+                const response = await github.request(
+                  'GET /repos/{owner}/{repo}/issues/{issue_number}/parent',
+                  { owner, repo, issue_number: issueNumber }
+                );
+                // Skip if parent is in a different repository
+                if (response.data.repository &&
+                    response.data.repository.full_name !== `${owner}/${repo}`) {
+                  core.info(`Parent #${response.data.number} is in a different repository, skipping`);
+                  return null;
+                }
+                return response.data;
+              } catch (error) {
+                if (error.status === 404) {
+                  return null;
+                }
+                throw error;
+              }
+            }
+
+            async function getSubIssues(issueNumber) {
+              const subIssues = [];
+              let page = 1;
+              while (true) {
+                const response = await github.request(
+                  'GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                  { owner, repo, issue_number: issueNumber, per_page: 100, page }
+                );
+                subIssues.push(...response.data);
+                if (response.data.length < 100) break;
+                page++;
+              }
+              return subIssues;
+            }
+
+            async function processParentChain(issueNumber, depth) {
+              if (depth >= MAX_DEPTH) {
+                core.info(`Reached max depth (${MAX_DEPTH}), stopping recursion`);
+                return;
+              }
+
+              const parent = await getParent(issueNumber);
+              if (!parent) {
+                core.info(`Issue #${issueNumber} has no parent issue`);
+                return;
+              }
+
+              core.info(`Found parent issue #${parent.number}: ${parent.title}`);
+
+              // Skip if parent is already closed
+              if (parent.state === 'closed') {
+                core.info(`Parent #${parent.number} is already closed, checking grandparent`);
+                await processParentChain(parent.number, depth + 1);
+                return;
+              }
+
+              // Check all sub-issues of the parent
+              const subIssues = await getSubIssues(parent.number);
+              if (subIssues.length === 0) {
+                core.info(`Parent #${parent.number} has no sub-issues`);
+                return;
+              }
+
+              const allClosed = subIssues.every(sub => sub.state === 'closed');
+              core.info(`Parent #${parent.number} has ${subIssues.length} sub-issues, all closed: ${allClosed}`);
+
+              if (!allClosed) {
+                const openSubs = subIssues.filter(sub => sub.state !== 'closed');
+                core.info(`Open sub-issues: ${openSubs.map(s => `#${s.number}`).join(', ')}`);
+                return;
+              }
+
+              // All sub-issues are closed - close the parent
+              const subIssueList = subIssues
+                .map(sub => `- #${sub.number}: ${sub.title} (closed)`)
+                .join('\n');
+
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: parent.number,
+                body: [
+                  'All sub-issues have been completed. Automatically closing this issue.',
+                  '',
+                  '### Completed sub-issues',
+                  subIssueList,
+                  '',
+                  '---',
+                  '*This action was performed automatically by the auto-close-parent-issue workflow.*'
+                ].join('\n')
+              });
+
+              await github.rest.issues.addLabels({
+                owner, repo,
+                issue_number: parent.number,
+                labels: ['auto-closed']
+              });
+
+              await github.rest.issues.update({
+                owner, repo,
+                issue_number: parent.number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+
+              core.info(`Closed parent issue #${parent.number}`);
+
+              // Recursively check grandparent
+              await processParentChain(parent.number, depth + 1);
+            }
+
+            await processParentChain(context.issue.number, 0);
+
+  auto-reopen-parent:
+    name: Reopen Parent Issue
+    if: github.event.action == 'reopened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check and reopen parent issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const MAX_DEPTH = 5;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            async function getParent(issueNumber) {
+              try {
+                const response = await github.request(
+                  'GET /repos/{owner}/{repo}/issues/{issue_number}/parent',
+                  { owner, repo, issue_number: issueNumber }
+                );
+                if (response.data.repository &&
+                    response.data.repository.full_name !== `${owner}/${repo}`) {
+                  core.info(`Parent #${response.data.number} is in a different repository, skipping`);
+                  return null;
+                }
+                return response.data;
+              } catch (error) {
+                if (error.status === 404) {
+                  return null;
+                }
+                throw error;
+              }
+            }
+
+            async function processParentChain(issueNumber, depth) {
+              if (depth >= MAX_DEPTH) {
+                core.info(`Reached max depth (${MAX_DEPTH}), stopping recursion`);
+                return;
+              }
+
+              const parent = await getParent(issueNumber);
+              if (!parent) {
+                core.info(`Issue #${issueNumber} has no parent issue`);
+                return;
+              }
+
+              core.info(`Found parent issue #${parent.number}: ${parent.title}`);
+
+              // Only reopen if parent was auto-closed
+              if (parent.state !== 'closed') {
+                core.info(`Parent #${parent.number} is not closed, skipping`);
+                return;
+              }
+
+              const labels = parent.labels.map(l => l.name);
+              if (!labels.includes('auto-closed')) {
+                core.info(`Parent #${parent.number} was not auto-closed, skipping`);
+                return;
+              }
+
+              // Reopen the parent
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: parent.number,
+                body: [
+                  `Sub-issue #${issueNumber} was reopened. Automatically reopening this parent issue.`,
+                  '',
+                  '---',
+                  '*This action was performed automatically by the auto-close-parent-issue workflow.*'
+                ].join('\n')
+              });
+
+              await github.rest.issues.removeLabel({
+                owner, repo,
+                issue_number: parent.number,
+                name: 'auto-closed'
+              }).catch(err => {
+                // Label may have been manually removed
+                if (err.status !== 404) throw err;
+              });
+
+              await github.rest.issues.update({
+                owner, repo,
+                issue_number: parent.number,
+                state: 'open'
+              });
+
+              core.info(`Reopened parent issue #${parent.number}`);
+
+              // Recursively check grandparent
+              await processParentChain(parent.number, depth + 1);
+            }
+
+            await processParentChain(context.issue.number, 0);


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that automatically closes parent issues when all sub-issues are completed
- Add `auto-closed` label to `.github/labels.yml` for tracking auto-closed issues
- Support automatic reopening of parent issues when a sub-issue is reopened

## Type of Change

- [x] CI/CD changes

## Motivation and Context

GitHub's sub-issue feature does not automatically close parent issues when all sub-issues are completed. This workflow automates that process using the GitHub sub-issues REST API (GA since December 2024).

Key features:
- Recursive parent chain traversal (up to 5 levels)
- Automatic comment with completed sub-issue summary
- `auto-closed` label to distinguish from manually closed issues
- Automatic reopening when a sub-issue is reopened (only for `auto-closed` parents)
- Cross-repository parent skip, pagination support for 100+ sub-issues

## How Was This Tested?

- [ ] Create a test parent issue with 2-3 sub-issues
- [ ] Close sub-issues one by one
- [ ] Verify parent auto-closes with comment and label on last sub-issue close
- [ ] Reopen a sub-issue and verify parent reopens with label removed

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `ci-cd` - CI/CD workflow changes

### Scope Label (select all that apply)
- [x] `github-actions` - GitHub Actions workflow files

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)