### PR TITLE
fix(core): add WebSocketRouter::with_namespace for url_patterns ws mode

### DIFF
--- a/crates/reinhardt-core/src/ws.rs
+++ b/crates/reinhardt-core/src/ws.rs
@@ -122,6 +122,8 @@ pub struct WebSocketRouter {
 	names: Arc<RwLock<HashMap<String, String>>>,
 	/// Build-time consumer registrations (added by `consumer()` builder).
 	pending_consumers: Vec<WebSocketRoute>,
+	/// Optional namespace (app label) for this router.
+	namespace: Option<String>,
 }
 
 impl WebSocketRouter {
@@ -131,7 +133,27 @@ impl WebSocketRouter {
 			routes: Arc::new(RwLock::new(HashMap::new())),
 			names: Arc::new(RwLock::new(HashMap::new())),
 			pending_consumers: Vec::new(),
+			namespace: None,
 		}
+	}
+
+	/// Set the namespace for this router.
+	///
+	/// Parallel to `ServerRouter::with_namespace`, emitted by
+	/// `#[url_patterns(mode = ws)]` to pass the `AppLabel::path(...)`.
+	/// WebSocket route paths are absolute today and are not rewritten
+	/// with this namespace; the value is stored for parity with other
+	/// routers and future use. See reinhardt-web#3829.
+	pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
+		self.namespace = Some(namespace.into());
+		self
+	}
+
+	/// Returns the namespace set via [`with_namespace`], if any.
+	///
+	/// [`with_namespace`]: Self::with_namespace
+	pub fn namespace(&self) -> Option<&str> {
+		self.namespace.as_deref()
 	}
 
 	/// Register a WebSocket consumer by its factory function.
@@ -303,6 +325,18 @@ mod tests {
 		let route = router.find_pending("chat_ws");
 		assert!(route.is_some());
 		assert_eq!(route.unwrap().path(), "/ws/chat/{room_id}/");
+	}
+
+	#[rstest]
+	fn test_with_namespace_stores_value_without_rewriting_paths() {
+		let router = WebSocketRouter::new()
+			.with_namespace("auth")
+			.consumer(|| TestConsumer);
+		assert_eq!(router.namespace(), Some("auth"));
+		assert_eq!(
+			router.find_pending("chat_ws").unwrap().path(),
+			"/ws/chat/{room_id}/"
+		);
 	}
 
 	#[rstest]


### PR DESCRIPTION
## Summary

Add `WebSocketRouter::with_namespace(impl Into<String>) -> Self` so that code emitted by `#[url_patterns(mode = ws)]` compiles.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`#[url_patterns(mode = ws)]` (introduced in #3782) shares `build_wrapper_and_assertion` with the server/client/unified modes, emitting `__router.with_namespace(<AppLabel>::path(...))` on the function's return value. `WebSocketRouter` did not implement `with_namespace`, so any ws-mode consumer failed to compile with `E0599: no method named with_namespace found for struct WebSocketRouter`.

This PR takes option 1 from the issue (add the method, parallel to `ServerRouter`) because:

- It keeps the macro uniform — all four modes continue to share one wrapper shape.
- It makes `WebSocketRouter`'s builder surface consistent with `ServerRouter` / `ClientRouter` / `UnifiedRouter`.
- It preserves the `AppLabel`-derived namespace at the ws layer for future use (ws paths are absolute today and are not rewritten).

Fixes #3829

## How Was This Tested?

- Added `test_with_namespace_stores_value_without_rewriting_paths` in `crates/reinhardt-core/src/ws.rs` (verifies the namespace is stored and pending consumer paths remain absolute).
- `cargo check -p reinhardt-core --all-features` — clean.
- `cargo nextest run -p reinhardt-core --all-features` — 1673 / 1673 pass.
- `cargo nextest run -p reinhardt-websockets --all-features` — 323 / 323 pass.
- `cargo make fmt-check` — clean.
- `cargo make clippy-check` — clean.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug`

### Scope Label
- [x] `websockets`
- [x] `routing`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)