### PR TITLE
fix(macros): suppress private_interfaces warning in #[routes] macro output

### DIFF
--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -170,6 +170,10 @@ pub(crate) fn routes_impl(_args: TokenStream, input: ItemFn) -> Result<TokenStre
 		// Case 1: Sync, no #[inject] — existing behavior unchanged
 		let fn_sig = &input.sig;
 		quote! {
+			// private_interfaces: The macro forces `pub` visibility, but users
+			// legitimately use `pub(crate)` newtype wrappers for DI parameters
+			// (see #3498, #3468 DI pseudo orphan rule).
+			#[allow(private_interfaces)]
 			#(#fn_attrs)*
 			#fn_vis #fn_sig #fn_block
 
@@ -201,6 +205,7 @@ pub(crate) fn routes_impl(_args: TokenStream, input: ItemFn) -> Result<TokenStre
 		// Case 2: Async, no #[inject]
 		let fn_sig = &input.sig;
 		quote! {
+			#[allow(private_interfaces)]
 			#(#fn_attrs)*
 			#fn_vis #fn_sig #fn_block
 
@@ -300,6 +305,7 @@ pub(crate) fn routes_impl(_args: TokenStream, input: ItemFn) -> Result<TokenStre
 			.collect();
 
 		quote! {
+			#[allow(private_interfaces)]
 			#(#fn_attrs)*
 			#fn_vis async fn #fn_name #fn_generics(#(#stripped_params),*) #fn_return #fn_block
 


### PR DESCRIPTION
## Summary

- Emit `#[allow(private_interfaces)]` on functions generated by the `#[routes]` macro

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `#[routes]` macro forces `pub` visibility on the decorated function, but after the DI pseudo orphan rule (#3468), users must wrap `UnifiedRouter` in a `pub(crate)` newtype (e.g., `DashboardRouter`). This creates a `private_interfaces` warning because a `pub` function exposes a `pub(crate)` type in its signature.

Fixes #3498

Related to: #3468, #3465, kent8192/reinhardt-cloud#329

## How Was This Tested?

- `cargo check -p reinhardt-macros --all-features` — compiles cleanly
- `cargo test -p reinhardt-macros --test ui test_routes_registration_macro_fail` — existing fail tests pass
- `cargo check --workspace --all-features` — full workspace compiles cleanly

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #3498 — `private_interfaces` warning from `#[routes]` macro
- #3468 — DI pseudo orphan rule (introduced the newtype pattern)
- #3465 — API Change Proposal
- kent8192/reinhardt-cloud#329 — downstream fix applying the newtype pattern

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `routing` - URL routing, path matching

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)