### PR TITLE
fix(auth): transform GitHub /user response into StandardClaims

### DIFF
--- a/crates/reinhardt-auth/src/social/backend.rs
+++ b/crates/reinhardt-auth/src/social/backend.rs
@@ -133,17 +133,34 @@ impl SocialAuthBackend {
 					.await?;
 				Some(StandardClaims::from(id_token))
 			} else {
-				// Fall back to UserInfo endpoint
+				// Fall back to UserInfo endpoint. UserInfo failures are non-fatal:
+				// log them so operators can diagnose silent claim losses (issue #4001).
 				provider
 					.get_user_info(&token_response.access_token)
 					.await
+					.inspect_err(|e| {
+						tracing::warn!(
+							provider = %provider_name,
+							error = %e,
+							"Failed to fetch user info from OIDC UserInfo fallback; claims will be None",
+						)
+					})
 					.ok()
 			}
 		} else {
-			// For OAuth2-only providers, use UserInfo endpoint
+			// For OAuth2-only providers, use UserInfo endpoint. UserInfo failures
+			// are non-fatal: log them so operators can diagnose silent claim
+			// losses (issue #4001).
 			provider
 				.get_user_info(&token_response.access_token)
 				.await
+				.inspect_err(|e| {
+					tracing::warn!(
+						provider = %provider_name,
+						error = %e,
+						"Failed to fetch user info from OAuth2 provider; claims will be None",
+					)
+				})
 				.ok()
 		};
 

--- a/crates/reinhardt-auth/src/social/providers/github.rs
+++ b/crates/reinhardt-auth/src/social/providers/github.rs
@@ -174,6 +174,25 @@ impl OAuthProvider for GitHubProvider {
 			SocialAuthError::InvalidConfiguration("Missing UserInfo endpoint".into())
 		})?;
 
