### PR TITLE
fix(ci): add missing validator dependency to reinhardt-test-support

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -82,6 +82,7 @@ sqlx = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
 reinhardt-query = { workspace = true, features = ["derive"] }
 utoipa = { version = "^5.4.0", features = ["url", "uuid", "yaml"] }
+validator = { version = "0.20", features = ["derive"] }
 ctor = "0.6.0"
 linkme = "0.3"
 


### PR DESCRIPTION
## Summary

- Add missing `validator` dependency to `tests/Cargo.toml` (`reinhardt-test-support`)
- `pre_validate.rs` uses `validator::Validate` but the dependency was only in `reinhardt-integration-tests`

Fixes #1995

## Test plan

- [x] `cargo check -p reinhardt-test-support --all-features --tests` passes
- [x] `cargo check --workspace --all-features --bins --examples --benches` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)