### PR TITLE
docs(website): propagate #3060 auth model changes to tutorials and reference

### DIFF
--- a/website/content/docs/api/_index.md
+++ b/website/content/docs/api/_index.md
@@ -508,6 +508,31 @@ let auth = JwtAuth::new(secret_key);
 // Protect endpoints with IsAuthenticated
 ```
 
+**Database Models** (requires `database` feature):
+
+- `AuthPermission` — Database-backed permission model (`auth_permission` table).
+  Fields: `id` (UUID), `name`, `codename`, `app_label`.
+- `Group` — User group model (`auth_group` table) with conditional `#[model]` support.
+  Fields: `id` (UUID), `name`, `description`.
+
+**Group Management:**
+
+- `GroupManager` — In-memory group management with permission assignment.
+- `register_group_manager(Arc<GroupManager>)` — Register a global `GroupManager`.
+  Once registered, `PermissionsMixin::get_group_permissions()` automatically resolves
+  group permissions.
+- `get_group_manager()` — Retrieve the global `GroupManager`.
+
+**PermissionsMixin Integration:**
+
+- `user_permissions(&self) -> &[String]` — Direct user permissions
+- `groups(&self) -> &[String]` — User's group memberships
+- `get_group_permissions(&self) -> HashSet<String>` — Resolves permissions from groups
+  via global `GroupManager` (returns empty set if no manager registered)
+- `has_perm(&str) -> bool` — Check single permission (superuser always true)
+- `has_perms(&[&str]) -> bool` — Check multiple permissions (AND)
+- `has_module_perms(&str) -> bool` — Check app-level permissions
+
 **Documentation:**
 
 - [Module documentation](https://docs.rs/reinhardt-auth) (available after crates.io publish)

--- a/website/content/docs/feature-flags.md
+++ b/website/content/docs/feature-flags.md
@@ -236,10 +236,12 @@ reinhardt = {
 
 #### database
 
-Enables general database functionality.
+Enables general database functionality. Also enables database-backed models in
+`reinhardt-auth`: `AuthPermission` (permission model) and `Group` (group model
+with `#[model]` support).
 
 ```toml
-features = ["database"]  # Includes: ORM, migrations, contenttypes
+features = ["database"]  # Includes: ORM, migrations, contenttypes, auth models
 ```
 
 #### Database-Specific

--- a/website/content/docs/field-attributes.md
+++ b/website/content/docs/field-attributes.md
@@ -196,6 +196,38 @@ age: i32,
 
 **Supported DBMS**: All **SQL Output**: `CHECK (age >= 0 AND age <= 150)`
 
+### Model Processing Control
+
+#### `skip: bool`
+
+Completely excludes a field from model processing. The field is not included in
+type validation, metadata, registration, getter/setter generation, or constructor
+parameters. Skipped fields are initialized with `Default::default()`.
+
+Used by the `#[user]` macro for non-database cache fields (e.g., `Vec<String>`
+permissions) when combined with `#[model]`.
+
+```rust
+#[field(skip = true)]
+cached_data: Vec<String>,
+```
+
+**Supported DBMS**: All (meta-attribute) **SQL Output**: None — field is excluded from schema
+
+#### `skip_getter: bool`
+
+Skips getter and setter method generation for this field. The field still
+participates in model processing (type validation, metadata, constructor).
+
+Used by the `#[user]` macro to avoid conflicts with trait method signatures.
+
+```rust
+#[field(skip_getter = true)]
+password_hash: Option<String>,
+```
+
+**Supported DBMS**: All (meta-attribute) **SQL Output**: None
+
 ### Relations
 
 #### `foreign_key: Type or &str`
@@ -226,6 +258,73 @@ user_id: i32,
 ```
 
 **Supported DBMS**: All **SQL Output**: `ON DELETE CASCADE`
+
+#### Many-to-Many Relationships
+
+Use `ManyToManyField<Source, Target>` with `#[rel(many_to_many, ...)]` for
+bidirectional N:N relationships. An intermediate table is auto-generated.
+
+```rust
+use reinhardt::db::associations::ManyToManyField;
+
+#[model(app_label = "blog", table_name = "blog_article")]
+pub struct Article {
+    #[field(primary_key = true)]
+    pub id: i64,
+
+    #[serde(skip, default)]
+    #[rel(many_to_many, related_name = "articles")]
+    pub tags: ManyToManyField<Article, Tag>,
+}
+```
+
+**Required attributes:**
+- `related_name` — reverse accessor name on the target model
+
+**Intermediate table:** Named `{app_label}_{source_model}_{field_name}`
+(e.g., `blog_article_tags`), containing `{source}_id` and `{target}_id` columns.
+
+**Supported DBMS**: All **SQL Output**: Creates intermediate table with foreign keys
+
+### PostgreSQL-Specific Types
+
+#### `Vec<T>` → ArrayField
+
+`Vec<T>` maps to PostgreSQL ARRAY columns. The element type is inferred automatically:
+
+```rust
+// Inferred: TEXT[] array
+pub tags: Vec<String>,
+
+// Inferred: INTEGER[] array
+pub scores: Vec<i32>,
+
+// Explicit base type override
+#[field(array_base_type = "VARCHAR(50)")]
+pub labels: Vec<String>,
+```
+
+**Supported DBMS**: PostgreSQL only **SQL Output**: `TEXT[]`, `INTEGER[]`, etc.
+
+#### `Value` → JsonField (JSONB)
+
+`serde_json::Value` maps to PostgreSQL JSONB columns:
+
+```rust
+pub metadata: serde_json::Value,
+```
+
+**Supported DBMS**: PostgreSQL only **SQL Output**: `JSONB`
+
+#### `HashMap` → HStoreField
+
+`HashMap<String, String>` maps to PostgreSQL HStore columns:
+
+```rust
+pub attributes: std::collections::HashMap<String, String>,
+```
+
+**Supported DBMS**: PostgreSQL only (requires hstore extension) **SQL Output**: `HSTORE`
 
 ### Other
 

--- a/website/content/quickstart/tutorials/basis/2-models-and-database.md
+++ b/website/content/quickstart/tutorials/basis/2-models-and-database.md
@@ -239,6 +239,61 @@ The `#[field(...)]` and `#[rel(...)]` attributes provide metadata for the ORM:
   - **⚠️ IMPORTANT**: `related_name` is REQUIRED for `#[rel(foreign_key)]`
   - It defines the name for reverse access from the related model
   - Example: `related_name = "choices"` allows `Question.choices_accessor()`
+- `#[rel(many_to_many, related_name = "name")]` - Defines a many-to-many relationship
+  - Creates an intermediate (join) table automatically
+  - Example: `related_name = "followers"` allows reverse access from the target model
+
+### Many-to-Many Relationships
+
+For relationships where both sides can have multiple associated records, use
+`ManyToManyField<Source, Target>`:
+
+```rust
+use reinhardt::prelude::*;
+use reinhardt::db::associations::ManyToManyField;
+
+#[model(app_label = "blog", table_name = "blog_article")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Article {
+    #[field(primary_key = true)]
+    pub id: i64,
+
+    #[field(max_length = 200)]
+    pub title: String,
+
+    // Many-to-many: an article can have multiple tags, a tag can belong to multiple articles
+    #[serde(skip, default)]
+    #[rel(many_to_many, related_name = "articles")]
+    pub tags: ManyToManyField<Article, Tag>,
+}
+
+#[model(app_label = "blog", table_name = "blog_tag")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tag {
+    #[field(primary_key = true)]
+    pub id: i64,
+
+    #[field(max_length = 50, unique = true)]
+    pub name: String,
+}
+```
+
+This automatically creates an intermediate table `blog_article_tags` with
+`article_id` and `tag_id` columns. Access related objects through the accessor:
+
+```rust
+// Get all tags for an article
+let tags = article.tags_accessor(&db).all().await?;
+
+// Add a tag to an article
+article.tags_accessor(&db).add(&tag).await?;
+
+// Remove a tag
+article.tags_accessor(&db).remove(&tag).await?;
+
+// Count tags
+let count = article.tags_accessor(&db).count().await?;
+```
 
 ## Model Macro Benefits
 

--- a/website/content/quickstart/tutorials/rest/4-authentication-and-permissions.md
+++ b/website/content/quickstart/tutorials/rest/4-authentication-and-permissions.md
@@ -283,6 +283,100 @@ let handler_with_custom = ModelViewSetHandler::<Snippet>::new()
     .add_permission(Arc::new(IsOwnerOrReadOnly));
 ```
 
+## Group-Based Permissions
+
+Reinhardt supports group-based permission management through `GroupManager`.
+Users can be assigned to groups, and each group can have its own set of permissions.
+
+### Setting Up GroupManager
+
+Register a global `GroupManager` at application startup:
+
+```rust
+use reinhardt_auth::{GroupManager, register_group_manager};
+use reinhardt_auth::group_management::CreateGroupData;
+use std::sync::Arc;
+
+async fn setup_groups() {
+    let mut manager = GroupManager::new();
+
+    // Create groups
+    let editors = manager.create_group(CreateGroupData {
+        name: "editors".to_string(),
+        description: Some("Content editors".to_string()),
+    }).await.unwrap();
+
+    // Assign permissions to groups
+    manager.add_group_permission(
+        &editors.id.to_string(), "blog.add_post"
+    ).await.unwrap();
+    manager.add_group_permission(
+        &editors.id.to_string(), "blog.edit_post"
+    ).await.unwrap();
+
+    // Register globally — PermissionsMixin will use this automatically
+    register_group_manager(Arc::new(manager));
+}
+```
+
+### How Group Permissions Work
+
+Once a `GroupManager` is registered, `PermissionsMixin::get_group_permissions()`
+automatically resolves permissions for the user's groups:
+
+```rust
+use reinhardt_auth::PermissionsMixin;
+
+// User belongs to "editors" group
+let user = get_current_user().await;
+
+// Automatically includes group permissions
+assert!(user.has_perm("blog.add_post"));    // from "editors" group
+assert!(user.has_perm("blog.edit_post"));   // from "editors" group
+
+// get_all_permissions() merges direct + group permissions
+let all = user.get_all_permissions();
+```
+
+The resolution flow:
+1. `has_perm()` calls `get_all_permissions()`
+2. `get_all_permissions()` merges `get_user_permissions()` (direct) and `get_group_permissions()` (from groups)
+3. `get_group_permissions()` looks up the global `GroupManager` and resolves permissions for each group name
+4. Superusers bypass all checks and always return `true`
+
+## User Model with Database Integration
+
+When combining `#[user]` with `#[model]`, the user macro automatically injects
+`ManyToManyField` relationships for structured database queries:
+
+```rust
+use reinhardt::prelude::*;
+use reinhardt_auth::Argon2Hasher;
+
+// What you write:
+#[user(hasher = Argon2Hasher, username_field = "username", full = true)]
+#[model(app_label = "auth", table_name = "auth_user")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct User {
+    #[field(primary_key = true)]
+    pub id: Uuid,
+    #[field(max_length = 150, unique = true)]
+    pub username: String,
+    // ... other fields ...
+    pub user_permissions: Vec<String>,  // PermissionsMixin cache
+    pub groups: Vec<String>,            // PermissionsMixin cache
+}
+
+// The macro automatically:
+// 1. Marks Vec<String> fields with #[field(skip = true)] (excluded from DB)
+// 2. Injects ManyToManyField<User, AuthPermission> for permission relationships
+// 3. Injects ManyToManyField<User, Group> for group relationships
+// 4. Generates BaseUser, FullUser, PermissionsMixin, AuthIdentity impls
+```
+
+The `Vec<String>` fields serve as in-memory caches for `PermissionsMixin`,
+while `ManyToManyField` relationships handle structured ORM queries.
+
 ## Summary
 
 In this tutorial, you learned:
@@ -294,5 +388,7 @@ In this tutorial, you learned:
 5. Object-level permissions
 6. Combining multiple permissions
 7. Applying permissions to ViewSets
+8. Group-based permissions with `GroupManager`
+9. Database-backed user models with `#[user]` + `#[model]`
 
 Next tutorial: [Tutorial 5: Relationships and Hyperlinked APIs](../5-relationships-and-hyperlinked-apis/)


### PR DESCRIPTION
## Summary

- Add GroupManager integration and `#[user]+#[model]` sections to REST Tutorial 4
- Add `ManyToManyField` relationship examples to Basis Tutorial 2
- Add `#[field(skip)]`, `ManyToManyField`, `ArrayField`/`JsonField`/`HStoreField` to Field Attributes reference
- Add `AuthPermission`, `Group` model, `GroupManager` API, `PermissionsMixin` to API reference
- Note `database` feature enables auth models in Feature Flags

## Type of Change

- [x] Documentation update

## Motivation and Context

Propagates the changes from PR #3070 (fix #3060) to the website documentation. The new features (`#[field(skip)]`, `AuthPermission` model, `Group` model, `GroupManager` integration, `ManyToManyField` support) need corresponding documentation in tutorials and reference pages.

Refs #3060
Related to: #3070

## How Was This Tested?

- `zola build` passes with no errors (32 pages, 9 sections)
- All code examples verified for syntax correctness

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label
- [x] `documentation` - Documentation update

### Scope Label
- [x] `auth` - Authentication, authorization, sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)