### PR TITLE
fix(commands): update startapp test assertions for Rust 2024 module paths

### DIFF
--- a/crates/reinhardt-commands/tests/admin_scripts_tests.rs
+++ b/crates/reinhardt-commands/tests/admin_scripts_tests.rs
@@ -440,7 +440,7 @@ async fn test_startapp_creates_app_structure() {
 	assert!(result.is_ok(), "StartApp command failed: {:?}", result);
 
 	// Verify app directory was created in src/apps/ (default module mode)
-	assert!(env.file_exists(&format!("src/apps/{}/lib.rs", app_name)));
+	assert!(env.file_exists(&format!("src/apps/{}.rs", app_name)));
 }
 
 #[serial]
@@ -668,7 +668,7 @@ async fn test_startapp_template() {
 
 	if result.is_ok() {
 		// Custom template should be used (default module mode creates in src/apps/)
-		assert!(env.file_exists("src/apps/myapp/lib.rs") || env.file_exists("myapp/lib.rs"));
+		assert!(env.file_exists("src/apps/myapp.rs"));
 	}
 }
 
@@ -985,7 +985,7 @@ async fn test_full_project_and_app_workflow() {
 	match app_result {
 		Ok(_) => {
 			// Verify app was created in src/apps/ (default module mode)
-			assert!(env.file_exists(&format!("{}/src/apps/{}/lib.rs", project_name, app_name)));
+			assert!(env.file_exists(&format!("{}/src/apps/{}.rs", project_name, app_name)));
 		}
 		Err(e) => {
 			// Log error but don't fail test as this depends on project template completeness

--- a/examples/examples-tutorial-basis/src/config/urls.rs
+++ b/examples/examples-tutorial-basis/src/config/urls.rs
@@ -2,9 +2,9 @@
 //!
 //! The `routes` function defines all URL patterns for this project.
 
-use reinhardt::prelude::*;
 #[cfg(server)]
 use reinhardt::pages::server_fn::ServerFnRouterExt;
+use reinhardt::prelude::*;
 #[cfg(server)]
 use reinhardt::routes;
 


### PR DESCRIPTION
## Summary

- Update 3 test assertions in `admin_scripts_tests.rs` to check for `src/apps/{app}.rs` instead of `src/apps/{app}/lib.rs`, matching the Rust 2024 Edition module path changes in `StartAppCommand`
- Fix import ordering in `examples/examples-tutorial-basis/src/config/urls.rs` detected by `reinhardt-admin fmt`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

PR #2159 (release-plz auto-release PR) has 4 failing CI jobs. All failures stem from `StartAppCommand` generating Rust 2024 Edition module structure (`src/apps/{app}.rs`) while tests still assert the old path (`src/apps/{app}/lib.rs`). The examples formatting violation is an unrelated pre-existing issue.

Related to: #2159

## How Was This Tested?

- [x] `cargo nextest run -p reinhardt-commands test_startapp_creates_app_structure` passes
- [x] `cargo nextest run -p reinhardt-commands test_startapp_template` passes
- [x] `cargo nextest run -p reinhardt-commands test_full_project_and_app_workflow` passes
- [x] `reinhardt-admin fmt . --check` passes in examples-tutorial-basis
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)