### PR TITLE
fix(infra): add data_type to SSM parameter for Launch Template resolution

### DIFF
--- a/infra/github-runners/imports.tf
+++ b/infra/github-runners/imports.tf
@@ -15,3 +15,10 @@
 #   to = github_actions_variable.self_hosted_enabled
 #   id = "${var.github_owner}/${var.github_repository}/SELF_HOSTED_ENABLED"
 # }
+
+# Golden AMI SSM parameter (see #2023).
+# Idempotent: no-op if already managed by this workspace.
+import {
+	to = aws_ssm_parameter.runner_ami_id
+	id = "/${var.prefix}/runner-ami-id"
+}

--- a/infra/github-runners/ssm.tf
+++ b/infra/github-runners/ssm.tf
@@ -1,10 +1,34 @@
+# Latest Ubuntu 22.04 arm64 AMI (Canonical) for SSM parameter initial value.
+# The build-runner-ami workflow overwrites this with the Golden AMI;
+# this data source only provides a valid AMI ID so Terraform can create
+# the parameter with data_type = "aws:ec2:image" (which validates the value).
+data "aws_ami" "ubuntu_arm64_latest" {
+	most_recent = true
+	owners      = ["099720109477"] # Canonical
+
+	filter {
+		name   = "name"
+		values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"]
+	}
+
+	filter {
+		name   = "virtualization-type"
+		values = ["hvm"]
+	}
+}
+
 # SSM Parameter to store the Golden AMI ID.
 # Value is managed by the build-runner-ami GitHub Actions workflow;
 # Terraform only creates the parameter and ignores subsequent value changes.
+#
+# data_type = "aws:ec2:image" is REQUIRED: the EC2 Launch Template resolves
+# the AMI via `resolve:ssm:` which only works with this data type.
+# See: https://github.com/kent8192/reinhardt-web/issues/2023
 resource "aws_ssm_parameter" "runner_ami_id" {
-	name  = "/${var.prefix}/runner-ami-id"
-	type  = "String"
-	value = "ami-placeholder"
+	name      = "/${var.prefix}/runner-ami-id"
+	type      = "String"
+	data_type = "aws:ec2:image"
+	value     = data.aws_ami.ubuntu_arm64_latest.id
 
 	tags = {
 		Description = "Golden AMI ID for self-hosted GitHub Actions runners"


### PR DESCRIPTION
## Summary

- Add `data_type = "aws:ec2:image"` to the Golden AMI SSM parameter, required by EC2 Launch Template's `resolve:ssm:` feature
- Replace `ami-placeholder` initial value with a valid AMI from `data.aws_ami` to pass AWS validation
- Add idempotent import block for the SSM parameter

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The SSM parameter for the Golden AMI was created without `data_type = "aws:ec2:image"`, causing Launch Template version creation to fail with `SsmInvalidParameter`. This was introduced in PR #2021 when the parameter was moved from module-managed to root-managed scope.

Fixes #2023

Related to: #2021

## How Was This Tested?

- [x] `terraform plan` shows no unexpected changes
- [x] `terraform apply` completes successfully
- [x] Launch Template version created with correct SSM parameter reference
- [x] SSM parameter has `data_type = "aws:ec2:image"` confirmed in AWS Console

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)