### PR TITLE
fix(urls): panic when mount() prefix contains path parameter placeholders

### DIFF
--- a/crates/reinhardt-urls/src/routers/server_router.rs
+++ b/crates/reinhardt-urls/src/routers/server_router.rs
@@ -289,6 +289,16 @@ impl ServerRouter {
 	///     .mount("", ServerRouter::new());
 	/// ```
 	fn validate_prefix(prefix: &str) {
+		// Prefix must not contain path parameter placeholders.
+		// Mount prefixes are matched as literal strings, so a placeholder like
+		// `{org}` would never match an actual path segment and all child routes
+		// would silently 404. Fail early at construction time instead.
+		if prefix.contains('{') || prefix.contains('}') {
+			panic!(
+				"`mount()` prefix `{prefix}` contains a path parameter placeholder (`{{...}}`); this is not supported.\nUse `route()` with the full path on the child router instead, or mount at a literal prefix."
+			);
+		}
+
 		// Prefix must end with "/"
 		if !prefix.ends_with('/') {
 			if prefix.is_empty() {
@@ -489,6 +499,12 @@ impl ServerRouter {
 	///
 	/// Panics if the prefix is non-empty, not "/" and doesn't end with "/".
 	/// This follows Django's URL configuration conventions.
+	///
+	/// Also panics if the prefix contains a path parameter placeholder
+	/// (e.g. `/orgs/{org}/`). Mount prefixes are matched as literal strings,
+	/// so placeholders would silently cause all child routes to return 404.
+	/// Use `route()` with the full path on the child router instead, or
+	/// mount at a literal prefix.
 	///
 	/// # Examples
 	///
@@ -2100,6 +2116,20 @@ mod tests {
 
 		// Assert
 		assert_eq!(router.children_count(), 1);
+	}
+
+	#[rstest]
+	#[should_panic(expected = "path parameter placeholder")]
+	fn test_mount_panics_on_param_prefix() {
+		// Arrange
+		let child = ServerRouter::new();
+
+		// Act
+		// Mounting with a `{param}` placeholder in the prefix is not supported
+		// and must panic at construction time.
+		let _ = ServerRouter::new().mount("/orgs/{org}/clusters/", child);
+
+		// Assert: handled by `#[should_panic]`.
 	}
 
 	#[rstest]


### PR DESCRIPTION
## Summary

`ServerRouter::mount("/orgs/{org}/clusters/", child)` previously accepted a prefix containing path parameter placeholders, but matched it as a literal string via `str::strip_prefix`. All routes under such a prefix silently returned 404 with no startup warning.

This change detects `{` / `}` in the prefix at `mount()` construction time and panics with an actionable message, matching the project's "fail early" design philosophy.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Discovered while implementing reinhardt-cloud#418 (org-scoped API endpoints). Full path-parameter-aware mount prefixes are a larger refactor and tracked separately; the immediate priority is to surface the misconfiguration loudly rather than silently 404.

Fixes #4012

## How Was This Tested

- [x] `cargo nextest run -p reinhardt-urls` (741 tests passed)
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`
- [x] New test `test_mount_panics_on_param_prefix` covers the panic path

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)