### PR TITLE
fix(templates): use 'manage' as bin name in pages startproject template

### DIFF
--- a/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
@@ -8,7 +8,7 @@ default-run = "{{ project_name }}"
 crate-type = ["cdylib", "rlib"]  # cdylib for WASM, rlib for server
 
 [[bin]]
-name = "{{ project_name }}"
+name = "manage"
 path = "src/bin/manage.rs"
 
 [dependencies]


### PR DESCRIPTION
## Summary

The `[[bin]]` entry in the generated Cargo.toml for the `startproject --with-pages` template was using `{{ project_name }}` instead of the literal string `"manage"`.

This meant users had to run:
```sh
cargo run --bin fullstack_demo makemigrations posts
```
instead of the documented command:
```sh
cargo run --bin manage makemigrations posts
```

## Fix

Changed one line in `crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl`:

```diff
- name = "{{ project_name }}"
+ name = "manage"
```

The restful template (`project_restful_template/Cargo.toml.tpl`) already uses `"manage"` correctly — this brings the pages template into alignment.

Fixes #3862