### PR TITLE
docs(commands/templates): document TOML interpolation and server_fn cross-target stub

### DIFF
--- a/crates/reinhardt-commands/templates/app_restful_template/views.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_restful_template/views.rs.tpl
@@ -22,3 +22,22 @@
 // ) -> ViewResult<Response> {
 //     Ok(Response::new(StatusCode::OK).with_body(user.email().to_string()))
 // }
+//
+// Generic DI for app services uses `Depends<T>` (rc.16+) — the replacement
+// for the deprecated `Arc<T>` / `Injected<T>` parameter form:
+//
+// use reinhardt::extract::Depends;
+//
+// #[get("/health/", name = "{{ app_name }}_health")]
+// pub async fn health(
+//     #[inject] svc: Depends<MyService>,
+// ) -> ViewResult<Response> {
+//     Ok(Response::new(StatusCode::OK).with_body(svc.status()))
+// }
+//
+// For declarative endpoint-level authorization, use `guard!()` (rc.16+):
+//
+// use reinhardt::guard;
+//
+// #[get("/admin/", name = "{{ app_name }}_admin", guards = guard!(IsStaff))]
+// pub async fn admin_only() -> ViewResult<Response> { /* ... */ }

--- a/crates/reinhardt-commands/templates/project_pages_template/src/client/lib.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/client/lib.rs.tpl
@@ -13,5 +13,11 @@ use super::router;
 pub fn main() -> Result<(), JsValue> {
 	ClientLauncher::new("#root")
 		.router(router::init_router)
+		// Optional builder hooks (since reinhardt-web v0.1.0-rc.23):
+		//   .intercept_links()                     // built-in SPA link interception
+		//   .before_launch(|| { /* setup */ })     // pre-mount lifecycle hook
+		//   .after_launch(|| { /* boot done */ })  // post-mount lifecycle hook
+		//   .on_path("/login", || { /* run on exact path */ })
+		//   .on_path_pattern("/users/{id}", |params| { /* path-driven side effect */ })
 		.launch()
 }

--- a/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
@@ -26,6 +26,19 @@
 //! - `production` → loads `production.toml`
 //!
 //! If `REINHARDT_ENV` is not set, it defaults to `local`.
+//!
+//! ## Environment Variable Interpolation
+//!
+//! `TomlFileSource` interpolates `${VAR}` syntax inside TOML values by
+//! default (since reinhardt-web v0.1.0-rc.27). Supported forms:
+//!
+//! - `${VAR}` — required; build fails if `VAR` is unset
+//! - `${VAR:-default}` — falls back to `default` when `VAR` is unset
+//! - `${VAR:?message}` — fails with `message` when `VAR` is unset
+//!
+//! Interpolated strings are typed-coerced at deserialization time, so
+//! `pool_size = "${DB_POOL_SIZE:-10}"` resolves directly to the field's
+//! declared Rust type (e.g. `u16`) without manual parsing.
 
 use reinhardt::conf::settings::builder::SettingsBuilder;
 use reinhardt::conf::settings::profile::Profile;

--- a/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
@@ -29,12 +29,13 @@
 //!
 //! ## Environment Variable Interpolation
 //!
-//! `TomlFileSource` interpolates `${VAR}` syntax inside TOML values by
-//! default (since reinhardt-web v0.1.0-rc.27). Supported forms:
+//! `TomlFileSource` interpolates `${VAR}` syntax inside TOML string values
+//! by default (since reinhardt-web v0.1.0-rc.27). The `${...}` syntax is
+//! not valid in non-string TOML literals. Supported forms:
 //!
-//! - `${VAR}` — required; build fails if `VAR` is unset
+//! - `${VAR}` — required; settings load fails if `VAR` is unset
 //! - `${VAR:-default}` — falls back to `default` when `VAR` is unset
-//! - `${VAR:?message}` — fails with `message` when `VAR` is unset
+//! - `${VAR:?message}` — settings load fails with `message` when `VAR` is unset
 //!
 //! Interpolated strings are typed-coerced at deserialization time, so
 //! `pool_size = "${DB_POOL_SIZE:-10}"` resolves directly to the field's

