### PR TITLE
feat(commands): add RunserverHook for concurrent service startup and pre-listen validation

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1607,6 +1607,20 @@ impl RunServerCommand {
 			shutdown_tx.shutdown();
 		});
 
+		// Collect and validate runserver hooks (#3442)
+		let hooks = crate::runserver_hooks::collect_hooks();
+		if !hooks.is_empty() {
+			ctx.verbose(&format!("Found {} runserver hook(s)", hooks.len()));
+		}
+		for hook in &hooks {
+			hook.validate().await.map_err(|e| {
+				crate::CommandError::ExecutionError(format!(
+					"Runserver hook validation failed: {}",
+					e
+				))
+			})?;
+		}
+
 		// OpenAPI documentation is shown in startup banner above
 
 		// Resolve DI context: reuse user-provided context from router, or create a new one.
@@ -1662,6 +1676,22 @@ impl RunServerCommand {
 				reinhardt_di::InjectionContext::builder(singleton_scope).build(),
 			),
 		};
+
+		// Invoke runserver hook startup phase (#3442)
+		if !hooks.is_empty() {
+			let runserver_ctx = crate::runserver_hooks::RunserverContext {
+				shutdown_coordinator: coordinator.clone(),
+				di_context: di_context.clone(),
+			};
+			for hook in &hooks {
+				hook.on_server_start(&runserver_ctx).await.map_err(|e| {
+					crate::CommandError::ExecutionError(format!(
+						"Runserver hook startup failed: {}",
+						e
+					))
+				})?;
+			}
+		}
 
 		// Create HTTP server with DI context and logging middleware
 		let mut server = HttpServer::new(router)

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1612,11 +1612,11 @@ impl RunServerCommand {
 		if !hooks.is_empty() {
 			ctx.verbose(&format!("Found {} runserver hook(s)", hooks.len()));
 		}
-		for hook in &hooks {
-			hook.validate().await.map_err(|e| {
+		for collected in &hooks {
+			collected.hook.validate().await.map_err(|e| {
 				crate::CommandError::ExecutionError(format!(
-					"Runserver hook validation failed: {}",
-					e
+					"Runserver hook validation failed for {}: {}",
+					collected.type_name, e
 				))
 			})?;
 		}
@@ -1683,13 +1683,17 @@ impl RunServerCommand {
 				shutdown_coordinator: coordinator.clone(),
 				di_context: di_context.clone(),
 			};
-			for hook in &hooks {
-				hook.on_server_start(&runserver_ctx).await.map_err(|e| {
-					crate::CommandError::ExecutionError(format!(
-						"Runserver hook startup failed: {}",
-						e
-					))
-				})?;
+			for collected in &hooks {
+				collected
+					.hook
+					.on_server_start(&runserver_ctx)
+					.await
+					.map_err(|e| {
+						crate::CommandError::ExecutionError(format!(
+							"Runserver hook startup failed for {}: {}",
+							collected.type_name, e
+						))
+					})?;
 			}
 		}
 

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -169,6 +169,8 @@ pub mod output;
 pub mod plugin_commands;
 /// Command registry for discovery and dispatch.
 pub mod registry;
+/// Runserver lifecycle hooks for concurrent services and pre-listen validation.
+pub mod runserver_hooks;
 /// Project and app scaffolding commands (startproject, startapp).
 pub mod start_commands;
 /// Template-based code generation utilities.
@@ -198,6 +200,7 @@ pub use introspect::IntrospectCommand;
 pub use mail_commands::SendTestEmailCommand;
 pub use output::OutputWrapper;
 pub use registry::CommandRegistry;
+pub use runserver_hooks::{RunserverContext, RunserverHook, RunserverHookRegistration};
 pub use start_commands::{StartAppCommand, StartProjectCommand};
 pub use template::{TemplateCommand, TemplateContext, generate_secret_key, to_camel_case};
 pub use wasm_builder::{

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -170,6 +170,7 @@ pub mod plugin_commands;
 /// Command registry for discovery and dispatch.
 pub mod registry;
 /// Runserver lifecycle hooks for concurrent services and pre-listen validation.
+#[cfg(feature = "server")]
 pub mod runserver_hooks;
 /// Project and app scaffolding commands (startproject, startapp).
 pub mod start_commands;
@@ -200,6 +201,7 @@ pub use introspect::IntrospectCommand;
 pub use mail_commands::SendTestEmailCommand;
 pub use output::OutputWrapper;
 pub use registry::CommandRegistry;
+#[cfg(feature = "server")]
 pub use runserver_hooks::{RunserverContext, RunserverHook, RunserverHookRegistration};
 pub use start_commands::{StartAppCommand, StartProjectCommand};
 pub use template::{TemplateCommand, TemplateContext, generate_secret_key, to_camel_case};

--- a/crates/reinhardt-commands/src/runserver_hooks.rs
+++ b/crates/reinhardt-commands/src/runserver_hooks.rs
@@ -1,0 +1,457 @@
+//! Runserver lifecycle hooks for extending server startup behavior.
+//!
+//! Hooks are auto-discovered via `inventory` and invoked by
+//! [`RunServerCommand`](crate::RunServerCommand) at two lifecycle points:
+//!
+//! 1. **Validation** ([`RunserverHook::validate`]) — before DI setup; return `Err` to abort.
+//! 2. **Startup** ([`RunserverHook::on_server_start`]) — after DI is ready, before listen.
+//!
+//! Register hooks with the `#[hook(on = runserver)]` attribute macro.
+
+use std::error::Error;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use reinhardt_di::InjectionContext;
+use reinhardt_server::ShutdownCoordinator;
+
+/// Context passed to [`RunserverHook::on_server_start`].
+pub struct RunserverContext {
+	/// Shutdown coordinator for subscribing to graceful shutdown signals.
+	///
+	/// Use `shutdown_coordinator.subscribe()` to receive shutdown notifications
+	/// in spawned concurrent services.
+	pub shutdown_coordinator: ShutdownCoordinator,
+
+	/// DI context for resolving application services.
+	pub di_context: Arc<InjectionContext>,
+}
+
+/// Hook for extending runserver behavior.
+///
+/// Implementations are auto-discovered via `inventory` when registered
+/// with the `#[hook(on = runserver)]` attribute macro.
+///
+/// # Lifecycle
+///
+/// 1. `validate()` is called before DI context setup.
+///    Return `Err` to abort server startup (fail-fast).
+/// 2. `on_server_start()` is called after DI context is ready,
+///    before the server starts listening.
+///    Spawn concurrent services here and subscribe to shutdown via
+///    `ctx.shutdown_coordinator.subscribe()`.
+///
+/// Both methods have default no-op implementations. Implement only
+/// the phases your hook needs.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use reinhardt::prelude::*;
+///
+/// #[hook(on = runserver)]
+/// struct MyHook;
+///
+/// #[async_trait]
+/// impl RunserverHook for MyHook {
+///     async fn validate(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+///         // Check required configuration
+///         Ok(())
+///     }
+///
+///     async fn on_server_start(
+///         &self,
+///         ctx: &RunserverContext,
+///     ) -> Result<(), Box<dyn Error + Send + Sync>> {
+///         // Spawn a concurrent service
+///         let mut shutdown_rx = ctx.shutdown_coordinator.subscribe();
+///         tokio::spawn(async move {
+///             tokio::select! {
+///                 _ = shutdown_rx.recv() => { /* cleanup */ }
+///             }
+///         });
+///         Ok(())
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait RunserverHook: Send + Sync {
+	/// Validation phase: return `Err` to prevent server startup.
+	///
+	/// Runs before `on_server_start` and before DI context setup.
+	async fn validate(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+		Ok(())
+	}
+
+	/// Startup phase: spawn concurrent services, register shutdown handlers.
+	///
+	/// Receives [`RunserverContext`] with access to [`ShutdownCoordinator`]
+	/// and [`InjectionContext`].
+	async fn on_server_start(
+		&self,
+		ctx: &RunserverContext,
+	) -> Result<(), Box<dyn Error + Send + Sync>> {
+		let _ = ctx;
+		Ok(())
+	}
+}
+
+/// Compile-time registration entry for auto-discovered runserver hooks.
+///
+/// Submitted via `inventory::submit!` by the `#[hook(on = runserver)]` macro.
+/// You typically do not create this struct directly.
+pub struct RunserverHookRegistration {
+	/// Factory function that produces a boxed [`RunserverHook`].
+	pub create: fn() -> Box<dyn RunserverHook>,
+
+	/// Type name of the hook struct (for diagnostics).
+	pub type_name: &'static str,
+}
+
+impl RunserverHookRegistration {
+	/// Internal constructor used by the `#[hook]` macro.
+	#[doc(hidden)]
+	pub const fn __macro_new(
+		create: fn() -> Box<dyn RunserverHook>,
+		type_name: &'static str,
+	) -> Self {
+		Self { create, type_name }
+	}
+}
+
+inventory::collect!(RunserverHookRegistration);
+
+/// Collect all registered runserver hooks from inventory.
+pub(crate) fn collect_hooks() -> Vec<Box<dyn RunserverHook>> {
+	inventory::iter::<RunserverHookRegistration>
+		.into_iter()
+		.map(|reg| (reg.create)())
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::*;
+
+	// -- Test hook implementations --
+
+	struct PassingValidateHook;
+
+	#[async_trait]
+	impl RunserverHook for PassingValidateHook {
+		async fn validate(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+			Ok(())
+		}
+	}
+
+	struct FailingValidateHook {
+		message: &'static str,
+	}
+
+	#[async_trait]
+	impl RunserverHook for FailingValidateHook {
+		async fn validate(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+			Err(self.message.into())
+		}
+	}
+
+	struct StartHookWithSideEffect {
+		flag: Arc<std::sync::atomic::AtomicBool>,
+	}
+
+	#[async_trait]
+	impl RunserverHook for StartHookWithSideEffect {
+		async fn on_server_start(
+			&self,
+			_ctx: &RunserverContext,
+		) -> Result<(), Box<dyn Error + Send + Sync>> {
+			self.flag.store(true, std::sync::atomic::Ordering::SeqCst);
+			Ok(())
+		}
+	}
+
+	struct FailingStartHook;
+
+	#[async_trait]
+	impl RunserverHook for FailingStartHook {
+		async fn on_server_start(
+			&self,
+			_ctx: &RunserverContext,
+		) -> Result<(), Box<dyn Error + Send + Sync>> {
+			Err("startup failed".into())
+		}
+	}
+
+	struct NoOpHook;
+
+	#[async_trait]
+	impl RunserverHook for NoOpHook {}
+
+	struct ValidateAndStartHook {
+		validate_flag: Arc<std::sync::atomic::AtomicBool>,
+		start_flag: Arc<std::sync::atomic::AtomicBool>,
+	}
+
+	#[async_trait]
+	impl RunserverHook for ValidateAndStartHook {
+		async fn validate(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+			self.validate_flag
+				.store(true, std::sync::atomic::Ordering::SeqCst);
+			Ok(())
+		}
+
+		async fn on_server_start(
+			&self,
+			_ctx: &RunserverContext,
+		) -> Result<(), Box<dyn Error + Send + Sync>> {
+			self.start_flag
+				.store(true, std::sync::atomic::Ordering::SeqCst);
+			Ok(())
+		}
+	}
+
+	// -- Helper --
+
+	fn make_runserver_context() -> RunserverContext {
+		RunserverContext {
+			shutdown_coordinator: ShutdownCoordinator::new(std::time::Duration::from_secs(1)),
+			di_context: Arc::new(
+				reinhardt_di::InjectionContext::builder(Arc::new(
+					reinhardt_di::SingletonScope::new(),
+				))
+				.build(),
+			),
+		}
+	}
+
+	// ========================================================================
+	// Normal cases
+	// ========================================================================
+
+	#[rstest]
+	#[tokio::test]
+	async fn validate_succeeds_for_passing_hook() {
+		let hook = PassingValidateHook;
+		assert!(hook.validate().await.is_ok());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn on_server_start_sets_side_effect_flag() {
+		// Arrange
+		let flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+		let hook = StartHookWithSideEffect { flag: flag.clone() };
+		let ctx = make_runserver_context();
+
+		// Act
+		let result = hook.on_server_start(&ctx).await;
+
+		// Assert
+		assert!(result.is_ok());
+		assert!(flag.load(std::sync::atomic::Ordering::SeqCst));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn hook_implementing_both_phases_calls_both() {
+		// Arrange
+		let validate_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+		let start_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+		let hook = ValidateAndStartHook {
+			validate_flag: validate_flag.clone(),
+			start_flag: start_flag.clone(),
+		};
+		let ctx = make_runserver_context();
+
+		// Act
+		hook.validate().await.unwrap();
+		hook.on_server_start(&ctx).await.unwrap();
+
+		// Assert
+		assert!(validate_flag.load(std::sync::atomic::Ordering::SeqCst));
+		assert!(start_flag.load(std::sync::atomic::Ordering::SeqCst));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn context_provides_shutdown_coordinator() {
+		// Arrange
+		let ctx = make_runserver_context();
+
+		// Act: subscribe to shutdown coordinator (should not panic)
+		let _rx = ctx.shutdown_coordinator.subscribe();
+
+		// Assert: subscription succeeded (no panic)
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn context_provides_di_context() {
+		// Arrange
+		let ctx = make_runserver_context();
+
+		// Assert: DI context is accessible
+		let _ = ctx.di_context.clone();
+	}
+
+	// ========================================================================
+	// Error / failure cases
+	// ========================================================================
+
+	#[rstest]
+	#[tokio::test]
+	async fn validate_returns_error_with_message() {
+		// Arrange
+		let hook = FailingValidateHook {
+			message: "JWT_SECRET not configured",
+		};
+
+		// Act
+		let result = hook.validate().await;
+
+		// Assert
+		assert!(result.is_err());
+		assert_eq!(result.unwrap_err().to_string(), "JWT_SECRET not configured");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn on_server_start_returns_error() {
+		// Arrange
+		let hook = FailingStartHook;
+		let ctx = make_runserver_context();
+
+		// Act
+		let result = hook.on_server_start(&ctx).await;
+
+		// Assert
+		assert!(result.is_err());
+		assert_eq!(result.unwrap_err().to_string(), "startup failed");
+	}
+
+	// ========================================================================
+	// Edge cases / default implementations
+	// ========================================================================
+
+	#[rstest]
+	#[tokio::test]
+	async fn default_validate_returns_ok() {
+		let hook = NoOpHook;
+		assert!(hook.validate().await.is_ok());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn default_on_server_start_returns_ok() {
+		// Arrange
+		let hook = NoOpHook;
+		let ctx = make_runserver_context();
+
+		// Act & Assert
+		assert!(hook.on_server_start(&ctx).await.is_ok());
+	}
+
+	#[rstest]
+	fn collect_hooks_returns_vec_without_panic() {
+		// Act: collect hooks from inventory
+		let hooks = collect_hooks();
+
+		// Assert: returns a Vec (contents depend on linked registrations)
+		let _ = hooks.len();
+	}
+
+	#[rstest]
+	fn registration_macro_new_creates_valid_entry() {
+		// Arrange & Act
+		let reg = RunserverHookRegistration::__macro_new(|| Box::new(NoOpHook), "NoOpHook");
+
+		// Assert
+		assert_eq!(reg.type_name, "NoOpHook");
+		let hook = (reg.create)();
+		// Verify the created hook is usable (trait object is valid)
+		let _ = hook;
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn registration_factory_produces_working_hook() {
+		// Arrange
+		let reg = RunserverHookRegistration::__macro_new(
+			|| Box::new(PassingValidateHook),
+			"PassingValidateHook",
+		);
+
+		// Act
+		let hook = (reg.create)();
+		let result = hook.validate().await;
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn multiple_hooks_sequential_validation() {
+		// Arrange
+		let hooks: Vec<Box<dyn RunserverHook>> = vec![
+			Box::new(PassingValidateHook),
+			Box::new(PassingValidateHook),
+			Box::new(PassingValidateHook),
+		];
+
+		// Act & Assert: all validations pass
+		for hook in &hooks {
+			assert!(hook.validate().await.is_ok());
+		}
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn validation_stops_on_first_error() {
+		// Arrange
+		let hooks: Vec<Box<dyn RunserverHook>> = vec![
+			Box::new(PassingValidateHook),
+			Box::new(FailingValidateHook {
+				message: "second hook fails",
+			}),
+			Box::new(PassingValidateHook),
+		];
+
+		// Act: simulate the run_server validation loop
+		let mut first_error = None;
+		for hook in &hooks {
+			if let Err(e) = hook.validate().await {
+				first_error = Some(e);
+				break;
+			}
+		}
+
+		// Assert: stopped at second hook
+		assert!(first_error.is_some());
+		assert_eq!(first_error.unwrap().to_string(), "second hook fails");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn on_server_start_not_called_when_validate_fails() {
+		// Arrange
+		let start_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+		let hook = FailingValidateHook {
+			message: "config error",
+		};
+		let ctx = make_runserver_context();
+
+		// Act: simulate run_server flow — validate first, skip on_server_start on error
+		let validate_result = hook.validate().await;
+		if validate_result.is_ok() {
+			// This simulates the NoOpHook case for on_server_start
+			let _ = NoOpHook.on_server_start(&ctx).await;
+			start_flag.store(true, std::sync::atomic::Ordering::SeqCst);
+		}
+
+		// Assert: on_server_start was never called
+		assert!(validate_result.is_err());
+		assert!(!start_flag.load(std::sync::atomic::Ordering::SeqCst));
+	}
+}

--- a/crates/reinhardt-commands/src/runserver_hooks.rs
+++ b/crates/reinhardt-commands/src/runserver_hooks.rs
@@ -47,9 +47,9 @@ pub struct RunserverContext {
 /// # Examples
 ///
 /// ```rust,ignore
-/// use reinhardt::prelude::*;
+/// use reinhardt::commands::{RunserverHook, RunserverContext};
 ///
-/// #[hook(on = runserver)]
+/// #[reinhardt::hook(on = runserver)]
 /// struct MyHook;
 ///
 /// #[async_trait]
@@ -121,11 +121,24 @@ impl RunserverHookRegistration {
 
 inventory::collect!(RunserverHookRegistration);
 
-/// Collect all registered runserver hooks from inventory.
-pub(crate) fn collect_hooks() -> Vec<Box<dyn RunserverHook>> {
+/// A collected runserver hook paired with its registration metadata.
+pub(crate) struct CollectedRunserverHook {
+	/// Instantiated hook implementation.
+	pub hook: Box<dyn RunserverHook>,
+
+	/// Type name of the hook struct (for diagnostics).
+	pub type_name: &'static str,
+}
+
+/// Collect all registered runserver hooks from inventory, preserving
+/// diagnostic identity for error reporting.
+pub(crate) fn collect_hooks() -> Vec<CollectedRunserverHook> {
 	inventory::iter::<RunserverHookRegistration>
 		.into_iter()
-		.map(|reg| (reg.create)())
+		.map(|reg| CollectedRunserverHook {
+			hook: (reg.create)(),
+			type_name: reg.type_name,
+		})
 		.collect()
 }
 
@@ -357,8 +370,11 @@ mod tests {
 		// Act: collect hooks from inventory
 		let hooks = collect_hooks();
 
-		// Assert: returns a Vec (contents depend on linked registrations)
-		let _ = hooks.len();
+		// Assert: returns a Vec of CollectedRunserverHook
+		for collected in &hooks {
+			// type_name is preserved from registration
+			assert!(!collected.type_name.is_empty());
+		}
 	}
 
 	#[rstest]

--- a/crates/reinhardt-core/macros/src/crate_paths.rs
+++ b/crates/reinhardt-core/macros/src/crate_paths.rs
@@ -698,3 +698,43 @@ pub(crate) fn get_inventory_crate() -> TokenStream {
 	// Final fallback
 	quote!(::inventory)
 }
+
+/// Resolves the path to the `reinhardt_commands` crate dynamically.
+///
+/// Used by the `#[hook]` macro to reference `RunserverHookRegistration`.
+pub(crate) fn get_reinhardt_commands_crate() -> TokenStream {
+	use proc_macro_crate::{FoundCrate, crate_name};
+
+	// Try direct crate first
+	match crate_name("reinhardt-commands") {
+		Ok(FoundCrate::Itself) => return quote!(crate),
+		Ok(FoundCrate::Name(name)) => {
+			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
+			return quote!(::#ident);
+		}
+		Err(_) => {}
+	}
+
+	// Try via reinhardt crate (when used with `package = "reinhardt-web"`)
+	match crate_name("reinhardt") {
+		Ok(FoundCrate::Itself) => return quote!(crate::reinhardt_commands),
+		Ok(FoundCrate::Name(name)) => {
+			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
+			return quote!(::#ident::reinhardt_commands);
+		}
+		Err(_) => {}
+	}
+
+	// Try via reinhardt-web (published package name)
+	match crate_name("reinhardt-web") {
+		Ok(FoundCrate::Itself) => return quote!(crate::reinhardt_commands),
+		Ok(FoundCrate::Name(name)) => {
+			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
+			return quote!(::#ident::reinhardt_commands);
+		}
+		Err(_) => {}
+	}
+
+	// Final fallback
+	quote!(::reinhardt_commands)
+}

--- a/crates/reinhardt-core/macros/src/hook.rs
+++ b/crates/reinhardt-core/macros/src/hook.rs
@@ -1,0 +1,57 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{ItemStruct, Result, parse::Parse, parse::ParseStream};
+
+use crate::crate_paths::{get_inventory_crate, get_reinhardt_commands_crate};
+
+/// Parsed arguments for `#[hook(on = <target>)]`.
+struct HookArgs {
+	target: syn::Ident,
+}
+
+impl Parse for HookArgs {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let on_ident: syn::Ident = input.parse()?;
+		if on_ident != "on" {
+			return Err(syn::Error::new(on_ident.span(), "expected `on`"));
+		}
+		let _eq: syn::Token![=] = input.parse()?;
+		let target: syn::Ident = input.parse()?;
+		Ok(HookArgs { target })
+	}
+}
+
+/// Implementation for `#[hook(on = runserver)]`.
+///
+/// Generates `inventory::submit!` registration for the annotated struct.
+/// The struct must implement the corresponding hook trait.
+pub(crate) fn hook_impl(args: TokenStream, input: ItemStruct) -> Result<TokenStream> {
+	let args: HookArgs = syn::parse2(args)?;
+	let struct_name = &input.ident;
+	let type_name_str = struct_name.to_string();
+
+	match args.target.to_string().as_str() {
+		"runserver" => {
+			let inventory_crate = get_inventory_crate();
+			let commands_crate = get_reinhardt_commands_crate();
+
+			Ok(quote! {
+				#input
+
+				#inventory_crate::submit! {
+					#commands_crate::RunserverHookRegistration::__macro_new(
+						|| Box::new(#struct_name),
+						#type_name_str,
+					)
+				}
+			})
+		}
+		other => Err(syn::Error::new(
+			args.target.span(),
+			format!(
+				"unknown hook target `{}`. Expected one of: runserver",
+				other
+			),
+		)),
+	}
+}

--- a/crates/reinhardt-core/macros/src/hook.rs
+++ b/crates/reinhardt-core/macros/src/hook.rs
@@ -30,6 +30,22 @@ pub(crate) fn hook_impl(args: TokenStream, input: ItemStruct) -> Result<TokenStr
 	let struct_name = &input.ident;
 	let type_name_str = struct_name.to_string();
 
+	// Validate: only unit structs (no fields) are supported
+	if !input.fields.is_empty() {
+		return Err(syn::Error::new_spanned(
+			&input.fields,
+			"#[hook] can only be applied to unit structs (structs without fields)",
+		));
+	}
+
+	// Validate: no generic parameters
+	if !input.generics.params.is_empty() {
+		return Err(syn::Error::new_spanned(
+			&input.generics,
+			"#[hook] does not support generic structs",
+		));
+	}
+
 	match args.target.to_string().as_str() {
 		"runserver" => {
 			let inventory_crate = get_inventory_crate();

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -23,6 +23,7 @@ mod apply_update_attribute;
 mod apply_update_derive;
 mod collect_migrations;
 mod crate_paths;
+mod hook;
 mod injectable_common;
 mod injectable_fn;
 mod injectable_struct;
@@ -363,6 +364,34 @@ pub fn receiver(args: TokenStream, input: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(input as ItemFn);
 
 	receiver_impl(args.into(), input)
+		.unwrap_or_else(|e| e.to_compile_error())
+		.into()
+}
+
+/// Attribute macro for registering lifecycle hooks.
+///
+/// Currently supports `runserver` hooks for extending server startup behavior.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// use reinhardt::prelude::*;
+///
+/// #[hook(on = runserver)]
+/// struct MyValidationHook;
+///
+/// #[async_trait]
+/// impl RunserverHook for MyValidationHook {
+///     async fn validate(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+///         // Fail-fast validation before server starts
+///         Ok(())
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn hook(args: TokenStream, input: TokenStream) -> TokenStream {
+	let input = parse_macro_input!(input as ItemStruct);
+	hook::hook_impl(args.into(), input)
 		.unwrap_or_else(|e| e.to_compile_error())
 		.into()
 }

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -375,9 +375,9 @@ pub fn receiver(args: TokenStream, input: TokenStream) -> TokenStream {
 /// # Usage
 ///
 /// ```rust,ignore
-/// use reinhardt::prelude::*;
+/// use reinhardt::commands::{RunserverHook, RunserverContext};
 ///
-/// #[hook(on = runserver)]
+/// #[reinhardt::hook(on = runserver)]
 /// struct MyValidationHook;
 ///
 /// #[async_trait]

--- a/crates/reinhardt-core/macros/tests/ui.rs
+++ b/crates/reinhardt-core/macros/tests/ui.rs
@@ -137,6 +137,14 @@ fn test_validate_macro_fail() {
 	t.compile_fail("tests/ui/validate/fail/*.rs");
 }
 
+// ===== Hook =====
+
+#[test]
+fn test_hook_macro_fail() {
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/ui/hook/fail/*.rs");
+}
+
 // ===== Settings =====
 
 #[test]

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_empty_args.rs
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_empty_args.rs
@@ -1,0 +1,6 @@
+use reinhardt_macros::hook;
+
+#[hook()]
+struct MyHook;
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_empty_args.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_empty_args.stderr
@@ -1,0 +1,5 @@
+error: unexpected end of input, expected `on`
+ --> tests/ui/hook/fail/hook_empty_args.rs:3:7
+  |
+3 | #[hook()]
+  |        ^

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_empty_args.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_empty_args.stderr
@@ -1,5 +1,7 @@
-error: unexpected end of input, expected `on`
- --> tests/ui/hook/fail/hook_empty_args.rs:3:7
+error: unexpected end of input, expected identifier
+ --> tests/ui/hook/fail/hook_empty_args.rs:3:1
   |
 3 | #[hook()]
-  |        ^
+  | ^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `hook` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_generic_struct.rs
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_generic_struct.rs
@@ -1,0 +1,6 @@
+use reinhardt_macros::hook;
+
+#[hook(on = runserver)]
+struct MyHook<T>;
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_generic_struct.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_generic_struct.stderr
@@ -1,0 +1,5 @@
+error: #[hook] does not support generic structs
+ --> tests/ui/hook/fail/hook_generic_struct.rs:4:14
+  |
+4 | struct MyHook<T>;
+  |              ^^^

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_invalid_target.rs
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_invalid_target.rs
@@ -1,0 +1,6 @@
+use reinhardt_macros::hook;
+
+#[hook(on = invalid_target)]
+struct MyHook;
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_invalid_target.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_invalid_target.stderr
@@ -1,0 +1,5 @@
+error: unknown hook target `invalid_target`. Expected one of: runserver
+ --> tests/ui/hook/fail/hook_invalid_target.rs:3:14
+  |
+3 | #[hook(on = invalid_target)]
+  |              ^^^^^^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_invalid_target.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_invalid_target.stderr
@@ -1,5 +1,5 @@
 error: unknown hook target `invalid_target`. Expected one of: runserver
- --> tests/ui/hook/fail/hook_invalid_target.rs:3:14
+ --> tests/ui/hook/fail/hook_invalid_target.rs:3:13
   |
 3 | #[hook(on = invalid_target)]
-  |              ^^^^^^^^^^^^^^
+  |             ^^^^^^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_missing_eq.rs
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_missing_eq.rs
@@ -1,0 +1,6 @@
+use reinhardt_macros::hook;
+
+#[hook(on runserver)]
+struct MyHook;
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_missing_eq.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_missing_eq.stderr
@@ -1,0 +1,5 @@
+error: expected `=`
+ --> tests/ui/hook/fail/hook_missing_eq.rs:3:11
+  |
+3 | #[hook(on runserver)]
+  |           ^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_missing_on.rs
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_missing_on.rs
@@ -1,0 +1,6 @@
+use reinhardt_macros::hook;
+
+#[hook(runserver)]
+struct MyHook;
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_missing_on.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_missing_on.stderr
@@ -1,0 +1,5 @@
+error: expected `on`
+ --> tests/ui/hook/fail/hook_missing_on.rs:3:7
+  |
+3 | #[hook(runserver)]
+  |        ^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_missing_on.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_missing_on.stderr
@@ -1,5 +1,5 @@
 error: expected `on`
- --> tests/ui/hook/fail/hook_missing_on.rs:3:7
+ --> tests/ui/hook/fail/hook_missing_on.rs:3:8
   |
 3 | #[hook(runserver)]
   |        ^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_struct_with_fields.rs
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_struct_with_fields.rs
@@ -1,0 +1,8 @@
+use reinhardt_macros::hook;
+
+#[hook(on = runserver)]
+struct MyHook {
+    config: String,
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_struct_with_fields.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/hook/fail/hook_struct_with_fields.stderr
@@ -1,0 +1,8 @@
+error: #[hook] can only be applied to unit structs (structs without fields)
+ --> tests/ui/hook/fail/hook_struct_with_fields.rs:4:15
+  |
+4 |   struct MyHook {
+  |  _______________^
+5 | |     config: String,
+6 | | }
+  | |_^

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,12 @@ pub mod reinhardt_auth {
 	pub use reinhardt_auth::*;
 }
 
+#[cfg(all(feature = "commands", native))]
+#[doc(hidden)]
+pub mod reinhardt_commands {
+	pub use reinhardt_commands::*;
+}
+
 #[cfg(native)]
 #[doc(hidden)]
 pub mod reinhardt_core {


### PR DESCRIPTION
## Summary

- Add `inventory`-based `RunserverHook` trait to `reinhardt-commands` for extending runserver lifecycle
- Add `#[hook(on = runserver)]` proc-macro for zero-boilerplate hook registration
- Integrate hook invocation in `RunServerCommand::run_server()` with two lifecycle phases:
  - `validate()` — before DI setup (fail-fast config validation)
  - `on_server_start()` — after DI ready, before listen (spawn concurrent services)

## Motivation

Applications like `reinhardt-cloud` need to validate configuration and start concurrent services (e.g., gRPC) alongside the HTTP server. Currently this requires custom `manage.rs` code. With `RunserverHook`, downstream apps can use the standard `execute_from_command_line()` entry point.

## Changes

| File | Description |
|------|-------------|
| `crates/reinhardt-commands/src/runserver_hooks.rs` | New: `RunserverHook` trait, `RunserverContext`, `RunserverHookRegistration`, `inventory::collect!` |
| `crates/reinhardt-commands/src/lib.rs` | Export new types |
| `crates/reinhardt-commands/src/builtin.rs` | Invoke hooks in `run_server()` |
| `crates/reinhardt-core/macros/src/hook.rs` | New: `#[hook(on = runserver)]` proc-macro |
| `crates/reinhardt-core/macros/src/crate_paths.rs` | Add `get_reinhardt_commands_crate()` resolver |
| `crates/reinhardt-core/macros/src/lib.rs` | Export `#[hook]` macro |
| `crates/reinhardt-core/macros/tests/ui/hook/fail/` | Trybuild compile-fail tests |
| `src/lib.rs` | Re-export `reinhardt_commands` from facade |

## Usage

```rust
use reinhardt::prelude::*;

#[hook(on = runserver)]
struct JwtValidationHook;

#[async_trait]
impl RunserverHook for JwtValidationHook {
    async fn validate(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
        // Fail-fast: check JWT_SECRET is configured
        JwtAuthMiddleware::validate_config();
        Ok(())
    }

    async fn on_server_start(&self, ctx: &RunserverContext) -> Result<(), Box<dyn Error + Send + Sync>> {
        let mut shutdown_rx = ctx.shutdown_coordinator.subscribe();
        tokio::spawn(async move {
            start_grpc_server(async { drop(shutdown_rx.recv().await) }).await;
        });
        Ok(())
    }
}
```

## Test plan

- [x] Unit tests: validate pass/fail, on_server_start with side effects, default impls, sequential validation, error propagation
- [x] Trybuild fail tests: invalid target, missing `on`, empty args, missing `=`
- [ ] CI: workspace check, clippy, fmt
- [ ] Manual: verify `runserver` command with a registered hook

Fixes #3442

🤖 Generated with [Claude Code](https://claude.com/claude-code)