### PR TITLE
fix(examples): merge base.toml into active profile in parse_local_toml.py

### DIFF
--- a/examples/examples-tutorial-basis/scripts/parse_local_toml.py
+++ b/examples/examples-tutorial-basis/scripts/parse_local_toml.py
@@ -6,6 +6,14 @@ configuration in a single source of truth. Despite the historical name,
 this script accepts any settings profile (`local.toml`, `ci.toml`, ...);
 the caller picks the file based on `REINHARDT_ENV`.
 
+The script mirrors the layered settings loader in `reinhardt_conf`: when
+a sibling `base.toml` exists next to the requested profile, it is loaded
+first as the default layer and the profile is deep-merged on top (the
+profile wins on key conflicts). This keeps the container provisioning
+script in sync with what `src/config/settings.rs` actually resolves at
+runtime, so a user-local `local.toml` containing only `[core]` overrides
+can still inherit the canonical `[database]` block from `base.toml`.
+
 The settings shape mirrors the example crates' top-level `[database]`
 section (see README "With Database" / `reinhardt_conf::settings::DatabaseConfig`).
 Redis URL is read from a top-level `redis_url = "..."` key with a sane
@@ -36,6 +44,7 @@ Exit codes:
 
 from __future__ import annotations
 
+import os.path
 import shlex
 import sys
 import urllib.parse
@@ -63,18 +72,49 @@ def _load_toml(path: str) -> dict:
 		raise SystemExit(1)
 
 
+def _deep_merge(base: dict, override: dict) -> dict:
+	# Recursively merge `override` into `base`. Nested dicts are merged
+	# key-by-key; scalars and lists in `override` replace the entry in
+	# `base`. Mirrors `reinhardt_conf`'s layered TOML loader so the
+	# provisioning script sees the same resolved values as the runtime.
+	result = dict(base)
+	for key, value in override.items():
+		existing = result.get(key)
+		if isinstance(existing, dict) and isinstance(value, dict):
+			result[key] = _deep_merge(existing, value)
+		else:
+			result[key] = value
+	return result
+
+
+def _load_settings(profile_path: str) -> dict:
+	# Layer the profile TOML on top of a sibling `base.toml` when one
+	# exists. When the caller asked for `base.toml` itself, or no sibling
+	# base is present, fall back to the profile as the sole source.
+	profile_data = _load_toml(profile_path)
+	settings_dir = os.path.dirname(profile_path) or "."
+	base_path = os.path.join(settings_dir, "base.toml")
+	if os.path.abspath(profile_path) == os.path.abspath(base_path):
+		return profile_data
+	if not os.path.isfile(base_path):
+		return profile_data
+	base_data = _load_toml(base_path)
+	return _deep_merge(base_data, profile_data)
+
+
 def main(argv: list[str]) -> int:
 	if len(argv) != 2:
 		sys.stderr.write("Usage: parse_local_toml.py <settings.toml>\n")
 		return 2
 
-	data = _load_toml(argv[1])
+	data = _load_settings(argv[1])
 
 	try:
 		db = data["database"]
 	except KeyError:
 		sys.stderr.write(
-			f"Error: top-level [database] missing from {argv[1]}\n"
+			f"Error: top-level [database] missing from {argv[1]} "
+			f"(and from sibling base.toml, if present)\n"
 		)
 		return 1
 

--- a/examples/examples-tutorial-basis/scripts/parse_local_toml.py
+++ b/examples/examples-tutorial-basis/scripts/parse_local_toml.py
@@ -14,8 +14,18 @@ script in sync with what `src/config/settings.rs` actually resolves at
 runtime, so a user-local `local.toml` containing only `[core]` overrides
 can still inherit the canonical `[database]` block from `base.toml`.
 
-The settings shape mirrors the example crates' top-level `[database]`
-section (see README "With Database" / `reinhardt_conf::settings::DatabaseConfig`).
+Two database schemas are accepted (in priority order):
+
+1. Top-level ``[database]`` -- the canonical shape consumed by
+   `reinhardt_conf::settings::DatabaseConfig` (examples-tutorial-basis,
+   examples-tutorial-rest).
+2. ``[core.databases.default]`` -- the Django-style multi-database
+   layout exposed through `CoreSettings` (examples-twitter).
+
+The second form is a fallback so that a `base.toml` carrying only the
+runtime-shape schema still satisfies the provisioning script when the
+caller selects `base.toml` directly (e.g., `REINHARDT_ENV=base`).
+
 Redis URL is read from a top-level `redis_url = "..."` key with a sane
 default; examples that don't actually use Redis still get an idle
 container spun up so the infra footprint is identical across examples.
