### PR TITLE
fix(commands): fix startapp template bugs in pages and restful scaffolds

### DIFF
--- a/crates/reinhardt-commands/templates/app_pages_template/lib.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/lib.rs.tpl
@@ -9,6 +9,8 @@ pub mod admin;
 pub mod models;
 pub mod serializers;
 pub mod urls;
+pub mod views;
+pub mod ws_urls;
 
 // Client-side modules
 #[cfg(client)]

--- a/crates/reinhardt-commands/templates/app_pages_template/models.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/models.rs.tpl
@@ -8,7 +8,9 @@
 //! ```rust,ignore
 //! use reinhardt::macros::user;
 //! use reinhardt::Argon2Hasher;
+//! use serde::{Deserialize, Serialize};
 //!
+//! #[derive(Serialize, Deserialize)]
 //! #[user(hasher = Argon2Hasher, username_field = "email")]
 //! #[model(table_name = "users")]
 //! pub struct User {

--- a/crates/reinhardt-commands/templates/app_pages_template/views.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/views.rs.tpl
@@ -1,0 +1,24 @@
+//! Views module for {{ app_name }} app (Pages)
+//!
+//! Define ViewSets here. Each `pub mod` declaration corresponds to a file
+//! under the `views/` directory.
+//!
+//! For multi-file views that need re-exports for discovery, use:
+//! ```rust,ignore
+//! flatten_imports! {
+//!     pub mod example;
+//! }
+//! ```
+//!
+//! # Example ViewSet
+//!
+//! ```rust,ignore
+//! use reinhardt::prelude::*;
+//! use reinhardt::viewset;
+//!
+//! // Import your model here
+//! // use crate::models::{{ camel_case_app_name }};
+//!
+//! #[viewset]
+//! pub struct {{ camel_case_app_name }}ViewSet;
+//! ```

--- a/crates/reinhardt-commands/templates/app_pages_template/ws_urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/ws_urls.rs.tpl
@@ -1,0 +1,29 @@
+//! WebSocket URL configuration for {{ app_name }} app
+//!
+//! Defines WebSocket consumer routes for this application.
+//! The `#[url_patterns(mode = ws)]` macro generates the `ws_url_resolvers` module
+//! consumed by the project-level `#[routes]` macro.
+//!
+//! # Example
+//!
+//! To register a WebSocket consumer:
+//!
+//! ```rust,ignore
+//! use reinhardt::url_patterns;
+//! use crate::config::apps::InstalledApp;
+//!
+//! #[url_patterns(InstalledApp::{{ app_name }}, mode = ws)]
+//! pub fn ws_url_patterns() {
+//!     // Register consumers via .consumer("path/", handler)
+//! }
+//! ```
+
+use reinhardt::url_patterns;
+
+use crate::config::apps::InstalledApp;
+
+#[url_patterns(InstalledApp::{{ app_name }}, mode = ws)]
+pub fn ws_url_patterns() {
+    // Register WebSocket consumers here.
+    // Example: .consumer("chat/", chat_consumer)
+}

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/lib.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/lib.rs.tpl
@@ -9,6 +9,8 @@ pub mod admin;
 pub mod models;
 pub mod serializers;
 pub mod urls;
+pub mod views;
+pub mod ws_urls;
 
 // Client-side modules
 #[cfg(client)]

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/models.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/models.rs.tpl
@@ -8,7 +8,9 @@
 //! ```rust,ignore
 //! use reinhardt::macros::user;
 //! use reinhardt::Argon2Hasher;
+//! use serde::{Deserialize, Serialize};
 //!
