### PR TITLE
fix(ci): isolate coverage jobs and replace sed with config overwrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
     outputs:
       runner: ${{ steps.set-runner.outputs.runner }}
       cargo-build-jobs: ${{ steps.set-runner.outputs.cargo-build-jobs }}
+      coverage-cargo-build-jobs: ${{ steps.set-runner.outputs.coverage-cargo-build-jobs }}
     steps:
       - name: Parse PR checkbox for self-hosted
         if: github.event_name == 'pull_request'
@@ -126,10 +127,12 @@ jobs:
             # Self-hosted: faster CI with AWS Spot instances
             echo 'runner=["self-hosted","linux","arm64","reinhardt-ci"]' >> "$GITHUB_OUTPUT"
             echo 'cargo-build-jobs=8' >> "$GITHUB_OUTPUT"
+            echo 'coverage-cargo-build-jobs=4' >> "$GITHUB_OUTPUT"
           else
             # GitHub-hosted: free, slower; CARGO_BUILD_JOBS=1 prevents OOM on 7GB RAM
             echo 'runner="ubuntu-latest"' >> "$GITHUB_OUTPUT"
             echo 'cargo-build-jobs=1' >> "$GITHUB_OUTPUT"
+            echo 'coverage-cargo-build-jobs=1' >> "$GITHUB_OUTPUT"
           fi
 
   # Detect which packages are affected by the PR changes.
@@ -303,7 +306,7 @@ jobs:
     secrets: inherit
     with:
       runner: ${{ needs.determine-runner.outputs.runner }}
