### PR TITLE
fix(examples-tutorial-basis): unbreak wasm-test by forwarding client-router and replacing success_url

### DIFF
--- a/examples/examples-tutorial-basis/Makefile.toml
+++ b/examples/examples-tutorial-basis/Makefile.toml
@@ -147,10 +147,20 @@ args = ["clean"]
 # (native-only, uses tokio / reinhardt::commands / async fn main) is skipped
 # via its `required-features`. Without this flag the wasm test build pulls
 # the bin in and fails to compile.
+#
+# `--features client-router` is also forwarded so that the
+# `#[cfg(feature = "client-router")]`-gated `impl ClientUrlResolver for
+# ResolvedUrls` block emitted by the `#[routes]` macro (see
+# `crates/reinhardt-core/macros/src/routes_registration.rs` around the
+# `ResolvedUrls` definition) stays in scope. Without it, `links.rs` cannot
+# call `resolve_client_url(name, params)` because the trait impl is gated
+# out — `--no-default-features` alone disables the example's default
+# `client-router` feature flag, which is what the macro probes at expansion
+# time in the consumer crate.
 [tasks.wasm-test]
 description = "Run WASM tests in headless Chrome"
 command = "wasm-pack"
-args = ["test", "--headless", "--chrome", "--", "--no-default-features"]
+args = ["test", "--headless", "--chrome", "--", "--no-default-features", "--features", "client-router"]
 
 [tasks.wasm-compile-dev]
 description = "Compile WASM binary (debug mode)"

