### PR TITLE
fix(ci): add missing Docker images to pre-pull lists

### DIFF
--- a/.github/docker-images-cross-crate.txt
+++ b/.github/docker-images-cross-crate.txt
@@ -8,6 +8,12 @@ mysql:8.0
 
 # Cache/Key-Value Stores
 redis:7-alpine
+memcached:1.6-alpine
+grokzen/redis-cluster:7.0.10
+neohq/redis-cluster:latest
+
+# Databases (additional)
+cockroachdb/cockroach:v23.1.0
 
 # Message Queues
 rabbitmq:3-management-alpine

--- a/.github/docker-images-intra-crate.txt
+++ b/.github/docker-images-intra-crate.txt
@@ -7,6 +7,7 @@ postgres:17-alpine
 
 # Cache/Key-Value Stores
 redis:7-alpine
+memcached:1.6-alpine
 
 # Message Queues
 rabbitmq:3-management-alpine


### PR DESCRIPTION
## Summary

- Add 4 missing Docker images to pre-pull list files that were causing Docker Hub rate limit errors in CI
- `memcached:1.6-alpine`, `cockroachdb/cockroach:v23.1.0`, `grokzen/redis-cluster:7.0.10`, `neohq/redis-cluster:latest` added to `docker-images-cross-crate.txt`
- `memcached:1.6-alpine` added to `docker-images-intra-crate.txt`

Fixes #3698

## Test plan

- [ ] CI integration tests no longer hit Docker Hub rate limits for these images
- [x] Verified all images are referenced in TestContainers code via `GenericImage::new(...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)