### PR TITLE
fix(manouche): drop redundant ':' in success_url parser arm

### DIFF
--- a/crates/reinhardt-manouche/src/parser/form.rs
+++ b/crates/reinhardt-manouche/src/parser/form.rs
@@ -2184,8 +2184,7 @@ mod tests {
 		let result: Result<FormMacro> = syn::parse2(input);
 
 		// Assert
-		assert!(result.is_ok(), "parse failed: {:?}", result.err());
-		let form = result.unwrap();
+		let form = result.unwrap_or_else(|err| panic!("parse failed: {err}"));
 		assert!(form.success_url.is_some());
 	}
 
@@ -2211,8 +2210,7 @@ mod tests {
 		let result: Result<FormMacro> = syn::parse2(input);
 
 		// Assert
-		assert!(result.is_ok(), "parse failed: {:?}", result.err());
-		let form = result.unwrap();
+		let form = result.unwrap_or_else(|err| panic!("parse failed: {err}"));
 		assert!(form.success_url.is_some());
 		assert!(form.callbacks.on_error.is_some());
 	}

--- a/crates/reinhardt-manouche/src/parser/form.rs
+++ b/crates/reinhardt-manouche/src/parser/form.rs
@@ -115,7 +115,6 @@ impl Parse for FormMacro {
 					parse_optional_comma(input)?;
 				}
 				"success_url" => {
-					let _colon: Token![:] = input.parse()?;
 					form.success_url = Some(input.parse()?);
 					parse_optional_comma(input)?;
 				}
@@ -2162,6 +2161,60 @@ mod tests {
 		assert!(form.callbacks.on_success.is_some());
 		assert!(form.redirect_on_success.is_some());
 		assert_eq!(form.redirect_on_success.unwrap().value(), "/dashboard");
+	}
+
+	#[rstest]
+	fn test_parse_success_url_closure() {
+		// Arrange — minimal valid form that declares a closure-valued
+		// `success_url:` attribute. Regression coverage for #4604/#4611: the
+		// outer key/value loop already consumes the `:`, so the `success_url`
+		// arm must not consume it again.
+		let input = quote! {
+			name: VotingForm,
+			server_fn: submit,
+
+			success_url: |_form, _value| String::new(),
+
+			fields: {
+				choice: CharField { required },
+			},
+		};
+
+		// Act
+		let result: Result<FormMacro> = syn::parse2(input);
+
+		// Assert
+		assert!(result.is_ok(), "parse failed: {:?}", result.err());
+		let form = result.unwrap();
+		assert!(form.success_url.is_some());
+	}
+
+	#[rstest]
+	fn test_parse_success_url_followed_by_sibling() {
+		// Arrange — `success_url:` followed by a sibling attribute. This
+		// pins the original symptom of #4604/#4611: under the bug, the
+		// success_url arm consumed an extra `:`, causing the parser to bail
+		// at the sibling key with "expected `:`".
+		let input = quote! {
+			name: VotingForm,
+			server_fn: submit,
+
+			success_url: |_form, _value| "/x".to_string(),
+			on_error: |_err| {},
+
+			fields: {
+				choice: CharField { required },
+			},
+		};
+
+		// Act
+		let result: Result<FormMacro> = syn::parse2(input);
+
+		// Assert
+		assert!(result.is_ok(), "parse failed: {:?}", result.err());
+		let form = result.unwrap();
+		assert!(form.success_url.is_some());
+		assert!(form.callbacks.on_error.is_some());
 	}
 
 	// =====================================================


### PR DESCRIPTION
## Summary

This PR addresses:

- Drop the redundant `Token![:]` consumed inside the `"success_url"` arm of `crates/reinhardt-manouche/src/parser/form.rs` (line 118). The outer key/value loop at line 38 (`input.parse::<Token![:]>()?;`) already consumed the colon, so the arm was double-consuming and either bailing out on the lone attribute or failing at the next sibling key with `expected `:``. Every other arm in the same loop (lines 40-158) already follows the correct "outer loop owns the `:`" contract — `success_url` was the lone outlier.
- Add two `rstest` regression tests in the existing `#[cfg(test)] mod tests` block covering (a) the closure-only `success_url:` case and (b) `success_url:` followed by a sibling `on_error:` attribute (which is the exact symptom that surfaced the bug).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Framework users could not write the canonical form-macro syntax `form! { ..., success_url: |_form, _value| ... }` because the parser bailed at the next sibling attribute with `expected `:``. This blocked the `examples/examples-tutorial-basis/src/client/components/polls.rs` poll-detail page from using the documented `success_url:` syntax (it has been carrying a `use_effect`-based workaround since PR #4603).

Fixes #4604

Related to: #4611 (duplicate of #4604, closed via this PR)

## How Was This Tested?

- New `rstest` cases in `crates/reinhardt-manouche/src/parser/form.rs`:
  - `test_parse_success_url_closure` — parses `success_url: |_, _| String::new(),` and asserts `form.success_url.is_some()`.
  - `test_parse_success_url_followed_by_sibling` — parses `success_url: |_, _| "/x".to_string(), on_error: |_| {},` and asserts both fields populate. This pins the original regression.
- `cargo nextest run -p reinhardt-manouche --all-features` — **358 passed / 0 failed**.
- `cargo make fmt-check` — clean.
- `cargo make clippy-check` — clean.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable) — N/A, one-line parser fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable) — N/A
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4604
- Closes #4611 (duplicate of #4604)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `forms` - Form handling, validation, rendering

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature (blocks the documented `success_url:` syntax)

---

**Additional Context:**

This is PR1 of a coordinated 2-PR batch tracked in plan `4610-4613-4604-4605-spicy-graham.md`. PR2 (separate branch) will add the `use_router` / `navigate` runtime API and lift the form macro's `on_success` / `success_url` to outer scope so that `success_url: |_, _| links::poll_results(qid)` both compiles and captures `qid`. This PR is independent and can merge first.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a parsing issue in form handling where providing a `success_url:` attribute before other attributes could cause failures.

* **Tests**
  * Added regression tests covering `success_url:` as a closure-valued attribute and when followed by sibling attributes to ensure parsing succeeds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->