### PR TITLE
fix(commands): align startproject --with-pages default-run with manage bin

### DIFF
--- a/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
@@ -2,7 +2,7 @@
 name = "{{ project_name }}"
 version = "0.1.0"
 edition = "2024"
-default-run = "{{ project_name }}"
+default-run = "manage"
 
 [lib]
 crate-type = ["cdylib", "rlib"]  # cdylib for WASM, rlib for server

--- a/crates/reinhardt-commands/tests/embedded_startproject.rs
+++ b/crates/reinhardt-commands/tests/embedded_startproject.rs
@@ -6,7 +6,30 @@ use reinhardt_commands::{BaseCommand, CommandContext};
 use rstest::*;
 use serial_test::serial;
 use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
 use tempfile::TempDir;
+
+// Assert that Cargo can fully parse the generated manifest.
+//
+// Uses `cargo metadata --no-deps` so no registry access is required; the
+// command still exercises the same manifest-parsing step that rejects
+// misconfigurations (e.g. a `default-run` pointing at a nonexistent bin)
+// which would break the scaffold for a real user on `cargo run`.
+fn assert_manifest_parses(manifest: &Path) {
+	let output = Command::new(env!("CARGO"))
+		.args(["metadata", "--no-deps", "--format-version", "1"])
+		.arg("--manifest-path")
+		.arg(manifest)
+		.output()
+		.expect("cargo metadata command spawns");
+	assert!(
+		output.status.success(),
+		"generated manifest failed to parse: {}\nstderr:\n{}",
+		manifest.display(),
+		String::from_utf8_lossy(&output.stderr),
+	);
+}
 
 #[rstest]
 #[tokio::test]
@@ -37,6 +60,7 @@ async fn startproject_restful_from_embedded_only() {
 		generated.join("src").is_dir(),
 		"src/ directory must be generated"
 	);
+	assert_manifest_parses(&generated.join("Cargo.toml"));
 }
 
 #[rstest]
@@ -68,4 +92,5 @@ async fn startproject_pages_from_embedded_only() {
 		generated.join("src").is_dir(),
 		"src/ directory must be generated"
 	);
+	assert_manifest_parses(&generated.join("Cargo.toml"));
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Stop emitting an unbuildable `Cargo.toml` from `reinhardt-admin startproject --with-pages` by aligning the templated `default-run` with the only bin the template actually ships (`manage`).
- Harden the embedded `startproject` integration tests so the same class of manifest regression fails CI instead of silently slipping through.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

On rc.19, `crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl` declared `default-run = "{{ project_name }}"`, but the template's only `[[bin]]` is `name = "manage"`. Cargo validates `default-run` during manifest parsing — before honoring any `--bin` override — so every freshly-scaffolded `--with-pages` project errored with:

```
error: failed to parse manifest at `.../Cargo.toml`

Caused by:
  default-run target `<project_name>` not found
```

Effect: **100% of `--with-pages` scaffolds on rc.19 are unusable out of the box**, including the `reinhardt-blog-demo` 15-minute demo walkthrough (Scene 3 scaffolds, Scene 5 runs `cargo run --bin manage -- makemigrations`, both dead on arrival).

Root cause: between rc.17 and rc.19 the sole bin was renamed to `manage`, but `default-run` was not updated. Sister template `project_restful_template/Cargo.toml.tpl` has no `default-run` line and is unaffected.

Secondary motivation: the existing regression test `tests/embedded_startproject.rs::startproject_pages_from_embedded_only` only checked that files existed on disk — the generated `Cargo.toml` was present but unparseable — so the bug slipped through CI.

Fixes #3923

## How Was This Tested?

- Reproduced the issue locally via `cargo run -p reinhardt-commands --bin reinhardt-admin -- startproject demo --with-pages` → `cargo metadata --no-deps --manifest-path demo/Cargo.toml` fails on unpatched main with the exact error above.
- Added `assert_manifest_parses()` helper to both `startproject_restful_from_embedded_only` and `startproject_pages_from_embedded_only`; runs `cargo metadata --no-deps --format-version 1` against the generated manifest. `--no-deps` keeps the check registry-free and deterministic while still exercising the exact manifest-parsing path that rejects invalid `default-run` targets.
- `cargo nextest run -p reinhardt-commands --test embedded_startproject` → 2/2 pass locally after the fix.
- `cargo fmt --check -p reinhardt-commands` → clean.
- `cargo clippy -p reinhardt-commands --tests --all-features` → no new warnings from this change (pre-existing warnings in unrelated tests are unchanged).

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable) — N/A (template + test only)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable) — N/A (no DB interaction)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #3923
- Orthogonal to #3917 (urls/ scaffold layout, shipped in rc.19) — same template family, different oversight.

## Labels to Apply

### Type Label (select one)
- [x] \`bug\` - Bug fix

### Scope Label (select all that apply)
<!-- This touches `reinhardt-commands` scaffolding templates; no `scope/*` label in .github/labels.yml matched, leaving type label only. -->

### Priority Label (for maintainers)
- [x] \`high\` - Important fix or feature (matches #3923)

---

**Additional Context:**

- Alternative considered: drop the `default-run` line entirely (Cargo auto-picks the sole `[[bin]]`). Kept the explicit `default-run = "manage"` per the issue author's recommendation — intent stays visible and the template is future-proof if more bins are added.
- The new `assert_manifest_parses()` runs on both restful and pages tests so future `[package]` / `[[bin]]` drift in either template surfaces in CI, not after a user runs the scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)