### PR TITLE
fix(auth): use get_singleton instead of resolve for DatabaseConnection in DI

### DIFF
--- a/crates/reinhardt-auth/src/auth_user.rs
+++ b/crates/reinhardt-auth/src/auth_user.rs
@@ -83,13 +83,15 @@ where
 
 		let model_pk = <U as Model>::PrimaryKey::from(user_pk);
 
-		// Resolve DatabaseConnection from DI
-		let db: Arc<DatabaseConnection> =
-			ctx.resolve::<DatabaseConnection>().await.map_err(|e| {
-				::tracing::warn!(
-					error = ?e,
-					"AuthUser: DatabaseConnection not available for user resolution"
-				);
+		// Resolve DatabaseConnection from DI (singleton-first, request-scope fallback)
+		// Uses get_singleton/get_request directly instead of ctx.resolve() because
+		// DatabaseConnection is pre-seeded into the singleton scope at server startup,
+		// not registered in the global DependencyRegistry.
+		let db: Arc<DatabaseConnection> = ctx
+			.get_singleton::<DatabaseConnection>()
+			.or_else(|| ctx.get_request::<DatabaseConnection>())
+			.ok_or_else(|| {
+				::tracing::warn!("AuthUser: DatabaseConnection not available for user resolution");
 				DiError::Internal {
 					message: "AuthUser: DatabaseConnection not registered in DI context"
 						.to_string(),

--- a/crates/reinhardt-auth/src/current_user.rs
+++ b/crates/reinhardt-auth/src/current_user.rs
@@ -189,12 +189,18 @@ where
 		let model_pk: <U as Model>::PrimaryKey = base_pk.into();
 
 		// 5. Get DatabaseConnection from DI context
+		// Resolve DatabaseConnection from DI (singleton-first, request-scope fallback)
+		// Uses get_singleton/get_request directly instead of ctx.resolve() because
+		// DatabaseConnection is pre-seeded into the singleton scope at server startup,
+		// not registered in the global DependencyRegistry.
 		#[cfg(feature = "params")]
-		let db: Arc<DatabaseConnection> = match ctx.resolve::<DatabaseConnection>().await {
-			Ok(conn) => conn,
-			Err(e) => {
+		let db: Arc<DatabaseConnection> = match ctx
+			.get_singleton::<DatabaseConnection>()
+			.or_else(|| ctx.get_request::<DatabaseConnection>())
+		{
+			Some(conn) => conn,
+			None => {
 				::tracing::warn!(
-					error = %e,
 					"DatabaseConnection not registered in DI context. \
 					 CurrentUser will be anonymous. \
 					 Hint: Register DatabaseConnection as a singleton in InjectionContext."

--- a/tests/integration/tests/admin/server_fn_helpers.rs
+++ b/tests/integration/tests/admin/server_fn_helpers.rs
@@ -294,29 +294,8 @@ pub async fn e2e_router_context(
 	// Build admin router with deferred DI
 	let (admin_router, admin_di) = admin_routes_with_di_deferred(site);
 
-	// Register DatabaseConnection in the global DI registry so ctx.resolve() works.
-	// AuthUser::inject() calls ctx.resolve::<DatabaseConnection>() which requires
-	// both a global registry scope entry AND a value in the singleton cache.
-	{
-		use reinhardt_di::registry::{DependencyScope, global_registry};
-		let registry = global_registry();
-		registry.register_async::<DatabaseConnection, _, _>(
-			DependencyScope::Singleton,
-			|ctx| async move {
-				// On cache miss, try to get from singleton scope (pre-seeded below)
-				ctx.get_singleton::<DatabaseConnection>()
-					.map(|arc| (*arc).clone())
-					.ok_or_else(|| {
-						reinhardt_di::DiError::NotFound(
-							"DatabaseConnection not in singleton cache".to_string(),
-						)
-					})
-			},
-		);
-	}
-
 	// Build the complete router using UnifiedRouter API.
-	// Pre-seed singleton scope with DatabaseConnection so resolve() finds it.
+	// Pre-seed singleton scope with DatabaseConnection so get_singleton() finds it.
 	let singleton = Arc::new(SingletonScope::new());
 	singleton.set_arc(db_conn);
 	let di_ctx = Arc::new(InjectionContext::builder(singleton).build());


### PR DESCRIPTION
## Summary

- Fix `AuthUser::inject()` and `CurrentUser::inject()` to use `ctx.get_singleton()` instead of `ctx.resolve()` for `DatabaseConnection`
- Remove the test workaround that manually registered `DatabaseConnection` in the global DI registry

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Admin server functions (`get_list`, `create_record`, etc.) fail with:
```
Dependency injection failed for AuthUser<AdminDefaultUser>: Internal { message: "AuthUser: DatabaseConnection not registered in DI context" }
```

**Root cause**: `ctx.resolve::<DatabaseConnection>()` requires the type to be registered in the global `DependencyRegistry`, but `DatabaseConnection` is only pre-seeded into the singleton scope via `singleton_scope.set()` at server startup. Other types (`AdminSite`, `AdminDatabase`, `DatabaseConnection::inject()` itself) correctly use `ctx.get_singleton()` which bypasses the global registry.

Fixes #3079

## How Was This Tested?

- `cargo nextest run --package reinhardt-auth --all-features` — 1001 tests passed
- `cargo nextest run --package reinhardt-integration-tests --all-features -E 'test(admin)'` — 167 tests passed
- `cargo make fmt-check` — passed
- `cargo check --package reinhardt-auth --all-features` — passed
- `cargo check --tests --package reinhardt-integration-tests --all-features` — passed

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `auth` - Authentication, authorization, sessions
- [x] `admin` - Admin interface, admin panels

---

**Additional Context:**

The fix uses `get_singleton().or_else(|| get_request())` pattern, matching `DatabaseConnection::inject()` implementation which checks both scopes as fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)