### PR TITLE
fix(ci): bump arm64 AMI build instance to t4g.medium

### DIFF
--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -58,7 +58,10 @@ variable "ami_prefix" {
 
 locals {
 	source_ami_filter = var.runner_arch == "arm64" ? "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*" : "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
-	build_instance_type = var.runner_arch == "arm64" ? "t4g.small" : "t3.medium"
+	# arm64 uses t4g.medium (4 GB RAM) instead of t4g.small (2 GB) so the
+	# cargo-make prebake (full LTO + codegen-units=1) does not get OOM-killed
+	# during rustc's link step. See reinhardt-web#4137.
+	build_instance_type = var.runner_arch == "arm64" ? "t4g.medium" : "t3.medium"
 	protoc_arch         = var.runner_arch == "arm64" ? "linux-aarch_64" : "linux-x86_64"
 	awscli_arch         = var.runner_arch == "arm64" ? "aarch64" : "x86_64"
 	cloudwatch_arch     = var.runner_arch == "arm64" ? "arm64" : "amd64"


### PR DESCRIPTION
## Summary

- Bump arm64 Packer build instance from `t4g.small` (2 GB RAM) to `t4g.medium` (4 GB RAM) so the cargo-make prebake added in c65d770c does not OOM-kill rustc.

Fixes #4137

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The Build Runner AMI workflow on `main` started failing immediately after `c65d770ca ci(packer): prebake cargo-make into aarch64 AMI` was merged. The new provisioner runs `cargo install --locked cargo-make@0.37.24` on the build instance. cargo-make's release profile uses `lto=full` + `codegen-units=1` + `opt-level=3`, which makes rustc's final link step exceed 2 GB RAM and be killed by SIGKILL on `t4g.small`.

```
process didn't exit successfully: rustc ... -C lto -C codegen-units=1 ... (signal: 9, SIGKILL: kill)
error: could not compile `cargo-make` (bin "cargo-make")
error: could not compile `cargo-make` (bin "makers")
```

The Packer build instance is terminated after each AMI build, so the cost impact of moving to `t4g.medium` is negligible. This also leaves headroom for any future prebakes (e.g. `cargo-nextest`).

Failed run: https://github.com/kent8192/reinhardt-web/actions/runs/25318706840/job/74222096359

Considered alternatives:
- Disabling LTO via env override — defeats the purpose of prebaking (slower binary).
- Adding a swapfile — works but adds operational noise and EBS IO cost.
- Reducing parallelism (`-j 1`) — does not help because the OOM is during the single-process final link stage.

## How Was This Tested

- [x] Inspected the failure log to confirm the SIGKILL pattern and the rustc command line (full-LTO + codegen-units=1).
- [ ] Will be confirmed once this PR's `Build Runner AMI` workflow run completes successfully on `main` after merge.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] No source code changed; existing tests are unaffected

## Labels to Apply

- `bug` — fixes a CI regression that blocks AMI builds
- `ci-cd` — Packer / GitHub Actions infrastructure

## Related Issues

Fixes #4137
Refs #4133 (cargo-make aarch64 prebuilt tracking)
Refs c65d770ca (commit that introduced the prebake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)