### PR TITLE
fix(ci): replace gh discussion CLI with GraphQL createDiscussion mutation

### DIFF
--- a/.github/actions/announce-breaking-change/action.yml
+++ b/.github/actions/announce-breaking-change/action.yml
@@ -45,13 +45,35 @@ runs:
         PR_NUMBER: ${{ inputs.pr-number }}
       run: |
         search_key="[${SOURCE_REPO}#${PR_NUMBER}]"
-        count=$(gh api graphql -f query="
+
+        # Fetch duplicate count, repository ID, and category ID in one query (#3547).
+        # The `gh discussion` CLI subcommand is unavailable on ubuntu-latest runners,
+        # so all Discussion operations use the GraphQL API instead.
+        result=$(gh api graphql -f query="
           {
             search(type: DISCUSSION, query: \"repo:kent8192/reinhardt-web in:title \\\"${search_key}\\\"\", first: 1) {
               discussionCount
             }
+            repository(owner: \"kent8192\", name: \"reinhardt-web\") {
+              id
+              discussionCategories(first: 30) {
+                nodes { id name }
+              }
+            }
           }
-        " --jq '.data.search.discussionCount')
+        ")
+
+        count=$(echo "$result" | jq -r '.data.search.discussionCount')
+        repo_id=$(echo "$result" | jq -r '.data.repository.id')
+        category_id=$(echo "$result" | jq -r '.data.repository.discussionCategories.nodes[] | select(.name == "Breaking Changes") | .id')
+
+        if [ -z "$repo_id" ] || [ -z "$category_id" ]; then
+          echo "::error::Failed to resolve repository ID or 'Breaking Changes' category ID"
+          exit 1
+        fi
+
+        echo "repo-id=${repo_id}" >> "$GITHUB_OUTPUT"
+        echo "category-id=${category_id}" >> "$GITHUB_OUTPUT"
 
         if [ "$count" -gt 0 ]; then
           echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -72,6 +94,8 @@ runs:
         PR_URL: ${{ inputs.pr-url }}
         PR_BODY: ${{ inputs.pr-body }}
         MERGED_AT: ${{ inputs.merged-at }}
+        REPO_ID: ${{ steps.duplicate-check.outputs.repo-id }}
+        CATEGORY_ID: ${{ steps.duplicate-check.outputs.category-id }}
       run: |
         # Extract ## Breaking Changes section
         details=$(printf '%s' "$PR_BODY" | awk '
@@ -117,16 +141,32 @@ runs:
           printf '%s\n' "${details}"
         } > /tmp/discussion-body.md
 
-        if ! url=$(gh discussion create \
-          --repo kent8192/reinhardt-web \
-          --category "Breaking Changes" \
-          --title "$disc_title" \
-          --body-file /tmp/discussion-body.md); then
+        # Create discussion via GraphQL mutation (#3547).
+        # The `gh discussion` CLI subcommand is unavailable on ubuntu-latest runners.
+        body=$(cat /tmp/discussion-body.md)
+
+        if ! result=$(gh api graphql \
+          -f repositoryId="$REPO_ID" \
+          -f categoryId="$CATEGORY_ID" \
+          -f title="$disc_title" \
+          -f body="$body" \
+          -f query='
+            mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+              createDiscussion(input: {repositoryId: $repositoryId, categoryId: $categoryId, title: $title, body: $body}) {
+                discussion { url }
+              }
+            }
+          '); then
           echo "::error::Failed to create discussion: ${disc_title}"
           exit 1
         fi
 
-        url=$(printf '%s' "$url" | tr -d '\r\n')
+        url=$(echo "$result" | jq -r '.data.createDiscussion.discussion.url // empty')
+        if [ -z "$url" ]; then
+          echo "::error::GraphQL mutation returned no URL for: ${disc_title}"
+          echo "$result" >&2
+          exit 1
+        fi
 
         echo "created=true" >> "$GITHUB_OUTPUT"
         echo "discussion-url=${url}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/announce-breaking-change.yml
+++ b/.github/workflows/announce-breaking-change.yml
@@ -60,6 +60,28 @@ jobs:
           failed=0
           processed=0
 
+          # Resolve repository node ID and "Breaking Changes" category ID once (#3547).
+          # The `gh discussion` CLI subcommand is unavailable on ubuntu-latest runners,
+          # so all Discussion operations use the GraphQL API instead.
+          repo_data=$(gh api graphql -f query='
+            {
+              repository(owner: "kent8192", name: "reinhardt-web") {
+                id
+                discussionCategories(first: 30) {
+                  nodes { id name }
+                }
+              }
+            }
+          ')
+          REPO_ID=$(echo "$repo_data" | jq -r '.data.repository.id')
+          CATEGORY_ID=$(echo "$repo_data" | jq -r '.data.repository.discussionCategories.nodes[] | select(.name == "Breaking Changes") | .id')
+
+          if [ -z "$REPO_ID" ] || [ -z "$CATEGORY_ID" ]; then
+            echo "::error::Failed to resolve repository ID or 'Breaking Changes' category ID"
+            exit 1
+          fi
+          echo "Resolved REPO_ID=${REPO_ID}, CATEGORY_ID=${CATEGORY_ID}"
+
           process_pr() {
             local pr_number="$1"
             echo "--- Processing PR #${pr_number} ---"
@@ -128,13 +150,38 @@ jobs:
               printf '%s\n' "${details}"
             } > /tmp/discussion-body.md
 
-            gh discussion create \
-              --repo kent8192/reinhardt-web \
-              --category "Breaking Changes" \
-              --title "$disc_title" \
-              --body-file /tmp/discussion-body.md
+            # Create discussion via GraphQL mutation (#3547).
+            # Explicit error checking is required because process_pr is called
+            # inside `if`, which disables `set -e` per POSIX errexit semantics.
+            local body
+            body=$(cat /tmp/discussion-body.md)
 
-            echo "CREATED: ${disc_title}"
+            local result
+            result=$(gh api graphql \
+              -f repositoryId="$REPO_ID" \
+              -f categoryId="$CATEGORY_ID" \
+              -f title="$disc_title" \
+              -f body="$body" \
+              -f query='
+                mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+                  createDiscussion(input: {repositoryId: $repositoryId, categoryId: $categoryId, title: $title, body: $body}) {
+                    discussion { url }
+                  }
+                }
+              ') || {
+              echo "::warning::Failed to create discussion: ${disc_title}"
+              return 1
+            }
+
+            local url
+            url=$(echo "$result" | jq -r '.data.createDiscussion.discussion.url // empty')
+            if [ -z "$url" ]; then
+              echo "::warning::GraphQL mutation returned no URL for: ${disc_title}"
+              echo "$result" >&2
+              return 1
+            fi
+
+            echo "CREATED: ${disc_title} -> ${url}"
             sleep 2
           }
 


### PR DESCRIPTION
## Summary

- Replace `gh discussion create` CLI (unavailable on ubuntu-latest) with `createDiscussion` GraphQL mutation in both the backfill job and composite action
- Add explicit error checking after GraphQL calls to fix false negatives caused by POSIX `set -e` being disabled inside `if` conditions
- Resolve repository ID and category ID upfront via GraphQL instead of relying on CLI subcommand discovery

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Run [#24336626941](https://github.com/kent8192/reinhardt-web/actions/runs/24336626941/job/71054974840) processed 48 PRs and reported `Processed: 48, Failed: 0` — yet no Discussions were created. Every `gh discussion create` failed with `unknown command "discussion" for "gh"`, but the errors were silently swallowed because:

1. **`gh discussion` is not a built-in gh CLI subcommand** on ubuntu-latest runners
2. **`set -e` is disabled inside `if` conditions** per POSIX errexit semantics — since `process_pr` is called as `if process_pr "$num"`, errors inside the function don't trigger errexit

## How Was This Tested

- `bash -n` syntax validation on extracted script
- `shellcheck` static analysis (only SC2016 info — intentional single-quote for GraphQL)
- Manual review of GraphQL mutation structure against GitHub GraphQL API docs

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] Comments explain non-obvious logic
- [x] No new warnings introduced

## Labels to Apply

- `ci-cd` — CI/CD workflow fix
- `bug` — False negative behavior

Fixes #3547

🤖 Generated with [Claude Code](https://claude.com/claude-code)