### PR TITLE
fix(admin): update integration tests to match new admin API signatures

### DIFF
--- a/crates/reinhardt-admin/src/server.rs
+++ b/crates/reinhardt-admin/src/server.rs
@@ -77,3 +77,4 @@ pub use fields::*;
 pub use import::*;
 pub use list::*;
 pub use update::*;
+pub use user::AdminDefaultUser;

--- a/crates/reinhardt-admin/src/server/user.rs
+++ b/crates/reinhardt-admin/src/server/user.rs
@@ -20,18 +20,31 @@ use uuid::Uuid;
 #[user(hasher = reinhardt_auth::Argon2Hasher, username_field = "username", full = true)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AdminDefaultUser {
+	/// Unique identifier.
 	pub id: Uuid,
+	/// Login username.
 	pub username: String,
+	/// Email address.
 	pub email: String,
+	/// First name.
 	pub first_name: String,
+	/// Last name.
 	pub last_name: String,
+	/// Hashed password (None if not set).
 	pub password_hash: Option<String>,
+	/// Timestamp of last login.
 	pub last_login: Option<DateTime<Utc>>,
+	/// Whether the user account is active.
 	pub is_active: bool,
+	/// Whether the user has staff privileges.
 	pub is_staff: bool,
+	/// Whether the user has superuser privileges.
 	pub is_superuser: bool,
+	/// Timestamp when the user joined.
 	pub date_joined: DateTime<Utc>,
+	/// List of permission codenames assigned to this user.
 	pub user_permissions: Vec<String>,
+	/// List of group names this user belongs to.
 	pub groups: Vec<String>,
 }
 

