### PR TITLE
docs(examples-tutorial-rest): repoint tutorial links to current website location

### DIFF
--- a/examples/examples-tutorial-rest/README.md
+++ b/examples/examples-tutorial-rest/README.md
@@ -1,6 +1,6 @@
 # Reinhardt REST Tutorial Example - Code Snippet Management API
 
-This example demonstrates the concepts covered in the [Reinhardt REST Tutorial](../../../docs/tutorials/en/rest/). It implements a complete RESTful API for managing code snippets.
+This example demonstrates the concepts covered in the [Reinhardt REST Tutorial](../../../website/content/quickstart/tutorials/rest/). It implements a complete RESTful API for managing code snippets.
 
 ## What This Example Covers
 
@@ -130,7 +130,7 @@ examples-tutorial-rest/
 
 This example is designed to be studied alongside the REST tutorial:
 
-1. **Start with the tutorial**: Read [Quickstart](../../../docs/tutorials/en/rest/quickstart.md)
+1. **Start with the tutorial**: Read [Quickstart](../../../website/content/quickstart/tutorials/rest/quickstart.md)
 2. **Examine the code**: Look at how concepts are implemented in this example
 3. **Run the tests**: `cargo test` to see the functionality in action
 4. **Experiment**: Modify the code and see what happens
@@ -291,7 +291,7 @@ After understanding this example:
 
 ## Related Documentation
 
-- [REST Tutorial](../../../docs/tutorials/en/rest/) - Step-by-step guide
+- [REST Tutorial](../../../website/content/quickstart/tutorials/rest/) - Step-by-step guide
 - [API Documentation](https://docs.rs/reinhardt-web) - Complete API reference
 
 ## License

--- a/examples/examples-tutorial-rest/README.md
+++ b/examples/examples-tutorial-rest/README.md
@@ -1,6 +1,6 @@
 # Reinhardt REST Tutorial Example - Code Snippet Management API
 
-This example demonstrates the concepts covered in the [Reinhardt REST Tutorial](../../../website/content/quickstart/tutorials/rest/). It implements a complete RESTful API for managing code snippets.
+This example demonstrates the concepts covered in the [Reinhardt REST Tutorial](../../website/content/quickstart/tutorials/rest/). It implements a complete RESTful API for managing code snippets.
 
 ## What This Example Covers
 
@@ -130,7 +130,7 @@ examples-tutorial-rest/
 
 This example is designed to be studied alongside the REST tutorial:
 
-1. **Start with the tutorial**: Read [Quickstart](../../../website/content/quickstart/tutorials/rest/quickstart.md)
+1. **Start with the tutorial**: Read [Quickstart](../../website/content/quickstart/tutorials/rest/quickstart.md)
 2. **Examine the code**: Look at how concepts are implemented in this example
 3. **Run the tests**: `cargo test` to see the functionality in action
 4. **Experiment**: Modify the code and see what happens
@@ -291,7 +291,7 @@ After understanding this example:
 
 ## Related Documentation
 
-- [REST Tutorial](../../../website/content/quickstart/tutorials/rest/) - Step-by-step guide
+- [REST Tutorial](../../website/content/quickstart/tutorials/rest/) - Step-by-step guide
 - [API Documentation](https://docs.rs/reinhardt-web) - Complete API reference
 
 ## License


### PR DESCRIPTION
## Summary

- Repoint three broken tutorial links in `examples/examples-tutorial-rest/README.md` to `website/content/quickstart/tutorials/rest/`

## Type of Change

- [x] Documentation update

## Motivation and Context

The README had three links pointing to `../../../docs/tutorials/en/rest/`, which no longer exists — the tutorial content has moved to `website/content/quickstart/tutorials/rest/`.

Fixes #4493

## How Was This Tested

- [x] `grep -n 'docs/tutorials/en/rest' examples/examples-tutorial-rest/README.md` returns no matches
- [x] All link targets verified to exist on disk (`website/content/quickstart/tutorials/rest/` and `quickstart.md`)

## Checklist

- [x] Documentation follows project standards
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated three REST tutorial hyperlinks to point to the new website tutorial locations.
  * Adjusted the introductory tutorial, the "Start with the tutorial" quickstart link, and the related REST documentation links to the current site structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->