### PR TITLE
fix(di): apply deferred DI registrations to existing singleton scope

### DIFF
--- a/crates/reinhardt-admin/src/core/site.rs
+++ b/crates/reinhardt-admin/src/core/site.rs
@@ -418,8 +418,8 @@ impl AdminSite {
 /// Injectable trait implementation for AdminSite
 ///
 /// Resolves `AdminSite` directly from the singleton scope.
-/// The `AdminSite` must be registered via `admin_routes_with_di()` which
-/// auto-registers the site in the singleton scope during route creation.
+/// The `AdminSite` must be registered via `admin_routes_with_di_deferred()` which
+/// returns a `DiRegistrationList` to be attached to the router.
 #[async_trait]
 impl Injectable for AdminSite {
 	async fn inject(ctx: &InjectionContext) -> DiResult<Self> {
@@ -428,7 +428,8 @@ impl Injectable for AdminSite {
 			.ok_or_else(|| reinhardt_di::DiError::NotRegistered {
 				type_name: "AdminSite".into(),
 				hint: "AdminSite must be registered as a singleton. \
-				       Use admin_routes_with_di(site, &singleton_scope) to auto-register."
+				       Use admin_routes_with_di_deferred(site) and attach the returned \
+				       DiRegistrationList via .with_di_registrations() on UnifiedRouter."
 					.into(),
 			})
 	}

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -60,3 +60,4 @@ tokio = { version = "1.41", features = ["full"] }
 bytes = { workspace = true }
 hyper = { workspace = true }
 rstest = { workspace = true }
+serial_test = { workspace = true }

--- a/crates/reinhardt-urls/src/routers/server_router.rs
+++ b/crates/reinhardt-urls/src/routers/server_router.rs
@@ -390,6 +390,11 @@ impl ServerRouter {
 		self
 	}
 
+	/// Returns a reference to the DI context, if set.
+	pub(crate) fn di_context(&self) -> Option<&Arc<InjectionContext>> {
+		self.di_context.as_ref()
+	}
+
 	/// Add middleware to this router
 	///
 	/// # Examples

--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -160,30 +160,45 @@ impl UnifiedRouter {
 		&mut self.client
 	}
 
+	/// Apply or stash deferred DI registrations.
+	///
+	/// If the server router already has a DI context, registrations are applied
+	/// directly to its singleton scope. Otherwise they are stashed globally
+	/// for later application (e.g., by the `runall` command).
+	fn flush_di_registrations(&mut self) {
+		if self.di_registrations.is_empty() {
+			return;
+		}
+		let registrations = std::mem::take(&mut self.di_registrations);
+		match self
+			.server
+			.di_context()
+			.map(|ctx| Arc::clone(ctx.singleton_scope()))
+		{
+			Some(scope) => registrations.apply_to(&scope),
+			None => crate::routers::register_di_registrations(registrations),
+		}
+	}
+
 	/// Consumes the router and returns the server router.
 	///
-	/// If this router has deferred DI registrations, they are stashed
-	/// in the global registry for later application by the server.
-	pub fn into_server(self) -> ServerRouter {
-		if !self.di_registrations.is_empty() {
-			crate::routers::register_di_registrations(self.di_registrations);
-		}
+	/// If this router has a DI context, deferred DI registrations are applied
+	/// directly to its singleton scope. Otherwise they are stashed in the
+	/// global registry for later application by the server.
+	pub fn into_server(mut self) -> ServerRouter {
+		self.flush_di_registrations();
 		self.server
 	}
 
 	/// Consumes the router and returns the client router.
-	pub fn into_client(self) -> ClientRouter {
-		if !self.di_registrations.is_empty() {
-			crate::routers::register_di_registrations(self.di_registrations);
-		}
+	pub fn into_client(mut self) -> ClientRouter {
+		self.flush_di_registrations();
 		self.client
 	}
 
 	/// Consumes the router and returns both parts.
-	pub fn into_parts(self) -> (ServerRouter, ClientRouter) {
-		if !self.di_registrations.is_empty() {
-			crate::routers::register_di_registrations(self.di_registrations);
-		}
+	pub fn into_parts(mut self) -> (ServerRouter, ClientRouter) {
+		self.flush_di_registrations();
 		(self.server, self.client)
 	}
 
@@ -212,11 +227,10 @@ impl UnifiedRouter {
 
 	/// Attach deferred DI registrations to this router.
 	///
-	/// These registrations will be stashed globally when the router is
-	/// consumed (via [`into_server`](Self::into_server),
-	/// [`into_parts`](Self::into_parts), or
-	/// [`register_globally`](Self::register_globally)),
-	/// and applied to the server's singleton scope during startup.
+	/// When the router is consumed, these registrations are applied directly
+	/// to the DI context's singleton scope if one has been set via
+	/// [`with_di_context`](Self::with_di_context). Otherwise they are stashed
+	/// globally for later application (e.g., by the `runall` command).
 	pub fn with_di_registrations(mut self, list: reinhardt_di::DiRegistrationList) -> Self {
 		self.di_registrations.merge(list);
 		self
@@ -381,32 +395,48 @@ impl UnifiedRouter {
 		&mut self.server
 	}
 
+	/// Apply or stash deferred DI registrations.
+	///
+	/// If the server router already has a DI context, registrations are applied
+	/// directly to its singleton scope. Otherwise they are stashed globally
+	/// for later application (e.g., by the `runall` command).
+	fn flush_di_registrations(&mut self) {
+		if self.di_registrations.is_empty() {
+			return;
+		}
+		let registrations = std::mem::take(&mut self.di_registrations);
+		match self
+			.server
+			.di_context()
+			.map(|ctx| Arc::clone(ctx.singleton_scope()))
+		{
+			Some(scope) => registrations.apply_to(&scope),
+			None => crate::routers::register_di_registrations(registrations),
+		}
+	}
+
 	/// Consumes the router and returns the server router.
 	///
-	/// If this router has deferred DI registrations, they are stashed
-	/// in the global registry for later application by the server.
-	pub fn into_server(self) -> ServerRouter {
-		if !self.di_registrations.is_empty() {
-			crate::routers::register_di_registrations(self.di_registrations);
-		}
+	/// If this router has a DI context, deferred DI registrations are applied
+	/// directly to its singleton scope. Otherwise they are stashed in the
+	/// global registry for later application by the server.
+	pub fn into_server(mut self) -> ServerRouter {
+		self.flush_di_registrations();
 		self.server
 	}
 
 	/// Registers server router globally.
-	pub fn register_globally(self) {
-		let di = self.di_registrations;
-		if !di.is_empty() {
-			crate::routers::register_di_registrations(di);
-		}
+	pub fn register_globally(mut self) {
+		self.flush_di_registrations();
 		crate::routers::register_router(self.server);
 	}
 
 	/// Attach deferred DI registrations to this router.
 	///
-	/// These registrations will be stashed globally when the router is
-	/// consumed (via [`into_server`](Self::into_server) or
-	/// [`register_globally`](Self::register_globally)),
-	/// and applied to the server's singleton scope during startup.
+	/// When the router is consumed, these registrations are applied directly
+	/// to the DI context's singleton scope if one has been set via
+	/// [`with_di_context`](Self::with_di_context). Otherwise they are stashed
+	/// globally for later application (e.g., by the `runall` command).
 	pub fn with_di_registrations(mut self, list: reinhardt_di::DiRegistrationList) -> Self {
 		self.di_registrations.merge(list);
 		self
@@ -665,5 +695,73 @@ mod tests {
 
 		let client = router.into_client();
 		assert_eq!(client.route_count(), 1);
+	}
+
+	mod flush_di_registrations {
+		use super::*;
+		use reinhardt_di::{DiRegistrationList, InjectionContext, SingletonScope};
+		use rstest::rstest;
+		use std::sync::Arc;
+
+		#[rstest]
+		fn applies_registrations_to_di_context_singleton_scope() {
+			// Arrange
+			let singleton_scope = Arc::new(SingletonScope::new());
+			let di_ctx = Arc::new(InjectionContext::builder(Arc::clone(&singleton_scope)).build());
+
+			let mut registrations = DiRegistrationList::new();
+			registrations.register(42i32);
+
+			// Act
+			let _server = UnifiedRouter::new()
+				.with_di_registrations(registrations)
+				.with_di_context(di_ctx)
+				.into_server();
+
+			// Assert
+			let value = singleton_scope
+				.get::<i32>()
+				.expect("i32 should be registered");
+			assert_eq!(*value, 42);
+		}
+
+		#[rstest]
+		fn applies_registrations_regardless_of_builder_order() {
+			// Arrange
+			let singleton_scope = Arc::new(SingletonScope::new());
+			let di_ctx = Arc::new(InjectionContext::builder(Arc::clone(&singleton_scope)).build());
+
+			let mut registrations = DiRegistrationList::new();
+			registrations.register(99u64);
+
+			// Act: with_di_context BEFORE with_di_registrations
+			let _server = UnifiedRouter::new()
+				.with_di_context(di_ctx)
+				.with_di_registrations(registrations)
+				.into_server();
+
+			// Assert
+			let value = singleton_scope
+				.get::<u64>()
+				.expect("u64 should be registered");
+			assert_eq!(*value, 99);
+		}
+
+		#[rstest]
+		#[serial_test::serial(global_di)]
+		fn stashes_globally_when_no_di_context() {
+			// Arrange
+			let mut registrations = DiRegistrationList::new();
+			registrations.register(7u8);
+
+			// Act
+			let _server = UnifiedRouter::new()
+				.with_di_registrations(registrations)
+				.into_server();
+
+			// Assert: registrations stashed globally
+			let taken = crate::routers::take_di_registrations();
+			assert!(taken.is_some(), "registrations should be stashed globally");
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fix `admin_routes_with_di_deferred()` `DiRegistrationList` not being applied to the server's singleton scope when a user-provided `InjectionContext` is already set on the router
- Add `flush_di_registrations()` helper to `UnifiedRouter` that applies registrations directly to the DI context's singleton scope if available, falling back to global stash
- Update `AdminSite` `Injectable` error hint to reference the current recommended API

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

When users construct their own `InjectionContext` and pass it via `.with_di_context()`, the deferred DI registrations from `.with_di_registrations()` were only stashed globally — never applied to the user's singleton scope. This caused `NotRegistered` errors at request time for `AdminSite` and any other deferred DI registrations. The `runall` command handled this manually, but custom server setups did not have this step.

Fixes #3033

## How Was This Tested?

- Added 3 new tests in `unified_router::tests::flush_di_registrations`:
  - `applies_registrations_to_di_context_singleton_scope`: verifies direct application when DI context is present
  - `applies_registrations_regardless_of_builder_order`: verifies order independence (`with_di_context` before/after `with_di_registrations`)
  - `stashes_globally_when_no_di_context`: verifies existing behavior when no DI context is set
- `cargo nextest run --package reinhardt-urls --all-features` — 718 tests pass
- `cargo make clippy-check` — clean
- `cargo make fmt-check` — clean

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #3033
- Related to PR #2999 (deferred DI feature)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `routing` - URL routing, path matching
- [x] `admin` - Admin interface, admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)