### PR TITLE
fix(release): bump all crates to v0.1.0-rc.6 to skip yanked reinhardt-query-macros rc.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 description = "A full-stack API framework for Rust, inspired by Django and Django REST Framework"
@@ -377,63 +377,63 @@ module_name_repetitions = "allow"
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-rc.5" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-rc.6" }
 
 # Internal crates
-reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0-rc.5" }
-reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.1.0-rc.5" }
-reinhardt-core = { path = "crates/reinhardt-core", version = "0.1.0-rc.5" }
-reinhardt-di = { path = "crates/reinhardt-di", version = "0.1.0-rc.5" }
-reinhardt-http = { path = "crates/reinhardt-http", version = "0.1.0-rc.5" }
-reinhardt-server = { path = "crates/reinhardt-server", version = "0.1.0-rc.5" }
-reinhardt-views = { path = "crates/reinhardt-views", version = "0.1.0-rc.5" }
-reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.1.0-rc.5" }
-reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.1.0-rc.5" }
-reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.0-rc.5" }
-reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.1.0-rc.5" }
-reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.0-rc.5" }
-reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.1.0-rc.5" }
-reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.0-rc.5" }
-reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.1.0-rc.5" }
-reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-rc.5" }
-reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.0-rc.5" }
-reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.0-rc.5" }
-reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-rc.5" }
-reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.0-rc.5" }
-reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0-rc.5" }
-reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0-rc.5" }
-reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-rc.5" }
-reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-rc.5" }
-reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0-rc.5" }
-reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0-rc.5" }
-reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-rc.5" }
-reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0-rc.5" }
-reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.1.0-rc.5" }
-reinhardt-query = { path = "crates/reinhardt-query", version = "0.1.0-rc.5" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-rc.5" }
-reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-rc.5" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-rc.5" }
-reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0-rc.5" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-rc.5" }
-reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0-rc.5" }
-reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0-rc.5" }
-reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.0-rc.5" }
-reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-rc.5" }
+reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0-rc.6" }
+reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.1.0-rc.6" }
+reinhardt-core = { path = "crates/reinhardt-core", version = "0.1.0-rc.6" }
+reinhardt-di = { path = "crates/reinhardt-di", version = "0.1.0-rc.6" }
+reinhardt-http = { path = "crates/reinhardt-http", version = "0.1.0-rc.6" }
+reinhardt-server = { path = "crates/reinhardt-server", version = "0.1.0-rc.6" }
+reinhardt-views = { path = "crates/reinhardt-views", version = "0.1.0-rc.6" }
+reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.1.0-rc.6" }
+reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.1.0-rc.6" }
+reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.0-rc.6" }
+reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.1.0-rc.6" }
+reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.0-rc.6" }
+reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.1.0-rc.6" }
+reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.0-rc.6" }
+reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.1.0-rc.6" }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-rc.6" }
+reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.0-rc.6" }
+reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.0-rc.6" }
+reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-rc.6" }
+reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.0-rc.6" }
+reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0-rc.6" }
+reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0-rc.6" }
+reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-rc.6" }
+reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-rc.6" }
+reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0-rc.6" }
+reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0-rc.6" }
+reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-rc.6" }
+reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0-rc.6" }
+reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.1.0-rc.6" }
+reinhardt-query = { path = "crates/reinhardt-query", version = "0.1.0-rc.6" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-rc.6" }
+reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-rc.6" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-rc.6" }
+reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0-rc.6" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-rc.6" }
+reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0-rc.6" }
+reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0-rc.6" }
+reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.0-rc.6" }
+reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-rc.6" }
 
 # Query subcrates
-reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.1.0-rc.5" }
+reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.1.0-rc.6" }
 
 # Core subcrates
-reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.0-rc.5" }
+reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.0-rc.6" }
 
 # DI subcrates
-reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.1.0-rc.5" }
+reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.1.0-rc.6" }
 
 # REST subcrates
-reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.1.0-rc.5" }
+reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.1.0-rc.6" }
 
 # REST subcrates (continued)
-reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.1.0-rc.5" }
+reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.1.0-rc.6" }
 
 # Web framework
 tokio = { version = "1.48.0", features = ["full"] }

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin-cli"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-apps/Cargo.toml
+++ b/crates/reinhardt-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-apps"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "Application registry and management for Reinhardt framework"
 edition.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "Authentication and authorization system"
 keywords = ["auth", "jwt", "authentication", "django", "web"]
 categories = ["authentication", "web-programming"]

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-commands"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-conf"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-core"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-core/macros/Cargo.toml
+++ b/crates/reinhardt-core/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-macros"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 description = "Procedural macros for Reinhardt framework"

--- a/crates/reinhardt-db-macros/Cargo.toml
+++ b/crates/reinhardt-db-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db-macros"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-db/Cargo.toml
+++ b/crates/reinhardt-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-deeplink/Cargo.toml
+++ b/crates/reinhardt-deeplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-deeplink"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 description = "Mobile app deep linking with iOS Universal Links, Android App Links, and custom URL schemes"

