### PR TITLE
style(examples): fix import ordering in twitter middleware

### DIFF
--- a/examples/examples-twitter/src/config/middleware.rs
+++ b/examples/examples-twitter/src/config/middleware.rs
@@ -2,9 +2,9 @@
 //!
 //! Production-ready middleware stack for the Twitter clone example.
 
+use reinhardt::SecuritySettings;
 use reinhardt::middleware::cors::CorsConfig;
 use reinhardt::middleware::security_middleware::SecurityMiddleware;
-use reinhardt::SecuritySettings;
 use reinhardt::middleware::session::{SessionConfig, SessionMiddleware};
 use reinhardt::middleware::{CorsMiddleware, LoggingMiddleware};
 use reinhardt::prelude::*;


### PR DESCRIPTION
## Summary

- Fix import ordering in `examples/examples-twitter/src/config/middleware.rs` to pass `cargo make fmt-check`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `examples-twitter` CI job (`fmt-check`) was failing because `reinhardt::SecuritySettings` was imported after submodule imports, violating the formatter's ordering rules.

This was one of two CI failures on the release-plz PR #3274. The other (UUID PK in admin `create()`) was fixed in PR #3275.

Related to: #3274

## How Was This Tested?

- `cargo make fmt-check` passes in `examples/examples-twitter/`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)