### PR TITLE
ci(release-plz): cancel in-flight Release PR runs on newer pushes

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -56,8 +56,15 @@ jobs:
     runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
     timeout-minutes: 360
     concurrency:
+      # Cancel any in-flight Release PR regeneration when a newer push lands
+      # on the same ref. release-plz rebuilds the release-plz-* branch from
+      # the latest Cargo.toml each run, so older runs are stale the moment
+      # a newer commit appears. Safe because this job only writes to the
+      # release-plz-* branch (idempotent regeneration), not to crates.io.
+      # The publish job (release-plz-release) intentionally keeps
+      # cancel-in-progress: false to avoid mid-publish interruption.
       group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     steps:
       - name: Generate GitHub token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
## Summary

- Set `cancel-in-progress: true` on the `release-plz-pr` job so newer pushes to `main` or `develop/**` immediately supersede any in-flight Release PR regeneration.
- The publish job (`release-plz-release`) intentionally keeps `cancel-in-progress: false` to avoid leaving crates.io in a partial-publish state mid-run.

## Type of Change

- [x] CI / Workflow change (non-breaking)

## Motivation and Context

`release-plz-pr` regenerates the `release-plz-*` branch from the latest `Cargo.toml` on the ref each run. With the previous `cancel-in-progress: false` setting, an in-flight run kept consuming the self-hosted ARM runner even when a newer push had already made its output stale; the next push then had to wait in the queue.

Switching this job to `cancel-in-progress: true` makes the workflow behavior match the user's mental model: only the latest push's Release PR run executes. Because the job is a pure branch regeneration against the latest `Cargo.toml` and writes only to the `release-plz-*` branch (no crates.io interaction), cancelling mid-run is safe — the next run will rebuild the branch from scratch.

The publish job (`release-plz-release`) is left untouched. Cancelling it mid-run would risk a partial `crates.io` publish across the 47 publishable crates, requiring the `RP-1` recovery procedure in `instructions/RELEASE_PROCESS.md`.

## How Was This Tested

- Reviewed `.github/workflows/release-plz.yml` diff: only the `release-plz-pr` concurrency block is touched.
- No code path changes; YAML structure is preserved.
- GitHub Actions YAML is syntactically validated implicitly by GitHub on push.

## Checklist

- [x] PR title follows Conventional Commits (`ci(release-plz): ...`)
- [x] Only `release-plz-pr` job is changed; `release-plz-release` retains `cancel-in-progress: false`
- [x] Rationale captured as a YAML comment block above the changed key
- [x] No untrusted input added to `run:` steps
- [x] Comment block explains *why* (cache regeneration is idempotent) and the asymmetric choice between the two jobs

## Labels to Apply

- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process efficiency by preventing redundant release PR regeneration runs. When a newer update is pushed, any in-progress release PR updates are now cancelled to ensure only the latest version is generated, reducing unnecessary CI/CD overhead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->