### PR TITLE
feat(commands): support REINHARDT_SUPERUSER_PASSWORD env var for noninteractive createsuperuser

### DIFF
--- a/crates/reinhardt-commands/CHANGELOG.md
+++ b/crates/reinhardt-commands/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `runserver --no-wasm-rebuild` opts out of the in-process WASM rebuild while keeping server hot-reload, for users who manage the wasm build externally. ([#4128](https://github.com/kent8192/reinhardt-web/issues/4128))
 - `runserver --no-override-wasm` reuses existing WASM artifacts in `dist/` when present/up-to-date, for callers that explicitly opt out of rebuilds (e.g. cargo-make tasks that pre-run `wasm-build-dev`). ([#4205](https://github.com/kent8192/reinhardt-web/issues/4205))
+- `createsuperuser --noinput` now reads the password from the `REINHARDT_SUPERUSER_PASSWORD` environment variable, unblocking automated provisioning flows (CI, devcontainers, agent-driven setup). Combining `--no-password` with the env var is rejected as mutually exclusive, and env-var passwords below 8 characters are rejected with the same length rule the interactive prompt enforces. ([#4233](https://github.com/kent8192/reinhardt-web/issues/4233))
 
 ### Changed
 - `cargo make watch`, `watch-test`, `watch-clippy`, `runserver-watch`, `dev-watch`, and `install-bacon` were removed from the workspace, the project templates, and the bundled examples. The built-in runserver hot-reload supersedes them; users who relied on `bacon` for unrelated workflows can invoke `bacon` directly. ([#4128](https://github.com/kent8192/reinhardt-web/issues/4128))

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -256,7 +256,13 @@ pub enum Commands {
 		postman: bool,
 	},
 
-	/// Create a superuser account
+	/// Create a superuser account.
+	///
+	/// In non-interactive mode (`--noinput`), the password is read from the
+	/// `REINHARDT_SUPERUSER_PASSWORD` environment variable. Use `--no-password`
+	/// to create an account with no password (the account will not be able to
+	/// log in). Setting `--no-password` together with `REINHARDT_SUPERUSER_PASSWORD`
+	/// is rejected as mutually exclusive.
 	#[cfg(feature = "auth")]
 	Createsuperuser {
 		/// Username for the superuser
@@ -267,11 +273,13 @@ pub enum Commands {
 		#[arg(long, value_name = "EMAIL")]
 		email: Option<String>,
 
-		/// Skip the password prompt (use with caution)
+		/// Skip the password prompt and create an account with no password
+		/// (cannot log in; mutually exclusive with REINHARDT_SUPERUSER_PASSWORD)
 		#[arg(long)]
 		no_password: bool,
 
-		/// Non-interactive mode (requires --username and --email)
+		/// Non-interactive mode (requires --username, --email, and either
+		/// REINHARDT_SUPERUSER_PASSWORD or --no-password)
 		#[arg(long)]
 		noinput: bool,
 

--- a/crates/reinhardt-commands/src/createsuperuser.rs
+++ b/crates/reinhardt-commands/src/createsuperuser.rs
@@ -8,12 +8,76 @@
 use console::style;
 use dialoguer::{Confirm, Input, Password};
 
+/// Environment variable that supplies the superuser password under `--noinput`.
+pub(crate) const SUPERUSER_PASSWORD_ENV: &str = "REINHARDT_SUPERUSER_PASSWORD";
+
+/// Minimum password length, mirrored from the interactive prompt validator.
+const MIN_PASSWORD_LEN: usize = 8;
+
 fn validate_email(email: &str) -> bool {
 	email.contains('@') && email.contains('.')
 }
 
 fn validate_username(username: &str) -> bool {
 	!username.is_empty() && username.len() >= 3
+}
+
+/// Errors that can occur when resolving a password from CLI flags + env vars.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PasswordResolutionError {
+	/// `--no-password` was combined with a non-empty `REINHARDT_SUPERUSER_PASSWORD`.
+	MutuallyExclusive,
+	/// `--noinput` was passed but no password source was provided.
+	MissingEnvVar,
+	/// The env-var password is shorter than [`MIN_PASSWORD_LEN`].
+	TooShort,
+}
+
+impl std::fmt::Display for PasswordResolutionError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::MutuallyExclusive => write!(
+				f,
+				"--no-password and {SUPERUSER_PASSWORD_ENV} are mutually exclusive"
+			),
+			Self::MissingEnvVar => write!(
+				f,
+				"--noinput requires the {SUPERUSER_PASSWORD_ENV} env var (or use --no-password)"
+			),
+			Self::TooShort => write!(
+				f,
+				"{SUPERUSER_PASSWORD_ENV} must be at least {MIN_PASSWORD_LEN} characters"
+			),
+		}
+	}
+}
+
+/// Outcome of [`resolve_noninteractive_password`].
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum NoninteractivePassword {
+	/// Use this password. Already passed length validation.
+	Use(String),
+	/// Create the account without a password (`--no-password` path).
+	None,
+}
+
+/// Resolve the password to use under `--noinput` or `--no-password`.
+///
+/// Empty env-var strings are treated as unset to avoid surprising the caller
+/// when the var is exported but blank in shell config.
+pub(crate) fn resolve_noninteractive_password(
+	no_password: bool,
+	env_password: Option<&str>,
+) -> Result<NoninteractivePassword, PasswordResolutionError> {
+	let env_pw = env_password.filter(|s| !s.is_empty());
+
+	match (no_password, env_pw) {
+		(true, Some(_)) => Err(PasswordResolutionError::MutuallyExclusive),
+		(true, None) => Ok(NoninteractivePassword::None),
+		(false, Some(pw)) if pw.len() < MIN_PASSWORD_LEN => Err(PasswordResolutionError::TooShort),
+		(false, Some(pw)) => Ok(NoninteractivePassword::Use(pw.to_string())),
+		(false, None) => Err(PasswordResolutionError::MissingEnvVar),
+	}
 }
 
 /// Execute the `createsuperuser` management command.
@@ -86,25 +150,32 @@ pub(crate) async fn execute_createsuperuser(
 			.interact_text()?
 	};
 
-	// Get password
-	let password = if no_password {
-		println!(
-			"{}",
-			style("Warning: Superuser created without password").yellow()
-		);
-		None
-	} else if noinput {
-		eprintln!(
-			"{}",
-			style("Error: Cannot set password in non-interactive mode without --no-password").red()
-		);
-		std::process::exit(1);
+	// Get password.
+	//
+	// Under `--noinput` or `--no-password`, defer to the pure
+	// `resolve_noninteractive_password` helper so the policy is unit-testable.
+	let password = if no_password || noinput {
+		let env_pw = std::env::var(SUPERUSER_PASSWORD_ENV).ok();
+		match resolve_noninteractive_password(no_password, env_pw.as_deref()) {
+			Ok(NoninteractivePassword::Use(pw)) => Some(pw),
+			Ok(NoninteractivePassword::None) => {
+				println!(
+					"{}",
+					style("Warning: Superuser created without password").yellow()
+				);
+				None
+			}
+			Err(e) => {
+				eprintln!("{}", style(format!("Error: {e}")).red());
+				std::process::exit(1);
+			}
+		}
 	} else {
 		let password = Password::new()
 			.with_prompt("Password")
 			.with_confirmation("Password (again)", "Error: Passwords do not match")
 			.validate_with(|input: &String| -> Result<(), &str> {
-				if input.len() >= 8 {
+				if input.len() >= MIN_PASSWORD_LEN {
 					Ok(())
 				} else {
 					Err("Password must be at least 8 characters")
@@ -184,4 +255,142 @@ pub(crate) async fn execute_createsuperuser(
 	}
 
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{
+		NoninteractivePassword, PasswordResolutionError, SUPERUSER_PASSWORD_ENV,
+		resolve_noninteractive_password,
+	};
+	use rstest::rstest;
+
+	#[rstest]
+	fn returns_password_when_env_var_meets_length_requirement() {
+		// Arrange
+		let env = Some("correcthorsebattery");
+
+		// Act
+		let result = resolve_noninteractive_password(false, env);
+
+		// Assert
+		assert_eq!(
+			result,
+			Ok(NoninteractivePassword::Use(
+				"correcthorsebattery".to_string()
+			))
+		);
+	}
+
+	#[rstest]
+	#[case::seven_chars("1234567")]
+	#[case::single_char("a")]
+	#[case::empty_after_filter("ab")]
+	fn rejects_env_var_password_below_minimum_length(#[case] password: &str) {
+		// Arrange
+		let env = Some(password);
+
+		// Act
+		let result = resolve_noninteractive_password(false, env);
+
+		// Assert
+		assert_eq!(result, Err(PasswordResolutionError::TooShort));
+	}
+
+	#[rstest]
+	fn missing_env_var_under_noinput_is_rejected() {
+		// Arrange
+		let env: Option<&str> = None;
+
+		// Act
+		let result = resolve_noninteractive_password(false, env);
+
+		// Assert
+		assert_eq!(result, Err(PasswordResolutionError::MissingEnvVar));
+	}
+
+	#[rstest]
+	fn empty_env_var_is_treated_as_unset() {
+		// Arrange — exported but blank shells behave like "not set" to avoid surprise.
+		let env = Some("");
+
+		// Act
+		let result = resolve_noninteractive_password(false, env);
+
+		// Assert
+		assert_eq!(result, Err(PasswordResolutionError::MissingEnvVar));
+	}
+
+	#[rstest]
+	fn no_password_without_env_var_returns_none_variant() {
+		// Arrange
+		let env: Option<&str> = None;
+
+		// Act
+		let result = resolve_noninteractive_password(true, env);
+
+		// Assert
+		assert_eq!(result, Ok(NoninteractivePassword::None));
+	}
+
+	#[rstest]
+	fn no_password_combined_with_env_var_is_rejected_as_mutually_exclusive() {
+		// Arrange
+		let env = Some("correcthorsebattery");
+
+		// Act
+		let result = resolve_noninteractive_password(true, env);
+
+		// Assert
+		assert_eq!(result, Err(PasswordResolutionError::MutuallyExclusive));
+	}
+
+	#[rstest]
+	fn no_password_with_empty_env_var_returns_none() {
+		// Arrange — empty env var is treated as unset, so no conflict.
+		let env = Some("");
+
+		// Act
+		let result = resolve_noninteractive_password(true, env);
+
+		// Assert
+		assert_eq!(result, Ok(NoninteractivePassword::None));
+	}
+
+	#[rstest]
+	fn error_messages_name_the_env_var_for_operator_clarity() {
+		// Arrange — operators copy-paste error text into chat / runbooks; the
+		// env-var name must appear so the fix is self-evident.
+
+		// Act + Assert
+		let mutex = PasswordResolutionError::MutuallyExclusive.to_string();
+		assert!(
+			mutex.contains(SUPERUSER_PASSWORD_ENV),
+			"MutuallyExclusive must mention {SUPERUSER_PASSWORD_ENV}, got: {mutex}"
+		);
+		assert!(
+			mutex.contains("--no-password"),
+			"MutuallyExclusive must mention --no-password, got: {mutex}"
+		);
+
+		let missing = PasswordResolutionError::MissingEnvVar.to_string();
+		assert!(
+			missing.contains(SUPERUSER_PASSWORD_ENV),
+			"MissingEnvVar must mention {SUPERUSER_PASSWORD_ENV}, got: {missing}"
+		);
+		assert!(
+			missing.contains("--no-password"),
+			"MissingEnvVar must mention --no-password as the escape hatch, got: {missing}"
+		);
+
+		let too_short = PasswordResolutionError::TooShort.to_string();
+		assert!(
+			too_short.contains(SUPERUSER_PASSWORD_ENV),
+			"TooShort must mention {SUPERUSER_PASSWORD_ENV}, got: {too_short}"
+		);
+		assert!(
+			too_short.contains('8'),
+			"TooShort must mention the 8-char minimum, got: {too_short}"
+		);
+	}
 }

--- a/crates/reinhardt-commands/src/createsuperuser.rs
+++ b/crates/reinhardt-commands/src/createsuperuser.rs
@@ -260,7 +260,7 @@ pub(crate) async fn execute_createsuperuser(
 #[cfg(test)]
 mod tests {
 	use super::{
-		NoninteractivePassword, PasswordResolutionError, SUPERUSER_PASSWORD_ENV,
+		MIN_PASSWORD_LEN, NoninteractivePassword, PasswordResolutionError, SUPERUSER_PASSWORD_ENV,
 		resolve_noninteractive_password,
 	};
 	use rstest::rstest;
@@ -285,7 +285,7 @@ mod tests {
 	#[rstest]
 	#[case::seven_chars("1234567")]
 	#[case::single_char("a")]
-	#[case::empty_after_filter("ab")]
+	#[case::two_chars("ab")]
 	fn rejects_env_var_password_below_minimum_length(#[case] password: &str) {
 		// Arrange
 		let env = Some(password);
@@ -388,9 +388,10 @@ mod tests {
 			too_short.contains(SUPERUSER_PASSWORD_ENV),
 			"TooShort must mention {SUPERUSER_PASSWORD_ENV}, got: {too_short}"
 		);
+		let min_len = MIN_PASSWORD_LEN.to_string();
 		assert!(
-			too_short.contains('8'),
-			"TooShort must mention the 8-char minimum, got: {too_short}"
+			too_short.contains(&min_len),
+			"TooShort must mention the {MIN_PASSWORD_LEN}-char minimum, got: {too_short}"
 		);
 	}
 }


### PR DESCRIPTION
## Summary

- `manage createsuperuser --noinput` now reads the password from the `REINHARDT_SUPERUSER_PASSWORD` environment variable, unblocking automated provisioning flows (CI, devcontainers, LLM-agent E2E setup, ephemeral preview envs) that were previously forced to either drop a TTY into the container or create accounts that cannot log in.
- Combining `--no-password` with `REINHARDT_SUPERUSER_PASSWORD` is rejected as mutually exclusive — the resulting account state would otherwise be ambiguous (login or no-login?).
- Env-var passwords below 8 characters are rejected with the same length rule the interactive prompt enforces, so weak credentials cannot slip in through CI.
- The non-interactive resolution is extracted into a pure helper (`resolve_noninteractive_password`) with rstest-driven unit tests covering the success path, length rejection, missing env var, empty-string-as-unset semantics, and the mutual-exclusion error.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Resolves #4233. Discovered while setting up the devcontainer for the `reinhardt-wasm-e2e` test skill — the cross-repo tracker is kent8192/reinhardt-cloud#583, which can be closed once this lands.

Before this change the only escape hatches were `--no-password` (creates an account that cannot log in) or seeding the user via raw SQL (loses `set_password` hashing semantics). Neither scales to the CI / devcontainer / agent flows the project needs.

## Behavior

When `--noinput` is set:

| `REINHARDT_SUPERUSER_PASSWORD` | `--no-password` | Result |
|---|---|---|
| set, len ≥ 8 | false | Use env var, hash via `BaseUser::set_password` |
| set, len < 8 | false | Error: "must be at least 8 characters" |
| unset / empty | false | Error: "--noinput requires REINHARDT_SUPERUSER_PASSWORD env var (or use --no-password)" |
| set | true | Error: "--no-password and REINHARDT_SUPERUSER_PASSWORD are mutually exclusive" |
| unset / empty | true | Existing behavior — no-password account |

Interactive mode (no `--noinput`) is unchanged — the env var is ignored, prompts are always shown.

## Scope decisions

- Framework-prefixed env var only (`REINHARDT_SUPERUSER_PASSWORD`); `DJANGO_SUPERUSER_PASSWORD` is intentionally not aliased — Reinhardt is its own framework.
- No `--password` / `--password-stdin` flags in this PR. The env-var path covers the headless use cases requested in the issue; flag-based password injection has security trade-offs (shell history, `ps`) that warrant a separate discussion.

## How Was This Tested

- [x] `cargo check -p reinhardt-commands --features auth` (clean — only pre-existing warnings)
- [x] `cargo nextest run -p reinhardt-commands --lib createsuperuser::` — 10/10 pass
- [x] `cargo fmt --check -p reinhardt-commands` — clean
- [x] `cargo clippy -p reinhardt-commands --features auth --tests --no-deps -- -D warnings` — clean for changed files (pre-existing `cmp_owned` lints in `template_source/merged.rs` exist on `main` too and are out of scope for this PR)
- [x] No new `todo!()` / `// TODO` / `// FIXME` introduced

Test cases (all rstest-driven, in `crates/reinhardt-commands/src/createsuperuser.rs::tests`):

1. `returns_password_when_env_var_meets_length_requirement`
2. `rejects_env_var_password_below_minimum_length` (3 cases: 7 chars / 1 char / 2 chars)
3. `missing_env_var_under_noinput_is_rejected`
4. `empty_env_var_is_treated_as_unset`
5. `no_password_without_env_var_returns_none_variant`
6. `no_password_combined_with_env_var_is_rejected_as_mutually_exclusive`
7. `no_password_with_empty_env_var_returns_none`
8. `error_messages_name_the_env_var_for_operator_clarity` (verifies error strings name `REINHARDT_SUPERUSER_PASSWORD`, `--no-password`, and the `8`-char minimum, so operators can self-diagnose from a copy-pasted error)

## Checklist

- [x] Code follows the project's style guidelines (tab indent, English comments)
- [x] Self-review completed
- [x] CHANGELOG entry added under `[Unreleased] / Added`
- [x] No relative paths beyond `../`
- [x] No `.bak` / `.old` / temp files left behind
- [x] Branch name follows `<type>/issue-<N>-<desc>` policy

## Labels to Apply

- `enhancement`

## Related

- Fixes #4233
- Cross-repo tracker (closeable once this lands): kent8192/reinhardt-cloud#583

🤖 Generated with [Claude Code](https://claude.com/claude-code)