### PR TITLE
refactor(macros): share Uuid PK shape detector via pk_shape helper

### DIFF
--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -38,6 +38,7 @@ mod pascal_case;
 mod path_macro;
 mod permission_macro;
 mod permissions;
+mod pk_shape;
 mod query_fields;
 mod receiver;
 mod rel;

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3395,15 +3395,13 @@ fn generate_relationship_metadata(
 	}
 }
 
-/// Check if a type is Uuid or `Option<Uuid>`
+/// Check if a type is Uuid or `Option<Uuid>`.
+///
+/// Thin projection of the shared `crate::pk_shape::pk_uuid_shape`
+/// helper — see issue #4246 for why the underlying detection lives in
+/// one place.
 fn is_uuid_type(ty: &Type) -> bool {
-	let (_, inner_ty) = extract_option_type(ty);
-	if let Type::Path(type_path) = inner_ty
-		&& let Some(last_segment) = type_path.path.segments.last()
-	{
-		return last_segment.ident == "Uuid";
-	}
-	false
+	crate::pk_shape::pk_uuid_shape(ty).0
 }
 
 /// Check if a type is String or `Option<String>`

--- a/crates/reinhardt-core/macros/src/pk_shape.rs
+++ b/crates/reinhardt-core/macros/src/pk_shape.rs
@@ -18,8 +18,10 @@ use syn::Type;
 /// - `is_uuid` is `true` when the (optionally `Option`-wrapped) type
 ///   has a final path segment of `Uuid`. Both bare `Uuid` and
 ///   fully-qualified `uuid::Uuid` resolve to `true`.
-/// - `is_option` is `true` when the outer type's last segment is
-///   `Option`, regardless of the inner type.
+/// - `is_option` is `true` when the type is syntactically `Option<T>`
+///   with a first generic *type* argument (the inner `T` itself is not
+///   inspected for `is_option`; only its presence is required, so e.g.
+///   bare `Option` with no generic arguments resolves to `false`).
 ///
 /// Detection is deliberately last-segment only: the macros never see
 /// the resolved type, so `MyUuid` or `UuidV4` correctly report

