### PR TITLE
fix(reinhardt-commands): add explicit type annotation for database connection

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -132,7 +132,7 @@ impl BaseCommand for MigrateCommand {
 			// 4. Connect to database (auto-create if it doesn't exist for PostgreSQL)
 			// This is done before filtering migrations to ensure connection errors are detected
 			// even when no migrations need to be applied
-			let connection = if database_url.starts_with("postgres://")
+			let connection: DatabaseConnection = if database_url.starts_with("postgres://")
 				|| database_url.starts_with("postgresql://")
 			{
 				#[cfg(feature = "postgres")]


### PR DESCRIPTION
## Summary

- Add explicit `DatabaseConnection` type annotation to resolve type-inference regression when compiling without `db-sqlite` feature

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

When only one database feature (e.g., `postgres` without `sqlite`) is enabled, the `#[cfg(not(feature = "sqlite"))]` branch compiles out the SQLite connection code, leaving only a `return Err(...)` statement. The compiler cannot infer the type of the if-else expression in this configuration, causing a type-inference error (`E0282`).

This is a regression from the fix for #2363, which added `#[cfg]` guards to the database connection branches.

Fixes #2390

Related to: #2363

## How Was This Tested?

- [x] `cargo check -p reinhardt-commands --no-default-features --features "migrations,postgres"` (postgres-only, no sqlite)
- [x] `cargo check -p reinhardt-commands --no-default-features --features "migrations,sqlite"` (sqlite-only, no postgres)
- [x] `cargo check --workspace --all --all-features`
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #2363 (original feature gate fix that introduced this regression)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)