### PR TITLE
fix(admin): add admin_static_routes to reinhardt re-exports

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -66,7 +66,7 @@ pub mod server {
 
 // Re-export core router for admin route mounting
 #[cfg(not(target_arch = "wasm32"))]
-pub use reinhardt_admin::core::{AdminRouter, admin_routes};
+pub use reinhardt_admin::core::{AdminRouter, admin_routes, admin_static_routes};
 
 // Also re-export at top level for convenience
 pub use adapters::*;


### PR DESCRIPTION
## Summary

- Add `admin_static_routes` to `reinhardt::admin` re-exports so users can access it via the standard import convention

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `admin_static_routes` function was defined in `reinhardt_admin::core` but not re-exported from `reinhardt::admin`, making it inaccessible to users following the standard import convention.

Fixes #2930

## How Was This Tested?

- [x] Verified `admin_static_routes` is accessible via `reinhardt::admin::admin_static_routes`
- [x] `cargo check --workspace --all-features` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Prerequisite for #2928 and #2932

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)