### PR TITLE
test(db): add CockroachDB unit test for AlterColumn reverse SQL stop-gap

### DIFF
--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -2548,14 +2548,21 @@ impl Operation {
 						// single-statement payloads can be dispatched — that
 						// change is tracked separately so this PR can unblock
 						// the rc.30 release without cascading into ~25 call
-						// sites and tests. The CockroachDB branch is
-						// exercised by `test_alter_column_type_rollback_cockroachdb`
-						// in `tests/integration/tests/migrations/migration_rollback_integration.rs`,
-						// which guards against regressions of this stop-gap
-						// (reinhardt-web#4639). The full `Vec<String>` API
-						// refactor that restores NOT NULL rollback fidelity
-						// is tracked in reinhardt-web#4640 and targets
-						// `develop/0.2.0`. Refs #4630, #4639, #4640.
+						// sites and tests. The stop-gap output shape of this
+						// branch (single statement, `ALTER COLUMN ... TYPE`,
+						// no nullability clause, no comma-combined form) is
+						// pinned by the inline unit test
+						// `test_to_reverse_sql_alter_column_cockroachdb` in
+						// the `#[cfg(test)] mod tests` block of this file,
+						// added under reinhardt-web#4639. An end-to-end
+						// integration test against a live CockroachDB
+						// testcontainer is blocked on reinhardt-web#4642
+						// (`DatabaseMigrationExecutor` calls
+						// `pg_advisory_lock()`, which CockroachDB does not
+						// implement). The full `Vec<String>` API refactor
+						// that restores NOT NULL rollback fidelity is
+						// tracked in reinhardt-web#4640 and targets
+						// `develop/0.2.0`. Refs #4630, #4639, #4640, #4642.
 						format!(
 							"ALTER TABLE {} ALTER COLUMN {} TYPE {};",
 							quote_identifier(table),

--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -5630,16 +5630,19 @@ mod tests {
 			.expect("reverse SQL should succeed")
 			.expect("reverse SQL should be present");
 
-		// Assert: must use `ALTER COLUMN ... TYPE` syntax with the original
-		// `VARCHAR(50)` type restored.
-		assert!(
-			sql.contains("ALTER COLUMN") && sql.contains("TYPE"),
-			"CockroachDB reverse SQL should use ALTER COLUMN ... TYPE syntax, got: {}",
-			sql
-		);
-		assert!(
-			sql.contains("VARCHAR(50)"),
-			"CockroachDB reverse SQL should restore VARCHAR(50), got: {}",
+		// Assert: shape must match the expected single-statement form
+		// exactly. Asserting `==` (not `contains`) is intentional: the
+		// stop-gap is supposed to emit *only* `ALTER TABLE "products" ALTER
+		// COLUMN "name" TYPE VARCHAR(50);` with no extra clauses (no
+		// nullability, no USING, no comma-combined sibling). A `contains`
+		// check would silently allow `, ALTER COLUMN ... SET NOT NULL`
+		// suffixes — exactly the regression this test is meant to pin.
+		let expected = r#"ALTER TABLE "products" ALTER COLUMN "name" TYPE VARCHAR(50);"#;
+		assert_eq!(
+			sql, expected,
+			"CockroachDB reverse SQL must match the pinned single-statement \
+			 form exactly (table/column identifiers double-quoted, no extra \
+			 clauses), got: {}",
 			sql
 		);
 
@@ -5647,8 +5650,9 @@ mod tests {
 		// Postgres comma-combined form, and `SchemaEditor::execute()` is a
 		// single-statement dispatcher (sqlx Extended Query), so the stop-gap
 		// must not return a `;\n`-joined multi-statement payload either.
-		// Strip the optional trailing semicolon before counting separators.
-		let trimmed = sql.trim_end_matches(';').trim();
+		// Trim whitespace first so a trailing `;\n` or `; ` still has its
+		// terminating semicolon recognised by `trim_end_matches(';')`.
+		let trimmed = sql.trim().trim_end_matches(';').trim();
 		assert!(
 			!trimmed.contains(';'),
 			"CockroachDB reverse SQL must be exactly one statement (no internal \

--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -2548,7 +2548,14 @@ impl Operation {
 						// single-statement payloads can be dispatched — that
 						// change is tracked separately so this PR can unblock
 						// the rc.30 release without cascading into ~25 call
-						// sites and tests. Refs #4630.
+						// sites and tests. The CockroachDB branch is
+						// exercised by `test_alter_column_type_rollback_cockroachdb`
+						// in `tests/integration/tests/migrations/migration_rollback_integration.rs`,
+						// which guards against regressions of this stop-gap
+						// (reinhardt-web#4639). The full `Vec<String>` API
+						// refactor that restores NOT NULL rollback fidelity
+						// is tracked in reinhardt-web#4640 and targets
+						// `develop/0.2.0`. Refs #4630, #4639, #4640.
 						format!(
 							"ALTER TABLE {} ALTER COLUMN {} TYPE {};",
 							quote_identifier(table),
@@ -5583,6 +5590,81 @@ mod tests {
 		assert!(
 			sql.contains("VARCHAR(50)"),
 			"MySQL reverse SQL should restore VARCHAR(50), got: {}",
+			sql
+		);
+	}
+
+	/// Reverse SQL for CockroachDB must emit the column-type reversion as a
+	/// single, dialect-isolated statement.
+	///
+	/// PR #4633 split CockroachDB off from PostgreSQL because CockroachDB
+	/// rejects the comma-combined `ALTER COLUMN ... TYPE T, ALTER COLUMN
+	/// ... {SET|DROP} NOT NULL` form that PostgreSQL accepts. The current
+	/// stop-gap emits only the column-type reversion and intentionally
+	/// drops nullability rollback fidelity (the full fix is tracked in
+	/// reinhardt-web#4640 and depends on `to_reverse_sql` returning
+	/// `Vec<String>`).
+	///
+	/// This unit test guards the stop-gap output shape so that a future
+	/// regression — e.g. re-folding CockroachDB into the Postgres comma form,
+	/// or accidentally appending the nullability clause as a second `\n`-joined
+	/// statement that `SchemaEditor::execute()` would reject — surfaces at
+	/// `cargo test` time instead of only at downstream CockroachDB deployments
+	/// (reinhardt-web#4639).
+	#[test]
+	fn test_to_reverse_sql_alter_column_cockroachdb() {
+		// Arrange
+		let op = alter_column_with_old_def();
+		let state = ProjectState::default();
+
+		// Act
+		let sql = op
+			.to_reverse_sql(&SqlDialect::Cockroachdb, &state)
+			.expect("reverse SQL should succeed")
+			.expect("reverse SQL should be present");
+
+		// Assert: must use `ALTER COLUMN ... TYPE` syntax with the original
+		// `VARCHAR(50)` type restored.
+		assert!(
+			sql.contains("ALTER COLUMN") && sql.contains("TYPE"),
+			"CockroachDB reverse SQL should use ALTER COLUMN ... TYPE syntax, got: {}",
+			sql
+		);
+		assert!(
+			sql.contains("VARCHAR(50)"),
+			"CockroachDB reverse SQL should restore VARCHAR(50), got: {}",
+			sql
+		);
+
+		// Assert: must be exactly one SQL statement. CockroachDB rejects the
+		// Postgres comma-combined form, and `SchemaEditor::execute()` is a
+		// single-statement dispatcher (sqlx Extended Query), so the stop-gap
+		// must not return a `;\n`-joined multi-statement payload either.
+		// Strip the optional trailing semicolon before counting separators.
+		let trimmed = sql.trim_end_matches(';').trim();
+		assert!(
+			!trimmed.contains(';'),
+			"CockroachDB reverse SQL must be exactly one statement (no internal \
+			 `;`), got: {}",
+			sql
+		);
+		assert!(
+			!sql.contains(",\n") && !sql.contains(", ALTER COLUMN"),
+			"CockroachDB reverse SQL must not emit the Postgres comma-combined \
+			 form (CockroachDB rejects it), got: {}",
+			sql
+		);
+
+		// Assert: nullability rollback is intentionally dropped under the
+		// stop-gap. Regressing toward emitting `SET NOT NULL` / `DROP NOT
+		// NULL` either as a second statement or inline in the same `ALTER
+		// TABLE` payload would re-break CockroachDB rollback — the
+		// `Vec<String>` API refactor (reinhardt-web#4640) is the supported
+		// path for restoring NOT NULL fidelity.
+		assert!(
+			!sql.contains("SET NOT NULL") && !sql.contains("DROP NOT NULL"),
+			"CockroachDB reverse SQL must not emit nullability clause under \
+			 the current stop-gap (tracked in #4640), got: {}",
 			sql
 		);
 	}


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds `test_to_reverse_sql_alter_column_cockroachdb` in `crates/reinhardt-db/src/migrations/operations.rs` to guard the CockroachDB `AlterColumn` reverse-SQL stop-gap introduced in PR #4633.
- Updates the CockroachDB branch comment in `to_reverse_sql` to cross-reference both this regression test (#4639) and the develop/0.2.0 `Vec<String>` API refactor (#4640).

## Type of Change

- [x] Code quality improvements (regression test coverage; no production-code behavior change)

## Motivation and Context

PR #4633 split the `Operation::AlterColumn` reverse-SQL path so CockroachDB emits only the column-type reversion (intentionally dropping NOT NULL rollback fidelity), because CockroachDB rejects PostgreSQL's comma-combined `ALTER COLUMN ... TYPE T, ALTER COLUMN ... {SET|DROP} NOT NULL` form and `SchemaEditor::execute()` is a single-statement dispatcher. Today the parametrized integration test `test_alter_column_type_rollback` only covers Postgres / MySQL / SQLite — the CockroachDB branch is exercised by **zero automated tests**. Any future regression that re-breaks the stop-gap (refolding into the comma form, mistakenly appending the nullability clause as a second `;\n`-joined statement, mis-routing the match arm, etc.) would pass CI silently and only surface in downstream CockroachDB deployments.

Fixes #4639

Related to: #4630, #4633, #4634, #4640, #4642

## How Was This Tested?

- `cargo test --package reinhardt-db --lib test_to_reverse_sql_alter_column -- --nocapture` → 4 passed, 0 failed (postgres / mysql / sqlite + the new cockroachdb case), runtime < 1 ms.
- `cargo check --package reinhardt-integration-tests --tests --all-features` → 0 errors.
- `cargo fmt --check -- crates/reinhardt-db/src/migrations/operations.rs` → clean.
- `cargo clippy --package reinhardt-db --lib --all-features -- -D warnings` → no issues from this change. (Pre-existing failures in `crates/reinhardt-db/tests/orm_model_fields.rs` and `tests/backend_query_builder.rs` are unrelated to this PR.)

## Implementation Note (integration → unit-test pivot)

The original Issue #4634 proposed adding a CockroachDB case to the existing integration test `test_alter_column_type_rollback`. While implementing that, I discovered `DatabaseMigrationExecutor::apply_migrations` calls `pg_advisory_lock()` — a PostgreSQL function CockroachDB does not implement. The first migration aborted with `DatabaseError(QueryError("unknown function: pg_advisory_lock(): function undefined"))` before reaching `Operation::AlterColumn` at all. That executor-layer incompatibility is now tracked as #4642 (`agent-suspect`) and must land before any end-to-end CockroachDB migration test can run. The unit test in this PR moves the regression coverage to the layer where the stop-gap is actually defined (`Operation::to_reverse_sql`), with no infrastructure dependency.

Out of scope for this PR (all tracked separately):

- `pg_advisory_lock` executor compatibility — #4642
- `Operation::to_reverse_sql` → `Result<Option<Vec<String>>>` API refactor — #4640 (targets `develop/0.2.0`)
- NOT NULL rollback fidelity on CockroachDB — restored by the #4640 refactor

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable) — the CockroachDB branch comment in `operations.rs` now cross-references #4639 and #4640
- [x] My changes generate no new warnings — verified via `cargo check --tests` and `cargo clippy --lib`
- [x] I have added tests that prove my fix is effective — `test_to_reverse_sql_alter_column_cockroachdb`
- [x] New and existing unit tests pass locally with my changes — 4 / 4 AlterColumn dialect tests pass
- [x] I have tested with all affected database backends (if applicable) — postgres / mysql / sqlite / cockroachdb unit tests all green
- [x] I have formatted the code with `cargo make fmt-fix` — `cargo fmt --check` clean
- [x] I have checked the code with `cargo make clippy-check` — `cargo clippy --lib -- -D warnings` clean for the changed file
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4639
- Refs #4630 — original CockroachDB AlterColumn rollback failure
- Refs #4633 — stop-gap PR this regression test guards
- Refs #4634 — original umbrella Issue (now split into #4639 / #4640)
- Refs #4640 — `develop/0.2.0` `Vec<String>` API refactor (restores NOT NULL fidelity)
- Refs #4642 — `pg_advisory_lock` executor incompatibility (blocks end-to-end CockroachDB migration tests)

## Labels to Apply

### Type Label
- [x] `enhancement` — regression-coverage test addition

### Scope Label
- [x] `database`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CockroachDB migration rollback behavior: rollbacks revert only column type changes and do not revert NOT NULL nullability, with guidance on expected SQL shape.

* **Tests**
  * Added a regression test ensuring CockroachDB ALTER COLUMN rollback emits a single TYPE-only statement, restores the original type, and omits NOT NULL changes and combined ALTER syntax.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->