### PR TITLE
test(graphql): thread real PgPool through GraphQL integration fixtures

### DIFF
--- a/tests/integration/src/graphql/database/models.rs
+++ b/tests/integration/src/graphql/database/models.rs
@@ -223,9 +223,9 @@ async fn test_model_relationships() {
 #[rstest]
 #[tokio::test]
 async fn test_model_graphql_integration(
-	#[future] graphql_schema_fixture: Schema<Query, Mutation, EmptySubscription>,
+	#[future] graphql_schema_fixture: (Schema<Query, Mutation, EmptySubscription>, Arc<PgPool>),
 ) {
-	let schema = graphql_schema_fixture.await;
+	let (schema, _pool) = graphql_schema_fixture.await;
 
 	// Test that we can query user-related types from the schema
 	let introspection_query = r#"

--- a/tests/integration/src/graphql/fixtures/models.rs
+++ b/tests/integration/src/graphql/fixtures/models.rs
@@ -102,17 +102,14 @@ impl Iden for Tables {
 
 /// Creates a test user in the database and returns it with the schema.
 ///
-/// This fixture demonstrates the pattern of wrapping generic database fixtures
-/// with specialized test data insertion.
+/// This fixture composes on `graphql_schema_fixture`, which owns the shared
+/// testcontainer-backed `PgPool`. The pool is threaded through so data seeded
+/// here lives in the same Postgres instance the schema is wired to.
 #[fixture]
 async fn user_model_fixture(
-	#[future] graphql_schema_fixture: Schema<Query, Mutation, EmptySubscription>,
+	#[future] graphql_schema_fixture: (Schema<Query, Mutation, EmptySubscription>, Arc<PgPool>),
 ) -> (Schema<Query, Mutation, EmptySubscription>, User) {
-	let schema = graphql_schema_fixture.await;
-
-	// Get database pool from schema context (simplified - in real implementation
-	// we would extract it from schema data)
-	let pool = get_pool_from_test_container().await;
+	let (schema, pool) = graphql_schema_fixture.await;
 
 	// Create user using reinhardt-query (not raw SQL)
 	let user = create_test_user_with_query(&pool).await;
@@ -123,12 +120,11 @@ async fn user_model_fixture(
 /// Creates a test post with author relationship.
 #[fixture]
 async fn post_model_fixture(
-	#[future] user_model_fixture: (Schema<Query, Mutation, EmptySubscription>, User),
+	#[future] graphql_schema_fixture: (Schema<Query, Mutation, EmptySubscription>, Arc<PgPool>),
 ) -> (Schema<Query, Mutation, EmptySubscription>, User, Post) {
-	let (schema, user) = user_model_fixture.await;
-	let pool = get_pool_from_test_container().await;
+	let (schema, pool) = graphql_schema_fixture.await;
 
-	// Create post using reinhardt-query
+	let user = create_test_user_with_query(&pool).await;
 	let post = create_test_post_with_query(&pool, user.id).await;
 
 	(schema, user, post)
@@ -137,21 +133,6 @@ async fn post_model_fixture(
 // ============================================================================
 // Helper Functions using reinhardt-query
 // ============================================================================
-
-/// Get database pool from test container (simplified implementation).
-///
-/// In a real implementation, this would extract the pool from the schema
-/// or use a shared test container fixture.
-// Allow: pool extraction is a placeholder for fixture pattern (permanently excluded)
-#[allow(clippy::unimplemented)]
-async fn get_pool_from_test_container() -> Arc<PgPool> {
-	use reinhardt_test::fixtures::postgres_container;
-	use rstest::*;
-
-	// This is a simplified implementation - in real tests we would
-	// use the actual postgres_container fixture
-	unimplemented!("Need to implement pool extraction from test container")
-}
 
 /// Create a test user in the database using reinhardt-query.
 async fn create_test_user_with_query(pool: &PgPool) -> User {
@@ -200,10 +181,9 @@ async fn create_test_post_with_query(pool: &PgPool, author_id: i32) -> Post {
 /// Creates multiple test users for batch testing.
 #[fixture]
 async fn multiple_users_fixture(
-	#[future] graphql_schema_fixture: Schema<Query, Mutation, EmptySubscription>,
+	#[future] graphql_schema_fixture: (Schema<Query, Mutation, EmptySubscription>, Arc<PgPool>),
 ) -> (Schema<Query, Mutation, EmptySubscription>, Vec<User>) {
-	let schema = graphql_schema_fixture.await;
-	let pool = get_pool_from_test_container().await;
+	let (schema, pool) = graphql_schema_fixture.await;
 
 	let users = vec![
 		create_test_user_with_query(&pool).await,

--- a/tests/integration/src/graphql/fixtures/models.rs
+++ b/tests/integration/src/graphql/fixtures/models.rs
@@ -103,28 +103,40 @@ impl Iden for Tables {
 /// Creates a test user in the database and returns it with the schema.
 ///
 /// This fixture composes on `graphql_schema_fixture`, which owns the shared
-/// testcontainer-backed `PgPool`. The pool is threaded through so data seeded
-/// here lives in the same Postgres instance the schema is wired to.
+/// testcontainer-backed `PgPool`. The pool is returned alongside the schema
+/// and seeded user so dependent fixtures (e.g. `post_model_fixture`) can
+/// reuse the already-seeded user without duplicating insert logic.
 #[fixture]
 async fn user_model_fixture(
 	#[future] graphql_schema_fixture: (Schema<Query, Mutation, EmptySubscription>, Arc<PgPool>),
-) -> (Schema<Query, Mutation, EmptySubscription>, User) {
+) -> (
+	Schema<Query, Mutation, EmptySubscription>,
+	Arc<PgPool>,
+	User,
+) {
 	let (schema, pool) = graphql_schema_fixture.await;
 
 	// Create user using reinhardt-query (not raw SQL)
 	let user = create_test_user_with_query(&pool).await;
 
-	(schema, user)
+	(schema, pool, user)
 }
 
 /// Creates a test post with author relationship.
+///
+/// Composes on `user_model_fixture` so user seeding is not duplicated and
+/// the post is always anchored to the same user instance the test would
+/// observe through `user_model_fixture`.
 #[fixture]
 async fn post_model_fixture(
-	#[future] graphql_schema_fixture: (Schema<Query, Mutation, EmptySubscription>, Arc<PgPool>),
+	#[future] user_model_fixture: (
+		Schema<Query, Mutation, EmptySubscription>,
+		Arc<PgPool>,
+		User,
+	),
 ) -> (Schema<Query, Mutation, EmptySubscription>, User, Post) {
-	let (schema, pool) = graphql_schema_fixture.await;
+	let (schema, pool, user) = user_model_fixture.await;
 
-	let user = create_test_user_with_query(&pool).await;
 	let post = create_test_post_with_query(&pool, user.id).await;
 
 	(schema, user, post)
@@ -135,47 +147,55 @@ async fn post_model_fixture(
 // ============================================================================
 
 /// Create a test user in the database using reinhardt-query.
+///
+/// Returns the model populated with the actual `SERIAL` id assigned by
+/// Postgres via `RETURNING id`. Using a hard-coded id collides on the
+/// second insert and breaks any test that reads the row back by id.
 async fn create_test_user_with_query(pool: &PgPool) -> User {
-	// Use reinhardt-query to build SQL (not raw strings)
+	let name = "Test User";
+	let email = "test@example.com";
+
+	// Use reinhardt-query to build SQL (not raw strings); append `RETURNING id`
+	// so we can fetch the actual generated primary key.
 	let mut insert_stmt = Query::insert();
 	let insert_query = insert_stmt
 		.into_table(Tables::Users.into_iden())
 		.columns([User::name(), User::email(), User::is_active()])
-		.values(["Test User".into(), "test@example.com".into(), true.into()])
+		.values([name.into(), email.into(), true.into()])
 		.unwrap()
 		.to_string(PostgresQueryBuilder::new());
+	let insert_with_returning = format!("{insert_query} RETURNING id");
 
-	// Execute the query
-	sqlx::query(&insert_query)
-		.execute(pool)
+	let id: i32 = sqlx::query_scalar(&insert_with_returning)
+		.fetch_one(pool)
 		.await
 		.expect("Failed to create test user");
 
-	// Return model instance using Model::new()
-	User::new(1, "Test User".to_string(), "test@example.com".to_string())
+	User::new(id, name.to_string(), email.to_string())
 }
 
 /// Create a test post in the database using reinhardt-query.
+///
+/// Returns the model populated with the actual generated `SERIAL` id.
 async fn create_test_post_with_query(pool: &PgPool, author_id: i32) -> Post {
+	let title = "Test Post";
+	let content = "Test content";
+
 	let mut insert_stmt = Query::insert();
 	let insert_query = insert_stmt
 		.into_table(Tables::Posts.into_iden())
 		.columns([Post::title(), Post::content(), Post::author_id()])
-		.values(["Test Post".into(), "Test content".into(), author_id.into()])
+		.values([title.into(), content.into(), author_id.into()])
 		.unwrap()
 		.to_string(PostgresQueryBuilder::new());
+	let insert_with_returning = format!("{insert_query} RETURNING id");
 
-	sqlx::query(&insert_query)
-		.execute(pool)
+	let id: i32 = sqlx::query_scalar(&insert_with_returning)
+		.fetch_one(pool)
 		.await
 		.expect("Failed to create test post");
 
-	Post::new(
-		1,
-		"Test Post".to_string(),
-		"Test content".to_string(),
-		author_id,
-	)
+	Post::new(id, title.to_string(), content.to_string(), author_id)
 }
 
 /// Creates multiple test users for batch testing.

--- a/tests/integration/src/graphql/fixtures/schema.rs
+++ b/tests/integration/src/graphql/fixtures/schema.rs
@@ -4,23 +4,32 @@
 
 use crate::prelude::*;
 use async_graphql::{EmptySubscription, Schema};
-use reinhardt_graphql::{Mutation, Query, create_schema};
+use reinhardt_graphql::{Mutation, Query, QueryLimits, UserStorage};
 use std::sync::Arc;
 
 /// Creates a GraphQL schema connected to a test database.
 ///
 /// This fixture wraps the generic `postgres_container` fixture from `reinhardt-test`
-/// and creates a GraphQL schema with a real PostgreSQL database connection.
+/// and creates a GraphQL schema with a real PostgreSQL database connection. The
+/// returned tuple carries both the schema and the pool so dependent fixtures can
+/// seed test data through the same container instance.
 #[fixture]
 async fn graphql_schema_fixture(
 	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<PgPool>, u16, String),
-) -> Schema<Query, Mutation, EmptySubscription> {
+) -> (Schema<Query, Mutation, EmptySubscription>, Arc<PgPool>) {
 	let (_container, pool, _port, _url) = postgres_container.await;
 
-	// Create schema with database connection
-	// Note: In a real implementation, we would configure the schema to use the database pool
-	// For now, we'll use the default in-memory storage
-	create_schema()
+	// Build the schema with the in-memory `UserStorage` (current resolver backend)
+	// and attach the real `PgPool` as schema data so future resolvers can use it.
+	let limits = QueryLimits::default();
+	let schema = Schema::build(Query, Mutation, EmptySubscription)
+		.data(UserStorage::new())
+		.data(pool.clone())
+		.limit_depth(limits.max_depth)
+		.limit_complexity(limits.max_complexity)
+		.finish();
+
+	(schema, pool)
 }
 
 /// Creates a GraphQL schema with DI context.


### PR DESCRIPTION
## Summary

- Replace the `unimplemented!()` pool-extraction stub in `tests/integration/src/graphql/fixtures/models.rs` with real `PgPool` plumbing from the existing postgres testcontainer fixture.
- `graphql_schema_fixture` now returns `(Schema, Arc<PgPool>)`, wiring the pool + `UserStorage` into the schema.

> **Note (clarification after Copilot review):** `UserStorage::new()` (in-memory) is intentionally still attached to the schema because the current `Query::user()` / `Mutation` resolvers in `reinhardt-graphql` read from it — the pool is wired alongside it as **prerequisite plumbing** for the eventual resolver-side migration to Postgres-backed storage, which is out of scope for this PR. The phrase "remove the in-memory fallback" in the original summary was inaccurate; what actually changed is that fixtures no longer build a fake/unwired pool — they now thread the real testcontainer-backed pool through.

## Follow-up changes (review feedback)

- `user_model_fixture` returns `(Schema, Arc<PgPool>, User)` so `post_model_fixture` composes on it instead of duplicating the user seed.
- Helpers append `RETURNING id` to the reinhardt-query-built INSERT and populate the model with the actual `SERIAL` id via `query_scalar`. Previously every seeded row was returned with hard-coded `id=1`, which collided in `multiple_users_fixture` and broke relationship assertions.

## Test plan

- [x] `cargo check -p reinhardt-integration-tests --tests --features graphql`
- [ ] GraphQL integration suite run against the testcontainer (Docker required)

Fixes #3739

🤖 Generated with [Claude Code](https://claude.com/claude-code)