### PR TITLE
docs(.devin): update wiki.json to reflect breaking changes since rc.15

### DIFF
--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -1,7 +1,7 @@
 {
   "repo_notes": [
     {
-      "content": "Reinhardt is a polylithic batteries-included Rust web framework inspired by Django, Django REST Framework, and FastAPI. The framework is organized as a Cargo workspace with 70+ crates, allowing users to select only the components they need via feature flags.",
+      "content": "Reinhardt is a polylithic batteries-included Rust web framework inspired by Django, Django REST Framework, and FastAPI. The framework is organized as a Cargo workspace with 70+ crates, allowing users to select only the components they need via feature flags. Current version: 0.1.0-rc.15 (next planned: 0.1.0-rc.16).",
       "author": "Maintainer"
     },
     {
@@ -9,38 +9,88 @@
       "author": "Architect"
     },
     {
-      "content": "The crates/ directory contains all workspace members. The examples/local/ directory contains 7 example projects demonstrating real-world usage. The docs/ directory contains comprehensive documentation including tutorials, API references, and coding standards.",
+      "content": "The crates/ directory contains all workspace members. The examples/ directory contains 8 independent workspace projects: hello-world, rest-api, database-integration, tutorial-basis, tutorial-rest, twitter, github-issues, di-showcase. The docs/ directory contains comprehensive documentation.",
       "author": "Maintainer"
     },
     {
-      "content": "Feature flag system: 'minimal' for microservices (~5-10MB), 'standard' for typical web apps (~20-30MB), 'full' for all features (~50+MB). Individual features can be toggled granularly (e.g., db-postgres, auth-jwt, middleware-cors).",
+      "content": "Feature flag system: 'minimal' for microservices (~5-10MB), 'standard' for typical web apps (~20-30MB), 'full' for all features (~50+MB). Individual features can be toggled granularly (e.g., db-postgres, auth-jwt, middleware-cors). Note: the url-resolver feature has been REMOVED — URL resolution is always available on native targets.",
+      "author": "Architect"
+    },
+    {
+      "content": "DI System migration (breaking, since rc.16 deprecation): (1) Injected<T>/OptionalInjected<T> deprecated → use Depends<T>. (2) #[inject] parameter type changed Arc<T> → Depends<T>. (3) #[injectable] no longer auto-derives Clone — add #[derive(Clone)] explicitly. (4) #[injectable] without explicit scope now registers with Request scope. (5) DependencyRegistration struct fields changed to fn pointers (const-compatible, Rust 2024). (6) Pseudo orphan rule: cannot register #[injectable_factory]/#[injectable] for reinhardt-managed types — use newtype wrapper. (7) Validated<T> extractor auto-calls Validate::validate() during extraction.",
+      "author": "Maintainer"
+    },
+    {
+      "content": "URL Routing migration (breaking): (1) #[url_patterns] now requires typed enum syntax: #[url_patterns(InstalledApp::app_name, mode = server|client|unified)]. Function name changed: url_patterns() → server_url_patterns() / client_url_patterns() / unified_url_patterns(). (2) Namespaced URL resolver access: urls.user_list() (deprecated) → urls.users().list(). (3) ViewSet route names use get_basename() instead of prefix. (4) UrlPatternsRegistration.get_server_router field renamed to factory.",
+      "author": "Architect"
+    },
+    {
+      "content": "Macros migration (breaking): #[export_endpoints] attribute macro removed — replaced by define_views! function-like proc macro for stable Rust support.",
+      "author": "Maintainer"
+    },
+    {
+      "content": "Forms/Frontend migration (breaking): (1) client_validators block in form! macro now emits compile error — migrate to unified validators with scope annotations: #[client(on = submit|input|blur)]. (2) form! macro now auto-passes CSRF token to server_fn on non-GET forms (no explicit csrf_token field needed). (3) SubmitButton is now a first-class field type in form! macro.",
+      "author": "Maintainer"
+    },
+    {
+      "content": "Auth system migration (breaking): (1) User trait deprecated → use AuthIdentity + BaseUser/FullUser + PermissionsMixin. (2) DefaultUser deprecated → define own struct with #[user(hasher = ..., username_field = ..., full = ...)] macro. (3) JwtAuth method return types changed to Result<_, JwtError> (was reinhardt_core::exception::Result). Expired tokens are now rejected by default.",
+      "author": "Architect"
+    },
+    {
+      "content": "Admin system migration (breaking): (1) admin_routes() removed (was deprecated since rc.14). admin_routes_with_di_deferred(site) renamed to admin_routes_with_di(site). (2) ModelAdmin permission methods now accept &dyn AdminUser instead of &(dyn Any + Send + Sync). (3) FormFieldSpec enum added — field_type_to_html_input_type removed. (4) Admin JWT authentication flow added for WASM SPA.",
+      "author": "Architect"
+    },
+    {
+      "content": "Configuration migration (breaking): (1) #[settings] macro introduced for Settings structs. SettingsFragment.validate() moved to SettingsValidation supertrait — import SettingsValidation where .validate() is called. External SettingsFragment implementors must also impl SettingsValidation. (2) Settings.installed_apps field, add_app(), and with_validated_apps() deprecated → use installed_apps! macro with ApplicationBuilder.",
+      "author": "Maintainer"
+    },
+    {
+      "content": "Background Tasks migration (breaking): TaskLock trait API changed. acquire() now returns Option<LockToken> instead of bool. release(task_id, &token) and extend(task_id, &token, ttl) now require ownership token for safety.",
+      "author": "Maintainer"
+    },
+    {
+      "content": "Database migration (breaking): BatchUpdateBuilder::add_update() and build_sql() removed (were SQL injection vulnerable). SetAutoIncrementValue and CreateCompositePrimaryKey migration ops added. Silent PostgreSQL fallbacks now cause hard failures.",
+      "author": "Maintainer"
+    },
+    {
+      "content": "Security hardening: DI resolution errors are redacted from server_fn 500 responses. UUID generation migrated to v7 across the codebase (v4 retained for security-sensitive tokens). Empty user_id is rejected as unauthenticated. is_active DB check enforced in admin dashboard. All deprecation since versions corrected to 0.1.0-rc.16.",
       "author": "Architect"
     }
   ],
   "pages": [
     {
       "title": "Architecture Overview",
-      "purpose": "Explain the polylithic architecture philosophy, how crates are organized in layers (Foundation, Data, REST, Auth, Advanced), and the request/response flow through the framework.",
+      "purpose": "Explain the polylithic architecture philosophy, how crates are organized in layers (Foundation, Data, REST, Auth, Advanced), the request/response flow through the framework, and the develop/0.2.0 roadmap for upcoming crates (payment, cms, deploy, social, taggit, etc.).",
       "parent": null
     },
     {
       "title": "Core Foundation",
-      "purpose": "Document reinhardt-core (types, exceptions, validators, signals), reinhardt-http (request/response types), reinhardt-server (Hyper-based server), and reinhardt-macros.",
+      "purpose": "Document reinhardt-core (types, exceptions, validators, signals, use_endpoint! macro for multi-file view resolver re-export), reinhardt-http (request/response types), reinhardt-server (Hyper-based server with RunserverHook for concurrent startup and pre-listen validation), and reinhardt-macros including the new define_views! macro (replaces deprecated #[export_endpoints] attribute).",
       "parent": "Architecture Overview"
     },
     {
       "title": "Dependency Injection",
-      "purpose": "Document reinhardt-di: FastAPI-inspired type-safe async DI system with scoped/singleton support, injectable types, and integration with request handlers.",
+      "purpose": "Document reinhardt-di: FastAPI-inspired type-safe async DI system. Key API (current): Depends<T> (preferred wrapper), #[injectable] macro (does NOT auto-derive Clone — add explicitly), #[inject] macro (parameter type is Depends<T>, NOT Arc<T>), DependencyRegistration with fn pointer fields (const-compatible for Rust 2024), Validated<T> extractor (auto-calls validate() during extraction), with_test_di_context() for isolated parallel-safe test DI contexts, startup registry sanity check, pseudo orphan rule (cannot register framework-managed types — use newtype wrapper), FrameworkTypeOverride validation, try_unwrap() for non-Clone ownership transfer. Deprecated: Injected<T>, OptionalInjected<T> (since 0.1.0-rc.16) — use Depends<T>.",
       "parent": "Architecture Overview"
     },
     {
       "title": "URL Routing",
-      "purpose": "Document reinhardt-urls: URL pattern matching, path converters, route registration, and how routing integrates with the middleware pipeline.",
+      "purpose": "Document reinhardt-urls: Typed URL pattern matching with #[url_patterns(InstalledApp::Variant, mode = server|client|unified)] (string literal syntax removed). Generated function names: server_url_patterns()/client_url_patterns()/unified_url_patterns(). #[viewset] macro for ViewSet registration (ViewSet route names use get_basename()). #[routes] macro (supports async functions), per-app namespaced URL resolver structs (urls.app_name().route_name() instead of deprecated urls.app_name_route_name()). define_views! macro for multi-file view modules (replaces removed #[export_endpoints]). ClientUrlReverser for client-side type-safe URL resolution. URL resolution is always available on native targets — url-resolver feature flag removed.",
+      "parent": "Architecture Overview"
+    },
+    {
+      "title": "App Registry",
+      "purpose": "Document reinhardt-apps: AppLabel trait (now requires explicit LABEL const — breaking), path() method for enum-style AppLabel implementors, installed_apps! macro with ApplicationBuilder (Settings.installed_apps field, add_app(), and with_validated_apps() are deprecated). The startapp command auto-appends entries to the installed_apps! block.",
+      "parent": "Architecture Overview"
+    },
+    {
+      "title": "Configuration",
+      "purpose": "Document reinhardt-conf: #[settings] macro for Settings struct definitions. SettingsFragment trait no longer has validate() — moved to SettingsValidation supertrait (import SettingsValidation where .validate() is called; external SettingsFragment impls must also impl SettingsValidation). Per-test settings override for TestContainers integration. DJANGO_SETTINGS_MODULE env var support.",
       "parent": "Architecture Overview"
     },
     {
       "title": "Database Layer",
-      "purpose": "Document reinhardt-db: ORM with Model definitions, QuerySet API (filter, exclude, annotate, aggregate), migrations system, relationships (ForeignKey, ManyToMany), and supported backends (PostgreSQL, MySQL, SQLite, CockroachDB).",
+      "purpose": "Document reinhardt-db: ORM with Model definitions, QuerySet API (filter, exclude, annotate, aggregate), migrations system including SetAutoIncrementValue and CreateCompositePrimaryKey ops (added since rc.15), relationships (ForeignKey, ManyToMany), supported backends (PostgreSQL, MySQL, SQLite, CockroachDB). Silent PostgreSQL fallbacks now cause hard failures. BatchUpdateBuilder.add_update() and build_sql() removed (SQL injection surface — use parameterized equivalents). Use reinhardt-query for SQL construction.",
       "parent": null
     },
     {
@@ -55,7 +105,7 @@
     },
     {
       "title": "Authentication System",
-      "purpose": "Document reinhardt-auth: Authentication backends (JWT, Token, Session, OAuth2, Basic), permission system (DjangoModelPermissions, object-level), user/group management.",
+      "purpose": "Document reinhardt-auth: Current API: AuthIdentity + BaseUser/FullUser + PermissionsMixin traits, #[user(hasher = ..., username_field = ..., full = ...)] derive macro. Deprecated (since 0.1.0-rc.16): User trait, DefaultUser struct. Authentication backends (JWT — JwtAuth methods now return Result<_, JwtError>, expired tokens rejected by default), Token, Session, OAuth2, Basic. Permission system (DjangoModelPermissions, object-level). #[user] attribute macro for auth trait generation. Social auth (GitHub, Google, Apple, Microsoft OIDC) is in develop/0.2.0.",
       "parent": null
     },
     {
@@ -65,12 +115,12 @@
     },
     {
       "title": "Forms",
-      "purpose": "Document reinhardt-forms: Django-style form processing with 20+ field types, validation, ModelForms, FormSets, and FormWizards.",
+      "purpose": "Document reinhardt-forms: Django-style form processing with 20+ field types, form! macro with unified validators (ValidatorScope with #[client(on = submit|input|blur)] scope annotations), SubmitButton field type, autocomplete attribute support, auto-pass CSRF token to server_fn on non-GET forms. Deprecated: client_validators block (compile error — migrate to unified validators). ModelForms, FormSets, FormWizards. See docs/migration/0.2.0-client-validators-removal.md.",
       "parent": null
     },
     {
       "title": "Frontend Framework",
-      "purpose": "Document reinhardt-pages: WASM-based frontend with fine-grained reactivity, SSR, hydration, and JSX-like macros (page!, head!).",
+      "purpose": "Document reinhardt-pages: WASM-based frontend with fine-grained reactivity, SSR, hydration, and JSX-like macros (page!, head!). MSW-style network interception via MockableServerFn trait (msw feature) — MockFetch and mock_server_fn are deprecated in favor of MSW. define_views! macro for multi-file view modules (stable Rust, replaces #[export_endpoints]).",
       "parent": null
     },
     {
@@ -80,33 +130,43 @@
     },
     {
       "title": "Background Tasks",
-      "purpose": "Document reinhardt-tasks: Celery-inspired task queue with scheduling, retries, DAG execution, worker load balancing, and integration with the framework.",
+      "purpose": "Document reinhardt-tasks: Celery-inspired task queue with scheduling, retries, DAG execution with edge rollback, worker load balancing, and integration with the framework. TaskLock trait API: acquire() returns Option<LockToken> (was bool); release(task_id, &token) and extend(task_id, &token, ttl) require LockToken for ownership verification (atomic lock acquisition).",
       "parent": null
     },
     {
       "title": "Admin Panel",
-      "purpose": "Document reinhardt-admin: Admin interface generation, model registration, custom admin views, and reinhardt-admin-cli.",
+      "purpose": "Document reinhardt-admin: Admin interface generation. API: admin_routes_with_di(site) is the sole entry point (admin_routes() removed since rc.16, AdminRouter deprecated). ModelAdmin permission methods accept &dyn AdminUser (not &dyn Any). FormFieldSpec enum for preserving field choices (field_type_to_html_input_type removed). TextArea/Select/MultiSelect render as proper HTML elements. JWT authentication flow for WASM SPA (sessionStorage token management). is_active DB check enforced in dashboard. BaseUser-only model support. reinhardt-admin-cli (AST-based page! detection, missing page! is a no-op).",
       "parent": null
     },
     {
       "title": "Utilities",
-      "purpose": "Document reinhardt-utils (timezone, caching, storage, static files), reinhardt-i18n (internationalization), reinhardt-mail (email backends).",
+      "purpose": "Document reinhardt-utils (timezone, caching, storage, static files), reinhardt-i18n (internationalization), reinhardt-mail (email backends). UUID generation: v7 used across the codebase for standard IDs; v4 retained for security-sensitive tokens.",
       "parent": null
     },
     {
       "title": "Feature Flags Guide",
-      "purpose": "Explain the three-level feature hierarchy (minimal/standard/full), module-level features, database backends, auth variants, and how to optimize binary size.",
+      "purpose": "Explain the three-level feature hierarchy (minimal/standard/full), module-level features, database backends, auth variants, and how to optimize binary size. Note: url-resolver feature has been REMOVED — URL resolution is now always available on native targets without any feature flag.",
       "parent": null
     },
     {
       "title": "Example Projects",
-      "purpose": "Document the 7 example projects in examples/local/: hello-world, rest-api, database-integration, tutorial-basis, tutorial-rest, twitter, github-issues.",
+      "purpose": "Document the 8 example projects in examples/ (each is an independent Cargo workspace): hello-world, rest-api, database-integration, tutorial-basis, tutorial-rest, twitter, github-issues, and di-showcase (demonstrates DI patterns with Depends<T>).",
       "parent": null
     },
     {
       "title": "Testing Guide",
-      "purpose": "Document reinhardt-test: TestContainers integration, test fixtures, and testing best practices for Reinhardt applications.",
+      "purpose": "Document reinhardt-test (TestContainers integration, test fixtures) and reinhardt-testkit (builder-based auth testing API, with_test_di_context() for isolated parallel-safe test DI contexts, per-test settings override for TestContainers). Testing best practices: use rstest, AAA pattern, reinhardt-testkit for auth scenarios, with_test_di_context() for DI isolation in parallel tests.",
       "parent": null
-    }
+    },
+    {
+      "title": "Security Hardening",
+      "purpose": "Document security improvements: (1) DI resolution errors redacted from server_fn 500 responses. (2) UUID v7 migration (v4 retained for CSRF/session tokens). (3) Empty user_id rejection as unauthenticated. (4) is_active DB check in admin dashboard. (5) BatchUpdateBuilder SQL injection surface removed. (6) JwtAuth now rejects expired tokens by default. (7) Pseudo orphan rule preventing framework type overrides in DI registry.",
+      "parent": null
+    },
+    {
+      "title": "Migration Guide: rc.15 → rc.16",
+      "purpose": "Step-by-step migration for the rc.16 breaking changes: (1) DI: replace Injected<T> with Depends<T>, change #[inject] Arc<T> to Depends<T>, add #[derive(Clone)] to #[injectable] types, update DependencyRegistration to fn pointer API. (2) URLs: update #[url_patterns] to typed InstalledApp::Variant syntax, rename url_patterns() to server/client/unified_url_patterns(), update URL resolver access to namespaced style, remove url-resolver feature from Cargo.toml. (3) Auth: replace User/DefaultUser with AuthIdentity/BaseUser/FullUser/#[user] macro, update JwtAuth error handling to JwtError. (4) Admin: replace admin_routes() with admin_routes_with_di(site), update ModelAdmin permission methods to &dyn AdminUser. (5) Conf: impl SettingsValidation for custom SettingsFragment types, migrate from Settings.installed_apps to installed_apps! macro. (6) Tasks: update TaskLock usage to LockToken pattern. (7) Forms: migrate client_validators to unified validators with #[client(on=...)] scope.",
+      "parent": null
+    },
   ]
 }

