### PR TITLE
security(ci): ignore RUSTSEC-2026-0098/0099 for rustls-webpki 0.101.7

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -53,4 +53,6 @@ jobs:
             --ignore RUSTSEC-2025-0134 \
             --ignore RUSTSEC-2024-0320 \
             --ignore RUSTSEC-2026-0049 \
-            --ignore RUSTSEC-2026-0066
+            --ignore RUSTSEC-2026-0066 \
+            --ignore RUSTSEC-2026-0098 \
+            --ignore RUSTSEC-2026-0099


### PR DESCRIPTION
## Summary

- Add RUSTSEC-2026-0098 and RUSTSEC-2026-0099 to `cargo audit` ignore list
- Both advisories affect `rustls-webpki 0.101.7` which is pulled in by `aws-smithy-http-client` → `rustls 0.21`
- The `0.103.x` instances are already resolved at `0.103.12` via `cargo update`

## Type of Change

- [x] CI/CD changes

## Motivation and Context

RUSTSEC-2026-0098 and RUSTSEC-2026-0099 (published 2026-04-14) report vulnerabilities in `rustls-webpki`. The fix requires `>=0.103.12`.

- `rustls-webpki 0.103.10` → `0.103.12`: resolved via `cargo update` (Cargo.lock is gitignored, CI resolves this automatically)
- `rustls-webpki 0.101.7`: **cannot be resolved** — locked by `aws-smithy-http-client 1.1.12` → `rustls 0.21.12` → `rustls-webpki 0.101.7`. No patched version of `rustls 0.21` exists. Must wait for AWS SDK to migrate to a newer rustls.

This is blocking CI on all open PRs (Security Audit → CI Success gate).

## How Was This Tested?

- `cargo audit` with the ignore list passes locally (only warnings remain for `rand`, which are non-blocking)

## Checklist

- [x] No untrusted input used in workflow changes (static `--ignore` flags only)

## Labels to Apply

- `security`
- `dependencies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)