### PR TITLE
chore(infra): add idempotent Terraform import blocks and lifecycle ignore

### DIFF
--- a/infra/mac-runner/terraform/imports.tf
+++ b/infra/mac-runner/terraform/imports.tf
@@ -1,0 +1,27 @@
+# Idempotent import blocks for recovering Terraform state.
+# These blocks are no-ops when resources are already managed by Terraform.
+# They activate only when state is lost and Docker resources still exist.
+#
+# Covered:
+#   - Volumes (stable, predictable names — preserves caches on state recovery)
+#
+# Not covered (safe to recreate):
+#   - docker_network  — import requires Docker network ID (SHA256), not name
+#   - docker_container — ephemeral; IDs change on every recreate
+#   - docker_image     — provider does not support import
+
+import {
+	to = docker_volume.dind_certs_ca
+	id = "mac-runner-dind-certs-ca"
+}
+
+import {
+	to = docker_volume.dind_certs_client
+	id = "mac-runner-dind-certs-client"
+}
+
+import {
+	for_each = { for i in range(var.runner_replicas) : tostring(i) => i }
+	to       = docker_volume.runner_work[each.value]
+	id       = "mac-runner-work-${each.value}"
+}

--- a/infra/mac-runner/terraform/main.tf
+++ b/infra/mac-runner/terraform/main.tf
@@ -78,6 +78,12 @@ resource "docker_container" "dind" {
   }
 
   restart = "always"
+
+  # Docker daemon injects default log_opts (max-file, max-size) into container
+  # state, causing spurious replacement diffs when not set in config.
+  lifecycle {
+    ignore_changes = [log_driver, log_opts, memory_swap]
+  }
 }
 
 # --- Runner Containers ---
@@ -145,5 +151,11 @@ resource "docker_container" "runner" {
     interval = "30s"
     timeout  = "10s"
     retries  = 3
+  }
+
+  # Docker daemon injects default log_opts (max-file, max-size) into container
+  # state, causing spurious replacement diffs when not set in config.
+  lifecycle {
+    ignore_changes = [log_driver, log_opts, memory_swap]
   }
 }


### PR DESCRIPTION
## Summary

- Add `imports.tf` with idempotent import blocks for Docker volumes, enabling automatic state recovery without manual `terraform import` commands
- Add `lifecycle { ignore_changes }` for Docker daemon-injected defaults (`log_driver`, `log_opts`, `memory_swap`) to prevent spurious container replacement diffs

## Type of Change

- [x] CI/CD changes

## Motivation and Context

When Terraform state is lost (e.g., state file deleted, new workstation setup), all existing Docker resources need to be manually re-imported one by one. The import blocks make volume recovery automatic — volumes have stable, predictable names and contain build caches worth preserving.

Additionally, the Docker daemon injects default `log_opts` (`max-file=5`, `max-size=20m`) and `memory_swap` values into container state that don't appear in the Terraform config, causing `terraform plan` to show spurious replacement diffs on every run after import.

## How Was This Tested?

- Ran `terraform validate` — configuration valid
- Ran `terraform plan` with existing state — confirmed `No changes` output
- Verified import blocks are no-ops when resources are already in state
- Verified `lifecycle { ignore_changes }` eliminates all spurious diffs

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)