### PR TITLE
security(admin): enforce is_active DB check in get_dashboard

### DIFF
--- a/crates/reinhardt-admin/src/server/dashboard.rs
+++ b/crates/reinhardt-admin/src/server/dashboard.rs
@@ -9,6 +9,8 @@ use reinhardt_pages::server_fn::ServerFnRequest;
 use reinhardt_pages::server_fn::{ServerFnError, server_fn};
 
 #[cfg(server)]
+use super::admin_auth::AdminAuthenticatedUser;
+#[cfg(server)]
 use super::error::AdminAuth;
 #[cfg(server)]
 use super::security::{build_csrf_cookie, generate_csrf_token};
@@ -39,8 +41,11 @@ use super::security::{build_csrf_cookie, generate_csrf_token};
 pub async fn get_dashboard(
 	#[inject] site: Depends<AdminSite>,
 	#[inject] http_request: ServerFnRequest,
+	#[inject] AdminAuthenticatedUser(_user): AdminAuthenticatedUser,
 ) -> Result<DashboardResponse, ServerFnError> {
-	// Authentication and authorization check
+	// Authentication and authorization check (Fixes #3679)
+	// AdminAuthenticatedUser injection performs DB lookup to verify is_active and is_staff.
+	// AdminAuth::require_staff() provides the HTTP-level error response.
 	let auth = AdminAuth::from_request(&http_request);
 	auth.require_staff()?;
 


### PR DESCRIPTION
## Summary

- Fix security gap where inactive users could access admin dashboard via valid JWT
- Add `AdminAuthenticatedUser` DI injection to `get_dashboard` to trigger DB-level `is_active` verification

## Motivation and Context

`AdminCookieAuthMiddleware` hardcodes `is_active = true` in `AuthState` (JWT has no `is_active` claim). All other admin handlers (list, detail, create, update, delete, fields, export, import) already inject `AdminAuthenticatedUser` which performs a DB lookup and verifies `is_active`. Only `get_dashboard` was missing this check.

Discovered via CI failure in PR #3528: `test_middleware_e2e_inactive_user_jwt_denied` expects 403/500 but got 200.

Fixes #3679
Refs #3528

## How Was This Tested

- `cargo check -p reinhardt-admin --all-features` passes
- The E2E test in PR #3528 (`test_middleware_e2e_inactive_user_jwt_denied`) will pass once this fix is merged into that branch

## Checklist

- [x] Code follows Rust 2024 edition module conventions
- [x] Comments are in English
- [x] No `todo!()` or `// TODO:` added
- [x] Existing tests still compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)