### PR TITLE
docs: add Reinhardt design philosophy as standalone instruction file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ See README.md for project details.
 
 **Repository URL**: https://github.com/kent8192/reinhardt-web
 
+@instructions/DESIGN_PHILOSOPHY.md
+
 ---
 
 ## Tech Stack

--- a/instructions/DESIGN_PHILOSOPHY.md
+++ b/instructions/DESIGN_PHILOSOPHY.md
@@ -1,0 +1,19 @@
+# Reinhardt Design Philosophy
+
+These principles guide ALL design decisions in the Reinhardt framework.
+
+---
+
+1. **Magic must be understandable** — Every convention must be a trick the user can see through; no opaque magic
+2. **CoC must be predictable without domain knowledge** — Convention over Configuration must be guessable regardless of the user's background knowledge
+   - Anti-pattern: `Person` → `People` (requires English pluralization knowledge)
+   - Good pattern: `Person` → `PersonSettings` (trivially predictable)
+3. **CoC is a right, not an obligation** — Users must always have the choice to opt out of conventions
+4. **Fail early** — Earlier error detection is always better:
+   - Type consistency errors > compile-time errors > runtime initialization errors > runtime errors
+5. **API ergonomics is paramount** — Delegate explicit boilerplate to macros that provide compile-time verification
+6. **Async over sync** — Prefer async APIs by default
+7. **Confusable APIs are bad APIs** — If two APIs can be confused, the design is wrong
+8. **Boilerplate is evil** — Minimize repetitive code at every opportunity
+9. **Every framework eventually becomes outdated** — Design with this inevitability in mind
+10. **Own the implementation for framework optimization** — Build custom implementations over adopting external libraries when it serves the framework's goals (e.g., SeaQuery → reinhardt-query)


### PR DESCRIPTION
## Summary

- Add `instructions/DESIGN_PHILOSOPHY.md` documenting Reinhardt's 10 core design principles
- Reference it from `CLAUDE.md` via `@instructions/DESIGN_PHILOSOPHY.md`

## Type of Change

- [x] Documentation update

## Motivation and Context

Reinhardt's design philosophy (understandable magic, predictable CoC, fail-early, API ergonomics, etc.) was not documented. Codifying these principles ensures consistent design decisions across the project.

## How Was This Tested?

- Verified file renders correctly in markdown
- Confirmed `@` reference placement in CLAUDE.md

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)