### PR TITLE
fix(di): fall back to Injectable::inject for non-Depends factory params

### DIFF
--- a/crates/reinhardt-di/macros/src/injectable_factory.rs
+++ b/crates/reinhardt-di/macros/src/injectable_factory.rs
@@ -100,11 +100,12 @@ pub(crate) fn injectable_factory_impl(args: TokenStream, input: ItemFn) -> Resul
 					let #pat: #ty = #di_crate::Depends::<#inner_ty>::resolve_from_registry(&*ctx, true).await?;
 				}
 			} else {
+				// `Depends::into_inner` consumes the `Depends<T>`, tries
+				// `Arc::try_unwrap`, and falls back to `(*arc).clone()` only when
+				// the Arc is still shared. This avoids an unconditional clone in
+				// the common single-owner path (factory body is the sole holder).
 				quote! {
-					let #pat: #ty = {
-						let __dep = #di_crate::Depends::<#ty>::resolve(&*ctx, true).await?;
-						(*__dep).clone()
-					};
+					let #pat: #ty = #di_crate::Depends::<#ty>::resolve(&*ctx, true).await?.into_inner();
 				}
 			}
 		})

--- a/crates/reinhardt-di/macros/src/injectable_factory.rs
+++ b/crates/reinhardt-di/macros/src/injectable_factory.rs
@@ -73,25 +73,37 @@ pub(crate) fn injectable_factory_impl(args: TokenStream, input: ItemFn) -> Resul
 	// Get dynamic crate path (needed by inject_resolutions below)
 	let di_crate = get_reinhardt_di_crate();
 
