### PR TITLE
fix(docs): replace RedisCache with InMemoryCache in hybrid cache doctests

### DIFF
--- a/crates/reinhardt-utils/src/cache/hybrid.rs
+++ b/crates/reinhardt-utils/src/cache/hybrid.rs
@@ -12,14 +12,14 @@
 //!
 //! # Examples
 //!
-//! ```no_run
-//! use reinhardt_utils::cache::{Cache, HybridCache, InMemoryCache, RedisCache};
+//! ```
+//! use reinhardt_utils::cache::{Cache, HybridCache, InMemoryCache};
 //! use std::time::Duration;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! // Create L1 (memory) and L2 (Redis) caches
+//! // Create L1 (memory) and L2 (distributed) caches
 //! let l1_cache = InMemoryCache::new();
-//! let l2_cache = RedisCache::new("redis://localhost:6379").await?;
+//! let l2_cache = InMemoryCache::new(); // In production, use RedisCache or MemcachedCache
 //!
 //! // Create hybrid cache
 //! let cache = HybridCache::new(l1_cache, l2_cache);
@@ -76,15 +76,12 @@ where
 	///
 	/// # Examples
 	///
-	/// ```no_run
-	/// use reinhardt_utils::cache::{HybridCache, InMemoryCache, RedisCache};
+	/// ```
+	/// use reinhardt_utils::cache::{HybridCache, InMemoryCache};
 	///
-	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 	/// let l1 = InMemoryCache::new();
-	/// let l2 = RedisCache::new("redis://localhost:6379").await?;
+	/// let l2 = InMemoryCache::new();
 	/// let cache = HybridCache::new(l1, l2);
-	/// # Ok(())
-	/// # }
 	/// ```
 	pub fn new(l1: L1, l2: L2) -> Self {
 		Self {
@@ -97,12 +94,12 @@ where
 	///
 	/// # Examples
 	///
-	/// ```no_run
-	/// use reinhardt_utils::cache::{Cache, HybridCache, InMemoryCache, RedisCache};
+	/// ```
+	/// use reinhardt_utils::cache::{Cache, HybridCache, InMemoryCache};
 	///
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 	/// let l1 = InMemoryCache::new();
-	/// let l2 = RedisCache::new("redis://localhost:6379").await?;
+	/// let l2 = InMemoryCache::new();
 	/// let cache = HybridCache::new(l1, l2);
 	///
 	/// // Clear only L1 cache
@@ -118,12 +115,12 @@ where
 	///
 	/// # Examples
 	///
-	/// ```no_run
-	/// use reinhardt_utils::cache::{Cache, HybridCache, InMemoryCache, RedisCache};
+	/// ```
+	/// use reinhardt_utils::cache::{Cache, HybridCache, InMemoryCache};
 	///
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 	/// let l1 = InMemoryCache::new();
-	/// let l2 = RedisCache::new("redis://localhost:6379").await?;
+	/// let l2 = InMemoryCache::new();
 	/// let cache = HybridCache::new(l1, l2);
 	///
 	/// // Clear only L2 cache


### PR DESCRIPTION
## Summary

This PR addresses:

- Replace feature-gated `RedisCache` with always-available `InMemoryCache` in `HybridCache` doc examples so doctests compile without `redis-backend` feature

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Motivation and Context

4 doctests in `crates/reinhardt-utils/src/cache/hybrid.rs` fail when the `redis-backend` feature is not enabled because they unconditionally import `RedisCache`. Using `InMemoryCache` for both L1 and L2 keeps examples compilable and matches the pattern used by the unit tests in the same file.

Fixes #3439

## How Was This Tested?

- `cargo test --doc -p reinhardt-utils -- hybrid` — all 4 doctests pass without `redis-backend` feature

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #3439

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [x] `documentation` - Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)