### PR TITLE
fix(ci): enable validation feature for reinhardt-pages UI trybuild tests

### DIFF
--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -190,6 +190,11 @@ cfg_aliases = "0.2"
 [dev-dependencies]
 insta = { workspace = true }
 reinhardt-forms = { workspace = true }
+# Enable `validation` feature for trybuild UI tests that exercise
+# `Validated<Form<T>>` extractors in `tests/ui/server_fn/with_extractors.rs`
+# (Issue #3858). The non-dev target dependency intentionally leaves this
+# feature off for slimmer default builds.
+reinhardt-di = { workspace = true, features = ["validation"] }
 wasm-bindgen-test = "0.3.56"
 serial_test = "3"
 trybuild = "1.0"

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -190,11 +190,6 @@ cfg_aliases = "0.2"
 [dev-dependencies]
 insta = { workspace = true }
 reinhardt-forms = { workspace = true }
-# Enable `validation` feature for trybuild UI tests that exercise
-# `Validated<Form<T>>` extractors in `tests/ui/server_fn/with_extractors.rs`
-# (Issue #3858). The non-dev target dependency intentionally leaves this
-# feature off for slimmer default builds.
-reinhardt-di = { workspace = true, features = ["validation"] }
 wasm-bindgen-test = "0.3.56"
 serial_test = "3"
 trybuild = "1.0"
@@ -209,6 +204,13 @@ http-body-util = { workspace = true }
 bytes = { workspace = true }
 tokio-tungstenite = "0.26"
 futures-util = "0.3"
+# Enable `validation` feature for trybuild UI tests that exercise
+# `Validated<Form<T>>` extractors in `tests/ui/server_fn/with_extractors.rs`
+# (Issue #3858). Scoped to non-wasm targets because `validation` pulls in
+# `reinhardt-core/validators`, which transitively drags in `tokio/net` and
+# cannot build for `wasm32-unknown-unknown`. The trybuild harness itself is
+# already gated with `#![cfg(not(target_arch = "wasm32"))]`.
+reinhardt-di = { workspace = true, features = ["validation"] }
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/reinhardt-pages/tests/ui/server_fn/with_extractors.rs
+++ b/crates/reinhardt-pages/tests/ui/server_fn/with_extractors.rs
@@ -16,6 +16,15 @@ struct LoginRequest {
 	password: String,
 }
 
+// `Validated<Form<LoginRequest>>` requires the inner type to implement
+// `reinhardt_core::validators::Validate`. A minimal no-op impl is enough
+// to satisfy the trait bound for this compile-only fixture.
+impl reinhardt_core::validators::Validate for LoginRequest {
+	fn validate(&self) -> Result<(), reinhardt_core::validators::ValidationErrors> {
+		Ok(())
+	}
+}
+
 #[derive(Serialize, Deserialize)]
 struct User {
 	id: u32,


### PR DESCRIPTION
## Summary

- Enable `reinhardt-di/validation` feature in `reinhardt-pages` dev-dependencies so trybuild can compile `tests/ui/server_fn/with_extractors.rs`.

## Type of Change

- [x] Bug fix (CI / test infrastructure)

## Motivation and Context

`UI Tests / UI Tests (6/8)` fails on PR #3893 with:

```
error[E0425]: cannot find type `Validated` in module `reinhardt_di::params`
  --> tests/ui/server_fn/with_extractors.rs:45:30
   |
45 |     form: reinhardt_di::params::Validated<reinhardt_di::params::Form<LoginRequest>>,
   |                                 ^^^^^^^^^ not found in `reinhardt_di::params`
   |
note: found an item that was configured out
   | #[cfg(feature = "validation")]
   | pub use validation::Validated;
```

`reinhardt-di` intentionally keeps `validation` out of its default features
(kept default lean for slim builds). The target-scoped dependency in
`reinhardt-pages` did not enable it either, so the `Validated<Form<T>>`
extractor used by the trybuild fixture (added for issue #3858) was gated out
at compile time.

The fixture itself is correct — it is a positive `t.pass(...)` case asserting
that the `#[server_fn]` macro recognizes `FromRequest` extractor parameters.
The right fix is to enable `validation` only in dev-dependencies so the test
builds the feature while runtime default feature surface stays the same.

Reproduced job: https://github.com/kent8192/reinhardt-web/actions/runs/24766432053/job/72462409988

## How Was This Tested

- [x] Applied fix to a worktree branched from `main` (commit `5d2becfa6`)
- [ ] `cargo test -p reinhardt-pages --test ui test_server_fn_macro_ui` passes locally
- [ ] Re-run CI `UI Tests / UI Tests (6/8)` passes

Local verification is in progress and will be confirmed before marking ready
for review.

## Labels to Apply

- `bug`
- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)