### PR TITLE
fix(ci): prevent false-negative in backfill breaking change job

### DIFF
--- a/.github/workflows/announce-breaking-change.yml
+++ b/.github/workflows/announce-breaking-change.yml
@@ -50,6 +50,16 @@ jobs:
     steps:
       - name: Run backfill
         run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::GH_TOKEN is not set. Ensure the DISCUSSION_PAT secret is configured."
+            exit 1
+          fi
+
+          failed=0
+          processed=0
+
           process_pr() {
             local pr_number="$1"
             echo "--- Processing PR #${pr_number} ---"
@@ -57,7 +67,7 @@ jobs:
             local pr_data
             pr_data=$(gh pr view "$pr_number" --repo "$TARGET_REPO" \
               --json title,body,url,mergedAt 2>&1) || {
-              echo "ERROR: Failed to fetch PR #${pr_number}: ${pr_data}"
+              echo "::warning::Failed to fetch PR #${pr_number}: ${pr_data}"
               return 1
             }
 
@@ -130,18 +140,22 @@ jobs:
 
           if [ "$INPUT_MODE" = "by-pr-number" ]; then
             if [ -z "$INPUT_PR_NUMBERS" ]; then
-              echo "ERROR: pr-numbers is required for by-pr-number mode"
+              echo "::error::pr-numbers is required for by-pr-number mode"
               exit 1
             fi
             IFS=',' read -ra NUMBERS <<< "$INPUT_PR_NUMBERS"
             for num in "${NUMBERS[@]}"; do
               num=$(echo "$num" | xargs)
-              process_pr "$num" || true
+              if process_pr "$num"; then
+                processed=$((processed + 1))
+              else
+                failed=$((failed + 1))
+              fi
             done
 
           elif [ "$INPUT_MODE" = "all" ]; then
             echo "Scanning all merged PRs for breaking changes..."
-            gh api --paginate "repos/${TARGET_REPO}/pulls?state=closed&per_page=100" \
+            pr_numbers=$(gh api --paginate "repos/${TARGET_REPO}/pulls?state=closed&per_page=100" \
               | jq -sr 'add
                 | map(select(.merged_at != null))
                 | map(select(
@@ -150,10 +164,19 @@ jobs:
                     (.body | test("\\[x\\] Breaking change"; "i"))
                   ))
                 | sort_by(.number)
-                | .[].number' \
-              | while read -r num; do
-                process_pr "$num" || true
-              done
+                | .[].number')
+
+            while read -r num; do
+              [ -z "$num" ] && continue
+              if process_pr "$num"; then
+                processed=$((processed + 1))
+              else
+                failed=$((failed + 1))
+              fi
+            done <<< "$pr_numbers"
           fi
 
-          echo "Backfill complete."
+          echo "Backfill complete. Processed: ${processed}, Failed: ${failed}"
+          if [ "$failed" -gt 0 ]; then
+            echo "::warning::${failed} PR(s) failed to process"
+          fi


### PR DESCRIPTION
## Summary

- Fix false-negative in `Backfill Breaking Change Announcements` job where the job reported success even when `GH_TOKEN` was empty and `gh api` failed
- Add `set -euo pipefail` to detect pipeline failures
- Validate `GH_TOKEN` before executing API calls
- Split `gh api | jq | while read` pipeline to ensure API errors propagate correctly

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

- GitHub Actions run [#24331371965](https://github.com/kent8192/reinhardt-web/actions/runs/24331371965/job/71037807872) completed with ✓ status despite `GH_TOKEN` being empty
- Root cause: missing `pipefail` meant that `gh api` failure was masked by the `while read` exit code at the end of the pipeline
- The `|| true` pattern on `process_pr` calls also swallowed all errors without reporting

## How Was This Tested?

- `bash -n` syntax validation on extracted script
- Manual review of pipeline error propagation paths

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)