### PR TITLE
feat(commands): reject reinhardt_ prefixed project and app names

### DIFF
--- a/crates/reinhardt-commands/src/start_commands.rs
+++ b/crates/reinhardt-commands/src/start_commands.rs
@@ -14,6 +14,25 @@ use async_trait::async_trait;
 use std::env;
 use std::path::{Path, PathBuf};
 
+/// Validate that a name does not use the reserved `reinhardt_*` namespace.
+///
+/// Names starting with `reinhardt_` or `reinhardt-` conflict with the DI
+/// pseudo orphan rule (#3468, #3502) which treats `reinhardt_*::*` as
+/// framework-managed types.
+fn validate_not_reserved_namespace(name: &str) -> CommandResult<()> {
+	let normalized = name.replace('-', "_");
+	if normalized.starts_with("reinhardt_") || normalized == "reinhardt" {
+		return Err(CommandError::InvalidArguments(format!(
+			"Name '{}' is not allowed: names starting with 'reinhardt_' or 'reinhardt-' \
+			 are reserved for the Reinhardt framework. This conflicts with the DI pseudo \
+			 orphan rule which treats 'reinhardt_*' namespaces as framework-managed. \
+			 Please choose a different name.",
+			name
+		)));
+	}
+	Ok(())
+}
+
 /// Create a Reinhardt project directory structure
 ///
 /// Translation of Django's startproject command
@@ -61,6 +80,9 @@ impl BaseCommand for StartProjectCommand {
 				CommandError::InvalidArguments("You must provide a project name.".to_string())
 			})?
 			.clone();
+
+		// Reject reserved reinhardt_* namespace (#3502)
+		validate_not_reserved_namespace(&project_name)?;
 
 		let target = ctx.arg(1).map(PathBuf::from);
 
@@ -197,6 +219,9 @@ impl BaseCommand for StartAppCommand {
 				CommandError::InvalidArguments("You must provide an application name.".to_string())
 			})?
 			.clone();
+
+		// Reject reserved reinhardt_* namespace (#3502)
+		validate_not_reserved_namespace(&app_name)?;
 
 		let target = ctx.arg(1).map(PathBuf::from);
 
@@ -779,5 +804,32 @@ mod tests {
 			options.iter().any(|opt| opt.long == "with-pages"),
 			"--with-pages flag should exist in StartAppCommand for mtv type mapping"
 		);
+	}
+
+	#[rstest]
+	#[case("reinhardt_myapp")]
+	#[case("reinhardt-myapp")]
+	#[case("reinhardt_")]
+	#[case("reinhardt-")]
+	#[case("reinhardt")]
+	fn test_reserved_namespace_rejected(#[case] name: &str) {
+		// Act
+		let result = validate_not_reserved_namespace(name);
+
+		// Assert
+		assert!(result.is_err(), "should reject '{}'", name);
+	}
+
+	#[rstest]
+	#[case("myapp")]
+	#[case("my_reinhardt_app")]
+	#[case("cool_project")]
+	#[case("reinhard")]
+	fn test_non_reserved_namespace_accepted(#[case] name: &str) {
+		// Act
+		let result = validate_not_reserved_namespace(name);
+
+		// Assert
+		assert!(result.is_ok(), "should accept '{}'", name);
 	}
 }

--- a/crates/reinhardt-commands/tests/admin_scripts_tests.rs
+++ b/crates/reinhardt-commands/tests/admin_scripts_tests.rs
@@ -1187,4 +1187,40 @@ async fn test_djangoadmin_defaultsettings_custom_command_with_environment() {
 	// env_guard automatically cleans up on drop
 }
 
+// ===== Reserved namespace validation (#3502) =====
+
+#[serial]
+#[tokio::test]
+async fn test_startproject_rejects_reinhardt_prefix() {
+	let env = TestEnvironment::new();
+	std::env::set_current_dir(env.path()).expect("Failed to change directory");
+
+	for name in ["reinhardt_myapp", "reinhardt-myapp"] {
+		// Act
+		let ctx = CommandContext::new(vec![name.to_string()]);
+		let cmd = StartProjectCommand;
+		let result = cmd.execute(&ctx).await;
+
+		// Assert
+		assert!(result.is_err(), "startproject should reject '{}'", name);
+	}
+}
+
+#[serial]
+#[tokio::test]
+async fn test_startapp_rejects_reinhardt_prefix() {
+	let env = TestEnvironment::new();
+	std::env::set_current_dir(env.path()).expect("Failed to change directory");
+
+	for name in ["reinhardt_myapp", "reinhardt-myapp"] {
+		// Act
+		let ctx = CommandContext::new(vec![name.to_string()]);
+		let cmd = StartAppCommand;
+		let result = cmd.execute(&ctx).await;
+
+		// Assert
+		assert!(result.is_err(), "startapp should reject '{}'", name);
+	}
+}
+
 // See docs/IMPLEMENTATION_NOTES.md for complete test coverage index


### PR DESCRIPTION
## Summary

- Add validation to `startproject` and `startapp` commands that rejects names starting with `reinhardt_` or `reinhardt-`
- These names conflict with the DI pseudo orphan rule which reserves the `reinhardt_*::*` namespace for framework-managed types

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

The DI pseudo orphan rule (#3468) states that users cannot register injectables for types in the `reinhardt_*::*` namespace. If a user creates a project named `reinhardt_myapp`, Cargo normalizes hyphens to underscores, placing all types under `reinhardt_myapp::*` — which overlaps with the reserved namespace. This leads to confusing DI registration rejections for user-defined types.

Fixes #3502

Related to: #3468

## How Was This Tested?

- Unit tests: 9 parametrized `rstest` cases (5 rejection + 4 acceptance) in `start_commands::tests`
- Integration tests: 2 async tests in `admin_scripts_tests.rs` covering both `startproject` and `startapp`
- `cargo check -p reinhardt-commands --all-features` — compiles cleanly

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #3502 — Feature: reject reinhardt_ prefixed project names
- #3468 — DI pseudo orphan rule

## Labels to Apply

### Type Label
- [x] `enhancement` - New feature or improvement

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)