### PR TITLE
docs(lib): mark `standard` as the default feature preset (not `full`)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@
 //! ### Presets
 //!
 //! - `minimal` - Core functionality only (routing, DI, params)
-//! - `full` (default) - All features enabled
-//! - `standard` - Balanced for most projects
+//! - `full` - All features enabled (opt-in for the broadest surface area)
+//! - `standard` (default) - Balanced for most projects
 //! - `api-only` - REST API without templates/forms
 //! - `graphql-server` - GraphQL-focused setup
 //! - `websocket-server` - WebSocket-centric setup


### PR DESCRIPTION
## Summary

- Fix `src/lib.rs` crate-level rustdoc so the `(default)` annotation matches `Cargo.toml`'s `default = ["standard"]`

## Type of Change

- [x] Documentation update

## Motivation and Context

The crate-level rustdoc in `src/lib.rs` claimed `full` was the default preset, while `Cargo.toml` actually sets `default = ["standard"]`. The root `README.md` already described `standard` as default, so docs.rs and source-repo readers got conflicting answers.

Fixes #4495

## How Was This Tested

- [x] `grep -nE '^//! - .* \(default\)' src/lib.rs` shows `standard` carrying `(default)`
- [x] `cargo doc -p reinhardt --no-deps --all-features` completes without warnings

## Checklist

- [x] Documentation follows project standards
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified feature-flag preset descriptions: the `full` preset is now described as opt-in with broader coverage, and the `standard` preset is indicated as the default. This update improves guidance when choosing presets and reduces confusion about which preset is enabled by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->