### PR TITLE
docs(admin): fix critical API inaccuracies in README

### DIFF
--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -102,31 +102,28 @@ first request, so no database connection is needed during route setup.
 
 ### Customizing the Admin
 
-Implement `ModelAdmin` for your admin structs using the trait-based approach:
+Use the `#[admin]` proc macro to register a model with the admin panel. The macro
+automatically implements `ModelAdmin` — no manual `impl` block is needed:
 
 ```rust
-use reinhardt::admin::ModelAdmin;
+use reinhardt::admin;
+use crate::models::User;
 
-struct UserAdmin {
-	list_display: Vec<String>,
-	list_filter: Vec<String>,
-	search_fields: Vec<String>,
-}
-
-impl Default for UserAdmin {
-	fn default() -> Self {
-		Self {
-			list_display: vec!["username".to_string(), "email".to_string(), "is_active".to_string()],
-			list_filter: vec!["is_active".to_string()],
-			search_fields: vec!["username".to_string(), "email".to_string()],
-		}
-	}
-}
-
-impl ModelAdmin for UserAdmin {
-	// Customize admin behavior by overriding trait methods
-}
+#[admin(model,
+	for = User,
+	name = "User",
+	list_display = [username, email, is_active],
+	list_filter = [is_active],
+	search_fields = [username, email],
+	ordering = [(date_joined, desc)],
+	list_per_page = 25,
+)]
+pub struct UserAdmin;
 ```
+
+The `#[admin(model, ...)]` attribute expands to a full `ModelAdmin` implementation
+at compile time, so you never need to write boilerplate field structs or
+`impl Default` blocks.
 
 ## Architecture
 

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -4,15 +4,10 @@ Django-style admin panel functionality for Reinhardt framework.
 
 ## Overview
 
-This crate provides two main components:
-
-- **Panel**: Web-based admin interface for managing database models
-- **CLI**: Command-line tool for project management (available as
-  `reinhardt-admin-cli`)
+This crate provides a web-based admin interface for managing database models,
+built as a WASM single-page application served by a Reinhardt server.
 
 ## Features
-
-### Admin Panel (`reinhardt-admin`)
 
 - ✅ **Model Management Interface**: Web-based CRUD operations for database
   models
@@ -24,8 +19,6 @@ This crate provides two main components:
 - ✅ **Permissions Integration**: Role-based access control for admin operations
 - ✅ **Change Logging**: Audit trail for all admin actions
 - ✅ **Inline Editing**: Edit related models inline
-- ✅ **Drag-and-Drop Reordering**: Reorder model instances with transaction-safe
-  operations
 - ✅ **Responsive Design**: Mobile-friendly admin interface with customizable
   templates
 
