### PR TITLE
fix(infra): add ed25519 SSH key type for Packer AMI builds

### DIFF
--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -76,6 +76,11 @@ source "amazon-ebs" "runner" {
 	subnet_id     = var.subnet_id
 	ssh_username  = "ubuntu"
 
+	# Ubuntu 22.04 AMIs from 2026-03 onwards require ed25519 keys for SSH.
+	# RSA keys are rejected by the updated OpenSSH default configuration.
+	temporary_key_pair_type = "ed25519"
+	ssh_timeout             = "5m"
+
 	source_ami_filter {
 		filters = {
 			name                = local.source_ami_filter


### PR DESCRIPTION
## Summary

- Add `temporary_key_pair_type = "ed25519"` to Packer amazon-ebs source
- Add `ssh_timeout = "5m"` for reliability

### Root cause

Ubuntu 22.04 AMIs from 2026-03 onwards ship with OpenSSH 8.9+ which disables RSA-SHA1 by default. Packer's default RSA key pair is rejected, causing SSH authentication failures during AMI builds.

This broke the weekly `build-runner-ami` workflow starting 2026-03-16, preventing Golden AMI creation. Without a Golden AMI (with Docker, AWS CLI v2, CloudWatch agent pre-installed), ephemeral CI runner instances fail to bootstrap and terminate immediately, causing the `release-plz` workflow to hang indefinitely.

### Impact chain

Packer SSH failure → no Golden AMI → stock Ubuntu AMI used → runner bootstrap fails → release-plz deadlocked

## Test plan

- [ ] Merge this PR
- [ ] Trigger `Build Runner AMI` workflow manually
- [ ] Verify AMI builds successfully and SSM parameter is updated
- [ ] Verify `release-plz` workflow runs on the next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)