### PR TITLE
fix(reinhardt-pages): reset email, staff, superuser, and permissions on login

### DIFF
--- a/crates/reinhardt-pages/src/auth.rs
+++ b/crates/reinhardt-pages/src/auth.rs
@@ -195,10 +195,17 @@ impl AuthState {
 	}
 
 	/// Sets the state to authenticated with the given user data.
+	///
+	/// Resets `email`, `is_staff`, `is_superuser`, and `permissions` to defaults
+	/// to prevent stale data from a previous session.
 	pub fn login(&self, user_id: i64, username: impl Into<String>) {
 		self.is_authenticated.set(true);
 		self.user_id.set(Some(user_id));
 		self.username.set(Some(username.into()));
+		self.email.set(None);
+		self.is_staff.set(false);
+		self.is_superuser.set(false);
+		self.permissions.set(HashSet::new());
 	}
 
 	/// Sets the state to authenticated with full user data.


### PR DESCRIPTION
## Summary

- Reset `email`, `is_staff`, `is_superuser`, and `permissions` fields when `login()` is called to prevent stale data from a previous session

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `login()` function in `AuthState` only sets `is_authenticated`, `user_id`, and `username`, but does not reset `email`, `is_staff`, `is_superuser`, or `permissions`. If a previous user's session had these fields set (e.g., via `login_full()` or `update()`), they persist for the new user, potentially granting incorrect privileges.

Fixes #2696

## How Was This Tested?

- `cargo check -p reinhardt-pages --all-features` passes
- `cargo nextest run -p reinhardt-pages --all-features` passes (1104 tests)
- Existing `test_auth_state_login` and `test_permissions_cleared_on_logout` tests cover the affected code paths

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `auth` - Authentication, authorization, sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)