### PR TITLE
fix(commands): gate startproject manage.rs template off wasm32 target

### DIFF
--- a/crates/reinhardt-commands/templates/project_pages_template/src/bin/manage.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/bin/manage.rs.tpl
@@ -2,28 +2,46 @@
 //!
 //! This is the project-specific management command interface (equivalent to Django's manage.py).
 //!
+//! This binary is intentionally native-only. The whole module body is gated
+//! behind `not(target_arch = "wasm32")` so that
+//! `cargo check --target wasm32-unknown-unknown` on the workspace does not
+//! try to compile a tokio-based CLI for the browser target. The wasm side
+//! still requires a `main` symbol for `bin` crate-types, so we keep an
+//! empty stub.
+//!
 //! ## Router Registration
 //!
 //! URL patterns are automatically registered by the framework.
 //! No manual registration is required - see `src/config/urls.rs` for the
 //! `#[routes]` attribute macro that enables this.
 
-use {{ crate_name }} as _;
-use reinhardt::commands::execute_from_command_line;
-use std::process;
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+	use {{ crate_name }} as _;
+	use reinhardt::commands::execute_from_command_line;
+	use std::process;
 
-#[tokio::main]
-async fn main() {
-	// Set settings module environment variable
-	// SAFETY: This is safe because we're setting it before any other code runs
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "{{ project_name }}.config.settings");
-	}
+	#[tokio::main]
+	pub(super) async fn main() {
+		// Set settings module environment variable
+		// SAFETY: Called at program start before any spawned tasks.
+		unsafe {
+			std::env::set_var("REINHARDT_SETTINGS_MODULE", "{{ project_name }}.config.settings");
+		}
 
-	// Router registration happens automatically inside execute_from_command_line()
-	// via the #[routes] attribute macro in src/config/urls.rs
-	if let Err(e) = execute_from_command_line().await {
-		eprintln!("Error: {}", e);
-		process::exit(1);
+		// Router registration happens automatically inside execute_from_command_line()
+		// via the #[routes] attribute macro in src/config/urls.rs
+		if let Err(e) = execute_from_command_line().await {
+			eprintln!("Error: {}", e);
+			process::exit(1);
+		}
 	}
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+	native::main();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/crates/reinhardt-commands/templates/project_restful_template/src/bin/manage.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/src/bin/manage.rs.tpl
@@ -2,28 +2,46 @@
 //!
 //! This is the project-specific management command interface (equivalent to Django's manage.py).
 //!
+//! This binary is intentionally native-only. The whole module body is gated
+//! behind `not(target_arch = "wasm32")` so that
+//! `cargo check --target wasm32-unknown-unknown` on the workspace does not
+//! try to compile a tokio-based CLI for the browser target. The wasm side
+//! still requires a `main` symbol for `bin` crate-types, so we keep an
+//! empty stub.
+//!
 //! ## Router Registration
 //!
 //! URL patterns are automatically registered by the framework.
 //! No manual registration is required - see `src/config/urls.rs` for the
 //! `#[routes]` attribute macro that enables this.
 
-use {{ crate_name }} as _;
-use reinhardt::commands::execute_from_command_line;
-use std::process;
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+	use {{ crate_name }} as _;
+	use reinhardt::commands::execute_from_command_line;
+	use std::process;
 
-#[tokio::main]
-async fn main() {
-	// Set settings module environment variable
-	// SAFETY: This is safe because we're setting it before any other code runs
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "{{ project_name }}.config.settings");
-	}
+	#[tokio::main]
+	pub(super) async fn main() {
+		// Set settings module environment variable
+		// SAFETY: Called at program start before any spawned tasks.
+		unsafe {
+			std::env::set_var("REINHARDT_SETTINGS_MODULE", "{{ project_name }}.config.settings");
+		}
 
-	// Router registration happens automatically inside execute_from_command_line()
-	// via the #[routes] attribute macro in src/config/urls.rs
-	if let Err(e) = execute_from_command_line().await {
-		eprintln!("Error: {}", e);
-		process::exit(1);
+		// Router registration happens automatically inside execute_from_command_line()
+		// via the #[routes] attribute macro in src/config/urls.rs
+		if let Err(e) = execute_from_command_line().await {
+			eprintln!("Error: {}", e);
+			process::exit(1);
+		}
 	}
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+	native::main();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}


### PR DESCRIPTION
## Summary

- Make the `manage.rs` emitted by `reinhardt-admin startproject` (both `project_pages_template` and `project_restful_template`) wasm-target-clean by gating the tokio-based body behind `#[cfg(not(target_arch = \"wasm32\"))]` and providing an empty `fn main() {}` stub on wasm.
- Mirrors the gate already applied to `examples/examples-tutorial-basis/src/bin/manage.rs` in 3637a4b2c.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Fresh projects (and any workspace containing a `reinhardt-pages` client) cannot run `cargo check --target wasm32-unknown-unknown` today: the generated `bin/manage` always pulls in `tokio`, `#[tokio::main]`, and `reinhardt::commands::execute_from_command_line` — all native-only — so the wasm check fails with E0432 / E0433 / E0752 on a binary the user never intended to compile for the browser. That noise masks any real wasm errors in the lib (DESIGN_PHILOSOPHY 1 / 4 / 8).

Fixes #4402

## How Was This Tested?

- Manually generated both `--template pages` and the default RESTful project from the patched template and ran `cargo check --target wasm32-unknown-unknown` on each; `bin/manage` now compiles to the empty stub on wasm and the original native code is unchanged.
- Native build path is structurally identical to the reference fix landed in `examples/examples-tutorial-basis/src/bin/manage.rs` (commit 3637a4b2c), which is already exercised by the workspace's native CI.
- Existing template tests (`cargo nextest run -p reinhardt-commands admin_scripts_tests`, `cargo nextest run -p reinhardt-admin-cli e2e_embedded_templates`) do not snapshot template body text, so they are unaffected.

## Breaking Changes

None. Newly generated projects gain the wasm gate; existing projects are not modified.

## Labels to Apply

- `bug`
- `medium`

🤖 Generated with [Claude Code](https://claude.com/claude-code)