@@ -87,6 +97,25 @@ def _deep_merge(base: dict, override: dict) -> dict:
 	return result
 
 
+def _resolve_database(data: dict) -> dict | None:
+	# Prefer the canonical top-level `[database]` schema. Fall back to
+	# the Django-style `[core.databases.default]` layout used by
+	# examples-twitter so that selecting `base.toml` directly still
+	# yields provisionable credentials even when only the runtime-shape
+	# schema is present.
+	candidate = data.get("database")
+	if isinstance(candidate, dict):
+		return candidate
+	nested = (
+		data.get("core", {})
+		.get("databases", {})
+		.get("default")
+	)
+	if isinstance(nested, dict):
+		return nested
+	return None
+
+
 def _load_settings(profile_path: str) -> dict:
 	# Layer the profile TOML on top of a sibling `base.toml` when one
 	# exists. When the caller asked for `base.toml` itself, or no sibling
@@ -109,11 +138,11 @@ def main(argv: list[str]) -> int:
 
 	data = _load_settings(argv[1])
 
-	try:
-		db = data["database"]
-	except KeyError:
+	db = _resolve_database(data)
+	if db is None:
 		sys.stderr.write(
-			f"Error: top-level [database] missing from {argv[1]} "
+			f"Error: neither top-level [database] nor "
+			f"[core.databases.default] found in {argv[1]} "
 			f"(and from sibling base.toml, if present)\n"
 		)
 		return 1

--- a/examples/examples-tutorial-rest/scripts/parse_local_toml.py
+++ b/examples/examples-tutorial-rest/scripts/parse_local_toml.py
@@ -6,6 +6,14 @@ configuration in a single source of truth. Despite the historical name,
 this script accepts any settings profile (`local.toml`, `ci.toml`, ...);
 the caller picks the file based on `REINHARDT_ENV`.
 
+The script mirrors the layered settings loader in `reinhardt_conf`: when
+a sibling `base.toml` exists next to the requested profile, it is loaded
+first as the default layer and the profile is deep-merged on top (the
+profile wins on key conflicts). This keeps the container provisioning
+script in sync with what `src/config/settings.rs` actually resolves at
+runtime, so a user-local `local.toml` containing only `[core]` overrides
+can still inherit the canonical `[database]` block from `base.toml`.
+
 The settings shape mirrors the example crates' top-level `[database]`
 section (see README "With Database" / `reinhardt_conf::settings::DatabaseConfig`).
 Redis URL is read from a top-level `redis_url = "..."` key with a sane
@@ -36,6 +44,7 @@ Exit codes:
 
 from __future__ import annotations
 
+import os.path
 import shlex
 import sys
 import urllib.parse
@@ -63,18 +72,49 @@ def _load_toml(path: str) -> dict:
 		raise SystemExit(1)
 
 
+def _deep_merge(base: dict, override: dict) -> dict:
+	# Recursively merge `override` into `base`. Nested dicts are merged
+	# key-by-key; scalars and lists in `override` replace the entry in
+	# `base`. Mirrors `reinhardt_conf`'s layered TOML loader so the
+	# provisioning script sees the same resolved values as the runtime.
+	result = dict(base)
+	for key, value in override.items():
+		existing = result.get(key)
+		if isinstance(existing, dict) and isinstance(value, dict):
+			result[key] = _deep_merge(existing, value)
+		else:
+			result[key] = value
+	return result
+
+
+def _load_settings(profile_path: str) -> dict:
+	# Layer the profile TOML on top of a sibling `base.toml` when one
+	# exists. When the caller asked for `base.toml` itself, or no sibling
+	# base is present, fall back to the profile as the sole source.
+	profile_data = _load_toml(profile_path)
+	settings_dir = os.path.dirname(profile_path) or "."
+	base_path = os.path.join(settings_dir, "base.toml")
+	if os.path.abspath(profile_path) == os.path.abspath(base_path):
+		return profile_data
+	if not os.path.isfile(base_path):
+		return profile_data
+	base_data = _load_toml(base_path)
+	return _deep_merge(base_data, profile_data)
+
+
 def main(argv: list[str]) -> int:
 	if len(argv) != 2:
 		sys.stderr.write("Usage: parse_local_toml.py <settings.toml>\n")
 		return 2
 
-	data = _load_toml(argv[1])
+	data = _load_settings(argv[1])
 
 	try:
 		db = data["database"]
 	except KeyError:
 		sys.stderr.write(
-			f"Error: top-level [database] missing from {argv[1]}\n"
+			f"Error: top-level [database] missing from {argv[1]} "
+			f"(and from sibling base.toml, if present)\n"
 		)
 		return 1
 

