### PR TITLE
chore: remove commented-out dead imports in reinhardt-core and reinhardt-urls

### DIFF
--- a/crates/reinhardt-core/src/serializers/fields.rs
+++ b/crates/reinhardt-core/src/serializers/fields.rs
@@ -3,7 +3,6 @@
 //! This module provides Django REST Framework-inspired field types for data validation
 //! and transformation in serializers.
 
-// use serde::{Deserialize, Serialize};
 use chrono::{NaiveDate, NaiveDateTime};
 use std::fmt;
 

--- a/crates/reinhardt-urls/src/routers/reverse.rs
+++ b/crates/reinhardt-urls/src/routers/reverse.rs
@@ -3,7 +3,6 @@
 ///
 /// This module provides both string-based (runtime) and type-safe (compile-time)
 /// URL reversal mechanisms.
-// use crate::path;
 use super::pattern::validate_reverse_param;
 use super::{PathPattern, Route};
 use aho_corasick::AhoCorasick;


### PR DESCRIPTION
## Summary

This PR addresses:

- Removal of two commented-out `use` imports that constitute dead code detected by the `rust-commented-out-code` semgrep rule

## Type of Change

- [x] Code quality improvements

## Motivation and Context

Two commented-out imports were flagged by the `rust-commented-out-code` semgrep rule added in #3757. Since neither import is used or referenced in any nearby code, they are safe to delete outright.

Fixes #3763

## How Was This Tested?

- `cargo check -p reinhardt-core -p reinhardt-urls` — passes with no warnings

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #3763

## Labels to Apply

- [x] `code-quality` - Code quality improvements
- [x] `ci-cd` - CI/CD workflow changes