### PR TITLE
fix(ci): unblock develop/0.2.0 baseline CI (TODO, publish, docs.rs)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -408,6 +408,7 @@ members = [
   "crates/reinhardt-pages-components",
   "crates/reinhardt-pages-components-macros",
   "crates/reinhardt-seeding",
+  "crates/reinhardt-seeding/macros",
   "crates/reinhardt-storages",
   "crates/reinhardt-deploy",
   # Integration tests
@@ -507,7 +508,8 @@ reinhardt-payment = { path = "crates/reinhardt-payment", version = "0.2.0-rc.1" 
 reinhardt-payment-mocks = { path = "crates/reinhardt-payment-mocks", version = "0.2.0-rc.1" }
 reinhardt-pages-components = { path = "crates/reinhardt-pages-components", version = "0.2.0-rc.1" }
 reinhardt-pages-components-macros = { path = "crates/reinhardt-pages-components-macros", version = "0.2.0-rc.1" }
-reinhardt-seeding = { path = "crates/reinhardt-seeding" }
+reinhardt-seeding = { path = "crates/reinhardt-seeding", version = "0.2.0-rc.1" }
+reinhardt-seeding-macros = { path = "crates/reinhardt-seeding/macros", version = "0.2.0-rc.1" }
 reinhardt-storages = { path = "crates/reinhardt-storages", version = "0.2.0-rc.1" }
 reinhardt-deploy = { path = "crates/reinhardt-deploy", version = "0.2.0-rc.1" }
 

--- a/crates/reinhardt-pages-components-macros/src/lib.rs
+++ b/crates/reinhardt-pages-components-macros/src/lib.rs
@@ -3,8 +3,13 @@
 //! This crate provides the `page!` and `form!` macros for declarative UI construction.
 
 use proc_macro::TokenStream;
+use quote::quote;
 
-/// Placeholder for page! macro
+/// Placeholder for `page!` macro.
+///
+/// The implementation is not yet available; invoking this macro emits a
+/// `compile_error!` so user code fails to compile cleanly rather than
+/// triggering a procedural-macro panic.
 ///
 /// # Examples
 ///
@@ -19,10 +24,17 @@ use proc_macro::TokenStream;
 /// ```
 #[proc_macro]
 pub fn page(_input: TokenStream) -> TokenStream {
-	todo!("page! macro implementation")
+	quote! {
+		::core::compile_error!("page! macro is not yet implemented");
+	}
+	.into()
 }
 
-/// Placeholder for form! macro
+/// Placeholder for `form!` macro.
+///
+/// The implementation is not yet available; invoking this macro emits a
+/// `compile_error!` so user code fails to compile cleanly rather than
+/// triggering a procedural-macro panic.
 ///
 /// # Examples
 ///
@@ -38,5 +50,8 @@ pub fn page(_input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn form(_input: TokenStream) -> TokenStream {
-	todo!("form! macro implementation")
+	quote! {
+		::core::compile_error!("form! macro is not yet implemented");
+	}
+	.into()
 }

--- a/crates/reinhardt-seeding/Cargo.toml
+++ b/crates/reinhardt-seeding/Cargo.toml
@@ -18,7 +18,7 @@ full = ["json", "yaml", "macros"]
 # Internal dependencies
 reinhardt-core = { workspace = true }
 reinhardt-db = { workspace = true }
-reinhardt-seeding-macros = { path = "macros", optional = true }
+reinhardt-seeding-macros = { workspace = true, optional = true }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/reinhardt-seeding/src/factory/faker.rs
+++ b/crates/reinhardt-seeding/src/factory/faker.rs
@@ -40,7 +40,7 @@ pub enum FakerType {
 	Password,
 	/// Domain name (e.g., "example.com")
 	DomainName,
-	/// URL (e.g., "https://example.com/page")
+	/// URL (e.g., `<https://example.com/page>`)
 	Url,
 
 	// Lorem types

--- a/crates/reinhardt-seeding/src/lib.rs
+++ b/crates/reinhardt-seeding/src/lib.rs
@@ -94,19 +94,19 @@
 //!
 //! The fixture system is designed to be compatible with Django fixtures:
 //!
-//! - [`FixtureRecord`](fixtures::FixtureRecord) - Single fixture record with model ID, pk, and fields
-//! - [`FixtureFormat`](fixtures::FixtureFormat) - Supported formats (JSON, YAML)
-//! - [`FixtureParser`](fixtures::FixtureParser) - Parse fixture files
-//! - [`FixtureLoader`](fixtures::FixtureLoader) - Load fixtures into database
+//! - [`FixtureRecord`] - Single fixture record with model ID, pk, and fields
+//! - [`FixtureFormat`] - Supported formats (JSON, YAML)
+//! - [`FixtureParser`] - Parse fixture files
+//! - [`FixtureLoader`] - Load fixtures into database
 //! - [`FixtureSerializer`](fixtures::FixtureSerializer) - Serialize data to fixtures
 //!
 //! ## Factory System
 //!
 //! The factory system is inspired by Factory Boy:
 //!
-//! - [`Factory`](factory::Factory) trait - Core factory interface
-//! - [`FakerType`](factory::FakerType) - Fake data generators
-//! - [`Sequence`](factory::Sequence) - Auto-incrementing values
+//! - [`Factory`] trait - Core factory interface
+//! - [`FakerType`] - Fake data generators
+//! - [`Sequence`] - Auto-incrementing values
 //! - [`FactoryBuilder`](factory::FactoryBuilder) - Fluent factory configuration
 //!
 //! ## Commands


### PR DESCRIPTION
## Summary

This PR fixes 3 CI failures that exist on the `develop/0.2.0` baseline itself and currently block every open PR targeting that branch (e.g. #4714):

- `TODO Check / Clippy TODO/unimplemented/dbg lint`
- `Publish Check / Publish Dry-Run Check`
- `Docs.rs Build Check`

The 4th failure observed on PR #4714, **Release Dry-Run**, is a release-plz / crates.io publish-ordering artifact (failure resolving `reinhardt-query-macros = \"^0.2.0-rc.1\"` from the registry) and is intentionally NOT addressed here — it should be triaged separately once the other three are clean and the next `release-plz` run uploads the prerelease versions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Every PR opened against `develop/0.2.0` currently inherits these failures regardless of its own diff. They are pre-existing baseline issues that should be resolved on the branch itself rather than carried into unrelated feature PRs.

The three patterns being fixed:

1. **`reinhardt-pages-components-macros`** — the `page!` and `form!` proc-macros panicked via `todo!()`. Two issues with that:
   - It trips `cargo make clippy-todo-check` (`-D clippy::todo`).
   - Invoking the macro produces a proc-macro panic backtrace instead of a clean compile-time error at the call site.

   Replaced with `compile_error!` TokenStreams so unimplemented usages emit a plain rustc diagnostic, matching the project's documented intent (`unimplemented!()` is for *permanently* excluded features; `todo!()` is forbidden in production code by clippy-todo-check).

2. **`reinhardt-seeding`** — `cargo publish --dry-run` failed with
   `dependency 'reinhardt-seeding-macros' does not specify a version`.
   The `[dependencies]` entry was a path-only dep, and the sub-crate was not registered as a workspace member. Promoted the macros sub-crate to a first-class workspace member and added a versioned workspace dependency entry (matching the pattern used by `reinhardt-auth-macros`, `reinhardt-db-macros`, `reinhardt-query-macros`).

3. **`reinhardt-seeding` rustdoc** — three doc warnings (`rustdoc::redundant-explicit-links` × 2 reported plus several more latent on the same lines, `rustdoc::bare-urls` × 1) failed Docs.rs Build under `-D warnings`. Removed redundant explicit module targets where the link label already resolves via the crate-root re-exports, and wrapped a bare example URL in angle brackets.

Related to: #4714

## How Was This Tested?

- Local verification was deferred per project guidance (see `feedback_defer_verification_to_end` memory rule); CI on this PR runs the same workflows that were previously failing on the baseline and is the authoritative check.
- Diff scoped to the exact files/lines reported by the failing CI jobs on PR #4714 run `26278650712` (jobs `77349118693`, `77349118033`, `77353484892`).
- Three commits are split by intent so that any of them can be reverted independently if needed.

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix
- [x] `ci-cd` - CI/CD workflow changes

### Scope Label
- [ ] (none — touches workspace Cargo.toml + two functional crates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)