### PR TITLE
fix(tests): symmetrize MySQL column helpers and surface information_schema diagnostics

### DIFF
--- a/tests/integration/tests/migrations/migration_rollback_integration.rs
+++ b/tests/integration/tests/migrations/migration_rollback_integration.rs
@@ -224,16 +224,36 @@ async fn column_exists(
 		}
 		DatabaseType::Mysql => {
 			let pool = connection.into_mysql().expect("mysql pool unavailable");
-			let count: i64 = sqlx::query_scalar(
+			// Symmetric with `column_data_type` — see Issue #4649. Both helpers
+			// case-fold `table_schema`, `table_name`, and `column_name` so that
+			// a passing `column_exists` strictly implies a hit in
+			// `column_data_type` and vice versa. Without this symmetry the two
+			// helpers could disagree on the same `information_schema.columns`
+			// rows, producing the impossible-looking failure shape reported in
+			// Issue #4649 (column_exists -> true, column_data_type -> None).
+			// We also surface sqlx errors via `eprintln!` instead of folding
+			// them into `count = 0`, so future flakes leave a debuggable trace
+			// in CI logs.
+			let result: Result<i64, _> = sqlx::query_scalar(
 				"SELECT COUNT(*) FROM information_schema.columns \
-				 WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?",
+				 WHERE LOWER(table_schema) = LOWER(DATABASE()) \
+				 AND LOWER(table_name) = LOWER(?) \
+				 AND LOWER(column_name) = LOWER(?)",
 			)
 			.bind(table_name)
 			.bind(column_name)
 			.fetch_one(&pool)
-			.await
-			.unwrap_or(0);
-			count > 0
+			.await;
+			match result {
+				Ok(count) => count > 0,
+				Err(err) => {
+					eprintln!(
+						"[issue#4649] column_exists({table_name:?}, {column_name:?}) \
+						 MySQL query failed: {err:?}"
+					);
+					false
+				}
+			}
 		}
 		DatabaseType::Sqlite => {
 			let pool = connection.into_sqlite().expect("sqlite pool unavailable");
@@ -341,18 +361,64 @@ async fn column_data_type(
 			// behaviour the rest of this fixture assumes so the assertion
 			// holds regardless of the runner's filesystem semantics.
 			// Fixes #4630.
-			sqlx::query_scalar::<_, String>(
+			//
+			// Issue #4649 follow-up: the WHERE clause is now symmetric with
+			// `column_exists` (case-fold `table_schema` too), so any divergence
+			// between the two helpers can no longer come from the WHERE shape
+			// alone. We also split the previously-silent `.ok().flatten()`
+			// into three explicit outcomes:
+			//   - `Err(_)`      => sqlx error; print it and return None so the
+			//                       caller's `.expect(...)` still panics, but
+			//                       with the underlying error logged to stderr.
+			//   - `Ok(Some(s))` => column exists with data type `s`.
+			//   - `Ok(None)`    => column genuinely absent; dump the rows in
+			//                       `information_schema.columns` that match
+			//                       `LOWER(table_name) = LOWER(?)` (without
+			//                       the schema filter) and the current value
+			//                       of `DATABASE()`, so the next residual
+			//                       flake's CI log carries enough state to
+			//                       diagnose the root cause.
+			let result = sqlx::query_scalar::<_, String>(
 				"SELECT data_type FROM information_schema.columns \
-				 WHERE table_schema = DATABASE() \
+				 WHERE LOWER(table_schema) = LOWER(DATABASE()) \
 				 AND LOWER(table_name) = LOWER(?) \
 				 AND LOWER(column_name) = LOWER(?)",
 			)
 			.bind(table_name)
 			.bind(column_name)
 			.fetch_optional(&pool)
-			.await
-			.ok()
-			.flatten()
+			.await;
+			match result {
+				Ok(Some(s)) => Some(s),
+				Ok(None) => {
+					let dump = sqlx::query_as::<_, (String, String, String, String)>(
+						"SELECT table_schema, table_name, column_name, data_type \
+						 FROM information_schema.columns \
+						 WHERE LOWER(table_name) = LOWER(?)",
+					)
+					.bind(table_name)
+					.fetch_all(&pool)
+					.await;
+					let current_db: Option<String> = sqlx::query_scalar("SELECT DATABASE()")
+						.fetch_optional(&pool)
+						.await
+						.ok()
+						.flatten();
+					eprintln!(
+						"[issue#4649] column_data_type({table_name:?}, {column_name:?}) \
+						 returned None; DATABASE()={current_db:?}, \
+						 information_schema.columns LIKE table = {dump:#?}"
+					);
+					None
+				}
+				Err(err) => {
+					eprintln!(
+						"[issue#4649] column_data_type({table_name:?}, {column_name:?}) \
+						 MySQL query failed: {err:?}"
+					);
+					None
+				}
+			}
 		}
 		DatabaseType::Sqlite => None,
 	}

--- a/tests/integration/tests/migrations/migration_rollback_integration.rs
+++ b/tests/integration/tests/migrations/migration_rollback_integration.rs
@@ -391,23 +391,36 @@ async fn column_data_type(
 			match result {
 				Ok(Some(s)) => Some(s),
 				Ok(None) => {
+					// Cap the diagnostic dump so a flake on a busy CI MySQL with
+					// many schemas can't produce multi-megabyte logs. 32 rows is
+					// large enough to spot duplicate-table-across-schemas drift
+					// without dominating the log.
 					let dump = sqlx::query_as::<_, (String, String, String, String)>(
 						"SELECT table_schema, table_name, column_name, data_type \
 						 FROM information_schema.columns \
-						 WHERE LOWER(table_name) = LOWER(?)",
+						 WHERE LOWER(table_name) = LOWER(?) \
+						 ORDER BY table_schema, column_name \
+						 LIMIT 32",
 					)
 					.bind(table_name)
 					.fetch_all(&pool)
 					.await;
-					let current_db: Option<String> = sqlx::query_scalar("SELECT DATABASE()")
-						.fetch_optional(&pool)
-						.await
-						.ok()
-						.flatten();
+					// Use an explicit match (not `.ok().flatten()`) so that a
+					// failed `SELECT DATABASE()` is logged as the failure it is
+					// rather than collapsing into a misleading `None`.
+					let current_db: Result<Option<String>, _> =
+						sqlx::query_scalar("SELECT DATABASE()")
+							.fetch_optional(&pool)
+							.await;
+					let current_db_repr = match current_db {
+						Ok(value) => format!("{value:?}"),
+						Err(err) => format!("<query failed: {err:?}>"),
+					};
 					eprintln!(
 						"[issue#4649] column_data_type({table_name:?}, {column_name:?}) \
-						 returned None; DATABASE()={current_db:?}, \
-						 information_schema.columns LIKE table = {dump:#?}"
+						 returned None; DATABASE()={current_db_repr}, \
+						 information_schema.columns WHERE LOWER(table_name)=LOWER(?) \
+						 (ORDER BY table_schema, column_name LIMIT 32) = {dump:#?}"
 					);
 					None
 				}


### PR DESCRIPTION
## Summary

This PR addresses:

- The residual MySQL flake in `test_alter_column_type_rollback::case_2_mysql` reported in Issue #4649: even after the Issue #4630 fix landed, `column_exists("products", "name")` succeeded but the immediately-following `column_data_type("products", "name")` returned `None` against the same `information_schema.columns` rows — a logically impossible outcome for the WHERE clauses involved.
- The fix takes the **diagnostics-first** approach selected during planning: it does **not** introduce silent retries, does **not** weaken the assertion, and does **not** add `#[ignore]`. Instead it (a) eliminates the impossible WHERE-shape asymmetry between the two helpers, and (b) makes the next failure self-diagnosing by dumping `information_schema` state to stderr.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The failure shape reported in Issue #4649 is logically inconsistent if both helpers see the same `information_schema.columns` rows. `LOWER("products") = "products"`, so if the strict `table_name = ?` lookup in `column_exists` matched, the case-folded `LOWER(table_name) = LOWER(?)` lookup in `column_data_type` *must* match the same row. The fact that it didn't leaves only three possible causes:

1. `DATABASE()` resolved to a different value across the two query executions (per-connection state on the sqlx pool).
2. `column_data_type` silently swallowed a sqlx error via `.ok().flatten()` and reported "no row" when it should have reported "query failed".
3. MySQL returned the two queries from different metadata snapshots (visibility race after the forward ALTER).

The previous code made (2) indistinguishable from "really no row" and (1) impossible to diagnose at all — the next residual flake would give us exactly the same opaque panic. This PR makes the next failure carry enough state to discriminate between (1), (2), and (3).

Refs #4649

## How Was This Tested?

- `cargo check --tests -p reinhardt-integration-tests` — **0 errors**.
- `cargo fmt -p reinhardt-integration-tests -- --check` — clean.
- `cargo clippy --tests -p reinhardt-integration-tests -- -D warnings` — no new clippy diagnostics on the changed file. (The crate has pre-existing clippy violations in unrelated test files; they exist on `main` already.)
- The residual flake has **not** been reproduced locally on macOS / Docker Desktop. **Absence of local reproduction is not evidence that `main` is unaffected** — the GitHub Actions ubuntu-24.04 runners differ significantly from macOS Docker Desktop (filesystem case-sensitivity defaults, MySQL container backing storage, kernel-level container behaviour). The flake observed on PR #4636 ran against the same `main` HEAD (merge base `556e4605e7`) that this PR branches from, so the underlying race almost certainly exists on `main` too — we just lack the observation surface to confirm it. The value of this PR is precisely that diagnostic surface: the next CI run on any PR (including `main` runs themselves) that hits the race will leave actionable state in the job log.

## Breaking Changes

None — this PR only touches a test helper in `tests/integration/tests/migrations/migration_rollback_integration.rs`. No production code in `crates/reinhardt-db/` is changed. The signature of `column_exists` and `column_data_type` is unchanged; only the WHERE clause shape and the error/`None` handling differ.

## Out of Scope

- `crates/reinhardt-db/src/migrations/introspection.rs:753` uses the same un-LOWERed pattern in production. If that surfaces in production it should be filed as a **separate** Issue per WU-1 (1 PR = 1 crate × 1 fix pattern).
- This PR is intentionally labelled `Refs #4649` rather than `Fixes #4649`, because we are eliminating the asymmetry and adding diagnostics rather than confirming the residual root cause is gone. The maintainer can close #4649 manually after a future CI failure (with diagnostic dump) has been root-caused, or after the flake stops appearing for a meaningful window.

## Labels to Apply

- [x] `bug`
- [x] `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)