### PR TITLE
feat(reinhardt-commands): implement Django-style migrate-with-target rollback

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -216,23 +216,34 @@ impl BaseCommand for MigrateCommand {
 				})?;
 
 				let recorder = DatabaseMigrationRecorder::new(connection.inner().clone());
-				// Ensure the recorder's bookkeeping table exists before querying it.
-				// On a fresh database the table has not been created yet; without this
-				// `get_applied_migrations()` fails with a "relation does not exist"
-				// error instead of returning an empty applied set — which would break
-				// the `migrate <app> zero` no-op contract on an empty database.
-				recorder.ensure_schema_table().await.map_err(|e| {
-					crate::CommandError::ExecutionError(format!(
-						"Failed to ensure migration recorder table: {}",
-						e
-					))
-				})?;
-				let applied = recorder.get_applied_migrations().await.map_err(|e| {
-					crate::CommandError::ExecutionError(format!(
-						"Failed to query applied migrations: {}",
-						e
-					))
-				})?;
+				// For non-plan execution, ensure the bookkeeping table exists so
+				// that the subsequent rollback can persist its unapply records.
+				// On a fresh database the `reinhardt_migrations` table is created
+				// lazily — `apply_migrations()` does the same precaution before
+				// recording (executor.rs:313/397/640).
+				//
+				// For `--plan` we DO NOT create the table: the contract is that
+				// dry-run modes leave the database untouched. If the table is
+				// absent on a fresh database, the applied set is by definition
+				// empty, so we swallow query failures in that mode and treat them
+				// as "no migrations applied". A real (non-table-missing) error
+				// would still surface when the user re-runs without `--plan`.
+				let applied = if is_plan {
+					recorder.get_applied_migrations().await.unwrap_or_default()
+				} else {
+					recorder.ensure_schema_table().await.map_err(|e| {
+						crate::CommandError::ExecutionError(format!(
+							"Failed to ensure migration recorder table: {}",
+							e
+						))
+					})?;
+					recorder.get_applied_migrations().await.map_err(|e| {
+						crate::CommandError::ExecutionError(format!(
+							"Failed to query applied migrations: {}",
+							e
+						))
+					})?
+				};
 				let applied_for_app: Vec<_> =
 					applied.iter().filter(|r| r.app == *app).cloned().collect();
 
