### PR TITLE
chore(deps): floor lettre and astral-tokio-tar to RUSTSEC-fixed versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -637,6 +637,12 @@ testcontainers-modules = { version = "0.15.0", features = [
   "mysql",
   "redis",
 ] }
+# Direct floor for the transitive dep of testcontainers-modules. Clears
+# RUSTSEC-2026-0145 (PAX header desynchronization in astral-tokio-tar; fixed
+# in 0.6.2). Referenced from reinhardt-testkit as an optional dep so the
+# minimum-version constraint reaches the resolver only when the
+# `testcontainers` feature is on.
+astral-tokio-tar = "0.6.2"
 proptest = "1.11.0"
 arbitrary = { version = "1.4", features = ["derive"] }
 tokio-test = "0.4.5"

--- a/crates/reinhardt-mail/Cargo.toml
+++ b/crates/reinhardt-mail/Cargo.toml
@@ -16,7 +16,11 @@ thiserror = { workspace = true }
 reinhardt-core = { workspace = true, features = ["exception", "types"] }
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
-lettre = { version = "0.11", features = [
+# Floor at 0.11.22 to clear RUSTSEC-2026-0141 (TLS hostname verification disabled
+# under boring-tls backend; fixed in 0.11.22). The `tokio1-native-tls` feature
+# does not hit the vulnerable boring-tls code path here, but the floor protects
+# downstream consumers that may enable other TLS backends.
+lettre = { version = "0.11.22", features = [
   "tokio1",
   "tokio1-native-tls",
   "builder",

--- a/crates/reinhardt-testkit/Cargo.toml
+++ b/crates/reinhardt-testkit/Cargo.toml
@@ -18,6 +18,7 @@ testcontainers = [
   "dep:tokio-util",
   "dep:redis",
   "dep:fs2",
+  "dep:astral-tokio-tar",
 ]
 static = ["reinhardt-utils/staticfiles"]
 websockets = ["dep:reinhardt-websockets", "reinhardt-server/websocket"]
@@ -64,6 +65,10 @@ tracing = { workspace = true }
 # Optional dependencies for testcontainers feature
 testcontainers = { workspace = true, optional = true, features = ["blocking"] }
 testcontainers-modules = { workspace = true, optional = true }
+# Minimum-version floor for a transitive dep of testcontainers-modules.
+# Declared (but not used in code) to force the resolver to pick >=0.6.2,
+# which clears RUSTSEC-2026-0145. See workspace Cargo.toml for details.
+astral-tokio-tar = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 memcache-async = { version = "0.9.0", optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }


### PR DESCRIPTION
## Summary

This PR addresses two RustSec advisories filed against transitive deps:

- **#4672** — lettre <0.11.22 (RUSTSEC-2026-0141, severity 9.1): TLS hostname verification disabled under boring-tls
- **#4673** — astral-tokio-tar 0.6.0 (RUSTSEC-2026-0145): PAX header desynchronization

**Why a Cargo.toml floor instead of a `cargo update` on Cargo.lock (as the Issues proposed)?**

`Cargo.lock` is gitignored in reinhardt-web — the workspace is a library, not a binary, and follows the standard guidance of letting downstream consumers own their own lockfile. `git log --all -- Cargo.lock` confirms it has never been committed (`.gitignore` L43-45 explicitly excludes it for libraries). A `cargo update -p lettre` produces no committable diff here. The only way to push the fix to downstream consumers (e.g. reinhardt-cloud, which DOES commit Cargo.lock) without each one maintaining a parallel override is to tighten the **minimum-version constraint in our Cargo.toml**, so every fresh resolution against reinhardt-web picks a non-vulnerable version.

## Type of Change

- [x] Code quality improvements (dependency floor adjustment)

## Motivation and Context

Both Issues were filed with the proposed fix `cargo update -p ...`, but that fix is non-applicable in reinhardt-web because the lockfile is intentionally not version-controlled. Without a Cargo.toml floor, downstream consumers must each maintain a `cargo update -p` override in their own lockfile to silence `cargo audit`. Tightening the floor here pushes the fix exactly once.

Fixes #4672
Fixes #4673

## How Was This Tested?

- `cargo check -p reinhardt-mail` → builds clean (lettre resolves to 0.11.22)
- `cargo check -p reinhardt-testkit --features testcontainers` → builds clean (astral-tokio-tar resolves to 0.6.2 via the new floor)
- Confirmed lockfile entries in the local worktree:
  - `lettre 0.11.22` (was 0.11.19 before bump)
  - `astral-tokio-tar 0.6.2` (was 0.6.0 before bump)

## Changes

### `crates/reinhardt-mail/Cargo.toml`
- `lettre = "0.11"` → `lettre = "0.11.22"` with a comment explaining the RUSTSEC floor

### `Cargo.toml` (workspace)
- Add `astral-tokio-tar = "0.6.2"` to `[workspace.dependencies]` as a min-version floor for the transitive dep of `testcontainers-modules`

### `crates/reinhardt-testkit/Cargo.toml`
- Add `astral-tokio-tar = { workspace = true, optional = true }`
- Add `dep:astral-tokio-tar` to the `testcontainers` feature deps array

The new astral-tokio-tar entry is declared (but not imported in source) purely so the resolver sees the workspace-pinned minimum when `reinhardt-testkit/testcontainers` is enabled. There is no other portable way to constrain a transitive dep in Cargo when no newer upstream version (testcontainers-modules 0.15.0 is latest on crates.io) ships the fix.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (inline Cargo.toml comments explaining the floor + RUSTSEC IDs)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works  (n/a — Cargo.toml metadata only)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable) (n/a)
- [x] I have formatted the code with `cargo make fmt-fix` (no .rs changes)
- [x] I have checked the code with `cargo make clippy-check` (no .rs changes)

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4672 (RUSTSEC-2026-0141 — lettre)
- Fixes #4673 (RUSTSEC-2026-0145 — astral-tokio-tar)

## Labels to Apply

### Type Label
- [x] `dependencies`

### Scope Label
- (none — touches dep manifests only, no functional scope)

---

**Additional Context:**

The Issue bodies cite reinhardt-cloud PRs #609 / #610 as "applies the same transitive bump"; on inspection, #609 is actually an unrelated SPA-workaround refactor. The downstream cargo audit story is real (downstream commits Cargo.lock), but the upstream fix in reinhardt-web has to be a Cargo.toml floor, not a lockfile update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated and pinned multiple dependencies to specific versions.
  * Added transitive dependency version constraints for downstream compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->