### PR TITLE
Add announcements section to changelog with GitHub-backed shortcode

### DIFF
--- a/website/content/changelog.md
+++ b/website/content/changelog.md
@@ -10,4 +10,4 @@ The Reinhardt changelog is maintained in the repository.
 
 ## Announcements
 
-{% announcement_links() %}
+{{ announcement_links() }}

--- a/website/content/changelog.md
+++ b/website/content/changelog.md
@@ -7,3 +7,7 @@ weight = 80
 The Reinhardt changelog is maintained in the repository.
 
 → [View full CHANGELOG.md on GitHub](https://github.com/kent8192/reinhardt-web/blob/main/CHANGELOG.md)
+
+## Announcements
+
+{% announcement_links() %}

--- a/website/templates/shortcodes/announcement_links.html
+++ b/website/templates/shortcodes/announcement_links.html
@@ -1,16 +1,29 @@
 {%- set data = load_data(
-    url="https://api.github.com/repos/kent8192/reinhardt-web/contents/announcements",
+    url="https://api.github.com/repos/kent8192/reinhardt-web/contents/announcements?ref=main",
     format="json",
     headers=["User-Agent=reinhardt-web-site (zola)"],
     required=false
 ) -%}
 {%- if data -%}
-{%- set files = data | filter(attribute="type", value="file") | sort(attribute="name") | reverse -%}
-<ul>
+{%- set files = data | filter(attribute="type", value="file") -%}
+{#- Build a numeric-aware sort key by zero-padding the trailing prerelease
+    counter to 3 digits (e.g. `v0.1.0-rc.9.md` -> `v0.1.0-rc.009.md`), so a
+    lex sort puts `rc.10` after `rc.9`. The original name is recovered later
+    by stripping the leading zero(s) on the trailing segment. -#}
+{%- set_global announcement_keys = [] -%}
 {%- for item in files -%}
-  {%- if item.name is starting_with("v") and item.name is ending_with(".md") %}
-  <li><a href="{{ item.html_url | safe }}">{{ item.name | trim_end_matches(pat=".md") }}</a></li>
+  {%- if item.name is starting_with("v") and item.name is ending_with(".md") -%}
+    {%- set sort_key = item.name
+        | regex_replace(pattern=`\.([0-9])\.md$`, rep=`.00$1.md`)
+        | regex_replace(pattern=`\.([0-9][0-9])\.md$`, rep=`.0$1.md`) -%}
+    {%- set_global announcement_keys = announcement_keys | concat(with=[sort_key]) -%}
   {%- endif -%}
+{%- endfor -%}
+{%- set sorted_keys = announcement_keys | sort | reverse -%}
+<ul>
+{%- for key in sorted_keys %}
+  {%- set name = key | regex_replace(pattern=`\.0+([0-9]+)\.md$`, rep=`.$1.md`) %}
+  <li><a href="https://github.com/kent8192/reinhardt-web/blob/main/announcements/{{ name | safe }}">{{ name | trim_end_matches(pat=".md") }}</a></li>
 {%- endfor %}
 </ul>
 {%- else %}

--- a/website/templates/shortcodes/announcement_links.html
+++ b/website/templates/shortcodes/announcement_links.html
@@ -1,0 +1,23 @@
+{%- set data = load_data(
+    url="https://api.github.com/repos/kent8192/reinhardt-web/contents/announcements",
+    format="json",
+    headers=["User-Agent=reinhardt-web-site (zola)"],
+    required=false
+) -%}
+
+{%- if data -%}
+{%- set_global rows = [] -%}
+{%- for item in data -%}
+  {%- if item.type == "file" and item.name is starting_with("v") and item.name is ending_with(".md") -%}
+    {%- set version = item.name | trim_end_matches(pat=".md") -%}
+    {%- set_global rows = rows | concat(with=[{"version": version, "url": item.html_url}]) -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- for row in rows | sort(attribute="version") | reverse -%}
+- [{{ row.version }}]({{ row.url }})
+{%- endfor -%}
+{%- else -%}
+- Announcement list is currently unavailable. Please check the repository directly:
+  [announcements directory](https://github.com/kent8192/reinhardt-web/tree/main/announcements)
+{%- endif -%}

--- a/website/templates/shortcodes/announcement_links.html
+++ b/website/templates/shortcodes/announcement_links.html
@@ -4,20 +4,15 @@
     headers=["User-Agent=reinhardt-web-site (zola)"],
     required=false
 ) -%}
-
 {%- if data -%}
-{%- set_global rows = [] -%}
-{%- for item in data -%}
-  {%- if item.type == "file" and item.name is starting_with("v") and item.name is ending_with(".md") -%}
-    {%- set version = item.name | trim_end_matches(pat=".md") -%}
-    {%- set_global rows = rows | concat(with=[{"version": version, "url": item.html_url}]) -%}
+{%- set files = data | filter(attribute="type", value="file") | sort(attribute="name") | reverse -%}
+<ul>
+{%- for item in files -%}
+  {%- if item.name is starting_with("v") and item.name is ending_with(".md") %}
+  <li><a href="{{ item.html_url | safe }}">{{ item.name | trim_end_matches(pat=".md") }}</a></li>
   {%- endif -%}
-{%- endfor -%}
-
-{%- for row in rows | sort(attribute="version") | reverse -%}
-- [{{ row.version }}]({{ row.url }})
-{%- endfor -%}
-{%- else -%}
-- Announcement list is currently unavailable. Please check the repository directly:
-  [announcements directory](https://github.com/kent8192/reinhardt-web/tree/main/announcements)
+{%- endfor %}
+</ul>
+{%- else %}
+<p>Announcement list is currently unavailable. Please check the <a href="https://github.com/kent8192/reinhardt-web/tree/main/announcements">announcements directory</a> directly.</p>
 {%- endif -%}


### PR DESCRIPTION
### Motivation

- Surface repository-hosted announcement files directly on the changelog page so releases/announcements are easier to discover. 
- Fetch and render announcement entries dynamically from GitHub to avoid manual duplication and keep the site in sync with the `announcements` directory.

### Description

- Added a new shortcode template `website/templates/shortcodes/announcement_links.html` that calls the GitHub API to list files in the `announcements` directory and produces a link list. 
- The shortcode filters items whose names start with `v` and end with `.md`, derives a `version` label, sorts versions descending, and renders each as a link to the file's `html_url`. 
- The shortcode includes a fallback message linking to the repository if the API data is unavailable. 
- Updated `website/content/changelog.md` to include a `## Announcements` section and invoke the shortcode via `{% announcement_links() %}`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa84fd60248327a74146ce7ec47437)