@@ -40,11 +33,10 @@ Add `reinhardt` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.13", features = ["admin"] }
+reinhardt = { version = "0.1.0-rc.19", features = ["admin"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.13", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.13", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.0-rc.19", features = ["full"] }  # All features
 ```
 
 Then import admin features:
@@ -54,24 +46,27 @@ use reinhardt::admin::{AdminSite, ModelAdmin};
 use reinhardt::admin::types::{ListQueryParams, AdminError};
 ```
 
-**Note:** Admin features are included in the `standard` and `full` feature presets.
-
 ## Quick Start
 
 ### Using the Admin Panel
 
 ```rust
-use reinhardt::admin::{AdminSite, ModelAdmin};
+use reinhardt_admin::core::{AdminSite, admin_routes_with_di, admin_static_routes};
+use reinhardt_urls::routers::UnifiedRouter;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
-    let mut admin = AdminSite::new("My Admin");
+	let site = Arc::new(AdminSite::new("My Admin"));
+	let (admin_router, admin_di) = admin_routes_with_di(site);
+	let assets = admin_static_routes();
 
-    // Register your models
-    admin.register::<User>(UserAdmin::default()).await;
+	let router = UnifiedRouter::new()
+		.mount("/admin/", admin_router)
+		.mount("/static/admin/", assets)
+		.with_di_registrations(admin_di);
 
-    // Start admin server
-    admin.serve("127.0.0.1:8001").await.unwrap();
+	// Attach `router` to your application server
 }
 ```
 
@@ -81,23 +76,23 @@ async fn main() {
 use reinhardt::admin::ModelAdmin;
 
 struct UserAdmin {
-    list_display: Vec<String>,
-    list_filter: Vec<String>,
-    search_fields: Vec<String>,
+	list_display: Vec<String>,
+	list_filter: Vec<String>,
+	search_fields: Vec<String>,
 }
 
 impl Default for UserAdmin {
-    fn default() -> Self {
-        Self {
-            list_display: vec!["username".to_string(), "email".to_string(), "is_active".to_string()],
-            list_filter: vec!["is_active".to_string()],
-            search_fields: vec!["username".to_string(), "email".to_string()],
-        }
-    }
+	fn default() -> Self {
+		Self {
+			list_display: vec!["username".to_string(), "email".to_string(), "is_active".to_string()],
+			list_filter: vec!["is_active".to_string()],
+			search_fields: vec!["username".to_string(), "email".to_string()],
+		}
+	}
 }
 ```
 
-## Panel Architecture
+## Architecture
 
 The admin panel is built on several key components:
 
@@ -111,130 +106,81 @@ Advanced filtering and query building with reinhardt-query integration:
 
 For detailed database layer documentation, see the [`core::database`](src/core/database.rs) module.
 
-### Handlers
+### Server Functions
 
-HTTP request handlers for all CRUD operations:
+All CRUD operations are implemented as reinhardt-pages server functions in
+individual modules under `src/server/`:
 
-- `AdminHandlers::dashboard()` - Admin dashboard
-- `AdminHandlers::list()` - Model list view with pagination
-- `AdminHandlers::detail()` - Detail view
-- `AdminHandlers::create()` - Create new instance
-- `AdminHandlers::update()` - Update instance
-- `AdminHandlers::delete()` - Delete instance
-- `AdminHandlers::bulk_delete()` - Bulk delete operations
-- `AdminHandlers::export()` - Export data (CSV, JSON, XML)
-- `AdminHandlers::import()` - Import data
+- `get_dashboard` — admin dashboard data
+- `get_list` — model list view with pagination
+- `get_detail` — detail view for a single record
+- `get_fields` — field metadata for a model
+- `create_record` — create a new record
+- `update_record` — update an existing record
+- `delete_record` — delete a single record
+- `bulk_delete_records` — bulk delete operations
+- `export_data` — export data (CSV, JSON, XML)
+- `import_data` — import data
+- `admin_login` — admin authentication
+- `admin_logout` — admin session termination
 
 ### Routing
 
-Automatic route registration for models:
+Route registration uses two free functions from `core::router`:
 
 ```rust
-use reinhardt::admin::router::AdminRouter;
+use reinhardt_admin::core::{AdminSite, admin_routes_with_di, admin_static_routes};
+use reinhardt_urls::routers::UnifiedRouter;
+use std::sync::Arc;
 
-let router = AdminRouter::new(site, db)
-    .with_favicon("static/favicon.ico")
-    .build();
+// Default: uses AdminDefaultUser (table "auth_user")
+let site = Arc::new(AdminSite::new("My Admin"));
+let (admin_router, admin_di) = admin_routes_with_di(site);
+let assets = admin_static_routes();
 
-// Automatically creates routes:
-// GET    /admin/<model>/
-// GET    /admin/<model>/{id}/
-// POST   /admin/<model>/
-// PUT    /admin/<model>/{id}/
-// DELETE /admin/<model>/{id}/
-// DELETE /admin/<model>/bulk/
-// GET    /admin/<model>/export/
-// POST   /admin/<model>/import/
-router.register_model_routes::<User>("/admin/user/")?;
+let router = UnifiedRouter::new()
+	.mount("/admin/", admin_router)
+	.mount("/static/admin/", assets)
+	.with_di_registrations(admin_di);
+
+// Routes registered under /admin/:
+// POST   /admin/api/server_fn/get_dashboard
+// POST   /admin/api/server_fn/get_list
+// POST   /admin/api/server_fn/get_detail
+// POST   /admin/api/server_fn/get_fields
+// POST   /admin/api/server_fn/create_record
+// POST   /admin/api/server_fn/update_record
+// POST   /admin/api/server_fn/delete_record
+// POST   /admin/api/server_fn/bulk_delete_records
+// POST   /admin/api/server_fn/export_data
+// POST   /admin/api/server_fn/import_data
+// POST   /admin/api/server_fn/admin_login
+// POST   /admin/api/server_fn/admin_logout
+// GET    /admin/              (SPA shell)
+// GET    /admin/{*tail}       (SPA client-side routing)
+
+// Static assets registered under /static/admin/:
+// GET    /static/admin/{*path}
+// HEAD   /static/admin/{*path}
 ```
 
-For comprehensive panel documentation, see the [`core`](src/core/) module.
-
-## Advanced Features
-
-### Drag-and-Drop Reordering
-
-Enable drag-and-drop reordering for your models with transaction-safe
-operations:
-
-```rust
-use reinhardt::admin::{DragDropConfig, ReorderableModel, ReorderHandler};
-use async_trait::async_trait;
-
-// 1. Configure drag-and-drop
-let config = DragDropConfig {
-	order_field: "display_order".to_string(),
-	enabled: true,
-	custom_js: None,  // Or provide custom JavaScript for client-side handling
-};
-
-// 2. Implement ReorderableModel for your model
-#[async_trait]
-impl ReorderableModel for MenuItem {
-	async fn get_order(&self) -> i32 {
-		self.display_order
-	}
-
-	async fn set_order(&mut self, new_order: i32) {
-		self.display_order = new_order;
-	}
-
-	fn get_id(&self) -> String {
-		self.id.to_string()
-	}
-}
-
-// 3. Create a reorder handler
-let handler = ReorderHandler::new(
-	config,
-	connection.clone(),
-	"menu_items",  // table name
-	"id",          // primary key field
-);
-
-// 4. Process reorder requests
-let reorder_items = vec![
-	("item_1".to_string(), 0),
-	("item_2".to_string(), 1),
-	("item_3".to_string(), 2),
-];
-
-match handler.process_reorder(reorder_items).await {
-	result if result.is_success() => {
-		println!("Reordered {} items successfully", result.items_updated);
-	}
-	result => {
-		eprintln!("Reorder failed: {}", result.message);
-	}
-}
-```
-
-**Key Features:**
-
-- **Validation**: Ensures order values are sequential, non-negative, and unique
-- **Transaction Safety**: All updates are executed within a database transaction
-- **Error Handling**: Detailed error messages for validation and database
-  failures
-- **Bulk Updates**: Efficient handling of multiple items in a single transaction
-
-**Implementation Details:**
-
-The `ReorderHandler` validates reorder operations by:
-
-1. Checking for negative order values
-2. Detecting duplicate order values
-3. Ensuring order values are sequential (0, 1, 2, ...)
-
-All database updates are performed using reinhardt-query within a
-transaction, ensuring atomicity.
-
-For a complete implementation example, see the [`core::database`](src/core/database.rs) module.
+For comprehensive routing documentation, see the [`core::router`](src/core/router.rs) module.
 
 ## Feature Flags
 
-- `panel` (default): Web admin panel
-- `cli`: Command-line interface
-- `all`: All admin functionality
+| Feature | Description |
+|---------|-------------|
+| `adapters` | Adapter layer utilities |
+| `core` | Core admin functionality |
+| `pages` | Page rendering support |
+| `server` | Server-side request handling |
+| `types` | Shared type definitions |
+| `all` | All of the above (`adapters`, `core`, `pages`, `server`, `types`) |
+| `file-uploads` | File upload support |
+| `admin` | Admin feature marker |
+| `full` | All features including `file-uploads` |
+
+By default, no features are enabled (`default = []`).
 
 ## Documentation
 

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -48,29 +48,61 @@ use reinhardt::admin::types::{ListQueryParams, AdminError};
 
 ## Quick Start
 
-### Using the Admin Panel
+### Configuring Admin Models
+
+Register models with `AdminSite` in a dedicated configuration function:
 
 ```rust
-use reinhardt_admin::core::{AdminSite, admin_routes_with_di, admin_static_routes};
-use reinhardt_urls::routers::UnifiedRouter;
-use std::sync::Arc;
+use reinhardt::admin::{AdminSite, ModelAdmin};
 
-#[tokio::main]
-async fn main() {
-	let site = Arc::new(AdminSite::new("My Admin"));
-	let (admin_router, admin_di) = admin_routes_with_di(site);
-	let assets = admin_static_routes();
-
-	let router = UnifiedRouter::new()
-		.mount("/admin/", admin_router)
-		.mount("/static/admin/", assets)
-		.with_di_registrations(admin_di);
-
-	// Attach `router` to your application server
+fn configure_admin() -> AdminSite {
+	let mut site = AdminSite::new("My Admin");
+	site.register::<User>(UserAdmin::default());
+	site
 }
 ```
 
+### Mounting Admin Routes
+
+Admin routes are registered inside the `routes()` function decorated with
+`#[routes(standalone)]`. Use `admin_routes_with_di()` to mount the admin
+panel with deferred DI registration:
+
+```rust
+use reinhardt::UnifiedRouter;
+use reinhardt::admin::{admin_routes_with_di, admin_static_routes};
+use reinhardt::routes;
+use std::sync::Arc;
+
+#[cfg_attr(native, routes(standalone))]
+pub fn routes() -> UnifiedRouter {
+	// Configure admin site (registration only, no DB needed yet)
+	#[cfg(native)]
+	let admin_site = Arc::new(configure_admin());
+
+	let router = UnifiedRouter::new()
+		// Mount your app routes here
+		;
+
+	// Mount admin panel routes and static assets (server-only)
+	#[cfg(native)]
+	let router = {
+		let (admin_router, admin_di) = admin_routes_with_di(admin_site);
+		router
+			.mount("/admin/", admin_router)
+			.mount("/static/admin/", admin_static_routes())
+			.with_di_registrations(admin_di)
+	};
+	router
+}
+```
+
+The `AdminDatabase` is lazily constructed from `DatabaseConnection` at the
+first request, so no database connection is needed during route setup.
+
 ### Customizing the Admin
+
+Implement `ModelAdmin` for your admin structs using the trait-based approach:
 
 ```rust
 use reinhardt::admin::ModelAdmin;
@@ -89,6 +121,10 @@ impl Default for UserAdmin {
 			search_fields: vec!["username".to_string(), "email".to_string()],
 		}
 	}
+}
+
+impl ModelAdmin for UserAdmin {
+	// Customize admin behavior by overriding trait methods
 }
 ```
 

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -65,7 +65,7 @@ fn configure_admin() -> AdminSite {
 ### Mounting Admin Routes
 
 Admin routes are registered inside the `routes()` function decorated with
-`#[routes(standalone)]`. Use `admin_routes_with_di()` to mount the admin
+`#[routes]`. Use `admin_routes_with_di()` to mount the admin
 panel with deferred DI registration:
 
 ```rust
@@ -74,7 +74,7 @@ use reinhardt::admin::{admin_routes_with_di, admin_static_routes};
 use reinhardt::routes;
 use std::sync::Arc;
 
-#[cfg_attr(native, routes(standalone))]
+#[routes]
 pub fn routes() -> UnifiedRouter {
 	// Configure admin site (registration only, no DB needed yet)
 	#[cfg(native)]


### PR DESCRIPTION
## Summary

- Replace non-existent `AdminHandlers` struct documentation with the actual server function list from `src/server/`
- Replace non-existent `AdminRouter` struct with the actual routing API (`admin_routes_with_di()` and `admin_static_routes()` free functions from `core::router`)
- Remove entirely fabricated drag-and-drop reordering section (`DragDropConfig`, `ReorderableModel`, `ReorderHandler` — none of these types exist in the codebase)
- Fix feature flags table to match actual `Cargo.toml` (remove `panel`/`cli`, document all real flags: `adapters`, `core`, `pages`, `server`, `types`, `all`, `file-uploads`, `admin`, `full`)
- Update stale version references from `0.1.0-rc.13` to `0.1.0-rc.19`

## Type of Change

- [x] Documentation update

## Motivation and Context

The `reinhardt-admin` README documented several APIs that do not exist in the codebase, which would mislead users attempting to integrate the admin panel. Specifically:

- `AdminHandlers` is not a struct; handlers are standalone server functions in individual modules
- `AdminRouter` is not a struct; routing uses free functions `admin_routes_with_di()` and `admin_static_routes()`
- The drag-and-drop reordering section (`DragDropConfig`, `ReorderableModel`, `ReorderHandler`) documents APIs with no corresponding implementation anywhere in the codebase
- The feature flags `panel` (default) and `cli` do not appear in `Cargo.toml`; the actual `default = []`

## How Was This Tested?

- Verified actual routing API by reading `crates/reinhardt-admin/src/core/router.rs`
- Verified actual server function modules by reading `crates/reinhardt-admin/src/server/` directory listing
- Verified actual feature flags by reading `crates/reinhardt-admin/Cargo.toml`
- Confirmed none of `AdminHandlers`, `AdminRouter`, `DragDropConfig`, `ReorderableModel`, `ReorderHandler` exist anywhere in the codebase

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

Fixes #3932

## Labels to Apply

### Type Label
- [x] `documentation` - Documentation update

### Priority Label
- [x] `high` - Important fix or feature

---

**Additional Context:**

Documentation-only change. No Rust source files were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)