### PR TITLE
fix(admin): render TextArea/Select/MultiSelect with proper HTML elements

### DIFF
--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -583,7 +583,10 @@ fn render_option_elements(choices: &[(String, String)], selected: &[&str]) -> Ve
 /// as a comma-separated list (e.g., `"read,write,delete"`). Empty entries
 /// are skipped so an empty value yields no selected options.
 fn parse_multi_value(raw: &str) -> Vec<&str> {
-	raw.split(',').map(str::trim).filter(|s| !s.is_empty()).collect()
+	raw.split(',')
+		.map(str::trim)
+		.filter(|s| !s.is_empty())
+		.collect()
 }
 
 /// Generates an input element for a form field
@@ -599,9 +602,7 @@ fn form_element(field: &FormField, input_id: &str) -> Page {
 		FormFieldSpec::Input { html_type } => {
 			render_input(html_type.clone(), input_id, name, value, required)
 		}
-		FormFieldSpec::File => {
-			render_input("file".to_string(), input_id, name, value, required)
-		}
+		FormFieldSpec::File => render_input("file".to_string(), input_id, name, value, required),
 		FormFieldSpec::Hidden => {
 			render_input("hidden".to_string(), input_id, name, value, required)
 		}

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -342,8 +342,8 @@ pub struct FormField {
 	pub name: String,
 	/// Field display label
 	pub label: String,
-	/// HTML input type (text, email, number, etc.)
-	pub field_type: String,
+	/// Rendering specification (input type, textarea, select, etc.)
+	pub spec: crate::types::FormFieldSpec,
 	/// Whether this field is required
 	pub required: bool,
 	/// Current field value (for edit forms)
@@ -450,12 +450,13 @@ fn detail_table(record: &std::collections::HashMap<String, String>) -> Page {
 ///
 /// ```ignore
 /// use reinhardt_admin::pages::components::features::{model_form, FormField};
+/// use reinhardt_admin::types::FormFieldSpec;
 ///
 /// let fields = vec![
 ///     FormField {
 ///         name: "username".to_string(),
 ///         label: "Username".to_string(),
-///         field_type: "text".to_string(),
+///         spec: FormFieldSpec::Input { html_type: "text" },
 ///         required: true,
 ///         value: "".to_string(),
 ///     },
@@ -545,18 +546,152 @@ fn form_group(field: &FormField) -> Page {
 	})()
 }
 
+/// Render `<option>` elements for a list of `(value, label)` choices,
+/// marking the option matching `current` as `selected`.
+fn render_options(choices: &[(String, String)], current: &str) -> Vec<Page> {
+	choices
+		.iter()
+		.map(|(value, label)| {
+			let value = value.clone();
+			let label = label.clone();
+			if value == current {
+				page!(|| {
+					option {
+						value: value,
+						selected: true,
+						{ label }
+					}
+				})()
+			} else {
+				page!(|| {
+					option {
+						value: value,
+						{ label }
+					}
+				})()
+			}
+		})
+		.collect()
+}
+
 /// Generates an input element for a form field
 fn form_element(field: &FormField, input_id: &str) -> Page {
-	let field_type = field.field_type.clone();
+	use crate::types::FormFieldSpec;
+
 	let input_id = input_id.to_string();
 	let name = field.name.clone();
 	let value = field.value.clone();
+	let required = field.required;
 
-	if field.required {
+	match &field.spec {
+		FormFieldSpec::Input { html_type } => {
+			let html_type = (*html_type).to_string();
+			render_input(html_type, input_id, name, value, required)
+		}
+		FormFieldSpec::File => {
+			render_input("file".to_string(), input_id, name, value, required)
+		}
+		FormFieldSpec::Hidden => {
+			render_input("hidden".to_string(), input_id, name, value, required)
+		}
+		FormFieldSpec::TextArea => {
+			if required {
+				page!(|| {
+					textarea {
+						class: "admin-input",
+						id: input_id,
+						name: name,
+						required: true,
+						autocomplete: "off",
+						{ value }
+					}
+				})()
+			} else {
+				page!(|| {
+					textarea {
+						class: "admin-input",
+						id: input_id,
+						name: name,
+						autocomplete: "off",
+						{ value }
+					}
+				})()
+			}
+		}
+		FormFieldSpec::Select { choices } => {
+			let options = render_options(choices, &value);
+			let options_container = page!(|| {
+				span {
+					{ options }
+				}
+			})();
+			if required {
+				page!(|| {
+					select {
+						class: "admin-select",
+						id: input_id,
+						name: name,
+						required: true,
+						{ options_container }
+					}
+				})()
+			} else {
+				page!(|| {
+					select {
+						class: "admin-select",
+						id: input_id,
+						name: name,
+						{ options_container }
+					}
+				})()
+			}
+		}
+		FormFieldSpec::MultiSelect { choices } => {
+			let options = render_options(choices, &value);
+			let options_container = page!(|| {
+				span {
+					{ options }
+				}
+			})();
+			if required {
+				page!(|| {
+					select {
+						class: "admin-select",
+						id: input_id,
+						name: name,
+						multiple: true,
+						required: true,
+						{ options_container }
+					}
+				})()
+			} else {
+				page!(|| {
+					select {
+						class: "admin-select",
+						id: input_id,
+						name: name,
+						multiple: true,
+						{ options_container }
+					}
+				})()
+			}
+		}
+	}
+}
+
+/// Render an `<input>` element with the given HTML `type`.
+fn render_input(
+	html_type: String,
+	input_id: String,
+	name: String,
+	value: String,
+	required: bool,
+) -> Page {
+	if required {
 		page!(|| {
 			input {
 				class: "admin-input",
-				type: field_type,
+				type: html_type,
 				id: input_id,
 				name: name,
 				value: value,
@@ -568,7 +703,7 @@ fn form_element(field: &FormField, input_id: &str) -> Page {
 		page!(|| {
 			input {
 				class: "admin-input",
-				type: field_type,
+				type: html_type,
 				id: input_id,
 				name: name,
 				value: value,

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -456,7 +456,7 @@ fn detail_table(record: &std::collections::HashMap<String, String>) -> Page {
 ///     FormField {
 ///         name: "username".to_string(),
 ///         label: "Username".to_string(),
-///         spec: FormFieldSpec::Input { html_type: "text" },
+///         spec: FormFieldSpec::Input { html_type: "text".to_string() },
 ///         required: true,
 ///         value: "".to_string(),
 ///     },
@@ -547,14 +547,19 @@ fn form_group(field: &FormField) -> Page {
 }
 
 /// Render `<option>` elements for a list of `(value, label)` choices,
-/// marking the option matching `current` as `selected`.
-fn render_options(choices: &[(String, String)], current: &str) -> Vec<Page> {
+/// marking each option whose value appears in `selected` as `selected`.
+///
+/// `selected` is a slice so that both single-select (`[current]`) and
+/// multi-select (`split` of the `FormField::value` string) can share the
+/// same renderer. See `parse_multi_value` for the multi-select wire format.
+fn render_option_elements(choices: &[(String, String)], selected: &[&str]) -> Vec<Page> {
 	choices
 		.iter()
 		.map(|(value, label)| {
 			let value = value.clone();
 			let label = label.clone();
-			if value == current {
+			let is_selected = selected.iter().any(|s| *s == value);
+			if is_selected {
 				page!(|| {
 					option {
 						value: value,
@@ -574,6 +579,13 @@ fn render_options(choices: &[(String, String)], current: &str) -> Vec<Page> {
 		.collect()
 }
 
+/// Multi-select wire format: `FormField::value` carries the selected values
+/// as a comma-separated list (e.g., `"read,write,delete"`). Empty entries
+/// are skipped so an empty value yields no selected options.
+fn parse_multi_value(raw: &str) -> Vec<&str> {
+	raw.split(',').map(str::trim).filter(|s| !s.is_empty()).collect()
+}
+
 /// Generates an input element for a form field
 fn form_element(field: &FormField, input_id: &str) -> Page {
 	use crate::types::FormFieldSpec;
@@ -585,8 +597,7 @@ fn form_element(field: &FormField, input_id: &str) -> Page {
 
 	match &field.spec {
 		FormFieldSpec::Input { html_type } => {
-			let html_type = (*html_type).to_string();
-			render_input(html_type, input_id, name, value, required)
+			render_input(html_type.clone(), input_id, name, value, required)
 		}
 		FormFieldSpec::File => {
 			render_input("file".to_string(), input_id, name, value, required)
@@ -619,12 +630,7 @@ fn form_element(field: &FormField, input_id: &str) -> Page {
 			}
 		}
 		FormFieldSpec::Select { choices } => {
-			let options = render_options(choices, &value);
-			let options_container = page!(|| {
-				span {
-					{ options }
-				}
-			})();
+			let options = render_option_elements(choices, &[value.as_str()]);
 			if required {
 				page!(|| {
 					select {
@@ -632,7 +638,7 @@ fn form_element(field: &FormField, input_id: &str) -> Page {
 						id: input_id,
 						name: name,
 						required: true,
-						{ options_container }
+						{ options }
 					}
 				})()
 			} else {
@@ -641,18 +647,14 @@ fn form_element(field: &FormField, input_id: &str) -> Page {
 						class: "admin-select",
 						id: input_id,
 						name: name,
-						{ options_container }
+						{ options }
 					}
 				})()
 			}
 		}
 		FormFieldSpec::MultiSelect { choices } => {
-			let options = render_options(choices, &value);
-			let options_container = page!(|| {
-				span {
-					{ options }
-				}
-			})();
+			let selected = parse_multi_value(&value);
+			let options = render_option_elements(choices, &selected);
 			if required {
 				page!(|| {
 					select {
@@ -661,7 +663,7 @@ fn form_element(field: &FormField, input_id: &str) -> Page {
 						name: name,
 						multiple: true,
 						required: true,
-						{ options_container }
+						{ options }
 					}
 				})()
 			} else {
@@ -671,7 +673,7 @@ fn form_element(field: &FormField, input_id: &str) -> Page {
 						id: input_id,
 						name: name,
 						multiple: true,
-						{ options_container }
+						{ options }
 					}
 				})()
 			}

--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -437,14 +437,18 @@ fn create_view_component(model_name: String) -> Page {
 		FormField {
 			name: "name".to_string(),
 			label: "Name".to_string(),
-			spec: crate::types::FormFieldSpec::Input { html_type: "text".to_string() },
+			spec: crate::types::FormFieldSpec::Input {
+				html_type: "text".to_string(),
+			},
 			required: true,
 			value: String::new(),
 		},
 		FormField {
 			name: "email".to_string(),
 			label: "Email".to_string(),
-			spec: crate::types::FormFieldSpec::Input { html_type: "email".to_string() },
+			spec: crate::types::FormFieldSpec::Input {
+				html_type: "email".to_string(),
+			},
 			required: true,
 			value: String::new(),
 		},
@@ -520,14 +524,18 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 		FormField {
 			name: "name".to_string(),
 			label: "Name".to_string(),
-			spec: crate::types::FormFieldSpec::Input { html_type: "text".to_string() },
+			spec: crate::types::FormFieldSpec::Input {
+				html_type: "text".to_string(),
+			},
 			required: true,
 			value: "Existing Value".to_string(),
 		},
 		FormField {
 			name: "email".to_string(),
 			label: "Email".to_string(),
-			spec: crate::types::FormFieldSpec::Input { html_type: "email".to_string() },
+			spec: crate::types::FormFieldSpec::Input {
+				html_type: "email".to_string(),
+			},
 			required: true,
 			value: "user@example.com".to_string(),
 		},

--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -437,14 +437,14 @@ fn create_view_component(model_name: String) -> Page {
 		FormField {
 			name: "name".to_string(),
 			label: "Name".to_string(),
-			spec: crate::types::FormFieldSpec::Input { html_type: "text" },
+			spec: crate::types::FormFieldSpec::Input { html_type: "text".to_string() },
 			required: true,
 			value: String::new(),
 		},
 		FormField {
 			name: "email".to_string(),
 			label: "Email".to_string(),
-			spec: crate::types::FormFieldSpec::Input { html_type: "email" },
+			spec: crate::types::FormFieldSpec::Input { html_type: "email".to_string() },
 			required: true,
 			value: String::new(),
 		},
@@ -520,14 +520,14 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 		FormField {
 			name: "name".to_string(),
 			label: "Name".to_string(),
-			spec: crate::types::FormFieldSpec::Input { html_type: "text" },
+			spec: crate::types::FormFieldSpec::Input { html_type: "text".to_string() },
 			required: true,
 			value: "Existing Value".to_string(),
 		},
 		FormField {
 			name: "email".to_string(),
 			label: "Email".to_string(),
-			spec: crate::types::FormFieldSpec::Input { html_type: "email" },
+			spec: crate::types::FormFieldSpec::Input { html_type: "email".to_string() },
 			required: true,
 			value: "user@example.com".to_string(),
 		},

--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -408,9 +408,9 @@ fn create_view_component(model_name: String) -> Page {
 					.fields
 					.into_iter()
 					.map(|field_info| FormField {
+						spec: crate::types::FormFieldSpec::from(&field_info.field_type),
 						name: field_info.name,
 						label: field_info.label,
-						field_type: field_type_to_html_input_type(&field_info.field_type),
 						required: field_info.required,
 						value: String::new(),
 					})
@@ -437,14 +437,14 @@ fn create_view_component(model_name: String) -> Page {
 		FormField {
 			name: "name".to_string(),
 			label: "Name".to_string(),
-			field_type: "text".to_string(),
+			spec: crate::types::FormFieldSpec::Input { html_type: "text" },
 			required: true,
 			value: String::new(),
 		},
 		FormField {
 			name: "email".to_string(),
 			label: "Email".to_string(),
-			field_type: "email".to_string(),
+			spec: crate::types::FormFieldSpec::Input { html_type: "email" },
 			required: true,
 			value: String::new(),
 		},
@@ -490,9 +490,9 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 						};
 
 						FormField {
+							spec: crate::types::FormFieldSpec::from(&field_info.field_type),
 							name: field_info.name,
 							label: field_info.label,
-							field_type: field_type_to_html_input_type(&field_info.field_type),
 							required: field_info.required,
 							value,
 						}
@@ -520,14 +520,14 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 		FormField {
 			name: "name".to_string(),
 			label: "Name".to_string(),
-			field_type: "text".to_string(),
+			spec: crate::types::FormFieldSpec::Input { html_type: "text" },
 			required: true,
 			value: "Existing Value".to_string(),
 		},
 		FormField {
 			name: "email".to_string(),
 			label: "Email".to_string(),
-			field_type: "email".to_string(),
+			spec: crate::types::FormFieldSpec::Input { html_type: "email" },
 			required: true,
 			value: "user@example.com".to_string(),
 		},
@@ -625,31 +625,6 @@ fn error_view(message: &str) -> Page {
 			{ dashboard_link }
 		}
 	})()
-}
-
-/// Convert FieldType to HTML input type string
-///
-/// Maps crate::types::FieldType to HTML input type attributes.
-#[cfg(client)]
-fn field_type_to_html_input_type(field_type: &crate::types::FieldType) -> String {
-	use crate::types::FieldType;
-
-	match field_type {
-		FieldType::Text => "text".to_string(),
-		// TextArea should render as <textarea>, not <input>; fall back to "text" for now
-		FieldType::TextArea => "text".to_string(),
-		FieldType::Number => "number".to_string(),
-		FieldType::Boolean => "checkbox".to_string(),
-		FieldType::Email => "email".to_string(),
-		FieldType::Date => "date".to_string(),
-		FieldType::DateTime => "datetime-local".to_string(),
-		// Select should render as <select>, not <input>; fall back to "text" for now
-		FieldType::Select { .. } => "text".to_string(),
-		// MultiSelect should render as <select multiple>, not <input>; fall back to "text" for now
-		FieldType::MultiSelect { .. } => "text".to_string(),
-		FieldType::File => "file".to_string(),
-		FieldType::Hidden => "hidden".to_string(),
-	}
 }
 
 /// Initialize the admin router

--- a/crates/reinhardt-admin/src/types/models.rs
+++ b/crates/reinhardt-admin/src/types/models.rs
@@ -64,6 +64,67 @@ pub enum FieldType {
 	Hidden,
 }
 
+/// Rendering specification for a form field.
+///
+/// This type preserves the structural information needed to emit the
+/// correct HTML element (e.g., `<input>`, `<textarea>`, `<select>`),
+/// along with any choices required for `<select>` options. It is derived
+/// from `FieldType` via `From<&FieldType>`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "data")]
+pub enum FormFieldSpec {
+	/// Plain `<input>` element with the given HTML `type` attribute.
+	Input {
+		/// Value for the HTML `type` attribute (e.g., "text", "email",
+		/// "number", "checkbox", "date", "datetime-local").
+		html_type: &'static str,
+	},
+	/// `<textarea>` element for multi-line text.
+	TextArea,
+	/// `<select>` dropdown with the given `(value, label)` choices.
+	Select {
+		/// Available choices as `(value, label)` pairs.
+		choices: Vec<(String, String)>,
+	},
+	/// `<select multiple>` dropdown with the given `(value, label)` choices.
+	MultiSelect {
+		/// Available choices as `(value, label)` pairs.
+		choices: Vec<(String, String)>,
+	},
+	/// `<input type="file">` for file uploads.
+	File,
+	/// `<input type="hidden">` for hidden values.
+	Hidden,
+}
+
+impl From<&FieldType> for FormFieldSpec {
+	fn from(field_type: &FieldType) -> Self {
+		match field_type {
+			FieldType::Text => FormFieldSpec::Input { html_type: "text" },
+			FieldType::Number => FormFieldSpec::Input {
+				html_type: "number",
+			},
+			FieldType::Boolean => FormFieldSpec::Input {
+				html_type: "checkbox",
+			},
+			FieldType::Email => FormFieldSpec::Input { html_type: "email" },
+			FieldType::Date => FormFieldSpec::Input { html_type: "date" },
+			FieldType::DateTime => FormFieldSpec::Input {
+				html_type: "datetime-local",
+			},
+			FieldType::TextArea => FormFieldSpec::TextArea,
+			FieldType::Select { choices } => FormFieldSpec::Select {
+				choices: choices.clone(),
+			},
+			FieldType::MultiSelect { choices } => FormFieldSpec::MultiSelect {
+				choices: choices.clone(),
+			},
+			FieldType::File => FormFieldSpec::File,
+			FieldType::Hidden => FormFieldSpec::Hidden,
+		}
+	}
+}
+
 /// Filter type for UI rendering
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "options")]

--- a/crates/reinhardt-admin/src/types/models.rs
+++ b/crates/reinhardt-admin/src/types/models.rs
@@ -77,7 +77,11 @@ pub enum FormFieldSpec {
 	Input {
 		/// Value for the HTML `type` attribute (e.g., "text", "email",
 		/// "number", "checkbox", "date", "datetime-local").
-		html_type: &'static str,
+		///
+		/// Owned `String` (not `&'static str`) so the variant can round-trip
+		/// through `serde` deserialization at API boundaries — borrowed
+		/// `'static` strings cannot be reconstructed from incoming JSON.
+		html_type: String,
 	},
 	/// `<textarea>` element for multi-line text.
 	TextArea,
@@ -100,17 +104,23 @@ pub enum FormFieldSpec {
 impl From<&FieldType> for FormFieldSpec {
 	fn from(field_type: &FieldType) -> Self {
 		match field_type {
-			FieldType::Text => FormFieldSpec::Input { html_type: "text" },
+			FieldType::Text => FormFieldSpec::Input {
+				html_type: "text".to_string(),
+			},
 			FieldType::Number => FormFieldSpec::Input {
-				html_type: "number",
+				html_type: "number".to_string(),
 			},
 			FieldType::Boolean => FormFieldSpec::Input {
-				html_type: "checkbox",
+				html_type: "checkbox".to_string(),
 			},
-			FieldType::Email => FormFieldSpec::Input { html_type: "email" },
-			FieldType::Date => FormFieldSpec::Input { html_type: "date" },
+			FieldType::Email => FormFieldSpec::Input {
+				html_type: "email".to_string(),
+			},
+			FieldType::Date => FormFieldSpec::Input {
+				html_type: "date".to_string(),
+			},
 			FieldType::DateTime => FormFieldSpec::Input {
-				html_type: "datetime-local",
+				html_type: "datetime-local".to_string(),
 			},
 			FieldType::TextArea => FormFieldSpec::TextArea,
 			FieldType::Select { choices } => FormFieldSpec::Select {

--- a/crates/reinhardt-admin/tests/wasm_components.rs
+++ b/crates/reinhardt-admin/tests/wasm_components.rs
@@ -128,7 +128,9 @@ fn test_model_form_create_mode() {
 	let fields = vec![FormField {
 		name: "username".to_string(),
 		label: "Username".to_string(),
-		spec: FormFieldSpec::Input { html_type: "text".to_string() },
+		spec: FormFieldSpec::Input {
+			html_type: "text".to_string(),
+		},
 		required: true,
 		value: String::new(),
 	}];
@@ -150,7 +152,9 @@ fn test_model_form_edit_mode() {
 	let fields = vec![FormField {
 		name: "username".to_string(),
 		label: "Username".to_string(),
-		spec: FormFieldSpec::Input { html_type: "text".to_string() },
+		spec: FormFieldSpec::Input {
+			html_type: "text".to_string(),
+		},
 		required: true,
 		value: "john_doe".to_string(),
 	}];

--- a/crates/reinhardt-admin/tests/wasm_components.rs
+++ b/crates/reinhardt-admin/tests/wasm_components.rs
@@ -11,7 +11,7 @@ use reinhardt_admin::pages::components::features::{
 	Column, FormField, ListViewData, dashboard, detail_view, list_view, model_form,
 };
 use reinhardt_admin::pages::components::login::login_form;
-use reinhardt_admin::types::ModelInfo;
+use reinhardt_admin::types::{FormFieldSpec, ModelInfo};
 use reinhardt_pages::Signal;
 use reinhardt_test::fixtures::wasm::*;
 use std::collections::HashMap;
@@ -128,7 +128,7 @@ fn test_model_form_create_mode() {
 	let fields = vec![FormField {
 		name: "username".to_string(),
 		label: "Username".to_string(),
-		field_type: "text".to_string(),
+		spec: FormFieldSpec::Input { html_type: "text" },
 		required: true,
 		value: String::new(),
 	}];
@@ -150,7 +150,7 @@ fn test_model_form_edit_mode() {
 	let fields = vec![FormField {
 		name: "username".to_string(),
 		label: "Username".to_string(),
-		field_type: "text".to_string(),
+		spec: FormFieldSpec::Input { html_type: "text" },
 		required: true,
 		value: "john_doe".to_string(),
 	}];

--- a/crates/reinhardt-admin/tests/wasm_components.rs
+++ b/crates/reinhardt-admin/tests/wasm_components.rs
@@ -128,7 +128,7 @@ fn test_model_form_create_mode() {
 	let fields = vec![FormField {
 		name: "username".to_string(),
 		label: "Username".to_string(),
-		spec: FormFieldSpec::Input { html_type: "text" },
+		spec: FormFieldSpec::Input { html_type: "text".to_string() },
 		required: true,
 		value: String::new(),
 	}];
@@ -150,7 +150,7 @@ fn test_model_form_edit_mode() {
 	let fields = vec![FormField {
 		name: "username".to_string(),
 		label: "Username".to_string(),
-		spec: FormFieldSpec::Input { html_type: "text" },
+		spec: FormFieldSpec::Input { html_type: "text".to_string() },
 		required: true,
 		value: "john_doe".to_string(),
 	}];
@@ -164,6 +164,98 @@ fn test_model_form_edit_mode() {
 		"Should have edit action URL"
 	);
 	assert!(html.contains("john_doe"), "Should pre-fill existing value");
+}
+
+#[wasm_bindgen_test]
+fn test_model_form_renders_textarea_for_text_area_spec() {
+	let fields = vec![FormField {
+		name: "bio".to_string(),
+		label: "Bio".to_string(),
+		spec: FormFieldSpec::TextArea,
+		required: false,
+		value: "Hello world".to_string(),
+	}];
+
+	let page = model_form("Profile", &fields, None);
+	let html = page.render_to_string();
+
+	assert!(
+		html.contains("<textarea"),
+		"TextArea spec should render a <textarea> element, got: {html}"
+	);
+	assert!(
+		html.contains("Hello world"),
+		"TextArea body should contain the field value"
+	);
+}
+
+#[wasm_bindgen_test]
+fn test_model_form_renders_select_with_inline_options() {
+	let fields = vec![FormField {
+		name: "status".to_string(),
+		label: "Status".to_string(),
+		spec: FormFieldSpec::Select {
+			choices: vec![
+				("active".to_string(), "Active".to_string()),
+				("inactive".to_string(), "Inactive".to_string()),
+			],
+		},
+		required: true,
+		value: "active".to_string(),
+	}];
+
+	let page = model_form("Account", &fields, None);
+	let html = page.render_to_string();
+
+	assert!(
+		html.contains("<select"),
+		"Select spec should render a <select> element"
+	);
+	// Options must be direct children of <select>, not wrapped in <span>.
+	assert!(
+		!html.contains("<span><option") && !html.contains("<span> <option"),
+		"Options must not be wrapped in <span> (invalid HTML), got: {html}"
+	);
+	assert!(
+		html.contains("<option") && html.contains("Active") && html.contains("Inactive"),
+		"All choices should render as <option> elements"
+	);
+	assert!(
+		html.contains("selected"),
+		"The current value should be marked selected"
+	);
+}
+
+#[wasm_bindgen_test]
+fn test_model_form_renders_multiselect_with_multiple_selections() {
+	let fields = vec![FormField {
+		name: "perms".to_string(),
+		label: "Permissions".to_string(),
+		spec: FormFieldSpec::MultiSelect {
+			choices: vec![
+				("read".to_string(), "Read".to_string()),
+				("write".to_string(), "Write".to_string()),
+				("delete".to_string(), "Delete".to_string()),
+			],
+		},
+		required: false,
+		// Multi-select wire format is comma-separated values; both `read`
+		// and `write` should end up marked selected.
+		value: "read,write".to_string(),
+	}];
+
+	let page = model_form("Role", &fields, None);
+	let html = page.render_to_string();
+
+	assert!(
+		html.contains("multiple"),
+		"MultiSelect spec should produce a <select multiple> element"
+	);
+	let selected_count = html.matches("selected").count();
+	assert!(
+		selected_count >= 2,
+		"Both `read` and `write` should be marked selected, found {selected_count} `selected` occurrences in: {html}"
+	);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Introduce `FormFieldSpec` enum to preserve `FieldType` information (incl. `Select`/`MultiSelect` choices) through to the renderer.
- Rewrite `form_element()` to emit `<textarea>`, `<select>`, and `<select multiple>` via the existing `page!` macro instead of falling back to `<input type="text">`.
- Remove `field_type_to_html_input_type` and the three `// ... for now` comments that tracked the limitation.

## Test plan

- [x] `cargo build -p reinhardt-admin --all-features`
- [x] `cargo nextest run -p reinhardt-admin --all-features` (502 passed)
- [ ] Admin UI manual check for TextArea/Select/MultiSelect rendering (follow-up)
- [ ] New WASM component tests covering the three variants (Track 6, tracked separately)

Fixes #3738