### PR TITLE
docs: revise PR policy — mandate Draft→Ready and drop Local SemVer Check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ Autonomously Allowed (no per-action confirmation required):
 | `git commit` | On any non-protected branch |
 | `git push` | On any non-protected branch (`feature/...`, `fix/...`, `refactor/...`, `docs/...`, `chore/...`, `test/...`, `perf/...`, `debug/...`, etc.); **never** on `main`, `master`, `develop/*`, or `release/*` |
 | Create a **Draft** Pull Request | `gh pr create --draft` / MCP `create_pull_request` with `draft=true`; body MUST follow `.github/PULL_REQUEST_TEMPLATE.md` |
-| Convert Draft PR to **Ready for Review** | **CI completion is not required** — this overrides any "CI green / tests pass" criterion in `instructions/`. All other PC-4a readiness criteria (implementation complete, PR description follows template, fmt/clippy clean, docs updated) still apply — see `instructions/PR_GUIDELINE.md` § PC-4a |
+| Convert Draft PR to **Ready for Review** | **REQUIRED (MUST) immediately once implementation is complete**. CI completion is NOT a prerequisite. See `instructions/PR_GUIDELINE.md` § PC-4a |
 | Create an Issue | `gh issue create` / MCP `issue_write`; MUST follow the appropriate issue template and apply at least one type label |
 
 **Protected Branches** (commit/push always require explicit user authorization):
@@ -195,9 +195,9 @@ Unchanged Quality Guardrails (apply equally to autonomous operations):
 - Branch naming, commit message format, Codex attribution footer, English-only policy, and all other rules in this document remain in force
 
 **Draft PR Policy:**
-- The agent MAY convert a Draft PR to Ready for Review autonomously once the PC-4a readiness criteria are met. CI completion is **not** required (the Autonomous Operation Policy overrides the previous "CI green / tests pass" prerequisite); fmt/clippy cleanliness and the other PC-4a criteria are still required
-- Explicit user instruction also authorizes conversion at any time (overrides readiness check)
-- The agent MUST NOT convert when any PC-4a readiness criterion (other than CI completion) is unmet, unless the user explicitly overrides
+- The agent **MUST** convert a Draft PR to Ready for Review **immediately once the implementation is complete**. "Implementation complete" means no remaining `todo!()` / `// TODO:` introduced by this PR. CI completion is **not** a prerequisite — the Autonomous Operation Policy explicitly waives "wait for CI green / tests to pass"
+- The agent **MUST NOT** leave a PR in Draft state after the implementation is complete
+- Explicit user instruction also authorizes (and requires) conversion at any time
 - Use `gh pr ready <number>` (or GitHub MCP equivalent) for conversion
 - See instructions/PR_GUIDELINE.md § PC-4a for full details
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,32 +401,6 @@ docker run --rm -v "$(pwd):/src" semgrep/semgrep semgrep scan --config .semgrep/
 cargo make audit  # Check for known vulnerabilities in dependencies
 ```
 
-**SemVer Check (Local, mirrors CI):**
-```bash
-# Run the same cargo-semver-checks command as CI semver-check.yml (normal PR path).
-# Capture output ONCE — semver-check is slow (typically 1.5–2 h) and running it twice
-# can also yield inconsistent results if `main` advances between invocations.
-OUT=$(cargo make semver-check 2>&1) || true
-
-# Post the result to the PR (required by PR_GUIDELINE.md RP-1a).
-# Use the <!-- local-semver-check --> marker. On re-runs, UPDATE the existing marked
-# comment via `gh api ... -X PATCH` instead of creating a new one.
-PR=<PR number>
-OWNER=<owner>
-REPO=<repo>
-BODY=$(printf '<!-- local-semver-check -->\n## Local SemVer Check Result\n\n````text\n%s\n````\n\n*Generated locally via `cargo make semver-check` (mirrors CI semver-check.yml).*' "$OUT")
-
-# Look up an existing marked comment, then PATCH it; otherwise create a new one.
-EXISTING=$(gh api "repos/$OWNER/$REPO/issues/$PR/comments" --paginate \
-  --jq '.[] | select(.body | startswith("<!-- local-semver-check -->")) | .id' \
-  | head -n1)
-if [ -n "$EXISTING" ]; then
-  gh api -X PATCH "repos/$OWNER/$REPO/issues/comments/$EXISTING" -f body="$BODY" >/dev/null
-else
-  gh api -X POST "repos/$OWNER/$REPO/issues/$PR/comments" -f body="$BODY" >/dev/null
-fi
-```
-
 **Placeholder Check (formatter artifact detection):**
 ```bash
 # Check for __reinhardt_placeholder__! left in source files after page! macro formatting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ Autonomously Allowed (no per-action confirmation required):
 | `git commit` | On any non-protected branch |
 | `git push` | On any non-protected branch (`feature/...`, `fix/...`, `refactor/...`, `docs/...`, `chore/...`, `test/...`, `perf/...`, `debug/...`, etc.); **never** on `main`, `master`, `develop/*`, or `release/*` |
 | Create a **Draft** Pull Request | `gh pr create --draft` / MCP `create_pull_request` with `draft=true`; body MUST follow `.github/PULL_REQUEST_TEMPLATE.md` |
