### PR TITLE
fix(commands): resolve startproject compile failure and makemigrations Docker panic

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -816,8 +816,16 @@ impl BaseCommand for MakeMigrationsCommand {
 			let mut results: Vec<MigrationResult> = Vec::new();
 
 			// Build from_state based on strategy (default: TestContainers)
+			//
+			// #3871: Check --force-empty-state before any TestContainers or DB call.
+			// postgres_container() panics when Docker is unavailable, so the flag must
+			// be respected before attempting container startup, not as a fallback.
 			let from_db_flag = ctx.has_option("from-db");
-			let from_state = if from_db_flag {
+			let from_state = if ctx.has_option("force-empty-state") {
+				ctx.warning("⚠️  Using empty state as requested (--force-empty-state)");
+				ctx.warning("This may create duplicate migrations!");
+				ProjectState::new()
+			} else if from_db_flag {
 				// When --from-db flag is specified: prioritize database history
 				match build_from_state_from_db(&migrations_dir, &database_url).await {
 					Ok(state) => {
@@ -862,15 +870,7 @@ impl BaseCommand for MakeMigrationsCommand {
 										);
 										ctx.error("");
 
-										if ctx.has_option("force-empty-state") {
-											ctx.warning(
-												"⚠️  Using empty state as requested (--force-empty-state)",
-											);
-											ctx.warning("This may create duplicate migrations!");
-											ProjectState::new()
-										} else {
-											return Err("from_state construction failed. Please fix TestContainers, use --from-db, or use --force-empty-state to continue anyway.".to_string().into());
-										}
+										return Err("from_state construction failed. Please fix TestContainers, use --from-db, or use --force-empty-state to continue anyway.".to_string().into());
 									}
 								}
 							}
@@ -922,15 +922,7 @@ impl BaseCommand for MakeMigrationsCommand {
 										);
 										ctx.error("");
 
-										if ctx.has_option("force-empty-state") {
-											ctx.warning(
-												"⚠️  Using empty state as requested (--force-empty-state)",
-											);
-											ctx.warning("This may create duplicate migrations!");
-											ProjectState::new()
-										} else {
-											return Err("from_state construction failed. Please fix database connection, remove --from-db, or use --force-empty-state to continue anyway.".to_string().into());
-										}
+										return Err("from_state construction failed. Please fix database connection, remove --from-db, or use --force-empty-state to continue anyway.".to_string().into());
 									}
 								}
 							}

--- a/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
@@ -33,7 +33,8 @@ use reinhardt::conf::settings::sources::{DefaultSource, LowPriorityEnvSource, To
 use reinhardt::settings;
 use std::env;
 
-#[settings(/* add fragments here, e.g.: cache: CacheSettings | session: SessionSettings */)]
+// Add fragments to extend settings: e.g. `#[settings(core: CoreSettings | cache: CacheSettings)]`
+#[settings(core: CoreSettings)]
 pub struct ProjectSettings;
 
 /// Get settings based on environment variable

--- a/crates/reinhardt-commands/templates/project_restful_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/src/config/settings.rs.tpl
@@ -33,7 +33,8 @@ use reinhardt::conf::settings::sources::{DefaultSource, LowPriorityEnvSource, To
 use reinhardt::settings;
 use std::env;
 
-#[settings(/* add fragments here, e.g.: cache: CacheSettings | session: SessionSettings */)]
+// Add fragments to extend settings: e.g. `#[settings(core: CoreSettings | cache: CacheSettings)]`
+#[settings(core: CoreSettings)]
 pub struct ProjectSettings;
 
 /// Get settings based on environment variable


### PR DESCRIPTION
## Summary

- Fix `startproject --with-pages` generating an invalid `#[settings(/* comment */)]` placeholder that compiles to empty `#[settings()]`, which the macro rejects
- Fix `makemigrations --force-empty-state` panicking when Docker is unavailable by checking the flag **before** any TestContainers or database call

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Two hard-block issues that prevent freshly scaffolded projects from building or running migrations without Docker:

**#3869 Error 1** — The comment inside `#[settings(/* ... */)]` is stripped at parse time, producing `#[settings()]` which the macro rejects with a hard compile error on a brand-new project.

**#3871** — `postgres_container()` panics (not returns `Err`) when Docker is unavailable, making the `--force-empty-state` fallback unreachable. The flag must gate entry into the TestContainers path entirely.

Fixes #3869 (Error 1)
Fixes #3871

## How Was This Tested?

- Verified `cargo check -p reinhardt-commands --all-features` passes (exit 0)
- Confirmed `#[settings(core: CoreSettings)]` is the valid minimal usage per macro docs
- Confirmed early `--force-empty-state` guard bypasses both TestContainers and database paths

## Checklist

- [x] Code follows project style guidelines
- [x] All code comments in English
- [x] No TODO/FIXME left in new code
- [ ] I use self-hosted runner for CI

## Labels to Apply

- `bug` — fixes compile and runtime errors in scaffold and migrations
- `high` — breaks project creation and migrations for Docker-less environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)