### PR TITLE
fix(admin): make AdminSite registry lookups case-insensitive

### DIFF
--- a/crates/reinhardt-admin/src/core/site.rs
+++ b/crates/reinhardt-admin/src/core/site.rs
@@ -814,7 +814,12 @@ mod tests {
 
 		let result = admin.register("user", ModelAdminConfig::new("user"));
 		assert!(result.is_err());
-		assert!(result.unwrap_err().to_string().contains("already registered"));
+		assert!(
+			result
+				.unwrap_err()
+				.to_string()
+				.contains("already registered")
+		);
 	}
 
 	#[rstest]


### PR DESCRIPTION
## Summary

- Make all `AdminSite` registry operations (`register`, `unregister`, `is_registered`, `get_model_admin`) case-insensitive
- `register()` now rejects case-insensitive duplicates to prevent URL collisions
- Add 4 unit tests for case-insensitive behavior

## Root Cause

Dashboard generates lowercase URLs (`/admin/testmodel/`) via `name.to_lowercase()`, but `get_model_admin()` performed case-sensitive `DashMap::get()`. Models registered as `"TestModel"` were not found when looked up as `"testmodel"` from URL params.

## Test plan

- [x] `cargo test -p reinhardt-admin --lib -- site::tests` — 20/20 pass (4 new)
- [x] `cargo check -p reinhardt-admin` — native build OK
- [x] `cargo check -p reinhardt-admin --target wasm32-unknown-unknown` — WASM build OK
- [ ] E2E: `cargo test --package reinhardt-admin --test e2e_pages` — verify 13/13 pass

Fixes #3353

🤖 Generated with [Claude Code](https://claude.com/claude-code)