### PR TITLE
ci: add sccache for compilation caching in CI workflows

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -25,6 +25,12 @@ runs:
       with:
         components: ${{ inputs.components }}
 
+    - name: Setup sccache
+      if: inputs.cache == 'true'
+      uses: mozilla-actions/sccache-action@v0.0.9
+      with:
+        version: "v0.10.0"
+
     # Issue #1831: Detect the actual CARGO_TARGET_DIR from the calling workflow's
     # environment. Workflows set CARGO_TARGET_DIR to an absolute path (e.g.
     # /tmp/cargo_target or $RUNNER_TEMP/cargo_target) to conserve workspace disk


### PR DESCRIPTION
## Summary

Add `mozilla-actions/sccache-action@v0.0.9` to the `setup-rust` composite action to enable compilation-level caching in CI workflows.

- sccache caches individual `rustc` compilation unit outputs via the GitHub Actions cache backend
- Complements the existing `Swatinem/rust-cache` which caches the target directory and registry
- Gated on `inputs.cache == 'true'` so fmt-only workflows (which pass `cache: 'false'`) skip sccache

## Type of Change

- [x] CI/CD changes

## Motivation and Context

CI compilation times can be reduced by caching individual compiler outputs across runs. sccache intercepts `rustc` invocations and caches the preprocessed-source-hash → object-file mapping in the GHA cache backend. This is complementary to `Swatinem/rust-cache`, which caches at the registry/target-directory level.

The project already sets `CARGO_INCREMENTAL: 0`, which is the recommended setting for sccache.

## How Was This Tested?

- Verified the diff adds the sccache step in the correct position (after toolchain install, before rust-cache)
- sccache effectiveness can be verified by checking the "Setup sccache" step output and post-action statistics in any compilation workflow run

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)