### PR TITLE
docs: restructure CLAUDE.md and policy files (reinhardt-query, draft PR readiness, MCP default, macro/research/artifact rules)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ See README.md for project details.
 
 - **Language**: Rust 2024 Edition
 - **Module System**: MUST use 2024 edition (NO `mod.rs`)
-- **Database**: SeaQuery v1.0.0-rc for building SQL queries
+- **Database**: `reinhardt-query` for building SQL queries (in-house wrapper, replaces direct SeaQuery usage)
 - **Testing**: Rust's built-in framework + TestContainers for infrastructure
 - **Build**: Cargo workspace with multiple crates
 
@@ -545,7 +545,7 @@ Before submitting code:
 - Follow Arrange-Act-Assert (AAA) pattern with `// Arrange`, `// Act`, `// Assert` comments for test structure
 - Use `reinhardt-test` fixtures for test setup/teardown
 - Create specialized fixtures wrapping generic `reinhardt-test` fixtures for test data injection
-- Use SeaQuery (not raw SQL) for SQL construction in tests
+- Use `reinhardt-query` (not raw SQL or direct SeaQuery) for SQL construction in tests
 - Wrap generic types in backticks in doc comments: `` `Result<T>` ``, NOT `Result<T>`
 - Wrap macro attributes in backticks: `` `#[inject]` ``, NOT `#[inject]`
 - Wrap URLs in angle brackets or backticks: `<https://...>` or `` `https://...` ``
@@ -625,7 +625,7 @@ Before submitting code:
 - Skip preceding PRs for cross-crate shared utilities
 - Use plain `#[test]` instead of `#[rstest]`
 - Use non-standard phase labels in tests (`// Setup`, `// Execute`, `// Verify` -- use `// Arrange`, `// Act`, `// Assert`)
-- Write raw SQL strings in tests (use SeaQuery instead)
+- Write raw SQL strings or call SeaQuery directly in tests (use `reinhardt-query` instead)
 - Duplicate infrastructure setup code (use `reinhardt-test` fixtures)
 - Write generic types without backticks in doc comments (causes HTML tag warnings)
 - Write macro attributes without backticks in doc comments (causes unresolved link warnings)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -673,7 +673,7 @@ For comprehensive guidelines, see:
 - **Anti-Patterns**: instructions/ANTI_PATTERNS.md
 - **Macro Usage**: instructions/MACRO_USAGE.md (includes `#[model(...)]` rules)
 - **Documentation**: instructions/DOCUMENTATION_STANDARDS.md
-- **Git Commits**: instructions/COMMIT_GUIDELINE.md (includes CHANGELOG generation guidelines)
+- **Git Commits**: instructions/COMMIT_GUIDELINE.md (includes CHANGELOG generation guidelines and excluded artifacts)
 - **Research Escalation**: instructions/RESEARCH_ESCALATION.md (when to use Perplexity/Tavily/Brave)
 - **Release Process**: instructions/RELEASE_PROCESS.md
 - **Stability Policy**: instructions/STABILITY_POLICY.md (includes DB-1 ~ DB-7 develop branch strategy)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -674,6 +674,7 @@ For comprehensive guidelines, see:
 - **Macro Usage**: instructions/MACRO_USAGE.md (includes `#[model(...)]` rules)
 - **Documentation**: instructions/DOCUMENTATION_STANDARDS.md
 - **Git Commits**: instructions/COMMIT_GUIDELINE.md (includes CHANGELOG generation guidelines)
+- **Research Escalation**: instructions/RESEARCH_ESCALATION.md (when to use Perplexity/Tavily/Brave)
 - **Release Process**: instructions/RELEASE_PROCESS.md
 - **Stability Policy**: instructions/STABILITY_POLICY.md (includes DB-1 ~ DB-7 develop branch strategy)
 - **Agent Bug Discovery**: instructions/STABILITY_POLICY.md (SC-2a)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -671,6 +671,7 @@ For comprehensive guidelines, see:
 - **Module System**: instructions/MODULE_SYSTEM.md
 - **Testing**: instructions/TESTING_STANDARDS.md
 - **Anti-Patterns**: instructions/ANTI_PATTERNS.md
