### PR TITLE
feat(testkit): add with_test_di_context() for isolated parallel-safe test DI contexts

### DIFF
--- a/crates/reinhardt-testkit/src/fixtures.rs
+++ b/crates/reinhardt-testkit/src/fixtures.rs
@@ -173,7 +173,7 @@ pub use migrations::{
 // From di module
 pub use di::{
 	injection_context, injection_context_with_database, injection_context_with_overrides,
-	injection_context_with_sqlite, singleton_scope,
+	injection_context_with_sqlite, singleton_scope, with_test_di_context,
 };
 
 // From schema module (conditional on feature)

--- a/crates/reinhardt-testkit/src/fixtures/di.rs
+++ b/crates/reinhardt-testkit/src/fixtures/di.rs
@@ -99,7 +99,9 @@
 //! ```
 
 use reinhardt_di::{InjectionContext, SingletonScope};
+use reinhardt_di::resolve_context::{RESOLVE_CTX, ResolveContext};
 use rstest::*;
+use std::future::Future;
 use std::sync::Arc;
 
 /// Fixture providing a singleton scope for dependency injection.
@@ -445,6 +447,64 @@ pub async fn injection_context_with_database(database_url: &str) -> InjectionCon
 	InjectionContext::builder(singleton_scope).build()
 }
 
