### PR TITLE
ci(terraform): exclude run-once bootstrap stack from plan/apply matrix

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -26,9 +26,9 @@ jobs:
           - module: github-runners
             dir: infra/github-runners
             backend: s3
-          - module: bootstrap
-            dir: infra/github-runners/bootstrap
-            backend: local
+          # Note: `bootstrap` is intentionally excluded — its local backend
+          # does not persist across CI runs, so apply would always fail with
+          # `BucketAlreadyExists`. Apply manually. See reinhardt-web#4145.
           - module: website
             dir: infra/website
             backend: local
@@ -182,9 +182,7 @@ jobs:
           - module: github-runners
             dir: infra/github-runners
             backend: s3
-          - module: bootstrap
-            dir: infra/github-runners/bootstrap
-            backend: local
+          # Note: `bootstrap` is intentionally excluded. See reinhardt-web#4145.
           - module: website
             dir: infra/website
             backend: local

--- a/.github/workflows/terraform-plan-privileged.yml
+++ b/.github/workflows/terraform-plan-privileged.yml
@@ -68,9 +68,8 @@ jobs:
           - module: github-runners
             dir: infra/github-runners
             backend: s3
-          - module: bootstrap
-            dir: infra/github-runners/bootstrap
-            backend: local
+          # Note: `bootstrap` is intentionally excluded — its local backend
+          # cannot survive CI re-runs. See reinhardt-web#4145.
           - module: website
             dir: infra/website
             backend: local
@@ -147,9 +146,7 @@ jobs:
           - module: github-runners
             dir: infra/github-runners
             backend: s3
-          - module: bootstrap
-            dir: infra/github-runners/bootstrap
-            backend: local
+          # Note: `bootstrap` is intentionally excluded. See reinhardt-web#4145.
           - module: website
             dir: infra/website
             backend: local

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -28,9 +28,12 @@ jobs:
           - module: github-runners
             dir: infra/github-runners
             backend: s3
-          - module: bootstrap
-            dir: infra/github-runners/bootstrap
-            backend: local
+          # Note: `bootstrap` (infra/github-runners/bootstrap) is intentionally
+          # excluded from CI. It uses a local backend that does not persist
+          # across runs, so every CI run would re-plan the S3 state bucket
+          # as a new resource and fail apply with `BucketAlreadyExists`.
+          # Bootstrap is run-once and must be applied manually with state in
+          # hand. See reinhardt-web#4145.
           - module: website
             dir: infra/website
             backend: local
@@ -91,7 +94,7 @@ jobs:
           TF_VAR_cloudflare_account_id: ${{ secrets.TF_CLOUDFLARE_ACCOUNT_ID }}
         run: |
           case "${{ matrix.module }}" in
-            bootstrap|github-runners)
+            github-runners)
               [ -z "$TF_VAR_aws_account_id" ] && SKIP=true ;;
             organizations)
               [ -z "$TF_VAR_account_email" ] && SKIP=true ;;

--- a/infra/github-runners/bootstrap/main.tf
+++ b/infra/github-runners/bootstrap/main.tf
@@ -1,6 +1,12 @@
 # Bootstrap: Creates S3 state bucket for the main github-runners Terraform config.
 # Uses LOCAL state (run once, state file stored locally in this directory).
 # After applying, use the outputs to configure backend.tfvars in the parent directory.
+#
+# IMPORTANT: This module is excluded from CI (terraform-plan.yml,
+# terraform-apply.yml, terraform-plan-privileged.yml). The local backend cannot
+# survive across CI runs, so any CI re-apply would re-plan the bucket as a new
+# resource and fail with `BucketAlreadyExists`. Apply this module manually with
+# the local state preserved. See reinhardt-web#4145.
 
 terraform {
   required_version = ">= 1.10"


### PR DESCRIPTION
## Summary

- Removes the `bootstrap` entry from the matrices of `terraform-plan.yml`, `terraform-apply.yml`, and `terraform-plan-privileged.yml`.
- Annotates `infra/github-runners/bootstrap/main.tf` with the manual-apply policy.
- Drops the now-unreachable `bootstrap|github-runners)` arm in `terraform-plan.yml`'s required-variable check (collapsed to `github-runners)`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI / build infra change

## Motivation and Context

Run [25321020081](https://github.com/kent8192/reinhardt-web/actions/runs/25321020081) (`Terraform Apply`) failed at `Apply (bootstrap)` with:

```
Error: creating S3 Bucket (***): BucketAlreadyExists
  with aws_s3_bucket.terraform_state,
  on main.tf line 40, in resource "aws_s3_bucket" "terraform_state":
```

The triggering commit (`59b60704`) only modified `infra/github-runners/packer/reinhardt-runner.pkr.hcl` — bootstrap was completely unrelated.

### Root cause

`infra/github-runners/bootstrap/main.tf` is documented as "Uses LOCAL state (run once, state file stored locally in this directory)." Local backend state does not survive across CI runs, so every `infra/**` push re-plans the S3 state bucket as a brand-new resource. Plan succeeds (it only checks against the empty local state), but apply fails when it actually contacts AWS and finds the bucket created by the original manual bootstrap.

### Why exclude rather than path-filter

Bootstrap is conceptually outside CI's scope: it creates the very state backend CI relies on. There is no scenario where re-running it from CI is correct, regardless of which subpath changed. Validation of bootstrap edits is still covered by `terraform-validate-fork.yml`, which already path-filters this module independently.

## How Was This Tested

- [x] Local `yamllint .github/workflows/*.yml` clean (n/a — pure matrix entry removal + comments)
- [x] Manually verified all four matrix occurrences updated (two in `terraform-apply.yml`, one in `terraform-plan.yml`, two in `terraform-plan-privileged.yml`)
- [x] Verified `bootstrap|github-runners)` collapse in `terraform-plan.yml` does not break the `github-runners` SKIP_PLAN guard
- [ ] Post-merge verification: a subsequent push under `infra/**` should produce a `Terraform Apply` run that has no `Apply (bootstrap)` job

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commit message references issue (`Fixes #4145`)
- [x] No code/comments in non-English
- [x] No documentation files created
- [x] Affected workflows documented inline with explanatory comments

## Related Issues

Fixes #4145

## Labels to Apply

- `bug`
- `ci-cd`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)