### PR TITLE
fix(ci): extend all workflow timeout-minutes to 360

### DIFF
--- a/.github/workflows/auto-close-parent-issue.yml
+++ b/.github/workflows/auto-close-parent-issue.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   auto-close-parent:
     name: Auto-Close Parent Issue
-    timeout-minutes: 10
+    timeout-minutes: 360
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
@@ -158,7 +158,7 @@ jobs:
 
   auto-reopen-parent:
     name: Reopen Parent Issue
-    timeout-minutes: 10
+    timeout-minutes: 360
     if: github.event.action == 'reopened'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   label-by-path:
     name: Label by changed files
-    timeout-minutes: 10
+    timeout-minutes: 360
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v6
@@ -22,7 +22,7 @@ jobs:
 
   label-by-title:
     name: Label by PR title
-    timeout-minutes: 10
+    timeout-minutes: 360
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v8

--- a/.github/workflows/build-runner-ami.yml
+++ b/.github/workflows/build-runner-ami.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   build-ami:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 360
     env:
       RUNNER_ARCH: ${{ github.event.inputs.architecture || 'arm64' }}
       PKR_VAR_runner_arch: ${{ github.event.inputs.architecture || 'arm64' }}

--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -11,7 +11,7 @@ jobs:
   cancel-stale-runs:
     name: Cancel Stale Workflow Runs
     runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
-    timeout-minutes: 8
+    timeout-minutes: 360
     steps:
       - name: Cancel and force-cancel stale runs
         uses: actions/github-script@v8

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
   check:
     name: Cargo Check (${{ matrix.target.name }})
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   # When conflicts exist, skip all CI jobs to save runner costs.
   check-branch-status:
     name: Check Branch Status
-    timeout-minutes: 10
+    timeout-minutes: 360
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
@@ -83,7 +83,7 @@ jobs:
   # GitHub-hosted: fallback for fork PRs or when self-hosted is unavailable.
   determine-runner:
     name: Determine Runner
-    timeout-minutes: 10
+    timeout-minutes: 360
     runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     outputs:
       runner: ${{ steps.set-runner.outputs.runner }}
@@ -386,7 +386,7 @@ jobs:
   # All jobs must pass
   ci-success:
     name: CI Success
-    timeout-minutes: 10
+    timeout-minutes: 360
     if: always()
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/cleanup-release-branch.yml
+++ b/.github/workflows/cleanup-release-branch.yml
@@ -14,7 +14,7 @@ jobs:
       github.event.pull_request.merged == false &&
       startsWith(github.event.pull_request.head.ref, 'release-plz-')
     runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
