### PR TITLE
fix(macros): use resolve_from_registry() for #[get]/#[post]/#[server_fn] factory compatibility

### DIFF
--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -6,6 +6,7 @@ use crate::crate_paths::{
 };
 use crate::injectable_common::{InjectOptions, is_inject_attr, parse_inject_options};
 use crate::path_macro;
+use crate::routes_registration::extract_depends_inner_type;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
@@ -418,6 +419,12 @@ fn generate_wrapper_with_both(
 	};
 
 	// Generate injection calls
+	//
+	// For `Depends<T>` parameters we resolve via `resolve_from_registry()`, which
+	// has no `T: Injectable` trait bound. This allows factory-produced types
+	// (registered via `#[injectable_factory]`) to be injected without manually
+	// implementing `Injectable`. This mirrors the fix applied to `#[routes]` in
+	// commit `98adb15b9` (see routes_registration.rs).
 	let injection_calls: Vec<_> = inject_params
 		.iter()
 		.map(|param| {
@@ -425,16 +432,15 @@ fn generate_wrapper_with_both(
 			let ty = &param.ty;
 			let use_cache = param.options.use_cache;
 
-			if use_cache {
+			if let Some(inner_ty) = extract_depends_inner_type(ty) {
 				quote! {
-					let #pat: #ty = #di_crate::Depends::<#ty>::resolve(&__di_ctx, true)
+					let #pat: #ty = #di_crate::Depends::<#inner_ty>::resolve_from_registry(&__di_ctx, #use_cache)
 						.await
-						.map_err(#core_crate::exception::Error::from)?
-						.into_inner();
+						.map_err(#core_crate::exception::Error::from)?;
 				}
 			} else {
 				quote! {
-					let #pat: #ty = #di_crate::Depends::<#ty>::resolve(&__di_ctx, false)
+					let #pat: #ty = #di_crate::Depends::<#ty>::resolve(&__di_ctx, #use_cache)
 						.await
 						.map_err(#core_crate::exception::Error::from)?
 						.into_inner();

--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -141,7 +141,7 @@ fn is_inject_attr(attr: &syn::Attribute) -> bool {
 /// Extract the inner type `T` from `Depends<T>`.
 ///
 /// Returns `Some(T)` if the type is `Depends<T>`, `None` otherwise.
-fn extract_depends_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
+pub(crate) fn extract_depends_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
 	if let syn::Type::Path(type_path) = ty {
 		let last_segment = type_path.path.segments.last()?;
 		if last_segment.ident == "Depends"

--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -141,6 +141,9 @@ fn is_inject_attr(attr: &syn::Attribute) -> bool {
 /// Extract the inner type `T` from `Depends<T>`.
 ///
 /// Returns `Some(T)` if the type is `Depends<T>`, `None` otherwise.
+/// A sibling copy lives in `crates/reinhardt-pages/macros/src/server_fn.rs`;
+/// the two proc-macro crates cannot share code directly, so keep both copies
+/// in sync.
 pub(crate) fn extract_depends_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
 	if let syn::Type::Path(type_path) = ty {
 		let last_segment = type_path.path.segments.last()?;

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -23,6 +23,24 @@ use crate::crate_paths::{
 	get_reinhardt_pages_crate, get_reinhardt_pages_crate_info,
 };
 
+/// Extract the inner type `T` from `Depends<T>`.
+///
+/// Returns `Some(T)` if the type is `Depends<T>`, `None` otherwise.
+/// Mirrors the helper in `reinhardt-core/macros/src/routes_registration.rs`.
+fn extract_depends_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
+	if let syn::Type::Path(type_path) = ty {
+		let last_segment = type_path.path.segments.last()?;
+		if last_segment.ident == "Depends"
+			&& let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
+			&& args.args.len() == 1
+			&& let syn::GenericArgument::Type(inner) = args.args.first()?
+		{
+			return Some(inner);
+		}
+	}
+	None
+}
+
 /// Convert snake_case identifier to UpperCamelCase for struct naming
 ///
 /// # Examples
@@ -738,9 +756,8 @@ fn generate_server_handler(
 	let regular_param_names: Vec<_> = regular_params.iter().map(|p| &p.pat).collect();
 	let regular_param_types: Vec<_> = regular_params.iter().map(|p| &p.ty).collect();
 
-	// Extract inject parameter names and types
+	// Extract inject parameter names (types handled per-param in di_resolution below)
 	let inject_param_names: Vec<_> = inject_params.iter().map(|p| &p.pat).collect();
-	let inject_param_types: Vec<_> = inject_params.iter().map(|p| &p.ty).collect();
 
 	// Generate unique names to avoid conflicts
 	let handler_name = quote::format_ident!("__server_fn_handler_{}", name);
@@ -762,11 +779,60 @@ fn generate_server_handler(
 	};
 
 	// Generate DI resolution code
-	// Pattern copied from reinhardt-core/crates/macros/src/use_inject.rs
+	//
+	// For `Depends<T>` parameters we resolve via `resolve_from_registry()`, which
+	// has no `T: Injectable` trait bound. This allows factory-produced types
+	// (registered via `#[injectable_factory]`) to be injected without manually
+	// implementing `Injectable`. This mirrors the fix applied to `#[routes]` in
+	// commit `98adb15b9`.
 	let di_resolution = if !inject_params.is_empty() {
 		// Dynamically resolve crate paths
 		let di_crate = get_reinhardt_di_crate();
 		let pages_crate_for_di = get_reinhardt_pages_crate();
+
+		let param_resolutions: Vec<_> = inject_params
+			.iter()
+			.map(|p| {
+				let pat = &p.pat;
+				let ty = &p.ty;
+				if let Some(inner_ty) = extract_depends_inner_type(&p.ty) {
+					quote! {
+						let #pat: #ty =
+							#di_crate::Depends::<#inner_ty>::resolve_from_registry(&__di_ctx, true)
+								.await
+								.map_err(|e| {
+									// Preserve HTTP status codes for auth-related DI errors
+									let (status, msg) = match &e {
+										#di_crate::DiError::Authentication(m) => (401u16, m.clone()),
+										#di_crate::DiError::Authorization(m) => (403u16, m.clone()),
+										other => (500u16, format!("Dependency injection failed for {}: {:?}", stringify!(#ty), other)),
+									};
+									let server_err = #pages_crate_for_di::server_fn::ServerFnError::server(status, msg);
+									::serde_json::to_string(&server_err)
+										.unwrap_or_else(|_| format!("Dependency injection failed for {}: {:?}", stringify!(#ty), e))
+								})?;
+					}
+				} else {
+					quote! {
+						let #pat: #ty =
+							#di_crate::Depends::<#ty>::resolve(&__di_ctx, true)
+								.await
+								.map_err(|e| {
+									// Preserve HTTP status codes for auth-related DI errors
+									let (status, msg) = match &e {
+										#di_crate::DiError::Authentication(m) => (401u16, m.clone()),
+										#di_crate::DiError::Authorization(m) => (403u16, m.clone()),
+										other => (500u16, format!("Dependency injection failed for {}: {:?}", stringify!(#ty), other)),
+									};
+									let server_err = #pages_crate_for_di::server_fn::ServerFnError::server(status, msg);
+									::serde_json::to_string(&server_err)
+										.unwrap_or_else(|_| format!("Dependency injection failed for {}: {:?}", stringify!(#ty), e))
+								})?
+								.into_inner();
+					}
+				}
+			})
+			.collect();
 
 		quote! {
 			// Get DI context from request and fork for per-request isolation
@@ -777,24 +843,8 @@ fn generate_server_handler(
 				::std::sync::Arc::new((*__shared_ctx).fork_for_request(__di_request))
 			};
 
-			// Resolve each #[inject] parameter using reinhardt_di::Depends<T>
-			#(
-				let #inject_param_names: #inject_param_types =
-					#di_crate::Depends::<#inject_param_types>::resolve(&__di_ctx, true)
-						.await
-						.map_err(|e| {
-							// Preserve HTTP status codes for auth-related DI errors
-							let (status, msg) = match &e {
-								#di_crate::DiError::Authentication(m) => (401u16, m.clone()),
-								#di_crate::DiError::Authorization(m) => (403u16, m.clone()),
-								other => (500u16, format!("Dependency injection failed for {}: {:?}", stringify!(#inject_param_types), other)),
-							};
-							let server_err = #pages_crate_for_di::server_fn::ServerFnError::server(status, msg);
-							::serde_json::to_string(&server_err)
-								.unwrap_or_else(|_| format!("Dependency injection failed for {}: {:?}", stringify!(#inject_param_types), e))
-						})?
-						.into_inner();
-			)*
+			// Resolve each #[inject] parameter
+			#(#param_resolutions)*
 		}
 	} else {
 		quote! {}

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -26,7 +26,10 @@ use crate::crate_paths::{
 /// Extract the inner type `T` from `Depends<T>`.
 ///
 /// Returns `Some(T)` if the type is `Depends<T>`, `None` otherwise.
-/// Mirrors the helper in `reinhardt-core/macros/src/routes_registration.rs`.
+/// Mirrors the helper in `crates/reinhardt-core/macros/src/routes_registration.rs`.
+/// Keep this implementation in sync with that file; the two proc-macro crates
+/// cannot share code directly without introducing a new non-proc-macro helper
+/// crate, and the helper is small enough that duplication is preferred.
 fn extract_depends_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
 	if let syn::Type::Path(type_path) = ty {
 		let last_segment = type_path.path.segments.last()?;

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -804,15 +804,25 @@ fn generate_server_handler(
 							#di_crate::Depends::<#inner_ty>::resolve_from_registry(&__di_ctx, true)
 								.await
 								.map_err(|e| {
-									// Preserve HTTP status codes for auth-related DI errors
+									// Auth errors (401/403) expose framework-provided user-facing
+									// messages. Any other DI failure is treated as an internal
+									// error: the detailed cause is logged server-side, and the
+									// client receives a generic message to avoid leaking internals.
 									let (status, msg) = match &e {
 										#di_crate::DiError::Authentication(m) => (401u16, m.clone()),
 										#di_crate::DiError::Authorization(m) => (403u16, m.clone()),
-										other => (500u16, format!("Dependency injection failed for {}: {:?}", stringify!(#ty), other)),
+										other => {
+											::tracing::error!(
+												error = ?other,
+												param = stringify!(#ty),
+												"Dependency injection failed",
+											);
+											(500u16, "Internal server error".to_string())
+										}
 									};
 									let server_err = #pages_crate_for_di::server_fn::ServerFnError::server(status, msg);
 									::serde_json::to_string(&server_err)
-										.unwrap_or_else(|_| format!("Dependency injection failed for {}: {:?}", stringify!(#ty), e))
+										.unwrap_or_else(|_| "Internal server error".to_string())
 								})?;
 					}
 				} else {
@@ -821,15 +831,25 @@ fn generate_server_handler(
 							#di_crate::Depends::<#ty>::resolve(&__di_ctx, true)
 								.await
 								.map_err(|e| {
-									// Preserve HTTP status codes for auth-related DI errors
+									// Auth errors (401/403) expose framework-provided user-facing
+									// messages. Any other DI failure is treated as an internal
+									// error: the detailed cause is logged server-side, and the
+									// client receives a generic message to avoid leaking internals.
 									let (status, msg) = match &e {
 										#di_crate::DiError::Authentication(m) => (401u16, m.clone()),
 										#di_crate::DiError::Authorization(m) => (403u16, m.clone()),
-										other => (500u16, format!("Dependency injection failed for {}: {:?}", stringify!(#ty), other)),
+										other => {
+											::tracing::error!(
+												error = ?other,
+												param = stringify!(#ty),
+												"Dependency injection failed",
+											);
+											(500u16, "Internal server error".to_string())
+										}
 									};
 									let server_err = #pages_crate_for_di::server_fn::ServerFnError::server(status, msg);
 									::serde_json::to_string(&server_err)
-										.unwrap_or_else(|_| format!("Dependency injection failed for {}: {:?}", stringify!(#ty), e))
+										.unwrap_or_else(|_| "Internal server error".to_string())
 								})?
 								.into_inner();
 					}


### PR DESCRIPTION
## Summary

- HTTP method macros (`#[get]`, `#[post]`, `#[put]`, `#[delete]`, `#[patch]`) and `#[server_fn]` generated `Depends::<T>::resolve(...)`, which requires `T: Injectable` and fails for factory-produced types registered via `#[injectable_factory]`.
- Switched the `Depends<T>` injection path to `resolve_from_registry()` (no trait bound), mirroring the fix applied to `#[routes]` in PR #3534 / commit `98adb15b9`.
- Parameters that are not wrapped in `Depends<T>` keep the original `Depends::<T>::resolve()` path for backward compatibility.

## Motivation

Before this PR, the following pattern failed to compile:

```rust
pub struct AuthTokenConfig {
    pub secret_key: String,
    pub base_url: String,
}

#[injectable_factory(scope = "singleton")]
async fn create_auth_token_config() -> AuthTokenConfig {
    AuthTokenConfig { secret_key: "...".into(), base_url: "http://localhost:8000".into() }
}

#[get("/verify-email/{token}/", name = "auth_verify_email")]
pub async fn verify_email(
    Path(token): Path<String>,
    #[inject] cfg: Depends<AuthTokenConfig>,
) -> ViewResult<Response> {
    // ...
    Ok(Response::ok())
}
```

Error: `the trait bound `AuthTokenConfig: Injectable` is not satisfied`.

## Changes

| File | Change |
|------|--------|
| `crates/reinhardt-core/macros/src/routes_registration.rs` | Promote `extract_depends_inner_type` to `pub(crate)` for reuse by sibling module. |
| `crates/reinhardt-core/macros/src/routes.rs` | Branch on `Depends<T>` vs plain `T`; use `resolve_from_registry` for the former. |
| `crates/reinhardt-pages/macros/src/server_fn.rs` | Duplicate `extract_depends_inner_type` helper locally (separate proc-macro crate) and apply the same branching. |

## Test plan

- [x] `cargo check --workspace --all-features` succeeds (verified, full workspace including `reinhardt-admin` which uses `#[inject] Depends<AdminSite>` inside `#[server_fn]`).
- [x] `cargo nextest run -p reinhardt-macros -p reinhardt-pages-macros --all-features --no-fail-fast` — 450/452 pass; the 2 failing `url_patterns` tests are pre-existing on `main` and unrelated to this change.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] Verify the issue's reproduction code compiles end-to-end against this branch (manual).
- [ ] Copilot review pass.

## Related

- Fixes #3723
- Mirrors the fix in PR #3534 (commit `98adb15b9`) for `#[routes]`
- Cross-referenced downstream in kent8192/reinhardt-cloud#356

🤖 Generated with [Claude Code](https://claude.com/claude-code)