### PR TITLE
feat(middleware): auto-register middleware-owned DI singletons via Middleware trait

### DIFF
--- a/crates/reinhardt-di/src/registration.rs
+++ b/crates/reinhardt-di/src/registration.rs
@@ -23,7 +23,7 @@
 //! assert_eq!(*scope.get::<i32>().unwrap(), 42);
 //! ```
 
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::sync::Arc;
 
 use crate::SingletonScope;
@@ -57,6 +57,20 @@ impl DiRegistrationList {
 		self.registrations
 			.push(Box::new(move |scope: &SingletonScope| {
 				scope.set_arc(value);
+			}));
+	}
+
+	/// Captures a type-erased `Arc<dyn Any + Send + Sync>` keyed by an
+	/// explicit `TypeId` for deferred singleton registration.
+	///
+	/// This is the type-erased counterpart of [`register_arc`](Self::register_arc)
+	/// and is used by router code that bridges middleware-contributed DI
+	/// registrations (which are exposed as `(TypeId, Arc<dyn Any + Send + Sync>)`
+	/// pairs by `reinhardt-http` to avoid a circular crate dependency).
+	pub fn register_arc_any(&mut self, type_id: TypeId, value: Arc<dyn Any + Send + Sync>) {
+		self.registrations
+			.push(Box::new(move |scope: &SingletonScope| {
+				scope.set_arc_any(type_id, value);
 			}));
 	}
 

--- a/crates/reinhardt-di/src/scope.rs
+++ b/crates/reinhardt-di/src/scope.rs
@@ -210,6 +210,18 @@ impl SingletonScope {
 		let type_id = TypeId::of::<T>();
 		cache.insert(type_id, value);
 	}
