### PR TITLE
feat(urls): add server_fn stub to ServerRouterStub for cross-target builder

### DIFF
--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -787,6 +787,20 @@ impl ServerRouterStub {
 	pub fn endpoint<F>(self, _f: F) -> Self {
 		self
 	}
+
+	/// No-op stub for `ServerFnRouterExt::server_fn` on the WASM side.
+	///
+	/// `server_fn` is provided to native `ServerRouter` by the
+	/// `ServerFnRouterExt` extension trait in `reinhardt-pages`. That trait
+	/// (and its `ServerFnRegistration` bound) is a native-only concern, so
+	/// the stub absorbs the call as a free-standing inherent method without
+	/// any trait bound. This lets cross-target builder chains such as
+	/// `UnifiedRouter::new().server(|s| s.server_fn(marker))` compile on
+	/// `wasm32-unknown-unknown` without `#[cfg(native)]` gates at the call
+	/// site.
+	pub fn server_fn<S>(self, _marker: S) -> Self {
+		self
+	}
 }
 
 #[cfg(wasm)]
@@ -831,6 +845,7 @@ const _: fn() = || {
 				.view_named("/v", "v", ())
 				.viewset("/vs/", ())
 				.endpoint(|| ())
+				.server_fn(())
 		})
 		.client(|c| c);
 };


### PR DESCRIPTION
## Summary

- Adds a no-op `server_fn` stub to `ServerRouterStub` so that
  `UnifiedRouter::new().server(|s| s.server_fn(marker))` compiles on
  `wasm32-unknown-unknown` without `#[cfg(native)]` gates at the call site.
- Extends the #4185 drift-detection `const _: fn() = ...` to include
  `.server_fn(())` so any future omission of stub methods is caught at
  WASM compile time.

## Type of Change

- [x] Enhancement (no behaviour change on native, removes a WASM compile error
      that previously forced consumers into `#[cfg(native)]` workarounds)

## Motivation and Context

Discovered while migrating reinhardt-cloud away from per-target router
construction. `ServerFnRouterExt::server_fn` is provided to the native
`ServerRouter` by an extension trait in `reinhardt-pages`; the WASM
sibling `ServerRouterStub` already mirrors ~22 native builder methods
(introduced by #4185 as a single cross-target builder surface) but
`server_fn` was missed. This PR closes that gap.

The stub is intentionally unbounded over the marker type because
`ServerFnRegistration` is native-only and the WASM stub never inspects
the marker — it only needs to type-check the chain.

Fixes #4259

## How Was This Tested

- [x] `cargo check -p reinhardt-urls --target wasm32-unknown-unknown` (drift
      detection const compiles, including new `.server_fn(())`)
- [x] `cargo check -p reinhardt-urls --target wasm32-unknown-unknown --all-features`
- [x] `cargo check -p reinhardt-urls` (native; existing `ServerRouter::server_fn`
      path unaffected)
- [x] `cargo nextest run -p reinhardt-urls` — 742/742 PASS
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`

## Checklist

- [x] Code follows the project's style guidelines
- [x] All comments are in English
- [x] Tests pass locally
- [x] No `todo!()` / `// TODO` / `// FIXME` introduced
- [x] PR title follows Conventional Commits
- [x] PR is linked to issue via `Fixes #4259`

## Labels to Apply

- `enhancement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)