### PR TITLE
fix(admin): unblock rc.29 release by fully-qualifying server_fn arg types

### DIFF
--- a/crates/reinhardt-admin/src/server/create.rs
+++ b/crates/reinhardt-admin/src/server/create.rs
@@ -5,7 +5,7 @@
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite};
-use crate::types::{MutationRequest, MutationResponse};
+use crate::types::MutationResponse;
 use reinhardt_di::Depends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;
@@ -53,12 +53,12 @@ use super::validation::validate_mutation_data;
 #[server_fn]
 pub async fn create_record(
 	model_name: String,
-	request: MutationRequest,
+	request: crate::types::MutationRequest,
 	#[inject] site: Depends<AdminSite>,
 	#[inject] db: Depends<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
 	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
-) -> Result<MutationResponse, ServerFnError> {
+) -> Result<crate::types::MutationResponse, ServerFnError> {
 	// CSRF token validation (double-submit cookie pattern)
 	require_csrf_token(&request.csrf_token, &http_request.inner().headers)?;
 

--- a/crates/reinhardt-admin/src/server/delete.rs
+++ b/crates/reinhardt-admin/src/server/delete.rs
@@ -4,9 +4,7 @@
 
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
-use crate::adapters::{
-	AdminDatabase, AdminRecord, AdminSite, BulkDeleteRequest, BulkDeleteResponse,
-};
+use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, BulkDeleteResponse};
 use crate::types::MutationResponse;
 use reinhardt_di::Depends;
 #[cfg(server)]
