### PR TITLE
fix(commands): resolve WASM artifact path relative to workspace root

### DIFF
--- a/crates/reinhardt-commands/src/bin/runserver.rs
+++ b/crates/reinhardt-commands/src/bin/runserver.rs
@@ -551,7 +551,19 @@ fn build_pages_wasm(force: bool) -> bool {
 		"{}",
 		format!("Building pages WASM for {}...", crate_name).cyan()
 	);
-	let config = WasmBuildConfig::new(".").output_dir("dist");
+	// Resolve workspace root so wasm-bindgen finds the artifact in the
+	// workspace-level target directory, not relative to the member crate CWD.
+	let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+	let workspace_root = manifest_dir
+		.parent()
+		.and_then(|p| p.parent())
+		.and_then(|p| p.parent())
+		.and_then(|p| p.parent())
+		.map(PathBuf::from)
+		.unwrap_or_else(|| PathBuf::from("."));
+	let config = WasmBuildConfig::new(".")
+		.output_dir("dist")
+		.target_dir(workspace_root.join("target"));
 	match WasmBuilder::new(config).build() {
 		Ok(_) => {
 			println!("{}", "Pages WASM build succeeded.".green());

--- a/crates/reinhardt-commands/src/wasm_builder.rs
+++ b/crates/reinhardt-commands/src/wasm_builder.rs
@@ -20,6 +20,10 @@ pub struct WasmBuildConfig {
 	pub optimize: bool,
 	/// Target name (crate name, used for output file naming)
 	pub target_name: Option<String>,
+	/// Override for the cargo target directory. When `None`, falls back to
+	/// `project_dir/target`. In workspace setups, this should point to the
+	/// workspace root's target directory.
+	pub target_dir: Option<PathBuf>,
 }
 
 impl Default for WasmBuildConfig {
@@ -30,6 +34,7 @@ impl Default for WasmBuildConfig {
 			release: false,
 			optimize: true,
 			target_name: None,
+			target_dir: None,
 		}
 	}
 }
@@ -64,6 +69,16 @@ impl WasmBuildConfig {
 	/// Set the target name explicitly.
 	pub fn target_name(mut self, name: impl Into<String>) -> Self {
 		self.target_name = Some(name.into());
+		self
+	}
+
+	/// Set the cargo target directory explicitly.
+	///
+	/// When building inside a Cargo workspace, the target directory is at
+	/// the workspace root, not relative to the member crate. Use this to
+	/// point wasm-bindgen at the correct artifact location.
+	pub fn target_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+		self.target_dir = Some(dir.into());
 		self
 	}
 }
@@ -146,10 +161,13 @@ impl WasmBuilder {
 		} else {
 			"debug"
 		};
-		let wasm_path = self
+		let target_base = self
 			.config
-			.project_dir
-			.join("target")
+			.target_dir
+			.as_ref()
+			.cloned()
+			.unwrap_or_else(|| self.config.project_dir.join("target"));
+		let wasm_path = target_base
 			.join("wasm32-unknown-unknown")
 			.join(profile)
 			.join(format!("{}.wasm", crate_name.replace('-', "_")));


### PR DESCRIPTION
## Summary

- Add `target_dir` override to `WasmBuildConfig` for workspace-aware WASM artifact resolution
- Detect workspace root via `CARGO_MANIFEST_DIR` parent traversal in `build_pages_wasm()`
- Reuses existing pattern from `build_admin_wasm()`

Fixes #3295

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

When `runserver --with-pages` is executed from a workspace member directory, wasm-bindgen looks for the WASM file at `./target/...` relative to CWD. However, cargo builds to the workspace root's `target/` directory, causing "No such file or directory" errors.

Fixes #3295

## How Was This Tested?

- `cargo check --workspace --all --all-features` passes
- `cargo nextest run --package reinhardt-commands --all-features` — 772 tests pass
- `cargo make fmt-check` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)