### PR TITLE
fix(macros): use module-scoped inner allow to suppress unexpected_cfgs in consuming crates

### DIFF
--- a/crates/reinhardt-core/macros/src/installed_apps.rs
+++ b/crates/reinhardt-core/macros/src/installed_apps.rs
@@ -649,14 +649,18 @@ pub(crate) fn installed_apps_impl(input: TokenStream) -> Result<TokenStream> {
 		///
 		/// Namespaced with `__reinhardt_` prefix to reduce collision risk
 		/// in the consuming crate's root macro namespace.
-		#[allow(unexpected_cfgs)]
-		#[cfg(feature = "url-resolver")]
 		#[doc(hidden)]
-		#[macro_export]
-		macro_rules! __reinhardt_for_each_app {
-			($callback:ident) => {
-				$callback!(#(#labels),*);
-			};
+		mod __for_each_app_cfg {
+			#![allow(unexpected_cfgs)]
+
+			#[cfg(feature = "url-resolver")]
+			#[doc(hidden)]
+			#[macro_export]
+			macro_rules! __reinhardt_for_each_app {
+				($callback:ident) => {
+					$callback!(#(#labels),*);
+				};
+			}
 		}
 	})
 }

--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -806,25 +806,23 @@ fn generate_url_resolver_tokens(
 	// because it depends on `ServerRouter` which is `native`-only.
 	if params.is_empty() {
 		quote! {
-			#[allow(unexpected_cfgs)]
-			#[cfg(feature = "url-resolver")]
-			#[doc = #doc_str]
-			pub trait #trait_ident: #reinhardt_crate::UrlResolver {
-				#[doc = #doc_str]
-				fn #method_ident(&self) -> String {
-					self.resolve_url(#name, &[])
-				}
-			}
-			#[allow(unexpected_cfgs)]
-			#[cfg(feature = "url-resolver")]
-			impl<T: #reinhardt_crate::UrlResolver> #trait_ident for T {}
-
-			#[allow(unexpected_cfgs)]
-			#[cfg(feature = "url-resolver")]
 			#[doc(hidden)]
 			pub mod #resolver_mod_ident {
-				pub use super::#trait_ident;
+				#![allow(unexpected_cfgs)]
+
+				#[cfg(feature = "url-resolver")]
+				#[doc = #doc_str]
+				pub trait #trait_ident: #reinhardt_crate::UrlResolver {
+					#[doc = #doc_str]
+					fn #method_ident(&self) -> String {
+						self.resolve_url(#name, &[])
+					}
+				}
+				#[cfg(feature = "url-resolver")]
+				impl<T: #reinhardt_crate::UrlResolver> #trait_ident for T {}
 			}
+			#[doc(hidden)]
+			pub use #resolver_mod_ident::*;
 		}
 	} else {
 		let param_idents: Vec<syn::Ident> = params
@@ -834,25 +832,23 @@ fn generate_url_resolver_tokens(
 		let param_strs: Vec<&str> = params.iter().map(|s| s.as_str()).collect();
 
 		quote! {
-			#[allow(unexpected_cfgs)]
-			#[cfg(feature = "url-resolver")]
-			#[doc = #doc_str]
-			pub trait #trait_ident: #reinhardt_crate::UrlResolver {
-				#[doc = #doc_str]
-				fn #method_ident(&self, #(#param_idents: &str),*) -> String {
-					self.resolve_url(#name, &[#((#param_strs, #param_idents)),*])
-				}
-			}
-			#[allow(unexpected_cfgs)]
-			#[cfg(feature = "url-resolver")]
-			impl<T: #reinhardt_crate::UrlResolver> #trait_ident for T {}
-
-			#[allow(unexpected_cfgs)]
-			#[cfg(feature = "url-resolver")]
 			#[doc(hidden)]
 			pub mod #resolver_mod_ident {
-				pub use super::#trait_ident;
+				#![allow(unexpected_cfgs)]
+
+				#[cfg(feature = "url-resolver")]
+				#[doc = #doc_str]
+				pub trait #trait_ident: #reinhardt_crate::UrlResolver {
+					#[doc = #doc_str]
+					fn #method_ident(&self, #(#param_idents: &str),*) -> String {
+						self.resolve_url(#name, &[#((#param_strs, #param_idents)),*])
+					}
+				}
+				#[cfg(feature = "url-resolver")]
+				impl<T: #reinhardt_crate::UrlResolver> #trait_ident for T {}
 			}
