### PR TITLE
fix(core): reject NaN quality values in AcceptHeader parsing

### DIFF
--- a/crates/reinhardt-core/src/negotiation/accept.rs
+++ b/crates/reinhardt-core/src/negotiation/accept.rs
@@ -34,7 +34,7 @@ impl AcceptHeader {
 			.collect();
 
 		// Sort by quality (highest first)
-		// Use unwrap_or as a safety net in case NaN slips through
+		// Non-finite values are rejected at parse time; unwrap_or is a safety net
 		media_types.sort_by(|a, b| {
 			b.quality
 				.partial_cmp(&a.quality)

--- a/crates/reinhardt-core/src/negotiation/encoding.rs
+++ b/crates/reinhardt-core/src/negotiation/encoding.rs
@@ -137,8 +137,8 @@ impl EncodingQuality {
 				&& key.trim() == "q"
 				&& let Ok(q) = value.trim().parse::<f32>()
 			{
-				// Reject NaN quality values to prevent partial_cmp panic
-				if q.is_nan() {
+				// Reject non-finite quality values (NaN, inf, -inf)
+				if !q.is_finite() {
 					return None;
 				}
 				quality = q.clamp(0.0, 1.0);
@@ -221,7 +221,7 @@ impl EncodingNegotiator {
 		let mut requested = self.parse_accept_encoding(accept_encoding);
 
 		// Sort by quality (highest first)
-		// Use unwrap_or as a safety net in case NaN slips through
+		// Non-finite values are rejected at parse time; unwrap_or is a safety net
 		requested.sort_by(|a, b| {
 			b.quality
 				.partial_cmp(&a.quality)
@@ -343,15 +343,18 @@ mod tests {
 	}
 
 	#[rstest]
-	fn test_parse_rejects_nan_quality() {
+	#[case("gzip;q=NaN")]
+	#[case("gzip;q=inf")]
+	#[case("gzip;q=-inf")]
+	fn test_parse_rejects_non_finite_quality(#[case] input: &str) {
 		// Arrange
-		let input = "gzip;q=NaN";
+		// (input provided by rstest case)
 
 		// Act
 		let result = EncodingQuality::parse(input);
 
 		// Assert
-		assert_eq!(result, None, "NaN quality value should be rejected");
+		assert_eq!(result, None, "Non-finite quality value should be rejected");
 	}
 
 	#[rstest]

--- a/crates/reinhardt-core/src/negotiation/language.rs
+++ b/crates/reinhardt-core/src/negotiation/language.rs
@@ -84,8 +84,8 @@ impl Language {
 				&& key.trim() == "q"
 				&& let Ok(q) = value.trim().parse::<f32>()
 			{
-				// Reject NaN quality values to prevent partial_cmp panic
-				if q.is_nan() {
+				// Reject non-finite quality values (NaN, inf, -inf)
+				if !q.is_finite() {
 					return None;
 				}
 				quality = q.clamp(0.0, 1.0);
@@ -216,7 +216,7 @@ impl LanguageNegotiator {
 		let mut requested = self.parse_accept_language(accept_language);
 
 		// Sort by quality (highest first)
-		// Use unwrap_or as a safety net in case NaN slips through
+		// Non-finite values are rejected at parse time; unwrap_or is a safety net
 		requested.sort_by(|a, b| {
 			b.quality
 				.partial_cmp(&a.quality)
@@ -355,15 +355,18 @@ mod tests {
 	}
 
 	#[rstest]
-	fn test_parse_rejects_nan_quality() {
+	#[case("en-US;q=NaN")]
+	#[case("en-US;q=inf")]
+	#[case("en-US;q=-inf")]
+	fn test_parse_rejects_non_finite_quality(#[case] input: &str) {
 		// Arrange
-		let input = "en-US;q=NaN";
+		// (input provided by rstest case)
 
 		// Act
 		let result = Language::parse(input);
 
 		// Assert
-		assert_eq!(result, None, "NaN quality value should be rejected");
+		assert_eq!(result, None, "Non-finite quality value should be rejected");
 	}
 
 	#[rstest]

--- a/crates/reinhardt-core/src/negotiation/media_type.rs
+++ b/crates/reinhardt-core/src/negotiation/media_type.rs
@@ -73,8 +73,8 @@ impl MediaType {
 
 				if key == "q" {
 					if let Ok(q) = value.parse::<f32>() {
-						// Reject NaN quality values to prevent partial_cmp panic
-						if q.is_nan() {
+						// Reject non-finite quality values (NaN, inf, -inf)
+						if !q.is_finite() {
 							return None;
 						}
 						media_type.quality = q.clamp(0.0, 1.0);
@@ -214,7 +214,9 @@ mod tests {
 	#[rstest]
 	#[case("text/html;q=NaN")]
 	#[case("application/json; q=NaN")]
-	fn test_parse_rejects_nan_quality(#[case] input: &str) {
+	#[case("text/html;q=inf")]
+	#[case("text/html;q=-inf")]
+	fn test_parse_rejects_non_finite_quality(#[case] input: &str) {
 		// Arrange
 		// (input provided by rstest case)
 
@@ -222,6 +224,6 @@ mod tests {
 		let result = MediaType::parse(input);
 
 		// Assert
-		assert_eq!(result, None, "NaN quality value should be rejected");
+		assert_eq!(result, None, "Non-finite quality value should be rejected");
 	}
 }


### PR DESCRIPTION
## Summary

- Add `is_nan()` validation during quality value parsing in Accept, Accept-Language, and Accept-Encoding header negotiation
- Replace `partial_cmp().unwrap()` with `unwrap_or(Ordering::Equal)` as a safety net in sort operations

Fixes #2598

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Parsing `q=NaN` in Accept headers (e.g., `text/html;q=NaN`) causes `partial_cmp()` to return `None`, which panics on `.unwrap()` during quality-based sorting. This is a denial-of-service vector via crafted HTTP headers.

Fixes #2598

## How Was This Tested?

- Added `#[rstest]` test cases for NaN quality rejection in `MediaType::parse`, `Language::parse`, and `EncodingQuality::parse`
- Added tests verifying `AcceptHeader::parse`, `LanguageNegotiator::negotiate/find_all_matches`, and `EncodingNegotiator::negotiate` do not panic with NaN quality values
- All 1621 existing tests pass: `cargo nextest run -p reinhardt-core --all-features`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `http` - HTTP layer, handlers, middleware

---

Generated with [Claude Code](https://claude.com/claude-code)