### PR TITLE
fix(core): use character count instead of byte length in string validators

### DIFF
--- a/crates/reinhardt-core/src/validators/string.rs
+++ b/crates/reinhardt-core/src/validators/string.rs
@@ -824,8 +824,9 @@ mod tests {
 		// "あいう" is 3 characters but 9 bytes in UTF-8
 		let validator = MaxLengthValidator::new(5);
 		assert!(validator.validate("あいう").is_ok()); // 3 chars <= 5: valid
-		assert!(validator.validate("あいうえおか").is_err()); // 6 chars > 5: invalid
-		match validator.validate("あいうえおか") {
+		let result = validator.validate("あいうえおか"); // 6 chars > 5: invalid
+		assert!(result.is_err());
+		match result {
 			Err(ValidationError::TooLong { length, max }) => {
 				assert_eq!(length, 6); // character count, not byte length (18)
 				assert_eq!(max, 5);


### PR DESCRIPTION
## Summary

- Replace `value.len()` (byte length) with `value.chars().count()` (character count) in `MinLengthValidator` and `MaxLengthValidator`
- Add tests verifying correct character-count behavior with multi-byte UTF-8 strings (CJK characters)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

- `MinLengthValidator` and `MaxLengthValidator` use `.len()` which returns byte length, not character count. For multi-byte UTF-8 characters (CJK, emoji), this causes incorrect validation — e.g., "あいう" (3 characters, 9 bytes) would be rejected by `MaxLengthValidator::new(5)` despite being only 3 characters

Fixes #2628

## How Was This Tested?

- Unit tests added/verified for the fix
- `cargo nextest run -p reinhardt-core --all-features` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply
### Type Label
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)