### PR TITLE
fix(commands/templates): switch settings scaffold to build_composed (Deep merge)

### DIFF
--- a/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
@@ -81,7 +81,9 @@ pub fn get_settings() -> ProjectSettings {
 			settings_dir.join(format!("{}.toml", profile_str)),
 		))
 		.build_composed::<ProjectSettings>()
-		.expect("Failed to build settings")
+		.unwrap_or_else(|err| {
+			panic!("Failed to build/compose settings for profile `{profile_str}`: {err}")
+		})
 }
 
 #[cfg(test)]

--- a/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
@@ -64,8 +64,11 @@ pub fn get_settings() -> ProjectSettings {
 	let base_dir = env::current_dir().expect("Failed to get current directory");
 	let settings_dir = base_dir.join("settings");
 
-	// Build settings by merging sources in priority order
-	let merged = SettingsBuilder::new()
+	// Build settings by merging sources in priority order.
+	// `build_composed::<T>()` uses `MergeStrategy::Deep` by default, so a
+	// single key in `production.toml` overrides only that key — sibling
+	// entries inside the same nested table inherit from `base.toml`.
+	SettingsBuilder::new()
 		.profile(profile)
 		// Lowest priority: Default values
 		.add_source(DefaultSource::new())
@@ -77,13 +80,8 @@ pub fn get_settings() -> ProjectSettings {
 		.add_source(TomlFileSource::new(
 			settings_dir.join(format!("{}.toml", profile_str)),
 		))
-		.build()
-		.expect("Failed to build settings");
-
-	// Convert MergedSettings to ProjectSettings
-	merged
-		.into_typed()
-		.expect("Failed to convert settings to ProjectSettings struct")
+		.build_composed::<ProjectSettings>()
+		.expect("Failed to build settings")
 }
 
 #[cfg(test)]

--- a/crates/reinhardt-commands/templates/project_restful_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/src/config/settings.rs.tpl
@@ -81,7 +81,9 @@ pub fn get_settings() -> ProjectSettings {
 			settings_dir.join(format!("{}.toml", profile_str)),
 		))
 		.build_composed::<ProjectSettings>()
-		.expect("Failed to build settings")
+		.unwrap_or_else(|err| {
+			panic!("Failed to build/compose settings for profile `{profile_str}`: {err}")
+		})
 }
 
 #[cfg(test)]

--- a/crates/reinhardt-commands/templates/project_restful_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/src/config/settings.rs.tpl
@@ -64,8 +64,11 @@ pub fn get_settings() -> ProjectSettings {
 	let base_dir = env::current_dir().expect("Failed to get current directory");
 	let settings_dir = base_dir.join("settings");
 
-	// Build settings by merging sources in priority order
-	let merged = SettingsBuilder::new()
+	// Build settings by merging sources in priority order.
+	// `build_composed::<T>()` uses `MergeStrategy::Deep` by default, so a
+	// single key in `production.toml` overrides only that key — sibling
+	// entries inside the same nested table inherit from `base.toml`.
+	SettingsBuilder::new()
 		.profile(profile)
 		// Lowest priority: Default values
 		.add_source(DefaultSource::new())
@@ -77,13 +80,8 @@ pub fn get_settings() -> ProjectSettings {
 		.add_source(TomlFileSource::new(
 			settings_dir.join(format!("{}.toml", profile_str)),
 		))
-		.build()
-		.expect("Failed to build settings");
-
-	// Convert MergedSettings to ProjectSettings
-	merged
-		.into_typed()
-		.expect("Failed to convert settings to ProjectSettings struct")
+		.build_composed::<ProjectSettings>()
+		.expect("Failed to build settings")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Replace \`.build().into_typed()\` with \`.build_composed::<ProjectSettings>()\` in both \`project_pages_template\` and \`project_restful_template\` so that scaffolded projects inherit the \`MergeStrategy::Deep\` default introduced in v0.1.0-rc.28.

With Deep merge, a single key in \`production.toml\` overrides only that key — sibling entries inside the same nested table inherit from \`base.toml\`. Under the previous Shallow default, users had to redeclare the entire parent table to change one nested key, which is the most common stumbling block for new scaffold users.

## Type of Change

- [x] Bug fix (template scaffold did not pick up the rc.28 best practice)

## How Was This Tested

- [x] Verified API surface against \`crates/reinhardt-conf/src/settings/builder.rs\` (\`build_composed<T: ComposedSettings>(self) -> Result<T, BuildError>\`, Deep default)
- [ ] CI: \`cargo test -p reinhardt-commands\` (template scaffolding integration tests)

## Related Issues

Refs #4304 (umbrella for rc.25–rc.28 template alignment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)