### PR TITLE
docs(release): finalize README and SECURITY for 0.1.0 stable graduation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ If you have written `ModelSerializer` or `Depends()` before, Reinhardt will feel
 
 <!-- reinhardt-version-sync -->
 ```bash
-# During the RC phase, `cargo install` requires an explicit `--version`
-# because pre-releases are not selected by default. Once a stable release
-# ships, `cargo install reinhardt-admin-cli` (no flag) will also work.
+# Pin a specific release for reproducibility (omit --version to pull the latest stable):
 cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
 
 reinhardt-admin startproject my-api && cd my-api
@@ -104,24 +102,14 @@ Reinhardt follows a **three-phase lifecycle** for every crate:
 | **Stable** (`0.x.0`) | Full SemVer 2.0 guarantees. |
 
 <!-- reinhardt-version-sync -->
-**Current status:** Reinhardt is at `0.1.0-rc.30` (Release Candidate). Most
-crates track this version; a small number lag by one or more patch numbers
-when no conventional-commit changes have touched them since their previous
-release-plz tag (release-plz correctly skips a bump in that case). At
-`rc.29` this applies to:
+**Current status:** Reinhardt is at `0.1.0-rc.30`. From `0.1.0` onward, all
+public APIs follow SemVer 2.0; breaking changes ship in a future
+`0.2.0-rc.N` series coordinated through the `develop/0.2.0` branch.
 
-- `reinhardt-testkit-macros` — remains at `0.1.0-rc.28` (no changes since
-  its rc.28 tag; re-exported through `reinhardt-testkit`, so depending on
-  `reinhardt-testkit` alone gives you a compatible pair).
-
-**What this means for you:**
-- Public APIs will only change to fix critical bugs -- no new features or additions
-- If a critical fix requires an API change, a migration guide is provided
-- Naming improvements use deprecation aliases (your existing code keeps compiling)
-- Bug fixes are shipped as `rc.2`, `rc.3`, etc.
-- Stable `0.1.0` will be released after a 2-week stability period with no critical issues
-
-For the full stability policy, see [Stability Policy](instructions/STABILITY_POLICY.md).
+For per-release detail (changelog summary, upgrade notes, known issues),
+see the [Release category in GitHub Discussions](https://github.com/kent8192/reinhardt-web/discussions/categories/release).
+The full lifecycle policy lives in
+[Stability Policy](instructions/STABILITY_POLICY.md).
 
 ## Installation
 
@@ -216,10 +204,9 @@ The main Reinhardt crate is published on crates.io as `reinhardt-web`, but you i
 
 ### 1. Install Reinhardt Admin Tool
 
-During the RC phase, only release-candidate versions are published to
-crates.io, so `cargo install` requires an explicit `--version`. The version
-shown below is auto-bumped by release-plz on each release. After a stable
-release ships, `cargo install reinhardt-admin-cli` (no flag) will also work.
+Omit `--version` to pull the latest stable release; pin a specific version
+for reproducibility. The pinned literal below is auto-bumped by release-plz
+on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ If you have written `ModelSerializer` or `Depends()` before, Reinhardt will feel
 
 <!-- reinhardt-version-sync -->
 ```bash
-# Pin a specific release for reproducibility (omit --version to pull the latest stable):
+# Currently a pre-release: --version is required. Once 0.1.0 stable ships,
+# --version becomes optional (and acts as an opt-in reproducibility pin).
 cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
 
 reinhardt-admin startproject my-api && cd my-api
@@ -204,9 +205,11 @@ The main Reinhardt crate is published on crates.io as `reinhardt-web`, but you i
 
 ### 1. Install Reinhardt Admin Tool
 
-Omit `--version` to pull the latest stable release; pin a specific version
-for reproducibility. The pinned literal below is auto-bumped by release-plz
-on each release.
+While Reinhardt is on a pre-release (`-rc.*` / `-alpha.*`), `cargo install`
+requires an explicit `--version` because pre-releases are not selected by
+default. Once `0.1.0` stable ships, omit `--version` to pull the latest
+stable (or keep `--version` as an opt-in reproducibility pin). The literal
+below is auto-bumped by release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,16 +4,19 @@
 
 Reinhardt follows the three-phase lifecycle described in
 [`instructions/STABILITY_POLICY.md`](instructions/STABILITY_POLICY.md).
-Security patches are applied to the latest stable patch of the most recent
-minor release. Pre-release artifacts (`-rc.*`, `-alpha.*`) are not
-security-supported once the corresponding stable release ships — upgrade
-to the matching stable version to receive patches.
+Security patches are applied to the **latest current release** of the most
+recent minor series: while `0.1.0` stable has not yet shipped, the latest
+`0.1.0-rc.*` is that current release; once `0.1.0` ships, support shifts
+to the latest `0.1.x` stable patch and older `-rc.*` / `-alpha.*` artifacts
+become unsupported — upgrade to the matching stable version to keep
+receiving patches.
 
 | Version | Supported |
 |---------|-----------|
