### PR TITLE
fix(pages-macros): form! initial and inner watch callbacks capture outer scope

### DIFF
--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -102,6 +102,10 @@ pub(super) fn generate(macro_ast: &TypedFormMacro) -> TokenStream {
 	// Generate field initializers
 	let field_inits = generate_field_initializers(&macro_ast.fields, pages_crate);
 
+	// Generate outer-scope assignments for fields with `initial: <expr>` so the
+	// expression is evaluated where its captured locals are visible (#4420).
+	let initial_outer_setup = generate_initial_outer_setup(&macro_ast.fields, pages_crate);
+
 	// Generate state field initializers
 	let state_inits = generate_state_initializers(&effective_state, pages_crate);
 
@@ -187,8 +191,10 @@ pub(super) fn generate(macro_ast: &TypedFormMacro) -> TokenStream {
 
 			// Build the form instance and bind user-supplied watch handlers in
 			// the outer scope, where enclosing-scope locals are visible. This is
-			// what makes `watch:` handlers behave as real closures (issue #4414).
+			// what makes `watch:` handlers behave as real closures (issue #4414)
+			// and what makes `initial: <expr>` capture outer locals (issue #4420).
 			let mut __reinhardt_form = #struct_name::new();
+			#initial_outer_setup
 			#watch_outer_setup
 			__reinhardt_form
 		}
@@ -238,14 +244,18 @@ fn generate_field_initializers(
 	pages_crate: &TokenStream,
 ) -> TokenStream {
 	let fields = collect_all_fields(entries);
+	// `new()` is a `fn` item, so any `initial: <expr>` referencing enclosing-scope
+	// locals fails to compile with `E0434: can't capture dynamic environment in
+	// a fn item` (issue #4420). To preserve closure-like capture semantics for
+	// `initial:` expressions, `new()` always seeds fields with the field type's
+	// default value here; the user-supplied `initial:` expression is evaluated
+	// later in the outer block (where its locals are visible) via
+	// `generate_initial_outer_setup`, which re-assigns the corresponding Signal.
 	let mut inits: Vec<TokenStream> = fields
 		.iter()
 		.map(|field| {
 			let name = &field.name;
-			let init = match &field.initial_expr {
-				Some(expr) => quote! { ::std::convert::Into::into(#expr) },
-				None => field_type_default_value(&field.field_type),
-			};
+			let init = field_type_default_value(&field.field_type);
 			quote! {
 				#name: #pages_crate::reactive::Signal::new(#init),
 			}
@@ -270,6 +280,36 @@ fn generate_field_initializers(
 
 	inits.extend(choices_inits);
 	quote! { #(#inits)* }
+}
+
+/// Generates outer-scope assignments for fields that declared `initial: <expr>`.
+///
+/// The user's `<expr>` is emitted lexically inside the same block as the
+/// `form!` invocation (after `let mut __reinhardt_form = FormName::new();`),
+/// so it can capture enclosing-function locals like any normal closure body.
+/// Each assignment replaces the field's default-seeded Signal with one that
+/// holds the user-supplied value. Because the form was just constructed and
+/// has no subscribers yet, replacing the Signal is observably identical to
+/// constructing it with that value in `new()` — only the scope at which the
+/// expression is evaluated changes (issue #4420).
+fn generate_initial_outer_setup(
+	entries: &[TypedFormFieldEntry],
+	pages_crate: &TokenStream,
+) -> TokenStream {
+	let fields = collect_all_fields(entries);
+	let assigns: Vec<TokenStream> = fields
+		.iter()
+		.filter_map(|field| {
+			let expr = field.initial_expr.as_ref()?;
+			let name = &field.name;
+			Some(quote! {
+				__reinhardt_form.#name = #pages_crate::reactive::Signal::new(
+					::std::convert::Into::into(#expr),
+				);
+			})
+		})
+		.collect();
+	quote! { #(#assigns)* }
 }
 
 /// Generates field accessor methods.
@@ -565,11 +605,26 @@ fn generate_watch_artifacts(
 		// user closure are moved/copied into the outer `move` closure's
 		// environment, and the user closure then borrows from those owned
 		// captures rather than from the surrounding stack frame.
+		//
+		// The user closure is funneled through a local `__coerce` identity
+		// function whose `where`-bound forces its parameter type to
+		// `&#struct_name`. Without this, the user's `|form| { form.method() }`
+		// fails with `E0282: type annotations needed` because Rust type-checks
+		// the closure body before learning the eventual call site's argument
+		// type. The local fn item can name `#struct_name` (types from the
+		// enclosing block are visible to fn items) but does not capture
+		// values, so it does not reintroduce the original `E0434` (#4420).
 		outer_setup.push(quote! {
 			{
 				let __wrapped: #handler_ty = ::std::sync::Arc::new(
 					move |__f: &#struct_name| -> #pages_crate::component::Page {
-						let __user_watch_handler = #closure;
+						fn __coerce<__F, __R>(__f: __F) -> __F
+						where
+							__F: ::core::ops::Fn(&#struct_name) -> __R,
+						{
+							__f
+						}
+						let __user_watch_handler = __coerce(#closure);
 						#pages_crate::component::IntoPage::into_page(
 							__user_watch_handler(__f),
 						)

--- a/crates/reinhardt-pages/tests/ui/form/pass/initial_and_inner_watch_capture_outer_local.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/initial_and_inner_watch_capture_outer_local.rs
@@ -1,0 +1,51 @@
+//! Issue #4420: `form!` macro must let `initial:` expressions and inner
+//! `watch:` callbacks (`submit_button:`, `error_display:`,
+//! `success_navigation:`) behave as real closures that:
+//!
+//! 1. Capture locals from the enclosing scope (no `E0434: can't capture
+//!    dynamic environment in a fn item`).
+//! 2. Type-infer their `|form|` parameter from the surrounding form struct
+//!    (no `E0282: type annotations needed`).
+//!
+//! PR #4416 fixed the outer `watch:` handler for #4414 but left these
+//! sibling sites emitting `fn` items / un-annotated closures. This fixture
+//! exercises both shapes simultaneously.
+
+use reinhardt_pages::form;
+
+fn main() {
+	// Enclosing-scope locals that the macro must let `initial:` and the inner
+	// watch callbacks reach.
+	let outer_initial: i64 = 7;
+	let outer_label = "hello".to_string();
+
+	let _form = form! {
+		name: CaptureFormFourTwoZero,
+		action: "/api/capture-4420",
+
+		state: { loading, error },
+
+		fields: {
+			// `initial: <expr>` referencing an outer local — previously emitted
+			// into `fn new()` and produced E0434.
+			counter: HiddenField { initial: outer_initial.to_string() },
+			content: CharField { required, initial: outer_label.clone() },
+		},
+
+		watch: {
+			// Each of these callbacks invokes a method on `form`. Without the
+			// type-inference fix they fail with E0282 because the closure body
+			// is type-checked before the eventual call site supplies `&Self`.
+			submit_button: |form| {
+				let _is_loading = form.loading().get();
+			},
+			error_display: |form| {
+				let _err = form.error().get();
+			},
+			success_navigation: |form| {
+				let _is_loading = form.loading().get();
+				let _captured = outer_label.clone();
+			},
+		},
+	};
+}


### PR DESCRIPTION
## Summary

The `form!` macro previously emitted user-supplied `initial: <expr>` inside `fn FormName::new()` and bound inner `watch:` callbacks (`submit_button:`, `error_display:`, `success_navigation:`) through an un-annotated intermediate `let`. Both shapes crossed a `fn` item / closure type-inference boundary and produced `E0434: can't capture dynamic environment in a fn item` (for `initial:` referencing outer locals) and `E0282: type annotations needed` (for inner watch closures whose body invokes methods on `form`).

This PR splits the responsibilities so each user expression is evaluated in the lexical scope of the `form!` macro invocation, mirroring the pattern PR #4416 introduced for the outer `watch:` handler.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`cargo make wasm-build` on `examples-tutorial-basis` fails with 4× compiler errors (1× E0434 + 3× E0282) in `client/components/polls.rs`. PR #4416 fixed the outer `watch:` handler for #4414 but did not migrate the sibling field-init expressions or per-callback variants. This PR completes that migration.

Fixes #4420
Refs #4414, #4416

## Implementation

`crates/reinhardt-pages/macros/src/form/codegen.rs`:

* `initial:` — `new()` is now seeded with the field type's default value, and the user expression is re-assigned to the corresponding Signal in the outer block (where its captured locals are visible) via a new `generate_initial_outer_setup` function. The form has no subscribers between construction and assignment, so the observable behavior is identical to constructing the Signal with the value in `new()`.
* Inner `watch:` callbacks — the user closure is now funneled through a local `fn __coerce<F, R>(f: F) -> F where F: Fn(&FormName) -> R` identity helper inside the Arc-wrapping `move` closure. The `where`-bound back-propagates the closure parameter type to its definition site so `|form|` resolves as `&FormName` even when the body calls methods on `form`. The local fn item can name `FormName` because types from the enclosing block are visible to fn items, but it does not capture values, so it does not reintroduce the original `E0434`.

## How Was This Tested?

- [x] `cargo nextest run -p reinhardt-pages-macros` — 285 / 285 passing
- [x] `cargo test -p reinhardt-pages --test ui test_form_macro_pass` — 10 / 10 passing (including new fixture)
- [x] `cargo fmt -p reinhardt-pages-macros -- --check` — clean
- [x] `cargo clippy -p reinhardt-pages-macros --all-features --no-deps -- -D warnings` — clean
- [x] `cargo check --lib --target wasm32-unknown-unknown` on `examples-tutorial-basis` — clean (previously 1× E0434 + 3× E0282)

Trybuild regression coverage added at `crates/reinhardt-pages/tests/ui/form/pass/initial_and_inner_watch_capture_outer_local.rs` exercising both vectors simultaneously: `initial:` referencing two enclosing-scope locals (one numeric, one owned `String`) and all three inner watch callbacks invoking `form.loading().get()` / `form.error().get()`.

## Breaking Changes

None. Generated form types and their public API are unchanged. Only the lexical position at which `initial:` and inner `watch:` user expressions are evaluated has moved (still observable as a single initialization step).

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (in-code rustdoc on the affected codegen helpers)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

- `bug`
- `forms`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)