### PR TITLE
fix(test): make host.docker.internal resolvable in cdp_browser fixture

### DIFF
--- a/crates/reinhardt-test/src/fixtures/wasm/e2e_cdp.rs
+++ b/crates/reinhardt-test/src/fixtures/wasm/e2e_cdp.rs
@@ -36,9 +36,9 @@ use chromiumoxide::browser::Browser;
 use chromiumoxide::error::CdpError;
 use futures::StreamExt;
 use rstest::*;
-use testcontainers::core::{ContainerPort, WaitFor};
+use testcontainers::core::{ContainerPort, Host, WaitFor};
 use testcontainers::runners::AsyncRunner;
-use testcontainers::{ContainerAsync, GenericImage};
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
 use tokio::task::JoinHandle;
 
 // Re-export chromiumoxide types for downstream convenience
@@ -126,7 +126,17 @@ impl CdpBrowser {
 	pub async fn start(config: CdpConfig) -> Result<Self, CdpError> {
 		let image = GenericImage::new(&config.chrome_image, &config.chrome_tag)
 			.with_exposed_port(ContainerPort::Tcp(CDP_PORT))
-			.with_wait_for(WaitFor::message_on_stderr("DevTools listening on"));
+			.with_wait_for(WaitFor::message_on_stderr("DevTools listening on"))
+			// Make `host.docker.internal` resolve to the host gateway inside
+			// the container on every supported platform. macOS Docker Desktop
+			// configures this automatically, but Linux containers (e.g. on
+			// the GitHub Actions `ubuntu-latest` runner) require an explicit
+			// `--add-host=host.docker.internal:host-gateway` mapping.
+			//
+			// Without this, browser tests that load resources from a host
+			// HTTP server via `http://host.docker.internal:NNNN/` fail with
+			// `ERR_NAME_NOT_RESOLVED` on Linux. (Refs #4106.)
+			.with_host("host.docker.internal", Host::HostGateway);
 
 		let container = image.start().await.map_err(|e| {
 			CdpError::Io(std::io::Error::new(

--- a/crates/reinhardt-test/src/fixtures/wasm/e2e_cdp.rs
+++ b/crates/reinhardt-test/src/fixtures/wasm/e2e_cdp.rs
@@ -127,15 +127,21 @@ impl CdpBrowser {
 		let image = GenericImage::new(&config.chrome_image, &config.chrome_tag)
 			.with_exposed_port(ContainerPort::Tcp(CDP_PORT))
 			.with_wait_for(WaitFor::message_on_stderr("DevTools listening on"))
-			// Make `host.docker.internal` resolve to the host gateway inside
-			// the container on every supported platform. macOS Docker Desktop
-			// configures this automatically, but Linux containers (e.g. on
-			// the GitHub Actions `ubuntu-latest` runner) require an explicit
-			// `--add-host=host.docker.internal:host-gateway` mapping.
+			// Map `host.docker.internal` to the Docker host gateway inside
+			// the container. macOS and Windows Docker Desktop configure this
+			// automatically, but Linux containers (e.g. the GitHub Actions
+			// `ubuntu-latest` runner) require an explicit
+			// `--add-host=host.docker.internal:host-gateway` mapping, which
+			// the `host-gateway` sentinel value enables.
 			//
-			// Without this, browser tests that load resources from a host
-			// HTTP server via `http://host.docker.internal:NNNN/` fail with
-			// `ERR_NAME_NOT_RESOLVED` on Linux. (Refs #4106.)
+			// Engine requirement: the `host-gateway` sentinel was added in
+			// Docker Engine 20.10 (2020-12). On older daemons the mapping
+			// is silently ignored, in which case host-served URLs must use
+			// a literal IP address instead of `host.docker.internal`.
+			//
+			// Without this mapping, browser tests that load resources from
+			// a host HTTP server via `http://host.docker.internal:NNNN/`
+			// fail with `ERR_NAME_NOT_RESOLVED` on Linux. (Refs #4106.)
 			.with_host("host.docker.internal", Host::HostGateway);
 
 		let container = image.start().await.map_err(|e| {


### PR DESCRIPTION
## Summary

- Add \`.with_host(\"host.docker.internal\", Host::HostGateway)\` to the \`GenericImage\` built by the \`cdp_browser\` rstest fixture (\`crates/reinhardt-test/src/fixtures/wasm/e2e_cdp.rs\`).
- This makes \`host.docker.internal\` resolve to the Docker host gateway on Linux, matching macOS Docker Desktop's automatic behavior. Without this, browser-based tests that load resources from a host-side HTTP server fail with \`ERR_NAME_NOT_RESOLVED\` on the GitHub Actions \`ubuntu-latest\` runner.
- Verified by Linux CI on the dependent #4102 PR, where the new SPA-navigation E2E test panicked with \`Could not find node with given id\` because the WASM bundle never loaded — the symptom of the unresolved hostname.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The new SPA-navigation E2E test added in #4102 (Refs #4088) exercises an end-to-end flow that requires a containerized Chrome instance to fetch a fixture WASM bundle from an axum HTTP server bound on the host. The current fixture leaves \`host.docker.internal\` unconfigured, which works on macOS Docker Desktop (the typical local-dev platform) but fails silently on Linux runners. This patch closes that gap so Linux CI can run the same test suite that passes locally.

This is a **preceding** fix per the project's WU-3 work-unit policy: cross-crate shared infrastructure must land before per-crate consumers.

## How Was This Tested

- \`cargo check -p reinhardt-test --features e2e-cdp\` — passes
- \`cargo make fmt-check\` — passes
- The fix is a 1-call addition to the \`GenericImage\` builder; the rest of the fixture (port mapping, wait-for, retries) is untouched. The actual cross-platform DNS behavior is verified by re-running #4102's CI once this PR merges and that branch is rebased on main.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to documentation (inline comment explains the rationale and references #4106)
- [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) format

## Labels to Apply

- \`bug\`
- \`ci-cd\`

## Related Issues

Fixes #4106
Refs #4088, #4102

🤖 Generated with [Claude Code](https://claude.com/claude-code)