### PR TITLE
fix(di): register DatabaseConnection in user-provided DI context

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1494,14 +1494,25 @@ impl RunServerCommand {
 
 		// OpenAPI documentation is shown in startup banner above
 
-		// Create DI context for dependency injection
-		let singleton_scope = std::sync::Arc::new(reinhardt_di::SingletonScope::new());
-
-		// Apply deferred DI registrations from route configuration (e.g., AdminSite from admin_routes_with_di_deferred)
-		if let Some(registrations) = reinhardt_urls::routers::take_di_registrations() {
-			ctx.verbose("Applying deferred DI registrations from route configuration");
-			registrations.apply_to(&singleton_scope);
-		}
+		// Resolve DI context: reuse user-provided context from router, or create a new one.
+		// When the user attaches a DI context via UnifiedRouter::with_di_context(),
+		// we must register server-managed singletons (e.g., DatabaseConnection)
+		// into that context's singleton scope rather than creating a separate one.
+		let (singleton_scope, user_provided_context) =
+			if let Some(existing_ctx) = reinhardt_urls::routers::get_router_di_context() {
+				ctx.verbose("Using user-provided DI context from router configuration");
+				(existing_ctx.singleton_scope().clone(), Some(existing_ctx))
+			} else {
+				let scope = std::sync::Arc::new(reinhardt_di::SingletonScope::new());
+				// Apply deferred DI registrations only when no user context exists.
+				// When a user context is present, UnifiedRouter::flush_di_registrations
+				// has already applied them to the user's singleton scope.
+				if let Some(registrations) = reinhardt_urls::routers::take_di_registrations() {
+					ctx.verbose("Applying deferred DI registrations from route configuration");
+					registrations.apply_to(&scope);
+				}
+				(scope, None)
+			};
 
 		// Register DatabaseConnection as singleton when database feature is enabled
 		#[cfg(feature = "reinhardt-db")]
@@ -1557,8 +1568,13 @@ impl RunServerCommand {
 			}
 		}
 
-		let di_context =
-			std::sync::Arc::new(reinhardt_di::InjectionContext::builder(singleton_scope).build());
+		// Build or reuse the DI context
+		let di_context = match user_provided_context {
+			Some(ctx) => ctx,
+			None => std::sync::Arc::new(
+				reinhardt_di::InjectionContext::builder(singleton_scope).build(),
+			),
+		};
 
 		// Create HTTP server with DI context and logging middleware
 		let mut server = HttpServer::new(router)

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -61,3 +61,4 @@ bytes = { workspace = true }
 hyper = { workspace = true }
 rstest = { workspace = true }
 serial_test = { workspace = true }
+reinhardt-testkit = { path = "../reinhardt-testkit" }

--- a/crates/reinhardt-urls/src/routers.rs
+++ b/crates/reinhardt-urls/src/routers.rs
@@ -206,8 +206,9 @@ pub use simple::SimpleRouter;
 // Server router (full HTTP routing implementation)
 #[cfg(not(target_arch = "wasm32"))]
 pub use server_router::{
-	FunctionHandler, MiddlewareInfo, ServerRouter, clear_router, get_router, is_router_registered,
-	register_di_registrations, register_router, register_router_arc, take_di_registrations,
+	FunctionHandler, MiddlewareInfo, ServerRouter, clear_router, get_router, get_router_di_context,
+	is_router_registered, register_di_registrations, register_router, register_router_arc,
+	take_di_registrations,
 };
 
 // Unified router (closure-based API combining server and client routers)

--- a/crates/reinhardt-urls/src/routers/server_router.rs
+++ b/crates/reinhardt-urls/src/routers/server_router.rs
@@ -39,8 +39,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, PoisonError, RwLock};
 
 pub use self::global::{
-	clear_router, get_router, is_router_registered, register_di_registrations, register_router,
-	register_router_arc, take_di_registrations,
+	clear_router, get_router, get_router_di_context, is_router_registered,
+	register_di_registrations, register_router, register_router_arc, take_di_registrations,
 };
 pub use self::handlers::FunctionHandler;
 pub use self::matching::{extract_params, path_matches};

--- a/crates/reinhardt-urls/src/routers/server_router/global.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/global.rs
@@ -118,6 +118,20 @@ pub fn take_di_registrations() -> Option<reinhardt_di::DiRegistrationList> {
 		.and_then(|cell| cell.write().unwrap_or_else(PoisonError::into_inner).take())
 }
 
