### PR TITLE
style(admin-cli): apply rustfmt formatting to main.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-rc.17](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-rc.16...reinhardt-web@v0.1.0-rc.17) - 2026-04-20
+
+### Changed
+
+- *(commands)* use typed TokenQuery struct instead of HashMap for Query extractor
+
+### Documentation
+
+- *(commands)* note auto-detection of #[inject] in server_fn.rs.tpl files
+- *(commands)* clarify WASM auto-injection in index.html.tpl
+- *(commands)* add JwtError handling example to views.rs.tpl
+
+### Fixed
+
+- *(commands)* update templates to reflect rc.13-rc.15 API changes
+- *(commands)* correct #[user] macro usage in all models.rs.tpl variants
+- *(commands)* add missing #[field] attributes to #[user] model examples
+- *(commands)* correct JwtError example in views.rs.tpl
+- *(commands)* use AuthUser<U> extractor in views.rs.tpl example
+- *(commands)* remove unnecessary #[use_inject] from views.rs.tpl example
+- *(commands)* add correct #[field] constraints to user model example in templates
+- *(commands)* replace include_in_new with auto_now_add in user model template example
+
 ## [0.1.0-rc.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-rc.15...reinhardt-web@v0.1.0-rc.16) - 2026-04-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -416,65 +416,65 @@ module_name_repetitions = "allow"
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-rc.16" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-rc.17" }
 
 # Internal crates
-reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0-rc.16" }
-reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.1.0-rc.16" }
-reinhardt-core = { path = "crates/reinhardt-core", version = "0.1.0-rc.16" }
-reinhardt-di = { path = "crates/reinhardt-di", version = "0.1.0-rc.16" }
-reinhardt-http = { path = "crates/reinhardt-http", version = "0.1.0-rc.16" }
-reinhardt-server = { path = "crates/reinhardt-server", version = "0.1.0-rc.16" }
-reinhardt-views = { path = "crates/reinhardt-views", version = "0.1.0-rc.16" }
-reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.1.0-rc.16" }
-reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.1.0-rc.16" }
-reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.0-rc.16" }
-reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.1.0-rc.16" }
-reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.0-rc.16" }
-reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.1.0-rc.16" }
-reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.0-rc.16" }
-reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.1.0-rc.16" }
-reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-rc.16" }
-reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.0-rc.16" }
+reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0-rc.17" }
+reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.1.0-rc.17" }
+reinhardt-core = { path = "crates/reinhardt-core", version = "0.1.0-rc.17" }
+reinhardt-di = { path = "crates/reinhardt-di", version = "0.1.0-rc.17" }
+reinhardt-http = { path = "crates/reinhardt-http", version = "0.1.0-rc.17" }
+reinhardt-server = { path = "crates/reinhardt-server", version = "0.1.0-rc.17" }
+reinhardt-views = { path = "crates/reinhardt-views", version = "0.1.0-rc.17" }
+reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.1.0-rc.17" }
+reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.1.0-rc.17" }
+reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.0-rc.17" }
+reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.1.0-rc.17" }
+reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.0-rc.17" }
+reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.1.0-rc.17" }
+reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.0-rc.17" }
+reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.1.0-rc.17" }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-rc.17" }
+reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.0-rc.17" }
 reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.1.0-alpha.1" }
-reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.0-rc.16" }
-reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-rc.16" }
-reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.0-rc.16" }
-reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0-rc.16" }
+reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.0-rc.17" }
+reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-rc.17" }
+reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.0-rc.17" }
+reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0-rc.17" }
 reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.1.0-rc.16" }
-reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0-rc.16" }
-reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-rc.16" }
-reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-rc.16" }
-reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0-rc.16" }
-reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0-rc.16" }
-reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-rc.16" }
-reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0-rc.16" }
-reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.1.0-rc.16" }
-reinhardt-query = { path = "crates/reinhardt-query", version = "0.1.0-rc.16" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-rc.16" }
-reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-rc.16" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-rc.16" }
-reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0-rc.16" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-rc.16" }
-reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0-rc.16" }
-reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0-rc.16" }
-reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.0-rc.16" }
-reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-rc.16" }
+reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0-rc.17" }
+reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-rc.17" }
+reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-rc.17" }
+reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0-rc.17" }
+reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0-rc.17" }
+reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-rc.17" }
+reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0-rc.17" }
+reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.1.0-rc.17" }
+reinhardt-query = { path = "crates/reinhardt-query", version = "0.1.0-rc.17" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-rc.17" }
+reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-rc.17" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-rc.17" }
+reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0-rc.17" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-rc.17" }
+reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0-rc.17" }
+reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0-rc.17" }
+reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.0-rc.17" }
+reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-rc.17" }
 
 # Query subcrates
-reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.1.0-rc.16" }
+reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.1.0-rc.17" }
 
 # Core subcrates
-reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.0-rc.16" }
+reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.0-rc.17" }
 
 # DI subcrates
-reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.1.0-rc.16" }
+reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.1.0-rc.17" }
 
 # REST subcrates
-reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.1.0-rc.16" }
+reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.1.0-rc.17" }
 
 # REST subcrates (continued)
-reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.1.0-rc.16" }
+reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.1.0-rc.17" }
 
 # Streaming
 rskafka = { version = "0.5" }

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-rc.17](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.0-rc.16...reinhardt-admin-cli@v0.1.0-rc.17) - 2026-04-20
+
+### Documentation
+
+- *(admin-cli)* fix outdated --help reference and update README for new flags
+
+### Fixed
+
+- *(admin-cli)* replace --template-type with --template/--with-pages/--with-rest ArgGroup
+
+### Testing
+
+- *(admin-cli)* update e2e tests to use --with-rest/--with-pages flags
+- *(admin-cli)* add unit tests for resolve_project_type
+
 ## [0.1.0-rc.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.0-rc.15...reinhardt-admin-cli@v0.1.0-rc.16) - 2026-04-20
 
 ### Added

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin-cli"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -383,7 +383,16 @@ async fn main() {
 			with_rest,
 			template_dir,
 		} => {
-			run_startproject(name, directory, template, with_pages, with_rest, template_dir, cli.verbosity).await
+			run_startproject(
+				name,
+				directory,
+				template,
+				with_pages,
+				with_rest,
+				template_dir,
+				cli.verbosity,
+			)
+			.await
 		}
 		Commands::Startapp {
 			name,
@@ -393,7 +402,16 @@ async fn main() {
 			with_rest,
 			template_dir,
 		} => {
-			run_startapp(name, directory, template, with_pages, with_rest, template_dir, cli.verbosity).await
+			run_startapp(
+				name,
+				directory,
+				template,
+				with_pages,
+				with_rest,
+				template_dir,
+				cli.verbosity,
+			)
+			.await
 		}
 		Commands::Plugin { subcommand } => run_plugin(subcommand, cli.verbosity).await,
 		Commands::Fmt {
@@ -1779,8 +1797,14 @@ mod arg_group_tests {
 	#[test]
 	fn startproject_template_pages_accepted() {
 		assert!(
-			try_parse(&["reinhardt-admin", "startproject", "myproj", "--template", "pages"])
-				.is_ok(),
+			try_parse(&[
+				"reinhardt-admin",
+				"startproject",
+				"myproj",
+				"--template",
+				"pages"
+			])
+			.is_ok(),
 			"--template pages should be accepted"
 		);
 	}
@@ -1788,7 +1812,14 @@ mod arg_group_tests {
 	#[test]
 	fn startproject_template_rest_accepted() {
 		assert!(
-			try_parse(&["reinhardt-admin", "startproject", "myproj", "--template", "rest"]).is_ok(),
+			try_parse(&[
+				"reinhardt-admin",
+				"startproject",
+				"myproj",
+				"--template",
+				"rest"
+			])
+			.is_ok(),
 			"--template rest should be accepted"
 		);
 	}
@@ -1797,7 +1828,10 @@ mod arg_group_tests {
 	fn startproject_missing_type_is_error() {
 		let result = try_parse(&["reinhardt-admin", "startproject", "myproj"]);
 		assert!(result.is_err(), "expected Err when type flag omitted");
-		assert_eq!(result.err().unwrap().kind(), ErrorKind::MissingRequiredArgument);
+		assert_eq!(
+			result.err().unwrap().kind(),
+			ErrorKind::MissingRequiredArgument
+		);
 	}
 
 	#[test]
@@ -1843,6 +1877,9 @@ mod arg_group_tests {
 	fn startapp_missing_type_is_error() {
 		let result = try_parse(&["reinhardt-admin", "startapp", "myapp"]);
 		assert!(result.is_err(), "expected Err when type flag omitted");
-		assert_eq!(result.err().unwrap().kind(), ErrorKind::MissingRequiredArgument);
+		assert_eq!(
+			result.err().unwrap().kind(),
+			ErrorKind::MissingRequiredArgument
+		);
 	}
 }

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-apps/Cargo.toml
+++ b/crates/reinhardt-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-apps"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "Application registry and management for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "Authentication and authorization system"
 keywords = ["auth", "jwt", "authentication", "django", "web"]
 categories = ["authentication", "web-programming"]

--- a/crates/reinhardt-commands/CHANGELOG.md
+++ b/crates/reinhardt-commands/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-rc.17](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0-rc.16...reinhardt-commands@v0.1.0-rc.17) - 2026-04-20
+
+### Changed
+
+- *(commands)* use typed TokenQuery struct instead of HashMap for Query extractor
+
+### Documentation
+
+- *(commands)* note auto-detection of #[inject] in server_fn.rs.tpl files
+- *(commands)* clarify WASM auto-injection in index.html.tpl
+- *(commands)* add JwtError handling example to views.rs.tpl
+
+### Fixed
+
+- *(commands)* update templates to reflect rc.13-rc.15 API changes
+- *(commands)* correct #[user] macro usage in all models.rs.tpl variants
+- *(commands)* add missing #[field] attributes to #[user] model examples
+- *(commands)* correct JwtError example in views.rs.tpl
+- *(commands)* use AuthUser<U> extractor in views.rs.tpl example
+- *(commands)* remove unnecessary #[use_inject] from views.rs.tpl example
+- *(commands)* add correct #[field] constraints to user model example in templates
+- *(commands)* replace include_in_new with auto_now_add in user model template example
+
 ## [0.1.0-rc.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0-rc.15...reinhardt-commands@v0.1.0-rc.16) - 2026-04-20
 
 ### Added

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-commands"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-conf"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-core"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-core/macros/Cargo.toml
+++ b/crates/reinhardt-core/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-macros"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db-macros/Cargo.toml
+++ b/crates/reinhardt-db-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db-macros"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db/Cargo.toml
+++ b/crates/reinhardt-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-deeplink/Cargo.toml
+++ b/crates/reinhardt-deeplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-deeplink"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/Cargo.toml
+++ b/crates/reinhardt-dentdelion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dentdelion"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "reinhardt-di"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-di/macros/Cargo.toml
+++ b/crates/reinhardt-di/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-di-macros"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-dispatch/Cargo.toml
+++ b/crates/reinhardt-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dispatch"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-forms/Cargo.toml
+++ b/crates/reinhardt-forms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-forms"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "Form handling and validation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-graphql/macros/Cargo.toml
+++ b/crates/reinhardt-graphql/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql-macros"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "Procedural macros for GraphQL schema generation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "gRPC support for building RPC services"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/macros/Cargo.toml
+++ b/crates/reinhardt-grpc/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc-macros"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-http/Cargo.toml
+++ b/crates/reinhardt-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-http"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "Internationalization and localization support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-mail/Cargo.toml
+++ b/crates/reinhardt-mail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-mail"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "Email sending functionality with multiple backends"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-manouche/Cargo.toml
+++ b/crates/reinhardt-manouche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-manouche"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-middleware"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "Middleware system for request/response processing pipeline"
 keywords = ["middleware", "web", "cors", "security", "http"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-openapi/Cargo.toml
+++ b/crates/reinhardt-openapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/ast/Cargo.toml
+++ b/crates/reinhardt-pages/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-ast"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/macros/Cargo.toml
+++ b/crates/reinhardt-pages/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-macros"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-query/Cargo.toml
+++ b/crates/reinhardt-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-query/macros/Cargo.toml
+++ b/crates/reinhardt-query/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query-macros"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-rest/Cargo.toml
+++ b/crates/reinhardt-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-rest"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "REST API framework aggregator for Reinhardt"
 keywords = ["rest", "api", "web", "framework", "django"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-rest/openapi-macros/Cargo.toml
+++ b/crates/reinhardt-rest/openapi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi-macros"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-server/Cargo.toml
+++ b/crates/reinhardt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-server"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-tasks/Cargo.toml
+++ b/crates/reinhardt-tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-tasks"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "Background task execution and scheduling"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-test"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-testkit/Cargo.toml
+++ b/crates/reinhardt-testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-throttling/Cargo.toml
+++ b/crates/reinhardt-throttling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-throttling"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "Throttling and rate limiting for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-urls"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-urls/routers-macros/Cargo.toml
+++ b/crates/reinhardt-urls/routers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-routers-macros"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-utils"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "Utility functions aggregator for Reinhardt"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-views/Cargo.toml
+++ b/crates/reinhardt-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-views"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "View layer aggregator for viewsets and views-core"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-websockets/Cargo.toml
+++ b/crates/reinhardt-websockets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-websockets"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 description = "WebSocket support for real-time bidirectional communication"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

- Apply `rustfmt` formatting to `crates/reinhardt-admin-cli/src/main.rs`
- Long function calls (`run_startproject`, `run_startapp`) and `try_parse` test calls now conform to `fn_call_width = 60` in `rustfmt.toml`

## Type of Change

- [x] Style / Formatting (no logic change)

## Motivation and Context

The Format Check CI was failing on the release-plz PR #3854 because `crates/reinhardt-admin-cli/src/main.rs` had single-line function calls exceeding the configured `fn_call_width = 60`. These were introduced when the `--with-rest`, `--with-pages`, and `--template-dir` flags were added to `startproject`/`startapp` commands.

## How Was This Tested

- [x] `cargo make fmt-check` passes locally (0 files would be formatted)

## Checklist

- [x] Code follows project style guidelines (`rustfmt.toml`)
- [x] No logic changes — formatting only
- [x] All comments in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)