### PR TITLE
ci: add workflow to auto-delete release-plz branches on PR close

### DIFF
--- a/.github/workflows/cleanup-release-branch.yml
+++ b/.github/workflows/cleanup-release-branch.yml
@@ -1,0 +1,38 @@
+name: Cleanup Release Branch on PR Close
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup-release-branch:
+    name: Delete release-plz branch
+    if: >-
+      github.event.pull_request.merged == false &&
+      startsWith(github.event.pull_request.head.ref, 'release-plz-')
+    runs-on: [self-hosted, linux, arm64, reinhardt-cancel]
+    timeout-minutes: 5
+    steps:
+      - name: Delete remote branch
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            console.log(`Deleting branch: ${branch}`);
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`,
+              });
+              console.log(`Successfully deleted branch: ${branch}`);
+            } catch (e) {
+              if (e.status === 422) {
+                console.log(`Branch already deleted: ${branch}`);
+              } else {
+                throw e;
+              }
+            }


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically delete `release-plz-*` branches when their PR is closed without merging
- Also cleaned up 10 stale `release-plz-*` branches from the remote

## Type of Change

- [x] CI/CD changes

## Motivation and Context

release-plz creates Release PRs with branches named `release-plz-*`. When merged, GitHub's "Automatically delete head branches" setting handles cleanup. However, when PRs are closed without merging (e.g., superseded by a newer release PR), branches accumulate on the remote. This workflow automates their deletion.

## How Was This Tested?

- YAML syntax validated with Python yaml parser
- Workflow logic follows the same `actions/github-script@v8` pattern as `cancel-on-pr-close.yml`
- Conditions verified: only triggers on unmerged PR close with `release-plz-` prefix branch

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)