### PR TITLE
fix(pages-macros): replace implicit csrf inject with explicit strip_arguments

### DIFF
--- a/crates/reinhardt-manouche/src/core/form_node.rs
+++ b/crates/reinhardt-manouche/src/core/form_node.rs
@@ -94,6 +94,15 @@ pub struct FormMacro {
 	/// Unified validators. Each rule carries an optional scope annotation
 	/// (`#[server]` / `#[client(on = ...)]`) that controls where it executes.
 	pub validators: Vec<FormValidator>,
+	/// Arguments appended positionally to the server_fn call but never exposed
+	/// as user-facing form fields. Each entry maps a server_fn argument name to
+	/// the expression evaluated at submit time.
+	///
+	/// Order in the source matches the order in which arguments are appended
+	/// after the regular form-field arguments.
+	///
+	/// See `StripArgument` for details. Tracked under reinhardt-web#3971.
+	pub strip_arguments: Vec<StripArgument>,
 	/// Span for error reporting
 	pub span: Span,
 }
@@ -716,6 +725,53 @@ pub struct ValidatorRule {
 	pub span: Span,
 }
 
+/// Argument stripped from the surface form fields and instead passed directly
+/// to the underlying server_fn at submit time.
+///
+/// Useful for values like CSRF tokens or other ambient context that should not
+/// be exposed as user-editable form fields, but must appear in the server_fn
+/// signature.
+///
+/// ## Behavior
+///
+/// - The expression is evaluated **on the client side at submit time** and
+///   appended positionally to the server_fn call after all regular form-field
+///   arguments.
+/// - The argument **does not** appear in the form struct, the rendered HTML,
+///   or the validation pipeline.
+/// - The corresponding server_fn argument **must** exist in the server_fn
+///   signature; otherwise the build fails with a standard arity mismatch.
+///
+/// ## Relationship to CSRF auto-injection
+///
+/// Prior to reinhardt-web#3971 the `form!` macro silently appended a
+/// `__csrf_token: String` argument to every `method != Get` server_fn call.
+/// `strip_arguments` makes that injection explicit and generalizes it to any
+/// argument the user wants to supply outside the form's field surface.
+///
+/// ## Example DSL
+///
+/// ```ignore
+/// form! {
+///     server_fn: submit_vote,
+///     method: Post,
+///     strip_arguments: {
+///         csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token()
+///             .unwrap_or_default(),
+///     },
+///     fields: { ... }
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct StripArgument {
+	/// Argument name as it appears in the server_fn signature.
+	pub name: Ident,
+	/// Expression evaluated at submit time to supply the argument's value.
+	pub value: Expr,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
 /// Form submission callbacks configuration.
 ///
 /// Allows defining custom behavior at different stages of form submission:
@@ -1047,6 +1103,7 @@ impl FormMacro {
 			slots: None,
 			fields: Vec::new(),
 			validators: Vec::new(),
+			strip_arguments: Vec::new(),
 			span,
 		}
 	}

--- a/crates/reinhardt-manouche/src/core/form_typed.rs
+++ b/crates/reinhardt-manouche/src/core/form_typed.rs
@@ -117,6 +117,12 @@ pub struct TypedFormMacro {
 	/// Validated unified validators. Each rule carries a `ValidatorScope`
 	/// controlling whether it executes on server, client, or both.
 	pub validators: Vec<TypedFormValidator>,
+	/// Validated arguments stripped from the form-field surface and appended
+	/// positionally to the server_fn call at submit time.
+	///
+	/// Keys must not collide with declared form field names. See
+	/// `TypedStripArgument` for details. Tracked under reinhardt-web#3971.
+	pub strip_arguments: Vec<TypedStripArgument>,
 	/// Span for error reporting
 	pub span: Span,
 }
@@ -1024,6 +1030,21 @@ pub struct TypedValidatorRule {
 	pub span: Span,
 }
 
