### PR TITLE
docs: add draft PR conversion protection policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,12 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 - Use `git apply <patchfile name>.patch` for partial file commits
 - **NEVER** execute batch commits without user confirmation
 
+**Draft PR Policy:**
+- **NEVER** convert a Draft PR to Ready for Review without explicit user instruction
+- **NO EXCEPTIONS**: Plan Mode approval does NOT authorize Draft PR conversion (unlike commits/pushes)
+- Before converting, ensure all CI checks pass and tests pass locally
+- Use `gh pr ready <number>` for conversion
+
 **Branch Operations:**
 - When merging branches and resolving conflicts, execute immediately without entering Plan Mode
 - Before creating branches, verify names don't conflict with existing ones using `git worktree list` and `git branch -a`
@@ -455,6 +461,7 @@ Before submitting code:
 - Delete temp files from `/tmp` immediately
 - Wait for explicit user instruction before commits
 - Understand that Plan Mode approval authorizes both implementation and commits
+- Wait for explicit user instruction before converting Draft PRs to Ready for Review (Plan Mode approval does NOT authorize conversion)
 - Mark placeholders with `todo!()` or `// TODO:`
 - Use `#[serial(group_name)]` for global state tests
 - Split commits by specific intent, not features
@@ -518,6 +525,7 @@ Before submitting code:
 ### ❌ NEVER DO
 - Use `mod.rs` files (deprecated pattern)
 - Commit without user instruction (except Plan Mode approval)
+- Convert Draft PRs to Ready for Review without explicit user instruction (Plan Mode approval does NOT count)
 - Leave docs outdated after code changes
 - Document user requests or AI interactions in project documentation
 - Save files to project directory (use `/tmp`)

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -145,6 +145,58 @@ gitGraph
 gh pr create --draft --title "feat(auth): add JWT validation (WIP)"
 ```
 
+### PC-4a (MUST): Draft PR Conversion Protection
+
+Converting a Draft PR to Ready for Review is a **visibility-affecting action** that exposes the PR to reviewers and triggers notifications. This conversion **MUST** require explicit user instruction.
+
+**Rules:**
+- **NEVER** convert a Draft PR to Ready for Review without explicit user instruction
+- **Plan Mode approval does NOT authorize Draft PR conversion** (unlike commits/pushes)
+  - Rationale: Plan Mode authorizes *implementation work* (code changes, commits, pushes), but Draft PR conversion is a *review readiness decision* that only the user can make
+- Before converting, ensure all CI checks pass and tests pass locally
+- Use `gh pr ready <number>` for conversion
+
+**Pre-Conversion Checklist:**
+- [ ] User has explicitly instructed conversion
+- [ ] All CI checks pass
+- [ ] All tests pass locally
+- [ ] PR description is complete and accurate
+- [ ] Code follows project style guidelines
+- [ ] Documentation is updated (if applicable)
+
+**Example:**
+```bash
+# Convert Draft PR to Ready for Review (ONLY after explicit user instruction)
+gh pr ready 123
+
+# Verify PR status after conversion
+gh pr view 123 --json isDraft
+```
+
+**Authorization Comparison:**
+
+| Action | Explicit Instruction | Plan Mode Approval |
+|--------|---------------------|-------------------|
+| Commit | ✅ Authorized | ✅ Authorized |
+| Push | ✅ Authorized | ✅ Authorized |
+| GitHub Comments | ✅ Authorized | ✅ Authorized |
+| Draft PR → Ready | ✅ Authorized | ❌ NOT Authorized |
+
+The following diagram illustrates the Draft PR lifecycle:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft: gh pr create --draft
+    Draft --> Draft: Implementation continues
+    Draft --> Draft: CI checks run
+    Draft --> ReadyForReview: User explicitly instructs conversion
+    note right of ReadyForReview: Requires explicit user instruction\nPlan Mode approval NOT sufficient
+    ReadyForReview --> Review: Reviewers notified
+    Review --> Merged: Approved and merged
+    Review --> Draft: Converted back to draft
+    Merged --> [*]
+```
+
 ### PC-5 (MUST): PR Labels
 
 - **MUST** add appropriate labels to every PR
@@ -746,6 +798,7 @@ docs(readme): add installation instructions
 - Address all review comments
 - Ensure all CI checks pass before merge
 - Use three-dot diff (`main...branch`) for PR verification to exclude merge history noise
+- Wait for explicit user instruction before converting Draft PRs to Ready for Review (Plan Mode approval does NOT authorize conversion)
 
 ### ❌ NEVER DO
 - Write PR titles or descriptions in non-English languages
@@ -758,6 +811,7 @@ docs(readme): add installation instructions
 - Force push after review has started (unless explicitly requested)
 - Use rebase or force-push to resolve PR conflicts (use worktree merge instead)
 - Use two-dot diff (`main..branch`) for PR verification (includes merge history noise)
+- Convert Draft PRs to Ready for Review without explicit user instruction (Plan Mode approval does NOT count)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add PC-4a (MUST) rule to `instructions/PR_GUIDELINE.md` requiring explicit user instruction before converting Draft PRs to Ready for Review
- Add Draft PR Policy subsection to `CLAUDE.md` Git Workflow section
- Update Quick Reference (MUST DO / NEVER DO) in both files

## Type of Change

- [x] Documentation update

## Motivation and Context

Draft PR to Ready for Review conversion is a visibility-affecting action that exposes the PR to reviewers and triggers notifications. While the project already has protection policies for commits, pushes, and GitHub comments (requiring explicit user instruction), Draft PR conversion had no such protection. This gap could lead to unintended reviewer notifications and premature review requests.

Key design decision: Plan Mode approval does **not** authorize Draft PR conversion, unlike commits/pushes. This is because Plan Mode authorizes *implementation work*, but Draft PR conversion is a *review readiness decision* that only the user can make.

## How Was This Tested?

- [x] Verified all edits are consistent across `CLAUDE.md` and `instructions/PR_GUIDELINE.md`
- [x] Verified Mermaid diagram syntax is correct
- [x] Verified Authorization Comparison table accurately reflects existing policies
- [x] Verified no contradictions with existing commit/push/GitHub comment authorization patterns

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)