### PR TITLE
fix(infra): remove redundant package installs from runner userdata

### DIFF
--- a/infra/github-runners/userdata-ubuntu.sh
+++ b/infra/github-runners/userdata-ubuntu.sh
@@ -10,34 +10,8 @@ set -x
 
 ${pre_install}
 
-# Install system packages required for CI builds and runner dependencies
-apt-get -q update
-DEBIAN_FRONTEND=noninteractive apt-get install -q -y \
-	build-essential \
-	ca-certificates \
-	curl \
-	git \
-	jq \
-	unzip \
-	wget
-
-# Install AWS CLI v2 (required for S3 runner binary download and SSM)
-# Detect architecture for correct binary download
-ARCH=$$(uname -m)
-curl -fsSL -o "awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-$${ARCH}.zip"
-unzip -q awscliv2.zip
-aws/install
-rm -rf aws awscliv2.zip
-
-# Install and configure CloudWatch agent for log shipping
-if [ "$$ARCH" = "aarch64" ]; then
-	CW_ARCH="arm64"
-else
-	CW_ARCH="amd64"
-fi
-curl -fsSL -o "/tmp/amazon-cloudwatch-agent.deb" "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/$${CW_ARCH}/latest/amazon-cloudwatch-agent.deb"
-dpkg -i -E /tmp/amazon-cloudwatch-agent.deb
-rm -f /tmp/amazon-cloudwatch-agent.deb
+# All system packages, AWS CLI v2, and CloudWatch agent are pre-installed
+# in the Golden AMI (built by Packer). Only CloudWatch config is fetched here.
 amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c "ssm:${ssm_key_cloudwatch_agent_config}"
 
 ${install_runner}


### PR DESCRIPTION
## Summary

- Remove redundant system package, AWS CLI v2, and CloudWatch agent installation from userdata template
- These tools are already pre-installed in the Golden AMI (built by Packer)
- Eliminates Terraform template `$$` escape syntax error that crashed the userdata script at boot

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The userdata template (`userdata-ubuntu.sh`) contained `$$` Terraform template escapes (e.g., `ARCH=$$(uname -m)`) that were not rendered to `$` by `templatefile()`. In bash, `$$` is the PID variable, causing:
```
line 25: syntax error near unexpected token `('
```
This prevented all self-hosted runners from starting, blocking CI for all PRs.

Since the Golden AMI already has all required tools pre-installed via Packer, the redundant installation steps are removed entirely.

## How Was This Tested

- [x] Verified Golden AMI contains all required tools (Packer build config reviewed)
- [x] Terraform plan confirms launch template version update
- [x] CloudWatch config fetch retained (only runtime config needed)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Labels to Apply

- `bug` - Fixes runner startup crash
- `ci-cd` - Infrastructure change

🤖 Generated with [Claude Code](https://claude.com/claude-code)