### PR TITLE
fix(urls): normalize viewset prefix in URL reversal to prevent triple slash

### DIFF
--- a/crates/reinhardt-urls/src/routers/server_router/introspection.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/introspection.rs
@@ -109,11 +109,14 @@ impl ServerRouter {
 
 		// Collect ViewSet routes
 		for prefix in self.viewsets.keys() {
-			let base_path = if self.prefix.is_empty() {
-				format!("/{}", prefix)
-			} else {
-				format!("{}/{}", self.prefix, prefix)
-			};
+			// Same composition rule as `collect_routes_recursive` below: normalize
+			// the viewset prefix to a single leading `/` and join via
+			// `join_prefix_path` so a trailing `/` on `self.prefix` and a leading
+			// `/` on `prefix` do not stack into a double / triple slash. Refs
+			// Issue #4581.
+			let prefix_normalized = format!("/{}", prefix.trim_matches('/'));
+			let base_path =
+				crate::routers::path_utils::join_prefix_path(&self.prefix, &prefix_normalized);
 
 			// ViewSets generate standard CRUD routes
 			let viewset_routes = vec![
@@ -306,11 +309,22 @@ impl ServerRouter {
 
 		// Collect ViewSet routes with standard names (Django convention: basename, not prefix)
 		for (prefix, viewset) in &self.viewsets {
-			let base_path = if current_prefix.is_empty() {
-				format!("/{}", prefix)
-			} else {
-				format!("{}/{}", current_prefix, prefix)
-			};
+			// Normalize the viewset prefix to a single leading `/` (and no
+			// trailing `/`) before composing it under `current_prefix` with
+			// `join_prefix_path`. Function and view routes already go through
+			// `join_prefix_path` (see above), but the viewset branch used to
+			// concatenate with a raw `format!("{}/{}", current_prefix, prefix)`,
+			// which produced a triple slash whenever `current_prefix` carried
+			// a trailing `/` (e.g. from `UnifiedRouter::mount("/api/", ...)`)
+			// AND `prefix` carried a leading `/` (the common user input from
+			// `.viewset("/snippets-viewset", ...)`). Routing the viewset prefix
+			// through the same slash-collapsing helper mirrors the runtime
+			// `register_viewset` normalization (see `router.rs::register_viewset`,
+			// which uses `prefix.trim_matches('/')`) and brings reversal in
+			// line with function-route composition. Refs Issue #4581.
+			let prefix_normalized = format!("/{}", prefix.trim_matches('/'));
+			let base_path =
+				crate::routers::path_utils::join_prefix_path(&current_prefix, &prefix_normalized);
 
 			let basename = viewset.get_basename();
 			let lookup_field = viewset.get_lookup_field();
@@ -419,5 +433,114 @@ impl ServerRouter {
 		}
 
 		None
+	}
+}
+
+#[cfg(test)]
+mod viewset_path_composition_tests {
+	use super::*;
+	use async_trait::async_trait;
+	use reinhardt_http::{Request, Response, Result};
+	use reinhardt_views::viewsets::{Action, ViewSet};
+	use rstest::rstest;
+
+	/// Minimal `ViewSet` fixture used purely for URL-pattern composition
+	/// assertions — the dispatch body is irrelevant because these tests only
+	/// inspect what `collect_routes_recursive` reports back.
+	#[derive(Debug, Clone)]
+	struct DummyViewSet {
+		basename: String,
+	}
+
+	#[async_trait]
+	impl ViewSet for DummyViewSet {
+		fn get_basename(&self) -> &str {
+			&self.basename
+		}
+
+		async fn dispatch(&self, _request: Request, _action: Action) -> Result<Response> {
+			Ok(Response::ok())
+		}
+	}
+
+	fn find_path<'a>(routes: &'a [(String, String)], name: &str) -> Option<&'a str> {
+		routes
+			.iter()
+			.find_map(|(n, p)| if n == name { Some(p.as_str()) } else { None })
+	}
+
+	/// Regression for Issue #4581: when a router carries a `with_prefix("/api/")`
+	/// (which is what `UnifiedRouter::mount("/api/", child)` plants on the
+	/// child) AND the user passes a viewset prefix that starts with `/`
+	/// (the natural form, e.g. `.viewset("/snippets-viewset", _)`), the
+	/// typed-accessor URL must be a single-slashed `/api/snippets-viewset/`,
+	/// not the previously observed triple-slash `/api///snippets-viewset/`.
+	#[rstest]
+	fn viewset_under_mount_prefix_emits_single_slash() {
+		// Arrange — mirror what `UnifiedRouter::mount("/api/", url_patterns())`
+		// plants: the child ServerRouter ends up with `prefix = "/api/"` and a
+		// viewset registered at `/snippets-viewset`.
+		let router = ServerRouter::new().with_prefix("/api/").viewset(
+			"/snippets-viewset",
+			DummyViewSet {
+				basename: "snippet".to_string(),
+			},
+		);
+
+		// Act — `register_all_routes` calls into this with `parent_prefix=""`,
+		// so we replicate that contract directly.
+		let routes = router.collect_routes_recursive(None, "");
+
+		// Assert — both the list and detail forms must compose to single-slash
+		// paths. The previously broken values were `/api///snippets-viewset/`
+		// and `/api///snippets-viewset/{id}/`.
+		assert_eq!(
+			find_path(&routes, "snippet-list"),
+			Some("/api/snippets-viewset/"),
+			"snippet-list path corrupted (got {:?})",
+			find_path(&routes, "snippet-list"),
+		);
+		assert_eq!(
+			find_path(&routes, "snippet-detail"),
+			Some("/api/snippets-viewset/{id}/"),
+			"snippet-detail path corrupted (got {:?})",
+			find_path(&routes, "snippet-detail"),
+		);
+	}
+
+	/// Sanity check — the historical "no mount" path is unchanged. Both
+	/// fed-prefix-less invocations and explicit-no-leading-slash prefixes
+	/// must still produce single-slashed URLs.
+	#[rstest]
+	#[case::leading_slash_no_mount("", "/snippets-viewset", "/snippets-viewset/")]
+	#[case::no_leading_slash_no_mount("", "snippets-viewset", "/snippets-viewset/")]
+	#[case::mount_with_no_leading_slash_viewset(
+		"/api/",
+		"snippets-viewset",
+		"/api/snippets-viewset/"
+	)]
+	#[case::mount_without_trailing_slash("/api", "/snippets-viewset", "/api/snippets-viewset/")]
+	fn viewset_prefix_normalization_matrix(
+		#[case] router_prefix: &str,
+		#[case] viewset_prefix: &str,
+		#[case] expected_list_path: &str,
+	) {
+		// Arrange
+		let mut builder = ServerRouter::new();
+		if !router_prefix.is_empty() {
+			builder = builder.with_prefix(router_prefix);
+		}
+		let router = builder.viewset(
+			viewset_prefix,
+			DummyViewSet {
+				basename: "snippet".to_string(),
+			},
+		);
+
+		// Act
+		let routes = router.collect_routes_recursive(None, "");
+
+		// Assert
+		assert_eq!(find_path(&routes, "snippet-list"), Some(expected_list_path));
 	}
 }

