### PR TITLE
fix(ci): use github-hosted runner for housekeeping workflow

### DIFF
--- a/.github/workflows/housekeeping-cancel.yml
+++ b/.github/workflows/housekeeping-cancel.yml
@@ -1,0 +1,97 @@
+name: Housekeeping - Cancel Orphaned Runs
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  pull-requests: read
+
+jobs:
+  cancel-orphaned-runs:
+    name: Cancel Orphaned Workflow Runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Cancel runs for closed/merged PRs
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const targetWorkflows = ['ci.yml', 'test-examples.yml', 'coverage-main.yml'];
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            let totalCancelled = 0;
+
+            for (const wf of targetWorkflows) {
+              for (const status of ['in_progress', 'queued']) {
+                const { data } = await github.rest.actions.listWorkflowRuns({
+                  owner, repo,
+                  workflow_id: wf,
+                  status,
+                  per_page: 100,
+                });
+
+                for (const run of data.workflow_runs) {
+                  if (run.event !== 'pull_request') continue;
+
+                  const prNumbers = run.pull_requests.map(pr => pr.number);
+                  if (prNumbers.length === 0) continue;
+
+                  for (const prNumber of prNumbers) {
+                    const { data: pr } = await github.rest.pulls.get({
+                      owner, repo,
+                      pull_number: prNumber,
+                    });
+
+                    if (pr.state === 'closed') {
+                      console.log(`Cancelling ${wf} run #${run.id} (PR #${prNumber} is ${pr.merged ? 'merged' : 'closed'})`);
+                      try {
+                        await github.rest.actions.cancelWorkflowRun({
+                          owner, repo, run_id: run.id,
+                        });
+                        totalCancelled++;
+                      } catch (e) {
+                        console.log(`Failed to cancel: ${e.message}`);
+                      }
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+
+            console.log(`Total cancelled: ${totalCancelled}`);
+
+            // Force-cancel runs that were previously cancelled but not yet completed
+            for (const wf of targetWorkflows) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner, repo,
+                workflow_id: wf,
+                status: 'in_progress',
+                per_page: 50,
+              });
+
+              for (const run of data.workflow_runs) {
+                if (run.event !== 'pull_request') continue;
+
+                const prNumbers = run.pull_requests.map(pr => pr.number);
+                for (const prNumber of prNumbers) {
+                  try {
+                    const { data: pr } = await github.rest.pulls.get({
+                      owner, repo, pull_number: prNumber,
+                    });
+                    if (pr.state === 'closed') {
+                      console.log(`Force-cancelling ${wf} run #${run.id}`);
+                      await github.rest.actions.forceCancelWorkflowRun({
+                        owner, repo, run_id: run.id,
+                      });
+                    }
+                  } catch (e) {
+                    console.log(`Force-cancel failed: ${e.message}`);
+                  }
+                  break;
+                }
+              }
+            }


### PR DESCRIPTION
## Summary

- Switch `housekeeping-cancel.yml` from self-hosted runner to `ubuntu-latest`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The `housekeeping-cancel.yml` workflow was configured with `runs-on: [self-hosted, linux, arm64, reinhardt-housekeeping]`, but no self-hosted runner with the `reinhardt-housekeeping` label is available. This caused all housekeeping jobs to hang indefinitely in `queued` state.

Since this workflow only makes GitHub API calls via `actions/github-script` (no builds, no tests), it does not need a self-hosted runner. `ubuntu-latest` is sufficient and avoids the hang.

## How Was This Tested?

- Verified the workflow content only uses `actions/github-script` (no Rust builds or heavy operations)
- Confirmed `cancel-on-pr-close.yml` (similar workflow) already uses `ubuntu-latest` successfully

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)