### PR TITLE
fix(infra): install aws cli in housekeeping runner userdata

### DIFF
--- a/infra/github-runners/housekeeping-userdata.sh
+++ b/infra/github-runners/housekeeping-userdata.sh
@@ -17,7 +17,13 @@ fi
 # --- First boot: install and register runner ---
 
 apt-get update -y
-apt-get install -y jq curl openssl
+apt-get install -y jq curl openssl unzip
+
+# Install AWS CLI v2 (arm64) - not included in base Ubuntu AMI
+curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install
+rm -rf /tmp/awscliv2.zip /tmp/aws
 
 # Fetch GitHub App credentials from SSM
 APP_ID=$(aws ssm get-parameter \


### PR DESCRIPTION
## Summary

- Add AWS CLI v2 (arm64) installation to `housekeeping-userdata.sh`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The housekeeping runner EC2 instance uses the base Ubuntu 22.04 AMI (not the Golden AMI used by CI runners), which does not include AWS CLI. The userdata script calls `aws ssm get-parameter` to fetch GitHub App credentials for runner registration, but fails with `aws: command not found`. This prevented the runner from registering with GitHub, causing all housekeeping workflow jobs to hang in `queued` state.

## How Was This Tested?

- Manually installed AWS CLI and ran the runner setup on the live instance via SSM `send-command`
- Confirmed runner is now registered and online on GitHub (`housekeeping-runner`, status: `online`)
- Verified labels: `self-hosted`, `linux`, `arm64`, `reinhardt-housekeeping`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)