+			#[doc(hidden)]
+			pub use #resolver_mod_ident::*;
 		}
 	}
 }

--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -347,64 +347,67 @@ pub(crate) fn routes_impl(_args: TokenStream, input: ItemFn) -> Result<TokenStre
 	// Generate ResolvedUrls struct + url_prelude module (url-resolver feature)
 	// Gate on both `native` and `url-resolver` to stay consistent with the
 	// underlying types (`ServerRouter`, `UrlResolver`) which are `native`-only.
+	// Wrapped in a module with inner `#![allow(unexpected_cfgs)]` so that
+	// consuming crates do not see check-cfg warnings for `url-resolver`/`native`.
 	let url_resolver_code = quote! {
-		/// Type-safe URL resolver backed by the global `ServerRouter`.
-		///
-		/// Provides URL resolution methods via extension traits generated
-		/// by view macros. Import `url_prelude::*` to bring all resolver
-		/// methods into scope.
-		#[allow(unexpected_cfgs)]
-		#[cfg(all(native, feature = "url-resolver"))]
-		pub struct ResolvedUrls {
-			router: ::std::sync::Arc<#reinhardt::ServerRouter>,
-		}
-
-		#[allow(unexpected_cfgs)]
-		#[cfg(all(native, feature = "url-resolver"))]
-		impl #reinhardt::UrlResolver for ResolvedUrls {
-			fn resolve_url(&self, name: &str, params: &[(&str, &str)]) -> String {
-				self.router
-					.reverse(name, params)
-					.unwrap_or_else(|| panic!("Route '{}' not found in router", name))
-			}
-		}
-
-		#[allow(unexpected_cfgs)]
-		#[cfg(all(native, feature = "url-resolver"))]
-		impl ResolvedUrls {
-			/// Create a `ResolvedUrls` from the globally registered router.
-			///
-			/// # Panics
-			///
-			/// Panics if no global router has been registered via `#[routes]`.
-			pub fn from_global() -> Self {
-				let router = #reinhardt::get_router()
-					.expect("Global router not registered. Ensure the #[routes] function has been called.");
-				Self { router }
-			}
-
-			/// Create a `ResolvedUrls` from an explicit `ServerRouter`.
-			pub fn from_router(router: ::std::sync::Arc<#reinhardt::ServerRouter>) -> Self {
-				Self { router }
-			}
-		}
-
-		#[allow(unexpected_cfgs)]
-		#[cfg(all(native, feature = "url-resolver"))]
 		#[doc(hidden)]
