### PR TITLE
fix(test): update admin test helpers for AdminAuthenticatedUser type

### DIFF
--- a/tests/integration/tests/admin/server_fn_helpers.rs
+++ b/tests/integration/tests/admin/server_fn_helpers.rs
@@ -1,11 +1,10 @@
 //! Shared test helpers for admin server function integration tests
 //!
-//! Provides helper functions to construct `ServerFnRequest`, `AuthUser<DefaultUser>`,
+//! Provides helper functions to construct `ServerFnRequest`, `AdminAuthenticatedUser`,
 //! and a permission-granting ModelAdmin for testing server functions.
 
 use reinhardt_admin::core::{AdminDatabase, AdminSite, AdminUser, ModelAdmin};
-use reinhardt_admin::server::AdminDefaultUser;
-use reinhardt_auth::AuthUser;
+use reinhardt_admin::server::{AdminAuthenticatedUser, AdminDefaultUser};
 use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection;
 use reinhardt_db::backends::dialect::PostgresBackend;
 use reinhardt_db::orm::connection::{DatabaseBackend, DatabaseConnection};
@@ -65,9 +64,12 @@ pub fn make_staff_user() -> AdminDefaultUser {
 	}
 }
 
-/// Creates an `AuthUser<AdminDefaultUser>` with staff privileges for testing.
-pub fn make_auth_user() -> AuthUser<AdminDefaultUser> {
-	AuthUser(make_staff_user())
+/// Creates an `AdminAuthenticatedUser` with staff privileges for testing.
+///
+/// Wraps the staff user in `Arc<dyn AdminUser>` to match the type-erased
+/// authentication used by admin server functions.
+pub fn make_auth_user() -> AdminAuthenticatedUser {
+	AdminAuthenticatedUser(Arc::new(make_staff_user()))
 }
 
 /// A ModelAdmin implementation that grants all permissions.


### PR DESCRIPTION
## Summary

- Update `make_auth_user()` test helper to return `AdminAuthenticatedUser` instead of `AuthUser<AdminDefaultUser>`
- Fixes type mismatch compilation errors in all admin server function integration tests

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

PR #3097 changed admin server functions to accept `AdminAuthenticatedUser` (type-erased `Arc<dyn AdminUser>`) instead of the hardcoded `AuthUser<AdminDefaultUser>`. However, the integration test helper `make_auth_user()` was not updated to match, causing compilation failures in CI (`Cargo Check (tests)` job).

Related to: #3097

## How Was This Tested?

- `cargo check --workspace --all --all-features` passes locally

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `admin` - Admin interface, admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)