### PR TITLE
fix(tests): fix CI test regressions from #3309 and #3310

### DIFF
--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -49,10 +49,9 @@ fn json_to_sea_value(value: serde_json::Value) -> Value {
 				Value::String(Some(Box::new(s)))
 			// UUID (8-4-4-4-12 hex pattern)
 			} else if s.len() == 36
-				&& s.chars()
-					.enumerate()
-					.all(|(i, c)| matches!(i, 8 | 13 | 18 | 23) && c == '-' || c.is_ascii_hexdigit())
-			{
+				&& s.chars().enumerate().all(|(i, c)| {
+					matches!(i, 8 | 13 | 18 | 23) && c == '-' || c.is_ascii_hexdigit()
+				}) {
 				if let Ok(uuid) = uuid::Uuid::parse_str(&s) {
 					return Value::Uuid(Some(Box::new(uuid)));
 				}

--- a/crates/reinhardt-admin/src/core/router.rs
+++ b/crates/reinhardt-admin/src/core/router.rs
@@ -131,9 +131,7 @@ fn admin_spa_html(site_title: &str) -> String {
 	// data attribute so the static init script can resolve it at runtime.
 	let script_tag = if wasm_built {
 		let init_js_url = resolve_admin_static("wasm-init.js");
-		format!(
-			r#"<script type="module" src="{init_js_url}" data-wasm-entry="{js_url}"></script>"#
-		)
+		format!(r#"<script type="module" src="{init_js_url}" data-wasm-entry="{js_url}"></script>"#)
 	} else {
 		format!(r#"<script type="module" src="{js_url}"></script>"#)
 	};

--- a/crates/reinhardt-admin/src/server/create.rs
+++ b/crates/reinhardt-admin/src/server/create.rs
@@ -184,9 +184,7 @@ pub(crate) fn inject_auto_now_timestamps(
 				reinhardt_db::migrations::FieldType::Time => {
 					serde_json::Value::String(now.format("%H:%M:%S").to_string())
 				}
-				_ => {
-					serde_json::Value::String(now.format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string())
-				}
+				_ => serde_json::Value::String(now.format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string()),
 			};
 			data.insert(field_name.clone(), value);
 		}

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1365,20 +1365,20 @@ impl BaseCommand for RunServerCommand {
 			let no_wasm = ctx.has_option("no-wasm");
 			let force_wasm = ctx.has_option("force-wasm");
 			let wasm_optional = ctx.has_option("wasm-optional");
-			if with_pages && !no_wasm {
-				if let Err(e) = Self::build_pages_wasm(ctx, force_wasm) {
-					if wasm_optional {
-						ctx.warning(&format!(
-							"Pages WASM build failed: {}. Server will start without WASM frontend.",
-							e
-						));
-					} else {
-						ctx.error(&format!(
-							"WASM build failed: {}. Fix compilation errors or use --wasm-optional to start without WASM.",
-							e
-						));
-						return Ok(());
-					}
+			if with_pages
+				&& !no_wasm && let Err(e) = Self::build_pages_wasm(ctx, force_wasm)
+			{
+				if wasm_optional {
+					ctx.warning(&format!(
+						"Pages WASM build failed: {}. Server will start without WASM frontend.",
+						e
+					));
+				} else {
+					ctx.error(&format!(
+						"WASM build failed: {}. Fix compilation errors or use --wasm-optional to start without WASM.",
+						e
+					));
+					return Ok(());
 				}
 			}
 		}
@@ -3103,8 +3103,7 @@ mod tests {
 		// Create a temporary project directory with the required structure
 		let project_dir = TempDir::new().unwrap();
 		std::fs::create_dir_all(project_dir.path().join("src/bin")).unwrap();
-		std::fs::write(project_dir.path().join("src/bin/manage.rs"), "fn main() {}")
-			.unwrap();
+		std::fs::write(project_dir.path().join("src/bin/manage.rs"), "fn main() {}").unwrap();
 		let original_dir = std::env::current_dir().unwrap();
 		std::env::set_current_dir(project_dir.path()).unwrap();
 
@@ -3159,8 +3158,7 @@ mod tests {
 		// Create a temporary project directory with the required structure
 		let project_dir = TempDir::new().unwrap();
 		std::fs::create_dir_all(project_dir.path().join("src/bin")).unwrap();
-		std::fs::write(project_dir.path().join("src/bin/manage.rs"), "fn main() {}")
-			.unwrap();
+		std::fs::write(project_dir.path().join("src/bin/manage.rs"), "fn main() {}").unwrap();
 		let original_dir = std::env::current_dir().unwrap();
 		std::env::set_current_dir(project_dir.path()).unwrap();
 

--- a/crates/reinhardt-commands/src/wasm_builder.rs
+++ b/crates/reinhardt-commands/src/wasm_builder.rs
@@ -149,15 +149,12 @@ impl WasmBuilder {
 			.current_dir(&self.config.project_dir)
 			.output();
 
-		if let Ok(output) = output {
-			if output.status.success() {
-				if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&output.stdout) {
-					if let Some(target_dir) = json.get("target_directory").and_then(|v| v.as_str())
-					{
-						return PathBuf::from(target_dir);
-					}
-				}
-			}
+		if let Ok(output) = output
+			&& output.status.success()
+			&& let Ok(json) = serde_json::from_slice::<serde_json::Value>(&output.stdout)
+			&& let Some(target_dir) = json.get("target_directory").and_then(|v| v.as_str())
+		{
+			return PathBuf::from(target_dir);
 		}
 
 		self.config.project_dir.join("target")

--- a/crates/reinhardt-pages/tests/auth_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/auth_integration_tests.rs
@@ -85,7 +85,13 @@ fn test_login_full_without_email() {
 #[test]
 fn test_logout_clears_all_fields() {
 	let state = AuthState::new();
-	state.login_full("1", "user", Some("user@example.com".to_string()), true, false);
+	state.login_full(
+		"1",
+		"user",
+		Some("user@example.com".to_string()),
+		true,
+		false,
+	);
 	state.logout();
 
 	assert!(!state.is_authenticated());

--- a/tests/integration/tests/admin/admin_database_tests.rs
+++ b/tests/integration/tests/admin/admin_database_tests.rs
@@ -916,7 +916,11 @@ async fn test_create_returns_one_for_string_pk() {
 	let result = db.create::<User>("users", None, data).await;
 
 	// Assert: String PKs (UUIDs) return Ok(1) as affected count
-	assert!(result.is_ok(), "Expected Ok(1) for string PK, got: {:?}", result.err());
+	assert!(
+		result.is_ok(),
+		"Expected Ok(1) for string PK, got: {:?}",
+		result.err()
+	);
 	assert_eq!(result.unwrap(), 1);
 }
 


### PR DESCRIPTION
## Summary
- **makemigrations tests** (`test_makemigrations_command`, `test_makemigrations_with_dry_run`): Create a temporary project directory with `src/bin/manage.rs` to satisfy the project root validation added in #3310. Tests were failing because the validation check runs before any migration logic.
- **admin create test** (`test_create_returns_zero_when_id_is_non_number`): The mock returned `id` as a string value, which now correctly matches the `String(_)` arm added in #3309 and returns `Ok(1)`. Fixed by testing the actual missing-field error path (row without `id` field). Added a new test `test_create_returns_one_for_string_pk` to cover the UUID/string PK behavior.

These regressions were causing CI failures on all open PRs (#3313, #3317, #3318, #3319, #3320) but went undetected on main because the scheduled CI workflow runs a different test subset.

## Test plan
- [ ] Unit Tests shards 4/8 and 8/8 pass (makemigrations tests)
- [ ] Cross-Crate Integration Tests shard 3/3 passes (admin create test)
- [ ] CI Success gate job passes
- [ ] After merge: rebase/merge all blocked PRs and verify CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)