### PR TITLE
refactor(di): remove unnecessary Clone bound from Depends<T>

### DIFF
--- a/crates/reinhardt-core/macros/src/injectable_struct.rs
+++ b/crates/reinhardt-core/macros/src/injectable_struct.rs
@@ -178,7 +178,7 @@ pub(crate) fn injectable_struct_impl(
 	let generics = &input.generics;
 	let where_clause = &generics.where_clause;
 
-	// Auto-derive Clone for DI-ready types (required by Depends<T>)
+	// Auto-derive Clone for DI-ready types (used by into_inner() and injectable_factory patterns)
 	if !has_clone_derive(&input.attrs) {
 		input.attrs.push(syn::parse_quote!(#[derive(Clone)]));
 	}

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -497,7 +497,7 @@ pub fn derive_schema(input: TokenStream) -> TokenStream {
 /// - Struct must have named fields
 /// - All fields must have either `#[inject]` or `#[no_inject]` attribute
 /// - `#[no_inject]` without default value requires field type to be `Option<T>`
-/// - `Clone` is auto-derived if not already present (required by `Depends<T>`)
+/// - `Clone` is auto-derived if not already present (used by `into_inner()` and `injectable_factory` patterns)
 /// - All `#[inject]` field types must implement `Injectable`
 ///
 /// # Attribute Ordering

--- a/crates/reinhardt-di/macros/src/injectable.rs
+++ b/crates/reinhardt-di/macros/src/injectable.rs
@@ -278,7 +278,7 @@ pub(crate) fn injectable_impl(args: TokenStream, input: DeriveInput) -> Result<T
 		}
 	}
 
-	// Auto-derive Clone for DI-ready types (required by Depends<T>)
+	// Auto-derive Clone for DI-ready types (used by into_inner() and injectable_factory patterns)
 	if !has_clone_derive(&cleaned_input.attrs) {
 		cleaned_input
 			.attrs

--- a/crates/reinhardt-di/macros/src/lib.rs
+++ b/crates/reinhardt-di/macros/src/lib.rs
@@ -15,7 +15,7 @@ mod utils;
 /// Mark a struct as injectable and register it with the global registry
 ///
 /// This macro automatically derives `Clone` for the annotated type if it is
-/// not already derived, because `Depends<T>` requires `T: Clone`.
+/// not already derived. `Clone` is used by `into_inner()` and `injectable_factory` patterns.
 ///
 /// # Attribute Ordering
 ///

--- a/crates/reinhardt-di/src/context.rs
+++ b/crates/reinhardt-di/src/context.rs
@@ -336,7 +336,7 @@ impl InjectionContext {
 	///
 	/// This avoids the need to unwrap and re-wrap Arc values that are
 	/// already in Arc form, such as those returned by factory functions.
-	fn set_request_arc<T: Any + Send + Sync>(&self, value: Arc<T>) {
+	pub(crate) fn set_request_arc<T: Any + Send + Sync>(&self, value: Arc<T>) {
 		self.request_scope.set_arc(value);
 	}
 	/// Retrieves a singleton value from the context.

--- a/crates/reinhardt-di/src/depends.rs
+++ b/crates/reinhardt-di/src/depends.rs
@@ -12,7 +12,7 @@
 //! use reinhardt_di::{Depends, DiResult, InjectionContext, SingletonScope, global_registry, DependencyScope};
 //! use std::sync::Arc;
 //!
-//! #[derive(Clone, Default)]
+//! #[derive(Default)]
 //! struct Config {
 //!     database_url: String,
 //! }
@@ -51,15 +51,12 @@ use std::sync::Arc;
 /// the global dependency registry, so any type registered via
 /// `#[injectable_factory]` or `#[injectable]` can be used.
 #[derive(Debug)]
-pub struct Depends<T: Clone + Send + Sync + 'static> {
+pub struct Depends<T: Send + Sync + 'static> {
 	inner: Arc<T>,
 	metadata: InjectionMetadata,
 }
 
-impl<T> Depends<T>
-where
-	T: Clone + Send + Sync + 'static,
-{
+impl<T: Send + Sync + 'static> Depends<T> {
 	/// Create a new DependsBuilder with caching enabled (default behavior).
 	///
 	/// Similar to FastAPI's `Depends(dependency, use_cache=True)`.
@@ -209,38 +206,6 @@ where
 		}
 	}
 
-	/// Extract the inner value from the Depends wrapper.
-	///
-	/// This method tries to unwrap the Arc. If the Arc has multiple strong references,
-	/// it clones the inner value instead.
-	///
-	/// # Examples
-	///
-	/// ```
-	/// use reinhardt_di::{Depends, Injectable, InjectionContext, DiResult};
-	/// # use async_trait::async_trait;
-	///
-	/// #[derive(Clone, Default)]
-	/// struct Config {
-	///     value: String,
-	/// }
-	///
-	/// # #[async_trait]
-	/// # impl Injectable for Config {
-	/// #     async fn inject(_ctx: &InjectionContext) -> DiResult<Self> {
-	/// #         Ok(Config::default())
-	/// #     }
-	/// # }
-	///
-	/// let config = Config { value: "test".to_string() };
-	/// let depends = Depends::from_value(config);
-	/// let inner = depends.into_inner();
-	/// assert_eq!(inner.value, "test");
-	/// ```
-	pub fn into_inner(self) -> T {
-		Arc::try_unwrap(self.inner).unwrap_or_else(|arc| (*arc).clone())
-	}
-
 	/// Get Arc reference
 	///
 	/// # Examples
@@ -292,16 +257,47 @@ where
 	}
 }
 
+impl<T: Clone + Send + Sync + 'static> Depends<T> {
+	/// Extract the inner value from the Depends wrapper.
+	///
+	/// This method tries to unwrap the Arc. If the Arc has multiple strong references,
+	/// it clones the inner value instead.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use reinhardt_di::{Depends, Injectable, InjectionContext, DiResult};
+	/// # use async_trait::async_trait;
+	///
+	/// #[derive(Clone, Default)]
+	/// struct Config {
+	///     value: String,
+	/// }
+	///
+	/// # #[async_trait]
+	/// # impl Injectable for Config {
+	/// #     async fn inject(_ctx: &InjectionContext) -> DiResult<Self> {
+	/// #         Ok(Config::default())
+	/// #     }
+	/// # }
+	///
+	/// let config = Config { value: "test".to_string() };
+	/// let depends = Depends::from_value(config);
+	/// let inner = depends.into_inner();
+	/// assert_eq!(inner.value, "test");
+	/// ```
+	pub fn into_inner(self) -> T {
+		Arc::try_unwrap(self.inner).unwrap_or_else(|arc| (*arc).clone())
+	}
+}
+
 /// Builder for Depends to support FastAPI-style API.
