### PR TITLE
fix(admin): encode URL path segments and add form method/action attributes

### DIFF
--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -63,6 +63,7 @@ js-sys = "0.3.83"
 serde-wasm-bindgen = "0.6"
 serde_urlencoded = { workspace = true }  # Needed for URL codec in server functions
 serde_bytes = { workspace = true }
+percent-encoding = "2.3"
 
 [features]
 default = []

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -9,9 +9,15 @@
 //! - `DataTable` - Data table component
 
 use crate::types::{FilterInfo, FilterType, ModelInfo};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use reinhardt_pages::Signal;
 use reinhardt_pages::component::{IntoPage, Page, PageElement};
 use std::collections::HashMap;
+
+/// Encodes a string for safe use in URL path segments
+fn encode_path_segment(s: &str) -> String {
+	utf8_percent_encode(s, NON_ALPHANUMERIC).to_string()
+}
 
 #[cfg(target_arch = "wasm32")]
 use reinhardt_pages::dom::EventType;
@@ -264,8 +270,16 @@ fn action_buttons(model_name: &str, record_id: &str) -> Page {
 	use reinhardt_pages::component::Component;
 	use reinhardt_pages::router::Link;
 
-	let detail_url = format!("/admin/{}/{}/", model_name.to_lowercase(), record_id);
-	let edit_url = format!("/admin/{}/{}/change/", model_name.to_lowercase(), record_id);
+	let detail_url = format!(
+		"/admin/{}/{}/",
+		encode_path_segment(&model_name.to_lowercase()),
+		encode_path_segment(record_id)
+	);
+	let edit_url = format!(
+		"/admin/{}/{}/change/",
+		encode_path_segment(&model_name.to_lowercase()),
+		encode_path_segment(record_id)
+	);
 
 	PageElement::new("div")
 		.attr("class", "btn-group btn-group-sm")
@@ -321,8 +335,15 @@ pub fn detail_view(
 	use reinhardt_pages::component::Component;
 	use reinhardt_pages::router::Link;
 
-	let edit_url = format!("/admin/{}/{}/change/", model_name.to_lowercase(), record_id);
-	let list_url = format!("/admin/{}/", model_name.to_lowercase());
+	let edit_url = format!(
+		"/admin/{}/{}/change/",
+		encode_path_segment(&model_name.to_lowercase()),
+		encode_path_segment(record_id)
+	);
+	let list_url = format!(
+		"/admin/{}/",
+		encode_path_segment(&model_name.to_lowercase())
+	);
 
 	PageElement::new("div")
 		.attr("class", "detail-view")
@@ -405,7 +426,23 @@ pub fn model_form(model_name: &str, fields: &[FormField], record_id: Option<&str
 		format!("Create {}", model_name)
 	};
 
-	let list_url = format!("/admin/{}/", model_name.to_lowercase());
+	let action_url = if let Some(rid) = record_id {
+		format!(
+			"/admin/{}/{}/change/",
+			encode_path_segment(&model_name.to_lowercase()),
+			encode_path_segment(rid)
+		)
+	} else {
+		format!(
+			"/admin/{}/add/",
+			encode_path_segment(&model_name.to_lowercase())
+		)
+	};
+
+	let list_url = format!(
+		"/admin/{}/",
+		encode_path_segment(&model_name.to_lowercase())
+	);
 
 	// Add form fields
 	let form_groups: Vec<Page> = fields.iter().map(form_group).collect();
@@ -420,7 +457,8 @@ pub fn model_form(model_name: &str, fields: &[FormField], record_id: Option<&str
 		.child(
 			PageElement::new("form")
 				.attr("class", "needs-validation")
-				.attr("novalidate", "true")
+				.attr("method", "POST")
+				.attr("action", action_url)
 				.children(form_groups)
 				.child(
 					PageElement::new("div")


### PR DESCRIPTION
## Summary

- Add URL percent-encoding to all path segment interpolations in admin feature components to prevent malformed URLs
- Add `method="POST"` and `action` attributes to admin model form element
- Remove `novalidate` attribute to re-enable browser form validation

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Independent verification of agent-detected bugs confirmed two issues in the admin pages component:

1. **#2923**: `record_id` and `model_name` were interpolated into URL paths via `format!()` without percent-encoding. Special characters could produce malformed URLs. While the router's `[^/]+` regex mitigates path traversal, characters like `?`, `#`, `%` could still break URLs.

2. **#2924**: The admin `<form>` element lacked `method` and `action` attributes, and had `novalidate="true"` with no custom validation. The form was visually present but functionally non-operational — clicking "Save" triggered browser default behavior (page reload) without submitting data to any server endpoint.

Fixes #2923
Fixes #2924

Related to: #2926

## How Was This Tested?

- `cargo check --workspace --all --all-features` passed
- `cargo nextest run --package reinhardt-admin --all-features` passed (248 tests)
- `cargo make fmt-check` passed
- `cargo clippy --package reinhardt-admin --all-features --no-deps -- -D warnings` passed

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `admin` - Admin interface, admin panels

### Priority Label
- [x] `high` - Important fix (form was non-functional)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)