### PR TITLE
ci: add develop leak guard to detect indirect develop/* merges

### DIFF
--- a/.github/workflows/develop-leak-guard.yml
+++ b/.github/workflows/develop-leak-guard.yml
@@ -1,0 +1,81 @@
+name: Develop Leak Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  develop-leak-guard:
+    name: Develop Leak Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if migration-approved
+        id: label-check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const labels = pr.labels.map(l => l.name);
+            const approved = labels.includes('migration-approved');
+            core.setOutput('skip', approved ? 'true' : 'false');
+            if (approved) {
+              core.info('migration-approved label found, skipping leak check.');
+            }
+
+      - name: Checkout full history
+        if: steps.label-check.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for develop/* merge leaks
+        if: steps.label-check.outputs.skip != 'true'
+        run: |
+          # Fetch all remote develop/* refs
+          git fetch origin '+refs/heads/develop/*:refs/remotes/origin/develop/*' --no-tags 2>/dev/null || true
+
+          # Check if any develop/* remote branches exist
+          if ! git branch -r | grep -q 'origin/develop/'; then
+            echo "No origin/develop/* branches found. Nothing to check."
+            exit 0
+          fi
+
+          MERGE_BASE=$(git merge-base origin/main HEAD)
+          FOUND=0
+          DETAILS=""
+
+          while IFS=' ' read -r HASH PARENT1 PARENT2 REST; do
+            if [ -n "$PARENT2" ]; then
+              DEVELOP_BRANCH=$(git branch -r --contains "$PARENT2" 2>/dev/null \
+                | grep 'origin/develop/' | head -1 | xargs)
+              if [ -n "$DEVELOP_BRANCH" ]; then
+                SUBJECT=$(git log --oneline -1 "$HASH")
+                DETAILS="${DETAILS}  - ${SUBJECT} (parent: ${PARENT2:0:12} on ${DEVELOP_BRANCH})\n"
+                FOUND=1
+              fi
+            fi
+          done < <(git log "$MERGE_BASE"..HEAD --merges --format="%H %P")
+
+          if [ "$FOUND" -eq 1 ]; then
+            echo "::error::This PR contains merge commits from develop/* branches."
+            echo "Detected develop/* merge leaks:"
+            echo -e "$DETAILS"
+            echo ""
+            echo "If this is an intentional develop branch merge, apply the 'migration-approved' label."
+            exit 1
+          else
+            echo "No develop/* merge leaks detected."
+          fi


### PR DESCRIPTION
## Summary

- Add `develop-leak-guard.yml` workflow to detect merge commits from `develop/*` branches in non-develop PRs
- Uses `git branch -r --contains` on merge commit second parents to detect develop ancestry
- Skips check for PRs with `migration-approved` label (legitimate develop merges)

## Type of Change

- [x] CI/CD changes

## Motivation and Context

The existing Develop Merge Guard only checks PR source branch names. Content from `develop/*` can leak into `main` through feature branches that merged `develop/*` into themselves (e.g., PR #1918).

Fixes #1986

## How Was This Tested?

- [x] Locally verified detection against PR #1918 history (correctly blocked)
- [x] Locally verified no false positives on clean branch (`chore/cleanup-serena-project-yml`)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)