--- a/crates/reinhardt-core/macros/src/pk_shape.rs
+++ b/crates/reinhardt-core/macros/src/pk_shape.rs
@@ -1,0 +1,138 @@
+//! Shared `Uuid` / `Option<Uuid>` primary-key shape detection.
+//!
+//! This module is the single source of truth for asking "does this PK
+//! type need the `Uuid::now_v7()` codegen path?". It serves both
+//! `user_attribute` (which decides whether to emit a fresh-UUID PK
+//! setter for `init_superuser`, see issue #4237) and `model_derive`
+//! (which uses `is_uuid_type` while wiring up auto-generated field
+//! defaults). Centralising the detection here prevents the two macros
+//! from drifting when we add support for additional UUID wrappers or
+//! alternative path patterns. See issue #4246.
+
+use syn::Type;
+
+/// Inspect a syntactic type and report whether it is a `Uuid` (or an
+/// `Option<Uuid>`) primary key.
+///
+/// Returns `(is_uuid, is_option)`:
+/// - `is_uuid` is `true` when the (optionally `Option`-wrapped) type
+///   has a final path segment of `Uuid`. Both bare `Uuid` and
+///   fully-qualified `uuid::Uuid` resolve to `true`.
+/// - `is_option` is `true` when the outer type's last segment is
+///   `Option`, regardless of the inner type.
+///
+/// Detection is deliberately last-segment only: the macros never see
+/// the resolved type, so `MyUuid` or `UuidV4` correctly report
+/// `is_uuid = false`.
+pub(crate) fn pk_uuid_shape(ty: &Type) -> (bool, bool) {
+	fn last_segment_is(ty: &Type, name: &str) -> bool {
+		matches!(ty, Type::Path(p) if p.path.segments.last().is_some_and(|s| s.ident == name))
+	}
+	if let Type::Path(type_path) = ty
+		&& let Some(last_segment) = type_path.path.segments.last()
+		&& last_segment.ident == "Option"
+		&& let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
+		&& let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+	{
+		return (last_segment_is(inner, "Uuid"), true);
+	}
+	(last_segment_is(ty, "Uuid"), false)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::pk_uuid_shape;
+	use syn::parse_quote;
+
+	// Regression coverage migrated from `user_attribute.rs` for issue
+	// #4237: the macro decides whether to emit a `Uuid::now_v7()` PK
+	// setter based on `pk_uuid_shape`. Each case below corresponds to a
+	// real-world PK declaration we expect users to write in
+	// `#[user(full = true)] #[model(...)] ...` types.
+
+	#[test]
+	fn pk_uuid_shape_detects_bare_uuid() {
+		// Arrange / Act
+		let ty: syn::Type = parse_quote!(Uuid);
+
+		// Assert — bare `Uuid` is the canonical superuser-PK shape.
+		assert_eq!(pk_uuid_shape(&ty), (true, false));
+	}
+
+	#[test]
+	fn pk_uuid_shape_detects_qualified_uuid_path() {
+		// Arrange / Act
+		let ty: syn::Type = parse_quote!(uuid::Uuid);
+
+		// Assert — fully-qualified path must still resolve, otherwise
+		// users who write `pub id: uuid::Uuid` would silently slip
+		// back into the nil-UUID bug.
+		assert_eq!(pk_uuid_shape(&ty), (true, false));
+	}
+
+	#[test]
+	fn pk_uuid_shape_detects_option_uuid() {
+		// Arrange / Act
+		let ty: syn::Type = parse_quote!(Option<Uuid>);
+
+		// Assert — `Option<Uuid>` is uncommon for a PK but legal; the
+		// macro must wrap the seed value in `Some(now_v7())` to keep
+		// type-checking happy.
+		assert_eq!(pk_uuid_shape(&ty), (true, true));
+	}
+
+	#[test]
+	fn pk_uuid_shape_detects_option_qualified_uuid() {
+		// Arrange / Act
+		let ty: syn::Type = parse_quote!(Option<uuid::Uuid>);
+
+		// Assert — Option around a fully-qualified Uuid still counts.
+		assert_eq!(pk_uuid_shape(&ty), (true, true));
+	}
+
+	#[test]
+	fn pk_uuid_shape_skips_integer_pk() {
+		// Arrange / Act
+		let ty: syn::Type = parse_quote!(i64);
+
+		// Assert — integer PK types must NOT receive the `now_v7()`
+		// assignment; the existing `Self::default()` path is correct
+		// for non-Uuid PKs and the macro must not corrupt that.
+		assert_eq!(pk_uuid_shape(&ty), (false, false));
+	}
+
+	#[test]
+	fn pk_uuid_shape_skips_string_pk() {
+		// Arrange / Act
+		let ty: syn::Type = parse_quote!(String);
+
+		// Assert — string PK (e.g. natural keys) is also untouched.
+		assert_eq!(pk_uuid_shape(&ty), (false, false));
+	}
+
+	#[test]
+	fn pk_uuid_shape_skips_option_non_uuid() {
+		// Arrange / Act
+		let ty: syn::Type = parse_quote!(Option<i64>);
+
+		// Assert — Option of a non-Uuid scalar must report
+		// `is_uuid = false`, so the macro emits no setter.
+		assert_eq!(pk_uuid_shape(&ty), (false, true));
+	}
+
+	#[test]
+	fn pk_uuid_shape_does_not_match_lookalike_named_types() {
+		// Arrange / Act — `MyUuid` shares a substring with `Uuid` but is
+		// a different identifier. The helper compares whole identifiers
+		// (not substrings), so it must not falsely seed a v7 UUID into
+		// an unrelated user-defined PK type.
+		let aliased: syn::Type = parse_quote!(MyUuid);
+		let suffixed: syn::Type = parse_quote!(UuidV4);
+
+		// Assert — neither lookalike resolves to `Uuid`, so the macro
+		// will skip the `now_v7()` setter (and the user's existing
+		// `Default` for the type takes effect, just as before).
+		assert_eq!(pk_uuid_shape(&aliased), (false, false));
+		assert_eq!(pk_uuid_shape(&suffixed), (false, false));
+	}
+}

--- a/crates/reinhardt-core/macros/src/user_attribute.rs
+++ b/crates/reinhardt-core/macros/src/user_attribute.rs
@@ -318,37 +318,6 @@ fn generate_permissions_mixin_impl(
 	})
 }
 
