### PR TITLE
ci: install wasm-pack in intra-crate integration tests

### DIFF
--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -110,6 +110,15 @@ jobs:
         with:
           tool: nextest
 
+      # Required by Tier 3 E2E tests (e.g. spa_navigation_full_layout_e2e in
+      # crates/reinhardt-pages) which build a fixture WASM bundle via
+      # `wasm-pack build`. The test refuses to skip silently when CI=true.
+      # Tracked in #4134.
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
       - name: Pull Docker images
         uses: ./.github/actions/pull-docker-images
         with:


### PR DESCRIPTION
## Summary

- Add a `wasm-pack` install step to `.github/workflows/intra-crate-integration-test.yml` so the Tier 3 E2E test `spa_navigation_full_layout_e2e` can build its fixture WASM bundle.

Fixes #4134

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The Tier 3 E2E test `spa_navigation_full_layout_e2e` (added in #4129) is intentionally designed to refuse silent skipping when `wasm-pack` is missing on PATH and `CI=true` — preventing the e2e regression net from being silently disabled. However, the `Intra-Crate Integration Tests` workflow does not install `wasm-pack`, so partition 8/8 fails on every PR built on current `main` (e.g. PR #4132).

Other workflows (`wasm-check.yml`, `examples-test.yml`) already install `wasm-pack`; this change brings the intra-crate workflow in line.

The fix is intentionally minimal and CI-only; the test design (loud failure when misconfigured) is preserved.

## How Was This Tested

- [x] Confirmed that PR #4132 (and any other PR off current main) fails with the documented panic, and the only missing piece is the `wasm-pack` install step.
- [ ] Will be confirmed once this PR's `Intra-Crate Integration Tests (8/8)` job passes.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (no source code changed)

## Labels to Apply

- `bug` — fixes a CI regression that blocks all PRs
- `ci-cd` — workflow change

## Related Issues

Fixes #4134
Refs #4129 (introduced the test), #4132 (first observed failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)