### PR TITLE
fix(pages-macros): resolve clippy::collapsible_if in extract_initial_expr

### DIFF
--- a/crates/reinhardt-pages/macros/src/form/validator.rs
+++ b/crates/reinhardt-pages/macros/src/form/validator.rs
@@ -1213,10 +1213,10 @@ fn extract_initial_from(properties: &[FormFieldProperty]) -> Option<String> {
 /// default (issue #4386).
 fn extract_initial_expr(properties: &[FormFieldProperty]) -> Option<syn::Expr> {
 	for prop in properties {
-		if let FormFieldProperty::Named { name, value, .. } = prop {
-			if name == "initial" {
-				return Some(value.clone());
-			}
+		if let FormFieldProperty::Named { name, value, .. } = prop
+			&& name == "initial"
+		{
+			return Some(value.clone());
 		}
 	}
 	None


### PR DESCRIPTION
## Summary

- Collapse nested `if let ... { if cond { .. } }` into a let-chain (`if let ... && cond { .. }`) in `extract_initial_expr` (`crates/reinhardt-pages/macros/src/form/validator.rs`).
- Unblocks Clippy / WASM Clippy CI on the release-plz PR #4405.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

PR #4405 (release-plz auto-release) is failing on:
- `Clippy / Clippy Lint`
- `WASM Check / WASM Clippy (reinhardt-pages)`
- `WASM Check / WASM Clippy (reinhardt-web)`
- `WASM Check / WASM Clippy (reinhardt-web (wasm-features))`

All four failures share the same root cause:

```
error: this `if` statement can be collapsed
    --> crates/reinhardt-pages/macros/src/form/validator.rs:1216:3
     = note: `-D clippy::collapsible-if` implied by `-D warnings`
```

The nested form was introduced for issue #4386 (`initial:` field property). Rust 2024's stabilized let-chains let us merge the outer `if let` with the inner equality check into a single expression.

## How Was This Tested

- [x] `cargo clippy -p reinhardt-pages-macros --all-features -- -D warnings`
- [x] Visual diff confirmed semantics are identical (early-return on `name == "initial"`).

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] I have run `cargo make fmt-check` and `cargo make clippy-check` locally on the changed file

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)