### PR TITLE
chore(infra): re-integrate AMI builder resources and pin Packer version

### DIFF
--- a/.github/workflows/build-runner-ami.yml
+++ b/.github/workflows/build-runner-ami.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp/setup-packer@v3
         with:
-          version: latest
+          version: 1.15.0
 
       - name: Packer Init
         run: |

--- a/infra/github-runners/ami-builder.tf
+++ b/infra/github-runners/ami-builder.tf
@@ -1,0 +1,114 @@
+# OIDC identity provider for GitHub Actions.
+# Allows GitHub Actions workflows to assume IAM roles without long-lived credentials.
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["ffffffffffffffffffffffffffffffffffffffff"]
+}
+
+# IAM role for the AMI builder GitHub Actions workflow (build-runner-ami.yml).
+# Assumed via OIDC federation from GitHub Actions.
+resource "aws_iam_role" "github_actions_ami_builder" {
+  name = "${var.prefix}-gha-ami-builder"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_owner}/${var.github_repository}:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# EC2 permissions for Packer AMI builds.
+resource "aws_iam_role_policy" "ami_builder_ec2" {
+  name = "packer-ec2-ami-build"
+  role = aws_iam_role.github_actions_ami_builder.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "PackerBuild"
+        Effect = "Allow"
+        Action = [
+          "ec2:AttachVolume",
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:CopyImage",
+          "ec2:CreateImage",
+          "ec2:CreateKeypair",
+          "ec2:CreateSecurityGroup",
+          "ec2:CreateSnapshot",
+          "ec2:CreateTags",
+          "ec2:CreateVolume",
+          "ec2:DeleteKeyPair",
+          "ec2:DeleteSecurityGroup",
+          "ec2:DeleteSnapshot",
+          "ec2:DeleteVolume",
+          "ec2:DeregisterImage",
+          "ec2:DescribeImageAttribute",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceStatus",
+          "ec2:DescribeRegions",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSnapshots",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVolumes",
+          "ec2:DescribeVpcs",
+          "ec2:DetachVolume",
+          "ec2:GetPasswordData",
+          "ec2:ModifyImageAttribute",
+          "ec2:ModifyInstanceAttribute",
+          "ec2:ModifySnapshotAttribute",
+          "ec2:RegisterImage",
+          "ec2:RunInstances",
+          "ec2:StopInstances",
+          "ec2:TerminateInstances",
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# SSM permissions for updating the Golden AMI parameter after build.
+resource "aws_iam_role_policy" "ami_builder_ssm" {
+  name = "ssm-put-parameter-ami"
+  role = aws_iam_role.github_actions_ami_builder.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "UpdateAmiParameter"
+        Effect = "Allow"
+        Action = ["ssm:PutParameter"]
+        Resource = [
+          "arn:aws:ssm:${var.aws_region}:${var.aws_account_id}:parameter/${var.prefix}/runner-ami-id",
+        ]
+      }
+    ]
+  })
+}
+
+# Store the IAM role ARN as a GitHub Actions secret for the build-runner-ami workflow.
+resource "github_actions_secret" "aws_role_arn" {
+  repository      = var.github_repository
+  secret_name     = "AWS_ROLE_ARN"
+  plaintext_value = aws_iam_role.github_actions_ami_builder.arn
+}

--- a/infra/github-runners/imports.tf
+++ b/infra/github-runners/imports.tf
@@ -22,3 +22,30 @@ import {
   to = aws_ssm_parameter.runner_ami_id
   id = "/${var.prefix}/runner-ami-id"
 }
+
+# AMI builder resources (re-integrated after state rm, see #2060).
+# Idempotent: no-op if already managed by this workspace.
+import {
+  to = aws_iam_openid_connect_provider.github_actions
+  id = "arn:aws:iam::819171434490:oidc-provider/token.actions.githubusercontent.com"
+}
+
+import {
+  to = aws_iam_role.github_actions_ami_builder
+  id = "${var.prefix}-gha-ami-builder"
+}
+
+import {
+  to = aws_iam_role_policy.ami_builder_ec2
+  id = "${var.prefix}-gha-ami-builder:packer-ec2-ami-build"
+}
+
+import {
+  to = aws_iam_role_policy.ami_builder_ssm
+  id = "${var.prefix}-gha-ami-builder:ssm-put-parameter-ami"
+}
+
+import {
+  to = github_actions_secret.aws_role_arn
+  id = "${var.github_repository}:AWS_ROLE_ARN"
+}

--- a/infra/github-runners/outputs.tf
+++ b/infra/github-runners/outputs.tf
@@ -38,3 +38,13 @@ output "webhook_setup_guide" {
 		3. Verify: Push a commit to trigger CI and check AWS CloudWatch for Lambda invocations
 	EOT
 }
+
+output "github_actions_oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC identity provider"
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+}
+
+output "github_actions_ami_builder_role_arn" {
+  description = "ARN of the IAM role used by the AMI builder workflow"
+  value       = aws_iam_role.github_actions_ami_builder.arn
+}


### PR DESCRIPTION
## Summary

- Re-integrate AMI builder OIDC/IAM/secret resources into Terraform management after state rm during #2060 fix
- Pin Packer version to 1.15.0 in build-runner-ami workflow to prevent future breaking changes

## Type of Change

- [x] CI/CD changes
- [x] Code quality improvements

## Motivation and Context

During the #2060 fix, 5 AMI builder resources were removed from Terraform state via `terraform state rm` to prevent accidental destruction. This PR re-adds their definitions to `.tf` files with idempotent import blocks, restoring proper Terraform management.

Additionally, the `build-runner-ami` workflow used `version: latest` for Packer, which caused the original #2058/#2060 breakage when Packer 1.15.0 was released with HCL2 behavior changes. Pinning to 1.15.0 prevents future unexpected breakage.

Refs #2060

## How Was This Tested?

- `terraform plan`: 5 to import, 0 to add, 1 to change (sensitive value re-set), 0 to destroy
- `terraform apply`: Successfully applied, second apply confirms `No changes`
- All resources verified via AWS CLI before re-integration

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)