+/// Typed argument stripped from the surface form fields and appended to the
+/// server_fn call at submit time.
+///
+/// See `crate::core::form_node::StripArgument` for the source AST and
+/// rationale. Tracked under reinhardt-web#3971.
+#[derive(Debug)]
+pub struct TypedStripArgument {
+	/// Argument name as it appears in the server_fn signature.
+	pub name: Ident,
+	/// Expression evaluated at submit time to supply the argument's value.
+	pub value: syn::Expr,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
 /// A validated wrapper element definition for custom field containers.
 ///
 /// Wrappers allow specifying custom HTML elements to wrap around form fields,
@@ -1293,6 +1314,7 @@ impl TypedFormMacro {
 			slots: None,
 			fields: Vec::new(),
 			validators: Vec::new(),
+			strip_arguments: Vec::new(),
 			span,
 		}
 	}

--- a/crates/reinhardt-manouche/src/parser/form.rs
+++ b/crates/reinhardt-manouche/src/parser/form.rs
@@ -14,8 +14,8 @@ use crate::{
 	ClientTrigger, CustomAttr, FormAction, FormDerived, FormDerivedItem, FormFieldDef,
 	FormFieldEntry, FormFieldGroup, FormFieldProperty, FormMacro, FormSlots, FormState,
 	FormStateField, FormSubmitButtonDef, FormValidator, FormWatch, FormWatchItem, IconAttr,
-	IconChild, IconElement, IconPosition, ValidatorRule, ValidatorScope, WrapperAttr,
-	WrapperElement,
+	IconChild, IconElement, IconPosition, StripArgument, ValidatorRule, ValidatorScope,
+	WrapperAttr, WrapperElement,
 };
 
 /// Parses a `form!` macro invocation into an untyped AST.
@@ -144,11 +144,17 @@ impl Parse for FormMacro {
 				"client_validators" => {
 					return Err(reject_client_validators_with_guidance(&key));
 				}
+				"strip_arguments" => {
+					let content;
+					braced!(content in input);
+					form.strip_arguments = parse_strip_arguments(&content)?;
+					parse_optional_comma(input)?;
+				}
 				_ => {
 					return Err(syn::Error::new(
 						key.span(),
 						format!(
-							"Unknown form property: '{}'. Expected: name, action, server_fn, method, class, state, on_submit, on_success, on_error, on_loading, watch, redirect_on_success, initial_loader, choices_loader, slots, fields, validators",
+							"Unknown form property: '{}'. Expected: name, action, server_fn, method, class, state, on_submit, on_success, on_error, on_loading, watch, redirect_on_success, initial_loader, choices_loader, slots, fields, validators, strip_arguments",
 							key
 						),
 					));
@@ -562,6 +568,29 @@ fn parse_icon_child(tag: Ident, input: ParseStream, span: Span) -> Result<IconCh
 		children,
 		span,
 	})
+}
+
+/// Parses strip_arguments inside the `strip_arguments: { ... }` block.
+///
+/// Format: `arg_name: <expression>,` repeated. Each entry binds one
+/// server_fn argument name to an expression evaluated at submit time on the
+/// client; the resulting value is appended positionally to the server_fn
+/// call after all regular form-field arguments.
+///
+/// Tracked under reinhardt-web#3971.
+fn parse_strip_arguments(input: ParseStream) -> Result<Vec<StripArgument>> {
+	let mut args = Vec::new();
+
+	while !input.is_empty() {
+		let span = input.span();
+		let name: Ident = input.parse()?;
+		input.parse::<Token![:]>()?;
+		let value: Expr = input.parse()?;
+		args.push(StripArgument { name, value, span });
+		parse_optional_comma(input)?;
+	}
+
+	Ok(args)
 }
 
 /// Parses server-side validators inside the `validators: { ... }` block.

