### PR TITLE
fix(infra/repository)!: replace data "github_user" reviewer lookup with numeric user-ID variable

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -152,7 +152,7 @@ jobs:
           TF_VAR_dns_record_www_id: ${{ secrets.TF_DNS_RECORD_WWW_ID }}
           TF_VAR_dns_record_google_verification_id: ${{ secrets.TF_DNS_RECORD_GOOGLE_VERIFICATION_ID }}
           TF_VAR_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
-          TF_VAR_environment_reviewer: ${{ secrets.TF_ENVIRONMENT_REVIEWER }}
+          TF_VAR_environment_reviewer_user_id: ${{ secrets.TF_ENVIRONMENT_REVIEWER_USER_ID }}
         run: |
           terraform plan -no-color -input=false -out=tfplan 2>&1 | tee plan-output.txt
           echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
@@ -266,6 +266,6 @@ jobs:
           TF_VAR_dns_record_www_id: ${{ secrets.TF_DNS_RECORD_WWW_ID }}
           TF_VAR_dns_record_google_verification_id: ${{ secrets.TF_DNS_RECORD_GOOGLE_VERIFICATION_ID }}
           TF_VAR_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
-          TF_VAR_environment_reviewer: ${{ secrets.TF_ENVIRONMENT_REVIEWER }}
+          TF_VAR_environment_reviewer_user_id: ${{ secrets.TF_ENVIRONMENT_REVIEWER_USER_ID }}
         run: |
           terraform apply -no-color -input=false tfplan

--- a/.github/workflows/terraform-plan-privileged.yml
+++ b/.github/workflows/terraform-plan-privileged.yml
@@ -277,7 +277,7 @@ jobs:
           TF_VAR_dns_record_google_verification_id: ${{ secrets.TF_DNS_RECORD_GOOGLE_VERIFICATION_ID }}
           TF_VAR_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
           TF_VAR_organizations_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
-          TF_VAR_environment_reviewer: ${{ secrets.TF_ENVIRONMENT_REVIEWER }}
+          TF_VAR_environment_reviewer_user_id: ${{ secrets.TF_ENVIRONMENT_REVIEWER_USER_ID }}
         run: |
           terraform plan -detailed-exitcode -no-color -input=false 2>&1 | tee plan-output.txt
           echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -187,7 +187,7 @@ jobs:
           TF_VAR_tf_plan_aws_access_key_id: ${{ secrets.TF_AWS_ACCESS_KEY_ID }}
           TF_VAR_tf_plan_aws_secret_access_key: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
           TF_VAR_organizations_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
-          TF_VAR_environment_reviewer: ${{ secrets.TF_ENVIRONMENT_REVIEWER }}
+          TF_VAR_environment_reviewer_user_id: ${{ secrets.TF_ENVIRONMENT_REVIEWER_USER_ID }}
         run: |
           terraform plan -no-color -input=false 2>&1 | tee plan-output.txt
           echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"

--- a/infra/repository/environments.tf
+++ b/infra/repository/environments.tf
@@ -1,9 +1,12 @@
 # GitHub repository environments for deployment protection.
-
-# Look up the reviewer's GitHub user ID for environment protection rules.
-data "github_user" "reviewer" {
-  username = var.environment_reviewer
-}
+#
+# The reviewer is identified by their numeric GitHub user ID supplied directly
+# via `var.environment_reviewer_user_id`. We avoid `data "github_user"` here
+# because the integrations/github provider routes that lookup through the
+# configured token, which fails with `401 Bad credentials` whenever the token
+# is a GitHub App installation token, an expired PAT, or a PAT lacking
+# `read:user`. The numeric user ID is stable, so a static value is strictly
+# preferable to a runtime API call. See reinhardt-web#4150.
 
 # Gate for terraform plan on fork PRs.
 # Requires manual approval before CI runs plan on external contributions.
@@ -15,7 +18,7 @@ resource "github_repository_environment" "fork_review" {
   prevent_self_review = true
 
   reviewers {
-    users = [data.github_user.reviewer.id]
+    users = [var.environment_reviewer_user_id]
   }
 }
 
