### PR TITLE
refactor(examples-tutorial-basis): introduce AuthoredQuestion/AuthoredChoice forward-looking newtypes

### DIFF
--- a/examples/examples-tutorial-basis/src/apps/polls/di.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/di.rs
@@ -68,17 +68,41 @@
 //! "DB outage" branch separate from "user is anonymous" so an
 //! availability problem cannot be silently rewritten into a fake 401.
 //!
-//! ## Limitation: dynamic request data
+//! ## Limitation: dynamic request data (status of #4645)
 //!
-//! `#[injectable_factory]` today rejects any parameter that is not
-//! `#[inject]`-tagged
-//! (`crates/reinhardt-di/macros/src/injectable_factory.rs:60-71`), so
-//! authentication scoped to a *path-bound* resource — e.g.,
-//! `require_question_author(question_id, &user)` — cannot be expressed
-//! as a factory yet. That is tracked as a `rc-migration` follow-up in
-//! [#4645](https://github.com/kent8192/reinhardt-web/issues/4645);
-//! until it ships, the per-row authorization helper stays a plain
-//! `async fn` in `server_fn.rs`.
+//! `#[injectable_factory]` today still rejects any parameter that is
+//! not `#[inject]`-tagged
+//! (`crates/reinhardt-di/macros/src/injectable_factory.rs:60-71`), so a
+//! plain `Path<i64>` cannot appear bare in a factory signature. The
+//! first wave of [#4645](https://github.com/kent8192/reinhardt-web/issues/4645)
+//! shipped `impl Injectable for Path<T> / Query<T> / Json<T>` (see
+//! `crates/reinhardt-di/src/params/{path,query,json}.rs`), so factories
+//! *can* now spell `#[inject] Path(id): Path<i64>` and the DI container
+//! resolves it from the active request's `ParamContext`.
+//!
+//! Two gaps remain before per-row authorization (e.g.
+//! `require_question_author(question_id, &user)`) collapses cleanly
+//! into a factory:
+//!
+//! 1. **form! ABI**: `#[server_fn]` arguments today must be `String`
+//!    (#4397 — relaxation in progress). The five Choice/Question
+//!    mutation handlers below therefore still parse `String → i64` by
+//!    hand even though `Path<i64>` itself is now injectable.
+//! 2. **`{question_id}` URL slot**: `Path<i64>` reads from the active
+//!    URL pattern's path params. The current `#[server_fn]` URLs are
+//!    flat (e.g. `/api/polls/update_question/`), so a factory taking
+//!    `Path<i64>` has nothing to bind to until either the form! relax
+//!    lets handlers take `question_id: i64` natively and pass it on,
+//!    or the server_fn URLs grow `{id}` slots.
+//!
+//! Until both gaps close, the per-row authorization helper
+//! (`require_question_author` in `server_fn.rs`) stays a plain
+//! `async fn`. The `AuthoredQuestion` / `AuthoredChoice` newtypes
+//! defined below are the **forward-looking shape** the helper will
+//! collapse into once #4397's relaxation lands; they are deliberately
+//! left without an `#[injectable_factory]` annotation today because
+//! firing them would always trip the `MissingParamContext` path in a
+//! `#[server_fn]` request and surface as a hard 500.
 
 #[cfg(native)]
 use reinhardt::Model;
@@ -219,4 +243,51 @@ async fn session_user_factory(#[inject] session: SessionData) -> SessionUser {
 	} else {
 		SessionUser::Inactive(user)
 	}
