### PR TITLE
refactor(pages): unify spawn into platform/, expose spawn_task from prelude

### DIFF
--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -906,7 +906,7 @@ fn generate_onsubmit_handler(macro_ast: &TypedFormMacro, pages_crate: &TokenStre
 								// Clone loading/error signals for async block if they exist
 								#async_signal_clones
 
-								#pages_crate::spawn::spawn_task(async move {
+								#pages_crate::platform::spawn_task(async move {
 									match #server_fn_call {
 										Ok(_value) => {
 											#on_success_code

--- a/crates/reinhardt-pages/src/callback.rs
+++ b/crates/reinhardt-pages/src/callback.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 
 use crate::component::PageEventHandler;
 #[cfg(wasm)]
-use crate::spawn::spawn_task;
+use crate::platform::spawn_task;
 
 #[cfg(wasm)]
 type EventArg = web_sys::Event;

--- a/crates/reinhardt-pages/src/form/component.rs
+++ b/crates/reinhardt-pages/src/form/component.rs
@@ -53,10 +53,10 @@ use super::validators::ValidatorRegistry;
 #[cfg(wasm)]
 use crate::dom::{Document, Element};
 #[cfg(wasm)]
+use crate::platform::spawn_task;
+#[cfg(wasm)]
 use crate::reactive::Effect;
 use crate::reactive::Signal;
-#[cfg(wasm)]
-use crate::spawn::spawn_task;
 #[cfg(wasm)]
 use js_sys::Function;
 #[cfg(wasm)]

--- a/crates/reinhardt-pages/src/platform.rs
+++ b/crates/reinhardt-pages/src/platform.rs
@@ -1,117 +1,28 @@
-//! Platform abstraction for WASM and native targets.
+//! Cross-target platform abstraction (Issue #4365).
 //!
-//! This module provides unified type aliases that work across both WASM and native platforms,
-//! reducing the need for conditional compilation in user code.
-//!
-//! # Example
+//! Unified type aliases and task-spawning utilities that work across both
+//! browser-WASM and native (SSR / proc-macro host) targets. Concentrates the
+//! `#[cfg(wasm)] / #[cfg(native)]` split into [`wasm`] and [`native`]
+//! submodules so consumer code can write:
 //!
 //! ```rust,ignore
-//! use reinhardt_pages::platform::Event;
+//! use reinhardt_pages::platform::{Event, spawn_task};
 //!
-//! // Works on both WASM and native targets
 //! fn handle_click(event: Event) {
-//!     // Event handling logic
+//!     spawn_task(async move {
+//!         // …cross-target async work…
+//!     });
 //! }
 //! ```
 
-/// Platform-specific types for WASM targets.
 #[cfg(wasm)]
-mod inner {
-	/// DOM Event type (web_sys::Event on WASM).
-	pub type Event = web_sys::Event;
+mod wasm;
 
-	/// Window object type (web_sys::Window on WASM).
-	pub type Window = web_sys::Window;
-
-	/// HTML input element type (web_sys::HtmlInputElement on WASM).
-	pub type HtmlInputElement = web_sys::HtmlInputElement;
-
-	/// HTML textarea element type (web_sys::HtmlTextAreaElement on WASM).
-	pub type HtmlTextAreaElement = web_sys::HtmlTextAreaElement;
-
-	/// HTML select element type (web_sys::HtmlSelectElement on WASM).
-	pub type HtmlSelectElement = web_sys::HtmlSelectElement;
-
-	/// HTML form element type (web_sys::HtmlFormElement on WASM).
-	pub type HtmlFormElement = web_sys::HtmlFormElement;
-
-	/// HTML button element type (web_sys::HtmlButtonElement on WASM).
-	pub type HtmlButtonElement = web_sys::HtmlButtonElement;
-}
-
-/// Platform-specific types for native (non-WASM) targets.
-///
-/// These are stub types that maintain API compatibility with WASM code
-/// without requiring web-sys dependencies on native targets.
 #[cfg(native)]
-mod inner {
-	pub use crate::component::DummyEvent as Event;
+mod native;
 
-	/// Stub Window type for SSR compatibility.
-	#[derive(Debug, Clone, Default)]
-	pub struct Window;
+#[cfg(wasm)]
+pub use wasm::*;
 
-	/// Stub HtmlInputElement for SSR compatibility.
-	#[derive(Debug, Clone, Default)]
-	pub struct HtmlInputElement {
-		value: String,
-	}
-
-	impl HtmlInputElement {
-		/// Get the input value.
-		pub fn value(&self) -> String {
-			self.value.clone()
-		}
-
-		/// Set the input value.
-		pub fn set_value(&mut self, value: &str) {
-			self.value = value.to_string();
-		}
-	}
-
-	/// Stub HtmlTextAreaElement for SSR compatibility.
-	#[derive(Debug, Clone, Default)]
-	pub struct HtmlTextAreaElement {
-		value: String,
-	}
-
-	impl HtmlTextAreaElement {
-		/// Get the textarea value.
-		pub fn value(&self) -> String {
-			self.value.clone()
-		}
-
-		/// Set the textarea value.
-		pub fn set_value(&mut self, value: &str) {
-			self.value = value.to_string();
-		}
-	}
-
-	/// Stub HtmlSelectElement for SSR compatibility.
-	#[derive(Debug, Clone, Default)]
-	pub struct HtmlSelectElement {
-		value: String,
-	}
-
-	impl HtmlSelectElement {
-		/// Get the selected value.
-		pub fn value(&self) -> String {
-			self.value.clone()
-		}
-
-		/// Set the selected value.
-		pub fn set_value(&mut self, value: &str) {
-			self.value = value.to_string();
-		}
-	}
-
-	/// Stub HtmlFormElement for SSR compatibility.
-	#[derive(Debug, Clone, Default)]
-	pub struct HtmlFormElement;
-
-	/// Stub HtmlButtonElement for SSR compatibility.
-	#[derive(Debug, Clone, Default)]
-	pub struct HtmlButtonElement;
-}
-
-pub use inner::*;
+#[cfg(native)]
+pub use native::*;

--- a/crates/reinhardt-pages/src/platform/native.rs
+++ b/crates/reinhardt-pages/src/platform/native.rs
@@ -1,0 +1,94 @@
+//! Native (non-WASM) platform stubs.
+//!
+//! Provides type stubs that preserve API compatibility with WASM code
+//! without requiring `web_sys` dependencies on native targets, plus a
+//! no-op `spawn_task` so cross-target component code compiles unmodified.
+
+use std::future::Future;
+
+// --- DOM type stubs -------------------------------------------------------
+
+pub use crate::component::DummyEvent as Event;
+
+/// Stub Window type for SSR compatibility.
+#[derive(Debug, Clone, Default)]
+pub struct Window;
+
+/// Stub HtmlInputElement for SSR compatibility.
+#[derive(Debug, Clone, Default)]
+pub struct HtmlInputElement {
+	value: String,
+}
+
+impl HtmlInputElement {
+	/// Get the input value.
+	pub fn value(&self) -> String {
+		self.value.clone()
+	}
+
+	/// Set the input value.
+	pub fn set_value(&mut self, value: &str) {
+		self.value = value.to_string();
+	}
+}
+
+/// Stub HtmlTextAreaElement for SSR compatibility.
+#[derive(Debug, Clone, Default)]
+pub struct HtmlTextAreaElement {
+	value: String,
+}
+
+impl HtmlTextAreaElement {
+	/// Get the textarea value.
+	pub fn value(&self) -> String {
+		self.value.clone()
+	}
+
+	/// Set the textarea value.
+	pub fn set_value(&mut self, value: &str) {
+		self.value = value.to_string();
+	}
+}
+
+/// Stub HtmlSelectElement for SSR compatibility.
+#[derive(Debug, Clone, Default)]
+pub struct HtmlSelectElement {
+	value: String,
+}
+
+impl HtmlSelectElement {
+	/// Get the selected value.
+	pub fn value(&self) -> String {
+		self.value.clone()
+	}
+
+	/// Set the selected value.
+	pub fn set_value(&mut self, value: &str) {
+		self.value = value.to_string();
+	}
+}
+
+/// Stub HtmlFormElement for SSR compatibility.
+#[derive(Debug, Clone, Default)]
+pub struct HtmlFormElement;
+
+/// Stub HtmlButtonElement for SSR compatibility.
+#[derive(Debug, Clone, Default)]
+pub struct HtmlButtonElement;
+
+// --- Task spawning (no-op) ------------------------------------------------
+
+/// No-op task spawner for native targets.
+///
+/// Mirrors the WASM `spawn_task` signature so cross-target component code
+/// compiles unmodified. The future is dropped; native runtime integration
+/// belongs to the caller (e.g. a tokio context).
+pub fn spawn_task<F>(_fut: F)
+where
+	F: Future<Output = ()> + 'static,
+{
+	// Native: drop the future without execution.
+}
+
+/// No-op yield for native targets. Returns immediately.
+pub async fn defer_yield() {}

--- a/crates/reinhardt-pages/src/platform/wasm.rs
+++ b/crates/reinhardt-pages/src/platform/wasm.rs
@@ -1,0 +1,55 @@
+//! Browser-WASM platform types and task spawning.
+//!
+//! Backed by `web_sys` / `wasm_bindgen_futures`. See [`super`] for the
+//! cross-target dispatch point.
+
+use std::future::Future;
+
+// --- DOM type aliases -----------------------------------------------------
+
+/// DOM Event type (`web_sys::Event` on WASM).
+pub type Event = web_sys::Event;
+
+/// Window object type (`web_sys::Window` on WASM).
+pub type Window = web_sys::Window;
+
+/// HTML input element type (`web_sys::HtmlInputElement` on WASM).
+pub type HtmlInputElement = web_sys::HtmlInputElement;
+
+/// HTML textarea element type (`web_sys::HtmlTextAreaElement` on WASM).
+pub type HtmlTextAreaElement = web_sys::HtmlTextAreaElement;
+
+/// HTML select element type (`web_sys::HtmlSelectElement` on WASM).
+pub type HtmlSelectElement = web_sys::HtmlSelectElement;
+
+/// HTML form element type (`web_sys::HtmlFormElement` on WASM).
+pub type HtmlFormElement = web_sys::HtmlFormElement;
+
+/// HTML button element type (`web_sys::HtmlButtonElement` on WASM).
+pub type HtmlButtonElement = web_sys::HtmlButtonElement;
+
+// --- Task spawning --------------------------------------------------------
+
+/// Spawn a task on the browser's event loop.
+///
+/// Uses `wasm_bindgen_futures::spawn_local` to schedule the future. The
+/// native counterpart is a no-op stub, so this function is cross-target
+/// safe for use in component code that does not care about target.
+pub fn spawn_task<F>(fut: F)
+where
+	F: Future<Output = ()> + 'static,
+{
+	wasm_bindgen_futures::spawn_local(fut);
+}
+
+/// Yield to the event loop by queuing a microtask.
+///
+/// Resolves a `JsFuture` wrapping `Promise.resolve()`, giving the browser
+/// event loop a chance to tick. This is necessary when spawning async work
+/// during initialization (e.g. inside `main()`), where `JsFuture`s from
+/// fetch would otherwise hang.
+pub async fn defer_yield() {
+	use wasm_bindgen::JsValue;
+	let promise = js_sys::Promise::resolve(&JsValue::UNDEFINED);
+	let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+}

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -177,11 +177,24 @@ pub use crate::head;
 pub use crate::page;
 
 // ============================================================================
-// WASM-specific utilities
+// Task spawning (cross-target)
+// ============================================================================
+
+// Cross-target task spawner: WASM uses `wasm_bindgen_futures::spawn_local`,
+// native is a no-op. See [`crate::platform`] for details (Issue #4365).
+pub use crate::platform::{defer_yield, spawn_task};
+
+// ============================================================================
+// WASM-specific utilities (deprecated)
 // ============================================================================
 
 /// Spawn a local async task (WASM only).
 ///
-/// This is a convenience re-export from `wasm_bindgen_futures`.
+/// **Deprecated**: this is a thin re-export from `wasm_bindgen_futures`. Use
+/// [`spawn_task`] instead, which works on both WASM and native targets.
 #[cfg(wasm)]
+#[deprecated(
+	since = "0.1.0-rc.29",
+	note = "use `spawn_task` from `reinhardt_pages::prelude` (cross-target) instead"
+)]
 pub use wasm_bindgen_futures::spawn_local;

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -193,7 +193,5 @@ pub use crate::platform::{defer_yield, spawn_task};
 /// **Deprecated**: this is a thin re-export from `wasm_bindgen_futures`. Use
 /// [`spawn_task`] instead, which works on both WASM and native targets.
 #[cfg(wasm)]
