### PR TITLE
docs(conf): add missing documentation for settings, dynamic, and types modules

### DIFF
--- a/crates/reinhardt-conf/src/settings.rs
+++ b/crates/reinhardt-conf/src/settings.rs
@@ -21,6 +21,7 @@ pub mod dynamic;
 #[cfg(feature = "async")]
 pub mod backends;
 
+/// Secret management with provider-based storage and rotation support.
 #[cfg(feature = "async")]
 pub mod secrets;
 

--- a/crates/reinhardt-conf/src/settings/dynamic.rs
+++ b/crates/reinhardt-conf/src/settings/dynamic.rs
@@ -52,21 +52,27 @@ use std::time::{Duration, Instant};
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum DynamicError {
+	/// An error originating from the storage backend.
 	#[error("Backend error: {0}")]
 	Backend(String),
 
+	/// A serialization or deserialization error.
 	#[error("Serialization error: {0}")]
 	Serialization(#[from] serde_json::Error),
 
+	/// The requested key was not found in the backend.
 	#[error("Key not found: {0}")]
 	KeyNotFound(String),
 
+	/// The stored value could not be converted to the requested type.
 	#[error("Invalid value type")]
 	InvalidType,
 
+	/// An error originating from the cache layer.
 	#[error("Cache error: {0}")]
 	Cache(String),
 
+	/// An error from the hot-reload file watcher.
 	#[cfg(feature = "hot-reload")]
 	#[error("Hot reload error: {0}")]
 	HotReload(String),

--- a/crates/reinhardt-conf/src/settings/secrets.rs
+++ b/crates/reinhardt-conf/src/settings/secrets.rs
@@ -1,6 +1,15 @@
+//! Secret management infrastructure.
+//!
+//! Provides secret storage, retrieval, rotation, and audit capabilities
+//! through pluggable provider backends.
+
+/// Audit logging for secret access operations.
 pub mod audit;
+/// Secret provider backend implementations.
 pub mod providers;
+/// Automatic secret rotation support.
 pub mod rotation;
+/// Core secret types, errors, and traits.
 pub mod types;
 
 pub use types::*;

--- a/crates/reinhardt-conf/src/settings/secrets/types.rs
+++ b/crates/reinhardt-conf/src/settings/secrets/types.rs
@@ -12,12 +12,17 @@ use std::fmt;
 // Re-export core secret types from the always-available module
 pub use crate::settings::secret_types::{SecretString, SecretValue};
 
+/// Error type for secret management operations.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum SecretError {
+	/// The requested secret was not found.
 	NotFound(String),
+	/// A general provider error.
 	Provider(String),
+	/// An error returned by the secret provider backend.
 	ProviderError(String),
+	/// A network error occurred while communicating with the provider.
 	NetworkError(String),
 }
 
@@ -34,26 +39,42 @@ impl fmt::Display for SecretError {
 
 impl std::error::Error for SecretError {}
 
+/// Result type alias for secret management operations.
 pub type SecretResult<T> = Result<T, SecretError>;
 
+/// Manages secret storage, retrieval, and lifecycle operations.
 pub struct SecretManager;
+
+/// Metadata associated with a stored secret.
 #[derive(Debug, Clone, Default)]
 pub struct SecretMetadata {
+	/// Timestamp when the secret was created.
 	pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+	/// Timestamp when the secret was last updated.
 	pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
+
+/// Represents a specific version of a secret.
 pub struct SecretVersion;
 
+/// Trait for secret storage backends.
 #[async_trait]
 pub trait SecretProvider: Send + Sync {
+	/// Retrieve a secret by name.
 	async fn get_secret(&self, name: &str) -> SecretResult<SecretString>;
+	/// Retrieve a secret along with its metadata.
 	async fn get_secret_with_metadata(
 		&self,
 		name: &str,
 	) -> SecretResult<(SecretString, SecretMetadata)>;
+	/// Store or update a secret.
 	async fn set_secret(&self, name: &str, value: SecretString) -> SecretResult<()>;
+	/// Delete a secret by name.
 	async fn delete_secret(&self, name: &str) -> SecretResult<()>;
+	/// List all available secret names.
 	async fn list_secrets(&self) -> SecretResult<Vec<String>>;
+	/// Check whether a secret with the given name exists.
 	fn exists(&self, name: &str) -> bool;
+	/// Return the name of this provider.
 	fn name(&self) -> &str;
 }


### PR DESCRIPTION
## Summary

- Add missing doc comments to `pub mod secrets` in `settings.rs`
- Add missing doc comments to `DynamicError` enum variants in `dynamic.rs`
- Add missing doc comments to `SecretError` enum/variants, `SecretResult` type alias, `SecretManager`/`SecretMetadata`/`SecretVersion` structs, struct fields, and `SecretProvider` trait methods in `secrets/types.rs`
- Add module-level and submodule doc comments to `secrets.rs`

## Type of Change

- [x] Documentation update
- [x] Code quality improvements

## Motivation and Context

These `missing_docs` clippy errors are blocking PR #1917's CI. The `-D missing-docs` lint is enabled for the `reinhardt-conf` crate, and several public items were missing documentation.

Related to: #1917

## How Was This Tested?

- [x] `cargo clippy -p reinhardt-conf --features async -- -D missing-docs` passes with no errors
- [x] `cargo check -p reinhardt-conf --features async` compiles successfully

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update
- [x] `code-quality` - Code quality improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)