### PR TITLE
fix(ws): apply Copilot review feedback from PR #3812

### DIFF
--- a/crates/reinhardt-core/macros/src/websocket.rs
+++ b/crates/reinhardt-core/macros/src/websocket.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
     FnArg, ItemFn, LitStr, Pat, PatType, Result, Token,
-    parse::{Parse, ParseStream, Parser},
+    parse::{Parse, ParseStream},
 };
 
 use crate::crate_paths::get_reinhardt_crate;
@@ -48,7 +48,7 @@ impl Parse for WebSocketArgs {
 
 impl WebSocketArgs {
     pub(crate) fn parse(args: TokenStream) -> Result<Self> {
-        <Self as Parse>::parse.parse2(args)
+        syn::parse2::<Self>(args)
     }
 }
 

--- a/crates/reinhardt-websockets/tests/websocket_macro_e2e.rs
+++ b/crates/reinhardt-websockets/tests/websocket_macro_e2e.rs
@@ -181,7 +181,11 @@ async fn test_e2e_url_resolution_then_connect() {
 
     // Connect to the actual server using the resolved URL path so that this
     // test actually exercises the resolver (not just the server root).
-    let connect_url = format!("{}{}", server_url, resolved);
+    let connect_url = format!(
+        "{}/{}",
+        server_url.trim_end_matches('/'),
+        resolved.trim_start_matches('/')
+    );
     let (mut ws, _) = connect_async(&connect_url).await.unwrap();
     ws.send(TMsg::Text("hello".into())).await.unwrap();
 


### PR DESCRIPTION
## Summary

Applies two Copilot review suggestions from PR #3812:

- URL join in \`crates/reinhardt-websockets/tests/websocket_macro_e2e.rs\`: normalize \`server_url\`/\`resolved\` boundaries before concatenation so the test cannot produce \`ws://host//ws/echo/\` if the test fixture ever changes.
- \`WebSocketArgs::parse\` in \`crates/reinhardt-core/macros/src/websocket.rs\`: drop the manual \`Parser\` trait import and use \`syn::parse2::<Self>(args)\` directly, which is idiomatic for a \`Parse\`-implementing type.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Refs #3798, #3795 (Copilot follow-up to PR #3812)

## How Was This Tested?

- \`cargo check -p reinhardt-macros\` — clean
- No behavioral change (test string join result is byte-identical under the fixtures used)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Based on PR #3782 (\`feature/websocket-url-resolver\`)
- Follow-up to merged PR #3812

## Labels to Apply

### Type Label
- [x] \`bug\` - Bug fix

### Scope Label
- [x] \`websockets\`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)