-#[deprecated(
-	note = "use `spawn_task` from `reinhardt_pages::prelude` (cross-target) instead"
-)]
+#[deprecated(note = "use `spawn_task` from `reinhardt_pages::prelude` (cross-target) instead")]
 pub use wasm_bindgen_futures::spawn_local;

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -194,7 +194,6 @@ pub use crate::platform::{defer_yield, spawn_task};
 /// [`spawn_task`] instead, which works on both WASM and native targets.
 #[cfg(wasm)]
 #[deprecated(
-	since = "0.1.0-rc.29",
 	note = "use `spawn_task` from `reinhardt_pages::prelude` (cross-target) instead"
 )]
 pub use wasm_bindgen_futures::spawn_local;

--- a/crates/reinhardt-pages/src/reactive/hooks/async_action.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/async_action.rs
@@ -260,7 +260,7 @@ where
 
 			#[cfg(wasm)]
 			{
-				use crate::spawn::spawn_task;
+				use crate::platform::spawn_task;
 				let state = state.clone();
 				let fut = action_fn(*payload);
 				spawn_task(async move {

--- a/crates/reinhardt-pages/src/reactive/hooks/transition.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/transition.rs
@@ -90,7 +90,7 @@ pub fn use_transition() -> TransitionState {
 
 			#[cfg(wasm)]
 			{
-				use crate::spawn::spawn_task;
+				use crate::platform::spawn_task;
 				let is_pending = is_pending.clone();
 				spawn_task(async move {
 					f();
@@ -164,7 +164,7 @@ pub fn use_deferred_value<T: Clone + 'static>(value: Signal<T>) -> Signal<T> {
 
 			#[cfg(wasm)]
 			{
-				use crate::spawn::spawn_task;
+				use crate::platform::spawn_task;
 				let deferred_clone = deferred_clone.clone();
 				spawn_task(async move {
 					deferred_clone.set(new_value);

--- a/crates/reinhardt-pages/src/reactive/resource.rs
+++ b/crates/reinhardt-pages/src/reactive/resource.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use std::rc::Rc;
 
 #[cfg(wasm)]
-use crate::spawn::{defer_yield, spawn_task};
+use crate::platform::{defer_yield, spawn_task};
 
 /// Type alias for the refetch callback function
 ///

--- a/crates/reinhardt-pages/src/spawn.rs
+++ b/crates/reinhardt-pages/src/spawn.rs
@@ -13,7 +13,6 @@ use std::future::Future;
 
 /// Deprecated alias for [`crate::platform::spawn_task`].
 #[deprecated(
-	since = "0.1.0-rc.29",
 	note = "use `reinhardt_pages::platform::spawn_task` (or the prelude) instead"
 )]
 pub fn spawn_task<F>(fut: F)
@@ -25,7 +24,6 @@ where
 
 /// Deprecated alias for [`crate::platform::defer_yield`].
 #[deprecated(
-	since = "0.1.0-rc.29",
 	note = "use `reinhardt_pages::platform::defer_yield` (or the prelude) instead"
 )]
 pub async fn defer_yield() {

--- a/crates/reinhardt-pages/src/spawn.rs
+++ b/crates/reinhardt-pages/src/spawn.rs
@@ -1,65 +1,33 @@
-//! Task spawning utilities for WASM and non-WASM environments.
+//! Deprecated task-spawning module (Issue #4365).
+//!
+//! The implementation now lives in [`crate::platform`]. This module is kept
+//! as a thin deprecation shim so external code importing
+//! `reinhardt_pages::spawn::{spawn_task, defer_yield}` continues to compile
+//! with a deprecation warning.
+//!
+//! Migration: replace `reinhardt_pages::spawn::*` with
+//! `reinhardt_pages::platform::*` (or use `reinhardt_pages::prelude::*`,
+//! which re-exports both under their canonical names).
 
 use std::future::Future;
 
-/// Spawns a task on the current runtime.
-///
-/// On WASM, this uses `wasm_bindgen_futures::spawn_local` to schedule
-/// the task on the browser's event loop. On non-WASM targets, this is
-/// a no-op stub.
-///
-/// # Example
-///
-/// ```ignore
-/// use reinhardt_pages::spawn::spawn_task;
-///
-/// spawn_task(async move {
-///     let data = fetch_data().await;
-///     process(data);
-/// });
-/// ```
-#[cfg(wasm)]
+/// Deprecated alias for [`crate::platform::spawn_task`].
+#[deprecated(
+	since = "0.1.0-rc.29",
+	note = "use `reinhardt_pages::platform::spawn_task` (or the prelude) instead"
+)]
 pub fn spawn_task<F>(fut: F)
 where
 	F: Future<Output = ()> + 'static,
 {
-	wasm_bindgen_futures::spawn_local(fut);
+	crate::platform::spawn_task(fut)
 }
 
-/// No-op stub for non-WASM targets.
-#[cfg(native)]
-pub fn spawn_task<F>(_fut: F)
-where
-	F: Future<Output = ()> + 'static,
-{
-	// Non-WASM: just drop the future
-}
-
-/// Yields to the event loop by queuing a microtask.
-///
-/// On WASM, this resolves a `JsFuture` wrapping a `Promise.resolve()`,
-/// giving the browser event loop a chance to tick. This is necessary when
-/// spawning async work during initialization (e.g. inside `main()`),
-/// where `JsFuture`s from fetch would otherwise hang.
-#[cfg(wasm)]
+/// Deprecated alias for [`crate::platform::defer_yield`].
+#[deprecated(
+	since = "0.1.0-rc.29",
+	note = "use `reinhardt_pages::platform::defer_yield` (or the prelude) instead"
+)]
 pub async fn defer_yield() {
-	use wasm_bindgen::JsValue;
-	let promise = js_sys::Promise::resolve(&JsValue::UNDEFINED);
-	let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
-}
-
-/// No-op stub for non-WASM targets.
-#[cfg(native)]
-pub async fn defer_yield() {}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn test_spawn_task_compiles() {
-		spawn_task(async {
-			// テスト処理
-		});
-	}
+	crate::platform::defer_yield().await
 }

--- a/crates/reinhardt-pages/src/spawn.rs
+++ b/crates/reinhardt-pages/src/spawn.rs
@@ -12,9 +12,7 @@
 use std::future::Future;
 
 /// Deprecated alias for [`crate::platform::spawn_task`].
-#[deprecated(
-	note = "use `reinhardt_pages::platform::spawn_task` (or the prelude) instead"
-)]
+#[deprecated(note = "use `reinhardt_pages::platform::spawn_task` (or the prelude) instead")]
 pub fn spawn_task<F>(fut: F)
 where
 	F: Future<Output = ()> + 'static,
