### PR TITLE
fix(examples): replace undefined cfg(server) with cfg(native) in twitter example

### DIFF
--- a/examples/examples-twitter/src/apps/auth/shared/types.rs
+++ b/examples/examples-twitter/src/apps/auth/shared/types.rs
@@ -54,7 +54,7 @@ pub struct LoginRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisterRequest {
 	#[cfg_attr(
-		server,
+		native,
 		validate(length(
 			min = 3,
 			max = 150,
@@ -67,13 +67,13 @@ pub struct RegisterRequest {
 	pub email: String,
 
 	#[cfg_attr(
-		server,
+		native,
 		validate(length(min = 8, message = "Password must be at least 8 characters"))
 	)]
 	pub password: String,
 
 	#[cfg_attr(
-		server,
+		native,
 		validate(length(
 			min = 8,
 			message = "Password confirmation must be at least 8 characters"

--- a/examples/examples-twitter/src/apps/profile/shared/types.rs
+++ b/examples/examples-twitter/src/apps/profile/shared/types.rs
@@ -45,7 +45,7 @@ impl From<crate::apps::profile::models::Profile> for ProfileResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UpdateProfileRequest {
 	#[cfg_attr(
-		server,
+		native,
 		validate(length(max = 500, message = "Bio must be less than 500 characters"))
 	)]
 	pub bio: Option<String>,
@@ -54,7 +54,7 @@ pub struct UpdateProfileRequest {
 	pub avatar_url: Option<String>,
 
 	#[cfg_attr(
-		server,
+		native,
 		validate(length(max = 100, message = "Location must be less than 100 characters"))
 	)]
 	pub location: Option<String>,

--- a/examples/examples-twitter/src/apps/tweet/shared/types.rs
+++ b/examples/examples-twitter/src/apps/tweet/shared/types.rs
@@ -72,7 +72,7 @@ impl From<crate::apps::tweet::models::Tweet> for TweetInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateTweetRequest {
 	#[cfg_attr(
-		server,
+		native,
 		validate(length(
 			min = 1,
 			max = 280,

--- a/examples/examples-twitter/src/config/urls.rs
+++ b/examples/examples-twitter/src/config/urls.rs
@@ -67,12 +67,7 @@ pub fn routes() -> UnifiedRouter {
 	// Mount admin panel routes and static assets with deferred DI registration (server-only)
 	#[cfg(native)]
 	let router = {
-		#[cfg(native)]
 		let (admin_router, admin_di) = admin_routes_with_di(admin_site);
-		#[cfg(not(server))]
-		let (admin_router, admin_di) = admin_routes_with_di(std::sync::Arc::new(
-			reinhardt::admin::AdminSite::new("Twitter Admin"),
-		));
 		router
 			.mount("/admin/", admin_router)
 			.mount("/static/admin/", admin_static_routes())


### PR DESCRIPTION
## Summary

Fix compilation errors in `examples-twitter` caused by using undefined `cfg(server)` condition.

- Replace `#[cfg_attr(server, ...)]` with `#[cfg_attr(native, ...)]` in shared types (auth, profile, tweet)
- Remove dead code in `urls.rs`: redundant `#[cfg(native)]` and unreachable `#[cfg(not(server))]` branch

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The release CI run ([#24439941089](https://github.com/kent8192/reinhardt-web/actions/runs/24439941089)) fails on `examples-twitter` because `cfg(server)` is not a recognized cfg condition. With `-D warnings`, this `unexpected_cfgs` lint becomes a hard error.

The correct cfg for server-side code in Reinhardt is `cfg(native)` (non-WASM target).

Related to: #3671 (release PR CI failure)

## How Was This Tested?

- `cargo check` passes for `examples-twitter` with local dev mode
- Remaining `cfg(msw)` warnings are a separate issue addressed by #3672

## Checklist

- [x] Code follows project style guidelines
- [x] All code comments are written in English
- [x] No `mod.rs` files used (Rust 2024 Edition module system)

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)