### PR TITLE
docs(admin-cli): document install command for RC phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,13 @@ If you have written `ModelSerializer` or `Depends()` before, Reinhardt will feel
 
 ## Quick Start
 
+<!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli
+# During the RC phase, `cargo install` requires an explicit `--version`
+# because pre-releases are not selected by default. Once a stable release
+# ships, `cargo install reinhardt-admin-cli` (no flag) will also work.
+cargo install reinhardt-admin-cli --version "0.1.0-rc.21"
+
 reinhardt-admin startproject my-api && cd my-api
 cargo run --bin manage runserver  # Visit http://127.0.0.1:8000
 ```
@@ -202,8 +207,14 @@ The main Reinhardt crate is published on crates.io as `reinhardt-web`, but you i
 
 ### 1. Install Reinhardt Admin Tool
 
+During the RC phase, only release-candidate versions are published to
+crates.io, so `cargo install` requires an explicit `--version`. The version
+shown below is auto-bumped by release-plz on each release. After a stable
+release ships, `cargo install reinhardt-admin-cli` (no flag) will also work.
+
+<!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli
+cargo install reinhardt-admin-cli --version "0.1.0-rc.21"
 ```
 
 ### 2. Create a New Project

--- a/crates/reinhardt-admin-cli/README.md
+++ b/crates/reinhardt-admin-cli/README.md
@@ -8,10 +8,14 @@ Global command-line tool for Reinhardt project management.
 
 ## Installation
 
-Install globally using cargo:
+Install globally using cargo. During the RC phase, only release-candidate
+versions are published to crates.io, so `cargo install` requires an explicit
+`--version`. The version shown below is auto-bumped by release-plz on each
+release. After a stable release ships, the bare command will also work.
 
+<!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli
+cargo install reinhardt-admin-cli --version "0.1.0-rc.21"
 ```
 
 This installs the `reinhardt-admin` command.

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -7,8 +7,13 @@
 //!
 //! ## Installation
 //!
+//! During the RC phase, only release-candidate versions are published to
+//! crates.io, so `cargo install` requires an explicit `--version`. The
+//! version below is auto-bumped by release-plz on each release.
+//!
+//! <!-- reinhardt-version-sync -->
 //! ```bash
-//! cargo install reinhardt-admin-cli
+//! cargo install reinhardt-admin-cli --version "0.1.0-rc.21"
 //! ```
 //!
 //! ## Usage

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -35,8 +35,11 @@ use reinhardt::commands::{BaseCommand, CommandRegistry};
 For creating new projects and apps, use the separate `reinhardt-admin-cli`
 package:
 
+<!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli
+# During the RC phase, `cargo install` requires an explicit `--version`.
+# The version below is auto-bumped by release-plz on each release.
+cargo install reinhardt-admin-cli --version "0.1.0-rc.21"
 ```
 
 This installs the `reinhardt-admin` command:

--- a/scripts/update-version-refs.sh
+++ b/scripts/update-version-refs.sh
@@ -60,6 +60,7 @@ else
 		"examples/Cargo.toml"
 		"examples/CLAUDE.md"
 		"website/config.toml"
+		"crates/reinhardt-admin-cli/src/main.rs"
 	)
 	while IFS= read -r f; do
 		TARGETS+=("$f")
@@ -68,6 +69,11 @@ else
 	while IFS= read -r f; do
 		TARGETS+=("$f")
 	done < <(find "$REPO_ROOT/docs" -name "*.md" | sort | \
+	          sed "s|$REPO_ROOT/||")
+	# Quickstart and tutorial pages (Hugo content, not under docs/)
+	while IFS= read -r f; do
+		TARGETS+=("$f")
+	done < <(find "$REPO_ROOT/website/content" -name "*.md" 2>/dev/null | sort | \
 	          sed "s|$REPO_ROOT/||")
 fi
 
@@ -85,12 +91,19 @@ echo "Updating version references to $NEW_VER in $REPO_ROOT"
 
 AWK_PROG='
 BEGIN {
+	# Marker forms accepted:
+	#   # reinhardt-version-sync                    (TOML / shell / Python)
+	#   // reinhardt-version-sync                   (Rust / TypeScript regular comment)
+	#   <!-- reinhardt-version-sync -->             (Markdown / HTML)
+	#   //! <!-- reinhardt-version-sync -->         (Rust rustdoc inner-comment block)
+	#   <!-- reinhardt-version-sync:N --> + variant Rustdoc form (count = N)
 	marker_re      = "^[[:space:]]*(#|//)[[:space:]]*reinhardt-version-sync[[:space:]]*$"
-	marker_html_re = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync[[:space:]]*-->[[:space:]]*$"
-	marker_html_n  = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync:[0-9]+[[:space:]]*-->[[:space:]]*$"
+	marker_html_re = "^[[:space:]]*(//![[:space:]]+)?<!--[[:space:]]*reinhardt-version-sync[[:space:]]*-->[[:space:]]*$"
+	marker_html_n  = "^[[:space:]]*(//![[:space:]]+)?<!--[[:space:]]*reinhardt-version-sync:[0-9]+[[:space:]]*-->[[:space:]]*$"
 	version_re     = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
-	fence_re       = "^[[:space:]]*```"
-	blank_re       = "^[[:space:]]*$"
+	# Code fence with optional rustdoc inner-comment prefix `//! `
+	fence_re       = "^[[:space:]]*(//![[:space:]]+)?```"
+	blank_re       = "^[[:space:]]*(//![[:space:]]*)?$"
 	state        = "SCANNING"
 	armed_count  = 0
 	in_code_block = 0

