### PR TITLE
fix(ci): remove inputs references from mutation-test job-level if

### DIFF
--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -41,7 +41,7 @@ jobs:
   mutation-test:
     name: "Shard ${{ matrix.shard }}/5"
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.shard == '0' || github.event.inputs.shard == matrix.shard))
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 360
     strategy:
       fail-fast: false
@@ -71,11 +71,12 @@ jobs:
           tool: nextest
 
       - name: Run mutation testing
+        if: github.event_name == 'schedule' || inputs.shard == '0' || inputs.shard == matrix.shard
         continue-on-error: true
         run: cargo mutants --shard ${{ matrix.shard }}/${{ env.TOTAL_SHARDS }} --test-tool nextest --timeout-multiplier 2 --jobs 1 --output /tmp/mutants-shard-${{ matrix.shard }}
 
       - name: Summary
-        if: always()
+        if: (!cancelled()) && (github.event_name == 'schedule' || inputs.shard == '0' || inputs.shard == matrix.shard)
         run: |
           echo "## Mutation Testing Results - Shard ${{ matrix.shard }}/${{ env.TOTAL_SHARDS }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -93,7 +94,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        if: always()
+        if: (!cancelled()) && (github.event_name == 'schedule' || inputs.shard == '0' || inputs.shard == matrix.shard)
         uses: actions/upload-artifact@v4
         with:
           name: mutants-shard-${{ matrix.shard }}


### PR DESCRIPTION
## Summary

- Remove all `github.event.inputs` / `inputs` references from job-level `if` condition in mutation-test.yml
- Move shard filtering to step-level `if` on "Run mutation testing" step
- Apply same shard filter to Summary and Upload artifacts steps

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

GitHub Actions evaluates job-level `if` expressions during push event validation for ALL workflow files, even those without `push` triggers. References to `github.event.inputs.*` are undefined in push event contexts, causing phantom "workflow file issue" failures with 0 jobs.

Step-level `if` conditions are only evaluated when the job actually runs, where `inputs` context is guaranteed to be defined.

Fixes #3459

## How Was This Tested

- [x] Verified syntax with `actionlint`
- [ ] Will monitor CI after merge for phantom failures

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Labels to Apply

- `bug`
- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update improves internal continuous integration workflows for better test execution and artifact handling during automated testing processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4750?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->