### PR TITLE
fix(reinhardt-web): re-export WebSocket routing types from facade

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1109,6 +1109,11 @@ pub use reinhardt_websockets::room::RoomManager;
 pub use reinhardt_websockets::{
 	ConsumerContext, Message, WebSocketConsumer, WebSocketError, WebSocketResult,
 };
+#[cfg(all(feature = "websockets", not(target_arch = "wasm32")))]
+pub use reinhardt_websockets::{
+	RouteError, RouteResult, WebSocketRoute, WebSocketRouter, clear_websocket_router,
+	get_websocket_router, register_websocket_router, reverse_websocket_url,
+};
 
 /// SQL query builder module.
 ///


### PR DESCRIPTION
## Summary

- Add missing WebSocket routing type re-exports (`RouteError`, `RouteResult`, `WebSocketRoute`, `WebSocketRouter`) and helper functions (`clear_websocket_router`, `get_websocket_router`, `register_websocket_router`, `reverse_websocket_url`) to the `reinhardt-web` facade crate

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `reinhardt-web` facade crate re-exports WebSocket consumer types from `reinhardt-websockets` but omits the routing-related types and functions. Users who depend on `reinhardt-web` cannot access WebSocket routing without directly depending on `reinhardt-websockets`.

Fixes #2790

## How Was This Tested?

- [x] `cargo check --workspace --all --all-features` passes
- [x] `cargo make clippy-check` passes
- [x] `cargo make fmt-check` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `websockets` - WebSocket connections, handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)