### PR TITLE
feat(commands): make runserver rebuild WASM by default; add --no-override-wasm opt-out

### DIFF
--- a/crates/reinhardt-commands/CHANGELOG.md
+++ b/crates/reinhardt-commands/CHANGELOG.md
@@ -12,9 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `runserver --no-wasm-rebuild` opts out of the in-process WASM rebuild while keeping server hot-reload, for users who manage the wasm build externally. ([#4128](https://github.com/kent8192/reinhardt-web/issues/4128))
+- `runserver --no-override-wasm` reuses existing WASM artifacts in `dist/` when present/up-to-date, for callers that explicitly opt out of rebuilds (e.g. cargo-make tasks that pre-run `wasm-build-dev`). ([#4205](https://github.com/kent8192/reinhardt-web/issues/4205))
 
 ### Changed
 - `cargo make watch`, `watch-test`, `watch-clippy`, `runserver-watch`, `dev-watch`, and `install-bacon` were removed from the workspace, the project templates, and the bundled examples. The built-in runserver hot-reload supersedes them; users who relied on `bacon` for unrelated workflows can invoke `bacon` directly. ([#4128](https://github.com/kent8192/reinhardt-web/issues/4128))
+- `runserver --with-pages` now rebuilds the Pages/Admin WASM bundle by default at startup and on every hot-reload restart. The previous "skip if artifacts exist / up-to-date" behavior is now opt-in via `--no-override-wasm`, preventing stale `dist/` content from being served after edits to client-side Rust code. ([#4205](https://github.com/kent8192/reinhardt-web/issues/4205))
+
+### Deprecated
+- `runserver --force-wasm` is now redundant (rebuild is the default) and emits a deprecation warning when invoked. To be removed in a future major release. ([#4205](https://github.com/kent8192/reinhardt-web/issues/4205))
 
 ## [0.1.0-rc.26](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0-rc.25...reinhardt-commands@v0.1.0-rc.26) - 2026-05-05
 

--- a/crates/reinhardt-commands/src/bin/runserver.rs
+++ b/crates/reinhardt-commands/src/bin/runserver.rs
@@ -80,7 +80,12 @@ struct Args {
 	#[arg(long)]
 	no_wasm: bool,
 
-	/// Force rebuild WASM even when artifacts are up-to-date relative to sources.
+	/// Reuse existing WASM artifacts in dist/ when they are up-to-date relative to
+	/// sources (the prior default). Without this flag, WASM is always rebuilt.
+	#[arg(long)]
+	no_override_wasm: bool,
+
+	/// DEPRECATED: rebuild is now the default. Use --no-override-wasm to opt out.
 	#[arg(long)]
 	force_wasm: bool,
 
@@ -465,7 +470,7 @@ fn build_admin_wasm(force: bool) -> bool {
 	if !force && !is_wasm_stale(&admin_crate_dir, &artifact) {
 		println!(
 			"{}",
-			"Admin WASM: artifacts up to date, skipping build".dimmed()
+			"Admin WASM: artifacts up to date, skipping build (--no-override-wasm)".dimmed()
 		);
 		return true;
 	}
@@ -565,7 +570,7 @@ fn build_pages_wasm(force: bool) -> bool {
 	if !force && !is_wasm_stale(&cwd, &artifact) {
 		println!(
 			"{}",
-			"Pages WASM: artifacts up to date, skipping build".dimmed()
+			"Pages WASM: artifacts up to date, skipping build (--no-override-wasm)".dimmed()
 		);
 		return true;
 	}
@@ -610,17 +615,33 @@ fn build_pages_wasm(force: bool) -> bool {
 }
 
 /// Orchestrate WASM builds for all enabled targets.
-fn build_wasm_targets(no_wasm: bool, force_wasm: bool) {
+///
+/// `no_override_wasm` honours up-to-date `dist/` artifacts (the prior default);
+/// without it, WASM is rebuilt unconditionally to avoid serving stale bundles.
+/// `force_wasm_legacy` accepts the deprecated `--force-wasm` flag and emits a
+/// warning; rebuild is otherwise the default.
+fn build_wasm_targets(no_wasm: bool, no_override_wasm: bool, force_wasm_legacy: bool) {
 	if no_wasm {
 		println!("{}", "WASM builds skipped (--no-wasm)".dimmed());
 		return;
 	}
 
+	if force_wasm_legacy {
+		eprintln!(
+			"{}",
+			"Warning: --force-wasm is now the default behavior; this flag is deprecated. \
+			 Use --no-override-wasm to opt out of rebuilds."
+				.yellow()
+		);
+	}
+
+	let force = !no_override_wasm;
+
 	#[cfg(feature = "admin")]
-	build_admin_wasm(force_wasm);
+	build_admin_wasm(force);
 
 	#[cfg(feature = "pages")]
-	build_pages_wasm(force_wasm);
+	build_pages_wasm(force);
 }
 
 /// Run collectstatic to copy all static files into STATIC_ROOT.
@@ -736,7 +757,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	}
 
 	// Phase 1: Build WASM targets
-	build_wasm_targets(args.no_wasm, args.force_wasm);
+	build_wasm_targets(args.no_wasm, args.no_override_wasm, args.force_wasm);
 
 	// Load settings at startup
 	let settings = Arc::new(load_settings());

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1334,8 +1334,13 @@ impl BaseCommand for RunServerCommand {
 			CommandOption::flag(None, "no-wasm", "Skip WASM build at startup"),
 			CommandOption::flag(
 				None,
+				"no-override-wasm",
+				"Reuse existing WASM artifacts in dist/ if present (default: rebuild)",
+			),
+			CommandOption::flag(
+				None,
 				"force-wasm",
-				"Force rebuild WASM even if artifacts exist",
+				"DEPRECATED: rebuild is now the default. Use --no-override-wasm to opt out.",
 			),
 			CommandOption::flag(
 				None,
@@ -1361,10 +1366,18 @@ impl BaseCommand for RunServerCommand {
 		#[cfg(feature = "pages")]
 		{
 			let no_wasm = ctx.has_option("no-wasm");
-			let force_wasm = ctx.has_option("force-wasm");
+			let no_override_wasm = ctx.has_option("no-override-wasm");
+			let force_wasm_legacy = ctx.has_option("force-wasm");
+			if force_wasm_legacy {
+				ctx.warning(
+					"--force-wasm is now the default behavior; this flag is deprecated. \
+					 Use --no-override-wasm to opt out of rebuilds.",
+				);
+			}
+			let force = !no_override_wasm;
 			let wasm_optional = ctx.has_option("wasm-optional");
 			if with_pages
-				&& !no_wasm && let Err(e) = Self::build_pages_wasm(ctx, force_wasm)
+				&& !no_wasm && let Err(e) = Self::build_pages_wasm(ctx, force)
 			{
 				if wasm_optional {
 					ctx.warning(&format!(
@@ -2024,7 +2037,10 @@ impl RunServerCommand {
 		let js_name = crate_name.replace('-', "_");
 		let artifact = cwd.join("dist").join(format!("{}.js", js_name));
 		if artifact.exists() && !force {
-			ctx.info("Pages WASM: artifacts exist, skipping build (use --force-wasm to rebuild)");
+			ctx.info(&format!(
+				"Pages WASM: --no-override-wasm set and dist/{}.js exists, skipping build",
+				js_name
+			));
 			return Ok(());
 		}
 
@@ -3285,6 +3301,28 @@ mod tests {
 		let options = cmd.options();
 		// Should have migration-related options
 		assert!(!options.is_empty());
+	}
+
+	#[test]
+	fn test_runserver_command_options_include_no_override_wasm() {
+		// Arrange
+		let cmd = RunServerCommand;
+
+		// Act
+		let options = cmd.options();
+		let option_names: Vec<&str> = options.iter().map(|o| o.long.as_str()).collect();
+
+		// Assert: --no-override-wasm replaces --force-wasm as the supported opt-out;
+		// --force-wasm is retained as a deprecated alias.
+		assert!(
+			option_names.contains(&"no-override-wasm"),
+			"--no-override-wasm must be registered as a runserver option"
+		);
+		assert!(
+			option_names.contains(&"force-wasm"),
+			"--force-wasm must remain registered (deprecated alias)"
+		);
+		assert!(option_names.contains(&"no-wasm"));
 	}
 
 	#[test]

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -134,6 +134,22 @@ pub enum Commands {
 		#[arg(long = "no-wasm-rebuild")]
 		no_wasm_rebuild: bool,
 
+		/// Skip the WASM build at startup (existing artifacts in dist/ are served as-is).
+		#[arg(long = "no-wasm")]
+		no_wasm: bool,
+
+		/// Reuse existing WASM artifacts in dist/ if present (default: rebuild on every start).
+		#[arg(long = "no-override-wasm")]
+		no_override_wasm: bool,
+
+		/// DEPRECATED: rebuild is now the default. Use --no-override-wasm to opt out.
+		#[arg(long = "force-wasm")]
+		force_wasm: bool,
+
+		/// Allow the server to start even when the WASM build fails.
+		#[arg(long = "wasm-optional")]
+		wasm_optional: bool,
+
 		/// Serve static files in development mode
 		#[arg(long)]
 		insecure: bool,
@@ -526,6 +542,10 @@ pub async fn run_command_with_registry(
 			address,
 			noreload,
 			no_wasm_rebuild,
+			no_wasm,
+			no_override_wasm,
+			force_wasm,
+			wasm_optional,
 			insecure,
 			no_docs,
 			with_pages,
@@ -537,6 +557,10 @@ pub async fn run_command_with_registry(
 				address,
 				noreload,
 				no_wasm_rebuild,
+				no_wasm,
+				no_override_wasm,
+				force_wasm,
+				wasm_optional,
 				insecure,
 				no_docs,
 				with_pages,
@@ -768,6 +792,10 @@ struct RunServerOptions {
 	address: String,
 	noreload: bool,
 	no_wasm_rebuild: bool,
+	no_wasm: bool,
+	no_override_wasm: bool,
+	force_wasm: bool,
+	wasm_optional: bool,
 	insecure: bool,
 	no_docs: bool,
 	with_pages: bool,
@@ -788,6 +816,18 @@ async fn execute_runserver(options: RunServerOptions) -> Result<(), Box<dyn std:
 	}
 	if options.no_wasm_rebuild {
 		ctx.set_option("no-wasm-rebuild".to_string(), "true".to_string());
+	}
+	if options.no_wasm {
+		ctx.set_option("no-wasm".to_string(), "true".to_string());
+	}
+	if options.no_override_wasm {
+		ctx.set_option("no-override-wasm".to_string(), "true".to_string());
+	}
+	if options.force_wasm {
+		ctx.set_option("force-wasm".to_string(), "true".to_string());
+	}
+	if options.wasm_optional {
+		ctx.set_option("wasm-optional".to_string(), "true".to_string());
 	}
 	if options.insecure {
 		ctx.set_option("insecure".to_string(), "true".to_string());
@@ -1348,6 +1388,10 @@ mod tests {
 			address: "127.0.0.1:8000".to_string(),
 			noreload: false,
 			no_wasm_rebuild: false,
+			no_wasm: false,
+			no_override_wasm: false,
+			force_wasm: false,
+			wasm_optional: false,
 			insecure: false,
 			no_docs: false,
 			with_pages: false,
@@ -1531,6 +1575,10 @@ mod tests {
 			address: "127.0.0.1:8000".to_string(),
 			noreload: false,
 			no_wasm_rebuild: false,
+			no_wasm: false,
+			no_override_wasm: false,
+			force_wasm: false,
+			wasm_optional: false,
 			insecure: false,
 			no_docs: false,
 			with_pages: true,
@@ -1554,6 +1602,10 @@ mod tests {
 			address: "127.0.0.1:8000".to_string(),
 			noreload: false,
 			no_wasm_rebuild: false,
+			no_wasm: false,
+			no_override_wasm: false,
+			force_wasm: false,
+			wasm_optional: false,
 			insecure: false,
 			no_docs: false,
 			with_pages: false,
@@ -1577,6 +1629,10 @@ mod tests {
 			address: "127.0.0.1:8000".to_string(),
 			noreload: false,
 			no_wasm_rebuild: false,
+			no_wasm: false,
+			no_override_wasm: false,
+			force_wasm: false,
+			wasm_optional: false,
 			insecure: false,
 			no_docs: false,
 			with_pages: true,
@@ -1601,6 +1657,10 @@ mod tests {
 			address: "127.0.0.1:8000".to_string(),
 			noreload: false,
 			no_wasm_rebuild: false,
+			no_wasm: false,
+			no_override_wasm: false,
+			force_wasm: false,
+			wasm_optional: false,
 			insecure: false,
 			no_docs: false,
 			with_pages: false,
@@ -1628,6 +1688,10 @@ mod tests {
 			address: "127.0.0.1:8000".to_string(),
 			noreload: false,
 			no_wasm_rebuild: true,
+			no_wasm: false,
+			no_override_wasm: false,
+			force_wasm: false,
+			wasm_optional: false,
 			insecure: false,
 			no_docs: false,
 			with_pages: false,
@@ -1650,6 +1714,120 @@ mod tests {
 
 		// Assert
 		assert_eq!(ctx.option("no-wasm-rebuild"), Some(&"true".to_string()));
+	}
+
+	#[rstest]
+	fn test_runserver_no_override_wasm_flag_propagates() {
+		// Arrange: build options as the CLI parser would after `--no-override-wasm`
+		let options = RunServerOptions {
+			address: "127.0.0.1:8000".to_string(),
+			noreload: false,
+			no_wasm_rebuild: false,
+			no_wasm: false,
+			no_override_wasm: true,
+			force_wasm: false,
+			wasm_optional: false,
+			insecure: false,
+			no_docs: false,
+			with_pages: true,
+			static_dir: "dist".to_string(),
+			no_spa: false,
+			index: None,
+			verbosity: 0,
+		};
+
+		// Act: replicate execute_runserver's option propagation onto a CommandContext
+		let mut ctx = CommandContext::default();
+		ctx.add_arg(options.address);
+		if options.no_override_wasm {
+			ctx.set_option("no-override-wasm".to_string(), "true".to_string());
+		}
+		if options.with_pages {
+			ctx.set_option("with-pages".to_string(), "true".to_string());
+		}
+
+		// Assert
+		assert_eq!(ctx.option("no-override-wasm"), Some(&"true".to_string()));
+		assert_eq!(ctx.option("with-pages"), Some(&"true".to_string()));
+	}
+
+	#[rstest]
+	fn test_runserver_force_wasm_legacy_flag_propagates() {
+		// Arrange: legacy `--force-wasm` is still parsed but emits a deprecation
+		// warning at runtime; the CommandContext key is preserved so RunServerCommand
+		// can detect it and emit the warning.
+		let options = RunServerOptions {
+			address: "127.0.0.1:8000".to_string(),
+			noreload: false,
+			no_wasm_rebuild: false,
+			no_wasm: false,
+			no_override_wasm: false,
+			force_wasm: true,
+			wasm_optional: false,
+			insecure: false,
+			no_docs: false,
+			with_pages: true,
+			static_dir: "dist".to_string(),
+			no_spa: false,
+			index: None,
+			verbosity: 0,
+		};
+
+		// Act
+		let mut ctx = CommandContext::default();
+		ctx.add_arg(options.address);
+		if options.force_wasm {
+			ctx.set_option("force-wasm".to_string(), "true".to_string());
+		}
+
+		// Assert
+		assert_eq!(ctx.option("force-wasm"), Some(&"true".to_string()));
+	}
+
+	#[rstest]
+	fn test_runserver_clap_accepts_no_override_wasm() {
+		use clap::Parser;
+
+		// Arrange & Act: clap parsing must accept the new flag.
+		let cli = Cli::parse_from(["manage", "runserver", "--with-pages", "--no-override-wasm"]);
+
+		// Assert
+		match cli.command {
+			Commands::Runserver {
+				with_pages,
+				no_override_wasm,
+				force_wasm,
+				..
+			} => {
+				assert!(with_pages, "--with-pages should be parsed");
+				assert!(no_override_wasm, "--no-override-wasm should be parsed");
+				assert!(!force_wasm, "--force-wasm was not provided");
+			}
+			#[allow(unreachable_patterns)]
+			_ => panic!("Expected Commands::Runserver"),
+		}
+	}
+
+	#[rstest]
+	fn test_runserver_clap_accepts_force_wasm_legacy() {
+		use clap::Parser;
+
+		// Arrange & Act: legacy `--force-wasm` must still parse for back-compat.
+		let cli = Cli::parse_from(["manage", "runserver", "--with-pages", "--force-wasm"]);
+
+		// Assert
+		match cli.command {
+			Commands::Runserver {
+				force_wasm,
+				no_override_wasm,
+				..
+			} => {
+				assert!(force_wasm, "--force-wasm should still parse (deprecated)");
+				assert!(!no_override_wasm, "--no-override-wasm was not provided");
+			}
+			#[allow(unreachable_patterns)]
+			_ => panic!("Expected Commands::Runserver"),
+		}
 	}
 
 	#[rstest]
@@ -1680,6 +1858,10 @@ mod tests {
 			address: "127.0.0.1:8000".to_string(),
 			noreload: false,
 			no_wasm_rebuild: false,
+			no_wasm: false,
+			no_override_wasm: false,
+			force_wasm: false,
+			wasm_optional: false,
 			insecure: false,
 			no_docs: false,
 			with_pages: false,

--- a/crates/reinhardt-commands/templates/project_pages_template/Makefile.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/Makefile.toml.tpl
@@ -25,7 +25,8 @@ WASM_BINDGEN_VERSION = "0.2.100"
 [tasks.runserver]
 description = "Start the development server with static files (auto-reloads)"
 command = "cargo"
-args = ["run", "--bin", "manage", "runserver", "--with-pages"]
+# `wasm-build-dev` already produced fresh artifacts; skip runserver's own rebuild.
+args = ["run", "--bin", "manage", "runserver", "--with-pages", "--no-override-wasm"]
 dependencies = ["wasm-build-dev"]
 
 # ============================================================================

--- a/examples/examples-tutorial-basis/Makefile.toml
+++ b/examples/examples-tutorial-basis/Makefile.toml
@@ -287,7 +287,8 @@ if [ "$CURRENT_DIR" != "examples-tutorial-basis" ]; then
 fi
 
 echo "🚀 Starting development server with WASM frontend..."
-cargo run --bin examples-tutorial-basis -- runserver --with-pages --noreload
+# wasm-build-dev already produced fresh artifacts; skip runserver's own rebuild.
+cargo run --bin examples-tutorial-basis -- runserver --with-pages --noreload --no-override-wasm
 '''
 
 [tasks.dev-release]
@@ -298,7 +299,8 @@ dependencies = ["clean-cache", "wasm-build-release", "collectstatic", "run-dev-r
 script = '''
 #!/bin/bash
 echo "🚀 Starting server with optimized WASM frontend..."
-cargo run --release --bin examples-tutorial-basis -- runserver --with-pages --noreload
+# wasm-build-release already produced optimized artifacts; skip runserver's own rebuild.
+cargo run --release --bin examples-tutorial-basis -- runserver --with-pages --noreload --no-override-wasm
 '''
 
 # ============================================================================

--- a/examples/examples-twitter/Makefile.toml
+++ b/examples/examples-twitter/Makefile.toml
@@ -303,7 +303,8 @@ if [ "$CURRENT_DIR" != "examples-twitter" ]; then
 fi
 
 echo "🚀 Starting development server with WASM frontend..."
-cargo run --bin examples-twitter -- runserver --with-pages --noreload
+# wasm-build-dev already produced fresh artifacts; skip runserver's own rebuild.
+cargo run --bin examples-twitter -- runserver --with-pages --noreload --no-override-wasm
 '''
 
 [tasks.dev-release]
@@ -314,7 +315,8 @@ dependencies = ["clean-cache", "wasm-build-release", "collectstatic", "run-dev-r
 script = '''
 #!/bin/bash
 echo "🚀 Starting server with optimized WASM frontend..."
-cargo run --release --bin examples-twitter -- runserver --with-pages --noreload
+# wasm-build-release already produced optimized artifacts; skip runserver's own rebuild.
+cargo run --release --bin examples-twitter -- runserver --with-pages --noreload --no-override-wasm
 '''
 
 # ============================================================================


### PR DESCRIPTION
## Summary

This PR addresses:

- Flips the default of `runserver --with-pages` so that the Pages and Admin WASM bundles are **rebuilt on every startup** (and on every hot-reload restart), instead of being skipped when `dist/` artefacts already exist or are mtime-up-to-date.
- Adds a new `--no-override-wasm` opt-out flag that preserves the prior "reuse existing artefacts" behavior, for callers (e.g. cargo-make tasks that pre-run `wasm-build-dev`) that want to avoid the redundant build.
- Deprecates `--force-wasm`: it remains accepted (rebuild is now the default, so it is a no-op) but emits a runtime warning. Slated for removal in a future major release.
- Wires the new and existing WASM-related flags (`--no-wasm`, `--force-wasm`, `--wasm-optional`, `--no-override-wasm`) through the `manage` CLI parser, which previously did not propagate them despite their declarations on `RunServerCommand::options()`.
- Updates the project page template and the bundled examples (`examples-twitter`, `examples-tutorial-basis`) to pin `--no-override-wasm` on `dev` / `dev-release` tasks that already run a dedicated WASM build step, so no double-build is paid for those tasks.

Updated flag matrix:

| Flags | Behavior |
|-------|----------|
| (default) | always rebuild |
| `--no-override-wasm` | reuse existing `dist/` artefacts (skip if present / up-to-date) |
| `--no-wasm` | never build |
| `--force-wasm` | (deprecated) same as default + emits a deprecation warning |

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes

## Motivation and Context

The previous "skip if artefacts exist / are up-to-date" default optimised for the rare case of "developer wants to iterate on the server without touching the client," at the cost of correctness in the common case. After editing client-side Rust code without remembering to run `cargo make wasm-build-dev` (or pass `--force-wasm`), the server cheerfully served the previous build's `dist/`, masking regressions during browser testing. The hot-reload restart path inherited the same skip, so source edits had no effect on the running app until the developer manually deleted `dist/` or restarted with `--force-wasm`.

Forced rebuild is cheap when nothing changed (`cargo build` is incremental) and catches stale-artefact bugs immediately — a much better trade-off for the common iterative-development workflow.

Fixes #4205

Related to: #4128 (hot-reload pipeline) and the typed-URL refactor in reinhardt-cloud#519/PR#545 where stale-WASM nearly masked a regression.

## How Was This Tested?

- \`cargo check -p reinhardt-commands --all-features\`: clean.
- \`cargo make fmt-check\`, \`cargo make clippy-check\`: clean.
- \`cargo nextest run -p reinhardt-commands --all-features\`: 950/950 passed, including 5 new tests:
  - \`builtin::tests::test_runserver_command_options_include_no_override_wasm\` — verifies the new flag is registered on \`RunServerCommand::options()\` and that \`--force-wasm\` is retained (deprecated alias).
  - \`cli::tests::test_runserver_clap_accepts_no_override_wasm\` — round-trips \`manage runserver --with-pages --no-override-wasm\` through clap.
  - \`cli::tests::test_runserver_clap_accepts_force_wasm_legacy\` — round-trips the legacy \`--force-wasm\` for backward compatibility.
  - \`cli::tests::test_runserver_no_override_wasm_flag_propagates\` — verifies \`RunServerOptions\` propagation onto \`CommandContext\`.
  - \`cli::tests::test_runserver_force_wasm_legacy_flag_propagates\` — same for the deprecated alias.

## Breaking Changes

None at the user-visible API level. The behavior change is intended (Issue acceptance criteria), and \`--force-wasm\` remains accepted (with a deprecation warning) for backward compatibility. Pre-built cargo-make tasks in the bundled templates and examples have been updated in the same PR to pin \`--no-override-wasm\` so they retain their current cost profile.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable) — \`crates/reinhardt-commands/CHANGELOG.md\` Unreleased section.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable) — N/A
- [x] I have formatted the code with \`cargo make fmt-fix\`
- [x] I have checked the code with \`cargo make clippy-check\`

## Related Issues

- Fixes #4205
- Refs #4128 (hot-reload pipeline that re-enters the WASM build path)

## Labels to Apply

### Type Label (select one)
- [x] \`enhancement\` - New feature or improvement

### Scope Label (select all that apply)
- [x] \`ci-cd\` - dev-loop tooling (cargo-make tasks, runserver flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)