### PR TITLE
feat(conf): add MergeStrategy with Deep default for layered TOML merge

### DIFF
--- a/crates/reinhardt-conf/src/settings.rs
+++ b/crates/reinhardt-conf/src/settings.rs
@@ -20,8 +20,7 @@ pub mod i18n;
 pub mod interpolation;
 pub mod logging;
 pub mod media;
-/// Deep-merge primitive shared by the settings builder and test overrides.
-pub mod merge;
+pub(crate) mod merge;
 /// OpenAPI documentation endpoint configuration.
 pub mod openapi;
 /// Field-level policy types for settings fragments.

--- a/crates/reinhardt-conf/src/settings.rs
+++ b/crates/reinhardt-conf/src/settings.rs
@@ -20,6 +20,8 @@ pub mod i18n;
 pub mod interpolation;
 pub mod logging;
 pub mod media;
+/// Deep-merge primitive shared by the settings builder and test overrides.
+pub mod merge;
 /// OpenAPI documentation endpoint configuration.
 pub mod openapi;
 /// Field-level policy types for settings fragments.

--- a/crates/reinhardt-conf/src/settings.rs
+++ b/crates/reinhardt-conf/src/settings.rs
@@ -480,6 +480,9 @@ pub use policy::{FieldPolicy, FieldRequirement};
 // Re-export ComposedSettings trait
 pub use composed::ComposedSettings;
 
+// Re-export the merge strategy selector for SettingsBuilder. See issue #4260.
+pub use builder::MergeStrategy;
+
 /// Template engine configuration
 #[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/reinhardt-conf/src/settings/builder.rs
+++ b/crates/reinhardt-conf/src/settings/builder.rs
@@ -14,14 +14,11 @@ use std::sync::Arc;
 /// Strategy for merging multiple configuration sources.
 ///
 /// Selected via [`SettingsBuilder::with_merge_strategy`]. The default
-/// differs between [`SettingsBuilder::build`] (uses [`Shallow`]) and
-/// [`SettingsBuilder::build_composed`] (uses [`Deep`]) — see those
-/// methods for the rationale.
+/// differs between [`SettingsBuilder::build`] (uses
+/// [`MergeStrategy::Shallow`]) and [`SettingsBuilder::build_composed`]
+/// (uses [`MergeStrategy::Deep`]) — see those methods for the rationale.
 ///
 /// See [issue #4260](https://github.com/kent8192/reinhardt-web/issues/4260).
