### PR TITLE
fix(rest): honor MetaConfig and run sync validators in serializers (#3992)

### DIFF
--- a/crates/reinhardt-rest/src/serializers.rs
+++ b/crates/reinhardt-rest/src/serializers.rs
@@ -18,6 +18,20 @@
 //! - **Performance**: Query caching, N+1 detection, batch validation
 //! - **Content Negotiation**: JSON, XML, and custom parsers
 //!
+//! ## Validation Strategies
+//!
+//! [`ModelSerializer`] runs three validator layers, ordered by latency:
+//!
+//! | Layer | Where it runs | Use case |
+//! |-------|---------------|----------|
+//! | Object-sync | [`ModelSerializer::validate`] (called first by `validate_async`) | Cross-field invariants, no DB (e.g. `start < end`) |
+//! | Field-async (unique) | [`ModelSerializer::validate_async`] | Per-field DB checks (UNIQUE constraints) |
+//! | Composite-async (unique-together) | [`ModelSerializer::validate_async`] | Multi-field DB checks |
+//!
+//! Register synchronous validators with [`ModelSerializer::with_model_validator`].
+//! Register database-backed validators with [`ModelSerializer::with_unique_validator`]
+//! and [`ModelSerializer::with_unique_together_validator`].
+//!
 //! ## Quick Start
 //!
 //! ### Basic Serializer
@@ -259,5 +273,5 @@ pub use relations::{
 	HyperlinkedRelatedField, IdentityField, ManyRelatedField, PrimaryKeyRelatedField,
 	RelationField, SlugRelatedField, StringRelatedField,
 };
-pub use validator_config::ValidatorConfig;
+pub use validator_config::{ModelLevelValidator, ValidatorConfig};
 pub use validators::{DatabaseValidatorError, UniqueTogetherValidator, UniqueValidator};

--- a/crates/reinhardt-rest/src/serializers/model_serializer.rs
+++ b/crates/reinhardt-rest/src/serializers/model_serializer.rs
@@ -6,13 +6,14 @@
 use super::introspection::{FieldInfo, FieldIntrospector};
 use super::meta::MetaConfig;
 use super::nested_config::{NestedFieldConfig, NestedSerializerConfig};
-use super::validator_config::ValidatorConfig;
+use super::validator_config::{ModelLevelValidator, ValidatorConfig};
 use super::validators::{UniqueTogetherValidator, UniqueValidator};
 use super::{Serializer, SerializerError, ValidatorError};
 use reinhardt_db::backends::DatabaseConnection;
 use reinhardt_db::orm::Model;
 use std::collections::HashMap;
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 /// ModelSerializer provides automatic serialization for ORM models
 ///
@@ -406,6 +407,20 @@ where
 		self
 	}
 
+	/// Add an object-level synchronous validator.
+	///
+	/// Synchronous validators run inside [`Self::validate`] and at the start
+	/// of [`Self::validate_async`]. They never touch the database — pair
+	/// them with [`Self::with_unique_validator`] for DB-backed checks.
+	pub fn with_model_validator<V>(mut self, validator: V) -> Self
+	where
+		V: ModelLevelValidator<M> + 'static,
+	{
+		self.validator_config
+			.add_sync_model_validator(Arc::new(validator));
+		self
+	}
+
 	/// Get the validator configuration
 	///
 	/// # Examples
@@ -424,9 +439,16 @@ where
 		&self.validator_config
 	}
 
-	/// Validate a model instance
+	/// Run synchronous validators against `instance`.
 	///
-	/// This method can be extended to support custom validators.
+	/// Executes every [`ModelLevelValidator`] registered via
+	/// [`Self::with_model_validator`] in registration order, returning the
+	/// first failure as `SerializerError::Validation`. With no synchronous
+	/// validators registered the call is a cheap `Ok(())`, preserving the
+	/// behavior of the prior placeholder implementation.
+	///
+	/// Database-backed checks (unique constraints) belong in
+	/// [`Self::validate_async`].
 	///
 	/// # Examples
 	///
@@ -443,10 +465,10 @@ where
 	/// };
 	/// assert!(serializer.validate(&user).is_ok());
 	/// ```
