### PR TITLE
chore(release): graduate v0.1.0-rc.30 to stable v0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -427,7 +427,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.1.0-rc.19"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.94.0"
 license = "BSD-3-Clause"
@@ -445,67 +445,67 @@ module_name_repetitions = "allow"
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0-rc.30" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0" }
 
 # Internal crates
-reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0-rc.30" }
-reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.1.0-rc.30" }
-reinhardt-core = { path = "crates/reinhardt-core", version = "0.1.0-rc.30" }
-reinhardt-di = { path = "crates/reinhardt-di", version = "0.1.0-rc.30" }
-reinhardt-http = { path = "crates/reinhardt-http", version = "0.1.0-rc.30" }
-reinhardt-server = { path = "crates/reinhardt-server", version = "0.1.0-rc.30" }
-reinhardt-views = { path = "crates/reinhardt-views", version = "0.1.0-rc.30" }
-reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.1.0-rc.30" }
-reinhardt-router = { path = "crates/reinhardt-router", version = "0.1.0-rc.30" }
-reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.1.0-rc.30" }
-reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.0-rc.30" }
-reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.1.0-rc.30" }
-reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.0-rc.30" }
-reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.1.0-rc.30" }
-reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.0-rc.30" }
-reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.1.0-rc.30" }
-reinhardt-testkit-macros = { path = "crates/reinhardt-testkit-macros", version = "0.1.0-rc.29" }
-reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0-rc.30" }
-reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.0-rc.30" }
-reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.1.0-rc.30" }
-reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.0-rc.30" }
-reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0-rc.30" }
-reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.0-rc.30" }
-reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0-rc.30" }
-reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.1.0-rc.30" }
-reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0-rc.30" }
-reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0-rc.30" }
-reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0-rc.30" }
-reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0-rc.30" }
-reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0-rc.30" }
-reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0-rc.30" }
-reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0-rc.30" }
-reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.1.0-rc.30" }
-reinhardt-query = { path = "crates/reinhardt-query", version = "0.1.0-rc.30" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0-rc.30" }
-reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0-rc.30" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0-rc.30" }
-reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0-rc.30" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0-rc.30" }
-reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0-rc.30" }
-reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0-rc.30" }
-reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.0-rc.30" }
-reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0-rc.30" }
+reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0" }
+reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.1.0" }
+reinhardt-core = { path = "crates/reinhardt-core", version = "0.1.0" }
+reinhardt-di = { path = "crates/reinhardt-di", version = "0.1.0" }
+reinhardt-http = { path = "crates/reinhardt-http", version = "0.1.0" }
+reinhardt-server = { path = "crates/reinhardt-server", version = "0.1.0" }
+reinhardt-views = { path = "crates/reinhardt-views", version = "0.1.0" }
+reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.1.0" }
+reinhardt-router = { path = "crates/reinhardt-router", version = "0.1.0" }
+reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.1.0" }
+reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.0" }
+reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.1.0" }
+reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.0" }
+reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.1.0" }
+reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.0" }
+reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.1.0" }
+reinhardt-testkit-macros = { path = "crates/reinhardt-testkit-macros", version = "0.1.0" }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0" }
+reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.0" }
+reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.1.0" }
+reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.0" }
+reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0" }
+reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.0" }
+reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0" }
+reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.1.0" }
+reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0" }
+reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0" }
+reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0" }
+reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0" }
+reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0" }
+reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0" }
+reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0" }
+reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.1.0" }
+reinhardt-query = { path = "crates/reinhardt-query", version = "0.1.0" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0" }
+reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0" }
+reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0" }
+reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0" }
+reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0" }
+reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.0" }
+reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0" }
 
 # Query subcrates
-reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.1.0-rc.30" }
+reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.1.0" }
 
 # Core subcrates
-reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.0-rc.30" }
+reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.0" }
 
 # DI subcrates
-reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.1.0-rc.30" }
+reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.1.0" }
 
 # REST subcrates
-reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.1.0-rc.30" }
+reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.1.0" }
 
 # REST subcrates (continued)
-reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.1.0-rc.30" }
+reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.1.0" }
 
 # Streaming
 rskafka = { version = "0.5" }

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin-cli"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-apps/Cargo.toml
+++ b/crates/reinhardt-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-apps"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Application registry and management for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Authentication and authorization system"
 keywords = ["auth", "jwt", "authentication", "django", "web"]
 categories = ["authentication", "web-programming"]

--- a/crates/reinhardt-auth/macros/Cargo.toml
+++ b/crates/reinhardt-auth/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth-macros"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Procedural macros for reinhardt-auth (guard!)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-commands"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-conf"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-core"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-core/macros/Cargo.toml
+++ b/crates/reinhardt-core/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-macros"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db-macros/Cargo.toml
+++ b/crates/reinhardt-db-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db-macros"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db/Cargo.toml
+++ b/crates/reinhardt-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-deeplink/Cargo.toml
+++ b/crates/reinhardt-deeplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-deeplink"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/Cargo.toml
+++ b/crates/reinhardt-dentdelion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dentdelion"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/tests/fixtures/plugins/config/Cargo.toml
+++ b/crates/reinhardt-dentdelion/tests/fixtures/plugins/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "config-plugin"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition = "2024"
 
 [lib]

--- a/crates/reinhardt-dentdelion/tests/fixtures/plugins/logging/Cargo.toml
+++ b/crates/reinhardt-dentdelion/tests/fixtures/plugins/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logging-plugin"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition = "2024"
 
 [lib]

--- a/crates/reinhardt-dentdelion/tests/fixtures/plugins/minimal/Cargo.toml
+++ b/crates/reinhardt-dentdelion/tests/fixtures/plugins/minimal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimal-plugin"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition = "2024"
 
 [lib]

--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "reinhardt-di"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-di/macros/Cargo.toml
+++ b/crates/reinhardt-di/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-di-macros"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-dispatch/Cargo.toml
+++ b/crates/reinhardt-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dispatch"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-forms/Cargo.toml
+++ b/crates/reinhardt-forms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-forms"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Form handling and validation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-graphql/macros/Cargo.toml
+++ b/crates/reinhardt-graphql/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql-macros"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Procedural macros for GraphQL schema generation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "gRPC support for building RPC services"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/macros/Cargo.toml
+++ b/crates/reinhardt-grpc/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc-macros"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-http/Cargo.toml
+++ b/crates/reinhardt-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-http"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Internationalization and localization support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-mail/Cargo.toml
+++ b/crates/reinhardt-mail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-mail"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Email sending functionality with multiple backends"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-manouche/Cargo.toml
+++ b/crates/reinhardt-manouche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-manouche"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-middleware"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Middleware system for request/response processing pipeline"
 keywords = ["middleware", "web", "cors", "security", "http"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-openapi/Cargo.toml
+++ b/crates/reinhardt-openapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/ast/Cargo.toml
+++ b/crates/reinhardt-pages/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-ast"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/macros/Cargo.toml
+++ b/crates/reinhardt-pages/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-macros"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-query/Cargo.toml
+++ b/crates/reinhardt-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-query/macros/Cargo.toml
+++ b/crates/reinhardt-query/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query-macros"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-rest/Cargo.toml
+++ b/crates/reinhardt-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-rest"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "REST API framework aggregator for Reinhardt"
 keywords = ["rest", "api", "web", "framework", "django"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-rest/openapi-macros/Cargo.toml
+++ b/crates/reinhardt-rest/openapi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi-macros"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-router/Cargo.toml
+++ b/crates/reinhardt-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-router"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-server/Cargo.toml
+++ b/crates/reinhardt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-server"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-streaming/Cargo.toml
+++ b/crates/reinhardt-streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-streaming"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Backend-agnostic streaming abstraction with Kafka support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-tasks/Cargo.toml
+++ b/crates/reinhardt-tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-tasks"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Background task execution and scheduling"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-test"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-testkit-macros/Cargo.toml
+++ b/crates/reinhardt-testkit-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit-macros"
-version = "0.1.0-rc.29"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-testkit/Cargo.toml
+++ b/crates/reinhardt-testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-throttling/Cargo.toml
+++ b/crates/reinhardt-throttling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-throttling"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Throttling and rate limiting for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-urls"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-urls/routers-macros/Cargo.toml
+++ b/crates/reinhardt-urls/routers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-routers-macros"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-utils"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "Utility functions aggregator for Reinhardt"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-views/Cargo.toml
+++ b/crates/reinhardt-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-views"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "View layer aggregator for viewsets and views-core"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-websockets/Cargo.toml
+++ b/crates/reinhardt-websockets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-websockets"
-version = "0.1.0-rc.30"
+version = "0.1.0"
 description = "WebSocket support for real-time bidirectional communication"
 edition.workspace = true
 rust-version.workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 [workspace.dependencies]
 # Reinhardt framework (crates.io published versions)
 # reinhardt-version-sync
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web" }
+reinhardt = { version = "0.1.0", package = "reinhardt-web" }
 
 # Testing
 testcontainers = { version = "0.27.2", features = ["blocking"] }

--- a/examples/examples-tutorial-basis/Cargo.toml
+++ b/examples/examples-tutorial-basis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples-tutorial-basis"
-version = "0.1.0-alpha.1"
+version = "0.1.0"
 edition = "2024"
 publish = false
 description = "Reinhardt basis tutorial example - Polling application with Pages"

--- a/examples/examples-tutorial-rest/Cargo.toml
+++ b/examples/examples-tutorial-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples-tutorial-rest"
-version = "0.1.0-alpha.1"
+version = "0.1.0"
 edition = "2024"
 publish = false
 description = "Reinhardt REST tutorial example - Code snippet management API"

--- a/examples/examples-twitter/Cargo.toml
+++ b/examples/examples-twitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples-twitter"
-version = "0.1.0-alpha.1"
+version = "0.1.0"
 edition = "2024"
 publish = false
 default-run = "examples-twitter"

--- a/tests/bench/Cargo.toml
+++ b/tests/bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-benchmarks"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-integration-tests"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
## Summary

- Strip `-rc.30` (and the lone `-rc.29` skew on `reinhardt-testkit-macros`) suffix from every workspace `Cargo.toml`, promoting Reinhardt's 0.1.0 release stream from prerelease to stable.
- This is the **first stable release** of Reinhardt. Subsequent stable releases will go through the standard `develop/X.Y.Z` → `release-plz-promote.yml` flow per DBR-3.

## Type of Change

- [x] Release preparation (version bump)

## Motivation and Context

The 0.1.0 release stream has reached `rc.30`. There is no `develop/0.1.0` branch (`main` itself is the 0.1.0 line — `develop/0.2.0` exists for the next release), so the standard `release-plz-promote.yml` workflow — which requires `develop/X.Y.Z` to be merged into `main` — cannot be used directly. Instead, this PR runs the same sed transformation that `scripts/strip-prerelease-suffix.sh` would apply, but restricted to workspace `Cargo.toml` files (excluding `.claude/worktrees/` to avoid contaminating other branches' checkouts).

After merge, `release-plz.yml` will detect the version change and create a stable Release PR. Merging that Release PR triggers crates.io publication and per-crate Git tag creation (`reinhardt-*@v0.1.0`).

## How Was This Tested

- `cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | "\(.name): \(.version)"'` confirms **all 52 workspace packages report `0.1.0`** (no skew remaining)
- `git diff --name-only` confirms **only 58 `Cargo.toml` files changed** (no source code mutations)
- Version transition breakdown (from `git diff -U0 | grep -E '^[+-]version' | sort | uniq -c`):
  - 48 × `0.1.0-rc.30` → `0.1.0` (the bulk of the workspace)
  - 5 × `0.1.0-rc.1` → `0.1.0` (`tests/bench`, `tests/integration` and fixture-adjacent crates)
  - 3 × `0.1.0-alpha.1` → `0.1.0` (dentdelion plugin fixtures)
  - 1 × `0.1.0-rc.29` → `0.1.0` (`reinhardt-testkit-macros` skew)
  - 1 × `0.1.0-rc.19` → `0.1.0` (`[workspace.package].version`)

No CHANGELOG mutations in this PR — release-plz handles those when it auto-generates the stable Release PR.

## Checklist

- [x] Branch name follows `<type>/<scope>-<desc>` (`chore/promote-rc-to-stable-v0.1.0`)
- [x] Commit message follows Conventional Commits
- [x] No workaround / TODO / FIXME added
- [x] `release` label applied (triggers post-merge release automation per PR_GUIDELINE.md PC-5)

## Labels to Apply

- `release`

## Out of Scope

- `develop/0.2.0` への forward-merge (DB-4): to be handled in a follow-up PR after 0.1.0 stable is published
- Modifying `scripts/strip-prerelease-suffix.sh` to exclude `.claude/worktrees/` (a separate concern; should be filed as its own issue)

## Post-Merge Actions

1. Wait for `release-plz.yml` to auto-generate a stable Release PR on a `release-plz-*` branch
2. Review and merge the auto Release PR → publishes all reinhardt-* crates to crates.io + creates per-crate Git tags (`reinhardt-*@v0.1.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Stable version 0.1.0 released across all framework packages, graduating from pre-release versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->