### PR TITLE
fix(macros): suppress null=true emission for Option<T> primary keys

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -2657,14 +2657,23 @@ fn generate_registration_code(
 		{
 			params.push(quote! { .with_param("unique", "true") });
 		}
-		// Infer nullable from Rust type when not explicitly set
+		// Infer nullable from Rust type when not explicitly set.
+		//
+		// PK columns are always NOT NULL at the DB level. The Option<T>
+		// wrapper for PKs is a Rust-side convention to allow `id = None`
+		// before the DB assigns the auto-increment value, not a DB-level
+		// nullability statement. Emitting `null = "true"` for `Option<T>`
+		// PKs would diverge from `column_def_to_field_state`'s migration-
+		// replay output (which derives nullability from `not_null`) and
+		// surface as a spurious `AlterColumn` for the unchanged PK under
+		// offline state reconstruction.
+		//
+		// See reinhardt-web#4052 for the residual regression.
 		if config.null.is_none() {
 			let (is_option, _) = extract_option_type(&field_info.ty);
-			if is_option {
-				params.push(quote! { .with_param("null", "true") });
-			} else {
-				params.push(quote! { .with_param("null", "false") });
-			}
+			let nullable = !config.primary_key && is_option;
+			let null_str = nullable.to_string();
+			params.push(quote! { .with_param("null", #null_str) });
 		}
 		// auto_increment: explicit value or default true for integer PKs
 		if config.primary_key && is_integer_primary_key_type(&field_info.ty) {

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -6945,6 +6945,158 @@ mod tests {
 	}
 
 	#[rstest]
+	fn generate_operations_no_spurious_altercolumn_for_option_pk_via_apply_migration_operations() {
+		// Arrange — regression for issue #4052 (residual after #4050).
+		//
+		// Reproduces the production CLI path that #4050's regression test
+		// missed: from_state is built by feeding a synthetic
+		// `Operation::CreateTable` (modeled on `0001_initial.rs`) through
+		// `ProjectState::apply_migration_operations`, so its `id` FieldState
+		// flows through `column_def_to_field_state`. to_state mirrors the
+		// `#[model]` macro's output for `id: Option<i64>` with
+		// `#[field(primary_key = true)]` AFTER the macro fix that suppresses
+		// `null = "true"` for primary keys (the Option<T> wrapper for PKs
+		// reflects "id is None until DB assigns it on insert", not DB-level
+		// nullability).
+		//
+		// Pre-fix, the macro emitted `null = "true"` for any Option<T>
+		// field, including PKs. `to_model_state` then set
+		// `FieldState.nullable = true` while `column_def_to_field_state`
+		// produced `nullable = false`. `has_field_changed`'s direct
+		// `nullable != nullable` short-circuit (added by #4050 to keep the
+		// authoritative NOT NULL bit on the canonical comparison path)
+		// returned true before the canonical `ColumnDefinition::from_field_state`
+		// folding could absorb the asymmetry, surfacing as a no-op
+		// `Operation::AlterColumn { old_definition: None, .. }` for the
+		// unchanged PK.
+
+		// Build to_state via the model registry layer that the macro feeds.
+		// Mirror the FIXED macro params for `id: Option<i64>` with
+		// `#[field(primary_key = true)]`: `null = "false"` (forced by the
+		// fix), `not_null = "true"`, `primary_key = "true"`,
+		// `auto_increment = "true"`. The dense param population is exactly
+		// what `ModelMetadata::to_model_state` consumes.
+		let mut id_meta =
+			super::super::model_registry::FieldMetadata::new(super::super::FieldType::BigInteger);
+		id_meta = id_meta
+			.with_param("primary_key", "true")
+			.with_param("auto_increment", "true")
+			.with_param("not_null", "true")
+			.with_param("null", "false");
+		let mut name_meta =
+			super::super::model_registry::FieldMetadata::new(super::super::FieldType::VarChar(255));
+		name_meta = name_meta
+			.with_param("max_length", "255")
+			.with_param("not_null", "true")
+			.with_param("null", "false");
+
+		let mut metadata =
+			super::super::model_registry::ModelMetadata::new("clusters", "Cluster", "clusters");
+		metadata.add_field("id".to_string(), id_meta);
+		metadata.add_field("name".to_string(), name_meta);
+
+		let to_model = metadata.to_model_state();
+		// Sanity: the FIXED macro contract must fold `null = "false"` into
+		// `FieldState.nullable = false` for the PK, matching the migration
+		// replay side.
+		let to_id = to_model.fields.get("id").expect("id field present");
+		assert!(
+			!to_id.nullable,
+			"to_state PK FieldState.nullable must be false; got nullable=true \
+			 with params={:?}. Did the #[model] macro regress to emitting \
+			 null=\"true\" for Option<T> PKs?",
+			to_id.params
+		);
+
+		let to_state = build_project_state(vec![(
+			("clusters".to_string(), "Cluster".to_string()),
+			to_model,
+		)]);
+
+		// Build from_state via the production CLI path: feed a CreateTable
+		// (modeled on 0001_initial.rs) through apply_migration_operations.
+		// This populates from_state via column_def_to_field_state, which
+		// derives nullability from `not_null` (sparse params).
+		let create_clusters = super::super::Operation::CreateTable {
+			name: "clusters".to_string(),
+			columns: vec![
+				super::super::ColumnDefinition {
+					name: "id".to_string(),
+					type_definition: super::super::FieldType::BigInteger,
+					not_null: true,
+					unique: false,
+					primary_key: true,
+					auto_increment: true,
+					default: None,
+				},
+				super::super::ColumnDefinition {
+					name: "name".to_string(),
+					type_definition: super::super::FieldType::VarChar(255),
+					not_null: true,
+					unique: false,
+					primary_key: false,
+					auto_increment: false,
+					default: None,
+				},
+			],
+			constraints: vec![],
+			without_rowid: None,
+			interleave_in_parent: None,
+			partition: None,
+		};
+		let mut from_state = ProjectState::new();
+		from_state.apply_migration_operations(&[create_clusters], "clusters");
+
+		// Sanity: the migration-replay path must produce nullable=false for
+		// the PK.
+		let from_clusters = from_state
+			.find_model_by_table("clusters")
+			.expect("clusters model present in from_state");
+		assert!(
+			!from_clusters
+				.fields
+				.get("id")
+				.expect("id field in from_state")
+				.nullable,
+			"from_state PK FieldState.nullable must be false (column_def_to_field_state derives \
+			 from not_null); got nullable=true"
+		);
+
+		let detector = MigrationAutodetector::new(from_state, to_state);
+
+		// Act — call BOTH lower-level generate_operations() and the CLI
+		// entry generate_migrations(), since #4052's reproducer asserts
+		// against both.
+		let direct_ops = detector.generate_operations();
+		let migrations = detector.generate_migrations();
+		let migration_ops: Vec<&super::super::Operation> = migrations
+			.iter()
+			.flat_map(|m| m.operations.iter())
+			.collect();
+
+		// Assert — neither path may emit AlterColumn for the unchanged `id`
+		// PK. Pre-fix, both emitted exactly such an AlterColumn.
+		assert!(
+			!direct_ops.iter().any(|op| matches!(
+				op,
+				super::super::Operation::AlterColumn { column, .. } if column == "id"
+			)),
+			"generate_operations() emitted spurious AlterColumn for unchanged `id` PK \
+			 under apply_migration_operations from_state. ops={:?}",
+			direct_ops
+		);
+		assert!(
+			!migration_ops.iter().any(|op| matches!(
+				op,
+				super::super::Operation::AlterColumn { column, .. } if column == "id"
+			)),
+			"generate_migrations() emitted spurious AlterColumn for unchanged `id` PK \
+			 under apply_migration_operations from_state. ops={:?}",
+			migration_ops
+		);
+	}
+
+	#[rstest]
 	fn generate_migrations_emits_add_constraint_for_added_unique_together() {
 		// Arrange — regression for issue #4040.
 		//

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -663,4 +663,62 @@ mod tests {
 		let field_state = model_state.fields.get("description").unwrap();
 		assert_eq!(field_state.nullable, expected_nullable);
 	}
+
+	#[rstest]
+	fn to_model_state_nullable_false_for_primary_key_matches_macro_contract() {
+		// Arrange — regression for issue #4052.
+		//
+		// The `#[model]` macro must emit `null = "false"` for primary key
+		// fields regardless of whether the Rust type is `Option<T>`. The
+		// `Option<T>` wrapper for PKs is a Rust-side convention to allow
+		// `id = None` before the DB assigns the auto-increment value, not
+		// a DB-level nullability statement. PK columns are always NOT NULL
+		// at the DB level.
+		//
+		// This test codifies the contract that `to_model_state` consumes
+		// from the macro: with the fixed macro params, the resulting
+		// `FieldState.nullable` for an `Option<i64>` PK must be `false`,
+		// matching the migration-replay path's
+		// `column_def_to_field_state(...).nullable = !col.not_null = false`.
+		//
+		// Pre-fix, the macro emitted `null = "true"` for any Option<T>
+		// field including PKs, producing `FieldState.nullable = true` and
+		// surfacing as a spurious `AlterColumn` for the unchanged PK in
+		// offline `makemigrations` runs.
+		let mut metadata = ModelMetadata::new("clusters", "Cluster", "clusters");
+		// Mirror the fixed macro params for `id: Option<i64>` with
+		// `#[field(primary_key = true)]`: `null = "false"` (forced by the
+		// fix), `not_null = "true"`, `primary_key = "true"`,
+		// `auto_increment = "true"`.
+		let id_field = FieldMetadata::new(FieldType::BigInteger)
+			.with_param("primary_key", "true")
+			.with_param("auto_increment", "true")
+			.with_param("not_null", "true")
+			.with_param("null", "false");
+		metadata.add_field("id".to_string(), id_field);
+
+		// Act
+		let model_state = metadata.to_model_state();
+
+		// Assert — nullable=false on the FieldState side, regardless of
+		// the underlying Rust Option<T> wrapping.
+		let id_state = model_state
+			.fields
+			.get("id")
+			.expect("id field present in to_model_state output");
+		assert!(
+			!id_state.nullable,
+			"PK FieldState.nullable must be false even when the Rust type is \
+			 Option<i64>. Did the #[model] macro regress to emitting \
+			 null=\"true\" for Option<T> PKs? params={:?}",
+			id_state.params
+		);
+		assert_eq!(
+			id_state.params.get("null").map(String::as_str),
+			Some("false"),
+			"PK params[\"null\"] must be \"false\" (fixed macro contract). \
+			 Got params={:?}",
+			id_state.params
+		);
+	}
 }


### PR DESCRIPTION
## Summary

- Macro fix: `#[model]` no longer infers `null = \"true\"` for `Option<T>` fields when they are primary keys
- Resolves the residual after #4050: PK FieldState.nullable now matches between `apply_migration_operations` migration-replay and `to_model_state` registry paths
- Eliminates the spurious no-op `Operation::AlterColumn { old_definition: None, .. }` that `kent8192/reinhardt-cloud#469` had to hand-edit out of every regenerated migration

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

After #4050 closed #4049, the `dashboard/migrations/clusters/...` regeneration in `kent8192/reinhardt-cloud@chore/reinhardt-web-main-refactor` still emitted a no-op `AlterColumn` for the unchanged `id` PK. The reproducer is captured by the (currently `#[ignore]`-marked) `diag_apply_migration_operations_from_state_no_spurious_altercolumn` test pinned at `reinhardt-web` `main` `9cfaa26c`.

### Root cause

The `Cluster` model declares `id: Option<i64>` with `#[field(primary_key = true)]`. The `Option<T>` wrapper is a Rust-side convention to allow `id = None` before the DB assigns the auto-increment value — it is **not** a DB-level nullability statement. PK columns are always `NOT NULL` at the DB level.

Pre-fix, the macro at `crates/reinhardt-core/macros/src/model_derive.rs:2660-2668` derived `null` purely from the Rust `Option<T>` wrapper, even for primary keys:

```rust
if config.null.is_none() {
    let (is_option, _) = extract_option_type(&field_info.ty);
    if is_option {
        params.push(quote! { .with_param(\"null\", \"true\") });   // wrong for PK
    } else {
        params.push(quote! { .with_param(\"null\", \"false\") });
    }
}
```

This produced `params[\"null\"] = \"true\"` on the registry side. `ModelMetadata::to_model_state` (model_registry.rs:160) then set `FieldState.nullable = true`. Meanwhile `column_def_to_field_state` (autodetector.rs:1322) correctly produced `nullable = !col.not_null = false` from `0001_initial`'s `CreateTable` whose `id` column has `not_null = true`.

`has_field_changed` (autodetector.rs:3920, post-#4050) compares `nullable` directly:

```rust
if from_field.nullable != to_field.nullable {
    return true;   // false != true → returns early
}
// canonicalization via from_field_state never reached
```

The canonical `ColumnDefinition::from_field_state` folding (added by #4050) was never reached, so the asymmetry surfaced as `altered_fields.push((\"clusters\", \"Cluster\", \"id\"))` and downstream as the spurious `AlterColumn`.

### Why #4050's regression test missed this

`generate_operations_no_spurious_altercolumn_for_pk_via_offline_reconstructed_state` hand-builds `from_id_field.nullable = false` and `to_id_field.nullable = false` on both sides (autodetector.rs:6856, 6889). It exercises the `params` HashMap asymmetry that #4050 was designed to canonicalize, but it never flows through the macro path that produces the divergent `nullable` bit, because both sides of the test are aligned. The macro contract that `to_model_state` consumes was never anchored.

### Fix scope

`config.primary_key` is now folded into the `null` inference at the macro source — the same logic the surrounding `is_not_null` inference (lines 2634-2645) already uses. This collapses the asymmetry at the source, so every downstream consumer of `FieldState.nullable` sees aligned bits:

| Consumer | Pre-fix behavior | Post-fix behavior |
|---|---|---|
| `has_field_changed` (autodetector.rs:3920) | spurious `AlterColumn` for unchanged `Option<T>` PK | no diff |
| `to_database_schema*` → `schema_diff::detect()` (autodetector.rs:556/645) | spurious `AlterColumn` from live-DB introspection diff (Bug B in investigation) | no diff |
| `detect_renamed_fields` (autodetector.rs:4080) | `Option<T>` PK rename mis-classified as drop+create | rename detected |
| `nullable_boost` (autodetector.rs:4237) | model rename similarity reduced when one side has `Option<T>` PK | full boost |

## How Was This Tested

Added two regression tests:

- `to_model_state_nullable_false_for_primary_key_matches_macro_contract` (model_registry.rs) — codifies the macro contract that `to_model_state` consumes: with the fixed params (`null = \"false\"`, `not_null = \"true\"`, `primary_key = \"true\"`, `auto_increment = \"true\"`), the resulting `FieldState.nullable` is `false`.
- `generate_operations_no_spurious_altercolumn_for_option_pk_via_apply_migration_operations` (autodetector.rs) — mirrors the issue #4052 production CLI path: builds `from_state` via `apply_migration_operations` from a `CreateTable` modeled on `0001_initial.rs`, builds `to_state` via `ModelMetadata::to_model_state` with the fixed dense params, and asserts neither `generate_operations()` nor `generate_migrations()` emits an `AlterColumn` for the unchanged `id` PK.

Verification:
- [x] `cargo check -p reinhardt-db --tests` passes
- [x] `cargo test -p reinhardt-db --lib migrations::` — 551 passed, 0 failed
- [x] `cargo test -p reinhardt-db --test migrations_graph --test orm_model_fields --test orm_queryset_builder` — all passed
- [x] `cargo make fmt-check` — 0 would be formatted, 2702 unchanged
- [x] `cargo clippy -p reinhardt-macros --tests` — clean
- [x] Pre-existing `generate_operations_no_spurious_altercolumn_for_pk_via_offline_reconstructed_state` (#4050 regression) still passes
- [ ] **Cross-repo follow-up** (NOT in scope of this PR): un-ignore `diag_apply_migration_operations_from_state_no_spurious_altercolumn` in `kent8192/reinhardt-cloud@chore/reinhardt-web-main-refactor` and remove `dashboard/migrations/clusters/0005_add_organization_id_name_unique.rs` workaround once this fix is published

## Breaking Changes

None at the API or schema level. The macro change only affects the `null` registry param emitted for primary key fields whose Rust type is `Option<T>`. Pre-fix the param was misleading (`\"true\"` for a column that is in fact `NOT NULL` at the DB level); post-fix it correctly reads `\"false\"`. No public types or function signatures change.

Existing migrations are unaffected — the param is consumed at registry-build time, not persisted.

## Related Issues

Fixes #4052
Refs #4049 #4050

## Labels to Apply

- bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)