### PR TITLE
fix(admin): fix HTML input types, signal lifecycle, and route ordering

### DIFF
--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -166,6 +166,7 @@ fn dashboard_view() -> Page {
 #[cfg(target_arch = "wasm32")]
 fn list_view_component(model_name: String) -> Page {
 	use reinhardt_pages::component::{IntoPage, PageElement};
+	use reinhardt_pages::use_effect;
 
 	let list_resource = create_resource(move || {
 		let model_name = model_name.clone();
@@ -181,6 +182,21 @@ fn list_view_component(model_name: String) -> Page {
 	let page_signal = Signal::new(1u64);
 	let filters_signal = Signal::new(HashMap::new());
 
+	// Sync page_signal from the completed resource outside the rendering closure.
+	// Updating signals inside a rendering closure is an anti-pattern: it causes
+	// a state change during render and could create an infinite loop if the
+	// resource ever reads page_signal. Using use_effect keeps side-effects
+	// separate from the render path.
+	{
+		let resource = list_resource.clone();
+		let page_signal = page_signal.clone();
+		use_effect(move || {
+			if let ResourceState::Success(ref response) = resource.get() {
+				page_signal.set(response.page);
+			}
+		});
+	}
+
 	PageElement::new("div")
 		.attr("class", "list-container")
 		.child({
@@ -190,9 +206,6 @@ fn list_view_component(model_name: String) -> Page {
 			move || match resource.get() {
 				ResourceState::Loading => loading_view(),
 				ResourceState::Success(response) => {
-					// Update page signal from response without recreating it
-					page_signal.set(response.page);
-
 					// Convert ListResponse to ListViewData
 					let data = ListViewData {
 						model_name: response.model_name.clone(),
@@ -525,7 +538,8 @@ fn field_type_to_html_input_type(field_type: &reinhardt_admin::types::FieldType)
 		FieldType::Email => "email".to_string(),
 		FieldType::Date => "date".to_string(),
 		FieldType::DateTime => "datetime-local".to_string(),
-		FieldType::Select { .. } => "select".to_string(),
+		// Select should render as <select>, not <input>; fall back to "text" for now
+		FieldType::Select { .. } => "text".to_string(),
 		// MultiSelect should render as <select multiple>, not <input>; fall back to "text" for now
 		FieldType::MultiSelect { .. } => "text".to_string(),
 		FieldType::File => "file".to_string(),


### PR DESCRIPTION
## Summary

- Map TextArea/MultiSelect to `"text"` instead of invalid HTML input type values
- Move page and filter signals outside reactive closure to persist across re-renders
- Document required route registration order to prevent incorrect matching

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

TextArea mapped to invalid `"textarea"` input type, Signal recreated on every render resetting page state, and route correctness depended on fragile undocumented registration order.

Fixes #2940, fixes #2941, fixes #2953

## How Was This Tested?

- `cargo check --workspace --all --all-features`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `admin` - Admin interface, admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)