### PR TITLE
fix: suppress unused_variables warnings in form! macro codegen

### DIFF
--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -899,7 +899,7 @@ fn generate_onsubmit_handler(macro_ast: &TypedFormMacro, pages_crate: &TokenStre
 
 								// Get field values from cloned signals - allow non_snake_case for generated variable names
 								#(
-									#[allow(non_snake_case)]
+									#[allow(non_snake_case, unused_variables)]
 									let #field_names = #field_value_getters;
 								)*
 
@@ -934,7 +934,7 @@ fn generate_onsubmit_handler(macro_ast: &TypedFormMacro, pages_crate: &TokenStre
 								#loading_start
 
 								#(
-									#[allow(non_snake_case)]
+									#[allow(non_snake_case, unused_variables)]
 									let #field_names = #field_value_getters;
 								)*
 


### PR DESCRIPTION
## Summary
- Add `unused_variables` to `#[allow]` attributes on generated `let` bindings for field values in the form! macro's onsubmit handler
- Without this fix, `cargo fix` / `cargo make auto-fix` renames fields with `_` prefix (e.g. `username` → `_username`), which **breaks generated DOM** since field names are used as `id` and `name` attributes

## Changes
- `crates/reinhardt-pages/macros/src/form/codegen.rs` — 2 sites: WASM and non-WASM onsubmit handlers

Fixes #3340

## Test plan
- [x] `cargo build -p reinhardt-pages-macros` passes
- [x] `cargo test -p reinhardt-pages-macros` — 274 tests pass
- [x] `cargo build -p reinhardt-admin` — zero warnings from reinhardt-admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)