### PR TITLE
ci(packer): prebake cargo-make into aarch64 AMI (Stage A)

### DIFF
--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -159,6 +159,42 @@ build {
 		]
 	}
 
+	# -- cargo-make (aarch64-only prebake; workaround for missing upstream artifact) ---
+	#
+	# Workaround for sagiegurari/cargo-make#1327 (tracked in reinhardt-web#4133).
+	# `taiki-e/install-action` has no `aarch64_linux` entry for cargo-make in its
+	# manifest because upstream does not publish an aarch64-linux prebuilt binary,
+	# so it falls back to `cargo binstall` and emits a `::warning::` on every job.
+	# Prebaking cargo-make into the AMI avoids that runtime install entirely on
+	# self-hosted aarch64 runners; CI workflows skip the install-action step when
+	# `cargo-make` is already on PATH (separate Stage B PR).
+	#
+	# Remove this provisioner once cargo-make publishes aarch64-linux artifacts
+	# AND `taiki-e/install-action`'s manifest covers `aarch64_linux`.
+	#
+	# Ideal implementation (without workaround):
+	#   (no provisioner; let `taiki-e/install-action` install cargo-make at job time)
+	provisioner "shell" {
+		execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+		environment_vars = [
+			"RUNNER_ARCH=${var.runner_arch}",
+		]
+		inline = [
+			"if [ \"$${RUNNER_ARCH}\" != \"arm64\" ]; then",
+			"  echo \"Skipping cargo-make prebake on x64 (install-action has prebuilt for x86_64-linux)\"",
+			"  exit 0",
+			"fi",
+			"CARGO_MAKE_VERSION=0.37.24",
+			# Install rustup + stable toolchain temporarily (minimal profile, no docs/components)
+			"su - ubuntu -c 'curl --proto =https --tlsv1.2 -sSfL https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal'",
+			"su - ubuntu -c \"~/.cargo/bin/cargo install --locked cargo-make@$${CARGO_MAKE_VERSION}\"",
+			"cp /home/ubuntu/.cargo/bin/cargo-make /usr/local/bin/cargo-make",
+			"chmod 0755 /usr/local/bin/cargo-make",
+			# Verify installation succeeded before AMI snapshot
+			"/usr/local/bin/cargo-make --version",
+		]
+	}
+
 	# -- AWS CLI v2 (architecture-aware) --------------------------------------
 	provisioner "shell" {
 		execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"


### PR DESCRIPTION
## Summary

- Add a Packer provisioner that prebakes `cargo-make@0.37.24` into the self-hosted aarch64 AMI, eliminating the `cargo-make@latest for 'aarch64_linux' is not supported; fallback to cargo-binstall` warning emitted on every self-hosted Graviton CI job
- Provisioner is a no-op on x64 builds (install-action already has an x86_64-linux-musl prebuilt for cargo-make)
- This is **Stage A** of a two-stage rollout. Stage B (workflow `if:` guards) is a separate PR after AMI deploy

**Draft until** the user is ready to deploy: AMI rebuild requires `gh workflow run build-runner-ami.yml -f architecture=arm64 -f force_rebuild=true` and consumes AWS resources, so leaving as draft so the user can decide rebuild timing.

## Type of Change

- [x] CI/CD update (infrastructure provisioner)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Motivation and Context

`taiki-e/install-action`'s manifest [`cargo-make.json`](https://github.com/taiki-e/install-action/blob/main/manifests/cargo-make.json) has these entries for the latest `cargo-make` 0.37.24:

- `x86_64_linux_musl`
- `x86_64_macos`
- `x86_64_windows`
- `aarch64_macos`

…and **no `aarch64_linux`** because cargo-make upstream doesn't publish an aarch64-unknown-linux-gnu prebuilt artifact ([sagiegurari/cargo-make#1327](https://github.com/sagiegurari/cargo-make/issues/1327)). Without that manifest entry, install-action falls through to `cargo binstall` and emits a workflow `::warning::` on every job. On our self-hosted Graviton fleet this fires 14 times per CI run.

Prebaking cargo-make into the AMI sidesteps the install entirely on aarch64. The build instance bootstraps rustup once during AMI build (~3 min added to the weekly Packer build), so per-CI-job overhead is zero.

## Changes

`infra/github-runners/packer/reinhardt-runner.pkr.hcl` — add one provisioner block after the existing protoc one (36 line additions, no deletions):

```hcl
# -- cargo-make (aarch64-only prebake; workaround for missing upstream artifact) ---
#
# Workaround for sagiegurari/cargo-make#1327 (tracked in reinhardt-web#4133).
# ...
provisioner "shell" {
  execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
  environment_vars = ["RUNNER_ARCH=${var.runner_arch}"]
  inline = [
    "if [ \"$${RUNNER_ARCH}\" != \"arm64\" ]; then",
    "  echo \"Skipping cargo-make prebake on x64 (install-action has prebuilt for x86_64-linux)\"",
    "  exit 0",
    "fi",
    "CARGO_MAKE_VERSION=0.37.24",
    "su - ubuntu -c 'curl --proto =https --tlsv1.2 -sSfL https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal'",
    "su - ubuntu -c \"~/.cargo/bin/cargo install --locked cargo-make@$${CARGO_MAKE_VERSION}\"",
    "cp /home/ubuntu/.cargo/bin/cargo-make /usr/local/bin/cargo-make",
    "chmod 0755 /usr/local/bin/cargo-make",
    "/usr/local/bin/cargo-make --version",
  ]
}
```

The block follows the existing protoc / awscli / cloudwatch-agent provisioner pattern (sudo sh -c, environment_vars, inline array). Tab indentation matches the rest of the file.

## How Was This Tested

- Visual diff verified: 36 inserts only, no other modifications, brackets balanced, tab indentation consistent
- HCL syntax: parsed successfully (manual structural review; `packer` not installed locally, full validation deferred to AMI rebuild step)
- Architecture guard: when `RUNNER_ARCH != arm64`, the provisioner echoes a skip message and exits 0; only the arm64 build path executes the rustup + cargo install steps
- The script verifies `cargo-make --version` before the AMI snapshot, so a corrupt install fails the AMI build instead of CI runtime

## Deploy Plan (post-merge, manual)

1. Merge this PR
2. Trigger AMI rebuild: `gh workflow run build-runner-ami.yml -f architecture=arm64 -f force_rebuild=true`
3. Wait for the workflow to complete; it updates SSM `/reinhardt-ci/runner-ami-id` automatically
4. Probe-PR verification: open a no-op PR and confirm `which cargo-make` resolves to `/usr/local/bin/cargo-make` and `cargo-make --version` prints `0.37.24` on a self-hosted aarch64 job
5. Open Stage B PR: add `if:` guards to skip `taiki-e/install-action` (cargo-make) on self-hosted aarch64 in the 14 affected workflows

## Checklist

- [x] My code follows the project's coding standards
- [x] I have linked this PR to the related issue (#4133)
- [x] I have used a descriptive PR title following Conventional Commits
- [x] Workaround comment includes upstream issue reference, ideal implementation, and removal condition (per CLAUDE.md UR-4 / WP-3)

## Labels to Apply

- `enhancement`
- `ci-cd`
- `upstream-tracking`
- `infrastructure`
- `medium`

## Risks

- AMI build time grows by ~3 minutes (one-time per build, weekly cadence) due to rustup + cargo install --locked cargo-make. Acceptable.
- If `cargo install` fails on the build instance (e.g., MSRV drift on stable toolchain or transient network issue), Packer aborts and the AMI build fails — caught at AMI build time, not CI runtime. The pinned version (`0.37.24`) makes this stable.
- Bumping `cargo-make` requires updating the pin and rebuilding the AMI, but does not require workflow changes since the binary stays on `/usr/local/bin`.

## Removal Condition

Tracked in #4133: remove this provisioner once [sagiegurari/cargo-make#1327](https://github.com/sagiegurari/cargo-make/issues/1327) is closed by upstream publishing aarch64-linux artifacts AND `taiki-e/install-action`'s manifest covers `aarch64_linux`.

## Related Issues

Refs #4133

## Additional Context

This is **Stage A** of **Phase 3** of the broader CI warning remediation. Phase 1 (#4123 / PR #4124, merged) bumped node24-ready actions; Phase 2 (#4125 / PR #4126, merged) opted into `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` for still-node20 actions. Stage B (workflow `if:` guards) will be filed in a separate PR after this one merges and the AMI is rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)