--- a/crates/reinhardt-commands/templates/project_pages_template/src/config/urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/config/urls.rs.tpl
@@ -16,6 +16,14 @@ pub fn routes() -> UnifiedRouter {
     //
     // Or register ViewSets:
     // router.register_viewset("users", user_viewset);
+    //
+    // For server-function endpoints in `mode = unified` builder chains, use
+    // `s.server_fn(marker)`. Since reinhardt-web v0.1.0-rc.28,
+    // `ServerRouterStub` carries a no-op `server_fn` stub, so the same
+    // builder chain compiles unchanged on `wasm32-unknown-unknown` — no
+    // `#[cfg(native)]` workaround is required at call sites:
+    //
+    // router.server(|s| s.server_fn(my_server_fn_marker));
 
     router
 }

--- a/crates/reinhardt-commands/templates/project_restful_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/src/config/settings.rs.tpl
@@ -26,6 +26,19 @@
 //! - `production` → loads `production.toml`
 //!
 //! If `REINHARDT_ENV` is not set, it defaults to `local`.
+//!
+//! ## Environment Variable Interpolation
+//!
+//! `TomlFileSource` interpolates `${VAR}` syntax inside TOML values by
+//! default (since reinhardt-web v0.1.0-rc.27). Supported forms:
+//!
+//! - `${VAR}` — required; build fails if `VAR` is unset
+//! - `${VAR:-default}` — falls back to `default` when `VAR` is unset
+//! - `${VAR:?message}` — fails with `message` when `VAR` is unset
+//!
+//! Interpolated strings are typed-coerced at deserialization time, so
+//! `pool_size = "${DB_POOL_SIZE:-10}"` resolves directly to the field's
+//! declared Rust type (e.g. `u16`) without manual parsing.
 
 use reinhardt::conf::settings::builder::SettingsBuilder;
 use reinhardt::conf::settings::profile::Profile;

--- a/crates/reinhardt-commands/templates/project_restful_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/src/config/settings.rs.tpl
@@ -29,12 +29,13 @@
 //!
 //! ## Environment Variable Interpolation
 //!
-//! `TomlFileSource` interpolates `${VAR}` syntax inside TOML values by
-//! default (since reinhardt-web v0.1.0-rc.27). Supported forms:
+//! `TomlFileSource` interpolates `${VAR}` syntax inside TOML string values
+//! by default (since reinhardt-web v0.1.0-rc.27). The `${...}` syntax is
+//! not valid in non-string TOML literals. Supported forms:
 //!
-//! - `${VAR}` — required; build fails if `VAR` is unset
+//! - `${VAR}` — required; settings load fails if `VAR` is unset
 //! - `${VAR:-default}` — falls back to `default` when `VAR` is unset
-//! - `${VAR:?message}` — fails with `message` when `VAR` is unset
+//! - `${VAR:?message}` — settings load fails with `message` when `VAR` is unset
 //!
 //! Interpolated strings are typed-coerced at deserialization time, so
 //! `pool_size = "${DB_POOL_SIZE:-10}"` resolves directly to the field's


### PR DESCRIPTION
## Summary

Two scaffold-time documentation gaps relative to recent reinhardt-web releases:

- \`settings.rs.tpl\` (both project templates) now documents the \`\${VAR}\` / \`\${VAR:-default}\` / \`\${VAR:?message}\` interpolation syntax that \`TomlFileSource\` has enabled by default since rc.27, along with the typed-coercion behavior on the deserialized value.
- \`urls.rs.tpl\` (\`project_pages_template\`) adds a commented example for \`router.server(\|s\| s.server_fn(marker))\`, noting that rc.28's \`ServerRouterStub::server_fn\` no-op stub makes the same builder chain compile on \`wasm32-unknown-unknown\` without a \`#[cfg(native)]\` workaround.

Pure scaffold-output comment changes; no scaffolded API surface changes.

## Type of Change

- [x] Documentation update (scaffold-generated comments)

## How Was This Tested

- [x] Visual inspection of the rendered comments in the \`.tpl\` files
- [ ] CI: \`cargo test -p reinhardt-commands\` (template scaffolding integration tests)

## Related Issues

Refs #4304 (umbrella for rc.25–rc.28 template alignment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)