### PR TITLE
fix(throttling): resolve token bucket validation and timing bugs

### DIFF
--- a/crates/reinhardt-throttling/src/token_bucket.rs
+++ b/crates/reinhardt-throttling/src/token_bucket.rs
@@ -214,11 +214,9 @@ impl TokenBucketConfigBuilder {
 		let refill_rate = self
 			.refill_rate
 			.ok_or_else(|| ThrottleError::InvalidConfig("refill_rate must be set".to_string()))?;
-		let refill_interval = self
-			.refill_interval
-			.ok_or_else(|| {
-				ThrottleError::InvalidConfig("refill_interval must be set".to_string())
-			})?;
+		let refill_interval = self.refill_interval.ok_or_else(|| {
+			ThrottleError::InvalidConfig("refill_interval must be set".to_string())
+		})?;
 		let tokens_per_request = self.tokens_per_request.unwrap_or(1);
 
 		// Delegate to TokenBucketConfig::new for centralized validation


### PR DESCRIPTION
## Summary

- Validate `TokenBucketConfig` rejects zero values for capacity, tokens_per_request, refill_rate, and refill_interval in both `new()` and `build()`
- Fix `refill_tokens` to preserve fractional interval time instead of resetting `last_refill` to current time
- Fix `wait_time` to call `refill_tokens` before computing wait duration to avoid stale results

Fixes #2237
Fixes #2246
Fixes #2249

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Was This Tested

- [x] `cargo nextest run -p reinhardt-throttling --all-features` — all 157 tests pass
- [x] `cargo fmt -p reinhardt-throttling -- --check` passes
- [x] `cargo clippy -p reinhardt-throttling --all-features -- -D warnings` passes
- [x] New tests added for all three fixes:
  - Zero-value rejection tests for `new()` and `build()` (6 tests)
  - `test_wait_time_refills_before_computing` — verifies wait_time returns None after refill
  - `test_refill_preserves_fractional_interval` — verifies partial intervals are preserved

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary (in English)
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)