+
+	/// Inserts a pre-erased `Arc<dyn Any + Send + Sync>` keyed by an explicit
+	/// `TypeId`.
+	///
+	/// This is the type-erased counterpart of [`set_arc`](Self::set_arc) and
+	/// is intended for callers (such as the `Middleware::di_registrations`
+	/// bridge in `reinhardt-urls`) that have already type-erased the value to
+	/// avoid a circular crate dependency on `reinhardt-di`.
+	pub fn set_arc_any(&self, type_id: TypeId, value: Arc<dyn Any + Send + Sync>) {
+		let mut cache = self.cache.write().unwrap_or_else(PoisonError::into_inner);
+		cache.insert(type_id, value);
+	}
 }
 
 impl Default for SingletonScope {

--- a/crates/reinhardt-http/src/lib.rs
+++ b/crates/reinhardt-http/src/lib.rs
@@ -110,7 +110,9 @@ pub use chunked_upload::{
 pub use extensions::{Extensions, IsActive, IsAdmin, IsAuthenticated};
 #[cfg(feature = "messages")]
 pub use messages_middleware::MessagesMiddleware;
-pub use middleware::{ExcludeMiddleware, Handler, Middleware, MiddlewareChain};
+pub use middleware::{
+	ExcludeMiddleware, Handler, Middleware, MiddlewareChain, MiddlewareDiRegistration,
+};
 pub use path_params::PathParams;
 pub use request::{Request, RequestBuilder, TrustedProxies};
 pub use response::{Response, SafeErrorResponse, StreamBody, StreamingResponse};

--- a/crates/reinhardt-http/src/middleware.rs
+++ b/crates/reinhardt-http/src/middleware.rs
@@ -43,9 +43,19 @@
 
 use async_trait::async_trait;
 use reinhardt_core::exception::Result;
+use std::any::{Any, TypeId};
 use std::sync::Arc;
 
 use crate::{Request, Response};
+
+/// Type-erased DI singleton registration entry contributed by a middleware.
+///
+/// Pairs the concrete `TypeId` of `T` with an `Arc<dyn Any + Send + Sync>` that
+/// can be inserted directly into a DI singleton scope keyed by that `TypeId`.
+/// This indirection lets `reinhardt-http` expose a DI hook on the `Middleware`
+/// trait without taking a dependency on `reinhardt-di` (which would create a
+/// circular crate dependency).
+pub type MiddlewareDiRegistration = (TypeId, Arc<dyn Any + Send + Sync>);
 
 /// Handler trait for processing requests.
 ///
@@ -114,6 +124,43 @@ pub trait Middleware: Send + Sync {
 	/// By default, returns `true` (always execute), maintaining backward compatibility.
 	fn should_continue(&self, _request: &Request) -> bool {
 		true
+	}
+
+	/// Returns DI singleton registrations contributed by this middleware.
+	///
+	/// Each entry is a `(TypeId, Arc<dyn Any + Send + Sync>)` pair representing
+	/// a singleton that the middleware owns and wants to expose to handlers
+	/// resolved via `#[inject]`. The default implementation returns an empty
+	/// vector, preserving backward compatibility for middleware that does not
+	/// own any DI-visible state.
+	///
+	/// Routers such as `ServerRouter` / `UnifiedRouter` call this method when
+	/// the middleware is registered via `with_middleware()` and merge the
+	/// resulting list into the server's DI singleton scope. This lets a
+	/// middleware (for example `SessionMiddleware`) automatically register the
+	/// `Arc<T>` it constructs in its constructor, so callers no longer have to
+	/// thread a parallel `with_di_registrations(...)` call alongside every
+	/// `with_middleware(...)`.
+	///
+	/// # Example
+	///
+	/// ```rust,ignore
+	/// use std::any::TypeId;
+	/// use std::sync::Arc;
+	/// use reinhardt_http::{Middleware, MiddlewareDiRegistration};
+	///
+	/// struct MyStore;
+	/// struct MyMiddleware { store: Arc<MyStore> }
+	///
+	/// impl Middleware for MyMiddleware {
+	///     // ... process / should_continue ...
+	///     fn di_registrations(&self) -> Vec<MiddlewareDiRegistration> {
+	///         vec![(TypeId::of::<MyStore>(), Arc::clone(&self.store) as _)]
+	///     }
+	/// }
+	/// ```
+	fn di_registrations(&self) -> Vec<MiddlewareDiRegistration> {
+		Vec::new()
 	}
 }
 

--- a/crates/reinhardt-middleware/src/session/middleware.rs
+++ b/crates/reinhardt-middleware/src/session/middleware.rs
@@ -318,4 +318,66 @@ mod tests {
 			"resolved Arc<SessionStore> must point at the same allocation the middleware owns"
 		);
 	}
+
+	/// End-to-end injection test: drives the same path a handler with
+	/// `#[inject] session: SessionData` would take. Catches `TypeId` /
+	/// shape regressions in `di_registrations` that `SingletonScope::get`-only
+	/// tests would miss, by going through `InjectionContext` and the real
+	/// `Injectable for SessionData` implementation. See PR #4435 Copilot review.
+	#[tokio::test]
+	async fn test_session_data_inject_resolves_via_middleware_di_registrations() {
+		use crate::session::data::SessionData;
+		use bytes::Bytes;
+		use hyper::{Method, Version};
+		use reinhardt_di::{Injectable, InjectionContext, SingletonScope};
+		use reinhardt_http::Request;
+
+		// Arrange: middleware contributes its Arc<SessionStore> via DI; pre-seed
+		// the store with a valid session so the inject path can load it.
+		let middleware = make_middleware();
+		let store_arc = middleware.store_arc();
+		let mut seeded = SessionData::new(Duration::from_secs(3600));
+		seeded
+			.set("user_id".to_string(), "alice".to_string())
+			.unwrap();
+		let seeded_id = seeded.id.clone();
+		store_arc.save(seeded.clone());
+
+		let scope = SingletonScope::new();
+		let mut list = reinhardt_di::DiRegistrationList::new();
+		for (type_id, value) in middleware.di_registrations() {
+			list.register_arc_any(type_id, value);
+		}
+		list.apply_to(&scope);
+
+		// Build a request that carries the SessionId extension the middleware
+		// would normally inject during `process`. This bypasses Cookie parsing
+		// but exercises the exact branch `SessionData::inject` takes when
+		// `SessionMiddleware` is upstream.
+		let request = Request::builder()
+			.method(Method::GET)
+			.uri("/")
+			.version(Version::HTTP_11)
+			.body(Bytes::new())
+			.build()
+			.unwrap();
+		request.extensions.insert(SessionId::new(seeded_id.clone()));
+
+		// `SessionData::inject` reads the request from the per-request scope
+		// via `ctx.get_request::<Request>()`, so the request must be stored
+		// with `set_request` (request scope) rather than the builder's
+		// `with_request` (which populates the HTTP-request slot accessed by
+		// `get_http_request`).
+		let ctx = InjectionContext::builder(Arc::new(scope)).build();
+		ctx.set_request(request);
+
+		// Act: resolve `SessionData` through the real `#[inject]` code path.
+		let resolved = SessionData::inject(&ctx)
+			.await
+			.expect("SessionData::inject must succeed when middleware DI is registered");
+
+		// Assert: the resolved session is the one the store holds.
+		assert_eq!(resolved.id, seeded_id);
+		assert_eq!(resolved.get::<String>("user_id").as_deref(), Some("alice"));
+	}
 }

