### PR TITLE
ci(release-plz): move announcement jobs to self-hosted AWS runner

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -415,7 +415,7 @@ jobs:
         (github.event_name == 'workflow_dispatch')
       )
     needs: [release-plz-release]
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
     timeout-minutes: 60
     steps:
       - name: Generate GitHub token
@@ -430,6 +430,16 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
+
+      # The AWS Packer AMI (infra/github-runners/packer/reinhardt-runner.pkr.hcl)
+      # bakes in gh / jq / git / curl / docker / protoc / cargo-make but NOT
+      # Node.js. The runner agent's bundled Node is only used to execute JS
+      # actions and is not on PATH for shell steps, so `npm install -g` below
+      # would fail without an explicit Node setup. Issue #4694.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
@@ -664,7 +674,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'announcement')
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
     timeout-minutes: 10
     steps:
       - name: Generate GitHub token


### PR DESCRIPTION
## Summary

- Move `release-announcement-pr` and `post-announcement` from `ubuntu-latest` to `[self-hosted, linux, arm64, reinhardt-ci]` so the entire release-plz pipeline runs on the same AWS runner pool.
- Add `actions/setup-node@v4` before the `npm install -g @anthropic-ai/claude-code` step in `release-announcement-pr` — the AWS Packer AMI does not bake in Node.js.
- `post-announcement` only uses `gh` and shell scripts that the AMI already provides, no additional setup needed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD change

## Motivation and Context

Fixes #4694.

Observed on workflow_dispatch run [`26263481935`](https://github.com/kent8192/reinhardt-web/actions/runs/26263481935) (since cancelled): `Create Release Announcement PR` sat in `queued` for ~10 minutes waiting for a GitHub-hosted ubuntu-latest runner that never came up. Every other ubuntu-latest job in the repo at the same moment was also queued, indicating an account-wide GitHub-hosted runner shortage.

Meanwhile two self-hosted AWS runners (`i-01289ef0cc713ff89` idle, plus two busy ones in the `reinhardt-ci` group) were online. The work should have been running there immediately — the only reason it wasn't is that `release-plz.yml` was left half-migrated when the rest of the release-plz pipeline moved to self-hosted.

## How Was This Tested

- [x] `python3 -c 'yaml.safe_load(open(...))'` confirms the YAML still parses and all four release-plz jobs now share the same `runs-on`.
- [ ] End-to-end verification will happen when the next stable release tag is pushed (or a workflow_dispatch run is kicked off after merge).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] CI changes are limited to a single workflow file (`.github/workflows/release-plz.yml`)
- [x] No secrets, tokens, or untrusted inputs are interpolated into shell scripts

## Labels to Apply

- `ci-cd`
- `bug`

## Notes

- The AMI's installed tooling is documented in `infra/github-runners/packer/reinhardt-runner.pkr.hcl` (lines 124-156) — `gh`, `jq`, `git`, `curl`, `docker`, `protoc`, `cargo-make` are baked in; Node.js is not. The inline comment in the diff explains this for future maintainers.
- The existing `release-plz-release` job has a runtime `gh` install fallback (lines 285-295) from before the AMI baked it in. That fallback is now effectively a no-op but it is not touched here to keep the PR scope minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release workflow configuration to improve reliability and ensure compatibility for automated release announcement automation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->