### PR TITLE
docs(examples-tutorial-basis): align README with current MSRV and tutorial paths

### DIFF
--- a/examples/examples-tutorial-basis/README.md
+++ b/examples/examples-tutorial-basis/README.md
@@ -1,6 +1,6 @@
 # Reinhardt Basis Tutorial Example - Polling Application
 
-This example demonstrates the concepts covered in the [Reinhardt Basis Tutorial](../../../docs/tutorials/en/basis/). It implements a complete polling application with two cooperating apps (`polls` and `users`) — server-rendered REST endpoints, typed RPC server functions, an admin panel, and a WASM single-page-application client all in a single crate.
+This example demonstrates the concepts covered in the [Reinhardt Basis Tutorial](../../../website/content/quickstart/tutorials/basis/). It implements a complete polling application with two cooperating apps (`polls` and `users`) — server-rendered REST endpoints, typed RPC server functions, an admin panel, and a WASM single-page-application client all in a single crate.
 
 ## What This Example Covers
 
@@ -48,7 +48,7 @@ App routers are auto-mounted by `#[url_patterns(InstalledApp::<app>, mode = serv
 
 ### Prerequisites
 
-- Rust 1.75 or later (2024 edition)
+- Rust 1.94 or later (2024 edition, matches the workspace MSRV)
 - `cargo-make` (`cargo install cargo-make`)
 - `wasm-pack` for the WASM client build
 - Docker (optional, for TestContainers in integration tests)
@@ -193,7 +193,7 @@ examples-tutorial-basis/
 
 This example is designed to be studied alongside the basis tutorial:
 
-1. **Start with the tutorial**: Read [Part 1](../../../docs/tutorials/en/basis/1-project-setup.md)
+1. **Start with the tutorial**: Read [Part 1](../../../website/content/quickstart/tutorials/basis/1-project-setup.md)
 2. **Examine the code**: Look at how concepts are implemented in this example
 3. **Run the tests**: `cargo make test` to see the functionality in action
 4. **Experiment**: Modify the code and see what happens
@@ -387,7 +387,7 @@ After understanding this example:
 
 ## Related Documentation
 
-- [Basis Tutorial](../../../docs/tutorials/en/basis/) - Step-by-step guide
+- [Basis Tutorial](../../../website/content/quickstart/tutorials/basis/) - Step-by-step guide
 - [API Documentation](https://docs.rs/reinhardt-web) - Complete API reference
 
 ## License


### PR DESCRIPTION
## Summary

- Update Rust prerequisite from `1.75` to `1.94` (matches workspace MSRV)
- Repoint three broken tutorial links from `docs/tutorials/en/basis/` to `website/content/quickstart/tutorials/basis/`

## Type of Change

- [x] Documentation update

## Motivation and Context

`examples/examples-tutorial-basis/README.md` had two stale references:
1. The Rust prerequisite was `1.75`, but the workspace MSRV is `1.94` — users following the tutorial would hit unattributed edition-2024 compile errors.
2. Three tutorial links pointed to `../../../docs/tutorials/en/basis/`, which no longer exists. The tutorial content has moved to `website/content/quickstart/tutorials/basis/`.

Fixes #4491
Fixes #4494

## How Was This Tested

- [x] `grep -n 'docs/tutorials/en/basis' examples/examples-tutorial-basis/README.md` returns no matches
- [x] All link targets exist on disk
- [x] No outdated Rust version mentions remain

## Checklist

- [x] Documentation follows project standards
- [x] Self-reviewed
- [x] All linked paths verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated tutorial documentation links
  * Bumped minimum Rust version requirement to 1.94 (2024 edition)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->