### PR TITLE
ci: scope mold linker to host target so wasm-pack builds succeed

### DIFF
--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -98,6 +98,27 @@ jobs:
         with:
           tool: nextest
 
+      # Scope mold to the host target only. A global `RUSTFLAGS=...-fuse-ld=mold`
+      # leaks into wasm32 builds and clang rejects `-fuse-ld=mold` for that
+      # target. See reinhardt-web#4147.
+      - name: Configure mold linker (host target only)
+        run: |
+          cat > /tmp/clang-mold-wrapper << 'WRAPPER'
+          #!/bin/sh
+          exec clang -fuse-ld=mold "$@"
+          WRAPPER
+          chmod +x /tmp/clang-mold-wrapper
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            ENV_KEY="CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER"
+          elif [ "$ARCH" = "x86_64" ]; then
+            ENV_KEY="CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER"
+          else
+            echo "Unsupported architecture for mold linker configuration: $ARCH" >&2
+            exit 1
+          fi
+          echo "${ENV_KEY}=/tmp/clang-mold-wrapper" >> "$GITHUB_ENV"
+
       - name: Pull Docker images
         uses: ./.github/actions/pull-docker-images
         with:
@@ -126,7 +147,6 @@ jobs:
 
       - name: Run cross-crate integration tests (partition ${{ matrix.partition }}/3)
         env:
-          RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold"
           NEXTEST_FILTER_EXPR: ${{ inputs.nextest-filter }}
           RUN_ALL: ${{ inputs.run-all }}
         run: |

--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -119,6 +119,27 @@ jobs:
         with:
           tool: wasm-pack
 
+      # Scope mold to the host target only. A global `RUSTFLAGS=...-fuse-ld=mold`
+      # leaks into wasm32 builds (e.g. wasm-pack fixtures) and clang rejects
+      # `-fuse-ld=mold` for that target. See reinhardt-web#4147.
+      - name: Configure mold linker (host target only)
+        run: |
+          cat > /tmp/clang-mold-wrapper << 'WRAPPER'
+          #!/bin/sh
+          exec clang -fuse-ld=mold "$@"
+          WRAPPER
+          chmod +x /tmp/clang-mold-wrapper
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            ENV_KEY="CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER"
+          elif [ "$ARCH" = "x86_64" ]; then
+            ENV_KEY="CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER"
+          else
+            echo "Unsupported architecture for mold linker configuration: $ARCH" >&2
+            exit 1
+          fi
+          echo "${ENV_KEY}=/tmp/clang-mold-wrapper" >> "$GITHUB_ENV"
+
       - name: Pull Docker images
         uses: ./.github/actions/pull-docker-images
         with:
@@ -147,7 +168,6 @@ jobs:
 
       - name: Run intra-crate integration tests (partition ${{ matrix.partition }}/${{ inputs.partition-count || '8' }})
         env:
-          RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold"
           NEXTEST_FILTER_EXPR: ${{ inputs.nextest-filter }}
           RUN_ALL: ${{ inputs.run-all }}
           CARGO_PACKAGES: ${{ inputs.cargo-packages }}

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -105,6 +105,27 @@ jobs:
         with:
           tool: nextest
 
+      # Scope mold to the host target only. A global `RUSTFLAGS=...-fuse-ld=mold`
+      # leaks into wasm32 builds and clang rejects `-fuse-ld=mold` for that
+      # target. See reinhardt-web#4147.
+      - name: Configure mold linker (host target only)
+        run: |
+          cat > /tmp/clang-mold-wrapper << 'WRAPPER'
+          #!/bin/sh
+          exec clang -fuse-ld=mold "$@"
+          WRAPPER
+          chmod +x /tmp/clang-mold-wrapper
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            ENV_KEY="CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER"
+          elif [ "$ARCH" = "x86_64" ]; then
+            ENV_KEY="CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER"
+          else
+            echo "Unsupported architecture for mold linker configuration: $ARCH" >&2
+            exit 1
+          fi
+          echo "${ENV_KEY}=/tmp/clang-mold-wrapper" >> "$GITHUB_ENV"
+
       - name: Additional disk cleanup before tests
         if: ${{ !contains(inputs.runner, 'self-hosted') }}
         run: |