-    timeout-minutes: 5
+    timeout-minutes: 360
     steps:
       - name: Delete remote branch
         uses: actions/github-script@v8

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -24,7 +24,7 @@ jobs:
   clippy:
     name: Clippy Lint
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     steps:
       - name: Free Disk Space (Ubuntu)
         if: ${{ !contains(inputs.runner || '', 'self-hosted') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
   codeql:
     name: Analyze Rust code
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 45
+    timeout-minutes: 360
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 360
     permissions:
       contents: read
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
   unit-coverage:
     name: Unit Test Coverage
     runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: 60
+    timeout-minutes: 360
     env:
       CARGO_TARGET_DIR: /tmp/cargo_target_unit_cov
     permissions:
@@ -182,7 +182,7 @@ jobs:
   intra-crate-integration-coverage:
     name: Intra-Crate Integration Coverage
     runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: 120
+    timeout-minutes: 360
     env:
       CARGO_TARGET_DIR: /tmp/cargo_target_intra_cov
     permissions:
@@ -340,7 +340,7 @@ jobs:
   cross-crate-integration-coverage:
     name: Cross-Crate Integration Coverage
     runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: 60
+    timeout-minutes: 360
     env:
       CARGO_TARGET_DIR: /tmp/cargo_target_cross_cov
     permissions:

--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -35,7 +35,7 @@ jobs:
   cross-crate-integration-test:
     name: Cross-Crate Integration Tests (${{ matrix.partition }}/3)
     runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: 40
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cross-platform-check.yml
+++ b/.github/workflows/cross-platform-check.yml
@@ -13,7 +13,7 @@ jobs:
   cross-platform-check:
     name: Cross-Platform Check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   build-and-deploy:
     name: Build & Deploy
-    timeout-minutes: 15
+    timeout-minutes: 360
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
@@ -78,7 +78,7 @@ jobs:
 
   cleanup-preview:
     name: Cleanup Preview
-    timeout-minutes: 10
+    timeout-minutes: 360
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/detect-affected-packages.yml
+++ b/.github/workflows/detect-affected-packages.yml
@@ -32,7 +32,7 @@ jobs:
   detect:
     name: Detect Affected Packages
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 360
     outputs:
       run-all: ${{ steps.detect.outputs.run-all }}
       has-affected: ${{ steps.detect.outputs.has-affected }}

--- a/.github/workflows/develop-leak-guard.yml
+++ b/.github/workflows/develop-leak-guard.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   develop-leak-guard:
     name: Develop Leak Guard
-    timeout-minutes: 10
+    timeout-minutes: 360
     if: >-
       github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
       github.event.label.name == 'migration-approved'

--- a/.github/workflows/develop-merge-guard.yml
+++ b/.github/workflows/develop-merge-guard.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   develop-merge-guard:
     name: Develop Merge Guard
-    timeout-minutes: 10
+    timeout-minutes: 360
     if: >-
       github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
       github.event.label.name == 'migration-approved'

--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -32,7 +32,7 @@ jobs:
   doc-test:
     name: Documentation Tests
     runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: 45
+    timeout-minutes: 360
     steps:
       - name: Free Disk Space (Ubuntu)
         if: ${{ !contains(inputs.runner, 'self-hosted') }}

--- a/.github/workflows/docs-rs-check.yml
+++ b/.github/workflows/docs-rs-check.yml
@@ -25,7 +25,7 @@ jobs:
   docs-rs-check:
     name: Docs.rs Build Check
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     steps:
       - name: Free Disk Space (Ubuntu)
         if: ${{ !contains(inputs.runner || '', 'self-hosted') }}

--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -25,7 +25,7 @@ jobs:
   test-example:
     name: ${{ matrix.example }}
     runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: 40
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
   fmt:
     name: Format Check
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 10
+    timeout-minutes: 360
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -47,7 +47,7 @@ jobs:
   intra-crate-integration-test:
     name: Intra-Crate Integration Tests (${{ matrix.partition }}/${{ inputs.partition-count || '8' }})
     runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: 90
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/monitor-rc-stability.yml
+++ b/.github/workflows/monitor-rc-stability.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   check-stability:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 360
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/msrv-test.yml
+++ b/.github/workflows/msrv-test.yml
@@ -24,7 +24,7 @@ jobs:
   msrv-check:
     name: MSRV Check (${{ matrix.rust }})
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -16,7 +16,7 @@ jobs:
     name: OSV scan (PR diff)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
 
@@ -45,7 +45,7 @@ jobs:
     name: OSV scan (full)
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -21,7 +21,7 @@ jobs:
   publish-check:
     name: Publish Dry-Run Check
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     # Skip for release-plz branches and release-fix branches - versions may not yet be on crates.io
     if: >-
       ${{

--- a/.github/workflows/reinhardt-feature-check.yml
+++ b/.github/workflows/reinhardt-feature-check.yml
@@ -41,7 +41,7 @@ jobs:
     name: Cache Seed (all-features)
     if: github.event_name == 'push'
     runs-on: [self-hosted, linux, arm64, reinhardt-ci]
-    timeout-minutes: 30
+    timeout-minutes: 360
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -84,7 +84,7 @@ jobs:
     name: Feature Check (${{ matrix.combo.name }})
     if: github.event_name != 'push'
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     env:
       CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
     strategy:
@@ -173,7 +173,7 @@ jobs:
     name: Feature Test (${{ matrix.combo.name }})
     if: github.event_name != 'push'
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 45
+    timeout-minutes: 360
     env:
       CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
     strategy:

--- a/.github/workflows/release-plz-dry-run.yml
+++ b/.github/workflows/release-plz-dry-run.yml
@@ -16,7 +16,7 @@ jobs:
   release-dry-run:
     name: Release Dry-Run Check
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     steps:
       - name: Free Disk Space
         if: ${{ !contains(inputs.runner || '', 'self-hosted') }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -26,7 +26,7 @@ jobs:
     name: Release PR
     if: github.event_name == 'push'
     runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
-    timeout-minutes: 30
+    timeout-minutes: 360
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
@@ -64,7 +64,7 @@ jobs:
     name: Release
     if: github.event_name == 'push'
     runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
-    timeout-minutes: 30
+    timeout-minutes: 360
     concurrency:
       group: release-plz-release-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -19,7 +19,7 @@ jobs:
   security-audit:
     name: Scan for known vulnerabilities
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 10
+    timeout-minutes: 360
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -25,7 +25,7 @@ jobs:
   semver-checks:
     name: SemVer Compatibility Check
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 90
+    timeout-minutes: 360
     steps:
       - name: Free Disk Space (Ubuntu)
         if: ${{ !contains(inputs.runner || '', 'self-hosted') }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 360
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -18,7 +18,7 @@ jobs:
   plan:
     name: Plan (${{ matrix.module }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +155,7 @@ jobs:
     name: Apply (${{ matrix.module }})
     needs: plan
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 360
     environment: production
     strategy:
       fail-fast: false

--- a/.github/workflows/terraform-check.yml
+++ b/.github/workflows/terraform-check.yml
@@ -8,7 +8,7 @@ jobs:
   terraform:
     name: Terraform (${{ matrix.module.name }})
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/terraform-plan-privileged.yml
+++ b/.github/workflows/terraform-plan-privileged.yml
@@ -60,7 +60,7 @@ jobs:
     needs: gate
     if: needs.gate.outputs.is_fork == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
@@ -138,7 +138,7 @@ jobs:
     needs: [gate, validate]
     if: needs.gate.outputs.is_fork == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 360
     environment: fork-review
     strategy:
       fail-fast: false

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     name: Plan (${{ matrix.module }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/terraform-validate-fork.yml
+++ b/.github/workflows/terraform-validate-fork.yml
@@ -20,7 +20,7 @@ jobs:
     name: Detect changed modules
     if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 360
     outputs:
       website: ${{ steps.filter.outputs.website }}
       github-runners: ${{ steps.filter.outputs.github-runners }}
@@ -52,7 +52,7 @@ jobs:
     name: Validate (${{ matrix.module.name }})
     needs: detect-changes
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -26,7 +26,7 @@ jobs:
     # github.event.pull_request is available in workflow_call context when caller is triggered by pull_request
     if: github.event.pull_request != null && github.actor != 'dependabot[bot]'
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 10
+    timeout-minutes: 360
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -39,7 +39,7 @@ jobs:
   clippy-todo-check:
     name: Clippy TODO/unimplemented/dbg lint
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     steps:
       - name: Free Disk Space (Ubuntu)
         if: ${{ !contains(inputs.runner || '', 'self-hosted') }}

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -42,7 +42,7 @@ jobs:
   ui-test:
     name: UI Tests (${{ matrix.partition }}/${{ inputs.partition-count || '8' }})
     runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: 60
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -47,7 +47,7 @@ jobs:
   unit-test:
     name: Unit Tests (${{ matrix.partition }}/${{ inputs.partition-count || '8' }})
     runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: 45
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update-version-refs.yml
+++ b/.github/workflows/update-version-refs.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   update-version-refs:
     name: Update docs/examples version references
-    timeout-minutes: 10
+    timeout-minutes: 360
     # Only trigger for reinhardt-web releases (release-plz creates GitHub Release for reinhardt-web only)
     if: >
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/wasm-check.yml
+++ b/.github/workflows/wasm-check.yml
@@ -24,7 +24,7 @@ jobs:
   wasm-check:
     name: WASM Check (${{ matrix.target.name }})
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
@@ -89,7 +89,7 @@ jobs:
     name: WASM Test (headless Chrome)
     if: github.event_name != 'push'
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
-    timeout-minutes: 30
+    timeout-minutes: 360
     env:
       CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
     steps:


### PR DESCRIPTION
## Summary

- Extend all `timeout-minutes` values to 360 (GitHub-hosted runner maximum) across 42 workflow files
- Eliminates timeout as a CI failure source — Examples Tests and Coverage Cross-Crate Integration were consistently hitting their limits

### Evidence from investigation

| Workflow | Previous timeout | Actual runtime | Result |
|----------|-----------------|----------------|--------|
| Examples Tests (rest-api, tutorial-basis, twitter) | 40 min | 40 min | **timeout** |
| Examples Tests (other 5 jobs) | 40 min | 36-38 min | success (barely) |
| Coverage Cross-Crate Integration | 60 min | 60-61 min | **timeout every run** |
| Coverage-main overall | — | — | 16/20 recent runs cancelled |

### Root cause

GitHub-hosted runners with `CARGO_BUILD_JOBS=1` compile slowly. Previous timeout values left no margin for runner performance variance.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Monitor next few Coverage-main runs after merge
- [ ] Confirm Examples Tests no longer timeout

Fixes #3466

🤖 Generated with [Claude Code](https://claude.com/claude-code)