--- a/crates/reinhardt-manouche/src/validator/form.rs
+++ b/crates/reinhardt-manouche/src/validator/form.rs
@@ -19,13 +19,13 @@ use syn::{Error, Result};
 use crate::core::{
 	FormAction, FormCallbacks, FormDerived, FormFieldDef, FormFieldEntry, FormFieldGroup,
 	FormFieldProperty, FormMacro, FormMethod, FormSlots, FormState, FormSubmitButtonDef,
-	FormValidator, FormWatch, IconAttr, IconChild, IconPosition, TypedChoicesConfig,
+	FormValidator, FormWatch, IconAttr, IconChild, IconPosition, StripArgument, TypedChoicesConfig,
 	TypedCustomAttr, TypedDerivedItem, TypedFieldDisplay, TypedFieldStyling, TypedFieldType,
 	TypedFieldValidation, TypedFormAction, TypedFormCallbacks, TypedFormDerived, TypedFormFieldDef,
 	TypedFormFieldEntry, TypedFormFieldGroup, TypedFormMacro, TypedFormSlots, TypedFormState,
 	TypedFormStyling, TypedFormValidator, TypedFormWatch, TypedFormWatchItem, TypedIcon,
-	TypedIconAttr, TypedIconChild, TypedIconPosition, TypedSubmitButtonDef, TypedValidatorRule,
-	TypedWidget, TypedWrapper, TypedWrapperAttr, ValidatorRule,
+	TypedIconAttr, TypedIconChild, TypedIconPosition, TypedStripArgument, TypedSubmitButtonDef,
+	TypedValidatorRule, TypedWidget, TypedWrapper, TypedWrapperAttr, ValidatorRule,
 };
 
 /// Validates and transforms the FormMacro AST into a typed AST.
@@ -78,6 +78,9 @@ pub fn validate_form(ast: &FormMacro) -> Result<TypedFormMacro> {
 	// Transform unified validators (scope filtering happens at codegen)
 	let validators = transform_validators(&ast.validators, &ast.fields)?;
 
+	// Transform stripped server_fn arguments (reinhardt-web#3971).
+	let strip_arguments = transform_strip_arguments(&ast.strip_arguments, &ast.fields)?;
+
 	// The parser guarantees that `name` is Some after successful parsing.
 	let name = ast
 		.name
@@ -99,6 +102,7 @@ pub fn validate_form(ast: &FormMacro) -> Result<TypedFormMacro> {
 		slots,
 		fields,
 		validators,
+		strip_arguments,
 		span: ast.span,
 	})
 }
@@ -1166,6 +1170,51 @@ fn extract_choices_config(properties: &[FormFieldProperty]) -> Option<TypedChoic
 			span,
 		)
 	})
+}
+
+/// Transforms `strip_arguments` entries into their typed form.
+///
+/// Validates two constraints:
+/// 1. No duplicate argument names (each server_fn parameter may only be supplied once).
+/// 2. No collision with declared form field names (would shadow a real input).
+///
+/// Tracked under reinhardt-web#3971.
+fn transform_strip_arguments(
+	args: &[StripArgument],
+	fields: &[FormFieldEntry],
+) -> Result<Vec<TypedStripArgument>> {
+	let mut seen = HashSet::new();
+	let mut typed = Vec::with_capacity(args.len());
+
+	for arg in args {
+		let name_str = arg.name.to_string();
+
+		if !seen.insert(name_str.clone()) {
+			return Err(Error::new(
+				arg.span,
+				format!(
+					"duplicate strip_arguments entry '{name_str}': each server_fn argument may only appear once"
+				),
+			));
+		}
+
+		if field_exists(fields, &arg.name) {
+			return Err(Error::new(
+				arg.span,
+				format!(
+					"strip_arguments key '{name_str}' collides with a declared form field; either rename the field or remove this strip entry"
+				),
+			));
+		}
+
+		typed.push(TypedStripArgument {
+			name: arg.name.clone(),
+			value: arg.value.clone(),
+			span: arg.span,
+		});
+	}
+
+	Ok(typed)
 }
 
 /// Checks if a field with the given name exists in the field entries.

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -1504,9 +1504,38 @@ fn generate_submit_method(macro_ast: &TypedFormMacro, pages_crate: &TokenStream)
 			// Check if CSRF token should be auto-injected as a server_fn argument
 			let has_explicit_csrf_field = all_fields.iter().any(|f| f.name == "csrf_token");
 			let needs_csrf = !matches!(macro_ast.method, FormMethod::Get);
