### PR TITLE
style(pages): fix formatting in renderer.rs

### DIFF
--- a/crates/reinhardt-pages/src/ssr/renderer.rs
+++ b/crates/reinhardt-pages/src/ssr/renderer.rs
@@ -484,10 +484,12 @@ fn minify_html(html: &str) -> String {
 		// Detect opening preserved tag (e.g. <pre>, <textarea class="...">)
 		if preserved_tag.is_none() && c == '<' {
 			for tag in &PRESERVED_TAGS {
-				if remaining.strip_prefix(&format!("<{tag}")).is_some_and(|after| {
-					after.starts_with(|ch: char| ch == '>' || ch.is_ascii_whitespace())
-						|| after.is_empty()
-				}) {
+				if remaining
+					.strip_prefix(&format!("<{tag}"))
+					.is_some_and(|after| {
+						after.starts_with(|ch: char| ch == '>' || ch.is_ascii_whitespace())
+							|| after.is_empty()
+					}) {
 					preserved_tag = Some(tag);
 					break;
 				}
@@ -768,10 +770,7 @@ mod tests {
 	}
 
 	#[rstest]
-	#[case::pre(
-		"<pre>  hello\n  world  </pre>",
-		"<pre>  hello\n  world  </pre>"
-	)]
+	#[case::pre("<pre>  hello\n  world  </pre>", "<pre>  hello\n  world  </pre>")]
 	#[case::textarea(
 		"<textarea>  hello\n  world  </textarea>",
 		"<textarea>  hello\n  world  </textarea>"


### PR DESCRIPTION
## Summary

- Fix formatting violation in `crates/reinhardt-pages/src/ssr/renderer.rs` that causes `cargo make fmt-check` to fail on the `main` branch

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`cargo make fmt-check` fails on `main` due to a formatting inconsistency in `renderer.rs`. This blocks CI for any branch based on current `main`.

Fixes #2742

## How Was This Tested?

- [x] `cargo make fmt-check` passes after the fix
- No logic changes — pure formatting fix

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- #2742

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)