### PR TITLE
fix(test): update admin create tests to match fixed implementation

### DIFF
--- a/tests/integration/tests/admin/admin_database_tests.rs
+++ b/tests/integration/tests/admin/admin_database_tests.rs
@@ -90,6 +90,8 @@ async fn test_get_by_id(mock_connection: DatabaseConnection) {
 #[tokio::test]
 async fn test_create(mock_connection: DatabaseConnection) {
 	// Arrange
+	// Default mock returns {"count": 0} without "id" field,
+	// so create() returns Err (missing pk field). Fixes #3029
 	let db = AdminDatabase::new(mock_connection);
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), serde_json::json!("Alice"));
@@ -99,7 +101,13 @@ async fn test_create(mock_connection: DatabaseConnection) {
 	let result = db.create::<User>("users", None, data).await;
 
 	// Assert
-	assert!(result.is_ok());
+	assert!(result.is_err());
+	let err_msg = result.unwrap_err().to_string();
+	assert!(
+		err_msg.contains("RETURNING clause did not return expected primary key field"),
+		"Expected missing pk field error, got: {}",
+		err_msg
+	);
 }
 
 #[rstest]
@@ -740,7 +748,7 @@ fn test_filter_value_to_sea_value_expression_fallback() {
 
 #[rstest]
 #[tokio::test]
-async fn test_create_returns_zero_when_response_has_no_id_field(
+async fn test_create_returns_error_when_response_has_no_id_field(
 	mock_connection: DatabaseConnection,
 ) {
 	// Arrange
@@ -753,13 +761,14 @@ async fn test_create_returns_zero_when_response_has_no_id_field(
 	let result = db.create::<User>("users", None, data).await;
 
 	// Assert
-	// Bug #2946: When the RETURNING clause returns a row without "id" field,
-	// the function silently returns 0 instead of an error
-	assert!(result.is_ok());
-	assert_eq!(
-		result.unwrap(),
-		0,
-		"Bug #2946: create() returns 0 when 'id' field is missing from response"
+	// Bug #2946 was fixed: create() now returns Err when the RETURNING clause
+	// does not contain the expected primary key field. Fixes #3029
+	assert!(result.is_err());
+	let err_msg = result.unwrap_err().to_string();
+	assert!(
+		err_msg.contains("RETURNING clause did not return expected primary key field"),
+		"Expected missing pk field error, got: {}",
+		err_msg
 	);
 }
 
@@ -854,12 +863,14 @@ async fn test_create_returns_zero_when_id_is_non_number() {
 	let result = db.create::<User>("users", None, data).await;
 
 	// Assert
-	// Bug #2946: Non-numeric ID values silently return 0
-	assert!(result.is_ok());
-	assert_eq!(
-		result.unwrap(),
-		0,
-		"Bug #2946: create() returns 0 when 'id' is not a number"
+	// Bug #2946 was fixed: Non-numeric ID values now return Err instead of
+	// silently returning 0. Fixes #3029
+	assert!(result.is_err());
+	let err_msg = result.unwrap_err().to_string();
+	assert!(
+		err_msg.contains("RETURNING clause did not return expected primary key field"),
+		"Expected missing pk field error, got: {}",
+		err_msg
 	);
 }
 


### PR DESCRIPTION
## Summary

- Update 3 admin database `create()` tests to expect `Err` instead of `Ok`
- Tests were asserting old buggy behavior (Bug #2946) that was fixed in PR #2973
- Rename `test_create_returns_zero_when_response_has_no_id_field` to `test_create_returns_error_when_response_has_no_id_field`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

PR #2973 fixed Bug #2946 so that `AdminDatabase::create()` returns `Err` when the RETURNING clause doesn't contain the expected primary key field. PR #3014 updated the API signatures (`pk_field: Option<&str>`) but did not update the test assertions. Three tests still expected the old buggy behavior (`Ok(0)`), causing CI failures on any PR that triggers Cross-Crate Integration Tests.

Fixes #3029

## How Was This Tested?

- `cargo nextest run --package reinhardt-integration-tests -E 'test(admin::admin_database_tests)' --all-features --no-fail-fast` — 38 tests run, 38 passed, 0 failed

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)