### PR TITLE
fix(ci): use semgrep scan with baseline-commit for diff-aware scanning

### DIFF
--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Semgrep TODO/FIXME scan
-        run: docker run --rm -v "${{ github.workspace }}:/src" -w /src semgrep/semgrep semgrep ci --config .semgrep/ --metrics off
+        run: docker run --rm -v "${{ github.workspace }}:/src" -w /src semgrep/semgrep semgrep scan --config .semgrep/ --baseline-commit origin/main --error --metrics off
 
   clippy-todo-check:
     name: Clippy TODO/unimplemented/dbg lint


### PR DESCRIPTION
## Summary

- Replace `semgrep ci` with `semgrep scan --baseline-commit origin/main` in the TODO check workflow
- Fixes diff-aware scanning when running semgrep via `docker run` on arm64 self-hosted runners

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

When PR #2073 changed the semgrep job from `container: image:` to `docker run`, GitHub CI environment variables are no longer passed into the container. The `semgrep ci` command relies on these env vars for diff-aware scanning (to only check files changed in the PR). Without them, `semgrep ci` scans all files and finds pre-existing TODOs, causing false failures.

`semgrep scan --baseline-commit origin/main` performs local diff-aware scanning using git history instead of Semgrep App env vars, which works correctly inside the Docker container since the repository is mounted with full history (`fetch-depth: 0`).

Related to: #2072

## How Was This Tested?

- Verified the workflow YAML syntax is valid
- The `--baseline-commit origin/main` flag is documented in semgrep's CLI reference for local diff-aware scanning
- The `--error` flag ensures non-zero exit on findings (matching previous `semgrep ci` behavior)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Refs #2072

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)