### PR TITLE
fix(testkit): remove auth-testing feature, make auth unconditional on native targets

### DIFF
--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -129,7 +129,7 @@ cfg_aliases = "0.2"
 # Native-only dependencies (cannot compile on wasm32-unknown-unknown)
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 # Core: delegate to reinhardt-testkit
-reinhardt-testkit = { workspace = true, features = ["auth-testing"] }
+reinhardt-testkit = { workspace = true }
 
 # Dependencies required by reinhardt-test's own modules (auth, admin)
 reinhardt-auth = { workspace = true, features = ["jwt", "argon2-hasher", "sessions", "oauth", "token"] }

--- a/crates/reinhardt-testkit/Cargo.toml
+++ b/crates/reinhardt-testkit/Cargo.toml
@@ -26,12 +26,7 @@ property-based = ["dep:proptest"]
 viewsets = []
 admin = ["dep:reinhardt-conf"]
 messages = ["reinhardt-core/messages"]
-auth-testing = [
-  "dep:reinhardt-auth",
-  "dep:reinhardt-middleware",
-  "dep:totp-lite",
-]
-full = ["testcontainers", "static", "websockets", "graphql", "property-based", "viewsets", "admin", "messages", "auth-testing"]
+full = ["testcontainers", "static", "websockets", "graphql", "property-based", "viewsets", "admin", "messages"]
 
 [dependencies]
 reinhardt-db = { workspace = true, features = ["backends", "migrations", "mysql", "orm", "postgres", "sqlite"] }
@@ -83,10 +78,6 @@ proptest = { workspace = true, optional = true }
 # Optional dependencies for graphql feature
 async-graphql = { workspace = true, optional = true }
 
-# Optional dependencies for auth-testing feature
-reinhardt-auth = { workspace = true, optional = true, features = ["jwt", "sessions"] }
-reinhardt-middleware = { workspace = true, optional = true, features = ["sessions"] }
-totp-lite = { version = "2.0", optional = true }
 
 # WebSocket and messaging
 tokio-tungstenite = "0.28.0"
@@ -108,6 +99,11 @@ mockall = { workspace = true }
 
 reinhardt-urls = { workspace = true, features = ["routers"] }
 reinhardt-conf = { workspace = true, features = ["settings", "async"], optional = true }
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+reinhardt-auth = { workspace = true, features = ["jwt", "sessions"] }
+reinhardt-middleware = { workspace = true, features = ["sessions"] }
+totp-lite = { version = "2.0" }
 
 [build-dependencies]
 cfg_aliases = "0.2"

--- a/crates/reinhardt-testkit/src/auth.rs
+++ b/crates/reinhardt-testkit/src/auth.rs
@@ -6,14 +6,15 @@
 //! # Architecture
 //!
 //! - **[`ForceLoginUser`]**: Trait for extracting session identity from any user type.
-//!   Blanket-implemented for all `AuthIdentity` types (requires `auth-testing` feature).
+//!   Blanket-implemented for all `AuthIdentity` types (available on native targets).
 //! - **[`SessionIdentity`]**: Type-erased identity struct matching `CookieSessionAuthMiddleware` fields.
 //! - **[`AuthBuilder`]**: Entry point returned by `APIClient::auth()`.
 //! - **[`SecondaryAuth`]**: Open trait for secondary auth layers (MFA, PassKey, etc.).
 //!
-//! # Feature Flags
+//! # Platform Support
 //!
-//! - `auth-testing`: Enables session/JWT builders, TOTP secondary auth, and `AuthIdentity` blanket impl.
+//! Session/JWT builders, TOTP secondary auth, and `AuthIdentity` blanket impl are
+//! available unconditionally on native targets (non-wasm).
 
 mod error;
 mod identity;
@@ -25,15 +26,15 @@ pub use identity::SessionIdentity;
 pub use secondary::SecondaryAuth;
 pub use traits::ForceLoginUser;
 
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 pub use secondary::TotpSecondaryAuth;
 
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 mod builder;
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 pub use builder::{AuthBuilder, JwtAuthBuilder, JwtTestConfig, SessionAuthBuilder};
 
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 mod server_fn_builder;
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 pub use server_fn_builder::ServerFnAuthBuilder;

