### PR TITLE
fix(commands): trigger hot-reload rebuild on Cargo.lock changes

### DIFF
--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -28,7 +28,9 @@ pub const DEBOUNCE_WINDOW: Duration = Duration::from_millis(300);
 ///
 /// The accept rules are intentionally narrow:
 /// * Event kind must be `Modify`, `Create`, or `Remove`.
-/// * At least one path must end in `.rs` or `.toml`.
+/// * At least one path must end in `.rs` or `.toml`, or have the exact
+///   file name `Cargo.lock` (matched via `Path::file_name`, so unrelated
+///   `.lock` files and `Cargo.lock.bak` do not slip through).
 /// * Paths inside `target/` or `.git/`, and editor sidecar files
 ///   (`~`, `.swp`, `.tmp`), are rejected.
 pub fn is_relevant_change(event: &Event) -> bool {
@@ -113,8 +115,11 @@ pub struct WatcherConfig {
 /// The loop handles three concerns:
 ///
 /// 1. Subscribes the recommended `notify` watcher to every existing
-///    `roots.src_dirs` (recursively) and `roots.manifest_files`
-///    (non-recursively). Non-existent paths are skipped without error.
+///    `roots.src_dirs` (recursively), `roots.manifest_files`
+///    (non-recursively), and `roots.lockfile` when present
+///    (non-recursively, so `cargo update` triggers a rebuild even when
+///    no path-dep source files change; see issue #4214). Non-existent
+///    paths are skipped without error.
 /// 2. Awaits debounced events, dispatching each to the WASM pipeline
 ///    (when `pages_enabled && !no_wasm_rebuild`) and then the server
 ///    pipeline. Pipeline failures are logged but never returned as `Err`.

--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -42,12 +42,15 @@ pub fn is_relevant_change(event: &Event) -> bool {
 	}
 	event.paths.iter().any(|p| {
 		let path_str = p.to_string_lossy();
+		// `Path::file_name` (not suffix matching) so that `Cargo.lock.bak`
+		// and unrelated `.lock` files do not slip through. See issue #4214.
+		let is_cargo_lock = p.file_name() == Some(std::ffi::OsStr::new("Cargo.lock"));
 		!path_str.contains("/target/")
 			&& !path_str.contains("/.git/")
 			&& !path_str.ends_with('~')
 			&& !path_str.ends_with(".swp")
 			&& !path_str.ends_with(".tmp")
-			&& (path_str.ends_with(".rs") || path_str.ends_with(".toml"))
+			&& (path_str.ends_with(".rs") || path_str.ends_with(".toml") || is_cargo_lock)
 	})
 }
 
@@ -157,6 +160,13 @@ pub async fn run_watcher(
 		if manifest.exists() {
 			watcher.watch(manifest, RecursiveMode::NonRecursive)?;
 		}
+	}
+	// Subscribe the workspace Cargo.lock so `cargo update` triggers a
+	// rebuild even when no path-dep source files change. See issue #4214.
+	if let Some(lockfile) = &config.roots.lockfile
+		&& lockfile.exists()
+	{
+		watcher.watch(lockfile, RecursiveMode::NonRecursive)?;
 	}
 
 	let mut shutdown_rx = shutdown_rx;

--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -271,6 +271,13 @@ mod tests {
 		false
 	)]
 	#[case::markdown_rejected(EventKind::Modify(ModifyKind::Any), "/project/README.md", false)]
+	#[case::cargo_lock_modify(EventKind::Modify(ModifyKind::Any), "/project/Cargo.lock", true)]
+	#[case::cargo_lock_bak_rejected(
+		EventKind::Modify(ModifyKind::Any),
+		"/project/Cargo.lock.bak",
+		false
+	)]
+	#[case::generic_lock_rejected(EventKind::Modify(ModifyKind::Any), "/project/foo.lock", false)]
 	fn is_relevant_change_filter_cases(
 		#[case] kind: EventKind,
 		#[case] path: &str,

--- a/crates/reinhardt-commands/src/source_roots.rs
+++ b/crates/reinhardt-commands/src/source_roots.rs
@@ -26,6 +26,11 @@ pub struct SourceRoots {
 	pub src_dirs: Vec<PathBuf>,
 	/// Per-package `Cargo.toml` files to watch as single files.
 	pub manifest_files: Vec<PathBuf>,
+	/// Workspace `Cargo.lock`. Watched separately so that `cargo update`
+	/// against git/registry deps still triggers a rebuild, even when no
+	/// path-dep source changes. `None` only when `from_metadata` cannot
+	/// anchor on the supplied manifest. See issue #4214.
+	pub lockfile: Option<PathBuf>,
 }
 
 impl SourceRoots {
@@ -49,6 +54,7 @@ impl SourceRoots {
 			return SourceRoots {
 				src_dirs: Vec::new(),
 				manifest_files: Vec::new(),
+				lockfile: None,
 			};
 		};
 
@@ -86,6 +92,7 @@ impl SourceRoots {
 		SourceRoots {
 			src_dirs: src_dirs.into_iter().collect(),
 			manifest_files: manifest_files.into_iter().collect(),
+			lockfile: Some(PathBuf::from(metadata.workspace_root.as_str()).join("Cargo.lock")),
 		}
 	}
 }

--- a/crates/reinhardt-commands/src/source_roots.rs
+++ b/crates/reinhardt-commands/src/source_roots.rs
@@ -131,6 +131,10 @@ mod tests {
 			roots.manifest_files,
 			vec![PathBuf::from("/fixtures/single_crate/Cargo.toml")]
 		);
+		assert_eq!(
+			roots.lockfile,
+			Some(PathBuf::from("/fixtures/single_crate/Cargo.lock"))
+		);
 	}
 
 	#[rstest]
