### PR TITLE
fix(i18n): handle msgctxt continuation lines in PO parser

### DIFF
--- a/crates/reinhardt-i18n/src/po_parser.rs
+++ b/crates/reinhardt-i18n/src/po_parser.rs
@@ -512,8 +512,8 @@ msgstr "Ouvrir"
 
 		// Assert
 		assert_eq!(
-			catalog.get_context("menu.file", "Open"),
-			Some(&"Ouvrir".to_string())
+			catalog.get_context("menu.file", "Open").map(String::as_str),
+			Some("Ouvrir")
 		);
 	}
 
@@ -532,8 +532,8 @@ msgstr "Retour"
 
 		// Assert
 		assert_eq!(
-			catalog.get_context("navigation", "Back"),
-			Some(&"Retour".to_string())
+			catalog.get_context("navigation", "Back").map(String::as_str),
+			Some("Retour")
 		);
 	}
 
@@ -558,8 +558,8 @@ msgstr ""
 
 		// Assert
 		assert_eq!(
-			catalog.get_context("ctx.part", "hello world"),
-			Some(&"bonjour monde".to_string())
+			catalog.get_context("ctx.part", "hello world").map(String::as_str),
+			Some("bonjour monde")
 		);
 	}
 }


### PR DESCRIPTION
## Summary

- Add `LastKeyword` enum to track the most recently parsed keyword in the PO parser
- Dispatch continuation lines to `msgctxt` when it was the last keyword parsed
- Previously, multiline `msgctxt` continuation lines were silently lost
- Add 3 unit tests for multiline msgctxt, single-line msgctxt, and all-multiline-keywords scenarios

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The PO parser's continuation line handler only dispatched to `msgid` and `msgid_plural`, but not to `msgctxt`. When a `msgctxt` value spanned multiple lines (using the standard PO multiline format with empty initial string), the continuation lines were silently dropped, resulting in incorrect context lookups.

Fixes #2638

## How Was This Tested?

- `cargo nextest run -p reinhardt-i18n --all-features -E 'test(po_parser) or test(msgctxt)'` — 20 tests pass
- Tests cover multiline msgctxt, single-line msgctxt, and mixed multiline keywords

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply
### Type Label
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)