### PR TITLE
fix(apps): validate database url scheme at ApplicationBuilder::build

### DIFF
--- a/crates/reinhardt-apps/src/builder.rs
+++ b/crates/reinhardt-apps/src/builder.rs
@@ -144,7 +144,19 @@ pub struct ApplicationDatabaseConfig {
 }
 
 impl ApplicationDatabaseConfig {
-	/// Create a new database configuration
+	/// Create a new database configuration.
+	///
+	/// The URL is stored as-is at this stage; scheme validation is performed
+	/// later by [`ApplicationBuilder::build`] so that
+	/// [`ApplicationDatabaseConfig`] remains a plain data carrier. Build-time
+	/// validation rejects unrecognized schemes (see issue
+	/// [#485](https://github.com/kent8192/reinhardt-web/issues/485)) before any
+	/// connection attempt is made.
+	///
+	/// A future major release may move this validation into the constructor
+	/// itself; see issue
+	/// [#4056](https://github.com/kent8192/reinhardt-web/issues/4056) for the
+	/// breaking-change proposal.
 	///
 	/// # Examples
 	///
@@ -446,6 +458,14 @@ impl ApplicationBuilder {
 					full_name
 				)));
 			}
+		}
+
+		// Validate the database URL scheme at build time so that obviously
+		// malformed URLs surface as a clear configuration error rather than
+		// later as an opaque connection failure (issue #485).
+		if let Some(db_config) = &self.database_config {
+			reinhardt_conf::settings::database_config::validate_database_url_scheme(&db_config.url)
+				.map_err(BuildError::DatabaseError)?;
 		}
 
 		Ok(())
@@ -950,6 +970,67 @@ mod tests {
 		assert_eq!(db_config.pool_size, None);
 		assert_eq!(db_config.max_overflow, None);
 		assert_eq!(db_config.timeout, None);
+	}
+
+	// Issue #485: build-time validation of the database URL scheme. The
+	// constructor stays infallible (data-carrier role); rejection happens
+	// once, at build() time.
+
+	#[rstest::rstest]
+	#[case::postgres("postgres://localhost/db")]
+	#[case::postgresql("postgresql://user:pass@localhost:5432/db")]
+	#[case::sqlite_memory("sqlite::memory:")]
+	#[case::sqlite_absolute("sqlite:///var/data/db.sqlite3")]
+	#[case::sqlite_relative("sqlite:db.sqlite3")]
+	#[case::mysql("mysql://root@localhost/db")]
+	#[case::mariadb("mariadb://root@localhost/db")]
+	#[serial(apps_registry)]
+	fn test_application_builder_accepts_valid_database_url_scheme(#[case] url: &str) {
+		// Arrange
+		crate::registry::reset_global_registry();
+		let db_config = ApplicationDatabaseConfig::new(url);
+
+		// Act
+		let result = ApplicationBuilder::new().database(db_config).build();
+
+		// Assert
+		assert!(
+			result.is_ok(),
+			"expected URL {:?} to be accepted but got {:?}",
+			url,
+			result.err()
+		);
+	}
+
+	#[rstest::rstest]
+	#[case::empty("")]
+	#[case::not_a_url("not a url")]
+	#[case::http("http://localhost/db")]
+	#[case::ftp("ftp://localhost/db")]
+	#[case::redis("redis://localhost")]
+	#[case::missing_scheme("localhost/db")]
+	fn test_application_builder_rejects_invalid_database_url_scheme(#[case] url: &str) {
+		// Arrange
+		let db_config = ApplicationDatabaseConfig::new(url);
+
+		// Act
+		// `Application` does not implement `Debug`, so we cannot use
+		// `expect_err()` here (it would require `T: Debug`). Match instead.
+		let result = ApplicationBuilder::new().database(db_config).build();
+
+		// Assert
+		match result {
+			Err(BuildError::DatabaseError(msg)) => {
+				assert!(
+					msg.contains("Invalid database URL"),
+					"unexpected error message for {:?}: {}",
+					url,
+					msg
+				);
+			}
+			Err(other) => panic!("expected BuildError::DatabaseError, got {:?}", other),
+			Ok(_) => panic!("expected build to fail for invalid URL: {:?}", url),
+		}
 	}
 
 	#[test]

