### PR TITLE
test(routing): add direct symptom-shape test for history.state regression

### DIFF
--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -297,6 +297,11 @@ path = "tests/wasm/spa_navigation_diag_named_test.rs"
 required-features = ["wasm-diag-test"]
 
 [[test]]
+name = "history_state_shape_test"
+path = "tests/wasm/history_state_shape_test.rs"
+required-features = ["wasm-diag-test"]
+
+[[test]]
 name = "spa_navigation_full_layout_e2e_test"
 path = "tests/integration/spa_navigation_full_layout_e2e_test.rs"
 required-features = ["e2e-cdp-test"]

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -302,6 +302,11 @@ path = "tests/wasm/history_state_shape_test.rs"
 required-features = ["wasm-diag-test"]
 
 [[test]]
+name = "wasm_bindgen_abi_pin_test"
+path = "tests/wasm/wasm_bindgen_abi_pin_test.rs"
+required-features = ["wasm-diag-test"]
+
+[[test]]
 name = "spa_navigation_full_layout_e2e_test"
 path = "tests/integration/spa_navigation_full_layout_e2e_test.rs"
 required-features = ["e2e-cdp-test"]

--- a/crates/reinhardt-pages/tests/wasm/history_state_shape_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/history_state_shape_test.rs
@@ -20,7 +20,8 @@
 #![cfg(wasm)]
 
 use reinhardt_pages::app::{ClientLauncher, with_router};
-use reinhardt_pages::component::{IntoPage, Page, PageElement};
+use reinhardt_pages::component::Page;
+use reinhardt_pages::page;
 use reinhardt_pages::router::Router;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
