### PR TITLE
fix(commands): scaffold urls/ submodule layout for app_pages templates

### DIFF
--- a/crates/reinhardt-commands/templates/app_pages_template/urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/urls.rs.tpl
@@ -3,7 +3,7 @@
 //! Both submodules use `#[url_patterns(InstalledApp::{{ app_name }}, mode = ...)]`,
 //! so the framework auto-registers them via inventory. The WASM entry point
 //! looks up the client router through
-//! `ClientLauncher::router_client(client_url_patterns)`, and the native
+//! `ClientLauncher::router_client(client_router::client_url_patterns)`, and the native
 //! aggregator does not need to mount the server router explicitly.
 //!
 //! - `server_urls` — `#[url_patterns(..., mode = server)]` → `ServerRouter`

--- a/crates/reinhardt-commands/templates/app_pages_template/urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/urls.rs.tpl
@@ -1,17 +1,16 @@
-//! URL routing for the {{ app_name }} app.
+//! URL configuration for the {{ app_name }} application.
 //!
-//! The `routes` function is mounted from the project-level `config/urls.rs`
-//! via `.mount("/{{ app_name }}/", crate::apps::{{ app_name }}::urls::routes())`.
-//! Do not annotate this function with `#[routes]` directly — that would
-//! register it without the mount prefix.
+//! Both submodules use `#[url_patterns(InstalledApp::{{ app_name }}, mode = ...)]`,
+//! so the framework auto-registers them via inventory. The WASM entry point
+//! looks up the client router through
+//! `ClientLauncher::router_client(client_url_patterns)`, and the native
+//! aggregator does not need to mount the server router explicitly.
+//!
+//! - `server_urls` — `#[url_patterns(..., mode = server)]` → `ServerRouter`
+//! - `client_router` — `#[url_patterns(..., mode = client)]` → `ClientRouter`
 
-use reinhardt::ServerRouter;
+#[cfg(server)]
+pub mod server_urls;
 
-#[allow(unused_imports)] // `views` will be used once endpoints are added.
-use super::views;
-
-pub fn routes() -> ServerRouter {
-	ServerRouter::new()
-	// Register endpoints here, e.g.:
-	//     .endpoint(views::index)
-}
+#[cfg(client)]
+pub mod client_router;

--- a/crates/reinhardt-commands/templates/app_pages_template/urls/client_router.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/urls/client_router.rs.tpl
@@ -1,17 +1,29 @@
 //! Client-side routing for the {{ app_name }} SPA.
 //!
 //! Routes are declared with `#[url_patterns(InstalledApp::{{ app_name }}, mode = client)]`,
-//! which auto-registers the router via inventory. The WASM entry point
-//! consumes this builder through `ClientLauncher::router_client(...)`.
+//! which auto-registers the router via inventory and namespaces named routes
+//! under the `InstalledApp::{{ app_name }}` label (e.g. `{{ app_name }}:index`).
+//! The WASM entry point consumes this builder through
+//! `ClientLauncher::router_client(...)`.
+//!
+//! Path parameters use the typed `ClientPath<T>` extractor.
 
+#[allow(unused_imports)] // `ClientPath` is used once typed-parameter routes are added.
+use reinhardt::ClientPath;
 use reinhardt::ClientRouter;
 use reinhardt::url_patterns;
 
+#[allow(unused_imports)] // `pages` will be used once client routes are added.
+use crate::client::pages;
 use crate::config::apps::InstalledApp;
 
 #[url_patterns(InstalledApp::{{ app_name }}, mode = client)]
 pub fn client_url_patterns() -> ClientRouter {
 	ClientRouter::new()
 	// Register client-side routes here, e.g.:
-	//     .route("/", index_page)
+	//     .named_route("index", "/", pages::index_page)
+	//     .route_path(
+	//         "/items/{id}/",
+	//         |ClientPath(id): ClientPath<i64>| pages::item_detail_page(id),
+	//     )
 }

