### PR TITLE
docs(di): replace `#[scope(...)]` with `(scope = "...")` argument form

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,10 +823,14 @@ Non-injected fields are marked with `#[no_inject]` and must implement
 ```rust
 use reinhardt::di::injectable;
 
-// `scope` is optional. Pass it as a macro argument:
+// `scope` is passed as a macro argument:
 //   #[injectable(scope = "singleton" | "request" | "transient")]
-// `#[injectable]` defaults to `request` scope; `#[injectable_factory]` defaults to `singleton`.
-#[injectable]
+// When omitted, `#[injectable]` defaults to `request` and
+// `#[injectable_factory]` defaults to `singleton`. A longer-lived dependent
+// (e.g. singleton) cannot depend on a shorter-lived dependency (e.g. request),
+// so `Config` is registered as a singleton here to match the singleton-scoped
+// `database_connection` factory below.
+#[injectable(scope = "singleton")]
 #[derive(Clone)]
 pub struct Config {
     #[no_inject]

--- a/README.md
+++ b/README.md
@@ -823,8 +823,10 @@ Non-injected fields are marked with `#[no_inject]` and must implement
 ```rust
 use reinhardt::di::injectable;
 
+// `scope` is optional. Pass it as a macro argument:
+//   #[injectable(scope = "singleton" | "request" | "transient")]
+// `#[injectable]` defaults to `request` scope; `#[injectable_factory]` defaults to `singleton`.
 #[injectable]
-#[scope(singleton)] // optional: singleton (default) | request | transient
 #[derive(Clone)]
 pub struct Config {
     #[no_inject]
@@ -848,8 +850,7 @@ hands the returned value to the DI container:
 use reinhardt::db::DatabaseConnection;
 use reinhardt::di::{Depends, injectable_factory};
 
-#[injectable_factory]
-#[scope(singleton)]
+#[injectable_factory(scope = "singleton")]
 async fn database_connection(
     #[inject] config: Depends<Config>,
 ) -> DatabaseConnection {

--- a/README.md
+++ b/README.md
@@ -826,10 +826,12 @@ use reinhardt::di::injectable;
 // `scope` is passed as a macro argument:
 //   #[injectable(scope = "singleton" | "request" | "transient")]
 // When omitted, `#[injectable]` defaults to `request` and
-// `#[injectable_factory]` defaults to `singleton`. A longer-lived dependent
-// (e.g. singleton) cannot depend on a shorter-lived dependency (e.g. request),
-// so `Config` is registered as a singleton here to match the singleton-scoped
-// `database_connection` factory below.
+// `#[injectable_factory]` defaults to `singleton`. `Config` is registered
+// as a singleton here so it matches the singleton-scoped
+// `database_connection` factory below: mixing a longer-lived dependent
+// with a shorter-lived dependency is not rejected by the registry, but it
+// captures whichever request-scoped instance was live at first resolution
+// and reuses it for the singleton's lifetime — almost never what you want.
 #[injectable(scope = "singleton")]
 #[derive(Clone)]
 pub struct Config {

--- a/README.md
+++ b/README.md
@@ -823,8 +823,8 @@ Non-injected fields are marked with `#[no_inject]` and must implement
 ```rust
 use reinhardt::di::injectable;
 
-// `scope` is passed as a macro argument:
-//   #[injectable(scope = "singleton" | "request" | "transient")]
+// `scope` is passed as a macro argument; accepted values are
+// "singleton", "request", or "transient" (one literal, not an alternation).
 // When omitted, `#[injectable]` defaults to `request` and
 // `#[injectable_factory]` defaults to `singleton`. `Config` is registered
 // as a singleton here so it matches the singleton-scoped

--- a/crates/reinhardt-di/README.md
+++ b/crates/reinhardt-di/README.md
@@ -467,8 +467,7 @@ Mark a struct as injectable and automatically register it with the global regist
 
 **Syntax:**
 ```rust
-#[injectable]
-#[scope(singleton|request|transient)]
+#[injectable(scope = "singleton" | "request" | "transient")]
 struct YourStruct {
     #[no_inject]
     field: Type,
@@ -476,17 +475,20 @@ struct YourStruct {
 ```
 
 **Attributes:**
-- `` `#[scope(singleton)]` `` - Singleton scope (default)
-- `` `#[scope(request)]` `` - Request scope
-- `` `#[scope(transient)]` `` - Transient scope (new instance every time)
+
+Scope is passed as a macro argument in key-value form. `#[injectable]`
+defaults to `request` when no `scope` argument is supplied.
+
+- `` `#[injectable(scope = "request")]` `` - Request scope (default)
+- `` `#[injectable(scope = "singleton")]` `` - Singleton scope
+- `` `#[injectable(scope = "transient")]` `` - Transient scope (new instance every time)
 - `` `#[no_inject]` `` - Exclude specific fields from automatic injection
 
 **Example:**
 ```rust
 use reinhardt::di::macros::injectable;
 
-#[injectable]
-#[scope(singleton)]
+#[injectable(scope = "singleton")]
 struct Config {
     #[no_inject]
     database_url: String,
@@ -500,17 +502,21 @@ Mark an async function as a dependency factory for complex initialization logic.
 
 **Syntax:**
 ```rust
-#[injectable_factory]
-#[scope(singleton|request|transient)]
+#[injectable_factory(scope = "singleton" | "request" | "transient")]
 async fn factory_function(#[inject] dep: Arc<Dependency>) -> ReturnType {
     // Initialization logic
 }
 ```
 
 **Attributes:**
-- `` `#[scope(singleton)]` `` - Singleton scope (default)
-- `` `#[scope(request)]` `` - Request scope
-- `` `#[scope(transient)]` `` - Transient scope
+
+Scope is passed as a macro argument in key-value form.
+`#[injectable_factory]` defaults to `singleton` when no `scope` argument is
+supplied.
+
+- `` `#[injectable_factory(scope = "singleton")]` `` - Singleton scope (default)
+- `` `#[injectable_factory(scope = "request")]` `` - Request scope
+- `` `#[injectable_factory(scope = "transient")]` `` - Transient scope
 - `` `#[inject]` `` - Mark function parameters for automatic injection
 
 **Example:**
@@ -518,8 +524,7 @@ async fn factory_function(#[inject] dep: Arc<Dependency>) -> ReturnType {
 use reinhardt::di::macros::injectable_factory;
 use std::sync::Arc;
 
-#[injectable_factory]
-#[scope(singleton)]
+#[injectable_factory(scope = "singleton")]
 async fn create_database(#[inject] config: Arc<Config>) -> DatabaseConnection {
     DatabaseConnection::connect(&config.database_url)
         .await
@@ -572,8 +577,7 @@ async fn main() {
 use reinhardt::di::macros::{injectable, injectable_factory};
 use std::sync::Arc;
 
-#[injectable]
-#[scope(singleton)]
+#[injectable(scope = "singleton")]
 struct AppConfig {
     #[no_inject]
     db_url: String,
@@ -581,8 +585,7 @@ struct AppConfig {
     cache_size: usize,
 }
 
-#[injectable_factory]
-#[scope(request)]
+#[injectable_factory(scope = "request")]
 async fn create_service(
     #[inject] config: Arc<AppConfig>
 ) -> MyService {

--- a/crates/reinhardt-di/README.md
+++ b/crates/reinhardt-di/README.md
@@ -467,7 +467,8 @@ Mark a struct as injectable and automatically register it with the global regist
 
 **Syntax:**
 ```rust
-#[injectable(scope = "singleton" | "request" | "transient")]
+// `scope` accepts "singleton", "request", or "transient" (see Attributes below).
+#[injectable(scope = "singleton")]
 struct YourStruct {
     #[no_inject]
     field: Type,
@@ -502,7 +503,8 @@ Mark an async function as a dependency factory for complex initialization logic.
 
 **Syntax:**
 ```rust
-#[injectable_factory(scope = "singleton" | "request" | "transient")]
+// `scope` accepts "singleton", "request", or "transient" (see Attributes below).
+#[injectable_factory(scope = "singleton")]
 async fn factory_function(#[inject] dep: Arc<Dependency>) -> ReturnType {
     // Initialization logic
 }

--- a/crates/reinhardt-di/macros/src/lib.rs
+++ b/crates/reinhardt-di/macros/src/lib.rs
@@ -49,8 +49,7 @@ mod utils;
 /// ```ignore
 /// use reinhardt_di_macros::injectable;
 ///
-/// #[injectable]
-/// #[scope(singleton)]
+/// #[injectable(scope = "singleton")]
 /// struct Config {
 ///     #[no_inject]
 ///     database_url: String,
@@ -59,9 +58,12 @@ mod utils;
 ///
 /// # Attributes
 ///
-/// - `#[scope(singleton)]` - Singleton scope (default)
-/// - `#[scope(request)]` - Request scope
-/// - `#[scope(transient)]` - Transient scope
+/// Scope is passed as a macro argument in key-value form. `#[injectable]`
+/// defaults to `request` when no `scope` argument is supplied.
+///
+/// - `#[injectable(scope = "request")]` - Request scope (default)
+/// - `#[injectable(scope = "singleton")]` - Singleton scope
+/// - `#[injectable(scope = "transient")]` - Transient scope
 #[proc_macro_attribute]
 pub fn injectable(args: TokenStream, input: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(input as DeriveInput);
@@ -79,8 +81,7 @@ pub fn injectable(args: TokenStream, input: TokenStream) -> TokenStream {
 /// use reinhardt_di::Depends;
 /// use reinhardt_di_macros::injectable_factory;
 ///
-/// #[injectable_factory]
-/// #[scope(singleton)]
+/// #[injectable_factory(scope = "singleton")]
 /// async fn create_database(#[inject] config: Depends<Config>) -> DatabaseConnection {
 ///     DatabaseConnection::connect(&config.database_url).await.unwrap()
 /// }
@@ -88,9 +89,13 @@ pub fn injectable(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Attributes
 ///
-/// - `#[scope(singleton)]` - Singleton scope (default)
-/// - `#[scope(request)]` - Request scope
-/// - `#[scope(transient)]` - Transient scope
+/// Scope is passed as a macro argument in key-value form.
+/// `#[injectable_factory]` defaults to `singleton` when no `scope` argument
+/// is supplied.
+///
+/// - `#[injectable_factory(scope = "singleton")]` - Singleton scope (default)
+/// - `#[injectable_factory(scope = "request")]` - Request scope
+/// - `#[injectable_factory(scope = "transient")]` - Transient scope
 /// - `#[inject]` - Mark function parameters for automatic injection
 #[proc_macro_attribute]
 pub fn injectable_factory(args: TokenStream, input: TokenStream) -> TokenStream {


### PR DESCRIPTION
## Summary

The `#[scope(...)]` separate-attribute form was documented in three places but never parsed by `reinhardt-di`'s macros (only `scope = "..."` as a macro argument is parsed by `KNOWN_ARGS` in `crates/reinhardt-di/macros/src/utils.rs:40-92`). Users copying the documented examples silently got the default scope because unknown attributes fall through `fn_attrs` without diagnostics.

This PR rewrites every documented example to the parsed `(scope = "...")` form across the workspace README, the `reinhardt-di` crate README, and both macro docstrings. It also corrects the asymmetric default-scope note in those docstrings:

- `#[injectable]` default scope is **`Request`** (`crates/reinhardt-di/macros/src/injectable.rs:161-168` explicitly returns `Scope::Request`).
- `#[injectable_factory]` default scope is **`Singleton`** (via `Scope::default()` in `crates/reinhardt-di/macros/src/utils.rs:11-12, 114-121`).

## Type of Change

- [x] Documentation update

## Motivation and Context

Fixes #4646. The implementation in `utils.rs` is the ground truth; documentation was drifting from it and silently misleading users into accepting the wrong default scope.

## How Was This Tested

- `grep -rn '#\[scope(' README.md crates/reinhardt-di/` returns **0 hits** after the change.
- `cargo doc --no-deps -p reinhardt-di-macros` builds cleanly (no rustdoc warnings introduced).
- `cargo fmt -p reinhardt-di-macros -- --check` clean.

No code paths changed; this is a pure documentation correction with no runtime impact.

## Checklist

- [x] Code follows project style (English-only doc comments, tab indent preserved)
- [x] Self-reviewed the diff against the source-of-truth (`utils.rs`, `injectable.rs`)
- [x] Documentation updated (this PR is the documentation update)
- [x] No new `todo!()` / `// TODO:` introduced
- [x] Conventional Commits format used

## Labels to Apply

- `documentation`

## Related Issues

Fixes #4646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated dependency-injection macro docs and examples to use key-value scope syntax (e.g., scope = "singleton" | "request" | "transient").
  * Clarified default scope values for injectable and factory macros and updated usage examples to reflect new macro ergonomics.
  * Added guidance on mixing singleton and request-scoped dependencies and the resulting caching implications for resolved instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->