### PR TITLE
fix(ci): resolve Packer 1.15.0 validation failure for runner_arch variable

### DIFF
--- a/.github/workflows/build-runner-ami.yml
+++ b/.github/workflows/build-runner-ami.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 30
     env:
       RUNNER_ARCH: ${{ github.event.inputs.architecture || 'x64' }}
+      PKR_VAR_runner_arch: ${{ github.event.inputs.architecture || 'x64' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,12 +55,12 @@ jobs:
       - name: Packer Validate
         run: |
           cd infra/github-runners/packer
-          packer validate -var "runner_arch=$RUNNER_ARCH" reinhardt-runner.pkr.hcl
+          packer validate reinhardt-runner.pkr.hcl
 
       - name: Build AMI
         run: |
           cd infra/github-runners/packer
-          PACKER_LOG=1 packer build -var "runner_arch=$RUNNER_ARCH" reinhardt-runner.pkr.hcl
+          PACKER_LOG=1 packer build reinhardt-runner.pkr.hcl
 
       - name: Extract AMI ID
         id: extract-ami

--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -20,7 +20,7 @@ variable "runner_arch" {
 	description = "Runner architecture: x64 or arm64"
 
 	validation {
-		condition     = contains(["x64", "arm64"], var.runner_arch)
+		condition     = var.runner_arch == "x64" || var.runner_arch == "arm64"
 		error_message = "Variable runner_arch must be either x64 or arm64."
 	}
 }


### PR DESCRIPTION
## Summary

- Replace `contains()` with explicit `==` comparison in Packer validation block for Packer 1.15.0 compatibility
- Switch from `-var` flag to `PKR_VAR_` environment variable for passing `runner_arch` to Packer

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The `build-ami` job in the "Build Runner AMI" workflow fails at Packer Validate with Packer 1.15.0. The `contains(["x64", "arm64"], var.runner_arch)` validation incorrectly fails when the value is passed via `-var` flag, even though the value `arm64` is in the list.

This is likely a Packer 1.15.0 regression where `contains()` does not properly evaluate command-line variables.

Fixes #2060

Related to: #2058

## How Was This Tested?

- Validated HCL syntax consistency
- Will be verified by re-running the Build Runner AMI workflow after merge

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Related Issues

- Fixes #2060
- Follows from #2058 (error_message capitalization fix)
- Failing run: https://github.com/kent8192/reinhardt-web/actions/runs/22822275762/job/66198494397

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

Two changes work together to ensure robustness:
1. **Validation condition**: `contains()` → `==` comparison avoids Packer 1.15.0 `contains()` regression
2. **Variable passing**: `-var` flag → `PKR_VAR_` env var avoids command-line parsing issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)