### PR TITLE
fix(admin): initialize UnoCSS runtime with v66+ API for preset-wind

### DIFF
--- a/crates/reinhardt-admin/src/core/router.rs
+++ b/crates/reinhardt-admin/src/core/router.rs
@@ -131,6 +131,13 @@ fn admin_spa_html() -> String {
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4/animate.min.css" />
 	<script src="https://cdn.jsdelivr.net/npm/@unocss/runtime/preset-wind.global.js"></script>
 	<script src="https://cdn.jsdelivr.net/npm/@unocss/runtime/core.global.js"></script>
+	<script>
+		// Initialize UnoCSS runtime with preset-wind (v66+ API)
+		if (window.__unocss_runtime && window.__unocss_runtime.presets.presetWind) {{
+			window.__unocss_runtime.uno.setConfig({{ presets: [window.__unocss_runtime.presets.presetWind()] }});
+			window.__unocss_runtime.extractAll();
+		}}
+	</script>
 	<link rel="stylesheet" href="{css_url}" />
 </head>
 <body class="bg-slate-50 text-slate-900 antialiased">
@@ -866,8 +873,12 @@ mod tests {
 			"HTML should load UnoCSS core runtime"
 		);
 		assert!(
-			!html.contains("presetWind()"),
-			"HTML should not use deprecated presetWind() global function (v66+ auto-registers)"
+			html.contains("__unocss_runtime.presets.presetWind()"),
+			"HTML should use v66+ runtime API to configure presetWind"
+		);
+		assert!(
+			html.contains("extractAll()"),
+			"HTML should call extractAll() to apply styles on page load"
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Add inline script after UnoCSS CDN scripts to properly initialize the runtime with preset-wind using v66+ API
- Previous fix (#3160) removed the deprecated `presetWind()` global function call but did not add a replacement
- UnoCSS v66+ runtime requires explicit `setConfig()` + `extractAll()` — presets are not auto-applied from the registry
- Update test assertions to verify the new initialization pattern

## Test plan

- [x] `cargo test -p reinhardt-admin -- test_admin_spa_html` passes
- [x] Verified in browser: UnoCSS styles (blue header, card layout, slate background) render correctly after fix

Fixes #3157

🤖 Generated with [Claude Code](https://claude.com/claude-code)