### PR TITLE
fix(migrations): handle `.to_string()` in dependency tuple parsing

### DIFF
--- a/crates/reinhardt-db/src/migrations/ast_parser.rs
+++ b/crates/reinhardt-db/src/migrations/ast_parser.rs
@@ -814,12 +814,19 @@ fn extract_string_tuple(expr: &Expr) -> Option<(String, String)> {
 	None
 }
 
-/// Extract string value from a literal expression
+/// Extract string value from a literal expression or `.to_string()` method call
 fn extract_string_literal(expr: &Expr) -> Option<String> {
+	// Handle direct string literal: "foo"
 	if let Expr::Lit(expr_lit) = expr
 		&& let syn::Lit::Str(lit_str) = &expr_lit.lit
 	{
 		return Some(lit_str.value());
+	}
+	// Handle "foo".to_string() pattern
+	if let Expr::MethodCall(method_call) = expr
+		&& method_call.method == "to_string"
+	{
+		return extract_string_literal(&method_call.receiver);
 	}
 	None
 }


### PR DESCRIPTION
## Summary

- Fix `extract_string_literal` in AST parser to handle `.to_string()` method call patterns
- Migration dependency tuples like `("app".to_string(), "name".to_string())` were silently ignored
- This caused empty dependency graphs and non-deterministic migration execution ordering

## Root Cause

`extract_string_literal` only matched `Expr::Lit` (direct string literals like `"foo"`), but migration files generated by `makemigrations` use `"foo".to_string()` which is `Expr::MethodCall`. The function `extract_string_field` already handled this pattern correctly, but `extract_string_literal` (used by `extract_string_tuple` for dependency parsing) did not.

## Impact

All migrations with cross-app dependencies had their dependencies silently dropped during `FilesystemSource` parsing, causing:
- Non-deterministic migration ordering (all migrations had in-degree 0 in topological sort)
- `relation "X" does not exist` errors when `ALTER TABLE` ran before `CREATE TABLE`

## Test plan

- [x] `cargo check --package reinhardt-db --all-features` passes
- [x] All `filesystem::tests` pass
- [x] Verified the fix resolves nuages CI failures (reinhardt-nuages#93)

🤖 Generated with [Claude Code](https://claude.com/claude-code)