-			let submit_server_fn_call = if needs_csrf && !has_explicit_csrf_field {
+
+			// reinhardt-web#3971: Generic strip_arguments take precedence over the
+			// implicit CSRF auto-injection. When the user supplies any
+			// `strip_arguments: { ... }` entries we route exactly those values to
+			// the server_fn — no hidden additional arguments — so the call signature
+			// matches what the user wrote in their server_fn definition.
+			let strip_arg_exprs: Vec<&syn::Expr> = macro_ast
+				.strip_arguments
+				.iter()
+				.map(|arg| &arg.value)
+				.collect();
+
+			let submit_server_fn_call = if !strip_arg_exprs.is_empty() {
+				// Explicit strip_arguments path: append exactly the user-supplied
+				// expressions positionally after the form-field arguments.
 				quote! {
 					{
+						#server_fn_ident(#(self.#field_names.get(),)* #(#strip_arg_exprs),*).await
+					}
+				}
+			} else if needs_csrf && !has_explicit_csrf_field {
+				// Backward-compatible CSRF auto-injection path. Triggers a
+				// deprecation warning at compile time so users migrate to
+				// explicit `strip_arguments: { csrf_token: ... }` (reinhardt-web#3971).
+				quote! {
+					{
+						#[deprecated(
+							since = "0.1.0-rc.22",
+							note = "implicit CSRF token injection is deprecated; declare `csrf_token: String` on the server_fn and pass it via `strip_arguments: { csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default() }`. See reinhardt-web#3971."
+						)]
+						const __FORM_CSRF_AUTO_INJECT_DEPRECATED: () = ();
+						let _ = __FORM_CSRF_AUTO_INJECT_DEPRECATED;
 						let __csrf_token = #pages_crate::csrf::get_csrf_token()
 							.unwrap_or_default();
 						#server_fn_ident(#(self.#field_names.get(),)* __csrf_token).await

--- a/crates/reinhardt-pages/macros/src/form/validator.rs
+++ b/crates/reinhardt-pages/macros/src/form/validator.rs
@@ -19,13 +19,13 @@ use syn::{Error, Result};
 use reinhardt_manouche::core::{
 	FormAction, FormCallbacks, FormDerived, FormFieldDef, FormFieldEntry, FormFieldGroup,
 	FormFieldProperty, FormMacro, FormMethod, FormSlots, FormState, FormSubmitButtonDef,
-	FormValidator, FormWatch, IconPosition, TypedChoicesConfig, TypedCustomAttr, TypedDerivedItem,
-	TypedFieldDisplay, TypedFieldStyling, TypedFieldType, TypedFieldValidation, TypedFormAction,
-	TypedFormCallbacks, TypedFormDerived, TypedFormFieldDef, TypedFormFieldEntry,
+	FormValidator, FormWatch, IconPosition, StripArgument, TypedChoicesConfig, TypedCustomAttr,
+	TypedDerivedItem, TypedFieldDisplay, TypedFieldStyling, TypedFieldType, TypedFieldValidation,
+	TypedFormAction, TypedFormCallbacks, TypedFormDerived, TypedFormFieldDef, TypedFormFieldEntry,
 	TypedFormFieldGroup, TypedFormMacro, TypedFormSlots, TypedFormState, TypedFormStyling,
 	TypedFormValidator, TypedFormWatch, TypedFormWatchItem, TypedIcon, TypedIconAttr,
-	TypedIconChild, TypedIconPosition, TypedSubmitButtonDef, TypedValidatorRule, TypedWidget,
-	TypedWrapper, TypedWrapperAttr, ValidatorRule,
+	TypedIconChild, TypedIconPosition, TypedStripArgument, TypedSubmitButtonDef,
+	TypedValidatorRule, TypedWidget, TypedWrapper, TypedWrapperAttr, ValidatorRule,
 };
 
 /// Allowlist of safe HTML tag names for wrapper and icon child elements.
@@ -161,6 +161,9 @@ pub(super) fn validate(ast: &FormMacro) -> Result<TypedFormMacro> {
 	// Transform unified validators (scope filtering happens at codegen)
 	let validators = transform_validators(&ast.validators, &ast.fields)?;
 
+	// Transform stripped server_fn arguments (reinhardt-web#3971).
+	let strip_arguments = transform_strip_arguments(&ast.strip_arguments, &ast.fields)?;
+
 	// The parser guarantees that `name` is Some after successful parsing.
 	let name = ast
 		.name
@@ -182,6 +185,7 @@ pub(super) fn validate(ast: &FormMacro) -> Result<TypedFormMacro> {
 		slots,
 		fields,
 		validators,
+		strip_arguments,
 		span: ast.span,
 	})
 }
@@ -1235,6 +1239,51 @@ fn extract_choices_config(properties: &[FormFieldProperty]) -> Option<TypedChoic
 			span,
 		)
 	})
