### PR TITLE
feat(scripts): extend version-sync marker coverage to crates/*/README.md and docs/**/*.md (PR-2/3)

### DIFF
--- a/crates/reinhardt-admin-cli/README.md
+++ b/crates/reinhardt-admin-cli/README.md
@@ -66,6 +66,7 @@ reinhardt-admin --version
 
 Manage Reinhardt plugins (Dentdelion):
 
+<!-- reinhardt-version-sync -->
 ```bash
 # List installed plugins
 reinhardt-admin plugin list

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -31,6 +31,7 @@ For project management commands (`startproject`, `startapp`), please use
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:2 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["admin"] }

--- a/crates/reinhardt-apps/README.md
+++ b/crates/reinhardt-apps/README.md
@@ -16,6 +16,7 @@ Application configuration and registry for Reinhardt framework.
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.13", package = "reinhardt-web", features = ["apps"] }
@@ -48,6 +49,7 @@ installed_apps! {
 
 **For built-in framework features, use Cargo feature flags:**
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 reinhardt = {
@@ -142,6 +144,7 @@ pub fn get_installed_apps() -> Vec<String> {
 
 **Framework features are enabled separately via Cargo.toml:**
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 reinhardt = {
@@ -232,6 +235,7 @@ pub fn get_installed_apps() -> Vec<String> {
 }
 ```
 
+<!-- reinhardt-version-sync -->
 ```toml
 # Cargo.toml
 [dependencies]
@@ -292,6 +296,7 @@ INSTALLED_APPS = [
 ```
 
 **Reinhardt (Rust):**
+<!-- reinhardt-version-sync -->
 ```toml
 # Cargo.toml
 [dependencies]

--- a/crates/reinhardt-auth/README.md
+++ b/crates/reinhardt-auth/README.md
@@ -12,6 +12,7 @@ password hashing with Argon2.
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["auth"] }

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -12,6 +12,7 @@ migrations, static file collection, development server, and more.
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["commands"] }
@@ -118,6 +119,7 @@ When rendering templates, the following variables are available:
 
 You can pass custom variables to templates programmatically:
 
+<!-- reinhardt-version-sync -->
 ```rust
 use reinhardt::commands::TemplateContext;
 
@@ -225,6 +227,7 @@ for compile-time distributed slice registration.
 
 Projects using `collect_migrations!` must add `linkme` as a dependency:
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["standard"] }

--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -26,6 +26,7 @@ This crate provides the following modules:
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["conf"] }
@@ -48,6 +49,7 @@ use reinhardt::conf::settings::sources::ConfigSource;
 
 Enable specific features based on your needs:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 # With async support
 reinhardt = { version = "0.1.0-rc.19", features = ["conf", "async"] }

--- a/crates/reinhardt-core/README.md
+++ b/crates/reinhardt-core/README.md
@@ -87,6 +87,7 @@ This crate provides the following modules:
 
 Add this to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 reinhardt-core = "0.1.0-rc.19"
@@ -96,6 +97,7 @@ reinhardt-core = "0.1.0-rc.19"
 
 Enable specific modules based on your needs:
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 reinhardt-core = { version = "0.1.0-rc.19", features = ["signals", "macros", "security"] }

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -152,6 +152,7 @@ Advanced features for specific use cases:
 
 Add this to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 reinhardt-db = "0.1.0-rc.19"
@@ -161,6 +162,7 @@ reinhardt-db = "0.1.0-rc.19"
 
 Enable specific features based on your needs:
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 reinhardt-db = { version = "0.1.0-rc.19", features = ["postgres", "orm", "migrations"] }

--- a/crates/reinhardt-dentdelion/README.md
+++ b/crates/reinhardt-dentdelion/README.md
@@ -19,6 +19,7 @@ Plugin system for the Reinhardt framework - easy to create, distribute, and inst
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["dentdelion"] }
@@ -50,6 +51,7 @@ use reinhardt::dentdelion::prelude::*;
 
 ### Creating a Static Plugin
 
