### PR TITLE
test(pages): add link-click reproducer to nav_diag_dom suite

### DIFF
--- a/crates/reinhardt-pages/tests/wasm/nav_diag_dom_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/nav_diag_dom_test.rs
@@ -17,7 +17,7 @@
 use reinhardt_pages::app::{ClientLauncher, with_router};
 use reinhardt_pages::component::{IntoPage, Page, PageElement};
 use reinhardt_pages::router::Router;
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -134,5 +134,102 @@ async fn nav_diag_dom_writes_notify_observers_after_router_push() {
 		 \"notify_observers\" (the final site in the navigate → notify_observers \
 		 chain). Got: {:?}",
 		site
+	);
+}
+
+/// End-to-end click reproducer requested by the cloud-side reporter on
+/// #4221. Mirrors the dashboard's exact runtime path:
+/// `ClientLauncher::launch()` (installs link interceptor) → real
+/// `<a href="/clusters">` click → `link_interceptor → Router::push →
+/// Router::navigate → notify_observers` chain. If this passes upstream
+/// while the dashboard still observes `setAttr_total: 0` and a
+/// JSON-string `history.state`, the bug is **not** in the framework's
+/// link-click → push → push_state path — it is in a code path that
+/// bypasses `Router::navigate` and calls `History::push_state_with_url`
+/// directly with `JsValue::from_str(json)`.
+#[wasm_bindgen_test]
+async fn nav_diag_dom_advances_through_full_link_click_chain() {
+	let _root = install_app_root();
+
+	ClientLauncher::new("#app")
+		.router(build_router)
+		.launch()
+		.expect("launch");
+
+	let document = web_sys::window()
+		.and_then(|w| w.document())
+		.expect("document");
+	let body = document.body().expect("body");
+
+	// Inject a real `<a href="/clusters">` anchor that the link interceptor
+	// must pick up on click. Append to body (outside `#app`) so re-renders
+	// of the route view do not detach the anchor before the click fires.
+	let anchor: web_sys::HtmlElement = document
+		.create_element("a")
+		.expect("create a")
+		.dyn_into()
+		.expect("dyn HtmlElement");
+	anchor.set_attribute("href", "/clusters").expect("set href");
+	anchor.set_text_content(Some("go to clusters"));
+	body.append_child(&anchor).expect("append a");
+
+	// Stamp a sentinel so the post-click assertion can only succeed if
+	// some `nav_diag_dom!` site fired during the click handling chain.
+	body.set_attribute("data-reinhardt-nav-site", "test_sentinel")
+		.expect("set sentinel");
+
+	// Snapshot `history.state` shape before the click so we can prove the
+	// click transitioned it to a JS object (the canonical post-#4218 shape).
+	let history = web_sys::window()
+		.expect("window")
+		.history()
+		.expect("history");
+	let state_before = history.state().expect("state_before");
+
+	// `HtmlElement::click()` dispatches a real, bubbling MouseEvent so the
+	// document-level listener installed by `ClientLauncher::launch()` sees
+	// it — equivalent to a user clicking the anchor.
+	anchor.click();
+
+	// Yield to the microtask queue once so any reactive scheduler updates
+	// flush before we read the body attribute.
+	let promise = js_sys::Promise::resolve(&JsValue::UNDEFINED);
+	let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+
+	let site = read_dataset_nav_site();
+	assert_ne!(
+		site.as_deref(),
+		Some("test_sentinel"),
+		"nav-diag-dom: click on `<a href=\"/clusters\">` did not overwrite the \
+		 pre-click sentinel; the link interceptor or the navigate chain is not \
+		 firing nav_diag_dom! sites in this build."
+	);
+	assert_eq!(
+		site.as_deref(),
+		Some("notify_observers"),
+		"nav-diag-dom: after a real link click, last-write-wins value should be \
+		 \"notify_observers\" (the final site in link_interceptor → navigate → \
+		 notify_observers). Got: {:?}",
+		site
+	);
+
+	// The original #4221 symptom: after a navigation, `history.state` must
+	// be a JS object (structured-clone of the serde-wasm-bindgen value),
+	// not a JSON string. If this assertion fires, the bug returned via the
+	// canonical `push_state` and `wasm_bindgen_abi_pin_test` is the next
+	// line of defence.
+	let state_after = history.state().expect("state_after");
+	assert!(
+		!state_after.is_string(),
+		"#4221 click reproducer: history.state is a JS string after link click. \
+		 Pre-click state: {:?}. Post-click state: {:?}",
+		state_before,
+		state_after
+	);
+	assert!(
+		state_after.is_object(),
+		"#4221 click reproducer: history.state is not is_object() after link \
+		 click. Post-click state: {:?}",
+		state_after
 	);
 }

