### PR TITLE
feat(middleware): add OptionalSessionValueNamed<K, T> for custom session keys

### DIFF
--- a/crates/reinhardt-middleware/src/session.rs
+++ b/crates/reinhardt-middleware/src/session.rs
@@ -35,7 +35,10 @@ pub use id::{ActiveSessionId, SessionCookieName, SessionId};
 pub use injectable::SessionStoreRef;
 pub use middleware::SessionMiddleware;
 pub use store::SessionStore;
-pub use value::{OptionalSessionValue, SessionKey, SessionValue, SessionValueNamed, UserIdKey};
+pub use value::{
+	OptionalSessionValue, OptionalSessionValueNamed, SessionKey, SessionValue, SessionValueNamed,
+	UserIdKey,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/reinhardt-middleware/src/session/value.rs
+++ b/crates/reinhardt-middleware/src/session/value.rs
@@ -1,6 +1,6 @@
 //! Typed session-value extractors usable directly in handler signatures.
 //!
-//! Three flavours mirror the rest of the Reinhardt extractor surface:
+//! Four flavours mirror the rest of the Reinhardt extractor surface:
 //!
 //! - [`SessionValue<T>`] reads `session["user_id"]` and deserialises it as
 //!   `T`; 401 when the session or key is missing.
@@ -8,6 +8,9 @@
 //!   collapses to `OptionalSessionValue(None)` rather than propagating.
 //! - [`SessionValueNamed<K, T>`] reads a custom session key chosen at
 //!   compile time via a marker type implementing [`SessionKey`].
+//! - [`OptionalSessionValueNamed<K, T>`] is the optional variant of
+//!   [`SessionValueNamed<K, T>`]: a missing/unreadable value collapses to
+//!   `None` instead of failing extraction.
 //!
 //! Each extractor is wired through both `Injectable` (for `#[inject]`
 //! parameters) **and** `FromRequest` (for `Path(...)`-style auto-extraction
@@ -181,6 +184,80 @@ impl<K: SessionKey, T: Clone> Clone for SessionValueNamed<K, T> {
 	}
 }
 
