### PR TITLE
chore: add .coderabbit.yaml to enable reviews on all base branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+reviews:
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    base_branches:
+      - ".*"
+    ignore_title_keywords:
+      - "WIP"
+      - "[skip review]"
+    labels:
+      - "!do-not-review"


### PR DESCRIPTION
## Summary

- Add `.coderabbit.yaml` configuration to enable CodeRabbit auto-review on PRs targeting **any** base branch
- Uses `base_branches: [".*"]` regex pattern to match all branch names (not just the default `main`)
- Includes `auto_incremental_review: true` for efficient re-reviews
- Provides opt-out mechanisms via `WIP` / `[skip review]` title keywords and `!do-not-review` label

## Type of Change

- [x] CI/CD / configuration change

## Motivation and Context

Currently, CodeRabbit only reviews PRs targeting the default branch (`main`). PRs targeting `develop/0.2.0` and other branches are skipped. This configuration ensures all PRs receive automated review regardless of their target branch.

## How Was This Tested

- [x] Configuration syntax verified against [CodeRabbit auto-review docs](https://docs.coderabbit.ai/configuration/auto-review)

## Checklist

- [x] I have followed the project's code style guidelines
- [x] This change does not break existing functionality

## Labels to Apply

- `chore` / `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automatic code review system with incremental review enabled across all base branches. Includes title-based exclusions to skip work-in-progress and explicitly flagged pull requests, as well as label-based filtering options to control which changes receive automated reviews and allow contributors to opt out.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->