### PR TITLE
docs(auth): fix private intra-doc link in get_user_info

### DIFF
--- a/crates/reinhardt-auth/src/social/oidc/userinfo.rs
+++ b/crates/reinhardt-auth/src/social/oidc/userinfo.rs
@@ -18,7 +18,7 @@ impl UserInfoClient {
 	/// Fetches user information from the UserInfo endpoint
 	///
 	/// The endpoint URL is expected to have been validated at discovery/config
-	/// time via [`validate_endpoint_url`](crate::social::url_validation::validate_endpoint_url),
+	/// time via `validate_endpoint_url`,
 	/// so no per-request re-parsing is performed here.
 	///
 	/// # Arguments


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix a pre-existing `rustdoc::private-intra-doc-links` warning in `reinhardt-auth` that was being treated as an error during docs.rs builds under `-D warnings`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Motivation and Context

- The `get_user_info` function in `crates/reinhardt-auth/src/social/oidc/userinfo.rs` had an intra-doc link pointing to a private module function `crate::social::url_validation::validate_endpoint_url`
- rustdoc emits `rustdoc::private-intra-doc-links` for such links, and docs.rs builds with `-D warnings`, causing the Docs.rs Build Check CI to fail
- Replaced the intra-doc link with a backtick reference (`` `validate_endpoint_url` ``) to eliminate the warning

Related to: #2323

## How Was This Tested?

- `cargo doc --no-deps -p reinhardt-auth` produces no errors or warnings after the fix

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `documentation` - Documentation update

### Scope Label
- [x] `auth` - Authentication, authorization, sessions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)