### PR TITLE
fix(rest): correct module path in versioning macro

### DIFF
--- a/crates/reinhardt-rest/src/versioning/handler.rs
+++ b/crates/reinhardt-rest/src/versioning/handler.rs
@@ -290,7 +290,7 @@ macro_rules! versioned_handler {
     ($versioning:expr, {
         $($version:literal => $handler:expr),* $(,)?
     }) => {{
-        let mut builder = $crate::handler::VersionedHandlerBuilder::new($versioning);
+        let mut builder = $crate::versioning::handler::VersionedHandlerBuilder::new($versioning);
         $(
             builder = builder.with_version_handler($version, $handler);
         )*
@@ -300,7 +300,7 @@ macro_rules! versioned_handler {
     ($versioning:expr, {
         $($version:literal => $handler:expr),* $(,)?
     }, default => $default_handler:expr) => {{
-        let mut builder = $crate::handler::VersionedHandlerBuilder::new($versioning);
+        let mut builder = $crate::versioning::handler::VersionedHandlerBuilder::new($versioning);
         $(
             builder = builder.with_version_handler($version, $handler);
         )*


### PR DESCRIPTION
## Summary

- Fix incorrect module path `$crate::handler` to `$crate::versioning::handler` in `versioned_handler!` macro

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `versioned_handler!` macro referenced `$crate::handler::VersionedHandlerBuilder` which resolves to the wrong module path when the macro is invoked from external crates. The correct path is `$crate::versioning::handler::VersionedHandlerBuilder` since `VersionedHandlerBuilder` is defined in the `versioning::handler` submodule.

Fixes #2592

## How Was This Tested?

- [x] `cargo check -p reinhardt-rest --all-features` passes
- [x] `cargo nextest run -p reinhardt-rest --all-features` passes (717/717 tests)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #2592

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `api` - REST API, serializers, views

---

**Additional Context:**

Both occurrences of `$crate::handler::VersionedHandlerBuilder` (lines 293 and 303) in `crates/reinhardt-rest/src/versioning/handler.rs` were corrected to `$crate::versioning::handler::VersionedHandlerBuilder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)