### PR TITLE
Validate project directory before running makemigrations

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -549,6 +549,19 @@ impl BaseCommand for MakeMigrationsCommand {
 			.unwrap_or_else(|| "migrations".to_string());
 		let migrations_dir = PathBuf::from(migrations_dir_str);
 
+		// Validate that we are running inside a Reinhardt project directory.
+		// A valid project must contain src/bin/manage.rs (the management command
+		// entry point). Running makemigrations from the wrong directory would
+		// silently create migration files in unexpected locations.
+		if !PathBuf::from("src/bin/manage.rs").exists() {
+			return Err(crate::CommandError::ExecutionError(
+				"Cannot find src/bin/manage.rs in the current directory. \
+				 Please run makemigrations from your Reinhardt project root \
+				 (the directory containing src/bin/manage.rs)."
+					.to_string(),
+			));
+		}
+
 		if is_dry_run {
 			ctx.warning("Dry run mode: No files will be created");
 		}


### PR DESCRIPTION
## Summary

- Add check that `src/bin/manage.rs` exists before creating migration files
- Prevents silently writing migrations to unexpected locations when running from the wrong directory
- Clear error message directs the user to the correct directory

## Test plan

- [x] `cargo check -p reinhardt-commands` passes
- [ ] Run `makemigrations` from project root → succeeds
- [ ] Run `makemigrations` from a non-project directory → errors with descriptive message

🤖 Generated with [Claude Code](https://claude.com/claude-code)