### PR TITLE
chore(commands): add autoreload spawn diagnostics for #4236

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1863,7 +1863,7 @@ impl RunServerCommand {
 			eprintln!(
 				"[autoreload-debug] bin_name={} {}",
 				bin_name,
-				Self::spawn_diagnostics(&current_exe_for_bin),
+				Self::spawn_diagnostics(&current_exe_for_bin, true),
 			);
 		}
 
@@ -1956,7 +1956,7 @@ impl RunServerCommand {
 	/// `(deleted)` suffix when cargo replaced the binary's inode while the
 	/// parent was already running.
 	#[cfg(all(feature = "server", feature = "autoreload"))]
-	fn spawn_diagnostics(exe: &std::path::Path) -> String {
+	fn spawn_diagnostics(exe: &std::path::Path, debug: bool) -> String {
 		let mut parts: Vec<String> = Vec::with_capacity(12);
 		parts.push(format!("exe={}", exe.display()));
 		parts.push(format!("exists={}", exe.exists()));
@@ -1987,8 +1987,12 @@ impl RunServerCommand {
 		{
 			match std::fs::read_link("/proc/self/exe") {
 				Ok(p) => {
+					// Linux marks a path read from /proc/self/exe whose backing
+					// inode was unlinked with the literal " (deleted)" suffix.
+					// Match the suffix exactly so paths that legitimately
+					// contain "(deleted)" elsewhere don't trip the flag.
 					let s = p.to_string_lossy();
-					let deleted_suffix = s.contains("(deleted)");
+					let deleted_suffix = s.ends_with(" (deleted)");
 					parts.push(format!(
 						"proc_self_exe={} deleted_suffix={}",
 						p.display(),
@@ -2000,14 +2004,28 @@ impl RunServerCommand {
 		}
 
 		parts.push(format!("pid={}", std::process::id()));
-		parts.push(format!(
-			"CARGO_TARGET_DIR={:?}",
-			std::env::var_os("CARGO_TARGET_DIR")
-		));
-		parts.push(format!(
-			"RUSTC_WRAPPER={:?}",
-			std::env::var_os("RUSTC_WRAPPER")
-		));
+		// Env var values can leak local toolchain/filesystem layout into
+		// always-on logs. Emit only presence in non-debug mode and full
+		// values when the user explicitly opted into debug output.
+		if debug {
+			parts.push(format!(
+				"CARGO_TARGET_DIR={:?}",
+				std::env::var_os("CARGO_TARGET_DIR")
+			));
+			parts.push(format!(
+				"RUSTC_WRAPPER={:?}",
+				std::env::var_os("RUSTC_WRAPPER")
+			));
+		} else {
+			parts.push(format!(
+				"CARGO_TARGET_DIR_set={}",
+				std::env::var_os("CARGO_TARGET_DIR").is_some()
+			));
+			parts.push(format!(
+				"RUSTC_WRAPPER_set={}",
+				std::env::var_os("RUSTC_WRAPPER").is_some()
+			));
+		}
 		parts.push(format!(
 			"REINHARDT_IS_AUTORELOAD_CHILD={:?}",
 			std::env::var_os("REINHARDT_IS_AUTORELOAD_CHILD")
@@ -2021,10 +2039,13 @@ impl RunServerCommand {
 	/// quiet; on for issue #4236 root-cause diagnosis.
 	#[cfg(all(feature = "server", feature = "autoreload"))]
 	fn autoreload_debug_enabled() -> bool {
-		matches!(
-			std::env::var("REINHARDT_AUTORELOAD_DEBUG").ok().as_deref(),
-			Some("1") | Some("true") | Some("TRUE")
-		)
+		match std::env::var("REINHARDT_AUTORELOAD_DEBUG") {
+			Ok(v) => {
+				let v = v.trim();
+				v == "1" || v.eq_ignore_ascii_case("true")
+			}
+			Err(_) => false,
+		}
 	}
 
 	/// Spawn server in child process
@@ -2042,12 +2063,22 @@ impl RunServerCommand {
 			crate::CommandError::ExecutionError(format!("Failed to get current executable: {}", e))
 		})?;
 
-		// Snapshot diagnostics BEFORE the spawn syscall so the error path can
-		// quote the same state the kernel saw. See issue #4236.
-		let diag = Self::spawn_diagnostics(&current_exe);
-		if Self::autoreload_debug_enabled() {
-			eprintln!("[autoreload-debug] pre-spawn {}", diag);
-		}
+		// Diagnostics policy (issue #4236):
+		// - Debug enabled: snapshot BEFORE the spawn syscall and emit so the
+		//   pre-spawn state is logged even on success.
+		// - Debug disabled: defer the snapshot to the error path to avoid
+		//   per-spawn filesystem cost on the success hot path. The post-spawn
+		//   read is acceptable because the kernel-visible state for an ENOENT
+		//   failure is effectively unchanged in the few microseconds between
+		//   the syscall returning and reading the diagnostics.
+		let debug = Self::autoreload_debug_enabled();
+		let pre_spawn_diag = if debug {
+			let d = Self::spawn_diagnostics(&current_exe, true);
+			eprintln!("[autoreload-debug] pre-spawn {}", d);
+			Some(d)
+		} else {
+			None
+		};
 
 		let mut cmd = tokio::process::Command::new(&current_exe);
 		cmd.arg("runserver").arg(address).arg("--noreload");
@@ -2081,7 +2112,12 @@ impl RunServerCommand {
 		cmd.spawn().map_err(|e| {
 			// Always-on enrichment (#4236): include the resolved path,
 			// `raw_os_error`, error kind, and Linux `/proc/self/exe` state in
-			// the error so the first failure log is actionable.
+			// the error so the first failure log is actionable. Reuse the
+			// pre-spawn snapshot when debug emitted one; otherwise compute it
+			// lazily here so the success path pays no diagnostic cost.
+			let diag = pre_spawn_diag
+				.clone()
+				.unwrap_or_else(|| Self::spawn_diagnostics(&current_exe, false));
 			crate::CommandError::ExecutionError(format!(
 				"Failed to spawn server process: {} (raw_os_error={:?} kind={:?}) [{}]",
 				e,

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1856,6 +1856,17 @@ impl RunServerCommand {
 			.unwrap_or("manage")
 			.to_string();
 
+		// Optional diagnostic snapshot at autoreload startup. See issue #4236.
+		// Gated on `REINHARDT_AUTORELOAD_DEBUG=1` so production runs stay
+		// quiet but the user can capture full state with one env flip.
+		if Self::autoreload_debug_enabled() {
+			eprintln!(
+				"[autoreload-debug] bin_name={} {}",
+				bin_name,
+				Self::spawn_diagnostics(&current_exe_for_bin),
+			);
+		}
+
 		// Startup banner (spec §7).
 		ctx.info("[hot-reload] enabled");
 		ctx.info(&format!(
@@ -1935,6 +1946,87 @@ impl RunServerCommand {
 		Ok(())
 	}
 
+	/// Collect diagnostic state about the candidate spawn target.
+	///
+	/// Used to (a) enrich the always-on spawn error message and (b) emit a
+	/// startup snapshot when `REINHARDT_AUTORELOAD_DEBUG=1`. See issue #4236
+	/// for the failure class this targets: an initial spawn that returns
+	/// `os error 2` (`ENOENT`) for a path `current_exe()` just produced. On
+	/// Linux the most common failure mode is `/proc/self/exe` carrying a
+	/// `(deleted)` suffix when cargo replaced the binary's inode while the
+	/// parent was already running.
+	#[cfg(all(feature = "server", feature = "autoreload"))]
+	fn spawn_diagnostics(exe: &std::path::Path) -> String {
+		let mut parts: Vec<String> = Vec::with_capacity(12);
+		parts.push(format!("exe={}", exe.display()));
+		parts.push(format!("exists={}", exe.exists()));
+
+		match exe.metadata() {
+			Ok(m) => {
+				parts.push(format!("size={}", m.len()));
+				#[cfg(unix)]
+				{
+					use std::os::unix::fs::MetadataExt;
+					parts.push(format!("inode={} nlink={}", m.ino(), m.nlink()));
+				}
+				if let Ok(mt) = m.modified()
+					&& let Ok(d) = mt.duration_since(std::time::UNIX_EPOCH)
+				{
+					parts.push(format!("mtime_unix={}", d.as_secs()));
+				}
+			}
+			Err(e) => parts.push(format!("metadata_err={}", e)),
+		}
+
+		match exe.canonicalize() {
+			Ok(c) => parts.push(format!("canonical={}", c.display())),
+			Err(e) => parts.push(format!("canonical_err={}", e)),
+		}
+
+		#[cfg(target_os = "linux")]
+		{
+			match std::fs::read_link("/proc/self/exe") {
+				Ok(p) => {
+					let s = p.to_string_lossy();
+					let deleted_suffix = s.contains("(deleted)");
+					parts.push(format!(
+						"proc_self_exe={} deleted_suffix={}",
+						p.display(),
+						deleted_suffix
+					));
+				}
+				Err(e) => parts.push(format!("proc_self_exe_err={}", e)),
+			}
+		}
+
+		parts.push(format!("pid={}", std::process::id()));
+		parts.push(format!(
+			"CARGO_TARGET_DIR={:?}",
+			std::env::var_os("CARGO_TARGET_DIR")
+		));
+		parts.push(format!(
+			"RUSTC_WRAPPER={:?}",
+			std::env::var_os("RUSTC_WRAPPER")
+		));
+		parts.push(format!(
+			"REINHARDT_IS_AUTORELOAD_CHILD={:?}",
+			std::env::var_os("REINHARDT_IS_AUTORELOAD_CHILD")
+		));
+
+		parts.join(" ")
+	}
+
+	/// Returns true when the user opted into autoreload debug logging via
+	/// `REINHARDT_AUTORELOAD_DEBUG=1`. Off by default to keep release output
+	/// quiet; on for issue #4236 root-cause diagnosis.
+	#[cfg(all(feature = "server", feature = "autoreload"))]
+	fn autoreload_debug_enabled() -> bool {
+		matches!(
+			std::env::var("REINHARDT_AUTORELOAD_DEBUG").ok().as_deref(),
+			Some("1") | Some("true") | Some("TRUE")
+		)
+	}
+
 	/// Spawn server in child process
 	#[cfg(all(feature = "server", feature = "autoreload"))]
 	fn spawn_server_process(
@@ -1950,7 +2042,14 @@ impl RunServerCommand {
 			crate::CommandError::ExecutionError(format!("Failed to get current executable: {}", e))
 		})?;
 
-		let mut cmd = tokio::process::Command::new(current_exe);
+		// Snapshot diagnostics BEFORE the spawn syscall so the error path can
+		// quote the same state the kernel saw. See issue #4236.
+		let diag = Self::spawn_diagnostics(&current_exe);
+		if Self::autoreload_debug_enabled() {
+			eprintln!("[autoreload-debug] pre-spawn {}", diag);
+		}
+
+		let mut cmd = tokio::process::Command::new(&current_exe);
 		cmd.arg("runserver").arg(address).arg("--noreload");
 
 		if insecure {
@@ -1980,7 +2079,16 @@ impl RunServerCommand {
 		cmd.stderr(std::process::Stdio::inherit());
 
 		cmd.spawn().map_err(|e| {
-			crate::CommandError::ExecutionError(format!("Failed to spawn server process: {}", e))
+			// Always-on enrichment (#4236): include the resolved path,
+			// `raw_os_error`, error kind, and Linux `/proc/self/exe` state in
+			// the error so the first failure log is actionable.
+			crate::CommandError::ExecutionError(format!(
+				"Failed to spawn server process: {} (raw_os_error={:?} kind={:?}) [{}]",
+				e,
+				e.raw_os_error(),
+				e.kind(),
+				diag,
+			))
 		})
 	}
 


### PR DESCRIPTION
## Summary

- Adds opt-in diagnostic instrumentation around the autoreload child-spawn path so `os error 2` (`ENOENT`) failures in the wild become localisable from a single log capture.
- **Always-on**: the spawn-error message now embeds `raw_os_error`, `kind`, the resolved `current_exe`, `exists`, metadata, `canonicalize` result, and on Linux `/proc/self/exe` (with explicit `(deleted)` suffix detection).
- **Opt-in via `REINHARDT_AUTORELOAD_DEBUG=1`**: a startup snapshot of the same fields lands at autoreload entry and again immediately before `Command::spawn` so future investigations can compare parent state against spawn state without recompiling.

## Type of Change

- [x] Diagnostic instrumentation (precursor to a fix; standalone observability value)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

[Issue #4236](https://github.com/kent8192/reinhardt-web/issues/4236) reported that `manage runserver` (default = autoreload on) panics on the *initial* spawn with `os error 2` inside Linux devcontainers, with the issue's stated hypothesis ("use `current_exe()` to resolve the spawn path"). That hypothesis does not match reality — `spawn_server_process` already calls `std::env::current_exe()` at `crates/reinhardt-commands/src/builtin.rs:1949`. A multi-pass investigation refuted every follow-up hypothesis:

| Hypothesis | Status | Evidence |
|-----------|--------|----------|
| `current_exe()` not used | Refuted | already in `builtin.rs:1949` |
| `cargo build --lib --target wasm32-unknown-unknown` re-links host `manage` | Refuted on macOS host | `target/debug/manage` inode/mtime/size unchanged across the wasm build |
| `current_exe()` returns `target/debug/deps/manage-<HASH>` then it gets reaped | Refuted on macOS | `current_exe()` returns canonical `target/debug/manage` |
| `/proc/self/exe` carries a ` (deleted)` suffix on Linux | **Refuted with this PR's diagnostics** | inside the reinhardt-cloud devcontainer, `proc_self_exe=/workspaces/reinhardt-cloud/target/debug/manage deleted_suffix=false exists=true inode=25838 nlink=2` immediately before `cmd.spawn()` |

The bug **does not currently reproduce** on this branch in the reinhardt-cloud devcontainer (Debian 12, kernel 6.19 OrbStack, virtiofs-mounted target/). The diagnostic confirmed the spawn path is healthy: child execs, listens on 0.0.0.0:8000, and only later trips on a separate `Address already in use (os error 98)` issue (filed separately).

This PR therefore lands the diagnostics on their merit — when the original `os error 2` recurs (transient race, different fs layout, different cargo state), the first failure log will already pinpoint which precondition broke instead of forcing another investigation cycle.

## How Was This Tested

- `cargo nextest run -p reinhardt-commands --features=autoreload,server,pages` → **848/848 PASS**.
- `cargo fmt --check` → clean.
- `cargo clippy -p reinhardt-commands --features=autoreload,server,pages -- -D warnings` → clean.
- macOS host simulation (shared `CARGO_TARGET_DIR` and a fresh `/tmp/test-fresh-target`): does not reproduce; instrumentation paths exercised manually with both `REINHARDT_AUTORELOAD_DEBUG=1` and unset.
- **End-to-end inside Linux devcontainer** with the diagnostic build pulled in via a temporary `Cargo.toml` branch-pin: parent and child spawn complete cleanly. Diagnostic output captured below for reference.

### Sample diagnostic capture (devcontainer)

```text
[autoreload-debug] bin_name=manage exe=/workspaces/reinhardt-cloud/target/debug/manage exists=true size=363021864 inode=25838 nlink=2 mtime_unix=1778302112 canonical=/workspaces/reinhardt-cloud/target/debug/manage proc_self_exe=/workspaces/reinhardt-cloud/target/debug/manage deleted_suffix=false pid=15798 CARGO_TARGET_DIR=None RUSTC_WRAPPER=None REINHARDT_IS_AUTORELOAD_CHILD=None
[INFO] [hot-reload] enabled
[autoreload-debug] pre-spawn exe=/workspaces/reinhardt-cloud/target/debug/manage exists=true size=363021864 inode=25838 nlink=2 mtime_unix=1778302112 canonical=/workspaces/reinhardt-cloud/target/debug/manage proc_self_exe=/workspaces/reinhardt-cloud/target/debug/manage deleted_suffix=false pid=15798 ...
```

### How to capture a reproduction log when the bug recurs

```bash
REINHARDT_AUTORELOAD_DEBUG=1 cargo run --bin manage -- runserver \
  --with-pages --insecure --static-dir dist 0.0.0.0:8000
```

If the failure returns, the enriched error line will read:
`Failed to spawn server process: ... (raw_os_error=Some(2) kind=NotFound) [exe=... exists=... proc_self_exe=... deleted_suffix=...]`

`deleted_suffix=true` would directly confirm a `/proc/self/exe`-deletion race; `exists=false` with a clean `proc_self_exe` would indicate the cargo binary moved between resolution and spawn; an unexpected `exe=` would point at an env/PATH issue.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments explain the why (Issue #4236 reference, Linux-specific rationale)
- [x] Tests pass (`cargo nextest run -p reinhardt-commands --features autoreload,server,pages`)
- [x] No new clippy warnings
- [x] PR linked to Issue #4236

## Labels to Apply

- `bug`

## Related Issues

Refs #4236

🤖 Generated with [Claude Code](https://claude.com/claude-code)