### PR TITLE
fix(manouche): resolve clippy errors blocking release-plz PR #4396

### DIFF
--- a/crates/reinhardt-manouche/src/core/form_node.rs
+++ b/crates/reinhardt-manouche/src/core/form_node.rs
@@ -75,6 +75,10 @@ pub struct FormMacro {
 	/// Supports static paths (`"/profile"`) or dynamic paths with parameter expansion (`"/profile/{id}"`).
 	/// The redirect is triggered after `on_success` callback (if any) completes.
 	pub redirect_on_success: Option<LitStr>,
+	/// Redirect URL expression on successful form submission
+	///
+	/// Accepts an arbitrary Rust expression (e.g. a function call returning a `String`)
+	/// for dynamic redirect targets that cannot be expressed as a static `LitStr`.
 	pub success_url: Option<Expr>,
 	/// Initial value loader server_fn
 	///

--- a/crates/reinhardt-manouche/src/core/form_typed.rs
+++ b/crates/reinhardt-manouche/src/core/form_typed.rs
@@ -101,6 +101,10 @@ pub struct TypedFormMacro {
 	/// Validated to start with `/` or be a valid URL pattern.
 	/// Supports parameter expansion with `{param}` syntax.
 	pub redirect_on_success: Option<String>,
+	/// Validated redirect URL expression on successful form submission
+	///
+	/// Holds the expression form (`Option<syn::Expr>`) that is emitted directly into the
+	/// generated code, used when the redirect target is computed at runtime.
 	pub success_url: Option<syn::Expr>,
 	/// Initial value loader server_fn
 	///
@@ -530,6 +534,10 @@ pub struct TypedFormFieldDef {
 	///
 	/// Maps this field to a property in the data returned by `initial_loader`.
 	pub initial_from: Option<String>,
+	/// Initial value expression for the field's `Signal::new(...)`
+	///
+	/// When `initial: <expr>` is specified on a field, this holds the user-provided
+	/// expression that overrides the type's default value (issue #4386).
 	pub initial_expr: Option<syn::Expr>,
 	/// Dynamic choices configuration for `ChoiceField`
 	///

--- a/crates/reinhardt-manouche/src/validator/form.rs
+++ b/crates/reinhardt-manouche/src/validator/form.rs
@@ -1152,10 +1152,10 @@ fn extract_initial_from(properties: &[FormFieldProperty]) -> Option<String> {
 /// default (issue #4386).
 fn extract_initial_expr(properties: &[FormFieldProperty]) -> Option<syn::Expr> {
 	for prop in properties {
-		if let FormFieldProperty::Named { name, value, .. } = prop {
-			if name == "initial" {
-				return Some(value.clone());
-			}
+		if let FormFieldProperty::Named { name, value, .. } = prop
+			&& name == "initial"
+		{
+			return Some(value.clone());
 		}
 	}
 	None


### PR DESCRIPTION
## Summary

Release PR #4396 (`chore: release`) fails Clippy / WASM Clippy because four `-D warnings` violations were merged into `main` in `reinhardt-manouche`. release-plz only bumps versions, so the fix must land on `main`; release-plz will then regenerate #4396.

Fixed:

- `crates/reinhardt-manouche/src/validator/form.rs:1155` — `clippy::collapsible_if` → collapsed nested `if` into a let-chain (Rust 1.94)
- `crates/reinhardt-manouche/src/core/form_node.rs:78` — `missing-docs` on `FormDefinition::success_url`
- `crates/reinhardt-manouche/src/core/form_typed.rs:104` — `missing-docs` on `TypedFormDefinition::success_url`
- `crates/reinhardt-manouche/src/core/form_typed.rs:533` — `missing-docs` on `TypedFormField::initial_expr`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Unblocks the v0.1.0-rc.29 release pipeline (release-plz cannot publish while CI is red on the auto-generated release branch).

## How Was This Tested

- [x] `cargo clippy -p reinhardt-manouche --all-features -- -D warnings` (local) passes

## Checklist

- [x] All code comments in English
- [x] No new TODO / FIXME / todo!() introduced
- [x] Docs updated (added doc strings)

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)