### PR TITLE
fix(reinhardt-websockets): resolve ABBA deadlock in group_send by reordering lock acquisition

### DIFF
--- a/crates/reinhardt-websockets/src/channels.rs
+++ b/crates/reinhardt-websockets/src/channels.rs
@@ -240,13 +240,17 @@ impl ChannelLayer for InMemoryChannelLayer {
 	}
 
 	async fn group_send(&self, group: &str, message: ChannelMessage) -> ChannelResult<()> {
-		let groups = self.groups.read().await;
+		// Collect channel IDs while holding the groups lock, then release it
+		// before calling self.send() to avoid ABBA deadlock with clear()
+		let channel_ids = {
+			let groups = self.groups.read().await;
+			groups
+				.get(group)
+				.ok_or_else(|| ChannelError::GroupNotFound(group.to_string()))?
+				.clone()
+		};
 
-		let channels = groups
-			.get(group)
-			.ok_or_else(|| ChannelError::GroupNotFound(group.to_string()))?;
-
-		for channel in channels {
+		for channel in &channel_ids {
 			self.send(channel, message.clone()).await?;
 		}
 


### PR DESCRIPTION
## Summary

- Resolve ABBA deadlock in `InMemoryChannelLayer::group_send` by collecting channel IDs before releasing the groups lock

Fixes #2729

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`group_send` held the `groups` read lock while calling `self.send()`, which internally acquires the `channels` write lock via `get_or_create_channel()`. Meanwhile, `clear()` acquires locks in the order `channels` -> `groups`. This inconsistent lock ordering creates an ABBA deadlock pattern.

The fix collects the channel IDs into a `Vec` while holding the groups lock, drops the lock, and then iterates over the collected IDs to send messages.

## How Was This Tested?

- `cargo check -p reinhardt-websockets --all-features` passes
- `cargo test -p reinhardt-websockets --all-features --lib` passes (294 tests)
- `cargo fmt -p reinhardt-websockets -- --check` passes
- `cargo clippy -p reinhardt-websockets --all-features --no-deps -- -D warnings` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `websockets` - WebSocket connections, handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)