--- a/examples/examples-tutorial-rest/scripts/parse_local_toml.py
+++ b/examples/examples-tutorial-rest/scripts/parse_local_toml.py
@@ -14,8 +14,18 @@ script in sync with what `src/config/settings.rs` actually resolves at
 runtime, so a user-local `local.toml` containing only `[core]` overrides
 can still inherit the canonical `[database]` block from `base.toml`.
 
-The settings shape mirrors the example crates' top-level `[database]`
-section (see README "With Database" / `reinhardt_conf::settings::DatabaseConfig`).
+Two database schemas are accepted (in priority order):
+
+1. Top-level ``[database]`` -- the canonical shape consumed by
+   `reinhardt_conf::settings::DatabaseConfig` (examples-tutorial-basis,
+   examples-tutorial-rest).
+2. ``[core.databases.default]`` -- the Django-style multi-database
+   layout exposed through `CoreSettings` (examples-twitter).
+
+The second form is a fallback so that a `base.toml` carrying only the
+runtime-shape schema still satisfies the provisioning script when the
+caller selects `base.toml` directly (e.g., `REINHARDT_ENV=base`).
+
 Redis URL is read from a top-level `redis_url = "..."` key with a sane
 default; examples that don't actually use Redis still get an idle
 container spun up so the infra footprint is identical across examples.
@@ -87,6 +97,25 @@ def _deep_merge(base: dict, override: dict) -> dict:
 	return result
 
 
+def _resolve_database(data: dict) -> dict | None:
+	# Prefer the canonical top-level `[database]` schema. Fall back to
+	# the Django-style `[core.databases.default]` layout used by
+	# examples-twitter so that selecting `base.toml` directly still
+	# yields provisionable credentials even when only the runtime-shape
+	# schema is present.
+	candidate = data.get("database")
+	if isinstance(candidate, dict):
+		return candidate
+	nested = (
+		data.get("core", {})
+		.get("databases", {})
+		.get("default")
+	)
+	if isinstance(nested, dict):
+		return nested
+	return None
+
+
 def _load_settings(profile_path: str) -> dict:
 	# Layer the profile TOML on top of a sibling `base.toml` when one
 	# exists. When the caller asked for `base.toml` itself, or no sibling
@@ -109,11 +138,11 @@ def main(argv: list[str]) -> int:
 
 	data = _load_settings(argv[1])
 
-	try:
-		db = data["database"]
-	except KeyError:
+	db = _resolve_database(data)
+	if db is None:
 		sys.stderr.write(
-			f"Error: top-level [database] missing from {argv[1]} "
+			f"Error: neither top-level [database] nor "
+			f"[core.databases.default] found in {argv[1]} "
 			f"(and from sibling base.toml, if present)\n"
 		)
 		return 1

--- a/examples/examples-twitter/scripts/parse_local_toml.py
+++ b/examples/examples-twitter/scripts/parse_local_toml.py
@@ -6,6 +6,14 @@ configuration in a single source of truth. Despite the historical name,
 this script accepts any settings profile (`local.toml`, `ci.toml`, ...);
 the caller picks the file based on `REINHARDT_ENV`.
 
+The script mirrors the layered settings loader in `reinhardt_conf`: when
+a sibling `base.toml` exists next to the requested profile, it is loaded
+first as the default layer and the profile is deep-merged on top (the
+profile wins on key conflicts). This keeps the container provisioning
+script in sync with what `src/config/settings.rs` actually resolves at
+runtime, so a user-local `local.toml` containing only `[core]` overrides
+can still inherit the canonical `[database]` block from `base.toml`.
+
 The settings shape mirrors the example crates' top-level `[database]`
 section (see README "With Database" / `reinhardt_conf::settings::DatabaseConfig`).
 Redis URL is read from a top-level `redis_url = "..."` key with a sane
@@ -36,6 +44,7 @@ Exit codes:
 
 from __future__ import annotations
 
+import os.path
 import shlex
 import sys
 import urllib.parse
@@ -63,18 +72,49 @@ def _load_toml(path: str) -> dict:
 		raise SystemExit(1)
 
 
