### PR TITLE
fix(examples): repair `cargo make runserver` for tutorial-basis and tutorial-rest

### DIFF
--- a/examples/examples-tutorial-basis/Cargo.toml
+++ b/examples/examples-tutorial-basis/Cargo.toml
@@ -4,18 +4,13 @@ version = "0.1.0-alpha.1"
 edition = "2024"
 publish = false
 description = "Reinhardt basis tutorial example - Polling application with Pages"
-default-run = "examples-tutorial-basis"
+default-run = "manage"
 
 [lib]
 crate-type = ["cdylib", "rlib"]  # cdylib for WASM, rlib for server
 
-[[bin]]
-name = "examples-tutorial-basis"
-path = "src/bin/manage.rs"
-
-[[bin]]
-name = "manage"
-path = "src/bin/manage.rs"
+# The `manage` binary is auto-discovered from src/bin/manage.rs, matching the
+# canonical `cargo run --bin manage -- runserver` form documented in README.
 
 [dependencies]
 # Common dependencies (both WASM and server)

--- a/examples/examples-tutorial-basis/Makefile.toml
+++ b/examples/examples-tutorial-basis/Makefile.toml
@@ -23,7 +23,7 @@ CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = ["CARGO_TARGE
 [tasks.runserver]
 description = "Start the development server (auto-reloads on changes)"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "--", "runserver", "--with-pages"]
+args = ["run", "--bin", "manage", "--", "runserver", "--with-pages"]
 
 # ============================================================================
 # Database Migrations
@@ -32,17 +32,17 @@ args = ["run", "--bin", "examples-tutorial-basis", "--", "runserver", "--with-pa
 [tasks.makemigrations]
 description = "Create new migrations based on model changes"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "makemigrations"]
+args = ["run", "--bin", "manage", "makemigrations"]
 
 [tasks.makemigrations-app]
 description = "Create new migrations for a specific app (usage: cargo make makemigrations-app -- <app_label>)"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "makemigrations", "${@}"]
+args = ["run", "--bin", "manage", "makemigrations", "${@}"]
 
 [tasks.migrate]
 description = "Apply database migrations"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "migrate"]
+args = ["run", "--bin", "manage", "migrate"]
 
 # ============================================================================
 # Static Files
@@ -51,7 +51,7 @@ args = ["run", "--bin", "examples-tutorial-basis", "migrate"]
 [tasks.collectstatic]
 description = "Collect static files into STATIC_ROOT"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "collectstatic"]
+args = ["run", "--bin", "manage", "collectstatic"]
 
 # ============================================================================
 # Project Management
@@ -60,17 +60,17 @@ args = ["run", "--bin", "examples-tutorial-basis", "collectstatic"]
 [tasks.check]
 description = "Check the project for common issues"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "check"]
+args = ["run", "--bin", "manage", "check"]
 
 [tasks.showurls]
 description = "Display all registered URL patterns"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "showurls"]
+args = ["run", "--bin", "manage", "showurls"]
 
 [tasks.shell]
 description = "Run an interactive Rust shell (REPL)"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "shell"]
+args = ["run", "--bin", "manage", "shell"]
 
 # ============================================================================
 # Testing
@@ -183,7 +183,7 @@ description = "Build WASM in debug mode and collect static files"
 dependencies = ["wasm-bindgen-dev"]
 script = '''
 echo "Running collectstatic..."
-cargo run --bin examples-tutorial-basis collectstatic --no-input
+cargo run --bin manage collectstatic --no-input
 echo "✓ WASM build and collectstatic completed"
 '''
 
@@ -224,7 +224,7 @@ description = "Build WASM in release mode with optimization and collect static f
 dependencies = ["wasm-finalize-release"]
 script = '''
 echo "Running collectstatic..."
-cargo run --bin examples-tutorial-basis collectstatic --no-input
+cargo run --bin manage collectstatic --no-input
 echo "✓ WASM release build and collectstatic completed"
 '''
 
@@ -288,7 +288,7 @@ fi
 
 echo "🚀 Starting development server with WASM frontend..."
 # wasm-build-dev already produced fresh artifacts; skip runserver's own rebuild.
