### PR TITLE
fix(admin): return error on filter depth overflow instead of silent None

### DIFF
--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -363,9 +363,11 @@ pub const MAX_FILTER_DEPTH: usize = 100;
 ///
 /// To prevent stack overflow with deeply nested filter conditions, this function
 /// limits recursion depth to `MAX_FILTER_DEPTH` (100 levels). If the depth limit
-/// is exceeded, the function returns `None`.
+/// is exceeded, the function returns an error.
 #[doc(hidden)]
-pub fn build_composite_filter_condition(filter_condition: &FilterCondition) -> Option<Condition> {
+pub fn build_composite_filter_condition(
+	filter_condition: &FilterCondition,
+) -> AdminResult<Option<Condition>> {
 	build_composite_filter_condition_with_depth(filter_condition, 0)
 }
 
@@ -374,46 +376,52 @@ pub fn build_composite_filter_condition(filter_condition: &FilterCondition) -> O
 pub fn build_composite_filter_condition_with_depth(
 	filter_condition: &FilterCondition,
 	depth: usize,
-) -> Option<Condition> {
+) -> AdminResult<Option<Condition>> {
 	// Prevent stack overflow by limiting recursion depth
 	if depth >= MAX_FILTER_DEPTH {
-		return None;
+		return Err(AdminError::ValidationError(format!(
+			"Filter condition exceeded maximum depth of {} levels",
+			MAX_FILTER_DEPTH
+		)));
 	}
 
 	match filter_condition {
 		FilterCondition::Single(filter) => {
-			build_single_filter_expr(filter).map(|expr| Condition::all().add(expr))
+			Ok(build_single_filter_expr(filter).map(|expr| Condition::all().add(expr)))
 		}
 		FilterCondition::And(conditions) => {
 			if conditions.is_empty() {
-				return None;
+				return Ok(None);
 			}
 			let mut and_condition = Condition::all();
 			for cond in conditions {
-				if let Some(sub_cond) = build_composite_filter_condition_with_depth(cond, depth + 1)
+				if let Some(sub_cond) =
+					build_composite_filter_condition_with_depth(cond, depth + 1)?
 				{
 					and_condition = and_condition.add(sub_cond);
 				}
 			}
-			Some(and_condition)
+			Ok(Some(and_condition))
 		}
 		FilterCondition::Or(conditions) => {
 			if conditions.is_empty() {
-				return None;
+				return Ok(None);
 			}
 			let mut or_condition = Condition::any();
 			for cond in conditions {
-				if let Some(sub_cond) = build_composite_filter_condition_with_depth(cond, depth + 1)
+				if let Some(sub_cond) =
+					build_composite_filter_condition_with_depth(cond, depth + 1)?
 				{
 					or_condition = or_condition.add(sub_cond);
 				}
 			}
-			Some(or_condition)
+			Ok(Some(or_condition))
 		}
-		FilterCondition::Not(inner) => {
-			build_composite_filter_condition_with_depth(inner, depth + 1)
-				.map(|inner_cond| inner_cond.not())
-		}
+		FilterCondition::Not(inner) => Ok(build_composite_filter_condition_with_depth(
+			inner,
+			depth + 1,
+		)?
+		.map(|inner_cond| inner_cond.not())),
 	}
 }
 
@@ -579,7 +587,7 @@ impl AdminDatabase {
 
 		// Add composite filter condition (e.g., OR search across fields)
 		if let Some(fc) = filter_condition
-			&& let Some(cond) = build_composite_filter_condition(fc)
+			&& let Some(cond) = build_composite_filter_condition(fc)?
 		{
 			combined = combined.add(cond);
 		}
@@ -661,7 +669,7 @@ impl AdminDatabase {
 
 		// Add composite filter condition
 		if let Some(fc) = filter_condition
-			&& let Some(cond) = build_composite_filter_condition(fc)
+			&& let Some(cond) = build_composite_filter_condition(fc)?
 		{
 			combined = combined.add(cond);
 		}
@@ -1244,6 +1252,8 @@ mod tests {
 
 		let result = build_composite_filter_condition(&condition);
 
+		assert!(result.is_ok());
+		let result = result.unwrap();
 		assert!(result.is_some());
 		// The condition should produce valid SQL when used
 		let cond = result.unwrap();
@@ -1276,6 +1286,8 @@ mod tests {
 
 		let result = build_composite_filter_condition(&condition);
 
+		assert!(result.is_ok());
+		let result = result.unwrap();
 		assert!(result.is_some());
 		let cond = result.unwrap();
 		let query = Query::select()
@@ -1309,6 +1321,8 @@ mod tests {
 
 		let result = build_composite_filter_condition(&condition);
 
+		assert!(result.is_ok());
+		let result = result.unwrap();
 		assert!(result.is_some());
 		let cond = result.unwrap();
 		let query = Query::select()
@@ -1351,6 +1365,8 @@ mod tests {
 
 		let result = build_composite_filter_condition(&and_condition);
 
+		assert!(result.is_ok());
+		let result = result.unwrap();
 		assert!(result.is_some());
 		let cond = result.unwrap();
 		let query = Query::select()
@@ -1372,8 +1388,9 @@ mod tests {
 
 		let result = build_composite_filter_condition(&condition);
 
-		// Empty OR should return None
-		assert!(result.is_none());
+		// Empty OR should return Ok(None)
+		assert!(result.is_ok());
+		assert!(result.unwrap().is_none());
 	}
 
 	#[test]
@@ -1382,8 +1399,36 @@ mod tests {
 
 		let result = build_composite_filter_condition(&condition);
 
-		// Empty AND should return None
-		assert!(result.is_none());
+		// Empty AND should return Ok(None)
+		assert!(result.is_ok());
+		assert!(result.unwrap().is_none());
+	}
+
+	#[test]
+	fn test_build_composite_depth_overflow_returns_error() {
+		// Build a filter condition that exceeds MAX_FILTER_DEPTH by nesting
+		let base_filter = Filter::new(
+			"name".to_string(),
+			FilterOperator::Eq,
+			FilterValue::String("Alice".to_string()),
+		);
+		let mut condition = FilterCondition::Single(base_filter);
+		// Wrap in And() nesting MAX_FILTER_DEPTH + 1 times to exceed the limit
+		for _ in 0..=MAX_FILTER_DEPTH {
+			condition = FilterCondition::And(vec![condition]);
+		}
+
+		let result = build_composite_filter_condition(&condition);
+
+		assert!(result.is_err());
+		let err = result.unwrap_err();
+		assert!(matches!(err, AdminError::ValidationError(_)));
+		let err_msg = err.to_string();
+		assert!(
+			err_msg.contains("exceeded maximum depth"),
+			"Error message should mention exceeded depth, got: {}",
+			err_msg
+		);
 	}
 
 	// ==================== FieldRef/OuterRef/Expression filter tests ====================

--- a/tests/integration/tests/admin/admin_database_tests.rs
+++ b/tests/integration/tests/admin/admin_database_tests.rs
@@ -173,6 +173,8 @@ fn test_build_composite_single_condition() {
 	let result = build_composite_filter_condition(&condition);
 
 	// Assert
+	assert!(result.is_ok());
+	let result = result.unwrap();
 	assert!(result.is_some());
 	let cond = result.unwrap();
 	let query = Query::select()
@@ -206,6 +208,8 @@ fn test_build_composite_or_condition() {
 	let result = build_composite_filter_condition(&condition);
 
 	// Assert
+	assert!(result.is_ok());
+	let result = result.unwrap();
 	assert!(result.is_some());
 	let cond = result.unwrap();
 	let query = Query::select()
@@ -240,6 +244,8 @@ fn test_build_composite_and_condition() {
 	let result = build_composite_filter_condition(&condition);
 
 	// Assert
+	assert!(result.is_ok());
+	let result = result.unwrap();
 	assert!(result.is_some());
 	let cond = result.unwrap();
 	let query = Query::select()
@@ -281,6 +287,8 @@ fn test_build_composite_nested_condition() {
 	let result = build_composite_filter_condition(&and_condition);
 
 	// Assert
+	assert!(result.is_ok());
+	let result = result.unwrap();
 	assert!(result.is_some());
 	let cond = result.unwrap();
 	let query = Query::select()
@@ -304,7 +312,8 @@ fn test_build_composite_empty_or() {
 	let result = build_composite_filter_condition(&condition);
 
 	// Assert
-	assert!(result.is_none());
+	assert!(result.is_ok());
+	assert!(result.unwrap().is_none());
 }
 
 #[rstest]
@@ -316,7 +325,8 @@ fn test_build_composite_empty_and() {
 	let result = build_composite_filter_condition(&condition);
 
 	// Assert
-	assert!(result.is_none());
+	assert!(result.is_ok());
+	assert!(result.unwrap().is_none());
 }
 
 // ==================== list_with_condition / count_with_condition tests ====================


### PR DESCRIPTION
## Summary

- Change `build_composite_filter_condition()` and `build_composite_filter_condition_with_depth()` return type from `Option<Condition>` to `AdminResult<Option<Condition>>`
- Depth overflow now returns `Err(AdminError::ValidationError(...))` instead of silently returning `None`
- Update all callers to propagate the error via `?`
- Add test for depth overflow error behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Independent verification confirmed that `build_composite_filter_condition_with_depth()` returned `None` when recursion depth exceeded `MAX_FILTER_DEPTH` (100). Callers treated `None` as "no filter condition," meaning queries could execute without intended filtering. While the practical risk is low (depth 100 is unreachable in normal use), returning `None` instead of an error is semantically incorrect — a filter that cannot be processed should fail loudly, not silently produce an unfiltered query.

Fixes #2919

Related to: #2926

## How Was This Tested?

- `cargo check --workspace --all --all-features` passed
- `cargo nextest run --package reinhardt-admin --all-features` passed (249 tests, +1 new)
- `cargo make fmt-check` passed
- `cargo make clippy-check` passed
- New test `test_build_composite_depth_overflow_returns_error` verifies deeply nested conditions produce `AdminError::ValidationError`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `admin` - Admin interface, admin panels

### Priority Label
- [x] `low` - Minor fix (depth 100 practically unreachable)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)