### PR TITLE
fix(pages): eliminate two-phase mount to restore SPA navigation

### DIFF
--- a/.github/workflows/wasm-check.yml
+++ b/.github/workflows/wasm-check.yml
@@ -147,3 +147,36 @@ jobs:
             cargo test --target wasm32-unknown-unknown \
               --test csrf_wasm_test --test server_fn_wasm_test \
               --test client_launcher_navigation_test
+
+  # Native e2e regression test for the SPA link interceptor -> Router::push
+  # -> re-render path. Boots a Chrome container via testcontainers and drives
+  # it through the fixture SPA. Refs #4088.
+  e2e-test:
+    name: E2E Test (Chrome via CDP)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key: "e2e-cdp-test"
+
+      - name: Install wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Pull headless-shell image (warm cache)
+        run: docker pull chromedp/headless-shell:latest
+
+      - name: Run e2e_cdp regression test
+        run: |
+          cargo test \
+            -p reinhardt-pages \
+            --features e2e-cdp-test \
+            --test spa_navigation_e2e_test \
+            -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,7 +387,10 @@ members = [
 ]
 
 # Exclude examples (independent workspace with own dependency management)
-exclude = ["examples"]
+exclude = [
+	"examples",
+	"crates/reinhardt-pages/tests/fixtures/spa_navigation_app",
+]
 
 default-members = [
   "crates/reinhardt-views",

--- a/crates/reinhardt-core/CHANGELOG.md
+++ b/crates/reinhardt-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Runtime::debug_subscribers`, `debug_dependencies`, `debug_observer_stack`,
+  `debug_pending_updates` `#[doc(hidden)]` diagnostic methods for inspecting
+  the reactive dependency graph in cross-crate WASM tests.
+  ([#4088](https://github.com/kent8192/reinhardt-web/issues/4088))
+
 ## [0.1.0-rc.25](https://github.com/kent8192/reinhardt-web/compare/reinhardt-core@v0.1.0-rc.24...reinhardt-core@v0.1.0-rc.25) - 2026-04-30
 
 ### Fixed

--- a/crates/reinhardt-core/src/reactive/runtime.rs
+++ b/crates/reinhardt-core/src/reactive/runtime.rs
@@ -348,6 +348,48 @@ impl Runtime {
 			.map(|node| node.subscribers.len())
 			.unwrap_or(0)
 	}
+
+	/// Returns the list of NodeIds subscribed to the given node.
+	///
+	/// Diagnostic-only. Used by `reinhardt-pages` WASM tests to verify
+	/// dependency-tracking shape (Refs #4088). Analogous to React's
+	/// internal subscriber tracking inside `useSyncExternalStore`.
+	#[doc(hidden)]
+	pub fn debug_subscribers(&self, node_id: NodeId) -> alloc::vec::Vec<NodeId> {
+		self.dependency_graph
+			.borrow()
+			.get(&node_id)
+			.map(|n| n.subscribers.clone())
+			.unwrap_or_default()
+	}
+
+	/// Returns the list of NodeIds the given observer depends on.
+	///
+	/// Diagnostic-only (Refs #4088).
+	#[doc(hidden)]
+	pub fn debug_dependencies(&self, node_id: NodeId) -> alloc::vec::Vec<NodeId> {
+		self.dependency_graph
+			.borrow()
+			.get(&node_id)
+			.map(|n| n.dependencies.clone())
+			.unwrap_or_default()
+	}
+
+	/// Returns the current observer stack as a list of NodeIds (bottom to top).
+	///
+	/// Diagnostic-only (Refs #4088).
+	#[doc(hidden)]
+	pub fn debug_observer_stack(&self) -> alloc::vec::Vec<NodeId> {
+		self.observer_stack.borrow().iter().map(|o| o.id).collect()
+	}
+
+	/// Returns the pending updates queue as a snapshot (does not drain).
+	///
+	/// Diagnostic-only (Refs #4088).
+	#[doc(hidden)]
+	pub fn debug_pending_updates(&self) -> alloc::vec::Vec<NodeId> {
+		self.pending_updates.borrow().clone()
+	}
 }
 
 impl Default for Runtime {
@@ -533,5 +575,98 @@ mod tests {
 
 		let effect_node = graph.get(&effect_id).unwrap();
 		assert!(effect_node.dependencies.is_empty());
+	}
+
+	#[test]
+	#[serial]
+	fn debug_subscribers_returns_registered_observers_in_insertion_order() {
+		// Arrange
+		let runtime = Runtime::new();
+		let signal_id = NodeId::new();
+		let effect_id_a = NodeId::new();
+		let effect_id_b = NodeId::new();
+		{
+			let mut graph = runtime.dependency_graph.borrow_mut();
+			let node = graph.entry(signal_id).or_default();
+			node.subscribers.push(effect_id_a);
+			node.subscribers.push(effect_id_b);
+		}
+
+		// Act
+		let subs = runtime.debug_subscribers(signal_id);
+
+		// Assert
+		assert_eq!(subs, alloc::vec![effect_id_a, effect_id_b]);
+	}
+
+	#[test]
+	#[serial]
+	fn debug_dependencies_returns_observer_dependency_list() {
+		// Arrange
+		let runtime = Runtime::new();
+		let observer_id = NodeId::new();
+		let signal_a = NodeId::new();
+		let signal_b = NodeId::new();
+		{
+			let mut graph = runtime.dependency_graph.borrow_mut();
+			let node = graph.entry(observer_id).or_default();
+			node.dependencies.push(signal_a);
+			node.dependencies.push(signal_b);
+		}
+
+		// Act
+		let deps = runtime.debug_dependencies(observer_id);
+
+		// Assert
+		assert_eq!(deps, alloc::vec![signal_a, signal_b]);
+	}
+
+	#[test]
+	#[serial]
+	fn debug_observer_stack_returns_pushed_observers_bottom_to_top() {
+		// Arrange
+		let runtime = Runtime::new();
+		let outer_id = NodeId::new();
+		let inner_id = NodeId::new();
+		runtime.push_observer(Observer {
+			id: outer_id,
+			node_type: NodeType::Effect,
+			timing: EffectTiming::default(),
+			cleanup: None,
+		});
+		runtime.push_observer(Observer {
+			id: inner_id,
+			node_type: NodeType::Effect,
+			timing: EffectTiming::default(),
+			cleanup: None,
+		});
+
+		// Act
+		let stack = runtime.debug_observer_stack();
+
+		// Assert
+		assert_eq!(stack, alloc::vec![outer_id, inner_id]);
+	}
+
+	#[test]
+	#[serial]
+	fn debug_pending_updates_returns_scheduled_node_ids_snapshot() {
+		// Arrange
+		let runtime = Runtime::new();
+		let pending_a = NodeId::new();
+		let pending_b = NodeId::new();
+		{
+			let mut p = runtime.pending_updates.borrow_mut();
+			p.push(pending_a);
+			p.push(pending_b);
+		}
+
+		// Act
+		let snapshot = runtime.debug_pending_updates();
+
+		// Assert
+		assert_eq!(snapshot, alloc::vec![pending_a, pending_b]);
+		// Snapshot must not drain the queue
+		assert_eq!(runtime.pending_updates.borrow().len(), 2);
 	}
 }

--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -7,16 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(router)* `Router::on_navigate(callback) -> NavigationSubscription`
+  explicit subscription API, inspired by React Router's
+  `router.subscribe(listener)`. The listener is invoked synchronously after
+  every successful `push`/`replace` with the new path and params, independent
+  of any Signal/Effect auto-tracking. Robust against the reactivity-tracking
+  corruption class that affected #3348, #4075, and #4088.
+  ([#4088](https://github.com/kent8192/reinhardt-web/issues/4088))
+
 ### Fixed
 
-- *(pages)* `ClientLauncher` render Effect now re-fires when `Router::push`
-  updates the path Signal, restoring SPA navigation. Hoist `current_path` /
-  `current_params` Signal clones out of the `with_router(|r| ...)`
-  thread-local borrow so the launcher Effect tracks both Signals as a
-  direct subscriber, independent of nested reactive nodes spawned during
-  `view.mount(...)`. Downstream report:
+- *(pages)* `ClientLauncher::launch` SPA navigation regression where the
+  render Effect did not re-fire on `Router::push`, leaving the boot-time
+  view rendered for every subsequent route. Eliminated the two-phase mount
+  (initial inline mount + later Effect) and consolidated into a single
+  `EffectTiming::Layout` Effect that performs both the first mount and
+  every subsequent re-render. The post-#4078 hoisted Signal clones are no
+  longer needed. Downstream report:
   [reinhardt-cloud#514](https://github.com/kent8192/reinhardt-cloud/issues/514).
-  ([#4075](https://github.com/kent8192/reinhardt-web/issues/4075))
+  ([#4088](https://github.com/kent8192/reinhardt-web/issues/4088),
+  [#4075](https://github.com/kent8192/reinhardt-web/issues/4075),
+  [#3348](https://github.com/kent8192/reinhardt-web/issues/3348))
 
 ## [0.1.0-rc.23](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.1.0-rc.22...reinhardt-pages@v0.1.0-rc.23) - 2026-04-29
 

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -24,6 +24,15 @@ debug-hooks = []
 uuid = ["dep:uuid"]
 chrono = ["dep:chrono"]
 ast = []
+# Enables the `tests/integration/spa_navigation_e2e_test.rs` integration
+# test (Refs #4088). This is a marker feature: the actual test deps
+# (`reinhardt-test`, `axum`, `tower-http`) live as native-only path
+# dev-dependencies (see `[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]`).
+# Per CLAUDE.md KI-2, `reinhardt-test` is a path-only dev-dep here to avoid
+# both cyclic publishable dependencies and release-plz publish ordering
+# breakage. Cargo dev-dependencies cannot be optional, so feature gating
+# is achieved via `#![cfg(feature = "e2e-cdp-test")]` and `required-features`.
+e2e-cdp-test = []
 hmr = ["dep:notify", "dep:tokio-tungstenite", "dep:futures-util"]
 # web-sys features for WASM applications
 # Applications should use this feature to get all required web-sys features
@@ -216,6 +225,13 @@ futures-util = "0.3"
 # cannot build for `wasm32-unknown-unknown`. The trybuild harness itself is
 # already gated with `#![cfg(not(target_arch = "wasm32"))]`.
 reinhardt-di = { workspace = true, features = ["validation"] }
+# E2E CDP regression test (`tests/integration/spa_navigation_e2e_test.rs`,
+# Refs #4088). Path-only per CLAUDE.md KI-2: avoids both release-plz publish
+# ordering breakage and cyclic publish dependencies. Test compilation is
+# gated by `[[test]] required-features = ["e2e-cdp-test"]`.
+reinhardt-test = { path = "../reinhardt-test", default-features = false, features = ["e2e-cdp"] }
+axum = "0.7"
+tower-http = { version = "0.5", features = ["fs"] }
 
 [lib]
 crate-type = ["rlib"]
@@ -243,3 +259,8 @@ required-features = []
 name = "client_launcher_navigation_test"
 path = "tests/wasm/client_launcher_navigation_test.rs"
 required-features = []
+
+[[test]]
+name = "spa_navigation_e2e_test"
+path = "tests/integration/spa_navigation_e2e_test.rs"
+required-features = ["e2e-cdp-test"]

--- a/crates/reinhardt-pages/src/app.rs
+++ b/crates/reinhardt-pages/src/app.rs
@@ -426,8 +426,18 @@ impl ClientLauncher {
 		// in a state that interfered with dependency tracking on the second
 		// run (Refs #3348, #4075).
 		//
+		// The initial mount result is captured here and propagated as the
+		// return value of `launch()` so callers retain the previous "fail
+		// fast on boot mount error" behavior. Errors from subsequent
+		// re-renders are still logged (not propagated) because there is no
+		// caller frame to receive them after `launch()` returns.
+		//
 		// Fixes #4088, Refs #4075, #3348.
 		let root_clone = root_el.clone();
+		let initial_mount_result: std::rc::Rc<
+			std::cell::RefCell<Option<Result<(), crate::component::MountError>>>,
+		> = std::rc::Rc::new(std::cell::RefCell::new(None));
+		let initial_mount_result_inner = initial_mount_result.clone();
 		let _effect = crate::reactive::Effect::new_with_timing(
 			move || {
 				let view = with_router(|r| {
@@ -438,8 +448,13 @@ impl ClientLauncher {
 				crate::component::cleanup_reactive_nodes();
 				root_clone.set_inner_html("");
 				let wrapper = crate::dom::Element::new(root_clone.clone());
-				if let Err(e) = view.mount(&wrapper) {
-					web_sys::console::error_1(&format!("re-render failed: {e:?}").into());
+				let mount_result = view.mount(&wrapper);
+				// Record only the first run; later re-renders log instead.
+				let mut slot = initial_mount_result_inner.borrow_mut();
+				if slot.is_none() {
+					*slot = Some(mount_result.clone());
+				} else if let Err(e) = &mount_result {
+					web_sys::console::error_1(&format!("re-render failed: {e}").into());
 				}
 			},
 			crate::reactive::EffectTiming::Layout,
@@ -447,6 +462,17 @@ impl ClientLauncher {
 		// Intentional leak: Effect must persist for the entire application lifetime.
 		// WASM modules never terminate, so there is no destructor to run.
 		std::mem::forget(_effect);
+
+		// EffectTiming::Layout runs synchronously, so the initial mount has
+		// already completed by the time we reach this point.
+		match initial_mount_result.borrow_mut().take() {
+			Some(Err(e)) => {
+				return Err(wasm_bindgen::JsValue::from_str(&format!(
+					"initial mount failed: {e}"
+				)));
+			}
+			Some(Ok(())) | None => {}
+		}
 
 		// Step 9: drain after_launch callbacks now that the router is live and
 		// the first DOM mount has completed.

--- a/crates/reinhardt-pages/src/app.rs
+++ b/crates/reinhardt-pages/src/app.rs
@@ -416,16 +416,37 @@ impl ClientLauncher {
 				))
 			})?;
 
-		let view = with_router(|r| {
-			let _ = r.current_path().get();
-			let _ = r.current_params().get();
-			r.render_current()
-		});
-		crate::component::cleanup_reactive_nodes();
-		root_el.set_inner_html("");
-		let wrapper = crate::dom::Element::new(root_el.clone());
-		view.mount(&wrapper)
-			.map_err(|e| wasm_bindgen::JsValue::from_str(&format!("mount failed: {e:?}")))?;
+		// Step 8 (consolidated): single-phase reactive mount.
+		//
+		// The launcher's render Effect performs both the initial mount and
+		// every subsequent re-render. EffectTiming::Layout makes signal-driven
+		// re-execution synchronous (no microtask delay), matching React's
+		// useSyncExternalStore semantics for synchronous external-store reads.
+		// This eliminates the previous two-phase mount that left REACTIVE_NODES
+		// in a state that interfered with dependency tracking on the second
+		// run (Refs #3348, #4075).
+		//
+		// Fixes #4088, Refs #4075, #3348.
+		let root_clone = root_el.clone();
+		let _effect = crate::reactive::Effect::new_with_timing(
+			move || {
+				let view = with_router(|r| {
+					let _ = r.current_path().get();
+					let _ = r.current_params().get();
+					r.render_current()
+				});
+				crate::component::cleanup_reactive_nodes();
+				root_clone.set_inner_html("");
+				let wrapper = crate::dom::Element::new(root_clone.clone());
+				if let Err(e) = view.mount(&wrapper) {
+					web_sys::console::error_1(&format!("re-render failed: {e:?}").into());
+				}
+			},
+			crate::reactive::EffectTiming::Layout,
+		);
+		// Intentional leak: Effect must persist for the entire application lifetime.
+		// WASM modules never terminate, so there is no destructor to run.
+		std::mem::forget(_effect);
 
 		// Step 9: drain after_launch callbacks now that the router is live and
 		// the first DOM mount has completed.
@@ -439,47 +460,6 @@ impl ClientLauncher {
 				hook(&ctx);
 			}
 		}
-
-		// Workaround for kent8192/reinhardt-web#4075
-		// Remove this workaround when the upstream issue is resolved.
-		//
-		// Ideal implementation (without workaround):
-		//   let _effect = crate::reactive::Effect::new(move || {
-		//       let view = with_router(|r| {
-		//           let _ = r.current_path().get();
-		//           let _ = r.current_params().get();
-		//           r.render_current()
-		//       });
-		//       crate::component::cleanup_reactive_nodes();
-		//       root_clone.set_inner_html("");
-		//       let wrapper = crate::dom::Element::new(root_clone.clone());
-		//       if let Err(e) = view.mount(&wrapper) {
-		//           web_sys::console::error_1(&format!("re-render failed: {e:?}").into());
-		//       }
-		//   });
-		//
-		// Hoist Signal clones out of with_router so Signal::get() runs while
-		// the Router thread-local is NOT borrowed; track_dependency then sees
-		// the launcher Effect as the current observer regardless of any nested
-		// reactive nodes that may run during the subsequent view.mount(...).
-		let (path_signal, params_signal) =
-			with_router(|r| (r.current_path().clone(), r.current_params().clone()));
-		let root_clone = root_el.clone();
-		let _effect = crate::reactive::Effect::new(move || {
-			// Subscribe outside the with_router borrow.
-			let _ = path_signal.get();
-			let _ = params_signal.get();
-			let view = with_router(|r| r.render_current());
-			crate::component::cleanup_reactive_nodes();
-			root_clone.set_inner_html("");
-			let wrapper = crate::dom::Element::new(root_clone.clone());
-			if let Err(e) = view.mount(&wrapper) {
-				web_sys::console::error_1(&format!("re-render failed: {e:?}").into());
-			}
-		});
-		// Intentional leak: Effect must persist for the entire application lifetime.
-		// WASM modules never terminate, so there is no destructor to run.
-		std::mem::forget(_effect);
 
 		// Step 11: register one leaked Effect per path subscription. Each
 		// Effect re-reads the router's `current_path` Signal, so the

--- a/crates/reinhardt-pages/src/router.rs
+++ b/crates/reinhardt-pages/src/router.rs
@@ -42,7 +42,7 @@ mod params;
 mod pattern;
 
 pub use components::{Link, Redirect, RouterOutlet, guard, guard_or};
-pub use core::{PathError, Route, RouteMatch, Router, RouterError};
+pub use core::{NavigationSubscription, PathError, Route, RouteMatch, Router, RouterError};
 pub use history::{HistoryState, NavigationType, setup_popstate_listener};
 pub use params::{FromPath, ParamContext, PathParams};
 pub use pattern::{PathParam, PathPattern};

--- a/crates/reinhardt-pages/src/router/core.rs
+++ b/crates/reinhardt-pages/src/router/core.rs
@@ -210,6 +210,33 @@ pub struct Router {
 	current_route_name: Signal<Option<String>>,
 	/// Not found handler.
 	not_found: Option<Arc<dyn Fn() -> Page + Send + Sync>>,
+	/// Navigation observers registered via `on_navigate`.
+	///
+	/// Inspired by React Router's `router.subscribe(listener)` design:
+	/// listeners are registered explicitly and notified on every successful
+	/// navigation, independent of any reactive Effect / Signal tracking.
+	/// Refs #4088, #4075, #3348.
+	navigation_observers: NavigationObservers,
+}
+
+/// Type alias for the navigation observer storage.
+///
+/// `Rc<RefCell<...>>` because Routers are not `Send` on wasm32 anyway,
+/// and the borrow is released before listeners run (see `navigate`).
+type NavigationObservers = std::rc::Rc<std::cell::RefCell<Vec<std::rc::Weak<NavigationListener>>>>;
+
+/// Boxed closure stored behind a `Weak<...>` so a dropped `NavigationSubscription`
+/// drops its strong `Rc`, after which `navigate` filters out the dead `Weak`.
+type NavigationListener = dyn Fn(&str, &HashMap<String, String>) + 'static;
+
+/// RAII handle returned by [`Router::on_navigate`].
+///
+/// While alive, the registered listener fires on every [`Router::push`] /
+/// [`Router::replace`]. Dropping this handle removes the listener (no
+/// explicit `unsubscribe` call needed).
+pub struct NavigationSubscription {
+	#[allow(dead_code)] // Dropped automatically; presence keeps the Weak alive.
+	listener: std::rc::Rc<NavigationListener>,
 }
 
 impl std::fmt::Debug for Router {
@@ -242,6 +269,7 @@ impl Router {
 			current_params: Signal::new(HashMap::new()),
 			current_route_name: Signal::new(None),
 			not_found: None,
+			navigation_observers: std::rc::Rc::new(std::cell::RefCell::new(Vec::new())),
 		}
 	}
 
@@ -421,6 +449,37 @@ impl Router {
 		self.navigate(path, NavigationType::Replace)
 	}
 
+	/// Registers a navigation observer.
+	///
+	/// Inspired by React Router's `router.subscribe(listener)` design.
+	/// The listener is invoked synchronously on every successful navigation
+	/// ([`Self::push`] or [`Self::replace`]) with the new path and matched
+	/// params. The listener fires **after** the path / params Signals have
+	/// been updated, so calling `Signal::get` from within the listener
+	/// returns the new values.
+	///
+	/// Returns a [`NavigationSubscription`] handle. Drop the handle to
+	/// unregister the listener. The router itself does not retain a strong
+	/// reference; if all subscriptions are dropped, the listener is freed
+	/// at the next `navigate` call (see `navigate` body which prunes dead
+	/// Weak references on every invocation).
+	///
+	/// Robust against nested reactive nodes spawned during view rendering
+	/// because this subscription is independent of the Effect / Signal
+	/// auto-tracking system.
+	///
+	/// Refs #4088, #4075, #3348.
+	pub fn on_navigate<F>(&self, listener: F) -> NavigationSubscription
+	where
+		F: Fn(&str, &HashMap<String, String>) + 'static,
+	{
+		let listener: std::rc::Rc<NavigationListener> = std::rc::Rc::new(listener);
+		self.navigation_observers
+			.borrow_mut()
+			.push(std::rc::Rc::downgrade(&listener));
+		NavigationSubscription { listener }
+	}
+
 	/// Internal navigation implementation.
 	fn navigate(&self, path: &str, nav_type: NavigationType) -> Result<(), RouterError> {
 		let route_match = self.match_path(path);
@@ -460,6 +519,26 @@ impl Router {
 				.as_ref()
 				.and_then(|m| m.route.name().map(|s| s.to_string())),
 		);
+
+		// Invoke registered navigation observers AFTER signal updates so
+		// listeners reading `Signal::get` from inside their closure see the
+		// new state. Refs #4088.
+		let params_for_observers = route_match
+			.as_ref()
+			.map(|m| m.params.clone())
+			.unwrap_or_default();
+		// Snapshot strong refs before invoking listeners; this avoids
+		// holding the `RefCell` borrow across user-supplied closure code
+		// (which could re-enter `on_navigate` and panic on RefCell reentry).
+		let listeners_snapshot: Vec<std::rc::Rc<NavigationListener>> = {
+			let mut observers = self.navigation_observers.borrow_mut();
+			// Prune dropped subscriptions on every navigate.
+			observers.retain(|w| w.strong_count() > 0);
+			observers.iter().filter_map(|w| w.upgrade()).collect()
+		};
+		for listener in listeners_snapshot {
+			listener(path, &params_for_observers);
+		}
 
 		Ok(())
 	}
@@ -723,5 +802,48 @@ mod tests {
 
 		// Non-WASM replace should succeed
 		assert!(router.replace("/").is_ok());
+	}
+
+	use std::cell::RefCell;
+	use std::rc::Rc;
+
+	#[test]
+	#[serial_test::serial]
+	fn on_navigate_fires_listener_after_router_push() {
+		// Arrange
+		let calls: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+		let calls_clone = calls.clone();
+		let router = Router::new().route("/", home_view).route("/foo", user_view);
+		let _sub = router.on_navigate(
+			move |path: &str, _params: &std::collections::HashMap<String, String>| {
+				calls_clone.borrow_mut().push(path.to_string());
+			},
+		);
+
+		// Act
+		router.push("/foo").expect("push /foo");
+
+		// Assert
+		assert_eq!(*calls.borrow(), vec!["/foo".to_string()]);
+	}
+
+	#[test]
+	#[serial_test::serial]
+	fn on_navigate_subscription_drop_unregisters_listener() {
+		// Arrange
+		let calls = Rc::new(RefCell::new(0_usize));
+		let calls_clone = calls.clone();
+		let router = Router::new().route("/", home_view).route("/foo", user_view);
+		let sub = router.on_navigate(move |_p, _ps| {
+			*calls_clone.borrow_mut() += 1;
+		});
+
+		// Act
+		router.push("/foo").expect("push /foo");
+		drop(sub);
+		router.push("/").expect("push /");
+
+		// Assert: listener fired exactly once (before drop), not twice
+		assert_eq!(*calls.borrow(), 1);
 	}
 }

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/.gitignore
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/.gitignore
@@ -1,0 +1,2 @@
+pkg/
+target/

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/Cargo.toml
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "spa-navigation-app"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+# Detached from the parent Cargo workspace so that wasm-pack can build this
+# crate independently. The parent workspace's `exclude` array also lists this
+# path; this empty `[workspace]` table is the matching, recommended Cargo
+# pattern for nested-but-detached crates.
+[workspace]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+reinhardt-pages = { path = "../../../" }
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["Window", "Document", "Element"] }
+console_error_panic_hook = "0.1"

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/index.html
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>SPA Navigation Fixture</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module">
+      import init from "./pkg/spa_navigation_app.js";
+      init();
+    </script>
+  </body>
+</html>

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/lib.rs
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/lib.rs
@@ -1,0 +1,46 @@
+//! Minimal SPA fixture used by `spa_navigation_e2e_test` to verify
+//! that `<a href="/...">` clicks trigger SPA navigation and route
+//! re-rendering against a real Chrome browser via CDP.
+//!
+//! Two routes:
+//! - `/` renders `<div id="route-home"><a href="/login">Go to login</a></div>`
+//! - `/login` renders `<div id="route-login">LOGIN VIEW</div>`
+//!
+//! Refs #4088.
+
+use reinhardt_pages::app::ClientLauncher;
+use reinhardt_pages::component::{IntoPage, Page, PageElement};
+use reinhardt_pages::router::Router;
+use wasm_bindgen::prelude::*;
+
+fn home_page() -> Page {
+	PageElement::new("div")
+		.attr("id", "route-home")
+		.child(
+			PageElement::new("a")
+				.attr("href", "/login")
+				.attr("id", "go-to-login")
+				.child("Go to login"),
+		)
+		.into_page()
+}
+
+fn login_page() -> Page {
+	PageElement::new("div")
+		.attr("id", "route-login")
+		.child("LOGIN VIEW")
+		.into_page()
+}
+
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), JsValue> {
+	console_error_panic_hook::set_once();
+
+	ClientLauncher::new("#app")
+		.router(|| {
+			Router::new()
+				.route("/", home_page)
+				.route("/login", login_page)
+		})
+		.launch()
+}

--- a/crates/reinhardt-pages/tests/integration/spa_navigation_e2e_test.rs
+++ b/crates/reinhardt-pages/tests/integration/spa_navigation_e2e_test.rs
@@ -103,16 +103,30 @@ async fn spa_navigation_link_click_re_renders_view(#[future] cdp_browser: CdpBro
 		.parent()
 		.expect("pkg dir has parent (the fixture crate root)");
 	let (base_url, _server) = boot_test_server(fixture_root).await;
+	eprintln!("[e2e] base_url = {base_url}");
 	let browser = cdp_browser.await;
 	let page = browser
 		.new_page(&base_url)
 		.await
 		.expect("open new page at fixture URL");
 
-	// Boot mount: home page is rendered with the link to /login
-	page.wait_for("#route-home")
-		.await
-		.expect("wait for #route-home");
+	// Boot mount: home page is rendered with the link to /login.
+	// On failure, dump the URL Chrome actually navigated to and the page
+	// HTML so CI logs reveal whether the WASM bundle loaded at all (e.g.
+	// `host.docker.internal` resolution failures vs. mount-time errors).
+	if let Err(e) = page.wait_for("#route-home").await {
+		let actual_url = page.url().await.ok().flatten().unwrap_or_default();
+		let html = page
+			.content()
+			.await
+			.unwrap_or_else(|err| format!("<failed to read page content: {err:?}>"));
+		panic!(
+			"wait for #route-home failed: {e:?}\n\
+			 base_url:   {base_url}\n\
+			 actual url: {actual_url}\n\
+			 html:       {html}"
+		);
+	}
 	let go_to_login = page
 		.find("#go-to-login")
 		.await

--- a/crates/reinhardt-pages/tests/integration/spa_navigation_e2e_test.rs
+++ b/crates/reinhardt-pages/tests/integration/spa_navigation_e2e_test.rs
@@ -44,15 +44,35 @@ fn build_fixture_bundle() -> Result<Option<PathBuf>, String> {
 	Ok(Some(dir.join("pkg")))
 }
 
+/// RAII guard that aborts the server task on drop, ensuring deterministic
+/// cleanup regardless of test outcome (including panics).
+struct ServerGuard {
+	abort: tokio::task::AbortHandle,
+}
+
+impl Drop for ServerGuard {
+	fn drop(&mut self) {
+		self.abort.abort();
+	}
+}
+
 /// Boots an axum server on an ephemeral port, serving the fixture index.html
-/// and the WASM bundle. Returns the bound URL and a `JoinHandle` whose Drop
-/// shuts down the server.
-async fn boot_test_server(fixture_dir: &Path) -> (String, tokio::task::JoinHandle<()>) {
+/// and the WASM bundle. Returns the bound URL and a `ServerGuard` whose Drop
+/// aborts the spawned task. Without the guard, dropping a bare `JoinHandle`
+/// only detaches the task — the server would keep running until the tokio
+/// runtime is torn down.
+async fn boot_test_server(fixture_dir: &Path) -> (String, ServerGuard) {
 	use axum::Router;
 	use tower_http::services::ServeDir;
 
-	// ServeDir serves the fixture directory. index.html and pkg/ are siblings.
-	let app = Router::new().nest_service("/", ServeDir::new(fixture_dir));
+	// `append_index_html_on_directories(true)` makes ServeDir serve
+	// `index.html` for directory requests like `/`. This is the documented
+	// default in tower-http but is set explicitly so the test does not rely
+	// on version-specific behavior.
+	let app = Router::new().nest_service(
+		"/",
+		ServeDir::new(fixture_dir).append_index_html_on_directories(true),
+	);
 
 	let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
 		.await
@@ -61,7 +81,10 @@ async fn boot_test_server(fixture_dir: &Path) -> (String, tokio::task::JoinHandl
 	let handle = tokio::spawn(async move {
 		axum::serve(listener, app).await.expect("axum serve");
 	});
-	(format!("http://host.docker.internal:{port}"), handle)
+	let guard = ServerGuard {
+		abort: handle.abort_handle(),
+	};
+	(format!("http://host.docker.internal:{port}"), guard)
 }
 
 #[rstest]

--- a/crates/reinhardt-pages/tests/integration/spa_navigation_e2e_test.rs
+++ b/crates/reinhardt-pages/tests/integration/spa_navigation_e2e_test.rs
@@ -1,0 +1,117 @@
+//! End-to-end regression test for SPA navigation via the link interceptor.
+//!
+//! This is a NATIVE test (not wasm-bindgen-test). It:
+//! 1. Builds the `spa_navigation_app` fixture WASM bundle via `wasm-pack build`.
+//! 2. Boots an axum HTTP server on an ephemeral port serving the bundle.
+//! 3. Uses the `cdp_browser` rstest fixture from `reinhardt-test` to spin up
+//!    an isolated Chrome container and drive it through the navigation flow.
+//!
+//! Skipped (with a clear log line) if `wasm-pack` is not on `PATH`.
+//!
+//! Refs #4088.
+
+#![cfg(all(feature = "e2e-cdp-test", not(target_arch = "wasm32")))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use reinhardt_test::fixtures::wasm::e2e_cdp::{CdpBrowser, cdp_browser};
+use rstest::*;
+
+const FIXTURE_DIR_REL: &str = "tests/fixtures/spa_navigation_app";
+
+/// Locates the fixture crate root (relative to the test invocation cwd).
+fn fixture_dir() -> PathBuf {
+	let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
+	PathBuf::from(manifest).join(FIXTURE_DIR_REL)
+}
+
+/// Builds the fixture WASM bundle via `wasm-pack build --target web`.
+/// Returns `Ok(Some(pkg_dir))` on success, `Ok(None)` if `wasm-pack` is missing.
+fn build_fixture_bundle() -> Result<Option<PathBuf>, String> {
+	if Command::new("wasm-pack").arg("--version").output().is_err() {
+		return Ok(None);
+	}
+	let dir = fixture_dir();
+	let status = Command::new("wasm-pack")
+		.args(["build", "--target", "web", "--out-dir", "pkg"])
+		.current_dir(&dir)
+		.status()
+		.map_err(|e| format!("wasm-pack failed to spawn: {e}"))?;
+	if !status.success() {
+		return Err(format!("wasm-pack build failed with status {status}"));
+	}
+	Ok(Some(dir.join("pkg")))
+}
+
+/// Boots an axum server on an ephemeral port, serving the fixture index.html
+/// and the WASM bundle. Returns the bound URL and a `JoinHandle` whose Drop
+/// shuts down the server.
+async fn boot_test_server(fixture_dir: &Path) -> (String, tokio::task::JoinHandle<()>) {
+	use axum::Router;
+	use tower_http::services::ServeDir;
+
+	// ServeDir serves the fixture directory. index.html and pkg/ are siblings.
+	let app = Router::new().nest_service("/", ServeDir::new(fixture_dir));
+
+	let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+		.await
+		.expect("bind ephemeral port");
+	let port = listener.local_addr().expect("local_addr").port();
+	let handle = tokio::spawn(async move {
+		axum::serve(listener, app).await.expect("axum serve");
+	});
+	(format!("http://host.docker.internal:{port}"), handle)
+}
+
+#[rstest]
+#[tokio::test]
+async fn spa_navigation_link_click_re_renders_view(#[future] cdp_browser: CdpBrowser) {
+	// Arrange
+	let pkg_dir = match build_fixture_bundle() {
+		Ok(Some(p)) => p,
+		Ok(None) => {
+			eprintln!("[skip] wasm-pack not found on PATH; spa_navigation_e2e_test skipped");
+			return;
+		}
+		Err(e) => panic!("fixture build failed: {e}"),
+	};
+	let fixture_root = pkg_dir
+		.parent()
+		.expect("pkg dir has parent (the fixture crate root)");
+	let (base_url, _server) = boot_test_server(fixture_root).await;
+	let browser = cdp_browser.await;
+	let page = browser
+		.new_page(&base_url)
+		.await
+		.expect("open new page at fixture URL");
+
+	// Boot mount: home page is rendered with the link to /login
+	page.wait_for("#route-home")
+		.await
+		.expect("wait for #route-home");
+	let go_to_login = page
+		.find("#go-to-login")
+		.await
+		.expect("locate #go-to-login");
+
+	// Act
+	go_to_login.click().await.expect("click <a href=/login>");
+	page.wait_for_url(|u| u.ends_with("/login"))
+		.await
+		.expect("URL updates to /login within timeout");
+	page.wait_for("#route-login")
+		.await
+		.expect("login view mounts within timeout");
+
+	// Assert
+	let html = page.content().await.expect("page content");
+	assert!(
+		html.contains("LOGIN VIEW"),
+		"expected LOGIN VIEW after link click; got: {html}"
+	);
+	assert!(
+		!html.contains("Go to login"),
+		"home view should be unmounted after navigation; got: {html}"
+	);
+}

--- a/crates/reinhardt-pages/tests/wasm/client_launcher_navigation_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/client_launcher_navigation_test.rs
@@ -1,4 +1,4 @@
-//! WASM regression test for issue #4075 — verifies that
+//! WASM regression test for issues #4075 and #4088 — verifies that
 //! `ClientLauncher::launch()` installs a render Effect that re-fires
 //! when `Router::push` updates the path Signal.
 //!
@@ -16,6 +16,7 @@
 
 use reinhardt_pages::app::{ClientLauncher, with_router};
 use reinhardt_pages::component::{IntoPage, Page, PageElement};
+use reinhardt_pages::reactive::with_runtime;
 use reinhardt_pages::router::Router;
 use wasm_bindgen_test::*;
 
@@ -47,7 +48,6 @@ fn page_b() -> Page {
 
 fn install_app_root() -> web_sys::Element {
 	let document = web_sys::window().unwrap().document().unwrap();
-	// Remove any pre-existing root left behind by a prior test run.
 	if let Some(prev) = document.get_element_by_id("app") {
 		prev.remove();
 	}
@@ -67,8 +67,6 @@ async fn yield_to_microtasks() {
 async fn client_launcher_re_renders_on_router_push() {
 	let root = install_app_root();
 
-	// Register `/` so the boot mount has a deterministic view regardless of
-	// the test harness's starting URL.
 	ClientLauncher::new("#app")
 		.router(|| {
 			Router::new()
@@ -79,18 +77,35 @@ async fn client_launcher_re_renders_on_router_push() {
 		.launch()
 		.expect("launch");
 
-	// First yield: let any deferred reactive work after launch settle.
 	yield_to_microtasks().await;
+
+	// === Diagnostic: launcher Effect must be subscribed to path Signal ===
+	let path_signal_id = with_router(|r| r.current_path().id());
+	let subscribers_after_launch = with_runtime(|rt| rt.debug_subscribers(path_signal_id));
+	assert!(
+		!subscribers_after_launch.is_empty(),
+		"[DIAG #4088] path_signal has no subscribers after launch — launcher Effect was not tracked. \
+		 observer_stack: {:?}, dependencies: {:?}",
+		with_runtime(|rt| rt.debug_observer_stack()),
+		with_runtime(|rt| rt.debug_dependencies(path_signal_id)),
+	);
 
 	// Navigate to /a and confirm the body switches.
 	with_router(|r| r.push("/a")).expect("push /a");
+	let pending_after_push_a = with_runtime(|rt| rt.debug_pending_updates());
 	yield_to_microtasks().await;
 	yield_to_microtasks().await;
 
 	let html_after_a = root.inner_html();
 	assert!(
 		html_after_a.contains("ROUTE-A-CONTENT"),
-		"expected /a view after push('/a'), got: {html_after_a}"
+		"[DIAG #4088] expected /a view after push('/a'). \
+		 pending_updates immediately after push: {:?}, \
+		 subscribers of path_signal now: {:?}, \
+		 actual html: {}",
+		pending_after_push_a,
+		with_runtime(|rt| rt.debug_subscribers(path_signal_id)),
+		html_after_a,
 	);
 	assert!(
 		!html_after_a.contains("ROUTE-B-CONTENT"),
@@ -98,19 +113,105 @@ async fn client_launcher_re_renders_on_router_push() {
 	);
 
 	// Navigate to /b — this is the regression-critical step.
-	// Pre-fix: the render Effect never re-fires, so `inner_html` still
-	// shows route-a content.
 	with_router(|r| r.push("/b")).expect("push /b");
+	let pending_after_push_b = with_runtime(|rt| rt.debug_pending_updates());
 	yield_to_microtasks().await;
 	yield_to_microtasks().await;
 
 	let html_after_b = root.inner_html();
 	assert!(
 		html_after_b.contains("ROUTE-B-CONTENT"),
-		"expected /b view after push('/b'), got: {html_after_b}"
+		"[DIAG #4088] expected /b view after push('/b'). \
+		 pending_updates immediately after push: {:?}, \
+		 subscribers of path_signal now: {:?}, \
+		 actual html: {}",
+		pending_after_push_b,
+		with_runtime(|rt| rt.debug_subscribers(path_signal_id)),
+		html_after_b,
 	);
 	assert!(
 		!html_after_b.contains("ROUTE-A-CONTENT"),
 		"expected /a view absent after push('/b'), got: {html_after_b}"
+	);
+}
+
+/// Direct reproduction of Issue #4088: simulates the reinhardt-cloud dashboard
+/// flow with /, /login, /register, /clusters where /clusters has no route
+/// (falls through to not_found).
+#[wasm_bindgen_test]
+async fn client_launcher_reproduces_issue_4088_navigation_flow() {
+	let root = install_app_root();
+
+	fn login_page() -> Page {
+		PageElement::new("div")
+			.attr("id", "login")
+			.child("LOGIN-CONTENT")
+			.into_page()
+	}
+	fn register_page() -> Page {
+		PageElement::new("div")
+			.attr("id", "register")
+			.child("REGISTER-CONTENT")
+			.into_page()
+	}
+	fn dashboard() -> Page {
+		PageElement::new("div")
+			.attr("id", "dashboard")
+			.child("DASHBOARD-CONTENT")
+			.into_page()
+	}
+	fn not_found() -> Page {
+		PageElement::new("div")
+			.attr("id", "not-found")
+			.child("NOT-FOUND-CONTENT")
+			.into_page()
+	}
+
+	ClientLauncher::new("#app")
+		.router(|| {
+			Router::new()
+				.route("/", dashboard)
+				.route("/login", login_page)
+				.route("/register", register_page)
+				.not_found(not_found)
+		})
+		.launch()
+		.expect("launch");
+
+	yield_to_microtasks().await;
+	assert!(
+		root.inner_html().contains("DASHBOARD-CONTENT"),
+		"boot mount: expected DASHBOARD-CONTENT, got {}",
+		root.inner_html()
+	);
+
+	// Issue #4088 row 2: /login should render login_page after Router::push
+	with_router(|r| r.push("/login")).expect("push /login");
+	yield_to_microtasks().await;
+	yield_to_microtasks().await;
+	assert!(
+		root.inner_html().contains("LOGIN-CONTENT"),
+		"#4088 reproduction: /login must render login_page, got {}",
+		root.inner_html()
+	);
+
+	// Issue #4088 row 3: /register
+	with_router(|r| r.push("/register")).expect("push /register");
+	yield_to_microtasks().await;
+	yield_to_microtasks().await;
+	assert!(
+		root.inner_html().contains("REGISTER-CONTENT"),
+		"#4088 reproduction: /register must render register_page, got {}",
+		root.inner_html()
+	);
+
+	// Issue #4088 row 4: /clusters has no route — must fall through to not_found
+	with_router(|r| r.push("/clusters")).expect("push /clusters");
+	yield_to_microtasks().await;
+	yield_to_microtasks().await;
+	assert!(
+		root.inner_html().contains("NOT-FOUND-CONTENT"),
+		"#4088 reproduction: unmatched path /clusters must render not_found, got {}",
+		root.inner_html()
 	);
 }


### PR DESCRIPTION
## Summary

- Eliminate the two-phase mount in `ClientLauncher::launch` and consolidate into a single `EffectTiming::Layout` Effect. Fixes the SPA navigation regression where the render Effect did not re-fire after `Router::push`.
- Add `Router::on_navigate(callback) -> NavigationSubscription` as an explicit subscription escape hatch (inspired by React Router's `router.subscribe`).
- Add `#[doc(hidden)]` diagnostic API on `Runtime` so cross-crate WASM tests can inspect the dependency graph.
- Add a permanent e2e_cdp regression test exercising the full `<a href>` link-interceptor → `Router::push` → re-render flow against a real Chrome container.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (`Router::on_navigate` API addition)

## Motivation and Context

Same failure class as #3348 (closed) and #4075 (closed by #4078, regressed). PR #4078 attempted to fix #4075 by hoisting Signal clones out of `with_router(|r| ...)`, but the fix was never empirically verified in WASM (CI gap, fixed separately by #4093 / #4094 which is now merged). The regression reproduces against `db69894e` on `main`.

Diagnosis (see commits):

- Phase 1 (commit 1): adds diagnostic API to inspect the dependency graph.
- Phase 1.5 (commit 2): adds `Router::on_navigate` explicit subscription escape hatch.
- Phase 2 (commit 3): adds failing reproduction test with diagnostic asserts. **CI run for this commit is intentionally red.**
- Phase 3 (commit 4): consolidates the launcher into a single `Layout` Effect, eliminating the two-phase mount. **CI run for this commit turns the test green.**
- Phase 4 (commit 5): adds e2e_cdp regression test against the link-interceptor path.
- Phase 5 (commit 6): CHANGELOG updates.

## How Was This Tested?

- `cargo nextest run -p reinhardt-core --lib reactive::` — all reactive tests pass (4 new diagnostic tests added).
- `cargo nextest run -p reinhardt-pages --lib router::core::tests::on_navigate` — `on_navigate` tests pass (2 new tests added).
- `cargo check -p reinhardt-pages --tests --target wasm32-unknown-unknown` — clean compile.
- `cargo nextest run -p reinhardt-pages` — 1286 native tests pass (no regressions).
- `cargo check -p reinhardt-pages --features e2e-cdp-test --tests` — clean.
- `cargo make fmt-check` and `cargo make clippy-check` — clean on changed files (a pre-existing fmt issue in `crates/reinhardt-conf/tests/source_priority.rs` is unrelated and tracked separately).

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (CHANGELOG entries added for both crates)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Fixes #4088
- Refs #4075 (prior regression of the same class, supposedly fixed by #4078)
- Refs #3348 (older same-class regression, originally on the admin path)
- Refs #4101 (v0.3.0 roadmap: switch ClientLauncher default to `on_navigate`)
- Refs #4093 (CI gap that allowed #4088 to land — fixed in preceding PR #4094)

## Notes for Reviewers

**Merge strategy:** Please merge via **Rebase and Merge** (not Squash) to preserve the red→green TDD trace across the 6 commits. Per `instructions/PR_GUIDELINE.md` MP-2: rebase-and-merge is appropriate when commits are intentionally logical and history-preserving.

**Phase 4 marker feature design note:** `e2e-cdp-test` is implemented as an empty marker feature (`e2e-cdp-test = []`) rather than a feature with `dep:` activations. This is because Cargo rejects `optional = true` on `[dev-dependencies]`, and making the deps non-dev (regular `optional` deps) would create a publish-cycle with `reinhardt-test` (which already depends on `reinhardt-pages`). Test compilation is gated by both the `[[test]] required-features = ["e2e-cdp-test"]` Cargo entry and the `#![cfg(all(feature = "e2e-cdp-test", not(target_arch = "wasm32")))]` attribute, so the test only compiles when explicitly opted in. `reinhardt-test` is path-only (KI-2 compliant).

**Phase 4 fixture detached-workspace note:** `crates/reinhardt-pages/tests/fixtures/spa_navigation_app/Cargo.toml` includes an empty `[workspace]` table. This is the standard Cargo pattern for nested-but-detached crates and matches the workspace `exclude = [...]` entry; without it, Cargo errors with "current package believes it's in a workspace when it's not".

🤖 Generated with [Claude Code](https://claude.com/claude-code)