### PR TITLE
docs(auth): document DI context requirements for CurrentUser injection

### DIFF
--- a/crates/reinhardt-auth/src/current_user.rs
+++ b/crates/reinhardt-auth/src/current_user.rs
@@ -14,6 +14,51 @@
 //!    - Parses the user_id to the model's primary key type
 //!    - Loads the user from the database using `Model::objects().get(pk)`
 //! 3. Returns `CurrentUser::authenticated(user, user_id)` or `CurrentUser::anonymous()`
+//!
+//! # Prerequisites
+//!
+//! For `CurrentUser<U>` injection to work properly, the following must be configured:
+//!
+//! 1. **DI Context on Router**: The router must be configured with `.with_di_context()`
+//! 2. **`DatabaseConnection` Singleton**: A `DatabaseConnection` must be registered
+//!    as a singleton in the `InjectionContext`
+//! 3. **Authentication Middleware**: Middleware must insert `AuthState` into request extensions
+//!
+//! If the DI context is not configured, `CurrentUser` will fall back to anonymous.
+//! If `DatabaseConnection` is not registered, `CurrentUser` will also fall back to anonymous
+//! (with a warning log).
+//!
+//! ## Setup Example
+//!
+//! ```rust,ignore
+//! use reinhardt_di::InjectionContext;
+//! use reinhardt_db::DatabaseConnection;
+//! use std::sync::Arc;
+//!
+//! // 1. Create and configure the DI context
+//! let mut ctx = InjectionContext::new();
+//!
+//! // 2. Register DatabaseConnection as a singleton
+//! let db = DatabaseConnection::connect_postgres("postgres://...")
+//!     .await
+//!     .expect("Failed to connect");
+//! ctx.register_singleton(db);
+//!
+//! // 3. Configure the router with the DI context
+//! let router = Router::new()
+//!     .with_di_context(Arc::new(ctx))
+//!     .route("/api/profile", get(profile_handler));
+//! ```
+//!
+//! ## Fallback Behavior
+//!
+//! | Condition | Result |
+//! |-----------|--------|
+//! | DI context not set | `CurrentUser::anonymous()` (warning logged) |
+//! | `DatabaseConnection` not registered | `CurrentUser::anonymous()` (warning logged) |
+//! | `AuthState` not in extensions | `CurrentUser::anonymous()` |
+//! | User not found in database | `CurrentUser::anonymous()` |
+//! | All configured correctly | `CurrentUser::authenticated(user, id)` |
 
 use crate::AuthenticationError;
 use crate::BaseUser;

--- a/crates/reinhardt-auth/src/lib.rs
+++ b/crates/reinhardt-auth/src/lib.rs
@@ -35,6 +35,16 @@
 //! - `social` (feature-gated): OAuth2/OpenID Connect social authentication providers
 //! - `user_management`: CRUD operations for users and groups
 //!
+//! ## DI Setup for `CurrentUser`
+//!
+//! To use [`CurrentUser`] in endpoint handlers, configure:
+//! 1. `InjectionContext` with a `DatabaseConnection` singleton
+//! 2. Router with `.with_di_context()`
+//! 3. Authentication middleware that sets `AuthState` in request extensions
+//!
+//! See [`current_user`] module documentation for detailed setup examples and
+//! fallback behavior.
+//!
 //! ## Feature Flags
 //!
 //! | Feature | Default | Description |


### PR DESCRIPTION
## Summary

- Added Prerequisites, Setup Example, and Fallback Behavior sections to `current_user` module docs
- Added DI Setup section to `reinhardt-auth` crate-level docs
- Documents the required configuration for `CurrentUser<U>` injection to work properly

## Type of Change

- [x] Documentation update

## Motivation and Context

The DI context requirements for `CurrentUser` injection were not documented, making it difficult for users to understand why `CurrentUser` returns anonymous when the router or `DatabaseConnection` is not properly configured. This was discovered during reinhardt-nuages JWT middleware integration.

Fixes #2419

Related to: #2417

## How Was This Tested?

- `cargo doc -p reinhardt-auth --no-deps` — docs build cleanly with no warnings
- `cargo check -p reinhardt-auth --all-features` — passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

### Scope Label (select all that apply)
- [x] `auth` - Authentication, authorization, sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)