### PR TITLE
security: ignore RUSTSEC-2026-0104 (rustls-webpki panic via aws-sdk rustls 0.21)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -55,4 +55,5 @@ jobs:
             --ignore RUSTSEC-2026-0049 \
             --ignore RUSTSEC-2026-0066 \
             --ignore RUSTSEC-2026-0098 \
-            --ignore RUSTSEC-2026-0099
+            --ignore RUSTSEC-2026-0099 \
+            --ignore RUSTSEC-2026-0104


### PR DESCRIPTION
## Summary

- Add `--ignore RUSTSEC-2026-0104` to `.github/workflows/security-audit.yml` so every PR's Security Audit job stops failing on a brand-new rustls-webpki advisory.

## Type of Change

- [x] Bug fix (CI / security audit baseline)

## Motivation and Context

[RUSTSEC-2026-0104] (Reachable panic in certificate revocation list parsing) was published for `rustls-webpki`, affecting all versions < 0.103.13. Our workspace pulls in the vulnerable `rustls-webpki 0.101.7` transitively via `aws-smithy-http-client` → `rustls 0.21.12`, which cannot be bumped without the AWS SDK stack moving to `rustls >= 0.22`.

Evidence: https://github.com/kent8192/reinhardt-web/actions/runs/24770698094/job/72476113393

```
Crate:     rustls-webpki
Title:     Reachable panic in certificate revocation list parsing
ID:        RUSTSEC-2026-0104
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0104
error: 1 vulnerability found!
```

The vulnerable code path panics on a crafted CRL sent by a TLS peer. In this codebase the affected rustls-0.21 stack talks to AWS endpoints only, so the realized risk until the SDK updates is negligible. This matches the existing pattern we use for other transitive AWS SDK advisories (`RUSTSEC-2026-0098`, `RUSTSEC-2026-0099`, etc.).

[RUSTSEC-2026-0104]: https://rustsec.org/advisories/RUSTSEC-2026-0104

## How Was This Tested

- [x] Local `cargo audit` with the updated ignore list exits 0 in a worktree branched from `main` (commit `5d2becfa6`)
- [x] Verified vulnerable dep chain: `cargo tree -i rustls-webpki@0.101.7` → `rustls 0.21.12` → `aws-smithy-http-client` → `aws-config`
- [ ] CI `Security Audit / Scan for known vulnerabilities` passes on this PR

## Follow-up

Tracked in #3897. Remove the ignore entry once `aws-smithy-http-client` / `aws-config` adopt `rustls >= 0.22`, which pulls in `rustls-webpki >= 0.103.13`.

## Related Issues

Fixes #3897

## Labels to Apply

- `bug`
- `ci-cd`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)