### PR TITLE
docs(issues): add good first issue policy (GFI-1 ~ GFI-5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -559,6 +559,8 @@ Before submitting code:
 - Create upstream issue before implementing any workaround for external dependency bugs (WP-2)
 - Include the ideal implementation as a comment when introducing workaround code (WP-3)
 - Create a tracking issue in reinhardt-web for every upstream dependency issue with `upstream-tracking` label (UR-4)
+- Apply `good first issue` only when all GFI-1 criteria are met (single crate, ≤3 files, unambiguous fix)
+- Ensure issue description has file paths, expected behavior, and verification steps before applying `good first issue` (GFI-4)
 
 ### ❌ NEVER DO
 - Use `mod.rs` files (deprecated pattern)
@@ -634,6 +636,8 @@ Before submitting code:
 - Implement workarounds for upstream dependency issues without creating an upstream issue first (WP-2)
 - Introduce workaround code without an ideal implementation comment (WP-3)
 - Create upstream issues without corresponding reinhardt-web tracking issues (UR-4)
+- Apply `good first issue` to security, breaking-change, agent-suspect, or high/critical priority issues (GFI-2)
+- Apply `good first issue` without verifying issue description has sufficient guidance for new contributors (GFI-4)
 
 ### 📚 Detailed Standards
 
@@ -647,6 +651,7 @@ For comprehensive guidelines, see:
 - **Stability Policy**: instructions/STABILITY_POLICY.md (includes DB-1 ~ DB-7 develop branch strategy)
 - **Agent Bug Discovery**: instructions/STABILITY_POLICY.md (SC-2a)
 - **Issues**: instructions/ISSUE_GUIDELINES.md
+- **Good First Issue Policy**: instructions/ISSUE_GUIDELINES.md (GFI-1 ~ GFI-5)
 - **Issue Handling**: instructions/ISSUE_HANDLING.md
 - **Upstream Issue Reporting**: instructions/UPSTREAM_ISSUE_REPORTING.md
 - **GitHub Interactions**: instructions/GITHUB_INTERACTION.md

--- a/instructions/ISSUE_GUIDELINES.md
+++ b/instructions/ISSUE_GUIDELINES.md
@@ -407,6 +407,82 @@ Questions posted as Issues may be redirected to Discussions.
 
 ---
 
+## Good First Issue Policy
+
+### GFI-1 (MUST): Eligibility Criteria
+
+Apply the `good first issue` label ONLY when ALL of the following are true:
+
+**Scope Constraints:**
+- The fix or change is confined to a **single crate** (no cross-crate impact)
+- The change touches **3 or fewer files**
+- The estimated implementation is **under 50 lines** of Rust code
+
+**Complexity Constraints:**
+- Does NOT require understanding of Reinhardt's internal macro system (`#[model]`, `#[inject]`, etc.)
+- Does NOT require changes to public API signatures
+- Does NOT involve async runtime, database schema, or authentication logic
+- Does NOT require TestContainers or integration test infrastructure changes
+- The correct fix/approach is **unambiguous** (one clearly correct solution)
+
+**Documentation Constraints:**
+- The issue description provides **sufficient context** to start without maintainer guidance
+- Includes a clear **expected outcome** the contributor can verify
+
+### GFI-2 (MUST): Disqualification Criteria
+
+NEVER apply `good first issue` when any of the following apply:
+
+- Security-related issues (any `security` label)
+- API-breaking changes (any `breaking-change` or `rc-migration` label)
+- Issues requiring deep knowledge of SeaQuery internals
+- Cross-crate refactoring
+- Issues with `agent-suspect` label (unverified — may not be a real issue)
+- Issues with `needs more info` label (insufficient specification)
+- Issues with `critical` or `high` priority (too risky for new contributors)
+- Issues that require coordinated changes with a pending upstream fix
+
+### GFI-3 (SHOULD): Label Application Timing
+
+- Apply `good first issue` during **triage** (LC-1 step 3), not at issue creation
+- Re-evaluate and remove the label if the issue grows in scope during discussion
+- Remove the label once someone is actively working on it (assign + comment)
+
+### GFI-4 (MUST): Issue Description Requirements
+
+Before applying `good first issue`, the issue description MUST include:
+
+1. **Exact file(s) to modify** (repository-relative paths)
+2. **Specific behavior to change** (before/after)
+3. **How to verify the fix** (which test to run or what output to expect)
+4. **Relevant code pointers** (function name, line range, or struct name)
+
+If the issue lacks any of these, add them before applying the label (or use `needs more info` label first).
+
+**Example of a well-formed `good first issue` description:**
+
+> **File:** `crates/reinhardt-core/src/config/loader.rs` — `ConfigLoader::from_env()`
+>
+> **Problem:** When the `APP_PORT` environment variable is missing, the function panics
+> instead of returning an error.
+>
+> **Expected:** Return `Err(ConfigError::MissingEnvVar("APP_PORT"))` instead of panicking.
+>
+> **Verification:** Run `cargo nextest run -p reinhardt-core config::loader`.
+>
+> **Hint:** Look at how `from_file()` handles missing keys in the same file.
+
+### GFI-5 (SHOULD): Contributor Guidance
+
+When a new contributor comments on a `good first issue` to claim it:
+
+- Maintainer SHOULD reply within **48 hours** to confirm assignment
+- Provide a worktree setup hint: `git worktree add /tmp/<branch> -b fix/issue-XXXX-<desc>`
+- Point to `instructions/TESTING_STANDARDS.md` and `CLAUDE.md` Quick Reference
+- Set expectation: PR within **14 days** or the issue is unassigned for others
+
+---
+
 ## Security Issues
 
 ### SEC-1 (MUST): Private Disclosure


### PR DESCRIPTION
## Summary

- Add `## Good First Issue Policy` section to `instructions/ISSUE_GUIDELINES.md` with five policy rules (GFI-1 ~ GFI-5)
- Update `CLAUDE.md` Quick Reference with GFI rules in MUST DO, NEVER DO, and Detailed Standards sections

## Type of Change

- [x] Documentation update

## Motivation and Context

- The `good first issue` label existed in `.github/labels.yml` with only a one-line description ("Suitable for new contributors"), but no criteria for when to apply it or how contributors should use it
- This created inconsistent labeling by maintainers and gave new contributors insufficient guidance to successfully complete their first contribution
- The new policy establishes clear, verifiable criteria to ensure only well-scoped, unambiguous issues receive the label

## How Was This Tested?

- Documentation-only change; no code compilation required
- Verified insertion point is immediately before `## Security Issues` in `instructions/ISSUE_GUIDELINES.md`
- Verified CLAUDE.md Quick Reference additions are consistent with the new GFI rules

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

### Priority Label (for maintainers)
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The five GFI rules cover:
- **GFI-1**: Eligibility (single crate, ≤3 files, <50 lines, unambiguous fix, self-contained description)
- **GFI-2**: Disqualification (security, breaking-change, agent-suspect, high/critical priority, upstream-blocked)
- **GFI-3**: Timing (triage phase only, remove on scope growth or active assignment)
- **GFI-4**: Required description fields (file paths, before/after behavior, verification command, code pointers)
- **GFI-5**: Contributor response protocol (48h reply, 14-day PR deadline, worktree hint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)