### PR TITLE
fix(core): reject zero limit in LimitOffsetPagination to prevent infinite next-link loop

### DIFF
--- a/crates/reinhardt-core/src/pagination.rs
+++ b/crates/reinhardt-core/src/pagination.rs
@@ -498,10 +498,16 @@ mod tests {
 
 		let result = paginator.paginate(&items, Some("limit=0"), "http://api.example.com/items");
 		assert!(result.is_err());
-		assert!(matches!(
-			result.unwrap_err(),
-			crate::exception::Error::InvalidLimit(_)
-		));
+		let err = result.unwrap_err();
+		if let crate::exception::Error::InvalidLimit(msg) = &err {
+			assert!(
+				msg.contains("greater than zero"),
+				"expected zero-limit error message, got: {}",
+				msg
+			);
+		} else {
+			panic!("expected InvalidLimit error for zero limit, got: {:?}", err);
+		}
 	}
 
 	#[test]

--- a/crates/reinhardt-core/src/pagination/limit_offset.rs
+++ b/crates/reinhardt-core/src/pagination/limit_offset.rs
@@ -115,9 +115,10 @@ impl LimitOffsetPagination {
 					limit = Self::parse_positive_int(value)?;
 					// Reject zero limit to prevent infinite next-link loop
 					if limit == 0 {
-						return Err(Error::InvalidLimit(
-							"Limit must be greater than zero".to_string(),
-						));
+						return Err(Error::InvalidLimit(format!(
+							"{} must be greater than zero (got {})",
+							self.limit_query_param, limit
+						)));
 					}
 					// Apply max_limit if configured
 					if let Some(max) = self.max_limit


### PR DESCRIPTION
## Summary

- Reject `limit=0` in `LimitOffsetPagination::parse_params()` with `InvalidLimit` error to prevent infinite self-referencing next-link loop
- Add unit tests for zero limit rejection and limit=1 boundary case

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

- When `limit=0` is passed, the paginator returns empty results with a `next` link pointing back to `offset=0&limit=0`, causing clients following pagination links to loop infinitely

Fixes #2627

## How Was This Tested?

- Unit tests added/verified for the fix
- `cargo nextest run -p reinhardt-core --all-features` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply
### Type Label
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)