### PR TITLE
fix(db): derive NOT NULL from FieldState.nullable in autodetector

### DIFF
--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -2777,8 +2777,11 @@ impl ColumnDefinition {
 
 	/// Create a ColumnDefinition from FieldState with attribute parsing
 	///
-	/// This method reads field attributes (primary_key, not_null, unique, etc.) from
-	/// the FieldState.params HashMap and properly initializes ColumnDefinition fields.
+	/// Reads boolean attributes (primary_key, unique, auto_increment) and the
+	/// default expression from `FieldState.params`, and derives the NOT NULL
+	/// constraint from `FieldState.nullable` (the single source of truth
+	/// populated by `FieldMetadata::is_nullable()` in
+	/// `ModelMetadata::to_model_state()`).
 	///
 	/// # Arguments
 	///
@@ -2787,7 +2790,8 @@ impl ColumnDefinition {
 	///
 	/// # Notes
 	///
-	/// - If `primary_key` is true, `not_null` is automatically set to true
+	/// - If `primary_key` is true, `not_null` is forced to true regardless of
+	///   `FieldState.nullable` — primary keys cannot accept NULL.
 	/// - Default values are false/None for unspecified attributes
 	pub fn from_field_state(name: impl Into<String>, field_state: &FieldState) -> Self {
 		let name_str = name.into();
@@ -2799,11 +2803,17 @@ impl ColumnDefinition {
 			.and_then(|v| v.parse::<bool>().ok())
 			.unwrap_or(false);
 
-		let not_null = params
-			.get("not_null")
-			.and_then(|v| v.parse::<bool>().ok())
-			.or(if primary_key { Some(true) } else { None })
-			.unwrap_or(false);
+		// Derive `not_null` from FieldState's nullability field (single source
+		// of truth set in `ModelMetadata::to_model_state()`). Primary keys are
+		// always NOT NULL regardless of the nullability flag.
+		//
+		// Fixes #4573: the previous implementation read a `params["not_null"]`
+		// key that the proc-macro never emits (the macro emits the inverse,
+		// `params["null"]`, via `FieldMetadata::with_nullable`). The lookup
+		// always missed and `unwrap_or(false)` silently produced NULLABLE
+		// columns for every non-PK field, breaking the non-Optional Rust
+		// type ↔ NOT NULL schema contract.
+		let not_null = !field_state.nullable || primary_key;
 
 		let unique = params
 			.get("unique")
@@ -5661,6 +5671,164 @@ mod tests {
 			"auto_increment should default to false"
 		);
 		assert!(col.default.is_none(), "default should be None");
+	}
+
+	// -----------------------------------------------------------------------
+	// Regression tests for issue #4573:
+	// `ColumnDefinition::from_field_state` previously read a non-existent
+	// `params["not_null"]` key and silently emitted NULLABLE columns for
+	// every non-PK field, violating the non-Optional Rust type ↔ NOT NULL
+	// schema contract. These tests pin the corrected behavior:
+	//   not_null = !field_state.nullable || primary_key
+	// -----------------------------------------------------------------------
+
+	#[rstest]
+	fn from_field_state_non_optional_bool_with_true_default() {
+		// Arrange
+		// Models a Rust field declared as `pub is_active: bool` with
+		// `#[field(default = true)]`. The proc-macro sets
+		// `field_state.nullable = false` via `FieldMetadata::with_nullable`,
+		// and emits the default value as `params["default"] = "true"`.
+		let mut field_state = FieldState::new("is_active", FieldType::Boolean, false);
+		field_state.params.insert("default".to_string(), "true".to_string());
+
+		// Act
+		let col = ColumnDefinition::from_field_state("is_active", &field_state);
+
+		// Assert
+		assert_eq!(col.name, "is_active", "Column name should round-trip");
+		assert_eq!(
+			col.type_definition,
+			FieldType::Boolean,
+			"Boolean field type should round-trip"
+		);
+		assert!(
+			col.not_null,
+			"Non-Optional bool must emit NOT NULL (regression #4573)"
+		);
+		assert_eq!(
+			col.default,
+			Some("true".to_string()),
+			"`#[field(default = true)]` must propagate as Some(\"true\")"
+		);
+		assert!(!col.primary_key, "Non-PK field must not be primary_key");
+	}
+
+	#[rstest]
+	fn from_field_state_non_optional_bool_with_false_default() {
+		// Arrange
+		// Models a Rust field declared as `pub is_superuser: bool` with
+		// `#[field(default = false)]` — the symptom previously hand-patched
+		// in PR #4513.
+		let mut field_state = FieldState::new("is_superuser", FieldType::Boolean, false);
+		field_state
+			.params
+			.insert("default".to_string(), "false".to_string());
+
+		// Act
+		let col = ColumnDefinition::from_field_state("is_superuser", &field_state);
+
+		// Assert
+		assert!(
+			col.not_null,
+			"Non-Optional bool with default=false must emit NOT NULL"
+		);
+		assert_eq!(
+			col.default,
+			Some("false".to_string()),
+			"default=false must propagate as Some(\"false\")"
+		);
+	}
+
+	#[rstest]
+	fn from_field_state_optional_bool_with_default() {
+		// Arrange
+		// Models a Rust field declared as `pub maybe_flag: Option<bool>` with
+		// `#[field(default = true)]`. Existing behavior must be preserved:
+		// nullable column with default still set.
+		let mut field_state = FieldState::new("maybe_flag", FieldType::Boolean, true);
+		field_state
+			.params
+			.insert("default".to_string(), "true".to_string());
+
+		// Act
+		let col = ColumnDefinition::from_field_state("maybe_flag", &field_state);
+
+		// Assert
+		assert!(
+			!col.not_null,
+			"Optional bool must remain NULLABLE — no regression on Option<T>"
+		);
+		assert_eq!(
+			col.default,
+			Some("true".to_string()),
+			"Default propagation must work for Optional fields too"
+		);
+	}
+
+	#[rstest]
+	fn from_field_state_non_optional_non_bool() {
+		// Arrange
+		// Models a Rust field declared as `pub username: String` with no
+		// default. This confirms the fix is type-agnostic (not bool-only) —
+		// the broader symptom in `examples-twitter/migrations/auth/0001_initial.rs`
+		// where `username`, `bio`, `email`, etc. were all silently NULLABLE.
+		let field_state = FieldState::new("username", FieldType::VarChar(150), false);
+
+		// Act
+		let col = ColumnDefinition::from_field_state("username", &field_state);
+
+		// Assert
+		assert!(
+			col.not_null,
+			"Non-Optional String must emit NOT NULL (regression #4573 — bug \
+			 affected all field types, not just bool)"
+		);
+		assert!(col.default.is_none(), "No default annotation → default = None");
+	}
+
+	#[rstest]
+	fn from_field_state_primary_key_is_always_not_null() {
+		// Arrange
+		// A primary key column must be NOT NULL even when the nullability
+		// flag would otherwise allow NULL. This pins the `|| primary_key`
+		// short-circuit in the corrected expression.
+		let mut field_state = FieldState::new("id", FieldType::Uuid, true);
+		field_state
+			.params
+			.insert("primary_key".to_string(), "true".to_string());
+
+		// Act
+		let col = ColumnDefinition::from_field_state("id", &field_state);
+
+		// Assert
+		assert!(
+			col.primary_key,
+			"primary_key param must propagate to ColumnDefinition"
+		);
+		assert!(
+			col.not_null,
+			"Primary key must be NOT NULL regardless of nullable flag"
+		);
+	}
+
+	#[rstest]
+	fn from_field_state_optional_field_remains_nullable() {
+		// Arrange
+		// Models a Rust field declared as `pub last_login: Option<DateTime<Utc>>`
+		// with no default. Existing nullable-field behavior must be preserved.
+		let field_state = FieldState::new("last_login", FieldType::TimestampTz, true);
+
+		// Act
+		let col = ColumnDefinition::from_field_state("last_login", &field_state);
+
+		// Assert
+		assert!(
+			!col.not_null,
+			"Optional field with no default must remain NULLABLE"
+		);
+		assert!(col.default.is_none(), "No default → default = None");
+		assert!(!col.primary_key, "Non-PK field must not be primary_key");
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -2804,15 +2804,21 @@ impl ColumnDefinition {
 			.unwrap_or(false);
 
 		// Derive `not_null` from FieldState's nullability field (single source
-		// of truth set in `ModelMetadata::to_model_state()`). Primary keys are
-		// always NOT NULL regardless of the nullability flag.
+		// of truth set in `ModelMetadata::to_model_state()` from
+		// `FieldMetadata::is_nullable()`). Primary keys are always NOT NULL
+		// regardless of the nullability flag.
 		//
-		// Fixes #4573: the previous implementation read a `params["not_null"]`
-		// key that the proc-macro never emits (the macro emits the inverse,
-		// `params["null"]`, via `FieldMetadata::with_nullable`). The lookup
-		// always missed and `unwrap_or(false)` silently produced NULLABLE
-		// columns for every non-PK field, breaking the non-Optional Rust
-		// type ↔ NOT NULL schema contract.
+		// Fixes #4573: the previous implementation derived `not_null` from a
+		// `params["not_null"]` key, which the `#[model]` proc-macro only
+		// emits conditionally (when its `is_not_null` calculation returns
+		// `true`). The same macro also always emits `params["null"]`, which
+		// `is_nullable()` reads into `field_state.nullable`. Keeping the two
+		// keys as parallel sources of truth for nullability was the root
+		// cause of the drift: any code path that bypassed or mis-routed the
+		// `not_null` emission (e.g., offline state reconstruction, future
+		// macro refactors, or hand-built `FieldState` values in tests) would
+		// produce NULLABLE columns for non-Optional fields. Consolidating on
+		// `field_state.nullable` removes that class of regression.
 		let not_null = !field_state.nullable || primary_key;
 
 		let unique = params
@@ -5690,7 +5696,9 @@ mod tests {
 		// `field_state.nullable = false` via `FieldMetadata::with_nullable`,
 		// and emits the default value as `params["default"] = "true"`.
 		let mut field_state = FieldState::new("is_active", FieldType::Boolean, false);
-		field_state.params.insert("default".to_string(), "true".to_string());
+		field_state
+			.params
+			.insert("default".to_string(), "true".to_string());
 
 		// Act
 		let col = ColumnDefinition::from_field_state("is_active", &field_state);
@@ -5784,7 +5792,10 @@ mod tests {
 			"Non-Optional String must emit NOT NULL (regression #4573 — bug \
 			 affected all field types, not just bool)"
 		);
-		assert!(col.default.is_none(), "No default annotation → default = None");
+		assert!(
+			col.default.is_none(),
+			"No default annotation → default = None"
+		);
 	}
 
 	#[rstest]


### PR DESCRIPTION
## Summary

This PR addresses:

- `ColumnDefinition::from_field_state` previously read a `params["not_null"]` key that the proc-macro emits inconsistently (the canonical nullability signal is `params["null"]`, surfaced via `FieldState.nullable`). When the `"not_null"` key was missing, the lookup fell through to `unwrap_or(false)` and silently produced NULLABLE columns for every non-PK field, breaking the non-Optional Rust type ↔ NOT NULL schema contract.
- Switched to `FieldState.nullable` as the single source of truth; the primary-key short-circuit is preserved.
- Added six `rstest` regression tests covering bool ± default, `Option<bool>`, non-bool non-Optional, primary key, and Optional-without-default permutations.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The migration autodetector was generating `not_null: false` for **every non-primary-key field**, regardless of whether the Rust field type was `Option<T>` or `T`. The Issue describes the symptom in terms of `bool` fields, but the actual scope is broader — visible in `examples/examples-twitter/migrations/auth/0001_initial.rs` where `created_at`, `expires_at`, `last_login`, `bio`, `email`, `username`, `password_hash`, `is_active`, and `is_used` were all silently emitted as `not_null: false`. Two hand-patch PRs (#4513, #4566) had already corrected this manually for two boolean fields, and the same bug reproduced on every new project generated by `reinhardt-admin startproject` containing a non-`Option` field.

This violates `instructions/DESIGN_PHILOSOPHY.md` Principle 4 ("Fail early"): the type ↔ schema mismatch should be caught at code-gen time, not at runtime decode time when NULL decodes silently to `Default::default()`.

Fixes #4573

Related to: #4513, #4566

## How Was This Tested?

- Six new `rstest` regression tests in `crates/reinhardt-db/src/migrations/operations.rs`:
  - `from_field_state_non_optional_bool_with_true_default` — direct reproducer for the reported symptom (`pub is_active: bool` + `#[field(default = true)]`)
  - `from_field_state_non_optional_bool_with_false_default` — covers the `is_superuser` hand-patch case
  - `from_field_state_optional_bool_with_default` — confirms no regression on `Option<bool>` fields
  - `from_field_state_non_optional_non_bool` — proves the fix is type-agnostic (the broader symptom across `username`, `email`, etc.)
  - `from_field_state_primary_key_is_always_not_null` — pins the PK short-circuit
  - `from_field_state_optional_field_remains_nullable` — guards existing `Option<T>` behavior
- All six tests PASS locally: ``6 tests run: 6 passed, 2471 skipped``.
- Full `migrations::operations` module: ``153 tests run: 153 passed, 2324 skipped``.
- `cargo make fmt-check` ✓
- `cargo clippy --package reinhardt-db --all-features --lib -- -D warnings` ✓
- `cargo make clippy-todo-check` ✓
- `semgrep scan --config .semgrep/ --baseline-commit origin/main --error` ✓ (0 findings)

## Breaking Changes

None. `ColumnDefinition::from_field_state` signature is unchanged; only the internal logic that computes `not_null` is corrected. The behavioral change is the bug fix itself (NULLABLE → NOT NULL for non-Optional fields) — this is the intended outcome, not a SemVer break.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Original issue: #4573
- Prior symptom hand-patches: #4513 (`is_superuser`), #4566 (`is_active`)
- Out-of-scope follow-ups (per WU-1, deferred to separate Issues/PRs):
  - Hard-erroring `makemigrations` when a non-Optional field has no `#[field(default = ...)]` (Issue suggested fix #3.4)
  - CI lint scanning `examples/*/migrations/**/*.rs` for the bug pattern (Issue suggested fix #4)
  - Re-running `cargo make makemigrations` on `examples-twitter` to drop the hand-patches now that this generator fix is in place (Issue suggested fix #5)

## Labels to Apply

### Type Label
- [x] `bug` — Bug fix

### Scope Label
- [x] `database` — Database layer, schema, migrations

### Priority Label
- [x] `high` — applied at filing time on #4573

---

**Additional Context:**

The root cause is structural: two parallel sources of truth for nullability (`params["not_null"]` and `params["null"]` / `FieldState.nullable`) were drifting out of sync. The fix consolidates onto a single source (`FieldState.nullable`), which is already correctly populated by `FieldMetadata::is_nullable()` in `ModelMetadata::to_model_state()`. This eliminates the class of regressions that PRs #4513 and #4566 patched symptomatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database schema generation where non-optional fields were being incorrectly marked as nullable columns, which could have allowed unintended null values in required fields. Optional fields remain properly nullable as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->