-/// Inspects a primary-key field type and returns `(is_uuid, is_option)`.
-///
-/// `is_uuid` is true only when the (inner, if `Option<...>`) type's last
-/// path segment is `Uuid`. `is_option` is true whenever the outer type is
-/// `Option<T>` — for any inner `T`, not just `Uuid` (e.g. `Option<i64>`
-/// returns `(false, true)`). The two flags are independent: callers must
-/// branch on `is_uuid` first, since `is_option` alone does not imply a
-/// UUID-shaped field.
-///
-/// Mirrors the detection that `model_derive.rs::is_uuid_type` performs
-/// for `#[model]` PKs, kept local to avoid widening the visibility of a
-/// helper that is otherwise only used by the model derive itself. The
-/// `#[model]` derive injects `Uuid::now_v7()` into its generated `new()`
-/// constructor, but `init_superuser` builds the row via `Self::default()`,
-/// where `Uuid::default()` is `Uuid::nil()` — issue #4237. Detecting the
-/// shape here lets us inject the same fresh-UUID assignment.
-fn pk_uuid_shape(ty: &syn::Type) -> (bool, bool) {
-	fn last_segment_is(ty: &syn::Type, name: &str) -> bool {
-		matches!(ty, syn::Type::Path(p) if p.path.segments.last().is_some_and(|s| s.ident == name))
-	}
-	if let syn::Type::Path(type_path) = ty
-		&& let Some(last_segment) = type_path.path.segments.last()
-		&& last_segment.ident == "Option"
-		&& let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
-		&& let Some(syn::GenericArgument::Type(inner)) = args.args.first()
-	{
-		return (last_segment_is(inner, "Uuid"), true);
-	}
-	(last_segment_is(ty, "Uuid"), false)
-}
-
 fn generate_superuser_init_impl(
 	struct_name: &Ident,
 	mapping: &FieldMapping,
@@ -365,7 +334,7 @@ fn generate_superuser_init_impl(
 	let pk_setter = if let (Some(pk_ident), Some(pk_type)) =
 		(mapping.pk_field.as_ref(), mapping.pk_type.as_ref())
 	{
-		match pk_uuid_shape(pk_type) {
+		match crate::pk_shape::pk_uuid_shape(pk_type) {
 			(true, false) => quote! { user.#pk_ident = ::uuid::Uuid::now_v7(); },
 			(true, true) => {
 				quote! { user.#pk_ident = ::core::option::Option::Some(::uuid::Uuid::now_v7()); }
@@ -510,101 +479,4 @@ pub(crate) fn user_attribute_impl(args: TokenStream, mut input: ItemStruct) -> R
 		#auth_identity_impl
 		#superuser_init_impl
 	})
-}
-
-#[cfg(test)]
-mod tests {
-	use super::pk_uuid_shape;
-	use syn::parse_quote;
-
-	// Regression coverage for issue #4237: the macro decides whether to
-	// emit a `Uuid::now_v7()` PK setter based on `pk_uuid_shape`. Each
-	// case below corresponds to a real-world PK declaration we expect
-	// users to write in `#[user(full = true)] #[model(...)] ...` types.
-
-	#[test]
-	fn pk_uuid_shape_detects_bare_uuid() {
-		// Arrange / Act
-		let ty: syn::Type = parse_quote!(Uuid);
-
-		// Assert — bare `Uuid` is the canonical superuser-PK shape.
-		assert_eq!(pk_uuid_shape(&ty), (true, false));
-	}
-
-	#[test]
-	fn pk_uuid_shape_detects_qualified_uuid_path() {
-		// Arrange / Act
-		let ty: syn::Type = parse_quote!(uuid::Uuid);
-
-		// Assert — fully-qualified path must still resolve, otherwise
-		// users who write `pub id: uuid::Uuid` would silently slip
-		// back into the nil-UUID bug.
-		assert_eq!(pk_uuid_shape(&ty), (true, false));
-	}
-
-	#[test]
-	fn pk_uuid_shape_detects_option_uuid() {
-		// Arrange / Act
-		let ty: syn::Type = parse_quote!(Option<Uuid>);
-
-		// Assert — `Option<Uuid>` is uncommon for a PK but legal; the
-		// macro must wrap the seed value in `Some(now_v7())` to keep
-		// type-checking happy.
-		assert_eq!(pk_uuid_shape(&ty), (true, true));
-	}
-
-	#[test]
-	fn pk_uuid_shape_detects_option_qualified_uuid() {
-		// Arrange / Act
-		let ty: syn::Type = parse_quote!(Option<uuid::Uuid>);
-
-		// Assert — Option around a fully-qualified Uuid still counts.
-		assert_eq!(pk_uuid_shape(&ty), (true, true));
-	}
-
-	#[test]
-	fn pk_uuid_shape_skips_integer_pk() {
-		// Arrange / Act
-		let ty: syn::Type = parse_quote!(i64);
-
-		// Assert — integer PK types must NOT receive the `now_v7()`
-		// assignment; the existing `Self::default()` path is correct
-		// for non-Uuid PKs and the macro must not corrupt that.
-		assert_eq!(pk_uuid_shape(&ty), (false, false));
-	}
-
-	#[test]
-	fn pk_uuid_shape_skips_string_pk() {
-		// Arrange / Act
-		let ty: syn::Type = parse_quote!(String);
-
-		// Assert — string PK (e.g. natural keys) is also untouched.
-		assert_eq!(pk_uuid_shape(&ty), (false, false));
-	}
-
-	#[test]
-	fn pk_uuid_shape_skips_option_non_uuid() {
-		// Arrange / Act
-		let ty: syn::Type = parse_quote!(Option<i64>);
-
-		// Assert — Option of a non-Uuid scalar must report
-		// `is_uuid = false`, so the macro emits no setter.
-		assert_eq!(pk_uuid_shape(&ty), (false, true));
-	}
-
-	#[test]
-	fn pk_uuid_shape_does_not_match_lookalike_named_types() {
-		// Arrange / Act — `MyUuid` shares a substring with `Uuid` but is
-		// a different identifier. The helper compares whole identifiers
-		// (not substrings), so it must not falsely seed a v7 UUID into
-		// an unrelated user-defined PK type.
-		let aliased: syn::Type = parse_quote!(MyUuid);
-		let suffixed: syn::Type = parse_quote!(UuidV4);
-
-		// Assert — neither lookalike resolves to `Uuid`, so the macro
-		// will skip the `now_v7()` setter (and the user's existing
-		// `Default` for the type takes effect, just as before).
-		assert_eq!(pk_uuid_shape(&aliased), (false, false));
-		assert_eq!(pk_uuid_shape(&suffixed), (false, false));
-	}
 }


### PR DESCRIPTION
## Summary

- Extract the duplicated Uuid / `Option<Uuid>` primary-key shape detection from `user_attribute::pk_uuid_shape` and `model_derive::is_uuid_type` into a single `pub(crate)` helper at `crates/reinhardt-core/macros/src/pk_shape.rs`.
- Both call sites now route through `crate::pk_shape::pk_uuid_shape(ty)` (a `(is_uuid, is_option)` tuple); `is_uuid_type` becomes a thin `.0` projection.
- The eight regression tests previously living in `user_attribute.rs` (issue #4237 coverage) move alongside the helper without behavioral change.

## Type of Change

- [x] Refactoring (no behavior change)

## Motivation and Context

Tracked from Copilot review feedback on PR #4240. Two parallel implementations of the same syntactic detection risked drifting when adding new UUID wrappers or alternative path patterns; centralising the detection eliminates that risk and exposes the richer `(is_uuid, is_option)` shape to any future call site that needs optionality information.

Fixes #4246

## How Was This Tested

- `cargo nextest run -p reinhardt-macros` — 198/198 pass (includes the 8 migrated regression tests).
- `cargo test --doc -p reinhardt-macros` — clean.
- `cargo clippy -p reinhardt-macros --all-targets -- -D warnings` — clean.
- `cargo check -p reinhardt-core --all-features` — clean (exercises both `#[user]` and `#[model]` derive paths).
- `cargo make fmt-check` — clean (2744 unchanged, 0 errors).

## Checklist

- [x] All tests pass locally
- [x] Code follows project style (Rust 2024 module layout, tab indent, English comments)
- [x] No new TODO / FIXME / `dbg!` macros introduced
- [x] Docs colocated with the helper explain the contract
- [x] No public API change

## Labels to Apply

- `refactoring`
- `enhancement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)