--- a/crates/reinhardt-middleware/src/session/middleware.rs
+++ b/crates/reinhardt-middleware/src/session/middleware.rs
@@ -180,14 +180,15 @@ impl Default for SessionMiddleware {
 impl Middleware for SessionMiddleware {
 	/// Exposes the middleware-owned `Arc<SessionStore>` as a DI singleton.
 	///
-	/// Without this, server functions that take `#[inject] session: SessionData`
-	/// or `#[inject] store: SessionStoreRef` would fail to resolve because the
-	/// store created inside `SessionMiddleware::new(...)` would never reach the
-	/// server's `SingletonScope`. See #4426.
+	/// Registered under `TypeId::of::<Arc<SessionStore>>()` to match the lookup
+	/// performed by `SessionData::inject` (`get_singleton::<Arc<SessionStore>>()`),
+	/// which downcasts to `Arc<Arc<SessionStore>>`. The outer `Arc` is the
+	/// `dyn Any` envelope owned by `SingletonScope`; the inner `Arc<SessionStore>`
+	/// is the value handlers actually receive. See #4426.
 	fn di_registrations(&self) -> Vec<MiddlewareDiRegistration> {
 		vec![(
-			TypeId::of::<SessionStore>(),
-			Arc::clone(&self.store) as Arc<dyn std::any::Any + Send + Sync>,
+			TypeId::of::<Arc<SessionStore>>(),
+			Arc::new(Arc::clone(&self.store)) as Arc<dyn std::any::Any + Send + Sync>,
 		)]
 	}
 
@@ -274,17 +275,19 @@ mod tests {
 		// Act: ask the middleware for its DI registrations.
 		let registrations = middleware.di_registrations();
 
-		// Assert: exactly one entry, keyed by SessionStore's TypeId, pointing at
-		// the same underlying allocation as the middleware's own store handle.
+		// Assert: exactly one entry, keyed by Arc<SessionStore>'s TypeId to
+		// match `SessionData::inject`'s `get_singleton::<Arc<SessionStore>>()`
+		// lookup, pointing at the same underlying allocation as the middleware's
+		// own store handle.
 		assert_eq!(registrations.len(), 1);
 		let (type_id, value) = &registrations[0];
-		assert_eq!(*type_id, TypeId::of::<SessionStore>());
+		assert_eq!(*type_id, TypeId::of::<Arc<SessionStore>>());
 		let downcast = value
 			.clone()
-			.downcast::<SessionStore>()
-			.expect("registered Arc must downcast to SessionStore");
+			.downcast::<Arc<SessionStore>>()
+			.expect("registered Arc must downcast to Arc<SessionStore>");
 		assert!(
-			Arc::ptr_eq(&downcast, &store_arc),
+			Arc::ptr_eq(&*downcast, &store_arc),
 			"middleware DI registration must expose the same Arc<SessionStore> the middleware writes to"
 		);
 	}
@@ -304,14 +307,15 @@ mod tests {
 		}
 		list.apply_to(&scope);
 
-		// Assert: the scope now resolves SessionStore to the same Arc the
-		// middleware uses, so handlers injecting SessionData see the same store.
+		// Assert: the scope now resolves `Arc<SessionStore>` to the same Arc the
+		// middleware uses, mirroring what `SessionData::inject` does via
+		// `get_singleton::<Arc<SessionStore>>()`, so handlers see the same store.
 		let resolved = scope
-			.get::<SessionStore>()
-			.expect("SingletonScope must resolve SessionStore after applying middleware DI");
+			.get::<Arc<SessionStore>>()
+			.expect("SingletonScope must resolve Arc<SessionStore> after applying middleware DI");
 		assert!(
-			Arc::ptr_eq(&resolved, &store_arc),
-			"resolved SessionStore must be the same Arc owned by the middleware"
+			Arc::ptr_eq(&*resolved, &store_arc),
+			"resolved Arc<SessionStore> must point at the same allocation the middleware owns"
 		);
 	}
 }

