### PR TITLE
fix(examples-tutorial-basis): rustfmt drift on polls components and mock tests

### DIFF
--- a/examples/examples-tutorial-basis/src/client/components/polls.rs
+++ b/examples/examples-tutorial-basis/src/client/components/polls.rs
@@ -359,37 +359,37 @@ pub fn polls_results(question_id: i64) -> Page {
 									class: "divide-y divide-gray-200",
 									{
 										Page::Fragment(
-										        load_results_signal
-										            .result()
-										            .map(|(_, choices, total)| {
-										                choices
-										                    .iter()
-										                    .map(|choice| {
-										                        let percentage = if total > 0 {
-										                            (choice.votes as f64 / total as f64 * 100.0) as i32
-										                        } else {
-										                            0
-										                        };
-										                        let choice_text = choice.choice_text.clone();
-										                        let votes = choice.votes;
-										                        page!(
-										                            | choice_text : String, votes : i32, percentage : i32 | { div
-										                            { class : "py-4", div { class :
-										                            "flex justify-between items-center mb-2", strong { {
-										                            choice_text } } span { class :
-										                            "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
-										                            { format!("{} votes", votes) } } } div { class :
-										                            "w-full bg-gray-200 rounded-full h-2.5", div { class :
-										                            "bg-brand h-2.5 rounded-full", role : "progressbar", style :
-										                            format!("width: {}%", percentage), aria_valuenow : percentage
-										                            .to_string(), aria_valuemin : "0", aria_valuemax : "100", {
-										                            format!("{}%", percentage) } } } } }
-										                        )(choice_text, votes, percentage)
-										                    })
-										                    .collect::<Vec<_>>()
-										            })
-										            .unwrap_or_default(),
-										    )
+												load_results_signal
+													.result()
+													.map(|(_, choices, total)| {
+														choices
+															.iter()
+															.map(|choice| {
+																let percentage = if total > 0 {
+																	(choice.votes as f64 / total as f64 * 100.0) as i32
+																} else {
+																	0
+																};
+																let choice_text = choice.choice_text.clone();
+																let votes = choice.votes;
+																page!(
+																	| choice_text : String, votes : i32, percentage : i32 | { div
+																	{ class : "py-4", div { class :
+																	"flex justify-between items-center mb-2", strong { {
+																	choice_text } } span { class :
+																	"inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
+																	{ format!("{} votes", votes) } } } div { class :
+																	"w-full bg-gray-200 rounded-full h-2.5", div { class :
+																	"bg-brand h-2.5 rounded-full", role : "progressbar", style :
+																	format!("width: {}%", percentage), aria_valuenow : percentage
+																	.to_string(), aria_valuemin : "0", aria_valuemax : "100", {
+																	format!("{}%", percentage) } } } } }
+																)(choice_text, votes, percentage)
+															})
+															.collect::<Vec<_>>()
+													})
+													.unwrap_or_default(),
+											)
 									}
 								}
 								div {

--- a/examples/examples-tutorial-basis/tests/wasm/polls_mock_test.rs
+++ b/examples/examples-tutorial-basis/tests/wasm/polls_mock_test.rs
@@ -21,10 +21,10 @@ wasm_bindgen_test_configure!(run_in_browser);
 use examples_tutorial_basis::client::components::polls::{
 	polls_detail, polls_index, polls_results,
 };
-use examples_tutorial_basis::shared::types::{ChoiceInfo, QuestionInfo, VoteRequest};
 use examples_tutorial_basis::server_fn::polls::{
 	get_question_detail, get_question_results, get_questions, vote,
 };
+use examples_tutorial_basis::shared::types::{ChoiceInfo, QuestionInfo, VoteRequest};
 use reinhardt::pages::component::Page;
 use reinhardt::pages::server_fn::ServerFnError;
 use reinhardt::test::msw::MockServiceWorker;


### PR DESCRIPTION
## Summary

Run \`cargo fmt\` over \`examples/examples-tutorial-basis/\` to clear the rustfmt drift currently failing \`Examples Tests / examples-tutorial-basis\` on release-plz PR #4301.

Two files reformatted, no semantic changes:

- \`examples/examples-tutorial-basis/src/client/components/polls.rs\` (indentation in a closure chain)
- \`examples/examples-tutorial-basis/tests/wasm/polls_mock_test.rs\` (\`use\` ordering for \`examples_tutorial_basis::shared::types\`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

\`examples/examples-tutorial-basis/\` is an independent cargo workspace, so the repo-root \`cargo make fmt-check\` does not recurse into it. The drift slipped past the standard PR fmt gate and surfaced only when release-plz regenerated PR #4301 and the conditional \`Examples Tests\` job ran.

## How Was This Tested

- \`cd examples/examples-tutorial-basis && cargo fmt --check\` → exit 0 after the fix
- No source logic changed; behavior identical

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review
- [x] All existing tests pass

## Related Issues

Fixes #4302

🤖 Generated with [Claude Code](https://claude.com/claude-code)