### PR TITLE
fix(admin): accept any #[user] type for admin authentication

### DIFF
--- a/crates/reinhardt-admin/src/core/router.rs
+++ b/crates/reinhardt-admin/src/core/router.rs
@@ -209,10 +209,14 @@ pub fn admin_routes_with_di(site: Arc<AdminSite>, singleton: &SingletonScope) ->
 /// Admin router builder with deferred DI registration
 ///
 /// Builds a `ServerRouter` from an `AdminSite` with all CRUD endpoints,
-/// and returns a [`DiRegistrationList`] containing the `AdminSite`
-/// registration. The list should be attached to the [`UnifiedRouter`] via
-/// [`with_di_registrations`], which ensures it reaches the server's
-/// singleton scope during startup.
+/// and returns a [`DiRegistrationList`] containing the `AdminSite` and
+/// `AdminUserLoader` registrations. The list should be attached to the
+/// [`UnifiedRouter`] via [`with_di_registrations`], which ensures it reaches
+/// the server's singleton scope during startup.
+///
+/// If a custom user type was configured via [`AdminSite::set_user_type`],
+/// that type is used for admin authentication. Otherwise,
+/// [`AdminDefaultUser`] (table `auth_user`) is registered as a fallback.
 ///
 /// `AdminDatabase` is **not** registered here; it is lazily constructed
 /// from `DatabaseConnection` at first request via its `Injectable` impl.
@@ -224,6 +228,7 @@ pub fn admin_routes_with_di(site: Arc<AdminSite>, singleton: &SingletonScope) ->
 /// use reinhardt_urls::routers::UnifiedRouter;
 /// use std::sync::Arc;
 ///
+/// // Default: uses AdminDefaultUser (table "auth_user")
 /// let site = Arc::new(AdminSite::new("My Admin"));
 /// let (admin_router, admin_di) = admin_routes_with_di_deferred(site);
 ///
@@ -232,6 +237,16 @@ pub fn admin_routes_with_di(site: Arc<AdminSite>, singleton: &SingletonScope) ->
 ///     .with_di_registrations(admin_di);
 /// ```
 ///
+/// ```rust,ignore
+/// // Custom user type
+/// let mut site = AdminSite::new("My Admin");
+/// site.set_user_type::<MyCustomUser>();
+/// let site = Arc::new(site);
+/// let (admin_router, admin_di) = admin_routes_with_di_deferred(site);
+/// ```
+///
+/// [`AdminSite::set_user_type`]: AdminSite::set_user_type
+/// [`AdminDefaultUser`]: crate::server::user::AdminDefaultUser
 /// [`DiRegistrationList`]: reinhardt_di::DiRegistrationList
 /// [`UnifiedRouter`]: reinhardt_urls::routers::UnifiedRouter
 /// [`with_di_registrations`]: reinhardt_urls::routers::UnifiedRouter::with_di_registrations
@@ -239,6 +254,17 @@ pub fn admin_routes_with_di_deferred(
 	site: Arc<AdminSite>,
 ) -> (ServerRouter, reinhardt_di::DiRegistrationList) {
 	let mut registrations = reinhardt_di::DiRegistrationList::new();
+
+	// Register the user loader for admin authentication.
+	// If the site has a custom user type (set via set_user_type::<U>()),
+	// use that; otherwise fall back to AdminDefaultUser.
+	let loader = site.user_loader().unwrap_or_else(|| {
+		Arc::new(crate::server::admin_auth::create_admin_user_loader::<
+			crate::server::user::AdminDefaultUser,
+		>())
+	});
+	registrations.register_arc(loader);
+
 	registrations.register_arc(site);
 	(build_admin_router(), registrations)
 }

--- a/crates/reinhardt-admin/src/core/site.rs
+++ b/crates/reinhardt-admin/src/core/site.rs
@@ -4,6 +4,7 @@
 //! routing, authentication, and rendering functionality.
 
 use crate::core::{AdminRouter, ModelAdmin};
+use crate::server::admin_auth::AdminUserLoader;
 use crate::types::{AdminError, AdminResult};
 use async_trait::async_trait;
 use dashmap::DashMap;
