### PR TITLE
fix(pages): silence clippy violations in two test targets

### DIFF
--- a/crates/reinhardt-pages/tests/router_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/router_integration_tests.rs
@@ -218,6 +218,11 @@ fn test_link_external() {
 #[test]
 fn test_router_outlet() {
 	use std::sync::Arc;
+	// `Router` is not Send/Sync, but `RouterOutlet::new` accepts
+	// `Arc<Router>` to mirror the production API. This test runs
+	// single-threaded and never crosses thread boundaries, so the
+	// non-Send/Sync `Arc` is safe here. Refs #4115.
+	#[allow(clippy::arc_with_non_send_sync)]
 	let router = Arc::new(Router::new());
 	let outlet = RouterOutlet::new(router)
 		.id("main-content")

--- a/crates/reinhardt-pages/tests/static_resolver_tests.rs
+++ b/crates/reinhardt-pages/tests/static_resolver_tests.rs
@@ -49,10 +49,12 @@ fn test_resolve_static_strips_leading_slash() {
 /// Tests that is_initialized returns boolean correctly.
 #[rstest]
 fn test_is_initialized_returns_bool() {
-	// The function should return a boolean
-	// We can't test the exact value since it depends on global state
-	let result = is_initialized();
-	assert!(result == true || result == false);
+	// The function returns a bool that depends on global state, so we
+	// cannot assert a concrete value. Type-pin via annotation so this
+	// test still verifies the return type (a signature change to non-bool
+	// would fail to compile here) and that the call does not panic.
+	// Refs #4115.
+	let _: bool = is_initialized();
 }
 
 /// Tests multiple files can be resolved.


### PR DESCRIPTION
## Summary

- `crates/reinhardt-pages/tests/static_resolver_tests.rs:55` — replace tautological `result == true || result == false` assertion with a type-pinned binding (`let _: bool = is_initialized();`). Silences `clippy::bool_comparison` while preserving the test's intent (verify return type + no-panic).
- `crates/reinhardt-pages/tests/router_integration_tests.rs:221` — add documented `#[allow(clippy::arc_with_non_send_sync)]` on the `Arc::new(Router::new())` call site. The test mirrors the production API which takes `Arc<Router>`, runs single-threaded, and never crosses thread boundaries.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Fixes #4115. Surfaced while running local pre-push gates (`cargo make clippy-check`) for PR #4112 (Fixes #4111).

## How Was This Tested

- [x] `cargo clippy -p reinhardt-pages --all-features --test static_resolver_tests --test router_integration_tests -- -D warnings` — clean (was failing pre-fix)
- [x] `cargo nextest run -p reinhardt-pages --all-features --test static_resolver_tests --test router_integration_tests` — 27/27 PASS
- [x] CI: standard `Clippy / Clippy Lint` job runs on this PR

## Out of Scope

The same lint families surface elsewhere in the workspace (e.g. multiple `bool_assert_comparison` in `crates/reinhardt-pages/src/router/params.rs`, additional `arc_with_non_send_sync` in `hooks_integration` tests, plus several `default_trait_access`, `useless_vec`, `type_complexity` violations in component/router test targets).

These are pre-existing and broader than #4115, which is explicitly scoped to the two violations that block `cargo make clippy-check` on test integration targets I observed during PR #4112 verification. The remaining violations should be triaged in a follow-up issue.

A separate concern: `Clippy / Clippy Lint` CI job has been reporting **pass** on recent merges to `main` (e.g. `74121273714` for #4112) despite these violations existing on the merged tree. The clippy CI job appears not to surface these failures on Linux CI — root cause unknown; worth a separate investigation issue (likely caching / `Swatinem/rust-cache@v2` incremental artifact reuse) but not blocking this fix.

## Checklist

- [x] Code follows project style guidelines (tabs, English comments)
- [x] Comments added documenting the `#[allow]` and the type-pin rationale
- [x] No new warnings on the touched targets
- [x] `Refs #4115` and `Fixes #4115` linkage in code comments and commit message respectively
- [x] No production code changed (test targets only)

## Labels to Apply

- `bug`
- `ci-cd`

## Refs

- Closes #4115
- Surfaced by PR #4112 (Fixes #4111) local gate runs
- Companion concern (CI not catching these): noted in 'Out of Scope' section above

🤖 Generated with [Claude Code](https://claude.com/claude-code)