### PR TITLE
docs(tutorials/basis): align with pages template used by examples-tutorial-basis

### DIFF
--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -32,87 +32,85 @@ cargo install reinhardt-admin-cli
 
 ## Creating a Project
 
-Navigate to a directory where you'd like to store your code, then run:
+This tutorial uses the **reinhardt-pages template** — a WASM client + server functions + shared types layout. Generate the project from that template:
 
 ```bash
-reinhardt-admin startproject polls_project
+# Create a pages-backed project named polls_project
+reinhardt-admin startproject polls_project --template pages
 cd polls_project
 ```
 
-This creates a `polls_project` directory with the following structure:
+The generated tree matches the reference implementation in [`examples/examples-tutorial-basis/`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis):
 
-```
+```text
 polls_project/
-├── Cargo.toml
+├── Cargo.toml                 # cdylib + rlib; reinhardt with "pages" + "client-router" features
+├── Makefile.toml              # cargo make runserver / migrate / test / collectstatic / ...
+├── build.rs                   # cfg_aliases: `native` vs `wasm`
 ├── README.md
 ├── settings/
 │   ├── base.toml
-│   ├── local.toml
-│   ├── staging.toml
-│   └── production.toml
+│   ├── ci.toml
+│   └── local.example.toml
 └── src/
-    ├── config.rs
-    ├── apps.rs
+    ├── lib.rs                 # Entry: #[cfg(native)] server side, #[cfg(wasm)] client side
+    ├── bin/
+    │   └── manage.rs          # CLI binary (Django's manage.py equivalent)
     ├── config/
-    │   ├── settings.rs
-    │   ├── urls.rs
-    │   └── apps.rs
-    └── bin/
-        └── manage.rs
+    │   ├── settings.rs        # SettingsBuilder with profiles
+    │   ├── apps.rs            # installed_apps!{ ... }
+    │   ├── urls.rs            # UnifiedRouter + server_fn registration
+    │   └── wasm.rs            # dist-wasm/ registered for collectstatic
+    ├── apps/                  # (filled in Part 2 onward) — server-only Reinhardt apps
+    ├── server_fn/             # (filled in Part 3) — #[server_fn] async fns
+    ├── shared/                # DTOs + forms shared between client and server
+    │   ├── types.rs
+    │   └── forms.rs
+    └── client/                # (filled in Part 3) — WASM UI layer
+        ├── lib.rs             # #[wasm_bindgen(start)]
+        ├── router.rs
+        ├── pages.rs
+        └── components/
 ```
 
-### Alternative: Create a reinhardt-pages Project (WASM + SSR)
+**Why this layout?** Three rules keep it predictable:
 
-For a modern WASM-based frontend with SSR:
+1. **`#[cfg(native)]` vs `#[cfg(wasm)]`** — server-only code (`apps/`, `server_fn/` bodies) is gated on `native`; browser-only code (`client/`) on `wasm`. `shared/` compiles for both so DTOs stay in sync.
+2. **Server functions are the bridge** — the WASM client never touches the database directly. Every request goes through a `#[server_fn]` defined in `src/server_fn/` and returns a DTO from `src/shared/types.rs`.
+3. **Reactivity via `page!` + `watch` + `use_action`** — UI updates are declarative WASM components. There is no HTML templating engine.
 
-```bash
-# Create a pages project
-reinhardt-admin startproject my-app --template pages
-cd my-app
+**Available `cargo make` tasks (defined in `Makefile.toml`):**
 
-# Build WASM and start development server
-cargo make dev
-# Visit http://127.0.0.1:8000/
-```
+| Task | Purpose |
+|------|---------|
+| `cargo make runserver` | Start the development server |
+| `cargo make makemigrations` | Generate migrations from model changes |
+| `cargo make migrate` | Apply migrations to the configured database |
+| `cargo make collectstatic` | Collect static assets (including `dist-wasm/`) into `staticfiles/` |
+| `cargo make test` | `cargo nextest run --all-features` |
+| `cargo make showurls` | Print every registered URL pattern |
+| `cargo make check` | Project self-check (Django-style `check`) |
 
-This generates a project with 3-layer architecture:
-
-```
-my-app/
-├── Cargo.toml
-├── Makefile.toml
-├── index.html
-├── src/
-│   ├── client/       # WASM UI (runs in browser)
-│   ├── server/       # Server functions (runs on server)
-│   ├── shared/       # Shared types (used by both)
-│   └── ...
-```
-
-**Available commands:**
-- `cargo make dev` - Build WASM and start development server
-- `cargo make dev-watch` - Watch mode with auto-rebuild
-- `cargo make build-release` - Production binary build
-- `cargo make wasm-build-dev` - Build WASM only (debug)
-- `cargo make wasm-build-release` - Build WASM only (release, with wasm-opt)
-
-See [examples/examples-twitter](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-twitter) for a complete implementation.
-
-**Note**: This tutorial focuses on the **reinhardt-pages (WASM + SSR)** architecture with server functions. For building RESTful APIs instead, see the [REST API Tutorial](../rest/0-http-macros/).
+> **Note**: This tutorial targets the **reinhardt-pages** architecture end-to-end. If you are instead building a pure JSON backend consumed by an external SPA or mobile client, start with the [REST Tutorial](../rest/0-http-macros/).
 
 ## Understanding the Project Structure
 
-Let's understand the key elements of the generated project:
+Each generated file has a specific role. Walking top-down:
 
