### PR TITLE
feat(conf)!: typed TOML interpolation (Fixes #4226)

### DIFF
--- a/crates/reinhardt-conf/CHANGELOG.md
+++ b/crates/reinhardt-conf/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `CoercionError` and `BuildError::Coercion` for typed string-to-T failures during
+  settings deserialization (#4226).
+- `SettingsBuilder::with_typed_coercion(bool)` to opt in or out of typed coercion;
+  default is on (#4226).
+- `TypedSettingsDeserializer` (public) wrapping `&serde_json::Value` for type-aware
+  coercion at the visitor boundary (#4226).
+
+### Changed
+
+- **BREAKING**: `${VAR}` interpolation results are now coerced into the destination
+  Rust type at deserialize time. `port = "5432"` / `port = "${PORT:-5432}"` now
+  deserialize into `u16` directly. Coercion failures are reported at
+  `SettingsBuilder::build_composed()` time with full TOML key path, target type,
+  original value, and underlying parse error. Restore the legacy passthrough with
+  `.with_typed_coercion(false)` (#4226).
+- `base64` is now a required (non-optional) dependency of `reinhardt-conf` (#4226).
+
+### Migration
+
+- Manual `serde` shims that coerced strings into typed fields can be removed.
+- If your code relied on string-typed TOML producing serde mismatch errors, opt out
+  via `.with_typed_coercion(false)` or fix the data so it parses correctly.
+
 ## [0.1.0-rc.26](https://github.com/kent8192/reinhardt-web/compare/reinhardt-conf@v0.1.0-rc.25...reinhardt-conf@v0.1.0-rc.26) - 2026-05-05
 
 ### Added

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -92,3 +92,4 @@ serial_test = { workspace = true }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 proptest = { workspace = true }
+serde_bytes = { workspace = true }

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -49,7 +49,7 @@ azure_identity = { version = "0.29.0", optional = true }
 azure_security_keyvault_secrets = { version = "0.8.0", optional = true }
 futures = { workspace = true, optional = true }
 aes-gcm = { version = "0.10", optional = true }
-base64 = { version = "0.22", optional = true }
+base64 = { workspace = true }
 pbkdf2 = { version = "0.12", features = ["simple"], optional = true }
 sha2 = { version = "0.10", optional = true }
 notify = { version = "8.2.0", optional = true }
@@ -71,7 +71,7 @@ vault = ["async", "reqwest"]
 aws-secrets = ["async", "aws-config", "aws-sdk-secretsmanager", "aws-smithy-runtime"]
 azure-keyvault = ["async", "azure_identity", "azure_security_keyvault_secrets", "futures"]
 secret-rotation = ["async", "rand"]
-encryption = ["aes-gcm", "base64", "pbkdf2", "rand", "sha2"]
+encryption = ["aes-gcm", "pbkdf2", "rand", "sha2"]
 hot-reload = ["notify", "tokio", "async"]
 caching = ["moka", "async"]
 

--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -143,6 +143,34 @@ db_password = "${DB_PASSWORD:?Set DB_PASSWORD via direnv or 1Password CLI}"
 - **Composition**: interpolation runs at `TomlFileSource::load()` time. The resolved
   value participates in the normal source-priority merge; later sources at higher
   priority still override.
+- **Typed coercion** (since 0.1.0-rc.27, default ON): a resolved string value whose
+  destination Rust type is non-`String` is coerced into the target at deserialize
+  time. Supported destinations:
+
+  | Target                          | Source string format                              |
+  |---------------------------------|---------------------------------------------------|
+  | `bool`, integers, floats, `char`| `FromStr`-parseable text                          |
+  | enum unit variant               | variant name (matched via serde's normal rules)   |
+  | `Option<T>`                     | empty string -> `None`, otherwise recurse into `T`|
+  | `Vec<T>`                        | JSON array literal: `"[1, 2, 3]"`                 |
+  | `HashMap<K, V>` / `BTreeMap`    | JSON object literal: `"{\"a\": 1}"`               |
+  | `Vec<u8>`                       | base64 (STANDARD)                                 |
+
+  Coercion failures abort `SettingsBuilder::build_composed()` with
+  `BuildError::Coercion`, naming the TOML key path, target type, original value,
+  and parser cause.
+
+  Disable with `SettingsBuilder::with_typed_coercion(false)` to fall back to the
+  legacy serde-json passthrough.
+
+- **Nested struct from a single string is rejected** with
+  `CoercionError::UnsupportedShape`. Use per-field interpolation instead:
+
+  ```toml
+  [endpoint]
+  host = "${HOST:-localhost}"
+  port = "${PORT:-5432}"
+  ```
 
 ## Field Status
 

--- a/crates/reinhardt-conf/src/settings.rs
+++ b/crates/reinhardt-conf/src/settings.rs
@@ -32,6 +32,7 @@ pub mod session;
 pub mod sources;
 pub mod static_files;
 pub mod template_settings;
+pub mod typed_deserializer;
 pub mod validation;
 
 // Dynamic settings (async feature required)

--- a/crates/reinhardt-conf/src/settings/builder.rs
+++ b/crates/reinhardt-conf/src/settings/builder.rs
@@ -16,6 +16,7 @@ pub struct SettingsBuilder {
 	sources: Vec<Box<dyn ConfigSource>>,
 	profile: Option<Profile>,
 	strict: bool,
+	typed_coercion: bool,
 }
 
 impl SettingsBuilder {
@@ -37,6 +38,7 @@ impl SettingsBuilder {
 			sources: Vec::new(),
 			profile: None,
 			strict: false,
+			typed_coercion: true,
 		}
 	}
 	/// Set the application profile
@@ -74,6 +76,30 @@ impl SettingsBuilder {
 	/// ```
 	pub fn strict(mut self, enabled: bool) -> Self {
 		self.strict = enabled;
+		self
+	}
+	/// Enable or disable typed string coercion at deserialize time.
+	///
+	/// When `true` (default), `Value::String` values whose target type is
+	/// not `String` are parsed via the type's `FromStr` / JSON
+	/// representation. When `false`, the legacy `serde_json::from_value`
+	/// passthrough is used and string-typed fields surface as serde
+	/// type-mismatch errors.
+	///
+	/// See [issue #4226](https://github.com/kent8192/reinhardt-web/issues/4226).
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use reinhardt_conf::settings::builder::SettingsBuilder;
+	///
+	/// // Disable typed coercion to fall through to the legacy path.
+	/// let builder = SettingsBuilder::new().with_typed_coercion(false);
+	/// let settings = builder.build().unwrap();
+	/// assert_eq!(settings.keys().count(), 0);
+	/// ```
+	pub fn with_typed_coercion(mut self, enable: bool) -> Self {
+		self.typed_coercion = enable;
 		self
 	}
 	/// Add a configuration source
@@ -143,10 +169,26 @@ impl SettingsBuilder {
 	/// Fragment-level validation (`validate_fragments()`) should be called
 	/// separately by the caller with the appropriate profile.
 	pub fn build_composed<T: ComposedSettings>(self) -> Result<T, BuildError> {
+		// Capture the flag before `self.build()` consumes self.
+		let typed_coercion = self.typed_coercion;
 		let merged = self.build()?;
 		T::validate_requirements(merged.as_map())?;
-		let settings: T = merged.into_typed().map_err(BuildError::from)?;
-		Ok(settings)
+
+		if typed_coercion {
+			use crate::settings::typed_deserializer::TypedSettingsDeserializer;
+			let json_value = Value::Object(
+				merged
+					.as_map()
+					.iter()
+					.map(|(k, v)| (k.clone(), v.clone()))
+					.collect(),
+			);
+			let de = TypedSettingsDeserializer::new(&json_value);
+			T::deserialize(de).map_err(BuildError::Coercion)
+		} else {
+			let settings: T = merged.into_typed().map_err(BuildError::from)?;
+			Ok(settings)
+		}
 	}
 
 	/// Build the configuration by merging all sources
@@ -220,6 +262,7 @@ impl SettingsBuilder {
 		Ok(MergedSettings {
 			data: Arc::new(merged),
 			profile: self.profile,
+			typed_coercion: self.typed_coercion,
 		})
 	}
 }
@@ -289,6 +332,7 @@ impl Default for SettingsBuilder {
 pub struct MergedSettings {
 	data: Arc<IndexMap<String, Value>>,
 	profile: Option<Profile>,
+	typed_coercion: bool,
 }
 
 impl MergedSettings {
@@ -484,10 +528,24 @@ impl MergedSettings {
 				.collect(),
 		);
 
-		serde_json::from_value(json_value).map_err(|e| GetError::Deserialize {
-			key: "<root>".to_string(),
-			error: e,
-		})
+		if self.typed_coercion {
+			use crate::settings::typed_deserializer::TypedSettingsDeserializer;
+			use serde::de::Error as _;
+			let de = TypedSettingsDeserializer::new(&json_value);
+			T::deserialize(de).map_err(|e| GetError::Deserialize {
+				key: "<root>".to_string(),
+				// Bridge: CoercionError's Display preserves all the structured info
+				// (target type, key path, parse source). We surface the message
+				// through `serde_json::Error::custom` so the existing GetError shape
+				// is preserved without breaking downstream pattern matches.
+				error: serde_json::Error::custom(e.to_string()),
+			})
+		} else {
+			serde_json::from_value(json_value).map_err(|e| GetError::Deserialize {
+				key: "<root>".to_string(),
+				error: e,
+			})
+		}
 	}
 	/// Get all data as a HashMap
 	///
@@ -546,6 +604,10 @@ pub enum BuildError {
 	/// Failed to deserialize merged settings into the target type.
 	#[error("settings deserialization failed: {0}")]
 	Deserialization(String),
+
+	/// Type coercion failed during the typed deserialize pass (issue #4226).
+	#[error(transparent)]
+	Coercion(#[from] crate::settings::typed_deserializer::CoercionError),
 }
 
 impl From<GetError> for BuildError {

--- a/crates/reinhardt-conf/src/settings/interpolation.rs
+++ b/crates/reinhardt-conf/src/settings/interpolation.rs
@@ -296,25 +296,25 @@ use std::path::Path;
 
 /// One segment of a TOML key path — either a table key or an array index.
 #[derive(Debug, Clone)]
-enum KeyPathSegment {
+pub(super) enum KeyPathSegment {
 	Key(String),
 	Index(usize),
 }
 
 /// Stack of key-path segments accumulated during the AST walk.
 #[derive(Default)]
-struct KeyPath(Vec<KeyPathSegment>);
+pub(super) struct KeyPath(Vec<KeyPathSegment>);
 
 impl KeyPath {
-	fn push_key(&mut self, key: &str) {
+	pub(super) fn push_key(&mut self, key: &str) {
 		self.0.push(KeyPathSegment::Key(key.to_string()));
 	}
 
-	fn push_index(&mut self, idx: usize) {
+	pub(super) fn push_index(&mut self, idx: usize) {
 		self.0.push(KeyPathSegment::Index(idx));
 	}
 
-	fn pop(&mut self) {
+	pub(super) fn pop(&mut self) {
 		self.0.pop();
 	}
 }

--- a/crates/reinhardt-conf/src/settings/interpolation.rs
+++ b/crates/reinhardt-conf/src/settings/interpolation.rs
@@ -24,6 +24,11 @@
 //!    as `None` so `${VAR}` and `${VAR:-default}` apply uniformly.
 //! 3. **Fail-fast** — Any failure aborts `TomlFileSource::load()`.
 //! 4. **Type-bounded scope** — Only `toml::Value::String` is rewritten.
+//! 5. **Typed coercion at deserialize time** — When the merged
+//!    `serde_json::Value` tree is deserialized into a project-defined
+//!    settings struct, `Value::String` values whose destination is
+//!    non-`String` are coerced via [`super::typed_deserializer`]. See
+//!    that module for the per-shape strategy.
 //!
 //! [`TomlFileSource::with_interpolation(true)`]: super::sources::TomlFileSource::with_interpolation
 

--- a/crates/reinhardt-conf/src/settings/interpolation.rs
+++ b/crates/reinhardt-conf/src/settings/interpolation.rs
@@ -302,7 +302,7 @@ pub(super) enum KeyPathSegment {
 }
 
 /// Stack of key-path segments accumulated during the AST walk.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(super) struct KeyPath(Vec<KeyPathSegment>);
 
 impl KeyPath {

--- a/crates/reinhardt-conf/src/settings/prelude.rs
+++ b/crates/reinhardt-conf/src/settings/prelude.rs
@@ -19,6 +19,7 @@ pub use super::sources::{
 	ConfigSource, DefaultSource, DotEnvSource, EnvSource, HighPriorityEnvSource,
 	LowPriorityEnvSource, SourceError, TomlFileSource,
 };
+pub use super::typed_deserializer::CoercionError;
 // `JsonFileSource` and `auto_source` are deprecated alongside *.json
 // configuration support and will be removed in 0.2.0 (issue #4087). The prelude
 // continues to surface them during the deprecation window so existing user code

--- a/crates/reinhardt-conf/src/settings/typed_deserializer.rs
+++ b/crates/reinhardt-conf/src/settings/typed_deserializer.rs
@@ -19,6 +19,8 @@
 //! consumed exactly once.
 
 use super::interpolation::KeyPath;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use serde::de::{DeserializeSeed, Deserializer, MapAccess, Visitor};
 use serde::forward_to_deserialize_any;
 
@@ -134,17 +136,17 @@ impl<'de> TypedSettingsDeserializer<'de> {
 impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 	type Error = CoercionError;
 
-	// Phase 3a + 3b + 3c (#4226): bool, integers, floats, char, enum, and
-	// `Option<T>` are explicitly overridden below to coerce `Value::String`
-	// via `FromStr` (or, for `char`, `enum`, and `Option`, via shape-
-	// specific rules). `map`/`struct` are also overridden so that per-field
-	// dispatch flows through this deserializer (otherwise the scalar
-	// overrides would be unreachable when the top-level value is an
-	// object). Remaining shapes still forward to `deserialize_any` until
-	// later phases.
+	// Phase 3a + 3b + 3c + 3d (#4226): bool, integers, floats, char, enum,
+	// `Option<T>`, and bytes are explicitly overridden below to coerce
+	// `Value::String` via `FromStr` (or, for `char`, `enum`, `Option`, and
+	// `bytes`, via shape-specific rules — bytes use base64 STANDARD).
+	// `map`/`struct` are also overridden so that per-field dispatch flows
+	// through this deserializer (otherwise the scalar overrides would be
+	// unreachable when the top-level value is an object). Remaining shapes
+	// still forward to `deserialize_any` until later phases.
 	forward_to_deserialize_any! {
-		str string bytes byte_buf unit unit_struct newtype_struct seq tuple
-		tuple_struct identifier ignored_any
+		str string unit unit_struct newtype_struct seq tuple tuple_struct
+		identifier ignored_any
 	}
 
 	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -353,6 +355,50 @@ impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 		// Structs deserialize via `visit_map`; route through the same
 		// adapter as `deserialize_map`.
 		self.deserialize_map(visitor)
+	}
+
+	fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		// `forward_to_deserialize_any!` would route bytes through
+		// `deserialize_any`, which for `Value::String` calls `visit_str` —
+		// not `visit_bytes`. Override here so visitors that ask for bytes
+		// (e.g. `serde_bytes`) receive base64-decoded bytes when the source
+		// value is a JSON string. Native `Value::Array` of integers is
+		// preserved by delegating to `serde_json`'s own deserializer.
+		match self.value {
+			serde_json::Value::String(s) => {
+				let decoded = BASE64_STANDARD
+					.decode(s)
+					.map_err(|e| CoercionError::Parse {
+						target_type: "bytes".to_string(),
+						value: s.clone(),
+						key_path: self.key_path.to_string(),
+						source: Box::new(e),
+					})?;
+				visitor.visit_byte_buf(decoded)
+			}
+			other => other
+				.clone()
+				.deserialize_bytes(visitor)
+				.map_err(|e| CoercionError::Parse {
+					target_type: "bytes".to_string(),
+					value: other.to_string(),
+					key_path: self.key_path.to_string(),
+					source: Box::new(e),
+				}),
+		}
+	}
+
+	fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		// Same coercion rules as `deserialize_bytes`; serde permits routing
+		// `byte_buf` through `bytes` because the visitor is required to
+		// accept either via `visit_bytes` / `visit_byte_buf`.
+		self.deserialize_bytes(visitor)
 	}
 }
 

--- a/crates/reinhardt-conf/src/settings/typed_deserializer.rs
+++ b/crates/reinhardt-conf/src/settings/typed_deserializer.rs
@@ -1,0 +1,144 @@
+//! Type-aware deserializer adapter.
+//!
+//! Wraps `&serde_json::Value` and, at the visitor boundary, coerces
+//! `Value::String` into the target Rust type when the visitor expects a
+//! non-String type. Coercion strategies are per-shape:
+//!
+//! | Visitor expectation | Coercion                               |
+//! |---------------------|----------------------------------------|
+//! | scalar (bool/int/   | `FromStr`                              |
+//! |   float/char)       |                                        |
+//! | `Option<T>`         | empty string -> None, else recurse     |
+//! | `Vec<T>`            | parse as JSON array, recurse per item  |
+//! | `Map<K, V>`         | parse as JSON object, recurse per item |
+//! | `Vec<u8>` (bytes)   | base64 (STANDARD)                      |
+//! | struct/tuple/non-   | `CoercionError::UnsupportedShape`      |
+//! |   unit enum         |                                        |
+//!
+//! The wrapper never re-runs interpolation: the resolved string is
+//! consumed exactly once.
+
+use super::interpolation::KeyPath;
+use serde::de::{Deserializer, Visitor};
+use serde::forward_to_deserialize_any;
+
+/// Coercion failure surfaced from `TypedSettingsDeserializer`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum CoercionError {
+	/// Failed to parse a string into the visitor's expected scalar /
+	/// bytes / collection-element shape.
+	#[error(
+		"failed to coerce string `{value}` into {target_type} at \
+		key `{key_path}`: {source}"
+	)]
+	Parse {
+		/// `Visitor::expecting()` output for the destination type.
+		target_type: String,
+		/// Original string value that failed to coerce.
+		value: String,
+		/// Dot/bracket-separated TOML key path.
+		key_path: String,
+		/// Underlying parse error.
+		#[source]
+		source: Box<dyn std::error::Error + Send + Sync>,
+	},
+
+	/// The visitor expected a shape (struct, tuple, non-unit enum) that
+	/// has no defined string -> T coercion.
+	#[error(
+		"cannot coerce string into {target} at key `{key_path}`: \
+		use field-by-field interpolation instead"
+	)]
+	UnsupportedShape {
+		/// Description of the unsupported destination shape.
+		target: &'static str,
+		/// Dot/bracket-separated TOML key path.
+		key_path: String,
+	},
+
+	/// Pass-through for serde-internal errors.
+	#[error(transparent)]
+	Serde(#[from] serde::de::value::Error),
+}
+
+impl serde::de::Error for CoercionError {
+	fn custom<T: std::fmt::Display>(msg: T) -> Self {
+		CoercionError::Serde(serde::de::Error::custom(msg))
+	}
+}
+
+/// Type-aware adapter around `&serde_json::Value`.
+///
+/// Phase 2 skeleton: forwards every `deserialize_*` to `serde_json`'s
+/// own deserializer. Subsequent phases override individual visitor
+/// callbacks to coerce `Value::String` into the target Rust type.
+pub struct TypedSettingsDeserializer<'de> {
+	value: &'de serde_json::Value,
+	key_path: KeyPath,
+}
+
+impl<'de> TypedSettingsDeserializer<'de> {
+	/// Wrap a borrowed `serde_json::Value`. The returned deserializer
+	/// coerces string values when the visitor expects a non-String
+	/// target.
+	pub fn new(value: &'de serde_json::Value) -> Self {
+		Self {
+			value,
+			key_path: KeyPath::default(),
+		}
+	}
+}
+
+impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
+	type Error = CoercionError;
+
+	// Skeleton: forward everything to serde_json's deserializer for
+	// now. Phase 3+ overrides each `deserialize_*` we care about.
+	forward_to_deserialize_any! {
+		bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+		string bytes byte_buf option unit unit_struct newtype_struct seq
+		tuple tuple_struct map struct enum identifier ignored_any
+	}
+
+	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		// Delegate to serde_json's deserializer; map its error into ours.
+		self.value
+			.clone()
+			.deserialize_any(visitor)
+			.map_err(|e| CoercionError::Parse {
+				target_type: "any".to_string(),
+				value: self.value.to_string(),
+				key_path: self.key_path.to_string(),
+				source: Box::new(e),
+			})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+	use serde::Deserialize;
+
+	#[rstest]
+	fn skeleton_passthrough_for_native_int() {
+		// Arrange — native JSON int, no coerce needed.
+		let v = serde_json::json!({ "port": 5432 });
+
+		#[derive(Debug, Deserialize, PartialEq)]
+		struct S {
+			port: u16,
+		}
+
+		// Act
+		let de = TypedSettingsDeserializer::new(&v);
+		let got: S = S::deserialize(de).expect("should deserialize");
+
+		// Assert
+		assert_eq!(got, S { port: 5432 });
+	}
+}

--- a/crates/reinhardt-conf/src/settings/typed_deserializer.rs
+++ b/crates/reinhardt-conf/src/settings/typed_deserializer.rs
@@ -22,27 +22,31 @@ use super::interpolation::KeyPath;
 use serde::de::{DeserializeSeed, Deserializer, MapAccess, Visitor};
 use serde::forward_to_deserialize_any;
 
-/// Implement a `deserialize_<int>` method that coerces `Value::String`
-/// into the target integer type via `FromStr`. For non-string inputs, it
+/// Implement a `deserialize_<scalar>` method that coerces `Value::String`
+/// into the target scalar type via `FromStr`. For non-string inputs, it
 /// delegates to `serde_json::Value`'s deserializer and re-wraps any
 /// resulting error as `CoercionError::Parse` so callers always see a
 /// uniform error shape carrying `key_path` / `target_type`.
-macro_rules! impl_int_coerce {
-	($method:ident, $visit:ident, $ty:ty, $type_name:expr) => {
+///
+/// `$err_ty` is the concrete error type returned by `<$ty as FromStr>::Err`
+/// (e.g. `std::str::ParseBoolError`, `std::num::ParseIntError`,
+/// `std::num::ParseFloatError`). It is required because `s.parse()` infers
+/// `Err = <$ty as FromStr>::Err`, and the closure's `e:` annotation must
+/// match for `Box::new(e)` to coerce into `Box<dyn Error + Send + Sync>`.
+macro_rules! impl_scalar_coerce {
+	($method:ident, $visit:ident, $ty:ty, $err_ty:ty, $type_name:expr) => {
 		fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
 		where
 			V: Visitor<'de>,
 		{
 			match self.value {
 				serde_json::Value::String(s) => {
-					let parsed: $ty =
-						s.parse()
-							.map_err(|e: std::num::ParseIntError| CoercionError::Parse {
-								target_type: $type_name.to_string(),
-								value: s.clone(),
-								key_path: self.key_path.to_string(),
-								source: Box::new(e),
-							})?;
+					let parsed: $ty = s.parse().map_err(|e: $err_ty| CoercionError::Parse {
+						target_type: $type_name.to_string(),
+						value: s.clone(),
+						key_path: self.key_path.to_string(),
+						source: Box::new(e),
+					})?;
 					visitor.$visit(parsed)
 				}
 				other => other
@@ -130,15 +134,16 @@ impl<'de> TypedSettingsDeserializer<'de> {
 impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 	type Error = CoercionError;
 
-	// Phase 3a (#4226): bool + integers are explicitly overridden below
-	// to coerce `Value::String` via `FromStr`. `map`/`struct` are also
-	// overridden so that per-field dispatch flows through this
+	// Phase 3a + 3b (#4226): bool, integers, floats, char, and enum are
+	// explicitly overridden below to coerce `Value::String` via `FromStr`
+	// (or, for `char` and `enum`, via shape-specific rules). `map`/`struct`
+	// are also overridden so that per-field dispatch flows through this
 	// deserializer (otherwise the scalar overrides would be unreachable
-	// when the top-level value is an object). Other shapes still forward
-	// to `deserialize_any` until later phases.
+	// when the top-level value is an object). Remaining shapes still
+	// forward to `deserialize_any` until later phases.
 	forward_to_deserialize_any! {
-		f32 f64 char str string bytes byte_buf option unit unit_struct
-		newtype_struct seq tuple tuple_struct enum identifier ignored_any
+		str string bytes byte_buf option unit unit_struct
+		newtype_struct seq tuple tuple_struct identifier ignored_any
 	}
 
 	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -157,27 +162,118 @@ impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 			})
 	}
 
-	fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	impl_scalar_coerce!(
+		deserialize_bool,
+		visit_bool,
+		bool,
+		std::str::ParseBoolError,
+		"bool"
+	);
+	impl_scalar_coerce!(deserialize_i8, visit_i8, i8, std::num::ParseIntError, "i8");
+	impl_scalar_coerce!(
+		deserialize_i16,
+		visit_i16,
+		i16,
+		std::num::ParseIntError,
+		"i16"
+	);
+	impl_scalar_coerce!(
+		deserialize_i32,
+		visit_i32,
+		i32,
+		std::num::ParseIntError,
+		"i32"
+	);
+	impl_scalar_coerce!(
+		deserialize_i64,
+		visit_i64,
+		i64,
+		std::num::ParseIntError,
+		"i64"
+	);
+	impl_scalar_coerce!(
+		deserialize_i128,
+		visit_i128,
+		i128,
+		std::num::ParseIntError,
+		"i128"
+	);
+	impl_scalar_coerce!(deserialize_u8, visit_u8, u8, std::num::ParseIntError, "u8");
+	impl_scalar_coerce!(
+		deserialize_u16,
+		visit_u16,
+		u16,
+		std::num::ParseIntError,
+		"u16"
+	);
+	impl_scalar_coerce!(
+		deserialize_u32,
+		visit_u32,
+		u32,
+		std::num::ParseIntError,
+		"u32"
+	);
+	impl_scalar_coerce!(
+		deserialize_u64,
+		visit_u64,
+		u64,
+		std::num::ParseIntError,
+		"u64"
+	);
+	impl_scalar_coerce!(
+		deserialize_u128,
+		visit_u128,
+		u128,
+		std::num::ParseIntError,
+		"u128"
+	);
+	impl_scalar_coerce!(
+		deserialize_f32,
+		visit_f32,
+		f32,
+		std::num::ParseFloatError,
+		"f32"
+	);
+	impl_scalar_coerce!(
+		deserialize_f64,
+		visit_f64,
+		f64,
+		std::num::ParseFloatError,
+		"f64"
+	);
+
+	fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
 	where
 		V: Visitor<'de>,
 	{
 		match self.value {
 			serde_json::Value::String(s) => {
-				let parsed: bool =
-					s.parse()
-						.map_err(|e: std::str::ParseBoolError| CoercionError::Parse {
-							target_type: "bool".to_string(),
-							value: s.clone(),
-							key_path: self.key_path.to_string(),
-							source: Box::new(e),
-						})?;
-				visitor.visit_bool(parsed)
+				let mut iter = s.chars();
+				let c = iter.next().ok_or_else(|| CoercionError::Parse {
+					target_type: "char".to_string(),
+					value: s.clone(),
+					key_path: self.key_path.to_string(),
+					source: "expected exactly one char, got empty string".into(),
+				})?;
+				if iter.next().is_some() {
+					return Err(CoercionError::Parse {
+						target_type: "char".to_string(),
+						value: s.clone(),
+						key_path: self.key_path.to_string(),
+						source: format!(
+							"expected exactly one char, got {} chars",
+							s.chars().count()
+						)
+						.into(),
+					});
+				}
+				visitor.visit_char(c)
 			}
 			other => other
 				.clone()
-				.deserialize_bool(visitor)
+				.deserialize_char(visitor)
 				.map_err(|e| CoercionError::Parse {
-					target_type: "bool".to_string(),
+					target_type: "char".to_string(),
 					value: other.to_string(),
 					key_path: self.key_path.to_string(),
 					source: Box::new(e),
@@ -185,16 +281,25 @@ impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 		}
 	}
 
-	impl_int_coerce!(deserialize_i8, visit_i8, i8, "i8");
-	impl_int_coerce!(deserialize_i16, visit_i16, i16, "i16");
-	impl_int_coerce!(deserialize_i32, visit_i32, i32, "i32");
-	impl_int_coerce!(deserialize_i64, visit_i64, i64, "i64");
-	impl_int_coerce!(deserialize_i128, visit_i128, i128, "i128");
-	impl_int_coerce!(deserialize_u8, visit_u8, u8, "u8");
-	impl_int_coerce!(deserialize_u16, visit_u16, u16, "u16");
-	impl_int_coerce!(deserialize_u32, visit_u32, u32, "u32");
-	impl_int_coerce!(deserialize_u64, visit_u64, u64, "u64");
-	impl_int_coerce!(deserialize_u128, visit_u128, u128, "u128");
+	fn deserialize_enum<V>(
+		self,
+		name: &'static str,
+		variants: &'static [&'static str],
+		visitor: V,
+	) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		self.value
+			.clone()
+			.deserialize_enum(name, variants, visitor)
+			.map_err(|e| CoercionError::Parse {
+				target_type: format!("enum {name}"),
+				value: self.value.to_string(),
+				key_path: self.key_path.to_string(),
+				source: Box::new(e),
+			})
+	}
 
 	fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
 	where

--- a/crates/reinhardt-conf/src/settings/typed_deserializer.rs
+++ b/crates/reinhardt-conf/src/settings/typed_deserializer.rs
@@ -12,8 +12,10 @@
 //! | `Vec<T>`            | parse as JSON array, recurse per item  |
 //! | `Map<K, V>`         | parse as JSON object, recurse per item |
 //! | `Vec<u8>` (bytes)   | base64 (STANDARD)                      |
-//! | struct/tuple/non-   | `CoercionError::UnsupportedShape`      |
-//! |   unit enum         |                                        |
+//! | enum                | delegate to `serde_json`; failures     |
+//! |                     |   wrap as `CoercionError::Parse`       |
+//! | struct / tuple /    | `CoercionError::UnsupportedShape`      |
+//! |   tuple struct      |                                        |
 //!
 //! The wrapper never re-runs interpolation: the resolved string is
 //! consumed exactly once.
@@ -87,7 +89,7 @@ pub enum CoercionError {
 	/// Failed to parse a string into the visitor's expected scalar /
 	/// bytes / collection-element shape.
 	#[error(
-		"failed to coerce string `{value}` into {target_type} at \
+		"failed to coerce value `{value}` into {target_type} at \
 		key `{key_path}`: {source}"
 	)]
 	Parse {

--- a/crates/reinhardt-conf/src/settings/typed_deserializer.rs
+++ b/crates/reinhardt-conf/src/settings/typed_deserializer.rs
@@ -145,8 +145,8 @@ impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 	// unreachable when the top-level value is an object). Remaining shapes
 	// still forward to `deserialize_any` until later phases.
 	forward_to_deserialize_any! {
-		str string unit unit_struct newtype_struct seq tuple tuple_struct
-		identifier ignored_any
+		str string unit unit_struct newtype_struct seq identifier
+		ignored_any
 	}
 
 	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -352,9 +352,73 @@ impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 	where
 		V: Visitor<'de>,
 	{
+		// String -> struct has no defined coercion. Surface a clear
+		// `UnsupportedShape` error directing callers to use field-by-field
+		// interpolation instead, rather than letting an opaque serde
+		// "expected map, got string" error escape via `deserialize_map`.
+		if matches!(self.value, serde_json::Value::String(_)) {
+			return Err(CoercionError::UnsupportedShape {
+				target: "struct",
+				key_path: self.key_path.to_string(),
+			});
+		}
 		// Structs deserialize via `visit_map`; route through the same
 		// adapter as `deserialize_map`.
 		self.deserialize_map(visitor)
+	}
+
+	fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		// String -> tuple has no defined coercion. Same rationale as
+		// `deserialize_struct`: emit `UnsupportedShape` to direct callers
+		// to per-element interpolation. Native arrays still flow through
+		// `serde_json`'s deserializer.
+		if matches!(self.value, serde_json::Value::String(_)) {
+			return Err(CoercionError::UnsupportedShape {
+				target: "tuple",
+				key_path: self.key_path.to_string(),
+			});
+		}
+		self.value
+			.clone()
+			.deserialize_tuple(len, visitor)
+			.map_err(|e| CoercionError::Parse {
+				target_type: "tuple".to_string(),
+				value: self.value.to_string(),
+				key_path: self.key_path.to_string(),
+				source: Box::new(e),
+			})
+	}
+
+	fn deserialize_tuple_struct<V>(
+		self,
+		name: &'static str,
+		len: usize,
+		visitor: V,
+	) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		// String -> tuple struct has no defined coercion. Same rationale
+		// as `deserialize_tuple`: emit `UnsupportedShape` instead of a
+		// generic serde error.
+		if matches!(self.value, serde_json::Value::String(_)) {
+			return Err(CoercionError::UnsupportedShape {
+				target: "tuple struct",
+				key_path: self.key_path.to_string(),
+			});
+		}
+		self.value
+			.clone()
+			.deserialize_tuple_struct(name, len, visitor)
+			.map_err(|e| CoercionError::Parse {
+				target_type: format!("tuple struct {name}"),
+				value: self.value.to_string(),
+				key_path: self.key_path.to_string(),
+				source: Box::new(e),
+			})
 	}
 
 	fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/crates/reinhardt-conf/src/settings/typed_deserializer.rs
+++ b/crates/reinhardt-conf/src/settings/typed_deserializer.rs
@@ -343,23 +343,55 @@ impl<'de, 'a> Deserializer<'de> for TypedSettingsDeserializer<'a> {
 	where
 		V: Visitor<'de>,
 	{
-		match self.value {
-			serde_json::Value::Object(map) => visitor.visit_map(TypedMapAccess {
-				iter: map.iter(),
-				pending_key: None,
-				pending_value: None,
-				key_path: self.key_path,
-			}),
-			other => other
-				.clone()
-				.deserialize_map(visitor)
-				.map_err(|e| CoercionError::Parse {
-					target_type: "map".to_string(),
+		// Accept both native `Value::Object(...)` and JSON-object literals
+		// embedded in `Value::String(...)`. The string path supports
+		// operator-friendly env-var defaults like
+		// `${WEIGHTS:-{"a":1,"b":2}}`. Per-entry dispatch flows back through
+		// `TypedSettingsDeserializer` so per-value scalar coercion fires
+		// (e.g. `HashMap<String, i32>` from `{"a": "1"}` parses each string
+		// value via the `i32` `FromStr` override).
+		let object: serde_json::Map<String, serde_json::Value> = match self.value {
+			serde_json::Value::Object(o) => o.clone(),
+			serde_json::Value::String(s) => {
+				let parsed: serde_json::Value =
+					serde_json::from_str(s).map_err(|e| CoercionError::Parse {
+						target_type: "object".to_string(),
+						value: s.clone(),
+						key_path: self.key_path.to_string(),
+						source: Box::new(e),
+					})?;
+				match parsed {
+					serde_json::Value::Object(o) => o,
+					other => {
+						return Err(CoercionError::Parse {
+							target_type: "object".to_string(),
+							value: s.clone(),
+							key_path: self.key_path.to_string(),
+							source: format!(
+								"expected JSON object after parsing string, got {}",
+								json_kind_name(&other)
+							)
+							.into(),
+						});
+					}
+				}
+			}
+			other => {
+				return Err(CoercionError::Parse {
+					target_type: "object".to_string(),
 					value: other.to_string(),
 					key_path: self.key_path.to_string(),
-					source: Box::new(e),
-				}),
-		}
+					source: format!("expected object, got {}", json_kind_name(other)).into(),
+				});
+			}
+		};
+
+		visitor.visit_map(TypedMapAccess {
+			entries: object.into_iter(),
+			pending_value: None,
+			pending_key: None,
+			key_path: self.key_path,
+		})
 	}
 
 	fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -544,33 +576,30 @@ impl<'de, 'a> Deserializer<'de> for TypedSettingsDeserializer<'a> {
 /// pushes the current key onto `KeyPath` so error messages identify the
 /// failing field.
 ///
-/// The struct lifetime `'a` is the borrow lifetime of the wrapped
-/// `serde_json::Map`, decoupled from the serde `'de` deserialization
-/// lifetime to mirror `TypedSettingsDeserializer`.
-struct TypedMapAccess<'a> {
-	iter: serde_json::map::Iter<'a>,
-	pending_key: Option<&'a str>,
-	pending_value: Option<&'a serde_json::Value>,
+/// The struct owns its `serde_json::Map` iterator because the source may
+/// be a parsed-from-string object whose backing storage does not outlive
+/// `'de`. Children borrow from `self.pending_value` for the duration of
+/// `next_value_seed`, which is shorter than (or equal to) `'de` — and
+/// the child deserializer's struct lifetime is decoupled from `'de`, so
+/// this is sound. Mirrors `TypedSeqAccess`.
+struct TypedMapAccess {
+	entries: serde_json::map::IntoIter,
+	pending_key: Option<String>,
+	pending_value: Option<serde_json::Value>,
 	key_path: KeyPath,
 }
 
-impl<'de, 'a> MapAccess<'de> for TypedMapAccess<'a> {
+impl<'de> MapAccess<'de> for TypedMapAccess {
 	type Error = CoercionError;
 
 	fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
 	where
 		K: DeserializeSeed<'de>,
 	{
-		match self.iter.next() {
+		match self.entries.next() {
 			Some((k, v)) => {
-				self.pending_key = Some(k.as_str());
-				self.pending_value = Some(v);
 				// Keys are always strings in JSON objects; deserialize
 				// directly via serde_json's owned-string deserializer.
-				// We pass an owned `String` (cloned from the borrowed
-				// `&'a str`) because the deserialization lifetime `'de`
-				// is decoupled from the value-borrow lifetime `'a`, and
-				// `BorrowedStrDeserializer` would require `'a: 'de`.
 				let key = seed
 					.deserialize(serde::de::value::StringDeserializer::<
 						serde::de::value::Error,
@@ -581,6 +610,8 @@ impl<'de, 'a> MapAccess<'de> for TypedMapAccess<'a> {
 						key_path: self.key_path.to_string(),
 						source: Box::new(e),
 					})?;
+				self.pending_key = Some(k);
+				self.pending_value = Some(v);
 				Ok(Some(key))
 			}
 			None => Ok(None),
@@ -605,11 +636,11 @@ impl<'de, 'a> MapAccess<'de> for TypedMapAccess<'a> {
 		// Build a child `KeyPath` that includes the current field name
 		// so coercion errors identify the failing key.
 		let mut child_path = self.key_path.clone();
-		if let Some(k) = key {
+		if let Some(k) = key.as_deref() {
 			child_path.push_key(k);
 		}
 		let de = TypedSettingsDeserializer {
-			value,
+			value: &value,
 			key_path: child_path,
 		};
 		seed.deserialize(de)

--- a/crates/reinhardt-conf/src/settings/typed_deserializer.rs
+++ b/crates/reinhardt-conf/src/settings/typed_deserializer.rs
@@ -21,8 +21,23 @@
 use super::interpolation::KeyPath;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use serde::de::{DeserializeSeed, Deserializer, MapAccess, Visitor};
+use serde::de::{DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::forward_to_deserialize_any;
+
+/// Short, human-readable name for a `serde_json::Value` variant.
+///
+/// Used in `CoercionError::Parse` source messages to disambiguate
+/// "expected JSON array, got <kind>" failures.
+fn json_kind_name(v: &serde_json::Value) -> &'static str {
+	match v {
+		serde_json::Value::Null => "null",
+		serde_json::Value::Bool(_) => "bool",
+		serde_json::Value::Number(_) => "number",
+		serde_json::Value::String(_) => "string",
+		serde_json::Value::Array(_) => "array",
+		serde_json::Value::Object(_) => "object",
+	}
+}
 
 /// Implement a `deserialize_<scalar>` method that coerces `Value::String`
 /// into the target scalar type via `FromStr`. For non-string inputs, it
@@ -116,16 +131,21 @@ impl serde::de::Error for CoercionError {
 /// Phase 2 skeleton: forwards every `deserialize_*` to `serde_json`'s
 /// own deserializer. Subsequent phases override individual visitor
 /// callbacks to coerce `Value::String` into the target Rust type.
-pub struct TypedSettingsDeserializer<'de> {
-	value: &'de serde_json::Value,
+///
+/// The struct's lifetime `'a` is the borrow lifetime of the wrapped
+/// value. It is decoupled from the serde `'de` deserialization
+/// lifetime so that `TypedSeqAccess` can own its element storage and
+/// hand out children that borrow from it for shorter than `'de`.
+pub struct TypedSettingsDeserializer<'a> {
+	value: &'a serde_json::Value,
 	key_path: KeyPath,
 }
 
-impl<'de> TypedSettingsDeserializer<'de> {
+impl<'a> TypedSettingsDeserializer<'a> {
 	/// Wrap a borrowed `serde_json::Value`. The returned deserializer
 	/// coerces string values when the visitor expects a non-String
 	/// target.
-	pub fn new(value: &'de serde_json::Value) -> Self {
+	pub fn new(value: &'a serde_json::Value) -> Self {
 		Self {
 			value,
 			key_path: KeyPath::default(),
@@ -133,20 +153,19 @@ impl<'de> TypedSettingsDeserializer<'de> {
 	}
 }
 
-impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
+impl<'de, 'a> Deserializer<'de> for TypedSettingsDeserializer<'a> {
 	type Error = CoercionError;
 
-	// Phase 3a + 3b + 3c + 3d (#4226): bool, integers, floats, char, enum,
-	// `Option<T>`, and bytes are explicitly overridden below to coerce
-	// `Value::String` via `FromStr` (or, for `char`, `enum`, `Option`, and
-	// `bytes`, via shape-specific rules — bytes use base64 STANDARD).
+	// Phase 3a + 3b + 3c + 3d + 4 (#4226): bool, integers, floats, char,
+	// enum, `Option<T>`, bytes, and sequences are explicitly overridden
+	// below. Scalars use `FromStr`; bytes use base64 STANDARD; sequences
+	// recurse element-by-element so per-element scalar coercion fires.
 	// `map`/`struct` are also overridden so that per-field dispatch flows
 	// through this deserializer (otherwise the scalar overrides would be
 	// unreachable when the top-level value is an object). Remaining shapes
-	// still forward to `deserialize_any` until later phases.
+	// still forward to `deserialize_any`.
 	forward_to_deserialize_any! {
-		str string unit unit_struct newtype_struct seq identifier
-		ignored_any
+		str string unit unit_struct newtype_struct identifier ignored_any
 	}
 
 	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -343,6 +362,60 @@ impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 		}
 	}
 
+	fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		// Accept both native `Value::Array(...)` and JSON-array literals
+		// embedded in `Value::String(...)`. The string path supports
+		// operator-friendly env-var defaults like `${PORTS:-[5432, 5433]}`.
+		// Element-wise dispatch flows back through
+		// `TypedSettingsDeserializer` so per-element scalar coercion fires
+		// (e.g. `Vec<u16>` from `["5432", "5433"]` parses each element via
+		// the `u16` `FromStr` override).
+		let array: Vec<serde_json::Value> = match self.value {
+			serde_json::Value::Array(a) => a.clone(),
+			serde_json::Value::String(s) => {
+				let parsed: serde_json::Value =
+					serde_json::from_str(s).map_err(|e| CoercionError::Parse {
+						target_type: "array".to_string(),
+						value: s.clone(),
+						key_path: self.key_path.to_string(),
+						source: Box::new(e),
+					})?;
+				match parsed {
+					serde_json::Value::Array(a) => a,
+					other => {
+						return Err(CoercionError::Parse {
+							target_type: "array".to_string(),
+							value: s.clone(),
+							key_path: self.key_path.to_string(),
+							source: format!(
+								"expected JSON array after parsing string, got {}",
+								json_kind_name(&other)
+							)
+							.into(),
+						});
+					}
+				}
+			}
+			other => {
+				return Err(CoercionError::Parse {
+					target_type: "array".to_string(),
+					value: other.to_string(),
+					key_path: self.key_path.to_string(),
+					source: format!("expected array, got {}", json_kind_name(other)).into(),
+				});
+			}
+		};
+
+		visitor.visit_seq(TypedSeqAccess {
+			values: array,
+			index: 0,
+			key_path: self.key_path,
+		})
+	}
+
 	fn deserialize_struct<V>(
 		self,
 		_name: &'static str,
@@ -470,14 +543,18 @@ impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 /// `TypedSettingsDeserializer` so per-field type overrides apply, and
 /// pushes the current key onto `KeyPath` so error messages identify the
 /// failing field.
-struct TypedMapAccess<'de> {
-	iter: serde_json::map::Iter<'de>,
-	pending_key: Option<&'de str>,
-	pending_value: Option<&'de serde_json::Value>,
+///
+/// The struct lifetime `'a` is the borrow lifetime of the wrapped
+/// `serde_json::Map`, decoupled from the serde `'de` deserialization
+/// lifetime to mirror `TypedSettingsDeserializer`.
+struct TypedMapAccess<'a> {
+	iter: serde_json::map::Iter<'a>,
+	pending_key: Option<&'a str>,
+	pending_value: Option<&'a serde_json::Value>,
 	key_path: KeyPath,
 }
 
-impl<'de> MapAccess<'de> for TypedMapAccess<'de> {
+impl<'de, 'a> MapAccess<'de> for TypedMapAccess<'a> {
 	type Error = CoercionError;
 
 	fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
@@ -489,12 +566,15 @@ impl<'de> MapAccess<'de> for TypedMapAccess<'de> {
 				self.pending_key = Some(k.as_str());
 				self.pending_value = Some(v);
 				// Keys are always strings in JSON objects; deserialize
-				// directly via serde_json's borrowed-str deserializer.
+				// directly via serde_json's owned-string deserializer.
+				// We pass an owned `String` (cloned from the borrowed
+				// `&'a str`) because the deserialization lifetime `'de`
+				// is decoupled from the value-borrow lifetime `'a`, and
+				// `BorrowedStrDeserializer` would require `'a: 'de`.
 				let key = seed
-					.deserialize(serde::de::value::BorrowedStrDeserializer::<
-						'de,
+					.deserialize(serde::de::value::StringDeserializer::<
 						serde::de::value::Error,
-					>::new(k.as_str()))
+					>::new(k.clone()))
 					.map_err(|e| CoercionError::Parse {
 						target_type: "map_key".to_string(),
 						value: k.clone(),
@@ -533,6 +613,50 @@ impl<'de> MapAccess<'de> for TypedMapAccess<'de> {
 			key_path: child_path,
 		};
 		seed.deserialize(de)
+	}
+}
+
+/// `SeqAccess` adapter that re-wraps each element in a
+/// `TypedSettingsDeserializer` so per-element type overrides apply,
+/// and pushes the current index onto `KeyPath` so error messages
+/// identify the failing element.
+///
+/// The struct owns its `Vec<Value>` because the source may be a parsed
+/// JSON string whose backing storage does not outlive `'de`. Children
+/// borrow from `self.values` for the duration of `next_element_seed`,
+/// which is shorter than (or equal to) `'de` — but the child
+/// deserializer's struct lifetime is decoupled from `'de`, so this is
+/// sound.
+struct TypedSeqAccess {
+	values: Vec<serde_json::Value>,
+	index: usize,
+	key_path: KeyPath,
+}
+
+impl<'de> SeqAccess<'de> for TypedSeqAccess {
+	type Error = CoercionError;
+
+	fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+	where
+		T: DeserializeSeed<'de>,
+	{
+		if self.index >= self.values.len() {
+			return Ok(None);
+		}
+		let value = &self.values[self.index];
+		let mut child_path = self.key_path.clone();
+		child_path.push_index(self.index);
+		self.index += 1;
+
+		let de = TypedSettingsDeserializer {
+			value,
+			key_path: child_path,
+		};
+		seed.deserialize(de).map(Some)
+	}
+
+	fn size_hint(&self) -> Option<usize> {
+		Some(self.values.len().saturating_sub(self.index))
 	}
 }
 

--- a/crates/reinhardt-conf/src/settings/typed_deserializer.rs
+++ b/crates/reinhardt-conf/src/settings/typed_deserializer.rs
@@ -19,8 +19,45 @@
 //! consumed exactly once.
 
 use super::interpolation::KeyPath;
-use serde::de::{Deserializer, Visitor};
+use serde::de::{DeserializeSeed, Deserializer, MapAccess, Visitor};
 use serde::forward_to_deserialize_any;
+
+/// Implement a `deserialize_<int>` method that coerces `Value::String`
+/// into the target integer type via `FromStr`. For non-string inputs, it
+/// delegates to `serde_json::Value`'s deserializer and re-wraps any
+/// resulting error as `CoercionError::Parse` so callers always see a
+/// uniform error shape carrying `key_path` / `target_type`.
+macro_rules! impl_int_coerce {
+	($method:ident, $visit:ident, $ty:ty, $type_name:expr) => {
+		fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: Visitor<'de>,
+		{
+			match self.value {
+				serde_json::Value::String(s) => {
+					let parsed: $ty =
+						s.parse()
+							.map_err(|e: std::num::ParseIntError| CoercionError::Parse {
+								target_type: $type_name.to_string(),
+								value: s.clone(),
+								key_path: self.key_path.to_string(),
+								source: Box::new(e),
+							})?;
+					visitor.$visit(parsed)
+				}
+				other => other
+					.clone()
+					.$method(visitor)
+					.map_err(|e| CoercionError::Parse {
+						target_type: $type_name.to_string(),
+						value: other.to_string(),
+						key_path: self.key_path.to_string(),
+						source: Box::new(e),
+					}),
+			}
+		}
+	};
+}
 
 /// Coercion failure surfaced from `TypedSettingsDeserializer`.
 #[derive(Debug, thiserror::Error)]
@@ -93,12 +130,15 @@ impl<'de> TypedSettingsDeserializer<'de> {
 impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 	type Error = CoercionError;
 
-	// Skeleton: forward everything to serde_json's deserializer for
-	// now. Phase 3+ overrides each `deserialize_*` we care about.
+	// Phase 3a (#4226): bool + integers are explicitly overridden below
+	// to coerce `Value::String` via `FromStr`. `map`/`struct` are also
+	// overridden so that per-field dispatch flows through this
+	// deserializer (otherwise the scalar overrides would be unreachable
+	// when the top-level value is an object). Other shapes still forward
+	// to `deserialize_any` until later phases.
 	forward_to_deserialize_any! {
-		bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
-		string bytes byte_buf option unit unit_struct newtype_struct seq
-		tuple tuple_struct map struct enum identifier ignored_any
+		f32 f64 char str string bytes byte_buf option unit unit_struct
+		newtype_struct seq tuple tuple_struct enum identifier ignored_any
 	}
 
 	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -115,6 +155,152 @@ impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 				key_path: self.key_path.to_string(),
 				source: Box::new(e),
 			})
+	}
+
+	fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		match self.value {
+			serde_json::Value::String(s) => {
+				let parsed: bool =
+					s.parse()
+						.map_err(|e: std::str::ParseBoolError| CoercionError::Parse {
+							target_type: "bool".to_string(),
+							value: s.clone(),
+							key_path: self.key_path.to_string(),
+							source: Box::new(e),
+						})?;
+				visitor.visit_bool(parsed)
+			}
+			other => other
+				.clone()
+				.deserialize_bool(visitor)
+				.map_err(|e| CoercionError::Parse {
+					target_type: "bool".to_string(),
+					value: other.to_string(),
+					key_path: self.key_path.to_string(),
+					source: Box::new(e),
+				}),
+		}
+	}
+
+	impl_int_coerce!(deserialize_i8, visit_i8, i8, "i8");
+	impl_int_coerce!(deserialize_i16, visit_i16, i16, "i16");
+	impl_int_coerce!(deserialize_i32, visit_i32, i32, "i32");
+	impl_int_coerce!(deserialize_i64, visit_i64, i64, "i64");
+	impl_int_coerce!(deserialize_i128, visit_i128, i128, "i128");
+	impl_int_coerce!(deserialize_u8, visit_u8, u8, "u8");
+	impl_int_coerce!(deserialize_u16, visit_u16, u16, "u16");
+	impl_int_coerce!(deserialize_u32, visit_u32, u32, "u32");
+	impl_int_coerce!(deserialize_u64, visit_u64, u64, "u64");
+	impl_int_coerce!(deserialize_u128, visit_u128, u128, "u128");
+
+	fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		match self.value {
+			serde_json::Value::Object(map) => visitor.visit_map(TypedMapAccess {
+				iter: map.iter(),
+				pending_key: None,
+				pending_value: None,
+				key_path: self.key_path,
+			}),
+			other => other
+				.clone()
+				.deserialize_map(visitor)
+				.map_err(|e| CoercionError::Parse {
+					target_type: "map".to_string(),
+					value: other.to_string(),
+					key_path: self.key_path.to_string(),
+					source: Box::new(e),
+				}),
+		}
+	}
+
+	fn deserialize_struct<V>(
+		self,
+		_name: &'static str,
+		_fields: &'static [&'static str],
+		visitor: V,
+	) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		// Structs deserialize via `visit_map`; route through the same
+		// adapter as `deserialize_map`.
+		self.deserialize_map(visitor)
+	}
+}
+
+/// `MapAccess` adapter that re-wraps each value in a
+/// `TypedSettingsDeserializer` so per-field type overrides apply, and
+/// pushes the current key onto `KeyPath` so error messages identify the
+/// failing field.
+struct TypedMapAccess<'de> {
+	iter: serde_json::map::Iter<'de>,
+	pending_key: Option<&'de str>,
+	pending_value: Option<&'de serde_json::Value>,
+	key_path: KeyPath,
+}
+
+impl<'de> MapAccess<'de> for TypedMapAccess<'de> {
+	type Error = CoercionError;
+
+	fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+	where
+		K: DeserializeSeed<'de>,
+	{
+		match self.iter.next() {
+			Some((k, v)) => {
+				self.pending_key = Some(k.as_str());
+				self.pending_value = Some(v);
+				// Keys are always strings in JSON objects; deserialize
+				// directly via serde_json's borrowed-str deserializer.
+				let key = seed
+					.deserialize(serde::de::value::BorrowedStrDeserializer::<
+						'de,
+						serde::de::value::Error,
+					>::new(k.as_str()))
+					.map_err(|e| CoercionError::Parse {
+						target_type: "map_key".to_string(),
+						value: k.clone(),
+						key_path: self.key_path.to_string(),
+						source: Box::new(e),
+					})?;
+				Ok(Some(key))
+			}
+			None => Ok(None),
+		}
+	}
+
+	fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+	where
+		V: DeserializeSeed<'de>,
+	{
+		let value = self
+			.pending_value
+			.take()
+			.ok_or_else(|| CoercionError::Parse {
+				target_type: "map_value".to_string(),
+				value: String::new(),
+				key_path: self.key_path.to_string(),
+				source: "next_value_seed called before next_key_seed".into(),
+			})?;
+		let key = self.pending_key.take();
+
+		// Build a child `KeyPath` that includes the current field name
+		// so coercion errors identify the failing key.
+		let mut child_path = self.key_path.clone();
+		if let Some(k) = key {
+			child_path.push_key(k);
+		}
+		let de = TypedSettingsDeserializer {
+			value,
+			key_path: child_path,
+		};
+		seed.deserialize(de)
 	}
 }
 

--- a/crates/reinhardt-conf/src/settings/typed_deserializer.rs
+++ b/crates/reinhardt-conf/src/settings/typed_deserializer.rs
@@ -134,16 +134,17 @@ impl<'de> TypedSettingsDeserializer<'de> {
 impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 	type Error = CoercionError;
 
-	// Phase 3a + 3b (#4226): bool, integers, floats, char, and enum are
-	// explicitly overridden below to coerce `Value::String` via `FromStr`
-	// (or, for `char` and `enum`, via shape-specific rules). `map`/`struct`
-	// are also overridden so that per-field dispatch flows through this
-	// deserializer (otherwise the scalar overrides would be unreachable
-	// when the top-level value is an object). Remaining shapes still
-	// forward to `deserialize_any` until later phases.
+	// Phase 3a + 3b + 3c (#4226): bool, integers, floats, char, enum, and
+	// `Option<T>` are explicitly overridden below to coerce `Value::String`
+	// via `FromStr` (or, for `char`, `enum`, and `Option`, via shape-
+	// specific rules). `map`/`struct` are also overridden so that per-field
+	// dispatch flows through this deserializer (otherwise the scalar
+	// overrides would be unreachable when the top-level value is an
+	// object). Remaining shapes still forward to `deserialize_any` until
+	// later phases.
 	forward_to_deserialize_any! {
-		str string bytes byte_buf option unit unit_struct
-		newtype_struct seq tuple tuple_struct identifier ignored_any
+		str string bytes byte_buf unit unit_struct newtype_struct seq tuple
+		tuple_struct identifier ignored_any
 	}
 
 	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -241,6 +242,22 @@ impl<'de> Deserializer<'de> for TypedSettingsDeserializer<'de> {
 		std::num::ParseFloatError,
 		"f64"
 	);
+
+	fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		// `Value::Null` and the empty string both map to `None`. The empty-
+		// string rule supports env-var defaults like `${VAR:-}` where an
+		// optional field naturally produces `""`. For any other value, recurse
+		// into `self` so that scalar coercion (Phase 3a/3b) fires for the
+		// `Some(_)` payload's inner type.
+		match self.value {
+			serde_json::Value::Null => visitor.visit_none(),
+			serde_json::Value::String(s) if s.is_empty() => visitor.visit_none(),
+			_ => visitor.visit_some(self),
+		}
+	}
 
 	fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
 	where

--- a/crates/reinhardt-conf/tests/typed_coercion.rs
+++ b/crates/reinhardt-conf/tests/typed_coercion.rs
@@ -59,3 +59,87 @@ fn scalar_coerce_error(
 	assert!(msg.contains(expected_key), "msg = {msg}");
 	assert!(msg.contains(expected_target), "msg = {msg}");
 }
+
+// --- floats / char ---------------------------------------------------
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct FloatChar {
+	rate: f64,
+	sigil: char,
+}
+
+#[rstest]
+#[case::strings(
+	json!({ "rate": "1.5", "sigil": "x" }),
+	FloatChar { rate: 1.5, sigil: 'x' }
+)]
+#[case::native(
+	json!({ "rate": 2.25, "sigil": "z" }),
+	FloatChar { rate: 2.25, sigil: 'z' }
+)]
+fn float_char_coerce_happy(#[case] v: serde_json::Value, #[case] expected: FloatChar) {
+	// Arrange
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let got: FloatChar = FloatChar::deserialize(de).expect("ok");
+
+	// Assert
+	assert_eq!(got, expected);
+}
+
+#[rstest]
+#[case::bad_float(json!({ "rate": "fast", "sigil": "x" }), "rate", "f64")]
+#[case::char_too_long(json!({ "rate": "1.0", "sigil": "long" }), "sigil", "char")]
+fn float_char_coerce_error(
+	#[case] v: serde_json::Value,
+	#[case] expected_key: &str,
+	#[case] expected_target: &str,
+) {
+	// Arrange
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let err = FloatChar::deserialize(de).unwrap_err();
+
+	// Assert
+	let msg = err.to_string();
+	assert!(matches!(err, CoercionError::Parse { .. }), "got: {err:?}");
+	assert!(msg.contains(expected_key), "msg = {msg}");
+	assert!(msg.contains(expected_target), "msg = {msg}");
+}
+
+// --- enum-unit -------------------------------------------------------
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum LogLevel {
+	Trace,
+	Debug,
+	Info,
+	Warn,
+	Error,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithLevel {
+	level: LogLevel,
+}
+
+#[rstest]
+fn enum_unit_coerce_from_string() {
+	// Arrange
+	let v = json!({ "level": "info" });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let got: WithLevel = WithLevel::deserialize(de).expect("ok");
+
+	// Assert
+	assert_eq!(
+		got,
+		WithLevel {
+			level: LogLevel::Info
+		}
+	);
+}

--- a/crates/reinhardt-conf/tests/typed_coercion.rs
+++ b/crates/reinhardt-conf/tests/typed_coercion.rs
@@ -385,3 +385,67 @@ fn vec_string_with_object_inside_errors() {
 	// Assert
 	assert!(matches!(err, CoercionError::Parse { .. }));
 }
+
+// --- HashMap<K, V> ---------------------------------------------------
+
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithWeights {
+	weights: HashMap<String, i32>,
+}
+
+#[rstest]
+#[case::map_native(
+	json!({ "weights": { "a": 1, "b": 2 } }),
+	WithWeights { weights: HashMap::from([("a".into(), 1), ("b".into(), 2)]) }
+)]
+#[case::map_string_with_native_values(
+	json!({ "weights": "{\"a\": 1, \"b\": 2}" }),
+	WithWeights { weights: HashMap::from([("a".into(), 1), ("b".into(), 2)]) }
+)]
+#[case::map_string_with_string_values(
+	json!({ "weights": "{\"a\": \"1\", \"b\": \"2\"}" }),
+	WithWeights { weights: HashMap::from([("a".into(), 1), ("b".into(), 2)]) }
+)]
+fn map_coerce_happy(#[case] v: serde_json::Value, #[case] expected: WithWeights) {
+	// Arrange
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let got: WithWeights = WithWeights::deserialize(de).expect("ok");
+
+	// Assert
+	assert_eq!(got, expected);
+}
+
+#[rstest]
+fn map_invalid_json_errors() {
+	// Arrange — Map<String, i32> field whose source string isn't JSON
+	let v = json!({ "weights": "not-json-at-all" });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let err = WithWeights::deserialize(de).unwrap_err();
+
+	// Assert
+	assert!(matches!(err, CoercionError::Parse { .. }));
+	let msg = err.to_string();
+	assert!(
+		msg.contains("object") || msg.contains("weights"),
+		"msg = {msg}"
+	);
+}
+
+#[rstest]
+fn map_string_with_array_inside_errors() {
+	// Arrange — string contains JSON array (not object)
+	let v = json!({ "weights": "[1, 2, 3]" });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let err = WithWeights::deserialize(de).unwrap_err();
+
+	// Assert
+	assert!(matches!(err, CoercionError::Parse { .. }));
+}

--- a/crates/reinhardt-conf/tests/typed_coercion.rs
+++ b/crates/reinhardt-conf/tests/typed_coercion.rs
@@ -449,3 +449,76 @@ fn map_string_with_array_inside_errors() {
 	// Assert
 	assert!(matches!(err, CoercionError::Parse { .. }));
 }
+
+// --- builder integration --------------------------------------------
+
+use reinhardt_conf::settings::builder::SettingsBuilder;
+use reinhardt_conf::settings::sources::DefaultSource;
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct DbSettings {
+	host: String,
+	port: u16,
+	read_only: bool,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithDb {
+	database: DbSettings,
+}
+
+#[rstest]
+fn builder_coerces_strings_to_typed_fields() {
+	// Arrange — DefaultSource pushes string-typed values that still
+	// need to coerce into DbSettings.
+	let settings = SettingsBuilder::new()
+		.add_source(DefaultSource::new().with_value(
+			"database",
+			json!({
+				"host": "localhost",
+				"port": "5432",
+				"read_only": "false",
+			}),
+		))
+		.build()
+		.expect("build");
+
+	// Act
+	let got: WithDb = settings.into_typed().expect("into_typed");
+
+	// Assert
+	assert_eq!(
+		got,
+		WithDb {
+			database: DbSettings {
+				host: "localhost".into(),
+				port: 5432,
+				read_only: false
+			}
+		}
+	);
+}
+
+#[rstest]
+fn builder_with_typed_coercion_disabled_falls_through_to_legacy() {
+	// Arrange — same input as above, but coercion disabled.
+	let result: Result<WithDb, _> = SettingsBuilder::new()
+		.with_typed_coercion(false)
+		.add_source(DefaultSource::new().with_value(
+			"database",
+			json!({
+				"host": "localhost",
+				"port": "5432",
+				"read_only": "false",
+			}),
+		))
+		.build()
+		.unwrap()
+		.into_typed();
+
+	// Act / Assert — expect the legacy serde error path.
+	assert!(
+		result.is_err(),
+		"legacy path should reject string-typed port"
+	);
+}

--- a/crates/reinhardt-conf/tests/typed_coercion.rs
+++ b/crates/reinhardt-conf/tests/typed_coercion.rs
@@ -1,0 +1,61 @@
+//! Integration tests for typed string coercion (issue #4226).
+
+use reinhardt_conf::settings::typed_deserializer::{CoercionError, TypedSettingsDeserializer};
+
+use rstest::rstest;
+use serde::Deserialize;
+use serde_json::json;
+
+// --- bool / int coercion ----------------------------------------------
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Scalars {
+	flag: bool,
+	port: u16,
+	count: i64,
+}
+
+#[rstest]
+#[case::all_strings(
+	json!({ "flag": "true", "port": "5432", "count": "-42" }),
+	Scalars { flag: true, port: 5432, count: -42 }
+)]
+#[case::mixed(
+	json!({ "flag": true, "port": "5432", "count": -42 }),
+	Scalars { flag: true, port: 5432, count: -42 }
+)]
+#[case::all_native(
+	json!({ "flag": false, "port": 8080, "count": 0 }),
+	Scalars { flag: false, port: 8080, count: 0 }
+)]
+fn scalar_coerce_happy(#[case] v: serde_json::Value, #[case] expected: Scalars) {
+	// Arrange
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let got: Scalars = Scalars::deserialize(de).expect("coerce should succeed");
+
+	// Assert
+	assert_eq!(got, expected);
+}
+
+#[rstest]
+#[case::bad_int(json!({ "flag": "true", "port": "five-thousand", "count": "0" }), "port", "u16")]
+#[case::bad_bool(json!({ "flag": "yep", "port": "1", "count": "0" }), "flag", "bool")]
+fn scalar_coerce_error(
+	#[case] v: serde_json::Value,
+	#[case] expected_key: &str,
+	#[case] expected_target: &str,
+) {
+	// Arrange
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let err = Scalars::deserialize(de).unwrap_err();
+
+	// Assert
+	let msg = err.to_string();
+	assert!(matches!(err, CoercionError::Parse { .. }), "got: {err:?}");
+	assert!(msg.contains(expected_key), "msg = {msg}");
+	assert!(msg.contains(expected_target), "msg = {msg}");
+}

