### PR TITLE
feat(di): cache request body in ParamContext for repeated Json<T> resolution

### DIFF
--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = { workspace = true }
 serde_urlencoded = "0.7"
 form_urlencoded = "1.2"
 http = "1.0"
+bytes.workspace = true
 urlencoding = "2.1"
 regex = { workspace = true }
 multer = { version = "3.1", optional = true }

--- a/crates/reinhardt-di/src/params.rs
+++ b/crates/reinhardt-di/src/params.rs
@@ -55,6 +55,7 @@ pub mod validation;
 use reinhardt_http::Error as CoreError;
 use std::any::TypeId;
 use std::collections::HashMap;
+use std::sync::Mutex;
 use thiserror::Error;
 
 // Re-export Request from reinhardt-http and parameter error types from reinhardt-exception
@@ -268,6 +269,13 @@ pub struct ParamContext {
 	header_names: HashMap<TypeId, &'static str>,
 	/// Cookie name registry keyed by value type
 	cookie_names: HashMap<TypeId, &'static str>,
+	/// Cached request body bytes. Populated on first call to
+	/// [`read_body_cached`](Self::read_body_cached) so that multiple
+	/// body-consuming extractors (e.g. two `Json<T>` factories in the same
+	/// request, see #4645) can share a single read of the underlying
+	/// stream instead of failing with "body already consumed" on the
+	/// second call. The `Mutex` is held only briefly during init.
+	body_cache: Mutex<Option<bytes::Bytes>>,
 }
 
 impl ParamContext {
@@ -286,6 +294,7 @@ impl ParamContext {
 			path_params: reinhardt_http::PathParams::new(),
 			header_names: HashMap::new(),
 			cookie_names: HashMap::new(),
+			body_cache: Mutex::new(None),
 		}
 	}
 	/// Create a ParamContext with pre-populated path parameters.
@@ -315,6 +324,7 @@ impl ParamContext {
 			path_params: path_params.into(),
 			header_names: HashMap::new(),
 			cookie_names: HashMap::new(),
+			body_cache: Mutex::new(None),
 		}
 	}
 	/// Get a path parameter by name
@@ -356,6 +366,40 @@ impl ParamContext {
 	/// Get a registered cookie name for value type `T`
 	pub fn get_cookie_name<T: 'static>(&self) -> Option<&'static str> {
 		self.cookie_names.get(&TypeId::of::<T>()).copied()
+	}
+
+	/// Read the request body, caching the bytes on first call.
+	///
+	/// `Request::read_body()` is one-shot: it flips an internal
+	/// `body_consumed` flag and refuses subsequent calls. That is fine for
+	/// a single handler, but breaks down once multiple request-scoped
+	/// extractors (e.g. two `Json<T>` factories within one
+	/// `#[injectable_factory]` resolution chain — see #4645) want to read
+	/// the same body. This method consumes the body exactly once per
+	/// request and caches the resulting [`bytes::Bytes`] in
+	/// `ParamContext`; subsequent callers receive a cheap `Bytes::clone`
+	/// (refcount bump, no copy).
+	///
+	/// Returns `ParamError::BodyError` if the underlying read fails or
+	/// the body was previously consumed through some path that bypassed
+	/// this cache.
+	pub fn read_body_cached(&self, request: &reinhardt_http::Request) -> ParamResult<bytes::Bytes> {
+		// Brief critical section: short-lived sync mutex is acceptable
+		// because the cached bytes never block on I/O — the only work
+		// done inside the lock is the (sync) `request.read_body()` call,
+		// which is itself just an `AtomicBool` swap + `Bytes::clone()`.
+		let mut guard = self
+			.body_cache
+			.lock()
+			.expect("ParamContext body_cache mutex poisoned");
+		if let Some(bytes) = guard.as_ref() {
+			return Ok(bytes.clone());
+		}
+		let bytes = request
+			.read_body()
+			.map_err(|e| ParamError::BodyError(format!("Failed to read body: {}", e)))?;
+		*guard = Some(bytes.clone());
+		Ok(bytes)
 	}
 }
 