--- a/crates/reinhardt-dentdelion/Cargo.toml
+++ b/crates/reinhardt-dentdelion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dentdelion"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "reinhardt-di"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-di/macros/Cargo.toml
+++ b/crates/reinhardt-di/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-di-macros"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dispatch/Cargo.toml
+++ b/crates/reinhardt-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dispatch"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-forms/Cargo.toml
+++ b/crates/reinhardt-forms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-forms"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "Form handling and validation"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-graphql/macros/Cargo.toml
+++ b/crates/reinhardt-graphql/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql-macros"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "Procedural macros for GraphQL schema generation"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "gRPC support for building RPC services"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-grpc/macros/Cargo.toml
+++ b/crates/reinhardt-grpc/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc-macros"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/reinhardt-http/Cargo.toml
+++ b/crates/reinhardt-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-http"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "Internationalization and localization support"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-mail/Cargo.toml
+++ b/crates/reinhardt-mail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-mail"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "Email sending functionality with multiple backends"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-manouche/Cargo.toml
+++ b/crates/reinhardt-manouche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-manouche"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-middleware"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "Middleware system for request/response processing pipeline"
 keywords = ["middleware", "web", "cors", "security", "http"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-openapi/Cargo.toml
+++ b/crates/reinhardt-openapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/reinhardt-pages/ast/Cargo.toml
+++ b/crates/reinhardt-pages/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-ast"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/reinhardt-pages/macros/Cargo.toml
+++ b/crates/reinhardt-pages/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-macros"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/reinhardt-query/Cargo.toml
+++ b/crates/reinhardt-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-query/macros/Cargo.toml
+++ b/crates/reinhardt-query/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query-macros"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/reinhardt-rest/Cargo.toml
+++ b/crates/reinhardt-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-rest"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "REST API framework aggregator for Reinhardt"
 keywords = ["rest", "api", "web", "framework", "django"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-rest/openapi-macros/Cargo.toml
+++ b/crates/reinhardt-rest/openapi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi-macros"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-server/Cargo.toml
+++ b/crates/reinhardt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-server"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-tasks/Cargo.toml
+++ b/crates/reinhardt-tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-tasks"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "Background task execution and scheduling"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-test"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 description = "Testing utilities and helpers for Reinhardt framework"

--- a/crates/reinhardt-testkit/Cargo.toml
+++ b/crates/reinhardt-testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 authors.workspace = true
 description = "Core testing infrastructure for Reinhardt framework (no functional crate dependencies)"

--- a/crates/reinhardt-throttling/Cargo.toml
+++ b/crates/reinhardt-throttling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-throttling"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "Throttling and rate limiting for Reinhardt framework"
 edition.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-urls"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-urls/routers-macros/Cargo.toml
+++ b/crates/reinhardt-urls/routers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-routers-macros"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-utils"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "Utility functions aggregator for Reinhardt"
 edition.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-views/Cargo.toml
+++ b/crates/reinhardt-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-views"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "View layer aggregator for viewsets and views-core"
 edition.workspace = true
 license.workspace = true

--- a/crates/reinhardt-websockets/Cargo.toml
+++ b/crates/reinhardt-websockets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-websockets"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 description = "WebSocket support for real-time bidirectional communication"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

This PR addresses:

- Bump all 45 crates in the `reinhardt` version_group from v0.1.0-rc.5 to v0.1.0-rc.6
- Resolves release-plz deadlock caused by yanked `reinhardt-query-macros` v0.1.0-rc.5 on crates.io

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

`reinhardt-query-macros` v0.1.0-rc.5 was published to crates.io but subsequently yanked due to a code defect. The code defect has been fixed on `main`, but the git tag `reinhardt-query-macros@v0.1.0-rc.5` still exists. This causes release-plz to enter a deadlock state:

> local package `reinhardt-query-macros` has a greater version (0.1.0-rc.5) with respect to the registry package (0.1.0-rc.4), but the git tag reinhardt-query-macros@v0.1.0-rc.5 exists.

Since all 45 crates share `version_group = "reinhardt"` in `release-plz.toml`, they must be bumped together from rc.5 to rc.6.

The git tag `reinhardt-query-macros@v0.1.0-rc.5` is preserved for historical traceability (consistent with crates.io's yank ≠ delete philosophy).

Fixes #2100

Related to: https://github.com/kent8192/reinhardt-web/actions/runs/22893959554

## How Was This Tested?

- [x] `cargo check --workspace --all --all-features` passes
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes
- [x] `grep -r 'version = "0.1.0-rc.5"' Cargo.toml crates/*/Cargo.toml` returns empty (all rc.5 eliminated)
- [x] `workspace.package.version = "0.1.0-rc.1"` (shared metadata) remains unchanged

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #2100
- CI run: https://github.com/kent8192/reinhardt-web/actions/runs/22893959554

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

This follows the same pattern as PR #1317 (alpha.3 → alpha.4 skip) but affects all 45 crates due to `version_group` synchronization introduced in the RC phase.

After merge, release-plz should:
1. Detect local=rc.6 > crates.io=rc.5 for all 45 crates
2. Publish all rc.6 to crates.io (`release_always = true`)
3. Create `*@v0.1.0-rc.6` tags
4. Resume normal Release PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)