### PR TITLE
feat(admin-cli): add migrate-manouche-v2 codemod (spec §6.1 + §6.2)

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -754,3 +754,8 @@ args = ["mutants", "--shard", "${SHARD}/${TOTAL_SHARDS}", "--test-tool", "nextes
 description = "Run mutation testing for all mutants (no sharding)"
 command = "cargo"
 args = ["mutants", "--test-tool", "nextest", "--timeout-multiplier", "2", "--jobs", "1"]
+
+[tasks.migrate-manouche-v2]
+description = "Apply the Manouche v1 → v2 codemod (spec §6.1 + §6.2)"
+command = "cargo"
+args = ["run", "-p", "reinhardt-admin-cli", "--", "migrate-manouche-v2", "${@}"]

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `reinhardt-admin migrate-manouche-v2 [PATH]` subcommand applying the
+  Manouche v1 → v2 codemod (spec §6.1 + §6.2). Available as `cargo make
+  migrate-manouche-v2`. Supports `--dry-run` and `--skip <rule>`. Rules:
+  `bare_ident`, `watch_unwrap`, `use_effect_deps`, `component_props`.
+
 ## [0.1.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.0-rc.30...reinhardt-admin-cli@v0.1.0) - 2026-05-22
 
 Initial stable release of `reinhardt-admin-cli` as part of the

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -27,6 +27,7 @@ ctrlc = "3.4"
 regex = "1.10"
 reinhardt-pages = {workspace = true, features = ["ast"]}
 zeroize = "1.8"
+anyhow = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.8"
@@ -35,6 +36,10 @@ walkdir = "2.5"
 
 [features]
 full = []
+
+[lib]
+name = "reinhardt_admin_cli"
+path = "src/lib.rs"
 
 [[bin]]
 name = "reinhardt-admin"

--- a/crates/reinhardt-admin-cli/src/lib.rs
+++ b/crates/reinhardt-admin-cli/src/lib.rs
@@ -1,0 +1,9 @@
+//! Library entry point for `reinhardt-admin-cli`.
+//!
+//! Exposes internal modules so they can be invoked from integration tests
+//! and (eventually) from other tooling. The actual command-line entry
+//! point lives in `src/main.rs`.
+
+#![warn(missing_docs)]
+
+pub mod migrate_v2;

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -32,6 +32,8 @@ mod ast_formatter;
 mod formatter;
 mod utils;
 
+use reinhardt_admin_cli::migrate_v2;
+
 use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -247,6 +249,9 @@ enum Commands {
 		#[arg(long)]
 		backup: bool,
 	},
+
+	/// Migrate Manouche v1 source files to v2 grammar (spec §6.1 + §6.2).
+	MigrateManoucheV2(migrate_v2::MigrateV2Args),
 }
 
 /// Plugin management subcommands
@@ -461,6 +466,13 @@ async fn main() {
 			backup,
 			cli.verbosity,
 		),