-		macro_rules! __build_url_prelude {
-			($($app:ident),*) => {
-				/// Prelude module re-exporting all URL resolver traits and `ResolvedUrls`.
-				pub mod url_prelude {
-					pub use super::ResolvedUrls;
-					$(pub use crate::apps::$app::urls::url_resolvers::*;)*
-				}
-			};
-		}
+		pub mod __url_resolver_support {
+			#![allow(unexpected_cfgs)]
 
-		#[allow(unexpected_cfgs)]
-		#[cfg(all(native, feature = "url-resolver"))]
-		crate::__reinhardt_for_each_app!(__build_url_prelude);
+			/// Type-safe URL resolver backed by the global `ServerRouter`.
+			///
+			/// Provides URL resolution methods via extension traits generated
+			/// by view macros. Import `url_prelude::*` to bring all resolver
+			/// methods into scope.
+			#[cfg(all(native, feature = "url-resolver"))]
+			pub struct ResolvedUrls {
+				router: ::std::sync::Arc<#reinhardt::ServerRouter>,
+			}
+
+			#[cfg(all(native, feature = "url-resolver"))]
+			impl #reinhardt::UrlResolver for ResolvedUrls {
+				fn resolve_url(&self, name: &str, params: &[(&str, &str)]) -> String {
+					self.router
+						.reverse(name, params)
+						.unwrap_or_else(|| panic!("Route '{}' not found in router", name))
+				}
+			}
+
+			#[cfg(all(native, feature = "url-resolver"))]
+			impl ResolvedUrls {
+				/// Create a `ResolvedUrls` from the globally registered router.
+				///
+				/// # Panics
+				///
+				/// Panics if no global router has been registered via `#[routes]`.
+				pub fn from_global() -> Self {
+					let router = #reinhardt::get_router()
+						.expect("Global router not registered. Ensure the #[routes] function has been called.");
+					Self { router }
+				}
+
+				/// Create a `ResolvedUrls` from an explicit `ServerRouter`.
+				pub fn from_router(router: ::std::sync::Arc<#reinhardt::ServerRouter>) -> Self {
+					Self { router }
+				}
+			}
+
+			#[cfg(all(native, feature = "url-resolver"))]
+			#[doc(hidden)]
+			macro_rules! __build_url_prelude {
+				($($app:ident),*) => {
+					/// Prelude module re-exporting all URL resolver traits and `ResolvedUrls`.
+					pub mod url_prelude {
+						pub use super::ResolvedUrls;
+						$(pub use crate::apps::$app::urls::url_resolvers::*;)*
+					}
+				};
+			}
+
+			#[cfg(all(native, feature = "url-resolver"))]
+			crate::__reinhardt_for_each_app!(__build_url_prelude);
+		}
+		pub use __url_resolver_support::*;
 	};
 
 	let combined = quote! {

--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -95,11 +95,14 @@ pub(crate) fn url_patterns_impl(
 	Ok(quote! {
 		#func
 
-		#[allow(unexpected_cfgs)]
-		#[cfg(feature = "url-resolver")]
 		#[doc(hidden)]
 		pub mod url_resolvers {
-			#(#re_exports)*
+			#![allow(unexpected_cfgs)]
+
+			#(
+				#[cfg(feature = "url-resolver")]
+				#re_exports
+			)*
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Replace per-item `#[allow(unexpected_cfgs)]` outer attributes with module-scoped `#![allow(unexpected_cfgs)]` inner attributes in all macro-generated url-resolver code
- Fixes standalone `#[get]`, `#[post]`, `#[put]`, `#[delete]`, `#[patch]` macros, as well as `#[routes]`, `installed_apps!`, and `#[url_patterns]` expansions

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

PR #3483 added `#[allow(unexpected_cfgs)]` as outer attributes to suppress `unexpected_cfgs` warnings in macro-generated url-resolver code. However, in Rust nightly 1.94 (with check-cfg enabled by default), outer `#[allow(unexpected_cfgs)]` attributes do not reliably suppress the lint because the check fires during cfg evaluation before the allow is processed.

This caused 19 warnings per consuming crate when using standalone HTTP method macros (`#[post]`, `#[get]`, etc.) outside `#[routes]` blocks.

The fix wraps all `cfg(feature = "url-resolver")` / `cfg(native)` generated code inside modules with `#![allow(unexpected_cfgs)]` inner attributes, which are processed when the module is entered — before any items are evaluated.

Fixes #3496

Related to: #3478, #3483

## How Was This Tested?

- `cargo make auto-fix` passes with 0 errors and 0 formatting changes
- Verified all four affected macro files produce correct module-wrapping output

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- #3478 — Original issue (closed, partially fixed)
- #3483 — Partial fix (`#[routes]` and `installed_apps!` only, outer attribute approach)
- #3486 — Related fix approach (module wrapping)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `routing` - URL routing, path matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)