+/// Optional typed session-value extractor parameterised by a [`SessionKey`].
+///
+/// Generalises [`OptionalSessionValue<T>`] to keys other than
+/// [`USER_ID_SESSION_KEY`], mirroring the relationship between
+/// [`SessionValue<T>`] and [`SessionValueNamed<K, T>`]. Extraction never
+/// fails: when the session is missing, expired, or carries no value at
+/// `K::KEY`, the extractor yields `None` rather than propagating the
+/// underlying error. Use this on handlers that accept a custom session key
+/// and may serve both anonymous and authenticated callers.
+///
+/// ```rust,ignore
+/// use reinhardt::middleware::session::{OptionalSessionValueNamed, SessionKey};
+///
+/// pub struct TenantIdKey;
+/// impl SessionKey for TenantIdKey {
+///     const KEY: &'static str = "tenant_id";
+/// }
+///
+/// #[server_fn]
+/// pub async fn current_tenant_opt(
+///     extractor: OptionalSessionValueNamed<TenantIdKey, i64>,
+/// ) -> Result<Option<TenantInfo>, ServerFnError> {
+///     let tenant_id: Option<i64> = extractor.into_inner();
+///     /* ... */
+/// }
+/// ```
+pub struct OptionalSessionValueNamed<K: SessionKey, T> {
+	value: Option<T>,
+	_phantom: PhantomData<fn() -> K>,
+}
+
+impl<K: SessionKey, T> OptionalSessionValueNamed<K, T> {
+	/// Construct an `OptionalSessionValueNamed` directly from an
+	/// `Option<T>`. Primarily useful in tests where extraction is
+	/// bypassed.
+	pub fn new(value: Option<T>) -> Self {
+		Self {
+			value,
+			_phantom: PhantomData,
+		}
+	}
+
+	/// Unwrap the extractor and return the inner `Option<T>`.
+	pub fn into_inner(self) -> Option<T> {
+		self.value
+	}
+}
+
+impl<K: SessionKey, T> Deref for OptionalSessionValueNamed<K, T> {
+	type Target = Option<T>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.value
+	}
+}
+
+impl<K: SessionKey, T: Debug> Debug for OptionalSessionValueNamed<K, T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("OptionalSessionValueNamed")
+			.field("key", &K::KEY)
+			.field("value", &self.value)
+			.finish()
+	}
+}
+
+impl<K: SessionKey, T: Clone> Clone for OptionalSessionValueNamed<K, T> {
+	fn clone(&self) -> Self {
+		Self {
+			value: self.value.clone(),
+			_phantom: PhantomData,
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers shared between `Injectable` and `FromRequest` impls.
 // ---------------------------------------------------------------------------
@@ -287,6 +364,24 @@ where
 	}
 }
 
+#[async_trait]
+impl<K, T> Injectable for OptionalSessionValueNamed<K, T>
+where
+	K: SessionKey,
+	T: DeserializeOwned + Send + Sync + 'static,
+{
+	async fn inject(ctx: &InjectionContext) -> DiResult<Self> {
+		// Mirror `OptionalSessionValue`, but parameterise the key over
+		// `K::KEY`. Collapse "no session"/"no value" into `None`; any
+		// other error (e.g. corrupted singleton scope) still bubbles up.
+		match SessionData::inject(ctx).await {
+			Ok(session) => Ok(Self::new(session.get::<T>(K::KEY))),
+			Err(DiError::NotFound(_)) => Ok(Self::new(None)),
+			Err(e) => Err(e),
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // FromRequest impls (auto-extraction without `#[inject]`).
 // ---------------------------------------------------------------------------
@@ -337,6 +432,28 @@ where
 	}
 }
 
+#[async_trait]
+impl<K, T> FromRequest for OptionalSessionValueNamed<K, T>
+where
+	K: SessionKey,
+	T: DeserializeOwned + Send + Sync + 'static,
+{
+	async fn from_request(req: &Request, _ctx: &ParamContext) -> ParamResult<Self> {
+		// Mirror `OptionalSessionValue::from_request`, parameterised on
+		// `K::KEY`: any failure to reach a live session collapses to
+		// `None` rather than 401/500, so this extractor never blocks the
+		// handler from running.
+		let di_ctx = match req.get_di_context::<InjectionContext>() {
+			Some(c) => c,
+			None => return Ok(Self::new(None)),
+		};
+		match SessionData::inject(&di_ctx).await {
+			Ok(session) => Ok(Self::new(session.get::<T>(K::KEY))),
+			Err(_) => Ok(Self::new(None)),
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -368,6 +485,69 @@ mod tests {
 		// Assert
 		assert_eq!(via_deref, 42);
 		assert_eq!(via_into_inner, 42);
+	}
+
+	#[rstest]
+	fn optional_session_value_named_constructor_and_deref_roundtrip_some() {
+		// Arrange
+		let extractor = OptionalSessionValueNamed::<TenantIdKey, i64>::new(Some(7));
+
+		// Act
+		let via_deref: Option<i64> = *extractor;
+		let via_into_inner = extractor.into_inner();
+
+		// Assert
+		assert_eq!(via_deref, Some(7));
+		assert_eq!(via_into_inner, Some(7));
+	}
+
+	#[rstest]
+	fn optional_session_value_named_constructor_and_deref_roundtrip_none() {
+		// Arrange
+		let extractor = OptionalSessionValueNamed::<TenantIdKey, i64>::new(None);
+
+		// Act
+		let via_deref: Option<i64> = *extractor;
+		let via_into_inner = extractor.into_inner();
+
+		// Assert
+		assert_eq!(via_deref, None);
+		assert_eq!(via_into_inner, None);
+	}
+
+	#[rstest]
+	fn optional_session_value_named_debug_includes_key_name() {
+		// Arrange
+		let extractor = OptionalSessionValueNamed::<TenantIdKey, i64>::new(Some(99));
+
+		// Act
+		let rendered = format!("{extractor:?}");
+
+		// Assert: the Debug impl should surface the `K::KEY` constant so
+		// failure diagnostics in handler logs identify which session key the
+		// extractor targeted. Mirror the contract verified for
+		// `SessionValueNamed` Debug output.
+		assert!(
+			rendered.contains("OptionalSessionValueNamed"),
+			"Debug output should name the struct, got {rendered:?}"
+		);
+		assert!(
+			rendered.contains("tenant_id"),
+			"Debug output should include the session key name, got {rendered:?}"
+		);
+	}
+
+	#[rstest]
+	fn optional_session_value_named_clone_preserves_inner_some() {
+		// Arrange
+		let original = OptionalSessionValueNamed::<TenantIdKey, i64>::new(Some(123));
+
+		// Act
+		let cloned = original.clone();
+
+		// Assert
+		assert_eq!(*cloned, Some(123));
+		assert_eq!(*original, Some(123));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-middleware/tests/session_value_from_request.rs
+++ b/crates/reinhardt-middleware/tests/session_value_from_request.rs
@@ -18,8 +18,8 @@ mod tests {
 	use reinhardt_di::{InjectionContext, SingletonScope};
 	use reinhardt_http::Request;
 	use reinhardt_middleware::session::{
-		OptionalSessionValue, SessionData, SessionKey, SessionStore, SessionValue,
-		SessionValueNamed, USER_ID_SESSION_KEY,
+		OptionalSessionValue, OptionalSessionValueNamed, SessionData, SessionKey, SessionStore,
+		SessionValue, SessionValueNamed, USER_ID_SESSION_KEY,
 	};
 
 	/// Build a request whose extensions carry the active `Arc<InjectionContext>`
@@ -202,6 +202,126 @@ mod tests {
 			matches!(err, ParamError::Authentication(_)),
 			"expected ParamError::Authentication, got {err:?}"
 		);
+	}
+
+	#[tokio::test]
+	async fn optional_session_value_named_from_request_returns_some_when_key_present() {
+		// Arrange
+		let store = Arc::new(SessionStore::new());
+		let mut session = SessionData::new(Duration::from_secs(3600));
+		session.set(TenantIdKey::KEY.to_string(), 4242i64).unwrap();
+		let session_id = session.id.clone();
+		store.save(session);
+
+		let request = build_request_with_session(Arc::clone(&store), Some(&session_id));
+		let ctx = ParamContext::new();
+
+		// Act
+		let extracted = <OptionalSessionValueNamed<TenantIdKey, i64> as FromRequest>::from_request(
+			&request, &ctx,
+		)
+		.await
+		.expect("OptionalSessionValueNamed must succeed when the key is present");
+
+		// Assert
+		assert_eq!(*extracted, Some(4242));
+	}
+
+	#[tokio::test]
+	async fn optional_session_value_named_from_request_yields_none_when_key_missing() {
+		// Arrange — session exists but does NOT carry the tenant_id key.
+		// The optional variant must collapse this to `None` rather than 401.
+		let store = Arc::new(SessionStore::new());
+		let session = SessionData::new(Duration::from_secs(3600));
+		let session_id = session.id.clone();
+		store.save(session);
+
+		let request = build_request_with_session(Arc::clone(&store), Some(&session_id));
+		let ctx = ParamContext::new();
+
+		// Act
+		let extracted = <OptionalSessionValueNamed<TenantIdKey, i64> as FromRequest>::from_request(
+			&request, &ctx,
+		)
+		.await
+		.expect("OptionalSessionValueNamed must never fail extraction");
+
+		// Assert
+		assert_eq!(*extracted, None);
+	}
+
+	#[tokio::test]
+	async fn optional_session_value_named_from_request_yields_none_when_session_missing() {
+		// Arrange — no session cookie => `SessionData::inject` fails with
+		// `DiError::NotFound`. The optional variant must swallow that into
+		// `None` rather than propagating an authentication error.
+		let store = Arc::new(SessionStore::new());
+		let request = build_request_with_session(store, None);
+		let ctx = ParamContext::new();
+
+		// Act
+		let extracted = <OptionalSessionValueNamed<TenantIdKey, i64> as FromRequest>::from_request(
+			&request, &ctx,
+		)
+		.await
+		.expect("OptionalSessionValueNamed must tolerate a missing session");
+
+		// Assert
+		assert_eq!(*extracted, None);
+	}
+
+	#[tokio::test]
+	async fn optional_session_value_named_from_request_yields_none_on_deserialisation_mismatch() {
+		// Arrange — store a string value under the tenant_id key, then ask
+		// for an i64. The Option<T> semantics of `SessionData::get` collapse
+		// a deserialisation failure to `None`, which `OptionalSessionValueNamed`
+		// must surface as `None` rather than 401/500.
+		let store = Arc::new(SessionStore::new());
+		let mut session = SessionData::new(Duration::from_secs(3600));
+		session
+			.set(TenantIdKey::KEY.to_string(), "not-an-i64".to_string())
+			.unwrap();
+		let session_id = session.id.clone();
+		store.save(session);
+
+		let request = build_request_with_session(Arc::clone(&store), Some(&session_id));
+		let ctx = ParamContext::new();
+
+		// Act
+		let extracted = <OptionalSessionValueNamed<TenantIdKey, i64> as FromRequest>::from_request(
+			&request, &ctx,
+		)
+		.await
+		.expect("OptionalSessionValueNamed must absorb deserialisation failures");
+
+		// Assert
+		assert_eq!(*extracted, None);
+	}
+
+	#[tokio::test]
+	async fn optional_session_value_named_from_request_yields_none_without_di_context() {
+		// Arrange — no DI context attached to the request. Mirror the
+		// behaviour verified for `OptionalSessionValue` (must collapse to
+		// `None` rather than 500).
+		let request = Request::builder()
+			.method(Method::GET)
+			.uri("/test")
+			.version(Version::HTTP_11)
+			.headers(HeaderMap::new())
+			.body(Bytes::new())
+			.build()
+			.unwrap();
+		let ctx = ParamContext::new();
+
+		// Act
+		let extracted = <OptionalSessionValueNamed<TenantIdKey, i64> as FromRequest>::from_request(
+			&request, &ctx,
+		)
+		.await
+		.expect("OptionalSessionValueNamed must tolerate a missing DI context");
+
+		// Assert
+		assert_eq!(*extracted, None);
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds `OptionalSessionValueNamed<K, T>` — the optional flavour of the typed session-value extractor introduced in #4458 for custom session keys.
- Restores parity between the required (`SessionValueNamed<K, T>`) and optional flavours so handlers using any key other than `USER_ID_SESSION_KEY` can now declare an optional version without writing manual `SessionData::inject` glue.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Before this PR, the three session-value extractors covered only two-thirds of the matrix:

| Required | Optional |
|----------|----------|
| `SessionValue<T>` (hardcoded `USER_ID_SESSION_KEY`) | `OptionalSessionValue<T>` (hardcoded `USER_ID_SESSION_KEY`) |
| `SessionValueNamed<K, T>` (custom key) | **missing** |

Applications that adopt a custom session key (e.g. `TenantIdKey`) were forced to either:

1. Materialise the optional case in their own glue code (re-implement `SessionData::inject` + `session.get` + the cookie-missing handling), or
2. Treat every lookup as required and accept HTTP 401 for legitimate anonymous traffic.

Both workarounds defeat the ergonomics goal of #4446 (avoiding boilerplate around `#[inject] session: SessionData`).

This was raised as an optional concern by Copilot on the #4458 review thread (`crates/reinhardt-middleware/src/session/value.rs` L317) and deferred to keep the original PR focused.

Fixes #4460

Related to: #4446, #4458

## How Was This Tested?

Locally on the worktree branch:

- `cargo check -p reinhardt-middleware --features sessions` — clean.
- `cargo clippy -p reinhardt-middleware --features sessions --no-deps -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo test --doc -p reinhardt-middleware --features sessions` — clean.
- `cargo nextest run -p reinhardt-middleware --features sessions --lib` — 384 / 384 tests passed (includes the new unit tests for `OptionalSessionValueNamed`).
- `cargo nextest run -p reinhardt-middleware --features sessions --test session_value_from_request --test session_value_extractor` — 18 / 18 tests passed (includes the 5 new integration tests).

New tests cover the documented contract surface:

**Unit tests (in `crates/reinhardt-middleware/src/session/value.rs`):**

- Constructor + `Deref<Target = Option<T>>` round-trip for both `Some` and `None`.
- `Debug` output includes the struct name and the `K::KEY` constant so logs identify which session key the extractor targeted.
- `Clone` preserves the inner `Option`.

**Integration tests (in `crates/reinhardt-middleware/tests/session_value_from_request.rs`):**

- `optional_session_value_named_from_request_returns_some_when_key_present` — happy path with `tenant_id` populated.
- `optional_session_value_named_from_request_yields_none_when_key_missing` — session exists but the named key is absent.
- `optional_session_value_named_from_request_yields_none_when_session_missing` — no session cookie.
- `optional_session_value_named_from_request_yields_none_on_deserialisation_mismatch` — wrong-type case.
- `optional_session_value_named_from_request_yields_none_without_di_context` — server misconfigured but optional extractor must still succeed.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable) — _not applicable, no DB involvement_
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

Fixes #4460

Refs #4446 (motivating issue), #4458 (PR that introduced `SessionValueNamed<K, T>`), #4461 (duplicate of #4460, closed)

## Labels to Apply

### Type Label
- [x] `enhancement` — New feature or improvement

### Scope Label
- [x] `api` — New public extractor type
- [x] `auth` — Authentication / session

### Priority Label (for maintainers)
- [ ] Maintainer to set

---

**Additional Context:**

- The implementation mirrors the existing `SessionValueNamed<K, T>` struct shape exactly (`value` + `PhantomData<fn() -> K>`, `new` / `into_inner` / `Deref` / `Debug` / `Clone`), differing only in `T` ↔ `Option<T>`. This keeps the two extractors mechanically aligned for future maintenance and makes the diff easy to audit.
- `OptionalSessionValueNamed<K, T>` is **not** a type alias for `Option<SessionValueNamed<K, T>>` — keeping it as a dedicated struct lets the `Debug` output advertise the session key by name (mirroring `SessionValueNamed`'s `Debug` contract), and matches the relationship between `SessionValue<T>` / `OptionalSessionValue<T>` already in the module.
- Aliasing `OptionalSessionValue<T>` as `OptionalSessionValueNamed<UserIdKey, T>` was considered and rejected for this PR — it would change `OptionalSessionValue`'s `Debug` representation and was out of scope for the optional follow-up. Tracked as a future optimisation if the type explosion becomes a concern.
- Follow-up #4462 (TenantIdKey fixture dedup) is intentionally deferred to its own PR to keep this one focused on the public API addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)