### PR TITLE
fix: capitalize Packer validation error_message for 1.15.0

### DIFF
--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -21,7 +21,7 @@ variable "runner_arch" {
 
 	validation {
 		condition     = contains(["x64", "arm64"], var.runner_arch)
-		error_message = "runner_arch must be either x64 or arm64."
+		error_message = "Variable runner_arch must be either x64 or arm64."
 	}
 }
 


### PR DESCRIPTION
## Summary

- Packer 1.15.0 enforces stricter `error_message` validation: must start with an uppercase letter and end with `.` or `?`
- Updated `runner_arch` validation message from `"runner_arch must be..."` to `"Variable runner_arch must be..."`
- Fixes the `Packer Init` step failure in the "Build Runner AMI" workflow (run #22819906957)

Fixes #2058

## Test plan

- [ ] Verify `packer init` succeeds with Packer 1.15.0
- [ ] Verify `packer validate` passes
- [ ] Re-run "Build Runner AMI" workflow via `workflow_dispatch` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)