### PR TITLE
fix(wasm): add reinhardt::prelude shim and soften installed_apps! gate

### DIFF
--- a/crates/reinhardt-core/macros/src/macro_state.rs
+++ b/crates/reinhardt-core/macros/src/macro_state.rs
@@ -56,8 +56,15 @@ pub(crate) fn write_installed_apps(labels: &[String]) -> Result<(), String> {
 pub(crate) fn read_installed_apps() -> Result<Vec<String>, String> {
 	let dir = state_dir_path()?;
 	let path = dir.join(STATE_FILE_NAME);
-	let content = std::fs::read_to_string(&path)
-		.map_err(|e| format!("Cannot read {}: {e}", path.display()))?;
+	let content = match std::fs::read_to_string(&path) {
+		Ok(c) => c,
+		// Missing file is the expected soft-fallback case (Issue #4189): wasm SPA
+		// consumers never run `installed_apps!`, so the state file simply does not
+		// exist. Other IO errors (permission denied, corrupt FS, etc.) are
+		// surfaced so they cannot be silently swallowed.
+		Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+		Err(e) => return Err(format!("Cannot read {}: {e}", path.display())),
+	};
 	Ok(content
 		.lines()
 		.filter(|line| !line.is_empty())

--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -512,18 +512,18 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 		// consumers. Fixes #4175.
 		quote! {}
 	} else {
-		let app_labels = match crate::macro_state::read_installed_apps() {
-			Ok(labels) => labels,
-			Err(msg) => {
-				return Err(syn::Error::new(
-					proc_macro2::Span::call_site(),
-					format!(
-						"Failed to read installed apps: {msg}. \
-						 Ensure `installed_apps!` is invoked before `#[routes]`."
-					),
-				));
-			}
-		};
+		// Soft-fallback when the installed-apps state file is missing
+		// (Issue #4189). Hard-erroring here breaks wasm SPA consumers
+		// where the scaffold's `mod apps` (containing `installed_apps!`)
+		// is gated `#[cfg(server)]`, so the file is never written for
+		// wasm builds. Cargo does not expose `CARGO_CFG_TARGET_FAMILY`
+		// to proc-macro processes (only to build scripts), so the macro
+		// cannot detect the consumer's target at expansion time. Falling
+		// back to an empty label list joins the existing
+		// `app_idents.is_empty()` branch below, which emits only the
+		// minimal `url_prelude { pub use super::ResolvedUrls; }` block —
+		// exactly the surface wasm SPA consumers need.
+		let app_labels = crate::macro_state::read_installed_apps().unwrap_or_default();
 
 		let app_idents: Vec<proc_macro2::Ident> = app_labels
 			.iter()

--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -523,7 +523,16 @@ pub(crate) fn routes_impl(args: TokenStream, input: ItemFn) -> Result<TokenStrea
 		// `app_idents.is_empty()` branch below, which emits only the
 		// minimal `url_prelude { pub use super::ResolvedUrls; }` block —
 		// exactly the surface wasm SPA consumers need.
-		let app_labels = crate::macro_state::read_installed_apps().unwrap_or_default();
+		// `read_installed_apps()` returns `Ok(empty)` when the state file is
+		// absent (the expected wasm soft-fallback) and `Err` for all other IO
+		// failures, so genuine misconfigurations still surface as macro errors
+		// rather than being silently swallowed.
+		let app_labels = crate::macro_state::read_installed_apps().map_err(|e| {
+			syn::Error::new(
+				proc_macro2::Span::call_site(),
+				format!("Failed to read installed apps state: {e}"),
+			)
+		})?;
 
 		let app_idents: Vec<proc_macro2::Ident> = app_labels
 			.iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1158,6 +1158,23 @@ pub use reinhardt_test::{APIClient, APIRequestFactory, APITestCase, TestResponse
 #[cfg(all(feature = "storage", native))]
 pub use reinhardt_utils::storage::{InMemoryStorage, LocalStorage, Storage};
 
+/// Wasm-side `prelude` shim (Issue #4189).
+///
+/// The native `prelude` module is `#[cfg(native)]`-gated, but the
+/// `--with-pages` scaffold emits `use reinhardt::prelude::*;` in the
+/// generated `src/config/urls.rs`, which must compile on
+/// `wasm32-unknown-unknown` so wasm SPA consumers can `cargo check --lib`
+/// without modifying the scaffolded sources.
+///
+/// This wasm-only stub re-exports the minimum surface the scaffold uses
+/// (`UnifiedRouter` from the wasm-side `urls::prelude` shim defined above).
+/// Native builds keep using the full server-side `prelude` declared below.
+#[cfg(not(native))]
+pub mod prelude {
+	#[cfg(feature = "client-router")]
+	pub use crate::urls::prelude::UnifiedRouter;
+}
+
 /// Convenience re-exports of commonly used types (server-side only).
 #[cfg(native)]
 pub mod prelude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1167,9 +1167,11 @@ pub use reinhardt_utils::storage::{InMemoryStorage, LocalStorage, Storage};
 /// without modifying the scaffolded sources.
 ///
 /// This wasm-only stub re-exports the minimum surface the scaffold uses
-/// (`UnifiedRouter` from the wasm-side `urls::prelude` shim defined above).
-/// Native builds keep using the full server-side `prelude` declared below.
-#[cfg(not(native))]
+/// (`UnifiedRouter` from the wasm-side `urls::prelude` shim, gated behind
+/// the `client-router` feature; the module is empty when that feature is
+/// disabled). Native builds keep using the full server-side `prelude`
+/// declared below.
+#[cfg(all(not(native), target_family = "wasm"))]
 pub mod prelude {
 	#[cfg(feature = "client-router")]
 	pub use crate::urls::prelude::UnifiedRouter;


### PR DESCRIPTION
## Summary

The \`--with-pages\` scaffold output failed to compile under \`cargo check --target wasm32-unknown-unknown --lib\`, blocking the **WASM Consumer Fixture (#4161 regression)** CI gate. Two distinct errors stem from the same divergence: features the scaffold relies on are silently absent on wasm builds.

```
error[E0432]: unresolved import `reinhardt::prelude`
error: Failed to read installed apps: ... .installed_apps not found.
       Ensure `installed_apps!` is invoked before `#[routes]`.
```

This PR fixes both at the framework layer (no scaffold/template change required, no churn for existing users).

Fixes #4189

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

### B-1: `reinhardt::prelude` was native-only

`src/lib.rs:1162` declares `pub mod prelude` under `#[cfg(native)]`, but the scaffolded `src/config/urls.rs` writes `use reinhardt::prelude::*;` with no cfg gate. Add a wasm-side `pub mod prelude` re-exporting the wasm `UnifiedRouter` (from the existing `urls::prelude` shim added for #4161) so the import resolves on wasm32.

### B-3: `#[routes]` hard-errored on missing state file

The macro called `read_installed_apps()` unconditionally and produced a hard error when the state file was missing. On wasm the scaffold's `mod apps` (containing `installed_apps!`) is gated `#[cfg(server)]`, so the file is never written for wasm builds.

**Why proc-macro env detection isn't an option:** Cargo passes `CARGO_CFG_TARGET_FAMILY` to *build scripts*, not to proc-macro processes. The macro therefore cannot detect the consumer's target at expansion time. (This was the first approach attempted; verifying locally showed the env var is unset during proc-macro execution.)

The chosen fix is to soften the read to \`unwrap_or_default()\` and join the existing \`app_idents.is_empty()\` branch, which already emits the minimal \`url_prelude { pub use super::ResolvedUrls; }\` block — exactly the surface wasm SPA consumers need.

**Trade-off (acceptable):** native consumers who forget to invoke `installed_apps!` no longer get a compile error from `#[routes]`; they silently get an empty `url_prelude`. The hard-error promise has been load-bearing for wasm-incompatibility since `mod apps` started being `#[cfg(server)]`-gated, so dropping it in favor of consistent behavior across targets is the right trade.

## How Was This Tested

End-to-end against a freshly-scaffolded `verifier` project using the same flow as the CI gate:

```bash
# Scaffold
cargo run -p reinhardt-admin-cli -- startproject verifier --with-pages /tmp/verifier
cd /tmp/verifier
cargo run -p reinhardt-admin-cli -- startapp demo --with-pages

# Apply augment patch (#[url_patterns mode=unified|ws]) — covered by PR #4177
git apply .github/fixtures/wasm-consumer-augment.patch

# The gate
cargo check --target wasm32-unknown-unknown --lib
# → Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.07s
```

Both original errors are gone; only benign `unused_imports` warnings on the scaffold-emitted `prelude::*` and `Serialize/Deserialize` remain (pre-existing, unrelated).

Native sanity check:
```bash
cargo check -p reinhardt-web --lib            # passes
cargo clippy -p reinhardt-web -p reinhardt-macros --lib --no-deps -- -D warnings  # clean
cargo fmt -p reinhardt-web -p reinhardt-macros -- --check                          # clean
```

CI's full WASM Consumer Fixture job (`Publish Check / Publish Dry-Run Check`) will exercise the `--use-packaged` path; this PR's gate result will confirm.

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed
- [x] No new TODOs introduced
- [x] Documentation updated where applicable (inline comments explaining the wasm rationale)
- [x] Linked to issue #4189
- [x] Native build passes
- [x] Wasm fixture verifier passes locally

## Labels to Apply

- \`bug\`
- \`high\`
- \`ci-cd\`

## Related

- Discovered while triaging PR #4177 (which fixes the earlier `git -c` ordering and augment-patch hunk-count failures). #4177 unblocks the script far enough to reach the gate where this regression surfaces; both PRs are needed to make the fixture green.
- Related: #4161 (original wasm consumer fixture), #4175 / #4179 (gating `#[routes]` body on wasm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)