### PR TITLE
style(test/msw): apply rustfmt to interceptor.rs (post-#4288 fmt drift)

### DIFF
--- a/crates/reinhardt-test/src/msw/interceptor.rs
+++ b/crates/reinhardt-test/src/msw/interceptor.rs
@@ -187,11 +187,9 @@ mod wasm_impl {
 							let primary = Headers::new_with_str_sequence_sequence(&h);
 							let normalized = match primary {
 								Ok(h) => Some(h),
-								Err(_) => h
-									.dyn_ref::<js_sys::Object>()
-									.and_then(|obj| {
-										Headers::new_with_record_from_str_to_str(obj).ok()
-									}),
+								Err(_) => h.dyn_ref::<js_sys::Object>().and_then(|obj| {
+									Headers::new_with_record_from_str_to_str(obj).ok()
+								}),
 							};
 							normalized.map(|n| extract_headers(&n))
 						}


### PR DESCRIPTION
## Summary

`cargo fmt --check` on `main` post-#4288 fails on the multi-line `.dyn_ref::<js_sys::Object>().and_then(...)` chain in the Headers fallback. rustfmt prefers the single-line form. Surfaced as the only Format Check failure on PR #4293; fixing in a focused PR so other open branches that pull main don't all surface the same failure.

## Type of Change

- [x] Style (no functional change)

## Motivation and Context

The chain was written across multiple lines for readability in #4288. `cargo fmt` collapses it to one line; without this change, every PR rebased on or branched from the post-#4288 main inherits a Format Check failure.

## How Was This Tested

- `cargo fmt --check`: clean

## Checklist

- [x] My code follows the project's style guidelines (`cargo fmt --check` clean)
- [x] No functional change
- [x] Smallest possible diff (3 ins / 5 del, 1 file)

## Labels to Apply

- `dependencies` (style/CI-fixup category)

## Related Issues

Refs #4287, PR #4288, PR #4293

🤖 Generated with [Claude Code](https://claude.com/claude-code)