### PR TITLE
fix(ci): use release-plz app identity for version-refs commit

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -81,6 +81,12 @@ jobs:
         # which makes `outputs.pr != ''` truthy. Without the extra checks,
         # fromJson('{}').head_branch becomes null -> HEAD_BRANCH empty ->
         # `git fetch origin ""` fails with exit 128. See run 24864402077.
+        #
+        # Identity must match the release-plz GitHub App that authenticates
+        # the push. Using "github-actions[bot]" here causes GitHub to suppress
+        # the pull_request: synchronize event (treated as GITHUB_TOKEN origin),
+        # which leaves the Release PR head SHA without any Actions check-runs.
+        # See #4029.
         if: >-
           steps.release-plz-pr.outputs.pr != ''
           && steps.release-plz-pr.outputs.pr != '{}'
@@ -94,8 +100,8 @@ jobs:
             echo "No release PR created (HEAD_BRANCH is empty); skipping."
             exit 0
           fi
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "reinhardt-release-plz[bot]"
+          git config user.email "258855725+reinhardt-release-plz[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
           git fetch origin "$HEAD_BRANCH"
           git checkout "$HEAD_BRANCH"


### PR DESCRIPTION
## Summary

Fix the `Update version references in release branch` step in the
`Release-plz` workflow so that the second commit on a Release PR is
authored by the release-plz GitHub App instead of `github-actions[bot]`.

This PR addresses:

- Release PRs (e.g. #4021) ending up with **zero Actions check-runs** on
  their head SHA, because the second commit was authored as
  `github-actions[bot]`. GitHub treats those commits as `GITHUB_TOKEN`-
  origin events and suppresses the `pull_request: synchronize` workflow
  trigger.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The push in this step is authenticated with the release-plz GitHub App
token (`actions/create-github-app-token@v2`), but the step explicitly
overrode the commit identity to `github-actions[bot]`. As a result the
PR's `pull_request: synchronize` event was suppressed and CI / CodeQL /
SemVer Check / Examples / etc. never attached to the new head SHA —
reviewers had to look up CI status through the global Actions tab.

Aligning the commit identity with the release-plz App
(`reinhardt-release-plz[bot]`, app user id `258855725`) lets the App's
push fire `synchronize` normally, restoring per-PR check visibility.

Fixes #4029

Related to: #4021

## How Was This Tested?

- `yq '.' .github/workflows/release-plz.yml > /dev/null` — YAML parses cleanly.
- `grep -n "github-actions\[bot\]\|reinhardt-release-plz\[bot\]"
  .github/workflows/release-plz.yml` — only the intended `git config`
  lines were updated; no other call sites were affected.
- Runtime verification will happen on the next release-plz run after
  merge: a new Release PR with the docs commit should show full Actions
  check-runs against its head SHA (verified via
  `gh api repos/.../commits/<sha>/check-runs`).

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage (AWS Spot instances),
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

> Note: this is a workflow-only change. There is no Rust code path to
> add unit tests for, and no database backend interaction. Verification
> is observational on the next release-plz run.

## Related Issues

- Fixes #4029
- Reference PR exhibiting the bug: #4021

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

GitHub docs: ["events created by the GITHUB_TOKEN will not create a new workflow run"](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)