--- a/crates/reinhardt-conf/tests/typed_coercion.rs
+++ b/crates/reinhardt-conf/tests/typed_coercion.rs
@@ -322,3 +322,66 @@ fn tuple_struct_from_string_is_unsupported() {
 	);
 	assert!(msg.contains("pair"), "msg = {msg}");
 }
+
+// --- Vec<T> ----------------------------------------------------------
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct VecCases {
+	ports: Vec<u16>,
+	hosts: Vec<String>,
+}
+
+#[rstest]
+#[case::vec_native(
+	json!({ "ports": [5432, 5433], "hosts": ["a", "b"] }),
+	VecCases { ports: vec![5432, 5433], hosts: vec!["a".into(), "b".into()] }
+)]
+#[case::vec_string_native_array(
+	json!({ "ports": "[5432, 5433]", "hosts": "[\"a\", \"b\"]" }),
+	VecCases { ports: vec![5432, 5433], hosts: vec!["a".into(), "b".into()] }
+)]
+#[case::vec_string_with_string_elements(
+	json!({ "ports": "[\"5432\", \"5433\"]", "hosts": "[\"a\", \"b\"]" }),
+	VecCases { ports: vec![5432, 5433], hosts: vec!["a".into(), "b".into()] }
+)]
+fn vec_coerce_happy(#[case] v: serde_json::Value, #[case] expected: VecCases) {
+	// Arrange
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let got: VecCases = VecCases::deserialize(de).expect("ok");
+
+	// Assert
+	assert_eq!(got, expected);
+}
+
+#[rstest]
+fn vec_invalid_json_errors() {
+	// Arrange — a Vec<u16> field whose source is a string that doesn't parse as JSON array
+	let v = json!({ "ports": "not-an-array", "hosts": [] });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let err = VecCases::deserialize(de).unwrap_err();
+
+	// Assert
+	assert!(matches!(err, CoercionError::Parse { .. }));
+	let msg = err.to_string();
+	assert!(
+		msg.contains("array") || msg.contains("ports"),
+		"msg = {msg}"
+	);
+}
+
+#[rstest]
+fn vec_string_with_object_inside_errors() {
+	// Arrange — string contains JSON object (not array)
+	let v = json!({ "ports": "{\"5432\":\"x\"}", "hosts": [] });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let err = VecCases::deserialize(de).unwrap_err();
+
+	// Assert
+	assert!(matches!(err, CoercionError::Parse { .. }));
+}

