### PR TITLE
fix(docs): resolve broken intra-doc links and incorrect test assertion

### DIFF
--- a/crates/reinhardt-auth/src/core/superuser_creator.rs
+++ b/crates/reinhardt-auth/src/core/superuser_creator.rs
@@ -12,7 +12,7 @@
 //!
 //! The [`SuperuserCreator`] trait provides the async database persistence
 //! layer, and [`TypedSuperuserCreator<U>`] bridges the two by combining
-//! [`SuperuserInit`] for construction with [`Model`] for ORM operations.
+//! [`SuperuserInit`] for construction with `Model` for ORM operations.
 //!
 //! # Global Registry
 //!
@@ -162,7 +162,7 @@ static SUPERUSER_CREATOR: OnceLock<Box<dyn SuperuserCreator>> = OnceLock::new();
 /// Register a [`SuperuserCreator`] for use by the `createsuperuser` command.
 ///
 /// This should be called early in program startup (e.g., in `main()`)
-/// before [`execute_from_command_line`](reinhardt_commands::execute_from_command_line).
+/// before `execute_from_command_line`.
 ///
 /// # Panics
 ///

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -982,11 +982,12 @@ fn generate_server_handler(
 		///
 		/// # Example
 		///
-		/// ```no_run
-		/// use axum::{Router, routing::post};
+		/// ```text
+		/// use reinhardt_pages::server_fn::ServerFnRouterExt;
+		/// use reinhardt_urls::routers::ServerRouter;
 		///
-		/// let app = Router::new()
-		///     .route("/api/server_fn/get_user", post(register_server_fn_get_user));
+		/// let router = ServerRouter::new()
+		///     .server_fn(get_user);
 		/// ```
 		pub fn #register_fn_name() -> &'static str {
 			#endpoint

--- a/tests/integration/tests/commands/collectstatic_admin_integration.rs
+++ b/tests/integration/tests/commands/collectstatic_admin_integration.rs
@@ -174,14 +174,14 @@ fn test_collectstatic_admin_css_content_integrity(temp_dir: TempDir) {
 	let collected_css =
 		fs::read_to_string(dest_dir.join("style.css")).expect("Should read collected style.css");
 
-	// Assert - verify UnoCSS preflight content
+	// Assert - verify theme content (utility classes are generated at runtime by UnoCSS)
 	assert!(
 		collected_css.contains("box-sizing"),
-		"Collected CSS should contain UnoCSS preflight reset"
+		"Collected CSS should contain box-sizing reset"
 	);
 	assert!(
-		collected_css.contains(".min-h-screen"),
-		"Collected CSS should contain UnoCSS utility classes"
+		collected_css.contains("--admin-amber"),
+		"Collected CSS should contain admin theme tokens"
 	);
 }
 


### PR DESCRIPTION
## Summary

- Fix broken intra-doc links in `reinhardt-auth` superuser_creator module that caused Docs.rs Build Check CI failure
- Replace `axum` example in `server_fn` macro doctest with reinhardt's `ServerFnRouterExt`/`ServerRouter` pattern
- Fix `test_collectstatic_admin_css_content_integrity` assertion: UnoCSS utility classes are runtime-generated, not embedded in `style.css`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Multiple open PRs (#3129, #3161, #3162, #3168, #3169, #3172) are failing CI due to these issues on `main`:
1. `RUSTDOCFLAGS="-D warnings"` catches unresolvable `[Model]` and `reinhardt_commands::execute_from_command_line` intra-doc links
2. Documentation tests fail because proc macro doctest references `axum` which is not a dependency
3. Cross-crate integration test asserts `.min-h-screen` in collected CSS, but UnoCSS utility classes are generated at runtime after #3166

## How Was This Tested

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p reinhardt-auth` passes
- [x] Verified `style.css` contains `--admin-amber` theme token (replacement assertion)
- [x] Verified `style.css` does not contain `.min-h-screen` (confirming runtime generation)

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated (doc comments fixed)
- [x] All code comments in English

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)