### PR TITLE
fix(pages): suppress check-cfg errors for msw feature in server_fn macro expansion

### DIFF
--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -1083,6 +1083,9 @@ fn generate_server_handler(
 			}
 
 			// MSW: Generate MockableServerFn impl (server-side) when msw feature is enabled
+			// allow(unexpected_cfgs): The `msw` feature is defined in the proc macro's
+			// origin crate, not necessarily in the crate where this macro is expanded.
+			#[allow(unexpected_cfgs)]
 			#[cfg(feature = "msw")]
 			mod __msw {
 				use ::serde::{Serialize, Deserialize};
@@ -1094,9 +1097,11 @@ fn generate_server_handler(
 				}
 			}
 
+			#[allow(unexpected_cfgs)]
 			#[cfg(feature = "msw")]
 			pub use __msw::Args;
 
+			#[allow(unexpected_cfgs)]
 			#[cfg(feature = "msw")]
 			impl #pages_crate::server_fn::MockableServerFn for marker {
 				type Args = Args;
@@ -1106,6 +1111,9 @@ fn generate_server_handler(
 		}
 
 		// MSW: WASM-side marker module with MockableServerFn (standalone, no ServerFnRegistration)
+		// allow(unexpected_cfgs): The `msw` feature is defined in the proc macro's
+		// origin crate, not necessarily in the crate where this macro is expanded.
+		#[allow(unexpected_cfgs)]
 		#[cfg(all(target_family = "wasm", target_os = "unknown", feature = "msw"))]
 		#vis mod #marker_module_name {
 			use ::serde::{Serialize, Deserialize};


### PR DESCRIPTION
## Summary

This PR addresses:

- CI compilation failures in `examples-tutorial-basis`, `examples-twitter`, and `Cargo Check (tests)` jobs on Release PR #3684, caused by `unexpected cfg condition value: "msw"` errors

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `#[server_fn]` proc macro emits `#[cfg(feature = "msw")]` into the expansion site. Since Rust 2024 Edition enables `check-cfg` by default, crates that don't define an `msw` feature (e.g., example crates) fail to compile with `unexpected cfg condition value: "msw"` errors.

This blocks the Release PR #3684 from merging.

Related to: #3684

## How Was This Tested?

- `cargo check -p reinhardt-pages-macros` — passes
- `cargo check -p examples-tutorial-basis` — passes (previously failed with `unexpected cfg` errors)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)