### PR TITLE
fix(pages): resolve macro codegen issues for consumer crates

### DIFF
--- a/crates/reinhardt-pages/macros/src/page/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/page/codegen.rs
@@ -69,10 +69,13 @@ pub(super) fn generate(macro_ast: &TypedPageMacro) -> TokenStream {
 		body
 	};
 
-	// Wrap in a closure with conditional use statement if needed
+	// Wrap in a closure with conditional use statement if needed.
+	// #[allow(unused_variables)] suppresses warnings for closure parameters that are
+	// only used inside @event handlers, which are cfg-gated to wasm32 (#3327).
 	quote! {
 		{
 			#use_statement
+			#[allow(unused_variables)]
 			#params -> #pages_crate::component::Page {
 				#body_with_head
 			}

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -638,7 +638,7 @@ fn generate_client_stub(
 			#serialize_code
 
 			// Build HTTP POST request with headers
-			let __client = ::reqwest::Client::new();
+			let __client = #pages_crate::__private::reqwest::Client::new();
 			let mut __request_builder = __client.post(&__endpoint)
 				.header("Content-Type", #content_type);
 

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -249,5 +249,12 @@ pub use reinhardt_pages_macros::form;
 pub use reinhardt_pages_macros::head;
 pub use reinhardt_pages_macros::page;
 
+// Private re-exports used by macro-generated code. Not part of the public API.
+#[doc(hidden)]
+#[cfg(target_arch = "wasm32")]
+pub mod __private {
+	pub use reqwest;
+}
+
 // Logging macros are automatically exported via #[macro_export]
 // Users can access them as: reinhardt_pages::debug_log!, reinhardt_pages::info_log!, etc.


### PR DESCRIPTION
## Summary

- **#3328**: Re-export `reqwest` via `#[doc(hidden)] __private` module in `reinhardt-pages`, so `#[server_fn]` WASM stubs reference `reinhardt_pages::__private::reqwest::Client` instead of `::reqwest::Client` — consumers no longer need `reqwest` as a direct dependency
- **#3327**: Add `#[allow(unused_variables)]` to the `page!` macro's generated closure, suppressing warnings for parameters that are only used inside `@event` handlers (cfg-gated to `wasm32`)

## Changed Files

| File | Change |
|------|--------|
| `crates/reinhardt-pages/src/lib.rs` | Add `__private` module with `pub use reqwest` (wasm32 only) |
| `crates/reinhardt-pages/macros/src/server_fn.rs` | Use `#pages_crate::__private::reqwest` path in codegen |
| `crates/reinhardt-pages/macros/src/page/codegen.rs` | Add `#[allow(unused_variables)]` to generated closure |

## Test plan

- [x] `cargo check -p reinhardt-pages-macros` passes
- [x] `cargo check -p reinhardt-pages` passes
- [x] `cargo test -p reinhardt-pages-macros` passes
- [ ] `cargo check --target wasm32-unknown-unknown -p reinhardt-pages` confirms `__private::reqwest` resolves
- [ ] Consumer crate builds for wasm32 without direct `reqwest` dependency

Fixes #3327
Fixes #3328

🤖 Generated with [Claude Code](https://claude.com/claude-code)