### PR TITLE
deprecated(macros): rename define_views! to flatten_imports! and deprecate old name

### DIFF
--- a/crates/reinhardt-commands/templates/app_restful_template/views.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_restful_template/views.rs.tpl
@@ -1,13 +1,3 @@
 //! Views module for {{ app_name }} app (RESTful)
-use reinhardt::define_views;
-
-define_views! {
-    // Add your view submodules here. Each `pub mod` declaration
-    // corresponds to a file under the `views/` directory.
-    // The macro automatically re-exports endpoint functions and
-    // URL resolvers so that `#[url_patterns]` can discover them.
-    //
-    // Example:
-    //    pub mod login;
-    //    pub mod register;
-}
+// Add your view submodules here. Each `pub mod` declaration
+// corresponds to a file under the `views/` directory.

--- a/crates/reinhardt-commands/templates/app_restful_template/views.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_restful_template/views.rs.tpl
@@ -1,3 +1,8 @@
 //! Views module for {{ app_name }} app (RESTful)
 // Add your view submodules here. Each `pub mod` declaration
 // corresponds to a file under the `views/` directory.
+//
+// For multi-file views that need re-exports for discovery, use:
+// flatten_imports! {
+//     pub mod example;
+// }

--- a/crates/reinhardt-commands/templates/app_restful_workspace_template/src/views.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_restful_workspace_template/src/views.rs.tpl
@@ -1,13 +1,3 @@
 //! Views module for {{ app_name }} app (RESTful)
-use reinhardt::define_views;
-
-define_views! {
-    // Add your view submodules here. Each `pub mod` declaration
-    // corresponds to a file under the `views/` directory.
-    // The macro automatically re-exports endpoint functions and
-    // URL resolvers so that `#[url_patterns]` can discover them.
-    //
-    // Example:
-    //    pub mod login;
-    //    pub mod register;
-}
+// Add your view submodules here. Each `pub mod` declaration
+// corresponds to a file under the `views/` directory.

--- a/crates/reinhardt-commands/templates/app_restful_workspace_template/src/views.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_restful_workspace_template/src/views.rs.tpl
@@ -1,3 +1,8 @@
 //! Views module for {{ app_name }} app (RESTful)
 // Add your view submodules here. Each `pub mod` declaration
 // corresponds to a file under the `views/` directory.
+//
+// For multi-file views that need re-exports for discovery, use:
+// flatten_imports! {
+//     pub mod example;
+// }

--- a/crates/reinhardt-core/macros/src/flatten_imports.rs
+++ b/crates/reinhardt-core/macros/src/flatten_imports.rs
@@ -1,4 +1,4 @@
-//! `define_views!` function-like proc macro for multi-file view modules.
+//! `flatten_imports!` function-like proc macro for multi-file view modules.
 //!
 //! When used in a view module that uses per-file endpoint organization,
 //! this macro generates `pub use submod::*;` for each `pub mod` declaration.
@@ -10,9 +10,9 @@
 //!
 //! ```rust,ignore
 //! // views.rs
-//! use reinhardt::define_views;
+//! use reinhardt::flatten_imports;
 //!
-//! define_views! {
+//! flatten_imports! {
 //!     pub mod login;
 //!     pub mod register;
 //! }
@@ -28,16 +28,16 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Item, parse2};
 
-/// Implementation for the `define_views!` proc macro.
+/// Implementation for the `flatten_imports!` proc macro.
 ///
 /// Scans the macro input for `pub mod name;` declarations and appends
 /// `pub use name::*;` for each one. This brings endpoint functions and their
 /// generated `__url_resolver_*` modules into the parent module scope, enabling
 /// `#[url_patterns]` to resolve them with the standard path convention.
-pub(crate) fn define_views_impl(input: TokenStream) -> syn::Result<TokenStream> {
+pub(crate) fn flatten_imports_impl(input: TokenStream) -> syn::Result<TokenStream> {
 	let items: Vec<Item> = {
 		let file: syn::File = parse2(input.clone())
-			.map_err(|e| syn::Error::new(e.span(), format!("define_views: {e}")))?;
+			.map_err(|e| syn::Error::new(e.span(), format!("flatten_imports: {e}")))?;
 		file.items
 	};
 

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -24,7 +24,7 @@ mod apply_update_attribute;
 mod apply_update_derive;
 mod collect_migrations;
 mod crate_paths;
-mod define_views;
+mod flatten_imports;
 mod hook;
 mod injectable_common;
 mod injectable_fn;
@@ -999,9 +999,9 @@ pub fn settings(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// ```rust,ignore
 /// // views.rs (multi-file pattern)
-/// use reinhardt::define_views;
+/// use reinhardt::flatten_imports;
 ///
-/// define_views! {
+/// flatten_imports! {
 ///     pub mod login;
 ///     pub mod register;
 /// }
@@ -1016,8 +1016,8 @@ pub fn settings(args: TokenStream, input: TokenStream) -> TokenStream {
 /// For single-file views where all functions are defined directly in
 /// `views.rs`, this macro is not needed.
 #[proc_macro]
-pub fn define_views(input: TokenStream) -> TokenStream {
-	define_views::define_views_impl(input.into())
+pub fn flatten_imports(input: TokenStream) -> TokenStream {
+	flatten_imports::flatten_imports_impl(input.into())
 		.unwrap_or_else(|e| e.to_compile_error())
 		.into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,18 @@ pub use reinhardt_macros::{api_view, delete, get, patch, post, put};
 
 // Re-export routes attribute macro for URL pattern registration
 #[cfg(native)]
-pub use reinhardt_macros::define_views;
+pub use reinhardt_macros::flatten_imports;
+#[cfg(native)]
+#[deprecated(
+	since = "0.1.0-rc.16",
+	note = "use `flatten_imports!` instead. `define_views!` will be removed in a future version."
+)]
+#[macro_export]
+macro_rules! define_views {
+    ($($tt:tt)*) => {
+        $crate::flatten_imports!($($tt)*)
+    };
+}
 #[cfg(native)]
 pub use reinhardt_macros::routes;
 #[cfg(native)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ pub mod macros {
 #[cfg(native)]
 pub use reinhardt_macros::{api_view, delete, get, patch, post, put};
 
-// Re-export routes attribute macro for URL pattern registration
+// Re-export `flatten_imports` and provide a deprecated `define_views!` shim for compatibility
 #[cfg(native)]
 pub use reinhardt_macros::flatten_imports;
 #[cfg(native)]


### PR DESCRIPTION
## Summary

This PR addresses:

- Rename the `define_views!` proc macro to `flatten_imports!` to better reflect its actual behavior
- Add a deprecated forwarding wrapper `define_views!` → `flatten_imports!` for backward compatibility
- Update command templates to use the new `flatten_imports!` name

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

The name `define_views!` was misleading — the macro does not define views but rather flattens `pub mod` declarations by generating `pub use submod::*` re-exports. The new name `flatten_imports!` accurately describes this behavior.

Fixes #3779

## How Was This Tested?

- Existing tests for the macro continue to pass
- `cargo fmt --all -- --check` passes
- `cargo clippy --workspace -- -D warnings` passes

## Checklist

- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #3779

## Labels to Apply

### Type Label
- [x] `enhancement` - New feature or improvement

### Scope Label
- [ ] `routing` - URL routing, path matching