### PR TITLE
refactor(apps): make reinhardt-apps cross-target

### DIFF
--- a/crates/reinhardt-apps/Cargo.toml
+++ b/crates/reinhardt-apps/Cargo.toml
@@ -9,39 +9,46 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+# Cross-target (wasm + native): pure data / trait dependencies only.
 reinhardt-http = { workspace = true }
-reinhardt-server = { workspace = true }
-
-# DI integration (optional)
-reinhardt-di = { workspace = true, optional = true }
+reinhardt-core = { workspace = true, features = ["types"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
-hyper = { workspace = true }
-hyper-util = { version = "0.1", features = ["tokio"] }
-http-body-util = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 sha2 = "0.10"
-flate2 = { workspace = true }
-brotli = { workspace = true }
-reqwest = { workspace = true }
 futures = "0.3.31"
 pin-project = "1.1"
 linkme = "0.3"
 inventory = "0.3"
-reinhardt-conf = {workspace = true, features = ["settings"]}
-reinhardt-core = {workspace = true, features = ["types"]}
+
+# Native-only dependencies. These pull in tokio's `net` feature (mio) or other
+# runtime/server machinery that does not compile on `wasm32-unknown-unknown`.
+# Source modules that use these crates are gated behind `#[cfg(native)]`.
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+reinhardt-server = { workspace = true }
+reinhardt-conf = { workspace = true, features = ["settings"] }
 reinhardt-utils = { workspace = true }
+reinhardt-di = { workspace = true, optional = true }
+tokio = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = { workspace = true }
+flate2 = { workspace = true }
+brotli = { workspace = true }
+reqwest = { workspace = true }
 
 [features]
 default = []
 full = ["di"]
 di = ["dep:reinhardt-di"]
 testing = []
+
+[build-dependencies]
+cfg_aliases = "0.2"
 
 [dev-dependencies]
 insta = { workspace = true }
@@ -53,4 +60,4 @@ rstest = { workspace = true }
 # When upstream cargo resolves these issues, replace with `workspace = true`.
 reinhardt-test = { path = "../reinhardt-test" }
 reinhardt-conf = { workspace = true, features = ["settings"] }
-reinhardt-core = {workspace = true, features = ["exception"]}
+reinhardt-core = { workspace = true, features = ["exception"] }

--- a/crates/reinhardt-apps/Cargo.toml
+++ b/crates/reinhardt-apps/Cargo.toml
@@ -22,13 +22,15 @@ chrono = { workspace = true }
 sha2 = "0.10"
 futures = "0.3.31"
 pin-project = "1.1"
-linkme = "0.3"
-inventory = "0.3"
 
 # Native-only dependencies. These pull in tokio's `net` feature (mio) or other
 # runtime/server machinery that does not compile on `wasm32-unknown-unknown`.
-# Source modules that use these crates are gated behind `#[cfg(native)]`.
+# `linkme` and `inventory` rely on link-section constructors that are not
+# portable to `wasm32-unknown-unknown`, so they are gated here as well; source
+# sites that use them are guarded by `#[cfg(native)]`.
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+linkme = "0.3"
+inventory = "0.3"
 reinhardt-server = { workspace = true }
 reinhardt-conf = { workspace = true, features = ["settings"] }
 reinhardt-utils = { workspace = true }

--- a/crates/reinhardt-apps/build.rs
+++ b/crates/reinhardt-apps/build.rs
@@ -1,0 +1,16 @@
+//! Build script for reinhardt-apps.
+//!
+//! Sets up cfg aliases for simplified conditional compilation, mirroring
+//! the convention established in `reinhardt-core/build.rs`.
+
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+	println!("cargo::rustc-check-cfg=cfg(wasm)");
+	println!("cargo::rustc-check-cfg=cfg(native)");
+
+	cfg_aliases! {
+		wasm: { all(target_family = "wasm", target_os = "unknown") },
+		native: { not(all(target_family = "wasm", target_os = "unknown")) },
+	}
+}

--- a/crates/reinhardt-apps/src/apps.rs
+++ b/crates/reinhardt-apps/src/apps.rs
@@ -1115,6 +1115,11 @@ inventory::collect!(AppMediaConfig);
 
 // ============================================================================
 // Registration Macros
+//
+// These macros expand to `$crate::inventory::submit!` blocks that reference
+// native-only types (`AppStaticFilesConfig`, `AppLocaleConfig`, etc.) and the
+// native-only `inventory` re-export. They are therefore `#[cfg(native)]`-gated
+// individually and not exported on `wasm32-unknown-unknown`.
 // ============================================================================
 
 /// Register static files for an application
@@ -1131,6 +1136,7 @@ inventory::collect!(AppMediaConfig);
 ///     "/static/myapp/"
 /// );
 /// ```
+#[cfg(native)]
 #[macro_export]
 macro_rules! register_app_static_files {
 	($app_label:expr, $static_dir:expr, $url_prefix:expr) => {
@@ -1157,6 +1163,7 @@ macro_rules! register_app_static_files {
 ///     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("locale")
 /// );
 /// ```
+#[cfg(native)]
 #[macro_export]
 macro_rules! register_app_locale {
 	($app_label:expr, $locale_dir:expr) => {
@@ -1191,6 +1198,7 @@ macro_rules! register_app_locale {
 ///     || Box::new(MyCommand)
 /// );
 /// ```
+#[cfg(native)]
 #[macro_export]
 macro_rules! register_app_command {
 	($app_label:expr, $command_name:expr, $command_fn:expr) => {
@@ -1218,6 +1226,7 @@ macro_rules! register_app_command {
 ///     "/media/myapp/"
 /// );
 /// ```
+#[cfg(native)]
 #[macro_export]
 macro_rules! register_app_media {
 	($app_label:expr, $media_dir:expr, $url_prefix:expr) => {

--- a/crates/reinhardt-apps/src/apps.rs
+++ b/crates/reinhardt-apps/src/apps.rs
@@ -78,6 +78,10 @@ pub struct AppConfig {
 /// `#[app_config]` attribute macro can refer to it via
 /// `reinhardt_apps::AppVendorAsset` without forcing user crates to depend on
 /// `reinhardt-utils` directly.
+///
+/// Native-only: `reinhardt-utils` currently pulls in tokio's `net` feature
+/// (mio) and does not compile on `wasm32-unknown-unknown`.
+#[cfg(native)]
 pub use reinhardt_utils::staticfiles::vendor::AppVendorAsset;
 
 impl AppConfig {
@@ -545,7 +549,12 @@ impl Apps {
 		// The models are already registered via #[derive(Model)] macro
 		// which automatically registers them at construction time
 
-		// 4. Build reverse relations between models
+		// 4. Build reverse relations between models.
+		//    The discovery + registry layers depend on `linkme` distributed
+		//    slices and on server-only crates, so this step only runs on
+		//    native targets. On `wasm32-unknown-unknown`, model registration
+		//    is a no-op (the client never owns the model graph).
+		#[cfg(native)]
 		if !*self
 			.models_ready
 			.lock()
@@ -1010,12 +1019,19 @@ mod typed_tests {
 
 // ============================================================================
 // Global Registry (inventory-based)
+//
+// The items below use `inventory::collect!`, which relies on link-section
+// constructors that are not portable to `wasm32-unknown-unknown`. They model
+// server-side discovery of static files / locales / commands / media files,
+// none of which are meaningful on the wasm client target, so they are
+// `#[cfg(native)]`-gated individually.
 // ============================================================================
 
 /// Base trait for custom management commands
 ///
 /// Applications can implement this trait to provide custom commands
 /// that will be automatically discovered by the manage.py CLI.
+#[cfg(native)]
 pub trait BaseCommand: Send + Sync {
 	/// Command name (e.g., "createsuperuser")
 	fn name(&self) -> &str;
@@ -1032,6 +1048,7 @@ pub trait BaseCommand: Send + Sync {
 /// Applications can register their static files directories using this struct.
 /// Registered configurations will be automatically discovered by collectstatic.
 /// Uses static string references for compile-time registration.
+#[cfg(native)]
 pub struct AppStaticFilesConfig {
 	/// Application label that owns these static files.
 	pub app_label: &'static str,
@@ -1041,6 +1058,7 @@ pub struct AppStaticFilesConfig {
 	pub url_prefix: &'static str,
 }
 
+#[cfg(native)]
 inventory::collect!(AppStaticFilesConfig);
 
 /// Locale configuration from an app
@@ -1048,6 +1066,7 @@ inventory::collect!(AppStaticFilesConfig);
 /// Applications can register their locale directories using this struct.
 /// Registered configurations will be automatically discovered by makemessages.
 /// Uses static string references for compile-time registration.
+#[cfg(native)]
 pub struct AppLocaleConfig {
 	/// Application label that owns these locale files.
 	pub app_label: &'static str,
@@ -1055,6 +1074,7 @@ pub struct AppLocaleConfig {
 	pub locale_dir: &'static str,
 }
 
+#[cfg(native)]
 inventory::collect!(AppLocaleConfig);
 
 /// Command configuration from an app
@@ -1062,6 +1082,7 @@ inventory::collect!(AppLocaleConfig);
 /// Applications can register their custom management commands using this struct.
 /// Registered commands will be automatically discovered by the manage.py CLI.
 /// Uses static string references for compile-time registration.
+#[cfg(native)]
 pub struct AppCommandConfig {
 	/// Application label that owns this command.
 	pub app_label: &'static str,
@@ -1071,6 +1092,7 @@ pub struct AppCommandConfig {
 	pub command_fn: fn() -> Box<dyn BaseCommand>,
 }
 
+#[cfg(native)]
 inventory::collect!(AppCommandConfig);
 
 /// Media files configuration from an app
@@ -1078,6 +1100,7 @@ inventory::collect!(AppCommandConfig);
 /// Applications can register their media files directories using this struct.
 /// Registered configurations will be automatically discovered by collectmedia.
 /// Uses static string references for compile-time registration.
+#[cfg(native)]
 pub struct AppMediaConfig {
 	/// Application label that owns these media files.
 	pub app_label: &'static str,
@@ -1087,6 +1110,7 @@ pub struct AppMediaConfig {
 	pub url_prefix: &'static str,
 }
 
+#[cfg(native)]
 inventory::collect!(AppMediaConfig);
 
 // ============================================================================
@@ -1226,6 +1250,7 @@ macro_rules! register_app_media {
 ///     println!("App: {}, Dir: {}", config.app_label, config.static_dir);
 /// }
 /// ```
+#[cfg(native)]
 pub fn get_app_static_files() -> Vec<&'static AppStaticFilesConfig> {
 	inventory::iter::<AppStaticFilesConfig>().collect()
 }
@@ -1245,6 +1270,7 @@ pub fn get_app_static_files() -> Vec<&'static AppStaticFilesConfig> {
 ///     println!("App: {}, Dir: {}", config.app_label, config.locale_dir);
 /// }
 /// ```
+#[cfg(native)]
 pub fn get_app_locales() -> Vec<&'static AppLocaleConfig> {
 	inventory::iter::<AppLocaleConfig>().collect()
 }
@@ -1264,6 +1290,7 @@ pub fn get_app_locales() -> Vec<&'static AppLocaleConfig> {
 ///     println!("App: {}, Command: {}", config.app_label, config.command_name);
 /// }
 /// ```
+#[cfg(native)]
 pub fn get_app_commands() -> Vec<&'static AppCommandConfig> {
 	inventory::iter::<AppCommandConfig>().collect()
 }
@@ -1283,6 +1310,7 @@ pub fn get_app_commands() -> Vec<&'static AppCommandConfig> {
 ///     println!("App: {}, Dir: {}", config.app_label, config.media_dir);
 /// }
 /// ```
+#[cfg(native)]
 pub fn get_app_media() -> Vec<&'static AppMediaConfig> {
 	inventory::iter::<AppMediaConfig>().collect()
 }

--- a/crates/reinhardt-apps/src/lib.rs
+++ b/crates/reinhardt-apps/src/lib.rs
@@ -81,47 +81,76 @@
 
 #![warn(missing_docs)]
 
+// Cross-target modules. These define the pure trait/data core (`AppLabel`,
+// `AppConfig`, lifecycle signals) that must be reachable from
+// `wasm32-unknown-unknown` callers (e.g., client-side code that names an
+// `AppLabel` impl without pulling in the server runtime).
 pub mod apps;
-pub mod builder;
-pub mod discovery;
-pub mod hooks;
-pub mod registry;
 pub mod signals;
+
+// Native-only modules.
+//
+// - `registry` uses `linkme::distributed_slice`, whose link-section
+//   constructors are not supported on `wasm32-unknown-unknown`.
+// - `builder`, `discovery`, `hooks`, `validation` depend on
+//   `reinhardt-server`, `reinhardt-conf`, `reinhardt-utils`, or
+//   `reinhardt-di`, none of which compile on wasm32 today (they pull in
+//   tokio's `net` feature → mio).
+#[cfg(native)]
+pub mod builder;
+#[cfg(native)]
+pub mod discovery;
+#[cfg(native)]
+pub mod hooks;
+#[cfg(native)]
+pub mod registry;
+#[cfg(native)]
 pub mod validation;
 
-// Re-export from reinhardt-http
+// Re-export from reinhardt-http (cross-target).
 pub use reinhardt_http::{Request, Response, StreamBody, StreamingResponse};
 
-// Re-export from reinhardt-conf
+// Re-export from reinhardt-conf (native-only: pulls in tokio runtime).
+#[cfg(native)]
 #[allow(deprecated)]
 pub use reinhardt_conf::settings::{DatabaseConfig, MiddlewareConfig, Settings, TemplateConfig};
 
-// Re-export from reinhardt-core::exception
+// Re-export from reinhardt-core::exception (cross-target).
 pub use reinhardt_core::exception::{Error, Result};
 
-// Re-export from reinhardt-server
+// Re-export from reinhardt-server (native-only).
+#[cfg(native)]
 pub use reinhardt_server::{HttpServer, serve};
 
-// Re-export from reinhardt-http
+// Re-export from reinhardt-http (cross-target).
 pub use reinhardt_http::{Handler, Middleware, MiddlewareChain};
 
-// Re-export inventory for macro usage
+// Re-export inventory for macro usage.
 pub use inventory;
 
-// Re-export from apps module
+// Re-export from apps module. Cross-target items (`AppLabel`, `AppConfig`, and
+// the trait providers) are unconditional; the `AppVendorAsset` re-export and
+// the `get_app_*` collector helpers depend on `reinhardt-utils` and remain
+// native-only.
+#[cfg(native)]
 pub use apps::{
-	AppCommandConfig, AppConfig, AppError, AppLabel, AppLocaleConfig, AppMediaConfig, AppResult,
-	AppStaticFilesConfig, AppVendorAsset, Apps, BaseCommand, LocaleProvider, MediaProvider,
-	StaticFilesProvider, get_app_commands, get_app_locales, get_app_media, get_app_static_files,
+	AppCommandConfig, AppLocaleConfig, AppMediaConfig, AppStaticFilesConfig, AppVendorAsset,
+	BaseCommand, get_app_commands, get_app_locales, get_app_media, get_app_static_files,
+};
+pub use apps::{
+	AppConfig, AppError, AppLabel, AppResult, Apps, LocaleProvider, MediaProvider,
+	StaticFilesProvider,
 };
 
-// Re-export from builder module
+// Re-export from builder module (native-only).
+#[cfg(native)]
 pub use builder::{
 	Application, ApplicationBuilder, ApplicationDatabaseConfig, BuildError, BuildResult,
 	RouteConfig,
 };
 
-// Re-export from registry module
+// Re-export from registry module (native-only).
+#[cfg(native)]
 pub use registry::{
 	MODELS, ModelMetadata, RELATIONSHIPS, RelationshipMetadata, RelationshipType,
 	ReverseRelationMetadata, ReverseRelationType, finalize_reverse_relations, find_model,
@@ -130,13 +159,15 @@ pub use registry::{
 	register_reverse_relation,
 };
 
-// Re-export from discovery module
+// Re-export from discovery module (native-only).
+#[cfg(native)]
 pub use discovery::{
 	MigrationMetadata, RelationMetadata, RelationType, build_reverse_relations,
 	create_reverse_relation, discover_all_models, discover_migrations, discover_models,
 };
 
-// Re-export from validation module
+// Re-export from validation module (native-only).
+#[cfg(native)]
 pub use validation::{
 	ValidationError, ValidationResult, check_circular_relationships, check_duplicate_model_names,
 	check_duplicate_table_names, validate_registry,

--- a/crates/reinhardt-apps/src/lib.rs
+++ b/crates/reinhardt-apps/src/lib.rs
@@ -125,7 +125,9 @@ pub use reinhardt_server::{HttpServer, serve};
 // Re-export from reinhardt-http (cross-target).
 pub use reinhardt_http::{Handler, Middleware, MiddlewareChain};
 
-// Re-export inventory for macro usage.
+// Re-export inventory for macro usage (native-only; inventory relies on
+// link-section constructors not portable to `wasm32-unknown-unknown`).
+#[cfg(native)]
 pub use inventory;
 
 // Re-export from apps module. Cross-target items (`AppLabel`, `AppConfig`, and


### PR DESCRIPTION
## Summary

Split the `reinhardt-apps` dependency graph and module tree along the
`cfg(native)` boundary so that `AppLabel`, `AppConfig`, `Apps`, the
trait providers (`StaticFilesProvider` / `LocaleProvider` /
`MediaProvider`), `AppError`, and the lifecycle signals are reachable
from `wasm32-unknown-unknown` targets.

- Cross-target (`apps`, `signals` modules + their re-exports): pure
  trait / data core.
- `#[cfg(native)]`-gated modules: `builder`, `discovery`, `hooks`,
  `registry`, `validation`.
- `#[cfg(native)]`-gated items inside `apps.rs`: the inventory-based
  collectors (`AppStaticFilesConfig`, `AppLocaleConfig`,
  `AppCommandConfig`, `AppMediaConfig`, `BaseCommand`, the four
  `get_app_*` helpers, and the `AppVendorAsset` re-export), plus the
  reverse-relation step inside `Apps::populate`.
- `Cargo.toml`: native-only crates (`reinhardt-server`,
  `reinhardt-conf`, `reinhardt-utils`, `reinhardt-di`, `tokio`,
  `hyper`, `hyper-util`, `http-body-util`, `flate2`, `brotli`,
  `reqwest`) are now under
  `[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]`.
  These all pull in tokio's `net` feature (mio), which does not
  compile on `wasm32-unknown-unknown`.
- `build.rs`: register the `wasm` / `native` cfg aliases via
  `cfg_aliases`, mirroring `crates/reinhardt-core/build.rs`.

The facade `src/lib.rs` `#[doc(hidden)]` shim added in #4161 (lines
124-172, the `AppLabel` / `AppConfig` aliases) is **left in place** for
this PR — removing it is C-3 in the #4168 PR chain.
`reinhardt-websockets` cross-target work is C-2 and is also a separate
PR.

## Type of Change

- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Motivation and Context

Issue #4168 sets an escalation rule: once a `#[doc(hidden)]` facade
shim has been amended **two or more times** to keep wasm callers
working, the underlying crate must be made cross-target instead of
continuing to patch the shim. The `AppLabel` / `AppConfig` shim added
in `30e27fe7c` (#4161) has been amended **six times** since, which
clears that threshold by a wide margin and triggers this refactor.

Making `reinhardt-apps` cross-target lets client-side code in
`reinhardt-web` / `reinhardt-cloud` / app-author code name `AppLabel`
impls and read `AppConfig` directly from the canonical crate, instead
of going through the facade re-export. Once C-2 (websockets) and C-3
(facade cleanup) land, the shim itself is deleted.

Refs #4168

## How Was This Tested?

- `cargo check -p reinhardt-apps --all-features` (native): passes.
- `cargo check -p reinhardt-apps --target wasm32-unknown-unknown --no-default-features`: passes (this is the new gate).
- `cargo check --workspace --all-features`: passes.
- `cargo nextest run -p reinhardt-apps --all-features`: 125 / 125 passed.
- `cargo fmt -p reinhardt-apps --check`: clean.
- `cargo clippy -p reinhardt-apps --all-features --all-targets -- -D warnings`: clean.
- `cargo make semver-check`: **not run locally** (CI semver-check is
  authoritative for this Draft PR; RP-1a will run before Draft → Ready
  conversion). The diff adds new public surface on wasm and gates
  internal items behind `#[cfg(native)]`, which CI semver-check will
  evaluate per platform.

## Breaking Changes

None on the native target — the public surface visible to native
callers is unchanged. On `wasm32-unknown-unknown`, this PR exposes
public items that previously did not compile at all on that target;
that is additive.

## Labels to Apply

- `refactoring`
- `enhancement`

## Related Issues

Refs #4168

Follow-ups in the #4168 chain:

- C-2: make `reinhardt-websockets` cross-target (covers the
  `WebSocketRouter` portion of the facade shim, lines 1368-1414).
- C-3: remove the facade `#[doc(hidden)]` shim once both C-1 (this PR)
  and C-2 have landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)