-      cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
+      cargo-build-jobs: ${{ needs.determine-runner.outputs.coverage-cargo-build-jobs }}
       nextest-filter: ${{ needs.detect-affected.outputs.nextest-filter }}
       run-all: ${{ needs.detect-affected.outputs.run-all }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  CARGO_TARGET_DIR: /tmp/cargo_target
   CARGO_INCREMENTAL: 0
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
@@ -36,6 +35,8 @@ jobs:
     name: Unit Test Coverage
     runs-on: ${{ fromJSON(inputs.runner) }}
     timeout-minutes: 60
+    env:
+      CARGO_TARGET_DIR: /tmp/cargo_target_unit_cov
     permissions:
       id-token: write
       contents: read
@@ -77,6 +78,13 @@ jobs:
         with:
           tool: nextest
 
+      - name: Install mold linker and build dependencies
+        run: |
+          sudo apt-get update -o DPkg::Lock::Timeout=120
+          sudo apt-get install -y -o DPkg::Lock::Timeout=120 mold clang lld build-essential
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
@@ -98,6 +106,32 @@ jobs:
           rm -rf ~/.m2 || true
           echo "Disk usage after additional cleanup:"
           df -h
+
+      - name: Clean coverage artifacts
+        run: |
+          cargo llvm-cov clean --workspace
+          rm -rf "${CARGO_TARGET_DIR}/llvm-cov-target"
+
+      - name: Configure cargo for coverage
+        run: |
+          cat > /tmp/clang-mold-wrapper << 'WRAPPER'
+          #!/bin/sh
+          exec clang -fuse-ld=mold "$@"
+          WRAPPER
+          chmod +x /tmp/clang-mold-wrapper
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            TARGET="aarch64-unknown-linux-gnu"
+          elif [ "$ARCH" = "x86_64" ]; then
+            TARGET="x86_64-unknown-linux-gnu"
+          fi
+          cat > .cargo/config.toml << EOF
+          [env]
+          RUST_ANALYZER_CARGO_FEATURES = "all"
+
+          [target.${TARGET}]
+          linker = "/tmp/clang-mold-wrapper"
+          EOF
 
       - name: Run unit tests with coverage
         env:
@@ -134,6 +168,8 @@ jobs:
     name: Intra-Crate Integration Coverage
     runs-on: ${{ fromJSON(inputs.runner) }}
     timeout-minutes: 120
+    env:
+      CARGO_TARGET_DIR: /tmp/cargo_target_intra_cov
     permissions:
       id-token: write
       contents: read
@@ -167,8 +203,8 @@ jobs:
 
       - name: Install mold linker and build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mold clang lld build-essential
+          sudo apt-get update -o DPkg::Lock::Timeout=120
+          sudo apt-get install -y -o DPkg::Lock::Timeout=120 mold clang lld build-essential
           sudo apt-get clean
           sudo rm -rf /var/lib/apt/lists/*
 
@@ -211,6 +247,32 @@ jobs:
         with:
           images-file: .github/docker-images-intra-crate.txt
 
+      - name: Clean coverage artifacts
+        run: |
+          cargo llvm-cov clean --workspace
+          rm -rf "${CARGO_TARGET_DIR}/llvm-cov-target"
+
+      - name: Configure cargo for coverage
+        run: |
+          cat > /tmp/clang-mold-wrapper << 'WRAPPER'
+          #!/bin/sh
+          exec clang -fuse-ld=mold "$@"
+          WRAPPER
+          chmod +x /tmp/clang-mold-wrapper
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            TARGET="aarch64-unknown-linux-gnu"
+          elif [ "$ARCH" = "x86_64" ]; then
+            TARGET="x86_64-unknown-linux-gnu"
+          fi
+          cat > .cargo/config.toml << EOF
+          [env]
+          RUST_ANALYZER_CARGO_FEATURES = "all"
+
+          [target.${TARGET}]
+          linker = "/tmp/clang-mold-wrapper"
+          EOF
+
       - name: Run intra-crate integration tests with coverage
         env:
           NEXTEST_FILTER_EXPR: ${{ inputs.nextest-filter }}
@@ -248,6 +310,8 @@ jobs:
     name: Cross-Crate Integration Coverage
     runs-on: ${{ fromJSON(inputs.runner) }}
     timeout-minutes: 60
+    env:
+      CARGO_TARGET_DIR: /tmp/cargo_target_cross_cov
     permissions:
       id-token: write
       contents: read
@@ -281,8 +345,8 @@ jobs:
 
       - name: Install mold linker and build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mold clang lld build-essential
+          sudo apt-get update -o DPkg::Lock::Timeout=120
+          sudo apt-get install -y -o DPkg::Lock::Timeout=120 mold clang lld build-essential
           sudo apt-get clean
           sudo rm -rf /var/lib/apt/lists/*
 
@@ -324,6 +388,32 @@ jobs:
         uses: ./.github/actions/pull-docker-images
         with:
           images-file: .github/docker-images-cross-crate.txt
+
+      - name: Clean coverage artifacts
+        run: |
+          cargo llvm-cov clean --workspace
+          rm -rf "${CARGO_TARGET_DIR}/llvm-cov-target"
+
+      - name: Configure cargo for coverage
+        run: |
+          cat > /tmp/clang-mold-wrapper << 'WRAPPER'
+          #!/bin/sh
+          exec clang -fuse-ld=mold "$@"
+          WRAPPER
+          chmod +x /tmp/clang-mold-wrapper
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            TARGET="aarch64-unknown-linux-gnu"
+          elif [ "$ARCH" = "x86_64" ]; then
+            TARGET="x86_64-unknown-linux-gnu"
+          fi
+          cat > .cargo/config.toml << EOF
+          [env]
+          RUST_ANALYZER_CARGO_FEATURES = "all"
+
+          [target.${TARGET}]
+          linker = "/tmp/clang-mold-wrapper"
+          EOF
 
       - name: Run cross-crate integration tests with coverage
         env:


### PR DESCRIPTION
## Summary

- Isolate `CARGO_TARGET_DIR` per coverage job to prevent profraw file path collisions
- Replace `sed`-based `.cargo/config.toml` modification with full config.toml overwrite
- Add mold linker installation and coverage artifact cleanup to all coverage jobs
- Reduce coverage build parallelism (self-hosted: 4, GitHub-hosted: 1)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

Coverage CI jobs fail on arm64 self-hosted runners because `.cargo/config.toml` contains `target-dir = "target"` and `rustflags` settings that conflict with `cargo-llvm-cov`. The `target-dir` config causes profraw file path mismatch (cargo-llvm-cov expects files under its internal `llvm-cov-target` directory, but the config redirects them elsewhere). The `rustflags` config conflicts with cargo-llvm-cov's own `RUSTFLAGS` injection.

The previous approach used `sed` to remove conflicting lines, but this is fragile and depends on exact line patterns. This PR replaces it with a deterministic config.toml overwrite that only includes settings needed for coverage builds (env vars and linker config), completely excluding the `[build]` section.

Fixes #2078

## How Was This Tested?

- CI coverage jobs will validate profraw generation on both GitHub-hosted and self-hosted runners
- The config.toml overwrite approach has been verified to exclude `target-dir` and `rustflags` settings

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Separated from PR #1917 to keep auth fixes and CI fixes independent

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)