### PR TITLE
style(i18n): format method chain in po_parser tests

### DIFF
--- a/crates/reinhardt-i18n/src/po_parser.rs
+++ b/crates/reinhardt-i18n/src/po_parser.rs
@@ -532,7 +532,9 @@ msgstr "Retour"
 
 		// Assert
 		assert_eq!(
-			catalog.get_context("navigation", "Back").map(String::as_str),
+			catalog
+				.get_context("navigation", "Back")
+				.map(String::as_str),
 			Some("Retour")
 		);
 	}
@@ -558,7 +560,9 @@ msgstr ""
 
 		// Assert
 		assert_eq!(
-			catalog.get_context("ctx.part", "hello world").map(String::as_str),
+			catalog
+				.get_context("ctx.part", "hello world")
+				.map(String::as_str),
 			Some("bonjour monde")
 		);
 	}


### PR DESCRIPTION
## Summary

- Format method chain expressions in `po_parser.rs` tests to comply with `rustfmt` style

## Type of Change

- [x] Code quality improvements

## Motivation and Context

- Method chain calls in two test functions exceeded the line length limit and needed formatting adjustment

## How Was This Tested?

- [x] `cargo make fmt-check` passes
- [x] `cargo nextest run -p reinhardt-i18n` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `code-quality` - Code quality improvements

### Scope Label
- [x] `i18n` - Internationalization, localization

🤖 Generated with [Claude Code](https://claude.com/claude-code)