### PR TITLE
feat(scripts): marker-based version-refs update + CI lint (PR-1/3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,22 @@ jobs:
       runner: ${{ needs.determine-runner.outputs.runner }}
       cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
 
+  version-markers:
+    name: Version Markers Lint
+    needs: [check-branch-status]
+    if: needs.check-branch-status.outputs.has-conflicts != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run shell-script tests
+        run: bash scripts/tests/run-all.sh
+
+      - name: Validate version-sync markers across repo
+        run: ./scripts/validate-version-markers.sh
+
   # Feature flag combination check - release PRs only.
   # Verifies that all documented feature presets compile correctly
   # before publishing to crates.io. Only runs on release-plz branches

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Get a well-balanced feature set with zero configuration:
 [dependencies]
 # Import as 'reinhardt', published as 'reinhardt-web'
 # Default enables the "standard" preset (balanced feature set)
+# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
 ```
 
@@ -142,6 +143,7 @@ For projects that need every available component:
 
 ```toml
 [dependencies]
+# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", default-features = false, features = ["full"] }
 ```
 
@@ -155,6 +157,7 @@ Lightweight and fast, perfect for simple APIs:
 
 ```toml
 [dependencies]
+# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", default-features = false, features = ["minimal"] }
 ```
 
@@ -169,23 +172,31 @@ Install only the components you need:
 ```toml
 [dependencies]
 # Core components
+# reinhardt-version-sync
 reinhardt-http = "0.1.0-rc.17"
+# reinhardt-version-sync
 reinhardt-urls = "0.1.0-rc.17"
 
 # Optional: Database
+# reinhardt-version-sync
 reinhardt-db = "0.1.0-rc.17"
 
 # Optional: Authentication
+# reinhardt-version-sync
 reinhardt-auth = "0.1.0-rc.17"
 
 # Optional: REST API features
+# reinhardt-version-sync
 reinhardt-rest = "0.1.0-rc.17"
 
 # Optional: Admin panel
+# reinhardt-version-sync
 reinhardt-admin = "0.1.0-rc.17"
 
 # Optional: Advanced features
+# reinhardt-version-sync
 reinhardt-graphql = "0.1.0-rc.17"
+# reinhardt-version-sync
 reinhardt-websockets = "0.1.0-rc.17"
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ Reinhardt is a modular framework. Choose your starting point:
 
 Get a well-balanced feature set with zero configuration:
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 # Import as 'reinhardt', published as 'reinhardt-web'
 # Default enables the "standard" preset (balanced feature set)
-# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
 ```
 
@@ -141,9 +141,9 @@ use reinhardt::{Request, Response, StatusCode};
 
 For projects that need every available component:
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", default-features = false, features = ["full"] }
 ```
 
@@ -155,9 +155,9 @@ reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", default-featur
 
 Lightweight and fast, perfect for simple APIs:
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", default-features = false, features = ["minimal"] }
 ```
 
@@ -169,34 +169,27 @@ reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", default-featur
 
 Install only the components you need:
 
+<!-- reinhardt-version-sync:8 -->
 ```toml
 [dependencies]
 # Core components
-# reinhardt-version-sync
 reinhardt-http = "0.1.0-rc.17"
-# reinhardt-version-sync
 reinhardt-urls = "0.1.0-rc.17"
 
 # Optional: Database
-# reinhardt-version-sync
 reinhardt-db = "0.1.0-rc.17"
 
 # Optional: Authentication
-# reinhardt-version-sync
 reinhardt-auth = "0.1.0-rc.17"
 
 # Optional: REST API features
-# reinhardt-version-sync
 reinhardt-rest = "0.1.0-rc.17"
 
 # Optional: Admin panel
-# reinhardt-version-sync
 reinhardt-admin = "0.1.0-rc.17"
 
 # Optional: Advanced features
-# reinhardt-version-sync
 reinhardt-graphql = "0.1.0-rc.17"
-# reinhardt-version-sync
 reinhardt-websockets = "0.1.0-rc.17"
 ```
 

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -35,6 +35,7 @@ By default, examples use published versions from crates.io:
 
 ```toml
 [dependencies]
+# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", features = ["standard"] }
 ```
 
@@ -68,6 +69,7 @@ rm -f .cargo/config.toml
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
+# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -33,9 +33,9 @@ Each `examples-*` directory is an independent Cargo project demonstrating specif
 
 By default, examples use published versions from crates.io:
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", features = ["standard"] }
 ```
 
@@ -66,10 +66,10 @@ rm -f .cargo/config.toml
 
 #### ✅ CORRECT Pattern
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
-# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine
@@ -83,9 +83,9 @@ rstest = "0.26.1"
 
 #### ❌ INCORRECT Pattern
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -85,6 +85,7 @@ rstest = "0.26.1"
 
 ```toml
 [dependencies]
+# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,6 +17,7 @@ members = [
 
 [workspace.dependencies]
 # Reinhardt framework (crates.io published versions)
+# reinhardt-version-sync
 reinhardt = { version = "0.1.0-rc.9", package = "reinhardt-web" }
 
 # Testing

--- a/scripts/tests/run-all.sh
+++ b/scripts/tests/run-all.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/tests/run-all.sh — entry point for all shell tests in this PR series.
+# Exit 0 on success, non-zero on first failing test file.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FAIL=0
+
+for test in "$SCRIPT_DIR"/test-*.sh; do
+	[ -f "$test" ] || continue
+	echo "=== $(basename "$test") ==="
+	if ! bash "$test"; then
+		echo "FAIL: $(basename "$test")" >&2
+		FAIL=1
+	fi
+done
+
+if [ "$FAIL" -eq 0 ]; then
+	echo "All script tests passed."
+fi
+exit "$FAIL"

--- a/scripts/tests/test-update-version-refs.sh
+++ b/scripts/tests/test-update-version-refs.sh
@@ -141,4 +141,41 @@ run_case "03 multi-version block" \
 	"0.1.0-rc.99" \
 	"multi.md"
 
+# Orphan marker case (expects non-zero exit)
+
+run_orphan_case() {
+	local name="$1"
+	local input_file="$2"
+	local target_rel="$3"
+
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	mkdir -p "$tmpdir/scripts" "$(dirname "$tmpdir/$target_rel")"
+	cp "$SCRIPT" "$tmpdir/scripts/update-version-refs.sh"
+	cp "$input_file" "$tmpdir/$target_rel"
+
+	set +e
+	REINHARDT_VERSION_SYNC_TARGETS="$target_rel" \
+		bash "$tmpdir/scripts/update-version-refs.sh" "0.1.0-rc.99" \
+		>/dev/null 2>"$tmpdir/err.log"
+	rc=$?
+	set -e
+
+	if [ "$rc" -eq 2 ] && grep -q "ORPHAN_MARKER" "$tmpdir/err.log"; then
+		pass "$name"
+	else
+		fail "$name (rc=$rc, stderr below)"
+		cat "$tmpdir/err.log" >&2
+	fi
+	rm -rf "$tmpdir"
+}
+
+# Fixture 04: marker with no following version
+cat > "$fx_dir/04-input.md" <<'MD_EOF'
+<!-- reinhardt-version-sync -->
+This paragraph has no version on the next line.
+MD_EOF
+
+run_orphan_case "04 orphan marker" "$fx_dir/04-input.md" "bad.md"
+
 exit "$FAIL"

--- a/scripts/tests/test-update-version-refs.sh
+++ b/scripts/tests/test-update-version-refs.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# scripts/tests/test-update-version-refs.sh
+# Self-contained tests for scripts/update-version-refs.sh.
+# Each test creates fixtures in a tempdir, invokes the script with
+# REPO_ROOT pointing at the tempdir, and asserts the result.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/update-version-refs.sh"
+
+# --- Test harness ---
+
+FAIL=0
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1" >&2; FAIL=1; }
+
+run_case() {
+	local name="$1"
+	local input_file="$2"
+	local expected_file="$3"
+	local new_ver="$4"
+	local target_rel="$5"
+
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	trap 'rm -rf "$tmpdir"' RETURN
+
+	# Lay out the tempdir as a fake REPO_ROOT
+	mkdir -p "$tmpdir/scripts"
+	cp "$SCRIPT" "$tmpdir/scripts/update-version-refs.sh"
+
+	# Place the fixture at the target path declared by the test
+	mkdir -p "$(dirname "$tmpdir/$target_rel")"
+	cp "$input_file" "$tmpdir/$target_rel"
+
+	# Override TARGET_FILES via env for testability (see Task 3 hook)
+	REINHARDT_VERSION_SYNC_TARGETS="$target_rel" \
+		bash "$tmpdir/scripts/update-version-refs.sh" "$new_ver" >/dev/null
+
+	if diff -q "$expected_file" "$tmpdir/$target_rel" >/dev/null; then
+		pass "$name"
+	else
+		fail "$name (diff below)"
+		diff -u "$expected_file" "$tmpdir/$target_rel" || true
+	fi
+}
+
+# --- Fixtures ---
+
+fx_dir=$(mktemp -d)
+trap 'rm -rf "$fx_dir"' EXIT
+
+# Fixture 01: plain TOML, single marker, single version
+cat > "$fx_dir/01-input.toml" <<'EOF'
+[package]
+name = "demo"
+
+# reinhardt-version-sync
+reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
+EOF
+
+cat > "$fx_dir/01-expected.toml" <<'EOF'
+[package]
+name = "demo"
+
+# reinhardt-version-sync
+reinhardt = { version = "0.1.0-rc.99", package = "reinhardt-web" }
+EOF
+
+run_case "01 plain TOML single marker" \
+	"$fx_dir/01-input.toml" \
+	"$fx_dir/01-expected.toml" \
+	"0.1.0-rc.99" \
+	"demo.toml"
+
+exit "$FAIL"

--- a/scripts/tests/test-update-version-refs.sh
+++ b/scripts/tests/test-update-version-refs.sh
@@ -106,4 +106,39 @@ run_case "02 markdown toml block single marker" \
 	"0.1.0-rc.99" \
 	"demo.md"
 
+# Fixture 03: Markdown with toml block containing multiple versions
+cat > "$fx_dir/03-input.md" <<'MD_EOF'
+```toml
+# Core components
+# reinhardt-version-sync
+reinhardt-http = "0.1.0-rc.17"
+# reinhardt-version-sync
+reinhardt-urls = "0.1.0-rc.17"
+
+# Optional: Database
+# reinhardt-version-sync
+reinhardt-db = "0.1.0-rc.17"
+```
+MD_EOF
+
+cat > "$fx_dir/03-expected.md" <<'MD_EOF'
+```toml
+# Core components
+# reinhardt-version-sync
+reinhardt-http = "0.1.0-rc.99"
+# reinhardt-version-sync
+reinhardt-urls = "0.1.0-rc.99"
+
+# Optional: Database
+# reinhardt-version-sync
+reinhardt-db = "0.1.0-rc.99"
+```
+MD_EOF
+
+run_case "03 multi-version block" \
+	"$fx_dir/03-input.md" \
+	"$fx_dir/03-expected.md" \
+	"0.1.0-rc.99" \
+	"multi.md"
+
 exit "$FAIL"

--- a/scripts/tests/test-update-version-refs.sh
+++ b/scripts/tests/test-update-version-refs.sh
@@ -178,4 +178,50 @@ MD_EOF
 
 run_orphan_case "04 orphan marker" "$fx_dir/04-input.md" "bad.md"
 
+# Fixture 05: counter marker N=3 — HTML comment arms three replacements
+cat > "$fx_dir/05-input.md" <<'MD_EOF'
+<!-- reinhardt-version-sync:3 -->
+```toml
+reinhardt-http = "0.1.0-rc.17"
+reinhardt-urls = "0.1.0-rc.17"
+reinhardt-db   = "0.1.0-rc.17"
+```
+MD_EOF
+
+cat > "$fx_dir/05-expected.md" <<'MD_EOF'
+<!-- reinhardt-version-sync:3 -->
+```toml
+reinhardt-http = "0.1.0-rc.99"
+reinhardt-urls = "0.1.0-rc.99"
+reinhardt-db   = "0.1.0-rc.99"
+```
+MD_EOF
+
+run_case "05 counter marker N=3" \
+	"$fx_dir/05-input.md" \
+	"$fx_dir/05-expected.md" \
+	"0.1.0-rc.99" \
+	"counter3.md"
+
+# Fixture 06: counter marker default (N=1, no colon) — equivalent to original HTML marker
+cat > "$fx_dir/06-input.md" <<'MD_EOF'
+<!-- reinhardt-version-sync -->
+```toml
+reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
+```
+MD_EOF
+
+cat > "$fx_dir/06-expected.md" <<'MD_EOF'
+<!-- reinhardt-version-sync -->
+```toml
+reinhardt = { version = "0.1.0-rc.99", package = "reinhardt-web" }
+```
+MD_EOF
+
+run_case "06 counter marker default N=1" \
+	"$fx_dir/06-input.md" \
+	"$fx_dir/06-expected.md" \
+	"0.1.0-rc.99" \
+	"counter1.md"
+
 exit "$FAIL"

--- a/scripts/tests/test-update-version-refs.sh
+++ b/scripts/tests/test-update-version-refs.sh
@@ -73,4 +73,37 @@ run_case "01 plain TOML single marker" \
 	"0.1.0-rc.99" \
 	"demo.toml"
 
+# Fixture 02: Markdown with toml fenced block, marker inside the block
+cat > "$fx_dir/02-input.md" <<'MD_EOF'
+# Demo
+
+Install it:
+
+```toml
+# reinhardt-version-sync
+reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
+```
+
+Done.
+MD_EOF
+
+cat > "$fx_dir/02-expected.md" <<'MD_EOF'
+# Demo
+
+Install it:
+
+```toml
+# reinhardt-version-sync
+reinhardt = { version = "0.1.0-rc.99", package = "reinhardt-web" }
+```
+
+Done.
+MD_EOF
+
+run_case "02 markdown toml block single marker" \
+	"$fx_dir/02-input.md" \
+	"$fx_dir/02-expected.md" \
+	"0.1.0-rc.99" \
+	"demo.md"
+
 exit "$FAIL"

--- a/scripts/tests/test-validate-version-markers.sh
+++ b/scripts/tests/test-validate-version-markers.sh
@@ -73,4 +73,15 @@ reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
 EOF
 run_validate_case "V3 unmarked hardcoded version" "$fx_dir/unmarked.toml" "bad.toml" 1 "UNMARKED"
 
+# V4: marker inside a Markdown fenced code block -> rc 1, MARKER_IN_CODE_BLOCK
+cat > "$fx_dir/v4-marker-in-block.md" <<'MD_EOF'
+# Example
+
+```toml
+# reinhardt-version-sync
+reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
+```
+MD_EOF
+run_validate_case "V4 marker in code block" "$fx_dir/v4-marker-in-block.md" "bad.md" 1 "MARKER_IN_CODE_BLOCK"
+
 exit "$FAIL"

--- a/scripts/tests/test-validate-version-markers.sh
+++ b/scripts/tests/test-validate-version-markers.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# scripts/tests/test-validate-version-markers.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/validate-version-markers.sh"
+
+FAIL=0
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1" >&2; FAIL=1; }
+
+run_validate_case() {
+	local name="$1"
+	local input_file="$2"
+	local target_rel="$3"
+	local expected_rc="$4"
+	local expected_stderr_substr="$5"
+
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	mkdir -p "$tmpdir/scripts" "$(dirname "$tmpdir/$target_rel")"
+	cp "$SCRIPT" "$tmpdir/scripts/validate-version-markers.sh"
+	cp "$input_file" "$tmpdir/$target_rel"
+
+	set +e
+	REINHARDT_VERSION_SYNC_TARGETS="$target_rel" \
+		bash "$tmpdir/scripts/validate-version-markers.sh" \
+		>"$tmpdir/out.log" 2>"$tmpdir/err.log"
+	rc=$?
+	set -e
+
+	if [ "$rc" -ne "$expected_rc" ]; then
+		fail "$name (rc=$rc, expected $expected_rc)"
+		cat "$tmpdir/err.log" >&2
+		rm -rf "$tmpdir"
+		return
+	fi
+
+	if [ -n "$expected_stderr_substr" ]; then
+		if grep -q "$expected_stderr_substr" "$tmpdir/err.log"; then
+			pass "$name"
+		else
+			fail "$name (stderr missing: $expected_stderr_substr)"
+			cat "$tmpdir/err.log" >&2
+		fi
+	else
+		pass "$name"
+	fi
+	rm -rf "$tmpdir"
+}
+
+fx_dir=$(mktemp -d)
+trap 'rm -rf "$fx_dir"' EXIT
+
+# Clean: marker directly above version -> rc 0
+cat > "$fx_dir/clean.toml" <<'EOF'
+# reinhardt-version-sync
+reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
+EOF
+run_validate_case "V1 clean" "$fx_dir/clean.toml" "ok.toml" 0 ""
+
+# Orphan: marker with no version on next non-blank line -> rc 1
+cat > "$fx_dir/orphan.md" <<'EOF'
+<!-- reinhardt-version-sync -->
+Just prose, no version here.
+EOF
+run_validate_case "V2 orphan marker" "$fx_dir/orphan.md" "orphan.md" 1 "ORPHAN_MARKER"
+
+# Unmarked: Reinhardt version present but no preceding marker -> rc 1
+cat > "$fx_dir/unmarked.toml" <<'EOF'
+[dependencies]
+reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
+EOF
+run_validate_case "V3 unmarked hardcoded version" "$fx_dir/unmarked.toml" "bad.toml" 1 "UNMARKED"
+
+exit "$FAIL"

--- a/scripts/update-version-refs.sh
+++ b/scripts/update-version-refs.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
-# Update version references in documentation and examples after a release.
+# Update version references in documentation and non-release-plz-managed
+# manifests after a version bump. Replacement is guided by explicit
+# '<lang-comment> reinhardt-version-sync' markers on the line immediately
+# above each target (see docs/superpowers/specs/2026-04-23-release-plz-
+# version-refs-sync-design.md).
+#
 # Usage: ./scripts/update-version-refs.sh <new-version> [--dry-run]
-# Example: ./scripts/update-version-refs.sh 0.1.0-rc.8
+# Example: ./scripts/update-version-refs.sh 0.1.0-rc.20
 
 set -euo pipefail
 
@@ -12,9 +17,7 @@ NEW_VER=""
 
 for arg in "$@"; do
 	case "$arg" in
-		--dry-run)
-			DRY_RUN=true
-			;;
+		--dry-run) DRY_RUN=true ;;
 		-*)
 			echo "Error: Unknown option '$arg'" >&2
 			echo "Usage: $0 <new-version> [--dry-run]" >&2
@@ -25,7 +28,6 @@ for arg in "$@"; do
 				NEW_VER="$arg"
 			else
 				echo "Error: Unexpected argument '$arg'" >&2
-				echo "Usage: $0 <new-version> [--dry-run]" >&2
 				exit 1
 			fi
 			;;
@@ -33,65 +35,128 @@ for arg in "$@"; do
 done
 
 if [ -z "$NEW_VER" ]; then
-	echo "Error: Version argument is required" >&2
 	echo "Usage: $0 <new-version> [--dry-run]" >&2
 	exit 1
 fi
 
-# --- Version format validation ---
-
+# Validate version format: X.Y.Z or X.Y.Z-prerelease
 if ! echo "$NEW_VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
 	echo "Error: Invalid version format '$NEW_VER'" >&2
-	echo "Expected: X.Y.Z or X.Y.Z-prerelease (e.g., 0.1.0, 0.1.0-rc.8)" >&2
+	echo "Expected: X.Y.Z or X.Y.Z-prerelease" >&2
 	exit 1
 fi
 
-# --- Resolve repository root ---
+# --- Resolve paths and target list ---
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Default in-scope files for PR-1. PR-2 will extend this list via a
+# follow-up commit. Tests override via the env var below.
+DEFAULT_TARGETS=(
+	"README.md"
+	"examples/Cargo.toml"
+	"examples/CLAUDE.md"
+	"website/config.toml"
+)
+
+if [ -n "${REINHARDT_VERSION_SYNC_TARGETS:-}" ]; then
+	# Space-separated override (for tests only)
+	read -r -a TARGETS <<< "$REINHARDT_VERSION_SYNC_TARGETS"
+else
+	TARGETS=("${DEFAULT_TARGETS[@]}")
+fi
+
 echo "Updating version references to $NEW_VER in $REPO_ROOT"
 
-# Export version for perl to access via $ENV{NEW_VER}
-# This avoids shell escaping issues with $1/$2 perl backreferences
-export NEW_VER
+# --- Awk program: marker-based replacer ---
+#
+# States:
+#   SCANNING: looking for a marker line
+#   ARMED:    marker seen, next non-blank non-fence line must carry a version
+#
+# Exit codes:
+#   0 = all files processed without orphan markers
+#   2 = at least one orphan marker encountered
 
-# --- Update files ---
+AWK_PROG='
+BEGIN {
+	marker_re  = "^[[:space:]]*(#|//)[[:space:]]*reinhardt-version-sync[[:space:]]*$"
+	marker_re2 = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync[[:space:]]*-->[[:space:]]*$"
+	version_re = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
+	fence_re   = "^[[:space:]]*```"
+	blank_re   = "^[[:space:]]*$"
+	state = "SCANNING"
+	orphans = 0
+}
+{
+	if (state == "SCANNING") {
+		print
+		if ($0 ~ marker_re || $0 ~ marker_re2) state = "ARMED"
+		next
+	}
+	# ARMED
+	if ($0 ~ fence_re || $0 ~ blank_re) { print; next }
+	if (match($0, version_re)) {
+		prefix = substr($0, 1, RSTART - 1)
+		suffix = substr($0, RSTART + RLENGTH)
+		print prefix new_ver suffix
+		state = "SCANNING"
+		next
+	}
+	# Marker with no version on the next eligible line.
+	printf("ORPHAN_MARKER %s:%d: next line has no version: %s\n", FILENAME, NR, $0) > "/dev/stderr"
+	print
+	orphans++
+	state = "SCANNING"
+}
+END { if (orphans > 0) exit 2 }
+'
 
