### PR TITLE
fix(ci): replace heredoc with echo in announce-breaking-change workflow

### DIFF
--- a/.github/actions/announce-breaking-change/action.yml
+++ b/.github/actions/announce-breaking-change/action.yml
@@ -105,17 +105,17 @@ runs:
         disc_title="[${SOURCE_REPO}#${PR_NUMBER}] ${PR_TITLE}"
 
         # Write body to temp file to preserve formatting
-        cat > /tmp/discussion-body.md <<EOF
-## Breaking Change: ${SOURCE_REPO}
-
-**PR**: ${SOURCE_REPO}#${PR_NUMBER} — ${PR_TITLE}
-**Merged**: ${merged_date}
-**Link**: ${PR_URL}
-
-### Details
-
-${details}
-EOF
+        {
+          echo "## Breaking Change: ${SOURCE_REPO}"
+          echo ""
+          echo "**PR**: ${SOURCE_REPO}#${PR_NUMBER} — ${PR_TITLE}"
+          echo "**Merged**: ${merged_date}"
+          echo "**Link**: ${PR_URL}"
+          echo ""
+          echo "### Details"
+          echo ""
+          echo "${details}"
+        } > /tmp/discussion-body.md
 
         if ! url=$(gh discussion create \
           --repo kent8192/reinhardt-web \

--- a/.github/actions/announce-breaking-change/action.yml
+++ b/.github/actions/announce-breaking-change/action.yml
@@ -114,7 +114,7 @@ runs:
           echo ""
           echo "### Details"
           echo ""
-          echo "${details}"
+          printf '%s\n' "${details}"
         } > /tmp/discussion-body.md
 
         if ! url=$(gh discussion create \

--- a/.github/workflows/announce-breaking-change.yml
+++ b/.github/workflows/announce-breaking-change.yml
@@ -106,17 +106,17 @@ jobs:
             local merged_date="${merged_at%%T*}"
             local disc_title="${search_key} ${pr_title}"
 
-            cat > /tmp/discussion-body.md <<BODY_EOF
-## Breaking Change: ${SOURCE_REPO}
-
-**PR**: ${SOURCE_REPO}#${pr_number} — ${pr_title}
-**Merged**: ${merged_date}
-**Link**: ${pr_url}
-
-### Details
-
-${details}
-BODY_EOF
+            {
+              echo "## Breaking Change: ${SOURCE_REPO}"
+              echo ""
+              echo "**PR**: ${SOURCE_REPO}#${pr_number} — ${pr_title}"
+              echo "**Merged**: ${merged_date}"
+              echo "**Link**: ${pr_url}"
+              echo ""
+              echo "### Details"
+              echo ""
+              echo "${details}"
+            } > /tmp/discussion-body.md
 
             gh discussion create \
               --repo kent8192/reinhardt-web \

--- a/.github/workflows/announce-breaking-change.yml
+++ b/.github/workflows/announce-breaking-change.yml
@@ -115,7 +115,7 @@ jobs:
               echo ""
               echo "### Details"
               echo ""
-              echo "${details}"
+              printf '%s\n' "${details}"
             } > /tmp/discussion-body.md
 
             gh discussion create \


### PR DESCRIPTION
## Summary

- Replace shell heredoc with `{ echo ... }` pattern in `announce-breaking-change` workflow and composite action to fix YAML literal block scalar breakage

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The `announce-breaking-change.yml` workflow fails on every push to `main` with:

> You have an error in your yaml syntax on line 112

**Root cause**: Heredoc content (lines starting with `## Breaking Change:`, `**PR**:`, etc.) was written at zero indentation inside a YAML `|` (literal block scalar). The YAML parser treats lines with less indentation than the first content line as the end of the block. Once the block ends, `**PR**: ...` is parsed as an invalid YAML mapping, causing the syntax error.

**Fix**: Replace `cat > file <<EOF ... EOF` with `{ echo "..."; } > file`, keeping all lines properly indented within the YAML block.

See failed run: https://github.com/kent8192/reinhardt-web/actions/runs/24316478175

## How Was This Tested?

- [x] YAML lint validation passes for both modified files (`npx yaml-lint`)
- [x] Verified the `run:` block content remains functionally equivalent (same markdown output)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

The same heredoc pattern existed in both the workflow file (backfill job) and the composite action. Both have been fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)