-- `Cargo.toml` - Configuration file for your project and its dependencies
-- `settings/` - Environment-specific settings files (base, local, staging,
-  production)
-- `src/config/` - Project configuration
-  - `settings.rs` - Settings loader
-  - `urls.rs` - URL routing configuration
-  - `apps.rs` - Installed apps registration
-- `src/bin/` - Executable files
-  - `manage.rs` - Management commands (equivalent to Django's `manage.py`), includes `runserver` command for the development server
+- `Cargo.toml` — declares `crate-type = ["cdylib", "rlib"]` (cdylib for WASM, rlib for the server binary) and pulls in `reinhardt` with the `pages` + `client-router` features for WASM, plus `full`, `conf`, `commands`, `db-sqlite`, `forms` for the server target.
+- `build.rs` — uses `cfg_aliases` to create `native` and `wasm` cfgs you will see throughout the source.
+- `settings/` — TOML settings files loaded by `SettingsBuilder`. `base.toml` is always loaded; `local.toml` / `ci.toml` / `production.toml` layer on top depending on `REINHARDT_ENV`.
+- `src/lib.rs` — the crate root. It `#[cfg(native)]`-gates server-only modules (`apps`, server pieces of `config`, `shared::forms`) and `#[cfg(wasm)]`-gates `client`. `server_fn` and `shared::types` compile for both targets.
+- `src/bin/manage.rs` — the server-side binary. It sets `REINHARDT_SETTINGS_MODULE` and calls `reinhardt::commands::execute_from_command_line()`. This is the Django `manage.py` equivalent.
+- `src/config/`
+  - `settings.rs` — `#[settings(core: CoreSettings)]` + `SettingsBuilder` that resolves the active profile and loads TOML files.
+  - `apps.rs` — `installed_apps!{ polls: "polls" }` macro declaring which apps are active.
+  - `urls.rs` — defines `routes() -> UnifiedRouter`, registers `#[server_fn]` entries, and mounts server-side `ServerRouter`s.
+  - `wasm.rs` — an `inventory::submit!` entry that registers `dist-wasm/` with `collectstatic` so WASM build artifacts end up in `staticfiles/`.
+- `src/apps/` — server-only Reinhardt apps (filled in starting from Part 2). Each app owns its models, views, serializers, and a `ServerRouter`.
+- `src/server_fn/` — `#[server_fn]` async functions. A single function compiles to both a server implementation and a client stub, giving you type-safe RPC.
+- `src/shared/` — code used by both targets. `types.rs` holds DTOs (`QuestionInfo`, `ChoiceInfo`, ...) with `Serialize + Deserialize`; `forms.rs` defines `Form`s used by the `form!` macro (server-only because it imports server-side field types).
+- `src/client/` — WASM-only UI. `lib.rs` is the `#[wasm_bindgen(start)]` entry, `router.rs` holds the `reinhardt::pages::router::Router`, `pages.rs` exposes page factories, and `components/` contains the `page!` components that render the UI.
 
 ### Architecture: WASM + SSR (reinhardt-pages)
 

--- a/website/content/quickstart/tutorials/basis/2-models-and-database.md
+++ b/website/content/quickstart/tutorials/basis/2-models-and-database.md
@@ -144,7 +144,15 @@ Let's create two models for our polls application:
 - **Question** - Stores poll questions with their publication date
 - **Choice** - Stores choices for each question with their vote counts
 
-Create `polls/models.rs`:
+Models live under the `polls` app inside the project. Following the reinhardt-pages layout established in Part 1 and matching [`examples/examples-tutorial-basis/src/apps/polls/models.rs`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis/src/apps/polls/models.rs), create the file at:
+
+```text
+src/apps/polls/models.rs
+```
+
+and register the app (once) from `src/apps.rs` with `pub mod polls;`, then from `src/apps/polls.rs` with `pub mod models;`. The app is already declared in `src/config/apps.rs` via `installed_apps!{ polls: "polls" }`.
+
+File contents:
 
 ```rust
 use serde::{Deserialize, Serialize};
@@ -327,15 +335,22 @@ with full type safety.
 ## Creating the Database Schema with Migrations
 
 Instead of manually creating SQL files, Reinhardt provides Django-style
-automatic migration generation:
+automatic migration generation. Run the commands **from the project root**
+(the directory containing `Makefile.toml`); do not run them from any other
+location:
 
 ```bash
 cargo make makemigrations
 ```
 
-This command analyzes your models and automatically generates migration files in
-`migrations/polls/`. The generated migration will create tables with proper
-schema.
+Under the hood, `cargo make makemigrations` invokes
+`cargo run --bin <your-project-name> makemigrations` using the project's own
+management binary (`src/bin/manage.rs`), so everything is scoped to the
+current project.
+
+This command analyzes your models and automatically generates migration files
+in `migrations/polls/`. The generated migration creates the tables with the
+proper schema.
 
 To apply the migrations:
 

--- a/website/content/quickstart/tutorials/basis/3-views-and-urls.md
+++ b/website/content/quickstart/tutorials/basis/3-views-and-urls.md
@@ -12,16 +12,56 @@ In this tutorial, we'll create a modern WASM-based frontend using reinhardt-page
 
 ## Understanding reinhardt-pages Architecture
 
-reinhardt-pages provides a reactive frontend framework with three layers:
+reinhardt-pages provides a reactive frontend framework with three layers. These layers correspond 1:1 to directories in the pages template (and to [`examples/examples-tutorial-basis/src/`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis/src)):
 
-- **`client/`**: WASM UI components that run in the browser
-- **`server/`**: Server functions that run on the server
-- **`shared/`**: Common types used by both client and server
+- **`src/client/`** — WASM UI components that run in the browser (`#[cfg(wasm)]`)
+- **`src/server_fn/`** — server functions that run on the server (bodies are `#[cfg(native)]`, but the function signatures compile for both targets so the client sees a typed stub)
+- **`src/shared/`** — DTOs and forms used by both client and server
+
+### "Views" ≡ Server Functions in the Pages Architecture
+
+In a classic Django-style stack, a *view* is a function that receives an HTTP request and returns a response. In the pages architecture, the same role is played by **server functions** declared with `#[server_fn]`:
+
+- They are `async fn` with typed parameters and a typed return `Result<T, ServerFnError>`.
+- The server implementation runs natively (database access, business logic).
+- The WASM client receives a **typed client stub** that performs the RPC over HTTP.
+- There is no hand-written URL + serializer + HTTP client boilerplate — the macro generates it.
+
+The data flow for one user interaction looks like this:
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as client/ (WASM)
+    participant S as server_fn/ (#[server_fn])
+    participant M as apps/*/models.rs
+    participant DB as Database
+
+    U->>C: Click "Vote"
+    C->>C: use_action(|req| submit_vote(req))
+    C->>S: RPC: submit_vote(req)     (typed stub)
+    S->>M: Choice::objects().get(id)
+    M->>DB: SELECT ... WHERE id = ?
+    DB-->>M: row
+    M-->>S: Choice
+    S->>M: Choice::update(&updated)
+    M->>DB: UPDATE ...
+    DB-->>M: ok
+    S-->>C: Result<VoteResult, ServerFnError>
+    C->>U: watch { ... } rerenders
+```
+
+Three takeaways:
+
+1. The client never constructs URLs or parses JSON by hand — it calls `submit_vote(...).await`.
+2. The function signature is shared between client and server, so renaming a field in `shared/types.rs` fails to compile on both sides simultaneously (a *fail-early* win, per the Reinhardt design philosophy).
+3. DTOs in `src/shared/types.rs` are the *only* types that cross the WASM/native boundary.
 
 This architecture enables:
-- **Type-safe RPC**: Server functions are called from WASM like regular async functions
-- **SSR support**: Components can be pre-rendered on the server
-- **Reactive UI**: State management with `use_action()` hooks
+
+- **Type-safe RPC**: server functions are called from WASM like regular async functions
+- **SSR support**: components can be pre-rendered on the server
+- **Reactive UI**: state management with `use_action()` hooks and `watch { ... }` blocks
 
 ## Project Setup
 
@@ -29,8 +69,8 @@ This architecture enables:
 
 Starting from Rust 2024 edition, Reinhardt supports simplified conditional compilation attributes for WASM/server targets. Instead of verbose `#[cfg(target_arch = "wasm32")]`, you can use shorter aliases:
 
-- **`#[cfg(client)]`** - Code runs only in WASM (browser)
-- **`#[cfg(server)]`** - Code runs only on native (server)
+- **`#[cfg(wasm)]`** - Code runs only in WASM (browser)
+- **`#[cfg(native)]`** - Code runs only on native (server)
 
 This is configured in your `build.rs` using the `cfg_aliases` crate:
 
@@ -39,25 +79,27 @@ use cfg_aliases::cfg_aliases;
 
 fn main() {
 	// Rust 2024 edition requires explicit check-cfg declarations
-	println!("cargo::rustc-check-cfg=cfg(client)");
-	println!("cargo::rustc-check-cfg=cfg(server)");
+	println!("cargo::rustc-check-cfg=cfg(wasm)");
+	println!("cargo::rustc-check-cfg=cfg(native)");
 
 	cfg_aliases! {
-		// Platform aliases for simpler conditional compilation
-		// Use `#[cfg(client)]` instead of `#[cfg(target_arch = "wasm32")]`
-		client: { target_arch = "wasm32" },
-		// Use `#[cfg(server)]` instead of `#[cfg(not(target_arch = "wasm32"))]`
-		server: { not(target_arch = "wasm32") },
+		// Platform aliases for simpler conditional compilation.
+		// Use `#[cfg(wasm)]` for browser-only code.
+		wasm: { all(target_family = "wasm", target_os = "unknown") },
+		// Use `#[cfg(native)]` for server / CLI code.
+		native: { not(all(target_family = "wasm", target_os = "unknown")) },
 	}
+
+	println!("cargo:rerun-if-changed=build.rs");
 }
 ```
 
 **Benefits:**
-- **Shorter code**: `#[cfg(client)]` vs `#[cfg(target_arch = "wasm32")]`
-- **Clearer intent**: `client` and `server` are more semantic than architecture names
+- **Shorter code**: `#[cfg(wasm)]` vs `#[cfg(all(target_family = "wasm", target_os = "unknown"))]`
+- **Clearer intent**: `wasm` and `native` name exactly what differs (the target family), matching the reference example
 - **Easier maintenance**: Less typing, less visual noise
 
-Throughout this tutorial, we use the simplified `#[cfg(client)]` and `#[cfg(server)]` syntax. If you see `#[cfg(target_arch = "wasm32")]` in older code, they are equivalent when the build.rs configuration is in place.
+Throughout this tutorial, we use the simplified `#[cfg(wasm)]` and `#[cfg(native)]` syntax. If you see `#[cfg(target_arch = "wasm32")]` in older code, they are equivalent when the build.rs configuration is in place.
 
 ### 1. Update Cargo.toml
 
@@ -67,20 +109,29 @@ Add WASM support and reinhardt-pages dependency:
 [lib]
 crate-type = ["cdylib", "rlib"]  # cdylib for WASM, rlib for server
 
-# WASM-specific dependencies (using simplified cfg)
-[target.'cfg(client)'.dependencies]
-reinhardt-pages = { workspace = true }
+# WASM-specific dependencies
+# (We select the target by family/os because Cargo does not yet resolve custom
+# `cfg_aliases` on the left-hand side of `[target.'cfg(...)'...]` headers.)
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+reinhardt = { workspace = true, features = ["pages", "client-router"] }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = [
 	"Window", "Document", "Element",
 ] }
 console_error_panic_hook = "0.1"
 
-# Server-specific dependencies (using simplified cfg)
-[target.'cfg(server)'.dependencies]
-reinhardt = { workspace = true, features = ["full", "pages"] }
+# Server-specific dependencies
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+reinhardt = { workspace = true, features = [
+	"full", "pages", "conf", "commands", "db-sqlite", "forms", "client-router",
+] }
 tokio = { version = "1", features = ["full"] }
 ```
+
+> These `[target.'cfg(...)'...]` headers must use the raw `target_family` /
+> `target_os` predicates (not the `wasm` / `native` aliases), because Cargo
+> evaluates them before `build.rs` registers the aliases. Inside your source
+> files, however, you freely use `#[cfg(wasm)]` / `#[cfg(native)]`.
 
 ### 2. Create Build Configuration
 
@@ -165,7 +216,7 @@ Update `src/lib.rs`:
 
 ```rust
 // Server-only re-exports for macro-generated code
-#[cfg(server)]
+#[cfg(native)]
 mod server_only {
 	pub use reinhardt::core::async_trait;
 	pub use reinhardt::reinhardt_apps;
@@ -173,18 +224,18 @@ mod server_only {
 	pub use reinhardt::reinhardt_di::params;
 	pub use reinhardt::reinhardt_http;
 }
-#[cfg(server)]
+#[cfg(native)]
 pub use server_only::*;
 
 // Applications (server-only, polls uses ServerRouter)
-#[cfg(server)]
+#[cfg(native)]
 pub mod apps;
 
 // Configuration (urls unconditional, rest server-only)
 pub mod config;
 
 // Client-only modules (WASM)
-#[cfg(client)]
+#[cfg(wasm)]
 pub mod client;
 
 // Shared modules (both WASM and server)
@@ -192,7 +243,7 @@ pub mod server_fn;
 pub mod shared;
 
 // Re-exports
-#[cfg(server)]
+#[cfg(native)]
 pub use config::settings::get_settings;
 ```
 
@@ -201,7 +252,7 @@ pub use config::settings::get_settings;
 Create `src/shared.rs`:
 
 ```rust
-#[cfg(server)]
+#[cfg(native)]
 pub mod forms;
 pub mod types;
 ```
@@ -234,7 +285,7 @@ pub struct VoteRequest {
 }
 
 // Server-side conversions (not available in WASM)
-#[cfg(server)]
+#[cfg(native)]
 impl From<crate::apps::polls::models::Question> for QuestionInfo {
 	fn from(question: crate::apps::polls::models::Question) -> Self {
 		QuestionInfo {
@@ -245,7 +296,7 @@ impl From<crate::apps::polls::models::Question> for QuestionInfo {
 	}
 }
 
-#[cfg(server)]
+#[cfg(native)]
 impl From<crate::apps::polls::models::Choice> for ChoiceInfo {
 	fn from(choice: crate::apps::polls::models::Choice) -> Self {
 		ChoiceInfo {
@@ -267,7 +318,7 @@ use crate::shared::types::{ChoiceInfo, QuestionInfo, VoteRequest};
 use reinhardt::pages::server_fn::{ServerFnError, server_fn};
 
 // Server-only imports
-#[cfg(server)]
+#[cfg(native)]
 use {
 	crate::shared::forms::create_vote_form,
 	reinhardt::forms::wasm_compat::{FormExt, FormMetadata},
@@ -391,7 +442,7 @@ pub async fn vote(
 /// Get vote form metadata for WASM client rendering
 ///
 /// Returns form metadata with CSRF token for the voting form.
-#[cfg(server)]
+#[cfg(native)]
 #[server_fn]
 pub async fn get_vote_form_metadata() -> std::result::Result<FormMetadata, ServerFnError> {
 	let form = create_vote_form();
@@ -425,7 +476,7 @@ pub async fn submit_vote(
 }
 
 /// Internal vote implementation (shared between vote and submit_vote)
-#[cfg(server)]
+#[cfg(native)]
 async fn vote_internal(
 	request: VoteRequest,
 	db: reinhardt::DatabaseConnection,

--- a/website/content/quickstart/tutorials/basis/4-forms-and-generic-views.md
+++ b/website/content/quickstart/tutorials/basis/4-forms-and-generic-views.md
@@ -12,31 +12,34 @@ In this tutorial, we'll implement form handling in reinhardt-pages using client-
 
 ## Understanding Form Handling in reinhardt-pages
 
-Unlike traditional server-rendered forms (using templates like Tera), reinhardt-pages handles forms on the client side with WASM components that communicate with server functions.
+Unlike traditional server-rendered forms (templating engines like Tera), the reinhardt-pages stack handles forms on the client side with WASM components that call server functions. The tutorial uses **exactly one recommended path**: the `form!` macro.
 
-> **📌 Recommended Approach**: This tutorial primarily demonstrates the **`form!` macro** for declarative form handling with automatic features:
-> 
-> **Why `form!` Macro is Recommended:**
-> - ✅ **Automatic CSRF Protection**: Built-in token injection for POST/PUT/PATCH/DELETE
-> - ✅ **Reactive State Management**: `watch` blocks automatically update UI when form state changes
-> - ✅ **Dynamic Choices**: Runtime population of select/radio options
-> - ✅ **Zero Boilerplate**: Loading states, error handling, and validation built-in
-> - ✅ **Type-Safe**: Compiler ensures field names match form definition
-> - ✅ **Declarative**: Focus on what the form does, not how it works
-> 
-> **Alternative: Manual Form Handling**
-> 
-> Manual form handling (using `use_state()` directly) is documented later in this tutorial for advanced use cases requiring fine-grained control. However, for 90% of forms, the `form!` macro provides everything you need with less code.
-> 
-> **Complete Example**: See `src/client/components/polls.rs` for the `form!` macro pattern with dynamic choices and reactive watch blocks.
+> **📌 The `form!` macro is the single recommended path for forms in this tutorial.**
+>
+> Why:
+> - ✅ **Automatic CSRF protection** — built-in token injection for POST/PUT/PATCH/DELETE
+> - ✅ **Reactive state management** — `watch` blocks update the UI when form state changes
+> - ✅ **Dynamic choices** — runtime population of select/radio options
+> - ✅ **Zero boilerplate** — loading states, error handling, validation out of the box
+> - ✅ **Type-safe** — the compiler checks that every field name matches the form definition
+> - ✅ **Declarative** — you describe what the form does, not how it works
+>
+> The **reference implementation** of this section lives in
+> [`examples/examples-tutorial-basis/src/shared/forms.rs`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis/src/shared/forms.rs)
+> (server-side `Form` definition used to emit `FormMetadata` / CSRF tokens)
+> and
+> [`examples/examples-tutorial-basis/src/client/components/polls.rs`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis/src/client/components/polls.rs)
+> (the `form!` macro + dynamic choices + `watch` blocks). Read them alongside the snippets below — they are the authoritative answer key.
+>
+> Low-level `use_state()` form handling is covered at the very end of this chapter under "Appendix: When You Need to Drop Below `form!`". Do not reach for it unless the `form!` macro cannot express your requirement — 90%+ of forms do not need it.
 
 **Key Concepts:**
 
-1. **Declarative Forms**: Use `form!` macro for automatic state management and CSRF protection
-2. **Manual Forms**: Use `use_state()` to manually manage form data when needed
-3. **Server Functions**: Call server functions for data persistence and validation
-4. **Error Handling**: Display validation errors and server errors to users
-5. **Navigation**: Client-side navigation after successful form submission
+1. **One form type declared twice**: server-side `Form` in `src/shared/forms.rs` (produces `FormMetadata` and CSRF tokens) + client-side `form!` macro in `src/client/components/polls.rs` (produces the UI + action dispatch).
+2. **`form!` macro as the primary API** — declarative fields, automatic state, reactive `watch` blocks.
+3. **Server functions as form targets** — every submission lands on a `#[server_fn]` for persistence and validation.
+4. **Error handling via `watch`** — validation errors and server errors display reactively.
+5. **Navigation after success** — the `success_navigation` `watch` pattern redirects on successful submission.
 
 ## Example: Declarative Forms with form! Macro (Recommended)
 
@@ -471,51 +474,36 @@ form! {
 - ✅ **@-handlers**: Buttons, modals, navigation, custom UI interactions (non-form)
 - ✅ **form! watch**: Input validation, field-dependent UI, form state management
 
-## Choosing Your Approach: form! vs Manual Form Handling
+## Appendix: When You Need to Drop Below `form!`
 
-While the `form!` macro is recommended for most use cases, manual form handling provides fine-grained control when you need it.
+Everything above — and the reference `examples-tutorial-basis` voting form — is built with the `form!` macro. That is the path we recommend for the entire tutorial and for nearly all production forms. This appendix documents the lower-level `use_state()` path **only** so that you recognize it when you see it in older code or in the `examples/` directory; it is *not* part of the main tutorial build.
 
-### When to Use Manual Form Handling
+### When `form!` Is Insufficient
 
-Use manual form handling when you need:
-- Custom state management beyond what `form!` macro provides
-- Integration with external state management libraries
-- Very complex validation logic not supported by standard validators
-- Fine-grained control over every aspect of form behavior
-- Learning how forms work under the hood
+Drop below `form!` only when you need:
+- Multi-step wizard logic with complex branching that the macro cannot express
+- Real-time collaborative editing with external CRDT libraries
+- Drag-and-drop form builders where the field set itself is runtime-defined
+- Integration with a third-party state management library the macro cannot plug into
+- Highly unusual validation sequencing beyond `#[validate(...)]` and server-side validation
 
-### Comparison: form! Macro vs Manual Handling
+For a login form, CRUD create/update, search with filters, or the voting form in this tutorial, **use `form!`**.
 
-| Aspect | form! Macro | Manual Handling |
-|--------|-------------|-----------------|
-| **CSRF Protection** | Automatic (POST/PUT/PATCH/DELETE) | Manual implementation required |
-| **State Management** | Built-in `watch` blocks, reactive Signals | Manual `use_state()` for each field |
+### Quick Comparison
+
+| Aspect | `form!` Macro | Manual `use_state()` |
+|--------|---------------|-----------------------|
+| **CSRF Protection** | Automatic (POST/PUT/PATCH/DELETE) | You must fetch and attach the token yourself |
+| **State Management** | Built-in `watch` blocks, reactive Signals | One `use_state()` per field |
 | **Boilerplate** | Minimal (declarative) | Extensive (imperative) |
-| **Error Handling** | Built-in `form.error()` Signal | Manual error state management |
-| **Loading States** | Built-in `form.loading()` Signal | Manual loading state tracking |
-| **Validation** | Integrated with server_fn validation | Manual validation implementation |
-| **Type Safety** | Compiler-enforced field names | Manual typing |
-| **Reactivity** | Automatic UI updates | Manual Signal updates |
-| **Recommended for** | Most forms (90% of use cases) | Advanced customization (10% of use cases) |
+| **Error Handling** | Built-in `form.error()` Signal | Your own error state |
+| **Loading States** | Built-in `form.loading()` Signal | Your own loading state |
+| **Validation** | Integrated with server_fn validation | Hand-written |
+| **Type Safety** | Compiler-enforced field names | Whatever you write yourself |
+| **Reactivity** | Automatic | Manual Signal updates |
+| **Use it for** | The entire tutorial (100% of forms) | Only escape hatches from the list above |
 
-### Example Use Cases
-
-✅ **Use form! macro for:**
-- Login/registration forms
-- CRUD operations (create, update, delete)
-- Search forms with filters
-- Survey/poll forms
-- Contact forms
-- Any form with standard validation
-
-⚠️ **Consider manual handling for:**
-- Multi-step wizards with complex branching logic
-- Forms with real-time collaborative editing
-- Custom drag-and-drop form builders
-- Forms requiring third-party state management integration
-- Very unusual validation requirements
-
-**For this tutorial, we use the `form!` macro approach**, as it provides the best balance of simplicity and power for most forms. Manual form handling examples are available in the examples directory for advanced use cases.
+Manual form code can be found in the Reinhardt repository under `examples/` for advanced scenarios; it is outside the scope of this tutorial.
 
 ## Server-Side Validation and Processing
 
@@ -527,7 +515,7 @@ use crate::shared::types::{ChoiceInfo, VoteRequest};
 use reinhardt::pages::server_fn::{server_fn, ServerFnError};
 
 // Server-only imports
-#[cfg(server)]
+#[cfg(native)]
 use reinhardt::atomic;
 
 /// Vote for a choice

--- a/website/content/quickstart/tutorials/basis/5-testing.md
+++ b/website/content/quickstart/tutorials/basis/5-testing.md
@@ -8,7 +8,27 @@ sidebar_weight = 50
 
 # Part 5: Testing
 
-In this tutorial, we'll write automated tests using modern Rust testing tools: **rstest** for fixtures and **TestContainers** for database isolation.
+In this chapter you write automated tests using modern Rust tooling: **rstest** for fixtures + parametrization, **reinhardt-test** for framework-aware fixtures, and **TestContainers** when you need real Postgres/MySQL in a container.
+
+> **Reference implementation:** the finished tests for this tutorial live at
+> [`examples/examples-tutorial-basis/tests/integration.rs`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis/tests/integration.rs).
+> That file shows two complementary approaches side by side:
+>
+> 1. **Manual SQLite setup** — raw `sqlx` + `tempfile`, full control over the schema.
+> 2. **`reinhardt-test` fixtures** — automatic table creation from your `#[model]` structs, recommended for new tests.
+>
+> Prefer the second approach whenever possible.
+
+**Conventions used in every test below (and required by `instructions/TESTING_STANDARDS.md`):**
+
+- Use `#[rstest]` (never plain `#[test]`).
+- Follow the **Arrange / Act / Assert** pattern with explicit `// Arrange`, `// Act`, `// Assert` comments separating the three phases (may be omitted for tests of 5 lines or fewer).
+- Every test MUST exercise at least one component from the `reinhardt` crate (model, server function, shared DTO, ...).
+- Use strict assertions (`assert_eq!`) over loose matching (`contains(...)`).
+- Tests that mutate global state go in `#[serial(group_name)]`.
+- Clean up all artifacts — temp files and containers are auto-cleaned via `Drop` when you use the fixtures correctly.
+
+Where snippets below omit the `// Arrange / // Act / // Assert` labels for space, assume they are present in the committed `tests/integration.rs` — compare each snippet against the reference file to see the exact comment placement.
 
 ## Why Testing Matters
 

--- a/website/content/quickstart/tutorials/basis/6-static-files.md
+++ b/website/content/quickstart/tutorials/basis/6-static-files.md
@@ -12,7 +12,26 @@ In this tutorial, we'll add CSS stylesheets and images to make our polls applica
 
 ## Understanding Static Files in reinhardt-pages
 
-Static files are assets like CSS, JavaScript, images, and fonts that don't change during runtime. In reinhardt-pages applications, static files are managed differently from traditional server-rendered frameworks:
+Static files are CSS, JavaScript, WASM, images, and fonts that don't change during runtime. The reinhardt-pages template stores them in **two distinct tiers** that merge into one served directory at deploy time:
+
+| Tier | Directory | Populated by | Purpose |
+|------|-----------|--------------|---------|
+| WASM build output | `dist-wasm/` | `wasm-bindgen` / `wasm-pack` during `cargo make wasm-build-*` | Compiled client bundle: `<project>.js` glue + `<project>_bg.wasm` |
+| Final served tree | `staticfiles/` | `cargo make collectstatic` | Flat tree served at `/static/` — contains `dist-wasm/` output **plus** any app `static/` directories and workspace `staticfiles_dirs` |
+
+This matches the layout of
+[`examples/examples-tutorial-basis/`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis):
+`dist-wasm/` and `staticfiles/` both live at the project root and are both git-ignored build artifacts.
+
+`src/config/wasm.rs` is what connects the two tiers — it registers `dist-wasm/` with the `collectstatic` inventory so that running `cargo make collectstatic` copies the WASM output into `staticfiles/` alongside everything else.
+
+```mermaid
+flowchart LR
+    A["wasm-bindgen build<br/>(cargo make wasm-build-release)"] --> B["dist-wasm/<br/>- project.js<br/>- project_bg.wasm"]
+    C["app static/ dirs<br/>(per-app assets)"] --> D
+    B --> D["cargo make collectstatic"]
+    D --> E["staticfiles/<br/>served at /static/"]
+```
 
 **Traditional Approach (Server-Side Rendering):**
 ```html
@@ -21,9 +40,10 @@ Static files are assets like CSS, JavaScript, images, and fonts that don't chang
 ```
 
 **reinhardt-pages Approach (WASM):**
-1. **CDN Resources**: External libraries loaded from CDNs
-2. **Local Assets**: Static files copied to `dist/` during build
-3. **Direct References**: Files referenced using one of three methods (see below)
+1. **WASM build output** — `dist-wasm/` (produced by the WASM build), registered for collection in `src/config/wasm.rs`.
+2. **Per-app `static/` directories** — optional; app-local assets collected by `collectstatic`.
+3. **Final `staticfiles/` directory** — what is actually served at `/static/` in production.
+4. **Direct references** from client code — use one of three methods (see below).
 
 ## Static File Reference Methods
 

--- a/website/content/quickstart/tutorials/basis/7-admin-customization.md
+++ b/website/content/quickstart/tutorials/basis/7-admin-customization.md
@@ -10,6 +10,19 @@ sidebar_weight = 70
 
 In this tutorial, we'll explore the Reinhardt admin interface and learn how to customize it for managing poll data.
 
+## How Admin Fits into the Pages Architecture
+
+Before enabling the admin, it helps to understand that in the reinhardt-pages stack the admin is **not** a separate server-rendered Django-style panel. It is assembled from two halves, each of which lives in a directory you already know from earlier chapters:
+
+| Half | Where | What it does |
+|------|-------|--------------|
+| **Server-side registration** | `src/apps/<app>/admin.rs` (per app) or a shared `src/admin.rs` — this is the `#[admin(...)]` / `impl ModelAdmin for ...` code | Declares list columns, search fields, permissions, and form layout for each model. Compiled under `#[cfg(native)]`. |
+| **Client-side UI mount** | `src/client/` — a WASM component that calls admin server functions and renders tables, search, and change forms | Displays the actual admin UI inside the same pages runtime that powers the rest of the app. Compiled under `#[cfg(wasm)]`. |
+
+The flow matches the one introduced in [Part 3](../3-views-and-urls/): the client component issues typed RPC calls through server functions, and the server side executes them against your models. The admin ships with a pre-built set of components plus a standard set of server functions — you only have to supply the `ModelAdmin` configuration.
+
+You do **not** write HTML templates, ship a separate admin binary, or mount a second router. Everything runs in the same pages application, with the admin UI mounted at `/admin/` through the pages `Router` alongside your public pages.
+
 ## Activating the Admin
 
 The Reinhardt admin is a powerful, automatically-generated interface for managing your application's data. Let's enable it for our polls application.

--- a/website/content/quickstart/tutorials/basis/_index.md
+++ b/website/content/quickstart/tutorials/basis/_index.md
@@ -11,118 +11,149 @@ sidebar_weight = 10
 
 # Reinhardt Basis Tutorial
 
-Learn the fundamentals of the Reinhardt framework by building a real-world polling application.
+Learn the fundamentals of the Reinhardt framework by building a real-world polling application on the **reinhardt-pages template** (WASM client + server functions + shared types).
 
 ## Overview
 
-This tutorial series will guide you through creating a fully functional polling application from scratch. You'll learn Reinhardt's core concepts including models, views, templates, forms, testing, and the admin interface.
+This tutorial series walks you through building a fully functional polling application from scratch. The reference implementation lives under [`examples/examples-tutorial-basis`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis); following the chapters in order will produce a project that is logically equivalent to it.
+
+Reinhardt's basis tutorial is intentionally different from a classic server-rendered Django-style stack: the UI is a Rust-compiled WebAssembly (WASM) client, the backend exposes typed **server functions** via `#[server_fn]`, and client and server share the same DTO types. You will see each of these layers introduced explicitly below.
 
 ## Who This Tutorial Is For
 
-This tutorial is designed for:
-
 - Developers new to Reinhardt who want to learn the framework from the ground up
-- Django developers transitioning to Rust and Reinhardt
-- Anyone building web applications with server-rendered templates
+- Django developers transitioning to Rust who want to understand Reinhardt's pages architecture
+- Anyone building full-stack web applications where the browser runs Rust (WASM) and talks to a server function backend
 
 ## Prerequisites
 
-Before starting this tutorial, you should have:
-
 - Basic knowledge of Rust programming
-- Familiarity with Cargo (Rust's package manager)
+- Familiarity with Cargo and `cargo make`
 - Understanding of HTTP concepts and web development
 - A code editor or IDE
 
 ## What You'll Build
 
-Throughout this tutorial, you'll build a polling application where users can:
+A polling application where end users can:
 
-- View polls and their choices
-- Vote on polls
-- See voting results
+- View the latest polls on a WASM-rendered index page
+- Open a poll, vote on a choice, and see the result update reactively
+- See aggregated voting results on a results page
 
-As an administrator, you'll be able to:
+Administrators can:
 
-- Create and manage polls through the admin interface
+- Create and manage polls via the Reinhardt admin (registered as a WASM admin component)
 - Add and edit choices for each poll
-- Customize the admin interface to your needs
+
+## The Pages Template at a Glance
+
+Every chapter maps onto this layout, which matches the completed example under `examples/examples-tutorial-basis/`:
+
+```text
+examples-tutorial-basis/
+├── Cargo.toml                 # cdylib + rlib; reinhardt with "pages" + "client-router" features
+├── Makefile.toml              # cargo make tasks: runserver, migrate, collectstatic, test, ...
+├── build.rs                   # cfg_aliases: `native` vs `wasm`
+├── settings/                  # TOML settings (base.toml, ci.toml, local.example.toml)
+├── src/
+│   ├── lib.rs                 # Entry point; #[cfg(native)] vs #[cfg(wasm)] gating
+│   ├── bin/
+│   │   └── manage.rs          # CLI binary (manage.py equivalent)
+│   ├── config/
+│   │   ├── settings.rs        # SettingsBuilder + profiles
+│   │   ├── apps.rs            # installed_apps!{ polls: "polls" }
+│   │   ├── urls.rs            # UnifiedRouter + server_fn registration
+│   │   └── wasm.rs            # collectstatic entry for dist-wasm/
+│   ├── apps/                  # Server-only Reinhardt apps
+│   │   └── polls/
+│   │       ├── models.rs      # #[model] structs (Question, Choice)
+│   │       ├── urls.rs        # ServerRouter for HTTP endpoints
+│   │       └── views.rs       # #[get]/#[post] handlers
+│   ├── server_fn/             # Server functions, callable from WASM client
+│   │   └── polls.rs           # #[server_fn] async fns (get_questions, submit_vote, ...)
+│   ├── shared/                # Types and forms shared between WASM and server
+│   │   ├── types.rs           # DTOs (QuestionInfo, ChoiceInfo, VoteRequest)
+│   │   └── forms.rs           # Server-only Form definitions used by form! on the client
+│   └── client/                # WASM-only UI layer
+│       ├── lib.rs             # #[wasm_bindgen(start)] entry, mounts router
+│       ├── router.rs          # reinhardt::pages::router::Router
+│       ├── pages.rs           # Page factory functions
+│       └── components/polls.rs# page! { ... } + watch blocks + form!
+└── tests/integration.rs       # rstest + reinhardt-test fixtures (AAA pattern)
+```
+
+Three rules keep this structure predictable:
+
+1. **Native vs WASM** — `#[cfg(native)]` code runs on the server (models, views, server_fn bodies). `#[cfg(wasm)]` code runs in the browser (client UI). `shared` modules compile for both.
+2. **Server functions are the bridge** — anything the WASM client needs from the database goes through a `#[server_fn]` in `src/server_fn/`. Client and server exchange the DTOs in `src/shared/types.rs`.
+3. **Reactivity via `page!` + `watch` + `use_action`** — UI updates happen declaratively in WASM components; there is no HTML templating engine.
 
 ## Tutorial Structure
 
-This tutorial is divided into seven parts:
-
 ### [Part 1: Project Setup](1-project-setup/)
 
-- Install Reinhardt
-- Create a new project
-- Run the development server
-- Create your first view and URL configuration
+- Generate a project from the reinhardt-pages template
+- Understand the `src/{lib,client,server_fn,shared,apps,config,bin}` layout
+- Configure `settings/base.toml` and run the dev server with `cargo make runserver`
 
 ### [Part 2: Models and Database](2-models-and-database/)
 
-- Set up the database
-- Create models (Question and Choice)
-- Use the database API
-- Introduction to the Reinhardt admin
+- Define `Question` and `Choice` with `#[model(app_label = "polls", table_name = "...")]`
+- Place models under `src/apps/polls/models.rs`
+- Run `cargo make makemigrations` and `cargo make migrate` from the project root
 
 ### [Part 3: Views and URLs](3-views-and-urls/)
 
-- Write more views
-- Connect views to URLs
-- Use templates to render HTML
-- Implement shortcut functions
+- Write **server functions** (`#[server_fn]`) in `src/server_fn/polls.rs` — this is the "views" layer of the pages architecture
+- Register them in `src/config/urls.rs` with `UnifiedRouter::new().server(|s| s.server_fn(...))`
+- Mount server-rendered `ServerRouter` endpoints from `src/apps/polls/urls.rs` at `/polls/`
+- Add client routes in `src/client/router.rs` that render `page!` components
 
 ### [Part 4: Forms and Generic Views](4-forms-and-generic-views/)
 
-- Create HTML forms
-- Process form submissions
-- Use generic views to reduce code
-- Implement the voting functionality
+- Define `VotingForm` in `src/shared/forms.rs` using `Form::new().add_field(...)`
+- Build the voting UI with the **`form!` macro** + `watch { ... }` blocks inside a `page!` component
+- Call `submit_vote` (a `#[server_fn]`) on submit; show server validation errors reactively
 
 ### [Part 5: Testing](5-testing/)
 
-- Write automated tests
-- Test models and views
-- Use the test client
-- Follow testing best practices
+- Use `rstest` fixtures + `reinhardt-test` helpers to spin up an in-memory SQLite
+- Follow the Arrange-Act-Assert pattern with `// Arrange`, `// Act`, `// Assert` labels
+- Exercise models, server functions, and shared DTO conversions
 
 ### [Part 6: Static Files](6-static-files/)
 
-- Add stylesheets (CSS)
-- Include images
-- Organize static files
-- Configure static file serving
+- Understand the two static-asset tiers used by the pages template:
+  - `dist-wasm/` — output of `wasm-pack` / WASM build, registered via `src/config/wasm.rs`
+  - `staticfiles/` — final output of `cargo make collectstatic`, served at `/static/`
+- Wire it all up through `Makefile.toml` tasks
 
 ### [Part 7: Admin Customization](7-admin-customization/)
 
-- Customize the admin form
-- Add related objects
-- Customize the change list
-- Modify admin templates
+- Register `ModelAdmin` implementations server-side
+- Mount the admin UI as a **WASM component** in `src/client/` so the admin renders inside the same pages runtime
+- Customize list columns, search, and change forms
 
 ## Recommended Learning Path
 
-Work through the tutorials in order, as each part builds on the previous ones. You can skip ahead if you're already familiar with certain concepts, but we recommend following along sequentially for the best learning experience.
+Work through the chapters in order. Each chapter assumes the directory layout produced by the previous one. If you get stuck, compare your tree against [`examples/examples-tutorial-basis/`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis) — the reference source is the authoritative answer key.
 
 ## Getting Help
 
-If you encounter issues while following this tutorial:
-
-- Check the [Reinhardt documentation](https://github.com/kent8192/reinhardt-web)
-- Review the [Getting Started Guide](/quickstart/getting-started/)
-- Look at the [Feature Flags Guide](/docs/feature-flags/)
-- Examine the individual crate READMEs for detailed information
+- [Reinhardt repository](https://github.com/kent8192/reinhardt-web)
+- [Getting Started Guide](/quickstart/getting-started/)
+- [Feature Flags Guide](/docs/feature-flags/)
+- [GitHub Discussions](https://github.com/kent8192/reinhardt-web/discussions)
 
 ## Comparison with REST Tutorial
 
-If you're also interested in building REST APIs, check out the [REST Tutorial](../rest/quickstart/). The key differences are:
+If you're also interested in building pure JSON APIs, see the [REST Tutorial](../rest/quickstart/).
 
-- **Basis Tutorial**: Focuses on full-stack web applications with server-rendered templates
-- **REST Tutorial**: Focuses on building APIs with JSON responses and serializers
+- **Basis Tutorial** (this one): full-stack pages template — WASM client + `#[server_fn]` + shared DTOs.
+- **REST Tutorial**: `#[get]` / `#[post]` views, `Serializer`s, and `ViewSet` + `Router` for classic REST endpoints.
 
-Both tutorials teach fundamental Reinhardt concepts, so learning one will help you understand the other.
+The underlying model and database layers are identical, so lessons transfer in both directions.
 
 ## Let's Get Started!
 
-Ready to begin? Head over to [Part 1: Project Setup](1-project-setup/) to create your first Reinhardt project!
+Head over to [Part 1: Project Setup](1-project-setup/) to generate your first pages project.


### PR DESCRIPTION
## Summary

- Align the Basis tutorial with the reinhardt-pages template layout used by `examples/examples-tutorial-basis/` so that following chapters 1–7 in order produces a project logically equivalent to the reference implementation.
- Lead with the pages template (WASM client + `server_fn` + shared DTOs) instead of the Django-style narrative.
- Fix CFG alias drift (`#[cfg(client)]`/`#[cfg(server)]` → `#[cfg(wasm)]`/`#[cfg(native)]`) to match the example's `build.rs`.

## Type of Change

- [x] Documentation update

## Motivation and Context

Readers who followed the Basis tutorial ended up with a file tree and CFG conventions that did not match the completed example under `examples/examples-tutorial-basis/`, even though the tutorial claimed to teach that project. This PR aligns each chapter — index through Part 7 — to the actual pages template so the final tree of a tutorial follower matches `examples-tutorial-basis/src/{lib,client,server_fn,shared,apps,config,bin}` and the `Makefile.toml` task names.

## Changes per Chapter

- **`_index.md`** — Rewrote the introduction and chapter table of contents around the pages template; added a directory tree that matches `examples-tutorial-basis/src/` exactly.
- **Part 1 — Project Setup** — Promote `reinhardt-admin startproject ... --template pages` as the primary (not "alternative") path; show the real example tree and explain each top-level file + the `cargo make` task surface.
- **Part 2 — Models and Database** — Pin model placement at `src/apps/polls/models.rs` and clarify that `cargo make makemigrations` / `migrate` run from the project root via the project's `manage` binary.
- **Part 3 — Views and URLs** — Rename `cfg(client)` / `cfg(server)` to `cfg(wasm)` / `cfg(native)` to match the example's `build.rs`; correct the `[target.'cfg(...)'.dependencies]` headers to use raw `target_family` / `target_os` predicates (Cargo cannot evaluate `build.rs` aliases at that layer); add an explicit "Views ≡ server functions" section with a Mermaid sequence diagram of one client→server_fn→models→DB call.
- **Part 4 — Forms and Generic Views** — Present `form!` macro as the single recommended path for the entire tutorial; move manual `use_state()` handling into an explicit appendix; sync the remaining `cfg(server)` occurrence to `cfg(native)`.
- **Part 5 — Testing** — Point readers at `examples-tutorial-basis/tests/integration.rs` as the answer key; document the two approaches (manual SQLite, `reinhardt-test` fixtures) and call out the rstest-only + AAA rule from `instructions/TESTING_STANDARDS.md` up front.
- **Part 6 — Static Files** — Add a two-tier table + Mermaid diagram explaining `dist-wasm/` (WASM build output, registered via `src/config/wasm.rs`) and `staticfiles/` (final served tree produced by `cargo make collectstatic`); stop implying a monolithic `static/` directory.
- **Part 7 — Admin Customization** — Add a "How Admin Fits into the Pages Architecture" section clarifying that admin is assembled from server-side `ModelAdmin` registration (`cfg(native)`) plus a client-side WASM mount from `src/client/`, mounted at `/admin/` through the pages `Router`.

## How Was This Tested

- [x] `git diff main...HEAD` reviewed chapter-by-chapter against `examples/examples-tutorial-basis/src/`.
- [x] All edits keep existing code fences language-tagged (`rust`, `toml`, `html`, `bash`, `mermaid`).
- [x] No source code under `reinhardt/` or `crates/` is modified; this is a docs-only PR.
- [ ] Local site build (`zola build` or project equivalent) — pending reviewer environment.

## Checklist

- [x] PR title follows Conventional Commits (`docs(tutorials/basis): ...`)
- [x] English-only content
- [x] Each commit is scoped to a single chapter + single intent and carries `Fixes #3963`
- [x] Claude Code attribution footer on every commit
- [x] No absolute local paths in docs (all repository-relative)

## Labels to Apply

- `documentation`

## Related Issues

Closes #3963

🤖 Generated with [Claude Code](https://claude.com/claude-code)
