### PR TITLE
fix(ci): cast MySQL information_schema text columns to CHAR in column_data_type

### DIFF
--- a/tests/integration/tests/migrations/migration_rollback_integration.rs
+++ b/tests/integration/tests/migrations/migration_rollback_integration.rs
@@ -378,8 +378,16 @@ async fn column_data_type(
 			//                       of `DATABASE()`, so the next residual
 			//                       flake's CI log carries enough state to
 			//                       diagnose the root cause.
+			//
+			// Issue #4675: wrap every `information_schema` text column in
+			// `CAST(... AS CHAR)`. The unwrapped columns are typed as
+			// `LONGBLOB`/`LONGTEXT` over the binary protocol on some MySQL
+			// 8.x + sqlx combinations, which makes `query_scalar::<_, String>`
+			// fail with `ColumnDecode { mismatched types ... String (as
+			// VARCHAR) is not compatible with SQL type LONGBLOB }`. The CAST
+			// forces the result back to a text type sqlx recognises.
 			let result = sqlx::query_scalar::<_, String>(
-				"SELECT data_type FROM information_schema.columns \
+				"SELECT CAST(data_type AS CHAR) FROM information_schema.columns \
 				 WHERE LOWER(table_schema) = LOWER(DATABASE()) \
 				 AND LOWER(table_name) = LOWER(?) \
 				 AND LOWER(column_name) = LOWER(?)",
@@ -396,7 +404,10 @@ async fn column_data_type(
 					// large enough to spot duplicate-table-across-schemas drift
 					// without dominating the log.
 					let dump = sqlx::query_as::<_, (String, String, String, String)>(
-						"SELECT table_schema, table_name, column_name, data_type \
+						"SELECT CAST(table_schema AS CHAR), \
+						        CAST(table_name AS CHAR), \
+						        CAST(column_name AS CHAR), \
+						        CAST(data_type AS CHAR) \
 						 FROM information_schema.columns \
 						 WHERE LOWER(table_name) = LOWER(?) \
 						 ORDER BY table_schema, column_name \
@@ -409,7 +420,7 @@ async fn column_data_type(
 					// failed `SELECT DATABASE()` is logged as the failure it is
 					// rather than collapsing into a misleading `None`.
 					let current_db: Result<Option<String>, _> =
-						sqlx::query_scalar("SELECT DATABASE()")
+						sqlx::query_scalar("SELECT CAST(DATABASE() AS CHAR)")
 							.fetch_optional(&pool)
 							.await;
 					let current_db_repr = match current_db {
@@ -417,7 +428,7 @@ async fn column_data_type(
 						Err(err) => format!("<query failed: {err:?}>"),
 					};
 					eprintln!(
-						"[issue#4649] column_data_type({table_name:?}, {column_name:?}) \
+						"[issue#4675] column_data_type({table_name:?}, {column_name:?}) \
 						 returned None; DATABASE()={current_db_repr}, \
 						 information_schema.columns WHERE LOWER(table_name)=LOWER(?) \
 						 (ORDER BY table_schema, column_name LIMIT 32) = {dump:#?}"
@@ -426,7 +437,7 @@ async fn column_data_type(
 				}
 				Err(err) => {
 					eprintln!(
-						"[issue#4649] column_data_type({table_name:?}, {column_name:?}) \
+						"[issue#4675] column_data_type({table_name:?}, {column_name:?}) \
 						 MySQL query failed: {err:?}"
 					);
 					None


### PR DESCRIPTION
## Summary

Resolves the integration-test failure on `migration_rollback_integration::test_alter_column_type_rollback::case_2_mysql` that has been blocking release-plz PRs (most recently #4671).

- Wrap every `information_schema` text column (`data_type`, `table_schema`, `table_name`, `column_name`) and `DATABASE()` in `CAST(... AS CHAR)` so sqlx receives a stable text type.
- Rename the diagnostic log prefix from `[issue#4649]` to `[issue#4675]` because the instrumentation is now maintained under this Issue. Issue #4649 was a different root cause (`Ok(None)` return) and is already closed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

CI failed with:

```
ColumnDecode { index: "0", source: "mismatched types; Rust type
  `alloc::string::String` (as SQL type `VARCHAR`) is not compatible
  with SQL type `LONGBLOB`" }
```

The `[issue#4649]` log prefix made the failure superficially look like a residual flake of the (closed) Issue #4649, but the root cause is different: the `Err(_)` arm added during that earlier fix now catches a brand-new failure mode where MySQL 8.x + sqlx reports `information_schema` text columns as `LONGBLOB`/`LONGTEXT` over the binary protocol. `query_scalar::<_, String>` rejects the decode and the wrapping `.ok().flatten()` collapses it into a misleading `None`, which the caller's `.expect(...)` then panics on.

The `CAST(... AS CHAR)` workaround is the standard sqlx + MySQL `information_schema` recipe for this class of mismatch.

## How Was This Tested

- [ ] `cargo nextest run -p reinhardt-integration-tests --test migrations test_alter_column_type_rollback::case_2_mysql` — verify locally after CI runs
- [ ] CI Cross-Crate Integration Tests / Cross-Crate Integration Tests (2/3) passes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My changes preserve the case-folding `WHERE` clause introduced for #4630 / #4649
- [x] Linked to Issue #4675

## Labels to Apply

- `bug` (sqlx decode failure causing CI failure)
- `ci-cd` (blocks every release-plz run)

## Related Issues

Fixes #4675
Carrier PR (not cause): #4671
Earlier related (closed, different root cause): #4630, #4649

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed MySQL schema introspection reliability in integration tests by improving data type handling and diagnostic error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->