+- **Macro Usage**: instructions/MACRO_USAGE.md (includes `#[model(...)]` rules)
 - **Documentation**: instructions/DOCUMENTATION_STANDARDS.md
 - **Git Commits**: instructions/COMMIT_GUIDELINE.md (includes CHANGELOG generation guidelines)
 - **Release Process**: instructions/RELEASE_PROCESS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,10 +142,11 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 - **NEVER** execute batch commits without user confirmation
 
 **Draft PR Policy:**
-- **NEVER** convert a Draft PR to Ready for Review without explicit user instruction
-- **NO EXCEPTIONS**: Plan Mode approval does NOT authorize Draft PR conversion (unlike commits/pushes)
-- Before converting, ensure all CI checks pass and tests pass locally
-- Use `gh pr ready <number>` for conversion
+- The agent MAY convert a Draft PR to Ready for Review autonomously once the PR meets readiness criteria (worth requesting Copilot Review): implementation complete, CI green, tests pass, fmt/clippy clean, description follows template
+- Explicit user instruction also authorizes conversion at any time (overrides readiness check)
+- The agent MUST NOT convert when readiness criteria are unmet, unless the user explicitly overrides
+- Use `gh pr ready <number>` (or GitHub MCP equivalent) for conversion
+- See instructions/PR_GUIDELINE.md § PC-4a for the full readiness checklist
 
 **Branch Operations:**
 - When merging branches and resolving conflicts, execute immediately without entering Plan Mode
@@ -516,7 +517,7 @@ Before submitting code:
 - Delete temp files from `/tmp` immediately
 - Wait for explicit user instruction before commits
 - Understand that Plan Mode approval authorizes both implementation and commits
-- Wait for explicit user instruction before converting Draft PRs to Ready for Review (Plan Mode approval does NOT authorize conversion)
+- Convert Draft PRs to Ready for Review autonomously once readiness criteria are met (implementation complete, CI green, fmt/clippy clean) OR upon explicit user instruction (see instructions/PR_GUIDELINE.md § PC-4a)
 - Mark placeholders with `todo!()` or `// TODO:`
 - Use `#[serial(group_name)]` for global state tests
 - Split commits by specific intent, not features
@@ -589,7 +590,7 @@ Before submitting code:
 ### ❌ NEVER DO
 - Use `mod.rs` files (deprecated pattern)
 - Commit without user instruction (except Plan Mode approval)
