### PR TITLE
fix(macros): propagate unique_together into ModelMetadata for autodetector

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -1891,6 +1891,15 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 		})
 		.collect();
 
+	// Token streams that register each model-level UNIQUE constraint
+	// (e.g., from `unique_together`) into ModelMetadata.constraints so the
+	// migration autodetector can emit AddConstraint operations.
+	// See reinhardt-web#4022.
+	let unique_constraint_field_lists: Vec<Vec<String>> = unique_constraints
+		.iter()
+		.map(|(fields, _, _)| fields.clone())
+		.collect();
+
 	// Define composite_pk_type_def and holder for code generation
 	let composite_pk_type_def: Option<TokenStream>;
 	// Note: composite_pk_type_holder is only assigned in the composite PK branch,
@@ -1939,6 +1948,8 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 		table_name,
 		&field_infos,
 		&fk_field_infos,
+		&unique_constraint_names,
+		&unique_constraint_field_lists,
 	)?;
 
 	// Generate relationship registration code for RELATIONSHIPS registry
@@ -2560,6 +2571,8 @@ fn generate_registration_code(
 	table_name: &str,
 	field_infos: &[FieldInfo],
 	fk_field_infos: &[ForeignKeyFieldInfo],
+	unique_constraint_names: &[String],
+	unique_constraint_field_lists: &[Vec<String>],
 ) -> Result<TokenStream> {
 	let migrations_crate = get_reinhardt_migrations_crate();
 	let orm_crate = get_reinhardt_orm_crate();
@@ -2826,6 +2839,29 @@ fn generate_registration_code(
 	// Generate type path for global model registry
 	let type_path = quote! { #struct_name }.to_string();
 
+	// Build per-constraint registration blocks for ModelMetadata.
+	// We walk three parallel vectors (names + field lists) and emit one
+	// `metadata.add_constraint(...)` call per declared `unique_together`.
+	// See reinhardt-web#4022.
+	let constraint_registrations: Vec<TokenStream> = unique_constraint_names
+		.iter()
+		.zip(unique_constraint_field_lists.iter())
+		.map(|(name, fields)| {
+			let field_lits = fields.iter().map(|f| quote! { #f.to_string() });
+			quote! {
+				metadata.add_constraint(
+					#migrations_crate::ConstraintDefinition {
+						name: #name.to_string(),
+						constraint_type: "unique".to_string(),
+						fields: vec![ #(#field_lits),* ],
+						expression: None,
+						foreign_key_info: None,
+					}
+				);
+			}
+		})
+		.collect();
+
 	let code = quote! {
 		#[::ctor::ctor]
 		fn #register_fn_name() {
@@ -2841,6 +2877,7 @@ fn generate_registration_code(
 			#(#field_registrations)*
 			#(#fk_id_registrations)*
 			#(#m2m_registrations)*
+			#(#constraint_registrations)*
 
 			#migrations_crate::model_registry::global_registry().register_model(metadata);
 

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -60,7 +60,11 @@ pub struct ModelMetadata {
 	/// and other peer-constraint attributes. Field-level `unique = true` is
 	/// still synthesized inside `to_model_state()` and not stored here, to
 	/// preserve the existing single-field UNIQUE behavior.
-	pub constraints: Vec<ConstraintDefinition>,
+	///
+	/// Kept private so that adding the field to a previously
+	/// externally-constructible struct does not break the public API.
+	/// Read via [`Self::constraints`]; write via [`Self::add_constraint`].
+	constraints: Vec<ConstraintDefinition>,
 }
 
 impl ModelMetadata {
@@ -100,6 +104,15 @@ impl ModelMetadata {
 	/// (e.g., `#[model(unique_together = ...)]`).
 	pub fn add_constraint(&mut self, constraint: ConstraintDefinition) {
 		self.constraints.push(constraint);
+	}
+
+	/// Returns model-level constraints registered by the `#[model(...)]`
+	/// macro (currently composite UNIQUE from `unique_together`).
+	///
+	/// Field-level `unique = true` is not included here; it is synthesized
+	/// inside [`Self::to_model_state`] from `FieldMetadata` parameters.
+	pub fn constraints(&self) -> &[ConstraintDefinition] {
+		&self.constraints
 	}
 
 	/// Convert to ModelState for migrations

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -11,6 +11,7 @@
 //!
 //! See [`ModelMetadata`] for the architecture comparison diagram.
 
+use super::ConstraintDefinition;
 use super::autodetector::{FieldState, ModelState};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -55,6 +56,11 @@ pub struct ModelMetadata {
 	pub options: HashMap<String, String>,
 	/// ManyToMany relationship definitions
 	pub many_to_many_fields: Vec<ManyToManyMetadata>,
+	/// Model-level constraints declared via `#[model(unique_together = ...)]`
+	/// and other peer-constraint attributes. Field-level `unique = true` is
+	/// still synthesized inside `to_model_state()` and not stored here, to
+	/// preserve the existing single-field UNIQUE behavior.
+	pub constraints: Vec<ConstraintDefinition>,
 }
 
 impl ModelMetadata {
@@ -71,6 +77,7 @@ impl ModelMetadata {
 			fields: HashMap::new(),
 			options: HashMap::new(),
 			many_to_many_fields: Vec::new(),
+			constraints: Vec::new(),
 		}
 	}
 
@@ -87,6 +94,12 @@ impl ModelMetadata {
 	/// Adds many to many.
 	pub fn add_many_to_many(&mut self, m2m: ManyToManyMetadata) {
 		self.many_to_many_fields.push(m2m);
+	}
+
+	/// Adds a model-level constraint declared via macro attributes
+	/// (e.g., `#[model(unique_together = ...)]`).
+	pub fn add_constraint(&mut self, constraint: ConstraintDefinition) {
+		self.constraints.push(constraint);
 	}
 
 	/// Convert to ModelState for migrations
@@ -156,7 +169,6 @@ impl ModelMetadata {
 		// Generate Unique constraints from field params
 		for (field_name, field_meta) in &self.fields {
 			if field_meta.params.get("unique").map(String::as_str) == Some("true") {
-				use super::ConstraintDefinition;
 				let constraint = ConstraintDefinition {
 					name: format!(
 						"{}_{}_{}_uniq",
@@ -172,6 +184,13 @@ impl ModelMetadata {
 				model_state.constraints.push(constraint);
 			}
 		}
+
+		// Copy model-level constraints declared via #[model(unique_together = ...)]
+		// (and other peer-constraint attributes). These are populated by the
+		// derive macro at registration time. See reinhardt-web#4022.
+		model_state
+			.constraints
+			.extend(self.constraints.iter().cloned());
 
 		model_state
 	}

--- a/tests/integration/tests/migrations.rs
+++ b/tests/integration/tests/migrations.rs
@@ -78,3 +78,7 @@ mod merge_migration_integration;
 // Migration Overwrite Prevention Tests
 #[path = "migrations/migration_overwrite_prevention_test.rs"]
 mod migration_overwrite_prevention_test;
+
+// Macro `unique_together` propagation regression tests (reinhardt-web#4022)
+#[path = "migrations/macro_unique_together_integration.rs"]
+mod macro_unique_together_integration;

--- a/tests/integration/tests/migrations/macro_unique_together_integration.rs
+++ b/tests/integration/tests/migrations/macro_unique_together_integration.rs
@@ -68,7 +68,7 @@ fn unique_together_propagates_into_model_metadata() {
 		.expect("Membership model should be registered by the #[model] macro");
 
 	// Act
-	let constraints = &metadata.constraints;
+	let constraints = metadata.constraints();
 
 	// Assert
 	assert_eq!(
@@ -132,9 +132,9 @@ fn models_without_unique_together_emit_no_extra_constraints() {
 
 	// Act / Assert
 	assert!(
-		metadata.constraints.is_empty(),
-		"ModelMetadata.constraints must stay empty when no unique_together \
+		metadata.constraints().is_empty(),
+		"ModelMetadata.constraints() must stay empty when no unique_together \
 		 attribute is declared, got {:?}",
-		metadata.constraints
+		metadata.constraints()
 	);
 }

--- a/tests/integration/tests/migrations/macro_unique_together_integration.rs
+++ b/tests/integration/tests/migrations/macro_unique_together_integration.rs
@@ -1,0 +1,140 @@
+//! Integration tests for `#[model(unique_together = ...)]` macro propagation.
+//!
+//! Verifies that the `#[model(...)]` derive macro correctly registers
+//! `unique_together` declarations into `ModelMetadata.constraints`, which is
+//! the source of truth consumed by `MigrationAutodetector` via
+//! `to_model_state()`.
+//!
+//! Regression test for kent8192/reinhardt-web#4022: previously, the macro
+//! parsed `unique_together` and emitted ORM-side metadata, but never pushed
+//! the corresponding `ConstraintDefinition` into the migration registry.
+//! That left `ModelState.constraints` empty for composite UNIQUE constraints,
+//! so `cargo make makemigrations` did not emit any `AddConstraint` operation
+//! even after PR #3998 taught the autodetector to consume the new entries.
+//!
+//! These tests assert two layers:
+//!
+//! 1. The constructor-time registration in `global_registry()` carries the
+//!    parsed `unique_together` constraints on `ModelMetadata`.
+//! 2. The `to_model_state()` conversion preserves the constraints on its way
+//!    to the autodetector.
+
+use reinhardt_db::migrations::model_registry::global_registry;
+use reinhardt_macros::model;
+use rstest::*;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Test fixtures: minimal models that exercise the `unique_together` parser.
+// ---------------------------------------------------------------------------
+
+#[allow(dead_code)]
+#[model(
+	app_label = "macro_unique_together_test",
+	table_name = "macro_unique_together_test_membership",
+	unique_together = ("organization_id", "user_id")
+)]
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct Membership {
+	#[field(primary_key = true)]
+	pub id: i64,
+	pub organization_id: i64,
+	pub user_id: i64,
+}
+
+#[allow(dead_code)]
+#[model(
+	app_label = "macro_unique_together_test",
+	table_name = "macro_unique_together_test_no_constraint"
+)]
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct PlainModel {
+	#[field(primary_key = true)]
+	pub id: i64,
+	#[field(max_length = 255)]
+	pub name: String,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn unique_together_propagates_into_model_metadata() {
+	// Arrange
+	let registry = global_registry();
+	let metadata = registry
+		.get_model("macro_unique_together_test", "Membership")
+		.expect("Membership model should be registered by the #[model] macro");
+
+	// Act
+	let constraints = &metadata.constraints;
+
+	// Assert
+	assert_eq!(
+		constraints.len(),
+		1,
+		"exactly one model-level constraint should be emitted from the single \
+		 `unique_together` declaration, got {constraints:?}"
+	);
+	let c = &constraints[0];
+	assert_eq!(c.constraint_type, "unique");
+	assert_eq!(
+		c.fields,
+		vec!["organization_id".to_string(), "user_id".to_string()],
+		"field order must match the declaration so that auto-generated names \
+		 stay deterministic"
+	);
+	assert_eq!(
+		c.name, "macro_unique_together_test_membership_organization_id_user_id_uniq",
+		"constraint name must follow the `{{table}}_{{f1}}_{{f2}}_uniq` rule \
+		 already used by the ORM-side ConstraintInfo so that downstream tools \
+		 see a single name"
+	);
+	assert!(c.expression.is_none());
+	assert!(c.foreign_key_info.is_none());
+}
+
+#[rstest]
+fn to_model_state_carries_unique_together_constraints() {
+	// Arrange
+	let registry = global_registry();
+	let metadata = registry
+		.get_model("macro_unique_together_test", "Membership")
+		.expect("Membership model should be registered by the #[model] macro");
+
+	// Act
+	let model_state = metadata.to_model_state();
+
+	// Assert
+	let unique_constraints: Vec<_> = model_state
+		.constraints
+		.iter()
+		.filter(|c| c.fields == vec!["organization_id".to_string(), "user_id".to_string()])
+		.collect();
+	assert_eq!(
+		unique_constraints.len(),
+		1,
+		"exactly one composite UNIQUE constraint should reach ModelState; got \
+		 all constraints = {:?}",
+		model_state.constraints
+	);
+	assert_eq!(unique_constraints[0].constraint_type, "unique");
+}
+
+#[rstest]
+fn models_without_unique_together_emit_no_extra_constraints() {
+	// Arrange
+	let registry = global_registry();
+	let metadata = registry
+		.get_model("macro_unique_together_test", "PlainModel")
+		.expect("PlainModel should be registered by the #[model] macro");
+
+	// Act / Assert
+	assert!(
+		metadata.constraints.is_empty(),
+		"ModelMetadata.constraints must stay empty when no unique_together \
+		 attribute is declared, got {:?}",
+		metadata.constraints
+	);
+}


### PR DESCRIPTION
## Summary

- Add `ModelMetadata.constraints: Vec<ConstraintDefinition>` so the migration registry has a place to carry model-level UNIQUE constraints.
- Have `#[model(unique_together = ...)]` emit one `metadata.add_constraint(...)` call per declaration in the generated `#[ctor]` registration block, reusing the existing `{table}_{f1}_{f2}_uniq` naming rule shared with ORM-side `ConstraintInfo`.
- Forward the new entries into `ModelState` via `to_model_state()` so `MigrationAutodetector::detect_added_constraints()` (taught in #3998) can finally observe them.
- Add macro→registry integration tests covering the propagation path; existing autodetector tests build `ModelState` by hand and do not cover this trajectory.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`#[model(unique_together = ("a", "b"))]` was parsed into `ConstraintSpec::Unique` and surfaced as ORM-side `ConstraintInfo`, but never reached `ModelMetadata`. After #3998 made `MigrationAutodetector::detect_added_constraints()` consume `DetectedChanges.added_constraints`, the diff input was still empty for composite UNIQUE constraints declared on existing tables, so `cargo make makemigrations` continued to omit `Operation::AddConstraint`.

This was reproduced downstream in [reinhardt-cloud](https://github.com/kent8192/reinhardt-cloud) where the `Cluster (organization_id, name)` UNIQUE had to be hand-written as `dashboard/migrations/clusters/0005_add_organization_id_name_unique.rs` and a string-match 409 Conflict workaround was added in views.

## How Was This Tested

- `cargo check --workspace --all-features`
- `cargo nextest run -p reinhardt-db --features migrations,contenttypes --lib` — 2311/2311 pass
- New integration tests:
  - `unique_together_propagates_into_model_metadata`
  - `to_model_state_carries_unique_together_constraints`
  - `models_without_unique_together_emit_no_extra_constraints`
  All three pass via `cargo nextest run -p reinhardt-integration-tests --test migrations macro_unique_together`.
- `cargo fmt --all -- --check`
- `cargo clippy -p reinhardt-db -p reinhardt-macros --features migrations -- -D warnings`
- `cargo make auto-fix` — 0 formatted, 2702 unchanged

## Checklist

- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix is effective (regression test)
- [x] All new and existing tests pass locally
- [x] I have made corresponding changes to the documentation (doc comment on `ModelMetadata.constraints` + module docs in the new test file)

## Labels to Apply

- `bug`

## Related Issues

Fixes #4022
Refs #3989, #3998

## Additional Context

Field-level `unique = true` keeps being synthesized inside `to_model_state()` and is intentionally not stored on the new `constraints` field, so existing single-field UNIQUE behavior is preserved exactly. Constraint names emitted from the macro match the ORM-side `ConstraintInfo` naming rule so downstream tools see a single identity per constraint.

Once this lands and a release tag ships, the downstream tracking issue [reinhardt-cloud#443](https://github.com/kent8192/reinhardt-cloud/issues/443) can drop its hand-written migration and string-match workaround (the view-layer 409 mapping is kept as defense-in-depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)