### PR TITLE
fix(ci): escape shell variables in Packer HCL2 inline scripts

### DIFF
--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -141,7 +141,7 @@ build {
 		]
 		inline = [
 			"PROTOC_VERSION=28.3",
-			"curl -fsSL -o /tmp/protoc.zip \"https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${PROTOC_ARCH}.zip\"",
+			"curl -fsSL -o /tmp/protoc.zip \"https://github.com/protocolbuffers/protobuf/releases/download/v$${PROTOC_VERSION}/protoc-$${PROTOC_VERSION}-$${PROTOC_ARCH}.zip\"",
 			"unzip -o /tmp/protoc.zip -d /usr/local bin/protoc",
 			"chmod +x /usr/local/bin/protoc",
 			"rm -f /tmp/protoc.zip",
@@ -155,7 +155,7 @@ build {
 			"AWSCLI_ARCH=${local.awscli_arch}",
 		]
 		inline = [
-			"curl -fsSL -o /tmp/awscliv2.zip \"https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip\"",
+			"curl -fsSL -o /tmp/awscliv2.zip \"https://awscli.amazonaws.com/awscli-exe-linux-$${AWSCLI_ARCH}.zip\"",
 			"unzip -q /tmp/awscliv2.zip -d /tmp",
 			"/tmp/aws/install",
 			"rm -rf /tmp/aws /tmp/awscliv2.zip",
@@ -169,7 +169,7 @@ build {
 			"CW_ARCH=${local.cloudwatch_arch}",
 		]
 		inline = [
-			"curl -fsSL -o /tmp/amazon-cloudwatch-agent.deb \"https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${CW_ARCH}/latest/amazon-cloudwatch-agent.deb\"",
+			"curl -fsSL -o /tmp/amazon-cloudwatch-agent.deb \"https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/$${CW_ARCH}/latest/amazon-cloudwatch-agent.deb\"",
 			"dpkg -i -E /tmp/amazon-cloudwatch-agent.deb",
 			"rm -f /tmp/amazon-cloudwatch-agent.deb",
 		]


### PR DESCRIPTION
## Summary

- Escape shell variable references (`${VAR}` → `$${VAR}`) in Packer HCL2 inline provisioner scripts
- Packer 1.15.0's stricter HCL2 parser interprets `${SHELL_VAR}` as HCL interpolation, causing "Unknown variable" errors

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

After PR #2061 fixed the validation condition, the build-ami job now fails with "Unknown variable" errors for shell variables (`PROTOC_VERSION`, `AWSCLI_ARCH`, `CW_ARCH`) used in inline provisioner scripts. Packer 1.15.0's updated HCL2 parser strictly interprets `${...}` as HCL interpolation.

The HCL2 escape syntax `$${VAR}` renders as literal `${VAR}` in the output, which the shell correctly interprets.

Fixes #2060

Related to: #2061, #2058

## How Was This Tested?

- Will be verified by re-running the Build Runner AMI workflow after merge

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)