-///
-/// [`Shallow`]: MergeStrategy::Shallow
-/// [`Deep`]: MergeStrategy::Deep
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum MergeStrategy {
@@ -35,7 +32,7 @@ pub enum MergeStrategy {
 	/// table at the same key, sibling keys from both sides are preserved
 	/// and only conflicting leaves are replaced. Arrays and scalars are
 	/// still replaced wholesale, so flat-key fallback paths continue to
-	/// work the same as under [`Shallow`].
+	/// work the same as under [`MergeStrategy::Shallow`].
 	Deep,
 }
 

--- a/crates/reinhardt-conf/src/settings/builder.rs
+++ b/crates/reinhardt-conf/src/settings/builder.rs
@@ -144,12 +144,23 @@ impl SettingsBuilder {
 	///
 	/// ```
 	/// use reinhardt_conf::settings::builder::{MergeStrategy, SettingsBuilder};
+	/// use reinhardt_conf::settings::sources::DefaultSource;
+	/// use serde_json::json;
 	///
 	/// // Force `build()` to deep-merge layered TOML files.
 	/// let builder = SettingsBuilder::new()
+	///     .add_source(DefaultSource::new().with_value("core", json!({
+	///         "secret_key": "from-base",
+	///         "security": {"secure_ssl_redirect": true},
+	///     })))
+	///     .add_source(DefaultSource::new().with_value("core", json!({"debug": true})))
 	///     .with_merge_strategy(MergeStrategy::Deep);
 	/// let settings = builder.build().unwrap();
-	/// assert_eq!(settings.keys().count(), 0);
+	///
+	/// let core = settings.get_raw("core").unwrap().as_object().unwrap();
+	/// assert_eq!(core.get("debug").unwrap(), &json!(true));
+	/// assert_eq!(core.get("secret_key").unwrap(), &json!("from-base"));
+	/// assert!(core.get("security").is_some());
 	/// ```
 	pub fn with_merge_strategy(mut self, strategy: MergeStrategy) -> Self {
 		self.merge_strategy = Some(strategy);

--- a/crates/reinhardt-conf/src/settings/builder.rs
+++ b/crates/reinhardt-conf/src/settings/builder.rs
@@ -11,12 +11,41 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::sync::Arc;
 
+/// Strategy for merging multiple configuration sources.
+///
+/// Selected via [`SettingsBuilder::with_merge_strategy`]. The default
+/// differs between [`SettingsBuilder::build`] (uses [`Shallow`]) and
+/// [`SettingsBuilder::build_composed`] (uses [`Deep`]) — see those
+/// methods for the rationale.
+///
+/// See [issue #4260](https://github.com/kent8192/reinhardt-web/issues/4260).
+///
+/// [`Shallow`]: MergeStrategy::Shallow
+/// [`Deep`]: MergeStrategy::Deep
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum MergeStrategy {
+	/// Top-level key replacement. Each later source overwrites the entire
+	/// value at any conflicting top-level key. This preserves env-source /
+	/// flat-key composition (e.g., `REINHARDT_REDIS_URL` overwriting a
+	/// scalar `redis_url` without disturbing other top-level keys) and
+	/// matches the historical behaviour of [`SettingsBuilder::build`].
+	Shallow,
+	/// Recursive merge of nested tables. When two sources both define a
+	/// table at the same key, sibling keys from both sides are preserved
+	/// and only conflicting leaves are replaced. Arrays and scalars are
+	/// still replaced wholesale, so flat-key fallback paths continue to
+	/// work the same as under [`Shallow`].
+	Deep,
+}
+
 /// Settings builder for layered configuration
 pub struct SettingsBuilder {
 	sources: Vec<Box<dyn ConfigSource>>,
 	profile: Option<Profile>,
 	strict: bool,
 	typed_coercion: bool,
+	merge_strategy: Option<MergeStrategy>,
 }
 
 impl SettingsBuilder {
@@ -39,6 +68,7 @@ impl SettingsBuilder {
 			profile: None,
 			strict: false,
 			typed_coercion: true,
+			merge_strategy: None,
 		}
 	}
 	/// Set the application profile
@@ -100,6 +130,32 @@ impl SettingsBuilder {
 	/// ```
 	pub fn with_typed_coercion(mut self, enable: bool) -> Self {
 		self.typed_coercion = enable;
+		self
+	}
+	/// Override the merge strategy used when combining configuration sources.
+	///
+	/// When unset, [`SettingsBuilder::build`] defaults to
+	/// [`MergeStrategy::Shallow`] and [`SettingsBuilder::build_composed`]
+	/// defaults to [`MergeStrategy::Deep`]. Calling this method forces both
+	/// build paths to use the supplied strategy regardless of the entry
+	/// point.
+	///
+	/// See [issue #4260](https://github.com/kent8192/reinhardt-web/issues/4260)
+	/// for the design discussion.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use reinhardt_conf::settings::builder::{MergeStrategy, SettingsBuilder};
+	///
+	/// // Force `build()` to deep-merge layered TOML files.
+	/// let builder = SettingsBuilder::new()
+	///     .with_merge_strategy(MergeStrategy::Deep);
+	/// let settings = builder.build().unwrap();
+	/// assert_eq!(settings.keys().count(), 0);
+	/// ```
+	pub fn with_merge_strategy(mut self, strategy: MergeStrategy) -> Self {
+		self.merge_strategy = Some(strategy);
 		self
 	}
 	/// Add a configuration source
@@ -168,7 +224,23 @@ impl SettingsBuilder {
 	///
 	/// Fragment-level validation (`validate_fragments()`) should be called
 	/// separately by the caller with the appropriate profile.
-	pub fn build_composed<T: ComposedSettings>(self) -> Result<T, BuildError> {
+	///
+	/// # Merge strategy
+	///
+	/// Defaults to [`MergeStrategy::Deep`] so that layered TOML files
+	/// (e.g. `base.toml` + `local.toml`) preserve sibling keys inside
+	/// nested tables. Use [`SettingsBuilder::with_merge_strategy`] to
+	/// opt back into [`MergeStrategy::Shallow`] for the legacy
+	/// top-level-replacement behaviour. See
+	/// [issue #4260](https://github.com/kent8192/reinhardt-web/issues/4260).
+	pub fn build_composed<T: ComposedSettings>(mut self) -> Result<T, BuildError> {
+		// `build_composed` exists for layered TOML files where deep merging is
+		// the natural expectation. Apply the deep default only when the caller
+		// has not explicitly chosen a strategy, so explicit `Shallow` opt-outs
+		// still work.
+		if self.merge_strategy.is_none() {
+			self.merge_strategy = Some(MergeStrategy::Deep);
+		}
 		// Capture the flag before `self.build()` consumes self.
 		let typed_coercion = self.typed_coercion;
 		let merged = self.build()?;
@@ -216,6 +288,13 @@ impl SettingsBuilder {
 		// Sort sources by priority (lowest first, so highest priority overwrites)
 		self.sources.sort_by_key(|a| a.priority());
 
+		// Resolve the merge strategy for this build. `build()` keeps `Shallow`
+		// as its default to preserve env-source / flat-key composition; only
+		// callers that explicitly opt in (or `build_composed`, which sets its
+		// own default upstream) will recurse into nested tables.
+		// See issue #4260.
+		let strategy = self.merge_strategy.unwrap_or(MergeStrategy::Shallow);
+
 		let mut merged = IndexMap::new();
 		// Track every loaded source's map alongside its description so that flat-key
 		// diagnostics can be attributed to the originating source rather than to the
@@ -233,9 +312,15 @@ impl SettingsBuilder {
 				error: e,
 			})?;
 
-			// Merge into the main config
-			for (key, value) in &config {
-				merged.insert(key.clone(), value.clone());
+			match strategy {
+				MergeStrategy::Shallow => {
+					for (key, value) in &config {
+						merged.insert(key.clone(), value.clone());
+					}
+				}
+				MergeStrategy::Deep => {
+					super::merge::deep_merge(&mut merged, config.clone());
+				}
 			}
 
 			per_source.push((description, config));

--- a/crates/reinhardt-conf/src/settings/builder.rs
+++ b/crates/reinhardt-conf/src/settings/builder.rs
@@ -245,7 +245,7 @@ impl SettingsBuilder {
 		// Overrides are internal test machinery and intentionally bypass the
 		// flat-key warning logic below.
 		if let Some(overrides) = super::testing::overrides::current_overrides() {
-			super::testing::overrides::deep_merge(&mut merged, overrides);
+			super::merge::deep_merge(&mut merged, overrides);
 		}
 
 		// Warn about flat top-level keys that belong under [core], deciding per

--- a/crates/reinhardt-conf/src/settings/fragment.rs
+++ b/crates/reinhardt-conf/src/settings/fragment.rs
@@ -36,12 +36,31 @@
 //! session_cookie_secure = true
 //! ```
 //!
-//! # Shallow merge semantics
+//! # Merge semantics
 //!
-//! When multiple TOML files are merged (e.g., `base.toml` + `local.toml`), each
-//! top-level section is replaced as a whole. If `local.toml` defines `[core]`, it
-//! replaces the entire `[core]` section from `base.toml`. Therefore, environment-specific
-//! files must be self-contained for any section they define.
+//! When multiple TOML files are merged (e.g., `base.toml` + `local.toml`),
+//! the resulting layout depends on the
+//! [`MergeStrategy`](super::builder::MergeStrategy) chosen on the
+//! [`SettingsBuilder`](super::builder::SettingsBuilder):
+//!
+//! - With [`MergeStrategy::Shallow`](super::builder::MergeStrategy::Shallow)
+//!   — the legacy default for
+//!   [`build`](super::builder::SettingsBuilder::build) — each top-level
+//!   section is replaced as a whole. If `local.toml` defines `[core]`, it
+//!   replaces the entire `[core]` section from `base.toml`, so
+//!   environment-specific files must be self-contained for any section
+//!   they touch.
+//! - With [`MergeStrategy::Deep`](super::builder::MergeStrategy::Deep)
+//!   — the default for
+//!   [`build_composed`](super::builder::SettingsBuilder::build_composed)
+//!   — nested tables are merged recursively. Defining `[core].debug =
+//!   true` in `local.toml` no longer erases sibling fields like
+//!   `[core].secret_key` or sub-sections like `[core.security]` that were
+//!   set in `base.toml`. Arrays and scalars are still replaced
+//!   wholesale.
+//!
+//! See [issue #4260](https://github.com/kent8192/reinhardt-web/issues/4260)
+//! for the design discussion.
 
 use super::policy::FieldPolicy;
 use super::profile::Profile;

--- a/crates/reinhardt-conf/src/settings/merge.rs
+++ b/crates/reinhardt-conf/src/settings/merge.rs
@@ -10,11 +10,11 @@
 //!   still replaced wholesale. The default for
 //!   [`SettingsBuilder::build_composed`](crate::settings::builder::SettingsBuilder::build_composed).
 //!
-//! [`deep_merge`] implements the deep variant. It is intentionally
-//! conservative: only `Value::Object` versus `Value::Object` collisions
-//! recurse; every other shape (scalar, array, mixed) defers to the source
-//! value, matching the behaviour described in
-//! [issue #4260](https://github.com/kent8192/reinhardt-web/issues/4260).
+//! The `deep_merge` function in this module implements the deep variant.
+//! It is intentionally conservative: only `Value::Object` versus
+//! `Value::Object` collisions recurse; every other shape (scalar, array,
+//! mixed) defers to the source value, matching the behaviour described
+//! in [issue #4260](https://github.com/kent8192/reinhardt-web/issues/4260).
 
 use indexmap::IndexMap;
 use serde_json::Value;

--- a/crates/reinhardt-conf/src/settings/merge.rs
+++ b/crates/reinhardt-conf/src/settings/merge.rs
@@ -34,47 +34,25 @@ use serde_json::Value;
 /// replaces the target array. This keeps the rule predictable for users:
 /// "objects deep-merge, everything else replaces".
 ///
-/// Insertion order of `target` is preserved for keys that already exist;
-/// new keys from `source` are appended in their original order.
+/// Insertion order of top-level `target` keys is preserved for keys that
+/// already exist; new top-level keys from `source` are appended in their
+/// original order. Nested object ordering follows `serde_json::Map`.
 ///
-/// # Examples
-///
-/// ```
-/// use indexmap::IndexMap;
-/// use reinhardt_conf::settings::merge::deep_merge;
-/// use serde_json::json;
-///
-/// let mut target: IndexMap<String, serde_json::Value> = IndexMap::new();
-/// target.insert("core".to_string(), json!({
-///     "secret_key": "from-base",
-///     "security": {"secure_ssl_redirect": true},
-/// }));
-///
-/// let mut source: IndexMap<String, serde_json::Value> = IndexMap::new();
-/// source.insert("core".to_string(), json!({"debug": true}));
-///
-/// deep_merge(&mut target, source);
-///
-/// // `secret_key` and `security` survive even though `local.toml` only
-/// // mentioned `[core].debug = true`.
-/// let core = target.get("core").unwrap().as_object().unwrap();
-/// assert_eq!(core.get("debug").unwrap(), &serde_json::Value::Bool(true));
-/// assert_eq!(core.get("secret_key").unwrap(), &serde_json::Value::String("from-base".into()));
-/// assert!(core.get("security").is_some());
-/// ```
-pub fn deep_merge(target: &mut IndexMap<String, Value>, source: IndexMap<String, Value>) {
+pub(crate) fn deep_merge(target: &mut IndexMap<String, Value>, source: IndexMap<String, Value>) {
 	for (key, source_val) in source {
-		match target.get_mut(&key) {
-			Some(Value::Object(target_obj)) if source_val.is_object() => {
-				// Both are objects — merge recursively.
-				let source_obj = source_val
-					.as_object()
-					.expect("source_val.is_object() guaranteed by match guard");
-				for (k, v) in source_obj {
-					deep_merge_json(target_obj, k.clone(), v.clone());
+		match source_val {
+			Value::Object(source_obj) => match target.get_mut(&key) {
+				Some(Value::Object(target_obj)) => {
+					// Both are objects — merge recursively.
+					for (k, v) in source_obj {
+						deep_merge_json(target_obj, k, v);
+					}
 				}
-			}
-			_ => {
+				_ => {
+					target.insert(key, Value::Object(source_obj));
+				}
+			},
+			source_val => {
 				target.insert(key, source_val);
 			}
 		}
@@ -86,16 +64,18 @@ pub fn deep_merge(target: &mut IndexMap<String, Value>, source: IndexMap<String,
 /// Mirrors [`deep_merge`] but operates on `serde_json::Map` to support
 /// the nested-table case after the first level.
 fn deep_merge_json(target: &mut serde_json::Map<String, Value>, key: String, value: Value) {
-	match target.get_mut(&key) {
-		Some(Value::Object(target_obj)) if value.is_object() => {
-			let source_obj = value
-				.as_object()
-				.expect("value.is_object() guaranteed by match guard");
-			for (k, v) in source_obj {
-				deep_merge_json(target_obj, k.clone(), v.clone());
+	match value {
+		Value::Object(source_obj) => match target.get_mut(&key) {
+			Some(Value::Object(target_obj)) => {
+				for (k, v) in source_obj {
+					deep_merge_json(target_obj, k, v);
+				}
 			}
-		}
-		_ => {
+			_ => {
+				target.insert(key, Value::Object(source_obj));
+			}
+		},
+		value => {
 			target.insert(key, value);
 		}
 	}

--- a/crates/reinhardt-conf/src/settings/merge.rs
+++ b/crates/reinhardt-conf/src/settings/merge.rs
@@ -1,0 +1,229 @@
+//! Deep merge primitive shared by the settings builder and test overrides.
+//!
+//! The settings system layers configuration from multiple sources (TOML
+//! files, environment variables, defaults, thread-local test overrides).
+//! Two distinct merge semantics are required:
+//!
+//! - **Shallow** — top-level key replacement. The legacy default for
+//!   [`SettingsBuilder::build`](crate::settings::builder::SettingsBuilder::build).
+//! - **Deep** — recursive merge of nested tables, with scalars and arrays
+//!   still replaced wholesale. The default for
+//!   [`SettingsBuilder::build_composed`](crate::settings::builder::SettingsBuilder::build_composed).
+//!
+//! [`deep_merge`] implements the deep variant. It is intentionally
+//! conservative: only `Value::Object` versus `Value::Object` collisions
+//! recurse; every other shape (scalar, array, mixed) defers to the source
+//! value, matching the behaviour described in
+//! [issue #4260](https://github.com/kent8192/reinhardt-web/issues/4260).
+
+use indexmap::IndexMap;
+use serde_json::Value;
+
+/// Deep-merges `source` into `target`.
+///
+/// For each `(key, source_value)` pair in `source`:
+///
+/// - If `target[key]` and `source_value` are both [`Value::Object`], merge
+///   them recursively, preserving sibling keys that appear in only one
+///   side.
+/// - Otherwise replace `target[key]` with `source_value`. This includes
+///   the case where one side is an object and the other is a scalar or
+///   array — there is no safe way to merge mismatched shapes.
+///
+/// Arrays are **never** merged element-wise; the source array always
+/// replaces the target array. This keeps the rule predictable for users:
+/// "objects deep-merge, everything else replaces".
+///
+/// Insertion order of `target` is preserved for keys that already exist;
+/// new keys from `source` are appended in their original order.
+///
+/// # Examples
+///
+/// ```
+/// use indexmap::IndexMap;
+/// use reinhardt_conf::settings::merge::deep_merge;
+/// use serde_json::json;
+///
+/// let mut target: IndexMap<String, serde_json::Value> = IndexMap::new();
+/// target.insert("core".to_string(), json!({
+///     "secret_key": "from-base",
+///     "security": {"secure_ssl_redirect": true},
+/// }));
+///
+/// let mut source: IndexMap<String, serde_json::Value> = IndexMap::new();
+/// source.insert("core".to_string(), json!({"debug": true}));
+///
+/// deep_merge(&mut target, source);
+///
+/// // `secret_key` and `security` survive even though `local.toml` only
+/// // mentioned `[core].debug = true`.
+/// let core = target.get("core").unwrap().as_object().unwrap();
+/// assert_eq!(core.get("debug").unwrap(), &serde_json::Value::Bool(true));
+/// assert_eq!(core.get("secret_key").unwrap(), &serde_json::Value::String("from-base".into()));
+/// assert!(core.get("security").is_some());
+/// ```
+pub fn deep_merge(target: &mut IndexMap<String, Value>, source: IndexMap<String, Value>) {
+	for (key, source_val) in source {
+		match target.get_mut(&key) {
+			Some(Value::Object(target_obj)) if source_val.is_object() => {
+				// Both are objects — merge recursively.
+				let source_obj = source_val
+					.as_object()
+					.expect("source_val.is_object() guaranteed by match guard");
+				for (k, v) in source_obj {
+					deep_merge_json(target_obj, k.clone(), v.clone());
+				}
+			}
+			_ => {
+				target.insert(key, source_val);
+			}
+		}
+	}
+}
+
+/// Recursive helper for merging into a [`serde_json::Map`].
+///
+/// Mirrors [`deep_merge`] but operates on `serde_json::Map` to support
+/// the nested-table case after the first level.
+fn deep_merge_json(target: &mut serde_json::Map<String, Value>, key: String, value: Value) {
+	match target.get_mut(&key) {
+		Some(Value::Object(target_obj)) if value.is_object() => {
+			let source_obj = value
+				.as_object()
+				.expect("value.is_object() guaranteed by match guard");
+			for (k, v) in source_obj {
+				deep_merge_json(target_obj, k.clone(), v.clone());
+			}
+		}
+		_ => {
+			target.insert(key, value);
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+	use serde_json::json;
+
+	#[rstest]
+	fn deep_merge_replaces_top_level_scalar() {
+		// Arrange
+		let mut target: IndexMap<String, Value> = IndexMap::new();
+		target.insert("port".to_string(), json!(8080));
+		let mut source: IndexMap<String, Value> = IndexMap::new();
+		source.insert("port".to_string(), json!(9090));
+
+		// Act
+		deep_merge(&mut target, source);
+
+		// Assert
+		assert_eq!(target.get("port").unwrap(), &json!(9090));
+	}
+
+	#[rstest]
+	fn deep_merge_recurses_into_nested_objects() {
+		// Arrange
+		let mut target: IndexMap<String, Value> = IndexMap::new();
+		target.insert(
+			"core".to_string(),
+			json!({"secret_key": "from-base", "debug": false}),
+		);
+		let mut source: IndexMap<String, Value> = IndexMap::new();
+		source.insert("core".to_string(), json!({"debug": true}));
+
+		// Act
+		deep_merge(&mut target, source);
+
+		// Assert: `secret_key` survives, `debug` flips
+		let core = target.get("core").unwrap().as_object().unwrap();
+		assert_eq!(core.get("secret_key").unwrap(), &json!("from-base"));
+		assert_eq!(core.get("debug").unwrap(), &json!(true));
+	}
+
+	#[rstest]
+	fn deep_merge_preserves_distinct_top_level_keys() {
+		// Arrange
+		let mut target: IndexMap<String, Value> = IndexMap::new();
+		target.insert("core".to_string(), json!({"debug": false}));
+		let mut source: IndexMap<String, Value> = IndexMap::new();
+		source.insert("cache".to_string(), json!({"ttl": 60}));
+
+		// Act
+		deep_merge(&mut target, source);
+
+		// Assert: both top-level keys present
+		assert!(target.get("core").is_some());
+		assert!(target.get("cache").is_some());
+	}
+
+	#[rstest]
+	fn deep_merge_replaces_array_wholesale() {
+		// Arrange
+		let mut target: IndexMap<String, Value> = IndexMap::new();
+		target.insert("hosts".to_string(), json!(["a", "b", "c"]));
+		let mut source: IndexMap<String, Value> = IndexMap::new();
+		source.insert("hosts".to_string(), json!(["x"]));
+
+		// Act
+		deep_merge(&mut target, source);
+
+		// Assert: arrays do not concatenate
+		assert_eq!(target.get("hosts").unwrap(), &json!(["x"]));
+	}
+
+	#[rstest]
+	fn deep_merge_replaces_when_shapes_mismatch() {
+		// Arrange: target is object, source is scalar — cannot merge
+		let mut target: IndexMap<String, Value> = IndexMap::new();
+		target.insert("core".to_string(), json!({"debug": false}));
+		let mut source: IndexMap<String, Value> = IndexMap::new();
+		source.insert("core".to_string(), json!("disabled"));
+
+		// Act
+		deep_merge(&mut target, source);
+
+		// Assert: source replaces wholesale
+		assert_eq!(target.get("core").unwrap(), &json!("disabled"));
+	}
+
+	#[rstest]
+	fn deep_merge_recurses_through_three_levels() {
+		// Arrange: [core.security.secure_ssl_redirect] survives a partial
+		// override at [core.security.session_cookie_secure].
+		let mut target: IndexMap<String, Value> = IndexMap::new();
+		target.insert(
+			"core".to_string(),
+			json!({
+				"security": {
+					"secure_ssl_redirect": true,
+					"session_cookie_secure": false,
+				}
+			}),
+		);
+		let mut source: IndexMap<String, Value> = IndexMap::new();
+		source.insert(
+			"core".to_string(),
+			json!({
+				"security": {
+					"session_cookie_secure": true,
+				}
+			}),
+		);
+
+		// Act
+		deep_merge(&mut target, source);
+
+		// Assert
+		let security = target
+			.get("core")
+			.unwrap()
+			.get("security")
+			.unwrap()
+			.as_object()
+			.unwrap();
+		assert_eq!(security.get("secure_ssl_redirect").unwrap(), &json!(true));
+		assert_eq!(security.get("session_cookie_secure").unwrap(), &json!(true));
+	}
+}

--- a/crates/reinhardt-conf/src/settings/prelude.rs
+++ b/crates/reinhardt-conf/src/settings/prelude.rs
@@ -7,7 +7,7 @@ pub use super::advanced::{
 	AdvancedSettings, CacheSettings, CorsSettings, DatabaseSettings as AdvancedDatabaseSettings,
 	EmailSettings, LoggingSettings, MediaSettings, SessionSettings, SettingsError, StaticSettings,
 };
-pub use super::builder::{BuildError, GetError, MergedSettings, SettingsBuilder};
+pub use super::builder::{BuildError, GetError, MergeStrategy, MergedSettings, SettingsBuilder};
 pub use super::env::{Env, EnvError};
 pub use super::env_loader::{EnvLoader, load_env, load_env_auto, load_env_optional};
 pub use super::env_parser::{

--- a/crates/reinhardt-conf/src/settings/testing/overrides.rs
+++ b/crates/reinhardt-conf/src/settings/testing/overrides.rs
@@ -38,6 +38,7 @@
 //! // Guard dropped here — overrides cleared automatically
 //! ```
 
+use crate::settings::merge::deep_merge;
 use indexmap::IndexMap;
 use serde_json::Value;
 use std::cell::RefCell;
@@ -183,42 +184,6 @@ fn build_nested(key: &str, value: Value) -> IndexMap<String, Value> {
 
 	result.insert(parts[0].to_string(), current);
 	result
-}
-
-/// Deep-merge `source` into `target`.
-///
-/// When both sides have a `Value::Object` at the same key, merge
-/// recursively. Otherwise the source value replaces the target.
-pub(crate) fn deep_merge(target: &mut IndexMap<String, Value>, source: IndexMap<String, Value>) {
-	for (key, source_val) in source {
-		match target.get_mut(&key) {
-			Some(Value::Object(target_obj)) if source_val.is_object() => {
-				// Both are objects — merge recursively
-				let source_obj = source_val.as_object().unwrap();
-				for (k, v) in source_obj {
-					deep_merge_json(target_obj, k.clone(), v.clone());
-				}
-			}
-			_ => {
-				target.insert(key, source_val);
-			}
-		}
-	}
-}
-
-/// Recursive helper for merging into a `serde_json::Map`.
-fn deep_merge_json(target: &mut serde_json::Map<String, Value>, key: String, value: Value) {
-	match target.get_mut(&key) {
-		Some(Value::Object(target_obj)) if value.is_object() => {
-			let source_obj = value.as_object().unwrap();
-			for (k, v) in source_obj {
-				deep_merge_json(target_obj, k.clone(), v.clone());
-			}
-		}
-		_ => {
-			target.insert(key, value);
-		}
-	}
 }
 
 #[cfg(test)]

--- a/crates/reinhardt-conf/tests/merge_strategy.rs
+++ b/crates/reinhardt-conf/tests/merge_strategy.rs
@@ -1,0 +1,236 @@
+// Integration tests for `MergeStrategy` on `SettingsBuilder`.
+//
+// Layers two `DefaultSource` instances (both at priority 0, so iteration
+// order follows insertion order) to simulate `base.toml` + `local.toml`
+// composition without writing temporary files. The "base" source is added
+// first; the "profile" source second. Under `Shallow` the profile entirely
+// replaces overlapping top-level keys; under `Deep` nested tables are
+// merged and sibling keys survive. See issue #4260.
+
+use reinhardt_conf::settings::ComposedSettings;
+use reinhardt_conf::settings::MergeStrategy;
+use reinhardt_conf::settings::builder::SettingsBuilder;
+use reinhardt_conf::settings::sources::DefaultSource;
+use rstest::rstest;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Helper: ComposedSettings target with a nested `[core]` section and one
+// flat top-level key, mirroring the `redis_url` flat-key fallback path
+// described in the issue.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+struct CoreFragment {
+	debug: bool,
+	secret_key: String,
+	#[serde(default)]
+	security: SecurityFragment,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+struct SecurityFragment {
+	#[serde(default)]
+	secure_ssl_redirect: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+struct LayeredSettings {
+	core: CoreFragment,
+	#[serde(default)]
+	redis_url: String,
+}
+
+impl ComposedSettings for LayeredSettings {
+	fn validate_requirements(
+		_merged: &indexmap::IndexMap<String, serde_json::Value>,
+	) -> Result<(), reinhardt_conf::settings::builder::BuildError> {
+		Ok(())
+	}
+
+	fn validate_fragments(
+		&self,
+		_profile: &reinhardt_conf::settings::profile::Profile,
+	) -> reinhardt_conf::settings::validation::ValidationResult {
+		Ok(())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// build() — `Shallow` is the historical default; the profile layer wipes
+// the entire `[core]` table from the base.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn build_with_shallow_strategy_keeps_legacy_replacement() {
+	// Arrange: base provides full [core], profile only overrides debug.
+	let base = DefaultSource::new().with_value(
+		"core",
+		json!({
+			"secret_key": "from-base",
+			"security": {"secure_ssl_redirect": true},
+		}),
+	);
+	let profile = DefaultSource::new().with_value("core", json!({"debug": true}));
+
+	// Act: default for build() is Shallow.
+	let merged = SettingsBuilder::new()
+		.add_source(base)
+		.add_source(profile)
+		.build()
+		.unwrap();
+
+	// Assert: profile's [core] replaced the base entirely; only `debug` survives.
+	let core = merged
+		.get_raw("core")
+		.expect("core key present")
+		.as_object()
+		.unwrap();
+	assert_eq!(core.get("debug"), Some(&json!(true)));
+	assert!(
+		core.get("secret_key").is_none(),
+		"shallow merge must drop base's secret_key"
+	);
+	assert!(
+		core.get("security").is_none(),
+		"shallow merge must drop base's nested security"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// build() — opt-in `Deep` strategy preserves base sibling keys inside the
+// nested table.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn build_with_deep_strategy_preserves_nested_siblings() {
+	// Arrange: same layering as above.
+	let base = DefaultSource::new().with_value(
+		"core",
+		json!({
+			"secret_key": "from-base",
+			"security": {"secure_ssl_redirect": true},
+		}),
+	);
+	let profile = DefaultSource::new().with_value("core", json!({"debug": true}));
+
+	// Act: explicit opt-in to Deep.
+	let merged = SettingsBuilder::new()
+		.with_merge_strategy(MergeStrategy::Deep)
+		.add_source(base)
+		.add_source(profile)
+		.build()
+		.unwrap();
+
+	// Assert: profile's `debug` was added without erasing siblings.
+	let core = merged
+		.get_raw("core")
+		.expect("core key present")
+		.as_object()
+		.unwrap();
+	assert_eq!(core.get("debug"), Some(&json!(true)));
+	assert_eq!(core.get("secret_key"), Some(&json!("from-base")));
+	let security = core
+		.get("security")
+		.and_then(serde_json::Value::as_object)
+		.expect("security sub-table present");
+	assert_eq!(security.get("secure_ssl_redirect"), Some(&json!(true)));
+}
+
+// ---------------------------------------------------------------------------
+// build() — under Deep, scalar (flat-key) layering still replaces
+// wholesale. This protects the `redis_url` / `jwt_secret` fallback paths
+// that callers rely on.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn build_with_deep_strategy_replaces_top_level_scalars() {
+	// Arrange: base sets a scalar, profile overrides it.
+	let base = DefaultSource::new().with_value("redis_url", json!("redis://base"));
+	let profile = DefaultSource::new().with_value("redis_url", json!("redis://profile"));
+
+	// Act
+	let merged = SettingsBuilder::new()
+		.with_merge_strategy(MergeStrategy::Deep)
+		.add_source(base)
+		.add_source(profile)
+		.build()
+		.unwrap();
+
+	// Assert
+	assert_eq!(merged.get_raw("redis_url"), Some(&json!("redis://profile")));
+}
+
+// ---------------------------------------------------------------------------
+// build_composed() — defaults to Deep, so consumers of layered TOML
+// profiles no longer need to redeclare every field of the sections they
+// touch. This is the main behaviour change of #4260.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn build_composed_defaults_to_deep() {
+	// Arrange: the profile only changes `debug`, base owns secret_key and security.
+	let base = DefaultSource::new().with_value(
+		"core",
+		json!({
+			"debug": false,
+			"secret_key": "from-base",
+			"security": {"secure_ssl_redirect": true},
+		}),
+	);
+	let profile = DefaultSource::new().with_value("core", json!({"debug": true}));
+
+	// Act: build_composed() with no explicit strategy → Deep.
+	let settings: LayeredSettings = SettingsBuilder::new()
+		.add_source(base)
+		.add_source(profile)
+		.build_composed()
+		.unwrap();
+
+	// Assert: every base field is preserved, only `debug` was overridden.
+	assert!(settings.core.debug);
+	assert_eq!(settings.core.secret_key, "from-base");
+	assert!(settings.core.security.secure_ssl_redirect);
+}
+
+// ---------------------------------------------------------------------------
+// build_composed() — explicit `Shallow` opt-out restores the legacy
+// behaviour (profile layer drops base sibling fields). Smoke-tests the
+// escape hatch promised in `with_merge_strategy`.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn build_composed_with_explicit_shallow_drops_siblings() {
+	// Arrange: same layering, but profile MUST redeclare every required
+	// field to satisfy `serde` since Shallow drops the base [core] entirely.
+	let base = DefaultSource::new().with_value(
+		"core",
+		json!({
+			"debug": false,
+			"secret_key": "from-base",
+			"security": {"secure_ssl_redirect": true},
+		}),
+	);
+	let profile = DefaultSource::new().with_value(
+		"core",
+		json!({
+			"debug": true,
+			"secret_key": "from-profile",
+		}),
+	);
+
+	// Act
+	let settings: LayeredSettings = SettingsBuilder::new()
+		.with_merge_strategy(MergeStrategy::Shallow)
+		.add_source(base)
+		.add_source(profile)
+		.build_composed()
+		.unwrap();
+
+	// Assert: profile values won wholesale; base's `security` defaulted
+	// (proving it was dropped, not preserved).
+	assert!(settings.core.debug);
+	assert_eq!(settings.core.secret_key, "from-profile");
+	assert!(!settings.core.security.secure_ssl_redirect);
+}


### PR DESCRIPTION
## Summary

- Adds `MergeStrategy { Shallow, Deep }` to `SettingsBuilder`.
- Promotes the existing `deep_merge` helper from `pub(crate)` test
  utility into a new `settings::merge` module so the builder can reuse it
  (refactor commit landed first).
- Wires `build_composed::<T>()` to default to `Deep`; `build()` keeps
  `Shallow` to preserve env-source / flat-key composition.
- Re-exports `MergeStrategy` from `settings::` and the prelude.
- Updates `settings::fragment` docs to describe both merge semantics.

## Type of Change

- [x] Enhancement / new feature
- [x] No breaking change for `build()` (default unchanged)
- [x] Default change for `build_composed()` (`Shallow` → `Deep`) — opt out
      via `with_merge_strategy(MergeStrategy::Shallow)`

## Motivation and Context

Today, `SettingsBuilder::build()` performs a shallow top-level-key
merge. This forces every environment-specific TOML to redeclare the
**entire** content of each section that the profile touches. Defining
`[core]` in `local.toml` discards `[core.security]` and
`[core.databases.default]` from `base.toml`, even when the profile only
intends to flip `debug = true`. Downstream `kent8192/reinhardt-cloud`
keeps a duplicate `[core]` block in every profile TOML purely to work
around this.

`Deep` is applied unconditionally inside `build_composed::<T>()` (no
need to enumerate "section keys" — the existing helper already only
recurses when both sides are objects, which leaves flat-key fallback
paths untouched).

Fixes #4260
Refs #3879 (same root cause; that PR added a flat-key warning, this PR
gives users a way to actually compose layered configs).

## How Was This Tested

Two-commit history:

1. `refactor(conf): extract deep_merge into shared settings::merge module`
   — pure code move, behaviour-preserving.
2. `feat(conf): add MergeStrategy with Deep default for build_composed`
   — feature itself, plus 5 new integration tests.

Verification on the resulting tree:

- [x] `cargo check -p reinhardt-conf --tests --all-features`
- [x] `cargo nextest run -p reinhardt-conf --all-features` — **721/721 PASS**
      (5 new `tests/merge_strategy.rs` cases included)
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`

New tests cover:

- `build()` + `Shallow` default — legacy replacement behaviour preserved
- `build()` + explicit `Deep` — nested siblings preserved
- `build()` + `Deep` — top-level scalars (e.g. `redis_url`) still replace
- `build_composed()` defaults to `Deep`
- `build_composed()` + explicit `Shallow` — opt-out works

## Checklist

- [x] Code follows the project's style guidelines
- [x] All comments are in English
- [x] Tests pass locally
- [x] No `todo!()` / `// TODO` / `// FIXME` introduced
- [x] PR title follows Conventional Commits
- [x] PR is linked to issue via `Fixes #4260`
- [x] Documentation updated (`settings::fragment` module docs)

## Labels to Apply

- `enhancement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)