@@ -157,6 +161,10 @@ mod tests {
 				PathBuf::from("/fixtures/ws/shared/Cargo.toml"),
 			]
 		);
+		assert_eq!(
+			roots.lockfile,
+			Some(PathBuf::from("/fixtures/ws/Cargo.lock"))
+		);
 	}
 
 	#[rstest]
@@ -178,5 +186,26 @@ mod tests {
 			roots.manifest_files,
 			vec![PathBuf::from("/fixtures/registry_dep/Cargo.toml")]
 		);
+		assert_eq!(
+			roots.lockfile,
+			Some(PathBuf::from("/fixtures/registry_dep/Cargo.lock"))
+		);
+	}
+
+	#[rstest]
+	fn anchor_not_in_metadata_yields_no_lockfile() {
+		// Arrange: use the workspace fixture but a manifest path that
+		// matches no package. The function should hit the early-return
+		// branch where every output (including lockfile) is empty/None.
+		let metadata = parse_metadata(WORKSPACE_JSON);
+		let anchor_manifest = PathBuf::from("/nonexistent/Cargo.toml");
+
+		// Act
+		let roots = SourceRoots::from_metadata(&metadata, &anchor_manifest);
+
+		// Assert
+		assert!(roots.src_dirs.is_empty());
+		assert!(roots.manifest_files.is_empty());
+		assert_eq!(roots.lockfile, None);
 	}
 }

--- a/crates/reinhardt-commands/tests/runserver_hot_reload.rs
+++ b/crates/reinhardt-commands/tests/runserver_hot_reload.rs
@@ -295,6 +295,7 @@ async fn hr_3_no_wasm_rebuild_flag_skips_wasm_pipeline() {
 		roots: SourceRoots {
 			src_dirs: Vec::new(),
 			manifest_files: Vec::new(),
+			lockfile: None,
 		},
 		no_wasm_rebuild: true,
 		pages_enabled: true,
@@ -494,6 +495,7 @@ async fn hr_7_run_watcher_processes_events() {
 		roots: SourceRoots {
 			src_dirs: vec![fixture.path().join("src")],
 			manifest_files: vec![fixture.path().join("Cargo.toml")],
+			lockfile: None,
 		},
 		no_wasm_rebuild: true,
 		pages_enabled: false,


### PR DESCRIPTION
## Summary

- Extend `SourceRoots` with `lockfile: Option<PathBuf>` populated from `metadata.workspace_root`
- Accept `Cargo.lock` (by exact filename, via `Path::file_name`) in `is_relevant_change`
- Subscribe the workspace lockfile in `run_watcher`
- Update existing `runserver_hot_reload` integration test fixtures for the new field

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Without this, `cargo update -p <git-pinned-crate>` during a running `runserver --with-pages` session leaves the WASM bundle stale until the developer manually restarts. The gap produced five false-positive regression reports against the SPA navigation regression class: #4075, #4088, #4122, #4203, #4213.

Two cooperating filters in `crates/reinhardt-commands/src/` excluded `Cargo.lock`:

1. `source_roots.rs::SourceRoots::from_metadata` walks **path dependencies only**, so the workspace `Cargo.lock` was never enumerated as a watch target.
2. `debounced_watcher.rs::is_relevant_change` accepts `.rs`/`.toml` only, so even if the event arrived it would be discarded.

This PR closes both filters without altering the existing accept/reject behaviour for `.rs`, `.toml`, `target/`, `.git/`, or editor sidecar files. `Path::file_name` is used (not suffix matching) so similar names like `Cargo.lock.bak` and unrelated `foo.lock` files do not slip through.

## How Was This Tested

- `cargo nextest run -p reinhardt-commands` — 838/838 pass (3 new `is_relevant_change` rstest cases + 3 updated `source_roots::tests` cases + 1 new anchor-mismatch case)
- `cargo make fmt-check` — clean
- `cargo make clippy-check` — clean

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- \`bug\`
- \`medium\`

## Related Issues

Fixes #4214

🤖 Generated with [Claude Code](https://claude.com/claude-code)