### PR TITLE
fix(commands): remove redundant explicit link targets in cli.rs

### DIFF
--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -1154,7 +1154,7 @@ async fn execute_generateopenapi(
 /// This function uses the `inventory` crate to discover URL pattern functions
 /// that were registered at compile time using the `#[routes]` attribute macro,
 /// then installs the resulting router into the global router slot consumed by
-/// [`RunServerCommand`](crate::RunServerCommand).
+/// [`RunServerCommand`].
 ///
 /// [`execute_from_command_line`] calls this internally for HTTP-serving
 /// subcommands, so most applications never need to invoke it directly. It is
@@ -1176,7 +1176,7 @@ async fn execute_generateopenapi(
 ///
 /// # Examples
 ///
-/// Compose with [`RunServerCommand`](crate::RunServerCommand) directly when
+/// Compose with [`RunServerCommand`] directly when
 /// you need control beyond what [`start_server`] offers:
 ///
 /// ```rust,no_run
@@ -1268,16 +1268,16 @@ pub async fn auto_register_router() -> Result<(), Box<dyn std::error::Error>> {
 /// registration via [`auto_register_router`] beforehand.
 ///
 /// This is a one-call convenience wrapper around the
-/// [`auto_register_router`] + [`RunServerCommand`](crate::RunServerCommand)
+/// [`auto_register_router`] + [`RunServerCommand`]
 /// composition. It is intended for **non-CLI server entrypoints** — for
 /// example, a container entrypoint binary that should expose only an HTTP
 /// server without the full `manage` clap surface.
 ///
-/// All [`RunServerCommand`](crate::RunServerCommand) options other than the
+/// All [`RunServerCommand`] options other than the
 /// bind address use their built-in defaults (autoreload enabled, no WASM
 /// frontend, `dist` static directory, etc.). Callers needing finer control
 /// should compose with [`auto_register_router`] and
-/// [`RunServerCommand`](crate::RunServerCommand) directly.
+/// [`RunServerCommand`] directly.
 ///
 /// Use [`execute_from_command_line`] instead when you want full clap argument
 /// parsing for the `manage` subcommand surface.


### PR DESCRIPTION
## Summary

- Remove 5 redundant `(crate::RunServerCommand)` explicit link targets in `crates/reinhardt-commands/src/cli.rs` doc comments
- Each label `[\`RunServerCommand\`]` already resolves to the same destination, so the explicit target violates `rustdoc::redundant-explicit-links` (a warning promoted to error under docs.rs's `-D warnings`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Motivation and Context

The `Docs.rs Build Check` CI job has been failing on the active release-plz PR (#4063), blocking the next RC release. Failing run: https://github.com/kent8192/reinhardt-web/actions/runs/25160087289/job/73753614755

## How Was This Tested

- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo +nightly doc --no-deps -p reinhardt-commands --all-features` passes locally
- [x] Verified affected lines no longer emit `rustdoc::redundant-explicit-links`
- [x] Preserved `[\`RunServerCommand::execute\`](crate::RunServerCommand)` (different label and target → not redundant)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Linked to issue #4064

## Related Issues

Fixes #4064
Refs #4063

🤖 Generated with [Claude Code](https://claude.com/claude-code)