### PR TITLE
fix(pages): #4122 stale-wasm false positive — add diagnostic counter API + Tier 2/3 regression suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -390,6 +390,7 @@ members = [
 exclude = [
 	"examples",
 	"crates/reinhardt-pages/tests/fixtures/spa_navigation_app",
+	"crates/reinhardt-pages/tests/fixtures/spa_navigation_with_sidebar_signal_app",
 ]
 
 default-members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,6 +391,7 @@ exclude = [
 	"examples",
 	"crates/reinhardt-pages/tests/fixtures/spa_navigation_app",
 	"crates/reinhardt-pages/tests/fixtures/spa_navigation_with_sidebar_signal_app",
+	"crates/reinhardt-pages/tests/fixtures/spa_navigation_with_full_layout_app",
 ]
 
 default-members = [

--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- *(router, pages)* Hidden diagnostic counter API
+  (`Router::__diag_observer_count`, `Router::__diag_dispatch_count`,
+  `ClientLauncher::__diag_render_count` on `cfg(wasm)`). All three are
+  `#[doc(hidden)]` and intended only as an internal regression-test surface.
+  Backed by a Tier 2 (sidebar-signal) and Tier 3 (full layout shell)
+  fixture suite plus a real-Chrome `e2e_cdp` test that assert observer-system
+  invariants Inv-1 ~ Inv-4 on every navigation. Replaces the DOM-only
+  assertions whose silence allowed earlier false-positive fixes (#4075 → #4078
+  regressed, #4088 → #4102 regressed in form). Issue #4122 itself was
+  reclassified during diagnosis as a stale-wasm-bundle false positive; the
+  underlying dev-loop hazard is tracked separately as #4127 (`runserver`
+  --with-pages does not auto-rebuild WASM) and #4128 (hot-reload WASM
+  rebuild verification).
+  ([#4122](https://github.com/kent8192/reinhardt-web/issues/4122),
+  [#4127](https://github.com/kent8192/reinhardt-web/issues/4127),
+  [#4128](https://github.com/kent8192/reinhardt-web/issues/4128))
 - *(router)* `Router::on_navigate(callback) -> NavigationSubscription`
   explicit subscription API, inspired by React Router's
   `router.subscribe(listener)`. The listener is invoked synchronously after

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -275,3 +275,13 @@ required-features = ["e2e-cdp-test"]
 name = "spa_navigation_diag_test"
 path = "tests/wasm/spa_navigation_diag_test.rs"
 required-features = ["wasm-diag-test"]
+
+[[test]]
+name = "spa_navigation_diag_tier3_test"
+path = "tests/wasm/spa_navigation_diag_tier3_test.rs"
+required-features = ["wasm-diag-test"]
+
+[[test]]
+name = "spa_navigation_full_layout_e2e_test"
+path = "tests/integration/spa_navigation_full_layout_e2e_test.rs"
+required-features = ["e2e-cdp-test"]

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -172,7 +172,6 @@ wasm-bindgen-futures = "0.4.56"
 reqwest = { workspace = true }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 uuid = { version = "1.7", features = ["v7", "js"] }
-tracing = { workspace = true }
 
 # Server-side only dependencies (DI, HTTP, Forms, Server Function Registry)
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -172,6 +172,7 @@ wasm-bindgen-futures = "0.4.56"
 reqwest = { workspace = true }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 uuid = { version = "1.7", features = ["v7", "js"] }
+tracing = { workspace = true }
 
 # Server-side only dependencies (DI, HTTP, Forms, Server Function Registry)
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -33,6 +33,12 @@ ast = []
 # breakage. Cargo dev-dependencies cannot be optional, so feature gating
 # is achieved via `#![cfg(feature = "e2e-cdp-test")]` and `required-features`.
 e2e-cdp-test = []
+# Marker feature for wasm-bindgen-test diagnostic suite that asserts
+# observer-system invariants Inv-1 ~ Inv-4 against the Tier 2 / Tier 3
+# fixtures. Activated by:
+#   wasm-pack test --chrome --headless --features wasm-diag-test
+# Refs #4122.
+wasm-diag-test = []
 hmr = ["dep:notify", "dep:tokio-tungstenite", "dep:futures-util"]
 # web-sys features for WASM applications
 # Applications should use this feature to get all required web-sys features
@@ -264,3 +270,8 @@ required-features = []
 name = "spa_navigation_e2e_test"
 path = "tests/integration/spa_navigation_e2e_test.rs"
 required-features = ["e2e-cdp-test"]
+
+[[test]]
+name = "spa_navigation_diag_test"
+path = "tests/wasm/spa_navigation_diag_test.rs"
+required-features = ["wasm-diag-test"]

--- a/crates/reinhardt-pages/src/app.rs
+++ b/crates/reinhardt-pages/src/app.rs
@@ -429,8 +429,11 @@ impl ClientLauncher {
 	/// re-mount. Used by tests in
 	/// `tests/wasm/spa_navigation_diag_test.rs` to assert Inv-4.
 	///
-	/// Returns 0 on non-WASM targets (the function exists only under
-	/// `cfg(wasm)`). Hidden API for testing only. Refs #4122.
+	/// Only available under `cfg(wasm)`: the entire `impl ClientLauncher`
+	/// block in this scope is gated, and `RENDER_COUNT` is a `cfg(wasm)`-
+	/// only thread_local. Calling from a non-wasm32 build results in a
+	/// compile error rather than a no-op zero. Hidden API for testing
+	/// only. Refs #4122.
 	#[doc(hidden)]
 	pub fn __diag_render_count() -> u64 {
 		RENDER_COUNT.with(|c| c.get())

--- a/crates/reinhardt-pages/src/app.rs
+++ b/crates/reinhardt-pages/src/app.rs
@@ -11,6 +11,14 @@ thread_local! {
 	static APP_ROUTER: RefCell<Option<Router>> = const { RefCell::new(None) };
 }
 
+#[cfg(wasm)]
+thread_local! {
+	/// Cumulative count of `ClientLauncher::render_and_mount` invocations
+	/// since the WASM module loaded. Backs `ClientLauncher::__diag_render_count()`.
+	/// Hidden diagnostic counter for testing — Refs #4122.
+	static RENDER_COUNT: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
 /// Access the globally registered client router.
 ///
 /// # Panics
@@ -407,11 +415,25 @@ impl ClientLauncher {
 	///
 	/// Refs #4101.
 	fn render_and_mount(root_el: &web_sys::Element) -> Result<(), crate::component::MountError> {
+		RENDER_COUNT.with(|c| c.set(c.get() + 1));
 		let view = with_router(|r| r.render_current());
 		crate::component::cleanup_reactive_nodes();
 		root_el.set_inner_html("");
 		let wrapper = crate::dom::Element::new(root_el.clone());
 		view.mount(&wrapper)
+	}
+
+	/// Diagnostic counter: cumulative count of `render_and_mount`
+	/// invocations since the WASM module loaded. Includes the initial
+	/// Phase B mount and every subsequent `Router::on_navigate`-driven
+	/// re-mount. Used by tests in
+	/// `tests/wasm/spa_navigation_diag_test.rs` to assert Inv-4.
+	///
+	/// Returns 0 on non-WASM targets (the function exists only under
+	/// `cfg(wasm)`). Hidden API for testing only. Refs #4122.
+	#[doc(hidden)]
+	pub fn __diag_render_count() -> u64 {
+		RENDER_COUNT.with(|c| c.get())
 	}
 
 	/// Start the WASM client application.

--- a/crates/reinhardt-pages/src/app.rs
+++ b/crates/reinhardt-pages/src/app.rs
@@ -416,11 +416,6 @@ impl ClientLauncher {
 	/// Refs #4101.
 	fn render_and_mount(root_el: &web_sys::Element) -> Result<(), crate::component::MountError> {
 		RENDER_COUNT.with(|c| c.set(c.get() + 1));
-		tracing::debug!(
-			target: "reinhardt_pages::app::diag",
-			render_count = RENDER_COUNT.with(|c| c.get()),
-			"ClientLauncher::render_and_mount entered"
-		);
 		let view = with_router(|r| r.render_current());
 		crate::component::cleanup_reactive_nodes();
 		root_el.set_inner_html("");

--- a/crates/reinhardt-pages/src/app.rs
+++ b/crates/reinhardt-pages/src/app.rs
@@ -416,6 +416,11 @@ impl ClientLauncher {
 	/// Refs #4101.
 	fn render_and_mount(root_el: &web_sys::Element) -> Result<(), crate::component::MountError> {
 		RENDER_COUNT.with(|c| c.set(c.get() + 1));
+		tracing::debug!(
+			target: "reinhardt_pages::app::diag",
+			render_count = RENDER_COUNT.with(|c| c.get()),
+			"ClientLauncher::render_and_mount entered"
+		);
 		let view = with_router(|r| r.render_current());
 		crate::component::cleanup_reactive_nodes();
 		root_el.set_inner_html("");

--- a/crates/reinhardt-pages/src/router/core.rs
+++ b/crates/reinhardt-pages/src/router/core.rs
@@ -496,12 +496,6 @@ impl Router {
 		self.navigation_observers
 			.borrow_mut()
 			.push(std::rc::Rc::downgrade(&listener));
-		tracing::debug!(
-			target: "reinhardt_pages::router::diag",
-			observer_count = self.__diag_observer_count(),
-			router_ptr = format!("{:p}", self),
-			"router::on_navigate registered new listener"
-		);
 		NavigationSubscription { listener }
 	}
 
@@ -528,23 +522,11 @@ impl Router {
 	/// Refs #4088, #4108.
 	fn notify_observers(&self, path: &str, params: &HashMap<String, String>) {
 		self.dispatch_count.set(self.dispatch_count.get() + 1);
-		tracing::debug!(
-			target: "reinhardt_pages::router::diag",
-			path = %path,
-			dispatch_count = self.dispatch_count.get(),
-			observer_count = self.__diag_observer_count(),
-			"router::notify_observers entered"
-		);
 		let listeners_snapshot: Vec<std::rc::Rc<NavigationListener>> = {
 			let mut observers = self.navigation_observers.borrow_mut();
 			observers.retain(|w| w.strong_count() > 0);
 			observers.iter().filter_map(|w| w.upgrade()).collect()
 		};
-		tracing::debug!(
-			target: "reinhardt_pages::router::diag",
-			snapshot_len = listeners_snapshot.len(),
-			"router::notify_observers snapshot taken"
-		);
 		for listener in listeners_snapshot {
 			listener(path, params);
 		}
@@ -597,14 +579,6 @@ impl Router {
 			.as_ref()
 			.map(|m| m.params.clone())
 			.unwrap_or_default();
-		tracing::debug!(
-			target: "reinhardt_pages::router::diag",
-			path = %path,
-			dispatch_count_before = self.dispatch_count.get(),
-			observer_count = self.__diag_observer_count(),
-			router_ptr = format!("{:p}", self),
-			"router::navigate about to notify_observers"
-		);
 		self.notify_observers(path, &params_for_observers);
 
 		Ok(())
@@ -744,11 +718,6 @@ impl Router {
 			// Bump the diagnostic counter to mirror `Router::notify_observers`,
 			// so tests can assert that popstate-driven dispatches are
 			// counted identically to push/replace-driven ones (Refs #4122).
-			tracing::debug!(
-				target: "reinhardt_pages::router::diag",
-				path = %path,
-				"router::popstate listener invoked, about to bump dispatch_count"
-			);
 			dispatch_count.set(dispatch_count.get() + 1);
 
 			// Dispatch on_navigate observers using the same snapshot-then-

--- a/crates/reinhardt-pages/src/router/core.rs
+++ b/crates/reinhardt-pages/src/router/core.rs
@@ -217,6 +217,10 @@ pub struct Router {
 	/// navigation, independent of any reactive Effect / Signal tracking.
 	/// Refs #4088, #4075, #3348.
 	navigation_observers: NavigationObservers,
+	/// Cumulative count of `notify_observers` invocations since this Router
+	/// was constructed. Hidden diagnostic counter used by tests to assert
+	/// invariants that DOM-only assertions cannot reach (Refs #4122).
+	dispatch_count: std::rc::Rc<std::cell::Cell<u64>>,
 }
 
 /// Type alias for the navigation observer storage.
@@ -270,6 +274,7 @@ impl Router {
 			current_route_name: Signal::new(None),
 			not_found: None,
 			navigation_observers: std::rc::Rc::new(std::cell::RefCell::new(Vec::new())),
+			dispatch_count: std::rc::Rc::new(std::cell::Cell::new(0)),
 		}
 	}
 
@@ -516,6 +521,7 @@ impl Router {
 	///
 	/// Refs #4088, #4108.
 	fn notify_observers(&self, path: &str, params: &HashMap<String, String>) {
+		self.dispatch_count.set(self.dispatch_count.get() + 1);
 		let listeners_snapshot: Vec<std::rc::Rc<NavigationListener>> = {
 			let mut observers = self.navigation_observers.borrow_mut();
 			observers.retain(|w| w.strong_count() > 0);
@@ -626,6 +632,35 @@ impl Router {
 		self.named_routes.contains_key(name)
 	}
 
+	/// Diagnostic counter: number of currently-alive navigation observers.
+	///
+	/// Returns the count of `Weak<NavigationListener>` entries in
+	/// `navigation_observers` whose `strong_count() > 0`. Used by tests in
+	/// `tests/wasm/spa_navigation_diag_test.rs` to assert Inv-1 / Inv-2.
+	///
+	/// Hidden API for testing only — `#[doc(hidden)]` keeps it out of the
+	/// rendered documentation and out of the SemVer surface. Refs #4122.
+	#[doc(hidden)]
+	pub fn __diag_observer_count(&self) -> usize {
+		self.navigation_observers
+			.borrow()
+			.iter()
+			.filter(|w| w.strong_count() > 0)
+			.count()
+	}
+
+	/// Diagnostic counter: cumulative `notify_observers` invocation count.
+	///
+	/// Includes invocations from `Router::push`, `Router::replace`, and the
+	/// popstate listener. Used by tests in
+	/// `tests/wasm/spa_navigation_diag_test.rs` to assert Inv-3.
+	///
+	/// Hidden API for testing only. Refs #4122.
+	#[doc(hidden)]
+	pub fn __diag_dispatch_count(&self) -> u64 {
+		self.dispatch_count.get()
+	}
+
 	/// Sets up a popstate event listener for browser back/forward navigation.
 	///
 	/// This method registers a listener for the browser's `popstate` event,
@@ -660,6 +695,7 @@ impl Router {
 		let params_signal = self.current_params.clone();
 		let route_name_signal = self.current_route_name.clone();
 		let navigation_observers = self.navigation_observers.clone();
+		let dispatch_count = self.dispatch_count.clone();
 
 		let closure = setup_popstate_listener(move |path, state| {
 			// Update Signals first, then notify observers, so listeners that
@@ -678,6 +714,11 @@ impl Router {
 				route_name_signal.set(None);
 				HashMap::new()
 			};
+
+			// Bump the diagnostic counter to mirror `Router::notify_observers`,
+			// so tests can assert that popstate-driven dispatches are
+			// counted identically to push/replace-driven ones (Refs #4122).
+			dispatch_count.set(dispatch_count.get() + 1);
 
 			// Dispatch on_navigate observers using the same snapshot-then-
 			// iterate pattern as Router::notify_observers. Inlined here
@@ -925,5 +966,52 @@ mod tests {
 
 		// Assert: listener fired exactly once (before drop), not twice
 		assert_eq!(*calls.borrow(), 1);
+	}
+
+	#[rstest]
+	fn diag_dispatch_count_starts_at_zero_and_increments_on_navigate() {
+		// Arrange
+		let router = Router::new()
+			.route("/a", || Page::text("A"))
+			.route("/b", || Page::text("B"));
+		assert_eq!(router.__diag_dispatch_count(), 0);
+
+		// Act
+		router.push("/a").expect("push /a");
+
+		// Assert
+		assert_eq!(router.__diag_dispatch_count(), 1);
+
+		// Act 2: a second navigation
+		router.push("/b").expect("push /b");
+
+		// Assert 2
+		assert_eq!(router.__diag_dispatch_count(), 2);
+	}
+
+	#[rstest]
+	fn diag_observer_count_reflects_alive_subscriptions() {
+		// Arrange
+		let router = Router::new();
+		assert_eq!(router.__diag_observer_count(), 0);
+
+		// Act
+		let sub1 = router.on_navigate(|_path, _params| {});
+		let sub2 = router.on_navigate(|_path, _params| {});
+
+		// Assert
+		assert_eq!(router.__diag_observer_count(), 2);
+
+		// Act 2: drop one
+		drop(sub1);
+
+		// Assert 2
+		assert_eq!(router.__diag_observer_count(), 1);
+
+		// Act 3: drop the other
+		drop(sub2);
+
+		// Assert 3
+		assert_eq!(router.__diag_observer_count(), 0);
 	}
 }

--- a/crates/reinhardt-pages/src/router/core.rs
+++ b/crates/reinhardt-pages/src/router/core.rs
@@ -496,6 +496,12 @@ impl Router {
 		self.navigation_observers
 			.borrow_mut()
 			.push(std::rc::Rc::downgrade(&listener));
+		tracing::debug!(
+			target: "reinhardt_pages::router::diag",
+			observer_count = self.__diag_observer_count(),
+			router_ptr = format!("{:p}", self),
+			"router::on_navigate registered new listener"
+		);
 		NavigationSubscription { listener }
 	}
 
@@ -522,11 +528,23 @@ impl Router {
 	/// Refs #4088, #4108.
 	fn notify_observers(&self, path: &str, params: &HashMap<String, String>) {
 		self.dispatch_count.set(self.dispatch_count.get() + 1);
+		tracing::debug!(
+			target: "reinhardt_pages::router::diag",
+			path = %path,
+			dispatch_count = self.dispatch_count.get(),
+			observer_count = self.__diag_observer_count(),
+			"router::notify_observers entered"
+		);
 		let listeners_snapshot: Vec<std::rc::Rc<NavigationListener>> = {
 			let mut observers = self.navigation_observers.borrow_mut();
 			observers.retain(|w| w.strong_count() > 0);
 			observers.iter().filter_map(|w| w.upgrade()).collect()
 		};
+		tracing::debug!(
+			target: "reinhardt_pages::router::diag",
+			snapshot_len = listeners_snapshot.len(),
+			"router::notify_observers snapshot taken"
+		);
 		for listener in listeners_snapshot {
 			listener(path, params);
 		}
@@ -579,6 +597,14 @@ impl Router {
 			.as_ref()
 			.map(|m| m.params.clone())
 			.unwrap_or_default();
+		tracing::debug!(
+			target: "reinhardt_pages::router::diag",
+			path = %path,
+			dispatch_count_before = self.dispatch_count.get(),
+			observer_count = self.__diag_observer_count(),
+			router_ptr = format!("{:p}", self),
+			"router::navigate about to notify_observers"
+		);
 		self.notify_observers(path, &params_for_observers);
 
 		Ok(())
@@ -718,6 +744,11 @@ impl Router {
 			// Bump the diagnostic counter to mirror `Router::notify_observers`,
 			// so tests can assert that popstate-driven dispatches are
 			// counted identically to push/replace-driven ones (Refs #4122).
+			tracing::debug!(
+				target: "reinhardt_pages::router::diag",
+				path = %path,
+				"router::popstate listener invoked, about to bump dispatch_count"
+			);
 			dispatch_count.set(dispatch_count.get() + 1);
 
 			// Dispatch on_navigate observers using the same snapshot-then-

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_full_layout_app/.gitignore
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_full_layout_app/.gitignore
@@ -1,0 +1,2 @@
+/pkg
+/target

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_full_layout_app/Cargo.toml
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_full_layout_app/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "spa-navigation-with-full-layout-app"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+# Detached from the parent Cargo workspace so wasm-pack can build this
+# crate independently. The parent workspace's `exclude` array also lists
+# this path. Refs #4122.
+[workspace]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+reinhardt-pages = { path = "../../../" }
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["Window", "Document", "Element", "HtmlElement"] }
+console_error_panic_hook = "0.1"

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_full_layout_app/index.html
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_full_layout_app/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tier 3 — Full Layout Fixture</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module">
+      import init, * as api from "./pkg/spa_navigation_with_full_layout_app.js";
+      await init();
+      window.__diag_observer_count_js = api.__diag_observer_count_js;
+      window.__diag_dispatch_count_js = api.__diag_dispatch_count_js;
+      window.__diag_render_count_js = api.__diag_render_count_js;
+    </script>
+  </body>
+</html>

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_full_layout_app/src/lib.rs
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_full_layout_app/src/lib.rs
@@ -1,0 +1,105 @@
+//! Tier 3 fixture — SPA navigation regression suite (#4122).
+//!
+//! Mirrors the cloud-dashboard structural traits we believed could
+//! trigger a navigation listener loss: a persistent layout shell with
+//! `<aside>` sidebar, content swapped per-route inside `<main>`, three
+//! routes, nested `<a>` tags inside the shell so the link interceptor
+//! must walk up parent elements.
+//!
+//! Routes:
+//! - `/`         → "Home" content under the persistent shell
+//! - `/clusters` → "Clusters" content
+//! - `/login`    → "Login" content
+//!
+//! Exposes `__diag_observer_count_js`, `__diag_dispatch_count_js`, and
+//! `__diag_render_count_js` via `#[wasm_bindgen]` so the e2e_cdp test
+//! (driven by Chrome via CDP) can read the counters through
+//! `execute_js`.
+//!
+//! Tests pass on current main HEAD — they exist as a future-regression
+//! net for the listener-loss class (#4075, #4088, #4122) so it cannot
+//! silently re-emerge through a real source change or a stale-wasm-
+//! bundle deployment hazard (the actual root cause of #4122; see
+//! tracking issues #4127 and #4128).
+
+use reinhardt_pages::app::{ClientLauncher, with_router};
+use reinhardt_pages::component::{IntoPage, Page, PageElement};
+use reinhardt_pages::router::Router;
+use wasm_bindgen::prelude::*;
+
+fn nav_link(href: &'static str, label: &'static str, current: &str) -> PageElement {
+	let class = if current == href { "active" } else { "" };
+	PageElement::new("a")
+		.attr("href", href)
+		.attr("class", class)
+		.child(label)
+}
+
+fn layout_shell(content_id: &'static str, content_label: &'static str) -> Page {
+	// Read `current_path` AT RENDER TIME so the sidebar's `active` class
+	// reflects the freshly-navigated path. `render_and_mount` runs only
+	// after `Router::push` has updated the path Signal and notified
+	// observers.
+	let current = with_router(|r| r.current_path().get());
+	PageElement::new("div")
+		.attr("id", "shell")
+		.child(
+			PageElement::new("aside").attr("id", "sidebar").child(
+				PageElement::new("ul")
+					.child(PageElement::new("li").child(nav_link("/", "Home", &current)))
+					.child(
+						PageElement::new("li")
+							.child(nav_link("/clusters", "Clusters", &current)),
+					)
+					.child(PageElement::new("li").child(nav_link("/login", "Login", &current))),
+			),
+		)
+		.child(
+			PageElement::new("main").attr("id", "content").child(
+				PageElement::new("section")
+					.attr("id", content_id)
+					.child(PageElement::new("h1").child(content_label)),
+			),
+		)
+		.into_page()
+}
+
+pub fn home_page() -> Page {
+	layout_shell("route-home", "HOME VIEW")
+}
+
+pub fn clusters_page() -> Page {
+	layout_shell("route-clusters", "CLUSTERS VIEW")
+}
+
+pub fn login_page() -> Page {
+	layout_shell("route-login", "LOGIN VIEW")
+}
+
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), JsValue> {
+	console_error_panic_hook::set_once();
+	ClientLauncher::new("#app")
+		.router(|| {
+			Router::new()
+				.route("/", home_page)
+				.route("/clusters", clusters_page)
+				.route("/login", login_page)
+		})
+		.launch()
+}
+
+#[wasm_bindgen]
+pub fn __diag_observer_count_js() -> usize {
+	with_router(|r| r.__diag_observer_count())
+}
+
+#[wasm_bindgen]
+pub fn __diag_dispatch_count_js() -> u64 {
+	with_router(|r| r.__diag_dispatch_count())
+}
+
+#[wasm_bindgen]
+pub fn __diag_render_count_js() -> u64 {
+	ClientLauncher::__diag_render_count()
+}

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_sidebar_signal_app/.gitignore
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_sidebar_signal_app/.gitignore
@@ -1,0 +1,2 @@
+/pkg
+/target

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_sidebar_signal_app/Cargo.toml
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_sidebar_signal_app/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "spa-navigation-with-sidebar-signal-app"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+# Detached from the parent Cargo workspace so wasm-pack can build this
+# crate independently. The parent workspace's `exclude` array also lists
+# this path. Refs #4122.
+[workspace]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+reinhardt-pages = { path = "../../../" }
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["Window", "Document", "Element", "HtmlElement"] }
+console_error_panic_hook = "0.1"

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_sidebar_signal_app/index.html
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_sidebar_signal_app/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tier 2 — Sidebar Signal Fixture</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module">
+      import init from "./pkg/spa_navigation_with_sidebar_signal_app.js";
+      init();
+    </script>
+  </body>
+</html>

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_sidebar_signal_app/src/lib.rs
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_with_sidebar_signal_app/src/lib.rs
@@ -1,0 +1,77 @@
+//! Tier 2 fixture — SPA navigation regression suite (#4122).
+//!
+//! Each route renders its own copy of a tiny nav with three `<a>` tags
+//! whose `class` attribute is computed at render time from the current
+//! `Router::current_path` Signal. There is no persistent layout shell —
+//! the entire view is rebuilt on each navigation. This isolates the
+//! "navigation pipeline reads current_path Signal correctly across
+//! re-renders" axis from the "persistent layout shell" axis when
+//! bisecting #4075 / #4088 / #4122.
+//!
+//! Routes:
+//! - `/`         -> `<div id="route-home">`
+//! - `/clusters` -> `<div id="route-clusters">`
+//! - `/login`    -> `<div id="route-login">`
+//!
+//! The wasm-bindgen-test harness in
+//! `tests/wasm/spa_navigation_diag_test.rs` boots this fixture through
+//! `ClientLauncher::launch`, then drives navigation via synthesized
+//! `<a>` clicks and asserts Inv-1 ~ Inv-4 against
+//! `Router::__diag_*` and `ClientLauncher::__diag_render_count`.
+
+use reinhardt_pages::app::{ClientLauncher, with_router};
+use reinhardt_pages::component::{IntoPage, Page, PageElement};
+use reinhardt_pages::router::Router;
+use wasm_bindgen::prelude::*;
+
+fn nav_link(href: &'static str, label: &'static str, current: &str) -> PageElement {
+	let class = if current == href { "active" } else { "" };
+	PageElement::new("a")
+		.attr("href", href)
+		.attr("class", class)
+		.child(label)
+}
+
+fn page_with_nav(id: &'static str, label: &'static str) -> Page {
+	// Read `current_path` AT RENDER TIME. `render_and_mount` runs only
+	// after `Router::push` has updated the path Signal and notified
+	// observers, so the value seen here is the freshly-navigated path.
+	// This keeps the fixture API-compatible with `reinhardt-pages` even
+	// though the public API has no per-attribute reactive helper.
+	let current = with_router(|r| r.current_path().get());
+	PageElement::new("div")
+		.attr("id", id)
+		.child(
+			PageElement::new("nav")
+				.child(nav_link("/", "Home", &current))
+				.child(nav_link("/clusters", "Clusters", &current))
+				.child(nav_link("/login", "Login", &current)),
+		)
+		.child(PageElement::new("p").child(label))
+		.into_page()
+}
+
+pub fn home_page() -> Page {
+	page_with_nav("route-home", "HOME VIEW")
+}
+
+pub fn clusters_page() -> Page {
+	page_with_nav("route-clusters", "CLUSTERS VIEW")
+}
+
+pub fn login_page() -> Page {
+	page_with_nav("route-login", "LOGIN VIEW")
+}
+
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), JsValue> {
+	console_error_panic_hook::set_once();
+	ClientLauncher::new("#app")
+		.router(|| {
+			Router::new()
+				.route("/", home_page)
+				.route("/clusters", clusters_page)
+				.route("/login", login_page)
+		})
+		.launch()
+}

--- a/crates/reinhardt-pages/tests/integration/spa_navigation_full_layout_e2e_test.rs
+++ b/crates/reinhardt-pages/tests/integration/spa_navigation_full_layout_e2e_test.rs
@@ -1,0 +1,276 @@
+//! Tier 3 e2e regression test — SPA navigation through real Chrome via
+//! CDP. Drives the persistent-layout-shell fixture
+//! (`spa_navigation_with_full_layout_app`) with sidebar `<a>` clicks
+//! and asserts both DOM swap AND the diagnostic counter increments
+//! (Inv-1, Inv-3, Inv-4) via `execute_js`.
+//!
+//! This is a NATIVE test (not wasm-bindgen-test). It:
+//! 1. Builds the Tier 3 fixture WASM bundle via `wasm-pack build`.
+//! 2. Boots an axum HTTP server on an ephemeral port serving the bundle
+//!    plus the fixture's `index.html`. The HTML wires the
+//!    `__diag_*_js` `#[wasm_bindgen]` exports onto `window` so this
+//!    test can read them through `execute_js`.
+//! 3. Uses the `cdp_browser` rstest fixture from `reinhardt-test` to
+//!    spin up an isolated Chrome container and drive it through the
+//!    sidebar navigation flow.
+//!
+//! Skipped (with a clear log line) if `wasm-pack` is not on `PATH`.
+//!
+//! Tests pass on current main HEAD — they exist as a future-regression
+//! net for the listener-loss class (#4075, #4088, #4122) so it cannot
+//! silently re-emerge through a real source change or a stale-wasm-
+//! bundle deployment hazard (the actual root cause of #4122; see
+//! tracking issues #4127 / #4128).
+//!
+//! Refs #4122.
+
+#![cfg(all(feature = "e2e-cdp-test", not(target_arch = "wasm32")))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use reinhardt_test::fixtures::wasm::e2e_cdp::{CdpBrowser, cdp_browser};
+use rstest::*;
+
+const FIXTURE_DIR_REL: &str = "tests/fixtures/spa_navigation_with_full_layout_app";
+
+/// Locates the Tier 3 fixture crate root (relative to the test invocation cwd).
+fn fixture_dir() -> PathBuf {
+	let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
+	PathBuf::from(manifest).join(FIXTURE_DIR_REL)
+}
+
+/// Builds the fixture WASM bundle via `wasm-pack build --target web`.
+/// Returns `Ok(Some(pkg_dir))` on success, `Ok(None)` if `wasm-pack` is missing.
+fn build_fixture_bundle() -> Result<Option<PathBuf>, String> {
+	if Command::new("wasm-pack").arg("--version").output().is_err() {
+		return Ok(None);
+	}
+	let dir = fixture_dir();
+	let status = Command::new("wasm-pack")
+		.args(["build", "--target", "web", "--out-dir", "pkg"])
+		.current_dir(&dir)
+		.status()
+		.map_err(|e| format!("wasm-pack failed to spawn: {e}"))?;
+	if !status.success() {
+		return Err(format!("wasm-pack build failed with status {status}"));
+	}
+	Ok(Some(dir.join("pkg")))
+}
+
+/// RAII guard that aborts the server task on drop, ensuring deterministic
+/// cleanup regardless of test outcome (including panics).
+struct ServerGuard {
+	abort: tokio::task::AbortHandle,
+}
+
+impl Drop for ServerGuard {
+	fn drop(&mut self) {
+		self.abort.abort();
+	}
+}
+
+/// Boots an axum server on an ephemeral port, serving the fixture index.html
+/// and the WASM bundle. Returns the bound URL and a `ServerGuard` whose Drop
+/// aborts the spawned task. Mirrors the layout used by
+/// `spa_navigation_e2e_test.rs`.
+async fn boot_test_server(fixture_dir: &Path) -> (String, ServerGuard) {
+	use axum::Router;
+	use tower_http::services::ServeDir;
+
+	let app = Router::new().nest_service(
+		"/",
+		ServeDir::new(fixture_dir).append_index_html_on_directories(true),
+	);
+
+	// Bind to 0.0.0.0 so the chromedp container can reach the listener via
+	// `host.docker.internal` on Linux CI. Refs #4111.
+	let listener = tokio::net::TcpListener::bind("0.0.0.0:0")
+		.await
+		.expect("bind ephemeral port");
+	let port = listener.local_addr().expect("local_addr").port();
+	let handle = tokio::spawn(async move {
+		axum::serve(listener, app).await.expect("axum serve");
+	});
+	let guard = ServerGuard {
+		abort: handle.abort_handle(),
+	};
+	(format!("http://host.docker.internal:{port}"), guard)
+}
+
+/// Reads a `u64`-valued diagnostic counter exposed by the fixture
+/// (`__diag_dispatch_count_js` / `__diag_render_count_js`). The
+/// fixture's `index.html` wires these into `window`, so they are
+/// reachable as bare globals.
+///
+/// wasm-bindgen marshals Rust `u64` as JavaScript `BigInt`, which
+/// `serde_json` cannot deserialize directly (it is not a JSON type).
+/// We therefore wrap the call site with `String(...)` so the value
+/// crosses the CDP boundary as a JSON string, then parse it on the
+/// Rust side.
+async fn read_u64_counter(
+	page: &reinhardt_test::fixtures::wasm::e2e_cdp::CdpPage,
+	js_name: &str,
+) -> u64 {
+	let val = page
+		.execute_js(&format!("String({}())", js_name))
+		.await
+		.unwrap_or_else(|e| panic!("execute_js {js_name} failed: {e:?}"));
+	let s = val
+		.as_str()
+		.unwrap_or_else(|| panic!("expected {js_name} stringified value; got {val:?}"));
+	s.parse::<u64>()
+		.unwrap_or_else(|e| panic!("expected {js_name} to parse as u64; got {s:?}: {e}"))
+}
+
+/// Reads a `usize`-valued diagnostic counter
+/// (`__diag_observer_count_js`). wasm-bindgen marshals Rust `usize`
+/// (32-bit on wasm32) as a JS `Number`, which is JSON-friendly.
+async fn read_usize_counter(
+	page: &reinhardt_test::fixtures::wasm::e2e_cdp::CdpPage,
+	js_name: &str,
+) -> usize {
+	let val = page
+		.execute_js(&format!("{}()", js_name))
+		.await
+		.unwrap_or_else(|e| panic!("execute_js {js_name} failed: {e:?}"));
+	val.as_u64().unwrap_or_else(|| {
+		panic!("expected {js_name} to return usize-compatible value; got {val:?}")
+	}) as usize
+}
+
+#[rstest]
+#[tokio::test]
+async fn spa_navigation_full_layout_e2e(#[future] cdp_browser: CdpBrowser) {
+	// Arrange: build the fixture bundle and boot the server.
+	let pkg_dir = match build_fixture_bundle() {
+		Ok(Some(p)) => p,
+		Ok(None) => {
+			eprintln!(
+				"[skip] wasm-pack not found on PATH; spa_navigation_full_layout_e2e_test skipped"
+			);
+			return;
+		}
+		Err(e) => panic!("Tier 3 fixture build failed: {e}"),
+	};
+	let fixture_root = pkg_dir
+		.parent()
+		.expect("pkg dir has parent (the fixture crate root)");
+	let (base_url, _server) = boot_test_server(fixture_root).await;
+	eprintln!("[e2e] base_url = {base_url}");
+	let browser = cdp_browser.await;
+	let page = browser
+		.new_page(&base_url)
+		.await
+		.expect("open new page at fixture URL");
+
+	// Boot mount: home content section is rendered under the layout shell.
+	if let Err(e) = page.wait_for("#route-home").await {
+		let actual_url = page.url().await.ok().flatten().unwrap_or_default();
+		let html = page
+			.content()
+			.await
+			.unwrap_or_else(|err| format!("<failed to read page content: {err:?}>"));
+		panic!(
+			"wait for #route-home failed: {e:?}\n\
+			 base_url:   {base_url}\n\
+			 actual url: {actual_url}\n\
+			 html:       {html}"
+		);
+	}
+
+	// Inv-1 (e2e): launch must register at least one render listener.
+	let observer_baseline = read_usize_counter(&page, "__diag_observer_count_js").await;
+	assert!(
+		observer_baseline >= 1,
+		"Inv-1 e2e: launch must register render listener; got {}",
+		observer_baseline
+	);
+
+	// Capture dispatch / render baselines after boot but before any click.
+	let dispatch_baseline = read_u64_counter(&page, "__diag_dispatch_count_js").await;
+	let render_baseline = read_u64_counter(&page, "__diag_render_count_js").await;
+
+	// Act 1: click the sidebar link to /clusters.
+	page.click("a[href='/clusters']")
+		.await
+		.expect("click sidebar /clusters link");
+	page.wait_for_url(|u| u.ends_with("/clusters"))
+		.await
+		.expect("URL updates to /clusters within timeout");
+	page.wait_for("#route-clusters")
+		.await
+		.expect("clusters view mounts within timeout");
+
+	// Assert (step 1): Inv-3 / Inv-4 / Inv-2 hold and DOM swapped.
+	let dispatch_after_one = read_u64_counter(&page, "__diag_dispatch_count_js").await;
+	let render_after_one = read_u64_counter(&page, "__diag_render_count_js").await;
+	let observer_after_one = read_usize_counter(&page, "__diag_observer_count_js").await;
+	assert_eq!(
+		dispatch_after_one,
+		dispatch_baseline + 1,
+		"Inv-3 e2e (click 1): dispatch_count expected {} got {}",
+		dispatch_baseline + 1,
+		dispatch_after_one
+	);
+	assert_eq!(
+		render_after_one,
+		render_baseline + 1,
+		"Inv-4 e2e (click 1): render_count expected {} got {}",
+		render_baseline + 1,
+		render_after_one
+	);
+	assert!(
+		observer_after_one >= observer_baseline,
+		"Inv-2 e2e (click 1): observer count dropped {} -> {}",
+		observer_baseline,
+		observer_after_one
+	);
+
+	// Act 2: click the sidebar link to /login.
+	page.click("a[href='/login']")
+		.await
+		.expect("click sidebar /login link");
+	page.wait_for_url(|u| u.ends_with("/login"))
+		.await
+		.expect("URL updates to /login within timeout");
+	page.wait_for("#route-login")
+		.await
+		.expect("login view mounts within timeout");
+
+	// Assert (step 2): cumulative increments and DOM swap.
+	let dispatch_after_two = read_u64_counter(&page, "__diag_dispatch_count_js").await;
+	let render_after_two = read_u64_counter(&page, "__diag_render_count_js").await;
+	let observer_after_two = read_usize_counter(&page, "__diag_observer_count_js").await;
+	assert_eq!(
+		dispatch_after_two,
+		dispatch_baseline + 2,
+		"Inv-3 e2e (click 2): dispatch_count expected {} got {}",
+		dispatch_baseline + 2,
+		dispatch_after_two
+	);
+	assert_eq!(
+		render_after_two,
+		render_baseline + 2,
+		"Inv-4 e2e (click 2): render_count expected {} got {}",
+		render_baseline + 2,
+		render_after_two
+	);
+	assert!(
+		observer_after_two >= observer_after_one,
+		"Inv-2 e2e (click 2): observer count dropped {} -> {}",
+		observer_after_one,
+		observer_after_two
+	);
+
+	// Final DOM-swap sanity check via the rendered HTML.
+	let html = page.content().await.expect("page content");
+	assert!(
+		html.contains("LOGIN VIEW"),
+		"expected LOGIN VIEW after second navigation; got: {html}"
+	);
+	assert!(
+		!html.contains("CLUSTERS VIEW"),
+		"clusters view must be unmounted after navigation to /login; got: {html}"
+	);
+}

--- a/crates/reinhardt-pages/tests/integration/spa_navigation_full_layout_e2e_test.rs
+++ b/crates/reinhardt-pages/tests/integration/spa_navigation_full_layout_e2e_test.rs
@@ -41,9 +41,20 @@ fn fixture_dir() -> PathBuf {
 }
 
 /// Builds the fixture WASM bundle via `wasm-pack build --target web`.
-/// Returns `Ok(Some(pkg_dir))` on success, `Ok(None)` if `wasm-pack` is missing.
+///
+/// Returns `Ok(Some(pkg_dir))` on success and `Ok(None)` when `wasm-pack`
+/// is missing on a developer workstation. **In CI** (`CI=true`) a missing
+/// `wasm-pack` is escalated to an error so a misconfigured runner cannot
+/// silently disable the regression net (Copilot review feedback on
+/// PR #4129).
 fn build_fixture_bundle() -> Result<Option<PathBuf>, String> {
 	if Command::new("wasm-pack").arg("--version").output().is_err() {
+		if std::env::var("CI").is_ok() {
+			return Err(
+				"wasm-pack not on PATH but CI=true; refusing to skip the Tier 3 e2e regression net silently"
+					.to_string(),
+			);
+		}
 		return Ok(None);
 	}
 	let dir = fixture_dir();

--- a/crates/reinhardt-pages/tests/wasm/spa_navigation_diag_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/spa_navigation_diag_test.rs
@@ -1,0 +1,201 @@
+//! WASM-bindgen tests asserting navigation observer invariants
+//! (Inv-1 ~ Inv-4) against the Tier 2 (sidebar-signal) fixture.
+//! Refs #4122.
+//!
+//! Run with (from the workspace root):
+//!   wasm-pack test --chrome --headless --features wasm-diag-test \
+//!     crates/reinhardt-pages -- --test spa_navigation_diag_test
+//!
+//! The Inv-N invariants are:
+//!   - Inv-1: launch() registers at least one navigation observer.
+//!   - Inv-2: observer count is monotonic non-decreasing across
+//!     navigations.
+//!   - Inv-3: every `<a>` click that resolves to a known route
+//!     produces exactly one `notify_observers` dispatch (i.e.
+//!     `__diag_dispatch_count` increments by 1 per click).
+//!   - Inv-4: every such click produces exactly one
+//!     `render_and_mount` call (i.e. `__diag_render_count`
+//!     increments by 1 per click).
+//!
+//! The four assertions are co-located in a single
+//! `#[wasm_bindgen_test]` so that the launcher's thread-local router
+//! state lives for the full sequence and so that the dispatch /
+//! render counters share a coherent baseline. Splitting into four
+//! tests would either require resetting the launcher's thread-local
+//! between cases (no public API for that today) or accept a fresh
+//! router whose pre-click counter baselines are not directly
+//! comparable to the post-click values from a previous case.
+
+#![cfg(all(target_arch = "wasm32", feature = "wasm-diag-test"))]
+
+use reinhardt_pages::app::{ClientLauncher, with_router};
+use reinhardt_pages::component::{IntoPage, Page, PageElement};
+use reinhardt_pages::router::Router;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// ---- Page builders (mirror the standalone fixture in
+// `tests/fixtures/spa_navigation_with_sidebar_signal_app/src/lib.rs`) ----
+
+fn nav_link(href: &'static str, label: &'static str, current: &str) -> PageElement {
+	let class = if current == href { "active" } else { "" };
+	PageElement::new("a")
+		.attr("href", href)
+		.attr("class", class)
+		.child(label)
+}
+
+fn page_with_nav(id: &'static str, label: &'static str) -> Page {
+	let current = with_router(|r| r.current_path().get());
+	PageElement::new("div")
+		.attr("id", id)
+		.child(
+			PageElement::new("nav")
+				.child(nav_link("/", "Home", &current))
+				.child(nav_link("/clusters", "Clusters", &current))
+				.child(nav_link("/login", "Login", &current)),
+		)
+		.child(PageElement::new("p").child(label))
+		.into_page()
+}
+
+fn home_page() -> Page {
+	page_with_nav("route-home", "HOME VIEW")
+}
+
+fn clusters_page() -> Page {
+	page_with_nav("route-clusters", "CLUSTERS VIEW")
+}
+
+fn login_page() -> Page {
+	page_with_nav("route-login", "LOGIN VIEW")
+}
+
+fn build_router() -> Router {
+	Router::new()
+		.route("/", home_page)
+		.route("/clusters", clusters_page)
+		.route("/login", login_page)
+}
+
+// ---- DOM helpers ----
+
+fn install_app_root() -> web_sys::Element {
+	let document = web_sys::window().unwrap().document().unwrap();
+	if let Some(prev) = document.get_element_by_id("app") {
+		prev.remove();
+	}
+	let root = document.create_element("div").unwrap();
+	root.set_id("app");
+	document.body().unwrap().append_child(&root).unwrap();
+	root
+}
+
+fn click_link(href: &str) {
+	let document = web_sys::window().unwrap().document().unwrap();
+	let selector = format!("a[href='{}']", href);
+	let anchor = document
+		.query_selector(&selector)
+		.expect("query_selector")
+		.unwrap_or_else(|| panic!("a[href={}] should exist after render", href));
+	let html = anchor
+		.dyn_ref::<web_sys::HtmlElement>()
+		.expect("anchor must be an HtmlElement");
+	html.click();
+}
+
+// ---- Test ----
+
+#[wasm_bindgen_test]
+fn tier2_invariants_inv1_through_inv4() {
+	let _root = install_app_root();
+
+	ClientLauncher::new("#app")
+		.router(build_router)
+		.launch()
+		.expect("launch");
+
+	// Inv-1: launch() must register at least one navigation observer.
+	let observer_count_initial = with_router(|r| r.__diag_observer_count());
+	assert!(
+		observer_count_initial >= 1,
+		"Inv-1 violated: launch() must register the render listener; got {}",
+		observer_count_initial
+	);
+
+	// Capture baselines after launch but before any navigation. The
+	// initial render performed during launch may or may not bump
+	// `__diag_render_count` and `__diag_dispatch_count`; for Inv-3 /
+	// Inv-4 we only assert per-click increments, so the absolute
+	// baseline is irrelevant.
+	let dispatch_before = with_router(|r| r.__diag_dispatch_count());
+	let render_before = ClientLauncher::__diag_render_count();
+
+	// First navigation: / -> /clusters via synthesized click.
+	click_link("/clusters");
+
+	let observer_after_one = with_router(|r| r.__diag_observer_count());
+	let dispatch_after_one = with_router(|r| r.__diag_dispatch_count());
+	let render_after_one = ClientLauncher::__diag_render_count();
+
+	// Inv-2 (step 1): observer count must not have decreased.
+	assert!(
+		observer_after_one >= observer_count_initial,
+		"Inv-2 violated after click 1: observer count dropped {} -> {}",
+		observer_count_initial,
+		observer_after_one
+	);
+
+	// Inv-3 (step 1): exactly one dispatch per click.
+	assert_eq!(
+		dispatch_after_one,
+		dispatch_before + 1,
+		"Inv-3 violated after click 1: dispatch_count expected {} got {}",
+		dispatch_before + 1,
+		dispatch_after_one
+	);
+
+	// Inv-4 (step 1): exactly one render per click.
+	assert_eq!(
+		render_after_one,
+		render_before + 1,
+		"Inv-4 violated after click 1: render_count expected {} got {}",
+		render_before + 1,
+		render_after_one
+	);
+
+	// Second navigation: /clusters -> /login.
+	click_link("/login");
+
+	let observer_after_two = with_router(|r| r.__diag_observer_count());
+	let dispatch_after_two = with_router(|r| r.__diag_dispatch_count());
+	let render_after_two = ClientLauncher::__diag_render_count();
+
+	// Inv-2 (step 2): still monotonic across the second navigation.
+	assert!(
+		observer_after_two >= observer_after_one,
+		"Inv-2 violated after click 2: observer count dropped {} -> {}",
+		observer_after_one,
+		observer_after_two
+	);
+
+	// Inv-3 (step 2): cumulative dispatches increased by exactly two.
+	assert_eq!(
+		dispatch_after_two,
+		dispatch_before + 2,
+		"Inv-3 violated after click 2: dispatch_count expected {} got {}",
+		dispatch_before + 2,
+		dispatch_after_two
+	);
+
+	// Inv-4 (step 2): cumulative renders increased by exactly two.
+	assert_eq!(
+		render_after_two,
+		render_before + 2,
+		"Inv-4 violated after click 2: render_count expected {} got {}",
+		render_before + 2,
+		render_after_two
+	);
+}

--- a/crates/reinhardt-pages/tests/wasm/spa_navigation_diag_tier3_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/spa_navigation_diag_tier3_test.rs
@@ -1,0 +1,267 @@
+//! WASM-bindgen tests asserting navigation observer invariants
+//! (Inv-1 ~ Inv-4) plus DOM swap against the Tier 3 (full-layout)
+//! fixture. Refs #4122.
+//!
+//! Run with (from the workspace root):
+//!   wasm-pack test --chrome --headless --features wasm-diag-test \
+//!     crates/reinhardt-pages -- --test spa_navigation_diag_tier3_test
+//!
+//! The Inv-N invariants are:
+//!   - Inv-1: launch() registers at least one navigation observer.
+//!   - Inv-2: observer count is monotonic non-decreasing across
+//!     navigations.
+//!   - Inv-3: every `<a>` click that resolves to a known route
+//!     produces exactly one `notify_observers` dispatch (i.e.
+//!     `__diag_dispatch_count` increments by 1 per click).
+//!   - Inv-4: every such click produces exactly one
+//!     `render_and_mount` call (i.e. `__diag_render_count`
+//!     increments by 1 per click).
+//!
+//! Additionally, this Tier 3 suite asserts the DOM-swap property:
+//! after each navigation, the previous route's content section is
+//! removed from the DOM and the new route's content section is
+//! mounted.
+//!
+//! Tier 2 and Tier 3 ship as SEPARATE `[[test]]` entries (separate
+//! cdylib binaries) because each `ClientLauncher::launch` populates a
+//! thread-local Router that cannot be reset within a single wasm
+//! module load — co-locating both tiers in one binary would cause the
+//! second `launch()` to panic on the lingering thread-local.
+//!
+//! The Inv-1 ~ Inv-4 + DOM-swap assertions are co-located in a single
+//! `#[wasm_bindgen_test]` for the same reason described in
+//! `spa_navigation_diag_test.rs`: the launcher's thread-local router
+//! state lives for the full sequence so the dispatch / render counters
+//! share a coherent baseline.
+
+#![cfg(all(target_arch = "wasm32", feature = "wasm-diag-test"))]
+
+use reinhardt_pages::app::{ClientLauncher, with_router};
+use reinhardt_pages::component::{IntoPage, Page, PageElement};
+use reinhardt_pages::router::Router;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// ---- Page builders (mirror the standalone fixture in
+// `tests/fixtures/spa_navigation_with_full_layout_app/src/lib.rs`) ----
+//
+// These page builders duplicate the standalone fixture by design: the
+// fixture exists so the e2e_cdp test can build a real WASM bundle and
+// drive it through Chrome, while this wasm-bindgen-test runs in-process
+// against the same logical structure. Cargo's `optional = true` is not
+// fully supported on `[dev-dependencies]`, so we cannot pull the
+// fixture crate in as a dev-dep. Drift between the two would surface
+// immediately as a test-vs-fixture divergence in CI.
+
+fn nav_link(href: &'static str, label: &'static str, current: &str) -> PageElement {
+	let class = if current == href { "active" } else { "" };
+	PageElement::new("a")
+		.attr("href", href)
+		.attr("class", class)
+		.child(label)
+}
+
+fn layout_shell(content_id: &'static str, content_label: &'static str) -> Page {
+	let current = with_router(|r| r.current_path().get());
+	PageElement::new("div")
+		.attr("id", "shell")
+		.child(
+			PageElement::new("aside").attr("id", "sidebar").child(
+				PageElement::new("ul")
+					.child(PageElement::new("li").child(nav_link("/", "Home", &current)))
+					.child(PageElement::new("li").child(nav_link(
+						"/clusters",
+						"Clusters",
+						&current,
+					)))
+					.child(PageElement::new("li").child(nav_link("/login", "Login", &current))),
+			),
+		)
+		.child(
+			PageElement::new("main").attr("id", "content").child(
+				PageElement::new("section")
+					.attr("id", content_id)
+					.child(PageElement::new("h1").child(content_label)),
+			),
+		)
+		.into_page()
+}
+
+fn home_page() -> Page {
+	layout_shell("route-home", "HOME VIEW")
+}
+
+fn clusters_page() -> Page {
+	layout_shell("route-clusters", "CLUSTERS VIEW")
+}
+
+fn login_page() -> Page {
+	layout_shell("route-login", "LOGIN VIEW")
+}
+
+fn build_router() -> Router {
+	Router::new()
+		.route("/", home_page)
+		.route("/clusters", clusters_page)
+		.route("/login", login_page)
+}
+
+// ---- DOM helpers ----
+
+fn install_app_root() -> web_sys::Element {
+	let document = web_sys::window().unwrap().document().unwrap();
+	if let Some(prev) = document.get_element_by_id("app") {
+		prev.remove();
+	}
+	let root = document.create_element("div").unwrap();
+	root.set_id("app");
+	document.body().unwrap().append_child(&root).unwrap();
+	root
+}
+
+fn click_link(href: &str) {
+	let document = web_sys::window().unwrap().document().unwrap();
+	let selector = format!("a[href='{}']", href);
+	let anchor = document
+		.query_selector(&selector)
+		.expect("query_selector")
+		.unwrap_or_else(|| panic!("a[href={}] should exist after render", href));
+	let html = anchor
+		.dyn_ref::<web_sys::HtmlElement>()
+		.expect("anchor must be an HtmlElement");
+	html.click();
+}
+
+// ---- Test ----
+
+#[wasm_bindgen_test]
+fn tier3_invariants_inv1_through_inv4_with_dom_swap() {
+	let _root = install_app_root();
+
+	ClientLauncher::new("#app")
+		.router(build_router)
+		.launch()
+		.expect("launch");
+
+	// Inv-1: launch() must register at least one navigation observer.
+	let observer_count_initial = with_router(|r| r.__diag_observer_count());
+	assert!(
+		observer_count_initial >= 1,
+		"Inv-1 (Tier 3) violated: launch() must register the render listener; got {}",
+		observer_count_initial
+	);
+
+	// DOM check: home content is mounted at boot.
+	let document = web_sys::window().unwrap().document().unwrap();
+	assert!(
+		document
+			.query_selector("#route-home")
+			.expect("query_selector")
+			.is_some(),
+		"home page should be mounted at boot"
+	);
+
+	// Capture baselines after launch but before any navigation.
+	let dispatch_before = with_router(|r| r.__diag_dispatch_count());
+	let render_before = ClientLauncher::__diag_render_count();
+
+	// First navigation: / -> /clusters via synthesized click.
+	click_link("/clusters");
+
+	let observer_after_one = with_router(|r| r.__diag_observer_count());
+	let dispatch_after_one = with_router(|r| r.__diag_dispatch_count());
+	let render_after_one = ClientLauncher::__diag_render_count();
+
+	// Inv-2 (step 1): observer count must not have decreased.
+	assert!(
+		observer_after_one >= observer_count_initial,
+		"Inv-2 (Tier 3) violated after click 1: observer count dropped {} -> {}",
+		observer_count_initial,
+		observer_after_one
+	);
+
+	// Inv-3 (step 1): exactly one dispatch per click.
+	assert_eq!(
+		dispatch_after_one,
+		dispatch_before + 1,
+		"Inv-3 (Tier 3) violated after click 1: dispatch_count expected {} got {}",
+		dispatch_before + 1,
+		dispatch_after_one
+	);
+
+	// Inv-4 (step 1): exactly one render per click.
+	assert_eq!(
+		render_after_one,
+		render_before + 1,
+		"Inv-4 (Tier 3) violated after click 1: render_count expected {} got {}",
+		render_before + 1,
+		render_after_one
+	);
+
+	// DOM swap (step 1): clusters mounted, home gone.
+	assert!(
+		document
+			.query_selector("#route-clusters")
+			.expect("query_selector")
+			.is_some(),
+		"clusters page must be in DOM after click 1"
+	);
+	assert!(
+		document
+			.query_selector("#route-home")
+			.expect("query_selector")
+			.is_none(),
+		"home page must be removed from DOM after navigation to /clusters"
+	);
+
+	// Second navigation: /clusters -> /login.
+	click_link("/login");
+
+	let observer_after_two = with_router(|r| r.__diag_observer_count());
+	let dispatch_after_two = with_router(|r| r.__diag_dispatch_count());
+	let render_after_two = ClientLauncher::__diag_render_count();
+
+	// Inv-2 (step 2): still monotonic across the second navigation.
+	assert!(
+		observer_after_two >= observer_after_one,
+		"Inv-2 (Tier 3) violated after click 2: observer count dropped {} -> {}",
+		observer_after_one,
+		observer_after_two
+	);
+
+	// Inv-3 (step 2): cumulative dispatches increased by exactly two.
+	assert_eq!(
+		dispatch_after_two,
+		dispatch_before + 2,
+		"Inv-3 (Tier 3) violated after click 2: dispatch_count expected {} got {}",
+		dispatch_before + 2,
+		dispatch_after_two
+	);
+
+	// Inv-4 (step 2): cumulative renders increased by exactly two.
+	assert_eq!(
+		render_after_two,
+		render_before + 2,
+		"Inv-4 (Tier 3) violated after click 2: render_count expected {} got {}",
+		render_before + 2,
+		render_after_two
+	);
+
+	// DOM swap (step 2): login mounted, clusters gone.
+	assert!(
+		document
+			.query_selector("#route-login")
+			.expect("query_selector")
+			.is_some(),
+		"login page must be in DOM after click 2"
+	);
+	assert!(
+		document
+			.query_selector("#route-clusters")
+			.expect("query_selector")
+			.is_none(),
+		"clusters page must be removed from DOM after navigation to /login"
+	);
+}

--- a/crates/reinhardt-pages/tests/wasm/spa_navigation_diag_tier3_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/spa_navigation_diag_tier3_test.rs
@@ -136,8 +136,48 @@ fn click_link(href: &str) {
 
 // ---- Test ----
 
+/// Yields execution to the event loop's microtask queue. Used after
+/// each synthesized click so any pending async work scheduled by the
+/// reactive runtime (Effect scheduling lives behind
+/// `wasm_bindgen_futures::spawn_local` per `app.rs::launch::Phase A`)
+/// has a chance to run before the test samples counters or DOM state.
+///
+/// The current navigate -> notify_observers -> render_and_mount path
+/// is fully synchronous, so this yield is defensive insurance against
+/// future async refactors of that path. Without it, a hypothetical
+/// async render would make this test flake by sampling before the
+/// dispatch / render completes (Copilot review feedback on PR #4129).
+async fn yield_microtask() {
+	let promise = js_sys::Promise::resolve(&wasm_bindgen::JsValue::UNDEFINED);
+	let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+}
+
+/// Polls `query_selector(selector)` until it returns `Some`, yielding
+/// to the microtask queue between attempts. Errors out with a clear
+/// message after `max_iterations` (each iteration costs ~one
+/// microtask, so 100 iterations corresponds to "give the runtime a
+/// few frames to settle"). Used by the Tier 3 test as a defensive
+/// post-click wait.
+async fn await_element(selector: &str, max_iterations: u32) {
+	let document = web_sys::window().unwrap().document().unwrap();
+	for _ in 0..max_iterations {
+		if document
+			.query_selector(selector)
+			.expect("query_selector")
+			.is_some()
+		{
+			return;
+		}
+		yield_microtask().await;
+	}
+	panic!(
+		"timed out waiting for `{}` to appear after {} microtask yields",
+		selector, max_iterations
+	);
+}
+
 #[wasm_bindgen_test]
-fn tier3_invariants_inv1_through_inv4_with_dom_swap() {
+async fn tier3_invariants_inv1_through_inv4_with_dom_swap() {
 	let _root = install_app_root();
 
 	ClientLauncher::new("#app")
@@ -153,22 +193,19 @@ fn tier3_invariants_inv1_through_inv4_with_dom_swap() {
 		observer_count_initial
 	);
 
-	// DOM check: home content is mounted at boot.
+	// DOM check: home content is mounted at boot. Wait for it explicitly
+	// so the test does not assume a fully synchronous initial mount.
+	await_element("#route-home", 100).await;
 	let document = web_sys::window().unwrap().document().unwrap();
-	assert!(
-		document
-			.query_selector("#route-home")
-			.expect("query_selector")
-			.is_some(),
-		"home page should be mounted at boot"
-	);
 
 	// Capture baselines after launch but before any navigation.
 	let dispatch_before = with_router(|r| r.__diag_dispatch_count());
 	let render_before = ClientLauncher::__diag_render_count();
 
-	// First navigation: / -> /clusters via synthesized click.
+	// First navigation: / -> /clusters via synthesized click. Wait for
+	// the post-click DOM to settle before sampling counters.
 	click_link("/clusters");
+	await_element("#route-clusters", 100).await;
 
 	let observer_after_one = with_router(|r| r.__diag_observer_count());
 	let dispatch_after_one = with_router(|r| r.__diag_dispatch_count());
@@ -216,8 +253,10 @@ fn tier3_invariants_inv1_through_inv4_with_dom_swap() {
 		"home page must be removed from DOM after navigation to /clusters"
 	);
 
-	// Second navigation: /clusters -> /login.
+	// Second navigation: /clusters -> /login. Wait for the post-click
+	// DOM to settle before sampling counters.
 	click_link("/login");
+	await_element("#route-login", 100).await;
 
 	let observer_after_two = with_router(|r| r.__diag_observer_count());
 	let dispatch_after_two = with_router(|r| r.__diag_dispatch_count());


### PR DESCRIPTION
## Summary

- Issue #4122 ("SPA navigation regression persists after #4102") was reclassified during live diagnosis as a **stale-wasm-bundle false positive**, not a third structural recurrence. Counter observation (added in this PR) showed Inv-1 ~ Inv-4 already pass on current main HEAD; the original report was based on Apr-4-dated `dist/` while main was already past #4102's May-3 fix. The dev-loop hazard is tracked separately in #4127 (`runserver` does not auto-rebuild WASM) and #4128 (hot-reload WASM rebuild verification).
- This PR ships the **diagnostic counter API** (`Router::__diag_observer_count`, `Router::__diag_dispatch_count`, `ClientLauncher::__diag_render_count`) plus a **Tier 2 + Tier 3 fixture regression suite** asserting observer-system invariants Inv-1 ~ Inv-4 in both `wasm-bindgen-test` (Rust assertions) and real-Chrome `e2e_cdp` (DOM swap + counter increments via `evaluate_script`). These exist as a future-regression net so the same listener-loss class cannot silently re-emerge through a real source change OR a stale-bundle deployment hazard.

## Type of Change

- [x] New feature (`#[doc(hidden)]` `__diag_*` API)
- [x] Test addition (Tier 2 + Tier 3 fixtures + 3 test files)
- [x] No structural fix (the bug was not reproducible — see diagnosis below)

## Diagnosis trace

The original plan (`docs/superpowers/plans/2026-05-04-issue-4122-spa-render-listener-regression-plan.md`) assumed a third real recurrence and budgeted for an intentional-red-then-green TDD cycle plus a structural fix commit. The Phase-3 live diagnostic step (manual browser observation against `reinhardt-cloud` rebuilt with `[patch.crates-io]` redirect) instead produced:

| Counter | Baseline (`/`) | After click `/clusters` | Expected |
|---------|---------------|------------------------|----------|
| `__diag_dispatch_count_js` | 0n | 1n | +1 |
| `__diag_observer_count_js` | 2 | 2 | non-decreasing |
| `__diag_render_count_js` | 1n | 2n | +1 |

All four invariants Inv-1 ~ Inv-4 satisfied. `<main>` swapped correctly. The user-reported "Loading from `<main>` does not change" symptom only appeared with the 4-week-old `dist/` bundle and resolved as soon as wasm was freshly rebuilt against current `reinhardt-pages`. The actual wedge is the `runserver` / hot-reload pipeline not auto-rebuilding WASM, which is out of this PR's scope.

The plan was therefore **pivoted** from "structural fix" to "ship the diagnostic counters + regression suite as future-regression-net". C3 (throwaway tracing) and the planned C6 (structural fix) / C7 (tracing removal) were dropped; C3 was reverted in commit 4 below.

## Commit Trace (Rebase-and-Merge recommended)

| # | Commit | Status | Body |
|---|--------|--------|------|
| 1 | `01830241b feat(router): add hidden diagnostic counters for navigation observers` | green | New `dispatch_count: Rc<Cell<u64>>` field on Router + `__diag_observer_count` / `__diag_dispatch_count` accessors. Native unit tests cover monotonic increment and Weak-drop accounting. |
| 2 | `a8f5a2a65 feat(pages): add hidden render-count counter on ClientLauncher` | green | Thread-local `RENDER_COUNT: Cell<u64>` (`cfg(wasm)`) bumped on entry to `render_and_mount` + `__diag_render_count` associated function. |
| 3 | `04a25b71a chore(pages): add throwaway tracing for navigation observer diagnosis` | green | Scaffolding `tracing::debug!` calls used during the Phase-3 live observation. Reverted in commit 4 once the diagnostic was complete. |
| 4 | `69452a9b6 Revert "chore(pages): add throwaway tracing..."` | green | Removes commit 3's scaffolding now that the regression suite is in place. |
| 5 | `b6400d6e4 test(pages): add Tier 2 sidebar-signal fixture and wasm-bindgen-test` | green | Tier 2 fixture (3 routes, no layout shell) + consolidated `tier2_invariants_inv1_through_inv4` test asserting Inv-1 ~ Inv-4 against `__diag_*` counters. New `wasm-diag-test = []` marker feature. |
| 6 | `099dc15cb test(pages): add Tier 3 full-layout fixture, wasm-bindgen-test, e2e_cdp test` | green | Tier 3 fixture (persistent layout shell, nested `<a>` tags, `__diag_*_js` `#[wasm_bindgen]` exports) + Tier 3 wasm-bindgen-test (separate `[[test]]` due to thread-local-Router constraint) + native e2e_cdp test driving real Chrome via the `chromedp` container. |
| 7 | `3b81e2372 docs(pages): add CHANGELOG entry for hidden diagnostic counters` | green | `[Unreleased] / Added` entry documenting the diag counter API, the Tier 2/3 suite, and the #4122 reclassification with cross-reference to #4127 / #4128. |

CI for every commit at HEAD is expected green; intermediate commit 3 is also green (tracing is dead-weight without a subscriber). No intentional-red commits in this PR.

## How Was This Tested

- `cargo nextest run -p reinhardt-pages --lib` — 498/498 pass on each of the 7 commits.
- `cargo check --workspace --all-features` and `cargo check -p reinhardt-pages --all-features --target wasm32-unknown-unknown` — green.
- `cargo make fmt-check` and `cargo make clippy-check --lib` — clean on the changed files.
- `cargo nextest run -p reinhardt-pages --features e2e-cdp-test --test spa_navigation_full_layout_e2e_test` — **passed locally in 3.91s** with Docker + chromedp container + wasm-pack 0.14.0. The Tier 1 e2e_cdp also passes locally.
- `wasm-pack test --chrome --headless --features wasm-diag-test --test spa_navigation_diag_test` and `--test spa_navigation_diag_tier3_test` — not runnable on this Mac (Chrome 147 vs ChromeDriver 148 mismatch); the same environmental issue blocks the pre-existing `client_launcher_navigation_test`. CI runners with version-aligned Chrome will exercise both new tests.
- Manual verification on `reinhardt-cloud` (`refactor/issue-519-typed-urls-client-accessor` HEAD `2d8c2fe6`) with `[patch.crates-io]` redirected at this branch: home page renders, sidebar clicks update `<main>` correctly, all `__diag_*_js` counters increment as expected. Cloud-side patches were never committed (uncommitted scratch only).

## Notes for Reviewers

1. **Bug was not reproducible at the source level**. The PR contains no production-source fix — only the new `#[doc(hidden)]` API surface and tests. If you'd like a defense-in-depth structural change anyway (e.g. migrate `Router::navigation_observers` from `Vec<Weak>` to `Vec<Rc>`), that is a separate Issue conversation.
2. **`__diag_*` API stability**: all three accessors are `#[doc(hidden)]` and intentionally unstable. They do not appear on docs.rs and are not subject to SemVer. Future deprecation requires no migration period.
3. **Tier 2 vs Tier 3 separated `[[test]]`**: each `ClientLauncher::launch` populates a thread-local Router. Tier 2 and Tier 3 must run in different cdylib binaries to avoid the second `launch()` panicking on a populated thread-local. Inline rationale in both test files.
4. **`u64` → `BigInt` workaround in e2e_cdp**: wasm-bindgen marshals `u64` as JS `BigInt`, which `serde_json` cannot deserialize. The e2e test reads counters as `String(__diag_*_count_js())` and parses on the Rust side. Documented in the test's helper.
5. **Page-builder duplication** between fixture `lib.rs` files and the test files is deliberate — Cargo's `optional = true` is not fully supported on `[dev-dependencies]` for detached cdylib fixtures. Drift surfaces immediately as a CI test-vs-fixture divergence. A `#[path = ...]`-based shared-helpers module would be a clean follow-up.

## Related Issues

- Closes #4122 (reclassified as stale-wasm false positive — see Diagnosis trace above)
- Refs #4127 (root-cause dev-loop hazard: `runserver` does not auto-rebuild WASM)
- Refs #4128 (root-cause dev-loop hazard: hot-reload WASM rebuild verification)
- Refs #4088 (regression of), #4075 (originator)
- Refs #3348 (older same-class regression on the admin path)
- Refs #4102 (#4078) — prior false-positive fixes
- Refs #4101 (`ClientLauncher` `on_navigate` migration roadmap)

## Labels to Apply

- `bug` (required)
- `high` (priority — original report was dashboard-blocking)
- `routing` (scope)
- `documentation` (CHANGELOG update + this is the ground-truth doc of the diag API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)