### PR TITLE
fix(ci): recognize proc-macro crates and fail loud on cargo metadata error

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -158,20 +158,42 @@ jobs:
           # have a lib, so the fallback path is unaffected.
           PKG_ARGS=()
           if [[ "$RUN_ALL" != "true" && -n "$CARGO_PACKAGES" ]]; then
-            METADATA_JSON="$(cargo metadata --format-version 1 --no-deps)"
+            # Capture `cargo metadata` with an explicit guard: bash `set -e`
+            # does NOT propagate failures through command substitutions inside
+            # assignments, so without this check a non-zero exit (or empty
+            # output) would silently cause every package to be filtered out
+            # and the job would exit 0 without running any tests (issue #3736).
+            if ! METADATA_JSON="$(cargo metadata --format-version 1 --no-deps)" || [[ -z "$METADATA_JSON" ]]; then
+              echo "Failed to generate cargo metadata for package filtering." >&2
+              exit 1
+            fi
+            # Treat any library-like target kind as acceptable for `--lib`
+            # testing. `cargo metadata` reports proc-macro crates with
+            # `"kind": ["proc-macro"]` (not `"lib"`), and they do compile and
+            # run tests under `--lib`; checking only `"lib"` would silently
+            # drop coverage for them (issue #3736).
             while IFS= read -r pkg; do
               [[ -z "$pkg" ]] && continue
-              has_lib="$(jq -r --arg pkg "$pkg" \
-                '[.packages[] | select(.name==$pkg) | .targets[] | select(.kind | index("lib"))] | length > 0' \
-                <<< "$METADATA_JSON")"
+              has_lib="$(jq -r --arg pkg "$pkg" '
+                [.packages[]
+                  | select(.name == $pkg)
+                  | .targets[]
+                  | select(any(.kind[];
+                      . == "lib"
+                      or . == "proc-macro"
+                      or . == "rlib"
+                      or . == "dylib"
+                      or . == "cdylib"
+                      or . == "staticlib"))]
+                | length > 0' <<< "$METADATA_JSON")"
               if [[ "$has_lib" == "true" ]]; then
                 PKG_ARGS+=(-p "$pkg")
               else
-                echo "Skipping bin-only package for --lib unit tests: $pkg"
+                echo "Skipping package with no library-like target for --lib unit tests: $pkg"
               fi
             done <<< "$CARGO_PACKAGES"
             if [[ ${#PKG_ARGS[@]} -eq 0 ]]; then
-              echo "No affected packages expose a library target; nothing to test in this job."
+              echo "No affected packages expose a library-like target; nothing to test in this job."
               exit 0
             fi
           fi


### PR DESCRIPTION
## Summary

- Broaden the `--lib` package filter in `.github/workflows/unit-test.yml` to accept any library-like target kind (`lib`, `proc-macro`, `rlib`, `dylib`, `cdylib`, `staticlib`), so proc-macro crates like `reinhardt-macros` and `reinhardt-pages-macros` are no longer silently dropped from the Unit Tests matrix.
- Guard the `cargo metadata` invocation with an explicit `if ! VAR=$(...)` plus empty-output check, so a non-zero exit (or blank output) aborts the job loudly instead of filtering every package out and exiting 0 — a false green.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

PR #3735 introduced the affected-package filter for `cargo nextest run --lib` but two review points surfaced after merge:

1. `cargo metadata` reports proc-macro packages with `"kind": ["proc-macro"]`, not `"lib"`. The previous `select(.kind | index("lib"))` rejected them, silently dropping their unit-test coverage. If only proc-macro crates were affected, the job also exited early with "nothing to test".
2. `METADATA_JSON=""$(cargo metadata ...)"" does not fail under `set -e` because bash does not propagate command-substitution exit codes through variable assignments. Any failure from `cargo metadata` (tooling breakage, malformed `Cargo.toml`, etc.) would have slipped through as a green job with zero tests run.

## How Was This Tested

Verified against a live workspace metadata dump in one of the existing worktrees:

```
reinhardt-core:        true    (lib target)
reinhardt-macros:      true    (proc-macro target; previously false)
reinhardt-pages-macros: true    (proc-macro target; previously false)
reinhardt-admin-cli:   false   (bin-only; correctly still skipped)
reinhardt-urls:        true    (lib target)
```

And simulated a `cargo metadata` failure:

```
(set -e; if ! METADATA_JSON=""$(false)"" || [[ -z ""$METADATA_JSON"" ]]; then
  echo ""guard caught failure (exit 1)"">&2
  exit 1
fi)
# -> prints the guard message, exits 1  ✓
```

## Checklist

- [x] Follows project style guidelines
- [x] No secrets / untrusted input introduced into `run:` commands (only env-provided `CARGO_PACKAGES` and `cargo metadata` output)
- [x] Self-reviewed the change
- [x] Linked to tracking issue

## Related Issues

Fixes #3736
Refs #3735

## Labels to Apply

- `bug`
- `ci-cd`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)