### PR TITLE
fix: exclude vendor fonts from .gitignore to resolve release-plz conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ dist-admin/
 # Admin vendor assets (downloaded/generated at build time or collectstatic)
 crates/reinhardt-admin/assets/vendor/*
 !crates/reinhardt-admin/assets/vendor/.gitkeep
+!crates/reinhardt-admin/assets/vendor/fonts/
 examples/examples-twitter/static/admin/
 
 # Design/planning documents (local only)


### PR DESCRIPTION
## Summary

- Add `!crates/reinhardt-admin/assets/vendor/fonts/` exception to `.gitignore`

### Root cause

Three Inter font files (`inter-latin-{600,700,800}-normal.woff2`) were both committed to git and matched by the `vendor/*` gitignore rule. This caused gix (release-plz's internal git library) to report "uncommitted changes", failing with:

```
ERROR failed to update packages
  0: failed to determine next versions
  1: the working directory of this project has uncommitted changes
```

Detected via `git ls-files -ci --exclude-standard`.

## Test plan

- [x] `git ls-files -ci --exclude-standard` returns empty
- [ ] Merge and verify release-plz runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)