### PR TITLE
fix(ci): guard against empty HEAD_BRANCH in version-ref update step

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -82,6 +82,10 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
+          if [ -z "$HEAD_BRANCH" ]; then
+            echo "No release PR created (HEAD_BRANCH is empty); skipping."
+            exit 0
+          fi
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"


### PR DESCRIPTION
## Summary

- Add a 4-line early-exit guard to the "Update version references in release branch" step in `release-plz.yml`

## Root Cause

When `release-plz release-pr` finds nothing to do (e.g. immediately after merging a release PR), it returns `{"prs":[]}`. The `release-plz/action@v0.5` sets `outputs.pr` to `{}` rather than an empty string, so the step-level guard `steps.release-plz-pr.outputs.pr != ''` still evaluates **TRUE** and the step runs.

`fromJson('{}').head_branch` is `null`, which GitHub Actions evaluates to `""` in `env:`, so `HEAD_BRANCH` is empty. Then:

```
git fetch origin ""
→ fatal: empty string is not a valid pathspec
→ exit 128
```

**Evidence from the failing run:**
```
release_pr_output: {"prs":[]}
HEAD_BRANCH:           ← empty
fatal: empty string is not a valid pathspec
##[error]Process completed with exit code 128.
```

## Fix

```diff
         run: |
+          if [ -z "$HEAD_BRANCH" ]; then
+            echo "No release PR created (HEAD_BRANCH is empty); skipping."
+            exit 0
+          fi
           git config user.name  "github-actions[bot]"
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes https://github.com/kent8192/reinhardt-web/actions/runs/24864402077/job/72797129434

## How Was This Tested?

- Verified the `HEAD_BRANCH: ` empty value in the CI log proves the guard would have triggered
- Next push to main after merge will confirm the step exits cleanly when `{"prs":[]}` is returned

## Checklist

- [x] Code follows project style guidelines
- [x] No new warnings introduced

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)