### PR TITLE
fix(admin): add padding and max-width to admin page containers

### DIFF
--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -187,7 +187,7 @@ fn dashboard_view() -> Page {
 
 	page!(|| {
 		div {
-			class: "dashboard-container",
+			class: "dashboard-container p-6 md:p-8 max-w-7xl mx-auto",
 			{ reactive_content }
 		}
 	})()
@@ -295,7 +295,7 @@ fn list_view_component(model_name: String) -> Page {
 
 	page!(|| {
 		div {
-			class: "list-container",
+			class: "list-container p-6 md:p-8 max-w-7xl mx-auto",
 			{ reactive_content }
 		}
 	})()
@@ -368,7 +368,7 @@ fn detail_view_component(model_name: String, record_id: String) -> Page {
 
 	page!(|| {
 		div {
-			class: "detail-container",
+			class: "detail-container p-6 md:p-8 max-w-7xl mx-auto",
 			{ reactive_content }
 		}
 	})()
@@ -423,7 +423,7 @@ fn create_view_component(model_name: String) -> Page {
 
 	page!(|| {
 		div {
-			class: "form-container",
+			class: "form-container p-6 md:p-8 max-w-7xl mx-auto",
 			{ reactive_content }
 		}
 	})()
@@ -506,7 +506,7 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 
 	page!(|| {
 		div {
-			class: "form-container",
+			class: "form-container p-6 md:p-8 max-w-7xl mx-auto",
 			{ reactive_content }
 		}
 	})()


### PR DESCRIPTION
## Summary

Fixes #3363

All admin panel pages rendered with content flush against the browser edges — no margin or padding. This PR adds consistent spacing to the 5 route container divs in `router.rs`:

- `p-6 md:p-8` — 24px padding (mobile), 32px (desktop)
- `max-w-7xl` — 80rem max width for readability on wide screens
- `mx-auto` — horizontal centering

## Affected Pages

| Page | Container Class |
|---|---|
| Dashboard | `dashboard-container` |
| List | `list-container` |
| Detail | `detail-container` |
| Create Form | `form-container` |
| Edit Form | `form-container` |

Login page is unaffected (uses its own `min-h-screen flex justify-center` layout).

## Test plan

- [x] `cargo check -p reinhardt-admin` (native) — passes
- [x] `cargo check -p reinhardt-admin --target wasm32-unknown-unknown` (WASM) — passes
- [ ] Visual verification: all admin pages have proper padding from browser edges
- [ ] Login page remains centered (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)