### PR TITLE
fix(ci): unblock release-plz rc.29 CI on three pre-existing failures

### DIFF
--- a/.github/fixtures/wasm-consumer-augment.patch
+++ b/.github/fixtures/wasm-consumer-augment.patch
@@ -1,63 +1,64 @@
 From: ci-fixture <ci@local>
 Subject: [PATCH] Augment generated wasm-consumer fixture for #4161 regression coverage
 
-Replaces the auto-generated `apps/demo/urls.rs` `routes()` with a
-`#[url_patterns(InstalledApp::demo, mode = unified)]` invocation, adds
-`apps/demo/ws_urls.rs` with `mode = ws`, and registers the new module in
-`apps/demo.rs`. This exercises the four macro re-exports that #4161
-ungated (`app_config`, `urls`, `reinhardt_apps::apps::AppLabel`, and
-`WebSocketRouter`) at a wasm SPA call site.
+The default `--with-pages` scaffold already exercises three of the four
+re-exports that #4161 ungated (`app_config`, `urls` macro, `AppLabel`
+via `InstalledApp::demo`) through the `mode = server` / `mode = client`
+routers it generates. This patch adds two new `#[cfg(client)]` modules
+that exercise the remaining macro modes at a wasm SPA call site:
+
+  - `apps/demo/urls/unified_urls.rs` — `mode = unified` against
+    `reinhardt::UnifiedRouter` (covers the `ServerRouterStub` /
+    `ClientRouter` builder-closure surface).
+  - `apps/demo/urls/ws_urls.rs` — `mode = ws` against
+    `reinhardt::WebSocketRouter` (covers the wasm-side stub's
+    `with_namespace` / `consumer` signature compatibility).
+
+The patch is additive: it does not edit any template-generated content
+beyond appending two `pub mod` declarations to `apps/demo/urls.rs`, so
+it remains stable across cosmetic template refreshes.
 
 Tracks: kent8192/reinhardt-web#4161
 ---
-diff --git a/src/apps/demo.rs b/src/apps/demo.rs
---- a/src/apps/demo.rs
-+++ b/src/apps/demo.rs
-@@ -9,6 +9,7 @@ pub mod admin;
- pub mod models;
- pub mod serializers;
- pub mod urls;
-+pub mod ws_urls;
- pub mod views;
- 
- #[app_config(name = "demo", label = "demo")]
 diff --git a/src/apps/demo/urls.rs b/src/apps/demo/urls.rs
 --- a/src/apps/demo/urls.rs
 +++ b/src/apps/demo/urls.rs
