### PR TITLE
test(core-macros): add missing manager_disabled_no_manager.stderr

### DIFF
--- a/crates/reinhardt-core/macros/tests/ui/user/fail/manager_disabled_no_manager.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/user/fail/manager_disabled_no_manager.stderr
@@ -1,0 +1,5 @@
+error[E0433]: failed to resolve: use of undeclared type `OptOutUserManager`
+  --> tests/ui/user/fail/manager_disabled_no_manager.rs:22:10
+   |
+22 |     let _ = OptOutUserManager::new();
+   |             ^^^^^^^^^^^^^^^^^ use of undeclared type `OptOutUserManager`


### PR DESCRIPTION
## Summary

- Add the trybuild expected-stderr fixture `tests/ui/user/fail/manager_disabled_no_manager.stderr` for the `reinhardt-core-macros` crate.
- The matching `.rs` was added in `5ba6e8aa6 feat(core-macros): emit BaseUserManager impl from #[user(...)]` but its companion `.stderr` was missed, breaking `test_user_macro_fail` on every PR rebased on current `main`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The trybuild test `test_user_macro_fail` (in `crates/reinhardt-core/macros/tests/ui.rs:165`) runs `t.compile_fail("tests/ui/user/fail/*.rs")` over every `.rs` file in that directory. Without the matching `.stderr` fixture, trybuild generated `wip/manager_disabled_no_manager.stderr` and panicked with:

```
successfully created new stderr files for 1 test cases
```

This broke the `UI Tests` job on every PR rebased on current `main`. Discovered while triaging CI failures on #4457 — that PR only touches `reinhardt-urls/` and `examples/`, so the failure was unrelated.

The fixture content matches exactly what the underlying compile error produces:

```text
error[E0433]: failed to resolve: use of undeclared type `OptOutUserManager`
  --> tests/ui/user/fail/manager_disabled_no_manager.rs:22:10
   |
22 |     let _ = OptOutUserManager::new();
   |             ^^^^^^^^^^^^^^^^^ use of undeclared type `OptOutUserManager`
```

which is the intended assertion for the test (`manager = false` MUST suppress emission of `<Name>Manager`).

Fixes #4474
Refs #4457

## How Was This Tested?

Locally on macOS:

1. Generated the fixture via `TRYBUILD=overwrite cargo nextest run --profile ui-test --manifest-path crates/reinhardt-core/macros/Cargo.toml --test ui -E 'test(test_user_macro_fail)' --no-fail-fast` — generated and the test passed.
2. Re-ran the same command *without* `TRYBUILD=overwrite` to verify the committed fixture is accepted:
   ```
    Starting 1 test across 1 binary (20 tests skipped)
         PASS [  18.481s] (1/1) reinhardt-macros::ui test_user_macro_fail
        Summary [  18.481s] 1 test run: 1 passed, 20 skipped
   ```

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (the fixture itself is the test artifact)
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix` (no Rust code touched)
- [x] I have checked the code with `cargo make clippy-check` (no Rust code touched)

## Related Issues

- Fixes #4474
- Refs #4457 (was blocked by this failure in UI Tests (2/8))

## Labels to Apply

### Type Label
- [x] `bug` - Confirmed bug or unexpected behavior

### Priority Label
- [x] `high`

### Scope Label
- [x] `testing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