-	// Generate dependency resolution code.
-	// `ctx.resolve::<T>()` returns `DiResult<Arc<T>>`, so we must handle two cases:
-	// - Parameter type is `Depends<T>`: resolve via `Depends::resolve()` with caching
-	// - Parameter type is `T` (non-Depends): resolve `T`, then clone out of the `Arc`
+	// Generate dependency resolution code (kent8192/reinhardt-web#4685).
+	//
+	// Two parameter shapes are supported:
+	//
+	// - `Depends<T>` — resolved via `Depends::resolve_from_registry`. The
+	//   registry-only path has no `T: Injectable` bound, which is the whole
+	//   reason factory-produced types (deliberately without `impl Injectable`)
+	//   can be injected this way. Callers wrap such types in `Depends<T>` by
+	//   project convention (see
+	//   `tests/integration/tests/di/ui/pass/factory_depends_in_server_fn.rs`).
+	//
+	// - non-`Depends` `T` — resolved via `Depends::resolve`, which consults
+	//   the registry *first* and falls back to `T::inject(ctx)` when the type
+	//   is not registered. This matches the codegen pattern used by
+	//   `#[server_fn]` / `#[routes]` for the same shape and lets factories
+	//   accept types whose only DI surface is a manual `impl Injectable`
+	//   (e.g. `SessionData`, `ServerFnRequest`, `AuthInfo`). The fallback
+	//   requires `T: Injectable`, satisfied by every callsite that uses the
+	//   non-`Depends` form today.
 	let inject_resolutions: Vec<_> = inject_params
 		.iter()
 		.map(|(pat, ty)| {
 			if let Some(inner_ty) = extract_depends_inner_type(ty) {
-				// Parameter is Depends<T>: resolve via registry only (no Injectable bound needed).
-				// Factory-produced types may not implement Injectable.
 				quote! {
 					let #pat: #ty = #di_crate::Depends::<#inner_ty>::resolve_from_registry(&*ctx, true).await?;
 				}
 			} else {
-				// Parameter is T: resolve T, unwrap Arc<T> via clone
 				quote! {
 					let #pat: #ty = {
-						let __arc = ctx.resolve::<#ty>().await?;
-						(*__arc).clone()
+						let __dep = #di_crate::Depends::<#ty>::resolve(&*ctx, true).await?;
+						(*__dep).clone()
 					};
 				}
 			}

--- a/crates/reinhardt-di/tests/injectable_factory_inject_fallback_tests.rs
+++ b/crates/reinhardt-di/tests/injectable_factory_inject_fallback_tests.rs
@@ -109,9 +109,7 @@ struct PagedRequest {
 }
 
 #[injectable_factory(scope = "transient")]
-async fn paged_request_factory(
-	#[inject] config: Depends<FactoryOnlyConfig>,
-) -> PagedRequest {
+async fn paged_request_factory(#[inject] config: Depends<FactoryOnlyConfig>) -> PagedRequest {
 	PagedRequest {
 		page_size: config.page_size,
 	}

--- a/crates/reinhardt-di/tests/injectable_factory_inject_fallback_tests.rs
+++ b/crates/reinhardt-di/tests/injectable_factory_inject_fallback_tests.rs
@@ -9,9 +9,17 @@
 //! `Depends::<T>::resolve`, which performs the registry-first +
 //! `T::inject` fallback used by `#[server_fn]` / `#[routes]`.
 //!
-//! Each test exercises both `#[inject] x: T` and `#[inject] x: Depends<T>`
-//! against an unregistered manually-Injectable type so the regression
-//! cannot reappear on either codegen path.
+//! The tests cover both `#[inject] x: T` and `#[inject] x: Depends<T>`:
+//!
+//! - **Variant 1** uses a manually-Injectable type that is *not* registered,
+//!   so the only way it can resolve is through the new `Injectable::inject`
+//!   fallback baked into the macro's non-`Depends` branch.
+//! - **Variant 2** uses a *factory-only* type with **no** `impl Injectable`,
+//!   registered via the global registry. This is both a runtime guard
+//!   (only `resolve_from_registry` can satisfy it) and a compile-time guard:
+//!   if the macro accidentally switches the `Depends<T>` branch to
+//!   `Depends::resolve` (which would add a `T: Injectable` bound), the
+//!   Variant 2 fixture stops compiling.
 
 #![cfg(all(feature = "macros", feature = "testing"))]
 
@@ -77,35 +85,35 @@ async fn factory_resolves_non_depends_manual_injectable_via_inject_fallback() {
 	assert_eq!(*derived, DerivedUser { user_id: 7 });
 }
 
-/// Variant 2: `Depends<T>` form. Keeps the `resolve_from_registry` path
-/// intact for factory-only types (no `Injectable` impl) while still
-/// covering the manual-Injectable case via the registry's cache hit on
-/// the second resolve. We register the manual type into the local
-/// registry view (still no `#[injectable]` macro) so the assertion is
-/// honest about which path runs.
+/// Variant 2: `Depends<T>` form against a *factory-only* type — i.e. one
+/// that deliberately has **no** `impl Injectable`. This is the regression
+/// guard the previous revision lacked: if the macro ever switches the
+/// `Depends<T>` branch back to `Depends::resolve` (which requires
+/// `T: Injectable`), `paged_request_factory` below stops compiling.
+///
+/// At the same time, the only DI surface available for `FactoryOnlyConfig`
+/// is the registry, so the runtime path exercised here is unambiguously
+/// `Depends::resolve_from_registry` — exactly the path used by
+/// factory-produced types (see
+/// `tests/integration/tests/di/ui/pass/factory_depends_in_server_fn.rs`).
 #[derive(Clone, Debug, PartialEq)]
-struct ManualClock {
-	now_ms: u64,
+struct FactoryOnlyConfig {
+	page_size: u32,
 }
 
-#[async_trait]
-impl Injectable for ManualClock {
-	async fn inject(_ctx: &InjectionContext) -> DiResult<Self> {
-		Ok(ManualClock {
-			now_ms: 1_700_000_000_000,
-		})
-	}
-}
+// NOTE: no `impl Injectable for FactoryOnlyConfig` on purpose. See doc above.
 
 #[derive(Clone, Debug, PartialEq)]
-struct StampedRequest {
-	at_ms: u64,
+struct PagedRequest {
+	page_size: u32,
 }
 
 #[injectable_factory(scope = "transient")]
-async fn stamped_request_factory(#[inject] clock: Depends<ManualClock>) -> StampedRequest {
-	StampedRequest {
-		at_ms: clock.now_ms,
+async fn paged_request_factory(
+	#[inject] config: Depends<FactoryOnlyConfig>,
+) -> PagedRequest {
+	PagedRequest {
+		page_size: config.page_size,
 	}
 }
 
@@ -113,22 +121,24 @@ async fn stamped_request_factory(#[inject] clock: Depends<ManualClock>) -> Stamp
 #[serial(di_registry)]
 #[tokio::test]
 async fn factory_with_depends_factory_only_type_still_uses_registry_only_path() {
-	// Arrange — register a factory for ManualClock so resolve_from_registry hits
+	// Arrange — `FactoryOnlyConfig` has no `Injectable` impl, so the only
+	// way `Depends<FactoryOnlyConfig>` can resolve is via the registry.
+	// Register a factory for it so `resolve_from_registry` succeeds.
 	let registry = global_registry();
-	let _guard = registry.register_override::<ManualClock, _, _>(
+	let _guard = registry.register_override::<FactoryOnlyConfig, _, _>(
 		reinhardt_di::DependencyScope::Transient,
-		|_ctx| async { Ok(ManualClock { now_ms: 42 }) },
+		|_ctx| async { Ok(FactoryOnlyConfig { page_size: 25 }) },
 	);
 	let scope = Arc::new(SingletonScope::new());
 	let ctx = InjectionContext::builder(scope).build();
 
 	// Act
-	let stamped = ctx
-		.resolve::<StampedRequest>()
+	let paged = ctx
+		.resolve::<PagedRequest>()
 		.await
 		.expect("Depends<T> factory parameter must resolve via the registry");
 
-	// Assert — value comes from the overridden factory, not from
-	// `ManualClock::inject` (which would yield `1_700_000_000_000`).
-	assert_eq!(*stamped, StampedRequest { at_ms: 42 });
+	// Assert — value comes from the registry override (the only DI path
+	// available for `FactoryOnlyConfig`).
+	assert_eq!(*paged, PagedRequest { page_size: 25 });
 }

--- a/crates/reinhardt-di/tests/injectable_factory_inject_fallback_tests.rs
+++ b/crates/reinhardt-di/tests/injectable_factory_inject_fallback_tests.rs
@@ -1,0 +1,134 @@
+//! Regression tests for kent8192/reinhardt-web#4685.
+//!
+//! `#[injectable_factory]` previously resolved non-`Depends` `#[inject]`
+//! parameters with `ctx.resolve::<T>()` only — no fallback to
+//! `Injectable::inject(ctx)` — so types whose only DI surface is a
+//! manual `impl Injectable` (and that are not pre-registered) failed at
+//! runtime with `DependencyNotRegistered`, surfacing as a generic 500 to
+//! HTTP callers. The fix routes the non-`Depends` branch through
+//! `Depends::<T>::resolve`, which performs the registry-first +
+//! `T::inject` fallback used by `#[server_fn]` / `#[routes]`.
+//!
+//! Each test exercises both `#[inject] x: T` and `#[inject] x: Depends<T>`
+//! against an unregistered manually-Injectable type so the regression
+//! cannot reappear on either codegen path.
+
+#![cfg(all(feature = "macros", feature = "testing"))]
+
+use async_trait::async_trait;
+use rstest::*;
+use serial_test::serial;
+use std::sync::Arc;
+
+use reinhardt_di::{
+	Depends, DiResult, Injectable, InjectionContext, SingletonScope, global_registry,
+	injectable_factory,
+};
+
+/// Manually-Injectable type that is *not* registered in the global
+/// registry — mirrors the framework shape used by `SessionData`,
+/// `ServerFnRequest`, `AuthInfo`, etc.
+#[derive(Clone, Debug, PartialEq)]
+struct ManualSession {
+	user_id: i64,
+}
+
+#[async_trait]
+impl Injectable for ManualSession {
+	async fn inject(_ctx: &InjectionContext) -> DiResult<Self> {
+		Ok(ManualSession { user_id: 7 })
+	}
+}
+
+/// Factory output that downstream code reads via `ctx.resolve` — proves
+/// the whole factory body executed (the buggy path returned an error
+/// before the body ran).
+#[derive(Clone, Debug, PartialEq)]
+struct DerivedUser {
+	user_id: i64,
+}
+
+#[injectable_factory(scope = "transient")]
+async fn derived_user_factory(#[inject] session: ManualSession) -> DerivedUser {
+	DerivedUser {
+		user_id: session.user_id,
+	}
+}
+
+#[rstest]
+#[serial(di_registry)]
+#[tokio::test]
+async fn factory_resolves_non_depends_manual_injectable_via_inject_fallback() {
+	// Arrange
+	let scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(scope).build();
+	assert!(
+		!global_registry().is_registered::<ManualSession>(),
+		"ManualSession must remain unregistered to exercise the inject fallback",
+	);
+
+	// Act
+	let derived = ctx
+		.resolve::<DerivedUser>()
+		.await
+		.expect("factory must resolve via Injectable::inject fallback");
+
+	// Assert
+	assert_eq!(*derived, DerivedUser { user_id: 7 });
+}
+
+/// Variant 2: `Depends<T>` form. Keeps the `resolve_from_registry` path
+/// intact for factory-only types (no `Injectable` impl) while still
+/// covering the manual-Injectable case via the registry's cache hit on
+/// the second resolve. We register the manual type into the local
+/// registry view (still no `#[injectable]` macro) so the assertion is
+/// honest about which path runs.
+#[derive(Clone, Debug, PartialEq)]
+struct ManualClock {
+	now_ms: u64,
+}
+
+#[async_trait]
+impl Injectable for ManualClock {
+	async fn inject(_ctx: &InjectionContext) -> DiResult<Self> {
+		Ok(ManualClock {
+			now_ms: 1_700_000_000_000,
+		})
+	}
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct StampedRequest {
+	at_ms: u64,
+}
+
+#[injectable_factory(scope = "transient")]
+async fn stamped_request_factory(#[inject] clock: Depends<ManualClock>) -> StampedRequest {
+	StampedRequest {
+		at_ms: clock.now_ms,
+	}
+}
+
+#[rstest]
+#[serial(di_registry)]
+#[tokio::test]
+async fn factory_with_depends_factory_only_type_still_uses_registry_only_path() {
+	// Arrange — register a factory for ManualClock so resolve_from_registry hits
+	let registry = global_registry();
+	let _guard = registry.register_override::<ManualClock, _, _>(
+		reinhardt_di::DependencyScope::Transient,
+		|_ctx| async { Ok(ManualClock { now_ms: 42 }) },
+	);
+	let scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(scope).build();
+
+	// Act
+	let stamped = ctx
+		.resolve::<StampedRequest>()
+		.await
+		.expect("Depends<T> factory parameter must resolve via the registry");
+
+	// Assert — value comes from the overridden factory, not from
+	// `ManualClock::inject` (which would yield `1_700_000_000_000`).
+	assert_eq!(*stamped, StampedRequest { at_ms: 42 });
+}


### PR DESCRIPTION
## Summary

Fixes #4685.

`#[injectable_factory]` previously resolved non-`Depends` `#[inject]` parameters via `ctx.resolve::<T>()` only — no fallback to `Injectable::inject(ctx)`. Manually-Injectable types that are not pre-registered in the global registry (`SessionData`, `ServerFnRequest`, `AuthInfo`, `AdminDatabase`, `AdminSite`, …) therefore failed at runtime with `DependencyNotRegistered`. The `#[server_fn]` macro maps the resulting non-Auth `DiError` to a generic 500, so authentication errors raised from inside such a factory surfaced as `Internal server error` to clients instead of the intended 401/403.

In production this hit `examples-tutorial-basis`: `session_user_factory` takes `#[inject] session: SessionData`, so an anonymous `POST /api/server_fn/create_question` (or `create_choice`) returned `{"Server":{"status":500,"message":"Internal server error"}}` rather than the intended 401.

## Changes

- `crates/reinhardt-di/macros/src/injectable_factory.rs` — non-`Depends` branch now emits `Depends::<T>::resolve(&*ctx, true).await?` (registry-first, with the `T::inject` fallback used by `#[server_fn]` / `#[routes]`). The `Depends<T>` branch keeps `resolve_from_registry` so factory-only types without `impl Injectable` continue to work.
- `crates/reinhardt-di/tests/injectable_factory_inject_fallback_tests.rs` — new rstest covering both shapes against an unregistered manually-Injectable type. Verified to fail against the previous codegen (`DependencyNotRegistered`) and pass with the fix.

## Compatibility

Per project convention factory-only types (deliberately without `impl Injectable`) are received as `Depends<T>` — see `tests/integration/tests/di/ui/pass/factory_depends_in_server_fn.rs`. A repo-wide grep confirms no callsite uses the non-`Depends` form for a factory-only type today, so the implicit `T: Injectable` bound that `Depends::resolve` adds on the non-`Depends` branch is satisfied everywhere.

## Test plan

- [x] `cargo nextest run -p reinhardt-di --features macros,testing` (333 tests pass)
- [x] `cargo nextest run -p reinhardt-di --features macros,testing --test injectable_factory_inject_fallback_tests` (2 tests pass)
- [x] Reproduce: stash this PR's macro edit and re-run the new test → first case fails with `DependencyNotRegistered`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p reinhardt-di-macros -p reinhardt-di --all-features --tests -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved injectable-factory parameter resolution: Depends<T> is resolved via registry-only path, while non-Depends parameters use a registry-first fallback to type-provided injection. Updated generated macro docs to describe supported shapes and resolution behavior.

* **Tests**
  * Added regression tests verifying both registry-resolved and fallback injection paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->