### PR TITLE
refactor(examples-twitter): rc.17-rc.29 modernization and workaround cleanup

### DIFF
--- a/examples/examples-twitter/migrations/auth/0001_initial.rs
+++ b/examples/examples-twitter/migrations/auth/0001_initial.rs
@@ -122,11 +122,17 @@ pub(super) fn migration() -> Migration {
 					ColumnDefinition {
 						name: "is_superuser".to_string(),
 						type_definition: FieldType::Boolean,
-						not_null: false,
+						// The Rust model declares `pub is_superuser: bool`
+						// (non-optional) with `#[field(default = false)]`,
+						// so the schema must mirror that contract: NOT NULL
+						// with a database-level default of `false`. Allowing
+						// NULL would let the column decode into a state the
+						// Rust type cannot represent.
+						not_null: true,
 						unique: false,
 						primary_key: false,
 						auto_increment: false,
-						default: None,
+						default: Some("false".to_string()),
 					},
 					ColumnDefinition {
 						name: "last_login".to_string(),

--- a/examples/examples-twitter/migrations/auth/0001_initial.rs
+++ b/examples/examples-twitter/migrations/auth/0001_initial.rs
@@ -120,6 +120,15 @@ pub(super) fn migration() -> Migration {
 						default: None,
 					},
 					ColumnDefinition {
+						name: "is_superuser".to_string(),
+						type_definition: FieldType::Boolean,
+						not_null: false,
+						unique: false,
+						primary_key: false,
+						auto_increment: false,
+						default: None,
+					},
+					ColumnDefinition {
 						name: "last_login".to_string(),
 						type_definition: FieldType::TimestampTz,
 						not_null: false,

--- a/examples/examples-twitter/src/apps/auth/models/user.rs
+++ b/examples/examples-twitter/src/apps/auth/models/user.rs
@@ -1,13 +1,19 @@
 //! User model for authentication
 //!
-//! Implements BaseUser trait with Argon2id password hashing.
-//! Note: `#[user]` macro cannot be used here due to ManyToManyField<User, User>
-//! self-referential relationships causing type inference issues.
+//! Implements BaseUser trait with Argon2id password hashing via the `#[user]`
+//! attribute macro. Supports self-referential `ManyToManyField<User, User>`
+//! relationships for following/blocking (kent8192/reinhardt-web#3651).
+//!
+//! Also provides a manual `impl AdminUser for User` so that `AdminSite::set_user_type::<User>()`
+//! works without requiring the full `FullUser` field set (kent8192/reinhardt-web#3652).
 
 use chrono::{DateTime, Utc};
+use reinhardt::Argon2Hasher;
+#[cfg(native)]
+use reinhardt::admin::AdminUser;
 use reinhardt::db::associations::ManyToManyField;
+use reinhardt::macros::user;
 use reinhardt::prelude::*;
-use reinhardt::{Argon2Hasher, BaseUser};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -15,6 +21,7 @@ use uuid::Uuid;
 #[cfg(all(test, native))]
 use sqlx::FromRow;
 
+#[user(hasher = Argon2Hasher, username_field = "email", manager = false)]
 #[model(app_label = "auth", table_name = "auth_user")]
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(all(test, native), derive(FromRow))]
@@ -33,6 +40,9 @@ pub struct User {
 
 	#[field(default = true)]
 	pub is_active: bool,
+
+	#[field(default = false)]
+	pub is_superuser: bool,
 
 	#[field(include_in_new = false)]
 	pub last_login: Option<DateTime<Utc>>,
@@ -55,42 +65,28 @@ pub struct User {
 	pub blocked_users: ManyToManyField<User, User>,
 }
 
-// Workaround for kent8192/reinhardt-web#3651 (tracked in reinhardt-web#3651)
-// Remove this workaround when the upstream issue is resolved.
-//
-// Ideal implementation (without workaround):
-//   #[user(hasher = Argon2Hasher, username_field = "email")]
-//   #[model(app_label = "auth", table_name = "auth_user")]
-//   pub struct User { ... }
-impl BaseUser for User {
-	type PrimaryKey = Uuid;
-	type Hasher = Argon2Hasher;
+// Manual `AdminUser` implementation for BaseUser-only models
+// (kent8192/reinhardt-web#3652, enabled by PR #3656). The struct intentionally
+// omits most of the `FullUser` field set (`first_name`/`last_name`/`is_staff`/
+// `date_joined`) to keep the demo schema small, so we cannot rely on the
+// blanket `impl<T: FullUser> AdminUser for T`. `is_staff` is delegated to
+// `is_superuser` for this demo — a real application would back it with a
+// dedicated DB column.
+#[cfg(native)]
+impl AdminUser for User {
+	fn is_active(&self) -> bool {
+		self.is_active
+	}
 
-	fn get_username_field() -> &'static str {
-		"email"
+	fn is_staff(&self) -> bool {
+		self.is_superuser
+	}
+
+	fn is_superuser(&self) -> bool {
+		self.is_superuser
 	}
 
 	fn get_username(&self) -> &str {
 		&self.email
-	}
-
-	fn password_hash(&self) -> Option<&str> {
-		self.password_hash.as_deref()
-	}
-
-	fn set_password_hash(&mut self, hash: String) {
-		self.password_hash = Some(hash);
-	}
-
-	fn last_login(&self) -> Option<DateTime<Utc>> {
-		self.last_login
-	}
-
-	fn set_last_login(&mut self, time: DateTime<Utc>) {
-		self.last_login = Some(time);
-	}
-
-	fn is_active(&self) -> bool {
-		self.is_active
 	}
 }

--- a/examples/examples-twitter/src/apps/auth/shared/server_fn.rs
+++ b/examples/examples-twitter/src/apps/auth/shared/server_fn.rs
@@ -133,9 +133,10 @@ pub async fn register(
 	let mut new_user = User::new(
 		request.username.trim().to_string(),
 		request.email.trim().to_string(),
-		None,
-		true,
-		None,
+		None,  // password_hash (set below)
+		true,  // is_active
+		false, // is_superuser
+		None,  // bio
 	);
 
 	// Set password

--- a/examples/examples-twitter/src/apps/auth/shared/types.rs
+++ b/examples/examples-twitter/src/apps/auth/shared/types.rs
@@ -23,10 +23,10 @@ pub struct UserInfo {
 impl From<crate::apps::auth::models::User> for UserInfo {
 	fn from(user: crate::apps::auth::models::User) -> Self {
 		UserInfo {
-			id: user.id(),
-			username: user.username().to_string(),
-			email: user.email().to_string(),
-			is_active: user.is_active(),
+			id: user.id,
+			username: user.username,
+			email: user.email,
+			is_active: user.is_active,
 		}
 	}
 }

--- a/examples/examples-twitter/src/apps/auth/tests/server_fn.rs
+++ b/examples/examples-twitter/src/apps/auth/tests/server_fn.rs
@@ -606,7 +606,7 @@ async fn test_login_success(#[future] twitter_db_pool: (PgPool, String)) {
 		.expect("User creation should succeed");
 
 	// Act & Assert
-	assert_eq!(user.email(), &test_user.email);
+	assert_eq!(&user.email, &test_user.email);
 	assert!(user.is_active());
 
 	let password_valid = user
@@ -680,7 +680,7 @@ async fn test_register_success(#[future] twitter_db_pool: (PgPool, String)) {
 
 	// Assert
 	assert_eq!(user.username(), "newuser");
-	assert_eq!(user.email(), "newuser@example.com");
+	assert_eq!(user.email, "newuser@example.com");
 	assert!(user.is_active());
 
 	let password_valid = user
@@ -851,6 +851,6 @@ async fn test_user_info_conversion(#[future] twitter_db_pool: (PgPool, String)) 
 	// Assert
 	assert_eq!(user_info.id, user.id());
 	assert_eq!(&user_info.username, user.username());
-	assert_eq!(&user_info.email, user.email());
+	assert_eq!(&user_info.email, &user.email);
 	assert_eq!(user_info.is_active, user.is_active());
 }

--- a/examples/examples-twitter/src/apps/auth/tests/server_fn.rs
+++ b/examples/examples-twitter/src/apps/auth/tests/server_fn.rs
@@ -163,7 +163,7 @@ async fn test_login_server_fn_success(#[future] twitter_db_pool: (PgPool, String
 	// Assert
 	assert_eq!(response.status, StatusCode::OK, "Login should succeed");
 	let user_info: UserInfo = parse_ok_body(&response);
-	assert_eq!(user_info.id, user.id());
+	assert_eq!(user_info.id, user.id);
 	assert_eq!(user_info.username, test_user.username);
 	assert_eq!(user_info.email, test_user.email);
 	assert!(user_info.is_active);
@@ -303,7 +303,7 @@ async fn test_current_user_authenticated(#[future] twitter_db_pool: (PgPool, Str
 	// Pre-populate session with user_id (simulating post-login state)
 	let mut session = SessionData::new(Duration::from_secs(3600));
 	session
-		.set("user_id".to_string(), created_user.id())
+		.set("user_id".to_string(), created_user.id)
 		.expect("Session set should succeed");
 	let session_id = session.id.clone();
 	store.save(session);
@@ -324,7 +324,7 @@ async fn test_current_user_authenticated(#[future] twitter_db_pool: (PgPool, Str
 	let user_info: Option<UserInfo> = parse_ok_body(&response);
 	assert!(user_info.is_some(), "Should return user info");
 	let user_info = user_info.unwrap();
-	assert_eq!(user_info.id, created_user.id());
+	assert_eq!(user_info.id, created_user.id);
 	assert_eq!(user_info.username, test_user.username);
 	assert_eq!(user_info.email, test_user.email);
 }
@@ -503,7 +503,7 @@ async fn test_auth_flow_login_then_current_user(#[future] twitter_db_pool: (PgPo
 		"Login should succeed"
 	);
 	let login_user_info: UserInfo = parse_ok_body(&login_response);
-	assert_eq!(login_user_info.id, created_user.id());
+	assert_eq!(login_user_info.id, created_user.id);
 
 	// Step 2: current_user with the login session cookie.
 	// The login handler stores user_id in the new session and sets a Set-Cookie
@@ -540,7 +540,7 @@ async fn test_auth_flow_login_then_current_user(#[future] twitter_db_pool: (PgPo
 		"Should return user after login"
 	);
 	let current_user_info = current_user_info.unwrap();
-	assert_eq!(current_user_info.id, created_user.id());
+	assert_eq!(current_user_info.id, created_user.id);
 	assert_eq!(current_user_info.username, test_user.username);
 	assert_eq!(current_user_info.email, test_user.email);
 
@@ -607,7 +607,7 @@ async fn test_login_success(#[future] twitter_db_pool: (PgPool, String)) {
 
 	// Act & Assert
 	assert_eq!(&user.email, &test_user.email);
-	assert!(user.is_active());
+	assert!(user.is_active);
 
 	let password_valid = user
 		.check_password(&test_user.password)
@@ -651,7 +651,7 @@ async fn test_login_inactive_user(#[future] twitter_db_pool: (PgPool, String)) {
 		.expect("User creation should succeed");
 
 	// Assert
-	assert!(!user.is_active(), "User should be inactive");
+	assert!(!user.is_active, "User should be inactive");
 }
 
 #[rstest]
@@ -679,9 +679,9 @@ async fn test_register_success(#[future] twitter_db_pool: (PgPool, String)) {
 		.expect("User creation should succeed");
 
 	// Assert
-	assert_eq!(user.username(), "newuser");
+	assert_eq!(user.username, "newuser");
 	assert_eq!(user.email, "newuser@example.com");
-	assert!(user.is_active());
+	assert!(user.is_active);
 
 	let password_valid = user
 		.check_password("SecurePassword123")
@@ -849,8 +849,8 @@ async fn test_user_info_conversion(#[future] twitter_db_pool: (PgPool, String)) 
 	let user_info = UserInfo::from(user.clone());
 
 	// Assert
-	assert_eq!(user_info.id, user.id());
-	assert_eq!(&user_info.username, user.username());
+	assert_eq!(user_info.id, user.id);
+	assert_eq!(&user_info.username, &user.username);
 	assert_eq!(&user_info.email, &user.email);
-	assert_eq!(user_info.is_active, user.is_active());
+	assert_eq!(user_info.is_active, user.is_active);
 }

--- a/examples/examples-twitter/src/apps/dm/lib.rs
+++ b/examples/examples-twitter/src/apps/dm/lib.rs
@@ -21,6 +21,11 @@ pub mod server;
 #[cfg(test)]
 pub mod tests;
 
+// DM WebSocket routes are intentionally NOT registered via a `urls/ws_urls.rs`
+// submodule (kent8192/reinhardt-web#3918). The DM app uses `DMHandler`, a
+// `WebSocketConsumer` wired through middleware in `src/config/middleware.rs`.
+// This shows an alternative WS integration path that bypasses the URL system.
+
 #[cfg(native)]
 #[app_config(name = "dm", label = "dm", verbose_name = "Direct Messages")]
 pub struct DmConfig;

--- a/examples/examples-twitter/src/apps/relationship/tests/server_fn.rs
+++ b/examples/examples-twitter/src/apps/relationship/tests/server_fn.rs
@@ -122,9 +122,9 @@ async fn test_create_multiple_users_for_following(#[future] twitter_db_pool: (Pg
 	assert_ne!(user1.id(), user3.id());
 
 	// Verify all users are active
-	assert!(user1.is_active());
-	assert!(user2.is_active());
-	assert!(user3.is_active());
+	assert!(user1.is_active);
+	assert!(user2.is_active);
+	assert!(user3.is_active);
 }
 
 // ============================================================================
@@ -223,7 +223,7 @@ async fn test_inactive_user_in_relationship(#[future] twitter_db_pool: (PgPool, 
 		.await
 		.expect("User creation should succeed");
 
-	assert!(!user.is_active(), "User should be inactive");
+	assert!(!user.is_active, "User should be inactive");
 
 	// In business logic, inactive users might be excluded from follow operations
 	let user_info = UserInfo::from(user);

--- a/examples/examples-twitter/src/config/admin.rs
+++ b/examples/examples-twitter/src/config/admin.rs
@@ -7,6 +7,7 @@
 //! - `#[admin(model, ...)]` macro-based registration
 //! - `fields` attribute for controlling form fields
 
+use crate::apps::auth::models::User;
 use crate::apps::dm::admin::{DMMessageAdmin, DMRoomAdmin};
 use crate::apps::profile::admin::ProfileAdmin;
 use crate::apps::tweet::admin::TweetAdmin;
@@ -18,13 +19,8 @@ use reinhardt::admin::AdminSite;
 /// Database connection will be configured via DI container in urls.rs.
 ///
 pub fn configure_admin() -> AdminSite {
-	// Workaround for kent8192/reinhardt-web#3652 (tracked in reinhardt-web#3652)
-	// Remove this workaround when the upstream issue is resolved.
-	//
-	// Ideal implementation (without workaround):
-	//   let mut site = AdminSite::new("Twitter Admin");
-	//   site.set_user_type::<User>();
-	let site = AdminSite::new("Twitter Admin");
+	let mut site = AdminSite::new("Twitter Admin");
+	site.set_user_type::<User>();
 
 	// Customize admin site configuration
 	site.configure(|config| {

--- a/examples/examples-twitter/src/config/settings.rs
+++ b/examples/examples-twitter/src/config/settings.rs
@@ -20,6 +20,17 @@
 //!
 //! The environment is determined by the `REINHARDT_ENV` environment variable.
 //! If `REINHARDT_ENV` is not set, it defaults to `local`.
+//!
+//! ## Variable Interpolation (rc.27+)
+//!
+//! `TomlFileSource::new(path)` enables `${VAR}` interpolation by default
+//! (kent8192/reinhardt-web#4229). To opt out, call `.without_interpolation()`
+//! on the source. Typed coercion of interpolated values (e.g.,
+//! `port = "${PORT:-5432}"` -> `u16`) is also ON by default (#4241);
+//! opt out with `SettingsBuilder::with_typed_coercion(false)`.
+//!
+//! `build_composed()` uses `MergeStrategy::Deep` by default starting in
+//! rc.28 (#4264), which merges nested tables key-by-key across sources.
 
 use reinhardt::conf::settings::builder::SettingsBuilder;
 use reinhardt::conf::settings::profile::Profile;

--- a/examples/examples-twitter/src/test_utils/factories/user.rs
+++ b/examples/examples-twitter/src/test_utils/factories/user.rs
@@ -290,7 +290,7 @@ mod tests {
 			.await
 			.expect("User creation should succeed");
 
-		assert_eq!(user.username(), "factoryuser");
+		assert_eq!(user.username, "factoryuser");
 		assert_eq!(user.email, "factoryuser@example.com");
 		assert!(user.is_active);
 	}

--- a/examples/examples-twitter/src/test_utils/factories/user.rs
+++ b/examples/examples-twitter/src/test_utils/factories/user.rs
@@ -60,6 +60,7 @@ impl UserFactory {
 				Alias::new("email"),
 				Alias::new("password_hash"),
 				Alias::new("is_active"),
+				Alias::new("is_superuser"),
 				Alias::new("created_at"),
 				Alias::new("bio"),
 			])
@@ -69,6 +70,7 @@ impl UserFactory {
 				Value::from(test_user.email.clone()),
 				Value::from(password_hash),
 				Value::from(test_user.is_active),
+				Value::from(test_user.is_superuser),
 				Value::from(Utc::now()),
 				test_user.bio.clone().into_value(),
 			])
@@ -110,6 +112,7 @@ impl UserFactory {
 				Alias::new("email"),
 				Alias::new("password_hash"),
 				Alias::new("is_active"),
+				Alias::new("is_superuser"),
 				Alias::new("last_login"),
 				Alias::new("created_at"),
 				Alias::new("bio"),
@@ -134,6 +137,7 @@ impl UserFactory {
 				Alias::new("email"),
 				Alias::new("password_hash"),
 				Alias::new("is_active"),
+				Alias::new("is_superuser"),
 				Alias::new("last_login"),
 				Alias::new("created_at"),
 				Alias::new("bio"),
@@ -287,8 +291,8 @@ mod tests {
 			.expect("User creation should succeed");
 
 		assert_eq!(user.username(), "factoryuser");
-		assert_eq!(user.email(), "factoryuser@example.com");
-		assert!(user.is_active());
+		assert_eq!(user.email, "factoryuser@example.com");
+		assert!(user.is_active);
 	}
 
 	#[rstest]

--- a/examples/examples-twitter/src/test_utils/fixtures/users.rs
+++ b/examples/examples-twitter/src/test_utils/fixtures/users.rs
@@ -17,6 +17,7 @@ pub struct TestTwitterUser {
 	pub email: String,
 	pub password: String,
 	pub is_active: bool,
+	pub is_superuser: bool,
 	pub bio: Option<String>,
 }
 
@@ -30,6 +31,7 @@ impl TestTwitterUser {
 			email: format!("{}@example.com", username),
 			password: "password123".to_string(),
 			is_active: true,
+			is_superuser: false,
 			bio: None,
 		}
 	}
@@ -55,6 +57,12 @@ impl TestTwitterUser {
 	/// Set the user's active status.
 	pub fn with_active(mut self, is_active: bool) -> Self {
 		self.is_active = is_active;
+		self
+	}
+
+	/// Set the user's superuser status.
+	pub fn with_superuser(mut self, is_superuser: bool) -> Self {
+		self.is_superuser = is_superuser;
 		self
 	}
 


### PR DESCRIPTION
## Summary

Reflect the API patterns and workaround resolutions from reinhardt-web `v0.1.0-rc.17` through `v0.1.0-rc.29` into the `examples-twitter` example. This PR resolves two long-standing workarounds (now-closed upstream issues #3651 and #3652) and documents three default behavior changes introduced during the RC window.

This PR addresses:

- Adopts the `#[user]` attribute macro on the auth `User` model, dropping the manual `BaseUser` impl workaround that existed because `#[user]` previously did not support self-referential `ManyToManyField<User, User>` relations (resolved by PR #3655).
- Re-enables `AdminSite::set_user_type::<User>()` via a manual `impl AdminUser for User`, the `BaseUser`-only admin pattern introduced by PR #3656.
- Adds module-level doc comments in `config/settings.rs` describing the new default-on TOML `${VAR}` interpolation (#4229), typed coercion (#4241), and `MergeStrategy::Deep` (#4264) behavior introduced in rc.27 / rc.28.
- Adds a code comment in `apps/dm/lib.rs` clarifying that the DM app intentionally bypasses the `urls/ws_urls.rs` scaffold (#3918) and wires WebSockets through middleware instead.

## Type of Change

- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update

## Motivation and Context

The `examples-twitter` project is the framework's "everything turned on" reference implementation. During the rapid rc.X cycle, several upstream improvements that unlock cleaner example code landed, but the example itself was not updated to reflect them. Two `// Workaround for kent8192/reinhardt-web#NNNN` blocks remained even after the corresponding upstream issues were closed on 2026-04-15:

- **#3651** (closed by PR #3655) — `#[user]` macro could not handle self-referential M2M fields. The example used a manual `BaseUser` impl as a workaround.
- **#3652** (closed by PR #3656) — `AdminSite::set_user_type` required `FullUser`. PR #3656 added the `AdminUser` trait abstraction with the option to manually implement it for `BaseUser`-only models. The example's User schema is intentionally minimal, so the manual impl path is the right one to demonstrate.

Beyond the workarounds, three rc.27 / rc.28 behavior changes deserve in-code documentation so readers studying the example understand what defaults are now in play:

- `TomlFileSource::new(path)` enables `${VAR}` interpolation by default (#4229).
- Typed coercion of interpolated values is ON by default (#4241).
- `SettingsBuilder::build_composed()` defaults to `MergeStrategy::Deep` (#4264).

Refs #3651
Refs #3652
Refs #4229
Refs #4241
Refs #4264
Refs #3918

## How Was This Tested?

Local verification on macOS (aarch64-apple-darwin), with `.cargo/config.toml` activated against the local workspace:

- ` ` ` cargo check -p examples-twitter --all-features -j 4` — clean
- ` ` ` cargo check -p examples-twitter --target wasm32-unknown-unknown --features client-router --lib -j 4` — clean (5 pre-existing #3971/#3972 deprecation warnings unrelated to this PR)
- ` ` ` cargo build -p examples-twitter --bin examples-twitter --all-features -j 4` — clean
- ` ` ` cargo fmt --check` on `apps/auth/models/user.rs` — clean (two unrelated `examples-twitter` files have pre-existing fmt diffs and are not touched by this PR)
- ` ` ` cargo clippy -p examples-twitter --all-features -j 4 -- -D warnings` — clean
- Workaround grep verification (zero hits for `Workaround for kent8192/reinhardt-web#3651` / `#3652` after this PR)

End-to-end test suite via TestContainers / PostgreSQL (` ` ` cargo nextest run -p examples-twitter --features e2e-tests`) was not exercised in this PR cycle; reviewers should run it before marking the PR ready for merge.

## Breaking Changes

None for users of the example. The example's own `auth` schema gains an `is_superuser: bool` column (required by the `PermissionsMixin` impl that the `#[user]` macro now emits as part of its trait bundle). The change is mirrored in the initial migration of the `auth` app (` ` ` migrations/auth/0001_initial.rs`), so freshly-bootstrapped databases see the new column without a separate migration step. There is no `examples-twitter` deployment to migrate.

## Out of Scope

Items reviewed and deliberately deferred to follow-up PRs (see ` ` ` /Users/kent8192/.claude/plans/example-examples-twitter-20-release-ann-serialized-cupcake.md`):

- `form!` macro `strip_arguments` migration (#3972) — the current `_csrf_token: String` auto-injection is BC-compatible and educational.
- `ClientLauncher::intercept_links` / lifecycle hooks (#3993) — WASM entry point refactor.
- `auto_register_router` / `start_server(addr)` (#4058) — the current `execute_from_command_line()` is sufficient.
- `HasCommonSettings` / `DatabaseConnection::database_url_from` (#4295) — DB-URL plumbing showcase belongs to its own PR.
- `BrokenLinkEmailsMiddleware::from_settings` (#4338) — the example does not use this middleware.
- `urls/server_urls.rs` + `urls/client_router.rs` scaffold (#4344) — 5-app mechanical refactor with no behavioral benefit.
- `with_di_overrides!` macro (#4350) — test-infrastructure modernization.
- PR #4456 (BC #4476) — unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an is_superuser flag to user accounts; new registrations default it to false.

* **Documentation**
  * Updated configuration docs with TOML interpolation and composition/merge details.
  * Clarified DM WebSocket integration approach.

* **Chores**
  * Admin panel now explicitly uses the app's user type.

* **Tests**
  * Updated tests, factories, and fixtures to match the revised user model fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->