### PR TITLE
chore(ci): exclude test code from CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,13 @@
+name: "Reinhardt CodeQL Configuration"
+
+# Exclude test code from analysis to reduce false positives
+# Test files contain intentional hard-coded values (passwords, tokens, keys)
+# that trigger false positive alerts for:
+# - rust/hard-coded-cryptographic-value
+# - rust/cleartext-logging
+# - rust/cleartext-storage-database
+paths-ignore:
+  - "tests/"
+  - "**/tests/"
+  - "**/tests/**"
+  - "tests/bench/"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
           languages: rust
           build-mode: none
           queries: security-and-quality
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- Create `.github/codeql/codeql-config.yml` to exclude test directories from CodeQL analysis
- Update `.github/workflows/codeql.yml` to reference the new configuration file

## Type of Change

- [x] CI/CD changes

## Motivation and Context

GitHub Code Scanning (CodeQL) reports ~170+ false positive alerts from test code containing intentional hard-coded values (passwords, tokens, cryptographic keys) used as test fixtures. These trigger:
- `rust/hard-coded-cryptographic-value` (164 alerts)
- `rust/cleartext-logging` (~42 false positives)
- `rust/cleartext-storage-database` (4 alerts)

Excluding test directories eliminates these false positives while maintaining security scanning for production source code.

### Excluded paths:
- `tests/` — workspace-level integration tests
- `**/tests/` — inline test modules
- `**/tests/**` — test helper files
- `tests/bench/` — benchmark tests

## How Was This Tested?

- [x] YAML syntax verified
- [x] CodeQL configuration format validated against [GitHub docs](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning)
- [x] Will be verified by CodeQL CI run on this PR

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)