### PR TITLE
fix(admin): gate server-only imports for wasm32 build

### DIFF
--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -489,25 +489,24 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 					.fields
 					.into_iter()
 					.map(|field_info| {
-						let (value, values) = if let Some(ref vals) = response.values {
+						let value = if let Some(ref vals) = response.values {
 							match vals.get(&field_info.name) {
-								// Multi-valued arrays become `values`
-								Some(v) if v.is_array() => {
-									let list: Vec<String> = v
-										.as_array()
-										.map(|arr| {
-											arr.iter()
-												.filter_map(|x| x.as_str().map(|s| s.to_string()))
-												.collect()
-										})
-										.unwrap_or_default();
-									(String::new(), list)
-								}
-								Some(v) => (v.as_str().unwrap_or("").to_string(), Vec::new()),
-								None => (String::new(), Vec::new()),
+								// Multi-valued arrays are flattened to a comma-separated
+								// string until FormField regains first-class multi-value support.
+								Some(v) if v.is_array() => v
+									.as_array()
+									.map(|arr| {
+										arr.iter()
+											.filter_map(|x| x.as_str().map(str::to_string))
+											.collect::<Vec<_>>()
+											.join(", ")
+									})
+									.unwrap_or_default(),
+								Some(v) => v.as_str().unwrap_or("").to_string(),
+								None => String::new(),
 							}
 						} else {
-							(String::new(), Vec::new())
+							String::new()
 						};
 
 						FormField {
@@ -516,7 +515,6 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 							label: field_info.label,
 							required: field_info.required,
 							value,
-							values,
 						}
 					})
 					.collect();

--- a/crates/reinhardt-admin/src/server/create.rs
+++ b/crates/reinhardt-admin/src/server/create.rs
@@ -6,6 +6,7 @@
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite};
 use crate::types::MutationResponse;
+#[cfg(server)]
 use reinhardt_di::Depends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;

--- a/crates/reinhardt-admin/src/server/dashboard.rs
+++ b/crates/reinhardt-admin/src/server/dashboard.rs
@@ -3,6 +3,7 @@
 //! Provides dashboard data retrieval functionality.
 
 use crate::adapters::{AdminSite, DashboardResponse, ModelInfo};
+#[cfg(server)]
 use reinhardt_di::Depends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;

--- a/crates/reinhardt-admin/src/server/delete.rs
+++ b/crates/reinhardt-admin/src/server/delete.rs
@@ -6,6 +6,7 @@
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, BulkDeleteResponse};
 use crate::types::MutationResponse;
+#[cfg(server)]
 use reinhardt_di::Depends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;

--- a/crates/reinhardt-admin/src/server/detail.rs
+++ b/crates/reinhardt-admin/src/server/detail.rs
@@ -5,6 +5,7 @@
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, DetailResponse};
+#[cfg(server)]
 use reinhardt_di::Depends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;

--- a/crates/reinhardt-admin/src/server/export.rs
+++ b/crates/reinhardt-admin/src/server/export.rs
@@ -5,6 +5,7 @@
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, ExportFormat, ExportResponse};
+#[cfg(server)]
 use reinhardt_di::Depends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;

--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -6,6 +6,7 @@
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, FieldInfo, FieldType};
 use crate::types::FieldsResponse;
+#[cfg(server)]
 use reinhardt_di::Depends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;

--- a/crates/reinhardt-admin/src/server/import.rs
+++ b/crates/reinhardt-admin/src/server/import.rs
@@ -5,6 +5,7 @@
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, ImportFormat, ImportResponse};
+#[cfg(server)]
 use reinhardt_di::Depends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;

--- a/crates/reinhardt-admin/src/server/list.rs
+++ b/crates/reinhardt-admin/src/server/list.rs
@@ -10,6 +10,7 @@ use crate::adapters::{
 };
 #[cfg(server)]
 use reinhardt_db::orm::{Filter, FilterCondition, FilterOperator, FilterValue};
+#[cfg(server)]
 use reinhardt_di::Depends;
 use reinhardt_pages::server_fn::{ServerFnError, server_fn};
 use std::sync::Arc;

--- a/crates/reinhardt-admin/src/server/security.rs
+++ b/crates/reinhardt-admin/src/server/security.rs
@@ -455,6 +455,7 @@ pub fn require_csrf_token(
 /// // Non-string values are unchanged
 /// assert_eq!(data.get("age").unwrap().as_i64().unwrap(), 25);
 /// ```
+#[cfg(server)]
 pub fn sanitize_mutation_values(data: &mut HashMap<String, serde_json::Value>) {
 	for value in data.values_mut() {
 		sanitize_json_value(value);
@@ -462,6 +463,7 @@ pub fn sanitize_mutation_values(data: &mut HashMap<String, serde_json::Value>) {
 }
 
 /// Recursively sanitizes a JSON value, escaping HTML in strings.
+#[cfg(server)]
 fn sanitize_json_value(value: &mut serde_json::Value) {
 	match value {
 		serde_json::Value::String(s) => {
@@ -485,11 +487,13 @@ fn sanitize_json_value(value: &mut serde_json::Value) {
 }
 
 /// Checks if a string contains characters that need HTML escaping.
+#[cfg(server)]
 fn needs_html_escaping(s: &str) -> bool {
 	s.contains('<') || s.contains('>') || s.contains('&') || s.contains('"') || s.contains('\'')
 }
 
 /// Escapes HTML special characters in a string.
+#[cfg(server)]
 fn escape_html(input: &str) -> String {
 	reinhardt_core::security::escape_html(input)
 }

--- a/crates/reinhardt-admin/src/server/update.rs
+++ b/crates/reinhardt-admin/src/server/update.rs
@@ -6,6 +6,7 @@
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite};
 use crate::types::MutationResponse;
+#[cfg(server)]
 use reinhardt_di::Depends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;


### PR DESCRIPTION
## Summary

- Gate unconditional `use reinhardt_di::Depends;` with `#[cfg(server)]` in 9 server-fn modules (`create`, `dashboard`, `delete`, `detail`, `export`, `fields`, `import`, `list`, `update`).
- Gate the `escape_html`/`needs_html_escaping`/`sanitize_*` chain in `server/security.rs` with `#[cfg(server)]` (its sole `reinhardt_core` consumer).
- Drop the obsolete `values` field at the `FormField` literal in `pages/router.rs`; flatten array-valued JSON into a comma-separated `value` string.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`cargo build -p reinhardt-admin --target wasm32-unknown-unknown` failed with 11 errors because native-only crates (`reinhardt-di`, `reinhardt-core`) were declared only under the native target in `Cargo.toml`, while the `use` statements were unconditional. The `#[server_fn]` macro removes function bodies on the client but does not touch module-level `use`. The `FormField.values` mismatch was an unrelated API drift.

## How Was This Tested

- `cargo build -p reinhardt-admin --target wasm32-unknown-unknown` — succeeds (0 errors).
- `cargo check -p reinhardt-admin --all-features` — succeeds on native.

## Checklist

- [x] Code compiles for `wasm32-unknown-unknown` and native targets
- [x] Follows project style (tabs, English comments, `module.rs` system)
- [x] No new `todo!()` / `// TODO:` introduced
- [x] Changes confined to the impacted call sites

## Labels to Apply

- `bug`
- `admin`
- `high`

## Related Issues

Fixes #4411

🤖 Generated with [Claude Code](https://claude.com/claude-code)