### PR TITLE
fix(examples): add missing feature flags for github-issues and rest-api examples

### DIFF
--- a/examples/examples-github-issues/Cargo.toml
+++ b/examples/examples-github-issues/Cargo.toml
@@ -17,6 +17,12 @@ reinhardt = { workspace = true, features = [
 	"argon2-hasher",  # Required for DefaultUser
 	"client-router",  # Client-side routing support (required for #[routes] macro)
 	"conf",           # Settings configuration (DefaultSource, Settings, SettingsBuilder)
+	"commands",       # Management commands (runserver, etc.)
+	"admin",          # reinhardt::admin module, #[admin] macro
+	"database",       # #[model(...)] macro for projects/models.rs
+	"db-postgres",    # PostgreSQL backend for database models
+	"middleware",     # reinhardt::middleware module
+	"middleware-cors", # CorsMiddleware in middleware
 ] }
 clap = { version = "4", features = ["derive"] }
 console = "0.16.1"
@@ -43,7 +49,7 @@ argon2 = { version = "0.5", features = ["std"] }
 # Use reinhardt with test feature (NOT reinhardt-test sub-crate)
 [dev-dependencies.reinhardt]
 workspace = true
-features = ["minimal", "graphql", "auth-jwt", "argon2-hasher", "client-router", "test", "testcontainers"]
+features = ["minimal", "graphql", "auth-jwt", "argon2-hasher", "client-router", "conf", "commands", "admin", "database", "db-postgres", "middleware", "middleware-cors", "test", "testcontainers"]
 
 [features]
 default = ["client-router"]

--- a/examples/examples-rest-api/Cargo.toml
+++ b/examples/examples-rest-api/Cargo.toml
@@ -37,6 +37,11 @@ reqwest = { version = "0.12", features = ["json"] }
 testcontainers = "0.25.2"
 testcontainers-modules = { version = "0.13.0", features = [] }
 
+# Use reinhardt with test feature (NOT reinhardt-test sub-crate)
+[dev-dependencies.reinhardt]
+workspace = true
+features = ["minimal", "conf", "commands", "client-router", "admin", "test"]
+
 [features]
 default = ["with-reinhardt", "client-router"]
 with-reinhardt = []


### PR DESCRIPTION
## Summary

- Add missing reinhardt feature flags to `examples-github-issues/Cargo.toml` (commands, admin, database, db-postgres, middleware, middleware-cors)
- Add `[dev-dependencies.reinhardt]` section with `test` feature to `examples-rest-api/Cargo.toml`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

CI run https://github.com/kent8192/reinhardt-web/actions/runs/23123554966 showed failures in examples-github-issues (clippy) and examples-rest-api (test) due to missing feature flags. The prior fix PR #2408 addressed some but not all missing features.

Related to: #2408

## How Was This Tested?

- [x] `cargo clippy --all-features -- -D warnings` passes for both examples
- [x] `cargo nextest run --all-features` passes: 20/20 tests (github-issues), 22/22 tests (rest-api)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)