-- Convert Draft PRs to Ready for Review without explicit user instruction (Plan Mode approval does NOT count)
+- Convert Draft PRs to Ready for Review while readiness criteria are unmet (incomplete impl, failing CI/tests, dirty fmt/clippy) without explicit user override
 - Leave docs outdated after code changes
 - Document user requests or AI interactions in project documentation
 - Save files to project directory (use `/tmp`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,17 +166,18 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 - This preserves commit history and avoids force-push risks
 
 **GitHub Integration:**
-- **MUST** use GitHub CLI (`gh`) for all GitHub operations
-- Use `gh pr create` for creating pull requests
-- Use `gh pr view` for viewing PR details
-- Use `gh issue create` for creating issues
-- Use `gh issue view` for viewing issue details
-- Use `gh api` for accessing GitHub API
-- Use `gh discussion list` for viewing discussions
-- Use `gh discussion create` for creating discussions
+- **DEFAULT**: Use GitHub MCP tools for all GitHub operations (PR, issues, discussions, releases)
+- **FALLBACK**: Use GitHub CLI (`gh`) **only** when GitHub MCP is unavailable, errors out (e.g., 404), or lacks the required capability
+- When GitHub MCP returns an error, immediately fall back to `gh` CLI without retrying the MCP call
+- **NEVER** use raw `curl` or web browser for GitHub operations
 - For usage questions, prefer GitHub Discussions over Issues
-- **NEVER** use raw `curl` or web browser for GitHub operations when `gh` is available
-- When GitHub MCP tools return errors (e.g., 404), immediately fall back to `gh` CLI instead of retrying
+- Common operations and their MCP/CLI equivalents:
+  - PR create: MCP `create_pull_request` / CLI `gh pr create`
+  - PR view: MCP `pull_request_read` / CLI `gh pr view`
+  - PR update: MCP `update_pull_request` / CLI `gh pr edit`
+  - Issue create: MCP `issue_write` / CLI `gh issue create`
+  - Issue view: MCP `issue_read` / CLI `gh issue view`
+  - Raw API: CLI `gh api` (use only when no MCP equivalent)
 
 **GitHub Comments & Interactions:**
 - **NEVER** post comments on PRs or Issues without authorization
@@ -532,7 +533,7 @@ Before submitting code:
 - Verify no circular dev-dependency chains exist before publishing (functional crates must not dev-depend on other Reinhardt crates)
 - Include `version` field in `reinhardt-test` workspace dependency (published crate, same as others)
 - Follow RP-1 procedure in instructions/RELEASE_PROCESS.md for partial release failures
-- Use GitHub CLI (`gh`) for all GitHub operations (PR, issues, releases)
+- Use GitHub MCP by default for all GitHub operations (PR, issues, releases); use `gh` CLI only as fallback when MCP is unavailable or errors
 - Search existing issues before creating new ones
 - Use appropriate issue templates for all issues
 - Apply at least one type label to every issue

--- a/instructions/COMMIT_GUIDELINE.md
+++ b/instructions/COMMIT_GUIDELINE.md
@@ -136,6 +136,18 @@ git apply --cached /tmp/changes.patch
 - Verify staged files before committing
 - Use `git status` to confirm no ignored files are included
 
+### CE-4a (MUST): Excluded Tooling Artifacts
+
+The following categories of files MUST NOT be committed, even if not in `.gitignore`:
+
+- **Superpowers skill documentation**: Any documentation, prompts, or reference material from the `superpowers` skill family or its sub-skills.
+  - Why: These are agent-runtime artifacts and are not part of the project's source of truth.
+  - How to apply: If `git status` shows files under paths like `superpowers/`, `.superpowers/`, or skill prompt dumps, exclude them from staging. If you find them already tracked, remove them in a dedicated `chore:` commit.
+- **Claude/agent runtime caches and tool-result spills**: Files under `.claude/projects/.../tool-results/`, `.claude/projects/.../memory/`, or similar runtime locations.
+  - Why: Per-machine, per-session, and may contain sensitive context.
+
+If unsure whether an artifact qualifies, default to excluding it and ask the user.
+
 ### CE-5: Automated Releases with release-plz
 
 **Overview:**

--- a/instructions/GITHUB_INTERACTION.md
+++ b/instructions/GITHUB_INTERACTION.md
@@ -485,7 +485,7 @@ When providing context for external coding agents (GitHub Copilot, Devin, etc.) 
 
 ### Project Constraints
 - **Module system:** Rust 2024 edition (`module.rs` + `module/` directory, NO `mod.rs`)
-- **SQL construction:** `reinhardt-query` (no raw SQL or direct SeaQuery usage)
+- **SQL construction:** `reinhardt-query` is the default; raw SQL and direct SeaQuery are permitted only as documented fallbacks for cases `reinhardt-query` cannot express yet (e.g., partial indexes and select schema operations)
 - **Testing:** `rstest` framework with Arrange-Act-Assert pattern
 - **Comments:** English only
 - **Indent:** Tab (not spaces)

--- a/instructions/GITHUB_INTERACTION.md
+++ b/instructions/GITHUB_INTERACTION.md
@@ -485,7 +485,7 @@ When providing context for external coding agents (GitHub Copilot, Devin, etc.) 
 
 ### Project Constraints
 - **Module system:** Rust 2024 edition (`module.rs` + `module/` directory, NO `mod.rs`)
-- **SQL construction:** SeaQuery v1.0.0-rc (no raw SQL)
+- **SQL construction:** `reinhardt-query` (no raw SQL or direct SeaQuery usage)
 - **Testing:** `rstest` framework with Arrange-Act-Assert pattern
 - **Comments:** English only
 - **Indent:** Tab (not spaces)

--- a/instructions/ISSUE_GUIDELINES.md
+++ b/instructions/ISSUE_GUIDELINES.md
@@ -435,7 +435,7 @@ NEVER apply `good first issue` when any of the following apply:
 
 - Security-related issues (any `security` label)
 - API-breaking changes (any `breaking-change` or `rc-migration` label)
-- Issues requiring deep knowledge of SeaQuery internals
+- Issues requiring deep knowledge of `reinhardt-query` (or its underlying SeaQuery) internals
 - Cross-crate refactoring
 - Issues with `agent-suspect` label (unverified — may not be a real issue)
 - Issues with `needs more info` label (insufficient specification)

--- a/instructions/MACRO_USAGE.md
+++ b/instructions/MACRO_USAGE.md
@@ -8,18 +8,19 @@ This file defines the policy for using Reinhardt's procedural macros (notably `#
 
 ## `#[model(...)]` Macro
 
-### MU-1 (MUST): Do Not Combine with `#[derive(Model)]`
+### MU-1 (SHOULD): Do Not Combine with `#[derive(Model)]`
 
-The `#[model(...)]` attribute macro automatically applies `#[derive(Model)]` internally. Combining the two produces duplicate derives and is rejected by the macro.
+The `#[model(...)]` attribute macro automatically applies `#[derive(Model)]` internally. If `#[derive(Model)]` is *also* written on the same struct, the attribute macro detects this and returns the input unchanged (the existing derive then handles the macro logic). Compilation succeeds today, but the explicit `Model` derive becomes redundant noise that obscures intent.
 
 **Rule:**
-- When using `#[model(...)]`, **do not** also write `#[derive(Model)]` on the same struct.
+- When using `#[model(...)]`, **prefer not** to also write `#[derive(Model)]` on the same struct — the attribute applies it for you.
 - Add other derives that `#[model(...)]` does not provide via a separate `#[derive(...)]` (e.g., `Debug`, `Clone`, `serde::Serialize`).
+- Existing code that combines both is supported and does not need an immediate fix; new code should follow the canonical form.
 
 **Examples:**
 
 ```rust
-// ✅ Correct
+// ✅ Canonical — let #[model(...)] add the Model derive
 #[model(table = "people")]
 #[derive(Debug, Clone)]
 pub struct Person {
@@ -27,7 +28,7 @@ pub struct Person {
     pub name: String,
 }
 
-// ❌ Incorrect — duplicate Model derive
+// ⚠️ Redundant but supported — Model derive duplicates what #[model(...)] applies
 #[model(table = "people")]
 #[derive(Debug, Clone, Model)]
 pub struct Person {
@@ -43,7 +44,7 @@ The `#[model(...)]` macro generates a `new(...)` associated function on the anno
 **Rule:**
 - Initialize `#[model(...)]` structs using the macro-generated `new(...)` function.
 - Do not initialize them via struct literals (`Person { id: 0, name: ... }`) when the macro-generated `new` is available.
-- Exception: Use struct literal syntax in tests *only when* the test specifically needs to bypass `new`'s validation (and document why with a comment).
+- Exception: struct-literal syntax may be used in tests when a test specifically needs to set fields that the constructor auto-fills (e.g., to inject a fixed primary key). Document the reason with a comment.
 
 **Examples:**
 
@@ -59,23 +60,23 @@ let person = Person {
 ```
 
 **Rationale:**
-- The generated `new` function applies any validation, defaulting, or invariant enforcement that the macro injects.
-- Direct struct-literal initialization can silently bypass these guarantees, leading to invalid model instances.
-- Centralizing initialization through `new` keeps call sites stable as the macro evolves.
+- The generated `new` accepts only the fields the user must supply and auto-fills macro-managed fields (auto-generated primary keys, foreign-key id columns, defaulted fields). Struct-literal initialization forces the caller to spell out every field, including those `new` would have filled — which is brittle.
+- Centralizing initialization through `new` keeps call sites stable as the macro evolves: when future macro versions add fields or validation, struct-literal call sites break or silently bypass the new guarantees, while `new(...)` call sites adapt automatically.
+- Today the generated `new` does not perform validation; this rule is about future-proofing and field coverage, not about a current invariant guarantee.
 
 ---
 
 ## Quick Reference
 
 ### ✅ MUST DO
-- Use `#[model(...)]` alone (do not also write `#[derive(Model)]`)
 - Initialize `#[model(...)]` structs via the macro-generated `new(...)` function
 - Add unrelated derives (e.g., `Debug`, `Clone`) via a separate `#[derive(...)]`
 
+### ✅ SHOULD DO
+- Use `#[model(...)]` alone (do not also write `#[derive(Model)]`) — the attribute applies the derive for you
+
 ### ❌ NEVER DO
-- Combine `#[model(...)]` with `#[derive(Model)]`
-- Initialize `#[model(...)]` structs via struct-literal syntax in production code
-- Re-implement validation logic that the macro already provides
+- Initialize `#[model(...)]` structs via struct-literal syntax in production code (use `new(...)`)
 
 ---
 

--- a/instructions/MACRO_USAGE.md
+++ b/instructions/MACRO_USAGE.md
@@ -1,0 +1,86 @@
+# Macro Usage Guidelines
+
+## Purpose
+
+This file defines the policy for using Reinhardt's procedural macros (notably `#[model(...)]`) consistently across the codebase.
+
+---
+
+## `#[model(...)]` Macro
+
+### MU-1 (MUST): Do Not Combine with `#[derive(Model)]`
+
+The `#[model(...)]` attribute macro automatically applies `#[derive(Model)]` internally. Combining the two produces duplicate derives and is rejected by the macro.
+
+**Rule:**
+- When using `#[model(...)]`, **do not** also write `#[derive(Model)]` on the same struct.
+- Add other derives that `#[model(...)]` does not provide via a separate `#[derive(...)]` (e.g., `Debug`, `Clone`, `serde::Serialize`).
+
+**Examples:**
+
+```rust
+// ✅ Correct
+#[model(table = "people")]
+#[derive(Debug, Clone)]
+pub struct Person {
+    pub id: i64,
+    pub name: String,
+}
+
+// ❌ Incorrect — duplicate Model derive
+#[model(table = "people")]
+#[derive(Debug, Clone, Model)]
+pub struct Person {
+    pub id: i64,
+    pub name: String,
+}
+```
+
+### MU-2 (MUST): Initialize via the Macro-Generated Constructor
+
+The `#[model(...)]` macro generates a `new(...)` associated function on the annotated struct. This generated constructor is the canonical initialization path.
+
+**Rule:**
+- Initialize `#[model(...)]` structs using the macro-generated `new(...)` function.
+- Do not initialize them via struct literals (`Person { id: 0, name: ... }`) when the macro-generated `new` is available.
+- Exception: Use struct literal syntax in tests *only when* the test specifically needs to bypass `new`'s validation (and document why with a comment).
+
+**Examples:**
+
+```rust
+// ✅ Correct — use macro-generated constructor
+let person = Person::new(1, "Alice".to_string());
+
+// ❌ Incorrect — bypasses macro-generated initialization
+let person = Person {
+    id: 1,
+    name: "Alice".to_string(),
+};
+```
+
+**Rationale:**
+- The generated `new` function applies any validation, defaulting, or invariant enforcement that the macro injects.
+- Direct struct-literal initialization can silently bypass these guarantees, leading to invalid model instances.
+- Centralizing initialization through `new` keeps call sites stable as the macro evolves.
+
+---
+
+## Quick Reference
+
+### ✅ MUST DO
+- Use `#[model(...)]` alone (do not also write `#[derive(Model)]`)
+- Initialize `#[model(...)]` structs via the macro-generated `new(...)` function
+- Add unrelated derives (e.g., `Debug`, `Clone`) via a separate `#[derive(...)]`
+
+### ❌ NEVER DO
+- Combine `#[model(...)]` with `#[derive(Model)]`
+- Initialize `#[model(...)]` structs via struct-literal syntax in production code
+- Re-implement validation logic that the macro already provides
+
+---
+
+## Related Documentation
+
+- **Module System**: instructions/MODULE_SYSTEM.md
+- **Anti-Patterns**: instructions/ANTI_PATTERNS.md
+- **Testing Standards**: instructions/TESTING_STANDARDS.md

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -161,28 +161,28 @@ gitGraph
 gh pr create --draft --title "feat(auth): add JWT validation (WIP)"
 ```
 
-### PC-4a (MUST): Draft PR Conversion Protection
+### PC-4a (MUST): Draft PR Conversion Readiness
 
-Converting a Draft PR to Ready for Review is a **visibility-affecting action** that exposes the PR to reviewers and triggers notifications. This conversion **MUST** require explicit user instruction.
+Converting a Draft PR to Ready for Review is a **review-readiness decision**. The agent MAY perform the conversion autonomously **once the PR meets readiness criteria** (i.e., it is in a state worth requesting Copilot Review). Explicit user instruction is also accepted at any time.
 
 **Rules:**
-- **NEVER** convert a Draft PR to Ready for Review without explicit user instruction
-- **Plan Mode approval does NOT authorize Draft PR conversion** (unlike commits/pushes)
-  - Rationale: Plan Mode authorizes *implementation work* (code changes, commits, pushes), but Draft PR conversion is a *review readiness decision* that only the user can make
-- Before converting, ensure all CI checks pass and tests pass locally
-- Use `gh pr ready <number>` for conversion
+- The agent MAY convert a Draft PR to Ready for Review when ALL readiness criteria below are satisfied
+- The agent MUST convert immediately when the user explicitly instructs it (regardless of CI state — the user accepts the trade-off)
+- The agent MUST NOT convert when any readiness criterion is unmet, unless the user explicitly overrides
+- Use `gh pr ready <number>` (or the equivalent GitHub MCP call) for conversion
 
-**Pre-Conversion Checklist:**
-- [ ] User has explicitly instructed conversion
-- [ ] All CI checks pass
-- [ ] All tests pass locally
-- [ ] PR description is complete and accurate
-- [ ] Code follows project style guidelines
-- [ ] Documentation is updated (if applicable)
+**Readiness Criteria (ALL must be true for autonomous conversion):**
+- [ ] Implementation is complete (no remaining `todo!()` or `// TODO:` introduced by this PR)
+- [ ] All CI checks pass on the latest commit
+- [ ] All relevant local tests pass (`cargo nextest run` for affected scope)
+- [ ] PR description follows the template and accurately reflects the diff
+- [ ] Code follows project style (`cargo make fmt-check` + `cargo make clippy-check` clean)
+- [ ] Documentation updated where applicable
+- [ ] PR is at a quality level worth submitting for Copilot Review
 
 **Example:**
 ```bash
-# Convert Draft PR to Ready for Review (ONLY after explicit user instruction)
+# Autonomous conversion once readiness criteria are met
 gh pr ready 123
 
 # Verify PR status after conversion
@@ -191,12 +191,12 @@ gh pr view 123 --json isDraft
 
 **Authorization Comparison:**
 
-| Action | Explicit Instruction | Plan Mode Approval |
-|--------|---------------------|-------------------|
-| Commit | ✅ Authorized | ✅ Authorized |
-| Push | ✅ Authorized | ✅ Authorized |
-| GitHub Comments | ✅ Authorized | ✅ Authorized |
-| Draft PR → Ready | ✅ Authorized | ❌ NOT Authorized |
+| Action | Explicit Instruction | Plan Mode Approval | Readiness Criteria Met |
+|--------|---------------------|-------------------|------------------------|
+| Commit | ✅ Authorized | ✅ Authorized | n/a |
+| Push | ✅ Authorized | ✅ Authorized | n/a |
+| GitHub Comments | ✅ Authorized | ✅ Authorized | n/a |
+| Draft PR → Ready | ✅ Authorized | ✅ Authorized (when readiness met) | ✅ Authorized |
 
 The following diagram illustrates the Draft PR lifecycle:
 
@@ -205,9 +205,9 @@ stateDiagram-v2
     [*] --> Draft: gh pr create --draft
     Draft --> Draft: Implementation continues
     Draft --> Draft: CI checks run
-    Draft --> ReadyForReview: User explicitly instructs conversion
-    note right of ReadyForReview: Requires explicit user instruction\nPlan Mode approval NOT sufficient
-    ReadyForReview --> Review: Reviewers notified
+    Draft --> ReadyForReview: Readiness criteria met OR user instructs
+    note right of ReadyForReview: Agent may convert autonomously\nonce ready for Copilot Review
+    ReadyForReview --> Review: Reviewers notified (incl. Copilot)
     Review --> Merged: Approved and merged
     Review --> Draft: Converted back to draft
     Merged --> [*]
@@ -814,7 +814,7 @@ docs(readme): add installation instructions
 - Address all review comments
 - Ensure all CI checks pass before merge
 - Use three-dot diff (`main...branch`) for PR verification to exclude merge history noise
-- Wait for explicit user instruction before converting Draft PRs to Ready for Review (Plan Mode approval does NOT authorize conversion)
+- Convert Draft PRs to Ready for Review autonomously once PC-4a readiness criteria are satisfied, OR upon explicit user instruction
 
 ### ❌ NEVER DO
 - Write PR titles or descriptions in non-English languages
@@ -827,7 +827,7 @@ docs(readme): add installation instructions
 - Force push after review has started (unless explicitly requested)
 - Use rebase or force-push to resolve PR conflicts (use worktree merge instead)
 - Use two-dot diff (`main..branch`) for PR verification (includes merge history noise)
-- Convert Draft PRs to Ready for Review without explicit user instruction (Plan Mode approval does NOT count)
+- Convert Draft PRs to Ready for Review while PC-4a readiness criteria are unmet (incomplete implementation, failing CI/tests, dirty fmt/clippy) without explicit user override
 
 ---
 

--- a/instructions/RESEARCH_ESCALATION.md
+++ b/instructions/RESEARCH_ESCALATION.md
@@ -1,0 +1,84 @@
+# Research Escalation Policy
+
+## Purpose
+
+This file defines when and how to escalate from local investigation to external research tools when troubleshooting or designing solutions. The goal is to avoid repeated unproductive attempts and to bring in authoritative external context promptly.
+
+---
+
+## RE-1 (MUST): Escalation Trigger
+
+If a problem is not resolved after **2 or more** unsuccessful improvement attempts (e.g., two distinct fixes that did not resolve the symptom), the agent **MUST** escalate to external research before further trial-and-error attempts.
+
+**What counts as an "attempt":**
+- A code change intended to fix the issue that did not resolve it
+- A configuration change intended to fix the issue that did not resolve it
+- A documented hypothesis tested and disproved
+
+**What does NOT count:**
+- Reading code or documentation
+- Running diagnostic commands without making changes
+
+---
+
+## RE-2 (MUST): Research Tool Order
+
+When escalating, use the following tool order:
+
+1. **Context7 / Fetch** (primary): Verify the current documentation of any library, framework, or tool involved. Cheaper and lower-latency than search engines.
+2. **Perplexity MCP** (preferred for research): Search with reasoning + citations. Use when documentation alone is insufficient or when the issue is not strictly a documentation gap.
+3. **Tavily MCP** (alternative): Use when Perplexity is unavailable or when broader coverage is needed.
+4. **Brave Search MCP** (fallback): Use when Perplexity and Tavily both fail to surface useful results, or for cross-checking citations.
+5. **Fetch MCP**: Always use to retrieve and verify the original text of any URL cited by a search result before relying on it.
+
+---
+
+## RE-3 (MUST): Information to Include in Research Queries
+
+When escalating, the research query MUST include:
+
+- **Symptoms**: The exact error message, failure mode, or unexpected behavior
+- **Constraints**: Project tech stack (Rust 2024, SeaQuery via `reinhardt-query`, TestContainers, etc.) and any environmental constraints (macOS, Docker not Podman, etc.)
+- **Attempts**: A summary of the 2+ attempts already tried
+- **Reasons attempts failed**: What evidence ruled each attempt out
+
+This structure prevents the research tool from suggesting solutions already disproved.
+
+---
+
+## RE-4 (SHOULD): Persist Findings
+
+After a successful escalation:
+
+- Save authoritative findings (root cause, working fix, citations) to **serena memory** when the knowledge will likely apply to future work
+- For project-specific decisions (architecture, library trade-offs), prefer GitWhy via `gitwhy_save` so the reasoning is captured alongside the commit
+- Verify URLs cited by Perplexity/Tavily/Brave by fetching the original source before relying on them
+
+---
+
+## RE-5 (SHOULD): Use Sequential Thinking for Complex Problems
+
+For multi-step problems where the failure is unclear or the solution space is large, use the `sequentialThinking` MCP tool to externalize reasoning steps before further trial-and-error.
+
+---
+
+## Quick Reference
+
+### ✅ MUST DO
+- Escalate to external research after 2 failed improvement attempts
+- Include symptoms, constraints, attempts, and failure reasons in research queries
+- Verify citation URLs via Fetch before acting on search results
+- Try Context7/Fetch first, then Perplexity, then Tavily, then Brave Search
+
+### ❌ NEVER DO
+- Continue trial-and-error past 2 failed attempts without external research
+- Trust search-tool summaries without verifying the original source
+- Skip recording authoritative findings that future sessions will need
+
+---
+
+## Related Documentation
+
+- **Issue Handling**: instructions/ISSUE_HANDLING.md
+- **Upstream Issue Reporting**: instructions/UPSTREAM_ISSUE_REPORTING.md
+- **GitHub Interaction**: instructions/GITHUB_INTERACTION.md


### PR DESCRIPTION
## Summary

Restructure project policy documentation in CLAUDE.md, CLAUDE.local.md (local-only), and the `instructions/` directory.

- Redirect SQL construction guidance from SeaQuery to the in-house `reinhardt-query` wrapper
- Replace the strict "explicit-instruction-only" Draft PR conversion rule with a readiness-based PC-4a (Copilot Review readiness)
- Make GitHub MCP the default and `gh` CLI the documented fallback
- Promote three previously local rules into shared `instructions/` files: `MACRO_USAGE.md`, `RESEARCH_ESCALATION.md`, and `COMMIT_GUIDELINE.md` CE-4a
- (Local-only, not in this PR) Trim CLAUDE.local.md by removing migrated rules and the now-redundant Agent Team / always-ultrathink lines

## Type of Change

- [x] Documentation (no code/runtime changes)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Motivation and Context

CLAUDE.md and CLAUDE.local.md had drifted: several stable rules were trapped in CLAUDE.local.md (per-machine, gitignored) and not visible to other contributors or CI; the Draft PR rule was overly strict and forced an unnecessary user round-trip when Copilot Review was already warranted; and the SeaQuery references no longer reflected the reality that we use the in-house `reinhardt-query` wrapper.

This PR consolidates shared rules into versioned `instructions/` files and aligns the policies with how the project is actually run today.

## How Was This Tested

- [x] `git diff main...HEAD` reviewed for accuracy
- [x] All cross-references between CLAUDE.md and `instructions/*.md` verified
- [x] No code changes; CI is expected to be green for docs-only diff

## Per-Commit Breakdown

| # | Commit | Files |
|---|--------|-------|
| 1 | `docs: redirect SQL construction guidance to reinhardt-query` | CLAUDE.md, instructions/GITHUB_INTERACTION.md, instructions/ISSUE_GUIDELINES.md |
| 2 | `docs(pr-policy): allow autonomous draft pr conversion when readiness criteria met` | CLAUDE.md, instructions/PR_GUIDELINE.md (PC-4a) |
| 3 | `docs: make github mcp the default and gh cli the fallback` | CLAUDE.md |
| 4 | `docs: add macro usage guideline for #[model(...)]` | CLAUDE.md, instructions/MACRO_USAGE.md (new) |
| 5 | `docs: add research escalation policy` | CLAUDE.md, instructions/RESEARCH_ESCALATION.md (new) |
| 6 | `docs(commit): exclude superpowers and agent runtime artifacts from commits` | CLAUDE.md, instructions/COMMIT_GUIDELINE.md (CE-4a) |

## Notable Policy Changes

**PC-4a — Draft PR Conversion Readiness (REVERSAL):**
Previously: agent must NEVER convert a Draft PR to Ready without explicit user instruction; Plan Mode approval was explicitly NOT sufficient.
Now: agent MAY convert autonomously once readiness criteria are met (implementation complete, CI green, tests pass, fmt/clippy clean, description follows template) — i.e., once the PR is worth submitting for Copilot Review. Explicit user instruction still authorizes conversion at any time and overrides the readiness check.

**RE-1 — Research Escalation Threshold (TIGHTENED):**
Previously (local rule): escalate to Perplexity after 3 unsuccessful attempts.
Now (shared rule): escalate to Context7/Fetch then Perplexity/Tavily/Brave after 2 unsuccessful attempts, with a structured query template and citation-verification requirement.

**GitHub Integration (REORDERED):**
Previously: "MUST use GitHub CLI (`gh`) for all GitHub operations" with MCP as alternative.
Now: GitHub MCP is the default; `gh` CLI is the explicit fallback when MCP is unavailable, errors out, or lacks the capability. Includes an MCP↔CLI mapping table.

## Out of Scope (Follow-up Work)

- Source code comments in `crates/` that still mention SeaQuery directly are unchanged. They likely refer to the underlying library through `reinhardt-query`'s wrapper, but verifying and migrating them is a separate code-level task.
- CHANGELOG and `announcements/` historical references to SeaQuery are immutable and intentionally untouched.

## Checklist

- [x] PR follows Conventional Commits format
- [x] All commits follow Conventional Commits (one specific intent each)
- [x] Documentation cross-references verified
- [x] No source-code or build-config changes
- [x] No CI/CD pipeline changes
- [x] PR is draft until reviewer is ready

## Labels to Apply

- `documentation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