@@ -23,9 +21,7 @@ where
 }
 
 /// Deprecated alias for [`crate::platform::defer_yield`].
-#[deprecated(
-	note = "use `reinhardt_pages::platform::defer_yield` (or the prelude) instead"
-)]
+#[deprecated(note = "use `reinhardt_pages::platform::defer_yield` (or the prelude) instead")]
 pub async fn defer_yield() {
 	crate::platform::defer_yield().await
 }


### PR DESCRIPTION
## Summary

Stage 2 of Issue #4362. Consolidate `reinhardt-pages`'s platform-specific types (web_sys aliases on WASM, SSR stubs on native) and task-spawning utilities (`spawn_task`, `defer_yield`) into a single `crates/reinhardt-pages/src/platform/` directory with target-dispatched submodules.

`reinhardt_pages::prelude` now exposes `spawn_task` / `defer_yield` as cross-target API. The existing `prelude::spawn_local` re-export is marked `#[deprecated]` pointing at the new cross-target `spawn_task` (the **only** user-visible surface change; non-breaking).

## Type of Change

- [x] Refactoring (non-breaking change that improves code structure)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`crates/reinhardt-pages/src/platform.rs` already provided cross-target DOM type aliases (Event / HtmlInputElement / ...), and `crates/reinhardt-pages/src/spawn.rs` provided `spawn_task` and `defer_yield`. Both were target-dispatched via `#[cfg(wasm)]` / `#[cfg(native)]`, but they lived in separate files with inline target branches. Stage 2 of #4362 unifies them under `platform/` so future browser-only or native-only additions have one obvious home.

