### PR TITLE
fix: resolve format violations and clippy warnings across workspace

### DIFF
--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -1096,8 +1096,12 @@ fn route_impl(method: &str, args: TokenStream, input: ItemFn) -> Result<TokenStr
 		}
 	};
 
-	let url_resolver_tokens =
-		generate_url_resolver_tokens(&options.name, &fn_name.to_string(), &path_str, &reinhardt_crate);
+	let url_resolver_tokens = generate_url_resolver_tokens(
+		&options.name,
+		&fn_name.to_string(),
+		&path_str,
+		&reinhardt_crate,
+	);
 
 	Ok(quote! {
 		// Submit endpoint metadata to global inventory

--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -56,8 +56,10 @@ fn build_resolver_reexport(path: &TokenStream) -> TokenStream {
 	}
 
 	let last_segment = &parsed.segments.last().unwrap().ident;
-	let resolver_mod =
-		syn::Ident::new(&format!("__url_resolver_{last_segment}"), last_segment.span());
+	let resolver_mod = syn::Ident::new(
+		&format!("__url_resolver_{last_segment}"),
+		last_segment.span(),
+	);
 
 	let first_segment = parsed.segments.first().unwrap().ident.to_string();
 	let is_absolute = first_segment == "crate" || first_segment == "super";

--- a/crates/reinhardt-core/src/exception/param_error.rs
+++ b/crates/reinhardt-core/src/exception/param_error.rs
@@ -177,6 +177,21 @@ pub fn extract_field_from_serde_error(err: &serde_json::Error) -> Option<String>
 	None
 }
 
+/// Extract field name from serde_urlencoded error message
+pub fn extract_field_from_urlencoded_error(err: &serde_urlencoded::de::Error) -> Option<String> {
+	let msg = err.to_string();
+
+	// "missing field `xxx`" pattern
+	if let Some(start) = msg.find("missing field `") {
+		let rest = &msg[start + 15..];
+		if let Some(end) = rest.find('`') {
+			return Some(rest[..end].to_string());
+		}
+	}
+
+	None
+}
+
 #[cfg(test)]
 mod tests {
 	use rstest::rstest;
@@ -187,7 +202,7 @@ mod tests {
 	fn with_raw_value_does_not_panic_on_multibyte_utf8() {
 		// Arrange - 500+ bytes of multi-byte Japanese characters
 		// Each character is 3 bytes in UTF-8, so 200 chars = 600 bytes
-		let japanese_str: String = std::iter::repeat('あ').take(200).collect();
+		let japanese_str: String = "あ".repeat(200);
 		assert!(japanese_str.len() > 500);
 
 		// Act - must not panic on multi-byte boundary
@@ -201,7 +216,7 @@ mod tests {
 	#[rstest]
 	fn with_raw_value_does_not_panic_on_emoji() {
 		// Arrange - emoji are 4 bytes each, 150 emojis = 600 bytes
-		let emoji_str: String = std::iter::repeat('\u{1F600}').take(150).collect();
+		let emoji_str: String = "\u{1F600}".repeat(150);
 		assert!(emoji_str.len() > 500);
 
 		// Act - must not panic on 4-byte char boundary
@@ -252,19 +267,4 @@ mod tests {
 		// Assert - should NOT be truncated (len is not > 500)
 		assert_eq!(ctx.raw_value.unwrap(), exact);
 	}
-}
-
-/// Extract field name from serde_urlencoded error message
-pub fn extract_field_from_urlencoded_error(err: &serde_urlencoded::de::Error) -> Option<String> {
-	let msg = err.to_string();
-
-	// "missing field `xxx`" pattern
-	if let Some(start) = msg.find("missing field `") {
-		let rest = &msg[start + 15..];
-		if let Some(end) = rest.find('`') {
-			return Some(rest[..end].to_string());
-		}
-	}
-
-	None
 }

--- a/crates/reinhardt-core/src/reactive/context.rs
+++ b/crates/reinhardt-core/src/reactive/context.rs
@@ -369,7 +369,7 @@ mod tests {
 	#[test]
 	fn test_context_clone() {
 		let ctx1: Context<i32> = Context::new();
-		let ctx2 = ctx1.clone();
+		let ctx2 = ctx1;
 
 		assert_eq!(ctx1.id(), ctx2.id());
 	}

--- a/crates/reinhardt-core/src/reactive/effect.rs
+++ b/crates/reinhardt-core/src/reactive/effect.rs
@@ -497,8 +497,8 @@ mod tests {
 		});
 
 		// Assert - both effects should have executed without panic
-		assert_eq!(*outer_ran.borrow(), true);
-		assert_eq!(*inner_ran.borrow(), true);
+		assert!(*outer_ran.borrow());
+		assert!(*inner_ran.borrow());
 	}
 
 	#[rstest::rstest]
@@ -522,7 +522,7 @@ mod tests {
 		});
 
 		// Assert - outer ran and inner captured the signal value
-		assert_eq!(*outer_ran.borrow(), true);
+		assert!(*outer_ran.borrow());
 		assert_eq!(*inner_value.borrow(), 42);
 	}
 
@@ -579,14 +579,14 @@ mod tests {
 		use std::sync::{Arc, Mutex};
 
 		// Collect tasks scheduled via set_scheduler
-		let scheduled_tasks: Arc<Mutex<Vec<Box<dyn FnOnce() + Send>>>> =
-			Arc::new(Mutex::new(Vec::new()));
+		type ScheduledTasks = Arc<Mutex<Vec<Box<dyn FnOnce() + Send>>>>;
+		let scheduled_tasks: ScheduledTasks = Arc::new(Mutex::new(Vec::new()));
 		let tasks_clone = scheduled_tasks.clone();
 
 		// Install a scheduler that captures tasks instead of executing them
 		// Note: OnceLock means this only works once per process, but serial
 		// test ordering ensures no conflict
-		let _ = set_scheduler(move |task| {
+		set_scheduler(move |task| {
 			tasks_clone.lock().unwrap().push(task);
 		});
 

--- a/crates/reinhardt-core/src/reactive/memo.rs
+++ b/crates/reinhardt-core/src/reactive/memo.rs
@@ -505,7 +505,7 @@ mod tests {
 
 		// Assert - memo returns the correct value and nested effect executed
 		assert_eq!(memo.get(), 42);
-		assert_eq!(*effect_ran.borrow(), true);
+		assert!(*effect_ran.borrow());
 	}
 
 	#[test]

--- a/crates/reinhardt-core/src/security/csrf.rs
+++ b/crates/reinhardt-core/src/security/csrf.rs
@@ -765,10 +765,7 @@ mod tests {
 		let result = should_rotate_token(token_timestamp, current_timestamp, Some(interval));
 
 		// Assert
-		assert_eq!(
-			result, true,
-			"Token older than interval should trigger rotation"
-		);
+		assert!(result, "Token older than interval should trigger rotation");
 	}
 
 	#[rstest]
@@ -782,10 +779,7 @@ mod tests {
 		let result = should_rotate_token(token_timestamp, current_timestamp, Some(interval));
 
 		// Assert
-		assert_eq!(
-			result, false,
-			"Future-dated token should not trigger rotation"
-		);
+		assert!(!result, "Future-dated token should not trigger rotation");
 	}
 
 	#[rstest]
@@ -798,9 +792,6 @@ mod tests {
 		let result = should_rotate_token(timestamp, timestamp, Some(interval));
 
 		// Assert
-		assert_eq!(
-			result, false,
-			"Equal timestamps (0 elapsed) should not trigger rotation"
-		);
+		assert!(!result, "Equal timestamps (0 elapsed) should not trigger rotation");
 	}
 }

--- a/crates/reinhardt-core/src/security/csrf.rs
+++ b/crates/reinhardt-core/src/security/csrf.rs
@@ -792,6 +792,9 @@ mod tests {
 		let result = should_rotate_token(timestamp, timestamp, Some(interval));
 
 		// Assert
-		assert!(!result, "Equal timestamps (0 elapsed) should not trigger rotation");
+		assert!(
+			!result,
+			"Equal timestamps (0 elapsed) should not trigger rotation"
+		);
 	}
 }

--- a/crates/reinhardt-core/tests/serializers_integration.rs
+++ b/crates/reinhardt-core/tests/serializers_integration.rs
@@ -614,10 +614,10 @@ fn integer_field_stores_default_value() {
 #[rstest]
 fn float_field_stores_default_value() {
 	// Act
-	let field = FloatField::new().default(3.14);
+	let field = FloatField::new().default(2.78);
 
 	// Assert
-	assert_eq!(field.default, Some(3.14));
+	assert_eq!(field.default, Some(2.78));
 }
 
 #[rstest]

--- a/crates/reinhardt-di/benches/cache_performance.rs
+++ b/crates/reinhardt-di/benches/cache_performance.rs
@@ -1,6 +1,7 @@
 //! Benchmark: Cache performance (hit vs miss)
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use reinhardt_di::{DiResult, Injectable, InjectionContext, SingletonScope};
 use std::sync::Arc;
 

--- a/crates/reinhardt-di/benches/cache_performance.rs
+++ b/crates/reinhardt-di/benches/cache_performance.rs
@@ -1,8 +1,8 @@
 //! Benchmark: Cache performance (hit vs miss)
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
 use reinhardt_di::{DiResult, Injectable, InjectionContext, SingletonScope};
+use std::hint::black_box;
 use std::sync::Arc;
 
 // Benchmark service

--- a/crates/reinhardt-di/benches/concurrency.rs
+++ b/crates/reinhardt-di/benches/concurrency.rs
@@ -1,6 +1,7 @@
 //! Benchmark: Concurrent resolution and scope contention
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use reinhardt_di::{DiResult, Injectable, InjectionContext, SingletonScope};
 use std::sync::Arc;
 
@@ -87,7 +88,7 @@ fn benchmark_scope_contention(c: &mut Criterion) {
 
 			// Wait for all tasks
 			for handle in handles {
-				let _ = handle.await.unwrap();
+				handle.await.unwrap();
 			}
 
 			black_box(())

--- a/crates/reinhardt-di/benches/concurrency.rs
+++ b/crates/reinhardt-di/benches/concurrency.rs
@@ -1,8 +1,8 @@
 //! Benchmark: Concurrent resolution and scope contention
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
 use reinhardt_di::{DiResult, Injectable, InjectionContext, SingletonScope};
+use std::hint::black_box;
 use std::sync::Arc;
 
 // Concurrent service

--- a/crates/reinhardt-di/benches/depth_sampling.rs
+++ b/crates/reinhardt-di/benches/depth_sampling.rs
@@ -1,6 +1,7 @@
 //! Benchmark: Dependency depth sampling
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use reinhardt_di::{DiResult, InjectionContext, SingletonScope};
 use std::sync::Arc;
 

--- a/crates/reinhardt-di/benches/depth_sampling.rs
+++ b/crates/reinhardt-di/benches/depth_sampling.rs
@@ -1,8 +1,8 @@
 //! Benchmark: Dependency depth sampling
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
 use reinhardt_di::{DiResult, InjectionContext, SingletonScope};
+use std::hint::black_box;
 use std::sync::Arc;
 
 // Nested dependency service

--- a/crates/reinhardt-di/src/function_handle.rs
+++ b/crates/reinhardt-di/src/function_handle.rs
@@ -245,6 +245,6 @@ mod tests {
 		let ctx = InjectionContext::builder(singleton).build();
 
 		let handle = ctx.dependency(create_string);
-		assert_eq!(handle.func_ptr(), create_string as usize);
+		assert_eq!(handle.func_ptr(), create_string as *const () as usize);
 	}
 }

--- a/crates/reinhardt-di/src/override_registry.rs
+++ b/crates/reinhardt-di/src/override_registry.rs
@@ -247,9 +247,9 @@ mod tests {
 	fn test_set_and_get_override() {
 		let registry = OverrideRegistry::new();
 
-		registry.set(factory_a as usize, "mock_a".to_string());
+		registry.set(factory_a as *const () as usize, "mock_a".to_string());
 
-		let value: Option<String> = registry.get(factory_a as usize);
+		let value: Option<String> = registry.get(factory_a as *const () as usize);
 		assert_eq!(value, Some("mock_a".to_string()));
 	}
 
@@ -257,11 +257,11 @@ mod tests {
 	fn test_different_functions_same_return_type() {
 		let registry = OverrideRegistry::new();
 
-		registry.set(factory_a as usize, "mock_a".to_string());
-		registry.set(factory_b as usize, "mock_b".to_string());
+		registry.set(factory_a as *const () as usize, "mock_a".to_string());
+		registry.set(factory_b as *const () as usize, "mock_b".to_string());
 
-		let value_a: Option<String> = registry.get(factory_a as usize);
-		let value_b: Option<String> = registry.get(factory_b as usize);
+		let value_a: Option<String> = registry.get(factory_a as *const () as usize);
+		let value_b: Option<String> = registry.get(factory_b as *const () as usize);
 
 		assert_eq!(value_a, Some("mock_a".to_string()));
 		assert_eq!(value_b, Some("mock_b".to_string()));
@@ -271,7 +271,7 @@ mod tests {
 	fn test_get_nonexistent_returns_none() {
 		let registry = OverrideRegistry::new();
 
-		let value: Option<String> = registry.get(factory_a as usize);
+		let value: Option<String> = registry.get(factory_a as *const () as usize);
 		assert!(value.is_none());
 	}
 
@@ -279,13 +279,13 @@ mod tests {
 	fn test_remove_override() {
 		let registry = OverrideRegistry::new();
 
-		registry.set(factory_a as usize, "mock_a".to_string());
-		assert!(registry.has(factory_a as usize));
+		registry.set(factory_a as *const () as usize, "mock_a".to_string());
+		assert!(registry.has(factory_a as *const () as usize));
 
-		registry.remove(factory_a as usize);
-		assert!(!registry.has(factory_a as usize));
+		registry.remove(factory_a as *const () as usize);
+		assert!(!registry.has(factory_a as *const () as usize));
 
-		let value: Option<String> = registry.get(factory_a as usize);
+		let value: Option<String> = registry.get(factory_a as *const () as usize);
 		assert!(value.is_none());
 	}
 
@@ -293,8 +293,8 @@ mod tests {
 	fn test_clear_overrides() {
 		let registry = OverrideRegistry::new();
 
-		registry.set(factory_a as usize, "mock_a".to_string());
-		registry.set(factory_b as usize, "mock_b".to_string());
+		registry.set(factory_a as *const () as usize, "mock_a".to_string());
+		registry.set(factory_b as *const () as usize, "mock_b".to_string());
 		assert_eq!(registry.len(), 2);
 
 		registry.clear();
@@ -309,14 +309,14 @@ mod tests {
 			42
 		}
 
-		registry.set(int_factory as usize, 100i32);
+		registry.set(int_factory as *const () as usize, 100i32);
 
 		// Try to get as wrong type
-		let value: Option<String> = registry.get(int_factory as usize);
+		let value: Option<String> = registry.get(int_factory as *const () as usize);
 		assert!(value.is_none());
 
 		// Correct type works
-		let value: Option<i32> = registry.get(int_factory as usize);
+		let value: Option<i32> = registry.get(int_factory as *const () as usize);
 		assert_eq!(value, Some(100));
 	}
 }

--- a/crates/reinhardt-di/src/registry.rs
+++ b/crates/reinhardt-di/src/registry.rs
@@ -317,9 +317,7 @@ Use a distinct newtype (e.g., `struct Primary{short}({short})`) for each."
 	}
 
 	/// Iterate over all qualified type name mappings without allocating a new map.
-	pub fn iter_qualified_type_names(
-		&self,
-	) -> impl Iterator<Item = (TypeId, &'static str)> + '_ {
+	pub fn iter_qualified_type_names(&self) -> impl Iterator<Item = (TypeId, &'static str)> + '_ {
 		self.qualified_type_names
 			.iter()
 			.map(|entry| (*entry.key(), *entry.value()))

--- a/crates/reinhardt-di/src/validation.rs
+++ b/crates/reinhardt-di/src/validation.rs
@@ -830,7 +830,11 @@ mod tests {
 	#[rstest]
 	#[case("reinhardtson::MyType", false, "similar prefix different crate")]
 	#[case("reinhardts::MyType", false, "similar prefix no separator")]
-	#[case("reinhardt_like_crate::MyType", false, "unknown crate starting with reinhardt_")]
+	#[case(
+		"reinhardt_like_crate::MyType",
+		false,
+		"unknown crate starting with reinhardt_"
+	)]
 	#[case("REINHARDT::Type", false, "uppercase")]
 	#[case("Reinhardt::Type", false, "capitalized")]
 	#[case("my_reinhardt_app::Type", false, "reinhardt in middle")]

--- a/crates/reinhardt-di/tests/resolve_context_dispatch_tests.rs
+++ b/crates/reinhardt-di/tests/resolve_context_dispatch_tests.rs
@@ -82,7 +82,7 @@ async fn nested_resolve_preserves_root_in_factory() {
 
 			// Inner factory gets its own current context but preserves root
 			let inner_current_ctx = build_context();
-			let inner_current_clone = Arc::clone(&inner_current_ctx);
+			let _inner_current_clone = Arc::clone(&inner_current_ctx);
 			let inner = ResolveContext {
 				root: Arc::clone(&root_clone),
 				current: inner_current_ctx,

--- a/crates/reinhardt-di/tests/resolve_context_e2e_tests.rs
+++ b/crates/reinhardt-di/tests/resolve_context_e2e_tests.rs
@@ -13,12 +13,6 @@ use reinhardt_di::{
 	ContextLevel, InjectionContext, SingletonScope, get_di_context, try_get_di_context,
 };
 
-/// Helper to build a fresh `InjectionContext` wrapped in `Arc`.
-fn build_context() -> Arc<InjectionContext> {
-	let scope = SingletonScope::new();
-	Arc::new(InjectionContext::builder(scope).build())
-}
-
 /// Helper to build a context with a shared singleton scope.
 fn build_context_with_scope(scope: Arc<SingletonScope>) -> Arc<InjectionContext> {
 	Arc::new(InjectionContext::builder(scope).build())
@@ -59,7 +53,7 @@ async fn factory_chain_context_propagation() {
 				// Factory A resolves type B, which triggers factory B
 				// Factory B gets a nested scope with the same root
 				let factory_b_current = build_context_with_scope(Arc::clone(&singleton_scope));
-				let factory_b_current_clone = Arc::clone(&factory_b_current);
+				let _factory_b_current_clone = Arc::clone(&factory_b_current);
 
 				let inner = ResolveContext {
 					root: Arc::clone(&root_clone),

--- a/crates/reinhardt-grpc/tests/di_integration.rs
+++ b/crates/reinhardt-grpc/tests/di_integration.rs
@@ -82,10 +82,7 @@ impl TestService {
 		#[inject] db: MockDatabase,
 	) -> Result<Response<String>, Status> {
 		let user_id = &request.into_inner().id;
-		let user = db
-			.fetch_user(user_id)
-			.await
-			.map_err(Status::not_found)?;
+		let user = db.fetch_user(user_id).await.map_err(Status::not_found)?;
 		Ok(Response::new(user))
 	}
 
@@ -104,10 +101,7 @@ impl TestService {
 		}
 
 		// Fetch from database
-		let user = db
-			.fetch_user(user_id)
-			.await
-			.map_err(Status::not_found)?;
+		let user = db.fetch_user(user_id).await.map_err(Status::not_found)?;
 		Ok(Response::new(user))
 	}
 
@@ -118,10 +112,7 @@ impl TestService {
 		#[inject(cache = false)] db: MockDatabase,
 	) -> Result<Response<String>, Status> {
 		let user_id = &request.into_inner().id;
-		let user = db
-			.fetch_user(user_id)
-			.await
-			.map_err(Status::not_found)?;
+		let user = db.fetch_user(user_id).await.map_err(Status::not_found)?;
 		Ok(Response::new(user))
 	}
 }

--- a/crates/reinhardt-grpc/tests/di_integration.rs
+++ b/crates/reinhardt-grpc/tests/di_integration.rs
@@ -85,7 +85,7 @@ impl TestService {
 		let user = db
 			.fetch_user(user_id)
 			.await
-			.map_err(|e| Status::not_found(e))?;
+			.map_err(Status::not_found)?;
 		Ok(Response::new(user))
 	}
 
@@ -107,7 +107,7 @@ impl TestService {
 		let user = db
 			.fetch_user(user_id)
 			.await
-			.map_err(|e| Status::not_found(e))?;
+			.map_err(Status::not_found)?;
 		Ok(Response::new(user))
 	}
 
@@ -121,7 +121,7 @@ impl TestService {
 		let user = db
 			.fetch_user(user_id)
 			.await
-			.map_err(|e| Status::not_found(e))?;
+			.map_err(Status::not_found)?;
 		Ok(Response::new(user))
 	}
 }

--- a/crates/reinhardt-grpc/tests/feature_flags_tests.rs
+++ b/crates/reinhardt-grpc/tests/feature_flags_tests.rs
@@ -19,8 +19,7 @@ mod di_feature_enabled {
 		// This test verifies that the code compiles when di feature is enabled
 		// Simply compiling this module is sufficient to test
 
-		// Verify that GrpcRequestExt is available
-		assert!(true, "GrpcRequestExt is available when di feature enabled");
+		// Verify that GrpcRequestExt is available (compile-test: if this builds, the feature works)
 	}
 
 	#[test]

--- a/crates/reinhardt-grpc/tests/proto_types_tests.rs
+++ b/crates/reinhardt-grpc/tests/proto_types_tests.rs
@@ -226,7 +226,7 @@ async fn test_timestamp_edge_values(#[case] seconds: i64, #[case] nanos: i32) {
 	// Additional validation for non-negative seconds
 	if seconds >= 0 {
 		assert!(
-			nanos >= 0 && nanos <= 999_999_999,
+			(0..=999_999_999).contains(&nanos),
 			"For non-negative seconds, nanos should be in [0, 999_999_999]"
 		);
 	}

--- a/crates/reinhardt-pages/macros/src/form/validator.rs
+++ b/crates/reinhardt-pages/macros/src/form/validator.rs
@@ -2409,7 +2409,7 @@ mod tests {
 		assert!(typed.initial_loader.is_some());
 		let loader = typed.initial_loader.as_ref().unwrap();
 		// Check that the path contains the expected identifier
-		assert!(loader.segments.len() > 0);
+		assert!(!loader.segments.is_empty());
 		assert_eq!(
 			loader.segments.last().unwrap().ident.to_string(),
 			"get_profile_data"

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -1077,7 +1077,7 @@ mod tests {
 	#[test]
 	fn test_server_fn_options_default() {
 		let options = ServerFnOptions::default();
-		assert_eq!(options.use_inject, false);
+		assert!(!options.use_inject);
 		assert_eq!(options.endpoint, None);
 		assert_eq!(options.codec, "json");
 	}
@@ -1097,7 +1097,7 @@ mod tests {
 			.collect();
 		let options = ServerFnOptions::from_list(&nested).unwrap();
 
-		assert_eq!(options.use_inject, false);
+		assert!(!options.use_inject);
 		assert_eq!(options.endpoint, Some("/custom".to_string()));
 		assert_eq!(options.codec, "json");
 	}
@@ -1118,7 +1118,7 @@ mod tests {
 			.collect();
 		let options = ServerFnOptions::from_list(&nested).unwrap();
 
-		assert_eq!(options.use_inject, true);
+		assert!(options.use_inject);
 		assert_eq!(options.endpoint, Some("/custom".to_string()));
 		assert_eq!(options.codec, "json");
 	}

--- a/crates/reinhardt-query/src/backend/mysql.rs
+++ b/crates/reinhardt-query/src/backend/mysql.rs
@@ -3347,6 +3347,16 @@ impl MySqlQueryBuilder {
 	}
 }
 
+impl crate::query::QueryBuilderTrait for MySqlQueryBuilder {
+	fn placeholder(&self) -> (&str, bool) {
+		("?", false)
+	}
+
+	fn quote_char(&self) -> char {
+		'`'
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -7668,15 +7678,5 @@ mod tests {
 
 		// Assert - single quotes in host must be escaped by doubling
 		assert_eq!(result, "'admin'@'host''; DROP USER root; --'");
-	}
-}
-
-impl crate::query::QueryBuilderTrait for MySqlQueryBuilder {
-	fn placeholder(&self) -> (&str, bool) {
-		("?", false)
-	}
-
-	fn quote_char(&self) -> char {
-		'`'
 	}
 }

--- a/crates/reinhardt-query/src/backend/postgres.rs
+++ b/crates/reinhardt-query/src/backend/postgres.rs
@@ -4446,6 +4446,115 @@ impl PostgresQueryBuilder {
 	}
 }
 
+/// Collect all dollar-quote delimiters present in the body text.
+///
+/// A dollar-quote delimiter in PostgreSQL has the form `$tag$` where `tag` is
+/// either empty or consists of `[a-zA-Z0-9_]` characters not starting with a
+/// digit. This function scans the body and returns the set of all such
+/// delimiters (including the surrounding `$` signs).
+///
+/// Using exact delimiter boundary detection instead of substring matching
+/// prevents false positives (e.g. `$100` is not a delimiter) and false
+/// negatives (e.g. partial overlap with candidate delimiter tags).
+fn collect_dollar_quote_delimiters(body: &str) -> std::collections::HashSet<String> {
+	let mut delimiters = std::collections::HashSet::new();
+	let bytes = body.as_bytes();
+	let len = bytes.len();
+	let mut i = 0;
+
+	while i < len {
+		if bytes[i] == b'$' {
+			// Found a '$', try to parse a dollar-quote delimiter
+			let start = i;
+			i += 1;
+
+			// Empty tag: `$$`
+			if i < len && bytes[i] == b'$' {
+				delimiters.insert("$$".to_string());
+				i += 1;
+				continue;
+			}
+
+			// Non-empty tag: tag must match [a-zA-Z_][a-zA-Z0-9_]*
+			if i < len && (bytes[i].is_ascii_alphabetic() || bytes[i] == b'_') {
+				let tag_start = i;
+				i += 1;
+				while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+					i += 1;
+				}
+				// Check for closing '$'
+				if i < len && bytes[i] == b'$' {
+					let delimiter = &body[start..=i];
+					delimiters.insert(delimiter.to_string());
+					i += 1;
+					continue;
+				}
+				// Not a valid delimiter, continue from after the initial '$'
+				i = tag_start;
+				continue;
+			}
+
+			// '$' followed by a digit or other non-tag character -- not a delimiter
+			continue;
+		}
+		i += 1;
+	}
+
+	delimiters
+}
+
+/// Generate a safe dollar-quote delimiter that does not appear in the body.
+///
+/// PostgreSQL dollar-quoting uses `$$` as the default delimiter. If the function
+/// body contains `$$`, an attacker could break out of the dollar-quoted string.
+/// This function scans for all dollar-quote delimiter patterns in the body and
+/// generates a unique delimiter that does not conflict with any of them.
+fn generate_safe_dollar_quote_delimiter(body: &str) -> String {
+	let existing = collect_dollar_quote_delimiters(body);
+
+	if !existing.contains("$$") {
+		return "$$".to_string();
+	}
+
+	// Try numbered delimiters: $body_0$, $body_1$, ...
+	for i in 0u64.. {
+		let candidate = format!("$body_{}$", i);
+		if !existing.contains(&candidate) {
+			return candidate;
+		}
+	}
+
+	// Unreachable in practice, but satisfy the compiler
+	"$$".to_string()
+}
+
+/// Determine the byte width of a UTF-8 character from its leading byte.
+///
+/// This avoids pushing individual bytes as `char` (which corrupts multi-byte
+/// UTF-8 sequences). The function assumes valid UTF-8 input, which is
+/// guaranteed because the input is a Rust `&str`.
+fn utf8_char_width(leading_byte: u8) -> usize {
+	if leading_byte < 0x80 {
+		1
+	} else if leading_byte < 0xE0 {
+		2
+	} else if leading_byte < 0xF0 {
+		3
+	} else {
+		4
+	}
+}
+
+impl crate::query::QueryBuilderTrait for PostgresQueryBuilder {
+	fn placeholder(&self) -> (&str, bool) {
+		("$", true)
+	}
+
+	fn quote_char(&self) -> char {
+		'"'
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -9783,114 +9892,5 @@ mod tests {
 			"Should NOT contain type cast syntax, got: {}",
 			sql
 		);
-	}
-}
-
-/// Collect all dollar-quote delimiters present in the body text.
-///
-/// A dollar-quote delimiter in PostgreSQL has the form `$tag$` where `tag` is
-/// either empty or consists of `[a-zA-Z0-9_]` characters not starting with a
-/// digit. This function scans the body and returns the set of all such
-/// delimiters (including the surrounding `$` signs).
-///
-/// Using exact delimiter boundary detection instead of substring matching
-/// prevents false positives (e.g. `$100` is not a delimiter) and false
-/// negatives (e.g. partial overlap with candidate delimiter tags).
-fn collect_dollar_quote_delimiters(body: &str) -> std::collections::HashSet<String> {
-	let mut delimiters = std::collections::HashSet::new();
-	let bytes = body.as_bytes();
-	let len = bytes.len();
-	let mut i = 0;
-
-	while i < len {
-		if bytes[i] == b'$' {
-			// Found a '$', try to parse a dollar-quote delimiter
-			let start = i;
-			i += 1;
-
-			// Empty tag: `$$`
-			if i < len && bytes[i] == b'$' {
-				delimiters.insert("$$".to_string());
-				i += 1;
-				continue;
-			}
-
-			// Non-empty tag: tag must match [a-zA-Z_][a-zA-Z0-9_]*
-			if i < len && (bytes[i].is_ascii_alphabetic() || bytes[i] == b'_') {
-				let tag_start = i;
-				i += 1;
-				while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
-					i += 1;
-				}
-				// Check for closing '$'
-				if i < len && bytes[i] == b'$' {
-					let delimiter = &body[start..=i];
-					delimiters.insert(delimiter.to_string());
-					i += 1;
-					continue;
-				}
-				// Not a valid delimiter, continue from after the initial '$'
-				i = tag_start;
-				continue;
-			}
-
-			// '$' followed by a digit or other non-tag character -- not a delimiter
-			continue;
-		}
-		i += 1;
-	}
-
-	delimiters
-}
-
-/// Generate a safe dollar-quote delimiter that does not appear in the body.
-///
-/// PostgreSQL dollar-quoting uses `$$` as the default delimiter. If the function
-/// body contains `$$`, an attacker could break out of the dollar-quoted string.
-/// This function scans for all dollar-quote delimiter patterns in the body and
-/// generates a unique delimiter that does not conflict with any of them.
-fn generate_safe_dollar_quote_delimiter(body: &str) -> String {
-	let existing = collect_dollar_quote_delimiters(body);
-
-	if !existing.contains("$$") {
-		return "$$".to_string();
-	}
-
-	// Try numbered delimiters: $body_0$, $body_1$, ...
-	for i in 0u64.. {
-		let candidate = format!("$body_{}$", i);
-		if !existing.contains(&candidate) {
-			return candidate;
-		}
-	}
-
-	// Unreachable in practice, but satisfy the compiler
-	"$$".to_string()
-}
-
-/// Determine the byte width of a UTF-8 character from its leading byte.
-///
-/// This avoids pushing individual bytes as `char` (which corrupts multi-byte
-/// UTF-8 sequences). The function assumes valid UTF-8 input, which is
-/// guaranteed because the input is a Rust `&str`.
-fn utf8_char_width(leading_byte: u8) -> usize {
-	if leading_byte < 0x80 {
-		1
-	} else if leading_byte < 0xE0 {
-		2
-	} else if leading_byte < 0xF0 {
-		3
-	} else {
-		4
-	}
-}
-
-impl crate::query::QueryBuilderTrait for PostgresQueryBuilder {
-	fn placeholder(&self) -> (&str, bool) {
-		("$", true)
-	}
-
-	fn quote_char(&self) -> char {
-		'"'
 	}
 }

--- a/crates/reinhardt-query/src/backend/sqlite.rs
+++ b/crates/reinhardt-query/src/backend/sqlite.rs
@@ -1944,6 +1944,16 @@ impl SqliteQueryBuilder {
 	}
 }
 
+impl crate::query::QueryBuilderTrait for SqliteQueryBuilder {
+	fn placeholder(&self) -> (&str, bool) {
+		("?", false)
+	}
+
+	fn quote_char(&self) -> char {
+		'"'
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -5396,15 +5406,5 @@ mod tests {
 		// Assert
 		assert!(sql.contains("\"orders\".\"status\""));
 		assert!(sql.contains("WHERE"));
-	}
-}
-
-impl crate::query::QueryBuilderTrait for SqliteQueryBuilder {
-	fn placeholder(&self) -> (&str, bool) {
-		("?", false)
-	}
-
-	fn quote_char(&self) -> char {
-		'"'
 	}
 }

--- a/crates/reinhardt-query/src/dcl/set_role_tests.rs
+++ b/crates/reinhardt-query/src/dcl/set_role_tests.rs
@@ -25,7 +25,7 @@ fn test_set_role_new() {
 	let stmt = SetRoleStatement::new();
 
 	// Default should be None or not set
-	assert!(stmt.target.is_none() || matches!(stmt.target, None));
+	assert!(stmt.target.is_none());
 }
 
 #[rstest]

--- a/crates/reinhardt-query/src/dcl/tests.rs
+++ b/crates/reinhardt-query/src/dcl/tests.rs
@@ -589,7 +589,7 @@ mod revoke_statement_tests {
 		let stmt = GrantRoleStatement::new();
 		assert_eq!(stmt.roles.len(), 0);
 		assert_eq!(stmt.grantees.len(), 0);
-		assert_eq!(stmt.with_admin_option, false);
+		assert!(!stmt.with_admin_option);
 		assert!(stmt.granted_by.is_none());
 	}
 
@@ -664,7 +664,7 @@ mod revoke_statement_tests {
 		let stmt = RevokeRoleStatement::new();
 		assert_eq!(stmt.roles.len(), 0);
 		assert_eq!(stmt.grantees.len(), 0);
-		assert_eq!(stmt.admin_option_for, false);
+		assert!(!stmt.admin_option_for);
 		assert!(stmt.granted_by.is_none());
 		assert!(stmt.drop_behavior.is_none());
 	}

--- a/crates/reinhardt-query/src/value/tests.rs
+++ b/crates/reinhardt-query/src/value/tests.rs
@@ -82,11 +82,11 @@ mod into_value_tests {
 
 	#[rstest]
 	fn test_float_into_value() {
-		let f32_val: Value = 3.14f32.into_value();
-		assert!(matches!(f32_val, Value::Float(Some(v)) if (v - 3.14).abs() < 0.001));
+		let f32_val: Value = 2.78f32.into_value();
+		assert!(matches!(f32_val, Value::Float(Some(v)) if (v - 2.78).abs() < 0.001));
 
-		let f64_val: Value = 3.14159f64.into_value();
-		assert!(matches!(f64_val, Value::Double(Some(v)) if (v - 3.14159).abs() < 0.00001));
+		let f64_val: Value = 2.78159f64.into_value();
+		assert!(matches!(f64_val, Value::Double(Some(v)) if (v - 2.78159).abs() < 0.00001));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-query/tests/ddl_backend_matrix.rs
+++ b/crates/reinhardt-query/tests/ddl_backend_matrix.rs
@@ -412,7 +412,7 @@ async fn test_postgres_fk_on_delete_matrix(
 			columns: vec!["parent_id".to_string().into_iden()],
 			ref_table: Box::new(parent_table.clone().into_table_ref()),
 			ref_columns: vec!["id".to_string().into_iden()],
-			on_delete: Some(action.clone()),
+			on_delete: Some(action),
 			on_update: None,
 		});
 
@@ -492,7 +492,7 @@ async fn test_postgres_fk_on_update_matrix(
 			ref_table: Box::new(parent_table.clone().into_table_ref()),
 			ref_columns: vec!["id".to_string().into_iden()],
 			on_delete: None,
-			on_update: Some(action.clone()),
+			on_update: Some(action),
 		});
 
 	let (sql, _values) = builder.build_create_table(&create_child);

--- a/crates/reinhardt-query/tests/ddl_edge_cases.rs
+++ b/crates/reinhardt-query/tests/ddl_edge_cases.rs
@@ -232,10 +232,12 @@ async fn test_postgres_reserved_keyword_as_identifier(
 	sqlx::query(&sql)
 		.execute(pool.as_ref())
 		.await
-		.unwrap_or_else(|_| panic!(
-			"Failed to create table with reserved keyword '{}' as column",
-			keyword
-		));
+		.unwrap_or_else(|_| {
+			panic!(
+				"Failed to create table with reserved keyword '{}' as column",
+				keyword
+			)
+		});
 
 	// Verify we can insert and select using the keyword column
 	sqlx::query(&format!(
@@ -375,10 +377,12 @@ async fn test_postgres_decimal_precision_boundaries(
 	sqlx::query(&sql)
 		.execute(pool.as_ref())
 		.await
-		.unwrap_or_else(|_| panic!(
-			"Failed to create table with DECIMAL({}, {})",
-			precision, scale
-		));
+		.unwrap_or_else(|_| {
+			panic!(
+				"Failed to create table with DECIMAL({}, {})",
+				precision, scale
+			)
+		});
 
 	// Cleanup
 	sqlx::query(&format!(
@@ -651,10 +655,12 @@ async fn test_mysql_reserved_keyword_as_identifier(
 	sqlx::query(&sql)
 		.execute(pool.as_ref())
 		.await
-		.unwrap_or_else(|_| panic!(
-			"Failed to create table with reserved keyword '{}' as column",
-			keyword
-		));
+		.unwrap_or_else(|_| {
+			panic!(
+				"Failed to create table with reserved keyword '{}' as column",
+				keyword
+			)
+		});
 
 	// Verify we can insert and select
 	sqlx::query(&format!(

--- a/crates/reinhardt-query/tests/ddl_edge_cases.rs
+++ b/crates/reinhardt-query/tests/ddl_edge_cases.rs
@@ -232,7 +232,7 @@ async fn test_postgres_reserved_keyword_as_identifier(
 	sqlx::query(&sql)
 		.execute(pool.as_ref())
 		.await
-		.expect(&format!(
+		.unwrap_or_else(|_| panic!(
 			"Failed to create table with reserved keyword '{}' as column",
 			keyword
 		));
@@ -304,7 +304,7 @@ async fn test_postgres_varchar_length_boundaries(
 	sqlx::query(&sql)
 		.execute(pool.as_ref())
 		.await
-		.expect(&format!("Failed to create table with VARCHAR({})", length));
+		.unwrap_or_else(|_| panic!("Failed to create table with VARCHAR({})", length));
 
 	// Insert data of maximum allowed length
 	let test_data = "x".repeat(length as usize);
@@ -375,7 +375,7 @@ async fn test_postgres_decimal_precision_boundaries(
 	sqlx::query(&sql)
 		.execute(pool.as_ref())
 		.await
-		.expect(&format!(
+		.unwrap_or_else(|_| panic!(
 			"Failed to create table with DECIMAL({}, {})",
 			precision, scale
 		));
@@ -651,7 +651,7 @@ async fn test_mysql_reserved_keyword_as_identifier(
 	sqlx::query(&sql)
 		.execute(pool.as_ref())
 		.await
-		.expect(&format!(
+		.unwrap_or_else(|_| panic!(
 			"Failed to create table with reserved keyword '{}' as column",
 			keyword
 		));
@@ -708,7 +708,7 @@ async fn test_mysql_varchar_length_boundaries(
 	sqlx::query(&sql)
 		.execute(pool.as_ref())
 		.await
-		.expect(&format!("Failed to create table with VARCHAR({})", length));
+		.unwrap_or_else(|_| panic!("Failed to create table with VARCHAR({})", length));
 
 	// Cleanup
 	sqlx::query(&format!(

--- a/crates/reinhardt-query/tests/ddl_indexes.rs
+++ b/crates/reinhardt-query/tests/ddl_indexes.rs
@@ -853,10 +853,12 @@ async fn test_postgres_index_combinations(
 	sqlx::query(&sql)
 		.execute(pool.as_ref())
 		.await
-		.unwrap_or_else(|_| panic!(
-			"Failed to create index with unique={}, columns={}",
-			is_unique, column_count
-		));
+		.unwrap_or_else(|_| {
+			panic!(
+				"Failed to create index with unique={}, columns={}",
+				is_unique, column_count
+			)
+		});
 
 	// Verify index properties
 	let index_info: (bool, i64) = sqlx::query_as(

--- a/crates/reinhardt-query/tests/ddl_indexes.rs
+++ b/crates/reinhardt-query/tests/ddl_indexes.rs
@@ -853,7 +853,7 @@ async fn test_postgres_index_combinations(
 	sqlx::query(&sql)
 		.execute(pool.as_ref())
 		.await
-		.expect(&format!(
+		.unwrap_or_else(|_| panic!(
 			"Failed to create index with unique={}, columns={}",
 			is_unique, column_count
 		));

--- a/crates/reinhardt-query/tests/ddl_tables.rs
+++ b/crates/reinhardt-query/tests/ddl_tables.rs
@@ -975,7 +975,7 @@ async fn test_postgres_integer_type_variants(
 		sqlx::query(&sql)
 			.execute(pool.as_ref())
 			.await
-			.expect(&format!(
+			.unwrap_or_else(|_| panic!(
 				"Failed to create table with integer type variant {}",
 				idx
 			));

--- a/crates/reinhardt-query/tests/ddl_tables.rs
+++ b/crates/reinhardt-query/tests/ddl_tables.rs
@@ -975,10 +975,7 @@ async fn test_postgres_integer_type_variants(
 		sqlx::query(&sql)
 			.execute(pool.as_ref())
 			.await
-			.unwrap_or_else(|_| panic!(
-				"Failed to create table with integer type variant {}",
-				idx
-			));
+			.unwrap_or_else(|_| panic!("Failed to create table with integer type variant {}", idx));
 
 		// Cleanup
 		sqlx::query(&format!(

--- a/crates/reinhardt-query/tests/ddl_triggers.rs
+++ b/crates/reinhardt-query/tests/ddl_triggers.rs
@@ -569,7 +569,7 @@ async fn test_mysql_create_trigger_before_insert(
 	let (sql, _values) = builder.build_create_trigger(&stmt);
 	// MySQL CREATE TRIGGER cannot use prepared statement protocol
 	// Execute the generated SQL directly via format! to bypass prepared statement limitations
-	sqlx::query(&format!("{}", sql))
+	sqlx::query(&sql.to_string())
 		.execute(pool.as_ref())
 		.await
 		.expect("Failed to create trigger");
@@ -651,7 +651,7 @@ async fn test_mysql_drop_trigger(
 	let (sql, _values) = builder.build_drop_trigger(&stmt);
 	// MySQL DROP TRIGGER cannot use prepared statement protocol
 	// Execute the generated SQL directly via format! to bypass prepared statement limitations
-	sqlx::query(&format!("{}", sql))
+	sqlx::query(&sql.to_string())
 		.execute(pool.as_ref())
 		.await
 		.expect("Failed to drop trigger");

--- a/crates/reinhardt-query/tests/ddl_triggers.rs
+++ b/crates/reinhardt-query/tests/ddl_triggers.rs
@@ -569,7 +569,7 @@ async fn test_mysql_create_trigger_before_insert(
 	let (sql, _values) = builder.build_create_trigger(&stmt);
 	// MySQL CREATE TRIGGER cannot use prepared statement protocol
 	// Execute the generated SQL directly via format! to bypass prepared statement limitations
-	sqlx::query(&sql.to_string())
+	sqlx::query(sql.as_str())
 		.execute(pool.as_ref())
 		.await
 		.expect("Failed to create trigger");
@@ -651,7 +651,7 @@ async fn test_mysql_drop_trigger(
 	let (sql, _values) = builder.build_drop_trigger(&stmt);
 	// MySQL DROP TRIGGER cannot use prepared statement protocol
 	// Execute the generated SQL directly via format! to bypass prepared statement limitations
-	sqlx::query(&sql.to_string())
+	sqlx::query(sql.as_str())
 		.execute(pool.as_ref())
 		.await
 		.expect("Failed to drop trigger");

--- a/crates/reinhardt-throttling/src/burst.rs
+++ b/crates/reinhardt-throttling/src/burst.rs
@@ -145,9 +145,9 @@ mod tests {
 		let third = throttle.allow_request("user1").await.unwrap();
 
 		// Assert - burst limit blocks the third request
-		assert_eq!(first, true);
-		assert_eq!(second, true);
-		assert_eq!(third, false);
+		assert!(first);
+		assert!(second);
+		assert!(!third);
 
 		// Assert - verify backend stores with prefixed keys, not raw key
 		let b = backend.lock().await;

--- a/crates/reinhardt-utils/src/staticfiles/dev_server/error_pages.rs
+++ b/crates/reinhardt-utils/src/staticfiles/dev_server/error_pages.rs
@@ -573,7 +573,7 @@ mod tests {
 		// Arrange
 		let handler = DevelopmentErrorHandler::new().with_stack_trace(false);
 		let xss_payload = "<script>alert('xss')</script>";
-		let error = io::Error::new(io::ErrorKind::Other, xss_payload);
+		let error = io::Error::other(xss_payload);
 
 		// Act
 		let html = handler.format_error(&error);
@@ -602,7 +602,7 @@ mod tests {
 		// Arrange
 		let handler = DevelopmentErrorHandler::new().with_stack_trace(false);
 		let xss_payload = "<img src=x onerror=alert(1)>";
-		let source = io::Error::new(io::ErrorKind::Other, xss_payload);
+		let source = io::Error::other(xss_payload);
 		let error = DevServerError::with_source("outer error", source);
 
 		// Act

--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -1101,7 +1101,7 @@ mod tests {
 		// Arrange
 		let dir = tempfile::tempdir().unwrap();
 		std::fs::write(dir.path().join("my_app.js"), "// js").unwrap();
-		std::fs::write(dir.path().join("my_app_bg.wasm"), &[0u8; 4]).unwrap();
+		std::fs::write(dir.path().join("my_app_bg.wasm"), [0u8; 4]).unwrap();
 		let config = StaticFilesConfig::new(dir.path());
 
 		// Act
@@ -1133,9 +1133,9 @@ mod tests {
 		// Arrange
 		let dir = tempfile::tempdir().unwrap();
 		std::fs::write(dir.path().join("app_a.js"), "// js a").unwrap();
-		std::fs::write(dir.path().join("app_a_bg.wasm"), &[0u8; 4]).unwrap();
+		std::fs::write(dir.path().join("app_a_bg.wasm"), [0u8; 4]).unwrap();
 		std::fs::write(dir.path().join("app_b.js"), "// js b").unwrap();
-		std::fs::write(dir.path().join("app_b_bg.wasm"), &[0u8; 4]).unwrap();
+		std::fs::write(dir.path().join("app_b_bg.wasm"), [0u8; 4]).unwrap();
 		let config = StaticFilesConfig::new(dir.path()).wasm_entry("app_a.js");
 
 		// Act
@@ -1167,7 +1167,7 @@ mod tests {
 		// Arrange
 		let dir = tempfile::tempdir().unwrap();
 		std::fs::write(dir.path().join("my_app.js"), "// js").unwrap();
-		std::fs::write(dir.path().join("my_app_bg.wasm"), &[0u8; 4]).unwrap();
+		std::fs::write(dir.path().join("my_app_bg.wasm"), [0u8; 4]).unwrap();
 		let config = StaticFilesConfig::new(dir.path()).auto_inject_wasm(false);
 
 		// Act
@@ -1325,7 +1325,7 @@ mod tests {
 		let sub = dir.path().join("pkg");
 		std::fs::create_dir_all(&sub).unwrap();
 		std::fs::write(sub.join("my_app.js"), "// js").unwrap();
-		std::fs::write(sub.join("my_app_bg.wasm"), &[0u8; 4]).unwrap();
+		std::fs::write(sub.join("my_app_bg.wasm"), [0u8; 4]).unwrap();
 		let config = StaticFilesConfig::new(dir.path()).wasm_entry("pkg/my_app.js");
 
 		// Act
@@ -1375,7 +1375,7 @@ mod tests {
 		)
 		.unwrap();
 		std::fs::write(dir.path().join("my_app.js"), "// js").unwrap();
-		std::fs::write(dir.path().join("my_app_bg.wasm"), &[0u8; 4]).unwrap();
+		std::fs::write(dir.path().join("my_app_bg.wasm"), [0u8; 4]).unwrap();
 
 		let config = StaticFilesConfig::new(dir.path());
 		let middleware = StaticFilesMiddleware::new(config);
@@ -1403,7 +1403,7 @@ mod tests {
 		)
 		.unwrap();
 		std::fs::write(dir.path().join("my_app.js"), "// js").unwrap();
-		std::fs::write(dir.path().join("my_app_bg.wasm"), &[0u8; 4]).unwrap();
+		std::fs::write(dir.path().join("my_app_bg.wasm"), [0u8; 4]).unwrap();
 
 		let config = StaticFilesConfig::new(dir.path()).auto_inject_wasm(false);
 		let middleware = StaticFilesMiddleware::new(config);
@@ -1425,7 +1425,7 @@ mod tests {
 		let dir = tempfile::tempdir().unwrap();
 		std::fs::write(dir.path().join("index.html"), "<html><body></body></html>").unwrap();
 		std::fs::write(dir.path().join("my_app.js"), "// js").unwrap();
-		std::fs::write(dir.path().join("my_app_bg.wasm"), &[0u8; 4]).unwrap();
+		std::fs::write(dir.path().join("my_app_bg.wasm"), [0u8; 4]).unwrap();
 
 		let config_with = StaticFilesConfig::new(dir.path());
 		let mw_with = StaticFilesMiddleware::new(config_with);
@@ -1470,7 +1470,7 @@ mod tests {
 		let invalid_bytes: Vec<u8> = vec![0xFF, 0xFE, 0x00, 0x3C, 0x68, 0x74, 0x6D, 0x6C];
 		std::fs::write(dir.path().join("index.html"), &invalid_bytes).unwrap();
 		std::fs::write(dir.path().join("my_app.js"), "// js").unwrap();
-		std::fs::write(dir.path().join("my_app_bg.wasm"), &[0u8; 4]).unwrap();
+		std::fs::write(dir.path().join("my_app_bg.wasm"), [0u8; 4]).unwrap();
 
 		let config = StaticFilesConfig::new(dir.path());
 		let middleware = StaticFilesMiddleware::new(config);
@@ -1490,7 +1490,7 @@ mod tests {
 		let dir = tempfile::tempdir().unwrap();
 		std::fs::write(dir.path().join("index.html"), "<html><body></body></html>").unwrap();
 		std::fs::write(dir.path().join("my_app.js"), "// js").unwrap();
-		std::fs::write(dir.path().join("my_app_bg.wasm"), &[0u8; 4]).unwrap();
+		std::fs::write(dir.path().join("my_app_bg.wasm"), [0u8; 4]).unwrap();
 
 		let config = StaticFilesConfig::new(dir.path());
 		let middleware = StaticFilesMiddleware::new(config);


### PR DESCRIPTION
## Summary

- Fix rustfmt formatting violations in 4 files detected by CI Format Check
- Resolve clippy warnings across 8 crates (reinhardt-query, reinhardt-core, reinhardt-di, reinhardt-grpc, reinhardt-pages-macros, reinhardt-throttling, reinhardt-utils, reinhardt-query backends)
- Fix deny-level `approx_constant` errors in test code
- Move `impl` blocks and functions before `#[cfg(test)] mod tests` to resolve `items_after_test_module` warnings

## Type of Change

- [x] Code quality improvements

## Motivation and Context

PR #3480 (release-plz rc.15 → rc.16) has CI failures including Format Check. Additionally, local `cargo clippy` with Rust 1.94.0 detects numerous warnings and deny-level errors that should be resolved before the release.

Related to: #3480

## How Was This Tested?

- `cargo make fmt-check` — 0 would be formatted (all clean)
- `cargo make clippy-check` — passes without warnings
- `cargo check --workspace --all-features` — compiles successfully

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `code-quality` - Code quality improvements

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [x] `auth` - Authentication, authorization, sessions

---

**Additional Context:**

Changes are purely mechanical (formatting, assertion style, lint compliance) with no behavioral modifications. The `items_after_test_module` fixes in backend files move code blocks without changing any logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)