### PR TITLE
fix(ci): skip binary-only crates in semver-check matrix

### DIFF
--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -70,10 +70,14 @@ jobs:
           # Publishable crate set: intersect with .workspace_members so that
           # future path-dependencies outside the workspace cannot leak into the
           # matrix (Copilot review feedback), then drop unpublished crates and
-          # the two binary-only members (reinhardt-web, reinhardt-pages) that
-          # have no public-library SemVer surface. Single source of truth for
-          # both the matrix and phase detection so an excluded/private crate
-          # cannot diverge phase from the crates actually under check
+          # crates without any library-shaped target (lib/rlib/cdylib/dylib/
+          # proc-macro). cargo-semver-checks only operates on library API
+          # surfaces and exits 1 when handed a binary-only crate (Issue #4575).
+          # The two members reinhardt-web and reinhardt-pages do expose library
+          # targets but are intentionally opted out of SemVer enforcement, so
+          # they remain on a hard-coded exclusion list. Single source of truth
+          # for both the matrix and phase detection so an excluded/private
+          # crate cannot diverge phase from the crates actually under check
           # (CodeRabbit review feedback). Emit name+version+manifest_path; the
           # manifest path is forwarded to the matrix shards so they can detect
           # newly-introduced crates whose Cargo.toml does not exist at the
@@ -84,6 +88,10 @@ jobs:
             [.packages[]
              | select(.id as $id | $wm | index($id))
              | select(.publish == null or (.publish | length > 0))
+             | select(.targets | any(.kind | any(
+                 . == "lib" or . == "rlib" or
+                 . == "cdylib" or . == "dylib" or
+                 . == "proc-macro")))
              | {name: .name,
                 version: .version,
                 manifest_path: (.manifest_path | sub("^" + $ws + "/"; ""))}]


### PR DESCRIPTION
## Summary

The SemVer Check matrix shard for `reinhardt-admin-cli` fails with exit code 1 because `cargo-semver-checks` cannot operate on a crate that has no library target. Filter the discover step by `.targets[].kind` so any binary-only workspace member is excluded automatically.

This PR addresses:

- Exclude crates without a library-shaped target (`lib`/`rlib`/`cdylib`/`dylib`/`proc-macro`) from the per-crate SemVer matrix in `.github/workflows/semver-check.yml`.
- Preserve the existing hard-coded `reinhardt-web` / `reinhardt-pages` exclusion list (those crates do expose library targets but are intentionally opted out).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

`reinhardt-admin-cli` is a binary-only crate (`[[bin]]` only, no `src/lib.rs`). After PR #4559 split SemVer Check into a per-crate matrix, every shard invokes `cargo semver-checks check-release --package <name>`. When that package has no library target, `cargo-semver-checks` reports:

```text
error: no crates with library targets selected, nothing to semver-check
note: only library targets contain an API surface that can be checked for semver
note: skipped the following crates since they have no library target: reinhardt-admin-cli
```

and exits with code 1, failing the whole job. The previous workspace-wide invocation silently absorbed this; the per-crate split surfaces it.

The discover step already maintains a hard-coded exclusion list (`reinhardt-web`, `reinhardt-pages`), but those crates _do_ have `lib`/`rlib` targets and are excluded by **design** (opt-out of SemVer enforcement), whereas `reinhardt-admin-cli` has _no_ library target at all (physical fact derivable from `cargo metadata`). Adding `reinhardt-admin-cli` to the same hard-coded list would conflate the two cases and require manual maintenance every time a future binary-only crate appears.

Instead, this PR adds a structural filter on `.targets[].kind` so binary-only crates drop out of the matrix automatically. The hard-coded exclusion remains for the design opt-out case.

This aligns with the Reinhardt design philosophy: principle #2 (\"CoC must be predictable without domain knowledge\" — \"no lib target -> no SemVer surface\" is derivable from Cargo facts) and #9 (\"every framework eventually becomes outdated\" — future binary-only crates require no workflow edits).

Fixes #4575

Related to: #4559 (per-crate matrix split)

## How Was This Tested?

- YAML syntax validated locally: `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/semver-check.yml'))\"` -> OK.
- jq filter dry-run against current `cargo metadata`:
  - Before fix: 47 publishable crates (including `reinhardt-admin-cli`).
  - After fix: 46 crates — exactly `reinhardt-admin-cli` removed, no other crates affected (verified by `diff`).
  - proc-macro crates (`reinhardt-*-macros`) remain in the matrix (`kind: [\"proc-macro\"]` matches the filter).
  - The WASM admin frontend crate `reinhardt-admin` (cdylib+rlib) remains in the matrix — distinct from `reinhardt-admin-cli`.
- The failing job that motivated this fix: https://github.com/kent8192/reinhardt-web/actions/runs/26013635795/job/76459996017

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (in-file comments updated to reflect the new filter rationale)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (workflow change; verified by jq dry-run and the CI run itself will confirm)
- [x] New and existing unit tests pass locally with my changes (no source-code changes)
- [ ] I have tested with all affected database backends (N/A)
- [x] I have formatted the code with `cargo make fmt-fix` (N/A — workflow YAML only)
- [x] I have checked the code with `cargo make clippy-check` (N/A — workflow YAML only)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4575
- Related to #4559 (per-crate matrix split that surfaced this latent issue)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to refine how publishable crates are identified during the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->