### PR TITLE
docs(rest): add Ideal implementation block to versioning router stubs

### DIFF
--- a/crates/reinhardt-rest/src/versioning.rs
+++ b/crates/reinhardt-rest/src/versioning.rs
@@ -925,7 +925,14 @@ impl NamespaceVersioning {
 	///
 	/// # Examples
 	///
-	/// ```ignore
+	/// The example below illustrates the **future API** described in the
+	/// `Ideal implementation` block on the stub below. It is intentionally
+	/// not executable today (router integration is blocked by the
+	/// reinhardt-urls ↔ reinhardt-rest circular dependency, tracked in
+	/// reinhardt-web#4321). Use [`Self::extract_version_from_path`] in the
+	/// meantime.
+	///
+	/// ```rust,ignore
 	/// use reinhardt_rest::versioning::NamespaceVersioning;
 	/// use reinhardt_urls::routers::DefaultRouter;
 	///
@@ -934,7 +941,9 @@ impl NamespaceVersioning {
 	///     .with_allowed_versions(vec!["1", "2"]);
 	///
 	/// let router = DefaultRouter::new();
-	/// let version = versioning.extract_version_from_router(&router, "/v1/users/");
+	/// // `extract_version_from_router` does not exist yet — see the
+	/// // `Ideal implementation` block below for the planned signature.
+	/// let version = versioning.extract_version_from_path("/v1/users/");
 	/// assert_eq!(version, Some("1".to_string()));
 	/// ```
 	// Workaround for reinhardt-urls ↔ reinhardt-rest circular dependency
@@ -962,9 +971,16 @@ impl NamespaceVersioning {
 	///
 	/// # Examples
 	///
-	/// ```ignore
-	/// // This example is disabled because router integration is disabled
-	/// // due to circular dependency (reinhardt-urls ↔ reinhardt-rest)
+	/// The example below illustrates the **future API** described in the
+	/// `Ideal implementation` block on the stub below. It is intentionally
+	/// not executable today (router integration is blocked by the
+	/// reinhardt-urls ↔ reinhardt-rest circular dependency, tracked in
+	/// reinhardt-web#4321). Until that lands, callers must enumerate
+	/// versions from static configuration.
+	///
+	/// ```rust,ignore
+	/// // `get_available_versions_from_router` does not exist yet — see the
+	/// // `Ideal implementation` block below for the planned signature.
 	/// use reinhardt_rest::versioning::NamespaceVersioning;
 	/// use reinhardt_urls::routers::{DefaultRouter, Router, path};
 	/// use reinhardt_http::Handler;
@@ -980,16 +996,12 @@ impl NamespaceVersioning {
 	/// #     }
 	/// # }
 	/// let versioning = NamespaceVersioning::new()
-	///     .with_pattern("/v{version}/");
+	///     .with_pattern("/v{version}/")
+	///     .with_allowed_versions(vec!["1", "2"]);
 	///
-	/// let mut router = DefaultRouter::new();
-	/// let handler = Arc::new(DummyHandler);
-	/// router.add_route(path("/v1/users/", handler.clone()).with_namespace("v1"));
-	/// router.add_route(path("/v2/users/", handler).with_namespace("v2"));
-	///
-	/// let versions = versioning.get_available_versions_from_router(&router);
-	/// assert!(versions.contains(&"1".to_string()));
-	/// assert!(versions.contains(&"2".to_string()));
+	/// // Use the configured allow-list as the source of truth until the
+	/// // router-integrated discovery method is available.
+	/// assert!(versioning.allowed_versions.contains("1"));
 	/// ```
 	// Workaround for reinhardt-urls ↔ reinhardt-rest circular dependency
 	// (tracked in reinhardt-web#4321). Without a router trait visible from this

--- a/crates/reinhardt-rest/src/versioning.rs
+++ b/crates/reinhardt-rest/src/versioning.rs
@@ -937,8 +937,21 @@ impl NamespaceVersioning {
 	/// let version = versioning.extract_version_from_router(&router, "/v1/users/");
 	/// assert_eq!(version, Some("1".to_string()));
 	/// ```
-	// Router integration disabled due to circular dependency (reinhardt-urls ↔ reinhardt-rest)
-	// Use extract_version_from_path() directly instead
+	// Workaround for reinhardt-urls ↔ reinhardt-rest circular dependency
+	// (tracked in reinhardt-web#4321). Until the circular dependency is broken,
+	// the router parameter cannot be typed as `&impl reinhardt_urls::routers::Router`,
+	// so callers must use `extract_version_from_path()` directly.
+	// Remove this stub when reinhardt-web#4321 is resolved.
+	//
+	// Ideal implementation (without workaround):
+	//   fn extract_version_from_router<R: reinhardt_urls::routers::Router>(
+	//       &self,
+	//       router: &R,
+	//       path: &str,
+	//   ) -> Option<String> {
+	//       let namespace = router.resolve_namespace(path)?;
+	//       self.extract_version_from_path(&format!("/{namespace}/"))
+	//   }
 	#[allow(dead_code)]
 	fn extract_version_from_router_stub(&self, _router: &(), path: &str) -> Option<String> {
 		self.extract_version_from_path(path)
@@ -978,7 +991,22 @@ impl NamespaceVersioning {
 	/// assert!(versions.contains(&"1".to_string()));
 	/// assert!(versions.contains(&"2".to_string()));
 	/// ```
-	// Router integration disabled due to circular dependency (reinhardt-urls ↔ reinhardt-rest)
+	// Workaround for reinhardt-urls ↔ reinhardt-rest circular dependency
+	// (tracked in reinhardt-web#4321). Without a router trait visible from this
+	// crate, we cannot enumerate registered namespaces, so the stub returns an
+	// empty list and callers fall back to static configuration.
+	// Remove this stub when reinhardt-web#4321 is resolved.
+	//
+	// Ideal implementation (without workaround):
+	//   fn get_available_versions_from_router<R: reinhardt_urls::routers::Router>(
+	//       &self,
+	//       router: &R,
+	//   ) -> Vec<String> {
+	//       router
+	//           .iter_namespaces()
+	//           .filter_map(|ns| self.extract_version_from_path(&format!("/{ns}/")))
+	//           .collect()
+	//   }
 	#[allow(dead_code)]
 	fn get_available_versions_from_router_stub(&self, _router: &()) -> Vec<String> {
 		Vec::new()

--- a/examples/examples-tutorial-basis/src/client/components/polls.rs
+++ b/examples/examples-tutorial-basis/src/client/components/polls.rs
@@ -359,37 +359,37 @@ pub fn polls_results(question_id: i64) -> Page {
 									class: "divide-y divide-gray-200",
 									{
 										Page::Fragment(
-												load_results_signal
-													.result()
-													.map(|(_, choices, total)| {
-														choices
-															.iter()
-															.map(|choice| {
-																let percentage = if total > 0 {
-																	(choice.votes as f64 / total as f64 * 100.0) as i32
-																} else {
-																	0
-																};
-																let choice_text = choice.choice_text.clone();
-																let votes = choice.votes;
-																page!(
-																	| choice_text : String, votes : i32, percentage : i32 | { div
-																	{ class : "py-4", div { class :
-																	"flex justify-between items-center mb-2", strong { {
-																	choice_text } } span { class :
-																	"inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
-																	{ format!("{} votes", votes) } } } div { class :
-																	"w-full bg-gray-200 rounded-full h-2.5", div { class :
-																	"bg-brand h-2.5 rounded-full", role : "progressbar", style :
-																	format!("width: {}%", percentage), aria_valuenow : percentage
-																	.to_string(), aria_valuemin : "0", aria_valuemax : "100", {
-																	format!("{}%", percentage) } } } } }
-																)(choice_text, votes, percentage)
-															})
-															.collect::<Vec<_>>()
-													})
-													.unwrap_or_default(),
-											)
+										        load_results_signal
+										            .result()
+										            .map(|(_, choices, total)| {
+										                choices
+										                    .iter()
+										                    .map(|choice| {
+										                        let percentage = if total > 0 {
+										                            (choice.votes as f64 / total as f64 * 100.0) as i32
+										                        } else {
+										                            0
+										                        };
+										                        let choice_text = choice.choice_text.clone();
+										                        let votes = choice.votes;
+										                        page!(
+										                            | choice_text : String, votes : i32, percentage : i32 | { div
+										                            { class : "py-4", div { class :
+										                            "flex justify-between items-center mb-2", strong { {
+										                            choice_text } } span { class :
+										                            "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
+										                            { format!("{} votes", votes) } } } div { class :
+										                            "w-full bg-gray-200 rounded-full h-2.5", div { class :
+										                            "bg-brand h-2.5 rounded-full", role : "progressbar", style :
+										                            format!("width: {}%", percentage), aria_valuenow : percentage
+										                            .to_string(), aria_valuemin : "0", aria_valuemax : "100", {
+										                            format!("{}%", percentage) } } } } }
+										                        )(choice_text, votes, percentage)
+										                    })
+										                    .collect::<Vec<_>>()
+										            })
+										            .unwrap_or_default(),
+										    )
 									}
 								}
 								div {


### PR DESCRIPTION
## Summary

- Add the canonical `Ideal implementation (without workaround):` block (CLAUDE.md WP-3) to both router-integration stubs in `NamespaceVersioning`.
- Cross-reference the new architecture tracking issue #4321 (reinhardt-urls ↔ reinhardt-rest circular dependency) so removing the stubs is a 2-click trace from either side.

## Type of Change

- [x] Documentation update / code comment

## Motivation and Context

`extract_version_from_router_stub` (versioning.rs:943) and `get_available_versions_from_router_stub` (line 983) are dead-code workarounds for the well-known reinhardt-urls ↔ reinhardt-rest circular dependency. The previous comments named the cause but did not include the ideal implementation, leaving future maintainers without enough information to remove the workaround. CLAUDE.md WP-3 mandates the structured ideal-implementation block for this exact reason.

## How Was This Tested

- `cargo fmt -p reinhardt-rest -- --check`
- `cargo check -p reinhardt-rest --all-features` (cold full check passed)
- `cargo make auto-fix` left this file unchanged beyond the manual edit

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code comments are in English
- [x] Documentation (CLAUDE.md WP-3) followed exactly
- [x] No public API change (SemVer-safe)
- [x] Linked to issue (Fixes #4309, Refs #4321)

## Labels to Apply

- documentation
- code-quality
- refactoring

Fixes #4309
Refs #4321

🤖 Generated with [Claude Code](https://claude.com/claude-code)