### PR TITLE
fix(core): unify flush_updates to execute pending effects

### DIFF
--- a/crates/reinhardt-core/src/reactive/effect.rs
+++ b/crates/reinhardt-core/src/reactive/effect.rs
@@ -308,11 +308,11 @@ impl super::runtime::Runtime {
 		Effect::execute_effect(effect_id);
 	}
 
-	/// Flush all pending updates (enhanced version)
+	/// Flush all pending updates
 	///
 	/// This executes all Effects that have been scheduled for update.
 	/// Skips effects that were disposed between scheduling and execution.
-	pub fn flush_updates_enhanced(&self) {
+	pub fn flush_updates(&self) {
 		*self.update_scheduled.borrow_mut() = false;
 
 		// Take all pending updates
@@ -389,12 +389,12 @@ mod tests {
 
 		// Change signal and flush updates
 		signal.set(10);
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 		assert_eq!(*values.borrow(), alloc::vec![0, 10]);
 
 		// Change again
 		signal.set(20);
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 		assert_eq!(*values.borrow(), alloc::vec![0, 10, 20]);
 	}
 
@@ -417,12 +417,12 @@ mod tests {
 
 		// Change first signal
 		signal1.set(10);
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 		assert_eq!(*sum.borrow(), 12);
 
 		// Change second signal
 		signal2.set(20);
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 		assert_eq!(*sum.borrow(), 30);
 	}
 
@@ -446,7 +446,7 @@ mod tests {
 
 		// Signal change should not trigger the effect
 		signal.set(10);
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 		assert_eq!(*run_count.borrow(), 1); // Still 1, not 2
 	}
 
@@ -469,7 +469,7 @@ mod tests {
 
 		// Signal change should not trigger the dropped effect
 		signal.set(10);
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 		assert_eq!(*run_count.borrow(), 1); // Still 1
 	}
 
@@ -555,16 +555,67 @@ mod tests {
 
 		// Act - trigger re-execution via signal change; effect disposes itself
 		signal.set(1);
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 
 		// Assert - effect ran a second time (during which it disposed itself)
 		assert_eq!(*run_count.borrow(), 2);
 
 		// Act - trigger another change; disposed effect should NOT run
 		signal.set(2);
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 
 		// Assert - still 2, effect did not run again
 		assert_eq!(*run_count.borrow(), 2);
+	}
+
+	/// Verify that `flush_updates()` actually executes pending passive effects.
+	///
+	/// This is a regression test for the bug where `flush_updates()` dropped
+	/// pending updates without executing them (Fixes #3348).
+	#[test]
+	#[serial]
+	fn test_flush_updates_executes_pending_effects() {
+		use crate::reactive::runtime::set_scheduler;
+		use std::sync::{Arc, Mutex};
+
+		// Collect tasks scheduled via set_scheduler
+		let scheduled_tasks: Arc<Mutex<Vec<Box<dyn FnOnce() + Send>>>> =
+			Arc::new(Mutex::new(Vec::new()));
+		let tasks_clone = scheduled_tasks.clone();
+
+		// Install a scheduler that captures tasks instead of executing them
+		// Note: OnceLock means this only works once per process, but serial
+		// test ordering ensures no conflict
+		let _ = set_scheduler(move |task| {
+			tasks_clone.lock().unwrap().push(task);
+		});
+
+		let signal = Signal::new(0);
+		let values = Rc::new(RefCell::new(alloc::vec::Vec::new()));
+		let values_clone = values.clone();
+
+		let signal_clone = signal.clone();
+		// Default timing is Passive, so signal changes go through scheduler
+		let _effect = Effect::new(move || {
+			values_clone.borrow_mut().push(signal_clone.get());
+		});
+
+		// Effect ran once immediately during creation
+		assert_eq!(*values.borrow(), alloc::vec![0]);
+
+		// Change signal — passive effect should be scheduled, not executed immediately
+		signal.set(42);
+
+		// The scheduler captured the flush task
+		let tasks = std::mem::take(&mut *scheduled_tasks.lock().unwrap());
+		assert!(!tasks.is_empty(), "scheduler should have captured a task");
+
+		// Execute the captured tasks (simulating what spawn_local would do)
+		for task in tasks {
+			task();
+		}
+
+		// Effect should have re-executed with the new value
+		assert_eq!(*values.borrow(), alloc::vec![0, 42]);
 	}
 }

--- a/crates/reinhardt-core/src/reactive/runtime.rs
+++ b/crates/reinhardt-core/src/reactive/runtime.rs
@@ -289,23 +289,6 @@ impl Runtime {
 		}
 	}
 
