### PR TITLE
ci: use github.event.inputs to prevent phantom workflow failures

### DIFF
--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -34,7 +34,7 @@ jobs:
   mutation-test:
     name: "Shard ${{ matrix.shard }}/5"
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (inputs.shard == '0' || inputs.shard == matrix.shard))
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.shard == '0' || github.event.inputs.shard == matrix.shard))
     timeout-minutes: 360
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Replace bare `inputs.shard` with `github.event.inputs.shard` in mutation-test.yml job-level `if:` condition
- Prevents phantom failed runs (0 jobs, "workflow file issue") that occur on every push event across all branches

## Motivation and Context

The `inputs` context is only defined for `workflow_dispatch`/`workflow_call` events. When GitHub validates workflow files on push, the undefined `inputs` context causes a parse-time failure. Using `github.event.inputs` instead accesses the event payload object which always exists, returning null for non-dispatch events.

## Test plan

- [x] Push triggers mutation-test run — verify it no longer fails with "workflow file issue"
- [ ] After merge, confirm push events stop producing phantom failure runs

Fixes #3459

🤖 Generated with [Claude Code](https://claude.com/claude-code)