### PR TITLE
fix(urls): merge child client routes in native mount_unified

### DIFF
--- a/crates/reinhardt-urls/src/routers/client_router/core.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/core.rs
@@ -187,8 +187,7 @@ impl ClientRouter {
 	///
 	/// Routes and named route mappings from `other` are appended.
 	/// Signals and not_found handler from `other` are discarded.
-	// Used by UnifiedRouter::mount_unified() on WASM targets
-	#[allow(dead_code)]
+	// Used by UnifiedRouter::mount_unified() on WASM and native targets.
 	pub(crate) fn merge(mut self, other: ClientRouter) -> Self {
 		let offset = self.routes.len();
 		for (name, idx) in other.named_routes {

--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -831,6 +831,63 @@ mod tests {
 		);
 	}
 
+	#[cfg(all(feature = "client-router", native))]
+	#[test]
+	fn mount_unified_merges_client_routes_on_native() {
+		// Arrange: a child UnifiedRouter that declares a client named route,
+		// mirroring what `#[url_patterns(InstalledApp::<app>, mode = client)]`
+		// produces on native via `client_url_patterns()`.
+		let child =
+			UnifiedRouter::new().client(|c| c.named_route("login_page", "/login/", || Page::Empty));
+		let parent = UnifiedRouter::new().client(|c| c.named_route("home", "/", || Page::Empty));
+
+		// Act
+		let merged = parent.mount_unified("/", child);
+
+		// Assert: both parent and child client routes are reachable on the
+		// resulting router, so a project-level reverser built from
+		// `client_ref().to_reverser()` can resolve `url_for(name)` for both.
+		assert!(merged.client_ref().has_route("home"));
+		assert!(
+			merged.client_ref().has_route("login_page"),
+			"native mount_unified must merge child client routes (#4076)"
+		);
+		assert_eq!(merged.client_ref().route_count(), 2);
+
+		let reverser = merged.client_ref().to_reverser();
+		assert_eq!(
+			reverser.reverse("login_page", &[]),
+			Some("/login/".to_string()),
+			"merged client routes must be resolvable via the reverser on native"
+		);
+	}
+
+	#[cfg(all(feature = "client-router", native))]
+	#[test]
+	fn mount_unified_merges_namespaced_client_routes_on_native() {
+		// Arrange: child router applies its own namespace before being mounted,
+		// matching the per-app composition pattern `mount_unified("/", auth::routes())`
+		// where `auth::routes()` already called `.with_namespace("auth")`.
+		let child = UnifiedRouter::new()
+			.client(|c| c.named_route("login_page", "/login/", || Page::Empty))
+			.with_namespace("auth");
+		let parent = UnifiedRouter::new();
+
+		// Act
+		let merged = parent.mount_unified("/", child);
+
+		// Assert
+		assert!(
+			merged.client_ref().has_route("auth:login_page"),
+			"namespaced child client routes must survive native mount_unified"
+		);
+		let reverser = merged.client_ref().to_reverser();
+		assert_eq!(
+			reverser.reverse("auth:login_page", &[]),
+			Some("/login/".to_string())
+		);
+	}
+
 	#[cfg(all(wasm, feature = "client-router"))]
 	#[test]
 	fn unified_wasm_with_namespace_propagates_to_client() {

--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -341,8 +341,15 @@ impl UnifiedRouter {
 
 	/// Mount a child UnifiedRouter on this router.
 	///
-	/// Extracts the server router from the child and mounts it.
-	pub fn mount_unified(self, prefix: &str, child: UnifiedRouter) -> Self {
+	/// Mounts the child's server router under `prefix` and merges its client
+	/// routes into the parent. Client named routes are preserved with index
+	/// offset adjustment so that `url_for("app:route")` resolves on the
+	/// project-level reverser obtained from `client_ref().to_reverser()`.
+	///
+	/// The `prefix` argument is applied to server routes only; client routes
+	/// keep their patterns as-declared, mirroring the WASM behavior.
+	pub fn mount_unified(mut self, prefix: &str, child: UnifiedRouter) -> Self {
+		self.client = self.client.merge(child.client);
 		self.mount(prefix, child.server)
 	}
 


### PR DESCRIPTION
## Summary

- Make native `UnifiedRouter::mount_unified` merge the child's `ClientRouter` in addition to mounting its `ServerRouter`, mirroring the existing WASM behavior.
- Restore the symmetry between targets so per-app `client_url_patterns()` declared via `#[url_patterns(InstalledApp::<app>, mode = client)]` can act as the single source of truth for SPA routes during SSR (`url_for("app:route")` resolves through `register_client_reverser`).
- No new public API. `ClientRouter::merge` stays `pub(crate)`; the previously needed `#[allow(dead_code)]` is dropped because native now also exercises it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Closes #4076. Without this fix, every app-namespaced named route had to be re-declared inline in the project-level `routes()` function in addition to its definition inside `apps/<app>/urls.rs::client_url_patterns()`, defeating the point of per-app URL decomposition on native. Tracked downstream in kent8192/reinhardt-cloud#518.

## How Was This Tested

- `cargo nextest run -p reinhardt-urls --all-features` — all 835 tests pass, including the two new unit tests:
  - `routers::unified_router::tests::mount_unified_merges_client_routes_on_native`
  - `routers::unified_router::tests::mount_unified_merges_namespaced_client_routes_on_native`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] PR description references the issue (`Fixes #4076`)

## Labels to Apply

- `bug`

Fixes #4076

🤖 Generated with [Claude Code](https://claude.com/claude-code)