### PR TITLE
fix(urls): middleware DI registrations survive every router-builder order

### DIFF
--- a/crates/reinhardt-urls/src/routers/server_router.rs
+++ b/crates/reinhardt-urls/src/routers/server_router.rs
@@ -143,6 +143,15 @@ pub struct ServerRouter {
 	/// DI context
 	pub(crate) di_context: Option<Arc<InjectionContext>>,
 
+	/// Middleware-contributed DI singleton registrations that have been
+	/// harvested by [`with_middleware`] but not yet applied. Filled when
+	/// [`with_middleware`] runs before [`with_di_context`]; drained either by
+	/// a later [`with_di_context`] call (into that context's `SingletonScope`)
+	/// or, if no context is ever attached, by [`register_all_routes`] (into
+	/// the global deferred-registration list). This avoids both the silent
+	/// drop and the global-list leak described in #4426.
+	pub(crate) pending_middleware_di: reinhardt_di::DiRegistrationList,
+
 	/// Middleware stack
 	pub(crate) middleware: Vec<Arc<dyn Middleware>>,
 

--- a/crates/reinhardt-urls/src/routers/server_router.rs
+++ b/crates/reinhardt-urls/src/routers/server_router.rs
@@ -144,12 +144,13 @@ pub struct ServerRouter {
 	pub(crate) di_context: Option<Arc<InjectionContext>>,
 
 	/// Middleware-contributed DI singleton registrations that have been
-	/// harvested by [`with_middleware`] but not yet applied. Filled when
-	/// [`with_middleware`] runs before [`with_di_context`]; drained either by
-	/// a later [`with_di_context`] call (into that context's `SingletonScope`)
-	/// or, if no context is ever attached, by [`register_all_routes`] (into
-	/// the global deferred-registration list). This avoids both the silent
-	/// drop and the global-list leak described in #4426.
+	/// harvested by [`Self::with_middleware`] but not yet applied. Filled
+	/// when [`Self::with_middleware`] runs before [`Self::with_di_context`];
+	/// drained either by a later [`Self::with_di_context`] call (into that
+	/// context's `SingletonScope`) or, if no context is ever attached, by
+	/// [`Self::register_all_routes`] (into the global deferred-registration
+	/// list). This avoids both the silent drop and the global-list leak
+	/// described in #4426.
 	pub(crate) pending_middleware_di: reinhardt_di::DiRegistrationList,
 
 	/// Middleware stack

--- a/crates/reinhardt-urls/src/routers/server_router/builder.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/builder.rs
@@ -342,16 +342,17 @@ impl ServerRouter {
 			child.prefix = prefix.to_string();
 		}
 
-		// Inherit DI context if child doesn't have one. When inheriting, drain
-		// any pending middleware DI registrations the child staged before it
-		// had a context, mirroring `with_di_context`. See #4426.
+		// Inherit DI context if child doesn't have one. When inheriting,
+		// recursively drain pending middleware DI from the entire subtree
+		// (the child itself AND any grandchildren that also lack a context),
+		// mirroring `with_di_context`. A non-recursive drain would leave
+		// nested grandchildren's staged registrations stranded; later
+		// `register_all_routes` would push them to the global list, which
+		// startup skips when the top router owns a context. See #4426.
 		if child.di_context.is_none()
 			&& let Some(parent_ctx) = self.di_context.as_ref()
 		{
-			if !child.pending_middleware_di.is_empty() {
-				let pending = std::mem::take(&mut child.pending_middleware_di);
-				pending.apply_to(parent_ctx.singleton_scope());
-			}
+			Self::adopt_di_context_recursive(&mut child, parent_ctx);
 			child.di_context = Some(Arc::clone(parent_ctx));
 		}
 
@@ -378,13 +379,11 @@ impl ServerRouter {
 		if child.prefix.is_empty() {
 			child.prefix = prefix.to_string();
 		}
+		// See `mount` for the rationale on recursive subtree adoption.
 		if child.di_context.is_none()
 			&& let Some(parent_ctx) = self.di_context.as_ref()
 		{
-			if !child.pending_middleware_di.is_empty() {
-				let pending = std::mem::take(&mut child.pending_middleware_di);
-				pending.apply_to(parent_ctx.singleton_scope());
-			}
+			Self::adopt_di_context_recursive(&mut child, parent_ctx);
 			child.di_context = Some(Arc::clone(parent_ctx));
 		}
 		self.children.push(child);
@@ -522,6 +521,33 @@ mod middleware_di_tests {
 			"flushed registration must resolve from the global deferred list after apply_to",
 		);
 		assert_eq!(resolved.0, "no-context");
+	}
+
+	#[rstest]
+	#[serial_test::serial(global_di)]
+	fn nested_grandchild_pending_drains_into_parent_context_on_mount() {
+		// Arrange: build a grandchild with pending middleware DI, nest it
+		// inside a child (neither has a context yet), then mount the whole
+		// subtree under a parent that already owns a context. `mount` must
+		// recursively drain the grandchild — not just the immediate child.
+		let scope = Arc::new(SingletonScope::new());
+		let ctx = Arc::new(InjectionContext::builder(Arc::clone(&scope)).build());
+		let grandchild = ServerRouter::new().with_middleware(make_mw("nested-grandchild"));
+		let child = ServerRouter::new().mount("/users/", grandchild);
+
+		// Act
+		let _parent = ServerRouter::new()
+			.with_di_context(Arc::clone(&ctx))
+			.mount("/api/", child);
+
+		let leaked = crate::routers::take_di_registrations();
+
+		// Assert
+		let resolved = scope.get::<DummyState>().expect(
+			"mount must recursively drain grandchildren's pending middleware DI into the parent's context",
+		);
+		assert_eq!(resolved.0, "nested-grandchild");
+		assert!(leaked.is_none());
 	}
 
 	#[rstest]

--- a/crates/reinhardt-urls/src/routers/server_router/builder.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/builder.rs
@@ -88,6 +88,7 @@ impl ServerRouter {
 			views: Vec::new(),
 			children: Vec::new(),
 			di_context: None,
+			pending_middleware_di: reinhardt_di::DiRegistrationList::new(),
 			middleware: Vec::new(),
 			middleware_names: Vec::new(),
 			middleware_exclusions: Vec::new(),
@@ -148,6 +149,15 @@ impl ServerRouter {
 	///     .with_di_context(di_ctx);
 	/// ```
 	pub fn with_di_context(mut self, ctx: Arc<InjectionContext>) -> Self {
+		// Drain any middleware-contributed DI registrations that were harvested
+		// before `with_di_context` was called. Without this, registrations
+		// staged by an earlier `with_middleware` would never reach this
+		// context's `SingletonScope` (startup's `take_di_registrations()` path
+		// is skipped whenever a user-supplied context exists). See #4426.
+		if !self.pending_middleware_di.is_empty() {
+			let pending = std::mem::take(&mut self.pending_middleware_di);
+			pending.apply_to(ctx.singleton_scope());
+		}
 		self.di_context = Some(ctx);
 		self
 	}
@@ -175,15 +185,17 @@ impl ServerRouter {
 			.next()
 			.unwrap_or(&full_type_name)
 			.to_string();
-		// Harvest middleware-contributed DI singleton registrations. When this
-		// router already owns an `InjectionContext` (via `with_di_context`),
-		// apply them directly to that context's `SingletonScope`; startup's
-		// `take_di_registrations()` path is skipped when a user-provided
-		// context exists, so deferring to the global list would silently drop
-		// the registrations (and leak them into the next startup that does
-		// consume the global list). When no context is set, fall back to the
-		// global deferred list so server startup can apply them. Mirrors
-		// `UnifiedRouter::with_middleware`. See #4426.
+		// Harvest middleware-contributed DI singleton registrations. Decision
+		// is order-independent across `with_middleware` / `with_di_context`:
+		//   - If a DI context is already attached, apply directly to its
+		//     `SingletonScope` so handlers resolved through it see the value.
+		//   - Otherwise, stage into `pending_middleware_di`. A later
+		//     `with_di_context` will drain it into the new context; if no
+		//     context is ever attached, `register_all_routes` flushes it to
+		//     the global deferred list (the path startup consumes when no
+		//     user-supplied context exists). This eliminates both the silent
+		//     drop on `with_middleware` → `with_di_context` ordering and the
+		//     global-list leak that would otherwise occur. See #4426.
 		let di_entries = mw.di_registrations();
 		if !di_entries.is_empty() {
 			if let Some(ctx) = self.di_context.as_ref() {
@@ -192,11 +204,9 @@ impl ServerRouter {
 					scope.set_arc_any(type_id, value);
 				}
 			} else {
-				let mut list = reinhardt_di::DiRegistrationList::new();
 				for (type_id, value) in di_entries {
-					list.register_arc_any(type_id, value);
+					self.pending_middleware_di.register_arc_any(type_id, value);
 				}
-				crate::routers::register_di_registrations(list);
 			}
 		}
 		self.middleware_names.push(MiddlewareInfo {
@@ -314,9 +324,17 @@ impl ServerRouter {
 			child.prefix = prefix.to_string();
 		}
 
-		// Inherit DI context if child doesn't have one
-		if child.di_context.is_none() {
-			child.di_context = self.di_context.clone();
+		// Inherit DI context if child doesn't have one. When inheriting, drain
+		// any pending middleware DI registrations the child staged before it
+		// had a context, mirroring `with_di_context`. See #4426.
+		if child.di_context.is_none()
+			&& let Some(parent_ctx) = self.di_context.as_ref()
+		{
+			if !child.pending_middleware_di.is_empty() {
+				let pending = std::mem::take(&mut child.pending_middleware_di);
+				pending.apply_to(parent_ctx.singleton_scope());
+			}
+			child.di_context = Some(Arc::clone(parent_ctx));
 		}
 
 		self.children.push(child);
@@ -342,8 +360,14 @@ impl ServerRouter {
 		if child.prefix.is_empty() {
 			child.prefix = prefix.to_string();
 		}
-		if child.di_context.is_none() {
-			child.di_context = self.di_context.clone();
+		if child.di_context.is_none()
+			&& let Some(parent_ctx) = self.di_context.as_ref()
+		{
+			if !child.pending_middleware_di.is_empty() {
+				let pending = std::mem::take(&mut child.pending_middleware_di);
+				pending.apply_to(parent_ctx.singleton_scope());
+			}
+			child.di_context = Some(Arc::clone(parent_ctx));
 		}
 		self.children.push(child);
 	}
@@ -369,5 +393,140 @@ impl ServerRouter {
 			self.children.push(router);
 		}
 		self
+	}
+}
+
+#[cfg(test)]
+mod middleware_di_tests {
+	use super::*;
+	use async_trait::async_trait;
+	use reinhardt_core::exception::Result;
+	use reinhardt_di::{InjectionContext, SingletonScope};
+	use reinhardt_http::{Handler, Request, Response};
+	use rstest::rstest;
+	use std::any::TypeId;
+	use std::sync::Arc;
+
+	#[derive(Debug, PartialEq, Eq)]
+	struct DummyState(&'static str);
+
+	struct DummyMiddleware {
+		state: Arc<DummyState>,
+	}
+
+	#[async_trait]
+	impl Middleware for DummyMiddleware {
+		async fn process(&self, request: Request, handler: Arc<dyn Handler>) -> Result<Response> {
+			handler.handle(request).await
+		}
+
+		fn di_registrations(&self) -> Vec<reinhardt_http::MiddlewareDiRegistration> {
+			vec![(
+				TypeId::of::<DummyState>(),
+				Arc::clone(&self.state) as Arc<dyn std::any::Any + Send + Sync>,
+			)]
+		}
+	}
+
+	fn make_mw(tag: &'static str) -> DummyMiddleware {
+		DummyMiddleware {
+			state: Arc::new(DummyState(tag)),
+		}
+	}
+
+	#[rstest]
+	#[serial_test::serial(global_di)]
+	fn with_middleware_before_with_di_context_applies_to_context() {
+		// Arrange: builder calls in the order that previously dropped the
+		// registration (with_middleware first, with_di_context later).
+		let scope = Arc::new(SingletonScope::new());
+		let ctx = Arc::new(InjectionContext::builder(Arc::clone(&scope)).build());
+
+		// Act
+		let _router = ServerRouter::new()
+			.with_middleware(make_mw("before-context"))
+			.with_di_context(Arc::clone(&ctx));
+
+		// Drain the global list to assert nothing leaked there.
+		let leaked = crate::routers::take_di_registrations();
+
+		// Assert: scope resolves the middleware-owned singleton, and the
+		// global deferred list received nothing.
+		let resolved = scope
+			.get::<DummyState>()
+			.expect("with_di_context must drain pending middleware DI into the new context");
+		assert_eq!(resolved.0, "before-context");
+		assert!(
+			leaked.is_none(),
+			"pending middleware DI must not leak into the global deferred list when a context is attached later"
+		);
+	}
+
+	#[rstest]
+	#[serial_test::serial(global_di)]
+	fn with_middleware_after_with_di_context_applies_to_context() {
+		// Arrange
+		let scope = Arc::new(SingletonScope::new());
+		let ctx = Arc::new(InjectionContext::builder(Arc::clone(&scope)).build());
+
+		// Act: reverse order — context first, then middleware.
+		let _router = ServerRouter::new()
+			.with_di_context(Arc::clone(&ctx))
+			.with_middleware(make_mw("after-context"));
+
+		let leaked = crate::routers::take_di_registrations();
+
+		// Assert
+		let resolved = scope
+			.get::<DummyState>()
+			.expect("with_middleware after with_di_context must apply directly to context scope");
+		assert_eq!(resolved.0, "after-context");
+		assert!(leaked.is_none());
+	}
+
+	#[rstest]
+	#[serial_test::serial(global_di)]
+	fn with_middleware_without_context_flushes_to_global_on_register_all_routes() {
+		// Arrange: no DI context ever attached. Pending must flush to global
+		// on `register_all_routes`.
+		let _ = crate::routers::take_di_registrations(); // clear any leftover
+
+		// Act
+		let mut router = ServerRouter::new().with_middleware(make_mw("no-context"));
+		let _errors = router.register_all_routes();
+
+		// Assert: global deferred list now contains the registration.
+		let taken = crate::routers::take_di_registrations()
+			.expect("register_all_routes must flush pending middleware DI when no context is set");
+		let scope = SingletonScope::new();
+		taken.apply_to(&scope);
+		let resolved = scope.get::<DummyState>().expect(
+			"flushed registration must resolve from the global deferred list after apply_to",
+		);
+		assert_eq!(resolved.0, "no-context");
+	}
+
+	#[rstest]
+	#[serial_test::serial(global_di)]
+	fn child_pending_drains_into_parent_context_on_mount() {
+		// Arrange: parent has a context; child staged a middleware DI before
+		// being mounted under the parent.
+		let scope = Arc::new(SingletonScope::new());
+		let ctx = Arc::new(InjectionContext::builder(Arc::clone(&scope)).build());
+		let child = ServerRouter::new().with_middleware(make_mw("mounted-child"));
+
+		// Act
+		let _parent = ServerRouter::new()
+			.with_di_context(Arc::clone(&ctx))
+			.mount("/api/", child);
+
+		let leaked = crate::routers::take_di_registrations();
+
+		// Assert
+		let resolved = scope.get::<DummyState>().expect(
+			"mounting a child with pending middleware DI into a context-bearing parent must drain into the parent's scope",
+		);
+		assert_eq!(resolved.0, "mounted-child");
+		assert!(leaked.is_none());
 	}
 }

--- a/crates/reinhardt-urls/src/routers/server_router/builder.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/builder.rs
@@ -406,7 +406,19 @@ impl ServerRouter {
 	/// assert_eq!(router.prefix(), "");
 	/// ```
 	pub fn group(mut self, routers: Vec<ServerRouter>) -> Self {
-		for router in routers {
+		for mut router in routers {
+			// Mirror `mount`: when this router owns a context, recursively
+			// adopt the grouped subtree into it so any pending middleware DI
+			// staged before grouping is drained. Otherwise the grouped
+			// subtree's pending lists would later be pushed onto the global
+			// deferred list, which startup skips when the parent owns a
+			// context. See #4426.
+			if router.di_context.is_none()
+				&& let Some(parent_ctx) = self.di_context.as_ref()
+			{
+				Self::adopt_di_context_recursive(&mut router, parent_ctx);
+				router.di_context = Some(Arc::clone(parent_ctx));
+			}
 			self.children.push(router);
 		}
 		self
@@ -521,6 +533,43 @@ mod middleware_di_tests {
 			"flushed registration must resolve from the global deferred list after apply_to",
 		);
 		assert_eq!(resolved.0, "no-context");
+	}
+
+	#[rstest]
+	#[serial_test::serial(global_di)]
+	fn group_drains_grouped_router_pending_into_parent_context() {
+		// Arrange: each grouped child stages its own middleware DI; one of
+		// them also has a nested grandchild with pending DI to verify the
+		// recursive walk through `group`.
+		let scope = Arc::new(SingletonScope::new());
+		let ctx = Arc::new(InjectionContext::builder(Arc::clone(&scope)).build());
+		let users = ServerRouter::new()
+			.with_prefix("/users")
+			.with_middleware(make_mw("group-users"));
+		let posts_grandchild =
+			ServerRouter::new().with_middleware(make_mw("group-posts-grandchild"));
+		let posts = ServerRouter::new()
+			.with_prefix("/posts")
+			.mount("/comments/", posts_grandchild);
+
+		// Act: group both routers under a context-owning parent.
+		let _parent = ServerRouter::new()
+			.with_di_context(Arc::clone(&ctx))
+			.group(vec![users, posts]);
+
+		let leaked = crate::routers::take_di_registrations();
+
+		// Assert: both staged values reach the parent's scope; the second
+		// `set_arc_any` overwrites the first under the same `DummyState`
+		// `TypeId`, so we only verify presence and absence of global leak.
+		let resolved = scope.get::<DummyState>().expect(
+			"group must recursively drain grouped routers' pending middleware DI into the parent context",
+		);
+		assert!(matches!(
+			resolved.0,
+			"group-users" | "group-posts-grandchild"
+		));
+		assert!(leaked.is_none());
 	}
 
 	#[rstest]

--- a/crates/reinhardt-urls/src/routers/server_router/builder.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/builder.rs
@@ -167,6 +167,20 @@ impl ServerRouter {
 	/// middleware DI registrations into the context's `SingletonScope` along
 	/// the way. Descendants that already own a different context are left
 	/// untouched. See #4426.
+	/// If `parent` owns an `InjectionContext` and `child` does not, recursively
+	/// adopt the parent's context into the child's subtree (draining any
+	/// pending middleware DI registrations along the way) and attach the
+	/// context to the child itself. Used by `mount`, `mount_mut`, and `group`
+	/// to keep the DI propagation behavior in one place. See #4426.
+	fn inherit_context_from_parent_if_any(parent: &ServerRouter, child: &mut ServerRouter) {
+		if child.di_context.is_none()
+			&& let Some(parent_ctx) = parent.di_context.as_ref()
+		{
+			Self::adopt_di_context_recursive(child, parent_ctx);
+			child.di_context = Some(Arc::clone(parent_ctx));
+		}
+	}
+
 	fn adopt_di_context_recursive(router: &mut ServerRouter, ctx: &Arc<InjectionContext>) {
 		if !router.pending_middleware_di.is_empty() {
 			let pending = std::mem::take(&mut router.pending_middleware_di);
@@ -349,12 +363,7 @@ impl ServerRouter {
 		// nested grandchildren's staged registrations stranded; later
 		// `register_all_routes` would push them to the global list, which
 		// startup skips when the top router owns a context. See #4426.
-		if child.di_context.is_none()
-			&& let Some(parent_ctx) = self.di_context.as_ref()
-		{
-			Self::adopt_di_context_recursive(&mut child, parent_ctx);
-			child.di_context = Some(Arc::clone(parent_ctx));
-		}
+		Self::inherit_context_from_parent_if_any(&self, &mut child);
 
 		self.children.push(child);
 		self
@@ -380,12 +389,7 @@ impl ServerRouter {
 			child.prefix = prefix.to_string();
 		}
 		// See `mount` for the rationale on recursive subtree adoption.
-		if child.di_context.is_none()
-			&& let Some(parent_ctx) = self.di_context.as_ref()
-		{
-			Self::adopt_di_context_recursive(&mut child, parent_ctx);
-			child.di_context = Some(Arc::clone(parent_ctx));
-		}
+		Self::inherit_context_from_parent_if_any(self, &mut child);
 		self.children.push(child);
 	}
 
@@ -413,12 +417,7 @@ impl ServerRouter {
 			// subtree's pending lists would later be pushed onto the global
 			// deferred list, which startup skips when the parent owns a
 			// context. See #4426.
-			if router.di_context.is_none()
-				&& let Some(parent_ctx) = self.di_context.as_ref()
-			{
-				Self::adopt_di_context_recursive(&mut router, parent_ctx);
-				router.di_context = Some(Arc::clone(parent_ctx));
-			}
+			Self::inherit_context_from_parent_if_any(&self, &mut router);
 			self.children.push(router);
 		}
 		self

--- a/crates/reinhardt-urls/src/routers/server_router/builder.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/builder.rs
@@ -150,16 +150,34 @@ impl ServerRouter {
 	/// ```
 	pub fn with_di_context(mut self, ctx: Arc<InjectionContext>) -> Self {
 		// Drain any middleware-contributed DI registrations that were harvested
-		// before `with_di_context` was called. Without this, registrations
-		// staged by an earlier `with_middleware` would never reach this
-		// context's `SingletonScope` (startup's `take_di_registrations()` path
-		// is skipped whenever a user-supplied context exists). See #4426.
-		if !self.pending_middleware_di.is_empty() {
-			let pending = std::mem::take(&mut self.pending_middleware_di);
-			pending.apply_to(ctx.singleton_scope());
-		}
+		// before `with_di_context` was called, walking children that have not
+		// already been bound to their own context (e.g., a child mounted
+		// before `with_di_context` was attached). Without this, registrations
+		// staged by an earlier `with_middleware` on this router or any
+		// not-yet-bound child would never reach this context's
+		// `SingletonScope` (startup's `take_di_registrations()` path is
+		// skipped whenever a user-supplied context exists). See #4426.
+		Self::adopt_di_context_recursive(&mut self, &ctx);
 		self.di_context = Some(ctx);
 		self
+	}
+
+	/// Propagate a newly attached `InjectionContext` into every descendant
+	/// that has no context of its own, draining each router's pending
+	/// middleware DI registrations into the context's `SingletonScope` along
+	/// the way. Descendants that already own a different context are left
+	/// untouched. See #4426.
+	fn adopt_di_context_recursive(router: &mut ServerRouter, ctx: &Arc<InjectionContext>) {
+		if !router.pending_middleware_di.is_empty() {
+			let pending = std::mem::take(&mut router.pending_middleware_di);
+			pending.apply_to(ctx.singleton_scope());
+		}
+		for child in router.children.iter_mut() {
+			if child.di_context.is_none() {
+				Self::adopt_di_context_recursive(child, ctx);
+				child.di_context = Some(Arc::clone(ctx));
+			}
+		}
 	}
 
 	/// Returns a reference to the DI context, if set.
@@ -504,6 +522,31 @@ mod middleware_di_tests {
 			"flushed registration must resolve from the global deferred list after apply_to",
 		);
 		assert_eq!(resolved.0, "no-context");
+	}
+
+	#[rstest]
+	#[serial_test::serial(global_di)]
+	fn child_pending_drains_when_context_attached_after_mount() {
+		// Arrange: child is mounted BEFORE the parent has a DI context, so
+		// `mount` cannot drain. Then `with_di_context` runs on the parent and
+		// must propagate into the already-mounted child.
+		let scope = Arc::new(SingletonScope::new());
+		let ctx = Arc::new(InjectionContext::builder(Arc::clone(&scope)).build());
+		let child = ServerRouter::new().with_middleware(make_mw("late-context-child"));
+
+		// Act: mount first, then attach context.
+		let _parent = ServerRouter::new()
+			.mount("/api/", child)
+			.with_di_context(Arc::clone(&ctx));
+
+		let leaked = crate::routers::take_di_registrations();
+
+		// Assert
+		let resolved = scope.get::<DummyState>().expect(
+			"attaching a context after mounting a child with pending middleware DI must propagate into the child",
+		);
+		assert_eq!(resolved.0, "late-context-child");
+		assert!(leaked.is_none());
 	}
 
 	#[rstest]

--- a/crates/reinhardt-urls/src/routers/server_router/introspection.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/introspection.rs
@@ -207,6 +207,13 @@ impl ServerRouter {
 	/// ```
 	#[must_use]
 	pub fn register_all_routes(&mut self) -> Vec<String> {
+		// Flush any middleware-contributed DI registrations that were staged
+		// when no `InjectionContext` was attached, walking children as well.
+		// If a context was attached later via `with_di_context` (or inherited
+		// via `mount`), the staging list is already empty. If no context is
+		// ever attached on this subtree, push the staged registrations onto
+		// the global deferred list so server startup can apply them. See #4426.
+		Self::flush_pending_middleware_di_recursive(self);
 		let registrations = self.collect_routes_recursive(None, "");
 		let mut errors = Vec::new();
 		for (name, path) in registrations {
@@ -215,6 +222,20 @@ impl ServerRouter {
 			}
 		}
 		errors
+	}
+
+	/// Recursively drain middleware-contributed DI registrations that were
+	/// staged before a context could be attached, pushing them to the global
+	/// deferred list when the owning subtree has no `InjectionContext`. See
+	/// #4426.
+	fn flush_pending_middleware_di_recursive(router: &mut ServerRouter) {
+		if !router.pending_middleware_di.is_empty() && router.di_context.is_none() {
+			let pending = std::mem::take(&mut router.pending_middleware_di);
+			crate::routers::register_di_registrations(pending);
+		}
+		for child in router.children.iter_mut() {
+			Self::flush_pending_middleware_di_recursive(child);
+		}
 	}
 
 	/// Register an alias for a route name in this router's reverser.


### PR DESCRIPTION
## Summary

Follow-up fixes to PR #4435 (already merged). After merge, Codex stop-time review surfaced four distinct builder-call orderings that still silently dropped middleware-contributed DI registrations:

1. \`with_middleware(...)\` → \`with_di_context(...)\` — registrations went to the global deferred list, which startup skips when a user-supplied context exists. *(c9baaecb3)*
2. \`mount(child_with_pending)\` → \`with_di_context(ctx)\` on parent — child stayed without context, its pending list was later flushed to the global list and dropped. *(e1400c3cf)*
3. \`with_di_context(ctx)\` → \`mount(child_with_nested_grandchild)\` — \`mount\` drained the direct child but not nested grandchildren. *(8a6abdd65)*
4. \`group(routers_with_pending)\` was the last child-attachment entry point bypassing the recursive adopt walk entirely. *(95af00457)*

Root cause for all four: \`ServerRouter::with_middleware\` used to stash registrations into the global \`deferred_registration\` cell unconditionally; the merged PR fixed the obvious "context already attached" case but left subtree composition holes.

## Fix

- Added a router-owned \`pending_middleware_di: DiRegistrationList\` field. \`with_middleware\` stages into it when no context is attached.
- New private helper \`adopt_di_context_recursive(router, ctx)\` walks the subtree, draining every descendant's pending list into the context's \`SingletonScope\` and inheriting the context. Descendants that already own a different context are left alone.
- \`with_di_context\` / \`mount\` / \`mount_mut\` / \`group\` all route through this helper — single source of truth for context propagation.
- \`register_all_routes\` recursively flushes any still-staged entries to the global deferred list (covers the "no context anywhere" path that startup actually consumes).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The bug was invisible to the existing \`SingletonScope::get\`-direct tests merged in #4435; the only handler-visible symptom was \`#[inject] session: SessionData\` returning \`DiError::NotFound\` at runtime under specific builder orderings. Codex stop-time review caught all four orderings in succession.

## How Was This Tested

Seven regression tests in \`crates/reinhardt-urls/src/routers/server_router/builder.rs\` (\`middleware_di_tests\` module), one per ordering plus the \"no context\" and nested-grandchild edge cases:

- \`with_middleware_before_with_di_context_applies_to_context\`
- \`with_middleware_after_with_di_context_applies_to_context\`
- \`with_middleware_without_context_flushes_to_global_on_register_all_routes\`
- \`child_pending_drains_into_parent_context_on_mount\`
- \`child_pending_drains_when_context_attached_after_mount\`
- \`nested_grandchild_pending_drains_into_parent_context_on_mount\`
- \`group_drains_grouped_router_pending_into_parent_context\`

All 7/7 pass. \`cargo nextest run -p reinhardt-urls -p reinhardt-middleware --all-features\` → 1729/1729 passed.

## Checklist

- [x] Code follows project style guidelines (\`cargo fmt\` / clippy clean on modified files)
- [x] Self-review of code completed
- [x] Code commented where necessary (each fix path references #4426 inline)
- [x] No new warnings introduced
- [x] Tests added that prove the fix is effective (7 regression tests, one per builder ordering)
- [x] All new and existing tests passing

## Labels to Apply

\`bug\` — addresses a runtime DI resolution failure under specific composition orders.

## Related Issues

Fix #4426
Refs #4435

🤖 Generated with [Claude Code](https://claude.com/claude-code)