--- a/crates/reinhardt-di/src/params/json.rs
+++ b/crates/reinhardt-di/src/params/json.rs
@@ -89,7 +89,7 @@ impl<T> FromRequest for Json<T>
 where
 	T: DeserializeOwned + Send,
 {
-	async fn from_request(req: &Request, _ctx: &ParamContext) -> ParamResult<Self> {
+	async fn from_request(req: &Request, ctx: &ParamContext) -> ParamResult<Self> {
 		// Check Content-Type header (case-insensitive per RFC 7231)
 		let content_type = req
 			.headers
@@ -112,10 +112,12 @@ where
 			)));
 		}
 
-		// Read body bytes from request
-		let body_bytes = req
-			.read_body()
-			.map_err(|e| ParamError::BodyError(format!("Failed to read body: {}", e)))?;
+		// Read body bytes through ParamContext's cache so that a second
+		// `Json<T>` factory in the same request (e.g. resolving two DI
+		// dependencies that each carry a body parameter — see #4645)
+		// reuses the same bytes instead of failing with "body already
+		// consumed" on the second call.
+		let body_bytes = ctx.read_body_cached(req)?;
 
 		// Enforce body size limit to prevent memory exhaustion
 		if body_bytes.len() > DEFAULT_MAX_JSON_BODY_SIZE {


### PR DESCRIPTION
## Summary

- Add `body_cache: Mutex<Option<bytes::Bytes>>` to `ParamContext`
- Add `ParamContext::read_body_cached(&Request)` helper that consumes the request body exactly once per request and caches the resulting `Bytes`
- Re-route `Json<T>::from_request` through that helper, so multiple `Json<T>` factories inside one `#[injectable_factory]` chain share a single body read

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Refs #4645. Stacked on top of #4720.

`Request::read_body()` (in `crates/reinhardt-http/src/request/body.rs:138`)
is one-shot — it flips an internal `body_consumed: AtomicBool` and the
second call returns `Err("Request body has already been consumed")`.
That was fine while only one extractor per handler ever touched the
body. With #4720's `impl Injectable for Json<T>`, two factories
(say `AuthoredQuestion` and `ValidatedRequest`) can both ask for the
same body in the same request, and the second factory would fail.

This PR makes `Json<T>` consumption idempotent by caching the bytes
at the `ParamContext` level. Subsequent factories receive a cheap
`Bytes::clone` (refcount bump, zero copy).

## How Was This Tested

- [x] `cargo nextest run -p reinhardt-di --all-features` — all 388 tests pass
- [x] `cargo clippy -p reinhardt-di --all-features --all-targets -- -D warnings` — clean
- [x] `rustfmt --check` on modified files — clean
- [ ] Integration test exercising two `Json<T>` factories in one request lands in PR-3 of the implementation plan

## Implementation Notes

- A `Mutex` rather than `OnceLock` is used because `OnceLock::get_or_try_init` is still nightly. The critical section is minimal (one body read + one `Bytes::clone`), so the Mutex cost is negligible.
- `bytes` moved from `[dev-dependencies]` to `[dependencies]` because the new `read_body_cached` helper exposes `bytes::Bytes` in its return type.
- The existing `body_consumed` semantics in `reinhardt-http` are unchanged. Callers that read the body directly (without going through `ParamContext::read_body_cached`) still see the one-shot behavior — only `Json<T>::from_request` is routed through the cache here.

## Checklist

- [x] Implementation is complete
- [x] Code follows project style (rustfmt + clippy clean)
- [x] Documentation updated (new helper, struct field, and `Json::from_request` body all have explanatory docstrings linking back to #4645)
- [x] Conventional Commits format
- [x] Branch name follows `feat/issue-XXXX-<desc>`
- [x] Stacked on top of #4720 (base: `feat/issue-4645-injectable-extractors`)

## Related Issues

Refs #4645
Stacked on #4720

## Labels to Apply

- `enhancement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)