### PR TITLE
fix(admin): use existing open-props version for vendor asset download

### DIFF
--- a/crates/reinhardt-admin/src/core/vendor.rs
+++ b/crates/reinhardt-admin/src/core/vendor.rs
@@ -28,9 +28,9 @@ pub struct VendorAsset {
 /// successful download using `verify_integrity`.
 #[cfg(not(target_arch = "wasm32"))]
 const ADMIN_VENDOR_ASSETS: &[VendorAsset] = &[
-	// Open Props v2.0.5 — CSS custom property design tokens
+	// Open Props v1.7.23 — CSS custom property design tokens
 	VendorAsset {
-		url: "https://cdn.jsdelivr.net/npm/open-props@2.0.5/open-props.min.css",
+		url: "https://cdn.jsdelivr.net/npm/open-props@1.7.23/open-props.min.css",
 		target: "vendor/open-props.min.css",
 		sha256: "",
 	},


### PR DESCRIPTION
## Summary

- Fix `collectstatic` HTTP 404 failure by changing `open-props@2.0.5` (non-existent) to `open-props@1.7.23` (latest stable)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `collectstatic` command fails with HTTP 404 because `open-props@2.0.5` was never published to npm. The admin CSS only uses v1.x custom properties (`--border-size-1`, `--radius-2`, `--shadow-2`, etc.), so the latest stable v1.7.23 is the correct version.

Fixes #3213

## How Was This Tested?

- [x] `cargo check --workspace --all --all-features` passes
- [x] `cargo nextest run --package reinhardt-admin` — 402 tests passed
- [x] `cargo clippy --package reinhardt-admin --all-features` — no errors

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)