### PR TITLE
fix(macros): gate #[routes] body on wasm so ResolvedUrls is reachable

### DIFF
--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -269,6 +269,20 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 		));
 	}
 
+	// Wasm-not gate applied to every item emitted in `#expanded` below
+	// (the user's `routes()` function, the inventory registration block, and
+	// the linker-marker static). These items reference native-only types
+	// (`ServerRouter`, `inventory`, DI scopes) and the user-written body is
+	// allowed to reference any native-only items the consumer crate uses
+	// (admin / middleware / Redis / `#[inject]` / etc.). Gating them out on
+	// `wasm32-unknown-unknown` lets the surrounding module compile cleanly
+	// on wasm so that `__url_resolver_support::ResolvedUrls` (defined in
+	// `#url_resolver_code` below, which is internally cfg-aware) is reachable
+	// from wasm SPA consumers. Fixes #4175.
+	let native_only = quote! {
+		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+	};
+
 	let expanded = if !is_async {
 		// Case 1: Sync, no #[inject] — existing behavior unchanged
 		let fn_sig = &input.sig;
@@ -276,12 +290,14 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 			// private_interfaces: The macro forces `pub` visibility, but users
 			// legitimately use `pub(crate)` newtype wrappers for DI parameters
 			// (see #3498, #3468 DI pseudo orphan rule).
+			#native_only
 			#[allow(private_interfaces)]
 			#(#fn_attrs)*
 			#fn_vis #fn_sig #fn_block
 
 			// Allow unsafe attributes used by inventory::submit! (#[link_section])
 			// Required for Rust 2024 edition compatibility
+			#native_only
 			#[allow(unsafe_attr_outside_unsafe)]
 			const _: () = {
 				// Server router extraction function
@@ -297,6 +313,7 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 			};
 
 			// Linker marker to enforce single #[routes] usage.
+			#native_only
 			#[doc(hidden)]
 			#[unsafe(no_mangle)]
 			#[allow(non_upper_case_globals, dead_code)]
@@ -308,10 +325,12 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 		// Case 2: Async, no #[inject]
 		let fn_sig = &input.sig;
 		quote! {
+			#native_only
 			#[allow(private_interfaces)]
 			#(#fn_attrs)*
 			#fn_vis #fn_sig #fn_block
 
+			#native_only
 			#[allow(unsafe_attr_outside_unsafe)]
 			const _: () = {
 				fn __get_server_router() -> ::std::pin::Pin<
@@ -335,6 +354,7 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 				}
 			};
 
+			#native_only
 			#[doc(hidden)]
 			#[unsafe(no_mangle)]
 			#[allow(non_upper_case_globals, dead_code)]
@@ -410,10 +430,12 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 			.collect();
 
 		quote! {
+			#native_only
 			#[allow(private_interfaces)]
 			#(#fn_attrs)*
 			#fn_vis async fn #fn_name #fn_generics(#(#stripped_params),*) #fn_return #fn_block
 
+			#native_only
 			#[allow(unsafe_attr_outside_unsafe)]
 			const _: () = {
 				fn __get_server_router() -> ::std::pin::Pin<
@@ -448,6 +470,7 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 				}
 			};
 
+			#native_only
 			#[doc(hidden)]
 			#[unsafe(no_mangle)]
 			#[allow(non_upper_case_globals, dead_code)]
@@ -477,6 +500,16 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 		// while the client-side `__client_router_gate` block emits
 		// unconditionally so that `urls.client().<app>().<route>()` typed
 		// accessors compile on `wasm32-unknown-unknown`. Fixes #4119.
+		//
+		// The `#expanded` token stream above (the user's `routes()` function
+		// body, the `inventory::submit!` registration, and the linker marker)
+		// is wasm-gated as a whole via `#native_only` because the
+		// user-written body is allowed to reference any native-only items
+		// (admin / middleware / Redis sessions / `#[inject]` / server fns)
+		// the consuming crate uses. Gating it out on wasm lets the
+		// surrounding module compile cleanly so that
+		// `__url_resolver_support::ResolvedUrls` is reachable from wasm SPA
+		// consumers. Fixes #4175.
 		quote! {}
 	} else {
 		let app_labels = match crate::macro_state::read_installed_apps() {


### PR DESCRIPTION
## Summary

The `#[routes]` proc-macro emits two sibling chunks: the user's `routes()` function body + `inventory::submit!` registration + linker marker, and the `__url_resolver_support` module containing `ResolvedUrls`. The latter is already wasm-aware via internal cfg gates, but the former was emitted unconditionally and references native-only types (`ServerRouter`, `inventory`, DI scopes). Any non-trivial `routes()` body for a real consumer transitively references native-only items (admin, middleware, Redis sessions, `#[inject]`, server functions), so the surrounding module failed to typecheck on `wasm32-unknown-unknown` — taking `__url_resolver_support::ResolvedUrls` down with it and defeating the typed accessor cascade #4068 → #4156 → #4161/#4166/#4167.

Apply `#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]` to every top-level item in `#expanded` across all three arms (sync, async-no-inject, async-with-inject). Native expansion is byte-identical; on wasm the function and registration scaffolding disappear, leaving `__url_resolver_support` reachable with its existing wasm-only `ResolvedUrls { client_reverser }` shape.

Mirrors the per-block gating strategy documented at `routes_registration.rs:472-479` (Fixes #4119) and extends it to the `#expanded` half. Issue #4175's option 1 in its lightest form.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Motivation and Context

Closes blocker for downstream wasm SPA consumers that need typed `ResolvedUrls::from_global().client().<app>().<route>()` accessors. Without this fix, every consumer with a non-trivial `routes()` body must keep a runtime `url_for_spa(name)` shim over `get_client_reverser().reverse()`, defeating the entire #4068 → #4167 cascade.

## How Was This Tested

- `cargo nextest run -p reinhardt-macros` — 190/190 passing (no regressions in compile-pass / compile-fail UI suite)
- `cargo make fmt-check` — clean
- `cargo make clippy-check` — clean
- Native expansion is byte-identical (existing UI snapshots unchanged)

### Downstream wasm verification (out-of-tree)

Against a downstream consumer pinned past this PR, removing the `#[cfg(native)]` wrapper on the `urls` module that holds `#[routes]` and running:

```sh
cargo check -p <consumer> --target wasm32-unknown-unknown --lib
```

should now succeed; `ResolvedUrls::from_global().client().<app>().<route>()` should resolve from wasm SPA code. The reproduction in the issue (kent8192/reinhardt-cloud#519, #528) is the canonical end-to-end check.

## Behavior Notes

- On wasm, `crate::routes` (the user's function) **no longer exists as a symbol**. Any downstream code that names `crate::routes` from a wasm-reachable code path must add its own `#[cfg(not(target_family = \"wasm\"))]` gate. No internal callers in this workspace exist (verified via `rg -n 'crate::routes\b|super::routes\b' crates/`).
- The wasm-side `impl ResolvedUrls` block at `routes_registration.rs:1046-1065` calls `#reinhardt::get_client_reverser()` ungated by `feature = "client-router"`. Downstream `reinhardt` facade exports of `ClientUrlReverser` / `get_client_reverser` are gated behind that feature — pre-existing, out of scope here. Track separately if a wasm consumer hits a missing symbol without `client-router`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (extended the gating strategy comment block)
- [x] My changes generate no new warnings
- [x] Existing tests pass with my changes (190/190)

## Labels to Apply

- `bug`

## Related Issues

Fixes #4175
Refs #4161 #4166 #4167 #4068 #4076 #4119 #4132 #4154 #4156

🤖 Generated with [Claude Code](https://claude.com/claude-code)