### PR TITLE
fix(query/nosql): address 2 bugs in Redis integration tests and ZAdd builder (Fixes #3804, #3805)

### DIFF
--- a/crates/reinhardt-query/src/nosql/redis/zset.rs
+++ b/crates/reinhardt-query/src/nosql/redis/zset.rs
@@ -75,7 +75,11 @@ impl ZAddBuilder<ZAddNoMode> {
     }
 
     /// Set GT flag: only update if new score is greater.
-    pub fn gt(self) -> ZAddBuilder<ZAddGtMode> {
+    ///
+    /// Named `only_if_greater` (rather than `gt`) to avoid ambiguity with
+    /// `Iterator::gt`, whose blanket impl would otherwise take precedence on
+    /// typestates where GT is not a valid transition.
+    pub fn only_if_greater(self) -> ZAddBuilder<ZAddGtMode> {
         ZAddBuilder {
             mode: Some(ZAddMode::Gt),
             key: self.key,
@@ -86,7 +90,10 @@ impl ZAddBuilder<ZAddNoMode> {
     }
 
     /// Set LT flag: only update if new score is less.
-    pub fn lt(self) -> ZAddBuilder<ZAddLtMode> {
+    ///
+    /// Named `only_if_less` (rather than `lt`) to avoid ambiguity with
+    /// `Iterator::lt`.
+    pub fn only_if_less(self) -> ZAddBuilder<ZAddLtMode> {
         ZAddBuilder {
             mode: Some(ZAddMode::Lt),
             key: self.key,
@@ -99,7 +106,7 @@ impl ZAddBuilder<ZAddNoMode> {
 
 impl ZAddBuilder<ZAddXxMode> {
     /// Add GT flag alongside XX.
-    pub fn gt(self) -> ZAddBuilder<ZAddGtMode> {
+    pub fn only_if_greater(self) -> ZAddBuilder<ZAddGtMode> {
         ZAddBuilder {
             mode: Some(ZAddMode::XxGt),
             key: self.key,
@@ -110,7 +117,7 @@ impl ZAddBuilder<ZAddXxMode> {
     }
 
     /// Add LT flag alongside XX.
-    pub fn lt(self) -> ZAddBuilder<ZAddLtMode> {
+    pub fn only_if_less(self) -> ZAddBuilder<ZAddLtMode> {
         ZAddBuilder {
             mode: Some(ZAddMode::XxLt),
             key: self.key,
@@ -426,7 +433,7 @@ mod tests {
 
     #[rstest]
     fn test_zadd_xx_gt_ch() {
-        let cmd = ZSetCommand::zadd("z").xx().gt().ch().member(5.0, "a").build();
+        let cmd = ZSetCommand::zadd("z").xx().only_if_greater().ch().member(5.0, "a").build();
         assert_eq!(cmd.args(), &[
             b"ZADD".to_vec(), b"z".to_vec(),
             b"XX".to_vec(), b"GT".to_vec(), b"CH".to_vec(),
@@ -436,7 +443,7 @@ mod tests {
 
     #[rstest]
     fn test_zadd_gt_without_xx() {
-        let cmd = ZSetCommand::zadd("z").gt().member(3.0, "m").build();
+        let cmd = ZSetCommand::zadd("z").only_if_greater().member(3.0, "m").build();
         assert_eq!(cmd.args(), &[
             b"ZADD".to_vec(), b"z".to_vec(),
             b"GT".to_vec(), b"3".to_vec(), b"m".to_vec(),
@@ -470,7 +477,7 @@ mod tests {
 
     #[rstest]
     fn test_zadd_lt() {
-        let cmd = ZSetCommand::zadd("z").lt().member(1.0, "x").build();
+        let cmd = ZSetCommand::zadd("z").only_if_less().member(1.0, "x").build();
         assert_eq!(cmd.args(), &[
             b"ZADD".to_vec(), b"z".to_vec(),
             b"LT".to_vec(), b"1".to_vec(), b"x".to_vec(),

--- a/crates/reinhardt-query/tests/compile_fail/zadd_gt_lt_conflict.rs
+++ b/crates/reinhardt-query/tests/compile_fail/zadd_gt_lt_conflict.rs
@@ -1,4 +1,4 @@
 fn main() {
     use reinhardt_query::nosql::redis::zset::ZSetCommand;
-    let _ = ZSetCommand::zadd("z").gt().lt();
+    let _ = ZSetCommand::zadd("z").only_if_greater().only_if_less();
 }

--- a/crates/reinhardt-query/tests/compile_fail/zadd_gt_lt_conflict.stderr
+++ b/crates/reinhardt-query/tests/compile_fail/zadd_gt_lt_conflict.stderr
@@ -1,14 +1,9 @@
-error[E0599]: `ZAddBuilder<ZAddGtMode>` is not an iterator
- --> tests/compile_fail/zadd_gt_lt_conflict.rs:3:41
+error[E0599]: no method named `only_if_less` found for struct `ZAddBuilder<ZAddGtMode>` in the current scope
+ --> tests/compile_fail/zadd_gt_lt_conflict.rs:3:54
   |
-3 |     let _ = ZSetCommand::zadd("z").gt().lt();
-  |                                         ^^ `ZAddBuilder<ZAddGtMode>` is not an iterator
+3 |     let _ = ZSetCommand::zadd("z").only_if_greater().only_if_less();
+  |                                                      ^^^^^^^^^^^^ method not found in `ZAddBuilder<ZAddGtMode>`
   |
- ::: src/nosql/redis/zset.rs
-  |
-  | pub struct ZAddBuilder<M = ZAddNoMode> {
-  | -------------------------------------- doesn't satisfy `ZAddBuilder<ZAddGtMode>: Iterator`
-  |
-  = note: the following trait bounds were not satisfied:
-          `ZAddBuilder<ZAddGtMode>: Iterator`
-          which is required by `&mut ZAddBuilder<ZAddGtMode>: Iterator`
+  = note: the method was found for
+          - `ZAddBuilder`
+          - `ZAddBuilder<ZAddXxMode>`

--- a/crates/reinhardt-query/tests/compile_fail/zadd_nx_gt_conflict.rs
+++ b/crates/reinhardt-query/tests/compile_fail/zadd_nx_gt_conflict.rs
@@ -1,4 +1,4 @@
 fn main() {
     use reinhardt_query::nosql::redis::zset::ZSetCommand;
-    let _ = ZSetCommand::zadd("z").nx().gt();
+    let _ = ZSetCommand::zadd("z").nx().only_if_greater();
 }

--- a/crates/reinhardt-query/tests/compile_fail/zadd_nx_gt_conflict.stderr
+++ b/crates/reinhardt-query/tests/compile_fail/zadd_nx_gt_conflict.stderr
@@ -1,14 +1,9 @@
-error[E0599]: `ZAddBuilder<ZAddNxMode>` is not an iterator
+error[E0599]: no method named `only_if_greater` found for struct `ZAddBuilder<ZAddNxMode>` in the current scope
  --> tests/compile_fail/zadd_nx_gt_conflict.rs:3:41
   |
-3 |     let _ = ZSetCommand::zadd("z").nx().gt();
-  |                                         ^^ `ZAddBuilder<ZAddNxMode>` is not an iterator
+3 |     let _ = ZSetCommand::zadd("z").nx().only_if_greater();
+  |                                         ^^^^^^^^^^^^^^^ method not found in `ZAddBuilder<ZAddNxMode>`
   |
- ::: src/nosql/redis/zset.rs
-  |
-  | pub struct ZAddBuilder<M = ZAddNoMode> {
-  | -------------------------------------- doesn't satisfy `ZAddBuilder<ZAddNxMode>: Iterator`
-  |
-  = note: the following trait bounds were not satisfied:
-          `ZAddBuilder<ZAddNxMode>: Iterator`
-          which is required by `&mut ZAddBuilder<ZAddNxMode>: Iterator`
+  = note: the method was found for
+          - `ZAddBuilder`
+          - `ZAddBuilder<ZAddXxMode>`

--- a/crates/reinhardt-query/tests/integration_redis.rs
+++ b/crates/reinhardt-query/tests/integration_redis.rs
@@ -12,6 +12,7 @@ mod redis_integration {
     use testcontainers::runners::AsyncRunner;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
+    use tokio::time::{Duration, timeout};
 
     async fn connect(port: u16) -> TcpStream {
         // Retry with exponential backoff while Redis is starting up inside the container.
@@ -21,7 +22,7 @@ mod redis_integration {
                 Ok(stream) => return stream,
                 Err(_) if retries < 8 => {
                     retries += 1;
-                    tokio::time::sleep(tokio::time::Duration::from_millis(100 * 2u64.pow(retries))).await;
+                    tokio::time::sleep(Duration::from_millis(100 * 2u64.pow(retries))).await;
                 }
                 Err(e) => panic!("failed to connect to Redis after {} retries: {}", retries, e),
             }
@@ -34,9 +35,96 @@ mod redis_integration {
 
     async fn send_recv(stream: &mut TcpStream, cmd: &RespCommand) -> Vec<u8> {
         stream.write_all(&cmd.to_resp3_bytes()).await.unwrap();
-        let mut buf = vec![0u8; 4096];
-        let n = stream.read(&mut buf).await.unwrap();
-        buf[..n].to_vec()
+        read_until_complete(stream).await
+    }
+
+    /// Read RESP frames from the stream until at least one complete frame is
+    /// buffered. TCP reads may return partial data, so a single `read()` call
+    /// is not sufficient. This loops until the accumulated buffer contains a
+    /// complete frame (or no more data arrives within a short timeout).
+    async fn read_until_complete(stream: &mut TcpStream) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::with_capacity(4096);
+        let mut tmp = [0u8; 4096];
+        loop {
+            match timeout(Duration::from_millis(500), stream.read(&mut tmp)).await {
+                Ok(Ok(0)) => break,
+                Ok(Ok(n)) => {
+                    buf.extend_from_slice(&tmp[..n]);
+                    if resp_frame_complete(&buf) {
+                        break;
+                    }
+                }
+                Ok(Err(e)) => panic!("read error: {}", e),
+                // Timed out waiting for more data; return what we have.
+                Err(_) => break,
+            }
+        }
+        buf
+    }
+
+    /// Check if the buffer contains at least one complete RESP2/RESP3 frame.
+    /// Returns the total consumed length on success, or `None` if incomplete.
+    fn resp_frame_len(buf: &[u8]) -> Option<usize> {
+        if buf.is_empty() {
+            return None;
+        }
+        match buf[0] {
+            // Simple string / error / integer / null / boolean / big-number:
+            // terminated by the first CRLF.
+            b'+' | b'-' | b':' | b'_' | b'#' | b'(' => {
+                let rel = find_crlf(&buf[1..])?;
+                Some(1 + rel + 2)
+            }
+            // Bulk string: $<len>\r\n<payload>\r\n (len == -1 means null bulk).
+            b'$' => {
+                let rel = find_crlf(&buf[1..])?;
+                let header_end = 1 + rel + 2;
+                let len: i64 = std::str::from_utf8(&buf[1..1 + rel]).ok()?.parse().ok()?;
+                if len < 0 {
+                    return Some(header_end);
+                }
+                let total = header_end + len as usize + 2;
+                if buf.len() >= total { Some(total) } else { None }
+            }
+            // Array / map / set: aggregate types contain N child frames.
+            b'*' | b'~' => {
+                let rel = find_crlf(&buf[1..])?;
+                let mut cursor = 1 + rel + 2;
+                let count: i64 = std::str::from_utf8(&buf[1..1 + rel]).ok()?.parse().ok()?;
+                if count < 0 {
+                    return Some(cursor);
+                }
+                for _ in 0..count {
+                    let child_len = resp_frame_len(&buf[cursor..])?;
+                    cursor += child_len;
+                }
+                Some(cursor)
+            }
+            b'%' => {
+                let rel = find_crlf(&buf[1..])?;
+                let mut cursor = 1 + rel + 2;
+                let count: i64 = std::str::from_utf8(&buf[1..1 + rel]).ok()?.parse().ok()?;
+                if count < 0 {
+                    return Some(cursor);
+                }
+                // Maps have 2 * count child frames (key + value pairs).
+                for _ in 0..count * 2 {
+                    let child_len = resp_frame_len(&buf[cursor..])?;
+                    cursor += child_len;
+                }
+                Some(cursor)
+            }
+            // Unknown prefix: fall back to the next CRLF so the loop can stop.
+            _ => find_crlf(buf).map(|r| r + 2),
+        }
+    }
+
+    fn resp_frame_complete(buf: &[u8]) -> bool {
+        resp_frame_len(buf).is_some()
+    }
+
+    fn find_crlf(buf: &[u8]) -> Option<usize> {
+        buf.windows(2).position(|w| w == b"\r\n")
     }
 
     fn parse_bulk_string(resp: &[u8]) -> Option<Vec<u8>> {
@@ -163,9 +251,10 @@ mod redis_integration {
         }
         conn.write_all(&all_bytes).await.unwrap();
 
-        // Read all responses (MULTI/EXEC produce multiple lines)
-        let mut buf = vec![0u8; 4096];
-        let _ = conn.read(&mut buf).await.unwrap();
+        // Read all responses (MULTI/EXEC produce multiple lines). Loop until
+        // no more data arrives so partial TCP reads don't leave responses in
+        // the kernel buffer for the next test call.
+        let _ = read_until_complete(&mut conn).await;
 
         // Verify final state
         let get_resp = send_recv(&mut conn, &StringCommand::get("tx_key").build()).await;


### PR DESCRIPTION
## Summary

This PR addresses 2 CONFIRMED bugs discovered during agent-suspect validation of PR #3785 (`feature/nosql-redis-query-builder`):

- #3804: integration tests read RESP responses with a single `stream.read()` call — partial TCP reads cause flakes
- #3805: `ZAddBuilder.gt()/.lt()` names collided with `Iterator::gt/lt` via blanket impls, producing confusing "not an iterator" errors on the wrong typestates

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

### #3804
Added `read_until_complete` helper and a RESP frame completeness parser (`resp_frame_len`) supporting `+`/`-`/`:`/`$`/`*`/`~`/`%`/`_`/`#`/`(` prefixes. The single-`read` calls in `send_recv` and the transaction test were replaced.

### #3805
Renamed `.gt()` → `.only_if_greater()` and `.lt()` → `.only_if_less()` on both `ZAddBuilder<ZAddNoMode>` and `ZAddBuilder<ZAddXxMode>`. Updated internal tests and the trybuild `compile_fail` fixtures (via `TRYBUILD=overwrite`) — errors are now clean `E0599 no method named 'only_if_greater' found` rather than the confusing `is not an iterator`.

Fixes #3804
Fixes #3805

## How Was This Tested?

- \`cargo check -p reinhardt-query --all-features\` — PASSED (clean)
- \`cargo test -p reinhardt-query --lib --features nosql-redis\` — 1974 passed, 0 failed
- \`cargo test -p reinhardt-query --test nosql_compile_fail --features nosql-redis\` — all 4 compile_fail cases pass

## Breaking Changes

This PR layers on top of unmerged PR #3785. Within the scope of the unmerged feature branch, `.gt()`/`.lt()` on `ZAddBuilder` are renamed to `.only_if_greater()`/`.only_if_less()`. No public crate release is affected yet.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #3804, #3805
- Based on PR #3785 (\`feature/nosql-redis-query-builder\`)

## Labels to Apply

### Type Label
- [x] \`bug\` - Bug fix

### Scope Label
- [x] \`orm\` (query builder)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)