### PR TITLE
fix(ci): add --first-parent, retry logic, and 1M context support to release announcements

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -277,6 +277,13 @@ jobs:
 
           for TAG in $TAGS_TO_PROCESS; do
             VERSION="${TAG#reinhardt-web@v}"
+
+            # Validate VERSION to prevent path traversal in temp file paths
+            if [[ "$VERSION" =~ [^a-zA-Z0-9._-] ]]; then
+              echo "::warning::Skipping $TAG: invalid version format '$VERSION'"
+              continue
+            fi
+
             ANNOUNCEMENT_FILE="announcements/v${VERSION}.md"
 
             echo "=== Processing $TAG ==="
@@ -316,17 +323,53 @@ jobs:
             # Stage 2: Generate announcement with Claude CLI
             # Redirect stdin from file (not command arg) to avoid ARG_MAX
             SYSTEM_PROMPT=$(cat scripts/prompts/announcement-system.md)
-            if claude --print \
-              --bare \
-              --model sonnet \
-              --system-prompt "$SYSTEM_PROMPT" \
-              --tools "" \
-              < "/tmp/release-data-${VERSION}.json" \
-              > "$ANNOUNCEMENT_FILE" 2>/dev/null; then
+
+            # Estimate input tokens and select context window (Fixes #3534)
+            # Rough estimate: 1 token ≈ 4 characters for English text
+            INPUT_CHARS=$(wc -c < "/tmp/release-data-${VERSION}.json")
+            SYSTEM_CHARS=${#SYSTEM_PROMPT}
+            ESTIMATED_TOKENS=$(( (INPUT_CHARS + SYSTEM_CHARS) / 4 ))
+            echo "Estimated input tokens: $ESTIMATED_TOKENS (input: $INPUT_CHARS chars, system: $SYSTEM_CHARS chars)"
+
+            CLAUDE_BETAS=""
+            if [ "$ESTIMATED_TOKENS" -gt 200000 ]; then
+              CLAUDE_BETAS="--betas context-1m-2025-08-07"
+              echo "Using 1M context window for large input (>200K tokens)"
+            fi
+
+            # Retry with exponential backoff (Fixes #3534)
+            CLAUDE_SUCCESS=false
+            for ATTEMPT in 1 2 3; do
+              echo "Claude CLI attempt $ATTEMPT/3..."
+              # shellcheck disable=SC2086
+              if claude --print \
+                --bare \
+                --model sonnet \
+                $CLAUDE_BETAS \
+                --system-prompt "$SYSTEM_PROMPT" \
+                --tools "" \
+                < "/tmp/release-data-${VERSION}.json" \
+                > "$ANNOUNCEMENT_FILE" 2>"/tmp/claude-stderr-${VERSION}.log"; then
+                CLAUDE_SUCCESS=true
+                break
+              else
+                CLAUDE_EXIT=$?
+                # Sanitize stderr to prevent log injection via workflow commands
+                CLAUDE_STDERR=$(tr -d '\n\r' < "/tmp/claude-stderr-${VERSION}.log" 2>/dev/null | head -c 200 || true)
+                echo "::warning::Claude CLI attempt $ATTEMPT failed (exit=$CLAUDE_EXIT): $CLAUDE_STDERR"
+                if [ "$ATTEMPT" -lt 3 ]; then
+                  BACKOFF=$((5 * ATTEMPT * ATTEMPT))
+                  echo "Retrying in ${BACKOFF}s..."
+                  sleep "$BACKOFF"
+                fi
+              fi
+            done
+
+            if $CLAUDE_SUCCESS; then
               echo "Generated announcement for $TAG"
             else
               # Fallback: template with CHANGELOG only
-              echo "::warning::Claude CLI failed for $TAG, using fallback template"
+              echo "::warning::Claude CLI failed for $TAG after 3 attempts, using fallback template"
               CHANGELOG_SECTION=$(jq -r '.changelog_section' "/tmp/release-data-${VERSION}.json")
               PRS_TABLE=$(jq -r '.pull_requests[] | "| [#\(.number)](\(.url)) | \(.title) | @\(.author) |"' \
                 "/tmp/release-data-${VERSION}.json" || true)

--- a/scripts/collect-release-data.sh
+++ b/scripts/collect-release-data.sh
@@ -127,16 +127,19 @@ echo "Extracting PRs from commit range: $COMMIT_RANGE"
 
 PR_NUMBERS=()
 
+# Use --first-parent to follow only the main line of history,
+# avoiding traversal into merged branches' internal commits (Fixes #3534)
+
 # Merge commits: "Merge pull request #NNN from ..."
 while IFS= read -r num; do
   [ -n "$num" ] && PR_NUMBERS+=("$num")
-done < <(git -C "$REPO_ROOT" log "$COMMIT_RANGE" --merges --format="%s" 2>/dev/null \
+done < <(git -C "$REPO_ROOT" log "$COMMIT_RANGE" --first-parent --merges --format="%s" 2>/dev/null \
   | grep -oE '#[0-9]+' | grep -oE '[0-9]+' || true)
 
 # Squash commits: "feat(scope): description (#NNN)"
 while IFS= read -r num; do
   [ -n "$num" ] && PR_NUMBERS+=("$num")
-done < <(git -C "$REPO_ROOT" log "$COMMIT_RANGE" --no-merges --format="%s" 2>/dev/null \
+done < <(git -C "$REPO_ROOT" log "$COMMIT_RANGE" --first-parent --no-merges --format="%s" 2>/dev/null \
   | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' || true)
 
 # Deduplicate and sort


### PR DESCRIPTION
## Summary

- Add `--first-parent` to `git log` in `collect-release-data.sh` to follow only the main line of commit history, preventing traversal into merged branches' internal commits
- Remove `2>/dev/null` from Claude CLI invocation and capture stderr with sanitized logging to expose actual error causes
- Add exponential backoff retry (3 attempts: 5s, 20s, 45s) for Claude CLI failures
- Estimate input tokens and enable 1M Sonnet context window via `--betas context-1m-2025-08-07` when input exceeds 200K tokens
- Validate VERSION format to prevent path traversal in temp file paths

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The "Create Release Announcement PR" job in `release-plz.yml` failed silently for tags with large PR ranges in [run #24330071325](https://github.com/kent8192/reinhardt-web/actions/runs/24330071325/job/71033670988). Investigation revealed:

1. **Missing `--first-parent`**: `git log` traversed merged branches' internal commits (1061 vs 295 commits for alpha.15→alpha.16), inflating PR counts
2. **`2>/dev/null` hiding errors**: Claude CLI errors (rate limits, context overflow) were silently suppressed
3. **No retry logic**: After one failure, all subsequent tags failed immediately without recovery
4. **No context window scaling**: All inputs used sonnet (200K context) regardless of size

Dry-run token estimation confirmed that even the largest tag (alpha.16, 292 PRs) produces ~124K tokens without truncation, fitting within sonnet's 200K window. The 1M context fallback provides safety margin for edge cases.

## How Was This Tested

- Verified `--first-parent` PR counts locally: alpha.15→alpha.16 reduces from 1061 to 295 commits (292 unique PRs)
- Ran dry-run token estimation script against representative tags (alpha.5, alpha.14, alpha.16) confirming all fit within 200K tokens
- Reviewed stderr sanitization logic for log injection prevention

Fixes #3534

🤖 Generated with [Claude Code](https://claude.com/claude-code)