### PR TITLE
fix(rest): replace private intra-doc link in versioning

### DIFF
--- a/crates/reinhardt-rest/src/versioning.rs
+++ b/crates/reinhardt-rest/src/versioning.rs
@@ -914,7 +914,7 @@ impl NamespaceVersioning {
 	/// Extract a version from a router-aware path, applying the
 	/// configured pattern.
 	///
-	/// Unlike [`Self::extract_version_from_path`], this method is
+	/// Unlike `extract_version_from_path` (private helper), this method is
 	/// router-aware: it returns `Some(version)` only if `path` matches
 	/// (starts with) at least one `path_prefix` registered on the
 	/// router AND the configured pattern successfully extracts a


### PR DESCRIPTION
## Summary

- Replace `[\`Self::extract_version_from_path\`]` with a plain backtick reference in `reinhardt-rest::versioning`
- The target method is private, so under `RUSTDOCFLAGS=--cfg docsrs -D warnings` (docs.rs profile) rustdoc errors out:
  `public documentation for extract_version_from_router links to private item Self::extract_version_from_path`
- This unblocks the **Docs.rs Build Check** job currently failing on the release-plz PR #4377 (rc.29)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The Docs.rs Build Check on PR #4377 fails with the above error, blocking the rc.29 release. Fix is a one-line doc edit; the private helper retains its same documented role.

## How Was This Tested

- Inspected the offending line at `crates/reinhardt-rest/src/versioning.rs:917`
- Pattern matches the known rustdoc intra-doc link failure mode documented in `instructions/QUICK_REFERENCE.md`

## Checklist

- [x] Code follows project style guidelines
- [x] No new TODO/FIXME comments introduced
- [x] Documentation updated (this is a doc-only change)
- [x] PR title follows Conventional Commits

## Labels to Apply

- `bug`
- `documentation`
- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)