### PR TITLE
fix(ci): prevent x64 AMI build from overwriting arm64 SSM parameter

### DIFF
--- a/.github/workflows/build-runner-ami.yml
+++ b/.github/workflows/build-runner-ami.yml
@@ -9,9 +9,9 @@ on:
         required: true
         type: choice
         options:
-          - x64
           - arm64
-        default: "x64"
+          - x64
+        default: "arm64"
       force_rebuild:
         description: "Force rebuild even if no changes detected"
         required: false
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      RUNNER_ARCH: ${{ github.event.inputs.architecture || 'x64' }}
-      PKR_VAR_runner_arch: ${{ github.event.inputs.architecture || 'x64' }}
+      RUNNER_ARCH: ${{ github.event.inputs.architecture || 'arm64' }}
+      PKR_VAR_runner_arch: ${{ github.event.inputs.architecture || 'arm64' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,6 +69,7 @@ jobs:
           echo "ami_id=$AMI_ID" >> "$GITHUB_OUTPUT"
 
       - name: Update SSM Parameter
+        if: env.RUNNER_ARCH == 'arm64'
         env:
           AMI_ID: ${{ steps.extract-ami.outputs.ami_id }}
         run: |
@@ -77,6 +78,11 @@ jobs:
             --type String \
             --value "$AMI_ID" \
             --overwrite
+
+      - name: Skip SSM Update (non-arm64)
+        if: env.RUNNER_ARCH != 'arm64'
+        run: |
+          echo "::notice::Skipping SSM parameter update: runners use arm64 instances, but this build is for ${RUNNER_ARCH}"
 
       - name: Clean up old AMIs
         run: |
@@ -105,4 +111,8 @@ jobs:
           echo "- **Architecture**: $RUNNER_ARCH" >> "$GITHUB_STEP_SUMMARY"
           echo "- **AMI ID**: $AMI_ID" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Region**: us-east-1" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **SSM Parameter**: /reinhardt-ci/runner-ami-id" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$RUNNER_ARCH" == "arm64" ]]; then
+            echo "- **SSM Parameter**: /reinhardt-ci/runner-ami-id (updated)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- **SSM Parameter**: /reinhardt-ci/runner-ami-id (not updated — runners use arm64)" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

- Default AMI build architecture changed from x64 to arm64 (matches runner Graviton instances)
- SSM parameter update restricted to arm64 builds only (x64 builds skip with notice)
- Prevents architecture mismatch error (`InvalidParameterValue: arm64 instance vs x86_64 AMI`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The `build-runner-ami` workflow defaulted to `x64`, causing the weekly cron and manual x64 builds to overwrite the SSM parameter (`/reinhardt-ci/runner-ami-id`) with an x86_64 AMI. Since runners use arm64 Graviton instances (c7g/c6g), EC2 CreateFleet failed with architecture mismatch, blocking all CI jobs.

## How Was This Tested

- [x] Verified SSM parameter is correctly set to arm64 AMI after manual revert
- [x] Confirmed scale-up Lambda successfully creates arm64 instances with correct AMI
- [x] Workflow logic reviewed for correctness

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Labels to Apply

- `bug` - Fixes CI runner infrastructure failure
- `ci-cd` - CI/CD workflow change

🤖 Generated with [Claude Code](https://claude.com/claude-code)