### PR TITLE
fix(infra): add spot interruption handler to prevent CI job loss

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -99,7 +99,7 @@ jobs:
           echo "Downloading Lambda zips for v${MODULE_VERSION}..."
           mkdir -p lambdas
           BASE_URL="https://github.com/github-aws-runners/terraform-aws-github-runner/releases/download/v${MODULE_VERSION}"
-          for name in webhook runners runner-binaries-syncer; do
+          for name in webhook runners runner-binaries-syncer termination-watcher; do
             curl -fsSL -o "lambdas/${name}.zip" "${BASE_URL}/${name}.zip"
             echo "  Downloaded ${name}.zip"
           done

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -131,7 +131,7 @@ jobs:
           echo "Downloading Lambda zips for v${MODULE_VERSION}..."
           mkdir -p lambdas
           BASE_URL="https://github.com/github-aws-runners/terraform-aws-github-runner/releases/download/v${MODULE_VERSION}"
-          for name in webhook runners runner-binaries-syncer; do
+          for name in webhook runners runner-binaries-syncer termination-watcher; do
             curl -fsSL -o "lambdas/${name}.zip" "${BASE_URL}/${name}.zip"
             echo "  Downloaded ${name}.zip"
           done

--- a/infra/github-runners/init.sh
+++ b/infra/github-runners/init.sh
@@ -112,13 +112,14 @@ fi
 if [[ "$CURRENT_TRACKED_VERSION" != "$MODULE_VERSION" && -n "$CURRENT_TRACKED_VERSION" ]]; then
   echo "  [version-change] Lambda version changed: v${CURRENT_TRACKED_VERSION} -> v${MODULE_VERSION}"
   echo "  [cleanup] Removing outdated Lambda zip files..."
-  for zip_name in webhook runners runner-binaries-syncer; do
+  for zip_name in webhook runners runner-binaries-syncer termination-watcher; do
     rm -f "${LAMBDA_DIR}/${zip_name}.zip"
   done
 fi
 
 # Download each required Lambda zip (skip if already downloaded for this version)
-for LAMBDA_NAME in webhook runners runner-binaries-syncer; do
+# termination-watcher: Lambda for spot interruption handling (cancels GitHub job on 2-min warning)
+for LAMBDA_NAME in webhook runners runner-binaries-syncer termination-watcher; do
   DEST="${LAMBDA_DIR}/${LAMBDA_NAME}.zip"
   # Check if the file exists and is non-empty
   if [[ -f "$DEST" && -s "$DEST" ]]; then

--- a/infra/github-runners/runner.tf
+++ b/infra/github-runners/runner.tf
@@ -109,8 +109,26 @@ module "github_runner" {
   job_retry = {
     enable           = true
     delay_in_seconds = 120
-    max_attempts     = 3
+    max_attempts     = 5
   }
+
+  # Spot termination watcher: cancel and re-queue GitHub jobs on EC2 Spot
+  # interruption notices (2-minute warning from instance metadata). Without
+  # this, an interrupted runner leaves the GitHub job in a "lost" state that
+  # must be manually re-run. Combined with job_retry above, interrupted jobs
+  # are automatically re-queued and picked up by a fresh runner.
+  instance_termination_watcher = {
+    enable = true
+    zip    = "${path.module}/lambdas/termination-watcher.zip"
+    features = {
+      enable_spot_termination_handler              = true
+      enable_spot_termination_notification_watcher = true
+    }
+  }
+
+  # On-demand failover: when no Spot capacity is available (InsufficientInstanceCapacity),
+  # fall back to on-demand instances to prevent job queue stalls.
+  enable_runner_on_demand_failover_for_errors = ["InsufficientInstanceCapacity"]
 }
 
 # Supplemental IAM policy: grant ssm:GetParameter (singular) for AMI SSM parameter.


### PR DESCRIPTION
## Summary

- Enable `instance_termination_watcher` to cancel and re-queue GitHub jobs when EC2 Spot instances receive a 2-minute termination notice
- Add `enable_runner_on_demand_failover_for_errors` to fall back to on-demand when Spot capacity is unavailable (`InsufficientInstanceCapacity`)
- Increase `job_retry.max_attempts` from 3 to 5 for additional resilience
- Update `init.sh` to download `termination-watcher.zip` Lambda alongside existing Lambda zips

## Type of Change

- [x] CI/CD changes

## Motivation and Context

CI jobs were frequently getting stuck or lost mid-execution because EC2 Spot instances were being interrupted by AWS. When a Spot interruption occurs:

**Before this fix:** The runner process is killed, leaving the GitHub job in a "lost" state with no automatic recovery. The job must be manually re-run, and the runner remains registered as `busy: true` on GitHub, blocking subsequent jobs from being assigned.

**After this fix:** The `instance_termination_watcher` Lambda polls the EC2 instance metadata endpoint for the 2-minute termination notice, cancels the in-flight GitHub job gracefully, and returns it to the queue. Combined with `job_retry`, a fresh runner picks up the job automatically.

The `enable_runner_on_demand_failover_for_errors` option addresses the secondary failure mode where Spot capacity exhaustion causes the scale-up Lambda to fail silently, leaving jobs queued indefinitely.

## How Was This Tested?

- Terraform plan validation via CI
- Logic reviewed against `terraform-aws-github-runner` v6.1 module documentation

## Performance Impact

- No impact on job execution performance
- On-demand fallback may increase cost marginally only when Spot capacity is exhausted; normal operation continues to use Spot pricing (~61% discount)

## Labels to Apply

- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)