## How Was This Tested

```bash
cargo check  -p reinhardt-pages                                           # native, 1m07s
cargo check  -p reinhardt-pages --target wasm32-unknown-unknown           # 18s
cargo clippy -p reinhardt-pages --lib -- -D warnings                      # native, 35s
cargo clippy -p reinhardt-pages --target wasm32-unknown-unknown --lib \
  -- -D warnings                                                          # 12s
cargo fmt --check -p reinhardt-pages -p reinhardt-pages-macros
```

All checks pass with **zero warnings, zero errors** in `reinhardt-pages` and `reinhardt-pages-macros`, including under `clippy::deprecated -D warnings` (i.e. no internal usage of the now-deprecated `spawn_local` re-export or `crate::spawn::*` path).

## File Map

**New:**
- `crates/reinhardt-pages/src/platform/wasm.rs` — `web_sys` type aliases + real `spawn_task` / `defer_yield`
- `crates/reinhardt-pages/src/platform/native.rs` — SSR stubs + no-op `spawn_task` / `defer_yield`

**Modified:**
- `crates/reinhardt-pages/src/platform.rs` — reduced to a `#[cfg(wasm)] mod wasm; #[cfg(native)] mod native; pub use {...}::*;` dispatch
- `crates/reinhardt-pages/src/spawn.rs` — converted to a deprecation shim that delegates to `crate::platform`; preserves the public `reinhardt_pages::spawn::*` path with `#[deprecated]` notices
- `crates/reinhardt-pages/src/prelude.rs` — adds `pub use crate::platform::{spawn_task, defer_yield};`; marks the existing `pub use wasm_bindgen_futures::spawn_local;` with `#[deprecated]`
- Internal call sites migrated to `crate::platform::*` (`callback.rs`, `form/component.rs`, `reactive/resource.rs`, `reactive/hooks/{transition,async_action}.rs`)
- `crates/reinhardt-pages/macros/src/form/codegen.rs` — `form!` macro emits `#pages_crate::platform::spawn_task` instead of `#pages_crate::spawn::spawn_task`

