### PR TITLE
fix(pages): add compile-time guard for msw cfg and re-export export_endpoints

### DIFF
--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -955,10 +955,10 @@ fn generate_server_handler(
 
 	// MSW: Generate MockableServerFn impl only when BOTH conditions are met:
 	// 1. The macro crate was compiled with `msw` feature (compile-time guard)
-	// 2. The consuming crate has `msw` feature enabled (runtime env var check)
+	// 2. The consuming crate has `msw` feature enabled (proc-macro expansion-time env var check)
 	//
-	// The compile-time guard (`cfg!`) eliminates the MSW code path entirely when
-	// the macro crate is built without `msw`, preventing any possibility of
+	// The compile-time guard (`cfg!`) avoids the MSW branch during proc-macro expansion
+	// when the macro crate is built without `msw`, preventing any possibility of
 	// env var leakage from the dependency graph. The env var check handles the
 	// case where the macro crate has `msw` but the consuming crate does not.
 	// This avoids emitting `#[cfg(feature = "msw")]` in generated code, which

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -953,11 +953,17 @@ fn generate_server_handler(
 	// and a `use` item with the same name in the same module.
 	let marker_module_name = name.clone();
 
-	// MSW: Check at proc-macro expansion time whether the consuming crate has
-	// the "msw" feature enabled. This avoids emitting #[cfg(feature = "msw")]
-	// in the generated code, which would trigger unexpected_cfgs warnings in
-	// crates that don't declare "msw" as a known feature. (Issue #3673)
-	let msw_enabled = std::env::var("CARGO_FEATURE_MSW").is_ok();
+	// MSW: Generate MockableServerFn impl only when BOTH conditions are met:
+	// 1. The macro crate was compiled with `msw` feature (compile-time guard)
+	// 2. The consuming crate has `msw` feature enabled (runtime env var check)
+	//
+	// The compile-time guard (`cfg!`) eliminates the MSW code path entirely when
+	// the macro crate is built without `msw`, preventing any possibility of
+	// env var leakage from the dependency graph. The env var check handles the
+	// case where the macro crate has `msw` but the consuming crate does not.
+	// This avoids emitting `#[cfg(feature = "msw")]` in generated code, which
+	// would trigger unexpected_cfgs warnings in consuming crates. (Issue #3673, #3700)
+	let msw_enabled = cfg!(feature = "msw") && std::env::var("CARGO_FEATURE_MSW").is_ok();
 
 	// MSW: Extract the Ok type from Result<T, ServerFnError> for MockableServerFn::Response
 	let response_type = extract_result_ok_type(return_type);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,8 @@ pub use reinhardt_macros::routes;
 pub use reinhardt_macros::url_patterns;
 #[cfg(native)]
 pub use reinhardt_macros::viewset;
+#[cfg(native)]
+pub use reinhardt_macros::export_endpoints;
 
 // client_routes! proc macro removed: superseded by #[url_patterns(client = true)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,13 +289,13 @@ pub use reinhardt_macros::{api_view, delete, get, patch, post, put};
 
 // Re-export routes attribute macro for URL pattern registration
 #[cfg(native)]
+pub use reinhardt_macros::export_endpoints;
+#[cfg(native)]
 pub use reinhardt_macros::routes;
 #[cfg(native)]
 pub use reinhardt_macros::url_patterns;
 #[cfg(native)]
 pub use reinhardt_macros::viewset;
-#[cfg(native)]
-pub use reinhardt_macros::export_endpoints;
 
 // client_routes! proc macro removed: superseded by #[url_patterns(client = true)]
 


### PR DESCRIPTION
## Summary

- Add `cfg!(feature = "msw")` compile-time guard to `#[server_fn]` macro's MSW code generation, preventing env var leakage from the dependency graph
- Re-export `export_endpoints` proc macro from the reinhardt facade crate

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

**#3700**: The `#[server_fn]` macro uses `std::env::var("CARGO_FEATURE_MSW")` at expansion time to conditionally generate MSW code. Adding a `cfg!(feature = "msw")` compile-time guard ensures the MSW code path is completely eliminated when the macro crate is built without `msw`, preventing any possibility of env var leakage.

> **Note**: #3700 could not be reproduced with Rust 1.94.1 on macOS. The env var approach from PR #3692 appears to work correctly. This fix adds a defensive compile-time guard as an additional safety measure.

**#3701**: The `#[export_endpoints]` proc macro was defined in `reinhardt_macros` but not re-exported from the `reinhardt` facade crate, making `#![reinhardt::export_endpoints]` unusable in consuming crates.

Fixes #3700
Fixes #3701

## How Was This Tested?

- `cargo check --workspace --all --all-features` passes
- `cargo test -p reinhardt-pages --all-features -- server_fn` passes
- Verified `export_endpoints` is accessible as `reinhardt::export_endpoints`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- #3692 (original msw cfg fix)
- #3695 (PR that added export_endpoints)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)