### PR TITLE
fix(admin-cli): treat missing page! as no-op, not skip

### DIFF
--- a/crates/reinhardt-admin-cli/src/ast_formatter.rs
+++ b/crates/reinhardt-admin-cli/src/ast_formatter.rs
@@ -37,8 +37,6 @@ use syn::{ExprMacro, Macro, parse_file};
 pub(crate) enum SkipReason {
 	/// File-wide ignore-all marker detected
 	FileWideMarker,
-	/// No page! macro found in file
-	NoPageMacro,
 	/// All page! macros were individually ignored
 	AllMacrosIgnored,
 }
@@ -47,7 +45,6 @@ impl std::fmt::Display for SkipReason {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			SkipReason::FileWideMarker => write!(f, "file-wide ignore marker"),
-			SkipReason::NoPageMacro => write!(f, "no page! macro"),
 			SkipReason::AllMacrosIgnored => write!(f, "all macros ignored"),
 		}
 	}

--- a/crates/reinhardt-admin-cli/src/ast_formatter.rs
+++ b/crates/reinhardt-admin-cli/src/ast_formatter.rs
@@ -437,12 +437,13 @@ impl AstPageFormatter {
 	/// Uses AST parsing for accurate macro detection. Falls back to returning
 	/// the original content if parsing fails.
 	pub(crate) fn format(&self, content: &str) -> Result<FormatResult, String> {
-		// Safety check FIRST: If no page! pattern exists, return unchanged
+		// Safety check FIRST: If no page! pattern exists, return unchanged.
+		// This is a successful no-op, not an intentional skip — skipped stays None.
 		if !content.contains("page!(") {
 			return Ok(FormatResult {
 				content: content.to_string(),
 				contains_page_macro: false,
-				skipped: Some(SkipReason::NoPageMacro),
+				skipped: None,
 			});
 		}
 
@@ -459,11 +460,12 @@ impl AstPageFormatter {
 		let macros = self.find_page_macros(content)?;
 
 		if macros.is_empty() {
-			// Safety check passed but no actual macros found (e.g., in comments)
+			// Substring matched but AST found no real invocation (e.g., inside
+			// a comment or string literal). Successful no-op, not a skip.
 			return Ok(FormatResult {
 				content: content.to_string(),
 				contains_page_macro: false,
-				skipped: Some(SkipReason::NoPageMacro),
+				skipped: None,
 			});
 		}
 

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -703,25 +703,17 @@ fn run_fmt(
 				Ok(result) => {
 					// Check if formatting was skipped
 					if let Some(reason) = &result.skipped {
-						use crate::ast_formatter::SkipReason;
-						match reason {
-							SkipReason::NoPageMacro => {
-								// Skip files without page! macros (no logging, no counting)
-								continue;
-							}
-							SkipReason::FileWideMarker | SkipReason::AllMacrosIgnored => {
-								// Log ignored files with reason
-								ignored_count += 1;
-								println!(
-									"{} {} {} ({})",
-									progress.bright_blue(),
-									"Ignored:".yellow(),
-									display_path(file_path),
-									reason
-								);
-								continue;
-							}
-						}
+						// All remaining SkipReason variants represent intentional
+						// ignore directives — log and count them.
+						ignored_count += 1;
+						println!(
+							"{} {} {} ({})",
+							progress.bright_blue(),
+							"Ignored:".yellow(),
+							display_path(file_path),
+							reason
+						);
+						continue;
 					}
 					result.content
 				}


### PR DESCRIPTION
## Summary

Fixes a contract mismatch in `AstPageFormatter::format()` where plain Rust input without a `page!` macro was marked `skipped = Some(SkipReason::NoPageMacro)`. The documented contract is that `Some(_)` means the formatter *intentionally* skipped due to an ignore directive (`// reinhardt-fmt: ignore-all` or per-macro ignore markers); plain absence of `page!` is a successful no-op and should be `None`.

This PR addresses:

- Change `format()` to return `skipped: None` when the input contains no `page!(` substring (L441) and when AST parsing finds no actual invocations (L461)
- Remove the now-unreachable `SkipReason::NoPageMacro` enum variant and its Display arm
- Collapse the `main.rs` consumer match since the remaining variants (`FileWideMarker`, `AllMacrosIgnored`) share log-and-count behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Motivation and Context

`test_contains_page_macro_field_without_macro` in `crates/reinhardt-admin-cli/src/ast_formatter.rs:2406` was failing on `main` (independently verified on commit `54435116`). For input `fn main() { println!("test"); }` the test asserts `result.skipped.is_none()`, but `format()` was returning `Some(SkipReason::NoPageMacro)`.

Root cause: commit `5297e6404` (Dec 29, 2025) introduced skip-tracking logic that marked absence of `page!` as a skip reason; commit `120f7d74f` (Mar 30, 2026) added assertions to ~24 tests expecting `skipped.is_none()` for non-skip cases, exposing the mismatch. The contract is unambiguous when read against sibling tests (`test_no_change_non_page` L1632, `test_ignore_all_with_page_macro` L2419), and the sole consumer in `main.rs:708` already `continue`d silently on `NoPageMacro` — behaviorally equivalent to "no skip happened".

Fixes #3732

## How Was This Tested?

- [x] `cargo test -p reinhardt-admin-cli --bin reinhardt-admin test_contains_page_macro_field_without_macro` → 1 passed; 0 failed
- [x] `cargo test -p reinhardt-admin-cli --bin reinhardt-admin ast_formatter::tests` → 82 passed; 0 failed (full module)
- [x] `cargo test -p reinhardt-admin-cli` → 89 passed; 0 failed (crate-wide)
- [x] `cargo clippy -p reinhardt-admin-cli -- -D warnings` → clean (no dead-code warning for removed variant)
- [x] `cargo fmt --check -p reinhardt-admin-cli` → clean

## Breaking Changes

None. `SkipReason` is `pub(crate)` and only used internally in the admin-cli crate. The `NoPageMacro` variant had no external consumers.

## Checklist

- [x] Two small, bisectable commits (behavioral fix + cleanup) with conventional-commit format
- [x] Each commit references `Fixes #3732`
- [x] Branch follows `fix/issue-3732-<desc>` naming
- [x] No new `todo!()` / `// TODO:` / `// FIXME:` introduced
- [x] English-only content per `LR-1`

## Labels to Apply

- `bug`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)