### PR TITLE
fix(urls): add UrlResolver trait import to generated url_prelude methods

### DIFF
--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -448,11 +448,14 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 					}
 
 					// Callback macro for __for_each_url_resolver to generate methods.
+					// Each arm imports UrlResolver trait to bring resolve_url() into
+					// scope. (Issue #3669)
 					macro_rules! #gen_method_macro {
 						// No params
 						($app_label:ident, $method:ident, $route_name:literal, ) => {
 							impl #urls_struct<'_> {
 								pub fn $method(&self) -> String {
+									use #reinhardt::UrlResolver as _;
 									self.resolver.resolve_url(
 										concat!(stringify!($app_label), ":", $route_name),
 										&[],
@@ -464,6 +467,7 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 						($app_label:ident, $method:ident, $route_name:literal, $p1:literal) => {
 							impl #urls_struct<'_> {
 								pub fn $method(&self, p1: &str) -> String {
+									use #reinhardt::UrlResolver as _;
 									self.resolver.resolve_url(
 										concat!(stringify!($app_label), ":", $route_name),
 										&[($p1, p1)],
@@ -475,6 +479,7 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 						($app_label:ident, $method:ident, $route_name:literal, $p1:literal, $p2:literal) => {
 							impl #urls_struct<'_> {
 								pub fn $method(&self, p1: &str, p2: &str) -> String {
+									use #reinhardt::UrlResolver as _;
 									self.resolver.resolve_url(
 										concat!(stringify!($app_label), ":", $route_name),
 										&[($p1, p1), ($p2, p2)],
@@ -486,6 +491,7 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 						($app_label:ident, $method:ident, $route_name:literal, $p1:literal, $p2:literal, $p3:literal) => {
 							impl #urls_struct<'_> {
 								pub fn $method(&self, p1: &str, p2: &str, p3: &str) -> String {
+									use #reinhardt::UrlResolver as _;
 									self.resolver.resolve_url(
 										concat!(stringify!($app_label), ":", $route_name),
 										&[($p1, p1), ($p2, p2), ($p3, p3)],
@@ -497,6 +503,7 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 						($app_label:ident, $method:ident, $route_name:literal, $p1:literal, $p2:literal, $p3:literal, $p4:literal) => {
 							impl #urls_struct<'_> {
 								pub fn $method(&self, p1: &str, p2: &str, p3: &str, p4: &str) -> String {
+									use #reinhardt::UrlResolver as _;
 									self.resolver.resolve_url(
 										concat!(stringify!($app_label), ":", $route_name),
 										&[($p1, p1), ($p2, p2), ($p3, p3), ($p4, p4)],
@@ -508,6 +515,7 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 						($app_label:ident, $method:ident, $route_name:literal, $p1:literal, $p2:literal, $p3:literal, $p4:literal, $p5:literal) => {
 							impl #urls_struct<'_> {
 								pub fn $method(&self, p1: &str, p2: &str, p3: &str, p4: &str, p5: &str) -> String {
+									use #reinhardt::UrlResolver as _;
 									self.resolver.resolve_url(
 										concat!(stringify!($app_label), ":", $route_name),
 										&[($p1, p1), ($p2, p2), ($p3, p3), ($p4, p4), ($p5, p5)],


### PR DESCRIPTION
## Summary

- Add `use reinhardt::UrlResolver as _;` inside each method body of the `__gen_*_method` callback macro generated by `#[routes]`
- This fixes the "no method named `resolve_url` found" error when using non-standalone `#[routes]` with url_prelude generation

**Note:** This PR addresses Issue 2 of #3669 (missing UrlResolver trait import). Issue 1 (incorrect `__url_resolver_*` import paths for multi-file views) requires a design decision and will be addressed separately.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `__gen_*_method` callback macro generated by `#[routes]` calls `self.resolver.resolve_url()`, which is a method on the `UrlResolver` trait. Without the trait in scope, Rust cannot find the method, resulting in a compile error. The fix adds a scoped import of the trait inside each generated method body.

Fixes #3669 (partial — Issue 2 of 2)

## How Was This Tested?

- `cargo check -p reinhardt-macros` — macro crate compiles cleanly
- The generated code now includes `use reinhardt::UrlResolver as _;` in each method arm

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `routing` - URL routing, path matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)