### PR TITLE
fix(test/msw): repair wasm32 build + expose facade msw feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,10 @@ di = ["reinhardt-di", "reinhardt-di/params", "reinhardt-di/macros", "reinhardt-d
 test = ["reinhardt-test"]
 testcontainers = ["test", "reinhardt-test/testcontainers"]
 server-fn-test = ["test", "reinhardt-test/server-fn-test"]
+# MSW (Mock Service Worker) for WASM testing — exposes
+# `reinhardt::test::msw::MockServiceWorker` and triggers `MockableServerFn`
+# impl generation for `#[server_fn]` in downstream crates.
+msw = ["test", "pages", "reinhardt-test/msw", "reinhardt-pages/msw"]
 openapi = ["reinhardt-rest", "reinhardt-rest/openapi", "rest", "dep:inventory"]
 openapi-router = ["reinhardt-openapi", "openapi", "reinhardt-commands/openapi-router"]
 reinhardt-browsable-api = ["reinhardt-rest", "reinhardt-rest/browsable-api"]

--- a/crates/reinhardt-test/src/msw/interceptor.rs
+++ b/crates/reinhardt-test/src/msw/interceptor.rs
@@ -179,10 +179,21 @@ mod wasm_impl {
 							// Normalize plain objects and arrays by constructing a Headers
 							// instance, which accepts both `Record<string, string>` and
 							// `[string, string][]` forms per the Fetch spec.
-							Headers::new_with_str_sequence_sequence(&h)
-								.or_else(|_| Headers::new_with_str_mapping(&h))
-								.ok()
-								.map(|normalized| extract_headers(&normalized))
+							//
+							// (Fixes #4287) web-sys 0.3.98 removed
+							// `Headers::new_with_str_mapping`. Fall back through
+							// `new_with_record_from_str_to_str` when the input is a plain
+							// object (`js_sys::Object`); skip the fallback otherwise.
+							let primary = Headers::new_with_str_sequence_sequence(&h);
+							let normalized = match primary {
+								Ok(h) => Some(h),
+								Err(_) => h
+									.dyn_ref::<js_sys::Object>()
+									.and_then(|obj| {
+										Headers::new_with_record_from_str_to_str(obj).ok()
+									}),
+							};
+							normalized.map(|n| extract_headers(&n))
 						}
 					})
 					.unwrap_or_default()
@@ -253,9 +264,12 @@ mod wasm_impl {
 		let func: &js_sys::Function = original.unchecked_ref();
 		// Use the window (or globalThis) as the receiver to avoid "Illegal invocation"
 		// errors that occur when calling `window.fetch` with `this = null`.
+		// (Fixes #4287) `js_sys::global()` in newer js-sys returns `Object` rather
+		// than `JsValue`, so adapt it through `JsValue::from` before the
+		// `Option::unwrap_or_else` chain that expects a uniform `JsValue` output.
 		let receiver = web_sys::window()
 			.map(JsValue::from)
-			.unwrap_or_else(js_sys::global);
+			.unwrap_or_else(|| JsValue::from(js_sys::global()));
 		let result = if !init.is_undefined() && !init.is_null() {
 			func.call2(&receiver, input, init)?
 		} else {


### PR DESCRIPTION
## Summary

Repairs `reinhardt-test/msw` for current web-sys/js-sys versions and exposes a top-level `msw` feature on the `reinhardt-web` facade so downstream consumers can enable MSW without reaching past the facade.

## Type of Change

- [x] Bug fix (web-sys 0.3.98 compatibility)
- [x] New feature (facade `msw` flag — non-breaking, additive)

## Motivation and Context

Surfaced while migrating `examples-tutorial-basis` tests off the deprecated `mock_server_fn` API in #4275 / PR #4279.

1. `crates/reinhardt-test/src/msw/interceptor.rs:183` called `Headers::new_with_str_mapping`, which web-sys 0.3.98 removed. The right replacement for the `Record<string, string>` fallback is `Headers::new_with_record_from_str_to_str(&Object)`. The code now downcasts via `JsCast::dyn_ref::<js_sys::Object>()` before falling back.
2. `interceptor.rs:269` called `js_sys::global` inside `Option::unwrap_or_else`; js-sys's `global()` now returns `Object`, not `JsValue`, breaking the inferred `Option<JsValue>::unwrap_or_else(F) -> JsValue` constraint. The fix wraps it through `JsValue::from`.
3. The `reinhardt-web` facade had no top-level `msw` feature, forcing downstream consumers (examples) to add a direct `reinhardt-test = { features = ["msw"] }` dev-dependency in violation of examples/CLAUDE.md DM-1. This PR adds `msw = ["test", "pages", "reinhardt-test/msw", "reinhardt-pages/msw"]` so the example can use `reinhardt = { features = ["test", "msw"] }`.

## How Was This Tested

- `cargo check -p reinhardt-test --features msw --target wasm32-unknown-unknown`: clean (6.65s)
- Patched the example workspace via `[patch.crates-io]` overlay and exercised via `wasm-pack test --headless --chrome --features msw`. The `Headers`/`global` errors no longer surface; remaining errors in the example are unrelated structural issues (native-only bins compiled by `wasm-pack test`'s blanket `--tests`, and a marker-generation pathway in `#[server_fn]` that requires further investigation) and are out of scope here.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (the wasm32 build leaves only pre-existing deprecation warnings)
- [ ] CI (delegated)
- [x] The new facade `msw` feature is additive and non-breaking

## Labels to Apply

- `bug`, `testing`

## Related Issues

Fixes #4287
Refs #4275, #3283
Unblocks PR #4279

🤖 Generated with [Claude Code](https://claude.com/claude-code)