--- a/crates/reinhardt-testkit/src/auth/identity.rs
+++ b/crates/reinhardt-testkit/src/auth/identity.rs
@@ -28,7 +28,7 @@ impl SessionIdentity {
 	///
 	/// Creates a `SessionData` with the fields that `CookieSessionAuthMiddleware`
 	/// expects: `user_id`, `is_staff`, `is_superuser`.
-	#[cfg(feature = "auth-testing")]
+	#[cfg(native)]
 	pub fn to_session_data(
 		&self,
 		session_id: &str,
@@ -112,7 +112,7 @@ mod tests {
 		assert!(!identity.is_superuser);
 	}
 
-	#[cfg(feature = "auth-testing")]
+	#[cfg(native)]
 	mod session_data_tests {
 		use std::time::Duration;
 

--- a/crates/reinhardt-testkit/src/auth/secondary.rs
+++ b/crates/reinhardt-testkit/src/auth/secondary.rs
@@ -24,13 +24,13 @@ pub trait SecondaryAuth: Send + Sync {
 ///
 /// When applied, sets the `X-MFA-Code` header with either an auto-generated
 /// valid TOTP code or a manually specified code.
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 pub struct TotpSecondaryAuth {
 	manager: reinhardt_auth::mfa::MFAAuthentication,
 	code_override: Option<String>,
 }
 
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 impl TotpSecondaryAuth {
 	/// Create a new TOTP secondary auth using the given MFA manager.
 	pub fn new(manager: reinhardt_auth::mfa::MFAAuthentication) -> Self {
@@ -60,7 +60,7 @@ impl TotpSecondaryAuth {
 	}
 }
 
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 #[async_trait]
 impl SecondaryAuth for TotpSecondaryAuth {
 	async fn apply_to_client(
@@ -90,7 +90,7 @@ impl SecondaryAuth for TotpSecondaryAuth {
 
 /// Generate a TOTP code from a base32-encoded secret using the same
 /// algorithm as `MFAAuthentication` (SHA-256, 6 digits, 30s window).
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 fn generate_totp_code(secret: &str) -> Result<String, String> {
 	use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -109,7 +109,7 @@ fn generate_totp_code(secret: &str) -> Result<String, String> {
 }
 
 /// Minimal base32 decoder (RFC 4648, no padding required).
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 fn base32_decode(input: &str) -> Option<Vec<u8>> {
 	const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 	let mut bits = 0u64;
@@ -136,7 +136,7 @@ fn base32_decode(input: &str) -> Option<Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
-	#[cfg(feature = "auth-testing")]
+	#[cfg(native)]
 	mod totp_tests {
 		use super::super::*;
 		use rstest::*;

--- a/crates/reinhardt-testkit/src/auth/server_fn_builder.rs
+++ b/crates/reinhardt-testkit/src/auth/server_fn_builder.rs
@@ -33,7 +33,7 @@ impl ServerFnAuthBuilder {
 	}
 
 	/// Authenticate via JWT (sets identity for mock session).
-	#[cfg(feature = "auth-testing")]
+	#[cfg(native)]
 	pub fn jwt(
 		mut self,
 		user: &impl ForceLoginUser,

--- a/crates/reinhardt-testkit/src/auth/traits.rs
+++ b/crates/reinhardt-testkit/src/auth/traits.rs
@@ -20,7 +20,7 @@ pub trait ForceLoginUser: Send + Sync {
 	}
 }
 
-#[cfg(feature = "auth-testing")]
+#[cfg(native)]
 impl<T: reinhardt_auth::AuthIdentity> ForceLoginUser for T {
 	fn session_user_id(&self) -> String {
 		self.id()

--- a/crates/reinhardt-testkit/src/client.rs
+++ b/crates/reinhardt-testkit/src/client.rs
@@ -523,7 +523,7 @@ impl APIClient {
 	///     .with_staff(true)
 	///     .apply().await?;
 	/// ```
-	#[cfg(feature = "auth-testing")]
+	#[cfg(native)]
 	pub fn auth(&self) -> crate::auth::AuthBuilder<'_> {
 		crate::auth::AuthBuilder::new(self)
 	}

--- a/crates/reinhardt-testkit/src/server_fn/context.rs
+++ b/crates/reinhardt-testkit/src/server_fn/context.rs
@@ -306,7 +306,7 @@ impl ServerFnTestContext {
 	///     .done()
 	///     .build();
 	/// ```
-	#[cfg(feature = "auth-testing")]
+	#[cfg(native)]
 	pub fn auth(self) -> crate::auth::ServerFnAuthBuilder {
 		crate::auth::ServerFnAuthBuilder::new(self)
 	}


### PR DESCRIPTION
## Summary

- Remove the `auth-testing` feature flag from `reinhardt-testkit`
- Make auth testing utilities (APIClient::auth(), AuthBuilder, SessionAuthBuilder, JwtAuthBuilder, TotpSecondaryAuth) unconditionally available on native targets
- Auth dependencies (`reinhardt-auth`, `reinhardt-middleware`, `totp-lite`) are now included via `cfg(not(wasm))` target dependencies instead of optional feature-gated deps

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `auth-testing` feature added unnecessary complexity for users. Auth testing utilities should be available by default on native targets without requiring explicit feature activation. This simplifies the dependency configuration for downstream crates.

Fixes #3532

## How Was This Tested?

- `cargo check -p reinhardt-testkit --all-features` passes
- `cargo check -p reinhardt-test --all-features` passes
- `cargo check -p reinhardt-web --features test` passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Priority Label
- [x] `high` - Important fix or feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)