### PR TITLE
refactor(admin): update workaround comments for @event closure capture

### DIFF
--- a/crates/reinhardt-admin/src/pages/components/common.rs
+++ b/crates/reinhardt-admin/src/pages/components/common.rs
@@ -79,6 +79,7 @@ pub fn button(text: &str, variant: ButtonVariant, disabled: bool, _on_click: Sig
 	// which prevents proper variable capture — `move` makes it FnOnce (wrapper can't
 	// re-invoke inner closure), and without `move` borrows aren't 'static.
 	// Use PageElement with #[cfg] until the macro supports direct capture propagation.
+	// See: https://github.com/kent8192/reinhardt-web/issues/3322
 	#[cfg(target_arch = "wasm32")]
 	let view = PageElement::new("button")
 		.attr("class", classes)
@@ -277,6 +278,7 @@ where
 		// which prevents proper variable capture — `move` makes it FnOnce (wrapper can't
 		// re-invoke inner closure), and without `move` borrows aren't 'static.
 		// Use PageElement with #[cfg] until the macro supports direct capture propagation.
+		// See: https://github.com/kent8192/reinhardt-web/issues/3322
 		use reinhardt_pages::component::{IntoPage, PageElement};
 
 		#[cfg(target_arch = "wasm32")]

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -561,6 +561,7 @@ fn form_element(field: &FormField, input_id: &str) -> Page {
 				name: name,
 				value: value,
 				required: true,
+				autocomplete: "off",
 			}
 		})()
 	} else {
@@ -571,6 +572,7 @@ fn form_element(field: &FormField, input_id: &str) -> Page {
 				id: input_id,
 				name: name,
 				value: value,
+				autocomplete: "off",
 			}
 		})()
 	}
@@ -619,6 +621,7 @@ fn filter_type_to_choices(filter_type: &FilterType) -> Vec<(String, String)> {
 /// which are unavailable on non-WASM targets. The `page!` macro's auto-cfg-gating
 /// wraps the `.on()` call but still compiles the closure body on all platforms.
 /// Migrate when `page!` supports platform-gated handler bodies.
+/// See: <https://github.com/kent8192/reinhardt-web/issues/3322>
 #[allow(unused_variables)]
 fn create_filter_select(
 	field: &str,


### PR DESCRIPTION
## Summary

- Update workaround comments in admin components to accurately describe the root cause of `#[cfg]`-gated `PageElement` usage
- Previous comments referenced #3312 (Send+Sync bounds) which was partially fixed by #3319
- New comments describe the actual remaining issue: `page!` macro's `@event` codegen wraps user closures in a typed wrapper, preventing proper variable capture
- Add issue #3322 references to all workaround comments for traceability
- Add `autocomplete="off"` to model form inputs (leveraging #3320) to prevent browser auto-fill interference with database field values

## Affected Components

- `button()` in `common.rs` — captures `Signal<bool>`
- `create_page_item()` in `common.rs` — captures `Fn(Signal<u64>)` callback
- `create_filter_select()` in `features.rs` — captures `Signal<HashMap>` + uses `JsCast`
- `form_element()` in `features.rs` — added `autocomplete="off"`

## Related

- Fixes #3322 (documents the limitation)
- #3312, #3315 — original issues partially addressed by #3319
- #3319 — cfg-gate @event handlers (enabled auto cfg-gating but didn't fix capture)
- #3320 — autocomplete attribute support (now used in model form inputs)

## Test plan

- [x] `cargo check -p reinhardt-admin --all-features` — passes
- [x] `cargo check -p reinhardt-admin --lib --target wasm32-unknown-unknown` — passes
- [x] `cargo test -p reinhardt-admin --lib` — 474 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)