### PR TITLE
fix(ci): skip packages without test targets in intra-crate integration tests

### DIFF
--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -139,6 +139,14 @@ jobs:
           # Build package selection args. Issue #2878
           # --exclude requires --workspace; when using -p flags, filter the
           # package list instead. Issue #2878
+          # Build set of packages that have integration test targets (kind == "test").
+          # Packages without test targets (e.g., reinhardt-web, reinhardt-test-support)
+          # cause `cargo test --no-run --test '*'` to fail with exit code 101.
+          # Fixes #3026
+          PKGS_WITH_TEST_TARGETS=$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.targets[] | .kind[] == "test") | .name' \
+            | sort -u)
+
           PKG_ARGS=()
           EXCLUDE_ARGS=()
           if [[ "$RUN_ALL" != "true" && -n "$CARGO_PACKAGES" ]]; then
@@ -146,8 +154,11 @@ jobs:
               [[ -z "$pkg" ]] && continue
               # Cross-crate integration tests run in a separate workflow
               [[ "$pkg" == "reinhardt-integration-tests" ]] && continue
-              # reinhardt-test-support has no test targets (lib-only crate)
-              [[ "$pkg" == "reinhardt-test-support" ]] && continue
+              # Skip packages without integration test targets
+              if ! echo "$PKGS_WITH_TEST_TARGETS" | grep -qx "$pkg"; then
+                echo "Skipping $pkg (no integration test targets)"
+                continue
+              fi
               PKG_ARGS+=(-p "$pkg")
             done <<< "$CARGO_PACKAGES"
           fi


### PR DESCRIPTION
## Summary

- Replace hardcoded package skip list with dynamic detection using `cargo metadata`
- Packages without integration test targets are now automatically skipped
- Prevents `cargo test --no-run --test '*'` exit code 101 failures

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

When a PR modifies files affecting a package without integration test targets (e.g., `reinhardt-web`), the intra-crate integration test CI workflow fails because `cargo test --no-run --test '*'` returns exit code 101 when no test targets match the pattern. The `--no-tests=warn` nextest flag does not help because the failure occurs at the cargo compilation step before nextest starts.

Previously, only `reinhardt-test-support` was hardcoded in the skip list. This fix dynamically detects all packages with test targets using `cargo metadata`, making it resilient to future workspace changes.

Fixes #3026

## How Was This Tested?

- Verified `cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.targets[] | .kind[] == "test") | .name'` correctly excludes `reinhardt-web` and `reinhardt-test-support`
- Confirmed the `coverage.yml` workflow uses `--workspace` pattern (unaffected)
- Only `intra-crate-integration-test.yml` uses the `-p` flag pattern that triggers this bug

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)