### PR TITLE
fix(infra): upgrade runner base image to Ubuntu Jammy for GLIBC 2.35

### DIFF
--- a/infra/mac-runner/docker/Dockerfile
+++ b/infra/mac-runner/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM myoung34/github-runner:2.333.0
+FROM myoung34/github-runner:2.333.0-ubuntu-jammy
 
 # Install build dependencies (pkg-config + libssl-dev required for openssl-sys crate)
 RUN apt-get update \
@@ -17,7 +17,7 @@ RUN curl -LsSf https://get.nexte.st/latest/linux-arm | tar zxf - -C /usr/local/b
 RUN . "$HOME/.cargo/env" \
 	&& cargo install cargo-make --locked
 
-# Install mold linker (not available in Ubuntu Focal repos, use GitHub release)
+# Install mold linker (repo version is too old, use GitHub release)
 RUN MOLD_VERSION=2.35.1 \
 	&& curl -LsSf "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-aarch64-linux.tar.gz" \
 	| tar xzf - --strip-components=1 -C /usr/local


### PR DESCRIPTION
## Summary

- Upgrade self-hosted runner base image from `myoung34/github-runner:2.333.0` (Ubuntu Focal, GLIBC 2.31) to `2.333.0-ubuntu-jammy` (Ubuntu Jammy, GLIBC 2.35)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

`release-plz` requires GLIBC 2.32+ but the previous base image (Ubuntu 20.04 Focal) only provides GLIBC 2.31. This causes the Release Dry-Run workflow to fail with:

```
release-plz: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by release-plz)
release-plz: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by release-plz)
release-plz: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by release-plz)
```

Related to: #2766

## How Was This Tested?

- [ ] Verify `release-plz` runs successfully on self-hosted runners after image rebuild
- [ ] Verify all CI workflows pass on self-hosted runners
- [ ] `terraform apply` will rebuild the Docker image (triggered by Dockerfile hash change)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)