@@ -54,7 +52,7 @@ pub async fn delete_record(
 	#[inject] db: Depends<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
 	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
-) -> Result<MutationResponse, ServerFnError> {
+) -> Result<crate::types::MutationResponse, ServerFnError> {
 	// CSRF token validation (double-submit cookie pattern)
 	require_csrf_token(&csrf_token, &http_request.inner().headers)?;
 
@@ -134,12 +132,12 @@ pub async fn delete_record(
 #[server_fn]
 pub async fn bulk_delete_records(
 	model_name: String,
-	request: BulkDeleteRequest,
+	request: crate::adapters::BulkDeleteRequest,
 	#[inject] site: Depends<AdminSite>,
 	#[inject] db: Depends<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
 	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
-) -> Result<BulkDeleteResponse, ServerFnError> {
+) -> Result<crate::adapters::BulkDeleteResponse, ServerFnError> {
 	// CSRF token validation (double-submit cookie pattern)
 	require_csrf_token(&request.csrf_token, &http_request.inner().headers)?;
 

--- a/crates/reinhardt-admin/src/server/export.rs
+++ b/crates/reinhardt-admin/src/server/export.rs
@@ -99,12 +99,12 @@ fn serialize_delimited(
 #[server_fn]
 pub async fn export_data(
 	model_name: String,
-	format: ExportFormat,
+	format: crate::adapters::ExportFormat,
 	#[inject] site: Depends<AdminSite>,
 	#[inject] db: Depends<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
 	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
-) -> Result<ExportResponse, ServerFnError> {
+) -> Result<crate::adapters::ExportResponse, ServerFnError> {
 	// Authentication and authorization check
 	let auth = AdminAuth::from_request(&http_request);
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;

--- a/crates/reinhardt-admin/src/server/import.rs
+++ b/crates/reinhardt-admin/src/server/import.rs
@@ -49,13 +49,13 @@ use super::limits::{MAX_IMPORT_FILE_SIZE, MAX_IMPORT_RECORDS};
 #[server_fn]
 pub async fn import_data(
 	model_name: String,
-	format: ImportFormat,
+	format: crate::adapters::ImportFormat,
 	data: Vec<u8>,
 	#[inject] site: Depends<AdminSite>,
 	#[inject] db: Depends<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
 	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
-) -> Result<ImportResponse, ServerFnError> {
+) -> Result<crate::adapters::ImportResponse, ServerFnError> {
 	// Authentication and authorization check
 	let auth = AdminAuth::from_request(&http_request);
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;

--- a/crates/reinhardt-admin/src/server/list.rs
+++ b/crates/reinhardt-admin/src/server/list.rs
@@ -5,8 +5,8 @@
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{
-	AdminDatabase, AdminRecord, AdminSite, ColumnInfo, FilterInfo, FilterType, ListQueryParams,
-	ListResponse, ModelAdmin,
+	AdminDatabase, AdminRecord, AdminSite, ColumnInfo, FilterInfo, FilterType, ListResponse,
+	ModelAdmin,
 };
 #[cfg(server)]
 use reinhardt_db::orm::{Filter, FilterCondition, FilterOperator, FilterValue};
@@ -99,11 +99,11 @@ fn build_columns(model_admin: &Arc<dyn ModelAdmin>) -> Vec<ColumnInfo> {
 #[server_fn]
 pub async fn get_list(
 	model_name: String,
-	params: ListQueryParams,
+	params: crate::adapters::ListQueryParams,
 	#[inject] site: Depends<AdminSite>,
 	#[inject] db: Depends<AdminDatabase>,
 	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
-) -> Result<ListResponse, ServerFnError> {
+) -> Result<crate::adapters::ListResponse, ServerFnError> {
 	// Get model admin and check permission
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
 	if !model_admin.has_view_permission(user.as_ref()).await {

--- a/crates/reinhardt-admin/src/server/update.rs
+++ b/crates/reinhardt-admin/src/server/update.rs
@@ -5,7 +5,7 @@
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite};
-use crate::types::{MutationRequest, MutationResponse};
+use crate::types::MutationResponse;
 use reinhardt_di::Depends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;
@@ -53,12 +53,12 @@ use super::validation::validate_mutation_data;
 pub async fn update_record(
 	model_name: String,
 	id: String,
-	request: MutationRequest,
+	request: crate::types::MutationRequest,
 	#[inject] site: Depends<AdminSite>,
 	#[inject] db: Depends<AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
 	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
-) -> Result<MutationResponse, ServerFnError> {
+) -> Result<crate::types::MutationResponse, ServerFnError> {
 	// CSRF token validation (double-submit cookie pattern)
 	require_csrf_token(&request.csrf_token, &http_request.inner().headers)?;
 

--- a/crates/reinhardt-di/tests/register_override.rs
+++ b/crates/reinhardt-di/tests/register_override.rs
@@ -11,7 +11,8 @@ use rstest::*;
 use serial_test::serial;
 
 use reinhardt_di::{
-	DependencyRegistry, DependencyScope, DiResult, InjectionContext, SingletonScope, global_registry,
+	DependencyRegistry, DependencyScope, DiResult, InjectionContext, SingletonScope,
+	global_registry,
 };
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/reinhardt-testkit/src/fixtures/di_overrides.rs
+++ b/crates/reinhardt-testkit/src/fixtures/di_overrides.rs
@@ -40,6 +40,11 @@ pub struct DiOverrides {
 	_guards: Vec<OverrideGuard>,
 }
 
+/// Seed closure that pre-populates a value into a freshly built
+/// `InjectionContext`'s request scope. Boxed so heterogeneous closures (one per
+/// `request` call) can be collected in a `Vec`.
+type RequestSeedFn = Box<dyn FnOnce(&InjectionContext) + Send + 'static>;
+
 /// Builder passed to the setup closure of
 /// [`injection_context_with_di_overrides`].
 pub struct DiOverrideBuilder<'a> {
@@ -52,7 +57,7 @@ pub struct DiOverrideBuilder<'a> {
 	// `guards` because seeds run once at context-build time and are then
 	// dropped, while guards must live for the entire test scope to keep their
 	// `register_override` mutations in effect.
-	request_seeds: Vec<Box<dyn FnOnce(&InjectionContext) + Send + 'static>>,
+	request_seeds: Vec<RequestSeedFn>,
 }
 
 impl<'a> DiOverrideBuilder<'a> {


### PR DESCRIPTION
## Summary

- Replace bare type names in six `#[server_fn]` signatures under `reinhardt-admin/src/server/` with fully-qualified paths (`crate::types::*` or `crate::adapters::*`), so the macro-generated scope can resolve them after the rc.29 regression
- Reflow the malformed `use` import in `crates/reinhardt-di/tests/register_override.rs` so `cargo make fmt-check` passes
- Extract `DiOverrideBuilder.request_seeds`'s boxed closure into a `RequestSeedFn` type alias to satisfy `clippy::type_complexity`

The release PR #4298 is failing on `main`-rooted commits with six CI checks red:
`Check / Cargo Check (lib|tests|bins-examples)`, `Clippy / Clippy Lint`, `TODO Check / Clippy TODO/unimplemented/dbg lint`, and `Format / Format Check`. None of `release-plz`'s commits touched Rust source, so the failures live on `main` itself; this PR repairs `main` so the release PR regenerates green.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement
- [ ] CI/CD or tooling change

## Motivation and Context

### Root cause (workaround applied here)

```text
error[E0425]: cannot find type `MutationRequest` in this scope
  --> crates/reinhardt-admin/src/server/create.rs:56:11
   |
56 |     request: MutationRequest,
   |              ^^^^^^^^^^^^^^^ not found in this scope
   |
   = help: consider importing this struct through its public re-export:
           crate::types::MutationRequest
```

`crate::types::MutationRequest` *is* already imported at the top of the file. The rustc hint reflects the fact that `#[server_fn]` (rc.29 of `reinhardt-pages-macros`) now expands the function signature into a scope that does not inherit the caller's `use` statements. Refs #4299, which tracks the upstream fix in the macro itself.

Six call sites were affected (one type each, except `MutationRequest` which appears twice):

| File | Type |
|---|---|
| `crates/reinhardt-admin/src/server/create.rs` | `MutationRequest`, `MutationResponse` |
| `crates/reinhardt-admin/src/server/update.rs` | `MutationRequest`, `MutationResponse` |
| `crates/reinhardt-admin/src/server/delete.rs` | `BulkDeleteRequest`, `BulkDeleteResponse`, `MutationResponse` |
| `crates/reinhardt-admin/src/server/export.rs` | `ExportFormat`, `ExportResponse` |
| `crates/reinhardt-admin/src/server/import.rs` | `ImportFormat`, `ImportResponse` |
| `crates/reinhardt-admin/src/server/list.rs` | `ListQueryParams`, `ListResponse` |

For DTO-shaped types (`MutationRequest`, `BulkDeleteRequest`, `ListQueryParams`, the `*Response` family) the absolute path is `crate::types::*`. For the cfg-aware enums `ExportFormat` / `ImportFormat`, the absolute path is `crate::adapters::*` so the existing server/client switch via `#[cfg(server)]` / `#[cfg(client)]` re-exports is preserved.

Function bodies are unchanged — the regression only affects the macro-expanded signature scope, and bodies continue to resolve via the in-module `use` statements.

### Adjacent fixes

- **Format Check** has been red on `main` since PR #4297 merged: the new `crates/reinhardt-di/tests/register_override.rs` file landed with an over-long `use` line. One `cargo fmt` invocation reflows the import.
- **`clippy::type_complexity`** is latent on `main` for the same reason. `DiOverrideBuilder.request_seeds: Vec<Box<dyn FnOnce(&InjectionContext) + Send + 'static>>` violates `clippy::type_complexity` (denied under `-D warnings`). The workspace clippy job masked it by aborting early on the E0425 errors above; once those are fixed clippy reaches testkit and fails. The fix here extracts a `RequestSeedFn` alias — no behavioural change.

## How Was This Tested

All commands run inside `/tmp/reinhardt-fix-ci-rc29-imports`:

- `cargo check --workspace --all --all-features` → exit 0
- `cargo check --workspace --all-features --tests` → exit 0
- `cargo make fmt-check` → `0 would be formatted, 2758 unchanged, 0 errors`
- `cargo make clippy-check` → exit 0 (no warnings, no errors)
- `cargo make clippy-todo-check` → exit 0

CI is expected to reproduce the same on the six previously-failing checks.

## Checklist

- [x] Code compiles without warnings (under `-D warnings`)
- [x] All existing tests still pass (compiled; runtime tests deferred to CI / TestContainers)
- [x] New code follows project style and conventions
- [x] Documentation updated where required (no public-API change)
- [x] Commits follow Conventional Commits format
- [x] PR description follows the template

## Labels to Apply

- `bug`
- `agent-suspect`

## Related Issues

Refs #4299 (root cause — pages-macros `server_fn` argument-type resolution regression)

Unblocks #4298 (rc.29 release PR).

## Additional Context

- This PR repairs `main`, not the release PR itself. After merge, `release-plz` regenerates the release PR on its next `main` push and CI should turn green.
- `agent-suspect` is applied per IL-3 because the fix was authored by Claude Code from a CI triage session; independent verification (by a separate agent context or a maintainer) is expected before the label is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
