### PR TITLE
fix(ci): skip bin-only packages in unit-tests --lib matrix

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -150,12 +150,30 @@ jobs:
           # Build package selection args. Issue #2878
           # When run-all is true or no cargo-packages provided, use --workspace.
           # Otherwise, use -p flags to compile only affected packages + rdeps.
+          #
+          # `cargo test --lib -p <bin-only-pkg>` errors with "no library targets
+          # found" (see issue #3734), so filter out packages that lack a library
+          # target before building the -p list. `--workspace --lib` is itself
+          # tolerant of bin-only members and only tests the packages that do
+          # have a lib, so the fallback path is unaffected.
           PKG_ARGS=()
           if [[ "$RUN_ALL" != "true" && -n "$CARGO_PACKAGES" ]]; then
+            METADATA_JSON="$(cargo metadata --format-version 1 --no-deps)"
             while IFS= read -r pkg; do
               [[ -z "$pkg" ]] && continue
-              PKG_ARGS+=(-p "$pkg")
+              has_lib="$(jq -r --arg pkg "$pkg" \
+                '[.packages[] | select(.name==$pkg) | .targets[] | select(.kind | index("lib"))] | length > 0' \
+                <<< "$METADATA_JSON")"
+              if [[ "$has_lib" == "true" ]]; then
+                PKG_ARGS+=(-p "$pkg")
+              else
+                echo "Skipping bin-only package for --lib unit tests: $pkg"
+              fi
             done <<< "$CARGO_PACKAGES"
+            if [[ ${#PKG_ARGS[@]} -eq 0 ]]; then
+              echo "No affected packages expose a library target; nothing to test in this job."
+              exit 0
+            fi
           fi
           if [[ ${#PKG_ARGS[@]} -eq 0 ]]; then
             PKG_ARGS=(--workspace)


### PR DESCRIPTION
## Summary

- Fix `Unit Tests` reusable workflow to skip bin-only packages when building per-package `-p` flags for `cargo nextest run --lib`.
- Use `cargo metadata` + `jq` to detect library targets; exit the job cleanly if no affected package exposes one.
- `--workspace --lib` is tolerant of bin-only members, so the full-workspace fallback path is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`cargo test --lib -p <bin-only-pkg>` exits with `error: no library targets found in package <pkg>`. Whenever the affected-packages list includes a bin-only crate such as `reinhardt-admin-cli` (declared `[[bin]] name = "reinhardt-admin"` with only `src/main.rs`), the `Unit Tests (2/2)` job fails and blocks PRs that legitimately touch those crates.

Example failure: https://github.com/kent8192/reinhardt-web/actions/runs/24564657146/job/71828564590

## How Was This Tested

- Locally ran the new filter against real workspace metadata:
  ```
  reinhardt-admin-cli: has_lib=false
  reinhardt-core:      has_lib=true
  reinhardt-urls:      has_lib=true
  ```
- Confirmed bin-only `reinhardt-admin-cli` is skipped with an informative message while lib-having crates are retained.
- `--workspace` fallback path (when `run-all=true` or `CARGO_PACKAGES` empty) is not exercised by the new branch and remains byte-identical.

## Checklist

- [x] Follows project style guidelines
- [x] No secrets / untrusted input introduced into `run:` commands (only existing env vars and `cargo metadata` output)
- [x] Self-reviewed the change
- [x] Linked to tracking issue

## Related Issues

Fixes #3734

## Labels to Apply

- `bug`
- `ci-cd`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)