--- a/crates/reinhardt-pages/tests/wasm/nav_diag_dom_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/nav_diag_dom_test.rs
@@ -151,6 +151,17 @@ async fn nav_diag_dom_writes_notify_observers_after_router_push() {
 async fn nav_diag_dom_advances_through_full_link_click_chain() {
 	let _root = install_app_root();
 
+	// `Router::new()` reads `current_path()` from `window.location` at
+	// construction time, so a previous test in the same wasm test binary
+	// that navigated away from `/` would make this reproducer start on a
+	// non-`/` path. Reset history to `/` before launching to keep the
+	// initial state deterministic regardless of test execution order.
+	let history = web_sys::window()
+		.expect("window")
+		.history()
+		.expect("history");
+	let _ = history.replace_state_with_url(&JsValue::NULL, "", Some("/"));
+
 	ClientLauncher::new("#app")
 		.router(build_router)
 		.launch()
@@ -164,11 +175,18 @@ async fn nav_diag_dom_advances_through_full_link_click_chain() {
 	// Inject a real `<a href="/clusters">` anchor that the link interceptor
 	// must pick up on click. Append to body (outside `#app`) so re-renders
 	// of the route view do not detach the anchor before the click fires.
+	// Use a stable id so we can remove any leftover anchor from a previous
+	// run of this test in the same wasm test binary.
+	const ANCHOR_ID: &str = "test-link-click-reproducer-anchor";
+	if let Some(prev) = document.get_element_by_id(ANCHOR_ID) {
+		prev.remove();
+	}
 	let anchor: web_sys::HtmlElement = document
 		.create_element("a")
 		.expect("create a")
 		.dyn_into()
 		.expect("dyn HtmlElement");
+	anchor.set_id(ANCHOR_ID);
 	anchor.set_attribute("href", "/clusters").expect("set href");
 	anchor.set_text_content(Some("go to clusters"));
 	body.append_child(&anchor).expect("append a");
@@ -180,10 +198,6 @@ async fn nav_diag_dom_advances_through_full_link_click_chain() {
 
 	// Snapshot `history.state` shape before the click so we can prove the
 	// click transitioned it to a JS object (the canonical post-#4218 shape).
-	let history = web_sys::window()
-		.expect("window")
-		.history()
-		.expect("history");
 	let state_before = history.state().expect("state_before");
 
 	// `HtmlElement::click()` dispatches a real, bubbling MouseEvent so the
@@ -232,4 +246,11 @@ async fn nav_diag_dom_advances_through_full_link_click_chain() {
 		 click. Post-click state: {:?}",
 		state_after
 	);
+
+	// Cleanup so subsequent tests in the same wasm test binary start with a
+	// clean DOM and history state, mirroring `wasm_bindgen_abi_pin_test`.
+	if let Some(prev) = document.get_element_by_id(ANCHOR_ID) {
+		prev.remove();
+	}
+	let _ = history.replace_state_with_url(&JsValue::NULL, "", Some("/"));
 }


### PR DESCRIPTION
## Summary

- Adds the end-to-end `<a href>` click reproducer that the cloud-side #4221 reporter explicitly requested.
- Test dispatches a real bubbling click via `HtmlElement::click()` on an anchor injected after `ClientLauncher::launch()` (so the document-level link interceptor sees it).
- Asserts both: (a) `body.dataset.reinhardtNavSite` advances to `"notify_observers"` (proving the full `link_interceptor → navigate → notify_observers` chain executed) AND (b) `history.state` is a JS object — not a JSON string — afterwards (the original #4221 symptom check).

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [x] Test addition

## Motivation and Context

PR #4223 added the `nav_diag_dom!` opt-in feature with two integration tests: `nav_diag_dom_writes_some_site_at_launch` and `nav_diag_dom_writes_notify_observers_after_router_push`. Both exercise programmatic `Router::push()` — they do **not** exercise a real DOM click on an `<a>` element, which is the path the cloud dashboard exercises and the path the cloud-side reporter explicitly asked for in https://github.com/kent8192/reinhardt-web/issues/4221#issuecomment-4404545280:

> Build a minimal upstream reproducer in `crates/reinhardt-pages/tests/wasm/` that reuses the dashboard's exact path: `ClientLauncher::new(...).router(init_router).launch()` → `<a href="/x">` click → assert `body.dataset.reinhardtNavSite` is non-empty.

The new test closes that coverage gap. Combined with the verifications already established (PR #4222's `wasm_bindgen_abi_pin_test` and `history_state_shape_test`, plus PR #4223's nav-diag-dom programmatic tests), this gives the framework an end-to-end CI guard for the entire `<a>` click → `Router::push` → canonical `push_state` path.

**Diagnostic value** when run against the cloud's reported symptoms:

| Test result on upstream | Cloud-side symptom | Implication |
| --- | --- | --- |
| Pass | `setAttr_total: 0` + `history.state: "string"` | Framework path is correct end-to-end. Bug is in a non-framework call site that bypasses `Router::navigate`. |
| Fail | (matches upstream) | Bug reproduces in framework's own test fixture; framework-side investigation continues. |

This run on macOS / headless Chrome at the current main + this commit returns **pass**, so the framework path is verified correct end-to-end, narrowing the remaining hypothesis space to dashboard-side direct `History::push_state_with_url` calls.

## How Was This Tested

```bash
cd /tmp/issue-4221-nav-diag-dom
wasm-pack test --headless --chrome crates/reinhardt-pages \
    --test nav_diag_dom_test \
    --features 'wasm-diag-test nav-diag-dom'
```

Result on macOS / headless Chrome at `main` + this commit:

```
running 3 tests
test nav_diag_dom_writes_some_site_at_launch ... ok
test nav_diag_dom_writes_notify_observers_after_router_push ... ok
test nav_diag_dom_advances_through_full_link_click_chain ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 filtered out; finished in 0.02s
```

## Checklist

- [x] My code follows the project's code style guidelines (`cargo fmt` clean)
- [x] All new and existing tests pass locally
- [x] No public API change (test-only addition gated on `wasm-diag-test,nav-diag-dom` features)
- [ ] CHANGELOG.md updated — n/a (test-only addition)

## Labels to Apply

- `test` — test addition
- `documentation` — augments diagnostic suite documentation

## Related

Refs #4221 (the active issue this reproducer was requested for)
Refs #4223 (parent feature; this PR extends its test suite)
Refs #4222 (companion ABI / shape CI guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)