+def _deep_merge(base: dict, override: dict) -> dict:
+	# Recursively merge `override` into `base`. Nested dicts are merged
+	# key-by-key; scalars and lists in `override` replace the entry in
+	# `base`. Mirrors `reinhardt_conf`'s layered TOML loader so the
+	# provisioning script sees the same resolved values as the runtime.
+	result = dict(base)
+	for key, value in override.items():
+		existing = result.get(key)
+		if isinstance(existing, dict) and isinstance(value, dict):
+			result[key] = _deep_merge(existing, value)
+		else:
+			result[key] = value
+	return result
+
+
+def _load_settings(profile_path: str) -> dict:
+	# Layer the profile TOML on top of a sibling `base.toml` when one
+	# exists. When the caller asked for `base.toml` itself, or no sibling
+	# base is present, fall back to the profile as the sole source.
+	profile_data = _load_toml(profile_path)
+	settings_dir = os.path.dirname(profile_path) or "."
+	base_path = os.path.join(settings_dir, "base.toml")
+	if os.path.abspath(profile_path) == os.path.abspath(base_path):
+		return profile_data
+	if not os.path.isfile(base_path):
+		return profile_data
+	base_data = _load_toml(base_path)
+	return _deep_merge(base_data, profile_data)
+
+
 def main(argv: list[str]) -> int:
 	if len(argv) != 2:
 		sys.stderr.write("Usage: parse_local_toml.py <settings.toml>\n")
 		return 2
 
-	data = _load_toml(argv[1])
+	data = _load_settings(argv[1])
 
 	try:
 		db = data["database"]
 	except KeyError:
 		sys.stderr.write(
-			f"Error: top-level [database] missing from {argv[1]}\n"
+			f"Error: top-level [database] missing from {argv[1]} "
+			f"(and from sibling base.toml, if present)\n"
 		)
 		return 1
 

--- a/examples/examples-twitter/scripts/parse_local_toml.py
+++ b/examples/examples-twitter/scripts/parse_local_toml.py
@@ -14,8 +14,18 @@ script in sync with what `src/config/settings.rs` actually resolves at
 runtime, so a user-local `local.toml` containing only `[core]` overrides
 can still inherit the canonical `[database]` block from `base.toml`.
 
-The settings shape mirrors the example crates' top-level `[database]`
-section (see README "With Database" / `reinhardt_conf::settings::DatabaseConfig`).
+Two database schemas are accepted (in priority order):
+
+1. Top-level ``[database]`` -- the canonical shape consumed by
+   `reinhardt_conf::settings::DatabaseConfig` (examples-tutorial-basis,
+   examples-tutorial-rest).
+2. ``[core.databases.default]`` -- the Django-style multi-database
+   layout exposed through `CoreSettings` (examples-twitter).
+
+The second form is a fallback so that a `base.toml` carrying only the
+runtime-shape schema still satisfies the provisioning script when the
+caller selects `base.toml` directly (e.g., `REINHARDT_ENV=base`).
+
 Redis URL is read from a top-level `redis_url = "..."` key with a sane
 default; examples that don't actually use Redis still get an idle
 container spun up so the infra footprint is identical across examples.
@@ -87,6 +97,25 @@ def _deep_merge(base: dict, override: dict) -> dict:
 	return result
 
 
+def _resolve_database(data: dict) -> dict | None:
+	# Prefer the canonical top-level `[database]` schema. Fall back to
+	# the Django-style `[core.databases.default]` layout used by
+	# examples-twitter so that selecting `base.toml` directly still
+	# yields provisionable credentials even when only the runtime-shape
+	# schema is present.
+	candidate = data.get("database")
+	if isinstance(candidate, dict):
+		return candidate
+	nested = (
+		data.get("core", {})
+		.get("databases", {})
+		.get("default")
+	)
+	if isinstance(nested, dict):
+		return nested
+	return None
+
+
 def _load_settings(profile_path: str) -> dict:
 	# Layer the profile TOML on top of a sibling `base.toml` when one
 	# exists. When the caller asked for `base.toml` itself, or no sibling
@@ -109,11 +138,11 @@ def main(argv: list[str]) -> int:
 
 	data = _load_settings(argv[1])
 
-	try:
-		db = data["database"]
-	except KeyError:
+	db = _resolve_database(data)
+	if db is None:
 		sys.stderr.write(
-			f"Error: top-level [database] missing from {argv[1]} "
+			f"Error: neither top-level [database] nor "
+			f"[core.databases.default] found in {argv[1]} "
 			f"(and from sibling base.toml, if present)\n"
 		)
 		return 1


### PR DESCRIPTION
## Summary

`scripts/infra_up.sh` calls `scripts/parse_local_toml.py` on the settings
profile selected by `REINHARDT_ENV` (defaults to `local`). The previous
implementation read the profile file in isolation, so a user-local
`local.toml` carrying only `[core]` overrides failed with
`top-level [database] missing` — even though the canonical `[database]`
block lives in `base.toml` and the runtime settings loader resolves
both layers transparently.

