### PR TITLE
fix(ci): correct mutation-test job condition to prevent push-triggered failures

### DIFF
--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -30,7 +30,7 @@ jobs:
   mutation-test:
     name: "Shard ${{ matrix.shard }}/5"
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_dispatch' || inputs.shard == '0' || inputs.shard == matrix.shard
+    if: github.event_name == 'schedule' || inputs.shard == '0' || inputs.shard == matrix.shard
     timeout-minutes: 360
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Fix inverted `if` condition in mutation-test workflow that caused "workflow file issue" failures on push events
- Changed `github.event_name != 'workflow_dispatch'` to `github.event_name == 'schedule'` to correctly scope shard execution

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The mutation-test workflow only defines `schedule` and `workflow_dispatch` triggers, but the job's `if` condition `github.event_name != 'workflow_dispatch'` evaluates to `true` on push events, causing GitHub to report "workflow file issue" failures. This was introduced in commit `18cddc4dd` which accidentally inverted the logic from the previous correct fix in commit `725327d29`.

## How Was This Tested

- Verified workflow YAML syntax is valid
- Confirmed the logical correctness: `schedule` runs all shards, `workflow_dispatch` respects shard selection

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

## Labels to Apply

- `bug` - Fixes incorrect workflow condition
- `ci-cd` - CI/CD workflow change
- `github-actions` - GitHub Actions workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)