--- a/examples/examples-tutorial-basis/src/client/components/polls.rs
+++ b/examples/examples-tutorial-basis/src/client/components/polls.rs
@@ -146,20 +146,34 @@ pub fn polls_detail(question_id: i64) -> Page {
 	// - strip_arguments: explicitly routes the CSRF token to the trailing
 	//   server_fn argument (reinhardt-web#3971), replacing the implicit
 	//   auto-injection that broke when server_fn signatures evolved.
-	// - state: loading/error signals for form submission feedback
+	// - state: loading/error/success signals for form submission feedback.
+	//   `success` is required so that a sibling `use_effect` below can
+	//   trigger a one-shot navigation when the form's success signal flips
+	//   to `true` (reinhardt-web#4519).
 	// - watch blocks for reactive UI updates (submit button + error display)
-	// - success_url: WASM-only declarative redirect that fires once per
-	//   successful submit (reinhardt-web#4519). The closure receives
-	//   `(&form, &value)` (the generated form struct and the submitted
-	//   payload) and is invoked from the form macro's `on_success`
-	//   codepath — NOT from a `watch` block — so it cannot fire on
-	//   initial mount when `loading == false && error == None`, which
-	//   was the root cause of the previous redirect-on-mount bug.
+	//
+	// The success-driven redirect is implemented with `use_effect` rather
+	// than the form macro's `success_url:` property because `success_url:`
+	// (a) has a parser bug in `reinhardt-manouche` that emits
+	// `error: expected `:`` at every call site
+	// (`crates/reinhardt-manouche/src/parser/form.rs:117-121` consumes a
+	// redundant colon), and (b) embeds the user closure inside the
+	// generated form struct's `submit()` method, which cannot capture
+	// enclosing-scope locals like `qid` (issues #4414 / #4420 fixed this
+	// for `watch:` and `initial:` only, by binding them in the outer
+	// scope where the form is constructed). `use_effect` runs in that
+	// same outer scope, so `qid` is captured cleanly and the redirect
+	// fires exactly once per `success.set(true)` transition.
+	//
+	// Ideal implementation (once the upstream parser bug is fixed AND
+	// `success_url:` is reworked to bind in the outer scope like `watch:`):
+	//     state: { loading, error },
+	//     success_url: |_form, _value| links::poll_results(qid),
 	let voting_form = form! {
 		name: VotingForm,
 		server_fn: submit_vote,
 		method: Post,
-		state: { loading, error },
+		state: { loading, error, success },
 
 		fields: {
 			question_id: HiddenField {
@@ -180,8 +194,6 @@ pub fn polls_detail(question_id: i64) -> Page {
 			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token()
 				.unwrap_or_default(),
 		},
-
-		success_url: |_form, _value| links::poll_results(qid),
 
 		watch: {
 			submit_button: |form| {
@@ -233,6 +245,33 @@ pub fn polls_detail(question_id: i64) -> Page {
 				voting_form_for_effect
 					.choice_id_choices()
 					.set(choice_options);
+			}
+		});
+	}
+
+	// One-shot redirect to the results page on a successful vote (reinhardt-web#4519).
+	//
+	// The form macro flips `__success` from `false` to `true` exactly once in
+	// the `on_success` codepath (`crates/reinhardt-pages/macros/src/form/codegen.rs`
+	// `generate_on_success_callback` — `self.__success.set(true)` after the
+	// `Ok(value)` branch). This `use_effect` reads `voting_form.success().get()`
+	// so it re-runs on every transition of that signal; the `if did_succeed`
+	// guard ensures the navigation fires only on the `true` edge and not on
+	// the initial `false` value at mount time. That avoids the redirect-on-mount
+	// bug from PR #4517 (the previous `watch{}` predicate
+	// `if !is_loading && err.is_none()` was true on first render).
+	{
+		let voting_form_for_redirect = voting_form.clone();
+		let dest = links::poll_results(qid);
+		use_effect(move || {
+			let did_succeed = voting_form_for_redirect.success().get();
+			if did_succeed {
+				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+				{
+					if let Some(window) = web_sys::window() {
+						let _ = window.location().set_href(&dest);
+					}
+				}
 			}
 		});
 	}

--- a/examples/examples-tutorial-basis/src/client/components/polls.rs
+++ b/examples/examples-tutorial-basis/src/client/components/polls.rs
@@ -260,17 +260,20 @@ pub fn polls_detail(question_id: i64) -> Page {
 	// the initial `false` value at mount time. That avoids the redirect-on-mount
 	// bug from PR #4517 (the previous `watch{}` predicate
 	// `if !is_loading && err.is_none()` was true on first render).
+	//
+	// The entire block is gated to `wasm32-unknown-unknown`: on native/SSR
+	// builds there is no browser `History` to drive, so cloning
+	// `voting_form`, allocating `dest`, and installing a re-running
+	// `use_effect` would be pure overhead with no observable effect.
+	#[cfg(all(target_family = "wasm", target_os = "unknown"))]
 	{
 		let voting_form_for_redirect = voting_form.clone();
 		let dest = links::poll_results(qid);
 		use_effect(move || {
 			let did_succeed = voting_form_for_redirect.success().get();
 			if did_succeed {
-				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
-				{
-					if let Some(window) = web_sys::window() {
-						let _ = window.location().set_href(&dest);
-					}
+				if let Some(window) = web_sys::window() {
+					let _ = window.location().set_href(&dest);
 				}
 			}
 		});


### PR DESCRIPTION
## Summary

Unblocks the `examples-tutorial-basis` CI test job (`Examples Tests (Standalone)`), which has been failing on every Release PR with two compile errors during the WASM test build:

```
error: expected `:`
  --> .../polls.rs:184:16     // success_url: |_form, _value| links::poll_results(qid),
error[E0599]: no method named `resolve_client_url` found for struct `ResolvedUrls`
  --> .../links.rs:23:9
```

Two narrowly-scoped commits, both confined to `examples/examples-tutorial-basis`:

1. **`Makefile.toml` — forward `--features client-router` to `wasm-pack test`.** `cargo make wasm-test` already passes `--no-default-features` so the `with-reinhardt`-gated `manage` bin gets skipped, but that also disables the example's default `client-router` feature flag — which is exactly what the `#[routes]` macro's `impl ClientUrlResolver for ResolvedUrls` block gates on at expansion time in the consumer crate (see `crates/reinhardt-core/macros/src/routes_registration.rs` around the `ResolvedUrls` definition). Without the impl in scope, `src/client/links.rs::resolve(...)` cannot call `resolve_client_url(name, params)`.
2. **`polls.rs` — replace broken `success_url:` closure with a `state: { ..., success }` + sibling `use_effect`.** Two upstream defects make `success_url: |_form, _value| <expr>` unusable today: (a) the `reinhardt-manouche` form parser arm for `success_url` consumes a redundant `:` (`crates/reinhardt-manouche/src/parser/form.rs:117-121`), and (b) the `on_success` codegen embeds the user closure inside the generated form struct's `submit()` method, which is a `fn` item that cannot capture enclosing-scope locals like `qid`. The replacement reads `voting_form.success().get()` from `use_effect`, which IS bound in the outer scope where `qid` lives, and the `if did_succeed` guard preserves PR #4519's one-shot semantics (no redirect on mount).

The reported "Failure 3" (`tutorial_user_is_registered_in_superuser_creator_inventory` panic) is **not actually reproducible**: in CI run [26040399559](https://github.com/kent8192/reinhardt-web/actions/runs/26040399559) the `Test` step never got past the two compile errors above, so the test binary was never linked or executed. The most recent successful `Examples Tests (Standalone)` runs on branches that don't carry the `success_url` regression all show this test passing (see e.g. run [26075253066](https://github.com/kent8192/reinhardt-web/actions/runs/26075253066)). The macro auto-registration introduced by #4545 / verified by #4563 continues to work.

Fixes #4599

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (inline workaround comments per `instructions/ANTI_PATTERNS.md` workaround template)
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] CI/CD update

## Motivation and Context

`examples-tutorial-basis` is the canonical onboarding example for the Pages stack — it must build cleanly on both native and `wasm32-unknown-unknown` against the current framework. PR #4519 / commit 25695a56cf introduced `success_url:` to fix a redirect-on-mount bug from PR #4517, but neither the `reinhardt-manouche` parser nor the `reinhardt-pages` codegen actually support that property end-to-end. Combined with the `--no-default-features` test build dropping the `client-router` impl in the macro emission, the example crate has been red on every Release PR since.

This commit fixes the example without depending on any framework crate landing first; the two underlying framework defects need their own PRs.

## Framework Bugs Discovered (for separate follow-up PRs)

Per the instruction in #4599 ("If during investigation any single sub-failure turns out to be a framework bug, STOP and report"), the following are NOT addressed here:

- **`reinhardt-manouche` parser bug — `success_url:` arm consumes a redundant colon.** `crates/reinhardt-manouche/src/parser/form.rs:117-121` does `let _colon: Token![:] = input.parse()?;` *after* the outer loop at line 38 already consumed the `:` between the key and the value. Every other arm in the same loop (`name`, `action`, `server_fn`, `state`, `on_submit`, `on_success`, …) skips the redundant parse. The 1-line fix is to remove that `let _colon` line. No test exercises this arm today — the property is never functional. Will file a dedicated framework issue + PR.

- **`reinhardt-pages` `on_success`/`success_url` codegen cannot capture enclosing locals.** `generate_on_success_callback` in `crates/reinhardt-pages/macros/src/form/codegen.rs` places the user closure inside the struct's `submit()` method body. `watch:` and `initial:` work around this by binding the user closure / expression in the outer `let mut __reinhardt_form = #struct_name::new(); ... #initial_outer_setup; #watch_outer_setup;` block where the form is constructed (issues #4414 / #4420). `on_success:` / `success_url:` need the same treatment.

## How Was This Tested

- [x] `cargo check --all-features` in `examples/examples-tutorial-basis` (native) — clean, 14m 31s on first cold build, 0 warnings, 0 errors
- [x] `cargo check --target wasm32-unknown-unknown --no-default-features --features client-router` in `examples/examples-tutorial-basis` — clean, only the 3 pre-existing `__FORM_CSRF_AUTO_INJECT_DEPRECATED` warnings (tracked in #3971, not in scope)
- [ ] Full `cargo nextest run --all-features --no-fail-fast` — relying on CI; locally `cargo nextest run --all-features --no-fail-fast --test createsuperuser` was attempted but is gated by the same fix, so it now compiles for the first time. CI's `Test` step (which runs the full nextest suite) will validate the `tutorial_user_is_registered_in_superuser_creator_inventory` test that #4599 hypothesised would fail — based on the most recent green runs on adjacent branches, it is expected to pass.
- [ ] `cargo make fmt-check` — pre-existing rustfmt diffs at `polls.rs:95`, `:444`, `:596` exist on `main` independently of this PR (verified by `git stash`). The CI `Check Format` step uses the project-local `cargo make fmt-check` (`reinhardt-admin-cli fmt-all --check`) which passed on the cited failing run, so these are formatter artefacts of the `page!` macro, not real fmt issues.

## Checklist

- [x] My code follows the project's style guidelines
- [x] PR title follows Conventional Commits format
- [x] All comments are in English
- [x] Workaround comments include the ideal implementation per the `instructions/ANTI_PATTERNS.md` template
- [x] No new `todo!()` / `// TODO:` introduced
- [x] Linked Issue (Fixes #4599)
- [ ] Tests added/updated where applicable (existing test coverage in `tests/createsuperuser.rs` is now reachable for the first time since #4519 landed)

## Labels to Apply

- bug
- examples
- documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voting form success handling to perform a reliable client-side redirect to poll results after a successful vote.

* **Chores**
  * Updated WASM test task configuration to forward an additional feature flag so tests build and run with required routing support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->