### PR TITLE
fix(ci): create version-refs commit via GraphQL to trigger PR Actions

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -82,11 +82,13 @@ jobs:
         # fromJson('{}').head_branch becomes null -> HEAD_BRANCH empty ->
         # `git fetch origin ""` fails with exit 128. See run 24864402077.
         #
-        # Identity must match the release-plz GitHub App that authenticates
-        # the push. Using "github-actions[bot]" here causes GitHub to suppress
-        # the pull_request: synchronize event (treated as GITHUB_TOKEN origin),
-        # which leaves the Release PR head SHA without any Actions check-runs.
-        # See #4029.
+        # Use GraphQL createCommitOnBranch (NOT git push) so the new commit's
+        # committer is `web-flow`, the only identity that reliably triggers
+        # `pull_request: synchronize`. Pushing via `git push` from a workflow
+        # runner preserves the workflow-configured `[bot]` committer, which
+        # GitHub treats as bot-origin and suppresses the synchronize event,
+        # leaving the Release PR head SHA without any Actions check-runs.
+        # See #4042 (this fix), #4029, #4031 (incomplete fix).
         if: >-
           steps.release-plz-pr.outputs.pr != ''
           && steps.release-plz-pr.outputs.pr != '{}'
@@ -96,23 +98,85 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
           if [ -z "$HEAD_BRANCH" ]; then
             echo "No release PR created (HEAD_BRANCH is empty); skipping."
             exit 0
           fi
-          git config user.name  "reinhardt-release-plz[bot]"
-          git config user.email "258855725+reinhardt-release-plz[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
+
+          # Sync the working tree to the release branch HEAD (created by
+          # release-plz/action) so update-version-refs.sh edits the right
+          # snapshot. We do NOT need a local commit -- the GraphQL mutation
+          # below creates the remote commit directly.
           git fetch origin "$HEAD_BRANCH"
           git checkout "$HEAD_BRANCH"
+          HEAD_OID=$(git rev-parse HEAD)
+
           VERSION=$(grep '^version = ' Cargo.toml | head -1 | \
                     sed 's/version = "\(.*\)"/\1/')
+
           ./scripts/update-version-refs.sh "$VERSION"
-          if ! git diff --quiet; then
-            git add -A
-            git commit -m "docs: update version references to v${VERSION}"
-            git push origin "$HEAD_BRANCH"
+
+          if git diff --quiet; then
+            echo "update-version-refs.sh produced no changes; skipping commit."
+            exit 0
           fi
+
+          # Build additions/deletions arrays for the GraphQL mutation.
+          # `additions` need base64-encoded contents; `deletions` need only path.
+          ADDITIONS='[]'
+          DELETIONS='[]'
+          while IFS=$'\t' read -r status path; do
+            case "$status" in
+              M|A)
+                content_b64=$(base64 -w0 < "$path")
+                ADDITIONS=$(jq --arg p "$path" --arg c "$content_b64" \
+                  '. + [{path: $p, contents: $c}]' <<< "$ADDITIONS")
+                ;;
+              D)
+                DELETIONS=$(jq --arg p "$path" \
+                  '. + [{path: $p}]' <<< "$DELETIONS")
+                ;;
+              *)
+                echo "::warning::Unsupported diff status '$status' for path '$path'; skipping."
+                ;;
+            esac
+          done < <(git diff --name-status HEAD)
+
+          PAYLOAD=$(jq -n \
+            --arg query 'mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url oid } } }' \
+            --arg repo "$REPO" \
+            --arg branch "$HEAD_BRANCH" \
+            --arg msg "docs: update version references to v${VERSION}" \
+            --arg oid "$HEAD_OID" \
+            --argjson adds "$ADDITIONS" \
+            --argjson dels "$DELETIONS" \
+            '{
+              query: $query,
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                  message: { headline: $msg },
+                  expectedHeadOid: $oid,
+                  fileChanges: { additions: $adds, deletions: $dels }
+                }
+              }
+            }')
+
+          # `gh api graphql --input -` posts the assembled body. Authentication
+          # uses GITHUB_TOKEN (the release-plz App installation token); this
+          # works because GraphQL accepts the same App token that already had
+          # contents:write permission for the previous git push path.
+          RESPONSE=$(echo "$PAYLOAD" | gh api graphql --input -)
+
+          NEW_OID=$(jq -r '.data.createCommitOnBranch.commit.oid' <<< "$RESPONSE")
+          NEW_URL=$(jq -r '.data.createCommitOnBranch.commit.url' <<< "$RESPONSE")
+          if [ -z "$NEW_OID" ] || [ "$NEW_OID" = "null" ]; then
+            echo "::error::createCommitOnBranch did not return a commit oid"
+            echo "$RESPONSE"
+            exit 1
+          fi
+          echo "Created version-refs commit $NEW_OID via GraphQL: $NEW_URL"
 
   release-plz-release:
     name: Release


### PR DESCRIPTION
## Summary

Replace `git push` with the GraphQL `createCommitOnBranch` mutation in
release-plz.yml's `Update version references in release branch` step so the
new commit's committer is `web-flow`, the only identity that reliably fires
`pull_request: synchronize` and attaches Actions check-runs to the Release
PR head SHA.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

PR #4031 attempted to fix #4029 by changing the version-refs commit's
identity from `github-actions[bot]` to `reinhardt-release-plz[bot]`. The
hypothesis was "App identity matching the auth token fires synchronize."

**That hypothesis was wrong.** Live evidence on PR #4039:

| Commit | Committer | Actions check-runs |
|---|---|---|
| `d87de5f` `chore: release` | `web-flow` (release-plz/action via GitHub API) | All 15 workflows triggered |
| `a89ff3f` `docs: update version references to v0.1.0-rc.24` | `reinhardt-release-plz[bot]` (workflow `git push`) | None — only Semgrep external app |

GitHub suppresses `pull_request: synchronize` whenever the **committer**
of the new commit is *any* `[bot]` account, regardless of token type. The
fix in #4031 only swapped one bot identity for another, so the suppression
remained.

The GraphQL `createCommitOnBranch` mutation creates the commit server-side
and assigns committer = `web-flow`, exactly like the first
`chore: release` commit produced by `release-plz/action`. The PR head SHA
then receives the full CI / CodeQL / SemVer Check / Examples workflow set.

Fixes #4042
Refs #4029 (root cause), #4031 (incomplete fix), #4039 (live broken PR)

## How Was This Tested?

- `yq eval '.' .github/workflows/release-plz.yml > /dev/null` — YAML parses cleanly.
- Extracted the `run:` block and ran `bash -n` — bash syntax OK.
- Smoke-tested the jq payload assembly against synthetic file lists; the
  resulting JSON matches the GraphQL `CreateCommitOnBranchInput!` schema
  (verified via introspection: `FileAddition`, `FileDeletion`,
  `CommittableBranch`, `CommitMessage`).
- Runtime verification will happen on the next release-plz run after merge.
  Expected: PR head SHA receives full Actions check-runs (verified via
  `gh api repos/.../commits/<sha>/check-runs`).

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable) — workflow comments updated; no user-facing docs affected
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (workflow-only change; runtime verification only)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable) — N/A
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️ -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4042
- Refs #4029 (closed-as-fixed but root cause still present)
- Refs #4031 (insufficient fix that this PR supersedes)
- Refs #4039 (live broken Release PR exhibiting the bug)

## Labels to Apply

### Type Label (select one)
- [x] `bug` — Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` — CI/CD workflow changes

### Priority
- [x] `high` — Affects every Release PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
