### PR TITLE
fix(ci): unblock Docs.rs and Intra-Crate tests broken by main regressions

### DIFF
--- a/crates/reinhardt-admin/tests/e2e_pages.rs
+++ b/crates/reinhardt-admin/tests/e2e_pages.rs
@@ -29,7 +29,8 @@ use reinhardt_db::backends::dialect::PostgresBackend;
 use reinhardt_db::orm::connection::{DatabaseBackend, DatabaseConnection};
 use reinhardt_di::{InjectionContext, SingletonScope};
 use reinhardt_query::prelude::{
-	ColumnDef, Expr, OnConflict, PostgresQueryBuilder, Query, QueryBuilder, Value,
+	ColumnDef, Expr, OnConflict, PostgresQueryBuilder, Query, QueryBuilder, QueryStatementBuilder,
+	Value,
 };
 use reinhardt_test::fixtures::shared_postgres::shared_db_pool;
 use reinhardt_test::fixtures::wasm::e2e_cdp::*;
@@ -308,7 +309,7 @@ where
 				.timestamp_with_time_zone()
 				.default(Expr::current_timestamp().into()),
 		);
-	let (sql, _) = builder.build_create_table(&create_test_models);
+	let sql = create_test_models.to_string(PostgresQueryBuilder);
 	execute_ddl(&pool, &sql, "create test_models").await;
 
 	// TRUNCATE TABLE test_models RESTART IDENTITY CASCADE
@@ -317,7 +318,7 @@ where
 		.table("test_models")
 		.restart_identity()
 		.cascade();
-	let (sql, _) = builder.build_truncate_table(&truncate_test_models);
+	let sql = truncate_test_models.to_string(PostgresQueryBuilder);
 	execute_ddl(&pool, &sql, "truncate test_models").await;
 
 	// Seed test_models with three rows.
@@ -346,7 +347,7 @@ where
 				.not_null(true),
 		)
 		.col(ColumnDef::new("name").string_len(255).not_null(true));
-	let (sql, _) = builder.build_create_table(&create_test_models_b);
+	let sql = create_test_models_b.to_string(PostgresQueryBuilder);
 	execute_ddl(&pool, &sql, "create test_models_b").await;
 
 	let mut truncate_test_models_b = Query::truncate_table();
@@ -354,13 +355,13 @@ where
 		.table("test_models_b")
 		.restart_identity()
 		.cascade();
-	let (sql, _) = builder.build_truncate_table(&truncate_test_models_b);
+	let sql = truncate_test_models_b.to_string(PostgresQueryBuilder);
 	execute_ddl(&pool, &sql, "truncate test_models_b").await;
 
 	// DROP TABLE IF EXISTS auth_user CASCADE
 	let mut drop_auth_user = Query::drop_table();
 	drop_auth_user.table("auth_user").if_exists().cascade();
-	let (sql, _) = builder.build_drop_table(&drop_auth_user);
+	let sql = drop_auth_user.to_string(PostgresQueryBuilder);
 	execute_ddl(&pool, &sql, "drop auth_user").await;
 
 	// CREATE TABLE auth_user (...)
@@ -425,7 +426,7 @@ where
 				.not_null(true)
 				.default(Expr::val("[]").into()),
 		);
-	let (sql, _) = builder.build_create_table(&create_auth_user);
+	let sql = create_auth_user.to_string(PostgresQueryBuilder);
 	execute_ddl(&pool, &sql, "create auth_user").await;
 
 	let hasher = Argon2Hasher::new();

--- a/crates/reinhardt-pages/src/app.rs
+++ b/crates/reinhardt-pages/src/app.rs
@@ -93,7 +93,7 @@ pub struct ClientLauncher {
 
 /// Context passed to [`ClientLauncher::after_launch`] callbacks.
 ///
-/// Borrows the resources [`ClientLauncher::launch`] already owns
+/// Borrows the resources `ClientLauncher::launch` already owns
 /// (`window`, `document`, root element); never owns them.
 pub struct LaunchCtx<'a> {
 	#[cfg_attr(not(wasm), allow(dead_code))]


### PR DESCRIPTION
## Summary

Two regressions on \`main\` are blocking every open PR. Fix both in one PR.

- **#4006**: Docs.rs Build Check fails with broken intra-doc link to \`cfg(wasm)\`-gated \`ClientLauncher::launch\` (introduced by #3997)
- **#4007**: 7 of 8 Intra-Crate Integration Test shards fail with \`there is no parameter \$1\` because the dashboard E2E fixture emits parameterized DDL (introduced by #3990)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Motivation and Context

Both bugs slipped through review because they only surface in specific CI jobs (Docs.rs builds for non-wasm targets; Intra-Crate tests run the dashboard E2E fixture). Since they live on \`main\`, every open PR inherits the failures regardless of its own changes — a single fix on \`main\` unblocks all of them.

## How Was This Tested

Local verification on \`fix/issue-4006-and-4007-ci-regressions\`:

\`\`\`
cargo check -p reinhardt-admin --tests --all-features
RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps -p reinhardt-pages --all-features
cargo fmt -- --check
\`\`\`

All three pass.

Per-issue detail:

### #4006 — \`crates/reinhardt-pages/src/app.rs\`
\`launch()\` only exists inside \`#[cfg(wasm)] impl ClientLauncher\` (lines 358-379). Replaced the broken intra-doc link \`[\`ClientLauncher::launch\`]\` with bare \`\`ClientLauncher::launch\`\` (code formatting, no link), matching the CLAUDE.md convention for feature-gated items.

### #4007 — \`crates/reinhardt-admin/tests/e2e_pages.rs\`
\`PostgresQueryBuilder::build_create_table\` returns parameterized SQL; \`DEFAULT \$1\` is invalid in Postgres DDL since DDL doesn't accept bind parameters. Switched all 6 DDL build sites (create/truncate \`test_models\`, create/truncate \`test_models_b\`, drop/create \`auth_user\`) from \`builder.build_*_table(&stmt)\` to \`stmt.to_string(PostgresQueryBuilder)\`, which inlines literal values directly into the SQL string. Same pattern is already used in \`reinhardt-conf/src/settings/audit/backends/database.rs\`.

\`PostgresQueryBuilder\` (a ZST unit struct) is passed by value at each call site so the existing \`builder\` binding remains usable for subsequent \`build_insert\` DML calls that legitimately need parameterization.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] No new warnings introduced
- [x] Changes focused on the single concern of unblocking CI

## Labels to Apply

- \`bug\`
- \`documentation\`

## Related Issues

Fixes #4006
Fixes #4007

🤖 Generated with [Claude Code](https://claude.com/claude-code)