### PR TITLE
security(admin): add auth check to get_fields and validate sort_by parameter

### DIFF
--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -4,11 +4,11 @@
 
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, FieldInfo, FieldType};
 use crate::types::FieldsResponse;
-use reinhardt_pages::server_fn::{ServerFnError, server_fn};
+use reinhardt_pages::server_fn::{ServerFnError, ServerFnRequest, server_fn};
 use std::sync::Arc;
 
 #[cfg(not(target_arch = "wasm32"))]
-use super::error::MapServerFnError;
+use super::error::{AdminAuth, MapServerFnError};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::server::type_inference::{get_field_metadata, infer_admin_field_type, infer_required};
 #[cfg(not(target_arch = "wasm32"))]
@@ -43,7 +43,12 @@ pub async fn get_fields(
 	id: Option<String>,
 	#[inject] site: Arc<AdminSite>,
 	#[inject] db: Arc<AdminDatabase>,
+	#[inject] http_request: ServerFnRequest,
 ) -> Result<FieldsResponse, ServerFnError> {
+	// Authentication and authorization check
+	let auth = AdminAuth::from_request(&http_request);
+	auth.require_view_permission(&model_name)?;
+
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
 	let field_names = model_admin
 		.fields()

--- a/crates/reinhardt-admin/src/server/list.rs
+++ b/crates/reinhardt-admin/src/server/list.rs
@@ -167,6 +167,21 @@ pub async fn get_list(
 		.as_deref()
 		.or_else(|| model_admin.ordering().first().copied());
 
+	// Validate sort_by against allowed fields to prevent arbitrary column access
+	if let Some(sort_field) = sort_by {
+		let raw_field = sort_field.strip_prefix('-').unwrap_or(sort_field);
+		let allowed_sort_fields = model_admin.list_display();
+		if !allowed_sort_fields.contains(&raw_field) {
+			return Err(ServerFnError::server(
+				400,
+				format!(
+					"Unknown sort field '{}'. Allowed sort fields: {:?}",
+					raw_field, allowed_sort_fields
+				),
+			));
+		}
+	}
+
 	// Calculate pagination with upper bound enforcement
 	let page = params.page.unwrap_or(1).max(1); // Ensure page is at least 1
 	let page_size = params


### PR DESCRIPTION
## Summary

- Add authentication/authorization check to `get_fields()` server function, which was the only endpoint missing auth
- Add `sort_by` parameter validation against `list_display()` allowed fields, matching the existing filter validation pattern

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Independent verification of agent-detected bugs confirmed two security issues in the admin server module:

1. **#2920**: `get_fields()` was the only server function without authentication. Unauthenticated users could enumerate model field names, types, and even fetch actual record data when an `id` parameter was provided.

2. **#2922**: `sort_by` parameter accepted any column name without validation, while filter fields were strictly validated against `model_admin.list_filter()`. This asymmetry could allow authenticated admin users to infer hidden column values through sort-order analysis.

Fixes #2920
Fixes #2922

Related to: #2926

## How Was This Tested?

- `cargo check --workspace --all --all-features` passed
- `cargo nextest run --package reinhardt-admin --all-features` passed (248 tests)
- `cargo make fmt-check` passed
- `cargo make clippy-check` passed (admin crate clean)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `admin` - Admin interface, admin panels
- [x] `security` - Security vulnerabilities or concerns

### Priority Label
- [x] `medium` - Normal priority

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)