### PR TITLE
docs(testkit-macros): clarify rc.28 lag relative to sibling crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,15 @@ Reinhardt follows a **three-phase lifecycle** for every crate:
 | **Stable** (`0.x.0`) | Full SemVer 2.0 guarantees. |
 
 <!-- reinhardt-version-sync -->
-**Current status:** All crates are at `0.1.0-rc.29` (Release Candidate).
+**Current status:** Reinhardt is at `0.1.0-rc.29` (Release Candidate). Most
+crates track this version; a small number lag by one or more patch numbers
+when no conventional-commit changes have touched them since their previous
+release-plz tag (release-plz correctly skips a bump in that case). At
+`rc.29` this applies to:
+
+- `reinhardt-testkit-macros` — remains at `0.1.0-rc.28` (no changes since
+  its rc.28 tag; re-exported through `reinhardt-testkit`, so depending on
+  `reinhardt-testkit` alone gives you a compatible pair).
 
 > **0.x.y Series Caveat:** The RC policy below — API freeze during `rc.*` and a
 > 2-week stability window before the first stable release — is followed strictly

--- a/crates/reinhardt-testkit-macros/README.md
+++ b/crates/reinhardt-testkit-macros/README.md
@@ -30,3 +30,17 @@ async fn test_login_flow() {
 ```
 
 See `reinhardt-testkit::fixtures::di_overrides` for the underlying API and the design rationale.
+
+## Versioning
+
+This crate's version is managed by release-plz independently of its sibling
+crates: a new patch is published only when a conventional-commit change
+(`feat`, `fix`, `refactor`, etc.) actually touches files inside this crate
+directory. As a result, the patch number may lag behind the rest of the
+Reinhardt workspace whenever no behaviour-affecting changes have landed
+here since the last tag. This is by design and not a release accident.
+
+For users, the practical guidance is to depend on
+[`reinhardt-testkit`](../reinhardt-testkit) (which re-exports these macros)
+rather than pinning this crate directly — Cargo then picks a compatible
+`reinhardt-testkit-macros` automatically.

--- a/crates/reinhardt-testkit-macros/README.md
+++ b/crates/reinhardt-testkit-macros/README.md
@@ -2,7 +2,7 @@
 
 <!-- reinhardt-version-sync: reinhardt-testkit-macros -->
 
-Procedural macros for [`reinhardt-testkit`](../reinhardt-testkit). The macros here are re-exported from `reinhardt-testkit` — depend on `reinhardt-testkit` rather than this crate directly.
+Procedural macros for [`reinhardt-testkit`](https://docs.rs/reinhardt-testkit/). The macros here are re-exported from `reinhardt-testkit` — depend on `reinhardt-testkit` rather than this crate directly.
 
 ## `with_di_overrides!`
 
@@ -37,10 +37,10 @@ This crate's version is managed by release-plz independently of its sibling
 crates: a new patch is published only when a conventional-commit change
 (`feat`, `fix`, `refactor`, etc.) actually touches files inside this crate
 directory. As a result, the patch number may lag behind the rest of the
-Reinhardt workspace whenever no behaviour-affecting changes have landed
+Reinhardt workspace whenever no behavior-affecting changes have landed
 here since the last tag. This is by design and not a release accident.
 
 For users, the practical guidance is to depend on
-[`reinhardt-testkit`](../reinhardt-testkit) (which re-exports these macros)
-rather than pinning this crate directly — Cargo then picks a compatible
-`reinhardt-testkit-macros` automatically.
+[`reinhardt-testkit`](https://docs.rs/reinhardt-testkit/) (which re-exports
+these macros) rather than pinning this crate directly — Cargo then picks a
+compatible `reinhardt-testkit-macros` automatically.


### PR DESCRIPTION
## Summary

- Document the intentional `0.1.0-rc.28` lag of `reinhardt-testkit-macros` relative to sibling crates at `0.1.0-rc.29` in the root `README.md` version table.
- Add a short "Versioning" section to `crates/reinhardt-testkit-macros/README.md` explaining release-plz's per-crate cadence and recommending that users depend on `reinhardt-testkit` (which re-exports the macros) rather than pinning this crate directly.

## Type of Change

- [x] Documentation update

## Motivation and Context

`reinhardt-testkit-macros` stayed at `0.1.0-rc.28` while all sibling crates moved to `0.1.0-rc.29`. The README's version table claimed uniform `rc.29`, which was misleading.

After inspecting git history since the `reinhardt-testkit-macros@v0.1.0-rc.28` tag, no commits have touched `crates/reinhardt-testkit-macros/` at all. release-plz therefore correctly skipped a version bump for this crate — the lag is intentional, not a release accident.

The fix here is documentation-only: annotate the root README's "Current status" line so the divergence is visible, and explain the per-crate cadence in the crate's own README. release-plz can keep doing the right thing without manual intervention.

Fixes #4496

## Investigation Notes

```
$ grep '^version' crates/reinhardt-testkit-macros/Cargo.toml
version = "0.1.0-rc.28"

$ git log "reinhardt-testkit-macros@v0.1.0-rc.28..HEAD" --oneline -- crates/reinhardt-testkit-macros/
(empty — no commits since the rc.28 tag touched this crate)

$ git tag | grep '^reinhardt-testkit-macros@v' | sort -V | tail -3
reinhardt-testkit-macros@v0.1.0-rc.28
```

For comparison, `reinhardt-testkit` itself has rc.27, rc.28, and rc.29 tags — it received changes that the macros crate did not.

## How Was This Tested

- [x] `scripts/validate-version-markers.sh` — clean (89 files scanned).
- [x] `scripts/update-version-refs.sh 0.1.0-rc.30 --dry-run` — confirmed that only the first version after each `<!-- reinhardt-version-sync -->` marker is bumped; the explanatory `rc.28` reference inside the new bullet stays untouched.
- [x] No code paths changed; no release-plz cycle triggered.

## Checklist

- [x] Documentation follows project standards (English-only, no user-instruction phrasing).
- [x] Self-reviewed.
- [x] No version manually bumped in `Cargo.toml` (per project policy, release-plz owns versions).
- [x] PR scoped to a single documentation concern.

## Labels to Apply

- `documentation`
- `low`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API stability information to reflect current version status across crates, noting most crates are on 0.1.0-rc.29 while the macro crate remains at 0.1.0-rc.28 and is re-exported to preserve compatibility.
  * Added versioning guidance recommending users depend on reinhardt-testkit rather than pinning the macro crate directly so Cargo will select a compatible release automatically.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->