### PR TITLE
test(admin): expand dashboard frontend E2E coverage with 6 new tests

### DIFF
--- a/crates/reinhardt-admin/tests/e2e_pages.rs
+++ b/crates/reinhardt-admin/tests/e2e_pages.rs
@@ -44,6 +44,11 @@ const TEST_PASSWORD: &str = "e2e-test-password-2026";
 const TEST_USER_UUID: &str = "00000000-0000-0000-0000-000000000001";
 const JWT_SECRET: &[u8] = b"e2e-test-jwt-secret-at-least-32-bytes!!";
 
+// Non-staff user credentials used by `test_dashboard_non_staff_user_blocked`.
+const NON_STAFF_USERNAME: &str = "test_non_staff";
+const NON_STAFF_PASSWORD: &str = "e2e-test-non-staff-pw-2026";
+const NON_STAFF_UUID: &str = "00000000-0000-0000-0000-000000000002";
+
 // ============================================================================
 // AllPermissionsModelAdmin (same pattern as server_fn_helpers.rs)
 // ============================================================================
@@ -190,23 +195,39 @@ struct E2eContext {
 	/// The browser page (one per test).
 	#[allow(dead_code)]
 	browser: CdpBrowser,
+	/// The configured admin `site_header` (sourced from `AdminSettings::default()`).
+	///
+	/// Tests assert against this value rather than hard-coding "Administration",
+	/// so changes to the default propagate automatically.
+	site_header: String,
+	/// Direct pool handle for tests that need additional DB setup
+	/// (e.g., inserting a non-staff user).
+	#[allow(dead_code)]
+	pool: sqlx::PgPool,
 	// Hold server and db alive for the test lifetime.
 	_server: TestServer,
 	_admin_db: Arc<AdminDatabase>,
 }
 
