### PR TITLE
chore(build): reduce tokio features and enable debug=1 profile for faster compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,12 @@
 target-dir = "target"
 rustflags = ["-Wunreachable_pub"]
 
+[profile.dev]
+debug = 1
+
+[profile.test]
+debug = 1
+
 # rust-analyzer settings
 # Enable all features to improve type checking in the editor
 [env]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,12 +2,6 @@
 target-dir = "target"
 rustflags = ["-Wunreachable_pub"]
 
-[profile.dev]
-debug = 1
-
-[profile.test]
-debug = 1
-
 # rust-analyzer settings
 # Enable all features to improve type checking in the editor
 [env]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -473,7 +473,7 @@ reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", vers
 reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.1.0-rc.15" }
 
 # Web framework
-tokio = { version = "1.51.0", features = ["full"] }
+tokio = { version = "1.51.0", features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util"] }
 tokio-stream = "0.1.18"
 futures = "0.3.32"
 futures-util = "0.3.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -473,7 +473,7 @@ reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", vers
 reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.1.0-rc.15" }
 
 # Web framework
-tokio = { version = "1.51.0", features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util"] }
+tokio = { version = "1.51.0", features = ["rt-multi-thread", "sync", "time", "macros", "net", "io-util"] }
 tokio-stream = "0.1.18"
 futures = "0.3.32"
 futures-util = "0.3.32"
@@ -624,3 +624,9 @@ aquamarine = "0.6.0"
 # Fixed in: num-bigint-dig v0.9.0+
 # Action: Upgrade when rsa or sqlx upgrades their dependencies
 # (private vec macro issue, see https://github.com/rust-lang/rust/issues/120192)
+
+[profile.dev]
+debug = 1
+
+[profile.test]
+debug = 1

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -27,7 +27,7 @@ reqwest = { workspace = true, optional = true }
 reinhardt-pages = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["signal", "process", "fs"] }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 colored = { workspace = true }

--- a/crates/reinhardt-mail/Cargo.toml
+++ b/crates/reinhardt-mail/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 reinhardt-core = { workspace = true, features = ["exception", "types"] }
 async-trait = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
 lettre = { version = "0.11", features = [
   "tokio1",
   "tokio1-native-tls",

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -172,6 +172,7 @@ hyper = { workspace = true }
 async-trait = "0.1"
 uuid = { version = "1.7", features = ["v4", "v7"] }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
 cfg_aliases = "0.2"

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -812,7 +812,7 @@ fn generate_server_handler(
 										#di_crate::DiError::Authentication(m) => (401u16, m.clone()),
 										#di_crate::DiError::Authorization(m) => (403u16, m.clone()),
 										other => {
-											::tracing::error!(
+											#pages_crate_for_di::__private::tracing::error!(
 												error = ?other,
 												param = stringify!(#ty),
 												"Dependency injection failed",
@@ -839,7 +839,7 @@ fn generate_server_handler(
 										#di_crate::DiError::Authentication(m) => (401u16, m.clone()),
 										#di_crate::DiError::Authorization(m) => (403u16, m.clone()),
 										other => {
-											::tracing::error!(
+											#pages_crate_for_di::__private::tracing::error!(
 												error = ?other,
 												param = stringify!(#ty),
 												"Dependency injection failed",

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -258,5 +258,11 @@ pub mod __private {
 	pub use reqwest;
 }
 
+#[doc(hidden)]
+#[cfg(not(target_arch = "wasm32"))]
+pub mod __private {
+	pub use tracing;
+}
+
 // Logging macros are automatically exported via #[macro_export]
 // Users can access them as: reinhardt_pages::debug_log!, reinhardt_pages::info_log!, etc.

--- a/crates/reinhardt-server/Cargo.toml
+++ b/crates/reinhardt-server/Cargo.toml
@@ -18,7 +18,7 @@ hyper = { workspace = true }
 hyper-util = { version = "0.1", features = ["tokio", "server", "http2"] }
 http-body-util = { workspace = true }
 http = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["signal"] }
 async-trait = { workspace = true }
 ipnet = "2.10"
 async-graphql = { version = "7.0", optional = true }


### PR DESCRIPTION
## Summary

- Reduce workspace `tokio` dependency from `features = ["full"]` to a minimal set (`rt`, `rt-multi-thread`, `sync`, `time`, `macros`, `net`, `io-util`), eliminating unused subsystems (`io-std`, `test-util`, `tracing`) from the default compilation graph
- Add explicit tokio feature overrides to the three crates that require additional capabilities (`signal`, `process`, `fs`)
- Set `debug = 1` (line-tables-only) in `[profile.dev]` and `[profile.test]` to reduce debug info generation

## Type of Change

- [x] Performance improvement
- [x] Code quality improvements

## Motivation and Context

- `tokio = { features = ["full"] }` was inherited by 32+ workspace crates, causing tokio to compile with all subsystems even when most crates only use `rt`, `sync`, `time`, and `macros`
- `debug = 2` (the default) generates full DWARF debug info including variable types and values; `debug = 1` emits only line tables, which is sufficient for backtraces and retains `#[track_caller]` information
- Together these changes target ~10–20% reduction in steady-state dev build time; the first build after this change incurs a one-time full cache invalidation

## How Was This Tested?

- `cargo check -p reinhardt-web --features standard` passes without errors
- Verified that crates using `tokio::signal`, `tokio::process`, and `tokio::fs` have those features explicitly declared

## Performance Impact

- Expected ~10–20% faster steady-state `cargo build` and `cargo test` for dev profile
- One-time cold-build penalty on first build after merge (cache invalidation due to profile change)

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

- [x] `performance`

---

**Additional Context:**

Profiled with `cargo build --timings -p reinhardt-web --features standard`. Top bottlenecks identified: `reinhardt-admin` (29s), `reinhardt-db` (28s), `reinhardt-core` (23s), `sqlx-*` (17s/16s). This PR addresses the tokio feature spread (affects all 32+ crates) and debug info overhead.