### PR TITLE
fix(macros/ws): address 5 bugs in #[websocket] macro and url_patterns consumer path (Fixes #3794-#3798)

### DIFF
--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -765,7 +765,13 @@ fn build_ws_resolvers(body_tokens: &[proc_macro2::TokenTree]) -> TokenStream {
 		.map(|path| {
 			let parsed: syn::Path = match syn::parse2(path.clone()) {
 				Ok(p) => p,
-				Err(_) => return quote! {},
+				Err(_) => {
+					return syn::Error::new_spanned(
+						path,
+						"`.consumer(...)` argument must be a path to a handler function",
+					)
+					.to_compile_error();
+				}
 			};
 			if parsed.segments.is_empty() {
 				return quote! {};

--- a/crates/reinhardt-core/macros/src/websocket.rs
+++ b/crates/reinhardt-core/macros/src/websocket.rs
@@ -1,6 +1,9 @@
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{FnArg, ItemFn, Pat, PatType, Result, punctuated::Punctuated, token::Comma};
+use syn::{
+    FnArg, ItemFn, LitStr, Pat, PatType, Result, Token,
+    parse::{Parse, ParseStream, Parser},
+};
 
 use crate::crate_paths::get_reinhardt_crate;
 use crate::routes::{InjectInfo, detect_inject_params, extract_url_params, to_resolver_trait_name};
@@ -10,35 +13,42 @@ pub(crate) struct WebSocketArgs {
     pub name: Option<String>,
 }
 
-impl WebSocketArgs {
-    pub(crate) fn parse(args: TokenStream) -> Result<Self> {
-        use proc_macro2::TokenTree;
+impl Parse for WebSocketArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        // First argument: the path string literal (supports raw strings and escapes).
+        let path_lit: LitStr = input.parse().map_err(|e| {
+            syn::Error::new(
+                e.span(),
+                "#[websocket] expects a string path as first argument",
+            )
+        })?;
+        let path = path_lit.value();
 
-        let mut iter = args.into_iter().peekable();
-        let path = match iter.next() {
-            Some(TokenTree::Literal(lit)) => lit.to_string().trim_matches('"').to_string(),
-            other => {
-                return Err(syn::Error::new(
-                    Span::call_site(),
-                    format!(
-                        "#[websocket] expects a string path as first argument, got {:?}",
-                        other.map(|t| t.to_string())
-                    ),
-                ))
+        let mut name: Option<String> = None;
+        while !input.is_empty() {
+            input.parse::<Token![,]>()?;
+            if input.is_empty() {
+                break;
             }
-        };
-        let mut name = None;
-        while let Some(tt) = iter.next() {
-            if let TokenTree::Ident(ident) = tt {
-                if ident == "name" {
-                    iter.next(); // consume `=`
-                    if let Some(TokenTree::Literal(lit)) = iter.next() {
-                        name = Some(lit.to_string().trim_matches('"').to_string());
-                    }
-                }
+            let ident: syn::Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+            if ident == "name" {
+                let lit: LitStr = input.parse()?;
+                name = Some(lit.value());
+            } else {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    format!("unknown #[websocket] argument `{}`", ident),
+                ));
             }
         }
         Ok(Self { path, name })
+    }
+}
+
+impl WebSocketArgs {
+    pub(crate) fn parse(args: TokenStream) -> Result<Self> {
+        <Self as Parse>::parse.parse2(args)
     }
 }
 

--- a/crates/reinhardt-core/macros/src/websocket.rs
+++ b/crates/reinhardt-core/macros/src/websocket.rs
@@ -158,6 +158,14 @@ pub(crate) fn generate_ws_url_resolver_tokens(
 /// Main implementation for `#[websocket]` proc macro.
 /// Parallel to `route_impl()` in routes.rs.
 pub(crate) fn websocket_impl(args: TokenStream, mut input: ItemFn) -> Result<TokenStream> {
+    // Handlers must be `async fn`; otherwise the generated `.await` in the
+    // WebSocketConsumer impl produces a confusing type error.
+    if input.sig.asyncness.is_none() {
+        return Err(syn::Error::new_spanned(
+            &input.sig.fn_token,
+            "`#[websocket]` handlers must be `async fn`",
+        ));
+    }
     let reinhardt_crate = get_reinhardt_crate();
     let ws_crate = crate::crate_paths::get_reinhardt_websockets_crate();
     let ws_args = WebSocketArgs::parse(args)?;

--- a/crates/reinhardt-core/macros/src/websocket.rs
+++ b/crates/reinhardt-core/macros/src/websocket.rs
@@ -172,16 +172,10 @@ pub(crate) fn websocket_impl(args: TokenStream, mut input: ItemFn) -> Result<Tok
         syn::Ident::new(&format!("{}_original", fn_name_str), Span::call_site());
     input.sig.ident = original_fn_ident.clone();
 
-    // Strip #[inject] attrs from parameters in the original fn
-    for arg in input.sig.inputs.iter_mut() {
-        if let FnArg::Typed(pt) = arg {
-            pt.attrs
-                .retain(|a| !crate::injectable_common::is_inject_attr(a));
-        }
-    }
-
-    // Separate non-inject params (context + message)
-    let non_inject_params: Vec<&FnArg> = input
+    // Separate non-inject params (context + message) BEFORE stripping
+    // #[inject] attributes — otherwise the filter below matches nothing and
+    // injected params leak into the generated WebSocketConsumer trait impl.
+    let non_inject_params: Vec<FnArg> = input
         .sig
         .inputs
         .iter()
@@ -194,7 +188,16 @@ pub(crate) fn websocket_impl(args: TokenStream, mut input: ItemFn) -> Result<Tok
                 true
             }
         })
+        .cloned()
         .collect();
+
+    // Strip #[inject] attrs from parameters in the original fn
+    for arg in input.sig.inputs.iter_mut() {
+        if let FnArg::Typed(pt) = arg {
+            pt.attrs
+                .retain(|a| !crate::injectable_common::is_inject_attr(a));
+        }
+    }
 
     let non_inject_arg_pats: Vec<&Pat> = non_inject_params
         .iter()

--- a/crates/reinhardt-websockets/tests/websocket_macro_e2e.rs
+++ b/crates/reinhardt-websockets/tests/websocket_macro_e2e.rs
@@ -179,8 +179,10 @@ async fn test_e2e_url_resolution_then_connect() {
     let resolved = router.reverse("echo_ws", &[]).unwrap();
     assert_eq!(resolved, "/ws/echo/");
 
-    // Connect to the actual server
-    let (mut ws, _) = connect_async(&server_url).await.unwrap();
+    // Connect to the actual server using the resolved URL path so that this
+    // test actually exercises the resolver (not just the server root).
+    let connect_url = format!("{}{}", server_url, resolved);
+    let (mut ws, _) = connect_async(&connect_url).await.unwrap();
     ws.send(TMsg::Text("hello".into())).await.unwrap();
 
     // Assert: consumer's on_message echoed back


### PR DESCRIPTION
## Summary

This PR addresses 5 CONFIRMED bugs discovered during agent-suspect validation of PR #3782 (`feature/websocket-url-resolver`):

- #3794: `#[websocket]` macro computed non-inject params before stripping `#[inject]`, producing wrong trait-impl arity
- #3795: macro used TokenTree + `trim_matches('"')` to parse `path = "..."`, breaking raw strings and escapes
- #3796: macro lacked `asyncness` validation — non-async fn produced confusing `.await` error
- #3797: `build_ws_resolvers` silently dropped non-path consumer expressions via `quote!{}` on parse failure
- #3798: WebSocket e2e resolver test connected to the server root rather than the resolved URL

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Each of these bugs was filed as an `agent-suspect` issue during the review of PR #3782, then independently verified with separate-context agents (label removed). This PR ships the fixes on top of `feature/websocket-url-resolver` so they can be folded into #3782 before merge.

Fixes #3794
Fixes #3795
Fixes #3796
Fixes #3797
Fixes #3798

## How Was This Tested?

- \`cargo check --workspace --all-features\` — PASSED
- Per-commit granularity allows individual review and revert

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #3794, #3795, #3796, #3797, #3798
- Based on PR #3782 (\`feature/websocket-url-resolver\`)

## Labels to Apply

### Type Label
- [x] \`bug\` - Bug fix

### Scope Label
- [x] \`websockets\`
- [x] \`routing\`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)