### PR TITLE
feat(conf): eliminate duplicated Settings defaults across DefaultSource definitions

### DIFF
--- a/crates/reinhardt-commands/src/bin/runserver.rs
+++ b/crates/reinhardt-commands/src/bin/runserver.rs
@@ -170,54 +170,10 @@ fn load_settings() -> Settings {
 	let merged = SettingsBuilder::new()
 		.profile(profile)
 		.add_source(
-			DefaultSource::new()
-				// Core settings
-				.with_value(
-					"base_dir",
-					serde_json::json!(base_dir.to_string_lossy().to_string()),
-				)
-				.with_value("debug", serde_json::json!(true))
-				.with_value(
-					"secret_key",
-					serde_json::json!(generate_random_secret_key()),
-				)
-				.with_value("allowed_hosts", serde_json::json!([]))
-				.with_value("installed_apps", serde_json::json!([]))
-				.with_value("databases", serde_json::json!({}))
-				.with_value("templates", serde_json::json!([]))
-				// Static/Media files
-				.with_value("static_url", serde_json::json!("/static/"))
-				.with_value("static_root", serde_json::json!(null))
-				.with_value("staticfiles_dirs", serde_json::json!([]))
-				.with_value("media_url", serde_json::json!("/media/"))
-				// Internationalization
-				.with_value("language_code", serde_json::json!("en-us"))
-				.with_value("time_zone", serde_json::json!("UTC"))
+			DefaultSource::for_settings(&base_dir, generate_random_secret_key())
+				// Override: dev server disables i18n/tz by default
 				.with_value("use_i18n", serde_json::json!(false))
-				.with_value("use_tz", serde_json::json!(false))
-				// Model settings
-				.with_value(
-					"default_auto_field",
-					serde_json::json!("reinhardt.db.models.BigAutoField"),
-				)
-				// Security settings
-				.with_value("secure_proxy_ssl_header", serde_json::json!(null))
-				.with_value("secure_ssl_redirect", serde_json::json!(false))
-				.with_value("secure_hsts_seconds", serde_json::json!(null))
-				.with_value("secure_hsts_include_subdomains", serde_json::json!(false))
-				.with_value("secure_hsts_preload", serde_json::json!(false))
-				.with_value("session_cookie_secure", serde_json::json!(false))
-				.with_value("csrf_cookie_secure", serde_json::json!(false))
-				.with_value("append_slash", serde_json::json!(true))
-				// Middleware
-				.with_value("middleware", serde_json::json!([]))
-				// URL configuration
-				.with_value("root_urlconf", serde_json::json!(""))
-				// Media files
-				.with_value("media_root", serde_json::json!(null))
-				// Admin/Manager contacts
-				.with_value("admins", serde_json::json!([]))
-				.with_value("managers", serde_json::json!([])),
+				.with_value("use_tz", serde_json::json!(false)),
 		)
 		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
 		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -2569,13 +2569,9 @@ fn get_database_url_from_settings() -> Result<String, crate::CommandError> {
 	let merged = reinhardt_conf::settings::builder::SettingsBuilder::new()
 		.profile(profile)
 		.add_source(
+			// Only override debug=false; language_code and time_zone use serde defaults
 			reinhardt_conf::settings::sources::DefaultSource::new()
-				.with_value("debug", serde_json::Value::Bool(false))
-				.with_value(
-					"language_code",
-					serde_json::Value::String("en-us".to_string()),
-				)
-				.with_value("time_zone", serde_json::Value::String("UTC".to_string())),
+				.with_value("debug", serde_json::Value::Bool(false)),
 		)
 		.add_source(
 			reinhardt_conf::settings::sources::LowPriorityEnvSource::new()

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -863,54 +863,15 @@ async fn execute_collectstatic(
 	let merged = SettingsBuilder::new()
 		.profile(profile)
 		.add_source(
-			DefaultSource::new()
-				.with_value(
-					"base_dir",
-					Value::String(
-						base_dir
-							.to_str()
-							.ok_or_else(|| {
-								format!("base_dir contains invalid UTF-8: {}", base_dir.display())
-							})?
-							.to_string(),
-					),
-				)
-				.with_value("debug", Value::Bool(true))
-				.with_value("secret_key", Value::String(default_secret_key))
-				.with_value("allowed_hosts", Value::Array(vec![]))
-				.with_value("installed_apps", Value::Array(vec![]))
-				.with_value("databases", serde_json::json!({}))
-				.with_value("templates", Value::Array(vec![]))
-				.with_value("static_url", Value::String("/static/".to_string()))
+			DefaultSource::for_settings(&base_dir, default_secret_key)
+				// Override: collectstatic needs static_root set
 				.with_value(
 					"static_root",
 					Value::String(base_dir.join("staticfiles").to_string_lossy().to_string()),
 				)
-				.with_value("staticfiles_dirs", Value::Array(vec![]))
-				.with_value("media_url", Value::String("/media/".to_string()))
-				.with_value("language_code", Value::String("en-us".to_string()))
-				.with_value("time_zone", Value::String("UTC".to_string()))
+				// Override: disable i18n/tz for CLI commands
 				.with_value("use_i18n", Value::Bool(false))
-				.with_value("use_tz", Value::Bool(false))
-				.with_value(
-					"default_auto_field",
-					Value::String("reinhardt.db.models.BigAutoField".to_string()),
-				)
-				.with_value("secure_ssl_redirect", Value::Bool(false))
-				.with_value("secure_hsts_include_subdomains", Value::Bool(false))
-				.with_value("secure_hsts_preload", Value::Bool(false))
-				.with_value("session_cookie_secure", Value::Bool(false))
-				.with_value("csrf_cookie_secure", Value::Bool(false))
-				.with_value("append_slash", Value::Bool(false))
-				// Middleware
-				.with_value("middleware", Value::Array(vec![]))
-				// URL configuration
-				.with_value("root_urlconf", Value::String(String::new()))
-				// Media files
-				.with_value("media_root", Value::Null)
-				// Admin/Manager contacts
-				.with_value("admins", Value::Array(vec![]))
-				.with_value("managers", Value::Array(vec![])),
+				.with_value("use_tz", Value::Bool(false)),
 		)
 		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
 		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))

--- a/crates/reinhardt-commands/src/introspect.rs
+++ b/crates/reinhardt-commands/src/introspect.rs
@@ -307,10 +307,6 @@ fn build_settings(
 	use reinhardt_conf::settings::builder::SettingsBuilder;
 	use reinhardt_conf::settings::sources::{DefaultSource, LowPriorityEnvSource, TomlFileSource};
 
-	let base_dir_str = base_dir
-		.to_str()
-		.ok_or_else(|| format!("base_dir contains invalid UTF-8: {}", base_dir.display()))?;
-
 	// Generate a random secret key to avoid shipping a hardcoded value,
 	// consistent with the approach used in execute_collectstatic.
 	let default_secret_key = crate::cli::generate_random_secret_key();
@@ -318,57 +314,17 @@ fn build_settings(
 	let merged = SettingsBuilder::new()
 		.profile(profile)
 		.add_source(
-			DefaultSource::new()
-				.with_value(
-					"base_dir",
-					serde_json::Value::String(base_dir_str.to_string()),
-				)
-				.with_value("debug", serde_json::Value::Bool(true))
-				.with_value("secret_key", serde_json::Value::String(default_secret_key))
-				.with_value("allowed_hosts", serde_json::Value::Array(vec![]))
-				.with_value("installed_apps", serde_json::Value::Array(vec![]))
-				.with_value("databases", serde_json::json!({}))
-				.with_value("templates", serde_json::Value::Array(vec![]))
-				.with_value(
-					"static_url",
-					serde_json::Value::String("/static/".to_string()),
-				)
+			DefaultSource::for_settings(base_dir, default_secret_key)
+				// Override: introspect needs static_root set
 				.with_value(
 					"static_root",
 					serde_json::Value::String(
 						base_dir.join("staticfiles").to_string_lossy().to_string(),
 					),
 				)
-				.with_value("staticfiles_dirs", serde_json::Value::Array(vec![]))
-				.with_value(
-					"media_url",
-					serde_json::Value::String("/media/".to_string()),
-				)
-				.with_value(
-					"language_code",
-					serde_json::Value::String("en-us".to_string()),
-				)
-				.with_value("time_zone", serde_json::Value::String("UTC".to_string()))
+				// Override: disable i18n/tz for introspection
 				.with_value("use_i18n", serde_json::Value::Bool(false))
-				.with_value("use_tz", serde_json::Value::Bool(false))
-				.with_value(
-					"default_auto_field",
-					serde_json::Value::String("reinhardt.db.models.BigAutoField".to_string()),
-				)
-				.with_value("secure_ssl_redirect", serde_json::Value::Bool(false))
-				.with_value(
-					"secure_hsts_include_subdomains",
-					serde_json::Value::Bool(false),
-				)
-				.with_value("secure_hsts_preload", serde_json::Value::Bool(false))
-				.with_value("session_cookie_secure", serde_json::Value::Bool(false))
-				.with_value("csrf_cookie_secure", serde_json::Value::Bool(false))
-				.with_value("append_slash", serde_json::Value::Bool(false))
-				.with_value("middleware", serde_json::Value::Array(vec![]))
-				.with_value("root_urlconf", serde_json::Value::String(String::new()))
-				.with_value("media_root", serde_json::Value::Null)
-				.with_value("admins", serde_json::Value::Array(vec![]))
-				.with_value("managers", serde_json::Value::Array(vec![])),
+				.with_value("use_tz", serde_json::Value::Bool(false)),
 		)
 		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
 		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))

--- a/crates/reinhardt-conf/src/settings.rs
+++ b/crates/reinhardt-conf/src/settings.rs
@@ -139,27 +139,34 @@ pub struct Settings {
 	/// **Note:** Currently not consumed by the framework. Reserved for future
 	/// template engine integration. Setting this value has no effect on framework
 	/// behavior.
+	#[serde(default = "default_templates")]
 	pub templates: Vec<TemplateConfig>,
 
 	/// Static files URL prefix.
+	#[serde(default = "default_static_url")]
 	pub static_url: String,
 
 	/// Static files root directory.
+	#[serde(default)]
 	pub static_root: Option<PathBuf>,
 
 	/// Additional static files directories (STATICFILES_DIRS).
+	#[serde(default)]
 	pub staticfiles_dirs: Vec<PathBuf>,
 
 	/// Media files URL prefix.
+	#[serde(default = "default_media_url")]
 	pub media_url: String,
 
 	/// Media files root directory.
+	#[serde(default)]
 	pub media_root: Option<PathBuf>,
 
 	/// Language code for internationalization.
 	///
 	/// **Note:** Currently not consumed by the framework. Reserved for future
 	/// i18n implementation. Setting this value has no effect on framework behavior.
+	#[serde(default = "default_language_code")]
 	pub language_code: String,
 
 	/// Time zone for datetime handling.
@@ -167,12 +174,14 @@ pub struct Settings {
 	/// **Note:** Currently not consumed by the framework. Reserved for future
 	/// timezone support implementation. Setting this value has no effect on
 	/// framework behavior.
+	#[serde(default = "default_time_zone")]
 	pub time_zone: String,
 
 	/// Enable internationalization.
 	///
 	/// **Note:** Currently not consumed by the framework. Reserved for future
 	/// i18n implementation. Setting this value has no effect on framework behavior.
+	#[serde(default = "default_use_i18n")]
 	pub use_i18n: bool,
 
 	/// Use timezone-aware datetimes.
@@ -180,6 +189,7 @@ pub struct Settings {
 	/// **Note:** Currently not consumed by the framework. Reserved for future
 	/// timezone support implementation. Setting this value has no effect on
 	/// framework behavior.
+	#[serde(default = "default_use_tz")]
 	pub use_tz: bool,
 
 	/// Default auto field type for models.
@@ -187,14 +197,17 @@ pub struct Settings {
 	/// **Note:** Currently not consumed by the framework. Reserved for future
 	/// auto field configuration. Setting this value has no effect on framework
 	/// behavior.
+	#[serde(default = "default_auto_field")]
 	pub default_auto_field: String,
 
 	/// List of administrators who receive error notifications.
 	/// Django equivalent: ADMINS = [('name', 'email'), ...]
+	#[serde(default)]
 	pub admins: Vec<Contact>,
 
 	/// List of managers who receive broken link notifications, etc.
 	/// Django equivalent: MANAGERS = [('name', 'email'), ...]
+	#[serde(default)]
 	pub managers: Vec<Contact>,
 }
 
@@ -228,17 +241,17 @@ impl Settings {
 				debug: true,
 				..Default::default()
 			},
-			templates: vec![TemplateConfig::default()],
-			static_url: "/static/".to_string(),
+			templates: default_templates(),
+			static_url: default_static_url(),
 			static_root: None,
 			staticfiles_dirs: vec![],
-			media_url: "/media/".to_string(),
+			media_url: default_media_url(),
 			media_root: None,
-			language_code: "en-us".to_string(),
-			time_zone: "UTC".to_string(),
-			use_i18n: true,
-			use_tz: true,
-			default_auto_field: "reinhardt.db.models.BigAutoField".to_string(),
+			language_code: default_language_code(),
+			time_zone: default_time_zone(),
+			use_i18n: default_use_i18n(),
+			use_tz: default_use_tz(),
+			default_auto_field: default_auto_field(),
 			admins: vec![],
 			managers: vec![],
 		}
@@ -448,6 +461,41 @@ impl Settings {
 			media_url: Some(self.media_url.clone()),
 		})
 	}
+}
+
+// Serde default functions for Settings fields.
+// These return the same values as Settings::new() to maintain a single source of truth.
+
+fn default_templates() -> Vec<TemplateConfig> {
+	vec![TemplateConfig::default()]
+}
+
+fn default_static_url() -> String {
+	"/static/".to_string()
+}
+
+fn default_media_url() -> String {
+	"/media/".to_string()
+}
+
+fn default_language_code() -> String {
+	"en-us".to_string()
+}
+
+fn default_time_zone() -> String {
+	"UTC".to_string()
+}
+
+fn default_use_i18n() -> bool {
+	true
+}
+
+fn default_use_tz() -> bool {
+	true
+}
+
+fn default_auto_field() -> String {
+	"reinhardt.db.models.BigAutoField".to_string()
 }
 
 #[allow(deprecated)] // Internal: Settings is deprecated but we still need to implement Default
@@ -739,5 +787,95 @@ mod tests {
 		assert_eq!(core.base_dir, PathBuf::from("/app"));
 		assert_eq!(core.secret_key, "test-secret");
 		assert!(core.debug);
+	}
+
+	#[rstest]
+	fn test_settings_deserialize_minimal_fields() {
+		// Arrange: only required fields (secret_key, base_dir)
+		let json = serde_json::json!({
+			"secret_key": "test-secret",
+			"base_dir": "/app"
+		});
+
+		// Act
+		let settings: Settings = serde_json::from_value(json).unwrap();
+
+		// Assert: all other fields use serde defaults matching Settings::new()
+		assert_eq!(settings.core.secret_key, "test-secret");
+		assert_eq!(settings.core.base_dir, PathBuf::from("/app"));
+		assert_eq!(settings.static_url, "/static/");
+		assert_eq!(settings.media_url, "/media/");
+		assert_eq!(settings.language_code, "en-us");
+		assert_eq!(settings.time_zone, "UTC");
+		assert!(settings.use_i18n);
+		assert!(settings.use_tz);
+		assert_eq!(
+			settings.default_auto_field,
+			"reinhardt.db.models.BigAutoField"
+		);
+		assert!(settings.static_root.is_none());
+		assert!(settings.media_root.is_none());
+		assert!(settings.staticfiles_dirs.is_empty());
+		assert!(settings.admins.is_empty());
+		assert!(settings.managers.is_empty());
+	}
+
+	#[rstest]
+	fn test_settings_deserialize_with_override() {
+		// Arrange: override some fields while omitting others
+		let json = serde_json::json!({
+			"secret_key": "test-secret",
+			"base_dir": "/app",
+			"static_url": "/assets/",
+			"use_i18n": false
+		});
+
+		// Act
+		let settings: Settings = serde_json::from_value(json).unwrap();
+
+		// Assert: overridden fields have custom values
+		assert_eq!(settings.static_url, "/assets/");
+		assert!(!settings.use_i18n);
+		// Assert: non-overridden fields still use defaults
+		assert_eq!(settings.media_url, "/media/");
+		assert!(settings.use_tz);
+		assert_eq!(settings.language_code, "en-us");
+	}
+
+	#[rstest]
+	fn test_settings_deserialize_all_fields_backward_compat() {
+		// Arrange: specify all fields explicitly (old pattern)
+		let json = serde_json::json!({
+			"secret_key": "my-secret",
+			"base_dir": "/my-app",
+			"debug": false,
+			"templates": [],
+			"static_url": "/static/",
+			"static_root": "/my-app/static",
+			"staticfiles_dirs": ["/extra"],
+			"media_url": "/media/",
+			"media_root": "/my-app/media",
+			"language_code": "ja",
+			"time_zone": "Asia/Tokyo",
+			"use_i18n": true,
+			"use_tz": true,
+			"default_auto_field": "reinhardt.db.models.BigAutoField",
+			"admins": [{"name": "Admin", "email": "admin@example.com"}],
+			"managers": []
+		});
+
+		// Act
+		let settings: Settings = serde_json::from_value(json).unwrap();
+
+		// Assert: all explicit values preserved
+		assert_eq!(settings.core.secret_key, "my-secret");
+		assert_eq!(settings.core.base_dir, PathBuf::from("/my-app"));
+		assert!(!settings.core.debug);
+		assert_eq!(settings.language_code, "ja");
+		assert_eq!(settings.time_zone, "Asia/Tokyo");
+		assert_eq!(settings.static_root, Some(PathBuf::from("/my-app/static")));
+		assert_eq!(settings.media_root, Some(PathBuf::from("/my-app/media")));
+		assert_eq!(settings.admins.len(), 1);
+		assert_eq!(settings.admins[0].name, "Admin");
 	}
 }

