### PR TITLE
fix(reinhardt-pages): add lifted on_success_ref: callback for outer-scope capture

### DIFF
--- a/crates/reinhardt-manouche/src/core/form_node.rs
+++ b/crates/reinhardt-manouche/src/core/form_node.rs
@@ -817,6 +817,23 @@ pub struct FormCallbacks {
 	/// Receives the server_fn return value.
 	/// Signature: `|result: T| { ... }`
 	pub on_success: Option<ExprClosure>,
+	/// Lifted variant of `on_success` that captures outer-scope locals.
+	///
+	/// Unlike `on_success` (which is expanded inside the generated `fn submit()`
+	/// body and therefore cannot see enclosing-scope locals like `user_id`),
+	/// `on_success_ref` is expanded at the outer construction block. This lets
+	/// the user closure capture locals from the surrounding function scope.
+	///
+	/// The closure receives the server_fn return value by reference (`&T`)
+	/// instead of by move (`T`); for callbacks that must *consume* the value
+	/// (e.g., `set_current_user(Some(value))`), keep using `on_success`.
+	///
+	/// Both may be supplied together. Execution order: `on_success_ref` runs
+	/// first (receives `&value`), then `on_success` runs (receives `value` by
+	/// move).
+	///
+	/// Signature: `|form: &Self, result: &T| { ... }`
+	pub on_success_ref: Option<ExprClosure>,
 	/// Callback called when submission fails.
 	/// Signature: `|error: ServerFnError| { ... }`
 	pub on_error: Option<ExprClosure>,
@@ -837,6 +854,7 @@ impl FormCallbacks {
 	pub fn has_any(&self) -> bool {
 		self.on_submit.is_some()
 			|| self.on_success.is_some()
+			|| self.on_success_ref.is_some()
 			|| self.on_error.is_some()
 			|| self.on_loading.is_some()
 	}

--- a/crates/reinhardt-manouche/src/core/form_typed.rs
+++ b/crates/reinhardt-manouche/src/core/form_typed.rs
@@ -269,15 +269,20 @@ impl TypedFormState {
 /// | Callback | Signature | Description |
 /// |----------|-----------|-------------|
 /// | `on_submit` | `\|form: &Self\| { ... }` | Called before submission starts |
-/// | `on_success` | `\|result: T\| { ... }` | Called when server_fn returns successfully |
+/// | `on_success` | `\|result: T\| { ... }` | Called when server_fn returns successfully (consumes `T` by move) |
+/// | `on_success_ref` | `\|form: &Self, result: &T\| { ... }` | Lifted variant: captures outer-scope locals, receives `&T` by ref |
 /// | `on_error` | `\|error: ServerFnError\| { ... }` | Called when submission fails |
 /// | `on_loading` | `\|is_loading: bool\| { ... }` | Called when loading state changes |
 #[derive(Debug, Clone, Default)]
 pub struct TypedFormCallbacks {
 	/// Callback called before form submission starts.
 	pub on_submit: Option<ExprClosure>,
-	/// Callback called when submission succeeds.
+	/// Callback called when submission succeeds (receives `T` by move,
+	/// expanded inline inside `fn submit()` — cannot capture outer-scope locals).
 	pub on_success: Option<ExprClosure>,
+	/// Lifted variant of `on_success` (receives `&T` by ref, expanded at the
+	/// outer construction block — can capture enclosing-scope locals).
+	pub on_success_ref: Option<ExprClosure>,
 	/// Callback called when submission fails.
 	pub on_error: Option<ExprClosure>,
 	/// Callback called when loading state changes.
@@ -296,6 +301,7 @@ impl TypedFormCallbacks {
 	pub fn has_any(&self) -> bool {
 		self.on_submit.is_some()
 			|| self.on_success.is_some()
+			|| self.on_success_ref.is_some()
 			|| self.on_error.is_some()
 			|| self.on_loading.is_some()
 	}
@@ -308,6 +314,11 @@ impl TypedFormCallbacks {
 	/// Returns true if on_success callback is defined.
 	pub fn has_on_success(&self) -> bool {
 		self.on_success.is_some()
+	}
+
+	/// Returns true if on_success_ref callback is defined.
+	pub fn has_on_success_ref(&self) -> bool {
+		self.on_success_ref.is_some()
 	}
 
 	/// Returns true if on_error callback is defined.

--- a/crates/reinhardt-manouche/src/parser/form.rs
+++ b/crates/reinhardt-manouche/src/parser/form.rs
@@ -166,7 +166,7 @@ impl Parse for FormMacro {
 					return Err(syn::Error::new(
 						key.span(),
 						format!(
-							"Unknown form property: '{}'. Expected: name, action, server_fn, method, class, state, on_submit, on_success, on_success_ref, on_error, on_loading, watch, redirect_on_success, success_url, initial_loader, choices_loader, slots, fields, validators, strip_arguments",
+							"Unknown form property: '{}'. Expected: name, action, server_fn, method, class, state, on_submit, on_success, on_success_ref, on_error, on_loading, watch, redirect_on_success, success_url, initial_loader, choices_loader, slots, fields, validators, derived, strip_arguments",
 							key
 						),
 					));

--- a/crates/reinhardt-manouche/src/parser/form.rs
+++ b/crates/reinhardt-manouche/src/parser/form.rs
@@ -82,6 +82,14 @@ impl Parse for FormMacro {
 					form.callbacks.on_success = Some(closure);
 					parse_optional_comma(input)?;
 				}
+				"on_success_ref" => {
+					let closure: ExprClosure = input.parse()?;
+					if form.callbacks.span.is_none() {
+						form.callbacks.span = Some(key.span());
+					}
+					form.callbacks.on_success_ref = Some(closure);
+					parse_optional_comma(input)?;
+				}
 				"on_error" => {
 					let closure: ExprClosure = input.parse()?;
 					if form.callbacks.span.is_none() {
@@ -158,7 +166,7 @@ impl Parse for FormMacro {
 					return Err(syn::Error::new(
 						key.span(),
 						format!(
-							"Unknown form property: '{}'. Expected: name, action, server_fn, method, class, state, on_submit, on_success, on_error, on_loading, watch, redirect_on_success, initial_loader, choices_loader, slots, fields, validators, strip_arguments",
+							"Unknown form property: '{}'. Expected: name, action, server_fn, method, class, state, on_submit, on_success, on_success_ref, on_error, on_loading, watch, redirect_on_success, success_url, initial_loader, choices_loader, slots, fields, validators, strip_arguments",
 							key
 						),
 					));
@@ -1190,6 +1198,60 @@ mod tests {
 		assert!(form.callbacks.on_success.is_some());
 		assert!(form.callbacks.on_error.is_none());
 		assert!(form.callbacks.on_loading.is_none());
+	}
+
+	#[rstest]
+	fn test_parse_on_success_ref() {
+		// Arrange — issue #4624: the lifted `on_success_ref:` keyword.
+		let input = quote! {
+			name: OnSuccessRefForm,
+			server_fn: update_profile,
+
+			on_success_ref: |_form, _result| {
+				let _ = _result;
+			},
+
+			fields: {
+				data: CharField {},
+			},
+		};
+
+		// Act
+		let result: Result<FormMacro> = syn::parse2(input);
+
+		// Assert
+		assert!(result.is_ok(), "form! with on_success_ref should parse");
+		let form = result.unwrap();
+		assert!(form.callbacks.has_any());
+		assert!(form.callbacks.on_success_ref.is_some());
+		assert!(form.callbacks.on_success.is_none());
+	}
+
+	#[rstest]
+	fn test_parse_on_success_and_on_success_ref_coexist() {
+		// Arrange — issue #4624 contract: both callbacks may be supplied
+		// simultaneously. The validator does not reject the combination;
+		// codegen documents the order (ref-first, move-second).
+		let input = quote! {
+			name: DualCallbackForm,
+			server_fn: update_profile,
+
+			on_success_ref: |_form, _result| {},
+			on_success: |_result| {},
+
+			fields: {
+				data: CharField {},
+			},
+		};
+
+		// Act
+		let result: Result<FormMacro> = syn::parse2(input);
+
+		// Assert
+		assert!(result.is_ok(), "coexistence must parse");
+		let form = result.unwrap();
+		assert!(form.callbacks.on_success_ref.is_some());
+		assert!(form.callbacks.on_success.is_some());
 	}
 
 	#[rstest]

--- a/crates/reinhardt-manouche/src/validator/form.rs
+++ b/crates/reinhardt-manouche/src/validator/form.rs
@@ -247,6 +247,7 @@ fn transform_callbacks(callbacks: &FormCallbacks) -> Result<TypedFormCallbacks> 
 	Ok(TypedFormCallbacks {
 		on_submit: callbacks.on_submit.clone(),
 		on_success: callbacks.on_success.clone(),
+		on_success_ref: callbacks.on_success_ref.clone(),
 		on_error: callbacks.on_error.clone(),
 		on_loading: callbacks.on_loading.clone(),
 		span: callbacks.span,

--- a/crates/reinhardt-pages/ast/src/form_node.rs
+++ b/crates/reinhardt-pages/ast/src/form_node.rs
@@ -622,6 +622,23 @@ pub struct FormCallbacks {
 	/// Receives the server_fn return value.
 	/// Signature: `|result: T| { ... }`
 	pub on_success: Option<ExprClosure>,
+	/// Lifted variant of `on_success` that captures outer-scope locals.
+	///
+	/// Unlike `on_success` (which is expanded inside the generated `fn submit()`
+	/// body and therefore cannot see enclosing-scope locals like `user_id`),
+	/// `on_success_ref` is expanded at the outer construction block. This lets
+	/// the user closure capture locals from the surrounding function scope.
+	///
+	/// The closure receives the server_fn return value by reference (`&T`)
+	/// instead of by move (`T`); for callbacks that must *consume* the value
+	/// (e.g., `set_current_user(Some(value))`), keep using `on_success`.
+	///
+	/// Both may be supplied together. Execution order: `on_success_ref` runs
+	/// first (receives `&value`), then `on_success` runs (receives `value` by
+	/// move).
+	///
+	/// Signature: `|form: &Self, result: &T| { ... }`
+	pub on_success_ref: Option<ExprClosure>,
 	/// Callback called when submission fails.
 	/// Signature: `|error: ServerFnError| { ... }`
 	pub on_error: Option<ExprClosure>,
@@ -642,6 +659,7 @@ impl FormCallbacks {
 	pub fn has_any(&self) -> bool {
 		self.on_submit.is_some()
 			|| self.on_success.is_some()
+			|| self.on_success_ref.is_some()
 			|| self.on_error.is_some()
 			|| self.on_loading.is_some()
 	}

--- a/crates/reinhardt-pages/ast/src/form_parser.rs
+++ b/crates/reinhardt-pages/ast/src/form_parser.rs
@@ -155,7 +155,7 @@ impl Parse for FormMacro {
 					return Err(syn::Error::new(
 						key.span(),
 						format!(
-							"Unknown form property: '{}'. Expected: name, action, server_fn, method, class, state, on_submit, on_success, on_success_ref, on_error, on_loading, watch, redirect_on_success, initial_loader, choices_loader, slots, fields, validators, client_validators",
+							"Unknown form property: '{}'. Expected: name, action, server_fn, method, class, state, on_submit, on_success, on_success_ref, on_error, on_loading, watch, redirect_on_success, initial_loader, choices_loader, slots, fields, validators, client_validators, derived",
 							key
 						),
 					));

--- a/crates/reinhardt-pages/ast/src/form_parser.rs
+++ b/crates/reinhardt-pages/ast/src/form_parser.rs
@@ -78,6 +78,14 @@ impl Parse for FormMacro {
 					form.callbacks.on_success = Some(closure);
 					parse_optional_comma(input)?;
 				}
+				"on_success_ref" => {
+					let closure: ExprClosure = input.parse()?;
+					if form.callbacks.span.is_none() {
+						form.callbacks.span = Some(key.span());
+					}
+					form.callbacks.on_success_ref = Some(closure);
+					parse_optional_comma(input)?;
+				}
 				"on_error" => {
 					let closure: ExprClosure = input.parse()?;
 					if form.callbacks.span.is_none() {
@@ -147,7 +155,7 @@ impl Parse for FormMacro {
 					return Err(syn::Error::new(
 						key.span(),
 						format!(
-							"Unknown form property: '{}'. Expected: name, action, server_fn, method, class, state, on_submit, on_success, on_error, on_loading, watch, redirect_on_success, initial_loader, choices_loader, slots, fields, validators, client_validators",
+							"Unknown form property: '{}'. Expected: name, action, server_fn, method, class, state, on_submit, on_success, on_success_ref, on_error, on_loading, watch, redirect_on_success, initial_loader, choices_loader, slots, fields, validators, client_validators",
 							key
 						),
 					));

--- a/crates/reinhardt-pages/ast/src/form_typed.rs
+++ b/crates/reinhardt-pages/ast/src/form_typed.rs
@@ -252,15 +252,20 @@ impl TypedFormState {
 /// | Callback | Signature | Description |
 /// |----------|-----------|-------------|
 /// | `on_submit` | `\|form: &Self\| { ... }` | Called before submission starts |
-/// | `on_success` | `\|result: T\| { ... }` | Called when server_fn returns successfully |
+/// | `on_success` | `\|result: T\| { ... }` | Called when server_fn returns successfully (consumes `T` by move) |
+/// | `on_success_ref` | `\|form: &Self, result: &T\| { ... }` | Lifted variant: captures outer-scope locals, receives `&T` by ref |
 /// | `on_error` | `\|error: ServerFnError\| { ... }` | Called when submission fails |
 /// | `on_loading` | `\|is_loading: bool\| { ... }` | Called when loading state changes |
 #[derive(Debug, Clone, Default)]
 pub struct TypedFormCallbacks {
 	/// Callback called before form submission starts.
 	pub on_submit: Option<ExprClosure>,
-	/// Callback called when submission succeeds.
+	/// Callback called when submission succeeds (receives `T` by move,
+	/// expanded inline inside `fn submit()` — cannot capture outer-scope locals).
 	pub on_success: Option<ExprClosure>,
+	/// Lifted variant of `on_success` (receives `&T` by ref, expanded at the
+	/// outer construction block — can capture enclosing-scope locals).
+	pub on_success_ref: Option<ExprClosure>,
 	/// Callback called when submission fails.
 	pub on_error: Option<ExprClosure>,
 	/// Callback called when loading state changes.
@@ -279,6 +284,7 @@ impl TypedFormCallbacks {
 	pub fn has_any(&self) -> bool {
 		self.on_submit.is_some()
 			|| self.on_success.is_some()
+			|| self.on_success_ref.is_some()
 			|| self.on_error.is_some()
 			|| self.on_loading.is_some()
 	}
@@ -291,6 +297,11 @@ impl TypedFormCallbacks {
 	/// Returns true if on_success callback is defined.
 	pub fn has_on_success(&self) -> bool {
 		self.on_success.is_some()
+	}
+
+	/// Returns true if on_success_ref callback is defined.
+	pub fn has_on_success_ref(&self) -> bool {
+		self.on_success_ref.is_some()
 	}
 
 	/// Returns true if on_error callback is defined.

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -862,18 +862,26 @@ fn generate_on_success_ref_artifacts(
 					}
 					let __user_on_success_ref = __coerce_form(#closure);
 
-					// Compile-time type assertion (#4624): forces
-					// `__T` == server_fn's Ok type. See the macro
-					// doc comment on `generate_on_success_ref_artifacts`
-					// for why this is sound.
+					// Compile-time type assertion (#4624). The dead-code
+					// branch emitted by `#type_check_dead_code` calls the
+					// server_fn and feeds its Ok value into the user
+					// closure, so the compiler unifies `__T` with the
+					// server_fn's Ok type. If the user annotates the
+					// closure parameter with a wrong type, compilation
+					// fails AT the annotation site — never here at the
+					// runtime downcast. See the doc comment on
+					// `generate_on_success_ref_artifacts` for the full
+					// soundness argument.
 					#type_check_dead_code
 
 					let __value_ref = __erased.downcast_ref().expect(
-						"on_success_ref: server_fn Ok value type does not match \
-						 the closure parameter type — unreachable in user-facing \
-						 builds because `#type_check_dead_code` makes any \
-						 mismatch a compile error; this `expect` is a defensive \
-						 macro-internal invariant",
+						"on_success_ref: internal invariant violated — \
+						 server_fn Ok value did not downcast to the user \
+						 closure's parameter type. This branch should be \
+						 unreachable because the macro emits a compile-time \
+						 type assertion that forces them to match; \
+						 reaching it indicates a macro implementation bug, \
+						 not a user error",
 					);
 					let _ = __user_on_success_ref(__form, __value_ref);
 				},

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -135,6 +135,16 @@ pub(super) fn generate(macro_ast: &TypedFormMacro) -> TokenStream {
 		outer_setup: watch_outer_setup,
 	} = generate_watch_artifacts(&macro_ast.watch, pages_crate, struct_name);
 
+	// Generate on_success_ref artifacts (#4624). When the user has not
+	// supplied `on_success_ref:`, all four TokenStreams are empty, so the
+	// macro output is unchanged for forms that don't use this feature.
+	let OnSuccessRefArtifacts {
+		field_decl: on_success_ref_field_decl,
+		field_default_init: on_success_ref_field_default_init,
+		setter_method: on_success_ref_setter_method,
+		outer_setup: on_success_ref_outer_setup,
+	} = generate_on_success_ref_artifacts(&macro_ast.callbacks, pages_crate, struct_name);
+
 	// Generate derived methods
 	let derived_methods = generate_derived_methods(&macro_ast.derived, pages_crate);
 
@@ -165,6 +175,7 @@ pub(super) fn generate(macro_ast: &TypedFormMacro) -> TokenStream {
 				#field_decls
 				#state_decls
 				#watch_field_decls
+				#on_success_ref_field_decl
 			}
 
 			impl #struct_name {
@@ -173,6 +184,7 @@ pub(super) fn generate(macro_ast: &TypedFormMacro) -> TokenStream {
 						#field_inits
 						#state_inits
 						#watch_field_default_inits
+						#on_success_ref_field_default_init
 					}
 				}
 
@@ -180,6 +192,7 @@ pub(super) fn generate(macro_ast: &TypedFormMacro) -> TokenStream {
 				#state_accessors
 				#watch_methods
 				#watch_setter_methods
+				#on_success_ref_setter_method
 				#derived_methods
 				#metadata_fn
 				#validate_method
@@ -191,11 +204,13 @@ pub(super) fn generate(macro_ast: &TypedFormMacro) -> TokenStream {
 
 			// Build the form instance and bind user-supplied watch handlers in
 			// the outer scope, where enclosing-scope locals are visible. This is
-			// what makes `watch:` handlers behave as real closures (issue #4414)
-			// and what makes `initial: <expr>` capture outer locals (issue #4420).
+			// what makes `watch:` handlers behave as real closures (issue #4414),
+			// what makes `initial: <expr>` capture outer locals (issue #4420),
+			// and what makes `on_success_ref:` capture outer locals (issue #4624).
 			let mut __reinhardt_form = #struct_name::new();
 			#initial_outer_setup
 			#watch_outer_setup
+			#on_success_ref_outer_setup
 			__reinhardt_form
 		}
 	}
@@ -644,6 +659,158 @@ fn generate_watch_artifacts(
 	}
 }
 
+/// Artifacts produced for the `on_success_ref:` callback (issue #4624).
+///
+/// `on_success_ref:` is the "lifted" sibling of `on_success:` — its user
+/// closure is expanded at the outer construction block (same lexical scope
+/// as the `form!` macro invocation), so it can capture enclosing-scope
+/// locals (e.g. a `user_id` bound earlier in the surrounding function).
+/// `on_success:` itself stays inline in `fn submit()` because it consumes
+/// the server_fn return value `T` by move, and three in-tree callers rely
+/// on that — flipping the signature to `&T` is a SemVer break deferred to
+/// `develop/0.2.0`.
+///
+/// The trick that makes this work without naming `T` anywhere in the
+/// macro output is the same `__coerce`-style identity-fn pattern used by
+/// `WatchArtifacts`, extended to three generic parameters so the user
+/// closure's `&T` value parameter can be inferred without the user having
+/// to annotate it. At the `Arc<dyn Fn(&Form, &dyn Any)>` storage boundary
+/// the inferred `T` is then type-erased; the submit-site downcast is
+/// infallible by macro construction because both sides of the type
+/// identity are produced from the same closure literal.
+struct OnSuccessRefArtifacts {
+	/// Field declaration to splice into `struct FormName { ... }`. Empty
+	/// when the user did not supply `on_success_ref:`.
+	field_decl: TokenStream,
+	/// Default initializer used in `FormName::new()`. Empty when the user
+	/// did not supply `on_success_ref:`.
+	field_default_init: TokenStream,
+	/// Private setter method on `FormName` used to bind the real handler
+	/// after `new()` returns. Empty when the user did not supply
+	/// `on_success_ref:`.
+	setter_method: TokenStream,
+	/// Code emitted in the outer block, after `let mut __reinhardt_form = FormName::new();`.
+	/// This is where the user's closure literal appears lexically, so it
+	/// can capture enclosing-scope locals.
+	outer_setup: TokenStream,
+}
+
+/// Generates the artifacts needed to wire up `on_success_ref:`.
+///
+/// When the user has not supplied `on_success_ref:`, every TokenStream in
+/// the returned artifacts is empty — the resulting macro output is
+/// indistinguishable from a form that doesn't use the feature.
+///
+/// When supplied, this produces:
+///
+/// 1. A private struct field
+///    `__on_success_ref_handler: Arc<dyn Fn(&FormName, &dyn Any)>` storing
+///    a type-erased handler.
+/// 2. A default initializer in `FormName::new()` returning a no-op closure
+///    so `new()` keeps its zero-argument signature.
+/// 3. A private setter `__set_on_success_ref_handler` used internally.
+/// 4. Outer-scope setup code that captures the user's closure literal
+///    (where enclosing-scope locals are visible), funnels it through a
+///    `__coerce_form<__F, __T, __R>` identity fn to fix the parameter
+///    shape `(&FormName, &__T) -> __R`, wraps it in an `Arc`, and calls
+///    the setter on the form instance.
+fn generate_on_success_ref_artifacts(
+	callbacks: &TypedFormCallbacks,
+	pages_crate: &TokenStream,
+	struct_name: &syn::Ident,
+) -> OnSuccessRefArtifacts {
+	let _ = pages_crate; // reserved for future cross-crate refs; quiet warnings now.
+	let empty = OnSuccessRefArtifacts {
+		field_decl: quote! {},
+		field_default_init: quote! {},
+		setter_method: quote! {},
+		outer_setup: quote! {},
+	};
+
+	let Some(closure) = &callbacks.on_success_ref else {
+		return empty;
+	};
+
+	// Stored handler type — type-erased so the form struct stays nameable.
+	// The `&dyn Any` parameter is what lets the macro avoid spelling `T`:
+	// `T` is inferred from the user closure's second parameter via the
+	// `__coerce_form` identity fn below, and immediately erased here.
+	let handler_ty = quote! {
+		::std::sync::Arc<
+			dyn ::core::ops::Fn(&#struct_name, &dyn ::core::any::Any),
+		>
+	};
+
+	let field_decl = quote! {
+		__on_success_ref_handler: #handler_ty,
+	};
+
+	// Default no-op handler used before the real one is bound. Calling it
+	// is harmless: it ignores both the form ref and the erased value.
+	let field_default_init = quote! {
+		__on_success_ref_handler: ::std::sync::Arc::new(
+			|_: &#struct_name, _: &dyn ::core::any::Any| {},
+		),
+	};
+
+	let setter_method = quote! {
+		#[doc(hidden)]
+		fn __set_on_success_ref_handler(&mut self, __handler: #handler_ty) {
+			self.__on_success_ref_handler = __handler;
+		}
+	};
+
+	// Outer-scope capture. The user's `#closure` is expanded *here*,
+	// which is the same lexical scope as the `form!` macro invocation,
+	// so it can capture locals from the enclosing function (issue #4624).
+	//
+	// The closure is funneled through `__coerce_form` whose `where`-bound
+	// pins its parameter shape to `(&#struct_name, &__T) -> __R`. This
+	// gives the user's `|form, value| { ... }` enough type information
+	// to infer the value type from the body, without the user having to
+	// write `|form: &MyForm, value: &MyT|` annotations. `__T: 'static`
+	// is required because `Any::downcast_ref` only works on `'static`
+	// types — server_fn return types are owned types and naturally
+	// satisfy this.
+	//
+	// The downcast at the call boundary is infallible by macro
+	// construction: at the submit site, the value passed via
+	// `&value as &dyn Any` has the exact concrete type the server_fn
+	// returns in its Ok arm, and that type is the same `__T` inferred
+	// from this closure literal. A mismatch would indicate a bug in the
+	// macro itself, not in user code, so `expect` is appropriate.
+	let outer_setup = quote! {
+		{
+			let __wrapped: #handler_ty = ::std::sync::Arc::new(
+				move |__form: &#struct_name, __erased: &dyn ::core::any::Any| {
+					fn __coerce_form<__F, __T, __R>(__f: __F) -> __F
+					where
+						__F: ::core::ops::Fn(&#struct_name, &__T) -> __R,
+						__T: 'static,
+					{
+						__f
+					}
+					let __user_on_success_ref = __coerce_form(#closure);
+					let __value_ref = __erased.downcast_ref().expect(
+						"on_success_ref: server_fn Ok value type does not match \
+						 the closure parameter type — this is a bug in \
+						 reinhardt-pages-macros, not in user code",
+					);
+					let _ = __user_on_success_ref(__form, __value_ref);
+				},
+			);
+			__reinhardt_form.__set_on_success_ref_handler(__wrapped);
+		}
+	};
+
+	OnSuccessRefArtifacts {
+		field_decl,
+		field_default_init,
+		setter_method,
+		outer_setup,
+	}
+}
+
 /// Generates derived methods that compute derived values.
 ///
 /// Each derived item becomes a method on the form struct that evaluates the closure
@@ -1014,6 +1181,30 @@ fn generate_onsubmit_handler(macro_ast: &TypedFormMacro, pages_crate: &TokenStre
 				quote! {}
 			};
 
+			// Generate on_success_ref clones + invocation if present (#4624).
+			// The `spawn_task` async block captures by move, so the lifted
+			// `Arc<dyn Fn(&Self, &dyn Any)>` handler and a form-instance
+			// clone must be hoisted into the surrounding scope first.
+			// `Form::clone()` is cheap — every field is an `Arc` or `Signal`.
+			let on_success_ref_outer_clones = if callbacks.on_success_ref.is_some() {
+				quote! {
+					let __on_success_ref_handler_clone = self.__on_success_ref_handler.clone();
+					let __form_clone_for_on_success_ref = self.clone();
+				}
+			} else {
+				quote! {}
+			};
+			let on_success_ref_invocation = if callbacks.on_success_ref.is_some() {
+				quote! {
+					__on_success_ref_handler_clone(
+						&__form_clone_for_on_success_ref,
+						&_value as &dyn ::core::any::Any,
+					);
+				}
+			} else {
+				quote! {}
+			};
+
 			// Generate on_error callback if present
 			let on_error_code = if let Some(callback) = &callbacks.on_error {
 				quote! { (#callback)(e.clone()); }
@@ -1054,6 +1245,11 @@ fn generate_onsubmit_handler(macro_ast: &TypedFormMacro, pages_crate: &TokenStre
 				// Clone state signals for onsubmit handler
 				#state_signal_clones
 
+				// Clone the lifted on_success_ref Arc + a form-instance ref
+				// for the async block (#4624). Both must live in the outer
+				// scope so `async move` can capture them.
+				#on_success_ref_outer_clones
+
 				let form_element = PageElement::new("form")
 					.attr("id", #form_id_str)
 					.attr("action", #action_str)
@@ -1088,6 +1284,10 @@ fn generate_onsubmit_handler(macro_ast: &TypedFormMacro, pages_crate: &TokenStre
 								#pages_crate::spawn::spawn_task(async move {
 									match #server_fn_call {
 										Ok(_value) => {
+											// Order matters: on_success_ref
+											// (borrows) runs before on_success
+											// (may consume by move). #4624.
+											#on_success_ref_invocation
 											#on_success_code
 											#redirect_code
 										}
@@ -1733,6 +1933,28 @@ fn generate_submit_method(macro_ast: &TypedFormMacro, pages_crate: &TokenStream)
 			let on_error_code = generate_on_error_callback(callbacks, state);
 			let redirect_code = generate_redirect_code(redirect);
 
+			// Lifted `on_success_ref:` invocation (issue #4624). Pulls the
+			// stored `Arc<dyn Fn(&Self, &dyn Any)>` handler installed by
+			// the outer-scope setup and invokes it with `&value as &dyn Any`.
+			// Emitted only when the user supplied `on_success_ref:` — when
+			// they did not, the field itself is absent from the form
+			// struct (gated symmetrically in `generate_on_success_ref_artifacts`)
+			// so the invocation must be gated here too. Ordering: this
+			// runs *before* `#on_success_code` so that the by-ref handler
+			// observes `value` first and the by-move `on_success` consumes
+			// it second (ref-first, move-second contract documented on
+			// `TypedFormCallbacks::on_success_ref`).
+			let on_success_ref_invocation = if callbacks.on_success_ref.is_some() {
+				quote! {
+					{
+						let __handler = self.__on_success_ref_handler.clone();
+						__handler(self, &value as &dyn ::core::any::Any);
+					}
+				}
+			} else {
+				quote! {}
+			};
+
 			quote! {
 				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
 				pub async fn submit(&self) -> Result<(), #pages_crate::ServerFnError> {
@@ -1751,6 +1973,12 @@ fn generate_submit_method(macro_ast: &TypedFormMacro, pages_crate: &TokenStream)
 					// Handle result with callbacks and redirect
 					match result {
 						Ok(value) => {
+							// Order matters: `on_success_ref` (lifted,
+							// borrows `value` via `&dyn Any`) runs before
+							// `on_success` (inline, may consume `value`
+							// by move). See #4624 ordering contract on
+							// `TypedFormCallbacks::on_success_ref`.
+							#on_success_ref_invocation
 							#on_success_code
 							#redirect_code
 							Ok(())
@@ -2368,6 +2596,77 @@ mod tests {
 		assert!(output_str.contains("my-form"));
 		assert!(output_str.contains("email-input"));
 		assert!(output_str.contains("field-wrapper"));
+	}
+
+	#[rstest::rstest]
+	fn test_generate_on_success_ref_lift() {
+		// Arrange — issue #4624. When `on_success_ref:` is supplied, the
+		// macro must emit the lifted-handler scaffold: a private struct
+		// field, its setter, the `__coerce_form` 3-param identity fn that
+		// pins the user closure's `(&Self, &__T)` shape, and the
+		// outer-scope setup that installs the Arc.
+		let input = quote! {
+			name: OnSuccessRefForm,
+			server_fn: update_profile,
+
+			on_success_ref: |_form, _value| {
+				let _ = _value;
+			},
+
+			fields: {
+				data: CharField {},
+			},
+		};
+
+		// Act
+		let output = parse_validate_generate(input);
+		let output_str = output.to_string();
+
+		// Assert — all four artifact splice points are present.
+		assert!(
+			output_str.contains("__on_success_ref_handler"),
+			"missing field declaration"
+		);
+		assert!(
+			output_str.contains("__set_on_success_ref_handler"),
+			"missing setter method"
+		);
+		assert!(
+			output_str.contains("__coerce_form"),
+			"missing identity-fn type-coercion trick (E0282 will return)"
+		);
+		assert!(
+			output_str.contains("downcast_ref"),
+			"missing infallible type-erasure downcast"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_generate_omits_on_success_ref_scaffold_when_unused() {
+		// Arrange — a form without `on_success_ref:` must NOT pay the
+		// scaffold cost: no field, no setter, no Arc allocation in `new()`.
+		let input = quote! {
+			name: NoRefForm,
+			server_fn: update_profile,
+
+			fields: {
+				data: CharField {},
+			},
+		};
+
+		// Act
+		let output = parse_validate_generate(input);
+		let output_str = output.to_string();
+
+		// Assert — the scaffold tokens are absent when the feature is unused.
+		assert!(
+			!output_str.contains("__on_success_ref_handler"),
+			"unused on_success_ref must not allocate a struct field"
+		);
+		assert!(
+			!output_str.contains("__set_on_success_ref_handler"),
+			"unused on_success_ref must not generate a setter"
+		);
 	}
 
 	#[rstest::rstest]

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -138,12 +138,14 @@ pub(super) fn generate(macro_ast: &TypedFormMacro) -> TokenStream {
 	// Generate on_success_ref artifacts (#4624). When the user has not
 	// supplied `on_success_ref:`, all four TokenStreams are empty, so the
 	// macro output is unchanged for forms that don't use this feature.
+	// Takes the full `macro_ast` so the outer-scope wrapper can emit a
+	// dead-code type-safety guard against the server_fn signature.
 	let OnSuccessRefArtifacts {
 		field_decl: on_success_ref_field_decl,
 		field_default_init: on_success_ref_field_default_init,
 		setter_method: on_success_ref_setter_method,
 		outer_setup: on_success_ref_outer_setup,
-	} = generate_on_success_ref_artifacts(&macro_ast.callbacks, pages_crate, struct_name);
+	} = generate_on_success_ref_artifacts(macro_ast, pages_crate);
 
 	// Generate derived methods
 	let derived_methods = generate_derived_methods(&macro_ast.derived, pages_crate);
@@ -715,11 +717,13 @@ struct OnSuccessRefArtifacts {
 ///    shape `(&FormName, &__T) -> __R`, wraps it in an `Arc`, and calls
 ///    the setter on the form instance.
 fn generate_on_success_ref_artifacts(
-	callbacks: &TypedFormCallbacks,
+	macro_ast: &TypedFormMacro,
 	pages_crate: &TokenStream,
-	struct_name: &syn::Ident,
 ) -> OnSuccessRefArtifacts {
 	let _ = pages_crate; // reserved for future cross-crate refs; quiet warnings now.
+	let callbacks = &macro_ast.callbacks;
+	let struct_name = &macro_ast.name;
+
 	let empty = OnSuccessRefArtifacts {
 		field_decl: quote! {},
 		field_default_init: quote! {},
@@ -729,6 +733,69 @@ fn generate_on_success_ref_artifacts(
 
 	let Some(closure) = &callbacks.on_success_ref else {
 		return empty;
+	};
+
+	// Compile-time type-safety guard (#4624). Forces the user closure's
+	// inferred `__T` (the second-parameter type, e.g. `&Wrong` in
+	// `on_success_ref: |_, _v: &Wrong| { ... }`) to equal the server_fn's
+	// Ok arm. Implemented as a dead-code branch that calls the server_fn
+	// (via `::core::unreachable!()` for every argument, which never-coerces
+	// to any required type) and feeds the extracted Ok value into the
+	// user closure. If the types disagree, compilation fails AT the user
+	// closure's parameter type — not at runtime in `downcast_ref().expect()`.
+	//
+	// Skipped for non-ServerFn actions: a URL form has no Future to extract
+	// `T` from, and `on_success_ref` would never actually fire there.
+	let type_check_dead_code = match &macro_ast.action {
+		TypedFormAction::ServerFn(server_fn_ident) => {
+			// Replicate `generate_submit_method`'s argument count
+			// computation (codegen.rs ~L1698-1725) so that the dead-code
+			// call below matches whatever signature the runtime call uses.
+			let all_fields = collect_all_fields(&macro_ast.fields);
+			let field_count = all_fields.len();
+			let has_explicit_csrf_field =
+				all_fields.iter().any(|f| f.name == "csrf_token");
+			let needs_csrf = !matches!(macro_ast.method, FormMethod::Get);
+			let strip_arg_count = macro_ast.strip_arguments.len();
+			let extra_count = if strip_arg_count > 0 {
+				strip_arg_count
+			} else if needs_csrf && !has_explicit_csrf_field {
+				1usize
+			} else {
+				0usize
+			};
+			let total_arg_count = field_count + extra_count;
+			let probe_args = (0..total_arg_count)
+				.map(|_| quote! { ::core::unreachable!() })
+				.collect::<Vec<_>>();
+
+			quote! {
+				#[allow(unreachable_code, dead_code, unused_variables, clippy::diverging_sub_expression)]
+				if false {
+					// Extract the `Ok` type `T` from the server_fn's
+					// `Future<Output = Result<T, _>>`. Generic over the
+					// future / Ok / Err types so it works regardless of
+					// the user's concrete server_fn signature.
+					fn __on_success_ref_extract_ok<__Fut, __T, __E>(_: __Fut) -> __T
+					where
+						__Fut: ::core::future::Future<
+							Output = ::core::result::Result<__T, __E>,
+						>,
+					{
+						::core::unreachable!()
+					}
+					let __probe_future = #server_fn_ident(#(#probe_args),*);
+					let __probe_ok = __on_success_ref_extract_ok(__probe_future);
+					// This call forces `__user_on_success_ref`'s second
+					// parameter type to equal `__probe_ok`'s type, which
+					// equals the server_fn's `Ok` arm. A mismatch with
+					// the user closure's annotated/inferred `__T` fails
+					// here at compile time.
+					let _ = __user_on_success_ref(__form, &__probe_ok);
+				}
+			}
+		}
+		_ => quote! {},
 	};
 
 	// Stored handler type — type-erased so the form struct stays nameable.
@@ -773,12 +840,15 @@ fn generate_on_success_ref_artifacts(
 	// types — server_fn return types are owned types and naturally
 	// satisfy this.
 	//
-	// The downcast at the call boundary is infallible by macro
-	// construction: at the submit site, the value passed via
-	// `&value as &dyn Any` has the exact concrete type the server_fn
-	// returns in its Ok arm, and that type is the same `__T` inferred
-	// from this closure literal. A mismatch would indicate a bug in the
-	// macro itself, not in user code, so `expect` is appropriate.
+	// Type safety is enforced by `#type_check_dead_code`: a dead-code
+	// branch that calls the server_fn (via `unreachable!()` args) and
+	// feeds the extracted Ok value into the user closure, forcing
+	// Rust's type-checker to unify the closure's `__T` with the
+	// server_fn's Ok arm at COMPILE TIME. With that guard in place,
+	// the `downcast_ref().expect(...)` below is provably unreachable
+	// in user-facing builds — it remains as a defensive runtime
+	// invariant check in case the macro's own scaffolding ever
+	// regresses, not as a fallibility ever surfaced to users.
 	let outer_setup = quote! {
 		{
 			let __wrapped: #handler_ty = ::std::sync::Arc::new(
@@ -791,10 +861,19 @@ fn generate_on_success_ref_artifacts(
 						__f
 					}
 					let __user_on_success_ref = __coerce_form(#closure);
+
+					// Compile-time type assertion (#4624): forces
+					// `__T` == server_fn's Ok type. See the macro
+					// doc comment on `generate_on_success_ref_artifacts`
+					// for why this is sound.
+					#type_check_dead_code
+
 					let __value_ref = __erased.downcast_ref().expect(
 						"on_success_ref: server_fn Ok value type does not match \
-						 the closure parameter type — this is a bug in \
-						 reinhardt-pages-macros, not in user code",
+						 the closure parameter type — unreachable in user-facing \
+						 builds because `#type_check_dead_code` makes any \
+						 mismatch a compile error; this `expect` is a defensive \
+						 macro-internal invariant",
 					);
 					let _ = __user_on_success_ref(__form, __value_ref);
 				},
@@ -2638,6 +2717,89 @@ mod tests {
 		assert!(
 			output_str.contains("downcast_ref"),
 			"missing infallible type-erasure downcast"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_generate_on_success_ref_type_safety_guard() {
+		// Arrange — issue #4624 type-safety regression caught by review.
+		// The runtime `downcast_ref().expect()` is only sound if the
+		// macro *also* emits a compile-time check that the user closure's
+		// `__T` matches the server_fn's Ok type. The guard takes the form
+		// of a dead-code branch that calls the server_fn (with
+		// `unreachable!()` for every arg) and feeds the extracted Ok
+		// value into the user closure.
+		let input = quote! {
+			name: TypeSafeRefForm,
+			server_fn: update_profile,
+
+			on_success_ref: |_form, _value| {
+				let _ = _value;
+			},
+
+			fields: {
+				data: CharField {},
+			},
+		};
+
+		// Act
+		let output = parse_validate_generate(input);
+		let output_str = output.to_string();
+
+		// Assert — the dead-code typecheck infrastructure must appear:
+		// the Future-Ok extractor, the never-typed arg placeholders, and
+		// the user-closure invocation that pins `__T` to the server_fn
+		// Ok arm.
+		assert!(
+			output_str.contains("__on_success_ref_extract_ok"),
+			"missing dead-code Future<Output=Result<T,E>> Ok extractor"
+		);
+		assert!(
+			output_str.contains("unreachable"),
+			"missing never-typed arg placeholders for server_fn probe call"
+		);
+		assert!(
+			output_str.contains("__probe_ok"),
+			"missing probe-value binding that forces __T = server_fn Ok type"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_generate_on_success_ref_no_type_guard_for_url_action() {
+		// Arrange — URL action forms have no server_fn to extract a
+		// return type from, and `on_success_ref` would never actually
+		// fire there. The type-safety guard must be omitted in that case
+		// (otherwise we'd emit a dead-code call to a nonexistent
+		// `server_fn_ident`).
+		//
+		// The lifted handler scaffold is still emitted (parser/codegen
+		// don't reject the combination — it's a no-op at runtime), but
+		// without the compile-time probe.
+		let input = quote! {
+			name: UrlActionRefForm,
+			action: "/api/submit",
+
+			on_success_ref: |_form, _value| {
+				let _ = _value;
+			},
+
+			fields: {
+				data: CharField {},
+			},
+		};
+
+		// Act
+		let output = parse_validate_generate(input);
+		let output_str = output.to_string();
+
+		// Assert — scaffold present, but typecheck infrastructure absent.
+		assert!(
+			output_str.contains("__on_success_ref_handler"),
+			"scaffold should still be emitted for URL forms"
+		);
+		assert!(
+			!output_str.contains("__on_success_ref_extract_ok"),
+			"URL form must not emit the Future Ok extractor (no server_fn to probe)"
 		);
 	}
 

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -753,8 +753,7 @@ fn generate_on_success_ref_artifacts(
 			// call below matches whatever signature the runtime call uses.
 			let all_fields = collect_all_fields(&macro_ast.fields);
 			let field_count = all_fields.len();
-			let has_explicit_csrf_field =
-				all_fields.iter().any(|f| f.name == "csrf_token");
+			let has_explicit_csrf_field = all_fields.iter().any(|f| f.name == "csrf_token");
 			let needs_csrf = !matches!(macro_ast.method, FormMethod::Get);
 			let strip_arg_count = macro_ast.strip_arguments.len();
 			let extra_count = if strip_arg_count > 0 {

--- a/crates/reinhardt-pages/macros/src/form/validator.rs
+++ b/crates/reinhardt-pages/macros/src/form/validator.rs
@@ -330,6 +330,7 @@ fn transform_callbacks(callbacks: &FormCallbacks) -> Result<TypedFormCallbacks> 
 	Ok(TypedFormCallbacks {
 		on_submit: callbacks.on_submit.clone(),
 		on_success: callbacks.on_success.clone(),
+		on_success_ref: callbacks.on_success_ref.clone(),
 		on_error: callbacks.on_error.clone(),
 		on_loading: callbacks.on_loading.clone(),
 		span: callbacks.span,

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -1746,8 +1746,24 @@ pub fn head(input: TokenStream) -> TokenStream {
 /// |----------|-----------|-------------|
 /// | `on_submit` | `\|&Form\|` | Before submission starts |
 /// | `on_loading` | `\|bool\|` | When loading state changes |
-/// | `on_success` | `\|Result\|` | After successful submission |
+/// | `on_success` | `\|T\|` | After successful submission (consumes `T` by move) |
+/// | `on_success_ref` | `\|&Form, &T\|` | After successful submission (borrows `&T`, can capture outer-scope locals) |
 /// | `on_error` | `\|ServerFnError\|` | After submission error |
+///
+/// ### Choosing between `on_success` and `on_success_ref`
+///
+/// Use `on_success_ref:` when the callback needs to reference locals
+/// from the surrounding function — the closure is expanded at the
+/// `form!` call site rather than inside the generated `submit()` body,
+/// so enclosing-scope captures work naturally (issue #4624).
+///
+/// Use `on_success:` when the callback needs to *consume* the server_fn
+/// return value (`T`) by move — for example to call a function that
+/// takes `T` by value.
+///
+/// Both may be supplied together; `on_success_ref` runs first
+/// (receives `&value`), then `on_success` runs (receives `value` by
+/// move).
 ///
 /// ### Example
 ///
@@ -1772,6 +1788,25 @@ pub fn head(input: TokenStream) -> TokenStream {
 ///     fields: {
 ///         message: TextField { required },
 ///     },
+/// };
+/// ```
+///
+/// ### Example: outer-scope capture with `on_success_ref`
+///
+/// ```ignore
+/// let user_id: i64 = 42;
+/// let form = form! {
+///     name: ProfileForm,
+///     server_fn: update_profile,
+///
+///     // The closure can reference `user_id` from the surrounding
+///     // function. `on_success: |_v| { let _ = user_id; }` would
+///     // fail with E0434.
+///     on_success_ref: |_form, _updated: &ProfileUpdate| {
+///         navigate(&format!("/users/{user_id}/"), NavigationType::Push);
+///     },
+///
+///     fields: { /* ... */ },
 /// };
 /// ```
 ///

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -1744,11 +1744,11 @@ pub fn head(input: TokenStream) -> TokenStream {
 ///
 /// | Callback | Signature | When Called |
 /// |----------|-----------|-------------|
-/// | `on_submit` | `\|&Form\|` | Before submission starts |
-/// | `on_loading` | `\|bool\|` | When loading state changes |
-/// | `on_success` | `\|T\|` | After successful submission (consumes `T` by move) |
-/// | `on_success_ref` | `\|&Form, &T\|` | After successful submission (borrows `&T`, can capture outer-scope locals) |
-/// | `on_error` | `\|ServerFnError\|` | After submission error |
+/// | `on_submit` | `\|form: &Self\|` | Before submission starts |
+/// | `on_loading` | `\|loading: bool\|` | When loading state changes |
+/// | `on_success` | `\|result: T\|` | After successful submission (consumes `T` by move) |
+/// | `on_success_ref` | `\|form: &Self, result: &T\|` | After successful submission (borrows `&T`, can capture outer-scope locals) |
+/// | `on_error` | `\|err: ServerFnError\|` | After submission error |
 ///
 /// ### Choosing between `on_success` and `on_success_ref`
 ///

--- a/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_and_on_success_coexist.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_and_on_success_coexist.rs
@@ -1,0 +1,39 @@
+//! Issue #4624: `on_success_ref:` and `on_success:` may be supplied
+//! together. Documented order: `on_success_ref` (borrows `&value`)
+//! runs first, then `on_success` (receives `value` by move).
+//!
+//! This compile-pass fixture only proves the parser/codegen accept
+//! both fields simultaneously; runtime ordering is enforced by the
+//! splice order inside the generated `Ok(value) =>` arm.
+
+use reinhardt_pages::form;
+
+mod server_fns {
+	pub fn update_profile() {}
+}
+
+use server_fns::update_profile;
+
+fn main() {
+	let user_id: i64 = 7;
+
+	let _form = form! {
+		name: DualCallbackForm,
+		server_fn: update_profile,
+
+		// Lifted variant — captures outer local.
+		on_success_ref: |_form, _updated: &i64| {
+			let _captured = user_id;
+		},
+
+		// Inline variant — consumes the value by move. Stays inside
+		// the generated `fn submit()` body; cannot see outer locals.
+		on_success: |_value| {
+			// Side effect only — does not touch outer scope.
+		},
+
+		fields: {
+			name: CharField { required },
+		},
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_and_on_success_coexist.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_and_on_success_coexist.rs
@@ -9,7 +9,14 @@
 use reinhardt_pages::form;
 
 mod server_fns {
-	pub async fn update_profile() -> ::core::result::Result<i64, ::core::convert::Infallible> {
+	// Signature mirrors what `form!` calls at runtime: one positional
+	// arg per field + a trailing CSRF arg (auto-injected for POST).
+	// Returns a Future-of-Result so the on_success_ref type-safety
+	// guard can extract `T = i64`.
+	pub async fn update_profile(
+		_name: ::std::string::String,
+		_csrf: ::std::string::String,
+	) -> ::core::result::Result<i64, ::core::convert::Infallible> {
 		::core::result::Result::Ok(0)
 	}
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_and_on_success_coexist.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_and_on_success_coexist.rs
@@ -9,7 +9,9 @@
 use reinhardt_pages::form;
 
 mod server_fns {
-	pub fn update_profile() {}
+	pub async fn update_profile() -> ::core::result::Result<i64, ::core::convert::Infallible> {
+		::core::result::Result::Ok(0)
+	}
 }
 
 use server_fns::update_profile;

--- a/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_captures_outer_local.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_captures_outer_local.rs
@@ -12,10 +12,14 @@
 use reinhardt_pages::form;
 
 mod server_fns {
-	// Stub server_fn body. The submit body that would actually `.await`
-	// this is wasm-only-gated, so on native we only need the function
-	// to exist as a referenceable item.
-	pub fn update_profile() {}
+	// Stub server_fn body. Returns an `impl Future<Output = Result<T, E>>`
+	// so the compile-time type-safety guard inside the `on_success_ref:`
+	// lift (#4624) can extract the Ok type `T = i64` and force-unify it
+	// with the user closure's value parameter type. A real `#[server_fn]`
+	// expansion has the same shape.
+	pub async fn update_profile() -> ::core::result::Result<i64, ::core::convert::Infallible> {
+		::core::result::Result::Ok(0)
+	}
 }
 
 use server_fns::update_profile;

--- a/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_captures_outer_local.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_captures_outer_local.rs
@@ -1,0 +1,46 @@
+//! Issue #4624: `on_success_ref:` must capture enclosing-scope locals.
+//!
+//! `on_success:` (the legacy callback) is expanded inline inside the
+//! generated `fn submit()` body, so it cannot reference locals like
+//! `user_id` from the surrounding function (E0434).
+//!
+//! `on_success_ref:` is the lifted variant introduced by this issue —
+//! its user closure is expanded at the outer construction block (same
+//! lexical scope as the `form!` macro invocation), so capturing outer
+//! locals compiles cleanly.
+
+use reinhardt_pages::form;
+
+mod server_fns {
+	// Stub server_fn body. The submit body that would actually `.await`
+	// this is wasm-only-gated, so on native we only need the function
+	// to exist as a referenceable item.
+	pub fn update_profile() {}
+}
+
+use server_fns::update_profile;
+
+fn main() {
+	// `user_id` lives in this function. Before #4624, referencing it
+	// from inside an `on_success:` closure failed with E0434. The new
+	// `on_success_ref:` lifts the closure into this same scope, so the
+	// capture works.
+	let user_id: i64 = 42;
+
+	let _form = form! {
+		name: ProfileForm,
+		server_fn: update_profile,
+
+		// Two-parameter closure: `&Self` and `&T` (the server_fn Ok type).
+		// `T` is inferred from the closure body / parameter annotation;
+		// the macro never needs to name it. Here we just touch `user_id`
+		// to prove the outer-scope capture compiles.
+		on_success_ref: |_form, _updated: &i64| {
+			let _captured = user_id;
+		},
+
+		fields: {
+			name: CharField { required },
+		},
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_captures_outer_local.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_captures_outer_local.rs
@@ -12,12 +12,19 @@
 use reinhardt_pages::form;
 
 mod server_fns {
-	// Stub server_fn body. Returns an `impl Future<Output = Result<T, E>>`
-	// so the compile-time type-safety guard inside the `on_success_ref:`
-	// lift (#4624) can extract the Ok type `T = i64` and force-unify it
-	// with the user closure's value parameter type. A real `#[server_fn]`
-	// expansion has the same shape.
-	pub async fn update_profile() -> ::core::result::Result<i64, ::core::convert::Infallible> {
+	// Stub server_fn body. The signature must match what `form!` would
+	// generate at the call site: one positional arg per form field
+	// (`name: String` from the `CharField`) plus a trailing CSRF token
+	// arg (auto-injected for the default POST method). Returns an
+	// `impl Future<Output = Result<T, E>>` so the compile-time
+	// type-safety guard inside the `on_success_ref:` lift (#4624) can
+	// extract `T = i64` and force-unify it with the user closure's
+	// value parameter type. A real `#[server_fn]` expansion has the
+	// same shape.
+	pub async fn update_profile(
+		_name: ::std::string::String,
+		_csrf: ::std::string::String,
+	) -> ::core::result::Result<i64, ::core::convert::Infallible> {
 		::core::result::Result::Ok(0)
 	}
 }


### PR DESCRIPTION
## Summary

Adds the new `on_success_ref:` callback to `form! { ... }` that captures
enclosing-scope locals (issue #4624). Mirrors the lift pattern used by
`watch:` handlers (PR #4414) — the user closure is expanded at the outer
construction block, type-erased into an `Arc<dyn Fn(&Self, &dyn Any)>`
stored on the form struct, and invoked from both `submit()` and the inline
onsubmit event handler.

**Non-breaking, additive.** The existing `on_success:` callback (which
receives `T` by move and cannot capture outer locals) stays unchanged.
The unification — making `on_success:` itself take `&T` — is deferred to
`develop/0.2.0` per `instructions/STABILITY_POLICY.md` § DB-2.

## Why two callbacks?

Three in-tree callers rely on `on_success:` taking `T` by move:

- `crates/reinhardt-admin/src/pages/components/login.rs:106` (uses `.clone()` already; would work with `&T`)
- `examples/examples-twitter/src/apps/auth/.../components.rs:42` (`set_current_user(Some(user_info))` — true move)
- `examples/examples-twitter/src/apps/tweet/.../components.rs:361` (`\|_result\|` — ignores T)

Flipping the signature is a SemVer break (Issue Option A). Adding a
sibling lifted variant is additive (Option A-alias) and lets the
unification happen cleanly during the next major-bump window.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How was this tested?

- New `crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_captures_outer_local.rs` trybuild fixture mirrors the issue's Reproduction example — a `user_id` outer local referenced from inside `on_success_ref:`. Compiles cleanly under the lift.
- New `crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_and_on_success_coexist.rs` trybuild fixture proves both callbacks may be supplied together.
- New parser unit tests in `crates/reinhardt-manouche/src/parser/form.rs` for the new keyword + coexistence (2/2 pass locally).
- Four new codegen unit tests in `crates/reinhardt-pages/macros/src/form/codegen.rs` (4/4 pass locally) asserting the scaffold appears when used, is absent when unused, the compile-time type-safety guard is emitted for server_fn actions, and is omitted for URL actions.
- Local `cargo check`, `cargo fmt --check`, `cargo clippy --no-deps -D warnings` all clean on `reinhardt-pages`, `reinhardt-pages-macros`, and `reinhardt-manouche`.

## Design notes

### Lift pattern (commits 1–5)

The lift trick that avoids naming `T` anywhere in the macro output:

1. **Storage**: `Arc<dyn Fn(&Form, &dyn ::core::any::Any)>` — type-erased so the form struct stays nameable without becoming generic over `T`.
2. **Inference at outer setup**: a 3-parameter `__coerce_form<__F, __T, __R>` identity fn pins the user closure's `(&Form, &__T) -> __R` shape, letting Rust infer `T` from the user closure body / annotation without forcing the user to write `|form: &MyForm, value: &MyT|`.
3. **Submit-site invocation**: the form struct holds the Arc; `submit()` (and the inline onsubmit handler) calls it with `&value as &dyn Any` after the server_fn returns.

### Compile-time type-safety guard (commit 6)

The naive lift's `downcast_ref().expect(...)` only fails at runtime if
the user's `__T` doesn't match the server_fn's `Ok` arm. A user writing
`on_success_ref: |_, v: &Wrong|` against a server_fn returning
`Result<Right, _>` would compile cleanly and panic at runtime — that is
a real type-safety regression.

Commit 6 adds a dead-code branch inside the lifted wrapper that calls
`#server_fn_ident(::core::unreachable!(), ..., ::core::unreachable!())`
to produce an `impl Future<Output = Result<T, _>>`, extracts `T` via a
generic `__on_success_ref_extract_ok::<Fut, T, E>(_) -> T`, and calls
the user closure with `&__probe_ok`. Rust's type checker then unifies
the closure's `__T` with the server_fn's `Ok` type AT COMPILE TIME.
A mismatch now produces a type error pointing at the user closure's
parameter, not a runtime panic.

The `unreachable!()` arg placeholders work because the never type (`!`)
coerces to any argument type via never-fallback, so the probe call
type-checks regardless of the server_fn's actual signature (field
count, `strip_arguments`, csrf auto-injection). The argument count is
computed by mirroring `generate_submit_method`'s logic.

The guard is skipped for URL-action forms (no server_fn to probe);
those forms never invoke `on_success_ref` at runtime anyway, so the
runtime `.expect(...)` remains the only safety net there. The
`test_generate_on_success_ref_no_type_guard_for_url_action` codegen
test pins that behavior.

## Out of scope

- `examples-twitter/auth/.../components.rs:42` consumer-side migration (Option-A `.clone()` cleanup) waits for `develop/0.2.0`.
- Renaming `on_success_ref:` back to `on_success:` with `&T` semantics is the eventual 0.2.0 unification, tracked separately.

## Labels to Apply

- `enhancement`

Fixes #4624

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on_success_ref form callback that receives the server result by reference, may capture outer-scope locals, and is invoked before the existing on_success; both can coexist.

* **Documentation**
  * Updated form callback docs with guidance and examples comparing on_success_ref vs on_success and showing outer-scope capture and invocation order.

* **Tests**
  * Added UI tests validating parsing, outer-scope capture, coexistence, and invocation order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->