--- a/scripts/validate-version-markers.sh
+++ b/scripts/validate-version-markers.sh
@@ -23,6 +23,7 @@ else
 		"examples/Cargo.toml"
 		"examples/CLAUDE.md"
 		"website/config.toml"
+		"crates/reinhardt-admin-cli/src/main.rs"
 	)
 	while IFS= read -r f; do
 		TARGETS+=("$f")
@@ -32,18 +33,29 @@ else
 		TARGETS+=("$f")
 	done < <(find "$REPO_ROOT/docs" -name "*.md" | sort | \
 	          sed "s|$REPO_ROOT/||")
+	while IFS= read -r f; do
+		TARGETS+=("$f")
+	done < <(find "$REPO_ROOT/website/content" -name "*.md" 2>/dev/null | sort | \
+	          sed "s|$REPO_ROOT/||")
 fi
 
 AWK_PROG='
 BEGIN {
+	# Marker forms (mirrored in scripts/update-version-refs.sh):
+	#   # reinhardt-version-sync                    (TOML / shell / Python)
+	#   // reinhardt-version-sync                   (Rust / TypeScript regular comment)
+	#   <!-- reinhardt-version-sync -->             (Markdown / HTML)
+	#   //! <!-- reinhardt-version-sync -->         (Rust rustdoc inner-comment block)
+	#   <!-- reinhardt-version-sync:N --> + variant rustdoc form (count = N)
 	marker_re      = "^[[:space:]]*(#|//)[[:space:]]*reinhardt-version-sync[[:space:]]*$"
-	marker_html_re = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync[[:space:]]*-->[[:space:]]*$"
-	marker_html_n  = "^[[:space:]]*<!--[[:space:]]*reinhardt-version-sync:[0-9]+[[:space:]]*-->[[:space:]]*$"
+	marker_html_re = "^[[:space:]]*(//![[:space:]]+)?<!--[[:space:]]*reinhardt-version-sync[[:space:]]*-->[[:space:]]*$"
+	marker_html_n  = "^[[:space:]]*(//![[:space:]]+)?<!--[[:space:]]*reinhardt-version-sync:[0-9]+[[:space:]]*-->[[:space:]]*$"
 	# Hints that a line carries a Reinhardt version we should have marked.
 	hint_re    = "(reinhardt[a-z-]*[[:space:]]*=|reinhardt_version[[:space:]]*=|package[[:space:]]*=[[:space:]]*\"reinhardt-web\")"
 	version_re = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
-	fence_re   = "^[[:space:]]*```"
-	blank_re   = "^[[:space:]]*$"
+	# Code fence with optional rustdoc inner-comment prefix `//! `
+	fence_re   = "^[[:space:]]*(//![[:space:]]+)?```"
+	blank_re   = "^[[:space:]]*(//![[:space:]]*)?$"
 	state       = "SCANNING"
 	armed_count = 0
 	findings    = 0

--- a/website/content/quickstart/_index.md
+++ b/website/content/quickstart/_index.md
@@ -11,8 +11,14 @@ Get up and running with Reinhardt in 5 minutes.
 
 ## 1. Install Reinhardt Admin CLI
 
+During the RC phase, only release-candidate versions are published to
+crates.io, so `cargo install` requires an explicit `--version`. The version
+below is auto-bumped by release-plz on each release. Once a stable release
+ships, the bare `cargo install reinhardt-admin-cli` will also work.
+
+<!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli
+cargo install reinhardt-admin-cli --version "0.1.0-rc.21"
 ```
 
 ## 2. Create your project

--- a/website/content/quickstart/getting-started.md
+++ b/website/content/quickstart/getting-started.md
@@ -25,8 +25,14 @@ Before you begin, make sure you have:
 
 ### Step 1: Install Reinhardt Admin
 
+During the RC phase, only release-candidate versions are published to
+crates.io, so `cargo install` requires an explicit `--version`. The version
+below is auto-bumped by release-plz on each release. Once a stable release
+ships, the bare `cargo install reinhardt-admin-cli` will also work.
+
+<!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli
+cargo install reinhardt-admin-cli --version "0.1.0-rc.21"
 ```
 
 **Note:** After installation, the command is `reinhardt-admin`, not

--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -24,10 +24,15 @@ You should see version information for both commands. If not, visit
 
 ## Installing Reinhardt Admin CLI
 
-First, install the global tool for project generation:
+First, install the global tool for project generation. During the RC phase,
+only release-candidate versions are published to crates.io, so
+`cargo install` requires an explicit `--version`. The version below is
+auto-bumped by release-plz on each release. Once a stable release ships, the
+bare `cargo install reinhardt-admin-cli` will also work.
 
+<!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli
+cargo install reinhardt-admin-cli --version "0.1.0-rc.21"
 ```
 
 ## Creating a Project

--- a/website/content/quickstart/tutorials/rest/quickstart.md
+++ b/website/content/quickstart/tutorials/rest/quickstart.md
@@ -12,10 +12,15 @@ Create a simple API for administrators to view and edit users and groups in the 
 
 ## Project Setup
 
-First, install the global tool:
+First, install the global tool. During the RC phase, only release-candidate
+versions are published to crates.io, so `cargo install` requires an explicit
+`--version`. The version below is auto-bumped by release-plz on each release.
+Once a stable release ships, the bare `cargo install reinhardt-admin-cli`
+will also work.
 
+<!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli
+cargo install reinhardt-admin-cli --version "0.1.0-rc.21"
 ```
 
 **Note:** After installation, the command is `reinhardt-admin`, not `reinhardt-admin-cli`.


### PR DESCRIPTION
## Summary

This PR addresses:

- `cargo install reinhardt-admin-cli` (no flag) fails during the RC phase because cargo install does not select pre-releases by default. Document `--version "0.1.0-rc.21"` alongside every existing install snippet (9 occurrences) and wire them into the existing `reinhardt-version-sync` marker system so release-plz auto-bumps the documented version on each release.

## Type of Change

- [x] Documentation update

## Motivation and Context

Reported in #3969: `cargo install reinhardt-admin-cli` returns `could not find ... in registry crates-io with version *` because only RC versions are published. The documented quick-start commands therefore do not work as written. The maintainer reply on #3969 commits to fixing the document by also writing a command that is valid during the RC phase.

Fixes #3969

## How Was This Tested?

- `bash scripts/validate-version-markers.sh` → 83 files OK
- `bash scripts/tests/test-validate-version-markers.sh` → all PASS (V1–V4)
- `bash scripts/tests/test-update-version-refs.sh` → all PASS (01–06)
- `bash scripts/update-version-refs.sh 0.1.0-rc.99 --dry-run` → all 9 newly-marked occurrences are detected and their version is rewritten, including the new targets (`crates/reinhardt-admin-cli/src/main.rs` rustdoc and `website/content/quickstart/**/*.md`).
- `cargo doc --no-deps -p reinhardt-admin-cli` → builds without warnings.

## Files Changed

Documentation snippets updated (9 occurrences across 7 files):

- `README.md` (Quick Start, Getting Started Guide)
- `crates/reinhardt-admin-cli/README.md`
- `crates/reinhardt-admin-cli/src/main.rs` (rustdoc)
- `crates/reinhardt-commands/README.md`
- `website/content/quickstart/_index.md`
- `website/content/quickstart/getting-started.md`
- `website/content/quickstart/tutorials/basis/1-project-setup.md`
- `website/content/quickstart/tutorials/rest/quickstart.md`

Sync infrastructure extended:

- `scripts/update-version-refs.sh` and `scripts/validate-version-markers.sh`:
  - TARGETS gain `crates/reinhardt-admin-cli/src/main.rs` and `website/content/**/*.md`
  - `marker_html_re` / `marker_html_n` accept an optional `//! ` rustdoc prefix
  - `fence_re` / `blank_re` accept the same prefix so rustdoc-prefixed code fences are skipped correctly during ARMED scanning

## Labels to Apply

- `documentation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)