+<!-- reinhardt-version-sync -->
 ```rust
 use reinhardt::dentdelion::prelude::*;
 
@@ -221,6 +223,7 @@ timeout_seconds = 30
 
 Dentdelion uses the WebAssembly Interface Types (WIT) standard for plugin interfaces. The complete interface is defined in `wit/dentdelion.wit`:
 
+<!-- reinhardt-version-sync -->
 ```wit
 package reinhardt:dentdelion@0.1.0;
 

--- a/crates/reinhardt-di/README.md
+++ b/crates/reinhardt-di/README.md
@@ -12,6 +12,7 @@ Delivers the FastAPI development experience in Rust with type-safe and async-fir
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.13", features = ["di"] }

--- a/crates/reinhardt-dispatch/README.md
+++ b/crates/reinhardt-dispatch/README.md
@@ -10,6 +10,7 @@ HTTP request dispatching and handler system for the Reinhardt framework.
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["dispatch"] }

--- a/crates/reinhardt-forms/README.md
+++ b/crates/reinhardt-forms/README.md
@@ -12,6 +12,7 @@ This crate is designed to be **WASM-compatible**, providing a pure form processi
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.13", features = ["forms"] }

--- a/crates/reinhardt-graphql/README.md
+++ b/crates/reinhardt-graphql/README.md
@@ -104,6 +104,7 @@ Users should depend on `` `reinhardt-graphql` `` (this facade crate) for all Gra
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["graphql"] }
@@ -124,6 +125,7 @@ use reinhardt::graphql::types::{UserStorage, UserEvent};
 
 ### Optional Features
 
+<!-- reinhardt-version-sync:2 -->
 ```toml
 # With dependency injection
 reinhardt = { version = "0.1.0-rc.19", features = ["graphql", "di"] }
@@ -248,6 +250,7 @@ async fn handler(
 
 ### GraphQL over gRPC Server
 
+<!-- reinhardt-version-sync -->
 ```rust
 use async_graphql::{EmptySubscription, Schema};
 use reinhardt::graphql::grpc_service::GraphQLGrpcService;
@@ -276,6 +279,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### GraphQL over gRPC Client
 
+<!-- reinhardt-version-sync -->
 ```rust
 use reinhardt::grpc::proto::graphql::{
     graph_ql_service_client::GraphQlServiceClient,

--- a/crates/reinhardt-grpc/README.md
+++ b/crates/reinhardt-grpc/README.md
@@ -12,6 +12,7 @@ with domain-specific implementations left to users.
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["grpc"] }
@@ -156,6 +157,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 3. Add dependencies to `Cargo.toml`
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 reinhardt-grpc = "0.1.0-rc.19"
@@ -188,6 +190,7 @@ use reinhardt::grpc::proto::common::{Empty, Timestamp, PageInfo};
 
 Enable the `di` feature to use dependency injection in gRPC handlers:
 
+<!-- reinhardt-version-sync:2 -->
 ```toml
 [dependencies]
 reinhardt-grpc = { version = "0.1.0-rc.13", features = ["di"] }

--- a/crates/reinhardt-http/README.md
+++ b/crates/reinhardt-http/README.md
@@ -84,6 +84,7 @@ Core HTTP abstractions for the Reinhardt framework. Provides comprehensive reque
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = "0.1.0-rc.19"

--- a/crates/reinhardt-i18n/README.md
+++ b/crates/reinhardt-i18n/README.md
@@ -10,6 +10,7 @@ Framework for translating applications into multiple languages with Django-style
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.13", features = ["i18n"] }

--- a/crates/reinhardt-mail/README.md
+++ b/crates/reinhardt-mail/README.md
@@ -10,6 +10,7 @@ Email framework for sending emails with support for HTML and plain text, attachm
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.13", features = ["mail"] }

--- a/crates/reinhardt-middleware/README.md
+++ b/crates/reinhardt-middleware/README.md
@@ -10,6 +10,7 @@ Middleware system for processing requests and responses. Provides comprehensive 
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["middleware"] }

--- a/crates/reinhardt-query/README.md
+++ b/crates/reinhardt-query/README.md
@@ -41,6 +41,7 @@ A type-safe SQL query builder for the Reinhardt framework.
 
 Add to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 reinhardt-query = { version = "0.1.0-rc.13" }

