### PR TITLE
ci(workflows): opt in to FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 for still-node20 actions

### DIFF
--- a/.github/workflows/build-runner-ami.yml
+++ b/.github/workflows/build-runner-ami.yml
@@ -29,6 +29,15 @@ concurrency:
   group: build-runner-ami-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-ami:
     runs-on: ubuntu-latest
@@ -46,7 +55,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
-      # NOTE: Still on Node.js 20 - update when Node.js 24 version becomes available
       - name: Install Packer
         uses: hashicorp/setup-packer@v3
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,13 @@ env:
   CARGO_TARGET_DIR: /tmp/cargo_target
   CARGO_INCREMENTAL: 0
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # Split cargo check by target type for parallel execution across runners.

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -19,6 +19,13 @@ env:
   CARGO_TARGET_DIR: /tmp/cargo_target
   CARGO_INCREMENTAL: 0
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   clippy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,13 @@ env:
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
   RUST_MIN_STACK: 8388608
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   unit-coverage:

--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -30,6 +30,13 @@ env:
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
   RUST_MIN_STACK: 8388608  # 8MB - prevent stack overflow in deep async fixture chains
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   cross-crate-integration-test:

--- a/.github/workflows/cross-platform-check.yml
+++ b/.github/workflows/cross-platform-check.yml
@@ -8,6 +8,13 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   cross-platform-check:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -22,6 +22,15 @@ concurrency:
   group: deploy-website-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
+env:
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-and-deploy:
     name: Build & Deploy

--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -27,6 +27,13 @@ env:
   CARGO_TARGET_DIR: /tmp/cargo_target
   CARGO_INCREMENTAL: 0
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   doc-test:

--- a/.github/workflows/docs-rs-check.yml
+++ b/.github/workflows/docs-rs-check.yml
@@ -20,6 +20,13 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
   RUSTDOCFLAGS: "--cfg docsrs -D warnings"
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   docs-rs-check:

--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -20,6 +20,13 @@ env:
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   test-example:

--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -42,6 +42,13 @@ env:
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
   RUST_MIN_STACK: 8388608  # 8MB - prevent stack overflow in deep async fixture chains
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   intra-crate-integration-test:

--- a/.github/workflows/msrv-test.yml
+++ b/.github/workflows/msrv-test.yml
@@ -19,6 +19,13 @@ env:
   CARGO_TARGET_DIR: /tmp/cargo_target
   CARGO_INCREMENTAL: 0
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   msrv-check:

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -29,6 +29,13 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TARGET_DIR: /tmp/cargo_target
   TOTAL_SHARDS: 5
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   mutation-test:

--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -16,6 +16,13 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   publish-check:

--- a/.github/workflows/reinhardt-feature-check.yml
+++ b/.github/workflows/reinhardt-feature-check.yml
@@ -30,6 +30,13 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TARGET_DIR: /tmp/cargo_target
   CARGO_INCREMENTAL: 0
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # Cache seeding: runs ONE --all-features check on main push to populate

--- a/.github/workflows/release-plz-dry-run.yml
+++ b/.github/workflows/release-plz-dry-run.yml
@@ -12,6 +12,15 @@ on:
         type: string
         default: "1"
 
+env:
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release-dry-run:
     name: Release Dry-Run Check

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,6 +24,15 @@ on:
     types: [closed]
     paths: ['announcements/**']
 
+env:
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # Native two-step release workflow:
   # 1. Push to main → release-plz creates Release PR (branch: release-plz-*)

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -20,6 +20,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   semver-checks:

--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -19,6 +19,13 @@ env:
   CARGO_TARGET_DIR: /tmp/cargo_target
   CARGO_INCREMENTAL: 0
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   todo-check:

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -37,6 +37,13 @@ env:
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   ui-test:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -42,6 +42,13 @@ env:
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
   RUST_MIN_STACK: 8388608  # 8MB - prevent stack overflow in deep async fixture chains
+  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
+  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
+  # once all three upstreams ship node24 releases.
+  #
+  # Ideal implementation (without workaround):
+  #   (no env override; let runner default kick in)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   unit-test:


### PR DESCRIPTION
## Summary

- Opt in to GitHub's official `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env at the **workflow level** in 21 workflow files that use actions still on Node.js 20 upstream
- Bridges the gap until upstream ships node24 releases for `arduino/setup-protoc`, `cloudflare/wrangler-action`, and `hashicorp/setup-packer`
- Drops the obsolete `# NOTE: Still on Node.js 20` comment in `build-runner-ami.yml`

