### PR TITLE
fix(db): introspect within open SchemaEditor transaction during SQLite recreation

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -1035,6 +1035,53 @@ fn field_type_to_metadata_string(ty: &Type, _config: &FieldConfig) -> Result<Str
 	}
 }
 
+/// Serialize a `#[field(default = ...)]` expression into the dialect-neutral
+/// SQL fragment stored in `FieldState.params["default"]`.
+///
+/// The autodetector reads this string verbatim into the generated migration's
+/// `ColumnDefinition.default`, and the runner interpolates it as
+/// `DEFAULT <fragment>` inside the generated DDL. The serialization therefore
+/// has to:
+///
+/// * Produce SQL the three supported dialects (Postgres, MySQL, SQLite) all
+///   accept. For booleans we emit lowercase `true` / `false`; Postgres and
+///   MySQL accept these as literals and SQLite (≥ 3.23) treats them as
+///   integer 1 / 0.
+/// * Quote string literals so that `default = "active"` lands as `'active'`.
+///   We use SQL single-quote escaping (double the inner quote) rather than
+///   Rust escaping.
+/// * Stay opt-in for anything we cannot prove is safe — unrecognised forms
+///   (function calls, paths, complex expressions) return `None` so that the
+///   macro keeps today's behaviour of silently omitting the default rather
+///   than emitting something that would break parsing downstream. The runner
+///   surfaces a clearer "missing default" failure when this matters; see
+///   reinhardt-web#4447.
+fn serialize_field_default(expr: &syn::Expr) -> Option<String> {
+	// Allow a leading unary `-` so `default = -1` works.
+	if let syn::Expr::Unary(unary) = expr
+		&& matches!(unary.op, syn::UnOp::Neg(_))
+		&& let Some(inner) = serialize_field_default(&unary.expr)
+	{
+		return Some(format!("-{}", inner));
+	}
+
+	let lit = match expr {
+		syn::Expr::Lit(l) => &l.lit,
+		_ => return None,
+	};
+	match lit {
+		syn::Lit::Bool(b) => Some(if b.value {
+			"true".into()
+		} else {
+			"false".into()
+		}),
+		syn::Lit::Int(i) => Some(i.base10_digits().to_string()),
+		syn::Lit::Float(f) => Some(f.base10_digits().to_string()),
+		syn::Lit::Str(s) => Some(format!("'{}'", s.value().replace('\'', "''"))),
+		_ => None,
+	}
+}
+
 /// Map Rust type to ORM field type
 fn map_type_to_field_type(ty: &Type, config: &FieldConfig) -> Result<TokenStream> {
 	let migrations_crate = get_reinhardt_migrations_crate();
@@ -2692,6 +2739,18 @@ fn generate_registration_code(
 		}
 		if config.auto_now_add == Some(true) {
 			params.push(quote! { .with_param("auto_now_add", "true") });
+		}
+
+		// Propagate `#[field(default = ...)]` into FieldState.params so the
+		// autodetector emits `ColumnDefinition.default = Some(<sql>)`. Without
+		// this, makemigrations dropped the default on the floor and the
+		// runner produced `ADD COLUMN ... NOT NULL` with no DEFAULT — see
+		// reinhardt-web#4447. Unrecognised expression forms are intentionally
+		// skipped (today's behaviour) rather than emitted as garbage.
+		if let Some(ref default_expr) = config.default
+			&& let Some(serialized) = serialize_field_default(default_expr)
+		{
+			params.push(quote! { .with_param("default", #serialized) });
 		}
 
 		// Generate ForeignKey information if present

--- a/crates/reinhardt-db/src/migrations/executor.rs
+++ b/crates/reinhardt-db/src/migrations/executor.rs
@@ -717,46 +717,100 @@ impl DatabaseMigrationExecutor {
 		Ok(plan)
 	}
 
-	/// Get table information for SQLite table recreation
+	/// Read columns + constraints for a SQLite table using the SchemaEditor's
+	/// currently-open transaction (if any), falling back to the live pool when
+	/// the editor is non-atomic.
 	///
-	/// Uses introspection to read current table schema and convert to
-	/// ColumnDefinition and Constraint types needed for SqliteTableRecreation.
+	/// This exists because `SQLiteIntrospector` issues every query through the
+	/// underlying `sqlx::SqlitePool`, which transparently picks a *different*
+	/// physical connection than the one holding the editor's open transaction.
+	/// That second connection cannot see uncommitted DDL — so a recreation
+	/// triggered later in the same migration would rebuild the table from a
+	/// stale column list and silently discard the just-`ALTER`'d column.
+	/// See reinhardt-web#4447.
 	#[cfg(feature = "sqlite")]
-	async fn get_sqlite_table_metadata(
-		&self,
+	async fn read_sqlite_table_via_editor(
+		editor: &mut SchemaEditor,
 		table_name: &str,
 	) -> Result<(Vec<super::ColumnDefinition>, Vec<super::Constraint>)> {
-		use super::introspection::DatabaseIntrospector;
+		// 1. PRAGMA table_info(<table>) → columns
+		let table_info_sql = format!("PRAGMA table_info({})", table_name);
+		let info_rows = editor.fetch_all(&table_info_sql, vec![]).await?;
 
-		// Get SQLite pool from connection
-		let pool = self.connection.into_sqlite().ok_or_else(|| {
-			MigrationError::IntrospectionError(
-				"Failed to get SQLite pool from connection".to_string(),
+		// Collect rows into typed records first so we can detect AUTOINCREMENT.
+		struct ColRow {
+			name: String,
+			type_str: String,
+			notnull: i64,
+			default: Option<String>,
+			pk: i64,
+		}
+		let mut col_rows: Vec<ColRow> = Vec::with_capacity(info_rows.len());
+		for row in &info_rows {
+			let name: String = row
+				.get("name")
+				.map_err(|e| MigrationError::IntrospectionError(format!("table_info name: {e}")))?;
+			let type_str: String = row.get("type").unwrap_or_default();
+			let notnull: i64 = row.get("notnull").unwrap_or(0);
+			let default: Option<String> = row.get("dflt_value").ok();
+			let pk: i64 = row.get("pk").unwrap_or(0);
+			col_rows.push(ColRow {
+				name,
+				type_str,
+				notnull,
+				default,
+				pk,
+			});
+		}
+
+		// 2. CREATE TABLE SQL → detect AUTOINCREMENT and parse named
+		//    constraint metadata (FK names + CHECK constraints).
+		let create_sql_row = editor
+			.fetch_optional(
+				"SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+				vec![table_name.into()],
 			)
-		})?;
+			.await?;
+		let create_sql: Option<String> = create_sql_row.and_then(|r| r.get("sql").ok());
+		let has_autoincrement = create_sql
+			.as_ref()
+			.map(|sql| sql.to_uppercase().contains("AUTOINCREMENT"))
+			.unwrap_or(false);
 
-		// Create introspector and read table
-		let introspector = SQLiteIntrospector::new(pool);
-		let table_info = introspector.read_table(table_name).await?.ok_or_else(|| {
-			MigrationError::IntrospectionError(format!("Table '{}' not found", table_name))
-		})?;
-
-		// Convert ColumnInfo to ColumnDefinition
-		let mut columns: Vec<super::ColumnDefinition> = table_info
-			.columns
-			.values()
-			.map(|col_info| {
-				let mut col_def =
-					super::ColumnDefinition::new(&col_info.name, col_info.column_type.clone());
-				col_def.not_null = !col_info.nullable;
-				col_def.auto_increment = col_info.auto_increment;
-				col_def.primary_key = table_info.primary_key.contains(&col_info.name);
-				col_def.default = col_info.default.clone();
-				col_def
+		// 3. Build ColumnDefinition list, mirroring the introspector's
+		//    semantics (PK columns are implicitly NOT NULL; AUTOINCREMENT is
+		//    only meaningful on PK columns).
+		let mut columns: Vec<super::ColumnDefinition> = col_rows
+			.iter()
+			.map(|c| {
+				let is_pk = c.pk > 0;
+				let is_auto = is_pk && has_autoincrement;
+				let nullable = if is_pk { false } else { c.notnull == 0 };
+				let default = c.default.as_ref().map(|v| {
+					let trimmed = v.trim();
+					if (trimmed.starts_with('\'') && trimmed.ends_with('\''))
+						|| (trimmed.starts_with('"') && trimmed.ends_with('"'))
+					{
+						trimmed[1..trimmed.len() - 1].to_string()
+					} else {
+						trimmed.to_string()
+					}
+				});
+				super::ColumnDefinition {
+					name: c.name.clone(),
+					type_definition: SQLiteIntrospector::parse_sqlite_type(&c.type_str),
+					not_null: !nullable,
+					unique: false,
+					primary_key: is_pk,
+					auto_increment: is_auto,
+					default,
+				}
 			})
 			.collect();
 
-		// Sort columns to maintain consistent order (primary key columns first, then by name)
+		// Preserve the introspector's ordering: PK first, then by name. This
+		// matters because `SqliteTableRecreation` uses column order to emit
+		// the new CREATE TABLE and the INSERT SELECT.
 		columns.sort_by(|a, b| {
 			if a.primary_key && !b.primary_key {
 				std::cmp::Ordering::Less
@@ -767,49 +821,111 @@ impl DatabaseMigrationExecutor {
 			}
 		});
 
-		// Helper function to convert Option<String> to ForeignKeyAction
-		fn parse_fk_action(action: &Option<String>) -> ForeignKeyAction {
-			match action.as_deref() {
-				Some("CASCADE") => ForeignKeyAction::Cascade,
-				Some("SET NULL") => ForeignKeyAction::SetNull,
-				Some("SET DEFAULT") => ForeignKeyAction::SetDefault,
-				Some("NO ACTION") => ForeignKeyAction::NoAction,
-				_ => ForeignKeyAction::Restrict,
-			}
-		}
+		// 4. Foreign keys via PRAGMA foreign_key_list(<table>), grouped by id.
+		let fk_sql = format!("PRAGMA foreign_key_list({})", table_name);
+		let fk_rows = editor.fetch_all(&fk_sql, vec![]).await?;
 
-		// Convert ForeignKeyInfo to Constraint
-		let mut constraints: Vec<super::Constraint> = table_info
-			.foreign_keys
+		struct FkRow {
+			id: i64,
+			seq: i64,
+			table: String,
+			from: String,
+			to: String,
+			on_update: String,
+			on_delete: String,
+		}
+		let parsed_fks: Vec<FkRow> = fk_rows
 			.iter()
-			.map(|fk| super::Constraint::ForeignKey {
-				name: fk.name.clone(),
-				columns: fk.columns.clone(),
-				referenced_table: fk.referenced_table.clone(),
-				referenced_columns: fk.referenced_columns.clone(),
-				on_delete: parse_fk_action(&fk.on_delete),
-				on_update: parse_fk_action(&fk.on_update),
-				deferrable: None,
+			.map(|row| FkRow {
+				id: row.get("id").unwrap_or(0),
+				seq: row.get("seq").unwrap_or(0),
+				table: row.get("table").unwrap_or_default(),
+				from: row.get("from").unwrap_or_default(),
+				to: row.get("to").unwrap_or_default(),
+				on_update: row.get("on_update").unwrap_or_default(),
+				on_delete: row.get("on_delete").unwrap_or_default(),
 			})
 			.collect();
 
-		// Add unique constraints
-		for unique in &table_info.unique_constraints {
-			constraints.push(super::Constraint::Unique {
-				name: unique.name.clone(),
-				columns: unique.columns.clone(),
+		let named_fks = create_sql
+			.as_ref()
+			.map(|sql| SQLiteIntrospector::parse_fk_constraint_names(sql))
+			.unwrap_or_default();
+
+		let mut fk_groups: std::collections::HashMap<i64, Vec<FkRow>> =
+			std::collections::HashMap::new();
+		for r in parsed_fks {
+			fk_groups.entry(r.id).or_default().push(r);
+		}
+
+		fn fk_action(s: &str) -> super::ForeignKeyAction {
+			match s {
+				"CASCADE" => super::ForeignKeyAction::Cascade,
+				"SET NULL" => super::ForeignKeyAction::SetNull,
+				"SET DEFAULT" => super::ForeignKeyAction::SetDefault,
+				"NO ACTION" => super::ForeignKeyAction::NoAction,
+				_ => super::ForeignKeyAction::Restrict,
+			}
+		}
+
+		let mut constraints: Vec<super::Constraint> = Vec::new();
+		for (fk_id, mut group) in fk_groups {
+			group.sort_by_key(|r| r.seq);
+			let referenced_table = group[0].table.clone();
+			let columns_from: Vec<String> = group.iter().map(|r| r.from.clone()).collect();
+			let columns_to: Vec<String> = group.iter().map(|r| r.to.clone()).collect();
+			let signature = (columns_from.clone(), referenced_table.clone());
+			let name = named_fks
+				.get(&signature)
+				.cloned()
+				.unwrap_or_else(|| format!("fk_{}_{}", table_name, fk_id));
+			constraints.push(super::Constraint::ForeignKey {
+				name,
+				columns: columns_from,
+				referenced_table,
+				referenced_columns: columns_to,
+				on_delete: fk_action(&group[0].on_delete),
+				on_update: fk_action(&group[0].on_update),
+				deferrable: None,
 			});
 		}
 
-		// Add CHECK constraints
-		for (idx, check) in table_info.check_constraints.iter().enumerate() {
-			constraints.push(super::Constraint::Check {
-				name: check
-					.name
-					.clone()
-					.unwrap_or_else(|| format!("check_{}", idx)),
-				expression: check.expression.clone(),
+		// 5. Unique constraints via PRAGMA index_list / index_info where
+		//    origin = 'u' (i.e. declared with the UNIQUE keyword or as a
+		//    named CONSTRAINT … UNIQUE).
+		let idx_list_sql = format!("PRAGMA index_list({})", table_name);
+		let idx_rows = editor.fetch_all(&idx_list_sql, vec![]).await?;
+		for row in &idx_rows {
+			let origin: String = row.get("origin").unwrap_or_default();
+			let unique: i64 = row.get("unique").unwrap_or(0);
+			if origin != "u" || unique != 1 {
+				continue;
+			}
+			let idx_name: String = row.get("name").unwrap_or_default();
+			let info_sql = format!("PRAGMA index_info({})", idx_name);
+			let info_rows = editor.fetch_all(&info_sql, vec![]).await?;
+			let cols: Vec<String> = info_rows
+				.iter()
+				.filter_map(|r| r.get::<String>("name").ok())
+				.collect();
+			constraints.push(super::Constraint::Unique {
+				name: idx_name,
+				columns: cols,
 			});
+		}
+
+		// 6. CHECK constraints parsed from CREATE TABLE SQL (SQLite has no
+		//    PRAGMA for these).
+		if let Some(ref sql) = create_sql {
+			for (idx, check) in SQLiteIntrospector::parse_check_constraints(sql)?
+				.into_iter()
+				.enumerate()
+			{
+				constraints.push(super::Constraint::Check {
+					name: check.name.unwrap_or_else(|| format!("check_{}", idx)),
+					expression: check.expression,
+				});
+			}
 		}
 
 		Ok((columns, constraints))
@@ -837,7 +953,14 @@ impl DatabaseMigrationExecutor {
 		// This prevents FK violations during the temporary DROP TABLE phase
 		editor.disable_foreign_keys().await?;
 
-		// Build the recreation plan based on operation type
+		// Build the recreation plan based on operation type.
+		//
+		// Critical: introspection must run via the editor's open transaction so
+		// that DDL applied earlier in the same migration (e.g. a preceding
+		// `AddColumn`) is visible. Reading via the pool would land on a
+		// different connection that cannot see the uncommitted schema and
+		// would silently rebuild the table from a stale column set — the
+		// root cause of reinhardt-web#4447.
 		let recreation = match operation {
 			Operation::DropColumn { table, column } => {
 				tracing::debug!(
@@ -845,7 +968,8 @@ impl DatabaseMigrationExecutor {
 					table,
 					column
 				);
-				let (columns, constraints) = self.get_sqlite_table_metadata(table).await?;
+				let (columns, constraints) =
+					Self::read_sqlite_table_via_editor(editor, table).await?;
 				SqliteTableRecreation::for_drop_column(table, columns, column, constraints)
 			}
 			Operation::AlterColumn {
@@ -859,7 +983,8 @@ impl DatabaseMigrationExecutor {
 					table,
 					column
 				);
-				let (columns, constraints) = self.get_sqlite_table_metadata(table).await?;
+				let (columns, constraints) =
+					Self::read_sqlite_table_via_editor(editor, table).await?;
 				SqliteTableRecreation::for_alter_column(
 					table,
 					columns,
@@ -876,7 +1001,8 @@ impl DatabaseMigrationExecutor {
 					"Handling SQLite table recreation for AddConstraint: table={}",
 					table
 				);
-				let (columns, constraints) = self.get_sqlite_table_metadata(table).await?;
+				let (columns, constraints) =
+					Self::read_sqlite_table_via_editor(editor, table).await?;
 				SqliteTableRecreation::for_add_constraint(
 					table,
 					columns,
@@ -893,7 +1019,8 @@ impl DatabaseMigrationExecutor {
 					table,
 					constraint_name
 				);
-				let (columns, constraints) = self.get_sqlite_table_metadata(table).await?;
+				let (columns, constraints) =
+					Self::read_sqlite_table_via_editor(editor, table).await?;
 				SqliteTableRecreation::for_drop_constraint(
 					table,
 					columns,

--- a/crates/reinhardt-db/src/migrations/introspection.rs
+++ b/crates/reinhardt-db/src/migrations/introspection.rs
@@ -1023,7 +1023,7 @@ impl SQLiteIntrospector {
 		Self { pool }
 	}
 
-	fn parse_sqlite_type(type_str: &str) -> super::FieldType {
+	pub(crate) fn parse_sqlite_type(type_str: &str) -> super::FieldType {
 		use super::FieldType;
 		let upper = type_str.to_uppercase();
 		let upper = upper.trim();
@@ -1313,7 +1313,7 @@ impl SQLiteIntrospector {
 	}
 
 	/// Parses CHECK constraints from a CREATE TABLE SQL statement.
-	fn parse_check_constraints(create_sql: &str) -> Result<Vec<CheckConstraintInfo>> {
+	pub(crate) fn parse_check_constraints(create_sql: &str) -> Result<Vec<CheckConstraintInfo>> {
 		let mut constraints = Vec::new();
 
 		// Named CHECK constraint pattern: CONSTRAINT name CHECK(...)
@@ -1412,7 +1412,9 @@ impl SQLiteIntrospector {
 	/// - Value: constraint name
 	///
 	/// This is used to match PRAGMA foreign_key_list results with actual constraint names.
-	fn parse_fk_constraint_names(create_sql: &str) -> HashMap<(Vec<String>, String), String> {
+	pub(crate) fn parse_fk_constraint_names(
+		create_sql: &str,
+	) -> HashMap<(Vec<String>, String), String> {
 		let mut result = HashMap::new();
 
 		// Pattern: CONSTRAINT name FOREIGN KEY (cols) REFERENCES table(cols)

--- a/crates/reinhardt-db/src/migrations/schema_editor.rs
+++ b/crates/reinhardt-db/src/migrations/schema_editor.rs
@@ -37,7 +37,7 @@
 use super::Result;
 use crate::backends::{
 	connection::DatabaseConnection,
-	types::{DatabaseType, TransactionExecutor},
+	types::{DatabaseType, QueryValue, Row, TransactionExecutor},
 };
 
 /// Schema editor for executing DDL statements with optional transaction support
@@ -132,6 +132,36 @@ impl SchemaEditor {
 		}
 
 		Ok(())
+	}
+
+	/// Fetch all rows for a read query, routed through the same connection as
+	/// in-flight DDL so that in-transaction schema changes are visible.
+	///
+	/// When the editor is in atomic mode, the query is dispatched on the open
+	/// transaction. Without this, a read issued through the pool would
+	/// transparently land on a *different* physical connection and would not
+	/// observe uncommitted DDL — the failure mode behind reinhardt-web#4447.
+	pub async fn fetch_all(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Vec<Row>> {
+		if let Some(ref mut tx) = self.executor {
+			Ok(tx.fetch_all(sql, params).await?)
+		} else {
+			Ok(self.connection.fetch_all(sql, params).await?)
+		}
+	}
+
+	/// Fetch a single optional row through the in-flight transaction (if any).
+	///
+	/// Mirrors [`Self::fetch_all`] for callers that expect zero or one row.
+	pub async fn fetch_optional(
+		&mut self,
+		sql: &str,
+		params: Vec<QueryValue>,
+	) -> Result<Option<Row>> {
+		if let Some(ref mut tx) = self.executor {
+			Ok(tx.fetch_optional(sql, params).await?)
+		} else {
+			Ok(self.connection.fetch_optional(sql, params).await?)
+		}
 	}
 
 	/// Defer SQL execution until finish()

--- a/tests/integration/tests/migrations.rs
+++ b/tests/integration/tests/migrations.rs
@@ -86,3 +86,11 @@ mod migration_overwrite_prevention_test;
 // Macro `unique_together` propagation regression tests (reinhardt-web#4022)
 #[path = "migrations/macro_unique_together_integration.rs"]
 mod macro_unique_together_integration;
+
+// SQLite AddColumn atomic-history regression tests (reinhardt-web#4447)
+#[path = "migrations/sqlite_add_column_atomic.rs"]
+mod sqlite_add_column_atomic;
+
+// #[field(default = ...)] propagation regression tests (reinhardt-web#4447)
+#[path = "migrations/field_default_propagation.rs"]
+mod field_default_propagation;

--- a/tests/integration/tests/migrations/field_default_propagation.rs
+++ b/tests/integration/tests/migrations/field_default_propagation.rs
@@ -1,0 +1,101 @@
+//! Regression tests for reinhardt-web#4447 (macro half):
+//!
+//! `#[field(default = ...)]` previously parsed the expression but never
+//! pushed it into `FieldMetadata.params`, so the autodetector emitted
+//! `ColumnDefinition.default = None` even for plain boolean / integer /
+//! string defaults. That left the SQL runner with `ADD COLUMN ... NOT NULL`
+//! without a DEFAULT clause — guaranteed to fail (silently, on SQLite empty
+//! tables) the moment any existing row was present.
+//!
+//! These tests exercise the macro end-to-end via the global registry: if the
+//! propagation works the registered `FieldMetadata.params` contains the
+//! serialized SQL fragment, and `to_model_state()` carries it into the
+//! `FieldState.params` that `ColumnDefinition::from_field_state` consumes.
+
+use reinhardt_db::migrations::model_registry::global_registry;
+use reinhardt_macros::model;
+use rstest::*;
+use serde::{Deserialize, Serialize};
+
+#[allow(dead_code)]
+#[model(
+	app_label = "field_default_propagation_test",
+	table_name = "field_default_propagation_test_user"
+)]
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct DefaultsUser {
+	#[field(primary_key = true)]
+	pub id: i64,
+	#[field(default = false)]
+	pub is_superuser: bool,
+	#[field(default = true)]
+	pub is_active: bool,
+	#[field(default = 0)]
+	pub login_count: i64,
+	#[field(default = "pending", max_length = 32)]
+	pub status: String,
+}
+
+#[rstest]
+fn field_default_propagates_to_metadata() {
+	let registry = global_registry();
+	let metadata = registry
+		.get_model("field_default_propagation_test", "DefaultsUser")
+		.expect("DefaultsUser must be registered by the #[model] macro");
+
+	let is_superuser = metadata
+		.fields
+		.get("is_superuser")
+		.expect("is_superuser field");
+	assert_eq!(
+		is_superuser.params.get("default").map(String::as_str),
+		Some("false"),
+		"#[field(default = false)] must serialize to the SQL fragment `false`"
+	);
+
+	let is_active = metadata.fields.get("is_active").expect("is_active field");
+	assert_eq!(
+		is_active.params.get("default").map(String::as_str),
+		Some("true"),
+		"#[field(default = true)] must serialize to the SQL fragment `true`"
+	);
+
+	let login_count = metadata
+		.fields
+		.get("login_count")
+		.expect("login_count field");
+	assert_eq!(
+		login_count.params.get("default").map(String::as_str),
+		Some("0"),
+		"integer defaults survive as their base-10 representation"
+	);
+
+	let status = metadata.fields.get("status").expect("status field");
+	assert_eq!(
+		status.params.get("default").map(String::as_str),
+		Some("'pending'"),
+		"string defaults are SQL-quoted so they slot into `DEFAULT <frag>`"
+	);
+}
+
+#[rstest]
+fn field_default_reaches_column_definition_via_field_state() {
+	use reinhardt_db::migrations::ColumnDefinition;
+
+	let registry = global_registry();
+	let metadata = registry
+		.get_model("field_default_propagation_test", "DefaultsUser")
+		.expect("DefaultsUser must be registered");
+	let model_state = metadata.to_model_state();
+
+	let field = model_state
+		.get_field("is_superuser")
+		.expect("is_superuser field reachable via ModelState");
+	let col = ColumnDefinition::from_field_state("is_superuser", field);
+
+	assert_eq!(
+		col.default.as_deref(),
+		Some("false"),
+		"ColumnDefinition.default must be Some(_) so the runner can emit DEFAULT"
+	);
+}

--- a/tests/integration/tests/migrations/sqlite_add_column_atomic.rs
+++ b/tests/integration/tests/migrations/sqlite_add_column_atomic.rs
@@ -141,27 +141,53 @@ async fn issue_4447_add_column_then_add_constraint_preserves_column() {
 		"is_superuser column was lost across AddConstraint recreation: have {names:?}"
 	);
 
-	// And the unique constraint added by op #2 must exist.
+	// And the unique constraint added by op #2 must exist on `username`.
+	// SQLite reports the underlying auto-index in PRAGMA index_list; the name
+	// it picks for `CONSTRAINT … UNIQUE` is implementation-defined (often
+	// `sqlite_autoindex_<table>_<n>`), so we verify by column instead of by
+	// constraint name.
 	let idxs = conn
 		.fetch_all("PRAGMA index_list(users)", vec![])
 		.await
 		.expect("read index_list");
-	let unique_names: Vec<String> = idxs
-		.iter()
-		.filter_map(|r| {
-			let origin: String = r.get("origin").ok()?;
-			let unique: i64 = r.get("unique").unwrap_or(0);
-			if origin == "u" && unique == 1 {
-				r.get::<String>("name").ok()
-			} else {
-				None
-			}
-		})
-		.collect();
-
+	let mut covers_username = false;
+	for row in &idxs {
+		let origin: String = row.get("origin").unwrap_or_default();
+		let unique: i64 = row.get("unique").unwrap_or(0);
+		if origin != "u" || unique != 1 {
+			continue;
+		}
+		let idx_name: String = row.get("name").unwrap_or_default();
+		let info = conn
+			.fetch_all(&format!("PRAGMA index_info({})", idx_name), vec![])
+			.await
+			.expect("read index_info");
+		let cols: Vec<String> = info
+			.iter()
+			.filter_map(|r| r.get::<String>("name").ok())
+			.collect();
+		if cols == vec!["username".to_string()] {
+			covers_username = true;
+			break;
+		}
+	}
 	assert!(
-		unique_names.iter().any(|n| n == "users_user_username_uniq"),
-		"named uniqueness constraint missing after migration: have {unique_names:?}"
+		covers_username,
+		"AddConstraint UNIQUE(username) was not preserved across recreation: \
+		 PRAGMA index_list returned {idxs:?}"
+	);
+
+	// Verify the constraint is actually enforced (orthogonal to introspection
+	// quirks above): duplicate inserts must fail.
+	conn.execute("INSERT INTO users (username) VALUES ('alice')", vec![])
+		.await
+		.expect("first insert");
+	let dup = conn
+		.execute("INSERT INTO users (username) VALUES ('alice')", vec![])
+		.await;
+	assert!(
+		dup.is_err(),
+		"AddConstraint UNIQUE(username) must be enforced after recreation"
 	);
 }
 

--- a/tests/integration/tests/migrations/sqlite_add_column_atomic.rs
+++ b/tests/integration/tests/migrations/sqlite_add_column_atomic.rs
@@ -1,0 +1,245 @@
+//! Regression tests for reinhardt-web#4447:
+//!
+//! `manage migrate` reported a migration as `Applied` even though its
+//! `Operation::AddColumn` step did not survive on a SQLite database.
+//!
+//! The migration's other operations (e.g. `Operation::AddConstraint` in the
+//! same migration) DID apply, so the schema ended up partially migrated while
+//! the migration history claimed success.
+//!
+//! Root cause: when SQLite recreation runs *inside* the schema editor's open
+//! transaction, the introspector used to read the pre-recreation column list
+//! goes through a *separate* connection in the pool. That separate connection
+//! cannot see the just-`ALTER`'d column (still inside the editor's TX), so the
+//! recreation rebuilds the table from a stale column set and effectively
+//! discards the prior `AddColumn`.
+
+use reinhardt_db::backends::connection::DatabaseConnection;
+use reinhardt_db::migrations::{
+	ColumnDefinition, FieldType, Migration, executor::DatabaseMigrationExecutor,
+	operations::Operation,
+};
+use rstest::*;
+
+fn pk_column(name: &str) -> ColumnDefinition {
+	ColumnDefinition {
+		name: name.to_string(),
+		type_definition: FieldType::Integer,
+		not_null: true,
+		unique: false,
+		primary_key: true,
+		auto_increment: true,
+		default: None,
+	}
+}
+
+fn col(name: &str, ty: FieldType, not_null: bool) -> ColumnDefinition {
+	ColumnDefinition {
+		name: name.to_string(),
+		type_definition: ty,
+		not_null,
+		unique: false,
+		primary_key: false,
+		auto_increment: false,
+		default: None,
+	}
+}
+
+fn migration(app: &str, name: &str, ops: Vec<Operation>) -> Migration {
+	Migration {
+		app_label: app.to_string(),
+		name: name.to_string(),
+		operations: ops,
+		dependencies: vec![],
+		replaces: vec![],
+		atomic: true,
+		initial: None,
+		state_only: false,
+		database_only: false,
+		swappable_dependencies: vec![],
+		optional_dependencies: vec![],
+	}
+}
+
+/// Reproduces issue #4447 directly:
+///
+/// 1. CreateTable(users) with no rows.
+/// 2. A second migration that combines AddColumn(NOT NULL) + AddConstraint.
+///    Atomic = true (the default). On SQLite, AddConstraint triggers table
+///    recreation. The recreation must NOT lose the just-added column.
+#[rstest]
+#[tokio::test]
+async fn issue_4447_add_column_then_add_constraint_preserves_column() {
+	let connection = DatabaseConnection::connect_sqlite("sqlite::memory:")
+		.await
+		.expect("connect");
+	let conn = connection.clone();
+	let mut executor = DatabaseMigrationExecutor::new(connection);
+
+	// Step 1: create the users table without is_superuser.
+	let m0001 = migration(
+		"users",
+		"0001_initial",
+		vec![Operation::CreateTable {
+			name: "users".to_string(),
+			columns: vec![
+				pk_column("id"),
+				col("username", FieldType::VarChar(150), true),
+			],
+			constraints: vec![],
+			without_rowid: None,
+			interleave_in_parent: None,
+			partition: None,
+		}],
+	);
+
+	// Step 2: two-op migration. AddColumn first, AddConstraint second.
+	// This mirrors the exact sequence from the reproduction in #4447.
+	let m0002 = migration(
+		"users",
+		"0002_add_is_superuser_and_constraint",
+		vec![
+			Operation::AddColumn {
+				table: "users".to_string(),
+				column: ColumnDefinition {
+					name: "is_superuser".to_string(),
+					type_definition: FieldType::Boolean,
+					not_null: true,
+					unique: false,
+					primary_key: false,
+					auto_increment: false,
+					// Note: a default IS provided here. The "no default" path
+					// is exercised by the macro-level regression test.
+					default: Some("false".to_string()),
+				},
+				mysql_options: None,
+			},
+			Operation::AddConstraint {
+				table: "users".to_string(),
+				constraint_sql: "CONSTRAINT users_user_username_uniq UNIQUE (username)".to_string(),
+			},
+		],
+	);
+
+	executor
+		.apply_migrations(&[m0001, m0002])
+		.await
+		.expect("migrations should apply cleanly");
+
+	// The just-added column must survive the AddConstraint recreation.
+	let rows = conn
+		.fetch_all("PRAGMA table_info(users)", vec![])
+		.await
+		.expect("read pragma");
+	let names: Vec<String> = rows
+		.iter()
+		.filter_map(|r| r.get::<String>("name").ok())
+		.collect();
+
+	assert!(
+		names.iter().any(|n| n == "is_superuser"),
+		"is_superuser column was lost across AddConstraint recreation: have {names:?}"
+	);
+
+	// And the unique constraint added by op #2 must exist.
+	let idxs = conn
+		.fetch_all("PRAGMA index_list(users)", vec![])
+		.await
+		.expect("read index_list");
+	let unique_names: Vec<String> = idxs
+		.iter()
+		.filter_map(|r| {
+			let origin: String = r.get("origin").ok()?;
+			let unique: i64 = r.get("unique").unwrap_or(0);
+			if origin == "u" && unique == 1 {
+				r.get::<String>("name").ok()
+			} else {
+				None
+			}
+		})
+		.collect();
+
+	assert!(
+		unique_names.iter().any(|n| n == "users_user_username_uniq"),
+		"named uniqueness constraint missing after migration: have {unique_names:?}"
+	);
+}
+
+/// When a single-op AddColumn(NOT NULL, default=None) migration is applied to
+/// a NON-empty SQLite table, the operation MUST surface an error from the
+/// runner AND the migration MUST NOT be recorded as applied. The migration
+/// history must stay consistent with the actual DB state.
+#[rstest]
+#[tokio::test]
+async fn issue_4447_failed_add_column_does_not_record_applied() {
+	let connection = DatabaseConnection::connect_sqlite("sqlite::memory:")
+		.await
+		.expect("connect");
+	let conn = connection.clone();
+	let mut executor = DatabaseMigrationExecutor::new(connection);
+
+	// Create the table and insert a row to make ADD COLUMN NOT NULL impossible
+	// without a default.
+	let create = migration(
+		"users",
+		"0001_initial",
+		vec![Operation::CreateTable {
+			name: "users".to_string(),
+			columns: vec![
+				pk_column("id"),
+				col("username", FieldType::VarChar(150), true),
+			],
+			constraints: vec![],
+			without_rowid: None,
+			interleave_in_parent: None,
+			partition: None,
+		}],
+	);
+	executor
+		.apply_migrations(&[create])
+		.await
+		.expect("initial migration applies");
+
+	conn.execute("INSERT INTO users (username) VALUES ('alice')", vec![])
+		.await
+		.expect("seed row");
+
+	// Now attempt AddColumn(NOT NULL, default=None). SQLite must reject it on
+	// a non-empty table.
+	let bad = migration(
+		"users",
+		"0002_add_super_no_default",
+		vec![Operation::AddColumn {
+			table: "users".to_string(),
+			column: ColumnDefinition {
+				name: "is_superuser".to_string(),
+				type_definition: FieldType::Boolean,
+				not_null: true,
+				unique: false,
+				primary_key: false,
+				auto_increment: false,
+				default: None,
+			},
+			mysql_options: None,
+		}],
+	);
+
+	let result = executor.apply_migrations(&[bad]).await;
+	assert!(
+		result.is_err(),
+		"AddColumn(NOT NULL, default=None) on a non-empty SQLite table must fail; got {result:?}"
+	);
+
+	// And critically: the migration MUST NOT be recorded as applied.
+	let recorded = conn
+		.fetch_all(
+			"SELECT name FROM reinhardt_migrations WHERE app = 'users' AND name = '0002_add_super_no_default'",
+			vec![],
+		)
+		.await
+		.expect("query history");
+	assert!(
+		recorded.is_empty(),
+		"migration was recorded as applied despite failure (atomicity violation)"
+	);
+}


### PR DESCRIPTION
## Summary

- Routes SQLite table-recreation introspection through the editor's open transaction (`SchemaEditor::fetch_all` / `fetch_optional`), so column metadata read during recreation reflects DDL applied earlier in the same migration.
- Propagates `#[field(default = ...)]` into `FieldState.params["default"]` so `makemigrations` emits `ColumnDefinition.default = Some(...)` for primitive defaults (closing the secondary half of the issue).
- Adds two-migration regression rstests in `migrations::sqlite_add_column_atomic` and a separate `migrations::field_default_propagation` suite.
- Makes the SQLite introspection parsers (`parse_sqlite_type`, `parse_fk_constraint_names`, `parse_check_constraints`) `pub(crate)`-visible so the new editor-based reader can re-use them.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`manage migrate` reported a migration as `Applied` even when its `Operation::AddColumn` step never landed on a SQLite database. Other operations in the same migration (e.g. `AddConstraint`) did apply, so the schema ended up partially migrated while migration history claimed success.

There are **two independent root causes**, both fixed here:

1. **Executor** (atomic-transaction visibility): when SQLite recreation runs inside the editor's open transaction (`atomic = true`, the default), the prior introspection step read columns through `SQLiteIntrospector` → the shared `sqlx::SqlitePool`. SQLx transparently picks a *different* physical connection than the one holding the editor's open transaction, so the introspector could not see the just-`ALTER`'d column. The recreation then rebuilt the table from a stale column list and silently discarded the new column.
2. **Macros** (`#[field(default = ...)]` propagation): `model_derive` parsed `config.default: syn::Expr` into `FieldConfig` but `generate_registration_code` never emitted a matching `.with_param("default", ...)`. `makemigrations` therefore produced `ColumnDefinition.default = None` even for plain bool/int/string defaults — which is what triggers the SQLite "Cannot add NOT NULL column with default value NULL" error on non-empty tables and the silent-failure path on empty tables.

Fixes #4447

## How Was This Tested?

- `cargo test -p reinhardt-integration-tests --test migrations -- sqlite_add_column_atomic field_default_propagation` → 4 passed / 0 failed.
- Wider regression: `cargo test -p reinhardt-integration-tests --test migrations` → 333 passed / 8 ignored / 0 failed.
- `cargo fmt --all -- --check` clean; `cargo clippy -p reinhardt-macros --all-targets -- -D warnings` clean.

## Key Implementation Notes

- `read_sqlite_table_via_editor` reimplements the SQLite metadata read in terms of the editor's executor so it sees uncommitted DDL. The previous pool-based `get_sqlite_table_metadata` is now unused on the recreation path.
- The SQLite UNIQUE-constraint assertion in the regression test reads by column + enforcement rather than by literal `name == "users_user_username_uniq"`, because SQLite reports `sqlite_autoindex_<table>_<n>` for `CONSTRAINT … UNIQUE` indexes.
- No separate runner-level guard was added for "reject NOT NULL ADD COLUMN without default" — SQLite already surfaces the right error, and the new atomicity test (`issue_4447_failed_add_column_does_not_record_applied`) confirms history is not recorded on failure.

## Commits

- `3c80d9765` fix(db): introspect within open SchemaEditor transaction during SQLite recreation
- `2b00c9fc0` test(db): regression test for #4447 AddColumn + AddConstraint visibility
- `ec7630dfa` feat(core-macros): propagate `#[field(default = ...)]` into `FieldState.params`
- `6f78cac1b` test(db): assert SQLite UNIQUE-by-column + enforcement after recreation

## Checklist

- [x] Code follows project style (rustfmt clean)
- [x] All commits follow Conventional Commits
- [x] Linked to issue (`Fixes #4447`)

## Labels to Apply

- bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)