### PR TITLE
fix(examples-twitter): derive Default on User to satisfy #[user] auto-register

### DIFF
--- a/examples/examples-twitter/src/apps/auth/models/user.rs
+++ b/examples/examples-twitter/src/apps/auth/models/user.rs
@@ -23,7 +23,7 @@ use sqlx::FromRow;
 
 #[user(hasher = Argon2Hasher, username_field = "email", manager = false)]
 #[model(app_label = "auth", table_name = "auth_user")]
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 #[cfg_attr(all(test, native), derive(FromRow))]
 pub struct User {
 	#[field(primary_key = true)]


### PR DESCRIPTION
## Summary

- Add `Default` to the `User` derive list (or equivalent minimal change) in `examples-twitter` so the example compiles under the new `#[user] + #[model]` auto-register contract from PR #4545.

Fixes #4598.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] CI/CD update

## Motivation and Context

PR #4545 introduced automatic `SuperuserCreator` registration for any `#[user] + #[model]` type. The generated registration code calls `User::default()`. The `examples-twitter` `User` struct was not updated to derive `Default`, so the example failed to compile (E0277/E0599) once #4545 was merged. This PR brings the example back in sync with the framework macro contract.

## How Was This Tested

- [x] `cargo check --all-features` in `examples/examples-twitter`
- [x] `cargo check --all-features --tests` in `examples/examples-twitter`
- [x] `cargo make fmt-check`

## Checklist

- [x] My code follows the project's style guidelines
- [x] PR title follows Conventional Commits format
- [x] Linked Issue (Fixes #4598)
- [x] All comments are in English

## Labels to Apply

- bug
- examples
- macros

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to support additional functionality in the authentication module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->