### PR TITLE
fix(examples): make `cargo make runserver` launch the dev server

### DIFF
--- a/examples/examples-tutorial-basis/Makefile.toml
+++ b/examples/examples-tutorial-basis/Makefile.toml
@@ -23,7 +23,7 @@ CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = ["CARGO_TARGE
 [tasks.runserver]
 description = "Start the development server (auto-reloads on changes)"
 command = "cargo"
-args = ["run", "runserver"]
+args = ["run", "--bin", "examples-tutorial-basis", "--", "runserver", "--with-pages"]
 
 # ============================================================================
 # Database Migrations

--- a/examples/examples-tutorial-rest/Makefile.toml
+++ b/examples/examples-tutorial-rest/Makefile.toml
@@ -23,7 +23,7 @@ CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = ["CARGO_TARGE
 [tasks.runserver]
 description = "Start the development server"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "runserver"]
+args = ["run", "--bin", "examples-tutorial-rest", "--", "runserver"]
 
 # ============================================================================
 # Database Migrations

--- a/examples/examples-twitter/Makefile.toml
+++ b/examples/examples-twitter/Makefile.toml
@@ -24,7 +24,7 @@ CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = ["CARGO_TARGE
 description = "Start the development server"
 dependencies = ["docker-up"]
 command = "cargo"
-args = ["run", "runserver"]
+args = ["run", "--bin", "examples-twitter", "--", "runserver", "--with-pages"]
 
 # ============================================================================
 # Docker Services


### PR DESCRIPTION
## Summary

Fix `[tasks.runserver]` in three examples so `cargo make runserver` actually launches the dev server.

- `examples-tutorial-basis` and `examples-twitter`: replace the broken `cargo run runserver` (which made cargo search for a binary named `runserver`) with `cargo run --bin <name> -- runserver --with-pages`. Both examples enable the `pages` feature.
- `examples-tutorial-rest`: add the missing `--` separator. REST-only example, so no `--with-pages`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Fixes #4268.

New contributors following the README (`cargo make runserver`) hit a `no bin target named 'runserver'` error in `examples-tutorial-basis` and `examples-twitter`, and silently rely on the missing `--` separator in `examples-tutorial-rest`. The fix matches what each example actually needs:

| Example | `pages` feature | `--with-pages` | Notes |
|---|---|---|---|
| tutorial-basis | yes | yes | Polls tutorial (WASM + SSR) |
| tutorial-rest | no | no | Snippets REST API (`db-sqlite`) |
| twitter | yes | yes | full-stack Twitter clone; keeps `docker-up` dep |

## How Was This Tested

- `cargo run --bin examples-tutorial-basis -- runserver --help` confirms `--with-pages` is a real framework flag (defined at `crates/reinhardt-commands/src/builtin.rs:1324`).
- `cargo make showurls` from `examples-tutorial-basis` → registers **10 URL patterns** (Polls tutorial), exit 0.
- `cargo make showurls` from `examples-tutorial-rest` → registers **5 URL patterns** (Snippets REST API), exit 0.
- `cargo make --list-all-steps` from `examples-twitter` → Makefile.toml parses, all tasks listed (skipped full server startup because `docker-up` dependency requires Docker Desktop running locally).
- Empirical check on cargo 1.94: positional args (including short flags like `-v`) after `--bin <name>` are passed through to the binary, so existing `runserver-v/-vv/-vvv` and other non-runserver tasks remain functional without any change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added/updated tests where applicable (manual verification via `cargo make showurls` in both built examples)
- [x] New and existing tests pass locally with my changes
- [x] No framework documentation update needed (Makefile.toml-only; README's UX is unchanged)

## Labels to Apply

- `bug` — runserver task was non-functional in two of the three examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)