### PR TITLE
fix(examples-tutorial-basis): hide vote form when question has no choices

### DIFF
--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -282,6 +282,13 @@ pub fn polls_detail(question_id: i64) -> Page {
 						}
 					}
 				} else if load_detail_signal.result().is_some() {
+					// Render either the voting form or an empty-state message,
+					// depending on whether the question has any choices yet
+					// (reinhardt-web#4686). The previous unconditional render
+					// of `voting_form` produced an empty `RadioSelect` group
+					// for choiceless questions, so any submit emitted
+					// `choice_id=""` and `submit_vote` rejected the request
+					// with the runtime `Invalid choice_id` application error.
 					div {
 						class: "max-w-4xl mx-auto px-4 mt-12",
 						div {
@@ -313,7 +320,14 @@ pub fn polls_detail(question_id: i64) -> Page {
 								}
 							}
 						}
-						{ voting_form.clone().into_page() }
+						if load_detail_signal.result().map(|(_, c)| !c.is_empty()).unwrap_or(false) {
+							{ voting_form.clone().into_page() }
+						} else {
+							div {
+								class: "alert-warning",
+								"This question has no choices yet. Add one below to start voting."
+							}
+						}
 						div {
 							class: "mt-4",
 							a {

--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -248,6 +248,14 @@ pub fn polls_detail(question_id: i64) -> Page {
 	// outer `div` + single `watch{}` block + the `Action<..>` signal and
 	// the route id flow into `page!` as typed parameters. The voting form
 	// is captured by the watch closure's implicit `move`.
+	//
+	// The `load_detail_signal.result().is_some()` branch renders either the
+	// voting form or an empty-state message, depending on whether the
+	// question has any choices yet (reinhardt-web#4686). The previous
+	// unconditional render of `voting_form` produced an empty
+	// `RadioSelect` group for choiceless questions, so any submit emitted
+	// `choice_id=""` and `submit_vote` rejected the request with the
+	// runtime `Invalid choice_id` application error.
 	page!(|load_detail_signal: Action<(QuestionInfo, Vec<ChoiceInfo>), String>, question_id: i64| {
 		div {
 			watch {
@@ -282,13 +290,6 @@ pub fn polls_detail(question_id: i64) -> Page {
 						}
 					}
 				} else if load_detail_signal.result().is_some() {
-					// Render either the voting form or an empty-state message,
-					// depending on whether the question has any choices yet
-					// (reinhardt-web#4686). The previous unconditional render
-					// of `voting_form` produced an empty `RadioSelect` group
-					// for choiceless questions, so any submit emitted
-					// `choice_id=""` and `submit_vote` rejected the request
-					// with the runtime `Invalid choice_id` application error.
 					div {
 						class: "max-w-4xl mx-auto px-4 mt-12",
 						div {
@@ -320,7 +321,7 @@ pub fn polls_detail(question_id: i64) -> Page {
 								}
 							}
 						}
-						if load_detail_signal.result().map(|(_, c)| !c.is_empty()).unwrap_or(false) {
+						if load_detail_signal.result().map(|(_, c)| ! c.is_empty()).unwrap_or(false) {
 							{ voting_form.clone().into_page() }
 						} else {
 							div {

--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -289,18 +289,17 @@ pub fn polls_detail(question_id: i64) -> Page {
 							"Back to Polls"
 						}
 					}
-				} else if load_detail_signal.result().is_some() {
+				} else if let Some((ref q, ref choices)) = load_detail_signal.result() {
+					// Bind the result once: `Action::result()` clones the
+					// underlying `(QuestionInfo, Vec<ChoiceInfo>)` on every
+					// call, so reusing `q`/`choices` here avoids redundant
+					// allocations on each reactive render.
 					div {
 						class: "max-w-4xl mx-auto px-4 mt-12",
 						div {
 							class: "flex justify-between items-center mb-4",
 							h1 {
-								{
-									load_detail_signal
-											.result()
-											.map(|(q, _)| q.question_text.clone())
-											.unwrap_or_default()
-								}
+								{ q.question_text.clone() }
 							}
 							div {
 								class: "flex gap-2",
@@ -321,7 +320,7 @@ pub fn polls_detail(question_id: i64) -> Page {
 								}
 							}
 						}
-						if load_detail_signal.result().map(|(_, c)| ! c.is_empty()).unwrap_or(false) {
+						if !choices.is_empty() {
 							{ voting_form.clone().into_page() }
 						} else {
 							div {


### PR DESCRIPTION
## Summary

Fixes #4686.

`polls_detail` rendered the `VotingForm` unconditionally, including for questions with zero choices. The macro-generated `RadioSelect` widget then exposed an empty option list, so any submit emitted `choice_id=""` and `submit_vote` rejected the request with the runtime application error `Invalid choice_id`:

```
[server_fn ERROR] submit_vote (/api/server_fn/submit_vote): {"Application":"Invalid choice_id"}
[22/May/2026 09:11:59] "POST /api/server_fn/submit_vote HTTP/1.1" 500 35 0ms
```

## Changes

- `examples/examples-tutorial-basis/src/apps/polls/client/components.rs::polls_detail` — branch the reactive `watch{}` body on the loaded choices. Render `voting_form.clone().into_page()` only when at least one choice exists; otherwise show an explanatory `alert-warning`. The "Add choice" CTA remains visible in both branches so the author can populate the question without navigating away.

The check uses `load_detail_signal.result().map(|(_, c)| !c.is_empty()).unwrap_or(false)` inline (rather than a `let` binding) to satisfy the DSL's restriction on Rust `let` statements between sibling nodes inside a `watch{}` block (documented in this module's header).

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown` (wasm side compiles)
- [x] `cargo check --all-features` (native side compiles)
- [x] `cargo clippy --all-features --target wasm32-unknown-unknown` — no new lints introduced (pre-existing `__FORM_CSRF_AUTO_INJECT_DEPRECATED` warnings in `apps/users/client/components.rs` are tracked by reinhardt-web#3971 and out of scope here)
- [ ] Manual: run `cargo make runserver` against a question with zero choices and confirm the form no longer renders; add a choice and confirm voting works again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Voting form now only appears when a poll has one or more choices.
  * Polls without choices display a clear warning message and prevent invalid submissions, avoiding runtime errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->