+		self.fetch_github_userinfo(userinfo_endpoint, access_token)
+			.await
+	}
+}
+
+impl GitHubProvider {
+	/// Fetches and maps the GitHub `/user` payload to [`StandardClaims`].
+	///
+	/// Lives in a dedicated method (rather than inlined in
+	/// [`OAuthProvider::get_user_info`]) so the `userinfo_endpoint` argument
+	/// crosses a function boundary after [`validate_endpoint_url`] has
+	/// rejected non-HTTPS schemes — mirroring the
+	/// [`UserInfoClient::get_user_info`](crate::social::oidc::userinfo::UserInfoClient::get_user_info)
+	/// pattern.
+	async fn fetch_github_userinfo(
+		&self,
+		userinfo_endpoint: &str,
+		access_token: &str,
+	) -> Result<StandardClaims, SocialAuthError> {
 		// Enforce HTTPS (or loopback HTTP) before transmitting the bearer token.
 		// Mirrors the validation performed by `UserInfoClient` and by
 		// `GenericOidcProvider::get_user_info` so the bearer token is never sent

--- a/crates/reinhardt-auth/src/social/providers/github.rs
+++ b/crates/reinhardt-auth/src/social/providers/github.rs
@@ -1,23 +1,81 @@
 //! GitHub OAuth2 provider
+//!
+//! Implements OAuth2 authentication against GitHub's API. Unlike OIDC providers,
+//! GitHub's `/user` endpoint returns a non-standard payload (numeric `id` instead
+//! of the OIDC `sub` claim, and uses `avatar_url` instead of `picture`). This
+//! module fetches that payload and transforms it into [`StandardClaims`] so the
+//! rest of the social authentication pipeline can consume it uniformly.
 
 use crate::social::core::{
 	OAuth2Client, OAuthProvider, ProviderConfig, SocialAuthError, StandardClaims, TokenResponse,
 };
 use crate::social::flow::pkce::{CodeChallenge, CodeVerifier};
 use crate::social::flow::{AuthorizationFlow, RefreshFlow, TokenExchangeFlow};
-use crate::social::oidc::UserInfoClient;
 use async_trait::async_trait;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// GitHub `/user` endpoint response shape.
+///
+/// GitHub's REST API does not follow the OIDC UserInfo schema, so we deserialize
+/// into this private intermediate struct and then map to [`StandardClaims`] via
+/// [`map_github_user_to_claims`].
+#[derive(Debug, Deserialize)]
+struct GitHubUserResponse {
+	/// Numeric GitHub user ID. Mapped to `StandardClaims::sub` as a string.
+	id: u64,
+	/// GitHub login (username). Used as a fallback for `name` when null.
+	login: String,
+	/// Public email address. May be `null` if the user keeps their email private.
+	#[serde(default)]
+	email: Option<String>,
+	/// Display name. May be `null` if the user has not set one.
+	#[serde(default)]
+	name: Option<String>,
+	/// Avatar URL. Mapped to `StandardClaims::picture`.
+	#[serde(default)]
+	avatar_url: Option<String>,
+}
+
+/// Map a GitHub `/user` response into the framework's [`StandardClaims`].
+///
+/// - `sub` is set to the stringified numeric `id`.
+/// - `name` falls back to `login` when GitHub returns `null`.
+/// - `email` and `picture` (from `avatar_url`) pass through as-is.
+fn map_github_user_to_claims(user: GitHubUserResponse) -> StandardClaims {
+	let GitHubUserResponse {
+		id,
+		login,
+		email,
+		name,
+		avatar_url,
+	} = user;
+
+	StandardClaims {
+		sub: id.to_string(),
+		email,
+		email_verified: None,
+		name: name.or(Some(login)),
+		given_name: None,
+		family_name: None,
+		picture: avatar_url,
+		locale: None,
+		additional_claims: HashMap::new(),
+	}
+}
 
 /// GitHub OAuth2 provider
 ///
 /// Implements OAuth2-only authentication flow using static endpoints
-/// configured via `ProviderConfig::github()`.
+/// configured via `ProviderConfig::github()`. GitHub's `/user` endpoint
+/// returns a non-OIDC payload, so this provider issues its own HTTP request
+/// instead of delegating to a generic `UserInfoClient`.
 pub struct GitHubProvider {
 	config: ProviderConfig,
 	auth_flow: AuthorizationFlow,
 	token_exchange: TokenExchangeFlow,
 	refresh_flow: RefreshFlow,
-	userinfo_client: UserInfoClient,
+	client: OAuth2Client,
 }
 
 impl GitHubProvider {
@@ -36,14 +94,13 @@ impl GitHubProvider {
 		let auth_flow = AuthorizationFlow::new(config.clone());
 		let token_exchange = TokenExchangeFlow::new(client.clone(), config.clone());
 		let refresh_flow = RefreshFlow::new(client.clone(), config.clone());
-		let userinfo_client = UserInfoClient::new(client);
 
 		Ok(Self {
 			config,
 			auth_flow,
 			token_exchange,
 			refresh_flow,
-			userinfo_client,
+			client,
 		})
 	}
 }
@@ -116,8 +173,214 @@ impl OAuthProvider for GitHubProvider {
 			SocialAuthError::InvalidConfiguration("Missing UserInfo endpoint".into())
 		})?;
 
-		self.userinfo_client
-			.get_user_info(userinfo_endpoint, access_token)
+		// GitHub requires a User-Agent header on `/user` requests, and returns
+		// a non-OIDC payload, so we do not delegate to `UserInfoClient` here.
+		let response = self
+			.client
+			.client()
+			.get(userinfo_endpoint)
+			.bearer_auth(access_token)
+			.header("User-Agent", "reinhardt-auth")
+			.header("Accept", "application/vnd.github+json")
+			.send()
 			.await
+			.map_err(|e| SocialAuthError::Network(e.to_string()))?;
+
+		if !response.status().is_success() {
+			let status = response.status();
+			let error_body = response
+				.text()
+				.await
+				.unwrap_or_else(|_| "Unknown error".to_string());
+
+			return Err(SocialAuthError::UserInfoError(format!(
+				"GitHub UserInfo request failed ({}): {}",
+				status, error_body
+			)));
+		}
+
+		let user: GitHubUserResponse = response
+			.json()
+			.await
+			.map_err(|e| SocialAuthError::UserInfoError(e.to_string()))?;
+
+		Ok(map_github_user_to_claims(user))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	fn github_user_response_deserializes_typical_payload() {
+		// Arrange
+		let json = r#"{
+			"id": 12345,
+			"login": "octotest",
+			"email": "octo@example.com",
+			"name": "Octo Test",
+			"avatar_url": "https://avatars.githubusercontent.com/u/12345"
+		}"#;
+
+		// Act
+		let user: GitHubUserResponse =
+			serde_json::from_str(json).expect("typical GitHub /user payload must deserialize");
+
+		// Assert
+		assert_eq!(user.id, 12345);
+		assert_eq!(user.login, "octotest");
+		assert_eq!(user.email.as_deref(), Some("octo@example.com"));
+		assert_eq!(user.name.as_deref(), Some("Octo Test"));
+		assert_eq!(
+			user.avatar_url.as_deref(),
+			Some("https://avatars.githubusercontent.com/u/12345")
+		);
+	}
+
+	#[rstest]
+	fn github_user_response_deserializes_with_null_optional_fields() {
+		// Arrange: GitHub returns `null` for email/name when the user keeps them private.
+		let json = r#"{
+			"id": 99,
+			"login": "ghost",
+			"email": null,
+			"name": null,
+			"avatar_url": null
+		}"#;
+
+		// Act
+		let user: GitHubUserResponse =
+			serde_json::from_str(json).expect("payload with null optionals must deserialize");
+
+		// Assert
+		assert_eq!(user.id, 99);
+		assert_eq!(user.login, "ghost");
+		assert!(user.email.is_none());
+		assert!(user.name.is_none());
+		assert!(user.avatar_url.is_none());
+	}
+
+	#[rstest]
+	fn github_user_response_deserializes_with_missing_optional_fields() {
+		// Arrange: GitHub may omit optional fields entirely for some account types.
+		let json = r#"{
+			"id": 7,
+			"login": "minimal"
+		}"#;
+
+		// Act
+		let user: GitHubUserResponse = serde_json::from_str(json)
+			.expect("payload with missing optional fields must deserialize");
+
+		// Assert
+		assert_eq!(user.id, 7);
+		assert_eq!(user.login, "minimal");
+		assert!(user.email.is_none());
+		assert!(user.name.is_none());
+		assert!(user.avatar_url.is_none());
+	}
+
+	#[rstest]
+	fn map_github_user_to_claims_maps_full_payload() {
+		// Arrange
+		let user = GitHubUserResponse {
+			id: 12345,
+			login: "octotest".to_string(),
+			email: Some("octo@example.com".to_string()),
+			name: Some("Octo Test".to_string()),
+			avatar_url: Some("https://avatars.githubusercontent.com/u/12345".to_string()),
+		};
+
+		// Act
+		let claims = map_github_user_to_claims(user);
+
+		// Assert
+		assert_eq!(claims.sub, "12345");
+		assert_eq!(claims.email.as_deref(), Some("octo@example.com"));
+		assert_eq!(claims.name.as_deref(), Some("Octo Test"));
+		assert_eq!(
+			claims.picture.as_deref(),
+			Some("https://avatars.githubusercontent.com/u/12345")
+		);
+		assert!(claims.email_verified.is_none());
+		assert!(claims.given_name.is_none());
+		assert!(claims.family_name.is_none());
+		assert!(claims.locale.is_none());
+		assert!(claims.additional_claims.is_empty());
+	}
+
+	#[rstest]
+	fn map_github_user_to_claims_falls_back_to_login_when_name_is_null() {
+		// Arrange
+		let user = GitHubUserResponse {
+			id: 42,
+			login: "octotest".to_string(),
+			email: Some("octo@example.com".to_string()),
+			name: None,
+			avatar_url: None,
+		};
+
+		// Act
+		let claims = map_github_user_to_claims(user);
+
+		// Assert
+		assert_eq!(claims.sub, "42");
+		assert_eq!(
+			claims.name.as_deref(),
+			Some("octotest"),
+			"name must fall back to login when GitHub returns null"
+		);
+		assert_eq!(claims.email.as_deref(), Some("octo@example.com"));
+		assert!(claims.picture.is_none());
+	}
+
+	#[rstest]
+	fn map_github_user_to_claims_handles_both_name_and_email_null() {
+		// Arrange: edge case where the user has hidden both display name and email.
+		let user = GitHubUserResponse {
+			id: 1,
+			login: "ghost".to_string(),
+			email: None,
+			name: None,
+			avatar_url: None,
+		};
+
+		// Act
+		let claims = map_github_user_to_claims(user);
+
+		// Assert
+		assert_eq!(claims.sub, "1");
+		assert_eq!(
+			claims.name.as_deref(),
+			Some("ghost"),
+			"name must fall back to login when GitHub returns null"
+		);
+		assert!(
+			claims.email.is_none(),
+			"email must remain None when GitHub returns null"
+		);
+		assert!(claims.picture.is_none());
+	}
+
+	#[rstest]
+	#[case::numeric_id_serializes_as_string(0_u64, "0")]
+	#[case::large_id_preserved(9_999_999_999_u64, "9999999999")]
+	fn map_github_user_to_claims_stringifies_id(#[case] id: u64, #[case] expected_sub: &str) {
+		// Arrange
+		let user = GitHubUserResponse {
+			id,
+			login: "any".to_string(),
+			email: None,
+			name: None,
+			avatar_url: None,
+		};
+
+		// Act
+		let claims = map_github_user_to_claims(user);
+
+		// Assert
+		assert_eq!(claims.sub, expected_sub);
 	}
 }

