### PR TITLE
fix(commands): return WebSocketRouter from ws_urls scaffold template

### DIFF
--- a/crates/reinhardt-commands/templates/app_pages_template/ws_urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/ws_urls.rs.tpl
@@ -10,20 +10,24 @@
 //!
 //! ```rust,ignore
 //! use reinhardt::url_patterns;
+//! use reinhardt::WebSocketRouter;
 //! use crate::config::apps::InstalledApp;
 //!
 //! #[url_patterns(InstalledApp::{{ app_name }}, mode = ws)]
-//! pub fn ws_url_patterns() {
-//!     // Register consumers via .consumer("path/", handler)
+//! pub fn ws_url_patterns() -> WebSocketRouter {
+//!     WebSocketRouter::new()
+//!     // Register consumers via .consumer(handler)
 //! }
 //! ```
 
 use reinhardt::url_patterns;
+use reinhardt::WebSocketRouter;
 
 use crate::config::apps::InstalledApp;
 
 #[url_patterns(InstalledApp::{{ app_name }}, mode = ws)]
-pub fn ws_url_patterns() {
+pub fn ws_url_patterns() -> WebSocketRouter {
+    WebSocketRouter::new()
     // Register WebSocket consumers here.
-    // Example: .consumer("chat/", chat_consumer)
+    // Example: .consumer(chat_consumer)
 }

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/ws_urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/ws_urls.rs.tpl
@@ -10,20 +10,24 @@
 //!
 //! ```rust,ignore
 //! use reinhardt::url_patterns;
+//! use reinhardt::WebSocketRouter;
 //! use crate::config::apps::InstalledApp;
 //!
 //! #[url_patterns(InstalledApp::{{ app_name }}, mode = ws)]
-//! pub fn ws_url_patterns() {
-//!     // Register consumers via .consumer("path/", handler)
+//! pub fn ws_url_patterns() -> WebSocketRouter {
+//!     WebSocketRouter::new()
+//!     // Register consumers via .consumer(handler)
 //! }
 //! ```
 
 use reinhardt::url_patterns;
+use reinhardt::WebSocketRouter;
 
 use crate::config::apps::InstalledApp;
 
 #[url_patterns(InstalledApp::{{ app_name }}, mode = ws)]
-pub fn ws_url_patterns() {
+pub fn ws_url_patterns() -> WebSocketRouter {
+    WebSocketRouter::new()
     // Register WebSocket consumers here.
-    // Example: .consumer("chat/", chat_consumer)
+    // Example: .consumer(chat_consumer)
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- `reinhardt-admin startapp --with-pages` produced an `ws_urls.rs` whose empty `pub fn ws_url_patterns()` body returned `()`, and `#[url_patterns(mode = ws)]` wraps that with `.with_namespace(...)`. The generated code failed `cargo check` with `E0599: no method named \`with_namespace\` found for unit type \`()\``.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The scaffold templates for the pages project type shipped with `ws_urls.rs.tpl` using the placeholder shape `pub fn ws_url_patterns() { ... }`. That compiled fine for the macro's `unified` / `server` / `client` modes (because the body there returns a router via `UnifiedRouter::new()`), but the `ws` mode wrapper expects a `WebSocketRouter` value. The in-repo unit test for `mode = ws` uses the correct shape (`-> WebSocketRouter` returning `WebSocketRouter::new().consumer(...)`), so aligning the scaffold with the macro contract is the right fix. Option A from the issue.

Fixes #3908

## How Was This Tested?

- `diff` confirms both template files remain identical after the edit.
- Templates are not directly compiled; the scaffold-path verification is covered by a follow-up scaffold integration test (planned, separate PR, blocked on this + #3909).

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Fixes #3908
- Sibling scaffold fix: #3909 (same failure path, `admin` feature activation of the `pages` module)

## Labels to Apply

### Type Label
- [x] `bug`

### Scope Label
- [x] `websockets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)