### PR TITLE
fix(infra/packer): use makers alias for cargo-make smoke test

### DIFF
--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -209,7 +209,7 @@ build {
 			# cargo-make enforces invocation as a cargo subcommand and its
 			# internal `cliparser` raises `InvalidCommandLine` on bare argv.
 			# See reinhardt-web#4162.
-			"makers --version",
+			"/usr/local/bin/makers --version",
 		]
 	}
 

--- a/infra/github-runners/packer/reinhardt-runner.pkr.hcl
+++ b/infra/github-runners/packer/reinhardt-runner.pkr.hcl
@@ -202,9 +202,14 @@ build {
 			"su - ubuntu -c 'curl --proto =https --tlsv1.2 -sSfL https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal'",
 			"su - ubuntu -c \"~/.cargo/bin/cargo install --locked cargo-make@$${CARGO_MAKE_VERSION}\"",
 			"cp /home/ubuntu/.cargo/bin/cargo-make /usr/local/bin/cargo-make",
-			"chmod 0755 /usr/local/bin/cargo-make",
-			# Verify installation succeeded before AMI snapshot
-			"/usr/local/bin/cargo-make --version",
+			"cp /home/ubuntu/.cargo/bin/makers /usr/local/bin/makers",
+			"chmod 0755 /usr/local/bin/cargo-make /usr/local/bin/makers",
+			# Verify installation succeeded before AMI snapshot.
+			# Use the `makers` alias rather than bare `cargo-make --version`:
+			# cargo-make enforces invocation as a cargo subcommand and its
+			# internal `cliparser` raises `InvalidCommandLine` on bare argv.
+			# See reinhardt-web#4162.
+			"makers --version",
 		]
 	}
 


### PR DESCRIPTION
## Summary

- Switch the cargo-make prebake smoke test from bare `cargo-make --version` to `makers --version`.
- Also copy `/home/ubuntu/.cargo/bin/makers` into `/usr/local/bin/` so the alias is available system-wide.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The aarch64 AMI build (workflow run [25364809432](https://github.com/kent8192/reinhardt-web/actions/runs/25364809432)) fails at the cargo-make prebake provisioner's smoke test:

```
==> amazon-ebs.runner: `cliparser::types::ParserError` error.
    InvalidCommandLine("Command does not match spec, command line:
    [\"/usr/local/bin/cargo-make\", \"--version\"]")
==> amazon-ebs.runner: exit code 731
```

Root cause: `cargo-make` is a cargo subcommand and its internal argv parser (`cliparser`, also authored by sagiegurari) raises `InvalidCommandLine` when invoked bare. The companion `makers` binary, shipped in the same crate, is the standalone alias intended for non-`cargo` invocation paths and accepts `--version` directly.

Fixes #4162

## How Was This Tested

- Visual diff review of the HCL change.
- `packer fmt` not run locally (packer not installed on dev host); CI's `Build Runner AMI` workflow on this branch (run via `workflow_dispatch`) will validate end-to-end. The smoke test step will print `cargo-make 0.37.24` on success.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Issue linked via `Fixes #4162`

## Labels to Apply

- `bug` (regression in CI infrastructure)
- `ci-cd`
- `infrastructure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)