--- a/crates/reinhardt-conf/src/settings/database_config.rs
+++ b/crates/reinhardt-conf/src/settings/database_config.rs
@@ -342,8 +342,7 @@ impl Default for DatabaseConfig {
 }
 
 /// Recognized database URL schemes for connection validation.
-#[allow(dead_code)] // Used by backends::database which may not be compiled in all configurations
-pub(crate) const VALID_DATABASE_SCHEMES: &[&str] = &[
+pub const VALID_DATABASE_SCHEMES: &[&str] = &[
 	"postgres://",
 	"postgresql://",
 	"sqlite://",
@@ -356,8 +355,7 @@ pub(crate) const VALID_DATABASE_SCHEMES: &[&str] = &[
 ///
 /// Returns `Ok(())` if the URL starts with one of the supported schemes,
 /// or `Err` with a descriptive message listing the accepted schemes.
-#[allow(dead_code)] // Used by backends::database which may not be compiled in all configurations
-pub(crate) fn validate_database_url_scheme(url: &str) -> Result<(), String> {
+pub fn validate_database_url_scheme(url: &str) -> Result<(), String> {
 	if VALID_DATABASE_SCHEMES.iter().any(|s| url.starts_with(s)) {
 		Ok(())
 	} else {


### PR DESCRIPTION
## Summary

- Reject malformed database URLs at build time so issue #485's symptom (silent acceptance, then opaque connection failure) surfaces as a clear `BuildError::DatabaseError` instead.
- Re-use the existing `validate_database_url_scheme` from `reinhardt-conf` (promoted from `pub(crate)` to `pub`) so accepted schemes (postgres / postgresql / sqlite / mysql / mariadb) stay in one place.
- Constructor signature is intentionally **not** changed: `ApplicationDatabaseConfig::new()` stays infallible to avoid an RC-phase breaking change. The `Result`-returning constructor is tracked as a post-RC proposal in #4056.

## Why this layer

Verifying #485 showed that PR #1241 added validation in `reinhardt-conf::DatabaseBackend::new()` but left `ApplicationDatabaseConfig` (the exact code path called out in the issue) untouched. Adding the check in `ApplicationBuilder::validate()` (called from `build()`) keeps `ApplicationDatabaseConfig` as a plain data carrier while still failing early — strictly earlier than connection time, strictly later than construction time, and strictly without breaking the API.

See the design discussion in #4056 for the full rationale and the trade-offs against the breaking-change alternative.

## Changes

- `crates/reinhardt-conf/src/settings/database_config.rs` — `validate_database_url_scheme` and `VALID_DATABASE_SCHEMES` are now `pub` (the dead-code allow attributes are no longer needed).
- `crates/reinhardt-apps/src/builder.rs`
  - `ApplicationBuilder::validate()` now rejects unrecognized schemes with `BuildError::DatabaseError`.
  - Doc comment on `ApplicationDatabaseConfig::new()` clarifies that validation happens at `build()` time and links to #485 / #4056.
  - Adds 13 parametrized `rstest` cases (7 accepted, 6 rejected) following the AAA pattern.

## Test plan

- [x] `cargo check -p reinhardt-apps -p reinhardt-conf --all-features`
- [x] `cargo nextest run -p reinhardt-apps -p reinhardt-conf --all-features` — 739 tests pass, 2 skipped
- [x] `cargo fmt --check -p reinhardt-apps -p reinhardt-conf`
- [x] `cargo clippy -p reinhardt-apps -p reinhardt-conf --all-features -- -D warnings` — 0 warnings
- [ ] CI green

Fixes #485
Refs #4056

🤖 Generated with [Claude Code](https://claude.com/claude-code)