### PR TITLE
fix(commands): remove stray `pub mod ws_urls` from app-root template

### DIFF
--- a/crates/reinhardt-commands/templates/app_pages_template/lib.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/lib.rs.tpl
@@ -10,7 +10,6 @@ pub mod models;
 pub mod serializers;
 pub mod urls;
 pub mod views;
-pub mod ws_urls;
 
 // Client-side modules
 #[cfg(client)]

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/lib.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/lib.rs.tpl
@@ -10,7 +10,6 @@ pub mod models;
 pub mod serializers;
 pub mod urls;
 pub mod views;
-pub mod ws_urls;
 
 // Client-side modules
 #[cfg(client)]


### PR DESCRIPTION
## Summary

- Remove `pub mod ws_urls;` from `app_pages_template/lib.rs.tpl`
- Remove `pub mod ws_urls;` from `app_pages_workspace_template/lib.rs.tpl`

## Root Cause

`ws_urls` is a submodule of `urls`, declared correctly in `urls.rs.tpl` as:

```rust
#[cfg(server)]
pub mod ws_urls;
```

The duplicate top-level `pub mod ws_urls;` in `lib.rs.tpl` caused an immediate `E0583` error
after `reinhardt-admin startapp --with-pages` because the compiler looked for
`src/apps/<name>/ws_urls.rs` (does not exist; the file lives at `src/apps/<name>/urls/ws_urls.rs`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #3958
Fixes #3959

## How Was This Tested?

- Verified template diff: only `pub mod ws_urls;` removed, no other changes
- `urls.rs.tpl` already contains the correct `#[cfg(server)] pub mod ws_urls;` declaration
- Affects both `app_pages_template` and `app_pages_workspace_template` variants

## Checklist

- [x] My changes follow the code style of this project
- [x] Documentation updated (template change, no docs needed)
- [x] No new warnings introduced

## Labels to Apply

- `bug`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)