### PR TITLE
fix(di): register HTTP request in request_scope during fork_for_request

### DIFF
--- a/crates/reinhardt-di/src/context.rs
+++ b/crates/reinhardt-di/src/context.rs
@@ -420,19 +420,33 @@ impl InjectionContext {
 	/// The forked context shares the same singleton scope but has a fresh
 	/// request scope. When the `params` feature is enabled, the HTTP request
 	/// and its path parameters are made available for parameter extraction.
-	#[allow(unused_variables)] // `request` is unused when `params` feature is disabled
+	///
+	/// The HTTP request is stored in both the dedicated `request` field
+	/// (for [`get_http_request()`](Self::get_http_request)) and the
+	/// `request_scope` (for [`get_request::<HttpRequest>()`](Self::get_request)),
+	/// ensuring that `Injectable` types such as `ServerFnRequest` can
+	/// retrieve it via either accessor.
 	pub fn fork_for_request(&self, request: HttpRequest) -> InjectionContext {
+		let request_arc = Arc::new(request);
+
 		#[cfg(feature = "params")]
 		let param_context = Some(Arc::new(ParamContext::with_path_params(
-			request.path_params.clone(),
+			request_arc.path_params.clone(),
 		)));
 
-		self.fork_inner(
+		let ctx = self.fork_inner(
 			#[cfg(feature = "params")]
-			Some(Arc::new(request)),
+			Some(Arc::clone(&request_arc)),
 			#[cfg(feature = "params")]
 			param_context,
-		)
+		);
+
+		// Also register in request_scope so that Injectable types
+		// (e.g. ServerFnRequest, ServerFnBody) can retrieve it via
+		// get_request::<HttpRequest>()
+		ctx.set_request_arc(request_arc);
+
+		ctx
 	}
 
 	/// Creates a per-request fork of this context without an HTTP request.
@@ -781,5 +795,29 @@ mod tests {
 		let http_req = forked.get_http_request();
 		assert!(http_req.is_some());
 		assert_eq!(http_req.unwrap().method, hyper::Method::POST);
+	}
+
+	#[rstest]
+	fn test_fork_for_request_registers_http_request_in_request_scope() {
+		// Arrange
+		let singleton_scope = Arc::new(SingletonScope::new());
+		let ctx = InjectionContext::builder(singleton_scope).build();
+
+		let request = HttpRequest::builder()
+			.method(hyper::Method::POST)
+			.uri("/admin/api/server_fn/get_dashboard")
+			.build()
+			.unwrap();
+
+		// Act
+		let forked = ctx.fork_for_request(request);
+
+		// Assert - HTTP request is retrievable via get_request::<HttpRequest>()
+		// This is the accessor used by Injectable types like ServerFnRequest
+		let req_from_scope: Option<Arc<HttpRequest>> = forked.get_request();
+		assert!(req_from_scope.is_some());
+		let req = req_from_scope.unwrap();
+		assert_eq!(req.method, hyper::Method::POST);
+		assert_eq!(req.uri.path(), "/admin/api/server_fn/get_dashboard");
 	}
 }


### PR DESCRIPTION
## Summary

- Fix `ServerFnRequest` NotFound error in admin server function handlers by registering the HTTP request in `request_scope` during `fork_for_request()`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`fork_for_request()` stored the HTTP request only in the dedicated `request` field but not in the `request_scope`. Injectable types like `ServerFnRequest` and `ServerFnBody` use `get_request::<HttpRequest>()` which reads from `request_scope`, causing `NotFound` errors for admin server function handlers that depend on `#[inject] ServerFnRequest`.

The root cause is a storage mismatch between two accessors:
- `get_http_request()` → reads from `self.request` field (set by `fork_for_request`)
- `get_request::<T>()` → reads from `self.request_scope` (never populated with the HTTP request)

Non-admin server functions were unaffected because they don't use `#[inject] ServerFnRequest`.

Fixes #3044

Related to: #3033, #3038

## How Was This Tested?

- Added unit test `test_fork_for_request_registers_http_request_in_request_scope` that verifies `get_request::<HttpRequest>()` returns the correct request after `fork_for_request()`
- All 251 existing `reinhardt-di` tests pass
- `cargo check --workspace --all-features` passes
- `cargo make fmt-check` and `cargo make clippy-check` pass

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #3044 — Admin server_fn handlers fail with ServerFnRequest NotFound
- #3033 — Original deferred DI scope issue
- #3038 — Fix that enabled AdminSite DI, revealing this deeper issue

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `admin` - Admin interface, admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)