### PR TITLE
fix(web): activate pages feature alias when admin is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ api = [
 auth = ["reinhardt-auth", "reinhardt-commands?/auth"]
 argon2-hasher = ["auth", "reinhardt-auth/argon2-hasher"]
 admin = [
+  "pages",
   "reinhardt-admin",
   "reinhardt-admin/adapters",
   "reinhardt-admin/server",


### PR DESCRIPTION
## Summary

This PR addresses:

- Enabling the `admin` feature alias pulled in the `reinhardt-pages` crate as a dependency but did not activate this crate's own `pages` feature alias. Because `pub mod pages;` and the `reinhardt_pages` re-export in `src/lib.rs` are gated on `#[cfg(feature = "pages")]`, user code calling `reinhardt::pages::ClientLauncher` or `reinhardt::pages::router::Router` failed to resolve on any scaffolded pages project.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`reinhardt-admin startproject --with-pages` generates a `Cargo.toml` with `features = ["full", "admin"]`. `admin` already activates `reinhardt-admin/pages` and depends on the `reinhardt-pages` crate, but the local `pages` feature alias (which gates the `reinhardt::pages` module itself) was never activated. Option A from the issue — pulling `pages` into `admin` — keeps the feature alias semantics aligned with the dependency alias and does not require users to edit their `Cargo.toml`.

Fixes #3909

## How Was This Tested?

- `cargo check -p reinhardt-web -F admin --no-default-features` — succeeds after the change, with `reinhardt-pages`, `reinhardt-pages-ast`, `reinhardt-pages-macros`, and `reinhardt-admin` all compiling. Before this change the same command does not expose the `pages` module to downstream users relying on `admin` alone.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Fixes #3909
- Sibling scaffold fix: #3908 (`ws_urls.rs.tpl` return type for pages scaffold)

## Labels to Apply

### Type Label
- [x] `bug`

### Scope Label
- [x] `admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)