### PR TITLE
fix(infra): add OpenSSL dev packages to Mac runner Docker image

### DIFF
--- a/infra/mac-runner/docker/Dockerfile
+++ b/infra/mac-runner/docker/Dockerfile
@@ -1,5 +1,10 @@
 FROM myoung34/github-runner:2.333.0
 
+# Install build dependencies (pkg-config + libssl-dev required for openssl-sys crate)
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends pkg-config libssl-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
 # Install Rust toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable \
 	&& . "$HOME/.cargo/env" \


### PR DESCRIPTION
## Summary

- Add `pkg-config` and `libssl-dev` to Mac runner Docker image to fix `openssl-sys` crate compilation failure

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The Mac runner Docker image (`infra/mac-runner/docker/Dockerfile`) was missing OpenSSL development packages. This caused CI jobs running on the Mac runner to fail when compiling crates that depend on `openssl-sys`, such as during `cargo make fmt-check` (which builds the project to run format checks).

Error: `Could not find directory of OpenSSL installation`

## How Was This Tested?

- Verified the base image `myoung34/github-runner:2.333.0` is Ubuntu-based and supports `apt-get`
- Confirmed `pkg-config` and `libssl-dev` are the required packages for `openssl-sys` on Ubuntu

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)