### PR TITLE
chore(serena): add additional_workspace_folders config option

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -161,3 +161,14 @@ ls_specific_settings: {}
 # The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
 # See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []


### PR DESCRIPTION
## Summary

- Add `additional_workspace_folders: []` option to `.serena/project.yml` with documentation comments
- Enables LSP cross-package reference support for monorepos (currently TypeScript only)

## Type of Change

- [x] Chore (configuration / tooling)

## Motivation and Context

Serena's recent versions support `additional_workspace_folders` for cross-package symbol resolution. Adding the option (with explanatory comments) makes it discoverable for future use without changing current behavior (empty list = no-op).

## How Was This Tested

- [x] No code changes; config-only addition with empty default

## Checklist

- [x] English-only content
- [x] Conventional Commits format

🤖 Generated with [Claude Code](https://claude.com/claude-code)