### PR TITLE
fix(tests): align nested router integration tests with mount() literal-prefix contract

### DIFF
--- a/tests/integration/tests/routing/nested_router_integration.rs
+++ b/tests/integration/tests/routing/nested_router_integration.rs
@@ -80,18 +80,20 @@ async fn test_nested_url_helpers() {
 
 #[tokio::test]
 async fn test_deeply_nested_router() {
-	// Create deeply nested router structure:
-	// /api/v1/orgs/{org_id}/teams/{team_id}/members/
+	// Create deeply nested router structure with literal mount prefixes.
+	// Path parameters ({org_id}, {team_id}) belong on child routes, not on
+	// mount() prefixes — see ServerRouter::validate_prefix (Fixes #4025).
+	// Effective shape: /api/v1/orgs/teams/members/
 
 	let members_router = ServerRouter::new().with_namespace("members");
 
 	let teams_router = ServerRouter::new()
 		.with_namespace("teams")
-		.mount("/{team_id}/members/", members_router);
+		.mount("/members/", members_router);
 
 	let orgs_router = ServerRouter::new()
 		.with_namespace("orgs")
-		.mount("/{org_id}/teams/", teams_router);
+		.mount("/teams/", teams_router);
 
 	let api_router = ServerRouter::new()
 		.with_prefix("/api/v1")

--- a/tests/integration/tests/routing/router_include_integration.rs
+++ b/tests/integration/tests/routing/router_include_integration.rs
@@ -56,12 +56,14 @@ async fn test_router_mount_multiple() {
 
 #[tokio::test]
 async fn test_router_mount_nested() {
-	// Create deeply nested router structure
+	// Create deeply nested router structure with literal mount prefixes.
+	// Path parameters ({id}) belong on child routes, not on mount() prefixes —
+	// see ServerRouter::validate_prefix (Fixes #4025).
 	let detail_router = ServerRouter::new().with_namespace("user_detail");
 
 	let users_router = ServerRouter::new()
 		.with_namespace("users")
-		.mount("/{id}/", detail_router);
+		.mount("/detail/", detail_router);
 
 	let api_router = ServerRouter::new()
 		.with_prefix("/api")


### PR DESCRIPTION
## Summary

- Two routing integration tests (`test_deeply_nested_router`, `test_router_mount_nested`) were panicking on `main` because they passed `{param}` placeholders to `ServerRouter::mount()`, which is rejected by `validate_prefix()` introduced in #4012.
- Switch the affected `mount()` calls to literal prefixes (`/teams/`, `/members/`, `/detail/`) — placeholders belong on child `route()` calls, not on `mount()` prefixes — restoring green CI for `Cross-Crate Integration Tests`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`ServerRouter::validate_prefix()` was added as a deliberate API contract change (#4012). The two integration tests under `tests/integration/tests/routing/` were never updated, so they panicked at the new guard and turned every open PR's `Cross-Crate Integration Tests (2/3)` job red on `main`.

This PR takes Issue #4025's recommended Option (1) — update the tests to use literal mount prefixes — which is the lower-risk path consistent with the new contract.

## How Was This Tested

```bash
cargo nextest run -p reinhardt-integration-tests test_deeply_nested_router test_router_mount_nested
# Summary: 2 tests run: 2 passed, 3023 skipped
```

Both previously panicking tests now PASS.

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] No assertion weakening or `#[ignore]` added (test-quality rule compliance)
- [x] Test intent (verifying nested router structure) preserved
- [x] Issue reference comment added in modified tests (`Fixes #4025`)

## Related Issues

Fixes #4025
Refs #4012

🤖 Generated with [Claude Code](https://claude.com/claude-code)