### PR TITLE
fix(ci): apply rustfmt to admin vendor shim

### DIFF
--- a/crates/reinhardt-admin/src/core/vendor.rs
+++ b/crates/reinhardt-admin/src/core/vendor.rs
@@ -111,8 +111,6 @@ pub async fn download_vendor_assets(
 	note = "Use reinhardt_utils::staticfiles::vendor::ensure_vendor_assets_for_app instead"
 )]
 pub async fn ensure_vendor_assets(base_dir: &std::path::Path) {
-	let _ = reinhardt_utils::staticfiles::vendor::ensure_vendor_assets_for_app(
-		"admin", base_dir,
-	)
-	.await;
+	let _ =
+		reinhardt_utils::staticfiles::vendor::ensure_vendor_assets_for_app("admin", base_dir).await;
 }


### PR DESCRIPTION
## Summary

Run rustfmt on `crates/reinhardt-admin/src/core/vendor.rs` so the `Format / Format Check` job passes again.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The deprecated-shim re-introduction in `26d721d fix(ci): restore admin/core/vendor as deprecated shim to satisfy semver` left a multi-line function call that current rustfmt collapses onto a two-line wrapped form. The mismatch broke `Format / Format Check` on `main` and propagated to every downstream PR — including the release-plz PR #4209, which carries no source changes but inherited the unformatted file.

```text
[1733/2733] Would format: crates/reinhardt-admin/src/core/vendor.rs
Summary: 1 would be formatted, 2732 unchanged, 0 errors
Error: Execution error: Some files are not properly formatted
```

This PR is a one-file rustfmt application with no behavioural impact.

Fixes #4210

## How Was This Tested?

- `cargo fmt --check -- crates/reinhardt-admin/src/core/vendor.rs` exits 0.
- `cargo fmt --check --all` exits 0 (no other formatting drift on `main`).

## Checklist

- [x] No source-logic changes (formatting only)
- [x] `cargo fmt --check --all` passes locally
- [x] Linked issue includes reproduction commands
- [x] Release-plz PR #4209 will pass on its next regeneration once this lands

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)