### PR TITLE
docs(testing): document direct-invocation convention for server_fn tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ See instructions/ANTI_PATTERNS.md for comprehensive anti-patterns guide.
 See instructions/TESTING_STANDARDS.md for comprehensive testing standards including:
 - Testing philosophy (TP-1, TP-2)
 - Test organization (TO-1, TO-2)
-- Test implementation (TI-1 ~ TI-6)
+- Test implementation (TI-1 ~ TI-7)
 - Infrastructure testing (IT-1)
 
 ### File Management

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -350,6 +350,11 @@ mod tests {
 
 ### TS-3 (SHOULD): Direct Invocation for `#[server_fn]` Tests
 
+TS-3 is the examples-project mirror of `instructions/TESTING_STANDARDS.md`
+§ TI-7. The underlying convention is identical; TS-3 exists so examples
+contributors find the rule here without having to cross-reference the top-level
+standards doc.
+
 When testing `#[server_fn]` functions in example projects, prefer **direct
 invocation** (call the function as a regular `async fn` and pass injected
 dependencies positionally) over routing JSON requests through

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -348,6 +348,19 @@ mod tests {
 }
 ```
 
+### TS-3 (SHOULD): Direct Invocation for `#[server_fn]` Tests
+
+When testing `#[server_fn]` functions in example projects, prefer **direct
+invocation** (call the function as a regular `async fn` and pass injected
+dependencies positionally) over routing JSON requests through
+`ServerRouter::handle()`. The `#[inject]` attributes are stripped at expansion
+time, so server functions are normal Rust functions on the server side.
+
+Reserve HTTP routing for tests whose stated purpose is to verify the
+HTTP/DI/middleware pipeline itself (document the rationale in the module
+header). See `instructions/TESTING_STANDARDS.md` § TI-7 for the full
+convention and #3826 for context.
+
 ---
 
 ## Quick Reference

--- a/instructions/TESTING_STANDARDS.md
+++ b/instructions/TESTING_STANDARDS.md
@@ -864,7 +864,12 @@ header so future readers understand why the more verbose path is used.
 **Direct call (preferred):**
 
 ```rust
+// Schematic — adapt types, imports, and fixture names to your project.
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use rstest::*;
+use serde_json::json;
 
 #[rstest]
 #[tokio::test]
@@ -918,8 +923,8 @@ fixtures (auth, transactions, mocked HTTP request, CSRF token). Prefer
 that helper over hand-rolled DI scaffolding.
 
 See: #3826 (convention), #3525 (HTTP-routed exception rationale),
-`tests/integration/admin_integration_tests.rs` for representative direct
-call test examples.
+`tests/integration/tests/admin/` for representative direct call test
+examples.
 
 ---
 

--- a/instructions/TESTING_STANDARDS.md
+++ b/instructions/TESTING_STANDARDS.md
@@ -830,6 +830,97 @@ fn test_update_user(db_with_user: (Database, User)) {
 }
 ```
 
+### TI-7 (SHOULD): Direct Invocation for `#[server_fn]` Tests
+
+Tests that exercise functions annotated with `#[server_fn]` SHOULD call them
+**directly** as regular Rust functions, passing each `#[inject]` parameter
+as a positional argument from a test fixture, rather than constructing an
+HTTP request and routing it through `ServerRouter::handle()`.
+
+The `#[server_fn]` macro strips `#[inject]` attributes from the underlying
+function definition, so direct calls are just normal `async fn` invocations.
+Test fixtures can build the `DatabaseConnection`, `Depends<T>`, `AuthUser<U>`,
+session/store handles, etc. once and pass them in.
+
+**When to use direct invocation (default):**
+
+- Verifying business logic, validation, error mapping, persistence side
+  effects.
+- Asserting on the function's return value and any state it mutated.
+- Most happy-path and error-path test cases.
+
+**When HTTP routing is justified (special reason):**
+
+- The test's purpose is to verify the HTTP/DI/middleware pipeline itself —
+  e.g., DI resolution end-to-end (#3525), CSRF cookie-to-header validation
+  (#3049), middleware ordering, codec/serialisation, or full request
+  authentication flow.
+- WASM client-side mock tests (`mock_server_fn`, `MockableServerFn`) that
+  exercise the generated client RPC stub.
+
+If you keep an HTTP-routed test, document the rationale in the module
+header so future readers understand why the more verbose path is used.
+
+**Direct call (preferred):**
+
+```rust
+use rstest::*;
+
+#[rstest]
+#[tokio::test]
+async fn test_create_record_persists_data(
+	#[future] server_fn_test_context: (Arc<AdminSite>, Arc<AdminDatabase>),
+) {
+	// Arrange: fixture builds the DI inputs once
+	let (site, db) = server_fn_test_context.await;
+	let request = MutationRequest {
+		data: HashMap::from([("name".to_string(), json!("Alice"))]),
+	};
+
+	// Act: call the server_fn directly
+	let result = create_record("TestModel".to_string(), request, site, db).await;
+
+	// Assert
+	let response = result.expect("create_record should succeed");
+	assert!(response.id.is_some());
+}
+```
+
+**HTTP-routed (only when verifying the pipeline itself):**
+
+```rust
+//! Tests that exercise the full DI resolution pipeline by routing HTTP
+//! requests through `ServerRouter::handle()`. This ensures `#[inject]`
+//! parameters are resolved via `InjectionContext` rather than passed
+//! directly. Covers #3525.
+
+#[rstest]
+#[tokio::test]
+async fn test_login_via_http_pipeline(...) {
+	let request = make_request("/api/server_fn/login", json!({ ... }), None);
+	let response = router.handle(request).await.unwrap();
+	// ...
+}
+```
+
+**Why direct invocation by default:**
+
+- Avoids JSON/URL body construction, cookie/CSRF plumbing, and middleware
+  setup that the test does not actually verify.
+- Faster: no router resolution, no codec round-trip.
+- Failures point at the handler itself rather than at the routing layer.
+- Matches the convention already followed by the bulk of the admin
+  server_fn integration tests (`tests/integration/tests/admin/`).
+
+The framework already provides `ServerFnTestContext` (in
+`reinhardt-testkit::server_fn::context`) for tests that need richer
+fixtures (auth, transactions, mocked HTTP request, CSRF token). Prefer
+that helper over hand-rolled DI scaffolding.
+
+See: #3826 (convention), #3525 (HTTP-routed exception rationale),
+`tests/integration/admin_integration_tests.rs` for representative direct
+call test examples.
+
 ---
 
 ## Infrastructure Testing


### PR DESCRIPTION
## Summary

This PR addresses:

- Establishes a documented convention for how to test \`#[server_fn]\` functions: direct invocation by default, HTTP routing only when verifying the pipeline itself.

## Type of Change

- [x] Documentation update

## Motivation and Context

The recent rc.16 work surfaced ambiguity around how server_fn tests should be written: some tests POST JSON through \`ServerRouter::handle()\`, others call the function directly with manually-constructed DI inputs. The two styles serve different purposes but the difference was not documented, leading to (a) churn around CSRF auto-injection (#3825 / #3337) leaking into HTTP test bodies that don't actually verify CSRF, and (b) tests that re-implement HTTP scaffolding when a one-line direct call would do.

This PR codifies the convention already followed de-facto by the bulk of admin server_fn integration tests, and points future authors at the right pattern.

**Audit summary** (no behavioural changes needed):

| Test file | Style | Status |
|-----------|-------|--------|
| \`tests/integration/tests/admin/server_fn_e2e_tests.rs\` | HTTP | ✅ rationale documented in header (#3046, #3049) |
| \`tests/integration/tests/admin/server_fn_login_tests.rs\` | HTTP | ✅ verifies CSRF/JWT pipeline |
| \`tests/integration/tests/admin/server_fn_middleware_e2e_tests.rs\` | HTTP | ✅ verifies middleware chain (#3083) |
| \`tests/integration/tests/admin/server_fn_{permission,state_transition,update,usecase,uuid_pk}_tests.rs\` | Direct | ✅ already follow convention |
| \`tests/integration/tests/pages/server_fn_execution_integration.rs\` | HTTP | ✅ explicitly tests RPC mechanism (codecs, CSRF auto-injection) |
| \`examples/examples-tutorial-basis/tests/wasm/polls_mock_test.rs\` | WASM mock | ✅ client-side mock test, exempted by TI-7 |
| \`examples/examples-twitter/src/apps/auth/tests/server_fn.rs\` | HTTP | ✅ rationale documented (#3525) |

Fixes #3826

Related to: #3525, #3825, #3828

## How Was This Tested?

Documentation-only change. No code modifications, no behavioural impact.

- \`cargo doc --no-deps\` not required (no rustdoc changes).
- Convention text reviewed against the audit table above; no test files contradict the new TI-7 guidance.

## Breaking Changes

None.

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my code
- [x] Relevant audit performed against current test surface
- [x] Cross-references added (CLAUDE.md, examples/CLAUDE.md → TI-7)
- [x] My commits follow the conventional commits format

## Labels to Apply

- \`documentation\`
- \`medium\`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)