-| `0.1.x` (latest stable patch) | ✅ Yes |
-| Older `0.1.x` patches | ❌ No |
-| `0.1.0-rc.*` / `0.1.0-alpha.*` | ❌ No — upgrade to `0.1.x` |
+| Latest `0.1.0-rc.*` (current release, until `0.1.0` ships) | ✅ Yes |
+| `0.1.x` (latest stable patch, once `0.1.0` has shipped) | ✅ Yes |
+| Older `0.1.0-rc.*` / `0.1.0-alpha.*` | ❌ No |
+| Older `0.1.x` patches (after `0.1.0` has shipped) | ❌ No |
 | Development branches (`main`, `develop/*`) | ❌ No |
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,19 @@
 
 ## Supported Versions
 
-This project is currently in Release Candidate (RC) phase. Only the latest RC version is supported with security patches.
+Reinhardt follows the three-phase lifecycle described in
+[`instructions/STABILITY_POLICY.md`](instructions/STABILITY_POLICY.md).
+Security patches are applied to the latest stable patch of the most recent
+minor release. Pre-release artifacts (`-rc.*`, `-alpha.*`) are not
+security-supported once the corresponding stable release ships — upgrade
+to the matching stable version to receive patches.
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.0-rc.x (latest) | ✅ Yes |
-| Older RC versions | ❌ No |
-| Development branches | ❌ No |
-
-**Note:** This project has not yet reached a stable 1.0 release. Security patches are applied to the latest RC version only.
+| `0.1.x` (latest stable patch) | ✅ Yes |
+| Older `0.1.x` patches | ❌ No |
+| `0.1.0-rc.*` / `0.1.0-alpha.*` | ❌ No — upgrade to `0.1.x` |
+| Development branches (`main`, `develop/*`) | ❌ No |
 
 ---
 

--- a/crates/reinhardt-admin-cli/README.md
+++ b/crates/reinhardt-admin-cli/README.md
@@ -8,10 +8,12 @@ Global command-line tool for Reinhardt project management.
 
 ## Installation
 
-Install globally using cargo. During the RC phase, only release-candidate
-versions are published to crates.io, so `cargo install` requires an explicit
-`--version`. The version shown below is auto-bumped by release-plz on each
-release. After a stable release ships, the bare command will also work.
+Install globally using cargo. While Reinhardt is on a pre-release
+(`-rc.*` / `-alpha.*`), `cargo install` requires an explicit `--version`
+because pre-releases are not selected by default. Once `0.1.0` stable
+ships, omit `--version` to pull the latest stable (or keep `--version`
+as an opt-in reproducibility pin). The literal below is auto-bumped by
+release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -7,9 +7,11 @@
 //!
 //! ## Installation
 //!
-//! During the RC phase, only release-candidate versions are published to
-//! crates.io, so `cargo install` requires an explicit `--version`. The
-//! version below is auto-bumped by release-plz on each release.
+//! While Reinhardt is on a pre-release (`-rc.*` / `-alpha.*`),
+//! `cargo install` requires an explicit `--version` because pre-releases
+//! are not selected by default. Once `0.1.0` stable ships, `--version`
+//! becomes optional. The literal below is auto-bumped by release-plz on
+//! each release.
 //!
 //! <!-- reinhardt-version-sync -->
 //! ```bash

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -37,8 +37,8 @@ package:
 
 <!-- reinhardt-version-sync -->
 ```bash
-# During the RC phase, `cargo install` requires an explicit `--version`.
-# The version below is auto-bumped by release-plz on each release.
+# Pre-release: --version is required. Once 0.1.0 stable ships, --version
+# becomes optional. The literal below is auto-bumped by release-plz.
 cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
 ```
 

--- a/website/content/quickstart/_index.md
+++ b/website/content/quickstart/_index.md
@@ -11,10 +11,11 @@ Get up and running with Reinhardt in 5 minutes.
 
 ## 1. Install Reinhardt Admin CLI
 
-During the RC phase, only release-candidate versions are published to
-crates.io, so `cargo install` requires an explicit `--version`. The version
-below is auto-bumped by release-plz on each release. Once a stable release
-ships, the bare `cargo install reinhardt-admin-cli` will also work.
+While Reinhardt is on a pre-release (`-rc.*` / `-alpha.*`),
+`cargo install` requires an explicit `--version` because pre-releases are
+not selected by default. Once `0.1.0` stable ships, omit `--version` to
+pull the latest stable (or keep `--version` as an opt-in reproducibility
+pin). The literal below is auto-bumped by release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash

