### PR TITLE
docs(auth): document SuperuserInit manual implementation path

### DIFF
--- a/crates/reinhardt-auth/src/core/superuser_creator.rs
+++ b/crates/reinhardt-auth/src/core/superuser_creator.rs
@@ -1,7 +1,6 @@
 //! Superuser creation support for management commands.
 //!
-//! Provides type-erased superuser creation that works with any user model
-//! decorated with `#[user(...)]` + `#[model(...)]` macros.
+//! Provides type-erased superuser creation that works with any user model.
 //!
 //! # Architecture
 //!
@@ -14,18 +13,31 @@
 //! layer, and [`TypedSuperuserCreator<U>`] bridges the two by combining
 //! [`SuperuserInit`] for construction with `Model` for ORM operations.
 //!
-//! # Global Registry
+//! # Registration
 //!
 //! Projects register their user type at startup via
 //! [`register_superuser_creator`], and the `createsuperuser` management
 //! command retrieves it via [`get_superuser_creator`].
 //!
+//! ## Recommended: Using `#[user]` macro
+//!
+//! The simplest path is to use `#[user(full=true)]` with `#[model]`,
+//! which auto-generates [`SuperuserInit`]:
+//!
 //! ```rust,ignore
 //! use reinhardt_auth::{register_superuser_creator, superuser_creator_for};
 //! use myapp::models::CustomUser;
 //!
+//! // CustomUser has #[user(hasher = Argon2Hasher, username_field = "username", full = true)]
+//! // and #[model(table_name = "auth_user")] — SuperuserInit is auto-generated.
 //! register_superuser_creator(superuser_creator_for::<CustomUser>());
 //! ```
+//!
+//! ## Manual `BaseUser` implementors
+//!
+//! If you implement [`BaseUser`] manually without the `#[user]` macro,
+//! you can still use `createsuperuser` by implementing [`SuperuserInit`]
+//! yourself. See the [`SuperuserInit`] documentation for an example.
 
 use async_trait::async_trait;
 use std::marker::PhantomData;
@@ -35,15 +47,42 @@ use crate::core::BaseUser;
 
 /// Trait for initializing a user struct as a superuser.
 ///
-/// This trait is automatically implemented by the `#[user]` attribute macro.
-/// It uses compile-time field name resolution, so field renames via
+/// # Auto-generation (recommended)
+///
+/// This trait is automatically implemented by the `#[user(full=true)]`
+/// attribute macro when `#[model]` is also present. The macro uses
+/// compile-time field name resolution, so field renames via
 /// `#[user_field(...)]` are handled correctly.
 ///
-/// # Example
+/// # Manual implementation
 ///
-/// Given a struct with `#[user_field(date_joined)]` on a field named
-/// `created_at`, the generated implementation will correctly set
-/// `self.created_at` rather than looking for `self.date_joined`.
+/// Projects that implement [`BaseUser`] manually (without the `#[user]`
+/// macro) can implement this trait directly. The struct must also
+/// implement `Default`.
+///
+/// ```rust,ignore
+/// use reinhardt_auth::SuperuserInit;
+///
+/// impl SuperuserInit for MyUser {
+///     fn init_superuser(username: &str, email: &str) -> Self {
+///         Self {
+///             username: username.to_string(),
+///             email: email.to_string(),
+///             is_superuser: true,
+///             is_staff: true,
+///             is_active: true,
+///             date_joined: chrono::Utc::now(),
+///             ..Default::default()
+///         }
+///     }
+/// }
+/// ```
+///
+/// Then register in `manage.rs`:
+///
+/// ```rust,ignore
+/// register_superuser_creator(superuser_creator_for::<MyUser>());
+/// ```
 pub trait SuperuserInit: Default + Send + Sync {
 	/// Create a new instance configured as a superuser.
 	///

--- a/crates/reinhardt-commands/src/createsuperuser.rs
+++ b/crates/reinhardt-commands/src/createsuperuser.rs
@@ -155,7 +155,13 @@ pub(crate) async fn execute_createsuperuser(
 
 	let creator = reinhardt_auth::get_superuser_creator().ok_or(
 		"No SuperuserCreator registered. Call reinhardt_auth::register_superuser_creator() \
-		 in your manage.rs before execute_from_command_line().",
+		 in your manage.rs before execute_from_command_line().\n\
+		 \n\
+		 If using #[user(full=true)] + #[model]:\n  \
+		   register_superuser_creator(superuser_creator_for::<YourUser>());\n\
+		 \n\
+		 If implementing BaseUser manually, also implement SuperuserInit.\n\
+		 See reinhardt_auth::SuperuserInit documentation for details.",
 	)?;
 
 	match creator


### PR DESCRIPTION
## Summary

- Document how to manually implement `SuperuserInit` for custom user types without `#[user]` macro
- Improve error message in `createsuperuser` command to guide users to both macro and manual paths

## Type of Change

- [x] Documentation update

## Motivation and Context

`createsuperuser` requires `SuperuserInit`, which is only auto-generated by `#[user(full=true)]` + `#[model]`. Manual `BaseUser` implementors had no documented path to make `createsuperuser` work, even though `SuperuserInit` is a simple public trait that can be implemented manually.

Fixes #3182

## How Was This Tested?

- `cargo check -p reinhardt-auth -p reinhardt-commands --all-features` passes
- Documentation-only changes verified by reading the rendered doc comments

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

### Scope Label (select all that apply)
- [x] `auth` - Authentication, authorization, sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)