### PR TITLE
fix(ci): add checkout step before local composite action in announce workflow

### DIFF
--- a/.github/workflows/announce-breaking-change.yml
+++ b/.github/workflows/announce-breaking-change.yml
@@ -27,6 +27,8 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - uses: ./.github/actions/announce-breaking-change
         with:
           source-repo: reinhardt-web


### PR DESCRIPTION
## Summary

This PR addresses:

- Add `actions/checkout@v4` as the first step in the `announce` job of `.github/workflows/announce-breaking-change.yml`

Local composite actions (those referenced as `uses: ./.github/actions/...`) require the repository to be checked out before they can be loaded. The `announce` job was missing this step, causing every breaking-change PR merge to fail with:
> `Can't find 'action.yml' under '.github/actions/announce-breaking-change'`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

- The `Announce Breaking Change` workflow was failing on every merged PR labeled `breaking-change` or whose title contained `!:`
- Observed failure: https://github.com/kent8192/reinhardt-web/actions/runs/24602939877

Fixes #3760

Related to: #

## How Was This Tested?

- Verified the diff is a single-step addition with no logic change
- The next merged breaking-change PR will serve as the live verification

## Performance Impact

- N/A — CI-only change with no runtime impact

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #3760

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

The root cause is that GitHub Actions runners do not automatically check out the repository. Any workflow step that references a local action (`uses: ./...`) must be preceded by `actions/checkout`.