### PR TITLE
fix(macros): use tt repetition instead of path fragment in __for_each_url_resolver

### DIFF
--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -382,9 +382,9 @@ pub(crate) fn url_patterns_impl(args: TokenStream, input: TokenStream) -> syn::R
 			/// so that the metadata macros resolve at the call site.
 			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 			macro_rules! __for_each_url_resolver {
-				($callback:ident, $app:ident, $base:path) => {
+				($callback:ident, $app:ident, $($base:tt)*) => {
 					#(
-						$base :: #meta_idents ! ($callback, $app);
+						$($base)* :: #meta_idents ! ($callback, $app);
 					)*
 				};
 			}
@@ -530,14 +530,26 @@ mod tests {
 		let result = url_patterns_impl(quote! {}, input).unwrap();
 		let output = result.to_string();
 
+		// Verify __for_each_url_resolver macro is generated
 		assert!(
 			output.contains("__for_each_url_resolver"),
 			"missing __for_each_url_resolver macro"
 		);
+
+		// Verify $base uses tt repetition (not :path) so it can be extended with ::
 		assert!(
-			output.contains("$base"),
-			"missing $base parameter in __for_each_url_resolver"
+			output.contains("$ ($ base : tt) *"),
+			"__for_each_url_resolver must use $($base:tt)* (not $base:path) \
+			 to allow path extension with ::"
 		);
+
+		// Verify the macro body uses $($base)* :: for path concatenation
+		assert!(
+			output.contains("$ ($ base) * ::"),
+			"__for_each_url_resolver body must use $($base)* :: to extend the base path"
+		);
+
+		// Verify meta idents for each endpoint are present
 		assert!(
 			output.contains("__url_resolver_meta_login"),
 			"missing login meta ident"
@@ -545,6 +557,60 @@ mod tests {
 		assert!(
 			output.contains("__url_resolver_meta_register"),
 			"missing register meta ident"
+		);
+	}
+
+	// --- Regression tests for __for_each_url_resolver syntax (Issue #3660) ---
+
+	#[test]
+	fn for_each_url_resolver_macro_is_syntactically_valid() {
+		// The generated code must be parseable as valid Rust.
+		// Previously, $base:path was used instead of $($base:tt)*,
+		// which made the generated macro unparseable because :path
+		// fragments cannot be extended with :: in declarative macros.
+		let input = quote! {
+			pub fn url_patterns() -> ServerRouter {
+				ServerRouter::new()
+					.endpoint(views::login)
+					.endpoint(views::register)
+			}
+		};
+
+		let result = url_patterns_impl(quote! {}, input).unwrap();
+
+		// Wrap in a module so it parses as a complete file
+		let wrapped = quote! {
+			mod __test_wrapper {
+				#result
+			}
+		};
+
+		let parsed: Result<syn::File, _> = syn::parse2(wrapped);
+		assert!(
+			parsed.is_ok(),
+			"generated code is not valid Rust: {}",
+			parsed.unwrap_err()
+		);
+	}
+
+	#[test]
+	fn for_each_url_resolver_no_path_fragment_specifier() {
+		// Ensure the generated macro does NOT use :path for $base,
+		// which would prevent extending the path with :: at call sites.
+		let input = quote! {
+			pub fn url_patterns() -> ServerRouter {
+				ServerRouter::new()
+					.endpoint(views::login)
+			}
+		};
+
+		let result = url_patterns_impl(quote! {}, input).unwrap();
+		let output = result.to_string();
+
+		assert!(
+			!output.contains("$ base : path"),
+			"__for_each_url_resolver must NOT use $base:path — \
+			 :path fragments cannot be extended with :: in declarative macros"
 		);
 	}
 

--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -382,9 +382,9 @@ pub(crate) fn url_patterns_impl(args: TokenStream, input: TokenStream) -> syn::R
 			/// so that the metadata macros resolve at the call site.
 			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 			macro_rules! __for_each_url_resolver {
-				($callback:ident, $app:ident, $($base:tt)*) => {
+				($callback:ident, $app:ident, $($base:tt)+) => {
 					#(
-						$($base)* :: #meta_idents ! ($callback, $app);
+						$($base)+ :: #meta_idents ! ($callback, $app);
 					)*
 				};
 			}
@@ -517,6 +517,12 @@ mod tests {
 		assert_eq!(result.to_string(), "__url_resolver_meta_login");
 	}
 
+	/// Normalize whitespace in a token stream string for robust comparison.
+	/// Collapses all runs of whitespace to a single space.
+	fn normalize_ws(s: &str) -> String {
+		s.split_whitespace().collect::<Vec<_>>().join(" ")
+	}
+
 	#[test]
 	fn url_patterns_impl_generates_for_each_macro() {
 		let input = quote! {
@@ -528,34 +534,35 @@ mod tests {
 		};
 
 		let result = url_patterns_impl(quote! {}, input).unwrap();
-		let output = result.to_string();
+		let normalized = normalize_ws(&result.to_string());
 
 		// Verify __for_each_url_resolver macro is generated
 		assert!(
-			output.contains("__for_each_url_resolver"),
+			normalized.contains("__for_each_url_resolver"),
 			"missing __for_each_url_resolver macro"
 		);
 
-		// Verify $base uses tt repetition (not :path) so it can be extended with ::
+		// Verify $base uses tt+ repetition (not :path) so it can be extended with ::
 		assert!(
-			output.contains("$ ($ base : tt) *"),
-			"__for_each_url_resolver must use $($base:tt)* (not $base:path) \
-			 to allow path extension with ::"
+			normalized.contains("$($ base : tt) +"),
+			"__for_each_url_resolver must use $($base:tt)+ (not $base:path) \
+			 to allow path extension with :: — got: {normalized}"
 		);
 
-		// Verify the macro body uses $($base)* :: for path concatenation
+		// Verify the macro body uses $($base)+ :: for path concatenation
 		assert!(
-			output.contains("$ ($ base) * ::"),
-			"__for_each_url_resolver body must use $($base)* :: to extend the base path"
+			normalized.contains("$($ base) + ::"),
+			"__for_each_url_resolver body must use $($base)+ :: to extend the base path \
+			 — got: {normalized}"
 		);
 
 		// Verify meta idents for each endpoint are present
 		assert!(
-			output.contains("__url_resolver_meta_login"),
+			normalized.contains("__url_resolver_meta_login"),
 			"missing login meta ident"
 		);
 		assert!(
-			output.contains("__url_resolver_meta_register"),
+			normalized.contains("__url_resolver_meta_register"),
 			"missing register meta ident"
 		);
 	}
@@ -565,7 +572,7 @@ mod tests {
 	#[test]
 	fn for_each_url_resolver_macro_is_syntactically_valid() {
 		// The generated code must be parseable as valid Rust.
-		// Previously, $base:path was used instead of $($base:tt)*,
+		// Previously, $base:path was used instead of $($base:tt)+,
 		// which made the generated macro unparseable because :path
 		// fragments cannot be extended with :: in declarative macros.
 		let input = quote! {
@@ -605,10 +612,10 @@ mod tests {
 		};
 
 		let result = url_patterns_impl(quote! {}, input).unwrap();
-		let output = result.to_string();
+		let normalized = normalize_ws(&result.to_string());
 
 		assert!(
-			!output.contains("$ base : path"),
+			!normalized.contains("$ base : path"),
 			"__for_each_url_resolver must NOT use $base:path — \
 			 :path fragments cannot be extended with :: in declarative macros"
 		);


### PR DESCRIPTION
## Summary

- Fix invalid `__for_each_url_resolver!` macro generated by `#[url_patterns]`
- Change `$base:path` to `$($base:tt)*` so the base path can be extended with `::`
- Add strict assertions and regression tests for generated macro syntax

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `#[url_patterns]` attribute macro generates a declarative `__for_each_url_resolver!` macro that uses `$base:path` as a fragment specifier, then attempts `$base :: meta_ident !` in the replacement body. This is invalid because Rust's `:path` fragments cannot be followed by `::` in declarative macro expansion — they are opaque units that cannot be extended.

This blocks any project using `installed_apps!` + `#[url_patterns]` from compiling, including the in-repo `examples-tutorial-rest` example.

Fixes #3660

Related to: #3649

## How Was This Tested?

- Updated existing `url_patterns_impl_generates_for_each_macro` test with strict assertions verifying `$($base:tt)*` usage
- Added `for_each_url_resolver_macro_is_syntactically_valid` regression test that parses the generated code through `syn::parse2::<syn::File>()`
- Added `for_each_url_resolver_no_path_fragment_specifier` test asserting `:path` is not used for `$base`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `routing` - URL routing, path matching

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)