### PR TITLE
fix: resolve CI failures blocking rc.16 release PR

### DIFF
--- a/crates/reinhardt-pages/src/component/suspense.rs
+++ b/crates/reinhardt-pages/src/component/suspense.rs
@@ -1,7 +1,7 @@
 //! Suspense boundary for lazy loading with resource-aware rendering.
 //!
 //! This module provides [`SuspenseBoundary`], a component that displays a fallback UI
-//! while one or more [`Resource`]s are in the [`ResourceState::Loading`] state. Once all
+//! while one or more [`Resource`]s are in the `ResourceState::Loading` state. Once all
 //! tracked resources have resolved, the actual content is rendered.
 //!
 //! ## Features

--- a/crates/reinhardt-pages/tests/hmr_e2e_tests.rs
+++ b/crates/reinhardt-pages/tests/hmr_e2e_tests.rs
@@ -1,4 +1,4 @@
-#![cfg(not(target_arch = "wasm32"))]
+#![cfg(all(not(target_arch = "wasm32"), feature = "hmr"))]
 //! HMR end-to-end tests.
 //!
 //! Success Criteria:

--- a/crates/reinhardt-pages/tests/hmr_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/hmr_integration_tests.rs
@@ -1,4 +1,4 @@
-#![cfg(not(target_arch = "wasm32"))]
+#![cfg(all(not(target_arch = "wasm32"), feature = "hmr"))]
 //! HMR integration tests.
 //!
 //! Success Criteria:

--- a/crates/reinhardt-testkit/src/containers.rs
+++ b/crates/reinhardt-testkit/src/containers.rs
@@ -1128,7 +1128,7 @@ impl KafkaContainer {
 
 		let host_port = reserve_free_port();
 
-		let image = GenericImage::new("bitnami/kafka", "3.7")
+		let image = GenericImage::new("bitnami/kafka", "3.9")
 			.with_exposed_port(9092.tcp())
 			.with_wait_for(WaitFor::message_on_stdout("Kafka Server started"))
 			.with_env_var("KAFKA_CFG_NODE_ID", "0")

--- a/crates/reinhardt-testkit/src/containers.rs
+++ b/crates/reinhardt-testkit/src/containers.rs
@@ -1084,7 +1084,7 @@ mod tests {
 // KafkaContainer
 // ---------------------------------------------------------------------------
 
-/// A single-broker Kafka container using `bitnami/kafka:3.7` in KRaft mode.
+/// A single-broker Kafka container using `apache/kafka:3.8.1` in KRaft mode.
 ///
 /// # Example
 ///
@@ -1128,28 +1128,26 @@ impl KafkaContainer {
 
 		let host_port = reserve_free_port();
 
-		let image = GenericImage::new("bitnami/kafka", "3.9")
+		let image = GenericImage::new("apache/kafka", "3.8.1")
 			.with_exposed_port(9092.tcp())
 			.with_wait_for(WaitFor::message_on_stdout("Kafka Server started"))
-			.with_env_var("KAFKA_CFG_NODE_ID", "0")
-			.with_env_var("KAFKA_CFG_PROCESS_ROLES", "controller,broker")
+			.with_env_var("KAFKA_NODE_ID", "0")
+			.with_env_var("KAFKA_PROCESS_ROLES", "controller,broker")
 			.with_env_var(
-				"KAFKA_CFG_LISTENERS",
+				"KAFKA_LISTENERS",
 				"PLAINTEXT://:9092,CONTROLLER://:9093",
 			)
 			.with_env_var(
-				"KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP",
+				"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
 				"CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT",
 			)
-			.with_env_var("KAFKA_CFG_CONTROLLER_QUORUM_VOTERS", "0@localhost:9093")
-			.with_env_var("KAFKA_CFG_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
-			.with_env_var("KAFKA_CFG_INTER_BROKER_LISTENER_NAME", "PLAINTEXT")
-			// Required by Bitnami images for PLAINTEXT listeners.
-			.with_env_var("ALLOW_PLAINTEXT_LISTENER", "yes")
+			.with_env_var("KAFKA_CONTROLLER_QUORUM_VOTERS", "0@localhost:9093")
+			.with_env_var("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
+			.with_env_var("KAFKA_INTER_BROKER_LISTENER_NAME", "PLAINTEXT")
 			// Advertise the externally reachable host:port so clients connect to
 			// the mapped host port (not the container-internal 9092).
 			.with_env_var(
-				"KAFKA_CFG_ADVERTISED_LISTENERS",
+				"KAFKA_ADVERTISED_LISTENERS",
 				format!("PLAINTEXT://localhost:{host_port}"),
 			)
 			.with_mapped_port(host_port, 9092.tcp());

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = { workspace = true }
 reinhardt-core = { workspace = true, features = ["exception", "security", "types"] }
 reinhardt-http = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
 hyper = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix rustdoc broken intra-doc link (`ResourceState::Loading`) in `reinhardt-pages` suspense component
- Fix missing `feature = \"hmr\"` cfg gate in HMR integration test file (`hmr_integration_tests.rs`)
- Fix missing `feature = \"hmr\"` cfg gate in HMR e2e test file (`hmr_e2e_tests.rs`)
- Fix missing `tokio/fs` feature in `reinhardt-utils` Cargo.toml
- Migrate Kafka TestContainers image from `bitnami/kafka:3.9` to `apache/kafka:3.8.1` (bitnami/kafka removed from Docker Hub)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

PR #3819 (release-plz rc.15 → rc.16) exposed 4 CI failures all present in `main`:

| Check | Root Cause |
|-------|-----------|
| Docs.rs Build | `` [`ResourceState::Loading`] `` intra-doc link broken (item not in scope) |
| UI Tests (all 8) | `hmr_integration_tests.rs` and `hmr_e2e_tests.rs` missing `feature = "hmr"` in `#![cfg(...)]` |
| SemVer Check | `reinhardt-utils` uses `tokio::fs` but workspace tokio lacks `fs` feature |
| Intra-Crate Tests | `bitnami/kafka` removed from Docker Hub; migrated to `apache/kafka:3.8.1` |

Related to: #3819

## How Was This Tested?

- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps -p reinhardt-pages` → passes
- `cargo check -p reinhardt-utils --all-features` → passes (previously 49 errors)
- `apache/kafka:3.8.1` confirmed available on Docker Hub with same startup message

🤖 Generated with [Claude Code](https://claude.com/claude-code)