### PR TITLE
fix(release): use path-only dev-deps for reinhardt-test/reinhardt-testkit in reinhardt-admin

### DIFF
--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -105,11 +105,11 @@ console_error_panic_hook = ["dep:console_error_panic_hook"]
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 insta = { workspace = true }
 reinhardt-db = { workspace = true, features = ["orm", "backends"] }
-reinhardt-test = { workspace = true, features = ["e2e-cdp", "testcontainers"] }
+reinhardt-test = { path = "../reinhardt-test", features = ["e2e-cdp", "testcontainers"] }
 reinhardt-pages = { workspace = true, features = ["testing"] }
 reinhardt-server = { workspace = true }
 reinhardt-di = { workspace = true }
-reinhardt-testkit = { workspace = true }
+reinhardt-testkit = { path = "../reinhardt-testkit" }
 tokio = { workspace = true, features = ["full"] }
 tokio-test = { workspace = true }
 rstest = { workspace = true }
@@ -124,7 +124,7 @@ toml = { workspace = true }
 # WASM-only dev-dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3.56"
-reinhardt-test = { workspace = true, features = ["wasm"] }
+reinhardt-test = { path = "../reinhardt-test", features = ["wasm"] }
 
 
 [build-dependencies]


### PR DESCRIPTION
## Summary

- Use path-only dev-dependencies for `reinhardt-test` and `reinhardt-testkit` in `reinhardt-admin/Cargo.toml` (KI-2 fix)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

KI-2 (Cargo 1.84+ dev-dep resolution during publish) caused the rc.16 release to fail:

```
failed to select a version for the requirement `reinhardt-test = "^0.1.0-rc.16"`
candidate versions found which didn't match: 0.1.0-rc.15, ...
```

`reinhardt-admin` had `reinhardt-test = { workspace = true }` and `reinhardt-testkit = { workspace = true }` in dev-dependencies.  Workspace deps include a version field, and Cargo 1.84+ resolves dev-dep versions during packaging even with `--no-verify`.  Since release-plz determines publish order from regular deps only, `reinhardt-admin` can be packaged before `reinhardt-test`/`reinhardt-testkit` are published, causing the failure.

**Fix**: Path-only dev-deps (`path = "../..."` without `version`) are stripped from the published manifest by Cargo, bypassing the registry version resolution check.

Per KI-2 Strategy 3 (path-only dev-dependency, fallback for crates needing `reinhardt-test`-specific modules like `e2e-cdp`).

## How Was This Tested

- Verified `cargo publish --dry-run -p reinhardt-admin` resolves correctly with path-only deps
- KI-2 is a known pattern; the same fix has been applied to other crates in prior PRs (#185, #207, #223)

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly (KI-2 already documented in instructions/RELEASE_PROCESS.md)
- [x] All new and existing tests passed
- [ ] I use self-hosted runner for CI (unchecked — repository owner only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)