### PR TITLE
refactor(ci): move lightweight gate jobs to self-hosted hotpath runner

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -18,7 +18,8 @@ permissions:
 jobs:
   label-by-path:
     name: Label by changed files
-    timeout-minutes: 360
+    timeout-minutes: 10
+    # See infra/github-runners/hotpath-runner-userdata.sh for the canonical hotpath runner labels.
     runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     steps:
       - uses: actions/labeler@v6
@@ -29,7 +30,7 @@ jobs:
 
   label-by-title:
     name: Label by PR title
-    timeout-minutes: 360
+    timeout-minutes: 10
     runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     steps:
       - uses: actions/github-script@v8

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -19,7 +19,7 @@ jobs:
   label-by-path:
     name: Label by changed files
     timeout-minutes: 360
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     steps:
       - uses: actions/labeler@v6
         with:
@@ -30,7 +30,7 @@ jobs:
   label-by-title:
     name: Label by PR title
     timeout-minutes: 360
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: Check Branch Status
     timeout-minutes: 360
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     outputs:
       has-conflicts: ${{ steps.check.outputs.has-conflicts }}
       infra-changed: ${{ steps.check-infra.outputs.infra-changed }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,9 @@ jobs:
   # When conflicts exist, skip all CI jobs to save runner costs.
   check-branch-status:
     name: Check Branch Status
-    timeout-minutes: 360
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
+    # See infra/github-runners/hotpath-runner-userdata.sh for the canonical hotpath runner labels.
     runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     outputs:
       has-conflicts: ${{ steps.check.outputs.has-conflicts }}

--- a/.github/workflows/develop-leak-guard.yml
+++ b/.github/workflows/develop-leak-guard.yml
@@ -20,10 +20,11 @@ concurrency:
 jobs:
   develop-leak-guard:
     name: Develop Leak Guard
-    timeout-minutes: 360
+    timeout-minutes: 15
     if: >-
       github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
       github.event.label.name == 'migration-approved'
+    # See infra/github-runners/hotpath-runner-userdata.sh for the canonical hotpath runner labels.
     runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     steps:
       - name: Check if migration-approved

--- a/.github/workflows/develop-leak-guard.yml
+++ b/.github/workflows/develop-leak-guard.yml
@@ -24,7 +24,7 @@ jobs:
     if: >-
       github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
       github.event.label.name == 'migration-approved'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     steps:
       - name: Check if migration-approved
         id: label-check

--- a/.github/workflows/develop-merge-guard.yml
+++ b/.github/workflows/develop-merge-guard.yml
@@ -20,10 +20,11 @@ concurrency:
 jobs:
   develop-merge-guard:
     name: Develop Merge Guard
-    timeout-minutes: 360
+    timeout-minutes: 10
     if: >-
       github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
       github.event.label.name == 'migration-approved'
+    # See infra/github-runners/hotpath-runner-userdata.sh for the canonical hotpath runner labels.
     runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     steps:
       - name: Check if guard applies

--- a/.github/workflows/develop-merge-guard.yml
+++ b/.github/workflows/develop-merge-guard.yml
@@ -24,7 +24,7 @@ jobs:
     if: >-
       github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
       github.event.label.name == 'migration-approved'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     steps:
       - name: Check if guard applies
         id: guard-scope


### PR DESCRIPTION
## Summary

Switches `runs-on` for four gate-only workflows from `ubuntu-latest` to the
always-on self-hosted hotpath runner. Eliminates 10+ minute GitHub-hosted
queue waits that were blocking downstream CI on Release PRs and feature PRs.

| Workflow | Job | Before | After |
|---|---|---|---|
| `ci.yml` | `check-branch-status` | `ubuntu-latest` | `[self-hosted, linux, arm64, reinhardt-hotpath]` |
| `auto-label-pr.yml` | `label-by-path` | `ubuntu-latest` | same hotpath |
| `auto-label-pr.yml` | `label-by-title` | `ubuntu-latest` | same hotpath |
| `develop-leak-guard.yml` | `develop-leak-guard` | `ubuntu-latest` | same hotpath |
| `develop-merge-guard.yml` | `develop-merge-guard` | `ubuntu-latest` | same hotpath |

Heavier `ubuntu-latest` jobs (`deploy-website.yml::build-deploy`,
`osv-scanner.yml`) are intentionally left on GitHub-hosted because they
need either the build toolchain or would saturate the single-runner
hotpath instance.

## Type of Change

- [x] Refactor (no functional change, infrastructure routing only)
- [x] CI/CD enhancement

## Motivation and Context

Concrete observation on 2026-05-19 (PR #4615, release-plz Release PR):

- `Check Branch Status`: queued 10+ minutes on `ubuntu-latest`; actual
  runtime is ~5 seconds (2× GitHub REST API calls via
  `actions/github-script@v8`).
- Sibling `Determine Runner` in the same workflow already runs on the
  hotpath runner and completes in 3 seconds.
- AWS sub-account inspection (`reinhardt-ci`, `495680546359`) confirmed:
  - SQS queues empty (0 messages, 0 retries)
  - `scale-up` Lambda: 0 errors in last 30 min
  - `orphan-detector` Lambda: 0 stranded jobs
  - Hotpath runner `i-072369ef67cb1376e` (t4g.small) idle
- Conclusion: the wait was purely on GitHub.com's hosted runner pool,
  with the Reinhardt self-hosted side fully healthy.

The pattern of routing trivial gate jobs to the hotpath runner is already
in production for:
- `cancel-on-pr-close.yml::Cancel Stale Workflow Runs`
- `cleanup-release-branch.yml::Delete release-plz branch`
- `ci.yml::determine-runner`

This PR brings four more gate jobs in line with that pattern.

## How Was This Tested

- [x] `actionlint` (local): only pre-existing custom-label warnings
  (`reinhardt-hotpath` not registered) which also fire for the existing
  `determine-runner`/`cancel-on-pr-close` jobs. No actionlint config is
  wired into CI, so these warnings are advisory only.
- [x] YAML syntax validated (changes are mechanical 5-line replacements).
- [x] Hotpath runner verified live (`i-072369ef67cb1376e`, ASG-managed,
  `reinhardt-hotpath` label registered via
  `infra/github-runners/hotpath-runner-userdata.sh`).
- [ ] CI run on this PR will exercise the new routing end-to-end (Draft
  until first push picks up the new runner config).

## Hotpath Capacity Note

The hotpath runner is a single GitHub Actions runner registration on a
t4g.small ASG instance — so the migrated jobs serialize there rather
than run in parallel. Expected added load per PR push: ~30–60 seconds of
cumulative work, well within capacity. If contention emerges on busy
days, follow-ups can either (a) scale to two hotpath registrations
behind the same label, or (b) move the least-critical jobs back.

## Out of Scope (deferred to follow-up PRs)

- `auto-close-parent-issue.yml` (low urgency)
- `stale.yml` (cron schedule)
- `deploy-website.yml::cleanup-preview` (low frequency)
- `update-version-refs.yml` (workflow_dispatch only)
- Registering `reinhardt-hotpath`, `reinhardt-ci`, `reinhardt-release`
  in an `actionlint.yaml` to silence pre-existing custom-label warnings.

## Checklist

- [x] Code follows project style (mechanical YAML edits, no logic change)
- [x] Self-reviewed
- [x] Documentation updated where applicable (no doc changes needed —
      the migration is opaque to consumers)
- [x] No `todo!()` / `// TODO` introduced
- [x] PR linked to tracking issue (`Fixes #4616`)
- [x] Draft created from non-protected branch per Autonomous Operation Policy

## Labels to Apply

- `ci-cd` (primary)
- `enhancement`

## Related Issues

Fixes #4616
Context: PR #4615 (release-plz) where the queue tax was first observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflows (PR labeling, branch-status checks, leak and merge guards) now run on self-hosted ARM64 Linux runners to align with optimized runner infrastructure.
  * Job timeouts were significantly reduced (from multi-hour defaults to short time limits) to fail faster and conserve runner capacity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->