--- a/crates/reinhardt-middleware/src/session/middleware.rs
+++ b/crates/reinhardt-middleware/src/session/middleware.rs
@@ -3,7 +3,8 @@
 use async_trait::async_trait;
 #[allow(deprecated)]
 use reinhardt_conf::Settings;
-use reinhardt_http::{Handler, Middleware, Request, Response, Result};
+use reinhardt_http::{Handler, Middleware, MiddlewareDiRegistration, Request, Response, Result};
+use std::any::TypeId;
 use std::sync::Arc;
 
 use super::config::SessionConfig;
@@ -177,6 +178,19 @@ impl Default for SessionMiddleware {
 
 #[async_trait]
 impl Middleware for SessionMiddleware {
+	/// Exposes the middleware-owned `Arc<SessionStore>` as a DI singleton.
+	///
+	/// Without this, server functions that take `#[inject] session: SessionData`
+	/// or `#[inject] store: SessionStoreRef` would fail to resolve because the
+	/// store created inside `SessionMiddleware::new(...)` would never reach the
+	/// server's `SingletonScope`. See #4426.
+	fn di_registrations(&self) -> Vec<MiddlewareDiRegistration> {
+		vec![(
+			TypeId::of::<SessionStore>(),
+			Arc::clone(&self.store) as Arc<dyn std::any::Any + Send + Sync>,
+		)]
+	}
+
 	async fn process(&self, request: Request, handler: Arc<dyn Handler>) -> Result<Response> {
 		// Get or generate session ID
 		let session_id = self.get_session_id(&request);
@@ -233,5 +247,71 @@ impl Middleware for SessionMiddleware {
 		);
 
 		Ok(response)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+	use std::time::Duration;
+
+	/// Returns a `SessionMiddleware` with a fixed cookie name and TTL for
+	/// deterministic tests.
+	fn make_middleware() -> SessionMiddleware {
+		SessionMiddleware::new(SessionConfig::new(
+			"sessionid".to_string(),
+			Duration::from_secs(3600),
+		))
+	}
+
+	#[rstest]
+	fn test_session_middleware_di_registrations_returns_store() {
+		// Arrange: build a middleware (which internally creates an Arc<SessionStore>).
+		let middleware = make_middleware();
+		let store_arc = middleware.store_arc();
+
+		// Act: ask the middleware for its DI registrations.
+		let registrations = middleware.di_registrations();
+
+		// Assert: exactly one entry, keyed by SessionStore's TypeId, pointing at
+		// the same underlying allocation as the middleware's own store handle.
+		assert_eq!(registrations.len(), 1);
+		let (type_id, value) = &registrations[0];
+		assert_eq!(*type_id, TypeId::of::<SessionStore>());
+		let downcast = value
+			.clone()
+			.downcast::<SessionStore>()
+			.expect("registered Arc must downcast to SessionStore");
+		assert!(
+			Arc::ptr_eq(&downcast, &store_arc),
+			"middleware DI registration must expose the same Arc<SessionStore> the middleware writes to"
+		);
+	}
+
+	#[rstest]
+	fn test_session_middleware_di_registrations_apply_to_singleton_scope() {
+		// Arrange: middleware + an empty SingletonScope.
+		let middleware = make_middleware();
+		let store_arc = middleware.store_arc();
+		let scope = reinhardt_di::SingletonScope::new();
+
+		// Act: feed the middleware's registrations into a DiRegistrationList and
+		// apply it to the scope (mirroring what `with_middleware` does internally).
+		let mut list = reinhardt_di::DiRegistrationList::new();
+		for (type_id, value) in middleware.di_registrations() {
+			list.register_arc_any(type_id, value);
+		}
+		list.apply_to(&scope);
+
+		// Assert: the scope now resolves SessionStore to the same Arc the
+		// middleware uses, so handlers injecting SessionData see the same store.
+		let resolved = scope
+			.get::<SessionStore>()
+			.expect("SingletonScope must resolve SessionStore after applying middleware DI");
+		assert!(
+			Arc::ptr_eq(&resolved, &store_arc),
+			"resolved SessionStore must be the same Arc owned by the middleware"
+		);
 	}
 }

--- a/crates/reinhardt-urls/src/routers/server_router/builder.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/builder.rs
@@ -175,6 +175,22 @@ impl ServerRouter {
 			.next()
 			.unwrap_or(&full_type_name)
 			.to_string();
+		// Harvest middleware-contributed DI singleton registrations and push
+		// them onto the global deferred-registration list so server startup
+		// can apply them to the `SingletonScope`. See #4426. Note that when
+		// this router is wrapped by `UnifiedRouter::with_middleware`, the
+		// outer wrapper has already harvested these into its local
+		// `di_registrations` field; collecting again here is harmless because
+		// both paths ultimately target the same `SingletonScope` and a
+		// repeated `set_arc_any` simply overwrites with the identical `Arc`.
+		let di_entries = mw.di_registrations();
+		if !di_entries.is_empty() {
+			let mut list = reinhardt_di::DiRegistrationList::new();
+			for (type_id, value) in di_entries {
+				list.register_arc_any(type_id, value);
+			}
+			crate::routers::register_di_registrations(list);
+		}
 		self.middleware_names.push(MiddlewareInfo {
 			name: short_name,
 			type_name: full_type_name,

--- a/crates/reinhardt-urls/src/routers/server_router/builder.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/builder.rs
@@ -175,21 +175,29 @@ impl ServerRouter {
 			.next()
 			.unwrap_or(&full_type_name)
 			.to_string();
-		// Harvest middleware-contributed DI singleton registrations and push
-		// them onto the global deferred-registration list so server startup
-		// can apply them to the `SingletonScope`. See #4426. Note that when
-		// this router is wrapped by `UnifiedRouter::with_middleware`, the
-		// outer wrapper has already harvested these into its local
-		// `di_registrations` field; collecting again here is harmless because
-		// both paths ultimately target the same `SingletonScope` and a
-		// repeated `set_arc_any` simply overwrites with the identical `Arc`.
+		// Harvest middleware-contributed DI singleton registrations. When this
+		// router already owns an `InjectionContext` (via `with_di_context`),
+		// apply them directly to that context's `SingletonScope`; startup's
+		// `take_di_registrations()` path is skipped when a user-provided
+		// context exists, so deferring to the global list would silently drop
+		// the registrations (and leak them into the next startup that does
+		// consume the global list). When no context is set, fall back to the
+		// global deferred list so server startup can apply them. Mirrors
+		// `UnifiedRouter::with_middleware`. See #4426.
 		let di_entries = mw.di_registrations();
 		if !di_entries.is_empty() {
-			let mut list = reinhardt_di::DiRegistrationList::new();
-			for (type_id, value) in di_entries {
-				list.register_arc_any(type_id, value);
+			if let Some(ctx) = self.di_context.as_ref() {
+				let scope = ctx.singleton_scope();
+				for (type_id, value) in di_entries {
+					scope.set_arc_any(type_id, value);
+				}
+			} else {
+				let mut list = reinhardt_di::DiRegistrationList::new();
+				for (type_id, value) in di_entries {
+					list.register_arc_any(type_id, value);
+				}
+				crate::routers::register_di_registrations(list);
 			}
-			crate::routers::register_di_registrations(list);
 		}
 		self.middleware_names.push(MiddlewareInfo {
 			name: short_name,

--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -318,7 +318,16 @@ impl UnifiedRouter {
 	/// Add middleware to server router.
 	///
 	/// This is a convenience method that delegates to [`ServerRouter::with_middleware`].
+	///
+	/// Any DI singleton registrations contributed by the middleware (via
+	/// [`Middleware::di_registrations`]) are merged into this router's
+	/// deferred DI registration list so that handlers resolved through
+	/// `#[inject]` can see middleware-owned state without a parallel
+	/// `with_di_registrations(...)` call. See #4426.
 	pub fn with_middleware<M: Middleware + 'static>(mut self, middleware: M) -> Self {
+		for (type_id, value) in middleware.di_registrations() {
+			self.di_registrations.register_arc_any(type_id, value);
+		}
 		self.server = self.server.with_middleware(middleware);
 		self
 	}
@@ -561,7 +570,16 @@ impl UnifiedRouter {
 	}
 
 	/// Add middleware to server router.
+	///
+	/// Any DI singleton registrations contributed by the middleware (via
+	/// [`Middleware::di_registrations`]) are merged into this router's
+	/// deferred DI registration list so that handlers resolved through
+	/// `#[inject]` can see middleware-owned state without a parallel
+	/// `with_di_registrations(...)` call. See #4426.
 	pub fn with_middleware<M: Middleware + 'static>(mut self, middleware: M) -> Self {
+		for (type_id, value) in middleware.di_registrations() {
+			self.di_registrations.register_arc_any(type_id, value);
+		}
 		self.server = self.server.with_middleware(middleware);
 		self
 	}

--- a/examples/examples-tutorial-basis/src/config/urls.rs
+++ b/examples/examples-tutorial-basis/src/config/urls.rs
@@ -91,21 +91,14 @@ pub fn routes() -> UnifiedRouter {
 			.with_di_registrations(admin_di)
 	};
 
-	// Register the SessionMiddleware's `Arc<SessionStore>` as a DI singleton
-	// so server functions that `#[inject] session: SessionData` (or
-	// `#[inject] store: SessionStoreRef`) can resolve the same store the
-	// middleware writes to. Without this, `SessionData::inject` cannot find
-	// the store in `SingletonScope` and every server_fn returns a generic
-	// 500 — see #4423.
+	// `SessionMiddleware` auto-registers its `Arc<SessionStore>` as a DI
+	// singleton via `Middleware::di_registrations`, so server functions that
+	// `#[inject] session: SessionData` (or `#[inject] store: SessionStoreRef`)
+	// can resolve the same store the middleware writes to without a parallel
+	// `with_di_registrations(...)` call. See #4426 (and the original #4423
+	// regression that motivated the auto-registration hook).
 	#[cfg(native)]
-	let router = {
-		let session_mw = create_session_middleware();
-		let mut session_di = reinhardt::di::DiRegistrationList::new();
-		session_di.register(session_mw.store_arc());
-		router
-			.with_middleware(session_mw)
-			.with_di_registrations(session_di)
-	};
+	let router = router.with_middleware(create_session_middleware());
 
 	router
 }


### PR DESCRIPTION
## Summary

Adds a default `di_registrations()` method to the `Middleware` trait so a middleware can expose `Arc`-wrapped singletons it owns as DI registrations. `SessionMiddleware` implements it for its internal `Arc<SessionStore>`, and `ServerRouter::with_middleware` / `UnifiedRouter::with_middleware` harvest the entries and feed them into the deferred DI registration list.

The net effect: callers can replace

```rust
let mw = SessionMiddleware::new(cfg);
let mut di = DiRegistrationList::new();
di.register(mw.store_arc());
router.with_middleware(mw).with_di_registrations(di);
```

with simply

```rust
router.with_middleware(SessionMiddleware::new(cfg));
```

This fixes the root cause behind #4426 (and the regression first patched in #4423): `#[inject] session: SessionData` previously returned `DiError::NotFound` because the middleware-owned `Arc<SessionStore>` never reached the server's `SingletonScope` without explicit wiring.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [x] Refactoring (examples/examples-tutorial-basis simplification)
- [ ] Documentation update

## Motivation and Context

Issue #4426 calls out that `SessionMiddleware::new(config)` constructs `Arc<SessionStore>` internally but never registers it for DI, so any server function using `#[inject] session: SessionData` fails with a generic 500 unless the application manually mirrors the wiring with `with_di_registrations`. Candidate A from the issue body (extend the `Middleware` trait with a DI-registration hook) is implemented here.

## How Was This Tested

- `cargo make fmt-fix` / `cargo make fmt-check` — clean
- `cargo clippy -p reinhardt-http -p reinhardt-di -p reinhardt-middleware -p reinhardt-urls --all-features` — clean
- `cargo nextest run -p reinhardt-http -p reinhardt-di -p reinhardt-urls` — only pre-existing `reinhardt-di::trybuild_tests::injectable_compile_fail` failure (also failing on `origin/main`, unrelated to this PR)
- `cargo nextest run -p reinhardt-middleware --lib session::middleware` — 2/2 new tests pass:
  - `test_session_middleware_di_registrations_returns_store` (shape + `Arc::ptr_eq`)
  - `test_session_middleware_di_registrations_apply_to_singleton_scope` (end-to-end `SingletonScope` resolution)
- `cargo check --manifest-path examples/examples-tutorial-basis/Cargo.toml` — pre-existing `#[model]` derive failure on the polls models that also reproduces on `origin/main` (unrelated)
- SemVer check: **pending** (`cargo make semver-check` not run; will be posted via the `<!-- local-semver-check -->` marker once it completes — see below)

## Design Note: No Circular Dependency

`reinhardt-di` already depends on `reinhardt-http`. To extend the `Middleware` trait in `reinhardt-http` without inverting that dependency, the new method returns `Vec<(TypeId, Arc<dyn Any + Send + Sync>)>` (a fully type-erased pair) instead of a `DiRegistrationList`. `reinhardt-di` exposes matching type-erased entry points (`SingletonScope::set_arc_any`, `DiRegistrationList::register_arc_any`) for the router code to bridge the two crates.

## Breaking Changes

None — the new `Middleware::di_registrations` method has a default implementation returning an empty `Vec`, so all existing `Middleware` impls compile unchanged.

## Maintainer Review Request: SP-6 (`rc-addition`)

This PR adds new public API surface during the RC phase (a default method on the public `Middleware` trait + two new public methods on `SingletonScope` / `DiRegistrationList`). Per `instructions/STABILITY_POLICY.md` SP-6, this requires maintainer approval before being marked Ready for Review. Please confirm the design (especially the type-erased `(TypeId, Arc<dyn Any>)` return shape and the `set_arc_any` / `register_arc_any` companion APIs) before this PR leaves Draft status.

## Local SemVer Check

`cargo make semver-check` is **pending** at the time of PR creation. The marked `<!-- local-semver-check -->` comment will be added once the local run finishes (RP-1a).

## Related Issues

Refs #4426
Refs #4423 (the regression this generalizes the fix for)

🤖 Generated with [Claude Code](https://claude.com/claude-code)