### PR TITLE
ci(workflows): bump sccache/setup-chrome/sticky-pr-comment to node24 builds

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Setup sccache
       if: inputs.cache == 'true'
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@v0.0.10
       with:
         version: "v0.10.0"
 

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -66,10 +66,9 @@ jobs:
             --project-name=reinhardt-web
             --branch=${{ github.head_ref || github.ref_name }}
 
-      # NOTE: Still on Node.js 20 - update when Node.js 24 version becomes available
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: website-preview
           message: |

--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -136,9 +136,10 @@ jobs:
 
       - name: Install Chrome
         if: ${{ matrix.needs-wasm }}
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@v2
         with:
           chrome-version: stable
+          install-chromedriver: true
 
       - name: Install wasm-pack
         if: ${{ matrix.needs-wasm }}

--- a/.github/workflows/wasm-check.yml
+++ b/.github/workflows/wasm-check.yml
@@ -124,9 +124,10 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@v2
         with:
           chrome-version: stable
+          install-chromedriver: true
 
       - name: Run WASM lib tests (reinhardt-pages)
         working-directory: crates/reinhardt-pages


### PR DESCRIPTION
## Summary

- Bump three GitHub Actions to versions that already run on Node.js 24, ahead of the **2026-06-02** runner-side cutover that will force every node20 action onto node24
- For `browser-actions/setup-chrome@v2`, also opt in to `install-chromedriver: true` because v2 switches the `stable` channel to install Chrome for Testing — the chromedriver pre-installed on GitHub-hosted runners is built against the official Chrome and may version-mismatch otherwise

## Type of Change

- [x] CI/CD update (no runtime behavior change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Motivation and Context

CI run [#25294142466](https://github.com/kent8192/reinhardt-web/actions/runs/25294142466) emits `Node.js 20 actions are deprecated` warnings for these three actions on every job. The GitHub Actions runner will force-migrate to node24 on 2026-06-02; bumping now silences the warnings and removes the time-bomb risk.

## Changes

| File | Change |
|---|---|
| `.github/actions/setup-rust/action.yml:30` | `mozilla-actions/sccache-action@v0.0.9` → `@v0.0.10` (only deps + node24 update) |
| `.github/workflows/wasm-check.yml:127` | `browser-actions/setup-chrome@v1` → `@v2`, add `install-chromedriver: true` |
| `.github/workflows/examples-test.yml:139` | `browser-actions/setup-chrome@v1` → `@v2`, add `install-chromedriver: true` |
| `.github/workflows/deploy-website.yml:72` | `marocchino/sticky-pull-request-comment@v2` → `@v3` (only deps + node24 update); drop `# NOTE: Still on Node.js 20` comment |

## How Was This Tested

- `python3 -c \"import yaml; yaml.safe_load(open(...))\"` on each edited file (passes)
- `actionlint` on the three workflow files (no new warnings; pre-existing SC2086 in `wasm-check.yml:78` is untouched)
- Inputs used by `sticky-pull-request-comment` (`header` + `message`) and `setup-chrome` (`chrome-version: stable`) are still valid in v3 / v2 per the upstream migration guides
- CI run on this branch will confirm zero deprecation annotations for these three actions

## Checklist

- [x] My code follows the project's coding standards
- [x] I have linked this PR to the related issue (#4123)
- [x] I have used a descriptive PR title following Conventional Commits
- [x] I have validated YAML syntax for all changed files

## Labels to Apply

- `enhancement`
- `ci-cd`

## Related Issues

Fixes #4123

## Additional Context

This is **Phase 1** of the broader CI warning remediation tracked in #4123. Phases 2 (still-node20 actions: `arduino/setup-protoc`, `cloudflare/wrangler-action`, `hashicorp/setup-packer`) and Phase 3 (cargo-make aarch64 fallback) will follow in separate issues/PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)