### PR TITLE
fix(examples-tutorial-rest): make Bruno CI deterministic and writable on Linux

### DIFF
--- a/examples/examples-tutorial-rest/Dockerfile.bruno
+++ b/examples/examples-tutorial-rest/Dockerfile.bruno
@@ -3,7 +3,9 @@
 # container can run with a read-only root filesystem.
 FROM node:24-alpine
 
-RUN npm install -g @usebruno/cli@latest \
+# Pinned for reproducibility — bump deliberately when upgrading.
+# Using @latest makes CI failures impossible to bisect against upstream changes.
+RUN npm install -g @usebruno/cli@3.3.0 \
 	&& npm cache clean --force
 
 WORKDIR /etc/bruno

--- a/examples/examples-tutorial-rest/Makefile.toml
+++ b/examples/examples-tutorial-rest/Makefile.toml
@@ -165,6 +165,13 @@ dependencies = ["fmt-check", "clippy-check", "build", "test"]
 description = "Run Bruno API tests"
 script = '''
 #!/bin/bash
+# Export the host UID/GID so the Bruno container can write the bind-mounted
+# reports directory on Linux CI runners. Bash's `$UID`/`$GID` are shell
+# built-ins that are not exported by default, which would let Compose
+# silently fall back to the 1000:1000 default declared in
+# docker-compose.api-tests.yml even when the checkout is owned by another UID.
+export BRUNO_UID="$(id -u)"
+export BRUNO_GID="$(id -g)"
 docker-compose -f docker-compose.api-tests.yml up --build --abort-on-container-exit
 docker-compose -f docker-compose.api-tests.yml down
 '''

--- a/examples/examples-tutorial-rest/docker-compose.api-tests.yml
+++ b/examples/examples-tutorial-rest/docker-compose.api-tests.yml
@@ -28,6 +28,12 @@ services:
     tmpfs:
       - /tmp
     working_dir: /etc/bruno
+    # Run as host UID/GID so the `./bruno/reports` bind mount stays writable
+    # on Linux CI runners whose checkout is not owned by UID 1000 (the `node`
+    # user from the upstream Bruno image). Defaults to 1000:1000 for local
+    # macOS development where the host UID is typically 501 but Docker Desktop
+    # transparently maps file ownership.
+    user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - ./bruno:/etc/bruno:ro
       - ./bruno/reports:/etc/bruno/reports

--- a/examples/examples-tutorial-rest/docker-compose.api-tests.yml
+++ b/examples/examples-tutorial-rest/docker-compose.api-tests.yml
@@ -34,7 +34,12 @@ services:
     # Dockerfile.bruno). Defaults to 1000:1000 for local macOS development
     # where the host UID is typically 501 but Docker Desktop transparently
     # maps file ownership.
-    user: "${UID:-1000}:${GID:-1000}"
+    #
+    # Use `BRUNO_UID`/`BRUNO_GID` rather than bash's `$UID`/`$GID`: the bash
+    # built-ins are not exported by default, so Compose interpolation would
+    # otherwise silently fall back to 1000 even on Linux CI. The `api-test`
+    # task in `Makefile.toml` exports these via `id -u`/`id -g`.
+    user: "${BRUNO_UID:-1000}:${BRUNO_GID:-1000}"
     volumes:
       - ./bruno:/etc/bruno:ro
       - ./bruno/reports:/etc/bruno/reports

--- a/examples/examples-tutorial-rest/docker-compose.api-tests.yml
+++ b/examples/examples-tutorial-rest/docker-compose.api-tests.yml
@@ -29,10 +29,11 @@ services:
       - /tmp
     working_dir: /etc/bruno
     # Run as host UID/GID so the `./bruno/reports` bind mount stays writable
-    # on Linux CI runners whose checkout is not owned by UID 1000 (the `node`
-    # user from the upstream Bruno image). Defaults to 1000:1000 for local
-    # macOS development where the host UID is typically 501 but Docker Desktop
-    # transparently maps file ownership.
+    # on Linux CI runners whose checkout is not owned by UID 1000 (the default
+    # UID of the `node` user in the node:24-alpine base image used by
+    # Dockerfile.bruno). Defaults to 1000:1000 for local macOS development
+    # where the host UID is typically 501 but Docker Desktop transparently
+    # maps file ownership.
     user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - ./bruno:/etc/bruno:ro


### PR DESCRIPTION
## Summary

- Pin `@usebruno/cli` to a specific version (3.3.0) instead of `@latest` for reproducible CI in `examples/examples-tutorial-rest/Dockerfile.bruno`
- Pass host UID/GID to the Bruno container in `examples/examples-tutorial-rest/docker-compose.api-tests.yml` so it can write reports on Linux CI runners

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The Bruno API-tests harness in `examples/examples-tutorial-rest/` had two CI reliability gaps:

1. **Non-reproducible install (#4488)**: `Dockerfile.bruno` installed `@usebruno/cli@latest`, making test behavior depend on a moving target. CI failures could not be reliably bisected because the same SHA could yield different CLI versions across builds. Pinned to `3.3.0` (the current upstream latest at the time of this fix).
2. **Bind mount writability (#4487)**: `docker-compose.api-tests.yml` bind-mounted `./bruno/reports` writable, but the container ran as UID 1000 (`node` user from the Bruno base image) while Linux CI checkouts are commonly owned by a different UID — causing permission-denied when the container tried to write `junit.xml`/`report.html`. Adding `user: "${UID:-1000}:${GID:-1000}"` makes the container run as the host's user on Linux, while defaulting to 1000:1000 on macOS where Docker Desktop transparently maps file ownership.

Fixes #4487
Fixes #4488

## How Was This Tested

- [x] `docker compose -f docker-compose.api-tests.yml config` validates the YAML and confirms `user: 1000:1000` resolves correctly on macOS (the default branch).
- [x] Visual review of the Dockerfile pin and the explanatory comment.
- [ ] CI workflow re-run will exercise both fixes end-to-end on Linux runners.

## Checklist

- [x] Code follows project style
- [x] No mock implementations
- [x] Self-reviewed
- [x] Documentation reviewed (the Dockerfile comment notes the deliberate pin)

## Labels to Apply

- `bug`
- `medium`
- `ci-cd`
- `examples`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the Bruno CLI to a specific version to ensure deterministic, reproducible builds in CI.
  * Ensured test runner runs with the host UID/GID so generated reports and mounted volumes remain writable and permission-consistent across CI and local environments.
  * Exported UID/GID into the test-run environment to reliably propagate host ownership into containers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->