-cargo run --bin examples-tutorial-basis -- runserver --with-pages --noreload --no-override-wasm
+cargo run --bin manage -- runserver --with-pages --noreload --no-override-wasm
 '''
 
 [tasks.dev-release]
@@ -300,7 +300,7 @@ script = '''
 #!/bin/bash
 echo "🚀 Starting server with optimized WASM frontend..."
 # wasm-build-release already produced optimized artifacts; skip runserver's own rebuild.
-cargo run --release --bin examples-tutorial-basis -- runserver --with-pages --noreload --no-override-wasm
+cargo run --release --bin manage -- runserver --with-pages --noreload --no-override-wasm
 '''
 
 # ============================================================================
@@ -318,14 +318,14 @@ dependencies = ["fmt-check", "clippy-check", "build", "test"]
 [tasks.runserver-v]
 description = "Start the development server with verbose output"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "runserver", "-v"]
+args = ["run", "--bin", "manage", "runserver", "-v"]
 
 [tasks.runserver-vv]
 description = "Start the development server with very verbose output"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "runserver", "-vv"]
+args = ["run", "--bin", "manage", "runserver", "-vv"]
 
 [tasks.runserver-vvv]
 description = "Start the development server with maximum verbosity"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-basis", "runserver", "-vvv"]
+args = ["run", "--bin", "manage", "runserver", "-vvv"]

--- a/examples/examples-tutorial-basis/settings/base.toml
+++ b/examples/examples-tutorial-basis/settings/base.toml
@@ -1,20 +1,16 @@
 # Base settings for examples-tutorial-basis
+#
+# Keys are limited to fields actually consumed by Reinhardt's settings
+# fragments (CoreSettings, SecuritySettings, DatabaseConfig). Django-style
+# keys such as `templates`, `static_url`, `language_code`, `time_zone`, etc.
+# are not yet wired into the framework, so they are intentionally omitted to
+# avoid implying they take effect here.
+
 [core]
 debug = false
 secret_key = "CHANGE_THIS_IN_PRODUCTION"
 allowed_hosts = []
 installed_apps = []
-templates = []
-static_url = "/static/"
-staticfiles_dirs = []
-media_url = "/media/"
-language_code = "en-us"
-time_zone = "UTC"
-use_i18n = true
-use_tz = true
-default_auto_field = "BigAutoField"
-admins = []
-managers = []
 middleware = []
 root_urlconf = ""
 
@@ -26,6 +22,9 @@ session_cookie_secure = false
 csrf_cookie_secure = false
 append_slash = true
 
-[core.databases.default]
+# Top-level [database] is the canonical schema consumed by
+# `reinhardt_db::connection::get_database_url_from_env_or_settings`.
+# See README "With Database" section and reinhardt_conf::settings::DatabaseConfig.
+[database]
 engine = "sqlite"
 name = "db.sqlite3"

--- a/examples/examples-tutorial-basis/settings/ci.toml
+++ b/examples/examples-tutorial-basis/settings/ci.toml
@@ -1,4 +1,10 @@
-# CI environment settings (committed, used by GitHub Actions)
+# CI environment settings (committed, used by GitHub Actions).
+#
+# `CoreSettings` is registered as `#[settings(section = "core")]`, so its
+# fields must live under `[core]` to override values from base.toml. The
+# `[database]` section is consumed at the top level by reinhardt-db.
+
+[core]
 debug = false
 secret_key = "ci-testing-secret-key-not-for-production"
 

--- a/examples/examples-tutorial-basis/settings/local.example.toml
+++ b/examples/examples-tutorial-basis/settings/local.example.toml
@@ -1,4 +1,9 @@
 # Local development settings
 # Copy to local.toml: cp local.example.toml local.toml
+#
+# CoreSettings is registered as `#[settings(section = "core")]`, so its
+# fields must live under `[core]` to override values from base.toml.
+
+[core]
 debug = true
 secret_key = "local-development-secret-key"

--- a/examples/examples-tutorial-rest/Cargo.toml
+++ b/examples/examples-tutorial-rest/Cargo.toml
@@ -4,15 +4,10 @@ version = "0.1.0-alpha.1"
 edition = "2024"
 publish = false
 description = "Reinhardt REST tutorial example - Code snippet management API"
-default-run = "examples-tutorial-rest"
+default-run = "manage"
 
-[[bin]]
-name = "examples-tutorial-rest"
-path = "src/bin/manage.rs"
-
-[[bin]]
-name = "manage"
-path = "src/bin/manage.rs"
+# The `manage` binary is auto-discovered from src/bin/manage.rs, matching the
+# canonical `cargo run --bin manage -- runserver` form documented in README.
 
 [dependencies]
 reinhardt = { workspace = true, features = [

--- a/examples/examples-tutorial-rest/Makefile.toml
+++ b/examples/examples-tutorial-rest/Makefile.toml
@@ -23,7 +23,7 @@ CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = ["CARGO_TARGE
 [tasks.runserver]
 description = "Start the development server"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "--", "runserver"]
+args = ["run", "--bin", "manage", "--", "runserver"]
 
 # ============================================================================
 # Database Migrations
@@ -32,12 +32,12 @@ args = ["run", "--bin", "examples-tutorial-rest", "--", "runserver"]
 [tasks.makemigrations]
 description = "Create new migrations based on model changes"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "makemigrations"]
+args = ["run", "--bin", "manage", "makemigrations"]
 
 [tasks.migrate]
 description = "Apply database migrations"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "migrate"]
+args = ["run", "--bin", "manage", "migrate"]
 
 # ============================================================================
 # Testing
@@ -112,42 +112,42 @@ args = ["clean"]
 [tasks.makemigrations-app]
 description = "Create new migrations for a specific app (usage: cargo make makemigrations-app -- <app_label>)"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "makemigrations", "${@}"]
+args = ["run", "--bin", "manage", "makemigrations", "${@}"]
 
 [tasks.collectstatic]
 description = "Collect static files into STATIC_ROOT"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "collectstatic"]
+args = ["run", "--bin", "manage", "collectstatic"]
 
 [tasks.check]
 description = "Check the project for common issues"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "check"]
+args = ["run", "--bin", "manage", "check"]
 
 [tasks.showurls]
 description = "Display all registered URL patterns"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "showurls"]
+args = ["run", "--bin", "manage", "showurls"]
 
 [tasks.shell]
 description = "Run an interactive Rust shell (REPL)"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "shell"]
+args = ["run", "--bin", "manage", "shell"]
 
 [tasks.runserver-v]
 description = "Start the development server with verbose output"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "runserver", "-v"]
+args = ["run", "--bin", "manage", "runserver", "-v"]
 
 [tasks.runserver-vv]
 description = "Start the development server with very verbose output"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "runserver", "-vv"]
+args = ["run", "--bin", "manage", "runserver", "-vv"]
 
 [tasks.runserver-vvv]
 description = "Start the development server with maximum verbosity"
 command = "cargo"
-args = ["run", "--bin", "examples-tutorial-rest", "runserver", "-vvv"]
+args = ["run", "--bin", "manage", "runserver", "-vvv"]
 
 # ============================================================================
 # CI/CD Workflow

--- a/examples/examples-tutorial-rest/settings/base.toml
+++ b/examples/examples-tutorial-rest/settings/base.toml
@@ -1,20 +1,16 @@
 # Base settings for examples-tutorial-rest
+#
+# Keys are limited to fields actually consumed by Reinhardt's settings
+# fragments (CoreSettings, SecuritySettings, DatabaseConfig). Django-style
+# keys such as `templates`, `static_url`, `language_code`, `time_zone`, etc.
+# are not yet wired into the framework, so they are intentionally omitted to
+# avoid implying they take effect here.
+
 [core]
 debug = false
 secret_key = "CHANGE_THIS_IN_PRODUCTION"
 allowed_hosts = []
 installed_apps = []
-templates = []
-static_url = "/static/"
-staticfiles_dirs = []
-media_url = "/media/"
-language_code = "en-us"
-time_zone = "UTC"
-use_i18n = true
-use_tz = true
-default_auto_field = "BigAutoField"
-admins = []
-managers = []
 middleware = []
 root_urlconf = ""
 
@@ -26,6 +22,9 @@ session_cookie_secure = false
 csrf_cookie_secure = false
 append_slash = true
 
-[core.databases.default]
+# Top-level [database] is the canonical schema consumed by
+# `reinhardt_db::connection::get_database_url_from_env_or_settings`.
+# See README "With Database" section and reinhardt_conf::settings::DatabaseConfig.
+[database]
 engine = "sqlite"
 name = "db.sqlite3"

--- a/examples/examples-tutorial-rest/settings/ci.toml
+++ b/examples/examples-tutorial-rest/settings/ci.toml
@@ -1,4 +1,10 @@
-# CI environment settings (committed, used by GitHub Actions)
+# CI environment settings (committed, used by GitHub Actions).
+#
+# `CoreSettings` is registered as `#[settings(section = "core")]`, so its
+# fields must live under `[core]` to override values from base.toml. The
+# `[database]` section is consumed at the top level by reinhardt-db.
+
+[core]
 debug = false
 secret_key = "ci-testing-secret-key-not-for-production"
 

--- a/examples/examples-tutorial-rest/settings/local.example.toml
+++ b/examples/examples-tutorial-rest/settings/local.example.toml
@@ -1,4 +1,9 @@
 # Local development settings
 # Copy to local.toml: cp local.example.toml local.toml
+#
+# CoreSettings is registered as `#[settings(section = "core")]`, so its
+# fields must live under `[core]` to override values from base.toml.
+
+[core]
 debug = true
 secret_key = "local-development-secret-key"


### PR DESCRIPTION
## Summary

After #4269 corrected the `cargo make runserver` invocation form, two
follow-up problems remained in `examples-tutorial-basis` and
`examples-tutorial-rest`:

1. **Duplicate `bin` target warning.** Both Cargo manifests declared an
   `examples-tutorial-*` bin alongside an explicit `manage` bin, both
   pointing at `src/bin/manage.rs`; Cargo's autobins also registered
   `manage`, producing a "file present in multiple build targets"
   warning.
2. **Database configuration not found.** `runserver --with-pages`
   eventually calls
   `reinhardt_db::connection::get_database_url_from_env_or_settings`,
   which expects a top-level `[database]` (or `[databases.default]`)
   section. The example settings used Django-style
   `[core.databases.default]` instead.

This PR fixes both, and additionally cleans up Django-carryover keys
under `[core]` that no `CoreSettings` field consumes (which previously
gave a misleading impression that they took effect).

## Changes

### Commit 1 — `fix(examples): unify tutorial binaries on `manage``

- Drop the duplicate `[[bin]]` alias on both tutorial Cargo manifests
  and rely on autobins to pick up `src/bin/manage.rs` as the single
  `manage` binary.
- Set `default-run = "manage"`.
- Update every `Makefile.toml` task to use `cargo run --bin manage`,
  matching the canonical form documented in `README.md`.

### Commit 2 — `refactor(examples): align tutorial settings with Reinhardt schema`

- Move the SQLite database config from `[core.databases.default]` to
  top-level `[database]` so it is consumed by `reinhardt-db`.
- Remove Django-carryover keys (`templates`, `static_url`,
  `staticfiles_dirs`, `media_url`, `language_code`, `time_zone`,
  `use_i18n`, `use_tz`, `default_auto_field`, `admins`, `managers`).
- Move `debug` / `secret_key` overrides in `ci.toml` and
  `local.example.toml` under `[core]` (CoreSettings is registered as
  `section = "core"`).

## How Was This Tested

Local verification in a worktree:

```bash
cd examples/examples-tutorial-basis
cargo make runserver
```

Observed output (relevant portion):

```
Execute Command: "cargo" "run" "--bin" "manage" "--" "runserver" "--with-pages"
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.90s
[VERBOSE] Synced DATABASE_URL from settings configuration
[VERBOSE] ORM database initialized
[INFO] 💾 Database: sqlite:db.sqlite3 (connected)
[INFO] Building pages WASM for examples-tutorial-basis...
```

- ✅ `multiple build targets` warning is gone.
- ✅ Database is resolved from the new top-level `[database]` section.
- ✅ Pages WASM build phase is reached (subsequent WASM tooling
  requirement is outside the scope of this PR).

Also verified `cargo run --bin manage -- check` succeeds with the new
settings layout.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code style / refactor (no functional change, but improves clarity)
- [ ] New feature
- [ ] Breaking change

## Motivation and Context

Issue #4273 — `cargo make runserver` could not launch either tutorial
example after #4269 due to duplicate-bin warnings and a
schema-mismatch in the database settings.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (Makefile.toml comments)
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

## Labels to Apply

- `bug`
- `examples`

## Related Issues

Fixes #4273
Refs #4268, #4269

## Follow-up Work

The underlying asymmetry — that `reinhardt-db` re-loads the settings
TOML in `get_database_url_from_env_or_settings` rather than consuming
the already-built `ProjectSettings` — is being tracked separately so
that the loader can read from `CoreSettings::databases` consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)