### PR TITLE
fix(ci): revert create-github-app-token to v2

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -29,7 +29,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
@@ -82,7 +82,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}


### PR DESCRIPTION
## Summary

- Revert `actions/create-github-app-token` from `@v3` to `@v2` in `release-plz.yml`
- `@v3` does not exist, causing both Release PR and Release jobs to fail at action resolution

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The Release-plz workflow (`release-plz.yml`) was updated to use `actions/create-github-app-token@v3`, but this version does not exist. The latest available major version is v2 (v2.2.1). This causes both the "Release PR" and "Release" jobs to fail immediately with:

> Unable to resolve action `actions/create-github-app-token@v3`, unable to find version `v3`

See: https://github.com/kent8192/reinhardt-web/actions/runs/23042844843

## How Was This Tested?

- Verified latest release of `actions/create-github-app-token` is v2.2.1 via GitHub API
- Confirmed `@v3` tag does not exist in the action repository
- CI will validate the fix upon merge

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)