### PR TITLE
fix(commands): replace include_in_new with auto_now_add in user model template example

### DIFF
--- a/crates/reinhardt-commands/templates/app_pages_template/models.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/models.rs.tpl
@@ -18,11 +18,13 @@
 //!     pub email: String,
 //!     #[field(max_length = 255)]
 //!     pub password_hash: Option<String>,
-//!     #[field(include_in_new = false)]
+//!     #[field]
 //!     pub last_login: Option<chrono::DateTime<chrono::Utc>>,
 //!     #[field(default = true)]
 //!     pub is_active: bool,
 //!     #[field(default = false)]
 //!     pub is_superuser: bool,
+//!     #[field(auto_now_add = true)]
+//!     pub created_at: chrono::DateTime<chrono::Utc>,
 //! }
 //! ```

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/models.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/models.rs.tpl
@@ -18,11 +18,13 @@
 //!     pub email: String,
 //!     #[field(max_length = 255)]
 //!     pub password_hash: Option<String>,
-//!     #[field(include_in_new = false)]
+//!     #[field]
 //!     pub last_login: Option<chrono::DateTime<chrono::Utc>>,
 //!     #[field(default = true)]
 //!     pub is_active: bool,
 //!     #[field(default = false)]
 //!     pub is_superuser: bool,
+//!     #[field(auto_now_add = true)]
+//!     pub created_at: chrono::DateTime<chrono::Utc>,
 //! }
 //! ```

--- a/crates/reinhardt-commands/templates/app_restful_template/models.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_restful_template/models.rs.tpl
@@ -18,11 +18,13 @@
 //!     pub email: String,
 //!     #[field(max_length = 255)]
 //!     pub password_hash: Option<String>,
-//!     #[field(include_in_new = false)]
+//!     #[field]
 //!     pub last_login: Option<chrono::DateTime<chrono::Utc>>,
 //!     #[field(default = true)]
 //!     pub is_active: bool,
 //!     #[field(default = false)]
 //!     pub is_superuser: bool,
+//!     #[field(auto_now_add = true)]
+//!     pub created_at: chrono::DateTime<chrono::Utc>,
 //! }
 //! ```

--- a/crates/reinhardt-commands/templates/app_restful_workspace_template/src/models.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_restful_workspace_template/src/models.rs.tpl
@@ -18,11 +18,13 @@
 //!     pub email: String,
 //!     #[field(max_length = 255)]
 //!     pub password_hash: Option<String>,
-//!     #[field(include_in_new = false)]
+//!     #[field]
 //!     pub last_login: Option<chrono::DateTime<chrono::Utc>>,
 //!     #[field(default = true)]
 //!     pub is_active: bool,
 //!     #[field(default = false)]
 //!     pub is_superuser: bool,
+//!     #[field(auto_now_add = true)]
+//!     pub created_at: chrono::DateTime<chrono::Utc>,
 //! }
 //! ```


### PR DESCRIPTION
## Summary

- Replace `#[field(include_in_new = false)]` on `last_login` with plain `#[field]` in the user model doc example
- Add `created_at` field with `#[field(auto_now_add = true)]` to demonstrate the auto-timestamp pattern
- Applies to all four template variants: `app_pages_template`, `app_restful_template`, `app_pages_workspace_template`, `app_restful_workspace_template`

## Type of Change

- [x] Documentation update

## Motivation and Context

- `include_in_new` is an internal implementation detail that should not appear in user-facing template examples
- `auto_now_add` is the idiomatic way to express creation timestamps in `#[model]` structs
- Adding `created_at` with `auto_now_add = true` gives users a clear, practical example of the auto-timestamp feature

Related to: #3843

## How Was This Tested?

- Verified `auto_now_add` attribute is parsed in `crates/reinhardt-core/macros/src/model_derive.rs`
- Cross-referenced with `examples/examples-twitter/src/apps/snippets/models.rs` which uses `auto_now_add = true`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label
- [x] `documentation` - Documentation update

### Priority Label
- [x] `low` - Minor fix or enhancement

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)