--- a/tests/integration/tests/admin/admin_database_tests.rs
+++ b/tests/integration/tests/admin/admin_database_tests.rs
@@ -750,7 +750,7 @@ async fn test_create_returns_zero_when_response_has_no_id_field(
 	data.insert("name".to_string(), serde_json::json!("Alice"));
 
 	// Act
-	let result = db.create::<User>("users", data).await;
+	let result = db.create::<User>("users", None, data).await;
 
 	// Assert
 	// Bug #2946: When the RETURNING clause returns a row without "id" field,
@@ -801,7 +801,7 @@ async fn test_create_returns_id_when_response_has_id_field() {
 	data.insert("name".to_string(), serde_json::json!("Alice"));
 
 	// Act
-	let result = db.create::<User>("users", data).await;
+	let result = db.create::<User>("users", None, data).await;
 
 	// Assert
 	assert!(result.is_ok());
@@ -851,7 +851,7 @@ async fn test_create_returns_zero_when_id_is_non_number() {
 	data.insert("name".to_string(), serde_json::json!("Bob"));
 
 	// Act
-	let result = db.create::<User>("users", data).await;
+	let result = db.create::<User>("users", None, data).await;
 
 	// Assert
 	// Bug #2946: Non-numeric ID values silently return 0

--- a/tests/integration/tests/admin/server_fn_delete_tests.rs
+++ b/tests/integration/tests/admin/server_fn_delete_tests.rs
@@ -33,7 +33,7 @@ async fn test_delete_record_happy_path(
 	data.insert("name".to_string(), json!("To Delete"));
 	data.insert("status".to_string(), json!("active"));
 	let created_id = db
-		.create::<AdminRecord>("test_models", data)
+		.create::<AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 
@@ -71,7 +71,7 @@ async fn test_delete_record_actually_removes(
 	data.insert("name".to_string(), json!("Will Be Deleted"));
 	data.insert("status".to_string(), json!("active"));
 	let created_id = db
-		.create::<AdminRecord>("test_models", data)
+		.create::<AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 
@@ -186,7 +186,7 @@ async fn test_bulk_delete_happy_path(
 		data.insert("name".to_string(), json!(format!("Bulk Delete {}", i)));
 		data.insert("status".to_string(), json!("active"));
 		let id = db
-			.create::<AdminRecord>("test_models", data)
+			.create::<AdminRecord>("test_models", None, data)
 			.await
 			.expect("Failed to create test record");
 		ids.push(id.to_string());
@@ -230,7 +230,7 @@ async fn test_bulk_delete_single_id(
 	data.insert("name".to_string(), json!("Single Bulk Delete"));
 	data.insert("status".to_string(), json!("active"));
 	let id = db
-		.create::<AdminRecord>("test_models", data)
+		.create::<AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 
@@ -358,7 +358,7 @@ async fn test_bulk_delete_partial_match(
 	data.insert("name".to_string(), json!("Partial Match"));
 	data.insert("status".to_string(), json!("active"));
 	let existing_id = db
-		.create::<AdminRecord>("test_models", data)
+		.create::<AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 

--- a/tests/integration/tests/admin/server_fn_detail_tests.rs
+++ b/tests/integration/tests/admin/server_fn_detail_tests.rs
@@ -31,7 +31,7 @@ async fn test_get_detail_happy_path(
 	data.insert("status".to_string(), json!("active"));
 
 	let created_id = db
-		.create::<AdminRecord>("test_models", data)
+		.create::<AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 
@@ -70,7 +70,7 @@ async fn test_get_detail_returns_all_fields(
 	data.insert("status".to_string(), json!("pending"));
 
 	let created_id = db
-		.create::<AdminRecord>("test_models", data)
+		.create::<AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 
@@ -117,7 +117,7 @@ async fn test_get_detail_with_various_data_types(
 	data.insert("status".to_string(), json!("active"));
 
 	let created_id = db
-		.create::<AdminRecord>("test_models", data)
+		.create::<AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 

--- a/tests/integration/tests/admin/server_fn_export_tests.rs
+++ b/tests/integration/tests/admin/server_fn_export_tests.rs
@@ -30,7 +30,7 @@ async fn test_export_json_happy_path(
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), json!("Export JSON Test"));
 	data.insert("status".to_string(), json!("active"));
-	db.create::<reinhardt_admin::core::AdminRecord>("test_models", data)
+	db.create::<reinhardt_admin::core::AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 
@@ -72,7 +72,7 @@ async fn test_export_csv_returns_serialization_error(
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), json!("Export CSV Test"));
 	data.insert("status".to_string(), json!("active"));
-	db.create::<reinhardt_admin::core::AdminRecord>("test_models", data)
+	db.create::<reinhardt_admin::core::AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 
@@ -116,7 +116,7 @@ async fn test_export_tsv_returns_serialization_error(
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), json!("Export TSV Test"));
 	data.insert("status".to_string(), json!("active"));
-	db.create::<reinhardt_admin::core::AdminRecord>("test_models", data)
+	db.create::<reinhardt_admin::core::AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 

--- a/tests/integration/tests/admin/server_fn_fields_tests.rs
+++ b/tests/integration/tests/admin/server_fn_fields_tests.rs
@@ -71,7 +71,7 @@ async fn test_get_fields_edit_form(
 	data.insert("name".to_string(), json!("Edit Form Item"));
 	data.insert("status".to_string(), json!("active"));
 	let created_id = db
-		.create::<AdminRecord>("test_models", data)
+		.create::<AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 

--- a/tests/integration/tests/admin/server_fn_helpers.rs
+++ b/tests/integration/tests/admin/server_fn_helpers.rs
@@ -3,8 +3,9 @@
 //! Provides helper functions to construct `ServerFnRequest`, `AuthUser<DefaultUser>`,
 //! and a permission-granting ModelAdmin for testing server functions.
 
-use reinhardt_admin::core::{AdminDatabase, AdminSite, ModelAdmin};
-use reinhardt_auth::{AuthUser, DefaultUser};
+use reinhardt_admin::core::{AdminDatabase, AdminSite, AdminUser, ModelAdmin};
+use reinhardt_admin::server::AdminDefaultUser;
+use reinhardt_auth::AuthUser;
 use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection;
 use reinhardt_db::backends::dialect::PostgresBackend;
 use reinhardt_db::orm::connection::{DatabaseBackend, DatabaseConnection};
@@ -39,9 +40,9 @@ pub fn make_staff_request() -> ServerFnRequest {
 	ServerFnRequest(Arc::new(request))
 }
 
-/// Creates a `DefaultUser` with staff privileges for testing.
-pub fn make_staff_user() -> DefaultUser {
-	DefaultUser {
+/// Creates an `AdminDefaultUser` with staff privileges for testing.
+pub fn make_staff_user() -> AdminDefaultUser {
+	AdminDefaultUser {
 		id: Uuid::new_v4(),
 		username: "test_staff".to_string(),
 		email: "staff@test.example".to_string(),
@@ -58,8 +59,8 @@ pub fn make_staff_user() -> DefaultUser {
 	}
 }
 
-/// Creates an `AuthUser<DefaultUser>` with staff privileges for testing.
-pub fn make_auth_user() -> AuthUser<DefaultUser> {
+/// Creates an `AuthUser<AdminDefaultUser>` with staff privileges for testing.
+pub fn make_auth_user() -> AuthUser<AdminDefaultUser> {
 	AuthUser(make_staff_user())
 }
 
@@ -126,19 +127,19 @@ impl ModelAdmin for AllPermissionsModelAdmin {
 		Some(vec!["id", "name", "status", "description", "created_at"])
 	}
 
-	async fn has_view_permission(&self, _user: &(dyn std::any::Any + Send + Sync)) -> bool {
+	async fn has_view_permission(&self, _user: &dyn AdminUser) -> bool {
 		true
 	}
 
-	async fn has_add_permission(&self, _user: &(dyn std::any::Any + Send + Sync)) -> bool {
+	async fn has_add_permission(&self, _user: &dyn AdminUser) -> bool {
 		true
 	}
 
-	async fn has_change_permission(&self, _user: &(dyn std::any::Any + Send + Sync)) -> bool {
+	async fn has_change_permission(&self, _user: &dyn AdminUser) -> bool {
 		true
 	}
 
-	async fn has_delete_permission(&self, _user: &(dyn std::any::Any + Send + Sync)) -> bool {
+	async fn has_delete_permission(&self, _user: &dyn AdminUser) -> bool {
 		true
 	}
 }

--- a/tests/integration/tests/admin/server_fn_list_tests.rs
+++ b/tests/integration/tests/admin/server_fn_list_tests.rs
@@ -31,7 +31,7 @@ async fn test_get_list_happy_path(
 		let mut data = HashMap::new();
 		data.insert("name".to_string(), json!(format!("Item {}", i)));
 		data.insert("status".to_string(), json!("active"));
-		db.create::<AdminRecord>("test_models", data)
+		db.create::<AdminRecord>("test_models", None, data)
 			.await
 			.expect("Failed to create test record");
 	}
@@ -64,7 +64,7 @@ async fn test_get_list_with_search(
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), json!("UniqueSearchTarget"));
 	data.insert("status".to_string(), json!("active"));
-	db.create::<AdminRecord>("test_models", data)
+	db.create::<AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 
@@ -97,7 +97,7 @@ async fn test_get_list_with_filter(
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), json!("Filter Test"));
 	data.insert("status".to_string(), json!("filterable_status"));
-	db.create::<AdminRecord>("test_models", data)
+	db.create::<AdminRecord>("test_models", None, data)
 		.await
 		.expect("Failed to create test record");
 


### PR DESCRIPTION
## Summary

- Update admin integration tests to match API signatures changed by PR #2999
- Export `AdminDefaultUser` from `reinhardt_admin::server` for test construction
- Add field documentation to `AdminDefaultUser`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

PR #2999 (admin DI deferred registration) changed several API signatures but integration tests were not updated, causing `cargo check --workspace --all-features --tests` to fail with 79 compilation errors. This blocks CI for all open PRs.

Fixes #3013

## How Was This Tested?

- `cargo check --workspace --all-features --tests` passes
- `cargo make fmt-check` passes
- `cargo make clippy-check` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `admin` - Admin interface, admin panels

### Priority Label
- [x] `high` - Important fix or feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)