### PR TITLE
feat(urls): ClientRouter::page with FromRequest integration (#4668 / P7)

### DIFF
--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `reinhardt_pages::router::request` submodule re-exports the
+  Manouche DSL v2 spec §4.3 `FromRequest` building blocks
+  (`FromRequest`, `RouteContext`, `ExtractError`, `PathParam<T>`,
+  `QueryParam<T>`) from `reinhardt_urls::routers::client_router::from_request`
+  so application code can write
+  `use reinhardt_pages::router::request::FromRequest;` matching the
+  spec's namespace. The legacy non-generic `PathParam` re-exported at
+  `reinhardt_pages::router::PathParam` (deprecated since `0.1.0-rc.27`)
+  is unrelated and remains in place during its deprecation cycle.
+  (Refs #4668)
+
 ## [0.1.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.1.0-rc.30...reinhardt-pages@v0.1.0) - 2026-05-22
 
 Initial stable release of `reinhardt-pages` as part of the

--- a/crates/reinhardt-pages/src/router.rs
+++ b/crates/reinhardt-pages/src/router.rs
@@ -69,6 +69,44 @@ mod navigate;
 mod params;
 mod pattern;
 
+/// Manouche DSL v2 spec §4.3 `FromRequest`-based page handlers.
+///
+/// Re-exports the building blocks for
+/// `ClientRouter::page<F, P>(pattern, handler)` where
+/// `P: FromRequest`. The canonical implementations live in
+/// `reinhardt_urls::routers::client_router::from_request` (because
+/// `ClientRouter` itself is defined there); they are re-exposed here
+/// so application code can write
+/// `use reinhardt_pages::router::request::FromRequest;` matching the
+/// spec's namespace.
+///
+/// # Example
+///
+/// ```ignore
+/// use reinhardt_pages::router::request::{
+///     ExtractError, FromRequest, PathParam, RouteContext,
+/// };
+/// use reinhardt_urls::routers::ClientRouter;
+///
+/// struct UserPageProps { id: PathParam<i32> }
+///
+/// impl FromRequest for UserPageProps {
+///     fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError> {
+///         Ok(Self { id: PathParam::extract(ctx, "id")? })
+///     }
+/// }
+/// ```
+///
+/// The legacy non-generic `PathParam` re-exported at
+/// `reinhardt_pages::router::PathParam` (deprecated since
+/// `0.1.0-rc.27`) is unrelated to the v2 `PathParam<T>` extractor in
+/// this submodule.
+pub mod request {
+	pub use reinhardt_urls::routers::client_router::from_request::{
+		ExtractError, FromRequest, PathParam, QueryParam, RouteContext,
+	};
+}
+
 pub use components::{Link, Redirect, RouterOutlet, guard, guard_or};
 #[allow(deprecated)] // (Refs #4234) Re-exporting deprecated symbols intentionally.
 pub use core::{NavigationSubscription, PathError, Route, RouteMatch, Router, RouterError};

--- a/crates/reinhardt-urls/CHANGELOG.md
+++ b/crates/reinhardt-urls/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ClientRouter::page<F, P>(pattern, handler)` and
+  `ClientRouter::named_page<F, P>(name, pattern, handler)` accepting any
+  handler `Fn(P) -> Page` where `P: FromRequest`. The same Props struct
+  can be used both as a Component prop bag (Manouche DSL v2 spec §4.3)
+  and as a page function — "every page is a component." Path / query
+  extraction errors surface as a `Page::Text` at the router boundary
+  rather than panicking. (Refs #4668)
+- `reinhardt_urls::routers::client_router::from_request` module
+  exposing `FromRequest`, `RouteContext`, `ExtractError`,
+  `PathParam<T>`, and `QueryParam<T>` — the manual building blocks for
+  `ClientRouter::page` handlers. `#[derive(FromRequest)]` and
+  `#[derive(PageProps)]` proc-macros are deferred to spec §10.
+- `ClientRouteMatch::query: Option<String>` — populated by `match_path`
+  after stripping an optional `?query` suffix from the path before
+  pattern matching. Required for `QueryParam<T>` to see the query under
+  real routing.
+- `ParamContext::with_query(...)` / `ParamContext::query()` /
+  `ParamContext::params()` — `render_current` threads the captured
+  query through to the `RouteHandler` trait. Backward-compatible:
+  existing `ParamContext::new(...)` keeps the previous signature and
+  defaults the new field to `None`.
+
 ## [0.1.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-urls@v0.1.0-rc.30...reinhardt-urls@v0.1.0) - 2026-05-22
 
 Initial stable release of `reinhardt-urls` as part of the reinhardt-web

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -94,6 +94,9 @@ tokio = { version = "1.41", features = ["full"] }
 bytes = { workspace = true }
 hyper = { workspace = true }
 reinhardt-testkit = { path = "../reinhardt-testkit" }
+# trybuild: UI tests for the `ClientRouter::page` API surface
+# (compile-pass / compile-fail for `FromRequest` bounds — Refs #4668 / P7).
+trybuild = { workspace = true }
 
 # WASM-only dev dependencies (used by tests/wasm/*).
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]

--- a/crates/reinhardt-urls/src/routers/client_router.rs
+++ b/crates/reinhardt-urls/src/routers/client_router.rs
@@ -73,6 +73,7 @@
 
 mod core;
 mod error;
+pub mod from_request;
 mod global;
 mod handler;
 // Issue #4217: `history` is exposed publicly so reinhardt-pages can
@@ -87,6 +88,10 @@ mod reverser;
 // Public re-exports
 pub use core::{ClientRoute, ClientRouteMatch, ClientRouter, NavigationSubscription};
 pub use error::{MergeError, PathError, RouterError};
+// Re-export the `FromRequest` building blocks at the
+// `client_router` module level so callers can write
+// `use reinhardt_urls::routers::client_router::{FromRequest, ...}`.
+pub use from_request::{ExtractError, FromRequest, PathParam, QueryParam, RouteContext};
 pub use global::{clear_client_reverser, get_client_reverser, register_client_reverser};
 pub use handler::RouteHandler;
 // Issue #4217: drop helper-function re-exports from this module's

--- a/crates/reinhardt-urls/src/routers/client_router/core.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/core.rs
@@ -1028,11 +1028,9 @@ impl ClientRouter {
 		let path = self.current_path.get();
 
 		if let Some(route_match) = self.match_path(&path) {
-			let ctx = ParamContext::new(
-				route_match.params.clone(),
-				route_match.param_values.clone(),
-			)
-			.with_query(route_match.query.clone());
+			let ctx =
+				ParamContext::new(route_match.params.clone(), route_match.param_values.clone())
+					.with_query(route_match.query.clone());
 
 			match route_match.route.handler.handle(&ctx) {
 				Ok(view) => view,

--- a/crates/reinhardt-urls/src/routers/client_router/core.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/core.rs
@@ -4,9 +4,10 @@
 //! The router uses `Page` type for all view rendering.
 
 use super::error::{MergeError, RouterError};
+use super::from_request::FromRequest;
 use super::handler::{
-	RouteHandler, no_params_handler, result_handler, single_path_handler, three_path_handler,
-	two_path_handler, with_params_handler,
+	RouteHandler, from_request_handler, no_params_handler, result_handler, single_path_handler,
+	three_path_handler, two_path_handler, with_params_handler,
 };
 #[cfg(wasm)]
 use super::history::setup_popstate_listener;
@@ -88,6 +89,16 @@ pub struct ClientRouteMatch {
 	/// This guarantees that tuple extraction works correctly by index,
 	/// matching the order of parameters in the URL pattern.
 	pub(crate) param_values: Vec<String>,
+	/// Raw query string (without the leading `?`), captured from the
+	/// path passed to [`ClientRouter::match_path`].
+	///
+	/// Populated by `match_path` so [`ClientRouter::page`] handlers can
+	/// surface query data via [`QueryParam<T>`]. `None` when the path
+	/// had no `?` segment.
+	///
+	/// [`ClientRouter::page`]: ClientRouter::page
+	/// [`QueryParam<T>`]: super::from_request::QueryParam
+	pub query: Option<String>,
 }
 
 /// A single route definition.
@@ -453,6 +464,92 @@ impl ClientRouter {
 		self
 	}
 
+	/// Adds a route whose handler receives a single Props struct
+	/// constructed via [`FromRequest`] (Manouche DSL v2 spec §4.3).
+	///
+	/// This is the canonical v2 route-handler shape: the same Props
+	/// struct can be used both as a Component (passed via the
+	/// `Component { ... }` invocation syntax) and as a page function
+	/// (registered here). Path / query extraction errors surface as a
+	/// `Page::Text` describing the failure rather than panicking.
+	///
+	/// The `#[derive(FromRequest)]` / `#[derive(PageProps)]` proc-macros
+	/// that automate the manual `impl FromRequest` boilerplate are
+	/// deferred to spec §10.
+	///
+	/// # Example
+	///
+	/// ```ignore
+	/// use reinhardt_urls::routers::ClientRouter;
+	/// use reinhardt_urls::routers::client_router::from_request::{
+	///     ExtractError, FromRequest, PathParam, RouteContext,
+	/// };
+	///
+	/// struct UserPageProps { id: PathParam<i32> }
+	///
+	/// impl FromRequest for UserPageProps {
+	///     fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError> {
+	///         Ok(Self { id: PathParam::extract(ctx, "id")? })
+	///     }
+	/// }
+	///
+	/// fn user_page(props: UserPageProps) -> reinhardt_core::types::page::Page {
+	///     reinhardt_core::types::page::Page::Text(
+	///         format!("user {}", props.id.into_inner()).into(),
+	///     )
+	/// }
+	///
+	/// let router = ClientRouter::new().page("/users/{id}/", user_page);
+	/// ```
+	///
+	/// # Panics
+	///
+	/// Panics if the pattern is invalid (exceeds length/segment limits
+	/// or invalid regex). Use [`ClientPathPattern::new`] directly for
+	/// fallible construction.
+	pub fn page<F, P>(mut self, pattern: &str, handler: F) -> Self
+	where
+		F: Fn(P) -> Page + Send + Sync + 'static,
+		P: FromRequest + Send + Sync + 'static,
+	{
+		self.routes.push(ClientRoute {
+			pattern: ClientPathPattern::new(pattern)
+				.unwrap_or_else(|e| panic!("Invalid route pattern '{}': {}", pattern, e)),
+			name: None,
+			handler: from_request_handler(handler, pattern.to_string()),
+			guard: None,
+		});
+		self
+	}
+
+	/// Adds a named route whose handler receives a single Props struct
+	/// constructed via [`FromRequest`] (Manouche DSL v2 spec §4.3).
+	///
+	/// Named-route variant of [`ClientRouter::page`]. Enables reverse
+	/// URL lookup via the registered name.
+	///
+	/// # Panics
+	///
+	/// Panics if the pattern is invalid (exceeds length/segment limits
+	/// or invalid regex). Use [`ClientPathPattern::new`] directly for
+	/// fallible construction.
+	pub fn named_page<F, P>(mut self, name: &str, pattern: &str, handler: F) -> Self
+	where
+		F: Fn(P) -> Page + Send + Sync + 'static,
+		P: FromRequest + Send + Sync + 'static,
+	{
+		let index = self.routes.len();
+		self.routes.push(ClientRoute {
+			pattern: ClientPathPattern::new(pattern)
+				.unwrap_or_else(|e| panic!("Invalid route pattern '{}': {}", pattern, e)),
+			name: Some(name.to_string()),
+			handler: from_request_handler(handler, pattern.to_string()),
+			guard: None,
+		});
+		self.named_routes.insert(name.to_string(), index);
+		self
+	}
+
 	/// Adds a named route with typed path parameters that returns a Result.
 	pub fn named_route_result<F, T, E>(mut self, name: &str, pattern: &str, handler: F) -> Self
 	where
@@ -655,13 +752,27 @@ impl ClientRouter {
 	}
 
 	/// Matches a path against registered routes.
+	///
+	/// Strips an optional `?query` suffix before matching and stores
+	/// the captured query (without the leading `?`) on
+	/// [`ClientRouteMatch::query`]. Patterns therefore match against
+	/// the path portion only; the query is delivered to handlers via
+	/// the match struct (used by [`ClientRouter::page`] /
+	/// [`QueryParam`]).
+	///
+	/// [`QueryParam`]: super::from_request::QueryParam
 	pub fn match_path(&self, path: &str) -> Option<ClientRouteMatch> {
+		let (path_only, query) = match path.split_once('?') {
+			Some((p, q)) => (p, Some(q.to_string())),
+			None => (path, None),
+		};
 		for route in &self.routes {
-			if let Some((params, param_values)) = route.pattern.matches(path) {
+			if let Some((params, param_values)) = route.pattern.matches(path_only) {
 				let route_match = ClientRouteMatch {
 					route: route.clone(),
 					params,
 					param_values,
+					query: query.clone(),
 				};
 
 				// Check guard if present
@@ -917,8 +1028,11 @@ impl ClientRouter {
 		let path = self.current_path.get();
 
 		if let Some(route_match) = self.match_path(&path) {
-			let ctx =
-				ParamContext::new(route_match.params.clone(), route_match.param_values.clone());
+			let ctx = ParamContext::new(
+				route_match.params.clone(),
+				route_match.param_values.clone(),
+			)
+			.with_query(route_match.query.clone());
 
 			match route_match.route.handler.handle(&ctx) {
 				Ok(view) => view,

--- a/crates/reinhardt-urls/src/routers/client_router/from_request.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/from_request.rs
@@ -234,23 +234,36 @@ fn parse_query(query: &str, key: &str) -> Option<String> {
 /// the `percent-encoding` crate if more robust handling becomes
 /// necessary.
 fn url_decode(s: &str) -> String {
-	let mut out = String::with_capacity(s.len());
-	let mut bytes = s.bytes();
-	while let Some(b) = bytes.next() {
-		match b {
-			b'+' => out.push(' '),
-			b'%' => {
-				let hi = bytes.next();
-				let lo = bytes.next();
-				if let (Some(h), Some(l)) = (hi, lo)
-					&& let (Some(h), Some(l)) = (hex_digit(h), hex_digit(l))
-				{
-					out.push((h * 16 + l) as char);
-					continue;
-				}
-				out.push('%');
+	let bytes = s.as_bytes();
+	let mut out = String::with_capacity(bytes.len());
+	let mut i = 0;
+	while i < bytes.len() {
+		match bytes[i] {
+			b'+' => {
+				out.push(' ');
+				i += 1;
 			}
-			_ => out.push(b as char),
+			b'%' if i + 2 < bytes.len() => {
+				if let (Some(h), Some(l)) = (hex_digit(bytes[i + 1]), hex_digit(bytes[i + 2])) {
+					out.push((h * 16 + l) as char);
+					i += 3;
+				} else {
+					// Invalid escape — emit the `%` and continue scanning
+					// from the next byte so trailing characters are
+					// preserved literally.
+					out.push('%');
+					i += 1;
+				}
+			}
+			b'%' => {
+				// Trailing `%` with fewer than 2 hex digits — emit literal.
+				out.push('%');
+				i += 1;
+			}
+			b => {
+				out.push(b as char);
+				i += 1;
+			}
 		}
 	}
 	out

--- a/crates/reinhardt-urls/src/routers/client_router/from_request.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/from_request.rs
@@ -18,7 +18,7 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```no_run
 //! use reinhardt_urls::routers::client_router::from_request::{
 //!     ExtractError, FromRequest, PathParam, RouteContext,
 //! };
@@ -253,38 +253,40 @@ fn parse_query(query: &str, key: &str) -> Option<String> {
 /// necessary.
 fn url_decode(s: &str) -> String {
 	let bytes = s.as_bytes();
-	let mut out = String::with_capacity(bytes.len());
+	let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
 	let mut i = 0;
 	while i < bytes.len() {
 		match bytes[i] {
 			b'+' => {
-				out.push(' ');
+				out.push(b' ');
 				i += 1;
 			}
 			b'%' if i + 2 < bytes.len() => {
 				if let (Some(h), Some(l)) = (hex_digit(bytes[i + 1]), hex_digit(bytes[i + 2])) {
-					out.push((h * 16 + l) as char);
+					out.push(h * 16 + l);
 					i += 3;
 				} else {
 					// Invalid escape — emit the `%` and continue scanning
 					// from the next byte so trailing characters are
 					// preserved literally.
-					out.push('%');
+					out.push(b'%');
 					i += 1;
 				}
 			}
 			b'%' => {
 				// Trailing `%` with fewer than 2 hex digits — emit literal.
-				out.push('%');
+				out.push(b'%');
 				i += 1;
 			}
 			b => {
-				out.push(b as char);
+				out.push(b);
 				i += 1;
 			}
 		}
 	}
-	out
+	String::from_utf8(out).unwrap_or_else(|e| {
+		String::from_utf8_lossy(&e.into_bytes()).into_owned()
+	})
 }
 
 fn hex_digit(b: u8) -> Option<u8> {

--- a/crates/reinhardt-urls/src/routers/client_router/from_request.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/from_request.rs
@@ -147,9 +147,18 @@ impl<T> PathParam<T> {
 	pub fn into_inner(self) -> T {
 		self.0
 	}
+}
 
-	/// Borrows the inner value.
-	pub fn as_ref(&self) -> &T {
+impl<T> AsRef<T> for PathParam<T> {
+	fn as_ref(&self) -> &T {
+		&self.0
+	}
+}
+
+impl<T> std::ops::Deref for PathParam<T> {
+	type Target = T;
+
+	fn deref(&self) -> &T {
 		&self.0
 	}
 }
@@ -187,9 +196,18 @@ impl<T> QueryParam<T> {
 	pub fn into_inner(self) -> T {
 		self.0
 	}
+}
 
-	/// Borrows the inner value.
-	pub fn as_ref(&self) -> &T {
+impl<T> AsRef<T> for QueryParam<T> {
+	fn as_ref(&self) -> &T {
+		&self.0
+	}
+}
+
+impl<T> std::ops::Deref for QueryParam<T> {
+	type Target = T;
+
+	fn deref(&self) -> &T {
 		&self.0
 	}
 }

--- a/crates/reinhardt-urls/src/routers/client_router/from_request.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/from_request.rs
@@ -1,0 +1,296 @@
+//! `FromRequest` integration for `ClientRouter::page` route handlers.
+//!
+//! Implements spec §4.3 of the Manouche DSL v2 design: a route page
+//! function takes a single Props struct that implements [`FromRequest`].
+//! The Props struct is constructed from a [`RouteContext`] (matched
+//! path + captured path params + raw query string), with extractor
+//! errors surfaced through [`ExtractError`].
+//!
+//! The same Props struct can also be used as a Component prop bag
+//! (spec §4.3 last paragraph: "every page is a component").
+//!
+//! # Manual vs. derived
+//!
+//! `FromRequest` is implemented manually in v2. The
+//! `#[derive(FromRequest)]` / `#[derive(PageProps)]` / `#[component]`
+//! proc-macros that automate this boilerplate are deferred to
+//! spec §10. See the tracking issue referenced from the PR.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reinhardt_urls::routers::client_router::from_request::{
+//!     ExtractError, FromRequest, PathParam, RouteContext,
+//! };
+//! use reinhardt_urls::routers::ClientRouter;
+//!
+//! struct UserPageProps {
+//!     id: PathParam<i32>,
+//! }
+//!
+//! impl FromRequest for UserPageProps {
+//!     fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError> {
+//!         Ok(Self {
+//!             id: PathParam::extract(ctx, "id")?,
+//!         })
+//!     }
+//! }
+//!
+//! fn user_page(props: UserPageProps) -> reinhardt_core::types::page::Page {
+//!     reinhardt_core::types::page::Page::Text(
+//!         format!("user {}", props.id.into_inner()).into(),
+//!     )
+//! }
+//!
+//! let _router = ClientRouter::new().page("/users/{id}/", user_page);
+//! ```
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// The data a route handler receives from the router.
+///
+/// Wraps the data already produced by the client-router's pattern
+/// matcher: the resolved path, the captured path parameters (by
+/// name), and the raw query string (the portion after `?`, without
+/// the leading `?`). Server-side rendering can construct the same
+/// context shape.
+#[derive(Debug, Clone)]
+pub struct RouteContext {
+	path: String,
+	path_params: HashMap<String, String>,
+	query: String,
+}
+
+impl RouteContext {
+	/// Creates a new `RouteContext`.
+	pub fn new(path: String, path_params: HashMap<String, String>, query: String) -> Self {
+		Self {
+			path,
+			path_params,
+			query,
+		}
+	}
+
+	/// Returns the matched path (without the query string).
+	pub fn path(&self) -> &str {
+		&self.path
+	}
+
+	/// Returns the raw query string (without the leading `?`).
+	pub fn query(&self) -> &str {
+		&self.query
+	}
+
+	/// Looks up a named path parameter.
+	///
+	/// Returns `None` when the parameter was not captured by the route
+	/// pattern. Returns an owned `String` so callers can decode /
+	/// parse without borrowing the context.
+	pub fn path_param(&self, name: &str) -> Option<String> {
+		self.path_params.get(name).cloned()
+	}
+
+	/// Borrows the full path-parameter map.
+	pub fn path_params(&self) -> &HashMap<String, String> {
+		&self.path_params
+	}
+}
+
+/// Errors surfaced when constructing a Props struct from a
+/// [`RouteContext`].
+///
+/// Returned by [`FromRequest::from_request`] and the
+/// `PathParam::extract` / `QueryParam::extract` helpers.
+#[derive(Debug, thiserror::Error)]
+pub enum ExtractError {
+	/// A required path parameter was not present in the match.
+	#[error("missing path parameter `{0}`")]
+	MissingPath(String),
+	/// A required query parameter was not present in the query string.
+	#[error("missing query parameter `{0}`")]
+	MissingQuery(String),
+	/// Parsing the raw string into the target type failed.
+	#[error("failed to parse `{name}`: {source}")]
+	Parse {
+		/// The parameter name (path or query) being parsed.
+		name: String,
+		/// The underlying parse error.
+		#[source]
+		source: Box<dyn std::error::Error + Send + Sync>,
+	},
+}
+
+/// Trait implemented by Props structs used as route page handlers.
+///
+/// `ClientRouter::page<F, P>(pattern, handler)` constructs `P` via
+/// `P::from_request(&ctx)` for every matched request, then calls
+/// `handler(props)`.
+pub trait FromRequest: Sized {
+	/// Construct `Self` from the request context.
+	///
+	/// # Errors
+	///
+	/// Returns [`ExtractError`] when a required parameter is missing
+	/// or fails to parse.
+	fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError>;
+}
+
+/// Extractor for a single named path parameter, parsed via [`FromStr`].
+///
+/// Construct with [`PathParam::extract`] inside a `FromRequest` impl.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PathParam<T>(T);
+
+impl<T> PathParam<T> {
+	/// Unwraps the inner value.
+	pub fn into_inner(self) -> T {
+		self.0
+	}
+
+	/// Borrows the inner value.
+	pub fn as_ref(&self) -> &T {
+		&self.0
+	}
+}
+
+impl<T: FromStr> PathParam<T>
+where
+	T::Err: std::error::Error + Send + Sync + 'static,
+{
+	/// Extracts the path parameter `name` from `ctx` and parses it as `T`.
+	///
+	/// # Errors
+	///
+	/// - [`ExtractError::MissingPath`] when `name` is not in the match
+	/// - [`ExtractError::Parse`] when `<T as FromStr>::from_str` fails
+	pub fn extract(ctx: &RouteContext, name: &str) -> Result<Self, ExtractError> {
+		let raw = ctx
+			.path_param(name)
+			.ok_or_else(|| ExtractError::MissingPath(name.to_string()))?;
+		let parsed = T::from_str(&raw).map_err(|e| ExtractError::Parse {
+			name: name.to_string(),
+			source: Box::new(e),
+		})?;
+		Ok(PathParam(parsed))
+	}
+}
+
+/// Extractor for a single named query parameter, parsed via [`FromStr`].
+///
+/// Construct with [`QueryParam::extract`] inside a `FromRequest` impl.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct QueryParam<T>(T);
+
+impl<T> QueryParam<T> {
+	/// Unwraps the inner value.
+	pub fn into_inner(self) -> T {
+		self.0
+	}
+
+	/// Borrows the inner value.
+	pub fn as_ref(&self) -> &T {
+		&self.0
+	}
+}
+
+impl<T: FromStr> QueryParam<T>
+where
+	T::Err: std::error::Error + Send + Sync + 'static,
+{
+	/// Extracts the query parameter `name` from `ctx` and parses it as `T`.
+	///
+	/// # Errors
+	///
+	/// - [`ExtractError::MissingQuery`] when `name` is not in the query string
+	/// - [`ExtractError::Parse`] when `<T as FromStr>::from_str` fails
+	pub fn extract(ctx: &RouteContext, name: &str) -> Result<Self, ExtractError> {
+		let raw = parse_query(ctx.query(), name)
+			.ok_or_else(|| ExtractError::MissingQuery(name.to_string()))?;
+		let parsed = T::from_str(&raw).map_err(|e| ExtractError::Parse {
+			name: name.to_string(),
+			source: Box::new(e),
+		})?;
+		Ok(QueryParam(parsed))
+	}
+}
+
+/// Minimal query-string parser: scans `k=v&k=v` pairs, returning
+/// the percent-decoded value for the first match.
+fn parse_query(query: &str, key: &str) -> Option<String> {
+	for pair in query.split('&').filter(|p| !p.is_empty()) {
+		let mut it = pair.splitn(2, '=');
+		let k = it.next()?;
+		let v = it.next().unwrap_or("");
+		if k == key {
+			return Some(url_decode(v));
+		}
+	}
+	None
+}
+
+/// Minimal percent-decoder + `+` → space. Sufficient for typical
+/// `application/x-www-form-urlencoded` query strings. Replace with
+/// the `percent-encoding` crate if more robust handling becomes
+/// necessary.
+fn url_decode(s: &str) -> String {
+	let mut out = String::with_capacity(s.len());
+	let mut bytes = s.bytes();
+	while let Some(b) = bytes.next() {
+		match b {
+			b'+' => out.push(' '),
+			b'%' => {
+				let hi = bytes.next();
+				let lo = bytes.next();
+				if let (Some(h), Some(l)) = (hi, lo)
+					&& let (Some(h), Some(l)) = (hex_digit(h), hex_digit(l))
+				{
+					out.push((h * 16 + l) as char);
+					continue;
+				}
+				out.push('%');
+			}
+			_ => out.push(b as char),
+		}
+	}
+	out
+}
+
+fn hex_digit(b: u8) -> Option<u8> {
+	match b {
+		b'0'..=b'9' => Some(b - b'0'),
+		b'a'..=b'f' => Some(b - b'a' + 10),
+		b'A'..=b'F' => Some(b - b'A' + 10),
+		_ => None,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_query_finds_first_match() {
+		assert_eq!(parse_query("a=1&b=2", "a"), Some("1".to_string()));
+		assert_eq!(parse_query("a=1&b=2", "b"), Some("2".to_string()));
+		assert_eq!(parse_query("a=1&b=2", "c"), None);
+	}
+
+	#[test]
+	fn parse_query_handles_empty_value() {
+		assert_eq!(parse_query("a=", "a"), Some("".to_string()));
+	}
+
+	#[test]
+	fn url_decode_handles_percent_encoding() {
+		assert_eq!(url_decode("hello%20world"), "hello world");
+		assert_eq!(url_decode("a+b"), "a b");
+		assert_eq!(url_decode("plain"), "plain");
+	}
+
+	#[test]
+	fn url_decode_passes_through_invalid_percent() {
+		// Stray % with non-hex following — keep the % literal.
+		assert_eq!(url_decode("a%ZZ"), "a%ZZ");
+	}
+}

--- a/crates/reinhardt-urls/src/routers/client_router/handler.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/handler.rs
@@ -5,6 +5,7 @@
 //! extraction in route definitions.
 
 use super::error::RouterError;
+use super::from_request::{FromRequest, RouteContext};
 use super::params::{FromPath, ParamContext, Path, SingleFromPath};
 use reinhardt_core::types::page::Page;
 use std::marker::PhantomData;
@@ -282,6 +283,74 @@ where
 	T3: SingleFromPath + Send + Sync + 'static,
 {
 	Arc::new(ThreePathHandler::new(handler))
+}
+
+// ============================================================================
+// FromRequest-based page handler (spec §4.3)
+// ============================================================================
+
+/// Handler for routes registered via [`ClientRouter::page`].
+///
+/// Wraps a `Fn(P) -> Page` closure where `P: FromRequest`. Constructs
+/// `P` from the matched path / query data via `P::from_request`, then
+/// invokes the closure. Extraction errors are surfaced as a
+/// `Page::Text` describing the failure so client-side navigation does
+/// not panic; a future iteration may route these through a dedicated
+/// error page.
+///
+/// [`ClientRouter::page`]: super::core::ClientRouter::page
+pub(crate) struct FromRequestHandler<F, P> {
+	handler: F,
+	pattern: String,
+	_phantom: PhantomData<P>,
+}
+
+impl<F, P> FromRequestHandler<F, P> {
+	pub(crate) fn new(handler: F, pattern: String) -> Self {
+		Self {
+			handler,
+			pattern,
+			_phantom: PhantomData,
+		}
+	}
+}
+
+// SAFETY: FromRequestHandler is Send + Sync when F is Send + Sync.
+// The PhantomData<P> is only used for type inference and does not
+// hold data — matching the established pattern in this file.
+unsafe impl<F: Send, P> Send for FromRequestHandler<F, P> {}
+unsafe impl<F: Sync, P> Sync for FromRequestHandler<F, P> {}
+
+impl<F, P> RouteHandler for FromRequestHandler<F, P>
+where
+	F: Fn(P) -> Page + Send + Sync,
+	P: FromRequest + Send + Sync,
+{
+	fn handle(&self, ctx: &ParamContext) -> Result<Page, RouterError> {
+		let route_ctx = RouteContext::new(
+			// The matched path is not directly available to RouteHandler;
+			// pass an empty placeholder. Handlers that need the path can
+			// read it from the router's `current_path` signal.
+			String::new(),
+			ctx.params().clone(),
+			ctx.query().unwrap_or("").to_string(),
+		);
+		match P::from_request(&route_ctx) {
+			Ok(props) => Ok((self.handler)(props)),
+			Err(e) => Ok(Page::Text(
+				format!("route extraction error on `{}`: {e}", self.pattern).into(),
+			)),
+		}
+	}
+}
+
+/// Helper function to create a `FromRequest`-based handler.
+pub(crate) fn from_request_handler<F, P>(handler: F, pattern: String) -> Arc<dyn RouteHandler>
+where
+	F: Fn(P) -> Page + Send + Sync + 'static,
+	P: FromRequest + Send + Sync + 'static,
+{
+	Arc::new(FromRequestHandler::new(handler, pattern))
 }
 
 #[cfg(test)]

--- a/crates/reinhardt-urls/src/routers/client_router/params.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/params.rs
@@ -15,13 +15,24 @@ use super::error::PathError;
 #[derive(Debug, Clone)]
 pub struct ParamContext {
 	/// Named parameters extracted from the path.
-	#[allow(dead_code)] // Reserved for future named parameter access
 	pub(crate) params: HashMap<String, String>,
 	/// Parameter values in the order they appear in the pattern.
 	///
 	/// This guarantees that tuple extraction works correctly by index,
 	/// matching the order of parameters in the URL pattern.
 	pub(crate) param_values: Vec<String>,
+	/// Raw query string (without the leading `?`), populated by
+	/// [`ClientRouter::render_current`] for routes registered via
+	/// [`ClientRouter::page`] so [`QueryParam<T>`] can extract values.
+	///
+	/// `None` for paths without a `?` segment or for routes registered
+	/// via the legacy `route` / `route_params` / `route_result` /
+	/// `route_path*` APIs (those handlers do not read the query).
+	///
+	/// [`ClientRouter::render_current`]: super::core::ClientRouter::render_current
+	/// [`ClientRouter::page`]: super::core::ClientRouter::page
+	/// [`QueryParam<T>`]: super::from_request::QueryParam
+	pub(crate) query: Option<String>,
 }
 
 impl ParamContext {
@@ -30,7 +41,33 @@ impl ParamContext {
 		Self {
 			params,
 			param_values,
+			query: None,
 		}
+	}
+
+	/// Creates a new parameter context with an attached query string.
+	///
+	/// Used by [`ClientRouter::render_current`] when dispatching a
+	/// [`ClientRouter::page`] handler so [`QueryParam<T>`] extractors
+	/// can see the captured query.
+	///
+	/// [`ClientRouter::render_current`]: super::core::ClientRouter::render_current
+	/// [`ClientRouter::page`]: super::core::ClientRouter::page
+	/// [`QueryParam<T>`]: super::from_request::QueryParam
+	pub fn with_query(mut self, query: Option<String>) -> Self {
+		self.query = query;
+		self
+	}
+
+	/// Returns the named-parameter map (path parameters captured by the
+	/// route pattern, keyed by their `{name}` placeholder).
+	pub fn params(&self) -> &HashMap<String, String> {
+		&self.params
+	}
+
+	/// Returns the raw query string (without the leading `?`), if any.
+	pub fn query(&self) -> Option<&str> {
+		self.query.as_deref()
 	}
 
 	/// Returns the number of parameters.

--- a/crates/reinhardt-urls/tests/clientrouter_page_integration_tests.rs
+++ b/crates/reinhardt-urls/tests/clientrouter_page_integration_tests.rs
@@ -101,11 +101,11 @@ fn page_method_surfaces_extract_error_as_page_text() {
 	let view = router_render(&router, "/users/abc/");
 
 	// Assert — the router surfaces the error as a Page::Text. The exact
-	// formatting is part of the public contract; assert the key tokens.
+	// formatting is part of the public contract.
 	let s = page_text(&view);
-	assert!(
-		s.contains("route extraction error") && s.contains("id"),
-		"expected an extraction-error page mentioning `id`, got: {s}"
+	assert_eq!(
+		s,
+		"route extraction error on `/users/{id}/`: failed to parse `id`: invalid digit found in string",
 	);
 }
 

--- a/crates/reinhardt-urls/tests/clientrouter_page_integration_tests.rs
+++ b/crates/reinhardt-urls/tests/clientrouter_page_integration_tests.rs
@@ -1,0 +1,149 @@
+//! Integration tests for `ClientRouter::page<F, P>(pattern, handler)`
+//! where `P: FromRequest`. Spec §4.3 / Refs #4668 / P7 part 2.
+
+use rstest::rstest;
+
+use reinhardt_core::types::page::Page;
+use reinhardt_urls::routers::ClientRouter;
+use reinhardt_urls::routers::client_router::from_request::{
+	ExtractError, FromRequest, PathParam, QueryParam, RouteContext,
+};
+
+// --- Test Props + handler used by every test case --------------------------
+
+#[derive(Debug)]
+struct UserPageProps {
+	id: PathParam<i32>,
+}
+
+impl FromRequest for UserPageProps {
+	fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError> {
+		Ok(Self {
+			id: PathParam::extract(ctx, "id")?,
+		})
+	}
+}
+
+fn user_page(props: UserPageProps) -> Page {
+	Page::Text(format!("user {}", props.id.into_inner()).into())
+}
+
+#[derive(Debug)]
+struct SearchPageProps {
+	q: QueryParam<String>,
+}
+
+impl FromRequest for SearchPageProps {
+	fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError> {
+		Ok(Self {
+			q: QueryParam::extract(ctx, "q")?,
+		})
+	}
+}
+
+fn search_page(props: SearchPageProps) -> Page {
+	Page::Text(format!("search: {}", props.q.into_inner()).into())
+}
+
+// --- Helpers ---------------------------------------------------------------
+
+/// Render the router for a path by driving the public `current_path` signal
+/// then invoking `render_current` — the same flow used by the existing
+/// `test_render_current_returns_page_without_not_found` test in
+/// `crates/reinhardt-urls/src/routers/client_router/core.rs`.
+fn router_render(router: &ClientRouter, path: &str) -> Page {
+	router.current_path().set(path.to_string());
+	router.render_current()
+}
+
+fn page_text(page: &Page) -> String {
+	match page {
+		Page::Text(t) => t.to_string(),
+		other => format!("{other:?}"),
+	}
+}
+
+// --- Tests -----------------------------------------------------------------
+
+#[rstest]
+fn page_method_registers_and_renders_with_path_param() {
+	// Arrange
+	let router = ClientRouter::new().page("/users/{id}/", user_page);
+
+	// Act
+	let view = router_render(&router, "/users/42/");
+
+	// Assert
+	let s = page_text(&view);
+	assert_eq!(s, "user 42", "expected `user 42`, got: {s}");
+}
+
+#[rstest]
+fn page_method_extracts_query_param() {
+	// Arrange
+	let router = ClientRouter::new().page("/search/", search_page);
+
+	// Act — drive with a query string. The router's `match_path` ignores
+	// the `?...` suffix; the extractor parses it from `RouteContext::query`.
+	let view = router_render(&router, "/search/?q=rust");
+
+	// Assert
+	let s = page_text(&view);
+	assert_eq!(s, "search: rust", "expected `search: rust`, got: {s}");
+}
+
+#[rstest]
+fn page_method_surfaces_extract_error_as_page_text() {
+	// Arrange — path matches but `id` cannot parse as i32
+	let router = ClientRouter::new().page("/users/{id}/", user_page);
+
+	// Act
+	let view = router_render(&router, "/users/abc/");
+
+	// Assert — the router surfaces the error as a Page::Text. The exact
+	// formatting is part of the public contract; assert the key tokens.
+	let s = page_text(&view);
+	assert!(
+		s.contains("route extraction error") && s.contains("id"),
+		"expected an extraction-error page mentioning `id`, got: {s}"
+	);
+}
+
+#[rstest]
+fn page_method_returns_not_found_for_unmatched_path() {
+	// Arrange
+	let router = ClientRouter::new().page("/users/{id}/", user_page);
+
+	// Act
+	let view = router_render(&router, "/nope/");
+
+	// Assert — no not_found registered → Page::Empty fallback
+	assert!(matches!(view, Page::Empty));
+}
+
+// --- Spec §4.3 last paragraph: "every page is a component" ----------------
+
+#[rstest]
+fn props_struct_can_be_constructed_directly_for_component_use() {
+	// Arrange — build the same RouteContext the router would produce
+	let mut params = std::collections::HashMap::new();
+	params.insert("id".to_string(), "7".to_string());
+	let ctx = RouteContext::new("/users/7/".to_string(), params, "".to_string());
+
+	// Act — construct Props via FromRequest, then call `user_page` as a
+	// plain function (i.e. as a component) and also via the registered
+	// route (i.e. as a page handler).
+	let props = UserPageProps::from_request(&ctx).expect("FromRequest must succeed");
+	let view_as_component = user_page(props);
+
+	let router = ClientRouter::new().page("/users/{id}/", user_page);
+	let view_as_page = router_render(&router, "/users/7/");
+
+	// Assert — both paths render identically. This is spec §4.3's
+	// "same Props struct = page function = component" invariant.
+	let a = page_text(&view_as_component);
+	let b = page_text(&view_as_page);
+	assert_eq!(a, "user 7");
+	assert_eq!(b, "user 7");
+	assert_eq!(a, b);
+}

--- a/crates/reinhardt-urls/tests/from_request_unit_tests.rs
+++ b/crates/reinhardt-urls/tests/from_request_unit_tests.rs
@@ -1,0 +1,176 @@
+//! Unit tests for `FromRequest`, `PathParam<T>`, `QueryParam<T>` extractors
+//! (spec §4.3 of Manouche DSL v2). Refs #4668 / P7 part 2.
+
+use rstest::rstest;
+use std::collections::HashMap;
+
+use reinhardt_urls::routers::client_router::from_request::{
+	ExtractError, FromRequest, PathParam, QueryParam, RouteContext,
+};
+
+#[derive(Debug)]
+struct StubProps {
+	id: String,
+}
+
+impl FromRequest for StubProps {
+	fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError> {
+		ctx.path_param("id")
+			.ok_or_else(|| ExtractError::MissingPath("id".to_string()))
+			.map(|id| StubProps { id })
+	}
+}
+
+#[rstest]
+fn from_request_reads_path_param() {
+	// Arrange
+	let mut params = HashMap::new();
+	params.insert("id".to_string(), "42".to_string());
+	let ctx = RouteContext::new("/users/42".to_string(), params, "".to_string());
+
+	// Act
+	let p = StubProps::from_request(&ctx).unwrap();
+
+	// Assert
+	assert_eq!(p.id, "42");
+}
+
+#[rstest]
+fn from_request_returns_extract_error_when_missing() {
+	// Arrange
+	let ctx = RouteContext::new("/users/".to_string(), HashMap::new(), "".to_string());
+
+	// Act
+	let err = StubProps::from_request(&ctx).unwrap_err();
+
+	// Assert
+	assert!(matches!(err, ExtractError::MissingPath(s) if s == "id"));
+}
+
+#[rstest]
+fn path_param_extracts_and_parses_i32() {
+	// Arrange
+	let mut params = HashMap::new();
+	params.insert("id".to_string(), "42".to_string());
+	let ctx = RouteContext::new("/users/42".to_string(), params, "".to_string());
+
+	// Act
+	let p: PathParam<i32> = PathParam::extract(&ctx, "id").unwrap();
+
+	// Assert
+	assert_eq!(p.into_inner(), 42);
+}
+
+#[rstest]
+fn path_param_returns_missing_path_when_absent() {
+	// Arrange
+	let ctx = RouteContext::new("/".to_string(), HashMap::new(), "".to_string());
+
+	// Act
+	let err = PathParam::<i32>::extract(&ctx, "id").unwrap_err();
+
+	// Assert
+	assert!(matches!(err, ExtractError::MissingPath(n) if n == "id"));
+}
+
+#[rstest]
+fn path_param_returns_parse_error_on_invalid() {
+	// Arrange
+	let mut params = HashMap::new();
+	params.insert("id".to_string(), "abc".to_string());
+	let ctx = RouteContext::new("/users/abc".to_string(), params, "".to_string());
+
+	// Act
+	let err = PathParam::<i32>::extract(&ctx, "id").unwrap_err();
+
+	// Assert
+	assert!(matches!(err, ExtractError::Parse { ref name, .. } if name == "id"));
+}
+
+#[rstest]
+fn query_param_extracts_string() {
+	// Arrange
+	let ctx = RouteContext::new(
+		"/x".to_string(),
+		HashMap::new(),
+		"tab=settings".to_string(),
+	);
+
+	// Act
+	let q: QueryParam<String> = QueryParam::extract(&ctx, "tab").unwrap();
+
+	// Assert
+	assert_eq!(q.into_inner(), "settings");
+}
+
+#[rstest]
+fn query_param_returns_missing_query_when_absent() {
+	// Arrange
+	let ctx = RouteContext::new("/x".to_string(), HashMap::new(), "".to_string());
+
+	// Act
+	let err = QueryParam::<String>::extract(&ctx, "tab").unwrap_err();
+
+	// Assert
+	assert!(matches!(err, ExtractError::MissingQuery(n) if n == "tab"));
+}
+
+#[rstest]
+fn query_param_returns_parse_error_on_invalid() {
+	// Arrange
+	let ctx = RouteContext::new(
+		"/x".to_string(),
+		HashMap::new(),
+		"n=not-a-number".to_string(),
+	);
+
+	// Act
+	let err = QueryParam::<i32>::extract(&ctx, "n").unwrap_err();
+
+	// Assert
+	assert!(matches!(err, ExtractError::Parse { ref name, .. } if name == "n"));
+}
+
+#[rstest]
+fn query_param_handles_multiple_pairs() {
+	// Arrange
+	let ctx = RouteContext::new(
+		"/x".to_string(),
+		HashMap::new(),
+		"a=1&b=hello&c=3".to_string(),
+	);
+
+	// Act
+	let b: QueryParam<String> = QueryParam::extract(&ctx, "b").unwrap();
+
+	// Assert
+	assert_eq!(b.into_inner(), "hello");
+}
+
+#[rstest]
+fn query_param_url_decodes_percent_encoded_values() {
+	// Arrange
+	let ctx = RouteContext::new(
+		"/x".to_string(),
+		HashMap::new(),
+		"q=hello%20world".to_string(),
+	);
+
+	// Act
+	let q: QueryParam<String> = QueryParam::extract(&ctx, "q").unwrap();
+
+	// Assert
+	assert_eq!(q.into_inner(), "hello world");
+}
+
+#[rstest]
+fn query_param_decodes_plus_as_space() {
+	// Arrange
+	let ctx = RouteContext::new("/x".to_string(), HashMap::new(), "q=a+b".to_string());
+
+	// Act
+	let q: QueryParam<String> = QueryParam::extract(&ctx, "q").unwrap();
+
+	// Assert
+	assert_eq!(q.into_inner(), "a b");
+}

--- a/crates/reinhardt-urls/tests/from_request_unit_tests.rs
+++ b/crates/reinhardt-urls/tests/from_request_unit_tests.rs
@@ -90,11 +90,7 @@ fn path_param_returns_parse_error_on_invalid() {
 #[rstest]
 fn query_param_extracts_string() {
 	// Arrange
-	let ctx = RouteContext::new(
-		"/x".to_string(),
-		HashMap::new(),
-		"tab=settings".to_string(),
-	);
+	let ctx = RouteContext::new("/x".to_string(), HashMap::new(), "tab=settings".to_string());
 
 	// Act
 	let q: QueryParam<String> = QueryParam::extract(&ctx, "tab").unwrap();

--- a/crates/reinhardt-urls/tests/page_ui.rs
+++ b/crates/reinhardt-urls/tests/page_ui.rs
@@ -1,0 +1,20 @@
+//! UI tests for `ClientRouter::page` and `FromRequest`.
+//!
+//! - `tests/ui/page/pass/*.rs` — valid usages must compile cleanly.
+//! - `tests/ui/page/fail/*.rs` — invalid usages must produce predictable
+//!   compiler diagnostics (single error type per file per
+//!   `instructions/DOCUMENTATION_STANDARDS.md`).
+//!
+//! Refs #4668 / P7 part 2.
+
+#[test]
+fn page_ui_pass() {
+	let t = trybuild::TestCases::new();
+	t.pass("tests/ui/page/pass/*.rs");
+}
+
+#[test]
+fn page_ui_fail() {
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/ui/page/fail/*.rs");
+}

--- a/crates/reinhardt-urls/tests/ui/page/fail/page_props_not_from_request.rs
+++ b/crates/reinhardt-urls/tests/ui/page/fail/page_props_not_from_request.rs
@@ -1,0 +1,15 @@
+//! Compile-fail: a Props struct without `FromRequest` cannot be used
+//! as a `ClientRouter::page` handler argument. Refs #4668 / P7 part 2.
+
+use reinhardt_core::types::page::Page;
+use reinhardt_urls::routers::ClientRouter;
+
+struct WhateverProps;
+
+fn handler(_p: WhateverProps) -> Page {
+	Page::Empty
+}
+
+fn main() {
+	let _ = ClientRouter::new().page("/x/", handler);
+}

--- a/crates/reinhardt-urls/tests/ui/page/fail/page_props_not_from_request.stderr
+++ b/crates/reinhardt-urls/tests/ui/page/fail/page_props_not_from_request.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `WhateverProps: FromRequest` is not satisfied
+  --> tests/ui/page/fail/page_props_not_from_request.rs:14:30
+   |
+14 |     let _ = ClientRouter::new().page("/x/", handler);
+   |                                 ^^^^ unsatisfied trait bound
+   |
+help: the trait `FromRequest` is not implemented for `WhateverProps`
+  --> tests/ui/page/fail/page_props_not_from_request.rs:7:1
+   |
+ 7 | struct WhateverProps;
+   | ^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `ClientRouter::page`
+  --> src/routers/client_router/core.rs
+   |
+   |     pub fn page<F, P>(mut self, pattern: &str, handler: F) -> Self
+   |            ---- required by a bound in this associated function
+...
+   |         P: FromRequest + Send + Sync + 'static,
+   |            ^^^^^^^^^^^ required by this bound in `ClientRouter::page`

--- a/crates/reinhardt-urls/tests/ui/page/pass/page_with_path_param.rs
+++ b/crates/reinhardt-urls/tests/ui/page/pass/page_with_path_param.rs
@@ -1,0 +1,29 @@
+//! Compile-pass: a Props struct with a `PathParam<T>` field, a manual
+//! `FromRequest` impl, and a page-fn registered via
+//! `ClientRouter::page`. Refs #4668 / P7 part 2.
+
+use reinhardt_core::types::page::Page;
+use reinhardt_urls::routers::ClientRouter;
+use reinhardt_urls::routers::client_router::from_request::{
+	ExtractError, FromRequest, PathParam, RouteContext,
+};
+
+struct UserPageProps {
+	id: PathParam<i32>,
+}
+
+impl FromRequest for UserPageProps {
+	fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError> {
+		Ok(Self {
+			id: PathParam::extract(ctx, "id")?,
+		})
+	}
+}
+
+fn user_page(props: UserPageProps) -> Page {
+	Page::Text(format!("user {}", props.id.into_inner()).into())
+}
+
+fn main() {
+	let _ = ClientRouter::new().page("/users/{id}/", user_page);
+}


### PR DESCRIPTION
## Summary

Implements **Manouche DSL v2 spec §4.3** — `ClientRouter::page<F, P>(pattern, handler)` where `P: FromRequest`. The same Props struct can be used both as a Component prop bag (PR6 / #4743) and as a page function — "every page is a component."

- `ClientRouter::page` + `ClientRouter::named_page` register handlers of shape `Fn(P) -> Page`
- `P: FromRequest` is constructed from a `RouteContext` (matched path + captured path params + raw query string) on every match
- Path / query extraction errors surface as `Page::Text` at the router boundary — no panics, no swallowed errors
- Manual `FromRequest` impls only; `#[derive(FromRequest)]` / `#[derive(PageProps)]` / `#[component]` proc-macros are deferred to spec §10, tracked in **#4752**

`Refs #4668 #4524`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation and Context

Spec §4.3 defines the canonical Reinhardt v2 page-handler shape: a single Props struct that doubles as a Component prop bag. Without this PR, application code wanting to use the §4.3 shape must hand-roll the route-dispatch glue. PR6 (#4743) landed the Component-side parser + codegen; this PR lands the route-side counterpart so both halves of the "every page is a component" claim are realized.

## Architecture & Adaptation Notes

- **Dependency direction probe outcome.** The plan called for direction **(A)** (`reinhardt-urls → reinhardt-pages`), but the worktree actually has `reinhardt-pages → reinhardt-urls` (verified via `grep -A 1 'reinhardt-pages' crates/reinhardt-urls/Cargo.toml`). I therefore chose **(B-a)**: place `FromRequest`/`PathParam<T>`/`QueryParam<T>` in `reinhardt-urls::routers::client_router::from_request` (the natural home, since `ClientRouter` lives there) and re-export them from a new `reinhardt_pages::router::request` submodule so application code can still write `use reinhardt_pages::router::request::FromRequest;` per the spec namespace. The legacy non-generic `PathParam` re-exported at `reinhardt_pages::router::PathParam` (deprecated since `0.1.0-rc.27`) is unrelated and remains in place during its deprecation cycle.
- **`bon` crate.** `bon` is not yet a workspace dep on this branch (PR6 adds it). I therefore avoided `bon::Builder` in the integration tests and constructed Props via plain struct literals — the spec §4.3 "every page is a component" invariant is still demonstrated by `props_struct_can_be_constructed_directly_for_component_use`. When PR6 lands, follow-up work can migrate the example to `bon::Builder` syntax.
- **`Path<T>` vs `PathParam<T>`.** Both exist for different purposes: the legacy `Path<T>` extractor is bound to the `RouteHandler` trait's positional-argument dispatch (used by `route_params`, `route_path*`); `PathParam<T>` is the new spec-§4.3 named-extractor variant constructed from a `RouteContext`. They are intentionally separate APIs; no migration / deprecation is implied for `Path<T>`.

## How Was This Tested

- 11 new unit tests in `crates/reinhardt-urls/tests/from_request_unit_tests.rs` covering `FromRequest`, `PathParam::extract`, `QueryParam::extract`, missing-param, parse-error, multi-pair query, percent-decoding, `+`-as-space
- 5 new integration tests in `crates/reinhardt-urls/tests/clientrouter_page_integration_tests.rs` covering path-param extraction, query-param extraction, extraction-error reporting, not-found fallback, and the spec §4.3 page-as-component invariant
- 2 new trybuild UI tests in `crates/reinhardt-urls/tests/ui/page/` (1 pass, 1 fail) — the fail case yields the single E0277 trait-bound diagnostic per `instructions/DOCUMENTATION_STANDARDS.md`
- All **887** existing `reinhardt-urls` tests still pass under `cargo nextest run -p reinhardt-urls --features client-router`
- `cargo fmt --check`, `cargo clippy -p reinhardt-urls -p reinhardt-pages --all-features --no-deps -- -D warnings`, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p reinhardt-urls -p reinhardt-pages --all-features` all clean

## Dependencies / Coordination

- **Depends on PR #4743 (PR6) for full spec §4.3 ergonomics.** This PR's runtime mechanism is independent of PR6, but the spec's "single Props struct used as both Component invocation and page function" pattern requires PR6's `Component { ... }` parser + codegen for the Component-side ergonomics. The integration test `props_struct_can_be_constructed_directly_for_component_use` demonstrates the same Props struct being constructed for both contexts without the `Component { ... }` sugar; once PR6 merges, application code can use the sugar over the manual constructor.
- **Follow-up Issue #4752** tracks the spec §10 `#[derive(FromRequest)]` / `#[derive(PageProps)]` / `#[component]` proc-macros that will eliminate the manual `FromRequest` boilerplate.

## Checklist

- [x] My code follows the project's code style guidelines (`cargo fmt --check` clean)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (`cargo clippy ... -D warnings` clean)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules — N/A; coordinates with PR #4743 / #4752 as noted above

## Labels to Apply

- `enhancement`

NOT applied (per Autonomous Operation Policy + plan): `breaking-change`, `rc-migration`, `release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ClientRouter::page` and `ClientRouter::named_page` methods for registering page handlers with structured parameter extraction via `FromRequest`
  * Added query string support to route matching and parameter extraction
  * Re-exported `FromRequest` building blocks (`PathParam<T>`, `QueryParam<T>`, `RouteContext`, `ExtractError`) from `reinhardt_pages::router::request` for simplified imports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->