--- a/crates/reinhardt-conf/tests/typed_coercion.rs
+++ b/crates/reinhardt-conf/tests/typed_coercion.rs
@@ -522,3 +522,57 @@ fn builder_with_typed_coercion_disabled_falls_through_to_legacy() {
 		"legacy path should reject string-typed port"
 	);
 }
+
+// --- hot reload (build path rejects coercion-breaking edits) -------
+
+use reinhardt_conf::settings::sources::TomlFileSource;
+use std::fs;
+use tempfile::NamedTempFile;
+
+#[rstest]
+fn hot_reload_rejects_coercion_breaking_change_and_keeps_old_settings() {
+	// Arrange — initial valid TOML that coerces cleanly.
+	let tmp = NamedTempFile::new().expect("tempfile");
+	fs::write(
+		tmp.path(),
+		r#"
+[database]
+host = "localhost"
+port = "5432"
+read_only = "false"
+"#,
+	)
+	.expect("write initial");
+
+	let initial: WithDb = SettingsBuilder::new()
+		.add_source(TomlFileSource::new(tmp.path()))
+		.build()
+		.expect("initial build")
+		.into_typed()
+		.expect("initial typed");
+	assert_eq!(initial.database.port, 5432);
+
+	// Act — overwrite the file with a coercion-breaking value.
+	fs::write(
+		tmp.path(),
+		r#"
+[database]
+host = "localhost"
+port = "five-thousand"
+read_only = "false"
+"#,
+	)
+	.expect("write breaking");
+
+	let result: Result<WithDb, _> = SettingsBuilder::new()
+		.add_source(TomlFileSource::new(tmp.path()))
+		.build()
+		.expect("rebuild")
+		.into_typed();
+
+	// Assert — reload returns Err; previous in-memory settings stay
+	// untouched (they are owned by this test; the watcher would
+	// equivalently swap on success only).
+	assert!(result.is_err(), "rebuild should reject coercion failure");
+	assert_eq!(initial.database.port, 5432, "previous settings stay valid");
+}

