### PR TITLE
fix(middleware): resolve SessionData injection for unauthenticated requests

### DIFF
--- a/crates/reinhardt-middleware/src/session.rs
+++ b/crates/reinhardt-middleware/src/session.rs
@@ -1400,8 +1400,14 @@ impl Injectable for SessionData {
 			.map(|cn| cn.as_str())
 			.unwrap_or(DEFAULT_SESSION_COOKIE_NAME);
 
-		// Extract session ID from Cookie header
-		let session_id = extract_session_id_from_request(&request, cookie_name)?;
+		// Prefer the SessionId injected by SessionMiddleware (present for all requests,
+		// including those without a Cookie header such as the initial login request).
+		// Fall back to parsing the Cookie header for requests that bypass the middleware.
+		let session_id = if let Some(sid) = request.extensions.get::<SessionId>() {
+			sid.as_ref().to_string()
+		} else {
+			extract_session_id_from_request(&request, cookie_name)?
+		};
 
 		// Load SessionData from store
 		store


### PR DESCRIPTION
## Summary

- Fix `SessionData::inject()` failing with HTTP 500 for requests without a session cookie (e.g., the initial login request)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`SessionData::inject()` resolved the session ID by parsing the Cookie header only. Requests without a prior session (such as an initial `POST /api/server_fn/login`) have no cookie, so `extract_session_id_from_request` returned `DiError::NotFound`. The `#[server_fn]` macro maps any non-Auth/AuthZ `DiError` to HTTP 500 "Internal server error", causing `test_auth_flow_login_then_current_user` to fail at the login assertion.

`SessionMiddleware` already handles this case: it creates a fresh `SessionData` for cookie-less requests, saves it to the store, and injects its ID into `request.extensions` as `SessionId`. The fix makes `SessionData::inject()` prefer the `SessionId` extension (always present when `SessionMiddleware` is in the pipeline) and fall back to Cookie-header parsing only when the extension is absent.

Fixes #3821

## How Was This Tested?

- Verified the root cause by tracing `SessionMiddleware::process` → `request.extensions.insert(SessionId)` → `SessionData::inject` reads Cookie header only, missing the extension
- Code change verified to compile cleanly with `cargo check -p reinhardt-middleware`
- Formatting verified with `cargo make fmt-check` (0 files would be reformatted)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `http` - HTTP layer, handlers, middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)