### PR TITLE
fix(migrations): resolve multi-element dependency parsing and deterministic sort

### DIFF
--- a/crates/reinhardt-db/src/migrations/ast_parser.rs
+++ b/crates/reinhardt-db/src/migrations/ast_parser.rs
@@ -259,6 +259,24 @@ fn parse_single_operation(expr: &Expr) -> Option<super::Operation> {
 				let columns = extract_string_vec_field(&expr_struct.fields, "columns");
 				return Some(super::Operation::DropIndex { table, columns });
 			}
+			"AddConstraint" => {
+				let table = extract_string_field(&expr_struct.fields, "table")?;
+				let constraint_sql =
+					extract_string_field(&expr_struct.fields, "constraint_sql")?;
+				return Some(super::Operation::AddConstraint {
+					table,
+					constraint_sql,
+				});
+			}
+			"DropConstraint" => {
+				let table = extract_string_field(&expr_struct.fields, "table")?;
+				let constraint_name =
+					extract_string_field(&expr_struct.fields, "constraint_name")?;
+				return Some(super::Operation::DropConstraint {
+					table,
+					constraint_name,
+				});
+			}
 			"RunSQL" => {
 				// Use extract_string_field to handle both literal and .to_string() patterns (#1336)
 				let sql = extract_string_field(&expr_struct.fields, "sql")?;
@@ -770,19 +788,13 @@ fn parse_tuple_vec_expr(expr: &Expr) -> Result<Vec<(String, String)>> {
 	match expr {
 		// Handle vec![...] macro
 		Expr::Macro(expr_macro) if expr_macro.mac.path.is_ident("vec") => {
-			// Parse the tokens inside vec! as an array expression
 			let tokens = &expr_macro.mac.tokens;
-			// Try to parse as array
-			if let Ok(array) = syn::parse2::<Expr>(tokens.clone()) {
-				if let Expr::Array(expr_array) = array {
-					for item in &expr_array.elems {
-						if let Some(tuple) = extract_string_tuple(item) {
-							result.push(tuple);
-						}
-					}
-				} else {
-					// Try parsing as single tuple
-					if let Some(tuple) = extract_string_tuple(&array) {
+			// Wrap tokens in array brackets so syn can parse comma-separated items
+			if let Ok(parsed) =
+				syn::parse2::<syn::ExprArray>(quote::quote! { [#tokens] })
+			{
+				for item in &parsed.elems {
+					if let Some(tuple) = extract_string_tuple(item) {
 						result.push(tuple);
 					}
 				}

--- a/crates/reinhardt-db/src/migrations/graph.rs
+++ b/crates/reinhardt-db/src/migrations/graph.rs
@@ -324,11 +324,18 @@ impl MigrationGraph {
 		}
 
 		// Find all nodes with in-degree 0 (no dependencies within the graph)
-		let mut queue: VecDeque<MigrationKey> = in_degree
+		// Sort deterministically by (app_label, name) to ensure consistent ordering
+		let mut zero_degree: Vec<MigrationKey> = in_degree
 			.iter()
 			.filter(|&(_, &degree)| degree == 0)
 			.map(|(key, _)| key.clone())
 			.collect();
+		zero_degree.sort_by(|a, b| {
+			a.app_label
+				.cmp(&b.app_label)
+				.then_with(|| a.name.cmp(&b.name))
+		});
+		let mut queue: VecDeque<MigrationKey> = zero_degree.into_iter().collect();
 
 		let mut result = Vec::new();
 


### PR DESCRIPTION
## Summary

- Fix `parse_tuple_vec_expr` to correctly parse multi-element `vec![]` dependency lists by wrapping tokens in array brackets (matching the technique already used in `parse_operations_vec`)
- Sort initial zero-in-degree nodes in topological sort deterministically by `(app_label, name)`
- Add `AddConstraint` and `DropConstraint` operation parsing support in the AST parser

## Motivation and Context

Migrations with multiple dependencies (e.g., `dependencies: vec![("auth".to_string(), "0001_initial".to_string()), ("clusters".to_string(), "0001_initial".to_string())]`) had their dependency lists silently dropped, causing wrong migration execution order and "relation does not exist" database errors.

The root cause was that `parse_tuple_vec_expr` tried `syn::parse2::<Expr>(tokens)` on raw comma-separated tuple tokens, which fails for multi-element lists since they don't form a valid single expression. The fix applies the same `quote::quote! { [#tokens] }` wrapping already used by `parse_operations_vec`.

## How Was This Tested

- `cargo check --package reinhardt-db` passes
- `cargo test --package reinhardt-db -- migration` — 171 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)