### PR TITLE
fix(pages,forms): handle case-insensitive HTML tags and formset prefix collisions

### DIFF
--- a/crates/reinhardt-forms/src/formset.rs
+++ b/crates/reinhardt-forms/src/formset.rs
@@ -26,6 +26,9 @@ impl FormSet {
 	/// assert!(!formset.can_delete());
 	/// ```
 	pub fn new(prefix: String) -> Self {
+		// Normalize: strip trailing delimiter so that `format!("{}-", prefix)`
+		// in `process_data` never produces a double-dash (e.g. "form--")
+		let prefix = prefix.strip_suffix('-').map_or(prefix.clone(), |s| s.to_owned());
 		Self {
 			forms: vec![],
 			prefix,

--- a/crates/reinhardt-pages/src/ssr/renderer.rs
+++ b/crates/reinhardt-pages/src/ssr/renderer.rs
@@ -483,14 +483,15 @@ fn minify_html(html: &str) -> String {
 
 		// Detect opening preserved tag (case-insensitive, e.g. <pre>, <PRE>, <Pre class="...">)
 		if preserved_tag.is_none() && c == '<' {
-			let remaining_lower = remaining.to_ascii_lowercase();
 			for tag in &PRESERVED_TAGS {
-				if remaining_lower
-					.strip_prefix(&format!("<{tag}"))
-					.is_some_and(|after| {
-						after.starts_with(|ch: char| ch == '>' || ch.is_ascii_whitespace())
-							|| after.is_empty()
-					}) {
+				// Bounded, allocation-free case-insensitive comparison:
+				// only inspect `<` + tag length + 1 char instead of lowercasing all remaining input
+				let open_len = 1 + tag.len(); // "<" + tag name
+				if remaining.len() >= open_len
+					&& remaining[1..open_len].eq_ignore_ascii_case(tag)
+					&& remaining[open_len..]
+						.starts_with(|ch: char| ch == '>' || ch.is_ascii_whitespace())
+				{
 					preserved_tag = Some(tag);
 					break;
 				}


### PR DESCRIPTION
## Summary

This PR fixes frontend HTML/form processing issues:

- `minify_html` now handles case-insensitive PRE/TEXTAREA/SCRIPT/STYLE tags (#2688)
- `FormSet::process_data` uses delimiter-aware prefix matching to prevent data collisions (#2691)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

HTML tags are case-insensitive per spec, but `minify_html` only matched lowercase tags. FormSet prefix matching used `starts_with` which caused "item" to match "item_extra" form data.

Fixes #2688, fixes #2691

## How Was This Tested?

- 6 new tests for case-insensitive tag handling
- 2 new tests for prefix collision prevention
- All 24 relevant tests pass
- `cargo make fmt-check` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `forms` - Form handling, validation, rendering

### Priority Label
- [x] `medium` - Normal priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)