### PR TITLE
fix(ci): add RUSTSEC-2026-0049 to security audit ignore list

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -51,4 +51,5 @@ jobs:
             --ignore RUSTSEC-2024-0370 \
             --ignore RUSTSEC-2025-0010 \
             --ignore RUSTSEC-2025-0134 \
-            --ignore RUSTSEC-2024-0320
+            --ignore RUSTSEC-2024-0320 \
+            --ignore RUSTSEC-2026-0049


### PR DESCRIPTION
## Summary

- Add RUSTSEC-2026-0049 to the security audit ignore list in CI workflow

## Type of Change

- [x] CI/CD changes

## Motivation and Context

RUSTSEC-2026-0049 affects `rustls-webpki` 0.101.7, which is an indirect dependency pulled in via `aws-smithy-http-client`. Since the dependency is transitive, it cannot be directly upgraded. Adding it to the ignore list prevents CI failures until the upstream dependency updates.

## How Was This Tested?

- [x] Verified the YAML syntax is correct
- [x] Confirmed the ignore flag format matches existing entries

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)