--- a/crates/reinhardt-commands/templates/app_pages_template/urls/client_router.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/urls/client_router.rs.tpl
@@ -1,0 +1,17 @@
+//! Client-side routing for the {{ app_name }} SPA.
+//!
+//! Routes are declared with `#[url_patterns(InstalledApp::{{ app_name }}, mode = client)]`,
+//! which auto-registers the router via inventory. The WASM entry point
+//! consumes this builder through `ClientLauncher::router_client(...)`.
+
+use reinhardt::ClientRouter;
+use reinhardt::url_patterns;
+
+use crate::config::apps::InstalledApp;
+
+#[url_patterns(InstalledApp::{{ app_name }}, mode = client)]
+pub fn client_url_patterns() -> ClientRouter {
+	ClientRouter::new()
+	// Register client-side routes here, e.g.:
+	//     .route("/", index_page)
+}

--- a/crates/reinhardt-commands/templates/app_pages_template/urls/server_urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/urls/server_urls.rs.tpl
@@ -1,0 +1,20 @@
+//! Server-side URL configuration for the {{ app_name }} application.
+//!
+//! The `#[url_patterns]` attribute auto-registers this router via inventory
+//! and derives the path prefix from `InstalledApp::{{ app_name }}`, so the
+//! aggregating `config/urls.rs` does not need an explicit
+//! `.mount("/{{ app_name }}/", ...)` call.
+
+use reinhardt::ServerRouter;
+use reinhardt::url_patterns;
+
+#[allow(unused_imports)] // `views` will be used once endpoints are added.
+use crate::apps::{{ app_name }}::views;
+use crate::config::apps::InstalledApp;
+
+#[url_patterns(InstalledApp::{{ app_name }}, mode = server)]
+pub fn server_url_patterns() -> ServerRouter {
+	ServerRouter::new()
+	// Register endpoints here, e.g.:
+	//     .endpoint(views::index)
+}

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/urls.rs.tpl
@@ -3,7 +3,7 @@
 //! Both submodules use `#[url_patterns(InstalledApp::{{ app_name }}, mode = ...)]`,
 //! so the framework auto-registers them via inventory. The WASM entry point
 //! looks up the client router through
-//! `ClientLauncher::router_client(client_url_patterns)`, and the native
+//! `ClientLauncher::router_client(client_router::client_url_patterns)`, and the native
 //! aggregator does not need to mount the server router explicitly.
 //!
 //! - `server_urls` — `#[url_patterns(..., mode = server)]` → `ServerRouter`

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/urls.rs.tpl
@@ -1,17 +1,16 @@
-//! URL routing for the {{ app_name }} app.
+//! URL configuration for the {{ app_name }} application crate.
 //!
-//! The `routes` function is mounted from the project-level `config/urls.rs`
-//! via `.mount("/{{ app_name }}/", {{ app_name }}::urls::routes())`. Do not
-//! annotate this function with `#[routes]` directly — that would register
-//! it without the mount prefix.
+//! Both submodules use `#[url_patterns(InstalledApp::{{ app_name }}, mode = ...)]`,
+//! so the framework auto-registers them via inventory. The WASM entry point
+//! looks up the client router through
+//! `ClientLauncher::router_client(client_url_patterns)`, and the native
+//! aggregator does not need to mount the server router explicitly.
+//!
+//! - `server_urls` — `#[url_patterns(..., mode = server)]` → `ServerRouter`
+//! - `client_router` — `#[url_patterns(..., mode = client)]` → `ClientRouter`
 
-use reinhardt::ServerRouter;
+#[cfg(server)]
+pub mod server_urls;
 
-#[allow(unused_imports)] // `views` will be used once endpoints are added.
-use super::views;
-
-pub fn routes() -> ServerRouter {
-	ServerRouter::new()
-	// Register endpoints here, e.g.:
-	//     .endpoint(views::index)
-}
+#[cfg(client)]
+pub mod client_router;

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/urls/client_router.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/urls/client_router.rs.tpl
@@ -1,17 +1,29 @@
 //! Client-side routing for the {{ app_name }} SPA (workspace crate).
 //!
 //! Routes are declared with `#[url_patterns(InstalledApp::{{ app_name }}, mode = client)]`,
-//! which auto-registers the router via inventory. The WASM entry point
-//! consumes this builder through `ClientLauncher::router_client(...)`.
+//! which auto-registers the router via inventory and namespaces named routes
+//! under the `InstalledApp::{{ app_name }}` label (e.g. `{{ app_name }}:index`).
+//! The WASM entry point consumes this builder through
+//! `ClientLauncher::router_client(...)`.
+//!
+//! Path parameters use the typed `ClientPath<T>` extractor.
 
