### PR TITLE
fix(urls): gate reverse re-exports with cfg(native)

### DIFF
--- a/crates/reinhardt-urls/src/routers.rs
+++ b/crates/reinhardt-urls/src/routers.rs
@@ -186,6 +186,7 @@ pub use helpers::{IncludedRouter, include_routes, path, re_path};
 pub use pattern::{MatchingMode, PathMatcher, PathPattern, RadixRouter, RadixRouterError};
 #[cfg(native)]
 pub use registration::{RouterFactory, UrlPatternsRegistration};
+#[cfg(native)]
 pub use reverse::{
 	ReverseError,
 	ReverseResult,


### PR DESCRIPTION
## Summary

- Add `#[cfg(native)]` to the `pub use reverse::{...}` re-export block in `crates/reinhardt-urls/src/routers.rs` so it matches the gating of `pub mod reverse;` (line 142) and its sibling re-exports.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`reinhardt-urls` fails to build for `wasm32-unknown-unknown` with the `client-router` feature at upstream `f50a484e` because `pub mod reverse;` is `#[cfg(native)]`-gated but the corresponding `pub use reverse::{...}` block is not, producing `error[E0432]: unresolved import \`reverse\``. The unflagged block is a regression from the recent reverse-helper / radix-tree work (#4262, #4321, #4345) that split out the `reverse` module without propagating the cfg gate to the re-export. All neighbouring re-exports (`cache`, `converters`, `helpers`, `pattern`, `registration`, and the deprecated helpers just below) already carry the gate, so this single re-export was the lone exception.

Unblocks `reinhardt-cloud#600` / `#577`, which need to bump past `f50a484e` to consume `ClientLauncher::router_client` (#4262) and `UnifiedRouter::register_globally()` (#4242).

## How Was This Tested

- `cargo check -p reinhardt-urls --all-features` — clean
- `cargo check -p reinhardt-urls --target wasm32-unknown-unknown --no-default-features --features client-router` — clean (this is the exact repro from the issue, previously failed with `E0432`)
- `cargo fmt --check -p reinhardt-urls` — clean
- `cargo clippy -p reinhardt-urls --all-features --no-deps -- -D warnings` — clean

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] No new warnings introduced
- [x] Bug fix verified locally against the issue's repro command
- [x] Documentation not affected (single attribute addition)

## Labels to Apply

- `bug`

## Related Issues

Fixes #4355

🤖 Generated with [Claude Code](https://claude.com/claude-code)