+/// Get a clone of the DI context from the globally registered router, if one was set.
+///
+/// This allows server startup code to detect when the user has already
+/// configured a DI context on their router (via [`ServerRouter::with_di_context`]
+/// or [`UnifiedRouter::with_di_context`]) and reuse its singleton scope
+/// instead of creating a new one.
+///
+/// Returns `None` if no router is registered or the router has no DI context.
+///
+/// [`UnifiedRouter::with_di_context`]: crate::routers::UnifiedRouter::with_di_context
+pub fn get_router_di_context() -> Option<Arc<reinhardt_di::InjectionContext>> {
+	get_router().and_then(|router| router.di_context().cloned())
+}
+
 /// Clear the registered router (useful for tests)
 ///
 /// # Examples
@@ -137,5 +151,78 @@ pub fn clear_router() {
 	if let Some(cell) = GLOBAL_DI_REGISTRATIONS.get() {
 		let mut guard = cell.write().unwrap_or_else(PoisonError::into_inner);
 		*guard = None;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use reinhardt_testkit::resource::{TeardownGuard, TestResource};
+	use rstest::{fixture, rstest};
+
+	/// Fixture that clears global router state before each test
+	/// and restores it after test completion via RAII.
+	struct CleanGlobalRouter;
+
+	impl TestResource for CleanGlobalRouter {
+		fn setup() -> Self {
+			clear_router();
+			Self
+		}
+
+		fn teardown(&mut self) {
+			clear_router();
+		}
+	}
+
+	#[fixture]
+	fn env() -> TeardownGuard<CleanGlobalRouter> {
+		TeardownGuard::new()
+	}
+
+	#[rstest]
+	#[serial_test::serial(global_router)]
+	fn returns_none_when_no_router_registered(_env: TeardownGuard<CleanGlobalRouter>) {
+		// Act
+		let result = get_router_di_context();
+
+		// Assert
+		assert!(result.is_none());
+	}
+
+	#[rstest]
+	#[serial_test::serial(global_router)]
+	fn returns_none_when_router_has_no_di_context(_env: TeardownGuard<CleanGlobalRouter>) {
+		// Arrange
+		let router = crate::routers::ServerRouter::new();
+		register_router(router);
+
+		// Act
+		let result = get_router_di_context();
+
+		// Assert
+		assert!(result.is_none());
+	}
+
+	#[rstest]
+	#[serial_test::serial(global_router)]
+	fn returns_context_when_router_has_di_context(_env: TeardownGuard<CleanGlobalRouter>) {
+		// Arrange
+		let singleton_scope = Arc::new(reinhardt_di::SingletonScope::new());
+		singleton_scope.set(42u32);
+		let di_ctx = Arc::new(reinhardt_di::InjectionContext::builder(singleton_scope).build());
+
+		let router = crate::routers::ServerRouter::new().with_di_context(di_ctx);
+		register_router(router);
+
+		// Act
+		let result = get_router_di_context();
+
+		// Assert
+		assert!(result.is_some());
+		let ctx = result.unwrap();
+		let value = ctx.singleton_scope().get::<u32>();
+		assert!(value.is_some());
+		assert_eq!(*value.unwrap(), 42);
 	}
 }


### PR DESCRIPTION
## Summary

- Register `DatabaseConnection` in the user-provided `InjectionContext` singleton scope when the user configures one via `UnifiedRouter::with_di_context()`
- Add `get_router_di_context()` API to extract DI context from the globally registered router
- Prevent `AdminDatabase` lazy construction failures caused by scope mismatch

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

When a user provides their own `InjectionContext` via `.with_di_context()`, the builtin `runserver` command was creating a separate `SingletonScope` and registering `DatabaseConnection` there, ignoring the user's context entirely. This caused `AdminDatabase` (which lazily wraps `DatabaseConnection`) to fail with `NotRegistered` errors because it looked up `DatabaseConnection` in the user's scope where it was never registered.

This is the same class of scope-mismatch that #3038 fixed for deferred DI registrations, now applied to server-managed singletons like `DatabaseConnection`.

Fixes #3051

Related to: #3038, #3045, #2995

## How Was This Tested?

- Added 3 unit tests for `get_router_di_context()` using `TeardownGuard<CleanGlobalRouter>` fixture:
  - `returns_none_when_no_router_registered`
  - `returns_none_when_router_has_no_di_context`
  - `returns_context_when_router_has_di_context`
- `cargo check --workspace --all-features` passes
- `cargo nextest run -p reinhardt-urls --all-features` passes (3/3 new tests)
- `cargo make auto-fix` clean

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #3051 — Builtin runserver does not register DatabaseConnection in user-provided InjectionContext
- #3038 — AdminSite DI scope mismatch (fixed, same pattern)
- #3045 — ServerFnRequest DI injection (fixed, same pattern)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `admin` - Admin interface, admin panels

---

**Additional Context:**

The fix follows the established pattern: detect user-provided DI context → reuse its singleton scope → register server-managed singletons there. When no user context exists, behavior is identical to before (backwards compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)