-# 1. examples/Cargo.toml: workspace dependency
-#    reinhardt = { version = "OLD", package = "reinhardt-web" }
-perl -i -pe 's/(reinhardt\s*=\s*\{\s*version\s*=\s*")[^"]+(",\s*package\s*=\s*"reinhardt-web")/$1$ENV{NEW_VER}$2/g' "$REPO_ROOT/examples/Cargo.toml"
+# --- Apply to each target ---
 
-# 2. website/config.toml: template variable
-#    reinhardt_version = "OLD"
-perl -i -pe 's/(reinhardt_version\s*=\s*")[^"]+(")/$1$ENV{NEW_VER}$2/g' "$REPO_ROOT/website/config.toml"
+CHANGED_FILES=()
+ORPHAN_FAIL=0
 
-# 3. README.md: umbrella crate references (with package = "reinhardt-web")
-#    reinhardt = { version = "OLD", package = "reinhardt-web", ... }
-#    Note: Does NOT match short version ranges like "0.1" (requires X.Y.Z format)
-perl -i -pe 's/(reinhardt\s*=\s*\{[^}]*version\s*=\s*")[0-9]+\.[0-9]+\.[0-9]+[^"]*(",?\s*(?:package\s*=\s*"reinhardt-web"|default-features))/$1$ENV{NEW_VER}$2/g' "$REPO_ROOT/README.md"
+for rel in "${TARGETS[@]}"; do
+	path="$REPO_ROOT/$rel"
+	if [ ! -f "$path" ]; then
+		echo "Warning: target not found: $rel" >&2
+		continue
+	fi
+	tmp=$(mktemp)
+	set +e
+	awk -v new_ver="$NEW_VER" "$AWK_PROG" "$path" > "$tmp"
+	rc=$?
+	set -e
 