+}
+
+/// Transforms `strip_arguments` entries into their typed form.
+///
+/// Validates two constraints:
+/// 1. No duplicate argument names (each server_fn parameter may only be supplied once).
+/// 2. No collision with declared form field names (would shadow a real input).
+///
+/// Tracked under reinhardt-web#3971.
+fn transform_strip_arguments(
+	args: &[StripArgument],
+	fields: &[FormFieldEntry],
+) -> Result<Vec<TypedStripArgument>> {
+	let mut seen = HashSet::new();
+	let mut typed = Vec::with_capacity(args.len());
+
+	for arg in args {
+		let name_str = arg.name.to_string();
+
+		if !seen.insert(name_str.clone()) {
+			return Err(Error::new(
+				arg.span,
+				format!(
+					"duplicate strip_arguments entry '{name_str}': each server_fn argument may only appear once"
+				),
+			));
+		}
+
+		if field_exists(fields, &arg.name) {
+			return Err(Error::new(
+				arg.span,
+				format!(
+					"strip_arguments key '{name_str}' collides with a declared form field; either rename the field or remove this strip entry"
+				),
+			));
+		}
+
+		typed.push(TypedStripArgument {
+			name: arg.name.clone(),
+			value: arg.value.clone(),
+			span: arg.span,
+		});
+	}
+
+	Ok(typed)
 }
 
 /// Checks if a field with the given name exists in the field entries.

--- a/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_duplicate_key.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_duplicate_key.rs
@@ -1,0 +1,23 @@
+//! Duplicate keys inside `strip_arguments: { ... }` must be rejected
+//! (reinhardt-web#3971). Each server_fn argument may only be supplied once.
+
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: DupForm,
+		server_fn: submit,
+		method: Post,
+
+		fields: {
+			payload: CharField { required },
+		},
+
+		strip_arguments: {
+			csrf_token: String::new(),
+			csrf_token: String::from("again"),
+		},
+	};
+}
+
+fn submit() {}

--- a/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_duplicate_key.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_duplicate_key.stderr
@@ -1,0 +1,5 @@
+error: duplicate strip_arguments entry 'csrf_token': each server_fn argument may only appear once
+  --> tests/ui/form/fail/strip_arguments_duplicate_key.rs:18:4
+   |
+18 |             csrf_token: String::from("again"),
+   |             ^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_field_collision.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_field_collision.rs
@@ -1,0 +1,26 @@
+//! `strip_arguments` keys must not collide with declared form field names
+//! (reinhardt-web#3971).
+//!
+//! A collision would mean the same identifier is both a user-facing input and
+//! a stripped server_fn argument, which is ambiguous. The validator must reject
+//! this at compile time.
+
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: ConflictForm,
+		server_fn: submit,
+		method: Post,
+
+		fields: {
+			tenant_id: IntegerField { required },
+		},
+
+		strip_arguments: {
+			tenant_id: 0u64,
+		},
+	};
+}
+
+fn submit() {}