-pub struct DependsBuilder<T: Clone + Send + Sync + 'static> {
+pub struct DependsBuilder<T: Send + Sync + 'static> {
 	use_cache: bool,
 	_phantom: std::marker::PhantomData<T>,
 }
 
-impl<T> DependsBuilder<T>
-where
-	T: Clone + Send + Sync + 'static,
-{
+impl<T: Send + Sync + 'static> DependsBuilder<T> {
 	/// Resolve the dependency.
 	///
 	/// # Examples
@@ -336,7 +332,7 @@ where
 	}
 }
 
-impl<T: Clone + Send + Sync + 'static> Deref for Depends<T> {
+impl<T: Send + Sync + 'static> Deref for Depends<T> {
 	type Target = T;
 
 	fn deref(&self) -> &Self::Target {
@@ -344,7 +340,7 @@ impl<T: Clone + Send + Sync + 'static> Deref for Depends<T> {
 	}
 }
 
-impl<T: Clone + Send + Sync + 'static> Clone for Depends<T> {
+impl<T: Send + Sync + 'static> Clone for Depends<T> {
 	fn clone(&self) -> Self {
 		Self {
 			inner: Arc::clone(&self.inner),
@@ -353,7 +349,7 @@ impl<T: Clone + Send + Sync + 'static> Clone for Depends<T> {
 	}
 }
 
-impl<T: Clone + Send + Sync + 'static> AsRef<T> for Depends<T> {
+impl<T: Send + Sync + 'static> AsRef<T> for Depends<T> {
 	fn as_ref(&self) -> &T {
 		&self.inner
 	}
