### PR TITLE
test(db,commands): cover DATABASE_URL loaders against interpolation default

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -2675,8 +2675,11 @@ fn get_database_url() -> Result<String, crate::CommandError> {
 ///
 /// Used for startup validation to detect configuration mismatches between
 /// the `DATABASE_URL` environment variable and `settings/*.toml` files.
+///
+/// Visibility is `pub(crate)` so the in-crate regression tests for issue
+/// #4247 can call the real loader without going through a public API.
 #[cfg(feature = "reinhardt-db")]
-fn get_database_url_from_settings() -> Result<String, crate::CommandError> {
+pub(crate) fn get_database_url_from_settings() -> Result<String, crate::CommandError> {
 	use std::env;
 
 	let profile_str = env::var("REINHARDT_ENV").unwrap_or_else(|_| "local".to_string());

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -3785,13 +3785,29 @@ port = 5432
 		use std::path::{Path, PathBuf};
 		use tempfile::TempDir;
 
-		struct EnvGuard(Vec<&'static str>);
+		// Captures each key's value on construction and restores it (or
+		// removes it if previously unset) on drop. This prevents the
+		// guard from leaking state into ambient env vars that existed
+		// before the test ran.
+		struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+		impl EnvGuard {
+			fn new(keys: Vec<&'static str>) -> Self {
+				let captured = keys.into_iter().map(|k| (k, env::var_os(k))).collect();
+				Self(captured)
+			}
+		}
 
 		impl Drop for EnvGuard {
 			fn drop(&mut self) {
-				for key in &self.0 {
+				for (key, prev) in &self.0 {
 					// SAFETY: env mutation in tests is protected by #[serial(env)].
-					unsafe { env::remove_var(key) };
+					unsafe {
+						match prev {
+							Some(value) => env::set_var(key, value),
+							None => env::remove_var(key),
+						}
+					}
 				}
 			}
 		}
@@ -3825,7 +3841,7 @@ port = 5432
 		#[serial(env)]
 		fn loader_expands_env_var_in_host() {
 			// Arrange
-			let _env = EnvGuard(vec!["IT4247C_DB_HOST", "REINHARDT_ENV"]);
+			let _env = EnvGuard::new(vec!["IT4247C_DB_HOST", "REINHARDT_ENV"]);
 			// SAFETY: serial-protected.
 			unsafe {
 				env::set_var("REINHARDT_ENV", "local");
@@ -3866,7 +3882,7 @@ port = 5432
 		fn loader_uses_inline_default_when_var_unset() {
 			// Arrange — declare the var in the guard even though we never set
 			// it, so an ambient value cannot silence the inline `:-fallback`.
-			let _env = EnvGuard(vec!["IT4247C_DB_HOST_OPT", "REINHARDT_ENV"]);
+			let _env = EnvGuard::new(vec!["IT4247C_DB_HOST_OPT", "REINHARDT_ENV"]);
 			// SAFETY: serial-protected.
 			unsafe {
 				env::remove_var("IT4247C_DB_HOST_OPT");

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -3763,4 +3763,143 @@ port = 5432
 
 	// `is_relevant_change` unit tests now live in
 	// `crate::debounced_watcher::tests` after the watcher refactor.
+
+	// End-to-end regression coverage for issue #4247.
+	//
+	// `get_database_url_from_settings` opts into
+	// `TomlFileSource::with_interpolation()` (PR #4239). The interpolation
+	// tests in `reinhardt-conf/tests/interpolation.rs` build a fresh
+	// `TomlFileSource`, so they will keep passing even if a future
+	// refactor accidentally drops the opt-in here. These tests exercise
+	// the real loader so that regression fails loudly.
+	//
+	// The loader reads cwd via `env::current_dir()`. Tests change cwd
+	// under `#[serial(env)]` and restore it via the drop guard.
+	#[cfg(feature = "reinhardt-db")]
+	mod interpolation_4247 {
+		use super::super::get_database_url_from_settings;
+		use rstest::rstest;
+		use serial_test::serial;
+		use std::env;
+		use std::io::Write;
+		use std::path::{Path, PathBuf};
+		use tempfile::TempDir;
+
+		struct EnvGuard(Vec<&'static str>);
+
+		impl Drop for EnvGuard {
+			fn drop(&mut self) {
+				for key in &self.0 {
+					// SAFETY: env mutation in tests is protected by #[serial(env)].
+					unsafe { env::remove_var(key) };
+				}
+			}
+		}
+
+		struct CwdGuard(PathBuf);
+
+		impl Drop for CwdGuard {
+			fn drop(&mut self) {
+				// Best-effort restore; if the original cwd vanished there is
+				// nothing the test process can do, and dropping silently is
+				// preferable to panicking from Drop.
+				let _ = env::set_current_dir(&self.0);
+			}
+		}
+
+		fn write_settings_dir(profile: &str, base_toml: &str) -> TempDir {
+			let temp = TempDir::new().expect("create temp dir");
+			let settings_dir = temp.path().join("settings");
+			std::fs::create_dir_all(&settings_dir).expect("create settings dir");
+			write_file(&settings_dir.join("base.toml"), base_toml);
+			write_file(&settings_dir.join(format!("{profile}.toml")), "");
+			temp
+		}
+
+		fn write_file(path: &Path, contents: &str) {
+			let mut f = std::fs::File::create(path).expect("create file");
+			f.write_all(contents.as_bytes()).expect("write file");
+		}
+
+		#[rstest]
+		#[serial(env)]
+		fn loader_expands_env_var_in_host() {
+			// Arrange
+			let _env = EnvGuard(vec!["IT4247C_DB_HOST", "REINHARDT_ENV"]);
+			// SAFETY: serial-protected.
+			unsafe {
+				env::set_var("REINHARDT_ENV", "local");
+				env::set_var("IT4247C_DB_HOST", "production-db.example.com");
+			}
+			let temp = write_settings_dir(
+				"local",
+				r#"
+[database]
+engine = "postgresql"
+name = "appdb"
+user = "app"
+password = "secret"
+host = "${IT4247C_DB_HOST}"
+port = 5432
+"#,
+			);
+			let original_cwd = env::current_dir().expect("read cwd");
+			let _cwd = CwdGuard(original_cwd);
+			env::set_current_dir(temp.path()).expect("set cwd");
+
+			// Act
+			let url = get_database_url_from_settings().expect("loader returns a URL");
+
+			// Assert
+			assert!(
+				url.contains("production-db.example.com"),
+				"expected expanded host in URL, got: {url}"
+			);
+			assert!(
+				!url.contains("${"),
+				"URL still contains literal interpolation pattern: {url}"
+			);
+		}
+
+		#[rstest]
+		#[serial(env)]
+		fn loader_uses_inline_default_when_var_unset() {
+			// Arrange — declare the var in the guard even though we never set
+			// it, so an ambient value cannot silence the inline `:-fallback`.
+			let _env = EnvGuard(vec!["IT4247C_DB_HOST_OPT", "REINHARDT_ENV"]);
+			// SAFETY: serial-protected.
+			unsafe {
+				env::remove_var("IT4247C_DB_HOST_OPT");
+				env::set_var("REINHARDT_ENV", "local");
+			}
+			let temp = write_settings_dir(
+				"local",
+				r#"
+[database]
+engine = "postgresql"
+name = "appdb"
+user = "app"
+password = "secret"
+host = "${IT4247C_DB_HOST_OPT:-fallback-host}"
+port = 5432
+"#,
+			);
+			let original_cwd = env::current_dir().expect("read cwd");
+			let _cwd = CwdGuard(original_cwd);
+			env::set_current_dir(temp.path()).expect("set cwd");
+
+			// Act
+			let url = get_database_url_from_settings().expect("loader returns a URL");
+
+			// Assert
+			assert!(
+				url.contains("fallback-host"),
+				"expected fallback host in URL, got: {url}"
+			);
+			assert!(
+				!url.contains("${"),
+				"URL still contains literal interpolation pattern: {url}"
+			);
+		}
+	}
 }

--- a/crates/reinhardt-db/tests/database_url_loader_interpolation.rs
+++ b/crates/reinhardt-db/tests/database_url_loader_interpolation.rs
@@ -23,21 +23,36 @@ use std::io::Write;
 use std::path::Path;
 use tempfile::TempDir;
 
-/// Drop-based env-var cleanup. Removes named keys when the guard is
-/// dropped, even on panic.
-struct EnvGuard(Vec<&'static str>);
+/// Drop-based env-var cleanup. Captures each key's value on
+/// construction and restores it (or removes it if previously unset) on
+/// drop, so the guard never leaks state into ambient env vars that
+/// existed before the test ran.
+struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+impl EnvGuard {
+	fn new(keys: Vec<&'static str>) -> Self {
+		let captured = keys.into_iter().map(|k| (k, env::var_os(k))).collect();
+		Self(captured)
+	}
+}
 
 impl Drop for EnvGuard {
 	fn drop(&mut self) {
-		for key in &self.0 {
+		for (key, prev) in &self.0 {
 			// SAFETY: env mutation in tests is protected by #[serial(env)].
-			unsafe { env::remove_var(key) };
+			unsafe {
+				match prev {
+					Some(value) => env::set_var(key, value),
+					None => env::remove_var(key),
+				}
+			}
 		}
 	}
 }
 
 /// Build a `<temp>/settings/{base.toml,<profile>.toml}` tree and return
-/// the temp dir + the base path the loader should be pointed at.
+/// the owned `TempDir`. Callers point the loader at `temp.path()` and
+/// must keep the returned guard alive for the duration of the test.
 fn write_settings_dir(profile: &str, base_toml: &str) -> TempDir {
 	let temp = TempDir::new().expect("create temp dir");
 	let settings_dir = temp.path().join("settings");
@@ -60,7 +75,7 @@ fn write_file(path: &Path, contents: &str) {
 fn loader_expands_env_var_in_host() {
 	// Arrange — DATABASE_URL would short-circuit the settings path, so
 	// list it in the guard alongside the test-specific keys.
-	let _guard = EnvGuard(vec!["IT4247_DB_HOST", "DATABASE_URL", "REINHARDT_ENV"]);
+	let _guard = EnvGuard::new(vec!["IT4247_DB_HOST", "DATABASE_URL", "REINHARDT_ENV"]);
 	// SAFETY: serial-protected.
 	unsafe {
 		env::remove_var("DATABASE_URL");
@@ -103,7 +118,7 @@ fn loader_uses_inline_default_when_var_unset() {
 	// Arrange — declare the var in the guard even though we never set it,
 	// so an ambient value from a prior test cannot leak in and silence
 	// the inline `:-fallback` branch.
-	let _guard = EnvGuard(vec!["IT4247_DB_HOST_OPT", "DATABASE_URL", "REINHARDT_ENV"]);
+	let _guard = EnvGuard::new(vec!["IT4247_DB_HOST_OPT", "DATABASE_URL", "REINHARDT_ENV"]);
 	// SAFETY: serial-protected.
 	unsafe {
 		env::remove_var("DATABASE_URL");

--- a/crates/reinhardt-db/tests/database_url_loader_interpolation.rs
+++ b/crates/reinhardt-db/tests/database_url_loader_interpolation.rs
@@ -1,0 +1,140 @@
+// End-to-end regression coverage for issue #4247.
+//
+// PR #4239 made `DatabaseConnection::get_database_url_from_env_or_settings`
+// opt into `TomlFileSource::with_interpolation()`. The interpolation tests
+// in `reinhardt-conf/tests/interpolation.rs` build a fresh `TomlFileSource`,
+// so they will keep passing even if a future refactor accidentally drops
+// the `.with_interpolation()` call from the real loader. These tests
+// exercise the *real* entry point and assert the `${VAR}` / `${VAR:-default}`
+// patterns expand end-to-end, so that regression fails loudly here.
+//
+// These tests mutate `std::env`, so they MUST run under `#[serial(env)]`.
+// `EnvGuard` ensures cleanup even on panic.
+
+#![cfg(feature = "settings")]
+
+// `reinhardt_db::DatabaseConnection` resolves to the ORM-level wrapper;
+// the loader entry point lives on the lower-level backends type.
+use reinhardt_db::backends::connection::DatabaseConnection;
+use rstest::rstest;
+use serial_test::serial;
+use std::env;
+use std::io::Write;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Drop-based env-var cleanup. Removes named keys when the guard is
+/// dropped, even on panic.
+struct EnvGuard(Vec<&'static str>);
+
+impl Drop for EnvGuard {
+	fn drop(&mut self) {
+		for key in &self.0 {
+			// SAFETY: env mutation in tests is protected by #[serial(env)].
+			unsafe { env::remove_var(key) };
+		}
+	}
+}
+
+/// Build a `<temp>/settings/{base.toml,<profile>.toml}` tree and return
+/// the temp dir + the base path the loader should be pointed at.
+fn write_settings_dir(profile: &str, base_toml: &str) -> TempDir {
+	let temp = TempDir::new().expect("create temp dir");
+	let settings_dir = temp.path().join("settings");
+	std::fs::create_dir_all(&settings_dir).expect("create settings dir");
+
+	write_file(&settings_dir.join("base.toml"), base_toml);
+	// Empty per-profile file keeps the loader's profile source happy
+	// without adding extra noise to the assertion.
+	write_file(&settings_dir.join(format!("{profile}.toml")), "");
+	temp
+}
+
+fn write_file(path: &Path, contents: &str) {
+	let mut f = std::fs::File::create(path).expect("create file");
+	f.write_all(contents.as_bytes()).expect("write file");
+}
+
+#[rstest]
+#[serial(env)]
+fn loader_expands_env_var_in_host() {
+	// Arrange — DATABASE_URL would short-circuit the settings path, so
+	// list it in the guard alongside the test-specific keys.
+	let _guard = EnvGuard(vec!["IT4247_DB_HOST", "DATABASE_URL", "REINHARDT_ENV"]);
+	// SAFETY: serial-protected.
+	unsafe {
+		env::remove_var("DATABASE_URL");
+		env::set_var("REINHARDT_ENV", "local");
+		env::set_var("IT4247_DB_HOST", "production-db.example.com");
+	}
+	let temp = write_settings_dir(
+		"local",
+		r#"
+[database]
+engine = "postgresql"
+name = "appdb"
+user = "app"
+password = "secret"
+host = "${IT4247_DB_HOST}"
+port = 5432
+"#,
+	);
+
+	// Act
+	let url =
+		DatabaseConnection::get_database_url_from_env_or_settings(Some(temp.path().to_path_buf()))
+			.expect("loader returns a URL");
+
+	// Assert — the expanded host must appear and the literal pattern
+	// must not survive the loader.
+	assert!(
+		url.contains("production-db.example.com"),
+		"expected expanded host in URL, got: {url}"
+	);
+	assert!(
+		!url.contains("${"),
+		"URL still contains literal interpolation pattern: {url}"
+	);
+}
+
+#[rstest]
+#[serial(env)]
+fn loader_uses_inline_default_when_var_unset() {
+	// Arrange — declare the var in the guard even though we never set it,
+	// so an ambient value from a prior test cannot leak in and silence
+	// the inline `:-fallback` branch.
+	let _guard = EnvGuard(vec!["IT4247_DB_HOST_OPT", "DATABASE_URL", "REINHARDT_ENV"]);
+	// SAFETY: serial-protected.
+	unsafe {
+		env::remove_var("DATABASE_URL");
+		env::remove_var("IT4247_DB_HOST_OPT");
+		env::set_var("REINHARDT_ENV", "local");
+	}
+	let temp = write_settings_dir(
+		"local",
+		r#"
+[database]
+engine = "postgresql"
+name = "appdb"
+user = "app"
+password = "secret"
+host = "${IT4247_DB_HOST_OPT:-fallback-host}"
+port = 5432
+"#,
+	);
+
+	// Act
+	let url =
+		DatabaseConnection::get_database_url_from_env_or_settings(Some(temp.path().to_path_buf()))
+			.expect("loader returns a URL");
+
+	// Assert — the inline fallback must apply because the var is unset.
+	assert!(
+		url.contains("fallback-host"),
+		"expected fallback host in URL, got: {url}"
+	);
+	assert!(
+		!url.contains("${"),
+		"URL still contains literal interpolation pattern: {url}"
+	);
+}


### PR DESCRIPTION
## Summary

- Add end-to-end regression coverage for `DatabaseConnection::get_database_url_from_env_or_settings` (`reinhardt-db`) and `get_database_url_from_settings` (`reinhardt-commands`).
- Each crate gets two tests covering `${VAR}` expansion and `${VAR:-fallback}` inline-default behavior, asserting both that the value reaches the produced URL and that no literal `${` survives.
- Promote `reinhardt_commands::builtin::get_database_url_from_settings` to `pub(crate)` so the in-crate unit tests can call the real loader without going through a public surface.

## Type of Change

- [x] Tests / regression coverage
- [x] Internal API visibility tweak (no public-API impact)

## Motivation and Context

Tracked from Copilot review feedback on PR #4239. The interpolation tests in `crates/reinhardt-conf/tests/interpolation.rs` build a fresh `TomlFileSource::with_interpolation()`, so they cannot detect a regression where a future refactor accidentally drops the opt-in from either real call site (`reinhardt-db/src/backends/connection.rs` lines 522–530, `reinhardt-commands/src/builtin.rs` lines 2708–2719). `reinhardt-conf` cannot depend on the downstream crates, so this coverage must live in their own test suites.

Locally flipping `with_interpolation()` → `without_interpolation()` in either production call site reproduces the regression: every new test in this PR fails, confirming the coverage is genuine.

Fixes #4247

## How Was This Tested

- Acceptance check: temporarily replaced `.with_interpolation()` with `.without_interpolation()` at all four production call sites — both new tests in `reinhardt-db` and both new tests in `reinhardt-commands` fail (URL contains literal `${VAR}`). Reverted before commit.
- `cargo nextest run -p reinhardt-db --all-features --test database_url_loader_interpolation` — 2/2 pass.
- `cargo nextest run -p reinhardt-commands --features reinhardt-db --lib tests::interpolation_4247::` — 2/2 pass.
- `cargo make fmt-check` — clean (after applying `cargo make fmt-fix`).
- `cargo make clippy-check` — clean across the workspace.

## Implementation Notes

- Each crate owns its own minimal `EnvGuard` / `CwdGuard` drop-guards (≈15 lines each). No `reinhardt-test` dependency is introduced — keeps publish ordering clean per **KI-2**.
- Tests are gated on `#[cfg(feature = "settings")]` (db) / `#[cfg(feature = "reinhardt-db")]` (commands) so they only build when the loader entry point itself is available.
- `#[serial(env)]` shares the existing serialization group; `EnvGuard` lists `DATABASE_URL` so an ambient value cannot short-circuit the settings path.

## Checklist

- [x] All new tests pass locally
- [x] Acceptance check confirms regression detection
- [x] Code follows project style (Rust 2024, tab indent, English comments)
- [x] No new TODO / FIXME / `dbg!` macros introduced
- [x] No public API change
- [x] Two commits split by intent (visibility flip vs new tests)

## Labels to Apply

- `test`
- `enhancement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)