@@ -41,6 +42,13 @@ pub struct AdminSite {
 
 	/// Favicon data (PNG, ICO, etc.)
 	favicon_data: Arc<RwLock<Option<Vec<u8>>>>,
+
+	/// Type-erased user loader for admin authentication.
+	///
+	/// When `None`, [`AdminDefaultUser`] is used as a fallback.
+	///
+	/// [`AdminDefaultUser`]: crate::server::user::AdminDefaultUser
+	user_loader: Option<Arc<AdminUserLoader>>,
 }
 
 /// Configuration for the admin site
@@ -95,6 +103,7 @@ impl AdminSite {
 			registry: Arc::new(DashMap::new()),
 			config: Arc::new(RwLock::new(AdminSiteConfig::default())),
 			favicon_data: Arc::new(RwLock::new(None)),
+			user_loader: None,
 		}
 	}
 
@@ -179,6 +188,52 @@ impl AdminSite {
 	/// Get the current configuration
 	pub fn config(&self) -> AdminSiteConfig {
 		self.config.read().clone()
+	}
+
+	/// Set the user type for admin authentication.
+	///
+	/// This determines which database table and model is used to load the
+	/// authenticated user in admin server functions. The type `U` must
+	/// implement both auth traits (`BaseUser`, `FullUser`) and the ORM
+	/// trait (`Model`), which is guaranteed for any type annotated with
+	/// both `#[model(...)]` and `#[user(full = true)]`.
+	///
+	/// If this method is not called, [`AdminDefaultUser`] (table `auth_user`)
+	/// is used as the default.
+	///
+	/// # Examples
+	///
+	/// ```rust,ignore
+	/// use reinhardt_admin::core::AdminSite;
+	///
+	/// let mut site = AdminSite::new("My Admin");
+	/// site.set_user_type::<MyCustomUser>();
+	/// ```
+	///
+	/// [`AdminDefaultUser`]: crate::server::user::AdminDefaultUser
+	pub fn set_user_type<U>(&mut self) -> &mut Self
+	where
+		U: reinhardt_auth::BaseUser
+			+ reinhardt_auth::FullUser
+			+ reinhardt_db::orm::Model
+			+ Clone
+			+ Send
+			+ Sync
+			+ 'static,
+		<U as reinhardt_auth::BaseUser>::PrimaryKey: std::str::FromStr + ToString + Send + Sync,
+		<<U as reinhardt_auth::BaseUser>::PrimaryKey as std::str::FromStr>::Err: std::fmt::Debug,
+		<U as reinhardt_db::orm::Model>::PrimaryKey:
+			From<<U as reinhardt_auth::BaseUser>::PrimaryKey>,
+	{
+		self.user_loader = Some(Arc::new(
+			crate::server::admin_auth::create_admin_user_loader::<U>(),
+		));
+		self
+	}
+
+	/// Returns the registered user loader, if any.
+	pub(crate) fn user_loader(&self) -> Option<Arc<AdminUserLoader>> {
+		self.user_loader.clone()
 	}
 
 	/// Register a model with the admin site

--- a/crates/reinhardt-admin/src/server.rs
+++ b/crates/reinhardt-admin/src/server.rs
@@ -34,6 +34,7 @@
 
 // The `#[server_fn]` proc macro generates internal modules that cannot have doc comments.
 // Allow missing docs for all server function submodules.
+pub(crate) mod admin_auth;
 #[allow(missing_docs)]
 pub mod create;
 #[allow(missing_docs)]
@@ -69,6 +70,7 @@ pub mod type_inference;
 pub mod validation;
 
 // Re-exports
+pub use admin_auth::AdminAuthenticatedUser;
 pub use create::*;
 pub use dashboard::*;
 pub use delete::*;

--- a/crates/reinhardt-admin/src/server/admin_auth.rs
+++ b/crates/reinhardt-admin/src/server/admin_auth.rs
@@ -1,0 +1,331 @@
+//! Type-erased admin user authentication.
+//!
+//! Provides [`AdminAuthenticatedUser`], a type-erased user extractor for admin
+//! server functions. Instead of hardcoding a specific user model, this module
+//! uses a registered loader function to query whichever concrete user type the
+//! project has configured via [`AdminSite::set_user_type`].
+//!
+//! [`AdminSite::set_user_type`]: crate::core::AdminSite::set_user_type
+
+use crate::core::AdminUser;
+use async_trait::async_trait;
+use reinhardt_auth::{BaseUser, FullUser};
+use reinhardt_db::orm::{DatabaseConnection, Model};
+use reinhardt_di::{DiError, DiResult, Injectable, InjectionContext};
+use reinhardt_http::AuthState;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Type-erased async loader that queries a user from the database and returns
+/// a boxed [`AdminUser`] trait object.
+///
+/// The closure captures the concrete user type `U` at registration time via
+/// [`create_admin_user_loader`], but the returned signature is fully erased.
+pub(crate) type AdminUserLoaderFn = Arc<
+	dyn Fn(
+			String,
+			Arc<DatabaseConnection>,
+		) -> Pin<Box<dyn Future<Output = Result<Arc<dyn AdminUser>, DiError>> + Send>>
+		+ Send
+		+ Sync,
+>;
+
+/// Newtype wrapper around [`AdminUserLoaderFn`] for DI registration.
+///
+/// Stored as a singleton in the DI scope so that [`AdminAuthenticatedUser`]
+/// can retrieve it during injection.
+#[derive(Clone)]
+pub(crate) struct AdminUserLoader(pub(crate) AdminUserLoaderFn);
+
+/// Type-erased authenticated admin user.
+///
+/// This replaces the hardcoded `AuthUser<AdminDefaultUser>` in admin server
+/// functions. It loads the user from the database using whichever concrete
+/// user type was registered via [`AdminSite::set_user_type`]. If no custom
+/// type was registered, [`AdminDefaultUser`] is used as a fallback.
+///
+/// The inner `Arc<dyn AdminUser>` provides access to authentication and
+/// permission methods without exposing the concrete user type. `Arc` is
+/// used instead of `Box` because the `#[server_fn]` macro requires
+/// injected types to implement `Clone`.
+///
+/// # Usage in server functions
+///
+/// ```rust,ignore
+/// use crate::server::admin_auth::AdminAuthenticatedUser;
+///
+/// #[server_fn]
+/// pub async fn my_admin_endpoint(
+///     #[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
+/// ) -> Result<(), ServerFnError> {
+///     // user is Arc<dyn AdminUser>
+///     if user.is_superuser() {
+///         // ...
+///     }
+///     Ok(())
+/// }
+/// ```
+///
+/// [`AdminSite::set_user_type`]: crate::core::AdminSite::set_user_type
+/// [`AdminDefaultUser`]: crate::server::user::AdminDefaultUser
+#[derive(Clone)]
+pub struct AdminAuthenticatedUser(pub Arc<dyn AdminUser>);
+
+impl std::fmt::Debug for AdminAuthenticatedUser {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("AdminAuthenticatedUser")
+			.field("username", &self.0.get_username())
+			.finish()
+	}
+}
+
+#[async_trait]
+impl Injectable for AdminAuthenticatedUser {
+	async fn inject(ctx: &InjectionContext) -> DiResult<Self> {
+		// Get HTTP request from context
+		let request = ctx.get_http_request().ok_or_else(|| {
+			DiError::NotFound(
+				"AdminAuthenticatedUser: No HTTP request available in InjectionContext".to_string(),
+			)
+		})?;
+
+		// Get AuthState from request extensions
+		let auth_state: AuthState = request.extensions.get().ok_or_else(|| {
+			DiError::NotFound(
+				"AdminAuthenticatedUser: No AuthState found in request extensions".to_string(),
+			)
+		})?;
+
+		if !auth_state.is_authenticated() {
+			return Err(DiError::NotFound(
+				"AdminAuthenticatedUser: User is not authenticated".to_string(),
+			));
+		}
+
+		let user_id = auth_state.user_id().to_string();
+
+		// Get the type-erased loader from DI singleton scope (check early to
+		// provide a clear error message if admin routes were not set up)
+		let loader: Arc<AdminUserLoader> =
+			ctx.get_singleton::<AdminUserLoader>()
+				.ok_or_else(|| DiError::NotRegistered {
+					type_name: "AdminUserLoader".into(),
+					hint: "Call AdminSite::set_user_type::<U>() before building admin routes, \
+					       or use the default by calling admin_routes_with_di_deferred() which \
+					       registers AdminDefaultUser as a fallback."
+						.into(),
+				})?;
+
+		// Resolve DatabaseConnection from DI (singleton-first, request-scope fallback)
+		let db: Arc<DatabaseConnection> = ctx
+			.get_singleton::<DatabaseConnection>()
+			.or_else(|| ctx.get_request::<DatabaseConnection>())
+			.ok_or_else(|| {
+				::tracing::warn!(
+					"AdminAuthenticatedUser: DatabaseConnection not available for user resolution"
+				);
+				DiError::Internal {
+					message:
+						"AdminAuthenticatedUser: DatabaseConnection not registered in DI context"
+							.to_string(),
+				}
+			})?;
+
+		// Call the type-erased loader to query the user from the database
+		let user = (loader.0)(user_id, db).await?;
+
+		Ok(AdminAuthenticatedUser(user))
+	}
+}
+
+/// Creates an [`AdminUserLoader`] that queries user type `U` from the database.
+///
+/// The returned loader captures the concrete type `U` in a closure, replicating
+/// the same database query logic as [`AuthUser<U>::inject`] but returning a
+/// type-erased `Arc<dyn AdminUser>`.
+///
+/// # Type requirements
+///
+/// `U` must implement both the auth traits (`BaseUser`, `FullUser`) and the
+/// ORM trait (`Model`). This is guaranteed for any type annotated with both
+/// `#[model]` and `#[user(full = true)]`.
+///
+/// [`AuthUser<U>::inject`]: reinhardt_auth::AuthUser
+pub(crate) fn create_admin_user_loader<U>() -> AdminUserLoader
+where
+	U: BaseUser + FullUser + Model + Clone + Send + Sync + 'static,
+	<U as BaseUser>::PrimaryKey: std::str::FromStr + ToString + Send + Sync,
+	<<U as BaseUser>::PrimaryKey as std::str::FromStr>::Err: std::fmt::Debug,
+	<U as Model>::PrimaryKey: From<<U as BaseUser>::PrimaryKey>,
+{
+	let loader: AdminUserLoaderFn = Arc::new(move |user_id, db| {
+		Box::pin(async move {
+			// Parse user_id — NO fallback to nil UUID
+			let pk = user_id
+				.parse::<<U as BaseUser>::PrimaryKey>()
+				.map_err(|e| {
+					::tracing::warn!(
+						user_id = %user_id,
+						error = ?e,
+						"AdminUserLoader: failed to parse user_id"
+					);
+					DiError::NotFound("AdminUserLoader: Invalid user_id format".to_string())
+				})?;
+
+			let model_pk = <U as Model>::PrimaryKey::from(pk);
+
+			// Query user from database
+			let user = U::objects()
+				.get(model_pk)
+				.first_with_db(&db)
+				.await
+				.map_err(|e| {
+					::tracing::warn!(error = ?e, "AdminUserLoader: Database query failed");
+					DiError::Internal {
+						message: "AdminUserLoader: Database query failed".to_string(),
+					}
+				})?
+				.ok_or_else(|| {
+					::tracing::warn!(
+						user_id = %user_id,
+						"AdminUserLoader: User not found in database"
+					);
+					DiError::NotFound("AdminUserLoader: User not found".to_string())
+				})?;
+
+			Ok(Arc::new(user) as Arc<dyn AdminUser>)
+		})
+	});
+
+	AdminUserLoader(loader)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use reinhardt_di::SingletonScope;
+	use rstest::rstest;
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_inject_returns_error_when_no_http_request() {
+		// Arrange
+		let singleton = Arc::new(SingletonScope::new());
+		let ctx = InjectionContext::builder(singleton).build();
+
+		// Act
+		let result = AdminAuthenticatedUser::inject(&ctx).await;
+
+		// Assert
+		assert!(result.is_err());
+		let err = result.unwrap_err();
+		assert!(
+			err.to_string().contains("No HTTP request"),
+			"Expected 'No HTTP request' error, got: {}",
+			err
+		);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_inject_returns_error_when_no_auth_state() {
+		// Arrange
+		let singleton = Arc::new(SingletonScope::new());
+		let request = reinhardt_http::Request::builder()
+			.uri("/admin/test")
+			.build()
+			.expect("Failed to build test request");
+		let ctx = InjectionContext::builder(singleton)
+			.with_request(request)
+			.build();
+
+		// Act
+		let result = AdminAuthenticatedUser::inject(&ctx).await;
+
+		// Assert
+		assert!(result.is_err());
+		let err = result.unwrap_err();
+		assert!(
+			err.to_string().contains("No AuthState"),
+			"Expected 'No AuthState' error, got: {}",
+			err
+		);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_inject_returns_error_when_not_authenticated() {
+		// Arrange
+		let singleton = Arc::new(SingletonScope::new());
+		let request = reinhardt_http::Request::builder()
+			.uri("/admin/test")
+			.build()
+			.expect("Failed to build test request");
+		// Insert unauthenticated AuthState
+		request.extensions.insert(AuthState::anonymous());
+		let ctx = InjectionContext::builder(singleton)
+			.with_request(request)
+			.build();
+
+		// Act
+		let result = AdminAuthenticatedUser::inject(&ctx).await;
+
+		// Assert
+		assert!(result.is_err());
+		let err = result.unwrap_err();
+		assert!(
+			err.to_string().contains("not authenticated"),
+			"Expected 'not authenticated' error, got: {}",
+			err
+		);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_inject_returns_error_when_no_loader_registered() {
+		// Arrange
+		let singleton = Arc::new(SingletonScope::new());
+		let request = reinhardt_http::Request::builder()
+			.uri("/admin/test")
+			.build()
+			.expect("Failed to build test request");
+		request
+			.extensions
+			.insert(AuthState::authenticated("user-123", true, true));
+		let ctx = InjectionContext::builder(singleton)
+			.with_request(request)
+			.build();
+
+		// Act
+		let result = AdminAuthenticatedUser::inject(&ctx).await;
+
+		// Assert
+		assert!(result.is_err());
+		let err = result.unwrap_err();
+		assert!(
+			err.to_string().contains("AdminUserLoader"),
+			"Expected 'AdminUserLoader' error, got: {}",
+			err
+		);
+	}
+
+	#[rstest]
+	fn test_admin_user_loader_can_be_stored_in_singleton_scope() {
+		// Arrange
+		let singleton = SingletonScope::new();
+		let loader = AdminUserLoader(Arc::new(|_user_id, _db| {
+			Box::pin(async { Err(DiError::NotFound("test loader".to_string())) })
+		}));
+
+		// Act
+		singleton.set_arc(Arc::new(loader));
+
+		// Assert
+		let retrieved = singleton.get::<AdminUserLoader>();
+		assert!(
+			retrieved.is_some(),
+			"AdminUserLoader should be retrievable from singleton scope"
+		);
+	}
+}

--- a/crates/reinhardt-admin/src/server/create.rs
+++ b/crates/reinhardt-admin/src/server/create.rs
@@ -2,10 +2,9 @@
 //!
 //! Provides create operations for admin models.
 
-use super::user::AdminDefaultUser;
+use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite};
 use crate::types::{MutationRequest, MutationResponse};
-use reinhardt_auth::AuthUser;
 use reinhardt_pages::server_fn::{ServerFnError, ServerFnRequest, server_fn};
 use std::sync::Arc;
 
@@ -55,7 +54,7 @@ pub async fn create_record(
 	#[inject] site: Arc<AdminSite>,
 	#[inject] db: Arc<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
-	#[inject] AuthUser(user): AuthUser<AdminDefaultUser>,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<MutationResponse, ServerFnError> {
 	// CSRF token validation (double-submit cookie pattern)
 	require_csrf_token(&request.csrf_token, &http_request.inner().headers)?;
@@ -63,12 +62,8 @@ pub async fn create_record(
 	// Authentication and authorization check
 	let auth = AdminAuth::from_request(&http_request);
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
-	auth.require_model_permission(
-		model_admin.as_ref(),
-		&user as &dyn crate::core::AdminUser,
-		ModelPermission::Add,
-	)
-	.await?;
+	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Add)
+		.await?;
 	let table_name = model_admin.table_name();
 	let pk_field = model_admin.pk_field();
 

--- a/crates/reinhardt-admin/src/server/delete.rs
+++ b/crates/reinhardt-admin/src/server/delete.rs
@@ -2,12 +2,11 @@
 //!
 //! Provides delete operations for admin models (single and bulk).
 
-use super::user::AdminDefaultUser;
+use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{
 	AdminDatabase, AdminRecord, AdminSite, BulkDeleteRequest, BulkDeleteResponse,
 };
 use crate::types::MutationResponse;
-use reinhardt_auth::AuthUser;
 use reinhardt_pages::server_fn::{ServerFnError, ServerFnRequest, server_fn};
 use std::sync::Arc;
 
@@ -51,7 +50,7 @@ pub async fn delete_record(
 	#[inject] site: Arc<AdminSite>,
 	#[inject] db: Arc<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
-	#[inject] AuthUser(user): AuthUser<AdminDefaultUser>,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<MutationResponse, ServerFnError> {
 	// CSRF token validation (double-submit cookie pattern)
 	require_csrf_token(&csrf_token, &http_request.inner().headers)?;
@@ -59,12 +58,8 @@ pub async fn delete_record(
 	// Authentication and authorization check
 	let auth = AdminAuth::from_request(&http_request);
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
-	auth.require_model_permission(
-		model_admin.as_ref(),
-		&user as &dyn crate::core::AdminUser,
-		ModelPermission::Delete,
-	)
-	.await?;
+	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Delete)
+		.await?;
 
 	let table_name = model_admin.table_name();
 	let pk_field = model_admin.pk_field();
@@ -140,7 +135,7 @@ pub async fn bulk_delete_records(
 	#[inject] site: Arc<AdminSite>,
 	#[inject] db: Arc<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
-	#[inject] AuthUser(user): AuthUser<AdminDefaultUser>,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<BulkDeleteResponse, ServerFnError> {
 	// CSRF token validation (double-submit cookie pattern)
 	require_csrf_token(&request.csrf_token, &http_request.inner().headers)?;
@@ -148,12 +143,8 @@ pub async fn bulk_delete_records(
 	// Authentication and authorization check
 	let auth = AdminAuth::from_request(&http_request);
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
-	auth.require_model_permission(
-		model_admin.as_ref(),
-		&user as &dyn crate::core::AdminUser,
-		ModelPermission::Delete,
-	)
-	.await?;
+	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Delete)
+		.await?;
 
 	let table_name = model_admin.table_name();
 	let pk_field = model_admin.pk_field();

--- a/crates/reinhardt-admin/src/server/detail.rs
+++ b/crates/reinhardt-admin/src/server/detail.rs
@@ -2,9 +2,8 @@
 //!
 //! Provides detail view operations for admin models.
 
-use super::user::AdminDefaultUser;
+use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, DetailResponse};
-use reinhardt_auth::AuthUser;
 use reinhardt_pages::server_fn::{ServerFnError, ServerFnRequest, server_fn};
 use std::sync::Arc;
 
@@ -41,17 +40,13 @@ pub async fn get_detail(
 	#[inject] site: Arc<AdminSite>,
 	#[inject] db: Arc<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
-	#[inject] AuthUser(user): AuthUser<AdminDefaultUser>,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<DetailResponse, ServerFnError> {
 	// Authentication and authorization check
 	let auth = AdminAuth::from_request(&http_request);
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
-	auth.require_model_permission(
-		model_admin.as_ref(),
-		&user as &dyn crate::core::AdminUser,
-		ModelPermission::View,
-	)
-	.await?;
+	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::View)
+		.await?;
 	let table_name = model_admin.table_name();
 	let pk_field = model_admin.pk_field();
 

--- a/crates/reinhardt-admin/src/server/error.rs
+++ b/crates/reinhardt-admin/src/server/error.rs
@@ -175,11 +175,12 @@ impl AdminAuth {
 	/// This method first verifies staff status, then delegates to the
 	/// `ModelAdmin`'s permission method for the specified permission type.
 	///
-	/// The caller is responsible for providing the actual user object extracted
-	/// from the DI context (e.g., via `AuthUser<AdminDefaultUser>`). This ensures
-	/// the same concrete type is passed to `ModelAdmin::has_*_permission` as in
-	/// other endpoints (e.g., `list.rs`, `create.rs`), allowing `downcast_ref`
-	/// calls inside `ModelAdmin` implementations to succeed.
+	/// The caller is responsible for providing the authenticated user object
+	/// extracted from the DI context via [`AdminAuthenticatedUser`]. The user
+	/// is passed as a `&dyn AdminUser` trait object, which is produced by the
+	/// type-erased user loader registered during admin route setup.
+	///
+	/// [`AdminAuthenticatedUser`]: crate::server::admin_auth::AdminAuthenticatedUser
 	///
 	/// # Arguments
 	///

--- a/crates/reinhardt-admin/src/server/export.rs
+++ b/crates/reinhardt-admin/src/server/export.rs
@@ -2,9 +2,8 @@
 //!
 //! Provides export operations for admin models.
 
-use super::user::AdminDefaultUser;
+use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, ExportFormat, ExportResponse};
-use reinhardt_auth::AuthUser;
 use reinhardt_pages::server_fn::{ServerFnError, ServerFnRequest, server_fn};
 use std::sync::Arc;
 
@@ -44,17 +43,13 @@ pub async fn export_data(
 	#[inject] site: Arc<AdminSite>,
 	#[inject] db: Arc<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
-	#[inject] AuthUser(user): AuthUser<AdminDefaultUser>,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<ExportResponse, ServerFnError> {
 	// Authentication and authorization check
 	let auth = AdminAuth::from_request(&http_request);
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
-	auth.require_model_permission(
-		model_admin.as_ref(),
-		&user as &dyn crate::core::AdminUser,
-		ModelPermission::View,
-	)
-	.await?;
+	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::View)
+		.await?;
 	let table_name = model_admin.table_name();
 
 	// Query total count to detect truncation

--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -2,10 +2,9 @@
 //!
 //! Provides field information for dynamic form generation.
 
-use super::user::AdminDefaultUser;
+use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, FieldInfo, FieldType};
 use crate::types::FieldsResponse;
-use reinhardt_auth::AuthUser;
 use reinhardt_pages::server_fn::{ServerFnError, ServerFnRequest, server_fn};
 use std::sync::Arc;
 
@@ -46,17 +45,13 @@ pub async fn get_fields(
 	#[inject] site: Arc<AdminSite>,
 	#[inject] db: Arc<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
-	#[inject] AuthUser(user): AuthUser<AdminDefaultUser>,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<FieldsResponse, ServerFnError> {
 	// Authentication and authorization check
 	let auth = AdminAuth::from_request(&http_request);
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
-	auth.require_model_permission(
-		model_admin.as_ref(),
-		&user as &dyn crate::core::AdminUser,
-		ModelPermission::View,
-	)
-	.await?;
+	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::View)
+		.await?;
 	let field_names = model_admin
 		.fields()
 		.unwrap_or_else(|| model_admin.list_display());

--- a/crates/reinhardt-admin/src/server/import.rs
+++ b/crates/reinhardt-admin/src/server/import.rs
@@ -2,9 +2,8 @@
 //!
 //! Provides import operations for admin models from various formats (JSON, CSV, TSV).
 
-use super::user::AdminDefaultUser;
+use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, ImportFormat, ImportResponse};
-use reinhardt_auth::AuthUser;
 use reinhardt_pages::server_fn::{ServerFnError, ServerFnRequest, server_fn};
 #[cfg(not(target_arch = "wasm32"))]
 use std::collections::HashMap;
@@ -52,17 +51,13 @@ pub async fn import_data(
 	#[inject] site: Arc<AdminSite>,
 	#[inject] db: Arc<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
-	#[inject] AuthUser(user): AuthUser<AdminDefaultUser>,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<ImportResponse, ServerFnError> {
 	// Authentication and authorization check
 	let auth = AdminAuth::from_request(&http_request);
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
-	auth.require_model_permission(
-		model_admin.as_ref(),
-		&user as &dyn crate::core::AdminUser,
-		ModelPermission::Add,
-	)
-	.await?;
+	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Add)
+		.await?;
 
 	// Validate import file size to prevent memory exhaustion
 	if data.len() > MAX_IMPORT_FILE_SIZE {

--- a/crates/reinhardt-admin/src/server/list.rs
+++ b/crates/reinhardt-admin/src/server/list.rs
@@ -2,12 +2,11 @@
 //!
 //! Provides list view operations for admin models.
 
-use super::user::AdminDefaultUser;
+use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{
 	AdminDatabase, AdminRecord, AdminSite, ColumnInfo, FilterInfo, FilterType, ListQueryParams,
 	ListResponse, ModelAdmin,
 };
-use reinhardt_auth::AuthUser;
 #[cfg(not(target_arch = "wasm32"))]
 use reinhardt_db::orm::{Filter, FilterCondition, FilterOperator, FilterValue};
 use reinhardt_pages::server_fn::{ServerFnError, server_fn};
@@ -101,14 +100,11 @@ pub async fn get_list(
 	params: ListQueryParams,
 	#[inject] site: Arc<AdminSite>,
 	#[inject] db: Arc<AdminDatabase>,
-	#[inject] AuthUser(user): AuthUser<AdminDefaultUser>,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<ListResponse, ServerFnError> {
 	// Get model admin and check permission
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
-	if !model_admin
-		.has_view_permission(&user as &dyn crate::core::AdminUser)
-		.await
-	{
+	if !model_admin.has_view_permission(user.as_ref()).await {
 		return Err(ServerFnError::server(403, "Permission denied"));
 	}
 

--- a/crates/reinhardt-admin/src/server/update.rs
+++ b/crates/reinhardt-admin/src/server/update.rs
@@ -2,10 +2,9 @@
 //!
 //! Provides update operations for admin models.
 
-use super::user::AdminDefaultUser;
+use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite};
 use crate::types::{MutationRequest, MutationResponse};
-use reinhardt_auth::AuthUser;
 use reinhardt_pages::server_fn::{ServerFnError, ServerFnRequest, server_fn};
 use std::sync::Arc;
 
@@ -55,7 +54,7 @@ pub async fn update_record(
 	#[inject] site: Arc<AdminSite>,
 	#[inject] db: Arc<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
-	#[inject] AuthUser(user): AuthUser<AdminDefaultUser>,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<MutationResponse, ServerFnError> {
 	// CSRF token validation (double-submit cookie pattern)
 	require_csrf_token(&request.csrf_token, &http_request.inner().headers)?;
@@ -63,12 +62,8 @@ pub async fn update_record(
 	// Authentication and authorization check
 	let auth = AdminAuth::from_request(&http_request);
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
-	auth.require_model_permission(
-		model_admin.as_ref(),
-		&user as &dyn crate::core::AdminUser,
-		ModelPermission::Change,
-	)
-	.await?;
+	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Change)
+		.await?;
 
 	let table_name = model_admin.table_name();
 	let pk_field = model_admin.pk_field();


### PR DESCRIPTION
## Summary

- Replace hardcoded `AuthUser<AdminDefaultUser>` with type-erased `AdminAuthenticatedUser` in all 9 admin server functions
- Add `AdminSite::set_user_type::<U>()` API for configuring custom User models
- Register type-erased user loader via DI singleton scope for testability
- `AdminDefaultUser` remains as fallback when no custom type is configured

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Admin server functions hardcoded `AdminDefaultUser` with table name `auth_user` for authentication. Projects using custom User models with different table names got "Database query failed" errors because the query targeted the wrong table.

## How Was This Tested

- [x] All 346 existing reinhardt-admin tests pass
- [x] New unit tests for `AdminAuthenticatedUser::inject` error paths (no HTTP request, no AuthState, unauthenticated, no loader registered)
- [x] New test for `AdminUserLoader` DI singleton registration
- [x] `cargo check --workspace --all --all-features` passes
- [x] `cargo clippy --package reinhardt-admin --all-features` clean

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Code comments in English
- [x] Tests added for new functionality
- [x] All tests pass locally
- [x] No `todo!()` or `// TODO:` in new code

## Labels to Apply

- `bug`

Fixes #3088

🤖 Generated with [Claude Code](https://claude.com/claude-code)