### PR TITLE
fix(admin): fix HTML disabled attribute and pagination disabled state

### DIFF
--- a/crates/reinhardt-admin/src/pages/components/common.rs
+++ b/crates/reinhardt-admin/src/pages/components/common.rs
@@ -265,6 +265,12 @@ where
 				.attr("aria-disabled", "true")
 				.attr("tabindex", "-1")
 				.child(text.to_string())
+		} else if active {
+			// Active (current page) items use <span> to prevent redundant navigation
+			PageElement::new("span")
+				.attr("class", "page-link")
+				.attr("aria-current", "page")
+				.child(text.to_string())
 		} else {
 			PageElement::new("a")
 				.attr("class", "page-link")
@@ -287,6 +293,12 @@ where
 				.attr("class", "page-link")
 				.attr("aria-disabled", "true")
 				.attr("tabindex", "-1")
+				.child(text.to_string())
+		} else if active {
+			// Active (current page) items use <span> to prevent redundant navigation
+			PageElement::new("span")
+				.attr("class", "page-link")
+				.attr("aria-current", "page")
 				.child(text.to_string())
 		} else {
 			// SSR: No event handler needed (will be hydrated on client)


### PR DESCRIPTION
## Summary

- Fix button `disabled="false"` being truthy in HTML — only set attribute when actually disabled
- Fix disabled pagination items: render as `<span>` with `aria-disabled="true"` instead of clickable `<a href="#">`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

HTML boolean attributes are truthy by presence alone. `disabled="false"` still disables elements. Disabled pagination items were still clickable and navigated to `#`.

Fixes #2939, fixes #2951

## How Was This Tested?

- `cargo check --workspace --all --all-features`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `admin` - Admin interface, admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)