### PR TITLE
test(pages): add FileField and ImageField coverage for typed form macro

### DIFF
--- a/crates/reinhardt-manouche/src/core/form_typed.rs
+++ b/crates/reinhardt-manouche/src/core/form_typed.rs
@@ -1487,18 +1487,24 @@ mod tests {
 		let integer_field = TypedFieldType::IntegerField;
 		let boolean_field = TypedFieldType::BooleanField;
 		let date_field = TypedFieldType::DateField;
+		let file_field = TypedFieldType::FileField;
+		let image_field = TypedFieldType::ImageField;
 
 		// Act
 		let char_type = char_field.rust_type();
 		let integer_type = integer_field.rust_type();
 		let boolean_type = boolean_field.rust_type();
 		let date_type = date_field.rust_type();
+		let file_type = file_field.rust_type();
+		let image_type = image_field.rust_type();
 
 		// Assert
 		assert_eq!(char_type, "String");
 		assert_eq!(integer_type, "i64");
 		assert_eq!(boolean_type, "bool");
 		assert_eq!(date_type, "Option<chrono::NaiveDate>");
+		assert_eq!(file_type, "Option<web_sys::File>");
+		assert_eq!(image_type, "Option<web_sys::File>");
 	}
 
 	#[rstest]
@@ -1508,18 +1514,24 @@ mod tests {
 		let email_field = TypedFieldType::EmailField;
 		let password_field = TypedFieldType::PasswordField;
 		let boolean_field = TypedFieldType::BooleanField;
+		let file_field = TypedFieldType::FileField;
+		let image_field = TypedFieldType::ImageField;
 
 		// Act
 		let char_widget = char_field.default_widget();
 		let email_widget = email_field.default_widget();
 		let password_widget = password_field.default_widget();
 		let boolean_widget = boolean_field.default_widget();
+		let file_widget = file_field.default_widget();
+		let image_widget = image_field.default_widget();
 
 		// Assert
 		assert_eq!(char_widget, TypedWidget::TextInput);
 		assert_eq!(email_widget, TypedWidget::EmailInput);
 		assert_eq!(password_widget, TypedWidget::PasswordInput);
 		assert_eq!(boolean_widget, TypedWidget::CheckboxInput);
+		assert_eq!(file_widget, TypedWidget::FileInput);
+		assert_eq!(image_widget, TypedWidget::FileInput);
 	}
 
 	#[rstest]
