### PR TITLE
docs: add Copilot review handling workflow (CR-1 ~ CR-5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 See instructions/GITHUB_INTERACTION.md for comprehensive GitHub interaction guidelines including:
 - Posting authorization policy (PP-1 ~ PP-3)
 - PR review response format (RR-1 ~ RR-3)
+- Copilot review handling (CR-1 ~ CR-5)
 - Issue discussion guidelines (ID-1 ~ ID-2)
 - Agent context provision (AC-1 ~ AC-2)
 
@@ -521,6 +522,9 @@ Before submitting code:
 - Use independent context (separate agent session) for agent re-evaluation of `agent-suspect` Issues
 - Obtain SP-6 approval before adding non-breaking APIs during RC phase (`enhancement` + `rc-addition` labels + maintainer approval)
 - Use three-dot diff (`main...branch`) for PR diff verification to exclude merge history noise
+- Evaluate, respond to, and resolve Copilot review comments after PR creation (CR-1 ~ CR-4)
+- Reply to every Copilot review thread before resolving it (no silent resolves)
+- Use GraphQL `resolveReviewThread` mutation to resolve Copilot review threads
 
 ### ❌ NEVER DO
 - Use `mod.rs` files (deprecated pattern)
@@ -589,6 +593,9 @@ Before submitting code:
 - Squash-merge the develop branch into `main` (DB-5)
 - Use the same agent context for both detection and verification of a bug
 - Use two-dot diff (`main..branch`) for PR verification (includes merge history noise)
+- Resolve Copilot review threads without posting a reply first
+- Poll in a loop waiting for Copilot review to appear
+- Dismiss valid Copilot review concerns without fixing the code
 
 ### 📚 Detailed Standards
 
@@ -604,6 +611,7 @@ For comprehensive guidelines, see:
 - **Issues**: instructions/ISSUE_GUIDELINES.md
 - **Issue Handling**: instructions/ISSUE_HANDLING.md
 - **GitHub Interactions**: instructions/GITHUB_INTERACTION.md
+- **Copilot Review Handling**: instructions/GITHUB_INTERACTION.md (CR-1 ~ CR-5)
 - **GitHub Discussions**: https://github.com/kent8192/reinhardt-web/discussions
 - **Security Policy**: SECURITY.md
 - **Code of Conduct**: CODE_OF_CONDUCT.md

--- a/instructions/GITHUB_INTERACTION.md
+++ b/instructions/GITHUB_INTERACTION.md
@@ -216,6 +216,174 @@ When changes affect multiple crates or modules, provide impact analysis:
 
 ---
 
+## Copilot Review Handling
+
+### CR-1 (MUST): Post-PR Copilot Review Workflow
+
+After creating a PR, Claude Code MUST handle GitHub Copilot's automated review comments as part of the PR workflow when authorized by PP-1 (explicit user instruction or Plan Mode approval).
+
+**Workflow:**
+
+```mermaid
+flowchart TD
+    A[PR created] --> B[Fetch review threads via GraphQL]
+    B --> C{Copilot review exists?}
+    C -->|No| D[Report to user and wait]
+    C -->|Yes| E[Filter unresolved Copilot threads]
+    E --> F[Evaluate each thread]
+    F --> G{Valid concern?}
+    G -->|Yes| H[Fix code + reply + resolve]
+    G -->|False positive| I[Reply with explanation + resolve]
+    G -->|Already addressed| J[Reply with reference + resolve]
+    H --> K[Commit fixes]
+    I --> K
+    J --> K
+    K --> L[Report summary to user]
+```
+
+**Authorization:**
+- Follows PP-1: requires explicit user instruction or Plan Mode approval
+- When Plan Mode approves a PR creation workflow, Copilot review handling is included in that authorization scope
+- Fix commits follow standard commit policy (CE-1)
+
+### CR-2 (MUST): Fetching Copilot Review Threads
+
+Use `gh api graphql` to retrieve review threads from a PR:
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 10) {
+            nodes {
+              author {
+                login
+              }
+              body
+              path
+              line
+              diffHunk
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner='kent8192' -f repo='reinhardt' -F pr=<PR_NUMBER>
+```
+
+**Filtering Criteria:**
+- Filter by `author.login` matching Copilot bot (e.g., `copilot-pull-request-reviewer[bot]`)
+- Filter by `isResolved == false` to process only unresolved threads
+
+**Polling Prohibition:**
+- **NEVER** poll in a loop waiting for Copilot review to appear
+- If no Copilot review exists yet, report to user once and wait for further instruction
+
+### CR-3 (MUST): Evaluating and Responding to Comments
+
+Evaluate each Copilot comment against these categories:
+
+| Category | Action | Response |
+|----------|--------|----------|
+| Valid concern | Fix code | Reply with fix description → Resolve |
+| False positive | No code change | Reply with technical explanation → Resolve |
+| Already addressed | No code change | Reply with reference to existing handling → Resolve |
+
+**Response Template (extends RR-2):**
+
+For valid concerns with code fix:
+```markdown
+**Fixed:** [Brief description of the fix]
+
+[Technical explanation of the change]
+
+Commit: [commit hash] — `path/to/file.rs:L42`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+For false positives or already addressed:
+```markdown
+**Re: [Copilot's concern summary]**
+
+[Technical explanation of why this is not an issue or is already handled]
+
+Reference: `path/to/file.rs:L42` — [Description of existing handling]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+**Guidelines:**
+- Follow RR-3 for code reference format (repository-relative paths)
+- Follow FF-1 for Claude Code attribution footer
+- Follow CG-2 content restrictions (no absolute paths, no user request details)
+- Every thread MUST receive a reply before being resolved (no silent resolves)
+
+### CR-4 (MUST): Resolving Threads via GraphQL
+
+**Step 1: Reply to the thread**
+
+```bash
+gh api graphql -f query='
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: $threadId,
+    body: $body
+  }) {
+    comment {
+      id
+    }
+  }
+}' -f threadId='<THREAD_ID>' -f body='<REPLY_BODY>'
+```
+
+**Step 2: Resolve the thread**
+
+```bash
+gh api graphql -f query='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {
+    threadId: $threadId
+  }) {
+    thread {
+      isResolved
+    }
+  }
+}' -f threadId='<THREAD_ID>'
+```
+
+**Rules:**
+- **MUST** reply before resolving (CR-3 compliance)
+- **NEVER** resolve a thread without posting a reply first
+- Verify `isResolved: true` in the mutation response
+
+### CR-5 (SHOULD): Completion Summary
+
+After processing all Copilot review threads, report a summary to the user:
+
+**Summary Format:**
+
+```markdown
+## Copilot Review Handling Summary
+
+| # | File | Line | Category | Action |
+|---|------|------|----------|--------|
+| 1 | `path/to/file.rs` | L42 | Valid concern | Fixed (commit abc1234) |
+| 2 | `path/to/other.rs` | L15 | False positive | Explained |
+| 3 | `path/to/third.rs` | L88 | Already addressed | Referenced |
+
+**Commits created:** 1
+**Threads resolved:** 3 / 3
+```
+
+---
+
 ## Issue Discussion
 
 ### ID-1 (MUST): Issue Comment Guidelines
@@ -404,6 +572,10 @@ All GitHub comments posted by Claude Code MUST include the following footer:
 - Use markdown code blocks with language specifiers
 - Wrap long output in `<details>` tags
 - Stay on topic and be actionable
+- Evaluate and respond to Copilot review threads after PR creation (CR-1 ~ CR-4)
+- Reply to every Copilot review thread before resolving (no silent resolves)
+- Use GraphQL mutations for thread replies and resolution (CR-4)
+- Report Copilot review handling summary after completion (CR-5)
 
 ### ❌ NEVER DO
 
@@ -417,6 +589,9 @@ All GitHub comments posted by Claude Code MUST include the following footer:
 - Post vague comments without code references or technical detail
 - Use raw `curl` for GitHub operations when MCP or CLI is available
 - Reference code without file path and line number
+- Resolve Copilot review threads without posting a reply first
+- Poll in a loop waiting for Copilot review to appear
+- Dismiss valid Copilot review concerns without fixing the code
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Copilot Review Handling section (CR-1 ~ CR-5) to `instructions/GITHUB_INTERACTION.md`
- Update `CLAUDE.md` Quick Reference with CR-related MUST DO / NEVER DO rules and detailed standards reference

## Type of Change

- [x] Documentation update

## Motivation and Context

There was no guideline for handling GitHub Copilot's automated review comments after PR creation. This addition defines a structured workflow for fetching, evaluating, responding to, and resolving Copilot review threads, ensuring consistent post-PR review handling.

## How Was This Tested?

- Verified document structure integrity (no section number conflicts)
- Verified cross-references between CLAUDE.md and GITHUB_INTERACTION.md are consistent
- Confirmed existing rule references (PP-1, RR-2, RR-3, FF-1, CE-1, CG-2) are accurately cited

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)