### PR TITLE
fix(ci): stream version-refs commit payload to avoid jq ARG_MAX overflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -123,19 +123,22 @@ jobs:
           fi
 
           # Build additions/deletions arrays for the GraphQL mutation.
-          # `additions` need base64-encoded contents; `deletions` need only path.
-          ADDITIONS='[]'
-          DELETIONS='[]'
+          # Stream entries to NDJSON files so each `jq` invocation has a
+          # tiny argv -- accumulating the JSON via `--argjson` would exceed
+          # the kernel's ARG_MAX once base64-encoded contents pile up.
+          # See #4045.
+          ADDITIONS_FILE=$(mktemp)
+          DELETIONS_FILE=$(mktemp)
+          trap 'rm -f "$ADDITIONS_FILE" "$DELETIONS_FILE"' EXIT
           while IFS=$'\t' read -r status path; do
             case "$status" in
               M|A)
-                content_b64=$(base64 -w0 < "$path")
-                ADDITIONS=$(jq --arg p "$path" --arg c "$content_b64" \
-                  '. + [{path: $p, contents: $c}]' <<< "$ADDITIONS")
+                base64 -w0 < "$path" \
+                  | jq -ncR --arg p "$path" '{path: $p, contents: input}' \
+                  >> "$ADDITIONS_FILE"
                 ;;
               D)
-                DELETIONS=$(jq --arg p "$path" \
-                  '. + [{path: $p}]' <<< "$DELETIONS")
+                jq -nc --arg p "$path" '{path: $p}' >> "$DELETIONS_FILE"
                 ;;
               *)
                 echo "::warning::Unsupported diff status '$status' for path '$path'; skipping."
@@ -143,14 +146,17 @@ jobs:
             esac
           done < <(git diff --name-status HEAD)
 
-          PAYLOAD=$(jq -n \
+          # `--slurpfile` reads each file as an array of its JSON values, so
+          # the large base64 payload never crosses the command line.
+          PAYLOAD_FILE=$(mktemp)
+          jq -n \
             --arg query 'mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url oid } } }' \
             --arg repo "$REPO" \
             --arg branch "$HEAD_BRANCH" \
             --arg msg "docs: update version references to v${VERSION}" \
             --arg oid "$HEAD_OID" \
-            --argjson adds "$ADDITIONS" \
-            --argjson dels "$DELETIONS" \
+            --slurpfile adds "$ADDITIONS_FILE" \
+            --slurpfile dels "$DELETIONS_FILE" \
             '{
               query: $query,
               variables: {
@@ -161,13 +167,14 @@ jobs:
                   fileChanges: { additions: $adds, deletions: $dels }
                 }
               }
-            }')
+            }' > "$PAYLOAD_FILE"
 
-          # `gh api graphql --input -` posts the assembled body. Authentication
+          # `gh api graphql --input` posts the assembled body. Authentication
           # uses GITHUB_TOKEN (the release-plz App installation token); this
           # works because GraphQL accepts the same App token that already had
           # contents:write permission for the previous git push path.
-          RESPONSE=$(echo "$PAYLOAD" | gh api graphql --input -)
+          RESPONSE=$(gh api graphql --input "$PAYLOAD_FILE")
+          rm -f "$PAYLOAD_FILE"
 
           NEW_OID=$(jq -r '.data.createCommitOnBranch.commit.oid' <<< "$RESPONSE")
           NEW_URL=$(jq -r '.data.createCommitOnBranch.commit.url' <<< "$RESPONSE")


### PR DESCRIPTION
## Summary

Fix `jq: Argument list too long` failure in the version-refs step that was
introduced by #4043. Switch from `--argjson` accumulation in a loop to a
streaming pattern that uses NDJSON temp files + `jq --slurpfile`, so per-
invocation `argv` stays tiny regardless of how many files
`update-version-refs.sh` modifies.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

After #4043 merged, the next release-plz run failed at the
`Update version references in release branch` step:

```
/opt/actions-runner/_work/_temp/...sh: line 64: /usr/bin/jq: Argument list too long
##[error]Process completed with exit code 126.
```

(Run: <https://github.com/kent8192/reinhardt-web/actions/runs/25140135622>)

37 files were modified by `update-version-refs.sh` (README + 27 crate
READMEs + docs + quickstart pages). The accumulation pattern repassed the
cumulative `additions` JSON to `jq` on each iteration:

```bash
ADDITIONS=$(jq --arg p "$path" --arg c "$content_b64" \
  '. + [{path: $p, contents: $c}]' <<< "$ADDITIONS")
```

With base64-encoded contents, the cumulative `argv` quickly exceeded the
kernel's `ARG_MAX` limit (typically 128KB-2MB on Linux), and `jq` could
not be `exec()`'d.

As a result, PR #4044 currently has **only the `chore: release` commit**
and is missing the `docs: update version references to v0.1.0-rc.24`
commit entirely. The release would ship with stale version refs in
README, examples, docs, etc.

Fixes #4045
Refs #4042, #4043, #4044 (live broken release PR)

## How Was This Tested?

- `yq eval '.' .github/workflows/release-plz.yml > /dev/null` — YAML OK.
- Extracted `run:` block, `bash -n` — bash syntax OK.
- Locally simulated the streaming pattern with 40 synthetic 5KB-base64
  files. The payload assembles to ~360KB total and contains all 40
  additions, matching the schema for `CreateCommitOnBranchInput!`.
- Runtime verification will happen on the next release-plz run after
  merge: PR head SHA should receive **two** commits (`chore: release` +
  `docs: update version references to v...`) and full Actions check-runs.

## Implementation Notes

- `jq -ncR ... '{path: $p, contents: input}'` reads base64 from stdin so
  the per-invocation argv only carries the path string.
- `jq --slurpfile adds <file>` reads the temp file as an array of JSON
  values, avoiding the argv channel for the large payload.
- `gh api graphql --input <file>` uses the file path (not `-`) so we
  don't materialize the whole payload in a shell variable either.
- `trap 'rm -f ...' EXIT` cleans up temp files even on error.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable) — workflow comments updated
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (workflow-only; runtime verification only)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable) — N/A
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️ -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4045
- Refs #4042 (root cause: bot-committer suppression)
- Refs #4043 (PR that introduced this regression)
- Refs #4044 (live broken release PR missing the version-refs commit)

## Labels to Apply

### Type Label (select one)
- [x] `bug` — Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` — CI/CD workflow changes

### Priority
- [x] `high` — Blocks every release until merged

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