@@ -1530,6 +1542,7 @@ mod tests {
 		let password_input = TypedWidget::PasswordInput;
 		let number_input = TypedWidget::NumberInput;
 		let date_input = TypedWidget::DateInput;
+		let file_input = TypedWidget::FileInput;
 
 		// Act
 		let text_type = text_input.html_type();
@@ -1537,6 +1550,7 @@ mod tests {
 		let password_type = password_input.html_type();
 		let number_type = number_input.html_type();
 		let date_type = date_input.html_type();
+		let file_type = file_input.html_type();
 
 		// Assert
 		assert_eq!(text_type, "text");
@@ -1544,6 +1558,7 @@ mod tests {
 		assert_eq!(password_type, "password");
 		assert_eq!(number_type, "number");
 		assert_eq!(date_type, "date");
+		assert_eq!(file_type, "file");
 	}
 
 	#[rstest]
@@ -1551,18 +1566,21 @@ mod tests {
 		// Arrange
 		let text_input = TypedWidget::TextInput;
 		let email_input = TypedWidget::EmailInput;
+		let file_input = TypedWidget::FileInput;
 		let textarea = TypedWidget::Textarea;
 		let select = TypedWidget::Select;
 
 		// Act
 		let text_is_input = text_input.is_input();
 		let email_is_input = email_input.is_input();
+		let file_is_input = file_input.is_input();
 		let textarea_is_input = textarea.is_input();
 		let select_is_input = select.is_input();
 
 		// Assert
 		assert!(text_is_input);
 		assert!(email_is_input);
+		assert!(file_is_input);
 		assert!(!textarea_is_input);
 		assert!(!select_is_input);
 	}
@@ -1573,16 +1591,19 @@ mod tests {
 		let text_input = TypedWidget::TextInput;
 		let textarea = TypedWidget::Textarea;
 		let select = TypedWidget::Select;
+		let file_input = TypedWidget::FileInput;
 
 		// Act
 		let text_tag = text_input.html_tag();
 		let textarea_tag = textarea.html_tag();
 		let select_tag = select.html_tag();
+		let file_tag = file_input.html_tag();
 
 		// Assert
 		assert_eq!(text_tag, "input");
 		assert_eq!(textarea_tag, "textarea");
 		assert_eq!(select_tag, "select");
+		assert_eq!(file_tag, "input");
 	}
 
 	#[rstest]

--- a/crates/reinhardt-pages/macros/src/form/validator.rs
+++ b/crates/reinhardt-pages/macros/src/form/validator.rs
@@ -3725,4 +3725,87 @@ mod tests {
 		assert!(result.is_ok());
 		assert_eq!(result.unwrap(), None);
 	}
+
+	#[rstest::rstest]
+	fn test_validate_file_field() {
+		// Arrange
+		let input = quote! {
+			name: UploadForm,
+			action: "/api/upload",
+
+			fields: {
+				document: FileField {},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_ok());
+		let typed = result.unwrap();
+		assert_eq!(typed.fields.len(), 1);
+		let field = typed.fields[0].as_field().unwrap();
+		assert!(matches!(field.field_type, TypedFieldType::FileField));
+		assert!(matches!(field.widget, TypedWidget::FileInput));
+	}
+
+	#[rstest::rstest]
+	fn test_validate_image_field() {
+		// Arrange
+		let input = quote! {
+			name: AvatarForm,
+			action: "/api/avatar",
+
+			fields: {
+				photo: ImageField {},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_ok());
+		let typed = result.unwrap();
+		assert_eq!(typed.fields.len(), 1);
+		let field = typed.fields[0].as_field().unwrap();
+		assert!(matches!(field.field_type, TypedFieldType::ImageField));
+		assert!(matches!(field.widget, TypedWidget::FileInput));
+	}
+
+	#[rstest::rstest]
+	fn test_validate_form_with_mixed_file_and_text_fields() {
+		// Arrange
+		let input = quote! {
+			name: ProfileForm,
+			action: "/api/profile",
+
+			fields: {
+				name: CharField { required },
+				avatar: ImageField {},
+				resume: FileField {},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_ok());
+		let typed = result.unwrap();
+		assert_eq!(typed.fields.len(), 3);
+		assert!(matches!(
+			typed.fields[0].as_field().unwrap().field_type,
+			TypedFieldType::CharField
+		));
+		assert!(matches!(
+			typed.fields[1].as_field().unwrap().field_type,
+			TypedFieldType::ImageField
+		));
+		assert!(matches!(
+			typed.fields[2].as_field().unwrap().field_type,
+			TypedFieldType::FileField
+		));
+	}
 }


### PR DESCRIPTION
## Summary

- Add missing test coverage for `FileField` and `ImageField` in the reinhardt-pages typed form macro pipeline

## Type of Change

- [x] Code quality improvements

## Motivation and Context

The typed form macro supports `FileField` and `ImageField`, but existing tests only covered `CharField`, `IntegerField`, `BooleanField`, etc. This left the file field code paths unverified across the AST layer and validator layer.

Fixes #3689

## How Was This Tested?

- `cargo test -p reinhardt-manouche --lib -- test_typed` (17 passed)
- `cargo test -p reinhardt-pages-macros --lib -- test_validate_file_field test_validate_image_field test_validate_form_with_mixed` (3 passed)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `code-quality` - Code quality improvements

### Scope Label
- [x] `forms` - Form handling, validation, rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)