-	/// Flush all pending updates (basic version)
-	///
-	/// This is a basic implementation that clears the pending updates queue.
-	/// For actual Effect execution, use `flush_updates()` which is
-	/// implemented in the effect module.
-	///
-	/// Note: This method is kept for backward compatibility and simple testing.
-	/// Production code should use `flush_updates()` instead.
-	pub fn flush_updates(&self) {
-		*self.update_scheduled.borrow_mut() = false;
-
-		// Take all pending updates
-		let pending = core::mem::take(&mut *self.pending_updates.borrow_mut());
-
-		// Clear the queue (actual execution is handled by flush_updates)
-		drop(pending);
-	}
 
 	/// Clear dependencies for a node
 	///

--- a/crates/reinhardt-pages/src/form/binding.rs
+++ b/crates/reinhardt-pages/src/form/binding.rs
@@ -453,7 +453,7 @@ mod tests {
 		username_signal.set("john_doe".to_string());
 
 		// Flush pending Effect updates
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 
 		// Verify Form was updated
 		assert_eq!(binding.get_field_value("username"), "john_doe");
@@ -537,7 +537,7 @@ mod tests {
 		username_signal.set("signal_update".to_string());
 
 		// Flush pending Effect updates
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 
 		// Sync to form (redundant due to Effect, but test explicit sync)
 		binding.sync_to_form();
@@ -568,7 +568,7 @@ mod tests {
 		email_signal.set("valid@example.com".to_string());
 
 		// Flush pending Effect updates
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 
 		// Note: Effects update the form automatically, so validation should pass
 		assert!(binding.validate());
@@ -594,7 +594,7 @@ mod tests {
 		email_signal.set("john@example.com".to_string());
 
 		// Flush pending Effect updates
-		with_runtime(|rt| rt.flush_updates_enhanced());
+		with_runtime(|rt| rt.flush_updates());
 
 		assert_eq!(binding.get_field_value("username"), "john");
 		assert_eq!(binding.get_field_value("email"), "john@example.com");

--- a/crates/reinhardt-pages/tests/auth_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/auth_integration_tests.rs
@@ -396,7 +396,7 @@ fn test_effect_triggered_by_auth_change() {
 
 	// Trigger effect by logging in
 	state.login("1", "effect_test");
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	// Effect should be triggered
 	assert!(triggered.get());
@@ -416,7 +416,7 @@ fn test_effect_triggered_by_user_id_change() {
 	});
 
 	state.login("42", "user");
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	assert_eq!(captured_id.get(), Some("42".to_string()));
 }
@@ -438,7 +438,7 @@ fn test_effect_triggered_by_permission_change() {
 	perms.insert("perm1".to_string());
 	perms.insert("perm2".to_string());
 	state.set_permissions(perms);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	assert_eq!(perm_count.get(), 2);
 }
@@ -469,7 +469,7 @@ fn test_multiple_effects_on_same_signal() {
 	});
 
 	state.login("1", "multi_effect");
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	assert!(effect1_triggered.get());
 	assert!(effect2_triggered.get());

--- a/crates/reinhardt-pages/tests/dom_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/dom_integration_tests.rs
@@ -69,20 +69,20 @@ fn test_reactive_attribute() {
 	// Initial value
 	// Note: Effect runs immediately, but we need to flush updates
 	use reinhardt_pages::reactive::with_runtime;
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	assert_eq!(div.get_attribute("data-count"), Some("0".to_string()));
 
 	// Update Signal
 	count.set(42);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	// Attribute should be updated automatically
 	assert_eq!(div.get_attribute("data-count"), Some("42".to_string()));
 
 	// Update again
 	count.set(100);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	assert_eq!(div.get_attribute("data-count"), Some("100".to_string()));
 }
@@ -100,7 +100,7 @@ fn test_multiple_reactive_attributes() {
 	div.set_reactive_attribute("data-y", y.clone());
 
 	use reinhardt_pages::reactive::with_runtime;
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	assert_eq!(div.get_attribute("data-x"), Some("10".to_string()));
 	assert_eq!(div.get_attribute("data-y"), Some("20".to_string()));
@@ -108,7 +108,7 @@ fn test_multiple_reactive_attributes() {
 	// Update both
 	x.set(100);
 	y.set(200);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	assert_eq!(div.get_attribute("data-x"), Some("100".to_string()));
 	assert_eq!(div.get_attribute("data-y"), Some("200".to_string()));
@@ -236,7 +236,7 @@ fn test_reactive_attribute_with_event_listener() {
 	button.set_reactive_attribute("data-count", count.clone());
 
 	use reinhardt_pages::reactive::with_runtime;
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	assert_eq!(button.get_attribute("data-count"), Some("0".to_string()));
 
@@ -250,14 +250,14 @@ fn test_reactive_attribute_with_event_listener() {
 	button.as_web_sys().dispatch_event(&event).unwrap();
 
 	// Flush updates to apply reactive changes
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	// Attribute should be updated automatically
 	assert_eq!(button.get_attribute("data-count"), Some("1".to_string()));
 
 	// Click again
 	button.as_web_sys().dispatch_event(&event).unwrap();
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	assert_eq!(button.get_attribute("data-count"), Some("2".to_string()));
 }

--- a/crates/reinhardt-pages/tests/reactive_system_tests.rs
+++ b/crates/reinhardt-pages/tests/reactive_system_tests.rs
@@ -29,17 +29,17 @@ fn test_effect_auto_execution_on_signal_change() {
 
 	// Change signal and flush updates
 	count.set(10);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(*execution_log.borrow(), vec![0, 10]);
 
 	// Change again
 	count.set(20);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(*execution_log.borrow(), vec![0, 10, 20]);
 
 	// Update with function
 	count.update(|n| *n += 5);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(*execution_log.borrow(), vec![0, 10, 20, 25]);
 }
 
@@ -63,18 +63,18 @@ fn test_effect_with_multiple_signals() {
 
 	// Change first signal
 	signal1.set(10);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(*sum.borrow(), 12); // 10 + 2
 
 	// Change second signal
 	signal2.set(20);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(*sum.borrow(), 30); // 10 + 20
 
 	// Change both (only one effect execution after flush)
 	signal1.set(100);
 	signal2.set(200);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(*sum.borrow(), 300); // 100 + 200
 }
 
@@ -145,7 +145,7 @@ fn test_effect_with_memo_dependency() {
 	// Change signal, mark memo dirty, flush effect
 	count.set(5);
 	doubled.mark_dirty();
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 
 	// Should trigger effect: 5 * 2 = 10
 	assert_eq!(*log.borrow(), vec![6, 10]);
@@ -188,7 +188,7 @@ fn test_effect_cleanup_on_drop() {
 
 	// Change signal - effect should NOT run (it's dropped)
 	signal.set(10);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(*run_count.borrow(), 1); // Still 1
 
 	// Verify effect was removed from runtime
@@ -276,19 +276,19 @@ fn test_complex_reactive_graph() {
 	// Change first name
 	first_name.set("Jane".to_string());
 	full_name.mark_dirty();
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(log.borrow()[1], "Jane Doe is a Adult");
 
 	// Change age
 	age.set(70);
 	age_category.mark_dirty();
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(log.borrow()[2], "Jane Doe is a Senior");
 
 	// Change last name
 	last_name.set("Smith".to_string());
 	full_name.mark_dirty();
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(log.borrow()[3], "Jane Smith is a Senior");
 }
 
@@ -312,7 +312,7 @@ fn test_get_untracked_no_dependency() {
 
 	// Change signal - effect should NOT rerun (no dependency)
 	signal.set(100);
-	with_runtime(|rt| rt.flush_updates_enhanced());
+	with_runtime(|rt| rt.flush_updates());
 	assert_eq!(*run_count.borrow(), 1); // Still 1
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `Runtime::flush_updates()` in `runtime.rs` dropped pending updates without executing them, while the correct execution logic existed in `flush_updates_enhanced()` in `effect.rs`
- **Fix**: Removed broken `flush_updates()` from `runtime.rs`, renamed `flush_updates_enhanced()` → `flush_updates()` so `schedule_update()` now correctly flushes and executes all pending effects
- **Regression test**: Added `test_flush_updates_executes_pending_effects` verifying scheduler-based passive Effect re-execution

## Test plan

- [x] `cargo check` (native) passes
- [x] `cargo test --package reinhardt-core --features reactive --lib -- reactive::effect::tests` — 10/10 pass
- [x] `cargo test --package reinhardt-pages --test reactive_system_tests` — 12/12 pass
- [x] New regression test validates the fix end-to-end

Fixes #3348

🤖 Generated with [Claude Code](https://claude.com/claude-code)