--- a/examples/examples-tutorial-rest/README.md
+++ b/examples/examples-tutorial-rest/README.md
@@ -274,8 +274,8 @@ let detail_url = urls.server().snippets().snippets_retrieve("42"); // "/api/snip
 // ViewSet endpoints (Tutorial 6) — the typed accessor is namespaced
 // per app, so the viewset's `<basename>_list` and `<basename>_detail`
 // live next to the function-based ones on the same gateway.
-let vs_list   = urls.server().snippets().snippet_list();        // see note below
-let vs_detail = urls.server().snippets().snippet_detail("42");  // see note below
+let vs_list   = urls.server().snippets().snippet_list();        // "/api/snippets-viewset/"
+let vs_detail = urls.server().snippets().snippet_detail("42");  // "/api/snippets-viewset/42/"
 
 // Equivalent calls through the `urls_demo` shim — useful when a caller
 // already has an `id: i64` and does not want to stringify at every

--- a/examples/examples-tutorial-rest/README.md
+++ b/examples/examples-tutorial-rest/README.md
@@ -308,19 +308,6 @@ remain functional but will be removed in `v0.2.0`. Run
 `cargo build --message-format=short 2>&1 | grep deprecated` to discover
 remaining call sites in your own code.
 
-#### Known framework defect — triple-slash in viewset mount
-
-The viewset endpoints registered via `.viewset("/snippets-viewset", ...)`
-in `apps/snippets/urls.rs` currently resolve to `/api///snippets-viewset/`
-through the typed accessor (rather than the expected
-`/api/snippets-viewset/`) when the project root mounts the per-app
-router with a literal prefix (`UnifiedRouter::new().mount("/api/", ...)`).
-The example's integration test (`tests/urls_typed_accessors.rs`) pins the
-currently observable values so a framework-side fix surfaces as a
-deliberate, reviewable diff. The function-based endpoints
-(`urls.server().snippets().snippets_list()` → `/api/snippets/`) are
-unaffected.
-
 ### 6. Validation
 
 ```rust

--- a/examples/examples-tutorial-rest/tests/urls_typed_accessors.rs
+++ b/examples/examples-tutorial-rest/tests/urls_typed_accessors.rs
@@ -140,30 +140,14 @@ mod tests {
 	// generated accessors live next to the function-based ones on the
 	// same `urls.server().snippets()` gateway.
 	//
-	// KNOWN-DEFECT NOTE — TRIPLE-SLASH IN VIEWSET-MOUNT COMPOSITION:
-	//
-	// The example's `routes()` function uses
-	// `UnifiedRouter::new().mount("/api/", url_patterns())`. The
-	// `url_patterns()` body in turn calls
-	// `ServerRouter::new().viewset("/snippets-viewset", ...)`, and the
-	// outer `#[url_patterns(InstalledApp::snippets, mode = server)]`
-	// applies `with_namespace("snippets")` which prepends another `"/"`
-	// to the route's URL pattern. The three slashes compose to
-	// `/api///snippets-viewset/`. The framework's own integration test
-	// for the typed viewset accessor (see
-	// `tests/integration/tests/url_patterns_viewset_typed_integration.rs`)
-	// works around this by replacing the default `ServerRouter` directly
-	// via `UnifiedRouter::new().server(|_| url_patterns())` so no `mount`
-	// indirection is involved.
-	//
-	// The assertions below pin the *currently observable* URL strings
-	// (with the duplicated slashes) so a fix in the framework will
-	// surface as a deliberate, reviewable test diff rather than a silent
-	// behaviour change. The function-based endpoints above are
-	// unaffected because their URL pattern (`/snippets/`) already starts
-	// with a leading slash that the namespace wrapper does not duplicate
-	// — the duplication is specific to the `.viewset()`-internal mount
-	// path. A follow-up framework Issue tracks the fix.
+	// The viewset path composition is symmetric with the function-based
+	// endpoints: `mount("/api/", url_patterns())` plants `/api/` on the
+	// child router, and `.viewset("/snippets-viewset", _)` registers the
+	// viewset under that prefix; the framework's URL-reversal layer joins
+	// them through `path_utils::join_prefix_path`, which collapses the
+	// trailing-slash-on-prefix + leading-slash-on-path boundary into a
+	// single `/`. This wasn't always the case — see Issue #4581 (fixed)
+	// for the historical triple-slash (`/api///snippets-viewset/`) bug.
 	// ------------------------------------------------------------------
 
 	#[rstest]