-# 4. README.md: individual crate references (reinhardt-xxx = "version")
-perl -i -pe 's/(reinhardt-[a-z][-a-z]*\s*=\s*")[0-9]+\.[0-9]+\.[0-9]+[^"]*(")/$1$ENV{NEW_VER}$2/g' "$REPO_ROOT/README.md"
+	if [ "$rc" -eq 2 ]; then
+		ORPHAN_FAIL=1
+	fi
 
-# 5. examples/CLAUDE.md: umbrella crate references
-perl -i -pe 's/(reinhardt\s*=\s*\{[^}]*version\s*=\s*")[0-9]+\.[0-9]+\.[0-9]+[^"]*(",?\s*(?:package\s*=\s*"reinhardt-web"|default-features))/$1$ENV{NEW_VER}$2/g' "$REPO_ROOT/examples/CLAUDE.md"
+	if ! diff -q "$path" "$tmp" >/dev/null 2>&1; then
+		if $DRY_RUN; then
+			diff -u "$path" "$tmp" || true
+		else
+			cp "$tmp" "$path"
+		fi
+		CHANGED_FILES+=("$rel")
+	fi
+	rm -f "$tmp"
+done
 
-# --- Show results ---
+# --- Summary ---
 
-if $DRY_RUN; then
-	echo ""
-	echo "=== Dry run: showing diff ==="
-	cd "$REPO_ROOT"
-	git diff || true
-	echo ""
-	echo "=== Dry run complete. No changes committed. ==="
-	# Revert changes in dry-run mode
-	git checkout -- . 2>/dev/null || true
+if [ "${#CHANGED_FILES[@]}" -eq 0 ]; then
+	echo "No changes required."
 else
