### PR TITLE
fix(infra): harden runner job-retry and add stuck-queue alarms

### DIFF
--- a/infra/github-runners/alerting.tf
+++ b/infra/github-runners/alerting.tf
@@ -1,0 +1,71 @@
+# CI stuck-queue alerting.
+#
+# Surfaces scale-up queue stagnation to operators before job-retry exhausts.
+# Context: kent8192/reinhardt-web#3902 documented 8 jobs stranded on PR #3901
+# when JIT runners silently failed to pick up assignments. By the time the
+# retry window closed (~75min), the jobs were unrecoverable without a manual
+# `gh run rerun`. This alarm fires when the oldest message in the scale-up
+# SQS queue has been waiting longer than 30 minutes, giving operators a
+# ~45-minute window (with the raised max_attempts=10) to intervene.
+
+resource "aws_sns_topic" "ci_alerts" {
+  name = "${var.prefix}-ci-alerts"
+}
+
+resource "aws_sns_topic_subscription" "ci_alerts_email" {
+  topic_arn = aws_sns_topic.ci_alerts.arn
+  protocol  = "email"
+  endpoint  = var.budget_alert_email
+}
+
+# ApproximateAgeOfOldestMessage rises when job_retry republishes a stuck job
+# to the scale-up queue and scale-up cannot successfully launch a runner that
+# picks up the assignment. Sustained elevation past 30 min indicates the
+# retry loop is not converging, typically from JIT-runner assignment races
+# or Spot capacity exhaustion.
+resource "aws_cloudwatch_metric_alarm" "stuck_queued_builds" {
+  alarm_name        = "${var.prefix}-stuck-queued-builds"
+  alarm_description = "Scale-up SQS queue has a message older than 30 minutes. Indicates CI runner-assignment failure; investigate scale-up and job-retry Lambda logs. See kent8192/reinhardt-web#3902."
+
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 1800
+
+  dimensions = {
+    QueueName = "${var.prefix}-queued-builds"
+  }
+
+  # Treat missing data as OK: queue is legitimately empty most of the time.
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.ci_alerts.arn]
+  ok_actions    = [aws_sns_topic.ci_alerts.arn]
+}
+
+# Secondary alarm on job-retry queue: if messages accumulate here, job_retry
+# Lambda itself is failing to drain (e.g. GitHub API rate limit, auth error).
+resource "aws_cloudwatch_metric_alarm" "stuck_job_retry" {
+  alarm_name        = "${var.prefix}-stuck-job-retry"
+  alarm_description = "Job-retry SQS queue has a message older than 30 minutes. Indicates job-retry Lambda is not draining; check /aws/lambda/${var.prefix}-job-retry logs. See kent8192/reinhardt-web#3902."
+
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 1800
+
+  dimensions = {
+    QueueName = "${var.prefix}-job-retry"
+  }
+
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.ci_alerts.arn]
+  ok_actions    = [aws_sns_topic.ci_alerts.arn]
+}

--- a/infra/github-runners/runner.tf
+++ b/infra/github-runners/runner.tf
@@ -106,10 +106,15 @@ module "github_runner" {
   # Without this, queued jobs can deadlock when the initial SQS message is
   # consumed but the runner terminates before the job starts (e.g. when
   # runners_maximum_count is reached or spot interruption occurs).
+  #
+  # max_attempts=10 covers ~2.5h of retry at 15-min intervals. Raised from
+  # 5 after 8 jobs were stranded on PR #3901 when retries exhausted in
+  # ~75min while JIT runners silently failed to pick up assignments.
+  # See kent8192/reinhardt-web#3902.
   job_retry = {
     enable           = true
     delay_in_seconds = 120
-    max_attempts     = 5
+    max_attempts     = 10
   }
 
   # Spot termination watcher: cancel and re-queue GitHub jobs on EC2 Spot


### PR DESCRIPTION
## Summary

- Raise JIT runner `job_retry.max_attempts` from 5 to 10 (~75min → ~2.5h retry coverage)
- Add CloudWatch alarms on scale-up and job-retry SQS queues (`ApproximateAgeOfOldestMessage > 30min`) with SNS email notification

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Fixes #3902.

On 2026-04-22, 8 jobs on PR #3901 were stranded in `queued` state for 90+ minutes. Root cause: the JIT runner pipeline (`terraform-aws-github-runner` module) relies on `job_retry` to re-queue jobs that ephemeral runners fail to pick up, but `max_attempts=5` at ~15min intervals only covers ~75min. After that window, orphan jobs have no recovery path and require manual `gh run rerun`.

Additionally, there was no operator-visible signal when the retry loop failed to converge.

## Changes

**`infra/github-runners/runner.tf`**
- `job_retry.max_attempts`: `5` → `10` (covers ~2.5h of retries instead of ~75min)

**`infra/github-runners/alerting.tf` (new)**
- `aws_sns_topic.ci_alerts` — notification channel (email subscription reuses `budget_alert_email`)
- `aws_cloudwatch_metric_alarm.stuck_queued_builds` — fires when the scale-up SQS queue's oldest message exceeds 30 min (3 consecutive 5-min periods)
- `aws_cloudwatch_metric_alarm.stuck_job_retry` — fires when the job-retry SQS queue's oldest message exceeds 30 min (catches job-retry Lambda drain failures)

## How Was This Tested

- [x] `terraform validate` passes
- [x] `terraform plan -var-file=terraform.tfvars` — produces `4 to add, 1 to change, 0 to destroy`, and `JOB_RETRY_CONFIG.maxAttempts` changes from `"5"` to `"10"` on the scale-up Lambda as expected

## Labels to Apply

- `bug`
- `high`
- `ci-cd`

## Related Issues

- Fixes #3902 (this PR)
- Refs #3903 (scheduled orphan detector — follow-up enhancement)

## Additional Context

- The raised `max_attempts=10` is a pragmatic band-aid; a secondary JIT-runner assignment-race bug still exists (EC2 instances terminated with `UserInitiatedShutdown` without picking up their assigned job). Tracked in #3903 as the scheduled orphan-detector enhancement.
- The alarm threshold of 30 min intentionally triggers well before the ~2.5h retry window closes, giving operators time to intervene.
- `treat_missing_data = "notBreaching"` prevents false alarms when the queue is legitimately empty (the normal idle state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)