### PR TITLE
fix(test): align DI-miss assertion with redacted server_fn body

### DIFF
--- a/tests/integration/tests/admin/server_fn_e2e_tests.rs
+++ b/tests/integration/tests/admin/server_fn_e2e_tests.rs
@@ -706,18 +706,28 @@ async fn test_e2e_get_list_fails_without_database_connection(
 	);
 	// Body intentionally redacted by `security(macros)` (commit c451e02c8) to
 	// avoid leaking DI internals (type names, configuration hints) to clients.
-	// Verify the redacted contract: a generic `ServerFnError::Server` envelope
-	// with no DI type names echoed back. Tracks issue #3740.
+	// Verify the redacted JSON envelope contract by structural parsing rather
+	// than substring matching, then explicitly guard against re-leaking the
+	// DI type name. Tracks issue #3740.
 	let body = String::from_utf8_lossy(&response.body);
-	assert!(
-		body.contains("\"Server\"") && body.contains("Internal server error"),
-		"Expected redacted ServerFnError::Server envelope, got: {}",
-		body
+	let parsed: serde_json::Value = serde_json::from_str(&body)
+		.unwrap_or_else(|e| panic!("Body is not valid JSON ({e}): {body}"));
+	let server = parsed
+		.get("Server")
+		.unwrap_or_else(|| panic!("Expected top-level `Server` envelope, got: {body}"));
+	assert_eq!(
+		server.get("status").and_then(serde_json::Value::as_u64),
+		Some(500),
+		"Expected `Server.status` == 500, got: {body}"
+	);
+	assert_eq!(
+		server.get("message").and_then(serde_json::Value::as_str),
+		Some("Internal server error"),
+		"Expected redacted `Server.message`, got: {body}"
 	);
 	assert!(
 		!body.contains("DatabaseConnection"),
-		"DI type name leaked into client body (security regression): {}",
-		body
+		"DI type name leaked into client body (security regression): {body}"
 	);
 }
 

--- a/tests/integration/tests/admin/server_fn_e2e_tests.rs
+++ b/tests/integration/tests/admin/server_fn_e2e_tests.rs
@@ -704,10 +704,19 @@ async fn test_e2e_get_list_fails_without_database_connection(
 		"Expected 4xx/5xx error status, got: {}",
 		response.status
 	);
+	// Body intentionally redacted by `security(macros)` (commit c451e02c8) to
+	// avoid leaking DI internals (type names, configuration hints) to clients.
+	// Verify the redacted contract: a generic `ServerFnError::Server` envelope
+	// with no DI type names echoed back. Tracks issue #3740.
 	let body = String::from_utf8_lossy(&response.body);
 	assert!(
-		body.contains("DatabaseConnection") || body.contains("injection"),
-		"Error body should mention DI failure, got: {}",
+		body.contains("\"Server\"") && body.contains("Internal server error"),
+		"Expected redacted ServerFnError::Server envelope, got: {}",
+		body
+	);
+	assert!(
+		!body.contains("DatabaseConnection"),
+		"DI type name leaked into client body (security regression): {}",
 		body
 	);
 }


### PR DESCRIPTION
## Summary

- Update `test_e2e_get_list_fails_without_database_connection` body assertion to match the redacted `ServerFnError::Server` envelope contract introduced by `c451e02c8` (`security(macros): redact DI error details in server_fn 500 responses`).
- The previous assertion expected the body to mention `"DatabaseConnection"` / `"injection"`, but DI internals are now intentionally suppressed and only logged server-side.
- The new assertion both verifies the redacted-envelope contract AND explicitly asserts the absence of the DI type name — turning the test into a guard against accidentally re-leaking DI internals.

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`test_e2e_get_list_fails_without_database_connection` has been failing on `main` since `c451e02c8`, blocking `Cross-Crate Integration Tests (1/3)` on every open PR (#3728, #3729, #3730, #3731). The redaction is intentional security hardening — see issue #3740 for the full diagnosis.

## How Was This Tested

- [x] Local: edited assertion compiles
- [ ] CI: `Cross-Crate Integration Tests (1/3)` will validate the test passes against the redacted body

## Checklist

- [x] Code compiles without warnings (test code only)
- [x] Comments in English
- [x] Commit follows Conventional Commits format
- [x] Linked issue with `Fixes #`

## Labels to Apply

- `bug`

## Related Issues

Fixes #3740

🤖 Generated with [Claude Code](https://claude.com/claude-code)