+#[allow(unused_imports)] // `ClientPath` is used once typed-parameter routes are added.
+use reinhardt::ClientPath;
 use reinhardt::ClientRouter;
 use reinhardt::url_patterns;
 
+#[allow(unused_imports)] // `pages` will be used once client routes are added.
+use crate::client::pages;
 use {{ project_crate_name }}::config::apps::InstalledApp;
 
 #[url_patterns(InstalledApp::{{ app_name }}, mode = client)]
 pub fn client_url_patterns() -> ClientRouter {
 	ClientRouter::new()
 	// Register client-side routes here, e.g.:
-	//     .route("/", index_page)
+	//     .named_route("index", "/", pages::index_page)
+	//     .route_path(
+	//         "/items/{id}/",
+	//         |ClientPath(id): ClientPath<i64>| pages::item_detail_page(id),
+	//     )
 }

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/urls/client_router.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/urls/client_router.rs.tpl
@@ -1,0 +1,17 @@
+//! Client-side routing for the {{ app_name }} SPA (workspace crate).
+//!
+//! Routes are declared with `#[url_patterns(InstalledApp::{{ app_name }}, mode = client)]`,
+//! which auto-registers the router via inventory. The WASM entry point
+//! consumes this builder through `ClientLauncher::router_client(...)`.
+
+use reinhardt::ClientRouter;
+use reinhardt::url_patterns;
+
+use {{ project_crate_name }}::config::apps::InstalledApp;
+
+#[url_patterns(InstalledApp::{{ app_name }}, mode = client)]
+pub fn client_url_patterns() -> ClientRouter {
+	ClientRouter::new()
+	// Register client-side routes here, e.g.:
+	//     .route("/", index_page)
+}

--- a/crates/reinhardt-commands/templates/app_pages_workspace_template/urls/server_urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_workspace_template/urls/server_urls.rs.tpl
@@ -1,0 +1,20 @@
+//! Server-side URL configuration for the {{ app_name }} application crate.
+//!
+//! The `#[url_patterns]` attribute auto-registers this router via inventory
+//! and derives the path prefix from `InstalledApp::{{ app_name }}`, so the
+//! aggregating `config/urls.rs` does not need an explicit
+//! `.mount("/{{ app_name }}/", ...)` call.
+
+use reinhardt::ServerRouter;
+use reinhardt::url_patterns;
+
+#[allow(unused_imports)] // `views` will be used once endpoints are added.
+use crate::views;
+use {{ project_crate_name }}::config::apps::InstalledApp;
+
+#[url_patterns(InstalledApp::{{ app_name }}, mode = server)]
+pub fn server_url_patterns() -> ServerRouter {
+	ServerRouter::new()
+	// Register endpoints here, e.g.:
+	//     .endpoint(views::index)
+}

--- a/crates/reinhardt-commands/tests/e2e_pages.rs
+++ b/crates/reinhardt-commands/tests/e2e_pages.rs
@@ -14,6 +14,32 @@ use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
 
