### PR TITLE
feat: expose reinhardt-query as reinhardt::query via database feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ database = [
   "reinhardt-db/orm",
   "reinhardt-db/migrations",
   "reinhardt-db/contenttypes",
+  "reinhardt-query",
   "linkme",
   "ctor",
 ]
@@ -287,6 +288,7 @@ reinhardt-graphql = { workspace = true, optional = true }
 reinhardt-websockets = { workspace = true, optional = true }
 reinhardt-openapi = { workspace = true, optional = true }
 reinhardt-dentdelion = { workspace = true, optional = true }
+reinhardt-query = { workspace = true, optional = true }
 
 # Dependencies used directly in this crate
 thiserror = { workspace = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1081,6 +1081,13 @@ pub use reinhardt_websockets::{
 	ConsumerContext, Message, WebSocketConsumer, WebSocketError, WebSocketResult,
 };
 
+/// SQL query builder module.
+///
+/// Re-exports [`reinhardt_query`] for building type-safe SQL queries.
+/// Requires `database` feature.
+#[cfg(all(feature = "database", not(target_arch = "wasm32")))]
+pub mod query;
+
 /// Database re-exports for Model derive macro generated code.
 ///
 /// These must be available at `::reinhardt::db::*` for the macro to work correctly.

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,29 @@
+//! SQL query builder module.
+//!
+//! This module re-exports [`reinhardt_query`] for building type-safe SQL queries
+//! targeting PostgreSQL, MySQL, and SQLite.
+//!
+//! # Availability
+//!
+//! Requires `database` feature.
+//!
+//! # Examples
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "database")]
+//! use reinhardt::query::prelude::*;
+//!
+//! # #[cfg(feature = "database")]
+//! # {
+//! let mut stmt = Query::select();
+//! stmt.column(Asterisk)
+//!     .from("users")
+//!     .and_where(Expr::col("active").eq(true));
+//!
+//! let builder = PostgresQueryBuilder::new();
+//! let (sql, values) = builder.build(&stmt);
+//! # }
+//! ```
+
+#[cfg(feature = "database")]
+pub use reinhardt_query::*;


### PR DESCRIPTION
## Summary

- Add `reinhardt-query` as an optional dependency in the `reinhardt-web` facade crate
- Enable it via the existing `database` feature (no new feature flags added)
- Expose `reinhardt-query` as `pub mod query` at `reinhardt::query`

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Users of the `reinhardt` crate with the `database` feature could not access
`reinhardt-query` types directly through the facade crate. This change exposes
the full query builder API as `reinhardt::query`, consistent with how other
sub-crates are exposed (e.g., `reinhardt::db`, `reinhardt::rest`).

Since `reinhardt-db` already depends on `reinhardt-query` with full features,
no additional compilation overhead is introduced.

**Usage after this change:**

```rust
// Cargo.toml
[dependencies]
reinhardt = { version = "0.1.0-rc.8", features = ["database"] }

// Rust code
use reinhardt::query::prelude::*;

let mut stmt = Query::select();
stmt.column(Asterisk)
    .from("users")
    .and_where(Expr::col("active").eq(true));

let builder = PostgresQueryBuilder::new();
let (sql, values) = builder.build(&stmt);
```

## How Was This Tested?

- `cargo check -p reinhardt-web --features database` — passes
- `cargo check -p reinhardt-web --all-features` — passes
- `cargo check -p reinhardt-web` (no database feature) — passes (module absent)

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `enhancement` - New feature or improvement

### Scope Label
- [x] `database` - Database layer
- [x] `orm` - ORM layer, query builder

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)