### PR TITLE
fix(admin-cli): recursively format nested page! macros

### DIFF
--- a/.semgrep/placeholder-check.yml
+++ b/.semgrep/placeholder-check.yml
@@ -1,9 +1,9 @@
 rules:
   - id: rust-reinhardt-placeholder-macro
     patterns:
-      - pattern-regex: "__reinhardt_placeholder__!\\("
+      - pattern-regex: "__reinhardt_placeholder(?:_\\d+)?__!\\("
     message: >-
-      Formatter placeholder macro __reinhardt_placeholder__! found in source code.
+      Formatter placeholder macro __reinhardt_placeholder_N__! found in source code.
       This is an internal marker used by reinhardt-admin-cli during page! macro formatting.
       The formatter should restore page!(...) calls before committing.
       Run `cargo make fmt-page-only` to restore the original macros.

--- a/crates/reinhardt-admin-cli/src/ast_formatter.rs
+++ b/crates/reinhardt-admin-cli/src/ast_formatter.rs
@@ -2926,8 +2926,8 @@ fn main() {
 	}
 
 	// Regression: a `page!(...)` literal inside a regular string literal
-	// must not be picked up as a macro invocation, even when its tokens
-	// match the real macro byte-for-byte.
+	// must not be picked up as a macro invocation, even when those tokens
+	// happen to match the real macro byte-for-byte.
 	#[rstest]
 	fn test_protect_skips_lookalike_in_string_literal() {
 		// Arrange

--- a/crates/reinhardt-admin-cli/src/ast_formatter.rs
+++ b/crates/reinhardt-admin-cli/src/ast_formatter.rs
@@ -167,10 +167,14 @@ impl<'a> PageMacroVisitor<'a> {
 	}
 
 	/// Find the page! macro in source and return its position info.
+	///
+	/// Accepts both the human-authored form `page!(...)` and the
+	/// `proc_macro2::TokenStream` Display form `page ! ( ... )`, which
+	/// appears when the formatter recurses via wrapper code built from
+	/// `expr.to_token_stream()` (it inserts whitespace between tokens).
+	/// Without the lenient match, nested `page!` macros inside such
+	/// wrapper code would be invisible to `protect_page_macros`.
 	fn find_macro_in_source(&self, _tokens_content: &str) -> Option<MacroInfo> {
-		// This is a simplified approach - we search for "page!(" patterns
-		// and verify by comparing token content
-		let pattern = "page!(";
 		let mut search_start = 0;
 
 		// Skip already found macros
@@ -180,9 +184,9 @@ impl<'a> PageMacroVisitor<'a> {
 			}
 		}
 
-		while let Some(pos) = self.source[search_start..].find(pattern) {
-			let abs_start = search_start + pos;
-			let content_start = abs_start + pattern.len();
+		while let Some(hit) = find_page_bang_paren(&self.source[search_start..]) {
+			let abs_start = search_start + hit.start;
+			let content_start = search_start + hit.paren_open + 1;
 
 			// Find matching closing paren
 			if let Some(end_pos) = find_matching_paren(self.source, content_start) {
@@ -216,6 +220,67 @@ impl<'ast, 'a> Visit<'ast> for PageMacroVisitor<'a> {
 		self.extract_macro_info(mac);
 		syn::visit::visit_macro(self, mac);
 	}
+}
+
+/// Result of locating a `page!(` invocation (with possible whitespace).
+struct PageBangParen {
+	/// Byte offset of the leading `p` of `page`.
+	start: usize,
+	/// Byte offset of the opening `(`.
+	paren_open: usize,
+}
+
+/// Find the next `page <ws>* ! <ws>* (` occurrence in `s`, ensuring the
+/// `page` token is at a word boundary (not part of a larger identifier
+/// like `mypage`). Returns `None` if none found. Accepts the canonical
+/// `page!(` form authored by users as well as the `page ! (` form emitted
+/// by `proc_macro2::TokenStream`'s `Display`.
+fn find_page_bang_paren(s: &str) -> Option<PageBangParen> {
+	let bytes = s.as_bytes();
+	let mut i = 0;
+	while let Some(rel) = s[i..].find("page") {
+		let start = i + rel;
+		// Reject if preceded by an identifier-continuation byte.
+		if start > 0 {
+			let prev = bytes[start - 1];
+			if prev.is_ascii_alphanumeric() || prev == b'_' {
+				i = start + 1;
+				continue;
+			}
+		}
+		let after = start + "page".len();
+		// Reject if followed by an identifier-continuation byte (excluding `!`).
+		if after < bytes.len() {
+			let nx = bytes[after];
+			if nx.is_ascii_alphanumeric() || nx == b'_' {
+				i = start + 1;
+				continue;
+			}
+		}
+		// Skip whitespace between `page` and `!`.
+		let mut j = after;
+		while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+			j += 1;
+		}
+		if j >= bytes.len() || bytes[j] != b'!' {
+			i = start + 1;
+			continue;
+		}
+		j += 1;
+		// Skip whitespace between `!` and `(`.
+		while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+			j += 1;
+		}
+		if j >= bytes.len() || bytes[j] != b'(' {
+			i = start + 1;
+			continue;
+		}
+		return Some(PageBangParen {
+			start,
+			paren_open: j,
+		});
+	}
+	None
 }
 
 /// Find the matching closing parenthesis, handling strings and nested parens.
@@ -436,7 +501,10 @@ impl AstPageFormatter {
 	pub(crate) fn format(&self, content: &str) -> Result<FormatResult, String> {
 		// Safety check FIRST: If no page! pattern exists, return unchanged.
 		// This is a successful no-op, not an intentional skip — skipped stays None.
-		if !content.contains("page!(") {
+		// Match both compact `page!(` and the TokenStream Display form `page ! (`
+		// so recursive formatting (which wraps via `to_token_stream()`) still
+		// sees nested macros at every depth.
+		if find_page_bang_paren(content).is_none() {
 			return Ok(FormatResult {
 				content: content.to_string(),
 				contains_page_macro: false,
@@ -544,13 +612,16 @@ impl AstPageFormatter {
 	}
 
 	/// Text-based fallback for finding page! macros.
+	///
+	/// Accepts both the compact `page!(` form and the TokenStream Display
+	/// form `page ! (` (see `find_page_bang_paren`).
 	fn find_page_macros_text_based(&self, content: &str) -> Result<Vec<MacroInfo>, String> {
 		let mut macros = Vec::new();
-		let pattern = "page!(";
 		let mut search_start = 0;
 
-		while let Some(pos) = content[search_start..].find(pattern) {
-			let abs_start = search_start + pos;
+		while let Some(hit) = find_page_bang_paren(&content[search_start..]) {
+			let abs_start = search_start + hit.start;
+			let abs_open = search_start + hit.paren_open;
 
 			// Check if we're in a comment or string
 			if self.is_in_comment_or_string(content, abs_start) {
@@ -558,7 +629,7 @@ impl AstPageFormatter {
 				continue;
 			}
 
-			let content_start = abs_start + pattern.len();
+			let content_start = abs_open + 1;
 
 			if let Some(end_pos) = find_matching_paren(content, content_start) {
 				let macro_content = &content[content_start..end_pos];
@@ -1118,8 +1189,11 @@ impl AstPageFormatter {
 		let prettyplease_output = prettyplease::unparse(&file);
 		let formatted = self.format_with_rustfmt(&prettyplease_output);
 
-		// Restore nested page! macros
-		let restored = Self::restore_page_macros(&formatted, &protect_result.backups);
+		// Restore nested page! macros, recursively re-formatting each one so
+		// that nested page!() invocations are pretty-printed instead of being
+		// re-inserted as the compact TokenStream stringification captured at
+		// protect time.
+		let restored = self.restore_page_macros_recursive(&formatted, &protect_result.backups);
 
 		// Extract the expression from the wrapper
 		let Some(expr_str) = Self::extract_handler_from_wrapper(&restored) else {
@@ -1508,11 +1582,11 @@ impl AstPageFormatter {
 	/// let view = page!(|| { div { "hello" } })(props);
 	///
 	/// // After:
-	/// let view = __reinhardt_placeholder__!(/*0*/)(props);
+	/// let view = __reinhardt_placeholder_0__!()(props);
 	/// ```
 	pub(crate) fn protect_page_macros(&self, content: &str) -> ProtectResult {
-		// Quick check: if no page! pattern exists, return unchanged
-		if !content.contains("page!(") {
+		// Quick check: accept both `page!(` and `page ! (` (see `find_page_bang_paren`).
+		if find_page_bang_paren(content).is_none() {
 			return ProtectResult {
 				protected_content: content.to_string(),
 				backups: Vec::new(),
@@ -1555,7 +1629,7 @@ impl AstPageFormatter {
 			backups.push(PageMacroBackup { id, original });
 
 			// Insert placeholder (macro format so rustfmt doesn't touch it)
-			result.push_str(&format!("__reinhardt_placeholder__!(/*{}*/)", id));
+			result.push_str(&format!("__reinhardt_placeholder_{}__!()", id));
 
 			last_end = macro_info.end;
 		}
@@ -1582,11 +1656,73 @@ impl AstPageFormatter {
 
 		// Replace placeholders in reverse order to maintain correct positions
 		for backup in backups.iter().rev() {
-			let placeholder = format!("__reinhardt_placeholder__!(/*{}*/)", backup.id);
+			let placeholder = format!("__reinhardt_placeholder_{}__!()", backup.id);
 			result = result.replace(&placeholder, &backup.original);
 		}
 
 		result
+	}
+
+	/// Restore page! macros from placeholders, re-formatting each one so
+	/// nested page! invocations get the same pretty-printing as top-level
+	/// ones. The base indent for the recursive format pass is computed from
+	/// the column where the placeholder appears in `content`.
+	pub(crate) fn restore_page_macros_recursive(
+		&self,
+		content: &str,
+		backups: &[PageMacroBackup],
+	) -> String {
+		if backups.is_empty() {
+			return content.to_string();
+		}
+
+		let mut result = content.to_string();
+
+		for backup in backups.iter().rev() {
+			let placeholder = format!("__reinhardt_placeholder_{}__!()", backup.id);
+			let replacement = self
+				.format_inner_page_macro(&backup.original, &result, &placeholder)
+				.unwrap_or_else(|| backup.original.clone());
+			result = result.replace(&placeholder, &replacement);
+		}
+
+		result
+	}
+
+	/// Reformat a single backed-up `page!(...)` string with `format_macro_tokens`,
+	/// using the indentation of the placeholder's line as the base indent.
+	/// Returns `None` if parsing or re-formatting fails, in which case the
+	/// caller falls back to the original (unformatted) backup text.
+	fn format_inner_page_macro(
+		&self,
+		original: &str,
+		surrounding: &str,
+		placeholder: &str,
+	) -> Option<String> {
+		// Extract `<inner>` from `page!(<inner>)` (or the equivalent
+		// TokenStream Display form `page ! ( <inner> )`).
+		let hit = find_page_bang_paren(original)?;
+		let head = hit.paren_open + 1;
+		let tail = original.rfind(')')?;
+		if tail <= head {
+			return None;
+		}
+		let inner = &original[head..tail];
+
+		// Reparse so the recursive formatter receives a real TokenStream.
+		let tokens = syn::parse_str::<proc_macro2::TokenStream>(inner).ok()?;
+
+		// Compute base indent from the placeholder's column (tabs only — the
+		// file uses hard tabs per rustfmt.toml `hard_tabs = true`).
+		let pos = surrounding.find(placeholder)?;
+		let line_start = surrounding[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
+		let base_indent = surrounding[line_start..pos]
+			.chars()
+			.filter(|c| *c == '\t')
+			.count();
+
+		let formatted = self.format_macro_tokens(&tokens, base_indent).ok()?;
+		Some(format!("page!({})", formatted))
 	}
 }
 
@@ -2474,7 +2610,7 @@ fn main() {}"#;
 		assert!(
 			result
 				.protected_content
-				.contains("__reinhardt_placeholder__!(/*0*/)")
+				.contains("__reinhardt_placeholder_0__!()")
 		);
 		assert!(!result.protected_content.contains("page!("));
 		assert_eq!(result.backups.len(), 1);
@@ -2498,12 +2634,12 @@ let view2 = page!(|| { div { "second" } });
 		assert!(
 			result
 				.protected_content
-				.contains("__reinhardt_placeholder__!(/*0*/)")
+				.contains("__reinhardt_placeholder_0__!()")
 		);
 		assert!(
 			result
 				.protected_content
-				.contains("__reinhardt_placeholder__!(/*1*/)")
+				.contains("__reinhardt_placeholder_1__!()")
 		);
 		assert!(!result.protected_content.contains("page!("));
 		assert_eq!(result.backups.len(), 2);
@@ -2531,7 +2667,7 @@ fn main() {}"#;
 		assert!(
 			result
 				.protected_content
-				.contains("__reinhardt_placeholder__!(/*0*/)")
+				.contains("__reinhardt_placeholder_0__!()")
 		);
 	}
 
@@ -2636,7 +2772,7 @@ fn main() {
 		assert!(
 			result
 				.protected_content
-				.contains("__reinhardt_placeholder__!(/*0*/)(props)")
+				.contains("__reinhardt_placeholder_0__!()(props)")
 		);
 		assert_eq!(result.backups.len(), 1);
 		assert_eq!(restored, input);
@@ -2730,7 +2866,7 @@ fn main() {
 		assert!(
 			protected
 				.protected_content
-				.contains("__reinhardt_placeholder__")
+				.contains("__reinhardt_placeholder_")
 		);
 		assert_eq!(restored, original);
 	}
@@ -3023,7 +3159,7 @@ fn main() {
 		assert!(result.skipped.is_none(), "formatting should not be skipped");
 		assert_eq!(
 			result.content,
-			"page!(|signal: Action<Vec<Item>, String>| {\n\tdiv {\n\t\t{\n\t\t\tView::fragment(\n\t\t\t\t\tsignal\n\t\t\t\t\t\t.result()\n\t\t\t\t\t\t.unwrap_or_default()\n\t\t\t\t\t\t.iter()\n\t\t\t\t\t\t.map(|item| {\n\t\t\t\t\t\t\tlet text = item.text.clone();\n\t\t\t\t\t\t\tpage!(| text : String | { span { { text } } })(text)\n\t\t\t\t\t\t})\n\t\t\t\t\t\t.collect::<Vec<_>>(),\n\t\t\t\t)\n\t\t}\n\t}\n})(signal)"
+			"page!(|signal: Action<Vec<Item>, String>| {\n\tdiv {\n\t\t{\n\t\t\tView::fragment(\n\t\t\t\t\tsignal\n\t\t\t\t\t\t.result()\n\t\t\t\t\t\t.unwrap_or_default()\n\t\t\t\t\t\t.iter()\n\t\t\t\t\t\t.map(|item| {\n\t\t\t\t\t\t\tlet text = item.text.clone();\n\t\t\t\t\t\t\tpage!(|text: String| {\n\t\t\t\t\t\t\t\tspan {\n\t\t\t\t\t\t\t\t\t{ text }\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t})(text)\n\t\t\t\t\t\t})\n\t\t\t\t\t\t.collect::<Vec<_>>(),\n\t\t\t\t)\n\t\t}\n\t}\n})(signal)"
 		);
 	}
 
@@ -3048,7 +3184,7 @@ fn main() {
 		assert!(result.skipped.is_none(), "formatting should not be skipped");
 		assert_eq!(
 			result.content,
-			"page!(|signal: Action<Vec<Item>, String>| {\n\tdiv {\n\t\tif signal.result().is_some() {\n\t\t\t{\n\t\t\t\tView::fragment(\n\t\t\t\t\t\tsignal\n\t\t\t\t\t\t\t.result()\n\t\t\t\t\t\t\t.unwrap_or_default()\n\t\t\t\t\t\t\t.iter()\n\t\t\t\t\t\t\t.map(|item| {\n\t\t\t\t\t\t\t\tlet text = item.text.clone();\n\t\t\t\t\t\t\t\tpage!(| text : String | { div class = \"item\" { { text } } })(text)\n\t\t\t\t\t\t\t})\n\t\t\t\t\t\t\t.collect::<Vec<_>>(),\n\t\t\t\t\t)\n\t\t\t}\n\t\t} else {\n\t\t\tp {\n\t\t\t\t\"Loading...\"\n\t\t\t}\n\t\t}\n\t}\n})(signal)"
+			"page!(|signal: Action<Vec<Item>, String>| {\n\tdiv {\n\t\tif signal.result().is_some() {\n\t\t\t{\n\t\t\t\tView::fragment(\n\t\t\t\t\t\tsignal\n\t\t\t\t\t\t\t.result()\n\t\t\t\t\t\t\t.unwrap_or_default()\n\t\t\t\t\t\t\t.iter()\n\t\t\t\t\t\t\t.map(|item| {\n\t\t\t\t\t\t\t\tlet text = item.text.clone();\n\t\t\t\t\t\t\t\tpage!(|text: String| {\n\t\t\t\t\t\t\t\t\tdiv\n\t\t\t\t\t\t\t\t\tclass = \"item\"\n\t\t\t\t\t\t\t\t\t{ { text } }\n\t\t\t\t\t\t\t\t})(text)\n\t\t\t\t\t\t\t})\n\t\t\t\t\t\t\t.collect::<Vec<_>>(),\n\t\t\t\t\t)\n\t\t\t}\n\t\t} else {\n\t\t\tp {\n\t\t\t\t\"Loading...\"\n\t\t\t}\n\t\t}\n\t}\n})(signal)"
 		);
 	}
 

--- a/crates/reinhardt-admin-cli/src/ast_formatter.rs
+++ b/crates/reinhardt-admin-cli/src/ast_formatter.rs
@@ -285,9 +285,9 @@ fn find_page_bang_paren(s: &str) -> Option<PageBangParen> {
 			continue;
 		}
 
-		// String literal — handle both raw (`r"..."`, `r#"..."#`...) and
-		// regular forms. `detect_raw_string_start` walks backwards from
-		// the `"` to find a leading `r` (plus optional `#`s) at a word
+		// String literal — handle both raw (`r"..."`, `r#"..."#`, `br#"..."#`...)
+		// and regular forms. `detect_raw_string_start` walks backwards from
+		// the `"` to find a leading `r` or `br` (plus optional `#`s) at a word
 		// boundary.
 		if b == b'"' {
 			if let Some(hash_count) = detect_raw_string_start(s, i)
@@ -472,14 +472,22 @@ fn find_matching_paren(source: &str, start: usize) -> Option<usize> {
 /// Detect if a '"' at the given offset is the start of a raw string.
 /// Returns Some(hash_count) if so (0 for r"...", 1 for r#"..."#, etc.).
 fn detect_raw_string_start(s: &str, quote_offset: usize) -> Option<usize> {
-	// Walk backwards from the quote to find r followed by optional #s
+	// Walk backwards from the quote to find r (or br) followed by optional #s
 	let before = &s[..quote_offset];
 	let trimmed = before.trim_end_matches('#');
 	let hash_count = before.len() - trimmed.len();
+
+	// Check for raw string (r"..." or r#"..."#) or raw byte string (br"..." or br#"..."#)
 	if trimmed.ends_with('r') {
 		// Verify the 'r' is not part of an identifier
 		let r_pos = trimmed.len() - 1;
 		if r_pos == 0 || !before.as_bytes()[r_pos - 1].is_ascii_alphanumeric() {
+			return Some(hash_count);
+		}
+	} else if trimmed.len() >= 2 && trimmed.ends_with("br") {
+		// Check for raw byte string: br"..." or br#"..."#
+		let br_pos = trimmed.len() - 2;
+		if br_pos == 0 || !before.as_bytes()[br_pos - 1].is_ascii_alphanumeric() {
 			return Some(hash_count);
 		}
 	}
@@ -2968,6 +2976,64 @@ fn main() {
 			result
 				.protected_content
 				.contains("__reinhardt_placeholder_0__!()")
+		);
+	}
+
+	// Regression: same as the raw string test but using raw byte strings
+	// (`br#"..."#`), which the scanner must also traverse without descending
+	// into the body.
+	#[rstest]
+	fn test_protect_skips_lookalike_in_raw_byte_string() {
+		// Arrange
+		let formatter = AstPageFormatter::new();
+		let input = "let s = br#\"page!(|| { div { \"hi\" } })\"#;\nlet view = page!(|| { div { \"hi\" } });";
+
+		// Act
+		let result = formatter.protect_page_macros(input);
+
+		// Assert
+		assert_eq!(result.backups.len(), 1);
+		assert_eq!(
+			result
+				.protected_content
+				.matches("br#\"page!(|| { div { \"hi\" } })\"#")
+				.count(),
+			1
+		);
+		assert_eq!(
+			result
+				.protected_content
+				.matches("__reinhardt_placeholder_0__!()")
+				.count(),
+			1
+		);
+	}
+
+	// Regression: raw byte string with multiple hashes (`br##"..."##`).
+	#[rstest]
+	fn test_protect_skips_lookalike_in_raw_byte_string_multi_hash() {
+		// Arrange
+		let formatter = AstPageFormatter::new();
+		let input = "let s = br##\"page!(|| { div { \"#hi#\" } })\"##;\nlet view = page!(|| { div { \"hi\" } });";
+
+		// Act
+		let result = formatter.protect_page_macros(input);
+
+		// Assert
+		assert_eq!(result.backups.len(), 1);
+		assert_eq!(
+			result
+				.protected_content
+				.matches("br##\"page!(|| { div { \"#hi#\" } })\"##")
+				.count(),
+			1
+		);
+		assert_eq!(
+			result
+				.protected_content
+				.matches("__reinhardt_placeholder_0__!()")
+				.count(),
+			1
 		);
 	}
 

--- a/crates/reinhardt-admin-cli/src/ast_formatter.rs
+++ b/crates/reinhardt-admin-cli/src/ast_formatter.rs
@@ -2607,12 +2607,10 @@ fn main() {}"#;
 		let result = formatter.protect_page_macros(input);
 
 		// Assert
-		assert!(
-			result
-				.protected_content
-				.contains("__reinhardt_placeholder_0__!()")
+		assert_eq!(
+			result.protected_content,
+			r#"let view = __reinhardt_placeholder_0__!();"#
 		);
-		assert!(!result.protected_content.contains("page!("));
 		assert_eq!(result.backups.len(), 1);
 		assert_eq!(result.backups[0].id, 0);
 		assert!(result.backups[0].original.starts_with("page!("));
@@ -2631,17 +2629,10 @@ let view2 = page!(|| { div { "second" } });
 		let result = formatter.protect_page_macros(input);
 
 		// Assert
-		assert!(
-			result
-				.protected_content
-				.contains("__reinhardt_placeholder_0__!()")
+		assert_eq!(
+			result.protected_content,
+			"\nlet view1 = __reinhardt_placeholder_0__!();\nlet view2 = __reinhardt_placeholder_1__!();\n"
 		);
-		assert!(
-			result
-				.protected_content
-				.contains("__reinhardt_placeholder_1__!()")
-		);
-		assert!(!result.protected_content.contains("page!("));
 		assert_eq!(result.backups.len(), 2);
 	}
 
@@ -2661,13 +2652,15 @@ fn main() {}"#;
 		let result = formatter.protect_page_macros(input);
 
 		// Assert
-		assert!(result.protected_content.contains("use foo::bar;"));
-		assert!(result.protected_content.contains("fn render() -> View"));
-		assert!(result.protected_content.contains("fn main() {}"));
-		assert!(
-			result
-				.protected_content
-				.contains("__reinhardt_placeholder_0__!()")
+		assert_eq!(
+			result.protected_content,
+			r#"use foo::bar;
+
+fn render() -> View {
+    __reinhardt_placeholder_0__!()
+}
+
+fn main() {}"#
 		);
 	}
 
@@ -2769,10 +2762,9 @@ fn main() {
 			AstPageFormatter::restore_page_macros(&result.protected_content, &result.backups);
 
 		// Assert
-		assert!(
-			result
-				.protected_content
-				.contains("__reinhardt_placeholder_0__!()(props)")
+		assert_eq!(
+			result.protected_content,
+			r#"let view = __reinhardt_placeholder_0__!()(props);"#
 		);
 		assert_eq!(result.backups.len(), 1);
 		assert_eq!(restored, input);
@@ -2863,10 +2855,9 @@ fn main() {
 
 		// Assert
 		assert_eq!(protected.backups.len(), 1);
-		assert!(
-			protected
-				.protected_content
-				.contains("__reinhardt_placeholder_")
+		assert_eq!(
+			protected.protected_content,
+			r#"let view = __reinhardt_placeholder_0__!();"#
 		);
 		assert_eq!(restored, original);
 	}

--- a/crates/reinhardt-admin-cli/src/ast_formatter.rs
+++ b/crates/reinhardt-admin-cli/src/ast_formatter.rs
@@ -244,14 +244,105 @@ struct PageBangParen {
 
 /// Find the next `page <ws>* ! <ws>* (` occurrence in `s`, ensuring the
 /// `page` token is at a word boundary (not part of a larger identifier
-/// like `mypage`). Returns `None` if none found. Accepts the canonical
-/// `page!(` form authored by users as well as the `page ! (` form emitted
-/// by `proc_macro2::TokenStream`'s `Display`.
+/// like `mypage`). Skips matches that appear inside line comments
+/// (`// ...`), block comments (`/* ... */`, nested), regular string
+/// literals (`"..."`), raw string literals (`r"..."`, `r#"..."#`, ...),
+/// and char literals (`'x'`), so a `page!(...)` substring embedded in
+/// such content cannot be mistaken for a real macro invocation.
+/// Returns `None` if none found. Accepts the canonical `page!(` form
+/// authored by users as well as the `page ! (` form emitted by
+/// `proc_macro2::TokenStream`'s `Display`.
 fn find_page_bang_paren(s: &str) -> Option<PageBangParen> {
 	let bytes = s.as_bytes();
 	let mut i = 0;
-	while let Some(rel) = s[i..].find("page") {
-		let start = i + rel;
+	while i + "page".len() <= bytes.len() {
+		let b = bytes[i];
+
+		// Line comment: skip to end of line.
+		if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+			i += 2;
+			while i < bytes.len() && bytes[i] != b'\n' {
+				i += 1;
+			}
+			continue;
+		}
+
+		// Block comment (Rust allows nesting): skip to matching `*/`.
+		if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+			i += 2;
+			let mut depth: usize = 1;
+			while i + 1 < bytes.len() && depth > 0 {
+				if bytes[i] == b'/' && bytes[i + 1] == b'*' {
+					depth += 1;
+					i += 2;
+				} else if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+					depth -= 1;
+					i += 2;
+				} else {
+					i += 1;
+				}
+			}
+			continue;
+		}
+
+		// String literal — handle both raw (`r"..."`, `r#"..."#`...) and
+		// regular forms. `detect_raw_string_start` walks backwards from
+		// the `"` to find a leading `r` (plus optional `#`s) at a word
+		// boundary.
+		if b == b'"' {
+			if let Some(hash_count) = detect_raw_string_start(s, i)
+				&& let Some(end) = skip_raw_string(s, i + 1, hash_count)
+			{
+				i = end;
+				continue;
+			}
+			i += 1;
+			while i < bytes.len() {
+				match bytes[i] {
+					b'\\' if i + 1 < bytes.len() => i += 2,
+					b'"' => {
+						i += 1;
+						break;
+					}
+					_ => i += 1,
+				}
+			}
+			continue;
+		}
+
+		// Char literal vs lifetime. A char literal closes its apostrophe
+		// within a few bytes (`'x'`, `'\n'`, `'\u{1F600}'`); a lifetime
+		// (`'a`, `'static`) does not. Look ahead with a small budget and
+		// only skip when a closing quote is found.
+		if b == b'\'' {
+			let mut j = i + 1;
+			let limit = (i + 10).min(bytes.len());
+			let mut closed = None;
+			while j < limit {
+				match bytes[j] {
+					b'\\' if j + 1 < bytes.len() => j += 2,
+					b'\'' => {
+						closed = Some(j);
+						break;
+					}
+					_ => j += 1,
+				}
+			}
+			if let Some(close) = closed {
+				i = close + 1;
+				continue;
+			}
+			// Treat as lifetime — step past the apostrophe only.
+			i += 1;
+			continue;
+		}
+
+		// Not in a comment or literal — look for the `page` keyword.
+		if &bytes[i..i + "page".len()] != b"page" {
+			i += 1;
+			continue;
+		}
+		let start = i;
 		// Reject if preceded by an identifier-continuation byte.
 		if start > 0 {
 			let prev = bytes[start - 1];
@@ -2783,6 +2874,101 @@ fn main() {
 		);
 		assert_eq!(result.backups.len(), 1);
 		assert_eq!(restored, input);
+	}
+
+	// Regression: a `page!(...)`-shaped substring inside a preceding
+	// `//` comment with the same token sequence as the real macro must
+	// not be mistaken for the real invocation. Previously the source
+	// scanner would lock onto the comment substring and leave the real
+	// macro unprotected.
+	#[rstest]
+	fn test_protect_skips_lookalike_in_line_comment() {
+		// Arrange
+		let formatter = AstPageFormatter::new();
+		let input = "// page!(|| { div { \"hi\" } })\nlet view = page!(|| { div { \"hi\" } });";
+
+		// Act
+		let result = formatter.protect_page_macros(input);
+
+		// Assert
+		assert_eq!(result.backups.len(), 1);
+		assert_eq!(
+			result.protected_content,
+			"// page!(|| { div { \"hi\" } })\nlet view = __reinhardt_placeholder_0__!();"
+		);
+	}
+
+	// Regression: same as the line-comment case but with a block comment
+	// preceding the real macro.
+	#[rstest]
+	fn test_protect_skips_lookalike_in_block_comment() {
+		// Arrange
+		let formatter = AstPageFormatter::new();
+		let input = "/* page!(|| { div { \"hi\" } }) */\nlet view = page!(|| { div { \"hi\" } });";
+
+		// Act
+		let result = formatter.protect_page_macros(input);
+
+		// Assert
+		assert_eq!(result.backups.len(), 1);
+		assert_eq!(
+			result.protected_content,
+			"/* page!(|| { div { \"hi\" } }) */\nlet view = __reinhardt_placeholder_0__!();"
+		);
+	}
+
+	// Regression: a `page!(...)` literal inside a regular string literal
+	// must not be picked up as a macro invocation, even when its tokens
+	// match the real macro byte-for-byte.
+	#[rstest]
+	fn test_protect_skips_lookalike_in_string_literal() {
+		// Arrange
+		let formatter = AstPageFormatter::new();
+		let input = "let s = \"page!(|| { div { \\\"hi\\\" } })\";\nlet view = page!(|| { div { \"hi\" } });";
+
+		// Act
+		let result = formatter.protect_page_macros(input);
+
+		// Assert
+		assert_eq!(result.backups.len(), 1);
+		// The string literal must be left intact and only the real
+		// macro on the second line should be replaced with a placeholder.
+		assert!(
+			result
+				.protected_content
+				.contains("\"page!(|| { div { \\\"hi\\\" } })\"")
+		);
+		assert!(
+			result
+				.protected_content
+				.contains("__reinhardt_placeholder_0__!()")
+		);
+	}
+
+	// Regression: same as the string-literal case but using a raw string
+	// (`r#"..."#`), which the scanner must traverse without descending
+	// into its body.
+	#[rstest]
+	fn test_protect_skips_lookalike_in_raw_string() {
+		// Arrange
+		let formatter = AstPageFormatter::new();
+		let input = "let s = r#\"page!(|| { div { \"hi\" } })\"#;\nlet view = page!(|| { div { \"hi\" } });";
+
+		// Act
+		let result = formatter.protect_page_macros(input);
+
+		// Assert
+		assert_eq!(result.backups.len(), 1);
+		assert!(
+			result
+				.protected_content
+				.contains("r#\"page!(|| { div { \"hi\" } })\"#")
+		);
+		assert!(
+			result
+				.protected_content
+				.contains("__reinhardt_placeholder_0__!()")
+		);
 	}
 
 	// ==================== Unicode Character Tests ====================

--- a/crates/reinhardt-admin-cli/src/ast_formatter.rs
+++ b/crates/reinhardt-admin-cli/src/ast_formatter.rs
@@ -174,7 +174,14 @@ impl<'a> PageMacroVisitor<'a> {
 	/// `expr.to_token_stream()` (it inserts whitespace between tokens).
 	/// Without the lenient match, nested `page!` macros inside such
 	/// wrapper code would be invisible to `protect_page_macros`.
-	fn find_macro_in_source(&self, _tokens_content: &str) -> Option<MacroInfo> {
+	///
+	/// `tokens_content` is the `TokenStream` Display form of the macro
+	/// being located (i.e. `mac.tokens.to_string()` from syn). It is
+	/// used to disambiguate when a `page!(...)`-shaped substring also
+	/// appears in a preceding string literal or comment: the parsed
+	/// candidate's `to_string()` must match `tokens_content` to be
+	/// accepted.
+	fn find_macro_in_source(&self, tokens_content: &str) -> Option<MacroInfo> {
 		let mut search_start = 0;
 
 		// Skip already found macros
@@ -192,8 +199,13 @@ impl<'a> PageMacroVisitor<'a> {
 			if let Some(end_pos) = find_matching_paren(self.source, content_start) {
 				let macro_content = &self.source[content_start..end_pos];
 
-				// Parse the content to get tokens
-				if let Ok(tokens) = syn::parse_str::<proc_macro2::TokenStream>(macro_content) {
+				// Parse the content to get tokens, and verify it matches the
+				// AST node we're locating. Without this check, a `page!(...)`
+				// substring inside a preceding string literal or `//` comment
+				// could be mistaken for the real macro invocation.
+				if let Ok(tokens) = syn::parse_str::<proc_macro2::TokenStream>(macro_content)
+					&& tokens.to_string() == tokens_content
+				{
 					return Some(MacroInfo {
 						start: abs_start,
 						end: end_pos + 1, // Include closing paren
@@ -1701,9 +1713,12 @@ impl AstPageFormatter {
 	) -> Option<String> {
 		// Extract `<inner>` from `page!(<inner>)` (or the equivalent
 		// TokenStream Display form `page ! ( <inner> )`).
+		// Use the string-aware `find_matching_paren` rather than
+		// `rfind(')')` so a `)` inside a string literal or nested group
+		// in the macro body never gets confused with the closing paren.
 		let hit = find_page_bang_paren(original)?;
 		let head = hit.paren_open + 1;
-		let tail = original.rfind(')')?;
+		let tail = find_matching_paren(original, head)?;
 		if tail <= head {
 			return None;
 		}

--- a/crates/reinhardt-db/src/m2m_naming.rs
+++ b/crates/reinhardt-db/src/m2m_naming.rs
@@ -90,7 +90,11 @@ fn to_snake_case(name: &str) -> String {
 /// assert_eq!(default_through_table("auth_user", "FollowedBy"), "auth_user_followed_by");
 /// ```
 pub fn default_through_table(source_table: &str, field_name: &str) -> String {
-	format!("{}_{}", source_table.to_lowercase(), to_snake_case(field_name))
+	format!(
+		"{}_{}",
+		source_table.to_lowercase(),
+		to_snake_case(field_name)
+	)
 }
 
 /// Default `(source_column, target_column)` for a ManyToMany intermediate table.

--- a/crates/reinhardt-manouche/src/parser/page.rs
+++ b/crates/reinhardt-manouche/src/parser/page.rs
@@ -316,12 +316,30 @@ fn parse_event(input: ParseStream) -> Result<PageEvent> {
 	})
 }
 
-/// Parses a braced expression: `{ expr }`
+/// Parses a braced expression: `{ expr }` (or `{ stmts...; expr }`).
+///
+/// Uses `Block::parse_within` so block bodies with let-statements such as
+/// `{ let x = ...; expr }` are accepted. When the body is a single trailing
+/// expression with no statements, the inner Expr is returned directly to
+/// preserve the legacy AST shape — wrapping it in `Expr::Block` would cause
+/// downstream formatters to emit a redundant outer `{ ... }`.
 fn parse_braced_expression(input: ParseStream) -> Result<PageNode> {
 	let span = input.span();
 	let content;
-	braced!(content in input);
-	let expr: Expr = content.parse()?;
+	let brace_token = braced!(content in input);
+	let stmts = syn::Block::parse_within(&content)?;
+
+	let expr = match stmts.as_slice() {
+		// Single trailing expression (no trailing `;`): unwrap to preserve
+		// the historical PageExpression shape so legacy formatters do not
+		// see an extra `Expr::Block` wrapper.
+		[syn::Stmt::Expr(inner, None)] => inner.clone(),
+		_ => Expr::Block(syn::ExprBlock {
+			attrs: Vec::new(),
+			label: None,
+			block: syn::Block { brace_token, stmts },
+		}),
+	};
 
 	Ok(PageNode::Expression(PageExpression {
 		expr,

--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -410,21 +410,40 @@ pub fn polls_results(question_id: i64) -> Page {
 												page!(|choices: Vec<ChoiceInfo>, total: i32| {
 													for choice in choices {
 														{
-															let percentage = if total > 0 {
-																(choice.votes as f64 / total as f64 * 100.0) as i32
-															} else {
-																0
-															};
-															page!(| choice : ChoiceInfo, percentage : i32 | { div {
-										            class : "py-4", div { class : "flex justify-between items-center mb-2",
-										            strong { { choice.choice_text.clone() } } span { class :
-										            "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
-										            { format!("{} votes", choice.votes) } } } div { class :
-										            "w-full bg-surface-tertiary rounded-full h-2.5", div { class :
-										            "bg-brand h-2.5 rounded-full", role : "progressbar", style :
-										            format!("width: {}%", percentage), aria_valuenow : percentage.to_string(),
-										            aria_valuemin : "0", aria_valuemax : "100", { format!("{}%", percentage) } }
-										            } } })(choice, percentage)
+															{
+																	let percentage = if total > 0 {
+																		(choice.votes as f64 / total as f64 * 100.0) as i32
+																	} else {
+																		0
+																	};
+																	page!(|choice: ChoiceInfo, percentage: i32| {
+																		div {
+																			class: "py-4",
+																			div {
+																				class: "flex justify-between items-center mb-2",
+																				strong {
+																					{ choice.choice_text.clone() }
+																				}
+																				span {
+																					class: "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
+																					{ format!("{} votes", choice.votes) }
+																				}
+																			}
+																			div {
+																				class: "w-full bg-surface-tertiary rounded-full h-2.5",
+																				div {
+																					class: "bg-brand h-2.5 rounded-full",
+																					role: "progressbar",
+																					style: format!("width: {}%", percentage),
+																					aria_valuenow: percentage.to_string(),
+																					aria_valuemin: "0",
+																					aria_valuemax: "100",
+																					{ format!("{}%", percentage) }
+																				}
+																			}
+																		}
+																	})(choice, percentage)
+																}
 														}
 													}
 												})(choices, total)


### PR DESCRIPTION
## Summary

- Fix nested `page!` macros being left as a compact single-line `page ! (...)` string after `reinhardt-admin fmt`
- Extend the page DSL parser to accept block bodies with let-statements such as `{ let x = ...; expr }` so recursive formatting can succeed

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

When `page!` macros are nested — e.g. `polls_results` in
`examples/examples-tutorial-basis/src/apps/polls/client/components.rs` — running
`reinhardt-admin fmt` left the inner `page!` as the raw TokenStream Display
form on a single line:

```
page ! (| choice : ChoiceInfo , percentage : i32 | { div { class : "py-4" , ... } })
```

### Root cause

1. **TokenStream Display inserts whitespace**: in `format_rust_expression` the
   wrapper code is built via `expr.to_token_stream().to_string()`. `proc_macro2`'s
   `Display` always emits whitespace between tokens, so nested macros come out
   as `page ! (`. Meanwhile `protect_page_macros` and `find_macro_in_source`
   searched for the literal `page!(`, so those inner macros were never
   protected from rustfmt and never recursively formatted — they were just
   re-inserted as the stringified token tree.
2. **prettyplease strips macro-arg comments**: the placeholder
   `__reinhardt_placeholder__!(/*N*/)` lost its `/*N*/` comment through
   `prettyplease::unparse`, leaving every placeholder indistinguishable on
   restore.
3. **page DSL parser rejected let-statements**: `parse_braced_expression`
   called `content.parse::<Expr>()` directly, so a body like
   `{ let percentage = ...; page!(...) }` (used in components.rs) failed to
   parse with `unexpected token, expected '}'`, and the recursive formatter
   always fell back to the unmodified backup.

## What Changed

### `crates/reinhardt-admin-cli/src/ast_formatter.rs`
- Add `find_page_bang_paren` helper that matches both `page!(` and `page ! (`
  at a word boundary.
- Route `find_macro_in_source` / `protect_page_macros` /
  `find_page_macros_text_based` / the `format()` early-exit through it so
  every page!-locator handles the TokenStream Display form.
- Change the placeholder format to `__reinhardt_placeholder_N__!()` so the
  ID lives in the macro name and survives `prettyplease::unparse`.
- Add `restore_page_macros_recursive` + `format_inner_page_macro`: each
  backup is reparsed as a `PageMacro` AST and reformatted via
  `format_macro_tokens`, with the placeholder's column (tabs only) used as
  the base indent so the inner macro aligns with its host expression.
- Update the related test expectations to reflect the new, properly
  pretty-printed nested output.

### `crates/reinhardt-manouche/src/parser/page.rs`
- Switch `parse_braced_expression` to `syn::Block::parse_within` so block
  bodies with let-statements are accepted.
- When the body parses to a single trailing expression (no statements),
  return the inner `Expr` directly instead of wrapping it in `Expr::Block`.
  Always wrapping would cause downstream formatters to emit an extra outer
  `{ ... }` around existing `{ x }` expressions, breaking idempotency.

### `.semgrep/placeholder-check.yml`
- Broaden the regex to `__reinhardt_placeholder(?:_\d+)?__!\(` so both the
  legacy and new placeholder forms are detected.

## How Was This Tested

- `cargo test -p reinhardt-admin-cli ast_formatter` — 82 passed
- `cargo test -p reinhardt-manouche` — 361 passed
- Ran `reinhardt-admin fmt` against the previously-broken
  `examples-tutorial-basis/src/apps/polls/client/components.rs` and verified
  both levels of nested `page!` are emitted with proper line breaks and
  indentation
- Ran the formatter twice in sequence and confirmed idempotency
  (`0 formatted, 1 unchanged` on the second pass)
- Verified that single-brace expressions like
  `{ x.unwrap_or_default() }` are preserved as single-brace (no regression
  from the parser change)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally

## Labels to Apply

- bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multi-statement braced expressions (including let-statements) in parsing.
  * More tolerant detection of page-like macros (accepts flexible spacing and bang/paren spacing).

* **Bug Fixes**
  * Placeholder format updated to allow optional numeric suffixes.
  * Recursive restoration/formatting for nested macros to preserve consistent indentation.

* **Tests**
  * Expanded regression tests covering nested macros and lookalikes in comments/strings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->