--- a/crates/reinhardt-conf/src/settings/sources.rs
+++ b/crates/reinhardt-conf/src/settings/sources.rs
@@ -461,6 +461,42 @@ impl DefaultSource {
 		self.values.extend(defaults);
 		self
 	}
+
+	/// Create a `DefaultSource` pre-populated with the minimum required dynamic
+	/// fields for deserializing into `Settings`.
+	///
+	/// Only `base_dir` and `secret_key` need to be provided because all other
+	/// fields have `#[serde(default)]` attributes on the `Settings` and
+	/// `CoreSettings` structs. Use `.with_value()` to override specific defaults
+	/// when needed.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use reinhardt_conf::settings::sources::DefaultSource;
+	/// use std::path::Path;
+	///
+	/// // Minimal: only required dynamic fields
+	/// let source = DefaultSource::for_settings(
+	///     Path::new("/app"),
+	///     "my-secret-key".to_string(),
+	/// );
+	///
+	/// // With overrides for site-specific values
+	/// let source = DefaultSource::for_settings(
+	///     Path::new("/app"),
+	///     "my-secret-key".to_string(),
+	/// )
+	/// .with_value("use_i18n", serde_json::Value::Bool(false));
+	/// ```
+	pub fn for_settings(base_dir: &Path, secret_key: String) -> Self {
+		Self::new()
+			.with_value(
+				"base_dir",
+				Value::String(base_dir.to_string_lossy().into_owned()),
+			)
+			.with_value("secret_key", Value::String(secret_key))
+	}
 }
 
 impl Default for DefaultSource {
@@ -707,5 +743,42 @@ secret_key = "test-key"
 		assert_eq!(DotEnvSource::new().priority(), 90);
 		assert_eq!(TomlFileSource::new("test.toml").priority(), 50);
 		assert_eq!(DefaultSource::new().priority(), 0);
+	}
+
+	#[test]
+	fn test_default_source_for_settings() {
+		// Arrange / Act
+		let source =
+			DefaultSource::for_settings(Path::new("/my-app"), "my-secret-key".to_string());
+		let config = source.load().unwrap();
+
+		// Assert: only base_dir and secret_key are set
+		assert_eq!(
+			config.get("base_dir").unwrap(),
+			&Value::String("/my-app".to_string())
+		);
+		assert_eq!(
+			config.get("secret_key").unwrap(),
+			&Value::String("my-secret-key".to_string())
+		);
+		assert_eq!(config.len(), 2);
+	}
+
+	#[test]
+	fn test_default_source_for_settings_with_overrides() {
+		// Arrange / Act
+		let source =
+			DefaultSource::for_settings(Path::new("/app"), "secret".to_string())
+				.with_value("use_i18n", Value::Bool(false))
+				.with_value("static_root", Value::String("/app/static".to_string()));
+		let config = source.load().unwrap();
+
+		// Assert: base_dir, secret_key, plus overrides
+		assert_eq!(config.len(), 4);
+		assert_eq!(config.get("use_i18n").unwrap(), &Value::Bool(false));
+		assert_eq!(
+			config.get("static_root").unwrap(),
+			&Value::String("/app/static".to_string())
+		);
 	}
 }


