### PR TITLE
fix(pages): resolve unexpected cfg(feature = "msw") warnings in consuming crates

### DIFF
--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -126,11 +126,6 @@ toml = { workspace = true }
 wasm-bindgen-test = "0.3.56"
 reinhardt-test = { workspace = true, features = ["wasm"] }
 
-[lints.rust]
-# The `server_fn` proc macro generates `#[cfg(feature = "msw")]` in expanded code.
-# This crate doesn't define `msw` as a feature, so declare it as an expected cfg
-# value to suppress `unexpected_cfgs` warnings from macro expansion.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("msw"))'] }
 
 [build-dependencies]
 cfg_aliases = "0.2"

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -953,6 +953,12 @@ fn generate_server_handler(
 	// and a `use` item with the same name in the same module.
 	let marker_module_name = name.clone();
 
+	// MSW: Check at proc-macro expansion time whether the consuming crate has
+	// the "msw" feature enabled. This avoids emitting #[cfg(feature = "msw")]
+	// in the generated code, which would trigger unexpected_cfgs warnings in
+	// crates that don't declare "msw" as a known feature. (Issue #3673)
+	let msw_enabled = std::env::var("CARGO_FEATURE_MSW").is_ok();
+
 	// MSW: Extract the Ok type from Result<T, ServerFnError> for MockableServerFn::Response
 	let response_type = extract_result_ok_type(return_type);
 
@@ -967,6 +973,61 @@ fn generate_server_handler(
 			}
 		})
 		.collect();
+
+	// MSW: Generate server-side MockableServerFn tokens only when msw feature is enabled
+	let msw_server_tokens = if msw_enabled {
+		quote! {
+			mod __msw {
+				use ::serde::{Serialize, Deserialize};
+
+				/// Public Args struct for MSW type-safe mocking.
+				#[derive(Serialize, Deserialize)]
+				pub struct Args {
+					#(pub #regular_param_names: #regular_param_types),*
+				}
+			}
+
+			pub use __msw::Args;
+
+			impl #pages_crate::server_fn::MockableServerFn for marker {
+				type Args = Args;
+				type Response = #response_type;
+				const INJECTED_PARAMS: &'static [&'static str] = &[#(#inject_param_name_strs),*];
+			}
+		}
+	} else {
+		quote! {}
+	};
+
+	// MSW: Generate WASM-side marker module only when msw feature is enabled
+	let msw_wasm_tokens = if msw_enabled {
+		quote! {
+			#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+			#vis mod #marker_module_name {
+				use ::serde::{Serialize, Deserialize};
+
+				#[doc = concat!("Marker struct for server function `", #name_str, "` (WASM MSW mock target)")]
+				pub struct marker;
+
+				/// Public Args struct for MSW type-safe mocking.
+				#[derive(Serialize, Deserialize)]
+				pub struct Args {
+					#(pub #regular_param_names: #regular_param_types),*
+				}
+
+				impl #pages_crate::server_fn::MockableServerFn for marker {
+					type Args = Args;
+					type Response = #response_type;
+					const PATH: &'static str = #endpoint;
+					const NAME: &'static str = #name_str;
+					const CODEC: &'static str = #codec;
+					const INJECTED_PARAMS: &'static [&'static str] = &[];
+				}
+			}
+		}
+	} else {
+		quote! {}
+	};
 
 	quote! {
 		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
@@ -1082,52 +1143,12 @@ fn generate_server_handler(
 				}
 			}
 
-			// MSW: Generate MockableServerFn impl (server-side) when msw feature is enabled
-			#[cfg(feature = "msw")]
-			mod __msw {
-				use ::serde::{Serialize, Deserialize};
-
-				/// Public Args struct for MSW type-safe mocking.
-				#[derive(Serialize, Deserialize)]
-				pub struct Args {
-					#(pub #regular_param_names: #regular_param_types),*
-				}
-			}
-
-			#[cfg(feature = "msw")]
-			pub use __msw::Args;
-
-			#[cfg(feature = "msw")]
-			impl #pages_crate::server_fn::MockableServerFn for marker {
-				type Args = Args;
-				type Response = #response_type;
-				const INJECTED_PARAMS: &'static [&'static str] = &[#(#inject_param_name_strs),*];
-			}
+			// MSW: server-side MockableServerFn (conditionally generated; Issue #3673)
+			#msw_server_tokens
 		}
 
-		// MSW: WASM-side marker module with MockableServerFn (standalone, no ServerFnRegistration)
-		#[cfg(all(target_family = "wasm", target_os = "unknown", feature = "msw"))]
-		#vis mod #marker_module_name {
-			use ::serde::{Serialize, Deserialize};
-
-			#[doc = concat!("Marker struct for server function `", #name_str, "` (WASM MSW mock target)")]
-			pub struct marker;
-
-			/// Public Args struct for MSW type-safe mocking.
-			#[derive(Serialize, Deserialize)]
-			pub struct Args {
-				#(pub #regular_param_names: #regular_param_types),*
-			}
-
-			impl #pages_crate::server_fn::MockableServerFn for marker {
-				type Args = Args;
-				type Response = #response_type;
-				const PATH: &'static str = #endpoint;
-				const NAME: &'static str = #name_str;
-				const CODEC: &'static str = #codec;
-				const INJECTED_PARAMS: &'static [&'static str] = &[];
-			}
-		}
+		// MSW: WASM-side marker module (conditionally generated; Issue #3673)
+		#msw_wasm_tokens
 	}
 }
 


### PR DESCRIPTION
## Summary

- Resolve `unexpected_cfgs` warnings caused by `server_fn` macro emitting `#[cfg(feature = "msw")]` in consuming crates
- Check `CARGO_FEATURE_MSW` at proc-macro expansion time instead of emitting compile-time cfg gates
- Remove the workaround in `reinhardt-admin/Cargo.toml`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `server_fn` proc macro emitted `#[cfg(feature = "msw")]` in generated code. Consuming crates that don't declare `msw` as a feature get `unexpected_cfgs` warnings. `#[allow(unexpected_cfgs)]` does not suppress these warnings on proc-macro-generated code because the Rust compiler evaluates cfg conditions before processing allow attributes on proc-macro spans.

The fix checks `CARGO_FEATURE_MSW` at proc-macro expansion time and conditionally generates MSW code only when the feature is enabled, eliminating the cfg attribute entirely from generated output.

Fixes #3673

## How Was This Tested?

- `cargo check -p reinhardt-admin --all-features` — confirmed 0 `unexpected_cfgs` warnings for `msw`
- `cargo check -p reinhardt-pages-macros` — macro crate compiles cleanly

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)