### PR TITLE
feat(commands): expose auto_register_router and add start_server helper

### DIFF
--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -1264,6 +1264,50 @@ pub async fn auto_register_router() -> Result<(), Box<dyn std::error::Error>> {
 	Ok(())
 }
 
+/// Start the HTTP server bound to `addr`, performing automatic route
+/// registration via [`auto_register_router`] beforehand.
+///
+/// This is a one-call convenience wrapper around the
+/// [`auto_register_router`] + [`RunServerCommand`](crate::RunServerCommand)
+/// composition. It is intended for **non-CLI server entrypoints** — for
+/// example, a container entrypoint binary that should expose only an HTTP
+/// server without the full `manage` clap surface.
+///
+/// All [`RunServerCommand`](crate::RunServerCommand) options other than the
+/// bind address use their built-in defaults (autoreload enabled, no WASM
+/// frontend, `dist` static directory, etc.). Callers needing finer control
+/// should compose with [`auto_register_router`] and
+/// [`RunServerCommand`](crate::RunServerCommand) directly.
+///
+/// Use [`execute_from_command_line`] instead when you want full clap argument
+/// parsing for the `manage` subcommand surface.
+///
+/// # Arguments
+///
+/// * `addr` - Bind address in `host:port` form (e.g. `"0.0.0.0:8080"`).
+///
+/// # Returns
+///
+/// Returns `Ok(())` on graceful shutdown, or an error if route registration
+/// or the server itself fails.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use reinhardt_commands::start_server;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     start_server("0.0.0.0:8080").await
+/// }
+/// ```
+#[cfg(feature = "server")]
+pub async fn start_server(addr: &str) -> Result<(), Box<dyn std::error::Error>> {
+	auto_register_router().await?;
+	let ctx = CommandContext::new(vec![addr.to_string()]);
+	RunServerCommand.execute(&ctx).await.map_err(Into::into)
+}
+
 /// Generate a cryptographically random secret key for fallback use.
 ///
 /// Produces a 50-character hex string (200 bits of entropy). This is used

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -1149,18 +1149,52 @@ async fn execute_generateopenapi(
 // Automatic Router Registration
 // ============================================================================
 
-/// Automatically discover and register URL pattern functions
+/// Automatically discover and register URL pattern functions.
 ///
 /// This function uses the `inventory` crate to discover URL pattern functions
-/// that were registered at compile time using the `#[routes]` attribute macro.
+/// that were registered at compile time using the `#[routes]` attribute macro,
+/// then installs the resulting router into the global router slot consumed by
+/// [`RunServerCommand`](crate::RunServerCommand).
+///
+/// [`execute_from_command_line`] calls this internally for HTTP-serving
+/// subcommands, so most applications never need to invoke it directly. It is
+/// exposed as a public building block for **non-CLI server entrypoints** —
+/// for example, a container entrypoint binary that calls
+/// [`RunServerCommand::execute`](crate::RunServerCommand) directly without
+/// going through clap argument parsing.
+///
+/// For the common "just start the HTTP server" case, prefer the higher-level
+/// [`start_server`] helper which wraps this function and `RunServerCommand`.
 ///
 /// # Returns
 ///
 /// Returns `Ok(())` on success, or an error if:
-/// - No URL patterns were registered
-/// - Multiple `#[routes]` functions were detected (should normally be caught at link time)
+/// - No URL patterns were registered (no `#[routes]` function was reachable
+///   from the linked binary)
+/// - Multiple `#[routes]` functions were detected (should normally be caught
+///   at link time)
+///
+/// # Examples
+///
+/// Compose with [`RunServerCommand`](crate::RunServerCommand) directly when
+/// you need control beyond what [`start_server`] offers:
+///
+/// ```rust,no_run
+/// use reinhardt_commands::{auto_register_router, BaseCommand, CommandContext, RunServerCommand};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     auto_register_router().await?;
+///
+///     let mut ctx = CommandContext::new(vec!["0.0.0.0:8080".to_string()]);
+///     ctx.set_option("noreload".to_string(), "true".to_string());
+///
+///     RunServerCommand.execute(&ctx).await?;
+///     Ok(())
+/// }
+/// ```
 #[cfg(feature = "routers")]
-async fn auto_register_router() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn auto_register_router() -> Result<(), Box<dyn std::error::Error>> {
 	use reinhardt_urls::routers::{UrlPatternsRegistration, register_router_arc};
 
 	// Collect all registrations for validation
@@ -1219,9 +1253,13 @@ async fn auto_register_router() -> Result<(), Box<dyn std::error::Error>> {
 	Ok(())
 }
 
-/// No-op implementation when routers feature is disabled
+/// No-op implementation when the `routers` feature is disabled.
+///
+/// Kept public to preserve API stability across feature-flag toggles: callers
+/// of [`auto_register_router`] should compile regardless of whether `routers`
+/// is enabled in the consuming crate.
 #[cfg(not(feature = "routers"))]
-async fn auto_register_router() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn auto_register_router() -> Result<(), Box<dyn std::error::Error>> {
 	// No router registration needed when routers feature is disabled
 	Ok(())
 }

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -191,6 +191,8 @@ pub use builtin::MakeMigrationsCommand;
 #[cfg(feature = "routers")]
 pub use builtin::ShowUrlsCommand;
 pub use builtin::{CheckCommand, CheckDiCommand, MigrateCommand, RunServerCommand, ShellCommand};
+#[cfg(feature = "server")]
+pub use cli::start_server;
 pub use cli::{
 	Cli, Commands, auto_register_router, execute_from_command_line,
 	execute_from_command_line_with_registry, run_command, run_command_with_registry,

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -192,8 +192,8 @@ pub use builtin::MakeMigrationsCommand;
 pub use builtin::ShowUrlsCommand;
 pub use builtin::{CheckCommand, CheckDiCommand, MigrateCommand, RunServerCommand, ShellCommand};
 pub use cli::{
-	Cli, Commands, execute_from_command_line, execute_from_command_line_with_registry, run_command,
-	run_command_with_registry,
+	Cli, Commands, auto_register_router, execute_from_command_line,
+	execute_from_command_line_with_registry, run_command, run_command_with_registry,
 };
 pub use collectstatic::{CollectStaticCommand, CollectStaticOptions, CollectStaticStats};
 pub use context::CommandContext;

--- a/crates/reinhardt-commands/tests/public_server_api_tests.rs
+++ b/crates/reinhardt-commands/tests/public_server_api_tests.rs
@@ -1,0 +1,54 @@
+//! Smoke tests for the public non-CLI server entrypoint surface (#4055).
+//!
+//! These tests verify that `auto_register_router` and `start_server` are
+//! reachable from outside the crate and surface the expected error when no
+//! `#[routes]` function is reachable in the test binary.
+
+use rstest::*;
+
+#[cfg(feature = "routers")]
+#[rstest]
+#[tokio::test]
+async fn auto_register_router_is_public_and_reports_missing_routes() {
+	// Arrange: integration-test binaries do not link any consumer-side
+	// `#[routes]` registration, so the inventory walk must be empty.
+
+	// Act
+	let result = reinhardt_commands::auto_register_router().await;
+
+	// Assert: function is reachable (public) and returns the documented
+	// "no routes registered" diagnostic with the lib+bin hint.
+	let err = result.expect_err("auto_register_router must error without #[routes]");
+	let message = err.to_string();
+	assert!(
+		message.contains("No URL patterns registered"),
+		"unexpected error message: {message}"
+	);
+	assert!(
+		message.contains("library/binary split"),
+		"missing lib+bin hint in error message: {message}"
+	);
+}
+
+#[cfg(feature = "server")]
+#[rstest]
+#[tokio::test]
+async fn start_server_is_public_and_propagates_route_registration_error() {
+	// Arrange: no #[routes] registered in the integration-test binary, so
+	// auto_register_router (called inside start_server) must fail before
+	// the server is bound. Using port 0 would otherwise bind a real socket.
+	let addr = "127.0.0.1:0";
+
+	// Act
+	let result = reinhardt_commands::start_server(addr).await;
+
+	// Assert: failure must come from route registration, not from binding,
+	// proving the helper performs auto-registration before delegating to
+	// RunServerCommand.
+	let err = result.expect_err("start_server must error without #[routes]");
+	let message = err.to_string();
+	assert!(
+		message.contains("No URL patterns registered"),
+		"start_server should surface auto_register_router error, got: {message}"
+	);
+}


### PR DESCRIPTION
## Summary

- Make `auto_register_router()` part of the public API of `reinhardt-commands` (both the `routers`-enabled and the no-op variants), giving downstream consumers a building block they can compose with `RunServerCommand::execute()` directly.
- Add a high-level `start_server(addr: &str)` helper (gated on `feature = "server"`) that performs auto-registration and delegates to `RunServerCommand` with a default `CommandContext` bound to the supplied address — the friendliest surface for non-CLI server entrypoints (e.g. container binaries that should not expose the `manage` clap surface).
- Re-export both new public symbols from the crate root and add an integration smoke test that locks in the public visibility contract and the route-registration error propagation path.

This implements the API change requested in #4055 (Option A *and* Option B from the issue) so that downstream `reinhardt-cloud-dashboard` (kent8192/reinhardt-cloud#478) can drop its inlined copy of `auto_register_router`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] CI/CD update
- [ ] Other

## Motivation and Context

`reinhardt-commands` previously offered two layers:

1. `execute_from_command_line()` — full clap dispatch, internally calls a private `auto_register_router()` for HTTP-serving subcommands.
2. `RunServerCommand::execute()` — public, but does **not** auto-register routes, so callers see `Execution error: No router registered.` immediately.

That left no public way to start the HTTP server in container-style entrypoint binaries that legitimately want to skip the `manage` clap surface. Consumers were forced to either re-implement the inventory walk locally or synthesize argv to call back through `execute_from_command_line()`.

This PR fills the gap by exposing the route-registration primitive *and* a one-call helper, so consumers can pick the level of control they need without leaking framework internals.

## How Was This Tested

- `cargo nextest run -p reinhardt-commands --all-features` — 923 tests pass (including the 2 newly added smoke tests).
- `cargo test --doc -p reinhardt-commands` — all 17 doc tests pass; the new rustdoc examples on `auto_register_router` and `start_server` compile cleanly.
- `cargo check -p reinhardt-commands --all-features`, `--no-default-features`, and `--no-default-features --features routers` all succeed (verifies feature-gate combinations for both the `routers` and `server` cuts).
- `cargo fmt --check -p reinhardt-commands` clean.
- Public API smoke test (`tests/public_server_api_tests.rs`) verifies that:
  - `auto_register_router()` is reachable as `reinhardt_commands::auto_register_router` and surfaces the `No URL patterns registered` diagnostic with the lib+bin hint.
  - `start_server(addr)` is reachable as `reinhardt_commands::start_server`, performs route registration before binding, and propagates the same diagnostic when no `#[routes]` are linked.

## Checklist

- [x] My code follows the project's style guidelines (2024 edition modules, English-only comments, tab indentation)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (rustdoc on the new public items, with runnable examples)
- [x] My changes generate no new warnings (the pre-existing clippy warnings under `crates/reinhardt-commands/src/template_source/*` are unrelated to this PR and exist on `main` already)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Labels to Apply

- `enhancement`
- `commands` (scope) — applied if available

## Breaking Changes

None — purely additive. Existing `execute_from_command_line()` callers are unaffected.

## Related Issues

Fixes #4055
Refs kent8192/reinhardt-cloud#478, kent8192/reinhardt-cloud#479

## Additional Context

Both new public items are gated on the existing feature flags:

- `auto_register_router()` — gated on `feature = "routers"`, with a public no-op variant under `cfg(not(feature = "routers"))` so callers can compile across feature toggles.
- `start_server(addr)` — gated on `feature = "server"` (which already implies `routers`), matching the gating of `RunServerCommand::run_server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)