### PR TITLE
fix(ci): ignore RUSTSEC-2026-0118 / 2026-0119 (hickory-proto via mongodb)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -56,4 +56,6 @@ jobs:
             --ignore RUSTSEC-2026-0066 \
             --ignore RUSTSEC-2026-0098 \
             --ignore RUSTSEC-2026-0099 \
-            --ignore RUSTSEC-2026-0104
+            --ignore RUSTSEC-2026-0104 \
+            --ignore RUSTSEC-2026-0118 \
+            --ignore RUSTSEC-2026-0119


### PR DESCRIPTION
## Summary

- Adds `--ignore RUSTSEC-2026-0118` and `--ignore RUSTSEC-2026-0119` to the `cargo audit` invocation in `.github/workflows/security-audit.yml`.
- Unblocks CI: `Security Audit / Scan for known vulnerabilities` is currently failing on every PR (release-plz, regular fixes, everything), and is a required gate via `CI Success`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Two new RUSTSEC advisories landed on 2026-05-01 against `hickory-proto 0.25.2`:

| Advisory | Title | Fix available? |
|---|---|---|
| RUSTSEC-2026-0118 | NSEC3 closest-encloser proof validation enters unbounded loop on cross-zone responses | **No fixed upgrade is available** |
| RUSTSEC-2026-0119 | CPU exhaustion during message encoding due to O(n²) name compression | Upgrade to >=0.26.1 |

`hickory-proto` is pulled in transitively by `mongodb v3.5.2`, which constrains `hickory-proto = "^0.25"`:

```
$ cargo update -p hickory-proto --precise 0.26.1
error: failed to select a version for the requirement `hickory-proto = "^0.25"`
required by package `mongodb v3.5.2`
```

We cannot escape these advisories until `mongodb` releases a version compatible with `hickory-proto >= 0.26`. Until then, ignoring matches the project's existing policy for advisories without reachable fixes.

The commit message records the removal condition (when `mongodb` accepts `hickory-proto >= 0.26`), per `UR-4` workaround template.

## How Was This Tested

- Workflow file is YAML; minimal change; CI on this PR will exercise `Security Audit` and prove it passes with the new ignore list.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review
- [x] No code paths changed (CI workflow only)
- [x] Removal condition documented in commit body

## Labels to Apply

- `bug`
- `high`

## Related Issues

Fixes #4081

🤖 Generated with [Claude Code](https://claude.com/claude-code)