### PR TITLE
fix(commands): rebuild stale wasm bundle in runserver

### DIFF
--- a/crates/reinhardt-commands/src/bin/runserver.rs
+++ b/crates/reinhardt-commands/src/bin/runserver.rs
@@ -15,7 +15,9 @@ use hyper::{Request, Response, StatusCode, body::Incoming};
 use hyper_util::rt::TokioIo;
 use reinhardt_commands::WelcomePage;
 use reinhardt_commands::{CollectStaticCommand, CollectStaticOptions};
-use reinhardt_commands::{WasmBuildConfig, WasmBuilder, detect_cdylib_in_cargo_toml};
+use reinhardt_commands::{
+	WasmBuildConfig, WasmBuilder, detect_cdylib_in_cargo_toml, is_wasm_stale,
+};
 use reinhardt_pages::component::Component;
 use reinhardt_pages::ssr::SsrRenderer;
 use reinhardt_utils::safe_path_join;
@@ -73,11 +75,12 @@ struct Args {
 	#[arg(long)]
 	self_signed: bool,
 
-	/// Skip WASM builds at startup
+	/// Skip WASM builds at startup (also skips staleness checks; existing artifacts
+	/// are served as-is regardless of source changes).
 	#[arg(long)]
 	no_wasm: bool,
 
-	/// Force rebuild WASM even if artifacts exist
+	/// Force rebuild WASM even when artifacts are up-to-date relative to sources.
 	#[arg(long)]
 	force_wasm: bool,
 
@@ -437,6 +440,10 @@ fn generate_random_secret_key() -> String {
 
 /// Build the admin WASM bundle from the reinhardt-admin crate.
 ///
+/// Skips the build only when the existing `_bg.wasm` artifact is newer than every
+/// tracked source file in the admin crate (mtime-based staleness check). See
+/// [`build_pages_wasm`] for the rationale (issue #4127).
+///
 /// Returns `true` if the build succeeded or was skipped, `false` on failure.
 #[cfg(feature = "admin")]
 fn build_admin_wasm(force: bool) -> bool {
@@ -454,16 +461,23 @@ fn build_admin_wasm(force: bool) -> bool {
 
 	let artifact = admin_crate_dir
 		.join("dist-admin")
-		.join("reinhardt_admin.js");
-	if artifact.exists() && !force {
+		.join("reinhardt_admin_bg.wasm");
+	if !force && !is_wasm_stale(&admin_crate_dir, &artifact) {
 		println!(
 			"{}",
-			"Admin WASM: artifacts exist, skipping build (use --force-wasm to rebuild)".dimmed()
+			"Admin WASM: artifacts up to date, skipping build".dimmed()
 		);
 		return true;
 	}
 
-	println!("{}", "Building admin WASM...".cyan());
+	let reason = if force {
+		"forced rebuild"
+	} else if artifact.exists() {
+		"source changed since last build"
+	} else {
+		"no existing artifact"
+	};
+	println!("{}", format!("Building admin WASM ({})...", reason).cyan());
 	let config = WasmBuildConfig::new(&admin_crate_dir)
 		.output_dir("dist-admin")
 		.target_name("reinhardt-admin");
@@ -483,6 +497,15 @@ fn build_admin_wasm(force: bool) -> bool {
 }
 
 /// Build the pages WASM bundle from the current project (if it declares cdylib).
+///
+/// Staleness handling:
+/// - If `dist/<crate>_bg.wasm` is missing or older than any tracked source file
+///   (every `.rs` under `src/` plus `Cargo.toml`), the bundle is rebuilt.
+/// - If the artifact is newer than every source file, the build is skipped.
+/// - When `force` is `true`, the artifact is always rebuilt regardless of mtimes.
+///
+/// This guards against the dev-loop hazard where stale `dist/` content is served
+/// after the developer edits Rust source — see issue #4127.
 ///
 /// Returns `true` if the build succeeded or was skipped, `false` on failure or if the
 /// current project is not a cdylib.
@@ -538,18 +561,25 @@ fn build_pages_wasm(force: bool) -> bool {
 	};
 
 	let js_name = crate_name.replace('-', "_");
-	let artifact = cwd.join("dist").join(format!("{}.js", js_name));
-	if artifact.exists() && !force {
+	let artifact = cwd.join("dist").join(format!("{}_bg.wasm", js_name));
+	if !force && !is_wasm_stale(&cwd, &artifact) {
 		println!(
 			"{}",
-			"Pages WASM: artifacts exist, skipping build (use --force-wasm to rebuild)".dimmed()
+			"Pages WASM: artifacts up to date, skipping build".dimmed()
 		);
 		return true;
 	}
 
+	let reason = if force {
+		"forced rebuild"
+	} else if artifact.exists() {
+		"source changed since last build"
+	} else {
+		"no existing artifact"
+	};
 	println!(
 		"{}",
-		format!("Building pages WASM for {}...", crate_name).cyan()
+		format!("Building pages WASM for {} ({})...", crate_name, reason).cyan()
 	);
 	// Resolve workspace root so wasm-bindgen finds the artifact in the
 	// workspace-level target directory, not relative to the member crate CWD.

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -211,7 +211,8 @@ pub use start_commands::{StartAppCommand, StartProjectCommand};
 pub use template::{TemplateCommand, TemplateContext, generate_secret_key, to_camel_case};
 pub use wasm_builder::{
 	WasmBuildConfig, WasmBuildError, WasmBuildOutput, WasmBuilder, check_wasm_tools_installed,
-	detect_cdylib_in_cargo_toml, detect_cdylib_in_cargo_toml_content,
+	detect_cdylib_in_cargo_toml, detect_cdylib_in_cargo_toml_content, is_wasm_stale,
+	latest_source_mtime,
 };
 pub use welcome_page::WelcomePage;
 

--- a/crates/reinhardt-commands/src/wasm_builder.rs
+++ b/crates/reinhardt-commands/src/wasm_builder.rs
@@ -6,6 +6,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::SystemTime;
 
 /// Configuration for WASM builds.
 #[derive(Debug, Clone)]
@@ -418,6 +419,70 @@ pub fn detect_cdylib_in_cargo_toml(path: &Path) -> bool {
 		.unwrap_or(false)
 }
 
+/// Returns the most recent modification time among the WASM crate's tracked
+/// source files: every `.rs` under `<crate_dir>/src/` (recursive) and
+/// `<crate_dir>/Cargo.toml`.
+///
+/// Returns `None` if neither `src/` nor `Cargo.toml` is readable.
+pub fn latest_source_mtime(crate_dir: &Path) -> Option<SystemTime> {
+	let mut latest: Option<SystemTime> = None;
+	let mut update = |t: SystemTime| {
+		latest = Some(latest.map_or(t, |l| l.max(t)));
+	};
+
+	if let Ok(meta) = std::fs::metadata(crate_dir.join("Cargo.toml"))
+		&& let Ok(mtime) = meta.modified()
+	{
+		update(mtime);
+	}
+
+	let src = crate_dir.join("src");
+	let mut stack = vec![src];
+	while let Some(dir) = stack.pop() {
+		let entries = match std::fs::read_dir(&dir) {
+			Ok(e) => e,
+			Err(_) => continue,
+		};
+		for entry in entries.flatten() {
+			let path = entry.path();
+			let file_type = match entry.file_type() {
+				Ok(t) => t,
+				Err(_) => continue,
+			};
+			if file_type.is_dir() {
+				stack.push(path);
+			} else if file_type.is_file()
+				&& path.extension().and_then(|e| e.to_str()) == Some("rs")
+				&& let Ok(meta) = entry.metadata()
+				&& let Ok(mtime) = meta.modified()
+			{
+				update(mtime);
+			}
+		}
+	}
+
+	latest
+}
+
+/// Returns `true` if the WASM bundle at `artifact` is missing or older than
+/// any tracked source file under `crate_dir` (see [`latest_source_mtime`]).
+///
+/// On any failure to read metadata, the function returns `true` (rebuild)
+/// to fail safely toward freshness rather than serving a potentially stale
+/// bundle.
+pub fn is_wasm_stale(crate_dir: &Path, artifact: &Path) -> bool {
+	let Ok(artifact_meta) = std::fs::metadata(artifact) else {
+		return true;
+	};
+	let Ok(artifact_mtime) = artifact_meta.modified() else {
+		return true;
+	};
+	match latest_source_mtime(crate_dir) {
+		Some(src_mtime) => src_mtime > artifact_mtime,
+		None => true,
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -480,5 +545,101 @@ name = "my-app"
 version = "0.1.0"
 "#;
 		assert!(!detect_cdylib_in_cargo_toml_content(content));
+	}
+
+	mod staleness {
+		use super::*;
+		use std::fs::{self, File};
+		use std::time::Duration;
+
+		// Build a minimal cdylib-like crate layout under `dir`:
+		//   <dir>/Cargo.toml
+		//   <dir>/src/lib.rs
+		//   <dir>/src/nested/mod_a.rs
+		// Returns the crate directory.
+		fn make_crate(dir: &Path) -> PathBuf {
+			fs::create_dir_all(dir.join("src/nested")).unwrap();
+			fs::write(dir.join("Cargo.toml"), b"[package]\nname=\"x\"\n").unwrap();
+			fs::write(dir.join("src/lib.rs"), b"// lib").unwrap();
+			fs::write(dir.join("src/nested/mod_a.rs"), b"// nested").unwrap();
+			dir.to_path_buf()
+		}
+
+		fn set_mtime(path: &Path, t: SystemTime) {
+			let f = File::options().write(true).open(path).unwrap();
+			f.set_modified(t).unwrap();
+		}
+
+		#[test]
+		fn returns_true_when_artifact_missing() {
+			let tmp = tempfile::tempdir().unwrap();
+			let crate_dir = make_crate(tmp.path());
+			let artifact = crate_dir.join("dist/x_bg.wasm");
+			// Arrange: artifact does not exist.
+			// Act + Assert
+			assert!(is_wasm_stale(&crate_dir, &artifact));
+		}
+
+		#[test]
+		fn returns_false_when_artifact_newer_than_sources() {
+			let tmp = tempfile::tempdir().unwrap();
+			let crate_dir = make_crate(tmp.path());
+			let dist = crate_dir.join("dist");
+			fs::create_dir_all(&dist).unwrap();
+			let artifact = dist.join("x_bg.wasm");
+			fs::write(&artifact, b"\0asm").unwrap();
+
+			let base = SystemTime::now() - Duration::from_secs(120);
+			set_mtime(&crate_dir.join("Cargo.toml"), base);
+			set_mtime(&crate_dir.join("src/lib.rs"), base);
+			set_mtime(&crate_dir.join("src/nested/mod_a.rs"), base);
+			set_mtime(&artifact, base + Duration::from_secs(60));
+
+			assert!(!is_wasm_stale(&crate_dir, &artifact));
+		}
+
+		#[test]
+		fn returns_true_when_source_newer_than_artifact() {
+			let tmp = tempfile::tempdir().unwrap();
+			let crate_dir = make_crate(tmp.path());
+			let dist = crate_dir.join("dist");
+			fs::create_dir_all(&dist).unwrap();
+			let artifact = dist.join("x_bg.wasm");
+			fs::write(&artifact, b"\0asm").unwrap();
+
+			let base = SystemTime::now() - Duration::from_secs(120);
+			set_mtime(&crate_dir.join("Cargo.toml"), base);
+			set_mtime(&crate_dir.join("src/lib.rs"), base);
+			set_mtime(&artifact, base);
+			// One nested source is newer than the artifact.
+			set_mtime(
+				&crate_dir.join("src/nested/mod_a.rs"),
+				base + Duration::from_secs(60),
+			);
+
+			assert!(is_wasm_stale(&crate_dir, &artifact));
+		}
+
+		#[test]
+		fn treats_cargo_toml_changes_as_stale() {
+			let tmp = tempfile::tempdir().unwrap();
+			let crate_dir = make_crate(tmp.path());
+			let dist = crate_dir.join("dist");
+			fs::create_dir_all(&dist).unwrap();
+			let artifact = dist.join("x_bg.wasm");
+			fs::write(&artifact, b"\0asm").unwrap();
+
+			let base = SystemTime::now() - Duration::from_secs(120);
+			set_mtime(&crate_dir.join("src/lib.rs"), base);
+			set_mtime(&crate_dir.join("src/nested/mod_a.rs"), base);
+			set_mtime(&artifact, base);
+			// Cargo.toml updated after artifact (e.g. dependency bump).
+			set_mtime(
+				&crate_dir.join("Cargo.toml"),
+				base + Duration::from_secs(60),
+			);
+
+			assert!(is_wasm_stale(&crate_dir, &artifact));
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Replace the artifact-existence check in `runserver`'s `build_pages_wasm` (and `build_admin_wasm`) with an mtime-based staleness check
- Add `latest_source_mtime` / `is_wasm_stale` helpers that compare the `<crate>_bg.wasm` artifact mtime against every `.rs` under `src/` plus `Cargo.toml`
- Watch the actual wasm binary (`_bg.wasm`) instead of the JS shim (`.js`) so the staleness signal matches what the browser loads

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`runserver --with-pages` previously skipped the wasm rebuild whenever the build artifact merely existed, regardless of whether Rust source had changed since. Developers iterating on the SPA layer would unknowingly serve a stale `dist/<crate>_bg.wasm` and chase "ghosts" of bugs that had already been fixed.

This was the documented root cause of the false-positive in #4122 (an Apr-4 `dist/` was being served against May-3 main HEAD). The fix replaces the existence check with a fail-safe mtime comparison so the dev loop is no longer dependent on the developer remembering to wipe `dist/`.

`--force-wasm` still forces a rebuild; `--no-wasm` still skips entirely (its help text now documents that staleness checks are also skipped).

## How Was This Tested

- New unit tests under `wasm_builder::tests::staleness` cover: missing artifact, source newer than artifact, artifact newer than sources, `Cargo.toml` change as a stale signal (4/4 passing locally)
- `cargo check -p reinhardt-commands --all-features` clean
- `cargo clippy -p reinhardt-commands --all-features --tests` produced no new warnings on the touched files

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- `bug`

## Related Issues

Fixes #4127
Refs #4122

🤖 Generated with [Claude Code](https://claude.com/claude-code)