### PR TITLE
fix(ci): prevent guard workflow cancellations from non-migration label events

### DIFF
--- a/.github/workflows/develop-leak-guard.yml
+++ b/.github/workflows/develop-leak-guard.yml
@@ -10,12 +10,19 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: >-
+    ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{
+    contains(fromJSON('["labeled","unlabeled"]'), github.event.action) &&
+    github.event.label.name != 'migration-approved' &&
+    github.event.label.name || 'default' }}
   cancel-in-progress: true
 
 jobs:
   develop-leak-guard:
     name: Develop Leak Guard
+    if: >-
+      github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
+      github.event.label.name == 'migration-approved'
     runs-on: ubuntu-latest
     steps:
       - name: Check if migration-approved

--- a/.github/workflows/develop-merge-guard.yml
+++ b/.github/workflows/develop-merge-guard.yml
@@ -10,12 +10,19 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: >-
+    ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{
+    contains(fromJSON('["labeled","unlabeled"]'), github.event.action) &&
+    github.event.label.name != 'migration-approved' &&
+    github.event.label.name || 'default' }}
   cancel-in-progress: true
 
 jobs:
   develop-merge-guard:
     name: Develop Merge Guard
+    if: >-
+      github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
+      github.event.label.name == 'migration-approved'
     runs-on: ubuntu-latest
     steps:
       - name: Check if guard applies


### PR DESCRIPTION
## Summary

This PR addresses:

- Guard workflows (`Develop Leak Guard`, `Develop Merge Guard`) were being cancelled ~50% of the time when any label was applied to a PR

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

When any label (e.g., `bug`, `ci-cd`, `enhancement`) was applied to a PR, the `labeled` event triggered a new run of both Guard workflows. Because both workflows use `cancel-in-progress: true`, the newly triggered run immediately cancelled the previous in-progress run.

**Fix:** Two-layer approach:

1. **Concurrency group key** — `labeled`/`unlabeled` events for non-`migration-approved` labels now get a unique concurrency group key (the label name), so they never cancel the main guard run.
2. **Job-level `if` condition** — Jobs skip immediately for non-`migration-approved` label events, avoiding unnecessary runner provisioning.

## How Was This Tested?

- Code review of concurrency group expression semantics
- Verified that `migration-approved` label events still share the main concurrency group and trigger the guard as expected
- Non-`migration-approved` label events resolve to a unique group key, preventing cancellation of in-progress runs

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] CI/CD-only change, no Rust code affected

## Related Issues

-

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

The root cause is that `auto-label-pr.yml` applies labels (which fires `labeled` events), and the Guard workflows are subscribed to `labeled`/`unlabeled` events to detect `migration-approved`. This creates a cascade: label applied → labeled event → Guard re-runs → cancels in-progress Guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)