### PR TITLE
fix(migrations): skip no-op migrations for struct-only renames

### DIFF
--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -3871,6 +3871,10 @@ impl MigrationAutodetector {
 	}
 
 	/// Check if a field has changed
+	///
+	/// Compares only schema-affecting parameters to avoid false positives
+	/// from asymmetric param populations between migration-replayed from_state
+	/// and code-registry to_state.
 	fn has_field_changed(&self, from_field: &FieldState, to_field: &FieldState) -> bool {
 		// Check if field type changed
 		if from_field.field_type != to_field.field_type {
@@ -3882,9 +3886,14 @@ impl MigrationAutodetector {
 			return true;
 		}
 
-		// Check if params changed
-		if from_field.params != to_field.params {
-			return true;
+		// Compare only schema-affecting params to avoid false positives
+		// from_state (migration replay) populates: primary_key, auto_increment, unique, default
+		// to_state (code registry) populates all params including non-schema ones like max_length
+		const SCHEMA_PARAMS: &[&str] = &["primary_key", "auto_increment", "unique", "default"];
+		for key in SCHEMA_PARAMS {
+			if from_field.params.get(*key) != to_field.params.get(*key) {
+				return true;
+			}
 		}
 
 		false
@@ -3958,10 +3967,22 @@ impl MigrationAutodetector {
 		for (deleted_key, created_key, _similarity) in matches {
 			// Check if this is a cross-app move or same-app rename
 			if deleted_key.0 == created_key.0 {
-				// Same app: this is a rename operation
-				changes
-					.renamed_models
-					.push((deleted_key.0, deleted_key.1, created_key.1));
+				// Same app: check if table names actually differ
+				// Struct-only renames (same table name) are not schema changes
+				let old_table = self
+					.from_state
+					.get_model(&deleted_key.0, &deleted_key.1)
+					.map(|m| m.table_name.as_str());
+				let new_table = self
+					.to_state
+					.get_model(&created_key.0, &created_key.1)
+					.map(|m| m.table_name.as_str());
+
+				if old_table != new_table {
+					changes
+						.renamed_models
+						.push((deleted_key.0, deleted_key.1, created_key.1));
+				}
 			} else {
 				// Different apps: this is a move operation
 				// Determine if table needs to be renamed
@@ -5043,13 +5064,16 @@ impl MigrationAutodetector {
 					.map(|m| m.table_name.clone())
 					.unwrap_or_else(|| format!("{}_{}", app_label, old_name.to_lowercase()));
 
-				migrations_by_app
-					.entry(app_label.clone())
-					.or_default()
-					.push(super::Operation::RenameTable {
-						old_name: old_table_name,
-						new_name: model.table_name.clone(),
-					});
+				// Defense-in-depth: skip no-op renames where table name is unchanged
+				if old_table_name != model.table_name {
+					migrations_by_app
+						.entry(app_label.clone())
+						.or_default()
+						.push(super::Operation::RenameTable {
+							old_name: old_table_name,
+							new_name: model.table_name.clone(),
+						});
+				}
 			}
 		}
 
@@ -5932,5 +5956,140 @@ mod tests {
 		assert!(schema.tables.contains_key("blog_post"));
 		let table = &schema.tables["blog_post"];
 		assert_eq!(table.name, "custom_posts_table");
+	}
+
+	// --- Tests for #3204: no-op migration detection ---
+
+	/// Build fields commonly used in #3204 tests
+	fn sample_fields() -> Vec<FieldState> {
+		vec![
+			FieldState::new("id", super::super::FieldType::Integer, false),
+			FieldState::new("name", super::super::FieldType::VarChar(255), false),
+		]
+	}
+
+	#[rstest]
+	fn detect_renamed_models_skips_struct_only_rename_with_same_table_name() {
+		// Arrange: struct name changed (Clusters -> Cluster) but table name is the same
+		let from_model =
+			build_model_state_with_table_name("myapp", "Clusters", "clusters", sample_fields());
+		let to_model =
+			build_model_state_with_table_name("myapp", "Cluster", "clusters", sample_fields());
+
+		let from_state = build_project_state(vec![(
+			("myapp".to_string(), "Clusters".to_string()),
+			from_model,
+		)]);
+		let to_state = build_project_state(vec![(
+			("myapp".to_string(), "Cluster".to_string()),
+			to_model,
+		)]);
+
+		let detector = MigrationAutodetector::new(from_state, to_state);
+
+		// Act
+		let changes = detector.detect_changes();
+
+		// Assert: no rename should be detected
+		assert!(
+			changes.renamed_models.is_empty(),
+			"struct-only rename with same table name should not produce renamed_models"
+		);
+	}
+
+	#[rstest]
+	fn detect_renamed_models_detects_actual_table_rename() {
+		// Arrange: struct name changed AND table name changed
+		let from_model =
+			build_model_state_with_table_name("myapp", "OldModel", "old_table", sample_fields());
+		let to_model =
+			build_model_state_with_table_name("myapp", "NewModel", "new_table", sample_fields());
+
+		let from_state = build_project_state(vec![(
+			("myapp".to_string(), "OldModel".to_string()),
+			from_model,
+		)]);
+		let to_state = build_project_state(vec![(
+			("myapp".to_string(), "NewModel".to_string()),
+			to_model,
+		)]);
+
+		let detector = MigrationAutodetector::new(from_state, to_state);
+
+		// Act
+		let changes = detector.detect_changes();
+
+		// Assert: rename should be detected
+		assert_eq!(
+			changes.renamed_models.len(),
+			1,
+			"actual table rename should be detected"
+		);
+		assert_eq!(changes.renamed_models[0].1, "OldModel");
+		assert_eq!(changes.renamed_models[0].2, "NewModel");
+	}
+
+	#[rstest]
+	fn has_field_changed_ignores_non_schema_params() {
+		// Arrange: same schema, but to_field has extra non-schema params
+		let from_field = FieldState {
+			name: "email".to_string(),
+			field_type: super::super::FieldType::VarChar(255),
+			nullable: false,
+			params: std::collections::HashMap::new(),
+			foreign_key: None,
+		};
+		let mut to_params = std::collections::HashMap::new();
+		to_params.insert("max_length".to_string(), "255".to_string());
+		to_params.insert("null".to_string(), "false".to_string());
+		to_params.insert("blank".to_string(), "false".to_string());
+		let to_field = FieldState {
+			name: "email".to_string(),
+			field_type: super::super::FieldType::VarChar(255),
+			nullable: false,
+			params: to_params,
+			foreign_key: None,
+		};
+
+		let detector = MigrationAutodetector::new(ProjectState::new(), ProjectState::new());
+
+		// Act
+		let changed = detector.has_field_changed(&from_field, &to_field);
+
+		// Assert: should NOT be detected as changed
+		assert!(
+			!changed,
+			"fields with identical schema but different non-schema params should not be detected as changed"
+		);
+	}
+
+	#[rstest]
+	fn generate_operations_empty_for_struct_only_rename() {
+		// Arrange: struct name changed but table name and fields are the same
+		let from_model =
+			build_model_state_with_table_name("myapp", "Clusters", "clusters", sample_fields());
+		let to_model =
+			build_model_state_with_table_name("myapp", "Cluster", "clusters", sample_fields());
+
+		let from_state = build_project_state(vec![(
+			("myapp".to_string(), "Clusters".to_string()),
+			from_model,
+		)]);
+		let to_state = build_project_state(vec![(
+			("myapp".to_string(), "Cluster".to_string()),
+			to_model,
+		)]);
+
+		let detector = MigrationAutodetector::new(from_state, to_state);
+
+		// Act
+		let operations = detector.generate_operations();
+
+		// Assert: no operations should be generated
+		assert!(
+			operations.is_empty(),
+			"struct-only rename with same table name and identical fields should produce no operations, got: {:?}",
+			operations
+		);
 	}
 }


### PR DESCRIPTION
## Summary

- Fix `makemigrations` generating unnecessary no-op migrations when a Rust struct name changes but the table name remains identical
- Skip `RenameTable` operations where old and new table names are the same
- Normalize `has_field_changed()` to compare only schema-affecting params

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

When renaming a struct (e.g., `Clusters` → `Cluster`) without changing the table name, `makemigrations` incorrectly generates:
1. `RenameTable { old_name: "clusters", new_name: "clusters" }` — a no-op
2. `AlterColumn` operations for every column with identical definitions

This adds noise to migration history and executes unnecessary SQL statements.

Fixes #3204

## How Was This Tested?

- [x] 4 new unit tests added:
  - `detect_renamed_models_skips_struct_only_rename_with_same_table_name`
  - `detect_renamed_models_detects_actual_table_rename` (regression test)
  - `has_field_changed_ignores_non_schema_params`
  - `generate_operations_empty_for_struct_only_rename`
- [x] `cargo nextest run --package reinhardt-db` — all tests pass
- [x] `cargo make clippy-check` — no new warnings

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)