### PR TITLE
ci(semver-check): skip proc-macro crates in per-crate matrix

### DIFF
--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -70,14 +70,18 @@ jobs:
           # Publishable crate set: intersect with .workspace_members so that
           # future path-dependencies outside the workspace cannot leak into the
           # matrix (Copilot review feedback), then drop unpublished crates and
-          # crates without any library-shaped target (lib/rlib/cdylib/dylib/
-          # proc-macro). cargo-semver-checks only operates on library API
-          # surfaces and exits 1 when handed a binary-only crate (Issue #4575).
-          # The two members reinhardt-web and reinhardt-pages do expose library
-          # targets but are intentionally opted out of SemVer enforcement, so
-          # they remain on a hard-coded exclusion list. Single source of truth
-          # for both the matrix and phase detection so an excluded/private
-          # crate cannot diverge phase from the crates actually under check
+          # crates without any analyzable library-shaped target
+          # (lib/rlib/cdylib/dylib). cargo-semver-checks only operates on
+          # library API surfaces and exits 1 when handed a binary-only crate
+          # (Issue #4575) or a proc-macro-only crate (Issue #4597) — proc-macro
+          # crates declare `[lib] proc-macro = true` but expose no analyzable
+          # library target surface, so they are dropped here too rather than
+          # producing one failing matrix shard per crate. The two members
+          # reinhardt-web and reinhardt-pages do expose library targets but
+          # are intentionally opted out of SemVer enforcement, so they remain
+          # on a hard-coded exclusion list. Single source of truth for both
+          # the matrix and phase detection so an excluded/private crate
+          # cannot diverge phase from the crates actually under check
           # (CodeRabbit review feedback). Emit name+version+manifest_path; the
           # manifest path is forwarded to the matrix shards so they can detect
           # newly-introduced crates whose Cargo.toml does not exist at the
@@ -90,8 +94,7 @@ jobs:
              | select(.publish == null or (.publish | length > 0))
              | select(.targets | any(.kind | any(
                  . == "lib" or . == "rlib" or
-                 . == "cdylib" or . == "dylib" or
-                 . == "proc-macro")))
+                 . == "cdylib" or . == "dylib")))
              | {name: .name,
                 version: .version,
                 manifest_path: (.manifest_path | sub("^" + $ws + "/"; ""))}]


### PR DESCRIPTION
## Summary

- Extend the binary-crate skip logic in `.github/workflows/semver-check.yml` (added in PR #4576) to also exclude proc-macro crates (`[lib] proc-macro = true`).
- Eliminates 11 spurious matrix-shard failures per PR run.

Fixes #4597.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [x] CI/CD update

## Motivation and Context

The per-crate SemVer Check matrix from PR #4559 schedules one cargo-semver-checks shard per workspace crate. Proc-macro crates have no library target that cargo-semver-checks can analyze, so each shard fails with `error: no crates with library targets selected`. PR #4576 fixed the equivalent case for binary-only crates; this PR applies the same pattern to proc-macro crates.

## How Was This Tested

- [x] YAML syntax validated
- [x] Matrix-generation script manually walked through with one library crate manifest and one proc-macro crate manifest
- [x] `cargo make fmt-check`
- [ ] Full CI run on this PR

## Checklist

- [x] My code follows the project's style guidelines
- [x] PR title follows Conventional Commits format
- [x] Linked Issue (Fixes #4597)
- [x] All comments are in English

## Labels to Apply

- bug
- ci-cd
- macros

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined the semantic versioning check workflow to be more precise and accurate. The workflow now exclusively targets crates that expose public library APIs, automatically excluding internal crate types that lack a library interface. This improvement ensures more relevant and reliable semantic versioning validation across the project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->