--- a/crates/reinhardt-rest/README.md
+++ b/crates/reinhardt-rest/README.md
@@ -10,6 +10,7 @@ This crate serves as a **convenience layer** that combines multiple Reinhardt cr
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["rest"] }

--- a/crates/reinhardt-server/README.md
+++ b/crates/reinhardt-server/README.md
@@ -41,6 +41,7 @@ This crate provides the following features:
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:5 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["server"] }
@@ -70,6 +71,7 @@ use reinhardt::server::graphql_handler;  // GraphQL
 
 ### Basic HTTP Server
 
+<!-- reinhardt-version-sync -->
 ```rust
 use reinhardt::server::{serve, HttpServer};
 use reinhardt::http::{Request, Response};
@@ -90,6 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### HTTP Server with Middleware
 
+<!-- reinhardt-version-sync -->
 ```rust
 use reinhardt::server::HttpServer;
 use reinhardt::http::{Handler, Middleware, Request, Response};
@@ -132,6 +135,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### WebSocket Server
 
+<!-- reinhardt-version-sync -->
 ```rust
 use reinhardt::server::{WebSocketServer, WebSocketHandler};
 use std::sync::Arc;
@@ -164,6 +168,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### WebSocket Server with Broadcast
 
+<!-- reinhardt-version-sync -->
 ```rust
 use reinhardt::server::{WebSocketServer, WebSocketHandler};
 use std::sync::Arc;
@@ -201,6 +206,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### GraphQL Server
 
+<!-- reinhardt-version-sync -->
 ```rust
 use reinhardt::server::graphql_handler;
 use async_graphql::{Object, Schema, EmptyMutation, EmptySubscription};

--- a/crates/reinhardt-shortcuts/README.md
+++ b/crates/reinhardt-shortcuts/README.md
@@ -10,6 +10,7 @@ Convenient shortcut functions for common HTTP operations, inspired by Django's `
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["shortcuts"] }

--- a/crates/reinhardt-tasks/README.md
+++ b/crates/reinhardt-tasks/README.md
@@ -12,6 +12,7 @@ Supports task scheduling, retries, task priorities, and multiple worker processe
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["tasks"] }

--- a/crates/reinhardt-test/README.md
+++ b/crates/reinhardt-test/README.md
@@ -12,6 +12,7 @@ Supports both unit testing and integration testing with real or test databases.
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.13", features = ["test"] }

--- a/crates/reinhardt-urls/README.md
+++ b/crates/reinhardt-urls/README.md
@@ -50,6 +50,7 @@ This crate provides the following modules:
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:4 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.13", features = ["urls"] }

--- a/crates/reinhardt-utils/README.md
+++ b/crates/reinhardt-utils/README.md
@@ -12,6 +12,7 @@ Includes date/time utilities, string manipulation, encoding/decoding, and other 
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["utils"] }
@@ -305,6 +306,7 @@ use reinhardt::utils::core::html::{escape, unescape};
 
 **Usage Example**:
 
+<!-- reinhardt-version-sync -->
 ```rust
 use reinhardt::utils::logging::security::{SecurityLogger, SecurityError};
 

--- a/crates/reinhardt-views/README.md
+++ b/crates/reinhardt-views/README.md
@@ -14,6 +14,7 @@ rendering.
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["views"] }
@@ -255,6 +256,7 @@ let list_create_view = ListCreateAPIView::<Article, JsonSerializer<Article>>::ne
 
 ### OpenAPI Schema Generation
 
+<!-- reinhardt-version-sync -->
 ```rust
 use reinhardt::views::{OpenAPISpec, Info, PathItem, Operation};
 

--- a/crates/reinhardt-websockets/README.md
+++ b/crates/reinhardt-websockets/README.md
@@ -10,6 +10,7 @@ WebSocket protocol support for real-time bidirectional communication. Includes c
 
 Add `reinhardt` to your `Cargo.toml`:
 
+<!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.1.0-rc.19", features = ["websockets"] }