--- a/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_field_collision.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_field_collision.stderr
@@ -1,0 +1,5 @@
+error: strip_arguments key 'tenant_id' collides with a declared form field; either rename the field or remove this strip entry
+  --> tests/ui/form/fail/strip_arguments_field_collision.rs:21:4
+   |
+21 |             tenant_id: 0u64,
+   |             ^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/pass/strip_arguments_basic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/strip_arguments_basic.rs
@@ -1,0 +1,47 @@
+//! form! macro with explicit `strip_arguments` (reinhardt-web#3971).
+//!
+//! `strip_arguments` lets the user supply server_fn arguments that should not
+//! appear as user-facing form fields. This test exercises the common case of
+//! routing a CSRF token explicitly instead of relying on the deprecated
+//! implicit auto-injection path.
+
+use reinhardt_pages::form;
+
+fn main() {
+	// Server_fn declares both data fields and a CSRF parameter explicitly.
+	// `strip_arguments` supplies the csrf_token expression at submit time.
+	let _vote_form = form! {
+		name: VoteForm,
+		server_fn: submit_vote,
+		method: Post,
+
+		fields: {
+			_question_id: IntegerField { widget: HiddenInput },
+			_choice_id: IntegerField { required },
+		},
+
+		strip_arguments: {
+			csrf_token: String::new(),
+		},
+	};
+
+	// Multiple stripped arguments append in source order.
+	let _multi_form = form! {
+		name: MultiForm,
+		server_fn: submit_multi,
+		method: Post,
+
+		fields: {
+			_payload: CharField { required },
+		},
+
+		strip_arguments: {
+			csrf_token: String::new(),
+			tenant_id: 0u64,
+		},
+	};
+}
+
+// Mock server functions (would normally be defined with #[server_fn]).
+fn submit_vote() {}
+fn submit_multi() {}

--- a/examples/examples-tutorial-basis/src/client/components/polls.rs
+++ b/examples/examples-tutorial-basis/src/client/components/polls.rs
@@ -104,8 +104,11 @@ pub fn polls_detail(question_id: i64) -> Page {
 		);
 
 	// Create the voting form using form! macro
