### PR TITLE
fix(macros): move urls.ws() accessor inside __namespaced_ws_resolvers to fix E0451

### DIFF
--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -820,6 +820,15 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 					impl WsUrls<'_> {
 						#(#ws_app_accessors)*
 					}
+
+					// urls.ws() accessor lives inside this module so that WsUrls.resolver
+					// (a private field) is accessible via struct-literal syntax (E0451 fix).
+					impl ResolvedUrls {
+						/// Access WebSocket URL resolvers via `urls.ws().<app>().<route>()`.
+						pub fn ws(&self) -> WsUrls<'_> {
+							WsUrls { resolver: self }
+						}
+					}
 				}
 				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 				pub use __namespaced_ws_resolvers::*;
@@ -834,15 +843,6 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 							"WebSocket URL resolution requires reinhardt-websockets. \
 							 Call impl_ws_url_resolver!(ResolvedUrls) to enable it."
 						)
-					}
-				}
-
-				// Add urls.ws() accessor to ResolvedUrls
-				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-				impl ResolvedUrls {
-					/// Access WebSocket URL resolvers via `urls.ws().<app>().<route>()`.
-					pub fn ws(&self) -> WsUrls<'_> {
-						WsUrls { resolver: self }
 					}
 				}
 


### PR DESCRIPTION
## Summary

- Move the `impl ResolvedUrls { pub fn ws() }` block inside `mod __namespaced_ws_resolvers` so `WsUrls.resolver` (private field) is accessible via struct-literal syntax.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `#[routes]` macro generated `WsUrls { resolver: self }` from **outside** `__namespaced_ws_resolvers`, where `WsUrls.resolver` is a private field. This caused E0451 in any downstream crate that declares `pub mod ws_urls;` and uses `#[url_patterns(mode = ws)]`.

The HTTP counterpart (`urls.server()`) already places `impl ResolvedUrls { fn server() }` **inside** `__namespaced_resolvers` — giving it access to `ServerUrls.resolver`. This PR applies the same pattern for `WsUrls`.

Fixes #3834

## How Was This Tested?

- `cargo check --workspace` in the fix worktree passes cleanly.
- End-to-end verified in `reinhardt-cloud` dashboard migration: adding `ws_urls.rs` with `#[url_patterns(InstalledApp::auth, mode = ws)]` now compiles after `cargo update -p reinhardt-web`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] `cargo check --workspace --all-features` passes
- [ ] Tests cover the fix (trybuild test for ws mode E0451 can be added as follow-up)
- [x] Documentation updated as needed

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)