### PR TITLE
fix(ci): restore RC announcement PR generation on main push

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -439,16 +439,28 @@ jobs:
         env:
           BACKFILL_MODE: ${{ inputs.mode }}
         run: |
-          # No tag-level filter is applied. The job-level branch guard on
-          # `release-announcement-pr` already restricts push triggers to
-          # `main`, which is sufficient to keep develop/** prereleases out
-          # of the announcement flow (#4541, #4692). Duplicate generation
-          # for tags that already have announcements or Discussions is
-          # prevented by the file-exists / Discussion-exists checks below.
+          # Scope tag selection to the checked-out HEAD's history via
+          # `--merged HEAD`. Tags are a global namespace, so without this
+          # constraint a higher semver tag from develop/** (e.g.
+          # v0.2.0-alpha.5) can shadow a newly pushed main release tag
+          # (e.g. v0.1.0-rc.31) and cause the wrong tag to be processed.
+          # With --merged HEAD:
+          #   - push to main: only main-reachable tags are considered, so
+          #     the new main release tag is correctly selected.
+          #   - workflow_dispatch from main: same scope; develop/** tags
+          #     are excluded automatically.
+          #   - workflow_dispatch from develop/**: tags reachable from the
+          #     develop HEAD (including the develop branch's own prerelease
+          #     tags) are considered, allowing alpha/rc announcements to
+          #     be backfilled from the matching develop checkout.
+          # See #4692 (regression fix) and CodeRabbit review on PR #4693.
+          # Duplicate generation for tags that already have announcements
+          # or Discussions is prevented by the file-exists and
+          # Discussion-exists checks further down in this job.
           if [ "$BACKFILL_MODE" = "backfill" ]; then
-            TAGS=$(git tag --list 'reinhardt-web@v*' --sort=version:refname | tr '\n' ' ')
+            TAGS=$(git tag --merged HEAD --list 'reinhardt-web@v*' --sort=version:refname | tr '\n' ' ')
           else
-            TAGS=$(git tag --list 'reinhardt-web@v*' --sort=-version:refname | head -1)
+            TAGS=$(git tag --merged HEAD --list 'reinhardt-web@v*' --sort=-version:refname | head -1)
           fi
 
           if [ -z "$TAGS" ]; then

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -402,10 +402,12 @@ jobs:
 
   release-announcement-pr:
     name: Create Release Announcement PR
-    # Stable-release announcements only. Pre-release tags from develop/** push
-    # are intentionally skipped at two layers: (1) this branch guard skips the
-    # entire job on develop pushes, (2) the tag-filter step below restricts
-    # workflow_dispatch backfill to stable tags. See issue #4541.
+    # Announcements are produced only for releases originating from main.
+    # Pre-release tags from develop/** push are skipped by the branch guard
+    # below (github.ref == 'refs/heads/main'). The previous stable-only tag
+    # filter was removed in #4692 because the branch guard already enforces
+    # the intent of #4541, and the regex also prevented legitimate RC
+    # releases on main (e.g. v0.1.0-rc.30) from receiving announcements.
     if: |
       always() &&
       (
@@ -437,17 +439,16 @@ jobs:
         env:
           BACKFILL_MODE: ${{ inputs.mode }}
         run: |
-          # Stable-tag filter: reinhardt-web@vX.Y.Z (no prerelease suffix).
-          # Without this filter, semver sorts 0.2.0-rc.1 between 0.1.x and
-          # 0.2.0, so `head -1` of all tags could pick up a prerelease tag
-          # and emit an announcement for it. Issue #4541.
-          STABLE_TAG_RE='^reinhardt-web@v[0-9]+\.[0-9]+\.[0-9]+$'
+          # No tag-level filter is applied. The job-level branch guard on
+          # `release-announcement-pr` already restricts push triggers to
+          # `main`, which is sufficient to keep develop/** prereleases out
+          # of the announcement flow (#4541, #4692). Duplicate generation
+          # for tags that already have announcements or Discussions is
+          # prevented by the file-exists / Discussion-exists checks below.
           if [ "$BACKFILL_MODE" = "backfill" ]; then
-            TAGS=$(git tag --list 'reinhardt-web@v*' --sort=version:refname \
-              | grep -E "$STABLE_TAG_RE" | tr '\n' ' ')
+            TAGS=$(git tag --list 'reinhardt-web@v*' --sort=version:refname | tr '\n' ' ')
           else
-            TAGS=$(git tag --list 'reinhardt-web@v*' --sort=-version:refname \
-              | grep -E "$STABLE_TAG_RE" | head -1)
+            TAGS=$(git tag --list 'reinhardt-web@v*' --sort=-version:refname | head -1)
           fi
 
           if [ -z "$TAGS" ]; then


### PR DESCRIPTION
## Summary

- Remove the stable-only tag regex (`STABLE_TAG_RE`) from `release-plz.yml`'s `Determine tags to process` step in the `release-announcement-pr` job
- The job-level guard (`github.ref == 'refs/heads/main'`) already restricts push triggers to `main`, so develop/** prereleases remain out of the announcement flow without the tag-level filter
- Restores the historical behavior where every release on `main` (including `-rc.N` tags during the RC phase) produces an announcement PR

Fixes #4692

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other

## Motivation and Context

The release-plz workflow stopped producing announcement PRs for RC releases on `main` after `4fce2bfdf9` (#4541) introduced a defensive stable-only tag regex. The regex was intended to keep develop/** prerelease pushes out of the announcement flow, but the job-level branch guard already enforces that intent. The extra filter over-restricted legitimate RC releases on `main` (e.g., `reinhardt-web@v0.1.0-rc.30`).

### Timeline

| Date | Event |
|------|-------|
| 2026-05-13 | rc.29 announcement created (PR #4391) ✓ |
| 2026-05-18 | Commit `4fce2bfdf9` introduces `STABLE_TAG_RE` |
| 2026-05-22 | rc.30 — announcement **not** created ✗ |

### Why removing the regex is safe

| Concern | Mitigation |
|---------|------------|
| develop/** prereleases creating announcements | Job-level `github.ref == 'refs/heads/main'` guard (line 412) blocks the entire job on non-main pushes |
| Backfill mode generating duplicates for already-announced tags | Per-tag file-exists check on `announcements/v${VERSION}.md` (line 486) |
| Discussion duplicates | GraphQL Discussion-title-exists check (line 491-508) |

## How Was This Tested

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-plz.yml'))"` — YAML syntax valid
- Diff scope: 1 file, +14/-13 lines, comments + regex removal only
- Behavioral verification requires a real release run; can be exercised post-merge via `workflow_dispatch` with `mode=backfill` to regenerate the missing rc.30 announcement

## Checklist

- [x] Changes follow Conventional Commits format
- [x] Comments updated to reflect new behavior (lines 405-410 and 442-447)
- [x] No breaking changes to public API
- [x] Issue referenced in commit and PR body
- [x] PR is Draft pending review

## Labels to Apply

- `bug` — regression from a previously working state
- `ci-cd` — release-plz workflow
- `high` — release announcement automation is currently dead for the entire RC phase

## Related Issues

Fixes #4692
Regression-from #4541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release announcement workflow to include pre-release tags as well as stable releases.
  * Tag discovery now scopes to the checked-out commit history.
  * Backfill mode includes all matched merged tags (including prereleases); normal mode selects the newest merged tag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->