@@ -175,9 +159,8 @@ mod tests {
 		// Act
 		let url = urls.server().snippets().snippet_list();
 
-		// Assert: currently observed value — see the "TRIPLE-SLASH"
-		// note above for the framework-side root cause and tracking.
-		assert_eq!(url, "/api///snippets-viewset/");
+		// Assert: single slash between `/api/` and the viewset prefix.
+		assert_eq!(url, "/api/snippets-viewset/");
 	}
 
 	#[rstest]
@@ -189,9 +172,8 @@ mod tests {
 		// Act
 		let url = urls.server().snippets().snippet_detail("42");
 
-		// Assert: currently observed value — see the "TRIPLE-SLASH"
-		// note above for the framework-side root cause and tracking.
-		assert_eq!(url, "/api///snippets-viewset/42/");
+		// Assert: single slash between `/api/` and the viewset prefix.
+		assert_eq!(url, "/api/snippets-viewset/42/");
 	}
 
 	// ------------------------------------------------------------------
@@ -209,17 +191,16 @@ mod tests {
 		// Act + Assert: every shim resolves to the same URL the underlying
 		// typed accessor would produce. This pins the helper-to-accessor
 		// mapping so a renamed route surfaces as a compile error rather
-		// than a behaviour drift. The viewset URLs reflect the same
-		// triple-slash known-defect noted above.
+		// than a behaviour drift.
 		assert_eq!(urls_demo::snippets_list(&urls), "/api/snippets/");
 		assert_eq!(urls_demo::snippets_create(&urls), "/api/snippets/");
 		assert_eq!(urls_demo::snippets_retrieve(&urls, 1), "/api/snippets/1/");
 		assert_eq!(urls_demo::snippets_update(&urls, 99), "/api/snippets/99/");
 		assert_eq!(urls_demo::snippets_delete(&urls, 7), "/api/snippets/7/");
-		assert_eq!(urls_demo::viewset_list(&urls), "/api///snippets-viewset/");
+		assert_eq!(urls_demo::viewset_list(&urls), "/api/snippets-viewset/");
 		assert_eq!(
 			urls_demo::viewset_detail(&urls, 42),
-			"/api///snippets-viewset/42/"
+			"/api/snippets-viewset/42/"
 		);
 	}
 