-	// - server_fn: submit_vote accepts (question_id: String, choice_id: String)
-	// - method: Post enables automatic CSRF token injection
+	// - server_fn: submit_vote accepts (question_id, choice_id, csrf_token)
+	// - method: Post enables CSRF hidden input rendering for non-WASM submits
+	// - strip_arguments: explicitly routes the CSRF token to the trailing
+	//   server_fn argument (reinhardt-web#3971), replacing the implicit
+	//   auto-injection that broke when server_fn signatures evolved.
 	// - state: loading/error signals for form submission feedback
 	// - watch blocks for reactive UI updates
 	let voting_form = form! {
@@ -127,6 +130,11 @@ pub fn polls_detail(question_id: i64) -> Page {
 				choice_value: "id",
 				choice_label: "choice_text",
 			},
+		},
+
+		strip_arguments: {
+			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token()
+				.unwrap_or_default(),
 		},
 
 		watch: {

--- a/examples/examples-tutorial-basis/src/server_fn/polls.rs
+++ b/examples/examples-tutorial-basis/src/server_fn/polls.rs
@@ -148,10 +148,17 @@ pub async fn get_vote_form_metadata() -> std::result::Result<FormMetadata, Serve
 ///
 /// Wrapper function that accepts individual field values from form! macro's submit.
 /// Converts String field values to the required types and calls the underlying vote function.
+///
+/// The trailing `_csrf_token: String` argument is supplied by `form!`'s
+/// `strip_arguments` block (reinhardt-web#3971). Actual CSRF verification is
+/// performed by the server-side CSRF middleware before this handler runs;
+/// receiving the value here keeps the WASM client stub's positional argument
+/// list aligned with the server signature.
 #[server_fn]
 pub async fn submit_vote(
 	question_id: String,
 	choice_id: String,
+	_csrf_token: String,
 	#[inject] db: reinhardt::DatabaseConnection,
 ) -> std::result::Result<ChoiceInfo, ServerFnError> {
 	let question_id: i64 = question_id


### PR DESCRIPTION
## Summary

Generalizes the `form!` macro's CSRF token handling into a first-class
`strip_arguments` mechanism, fixing a WASM build failure in the polls
tutorial reference implementation and removing an opaque convention that
silently appended a `__csrf_token: String` argument to every non-GET
server_fn call.

- Add `strip_arguments: { ident: expr, ... }` to the `form!` macro surface
- AST: `StripArgument` and `TypedStripArgument` nodes wired through the
  manouche parser/validator pipeline
- Validator: rejects duplicate keys and collisions with declared form fields
- Codegen: when present, strip_arguments expressions are appended
  positionally to the server_fn call; the legacy auto-injection path
  remains for backward compatibility but emits a deprecation marker
- Tests: three trybuild fixtures (one pass, two fail)
- Examples migration: `examples-tutorial-basis::submit_vote` now declares
  `csrf_token: String` explicitly and the `VotingForm` `form!` block
  routes the token via `strip_arguments`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [x] Refactoring (replaces implicit auto-injection with explicit DSL)
- [x] Documentation update (rustdoc on `StripArgument` + DSL header)

## Motivation and Context

Issue #3971 reported that the polls tutorial reference implementation
fails to compile for `wasm32-unknown-unknown` against rc.21:

```
error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> src/client/components/polls.rs:113:14
note: function defined here
   --> src/server_fn/polls.rs:152:14
```

Root cause: `crates/reinhardt-pages/macros/src/form/codegen.rs:1507-1517`
silently appends a `__csrf_token: String` to every `method != Get`
server_fn call, but `submit_vote` did not declare a CSRF parameter.
This pattern violates Reinhardt's design philosophy ("Magic must be
understandable" / "Confusable APIs are bad APIs") because the appended
argument is invisible at the form! call-site.

The fix introduces a generic, declarative replacement: `strip_arguments`
lets users explicitly route any expression to the server_fn, and the
mechanism is not CSRF-specific. Existing forms continue to work via a
backward-compatible auto-injection path that nudges users toward
migration with a compile-time deprecation marker.

Fixes #3971

## How Was This Tested?

- `cargo check -p reinhardt-pages -p reinhardt-pages-macros -p reinhardt-manouche`
  passes locally.
- New trybuild fixtures cover:
  - `pass/strip_arguments_basic`: explicit csrf_token routing + multi-entry case
  - `fail/strip_arguments_field_collision`: rejects keys that shadow form fields
  - `fail/strip_arguments_duplicate_key`: rejects repeated keys
- Existing `pass/csrf_auto_injection` retained to verify the
  backward-compatible auto-injection path still works for unmigrated forms.
- `cargo fmt --all` applied.
- WASM build of `examples/examples-tutorial-basis` (the original
  reproducer) is the next verification step on CI.

## Migration Guide

For users currently relying on the implicit CSRF auto-injection:

```rust
// Before (rc.21 and earlier)
#[server_fn]
pub async fn submit(payload: String) -> Result<(), ServerFnError> { /* ... */ }

form! {
    server_fn: submit,
    method: Post,
    fields: { payload: CharField { required } },
}

// After (this PR onward)
#[server_fn]
pub async fn submit(
    payload: String,
    _csrf_token: String,
) -> Result<(), ServerFnError> { /* ... */ }

form! {
    server_fn: submit,
    method: Post,
    fields: { payload: CharField { required } },
    strip_arguments: {
        csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token()
            .unwrap_or_default(),
    },
}
```

CSRF verification continues to run in the server-side CSRF middleware;
the receiving handler may discard the value (`_csrf_token`).

## Labels to Apply

- `bug`
- `documentation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)