### PR TITLE
docs(core): fix non-existent reinhardt-contrib crate reference in lib.rs

### DIFF
--- a/crates/reinhardt-core/src/lib.rs
+++ b/crates/reinhardt-core/src/lib.rs
@@ -24,7 +24,8 @@
 //! - **Storage Backends**: S3 (✅), Azure Blob (✅), GCS (✅), FileSystem (✅), Memory (✅)
 //!
 //! For detailed implementation and usage information, see the individual
-//! crate documentation in `reinhardt-contrib`, `reinhardt-tasks`, `reinhardt-core/backends`.
+//! crate documentation in `reinhardt-db`, `reinhardt-auth`, `reinhardt-mail`,
+//! and `reinhardt-tasks`.
 //!
 //! ## Quick Start
 //!


### PR DESCRIPTION
## Summary

- Replace reference to non-existent `reinhardt-contrib` crate in `reinhardt-core/src/lib.rs` doc comments
- Update with accurate crate references (`reinhardt-db`, `reinhardt-auth`, `reinhardt-mail`, `reinhardt-tasks`)

## Type of Change

- [x] Documentation update

## Motivation and Context

The module-level doc comment in `reinhardt-core/src/lib.rs` (line 27) referenced `reinhardt-contrib` as a crate containing backend implementations. This crate does not exist in the workspace. The actual backend implementations are distributed across `reinhardt-db`, `reinhardt-auth`, `reinhardt-mail`, and `reinhardt-tasks`.

Fixes #1510

## How Was This Tested?

- [x] `cargo check -p reinhardt-core --all-features` passes
- [x] `cargo test --doc -p reinhardt-core` passes (635 tests)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)