### PR TITLE
fix(staticfiles): disable immutable cache for bundle assets in dev builds

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1802,7 +1802,8 @@ impl RunServerCommand {
 			// bundle assets. Without this, browsers never re-validate during
 			// development and hot-reload appears broken. Release builds keep
 			// the immutable policy for production-grade caching.
-			if cfg!(debug_assertions) {
+			#[cfg(debug_assertions)]
+			{
 				static_config = static_config.cache_config(CacheControlConfig::disabled());
 			}
 

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1776,6 +1776,7 @@ impl RunServerCommand {
 		// Add static files middleware for WASM frontend if enabled
 		if with_pages {
 			use reinhardt_utils::staticfiles::PathResolver;
+			use reinhardt_utils::staticfiles::caching::CacheControlConfig;
 			use reinhardt_utils::staticfiles::middleware::{
 				StaticFilesConfig, StaticFilesMiddleware,
 			};
@@ -1794,6 +1795,16 @@ impl RunServerCommand {
 					"/admin/".to_string(),
 					"/static/admin/".to_string(),
 				]);
+
+			// Issue #4383: In debug builds (dev runserver), disable the
+			// long-lived `public, immutable, max-age=31536000` Cache-Control
+			// policy that is applied by default to `.js` / `.wasm` / `.css`
+			// bundle assets. Without this, browsers never re-validate during
+			// development and hot-reload appears broken. Release builds keep
+			// the immutable policy for production-grade caching.
+			if cfg!(debug_assertions) {
+				static_config = static_config.cache_config(CacheControlConfig::disabled());
+			}
 
 			// Resolve index file for SPA fallback (only when SPA mode is enabled)
 			// Refs #2869: Separate index.html (source) from dist/ (build output)

--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -1023,6 +1023,44 @@ mod tests {
 	}
 
 	#[rstest]
+	#[tokio::test]
+	async fn test_try_serve_wasm_with_disabled_cache_omits_cache_control() {
+		// Regression test for issue #4383: in dev (debug) builds the
+		// runserver disables long-lived caching so that browsers re-validate
+		// freshly-built `.wasm` / `.js` bundles. Verify that when the
+		// resolved cache config is `disabled`, the `try_serve` path (used
+		// for bundle assets) does NOT attach `Cache-Control: ... immutable`.
+
+		// Arrange
+		let dir = tempfile::tempdir().unwrap();
+		let wasm_path = dir.path().join("app_bg.wasm");
+		std::fs::write(&wasm_path, b"\0asm\x01\x00\x00\x00").unwrap();
+		let js_path = dir.path().join("app.js");
+		std::fs::write(&js_path, b"export default 0;").unwrap();
+
+		let config =
+			StaticFilesConfig::new(dir.path()).cache_config(CacheControlConfig::disabled());
+		let middleware = StaticFilesMiddleware::new(config);
+
+		// Act
+		let wasm_response = middleware
+			.try_serve("app_bg.wasm")
+			.await
+			.expect("wasm served");
+		let js_response = middleware.try_serve("app.js").await.expect("js served");
+
+		// Assert — neither asset should carry an immutable Cache-Control header.
+		assert!(
+			!wasm_response.headers.contains_key("Cache-Control"),
+			"wasm response should not carry Cache-Control when cache is disabled",
+		);
+		assert!(
+			!js_response.headers.contains_key("Cache-Control"),
+			"js response should not carry Cache-Control when cache is disabled",
+		);
+	}
+
+	#[rstest]
 	fn test_config_auto_inject_wasm_default_true() {
 		// Arrange & Act
 		let config = StaticFilesConfig::default();

--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -1022,7 +1022,6 @@ mod tests {
 		assert!(!response.headers.contains_key("Cache-Control"));
 	}
 
-	#[rstest]
 	#[tokio::test]
 	async fn test_try_serve_wasm_with_disabled_cache_omits_cache_control() {
 		// Regression test for issue #4383: in dev (debug) builds the


### PR DESCRIPTION
## Summary

In debug builds, downgrade the runserver's `--with-pages` StaticFilesConfig so that `.wasm` / `.js` / `.css` bundle assets are served *without* the long-lived `public, immutable, max-age=31536000` Cache-Control header. Release builds are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`StaticFilesConfig::default()` assigns `CachePolicy::long_term` (`public, immutable, max-age=31536000`) to `.js` / `.wasm` / `.css`. The dev runserver (`cargo run --bin manage runserver --with-pages`) inherits this default, so during local development the browser caches the WASM/JS bundles for one year and never re-validates after `wasm-pack` rebuilds — making hot-reload appear broken.

Strategy (a) from the issue is applied: only `crates/reinhardt-commands/src/builtin.rs` (the call site that builds the Pages `StaticFilesConfig`) is modified. When `cfg!(debug_assertions)` is true, `CacheControlConfig::disabled()` is applied; release builds keep the immutable policy for production-grade caching.

Fixes #4383

## How Was This Tested?

- `cargo nextest run -p reinhardt-utils staticfiles` — 213 passed (includes new regression test `test_try_serve_wasm_with_disabled_cache_omits_cache_control` exercising the `try_serve` path for `.wasm` and `.js` with `CacheControlConfig::disabled()`).
- `cargo check -p reinhardt-commands --all-features`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Breaking Changes

None. Behavior change is gated on `cfg!(debug_assertions)`; release builds are byte-identical for cache-control.

## Checklist

- [x] Code follows project style (`fmt-check` + `clippy-check` clean)
- [x] Tests added for the regression
- [x] No new `todo!()` / `// TODO`
- [x] Conventional Commits

## Labels to Apply

- `bug`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)