### PR TITLE
style(middleware): fix session.rs import order broken by allow(deprecated)

### DIFF
--- a/crates/reinhardt-middleware/src/session.rs
+++ b/crates/reinhardt-middleware/src/session.rs
@@ -39,9 +39,9 @@ mod tests {
 	use async_trait::async_trait;
 	use bytes::Bytes;
 	use hyper::{HeaderMap, Method, StatusCode, Version};
-	use reinhardt_http::{Handler, Middleware, Request, Response, Result};
 	#[allow(deprecated)]
 	use reinhardt_conf::Settings;
+	use reinhardt_http::{Handler, Middleware, Request, Response, Result};
 	use std::sync::{Arc, RwLock};
 	use std::thread;
 	use std::time::{Duration, SystemTime};


### PR DESCRIPTION
## Summary

- Reorder imports in `crates/reinhardt-middleware/src/session.rs` test module so rustfmt is satisfied
- `#[allow(deprecated)] use reinhardt_conf::Settings;` sits inside the import block; rustfmt wants `reinhardt_http` grouped before it

## Type of Change

- [x] Style / formatting only (no behavior change)

## Motivation and Context

`cargo make fmt-check` currently fails on `main`, causing every open PR's Format Check to fail (e.g. #4357). This is a minimal one-line reorder produced by `cargo make fmt-fix`.

## How Was This Tested

- [x] `cargo make fmt-check` clean locally

## Checklist

- [x] English-only
- [x] No new TODOs
- [x] Issue linked

## Labels to Apply

- `bug`

## Related Issues

Fixes #4360

🤖 Generated with [Claude Code](https://claude.com/claude-code)