**No deletions.** The Issue body proposed deleting `src/spawn.rs`; this PR keeps it as a deprecation shim so external code importing `reinhardt_pages::spawn::{spawn_task, defer_yield}` directly continues to compile (with a deprecation warning). This trade-off favours safer migration over a hard break and remains compatible with the issue's stated "only one user-visible change" criterion.

## User-Visible API Diff

| Symbol | Before | After |
|---|---|---|
| `reinhardt_pages::platform::{Event, HtmlInputElement, ...}` | exists | unchanged |
| `reinhardt_pages::platform::spawn_task` | n/a | **added** (cross-target) |
| `reinhardt_pages::platform::defer_yield` | n/a | **added** (cross-target) |
| `reinhardt_pages::spawn::spawn_task` | exists | **deprecated** (still works) |
| `reinhardt_pages::spawn::defer_yield` | exists | **deprecated** (still works) |
| `reinhardt_pages::prelude::spawn_task` | n/a | **added** (cross-target) |
| `reinhardt_pages::prelude::defer_yield` | n/a | **added** (cross-target) |
| `reinhardt_pages::prelude::spawn_local` (WASM) | exists | **deprecated** (still works) |

A local `cargo make semver-check` run will be posted as `<!-- local-semver-check -->` before Draft → Ready per `instructions/PR_GUIDELINE.md` § RP-1a. Expected diff: MINOR (additive + deprecation markers).

## Checklist

- [x] Code follows the project's `module.rs + module/` directory style (Rust 2024)
- [x] All code comments are in English
- [x] No `todo!()` / `// TODO:` / `// FIXME:` introduced
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (native + wasm)
- [x] No public API removals — `reinhardt_pages::spawn::*` preserved with `#[deprecated]`
- [x] `Fixes #4365` linked to close the sub-issue on merge
- [x] `Refs #4362` linked to the parent tracking issue
- [ ] `cargo make semver-check` posted as `<!-- local-semver-check -->` comment (before Draft → Ready)

## Labels to Apply

- `enhancement`
- `rc-migration`

Fixes #4365
Refs #4362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