## Type of Change

- [x] CI/CD update (no runtime behavior change)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Motivation and Context

GitHub Actions runner deprecates Node.js 20 and will force-migrate to Node.js 24 on **2026-06-02**, with full Node 20 removal on 2026-09-16. Three actions in this repository have not yet shipped node24 releases:

| Action | Upstream tracking |
|---|---|
| `arduino/setup-protoc@v3` (24× across 22 workflows) | [arduino/setup-protoc#112](https://github.com/arduino/setup-protoc/issues/112) |
| `cloudflare/wrangler-action@v3` (`deploy-website.yml:60`) | [cloudflare/wrangler-action#413](https://github.com/cloudflare/wrangler-action/issues/413) |
| `hashicorp/setup-packer@v3` (`build-runner-ami.yml`) | [hashicorp/setup-packer#162](https://github.com/hashicorp/setup-packer/issues/162) |

The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env is GitHub's [documented opt-in](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for exactly this transition window — it forces the runner to execute the JS entrypoint with bundled node24, working as long as the action's JS is node24-compatible (almost always true).

## Changes

21 workflow files modified (155 insertions, 1 deletion):

| Pattern | Files |
|---|---|
| Append to existing workflow-level `env:` block | check.yml, clippy.yml, coverage.yml, cross-crate-integration-test.yml, cross-platform-check.yml, doc-test.yml, docs-rs-check.yml, examples-test.yml, intra-crate-integration-test.yml, msrv-test.yml, mutation-test.yml, publish-check.yml, reinhardt-feature-check.yml, semver-check.yml, todo-check.yml, ui-test.yml, unit-test.yml |
| Add new workflow-level `env:` block | release-plz.yml, release-plz-dry-run.yml, deploy-website.yml, build-runner-ami.yml |
| Also drop obsolete comment | build-runner-ami.yml (`# NOTE: Still on Node.js 20`) |

Each addition includes a workaround comment with the upstream issue references and the ideal implementation (per CLAUDE.md WP-3 / UR-4):

```yaml
env:
  # Workaround for arduino/setup-protoc#112, cloudflare/wrangler-action#413,
  # hashicorp/setup-packer#162 (tracked in reinhardt-web#4125). Remove this
  # once all three upstreams ship node24 releases.
  #
  # Ideal implementation (without workaround):
  #   (no env override; let runner default kick in)
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
```

## How Was This Tested

- `python3 -c \"import yaml; yaml.safe_load(open(...))\"` on each of the 21 changed files (passes)
- `actionlint` on changed files: warning count unchanged (20 before, 20 after) — no new shellcheck/expression issues introduced
- `grep -rn 'uses:'` sweep across `.github/` confirms no other action requires node20-specific behavior; the env applies safely to all JS actions in scope
- After CI run on this PR, the only `Node.js 20 actions are deprecated` warnings expected to remain are zero (all three still-node20 actions are now run with node24 via the env opt-in)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have linked this PR to the related issue (#4125)
- [x] I have used a descriptive PR title following Conventional Commits
- [x] I have validated YAML syntax for all changed files
- [x] Workaround comments include upstream issue references and ideal implementation per CLAUDE.md UR-4 / WP-3

## Labels to Apply

- `enhancement`
- `ci-cd`
- `upstream-tracking`
- `high`

## Risks

- The env is workflow-level: it forces ALL JS actions in scope to run with node24, not just the still-node20 ones. Other actions used (`actions/*`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `taiki-e/install-action`, `mozilla-actions/sccache-action`, `browser-actions/setup-chrome`, `marocchino/sticky-pull-request-comment`, etc.) are either already node24 or composite actions that don't run JS at the runner level.
- If any single action breaks under node24, narrow the env to step-level (`step.env`) for the targeted action.

## Removal Condition

Tracked in #4125: remove the env from all 21 workflows once all three upstreams (#112, #413, #162) have shipped node24 releases AND we have bumped the action version pins to those releases.

## Related Issues

Fixes #4125

## Additional Context

This is **Phase 2** of the broader CI warning remediation tracked across #4123 (Phase 1) and a yet-to-be-filed Phase 3 issue (cargo-make aarch64_linux fallback). Phase 1 (PR #4124) bumped sccache-action / setup-chrome / sticky-pull-request-comment to their node24-compatible versions; Phase 3 will address the cargo-make fallback warning by prebaking it into the self-hosted aarch64 AMI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)