### PR TITLE
ci(wasm-check): seed wasm-feature-check cache for amd64 + arm64

### DIFF
--- a/.github/workflows/wasm-check-standalone.yml
+++ b/.github/workflows/wasm-check-standalone.yml
@@ -22,21 +22,49 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Seed the shared rust-cache for wasm-feature-check so PR matrix entries
-  # restore from a populated cache. Mirrors the pattern in
-  # reinhardt-feature-check.yml's cache-seed. Runs ONE wasm32 cargo check
+  # Seed the shared rust-cache for wasm-feature-check so downstream consumers
+  # restore from a populated cache. Runs ONE wasm32 cargo check per arch
   # against the largest representative feature preset; downstream matrix
   # entries reuse the resulting registry/build/dep artifacts (CARGO_INCREMENTAL=0
   # disables incremental compilation, so this is non-incremental dependency
   # caching only).
+  #
+  # Seeds BOTH amd64 (ubuntu-latest) AND arm64 (self-hosted) because
+  # wasm-feature-check runs on every PR and consumers span both architectures:
+  #   - regular PRs / standalone wasm-check inline:    ubuntu-latest (amd64)
+  #   - release-plz PRs / owner checkbox-opted PRs:    arm64 self-hosted
+  # Swatinem/rust-cache@v2 auto-keys by runner OS+arch, so the single
+  # shared-key "wasm-feature-check" produces two independent cache entries
+  # (linux-x64 and linux-arm64); each consumer restores the matching one
+  # without any change required on the consumer side. (Fixes #4207)
   cache-seed:
-    name: Cache Seed (wasm-feature-check)
-    runs-on: [self-hosted, linux, arm64, reinhardt-ci]
+    name: Cache Seed (wasm-feature-check, ${{ matrix.arch.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - name: amd64
+            labels: '"ubuntu-latest"'
+          - name: arm64
+            labels: '["self-hosted","linux","arm64","reinhardt-ci"]'
+    runs-on: ${{ fromJSON(matrix.arch.labels) }}
     timeout-minutes: 360
     env:
       CARGO_TARGET_DIR: /tmp/cargo_target
       CARGO_INCREMENTAL: 0
     steps:
+      - name: Free Disk Space (Ubuntu)
+        if: ${{ matrix.arch.name == 'amd64' }}
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout repository
         uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Convert `cache-seed` in `.github/workflows/wasm-check-standalone.yml` from a single ARM64 self-hosted run into a 2-entry matrix (`amd64` + `arm64`) so both architectures get their own pre-warmed `wasm-feature-check` cache on every push to main.

## Type of Change

- [x] CI/CD changes
- [x] Performance improvement (CI cache hit rate)

## Motivation and Context

`Swatinem/rust-cache@v2` auto-keys cache entries by runner OS+arch. The previous `cache-seed` ran only on `[self-hosted, linux, arm64, reinhardt-ci]`, so the cache it produced was keyed `…-Linux-ARM64-…` and could never be restored by amd64 consumers.

The actual consumer mix of `wasm-feature-check` skews heavily amd64:

- `wasm-check-standalone.yml`'s own downstream `wasm-check` invocation hard-codes `runner: '"ubuntu-latest"'`
- Regular PRs route through `ci.yml` -> `determine-runner`, which falls back to `ubuntu-latest` for everyone except release-plz / repo-owner-with-checkbox PRs
- `wasm-test` is permanently `ubuntu-latest` (Chrome ARM64 incompatibility)

So the prior seed effectively benefited only release-plz PRs and was a no-op for the majority of CI runs. Copilot flagged this on PR #4204 review; the fix was scoped out of #4202 because it is a separate optimization.

By keeping the same `shared-key: "wasm-feature-check"` but seeding under both architectures, two independent cache entries are produced (`linux-x64` and `linux-arm64`); each consumer automatically restores the matching one with no consumer-side workflow change required. `fail-fast: false` ensures one arch's failure does not cancel the other. The `Free Disk Space (Ubuntu)` step is gated to the amd64 entry only, mirroring the existing pattern in `wasm-check.yml`'s other jobs.

Fixes #4207
Refs #4204, #4202

## How Was This Tested?

- YAML syntax + structure validated locally with `python3 -c \"yaml.safe_load(...)\"`; the matrix expands to 2 entries (`amd64`, `arm64`) and `runs-on: \${{ fromJSON(matrix.arch.labels) }}` resolves at job-dispatch time.
- Post-merge verification (will be observable after this PR lands and the next push to main fires the workflow):
  - The `wasm-check-standalone.yml` Actions run shows two parallel `Cache Seed (wasm-feature-check, amd64)` and `Cache Seed (wasm-feature-check, arm64)` jobs.
  - GitHub Settings -> Actions -> Caches lists two new entries with `shared-key=wasm-feature-check` differentiated by `Linux-x64` and `Linux-ARM64` suffixes.
  - The next regular PR's `wasm-feature-check` matrix entries log `Cache restored successfully` from the amd64 entry instead of cache-missing into a full rebuild.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (N/A - workflow-only change; no Rust tests affected)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4207
- Originating Copilot review on #4204
- Out-of-scope split from #4202

## Labels to Apply

### Type Label
- [x] `enhancement`

### Scope Label
- [x] `ci-cd`

---

**Additional Context:**

- This intentionally does NOT touch `reinhardt-feature-check.yml`'s `cache-seed`, which is correctly ARM64-only (its consumers — release-plz PRs only — always run on ARM64).
- Single-commit change; revert is a one-line `git revert` and restores the previous ARM64-only seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)