### PR TITLE
fix(integration): add no_client_resolvers to viewset_typed_integration #[routes]

### DIFF
--- a/tests/integration/tests/url_patterns_viewset_typed_integration.rs
+++ b/tests/integration/tests/url_patterns_viewset_typed_integration.rs
@@ -137,7 +137,16 @@ pub mod apps {
 // `#[routes]` requires the function to return a `UnifiedRouter` — the macro
 // calls `.into_server()` on it to populate the global server router used by
 // `ResolvedUrls::from_global()`.
-#[reinhardt::routes]
+//
+// `no_client_resolvers` is required because the `snippets` app above declares
+// only `#[url_patterns(..., mode = server)]` (plus `mode = ws`) and never emits
+// a `client_url_resolvers` module. Without the flag, `#[routes]` expands a
+// `crate::apps::snippets::urls::client_url_resolvers::__for_each_client_url_resolver!`
+// reference that fails E0433 in `cargo check --tests`. The two sibling
+// regression tests (`url_patterns_viewset_collision_regression.rs`,
+// `url_patterns_viewset_namespace_regression.rs`) carry the same flag for
+// the same reason.
+#[reinhardt::routes(no_client_resolvers)]
 pub fn routes() -> UnifiedRouter {
 	// Replace the default empty `ServerRouter` with the snippets app's
 	// `ServerRouter` directly. `UnifiedRouter::server(|s| f(s))` lets the


### PR DESCRIPTION
## Summary

- Add the `no_client_resolvers` flag to `#[reinhardt::routes]` in `tests/integration/tests/url_patterns_viewset_typed_integration.rs:140` so the test compiles under `cargo check --workspace --all-features --tests`.
- Mirror the exact fix `faec0f9db6` ("fix(ci): restore rustfmt and resolve client_url_resolvers E0433 on main") applied to the two sibling regression tests; this is the third file that shared the same `mode = server`-only app layout but was missed.
- Add an inline rationale comment so future readers see why the flag is required for this server-only viewset test.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Performance improvement
- [ ] Test improvement
- [ ] CI/CD or build system change

## Motivation and Context

The `Check / Cargo Check (tests)` job has been failing on the release-plz Release PR (#4618, `chore: release` for `reinhardt-web@v0.1.0-rc.30`) with:

```
error[E0433]: failed to resolve: could not find `client_url_resolvers` in `urls`
   --> tests/integration/tests/url_patterns_viewset_typed_integration.rs:140:1
    |
140 | #[reinhardt::routes]
    | ^^^^^^^^^^^^^^^^^^^^ could not find `client_url_resolvers` in `urls`
```

(See https://github.com/kent8192/reinhardt-web/actions/runs/26082097605/job/76686236773 for the failing run.)

The `snippets` app declared inside this test uses only `#[url_patterns(..., mode = server)]` (plus a `mode = ws` submodule), so the `#[url_patterns]` macro never emits a `client_url_resolvers` module. The `#[routes]` expansion, however, walks every installed app and references `crate::apps::<app>::urls::client_url_resolvers::__for_each_client_url_resolver!` unless told otherwise. The `no_client_resolvers` flag introduced in PR #4567 / Issue #4509 (`routes_registration.rs:932`) suppresses that reference for REST-only apps.

`faec0f9db6` already applied this exact fix to:

- `tests/integration/tests/url_patterns_viewset_collision_regression.rs:170`
- `tests/integration/tests/url_patterns_viewset_namespace_regression.rs:129`

…but missed this third sibling. Adding the flag here closes the gap and unblocks the Release PR.

## How Was This Tested

- [x] Read-only audit confirming the three sibling integration tests share the same app layout (server-only) and that the two patched ones use `#[reinhardt::routes(no_client_resolvers)]` while this one did not.
- [x] Match the failing error message to the macro path emitted by `crates/reinhardt-core/macros/src/routes_registration.rs:996-1001`.
- [ ] CI: `Check / Cargo Check (tests)` to confirm the E0433 is resolved (runs after this PR is opened).
- [ ] Local: `cargo check -p reinhardt-integration-tests --all-features --tests` (optional spot-check).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (1-line attribute change)
- [x] I have added tests that prove my fix is effective or that my feature works (the affected test itself is now compilable)
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Labels to Apply

- `bug`
- `ci-cd`
- `high`

## Related Issues

Fixes #4619.

Refs #4509 (the original `no_client_resolvers` flag introduction).
Refs #4589 (prior cleanup pass — `faec0f9db6`).

## Additional Context

The failure is blocking PR #4618 (`chore: release`) for `reinhardt-web@v0.1.0-rc.30`. Once this lands on `main`, release-plz will pick the fix up on its next sync; alternatively the existing release-plz PR can be re-run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to properly handle route macro expansion for test scenarios without client URL resolvers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->