-	echo ""
-	echo "=== Updated files ==="
-	cd "$REPO_ROOT"
-	git diff --name-only || true
+	echo "Updated files:"
+	for f in "${CHANGED_FILES[@]}"; do
+		echo "  - $f"
+	done
+fi
+
+if [ "$ORPHAN_FAIL" -ne 0 ]; then
+	echo "Error: orphan markers detected (see stderr)." >&2
+	exit 2
 fi

--- a/scripts/update-version-refs.sh
+++ b/scripts/update-version-refs.sh
@@ -87,11 +87,15 @@ BEGIN {
 	version_re     = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
 	fence_re       = "^[[:space:]]*```"
 	blank_re       = "^[[:space:]]*$"
-	state       = "SCANNING"
-	armed_count = 0
-	orphans     = 0
+	state        = "SCANNING"
+	armed_count  = 0
+	in_code_block = 0
+	orphans      = 0
 }
 {
+	# Track fenced code block state (used in ARMED to skip non-version block content)
+	if ($0 ~ fence_re) in_code_block = !in_code_block
+
 	if (state == "SCANNING") {
 		print
 		if ($0 ~ marker_re || $0 ~ marker_html_re) {
@@ -120,7 +124,10 @@ BEGIN {
 		if (armed_count <= 0) state = "SCANNING"
 		next
 	}
-	# Marker with no version on the next eligible line.
+	# Non-version, non-fence, non-blank line while ARMED.
+	# If inside a code block, pass through and keep scanning (more lines to come).
+	if (in_code_block) { print; next }
+	# Outside any code block and no version found: report orphan.
 	printf("ORPHAN_MARKER %s:%d: next line has no version: %s\n", FILENAME, NR, $0) > "/dev/stderr"
 	print
 	orphans++

--- a/scripts/update-version-refs.sh
+++ b/scripts/update-version-refs.sh
@@ -81,27 +81,43 @@ echo "Updating version references to $NEW_VER in $REPO_ROOT"
 
 AWK_PROG='
 BEGIN {
-	marker_re  = "^[[:space:]]*(#|//)[[:space:]]*reinhardt-version-sync[[:space:]]*$"
-	marker_re2 = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync[[:space:]]*-->[[:space:]]*$"
-	version_re = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
-	fence_re   = "^[[:space:]]*```"
-	blank_re   = "^[[:space:]]*$"
-	state = "SCANNING"
-	orphans = 0
+	marker_re      = "^[[:space:]]*(#|//)[[:space:]]*reinhardt-version-sync[[:space:]]*$"
+	marker_html_re = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync[[:space:]]*-->[[:space:]]*$"
+	marker_html_n  = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync:[0-9]+[[:space:]]*-->[[:space:]]*$"
+	version_re     = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
+	fence_re       = "^[[:space:]]*```"
+	blank_re       = "^[[:space:]]*$"
+	state       = "SCANNING"
+	armed_count = 0
+	orphans     = 0
 }
 {
 	if (state == "SCANNING") {
 		print
-		if ($0 ~ marker_re || $0 ~ marker_re2) state = "ARMED"
+		if ($0 ~ marker_re || $0 ~ marker_html_re) {
+			armed_count = 1
+			state = "ARMED"
+		} else if ($0 ~ marker_html_n) {
+			# Extract the integer N from <!-- reinhardt-version-sync:N -->
+			tmp = $0
+			if (match(tmp, ":[0-9]+")) {
+				armed_count = int(substr(tmp, RSTART + 1, RLENGTH - 1))
+			} else {
+				armed_count = 1
+			}
+			if (armed_count < 1) armed_count = 1
+			state = "ARMED"
+		}
 		next
 	}
-	# ARMED
+	# ARMED: pass fence and blank lines through without consuming count
 	if ($0 ~ fence_re || $0 ~ blank_re) { print; next }
 	if (match($0, version_re)) {
 		prefix = substr($0, 1, RSTART - 1)
 		suffix = substr($0, RSTART + RLENGTH)
 		print prefix new_ver suffix
-		state = "SCANNING"
+		armed_count--
+		if (armed_count <= 0) state = "SCANNING"
 		next
 	}
 	# Marker with no version on the next eligible line.

--- a/scripts/validate-version-markers.sh
+++ b/scripts/validate-version-markers.sh
@@ -30,26 +30,59 @@ fi
 
 AWK_PROG='
 BEGIN {
-	marker_re  = "^[[:space:]]*(#|//)[[:space:]]*reinhardt-version-sync[[:space:]]*$"
-	marker_re2 = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync[[:space:]]*-->[[:space:]]*$"
+	marker_re      = "^[[:space:]]*(#|//)[[:space:]]*reinhardt-version-sync[[:space:]]*$"
+	marker_html_re = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync[[:space:]]*-->[[:space:]]*$"
+	marker_html_n  = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync:[0-9]+[[:space:]]*-->[[:space:]]*$"
 	# Hints that a line carries a Reinhardt version we should have marked.
 	hint_re    = "(reinhardt[a-z-]*[[:space:]]*=|reinhardt_version[[:space:]]*=|package[[:space:]]*=[[:space:]]*\"reinhardt-web\")"
 	version_re = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
 	fence_re   = "^[[:space:]]*```"
 	blank_re   = "^[[:space:]]*$"
-	state = "SCANNING"
-	findings = 0
+	state       = "SCANNING"
+	armed_count = 0
+	findings    = 0
 	marker_line = 0
+	in_code_block = 0
+	is_md_file    = 0
+}
+FNR == 1 {
+	# Detect if file is a Markdown file by checking FILENAME suffix
+	is_md_file = (FILENAME ~ /\.md$/)
+	in_code_block = 0
 }
 {
+	# Track fenced code block state for Markdown files
+	if (is_md_file && $0 ~ fence_re) {
+		in_code_block = !in_code_block
+	}
+
 	if (state == "SCANNING") {
-		if ($0 ~ marker_re || $0 ~ marker_re2) {
+		# In Markdown, # or // markers inside a code block are migration errors
+		if (is_md_file && in_code_block && $0 ~ marker_re) {
+			printf("MARKER_IN_CODE_BLOCK %s:%d: use '\''<!-- reinhardt-version-sync[:N] -->'\'' outside the code block instead: %s\n", FILENAME, NR, $0) > "/dev/stderr"
+			findings++
+			next
+		}
+		if ($0 ~ marker_re || $0 ~ marker_html_re) {
+			armed_count = 1
 			state = "ARMED"
 			marker_line = NR
 			next
 		}
-		# Unmarked hardcoded version detection.
-		if ($0 ~ hint_re && match($0, version_re)) {
+		if ($0 ~ marker_html_n) {
+			tmp = $0
+			if (match(tmp, ":[0-9]+")) {
+				armed_count = int(substr(tmp, RSTART + 1, RLENGTH - 1))
+			} else {
+				armed_count = 1
+			}
+			if (armed_count < 1) armed_count = 1
+			state = "ARMED"
+			marker_line = NR
+			next
+		}
+		# Unmarked hardcoded version detection (skip inside md code blocks).
+		if (!(is_md_file && in_code_block) && $0 ~ hint_re && match($0, version_re)) {
 			printf("UNMARKED %s:%d: no preceding marker: %s\n", FILENAME, NR, $0) > "/dev/stderr"
 			findings++
 		}
@@ -58,7 +91,8 @@ BEGIN {
 	# ARMED
 	if ($0 ~ fence_re || $0 ~ blank_re) next
 	if (match($0, version_re)) {
-		state = "SCANNING"
+		armed_count--
+		if (armed_count <= 0) state = "SCANNING"
 		next
 	}
 	printf("ORPHAN_MARKER %s:%d: no version follows marker\n", FILENAME, marker_line) > "/dev/stderr"

--- a/scripts/validate-version-markers.sh
+++ b/scripts/validate-version-markers.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# scripts/validate-version-markers.sh
+# Lint for the reinhardt-version-sync marker convention.
+#
+# Reports:
+#   ORPHAN_MARKER   - marker found with no version on next non-blank,
+#                     non-fence line.
+#   UNMARKED        - Reinhardt-looking hardcoded version with no marker
+#                     directly above it.
+#
+# Exit 0 on clean, 1 on any finding.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DEFAULT_TARGETS=(
+	"README.md"
+	"examples/Cargo.toml"
+	"examples/CLAUDE.md"
+	"website/config.toml"
+)
+
+if [ -n "${REINHARDT_VERSION_SYNC_TARGETS:-}" ]; then
+	read -r -a TARGETS <<< "$REINHARDT_VERSION_SYNC_TARGETS"
+else
+	TARGETS=("${DEFAULT_TARGETS[@]}")
+fi
+
+AWK_PROG='
+BEGIN {
+	marker_re  = "^[[:space:]]*(#|//)[[:space:]]*reinhardt-version-sync[[:space:]]*$"
+	marker_re2 = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync[[:space:]]*-->[[:space:]]*$"
+	# Hints that a line carries a Reinhardt version we should have marked.
+	hint_re    = "(reinhardt[a-z-]*[[:space:]]*=|reinhardt_version[[:space:]]*=|package[[:space:]]*=[[:space:]]*\"reinhardt-web\")"
+	version_re = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
+	fence_re   = "^[[:space:]]*```"
+	blank_re   = "^[[:space:]]*$"
+	state = "SCANNING"
+	findings = 0
+	marker_line = 0
+}
+{
+	if (state == "SCANNING") {
+		if ($0 ~ marker_re || $0 ~ marker_re2) {
+			state = "ARMED"
+			marker_line = NR
+			next
+		}
+		# Unmarked hardcoded version detection.
+		if ($0 ~ hint_re && match($0, version_re)) {
+			printf("UNMARKED %s:%d: no preceding marker: %s\n", FILENAME, NR, $0) > "/dev/stderr"
+			findings++
+		}
+		next
+	}
+	# ARMED
+	if ($0 ~ fence_re || $0 ~ blank_re) next
+	if (match($0, version_re)) {
+		state = "SCANNING"
+		next
+	}
+	printf("ORPHAN_MARKER %s:%d: no version follows marker\n", FILENAME, marker_line) > "/dev/stderr"
+	findings++
+	state = "SCANNING"
+}
+END { if (findings > 0) exit 1 }
+'
+
+FAIL=0
+for rel in "${TARGETS[@]}"; do
+	path="$REPO_ROOT/$rel"
+	if [ ! -f "$path" ]; then
+		continue
+	fi
+	if ! awk "$AWK_PROG" "$path"; then
+		FAIL=1
+	fi
+done
+
+if [ "$FAIL" -eq 0 ]; then
+	echo "version-markers: OK (${#TARGETS[@]} file(s) scanned)"
+fi
+exit "$FAIL"

--- a/scripts/validate-version-markers.sh
+++ b/scripts/validate-version-markers.sh
@@ -88,13 +88,19 @@ FNR == 1 {
 		}
 		next
 	}
-	# ARMED
+	# ARMED: skip fences, blanks, and non-version lines that precede the version
+	# (handles both legacy in-fence markers and new outside-fence markers where
+	# the opening ```, comment-only lines, and section headers appear first)
 	if ($0 ~ fence_re || $0 ~ blank_re) next
 	if (match($0, version_re)) {
 		armed_count--
 		if (armed_count <= 0) state = "SCANNING"
 		next
 	}
+	# Non-version, non-fence, non-blank line while ARMED.
+	# If we are inside a code block, continue scanning (the version may be on a later line).
+	if (in_code_block) next
+	# Outside a code block and no version found: orphan marker.
 	printf("ORPHAN_MARKER %s:%d: no version follows marker\n", FILENAME, marker_line) > "/dev/stderr"
 	findings++
 	state = "SCANNING"

--- a/website/config.toml
+++ b/website/config.toml
@@ -26,4 +26,5 @@ crates_io   = "https://crates.io/crates/reinhardt-web"
 docs_rs     = "https://docs.rs/reinhardt-web"
 changelog   = "https://github.com/kent8192/reinhardt-web/blob/main/CHANGELOG.md"
 deepwiki    = "https://deepwiki.com/kent8192/reinhardt-web"
+# reinhardt-version-sync
 reinhardt_version = "0.1.0-rc.14"


### PR DESCRIPTION
## Summary

First PR in a 3-PR series (Issue #3924) that eliminates the post-release
update-version-refs follow-up PR and broadens version-reference coverage
across the repo.

This PR only:

- Rewrites \`scripts/update-version-refs.sh\` to use a marker-based awk
  state machine instead of broad perl regex.
- Adds \`scripts/validate-version-markers.sh\` as a lint for orphan
  markers and unmarked hardcoded Reinhardt versions.
- Adds \`scripts/tests/run-all.sh\` plus two self-contained test files
  with inline fixtures (7 cases total).
- Migrates the 4 files currently in scope (\`README.md\`,
  \`examples/Cargo.toml\`, \`examples/CLAUDE.md\`, \`website/config.toml\`)
  to carry markers.
- Wires the tests + validator into CI (\`version-markers\` job).

Subsequent PRs (not in this PR):

- PR-2: extend marker coverage to \`crates/reinhardt-*/README.md\` and
  \`docs/**/*.md\` (Agent-Team parallelized).
- PR-3: wire the append step into \`.github/workflows/release-plz.yml\`
  so version refs update inside the Release PR itself, and downgrade
  \`.github/workflows/update-version-refs.yml\` to
  \`workflow_dispatch\`-only.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring (no functional change)
- [ ] Test update
- [x] CI/build change

## Motivation and Context

Today \`update-version-refs.yml\` runs post-release and opens a
separate follow-up PR, which means documentation lags every release. As
of branch-base, root \`README.md\` references \`0.1.0-rc.17\` while
\`crates/reinhardt-admin/README.md\` still references \`0.1.0-rc.13\`.
This PR lays the script + lint foundation that later PR-2/PR-3 rely on
to close the gap.

## How Was This Tested?

- [x] New shell-script tests in \`scripts/tests/\` cover 4 update
      fixtures (TOML single / Markdown toml block / multi-version block
      / orphan marker) and 3 validator fixtures (clean / orphan /
      unmarked). All 7 PASS.
- [x] Local smoke test: bumped to \`0.9.9-smoke-test\`, diffed
      (4 files, 16 bumps), reverted to clean tree.
- [x] \`scripts/validate-version-markers.sh\` exits 0 against the
      migrated repo: \`version-markers: OK (4 file(s) scanned)\`.
- [x] New CI job \`version-markers\` runs both the unit tests and the
      validator.

## Checklist

- [x] My code follows the project style guidelines (tabs, English
      comments, Conventional Commits)
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to documentation (local design
      spec; PR-3 will add a user-facing contributor note)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or my feature
      works
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- enhancement
- documentation
- high

## Related Issues

Refs #3924 — Full resolution (closing the Issue) lands with PR-3 once
the release-plz workflow integration is complete. This PR alone does
not yet change release-time behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)