### PR TITLE
docs: rename RP-1 from Pre-Review to Pre-Merge Checklist (align with PC-4a)

### DIFF
--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -459,9 +459,9 @@ Include additional sections when relevant:
 
 ## PR Review Process
 
-### RP-1 (MUST): Pre-Review Checklist
+### RP-1 (MUST): Pre-Merge Checklist
 
-Before requesting review, ensure:
+Before **merging** (NOT before Draft → Ready conversion — see § PC-4a, which mandates immediate Ready conversion upon implementation completion), ensure:
 
 - [ ] All CI checks pass
 - [ ] All tests pass locally
@@ -810,7 +810,7 @@ docs(readme): add installation instructions
 - Follow Conventional Commits format for titles
 - Include Summary, Type of Change, Motivation and Context, How Was This Tested, Checklist sections
 - Include Labels to Apply section with appropriate type and scope labels
-- Run all checks before requesting review
+- Run all checks before **merging** (NOT before Draft → Ready conversion — § PC-4a mandates immediate Ready conversion)
 - Address all review comments
 - Ensure all CI checks pass before merge
 - Use three-dot diff (`main...branch`) for PR verification to exclude merge history noise

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -33,18 +33,20 @@ This file defines the pull request (PR) policy for the Reinhardt project. These 
 - MCP and CLI both ensure consistency and can be automated
 - **Autonomy (Reinhardt family)**: Creating a **Draft** PR is authorized without further user confirmation in `reinhardt-web` / `reinhardt-cloud` / `awesome-delions` / `reinhardt-cc` (see Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md`); the Draft PR body MUST still follow `.github/PULL_REQUEST_TEMPLATE.md` and `--draft` MUST be passed. Marking a PR as Ready for Review is **REQUIRED** (MUST) immediately once the implementation is complete; CI completion is **not** a prerequisite. See § PC-4a.
 
-The following diagram summarizes the PR creation flow:
+The following diagram summarizes the PR creation flow. Ready-for-Review conversion is governed separately by § PC-4a (MUST immediately upon implementation completion — CI completion is NOT a prerequisite):
 
 ```mermaid
 flowchart TD
-    A[Create new PR] --> B{GitHub MCP available?}
-    B -->|Yes| C[Use create_pull_request MCP tool]
-    B -->|No| D[Use gh pr create CLI]
+    A[Create new PR as Draft] --> B{GitHub MCP available?}
+    B -->|Yes| C[create_pull_request with draft=true]
+    B -->|No| D[gh pr create --draft]
     C --> E[Follow PR template structure]
     D --> E
     E --> F[Add appropriate labels]
-    F --> G[Run pre-review checks]
-    G --> H[Request review]
+    F --> G[PR created as Draft]
+    G --> H["Implementation complete?<br/>see § PC-4a"]
+    H -->|Yes - MUST| I[Mark Ready immediately<br/>gh pr ready]
+    H -->|No| G
 ```
 
 **PR Template Location:** `.github/PULL_REQUEST_TEMPLATE.md`


### PR DESCRIPTION
## Summary

Follow-up to #4732 (caught by Codex stop-time review).

The previous RP-1 (MUST) **"Pre-Review Checklist"** required \`All CI checks pass\` and \`All tests pass locally\` **before requesting review**. That directly contradicts the new PC-4a policy introduced in #4732, which mandates **immediate Draft → Ready conversion upon implementation completion**, with CI completion explicitly NOT a prerequisite.

This PR resolves the contradiction by reframing RP-1 as a **pre-merge** checklist.

## Changes

| File | Change |
|---|---|
| \`instructions/PR_GUIDELINE.md\` § RP-1 | Rename "Pre-Review Checklist" → "Pre-Merge Checklist"; rephrase intro from "Before requesting review" → "Before **merging** (NOT before Draft → Ready conversion — see § PC-4a)" |
| \`instructions/PR_GUIDELINE.md\` Quick Reference | MUST DO: "Run all checks before requesting review" → "Run all checks before **merging** (NOT before Draft → Ready conversion)" |

The checklist contents themselves (CI pass, tests pass, style, docs, commit history, PR description) are **unchanged**; they remain required before merge per MP-1 and still serve as a useful summary.

## Type of Change

- [x] Documentation update (no functional code changes)

## Motivation and Context

PC-4a (per #4732) introduced a strong MUST rule: implementation complete = Ready conversion immediately, with CI completion explicitly waived. RP-1 (MUST) was unchanged from before #4732 and still required CI green / tests passing as a precondition for "requesting review" (= Draft → Ready). This left two MUST rules in direct conflict.

The fix preserves both rules by clarifying that RP-1's checklist applies to **merge**, not **Ready conversion**:

- Ready conversion: governed by PC-4a — immediate, CI not required
- Merge: governed by MP-1 / RP-1 — CI must pass, all checks green

## How Was This Tested

- [x] \`grep -n "Pre-Review Checklist\|before requesting review"\` confirms RP-1 references are updated (only RP-2's "review your own PR before requesting review from others" remains, which is SHOULD and refers to self-review timing, not Draft → Ready)
- [x] \`grep -n "Pre-Merge Checklist"\` returns the renamed section
- [x] Quick Reference MUST DO entry updated to "before merging"

## Checklist

- [x] PR title follows Conventional Commits
- [x] No code/CI changes (docs-only PR)
- [x] \`documentation\` label applied
- [x] Targets \`develop/0.2.0\` (current RC development branch per § PC-3)

## Labels to Apply

- \`documentation\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)