### PR TITLE
fix(ci): disable command-not-found post-invoke hook in AMI build

### DIFF
--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -112,11 +112,17 @@ build {
 	# -- System packages -----------------------------------------------------
 	provisioner "shell" {
 		execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+		# Disable the `command-not-found` post-invoke hook on apt-get update.
+		# On arm64 Ubuntu jammy, partial fetches via `-qq` can omit the
+		# `*_cnf_Commands-arm64` index files; `cnf-update-db` then fails to
+		# read them and aborts apt with exit 100, even though the update
+		# itself succeeded. The runner AMI does not need this DB.
+		# Tracked in reinhardt-web#4140.
 		inline = [
-			"DEBIAN_FRONTEND=noninteractive apt-get update -qq",
+			"DEBIAN_FRONTEND=noninteractive apt-get -o APT::Update::Post-Invoke-Success::=true update -qq",
 			"DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common",
 			"add-apt-repository -y universe",
-			"apt-get update -qq",
+			"apt-get -o APT::Update::Post-Invoke-Success::=true update -qq",
 			"DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \\",
 			"  docker.io \\",
 			"  docker-compose-v2 \\",
@@ -142,7 +148,7 @@ build {
 			"curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg",
 			"chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg",
 			"echo \"deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null",
-			"apt-get update -qq",
+			"apt-get -o APT::Update::Post-Invoke-Success::=true update -qq",
 			"apt-get install -y gh",
 		]
 	}


### PR DESCRIPTION
## Summary

- Fix two consecutive `Build Runner AMI` workflow failures on `main` (runs [25320045283](https://github.com/kent8192/reinhardt-web/actions/runs/25320045283), [25318706840](https://github.com/kent8192/reinhardt-web/actions/runs/25318706840)) caused by Ubuntu jammy's `command-not-found` post-invoke hook
- Pass `-o APT::Update::Post-Invoke-Success::=true` on every `apt-get update` invocation in the Packer provisioner so a missing arm64 cnf index file does not abort the build
- Add an explanatory comment referencing the tracking issue

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`apt-get update -qq` on arm64 jammy occasionally omits `*_cnf_Commands-arm64` files. The default `cnf-update-db` post-invoke hook then errors with exit 100 even though the update itself succeeded, killing the Packer step. The runner AMI does not use the `command-not-found` database, so suppressing the hook is safe and minimal.

Fixes #4140

## How Was This Tested

- [x] Local diff review against `infra/github-runners/packer/reinhardt-runner.pkr.hcl`
- [ ] `Build Runner AMI` workflow re-run after merge (cannot run pre-merge against AWS from a fork-style branch)

## Checklist

- [x] My code follows the project's code style
- [x] I have made corresponding changes to the documentation (inline comment + tracking issue)
- [x] My changes generate no new warnings
- [x] PR title follows Conventional Commits format
- [x] PR is linked to issue (Fixes #4140)

## Labels to Apply

- `bug`
- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)