### PR TITLE
deprecated(conf): mark JsonFileSource and auto_source as deprecated

### DIFF
--- a/crates/reinhardt-conf/CHANGELOG.md
+++ b/crates/reinhardt-conf/CHANGELOG.md
@@ -22,6 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with file path and TOML key path context. The boxed payload keeps the
   enum within `clippy::result_large_err` limits.
 
+### Deprecated
+
+- `JsonFileSource::new` and `auto_source` are deprecated and will be
+  removed in 0.2.0. TOML is the canonical Reinhardt configuration format
+  and the framework will no longer ship a privileged JSON source.
+  Migrate `.json` configuration files to `.toml` (TOML is a superset of
+  typical JSON config use cases including nested tables and arrays), or
+  implement the public `ConfigSource` trait against `serde_json` to keep
+  JSON support out of tree. For new TOML-only code, prefer
+  `TomlFileSource::new(path)` directly over `auto_source` to make the
+  configuration format explicit at the call site. Refs #4087.
+
 ## [0.1.0-rc.25](https://github.com/kent8192/reinhardt-web/compare/reinhardt-conf@v0.1.0-rc.24...reinhardt-conf@v0.1.0-rc.25) - 2026-04-30
 
 ### Changed

--- a/crates/reinhardt-conf/src/settings/prelude.rs
+++ b/crates/reinhardt-conf/src/settings/prelude.rs
@@ -15,15 +15,17 @@ pub use super::env_parser::{
 };
 pub use super::interpolation::InterpolationError;
 pub use super::profile::Profile;
+pub use super::sources::{
+	ConfigSource, DefaultSource, DotEnvSource, EnvSource, HighPriorityEnvSource,
+	LowPriorityEnvSource, SourceError, TomlFileSource,
+};
 // `JsonFileSource` and `auto_source` are deprecated alongside *.json
 // configuration support and will be removed in 0.2.0 (issue #4087). The prelude
 // continues to surface them during the deprecation window so existing user code
-// keeps compiling unchanged.
+// keeps compiling unchanged. The `#[allow(deprecated)]` is scoped to this
+// re-export only so deprecations added to other `sources` items remain visible.
 #[allow(deprecated)]
