### PR TITLE
fix(ci): enable universe repository for x64 AMI package installation

### DIFF
--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -102,6 +102,9 @@ build {
 	provisioner "shell" {
 		execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
 		inline = [
+			"DEBIAN_FRONTEND=noninteractive apt-get update -qq",
+			"DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common",
+			"add-apt-repository -y universe",
 			"apt-get update -qq",
 			"DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \\",
 			"  docker.io \\",


### PR DESCRIPTION
## Summary

- Enable Ubuntu `universe` repository before installing system packages in Packer AMI build
- Install `software-properties-common` and run `add-apt-repository -y universe` to ensure all package repositories are available

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The x64 AMI build fails because Ubuntu 22.04 x64 AMIs from Canonical may not have the `universe` repository enabled by default. Packages like `docker-compose-v2`, `mold`, `clang`, and `lld` require `universe`. Even `main` repository packages like `build-essential` fail, suggesting the apt sources configuration is minimal.

The arm64 AMI builds succeed because Graviton Ubuntu AMIs have different default repository configuration.

Fixes #2066

## How Was This Tested?

- Will be verified by re-running the Build Runner AMI workflow with x64 after merge

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)