### PR TITLE
fix(ci): install wasm32-unknown-unknown target in intra-crate integration test workflow

### DIFF
--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -128,6 +128,14 @@ jobs:
         with:
           tool: wasm-bindgen-cli
 
+      # Required by hot-reload tests in crates/reinhardt-commands
+      # (runserver_hot_reload.rs::hr_1_wasm_change_triggers_wasm_rebuild,
+      # hr_6_issue_4128_reproduction) which invoke an in-process
+      # `cargo build --target wasm32-unknown-unknown` and panic with
+      # TargetNotInstalled when the target is missing. Tracked in #4192.
+      - name: Install wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
+
       # Scope mold to the host target only. A global `RUSTFLAGS=...-fuse-ld=mold`
       # leaks into wasm32 builds (e.g. wasm-pack fixtures) and clang rejects
       # `-fuse-ld=mold` for that target. See reinhardt-web#4147.


### PR DESCRIPTION
## Summary

- Adds `rustup target add wasm32-unknown-unknown` to `.github/workflows/intra-crate-integration-test.yml` so the hot-reload tests in `crates/reinhardt-commands/tests/runserver_hot_reload.rs` can perform their in-process wasm build.
- Fixes `TargetNotInstalled` panics in `hr_1_wasm_change_triggers_wasm_rebuild` (line 240) and `hr_6_issue_4128_reproduction` (line 422) that have been failing shards 2/8 and 5/8 of the Intra-Crate Integration Tests check on every recent run.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

PR #4181 added `wasm-bindgen-cli` install but did not install the `wasm32-unknown-unknown` Rust target itself. The affected tests call `.expect("initial wasm build must succeed")` on a `cargo` invocation, so a missing target is fatal. The tests are explicitly designed to exercise the wasm build path, so installing the target on the runner (Suggested Fix #1 in #4192) preserves coverage rather than silently skipping.

## How Was This Tested

- [x] Workflow YAML edit reviewed; new step is colocated with the existing wasm tooling installs (`wasm-pack`, `wasm-bindgen-cli`).
- [ ] CI re-run on this PR confirms shards 2/8 and 5/8 pass and `hr_1_*` / `hr_6_*` show `passed`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to documentation (n/a — workflow comment included)
- [x] All new and existing tests pass locally (n/a — CI-only change)

## Labels to Apply

- `bug`
- `ci-cd`

## Related Issues

Fixes #4192
Refs #4181, #4180, #4161

🤖 Generated with [Claude Code](https://claude.com/claude-code)