-| Convert Draft PR to **Ready for Review** | **CI completion is not required** — this overrides any "CI green / tests pass" criterion in `instructions/`. All other PC-4a readiness criteria (implementation complete, PR description follows template, fmt/clippy clean, docs updated) still apply — see `instructions/PR_GUIDELINE.md` § PC-4a |
+| Convert Draft PR to **Ready for Review** | **REQUIRED (MUST) immediately once implementation is complete**. CI completion is NOT a prerequisite. See `instructions/PR_GUIDELINE.md` § PC-4a |
 | Create an Issue | `gh issue create` / MCP `issue_write`; MUST follow the appropriate issue template and apply at least one type label |
 
 **Protected Branches** (commit/push always require explicit user authorization):
@@ -195,9 +195,9 @@ Unchanged Quality Guardrails (apply equally to autonomous operations):
 - Branch naming, commit message format, Claude Code attribution footer, English-only policy, and all other rules in this document remain in force
 
 **Draft PR Policy:**
-- The agent MAY convert a Draft PR to Ready for Review autonomously once the PC-4a readiness criteria are met. CI completion is **not** required (the Autonomous Operation Policy overrides the previous "CI green / tests pass" prerequisite); fmt/clippy cleanliness and the other PC-4a criteria are still required
-- Explicit user instruction also authorizes conversion at any time (overrides readiness check)
-- The agent MUST NOT convert when any PC-4a readiness criterion (other than CI completion) is unmet, unless the user explicitly overrides
+- The agent **MUST** convert a Draft PR to Ready for Review **immediately once the implementation is complete**. "Implementation complete" means no remaining `todo!()` / `// TODO:` introduced by this PR. CI completion is **not** a prerequisite — the Autonomous Operation Policy explicitly waives "wait for CI green / tests to pass"
+- The agent **MUST NOT** leave a PR in Draft state after the implementation is complete
+- Explicit user instruction also authorizes (and requires) conversion at any time
 - Use `gh pr ready <number>` (or GitHub MCP equivalent) for conversion
 - See instructions/PR_GUIDELINE.md § PC-4a for full details
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,32 +401,6 @@ docker run --rm -v "$(pwd):/src" semgrep/semgrep semgrep scan --config .semgrep/
 cargo make audit  # Check for known vulnerabilities in dependencies
 ```
 
-**SemVer Check (Local, mirrors CI):**
-```bash
-# Run the same cargo-semver-checks command as CI semver-check.yml (normal PR path).
-# Capture output ONCE — semver-check is slow (typically 1.5–2 h) and running it twice
-# can also yield inconsistent results if `main` advances between invocations.
-OUT=$(cargo make semver-check 2>&1) || true
-
-# Post the result to the PR (required by PR_GUIDELINE.md RP-1a).
-# Use the <!-- local-semver-check --> marker. On re-runs, UPDATE the existing marked
-# comment via `gh api ... -X PATCH` instead of creating a new one.
-PR=<PR number>
-OWNER=<owner>
-REPO=<repo>
-BODY=$(printf '<!-- local-semver-check -->\n## Local SemVer Check Result\n\n````text\n%s\n````\n\n*Generated locally via `cargo make semver-check` (mirrors CI semver-check.yml).*' "$OUT")
-
-# Look up an existing marked comment, then PATCH it; otherwise create a new one.
-EXISTING=$(gh api "repos/$OWNER/$REPO/issues/$PR/comments" --paginate \
-  --jq '.[] | select(.body | startswith("<!-- local-semver-check -->")) | .id' \
-  | head -n1)
-if [ -n "$EXISTING" ]; then
-  gh api -X PATCH "repos/$OWNER/$REPO/issues/comments/$EXISTING" -f body="$BODY" >/dev/null
-else
-  gh api -X POST "repos/$OWNER/$REPO/issues/$PR/comments" -f body="$BODY" >/dev/null
-fi
-```
-
 **Placeholder Check (formatter artifact detection):**
 ```bash
 # Check for __reinhardt_placeholder__! left in source files after page! macro formatting

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -814,7 +814,7 @@ docs(readme): add installation instructions
 - Address all review comments
 - Ensure all CI checks pass before merge
 - Use three-dot diff (`main...branch`) for PR verification to exclude merge history noise