--- a/crates/reinhardt-auth/src/social/providers/github.rs
+++ b/crates/reinhardt-auth/src/social/providers/github.rs
@@ -11,6 +11,7 @@ use crate::social::core::{
 };
 use crate::social::flow::pkce::{CodeChallenge, CodeVerifier};
 use crate::social::flow::{AuthorizationFlow, RefreshFlow, TokenExchangeFlow};
+use crate::social::url_validation::validate_endpoint_url;
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -172,6 +173,12 @@ impl OAuthProvider for GitHubProvider {
 		let userinfo_endpoint = oauth2_config.userinfo_endpoint.as_ref().ok_or_else(|| {
 			SocialAuthError::InvalidConfiguration("Missing UserInfo endpoint".into())
 		})?;
+
+		// Enforce HTTPS (or loopback HTTP) before transmitting the bearer token.
+		// Mirrors the validation performed by `UserInfoClient` and by
+		// `GenericOidcProvider::get_user_info` so the bearer token is never sent
+		// to an arbitrary scheme.
+		validate_endpoint_url(userinfo_endpoint)?;
 
 		// GitHub requires a User-Agent header on `/user` requests, and returns
 		// a non-OIDC payload, so we do not delegate to `UserInfoClient` here.

--- a/crates/reinhardt-auth/tests/helpers/mock_server.rs
+++ b/crates/reinhardt-auth/tests/helpers/mock_server.rs
@@ -65,6 +65,9 @@ struct MockServerState {
 	auth_code: Option<String>,
 	token_response: Option<TokenResponse>,
 	userinfo_response: Option<StandardClaims>,
+	/// Raw userinfo JSON body. When set, takes precedence over `userinfo_response`.
+	/// Used to test providers (like GitHub) whose userinfo schema does not match `StandardClaims`.
+	raw_userinfo_response: Option<String>,
 	#[allow(dead_code)] // test fixture for multiple provider scenarios
 	id_token: Option<IdToken>,
 	discovery_response: Option<String>,
@@ -94,6 +97,7 @@ impl MockOAuth2Server {
 			auth_code: None,
 			token_response: None,
 			userinfo_response: None,
+			raw_userinfo_response: None,
 			id_token: None,
 			discovery_response: None,
 			jwks_response: None,
@@ -189,6 +193,16 @@ impl MockOAuth2Server {
 	pub(crate) fn set_userinfo_response(&mut self, claims: StandardClaims) {
 		let mut state = self.state.lock().unwrap();
 		state.userinfo_response = Some(claims);
+	}
+
+	/// Set a raw JSON userinfo response.
+	///
+	/// Use this when the provider expects a non-OIDC schema (for example GitHub's
+	/// `/user` endpoint, which returns `id` instead of `sub`).
+	#[allow(dead_code)] // test fixture for multiple provider scenarios
+	pub(crate) fn set_raw_userinfo_response(&mut self, json: impl Into<String>) {
+		let mut state = self.state.lock().unwrap();
+		state.raw_userinfo_response = Some(json.into());
 	}
 
 	/// Set discovery document (OIDC)
@@ -352,23 +366,28 @@ async fn handle_request(
 					.unwrap());
 			}
 
-			let userinfo =
-				state_guard
-					.userinfo_response
-					.clone()
-					.unwrap_or_else(|| StandardClaims {
-						sub: "test_user".to_string(),
-						email: Some("test@example.com".to_string()),
-						email_verified: Some(true),
-						name: Some("Test User".to_string()),
-						given_name: Some("Test".to_string()),
-						family_name: Some("User".to_string()),
-						picture: None,
-						locale: None,
-						additional_claims: HashMap::new(),
-					});
-
-			let json = serde_json::to_string(&userinfo).unwrap();
+			// Raw JSON override takes precedence so non-OIDC providers
+			// (for example GitHub) can supply their native payload shape.
+			let json = if let Some(raw) = state_guard.raw_userinfo_response.clone() {
+				raw
+			} else {
+				let userinfo =
+					state_guard
+						.userinfo_response
+						.clone()
+						.unwrap_or_else(|| StandardClaims {
+							sub: "test_user".to_string(),
+							email: Some("test@example.com".to_string()),
+							email_verified: Some(true),
+							name: Some("Test User".to_string()),
+							given_name: Some("Test".to_string()),
+							family_name: Some("User".to_string()),
+							picture: None,
+							locale: None,
+							additional_claims: HashMap::new(),
+						});
+				serde_json::to_string(&userinfo).unwrap()
+			};
 			Ok(Response::builder()
 				.status(StatusCode::OK)
 				.header("Content-Type", "application/json")

--- a/crates/reinhardt-auth/tests/social/e2e/complete_flow_test.rs
+++ b/crates/reinhardt-auth/tests/social/e2e/complete_flow_test.rs
@@ -12,7 +12,19 @@ mod helpers;
 #[tokio::test]
 async fn test_complete_github_oauth2_flow() {
 	// Arrange
-	let server = MockOAuth2Server::new().await;
+	let mut server = MockOAuth2Server::new().await;
+	// GitHub's `/user` endpoint returns a non-OIDC schema (numeric `id`,
+	// `login`, `avatar_url`, ...). Inject a realistic raw payload so the
+	// GitHub provider exercises its claim-mapping code path (issue #4001).
+	server.set_raw_userinfo_response(
+		r#"{
+			"id": 12345,
+			"login": "octotest",
+			"email": "octo@example.com",
+			"name": "Octo Test",
+			"avatar_url": "https://avatars.githubusercontent.com/u/12345"
+		}"#,
+	);
 	let config = ProviderConfig {
 		name: "github".to_string(),
 		client_id: "test_client_id".to_string(),
@@ -48,13 +60,19 @@ async fn test_complete_github_oauth2_flow() {
 	assert_eq!(token_response.access_token, "test_access_token");
 	assert_eq!(token_response.token_type, "Bearer");
 
-	// Step 4: Retrieve user info
+	// Step 4: Retrieve user info — verify GitHub's `id` is mapped to `sub`
+	// and `avatar_url` is mapped to `picture`.
 	let claims = provider
 		.get_user_info(&token_response.access_token)
 		.await
 		.unwrap();
-	assert_eq!(claims.sub, "test_user");
-	assert_eq!(claims.email, Some("test@example.com".to_string()));
+	assert_eq!(claims.sub, "12345");
+	assert_eq!(claims.email, Some("octo@example.com".to_string()));
+	assert_eq!(claims.name, Some("Octo Test".to_string()));
+	assert_eq!(
+		claims.picture,
+		Some("https://avatars.githubusercontent.com/u/12345".to_string())
+	);
 
 	// Step 5: Verify state retrieval
 	let retrieved_state = state_store.retrieve(state).await.unwrap();


### PR DESCRIPTION
## Summary

Fixes the latent `GitHubProvider` bug where the GitHub `/user` JSON could never deserialize into `StandardClaims` (GitHub returns numeric `id`, not OIDC `sub`), causing `claims = None` to be silently returned via `.ok()` on every real-world callback.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Tracked at #4001. Root cause: `GitHubProvider::get_user_info` delegated to the generic `UserInfoClient::get_user_info`, which deserializes the upstream response directly into `StandardClaims`. That struct requires a top-level `sub: String`, so the real GitHub schema (`{"id": 12345, "login": ..., "avatar_url": ...}`) always failed to deserialize, and the failure was swallowed in `SocialAuthBackend::handle_callback` via `.ok()`.

The pre-existing e2e test passed only because `MockOAuth2Server` returned synthetic OIDC-shaped JSON with `sub: "test_user"` — no real GitHub server has ever flowed through this code path successfully.

## How Was This Tested

- **Unit tests (8 new, all `#[rstest]` + AAA)** in `crates/reinhardt-auth/src/social/providers/github.rs`:
  - `GitHubUserResponse` deserialization for typical, all-null, and missing-optional payloads
  - `map_github_user_to_claims` mapping for full payload, name-fallback-to-login, both-null, and parametrized id stringification (id=0, id=9_999_999_999)
- **E2E test updated**: `tests/social/e2e/complete_flow_test.rs::test_complete_github_oauth2_flow` now injects realistic GitHub JSON via `set_raw_userinfo_response` and asserts `sub == "12345"` and `picture == avatar_url`.
- **Full suite**: `cargo nextest run -p reinhardt-auth --all-features` — **1079 passed, 0 failed**.
- `cargo fmt -p reinhardt-auth --check` — clean.
- `cargo clippy -p reinhardt-auth --all-features -- -D warnings` — clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- `bug`
- `auth`

## Related Issues

Fixes #4001

🤖 Generated with [Claude Code](https://claude.com/claude-code)