@@ -127,7 +148,6 @@ jobs:
 
       - name: Run UI tests (partition ${{ matrix.partition }}/${{ inputs.partition-count || '8' }})
         env:
-          RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold"
           NEXTEST_FILTER_EXPR: ${{ inputs.nextest-filter }}
           RUN_ALL: ${{ inputs.run-all }}
           PARTITION_COUNT: ${{ inputs.partition-count || '8' }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -110,6 +110,27 @@ jobs:
         with:
           tool: nextest
 
+      # Scope mold to the host target only. A global `RUSTFLAGS=...-fuse-ld=mold`
+      # leaks into wasm32 builds and clang rejects `-fuse-ld=mold` for that
+      # target. See reinhardt-web#4147.
+      - name: Configure mold linker (host target only)
+        run: |
+          cat > /tmp/clang-mold-wrapper << 'WRAPPER'
+          #!/bin/sh
+          exec clang -fuse-ld=mold "$@"
+          WRAPPER
+          chmod +x /tmp/clang-mold-wrapper
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            ENV_KEY="CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER"
+          elif [ "$ARCH" = "x86_64" ]; then
+            ENV_KEY="CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER"
+          else
+            echo "Unsupported architecture for mold linker configuration: $ARCH" >&2
+            exit 1
+          fi
+          echo "${ENV_KEY}=/tmp/clang-mold-wrapper" >> "$GITHUB_ENV"
+
       - name: Additional disk cleanup before tests
         if: ${{ !contains(inputs.runner, 'self-hosted') }}
         run: |
@@ -148,7 +169,6 @@ jobs:
 
       - name: Run unit tests (partition ${{ matrix.partition }}/${{ inputs.partition-count || '8' }})
         env:
-          RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold"
           NEXTEST_FILTER_EXPR: ${{ inputs.nextest-filter }}
           RUN_ALL: ${{ inputs.run-all }}
           CARGO_PACKAGES: ${{ inputs.cargo-packages }}


### PR DESCRIPTION
## Summary

- Replaces the job-level `RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=mold"` env var with the same wrapper-script + `CARGO_TARGET_<arch>_LINKER` pattern already used by `.github/workflows/coverage.yml`.
- Applied to all four affected workflows: `intra-crate-integration-test.yml`, `cross-crate-integration-test.yml`, `unit-test.yml`, `ui-test.yml`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI / build infra change

## Motivation and Context

`RUSTFLAGS` applies to every rustc invocation, so when intra-crate integration tests built the `spa_navigation_app` fixture via `wasm-pack`, the wasm32 build also picked up `-fuse-ld=mold`. clang doesn't recognize that flag for the wasm target:

```
clang: error: invalid linker name in argument '-fuse-ld=mold'
```

This caused `spa_navigation_link_click_re_renders_view` to fail in the `Intra-Crate Integration Tests` workflow on the release-plz PR #4144 (run [25321625594](https://github.com/kent8192/reinhardt-web/actions/runs/25321625594), partition 7/8 and 8/8).

`CARGO_TARGET_<arch>_UNKNOWN_LINUX_GNU_LINKER` is host-target-scoped, so non-host targets (wasm32) fall back to the default linker (`wasm-ld`).

## How Was This Tested

- [x] Verified the wrapper-script pattern is identical to the one already used in `coverage.yml` (which has been green).
- [x] Verified all four bare `RUSTFLAGS=...-fuse-ld=mold` env occurrences have been removed.
- [ ] Post-merge: re-run the failing job on PR #4144 and confirm `spa_navigation_link_click_re_renders_view` passes.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commit message references issue (`Fixes #4147`)
- [x] No code/comments in non-English
- [x] No documentation files created
- [x] Step has a comment pointing back to the issue

## Related Issues

Fixes #4147

## Labels to Apply

- `bug`
- `ci-cd`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)