### PR TITLE
docs(examples): remove references to non-existent example directories

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ Example applications demonstrating [Reinhardt](https://github.com/kent8192/reinh
 ### One Command Run
 
 ```bash
-git clone https://github.com/kent8192/reinhardt-web.git && cd reinhardt-web/examples/examples-hello-world && cargo run
+git clone https://github.com/kent8192/reinhardt-web.git && cd reinhardt-web/examples/examples-tutorial-basis && cargo run
 ```
 
 ### Step by Step
@@ -18,7 +18,7 @@ git clone https://github.com/kent8192/reinhardt-web.git
 cd reinhardt-web/examples
 
 # 2. Choose an example
-cd examples-hello-world
+cd examples-tutorial-basis
 
 # 3. Run it
 cargo run
@@ -26,10 +26,10 @@ cargo run
 
 ### Examples with PostgreSQL
 
-For examples that require PostgreSQL (database-integration, github-issues, twitter):
+For examples that require PostgreSQL (`examples-twitter`):
 
 ```bash
-cd reinhardt-web/examples/examples-database-integration
+cd reinhardt-web/examples/examples-twitter
 
 # Start PostgreSQL
 docker compose up -d
@@ -45,12 +45,8 @@ cargo run
 
 | Example | Description | Features |
 |---------|-------------|----------|
-| `examples-hello-world` | Basic Hello World application | Core HTTP, Routing |
-| `examples-rest-api` | REST API with CRUD operations | REST, Validation, Settings |
-| `examples-database-integration` | Database integration with migrations | Database, ORM, SQLite, PostgreSQL |
 | `examples-tutorial-basis` | Polling app tutorial (basis) | Pages, Forms, Database, WASM |
 | `examples-tutorial-rest` | REST API tutorial (snippets) | REST, Viewsets, Database |
-| `examples-github-issues` | GitHub Issues clone | GraphQL, JWT Auth |
 | `examples-twitter` | Full Twitter-like application | Full-stack, WebSockets, Auth, WASM |
 
 ## Dependency Management
@@ -90,7 +86,7 @@ cargo make local-examples-test
 
 ```bash
 # Test a specific example
-cd examples-hello-world && cargo nextest run --all-features
+cd examples-tutorial-basis && cargo nextest run --all-features
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- Trim `examples/README.md` to reference only the three example projects that actually exist
- Replace the broken Quick Start command (`examples-hello-world`) with a working one

## Type of Change

- [x] Documentation update

## Motivation and Context

`examples/README.md` referenced four example projects that no longer exist:
- `examples-hello-world`
- `examples-rest-api`
- `examples-database-integration`
- `examples-github-issues`

First-time users running the Quick Start `One Command Run` block would have hit a `cargo run` failure on `examples-hello-world`.

Fixes #4492

## How Was This Tested

- [x] Every `examples-*` name referenced in `examples/README.md` resolves to an existing directory
- [x] Quick Start command works end-to-end

## Checklist

- [x] Documentation follows project standards
- [x] Self-reviewed
- [x] All linked example paths exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated examples documentation with revised quick-start instructions for improved onboarding experience
  * Refreshed available examples list and directory references throughout guides
  * Modified step-by-step tutorial walkthrough to align with updated example structure
  * Updated testing documentation with current example references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->