### PR TITLE
fix(examples): gate Validate derive and imports for WASM target compatibility

### DIFF
--- a/examples/examples-tutorial-basis/Cargo.toml
+++ b/examples/examples-tutorial-basis/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0.145"
 
 # WASM-specific dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-reinhardt = { workspace = true, features = ["pages"] }
+reinhardt = { workspace = true, features = ["pages", "client-router"] }
 wasm-bindgen = "0.2.106"
 wasm-bindgen-futures = "0.4.56"
 web-sys = { version = "0.3.83", features = [

--- a/examples/examples-tutorial-basis/src/config/urls.rs
+++ b/examples/examples-tutorial-basis/src/config/urls.rs
@@ -4,9 +4,11 @@
 
 #[cfg(server)]
 use reinhardt::pages::server_fn::ServerFnRouterExt;
+#[cfg(server)]
 use reinhardt::prelude::*;
 #[cfg(server)]
 use reinhardt::routes;
+use reinhardt::UnifiedRouter;
 
 // Import server_fn marker modules (snake_case + ::marker)
 #[cfg(server)]

--- a/examples/examples-twitter/src/apps/auth/shared/types.rs
+++ b/examples/examples-twitter/src/apps/auth/shared/types.rs
@@ -4,6 +4,7 @@
 //! These types are serializable and can be sent between the WASM client
 //! and the Rust server via server functions.
 
+#[cfg(server)]
 use reinhardt::Validate;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -37,36 +38,47 @@ impl From<crate::apps::auth::models::User> for UserInfo {
 
 /// Login request
 #[cfg_attr(server, derive(Schema))]
-#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+#[cfg_attr(server, derive(Validate))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoginRequest {
-	#[validate(email(message = "Invalid email address"))]
+	#[cfg_attr(server, validate(email(message = "Invalid email address")))]
 	pub email: String,
 
-	#[validate(length(min = 1, message = "Password is required"))]
+	#[cfg_attr(server, validate(length(min = 1, message = "Password is required")))]
 	pub password: String,
 }
 
 /// Register request
 #[cfg_attr(server, derive(Schema))]
-#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+#[cfg_attr(server, derive(Validate))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisterRequest {
-	#[validate(length(
-		min = 3,
-		max = 150,
-		message = "Username must be between 3 and 150 characters"
-	))]
+	#[cfg_attr(
+		server,
+		validate(length(
+			min = 3,
+			max = 150,
+			message = "Username must be between 3 and 150 characters"
+		))
+	)]
 	pub username: String,
 
-	#[validate(email(message = "Invalid email address"))]
+	#[cfg_attr(server, validate(email(message = "Invalid email address")))]
 	pub email: String,
 
-	#[validate(length(min = 8, message = "Password must be at least 8 characters"))]
+	#[cfg_attr(
+		server,
+		validate(length(min = 8, message = "Password must be at least 8 characters"))
+	)]
 	pub password: String,
 
-	#[validate(length(
-		min = 8,
-		message = "Password confirmation must be at least 8 characters"
-	))]
+	#[cfg_attr(
+		server,
+		validate(length(
+			min = 8,
+			message = "Password confirmation must be at least 8 characters"
+		))
+	)]
 	pub password_confirmation: String,
 }
 

--- a/examples/examples-twitter/src/apps/profile/shared/types.rs
+++ b/examples/examples-twitter/src/apps/profile/shared/types.rs
@@ -3,6 +3,7 @@
 //! These types are serializable and can be sent between the WASM client
 //! and the Rust server via server functions.
 
+#[cfg(server)]
 use reinhardt::Validate;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -40,17 +41,24 @@ impl From<crate::apps::profile::models::Profile> for ProfileResponse {
 
 /// Update profile request
 #[cfg_attr(server, derive(Schema))]
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, Default)]
+#[cfg_attr(server, derive(Validate))]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UpdateProfileRequest {
-	#[validate(length(max = 500, message = "Bio must be less than 500 characters"))]
+	#[cfg_attr(
+		server,
+		validate(length(max = 500, message = "Bio must be less than 500 characters"))
+	)]
 	pub bio: Option<String>,
 
-	#[validate(url(message = "Invalid avatar URL"))]
+	#[cfg_attr(server, validate(url(message = "Invalid avatar URL")))]
 	pub avatar_url: Option<String>,
 
-	#[validate(length(max = 100, message = "Location must be less than 100 characters"))]
+	#[cfg_attr(
+		server,
+		validate(length(max = 100, message = "Location must be less than 100 characters"))
+	)]
 	pub location: Option<String>,
 
-	#[validate(url(message = "Invalid website URL"))]
+	#[cfg_attr(server, validate(url(message = "Invalid website URL")))]
 	pub website: Option<String>,
 }

--- a/examples/examples-twitter/src/apps/tweet/shared/types.rs
+++ b/examples/examples-twitter/src/apps/tweet/shared/types.rs
@@ -3,6 +3,7 @@
 //! These types are serializable and can be sent between the WASM client
 //! and the Rust server via server functions.
 
+#[cfg(server)]
 use reinhardt::Validate;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -67,12 +68,16 @@ impl From<crate::apps::tweet::models::Tweet> for TweetInfo {
 
 /// Create tweet request
 #[cfg_attr(server, derive(Schema))]
-#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+#[cfg_attr(server, derive(Validate))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateTweetRequest {
-	#[validate(length(
-		min = 1,
-		max = 280,
-		message = "Tweet must be between 1 and 280 characters"
-	))]
+	#[cfg_attr(
+		server,
+		validate(length(
+			min = 1,
+			max = 280,
+			message = "Tweet must be between 1 and 280 characters"
+		))
+	)]
 	pub content: String,
 }


### PR DESCRIPTION
## Summary

- Gate `reinhardt::Validate` imports with `#[cfg(server)]` in examples-twitter shared types
- Replace unconditional `derive(Validate)` with `#[cfg_attr(server, derive(Validate))]` for WASM compatibility
- Add `client-router` feature to examples-tutorial-basis WASM dependencies for `UnifiedRouter` availability
- Gate `use reinhardt::prelude::*` with `#[cfg(server)]` in tutorial-basis urls.rs

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

After commit f54be9a5, WASM target compilation (`wasm32-unknown-unknown`) fails because shared types in examples-twitter unconditionally import `reinhardt::Validate`, which is gated behind `#[cfg(not(target_arch = "wasm32"))]` in the framework. Similarly, tutorial-basis uses `reinhardt::prelude::*` unconditionally, but prelude is server-only.

Fixes #3281

## How Was This Tested?

- [x] `cargo check --target wasm32-unknown-unknown` passes for examples-twitter
- [x] `cargo check --target wasm32-unknown-unknown` passes for examples-tutorial-basis
- [x] `cargo check --workspace --all-features` passes (server-side)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)