### PR TITLE
fix(infra): tighten orphan-detector for missed workflow_job queued events

### DIFF
--- a/infra/github-runners/terraform.examples.tfvars
+++ b/infra/github-runners/terraform.examples.tfvars
@@ -41,3 +41,9 @@ organizations_account_email = "<your-email+reinhardt-ci@example.com>"
 # Set to true after initial CI setup is confirmed working.
 enable_hotpath_runner        = true
 hotpath_runner_instance_type = "t4g.micro"
+
+# Orphan detector (republishes stuck workflow_job events). See Issue #4253.
+# Defaults are tuned to recover within ~10 min when GitHub omits a queued event.
+# Override only if false-positive republishes occur on healthy provisioning.
+# orphan_detector_staleness_min       = 5
+# orphan_detector_schedule_expression = "rate(5 minutes)"

--- a/infra/github-runners/variables.tf
+++ b/infra/github-runners/variables.tf
@@ -130,9 +130,12 @@ variable "orphan_detector_enabled" {
 }
 
 variable "orphan_detector_staleness_min" {
-  description = "Jobs in queued state longer than this threshold (minutes) are considered orphaned. Default 60."
+  # Spot-AMI runners normally transition queued -> in_progress in well under 3 min,
+  # so a 5-min threshold catches webhook-event misses (Issue #4253) without
+  # false positives during legitimate slow provisioning.
+  description = "Jobs in queued state longer than this threshold (minutes) are considered orphaned. Default 5."
   type        = number
-  default     = 60
+  default     = 5
   validation {
     condition     = var.orphan_detector_staleness_min > 0
     error_message = "orphan_detector_staleness_min must be a positive integer."
@@ -150,9 +153,11 @@ variable "orphan_detector_circuit_breaker_margin" {
 }
 
 variable "orphan_detector_schedule_expression" {
-  description = "EventBridge schedule expression for the orphan detector scan interval. Default every 10 minutes."
+  # Combined with staleness_min=5, this yields a worst-case stuck time of
+  # staleness + scan_interval = ~10 min before republish (Issue #4253).
+  description = "EventBridge schedule expression for the orphan detector scan interval. Default every 5 minutes."
   type        = string
-  default     = "rate(10 minutes)"
+  default     = "rate(5 minutes)"
 }
 
 variable "orphan_detector_alert_email" {


### PR DESCRIPTION
## Summary

This PR addresses:

- Lower `orphan_detector_staleness_min` default from `60` to `5` minutes
- Lower `orphan_detector_schedule_expression` default from `rate(10 minutes)` to `rate(5 minutes)`
- Document the override knobs in `terraform.examples.tfvars` with a pointer to the underlying failure mode

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

When GitHub re-runs a failed job, the emitted `workflow_job` events do not always include `action=queued`, which is what the EventBridge rule `reinhardt-ci-workflow_job` filters on. Without the queued event, the scale-up Lambda is never invoked and the job sits in `queued` indefinitely until a human intervenes.

The existing `reinhardt-ci-orphan-detector` Lambda is the safety net for this failure mode (it republishes a synthetic, signed `workflow_job.queued` webhook to the upstream webhook Lambda), but its previous defaults — `staleness_min=60min` with a `rate(10 minutes)` scan — were too lax to catch a 10–15 minute stuck job. The reproduction in #4253 saw two `UI Tests` jobs sit `queued` for 28+ minutes after a "Re-run failed jobs" click.

The new defaults yield a worst-case stuck time of `5min (threshold) + 5min (next scan) = ~10min` before republish. Spot-AMI runners normally complete the queued → in_progress transition in well under 3 minutes, so the new threshold leaves ample headroom for legitimate slow provisioning without false positives. Lambda cost impact: doubling the orphan-detector schedule frequency adds <$2/month at current settings.

Fixes #4253

## How Was This Tested?

1. **Pre-flight reproduction**: Verified on the live CI sub-account that webhook Lambda received the rerun's `workflow_job` events (11 invocations, 0 errors), the EventBridge bus archive rule matched all 11, but the `reinhardt-ci-workflow_job` rule (which filters `action: ["queued"]`) matched 0 — confirming the missing `queued` action.
2. **Manual recovery**: Sent 2 synthetic SQS messages to `reinhardt-ci-queued-builds` for the stuck job IDs; scale-up Lambda spawned 2 ephemeral runners (`i-09014657f1d141553`, `i-0df84757b21ebfea8`) within 6 seconds and both jobs transitioned to `in_progress`.
3. **`terraform fmt`**: clean (no diff).
4. **`terraform plan` (targeted)**: confirms only the EventBridge rule is updated in-place — `description` and `schedule_expression` only — `Plan: 0 to add, 1 to change, 0 to destroy`. The Lambda env-var change (`STALENESS_MIN: "60" -> "5"`) is wired through `orphan-detector.tf:182` and will apply on the next full plan/apply once the lambda zip artifact is built.

## Performance Impact

- Orphan-detector Lambda invocations: 6/hr → 12/hr (~$2/month delta).
- Median CI rerun recovery time when the GitHub-side `queued` event is missed: indefinite (manual intervention) → ≤10 min.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own changes
- [x] I have commented my code in hard-to-understand areas (Issue #4253 referenced from `variables.tf`)
- [x] I have made corresponding changes to the documentation (`terraform.examples.tfvars`)
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes (no test changes needed; verified via `terraform plan`)
- [x] Any dependent changes have been merged and published in downstream modules

## Labels to Apply

- `bug` (issue regression — orphan-detector defaults insufficient)
- `ci-cd` (modifies CI runner infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)