### PR TITLE
fix(ci): remove non-existent paths from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,9 @@
 # Default owner for everything
 * @kent8192
 
-# Local examples
-/local/ @kent8192
-
-# Remote common utilities
-/remote/common/ @kent8192
-/remote/test-macros/ @kent8192
-
 # CI/CD
 /.github/workflows/ @kent8192
 
 # Documentation
 /README.md @kent8192
 /CONTRIBUTING.md @kent8192
-/SUBTREE_OPERATIONS.md @kent8192


### PR DESCRIPTION
## Summary

- Remove 4 non-existent path references from `.github/CODEOWNERS`
- Removed: `/local/`, `/remote/common/`, `/remote/test-macros/`, `/SUBTREE_OPERATIONS.md`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

CODEOWNERS referenced paths that no longer exist in the repository, likely remnants from a previous repository structure (subtree layout). These stale entries cause GitHub to show warnings.

Fixes #1541

## How Was This Tested?

- [x] Verified all removed paths do not exist in the repository
- [x] Verified remaining paths are valid

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)