### PR TITLE
test(integration): nest #[routes] trybuild fixtures under mod apps

### DIFF
--- a/tests/integration/tests/routes_registration_no_client_resolvers_trybuild.rs
+++ b/tests/integration/tests/routes_registration_no_client_resolvers_trybuild.rs
@@ -21,16 +21,47 @@ installed_apps! {
 	snippets: "snippets",
 }
 
-mod snippets {
-	pub mod urls {
-		use reinhardt::ServerRouter;
-		use reinhardt::url_patterns;
+// `#[routes(...)]` emits absolute paths of the form
+// `crate::apps::<app>::urls::url_resolvers::...` (see
+// `crates/reinhardt-core/macros/src/routes_registration.rs:905`). The
+// fixture's app module must therefore live under a `mod apps { ... }`
+// parent so the emitted path resolves; placing `mod snippets` at the
+// crate root would yield E0433. See #4596.
+//
+// `no_client_resolvers` suppresses *only* the per-app client resolver
+// lookups; the WS resolver path
+// `crate::apps::<app>::urls::ws_urls::ws_url_resolvers` is still
+// emitted (see `routes_registration.rs:1109` — that branch is gated by
+// `no_ws_resolvers`, not by `no_client_resolvers`). So this fixture
+// must also expose a `ws_urls` submodule populated by
+// `#[url_patterns(..., mode = ws)]`.
+mod apps {
+	pub(crate) mod snippets {
+		pub(crate) mod urls {
+			use reinhardt::ServerRouter;
+			use reinhardt::url_patterns;
 
-		use super::super::InstalledApp;
+			use super::super::super::InstalledApp;
 
-		#[url_patterns(InstalledApp::snippets, mode = server)]
-		pub fn url_patterns() -> ServerRouter {
-			ServerRouter::new()
+			#[url_patterns(InstalledApp::snippets, mode = server)]
+			pub fn url_patterns() -> ServerRouter {
+				ServerRouter::new()
+			}
+
+			// Empty stub: `#[routes]` walks every installed app and
+			// references `crate::apps::<app>::urls::ws_urls::ws_url_resolvers`.
+			// `mode = ws` emits the required resolver module with no entries.
+			pub(crate) mod ws_urls {
+				use reinhardt::UnifiedRouter;
+				use reinhardt::url_patterns;
+
+				use super::super::super::super::InstalledApp;
+
+				#[url_patterns(InstalledApp::snippets, mode = ws)]
+				pub fn ws_url_patterns() -> UnifiedRouter {
+					UnifiedRouter::new()
+				}
+			}
 		}
 	}
 }
@@ -42,7 +73,7 @@ pub fn routes() -> UnifiedRouter {
 	// The `installed_apps!` registry is consulted only for URL *resolver*
 	// lookups (`__for_each_url_resolver!`), not for route mounting — the
 	// user is responsible for the `.mount()` call.
-	UnifiedRouter::new().mount("/api/", crate::snippets::urls::url_patterns())
+	UnifiedRouter::new().mount("/api/", crate::apps::snippets::urls::url_patterns())
 }
 
 #[test]

--- a/tests/integration/tests/routes_registration_no_ws_resolvers_trybuild.rs
+++ b/tests/integration/tests/routes_registration_no_ws_resolvers_trybuild.rs
@@ -22,16 +22,33 @@ installed_apps! {
 	snippets: "snippets",
 }
 
-mod snippets {
-	pub mod urls {
-		use reinhardt::ServerRouter;
-		use reinhardt::url_patterns;
+// `#[routes(...)]` emits absolute paths of the form
+// `crate::apps::<app>::urls::url_resolvers::...` (see
+// `crates/reinhardt-core/macros/src/routes_registration.rs:905`). The
+// fixture's app module must therefore live under a `mod apps { ... }`
+// parent so the emitted path resolves; placing `mod snippets` at the
+// crate root would yield E0433. See #4596.
+//
+// `no_ws_resolvers` suppresses *only* the per-app WS resolver lookups;
+// the client resolver path
+// `crate::apps::<app>::urls::client_url_resolvers` is still emitted
+// when the `client-router` feature is enabled (see
+// `routes_registration.rs:999` — that branch is gated by
+// `no_client_resolvers`, not by `no_ws_resolvers`). `mode = unified`
+// emits both `url_resolvers` *and* `client_url_resolvers` modules in
+// a single `#[url_patterns]` expansion, satisfying both fan-outs.
+mod apps {
+	pub(crate) mod snippets {
+		pub(crate) mod urls {
+			use reinhardt::UnifiedRouter;
+			use reinhardt::url_patterns;
 
-		use super::super::InstalledApp;
+			use super::super::super::InstalledApp;
 
-		#[url_patterns(InstalledApp::snippets, mode = server)]
-		pub fn url_patterns() -> ServerRouter {
-			ServerRouter::new()
+			#[url_patterns(InstalledApp::snippets, mode = unified)]
+			pub fn url_patterns() -> UnifiedRouter {
+				UnifiedRouter::new()
+			}
 		}
 	}
 }
@@ -43,7 +60,7 @@ pub fn routes() -> UnifiedRouter {
 	// The `installed_apps!` registry is consulted only for URL *resolver*
 	// lookups (`__for_each_url_resolver!`), not for route mounting — the
 	// user is responsible for the `.mount()` call.
-	UnifiedRouter::new().mount("/api/", crate::snippets::urls::url_patterns())
+	UnifiedRouter::new().mount_unified("/api/", crate::apps::snippets::urls::url_patterns())
 }
 
 #[test]

--- a/tests/integration/tests/routes_registration_server_only_idempotent_trybuild.rs
+++ b/tests/integration/tests/routes_registration_server_only_idempotent_trybuild.rs
@@ -25,16 +25,24 @@ installed_apps! {
 	snippets: "snippets",
 }
 
-mod snippets {
-	pub mod urls {
-		use reinhardt::ServerRouter;
-		use reinhardt::url_patterns;
+// `#[routes(...)]` emits absolute paths of the form
+// `crate::apps::<app>::urls::url_resolvers::...` (see
+// `crates/reinhardt-core/macros/src/routes_registration.rs:905`). The
+// fixture's app module must therefore live under a `mod apps { ... }`
+// parent so the emitted path resolves; placing `mod snippets` at the
+// crate root would yield E0433. See #4596.
+mod apps {
+	pub(crate) mod snippets {
+		pub(crate) mod urls {
+			use reinhardt::ServerRouter;
+			use reinhardt::url_patterns;
 
-		use super::super::InstalledApp;
+			use super::super::super::InstalledApp;
 
-		#[url_patterns(InstalledApp::snippets, mode = server)]
-		pub fn url_patterns() -> ServerRouter {
-			ServerRouter::new()
+			#[url_patterns(InstalledApp::snippets, mode = server)]
+			pub fn url_patterns() -> ServerRouter {
+				ServerRouter::new()
+			}
 		}
 	}
 }
@@ -46,7 +54,7 @@ pub fn routes() -> UnifiedRouter {
 	// The `installed_apps!` registry is consulted only for URL *resolver*
 	// lookups (`__for_each_url_resolver!`), not for route mounting — the
 	// user is responsible for the `.mount()` call.
-	UnifiedRouter::new().mount("/api/", crate::snippets::urls::url_patterns())
+	UnifiedRouter::new().mount("/api/", crate::apps::snippets::urls::url_patterns())
 }
 
 #[test]

--- a/tests/integration/tests/routes_registration_server_only_trybuild.rs
+++ b/tests/integration/tests/routes_registration_server_only_trybuild.rs
@@ -22,16 +22,24 @@ installed_apps! {
 	snippets: "snippets",
 }
 
-mod snippets {
-	pub mod urls {
-		use reinhardt::ServerRouter;
-		use reinhardt::url_patterns;
+// `#[routes(...)]` emits absolute paths of the form
+// `crate::apps::<app>::urls::url_resolvers::...` (see
+// `crates/reinhardt-core/macros/src/routes_registration.rs:905`). The
+// fixture's app module must therefore live under a `mod apps { ... }`
+// parent so the emitted path resolves; placing `mod snippets` at the
+// crate root would yield E0433. See #4596.
+mod apps {
+	pub(crate) mod snippets {
+		pub(crate) mod urls {
+			use reinhardt::ServerRouter;
+			use reinhardt::url_patterns;
 
-		use super::super::InstalledApp;
+			use super::super::super::InstalledApp;
 
-		#[url_patterns(InstalledApp::snippets, mode = server)]
-		pub fn url_patterns() -> ServerRouter {
-			ServerRouter::new()
+			#[url_patterns(InstalledApp::snippets, mode = server)]
+			pub fn url_patterns() -> ServerRouter {
+				ServerRouter::new()
+			}
 		}
 	}
 }
@@ -45,7 +53,7 @@ pub fn routes() -> UnifiedRouter {
 	// user is responsible for the `.mount()` call. This mirrors the
 	// canonical pattern in
 	// `examples/examples-tutorial-rest/src/config/urls.rs`.
-	UnifiedRouter::new().mount("/api/", crate::snippets::urls::url_patterns())
+	UnifiedRouter::new().mount("/api/", crate::apps::snippets::urls::url_patterns())
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Wrap `mod snippets` in `mod apps` across all four `routes_registration_*_trybuild` positive-path fixtures so the path emitted by `#[routes]` (`crate::apps::<app>::urls::url_resolvers::...`) resolves deterministically.
- Update intra-fixture `use super::super::InstalledApp;` paths to compensate for the extra nesting level.
- Update the `routes()` body's `.mount(...)` argument to reflect the new module path.
- Complete `routes_registration_no_client_resolvers_trybuild` with a `ws_urls` submodule populated by `#[url_patterns(.., mode = ws)]` — the flag suppresses *client* resolvers only, so the still-emitted `crate::apps::<app>::urls::ws_urls::ws_url_resolvers` reference must exist.
- Switch `routes_registration_no_ws_resolvers_trybuild` to `#[url_patterns(.., mode = unified)]` so the still-emitted `crate::apps::<app>::urls::client_url_resolvers` reference resolves under `--all-features` (the `client-router` feature gate is active in `cargo check --tests`).

Fixes #4596.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [x] CI/CD update

## Motivation and Context

`cargo check --workspace --all-features --tests` was failing with E0433 on two of the four fixtures added in PR #4577 (positive-path coverage for `#[routes]` flag permutations). The other two passed only intermittently. The `#[routes]` macro reads app labels from `target/reinhardt/.installed_apps`, not from `installed_apps!` in the same translation unit; parallel test compilation races on this state file determine whether each fixture observes the apps it declared or the apps another fixture last wrote. Matching the fixtures' module layout to what the macro actually emits (`crate::apps::<app>::...`) makes them robust against any state-file pollution.

## How Was This Tested

- [x] `cargo check -p reinhardt-integration-tests --test routes_registration_no_client_resolvers_trybuild --all-features`
- [x] `cargo check -p reinhardt-integration-tests --test routes_registration_server_only_idempotent_trybuild --all-features`
- [x] `cargo check -p reinhardt-integration-tests --test routes_registration_no_ws_resolvers_trybuild --all-features`
- [x] `cargo check -p reinhardt-integration-tests --test routes_registration_server_only_trybuild --all-features`
- [x] `cargo make fmt-check`

## Checklist

- [x] My code follows the project's style guidelines
- [x] PR title follows Conventional Commits format
- [x] Tests added/updated where applicable
- [x] Linked Issue (Fixes #4596)
- [x] All comments are in English

## Labels to Apply

- bug
- ci-cd
- macros
- test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures for consistent module path resolution across macro expansion scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->