+/// RAII guard that restores the process-wide current working directory when
+/// dropped, including on panic-driven unwind. Tests under `#[serial(cwd)]`
+/// mutate global state via `std::env::set_current_dir`, so without this guard
+/// a panic inside `execute(...)` would leave the CWD pointing at a `TempDir`
+/// that gets deleted at end-of-scope, corrupting subsequent tests.
+struct CwdGuard {
+	prev: std::path::PathBuf,
+}
+
+impl CwdGuard {
+	fn enter(new_cwd: &Path) -> Self {
+		let prev = std::env::current_dir().unwrap();
+		std::env::set_current_dir(new_cwd).unwrap();
+		Self { prev }
+	}
+}
+
+impl Drop for CwdGuard {
+	fn drop(&mut self) {
+		// Best-effort restore — swallow errors during unwind so we never
+		// double-panic. The original directory may itself have been removed
+		// in pathological cases, which is acceptable for test cleanup.
+		let _ = std::env::set_current_dir(&self.prev);
+	}
+}
+
 /// Helper: build a `CommandContext` whose only option is `--with-pages`.
 fn pages_context(args: Vec<String>) -> CommandContext {
 	let mut ctx = CommandContext::new(args);
@@ -29,8 +55,7 @@ fn pages_context(args: Vec<String>) -> CommandContext {
 async fn project_pages_layout_matches_tutorial() {
 	// Arrange
 	let tmp = TempDir::new().unwrap();
-	let prev = std::env::current_dir().unwrap();
-	std::env::set_current_dir(tmp.path()).unwrap();
+	let _cwd_guard = CwdGuard::enter(tmp.path());
 
 	// Act
 	let res = StartProjectCommand
@@ -38,7 +63,6 @@ async fn project_pages_layout_matches_tutorial() {
 		.await;
 
 	// Assert
-	std::env::set_current_dir(prev).unwrap();
 	res.expect("startproject --with-pages must succeed");
 
 	let project = tmp.path().join("polls_project");
@@ -125,12 +149,10 @@ async fn project_pages_layout_matches_tutorial() {
 
 /// Set up a project so that `startapp --with-pages` can run inside it.
 async fn scaffold_pages_project(tmp: &Path, name: &str) {
-	let prev = std::env::current_dir().unwrap();
-	std::env::set_current_dir(tmp).unwrap();
+	let _cwd_guard = CwdGuard::enter(tmp);
 	let cmd = StartProjectCommand;
 	let ctx = pages_context(vec![name.to_string()]);
 	let result = cmd.execute(&ctx).await;
-	std::env::set_current_dir(prev).unwrap();
 	result.expect("startproject --with-pages must succeed");
 }
 
@@ -144,8 +166,7 @@ async fn app_pages_layout_matches_tutorial() {
 	scaffold_pages_project(tmp.path(), project_name).await;
 
 	let project_dir = tmp.path().join(project_name);
-	let prev = std::env::current_dir().unwrap();
-	std::env::set_current_dir(&project_dir).unwrap();
+	let _cwd_guard = CwdGuard::enter(&project_dir);
 
 	// Act
 	let res = StartAppCommand
@@ -153,7 +174,6 @@ async fn app_pages_layout_matches_tutorial() {
 		.await;
 
 	// Assert
-	std::env::set_current_dir(prev).unwrap();
 	res.expect("startapp --with-pages must succeed");
 
 	let apps = project_dir.join("src").join("apps");
@@ -231,8 +251,7 @@ async fn startapp_pages_layout_has_urls_submodule() {
 	scaffold_pages_project(tmp.path(), project_name).await;
 
 	let project_dir = tmp.path().join(project_name);
-	let prev = std::env::current_dir().unwrap();
-	std::env::set_current_dir(&project_dir).unwrap();
+	let _cwd_guard = CwdGuard::enter(&project_dir);
 
 	// Act
 	let res = StartAppCommand
@@ -240,7 +259,6 @@ async fn startapp_pages_layout_has_urls_submodule() {
 		.await;
 
 	// Assert
-	std::env::set_current_dir(prev).unwrap();
 	res.expect("startapp --with-pages must succeed");
 
 	let foo_dir = project_dir.join("src").join("apps").join("foo");

--- a/crates/reinhardt-commands/tests/e2e_pages.rs
+++ b/crates/reinhardt-commands/tests/e2e_pages.rs
@@ -189,14 +189,12 @@ async fn app_pages_layout_matches_tutorial() {
 	);
 
 	// 3. None of the previous over-generated subdirectories are produced.
-	for unwanted in [
-		"client",
-		"server",
-		"shared",
-		"urls/client_urls.rs",
-		"urls/server_urls.rs",
-		"urls/ws_urls.rs",
-	] {
+	//    `urls/ws_urls.rs` remains forbidden (websocket scaffold is opt-in
+	//    and explicitly out of scope for #4308). `urls/server_urls.rs` and
+	//    `urls/client_router.rs` are now REQUIRED by the canonical layout
+	//    introduced in rc.19 (see `startapp_pages_layout_has_urls_submodule`
+	//    below for the positive assertions).
+	for unwanted in ["client", "server", "shared", "urls/ws_urls.rs"] {
 		let path = polls_dir.join(unwanted);
 		assert!(
 			!path.exists(),
@@ -205,15 +203,100 @@ async fn app_pages_layout_matches_tutorial() {
 		);
 	}
 
-	// 4. urls.rs is a plain `routes()` mounted from config/urls.rs — not a
-	//    `unified_url_patterns` with #[url_patterns(... mode = unified)].
+	// 4. urls.rs is the aggregator that declares the `server_urls` and
+	//    `client_router` submodules with the appropriate cfg gates. The
+	//    legacy `unified_url_patterns` scaffold is still forbidden.
 	let urls_rs = fs::read_to_string(polls_dir.join("urls.rs")).expect("read apps/polls/urls.rs");
 	assert!(
-		urls_rs.contains("pub fn routes() -> ServerRouter"),
-		"apps/polls/urls.rs must define `pub fn routes() -> ServerRouter`:\n{urls_rs}"
+		urls_rs.contains("pub mod server_urls"),
+		"apps/polls/urls.rs must declare `pub mod server_urls`:\n{urls_rs}"
+	);
+	assert!(
+		urls_rs.contains("pub mod client_router"),
+		"apps/polls/urls.rs must declare `pub mod client_router`:\n{urls_rs}"
 	);
 	assert!(
 		!urls_rs.contains("unified_url_patterns"),
 		"apps/polls/urls.rs must not use the unified_url_patterns scaffold:\n{urls_rs}"
+	);
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(cwd)]
+async fn startapp_pages_layout_has_urls_submodule() {
+	// Arrange — scaffold a project, then scaffold a pages app inside it.
+	let tmp = TempDir::new().unwrap();
+	let project_name = "polls_project";
+	scaffold_pages_project(tmp.path(), project_name).await;
+
+	let project_dir = tmp.path().join(project_name);
+	let prev = std::env::current_dir().unwrap();
+	std::env::set_current_dir(&project_dir).unwrap();
+
+	// Act
+	let res = StartAppCommand
+		.execute(&pages_context(vec!["foo".to_string()]))
+		.await;
+
+	// Assert
+	std::env::set_current_dir(prev).unwrap();
+	res.expect("startapp --with-pages must succeed");
+
+	let foo_dir = project_dir.join("src").join("apps").join("foo");
+
+	// 1. The aggregator and both submodules exist.
+	let urls_rs = foo_dir.join("urls.rs");
+	let server_urls = foo_dir.join("urls").join("server_urls.rs");
+	let client_router = foo_dir.join("urls").join("client_router.rs");
+	assert!(urls_rs.exists(), "apps/foo/urls.rs must exist");
+	assert!(
+		server_urls.exists(),
+		"apps/foo/urls/server_urls.rs must exist"
+	);
+	assert!(
+		client_router.exists(),
+		"apps/foo/urls/client_router.rs must exist"
+	);
+
+	// 2. ws_urls.rs is explicitly out of scope (see #4308 scope boundaries).
+	assert!(
+		!foo_dir.join("urls").join("ws_urls.rs").exists(),
+		"apps/foo/urls/ws_urls.rs must NOT be generated"
+	);
+
+	// 3. The aggregator declares both submodules with the appropriate cfg
+	//    gates that match the project-level `build.rs` cfg_aliases
+	//    (`client` for wasm32, `server` for native).
+	let urls_contents = fs::read_to_string(&urls_rs).expect("read apps/foo/urls.rs");
+	assert!(
+		urls_contents.contains("#[cfg(server)]"),
+		"apps/foo/urls.rs must gate server_urls with #[cfg(server)]:\n{urls_contents}"
+	);
+	assert!(
+		urls_contents.contains("pub mod server_urls"),
+		"apps/foo/urls.rs must declare `pub mod server_urls`:\n{urls_contents}"
+	);
+	assert!(
+		urls_contents.contains("#[cfg(client)]"),
+		"apps/foo/urls.rs must gate client_router with #[cfg(client)]:\n{urls_contents}"
+	);
+	assert!(
+		urls_contents.contains("pub mod client_router"),
+		"apps/foo/urls.rs must declare `pub mod client_router`:\n{urls_contents}"
+	);
+
+	// 4. The submodules carry the canonical #[url_patterns] attribute with
+	//    `mode = server` / `mode = client`, matching the polls tutorial.
+	let server_contents = fs::read_to_string(&server_urls).expect("read server_urls.rs");
+	assert!(
+		server_contents.contains("#[url_patterns(InstalledApp::foo, mode = server)]"),
+		"server_urls.rs must carry the server-mode #[url_patterns] attribute:\n{server_contents}"
+	);
+
+	let client_contents = fs::read_to_string(&client_router).expect("read client_router.rs");
+	assert!(
+		client_contents.contains("#[url_patterns(InstalledApp::foo, mode = client)]"),
+		"client_router.rs must carry the client-mode #[url_patterns] attribute:\n{client_contents}"
 	);
 }


### PR DESCRIPTION
## Summary

- Replace the flat `urls.rs.tpl` in `app_pages_template/` and `app_pages_workspace_template/` with the canonical aggregator + `urls/{server_urls,client_router}.rs` submodule layout established in rc.19.
- A freshly scaffolded pages app (`reinhardt-admin startapp --with-pages foo`) can now host both server endpoints and a client-side SPA route without manually rewriting the urls module.
- Update the existing `app_pages_layout_matches_tutorial` test to match the new canonical layout and add a positive `startapp_pages_layout_has_urls_submodule` test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Per #4308, `app_pages_template/urls.rs.tpl` currently emits a single flat `urls.rs` returning `ServerRouter::new()` with no client-side surface, which contradicts the canonical layout used by `examples/examples-tutorial-basis/src/apps/polls/urls/`. The template predates the rc.19 `urls/` directory scaffold; this PR brings it in line.

Fixes #4308

## How Was This Tested?

- `cargo nextest run -p reinhardt-commands --test e2e_pages` — all 3 tests pass (existing `project_pages_layout_matches_tutorial`, updated `app_pages_layout_matches_tutorial`, new `startapp_pages_layout_has_urls_submodule`).
- `cargo make fmt-check` — clean (exit 0).
- `cargo make clippy-check` — clean (exit 0).

## Implementation Notes / Deviations from the original plan

- **`client_router.rs` vs `client_urls.rs`**: chose `client_router.rs` for parity with `examples/examples-tutorial-basis/src/apps/polls/urls/` (the rc.19 announcement called it `client_urls.rs`, but the example was later renamed).
- **`cfg(server)` / `cfg(client)`, not `cfg(native)` / `cfg(wasm)`**: the tutorial example uses `native`/`wasm` because its own `build.rs` declares those alias names, but the scaffold-generated project's `project_pages_template/build.rs.tpl` uses `client`/`server` as the cfg_aliases. The aggregator must match its own build.rs, so the templates use `#[cfg(server)]` / `#[cfg(client)]`.
- **`ws_urls.rs` not scaffolded**: explicitly out of scope per the issue's scope boundaries (WebSockets are opt-in).
- **`app_pages_workspace_template` layout**: the workspace template's existing `urls.rs.tpl` lives at the template root (not under `src/`), unlike `app_restful_workspace_template/src/`. The new files were placed alongside the existing one to preserve current behavior — fixing the broader `src/` layout in the workspace template is a separate pre-existing issue and out of scope here.
- **No `cargo check` on the generated project in the new test**: the existing e2e tests only check file existence/content (not compilation); adding `cargo check` would also expose the pre-existing workspace template `Cargo.toml` issue unrelated to #4308. Kept the new test consistent with the existing suite.

## Files Changed

- `crates/reinhardt-commands/templates/app_pages_template/urls.rs.tpl` — rewritten as aggregator with `#[cfg(server)]` / `#[cfg(client)]` submodule declarations
- `crates/reinhardt-commands/templates/app_pages_template/urls/server_urls.rs.tpl` — new, `#[url_patterns(InstalledApp::{{ app_name }}, mode = server)]`
- `crates/reinhardt-commands/templates/app_pages_template/urls/client_router.rs.tpl` — new, `#[url_patterns(InstalledApp::{{ app_name }}, mode = client)]`
- `crates/reinhardt-commands/templates/app_pages_workspace_template/urls.rs.tpl` — rewritten as aggregator
- `crates/reinhardt-commands/templates/app_pages_workspace_template/urls/server_urls.rs.tpl` — new
- `crates/reinhardt-commands/templates/app_pages_workspace_template/urls/client_router.rs.tpl` — new
- `crates/reinhardt-commands/tests/e2e_pages.rs` — updated `app_pages_layout_matches_tutorial` assertions (urls/ subdir now required, not forbidden); added `startapp_pages_layout_has_urls_submodule`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (template-level doc comments only)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

Fixes #4308
Refs #4304 (umbrella: rc.25–rc.28 template alignment)

## Labels to Apply

### Type Label
- [x] `bug` — restores the canonical layout broken since rc.19
- [x] `enhancement` — adds the client-routing scaffold surface

### Scope Label
- [x] `routing` — urls module scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)