-	pub fn validate(&self, _instance: &M) -> Result<(), SerializerError> {
-		// Base synchronous validation - for non-database validators
-		// For database-level validation (unique constraints), use validate_async()
-		Ok(())
+	pub fn validate(&self, instance: &M) -> Result<(), SerializerError> {
+		self.validator_config
+			.validate(instance)
+			.map_err(SerializerError::Validation)
 	}
 
 	/// Validate a model instance asynchronously with database checks
@@ -496,6 +518,10 @@ where
 	where
 		M::PrimaryKey: std::fmt::Display,
 	{
+		// Run synchronous validators first to fail-early without touching
+		// the database when the issue is detectable in-process.
+		self.validate(instance)?;
+
 		// Convert instance to JSON for field extraction
 		let json_value = serde_json::to_value(instance).map_err(|e| SerializerError::Serde {
 			message: format!("Failed to serialize instance for validation: {}", e),
@@ -565,6 +591,60 @@ where
 	}
 }
 
+// Direction of a meta-driven field filter pass.
+//
+// `Output` is used during `serialize` (model -> JSON): excluded keys and
+// write-only keys are stripped, because write-only fields must never leak
+// to API responses.
+//
+// `Input` is used during `deserialize` (JSON -> model): excluded keys and
+// read-only keys are stripped, because read-only fields are server-controlled
+// and must not be accepted from clients.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum FilterDirection {
+	Output,
+	Input,
+}
+
+// Mutate `value` in place, removing every key that is filtered out by `meta`
+// for the given direction. No-op when `value` is not a JSON object (defensive;
+// `Model` derive-`Serialize` always produces an object).
+//
+// The introspector field-name slice acts as the implicit allowlist when
+// `meta.fields()` is `None` AND the slice is non-empty. An explicit empty
+// `Vec` from the user via `with_fields(vec![])` still means "include nothing".
+fn apply_meta_filter(
+	value: &mut serde_json::Value,
+	meta: &MetaConfig,
+	introspector_field_names: Option<&[String]>,
+	direction: FilterDirection,
+) {
+	let serde_json::Value::Object(map) = value else {
+		return;
+	};
+
+	let implicit_allowlist: Option<&[String]> = match (meta.fields(), introspector_field_names) {
+		(Some(_), _) => None,
+		(None, Some(names)) if !names.is_empty() => Some(names),
+		_ => None,
+	};
+
+	map.retain(|key, _| {
+		if !meta.is_field_included(key) {
+			return false;
+		}
+		if let Some(allowed) = implicit_allowlist
+			&& !allowed.iter().any(|n| n == key)
+		{
+			return false;
+		}
+		match direction {
+			FilterDirection::Output => !meta.is_write_only(key),
+			FilterDirection::Input => !meta.is_read_only(key),
+		}
+	});
+}
+
 impl<M> Serializer for ModelSerializer<M>
 where
 	M: Model,
@@ -573,13 +653,46 @@ where
 	type Output = String;
 
 	fn serialize(&self, input: &Self::Input) -> Result<Self::Output, SerializerError> {
-		serde_json::to_string(input).map_err(|e| SerializerError::Serde {
+		// Convert to a JSON Value first so `MetaConfig` filters (fields /
+		// exclude / write_only) can be applied before emitting the final
+		// string. Backward compatible: an unconfigured serializer retains
+		// every key because `MetaConfig::default()` excludes nothing.
+		let mut value = serde_json::to_value(input).map_err(|e| SerializerError::Serde {
+			message: format!("Serialization error: {}", e),
+		})?;
+
+		let introspector_names = self.introspector.as_ref().map(|i| i.field_names());
+		apply_meta_filter(
+			&mut value,
+			&self.meta,
+			introspector_names.as_deref(),
+			FilterDirection::Output,
+		);
+
+		serde_json::to_string(&value).map_err(|e| SerializerError::Serde {
 			message: format!("Serialization error: {}", e),
 		})
 	}
 
 	fn deserialize(&self, output: &Self::Output) -> Result<Self::Input, SerializerError> {
-		serde_json::from_str(output).map_err(|e| SerializerError::Serde {
+		// Parse to a JSON Value, strip excluded / read_only keys, then
+		// reconstruct `M`. Stripping a read-only field that `M` requires
+		// surfaces as `SerializerError::Serde` (missing-field), matching
+		// the behavior callers already see for malformed input.
+		let mut value: serde_json::Value =
+			serde_json::from_str(output).map_err(|e| SerializerError::Serde {
+				message: format!("Deserialization error: {}", e),
+			})?;
+
+		let introspector_names = self.introspector.as_ref().map(|i| i.field_names());
+		apply_meta_filter(
+			&mut value,
+			&self.meta,
+			introspector_names.as_deref(),
+			FilterDirection::Input,
+		);
+
+		serde_json::from_value(value).map_err(|e| SerializerError::Serde {
 			message: format!("Deserialization error: {}", e),
 		})
 	}

--- a/crates/reinhardt-rest/src/serializers/nested.rs
+++ b/crates/reinhardt-rest/src/serializers/nested.rs
@@ -31,11 +31,49 @@
 //!
 //! This design avoids the N+1 query problem and gives developers explicit control
 //! over when and how relationships are loaded.
+//!
+//! ## Limitations of the synchronous trait API
+//!
+//! The [`Serializer`] trait is synchronous, so the [`Serializer::serialize`]
+//! and [`Serializer::deserialize`] implementations on [`NestedSerializer`] and
+//! [`WritableNestedSerializer`] cannot reach the database:
+//!
+//! - `serialize` emits whatever was preloaded and never lazy-loads. A null
+//!   `relationship_field` stays null in the output.
+//! - `WritableNestedSerializer::deserialize` validates structure and
+//!   permissions but returns only the parent model. To act on nested writes,
+//!   pair it with [`WritableNestedSerializer::extract_nested_data`] and
+//!   dispatch the result to your ORM inside a transaction.
+//! - `depth` controls how deeply the arena re-walks already-loaded data; it
+//!   does not trigger additional loads.
 
 use super::{SerializationArena, Serializer, SerializerError};
 use reinhardt_db::orm::Model;
 use serde_json::Value;
 use std::marker::PhantomData;
+
+// Module-private helper used by both `NestedSerializer` and
+// `WritableNestedSerializer` to emit the parent model's JSON. The arena path
+// honors prefetched relationship data already present in the serialized form;
+// it never triggers ORM lazy loading.
+fn serialize_via_arena_or_plain<M: Model>(
+	input: &M,
+	depth: usize,
+	use_arena: bool,
+) -> Result<String, SerializerError> {
+	if use_arena {
+		let arena = SerializationArena::new();
+		let serialized = arena.serialize_model(input, depth);
+		let json_value = arena.to_json(serialized);
+		serde_json::to_string(&json_value).map_err(|e| SerializerError::Other {
+			message: format!("Serialization error: {}", e),
+		})
+	} else {
+		serde_json::to_string(input).map_err(|e| SerializerError::Other {
+			message: format!("Serialization error: {}", e),
+		})
+	}
+}
 
 /// NestedSerializer - Serialize related models inline
 ///
@@ -278,17 +316,20 @@ impl<M: Model, R: Model> Serializer for NestedSerializer<M, R> {
 	type Input = M;
 	type Output = String;
 
+	/// Serialize the parent model honoring already-loaded relationships.
+	///
+	/// This method does **not** trigger ORM lazy loading. If the
+	/// `relationship_field` is null in the parent JSON, it stays null in the
+	/// output — no additional query is issued. To preload relationships, use
+	/// `QuerySet::select_related` / `prefetch_related` in the view layer
+	/// before calling [`Self::serialize`].
 	fn serialize(&self, input: &Self::Input) -> Result<Self::Output, SerializerError> {
 		if self.use_arena {
-			// Arena-based serialization
-			let arena = SerializationArena::new();
-			let serialized = arena.serialize_model(input, self.depth);
-			let json_value = arena.to_json(serialized);
-			serde_json::to_string(&json_value).map_err(|e| SerializerError::Other {
-				message: format!("Serialization error: {}", e),
-			})
+			serialize_via_arena_or_plain(input, self.depth, true)
 		} else {
-			// Traditional heap-based serialization (backward compatibility)
+			// `serialize_without_arena` keeps a depth > 0 sentinel that
+			// inspects the relationship field for prefetched data; the bare
+			// arena path does not need that branch.
 			self.serialize_without_arena(input)
 		}
 	}
@@ -666,14 +707,27 @@ impl<M: Model, R: Model> Serializer for WritableNestedSerializer<M, R> {
 	type Input = M;
 	type Output = String;
 
+	/// Serialize the parent model honoring already-loaded relationships.
+	///
+	/// Mirrors [`NestedSerializer::serialize`] (depth `1`, arena enabled): it
+	/// emits whatever relationship data was preloaded by the ORM and never
+	/// triggers lazy loading. For relationships you need to materialize at
+	/// response time, preload them via `select_related` /
+	/// `prefetch_related` in the view layer.
 	fn serialize(&self, input: &Self::Input) -> Result<Self::Output, SerializerError> {
-		// Same as NestedSerializer - requires ORM relationship loading
-		// See NestedSerializer::serialize for implementation roadmap
-		serde_json::to_string(input).map_err(|e| SerializerError::Other {
-			message: format!("Serialization error: {}", e),
-		})
+		serialize_via_arena_or_plain(input, 1, true)
 	}
 
+	/// Validate the parent JSON structure and nested-write permissions.
+	///
+	/// Returns the parent model only. Nested data is **not** materialized
+	/// into the returned `M` — call [`Self::extract_nested_data`] on the
+	/// same JSON to obtain the related-object payload, then perform the
+	/// create / update via the ORM in your view code.
+	///
+	/// Permission flags are enforced here: nested writes that violate
+	/// `allow_create` or `allow_update` cause this method to return
+	/// `SerializerError::Other`.
 	fn deserialize(&self, output: &Self::Output) -> Result<Self::Input, SerializerError> {
 		// Parse JSON to validate structure
 		let value: Value = serde_json::from_str(output).map_err(|e| SerializerError::Other {

--- a/crates/reinhardt-rest/src/serializers/validator_config.rs
+++ b/crates/reinhardt-rest/src/serializers/validator_config.rs
@@ -3,11 +3,28 @@
 //! This module provides configuration structures for managing validators
 //! in ModelSerializer instances.
 
+use super::ValidatorError;
 use super::validators::{DatabaseValidatorError, UniqueTogetherValidator, UniqueValidator};
 use reinhardt_db::backends::DatabaseConnection;
 use reinhardt_db::orm::Model;
 use serde::Serialize;
 use std::marker::PhantomData;
+use std::sync::Arc;
+
+/// Object-level synchronous validator that operates directly on a model
+/// instance.
+///
+/// Implementors typically check cross-field invariants that do not require
+/// database access (e.g., `start_date < end_date`, `password == password_confirm`).
+/// Database-backed checks belong in [`UniqueValidator`] / [`UniqueTogetherValidator`]
+/// and run via [`ValidatorConfig::validate_async`].
+///
+/// `Debug` is required as a supertrait so that [`ValidatorConfig`] retains its
+/// derived `Debug` impl.
+pub trait ModelLevelValidator<M>: Send + Sync + std::fmt::Debug {
+	/// Validate `instance`, returning `Err` to halt validation with a reason.
+	fn validate(&self, instance: &M) -> Result<(), ValidatorError>;
+}
 
 /// Configuration for field validators
 #[non_exhaustive]
@@ -15,6 +32,7 @@ use std::marker::PhantomData;
 pub struct ValidatorConfig<M: Model> {
 	unique_validators: Vec<UniqueValidator<M>>,
 	unique_together_validators: Vec<UniqueTogetherValidator<M>>,
+	sync_model_validators: Vec<Arc<dyn ModelLevelValidator<M>>>,
 	_phantom: PhantomData<M>,
 }
 
@@ -54,6 +72,7 @@ impl<M: Model> ValidatorConfig<M> {
 		Self {
 			unique_validators: Vec::new(),
 			unique_together_validators: Vec::new(),
+			sync_model_validators: Vec::new(),
 			_phantom: PhantomData,
 		}
 	}
@@ -135,6 +154,15 @@ impl<M: Model> ValidatorConfig<M> {
 		self.unique_together_validators.push(validator);
 	}
 
+	/// Add an object-level synchronous validator.
+	///
+	/// Synchronous validators run inside [`Self::validate`] and at the start of
+	/// [`Self::validate_async`]. They never touch the database; for unique-style
+	/// checks use [`Self::add_unique_validator`] instead.
+	pub fn add_sync_model_validator(&mut self, validator: Arc<dyn ModelLevelValidator<M>>) {
+		self.sync_model_validators.push(validator);
+	}
+
 	/// Get all unique validators
 	pub fn unique_validators(&self) -> &[UniqueValidator<M>] {
 		&self.unique_validators
@@ -143,6 +171,11 @@ impl<M: Model> ValidatorConfig<M> {
 	/// Get all unique together validators
 	pub fn unique_together_validators(&self) -> &[UniqueTogetherValidator<M>] {
 		&self.unique_together_validators
+	}
+
+	/// Get all object-level synchronous validators
+	pub fn sync_model_validators(&self) -> &[Arc<dyn ModelLevelValidator<M>>] {
+		&self.sync_model_validators
 	}
 
 	/// Check if any validators are configured
@@ -182,7 +215,21 @@ impl<M: Model> ValidatorConfig<M> {
 	/// assert!(config.has_validators());
 	/// ```
 	pub fn has_validators(&self) -> bool {
-		!self.unique_validators.is_empty() || !self.unique_together_validators.is_empty()
+		!self.unique_validators.is_empty()
+			|| !self.unique_together_validators.is_empty()
+			|| !self.sync_model_validators.is_empty()
+	}
+
+	/// Run only synchronous validators against `instance`.
+	///
+	/// Returns the first failure as an `Err`. No-op (returns `Ok(())`) when no
+	/// synchronous validators are registered, preserving backward compatibility
+	/// for callers that rely on [`Self::has_validators`] being false.
+	pub fn validate(&self, instance: &M) -> Result<(), ValidatorError> {
+		for validator in &self.sync_model_validators {
+			validator.validate(instance)?;
+		}
+		Ok(())
 	}
 
 	/// Validate model instance asynchronously against configured validators

--- a/crates/reinhardt-rest/src/serializers/validator_config.rs
+++ b/crates/reinhardt-rest/src/serializers/validator_config.rs
@@ -325,6 +325,16 @@ impl<M: Model> Default for ValidatorConfig<M> {
 	}
 }
 
+// Manually re-assert the `UnwindSafe` / `RefUnwindSafe` auto traits that the
+// new `Vec<Arc<dyn ModelLevelValidator<M>>>` field would otherwise strip.
+// Trait objects do not propagate these markers, so the previously
+// auto-derived impls disappeared, triggering cargo-semver-checks
+// `auto_trait_impl_removed` under the RC phase's no-breaking-change policy.
+// The trait objects are only reached via `&self` accessors and `Arc::clone`,
+// so panic-safety guarantees match the pre-PR public contract.
+impl<M: Model> std::panic::UnwindSafe for ValidatorConfig<M> {}
+impl<M: Model> std::panic::RefUnwindSafe for ValidatorConfig<M> {}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/crates/reinhardt-rest/tests/serializers_integration.rs
+++ b/crates/reinhardt-rest/tests/serializers_integration.rs
@@ -14,9 +14,10 @@
 use reinhardt_db::orm::{FieldSelector, Model};
 use reinhardt_rest::serializers::{
 	BooleanField, CharField, EmailField, FieldError, FloatField, HyperlinkedRelatedField,
-	IntegerField, JsonSerializer, ManyRelatedField, ModelSerializer, PrimaryKeyRelatedField,
-	RelationField, Serializer, SerializerError, SerializerMethodField, SlugRelatedField,
-	StringRelatedField, URLField, UniqueTogetherValidator, UniqueValidator, ValidationError,
+	IntegerField, JsonSerializer, ManyRelatedField, ModelLevelValidator, ModelSerializer,
+	PrimaryKeyRelatedField, RelationField, Serializer, SerializerError, SerializerMethodField,
+	SlugRelatedField, StringRelatedField, URLField, UniqueTogetherValidator, UniqueValidator,
+	ValidationError, ValidatorError, WritableNestedSerializer,
 	introspection::{FieldInfo, FieldIntrospector},
 	meta::{DefaultMeta, MetaConfig, SerializerMeta},
 	method_field::{MethodFieldError, MethodFieldRegistry},
@@ -26,7 +27,7 @@ use reinhardt_rest::serializers::{
 use rstest::rstest;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 // ============================================================
 // Helper types for tests
@@ -1168,4 +1169,380 @@ fn validation_error_multiple() {
 	// Assert
 	let error_str = format!("{}", combined);
 	assert!(!error_str.is_empty());
+}
+
+// ============================================================
+// Issue #3992 — ModelSerializer / NestedSerializer honesty
+// ============================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct TestAuthor {
+	id: Option<i64>,
+	name: String,
+}
+
+#[derive(Debug, Clone)]
+struct TestAuthorFields;
+
+impl FieldSelector for TestAuthorFields {
+	fn with_alias(self, _alias: &str) -> Self {
+		self
+	}
+}
+
+impl Model for TestAuthor {
+	type PrimaryKey = i64;
+	type Fields = TestAuthorFields;
+
+	fn table_name() -> &'static str {
+		"test_authors"
+	}
+
+	fn new_fields() -> Self::Fields {
+		TestAuthorFields
+	}
+
+	fn primary_key(&self) -> Option<Self::PrimaryKey> {
+		self.id
+	}
+
+	fn set_primary_key(&mut self, value: Self::PrimaryKey) {
+		self.id = Some(value);
+	}
+}
+
+fn sample_user() -> TestUser {
+	TestUser {
+		id: Some(7),
+		username: "alice".to_string(),
+		email: "alice@example.com".to_string(),
+	}
+}
+
+// ---- Track 1: MetaConfig is applied during serialize/deserialize ----
+
+#[rstest]
+fn model_serializer_serialize_with_no_meta_keeps_all_fields() {
+	// Arrange
+	let serializer = ModelSerializer::<TestUser>::new();
+	let user = sample_user();
+
+	// Act
+	let json = serializer.serialize(&user).unwrap();
+	let parsed: Value = serde_json::from_str(&json).unwrap();
+
+	// Assert: backward compatibility — empty MetaConfig keeps every field
+	assert_eq!(parsed["id"], 7);
+	assert_eq!(parsed["username"], "alice");
+	assert_eq!(parsed["email"], "alice@example.com");
+}
+
+#[rstest]
+fn model_serializer_deserialize_with_no_meta_round_trips() {
+	// Arrange
+	let serializer = ModelSerializer::<TestUser>::new();
+	let json = r#"{"id":7,"username":"alice","email":"alice@example.com"}"#.to_string();
+
+	// Act
+	let restored = serializer.deserialize(&json).unwrap();
+
+	// Assert
+	assert_eq!(restored, sample_user());
+}
+
+#[rstest]
+fn model_serializer_serialize_with_fields_allowlist_drops_others() {
+	// Arrange
+	let serializer = ModelSerializer::<TestUser>::new()
+		.with_fields(vec!["id".to_string(), "username".to_string()]);
+	let user = sample_user();
+
+	// Act
+	let parsed: Value = serde_json::from_str(&serializer.serialize(&user).unwrap()).unwrap();
+
+	// Assert
+	assert_eq!(parsed["id"], 7);
+	assert_eq!(parsed["username"], "alice");
+	assert!(parsed.get("email").is_none(), "email must be filtered out");
+}
+
+#[rstest]
+fn model_serializer_serialize_with_exclude_drops_listed_field() {
+	// Arrange
+	let serializer = ModelSerializer::<TestUser>::new().with_exclude(vec!["email".to_string()]);
+	let user = sample_user();
+
+	// Act
+	let parsed: Value = serde_json::from_str(&serializer.serialize(&user).unwrap()).unwrap();
+
+	// Assert
+	assert!(parsed.get("email").is_none());
+	assert_eq!(parsed["username"], "alice");
+}
+
+#[rstest]
+fn model_serializer_serialize_strips_write_only_fields() {
+	// Arrange: write-only fields must never leak to API responses.
+	let serializer =
+		ModelSerializer::<TestUser>::new().with_write_only_fields(vec!["email".to_string()]);
+	let user = sample_user();
+
+	// Act
+	let parsed: Value = serde_json::from_str(&serializer.serialize(&user).unwrap()).unwrap();
+
+	// Assert
+	assert!(parsed.get("email").is_none());
+	assert_eq!(parsed["id"], 7);
+}
+
+#[rstest]
+fn model_serializer_deserialize_keeps_write_only_fields() {
+	// Arrange: write_only blocks output only; input is unaffected.
+	let serializer =
+		ModelSerializer::<TestUser>::new().with_write_only_fields(vec!["email".to_string()]);
+	let json = r#"{"id":7,"username":"alice","email":"alice@example.com"}"#.to_string();
+
+	// Act
+	let restored = serializer.deserialize(&json).unwrap();
+
+	// Assert
+	assert_eq!(restored.email, "alice@example.com");
+}
+
+#[rstest]
+fn model_serializer_deserialize_strips_read_only_fields() {
+	// Arrange: server-set fields must not be accepted from clients.
+	let serializer =
+		ModelSerializer::<TestUser>::new().with_read_only_fields(vec!["id".to_string()]);
+	let json = r#"{"id":999,"username":"alice","email":"alice@example.com"}"#.to_string();
+
+	// Act
+	let restored = serializer.deserialize(&json).unwrap();
+
+	// Assert: incoming "id":999 was dropped before deserialization
+	assert_eq!(restored.id, None);
+	assert_eq!(restored.username, "alice");
+	assert_eq!(restored.email, "alice@example.com");
+}
+
+#[rstest]
+fn model_serializer_serialize_keeps_read_only_fields() {
+	// Arrange
+	let serializer =
+		ModelSerializer::<TestUser>::new().with_read_only_fields(vec!["id".to_string()]);
+	let user = sample_user();
+
+	// Act
+	let parsed: Value = serde_json::from_str(&serializer.serialize(&user).unwrap()).unwrap();
+
+	// Assert: read-only fields are still present in the response
+	assert_eq!(parsed["id"], 7);
+}
+
+#[rstest]
+fn model_serializer_combined_meta_serialize_filters_correctly() {
+	// Arrange: fields allowlist limits to id+username+email; exclude drops
+	// email; write_only drops username from output -> only id remains.
+	let serializer = ModelSerializer::<TestUser>::new()
+		.with_fields(vec!["id".into(), "username".into(), "email".into()])
+		.with_exclude(vec!["email".into()])
+		.with_write_only_fields(vec!["username".into()]);
+	let user = sample_user();
+
+	// Act
+	let parsed: Value = serde_json::from_str(&serializer.serialize(&user).unwrap()).unwrap();
+
+	// Assert
+	assert_eq!(parsed["id"], 7);
+	assert!(parsed.get("username").is_none());
+	assert!(parsed.get("email").is_none());
+}
+
+#[rstest]
+#[case::no_config(
+	ModelSerializer::<TestUser>::new(),
+	BTreeSet::from(["id".to_string(), "username".to_string(), "email".to_string()]),
+)]
+#[case::fields_only(
+	ModelSerializer::<TestUser>::new()
+		.with_fields(vec!["id".to_string(), "username".to_string()]),
+	BTreeSet::from(["id".to_string(), "username".to_string()]),
+)]
+#[case::exclude_only(
+	ModelSerializer::<TestUser>::new().with_exclude(vec!["email".to_string()]),
+	BTreeSet::from(["id".to_string(), "username".to_string()]),
+)]
+#[case::write_only_drops_field(
+	ModelSerializer::<TestUser>::new()
+		.with_write_only_fields(vec!["email".to_string()]),
+	BTreeSet::from(["id".to_string(), "username".to_string()]),
+)]
+#[case::fields_overrides_default(
+	ModelSerializer::<TestUser>::new().with_fields(vec!["id".to_string()]),
+	BTreeSet::from(["id".to_string()]),
+)]
+fn model_serializer_serialize_keys_match_expected(
+	#[case] serializer: ModelSerializer<TestUser>,
+	#[case] expected: BTreeSet<String>,
+) {
+	// Arrange
+	let user = sample_user();
+
+	// Act
+	let parsed: Value = serde_json::from_str(&serializer.serialize(&user).unwrap()).unwrap();
+	let actual: BTreeSet<String> = parsed.as_object().unwrap().keys().cloned().collect();
+
+	// Assert: exact key set, no extras and no missing
+	assert_eq!(actual, expected);
+}
+
+#[rstest]
+fn model_serializer_serialize_uses_introspector_when_fields_unset() {
+	// Arrange: introspector defines only id+username; email is unknown.
+	let mut introspector = FieldIntrospector::new();
+	introspector.register_field(FieldInfo::new("id", "i64").primary_key());
+	introspector.register_field(FieldInfo::new("username", "String"));
+
+	let serializer = ModelSerializer::<TestUser>::new().with_introspector(introspector);
+	let user = sample_user();
+
+	// Act
+	let parsed: Value = serde_json::from_str(&serializer.serialize(&user).unwrap()).unwrap();
+
+	// Assert: email is dropped because it is not in the introspector allowlist
+	assert_eq!(parsed["id"], 7);
+	assert_eq!(parsed["username"], "alice");
+	assert!(parsed.get("email").is_none());
+}
+
+// ---- Track 2: ModelSerializer::validate runs registered sync validators ----
+
+#[derive(Debug)]
+struct UsernameNonEmpty;
+
+impl ModelLevelValidator<TestUser> for UsernameNonEmpty {
+	fn validate(&self, instance: &TestUser) -> Result<(), ValidatorError> {
+		if instance.username.is_empty() {
+			Err(ValidatorError::Custom {
+				message: "username must not be empty".to_string(),
+			})
+		} else {
+			Ok(())
+		}
+	}
+}
+
+#[rstest]
+fn model_serializer_validate_with_no_validators_is_ok() {
+	// Arrange: empty config preserves the historical behavior of validate.
+	let serializer = ModelSerializer::<TestUser>::new();
+	let user = sample_user();
+
+	// Act
+	let result = serializer.validate(&user);
+
+	// Assert
+	assert!(result.is_ok());
+}
+
+#[rstest]
+fn model_serializer_validate_runs_registered_model_validator_pass() {
+	// Arrange: validator passes because username is non-empty.
+	let serializer = ModelSerializer::<TestUser>::new().with_model_validator(UsernameNonEmpty);
+	let user = sample_user();
+
+	// Act
+	let result = serializer.validate(&user);
+
+	// Assert
+	assert!(result.is_ok());
+}
+
+#[rstest]
+fn model_serializer_validate_runs_registered_model_validator_fail() {
+	// Arrange: validator should reject an empty username.
+	let serializer = ModelSerializer::<TestUser>::new().with_model_validator(UsernameNonEmpty);
+	let user = TestUser {
+		id: Some(1),
+		username: String::new(),
+		email: "ghost@example.com".to_string(),
+	};
+
+	// Act
+	let result = serializer.validate(&user);
+
+	// Assert: error must be wrapped as `SerializerError::Validation`
+	let err = result.expect_err("expected sync validator failure");
+	match err {
+		SerializerError::Validation(ValidatorError::Custom { ref message }) => {
+			assert_eq!(message, "username must not be empty");
+		}
+		other => panic!("unexpected error variant: {:?}", other),
+	}
+}
+
+#[rstest]
+fn validator_config_has_validators_includes_sync_model() {
+	// Arrange: empty config is empty; adding a sync model validator flips it.
+	let bare = ModelSerializer::<TestUser>::new();
+	let configured = ModelSerializer::<TestUser>::new().with_model_validator(UsernameNonEmpty);
+
+	// Act + Assert
+	assert!(!bare.validators().has_validators());
+	assert!(configured.validators().has_validators());
+}
+
+// ---- Track 3: WritableNestedSerializer is honest ----
+
+#[rstest]
+fn writable_nested_serializer_serialize_emits_full_parent_object() {
+	// Arrange: with the no-op gone, serialize must still produce a complete
+	// parent JSON object regardless of relationship loading state.
+	let serializer = WritableNestedSerializer::<TestPost, TestAuthor>::new("author");
+	let post = TestPost {
+		id: Some(42),
+		title: "hello".to_string(),
+		author_id: 7,
+	};
+
+	// Act
+	let json = serializer.serialize(&post).expect("serialize must succeed");
+	let parsed: Value = serde_json::from_str(&json).unwrap();
+
+	// Assert
+	assert_eq!(parsed["id"], 42);
+	assert_eq!(parsed["title"], "hello");
+	assert_eq!(parsed["author_id"], 7);
+}
+
+#[rstest]
+fn writable_nested_serializer_extract_nested_data_after_deserialize() {
+	// Arrange: trait method returns only the parent; the helper exposes
+	// nested data for the caller to dispatch to the ORM.
+	let serializer = WritableNestedSerializer::<TestPost, TestAuthor>::new("author")
+		.allow_create(true)
+		.allow_update(true);
+	let json = json!({
+		"id": 1,
+		"title": "post",
+		"author_id": 9,
+		"author": { "id": null, "name": "Alice" }
+	})
+	.to_string();
+
+	// Act
+	let parent = serializer
+		.deserialize(&json)
+		.expect("deserialize must validate structure");
+	let nested = serializer
+		.extract_nested_data(&json)
+		.expect("extract_nested_data must succeed");
+
+	// Assert: the trait method is honest about returning only the parent,
+	// while the helper surfaces the nested payload for ORM dispatch.
+	assert_eq!(parent.id, Some(1));
+	assert_eq!(parent.title, "post");
+	let nested = nested.expect("nested data must be present in JSON");
+	assert_eq!(nested["name"], "Alice");
+	assert!(nested["id"].is_null());
 }


### PR DESCRIPTION
## Summary

- `ModelSerializer<M>::serialize`/`deserialize` now reflect `MetaConfig`
  (`with_fields` / `with_exclude` / `with_read_only_fields` /
  `with_write_only_fields`) and the introspector instead of falling through to
  `serde_json` round-trip.
- `ModelSerializer::validate` now executes registered synchronous validators
  via the new `ModelLevelValidator<M>` trait + `with_model_validator` builder.
  `validate_async` runs `validate` first to fail-early.
- `WritableNestedSerializer::serialize` no longer ignores its parent — it now
  uses the same arena path as `NestedSerializer`. Module rustdoc and
  `deserialize` rustdoc are reworked to match what the sync trait actually
  does (no lazy loading; nested writes go through `extract_nested_data`).

Resolves #3992.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Motivation and Context

Issue #3992 reported that `ModelSerializer`, `NestedSerializer`, and
`WritableNestedSerializer` advertise rich configuration but the
`Serializer::serialize`/`deserialize`/`validate` implementations bypass the
configuration entirely. This is the same regression class as #3985: the
public API suggested behavior the implementation never performed, leading to
real risks (e.g., `password_hash` leaking despite `with_exclude`, `id`
silently overwritten despite `with_read_only_fields`).

## How Was This Tested

- `cargo nextest run -p reinhardt-rest --all-features` (97 tests, all
  passing — 80 existing + 17 new).
- `cargo test -p reinhardt-rest --doc --all-features` (398 doctests pass).
- `cargo make fmt-check`, `cargo make clippy-check`, `cargo make
  clippy-todo-check` — all clean.
- `cargo doc --no-deps -p reinhardt-rest` — zero warnings/errors.
- `semgrep scan --config .semgrep/ --baseline-commit main --error
  --metrics off crates/reinhardt-rest/src/serializers/` — zero new findings.

The new tests assert behaviors that previously slipped past structural
equality:

- `with_exclude` actually drops keys from the serialize output.
- `with_read_only_fields` actually strips keys from deserialize input.
- `with_write_only_fields` strips on serialize but not deserialize.
- `validate` executes registered validators and surfaces failures via
  `SerializerError::Validation`.
- `WritableNestedSerializer::serialize` emits a complete parent JSON.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented hard-to-understand parts (apply_meta_filter direction
      semantics, prefetch contract limitations)
- [x] I have made corresponding changes to the documentation (mod-level docs
      for Validation Strategies and Limitations of the synchronous trait API)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- `bug` (regression class shared with #3985)

## Out of scope (follow-up)

The plan deliberately defers to follow-up issues:

- `NestedSerializer::serialize_async` / `WritableNestedSerializer::save_nested_async`
  (true relationship loading via async helpers — needs verification that the
  ORM exposes a generic `R::objects().get(pk)`-style method).
- Field-level sync validator bridge (`with_field_validator(name, MaxLength(50))`).
- Folding `ModelSerializer::validate_async`'s body into
  `ValidatorConfig::validate_async` (the current implementation duplicates
  the loop logic).

## Notes

- 1 PR for all three tracks per user request, but commits are split per fix
  pattern so reviewers can read each track independently.
- Public API surface change: `ModelLevelValidator` trait,
  `with_model_validator` builder, `ValidatorConfig::validate` (sync),
  `ValidatorConfig::add_sync_model_validator`. All non-breaking additions.
- `cargo semver-checks` (CI) is expected to classify this as a minor
  addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)