--- a/website/content/quickstart/getting-started.md
+++ b/website/content/quickstart/getting-started.md
@@ -25,10 +25,11 @@ Before you begin, make sure you have:
 
 ### Step 1: Install Reinhardt Admin
 
-During the RC phase, only release-candidate versions are published to
-crates.io, so `cargo install` requires an explicit `--version`. The version
-below is auto-bumped by release-plz on each release. Once a stable release
-ships, the bare `cargo install reinhardt-admin-cli` will also work.
+While Reinhardt is on a pre-release (`-rc.*` / `-alpha.*`),
+`cargo install` requires an explicit `--version` because pre-releases are
+not selected by default. Once `0.1.0` stable ships, omit `--version` to
+pull the latest stable (or keep `--version` as an opt-in reproducibility
+pin). The literal below is auto-bumped by release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash

--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -29,7 +29,7 @@ cargo install cargo-make
 
 ## Installing Reinhardt Admin CLI
 
-Install the global tool for project generation. During the RC phase, only release-candidate versions are published to crates.io, so `cargo install` requires an explicit `--version`. The version below is auto-bumped by release-plz on each release. Once a stable release ships, the bare `cargo install reinhardt-admin-cli` will also work.
+Install the global tool for project generation. While Reinhardt is on a pre-release (`-rc.*` / `-alpha.*`), `cargo install` requires an explicit `--version` because pre-releases are not selected by default. Once `0.1.0` stable ships, omit `--version` to pull the latest stable (or keep `--version` as an opt-in reproducibility pin). The literal below is auto-bumped by release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash

--- a/website/content/quickstart/tutorials/rest/quickstart.md
+++ b/website/content/quickstart/tutorials/rest/quickstart.md
@@ -12,11 +12,12 @@ Create a simple API for administrators to view and edit users and groups in the 
 
 ## Project Setup
 
-First, install the global tool. During the RC phase, only release-candidate
-versions are published to crates.io, so `cargo install` requires an explicit
-`--version`. The version below is auto-bumped by release-plz on each release.
-Once a stable release ships, the bare `cargo install reinhardt-admin-cli`
-will also work.
+First, install the global tool. While Reinhardt is on a pre-release
+(`-rc.*` / `-alpha.*`), `cargo install` requires an explicit `--version`
+because pre-releases are not selected by default. Once `0.1.0` stable
+ships, omit `--version` to pull the latest stable (or keep `--version`
+as an opt-in reproducibility pin). The literal below is auto-bumped by
+release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash


### PR DESCRIPTION
## Summary

This PR addresses:

