### PR TITLE
fix!(auth): add JwtError enum and reject expired tokens by default

### DIFF
--- a/crates/reinhardt-auth/src/jwt.rs
+++ b/crates/reinhardt-auth/src/jwt.rs
@@ -4,7 +4,59 @@ use chrono::{Duration, Utc};
 use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use reinhardt_http::Request;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use uuid::Uuid;
+
+/// JWT-specific errors with distinct variants for each failure mode.
+///
+/// This enum allows callers to programmatically distinguish between
+/// token expiration, signature failures, and other token issues.
+///
+/// # Examples
+///
+/// ```
+/// use reinhardt_auth::jwt::{JwtAuth, JwtError};
+///
+/// let jwt_auth = JwtAuth::new(b"secret");
+/// let result = jwt_auth.verify_token("invalid.token.here");
+///
+/// match result {
+///     Ok(claims) => println!("Valid: {}", claims.sub),
+///     Err(JwtError::TokenExpired) => println!("Token has expired"),
+///     Err(JwtError::InvalidSignature(_)) => println!("Signature mismatch"),
+///     Err(e) => println!("Other error: {}", e),
+/// }
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum JwtError {
+	/// The token has expired.
+	#[error("Token expired")]
+	TokenExpired,
+	/// The token signature is invalid (wrong secret or tampered).
+	#[error("Invalid signature: {0}")]
+	InvalidSignature(String),
+	/// The token is malformed or cannot be decoded.
+	#[error("Invalid token: {0}")]
+	InvalidToken(String),
+	/// An error occurred during token encoding.
+	#[error("Encoding error: {0}")]
+	EncodingError(String),
+}
+
+impl From<jsonwebtoken::errors::Error> for JwtError {
+	fn from(err: jsonwebtoken::errors::Error) -> Self {
+		match err.kind() {
+			jsonwebtoken::errors::ErrorKind::ExpiredSignature => JwtError::TokenExpired,
+			jsonwebtoken::errors::ErrorKind::InvalidSignature
+			| jsonwebtoken::errors::ErrorKind::InvalidRsaKey(_)
+			| jsonwebtoken::errors::ErrorKind::InvalidEcdsaKey => {
+				JwtError::InvalidSignature(err.to_string())
+			}
+			_ => JwtError::InvalidToken(err.to_string()),
+		}
+	}
+}
 
 /// JWT Claims
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -74,6 +126,7 @@ pub struct JwtAuth {
 	encoding_key: EncodingKey,
 	decoding_key: DecodingKey,
 	validation: Validation,
+	validation_allow_expired: Validation,
 }
 
 impl JwtAuth {
@@ -88,10 +141,13 @@ impl JwtAuth {
 	/// let jwt_auth = JwtAuth::new(secret);
 	/// ```
 	pub fn new(secret: &[u8]) -> Self {
+		let mut validation_allow_expired = Validation::default();
+		validation_allow_expired.validate_exp = false;
 		Self {
 			encoding_key: EncodingKey::from_secret(secret),
 			decoding_key: DecodingKey::from_secret(secret),
 			validation: Validation::default(),
+			validation_allow_expired,
 		}
 	}
 	/// Encodes JWT claims into a token string.
@@ -112,9 +168,9 @@ impl JwtAuth {
 	/// let token = jwt_auth.encode(&claims).unwrap();
 	/// assert!(!token.is_empty());
 	/// ```
-	pub fn encode(&self, claims: &Claims) -> reinhardt_core::exception::Result<String> {
+	pub fn encode(&self, claims: &Claims) -> Result<String, JwtError> {
 		encode(&Header::default(), claims, &self.encoding_key)
-			.map_err(|e| reinhardt_core::exception::Error::Authentication(e.to_string()))
+			.map_err(|e| JwtError::EncodingError(e.to_string()))
 	}
 	/// Decodes a JWT token string into claims.
 	///
@@ -135,10 +191,10 @@ impl JwtAuth {
 	/// let decoded = jwt_auth.decode(&token).unwrap();
 	/// assert_eq!(decoded.sub, "user123");
 	/// ```
-	pub fn decode(&self, token: &str) -> reinhardt_core::exception::Result<Claims> {
+	pub fn decode(&self, token: &str) -> Result<Claims, JwtError> {
 		decode::<Claims>(token, &self.decoding_key, &self.validation)
 			.map(|data| data.claims)
-			.map_err(|e| reinhardt_core::exception::Error::Authentication(e.to_string()))
+			.map_err(JwtError::from)
 	}
 	/// Generates a JWT token for the given user with 24-hour expiration.
 	///
@@ -156,15 +212,44 @@ impl JwtAuth {
 	/// assert!(!token.is_empty());
 	/// assert!(token.contains('.'));
 	/// ```
-	pub fn generate_token(
-		&self,
-		user_id: String,
-		username: String,
-	) -> reinhardt_core::exception::Result<String> {
+	pub fn generate_token(&self, user_id: String, username: String) -> Result<String, JwtError> {
 		let claims = Claims::new(user_id, username, Duration::hours(24));
 		self.encode(&claims)
 	}
 	/// Verifies a JWT token and returns the claims if valid and not expired.
+	///
+	/// Returns [`JwtError::TokenExpired`] if the token has expired.
+	/// This method applies a strict zero-leeway expiration check.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use reinhardt_auth::jwt::{JwtAuth, JwtError};
+	///
+	/// let jwt_auth = JwtAuth::new(b"secret");
+	/// let token = jwt_auth.generate_token(
+	///     "user123".to_string(),
+	///     "john_doe".to_string()
+	/// ).unwrap();
+	///
+	/// let claims = jwt_auth.verify_token(&token).unwrap();
+	/// assert_eq!(claims.sub, "user123");
+	/// assert_eq!(claims.username, "john_doe");
+	/// ```
+	pub fn verify_token(&self, token: &str) -> Result<Claims, JwtError> {
+		let claims = self.decode(token)?;
+
+		if claims.is_expired() {
+			return Err(JwtError::TokenExpired);
+		}
+
+		Ok(claims)
+	}
+	/// Verifies a JWT token signature without checking expiration.
+	///
+	/// Useful for token refresh flows where the caller needs to read
+	/// claims from an expired token to issue a new one.
+	/// The token's signature and structure are still validated.
 	///
 	/// # Examples
 	///
@@ -177,20 +262,14 @@ impl JwtAuth {
 	///     "john_doe".to_string()
 	/// ).unwrap();
 	///
-	/// let claims = jwt_auth.verify_token(&token).unwrap();
+	/// // Even after token expires, claims can be read for refresh
+	/// let claims = jwt_auth.verify_token_allow_expired(&token).unwrap();
 	/// assert_eq!(claims.sub, "user123");
-	/// assert_eq!(claims.username, "john_doe");
 	/// ```
-	pub fn verify_token(&self, token: &str) -> reinhardt_core::exception::Result<Claims> {
-		let claims = self.decode(token)?;
-
-		if claims.is_expired() {
-			return Err(reinhardt_core::exception::Error::Authentication(
-				"Token expired".to_string(),
-			));
-		}
-
-		Ok(claims)
+	pub fn verify_token_allow_expired(&self, token: &str) -> Result<Claims, JwtError> {
+		decode::<Claims>(token, &self.decoding_key, &self.validation_allow_expired)
+			.map(|data| data.claims)
+			.map_err(JwtError::from)
 	}
 }
 
@@ -230,8 +309,8 @@ impl RestAuthentication for JwtAuth {
 							is_superuser: false,
 						})));
 					}
-					Err(_) => {
-						return Err(AuthenticationError::InvalidToken);
+					Err(err) => {
+						return Err(AuthenticationError::from(err));
 					}
 				}
 			}
@@ -500,5 +579,185 @@ mod tests {
 		// Verify the user was actually authenticated successfully
 		assert_eq!(user.username(), "alice");
 		assert_eq!(user.id(), "550e8400-e29b-41d4-a716-446655440000");
+	}
+
+	// === JwtError variant tests ===
+
+	#[rstest]
+	fn test_verify_expired_token_returns_token_expired_error() {
+		// Arrange
+		let jwt_auth = JwtAuth::new(b"test-secret-key-256bit!");
+		let claims = Claims {
+			sub: "user123".to_string(),
+			exp: Utc::now().timestamp() - 3600, // expired 1 hour ago
+			iat: Utc::now().timestamp() - 7200,
+			username: "alice".to_string(),
+		};
+		// encode() does not validate expiration, so this succeeds
+		let token = jwt_auth.encode(&claims).unwrap();
+
+		// Act
+		let result = jwt_auth.verify_token(&token);
+
+		// Assert
+		assert_eq!(result.unwrap_err(), JwtError::TokenExpired);
+	}
+
+	#[rstest]
+	fn test_verify_tampered_token_returns_invalid_token() {
+		// Arrange
+		let jwt_auth = JwtAuth::new(b"test-secret-key-256bit!");
+		let token = jwt_auth
+			.generate_token("user123".to_string(), "alice".to_string())
+			.unwrap();
+		let tampered = format!("{}tampered", token);
+
+		// Act
+		let result = jwt_auth.verify_token(&tampered);
+
+		// Assert
+		let err = result.unwrap_err();
+		assert!(
+			matches!(err, JwtError::InvalidToken(_)),
+			"expected InvalidToken, got: {:?}",
+			err
+		);
+	}
+
+	#[rstest]
+	fn test_verify_malformed_token_returns_invalid_token() {
+		// Arrange
+		let jwt_auth = JwtAuth::new(b"test-secret-key-256bit!");
+
+		// Act
+		let result = jwt_auth.verify_token("not-a-jwt");
+
+		// Assert
+		let err = result.unwrap_err();
+		assert!(
+			matches!(err, JwtError::InvalidToken(_)),
+			"expected InvalidToken, got: {:?}",
+			err
+		);
+	}
+
+	// === verify_token_allow_expired tests ===
+
+	#[rstest]
+	fn test_verify_allow_expired_returns_claims_for_expired_token() {
+		// Arrange
+		let jwt_auth = JwtAuth::new(b"test-secret-key-256bit!");
+		let claims = Claims {
+			sub: "user123".to_string(),
+			exp: Utc::now().timestamp() - 3600, // expired 1 hour ago
+			iat: Utc::now().timestamp() - 7200,
+			username: "alice".to_string(),
+		};
+		let token = jwt_auth.encode(&claims).unwrap();
+
+		// Act
+		let result = jwt_auth.verify_token_allow_expired(&token);
+
+		// Assert
+		let decoded = result.unwrap();
+		assert_eq!(decoded.sub, "user123");
+		assert_eq!(decoded.username, "alice");
+		assert!(decoded.is_expired());
+	}
+
+	#[rstest]
+	fn test_verify_allow_expired_rejects_tampered_token() {
+		// Arrange
+		let jwt_auth = JwtAuth::new(b"test-secret-key-256bit!");
+		let token = jwt_auth
+			.generate_token("user123".to_string(), "alice".to_string())
+			.unwrap();
+		let tampered = format!("{}tampered", token);
+
+		// Act
+		let result = jwt_auth.verify_token_allow_expired(&tampered);
+
+		// Assert
+		assert!(result.is_err());
+	}
+
+	#[rstest]
+	fn test_verify_allow_expired_rejects_wrong_secret() {
+		// Arrange
+		let jwt_auth_encode = JwtAuth::new(b"encoding-secret-key!!!");
+		let jwt_auth_decode = JwtAuth::new(b"different-secret-key!!");
+		let token = jwt_auth_encode
+			.generate_token("user123".to_string(), "alice".to_string())
+			.unwrap();
+
+		// Act
+		let result = jwt_auth_decode.verify_token_allow_expired(&token);
+
+		// Assert
+		assert!(result.is_err());
+	}
+
+	#[rstest]
+	fn test_verify_allow_expired_works_for_valid_token() {
+		// Arrange
+		let jwt_auth = JwtAuth::new(b"test-secret-key-256bit!");
+		let token = jwt_auth
+			.generate_token("user123".to_string(), "alice".to_string())
+			.unwrap();
+
+		// Act
+		let result = jwt_auth.verify_token_allow_expired(&token);
+
+		// Assert
+		let claims = result.unwrap();
+		assert_eq!(claims.sub, "user123");
+		assert!(!claims.is_expired());
+	}
+
+	// === AuthenticationError mapping tests ===
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_authenticate_expired_token_returns_token_expired() {
+		// Arrange
+		let jwt_auth = JwtAuth::new(b"test-secret-key-256bit!");
+		let claims = Claims {
+			sub: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+			exp: Utc::now().timestamp() - 3600,
+			iat: Utc::now().timestamp() - 7200,
+			username: "alice".to_string(),
+		};
+		let token = jwt_auth.encode(&claims).unwrap();
+		let request = create_request_with_bearer(&token);
+
+		// Act
+		let result = RestAuthentication::authenticate(&jwt_auth, &request).await;
+
+		// Assert
+		assert!(
+			matches!(&result, Err(AuthenticationError::TokenExpired)),
+			"expected TokenExpired"
+		);
+	}
+
+	#[rstest]
+	fn test_jwt_error_to_auth_error_mapping() {
+		// Arrange & Act & Assert
+		assert_eq!(
+			AuthenticationError::from(JwtError::TokenExpired),
+			AuthenticationError::TokenExpired
+		);
+		assert_eq!(
+			AuthenticationError::from(JwtError::InvalidSignature("bad sig".to_string())),
+			AuthenticationError::InvalidToken
+		);
+		assert_eq!(
+			AuthenticationError::from(JwtError::InvalidToken("bad token".to_string())),
+			AuthenticationError::InvalidToken
+		);
+		assert!(matches!(
+			AuthenticationError::from(JwtError::EncodingError("enc err".to_string())),
+			AuthenticationError::Unknown(_)
+		));
 	}
 }

--- a/crates/reinhardt-auth/src/lib.rs
+++ b/crates/reinhardt-auth/src/lib.rs
@@ -172,7 +172,7 @@ pub use group_management::{
 pub use handlers::{LoginCredentials, LoginHandler, LogoutHandler, SESSION_COOKIE_NAME};
 pub use ip_permission::{CidrRange, IpBlacklistPermission, IpWhitelistPermission};
 #[cfg(feature = "jwt")]
-pub use jwt::{Claims, JwtAuth};
+pub use jwt::{Claims, JwtAuth, JwtError};
 pub use mfa::MFAAuthentication as MfaManager;
 pub use model_permissions::{
 	DjangoModelPermissions, DjangoModelPermissionsOrAnonReadOnly, ModelPermission,
@@ -230,6 +230,8 @@ pub enum AuthenticationError {
 	SessionExpired,
 	/// The provided authentication token is invalid or malformed.
 	InvalidToken,
+	/// The JWT token has expired.
+	TokenExpired,
 	/// The request lacks valid authentication credentials.
 	NotAuthenticated,
 	/// A database error occurred during authentication.
@@ -245,6 +247,7 @@ impl std::fmt::Display for AuthenticationError {
 			AuthenticationError::UserNotFound => write!(f, "User not found"),
 			AuthenticationError::SessionExpired => write!(f, "Session expired"),
 			AuthenticationError::InvalidToken => write!(f, "Invalid token"),
+			AuthenticationError::TokenExpired => write!(f, "Token expired"),
 			AuthenticationError::NotAuthenticated => write!(f, "User is not authenticated"),
 			AuthenticationError::DatabaseError(msg) => write!(f, "Database error: {}", msg),
 			AuthenticationError::Unknown(msg) => write!(f, "Authentication error: {}", msg),
@@ -253,6 +256,19 @@ impl std::fmt::Display for AuthenticationError {
 }
 
 impl std::error::Error for AuthenticationError {}
+
+#[cfg(feature = "jwt")]
+impl From<JwtError> for AuthenticationError {
+	fn from(err: JwtError) -> Self {
+		match err {
+			JwtError::TokenExpired => AuthenticationError::TokenExpired,
+			JwtError::InvalidSignature(_) | JwtError::InvalidToken(_) => {
+				AuthenticationError::InvalidToken
+			}
+			JwtError::EncodingError(msg) => AuthenticationError::Unknown(msg),
+		}
+	}
+}
 
 /// Authentication backend trait
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,7 +658,7 @@ pub use reinhardt_auth::{
 pub use reinhardt_auth::Argon2Hasher;
 
 #[cfg(all(feature = "auth-jwt", not(target_arch = "wasm32")))]
-pub use reinhardt_auth::{Claims, JwtAuth};
+pub use reinhardt_auth::{Claims, JwtAuth, JwtError};
 
 // Re-export auth management
 //


### PR DESCRIPTION
## Summary

- Add dedicated `JwtError` enum with `TokenExpired`, `InvalidSignature`, `InvalidToken`, and `EncodingError` variants
- Change all `JwtAuth` method return types from `reinhardt_core::exception::Result` to `Result<T, JwtError>`
- Add `verify_token_allow_expired()` method for token refresh flows
- Add `TokenExpired` variant to `AuthenticationError` with `From<JwtError>` conversion

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Motivation and Context

`JwtAuth::verify_token()` returned a generic `Error::Authentication(String)` for all failures, making it impossible for callers to programmatically distinguish between expired tokens, invalid signatures, and malformed tokens. This led to security gaps in downstream projects (reinhardt-cloud) where manual `is_expired()` checks were inconsistently applied.

Fixes #2912

## How Was This Tested?

- `cargo nextest run -p reinhardt-auth --all-features` — 57 tests passed
- `cargo test --doc -p reinhardt-auth --all-features` — 382 doc tests passed
- `cargo clippy --workspace --all --all-features -- -D warnings` — clean
- `cargo make fmt-check` — clean

New tests added:
- `test_verify_expired_token_returns_token_expired_error`
- `test_verify_tampered_token_returns_invalid_token`
- `test_verify_malformed_token_returns_invalid_token`
- `test_verify_allow_expired_returns_claims_for_expired_token`
- `test_verify_allow_expired_rejects_tampered_token`
- `test_verify_allow_expired_rejects_wrong_secret`
- `test_verify_allow_expired_works_for_valid_token`
- `test_authenticate_expired_token_returns_token_expired`
- `test_jwt_error_to_auth_error_mapping`

## Breaking Changes

`JwtAuth` method return types changed:

| Method | Before | After |
|--------|--------|-------|
| `encode()` | `reinhardt_core::exception::Result<String>` | `Result<String, JwtError>` |
| `decode()` | `reinhardt_core::exception::Result<Claims>` | `Result<Claims, JwtError>` |
| `generate_token()` | `reinhardt_core::exception::Result<String>` | `Result<String, JwtError>` |
| `verify_token()` | `reinhardt_core::exception::Result<Claims>` | `Result<Claims, JwtError>` |

**Migration Guide:**

1. Replace pattern matches on `reinhardt_core::exception::Error::Authentication(_)` with `JwtError` variants
2. For most callers using `.unwrap()`, `.is_err()`, or `?` — no changes needed
3. For token refresh flows, use the new `verify_token_allow_expired()` method

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Tracking issue in Reinhardt Cloud: https://github.com/kent8192/reinhardt-cloud/issues/123

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix
- [x] `breaking-change` - Breaking change

### Scope Label
- [x] `auth` - Authentication, authorization, sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)