-@@ -1,17 +1,16 @@
--//! URL routing for the demo app.
--//!
--//! The `routes` function is mounted from the project-level `config/urls.rs`
--//! via `.mount("/demo/", crate::apps::demo::urls::routes())`.
--//! Do not annotate this function with `#[routes]` directly — that would
--//! register it without the mount prefix.
-+// Augmented for Issue #4161 regression coverage.
-+// Replaces the generated `routes()` with a #[url_patterns(... mode = unified)]
-+// invocation so the macro expands at a wasm SPA call site against the
-+// (now-ungated) `app_config` / `urls` / `reinhardt_apps::apps::AppLabel`
-+// re-exports.
-+use reinhardt::UnifiedRouter;
-+use reinhardt::url_patterns;
- 
--use reinhardt::ServerRouter;
--
--#[allow(unused_imports)] // `views` will be used once endpoints are added.
-+#[allow(unused_imports)]
- use super::views;
-+use crate::config::apps::InstalledApp;
- 
--pub fn routes() -> ServerRouter {
--	ServerRouter::new()
--	// Register endpoints here, e.g.:
--	//     .endpoint(views::index)
-+#[url_patterns(InstalledApp::demo, mode = unified)]
-+pub fn url_patterns() -> UnifiedRouter {
-+	UnifiedRouter::new()
- }
-diff --git a/src/apps/demo/ws_urls.rs b/src/apps/demo/ws_urls.rs
+@@ -13,3 +13,9 @@
+
+ #[cfg(client)]
+ pub mod client_router;
++
++#[cfg(client)]
++pub mod unified_urls;
++
++#[cfg(client)]
++pub mod ws_urls;
+diff --git a/src/apps/demo/urls/unified_urls.rs b/src/apps/demo/urls/unified_urls.rs
 new file mode 100644
 --- /dev/null
-+++ b/src/apps/demo/ws_urls.rs
++++ b/src/apps/demo/urls/unified_urls.rs
+@@ -0,0 +1,17 @@
++// Augmented for Issue #4161 regression coverage (mode = unified variant).
++// Exercises `reinhardt::UnifiedRouter` against macro expansion produced by
++// `#[url_patterns(... mode = unified)]` at a wasm SPA call site, so the
++// re-export of `UnifiedRouter` (and its `ServerRouterStub` / `ClientRouter`
++// builder closures) stays compatible with the macro output.
++use reinhardt::UnifiedRouter;
++use reinhardt::url_patterns;
++
++use crate::config::apps::InstalledApp;
++
++#[url_patterns(InstalledApp::demo, mode = unified)]
++pub fn unified_url_patterns() -> UnifiedRouter {
++	UnifiedRouter::new()
++	// Endpoints registered through `.server(|_| _)` / `.client(|_| _)`
++	// closures would land here; the empty form is sufficient for the
++	// macro-expansion gate.
++}
+diff --git a/src/apps/demo/urls/ws_urls.rs b/src/apps/demo/urls/ws_urls.rs
+new file mode 100644
+--- /dev/null
++++ b/src/apps/demo/urls/ws_urls.rs
 @@ -0,0 +1,18 @@
 +// Augmented for Issue #4161 regression coverage (mode = ws variant).
 +// Exercises the wasm-side stub of `WebSocketRouter` against macro

--- a/crates/reinhardt-middleware/src/session.rs
+++ b/crates/reinhardt-middleware/src/session.rs
@@ -5,13 +5,13 @@
 //!
 //! This module is split into responsibility-focused submodules:
 //!
-//! - [`id`] — session-ID newtypes and the request-scoped active ID holder
-//! - [`data`] — the `SessionData` payload, read/write/rotate helpers
-//! - [`store`] — in-memory `SessionStore` with lazy eviction
-//! - [`backend`] — pluggable `AsyncSessionBackend` trait
-//! - [`config`] — `SessionConfig` cookie/TTL knobs
-//! - [`middleware`] — `SessionMiddleware` that wires it all together
-//! - [`injectable`] — DI integration (`Injectable` impls + `SessionStoreRef`)
+//! - `id` — session-ID newtypes and the request-scoped active ID holder
+//! - `data` — the `SessionData` payload, read/write/rotate helpers
+//! - `store` — in-memory `SessionStore` with lazy eviction
+//! - `backend` — pluggable `AsyncSessionBackend` trait
+//! - `config` — `SessionConfig` cookie/TTL knobs
+//! - `middleware` — `SessionMiddleware` that wires it all together
+//! - `injectable` — DI integration (`Injectable` impls + `SessionStoreRef`)
 //!
 //! All public types are re-exported here so existing call sites that
 //! used `crate::session::*` continue to work unchanged.

--- a/crates/reinhardt-streaming/src/kafka/config.rs
+++ b/crates/reinhardt-streaming/src/kafka/config.rs
@@ -22,7 +22,7 @@ pub struct KafkaConfig {
 	/// indefinitely. Setting `Some(_)` is most useful in tests that must
 	/// surface a transport failure (e.g. unreachable brokers) within a known
 	/// budget instead of waiting for the test harness timeout.
-	pub backoff_deadline: Option<Duration>,
+	pub(crate) backoff_deadline: Option<Duration>,
 }
 
 impl KafkaConfig {

--- a/crates/reinhardt-streaming/src/kafka/config.rs
+++ b/crates/reinhardt-streaming/src/kafka/config.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU16;
+use std::{num::NonZeroU16, time::Duration};
 
 /// Configuration for connecting to a Kafka cluster.
 #[derive(Debug, Clone)]
@@ -15,6 +15,14 @@ pub struct KafkaConfig {
 	/// Encoded as `NonZeroU16` to make zero — which would be a meaningless
 	/// topic configuration — unrepresentable at the type level.
 	pub partitions: NonZeroU16,
+	/// Optional upper bound on the cumulative retry budget that the underlying
+	/// `rskafka` client applies during connect and metadata refresh.
+	///
+	/// `None` (the default) keeps `rskafka`'s built-in behavior of retrying
+	/// indefinitely. Setting `Some(_)` is most useful in tests that must
+	/// surface a transport failure (e.g. unreachable brokers) within a known
+	/// budget instead of waiting for the test harness timeout.
+	pub backoff_deadline: Option<Duration>,
 }
 
 impl KafkaConfig {
@@ -24,6 +32,7 @@ impl KafkaConfig {
 			client_id: "reinhardt".to_owned(),
 			// SAFETY: 1 is non-zero.
 			partitions: NonZeroU16::new(1).expect("1 is non-zero"),
+			backoff_deadline: None,
 		}
 	}
 
@@ -35,6 +44,17 @@ impl KafkaConfig {
 	/// Set the partition count to use when this config drives topic creation.
 	pub fn with_partitions(mut self, n: NonZeroU16) -> Self {
 		self.partitions = n;
+		self
+	}
+
+	/// Cap the cumulative retry budget for connect and metadata refresh.
+	///
+	/// Maps to `rskafka::client::BackoffConfig::deadline`. Useful to make
+	/// `KafkaProducer::connect` / `KafkaConsumer::connect` surface a
+	/// `StreamingError::Connection` against an unreachable broker within a
+	/// bounded window instead of retrying indefinitely.
+	pub fn with_backoff_deadline(mut self, deadline: Duration) -> Self {
+		self.backoff_deadline = Some(deadline);
 		self
 	}
 }

--- a/crates/reinhardt-streaming/src/kafka/consumer.rs
+++ b/crates/reinhardt-streaming/src/kafka/consumer.rs
@@ -1,5 +1,8 @@
 use crate::{Message, StreamingError, kafka::KafkaConfig};
-use rskafka::client::{Client, ClientBuilder, partition::UnknownTopicHandling};
+use rskafka::{
+	BackoffConfig,
+	client::{Client, ClientBuilder, partition::UnknownTopicHandling},
+};
 use serde::de::DeserializeOwned;
 use std::{
 	collections::HashMap,
@@ -24,8 +27,15 @@ pub struct KafkaConsumer {
 impl KafkaConsumer {
 	/// Connect to the Kafka brokers specified in `config`.
 	pub async fn connect(config: &KafkaConfig) -> Result<Self, StreamingError> {
-		let client = ClientBuilder::new(config.brokers.clone())
-			.client_id(config.client_id.clone())
+		let mut builder =
+			ClientBuilder::new(config.brokers.clone()).client_id(config.client_id.clone());
+		if let Some(deadline) = config.backoff_deadline {
+			builder = builder.backoff_config(BackoffConfig {
+				deadline: Some(deadline),
+				..BackoffConfig::default()
+			});
+		}
+		let client = builder
 			.build()
 			.await
 			.map_err(|e| StreamingError::Connection(e.to_string()))?;

--- a/crates/reinhardt-streaming/src/kafka/producer.rs
+++ b/crates/reinhardt-streaming/src/kafka/producer.rs
@@ -1,6 +1,7 @@
 use crate::{StreamingError, kafka::KafkaConfig};
 use chrono::Utc;
 use rskafka::{
+	BackoffConfig,
 	client::{Client, ClientBuilder, partition::UnknownTopicHandling},
 	record::Record,
 };
@@ -15,8 +16,15 @@ pub struct KafkaProducer {
 impl KafkaProducer {
 	/// Connect to the Kafka brokers specified in `config`.
 	pub async fn connect(config: &KafkaConfig) -> Result<Self, StreamingError> {
-		let client = ClientBuilder::new(config.brokers.clone())
-			.client_id(config.client_id.clone())
+		let mut builder =
+			ClientBuilder::new(config.brokers.clone()).client_id(config.client_id.clone());
+		if let Some(deadline) = config.backoff_deadline {
+			builder = builder.backoff_config(BackoffConfig {
+				deadline: Some(deadline),
+				..BackoffConfig::default()
+			});
+		}
+		let client = builder
 			.build()
 			.await
 			.map_err(|e| StreamingError::Connection(e.to_string()))?;

--- a/crates/reinhardt-streaming/tests/kafka_error_paths.rs
+++ b/crates/reinhardt-streaming/tests/kafka_error_paths.rs
@@ -47,8 +47,17 @@ async fn kafka() -> KafkaContainer {
 /// Port 1 is reserved/privileged and not bound by any normal service, so the
 /// initial metadata request raises a transport error and `connect` must
 /// surface `StreamingError::Connection`.
+///
+/// `rskafka` retries metadata refresh indefinitely by default, which on
+/// firewalled CI runners (where the SYN to `127.0.0.1:1` may be dropped
+/// rather than answered with RST) outlasts the outer `tokio` timeout.
+/// Cap the retry budget below that timeout so the failure surfaces as
+/// `StreamingError::Connection` from `connect` itself, not as an `Elapsed`
+/// panic from the test harness.
 fn unreachable_config() -> KafkaConfig {
-	KafkaConfig::new(["127.0.0.1:1"]).with_client_id("reinhardt-error-test")
+	KafkaConfig::new(["127.0.0.1:1"])
+		.with_client_id("reinhardt-error-test")
+		.with_backoff_deadline(Duration::from_secs(3))
 }
 
 #[rstest]

--- a/crates/reinhardt-testkit/src/fixtures/testcontainers.rs
+++ b/crates/reinhardt-testkit/src/fixtures/testcontainers.rs
@@ -2232,7 +2232,7 @@ static SHARED_KAFKA: tokio::sync::OnceCell<Arc<crate::containers::KafkaContainer
 /// — and its mapped host port — is reused across all callers in the same test
 /// binary.
 ///
-/// See [`SHARED_KAFKA`] for the topic-collision caveat.
+/// See the `SHARED_KAFKA` static for the topic-collision caveat.
 ///
 /// # Examples
 ///

--- a/crates/reinhardt-urls/src/routers/pattern.rs
+++ b/crates/reinhardt-urls/src/routers/pattern.rs
@@ -2,10 +2,10 @@
 //!
 //! This module is split by responsibility into the following submodules:
 //!
-//! - [`validation`]: shared length/segment limits and parameter validators
-//! - [`path_pattern`]: [`PathPattern`] — the parsed, reversible URL pattern
-//! - [`matcher`]: [`PathMatcher`] / [`MatchingMode`] — pattern dispatch
-//! - [`radix`]: [`RadixRouter`] / [`RadixRouterError`] — radix-tree routing
+//! - `validation`: shared length/segment limits and parameter validators
+//! - `path_pattern`: [`PathPattern`] — the parsed, reversible URL pattern
+//! - `matcher`: [`PathMatcher`] / [`MatchingMode`] — pattern dispatch
+//! - `radix`: [`RadixRouter`] / [`RadixRouterError`] — radix-tree routing
 //!
 //! The top-level re-exports below preserve the public API surface that was
 //! available when this module was a single file.

--- a/crates/reinhardt-urls/src/routers/reverse.rs
+++ b/crates/reinhardt-urls/src/routers/reverse.rs
@@ -4,9 +4,9 @@
 //! (compile-time) URL reversal mechanisms, organized into the following
 //! submodules:
 //!
-//! - [`runtime`]: free-function reversers used by both paths
-//! - [`reverser`]: the [`UrlReverser`] registry and top-level [`reverse`] fn
-//! - [`typed`]: [`UrlPattern`] / [`UrlPatternWithParams`] traits and helpers
+//! - `runtime`: free-function reversers used by both paths
+//! - `reverser`: the [`UrlReverser`] registry and top-level [`reverse()`] fn
+//! - `typed`: [`UrlPattern`] / [`UrlPatternWithParams`] traits and helpers
 //!
 //! The top-level re-exports below preserve the public API surface that was
 //! available when this module was a single file.

--- a/crates/reinhardt-urls/src/routers/reverse/runtime.rs
+++ b/crates/reinhardt-urls/src/routers/reverse/runtime.rs
@@ -216,7 +216,7 @@ pub fn reverse_single_pass(pattern: &str, params: &HashMap<String, String>) -> S
 /// Fallible variant of [`reverse_with_aho_corasick`].
 ///
 /// Returns `Err(ReverseError::Validation(..))` instead of panicking when any
-/// parameter value is rejected by [`validate_reverse_param`] (path separators,
+/// parameter value is rejected by `validate_reverse_param` (path separators,
 /// query delimiters, or encoded sequences). Behavior is otherwise identical to
 /// the panicking variant.
 ///
@@ -286,7 +286,7 @@ pub fn try_reverse_with_aho_corasick(
 /// Fallible variant of [`reverse_single_pass`].
 ///
 /// Returns `Err(ReverseError::Validation(..))` instead of panicking when any
-/// parameter value is rejected by [`validate_reverse_param`]. Behavior is
+/// parameter value is rejected by `validate_reverse_param`. Behavior is
 /// otherwise identical to the panicking variant.
 ///
 /// # Examples

--- a/crates/reinhardt-urls/src/routers/server_router.rs
+++ b/crates/reinhardt-urls/src/routers/server_router.rs
@@ -28,22 +28,22 @@
 //! The implementation is split across focused submodules to keep each file
 //! small and reviewable:
 //!
-//! - [`types`]    — `MiddlewareInfo`, `RouteInfo`, `FunctionRoute`, `ViewRoute`,
+//! - `types`    — `MiddlewareInfo`, `RouteInfo`, `FunctionRoute`, `ViewRoute`,
 //!   `RouteHandler`, `RouteMatch`, and the `join_path` helper
-//! - [`builder`] — constructors and builder-style configuration
+//! - `builder` — constructors and builder-style configuration
 //!   (`new`, `with_prefix`, `with_namespace`, `with_di_context`,
 //!   `with_middleware`, `exclude`, `mount`, `group`)
-//! - [`registration`] — route registration entry points
+//! - `registration` — route registration entry points
 //!   (`function`, `handler`, `route`, `viewset`, `endpoint`, `view`,
 //!   `with_route_middleware`)
-//! - [`compile`] — matchit compilation and `validate_*` helpers
-//! - [`introspection`] — read-only accessors, `get_all_routes`,
+//! - `compile` — matchit compilation and `validate_*` helpers
+//! - `introspection` — read-only accessors, `get_all_routes`,
 //!   `register_all_routes`, `reverse`
-//! - [`dispatch`] — `resolve`, `match_own_routes_*`, `path_exists_for_any_method`
-//! - [`router_impls`] — `Debug`, `Default`, `Handler`, `RegisterViewSet`
-//! - [`handlers`] — `FunctionHandler` and `ViewSetHandler` adapters
-//! - [`matching`] — `path_matches` and `extract_params` utilities
-//! - [`global`]   — global router registry used by `showurls`
+//! - `dispatch` — `resolve`, `match_own_routes_*`, `path_exists_for_any_method`
+//! - `router_impls` — `Debug`, `Default`, `Handler`, `RegisterViewSet`
+//! - `handlers` — `FunctionHandler` and `ViewSetHandler` adapters
+//! - `matching` — `path_matches` and `extract_params` utilities
+//! - `global`   — global router registry used by `showurls`
 
 use crate::routers::UrlReverser;
 use matchit::Router as MatchitRouter;

--- a/crates/reinhardt-urls/src/routers/server_router/introspection.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/introspection.rs
@@ -219,7 +219,7 @@ impl ServerRouter {
 
 	/// Register an alias for a route name in this router's reverser.
 	///
-	/// See [`UrlReverser::add_name_alias`] for details.
+	/// See `UrlReverser::add_name_alias` for details.
 	pub fn add_name_alias(&mut self, alias: &str, canonical: &str) {
 		self.reverser.add_name_alias(alias, canonical);
 	}

--- a/crates/reinhardt-views/src/viewsets/handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler.rs
@@ -2,15 +2,15 @@
 //!
 //! This module is split by responsibility:
 //!
-//! - [`view_set_handler`] — `ViewSetHandler`: HTTP-method-to-action mapping
+//! - `view_set_handler` — `ViewSetHandler`: HTTP-method-to-action mapping
 //!   and dispatch to a [`crate::ViewSet`], including DRF-compatible
 //!   `kwargs`/`args` attribute handling and `405 Method Not Allowed`
 //!   response shaping with a populated `Allow` header.
-//! - [`model_view_set_handler`] — `ModelViewSetHandler`: Django REST
+//! - `model_view_set_handler` — `ModelViewSetHandler`: Django REST
 //!   Framework-style CRUD handler (list / retrieve / create / update /
 //!   destroy) with permission checks, optional pagination, and response
 //!   rendering.
-//! - [`error`] — `ViewError` and its conversion into
+//! - `error` — `ViewError` and its conversion into
 //!   `reinhardt_core::exception::Error`.
 //!
 //! The public surface (`ViewSetHandler`, `ModelViewSetHandler`,


### PR DESCRIPTION
## Summary

Single PR resolving the three pre-existing CI failures that surfaced on the release-plz rc.28 → rc.29 PR #4368. None of the failures were caused by the version bump; they live on `main` and would block every future release PR until fixed.

- **Docs.rs Build Check** — backtick out a handful of `rustdoc::private_intra_doc_links` and unresolved-link violations in `reinhardt-testkit` and `reinhardt-urls`.
- **Intra-Crate Integration Tests (1/8, 8/8)** — `KafkaProducer::connect` / `KafkaConsumer::connect` against an unreachable broker exceeded the test's 10s `tokio::time::timeout` because `rskafka`'s default `BackoffConfig` retries forever. Expose a new additive `KafkaConfig::with_backoff_deadline` (plumbed to `ClientBuilder::backoff_config`) and have the test set a 3s deadline so the failure surfaces as `StreamingError::Connection` from `connect` itself.
- **WASM Consumer Fixture (#4161 regression)** — `.github/fixtures/wasm-consumer-augment.patch` no longer applied because the `app_pages_template` scaffold moved from a flat `apps/demo/urls.rs` to the sub-module form (`server_urls` + `client_router`). Rewrote the patch as purely additive: append two `#[cfg(client)] pub mod` declarations to `urls.rs`, plus two new files `urls/unified_urls.rs` (mode = unified / `UnifiedRouter`) and `urls/ws_urls.rs` (mode = ws / `WebSocketRouter`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

PR #4368 (release-plz rc.29) is red on three checks unrelated to the version bump. Without this fix, every subsequent release-plz PR will hit the same failures and block the release cadence.

Fixes #4372. Refs #4368, #4161, #4347.

## How Was This Tested

- `cargo test -p reinhardt-streaming --features kafka --test kafka_error_paths -- connect_returns_connection_error` → **both tests pass in ~3.3s** (previously panicked at 10s `Elapsed`).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p reinhardt-testkit -p reinhardt-urls` → **clean**.
- `git apply --check .github/fixtures/wasm-consumer-augment.patch` against the freshly rendered `apps/demo/urls.rs` from `app_pages_template/urls.rs.tpl` → **exits 0**.
- `cargo clippy -p reinhardt-streaming --features kafka --no-deps -- -D warnings` → **clean**.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (rustdoc only)
- [x] My changes generate no new warnings under the workspace CI invocation (`cargo clippy --workspace --all --all-features -- -D warnings`)
- [x] New / modified tests pass locally
- [x] Linked issue follows project policy (`Fixes #4372`)

## Labels to Apply

- `bug`
- `ci-cd`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)