### PR TITLE
feat(commands): auto-build WASM when runserver --with-pages is used

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1321,6 +1321,8 @@ impl BaseCommand for RunServerCommand {
 			)
 			.with_default("dist"),
 			CommandOption::flag(None, "no-spa", "Disable SPA mode (no index.html fallback)"),
+			CommandOption::flag(None, "no-wasm", "Skip WASM build at startup"),
+			CommandOption::flag(None, "force-wasm", "Force rebuild WASM even if artifacts exist"),
 		]
 	}
 
@@ -1335,6 +1337,15 @@ impl BaseCommand for RunServerCommand {
 			.map(|s| s.to_string())
 			.unwrap_or_else(|| "dist".to_string());
 		let no_spa = ctx.has_option("no-spa");
+		// Build WASM frontend if --with-pages and not --no-wasm
+		#[cfg(feature = "pages")]
+		{
+			let no_wasm = ctx.has_option("no-wasm");
+			let force_wasm = ctx.has_option("force-wasm");
+			if with_pages && !no_wasm {
+				Self::build_pages_wasm(ctx, force_wasm);
+			}
+		}
 
 		// Find available port early (before displaying banner)
 		#[cfg(feature = "server")]
@@ -1929,6 +1940,74 @@ impl RunServerCommand {
 				&& !path_str.ends_with(".tmp")
 				&& (path_str.ends_with(".rs") || path_str.ends_with(".toml"))
 		})
+	}
+
+	/// Build the pages WASM bundle from the current project (if it declares cdylib).
+	///
+	/// Mirrors the logic in the standalone runserver binary. Build failure is
+	/// non-fatal — a warning is displayed but the server continues to start.
+	#[cfg(feature = "pages")]
+	fn build_pages_wasm(ctx: &CommandContext, force: bool) {
+		let cwd = match std::env::current_dir() {
+			Ok(d) => d,
+			Err(e) => {
+				ctx.warning(&format!("Failed to get current directory: {}", e));
+				return;
+			}
+		};
+		let cargo_toml_path = cwd.join("Cargo.toml");
+
+		// Only build if this project exports cdylib
+		if !crate::wasm_builder::detect_cdylib_in_cargo_toml(&cargo_toml_path) {
+			return;
+		}
+
+		// Parse the crate name from Cargo.toml
+		let crate_name = match std::fs::read_to_string(&cargo_toml_path) {
+			Ok(content) => {
+				let mut name = String::new();
+				for line in content.lines() {
+					let trimmed = line.trim();
+					if trimmed.starts_with("name")
+						&& trimmed.contains('=')
+						&& let Some(val) = trimmed.split('=').nth(1)
+					{
+						name = val.trim().trim_matches('"').trim_matches('\'').to_string();
+						break;
+					}
+				}
+				if name.is_empty() {
+					ctx.warning("Could not determine crate name from Cargo.toml");
+					return;
+				}
+				name
+			}
+			Err(e) => {
+				ctx.warning(&format!("Failed to read Cargo.toml: {}", e));
+				return;
+			}
+		};
+
+		let js_name = crate_name.replace('-', "_");
+		let artifact = cwd.join("dist").join(format!("{}.js", js_name));
+		if artifact.exists() && !force {
+			ctx.info("Pages WASM: artifacts exist, skipping build (use --force-wasm to rebuild)");
+			return;
+		}
+
+		ctx.info(&format!("Building pages WASM for {}...", crate_name));
+		let config = crate::wasm_builder::WasmBuildConfig::new(".").output_dir("dist");
+		match crate::wasm_builder::WasmBuilder::new(config).build() {
+			Ok(_) => {
+				ctx.info("Pages WASM build succeeded.");
+			}
+			Err(e) => {
+				ctx.warning(&format!(
+					"Pages WASM build failed: {}. Server will start without WASM frontend.",
+					e
+				));
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add automatic WASM build step to `RunServerCommand::execute()` when `--with-pages` is used
- Add `--no-wasm` and `--force-wasm` flags to the management command's runserver
- Mirrors the behavior of the standalone runserver binary

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

The management command `cargo run --bin manage runserver --with-pages` did not build WASM before starting the server. The standalone binary (`bin/runserver.rs`) already had this functionality via `build_wasm_targets()`, but the management command path (`RunServerCommand` in `builtin.rs`) skipped it entirely. This caused the `dist/` directory to never be created, resulting in all frontend asset requests being served as SPA fallback HTML.

Fixes #3227

Related to: #3226

## How Was This Tested?

- `cargo check -p reinhardt-commands --all-features` — passes
- `cargo nextest run -p reinhardt-commands --all-features` — passes (876/878, 2 pre-existing failures in unrelated `collectstatic_tests`)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- #3227 — runserver --with-pages does not auto-build WASM
- #3226 — WASM build itself fails (separate fix in PR #3228)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `http` - HTTP layer, handlers, middleware

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

This PR reuses the existing `WasmBuilder` and `WasmBuildConfig` infrastructure from `wasm_builder.rs`. Build failure is non-fatal (warning only), matching the standalone binary behavior. The WASM build only runs when the project declares `cdylib` in its Cargo.toml.

Note: This PR should be merged after #3228 (which fixes the WASM build itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)