### PR TITLE
docs(graphql): fix engine names, feature flags, and API inaccuracies in crate docs

### DIFF
--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -4,10 +4,15 @@ Django-style admin panel functionality for Reinhardt framework.
 
 ## Overview
 
-This crate provides a web-based admin interface for managing database models,
-built as a WASM single-page application served by a Reinhardt server.
+This crate provides two main components:
+
+- **Panel**: Web-based admin interface for managing database models
+- **CLI**: Command-line tool for project management (available as
+  `reinhardt-admin-cli`)
 
 ## Features
+
+### Admin Panel (`reinhardt-admin`)
 
 - ✅ **Model Management Interface**: Web-based CRUD operations for database
   models
@@ -19,6 +24,8 @@ built as a WASM single-page application served by a Reinhardt server.
 - ✅ **Permissions Integration**: Role-based access control for admin operations
 - ✅ **Change Logging**: Audit trail for all admin actions
 - ✅ **Inline Editing**: Edit related models inline
+- ✅ **Drag-and-Drop Reordering**: Reorder model instances with transaction-safe
+  operations
 - ✅ **Responsive Design**: Mobile-friendly admin interface with customizable
   templates
 
@@ -33,10 +40,11 @@ Add `reinhardt` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.19", features = ["admin"] }
+reinhardt = { version = "0.1.0-rc.13", features = ["admin"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.19", features = ["full"] }  # All features
+# reinhardt = { version = "0.1.0-rc.13", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.0-rc.13", features = ["full"] }      # All features
 ```
 
 Then import admin features:
@@ -46,27 +54,24 @@ use reinhardt::admin::{AdminSite, ModelAdmin};
 use reinhardt::admin::types::{ListQueryParams, AdminError};
 ```
 
+**Note:** Admin features are included in the `standard` and `full` feature presets.
+
 ## Quick Start
 
 ### Using the Admin Panel
 
 ```rust
-use reinhardt_admin::core::{AdminSite, admin_routes_with_di, admin_static_routes};
-use reinhardt_urls::routers::UnifiedRouter;
-use std::sync::Arc;
+use reinhardt::admin::{AdminSite, ModelAdmin};
 
 #[tokio::main]
 async fn main() {
-	let site = Arc::new(AdminSite::new("My Admin"));
-	let (admin_router, admin_di) = admin_routes_with_di(site);
-	let assets = admin_static_routes();
+    let mut admin = AdminSite::new("My Admin");
 
-	let router = UnifiedRouter::new()
-		.mount("/admin/", admin_router)
-		.mount("/static/admin/", assets)
-		.with_di_registrations(admin_di);
+    // Register your models
+    admin.register::<User>(UserAdmin::default()).await;
 
-	// Attach `router` to your application server
+    // Start admin server
+    admin.serve("127.0.0.1:8001").await.unwrap();
 }
 ```
 
@@ -76,23 +81,23 @@ async fn main() {
 use reinhardt::admin::ModelAdmin;
 
 struct UserAdmin {
-	list_display: Vec<String>,
-	list_filter: Vec<String>,
-	search_fields: Vec<String>,
+    list_display: Vec<String>,
+    list_filter: Vec<String>,
+    search_fields: Vec<String>,
 }
 
 impl Default for UserAdmin {
-	fn default() -> Self {
-		Self {
-			list_display: vec!["username".to_string(), "email".to_string(), "is_active".to_string()],
-			list_filter: vec!["is_active".to_string()],
-			search_fields: vec!["username".to_string(), "email".to_string()],
-		}
-	}
+    fn default() -> Self {
+        Self {
+            list_display: vec!["username".to_string(), "email".to_string(), "is_active".to_string()],
+            list_filter: vec!["is_active".to_string()],
+            search_fields: vec!["username".to_string(), "email".to_string()],
+        }
+    }
 }
 ```
 
-## Architecture
+## Panel Architecture
 
 The admin panel is built on several key components:
 
@@ -106,81 +111,130 @@ Advanced filtering and query building with reinhardt-query integration:
 
 For detailed database layer documentation, see the [`core::database`](src/core/database.rs) module.
 
-### Server Functions
+### Handlers
 
-All CRUD operations are implemented as reinhardt-pages server functions in
-individual modules under `src/server/`:
+HTTP request handlers for all CRUD operations:
 
-- `get_dashboard` — admin dashboard data
-- `get_list` — model list view with pagination
-- `get_detail` — detail view for a single record
-- `get_fields` — field metadata for a model
-- `create_record` — create a new record
-- `update_record` — update an existing record
-- `delete_record` — delete a single record
-- `bulk_delete_records` — bulk delete operations
-- `export_data` — export data (CSV, JSON, XML)
-- `import_data` — import data
-- `admin_login` — admin authentication
-- `admin_logout` — admin session termination
+- `AdminHandlers::dashboard()` - Admin dashboard
+- `AdminHandlers::list()` - Model list view with pagination
+- `AdminHandlers::detail()` - Detail view
+- `AdminHandlers::create()` - Create new instance
+- `AdminHandlers::update()` - Update instance
+- `AdminHandlers::delete()` - Delete instance
+- `AdminHandlers::bulk_delete()` - Bulk delete operations
+- `AdminHandlers::export()` - Export data (CSV, JSON, XML)
+- `AdminHandlers::import()` - Import data
 
 ### Routing
 
-Route registration uses two free functions from `core::router`:
+Automatic route registration for models:
 
 ```rust
-use reinhardt_admin::core::{AdminSite, admin_routes_with_di, admin_static_routes};
-use reinhardt_urls::routers::UnifiedRouter;
-use std::sync::Arc;
+use reinhardt::admin::router::AdminRouter;
 
-// Default: uses AdminDefaultUser (table "auth_user")
-let site = Arc::new(AdminSite::new("My Admin"));
-let (admin_router, admin_di) = admin_routes_with_di(site);
-let assets = admin_static_routes();
+let router = AdminRouter::new(site, db)
+    .with_favicon("static/favicon.ico")
+    .build();
 
-let router = UnifiedRouter::new()
-	.mount("/admin/", admin_router)
-	.mount("/static/admin/", assets)
-	.with_di_registrations(admin_di);
-
-// Routes registered under /admin/:
-// POST   /admin/api/server_fn/get_dashboard
-// POST   /admin/api/server_fn/get_list
-// POST   /admin/api/server_fn/get_detail
-// POST   /admin/api/server_fn/get_fields
-// POST   /admin/api/server_fn/create_record
-// POST   /admin/api/server_fn/update_record
-// POST   /admin/api/server_fn/delete_record
-// POST   /admin/api/server_fn/bulk_delete_records
-// POST   /admin/api/server_fn/export_data
-// POST   /admin/api/server_fn/import_data
-// POST   /admin/api/server_fn/admin_login
-// POST   /admin/api/server_fn/admin_logout
-// GET    /admin/              (SPA shell)
-// GET    /admin/{*tail}       (SPA client-side routing)
-
-// Static assets registered under /static/admin/:
-// GET    /static/admin/{*path}
-// HEAD   /static/admin/{*path}
+// Automatically creates routes:
+// GET    /admin/<model>/
+// GET    /admin/<model>/{id}/
+// POST   /admin/<model>/
+// PUT    /admin/<model>/{id}/
+// DELETE /admin/<model>/{id}/
+// DELETE /admin/<model>/bulk/
+// GET    /admin/<model>/export/
+// POST   /admin/<model>/import/
+router.register_model_routes::<User>("/admin/user/")?;
 ```
 
-For comprehensive routing documentation, see the [`core::router`](src/core/router.rs) module.
+For comprehensive panel documentation, see the [`core`](src/core/) module.
+
+## Advanced Features
+
+### Drag-and-Drop Reordering
+
+Enable drag-and-drop reordering for your models with transaction-safe
+operations:
+
+```rust
+use reinhardt::admin::{DragDropConfig, ReorderableModel, ReorderHandler};
+use async_trait::async_trait;
+
+// 1. Configure drag-and-drop
+let config = DragDropConfig {
+	order_field: "display_order".to_string(),
+	enabled: true,
+	custom_js: None,  // Or provide custom JavaScript for client-side handling
+};
+
+// 2. Implement ReorderableModel for your model
+#[async_trait]
+impl ReorderableModel for MenuItem {
+	async fn get_order(&self) -> i32 {
+		self.display_order
+	}
+
+	async fn set_order(&mut self, new_order: i32) {
+		self.display_order = new_order;
+	}
+
+	fn get_id(&self) -> String {
+		self.id.to_string()
+	}
+}
+
+// 3. Create a reorder handler
+let handler = ReorderHandler::new(
+	config,
+	connection.clone(),
+	"menu_items",  // table name
+	"id",          // primary key field
+);
+
+// 4. Process reorder requests
+let reorder_items = vec![
+	("item_1".to_string(), 0),
+	("item_2".to_string(), 1),
+	("item_3".to_string(), 2),
+];
+
+match handler.process_reorder(reorder_items).await {
+	result if result.is_success() => {
+		println!("Reordered {} items successfully", result.items_updated);
+	}
+	result => {
+		eprintln!("Reorder failed: {}", result.message);
+	}
+}
+```
+
+**Key Features:**
+
+- **Validation**: Ensures order values are sequential, non-negative, and unique
+- **Transaction Safety**: All updates are executed within a database transaction
+- **Error Handling**: Detailed error messages for validation and database
+  failures
+- **Bulk Updates**: Efficient handling of multiple items in a single transaction
+
+**Implementation Details:**
+
+The `ReorderHandler` validates reorder operations by:
+
+1. Checking for negative order values
+2. Detecting duplicate order values
+3. Ensuring order values are sequential (0, 1, 2, ...)
+
+All database updates are performed using reinhardt-query within a
+transaction, ensuring atomicity.
+
+For a complete implementation example, see the [`core::database`](src/core/database.rs) module.
 
 ## Feature Flags
 
-| Feature | Description |
-|---------|-------------|
-| `adapters` | Adapter layer utilities |
-| `core` | Core admin functionality |
-| `pages` | Page rendering support |
-| `server` | Server-side request handling |
-| `types` | Shared type definitions |
-| `all` | All of the above (`adapters`, `core`, `pages`, `server`, `types`) |
-| `file-uploads` | File upload support |
-| `admin` | Admin feature marker |
-| `full` | All features including `file-uploads` |
-
-By default, no features are enabled (`default = []`).
+- `panel` (default): Web admin panel
+- `cli`: Command-line interface
+- `all`: All admin functionality
 
 ## Documentation
 

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -4,15 +4,10 @@ Django-style admin panel functionality for Reinhardt framework.
 
 ## Overview
 
-This crate provides two main components:
-
-- **Panel**: Web-based admin interface for managing database models
-- **CLI**: Command-line tool for project management (available as
-  `reinhardt-admin-cli`)
+This crate provides a web-based admin interface for managing database models,
+built as a WASM single-page application served by a Reinhardt server.
 
 ## Features
-
-### Admin Panel (`reinhardt-admin`)
 
 - ✅ **Model Management Interface**: Web-based CRUD operations for database
   models
@@ -24,8 +19,6 @@ This crate provides two main components:
 - ✅ **Permissions Integration**: Role-based access control for admin operations
 - ✅ **Change Logging**: Audit trail for all admin actions
 - ✅ **Inline Editing**: Edit related models inline
-- ✅ **Drag-and-Drop Reordering**: Reorder model instances with transaction-safe
-  operations
 - ✅ **Responsive Design**: Mobile-friendly admin interface with customizable
   templates
 
@@ -40,11 +33,10 @@ Add `reinhardt` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.13", features = ["admin"] }
+reinhardt = { version = "0.1.0-rc.19", features = ["admin"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.13", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.13", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.0-rc.19", features = ["full"] }  # All features
 ```
 
 Then import admin features:
@@ -54,24 +46,27 @@ use reinhardt::admin::{AdminSite, ModelAdmin};
 use reinhardt::admin::types::{ListQueryParams, AdminError};
 ```
 
-**Note:** Admin features are included in the `standard` and `full` feature presets.
-
 ## Quick Start
 
 ### Using the Admin Panel
 
 ```rust
-use reinhardt::admin::{AdminSite, ModelAdmin};
+use reinhardt_admin::core::{AdminSite, admin_routes_with_di, admin_static_routes};
+use reinhardt_urls::routers::UnifiedRouter;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
-    let mut admin = AdminSite::new("My Admin");
+	let site = Arc::new(AdminSite::new("My Admin"));
+	let (admin_router, admin_di) = admin_routes_with_di(site);
+	let assets = admin_static_routes();
 
-    // Register your models
-    admin.register::<User>(UserAdmin::default()).await;
+	let router = UnifiedRouter::new()
+		.mount("/admin/", admin_router)
+		.mount("/static/admin/", assets)
+		.with_di_registrations(admin_di);
 
-    // Start admin server
-    admin.serve("127.0.0.1:8001").await.unwrap();
+	// Attach `router` to your application server
 }
 ```
 
@@ -81,23 +76,23 @@ async fn main() {
 use reinhardt::admin::ModelAdmin;
 
 struct UserAdmin {
-    list_display: Vec<String>,
-    list_filter: Vec<String>,
-    search_fields: Vec<String>,
+	list_display: Vec<String>,
+	list_filter: Vec<String>,
+	search_fields: Vec<String>,
 }
 
 impl Default for UserAdmin {
-    fn default() -> Self {
-        Self {
-            list_display: vec!["username".to_string(), "email".to_string(), "is_active".to_string()],
-            list_filter: vec!["is_active".to_string()],
-            search_fields: vec!["username".to_string(), "email".to_string()],
-        }
-    }
+	fn default() -> Self {
+		Self {
+			list_display: vec!["username".to_string(), "email".to_string(), "is_active".to_string()],
+			list_filter: vec!["is_active".to_string()],
+			search_fields: vec!["username".to_string(), "email".to_string()],
+		}
+	}
 }
 ```
 
-## Panel Architecture
+## Architecture
 
 The admin panel is built on several key components:
 
@@ -111,130 +106,81 @@ Advanced filtering and query building with reinhardt-query integration:
 
 For detailed database layer documentation, see the [`core::database`](src/core/database.rs) module.
 
-### Handlers
+### Server Functions
 
-HTTP request handlers for all CRUD operations:
+All CRUD operations are implemented as reinhardt-pages server functions in
+individual modules under `src/server/`:
 
-- `AdminHandlers::dashboard()` - Admin dashboard
-- `AdminHandlers::list()` - Model list view with pagination
-- `AdminHandlers::detail()` - Detail view
-- `AdminHandlers::create()` - Create new instance
-- `AdminHandlers::update()` - Update instance
-- `AdminHandlers::delete()` - Delete instance
-- `AdminHandlers::bulk_delete()` - Bulk delete operations
-- `AdminHandlers::export()` - Export data (CSV, JSON, XML)
-- `AdminHandlers::import()` - Import data
+- `get_dashboard` — admin dashboard data
+- `get_list` — model list view with pagination
+- `get_detail` — detail view for a single record
+- `get_fields` — field metadata for a model
+- `create_record` — create a new record
+- `update_record` — update an existing record
+- `delete_record` — delete a single record
+- `bulk_delete_records` — bulk delete operations
+- `export_data` — export data (CSV, JSON, XML)
+- `import_data` — import data
+- `admin_login` — admin authentication
+- `admin_logout` — admin session termination
 
 ### Routing
 
-Automatic route registration for models:
+Route registration uses two free functions from `core::router`:
 
 ```rust
-use reinhardt::admin::router::AdminRouter;
+use reinhardt_admin::core::{AdminSite, admin_routes_with_di, admin_static_routes};
+use reinhardt_urls::routers::UnifiedRouter;
+use std::sync::Arc;
 
-let router = AdminRouter::new(site, db)
-    .with_favicon("static/favicon.ico")
-    .build();
+// Default: uses AdminDefaultUser (table "auth_user")
+let site = Arc::new(AdminSite::new("My Admin"));
+let (admin_router, admin_di) = admin_routes_with_di(site);
+let assets = admin_static_routes();
 
-// Automatically creates routes:
-// GET    /admin/<model>/
-// GET    /admin/<model>/{id}/
-// POST   /admin/<model>/
-// PUT    /admin/<model>/{id}/
-// DELETE /admin/<model>/{id}/
-// DELETE /admin/<model>/bulk/
-// GET    /admin/<model>/export/
-// POST   /admin/<model>/import/
-router.register_model_routes::<User>("/admin/user/")?;
+let router = UnifiedRouter::new()
+	.mount("/admin/", admin_router)
+	.mount("/static/admin/", assets)
+	.with_di_registrations(admin_di);
+
+// Routes registered under /admin/:
+// POST   /admin/api/server_fn/get_dashboard
+// POST   /admin/api/server_fn/get_list
+// POST   /admin/api/server_fn/get_detail
+// POST   /admin/api/server_fn/get_fields
+// POST   /admin/api/server_fn/create_record
+// POST   /admin/api/server_fn/update_record
+// POST   /admin/api/server_fn/delete_record
+// POST   /admin/api/server_fn/bulk_delete_records
+// POST   /admin/api/server_fn/export_data
+// POST   /admin/api/server_fn/import_data
+// POST   /admin/api/server_fn/admin_login
+// POST   /admin/api/server_fn/admin_logout
+// GET    /admin/              (SPA shell)
+// GET    /admin/{*tail}       (SPA client-side routing)
+
+// Static assets registered under /static/admin/:
+// GET    /static/admin/{*path}
+// HEAD   /static/admin/{*path}
 ```
 
-For comprehensive panel documentation, see the [`core`](src/core/) module.
-
-## Advanced Features
-
-### Drag-and-Drop Reordering
-
-Enable drag-and-drop reordering for your models with transaction-safe
-operations:
-
-```rust
-use reinhardt::admin::{DragDropConfig, ReorderableModel, ReorderHandler};
-use async_trait::async_trait;
-
-// 1. Configure drag-and-drop
-let config = DragDropConfig {
-	order_field: "display_order".to_string(),
-	enabled: true,
-	custom_js: None,  // Or provide custom JavaScript for client-side handling
-};
-
-// 2. Implement ReorderableModel for your model
-#[async_trait]
-impl ReorderableModel for MenuItem {
-	async fn get_order(&self) -> i32 {
-		self.display_order
-	}
-
-	async fn set_order(&mut self, new_order: i32) {
-		self.display_order = new_order;
-	}
-
-	fn get_id(&self) -> String {
-		self.id.to_string()
-	}
-}
-
-// 3. Create a reorder handler
-let handler = ReorderHandler::new(
-	config,
-	connection.clone(),
-	"menu_items",  // table name
-	"id",          // primary key field
-);
-
-// 4. Process reorder requests
-let reorder_items = vec![
-	("item_1".to_string(), 0),
-	("item_2".to_string(), 1),
-	("item_3".to_string(), 2),
-];
-
-match handler.process_reorder(reorder_items).await {
-	result if result.is_success() => {
-		println!("Reordered {} items successfully", result.items_updated);
-	}
-	result => {
-		eprintln!("Reorder failed: {}", result.message);
-	}
-}
-```
-
-**Key Features:**
-
-- **Validation**: Ensures order values are sequential, non-negative, and unique
-- **Transaction Safety**: All updates are executed within a database transaction
-- **Error Handling**: Detailed error messages for validation and database
-  failures
-- **Bulk Updates**: Efficient handling of multiple items in a single transaction
-
-**Implementation Details:**
-
-The `ReorderHandler` validates reorder operations by:
-
-1. Checking for negative order values
-2. Detecting duplicate order values
-3. Ensuring order values are sequential (0, 1, 2, ...)
-
-All database updates are performed using reinhardt-query within a
-transaction, ensuring atomicity.
-
-For a complete implementation example, see the [`core::database`](src/core/database.rs) module.
+For comprehensive routing documentation, see the [`core::router`](src/core/router.rs) module.
 
 ## Feature Flags
 
-- `panel` (default): Web admin panel
-- `cli`: Command-line interface
-- `all`: All admin functionality
+| Feature | Description |
+|---------|-------------|
+| `adapters` | Adapter layer utilities |
+| `core` | Core admin functionality |
+| `pages` | Page rendering support |
+| `server` | Server-side request handling |
+| `types` | Shared type definitions |
+| `all` | All of the above (`adapters`, `core`, `pages`, `server`, `types`) |
+| `file-uploads` | File upload support |
+| `admin` | Admin feature marker |
+| `full` | All features including `file-uploads` |
+
+By default, no features are enabled (`default = []`).
 
 ## Documentation
 

--- a/crates/reinhardt-dentdelion/README.md
+++ b/crates/reinhardt-dentdelion/README.md
@@ -21,11 +21,11 @@ Add `reinhardt` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.13", features = ["dentdelion"] }
+reinhardt = { version = "0.1.0-rc.19", features = ["dentdelion"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.13", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.13", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.0-rc.19", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.0-rc.19", features = ["full"] }      # All features
 ```
 
 Then import dentdelion features:
@@ -41,9 +41,10 @@ use reinhardt::dentdelion::prelude::*;
 | Feature | Description |
 |---------|-------------|
 | `default` | Core plugin system only |
-| `wasm` | WebAssembly plugin support (requires wasmtime) |
+| `wasm` | WebAssembly plugin support (requires wasmtime 36.x) |
+| `ts` | TypeScript/JavaScript SSR support via boa_engine (pure-Rust ECMAScript engine); also enables `wasm` |
 | `cli` | CLI support for crates.io integration |
-| `full` | All features enabled |
+| `full` | wasm + cli (note: `ts` is NOT included in `full`) |
 
 ## Quick Start
 

--- a/crates/reinhardt-dentdelion/src/lib.rs
+++ b/crates/reinhardt-dentdelion/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! - **Static Plugins**: Rust crates compiled with your application
 //! - **WASM Plugins**: Dynamic plugins loaded at runtime (with `wasm` feature)
-//! - **TypeScript Plugins**: TypeScript/JavaScript plugins via deno_core (with `ts` feature)
+//! - **TypeScript Plugins**: TypeScript/JavaScript plugins via boa_engine (pure-Rust ECMAScript engine) (with `ts` feature)
 //! - **Capability System**: Fine-grained control over what plugins can do
 //! - **CLI Management**: Install and manage plugins via `reinhardt plugin` commands
 //! - **Multi-Runtime**: Unified interface for Static, WASM, and TypeScript runtimes
@@ -109,10 +109,10 @@
 //! # Feature Flags
 //!
 //! - `default` - Core plugin system only
-//! - `wasm` - WASM plugin support with Component Model (requires wasmtime 39.x)
-//! - `ts` - TypeScript plugin support via deno_core (V8 engine)
+//! - `wasm` - WASM plugin support with Component Model (requires wasmtime 36.x)
+//! - `ts` - TypeScript/JavaScript SSR support via boa_engine (pure-Rust ECMAScript engine)
 //! - `cli` - CLI support for crates.io integration
-//! - `full` - All features enabled (wasm + ts + cli)
+//! - `full` - All features enabled (wasm + cli); note: `ts` is NOT included in `full`
 //!
 //! # WASM Plugin Support
 //!

--- a/crates/reinhardt-graphql/README.md
+++ b/crates/reinhardt-graphql/README.md
@@ -14,9 +14,7 @@ This is a facade crate that re-exports functionality from the following modules:
 
 ```
 reinhardt-graphql/              (facade crate - public API)
-├── crates/
-│   ├── core/                   (core GraphQL implementation)
-│   └── macros/                 (procedural macros)
+└── macros/                     (procedural macros)
 ```
 
 Users should depend on `` `reinhardt-graphql` `` (this facade crate) for all GraphQL functionality.
@@ -108,11 +106,11 @@ Add `reinhardt` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.13", features = ["graphql"] }
+reinhardt = { version = "0.1.0-rc.19", features = ["graphql"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.13", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.13", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.0-rc.19", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.0-rc.19", features = ["full"] }      # All features
 ```
 
 Then import GraphQL features:
@@ -128,10 +126,10 @@ use reinhardt::graphql::types::{UserStorage, UserEvent};
 
 ```toml
 # With dependency injection
-reinhardt = { version = "0.1.0-rc.13", features = ["graphql", "di"] }
+reinhardt = { version = "0.1.0-rc.19", features = ["graphql", "di"] }
 
 # With gRPC transport
-reinhardt = { version = "0.1.0-rc.13", features = ["graphql", "grpc"] }
+reinhardt = { version = "0.1.0-rc.19", features = ["graphql", "grpc"] }
 ```
 
 ## Examples

--- a/crates/reinhardt-graphql/macros/README.md
+++ b/crates/reinhardt-graphql/macros/README.md
@@ -13,11 +13,11 @@ Derive macros for GraphQL-gRPC integration in Reinhardt framework
 ```toml
 # ✅ Correct - use the reinhardt parent crate
 [dependencies]
-reinhardt = { version = "0.1.0-rc.13", features = ["graphql"] }
+reinhardt = { version = "0.1.0-rc.19", features = ["graphql"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.13", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.13", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.0-rc.19", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.0-rc.19", features = ["full"] }      # All features
 
 # ❌ Incorrect - don't depend on this crate directly
 [dependencies]
@@ -40,7 +40,6 @@ use reinhardt::graphql::macros::{GrpcGraphQLConvert, GrpcSubscription};
 
 - **GrpcGraphQLConvert** - Automatic type conversion between Protobuf and GraphQL types
   - Derives `From<proto::T> for T` and `From<T> for proto::T`
-  - Field renaming with `#[graphql(rename_all = "camelCase")]`
   - Conditional field inclusion with `#[graphql(skip_if = "...")]`
   - Custom protobuf type mapping with `#[proto(...)]` attributes
 
@@ -58,7 +57,6 @@ use reinhardt::graphql::macros::{GrpcGraphQLConvert, GrpcSubscription};
 use reinhardt::graphql::GrpcGraphQLConvert;
 
 #[derive(GrpcGraphQLConvert)]
-#[graphql(rename_all = "camelCase")]
 struct User {
     id: String,
     name: String,
@@ -94,7 +92,6 @@ This automatically generates a GraphQL subscription implementation that:
 
 ### GrpcGraphQLConvert Attributes
 
-- `#[graphql(rename_all = "...")]` - Rename all fields (camelCase, snake_case, PascalCase)
 - `#[graphql(skip_if = "...")]` - Skip field if predicate is true
 - `#[proto(type = "...")]` - Specify custom protobuf type
 - `#[proto(rename = "...")]` - Rename field in protobuf

--- a/crates/reinhardt-grpc/README.md
+++ b/crates/reinhardt-grpc/README.md
@@ -14,18 +14,18 @@ Add `reinhardt` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.13", features = ["grpc"] }
+reinhardt = { version = "0.1.0-rc.19", features = ["grpc"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.13", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.13", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.0-rc.19", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.0-rc.19", features = ["full"] }      # All features
 ```
 
 Then import gRPC features:
 
 ```rust
-use reinhardt::grpc::{Empty, Timestamp, Error, PageInfo};
-use reinhardt::grpc::adapter::{GrpcServiceAdapter, ServiceContext};
+use reinhardt::grpc::{GrpcServiceAdapter, GrpcSubscriptionAdapter};
+use reinhardt::grpc::proto::common::{Empty, Timestamp, PageInfo};
 ```
 
 **Note:** gRPC features are included in the `standard` and `full` feature presets.
@@ -158,7 +158,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ```toml
 [dependencies]
-reinhardt-grpc = "0.1.0-rc.13"
+reinhardt-grpc = "0.1.0-rc.19"
 tonic = "0.12"
 prost = "0.13"
 
@@ -191,7 +191,7 @@ Enable the `di` feature to use dependency injection in gRPC handlers:
 ```toml
 [dependencies]
 reinhardt-grpc = { version = "0.1.0-rc.13", features = ["di"] }
-reinhardt-di = "0.1.0-rc.13"
+reinhardt-di = "0.1.0-rc.19"
 ```
 
 #### Basic Usage

--- a/crates/reinhardt-tasks/README.md
+++ b/crates/reinhardt-tasks/README.md
@@ -14,11 +14,11 @@ Add `reinhardt` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.13", features = ["tasks"] }
+reinhardt = { version = "0.1.0-rc.19", features = ["tasks"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.13", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.13", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.0-rc.19", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.0-rc.19", features = ["full"] }      # All features
 ```
 
 Then import task features:
@@ -155,7 +155,7 @@ use reinhardt::tasks::backend::{TaskBackend, RedisTaskBackend};
   - Execution failure (`ExecutionFailed`)
   - Task not found (`TaskNotFound`)
   - Queue error (`QueueError`)
-  - Serialization failure (`SerializationFailed`)
+  - Serialization failure (`SerializationError`)
   - Timeout (`Timeout`)
   - Max retries exceeded (`MaxRetriesExceeded`)
 - **TaskExecutionError**: Backend execution errors

--- a/crates/reinhardt-websockets/README.md
+++ b/crates/reinhardt-websockets/README.md
@@ -12,18 +12,18 @@ Add `reinhardt` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.13", features = ["websockets"] }
+reinhardt = { version = "0.1.0-rc.19", features = ["websockets"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.13", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.13", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.0-rc.19", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.0-rc.19", features = ["full"] }      # All features
 ```
 
 Then import WebSocket features:
 
 ```rust
 use reinhardt::websockets::{WebSocketConnection, WebSocketHandler, Message};
-use reinhardt::websockets::{RoomManager, WebSocketMessage};
+use reinhardt_websockets::message::WebSocketMessage;
 ```
 
 **Note:** WebSocket features are included in the `standard` and `full` feature presets.


### PR DESCRIPTION
## Summary

- Fix critical documentation inaccuracies across GraphQL, gRPC, WebSocket, dentdelion, and tasks crates
- Replace incorrect `deno_core` references with `boa_engine` (the actual pure-Rust ECMAScript engine used)
- Fix wrong wasmtime version requirement (39.x → 36.x)
- Remove non-existent `ServiceContext` and wrong proto type import paths in grpc README
- Fix `WebSocketMessage` import path (not re-exported at crate root)
- Remove undocumented `rename_all` attribute from `GrpcGraphQLConvert` macro docs
- Fix crate structure diagram (remove non-existent `crates/core/` subdirectory)
- Rename `TaskError::SerializationFailed` to `SerializationError` to match actual source
- Update stale version references from `0.1.0-rc.13` to `0.1.0-rc.19`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Documentation inaccuracies in multiple crates create confusion and can cause integration failures when users follow incorrect import paths or assume wrong engine/version requirements.

Key issues resolved:
- `deno_core` (a V8-based JS engine) was documented but `boa_engine` (pure Rust) is the actual dependency
- `wasmtime 39.x` was documented but `36.0.6` is the pinned version
- `ServiceContext` type does not exist in `reinhardt-grpc` adapter module
- `WebSocketMessage` is in `reinhardt_websockets::message::WebSocketMessage`, not the crate root
- `rename_all` attribute was documented for `GrpcGraphQLConvert` but not implemented in `macros/src/convert.rs`
- `TaskError::SerializationFailed` variant was documented but the actual variant is `SerializationError`

Fixes #3934

Related to: #3926

## How Was This Tested?

- Verified each fix against actual source code (`Cargo.toml`, `src/lib.rs`, `src/adapter.rs`, `macros/src/convert.rs`)
- Confirmed `boa_engine` dependency via `crates/reinhardt-dentdelion/Cargo.toml:56`
- Confirmed `wasmtime = { version = "36.0.6" }` via `crates/reinhardt-dentdelion/Cargo.toml:63`
- Confirmed `full = ["wasm", "cli"]` (no `ts`) via `crates/reinhardt-dentdelion/Cargo.toml:13`
- Confirmed no `ServiceContext` in `crates/reinhardt-grpc/src/adapter.rs` or `src/lib.rs`
- Confirmed `WebSocketMessage` not in `pub use` statements of websockets `src/lib.rs`
- Confirmed `rename_all` not processed in `crates/reinhardt-graphql/macros/src/convert.rs`
- Confirmed `SerializationError(String)` at `crates/reinhardt-tasks/src/lib.rs:199`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

Fixes #3934
Refs #3926

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)