-pub use super::sources::{
-	ConfigSource, DefaultSource, DotEnvSource, EnvSource, HighPriorityEnvSource, JsonFileSource,
-	LowPriorityEnvSource, SourceError, TomlFileSource, auto_source,
-};
+pub use super::sources::{JsonFileSource, auto_source};
 pub use super::testing::{SettingsOverride, SettingsOverrideGuard};
 pub use super::validation::{
 	ChoiceValidator, PatternValidator, RangeValidator, RequiredValidator, SecurityValidator,

--- a/crates/reinhardt-conf/src/settings/prelude.rs
+++ b/crates/reinhardt-conf/src/settings/prelude.rs
@@ -15,6 +15,11 @@ pub use super::env_parser::{
 };
 pub use super::interpolation::InterpolationError;
 pub use super::profile::Profile;
+// `JsonFileSource` and `auto_source` are deprecated alongside *.json
+// configuration support and will be removed in 0.2.0 (issue #4087). The prelude
+// continues to surface them during the deprecation window so existing user code
+// keeps compiling unchanged.
+#[allow(deprecated)]
 pub use super::sources::{
 	ConfigSource, DefaultSource, DotEnvSource, EnvSource, HighPriorityEnvSource, JsonFileSource,
 	LowPriorityEnvSource, SourceError, TomlFileSource, auto_source,

--- a/crates/reinhardt-conf/src/settings/sources.rs
+++ b/crates/reinhardt-conf/src/settings/sources.rs
@@ -421,6 +421,12 @@ impl ConfigSource for TomlFileSource {
 }
 
 /// JSON file configuration source
+///
+/// **Deprecated since 0.1.0**: TOML is the canonical Reinhardt configuration
+/// format. `JsonFileSource` will be removed in 0.2.0. Migrate `.json` files to
+/// `.toml` (TOML is a superset of typical JSON config use cases) or implement
+/// the public `ConfigSource` trait against `serde_json` if you need to keep
+/// JSON support out of tree. See <https://github.com/kent8192/reinhardt-web/issues/4087>.
 pub struct JsonFileSource {
 	path: PathBuf,
 }
@@ -431,11 +437,16 @@ impl JsonFileSource {
 	/// # Examples
 	///
 	/// ```
+	/// # #![allow(deprecated)]
 	/// use reinhardt_conf::settings::sources::JsonFileSource;
 	/// use std::path::PathBuf;
 	///
 	/// let source = JsonFileSource::new(PathBuf::from("config.json"));
 	/// ```
+	#[deprecated(
+		since = "0.1.0",
+		note = "Use TomlFileSource::new instead. JsonFileSource will be removed in 0.2.0 (issue #4087)"
+	)]
 	pub fn new(path: impl Into<PathBuf>) -> Self {
 		Self { path: path.into() }
 	}
@@ -548,18 +559,28 @@ impl ConfigSource for DefaultSource {
 }
 /// Auto-detect configuration source based on file extension
 ///
+/// **Deprecated since 0.1.0**: The `*.json` branch is going away in 0.2.0
+/// alongside [`JsonFileSource`]. For TOML usage, prefer constructing
+/// [`TomlFileSource::new`] directly — it makes the configuration format
+/// explicit at the call site. See <https://github.com/kent8192/reinhardt-web/issues/4087>.
+///
 /// # Examples
 ///
 /// ```
+/// # #![allow(deprecated)]
 /// use reinhardt_conf::settings::sources::auto_source;
 /// use std::path::PathBuf;
 ///
 /// // Automatically detects TOML source from extension
 /// let source = auto_source(PathBuf::from("config.toml")).unwrap();
 ///
-/// // Or JSON source
+/// // Or JSON source (deprecated; will be removed in 0.2.0)
 /// let source = auto_source(PathBuf::from("settings.json")).unwrap();
 /// ```
+#[deprecated(
+	since = "0.1.0",
+	note = "Use TomlFileSource::new directly. The *.json branch will be removed in 0.2.0 (issue #4087)"
+)]
 pub fn auto_source(path: impl AsRef<Path>) -> Result<Box<dyn ConfigSource>, SourceError> {
 	let path = path.as_ref();
 	let ext = path
@@ -569,6 +590,9 @@ pub fn auto_source(path: impl AsRef<Path>) -> Result<Box<dyn ConfigSource>, Sour
 
 	match ext {
 		"toml" => Ok(Box::new(TomlFileSource::new(path))),
+		// JsonFileSource::new is deprecated alongside this function (issue #4087);
+		// keep wiring it through until the *.json branch is removed in 0.2.0.
+		#[allow(deprecated)]
 		"json" => Ok(Box::new(JsonFileSource::new(path))),
 		_ => Err(SourceError::InvalidSource(format!(
 			"Unsupported file extension: {}",
@@ -816,6 +840,9 @@ secret_key = "test-key"
 		);
 	}
 
+	// `JsonFileSource::new` is deprecated until removal in 0.2.0 (issue #4087);
+	// the test exercises load behavior so we still want to construct one here.
+	#[allow(deprecated)]
 	#[test]
 	fn test_json_source() {
 		let temp_dir = TempDir::new().unwrap();

--- a/crates/reinhardt-conf/src/settings/sources.rs
+++ b/crates/reinhardt-conf/src/settings/sources.rs
@@ -420,17 +420,22 @@ impl ConfigSource for TomlFileSource {
 	}
 }
 
-/// JSON file configuration source
+/// JSON file configuration source.
 ///
-/// **Deprecated since 0.1.0**: TOML is the canonical Reinhardt configuration
-/// format. `JsonFileSource` will be removed in 0.2.0. Migrate `.json` files to
-/// `.toml` (TOML is a superset of typical JSON config use cases) or implement
-/// the public `ConfigSource` trait against `serde_json` if you need to keep
-/// JSON support out of tree. See <https://github.com/kent8192/reinhardt-web/issues/4087>.
+/// TOML is the canonical Reinhardt configuration format; this type will be
+/// removed in 0.2.0. Migrate `.json` files to `.toml` (TOML is a superset of
+/// typical JSON config use cases) or implement the public `ConfigSource` trait
+/// against `serde_json` if you need to keep JSON support out of tree. See
+/// <https://github.com/kent8192/reinhardt-web/issues/4087>.
+#[deprecated(
+	since = "0.1.0-rc.26",
+	note = "Use TomlFileSource instead. JsonFileSource will be removed in 0.2.0 (issue #4087)"
+)]
 pub struct JsonFileSource {
 	path: PathBuf,
 }
 
+#[allow(deprecated)] // impl block on a deprecated type (issue #4087).
 impl JsonFileSource {
 	/// Create a new JSON file configuration source
 	///
@@ -444,7 +449,7 @@ impl JsonFileSource {
 	/// let source = JsonFileSource::new(PathBuf::from("config.json"));
 	/// ```
 	#[deprecated(
-		since = "0.1.0",
+		since = "0.1.0-rc.26",
 		note = "Use TomlFileSource::new instead. JsonFileSource will be removed in 0.2.0 (issue #4087)"
 	)]
 	pub fn new(path: impl Into<PathBuf>) -> Self {
@@ -452,6 +457,7 @@ impl JsonFileSource {
 	}
 }
 
+#[allow(deprecated)] // ConfigSource impl on a deprecated type (issue #4087).
 impl ConfigSource for JsonFileSource {
 	fn load(&self) -> Result<IndexMap<String, Value>, SourceError> {
 		if !self.path.exists() {
@@ -557,12 +563,12 @@ impl ConfigSource for DefaultSource {
 		"Default values".to_string()
 	}
 }
-/// Auto-detect configuration source based on file extension
+/// Auto-detect configuration source based on file extension.
 ///
-/// **Deprecated since 0.1.0**: The `*.json` branch is going away in 0.2.0
-/// alongside [`JsonFileSource`]. For TOML usage, prefer constructing
-/// [`TomlFileSource::new`] directly — it makes the configuration format
-/// explicit at the call site. See <https://github.com/kent8192/reinhardt-web/issues/4087>.
+/// The `*.json` branch is going away in 0.2.0 alongside [`JsonFileSource`].
+/// For TOML usage, prefer constructing [`TomlFileSource::new`] directly — it
+/// makes the configuration format explicit at the call site. See
+/// <https://github.com/kent8192/reinhardt-web/issues/4087>.
 ///
 /// # Examples
 ///
@@ -578,7 +584,7 @@ impl ConfigSource for DefaultSource {
 /// let source = auto_source(PathBuf::from("settings.json")).unwrap();
 /// ```
 #[deprecated(
-	since = "0.1.0",
+	since = "0.1.0-rc.26",
 	note = "Use TomlFileSource::new directly. The *.json branch will be removed in 0.2.0 (issue #4087)"
 )]
 pub fn auto_source(path: impl AsRef<Path>) -> Result<Box<dyn ConfigSource>, SourceError> {
@@ -590,7 +596,7 @@ pub fn auto_source(path: impl AsRef<Path>) -> Result<Box<dyn ConfigSource>, Sour
 
 	match ext {
 		"toml" => Ok(Box::new(TomlFileSource::new(path))),
-		// JsonFileSource::new is deprecated alongside this function (issue #4087);
+		// JsonFileSource is deprecated alongside this function (issue #4087);
 		// keep wiring it through until the *.json branch is removed in 0.2.0.
 		#[allow(deprecated)]
 		"json" => Ok(Box::new(JsonFileSource::new(path))),

--- a/crates/reinhardt-conf/tests/file_sources.rs
+++ b/crates/reinhardt-conf/tests/file_sources.rs
@@ -1,5 +1,10 @@
 // Integration tests for TomlFileSource, JsonFileSource, and auto_source.
 // Covers: real file reading, type parsing, missing/invalid files, and extension detection.
+//
+// `JsonFileSource` and `auto_source` are deprecated until removal in 0.2.0
+// (issue #4087); these tests must keep covering the deprecated paths so
+// regressions during the deprecation window are caught.
+#![allow(deprecated)]
 
 use reinhardt_conf::settings::builder::SettingsBuilder;
 use reinhardt_conf::settings::sources::{

--- a/crates/reinhardt-conf/tests/file_sources.rs
+++ b/crates/reinhardt-conf/tests/file_sources.rs
@@ -3,13 +3,14 @@
 //
 // `JsonFileSource` and `auto_source` are deprecated until removal in 0.2.0
 // (issue #4087); these tests must keep covering the deprecated paths so
-// regressions during the deprecation window are caught.
-#![allow(deprecated)]
+// regressions during the deprecation window are caught. Deprecation warnings
+// are silenced per import / per test function below so that any new
+// deprecation added elsewhere in this file still surfaces.
 
 use reinhardt_conf::settings::builder::SettingsBuilder;
-use reinhardt_conf::settings::sources::{
-	ConfigSource, JsonFileSource, TomlFileSource, auto_source,
-};
+use reinhardt_conf::settings::sources::{ConfigSource, TomlFileSource};
+#[allow(deprecated)] // Deprecated alongside *.json support (issue #4087).
+use reinhardt_conf::settings::sources::{JsonFileSource, auto_source};
 use rstest::rstest;
 use serde_json::Value;
 use std::io::Write;
@@ -167,6 +168,7 @@ fn toml_source_priority_is_50() {
 // ===========================================================================
 
 #[rstest]
+#[allow(deprecated)] // JsonFileSource is deprecated (issue #4087); test must keep covering it.
 fn json_source_loads_string_and_bool_via_builder() {
 	// Arrange
 	let (_dir, path) = write_json_file(r#"{"debug": false, "name": "app"}"#);
@@ -185,6 +187,7 @@ fn json_source_loads_string_and_bool_via_builder() {
 }
 
 #[rstest]
+#[allow(deprecated)] // JsonFileSource is deprecated (issue #4087); test must keep covering it.
 fn json_source_loads_integer_value() {
 	// Arrange
 	let (_dir, path) = write_json_file(r#"{"port": 3000}"#);
@@ -201,6 +204,7 @@ fn json_source_loads_integer_value() {
 }
 
 #[rstest]
+#[allow(deprecated)] // JsonFileSource is deprecated (issue #4087); test must keep covering it.
 fn json_source_loads_array_value() {
 	// Arrange
 	let (_dir, path) = write_json_file(r#"{"tags": ["web", "api"]}"#);
@@ -221,6 +225,7 @@ fn json_source_loads_array_value() {
 }
 
 #[rstest]
+#[allow(deprecated)] // JsonFileSource is deprecated (issue #4087); test must keep covering it.
 fn json_source_loads_nested_object() {
 	// Arrange
 	let (_dir, path) = write_json_file(r#"{"database": {"engine": "mysql", "port": 3306}}"#);
@@ -243,6 +248,7 @@ fn json_source_loads_nested_object() {
 }
 
 #[rstest]
+#[allow(deprecated)] // JsonFileSource is deprecated (issue #4087); test must keep covering it.
 fn json_source_missing_file_returns_empty() {
 	// Arrange
 	let path = PathBuf::from("/tmp/nonexistent_reinhardt_config.json");
@@ -258,6 +264,7 @@ fn json_source_missing_file_returns_empty() {
 }
 
 #[rstest]
+#[allow(deprecated)] // JsonFileSource is deprecated (issue #4087); test must keep covering it.
 fn json_source_invalid_content_returns_error() {
 	// Arrange
 	let (_dir, path) = write_json_file("{not valid json}");
@@ -272,6 +279,7 @@ fn json_source_invalid_content_returns_error() {
 }
 
 #[rstest]
+#[allow(deprecated)] // JsonFileSource is deprecated (issue #4087); test must keep covering it.
 fn json_source_priority_is_50() {
 	// Assert
 	assert_eq!(JsonFileSource::new("any.json").priority(), 50);
@@ -282,6 +290,7 @@ fn json_source_priority_is_50() {
 // ===========================================================================
 
 #[rstest]
+#[allow(deprecated)] // auto_source is deprecated (issue #4087); test must keep covering it.
 fn auto_source_detects_toml_extension() {
 	// Arrange
 	let (_dir, path) = write_toml_file("key = \"val\"\n");
@@ -299,6 +308,7 @@ fn auto_source_detects_toml_extension() {
 }
 
 #[rstest]
+#[allow(deprecated)] // auto_source is deprecated (issue #4087); test must keep covering it.
 fn auto_source_detects_json_extension() {
 	// Arrange
 	let (_dir, path) = write_json_file(r#"{"key": "val"}"#);
@@ -316,6 +326,7 @@ fn auto_source_detects_json_extension() {
 }
 
 #[rstest]
+#[allow(deprecated)] // auto_source is deprecated (issue #4087); test must keep covering it.
 fn auto_source_rejects_unsupported_extension() {
 	// Arrange
 	let dir = TempDir::new().unwrap();
@@ -330,6 +341,7 @@ fn auto_source_rejects_unsupported_extension() {
 }
 
 #[rstest]
+#[allow(deprecated)] // auto_source is deprecated (issue #4087); test must keep covering it.
 fn auto_source_rejects_no_extension() {
 	// Arrange
 	let dir = TempDir::new().unwrap();

--- a/crates/reinhardt-conf/tests/source_priority.rs
+++ b/crates/reinhardt-conf/tests/source_priority.rs
@@ -1,5 +1,9 @@
 // Integration tests for EnvSource type inference, LowPriorityEnvSource, and cross-priority merging.
 // Covers: smart parsing, prefix handling, priority chain (Default → LowPriorityEnv → Toml/Json → Env).
+//
+// `JsonFileSource` is deprecated until removal in 0.2.0 (issue #4087); the
+// JSON priority cases must keep running during the deprecation window.
+#![allow(deprecated)]
 
 use reinhardt_conf::settings::builder::SettingsBuilder;
 use reinhardt_conf::settings::sources::{

--- a/crates/reinhardt-conf/tests/source_priority.rs
+++ b/crates/reinhardt-conf/tests/source_priority.rs
@@ -3,12 +3,15 @@
 //
 // `JsonFileSource` is deprecated until removal in 0.2.0 (issue #4087); the
 // JSON priority cases must keep running during the deprecation window.
-#![allow(deprecated)]
+// Deprecation warnings are silenced per import / per test function below so
+// that any new deprecation added elsewhere in this file still surfaces.
 
 use reinhardt_conf::settings::builder::SettingsBuilder;
+#[allow(deprecated)] // Deprecated alongside *.json support (issue #4087).
+use reinhardt_conf::settings::sources::JsonFileSource;
 use reinhardt_conf::settings::sources::{
-	ConfigSource, DefaultSource, EnvSource, HighPriorityEnvSource, JsonFileSource,
-	LowPriorityEnvSource, TomlFileSource,
+	ConfigSource, DefaultSource, EnvSource, HighPriorityEnvSource, LowPriorityEnvSource,
+	TomlFileSource,
 };
 use rstest::rstest;
 use serde_json::Value;
@@ -356,6 +359,7 @@ fn low_priority_env_overrides_default() {
 }
 
 #[rstest]
+#[allow(deprecated)] // JsonFileSource is deprecated (issue #4087); test must keep covering it.
 fn json_overrides_default() {
 	// Arrange
 	let (_dir, json_path) = write_json_file(r#"{"name": "from_json"}"#);
@@ -375,6 +379,7 @@ fn json_overrides_default() {
 
 #[rstest]
 #[serial(env)]
+#[allow(deprecated)] // JsonFileSource is deprecated (issue #4087); test must keep covering it.
 fn env_overrides_json() {
 	// Arrange
 	let (_dir, json_path) = write_json_file(r#"{"port": 2000}"#);


### PR DESCRIPTION
## Summary

- Add `#[deprecated]` to `JsonFileSource::new` and `auto_source` so existing users get a full RC cycle of warnings before the `*.json` file-source path is removed in 0.2.0 (Issue #4087).
- Wire `#[allow(deprecated)]` (with explanatory comments referencing #4087) into the `auto_source` body, both doctests, the internal `test_json_source` unit test, the prelude re-export, and the two integration test files (`tests/file_sources.rs`, `tests/source_priority.rs`) so coverage of the deprecated paths is preserved during the deprecation window.
- Add a `### Deprecated` section to `crates/reinhardt-conf/CHANGELOG.md` documenting the deprecation, the migration path (`.json` → `.toml`, or implement `ConfigSource` against `serde_json` out of tree), and the removal target (0.2.0).

## Type of Change

- [x] API change proposal (deprecation)
- [x] Documentation update (CHANGELOG)

## Motivation and Context

JSON file configuration has zero observed usage across `examples/`, `crates/`, and `tests/` outside of `reinhardt-conf` itself, while every new TOML feature (e.g. `${ENV_VAR}` interpolation in #4086) requires symmetric implementation and tests for the JSON path. Pruning the JSON source before 0.2.0 stabilizes is the lowest-impact moment to do this — once 0.2.0 ships, removing public API requires another breaking-change cycle.

This PR is the additive **0.1.x phase** of the proposal. The actual removal will land separately on `develop/0.2.0` per the project's stability policy (DB-2).

## How Was This Tested

- ` + "`" + `cargo check -p reinhardt-conf --all-features` + "`" + ` — clean
- ` + "`" + `cargo nextest run -p reinhardt-conf --all-features` + "`" + ` — 664 passed, 2 skipped
- ` + "`" + `cargo test -p reinhardt-conf --all-features --doc` + "`" + ` — 216 passed, 1 ignored
- ` + "`" + `cargo fmt -p reinhardt-conf --check` + "`" + ` — clean
- ` + "`" + `cargo clippy -p reinhardt-conf --all-features --all-targets` + "`" + ` — no new warnings introduced (pre-existing baseline matches origin/main)
- ` + "`" + `cargo clippy -p reinhardt-conf --lib --all-features -- -D clippy::todo -D clippy::unimplemented -D clippy::dbg_macro` + "`" + ` — clean

## Migration Path (for downstream users)

Two options for users currently relying on JSON config files:

1. **Convert `.json` to `.toml`** — TOML is a superset of typical JSON config use cases (key/value, nested tables, arrays). One-time migration.
2. **Keep JSON via custom `ConfigSource` impl** — implement the public `ConfigSource` trait against `serde_json` directly. The trait remains public, so the extension point is preserved.

For new TOML-only code, prefer ` + "`" + `TomlFileSource::new(path)` + "`" + ` directly over ` + "`" + `auto_source(path)` + "`" + ` to make the configuration format explicit at the call site.

## Checklist

- [x] Code follows project style guidelines (tabs, English comments, `#[allow(...)]` documented)
- [x] Tests pass locally
- [x] Documentation/CHANGELOG updated
- [x] No new TODO/FIXME introduced
- [x] PR follows Conventional Commits format

## Labels to Apply

- `enhancement`
- `api-stability`

## Related Issues

Refs #4087

(Note: this PR is **only the 0.1.x deprecation phase**; the 0.2.0 removal will happen in a separate PR targeting ` + "`" + `develop/0.2.0` + "`" + `, which will close the issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)