### PR TITLE
fix(examples): unblock release-plz PR by repairing examples-twitter rc.16 drift

### DIFF
--- a/examples/examples-twitter/src/apps/auth/shared/server_fn.rs
+++ b/examples/examples-twitter/src/apps/auth/shared/server_fn.rs
@@ -18,10 +18,15 @@ use {
 };
 
 /// Login user, persist session, and return user info
+///
+/// `_csrf_token` is auto-appended by the `form!` macro for non-GET forms
+/// (commit 0fd5bf1e1 / #3337). CSRF is enforced by middleware, so we accept
+/// and ignore it here. See #3825.
 #[server_fn]
 pub async fn login(
 	email: String,
 	password: String,
+	_csrf_token: String,
 	#[inject] _db: DatabaseConnection,
 	#[inject] session: SessionData,
 	#[inject] store: SessionStoreRef,
@@ -80,12 +85,15 @@ pub async fn login(
 }
 
 /// Register new user
+///
+/// `_csrf_token` is auto-appended by the `form!` macro; see [`login`] for details.
 #[server_fn]
 pub async fn register(
 	username: String,
 	email: String,
 	password: String,
 	password_confirmation: String,
+	_csrf_token: String,
 	#[inject] db: DatabaseConnection,
 ) -> std::result::Result<(), ServerFnError> {
 	// Construct request from parameters

--- a/examples/examples-twitter/src/apps/auth/tests/server_fn.rs
+++ b/examples/examples-twitter/src/apps/auth/tests/server_fn.rs
@@ -149,7 +149,10 @@ async fn test_login_server_fn_success(#[future] twitter_db_pool: (PgPool, String
 	// Act
 	let request = make_request(
 		"/api/server_fn/login",
-		json!({ "email": test_user.email, "password": test_user.password }),
+		// `_csrf_token` is auto-appended by the form! macro on production clients
+		// (#3825 / 0fd5bf1e1); these HTTP tests pass an empty token because no CSRF
+		// middleware is wired in `build_auth_router`.
+		json!({ "email": test_user.email, "password": test_user.password, "_csrf_token": "" }),
 		None,
 	);
 	let response = router
@@ -187,7 +190,7 @@ async fn test_login_server_fn_invalid_credentials(#[future] twitter_db_pool: (Pg
 	// Act
 	let request = make_request(
 		"/api/server_fn/login",
-		json!({ "email": test_user.email, "password": "WrongPassword456" }),
+		json!({ "email": test_user.email, "password": "WrongPassword456", "_csrf_token": "" }),
 		None,
 	);
 	let response = router
@@ -217,7 +220,7 @@ async fn test_login_server_fn_nonexistent_user(#[future] twitter_db_pool: (PgPoo
 	// Act
 	let request = make_request(
 		"/api/server_fn/login",
-		json!({ "email": "nonexistent@example.com", "password": "SomePassword123" }),
+		json!({ "email": "nonexistent@example.com", "password": "SomePassword123", "_csrf_token": "" }),
 		None,
 	);
 	let response = router
@@ -256,7 +259,10 @@ async fn test_login_server_fn_inactive_user(#[future] twitter_db_pool: (PgPool, 
 	// Act
 	let request = make_request(
 		"/api/server_fn/login",
-		json!({ "email": test_user.email, "password": test_user.password }),
+		// `_csrf_token` is auto-appended by the form! macro on production clients
+		// (#3825 / 0fd5bf1e1); these HTTP tests pass an empty token because no CSRF
+		// middleware is wired in `build_auth_router`.
+		json!({ "email": test_user.email, "password": test_user.password, "_csrf_token": "" }),
 		None,
 	);
 	let response = router
@@ -433,7 +439,10 @@ async fn test_login_persists_session_data(#[future] twitter_db_pool: (PgPool, St
 	// Act
 	let request = make_request(
 		"/api/server_fn/login",
-		json!({ "email": test_user.email, "password": test_user.password }),
+		// `_csrf_token` is auto-appended by the form! macro on production clients
+		// (#3825 / 0fd5bf1e1); these HTTP tests pass an empty token because no CSRF
+		// middleware is wired in `build_auth_router`.
+		json!({ "email": test_user.email, "password": test_user.password, "_csrf_token": "" }),
 		Some(&old_session_id),
 	);
 	let response = router
@@ -476,7 +485,10 @@ async fn test_auth_flow_login_then_current_user(#[future] twitter_db_pool: (PgPo
 	// Step 1: Login
 	let request = make_request(
 		"/api/server_fn/login",
-		json!({ "email": test_user.email, "password": test_user.password }),
+		// `_csrf_token` is auto-appended by the form! macro on production clients
+		// (#3825 / 0fd5bf1e1); these HTTP tests pass an empty token because no CSRF
+		// middleware is wired in `build_auth_router`.
+		json!({ "email": test_user.email, "password": test_user.password, "_csrf_token": "" }),
 		None,
 	);
 	let login_response = router

--- a/examples/examples-twitter/src/apps/profile/shared/server_fn.rs
+++ b/examples/examples-twitter/src/apps/profile/shared/server_fn.rs
@@ -101,13 +101,16 @@ pub async fn update_profile(
 /// and converts them to UpdateProfileRequest. Returns `Result<(), ServerFnError>`
 /// as expected by form! macro's submit() method.
 ///
-/// The argument order matches form! macro's field order: avatar_url, bio, location, website
+/// The argument order matches form! macro's field order: avatar_url, bio, location, website,
+/// followed by `_csrf_token` which the macro auto-appends for non-GET forms (#3825).
+/// CSRF is enforced by middleware, so we accept and ignore it here.
 #[server_fn]
 pub async fn update_profile_form(
 	avatar_url: String,
 	bio: String,
 	location: String,
 	website: String,
+	_csrf_token: String,
 	#[inject] db: DatabaseConnection,
 	#[inject] AuthUser(user): AuthUser<User>,
 ) -> std::result::Result<(), ServerFnError> {

--- a/examples/examples-twitter/src/apps/tweet/shared/server_fn.rs
+++ b/examples/examples-twitter/src/apps/tweet/shared/server_fn.rs
@@ -22,9 +22,12 @@ use {
 ///
 /// Accepts `content` as a String parameter (form! macro passes individual field values).
 /// Internally constructs CreateTweetRequest for validation.
+/// `_csrf_token` is auto-appended by the `form!` macro for non-GET forms;
+/// CSRF is enforced by middleware. See #3825.
 #[server_fn]
 pub async fn create_tweet(
 	content: String,
+	_csrf_token: String,
 	#[inject] db: DatabaseConnection,
 	#[inject] AuthUser(user): AuthUser<User>,
 ) -> std::result::Result<TweetInfo, ServerFnError> {

--- a/examples/examples-twitter/src/config.rs
+++ b/examples/examples-twitter/src/config.rs
@@ -2,6 +2,10 @@
 
 #[cfg(native)]
 pub mod admin;
+// `installed_apps!` macro is server-only (the facade re-exports it under
+// `cfg(all(feature = "core", native))` and WASM builds disable `core`).
+// See #3825.
+#[cfg(native)]
 pub mod apps;
 #[cfg(native)]
 pub mod middleware;


### PR DESCRIPTION
## Summary

This PR addresses:

- Compile failure in `examples/examples-twitter` against current `main`, which is blocking the release-plz Release PR (#3824, rc.15 → rc.16) from going green.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`examples-twitter` had not been migrated to two recent framework changes:

1. **Auto-CSRF in `form!` macro** (commit `0fd5bf1e1`, #3337): the macro now appends a `__csrf_token` argument as the last positional parameter to non-GET form `server_fn` calls. The four affected `server_fn`s in examples-twitter (`login`, `register`, `create_tweet`, `update_profile_form`) had not added the corresponding parameter, causing `E0061` at every `form!` call site.
2. **Server-only `installed_apps!`**: the macro is re-exported from the facade only under `cfg(all(feature = "core", native))`, but `examples-twitter`'s WASM target enables only `pages-web-sys-full`/`uuid`/`client-router`. `config::apps` was unconditionally compiled for both targets, producing `E0432`/`E0433` on the cdylib build.

Together these surface as 6 compile errors that block CI on the release-plz PR. After this fix, release-plz can regenerate #3824 and the rc.16 release flow can resume.

Fixes #3825

Related to: #3337, #3824, #3826, #3827

## How Was This Tested?

- `cargo make quality-fix` at workspace root and inside `examples/examples-twitter` — both clean.
- `cargo check` in `examples/examples-twitter` (with local patch active) compiles without errors after the fixes.
- `test_auth_flow_login_then_current_user` still fails for an **unrelated** runtime regression that surfaced after #3823 made `login` return 200; tracked in #3827 and intentionally out of scope here.

## Breaking Changes

None — examples-only.

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective (existing HTTP tests updated to include `_csrf_token`)
- [x] All new and existing tests pass locally (excluding the pre-existing #3827 regression)
- [x] I have updated the documentation accordingly (workaround comment added near `config::apps` gate)
- [x] My commits follow the conventional commits format

## Labels to Apply

- `bug` (CI breaker on release-plz PR)
- `high` (blocks rc.16 release)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)