+		Commands::MigrateManoucheV2(args) => {
+			if let Err(e) = migrate_v2::run(args) {
+				eprintln!("{}", format!("error: {e}").red());
+				process::exit(1);
+			}
+			Ok(())
+		}
 	};
 
 	if let Err(e) = result {

--- a/crates/reinhardt-admin-cli/src/migrate_v2.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2.rs
@@ -1,0 +1,34 @@
+//! Manouche v1 → v2 codemod (spec §6.1 + §6.2).
+//!
+//! Invoked via `reinhardt-admin migrate-manouche-v2 [PATH]` or
+//! `cargo make migrate-manouche-v2`.
+
+use std::path::PathBuf;
+
+use clap::Args;
+
+pub mod rewriter;
+pub mod rules;
+pub mod walker;
+
+/// Arguments for the `migrate-manouche-v2` subcommand.
+#[derive(Args, Debug)]
+pub struct MigrateV2Args {
+	/// Root path to migrate. Defaults to the current workspace.
+	#[arg(default_value = ".")]
+	pub path: PathBuf,
+
+	/// Print changes without writing them.
+	#[arg(long)]
+	pub dry_run: bool,
+
+	/// Comma-separated list of rule names to skip (e.g. `--skip use_effect_deps`).
+	#[arg(long, value_delimiter = ',')]
+	pub skip: Vec<String>,
+}
+
+/// Entry point invoked by `main.rs`.
+pub fn run(args: MigrateV2Args) -> anyhow::Result<()> {
+	let _ = args;
+	anyhow::bail!("not implemented yet")
+}

--- a/crates/reinhardt-admin-cli/src/migrate_v2.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2.rs
@@ -46,10 +46,7 @@ pub fn run(args: MigrateV2Args) -> anyhow::Result<()> {
 	let mut changed = 0_usize;
 
 	for path in files {
-		let src = match read_developer_file(&path) {
-			Ok(s) => s,
-			Err(e) => return Err(e),
-		};
+		let src = read_developer_file(&path)?;
 		let parsed: syn::File = match syn::parse_file(&src) {
 			Ok(f) => f,
 			// Skip files we cannot parse (e.g. build scripts with cfg-gated items).
@@ -75,7 +72,11 @@ pub fn run(args: MigrateV2Args) -> anyhow::Result<()> {
 	println!(
 		"\nDone. {} file(s) {}.",
 		changed,
-		if args.dry_run { "would change" } else { "changed" }
+		if args.dry_run {
+			"would change"
+		} else {
+			"changed"
+		}
 	);
 	Ok(())
 }

--- a/crates/reinhardt-admin-cli/src/migrate_v2.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2.rs
@@ -37,7 +37,19 @@ pub struct MigrateV2Args {
 /// not a string literal, but the only "untrusted" surface here is the
 /// developer's own CLI invocation, which is an intentional capability.
 pub fn run(args: MigrateV2Args) -> anyhow::Result<()> {
-	let rules: Vec<_> = rules::all()
+	let all_rules = rules::all();
+	let known_rule_names: std::collections::BTreeSet<&'static str> =
+		all_rules.iter().map(|r| r.name()).collect();
+	let unknown: Vec<&str> = args
+		.skip
+		.iter()
+		.map(String::as_str)
+		.filter(|name| !known_rule_names.contains(name))
+		.collect();
+	if !unknown.is_empty() {
+		anyhow::bail!("unknown --skip rule(s): {}", unknown.join(", "));
+	}
+	let rules: Vec<_> = all_rules
 		.into_iter()
 		.filter(|r| !args.skip.iter().any(|s| s == r.name()))
 		.collect();
@@ -98,10 +110,15 @@ fn read_developer_file(path: &std::path::Path) -> anyhow::Result<String> {
 /// note as `read_developer_file`.
 fn write_developer_file(path: &std::path::Path, content: &str) -> anyhow::Result<()> {
 	let canonical = path.canonicalize()?;
-	let mut file = std::fs::OpenOptions::new()
-		.write(true)
-		.truncate(true)
-		.open(canonical)?;
-	std::io::Write::write_all(&mut file, content.as_bytes())?;
+	let parent = canonical
+		.parent()
+		.ok_or_else(|| anyhow::anyhow!("missing parent directory"))?;
+	let file_name = canonical
+		.file_name()
+		.and_then(|n| n.to_str())
+		.unwrap_or("rewrite");
+	let tmp = parent.join(format!(".{file_name}.tmp"));
+	std::fs::write(&tmp, content)?;
+	std::fs::rename(tmp, canonical)?;
 	Ok(())
 }

--- a/crates/reinhardt-admin-cli/src/migrate_v2.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2.rs
@@ -28,7 +28,79 @@ pub struct MigrateV2Args {
 }
 
 /// Entry point invoked by `main.rs`.
+///
+/// File paths are obtained from `walker::find_rs_files`, which enumerates
+/// entries rooted at the CLI-supplied `--path` directory via `walkdir`. No
+/// remote/HTTP input is involved; this is a developer-run codemod that
+/// rewrites files in the developer's own checkout. Semgrep's Actix
+/// "path-traversal" pattern flags any `std::fs` call whose path argument is
+/// not a string literal, but the only "untrusted" surface here is the
+/// developer's own CLI invocation, which is an intentional capability.
 pub fn run(args: MigrateV2Args) -> anyhow::Result<()> {
-	let _ = args;
-	anyhow::bail!("not implemented yet")
+	let rules: Vec<_> = rules::all()
+		.into_iter()
+		.filter(|r| !args.skip.iter().any(|s| s == r.name()))
+		.collect();
+
+	let files = walker::find_rs_files(&args.path)?;
+	let mut changed = 0_usize;
+
+	for path in files {
+		let src = match read_developer_file(&path) {
+			Ok(s) => s,
+			Err(e) => return Err(e),
+		};
+		let parsed: syn::File = match syn::parse_file(&src) {
+			Ok(f) => f,
+			// Skip files we cannot parse (e.g. build scripts with cfg-gated items).
+			Err(_) => continue,
+		};
+		let mut out_ast = parsed.clone();
+		for r in &rules {
+			out_ast = r.rewrite(out_ast);
+		}
+
+		let out = prettyplease::unparse(&out_ast);
+		if out != src {
+			changed += 1;
+			if args.dry_run {
+				println!("would rewrite: {}", path.display());
+			} else {
+				write_developer_file(&path, &out)?;
+				println!("rewrote: {}", path.display());
+			}
+		}
+	}
+
+	println!(
+		"\nDone. {} file(s) {}.",
+		changed,
+		if args.dry_run { "would change" } else { "changed" }
+	);
+	Ok(())
+}
+
+/// Reads a developer-owned source file enumerated by `walker::find_rs_files`.
+///
+/// The path argument is bounded by the CLI-supplied `--path` root; this is a
+/// developer-run codemod, not a network-facing service. We canonicalize the
+/// path before any IO to make the bounds explicit.
+fn read_developer_file(path: &std::path::Path) -> anyhow::Result<String> {
+	let canonical = path.canonicalize()?;
+	let mut file = std::fs::File::open(canonical)?;
+	let mut buf = String::new();
+	std::io::Read::read_to_string(&mut file, &mut buf)?;
+	Ok(buf)
+}
+
+/// Writes the rewritten source back to a developer-owned file. Same scope
+/// note as `read_developer_file`.
+fn write_developer_file(path: &std::path::Path, content: &str) -> anyhow::Result<()> {
+	let canonical = path.canonicalize()?;
+	let mut file = std::fs::OpenOptions::new()
+		.write(true)
+		.truncate(true)
+		.open(canonical)?;
+	std::io::Write::write_all(&mut file, content.as_bytes())?;
+	Ok(())
 }

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rewriter.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rewriter.rs
@@ -1,3 +1,14 @@
 //! Rewriter trait composed across rules.
-//!
-//! Implemented in Task 2.
+
+/// One mechanical migration step in the Manouche v1 → v2 codemod.
+///
+/// Each rule receives the parsed AST of a single `.rs` file and returns a
+/// (possibly) transformed copy. Rules are composed sequentially by the
+/// driver in `migrate_v2::run`.
+pub trait FileRewriter {
+	/// Returns a (possibly) transformed copy of the input file AST.
+	fn rewrite(&self, file: syn::File) -> syn::File;
+
+	/// Short name for `--skip` filtering and reporting.
+	fn name(&self) -> &'static str;
+}

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rewriter.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rewriter.rs
@@ -1,0 +1,3 @@
+//! Rewriter trait composed across rules.
+//!
+//! Implemented in Task 2.

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules.rs
@@ -1,0 +1,3 @@
+//! Registry of all rewriter rules.
+//!
+//! Implemented in Task 2.

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules.rs
@@ -1,3 +1,18 @@
 //! Registry of all rewriter rules.
-//!
-//! Implemented in Task 2.
+
+pub mod bare_ident;
+pub mod component_props;
+pub mod use_effect_deps;
+pub mod watch_unwrap;
+
+use crate::migrate_v2::rewriter::FileRewriter;
+
+/// Returns all rules in deterministic order.
+pub fn all() -> Vec<Box<dyn FileRewriter>> {
+	vec![
+		Box::new(bare_ident::Rule),
+		Box::new(watch_unwrap::Rule),
+		Box::new(use_effect_deps::Rule),
+		Box::new(component_props::Rule),
+	]
+}

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
@@ -1,0 +1,15 @@
+//! Rule §6.1 (1): `tag { ident }` → `tag { {ident} }` (no-op stub; implemented in Task 3).
+
+use crate::migrate_v2::rewriter::FileRewriter;
+
+/// Placeholder rule — replaced by the real implementation in Task 3.
+pub struct Rule;
+
+impl FileRewriter for Rule {
+	fn rewrite(&self, file: syn::File) -> syn::File {
+		file
+	}
+	fn name(&self) -> &'static str {
+		"bare_ident"
+	}
+}

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
@@ -1,15 +1,125 @@
-//! Rule §6.1 (1): `tag { ident }` → `tag { {ident} }` (no-op stub; implemented in Task 3).
+//! Rule §6.1 (1): `tag { ident }` → `tag { {ident} }`.
+//!
+//! Conservative implementation — bails out on any token that could mean
+//! attribute, event, nested element, component call, or method chain. The
+//! resulting diff is the developer's review surface; missing transformations
+//! are acceptable and caught on a second pass.
+
+use proc_macro2::{Delimiter, Group, TokenStream, TokenTree};
+use quote::quote;
+use syn::visit_mut::{self, VisitMut};
 
 use crate::migrate_v2::rewriter::FileRewriter;
 
-/// Placeholder rule — replaced by the real implementation in Task 3.
+/// `bare_ident` rule entry.
 pub struct Rule;
 
 impl FileRewriter for Rule {
-	fn rewrite(&self, file: syn::File) -> syn::File {
-		file
-	}
 	fn name(&self) -> &'static str {
 		"bare_ident"
 	}
+
+	fn rewrite(&self, mut file: syn::File) -> syn::File {
+		PageMacroBodyVisitor.visit_file_mut(&mut file);
+		file
+	}
+}
+
+struct PageMacroBodyVisitor;
+
+impl VisitMut for PageMacroBodyVisitor {
+	fn visit_macro_mut(&mut self, m: &mut syn::Macro) {
+		// Only target the `page!` macro (and any qualified path ending in `page`).
+		if m
+			.path
+			.segments
+			.last()
+			.map(|s| s.ident == "page")
+			.unwrap_or(false)
+		{
+			m.tokens = rewrite_page_body(m.tokens.clone());
+		}
+		visit_mut::visit_macro_mut(self, m);
+	}
+}
+
+/// Walks the token stream of a `page!` body. Inside brace-delimited groups,
+/// promotes any bare lowercase-leading identifier to a `{ident}` group.
+fn rewrite_page_body(input: TokenStream) -> TokenStream {
+	let mut out: Vec<TokenTree> = Vec::new();
+	let mut iter = input.into_iter();
+	while let Some(tt) = iter.next() {
+		match tt {
+			TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => {
+				let inner = rewrite_brace_body(g.stream());
+				out.push(TokenTree::Group(Group::new(Delimiter::Brace, inner)));
+			}
+			other => out.push(other),
+		}
+	}
+	out.into_iter().collect()
+}
+
+/// Inside a `{ ... }` body, promote a bare ident to `{ident}` when it appears
+/// in child-node position.
+fn rewrite_brace_body(input: TokenStream) -> TokenStream {
+	let mut out: Vec<TokenTree> = Vec::new();
+	let mut iter = input.into_iter().peekable();
+
+	while let Some(tt) = iter.next() {
+		// Look for `Ident` followed by something that is NOT one of:
+		//   `{` — element body
+		//   `(` — component call or function call
+		//   `:` — attribute syntax (`class: "x"`)
+		//   `!` — macro call (`println!`)
+		//   `.` — method chain or field access
+		//   `,` — would already be the end of a value but still ambiguous
+		//   `::` — path continuation
+		// These all mean "not a bare expression in body position".
+		if let TokenTree::Ident(id) = &tt
+			&& starts_lowercase(&id.to_string())
+		{
+			let is_followed_by_continuation = match iter.peek() {
+				Some(TokenTree::Group(g))
+					if matches!(g.delimiter(), Delimiter::Brace | Delimiter::Parenthesis) =>
+				{
+					true
+				}
+				Some(TokenTree::Punct(p))
+					if matches!(p.as_char(), ':' | '!' | '.' | ',') =>
+				{
+					true
+				}
+				_ => false,
+			};
+
+			if !is_followed_by_continuation {
+				// Bare ident in body position — wrap.
+				let ident = id.clone();
+				let wrapped = quote! { #ident };
+				out.push(TokenTree::Group(Group::new(Delimiter::Brace, wrapped)));
+				continue;
+			}
+		}
+
+		// Recurse into any nested braced group (could be a child element body).
+		if let TokenTree::Group(g) = &tt
+			&& g.delimiter() == Delimiter::Brace
+		{
+			let inner = rewrite_brace_body(g.stream());
+			out.push(TokenTree::Group(Group::new(Delimiter::Brace, inner)));
+			continue;
+		}
+
+		out.push(tt);
+	}
+
+	out.into_iter().collect()
+}
+
+fn starts_lowercase(s: &str) -> bool {
+	s.chars()
+		.next()
+		.map(|c| c.is_ascii_lowercase())
+		.unwrap_or(false)
 }

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
@@ -47,8 +47,7 @@ impl VisitMut for PageMacroBodyVisitor {
 /// promotes any bare lowercase-leading identifier to a `{ident}` group.
 fn rewrite_page_body(input: TokenStream) -> TokenStream {
 	let mut out: Vec<TokenTree> = Vec::new();
-	let mut iter = input.into_iter();
-	while let Some(tt) = iter.next() {
+	for tt in input {
 		match tt {
 			TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => {
 				let inner = rewrite_brace_body(g.stream());
@@ -103,12 +102,20 @@ fn rewrite_brace_body(input: TokenStream) -> TokenStream {
 			}
 		}
 
-		// Recurse into any nested braced group (could be a child element body).
+		// Recurse into any nested braced group (could be a child element body) —
+		// UNLESS the group is already in v2 expression-slot shape (`{ expr }`
+		// where the inner stream is itself wrapped in a single brace group).
+		// Recursing into such a body would re-wrap the inner ident on every
+		// pass, breaking idempotency.
 		if let TokenTree::Group(g) = &tt
 			&& g.delimiter() == Delimiter::Brace
 		{
-			let inner = rewrite_brace_body(g.stream());
-			out.push(TokenTree::Group(Group::new(Delimiter::Brace, inner)));
+			if is_already_wrapped_expression_slot(&g.stream()) {
+				out.push(tt);
+			} else {
+				let inner = rewrite_brace_body(g.stream());
+				out.push(TokenTree::Group(Group::new(Delimiter::Brace, inner)));
+			}
 			continue;
 		}
 
@@ -116,6 +123,19 @@ fn rewrite_brace_body(input: TokenStream) -> TokenStream {
 	}
 
 	out.into_iter().collect()
+}
+
+/// True when a brace body's entire contents are themselves a single brace
+/// group — i.e. the surrounding braces are already the v2 expression-slot
+/// wrapping (`{ {expr} }`) introduced by a prior run of this rule.
+fn is_already_wrapped_expression_slot(stream: &TokenStream) -> bool {
+	let mut iter = stream.clone().into_iter();
+	let first = iter.next();
+	let rest = iter.next();
+	match (first, rest) {
+		(Some(TokenTree::Group(g)), None) => g.delimiter() == Delimiter::Brace,
+		_ => false,
+	}
 }
 
 fn starts_lowercase(s: &str) -> bool {

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
@@ -78,6 +78,7 @@ fn rewrite_brace_body(input: TokenStream) -> TokenStream {
 		// These all mean "not a bare expression in body position".
 		if let TokenTree::Ident(id) = &tt
 			&& starts_lowercase(&id.to_string())
+			&& !is_reserved_keyword(&id.to_string())
 		{
 			let is_followed_by_continuation = match iter.peek() {
 				Some(TokenTree::Group(g))
@@ -122,4 +123,51 @@ fn starts_lowercase(s: &str) -> bool {
 		.next()
 		.map(|c| c.is_ascii_lowercase())
 		.unwrap_or(false)
+}
+
+/// Rust reserved keywords that can legally appear at the head of an
+/// expression / control-flow construct inside a `page!` body. We must
+/// never wrap these in braces — `{ if } cond { ... }` is a parse error.
+fn is_reserved_keyword(s: &str) -> bool {
+	matches!(
+		s,
+		"if" | "else"
+			| "match"
+			| "for"
+			| "while"
+			| "loop"
+			| "let"
+			| "return"
+			| "break"
+			| "continue"
+			| "move"
+			| "ref"
+			| "mut"
+			| "async"
+			| "await"
+			| "yield"
+			| "do"
+			| "in"
+			| "as"
+			| "where"
+			| "use"
+			| "fn"
+			| "true"
+			| "false"
+			| "self"
+			| "Self"
+			| "super"
+			| "crate"
+			| "impl"
+			| "trait"
+			| "struct"
+			| "enum"
+			| "type"
+			| "const"
+			| "static"
+			| "pub"
+			| "mod"
+			| "unsafe"
+			| "extern"
+	)
 }

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
@@ -80,7 +80,10 @@ fn rewrite_brace_body(input: TokenStream) -> TokenStream {
 		{
 			let is_followed_by_continuation = match iter.peek() {
 				Some(TokenTree::Group(g))
-					if matches!(g.delimiter(), Delimiter::Brace | Delimiter::Parenthesis) =>
+					if matches!(
+						g.delimiter(),
+						Delimiter::Brace | Delimiter::Parenthesis | Delimiter::Bracket
+					) =>
 				{
 					true
 				}

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
@@ -30,8 +30,7 @@ struct PageMacroBodyVisitor;
 impl VisitMut for PageMacroBodyVisitor {
 	fn visit_macro_mut(&mut self, m: &mut syn::Macro) {
 		// Only target the `page!` macro (and any qualified path ending in `page`).
-		if m
-			.path
+		if m.path
 			.segments
 			.last()
 			.map(|s| s.ident == "page")
@@ -85,11 +84,7 @@ fn rewrite_brace_body(input: TokenStream) -> TokenStream {
 				{
 					true
 				}
-				Some(TokenTree::Punct(p))
-					if matches!(p.as_char(), ':' | '!' | '.' | ',') =>
-				{
-					true
-				}
+				Some(TokenTree::Punct(p)) if matches!(p.as_char(), ':' | '!' | '.' | ',') => true,
 				_ => false,
 			};
 
@@ -152,41 +147,24 @@ fn is_reserved_keyword(s: &str) -> bool {
 	matches!(
 		s,
 		"if" | "else"
-			| "match"
-			| "for"
-			| "while"
-			| "loop"
-			| "let"
-			| "return"
-			| "break"
-			| "continue"
-			| "move"
-			| "ref"
-			| "mut"
-			| "async"
-			| "await"
-			| "yield"
-			| "do"
-			| "in"
-			| "as"
-			| "where"
-			| "use"
-			| "fn"
-			| "true"
-			| "false"
-			| "self"
-			| "Self"
-			| "super"
-			| "crate"
-			| "impl"
-			| "trait"
+			| "match" | "for"
+			| "while" | "loop"
+			| "let" | "return"
+			| "break" | "continue"
+			| "move" | "ref"
+			| "mut" | "async"
+			| "await" | "yield"
+			| "do" | "in"
+			| "as" | "where"
+			| "use" | "fn"
+			| "true" | "false"
+			| "self" | "Self"
+			| "super" | "crate"
+			| "impl" | "trait"
 			| "struct"
-			| "enum"
-			| "type"
-			| "const"
-			| "static"
-			| "pub"
-			| "mod"
+			| "enum" | "type"
+			| "const" | "static"
+			| "pub" | "mod"
 			| "unsafe"
 			| "extern"
 	)

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/component_props.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/component_props.rs
@@ -48,10 +48,18 @@ impl VisitMut for StructVisitor {
 		replace_derive_default_with_bon_builder(&mut s.attrs);
 
 		if let syn::Fields::Named(fields) = &mut s.fields {
-			for (idx, field) in fields.named.iter_mut().enumerate() {
+			let mut seen_first_non_option = false;
+			for field in fields.named.iter_mut() {
 				let is_option = is_option_type(&field.ty);
-				let is_first = idx == 0;
-				if !is_first || is_option {
+				let should_default = if is_option {
+					true
+				} else if !seen_first_non_option {
+					seen_first_non_option = true;
+					false
+				} else {
+					true
+				};
+				if should_default {
 					field.attrs.push(syn::parse_quote!(#[builder(default)]));
 				}
 			}
@@ -76,12 +84,39 @@ fn has_derive_default(attrs: &[syn::Attribute]) -> bool {
 	})
 }
 
-fn replace_derive_default_with_bon_builder(attrs: &mut [syn::Attribute]) {
-	for a in attrs.iter_mut() {
+fn replace_derive_default_with_bon_builder(attrs: &mut Vec<syn::Attribute>) {
+	// Collect all derives from all #[derive(...)] attributes first,
+	// so multiple derive attributes (e.g. #[derive(Clone)] #[derive(Default)])
+	// are merged into a single combined attribute.
+	let mut derives: Vec<syn::Path> = Vec::new();
+	for a in attrs.iter() {
 		if a.path().is_ident("derive") {
-			*a = syn::parse_quote!(#[derive(bon::Builder)]);
+			let _ = a.parse_nested_meta(|m| {
+				if !m.path.is_ident("Default") {
+					derives.push(m.path.clone());
+				}
+				Ok(())
+			});
 		}
 	}
+	if !derives.iter().any(|p| p.is_ident("bon::Builder")) {
+		derives.push(syn::parse_quote!(bon::Builder));
+	}
+
+	let mut new_attrs: Vec<syn::Attribute> = attrs
+		.iter()
+		.filter(|a| !a.path().is_ident("derive"))
+		.cloned()
+		.collect();
+
+	let insert_pos = attrs
+		.iter()
+		.position(|a| a.path().is_ident("derive"))
+		.unwrap_or(0)
+		.min(new_attrs.len());
+	new_attrs.insert(insert_pos, syn::parse_quote!(#[derive(#(#derives),*)]));
+
+	*attrs = new_attrs;
 }
 
 fn is_option_type(ty: &syn::Type) -> bool {

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/component_props.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/component_props.rs
@@ -99,7 +99,7 @@ fn replace_derive_default_with_bon_builder(attrs: &mut Vec<syn::Attribute>) {
 			});
 		}
 	}
-	if !derives.iter().any(|p| p.is_ident("bon::Builder")) {
+	if !derives.iter().any(is_bon_builder_path) {
 		derives.push(syn::parse_quote!(bon::Builder));
 	}
 
@@ -117,6 +117,12 @@ fn replace_derive_default_with_bon_builder(attrs: &mut Vec<syn::Attribute>) {
 	new_attrs.insert(insert_pos, syn::parse_quote!(#[derive(#(#derives),*)]));
 
 	*attrs = new_attrs;
+}
+
+fn is_bon_builder_path(p: &syn::Path) -> bool {
+	p.segments.len() == 2
+		&& p.segments[0].ident == "bon"
+		&& p.segments[1].ident == "Builder"
 }
 
 fn is_option_type(ty: &syn::Type) -> bool {

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/component_props.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/component_props.rs
@@ -1,0 +1,16 @@
+//! Rule §6.2: migrate `#[derive(Default)] struct *Props` to `#[derive(bon::Builder)]`
+//! (no-op stub; implemented in Task 6).
+
+use crate::migrate_v2::rewriter::FileRewriter;
+
+/// Placeholder rule — replaced by the real implementation in Task 6.
+pub struct Rule;
+
+impl FileRewriter for Rule {
+	fn rewrite(&self, file: syn::File) -> syn::File {
+		file
+	}
+	fn name(&self) -> &'static str {
+		"component_props"
+	}
+}

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/component_props.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/component_props.rs
@@ -52,9 +52,7 @@ impl VisitMut for StructVisitor {
 				let is_option = is_option_type(&field.ty);
 				let is_first = idx == 0;
 				if !is_first || is_option {
-					field
-						.attrs
-						.push(syn::parse_quote!(#[builder(default)]));
+					field.attrs.push(syn::parse_quote!(#[builder(default)]));
 				}
 			}
 		}
@@ -78,7 +76,7 @@ fn has_derive_default(attrs: &[syn::Attribute]) -> bool {
 	})
 }
 
-fn replace_derive_default_with_bon_builder(attrs: &mut Vec<syn::Attribute>) {
+fn replace_derive_default_with_bon_builder(attrs: &mut [syn::Attribute]) {
 	for a in attrs.iter_mut() {
 		if a.path().is_ident("derive") {
 			*a = syn::parse_quote!(#[derive(bon::Builder)]);

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/component_props.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/component_props.rs
@@ -1,16 +1,96 @@
-//! Rule §6.2: migrate `#[derive(Default)] struct *Props` to `#[derive(bon::Builder)]`
-//! (no-op stub; implemented in Task 6).
+//! Rule §6.2: migrate `#[derive(Default)] struct *Props` to
+//! `#[derive(bon::Builder)]` with `#[builder(default)]` on optional fields.
+//!
+//! Heuristics (matches the spec §6.2 "Mechanical" strategy):
+//!
+//! - Target: structs whose ident ends in `Props` and carry
+//!   `#[derive(Default)]`.
+//! - For each field whose type is `Option<...>`, attach
+//!   `#[builder(default)]` — these are always optional.
+//! - The first non-`Option` field stays required (no `#[builder(default)]`)
+//!   so `Card { item: x }` keeps working out of the box. Every other
+//!   non-`Option` field gets `#[builder(default)]`. The developer can
+//!   promote any of those back to required by deleting the attribute
+//!   during review.
+
+use syn::visit_mut::{self, VisitMut};
 
 use crate::migrate_v2::rewriter::FileRewriter;
 
-/// Placeholder rule — replaced by the real implementation in Task 6.
+/// `component_props` rule entry.
 pub struct Rule;
 
 impl FileRewriter for Rule {
-	fn rewrite(&self, file: syn::File) -> syn::File {
-		file
-	}
 	fn name(&self) -> &'static str {
 		"component_props"
 	}
+
+	fn rewrite(&self, mut file: syn::File) -> syn::File {
+		StructVisitor.visit_file_mut(&mut file);
+		file
+	}
+}
+
+struct StructVisitor;
+
+impl VisitMut for StructVisitor {
+	fn visit_item_struct_mut(&mut self, s: &mut syn::ItemStruct) {
+		let is_props = s.ident.to_string().ends_with("Props");
+		if !is_props {
+			visit_mut::visit_item_struct_mut(self, s);
+			return;
+		}
+		if !has_derive_default(&s.attrs) {
+			visit_mut::visit_item_struct_mut(self, s);
+			return;
+		}
+
+		replace_derive_default_with_bon_builder(&mut s.attrs);
+
+		if let syn::Fields::Named(fields) = &mut s.fields {
+			for (idx, field) in fields.named.iter_mut().enumerate() {
+				let is_option = is_option_type(&field.ty);
+				let is_first = idx == 0;
+				if !is_first || is_option {
+					field
+						.attrs
+						.push(syn::parse_quote!(#[builder(default)]));
+				}
+			}
+		}
+
+		visit_mut::visit_item_struct_mut(self, s);
+	}
+}
+
+fn has_derive_default(attrs: &[syn::Attribute]) -> bool {
+	attrs.iter().any(|a| {
+		a.path().is_ident("derive") && {
+			let mut found = false;
+			let _ = a.parse_nested_meta(|m| {
+				if m.path.is_ident("Default") {
+					found = true;
+				}
+				Ok(())
+			});
+			found
+		}
+	})
+}
+
+fn replace_derive_default_with_bon_builder(attrs: &mut Vec<syn::Attribute>) {
+	for a in attrs.iter_mut() {
+		if a.path().is_ident("derive") {
+			*a = syn::parse_quote!(#[derive(bon::Builder)]);
+		}
+	}
+}
+
+fn is_option_type(ty: &syn::Type) -> bool {
+	if let syn::Type::Path(p) = ty
+		&& let Some(seg) = p.path.segments.last()
+	{
+		return seg.ident == "Option";
+	}
+	false
 }

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/use_effect_deps.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/use_effect_deps.rs
@@ -1,16 +1,56 @@
-//! Rule §6.1 (4): inject explicit deps placeholder for `use_effect`-family hooks
-//! (no-op stub; implemented in Task 5).
+//! Rule §6.1 (4): `use_effect(closure)` →
+//! `use_effect(closure, compile_error!("add deps"))`.
+//!
+//! Per spec footnote, (4) is semi-automatic: the rule inserts a
+//! `compile_error!` placeholder as the new deps argument so the human
+//! must consciously add the dependency tuple. Auto-inferring deps would
+//! lock in subtle bugs (forgotten closures, accidental captures).
+
+use syn::visit_mut::{self, VisitMut};
 
 use crate::migrate_v2::rewriter::FileRewriter;
 
-/// Placeholder rule — replaced by the real implementation in Task 5.
+/// `use_effect_deps` rule entry.
 pub struct Rule;
 
 impl FileRewriter for Rule {
-	fn rewrite(&self, file: syn::File) -> syn::File {
-		file
-	}
 	fn name(&self) -> &'static str {
 		"use_effect_deps"
+	}
+
+	fn rewrite(&self, mut file: syn::File) -> syn::File {
+		HookVisitor.visit_file_mut(&mut file);
+		file
+	}
+}
+
+struct HookVisitor;
+
+/// Hooks whose v2 signature requires an explicit deps tuple as the final arg.
+const HOOKS_REQUIRING_DEPS: &[&str] = &[
+	"use_effect",
+	"use_layout_effect",
+	"use_memo",
+	"use_callback",
+	"use_callback_with",
+];
+
+impl VisitMut for HookVisitor {
+	fn visit_expr_call_mut(&mut self, c: &mut syn::ExprCall) {
+		// Match the bare path of the call.
+		if let syn::Expr::Path(p) = &*c.func
+			&& let Some(seg) = p.path.segments.last()
+		{
+			let name = seg.ident.to_string();
+			if HOOKS_REQUIRING_DEPS.contains(&name.as_str()) && c.args.len() == 1 {
+				let placeholder: syn::Expr = syn::parse_quote! {
+					compile_error!(
+						"manouche-v2 codemod: add explicit deps tuple here, e.g. `(count.clone(),)`"
+					)
+				};
+				c.args.push(placeholder);
+			}
+		}
+		visit_mut::visit_expr_call_mut(self, c);
 	}
 }

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/use_effect_deps.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/use_effect_deps.rs
@@ -1,0 +1,16 @@
+//! Rule §6.1 (4): inject explicit deps placeholder for `use_effect`-family hooks
+//! (no-op stub; implemented in Task 5).
+
+use crate::migrate_v2::rewriter::FileRewriter;
+
+/// Placeholder rule — replaced by the real implementation in Task 5.
+pub struct Rule;
+
+impl FileRewriter for Rule {
+	fn rewrite(&self, file: syn::File) -> syn::File {
+		file
+	}
+	fn name(&self) -> &'static str {
+		"use_effect_deps"
+	}
+}

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/watch_unwrap.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/watch_unwrap.rs
@@ -61,22 +61,23 @@ fn unwrap_watch(input: TokenStream) -> TokenStream {
 				out.push(tt);
 			}
 			// `#reactive` (Punct '#' then Ident "reactive") followed by a brace.
+			// Use a cloned lookahead iterator to avoid consuming the `reactive`
+			// token before confirming the brace.
 			TokenTree::Punct(p) if p.as_char() == '#' => {
-				let next = iter.peek().cloned();
-				if let Some(TokenTree::Ident(id2)) = next
-					&& id2 == "reactive"
-				{
+				let mut lookahead = iter.clone();
+				let reactive_with_brace = matches!(
+					(lookahead.next(), lookahead.next()),
+					(Some(TokenTree::Ident(id2)), Some(TokenTree::Group(g)))
+						if id2 == "reactive" && g.delimiter() == Delimiter::Brace
+				);
+				if reactive_with_brace {
 					let _ = iter.next(); // consume "reactive"
-					if let Some(TokenTree::Group(g)) = iter.peek()
-						&& g.delimiter() == Delimiter::Brace
-					{
-						let body = match iter.next() {
-							Some(TokenTree::Group(g)) => g.stream(),
-							_ => unreachable!("peek matched but next did not"),
-						};
-						out.extend(unwrap_watch(body));
-						continue;
-					}
+					let body = match iter.next() {
+						Some(TokenTree::Group(g)) => g.stream(),
+						_ => unreachable!("lookahead matched but next did not"),
+					};
+					out.extend(unwrap_watch(body));
+					continue;
 				}
 				out.push(tt);
 			}

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/watch_unwrap.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/watch_unwrap.rs
@@ -1,0 +1,16 @@
+//! Rule §6.1 (2)+(3): `watch { body }` and `#reactive { body }` unwrap
+//! (no-op stub; implemented in Task 4).
+
+use crate::migrate_v2::rewriter::FileRewriter;
+
+/// Placeholder rule — replaced by the real implementation in Task 4.
+pub struct Rule;
+
+impl FileRewriter for Rule {
+	fn rewrite(&self, file: syn::File) -> syn::File {
+		file
+	}
+	fn name(&self) -> &'static str {
+		"watch_unwrap"
+	}
+}

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/watch_unwrap.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/watch_unwrap.rs
@@ -28,8 +28,7 @@ struct PageMacroBodyVisitor;
 
 impl VisitMut for PageMacroBodyVisitor {
 	fn visit_macro_mut(&mut self, m: &mut syn::Macro) {
-		if m
-			.path
+		if m.path
 			.segments
 			.last()
 			.map(|s| s.ident == "page")

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/watch_unwrap.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/watch_unwrap.rs
@@ -1,16 +1,94 @@
-//! Rule §6.1 (2)+(3): `watch { body }` and `#reactive { body }` unwrap
-//! (no-op stub; implemented in Task 4).
+//! Rule §6.1 (2)+(3): `watch { body }` and `#reactive { body }` →
+//! splice `body` in place, dropping the wrapper.
+//!
+//! `#reactive` was an early-design wrapper that never reached `main`, but
+//! the rule keeps a defensive arm so any in-flight branch picking up the
+//! codemod still gets a clean result.
+
+use proc_macro2::{Delimiter, Group, TokenStream, TokenTree};
+use syn::visit_mut::{self, VisitMut};
 
 use crate::migrate_v2::rewriter::FileRewriter;
 
-/// Placeholder rule — replaced by the real implementation in Task 4.
+/// `watch_unwrap` rule entry.
 pub struct Rule;
 
 impl FileRewriter for Rule {
-	fn rewrite(&self, file: syn::File) -> syn::File {
-		file
-	}
 	fn name(&self) -> &'static str {
 		"watch_unwrap"
 	}
+
+	fn rewrite(&self, mut file: syn::File) -> syn::File {
+		PageMacroBodyVisitor.visit_file_mut(&mut file);
+		file
+	}
+}
+
+struct PageMacroBodyVisitor;
+
+impl VisitMut for PageMacroBodyVisitor {
+	fn visit_macro_mut(&mut self, m: &mut syn::Macro) {
+		if m
+			.path
+			.segments
+			.last()
+			.map(|s| s.ident == "page")
+			.unwrap_or(false)
+		{
+			m.tokens = unwrap_watch(m.tokens.clone());
+		}
+		visit_mut::visit_macro_mut(self, m);
+	}
+}
+
+fn unwrap_watch(input: TokenStream) -> TokenStream {
+	let mut out: Vec<TokenTree> = Vec::new();
+	let mut iter = input.into_iter().peekable();
+
+	while let Some(tt) = iter.next() {
+		match &tt {
+			// `watch` followed by a brace group → splice body.
+			TokenTree::Ident(id) if id == "watch" => {
+				if let Some(TokenTree::Group(g)) = iter.peek()
+					&& g.delimiter() == Delimiter::Brace
+				{
+					let body = match iter.next() {
+						Some(TokenTree::Group(g)) => g.stream(),
+						_ => unreachable!("peek matched but next did not"),
+					};
+					out.extend(unwrap_watch(body));
+					continue;
+				}
+				out.push(tt);
+			}
+			// `#reactive` (Punct '#' then Ident "reactive") followed by a brace.
+			TokenTree::Punct(p) if p.as_char() == '#' => {
+				let next = iter.peek().cloned();
+				if let Some(TokenTree::Ident(id2)) = next
+					&& id2 == "reactive"
+				{
+					let _ = iter.next(); // consume "reactive"
+					if let Some(TokenTree::Group(g)) = iter.peek()
+						&& g.delimiter() == Delimiter::Brace
+					{
+						let body = match iter.next() {
+							Some(TokenTree::Group(g)) => g.stream(),
+							_ => unreachable!("peek matched but next did not"),
+						};
+						out.extend(unwrap_watch(body));
+						continue;
+					}
+				}
+				out.push(tt);
+			}
+			// Recurse into any other brace group.
+			TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => {
+				let inner = unwrap_watch(g.stream());
+				out.push(TokenTree::Group(Group::new(Delimiter::Brace, inner)));
+			}
+			_ => out.push(tt),
+		}
+	}
+
+	out.into_iter().collect()
 }

--- a/crates/reinhardt-admin-cli/src/migrate_v2/walker.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/walker.rs
@@ -5,11 +5,14 @@ use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 /// Returns every `*.rs` file under `root`, skipping `target/` and hidden dirs.
+///
+/// The `root` itself is never skipped even if its file_name starts with `.`
+/// (e.g. macOS `tempdir()` returns paths under `/var/folders/.../T/.tmpXXX`).
 pub fn find_rs_files(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
 	let mut out = Vec::new();
 	for entry in WalkDir::new(root)
 		.into_iter()
-		.filter_entry(|e| !is_skipped(e.path()))
+		.filter_entry(|e| !is_skipped_descendant(root, e.path()))
 	{
 		let entry = entry?;
 		if entry.file_type().is_file()
@@ -21,9 +24,13 @@ pub fn find_rs_files(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
 	Ok(out)
 }
 
-fn is_skipped(p: &Path) -> bool {
+fn is_skipped_descendant(root: &Path, p: &Path) -> bool {
+	// Never skip the anchor itself.
+	if p == root {
+		return false;
+	}
 	let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
 	// Skip the cargo target directory and any hidden directory (e.g. `.git`),
-	// but not the path component itself ("." / "..") used to anchor the walk.
-	name == "target" || (name.starts_with('.') && name != "." && name != "..")
+	// but only when encountered as a descendant of `root`.
+	name == "target" || name.starts_with('.')
 }

--- a/crates/reinhardt-admin-cli/src/migrate_v2/walker.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/walker.rs
@@ -1,0 +1,3 @@
+//! Directory walker for the migrate-manouche-v2 codemod.
+//!
+//! Implemented in Task 2.

--- a/crates/reinhardt-admin-cli/src/migrate_v2/walker.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/walker.rs
@@ -1,3 +1,29 @@
 //! Directory walker for the migrate-manouche-v2 codemod.
-//!
-//! Implemented in Task 2.
+
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+/// Returns every `*.rs` file under `root`, skipping `target/` and hidden dirs.
+pub fn find_rs_files(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
+	let mut out = Vec::new();
+	for entry in WalkDir::new(root)
+		.into_iter()
+		.filter_entry(|e| !is_skipped(e.path()))
+	{
+		let entry = entry?;
+		if entry.file_type().is_file()
+			&& entry.path().extension().map(|e| e == "rs").unwrap_or(false)
+		{
+			out.push(entry.into_path());
+		}
+	}
+	Ok(out)
+}
+
+fn is_skipped(p: &Path) -> bool {
+	let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
+	// Skip the cargo target directory and any hidden directory (e.g. `.git`),
+	// but not the path component itself ("." / "..") used to anchor the walk.
+	name == "target" || (name.starts_with('.') && name != "." && name != "..")
+}

--- a/crates/reinhardt-admin-cli/src/migrate_v2/walker.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/walker.rs
@@ -21,6 +21,7 @@ pub fn find_rs_files(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
 			out.push(entry.into_path());
 		}
 	}
+	out.sort();
 	Ok(out)
 }
 
@@ -32,5 +33,11 @@ fn is_skipped_descendant(root: &Path, p: &Path) -> bool {
 	let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
 	// Skip the cargo target directory and any hidden directory (e.g. `.git`),
 	// but only when encountered as a descendant of `root`.
-	name == "target" || name.starts_with('.')
+	// Files in hidden directories are not skipped because `filter_entry`
+	// already prevents descent into them — we only need to filter
+	// hidden directories themselves.
+	if name == "target" {
+		return true;
+	}
+	p.is_dir() && name.starts_with('.')
 }

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/bare_ident/expected.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/bare_ident/expected.rs
@@ -1,0 +1,6 @@
+use reinhardt_pages::page;
+fn render(name: String) {
+    let _ = page!(
+        | name : String | { div { class : "greeting", h1 { { name } } p { { name } } } }
+    )(name);
+}

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/bare_ident/input.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/bare_ident/input.rs
@@ -1,0 +1,11 @@
+use reinhardt_pages::page;
+
+fn render(name: String) {
+	let _ = page!(|name: String| {
+		div {
+			class: "greeting",
+			h1 { name }
+			p { name }
+		}
+	})(name);
+}

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/component_props/expected.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/component_props/expected.rs
@@ -1,0 +1,10 @@
+#[derive(bon::Builder)]
+struct CardProps {
+    item: Item,
+    #[builder(default)]
+    variant: Variant,
+    #[builder(default)]
+    children: Option<reinhardt_pages::component::Page>,
+}
+struct Item;
+struct Variant;

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/component_props/input.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/component_props/input.rs
@@ -1,0 +1,9 @@
+#[derive(Default)]
+struct CardProps {
+	item: Item,
+	variant: Variant,
+	children: Option<reinhardt_pages::component::Page>,
+}
+
+struct Item;
+struct Variant;

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/use_effect_deps/expected.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/use_effect_deps/expected.rs
@@ -1,0 +1,15 @@
+use reinhardt_pages::reactive::hooks::use_effect;
+use reinhardt_pages::reactive::Signal;
+fn r(count: Signal<i32>) {
+    let _ = use_effect(
+        {
+            let count = count.clone();
+            move || {
+                let _ = count.get();
+            }
+        },
+        compile_error!(
+            "manouche-v2 codemod: add explicit deps tuple here, e.g. `(count.clone(),)`"
+        ),
+    );
+}

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/use_effect_deps/input.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/use_effect_deps/input.rs
@@ -1,0 +1,11 @@
+use reinhardt_pages::reactive::hooks::use_effect;
+use reinhardt_pages::reactive::Signal;
+
+fn r(count: Signal<i32>) {
+	let _ = use_effect({
+		let count = count.clone();
+		move || {
+			let _ = count.get();
+		}
+	});
+}

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/watch_unwrap/expected.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/watch_unwrap/expected.rs
@@ -1,0 +1,8 @@
+use reinhardt_pages::page;
+use reinhardt_pages::reactive::Signal;
+fn r(count: Signal<i32>) {
+    let _ = page!(
+        | count : Signal < i32 >| { div { if count.get() > 0 { p { "positive" } } else {
+        p { "non-positive" } } } }
+    )(count);
+}

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/watch_unwrap/input.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/watch_unwrap/input.rs
@@ -1,0 +1,16 @@
+use reinhardt_pages::page;
+use reinhardt_pages::reactive::Signal;
+
+fn r(count: Signal<i32>) {
+	let _ = page!(|count: Signal<i32>| {
+		div {
+			watch {
+				if count.get() > 0 {
+					p { "positive" }
+				} else {
+					p { "non-positive" }
+				}
+			}
+		}
+	})(count);
+}

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_snapshot.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_snapshot.rs
@@ -44,3 +44,28 @@ fn rule_matches_expected_fixture(#[case] rule_name: &str) {
 		"{rule_name} did not produce expected output"
 	);
 }
+
+#[rstest]
+#[case::bare_ident("bare_ident")]
+#[case::watch_unwrap("watch_unwrap")]
+#[case::use_effect_deps("use_effect_deps")]
+#[case::component_props("component_props")]
+fn rule_is_idempotent(#[case] rule_name: &str) {
+	// Arrange
+	let expected = std::fs::read_to_string(fixture_path(rule_name, "expected.rs")).unwrap();
+	let all_rules = rules::all();
+	let rule = all_rules
+		.iter()
+		.find(|r| r.name() == rule_name)
+		.unwrap_or_else(|| panic!("rule `{rule_name}` not registered"));
+
+	// Act — apply the rule to its own output.
+	let twice = apply(&**rule, &expected);
+
+	// Assert
+	assert_eq!(
+		twice.trim(),
+		expected.trim(),
+		"{rule_name} is not idempotent: re-running changed the output"
+	);
+}

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_snapshot.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_snapshot.rs
@@ -23,6 +23,7 @@ fn fixture_path(rule: &str, name: &str) -> PathBuf {
 #[case::bare_ident("bare_ident")]
 #[case::watch_unwrap("watch_unwrap")]
 #[case::use_effect_deps("use_effect_deps")]
+#[case::component_props("component_props")]
 fn rule_matches_expected_fixture(#[case] rule_name: &str) {
 	// Arrange
 	let input = std::fs::read_to_string(fixture_path(rule_name, "input.rs")).unwrap();

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_snapshot.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_snapshot.rs
@@ -1,0 +1,43 @@
+//! Golden-file snapshot tests for the migrate-manouche-v2 rules.
+
+use rstest::rstest;
+use std::path::PathBuf;
+
+use reinhardt_admin_cli::migrate_v2::rewriter::FileRewriter;
+use reinhardt_admin_cli::migrate_v2::rules;
+
+fn apply(rule: &dyn FileRewriter, src: &str) -> String {
+	let ast: syn::File = syn::parse_str(src).unwrap();
+	let out_ast = rule.rewrite(ast);
+	prettyplease::unparse(&out_ast)
+}
+
+fn fixture_path(rule: &str, name: &str) -> PathBuf {
+	PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+		.join("tests/fixtures/migrate_v2")
+		.join(rule)
+		.join(name)
+}
+
+#[rstest]
+#[case::bare_ident("bare_ident")]
+fn rule_matches_expected_fixture(#[case] rule_name: &str) {
+	// Arrange
+	let input = std::fs::read_to_string(fixture_path(rule_name, "input.rs")).unwrap();
+	let expected = std::fs::read_to_string(fixture_path(rule_name, "expected.rs")).unwrap();
+	let all_rules = rules::all();
+	let rule = all_rules
+		.iter()
+		.find(|r| r.name() == rule_name)
+		.unwrap_or_else(|| panic!("rule `{rule_name}` not registered"));
+
+	// Act
+	let actual = apply(&**rule, &input);
+
+	// Assert
+	assert_eq!(
+		actual.trim(),
+		expected.trim(),
+		"{rule_name} did not produce expected output"
+	);
+}

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_snapshot.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_snapshot.rs
@@ -22,6 +22,7 @@ fn fixture_path(rule: &str, name: &str) -> PathBuf {
 #[rstest]
 #[case::bare_ident("bare_ident")]
 #[case::watch_unwrap("watch_unwrap")]
+#[case::use_effect_deps("use_effect_deps")]
 fn rule_matches_expected_fixture(#[case] rule_name: &str) {
 	// Arrange
 	let input = std::fs::read_to_string(fixture_path(rule_name, "input.rs")).unwrap();

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_snapshot.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_snapshot.rs
@@ -21,6 +21,7 @@ fn fixture_path(rule: &str, name: &str) -> PathBuf {
 
 #[rstest]
 #[case::bare_ident("bare_ident")]
+#[case::watch_unwrap("watch_unwrap")]
 fn rule_matches_expected_fixture(#[case] rule_name: &str) {
 	// Arrange
 	let input = std::fs::read_to_string(fixture_path(rule_name, "input.rs")).unwrap();

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_walker.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_walker.rs
@@ -15,8 +15,7 @@ fn walker_finds_rs_files_recursively_and_skips_target() {
 	fs::write(dir.path().join("target/c.rs"), "fn c() {}").unwrap();
 
 	// Act
-	let mut files =
-		reinhardt_admin_cli::migrate_v2::walker::find_rs_files(dir.path()).unwrap();
+	let mut files = reinhardt_admin_cli::migrate_v2::walker::find_rs_files(dir.path()).unwrap();
 	files.sort();
 
 	// Assert

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_walker.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_walker.rs
@@ -1,0 +1,26 @@
+//! Tests for the codemod's directory walker.
+
+use rstest::rstest;
+use std::fs;
+use tempfile::tempdir;
+
+#[rstest]
+fn walker_finds_rs_files_recursively_and_skips_target() {
+	// Arrange
+	let dir = tempdir().unwrap();
+	fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
+	fs::create_dir_all(dir.path().join("nested")).unwrap();
+	fs::write(dir.path().join("nested/b.rs"), "fn b() {}").unwrap();
+	fs::create_dir_all(dir.path().join("target")).unwrap();
+	fs::write(dir.path().join("target/c.rs"), "fn c() {}").unwrap();
+
+	// Act
+	let mut files =
+		reinhardt_admin_cli::migrate_v2::walker::find_rs_files(dir.path()).unwrap();
+	files.sort();
+
+	// Assert
+	assert_eq!(files.len(), 2);
+	assert!(files[0].ends_with("a.rs"));
+	assert!(files[1].ends_with("nested/b.rs"));
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds a one-shot, idempotent codemod (`reinhardt-admin migrate-manouche-v2 [PATH]`, surfaced as `cargo make migrate-manouche-v2`) that automates the four mechanical Manouche v1 → v2 migrations from spec §6.1 plus the P7 ComponentProps migration from spec §6.2.
- Introduces a new `reinhardt-admin-cli` library target so the codemod's rule pipeline can be invoked from integration tests (the binary remains the only public entry point).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

- Manouche v2 (spec §6.1) replaces four v1 conveniences with explicit forms. Migrating every `examples/` and `dashboard/` file by hand would be error-prone; the codemod packages each migration as a `FileRewriter` rule that is independently testable, deterministic, and idempotent.
- Each rule was designed to be conservative: anything ambiguous is left for the developer to fix in a second pass. Rule (4) — `use_effect` deps — is intentionally semi-automatic: it inserts a `compile_error!` placeholder so the human must add the dependency tuple consciously (auto-inferring deps would lock in subtle bugs).

Fixes #

Related to: # — Refs #4524 #4527 #4528 #4195 #4668 (umbrella + dependent PRs in the Manouche v2 release train).

## How Was This Tested?

- `cargo nextest run -p reinhardt-admin-cli --test migrate_v2_walker --test migrate_v2_snapshot` — 9 tests across 2 binaries, all passing:
  - Walker: enumerates `*.rs`, skips `target/` and hidden directories (except the supplied anchor itself).
  - Snapshot: 4 rules × `expected.rs` fixtures via `prettyplease`.
  - Idempotency: 4 rules × re-applying to their own output is a fixed point.
- `cargo fmt -p reinhardt-admin-cli` (clean)
- `cargo clippy -p reinhardt-admin-cli --all-targets` — 0 errors, 0 new warnings from this PR (one pre-existing warning in `utils.rs`).
- Smoke test: `cargo run -p reinhardt-admin-cli -- migrate-manouche-v2 --help` and `--dry-run` against a fresh tempdir.

## Breaking Changes

None — this is purely additive: a new subcommand and a new lib target. The existing `fmt`, `fmt-all`, `startproject`, `startapp`, and `plugin` commands are unchanged.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable) — CHANGELOG `[Unreleased]` entry added.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable) — N/A
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #4524 (Manouche v2 umbrella)
- Refs #4527 (PR1)
- Refs #4528 (PR2)
- Refs #4195 (PR5)
- Refs #4668 (PR6)

> Note: full CI may stay red on this branch until PR1/PR2/PR5/PR6 land in the same release train, because the codemod's golden-file fixtures represent the **target** v2 syntax. The codemod's own logic operates on `TokenStream` so it is independent of the v2 compiler; the codemod tests included in this PR pass standalone.

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels
- [x] `rc-migration` - Migration tooling for the RC phase

---

**Additional Context:**

- Architecture: each rule (`bare_ident`, `watch_unwrap`, `use_effect_deps`, `component_props`) lives in its own module under `crates/reinhardt-admin-cli/src/migrate_v2/rules/` and implements the `FileRewriter` trait. The driver (`migrate_v2::run`) composes them in deterministic order, skips files that fail to parse (build scripts with `cfg`-gated items), and only writes when the rewritten output differs from the input.
- The `bare_ident` rule includes an idempotency guard (`is_already_wrapped_expression_slot`) that detects the v2 expression-slot shape (`{ {ident} }`) and skips re-wrapping. Without this, the rule would add a fresh brace pair on every invocation.
- `use_effect_deps` targets the full hook family (`use_effect`, `use_layout_effect`, `use_memo`, `use_callback`, `use_callback_with`) and only fires on the single-argument shape, so already-migrated calls (`use_effect(closure, (count.clone(),))`) are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `migrate-manouche-v2` CLI command to upgrade Manouche v1 codebases to v2. Includes four transformation rules with support for `--dry-run` preview mode and `--skip` option to selectively disable specific rules during migration.

* **Tests**
  * Added snapshot tests to validate transformation rule outputs and ensure idempotency across migration runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->