### PR TITLE
feat(macros): accept typed identifier instead of string literal in `#[url_patterns]`

### DIFF
--- a/crates/reinhardt-core/macros/src/macro_state.rs
+++ b/crates/reinhardt-core/macros/src/macro_state.rs
@@ -1,9 +1,11 @@
-//! Shared state file for cross-macro communication between `installed_apps!` and `#[routes]`.
+//! Shared state file for cross-macro communication between `installed_apps!`,
+//! `#[url_patterns]`, and `#[routes]`.
 //!
-//! Both proc macros expand within the same user crate, but cannot share data through
+//! These proc macros expand within the same user crate, but cannot share data through
 //! Rust's type system. This module provides file-based state sharing:
 //!
 //! - `installed_apps!` writes the list of app labels to a state file
+//! - `#[url_patterns]` reads that file to validate the app name identifier
 //! - `#[routes]` reads that file and generates `url_prelude` directly
 //!
 //! This eliminates the need for the `#[macro_export]` callback pattern that triggers

--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -683,7 +683,10 @@ mod tests {
 		};
 
 		let result = url_patterns_impl(quote! { "users" }, input);
-		assert!(result.is_err(), "string literal should be rejected, expected Ident");
+		assert!(
+			result.is_err(),
+			"string literal should be rejected, expected Ident"
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -575,14 +575,14 @@ mod tests {
 
 		// Verify $base uses tt+ repetition (not :path) so it can be extended with ::
 		assert!(
-			normalized.contains("$($ base : tt) +"),
+			normalized.contains("$ ($ base : tt) +"),
 			"__for_each_url_resolver must use $($base:tt)+ (not $base:path) \
 			 to allow path extension with :: — got: {normalized}"
 		);
 
 		// Verify the macro body uses $($base)+ :: for path concatenation
 		assert!(
-			normalized.contains("$($ base) + ::"),
+			normalized.contains("$ ($ base) + ::"),
 			"__for_each_url_resolver body must use $($base)+ :: to extend the base path \
 			 — got: {normalized}"
 		);

--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -322,9 +322,35 @@ fn build_mount_reexport(call: &MountCall) -> TokenStream {
 
 /// Implementation of the `#[url_patterns]` attribute macro.
 ///
-/// Optionally accepts an app label string: `#[url_patterns("users")]`.
+/// Validates an app name identifier against the installed apps state file.
+///
+/// Returns `Ok(())` if the app is registered, the state file is unavailable,
+/// or the target is WASM. Returns a compile error if the app is not registered.
+fn validate_app_label(label: &str, span: proc_macro2::Span) -> syn::Result<()> {
+	if crate::macro_state::is_wasm_target() {
+		return Ok(());
+	}
+	if let Ok(installed) = crate::macro_state::read_installed_apps()
+		&& !installed.contains(&label.to_string())
+	{
+		return Err(syn::Error::new(
+			span,
+			format!(
+				"unknown app `{label}`. Registered apps: [{}]",
+				installed.join(", ")
+			),
+		));
+	}
+	Ok(())
+}
+
+/// Optionally accepts an app name identifier: `#[url_patterns(users)]`.
 /// When provided, the returned router is wrapped with `.with_namespace("users")`
 /// to enable per-app route name namespacing (Issue #3526).
+///
+/// The identifier is validated against the installed apps state file written by
+/// `installed_apps!`. If the state file is available and the identifier is not
+/// a registered app, a compile-time error is emitted (Issue #3668).
 pub(crate) fn url_patterns_impl(args: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
 	let func: ItemFn = parse2(input)?;
 
@@ -337,9 +363,14 @@ pub(crate) fn url_patterns_impl(args: TokenStream, input: TokenStream) -> syn::R
 	let mount_re_exports = mount_calls.iter().map(build_mount_reexport);
 	let meta_idents: Vec<syn::Ident> = endpoint_paths.iter().filter_map(build_meta_ident).collect();
 
-	// Parse optional app label: #[url_patterns("users")]
+	// Parse optional app label: #[url_patterns(users)]
 	let func_output = if !args.is_empty() {
-		let app_label: syn::LitStr = syn::parse2(args)?;
+		let app_label: syn::Ident = syn::parse2(args)?;
+		let app_label_str = app_label.to_string();
+
+		// Validate against installed apps state file (Issue #3668).
+		validate_app_label(&app_label_str, app_label.span())?;
+
 		let fn_vis = &func.vis;
 		let fn_attrs = &func.attrs;
 		let fn_sig = &func.sig;
@@ -350,7 +381,7 @@ pub(crate) fn url_patterns_impl(args: TokenStream, input: TokenStream) -> syn::R
 			#(#fn_attrs)*
 			#fn_vis #fn_sig {
 				let __router = (|| #fn_block)();
-				__router.with_namespace(#app_label)
+				__router.with_namespace(#app_label_str)
 			}
 		}
 	} else {
@@ -622,7 +653,10 @@ mod tests {
 	}
 
 	#[test]
-	fn url_patterns_with_app_label_wraps_namespace() {
+	fn url_patterns_with_ident_app_label_wraps_namespace() {
+		// Write a temporary state file so validation passes in the test environment
+		let _ = crate::macro_state::write_installed_apps(&["users".to_string()]);
+
 		let input = quote! {
 			pub fn url_patterns() -> ServerRouter {
 				ServerRouter::new()
@@ -630,12 +664,46 @@ mod tests {
 			}
 		};
 
-		let result = url_patterns_impl(quote! { "users" }, input).unwrap();
+		let result = url_patterns_impl(quote! { users }, input).unwrap();
 		let output = result.to_string();
 
 		assert!(
 			output.contains("with_namespace"),
 			"missing with_namespace call"
+		);
+	}
+
+	#[test]
+	fn url_patterns_with_string_literal_errors() {
+		let input = quote! {
+			pub fn url_patterns() -> ServerRouter {
+				ServerRouter::new()
+					.endpoint(views::login)
+			}
+		};
+
+		let result = url_patterns_impl(quote! { "users" }, input);
+		assert!(result.is_err(), "string literal should be rejected, expected Ident");
+	}
+
+	#[test]
+	fn url_patterns_rejects_unknown_app_label() {
+		// Write a state file with known apps (not including "nonexistent")
+		let _ = crate::macro_state::write_installed_apps(&["myapp".to_string()]);
+
+		let input = quote! {
+			pub fn url_patterns() -> ServerRouter {
+				ServerRouter::new()
+					.endpoint(views::login)
+			}
+		};
+
+		let result = url_patterns_impl(quote! { nonexistent }, input);
+		assert!(result.is_err(), "unknown app should be rejected");
+		let err_msg = result.unwrap_err().to_string();
+		assert!(
+			err_msg.contains("unknown app `nonexistent`"),
+			"error should mention the unknown app name, got: {err_msg}"
 		);
 	}
 

--- a/tests/integration/tests/admin/server_fn_usecase_tests.rs
+++ b/tests/integration/tests/admin/server_fn_usecase_tests.rs
@@ -190,7 +190,8 @@ async fn test_admin_dashboard_shows_registered_models(
 	let request = make_staff_request();
 
 	// Act
-	let result = get_dashboard(site.clone(), request.clone()).await;
+	let auth_user = make_auth_user();
+	let result = get_dashboard(site.clone(), request.clone(), auth_user).await;
 
 	// Assert
 	let dashboard = result.expect("get_dashboard should succeed");


### PR DESCRIPTION
## Summary

- Change `#[url_patterns]` macro to accept an identifier (e.g., `#[url_patterns(users)]`) instead of a string literal (`#[url_patterns("users")]`)
- Validate the app name at compile time against the installed apps state file written by `installed_apps!`
- Unregistered app names now produce a compile-time error with a list of registered apps

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes

## Motivation and Context

The string literal form `#[url_patterns("users")]` provides no compile-time validation — a typo like `"uusers"` silently produces a mismatched namespace. Since `installed_apps!` already writes registered app names to a state file (used by `#[routes]`), `#[url_patterns]` can read the same file to validate the identifier at macro expansion time.

Fixes #3668

## How Was This Tested?

- `cargo test -p reinhardt-macros -- url_patterns` — all new and existing tests pass
- `cargo clippy -p reinhardt-macros -- -D warnings` — no warnings
- New tests added:
  - `url_patterns_with_ident_app_label_wraps_namespace` — verifies code generation with identifier
  - `url_patterns_with_string_literal_errors` — verifies string literals are rejected
  - `url_patterns_rejects_unknown_app_label` — verifies unknown apps produce errors

## Breaking Changes

`#[url_patterns("app_name")]` (string literal) is replaced by `#[url_patterns(app_name)]` (identifier).

**Migration Guide:**

```rust
// Before
#[url_patterns("users")]
pub fn url_patterns() -> ServerRouter { ... }

// After
#[url_patterns(users)]
pub fn url_patterns() -> ServerRouter { ... }
```

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #3668
- #3526 (original namespace feature)

## Labels to Apply

### Type Label
- [x] `enhancement` - New feature or improvement
- [x] `breaking-change` - Breaking change

### Scope Label
- [x] `routing` - URL routing, path matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)