### PR TITLE
fix(admin): remove broken presetWind() global function call for UnoCSS v66+

### DIFF
--- a/crates/reinhardt-admin/src/core/router.rs
+++ b/crates/reinhardt-admin/src/core/router.rs
@@ -130,9 +130,6 @@ fn admin_spa_html() -> String {
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/open-props/open-props.min.css" />
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4/animate.min.css" />
 	<script src="https://cdn.jsdelivr.net/npm/@unocss/runtime/preset-wind.global.js"></script>
-	<script>
-		window.__unocss = {{ presets: [presetWind()] }};
-	</script>
 	<script src="https://cdn.jsdelivr.net/npm/@unocss/runtime/core.global.js"></script>
 	<link rel="stylesheet" href="{css_url}" />
 </head>
@@ -869,8 +866,8 @@ mod tests {
 			"HTML should load UnoCSS core runtime"
 		);
 		assert!(
-			html.contains("presetWind()"),
-			"HTML should configure UnoCSS with preset-wind"
+			!html.contains("presetWind()"),
+			"HTML should not use deprecated presetWind() global function (v66+ auto-registers)"
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Remove broken `window.__unocss = { presets: [presetWind()] }` inline script that silently fails on UnoCSS v66+
- In v66+, `preset-wind.global.js` auto-registers with the runtime; no manual configuration needed

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

UnoCSS v66+ no longer exposes `presetWind` as a global function. The inline script calling `presetWind()` evaluates to `undefined`, causing the runtime to start with no presets. This means no utility classes are generated on the admin page.

Fixes #3157

## How Was This Tested?

- `cargo nextest run --package reinhardt-admin -E 'test(unocss)'` — 1 passed

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)