### PR TITLE
fix(pages): bind spa e2e test server to 0.0.0.0 for container access

### DIFF
--- a/crates/reinhardt-pages/tests/integration/spa_navigation_e2e_test.rs
+++ b/crates/reinhardt-pages/tests/integration/spa_navigation_e2e_test.rs
@@ -74,7 +74,13 @@ async fn boot_test_server(fixture_dir: &Path) -> (String, ServerGuard) {
 		ServeDir::new(fixture_dir).append_index_html_on_directories(true),
 	);
 
-	let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+	// Bind to 0.0.0.0 so the chromedp container can reach the listener via
+	// `host.docker.internal` on Linux CI. With `--add-host=...:host-gateway`
+	// (set by `reinhardt-test`'s `cdp_browser` fixture), the name resolves
+	// to the host's bridge interface (e.g. 172.17.0.1), which a 127.0.0.1
+	// only listener will not accept. Refs #4111. See also the same pattern
+	// used by `reinhardt-test::E2eTestServer` in `e2e_cdp.rs`.
+	let listener = tokio::net::TcpListener::bind("0.0.0.0:0")
 		.await
 		.expect("bind ephemeral port");
 	let port = listener.local_addr().expect("local_addr").port();


### PR DESCRIPTION
## Summary

- Bind `spa_navigation_e2e_test::boot_test_server` listener to `0.0.0.0:0` instead of `127.0.0.1:0`, so the chromedp container can reach the host listener via the resolved `host.docker.internal` IP (Linux host-gateway / bridge interface).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Fixes #4111. PR #4107 fixed `host.docker.internal` name resolution inside the chromedp container; this PR fixes the bind-address layer that the resolution fix exposed.

After #4107, the container resolves `host.docker.internal` to the host's bridge interface (e.g. `172.17.0.1` on Linux), but the test HTTP server bound only to `127.0.0.1` does not accept on that interface. Chrome ends up at `chrome-error://chromewebdata/` and the SPA DOM probe panics. Binding to `0.0.0.0` matches the pattern already documented and used by `reinhardt-test::E2eTestServer` (`crates/reinhardt-test/src/fixtures/wasm/e2e_cdp.rs:174-187`).

## How Was This Tested

- [x] `cargo check -p reinhardt-pages --all-features --tests` — clean
- [x] `cargo fmt --check -p reinhardt-pages` — clean
- [x] `cargo clippy -p reinhardt-pages --all-features --test spa_navigation_e2e_test -- -D warnings` — clean (the modified test target produces no new warnings)
- [ ] CI: `WASM Check / E2E Test (Chrome via CDP)` job goes green on Linux (this is the decisive verification — the failure has been observed on every PR since #4102)

The local macOS run does not reproduce the issue (Docker Desktop's `host.docker.internal` resolves to a reachable interface even with a 127.0.0.1 listener), so CI is the authoritative test.

## Checklist

- [x] Code follows project style guidelines (tabs, English comments)
- [x] Comments added explaining the bind-address rationale and pointing at the sibling pattern in `e2e_cdp.rs`
- [x] No new warnings on the touched target
- [x] Linked to issue with `Fixes #4111`
- [x] Single-file, single-purpose change

## Labels to Apply

- `bug`
- `ci-cd`

## Refs

- Closes #4111
- Companion to PR #4107 (resolved `host.docker.internal` name resolution in the chromedp fixture)
- Origin: PR #4102 (introduced the E2E test, but its E2E job ended `CANCELLED`, so this bind-address bug was never observed against a green baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)