### PR TITLE
fix(examples-tutorial-basis): construct Depends<SessionUser> for auth_tests

### DIFF
--- a/examples/examples-tutorial-basis/tests/integration.rs
+++ b/examples/examples-tutorial-basis/tests/integration.rs
@@ -840,14 +840,14 @@ mod server_fn_tests {
 
 #[cfg(with_reinhardt)]
 mod auth_tests {
+	use examples_tutorial_basis::apps::polls::di::SessionUser;
 	use examples_tutorial_basis::apps::polls::server_fn::{
 		create_choice, create_question, delete_choice, delete_question, update_choice,
 		update_question,
 	};
 	use reinhardt::DatabaseConnection;
-	use reinhardt::middleware::session::SessionData;
+	use reinhardt::di::Depends;
 	use rstest::*;
-	use std::time::Duration;
 	use tempfile::NamedTempFile;
 
 	/// Fixture: an empty SQLite database + DatabaseConnection wired through
@@ -864,11 +864,14 @@ mod auth_tests {
 		(temp_file, db_conn)
 	}
 
-	/// Empty (anonymous) session — has no `user_id` key, so the
-	/// `SessionUser` DI factory resolves to `SessionUser::Anonymous` and
-	/// every `session_user.require_active()` call rejects it with 401.
-	fn anonymous_session() -> SessionData {
-		SessionData::new(Duration::from_secs(60))
+	/// Anonymous `SessionUser` wrapped in `Depends<_>` — the same value the
+	/// request-scoped `session_user_factory` in `apps::polls::di` would
+	/// produce for a `SessionData` without a `user_id` key. We construct it
+	/// directly with `Depends::from_value` so the test does not need to spin
+	/// up the middleware stack or the DI container; the gate under test is
+	/// `SessionUser::require_active()`, not the factory itself.
+	fn anonymous_session_user() -> Depends<SessionUser> {
+		Depends::from_value(SessionUser::Anonymous)
 	}
 
 	/// Helper: assert that a ServerFnError result represents a 401.
@@ -900,14 +903,14 @@ mod auth_tests {
 	) {
 		// Arrange
 		let (_file, db_conn) = empty_db_conn.await;
-		let session = anonymous_session();
+		let session_user = anonymous_session_user();
 
 		// Act
 		let result = create_question(
 			"Anonymous attempt".to_string(),
 			"csrf-token-ignored".to_string(),
 			db_conn,
-			session,
+			session_user,
 		)
 		.await;
 
@@ -921,14 +924,14 @@ mod auth_tests {
 		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
 	) {
 		let (_file, db_conn) = empty_db_conn.await;
-		let session = anonymous_session();
+		let session_user = anonymous_session_user();
 
 		let result = update_question(
 			"1".to_string(),
 			"New text".to_string(),
 			"csrf".to_string(),
 			db_conn,
-			session,
+			session_user,
 		)
 		.await;
 
@@ -941,9 +944,9 @@ mod auth_tests {
 		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
 	) {
 		let (_file, db_conn) = empty_db_conn.await;
-		let session = anonymous_session();
+		let session_user = anonymous_session_user();
 
-		let result = delete_question("1".to_string(), "csrf".to_string(), db_conn, session).await;
+		let result = delete_question("1".to_string(), "csrf".to_string(), db_conn, session_user).await;
 
 		assert_unauthorized(result, "delete_question");
 	}
@@ -954,14 +957,14 @@ mod auth_tests {
 		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
 	) {
 		let (_file, db_conn) = empty_db_conn.await;
-		let session = anonymous_session();
+		let session_user = anonymous_session_user();
 
 		let result = create_choice(
 			"1".to_string(),
 			"Anonymous choice".to_string(),
 			"csrf".to_string(),
 			db_conn,
-			session,
+			session_user,
 		)
 		.await;
 
@@ -974,14 +977,14 @@ mod auth_tests {
 		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
 	) {
 		let (_file, db_conn) = empty_db_conn.await;
-		let session = anonymous_session();
+		let session_user = anonymous_session_user();
 
 		let result = update_choice(
 			"1".to_string(),
 			"Hijack".to_string(),
 			"csrf".to_string(),
 			db_conn,
-			session,
+			session_user,
 		)
 		.await;
 
@@ -994,9 +997,9 @@ mod auth_tests {
 		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
 	) {
 		let (_file, db_conn) = empty_db_conn.await;
-		let session = anonymous_session();
+		let session_user = anonymous_session_user();
 
-		let result = delete_choice("1".to_string(), "csrf".to_string(), db_conn, session).await;
+		let result = delete_choice("1".to_string(), "csrf".to_string(), db_conn, session_user).await;
 
 		assert_unauthorized(result, "delete_choice");
 	}

--- a/examples/examples-tutorial-basis/tests/integration.rs
+++ b/examples/examples-tutorial-basis/tests/integration.rs
@@ -946,7 +946,8 @@ mod auth_tests {
 		let (_file, db_conn) = empty_db_conn.await;
 		let session_user = anonymous_session_user();
 
-		let result = delete_question("1".to_string(), "csrf".to_string(), db_conn, session_user).await;
+		let result =
+			delete_question("1".to_string(), "csrf".to_string(), db_conn, session_user).await;
 
 		assert_unauthorized(result, "delete_question");
 	}
@@ -999,7 +1000,8 @@ mod auth_tests {
 		let (_file, db_conn) = empty_db_conn.await;
 		let session_user = anonymous_session_user();
 
-		let result = delete_choice("1".to_string(), "csrf".to_string(), db_conn, session_user).await;
+		let result =
+			delete_choice("1".to_string(), "csrf".to_string(), db_conn, session_user).await;
 
 		assert_unauthorized(result, "delete_choice");
 	}


### PR DESCRIPTION
## Summary

- Fix the `auth_tests` compile failure in `examples/examples-tutorial-basis/tests/integration.rs` by constructing `Depends<SessionUser>` directly (via `Depends::from_value(SessionUser::Anonymous)`) instead of passing raw `SessionData` to the six CUD server functions.
- Helper renamed `anonymous_session()` → `anonymous_session_user()` with the new return type; six call sites updated to match.
- Root cause: the `SessionUser` request-scoped DI factory landed in commit `2230146976`, which switched every authenticated server function to `#[inject] session_user: Depends<SessionUser>`. The `#[server_fn]` macro strips only the attribute, not the parameter type, so direct callers (these tests) must now supply `Depends<SessionUser>` themselves. The miss was not caught earlier because the `Examples Tests` workflow is `workflow_call` with path-based triggers and didn't fire on subsequent commits — it only surfaced when release-plz invoked it for PR #4681 (rc.29 → rc.30).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

PR #4681 (the rc.30 release-plz PR) is blocked because `Examples Tests / examples-tutorial-basis` fails to compile with six `E0308: mismatched types` errors (expected `Depends<SessionUser>`, found `SessionData`). This PR unblocks rc.30 and removes the latent test-crate bug from `main` so the same failure does not bite future Release PRs.

Fixes #4682

## How Was This Tested

- Local: compile verification deferred to CI per project preference (defer-verification feedback) — `cargo test --no-run --all-features` inside `examples/examples-tutorial-basis` is run by CI's `examples-test.yml` workflow.
- CI: `Examples Tests / examples-tutorial-basis` should now pass; all other checks should remain green.

## Checklist

- [x] My code follows the project style guidelines (tab indentation, English comments, AAA test layout preserved)
- [x] I have performed a self-review of my own code (diff: +22/-19 in a single file)
- [x] I have updated relevant comments (helper docstring rewritten to explain the new construction path and what it tests)
- [x] The fix is minimal and targeted at the root cause
- [x] My changes generate no new warnings related to this PR
- [x] PR description and commit message use English

## Labels to Apply

- `bug` — fixes a compile error in the example crate
- `examples` — change is scoped to `examples/examples-tutorial-basis/`
- `high` — blocks the rc.30 release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored authorization integration tests to use an injected anonymous session for auth checks across create/update/delete flows.
  * Updated test imports and setup to streamline authenticated CUD test paths.

---

Note: No user-facing changes; this update only affects internal test infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->