### PR TITLE
fix(pages-macros): keep server_fn use-stmt live on native (#4070)

### DIFF
--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -1584,7 +1584,12 @@ fn generate_submit_method(macro_ast: &TypedFormMacro, pages_crate: &TokenStream)
 
 				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 				pub async fn submit(&self) -> Result<(), #pages_crate::ServerFnError> {
-					// On server, submit is a no-op (form is submitted via HTTP)
+					// Reference server_fn on native so the user's `use` statement
+					// stays live and `unused_imports` does not fire under
+					// `-D warnings` (reinhardt-web#4070). The wasm branch is the
+					// only path that actually invokes it; on native the form is
+					// submitted over HTTP, so this is a pure compile-time sink.
+					let _ = &#server_fn_ident;
 					Ok(())
 				}
 			}

--- a/crates/reinhardt-pages/tests/ui/form/pass/choices_loader_basic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/choices_loader_basic.rs
@@ -21,3 +21,7 @@ fn main() {
 		},
 	};
 }
+
+// Mock server functions (would normally be defined with #[server_fn])
+fn submit_vote() {}
+fn get_poll_choices() {}

--- a/crates/reinhardt-pages/tests/ui/form/pass/server_fn_action_use.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/server_fn_action_use.rs
@@ -1,0 +1,26 @@
+//! Regression test for reinhardt-web#4070.
+//!
+//! When `server_fn:` is set to a function brought in scope via `use`, the
+//! `form!` expansion must reference the function on every target so the
+//! `use` statement is not flagged by `unused_imports` on native builds.
+#![deny(unused_imports)]
+
+use reinhardt_pages::form;
+
+mod server_fns {
+	pub fn submit_vote() {}
+}
+
+use server_fns::submit_vote;
+
+fn main() {
+	let _vote_form = form! {
+		name: VoteForm,
+		server_fn: submit_vote,
+
+		fields: {
+			_question_id: IntegerField { widget: HiddenInput },
+			_choice_id: IntegerField { required },
+		},
+	};
+}


### PR DESCRIPTION
## Summary

- Make `form! { server_fn: <fn>, ... }` reference `<fn>` on native targets so the user's `use` statement is not reported as `unused_imports` under `-D warnings`.
- Add a `server_fn_action_use` UI test (with `#![deny(unused_imports)]`) covering the imported-via-`use` regression.
- Update the existing `choices_loader_basic` UI test to declare stubs for `submit_vote` / `get_poll_choices` now that the server_fn ident is resolved on native too.

## Type of Change

- [x] Bug fix (non-breaking change)

## Motivation and Context

After #4068 made `UnifiedRouter` `Sync`, dashboard apps register their SPA `client(...)` page constructors from `make_router`. SPA page modules — including `form! { server_fn: <fn>, ... }` — therefore must compile on native. The macro emitted `<fn>` only in its wasm-gated `submit()` body, which left the user's `use crate::...::<fn>;` flagged as `unused_imports` on native and broke `-D warnings` CI in downstream apps.

The fix mirrors the existing `let _ = &__vh;` sink pattern used in `page!` codegen: add `let _ = &#server_fn_ident;` to the native no-op `submit()` body so the symbol is referenced (without being invoked) on every target.

## How Was This Tested

- `cargo nextest run -p reinhardt-pages --test ui` — all 5 trybuild suites pass.
- `cargo check -p reinhardt-pages --target wasm32-unknown-unknown` — no new warnings.
- `cargo clippy -p reinhardt-pages-macros --all-features -- -D warnings`.
- `cargo fmt --check -p reinhardt-pages-macros -p reinhardt-pages`.
- New `tests/ui/form/pass/server_fn_action_use.rs` uses `#![deny(unused_imports)]` so any regression of this exact issue would fail the trybuild pass.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (no public API surface changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- `bug`

## Related Issues

Fixes #4070
Refs #4068

🤖 Generated with [Claude Code](https://claude.com/claude-code)