-- Convert Draft PRs to Ready for Review autonomously once PC-4a readiness criteria are satisfied, OR upon explicit user instruction
+- **MUST** convert Draft PRs to Ready for Review **immediately** once the implementation is complete (CI completion is NOT required), OR upon explicit user instruction (see § PC-4a)
 
 ### ❌ NEVER DO
 - Write PR titles or descriptions in non-English languages
@@ -827,7 +827,8 @@ docs(readme): add installation instructions
 - Force push after review has started (unless explicitly requested)
 - Use rebase or force-push to resolve PR conflicts (use worktree merge instead)
 - Use two-dot diff (`main..branch`) for PR verification (includes merge history noise)
-- Convert Draft PRs to Ready for Review while PC-4a readiness criteria are unmet (incomplete implementation, failing CI/tests, dirty fmt/clippy) without explicit user override
+- Convert Draft PRs to Ready for Review while the implementation is incomplete (`todo!()` or `// TODO:` introduced by the PR still present), without explicit user override
+- Leave a PR in Draft state after the implementation is complete (MUST convert to Ready for Review immediately; CI completion is NOT a prerequisite)
 
 ---
 

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -478,37 +478,6 @@ cargo make fmt-check
 cargo make clippy-check
 ```
 
-### RP-1a (MUST): Local SemVer Check + PR Comment
-
-Before converting a Draft PR to Ready for Review on any PR that touches public API, the agent / developer MUST:
-
-1. Run `cargo make semver-check` locally (mirrors `.github/workflows/semver-check.yml` for the normal-PR path)
-2. Post the full stdout/stderr as a PR comment with the `<!-- local-semver-check -->` marker
-3. On re-runs, **update** the existing marked comment instead of creating a new one (use GraphQL `updateIssueComment` or `gh api`)
-
-**Rationale:**
-
-- CI semver-check typically takes 1.5〜2 hours wall clock (April 2026 measurement: 104 min avg ≈ 1.7 h), with tail-end outliers up to ~4.7 hours (max 284 min). Running it locally in parallel with CI shortens the feedback loop
-- Provides a permanent, reviewer-visible audit trail of SemVer impact directly on the PR, independent of CI logs that may expire
-- Replaces the previous CI-generated `cargo-public-api` PR comment that was removed from `semver-check.yml`
-
-**Comment template:**
-
-`````markdown
-<!-- local-semver-check -->
-## Local SemVer Check Result
-
-````text
-<output of `cargo make semver-check`>
-````
-
-*Generated locally via `cargo make semver-check` (mirrors CI `semver-check.yml`).*
-`````
-
-The inner fence uses a 4-backtick `text` block so that any backticks in the captured output do not prematurely terminate the fence. The outer 5-backtick fence wraps the whole template safely when rendered in this document.
-
-If local output diverges from CI, investigate the cause before requesting review.
-
 ### RP-2 (SHOULD): Self-Review
 
 - Review your own PR before requesting review from others

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -31,7 +31,7 @@ This file defines the pull request (PR) policy for the Reinhardt project. These 
 - **Fallback**: Use GitHub CLI (`gh pr create`) when GitHub MCP is not available
 - **NEVER** use web browser UI for PR creation when MCP or CLI is available
 - MCP and CLI both ensure consistency and can be automated
-- **Autonomy (Reinhardt family)**: Creating a **Draft** PR is authorized without further user confirmation in `reinhardt-web` / `reinhardt-cloud` / `awesome-delions` / `reinhardt-cc` (see Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md`); the Draft PR body MUST still follow `.github/PULL_REQUEST_TEMPLATE.md` and `--draft` MUST be passed. Marking a PR as Ready for Review is also authorized autonomously once the implementation is complete (CI completion is **not** required).
+- **Autonomy (Reinhardt family)**: Creating a **Draft** PR is authorized without further user confirmation in `reinhardt-web` / `reinhardt-cloud` / `awesome-delions` / `reinhardt-cc` (see Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md`); the Draft PR body MUST still follow `.github/PULL_REQUEST_TEMPLATE.md` and `--draft` MUST be passed. Marking a PR as Ready for Review is **REQUIRED** (MUST) immediately once the implementation is complete; CI completion is **not** a prerequisite. See § PC-4a.
 
 The following diagram summarizes the PR creation flow:
 
@@ -154,39 +154,35 @@ gitGraph
 ### PC-4 (SHOULD): Draft PRs for Work in Progress
 
 - Use draft PRs for incomplete work
-- Convert to Ready for Review **once the implementation is complete** — CI completion is **not** a prerequisite (the Reinhardt-family Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md` overrides any "wait for all tests to pass" criterion for the Draft→Ready transition)
+- **MUST** convert to Ready for Review **immediately once the implementation is complete** — CI completion is **not** a prerequisite (the Reinhardt-family Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md` overrides any "wait for all tests to pass" criterion for the Draft→Ready transition)
 - Draft PRs allow early feedback without formal review requests
 
 **Example:**
 ```bash
 gh pr create --draft --title "feat(auth): add JWT validation (WIP)"
 
-# Convert to Ready once implementation is complete (no need to wait for CI):
+# MUST convert to Ready immediately once implementation is complete (CI completion NOT required):
 gh pr ready <number>
 ```
 
-### PC-4a (MUST): Draft PR Conversion Readiness
+### PC-4a (MUST): Mandatory Draft → Ready Conversion on Implementation Completion
 
-Converting a Draft PR to Ready for Review is a **review-readiness decision**. The agent MAY perform the conversion autonomously **once the PR meets readiness criteria** (i.e., it is in a state worth requesting Copilot Review). Explicit user instruction is also accepted at any time.
+Converting a Draft PR to Ready for Review is **mandatory once the implementation is complete**. "Implementation complete" means no `todo!()` / `// TODO:` markers introduced by this PR remain in the diff. **CI completion is NOT a prerequisite** — the Reinhardt-family Autonomous Operation Policy explicitly waives "wait for CI green / tests to pass". The agent MUST convert immediately upon implementation completion, and MUST NOT leave the PR in Draft state once the implementation is complete.
 
 **Rules:**
-- The agent MAY convert a Draft PR to Ready for Review when ALL readiness criteria below are satisfied
-- The agent MUST convert immediately when the user explicitly instructs it (regardless of CI state — the user accepts the trade-off)
-- The agent MUST NOT convert when any readiness criterion is unmet, unless the user explicitly overrides
+- The agent **MUST** convert a Draft PR to Ready for Review immediately once the implementation is complete
+- The agent **MUST** convert immediately upon explicit user instruction (regardless of CI state)
+- The agent **MUST NOT** leave a PR in Draft state after the implementation is complete
 - Use `gh pr ready <number>` (or the equivalent GitHub MCP call) for conversion
 
-**Readiness Criteria (ALL must be true for autonomous conversion):**
+**Readiness Criterion (single check):**
 - [ ] Implementation is complete (no remaining `todo!()` or `// TODO:` introduced by this PR)
-- [ ] PR description follows the template and accurately reflects the diff
-- [ ] Code follows project style (`cargo make fmt-check` + `cargo make clippy-check` clean)
-- [ ] Documentation updated where applicable
-- [ ] PR is at a quality level worth submitting for Copilot Review
 
-**Note:** Under the Reinhardt-family Autonomous Operation Policy (`CLAUDE.md` / `AGENTS.md`), **CI completion is the single waived prerequisite** — the previous "wait for CI green / tests to pass" gate no longer applies in the four Reinhardt-family repos (`reinhardt-web`, `reinhardt-cloud`, `awesome-delions`, `reinhardt-cc`). All other readiness criteria above remain mandatory for autonomous conversion.
+> Other quality requirements (fmt-clippy clean, PR description following the template, documentation updated) are already enforced by the commit/push policies and the PR creation policy — they are NOT additional preconditions for the Draft → Ready transition.
 
 **Example:**
 ```bash
-# Autonomous conversion once readiness criteria are met
+# Mandatory conversion once implementation is complete
 gh pr ready 123
 
 # Verify PR status after conversion
@@ -195,12 +191,12 @@ gh pr view 123 --json isDraft
 
 **Authorization Comparison:**
 
-| Action | Explicit Instruction | Plan Mode Approval | Readiness Criteria Met |
-|--------|---------------------|-------------------|------------------------|
+| Action | Explicit Instruction | Plan Mode Approval | Implementation Complete |
+|--------|---------------------|-------------------|--------------------------|
 | Commit | ✅ Authorized | ✅ Authorized | n/a |
 | Push | ✅ Authorized | ✅ Authorized | n/a |
 | GitHub Comments | ✅ Authorized | ✅ Authorized | n/a |
-| Draft PR → Ready | ✅ Authorized | ✅ Authorized (when readiness met) | ✅ Authorized |
+| Draft PR → Ready | ✅ **REQUIRED** | ✅ **REQUIRED** | ✅ **REQUIRED (MUST convert immediately)** |
 
 The following diagram illustrates the Draft PR lifecycle:
 
@@ -209,8 +205,8 @@ stateDiagram-v2
     [*] --> Draft: gh pr create --draft
     Draft --> Draft: Implementation continues
     Draft --> Draft: CI checks run
-    Draft --> ReadyForReview: Readiness criteria met OR user instructs
-    note right of ReadyForReview: Agent may convert autonomously\nonce ready for Copilot Review
+    Draft --> ReadyForReview: Implementation complete OR user instructs (MANDATORY)
+    note right of ReadyForReview: Agent MUST convert immediately\nonce implementation is complete
     ReadyForReview --> Review: Reviewers notified (incl. Copilot)
     Review --> Merged: Approved and merged
     Review --> Draft: Converted back to draft

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -62,7 +62,6 @@
 - Use `issue-XXXX-to-YYYY` for consecutive issue ranges and `and` for multiple ranges in branch names
 - Check known CI failure patterns before deep investigation
 - Run `cargo doc --no-deps` locally before pushing doc-related fixes
-- Run `cargo make semver-check` locally and post the output as a PR comment with the `<!-- local-semver-check -->` marker before converting Draft → Ready on any PR touching public API (see instructions/PR_GUIDELINE.md § RP-1a)
 - Execute merge/conflict resolution and straightforward operations immediately without Plan Mode
 - Use worktree-based merge strategy for PR conflict resolution (NOT rebase/force-push)
 - Apply `migration-approved` label to develop/* → main PRs (requires maintainer approval for version transition)
@@ -153,8 +152,6 @@
 - Create branches without checking for name conflicts
 - Use hyphens between issue numbers for ranges in branch names (use `to` and `and` instead)
 - Use rebase or force-push to resolve PR conflicts (use worktree merge instead)
-- Convert a Draft PR to Ready for Review on a PR touching public API without first running `cargo make semver-check` locally and posting the result to the PR with the `<!-- local-semver-check -->` marker
-- Create duplicate `<!-- local-semver-check -->` comments on re-runs (update the existing marked comment instead)
 - Merge develop/* branches into main without `migration-approved` label and CI version validation
 - Remove `agent-suspect` label without independent verification (separate agent or human)
 - Count `agent-suspect` labeled Issues toward stability timer reset (SC-2a)

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -13,7 +13,7 @@
 - Understand that Plan Mode approval authorizes both implementation and commits
 - Treat the Autonomous Operation Policy (Reinhardt family) as a standing exception that allows commit and push on any non-protected branch (anything other than `main`/`master`/`develop/*`/`release/*`), Draft PR creation, Draft→Ready conversion (implementation-complete only — no CI requirement), and Issue creation without further confirmation
 - When editing `CLAUDE.md` or `AGENTS.md`, mirror the change into the other file in the same commit (sync policy)
-- Convert Draft PRs to Ready for Review autonomously once the implementation is complete (CI completion is NOT required under the Autonomous Operation Policy) OR upon explicit user instruction (see instructions/PR_GUIDELINE.md § PC-4a)
+- **MUST** convert Draft PRs to Ready for Review **immediately** once the implementation is complete (CI completion is NOT required) — leaving a PR in Draft state after implementation completion is forbidden (see instructions/PR_GUIDELINE.md § PC-4a)
 - Mark placeholders with `todo!()` or `// TODO:`
 - Use `#[serial(group_name)]` for global state tests
 - Split commits by specific intent, not features
@@ -97,6 +97,7 @@
 - Create release tags or any PR with the `release` label without explicit user authorization
 - Commit a change that touches only `CLAUDE.md` or only `AGENTS.md` without mirroring it into the other
 - Convert Draft PRs to Ready for Review when implementation is incomplete, without explicit user override
+- Leave a PR in Draft state after the implementation is complete (MUST convert to Ready for Review immediately; the agent MUST NOT wait for CI completion)
 - Leave docs outdated after code changes
 - Document user requests or AI interactions in project documentation
 - Save files to project directory (use `/tmp`)

--- a/instructions/STABILITY_POLICY.md
+++ b/instructions/STABILITY_POLICY.md
@@ -704,7 +704,6 @@ During the RC phase:
 Automated SemVer checking is performed on every pull request targeting `main` using [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks).
 
 - **CI workflow**: `.github/workflows/semver-check.yml` reports any detected SemVer violations before code is merged.
-- **Local mirror**: `cargo make semver-check` mirrors the CI workflow and MUST be run before converting a Draft PR to Ready for Review on any PR touching public API (see `instructions/PR_GUIDELINE.md` § RP-1a).
 - **Audit trail**: A full breaking change audit is maintained at `docs/breaking-change-audit.md`.
 
 ---


### PR DESCRIPTION
## Summary

Two complementary documentation policy changes that move PR review-readiness from "wait for CI / run heavy local checks" to "implementation complete = Ready immediately":

1. **Mandate Draft → Ready conversion on implementation completion (MAY → MUST)**
   - `PR_GUIDELINE.md` § PC-4a: "Implementation complete" is now the single Readiness Criterion
   - Other quality gates (fmt-clippy / docs / description / Copilot-worthy) are dropped from PC-4a (already enforced by commit/push policies)
   - CI completion remains explicitly waived (Autonomous Operation Policy)
   - New NEVER DO: "Leave a PR in Draft state after implementation is complete"

2. **Remove Local SemVer Check obligation (RP-1a)**
   - `PR_GUIDELINE.md` § RP-1a deleted in full
   - CLAUDE.md / AGENTS.md "SemVer Check (Local, mirrors CI)" Common Commands block removed
   - QUICK_REFERENCE.md MUST/NEVER entries removed
   - STABILITY_POLICY.md "Local mirror" bullet removed
   - CI workflow `.github/workflows/semver-check.yml` is untouched — SemVer validation continues automatically on every PR

## Type of Change

- [x] Documentation update (no functional code changes)

## Motivation and Context

The previous policy required Local SemVer Check (1.5–2 h wall clock) before any public-API PR could be marked Ready for Review. With the new MUST-convert-immediately rule, that prerequisite becomes incompatible. Removing the obligation aligns the two policies and removes a slow blocker. CI continues to enforce SemVer correctness independently.

## How Was This Tested

- [x] Mirror diff: \`diff CLAUDE.md AGENTS.md\` shows only allowed Claude Code↔Codex attribution differences
- [x] \`grep -rn "MAY convert\|may convert"\` returns 0 matches in policy files
- [x] \`grep -rn "local-semver-check\|RP-1a\|Local SemVer Check"\` returns 0 matches in policy files
- [x] PC-4a Readiness Criteria reduced to exactly 1 checklist item
- [x] NEVER DO entry "Leave a PR in Draft" present in QUICK_REFERENCE.md
- [x] PR_GUIDELINE.md section order: RP-1 directly followed by RP-2 (RP-1a removed)
- [x] STABILITY_POLICY.md Continuous SemVer Verification: 2 bullets remain (CI workflow + Audit trail)

## Checklist

- [x] PR title follows Conventional Commits
- [x] CLAUDE.md ↔ AGENTS.md sync policy upheld (atomic commits, allowed-substitution-only diff)
- [x] No code/CI changes (docs-only PR)
- [x] \`documentation\` label applied

## Labels to Apply

- \`documentation\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)