### PR TITLE
fix(ci): guard release-plz version-ref step against no-op PR output

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -76,7 +76,15 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Update version references in release branch
-        if: steps.release-plz-pr.outputs.pr != ''
+        # Guard against no-op release-pr runs: when release-plz/action@v0.5
+        # finds nothing to release it sets outputs.pr to "{}" (not empty),
+        # which makes `outputs.pr != ''` truthy. Without the extra checks,
+        # fromJson('{}').head_branch becomes null -> HEAD_BRANCH empty ->
+        # `git fetch origin ""` fails with exit 128. See run 24864402077.
+        if: >-
+          steps.release-plz-pr.outputs.pr != ''
+          && steps.release-plz-pr.outputs.pr != '{}'
+          && fromJson(steps.release-plz-pr.outputs.pr).head_branch != null
         env:
           HEAD_BRANCH: ${{ fromJson(steps.release-plz-pr.outputs.pr).head_branch }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary

Harden the `Update version references in release branch` step in
`.github/workflows/release-plz.yml` so that it is skipped at the workflow
level when `release-plz release-pr` finds nothing to release.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

On 2026-04-23 the release-plz workflow failed on the merge-to-`main`
of #3961 with exit code 128: [run 24864402077 / job 72797129434](https://github.com/kent8192/reinhardt-web/actions/runs/24864402077/job/72797129434).

Root cause:

- `release-plz release-pr` returned `{"prs":[]}` (no new release PR needed
  right after merging the previous one).
- `release-plz/action@v0.5` nonetheless sets its `outputs.pr` to the
  string `"{}"`, not an empty string.
- The existing step-level guard `if: steps.release-plz-pr.outputs.pr != ''`
  evaluated to **true** on `"{}"`.
- `fromJson('{}').head_branch` is `null`, so `HEAD_BRANCH` was set to the
  empty string, and `git fetch origin ""` aborted the job with
  `fatal: empty string is not a valid pathspec`.

PR #3962 introduced a **bash-level** early-exit for this. This PR
supersedes that approach with a **step-level `if:` guard**, which is more
idiomatic for GitHub Actions and avoids running token provisioning and
git setup when there is nothing to do.

## How Was This Tested?

- Reviewed the failing CI log; the new guard covers each branch:
  - `outputs.pr == ''`           → first condition false → step skipped.
  - `outputs.pr == '{}'` (the incident) → second condition false → step skipped.
  - `head_branch == null`        → third condition false → step skipped.
  - `head_branch == "release-plz-…"` (normal) → all conditions true → step runs as before.
- `actionlint` reports no new findings for this file (only pre-existing
  warnings about the self-hosted runner label and an unrelated SC2016 in
  another step).

Full end-to-end validation requires the next push-to-main release-plz
cycle.

## Checklist

- [x] Code follows project style guidelines
- [x] No new warnings introduced
- [x] Related issues / runs referenced in commit message

## Labels to Apply

- `bug`
- `ci-cd`

## Related Issues

Refs https://github.com/kent8192/reinhardt-web/actions/runs/24864402077/job/72797129434
Supersedes #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)