### PR TITLE
fix(core): prevent panics from user-controlled pagination and string inputs

### DIFF
--- a/crates/reinhardt-core/src/exception/param_error.rs
+++ b/crates/reinhardt-core/src/exception/param_error.rs
@@ -83,7 +83,7 @@ impl ParamErrorContext {
 	/// Set the raw value (truncated if too long)
 	pub fn with_raw_value(mut self, value: impl Into<String>) -> Self {
 		let value = value.into();
-		// Truncate to ~500 chars max to avoid log spam.
+		// Truncate to ~500 bytes max to avoid log spam.
 		// Use char_indices to find a safe truncation point on a char boundary,
 		// preventing panics on multi-byte UTF-8 strings (e.g., Japanese, emoji).
 		if value.len() > 500 {

--- a/crates/reinhardt-core/src/pagination/cursor.rs
+++ b/crates/reinhardt-core/src/pagination/cursor.rs
@@ -348,15 +348,13 @@ mod tests {
 
 	#[rstest]
 	fn paginate_returns_empty_results_for_out_of_range_cursor() {
-		// Arrange
+		// Arrange - use the same encoder instance for both cursor generation and paginator
 		let encoder =
 			encoder::Base64CursorEncoder::with_secret_key(b"test-secret-key-for-unit-tests!!");
-		let paginator = CursorPagination::new().with_encoder(
-			encoder::Base64CursorEncoder::with_secret_key(b"test-secret-key-for-unit-tests!!"),
-		);
 		let items: Vec<i32> = (1..=10).collect();
 		// Encode a cursor pointing beyond data length
 		let out_of_range_cursor = encoder.encode(100).unwrap();
+		let paginator = CursorPagination::new().with_encoder(encoder);
 
 		// Act
 		let result = paginator.paginate(
@@ -373,14 +371,12 @@ mod tests {
 
 	#[rstest]
 	fn paginate_returns_empty_results_for_cursor_on_empty_dataset() {
-		// Arrange
+		// Arrange - use the same encoder instance for both cursor generation and paginator
 		let encoder =
 			encoder::Base64CursorEncoder::with_secret_key(b"test-secret-key-for-unit-tests!!");
-		let paginator = CursorPagination::new().with_encoder(
-			encoder::Base64CursorEncoder::with_secret_key(b"test-secret-key-for-unit-tests!!"),
-		);
 		let items: Vec<i32> = vec![];
 		let cursor = encoder.encode(0).unwrap();
+		let paginator = CursorPagination::new().with_encoder(encoder);
 
 		// Act
 		let result = paginator.paginate(&items, Some(&cursor), "http://example.com/items");

--- a/crates/reinhardt-core/src/pagination/cursor/relay.rs
+++ b/crates/reinhardt-core/src/pagination/cursor/relay.rs
@@ -465,18 +465,14 @@ mod tests {
 
 	#[rstest]
 	fn relay_pagination_does_not_panic_on_out_of_range_after_cursor() {
-		// Arrange
+		// Arrange - use the same encoder instance for both cursor generation and paginator
 		let encoder = crate::pagination::cursor::Base64CursorEncoder::with_secret_key(
 			b"test-secret-key-for-unit-tests!!",
-		);
-		let paginator = RelayPagination::new().with_encoder(
-			crate::pagination::cursor::Base64CursorEncoder::with_secret_key(
-				b"test-secret-key-for-unit-tests!!",
-			),
 		);
 		let items: Vec<i32> = (1..=10).collect();
 		// Encode a cursor pointing beyond data length
 		let out_of_range_cursor = encoder.encode(100).unwrap();
+		let paginator = RelayPagination::new().with_encoder(encoder);
 
 		// Act
 		let result = paginator.paginate(&items, Some(5), Some(&out_of_range_cursor), None, None);
@@ -490,18 +486,14 @@ mod tests {
 
 	#[rstest]
 	fn relay_pagination_does_not_panic_on_out_of_range_before_cursor() {
-		// Arrange
+		// Arrange - use the same encoder instance for both cursor generation and paginator
 		let encoder = crate::pagination::cursor::Base64CursorEncoder::with_secret_key(
 			b"test-secret-key-for-unit-tests!!",
-		);
-		let paginator = RelayPagination::new().with_encoder(
-			crate::pagination::cursor::Base64CursorEncoder::with_secret_key(
-				b"test-secret-key-for-unit-tests!!",
-			),
 		);
 		let items: Vec<i32> = (1..=10).collect();
 		// Encode a cursor pointing beyond data length
 		let out_of_range_cursor = encoder.encode(100).unwrap();
+		let paginator = RelayPagination::new().with_encoder(encoder);
 
 		// Act
 		let result = paginator.paginate(&items, None, None, Some(5), Some(&out_of_range_cursor));
@@ -512,17 +504,13 @@ mod tests {
 
 	#[rstest]
 	fn relay_pagination_empty_dataset_with_after_cursor() {
-		// Arrange
+		// Arrange - use the same encoder instance for both cursor generation and paginator
 		let encoder = crate::pagination::cursor::Base64CursorEncoder::with_secret_key(
 			b"test-secret-key-for-unit-tests!!",
 		);
-		let paginator = RelayPagination::new().with_encoder(
-			crate::pagination::cursor::Base64CursorEncoder::with_secret_key(
-				b"test-secret-key-for-unit-tests!!",
-			),
-		);
 		let items: Vec<i32> = vec![];
 		let cursor = encoder.encode(0).unwrap();
+		let paginator = RelayPagination::new().with_encoder(encoder);
 
 		// Act
 		let result = paginator.paginate(&items, Some(10), Some(&cursor), None, None);

--- a/crates/reinhardt-core/src/pagination/page_number.rs
+++ b/crates/reinhardt-core/src/pagination/page_number.rs
@@ -84,6 +84,9 @@ impl PageNumberPagination {
 	}
 	/// Sets the default page size for pagination
 	///
+	/// A page size of 0 is treated as 1 to prevent division-by-zero errors
+	/// in pagination calculations.
+	///
 	/// # Examples
 	///
 	/// ```
@@ -91,9 +94,15 @@ impl PageNumberPagination {
 	///
 	/// let paginator = PageNumberPagination::new().page_size(20);
 	/// assert_eq!(paginator.page_size, 20);
+	///
+	/// // page_size=0 is normalized to 1
+	/// let paginator = PageNumberPagination::new().page_size(0);
+	/// assert_eq!(paginator.page_size, 1);
 	/// ```
 	pub fn page_size(mut self, size: usize) -> Self {
-		self.page_size = size;
+		// Enforce non-zero page size at the configuration boundary
+		// to prevent division-by-zero in both get_page() and paginate()
+		self.page_size = if size == 0 { 1 } else { size };
 		self
 	}
 	/// Sets the maximum allowed page size
@@ -211,12 +220,8 @@ impl PageNumberPagination {
 	pub fn get_page<T: Clone>(&self, items: &[T], page_param: Option<&str>) -> Page<T> {
 		let total_count = items.len();
 
-		// Guard against division by zero: treat page_size=0 as page_size=1
-		let effective_page_size = if self.page_size == 0 {
-			1
-		} else {
-			self.page_size
-		};
+		// page_size is guaranteed non-zero by the page_size() setter
+		let effective_page_size = self.page_size;
 
 		// Calculate total pages (same logic as paginate)
 		let total_pages = if total_count <= effective_page_size {
@@ -358,13 +363,7 @@ impl Paginator for PageNumberPagination {
 		page_param: Option<&str>,
 		base_url: &str,
 	) -> Result<PaginatedResponse<T>> {
-		// Guard against division by zero from user-controlled page_size
-		if self.page_size == 0 {
-			return Err(Error::InvalidPage(
-				"Page size must be greater than 0".to_string(),
-			));
-		}
-
+		// page_size is guaranteed non-zero by the page_size() setter
 		let total_count = items.len();
 
 		// Handle empty list with allow_empty_first_page=false
@@ -492,33 +491,40 @@ mod tests {
 	use super::*;
 
 	#[rstest]
-	fn paginate_returns_error_when_page_size_is_zero() {
-		// Arrange
+	fn page_size_setter_normalizes_zero_to_one() {
+		// Arrange & Act
 		let paginator = PageNumberPagination::new().page_size(0);
-		let items: Vec<i32> = (1..=20).collect();
+
+		// Assert - page_size=0 is normalized to 1 at the setter boundary
+		assert_eq!(paginator.page_size, 1);
+	}
+
+	#[rstest]
+	fn paginate_works_when_page_size_set_to_zero() {
+		// Arrange - page_size(0) is normalized to 1 by the setter
+		let paginator = PageNumberPagination::new().page_size(0);
+		let items: Vec<i32> = (1..=5).collect();
 
 		// Act
 		let result = paginator.paginate(&items, None, "http://example.com/items");
 
-		// Assert
-		assert!(result.is_err());
-		if let Err(Error::InvalidPage(msg)) = result {
-			assert_eq!(msg, "Page size must be greater than 0");
-		} else {
-			panic!("Expected InvalidPage error for page_size=0");
-		}
+		// Assert - should succeed with effective page_size=1
+		assert!(result.is_ok());
+		let response = result.unwrap();
+		assert_eq!(response.results, vec![1]);
+		assert_eq!(response.count, 5);
 	}
 
 	#[rstest]
-	fn get_page_does_not_panic_when_page_size_is_zero() {
-		// Arrange
+	fn get_page_works_when_page_size_set_to_zero() {
+		// Arrange - page_size(0) is normalized to 1 by the setter
 		let paginator = PageNumberPagination::new().page_size(0);
 		let items: Vec<i32> = (1..=5).collect();
 
 		// Act
 		let page = paginator.get_page(&items, Some("1"));
 
-		// Assert - should not panic; falls back to page_size=1
+		// Assert - consistent behavior: effective page_size=1
 		assert_eq!(page.page_size, 1);
 		assert_eq!(page.count, 5);
 	}


### PR DESCRIPTION
## Summary

This PR prevents panic/crash vulnerabilities in reinhardt-core:

- Fix division by zero in `PageNumberPagination` with page_size=0 (#2563)
- Fix UTF-8 panic in `ParamErrorContext::with_raw_value` on multi-byte strings (#2564)
- Fix out-of-range cursor panic in `CursorPagination`/`RelayPagination` (#2621)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

User-controlled inputs can cause server panics: zero page size triggers division by zero, multi-byte UTF-8 strings cause byte-index panics, and out-of-range cursor values cause slice panics. All three are denial-of-service vectors.

Fixes #2563, fixes #2564, fixes #2621

## How Was This Tested?

- 13 new tests covering edge cases (zero page size, Japanese/emoji strings, out-of-range cursors, empty datasets)
- All 1657 reinhardt-core tests pass
- `cargo make fmt-check` and `cargo make clippy-check` pass

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Priority Label
- [x] `high` - Important fix or feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)