### PR TITLE
fix(db,commands): opt DATABASE_URL settings loader explicitly in to TOML interpolation

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -2556,12 +2556,21 @@ fn get_database_url_from_settings() -> Result<String, crate::CommandError> {
 			reinhardt_conf::settings::sources::LowPriorityEnvSource::new()
 				.with_prefix("REINHARDT_"),
 		)
-		.add_source(reinhardt_conf::settings::sources::TomlFileSource::new(
-			settings_dir.join("base.toml"),
-		))
-		.add_source(reinhardt_conf::settings::sources::TomlFileSource::new(
-			settings_dir.join(format!("{}.toml", profile_str)),
-		))
+		// Explicitly opt in to ${VAR:-default} interpolation so the
+		// validation comparison sees the same expanded host that the ORM
+		// init path uses; otherwise a literal `${...}` host would be
+		// compared against an env-derived URL and produce a false
+		// "DATABASE_URL mismatch" warning (issue #4235).
+		.add_source(
+			reinhardt_conf::settings::sources::TomlFileSource::new(settings_dir.join("base.toml"))
+				.with_interpolation(),
+		)
+		.add_source(
+			reinhardt_conf::settings::sources::TomlFileSource::new(
+				settings_dir.join(format!("{}.toml", profile_str)),
+			)
+			.with_interpolation(),
+		)
 		.build()
 		.map_err(|e| {
 			crate::CommandError::ExecutionError(format!("Failed to load settings: {}", e))

--- a/crates/reinhardt-conf/tests/interpolation.rs
+++ b/crates/reinhardt-conf/tests/interpolation.rs
@@ -337,8 +337,7 @@ fn nested_db_config_falls_back_to_default_when_var_unset() {
 		.unwrap();
 	let db_value = merged.get_raw("database").expect("database key present");
 	let db_config: reinhardt_conf::settings::DatabaseConfig =
-		serde_json::from_value(db_value.clone())
-			.expect("deserializes into DatabaseConfig");
+		serde_json::from_value(db_value.clone()).expect("deserializes into DatabaseConfig");
 	let url = db_config.to_url();
 
 	// Assert

--- a/crates/reinhardt-conf/tests/interpolation.rs
+++ b/crates/reinhardt-conf/tests/interpolation.rs
@@ -293,17 +293,25 @@ fn nested_db_config_through_settings_builder_resolves_db_host() {
 		serde_json::from_value(db_value.clone())
 			.expect("database deserializes into DatabaseConfig");
 	let url = db_config.to_url();
+	let parsed = url::Url::parse(&url).expect("DATABASE_URL is a valid URL");
 
 	// Assert — `${IT_DB_HOST_E2E:-localhost}` is fully resolved before
 	// reaching DATABASE_URL. The env value (`postgres`) wins over the
-	// `:-localhost` fallback.
+	// `:-localhost` fallback. Compare against parsed URL fields to avoid
+	// coupling to formatting (percent-encoding, optional userinfo, etc.).
 	assert!(
 		!url.contains("${"),
 		"DATABASE_URL still contains a literal interpolation token: {url}",
 	);
-	assert!(
-		url.contains("@postgres:5432/"),
-		"DATABASE_URL host segment is not the env-resolved value: {url}",
+	assert_eq!(
+		parsed.host_str(),
+		Some("postgres"),
+		"DATABASE_URL host is not the env-resolved value: {url}",
+	);
+	assert_eq!(
+		parsed.port(),
+		Some(5432),
+		"DATABASE_URL port is not the configured value: {url}",
 	);
 }
 
@@ -339,14 +347,23 @@ fn nested_db_config_falls_back_to_default_when_var_unset() {
 	let db_config: reinhardt_conf::settings::DatabaseConfig =
 		serde_json::from_value(db_value.clone()).expect("deserializes into DatabaseConfig");
 	let url = db_config.to_url();
+	let parsed = url::Url::parse(&url).expect("DATABASE_URL is a valid URL");
 
-	// Assert
+	// Assert — compare against parsed URL fields rather than substrings so
+	// the test stays robust against formatting differences (percent-encoded
+	// userinfo, optional trailing slash, etc.).
 	assert!(
 		!url.contains("${"),
 		"DATABASE_URL still contains a literal interpolation token: {url}",
 	);
-	assert!(
-		url.contains("@fallback-host:5432/"),
+	assert_eq!(
+		parsed.host_str(),
+		Some("fallback-host"),
 		"DATABASE_URL host did not resolve to `:-default` fallback: {url}",
+	);
+	assert_eq!(
+		parsed.port(),
+		Some(5432),
+		"DATABASE_URL port is not the configured value: {url}",
 	);
 }

--- a/crates/reinhardt-conf/tests/interpolation.rs
+++ b/crates/reinhardt-conf/tests/interpolation.rs
@@ -250,3 +250,104 @@ fn nested_table_interpolation_resolves_keys() {
 	assert_eq!(db["port"], serde_json::json!("5433"));
 	assert_eq!(db["engine"], serde_json::json!("postgresql"));
 }
+
+// Regression coverage for issue #4235: end-to-end pipeline
+// `[database].host = "${VAR:-default}"` → SettingsBuilder merge
+// → DatabaseConfig deserialize → DatabaseConfig::to_url(). The
+// pre-existing `nested_table_interpolation_resolves_keys` covers
+// only the TomlFileSource::load() return value, but the actual
+// `manage migrate` path goes through SettingsBuilder.build() and
+// then constructs the DATABASE_URL from a typed DatabaseConfig.
+// A regression here would let a literal `${...}` reach DATABASE_URL
+// and trip the URL parser with a misleading "invalid port number".
+
+#[rstest]
+#[serial(env)]
+fn nested_db_config_through_settings_builder_resolves_db_host() {
+	// Arrange — env override takes effect; literal `${...}` must not
+	// reach the constructed DATABASE_URL.
+	let _guard = EnvGuard(vec!["IT_DB_HOST_E2E"]);
+	// SAFETY: serial-protected.
+	unsafe { env::set_var("IT_DB_HOST_E2E", "postgres") };
+	let (_dir, path) = write_toml_file(
+		r#"
+		[database]
+		engine = "postgresql"
+		name = "appdb"
+		user = "app"
+		password = "secret"
+		host = "${IT_DB_HOST_E2E:-localhost}"
+		port = 5432
+		"#,
+	);
+
+	// Act
+	let merged = SettingsBuilder::new()
+		.add_source(TomlFileSource::new(&path).with_interpolation())
+		.build()
+		.unwrap();
+	let db_value = merged
+		.get_raw("database")
+		.expect("database key present after merge");
+	let db_config: reinhardt_conf::settings::DatabaseConfig =
+		serde_json::from_value(db_value.clone())
+			.expect("database deserializes into DatabaseConfig");
+	let url = db_config.to_url();
+
+	// Assert — `${IT_DB_HOST_E2E:-localhost}` is fully resolved before
+	// reaching DATABASE_URL. The env value (`postgres`) wins over the
+	// `:-localhost` fallback.
+	assert!(
+		!url.contains("${"),
+		"DATABASE_URL still contains a literal interpolation token: {url}",
+	);
+	assert!(
+		url.contains("@postgres:5432/"),
+		"DATABASE_URL host segment is not the env-resolved value: {url}",
+	);
+}
+
+#[rstest]
+#[serial(env)]
+fn nested_db_config_falls_back_to_default_when_var_unset() {
+	// Companion to the env-set case: with the variable cleared, the
+	// `:-fallback` default must reach the URL — confirming that the
+	// fallback branch is never bypassed by the SettingsBuilder merge.
+
+	// Arrange
+	let _guard = EnvGuard(vec!["IT_DB_HOST_E2E_UNSET"]);
+	// SAFETY: serial-protected.
+	unsafe { env::remove_var("IT_DB_HOST_E2E_UNSET") };
+	let (_dir, path) = write_toml_file(
+		r#"
+		[database]
+		engine = "postgresql"
+		name = "appdb"
+		user = "app"
+		password = "secret"
+		host = "${IT_DB_HOST_E2E_UNSET:-fallback-host}"
+		port = 5432
+		"#,
+	);
+
+	// Act
+	let merged = SettingsBuilder::new()
+		.add_source(TomlFileSource::new(&path).with_interpolation())
+		.build()
+		.unwrap();
+	let db_value = merged.get_raw("database").expect("database key present");
+	let db_config: reinhardt_conf::settings::DatabaseConfig =
+		serde_json::from_value(db_value.clone())
+			.expect("deserializes into DatabaseConfig");
+	let url = db_config.to_url();
+
+	// Assert
+	assert!(
+		!url.contains("${"),
+		"DATABASE_URL still contains a literal interpolation token: {url}",
+	);
+	assert!(
+		url.contains("@fallback-host:5432/"),
+		"DATABASE_URL host did not resolve to `:-default` fallback: {url}",
+	);
+}

--- a/crates/reinhardt-db/src/backends/connection.rs
+++ b/crates/reinhardt-db/src/backends/connection.rs
@@ -513,12 +513,22 @@ impl DatabaseConnection {
 				reinhardt_conf::settings::sources::LowPriorityEnvSource::new()
 					.with_prefix("REINHARDT_"),
 			)
-			.add_source(reinhardt_conf::settings::sources::TomlFileSource::new(
-				settings_dir.join("base.toml"),
-			))
-			.add_source(reinhardt_conf::settings::sources::TomlFileSource::new(
-				settings_dir.join(format!("{}.toml", profile_str)),
-			))
+			// Explicitly opt in to ${VAR:-default} interpolation so that
+			// `[database].host = "${RC_DB_HOST:-localhost}"` style entries
+			// expand at load time. This avoids relying on the
+			// `TomlFileSource::new()` default, which is currently `true`
+			// but may flip again or be overridden by future builder changes
+			// (issue #4235).
+			.add_source(
+				reinhardt_conf::settings::sources::TomlFileSource::new(settings_dir.join("base.toml"))
+					.with_interpolation(),
+			)
+			.add_source(
+				reinhardt_conf::settings::sources::TomlFileSource::new(
+					settings_dir.join(format!("{}.toml", profile_str)),
+				)
+				.with_interpolation(),
+			)
 			.build()
 			.map_err(|e| {
 				super::error::DatabaseError::ConnectionError(format!(


### PR DESCRIPTION
## Summary

- Make both DATABASE_URL settings paths (`reinhardt-db::DatabaseConnection::get_database_url_from_env_or_settings` and the `runserver` mismatch-check helper in `reinhardt-commands`) call `.with_interpolation()` explicitly on every `TomlFileSource`, so `${VAR:-default}` expansion in `[database].host` no longer depends on the implicit `TomlFileSource::new()` default.
- Add two end-to-end regression tests in `reinhardt-conf` that exercise the full `SettingsBuilder.build()` → `merged.get_raw("database")` → `DatabaseConfig::to_url()` pipeline — the path the existing `nested_table_interpolation_resolves_keys` test does not cover.

## Type of Change

- Bug fix (non-breaking)

## Motivation and Context

Issue #4235 reports that a `[database].host = "${RC_DB_HOST:-localhost}"` entry can leak the literal `${...}` into the constructed `DATABASE_URL` and trip the URL parser with the misleading message ``Failed to initialize ORM database: Configuration error: invalid port number``. Tracing the call site shows the database settings loaders create `TomlFileSource` instances without an explicit `.with_interpolation()` call, so they ride the current `true` default introduced in `d48bfd232`. A future default flip-back, a `without_interpolation()` chained earlier in a builder, or an upstream refactor in `reinhardt-conf` could silently re-introduce the original symptom. Encoding the intent at the call site makes the loader robust against those changes and clarifies behavior for anyone reading the helper.

## How Was This Tested

- `cargo nextest run -p reinhardt-conf -- nested_db_config_through_settings_builder_resolves_db_host`
- `cargo nextest run -p reinhardt-conf -- nested_db_config_falls_back_to_default_when_var_unset`
- Workspace-wide: `cargo make fmt-check`, `cargo make clippy-check`

## Checklist

- [x] Code follows project style guidelines (`cargo make fmt-check`)
- [x] No new clippy warnings introduced (`cargo make clippy-check`)
- [x] All existing tests pass (`cargo nextest run`)
- [x] New regression tests added in `crates/reinhardt-conf/tests/interpolation.rs`
- [x] No new `todo!()` / `// TODO:` introduced
- [x] PR description follows `.github/PULL_REQUEST_TEMPLATE.md`

## Labels to Apply

- `bug`

## Related Issues

Fixes #4235

🤖 Generated with [Claude Code](https://claude.com/claude-code)