-/// Fixture that creates a fully isolated E2E environment:
-/// 1. Fresh PostgreSQL database with test data (testcontainers)
-/// 2. HTTP server on a random port bound to 0.0.0.0
-/// 3. Headless Chrome in a Docker container (testcontainers)
-#[fixture]
-async fn e2e(
-	#[future] shared_db_pool: (sqlx::PgPool, String),
-	#[future] cdp_browser: CdpBrowser,
-) -> E2eContext {
-	let (pool, _) = shared_db_pool.await;
-	let browser = cdp_browser.await;
-
+/// Build a fully isolated E2E context with caller-controlled model registration.
+///
+/// Common setup performed here:
+/// 1. Creates `test_models` and `test_models_b` tables (idempotent) and seeds
+///    `test_models` with three records.
+/// 2. Drops and recreates `auth_user`, inserting one staff user.
+/// 3. Constructs `AdminSite`, invokes `register_models` to register zero or more
+///    `ModelAdmin` instances, builds the router, and starts the test HTTP server.
+///
+/// The closure pattern lets tests vary which models are registered while sharing
+/// the rest of the setup, avoiding ~80 lines of duplication per fixture.
+async fn build_e2e_context<F>(
+	pool: sqlx::PgPool,
+	browser: CdpBrowser,
+	register_models: F,
+) -> E2eContext
+where
+	F: FnOnce(&Arc<AdminSite>),
+{
 	// ---- Database setup ----
 
 	pool.execute(
@@ -233,6 +254,21 @@ async fn e2e(
 	)
 	.await
 	.expect("Failed to insert test data");
+
+	// Second table for `e2e_multi_models`. Created unconditionally because
+	// CREATE TABLE IF NOT EXISTS is harmless for fixtures that ignore it.
+	pool.execute(
+		"CREATE TABLE IF NOT EXISTS test_models_b (
+			id SERIAL PRIMARY KEY,
+			name VARCHAR(255) NOT NULL
+		)",
+	)
+	.await
+	.expect("Failed to create test_models_b table");
+
+	pool.execute("TRUNCATE TABLE test_models_b RESTART IDENTITY CASCADE")
+		.await
+		.expect("Failed to truncate test_models_b");
 
 	pool.execute("DROP TABLE IF EXISTS auth_user CASCADE")
 		.await
@@ -277,6 +313,16 @@ async fn e2e(
 
 	// ---- Build router ----
 
+	// Snapshot the configured site_header before consuming the pool so tests
+	// can compare against it without re-fetching.
+	let site_header = reinhardt_admin::settings::get_admin_settings()
+		.site_header
+		.clone();
+
+	// Clone the pool for retention in E2eContext; sqlx::PgPool is Arc-backed
+	// so the clone is cheap.
+	let pool_for_ctx = pool.clone();
+
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
 	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
@@ -286,11 +332,7 @@ async fn e2e(
 	let mut site = AdminSite::new("E2E Test Admin");
 	site.set_jwt_secret(JWT_SECRET);
 	let site = Arc::new(site);
-	site.register(
-		"TestModel",
-		AllPermissionsModelAdmin::test_model("test_models"),
-	)
-	.expect("Failed to register TestModel");
+	register_models(&site);
 
 	let (admin_router, admin_di) = admin_routes_with_di(site);
 
@@ -313,9 +355,71 @@ async fn e2e(
 	E2eContext {
 		server_url,
 		browser,
+		site_header,
+		pool: pool_for_ctx,
 		_server: server,
 		_admin_db: admin_db,
 	}
+}
+
+/// Fixture that creates a fully isolated E2E environment with one TestModel registered:
+/// 1. Fresh PostgreSQL database with test data (testcontainers)
+/// 2. HTTP server on a random port bound to 0.0.0.0
+/// 3. Headless Chrome in a Docker container (testcontainers)
+#[fixture]
+async fn e2e(
+	#[future] shared_db_pool: (sqlx::PgPool, String),
+	#[future] cdp_browser: CdpBrowser,
+) -> E2eContext {
+	let (pool, _) = shared_db_pool.await;
+	let browser = cdp_browser.await;
+	build_e2e_context(pool, browser, |site| {
+		site.register(
+			"TestModel",
+			AllPermissionsModelAdmin::test_model("test_models"),
+		)
+		.expect("Failed to register TestModel");
+	})
+	.await
+}
+
+/// Fixture variant: no models registered. Used to exercise the dashboard
+/// empty-state branch (`No models registered` admin alert).
+#[fixture]
+async fn e2e_no_models(
+	#[future] shared_db_pool: (sqlx::PgPool, String),
+	#[future] cdp_browser: CdpBrowser,
+) -> E2eContext {
+	let (pool, _) = shared_db_pool.await;
+	let browser = cdp_browser.await;
+	build_e2e_context(pool, browser, |_site| {
+		// Intentionally register no models.
+	})
+	.await
+}
+
+/// Fixture variant: two distinct models registered. Used to verify the
+/// dashboard renders one card per registered model.
+#[fixture]
+async fn e2e_multi_models(
+	#[future] shared_db_pool: (sqlx::PgPool, String),
+	#[future] cdp_browser: CdpBrowser,
+) -> E2eContext {
+	let (pool, _) = shared_db_pool.await;
+	let browser = cdp_browser.await;
+	build_e2e_context(pool, browser, |site| {
+		site.register(
+			"TestModel",
+			AllPermissionsModelAdmin::test_model("test_models"),
+		)
+		.expect("Failed to register TestModel");
+		site.register(
+			"TestModelB",
+			AllPermissionsModelAdmin::test_model("test_models_b"),
+		)
+		.expect("Failed to register TestModelB");
+	})
+	.await
 }
 
 // ============================================================================
@@ -395,6 +499,14 @@ async fn wait_for_wasm_init(page: &CdpPage) {
 ///
 /// Waits for WASM to fully load and hydrate before interacting with form elements.
 async fn login_via_form(page: &CdpPage, server_url: &str) {
+	login_via_form_as(page, server_url, TEST_USERNAME, TEST_PASSWORD).await;
+}
+
+/// Performs login as the specified user. Generalization of `login_via_form`.
+///
+/// Used by tests that need to authenticate as a non-default user
+/// (e.g., the non-staff user in `test_dashboard_non_staff_user_blocked`).
+async fn login_via_form_as(page: &CdpPage, server_url: &str, username: &str, password: &str) {
 	page.navigate(&format!("{}/admin/login/", server_url))
 		.await
 		.expect("Failed to navigate to login page");
@@ -402,10 +514,10 @@ async fn login_via_form(page: &CdpPage, server_url: &str) {
 	// Wait for WASM to initialize (downloads ~5.6MB WASM binary in dev mode)
 	wait_for_wasm_init(page).await;
 
-	page.type_into("input[name='username']", TEST_USERNAME)
+	page.type_into("input[name='username']", username)
 		.await
 		.expect("Failed to type username");
-	page.type_into("input[name='password']", TEST_PASSWORD)
+	page.type_into("input[name='password']", password)
 		.await
 		.expect("Failed to type password");
 	page.click("button[type='submit']")
@@ -414,6 +526,71 @@ async fn login_via_form(page: &CdpPage, server_url: &str) {
 
 	// Wait for login server function call to complete and WASM to navigate
 	tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+}
+
+/// Polls until the dashboard resource resolves: either model cards or the
+/// empty-state alert appear inside `.dashboard-container`.
+///
+/// Centralizes wait logic so individual dashboard tests do not need to
+/// guess sleep durations. The poll interval is short (200 ms) and the
+/// total timeout is 15 s, which exceeds typical `get_dashboard()` server
+/// function latencies on CI.
+async fn wait_for_dashboard_loaded(page: &CdpPage) {
+	let start = std::time::Instant::now();
+	let timeout = std::time::Duration::from_secs(15);
+	let poll = std::time::Duration::from_millis(200);
+
+	loop {
+		let ready = page
+			.execute_js(
+				"(() => { \
+				 const c = document.querySelector('.dashboard-container'); \
+				 if (!c) return false; \
+				 return c.querySelector('.admin-card, .admin-alert-info, .admin-alert-danger') !== null; \
+				 })()",
+			)
+			.await
+			.ok()
+			.and_then(|v| v.as_bool())
+			.unwrap_or(false);
+
+		if ready {
+			// Brief settle for any reactive effects after the card grid commits.
+			tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+			return;
+		}
+
+		if start.elapsed() > timeout {
+			panic!(
+				"Dashboard did not finish loading within {:?} (looked for .admin-card, .admin-alert-info, or .admin-alert-danger inside .dashboard-container)",
+				timeout
+			);
+		}
+
+		tokio::time::sleep(poll).await;
+	}
+}
+
+/// Inserts an active non-staff user (`is_active=true`, `is_staff=false`) into
+/// `auth_user`. Used by `test_dashboard_non_staff_user_blocked` to verify the
+/// dashboard rejects users who lack admin privileges.
+async fn create_non_staff_user(pool: &sqlx::PgPool, username: &str, password: &str) {
+	let hasher = Argon2Hasher::new();
+	let password_hash = hasher
+		.hash(password)
+		.expect("Failed to hash non-staff password");
+
+	sqlx::query(
+		"INSERT INTO auth_user (id, username, password_hash, is_active, is_staff, date_joined)
+		 VALUES ($1, $2, $3, true, false, NOW())
+		 ON CONFLICT (id) DO UPDATE SET password_hash = $3, is_staff = false, is_active = true",
+	)
+	.bind(uuid::Uuid::parse_str(NON_STAFF_UUID).unwrap())
+	.bind(username)
+	.bind(&password_hash)
+	.execute(pool)
+	.await
+	.expect("Failed to insert non-staff user");
 }
 
 // ============================================================================

--- a/crates/reinhardt-admin/tests/e2e_pages.rs
+++ b/crates/reinhardt-admin/tests/e2e_pages.rs
@@ -28,12 +28,64 @@ use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection
 use reinhardt_db::backends::dialect::PostgresBackend;
 use reinhardt_db::orm::connection::{DatabaseBackend, DatabaseConnection};
 use reinhardt_di::{InjectionContext, SingletonScope};
+use reinhardt_query::prelude::{
+	ColumnDef, Expr, OnConflict, PostgresQueryBuilder, Query, QueryBuilder, Value,
+};
 use reinhardt_test::fixtures::shared_postgres::shared_db_pool;
 use reinhardt_test::fixtures::wasm::e2e_cdp::*;
 use rstest::*;
-use sqlx::Executor;
 use std::net::SocketAddr;
 use std::sync::Arc;
+
+// ============================================================================
+// SeaQuery <-> sqlx bridge helpers
+// ============================================================================
+//
+// `reinhardt-query` produces a `(sql, Values)` pair from `build_*` calls;
+// sqlx requires each value to be bound individually via `.bind()`. The two
+// helpers below wrap that boilerplate so fixture code can express its DDL
+// and DML through SeaQuery (per project convention) without sprinkling
+// `.bind()` chains in every call site.
+
+/// Bind a single SeaQuery `Value` to a sqlx Postgres query.
+///
+/// Pattern-matches the `Value` variants used by this fixture (Bool, String,
+/// Uuid). Other variants are not currently used and trigger a panic; extend
+/// the match arms when new types become necessary.
+fn bind_pg_value<'q>(
+	query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
+	value: Value,
+) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
+	match value {
+		Value::Bool(v) => query.bind(v),
+		Value::String(v) => query.bind(v.map(|b| *b)),
+		Value::Uuid(v) => query.bind(v.map(|b| *b)),
+		other => panic!("bind_pg_value: unsupported Value variant {:?}", other),
+	}
+}
+
+/// Execute a SeaQuery DML statement (e.g., INSERT) against a Postgres pool.
+///
+/// Binds all values from `Values` to the prepared statement in order.
+async fn execute_dml(pool: &sqlx::PgPool, sql: &str, values: Vec<Value>, context: &str) {
+	let mut q = sqlx::query(sql);
+	for v in values {
+		q = bind_pg_value(q, v);
+	}
+	q.execute(pool)
+		.await
+		.unwrap_or_else(|e| panic!("Failed to execute DML ({}): {}", context, e));
+}
+
+/// Execute a SeaQuery DDL statement (CREATE/DROP/TRUNCATE) against a Postgres pool.
+///
+/// DDL statements have no bind parameters; the generated SQL is executed verbatim.
+async fn execute_ddl(pool: &sqlx::PgPool, sql: &str, context: &str) {
+	sqlx::query(sql)
+		.execute(pool)
+		.await
+		.unwrap_or_else(|e| panic!("Failed to execute DDL ({}): {}", context, e));
+}
 
 // ============================================================================
 // Constants
@@ -228,88 +280,183 @@ async fn build_e2e_context<F>(
 where
 	F: FnOnce(&Arc<AdminSite>),
 {
+	let builder = PostgresQueryBuilder::new();
+
 	// ---- Database setup ----
 
-	pool.execute(
-		"CREATE TABLE IF NOT EXISTS test_models (
-			id SERIAL PRIMARY KEY,
-			name VARCHAR(255) NOT NULL,
-			status VARCHAR(50) DEFAULT 'active',
-			description TEXT,
-			created_at TIMESTAMPTZ DEFAULT NOW()
-		)",
-	)
-	.await
-	.expect("Failed to create test_models table");
+	// CREATE TABLE IF NOT EXISTS test_models (...)
+	let mut create_test_models = Query::create_table();
+	create_test_models
+		.table("test_models")
+		.if_not_exists()
+		.col(
+			ColumnDef::new("id")
+				.integer()
+				.primary_key(true)
+				.auto_increment(true)
+				.not_null(true),
+		)
+		.col(ColumnDef::new("name").string_len(255).not_null(true))
+		.col(
+			ColumnDef::new("status")
+				.string_len(50)
+				.default(Expr::val("active").into()),
+		)
+		.col(ColumnDef::new("description").text())
+		.col(
+			ColumnDef::new("created_at")
+				.timestamp_with_time_zone()
+				.default(Expr::current_timestamp().into()),
+		);
+	let (sql, _) = builder.build_create_table(&create_test_models);
+	execute_ddl(&pool, &sql, "create test_models").await;
 
-	pool.execute("TRUNCATE TABLE test_models RESTART IDENTITY CASCADE")
-		.await
-		.expect("Failed to truncate test_models");
+	// TRUNCATE TABLE test_models RESTART IDENTITY CASCADE
+	let mut truncate_test_models = Query::truncate_table();
+	truncate_test_models
+		.table("test_models")
+		.restart_identity()
+		.cascade();
+	let (sql, _) = builder.build_truncate_table(&truncate_test_models);
+	execute_ddl(&pool, &sql, "truncate test_models").await;
 
-	pool.execute(
-		"INSERT INTO test_models (name, status) VALUES
-		 ('Alice', 'active'),
-		 ('Bob', 'inactive'),
-		 ('Charlie', 'active')",
-	)
-	.await
-	.expect("Failed to insert test data");
+	// Seed test_models with three rows.
+	let mut seed_test_models = Query::insert();
+	seed_test_models
+		.into_table("test_models")
+		.columns(["name", "status"])
+		.values_panic(["Alice", "active"])
+		.values_panic(["Bob", "inactive"])
+		.values_panic(["Charlie", "active"]);
+	let (sql, values) = builder.build_insert(&seed_test_models);
+	execute_dml(&pool, &sql, values.0, "seed test_models").await;
 
-	// Second table for `e2e_multi_models`. Created unconditionally because
-	// CREATE TABLE IF NOT EXISTS is harmless for fixtures that ignore it.
-	pool.execute(
-		"CREATE TABLE IF NOT EXISTS test_models_b (
-			id SERIAL PRIMARY KEY,
-			name VARCHAR(255) NOT NULL
-		)",
-	)
-	.await
-	.expect("Failed to create test_models_b table");
+	// CREATE TABLE IF NOT EXISTS test_models_b (...)
+	// Created unconditionally because IF NOT EXISTS is harmless for fixtures
+	// that don't register a TestModelB.
+	let mut create_test_models_b = Query::create_table();
+	create_test_models_b
+		.table("test_models_b")
+		.if_not_exists()
+		.col(
+			ColumnDef::new("id")
+				.integer()
+				.primary_key(true)
+				.auto_increment(true)
+				.not_null(true),
+		)
+		.col(ColumnDef::new("name").string_len(255).not_null(true));
+	let (sql, _) = builder.build_create_table(&create_test_models_b);
+	execute_ddl(&pool, &sql, "create test_models_b").await;
 
-	pool.execute("TRUNCATE TABLE test_models_b RESTART IDENTITY CASCADE")
-		.await
-		.expect("Failed to truncate test_models_b");
+	let mut truncate_test_models_b = Query::truncate_table();
+	truncate_test_models_b
+		.table("test_models_b")
+		.restart_identity()
+		.cascade();
+	let (sql, _) = builder.build_truncate_table(&truncate_test_models_b);
+	execute_ddl(&pool, &sql, "truncate test_models_b").await;
 
-	pool.execute("DROP TABLE IF EXISTS auth_user CASCADE")
-		.await
-		.expect("Failed to drop auth_user");
+	// DROP TABLE IF EXISTS auth_user CASCADE
+	let mut drop_auth_user = Query::drop_table();
+	drop_auth_user.table("auth_user").if_exists().cascade();
+	let (sql, _) = builder.build_drop_table(&drop_auth_user);
+	execute_ddl(&pool, &sql, "drop auth_user").await;
 
-	pool.execute(
-		"CREATE TABLE auth_user (
-			id UUID PRIMARY KEY,
-			username VARCHAR(150) NOT NULL,
-			email VARCHAR(254) NOT NULL DEFAULT '',
-			first_name VARCHAR(150) NOT NULL DEFAULT '',
-			last_name VARCHAR(150) NOT NULL DEFAULT '',
-			password_hash TEXT,
-			last_login TIMESTAMPTZ,
-			is_active BOOLEAN NOT NULL DEFAULT true,
-			is_staff BOOLEAN NOT NULL DEFAULT false,
-			is_superuser BOOLEAN NOT NULL DEFAULT false,
-			date_joined TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			user_permissions TEXT NOT NULL DEFAULT '[]',
-			groups TEXT NOT NULL DEFAULT '[]'
-		)",
-	)
-	.await
-	.expect("Failed to create auth_user table");
+	// CREATE TABLE auth_user (...)
+	let mut create_auth_user = Query::create_table();
+	create_auth_user
+		.table("auth_user")
+		.col(ColumnDef::new("id").uuid().primary_key(true).not_null(true))
+		.col(ColumnDef::new("username").string_len(150).not_null(true))
+		.col(
+			ColumnDef::new("email")
+				.string_len(254)
+				.not_null(true)
+				.default(Expr::val("").into()),
+		)
+		.col(
+			ColumnDef::new("first_name")
+				.string_len(150)
+				.not_null(true)
+				.default(Expr::val("").into()),
+		)
+		.col(
+			ColumnDef::new("last_name")
+				.string_len(150)
+				.not_null(true)
+				.default(Expr::val("").into()),
+		)
+		.col(ColumnDef::new("password_hash").text())
+		.col(ColumnDef::new("last_login").timestamp_with_time_zone())
+		.col(
+			ColumnDef::new("is_active")
+				.boolean()
+				.not_null(true)
+				.default(Expr::val(true).into()),
+		)
+		.col(
+			ColumnDef::new("is_staff")
+				.boolean()
+				.not_null(true)
+				.default(Expr::val(false).into()),
+		)
+		.col(
+			ColumnDef::new("is_superuser")
+				.boolean()
+				.not_null(true)
+				.default(Expr::val(false).into()),
+		)
+		.col(
+			ColumnDef::new("date_joined")
+				.timestamp_with_time_zone()
+				.not_null(true)
+				.default(Expr::current_timestamp().into()),
+		)
+		.col(
+			ColumnDef::new("user_permissions")
+				.text()
+				.not_null(true)
+				.default(Expr::val("[]").into()),
+		)
+		.col(
+			ColumnDef::new("groups")
+				.text()
+				.not_null(true)
+				.default(Expr::val("[]").into()),
+		);
+	let (sql, _) = builder.build_create_table(&create_auth_user);
+	execute_ddl(&pool, &sql, "create auth_user").await;
 
 	let hasher = Argon2Hasher::new();
 	let password_hash = hasher
 		.hash(TEST_PASSWORD)
 		.expect("Failed to hash test password");
 
-	sqlx::query(
-		"INSERT INTO auth_user (id, username, password_hash, is_active, is_staff, date_joined)
-		 VALUES ($1, $2, $3, true, true, NOW())
-		 ON CONFLICT (id) DO UPDATE SET password_hash = $3, is_staff = true, is_active = true",
-	)
-	.bind(uuid::Uuid::parse_str(TEST_USER_UUID).unwrap())
-	.bind(TEST_USERNAME)
-	.bind(&password_hash)
-	.execute(&pool)
-	.await
-	.expect("Failed to insert test staff user");
+	// INSERT staff user; ON CONFLICT (id) refresh password_hash/is_staff/is_active
+	// from the EXCLUDED row (which carries the values we just attempted to insert).
+	// `date_joined` is omitted so the column DEFAULT (CURRENT_TIMESTAMP) applies.
+	let mut insert_staff = Query::insert();
+	insert_staff
+		.into_table("auth_user")
+		.columns(["id", "username", "password_hash", "is_active", "is_staff"])
+		.values(vec![
+			Value::Uuid(Some(Box::new(
+				uuid::Uuid::parse_str(TEST_USER_UUID).expect("valid TEST_USER_UUID"),
+			))),
+			Value::String(Some(Box::new(TEST_USERNAME.to_string()))),
+			Value::String(Some(Box::new(password_hash.clone()))),
+			Value::Bool(Some(true)),
+			Value::Bool(Some(true)),
+		])
+		.expect("staff user value count matches column count")
+		.on_conflict(
+			OnConflict::column("id")
+				.update_columns(["password_hash", "is_staff", "is_active"])
+				.to_owned(),
+		);
+	let (sql, values) = builder.build_insert(&insert_staff);
+	execute_dml(&pool, &sql, values.0, "insert staff user").await;
 
 	// ---- Build router ----
 
@@ -580,17 +727,28 @@ async fn create_non_staff_user(pool: &sqlx::PgPool, username: &str, password: &s
 		.hash(password)
 		.expect("Failed to hash non-staff password");
 
-	sqlx::query(
-		"INSERT INTO auth_user (id, username, password_hash, is_active, is_staff, date_joined)
-		 VALUES ($1, $2, $3, true, false, NOW())
-		 ON CONFLICT (id) DO UPDATE SET password_hash = $3, is_staff = false, is_active = true",
-	)
-	.bind(uuid::Uuid::parse_str(NON_STAFF_UUID).unwrap())
-	.bind(username)
-	.bind(&password_hash)
-	.execute(pool)
-	.await
-	.expect("Failed to insert non-staff user");
+	let builder = PostgresQueryBuilder::new();
+
+	let mut stmt = Query::insert();
+	stmt.into_table("auth_user")
+		.columns(["id", "username", "password_hash", "is_active", "is_staff"])
+		.values(vec![
+			Value::Uuid(Some(Box::new(
+				uuid::Uuid::parse_str(NON_STAFF_UUID).expect("valid NON_STAFF_UUID"),
+			))),
+			Value::String(Some(Box::new(username.to_string()))),
+			Value::String(Some(Box::new(password_hash))),
+			Value::Bool(Some(true)),
+			Value::Bool(Some(false)),
+		])
+		.expect("non-staff user value count matches column count")
+		.on_conflict(
+			OnConflict::column("id")
+				.update_columns(["password_hash", "is_staff", "is_active"])
+				.to_owned(),
+		);
+	let (sql, values) = builder.build_insert(&stmt);
+	execute_dml(pool, &sql, values.0, "insert non-staff user").await;
 }
 
 // ============================================================================

--- a/crates/reinhardt-admin/tests/e2e_pages.rs
+++ b/crates/reinhardt-admin/tests/e2e_pages.rs
@@ -971,3 +971,322 @@ async fn test_edit_form_renders_with_values(#[future] e2e: E2eContext) {
 		"Should have pre-filled values"
 	);
 }
+// ===== Dashboard tests (extended) =====
+//
+// The following tests target display branches in `dashboard()`
+// (crates/reinhardt-admin/src/pages/components/features.rs) that are not
+// covered by the basic dashboard tests above. They follow the AAA pattern
+// and use `cdp_browser` for parallel-safe isolation.
+
+/// Verify that the dashboard h1 renders the configured site_header
+/// (sourced from `AdminSettings::default()`), not just a hard-coded string.
+#[rstest]
+#[tokio::test]
+async fn test_dashboard_renders_site_header(#[future] e2e: E2eContext) {
+	// Arrange
+	let ctx = e2e.await;
+	let page = ctx
+		.browser
+		.new_page(&format!("{}/admin/login/", ctx.server_url))
+		.await
+		.expect("Failed to open page");
+	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+	let source = page.content().await.unwrap();
+	require_wasm!(&source);
+	inject_auth_token(&page, &ctx.server_url).await;
+	wait_for_dashboard_loaded(&page).await;
+
+	// Act
+	let h1 = page
+		.get_text(".dashboard-container h1")
+		.await
+		.expect("Failed to read dashboard h1")
+		.unwrap_or_default();
+
+	// Assert
+	assert!(
+		h1.contains(&ctx.site_header),
+		"h1 should contain site_header `{}`, got `{}`",
+		ctx.site_header,
+		h1,
+	);
+	assert!(
+		h1.contains("Dashboard"),
+		"h1 should contain `Dashboard`, got `{}`",
+		h1,
+	);
+}
+
+/// Verify that the dashboard renders the empty-state alert when no
+/// models are registered with the AdminSite.
+#[rstest]
+#[tokio::test]
+async fn test_dashboard_empty_state_shows_alert(#[future] e2e_no_models: E2eContext) {
+	// Arrange
+	let ctx = e2e_no_models.await;
+	let page = ctx
+		.browser
+		.new_page(&format!("{}/admin/login/", ctx.server_url))
+		.await
+		.expect("Failed to open page");
+	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+	let source = page.content().await.unwrap();
+	require_wasm!(&source);
+	inject_auth_token(&page, &ctx.server_url).await;
+	wait_for_dashboard_loaded(&page).await;
+
+	// Act
+	let alert_text = page
+		.get_text(".dashboard-container .admin-alert-info")
+		.await
+		.expect("Failed to read empty-state alert")
+		.unwrap_or_default();
+	let card_count = page
+		.execute_js("document.querySelectorAll('.dashboard-container .admin-card').length")
+		.await
+		.expect("Failed to count cards");
+
+	// Assert
+	assert!(
+		alert_text.contains("No models registered"),
+		"Expected empty-state alert text, got `{}`",
+		alert_text,
+	);
+	assert_eq!(
+		card_count.as_u64().unwrap_or(u64::MAX),
+		0,
+		"Expected zero `.admin-card` elements when no models are registered"
+	);
+}
+
+/// Verify that each registered model gets its own `.admin-card` on the dashboard.
+#[rstest]
+#[tokio::test]
+async fn test_dashboard_renders_card_per_model(#[future] e2e_multi_models: E2eContext) {
+	// Arrange
+	let ctx = e2e_multi_models.await;
+	let page = ctx
+		.browser
+		.new_page(&format!("{}/admin/login/", ctx.server_url))
+		.await
+		.expect("Failed to open page");
+	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+	let source = page.content().await.unwrap();
+	require_wasm!(&source);
+	inject_auth_token(&page, &ctx.server_url).await;
+	wait_for_dashboard_loaded(&page).await;
+
+	// Act
+	let card_count = page
+		.execute_js("document.querySelectorAll('.dashboard-container .admin-card').length")
+		.await
+		.expect("Failed to count cards");
+	let names_json = page
+		.execute_js(
+			"JSON.stringify(Array.from(document.querySelectorAll('.dashboard-container .admin-card h3')).map(e => e.textContent.trim()))",
+		)
+		.await
+		.expect("Failed to read card names");
+	let names: Vec<String> = match names_json {
+		serde_json::Value::String(s) => serde_json::from_str(&s).unwrap_or_default(),
+		serde_json::Value::Array(_) => serde_json::from_value(names_json).unwrap_or_default(),
+		_ => Vec::new(),
+	};
+	let names_set: std::collections::HashSet<&str> = names.iter().map(String::as_str).collect();
+
+	// Assert
+	assert_eq!(
+		card_count.as_u64().unwrap_or(u64::MAX),
+		2,
+		"Expected exactly 2 `.admin-card` elements for 2 registered models"
+	);
+	assert!(
+		names_set.contains("TestModel") && names_set.contains("TestModelB"),
+		"Expected card names to include both `TestModel` and `TestModelB`, got {:?}",
+		names_set,
+	);
+}
+
+/// Verify that a single dashboard card contains the full expected structure:
+/// model name in `<h3>`, "Manage X records" description, and a `View X` button
+/// with the correct `href` to the list view.
+#[rstest]
+#[tokio::test]
+async fn test_dashboard_card_structure(#[future] e2e: E2eContext) {
+	// Arrange
+	let ctx = e2e.await;
+	let page = ctx
+		.browser
+		.new_page(&format!("{}/admin/login/", ctx.server_url))
+		.await
+		.expect("Failed to open page");
+	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+	let source = page.content().await.unwrap();
+	require_wasm!(&source);
+	inject_auth_token(&page, &ctx.server_url).await;
+	wait_for_dashboard_loaded(&page).await;
+
+	// Act
+	let h3_text = page
+		.get_text(".dashboard-container .admin-card h3")
+		.await
+		.expect("Failed to read card h3")
+		.unwrap_or_default();
+	let description_text = page
+		.get_text(".dashboard-container .admin-card p")
+		.await
+		.expect("Failed to read card description")
+		.unwrap_or_default();
+	let button_text = page
+		.get_text(".dashboard-container .admin-card a.admin-btn-primary")
+		.await
+		.expect("Failed to read card button")
+		.unwrap_or_default();
+	let button_href = page
+		.get_attribute(
+			".dashboard-container .admin-card a.admin-btn-primary",
+			"href",
+		)
+		.await
+		.expect("Failed to read button href")
+		.unwrap_or_default();
+
+	// Assert
+	assert_eq!(h3_text.trim(), "TestModel", "card h3 should be model name");
+	assert!(
+		description_text.contains("Manage TestModel records"),
+		"card description mismatch: `{}`",
+		description_text,
+	);
+	assert!(
+		button_text.contains("View TestModel"),
+		"card button label mismatch: `{}`",
+		button_text,
+	);
+	assert!(
+		button_href.ends_with("/testmodel/"),
+		"card button href should target lowercased model list URL, got `{}`",
+		button_href,
+	);
+}
+
+/// Verify that an active but non-staff user cannot view the dashboard.
+///
+/// The expected behavior is either a redirect back to `/login` (auth gate)
+/// or an error alert rendered in place of the cards. Both outcomes indicate
+/// the dashboard correctly blocks unauthorized users.
+#[rstest]
+#[tokio::test]
+async fn test_dashboard_non_staff_user_blocked(#[future] e2e: E2eContext) {
+	// Arrange
+	let ctx = e2e.await;
+	create_non_staff_user(&ctx.pool, NON_STAFF_USERNAME, NON_STAFF_PASSWORD).await;
+
+	let page = ctx
+		.browser
+		.new_page(&format!("{}/admin/login/", ctx.server_url))
+		.await
+		.expect("Failed to open page");
+	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+	let source = page.content().await.unwrap();
+	require_wasm!(&source);
+
+	// Login as the non-staff user. The login server function may succeed
+	// (issuing a JWT) but `get_dashboard()` requires `is_staff=true`.
+	login_via_form_as(
+		&page,
+		&ctx.server_url,
+		NON_STAFF_USERNAME,
+		NON_STAFF_PASSWORD,
+	)
+	.await;
+	tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+	// Act
+	let url = page.url().await.unwrap().unwrap_or_default();
+	let card_count = page
+		.execute_js("document.querySelectorAll('.dashboard-container .admin-card').length")
+		.await
+		.expect("Failed to count cards");
+	let danger_present = page
+		.execute_js(
+			"document.querySelector('.admin-alert-danger, .dashboard-container [class*=error]') !== null",
+		)
+		.await
+		.expect("Failed to check error alert")
+		.as_bool()
+		.unwrap_or(false);
+
+	// Assert
+	assert_eq!(
+		card_count.as_u64().unwrap_or(u64::MAX),
+		0,
+		"Non-staff user must not see any model cards on the dashboard"
+	);
+	assert!(
+		url.contains("/login") || danger_present,
+		"Non-staff user should be redirected to login or shown an error alert; \
+		 url=`{}`, danger_present={}",
+		url,
+		danger_present,
+	);
+}
+
+/// Verify that navigating away from the dashboard and back via `history.back()`
+/// re-renders the model cards. Exercises the SPA router's resource re-fetch path.
+#[rstest]
+#[tokio::test]
+async fn test_dashboard_back_navigation_rerenders(#[future] e2e: E2eContext) {
+	// Arrange
+	let ctx = e2e.await;
+	let page = ctx
+		.browser
+		.new_page(&format!("{}/admin/login/", ctx.server_url))
+		.await
+		.expect("Failed to open page");
+	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+	let source = page.content().await.unwrap();
+	require_wasm!(&source);
+	inject_auth_token(&page, &ctx.server_url).await;
+	wait_for_dashboard_loaded(&page).await;
+
+	// Confirm dashboard is loaded before navigating away.
+	let initial_card_count = page
+		.execute_js("document.querySelectorAll('.dashboard-container .admin-card').length")
+		.await
+		.expect("Failed to count initial cards")
+		.as_u64()
+		.unwrap_or(0);
+	assert!(
+		initial_card_count >= 1,
+		"Dashboard should render at least one card before navigation"
+	);
+
+	// Act: navigate to list view, then back to dashboard.
+	spa_navigate(&page, "/admin/TestModel/").await;
+	let _ = page
+		.execute_js("window.history.back(); window.dispatchEvent(new PopStateEvent('popstate'));")
+		.await;
+	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+	wait_for_dashboard_loaded(&page).await;
+
+	// Assert
+	let url = page.url().await.unwrap().unwrap_or_default();
+	let final_card_count = page
+		.execute_js("document.querySelectorAll('.dashboard-container .admin-card').length")
+		.await
+		.expect("Failed to count cards after back navigation")
+		.as_u64()
+		.unwrap_or(0);
+
+	assert!(
+		url.ends_with("/admin/") || url.ends_with("/admin"),
+		"Should be back on dashboard URL after history.back(), got `{}`",
+		url,
+	);
+	assert!(
+		final_card_count >= 1,
+		"Dashboard cards should re-render after back navigation, got {} cards",
+		final_card_count,
+	);
+}


### PR DESCRIPTION
## Summary

- Adds 6 new E2E tests targeting display branches in the admin WASM SPA dashboard component (`/admin/`) that were not covered by the existing two dashboard tests.
- Refactors the existing `e2e` fixture into a `build_e2e_context` helper with a model-registration closure, enabling new fixture variants `e2e_no_models` and `e2e_multi_models` to share setup while varying registered models.
- Adds `wait_for_dashboard_loaded` and `create_non_staff_user` helpers + `login_via_form_as` parameterization.

Fixes #3988

## Type of Change

- [x] Test (adding or improving tests)
- [x] Refactoring (no functional changes; restructures existing fixture for reuse)

## Motivation and Context

The dashboard component (`crates/reinhardt-admin/src/pages/components/features.rs:65`) has multiple display branches — site header rendering, empty model state, multiple model cards, card structure (h3 / description / `View {name}` button), authorization gating, and SPA back-navigation re-render — that were not exercised by E2E tests. Regressions in dashboard rendering logic could land without detection.

## How Was This Tested

- `cargo check -p reinhardt-admin --tests` — passes with 0 errors and 0 warnings on the modified file.
- `cargo fmt --check -p reinhardt-admin` — passes.
- `cargo clippy -p reinhardt-admin --tests --no-deps` — passes; 0 new warnings on `e2e_pages.rs`.
- E2E test execution requires a running Docker daemon and a built admin WASM SPA. New tests gate behind the existing `require_wasm!` macro and skip cleanly when the SPA is unbuilt, matching the convention already used in the same file.

To run the new tests locally:

```sh
docker pull chromedp/headless-shell:latest
cargo nextest run -p reinhardt-admin --test e2e_pages -E 'test(/test_dashboard_/)' -- --nocapture
```

## Test Cases Added

| # | Test name | Verifies |
|---|-----------|----------|
| 1 | `test_dashboard_renders_site_header` | h1 contains the configured `site_header` |
| 2 | `test_dashboard_empty_state_shows_alert` | Zero models -> `No models registered` alert |
| 3 | `test_dashboard_renders_card_per_model` | Each registered model renders its own card (HashSet order-independent assertion) |
| 4 | `test_dashboard_card_structure` | Card has h3 + description + `View {name}` button with correct `href` |
| 5 | `test_dashboard_non_staff_user_blocked` | `is_staff=false` user sees no cards (login redirect or error alert) |
| 6 | `test_dashboard_back_navigation_rerenders` | SPA `history.back()` from list view re-renders dashboard cards |

## Checklist

- [x] All new tests follow the AAA pattern with `// Arrange / // Act / // Assert` comments
- [x] All comments are in English
- [x] Tab indentation matches project convention
- [x] No new `todo!()` / `// TODO:` / `// FIXME:` markers
- [x] Existing dashboard tests are unchanged; refactor preserves behavior
- [x] Tests gate behind `require_wasm!` to skip cleanly without the WASM SPA built
- [x] Linked to issue with `Fixes #3988`

## Labels to Apply

- `enhancement` (added during creation)
- `testing` (added during creation)
- `admin` (added during creation)

## Risk / Flakiness Notes

- Card-order assertions use `HashSet` comparison to avoid dependence on `registered_models()` internal ordering.
- The non-staff blocking test uses an OR assertion (URL `/login` redirect OR `.admin-alert-danger` present) until the observed behavior is documented; this keeps the test resilient to either auth-gate implementation.
- `wait_for_dashboard_loaded` polls every 200 ms with a 15 s timeout, replacing ad-hoc `tokio::time::sleep` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)