### PR TITLE
docs(db): fix ConnectionPool API and import path inaccuracies in README

### DIFF
--- a/crates/reinhardt-db-macros/Cargo.toml
+++ b/crates/reinhardt-db-macros/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "Procedural macros for Reinhardt database layer (ORM and NoSQL ODM)"
+description = "Procedural macros for Reinhardt database layer (NoSQL ODM)"
 
 [lib]
 proc-macro = true

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -154,7 +154,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-reinhardt-db = "0.1.0-rc.13"
+reinhardt-db = "0.1.0-rc.19"
 ```
 
 ### Optional Features
@@ -163,7 +163,7 @@ Enable specific features based on your needs:
 
 ```toml
 [dependencies]
-reinhardt-db = { version = "0.1.0-rc.13", features = ["postgres", "orm", "migrations"] }
+reinhardt-db = { version = "0.1.0-rc.19", features = ["postgres", "orm", "migrations"] }
 ```
 
 Available features:
@@ -187,7 +187,7 @@ Available features:
 ### Define Models
 
 ```rust
-use reinhardt::prelude::*;
+use reinhardt_db::prelude::*;
 use serde::{Serialize, Deserialize};
 use chrono::{DateTime, Utc};
 
@@ -229,7 +229,7 @@ pub struct User {
 - `#[field(default = value)]` - Default value
 - `#[field(foreign_key = "ModelType")]` - Foreign key relationship
 
-For a complete list of field attributes, see the [Field Attributes Guide](../../docs/field_attributes.md).
+For a complete list of field attributes, see the `#[field(...)]` macro documentation in `reinhardt-db-macros`.
 
 **Note**: The `#[model(...)]` attribute macro automatically generates:
 - `Model` trait implementation
@@ -240,7 +240,7 @@ For a complete list of field attributes, see the [Field Attributes Guide](../../
 ### Query with QuerySet
 
 ```rust
-use reinhardt::db::{QuerySet, Model};
+use reinhardt_db::orm::{QuerySet, Model};
 
 // Get all users
 let users = User::objects().all().await?;
@@ -262,7 +262,7 @@ let user = User::objects()
 ### Create Migrations
 
 ```rust
-use reinhardt::db::migrations::{Migration, CreateModel, AddField};
+use reinhardt_db::migrations::{Migration, CreateModel, AddField};
 
 // Create a new migration
 let migration = Migration::new("0001_initial")
@@ -282,16 +282,17 @@ migration.apply(db).await?;
 ### Connection Pooling
 
 ```rust
-use reinhardt_db::pool::ConnectionPool;
+use reinhardt_db::pool::{ConnectionPool, PoolConfig};
 
 // Create a connection pool
-let pool = ConnectionPool::new("postgres://user:pass@localhost/db")
-    .max_connections(10)
-    .build()
-    .await?;
+let config = PoolConfig {
+    max_connections: 10,
+    ..PoolConfig::default()
+};
+let pool = ConnectionPool::new_postgres("postgres://user:pass@localhost/db", config).await?;
 
-// Get a connection
-let conn = pool.get().await?;
+// Acquire a connection
+let conn = pool.acquire().await?;
 ```
 
 ## Module Organization
@@ -316,9 +317,9 @@ let conn = pool.get().await?;
 ### Using Modules
 
 ```rust
-use reinhardt::db::orm::{Model, QuerySet};
-use reinhardt::db::migrations::Migration;
-use reinhardt::db::pool::ConnectionPool;
+use reinhardt_db::orm::{Model, QuerySet};
+use reinhardt_db::migrations::Migration;
+use reinhardt_db::pool::ConnectionPool;
 ```
 
 ## Supported Databases
@@ -370,7 +371,7 @@ Database tests automatically use TestContainers to:
 **Standard Fixtures** from `reinhardt-test` are available:
 
 ```rust
-use reinhardt::test::fixtures::postgres_container;
+use reinhardt_test::fixtures::postgres_container;
 use rstest::*;
 
 #[rstest]


### PR DESCRIPTION
## Summary

- Fix `ConnectionPool` API examples to use the actual `new_postgres(url, config)` constructor instead of the non-existent `new()` builder chain
- Replace `.get()` with the correct `.acquire()` method
- Fix all import paths from `use reinhardt::db::...` to `use reinhardt_db::...` (no `reinhardt` facade crate exists)
- Remove broken link to `../../docs/field_attributes.md` (file does not exist in the repository)
- Update stale version references from `0.1.0-rc.13` to `0.1.0-rc.19`
- Correct `reinhardt-db-macros` crate description: it exports only `#[document]` (NoSQL ODM), not ORM macros

## Type of Change

- [x] Documentation update

## Motivation and Context

The `reinhardt-db` README contained several critical inaccuracies that would prevent users from successfully using the crate based on the documentation alone:

1. `ConnectionPool::new()` with a builder chain does not exist — the actual API is `ConnectionPool::new_postgres(url, config)` where `config` is a `PoolConfig` struct
2. `.get()` does not exist on `ConnectionPool` — the correct method is `.acquire()`
3. All examples used `use reinhardt::db::...` import paths, but there is no `reinhardt` re-export facade crate; imports must use `reinhardt_db::` directly
4. A link to `../../docs/field_attributes.md` pointed to a file that does not exist in the repository
5. Version references were stale (`0.1.0-rc.13` vs current `0.1.0-rc.19`)
6. `reinhardt-db-macros` Cargo.toml description claimed "ORM and NoSQL ODM" support, but the crate only exports `#[document]` for NoSQL ODM; the `#[model]` ORM macro lives in a different crate

## Related Issues

Fixes #3929
Refs #3926

## How Was This Tested?

- Documentation-only changes; verified against `crates/reinhardt-db/src/pool/pool.rs` for the actual `ConnectionPool` API signatures
- Confirmed `ConnectionPool::new_postgres()` at line 66, `.acquire()` at line 205
- Confirmed no `reinhardt` facade crate exists in the workspace
- Confirmed `reinhardt-db-macros` exports only `#[document]` proc-macro

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label
- [x] `documentation` - Documentation update

### Priority Label
- [x] `high` - Important fix or feature

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)