@@ -569,7 +565,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_depends_resolve_unregistered_type_returns_error() {
 		// Arrange
-		#[derive(Clone, Debug)]
+		#[derive(Debug)]
 		struct UnregisteredType;
 
 		let singleton_scope = Arc::new(SingletonScope::new());
@@ -597,5 +593,62 @@ mod tests {
 		// Assert
 		assert_eq!(depends1.metadata().scope, depends2.metadata().scope);
 		assert_eq!(depends1.metadata().cached, depends2.metadata().cached);
+	}
+
+	/// Non-Clone type can be used with `Depends<T>` via `from_value()`,
+	/// `clone()` (Arc-based), `Deref`, and `AsRef`.
+	/// `into_inner()` is NOT available for non-Clone types.
+	#[rstest]
+	#[tokio::test]
+	async fn test_depends_non_clone_type() {
+		// Arrange
+		#[derive(Debug)]
+		struct NonCloneService {
+			id: u32,
+		}
+
+		let service = NonCloneService { id: 42 };
+
+		// Act
+		let depends = Depends::from_value(service);
+		let cloned_depends = depends.clone();
+
+		// Assert
+		assert_eq!(depends.id, 42);
+		assert_eq!(cloned_depends.id, 42);
+		assert!(Arc::ptr_eq(depends.as_arc(), cloned_depends.as_arc()));
+		assert_eq!(depends.as_ref().id, 42);
+	}
+
+	/// Non-Clone type can be resolved via the global registry.
+	#[rstest]
+	#[tokio::test]
+	async fn test_depends_non_clone_type_resolve() {
+		// Arrange
+		#[derive(Debug)]
+		struct NonCloneRouter {
+			prefix: String,
+		}
+
+		let registry = global_registry();
+		if !registry.is_registered::<NonCloneRouter>() {
+			registry.register_async::<NonCloneRouter, _, _>(RegistryScope::Request, |_ctx| async {
+				Ok(NonCloneRouter {
+					prefix: "/api".to_string(),
+				})
+			});
+		}
+
+		let singleton_scope = Arc::new(SingletonScope::new());
+		let ctx = InjectionContext::builder(singleton_scope).build();
+
+		// Act
+		let depends = Depends::<NonCloneRouter>::resolve(&ctx, true)
+			.await
+			.unwrap();
+
+		// Assert
+		assert_eq!(depends.prefix, "/api");
+		assert!(depends.metadata().cached);
 	}
 }

--- a/crates/reinhardt-di/src/injectable.rs
+++ b/crates/reinhardt-di/src/injectable.rs
@@ -92,7 +92,7 @@ pub trait Injectable: Sized + Send + Sync + 'static {
 #[async_trait::async_trait]
 impl<T> Injectable for std::sync::Arc<T>
 where