--- a/crates/reinhardt-conf/tests/typed_coercion.rs
+++ b/crates/reinhardt-conf/tests/typed_coercion.rs
@@ -167,3 +167,47 @@ fn option_coerce(#[case] v: serde_json::Value, #[case] expected: OptionalPort) {
 	// Assert
 	assert_eq!(got, expected);
 }
+
+// --- bytes / Vec<u8> -------------------------------------------------
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithKey {
+	#[serde(with = "serde_bytes")]
+	key: Vec<u8>,
+}
+
+#[rstest]
+fn bytes_coerce_from_base64() {
+	// Arrange — "hello" in base64 = "aGVsbG8="
+	let v = json!({ "key": "aGVsbG8=" });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let got: WithKey = WithKey::deserialize(de).expect("ok");
+
+	// Assert
+	assert_eq!(
+		got,
+		WithKey {
+			key: b"hello".to_vec()
+		}
+	);
+}
+
+#[rstest]
+fn bytes_coerce_invalid_base64_errors() {
+	// Arrange
+	let v = json!({ "key": "not-valid-base64!@#" });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let err = WithKey::deserialize(de).unwrap_err();
+
+	// Assert
+	let msg = err.to_string();
+	assert!(matches!(err, CoercionError::Parse { .. }));
+	assert!(
+		msg.contains("bytes") || msg.contains("base64"),
+		"msg = {msg}"
+	);
+}

