### PR TITLE
style(conf): apply rustfmt to source_priority.rs

### DIFF
--- a/crates/reinhardt-conf/tests/source_priority.rs
+++ b/crates/reinhardt-conf/tests/source_priority.rs
@@ -499,8 +499,8 @@ fn high_priority_env_overrides_interpolated_toml() {
 	// with the other 17 tests in this file.
 	unsafe {
 		set_env_vars(&[
-			("IT_PG_PORT_PRIO", "8080"),  // for TOML interpolation
-			("PRIO_TEST_PORT", "9999"),   // for HighPriorityEnvSource override
+			("IT_PG_PORT_PRIO", "8080"), // for TOML interpolation
+			("PRIO_TEST_PORT", "9999"),  // for HighPriorityEnvSource override
 		])
 	};
 	let (_dir, path) = write_toml_file(r#"port = "${IT_PG_PORT_PRIO:-5432}""#);


### PR DESCRIPTION
## Summary

- Apply `rustfmt` (workspace `rustfmt.toml`, `--edition 2024`) to `crates/reinhardt-conf/tests/source_priority.rs`.
- Two-line whitespace-only change (collapses 2/3-space gaps before inline comments to 1/2 spaces).

## Type of Change

Bug fix / formatting (`style`).

## Motivation

`Format / Format Check` is failing on `main` and on the `release-plz-2026-05-03T08-03-51Z` branch:

- Failed run: https://github.com/kent8192/reinhardt-web/actions/runs/25273821497/job/74100679878
- Output: `[1052/2708] Would format: crates/reinhardt-conf/tests/source_priority.rs`

This blocks every release-plz PR and any new PR that runs Format Check. Tracked in #4099.

## Diff

```diff
@@ -499,8 +499,8 @@
 	// with the other 17 tests in this file.
 	unsafe {
 		set_env_vars(&[
-			("IT_PG_PORT_PRIO", "8080"),  // for TOML interpolation
-			("PRIO_TEST_PORT", "9999"),   // for HighPriorityEnvSource override
+			("IT_PG_PORT_PRIO", "8080"), // for TOML interpolation
+			("PRIO_TEST_PORT", "9999"),  // for HighPriorityEnvSource override
 		])
 	};
```

## How Was This Tested

- Locally ran `rustfmt --edition 2024 source_priority.rs` against the workspace `rustfmt.toml` (max_width=100, hard_tabs=true, tab_spaces=4) — produced the diff above and nothing else.
- Local rustfmt: `1.8.0-stable (e408947bfd 2026-03-25)` — same minor channel as the CI runner's pinned `rust-toolchain.toml` (`channel = "1.94.1"`).
- After merge, the next `Format / Format Check` run on `main` should pass; subsequent `release-plz-*` branches inherit the fix.

## Checklist

- [x] No-op for runtime behaviour (whitespace inside a doc-only inline comment alignment).
- [x] No new dependencies.
- [x] No public API change.
- [x] No test logic change (only formatting inside an existing test).
- [x] Linked issue: #4099.

Fixes #4099