### PR TITLE
fix(pages): resolve server_fn endpoint URL with mount prefix in WASM

### DIFF
--- a/crates/reinhardt-admin/src/core/router.rs
+++ b/crates/reinhardt-admin/src/core/router.rs
@@ -122,6 +122,7 @@ fn admin_spa_html() -> String {
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<meta name="server-fn-prefix" content="/admin" />
 	<title>Reinhardt Admin</title>
 	<link rel="stylesheet" href="{css_url}" />
 </head>
@@ -817,6 +818,10 @@ mod tests {
 		assert!(
 			html.contains("<!DOCTYPE html>"),
 			"HTML should be valid HTML5"
+		);
+		assert!(
+			html.contains(r#"<meta name="server-fn-prefix" content="/admin" />"#),
+			"HTML should contain server-fn-prefix meta tag for WASM endpoint resolution"
 		);
 	}
 

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -629,7 +629,7 @@ fn generate_client_stub(
 				#(#param_names: #param_types),*
 			}
 
-			let __endpoint = #endpoint;
+			let __endpoint = #pages_crate::server_fn::resolve_endpoint(#endpoint);
 			let __args = #args_struct_name {
 				#(#param_names),*
 			};

--- a/crates/reinhardt-pages/src/server_fn.rs
+++ b/crates/reinhardt-pages/src/server_fn.rs
@@ -102,3 +102,80 @@ pub use server_fn_trait::{ServerFn, ServerFnError};
 
 // Re-export the macro for convenience
 pub use reinhardt_pages_macros::server_fn;
+
+/// Resolves a server function endpoint path by prepending the mount prefix.
+///
+/// On WASM targets, reads the `<meta name="server-fn-prefix">` tag from the
+/// document to determine the mount prefix. The prefix is cached after the first
+/// DOM lookup for performance.
+///
+/// On non-WASM targets, returns the path unchanged (server-side routing handles
+/// prefix resolution via router mounting).
+///
+/// # Examples
+///
+/// ```ignore
+/// // With <meta name="server-fn-prefix" content="/admin"> in the document:
+/// assert_eq!(resolve_endpoint("/api/server_fn/get_list"), "/admin/api/server_fn/get_list");
+///
+/// // Without the meta tag:
+/// assert_eq!(resolve_endpoint("/api/server_fn/get_list"), "/api/server_fn/get_list");
+/// ```
+#[cfg(target_arch = "wasm32")]
+pub fn resolve_endpoint(path: &str) -> String {
+	use std::cell::RefCell;
+
+	thread_local! {
+		static CACHED_PREFIX: RefCell<Option<String>> = const { RefCell::new(None) };
+	}
+
+	CACHED_PREFIX.with(|cache| {
+		let mut cache = cache.borrow_mut();
+		if cache.is_none() {
+			let prefix = web_sys::window()
+				.and_then(|w| w.document())
+				.and_then(|d| {
+					d.query_selector("meta[name='server-fn-prefix']")
+						.ok()
+						.flatten()
+				})
+				.and_then(|el| el.get_attribute("content"))
+				.unwrap_or_default();
+			*cache = Some(prefix);
+		}
+		let prefix = cache.as_deref().unwrap_or("");
+		if prefix.is_empty() {
+			path.to_string()
+		} else {
+			let prefix = prefix.trim_end_matches('/');
+			format!("{}{}", prefix, path)
+		}
+	})
+}
+
+/// Non-WASM identity implementation - returns the path unchanged.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn resolve_endpoint(path: &str) -> String {
+	path.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	#[case("/api/server_fn/get_list", "/api/server_fn/get_list")]
+	#[case("/api/server_fn/admin_login", "/api/server_fn/admin_login")]
+	#[case("/custom/endpoint", "/custom/endpoint")]
+	fn test_resolve_endpoint_returns_path_unchanged_on_server(
+		#[case] input: &str,
+		#[case] expected: &str,
+	) {
+		// Arrange & Act
+		let result = resolve_endpoint(input);
+
+		// Assert
+		assert_eq!(result, expected);
+	}
+}


### PR DESCRIPTION
## Summary

- Add `resolve_endpoint()` function that reads `<meta name="server-fn-prefix">` from the document at runtime to prepend mount prefix to server_fn URLs in WASM
- Modify `#[server_fn]` macro to call `resolve_endpoint()` instead of using hardcoded endpoint paths
- Inject `<meta name="server-fn-prefix" content="/admin" />` in admin SPA HTML shell

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

When the admin router is mounted at `/admin/`, server functions are registered at `/admin/api/server_fn/<name>` on the server side. However, the WASM client code generated by `#[server_fn]` sends requests to `/api/server_fn/<name>` (without the mount prefix), resulting in 404 errors.

## How Was This Tested

- [x] `cargo check --workspace --all --all-features`
- [x] `cargo nextest run --package reinhardt-pages -E 'test(resolve_endpoint)'`
- [x] `cargo nextest run --package reinhardt-admin -E 'test(test_admin_spa_html)'`
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] All existing tests pass
- [x] Backward compatible (no meta tag = no prefix = existing behavior unchanged)

## Labels to Apply

- `bug`

Fixes #3145

🤖 Generated with [Claude Code](https://claude.com/claude-code)