@@ -624,22 +635,30 @@ impl BaseCommand for MigrationRollbackCommand {
 
 			// 4. Query the recorder for applied migrations (ordered ASC by applied timestamp).
 			let recorder = DatabaseMigrationRecorder::new(connection.inner().clone());
-			// Ensure the recorder's bookkeeping table exists. On a fresh database the
-			// table has not been created yet, in which case `get_applied_migrations()`
-			// would fail with a "relation does not exist" error instead of the
-			// expected "no migrations to roll back" message.
-			recorder.ensure_schema_table().await.map_err(|e| {
-				crate::CommandError::ExecutionError(format!(
-					"Failed to ensure migration recorder table: {}",
-					e
-				))
-			})?;
-			let applied = recorder.get_applied_migrations().await.map_err(|e| {
-				crate::CommandError::ExecutionError(format!(
-					"Failed to query applied migrations: {}",
-					e
-				))
-			})?;
+			// For non-dry-run execution, ensure the bookkeeping table exists so the
+			// subsequent rollback can persist its unapply records. For `--dry-run`
+			// we must NOT create the table — the contract is that the database is
+			// left untouched. A missing table on a fresh database means no
+			// migrations are applied, so swallowing the query failure is
+			// equivalent to returning an empty applied set; real connectivity or
+			// permission errors would still surface when the user re-runs without
+			// `--dry-run`.
+			let applied = if dry_run {
+				recorder.get_applied_migrations().await.unwrap_or_default()
+			} else {
+				recorder.ensure_schema_table().await.map_err(|e| {
+					crate::CommandError::ExecutionError(format!(
+						"Failed to ensure migration recorder table: {}",
+						e
+					))
+				})?;
+				recorder.get_applied_migrations().await.map_err(|e| {
+					crate::CommandError::ExecutionError(format!(
+						"Failed to query applied migrations: {}",
+						e
+					))
+				})?
+			};
 
 			if applied.is_empty() {
 				return Err(crate::CommandError::ExecutionError(

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -216,6 +216,17 @@ impl BaseCommand for MigrateCommand {
 				})?;
 
 				let recorder = DatabaseMigrationRecorder::new(connection.inner().clone());
+				// Ensure the recorder's bookkeeping table exists before querying it.
+				// On a fresh database the table has not been created yet; without this
+				// `get_applied_migrations()` fails with a "relation does not exist"
+				// error instead of returning an empty applied set — which would break
+				// the `migrate <app> zero` no-op contract on an empty database.
+				recorder.ensure_schema_table().await.map_err(|e| {
+					crate::CommandError::ExecutionError(format!(
+						"Failed to ensure migration recorder table: {}",
+						e
+					))
+				})?;
 				let applied = recorder.get_applied_migrations().await.map_err(|e| {
 					crate::CommandError::ExecutionError(format!(
 						"Failed to query applied migrations: {}",
@@ -613,6 +624,16 @@ impl BaseCommand for MigrationRollbackCommand {
 
 			// 4. Query the recorder for applied migrations (ordered ASC by applied timestamp).
 			let recorder = DatabaseMigrationRecorder::new(connection.inner().clone());
+			// Ensure the recorder's bookkeeping table exists. On a fresh database the
+			// table has not been created yet, in which case `get_applied_migrations()`
+			// would fail with a "relation does not exist" error instead of the
+			// expected "no migrations to roll back" message.
+			recorder.ensure_schema_table().await.map_err(|e| {
+				crate::CommandError::ExecutionError(format!(
+					"Failed to ensure migration recorder table: {}",
+					e
+				))
+			})?;
 			let applied = recorder.get_applied_migrations().await.map_err(|e| {
 				crate::CommandError::ExecutionError(format!(
 					"Failed to query applied migrations: {}",

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -49,6 +49,16 @@ impl BaseCommand for MigrateCommand {
 				"fake-initial",
 				"Skip initial migration if tables exist",
 			),
+			CommandOption::flag(
+				None,
+				"plan",
+				"Preview the migration plan without applying or rolling back",
+			),
+			CommandOption::option(
+				None,
+				"migrations-dir",
+				"Root directory containing migration files (default: ./migrations)",
+			),
 			CommandOption::option(Some('d'), "database", "Database to migrate")
 				.with_default("default"),
 		]
@@ -58,9 +68,10 @@ impl BaseCommand for MigrateCommand {
 		ctx.info("Running migrations...");
 
 		let app_label = ctx.arg(0).map(|s| s.to_string());
-		let _migration_name = ctx.arg(1).map(|s| s.to_string());
+		let target = ctx.arg(1).map(|s| s.to_string());
 		let is_fake = ctx.has_option("fake");
 		let _is_fake_initial = ctx.has_option("fake-initial");
+		let is_plan = ctx.has_option("plan");
 		let _database = ctx
 			.option("database")
 			.map(|s| s.to_string())
@@ -177,6 +188,191 @@ impl BaseCommand for MigrateCommand {
 				))
 			})?;
 
+			// 4.5. Direction detection (Django-style migrate-with-target semantics).
+			//
+			// Django's `manage.py migrate <app> <target>` syntax expresses both apply
+			// and unapply in a single command. The direction is resolved by comparing
+			// `<target>` against the currently applied state:
+			//
+			//   * `<target> == "zero"`  -> unapply ALL migrations for `<app>`.
+			//   * `<target>` is currently applied and migrations are applied AFTER it
+			//                            -> roll back those later migrations.
+			//   * `<target>` equals the current head -> no-op.
+			//   * `<target>` is not yet applied      -> forward direction (not yet
+			//                            supported in this PR; tracked separately).
+			//
+			// `--plan` previews the action without touching the database.
+			if let Some(target_name) = target.as_deref() {
+				use reinhardt_db::migrations::{
+					DatabaseMigrationRecorder, FilesystemSource, MigrationSource,
+				};
+				use std::path::PathBuf;
+
+				let app = app_label.as_ref().ok_or_else(|| {
+					crate::CommandError::InvalidArguments(
+						"<migration_name> requires <app_label>; usage: `migrate <app> <target>` or `migrate <app> zero`"
+							.to_string(),
+					)
+				})?;
+
+				let recorder = DatabaseMigrationRecorder::new(connection.inner().clone());
+				let applied = recorder.get_applied_migrations().await.map_err(|e| {
+					crate::CommandError::ExecutionError(format!(
+						"Failed to query applied migrations: {}",
+						e
+					))
+				})?;
+				let applied_for_app: Vec<_> =
+					applied.iter().filter(|r| r.app == *app).cloned().collect();
+
+				let migrations_dir = ctx
+					.option("migrations-dir")
+					.map(PathBuf::from)
+					.unwrap_or_else(|| PathBuf::from("migrations"));
+				let source = FilesystemSource::new(migrations_dir);
+
+				// Helper closure to load full Migration objects (with reverse SQL)
+				// from records, preserving the input slice order.
+				async fn load_migrations_from_records(
+					source: &reinhardt_db::migrations::FilesystemSource,
+					records: &[reinhardt_db::migrations::MigrationRecord],
+				) -> Result<Vec<reinhardt_db::migrations::Migration>, crate::CommandError> {
+					let mut out = Vec::with_capacity(records.len());
+					for record in records {
+						let migration = source
+							.get_migration(&record.app, &record.name)
+							.await
+							.map_err(|e| {
+								crate::CommandError::ExecutionError(format!(
+									"Failed to load migration {}:{}: {}",
+									record.app, record.name, e
+								))
+							})?;
+						out.push(migration);
+					}
+					Ok(out)
+				}
+
+				// Branch (a): `migrate <app> zero` -> unapply ALL applied migrations for app.
+				if target_name == "zero" {
+					if applied_for_app.is_empty() {
+						ctx.info(&format!(
+							"No applied migrations for app '{}'; nothing to do.",
+							app
+						));
+						return Ok(());
+					}
+
+					let to_rollback =
+						load_migrations_from_records(&source, &applied_for_app).await?;
+
+					if is_plan {
+						ctx.info(&format!(
+							"[plan] Would unapply {} migration(s) for app '{}':",
+							to_rollback.len(),
+							app
+						));
+						for migration in to_rollback.iter().rev() {
+							ctx.info(&format!(
+								"  - {}:{} (unapply)",
+								migration.app_label, migration.name
+							));
+						}
+						return Ok(());
+					}
+
+					let mut executor = DatabaseMigrationExecutor::new(connection);
+					let result = executor
+						.rollback_migrations(&to_rollback)
+						.await
+						.map_err(|e| {
+							crate::CommandError::ExecutionError(format!(
+								"Failed to roll back migrations: {}",
+								e
+							))
+						})?;
+					for id in &result.applied {
+						ctx.success(&format!("  ✓ Rolled back: {}", id));
+					}
+					ctx.success(&format!(
+						"Rolled back {} migration(s) for app '{}'",
+						result.applied.len(),
+						app
+					));
+					return Ok(());
+				}
+
+				// Branch (b): target is currently applied -> roll back everything after it.
+				if let Some(pos) = applied_for_app.iter().position(|r| r.name == target_name) {
+					let to_rollback_records: Vec<_> = applied_for_app[pos + 1..].to_vec();
+					if to_rollback_records.is_empty() {
+						ctx.info(&format!(
+							"Already at {}:{}; nothing to do.",
+							app, target_name
+						));
+						return Ok(());
+					}
+
+					let to_rollback =
+						load_migrations_from_records(&source, &to_rollback_records).await?;
+
+					if is_plan {
+						ctx.info(&format!(
+							"[plan] Would unapply {} migration(s) for app '{}' to reach target '{}':",
+							to_rollback.len(),
+							app,
+							target_name
+						));
+						for migration in to_rollback.iter().rev() {
+							ctx.info(&format!(
+								"  - {}:{} (unapply)",
+								migration.app_label, migration.name
+							));
+						}
+						return Ok(());
+					}
+
+					let mut executor = DatabaseMigrationExecutor::new(connection);
+					let result = executor
+						.rollback_migrations(&to_rollback)
+						.await
+						.map_err(|e| {
+							crate::CommandError::ExecutionError(format!(
+								"Failed to roll back migrations: {}",
+								e
+							))
+						})?;
+					for id in &result.applied {
+						ctx.success(&format!("  ✓ Rolled back: {}", id));
+					}
+					ctx.success(&format!(
+						"Rolled back to {}:{} ({} migration(s) unapplied)",
+						app,
+						target_name,
+						result.applied.len()
+					));
+					return Ok(());
+				}
+
+				// Branch (c): target is NOT currently applied. Forward-with-target is
+				// out of scope for issue #4558 (rollback only). Validate existence and
+				// surface a clear error pointing operators at the supported forms.
+				let target_exists = all_migrations
+					.iter()
+					.any(|m| m.app_label == *app && m.name == target_name);
+				if !target_exists {
+					return Err(crate::CommandError::ExecutionError(format!(
+						"Migration {}:{} does not exist on disk",
+						app, target_name
+					)));
+				}
+				return Err(crate::CommandError::ExecutionError(format!(
+					"Forward migration to a specific target ({}:{}) is not yet supported. \
+					 Use `migrate {}` to apply all unapplied migrations.",
+					app, target_name, app
+				)));
+			}
+
 			// 5. Filter and check migrations
 			let migrations_to_apply: Vec<_> = if let Some(ref app) = app_label {
 				all_migrations
@@ -259,6 +455,252 @@ impl BaseCommand for MigrateCommand {
 			ctx.warning("Migrations feature not enabled");
 			ctx.info("To use migrate, enable the 'migrations' feature");
 			Ok(())
+		}
+	}
+}
+
+/// Database migration rollback command (deprecated).
+///
+/// **Deprecated:** Prefer the Django-style `migrate <app_label> <target_migration>` form
+/// exposed by [`MigrateCommand`]. To unapply all migrations for an app, target the special
+/// migration name `"zero"`. Specifying a `<target_migration>` earlier than the currently
+/// applied state causes `MigrateCommand` to roll back to that target automatically; that
+/// is the canonical operator workflow.
+///
+/// This command is retained to honor the original CLI design proposed in
+/// <https://github.com/kent8192/reinhardt-web/issues/4558> and may be removed in a future
+/// release. Removal is tracked under the `rc-migration` label.
+///
+/// Behavior: rolls back the most recent N applied migrations on the configured database.
+/// The resolution order for the database URL is:
+///
+/// 1. `--database <url>` option (highest priority)
+/// 2. `DATABASE_URL` environment variable
+/// 3. `database.*` keys in `settings/base.toml` and `settings/<profile>.toml`
+///    under `--project-root` (defaults to current working directory)
+///
+/// The `--dry-run` flag previews which migrations would be rolled back without
+/// touching the database.
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `MigrateCommand` with a target migration name (Django-style). For full rollback, target `\"zero\"`. Tracked for removal under the `rc-migration` label."
+)]
+pub struct MigrationRollbackCommand;
+
+// The impl block references the deprecated struct via `Self`; that does not
+// itself constitute a user-facing call, so suppress the lint locally.
+#[allow(deprecated)]
+#[async_trait]
+impl BaseCommand for MigrationRollbackCommand {
+	fn name(&self) -> &str {
+		"migrate-rollback"
+	}
+
+	fn description(&self) -> &str {
+		"Roll back the most recent N applied database migrations"
+	}
+
+	fn options(&self) -> Vec<CommandOption> {
+		vec![
+			CommandOption::option(
+				Some('n'),
+				"steps",
+				"Number of migrations to roll back (default: 1)",
+			)
+			.with_default("1"),
+			CommandOption::flag(
+				None,
+				"dry-run",
+				"Preview which migrations would be rolled back without modifying the database",
+			),
+			CommandOption::option(
+				None,
+				"project-root",
+				"Project root directory (used to locate settings/*.toml). Defaults to the current working directory.",
+			),
+			CommandOption::option(Some('d'), "database", "Database URL override"),
+		]
+	}
+
+	async fn execute(&self, ctx: &CommandContext) -> CommandResult<()> {
+		#[cfg(feature = "migrations")]
+		{
+			use reinhardt_db::migrations::{
+				DatabaseMigrationRecorder, FilesystemSource, MigrationSource,
+			};
+			use std::path::PathBuf;
+
+			// 1. Parse arguments
+			let steps: usize = ctx
+				.option("steps")
+				.map(|s| s.to_string())
+				.unwrap_or_else(|| "1".to_string())
+				.parse()
+				.map_err(|e| {
+					crate::CommandError::InvalidArguments(format!("Invalid --steps value: {}", e))
+				})?;
+			if steps == 0 {
+				return Err(crate::CommandError::InvalidArguments(
+					"--steps must be at least 1".to_string(),
+				));
+			}
+			let dry_run = ctx.has_option("dry-run");
+			let project_root = ctx.option("project-root").map(PathBuf::from);
+
+			// 2. Resolve database URL via the standard precedence chain.
+			let database_url = ctx
+				.option("database")
+				.map(|s| s.to_string())
+				.or_else(|| {
+					DatabaseConnection::get_database_url_from_env_or_settings(
+						project_root.clone(),
+					)
+					.ok()
+				})
+				.ok_or_else(|| {
+					crate::CommandError::ExecutionError(
+						"No database URL provided. Use --database, set DATABASE_URL, or configure database in settings/*.toml".to_string()
+					)
+				})?;
+
+			// 3. Connect to the database. `backends::DatabaseConnection` exposes
+			//    scheme-specific constructors; dispatch by URL prefix to mirror
+			//    the pattern used by `MigrateCommand` above.
+			let connection: DatabaseConnection = if database_url.starts_with("postgres://")
+				|| database_url.starts_with("postgresql://")
+			{
+				#[cfg(feature = "postgres")]
+				{
+					DatabaseConnection::connect_postgres(&database_url).await
+				}
+				#[cfg(not(feature = "postgres"))]
+				{
+					return Err(crate::CommandError::ExecutionError(
+						"PostgreSQL support not enabled. Enable 'postgres' feature.".to_string(),
+					));
+				}
+			} else if database_url.starts_with("mysql://") {
+				#[cfg(feature = "mysql")]
+				{
+					DatabaseConnection::connect_mysql(&database_url).await
+				}
+				#[cfg(not(feature = "mysql"))]
+				{
+					return Err(crate::CommandError::ExecutionError(
+						"MySQL support not enabled. Enable 'mysql' feature.".to_string(),
+					));
+				}
+			} else if database_url.starts_with("sqlite:") {
+				#[cfg(feature = "sqlite")]
+				{
+					DatabaseConnection::connect_sqlite(&database_url).await
+				}
+				#[cfg(not(feature = "sqlite"))]
+				{
+					return Err(crate::CommandError::ExecutionError(
+						"SQLite support not enabled. Enable 'sqlite' feature.".to_string(),
+					));
+				}
+			} else {
+				return Err(crate::CommandError::ExecutionError(format!(
+					"Unsupported database URL scheme: {}",
+					database_url
+				)));
+			}
+			.map_err(|e| {
+				crate::CommandError::ExecutionError(format!("Failed to connect to database: {}", e))
+			})?;
+
+			// 4. Query the recorder for applied migrations (ordered ASC by applied timestamp).
+			let recorder = DatabaseMigrationRecorder::new(connection.inner().clone());
+			let applied = recorder.get_applied_migrations().await.map_err(|e| {
+				crate::CommandError::ExecutionError(format!(
+					"Failed to query applied migrations: {}",
+					e
+				))
+			})?;
+
+			if applied.is_empty() {
+				return Err(crate::CommandError::ExecutionError(
+					"no migrations to roll back".to_string(),
+				));
+			}
+
+			if steps > applied.len() {
+				return Err(crate::CommandError::ExecutionError(format!(
+					"only {} migration(s) applied, cannot roll back {}",
+					applied.len(),
+					steps
+				)));
+			}
+
+			// 5. Select the last `steps` records (newest first) and reconstruct
+			//    full Migration objects (with reverse SQL) via the filesystem source.
+			//
+			//    We collect them in ASC order; the executor reverses internally,
+			//    so the newest one is rolled back first.
+			let migrations_dir = project_root
+				.clone()
+				.unwrap_or_else(|| PathBuf::from("."))
+				.join("migrations");
+			let source = FilesystemSource::new(migrations_dir);
+
+			let to_rollback_records: Vec<_> = applied.iter().rev().take(steps).collect();
+			let mut to_rollback = Vec::with_capacity(to_rollback_records.len());
+			for record in to_rollback_records.iter().rev() {
+				let migration = source
+					.get_migration(&record.app, &record.name)
+					.await
+					.map_err(|e| {
+						crate::CommandError::ExecutionError(format!(
+							"Failed to load migration {}:{}: {}",
+							record.app, record.name, e
+						))
+					})?;
+				to_rollback.push(migration);
+			}
+
+			// 6. Dry-run preview — list and exit without mutating the database.
+			if dry_run {
+				ctx.info(&format!(
+					"[dry-run] Would roll back {} migration(s):",
+					to_rollback.len()
+				));
+				for migration in to_rollback.iter().rev() {
+					ctx.info(&format!("  - {}:{}", migration.app_label, migration.name));
+				}
+				return Ok(());
+			}
+
+			// 7. Execute the rollback.
+			let mut executor = DatabaseMigrationExecutor::new(connection);
+			let result = executor
+				.rollback_migrations(&to_rollback)
+				.await
+				.map_err(|e| {
+					crate::CommandError::ExecutionError(format!(
+						"Failed to roll back migrations: {}",
+						e
+					))
+				})?;
+
+			for id in &result.applied {
+				ctx.success(&format!("  ✓ Rolled back: {}", id));
+			}
+			ctx.success(&format!(
+				"Rolled back {} migration(s) successfully",
+				result.applied.len()
+			));
+			Ok(())
+		}
+
+		#[cfg(not(feature = "migrations"))]
+		{
+			ctx.warning("Migrations feature not enabled");
+			ctx.info("To use migrate-rollback, enable the 'migrations' feature");
+			Err(crate::CommandError::ExecutionError(
+				"migrations feature not enabled".to_string(),
+			))
 		}
 	}
 }

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -100,6 +100,10 @@ pub enum Commands {
 		/// Show migration plan without applying
 		#[arg(long)]
 		plan: bool,
+
+		/// Root directory containing migration files (default: ./migrations)
+		#[arg(long, value_name = "DIR")]
+		migrations_dir: Option<PathBuf>,
 	},
 
 	/// Start the development server
@@ -306,6 +310,7 @@ pub async fn run_command(
 			fake,
 			fake_initial,
 			plan,
+			migrations_dir,
 		} => {
 			execute_migrate(MigrateParams {
 				app_label,
@@ -314,6 +319,7 @@ pub async fn run_command(
 				fake,
 				fake_initial,
 				plan,
+				migrations_dir,
 				verbosity,
 			})
 			.await
@@ -407,6 +413,7 @@ struct MigrateParams {
 	fake: bool,
 	fake_initial: bool,
 	plan: bool,
+	migrations_dir: Option<PathBuf>,
 	verbosity: u8,
 }
 
@@ -433,6 +440,12 @@ async fn execute_migrate(params: MigrateParams) -> Result<(), Box<dyn std::error
 	}
 	if let Some(db) = params.database {
 		ctx.set_option("database".to_string(), db);
+	}
+	if let Some(dir) = params.migrations_dir {
+		ctx.set_option(
+			"migrations-dir".to_string(),
+			dir.to_string_lossy().to_string(),
+		);
 	}
 
 	let cmd = MigrateCommand;
@@ -905,6 +918,7 @@ mod tests {
 			fake: false,
 			fake_initial: false,
 			plan: false,
+			migrations_dir: None,
 		};
 
 		// Act

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -177,6 +177,10 @@ use thiserror::Error;
 pub use base::{BaseCommand, CommandArgument, CommandOption};
 #[cfg(feature = "migrations")]
 pub use builtin::MakeMigrationsCommand;
+// Deprecated re-export retained for compatibility with the original issue #4558 proposal.
+// Prefer `MigrateCommand` with a target migration name (Django-style); see the type's docs.
+#[allow(deprecated)]
+pub use builtin::MigrationRollbackCommand;
 #[cfg(feature = "routers")]
 pub use builtin::ShowUrlsCommand;
 pub use builtin::{CheckCommand, CheckDiCommand, MigrateCommand, RunServerCommand, ShellCommand};

--- a/crates/reinhardt-commands/tests/migrate_target_e2e.rs
+++ b/crates/reinhardt-commands/tests/migrate_target_e2e.rs
@@ -1,0 +1,335 @@
+//! E2E tests for Django-style migrate-with-target semantics.
+//!
+//! Covers the five scenarios listed in issue #4558:
+//!
+//! 1. `rollback_default_one_step_succeeds` — `migrate myapp <prev>` rolls back the
+//!    most recent migration when the target is exactly one step earlier than head.
+//! 2. `rollback_multi_step` — `migrate myapp <2-back>` rolls back two migrations
+//!    in a single invocation.
+//! 3. `rollback_dry_run_does_not_modify_db` — `migrate myapp <prev> --plan`
+//!    previews the action and leaves the database untouched.
+//! 4. `rollback_no_applied_migrations_exits_cleanly` — `migrate myapp zero`
+//!    against an empty applied set succeeds with an informational message.
+//! 5. `rollback_with_missing_reverse_sql_fails_loudly` — when a migration file
+//!    referenced in the applied set is missing from disk, `migrate myapp <prev>`
+//!    surfaces an error that identifies the offending `<app>.<name>`.
+//!
+//! These tests use the `migration_executor` fixture from `reinhardt-testkit`
+//! (re-exported as `reinhardt_test::fixtures::migrations`) which spins up a
+//! TestContainers PostgreSQL instance. The tests pre-populate the recorder via
+//! `executor.record_migration(...)` — because the migration `.rs` files written
+//! to the tempdir declare `operations: vec![]`, no real schema operations are
+//! exercised; the focus is on the direction-detection + rollback orchestration
+//! introduced by issue #4558.
+
+#![cfg(feature = "testcontainers")]
+
+use reinhardt_commands::{BaseCommand, CommandContext, MigrateCommand};
+use reinhardt_db::backends::DatabaseConnection;
+use reinhardt_db::migrations::DatabaseMigrationRecorder;
+use reinhardt_test::fixtures::migrations::{MigrationExecutorFixture, migration_executor};
+use rstest::rstest;
+use serial_test::serial;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Write a minimally valid migration `.rs` file under
+/// `<root>/<app>/<name>.rs`. The Migration struct literal has `operations:
+/// vec![]` so the file parses cleanly via `syn` but does not require any real
+/// `Operation` types to be resolvable in the file's import graph (the
+/// `FilesystemSource` only parses the AST — it does not compile the file).
+fn write_test_migration(
+	root: &Path,
+	app: &str,
+	name: &str,
+	deps: &[(&str, &str)],
+) -> std::io::Result<()> {
+	let app_dir = root.join(app);
+	std::fs::create_dir_all(&app_dir)?;
+	let deps_literal = deps
+		.iter()
+		.map(|(a, n)| format!("(\"{}\".to_string(), \"{}\".to_string())", a, n))
+		.collect::<Vec<_>>()
+		.join(", ");
+	let content = format!(
+		"use reinhardt::db::migrations::prelude::*;\n\
+		 pub(super) fn migration() -> Migration {{\n\
+		 \tMigration {{\n\
+		 \t\tapp_label: \"{app}\".to_string(),\n\
+		 \t\tname: \"{name}\".to_string(),\n\
+		 \t\toperations: vec![],\n\
+		 \t\tdependencies: vec![{deps_literal}],\n\
+		 \t\tatomic: true,\n\
+		 \t\treplaces: vec![],\n\
+		 \t\tinitial: None,\n\
+		 \t\tstate_only: false,\n\
+		 \t\tdatabase_only: false,\n\
+		 \t\tswappable_dependencies: vec![],\n\
+		 \t\toptional_dependencies: vec![],\n\
+		 \t}}\n\
+		 }}\n",
+	);
+	std::fs::write(app_dir.join(format!("{}.rs", name)), content)
+}
+
+/// Build a CommandContext targeting the given migrations directory and
+/// database URL, with optional positional args and flags.
+fn build_ctx(
+	migrations_dir: &Path,
+	database_url: &str,
+	app_label: Option<&str>,
+	target: Option<&str>,
+	plan: bool,
+) -> CommandContext {
+	let mut ctx = CommandContext::default();
+	if let Some(app) = app_label {
+		ctx.add_arg(app.to_string());
+		if let Some(t) = target {
+			ctx.add_arg(t.to_string());
+		}
+	}
+	ctx.set_option("database".to_string(), database_url.to_string());
+	ctx.set_option(
+		"migrations-dir".to_string(),
+		migrations_dir.to_string_lossy().to_string(),
+	);
+	if plan {
+		ctx.set_option("plan".to_string(), "true".to_string());
+	}
+	ctx
+}
+
+/// Set up a tempdir with three sequential migrations for `myapp` and mark them
+/// all as applied in the recorder via `record_migration`. Returns the tempdir
+/// (keep it alive for the duration of the test) and the migrations root path.
+async fn arrange_three_applied_migrations(
+	executor: &mut reinhardt_db::migrations::DatabaseMigrationExecutor,
+) -> (TempDir, std::path::PathBuf) {
+	let tempdir = tempfile::tempdir().expect("create tempdir");
+	let migrations_root = tempdir.path().join("migrations");
+	write_test_migration(&migrations_root, "myapp", "0001_first", &[]).unwrap();
+	write_test_migration(
+		&migrations_root,
+		"myapp",
+		"0002_second",
+		&[("myapp", "0001_first")],
+	)
+	.unwrap();
+	write_test_migration(
+		&migrations_root,
+		"myapp",
+		"0003_third",
+		&[("myapp", "0002_second")],
+	)
+	.unwrap();
+
+	for name in ["0001_first", "0002_second", "0003_third"] {
+		executor
+			.record_migration("myapp", name)
+			.await
+			.expect("record_migration should succeed against a fresh TestContainers Postgres");
+	}
+
+	(tempdir, migrations_root)
+}
+
+/// Re-query the recorder for the current applied set. Builds a fresh
+/// connection from `url` to avoid interfering with the fixture's executor.
+/// Uses `connect_postgres` because the `migration_executor` fixture is
+/// PostgreSQL-only (provided by TestContainers).
+async fn applied_for_app(url: &str, app: &str) -> Vec<String> {
+	let connection = DatabaseConnection::connect_postgres(url)
+		.await
+		.expect("re-connect to test Postgres");
+	let recorder = DatabaseMigrationRecorder::new(connection.inner().clone());
+	let applied = recorder
+		.get_applied_migrations()
+		.await
+		.expect("query applied migrations");
+	applied
+		.into_iter()
+		.filter(|r| r.app == app)
+		.map(|r| r.name)
+		.collect()
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(migrate_target_e2e)]
+async fn rollback_default_one_step_succeeds(
+	#[future] migration_executor: MigrationExecutorFixture,
+) {
+	// Arrange — 3 migrations applied, target is the second-to-last one.
+	let (mut executor, _container, _pool, _port, url) = migration_executor.await;
+	let (_tempdir, migrations_root) = arrange_three_applied_migrations(&mut executor).await;
+
+	// Act — `migrate myapp 0002_second` should unapply 0003_third.
+	let ctx = build_ctx(
+		&migrations_root,
+		&url,
+		Some("myapp"),
+		Some("0002_second"),
+		false,
+	);
+	MigrateCommand
+		.execute(&ctx)
+		.await
+		.expect("rollback should succeed");
+
+	// Assert — recorder should hold only 0001 and 0002.
+	let remaining = applied_for_app(&url, "myapp").await;
+	assert_eq!(remaining.len(), 2, "exactly two migrations should remain");
+	assert!(
+		remaining.iter().any(|n| n == "0001_first"),
+		"0001_first must remain applied"
+	);
+	assert!(
+		remaining.iter().any(|n| n == "0002_second"),
+		"0002_second must remain applied"
+	);
+	assert!(
+		!remaining.iter().any(|n| n == "0003_third"),
+		"0003_third must have been rolled back"
+	);
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(migrate_target_e2e)]
+async fn rollback_multi_step(#[future] migration_executor: MigrationExecutorFixture) {
+	// Arrange — 3 migrations applied, target two steps back.
+	let (mut executor, _container, _pool, _port, url) = migration_executor.await;
+	let (_tempdir, migrations_root) = arrange_three_applied_migrations(&mut executor).await;
+
+	// Act — `migrate myapp 0001_first` should unapply both 0002 and 0003.
+	let ctx = build_ctx(
+		&migrations_root,
+		&url,
+		Some("myapp"),
+		Some("0001_first"),
+		false,
+	);
+	MigrateCommand
+		.execute(&ctx)
+		.await
+		.expect("multi-step rollback should succeed");
+
+	// Assert — only 0001_first remains.
+	let remaining = applied_for_app(&url, "myapp").await;
+	assert_eq!(
+		remaining,
+		vec!["0001_first".to_string()],
+		"only the target migration must remain"
+	);
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(migrate_target_e2e)]
+async fn rollback_dry_run_does_not_modify_db(
+	#[future] migration_executor: MigrationExecutorFixture,
+) {
+	// Arrange — 3 migrations applied; we'll preview a 2-step rollback.
+	let (mut executor, _container, _pool, _port, url) = migration_executor.await;
+	let (_tempdir, migrations_root) = arrange_three_applied_migrations(&mut executor).await;
+
+	// Act — `migrate myapp 0001_first --plan` should print the plan but not
+	// touch the database.
+	let ctx = build_ctx(
+		&migrations_root,
+		&url,
+		Some("myapp"),
+		Some("0001_first"),
+		true,
+	);
+	MigrateCommand
+		.execute(&ctx)
+		.await
+		.expect("dry-run should succeed");
+
+	// Assert — all three migrations remain applied.
+	let remaining = applied_for_app(&url, "myapp").await;
+	assert_eq!(
+		remaining.len(),
+		3,
+		"--plan must not modify the recorder; got remaining = {:?}",
+		remaining
+	);
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(migrate_target_e2e)]
+async fn rollback_no_applied_migrations_exits_cleanly(
+	#[future] migration_executor: MigrationExecutorFixture,
+) {
+	// Arrange — recorder is empty; only the on-disk migration files exist.
+	let (_executor, _container, _pool, _port, url) = migration_executor.await;
+	let tempdir = tempfile::tempdir().expect("create tempdir");
+	let migrations_root = tempdir.path().join("migrations");
+	write_test_migration(&migrations_root, "myapp", "0001_first", &[]).unwrap();
+
+	// Act — `migrate myapp zero` against an empty applied set should report
+	// "nothing to do" and return Ok(()).
+	let ctx = build_ctx(&migrations_root, &url, Some("myapp"), Some("zero"), false);
+	MigrateCommand
+		.execute(&ctx)
+		.await
+		.expect("zero-rollback on empty state should be a no-op success");
+
+	// Assert — recorder still has no applied migrations for myapp.
+	let remaining = applied_for_app(&url, "myapp").await;
+	assert!(
+		remaining.is_empty(),
+		"recorder must remain empty; got {:?}",
+		remaining
+	);
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(migrate_target_e2e)]
+async fn rollback_with_missing_reverse_sql_fails_loudly(
+	#[future] migration_executor: MigrationExecutorFixture,
+) {
+	// Arrange — record three migrations as applied, but the `.rs` file for
+	// 0003_third is intentionally absent from disk. The rollback path must
+	// surface a clear error naming the missing migration when it tries to
+	// load reverse-SQL for it via the FilesystemSource.
+	let (mut executor, _container, _pool, _port, url) = migration_executor.await;
+	let tempdir = tempfile::tempdir().expect("create tempdir");
+	let migrations_root = tempdir.path().join("migrations");
+	write_test_migration(&migrations_root, "myapp", "0001_first", &[]).unwrap();
+	write_test_migration(
+		&migrations_root,
+		"myapp",
+		"0002_second",
+		&[("myapp", "0001_first")],
+	)
+	.unwrap();
+	// Note: 0003_third is intentionally NOT written to disk.
+
+	for name in ["0001_first", "0002_second", "0003_third"] {
+		executor.record_migration("myapp", name).await.unwrap();
+	}
+
+	// Act — `migrate myapp 0002_second` will try to load 0003_third's
+	// reverse-SQL but the file is missing.
+	let ctx = build_ctx(
+		&migrations_root,
+		&url,
+		Some("myapp"),
+		Some("0002_second"),
+		false,
+	);
+	let result = MigrateCommand.execute(&ctx).await;
+
+	// Assert — the error message points at the missing migration.
+	let err = result.expect_err("should fail when reverse SQL cannot be loaded");
+	let msg = err.to_string();
+	assert!(
+		msg.contains("0003_third"),
+		"error must name the offending migration; got: {}",
+		msg
+	);
+}

--- a/crates/reinhardt-commands/tests/migrate_target_e2e.rs
+++ b/crates/reinhardt-commands/tests/migrate_target_e2e.rs
@@ -301,6 +301,49 @@ async fn rollback_no_applied_migrations_exits_cleanly(
 #[rstest]
 #[tokio::test]
 #[serial(migrate_target_e2e)]
+async fn plan_on_fresh_db_does_not_create_recorder_table(
+	#[future] migration_executor: MigrationExecutorFixture,
+) {
+	// Regression test for the `--plan` no-mutation contract: on a fresh
+	// container the `reinhardt_migrations` bookkeeping table has not been
+	// created yet. A naïve implementation that unconditionally calls
+	// `recorder.ensure_schema_table()` before querying the applied set
+	// would silently create the table as a side effect, violating the
+	// dry-run guarantee. This test pins that behavior down.
+	let (_executor, _container, _pool, _port, url) = migration_executor.await;
+	let tempdir = tempfile::tempdir().expect("create tempdir");
+	let migrations_root = tempdir.path().join("migrations");
+	write_test_migration(&migrations_root, "myapp", "0001_first", &[]).unwrap();
+
+	// Act — `migrate myapp zero --plan` on a database without the recorder
+	// table must succeed (planning an empty rollback) without touching the
+	// database.
+	let ctx = build_ctx(&migrations_root, &url, Some("myapp"), Some("zero"), true);
+	MigrateCommand
+		.execute(&ctx)
+		.await
+		.expect("`--plan` on a fresh DB must succeed without modifying state");
+
+	// Assert — the recorder table still does not exist. Re-querying the
+	// applied set must therefore error (with a "relation does not exist"
+	// style error from the underlying driver) rather than returning an
+	// empty success.
+	let connection = DatabaseConnection::connect_postgres(&url)
+		.await
+		.expect("re-connect to test Postgres");
+	let recorder = DatabaseMigrationRecorder::new(connection.inner().clone());
+	let result = recorder.get_applied_migrations().await;
+	assert!(
+		result.is_err(),
+		"--plan must NOT create the recorder table as a side effect; \
+		 got Ok({:?}) — table appears to exist after dry-run",
+		result.ok()
+	);
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(migrate_target_e2e)]
 async fn rollback_with_missing_reverse_sql_fails_loudly(
 	#[future] migration_executor: MigrationExecutorFixture,
 ) {

--- a/crates/reinhardt-commands/tests/migrate_target_e2e.rs
+++ b/crates/reinhardt-commands/tests/migrate_target_e2e.rs
@@ -102,6 +102,12 @@ fn build_ctx(
 /// Set up a tempdir with three sequential migrations for `myapp` and mark them
 /// all as applied in the recorder via `record_migration`. Returns the tempdir
 /// (keep it alive for the duration of the test) and the migrations root path.
+///
+/// On a fresh TestContainers Postgres the `reinhardt_migrations` table does
+/// not exist yet — `record_migration` does NOT auto-create it (it just issues
+/// an INSERT against the table). We therefore construct a side recorder from
+/// `executor.connection()` and call `ensure_schema_table()` once before
+/// recording any applied migrations.
 async fn arrange_three_applied_migrations(
 	executor: &mut reinhardt_db::migrations::DatabaseMigrationExecutor,
 ) -> (TempDir, std::path::PathBuf) {
@@ -122,6 +128,12 @@ async fn arrange_three_applied_migrations(
 		&[("myapp", "0002_second")],
 	)
 	.unwrap();
+
+	let recorder = DatabaseMigrationRecorder::new(executor.connection().clone());
+	recorder
+		.ensure_schema_table()
+		.await
+		.expect("ensure_schema_table on fresh Postgres");
 
 	for name in ["0001_first", "0002_second", "0003_third"] {
 		executor
@@ -308,6 +320,11 @@ async fn rollback_with_missing_reverse_sql_fails_loudly(
 	)
 	.unwrap();
 	// Note: 0003_third is intentionally NOT written to disk.
+
+	// `record_migration` does not auto-create `reinhardt_migrations`; ensure
+	// the recorder table exists on the fresh container before recording.
+	let recorder = DatabaseMigrationRecorder::new(executor.connection().clone());
+	recorder.ensure_schema_table().await.unwrap();
 
 	for name in ["0001_first", "0002_second", "0003_third"] {
 		executor.record_migration("myapp", name).await.unwrap();


### PR DESCRIPTION
## Summary

Implements Django-style migrate-with-target semantics on the per-project `manage` binary, providing rollback functionality through the existing `migrate` command rather than a separate subcommand.

- `manage migrate <app> <target>` — auto-detects forward or backward direction based on the currently applied state.
- `manage migrate <app> zero` — unapplies ALL migrations for the app (matches Django's special `zero` token).
- `--plan` flag previews the action without modifying the database.
- `--migrations-dir` flag overrides the migration source directory (used by E2E tests).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage for new functionality

## Motivation and Context

Closes #4558.

The original issue proposed a Rails/Alembic-style `migrate rollback` subcommand exposed on `reinhardt-admin-cli`. After clarification, this PR adopts the Django design instead:

| Framework | Rollback command |
|---|---|
| Django | `manage.py migrate <app> <target>` (same command as apply) |
| Rails | `rake db:rollback` (separate command) |
| Alembic | `alembic downgrade <revision>` (separate command) |

Django's unified-direction design eliminates a confusable surface (\`migrate apply\` vs \`migrate rollback\`) and matches the mental model operators already have. It also aligns with Reinhardt's design philosophy #7 (\"Confusable APIs are bad APIs\") and #5 (\"API ergonomics is paramount\").

For users who prefer the originally proposed Rails-style shape, the new \`MigrationRollbackCommand\` ships as a deprecated public API; removal is tracked separately under the \`rc-migration\` label.

## How Was This Tested

Five E2E tests in \`crates/reinhardt-commands/tests/migrate_target_e2e.rs\` (gated on the \`testcontainers\` feature), backed by the TestContainers PostgreSQL fixture:

1. \`rollback_default_one_step_succeeds\` — \`migrate myapp 0002_second\` after applying 3 migrations unapplies only \`0003_third\`.
2. \`rollback_multi_step\` — \`migrate myapp 0001_first\` unapplies both \`0002\` and \`0003\`.
3. \`rollback_dry_run_does_not_modify_db\` — \`--plan\` previews the rollback without touching the recorder.
4. \`rollback_no_applied_migrations_exits_cleanly\` — \`migrate myapp zero\` on an empty applied set is a no-op success.
5. \`rollback_with_missing_reverse_sql_fails_loudly\` — when a migration referenced in the recorder is missing from disk, the error names the offending \`<app>.<name>\`.

Run locally: \`cargo nextest run -p reinhardt-commands --features \"migrations,postgres,testcontainers\"\` (requires Docker).

## Checklist

- [x] My code follows the project's style guidelines (cargo fmt applied)
- [x] All existing CommandContext / BaseCommand patterns are reused (no new abstractions)
- [x] New code is documented (rustdoc on \`MigrationRollbackCommand\`, inline comments on direction-detection branches)
- [x] Tests added for the new behavior (5 E2E scenarios)
- [x] Changes target \`develop/0.2.0\` per STABILITY_POLICY.md § DB-2 (new feature during RC phase)

## Labels to Apply

- enhancement
- database
- dx
- testing

## Additional Context

The deprecated \`MigrationRollbackCommand\` is intentionally added in the same PR that deprecates it; this honors the original CLI design proposal in #4558 while signaling the canonical Django-style path. Future PR (tracked under \`rc-migration\`) will remove the deprecated command.