### PR TITLE
fix(ci): resolve format, unused method, and cfg-gated prelude issues

### DIFF
--- a/crates/reinhardt-urls/src/routers/client_router/core.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/core.rs
@@ -183,19 +183,6 @@ impl ClientRouter {
 		}
 	}
 
-	/// Merges routes from another router into this one.
-	///
-	/// Routes and named route mappings from `other` are appended.
-	/// Signals and not_found handler from `other` are discarded.
-	pub(crate) fn merge(mut self, other: ClientRouter) -> Self {
-		let offset = self.routes.len();
-		for (name, idx) in other.named_routes {
-			self.named_routes.insert(name, idx + offset);
-		}
-		self.routes.extend(other.routes);
-		self
-	}
-
 	/// Adds a route to the router.
 	pub fn route<F>(mut self, pattern: &str, component: F) -> Self
 	where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,9 +592,8 @@ pub use reinhardt_views::viewsets::{
 // Re-export routers
 #[cfg(not(target_arch = "wasm32"))]
 pub use reinhardt_urls::routers::{
-	DefaultRouter, PathMatcher, PathPattern, Route, Router, ServerRouter,
-	UrlPatternsRegistration, clear_router, get_router, is_router_registered, register_router,
-	register_router_arc,
+	DefaultRouter, PathMatcher, PathPattern, Route, Router, ServerRouter, UrlPatternsRegistration,
+	clear_router, get_router, is_router_registered, register_router, register_router_arc,
 };
 
 // Re-export client-router types (requires client-router feature)
@@ -915,7 +914,6 @@ pub mod prelude {
 		ServerRouter,
 		SingleObjectMixin,
 		StatusCode,
-		UnifiedRouter,
 		View,
 		ViewResult,
 		ViewSet,
@@ -925,6 +923,10 @@ pub mod prelude {
 		is_router_registered,
 		register_router,
 	};
+
+	// Client-router types (requires client-router feature)
+	#[cfg(feature = "client-router")]
+	pub use crate::UnifiedRouter;
 
 	// External dependencies (via core)
 	#[cfg(feature = "core")]


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix tab/space mixed indentation in `src/lib.rs` (format check failure)
- Remove unused `pub(crate) merge` method from `ClientRouter` (clippy dead_code warning)
- Gate `UnifiedRouter` re-export in prelude with `#[cfg(feature = "client-router")]` (compilation failure when feature disabled)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

- 5 open PRs (#2105, #2115, #2112, #2111, #2109) share common CI failures caused by issues on the main branch
- Format check fails due to mixed tab/space indentation in `src/lib.rs`
- Clippy fails with "method 'merge' is never used" in `ClientRouter`
- Coverage/cross-crate integration fails with "unresolved import 'crate::UnifiedRouter'" when `client-router` feature is disabled, because prelude re-exports it unconditionally

## How Was This Tested?

- `cargo make fmt-check` - passes (0 files would be formatted)
- `cargo make clippy-check` - passes (no warnings)
- `cargo check --workspace --all --all-features` - passes
- `cargo test --workspace --all --all-features` - passes (3 pre-existing failures in `reinhardt-conf` audit backend tests are unrelated)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #2105, #2115, #2112, #2111, #2109

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)