### PR TITLE
fix(ci): run semgrep via docker run for arm64 compatibility

### DIFF
--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -25,17 +25,15 @@ jobs:
     name: Scan for unresolved TODO/FIXME
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    container:
-      image: semgrep/semgrep
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Run Semgrep TODO/FIXME scan
-        run: semgrep ci --config .semgrep/ --metrics off
+        run: docker run --rm -v "${{ github.workspace }}:/src" -w /src semgrep/semgrep semgrep ci --config .semgrep/ --metrics off
 
   clippy-todo-check:
     name: Clippy TODO/unimplemented/dbg lint


### PR DESCRIPTION
## Summary

- Replace `container: image: semgrep/semgrep` with `docker run` command in the `todo-check` job
- Update `actions/checkout` from v4 to v6 for consistency with the rest of the workflow

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The `todo-check` job uses `container: image: semgrep/semgrep` (Alpine-based). When running on arm64 self-hosted runners, `actions/checkout@v4` fails with:

```
JavaScript Actions in Alpine containers are only supported on x64 Linux runners. Detected Linux Arm64
```

By removing the `container:` directive and using `docker run` directly, semgrep runs correctly on both x64 GitHub-hosted and arm64 self-hosted runners, since Docker handles the platform abstraction.

Fixes #2072

## How Was This Tested?

- [x] YAML syntax validated
- [x] `docker run` approach verified locally: `docker run --rm -v "$(pwd):/src" semgrep/semgrep semgrep scan --config .semgrep/ --error --metrics off`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)