### PR TITLE
ci: fix Docker Hub rate limits via pre-pull cache drift cleanup

### DIFF
--- a/.github/docker-images-cross-crate.txt
+++ b/.github/docker-images-cross-crate.txt
@@ -14,9 +14,13 @@ neohq/redis-cluster:latest
 
 # Databases (additional)
 cockroachdb/cockroach:v23.1.0
+mongo:7.0
 
 # Message Queues
 rabbitmq:3-management-alpine
 
 # Email Testing
 axllent/mailpit:latest
+
+# AWS Service Mock
+localstack/localstack:latest

--- a/.github/docker-images-intra-crate.txt
+++ b/.github/docker-images-intra-crate.txt
@@ -14,3 +14,6 @@ rabbitmq:3-management-alpine
 
 # Email Testing
 axllent/mailpit:latest
+
+# Headless Browser (E2E CDP tests)
+chromedp/headless-shell:latest

--- a/crates/reinhardt-testkit/src/containers.rs
+++ b/crates/reinhardt-testkit/src/containers.rs
@@ -630,7 +630,7 @@ impl RabbitMQContainer {
 	pub async fn with_credentials(username: &str, password: &str) -> Self {
 		use testcontainers::core::IntoContainerPort;
 
-		let image = GenericImage::new("rabbitmq", "3.12-management-alpine")
+		let image = GenericImage::new("rabbitmq", "3-management-alpine")
 			.with_exposed_port(5672.tcp())      // AMQP port
 			.with_exposed_port(15672.tcp())     // Management UI port
 			.with_wait_for(WaitFor::message_on_stdout("Server startup complete"))


### PR DESCRIPTION
## Summary

- Align RabbitMQ image tag used by testkit fixture to the tag already pre-pulled in `.github/docker-images-*.txt` (`rabbitmq:3-management-alpine`), instead of the unmatched `3.12-management-alpine`.
- Add three runtime-only Docker images to the pre-pull cache lists so they are fetched via authenticated Docker Hub login rather than anonymously at test runtime:
  - `mongo:7.0` (MongoDB fixture) → `docker-images-cross-crate.txt`
  - `localstack/localstack:latest` (AWS service mock) → `docker-images-cross-crate.txt`
  - `chromedp/headless-shell:latest` (E2E CDP headless browser) → `docker-images-intra-crate.txt`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

PR #3717 CI failed on Unit Tests and Intra-Crate Integration Tests with Docker Hub `toomanyrequests` (HTTP 429) errors. Root-cause analysis showed these images are referenced by TestContainers fixtures at runtime but are not covered by the authenticated pre-pull cache (`.github/actions/pull-docker-images`), so they are fetched anonymously during the test and trip the rate limit.

Follow-up to #3698 (which addressed memcached, cockroachdb, and redis-cluster drift).

Fixes #3720

## How Was This Tested?

- [x] `cargo check -p reinhardt-testkit --features testcontainers` passes
- [x] Pre-pull list files validated by hand (format: one image per line, comments preserved)
- [ ] Full CI on this branch will verify that the new images are reachable through Docker Hub authenticated pulls

## Breaking Changes

None. RabbitMQ `3-management-alpine` is already the tag used by all other in-repo fixtures (`tests/integration/tests/utils/tasks_rabbitmq_backend_integration.rs`, `crates/reinhardt-testkit/src/fixtures/testcontainers.rs`).

## Related Issues

Fixes #3720
Refs #3698 #3717

## Labels to Apply

- `bug`
- `ci-cd`
- `high`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)