### PR TITLE
ci(terraform): remove manual approval gate from apply job

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -155,7 +155,6 @@ jobs:
     needs: plan
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: production
     strategy:
       fail-fast: false
       max-parallel: 1


### PR DESCRIPTION
## Summary

- Remove `environment: production` from the Terraform Apply job

## Type of Change

- [x] CI/CD changes

## Motivation and Context

The `environment: production` deployment protection rule required manual approval in the GitHub UI before Terraform Apply could run. This was redundant because:

1. **PR merge = approval**: Infrastructure changes in `infra/**` go through PR review via `terraform-plan.yml`, which posts plan output to the PR. Merging the PR is the approval.
2. **Development infrastructure only**: The managed modules (CI runners, website, GitHub org/repo config) are development infrastructure, not production application services.
3. **Stale plan risk**: Delayed manual approval can cause the saved plan to become stale, leading to apply failures.
4. **Single maintainer**: Self-approval adds friction without adding safety.

The workflow still has a plan step before apply, and `max-parallel: 1` ensures sequential execution.

## How Was This Tested?

- [x] YAML syntax validated
- [ ] Will verify on next infra change push to main

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `ci-cd` - CI/CD workflow changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)