--- a/crates/reinhardt-conf/tests/typed_coercion.rs
+++ b/crates/reinhardt-conf/tests/typed_coercion.rs
@@ -143,3 +143,27 @@ fn enum_unit_coerce_from_string() {
 		}
 	);
 }
+
+// --- Option<T> -------------------------------------------------------
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct OptionalPort {
+	port: Option<u16>,
+}
+
+#[rstest]
+#[case::some_str(json!({ "port": "5432" }),  OptionalPort { port: Some(5432) })]
+#[case::some_native(json!({ "port": 5432 }), OptionalPort { port: Some(5432) })]
+#[case::none_empty(json!({ "port": "" }),    OptionalPort { port: None })]
+#[case::none_null(json!({ "port": null }),   OptionalPort { port: None })]
+#[case::none_missing(json!({}),              OptionalPort { port: None })]
+fn option_coerce(#[case] v: serde_json::Value, #[case] expected: OptionalPort) {
+	// Arrange
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let got: OptionalPort = OptionalPort::deserialize(de).expect("ok");
+
+	// Assert
+	assert_eq!(got, expected);
+}

--- a/crates/reinhardt-conf/tests/typed_coercion.rs
+++ b/crates/reinhardt-conf/tests/typed_coercion.rs
@@ -211,3 +211,114 @@ fn bytes_coerce_invalid_base64_errors() {
 		"msg = {msg}"
 	);
 }
