### PR TITLE
fix(integration-tests): migrate dcl mod.rs to Rust 2024 layout

### DIFF
--- a/tests/integration/tests/dcl.rs
+++ b/tests/integration/tests/dcl.rs
@@ -8,11 +8,16 @@
 //! - **MySQL Tests**: MySQL-specific feature testing
 //! - **CockroachDB Tests**: PostgreSQL compatibility testing
 
+#[path = "dcl/postgres_tests.rs"]
 mod postgres_tests;
+
+#[path = "dcl/mysql_tests.rs"]
 mod mysql_tests;
+
+#[path = "dcl/cockroachdb_tests.rs"]
 mod cockroachdb_tests;
 
 // Re-exports for convenience
-pub use postgres_tests::*;
-pub use mysql_tests::*;
 pub use cockroachdb_tests::*;
+pub use mysql_tests::*;
+pub use postgres_tests::*;

--- a/tests/integration/tests/dcl/cockroachdb_tests.rs
+++ b/tests/integration/tests/dcl/cockroachdb_tests.rs
@@ -384,7 +384,7 @@ async fn test_set_role() {
 #[ignore = "Requires testcontainers setup"]
 async fn test_reset_role() {
 	// 1. SET ROLE admin
-// 2. RESET ROLE
+	// 2. RESET ROLE
 	// 3. Verify show role() returns current_user
 }
 

--- a/tests/integration/tests/dcl/mysql_tests.rs
+++ b/tests/integration/tests/dcl/mysql_tests.rs
@@ -59,12 +59,10 @@ async fn test_grant_select_appears_in_information_schema(
 	.expect("CREATE TABLE");
 
 	// Act
-	sqlx::query(&format!(
-		"GRANT SELECT ON test_db.{table} TO '{user}'@'%'"
-	))
-	.execute(pool.as_ref())
-	.await
-	.expect("GRANT SELECT");
+	sqlx::query(&format!("GRANT SELECT ON test_db.{table} TO '{user}'@'%'"))
+		.execute(pool.as_ref())
+		.await
+		.expect("GRANT SELECT");
 
 	// Assert: SELECT privilege is present in information_schema.
 	let count: i64 = sqlx::query(
@@ -112,12 +110,10 @@ async fn test_revoke_select_removes_privilege(
 	.execute(pool.as_ref())
 	.await
 	.expect("CREATE TABLE");
-	sqlx::query(&format!(
-		"GRANT SELECT ON test_db.{table} TO '{user}'@'%'"
-	))
-	.execute(pool.as_ref())
-	.await
-	.expect("GRANT SELECT");
+	sqlx::query(&format!("GRANT SELECT ON test_db.{table} TO '{user}'@'%'"))
+		.execute(pool.as_ref())
+		.await
+		.expect("GRANT SELECT");
 
 	// Act
 	sqlx::query(&format!(
@@ -285,7 +281,7 @@ async fn test_drop_user_verify() {
 
 #[rstest]
 #[tokio::test]
-ignore = "Requires testcontainers setup"]
+#[ignore = "Requires testcontainers setup"]
 async fn test_user_at_host_variations() {
 	// CREATE USER 'user'@'localhost'
 	// CREATE USER 'user'@'%'
@@ -325,7 +321,7 @@ async fn test_grant_all_privileges() {
 }
 
 #[rstest]
-tokio::test]
+#[tokio::test]
 #[ignore = "Requires testcontainers setup"]
 async fn test_revoke_privilege() {
 	// 1. GRANT SELECT ON table TO user
@@ -358,7 +354,7 @@ async fn test_database_level_privileges() {
 }
 
 #[rstest]
-[io::test]
+#[tokio::test]
 #[ignore = "Requires testcontainers setup"]
 async fn test_revoke_grant_option() {
 	// 1. GRANT ... WITH GRANT OPTION
@@ -491,7 +487,7 @@ async fn test_set_role_all_except() {
 #[ignore = "Requires testcontainers setup"]
 async fn test_set_default_role() {
 	// 1. GRANT role TO user
-// 2. SET DEFAULT ROLE role TO user
+	// 2. SET DEFAULT ROLE role TO user
 	// 3. Connect as user
 	// 4. Verify default role is active
 }
@@ -563,7 +559,7 @@ async fn test_account_lock_enforcement() {
 }
 
 #[rstest]
-tokio::test]
+#[tokio::test]
 #[ignore = "Requires testcontainers setup"]
 async fn test_password_expiration() {
 	// CREATE USER WITH PASSWORD EXPIRE INTERVAL 90 DAY
@@ -606,7 +602,7 @@ async fn test_admin_user_setup() {
 }
 
 #[rstest]
-#[okio::test]
+#[tokio::test]
 #[ignore = "Requires testcontainers setup"]
 async fn test_multi_host_user_setup() {
 	// 1. CREATE USER 'app@'host1', 'app@'host2', 'app@'host3'

--- a/tests/integration/tests/dcl/postgres_tests.rs
+++ b/tests/integration/tests/dcl/postgres_tests.rs
@@ -257,7 +257,7 @@ async fn test_cascade_revoke() {
 // ============================================================================
 
 #[rstest]
-#[io::test]
+#[tokio::test]
 #[ignore = "Requires testcontainers setup"]
 async fn test_grant_role_verify_membership() {
 	// 1. GRANT role1 TO user
@@ -300,7 +300,7 @@ async fn test_multiple_role_grants() {
 	// Verify all memberships
 }
 
-#[stest]
+#[rstest]
 #[tokio::test]
 #[ignore = "Requires testcontainers setup"]
 async fn test_role_hierarchy() {


### PR DESCRIPTION
## Summary

- Rename `tests/integration/tests/dcl/mod.rs` to `tests/integration/tests/dcl.rs` to comply with the Rust 2024 module policy mandated by `CLAUDE.md` and `instructions/MODULE_SYSTEM.md`.
- Add `#[path = "dcl/<child>.rs"]` attributes (mirroring the pattern used in `auth.rs`) so `postgres_tests`, `mysql_tests`, and `cockroachdb_tests` resolve correctly under the new layout, where the renamed `dcl.rs` becomes a cargo `autotests` integration-test target.
- Repair attribute-typo rot (`[io::test]`, `tokio::test]`, `#[okio::test]`, `#[stest]`) in the previously orphaned child files that surfaced once the test target started compiling, and apply `cargo fmt` to satisfy `cargo make fmt-check`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`CLAUDE.md` (Critical Rules -> Module System) and `instructions/MODULE_SYSTEM.md` mandate the Rust 2024 `module.rs` + `module/` layout and explicitly forbid `mod.rs`. The integration test crate was the last holdout. The original `tests/integration/tests/dcl/mod.rs` was not referenced anywhere in the workspace (no `mod dcl;` declaration existed), so the child test files had never been compiled and had accumulated minor typos that surface as soon as the migration wires the directory into a real test target.

Fixes #4489

## How Was This Tested

- [x] `find tests/integration -name 'mod.rs' -not -path '*/target/*'` returns zero results
- [x] `cargo check -p reinhardt-integration-tests --all-features --tests` -> success (exit 0)
- [x] `cargo make fmt-check` -> success
- [x] `cargo make clippy-check` -> success
- [ ] Full test execution (`cargo nextest run -p reinhardt-integration-tests`) is gated on testcontainers/Docker availability in CI; the affected dcl tests are all `#[ignore = "Requires testcontainers setup"]`, so this PR does not change runtime behaviour for currently-running tests.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings beyond pre-existing ones in the workspace
- [x] No `mod.rs` files exist anywhere under `tests/integration/`
- [x] No `mod.rs` files exist anywhere under the repository root

## Labels to Apply

- `bug`
- `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected invalid test attribute syntax across multiple integration tests to ensure proper test execution.

* **Refactor**
  * Reorganized test module declarations for improved file structure and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->