### PR TITLE
fix(di): use builder pattern for InjectionContext fallback in use_inject macro

### DIFF
--- a/crates/reinhardt-core/macros/src/use_inject.rs
+++ b/crates/reinhardt-core/macros/src/use_inject.rs
@@ -206,7 +206,9 @@ pub(crate) fn use_inject_impl(_args: TokenStream, input: ItemFn) -> Result<Token
 						"DI context not set on router. Creating empty fallback context. \
 						 Hint: Configure the router with .with_di_context() for proper dependency injection."
 					);
-					::std::sync::Arc::new(#di_crate::InjectionContext::new())
+					::std::sync::Arc::new(::std::sync::Arc::new(
+						#di_crate::InjectionContext::builder(#di_crate::SingletonScope::new()).build()
+					))
 				}
 			};
 		}


### PR DESCRIPTION
## Summary

- Fix `#[use_inject]` macro fallback path that generated non-existent `InjectionContext::new()`
- Use correct builder pattern: `InjectionContext::builder(SingletonScope::new()).build()`
- Fix type mismatch: `None` branch now returns `Arc<Arc<InjectionContext>>` to match `Some` branch

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `#[use_inject]` macro's fallback path (when no DI context is set on the router) generated `InjectionContext::new()`, but `InjectionContext` only supports construction via the builder pattern. This caused compilation failures in `cargo check --tests` and CI checks (`Cargo Check (tests)`, `Cross-Crate Integration Coverage`).

Fixes #2431

Related to: #2429 (release PR blocked by this CI failure)

## How Was This Tested?

- `cargo check --workspace --all --all-features --tests` — passes (previously failed with 9 E0599 errors)
- `cargo make fmt-check` — passes
- `cargo make clippy-check` — passes
- `cargo nextest run --package reinhardt-integration-tests --test di --all-features` — 40/41 tests pass (1 DB-dependent test skipped as expected without Docker)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

---

**Additional Context:**

This bug was latent on `main` but only manifested in CI because `Cargo Check (tests)` compiles test targets (which expand the `#[use_inject]` macro), while `Cargo Check (lib)` does not. The release PR #2429 was blocked by this failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)