### PR TITLE
fix(ci): pass explicit config path to tfprovidercheck

### DIFF
--- a/.github/workflows/terraform-plan-privileged.yml
+++ b/.github/workflows/terraform-plan-privileged.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           go install github.com/suzuki-shunsuke/tfprovidercheck/cmd/tfprovidercheck@v1.0.7
           if [ -f .terraform.lock.hcl ]; then
-            terraform version -json | tfprovidercheck
+            terraform version -json | tfprovidercheck -c "$GITHUB_WORKSPACE/.tfprovidercheck.yml"
           else
             echo "No .terraform.lock.hcl found — skipping provider check"
           fi

--- a/.github/workflows/terraform-validate-fork.yml
+++ b/.github/workflows/terraform-validate-fork.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           go install github.com/suzuki-shunsuke/tfprovidercheck/cmd/tfprovidercheck@v1.0.7
           if [ -f .terraform.lock.hcl ]; then
-            terraform version -json | tfprovidercheck
+            terraform version -json | tfprovidercheck -c "$GITHUB_WORKSPACE/.tfprovidercheck.yml"
           else
             echo "No .terraform.lock.hcl found — skipping provider check"
           fi


### PR DESCRIPTION
## Summary

- Fix `tfprovidercheck` failing with `open .tfprovidercheck.yaml: no such file or directory` in Terraform validate workflows
- Pass explicit `-c $GITHUB_WORKSPACE/.tfprovidercheck.yml` flag so the tool finds the config regardless of `working-directory`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The Terraform validate workflows (`terraform-validate-fork.yml`, `terraform-plan-privileged.yml`) set `working-directory` to each module path (e.g. `infra/github-runners`). `tfprovidercheck` defaults to looking for `.tfprovidercheck.yaml` in the current directory, but the config file lives at the repository root as `.tfprovidercheck.yml`. This causes all `github-runners` module validations to fail.

Refs #2323

## How Was This Tested

- Verified `.tfprovidercheck.yml` exists at repo root with all required providers
- Confirmed `tfprovidercheck` supports `-c` flag for explicit config path
- CI will validate on this PR

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings

## Labels to Apply

- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)