### PR TITLE
fix(docs): resolve broken intra-doc link and dead_code in reinhardt-pages

### DIFF
--- a/crates/reinhardt-pages/src/app.rs
+++ b/crates/reinhardt-pages/src/app.rs
@@ -14,7 +14,7 @@ thread_local! {
 ///
 /// # Panics
 ///
-/// Panics if [`ClientLauncher::launch`] has not been called yet.
+/// Panics if `ClientLauncher::launch` has not been called yet.
 pub fn with_router<F, R>(f: F) -> R
 where
 	F: FnOnce(&Router) -> R,
@@ -26,6 +26,7 @@ where
 	})
 }
 
+#[cfg(wasm)]
 fn store_router(router: Router) {
 	APP_ROUTER.with(|r| {
 		*r.borrow_mut() = Some(router);
@@ -52,6 +53,7 @@ fn store_router(router: Router) {
 /// }
 /// ```
 pub struct ClientLauncher {
+	#[cfg_attr(not(wasm), allow(dead_code))]
 	root_selector: &'static str,
 	router_init: Option<Box<dyn FnOnce() -> Router>>,
 }


### PR DESCRIPTION
## Summary

- Replaced the `` [`ClientLauncher::launch`] `` intra-doc link in `with_router`'s Panics section with a backtick-formatted reference — `launch()` lives in a `#[cfg(wasm)] impl` block and is invisible to non-wasm rustdoc, causing a `rustdoc::broken_intra_doc_links` error
- Wrapped `store_router` in `#[cfg(wasm)]` — it is only ever called from the wasm `launch()` impl, so clippy correctly flagged it as dead code on non-wasm targets
- Added `#[cfg_attr(not(wasm), allow(dead_code))]` to the `root_selector` field — it is only read inside the `#[cfg(wasm)]` impl block

## Test plan

- [x] `cargo make clippy-check` passes
- [x] `cargo make fmt-check` passes
- [x] `cargo doc --no-deps -p reinhardt-pages` passes with no broken intra-doc link errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)