--- a/scripts/update-version-refs.sh
+++ b/scripts/update-version-refs.sh
@@ -51,20 +51,24 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Default in-scope files for PR-1. PR-2 will extend this list via a
-# follow-up commit. Tests override via the env var below.
-DEFAULT_TARGETS=(
-	"README.md"
-	"examples/Cargo.toml"
-	"examples/CLAUDE.md"
-	"website/config.toml"
-)
-
 if [ -n "${REINHARDT_VERSION_SYNC_TARGETS:-}" ]; then
 	# Space-separated override (for tests only)
 	read -r -a TARGETS <<< "$REINHARDT_VERSION_SYNC_TARGETS"
 else
-	TARGETS=("${DEFAULT_TARGETS[@]}")
+	TARGETS=(
+		"README.md"
+		"examples/Cargo.toml"
+		"examples/CLAUDE.md"
+		"website/config.toml"
+	)
+	while IFS= read -r f; do
+		TARGETS+=("$f")
+	done < <(find "$REPO_ROOT/crates" -name "README.md" -maxdepth 2 | sort | \
+	          sed "s|$REPO_ROOT/||")
+	while IFS= read -r f; do
+		TARGETS+=("$f")
+	done < <(find "$REPO_ROOT/docs" -name "*.md" | sort | \
+	          sed "s|$REPO_ROOT/||")
 fi
 
 echo "Updating version references to $NEW_VER in $REPO_ROOT"

--- a/scripts/validate-version-markers.sh
+++ b/scripts/validate-version-markers.sh
@@ -15,17 +15,23 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-DEFAULT_TARGETS=(
-	"README.md"
-	"examples/Cargo.toml"
-	"examples/CLAUDE.md"
-	"website/config.toml"
-)
-
 if [ -n "${REINHARDT_VERSION_SYNC_TARGETS:-}" ]; then
 	read -r -a TARGETS <<< "$REINHARDT_VERSION_SYNC_TARGETS"
 else
-	TARGETS=("${DEFAULT_TARGETS[@]}")
+	TARGETS=(
+		"README.md"
+		"examples/Cargo.toml"
+		"examples/CLAUDE.md"
+		"website/config.toml"
+	)
+	while IFS= read -r f; do
+		TARGETS+=("$f")
+	done < <(find "$REPO_ROOT/crates" -name "README.md" -maxdepth 2 | sort | \
+	          sed "s|$REPO_ROOT/||")
+	while IFS= read -r f; do
+		TARGETS+=("$f")
+	done < <(find "$REPO_ROOT/docs" -name "*.md" | sort | \
+	          sed "s|$REPO_ROOT/||")
 fi
 
 AWK_PROG='


### PR DESCRIPTION
## Summary

- Extends `DEFAULT_TARGETS` in `update-version-refs.sh` and `validate-version-markers.sh`
  from 4 static files to a dynamic `find`-based list covering all
  `crates/*/README.md` and `docs/**/*.md`.
- Adds `<!-- reinhardt-version-sync[:N] -->` markers to every installation
  code block in 28 crate READMEs (51 markers total).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring (no functional change)
- [ ] Test update
- [ ] CI/build change

## Motivation and Context

PR-1 (#3939) established the marker infrastructure for 4 root-level files.
This PR extends coverage to all crate-level READMEs so that release-plz PR-3
can update them automatically inside the Release PR.

New crates added to the workspace will automatically be picked up by the
`find`-based enumeration — no manual list maintenance required.

## How Was This Tested?

- [x] All 10 existing shell-script unit tests pass (`scripts/tests/run-all.sh`)
- [x] `validate-version-markers.sh` exits 0 on full repo scan (40 files)
- [x] `update-version-refs.sh 9.9.9-smoke` bumps all 51 marked locations and
      validator still exits 0 afterwards
- [x] Marker insertion is idempotent (re-running the helper produces no changes)

## Checklist

- [x] Code follows project style (tabs, English comments)
- [x] Self-review performed
- [x] No new warnings
- [x] Tests added/pass

## Related Issues

Refs #3924

🤖 Generated with [Claude Code](https://claude.com/claude-code)