- Graduate the public-facing prose in install instructions and the security policy from RC-phase wording to **transition-aware** wording, so that the docs are correct both before *and* after the `0.1.0` stable cutover (no follow-up edit required when stable ships).
- Per [#1461 (comment)](https://github.com/kent8192/reinhardt-web/issues/1461#issuecomment-4513942782), per-release detail is redirected to the [Release category in GitHub Discussions](https://github.com/kent8192/reinhardt-web/discussions/categories/release) instead of being inlined in the README, keeping the README evergreen across future releases.
- Scope is intentionally narrow — **prose only**. Version literals stay under the `<!-- reinhardt-version-sync -->` (and `//! <!-- ... -->`) markers and are auto-bumped by release-plz on the next Release PR via `scripts/update-version-refs.sh`.

## Type of Change

- [x] Documentation update

## Motivation and Context

Issue #1461 ("Prepare: Update README and docs for stable release") is the documentation half of the Phase 3 stable cutover. Many surfaces contained RC-only paragraphs (e.g. "During the RC phase, `cargo install` requires an explicit `--version`...") that read naturally during the RC cadence but become noise — or actively misleading — once `0.1.0` ships stable.

A naive rewrite that simply says "omit `--version` to pull the latest stable" introduces a **pre-stable gap**: until `0.1.0` actually ships, that command fails (`cargo install` errors with "no matching versions" when no stable exists), and the SECURITY policy direction "upgrade to `0.1.x`" points at a version that doesn't yet exist. A Codex stop-time review caught this gap in the SECURITY table; an exhaustive re-grep then surfaced seven additional user-facing install-prose files with the same RC-only pattern that the initial inventory had missed.

This PR uses **transition-aware** wording everywhere ("While Reinhardt is on a pre-release ... Once `0.1.0` stable ships ..."), which is correct in both the pre-stable and post-stable states. The marker-guarded version literals continue to flow through `scripts/update-version-refs.sh` so the `0.1.0-rc.30` → `0.1.0` substitution happens automatically inside the next release-plz Release PR.

Fixes #1461

## How Was This Tested?

Prose-only changes — no code paths exercised. Verified via:

1. `grep -rn "During the RC phase" --include='*.md' --include='*.rs'` over all user-facing READMEs / docs / quickstart pages: **zero matches**. Remaining "RC phase" mentions are confined to (a) framework-wide policy docs that describe future `0.2.0-rc.N` series too (`instructions/STABILITY_POLICY.md`, `PR_GUIDELINE.md`, `RELEASE_PROCESS.md`, `QUICK_REFERENCE.md` — intentionally out of scope), and (b) in-code `auto_trait_impl_removed` workaround comments in `crates/reinhardt-{rest,views}/...` that are tied to the no-breaking-change semver-check policy and need separate removal once stable ships.
2. `bash scripts/update-version-refs.sh 0.1.0 --dry-run`: no orphan markers; all marker → SemVer pairings preserved across all 9 edited files (including the rustdoc `//! <!-- ... -->` variant in `crates/reinhardt-admin-cli/src/main.rs`).
3. `semgrep scan --config .semgrep/` scoped to the 9 edited files: 0 findings (verified the `//!` continuation lines starting with "While" are not flagged by `rust-commented-out-code`).
4. `git diff --stat origin/main...HEAD`: exactly 9 files, +47 / -34.

## Files Touched (9 total)

| File | Edit |
|------|------|
| `README.md` | Quick Start install comment, "Current status" paragraph, Getting Started §1 install rationale |
| `SECURITY.md` | "Supported Versions" section — adds latest `-rc.*` to the supported row until `0.1.0` ships, then shifts support to `0.1.x` stable patches |
| `crates/reinhardt-admin-cli/README.md` | Installation prose |
| `crates/reinhardt-admin-cli/src/main.rs` | `//!` rustdoc Installation block |
| `crates/reinhardt-commands/README.md` | `# During the RC phase ...` install comment inside install snippet |
| `website/content/quickstart/_index.md` | Quickstart install prose |
| `website/content/quickstart/getting-started.md` | Step 1 install prose |
| `website/content/quickstart/tutorials/basis/1-project-setup.md` | Tutorial install prose |
| `website/content/quickstart/tutorials/rest/quickstart.md` | REST tutorial install prose |

## Files Intentionally NOT Touched (for traceability)

- Per-crate `crates/*/README.md` (the 35 other crates): only contain marker-guarded dependency-example literals → release-plz auto-sync owns these.
- `examples/Cargo.toml`, `examples/CLAUDE.md`, all `examples/*/README.md`: same.
- Per-crate `crates/*/src/lib.rs` `//!` headers (other than the admin-cli bin): zero RC / version content.
- `CONTRIBUTING.md`: zero RC references.
- `Cargo.toml` (workspace + per-crate) version literals: release-plz owns these via the Release PR.
- `instructions/STABILITY_POLICY.md`, `PR_GUIDELINE.md`, `RELEASE_PROCESS.md`, `QUICK_REFERENCE.md`: describe framework-wide RC-phase rules that remain valid for future `0.2.0-rc.N` series.
- `crates/reinhardt-{rest,views}/src/**.rs` `// ... under the RC phase's no-breaking-change policy.` comments: tied to specific `auto_trait_impl_removed` workarounds; these workarounds will be **removed** (not just reworded) post-stable in a separate Issue.
- `announcements/v0.1.0-rc.*.md`, `CHANGELOG.md`: historical record.
- `examples/examples-tutorial-rest/` `0.1.0-rc.16` references: historical deprecation-since notation, preserved as-is.

## Commit History

1. `7f1896d489` docs(release): finalize README and SECURITY for 0.1.0 stable graduation — initial 2-file rewrite.
2. `bb887ec8ec` docs(release): close pre-stable security gap and extend to 7 missed install-prose files — Codex-review follow-up.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works *(N/A — prose-only doc change)*
- [ ] New and existing unit tests pass locally with my changes *(N/A — no code paths touched)*
- [ ] I have tested with all affected database backends (if applicable) *(N/A)*
- [x] I have formatted the code with `cargo make fmt-fix` *(N/A — no Rust source changed in a way that affects fmt; the `//!` doc edit in `src/main.rs` is prose-only)*
- [x] I have checked the code with `cargo make clippy-check` *(Semgrep `.semgrep/` scan clean, including rust-commented-out-code rule on the edited rustdoc block)*
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #1461

## Labels to Apply

### Type Label
- [x] `documentation`

### Scope Label
*(no scope label — repo-wide doc update)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified install instructions: pre-releases require an explicit --version; after 0.1.0 stable the flag is optional (or can be kept to pin); noted displayed version is auto-bumped.
  * Updated Quick Start, Getting Started, and tutorial pages with this guidance.
  * Condensed API Stability section into a shorter “current status” with links to discussions and policy.
* **Security**
  * Updated supported-versions guidance to reference the stability lifecycle and exclude pre-releases from security patch coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->