### PR TITLE
style(examples): apply reinhardt-admin fmt to clear examples-test drift

### DIFF
--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -36,11 +36,11 @@ use reinhardt::pages::resolve_static;
 // Typed URL helpers are now emitted by `#[url_patterns]` directly
 // (issue #4656); we alias the macro-emitted `urls` module as `links` to
 // keep call sites concise.
-use crate::apps::polls::urls::client_router::urls as links;
 use crate::apps::polls::server_fn::{
 	create_choice, create_question, delete_choice, delete_question, get_question_detail,
 	get_question_results, get_questions, submit_vote, update_choice, update_question,
 };
+use crate::apps::polls::urls::client_router::urls as links;
 
 /// Polls index page - List all polls
 ///

--- a/examples/examples-twitter/src/apps/relationship/client/components.rs
+++ b/examples/examples-twitter/src/apps/relationship/client/components.rs
@@ -134,11 +134,7 @@ pub fn follow_button(target_user_id: Uuid, is_following_initial: bool) -> Page {
 					}
 				}
 			}
-		})(
-			is_following_signal,
-			toggle_follow,
-			toggle_follow_for_error,
-		)
+		})(is_following_signal, toggle_follow, toggle_follow_for_error)
 	}
 
 	#[cfg(native)]


### PR DESCRIPTION
## Summary

Apply `reinhardt-admin fmt .` (the formatter CI invokes via `cargo make fmt-check`) inside two example workspaces to clear the formatting drift that is currently blocking the release-plz Release PR #4671.

- `examples/examples-tutorial-basis/src/apps/polls/client/components.rs` — reorder the typed-URL `links` alias to follow the `server_fn::{...}` use group.
- `examples/examples-twitter/src/apps/relationship/client/components.rs` — collapse the trailing IIFE argument list to a single line.

Total diff: 2 files, +2 / -6 lines.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Motivation and Context

`examples-test-standalone` jobs `examples-tutorial-basis` and `examples-twitter` fail at the **Check Format** step (`cargo make fmt-check`, which executes `reinhardt-admin fmt . --check`) on the release-plz Release PR #4671. The Release PR does not touch these files; the drift was introduced by earlier merges into `main`.

The discrepancy could not be reproduced with the locally-installed `reinhardt-admin 0.1.0-rc.27`, which still mis-protected `page!` macros. After re-installing from the tip of `main` (`cargo install --path crates/reinhardt-admin-cli` → `reinhardt-admin 0.1.0-rc.29`), the formatter writes the minimal diff above and `reinhardt-admin fmt . --check` is happy.

Related: #4671 (release-plz Release PR being unblocked by this fix).

## How Was This Tested

- `cd examples/examples-tutorial-basis && cargo make fmt-check` → `Summary: 0 would be formatted, 50 unchanged`
- `cd examples/examples-twitter && cargo make fmt-check` → `Summary: 0 would be formatted, 104 unchanged`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A — no source comments touched)
- [x] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — formatting-only change)
- [x] New and existing unit tests pass locally with my changes (only `cargo make fmt-check` was relevant to verify)
- [x] Any dependent changes have been merged and published

## Labels to Apply

- `bug`, `ci-cd`, `examples`

## Related Issues

Fixes #4679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code improvements including import reorganization and formatting adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->