-	T: Injectable + Clone,
+	T: Injectable,
 {
 	async fn inject(ctx: &InjectionContext) -> DiResult<Self> {
 		T::inject(ctx).await.map(std::sync::Arc::new)
@@ -124,11 +124,11 @@ where
 ///
 /// The implementation delegates to `Depends::resolve()`, which resolves `T`
 /// from the global registry with caching and circular dependency detection.
-/// `T` does not need to implement `Injectable` — only `Clone + Send + Sync + 'static`.
+/// `T` does not need to implement `Injectable` — only `Send + Sync + 'static`.
 #[async_trait::async_trait]
 impl<T> Injectable for crate::depends::Depends<T>
 where
-	T: Clone + Send + Sync + 'static,
+	T: Send + Sync + 'static,
 {
 	async fn inject(ctx: &InjectionContext) -> DiResult<Self> {
 		crate::depends::Depends::<T>::resolve(ctx, true).await
@@ -168,7 +168,7 @@ where
 #[async_trait::async_trait]
 impl<T> Injectable for Option<T>
 where
-	T: Injectable + Clone + Send + Sync + 'static,
+	T: Injectable,
 {
 	async fn inject(ctx: &InjectionContext) -> DiResult<Self> {
 		match T::inject(ctx).await {

--- a/crates/reinhardt-di/src/injected.rs
+++ b/crates/reinhardt-di/src/injected.rs
@@ -108,10 +108,7 @@ pub struct Injected<T: Injectable> {
 	metadata: InjectionMetadata,
 }
 
-impl<T: Injectable> Injected<T>
-where
-	T: Clone,
-{
+impl<T: Injectable> Injected<T> {
 	/// Resolve dependency with cache enabled (default)
 	///
 	/// # Examples
@@ -178,10 +175,10 @@ where
 	/// * `use_cache` - Whether to use request-scoped cache
 	async fn resolve_with_cache(ctx: &InjectionContext, use_cache: bool) -> DiResult<Self> {
 		with_cycle_detection_scope(async {
-			let value = if use_cache {
+			let inner = if use_cache {
 				// Check request cache first
 				if let Some(cached) = ctx.get_request::<T>() {
-					Arc::try_unwrap(cached).unwrap_or_else(|arc| (*arc).clone())
+					cached
 				} else {
 					// Begin circular dependency detection
 					let type_id = TypeId::of::<T>();
@@ -190,8 +187,9 @@ where
 						.map_err(|e| DiError::CircularDependency(e.to_string()))?;
 
 					let v = T::inject(ctx).await?;
-					ctx.set_request(v.clone());
-					v
+					let arc = Arc::new(v);
+					ctx.set_request_arc(Arc::clone(&arc));
+					arc
 				}
 			} else {
 				// Begin circular dependency detection (even for uncached)
@@ -201,11 +199,11 @@ where
 					.map_err(|e| DiError::CircularDependency(e.to_string()))?;
 
 				// Skip cache
-				T::inject_uncached(ctx).await?
+				Arc::new(T::inject_uncached(ctx).await?)
 			};
 
 			Ok(Self {
-				inner: Arc::new(value),
+				inner,
 				metadata: InjectionMetadata {
 					scope: DependencyScope::Request,
 					cached: use_cache,
@@ -246,30 +244,6 @@ where
 				cached: false,
 			},
 		}
-	}
-
-	/// Extract inner value
-	///
-	/// # Examples
-	///
-	/// ```
-	/// use reinhardt_di::{Injected, Injectable};
-	///
-	/// # #[derive(Clone, Default)]
-	/// # struct Config;
-	/// #
-	/// # #[async_trait::async_trait]
-	/// # impl Injectable for Config {
-	/// #     async fn inject(ctx: &reinhardt_di::InjectionContext) -> reinhardt_di::DiResult<Self> {
-	/// #         Ok(Config::default())
-	/// #     }
-	/// # }
-	/// #
-	/// let injected = Injected::from_value(Config::default());
-	/// let config = injected.into_inner();
-	/// ```
-	pub fn into_inner(self) -> T {
-		Arc::try_unwrap(self.inner).unwrap_or_else(|arc| (*arc).clone())
 	}
 
 	/// Get Arc reference
@@ -320,6 +294,35 @@ where
 	/// ```
 	pub fn metadata(&self) -> &InjectionMetadata {
 		&self.metadata
+	}
+}
+
+impl<T: Injectable + Clone> Injected<T> {
+	/// Extract inner value
+	///
+	/// This method tries to unwrap the Arc. If the Arc has multiple strong references,
+	/// it clones the inner value instead. Requires `T: Clone`.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use reinhardt_di::{Injected, Injectable};
+	///
+	/// # #[derive(Clone, Default)]
+	/// # struct Config;
+	/// #
+	/// # #[async_trait::async_trait]
+	/// # impl Injectable for Config {
+	/// #     async fn inject(ctx: &reinhardt_di::InjectionContext) -> reinhardt_di::DiResult<Self> {
+	/// #         Ok(Config::default())
+	/// #     }
+	/// # }
+	/// #
+	/// let injected = Injected::from_value(Config::default());
+	/// let config = injected.into_inner();
+	/// ```
+	pub fn into_inner(self) -> T {
+		Arc::try_unwrap(self.inner).unwrap_or_else(|arc| (*arc).clone())
 	}
 }
 

--- a/crates/reinhardt-di/tests/auto_injectable_tests.rs
+++ b/crates/reinhardt-di/tests/auto_injectable_tests.rs
@@ -96,7 +96,7 @@ async fn test_custom_injectable_override() {
 // --- Clone auto-derive tests ---
 
 /// Struct without explicit `#[derive(Clone)]` — the `#[injectable]` macro should
-/// auto-derive Clone so that `Depends<T>` (which requires `T: Clone`) works.
+/// auto-derive Clone for use with `into_inner()` and `injectable_factory` patterns.
 #[injectable]
 #[derive(Default, Debug, PartialEq)]
 struct AutoCloneConfig {


### PR DESCRIPTION
## Summary

- Remove the unnecessary `Clone` trait bound from `Depends<T>`, `DependsBuilder<T>`, and `Injected<T>`
- Refactor `Injected::resolve_with_cache()` to use Arc-based caching instead of `T::clone()`
- Move `into_inner()` to a separate impl block that retains `T: Clone` bound
- Add tests for non-Clone types with `Depends<T>`

## Type of Change

- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Motivation and Context

`Depends<T>` and `Injected<T>` store `Arc<T>` internally, making `T: Clone` unnecessary for construction, resolution, cloning (`Arc::clone`), and dereferencing. The `Clone` bound prevents using `Depends<T>` with non-Clone types commonly registered via `#[injectable_factory]`, such as types wrapping `RwLock<HashMap<...>>` (e.g., `WsBroadcaster`) or external framework types like `UnifiedRouter`.

Fixes #3450

## How Was This Tested?

- `cargo check --workspace --all-features` — builds successfully
- `cargo nextest run --workspace --all-features -E 'package(reinhardt-di)'` — 320/320 tests pass
- `cargo make auto-fix` — no formatting or lint issues
- New tests added for non-Clone types:
  - `test_depends_non_clone_type` — verifies `from_value()`, `clone()`, `Deref`, `AsRef` work without `T: Clone`
  - `test_depends_non_clone_type_resolve` — verifies resolution via global registry works for non-Clone types

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)