### PR TITLE
fix(conf): add else branch for SSL redirect validation

### DIFF
--- a/crates/reinhardt-conf/src/settings/validation.rs
+++ b/crates/reinhardt-conf/src/settings/validation.rs
@@ -678,9 +678,8 @@ mod tests {
 		// Assert
 		let err = result.unwrap_err();
 		let error_msg = err.to_string();
-		assert_eq!(
+		assert!(
 			error_msg.contains("SECURE_SSL_REDIRECT must be set in production"),
-			true,
 			"Expected error about missing SECURE_SSL_REDIRECT, got: {error_msg}"
 		);
 	}
@@ -707,9 +706,8 @@ mod tests {
 		// Assert
 		let err = result.unwrap_err();
 		let error_msg = err.to_string();
-		assert_eq!(
+		assert!(
 			error_msg.contains("SECURE_SSL_REDIRECT should be true in production"),
-			true,
 			"Expected error about SECURE_SSL_REDIRECT being false, got: {error_msg}"
 		);
 	}


### PR DESCRIPTION
## Summary

- Add missing `else` branch to `SECURE_SSL_REDIRECT` validation in `SecurityValidator::validate_settings`
- Previously, when `secure_ssl_redirect` key was absent from settings, the validation silently passed in production mode
- Now follows the same pattern used for `ALLOWED_HOSTS` validation, reporting an error when the setting is missing

Fixes #2577

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `SecurityValidator::validate_settings` method validates production security settings. The `ALLOWED_HOSTS` check (lines 182-195) correctly uses an `if let Some` / `else` pattern to catch both invalid values and missing settings. However, the `SECURE_SSL_REDIRECT` check (lines 197-204) only used `if let Some` with a `let`-chain, meaning a missing `secure_ssl_redirect` key would silently skip validation entirely. This is a security gap since production environments should always have SSL redirect explicitly configured.

## How Was This Tested?

- `cargo check -p reinhardt-conf --all-features` passes
- `cargo nextest run -p reinhardt-conf --all-features` passes (417 tests passed)
- Added 3 new test cases:
  - `test_security_validator_missing_ssl_redirect_in_production` - verifies error when setting is absent
  - `test_security_validator_ssl_redirect_false_in_production` - verifies error when set to `false`
  - `test_security_validator_ssl_redirect_true_in_production` - verifies validation passes when set to `true`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Fixes #2577

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `http` - HTTP layer, handlers, middleware

---

**Additional Context:**

The fix mirrors the existing `ALLOWED_HOSTS` validation pattern at lines 182-195 in the same method, converting a `let`-chain `if let` into an `if let` / `else` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)