### PR TITLE
fix(ci): skip release-plz when announcement PR is merged

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'announcements/**'
   workflow_dispatch:
     inputs:
       mode:


### PR DESCRIPTION
## Summary

- Add `paths-ignore: ['announcements/**']` to the `push` trigger in `release-plz.yml`

## Type of Change

- [x] Bug fix (announcement PR merge incorrectly triggered release-plz)

## Motivation and Context

When an announcement PR is merged into `main`, GitHub fires both a `pull_request: closed` event and a `push` event. The `push` event was causing `release-plz-pr` to run and create an unwanted Release PR.

Adding `paths-ignore` ensures that pushes containing only `announcements/**` files do not trigger the release jobs. The `post-announcement` job is unaffected as it uses the `pull_request` trigger.

## How Was This Tested

- Verified that `paths-ignore` on the `push` trigger skips the workflow when only `announcements/` files change
- `post-announcement` job continues to work via the separate `pull_request: closed` trigger

## Checklist

- [x] No functional changes to the release process for real code pushes
- [x] `post-announcement` job unaffected

## Related Issues

Fixes #3848

🤖 Generated with [Claude Code](https://claude.com/claude-code)