### PR TITLE
style(examples): apply reinhardt-admin fmt formatting

### DIFF
--- a/examples/examples-tutorial-basis/src/config/settings.rs
+++ b/examples/examples-tutorial-basis/src/config/settings.rs
@@ -30,12 +30,10 @@ pub fn get_settings() -> ProjectSettings {
 
 	SettingsBuilder::new()
 		.profile(Profile::parse(&profile_str))
-		.add_source(
-			DefaultSource::new().with_value(
-				"core.base_dir",
-				json::Value::String(base_dir.to_string_lossy().to_string()),
-			),
-		)
+		.add_source(DefaultSource::new().with_value(
+			"core.base_dir",
+			json::Value::String(base_dir.to_string_lossy().to_string()),
+		))
 		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
 		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
 		.add_source(TomlFileSource::new(

--- a/examples/examples-tutorial-rest/src/config/settings.rs
+++ b/examples/examples-tutorial-rest/src/config/settings.rs
@@ -30,12 +30,10 @@ pub fn get_settings() -> ProjectSettings {
 
 	SettingsBuilder::new()
 		.profile(Profile::parse(&profile_str))
-		.add_source(
-			DefaultSource::new().with_value(
-				"core.base_dir",
-				json::Value::String(base_dir.to_string_lossy().to_string()),
-			),
-		)
+		.add_source(DefaultSource::new().with_value(
+			"core.base_dir",
+			json::Value::String(base_dir.to_string_lossy().to_string()),
+		))
 		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
 		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
 		.add_source(TomlFileSource::new(

--- a/examples/examples-twitter/src/apps/dm/shared/server_fn.rs
+++ b/examples/examples-twitter/src/apps/dm/shared/server_fn.rs
@@ -39,9 +39,10 @@ pub async fn create_room(
 	participant_ids: Vec<Uuid>,
 	name: Option<String>,
 	#[inject] db: DatabaseConnection,
-	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<crate::apps::auth::models::User>,
+	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<
+		crate::apps::auth::models::User,
+	>,
 ) -> std::result::Result<RoomInfo, ServerFnError> {
-
 	// Validate participants
 	if participant_ids.is_empty() {
 		return Err(ServerFnError::application(
@@ -161,9 +162,10 @@ pub async fn create_room(
 #[server_fn]
 pub async fn list_rooms(
 	#[inject] db: DatabaseConnection,
-	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<crate::apps::auth::models::User>,
+	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<
+		crate::apps::auth::models::User,
+	>,
 ) -> std::result::Result<Vec<RoomInfo>, ServerFnError> {
-
 	// Get rooms the user is a member of
 	let rooms_accessor =
 		ManyToManyAccessor::<User, DMRoom>::new(&current_user, "rooms", db.clone());
@@ -237,9 +239,10 @@ pub async fn list_rooms(
 pub async fn get_room(
 	room_id: Uuid,
 	#[inject] db: DatabaseConnection,
-	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<crate::apps::auth::models::User>,
+	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<
+		crate::apps::auth::models::User,
+	>,
 ) -> std::result::Result<RoomInfo, ServerFnError> {
-
 	// Find the room
 	let room = DMRoom::objects()
 		.filter(
@@ -273,9 +276,10 @@ pub async fn send_message(
 	room_id: Uuid,
 	content: String,
 	#[inject] db: DatabaseConnection,
-	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<crate::apps::auth::models::User>,
+	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<
+		crate::apps::auth::models::User,
+	>,
 ) -> std::result::Result<MessageInfo, ServerFnError> {
-
 	// Validate content
 	if content.trim().is_empty() {
 		return Err(ServerFnError::application(
@@ -339,9 +343,10 @@ pub async fn list_messages(
 	limit: Option<i32>,
 	before: Option<Uuid>,
 	#[inject] db: DatabaseConnection,
-	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<crate::apps::auth::models::User>,
+	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<
+		crate::apps::auth::models::User,
+	>,
 ) -> std::result::Result<Vec<MessageInfo>, ServerFnError> {
-
 	// Find the room
 	let room = DMRoom::objects()
 		.filter(
@@ -435,9 +440,10 @@ pub async fn list_messages(
 pub async fn mark_as_read(
 	room_id: Uuid,
 	#[inject] db: DatabaseConnection,
-	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<crate::apps::auth::models::User>,
+	#[inject] reinhardt::AuthUser(current_user): reinhardt::AuthUser<
+		crate::apps::auth::models::User,
+	>,
 ) -> std::result::Result<(), ServerFnError> {
-
 	// Find the room
 	let room = DMRoom::objects()
 		.filter(

--- a/examples/examples-twitter/src/config/settings.rs
+++ b/examples/examples-twitter/src/config/settings.rs
@@ -75,12 +75,10 @@ pub fn get_settings() -> ProjectSettings {
 
 	SettingsBuilder::new()
 		.profile(Profile::parse(&profile_str))
-		.add_source(
-			DefaultSource::new().with_value(
-				"core.base_dir",
-				json::Value::String(base_dir.to_string_lossy().to_string()),
-			),
-		)
+		.add_source(DefaultSource::new().with_value(
+			"core.base_dir",
+			json::Value::String(base_dir.to_string_lossy().to_string()),
+		))
 		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
 		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
 		.add_source(TomlFileSource::new(


### PR DESCRIPTION
## Summary

- Apply `reinhardt-admin fmt` formatting to example projects
- Fixes formatting inconsistency in `settings.rs` (3 examples) and `server_fn.rs` (twitter example)
- Changes are auto-formatting only: method chain indentation and generic type line breaks

## Test plan

- [x] `reinhardt-admin fmt . --check` passes for all examples
- [ ] CI Examples Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)