### PR TITLE
fix(admin): use path_params instead of full URI in static file handler

### DIFF
--- a/crates/reinhardt-admin/src/core/router.rs
+++ b/crates/reinhardt-admin/src/core/router.rs
@@ -140,7 +140,11 @@ async fn admin_static_file_handler(
 ) -> reinhardt_core::exception::Result<reinhardt_http::Response> {
 	use reinhardt_utils::staticfiles::handler::StaticFileHandler;
 
-	let path = request.uri.path().trim_start_matches('/');
+	let path = request
+		.path_params
+		.get("path")
+		.map(|p| p.trim_start_matches('/'))
+		.unwrap_or("");
 
 	// 1. Try STATIC_ROOT/admin/ first (production: after collectstatic)
 	if let Some(admin_dir) = resolve_static_root_admin() {
@@ -825,10 +829,14 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_admin_static_file_handler_serves_css() {
-		// Arrange
+		// Arrange - use realistic URI matching production mount at /static/admin/
 		let request = reinhardt_http::Request::builder()
 			.method(hyper::Method::GET)
-			.uri("/style.css")
+			.uri("/static/admin/style.css")
+			.path_params(std::collections::HashMap::from([(
+				"path".to_string(),
+				"style.css".to_string(),
+			)]))
 			.build()
 			.unwrap();
 
@@ -853,10 +861,14 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_admin_static_file_handler_serves_js() {
-		// Arrange
+		// Arrange - use realistic URI matching production mount at /static/admin/
 		let request = reinhardt_http::Request::builder()
 			.method(hyper::Method::GET)
-			.uri("/main.js")
+			.uri("/static/admin/main.js")
+			.path_params(std::collections::HashMap::from([(
+				"path".to_string(),
+				"main.js".to_string(),
+			)]))
 			.build()
 			.unwrap();
 
@@ -881,10 +893,14 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_admin_static_file_handler_returns_404_for_missing_file() {
-		// Arrange
+		// Arrange - use realistic URI matching production mount at /static/admin/
 		let request = reinhardt_http::Request::builder()
 			.method(hyper::Method::GET)
-			.uri("/nonexistent.txt")
+			.uri("/static/admin/nonexistent.txt")
+			.path_params(std::collections::HashMap::from([(
+				"path".to_string(),
+				"nonexistent.txt".to_string(),
+			)]))
 			.build()
 			.unwrap();
 
@@ -903,10 +919,14 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_admin_static_file_handler_returns_404_for_wasm_when_not_built() {
-		// Arrange
+		// Arrange - use realistic URI matching production mount at /static/admin/
 		let request = reinhardt_http::Request::builder()
 			.method(hyper::Method::GET)
-			.uri("/reinhardt_admin_bg.wasm")
+			.uri("/static/admin/reinhardt_admin_bg.wasm")
+			.path_params(std::collections::HashMap::from([(
+				"path".to_string(),
+				"reinhardt_admin_bg.wasm".to_string(),
+			)]))
 			.build()
 			.unwrap();
 


### PR DESCRIPTION
## Summary

- Fix admin static file handler returning 404 for all files due to mount prefix not being stripped from URI path

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `admin_static_file_handler` used `request.uri.path()` to determine file paths, but this returns the full URI including the mount prefix (`/static/admin/`). Since the handler is mounted at `/static/admin/` with a `/{*path}` catch-all route, the full URI caused all file lookups to fail (e.g., looking for `static/admin/style.css` instead of `style.css`).

Fixes #3132

Related to: #3117

## How Was This Tested?

- `cargo nextest run --package reinhardt-admin -E 'test(admin_static)'` — all 7 tests pass
- `cargo check --workspace --all --all-features` — no errors
- `cargo make clippy-check` — no warnings
- `cargo make fmt-check` — no formatting issues
- Tests updated to use realistic production URIs (`/static/admin/style.css`) with `path_params` to prevent regression

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #3132 — Admin static file handler returns 404 for all files
- #3117 — Original admin WASM pipeline PR that introduced the handler

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `admin` - Admin interface, admin panels

### Priority Label
- [x] `high` - Important fix or feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)