### PR TITLE
fix(website): correct Tera template syntax for announcement_links shortcode

### DIFF
--- a/website/content/changelog.md
+++ b/website/content/changelog.md
@@ -10,4 +10,4 @@ The Reinhardt changelog is maintained in the repository.
 
 ## Announcements
 
-{% announcement_links() %}
+{{ announcement_links() }}

--- a/website/content/changelog.md
+++ b/website/content/changelog.md
@@ -7,3 +7,7 @@ weight = 80
 The Reinhardt changelog is maintained in the repository.
 
 → [View full CHANGELOG.md on GitHub](https://github.com/kent8192/reinhardt-web/blob/main/CHANGELOG.md)
+
+## Announcements
+
+{% announcement_links() %}

--- a/website/templates/shortcodes/announcement_links.html
+++ b/website/templates/shortcodes/announcement_links.html
@@ -1,0 +1,23 @@
+{%- set data = load_data(
+    url="https://api.github.com/repos/kent8192/reinhardt-web/contents/announcements",
+    format="json",
+    headers=["User-Agent=reinhardt-web-site (zola)"],
+    required=false
+) -%}
+
+{%- if data -%}
+{%- set_global rows = [] -%}
+{%- for item in data -%}
+  {%- if item.type == "file" and item.name is starting_with("v") and item.name is ending_with(".md") -%}
+    {%- set version = item.name | trim_end_matches(pat=".md") -%}
+    {%- set_global rows = rows | concat(with=[{"version": version, "url": item.html_url}]) -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- for row in rows | sort(attribute="version") | reverse -%}
+- [{{ row.version }}]({{ row.url }})
+{%- endfor -%}
+{%- else -%}
+- Announcement list is currently unavailable. Please check the repository directly:
+  [announcements directory](https://github.com/kent8192/reinhardt-web/tree/main/announcements)
+{%- endif -%}

--- a/website/templates/shortcodes/announcement_links.html
+++ b/website/templates/shortcodes/announcement_links.html
@@ -4,20 +4,15 @@
     headers=["User-Agent=reinhardt-web-site (zola)"],
     required=false
 ) -%}
-
 {%- if data -%}
-{%- set_global rows = [] -%}
-{%- for item in data -%}
-  {%- if item.type == "file" and item.name is starting_with("v") and item.name is ending_with(".md") -%}
-    {%- set version = item.name | trim_end_matches(pat=".md") -%}
-    {%- set_global rows = rows | concat(with=[{"version": version, "url": item.html_url}]) -%}
+{%- set files = data | filter(attribute="type", value="file") | sort(attribute="name") | reverse -%}
+<ul>
+{%- for item in files -%}
+  {%- if item.name is starting_with("v") and item.name is ending_with(".md") %}
+  <li><a href="{{ item.html_url | safe }}">{{ item.name | trim_end_matches(pat=".md") }}</a></li>
   {%- endif -%}
-{%- endfor -%}
-
-{%- for row in rows | sort(attribute="version") | reverse -%}
-- [{{ row.version }}]({{ row.url }})
-{%- endfor -%}
-{%- else -%}
-- Announcement list is currently unavailable. Please check the repository directly:
-  [announcements directory](https://github.com/kent8192/reinhardt-web/tree/main/announcements)
+{%- endfor %}
+</ul>
+{%- else %}
+<p>Announcement list is currently unavailable. Please check the <a href="https://github.com/kent8192/reinhardt-web/tree/main/announcements">announcements directory</a> directly.</p>
 {%- endif -%}


### PR DESCRIPTION
## Summary

Resolves the **Build & Deploy** CI failure on #4169 (the only failing check, which exited with code 1 after ~6s — Zola refused to parse the new shortcode template).

The original PR introduced two issues that caused `zola build` to fail:

1. **Inline object literals are not supported by Tera.** The expression
   `concat(with=[{"version": version, "url": item.html_url}])` triggered:
   ```
   = expected a value that can be negated
   ```
   Tera does not allow map/dict literals (`{key: value}`) inside array literals (verified locally with Zola 0.22.1).
2. **Body-shortcode syntax without a body.** `changelog.md` invoked the shortcode as `{% announcement_links() %}` without a `{% end %}`, which Zola rejected with `expected text in a shortcode body`.

## Fix

- Refactor `announcement_links.html` to filter and sort the GitHub API response directly via Tera's built-in `filter` → `sort` → `reverse` filters, eliminating the need to construct intermediate object literals.
- Emit HTML (`<ul><li><a>…</a></li></ul>`) directly from the shortcode. `{{ shortcode() }}` output is substituted as HTML, not re-parsed as Markdown — the original Markdown output rendered as raw text.
- Switch the call site in `changelog.md` from `{% announcement_links() %}` to `{{ announcement_links() }}` (void shortcode form).

## Test plan

- [x] Reproduced the parse error locally with Zola 0.22.1 (`expected a value that can be negated`).
- [x] Reproduced the second error after the first fix (`expected text in a shortcode body`).
- [x] `zola build` in `website/` now succeeds: `Done in 1.0s.`
- [x] Verified rendered fallback HTML at `/changelog/`: proper `<p>…<a>announcements directory</a>…</p>`.
- [ ] CI **Build & Deploy** passes on this branch.

Refs #4169

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vzwuq1g46M4AQUwsr5Acpw)_