+//! #[derive(Serialize, Deserialize)]
 //! #[user(hasher = Argon2Hasher, username_field = "email")]
 //! #[model(table_name = "users")]
 //! pub struct User {

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/views.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/views.rs.tpl
@@ -1,0 +1,24 @@
+//! Views module for {{ app_name }} app (Pages)
+//!
+//! Define ViewSets here. Each `pub mod` declaration corresponds to a file
+//! under the `views/` directory.
+//!
+//! For multi-file views that need re-exports for discovery, use:
+//! ```rust,ignore
+//! flatten_imports! {
+//!     pub mod example;
+//! }
+//! ```
+//!
+//! # Example ViewSet
+//!
+//! ```rust,ignore
+//! use reinhardt::prelude::*;
+//! use reinhardt::viewset;
+//!
+//! // Import your model here
+//! // use crate::models::{{ camel_case_app_name }};
+//!
+//! #[viewset]
+//! pub struct {{ camel_case_app_name }}ViewSet;
+//! ```

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/ws_urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/ws_urls.rs.tpl
@@ -1,0 +1,29 @@
+//! WebSocket URL configuration for {{ app_name }} app
+//!
+//! Defines WebSocket consumer routes for this application.
+//! The `#[url_patterns(mode = ws)]` macro generates the `ws_url_resolvers` module
+//! consumed by the project-level `#[routes]` macro.
+//!
+//! # Example
+//!
+//! To register a WebSocket consumer:
+//!
+//! ```rust,ignore
+//! use reinhardt::url_patterns;
+//! use crate::config::apps::InstalledApp;
+//!
+//! #[url_patterns(InstalledApp::{{ app_name }}, mode = ws)]
+//! pub fn ws_url_patterns() {
+//!     // Register consumers via .consumer("path/", handler)
+//! }
+//! ```
+
+use reinhardt::url_patterns;
+
+use crate::config::apps::InstalledApp;
+
+#[url_patterns(InstalledApp::{{ app_name }}, mode = ws)]
+pub fn ws_url_patterns() {
+    // Register WebSocket consumers here.
+    // Example: .consumer("chat/", chat_consumer)
+}

--- a/crates/reinhardt-commands/templates/app_restful_template/models.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_restful_template/models.rs.tpl
@@ -8,7 +8,9 @@
 //! ```rust,ignore
 //! use reinhardt::macros::user;
 //! use reinhardt::Argon2Hasher;
+//! use serde::{Deserialize, Serialize};
 //!
+//! #[derive(Serialize, Deserialize)]
 //! #[user(hasher = Argon2Hasher, username_field = "email")]
 //! #[model(table_name = "users")]
 //! pub struct User {

--- a/crates/reinhardt-commands/templates/app_restful_workspace_template/src/models.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_restful_workspace_template/src/models.rs.tpl
@@ -8,7 +8,9 @@
 //! ```rust,ignore
 //! use reinhardt::macros::user;
 //! use reinhardt::Argon2Hasher;
+//! use serde::{Deserialize, Serialize};
 //!
+//! #[derive(Serialize, Deserialize)]
 //! #[user(hasher = Argon2Hasher, username_field = "email")]
 //! #[model(table_name = "users")]
 //! pub struct User {

--- a/website/content/quickstart/tutorials/basis/3-views-and-urls.md
+++ b/website/content/quickstart/tutorials/basis/3-views-and-urls.md
@@ -260,13 +260,7 @@ impl From<crate::apps::polls::models::Choice> for ChoiceInfo {
 
 ## Implementing Server Functions
 
-Create `src/server_fn.rs`:
-
-```rust
-pub mod polls;
-```
-
-Create `src/server_fn/polls.rs`:
+Create `src/apps/polls/server/server_fn.rs`:
 
 ```rust
 use crate::shared::types::{ChoiceInfo, QuestionInfo, VoteRequest};


### PR DESCRIPTION
## Summary

- Add `#[derive(Serialize, Deserialize)]` and serde import to User model examples in all four template variants (#3864)
- Generate `ws_urls.rs` for pages templates so `#[routes]` resolves `ws_url_resolvers` correctly (#3865, partially resolves #3869 Error 2)
- Add `views.rs.tpl` with ViewSet scaffold for pages templates (#3867)
- Fix tutorial doc path `src/server_fn.rs` → `src/apps/<app>/server/server_fn.rs` (#3868)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Motivation and Context

Multiple startapp template deficiencies caused generated projects to fail compilation or mislead users:

- **#3864**: `#[user]`/`#[model]` macros do not add serde derives; example omitting them caused compile errors when following the template
- **#3865/#3869 Error 2**: `#[routes]` expects `crate::apps::<app>::ws_urls::ws_url_resolvers` but startapp generated no `ws_urls.rs`, producing a hard E0433 compile error
- **#3867**: Pages apps had no `views.rs` scaffold, leaving `UnifiedRouter` without a ViewSet integration point
- **#3868**: Tutorial referenced the pre-rc.14 path `src/server_fn.rs`; scaffold now generates `src/apps/<app>/server/server_fn.rs`

Fixes #3864
Fixes #3865
Fixes #3867
Fixes #3868
Refs #3869

## How Was This Tested?

- Verified all changed template files produce correct module structure
- `ws_urls.rs.tpl` uses `#[url_patterns(mode = ws)]` which generates `pub mod ws_url_resolvers` consumed by `#[routes]`

## Checklist

- [x] Code follows project style guidelines
- [x] All code comments in English
- [x] No TODO/FIXME left in new code
- [ ] I use self-hosted runner for CI

## Labels to Apply

- `bug` — fixes multiple compile errors and incorrect documentation in scaffold templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)