### PR TITLE
feat(ci): add automated release announcement to GitHub Discussions

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,12 +3,24 @@ name: Release-plz
 permissions:
   contents: write
   pull-requests: write
+  discussions: write
 
 on:
   push:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      mode:
+        description: "Run mode: release (normal) or backfill (generate announcements for all past releases)"
+        type: choice
+        options:
+          - release
+          - backfill
+        default: release
+  pull_request:
+    types: [closed]
+    paths: ['announcements/**']
 
 jobs:
   # Native two-step release workflow:
@@ -155,3 +167,237 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # --- Release Announcement Automation ---
+  # Job 3: Generate announcement content and create PR for human review
+  # Job 4: Post approved announcement to GitHub Discussions
+
+  release-announcement-pr:
+    name: Create Release Announcement PR
+    if: >
+      (github.event_name == 'push') ||
+      (github.event_name == 'workflow_dispatch')
+    needs: [release-plz-release]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Determine tags to process
+        id: tags
+        env:
+          BACKFILL_MODE: ${{ inputs.mode }}
+        run: |
+          if [ "$BACKFILL_MODE" = "backfill" ]; then
+            TAGS=$(git tag --list 'reinhardt-web@v*' --sort=version:refname | tr '\n' ' ')
+          else
+            TAGS=$(git tag --list 'reinhardt-web@v*' --sort=-version:refname | head -1)
+          fi
+
+          if [ -z "$TAGS" ]; then
+            echo "::notice::No reinhardt-web tags found. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Processing tags: $TAGS"
+          fi
+
+      - name: Collect data and generate announcements
+        if: steps.tags.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          BACKFILL_MODE: ${{ inputs.mode }}
+          TAGS_TO_PROCESS: ${{ steps.tags.outputs.tags }}
+        run: |
+          FAILED_TAGS=""
+
+          for TAG in $TAGS_TO_PROCESS; do
+            VERSION="${TAG#reinhardt-web@v}"
+            ANNOUNCEMENT_FILE="announcements/v${VERSION}.md"
+
+            echo "=== Processing $TAG ==="
+
+            # Skip if announcement file already exists
+            if [ -f "$ANNOUNCEMENT_FILE" ]; then
+              echo "Skipping $TAG: announcement file already exists"
+              continue
+            fi
+
+            # Skip if Discussion already exists
+            EXISTING=$(gh api graphql -f query='
+              query($owner: String!, $repo: String!, $categoryId: ID!) {
+                repository(owner: $owner, name: $repo) {
+                  discussions(first: 100, categoryId: $categoryId) {
+                    nodes { title }
+                  }
+                }
+              }' \
+              -f owner=kent8192 -f repo=reinhardt-web \
+              -f categoryId=DIC_kwDOP9Jw0c4C2aMg \
+              --jq ".data.repository.discussions.nodes[] | select(.title == \"reinhardt-web v${VERSION}\") | .title" \
+              2>/dev/null || true)
+
+            if [ -n "$EXISTING" ]; then
+              echo "Skipping $TAG: Discussion already exists"
+              continue
+            fi
+
+            # Stage 1: Collect release data
+            if ! ./scripts/collect-release-data.sh "$TAG" --output "/tmp/release-data-${VERSION}.json"; then
+              echo "::warning::Failed to collect data for $TAG"
+              FAILED_TAGS="$FAILED_TAGS $TAG"
+              continue
+            fi
+
+            # Stage 2: Generate announcement with Claude CLI
+            SYSTEM_PROMPT=$(cat scripts/prompts/announcement-system.md)
+            if claude --print \
+              --bare \
+              --model sonnet \
+              --system-prompt "$SYSTEM_PROMPT" \
+              --tools "" \
+              "$(cat "/tmp/release-data-${VERSION}.json")" \
+              > "$ANNOUNCEMENT_FILE" 2>/dev/null; then
+              echo "Generated announcement for $TAG"
+            else
+              # Fallback: template with CHANGELOG only
+              echo "::warning::Claude CLI failed for $TAG, using fallback template"
+              CHANGELOG_SECTION=$(jq -r '.changelog_section' "/tmp/release-data-${VERSION}.json")
+              PRS_TABLE=$(jq -r '.pull_requests[] | "| [#\(.number)](\(.url)) | \(.title) | @\(.author) |"' \
+                "/tmp/release-data-${VERSION}.json" || true)
+
+              cat > "$ANNOUNCEMENT_FILE" <<FALLBACK_EOF
+          # reinhardt-web v${VERSION}
+
+          ## Highlights
+
+          (Auto-generated summary unavailable — see CHANGELOG below)
+
+          ## Breaking Changes
+
+          No breaking changes in this release.
+
+          ## Related PRs
+
+          | PR | Title | Author |
+          |----|-------|--------|
+          ${PRS_TABLE}
+
+          <details><summary>Full CHANGELOG</summary>
+
+          ${CHANGELOG_SECTION}
+
+          </details>
+          FALLBACK_EOF
+              echo "Created fallback announcement for $TAG"
+            fi
+
+            # Rate limiting for backfill
+            if [ "$BACKFILL_MODE" = "backfill" ]; then
+              sleep 5
+            fi
+          done
+
+          if [ -n "$FAILED_TAGS" ]; then
+            echo "::warning::Failed tags:$FAILED_TAGS"
+          fi
+
+          # Check if any announcements were generated
+          GENERATED=$(find announcements -name '*.md' ! -name '.gitkeep' | wc -l)
+          if [ "$GENERATED" -eq 0 ]; then
+            echo "::notice::No new announcements to create"
+            echo "no_announcements=true" >> "$GITHUB_ENV"
+          else
+            echo "Generated $GENERATED announcement(s)"
+            echo "no_announcements=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Create Announcement PR
+        if: steps.tags.outputs.skip != 'true' && env.no_announcements != 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: "docs: add release announcement(s)"
+          branch: announcement/batch-${{ github.run_id }}
+          title: "docs: release announcement(s) for review"
+          labels: announcement,automated
+          body: |
+            ## Summary
+
+            Auto-generated release announcement(s) for human review.
+            Edit the files in `announcements/` before merging.
+            Merging this PR will automatically post the announcement(s) to GitHub Discussions.
+
+            ## Preview
+
+            See the changed files for announcement content.
+
+            ---
+
+            Generated by release-announcement-pr job in [release-plz workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+  post-announcement:
+    name: Post Announcement to Discussions
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'announcement')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Post announcements to Discussions
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          POSTED=0
+          FAILED=0
+
+          for FILE in announcements/v*.md; do
+            [ -f "$FILE" ] || continue
+
+            echo "=== Posting $FILE ==="
+
+            if ./scripts/post-release-discussion.sh "$FILE"; then
+              POSTED=$((POSTED + 1))
+            else
+              FAILED=$((FAILED + 1))
+              echo "::warning::Failed to post $FILE"
+            fi
+
+            sleep 2
+          done
+
+          echo "Posted: $POSTED, Failed: $FAILED"
+
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::$FAILED announcement(s) failed to post"
+            exit 1
+          fi

--- a/scripts/collect-release-data.sh
+++ b/scripts/collect-release-data.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Collect release data (CHANGELOG, PRs, Breaking Changes Discussions) into JSON.
+# Usage: ./scripts/collect-release-data.sh <tag> [--output <file>]
+# Example: ./scripts/collect-release-data.sh reinhardt-web@v0.1.0-rc.15
+
+set -euo pipefail
+
+# --- Constants ---
+
+REPO_OWNER="kent8192"
+REPO_NAME="reinhardt-web"
+TAG_PREFIX="reinhardt-web@v"
+BC_CATEGORY_ID="DIC_kwDOP9Jw0c4C6kgx"
+
+# Bot accounts to exclude from PR comments
+BOT_AUTHORS="github-actions\\[bot\\]|copilot\\[bot\\]|reinhardt-release-plz\\[bot\\]|dependabot\\[bot\\]"
+
+# --- Argument parsing ---
+
+TAG=""
+OUTPUT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    -*)
+      echo "Error: Unknown option '$1'" >&2
+      echo "Usage: $0 <tag> [--output <file>]" >&2
+      exit 1
+      ;;
+    *)
+      if [ -z "$TAG" ]; then
+        TAG="$1"
+      else
+        echo "Error: Unexpected argument '$1'" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$TAG" ]; then
+  echo "Error: Tag argument is required" >&2
+  echo "Usage: $0 <tag> [--output <file>]" >&2
+  exit 1
+fi
+
+# Extract version from tag: reinhardt-web@v0.1.0-rc.15 → 0.1.0-rc.15
+VERSION="${TAG#"$TAG_PREFIX"}"
+
+if [ -z "$VERSION" ] || [ "$VERSION" = "$TAG" ]; then
+  echo "Error: Tag must start with '$TAG_PREFIX'" >&2
+  exit 1
+fi
+
+if [ -z "$OUTPUT_FILE" ]; then
+  OUTPUT_FILE="release-data-${VERSION}.json"
+fi
+
+# --- Resolve repository root ---
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Collecting release data for $TAG..."
+
+# --- Find previous tag ---
+
+PREV_TAG=""
+FOUND_CURRENT=false
+
+while IFS= read -r t; do
+  if [ "$t" = "$TAG" ]; then
+    FOUND_CURRENT=true
+    continue
+  fi
+  if $FOUND_CURRENT; then
+    PREV_TAG="$t"
+    break
+  fi
+done < <(git -C "$REPO_ROOT" tag --list "${TAG_PREFIX}*" --sort=-version:refname)
+
+if ! $FOUND_CURRENT; then
+  echo "Error: Tag '$TAG' not found in repository" >&2
+  exit 1
+fi
+
+if [ -z "$PREV_TAG" ]; then
+  echo "No previous tag found (this is the first release)"
+  COMMIT_RANGE="$TAG"
+else
+  echo "Previous tag: $PREV_TAG"
+  COMMIT_RANGE="${PREV_TAG}..${TAG}"
+fi
+
+# --- Get release date from tag ---
+
+RELEASE_DATE=$(git -C "$REPO_ROOT" log -1 --format=%cs "$TAG")
+
+# --- Extract CHANGELOG section ---
+
+CHANGELOG_FILE="$REPO_ROOT/CHANGELOG.md"
+CHANGELOG_SECTION=""
+
+if [ -f "$CHANGELOG_FILE" ]; then
+  # Extract section between ## [VERSION] and next ## [
+  ESCAPED_VERSION="${VERSION//./\\.}"
+  CHANGELOG_SECTION=$(perl -0777 -ne "
+    if (/^(## \\[${ESCAPED_VERSION}\\].*?)(?=^## \\[|\\z)/ms) {
+      print \$1;
+    }
+  " "$CHANGELOG_FILE")
+fi
+
+if [ -z "$CHANGELOG_SECTION" ]; then
+  echo "Warning: No CHANGELOG section found for version $VERSION" >&2
+  CHANGELOG_SECTION="No CHANGELOG entry found for this version."
+fi
+
+# --- Extract PR numbers from commit range ---
+
+echo "Extracting PRs from commit range: $COMMIT_RANGE"
+
+PR_NUMBERS=()
+
+# Merge commits: "Merge pull request #NNN from ..."
+while IFS= read -r num; do
+  [ -n "$num" ] && PR_NUMBERS+=("$num")
+done < <(git -C "$REPO_ROOT" log "$COMMIT_RANGE" --merges --format="%s" 2>/dev/null \
+  | grep -oE '#[0-9]+' | grep -oE '[0-9]+' || true)
+
+# Squash commits: "feat(scope): description (#NNN)"
+while IFS= read -r num; do
+  [ -n "$num" ] && PR_NUMBERS+=("$num")
+done < <(git -C "$REPO_ROOT" log "$COMMIT_RANGE" --no-merges --format="%s" 2>/dev/null \
+  | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' || true)
+
+# Deduplicate and sort
+if [ ${#PR_NUMBERS[@]} -gt 0 ]; then
+  mapfile -t PR_NUMBERS < <(printf '%s\n' "${PR_NUMBERS[@]}" | sort -un)
+fi
+
+echo "Found ${#PR_NUMBERS[@]} PRs in range"
+
+# --- Fetch PR details ---
+
+PRS_JSON="[]"
+
+for pr_num in "${PR_NUMBERS[@]}"; do
+  echo "  Fetching PR #$pr_num..."
+
+  # Get PR data
+  PR_DATA=$(gh api "repos/$REPO_OWNER/$REPO_NAME/pulls/$pr_num" \
+    --jq '{
+      number: .number,
+      title: .title,
+      url: .html_url,
+      body: (.body // ""),
+      labels: [.labels[].name],
+      author: .user.login
+    }' 2>/dev/null || echo "null")
+
+  if [ "$PR_DATA" = "null" ]; then
+    echo "  Warning: Could not fetch PR #$pr_num, skipping" >&2
+    continue
+  fi
+
+  # Check exclusions: skip release-plz PRs and bot authors
+  PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+  PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author')
+
+  if [ "$PR_TITLE" = "chore: release" ]; then
+    echo "  Skipping release-plz PR #$pr_num"
+    continue
+  fi
+
+  if echo "$PR_AUTHOR" | grep -qE '\[bot\]$'; then
+    echo "  Skipping bot PR #$pr_num (author: $PR_AUTHOR)"
+    continue
+  fi
+
+  # Get human comments (exclude bots)
+  COMMENTS=$(gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$pr_num/comments" \
+    --jq "[.[] | select(.user.login | test(\"${BOT_AUTHORS}\") | not) | .body]" \
+    2>/dev/null || echo "[]")
+
+  # Merge PR data with comments
+  PR_WITH_COMMENTS=$(echo "$PR_DATA" | jq --argjson comments "$COMMENTS" '. + {human_comments: $comments}')
+
+  PRS_JSON=$(echo "$PRS_JSON" | jq --argjson pr "$PR_WITH_COMMENTS" '. += [$pr]')
+done
+
+# --- Fetch Breaking Changes Discussions ---
+
+echo "Checking Breaking Changes Discussions..."
+
+BC_DISCUSSIONS="[]"
+
+if [ -n "$PREV_TAG" ]; then
+  PREV_DATE=$(git -C "$REPO_ROOT" log -1 --format=%cI "$PREV_TAG")
+
+  # Query Breaking Changes category discussions created after previous release
+  BC_RESULT=$(gh api graphql -f query='
+    query($owner: String!, $repo: String!, $categoryId: ID!) {
+      repository(owner: $owner, name: $repo) {
+        discussions(first: 50, categoryId: $categoryId, orderBy: {field: CREATED_AT, direction: DESC}) {
+          nodes {
+            number
+            title
+            url
+            createdAt
+          }
+        }
+      }
+    }' \
+    -f owner="$REPO_OWNER" \
+    -f repo="$REPO_NAME" \
+    -f categoryId="$BC_CATEGORY_ID" \
+    --jq '.data.repository.discussions.nodes' 2>/dev/null || echo "[]")
+
+  # Filter to discussions created after previous release date
+  BC_DISCUSSIONS=$(echo "$BC_RESULT" | jq --arg after "$PREV_DATE" \
+    '[.[] | select(.createdAt > $after) | {number, title, url}]')
+fi
+
+BC_COUNT=$(echo "$BC_DISCUSSIONS" | jq 'length')
+echo "Found $BC_COUNT Breaking Changes Discussions since last release"
+
+# --- Assemble output JSON ---
+
+jq -n \
+  --arg version "$VERSION" \
+  --arg tag "$TAG" \
+  --arg previous_tag "$PREV_TAG" \
+  --arg date "$RELEASE_DATE" \
+  --arg changelog_section "$CHANGELOG_SECTION" \
+  --argjson pull_requests "$PRS_JSON" \
+  --argjson breaking_changes_discussions "$BC_DISCUSSIONS" \
+  '{
+    version: $version,
+    tag: $tag,
+    previous_tag: $previous_tag,
+    date: $date,
+    changelog_section: $changelog_section,
+    pull_requests: $pull_requests,
+    breaking_changes_discussions: $breaking_changes_discussions
+  }' > "$OUTPUT_FILE"
+
+echo "Release data written to $OUTPUT_FILE"
+echo "  PRs: $(echo "$PRS_JSON" | jq 'length')"
+echo "  Breaking Changes Discussions: $BC_COUNT"

--- a/scripts/post-release-discussion.sh
+++ b/scripts/post-release-discussion.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Post a release announcement to GitHub Discussions.
+# Reads an announcement markdown file and creates a Discussion in the Release category.
+# Usage: ./scripts/post-release-discussion.sh <announcement-file>
+# Example: ./scripts/post-release-discussion.sh announcements/v0.1.0-rc.15.md
+
+set -euo pipefail
+
+# --- Constants ---
+
+REPO_OWNER="kent8192"
+REPO_NAME="reinhardt-web"
+RELEASE_CATEGORY_ID="DIC_kwDOP9Jw0c4C2aMg"
+
+# --- Argument parsing ---
+
+if [ $# -lt 1 ]; then
+  echo "Error: Announcement file argument is required" >&2
+  echo "Usage: $0 <announcement-file>" >&2
+  exit 1
+fi
+
+ANNOUNCEMENT_FILE="$1"
+
+if [ ! -f "$ANNOUNCEMENT_FILE" ]; then
+  echo "Error: File not found: $ANNOUNCEMENT_FILE" >&2
+  exit 1
+fi
+
+# Extract version from filename: announcements/v0.1.0-rc.15.md → 0.1.0-rc.15
+FILENAME=$(basename "$ANNOUNCEMENT_FILE" .md)
+VERSION="${FILENAME#v}"
+DISCUSSION_TITLE="reinhardt-web v${VERSION}"
+
+echo "Posting announcement for $DISCUSSION_TITLE..."
+
+# --- Get repository ID ---
+
+REPO_ID=$(gh api graphql -f query='
+  query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) { id }
+  }' \
+  -f owner="$REPO_OWNER" \
+  -f repo="$REPO_NAME" \
+  --jq '.data.repository.id')
+
+echo "Repository ID: $REPO_ID"
+
+# --- Duplicate check ---
+
+echo "Checking for existing Discussion..."
+
+EXISTING=$(gh api graphql -f query='
+  query($owner: String!, $repo: String!, $categoryId: ID!) {
+    repository(owner: $owner, name: $repo) {
+      discussions(first: 100, categoryId: $categoryId) {
+        nodes { title url number }
+      }
+    }
+  }' \
+  -f owner="$REPO_OWNER" \
+  -f repo="$REPO_NAME" \
+  -f categoryId="$RELEASE_CATEGORY_ID" \
+  --jq '.data.repository.discussions.nodes')
+
+# Check exact match
+EXACT_MATCH=$(echo "$EXISTING" | jq -r --arg title "$DISCUSSION_TITLE" \
+  '.[] | select(.title == $title) | .url')
+
+if [ -n "$EXACT_MATCH" ]; then
+  echo "::notice::Discussion already exists: $EXACT_MATCH"
+  echo "Skipping creation."
+  exit 0
+fi
+
+# Check partial match (title contains version)
+PARTIAL_MATCH=$(echo "$EXISTING" | jq -r --arg version "$VERSION" \
+  '.[] | select(.title | contains($version)) | "\(.title) — \(.url)"')
+
+if [ -n "$PARTIAL_MATCH" ]; then
+  echo "::warning::Partial title match found. Manual check required:" >&2
+  echo "$PARTIAL_MATCH" >&2
+  exit 1
+fi
+
+# --- Create Discussion ---
+
+BODY=$(cat "$ANNOUNCEMENT_FILE")
+
+RESULT=$(gh api graphql -f query='
+  mutation($repoId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+    createDiscussion(input: {
+      repositoryId: $repoId,
+      categoryId: $categoryId,
+      title: $title,
+      body: $body
+    }) {
+      discussion { url number }
+    }
+  }' \
+  -f repoId="$REPO_ID" \
+  -f categoryId="$RELEASE_CATEGORY_ID" \
+  -f title="$DISCUSSION_TITLE" \
+  -f body="$BODY")
+
+DISCUSSION_URL=$(echo "$RESULT" | jq -r '.data.createDiscussion.discussion.url')
+DISCUSSION_NUM=$(echo "$RESULT" | jq -r '.data.createDiscussion.discussion.number')
+
+echo "Discussion #$DISCUSSION_NUM created: $DISCUSSION_URL"

--- a/scripts/prompts/announcement-system.md
+++ b/scripts/prompts/announcement-system.md
@@ -1,0 +1,60 @@
+You are a technical writer for the reinhardt-web Rust framework.
+You receive a JSON object containing release data and produce a GitHub Discussion
+announcement in Markdown.
+
+## Input Schema
+
+The JSON has these fields:
+- `version`: semver string (e.g., "0.1.0-rc.15")
+- `tag`: full git tag (e.g., "reinhardt-web@v0.1.0-rc.15")
+- `previous_tag`: the prior release tag
+- `date`: release date (YYYY-MM-DD)
+- `changelog_section`: the CHANGELOG.md content for this version
+- `pull_requests`: array of objects with `number`, `title`, `url`, `body`, `human_comments`, `labels`, `author`
+- `breaking_changes_discussions`: array of objects with `number`, `title`, `url`
+
+## Output Format
+
+Produce ONLY the Markdown below. No preamble, no commentary, no code fences wrapping
+the entire output.
+
+# reinhardt-web v{version}
+
+## Highlights
+
+{2-5 paragraphs summarizing the substantive feature additions, improvements, and
+bug fixes from a user's perspective. Synthesize information from PR bodies,
+human comments, and the CHANGELOG. Focus on WHAT changed and WHY it matters
+to users. Do NOT list every commit — group related changes into coherent
+narratives. Exclude pure refactoring, CI/CD changes, test-only additions,
+and documentation-only changes from Highlights unless they represent a
+significant user-facing improvement.}
+
+## Breaking Changes
+
+{If breaking_changes_discussions is non-empty, list each as:
+- ⚠️ [Discussion title](url)
+
+If empty, write: "No breaking changes in this release."}
+
+## Related PRs
+
+| PR | Title | Author |
+|----|-------|--------|
+{One row per PR from pull_requests array:
+| [#number](url) | title | @author |}
+
+<details><summary>Full CHANGELOG</summary>
+
+{changelog_section verbatim}
+
+</details>
+
+## Rules
+
+1. Write in English.
+2. Use present tense ("adds", "fixes", not "added", "fixed").
+3. Do not invent features — only describe what is evidenced by the PR data and CHANGELOG.
+4. If a PR body is empty or unhelpful, rely on the title and CHANGELOG entries.
+5. Keep Highlights concise: aim for 100-300 words total.
+6. Preserve all Markdown formatting in the CHANGELOG section exactly as provided.


### PR DESCRIPTION
## Summary

- Add automated release announcement pipeline integrated into `release-plz.yml`
- When release-plz publishes a new GitHub Release, a Claude Code CLI step generates a human-readable announcement from PR bodies/comments and CHANGELOG
- A PR is created for human review before posting to GitHub Discussions (Release category)
- Backfill mode via `workflow_dispatch` generates announcements for all past releases

## New Files

| File | Purpose |
|------|---------|
| `scripts/collect-release-data.sh` | Collects CHANGELOG, PR data, and Breaking Changes Discussions into JSON (tag-diff based) |
| `scripts/post-release-discussion.sh` | Posts announcement to GitHub Discussions with duplicate checking |
| `scripts/prompts/announcement-system.md` | System prompt for Claude Code CLI to generate Highlights |
| `announcements/.gitkeep` | Directory for announcement drafts pending human review |

## Workflow Changes (`release-plz.yml`)

- **Job 3 (`release-announcement-pr`)**: Runs after release, collects data → Claude CLI generates announcement → creates PR for review
- **Job 4 (`post-announcement`)**: Triggered when announcement PR is merged, posts to Discussions
- **New permission**: `discussions: write`
- **New trigger**: `pull_request.closed` on `announcements/**` path
- **New input**: `workflow_dispatch` with `mode: backfill` option

## Prerequisites

- [ ] Add `ANTHROPIC_API_KEY` repository secret before running the workflow

## Test plan

- [x] `collect-release-data.sh` tested locally with `reinhardt-web@v0.1.0-rc.15` (74 PRs collected)
- [x] `collect-release-data.sh` tested with first tag `reinhardt-web@v0.1.0-alpha.1` (empty previous_tag handled)
- [x] Workflow YAML syntax validated
- [ ] Run backfill mode via `workflow_dispatch` after adding `ANTHROPIC_API_KEY`
- [ ] Verify generated announcement PR content
- [ ] Merge announcement PR and verify Discussion creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)