+
+// --- UnsupportedShape: struct from string ----------------------------
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Endpoint {
+	host: String,
+	port: u16,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithEndpoint {
+	endpoint: Endpoint,
+}
+
+#[rstest]
+fn nested_struct_from_string_is_unsupported() {
+	// Arrange
+	let v = json!({ "endpoint": "{\"host\":\"localhost\",\"port\":5432}" });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let err = WithEndpoint::deserialize(de).unwrap_err();
+
+	// Assert
+	let msg = err.to_string();
+	assert!(
+		matches!(err, CoercionError::UnsupportedShape { .. }),
+		"got: {err:?}"
+	);
+	assert!(msg.contains("struct"), "msg = {msg}");
+	assert!(msg.contains("endpoint"), "msg = {msg}");
+}
+
+#[rstest]
+fn nested_struct_from_object_works() {
+	// Arrange — per-field interpolation is the recommended pattern
+	let v = json!({ "endpoint": { "host": "localhost", "port": "5432" } });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let got: WithEndpoint = WithEndpoint::deserialize(de).expect("ok");
+
+	// Assert
+	assert_eq!(
+		got,
+		WithEndpoint {
+			endpoint: Endpoint {
+				host: "localhost".into(),
+				port: 5432
+			}
+		}
+	);
+}
+
+// --- UnsupportedShape: tuple from string -----------------------------
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithTuple {
+	pair: (u16, u16),
+}
+
+#[rstest]
+fn tuple_from_string_is_unsupported() {
+	// Arrange
+	let v = json!({ "pair": "(1, 2)" });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let err = WithTuple::deserialize(de).unwrap_err();
+
+	// Assert
+	let msg = err.to_string();
+	assert!(
+		matches!(err, CoercionError::UnsupportedShape { .. }),
+		"got: {err:?}"
+	);
+	assert!(msg.contains("tuple"), "msg = {msg}");
+	assert!(msg.contains("pair"), "msg = {msg}");
+}
+
+// --- UnsupportedShape: tuple_struct from string ----------------------
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Pair(u16, u16);
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithTupleStruct {
+	pair: Pair,
+}
+
+#[rstest]
+fn tuple_struct_from_string_is_unsupported() {
+	// Arrange
+	let v = json!({ "pair": "(1, 2)" });
+	let de = TypedSettingsDeserializer::new(&v);
+
+	// Act
+	let err = WithTupleStruct::deserialize(de).unwrap_err();
+
+	// Assert
+	let msg = err.to_string();
+	assert!(
+		matches!(err, CoercionError::UnsupportedShape { .. }),
+		"got: {err:?}"
+	);
+	assert!(
+		msg.contains("tuple struct") || msg.contains("tuple"),
+		"msg = {msg}"
+	);
+	assert!(msg.contains("pair"), "msg = {msg}");
+}


### PR DESCRIPTION
## Summary

- Introduces `TypedSettingsDeserializer`, a `serde::Deserializer` adapter that coerces `Value::String` into the target Rust type at the visitor boundary.
- Coercion strategies: scalar via `FromStr`, `Vec<T>` and `HashMap<K, V>` via JSON parse with recursive per-element coercion, `Vec<u8>` via base64 (STANDARD), nested struct rejected with `CoercionError::UnsupportedShape`.
- Default ON; opt out via `SettingsBuilder::with_typed_coercion(false)`.

## Type of Change

- Breaking change (new behaviour at deserialize time)
- New feature (`with_typed_coercion`, `BuildError::Coercion`, `CoercionError`)

## Motivation and Context

Issue #4226: today \`port = "\${REINHARDT_DB_PORT:-5432}"\` resolves the env var but stays a string, breaking deserialization into typed fields. This PR makes interpolation type-aware and surfaces coerce failures at startup time.

The change targets the 0.1.0-rc series; release-plz will pick up the conventional commits and bump the version on merge.

## How Was This Tested

- \`cargo nextest run -p reinhardt-conf --all-features\` — 702/702 pass (33 typed_coercion + 1 hot-reload + smoke + prior suite)
- \`cargo make fmt-check\` — clean
- \`cargo make clippy-check\` — clean
- \`cargo doc -p reinhardt-conf --no-deps\` — clean

New tests in \`crates/reinhardt-conf/tests/typed_coercion.rs\` cover scalar, Option, Vec, HashMap, bytes, nested struct, builder integration, and hot-reload rejection (~33 rstest cases).

## Checklist

- [x] Module structure follows project conventions (no mod.rs)
- [x] All comments in English
- [x] Tests use rstest + AAA pattern
- [x] No new \`todo!()\` or \`// TODO\` markers introduced
- [x] CHANGELOG updated
- [x] README \"Behavior Notes\" updated
- [x] interpolation.rs module docs cross-reference the new module

## Labels to Apply

- \`enhancement\`
- \`breaking-change\`
- \`rc-migration\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #4226