### PR DESCRIPTION
## Summary

- Add per-field `#[serde(default)]` attributes to all non-core `Settings` fields so missing fields are automatically filled with sensible defaults during deserialization
- Add `DefaultSource::for_settings()` convenience constructor that requires only `base_dir` and `secret_key`
- Simplify all 4 `DefaultSource` call sites from 20-28 `.with_value()` calls to 1-3 calls each
- Remove dead security flat keys that never reached the nested `SecuritySettings` struct

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The `Settings` struct required all fields to be present during deserialization. Multiple locations defined their own `DefaultSource` with the same default values (20-28 `.with_value()` calls each). When a new field was added to `Settings`, every `DefaultSource` had to be updated manually — omitting a field caused a runtime deserialization error. This was the root cause of #2110.

Additionally, security-related flat keys (`secure_ssl_redirect`, `append_slash`, etc.) were specified at the top level in `DefaultSource` but never reached the nested `SecuritySettings` struct because `CoreSettings.security` is not `#[serde(flatten)]`. These were dead code.

Fixes #2113

Related to: #2110

## How Was This Tested?

- Added 3 new deserialization tests in `settings.rs`:
  - Minimal fields test (only `secret_key` + `base_dir`)
  - Override test (partial fields with defaults for rest)
  - Backward compatibility test (all fields specified)
- Added 2 new tests for `DefaultSource::for_settings()` in `sources.rs`
- `cargo check --workspace --all-features` passed in prior session

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

### Scope Label (select all that apply)
None applicable (configuration/settings infrastructure)

---

**Additional Context:**

Design decision: Per-field `#[serde(default)]` was chosen over struct-level `#[serde(default)]` to avoid known edge cases with `#[serde(flatten)]` + struct-level defaults in serde 1.0.228. This approach is also consistent with the existing pattern in `CoreSettings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)