### PR TITLE
fix(commands): add --lib flag to WASM cargo build

### DIFF
--- a/crates/reinhardt-commands/src/wasm_builder.rs
+++ b/crates/reinhardt-commands/src/wasm_builder.rs
@@ -247,6 +247,7 @@ impl WasmBuilder {
 	fn run_cargo_build(&self) -> Result<(), WasmBuildError> {
 		let mut cmd = Command::new("cargo");
 		cmd.arg("build")
+			.arg("--lib")
 			.arg("--target")
 			.arg("wasm32-unknown-unknown")
 			.current_dir(&self.config.project_dir);


### PR DESCRIPTION
## Summary

- Add `--lib` flag to `cargo build --target wasm32-unknown-unknown` in `wasm_builder.rs` to prevent binary targets from being compiled for WASM

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`runserver --with-pages` invokes `cargo build --target wasm32-unknown-unknown` without the `--lib` flag, causing all targets (including binaries like `manage.rs`) to be compiled for wasm32. Binary targets contain native-only imports (`reinhardt::commands`, `tokio`, etc.) that cannot compile for the WASM target.

Fixes #3289

## How Was This Tested?

- `cargo check --workspace --all-features` passes
- `cargo make fmt-check` passes
- `cargo make clippy-check` passes (pre-existing warnings only)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [ ] None specific — affects WASM build tooling in `reinhardt-commands`

🤖 Generated with [Claude Code](https://claude.com/claude-code)