### PR TITLE
fix(examples-twitter): mark is_active migration column NOT NULL with default true

### DIFF
--- a/examples/examples-twitter/migrations/auth/0001_initial.rs
+++ b/examples/examples-twitter/migrations/auth/0001_initial.rs
@@ -113,11 +113,17 @@ pub(super) fn migration() -> Migration {
 					ColumnDefinition {
 						name: "is_active".to_string(),
 						type_definition: FieldType::Boolean,
-						not_null: false,
+						// The Rust model declares `pub is_active: bool`
+						// (non-optional) with `#[field(default = true)]`,
+						// so the schema must mirror that contract: NOT NULL
+						// with a database-level default of `true`. Allowing
+						// NULL would let the column decode into a state the
+						// Rust type cannot represent.
+						not_null: true,
 						unique: false,
 						primary_key: false,
 						auto_increment: false,
-						default: None,
+						default: Some("true".to_string()),
 					},
 					ColumnDefinition {
 						name: "is_superuser".to_string(),


### PR DESCRIPTION
## Summary

This PR addresses:

- Changes `is_active` column in `examples/examples-twitter/migrations/auth/0001_initial.rs` from `not_null: false, default: None` to `not_null: true, default: Some("true")`.
- Mirrors the existing rationale comment on the adjacent `is_superuser` column (which received the same fix in PR #4513), eliminating the previously asymmetric nullability.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The Rust model declares `pub is_active: bool` (non-optional) with `#[field(default = true)]` in `examples/examples-twitter/src/apps/auth/models/user.rs`. Allowing NULL in the database would let the column decode into a state the Rust type cannot represent — silently substituting `Default::default()` (`false`) at decode time. This asymmetry became newly visible after PR #4513's explicit rationale comment on `is_superuser`.

Since examples-twitter is a demo with no production users, this updates the initial migration in place (rather than adding a follow-up migration that would only delay correctness) and replicates the `is_superuser` comment so future readers see the type-contract reason directly.

### Scope clarification: downstream hot-fix, not the root-cause fix

This PR is intentionally **scoped as a downstream hot-fix for the demo crate only**. The underlying root cause is a bug in `reinhardt-db`'s migration autodetector: non-Optional `bool` fields with `#[field(default = ...)]` are generated as nullable columns (`not_null: false, default: None`) instead of the schema that the Rust type contract demands (`NOT NULL DEFAULT '<value>'`). That generator bug is tracked separately in **#4573** and is the change that will actually prevent recurrence on every new project created via `reinhardt-admin startproject`.

Without the generator fix, the same hand-patch pattern will be required for every new bool flag added in any Reinhardt project — this PR is the third instance of the same symptom (after #4513 for `is_superuser`).

- Refs #4551 (re-scoped: that issue is now the symptom report; #4573 is the root-cause counterpart)
- Refs #4573 (generator-level fix; once landed, the hand-patches in this PR and #4513 can be regenerated cleanly via `cargo make makemigrations`)

## How Was This Tested?

- Verified `cargo check` runs cleanly against the local examples-twitter workspace **on the migration file in isolation** (syntactic validity).
- Note: the broader `examples-twitter` package surfaces unrelated compile errors (in `apps/auth/manager.rs`'s `#[user]` + `#[derive(Model)]` expansion) that are **outside the scope of this PR** — those predate this change and are unaffected by the column-definition edit. Leaving the PR as Draft until those are confirmed pre-existing on main.

## Labels to Apply

- bug
- low
- database
- examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Summary by CodeRabbit

* **Chores**
  * Enhanced database integrity for user authentication by implementing stricter constraints on the user active status field, ensuring all records maintain consistent and valid data states.



[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