+}
+
+/// Forward-looking newtype that collapses `require_question_author` into
+/// a DI-resolvable type once #4645 fully lands (see module docs).
+///
+/// The shape is intentionally minimal: a verified `Question` whose
+/// `author_id` has already been compared against the active session
+/// user. Handlers that consume `Depends<AuthoredQuestion>` drop both
+/// the `String → i64` parse and the inline 403 check.
+///
+/// Why no `#[injectable_factory]` here yet: see the "Limitation"
+/// section in the module docs. Until form!'s String ABI relaxation
+/// (#4397) ships, registering this factory would always fail at runtime
+/// inside a `#[server_fn]` request.
+#[cfg(native)]
+#[allow(
+	dead_code,
+	reason = "forward-looking newtype — wired up once #4397 + #4645 ship; see module docs"
+)]
+#[derive(Clone)]
+pub struct AuthoredQuestion(pub crate::apps::polls::models::Question);
+
+/// Forward-looking newtype for the Choice mutation handlers.
+///
+/// Unlike `AuthoredQuestion`, an authored *Choice* needs a two-stage
+/// lookup: the URL carries `choice_id`, the `Choice` row carries
+/// `question_id`, and ownership lives on the parent `Question`. The
+/// factory therefore loads the `Choice` first, then resolves the parent
+/// `Question` and verifies authorship — the same flow currently
+/// open-coded in `update_choice` / `delete_choice`.
+///
+/// The `choice` and `question` fields are kept side-by-side so handlers
+/// can mutate the `Choice` without re-fetching it.
+///
+/// Same forward-looking status as [`AuthoredQuestion`]: definition is
+/// in place, but no `#[injectable_factory]` is registered until the
+/// upstream blockers (#4397, plus a URL `{choice_id}` slot for the
+/// Choice mutation routes) clear.
+#[cfg(native)]
+#[allow(
+	dead_code,
+	reason = "forward-looking newtype — wired up once #4397 + #4645 ship; see module docs"
+)]
+#[derive(Clone)]
+pub struct AuthoredChoice {
+	pub choice: crate::apps::polls::models::Choice,
+	pub question: crate::apps::polls::models::Question,
 }


### PR DESCRIPTION
## Summary

- Pre-stage two forward-looking newtypes in `examples/examples-tutorial-basis/src/apps/polls/di.rs`: `AuthoredQuestion(Question)` and `AuthoredChoice { choice, question }`
- Update the "Limitation: dynamic request data" module docs to reflect that `impl Injectable for Path<T>` / `Query<T>` / `Json<T>` has now shipped (#4720, the first wave of #4645) and to document the two remaining blockers before the existing per-row authorization helper can collapse into a factory
- Define the newtypes **without** `#[injectable_factory]` today — they are deliberately left unwired so they document the eventual shape without surfacing a runtime `MissingParamContext` 500 inside the current `#[server_fn]` URL layout

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Refs #4645. Stacked on top of #4720.

The Issue #4645 body's headline use case was the `polls` tutorial's
`require_question_author(question_id, &user)` helper collapsing into a
`#[injectable_factory(scope = "request")]` named `authored_question`.
Two findings during implementation:

1. **PR-1 (#4720) is necessary but not sufficient** for the helper
   collapse. `impl Injectable for Path<T>` lets a factory take
   `#[inject] Path(question_id): Path<i64>` from the active request's
   `ParamContext`, but the `#[server_fn]` ABI today requires `String`
   arguments (#4397 — relaxation in progress) and the Choice mutation
   routes have no `{id}` URL slot for `Path<i64>` to bind to. Firing a
   `Path<i64>`-taking factory in the current shape would always trip
   the `MissingParamContext` path and surface as a 500.
2. **The Issue body's `update_choice` / `delete_choice` claim was wrong.**
   Those two handlers cannot share an `AuthoredQuestion` factory —
   `question_id` is not in the URL, it sits on the loaded `Choice`. A
   second newtype `AuthoredChoice { choice, question }` with a two-stage
   lookup is needed instead. This PR captures the correct shape in code
   and documents the discovery in the module docstring; the same point
   is also being communicated on Issue #4645 as a correction comment.

The five `update_question` / `delete_question` / `create_choice` /
`update_choice` / `delete_choice` handlers are intentionally **not**
touched in this PR — they would still parse `String → i64` by hand
even after the newtypes are wired, and the larger collapse waits for
form! (#4397).

## How Was This Tested

- [x] `cargo check` from `examples/examples-tutorial-basis/` — clean (0 errors, 1 unrelated config-template warning)
- [x] `rustfmt --check` on the modified file — clean
- [x] The two new `pub struct`s do not introduce a public surface change in any published Reinhardt crate (the examples crate is unpublished)

## Checklist

- [x] Implementation is complete
- [x] Code follows project style (rustfmt clean)
- [x] Documentation updated (module-level docstring rewritten to capture both blockers and the corrected `AuthoredChoice` shape)
- [x] Conventional Commits format
- [x] Branch name follows `refactor/issue-XXXX-<desc>`
- [x] Stacked on #4720 (base: `feat/issue-4645-injectable-extractors`)
- [x] `#[allow(dead_code, reason = "...")]` carries an explanatory reason on both newtypes per the project's `#[allow]` policy

## Related Issues

Refs #4645
Stacked on #4720

## Labels to Apply

- `enhancement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation on dependency injection constraints, clarifying parameter requirements and current authorization limitations in the polling module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->