This PR addresses:

- **Commit 1 — merge base.toml under the active profile.** Layer the
  profile TOML on top of a sibling `base.toml` using a recursive
  deep-merge that mirrors `reinhardt_conf`'s runtime loader semantics
  (profile wins on conflict, nested dicts merged key-by-key). Fall back
  to the profile alone when `base.toml` is absent, and avoid
  self-loading when the requested profile *is* `base.toml` (compared
  via `os.path.abspath` so relative/absolute forms collapse correctly).
- **Commit 2 — accept `[core.databases.default]` fallback for
  examples-twitter.** Its `base.toml` stores database credentials under
  the Django-style `[core.databases.default]` table (consumed via
  `CoreSettings` at runtime) rather than the top-level `[database]`
  block that the other example crates use. After commit 1, selecting
  `base.toml` directly (e.g., `REINHARDT_ENV=base`) still failed there
  because the script only recognised the top-level schema. Resolve
  `[database]` with a two-step lookup that prefers the canonical
  top-level form and falls back to `[core.databases.default]`.
- Sync the fix across the three example crates that ship a copy of
  this script (`examples-tutorial-basis`, `examples-tutorial-rest`,
  `examples-twitter`) so they stay byte-identically in lockstep
  (verified via `md5`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Reproducer from `examples/examples-tutorial-basis/`:

```
$ cargo make runserver
[cargo-make] Execute Command: "bash" "scripts/infra_up.sh"
Error: top-level [database] missing from .../settings/local.toml
```

The committed `settings/local.example.toml` (and therefore the typical
user-copy `local.toml`) only contains `[core]` overrides:

```toml
[core]
debug = true
secret_key = "local-development-secret-key"
```

`reinhardt_conf` merges this with `base.toml` at runtime, so `runserver`
itself sees a fully populated `[database]`. The infra provisioning
script, however, read only the active profile, so it couldn't find
database credentials to feed to the disposable Postgres container. The
runtime path and the provisioning path were silently disagreeing on the
shape of the settings space, which is exactly the kind of duplicated
semantics that the Reinhardt Design Philosophy ("Magic must be
understandable", "Fail early") asks us to avoid.

A second mismatch surfaced inside `examples-twitter`: its `base.toml`
uses `[core.databases.default]` while its `local.example.toml` /
`ci.toml` use top-level `[database]`. The runtime
(`#[settings(core: CoreSettings)]`) reads the former; the infra script
was hard-coded to the latter. Commit 2 adds a fallback so both schemas
are accepted. A deeper TOML schema alignment inside `examples-twitter`
is a separate concern (out of scope here per WU-1: 1 PR = 1 crate
x 1 fix pattern).

No GitHub Issue is open for this — the bug was discovered live by a
user running `cargo make runserver` against a freshly cloned example.

## How Was This Tested?

Manual runs of the patched script against six scenarios:

| Crate | Profile | Expectation | Result |
|---|---|---|---|
| examples-tutorial-basis | `local.toml` (`[core]` only) | inherits `[database]` from `base.toml` | `PG_DB=examples_tutorial_basis` ✓ |
| examples-tutorial-basis | `ci.toml` (own `[database]`) | profile override wins | `PG_DB=:memory:` ✓ |
| examples-tutorial-basis | `base.toml` directly | self-load short-circuited via `abspath` compare | `PG_DB=examples_tutorial_basis` ✓ |
| examples-tutorial-rest | `base.toml` directly | top-level `[database]` resolved | `PG_DB=examples_tutorial_rest` ✓ |
| examples-twitter | `base.toml` directly | `[core.databases.default]` fallback | `PG_DB=examples-twitter_db` ✓ |
| examples-twitter | `local.example.toml` | top-level `[database]` wins | `PG_DB=examples-twitter_dev` ✓ |

All three example crates' copies of the script remain byte-identical
post-fix (verified via `md5`).

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None (bug surfaced directly during local development).

## Labels to Apply

### Type Label
- [x] `bug` — Bug fix

### Scope Label
- (no single scope label fits cleanly — this is a tooling/build-script fix
  inside `examples/`; left unset rather than misapplying `ci-cd`.)

---

**Additional Context:**

The same `parse_local_toml.py` is duplicated across three example
crates. Consolidating it into a shared helper is out of scope for this
PR — fixing the divergence in-place keeps the diff small and the blast
radius bounded to `examples/`. A follow-up should align
`examples-twitter`'s TOML schema (`base.toml` vs. `local.example.toml`)
so the runtime credentials and the infra-provisioned container
credentials match by construction rather than by coincidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)