### PR TITLE
fix(query): correct doctest API calls for reinhardt-query

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -16,12 +16,12 @@
 //! # #[cfg(feature = "database")]
 //! # {
 //! let mut stmt = Query::select();
-//! stmt.column(Asterisk)
+//! stmt.column(ColumnRef::asterisk())
 //!     .from("users")
 //!     .and_where(Expr::col("active").eq(true));
 //!
 //! let builder = PostgresQueryBuilder::new();
-//! let (sql, values) = builder.build(&stmt);
+//! let (sql, values) = builder.build_select(&stmt);
 //! # }
 //! ```
 


### PR DESCRIPTION
## Summary

- Fix two doctest API errors in `src/query.rs` that cause Documentation Tests CI failure
  - `Asterisk` → `ColumnRef::asterisk()` (reinhardt-query API)
  - `builder.build(&stmt)` → `builder.build_select(&stmt)` (correct method name)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

PR #2355 (release-plz) Documentation Tests CI is failing due to API mismatches introduced in PR #2354.

Related to: #2355

## How Was This Tested?

- `cargo test -p reinhardt-web --doc --all-features`
- `cargo check --workspace --all --all-features`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)