### PR TITLE
fix(pages): invoke on_navigate observers from popstate listener

### DIFF
--- a/crates/reinhardt-pages/src/router/core.rs
+++ b/crates/reinhardt-pages/src/router/core.rs
@@ -496,6 +496,10 @@ impl Router {
 	/// `NavigationSubscription` handles without panicking on `RefCell`
 	/// reentry. Dropped subscriptions are pruned on every dispatch.
 	///
+	/// The popstate listener inlines the same snapshot pattern (it does
+	/// not have access to `&self`); keep both call sites in sync if this
+	/// helper changes.
+	///
 	/// Refs #4088, #4108.
 	fn notify_observers(&self, path: &str, params: &HashMap<String, String>) {
 		let listeners_snapshot: Vec<std::rc::Rc<NavigationListener>> = {
@@ -641,19 +645,37 @@ impl Router {
 		let path_signal = self.current_path.clone();
 		let params_signal = self.current_params.clone();
 		let route_name_signal = self.current_route_name.clone();
+		let navigation_observers = self.navigation_observers.clone();
 
 		let closure = setup_popstate_listener(move |path, state| {
-			// Update path signal
-			path_signal.set(path);
+			// Update Signals first, then notify observers, so listeners that
+			// read `Signal::get` from inside their closure see the new
+			// state. Mirrors `Router::navigate`. Refs #4088, #4108.
+			path_signal.set(path.clone());
 
-			// Update params and route name from history state if available
-			if let Some(hist_state) = state {
+			let params_for_observers = if let Some(hist_state) = state {
+				let params = hist_state.params.clone();
 				params_signal.set(hist_state.params);
 				route_name_signal.set(hist_state.route_name);
+				params
 			} else {
-				// Clear params when no state is available
+				// Clear params when no state is available.
 				params_signal.set(HashMap::new());
 				route_name_signal.set(None);
+				HashMap::new()
+			};
+
+			// Dispatch on_navigate observers using the same snapshot-then-
+			// iterate pattern as Router::notify_observers. Inlined here
+			// because this closure does not have access to `&self`.
+			// Keep in sync with Router::notify_observers.
+			let listeners_snapshot: Vec<std::rc::Rc<NavigationListener>> = {
+				let mut observers = navigation_observers.borrow_mut();
+				observers.retain(|w| w.strong_count() > 0);
+				observers.iter().filter_map(|w| w.upgrade()).collect()
+			};
+			for listener in listeners_snapshot {
+				listener(&path, &params_for_observers);
 			}
 		});
 

--- a/crates/reinhardt-pages/src/router/core.rs
+++ b/crates/reinhardt-pages/src/router/core.rs
@@ -449,26 +449,26 @@ impl Router {
 		self.navigate(path, NavigationType::Replace)
 	}
 
-	/// Registers a navigation observer.
+	/// Subscribe to navigation events.
 	///
-	/// Inspired by React Router's `router.subscribe(listener)` design.
-	/// The listener is invoked synchronously on every successful navigation
-	/// ([`Self::push`] or [`Self::replace`]) with the new path and matched
-	/// params. The listener fires **after** the path / params Signals have
-	/// been updated, so calling `Signal::get` from within the listener
-	/// returns the new values.
+	/// The listener fires on every successful navigation, including:
+	///
+	/// - `Router::push` and `Router::replace` (programmatic navigation).
+	/// - Browser back / forward (popstate). This is dispatched by
+	///   `setup_history_listener` after it updates the `current_path` /
+	///   `current_params` / `current_route_name` Signals.
 	///
 	/// Returns a [`NavigationSubscription`] handle. Drop the handle to
 	/// unregister the listener. The router itself does not retain a strong
 	/// reference; if all subscriptions are dropped, the listener is freed
 	/// at the next `navigate` call (see `navigate` body which prunes dead
-	/// Weak references on every invocation).
+	/// `Weak` references on every invocation).
 	///
 	/// Robust against nested reactive nodes spawned during view rendering
-	/// because this subscription is independent of the Effect / Signal
+	/// because this subscription is independent of the `Effect` / `Signal`
 	/// auto-tracking system.
 	///
-	/// Refs #4088, #4075, #3348.
+	/// Refs #4088, #4108.
 	pub fn on_navigate<F>(&self, listener: F) -> NavigationSubscription
 	where
 		F: Fn(&str, &HashMap<String, String>) + 'static,

--- a/crates/reinhardt-pages/src/router/core.rs
+++ b/crates/reinhardt-pages/src/router/core.rs
@@ -480,6 +480,34 @@ impl Router {
 		NavigationSubscription { listener }
 	}
 
+	/// Dispatch the registered `on_navigate` listeners with the given path
+	/// and params.
+	///
+	/// Both `Router::navigate` (after a programmatic push/replace) and the
+	/// popstate listener (after a browser-driven back/forward) call this
+	/// method after the `Signal` updates so listeners always see the new
+	/// state when they read `Signal::get` from inside their closure.
+	///
+	/// The helper takes a snapshot of strong references to listeners
+	/// before invoking them. The `RefCell` borrow is released before any
+	/// user-supplied closure runs, which lets listeners call
+	/// `Router::push` / `Router::replace` reentrantly, register new
+	/// listeners via `on_navigate`, or drop existing
+	/// `NavigationSubscription` handles without panicking on `RefCell`
+	/// reentry. Dropped subscriptions are pruned on every dispatch.
+	///
+	/// Refs #4088, #4108.
+	fn notify_observers(&self, path: &str, params: &HashMap<String, String>) {
+		let listeners_snapshot: Vec<std::rc::Rc<NavigationListener>> = {
+			let mut observers = self.navigation_observers.borrow_mut();
+			observers.retain(|w| w.strong_count() > 0);
+			observers.iter().filter_map(|w| w.upgrade()).collect()
+		};
+		for listener in listeners_snapshot {
+			listener(path, params);
+		}
+	}
+
 	/// Internal navigation implementation.
 	fn navigate(&self, path: &str, nav_type: NavigationType) -> Result<(), RouterError> {
 		let route_match = self.match_path(path);
@@ -527,18 +555,7 @@ impl Router {
 			.as_ref()
 			.map(|m| m.params.clone())
 			.unwrap_or_default();
-		// Snapshot strong refs before invoking listeners; this avoids
-		// holding the `RefCell` borrow across user-supplied closure code
-		// (which could re-enter `on_navigate` and panic on RefCell reentry).
-		let listeners_snapshot: Vec<std::rc::Rc<NavigationListener>> = {
-			let mut observers = self.navigation_observers.borrow_mut();
-			// Prune dropped subscriptions on every navigate.
-			observers.retain(|w| w.strong_count() > 0);
-			observers.iter().filter_map(|w| w.upgrade()).collect()
-		};
-		for listener in listeners_snapshot {
-			listener(path, &params_for_observers);
-		}
+		self.notify_observers(path, &params_for_observers);
 
 		Ok(())
 	}
@@ -656,6 +673,7 @@ impl Router {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::rstest;
 
 	fn test_view() -> Page {
 		Page::text("Test")
@@ -806,6 +824,32 @@ mod tests {
 
 	use std::cell::RefCell;
 	use std::rc::Rc;
+
+	#[rstest]
+	fn notify_observers_dispatches_to_registered_listener() {
+		// Arrange
+		let router = Router::new();
+		let observed_calls: std::rc::Rc<
+			std::cell::RefCell<Vec<(String, HashMap<String, String>)>>,
+		> = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+		let observed_calls_inner = observed_calls.clone();
+		let _subscription = router.on_navigate(move |path, params| {
+			observed_calls_inner
+				.borrow_mut()
+				.push((path.to_string(), params.clone()));
+		});
+		let mut params = HashMap::new();
+		params.insert("id".to_string(), "42".to_string());
+
+		// Act
+		router.notify_observers("/users/42/", &params);
+
+		// Assert
+		let calls = observed_calls.borrow();
+		assert_eq!(calls.len(), 1, "listener must fire exactly once");
+		assert_eq!(calls[0].0, "/users/42/");
+		assert_eq!(calls[0].1, params);
+	}
 
 	#[test]
 	#[serial_test::serial]

--- a/crates/reinhardt-pages/tests/wasm/client_launcher_navigation_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/client_launcher_navigation_test.rs
@@ -215,3 +215,89 @@ async fn client_launcher_reproduces_issue_4088_navigation_flow() {
 		root.inner_html()
 	);
 }
+
+/// Regression test for the popstate gap fixed in #4108: browser
+/// back/forward must trigger the launcher's render path, which means
+/// the underlying `on_navigate` observers must fire from popstate.
+/// Before the fix, only programmatic `Router::push` / `Router::replace`
+/// woke observers.
+#[wasm_bindgen_test]
+async fn client_launcher_re_renders_on_popstate() {
+	let root = install_app_root();
+
+	let observed_paths: std::rc::Rc<std::cell::RefCell<Vec<String>>> =
+		std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+	let observed_paths_for_listener = observed_paths.clone();
+
+	ClientLauncher::new("#app")
+		.router(|| {
+			Router::new()
+				.route("/", page_root)
+				.route("/a", page_a)
+				.route("/b", page_b)
+		})
+		.after_launch(move |_ctx| {
+			// after_launch is FnOnce, so observed_paths_for_listener can
+			// be moved straight into the listener body without an extra
+			// clone.
+			let sub = with_router(move |r| {
+				r.on_navigate(move |path, _params| {
+					observed_paths_for_listener
+						.borrow_mut()
+						.push(path.to_string());
+				})
+			});
+			// Leak the subscription for the lifetime of the test; it is
+			// dropped naturally when the WASM module exits.
+			std::mem::forget(sub);
+		})
+		.launch()
+		.expect("launch");
+
+	yield_to_microtasks().await;
+
+	// Arrange: navigate forward to /a then /b so popstate has somewhere
+	// to pop back to.
+	with_router(|r| r.push("/a")).expect("push /a");
+	yield_to_microtasks().await;
+	yield_to_microtasks().await;
+	with_router(|r| r.push("/b")).expect("push /b");
+	yield_to_microtasks().await;
+	yield_to_microtasks().await;
+
+	let html_at_b = root.inner_html();
+	assert!(
+		html_at_b.contains("ROUTE-B-CONTENT"),
+		"setup precondition: should be on /b before history.back, got: {html_at_b}"
+	);
+
+	// Act: simulate the browser back button.
+	let history = web_sys::window().unwrap().history().unwrap();
+	history.back().expect("history.back");
+	// popstate is dispatched as a macrotask. The yield_to_microtasks
+	// helper uses TimeoutFuture::new(0), which is itself a macrotask
+	// boundary (setTimeout(0)), so two yields suffice to let popstate
+	// fire and then for the launcher's render Effect (or, post-#4101,
+	// on_navigate listener) to commit the DOM update.
+	yield_to_microtasks().await;
+	yield_to_microtasks().await;
+
+	// Assert: DOM reflects /a, and the on_navigate observer received the
+	// popstate path (this is the bit that used to silently break).
+	let html_after_back = root.inner_html();
+	assert!(
+		html_after_back.contains("ROUTE-A-CONTENT"),
+		"expected /a view after history.back from /b, got: {html_after_back}"
+	);
+	assert!(
+		!html_after_back.contains("ROUTE-B-CONTENT"),
+		"/b view should be gone after history.back, got: {html_after_back}"
+	);
+
+	let paths = observed_paths.borrow();
+	assert_eq!(
+		paths.as_slice(),
+		&["/a".to_string(), "/b".to_string(), "/a".to_string()],
+		"on_navigate listener must fire for each push and the popstate, in order"
+	);
+}


### PR DESCRIPTION
## Summary

`Router::on_navigate` (added in #4088) registered listeners do not fire on browser back/forward because `Router::setup_history_listener` updates the Signals directly without invoking `navigation_observers`. This PR closes that gap by extracting a shared `notify_observers` helper from `Router::navigate` and inlining the same snapshot-iterate dispatch in the popstate closure (which does not have access to `&self`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

PR #4101 plans to migrate `ClientLauncher` from a reactive `Effect` to `Router::on_navigate`. That migration is unsafe while popstate silently bypasses observers, since browser back/forward would stop re-rendering. This PR is the prerequisite that makes the migration safe.

## How Was This Tested

- Native unit test added for `Router::notify_observers` dispatch (`crates/reinhardt-pages/src/router/core.rs` test module, `notify_observers_dispatches_to_registered_listener`).
- WASM e2e test added that triggers `history.back()` and asserts both DOM re-mount and observer firing in sequence (`crates/reinhardt-pages/tests/wasm/client_launcher_navigation_test.rs`, `client_launcher_re_renders_on_popstate`).
- `cargo nextest run -p reinhardt-pages`: 1287 passed.
- `cargo fmt --check`, `cargo clippy -p reinhardt-pages -- -D warnings`, and `cargo doc --no-deps -p reinhardt-pages` all clean.
- WASM test could not be run locally due to a Chrome/ChromeDriver version mismatch in this environment; CI's `wasm-check.yml` workflow uses `browser-actions/setup-chrome` to provide matched versions and will validate.

## Checklist

- [x] All code comments in English
- [x] All new tests use `#[rstest]` (native) or `#[wasm_bindgen_test]` (WASM) per project conventions
- [x] Existing tests pass locally
- [x] No `todo!()` / `// TODO:` / `// FIXME:` introduced
- [x] No `unimplemented!()` introduced
- [x] No `#[allow(...)]` added without explanatory comment
- [x] Doc comments updated on `Router::on_navigate` to make popstate dispatch explicit
- [x] `notify_observers` and the popstate inline copy reference each other via "keep in sync" comments

## Labels Applied

- `bug`
- `routing`

## Related Issues

Fixes #4108
Refs #4088, #4101

🤖 Generated with [Claude Code](https://claude.com/claude-code)