--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -162,11 +162,6 @@
       "title": "Security Hardening",
       "purpose": "Document security hardening across the framework: error response sanitization, UUID generation strategy, authentication strictness, admin access controls, SQL injection surface reduction, and DI registry type safety.",
       "parent": null
-    },
-    {
-      "title": "Migration Guide: rc.15 → rc.16",
-      "purpose": "Step-by-step migration guide for rc.16 breaking changes covering: DI system, URL routing, authentication, admin interface, configuration, background tasks, and forms.",
-      "parent": null
     }
   ]
 }

--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -1,7 +1,7 @@
 {
   "repo_notes": [
     {
-      "content": "Reinhardt is a polylithic batteries-included Rust web framework inspired by Django, Django REST Framework, and FastAPI. The framework is organized as a Cargo workspace with 70+ crates, allowing users to select only the components they need via feature flags. Current version: 0.1.0-rc.15 (next planned: 0.1.0-rc.16).",
+      "content": "Reinhardt is a polylithic batteries-included Rust web framework inspired by Django, Django REST Framework, and FastAPI. The framework is organized as a Cargo workspace with 70+ crates, allowing users to select only the components they need via feature flags.",
       "author": "Maintainer"
     },
     {
@@ -17,7 +17,7 @@
       "author": "Architect"
     },
     {
-      "content": "DI System migration (breaking, since rc.16 deprecation): (1) Injected<T>/OptionalInjected<T> deprecated → use Depends<T>. (2) #[inject] parameter type changed Arc<T> → Depends<T>. (3) #[injectable] no longer auto-derives Clone — add #[derive(Clone)] explicitly. (4) #[injectable] without explicit scope now registers with Request scope. (5) DependencyRegistration struct fields changed to fn pointers (const-compatible, Rust 2024). (6) Pseudo orphan rule: cannot register #[injectable_factory]/#[injectable] for reinhardt-managed types — use newtype wrapper. (7) Validated<T> extractor auto-calls Validate::validate() during extraction.",
+      "content": "DI System migration (breaking, deprecated as of rc.16): (1) Injected<T>/OptionalInjected<T> deprecated → use Depends<T>. (2) #[inject] parameter type changed Arc<T> → Depends<T>. (3) #[injectable] no longer auto-derives Clone — add #[derive(Clone)] explicitly. (4) #[injectable] without explicit scope now registers with Request scope. (5) DependencyRegistration struct fields changed to fn pointers (const-compatible, Rust 2024). (6) Pseudo orphan rule: cannot register #[injectable_factory]/#[injectable] for reinhardt-managed types — use newtype wrapper. (7) Validated<T> extractor auto-calls Validate::validate() during extraction.",
       "author": "Maintainer"
     },
     {
@@ -41,7 +41,7 @@
       "author": "Architect"
     },
     {
-      "content": "Configuration migration (breaking): (1) #[settings] macro introduced for Settings structs. SettingsFragment.validate() moved to SettingsValidation supertrait — import SettingsValidation where .validate() is called. External SettingsFragment implementors must also impl SettingsValidation. (2) Settings.installed_apps field, add_app(), and with_validated_apps() deprecated → use installed_apps! macro with ApplicationBuilder.",
+      "content": "Configuration migration (breaking): (1) #[settings] macro introduced for Settings structs. SettingsFragment.validate() moved to SettingsValidation supertrait — import SettingsValidation where .validate() is called. External SettingsFragment implementors must also impl SettingsValidation. (2) Settings.installed_apps field, add_app(), and with_validated_apps() are deprecated → use installed_apps! macro with ApplicationBuilder.",
       "author": "Maintainer"
     },
     {

--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -60,37 +60,37 @@
   "pages": [
     {
       "title": "Architecture Overview",
-      "purpose": "Explain the polylithic architecture philosophy, how crates are organized in layers (Foundation, Data, REST, Auth, Advanced), the request/response flow through the framework, and the develop/0.2.0 roadmap for upcoming crates (payment, cms, deploy, social, taggit, etc.).",
+      "purpose": "Explain the polylithic architecture philosophy, how crates are organized in layers (Foundation, Data, REST, Auth, Advanced), the request/response flow through the framework, and the roadmap for upcoming crates.",
       "parent": null
     },
     {
       "title": "Core Foundation",
-      "purpose": "Document reinhardt-core (types, exceptions, validators, signals), reinhardt-http (request/response types), reinhardt-server (Hyper-based server with RunserverHook for concurrent startup and pre-listen validation), and reinhardt-macros.",
+      "purpose": "Document reinhardt-core (types, exceptions, validators, signals), reinhardt-http (request/response types), reinhardt-server (Hyper-based server with lifecycle hooks), and reinhardt-macros.",
       "parent": "Architecture Overview"
     },
     {
       "title": "Dependency Injection",
-      "purpose": "Document reinhardt-di: FastAPI-inspired type-safe async DI system. Key API (current): Depends<T> (preferred wrapper), #[injectable] macro (does NOT auto-derive Clone — add explicitly), #[inject] macro (parameter type is Depends<T>, NOT Arc<T>), DependencyRegistration with fn pointer fields (const-compatible for Rust 2024), Validated<T> extractor (auto-calls validate() during extraction), with_test_di_context() for isolated parallel-safe test DI contexts, startup registry sanity check, pseudo orphan rule (cannot register framework-managed types — use newtype wrapper), FrameworkTypeOverride validation, try_unwrap() for non-Clone ownership transfer. Deprecated: Injected<T>, OptionalInjected<T> (since 0.1.0-rc.16) — use Depends<T>.",
+      "purpose": "Document reinhardt-di: FastAPI-inspired type-safe async DI system with scoped/singleton/request-scope support, injectable types and macros, validation extractors, startup registry sanity checks, pseudo orphan rule for framework type safety, and test isolation utilities.",
       "parent": "Architecture Overview"
     },
     {
       "title": "URL Routing",
-      "purpose": "Document reinhardt-urls: Typed URL pattern matching with #[url_patterns(InstalledApp::Variant, mode = server|client|unified)] (string literal syntax removed). Conventional function naming examples: server_url_patterns()/client_url_patterns()/unified_url_patterns(), but #[url_patterns] does not require specific function names. #[viewset] macro for ViewSet registration (ViewSet route names use get_basename()). #[routes] macro (supports async functions), per-app namespaced URL resolver structs (urls.app_name().route_name() instead of deprecated urls.app_name_route_name()). Multi-file view module organization. ClientUrlReverser for client-side type-safe URL resolution. URL resolution is always available on native targets — url-resolver feature flag removed.",
+      "purpose": "Document reinhardt-urls: typed URL pattern matching with mode-aware route registration (server/client/unified), per-app namespaced URL resolvers, ViewSet and route macros, client-side type-safe URL resolution, and multi-file view module organization.",
       "parent": "Architecture Overview"
     },
     {
       "title": "App Registry",
-      "purpose": "Document reinhardt-apps: AppLabel trait (now requires explicit LABEL const — breaking), path() method for enum-style AppLabel implementors, installed_apps! macro with ApplicationBuilder (Settings.installed_apps field, add_app(), and with_validated_apps() are deprecated). The startapp command auto-appends entries to the installed_apps! block.",
+      "purpose": "Document reinhardt-apps: application registry and discovery, AppLabel trait, installed_apps! macro with ApplicationBuilder, and the startapp command.",
       "parent": "Architecture Overview"
     },
     {
       "title": "Configuration",
-      "purpose": "Document reinhardt-conf: #[settings] macro for Settings struct definitions. SettingsFragment trait defines validate(). Per-test settings override for TestContainers integration. REINHARDT_SETTINGS_MODULE env var support.",
+      "purpose": "Document reinhardt-conf: settings struct macros, SettingsFragment trait, per-test settings override, and environment variable configuration.",
       "parent": "Architecture Overview"
     },
     {
       "title": "Database Layer",
-      "purpose": "Document reinhardt-db: ORM with Model definitions, QuerySet API (filter, exclude, annotate, aggregate), migrations system including SetAutoIncrementValue and CreateCompositePrimaryKey ops (added since rc.15), relationships (ForeignKey, ManyToMany), supported backends (PostgreSQL, MySQL, SQLite, CockroachDB). Silent PostgreSQL fallbacks now cause hard failures. BatchUpdateBuilder.add_update() and build_sql() removed (SQL injection surface — use parameterized equivalents). Use reinhardt-query for SQL construction.",
+      "purpose": "Document reinhardt-db: ORM with Model definitions, QuerySet API, migrations system, relationships (ForeignKey, ManyToMany), and supported backends (PostgreSQL, MySQL, SQLite, CockroachDB). Use reinhardt-query for SQL construction.",
       "parent": null
     },
     {
@@ -105,7 +105,7 @@
     },
     {
       "title": "Authentication System",
-      "purpose": "Document reinhardt-auth: Current API: AuthIdentity + BaseUser/FullUser + PermissionsMixin traits, #[user(hasher = ..., username_field = ..., full = ...)] attribute proc macro. Deprecated (since 0.1.0-rc.15): User trait, DefaultUser struct. Authentication backends (JWT — JwtAuth methods now return Result<_, JwtError>, expired tokens rejected by default), Token, Session, OAuth2, Basic. Permission system (DjangoModelPermissions, object-level). #[user] attribute macro for auth trait generation. Social auth (GitHub, Google, Apple, Microsoft OIDC) is in develop/0.2.0.",
+      "purpose": "Document reinhardt-auth: user identity traits and macros, authentication backends (JWT, Token, Session, OAuth2, Basic), and permission system (DjangoModelPermissions, object-level).",
       "parent": null
     },
     {
@@ -115,12 +115,12 @@
     },
     {
       "title": "Forms",
-      "purpose": "Document reinhardt-forms: Django-style form processing with 20+ field types, form! macro with unified validators (ValidatorScope with #[client(on = submit|input|blur)] scope annotations), SubmitButton field type, autocomplete attribute support, auto-pass CSRF token to server_fn on non-GET forms. Deprecated: client_validators block (compile error — migrate to unified validators). ModelForms, FormSets, FormWizards. See docs/migration/0.2.0-client-validators-removal.md.",
+      "purpose": "Document reinhardt-forms: Django-style form processing with multiple field types, form! macro with unified client/server validation, ModelForms, FormSets, and FormWizards.",
       "parent": null
     },
     {
       "title": "Frontend Framework",
-      "purpose": "Document reinhardt-pages: WASM-based frontend with fine-grained reactivity, SSR, hydration, and JSX-like macros (page!, head!). MSW-style network interception via MockableServerFn trait (msw feature) — MockFetch and mock_server_fn are deprecated in favor of MSW. Multi-file view module organization.",
+      "purpose": "Document reinhardt-pages: WASM-based frontend with fine-grained reactivity, SSR, hydration, JSX-like macros, network interception for testing, and multi-file view module organization.",
       "parent": null
     },
     {
@@ -130,22 +130,22 @@
     },
     {
       "title": "Background Tasks",
-      "purpose": "Document reinhardt-tasks: Celery-inspired task queue with scheduling, retries, DAG execution with edge rollback, worker load balancing, and integration with the framework. TaskLock trait API: acquire() returns Option<LockToken> (was bool); release(task_id, &token) and extend(task_id, &token, ttl) require LockToken for ownership verification (atomic lock acquisition).",
+      "purpose": "Document reinhardt-tasks: Celery-inspired task queue with scheduling, retries, DAG execution with edge rollback, worker load balancing, distributed lock primitives, and framework integration.",
       "parent": null
     },
     {
       "title": "Admin Panel",
-      "purpose": "Document reinhardt-admin: Admin interface generation. API: admin_routes_with_di(site) is the sole entry point (admin_routes() removed since rc.16, AdminRouter deprecated). ModelAdmin permission methods accept &dyn AdminUser (not &dyn Any). FormFieldSpec enum for preserving field choices (field_type_to_html_input_type removed). TextArea/Select/MultiSelect render as proper HTML elements. JWT authentication flow for WASM SPA (sessionStorage token management). is_active DB check enforced in dashboard. BaseUser-only model support. reinhardt-admin-cli (AST-based page! detection, missing page! is a no-op).",
+      "purpose": "Document reinhardt-admin: auto-generated admin interface, model registration, permission system, form field rendering, JWT authentication for WASM SPA, and reinhardt-admin-cli for code generation.",
       "parent": null
     },
     {
       "title": "Utilities",
-      "purpose": "Document reinhardt-utils (timezone, caching, storage, static files), reinhardt-i18n (internationalization), reinhardt-mail (email backends). UUID generation: v7 used across the codebase for standard IDs; v4 retained for security-sensitive tokens.",
+      "purpose": "Document reinhardt-utils (timezone, caching, storage, static files), reinhardt-i18n (internationalization), and reinhardt-mail (email backends).",
       "parent": null
     },
     {
       "title": "Feature Flags Guide",
-      "purpose": "Explain the three-level feature hierarchy (minimal/standard/full), module-level features, database backends, auth variants, and how to optimize binary size. Note: url-resolver feature has been REMOVED — URL resolution is now always available on native targets without any feature flag.",
+      "purpose": "Explain the three-level feature hierarchy (minimal/standard/full), module-level features, database backends, auth variants, and how to optimize binary size.",
       "parent": null
     },
     {
@@ -155,17 +155,17 @@
     },
     {
       "title": "Testing Guide",
-      "purpose": "Document reinhardt-test (TestContainers integration, test fixtures) and reinhardt-testkit (builder-based auth testing API, with_test_di_context() for isolated parallel-safe test DI contexts, per-test settings override for TestContainers). Testing best practices: use rstest, AAA pattern, reinhardt-testkit for auth scenarios, with_test_di_context() for DI isolation in parallel tests.",
+      "purpose": "Document reinhardt-test (TestContainers integration, test fixtures) and reinhardt-testkit (auth testing utilities, DI context isolation for parallel tests, per-test settings override). Testing best practices: rstest, AAA pattern.",
       "parent": null
     },
     {
       "title": "Security Hardening",
-      "purpose": "Document security improvements: (1) DI resolution errors redacted from server_fn 500 responses. (2) UUID v7 migration (v4 retained for CSRF/session tokens). (3) Empty user_id rejection as unauthenticated. (4) is_active DB check in admin dashboard. (5) BatchUpdateBuilder SQL injection surface removed. (6) JwtAuth now rejects expired tokens by default. (7) Pseudo orphan rule preventing framework type overrides in DI registry.",
+      "purpose": "Document security hardening across the framework: error response sanitization, UUID generation strategy, authentication strictness, admin access controls, SQL injection surface reduction, and DI registry type safety.",
       "parent": null
     },
     {
       "title": "Migration Guide: rc.15 → rc.16",
-      "purpose": "Step-by-step migration for the rc.16 breaking changes: (1) DI: replace Injected<T> with Depends<T>, change #[inject] Arc<T> to Depends<T>, add #[derive(Clone)] to #[injectable] types, update DependencyRegistration to fn pointer API. (2) URLs: update #[url_patterns] to typed InstalledApp::Variant syntax, rename url_patterns() to server/client/unified_url_patterns(), update URL resolver access to namespaced style, remove url-resolver feature from Cargo.toml. (3) Auth: replace User/DefaultUser with AuthIdentity/BaseUser/FullUser/#[user] macro, update JwtAuth error handling to JwtError. (4) Admin: replace admin_routes() with admin_routes_with_di(site), update ModelAdmin permission methods to &dyn AdminUser. (5) Conf: impl SettingsValidation for custom SettingsFragment types, migrate from Settings.installed_apps to installed_apps! macro. (6) Tasks: update TaskLock usage to LockToken pattern. (7) Forms: migrate client_validators to unified validators with #[client(on=...)] scope.",
+      "purpose": "Step-by-step migration guide for rc.16 breaking changes covering: DI system, URL routing, authentication, admin interface, configuration, background tasks, and forms.",
       "parent": null
     }
   ]

--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -25,7 +25,7 @@
       "author": "Architect"
     },
     {
-      "content": "Macros migration (breaking): #[export_endpoints] attribute macro removed — use a function-like proc macro for stable Rust support.",
+      "content": "Macros migration (breaking): #[export_endpoints] attribute macro removed — multi-file view module organization is now supported through stable alternatives.",
       "author": "Maintainer"
     },
     {
@@ -65,7 +65,7 @@
     },
     {
       "title": "Core Foundation",
-      "purpose": "Document reinhardt-core (types, exceptions, validators, signals), reinhardt-http (request/response types), reinhardt-server (Hyper-based server with RunserverHook for concurrent startup and pre-listen validation), and reinhardt-macros (including the macro replacing deprecated #[export_endpoints]).",
+      "purpose": "Document reinhardt-core (types, exceptions, validators, signals), reinhardt-http (request/response types), reinhardt-server (Hyper-based server with RunserverHook for concurrent startup and pre-listen validation), and reinhardt-macros.",
       "parent": "Architecture Overview"
     },
     {
@@ -75,7 +75,7 @@
     },
     {
       "title": "URL Routing",
-      "purpose": "Document reinhardt-urls: Typed URL pattern matching with #[url_patterns(InstalledApp::Variant, mode = server|client|unified)] (string literal syntax removed). Conventional function naming examples: server_url_patterns()/client_url_patterns()/unified_url_patterns(), but #[url_patterns] does not require specific function names. #[viewset] macro for ViewSet registration (ViewSet route names use get_basename()). #[routes] macro (supports async functions), per-app namespaced URL resolver structs (urls.app_name().route_name() instead of deprecated urls.app_name_route_name()). Multi-file view module support (replaces removed #[export_endpoints]). ClientUrlReverser for client-side type-safe URL resolution. URL resolution is always available on native targets — url-resolver feature flag removed.",
+      "purpose": "Document reinhardt-urls: Typed URL pattern matching with #[url_patterns(InstalledApp::Variant, mode = server|client|unified)] (string literal syntax removed). Conventional function naming examples: server_url_patterns()/client_url_patterns()/unified_url_patterns(), but #[url_patterns] does not require specific function names. #[viewset] macro for ViewSet registration (ViewSet route names use get_basename()). #[routes] macro (supports async functions), per-app namespaced URL resolver structs (urls.app_name().route_name() instead of deprecated urls.app_name_route_name()). Multi-file view module organization. ClientUrlReverser for client-side type-safe URL resolution. URL resolution is always available on native targets — url-resolver feature flag removed.",
       "parent": "Architecture Overview"
     },
     {
@@ -120,7 +120,7 @@
     },
     {
       "title": "Frontend Framework",
-      "purpose": "Document reinhardt-pages: WASM-based frontend with fine-grained reactivity, SSR, hydration, and JSX-like macros (page!, head!). MSW-style network interception via MockableServerFn trait (msw feature) — MockFetch and mock_server_fn are deprecated in favor of MSW. Multi-file view module support (stable Rust, replaces #[export_endpoints]).",
+      "purpose": "Document reinhardt-pages: WASM-based frontend with fine-grained reactivity, SSR, hydration, and JSX-like macros (page!, head!). MSW-style network interception via MockableServerFn trait (msw feature) — MockFetch and mock_server_fn are deprecated in favor of MSW. Multi-file view module organization.",
       "parent": null
     },
     {

--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -25,7 +25,7 @@
       "author": "Architect"
     },
     {
-      "content": "Macros migration (breaking): #[export_endpoints] attribute macro removed — replaced by define_views! function-like proc macro for stable Rust support.",
+      "content": "Macros migration (breaking): #[export_endpoints] attribute macro removed — use a function-like proc macro for stable Rust support.",
       "author": "Maintainer"
     },
     {
@@ -65,7 +65,7 @@
     },
     {
       "title": "Core Foundation",
-      "purpose": "Document reinhardt-core (types, exceptions, validators, signals, define_views! macro for multi-file view resolver re-export), reinhardt-http (request/response types), reinhardt-server (Hyper-based server with RunserverHook for concurrent startup and pre-listen validation), and reinhardt-macros including the new define_views! macro (replaces deprecated #[export_endpoints] attribute).",
+      "purpose": "Document reinhardt-core (types, exceptions, validators, signals), reinhardt-http (request/response types), reinhardt-server (Hyper-based server with RunserverHook for concurrent startup and pre-listen validation), and reinhardt-macros (including the macro replacing deprecated #[export_endpoints]).",
       "parent": "Architecture Overview"
     },
     {
@@ -75,7 +75,7 @@
     },
     {
       "title": "URL Routing",
-      "purpose": "Document reinhardt-urls: Typed URL pattern matching with #[url_patterns(InstalledApp::Variant, mode = server|client|unified)] (string literal syntax removed). Conventional function naming examples: server_url_patterns()/client_url_patterns()/unified_url_patterns(), but #[url_patterns] does not require specific function names. #[viewset] macro for ViewSet registration (ViewSet route names use get_basename()). #[routes] macro (supports async functions), per-app namespaced URL resolver structs (urls.app_name().route_name() instead of deprecated urls.app_name_route_name()). define_views! macro for multi-file view modules (replaces removed #[export_endpoints]). ClientUrlReverser for client-side type-safe URL resolution. URL resolution is always available on native targets — url-resolver feature flag removed.",
+      "purpose": "Document reinhardt-urls: Typed URL pattern matching with #[url_patterns(InstalledApp::Variant, mode = server|client|unified)] (string literal syntax removed). Conventional function naming examples: server_url_patterns()/client_url_patterns()/unified_url_patterns(), but #[url_patterns] does not require specific function names. #[viewset] macro for ViewSet registration (ViewSet route names use get_basename()). #[routes] macro (supports async functions), per-app namespaced URL resolver structs (urls.app_name().route_name() instead of deprecated urls.app_name_route_name()). Multi-file view module support (replaces removed #[export_endpoints]). ClientUrlReverser for client-side type-safe URL resolution. URL resolution is always available on native targets — url-resolver feature flag removed.",
       "parent": "Architecture Overview"
     },
     {
@@ -120,7 +120,7 @@
     },
     {
       "title": "Frontend Framework",
-      "purpose": "Document reinhardt-pages: WASM-based frontend with fine-grained reactivity, SSR, hydration, and JSX-like macros (page!, head!). MSW-style network interception via MockableServerFn trait (msw feature) — MockFetch and mock_server_fn are deprecated in favor of MSW. define_views! macro for multi-file view modules (stable Rust, replaces #[export_endpoints]).",
+      "purpose": "Document reinhardt-pages: WASM-based frontend with fine-grained reactivity, SSR, hydration, and JSX-like macros (page!, head!). MSW-style network interception via MockableServerFn trait (msw feature) — MockFetch and mock_server_fn are deprecated in favor of MSW. Multi-file view module support (stable Rust, replaces #[export_endpoints]).",
       "parent": null
     },
     {

--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -9,7 +9,7 @@
       "author": "Architect"
     },
     {
-      "content": "The crates/ directory contains all workspace members. The examples/ directory contains 8 independent workspace projects: hello-world, rest-api, database-integration, tutorial-basis, tutorial-rest, twitter, github-issues, di-showcase. The docs/ directory contains comprehensive documentation.",
+      "content": "The crates/ directory contains all workspace members. The examples/ directory currently contains 3 workspace members: examples-tutorial-basis, examples-tutorial-rest, examples-twitter. The docs/ directory contains comprehensive documentation.",
       "author": "Maintainer"
     },
     {
@@ -21,7 +21,7 @@
       "author": "Maintainer"
     },
     {
-      "content": "URL Routing migration (breaking): (1) #[url_patterns] now requires typed enum syntax: #[url_patterns(InstalledApp::app_name, mode = server|client|unified)]. Function name changed: url_patterns() → server_url_patterns() / client_url_patterns() / unified_url_patterns(). (2) Namespaced URL resolver access: urls.user_list() (deprecated) → urls.users().list(). (3) ViewSet route names use get_basename() instead of prefix. (4) UrlPatternsRegistration.get_server_router field renamed to factory.",
+      "content": "URL Routing migration (breaking): (1) #[url_patterns] now requires typed enum syntax: #[url_patterns(InstalledApp::app_name, mode = server|client|unified)]. Recommended naming convention: use server_url_patterns() / client_url_patterns() / unified_url_patterns() instead of url_patterns(); the #[url_patterns] macro does not require a specific function name. (2) Namespaced URL resolver access: urls.user_list() (deprecated) → urls.users().list(). (3) ViewSet route names use get_basename() instead of prefix. (4) UrlPatternsRegistration.get_server_router field renamed to factory.",
       "author": "Architect"
     },
     {
@@ -65,7 +65,7 @@
     },
     {
       "title": "Core Foundation",
-      "purpose": "Document reinhardt-core (types, exceptions, validators, signals, use_endpoint! macro for multi-file view resolver re-export), reinhardt-http (request/response types), reinhardt-server (Hyper-based server with RunserverHook for concurrent startup and pre-listen validation), and reinhardt-macros including the new define_views! macro (replaces deprecated #[export_endpoints] attribute).",
+      "purpose": "Document reinhardt-core (types, exceptions, validators, signals, define_views! macro for multi-file view resolver re-export), reinhardt-http (request/response types), reinhardt-server (Hyper-based server with RunserverHook for concurrent startup and pre-listen validation), and reinhardt-macros including the new define_views! macro (replaces deprecated #[export_endpoints] attribute).",
       "parent": "Architecture Overview"
     },
     {
@@ -75,7 +75,7 @@
     },
     {
       "title": "URL Routing",
-      "purpose": "Document reinhardt-urls: Typed URL pattern matching with #[url_patterns(InstalledApp::Variant, mode = server|client|unified)] (string literal syntax removed). Generated function names: server_url_patterns()/client_url_patterns()/unified_url_patterns(). #[viewset] macro for ViewSet registration (ViewSet route names use get_basename()). #[routes] macro (supports async functions), per-app namespaced URL resolver structs (urls.app_name().route_name() instead of deprecated urls.app_name_route_name()). define_views! macro for multi-file view modules (replaces removed #[export_endpoints]). ClientUrlReverser for client-side type-safe URL resolution. URL resolution is always available on native targets — url-resolver feature flag removed.",
+      "purpose": "Document reinhardt-urls: Typed URL pattern matching with #[url_patterns(InstalledApp::Variant, mode = server|client|unified)] (string literal syntax removed). Conventional function naming examples: server_url_patterns()/client_url_patterns()/unified_url_patterns(), but #[url_patterns] does not require specific function names. #[viewset] macro for ViewSet registration (ViewSet route names use get_basename()). #[routes] macro (supports async functions), per-app namespaced URL resolver structs (urls.app_name().route_name() instead of deprecated urls.app_name_route_name()). define_views! macro for multi-file view modules (replaces removed #[export_endpoints]). ClientUrlReverser for client-side type-safe URL resolution. URL resolution is always available on native targets — url-resolver feature flag removed.",
       "parent": "Architecture Overview"
     },
     {
@@ -85,7 +85,7 @@
     },
     {
       "title": "Configuration",
-      "purpose": "Document reinhardt-conf: #[settings] macro for Settings struct definitions. SettingsFragment trait no longer has validate() — moved to SettingsValidation supertrait (import SettingsValidation where .validate() is called; external SettingsFragment impls must also impl SettingsValidation). Per-test settings override for TestContainers integration. DJANGO_SETTINGS_MODULE env var support.",
+      "purpose": "Document reinhardt-conf: #[settings] macro for Settings struct definitions. SettingsFragment trait defines validate(). Per-test settings override for TestContainers integration. REINHARDT_SETTINGS_MODULE env var support.",
       "parent": "Architecture Overview"
     },
     {
@@ -105,7 +105,7 @@
     },
     {
       "title": "Authentication System",
-      "purpose": "Document reinhardt-auth: Current API: AuthIdentity + BaseUser/FullUser + PermissionsMixin traits, #[user(hasher = ..., username_field = ..., full = ...)] derive macro. Deprecated (since 0.1.0-rc.16): User trait, DefaultUser struct. Authentication backends (JWT — JwtAuth methods now return Result<_, JwtError>, expired tokens rejected by default), Token, Session, OAuth2, Basic. Permission system (DjangoModelPermissions, object-level). #[user] attribute macro for auth trait generation. Social auth (GitHub, Google, Apple, Microsoft OIDC) is in develop/0.2.0.",
+      "purpose": "Document reinhardt-auth: Current API: AuthIdentity + BaseUser/FullUser + PermissionsMixin traits, #[user(hasher = ..., username_field = ..., full = ...)] attribute proc macro. Deprecated (since 0.1.0-rc.15): User trait, DefaultUser struct. Authentication backends (JWT — JwtAuth methods now return Result<_, JwtError>, expired tokens rejected by default), Token, Session, OAuth2, Basic. Permission system (DjangoModelPermissions, object-level). #[user] attribute macro for auth trait generation. Social auth (GitHub, Google, Apple, Microsoft OIDC) is in develop/0.2.0.",
       "parent": null
     },
     {
@@ -150,7 +150,7 @@
     },
     {
       "title": "Example Projects",
-      "purpose": "Document the 8 example projects in examples/ (each is an independent Cargo workspace): hello-world, rest-api, database-integration, tutorial-basis, tutorial-rest, twitter, github-issues, and di-showcase (demonstrates DI patterns with Depends<T>).",
+      "purpose": "Document the 3 example projects in examples/: tutorial-basis, tutorial-rest, and twitter.",
       "parent": null
     },
     {
@@ -167,6 +167,6 @@
       "title": "Migration Guide: rc.15 → rc.16",
       "purpose": "Step-by-step migration for the rc.16 breaking changes: (1) DI: replace Injected<T> with Depends<T>, change #[inject] Arc<T> to Depends<T>, add #[derive(Clone)] to #[injectable] types, update DependencyRegistration to fn pointer API. (2) URLs: update #[url_patterns] to typed InstalledApp::Variant syntax, rename url_patterns() to server/client/unified_url_patterns(), update URL resolver access to namespaced style, remove url-resolver feature from Cargo.toml. (3) Auth: replace User/DefaultUser with AuthIdentity/BaseUser/FullUser/#[user] macro, update JwtAuth error handling to JwtError. (4) Admin: replace admin_routes() with admin_routes_with_di(site), update ModelAdmin permission methods to &dyn AdminUser. (5) Conf: impl SettingsValidation for custom SettingsFragment types, migrate from Settings.installed_apps to installed_apps! macro. (6) Tasks: update TaskLock usage to LockToken pattern. (7) Forms: migrate client_validators to unified validators with #[client(on=...)] scope.",
       "parent": null
-    },
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Update `.devin/wiki.json` to reflect post-0.1.0-rc.15 breaking changes and new documentation topics for the Reinhardt framework.

- Expanded `repo_notes` with migration/breaking-change context (DI, URLs, macros, forms, auth, admin, conf, tasks, DB, security)
- Updated existing page purposes and added new pages (App Registry, Security Hardening)
- Replaced version-specific API details with capability-level descriptions so Deepwiki can auto-detect the current API from the codebase

## Type of Change

- [x] Documentation update

## Motivation and Context

`.devin/wiki.json` was outdated and did not reflect the rc.16 breaking changes. Devin relies on this file to navigate the codebase; stale metadata leads to incorrect code generation.

## How Was This Tested?

- Validated JSON syntax with `python3 -m json.tool`
- Verified all Copilot review threads resolved

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage (AWS Spot instances),
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)