### PR TITLE
fix: correct version references from rc.15 to rc.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Reinhardt follows a **three-phase lifecycle** for every crate:
 | **RC** (`0.x.0-rc.N`) | API frozen. Bug fixes only. Safe to build against. |
 | **Stable** (`0.x.0`) | Full SemVer 2.0 guarantees. |
 
-**Current status:** All crates are at `0.1.0-rc.15` (Release Candidate).
+**Current status:** All crates are at `0.1.0-rc.14` (Release Candidate).
 
 **What this means for you:**
 - Public APIs will only change to fix critical bugs -- no new features or additions
@@ -122,7 +122,7 @@ Get a well-balanced feature set with zero configuration:
 [dependencies]
 # Import as 'reinhardt', published as 'reinhardt-web'
 # Default enables the "standard" preset (balanced feature set)
-reinhardt = { version = "0.1.0-rc.15", package = "reinhardt-web" }
+reinhardt = { version = "0.1.0-rc.14", package = "reinhardt-web" }
 ```
 
 **Includes:** Core, Database (PostgreSQL), REST API (serializers, parsers, pagination, filters, throttling, versioning, metadata, content negotiation), Auth, Middleware (sessions), Pages (WASM Frontend with SSR), Signals
@@ -141,7 +141,7 @@ For projects that need every available component:
 
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.15", package = "reinhardt-web", default-features = false, features = ["full"] }
+reinhardt = { version = "0.1.0-rc.14", package = "reinhardt-web", default-features = false, features = ["full"] }
 ```
 
 **Includes:** Everything in Standard, plus Admin, GraphQL, WebSockets, Cache, i18n, Mail, Static Files, Storage, and more
@@ -154,7 +154,7 @@ Lightweight and fast, perfect for simple APIs:
 
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.15", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+reinhardt = { version = "0.1.0-rc.14", package = "reinhardt-web", default-features = false, features = ["minimal"] }
 ```
 
 **Includes:** HTTP, routing, DI, parameter extraction, server
@@ -168,24 +168,24 @@ Install only the components you need:
 ```toml
 [dependencies]
 # Core components
-reinhardt-http = "0.1.0-rc.15"
-reinhardt-urls = "0.1.0-rc.15"
+reinhardt-http = "0.1.0-rc.14"
+reinhardt-urls = "0.1.0-rc.14"
 
 # Optional: Database
-reinhardt-db = "0.1.0-rc.15"
+reinhardt-db = "0.1.0-rc.14"
 
 # Optional: Authentication
-reinhardt-auth = "0.1.0-rc.15"
+reinhardt-auth = "0.1.0-rc.14"
 
 # Optional: REST API features
-reinhardt-rest = "0.1.0-rc.15"
+reinhardt-rest = "0.1.0-rc.14"
 
 # Optional: Admin panel
-reinhardt-admin = "0.1.0-rc.15"
+reinhardt-admin = "0.1.0-rc.14"
 
 # Optional: Advanced features
-reinhardt-graphql = "0.1.0-rc.15"
-reinhardt-websockets = "0.1.0-rc.15"
+reinhardt-graphql = "0.1.0-rc.14"
+reinhardt-websockets = "0.1.0-rc.14"
 ```
 
 **Note on Crate Naming:**

--- a/crates/reinhardt-auth/src/core/user.rs
+++ b/crates/reinhardt-auth/src/core/user.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 /// assert_eq!(user.username(), "alice");
 /// ```
 #[deprecated(
-	since = "0.1.0-rc.15",
+	since = "0.1.0-rc.14",
 	note = "Use AuthIdentity + BaseUser/FullUser + PermissionsMixin instead"
 )]
 pub trait User: Send + Sync {

--- a/crates/reinhardt-auth/src/default_user.rs
+++ b/crates/reinhardt-auth/src/default_user.rs
@@ -112,7 +112,7 @@ use uuid::Uuid;
 /// ```
 #[cfg(feature = "argon2-hasher")]
 #[deprecated(
-	since = "0.1.0-rc.15",
+	since = "0.1.0-rc.14",
 	note = "Use the `user` attribute macro to define your own user struct instead"
 )]
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/reinhardt-db/src/orm/query_execution.rs
+++ b/crates/reinhardt-db/src/orm/query_execution.rs
@@ -88,7 +88,7 @@ impl QueryCompiler {
 
 	/// Build condition expression from field, operator and value
 	fn build_condition_expr(field: &str, operator: &str, value: &str) -> SimpleExpr {
-		// For reinhardt-query v1.0.0-rc.15, we use custom SQL expressions
+		// For reinhardt-query v1.0.0-rc.14, we use custom SQL expressions
 		// as the API for building complex conditions has changed
 		// This is a temporary solution until we can use the proper API
 


### PR DESCRIPTION
## Summary

- Correct version references from `rc.15` to `rc.14` across documentation and source code

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

- Version references in README.md, deprecated attribute annotations, and code comments incorrectly stated `rc.15` instead of `rc.14`

## How Was This Tested?

- `cargo check --workspace --all --all-features` passes
- `grep -r "rc\.15"` confirms no remaining occurrences

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)