+/// Runs an async test body with an isolated DI context.
+///
+/// Creates a fresh [`SingletonScope`] and [`InjectionContext`] for each call,
+/// sets the task-local `RESOLVE_CTX` so that
+/// [`get_di_context`](reinhardt_di::resolve_context::get_di_context) works
+/// both in factory execution and in the test body, and returns the
+/// closure's result.
+///
+/// # Parallel Safety
+///
+/// Each invocation creates its own `SingletonScope` and `InjectionContext`.
+/// The `RESOLVE_CTX` is task-local (`tokio::task_local!`), so parallel
+/// test tasks do not interfere with each other.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use reinhardt_testkit::fixtures::with_test_di_context;
+/// use reinhardt_di::resolve_context::{get_di_context, ContextLevel};
+/// use rstest::*;
+/// use std::sync::Arc;
+///
+/// #[rstest]
+/// #[tokio::test]
+/// async fn test_with_di_context() {
+///     let result = with_test_di_context(
+///         |scope| {
+///             scope.set("test_value".to_string());
+///         },
+///         |di_ctx| async move {
+///             // get_di_context works here
+///             let root = get_di_context(ContextLevel::Root);
+///             assert!(Arc::ptr_eq(&root, &di_ctx));
+///             42
+///         },
+///     ).await;
+///
+///     assert_eq!(result, 42);
+/// }
+/// ```
+pub async fn with_test_di_context<F, Fut, T>(
+	setup: impl FnOnce(&SingletonScope),
+	f: F,
+) -> T
+where
+	F: FnOnce(Arc<InjectionContext>) -> Fut,
+	Fut: Future<Output = T>,
+{
+	let scope = Arc::new(SingletonScope::new());
+	setup(&scope);
+	let ctx = Arc::new(InjectionContext::builder(scope).build());
+	let resolve_ctx = ResolveContext {
+		root: Arc::clone(&ctx),
+		current: Arc::clone(&ctx),
+	};
+	RESOLVE_CTX.scope(resolve_ctx, f(ctx)).await
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -676,5 +736,101 @@ mod tests {
 			.unwrap();
 
 		assert_eq!(db.url, "test://database");
+	}
+
+	// Tests for with_test_di_context
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_with_test_di_context_unique_per_call() {
+		// Act
+		let ctx1 = with_test_di_context(|_| {}, |ctx| async move { ctx }).await;
+		let ctx2 = with_test_di_context(|_| {}, |ctx| async move { ctx }).await;
+
+		// Assert
+		assert!(!Arc::ptr_eq(&ctx1, &ctx2));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_with_test_di_context_get_di_context_root() {
+		use reinhardt_di::resolve_context::{get_di_context, ContextLevel};
+
+		// Act & Assert
+		with_test_di_context(
+			|_| {},
+			|ctx| async move {
+				let root = get_di_context(ContextLevel::Root);
+				assert!(Arc::ptr_eq(&root, &ctx));
+			},
+		)
+		.await;
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_with_test_di_context_get_di_context_current() {
+		use reinhardt_di::resolve_context::{get_di_context, ContextLevel};
+
+		// Act & Assert
+		with_test_di_context(
+			|_| {},
+			|ctx| async move {
+				let current = get_di_context(ContextLevel::Current);
+				assert!(Arc::ptr_eq(&current, &ctx));
+			},
+		)
+		.await;
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_with_test_di_context_setup_registers_singletons() {
+		// Arrange & Act
+		let result = with_test_di_context(
+			|scope| {
+				scope.set(TestConfig {
+					value: "from_setup".to_string(),
+				});
+			},
+			|ctx| async move {
+				// Assert
+				let config: Option<Arc<TestConfig>> = ctx.get_singleton();
+				config.unwrap().value.clone()
+			},
+		)
+		.await;
+
+		assert_eq!(result, "from_setup");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_with_test_di_context_parallel_safety() {
+		// Act
+		let (val1, val2) = tokio::join!(
+			with_test_di_context(
+				|scope| {
+					scope.set("task_1".to_string());
+				},
+				|ctx| async move {
+					let v: Option<Arc<String>> = ctx.get_singleton();
+					v.unwrap().as_str().to_owned()
+				},
+			),
+			with_test_di_context(
+				|scope| {
+					scope.set("task_2".to_string());
+				},
+				|ctx| async move {
+					let v: Option<Arc<String>> = ctx.get_singleton();
+					v.unwrap().as_str().to_owned()
+				},
+			),
+		);
+
+		// Assert
+		assert_eq!(val1, "task_1");
+		assert_eq!(val2, "task_2");
 	}
 }

--- a/crates/reinhardt-testkit/src/fixtures/di.rs
+++ b/crates/reinhardt-testkit/src/fixtures/di.rs
@@ -98,8 +98,8 @@
 //! }
 //! ```
 
-use reinhardt_di::{InjectionContext, SingletonScope};
 use reinhardt_di::resolve_context::{RESOLVE_CTX, ResolveContext};
+use reinhardt_di::{InjectionContext, SingletonScope};
 use rstest::*;
 use std::future::Future;
 use std::sync::Arc;
@@ -487,10 +487,7 @@ pub async fn injection_context_with_database(database_url: &str) -> InjectionCon
 ///     assert_eq!(result, 42);
 /// }
 /// ```
-pub async fn with_test_di_context<F, Fut, T>(
-	setup: impl FnOnce(&SingletonScope),
-	f: F,
-) -> T
+pub async fn with_test_di_context<F, Fut, T>(setup: impl FnOnce(&SingletonScope), f: F) -> T
 where
 	F: FnOnce(Arc<InjectionContext>) -> Fut,
 	Fut: Future<Output = T>,
@@ -754,7 +751,7 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_with_test_di_context_get_di_context_root() {
-		use reinhardt_di::resolve_context::{get_di_context, ContextLevel};
+		use reinhardt_di::resolve_context::{ContextLevel, get_di_context};
 
 		// Act & Assert
 		with_test_di_context(
@@ -770,7 +767,7 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_with_test_di_context_get_di_context_current() {
-		use reinhardt_di::resolve_context::{get_di_context, ContextLevel};
+		use reinhardt_di::resolve_context::{ContextLevel, get_di_context};
 
 		// Act & Assert
 		with_test_di_context(


### PR DESCRIPTION
## Summary

- Add `with_test_di_context()` to `reinhardt-testkit` that wraps async test execution with an isolated DI context
- Sets task-local `RESOLVE_CTX` so `get_di_context()` works in both factory execution and test body
- Each invocation creates its own `SingletonScope` and `InjectionContext` for parallel safety
- Re-exported through `reinhardt-testkit::fixtures`

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Server function tests that use `#[inject]` require `RESOLVE_CTX` to be set task-locally. Without a test helper, each test must manually create a `SingletonScope`, `InjectionContext`, `ResolveContext`, and call `RESOLVE_CTX.scope()`. This new function encapsulates the boilerplate and ensures parallel safety through task-local isolation.

Fixes #3504

## How Was This Tested?

- `cargo nextest run -p reinhardt-testkit --all-features` — 367 tests passed
- `cargo test -p reinhardt-testkit --doc` — 229 doc tests passed

Five new tests added:
- `test_with_test_di_context_unique_per_call` — each call creates a unique context
- `test_with_test_di_context_get_di_context_root` — `get_di_context(Root)` returns the same context
- `test_with_test_di_context_get_di_context_current` — `get_di_context(Current)` returns the same context
- `test_with_test_di_context_setup_registers_singletons` — setup closure registers singletons resolvable in body
- `test_with_test_di_context_parallel_safety` — `tokio::join!` execution doesn't mix contexts

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)