### PR TITLE
fix(ci): disable command-not-found hook globally in AMI build

### DIFF
--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -112,17 +112,21 @@ build {
 	# -- System packages -----------------------------------------------------
 	provisioner "shell" {
 		execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-		# Disable the `command-not-found` post-invoke hook on apt-get update.
-		# On arm64 Ubuntu jammy, partial fetches via `-qq` can omit the
+		# Disable the `command-not-found` post-invoke hook globally for the
+		# duration of the AMI build. On arm64 Ubuntu jammy, `apt-get update`
+		# (including transitive calls from `add-apt-repository`) can omit
 		# `*_cnf_Commands-arm64` index files; `cnf-update-db` then fails to
 		# read them and aborts apt with exit 100, even though the update
-		# itself succeeded. The runner AMI does not need this DB.
-		# Tracked in reinhardt-web#4140.
+		# itself succeeded. The per-call `-o` flag is insufficient because
+		# `add-apt-repository -y universe` invokes `apt-get update`
+		# internally without inheriting it. The runner AMI does not need
+		# this DB. Tracked in reinhardt-web#4140.
 		inline = [
-			"DEBIAN_FRONTEND=noninteractive apt-get -o APT::Update::Post-Invoke-Success::=true update -qq",
+			"echo 'APT::Update::Post-Invoke-Success \"\";' > /etc/apt/apt.conf.d/99-disable-cnf-hook",
+			"DEBIAN_FRONTEND=noninteractive apt-get update -qq",
 			"DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common",
 			"add-apt-repository -y universe",
-			"apt-get -o APT::Update::Post-Invoke-Success::=true update -qq",
+			"apt-get update -qq",
 			"DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \\",
 			"  docker.io \\",
 			"  docker-compose-v2 \\",
@@ -148,7 +152,7 @@ build {
 			"curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg",
 			"chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg",
 			"echo \"deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null",
-			"apt-get -o APT::Update::Post-Invoke-Success::=true update -qq",
+			"apt-get update -qq",
 			"apt-get install -y gh",
 		]
 	}


### PR DESCRIPTION
## Summary

Follow-up to #4141. The per-invocation `-o APT::Update::Post-Invoke-Success::=true` flag did not cover `apt-get update` calls invoked transitively by `add-apt-repository -y universe`, so the AMI build failed again on `main` ([run 25320524808](https://github.com/kent8192/reinhardt-web/actions/runs/25320524808/job/74228125304)) with the same `cnf-update-db` exit-100 error, this time on `jammy-security_universe_cnf_Commands-arm64`.

This PR writes a config snippet to `/etc/apt/apt.conf.d/99-disable-cnf-hook` before any apt operation, disabling the hook for every apt invocation in the build (including transitive ones) and removes the now-redundant per-call `-o` flags.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`add-apt-repository -y universe` invokes `apt-get update` internally with its own argv; the `-o` option set on our outer call is not inherited. A global apt config snippet covers all callers — direct or transitive — without rewriting tools we don't control.

Fixes #4140

## How Was This Tested

- [x] Local diff review of `infra/github-runners/packer/reinhardt-runner.pkr.hcl`
- [ ] `Build Runner AMI` workflow re-run after merge

## Checklist

- [x] My code follows the project's code style
- [x] Changes documented inline with reference to #4140
- [x] PR title follows Conventional Commits format
- [x] PR is linked to issue (Fixes #4140)

## Labels to Apply

- `bug`
- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)