### PR TITLE
fix(pages-macros): inline is_safe_url to remove reinhardt-core dependency

### DIFF
--- a/crates/reinhardt-pages/macros/Cargo.toml
+++ b/crates/reinhardt-pages/macros/Cargo.toml
@@ -20,9 +20,6 @@ default = []
 # DSL definitions (new canonical location)
 reinhardt-manouche = { workspace = true }
 
-# Security utilities for URL validation (Fixes #849)
-reinhardt-core = { workspace = true }
-
 # Procedural macro essentials
 syn = { workspace = true, features = ["full", "extra-traits"] }
 quote = { workspace = true }

--- a/crates/reinhardt-pages/macros/src/page/validator.rs
+++ b/crates/reinhardt-pages/macros/src/page/validator.rs
@@ -14,12 +14,32 @@
 use proc_macro2::Span;
 use syn::{Expr, Result};
 
-use reinhardt_core::security::xss::is_safe_url;
 use reinhardt_manouche::core::{
 	PageAttr, PageBody, PageComponent, PageElement, PageElse, PageEvent, PageMacro, PageNode,
 	PageWatch, TypedPageAttr, TypedPageBody, TypedPageComponent, TypedPageElement, TypedPageElse,
 	TypedPageFor, TypedPageIf, TypedPageMacro, TypedPageNode, TypedPageWatch, types::AttrValue,
 };
+
+/// Check if a URL is safe (no dangerous schemes like javascript:).
+///
+/// Inlined from `reinhardt_core::security::xss::is_safe_url` to avoid
+/// pulling the full reinhardt-core dependency chain (hyper/tokio/mio)
+/// into this proc-macro crate, which breaks WASM builds. (Fixes #3226)
+fn is_safe_url(url: &str) -> bool {
+	let url_lower = url.to_lowercase();
+
+	// Allow relative URLs and anchor links (but NOT parent traversal)
+	if url.starts_with('/') || url.starts_with("./") || url.starts_with('#') {
+		return true;
+	}
+
+	// Allow only safe protocols
+	let safe_protocols = ["http://", "https://", "mailto:", "ftp://", "ftps://"];
+
+	safe_protocols
+		.iter()
+		.any(|protocol| url_lower.starts_with(protocol))
+}
 
 /// Validates and transforms the entire PageMacro AST into a typed AST.
 ///
@@ -818,6 +838,7 @@ fn validate_element_nesting(elem: &PageElement, parent_tags: &[String]) -> Resul
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::rstest;
 	use syn::parse_quote;
 
 	#[test]
@@ -1422,5 +1443,22 @@ mod tests {
 		let result =
 			validate_button_accessibility(&attrs, &children, proc_macro2::Span::call_site());
 		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	#[case("https://example.com", true)]
+	#[case("http://example.com", true)]
+	#[case("mailto:user@example.com", true)]
+	#[case("ftp://files.example.com", true)]
+	#[case("ftps://files.example.com", true)]
+	#[case("/relative/path", true)]
+	#[case("./local/path", true)]
+	#[case("#anchor", true)]
+	#[case("javascript:alert(1)", false)]
+	#[case("data:text/html,<script>alert(1)</script>", false)]
+	#[case("vbscript:msgbox", false)]
+	#[case("JAVASCRIPT:alert(1)", false)]
+	fn test_is_safe_url(#[case] url: &str, #[case] expected: bool) {
+		assert_eq!(is_safe_url(url), expected);
 	}
 }


### PR DESCRIPTION
## Summary

- Inline `is_safe_url` function into `reinhardt-pages-macros` to break the transitive `hyper → tokio → mio` dependency chain that causes WASM builds to fail
- Remove `reinhardt-core` dependency from the proc-macro crate

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The proc-macro crate `reinhardt-pages-macros` depended on the full `reinhardt-core` crate solely for a single 15-line URL validation function (`is_safe_url`). Since proc-macro crates are compiled for the host target, this pulled `hyper/tokio/mio` into the WASM dependency graph through the resolver, causing `wasm32-unknown-unknown` builds to fail with 49 `mio` compilation errors.

Fixes #3226

Related to: #3227, #81, PR #111

## How Was This Tested?

- `cargo check -p reinhardt-pages-macros` — passes
- `cargo nextest run -p reinhardt-pages-macros` — 269 tests pass (12 new parametrized tests for inlined function)
- `cargo check -p reinhardt-pages --all-features` — passes
- `cargo tree --target wasm32-unknown-unknown -p reinhardt-web -i mio --edges normal` — returns empty (mio no longer in WASM dependency graph)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- #3226 — WASM build failure due to unconditional tokio/mio dependency
- #3227 — runserver --with-pages auto-build (related, separate PR)
- #81 — Original WASM build issue (closed, but fix was incomplete)
- PR #111 — Previous partial fix

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- None directly applicable (proc-macro dependency management)

### Priority Label (for maintainers)
- [x] `critical` - Blocks release or major functionality

---

**Additional Context:**

The `is_safe_url` function is a simple 15-line URL scheme validator with no external dependencies. Inlining it into the proc-macro crate eliminates the need for `reinhardt-core` as a dependency, which was the root cause of the WASM build failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)