@@ -28,17 +29,21 @@ use wasm_bindgen_test::*;
 wasm_bindgen_test_configure!(run_in_browser);
 
 fn home_page() -> Page {
-	PageElement::new("div")
-		.attr("id", "route-home")
-		.child("HOME")
-		.into_page()
+	page!(|| {
+		div {
+			id: "route-home",
+			"HOME"
+		}
+	})()
 }
 
 fn clusters_page() -> Page {
-	PageElement::new("div")
-		.attr("id", "route-clusters")
-		.child("CLUSTERS")
-		.into_page()
+	page!(|| {
+		div {
+			id: "route-clusters",
+			"CLUSTERS"
+		}
+	})()
 }
 
 fn install_app_root() -> web_sys::Element {
@@ -58,16 +63,20 @@ fn build_router() -> Router {
 		.named_route("clusters:list", "/clusters", clusters_page)
 }
 
-/// Read `typeof history.state` via `js_sys::Reflect`.
+/// Classify `history.state` into a JS-`typeof`-style label using
+/// `wasm_bindgen` helpers (`is_null`, `is_string`, `is_object`, ...).
 ///
-/// Returns the JS-level `typeof` result so the assertion can be expressed
-/// in the same vocabulary as the Issue #4221 reproduction (DevTools
-/// `typeof history.state`).
+/// This is a coarse heuristic, not a call into JS `typeof`, but it
+/// covers every shape relevant to the Issue #4221 reproduction
+/// (object vs. string) and is expressed in the same vocabulary as
+/// DevTools `typeof history.state`.
 fn typeof_history_state() -> String {
 	let window = web_sys::window().expect("window");
 	let history = window.history().expect("history");
 	let state = history.state().expect("state");
-	// JS-level typeof: cheaper than building a typeof helper via eval.
+	// Heuristic mapping mirroring JS `typeof` for the cases that matter
+	// to #4221. Avoids the cost (and global-scope pollution) of injecting
+	// an eval'd JS `typeof` helper.
 	if state.is_null() {
 		"object".to_string() // typeof null === "object" in JS
 	} else if state.is_undefined() {
@@ -107,9 +116,10 @@ async fn history_state_is_object_after_router_push() {
 	// `with_router(|r| r.push(href))` call site exactly.
 	with_router(|r| r.push("/clusters")).expect("push /clusters");
 
-	// Yield once so any async observers / scheduler tasks settle. The
-	// state assertion does not depend on observer ordering, but the DOM
-	// re-render guards do, and we want consistent failure shape.
+	// Yield once so any async observers / scheduler tasks settle before
+	// we read `history.state`. The state assertions below are independent
+	// of observer ordering, but yielding keeps the failure shape stable
+	// across runs.
 	let promise = js_sys::Promise::resolve(&JsValue::UNDEFINED);
 	let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
 

--- a/crates/reinhardt-pages/tests/wasm/history_state_shape_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/history_state_shape_test.rs
@@ -1,0 +1,200 @@
+//! Direct symptom-shape test for the SPA navigation regression class
+//! (#4075 / #4088 / #4122 / #4203 / #4213 / #4217 / #4221).
+//!
+//! Whereas Tier 4 (`spa_navigation_diag_named_test.rs`) reads
+//! `history.state.route_name` via `js_sys::Reflect::get` (which silently
+//! returns `None` for both "state is null" and "state is a JSON string"),
+//! this test asserts the *exact* DevTools observation that #4221 reports:
+//!
+//!   typeof history.state === "object"   // expected
+//!   typeof history.state === "string"   // failure shape of #4221
+//!
+//! Together with explicit `JsValue::is_object()` / `is_string()` checks,
+//! this catches the regression even if the value happens to look like a
+//! parseable JSON string.
+//!
+//! **Run with** (from the workspace root):
+//!   `wasm-pack test --headless --chrome crates/reinhardt-pages \
+//!        --features wasm-diag-test -- --test history_state_shape_test`
+
+#![cfg(wasm)]
+
+use reinhardt_pages::app::{ClientLauncher, with_router};
+use reinhardt_pages::component::{IntoPage, Page, PageElement};
+use reinhardt_pages::router::Router;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn home_page() -> Page {
+	PageElement::new("div")
+		.attr("id", "route-home")
+		.child("HOME")
+		.into_page()
+}
+
+fn clusters_page() -> Page {
+	PageElement::new("div")
+		.attr("id", "route-clusters")
+		.child("CLUSTERS")
+		.into_page()
+}
+
+fn install_app_root() -> web_sys::Element {
+	let document = web_sys::window().unwrap().document().unwrap();
+	if let Some(prev) = document.get_element_by_id("app") {
+		prev.remove();
+	}
+	let root = document.create_element("div").unwrap();
+	root.set_id("app");
+	document.body().unwrap().append_child(&root).unwrap();
+	root
+}
+
+fn build_router() -> Router {
+	Router::new()
+		.named_route("dashboard:home", "/", home_page)
+		.named_route("clusters:list", "/clusters", clusters_page)
+}
+
+/// Read `typeof history.state` via `js_sys::Reflect`.
+///
+/// Returns the JS-level `typeof` result so the assertion can be expressed
+/// in the same vocabulary as the Issue #4221 reproduction (DevTools
+/// `typeof history.state`).
+fn typeof_history_state() -> String {
+	let window = web_sys::window().expect("window");
+	let history = window.history().expect("history");
+	let state = history.state().expect("state");
+	// JS-level typeof: cheaper than building a typeof helper via eval.
+	if state.is_null() {
+		"object".to_string() // typeof null === "object" in JS
+	} else if state.is_undefined() {
+		"undefined".to_string()
+	} else if state.is_string() {
+		"string".to_string()
+	} else if state.as_f64().is_some() {
+		"number".to_string()
+	} else if state.as_bool().is_some() {
+		"boolean".to_string()
+	} else if state.is_object() {
+		"object".to_string()
+	} else {
+		format!("unknown: {:?}", state)
+	}
+}
+
+fn raw_history_state() -> JsValue {
+	web_sys::window()
+		.expect("window")
+		.history()
+		.expect("history")
+		.state()
+		.expect("state")
+}
+
+#[wasm_bindgen_test]
+async fn history_state_is_object_after_router_push() {
+	let _root = install_app_root();
+
+	ClientLauncher::new("#app")
+		.router(build_router)
+		.launch()
+		.expect("launch");
+
+	// Drive a programmatic navigation, mirroring the link-interceptor's
+	// `with_router(|r| r.push(href))` call site exactly.
+	with_router(|r| r.push("/clusters")).expect("push /clusters");
+
+	// Yield once so any async observers / scheduler tasks settle. The
+	// state assertion does not depend on observer ordering, but the DOM
+	// re-render guards do, and we want consistent failure shape.
+	let promise = js_sys::Promise::resolve(&JsValue::UNDEFINED);
+	let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+
+	let state = raw_history_state();
+	let typeof_str = typeof_history_state();
+
+	// Assertion 1: the *exact* DevTools symptom from #4221 reproduction.
+	assert_eq!(
+		typeof_str, "object",
+		"#4221 symptom shape: typeof history.state expected \"object\" \
+		 (the structured-JS-object format produced by `state_to_js_object`), \
+		 got {:?}. \
+		 Raw state JsValue: {:?}",
+		typeof_str, state
+	);
+
+	// Assertion 2: explicit failure-mode check. The regression class
+	// stores state as `JsValue::from_str(&json)` — a JS string. We must
+	// not be looking at one.
+	assert!(
+		!state.is_string(),
+		"#4221 regression: history.state must NOT be a JS string. \
+		 If this fires, `push_state` is taking a code path that calls \
+		 `JsValue::from_str(&json)` instead of `serde_wasm_bindgen::to_value(...)`. \
+		 Raw state: {:?}",
+		state
+	);
+
+	// Assertion 3: positive shape check. After successfully serializing
+	// via `serde_wasm_bindgen::to_value`, the JsValue must be `is_object()`.
+	assert!(
+		state.is_object(),
+		"#4221 regression: history.state expected to be a JS object \
+		 (`is_object()`); got {:?}",
+		state
+	);
+
+	// Assertion 4: external-consumer property access works. The whole
+	// point of the post-#4203 fix is that
+	// `history.state.route_name` resolves via JS property access.
+	let route_name_key = JsValue::from_str("route_name");
+	let value = js_sys::Reflect::get(&state, &route_name_key)
+		.expect("Reflect::get must succeed on an object");
+	assert_eq!(
+		value.as_string().as_deref(),
+		Some("clusters:list"),
+		"#4221: external-consumer property access must yield the matched \
+		 route name. If state were a JSON string, Reflect::get would \
+		 return undefined here."
+	);
+}
+
+#[wasm_bindgen_test]
+async fn history_state_is_object_after_router_replace() {
+	let _root = install_app_root();
+
+	ClientLauncher::new("#app")
+		.router(build_router)
+		.launch()
+		.expect("launch");
+
+	with_router(|r| r.replace("/clusters")).expect("replace /clusters");
+
+	let promise = js_sys::Promise::resolve(&JsValue::UNDEFINED);
+	let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+
+	let state = raw_history_state();
+	let typeof_str = typeof_history_state();
+
+	assert_eq!(
+		typeof_str, "object",
+		"#4221 symptom shape (replace path): typeof history.state expected \
+		 \"object\", got {:?}. Raw state: {:?}",
+		typeof_str, state
+	);
+	assert!(
+		!state.is_string(),
+		"#4221 regression (replace path): history.state must NOT be a JS string. \
+		 Raw state: {:?}",
+		state
+	);
+	assert!(
+		state.is_object(),
+		"#4221 regression (replace path): history.state expected `is_object()`; \
+		 got {:?}",
+		state
+	);
+}

--- a/crates/reinhardt-pages/tests/wasm/wasm_bindgen_abi_pin_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/wasm_bindgen_abi_pin_test.rs
@@ -1,0 +1,111 @@
+//! Standing CI guard for the wasm-bindgen ABI hypothesis from #4221.
+//!
+//! Independently of the framework's `state_to_js_object` call site,
+//! this test asserts the **library-level invariant** that
+//! `serde_wasm_bindgen::to_value(&HistoryStateJson)` returns a JS
+//! object (not a string), and that the value round-trips through
+//! `History::push_state_with_url` preserving `typeof === "object"`.
+//!
+//! Regression-prevention rationale: #4221 tracked a runtime symptom
+//! (`history.state` is a JSON string) that was once thought to be a
+//! `wasm-bindgen 0.2.118` ABI bug, fixable by bumping to 0.2.121.
+//! That hypothesis was falsified — the round-trip is correct on
+//! 0.2.118 too — but the assertion remains the cheapest, most direct
+//! verification that the SPA navigation regression class isn't
+//! returning via this layer. If a future `wasm-bindgen` /
+//! `serde-wasm-bindgen` upgrade silently changes how `to_value`
+//! produces structured-clone-compatible JsValues from a struct
+//! containing `HashMap<String, String>` fields, this test catches it
+//! before it reaches downstream consumers.
+//!
+//! **Run with**:
+//!   `wasm-pack test --headless --chrome crates/reinhardt-pages \
+//!        --features wasm-diag-test \
+//!        -- --test wasm_bindgen_abi_pin_test`
+
+#![cfg(wasm)]
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Mirror of `reinhardt-urls`'s private `HistoryStateJson` wire shape.
+///
+/// Kept here as a literal copy rather than re-exporting the framework
+/// type so the test exercises **only** the serde-wasm-bindgen → wasm
+/// layer, divorced from any framework-internal helper. If the framework
+/// type evolves, update this struct to mirror it.
+#[derive(Serialize, Deserialize)]
+struct HistoryStateJson {
+	path: String,
+	params: HashMap<String, String>,
+	route_name: Option<String>,
+	data: HashMap<String, String>,
+	scroll_x: Option<i32>,
+	scroll_y: Option<i32>,
+}
+
+fn make_state() -> HistoryStateJson {
+	HistoryStateJson {
+		path: "/clusters".to_string(),
+		params: HashMap::new(),
+		route_name: Some("dashboard:clusters".to_string()),
+		data: HashMap::new(),
+		scroll_x: None,
+		scroll_y: None,
+	}
+}
+
+#[wasm_bindgen_test]
+fn serde_wasm_bindgen_to_value_returns_object_not_string() {
+	let state = make_state();
+	let js_value = serde_wasm_bindgen::to_value(&state).expect("to_value");
+
+	assert!(
+		!js_value.is_string(),
+		"#4221 ABI: serde_wasm_bindgen::to_value produced a JS string \
+		 instead of an object. wasm-bindgen / serde-wasm-bindgen ABI \
+		 skew is the prime suspect. Raw JsValue: {:?}",
+		js_value
+	);
+	assert!(
+		js_value.is_object(),
+		"#4221 ABI: serde_wasm_bindgen::to_value produced a non-object \
+		 JsValue. Raw JsValue: {:?}",
+		js_value
+	);
+}
+
+#[wasm_bindgen_test]
+fn pushstate_round_trip_preserves_object_shape() {
+	let state = make_state();
+	let js_value = serde_wasm_bindgen::to_value(&state).expect("to_value");
+
+	let window = web_sys::window().expect("window");
+	let history = window.history().expect("history");
+	history
+		.push_state_with_url(&js_value, "", Some("/clusters"))
+		.expect("push_state");
+
+	let read_back = history.state().expect("state");
+
+	assert!(
+		!read_back.is_string(),
+		"#4221: history.state is a JS string after push_state. \
+		 If this fires, the wasm-bindgen / serde-wasm-bindgen / web-sys \
+		 stack has regressed `to_value` → structured-clone behaviour. \
+		 Raw: {:?}",
+		read_back
+	);
+	assert!(
+		read_back.is_object(),
+		"#4221: history.state is not is_object() after push_state. Raw: {:?}",
+		read_back
+	);
+
+	// Cleanup so subsequent tests start with a clean slate.
+	let _ = history.replace_state_with_url(&JsValue::NULL, "", Some("/"));
+}


### PR DESCRIPTION
## Summary

- Add `crates/reinhardt-pages/tests/wasm/history_state_shape_test.rs` (2 wasm-bindgen-test cases) asserting `typeof history.state === "object"` and `!state.is_string()` directly, on both `Router::push` and `Router::replace` paths.
- Wire it into the `wasm-diag-test` feature gate in `Cargo.toml` (no library code changes).

## Type of Change

- [x] Test addition (no library behaviour change)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Motivation and Context

PR #4218 deduplicated `client_router::history`. Issue #4221 reports that the SPA navigation regression chain (#4075 → #4088 → #4122 → #4203 → #4213 → #4217 → #4221) is still observable at runtime in downstream consumers, despite #4218.

I attempted to reproduce the regression at `b63bb3d3` (the merge commit of #4218) using the existing Tier 4 test (`spa_navigation_diag_named_test`) — it passes. However, that test uses `js_sys::Reflect::get(&state, "route_name").as_string()`, which returns `None` for both `state === null` and `state === "<JSON string>"`, masking one possible failure mode.

This new test removes that ambiguity by asserting:

1. `typeof history.state === "object"` — the exact DevTools observation in #4221.
2. `!state.is_string()` — the exact failure shape of the regression class (`JsValue::from_str(&json)`).
3. `state.is_object()` — the post-#4203 fix invariant.
4. `Reflect::get(state, "route_name") === "clusters:list"` — external-consumer property access still works.

Both new tests pass at `b63bb3d3`, supporting the verification posted on #4221 that the framework code at this revision produces a JS-object `history.state`.

## How Was This Tested

```bash
cargo install -f wasm-bindgen-cli --version 0.2.121

cd crates/reinhardt-pages
CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER="$HOME/.cargo/bin/wasm-bindgen-test-runner" \
CHROMEDRIVER="$(which chromedriver)" \
WASM_BINDGEN_TEST_ONLY_WEB=1 \
  cargo test --target wasm32-unknown-unknown \
    --test history_state_shape_test \
    --features wasm-diag-test
```

Result on macOS / headless Chrome at `b63bb3d3`:

```
running 2 tests
test history_state_is_object_after_router_replace ... ok
test history_state_is_object_after_router_push ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 filtered out; finished in 0.02s
```

The existing Tier 4 test (`spa_navigation_diag_named_test`) also passes at the same revision.

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove the change works
- [x] All new and existing tests pass locally
- [ ] Documentation updated (no public API change)
- [ ] CHANGELOG.md updated (test-only change)

## Labels to Apply

- `enhancement` — strengthens regression-detection net for the SPA navigation chain
- `testing`

## Follow-up (separate PRs)

The `wasm-diag-test` suite (Tier 2/3/4 + this new test) is currently **not run in `.github/workflows/wasm-check.yml`** — only `csrf_wasm_test`, `server_fn_wasm_test`, and `client_launcher_navigation_test` execute under `cargo test --target wasm32-unknown-unknown`. This is a structural gap in the regression-detection net that the #4075 → #4221 chain has been able to exploit. Wiring the diag suite into CI is a separate, mechanical follow-up.

## Related Issues

Refs #4221
Refs #4218 (the dedup PR this exercises)
Refs #4203 (introduced the `state_to_js_object` path this asserts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)