### PR TITLE
fix(ci): install wasm-bindgen-cli in intra-crate integration test workflow

### DIFF
--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -119,6 +119,15 @@ jobs:
         with:
           tool: wasm-pack
 
+      # Required by hot-reload tests in crates/reinhardt-commands
+      # (runserver_hot_reload.rs::detect_wasm_bindgen_cli_version) which
+      # shell out to `wasm-bindgen --version` to pin the fixture's
+      # wasm-bindgen dep to the installed CLI version. Tracked in #4180.
+      - name: Install wasm-bindgen-cli
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli
+
       # Scope mold to the host target only. A global `RUSTFLAGS=...-fuse-ld=mold`
       # leaks into wasm32 builds (e.g. wasm-pack fixtures) and clang rejects
       # `-fuse-ld=mold` for that target. See reinhardt-web#4147.


### PR DESCRIPTION
## Summary

- Add a `taiki-e/install-action` step to install `wasm-bindgen-cli` in `.github/workflows/intra-crate-integration-test.yml`
- Unblocks the `hr_*` hot-reload tests in `crates/reinhardt-commands` that panic at startup because the binary is missing on the runner

Fixes #4180

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`detect_wasm_bindgen_cli_version()` at `crates/reinhardt-commands/tests/runserver_hot_reload.rs:584` shells out to `wasm-bindgen --version` to pin the fixture's `wasm-bindgen` dependency to the installed CLI version. The Intra-Crate Integration Tests workflow only ran `Setup Rust` and never installed `wasm-bindgen-cli`, so every shard containing an `hr_*` test panicked:

```
wasm-bindgen-cli must be installed for the hot-reload tests:
Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

This affects every PR (visible on PR #4174 release-plz: https://github.com/kent8192/reinhardt-web/actions/runs/25427615101 — shards 2/8 and 4/8 failed).

The fix uses the same `taiki-e/install-action` mechanism already employed for `wasm-pack`, `cargo-make`, and `nextest` in this workflow, so it stays consistent with surrounding patterns.

## How Was This Tested

- The change is workflow-only and was verified by inspecting that the new step is structurally identical to the existing `wasm-pack` install step, which is known to work.
- Final validation comes from the Intra-Crate Integration Tests CI on this PR (`hr_*` tests should run instead of panicking).

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed
- [x] No new TODOs introduced
- [x] Linked to issue (#4180)

## Labels to Apply

- `bug`
- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)