### PR TITLE
fix(macros): emit per-app client URL accessors on wasm32

### DIFF
--- a/crates/reinhardt-core/macros/src/macro_state.rs
+++ b/crates/reinhardt-core/macros/src/macro_state.rs
@@ -64,13 +64,3 @@ pub(crate) fn read_installed_apps() -> Result<Vec<String>, String> {
 		.map(|line| line.to_string())
 		.collect())
 }
-
-/// Returns true if the current compilation target is WASM.
-///
-/// Checks `CARGO_CFG_TARGET_FAMILY` and `CARGO_CFG_TARGET_OS` environment
-/// variables set by Cargo during crate compilation.
-pub(crate) fn is_wasm_target() -> bool {
-	let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default();
-	let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-	family == "wasm" && os == "unknown"
-}

--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -469,10 +469,14 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 	// This replaces the __reinhardt_for_each_app callback pattern that triggers
 	// macro_expanded_macro_exports_accessed_by_absolute_paths on Rust 1.94+.
 	// Fixes #3639.
-	let url_prelude_code = if standalone || crate::macro_state::is_wasm_target() {
+	let url_prelude_code = if standalone {
 		// Standalone mode: projects that don't use installed_apps!.
-		// WASM target: URL resolvers are native-only; skip reading the state file
-		// to avoid failures when installed_apps! hasn't written it for WASM builds.
+		// Note: wasm targets are no longer skipped here. Server / ws resolver
+		// blocks inside the generated tokens are individually gated with
+		// `#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]`,
+		// while the client-side `__client_router_gate` block emits
+		// unconditionally so that `urls.client().<app>().<route>()` typed
+		// accessors compile on `wasm32-unknown-unknown`. Fixes #4119.
 		quote! {}
 	} else {
 		let app_labels = match crate::macro_state::read_installed_apps() {

--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -36,11 +36,25 @@ use syn::{ItemFn, parse2};
 ///
 /// Produces a `macro_rules!` definition that iterates over `meta_idents`,
 /// invoking `$base :: $meta_ident ! ($callback, $app)` for each.
-/// This pattern is shared by server (`__for_each_url_resolver`) and
-/// client (`__for_each_client_url_resolver`) modes.
-fn gen_for_each_macro(macro_name: &proc_macro2::Ident, meta_idents: &[syn::Ident]) -> TokenStream {
+///
+/// `native_only` controls whether the emitted macro is gated to non-wasm
+/// targets. Server (`__for_each_url_resolver`) and ws
+/// (`__for_each_ws_url_resolver`) modes are native-only because they depend on
+/// `ServerRouter`. Client (`__for_each_client_url_resolver`) mode must be
+/// available on wasm so that `urls.client().<app>().<route>()` typed accessors
+/// can be generated for SPA targets (issue #4119).
+fn gen_for_each_macro(
+	macro_name: &proc_macro2::Ident,
+	meta_idents: &[syn::Ident],
+	native_only: bool,
+) -> TokenStream {
+	let gate = if native_only {
+		quote! { #[cfg(not(all(target_family = "wasm", target_os = "unknown")))] }
+	} else {
+		quote! {}
+	};
 	quote! {
-		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+		#gate
 		macro_rules! #macro_name {
 			($callback:ident, $app:ident, $($base:tt)+) => {
 				#(
@@ -48,7 +62,7 @@ fn gen_for_each_macro(macro_name: &proc_macro2::Ident, meta_idents: &[syn::Ident
 				)*
 			};
 		}
-		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+		#gate
 		pub(crate) use #macro_name;
 	}
 }
@@ -564,6 +578,7 @@ fn build_server_resolvers(body_tokens: &[proc_macro2::TokenTree]) -> TokenStream
 	let for_each_resolver_macro = gen_for_each_macro(
 		&syn::Ident::new("__for_each_url_resolver", proc_macro2::Span::call_site()),
 		&meta_idents,
+		true,
 	);
 
 	quote! {
@@ -641,19 +656,23 @@ fn build_client_resolvers(body_tokens: &[proc_macro2::TokenTree]) -> syn::Result
 		meta_idents.push(meta_macro_ident);
 	}
 
+	// Client resolvers are cross-target (native + wasm) so that
+	// `urls.client().<app>().<route>()` typed accessors compile on
+	// `wasm32-unknown-unknown`. Server / ws resolvers stay native-only.
+	// Fixes #4119.
 	let for_each_client_resolver_macro = gen_for_each_macro(
 		&syn::Ident::new(
 			"__for_each_client_url_resolver",
 			proc_macro2::Span::call_site(),
 		),
 		&meta_idents,
+		false,
 	);
 
 	Ok(quote! {
 		#[doc(hidden)]
 		pub mod client_url_resolvers {
 			#(
-				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 				#meta_macro_defs
 			)*
 
@@ -814,6 +833,7 @@ fn build_ws_resolvers(body_tokens: &[proc_macro2::TokenTree]) -> TokenStream {
 	let for_each_macro = gen_for_each_macro(
 		&syn::Ident::new("__for_each_ws_url_resolver", proc_macro2::Span::call_site()),
 		&meta_idents,
+		true,
 	);
 
 	quote! {


### PR DESCRIPTION
## Summary

- Make per-app typed URL accessors (`urls.client().<app>().<route>()`) emit on `wasm32-unknown-unknown` so cross-target SPA call sites compile against a single source of truth.
- Drop the proc-macro-time `is_wasm_target()` gate in `#[routes]`; rely on the inline `#[cfg(not(wasm))]` attributes already present in the generated tokens to keep server / ws machinery native-only.
- Make `client_url_resolvers` (`__for_each_client_url_resolver` + meta macros) cross-target by parameterizing `gen_for_each_macro` with `native_only`; server / ws variants stay gated to native.
- Remove the now-unused `is_wasm_target()` helper.

Fixes #4119

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`#[routes]` skipped per-app URL accessor generation on wasm via the comment "*URL resolvers are native-only*". The gate was overly broad: `installed_apps!` writes its state file unconditionally, and the client-side `__client_router_gate` block in the generated tokens is already cross-target. Only server / ws URL machinery actually depend on `ServerRouter` and need to stay native-only.

Downstream consumers (reinhardt-cloud PR #528 dashboard migration to `ResolvedUrls::from_global().client().<app>().<route>()`) cannot use the typed accessor as a single source of truth across SSR + SPA — every cross-target file fails to compile on `wasm32-unknown-unknown` with E0433s pointing at the surrounding module path rather than the actually-missing per-app method.

## How Was This Tested

- [x] `cargo check -p reinhardt-macros` (native)
- [x] `cargo nextest run -p reinhardt-macros` — 190/190 passing (UI tests + integration)
- [x] `cargo clippy -p reinhardt-macros --all-targets -- -D warnings` clean
- [x] `cargo fmt -p reinhardt-macros --check` clean
- [x] `cargo nextest run -p reinhardt-integration-tests --test client_router_typed_url_integration` — compiles cleanly (existing `urls.client().<app>()` test surface)
- [x] `cargo check --target wasm32-unknown-unknown --lib` on `examples-tutorial-basis` (exercises `installed_apps!` + `#[routes]`)
- [x] `cargo check --target wasm32-unknown-unknown -p reinhardt-pages --tests`

End-to-end wasm verification of the new per-app client accessor surface will land via the downstream reinhardt-cloud PR #528 build (cited in the issue).

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- `bug` — fixes a regression in cross-target macro emission

## Related Issues

Fixes #4119
Refs kent8192/reinhardt-cloud#519, kent8192/reinhardt-cloud#528, kent8192/reinhardt-cloud#533

🤖 Generated with [Claude Code](https://claude.com/claude-code)