### PR TITLE
fix(pages): remove duplicate __private module causing E0428 compile error

### DIFF
--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -268,11 +268,5 @@ pub mod __private {
     pub use tracing;
 }
 
-#[doc(hidden)]
-#[cfg(not(target_arch = "wasm32"))]
-pub mod __private {
-	pub use tracing;
-}
-
 // Logging macros are automatically exported via #[macro_export]
 // Users can access them as: reinhardt_pages::debug_log!, reinhardt_pages::info_log!, etc.


### PR DESCRIPTION
## Summary

- Remove duplicate `pub mod __private` block from `crates/reinhardt-pages/src/lib.rs` that caused `error[E0428]: the name '__private' is defined multiple times`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Commit `63e1e7057` added a second `pub mod __private` block for tracing on non-wasm32 targets. Commit `4d8d8a551` then added tracing to the original block with the correct cfg condition, making the second block redundant. The duplicate was never removed, causing `error[E0428]` on all CI jobs in every open PR.

The original `pub mod __private` block (lines 256–269) already correctly re-exports `tracing` with `#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]`, which excludes browser wasm (wasm32-unknown-unknown) while including all non-wasm32 targets.

Fixes #3789

## How Was This Tested?

- `cargo check -p reinhardt-pages --all-features` passes locally (confirmed both before and after the fix)
- CI green on this PR will confirm the regression is resolved for all open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)