### PR TITLE
fix(admin): fix WASM init and HEAD request support for admin panel

### DIFF
--- a/crates/reinhardt-admin/src/core/router.rs
+++ b/crates/reinhardt-admin/src/core/router.rs
@@ -218,7 +218,9 @@ pub fn admin_static_routes() -> ServerRouter {
 	let router = ServerRouter::new();
 
 	#[cfg(not(target_arch = "wasm32"))]
-	let router = router.function("/{*path}", hyper::Method::GET, admin_static_file_handler);
+	let router = router
+		.function("/{*path}", hyper::Method::GET, admin_static_file_handler)
+		.function("/{*path}", hyper::Method::HEAD, admin_static_file_handler);
 
 	router
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix admin SPA HTML not calling `init()` for wasm-pack web target output (#3139)
- Fix admin static file handler returning 405 for HEAD requests (#3140)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

**#3139**: The `admin_spa_html()` function generates `<script type="module" src="...">` which imports the WASM module but never calls `init()`. With `wasm-pack --target web`, `init()` must be called explicitly to fetch and instantiate the WASM binary. The admin page remains blank.

**#3140**: The static file handler only registers a GET route. Per RFC 9110 §9.3.2, HEAD should be supported for any resource that supports GET. HEAD requests return 405 Method Not Allowed instead of 200.

Fixes #3139
Fixes #3140

## How Was This Tested?

- `cargo check -p reinhardt-admin --all-features` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)