@@ -29,6 +32,6 @@ resource "github_repository_environment" "production" {
   prevent_self_review = true
 
   reviewers {
-    users = [data.github_user.reviewer.id]
+    users = [var.environment_reviewer_user_id]
   }
 }

--- a/infra/repository/variables.tf
+++ b/infra/repository/variables.tf
@@ -16,7 +16,12 @@ variable "repository_name" {
   default     = "reinhardt"
 }
 
-variable "environment_reviewer" {
-  description = "GitHub username for environment deployment approvals."
-  type        = string
+variable "environment_reviewer_user_id" {
+  description = "Numeric GitHub user ID of the environment deployment reviewer. Look up via `gh api users/<username> --jq .id`. Using the numeric ID avoids a runtime `data \"github_user\"` lookup that would otherwise fail when the configured token cannot access the `/user` endpoint."
+  type        = number
+
+  validation {
+    condition     = var.environment_reviewer_user_id > 0
+    error_message = "environment_reviewer_user_id must be a positive integer (the reviewer's numeric GitHub user ID)."
+  }
 }


### PR DESCRIPTION
## Summary

- Drops `data "github_user" "reviewer"` from `infra/repository/environments.tf`.
- Replaces `var.environment_reviewer` (username string) with `var.environment_reviewer_user_id` (number) — a positive-integer-validated variable.
- Updates the four affected workflows to pass `TF_VAR_environment_reviewer_user_id` from a new `TF_ENVIRONMENT_REVIEWER_USER_ID` Actions secret.
- `terraform fmt -check -diff` and `terraform validate` both pass locally.

## Type of Change

- [x] Breaking change (variable rename in the `repository` module)
- [x] Bug fix (eliminates the persistent `Plan (repository)` 401)
- [x] CI / build infra change

## Motivation and Context

Every `Terraform Plan` run has been failing at `Plan (repository)` with:

```
Error: GET https://api.github.com/user: 401 Bad credentials []

  with data.github_user.reviewer,
  on environments.tf line 4, in data "github_user" "reviewer":
   4: data "github_user" "reviewer" {
```

The integrations/github provider routes that data source through the configured token. The configured token (`TF_GITHUB_TOKEN`) cannot read `/user` — likely because it's a GitHub App installation token (`ghs_...`), an expired PAT, or a PAT without `read:user`. The runtime lookup adds no functional value: the reviewer's numeric GitHub user ID is stable and can be supplied directly. Hard-coding it as a number removes the failure mode permanently.

Observed on PR #4146 and on the merged commit run [25321020081](https://github.com/kent8192/reinhardt-web/actions/runs/25321020081).

### Why this is preferable to rotating the token

- Token rotation re-introduces the same risk on the next expiry.
- The numeric user ID never changes; it's a strictly better key.
- Aligns with the project's "Fail early" design principle: a missing/invalid user ID surfaces at variable validation time, not deep inside a remote provider call.

## Required Operator Action (post-merge)

1. Look up the reviewer's numeric GitHub user ID:
   ```bash
   gh api users/<reviewer-username> --jq .id
   ```
2. Add a new GitHub Actions secret on `kent8192/reinhardt-web`:
   - Name: `TF_ENVIRONMENT_REVIEWER_USER_ID`
   - Value: the numeric ID from step 1
3. The previous `TF_ENVIRONMENT_REVIEWER` secret can be removed.

Until step 2 is complete, `Plan (repository)` will fail with a different (clearer) error: `Variable not provided`.

## How Was This Tested

- [x] `terraform fmt -check -diff` clean (in `infra/repository`)
- [x] `terraform validate` passes
- [x] Verified all four workflow occurrences of `TF_VAR_environment_reviewer` updated
- [x] Verified no other file in the workspace still references the old variable name
- [ ] Post-merge: re-run `Terraform Plan` after the operator adds the new secret; `Plan (repository)` should report only the `github_issue_label.infrastructure` add and complete successfully

## Checklist

- [x] PR title follows Conventional Commits with `!` to indicate the breaking variable rename
- [x] Commit message references issue (`Fixes #4150`)
- [x] No code/comments in non-English
- [x] No documentation files created (rationale captured inline in `environments.tf` and `variables.tf` description fields)

## Related Issues

Fixes #4150

## Labels to Apply

- `bug`
- `ci-cd`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)