### PR TITLE
refactor(reinhardt-di): extract fork_inner helper for InjectionContext fork methods

### DIFF
--- a/crates/reinhardt-di/src/context.rs
+++ b/crates/reinhardt-di/src/context.rs
@@ -395,6 +395,26 @@ impl InjectionContext {
 		&self.singleton_scope
 	}
 
+	/// Internal helper for creating forked contexts.
+	///
+	/// Centralizes the construction logic shared between `fork()` and
+	/// `fork_for_request()` to prevent field-drift when new fields are added.
+	fn fork_inner(
+		&self,
+		#[cfg(feature = "params")] request: Option<Arc<HttpRequest>>,
+		#[cfg(feature = "params")] param_context: Option<Arc<ParamContext>>,
+	) -> InjectionContext {
+		InjectionContext {
+			request_scope: RequestScope::new(),
+			singleton_scope: self.singleton_scope.clone(),
+			override_registry: self.override_registry.clone(),
+			#[cfg(feature = "params")]
+			request,
+			#[cfg(feature = "params")]
+			param_context,
+		}
+	}
+
 	/// Creates a per-request fork of this context with an HTTP request.
 	///
 	/// The forked context shares the same singleton scope but has a fresh
@@ -407,15 +427,12 @@ impl InjectionContext {
 			request.path_params.clone(),
 		)));
 
-		InjectionContext {
-			request_scope: RequestScope::new(),
-			singleton_scope: self.singleton_scope.clone(),
-			override_registry: self.override_registry.clone(),
+		self.fork_inner(
 			#[cfg(feature = "params")]
-			request: Some(Arc::new(request)),
+			Some(Arc::new(request)),
 			#[cfg(feature = "params")]
 			param_context,
-		}
+		)
 	}
 
 	/// Creates a per-request fork of this context without an HTTP request.
@@ -427,15 +444,12 @@ impl InjectionContext {
 	/// This is intended for non-HTTP protocols (gRPC, GraphQL) where
 	/// request-scoped isolation is needed but HTTP request data is not available.
 	pub fn fork(&self) -> InjectionContext {
-		InjectionContext {
-			request_scope: RequestScope::new(),
-			singleton_scope: self.singleton_scope.clone(),
-			override_registry: self.override_registry.clone(),
+		self.fork_inner(
 			#[cfg(feature = "params")]
-			request: None,
+			None,
 			#[cfg(feature = "params")]
-			param_context: None,
-		}
+			None,
+		)
 	}
 
 	/// Returns a reference to the override registry.


### PR DESCRIPTION
## Summary

- Extract private `fork_inner` helper method in `InjectionContext` to centralize construction logic shared between `fork()` and `fork_for_request()`
- Both fork methods now delegate to `fork_inner`, preventing field-drift when new fields are added to `InjectionContext`

## Type of Change

- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Motivation and Context

The `InjectionContext` struct has two fork methods (`fork()` and `fork_for_request()`) that duplicated the same constructor logic. When new fields are added to `InjectionContext`, both methods must be updated independently, risking field-drift where one method is updated but the other is missed.

By extracting a shared `fork_inner` helper, any new field added to `InjectionContext` only needs to be handled in one place for fork operations.

Fixes #2784

## How Was This Tested?

- [x] `cargo check --workspace --all --all-features` passes
- [x] `cargo nextest run -p reinhardt-di --all-features` passes (245 tests)
- [x] `cargo make clippy-check` passes
- [x] `cargo make fmt-check` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)