@@ -264,6 +245,6 @@ mod tests {
 		// flat one will be removed in v0.2.0. See Issue #4548 §
 		// "Deprecation removal milestone".
 		assert_eq!(typed, flat);
-		assert_eq!(typed, "/api///snippets-viewset/");
+		assert_eq!(typed, "/api/snippets-viewset/");
 	}
 }


### PR DESCRIPTION
## Summary

- Fix `ServerRouter` URL reversal to compose the mount/router prefix and the user-supplied viewset prefix through `path_utils::join_prefix_path` (with `trim_matches('/')` normalization), so a typed `urls.server().<app>().<basename>_list()` accessor returns `/api/snippets-viewset/` instead of the malformed `/api///snippets-viewset/`.
- The defect was specific to *URL reversal* — runtime routing was unaffected because `router.rs::register_viewset` already normalizes via `trim_matches('/')`. Function and view routes already used `join_prefix_path`; only the two viewset composition sites in `crates/reinhardt-urls/src/routers/server_router/introspection.rs` were doing raw `format!("{}/{}", prefix, prefix)`.
- Adds a framework-level five-case regression matrix (`viewset_path_composition_tests`) and flips the previously pinned "known-defect" assertions in `examples-tutorial-rest` back to the intended single-slash values.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

PR #4580 (Issue #4548 — examples typed URL migration) surfaced the defect while exercising the typed `ResolvedUrls` accessor on `examples-tutorial-rest`. The example test currently pins `/api///snippets-viewset/` as the observed runtime value, and the framework's own `tests/integration/tests/url_patterns_viewset_typed_integration.rs` works around it by replacing the default `ServerRouter` directly (avoiding `mount`) — both pieces of evidence corroborated the bug independently. See Issue #4581 for the full root-cause trace.

## How Was This Tested

### Framework regression coverage

`crates/reinhardt-urls/src/routers/server_router/introspection.rs::viewset_path_composition_tests`:

1. `viewset_under_mount_prefix_emits_single_slash` — the precise mount + viewset shape Issue #4581 reproduced (`with_prefix("/api/")` + `.viewset("/snippets-viewset", _)`), asserting `/api/snippets-viewset/` and `/api/snippets-viewset/{id}/`.
2. `viewset_prefix_normalization_matrix` — 4-case parametrized table covering:
   - no router prefix + leading-slash viewset prefix → `/snippets-viewset/`
   - no router prefix + no-leading-slash viewset prefix → `/snippets-viewset/`
   - `/api/` router prefix + no-leading-slash viewset prefix → `/api/snippets-viewset/`
   - `/api` (no trailing slash) router prefix + leading-slash viewset prefix → `/api/snippets-viewset/`

### Example regression coverage

`examples/examples-tutorial-rest/tests/urls_typed_accessors.rs` — flipped from triple-slash to single-slash:

- `typed_accessor_resolves_viewset_list` → `/api/snippets-viewset/`
- `typed_accessor_resolves_viewset_detail_with_id` → `/api/snippets-viewset/42/`
- `urls_demo_helpers_match_typed_accessors` — shim parity
- `deprecated_flat_viewset_accessor_matches_typed_accessor` — flat-surface parity (deprecated path also corrected)

### Local verification

- [x] `cargo nextest run -p reinhardt-urls --lib viewset_path_composition_tests viewset_with_actions_tests path_utils` — 33/33 pass
- [x] `cargo nextest run --test urls_typed_accessors` (in `examples/examples-tutorial-rest`, with `.cargo/config.toml` enabled) — 9/9 pass
- [x] `cargo make fmt-check` — clean after `cargo fmt -p reinhardt-urls`
- [x] `cargo clippy -p reinhardt-urls --all-features --no-deps -- -D warnings` — no warnings on touched code (pre-existing `reinhardt-db` warning unrelated)

## Checklist

- [x] My code follows the project's style guidelines (tab indent, English-only comments)
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas (root-cause and fix rationale captured inline at both composition sites)
- [x] I have made corresponding changes to the documentation (removed the "Known framework defect" section from `examples/examples-tutorial-rest/README.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally

## Labels to Apply

- `bug` — confirmed bug fix
- `routing` — affects `reinhardt-urls` URL reversal layer

## Related Issues

Fixes #4581
Refs #4548, #4580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL path generation for ViewSet routes that previously produced multiple slashes in certain prefix configurations.

* **Tests**
  * Added regression tests to validate correct path composition and normalization across various ViewSet prefix combinations.

* **Documentation**
  * Updated documentation and examples to reflect corrected URL formatting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->