### PR TITLE
fix(commands): allow .gitignore.tpl to pass hidden-file filter in template processor

### DIFF
--- a/crates/reinhardt-commands/src/template.rs
+++ b/crates/reinhardt-commands/src/template.rs
@@ -147,8 +147,13 @@ impl TemplateCommand {
 				.map(|s| s.to_string_lossy().into_owned())
 				.unwrap_or_default();
 
-			// Skip hidden files and __pycache__, but keep .gitkeep and .gitignore
-			if (file_name.starts_with('.') && file_name != ".gitkeep" && file_name != ".gitignore")
+			// Skip hidden files and __pycache__, but keep .gitkeep and .gitignore(.tpl).
+			// Strip the .tpl extension before comparing so that `.gitignore.tpl` is also
+			// recognized as the allowed dotfile `.gitignore`.
+			let base_name = file_name.strip_suffix(".tpl").unwrap_or(&file_name);
+			if (file_name.starts_with('.')
+				&& base_name != ".gitkeep"
+				&& base_name != ".gitignore")
 				|| file_name == "__pycache__"
 			{
 				continue;


### PR DESCRIPTION
## Summary

- Fix `template.rs` hidden-file filter that silently drops `.gitignore.tpl` during `startproject`, causing no `.gitignore` to be generated at all

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The dotfile filter in `crates/reinhardt-commands/src/template.rs:151` whitelisted `.gitignore` by exact string comparison. However, every template file uses a `.tpl` suffix, so the real template on disk is `.gitignore.tpl`. Since `.gitignore.tpl` starts with `.` and is not in the whitelist (`.gitkeep`, `.gitignore`), it was matched by the skip condition and **never written to the output directory**.

This means `reinhardt-admin startproject` has never produced a `.gitignore` file — the template content (which already includes `.DS_Store`, `settings/*.toml`, `.env`, etc.) was silently discarded on every invocation.

**Root cause trace:**

```
file_name = ".gitignore.tpl"
file_name.starts_with('.') → true
file_name != ".gitkeep"   → true
file_name != ".gitignore" → true  ← mismatch: ".gitignore.tpl" ≠ ".gitignore"
→ continue (skip)
```

**Fix**: strip the `.tpl` suffix before comparing against the whitelist, so `.gitignore.tpl` is recognized as the allowed dotfile `.gitignore`. This also future-proofs the check for any other dotfile templates (e.g. `.env.tpl`) that may be added later.

The `.gitignore.tpl` templates already contain the correct entries (`.DS_Store`, `settings/*.toml`, `.env`, etc.) — the only bug was that they were never emitted.

Fixes #3870

## How Was This Tested?

- `cargo check -p reinhardt-commands` passes (exit 0)
- Logic verified: `".gitignore.tpl".strip_suffix(".tpl")` = `Some(".gitignore")`, which matches the whitelist entry

## Checklist

- [x] Code follows project style guidelines
- [x] All code comments in English
- [x] No TODO/FIXME left in new code
- [ ] I use self-hosted runner for CI

## Labels to Apply

- `bug` — `.gitignore` was never generated by `startproject`, exposing users to accidental secret commits
- `high` — security risk: `local.toml` with secrets is not gitignored without this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)