### PR TITLE
fix(macros): expose routes/url_patterns re-exports on wasm targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,13 +272,16 @@ reinhardt-urls = { workspace = true }
 
 reinhardt-core = {workspace = true, features = ["types"]}
 
+# Proc-macro crate: runs host-side at compile time, safe on every target
+# (re-exported as `reinhardt::routes` / `reinhardt::url_patterns` for cross-target consumers)
+reinhardt-macros = { workspace = true }
+
 # Server-side dependencies (NOT for WASM)
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 # Core dependencies
 reinhardt-utils = { workspace = true }
 reinhardt-views = { workspace = true }
 reinhardt-http = { workspace = true }
-reinhardt-macros = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 hyper = { workspace = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,9 +303,7 @@ macro_rules! define_views {
         $crate::flatten_imports!($($tt)*)
     };
 }
-#[cfg(native)]
 pub use reinhardt_macros::routes;
-#[cfg(native)]
 pub use reinhardt_macros::url_patterns;
 #[cfg(native)]
 pub use reinhardt_macros::viewset;


### PR DESCRIPTION
## Summary

- Removes the `#[cfg(native)]` gates from `pub use reinhardt_macros::{routes, url_patterns}` in `src/lib.rs`.
- Moves `reinhardt-macros` from the native-only target dependency table into the unconditional `[dependencies]` section in `Cargo.toml`. The crate is `proc-macro = true` so it is compiled host-side and adds no runtime weight on wasm32.
- Closes the missing half of #4119: PR #4132 made the macro **emission** cross-target, but the macro **invocation gate** (re-export + dep) at the framework boundary defeated it. Now `ResolvedUrls::from_global().client().<app>().<route>()` is reachable from wasm SPA call sites without runtime untyped resolver shims.
- `viewset` re-export remains native-only (out of scope; it emits native-only artifacts).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Fixes #4154. Without this change, downstream wasm32 consumers (e.g. `kent8192/reinhardt-cloud` PR #528) cannot invoke `#[reinhardt::routes]` or `#[reinhardt::url_patterns]` at cross-target call sites, because both the re-export and the dependency itself are gated to native — defeating the cross-target macro emission shipped in #4132.

## How Was This Tested

- `cargo check -p reinhardt-web --all-features` (native): passes
- `cargo check -p reinhardt-web --target wasm32-unknown-unknown --no-default-features --features client-router`: passes (was failing with `unresolved import 'reinhardt_macros'` before this change)
- `cargo make fmt-check`: passes (0 would be formatted, 2716 unchanged)
- `cargo make clippy-todo-check`: passes (no new TODO/FIXME/dbg)

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] All commits follow Conventional Commits format
- [x] PR description follows the template

## Labels to Apply

- `bug`

## Related Issues

Fixes #4154
Refs #4119, #4132

🤖 Generated with [Claude Code](https://claude.com/claude-code)