### PR TITLE
ci: trigger release announcement only when release PR is merged

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -77,6 +77,8 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
     timeout-minutes: 360
+    outputs:
+      released: ${{ steps.check-release.outputs.released }}
     concurrency:
       group: release-plz-release-${{ github.ref }}
       cancel-in-progress: false
@@ -117,6 +119,13 @@ jobs:
       # Workaround for gix slotmap overflow (GitoxideLabs/gitoxide#1788)
       - name: Clear cargo registry git index cache
         run: rm -rf ~/.cargo/registry/index/github.com-*
+
+      - name: Snapshot tags before release
+        id: tags-before
+        run: |
+          git tag --list 'reinhardt-web@v*' --sort=version:refname > /tmp/tags-before.txt
+          echo "Tags before release:"
+          cat /tmp/tags-before.txt
 
       - name: Publish to crates.io and create releases (attempt 1/3)
         id: release-attempt-1
@@ -168,15 +177,36 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+      - name: Check if release was made
+        id: check-release
+        if: always()
+        run: |
+          git fetch --tags --force
+          git tag --list 'reinhardt-web@v*' --sort=version:refname > /tmp/tags-after.txt
+          echo "Tags after release:"
+          cat /tmp/tags-after.txt
+          NEW_TAGS=$(comm -13 /tmp/tags-before.txt /tmp/tags-after.txt || true)
+          if [ -n "$NEW_TAGS" ]; then
+            echo "New tags detected:"
+            echo "$NEW_TAGS"
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No new tags detected"
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # --- Release Announcement Automation ---
   # Job 3: Generate announcement content and create PR for human review
   # Job 4: Post approved announcement to GitHub Discussions
 
   release-announcement-pr:
     name: Create Release Announcement PR
-    if: >
-      (github.event_name == 'push') ||
-      (github.event_name == 'workflow_dispatch')
+    if: |
+      always() &&
+      (
+        (github.event_name == 'push' && needs.release-plz-release.outputs.released == 'true') ||
+        (github.event_name == 'workflow_dispatch')
+      )
     needs: [release-plz-release]
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -123,9 +123,11 @@ jobs:
       - name: Snapshot tags before release
         id: tags-before
         run: |
-          git tag --list 'reinhardt-web@v*' --sort=version:refname > /tmp/tags-before.txt
+          TAGS_BEFORE_FILE="${RUNNER_TEMP}/tags-before-${GITHUB_RUN_ID}.txt"
+          git tag --list 'reinhardt-web@v*' --sort=version:refname > "$TAGS_BEFORE_FILE"
+          echo "tags_file=$TAGS_BEFORE_FILE" >> "$GITHUB_OUTPUT"
           echo "Tags before release:"
-          cat /tmp/tags-before.txt
+          cat "$TAGS_BEFORE_FILE"
 
       - name: Publish to crates.io and create releases (attempt 1/3)
         id: release-attempt-1
@@ -180,12 +182,28 @@ jobs:
       - name: Check if release was made
         id: check-release
         if: always()
+        env:
+          TAGS_BEFORE_FILE: ${{ steps.tags-before.outputs.tags_file }}
         run: |
+          TAGS_AFTER_FILE="${RUNNER_TEMP}/tags-after-${GITHUB_RUN_ID}.txt"
+
           git fetch --tags --force
-          git tag --list 'reinhardt-web@v*' --sort=version:refname > /tmp/tags-after.txt
+          git tag --list 'reinhardt-web@v*' --sort=version:refname > "$TAGS_AFTER_FILE"
           echo "Tags after release:"
-          cat /tmp/tags-after.txt
-          NEW_TAGS=$(comm -13 /tmp/tags-before.txt /tmp/tags-after.txt || true)
+          cat "$TAGS_AFTER_FILE"
+
+          if [ ! -f "$TAGS_BEFORE_FILE" ]; then
+            echo "::warning::Missing tag snapshot: $TAGS_BEFORE_FILE"
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! NEW_TAGS=$(comm -13 "$TAGS_BEFORE_FILE" "$TAGS_AFTER_FILE"); then
+            echo "::warning::Failed to compare tag snapshots"
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [ -n "$NEW_TAGS" ]; then
             echo "New tags detected:"
             echo "$NEW_TAGS"


### PR DESCRIPTION
## Summary

- Fix `release-announcement-pr` job to only run when `release-plz release` actually creates new tags (i.e., when a Release PR is merged), not on every push to main
- Fix existing bug where `workflow_dispatch` (backfill mode) was silently skipped due to `needs` dependency on the skipped `release-plz-release` job

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The `release-announcement-pr` job was triggering on every push to main because its condition only checked `github.event_name == 'push'`. Since `release-plz-release` succeeds even when it doesn't publish anything (non-release push), the announcement job would still run and potentially create announcement PRs for existing unprocessed tags.

Additionally, the `workflow_dispatch` trigger for backfill mode was broken because `release-plz-release` is skipped on `workflow_dispatch` events, and the `needs` dependency caused the announcement job to be silently skipped as well.

## How Was This Tested?

- Validated YAML syntax with `actionlint` (no new errors introduced)
- Verified logic flow:
  - Regular push to main → `released=false` → announcement job skipped
  - Release PR merge → new tags created → `released=true` → announcement job runs
  - `workflow_dispatch` → `release-plz-release` skipped → `always()` allows announcement job to run

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)