### PR TITLE
style(middleware): apply rustfmt to session value modules

### DIFF
--- a/crates/reinhardt-middleware/src/session/value.rs
+++ b/crates/reinhardt-middleware/src/session/value.rs
@@ -456,8 +456,8 @@ where
 
 #[cfg(test)]
 mod tests {
-	use super::*;
 	use super::super::test_support::TenantIdKey;
+	use super::*;
 	use rstest::rstest;
 
 	#[rstest]

--- a/crates/reinhardt-middleware/tests/session_value_from_request.rs
+++ b/crates/reinhardt-middleware/tests/session_value_from_request.rs
@@ -23,8 +23,7 @@ mod tests {
 	use reinhardt_http::Request;
 	use reinhardt_middleware::session::{
 		OptionalSessionValue, OptionalSessionValueNamed, SessionData, SessionKey, SessionStore,
-		SessionValue, SessionValueNamed, USER_ID_SESSION_KEY,
-		test_support::TenantIdKey,
+		SessionValue, SessionValueNamed, USER_ID_SESSION_KEY, test_support::TenantIdKey,
 	};
 
 	/// Build a request whose extensions carry the active `Arc<InjectionContext>`


### PR DESCRIPTION
## Summary

- Re-apply rustfmt to two files in `reinhardt-middleware` whose imports were merged out-of-order in commit `675dae151`
- Unblocks the `Format / Format Check` CI job, which is currently red on `main` and on the release-plz PR #4479

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code style update (formatting, renaming)

## Motivation and Context

Commit `675dae151` (`refactor(middleware): share TenantIdKey fixture via test_support module`) added a new `use super::super::test_support::TenantIdKey;` import without re-running rustfmt. As a result, the `Format / Format Check` job started failing on `main` (and on the release-plz PR #4479 which is otherwise correct).

The diff is purely import reordering — no semantic change.

Fixes #4481

## How Was This Tested?

- `rustfmt --edition 2024 --check crates/reinhardt-middleware/src/session/value.rs crates/reinhardt-middleware/tests/session_value_from_request.rs` → passes
- Diff scope verified: only the 2 reported files, only `use` statement ordering
- No code logic changed

## Changed Files

- `crates/reinhardt-middleware/src/session/value.rs` — sort `use super::*;` / `use super::super::test_support::TenantIdKey;` per rustfmt
- `crates/reinhardt-middleware/tests/session_value_from_request.rs` — collapse multi-line `use` group per rustfmt

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] Targeted rustfmt verification passes locally
- [x] Documentation update not required (style-only change)

## Labels to Apply

- `bug` — currently breaking CI on main and release PR #4479

🤖 Generated with [Claude Code](https://claude.com/claude-code)