### PR TITLE
docs: add #[cfg(any())] and protected branch prohibition policies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 
 **Commit Policy:**
 - **NEVER** commit without explicit user instruction
+- **NEVER** commit directly to a protected branch (`develop/*`, `release/*`, `main`, `master`) — all changes to these branches MUST be staged on a non-protected feature/fix/docs branch and merged through a Pull Request
 - **NEVER** push without explicit user instruction
 - **EXCEPTION**: Plan Mode approval is considered explicit commit authorization
   - When user approves a plan via Exit Plan Mode, implementation and commits are both authorized

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ See instructions/MODULE_SYSTEM.md for comprehensive module system standards incl
 - **ALL code comments MUST be written in English** (no exceptions)
 - MINIMIZE `.to_string()` calls - prefer borrowing
 - DELETE obsolete code immediately
+- NEVER use `#[cfg(any())]` to gate deprecated code — delete deprecated APIs entirely
 - NO deletion record comments in code
 - NO relative paths beyond `../` (use absolute paths)
 - Mark ALL placeholders with `todo!()` or `// TODO:` comment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,14 +175,13 @@ Autonomously Allowed (no per-action confirmation required):
 | Convert Draft PR to **Ready for Review** | **REQUIRED (MUST) immediately once implementation is complete**. CI completion is NOT a prerequisite. See `instructions/PR_GUIDELINE.md` § PC-4a |
 | Create an Issue | `gh issue create` / MCP `issue_write`; MUST follow the appropriate issue template and apply at least one type label |
 
-**Protected Branches** (commit/push always require explicit user authorization):
+**Protected Branches** (direct commit/push NEVER allowed; changes MUST go through Pull Requests from non-protected branches):
 - `main`, `master`
 - `develop/*` (any branch starting with `develop/`)
 - `release/*` (any branch starting with `release/`)
 
 Still Requires Explicit User Authorization (no autonomy):
 
-- Direct push to any protected branch listed above
 - `git push --force`, `--force-with-lease`, or any other history-rewriting push
 - `git rebase`, `git reset --hard`, `git branch -D`, deleting tags, or any other history-destructive operation
 - Closing, merging, or deleting PRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 
 **Commit Policy:**
 - **NEVER** commit without explicit user instruction
+- **NEVER** commit directly to a protected branch (`develop/*`, `release/*`, `main`, `master`) — all changes to these branches MUST be staged on a non-protected feature/fix/docs branch and merged through a Pull Request
 - **NEVER** push without explicit user instruction
 - **EXCEPTION**: Plan Mode approval is considered explicit commit authorization
   - When user approves a plan via Exit Plan Mode, implementation and commits are both authorized

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ See instructions/MODULE_SYSTEM.md for comprehensive module system standards incl
 - **ALL code comments MUST be written in English** (no exceptions)
 - MINIMIZE `.to_string()` calls - prefer borrowing
 - DELETE obsolete code immediately
+- NEVER use `#[cfg(any())]` to gate deprecated code — delete deprecated APIs entirely
 - NO deletion record comments in code
 - NO relative paths beyond `../` (use absolute paths)
 - Mark ALL placeholders with `todo!()` or `// TODO:` comment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,14 +175,13 @@ Autonomously Allowed (no per-action confirmation required):
 | Convert Draft PR to **Ready for Review** | **REQUIRED (MUST) immediately once implementation is complete**. CI completion is NOT a prerequisite. See `instructions/PR_GUIDELINE.md` § PC-4a |
 | Create an Issue | `gh issue create` / MCP `issue_write`; MUST follow the appropriate issue template and apply at least one type label |
 
-**Protected Branches** (commit/push always require explicit user authorization):
+**Protected Branches** (direct commit/push NEVER allowed; changes MUST go through Pull Requests from non-protected branches):
 - `main`, `master`
 - `develop/*` (any branch starting with `develop/`)
 - `release/*` (any branch starting with `release/`)
 
 Still Requires Explicit User Authorization (no autonomy):
 
-- Direct push to any protected branch listed above
 - `git push --force`, `--force-with-lease`, or any other history-rewriting push
 - `git rebase`, `git reset --hard`, `git branch -D`, deleting tags, or any other history-destructive operation
 - Closing, merging, or deleting PRs

--- a/instructions/ANTI_PATTERNS.md
+++ b/instructions/ANTI_PATTERNS.md
@@ -21,6 +21,7 @@ mindmap
       Obsolete code comments
       Alternative TODO notations
       Undocumented allow attrs
+      cfg(any()) gate
     Testing
       Skeleton tests
       No Reinhardt components
@@ -321,6 +322,29 @@ pub fn send_email(to: &str, body: &str) -> Result<()> {
 ```
 
 **Why?** Unmarked placeholders can be mistaken for production code.
+
+### ❌ Using `#[cfg(any())]` as a Deletion Substitute
+
+**DON'T:**
+
+```rust
+#[cfg(any())] // Removed in 0.2.0, kept for reference
+pub fn old_api() {}
+```
+
+**DO:**
+
+```rust
+// Delete the function entirely. Git history preserves old code.
+```
+
+**Why?** `#[cfg(any())]` is always false, leaving dead code in the sourcebase
+even though no target can ever activate it. This confuses readers who may think
+there is a valid compilation target where this code exists, creates a
+maintenance burden (dead imports, type requirements, async/sync mismatches),
+and circumvents the project's delete-over-hide policy. If removal must be
+staged, use `#[deprecated]` on the API surface while keeping real callers;
+delete unconditionally when the deprecation period ends.
 
 ### ❌ Undocumented `#[allow(...)]` Attributes
 

--- a/instructions/ANTI_PATTERNS.md
+++ b/instructions/ANTI_PATTERNS.md
@@ -552,6 +552,31 @@ git commit -m "..."
 
 **Why?** Commits should only be made with explicit user authorization.
 
+### ❌ Committing Directly to Protected Branches
+
+**DON'T:**
+
+```bash
+# ❌ Never commit directly on a protected branch
+git checkout develop/0.2.0
+# ... make changes ...
+git add .
+git commit -m "docs: update some instruction files"
+```
+
+**DO:**
+
+```bash
+# ✅ Always use a non-protected feature/fix/docs branch
+git checkout -b docs/update-instructions
+# ... make changes ...
+git add .
+git commit -m "docs: update some instruction files"
+# Then create a Pull Request from docs/update-instructions to develop/0.2.0
+```
+
+**Why?** Protected branches (`main`, `master`, `develop/*`, `release/*`) receive changes exclusively through Pull Requests. Direct commits bypass review, CI validation, and branch protection rules.
+
 ### ❌ Batch Operations Without Dry-Run
 
 **DON'T:**

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -15,6 +15,7 @@
 - When editing `CLAUDE.md` or `AGENTS.md`, mirror the change into the other file in the same commit (sync policy)
 - **MUST** convert Draft PRs to Ready for Review **immediately** once the implementation is complete (CI completion is NOT required) — leaving a PR in Draft state after implementation completion is forbidden (see instructions/PR_GUIDELINE.md § PC-4a)
 - Mark placeholders with `todo!()` or `// TODO:`
+- Delete deprecated code entirely — never use `#[cfg(any())]` as a hiding mechanism
 - Use `#[serial(group_name)]` for global state tests
 - Split commits by specific intent, not features
 - Follow Conventional Commits v1.0.0 format: `<type>[scope]: <description>`
@@ -97,6 +98,7 @@
 - Commit a change that touches only `CLAUDE.md` or only `AGENTS.md` without mirroring it into the other
 - Convert Draft PRs to Ready for Review when implementation is incomplete, without explicit user override
 - Leave a PR in Draft state after the implementation is complete (MUST convert to Ready for Review immediately; the agent MUST NOT wait for CI completion)
+- Use `#[cfg(any())]` instead of deleting deprecated APIs — always delete dead code, never cfg-gate it
 - Leave docs outdated after code changes
 - Document user requests or AI interactions in project documentation
 - Save files to project directory (use `/tmp`)

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -91,7 +91,7 @@
 ### ❌ NEVER DO
 - Use `mod.rs` files (deprecated pattern)
 - Commit without user instruction (except Plan Mode approval or the Autonomous Operation Policy for Reinhardt-family repos)
-- Push directly to any protected branch (`main`, `master`, `develop/*`, `release/*`) — even under the Autonomous Operation Policy these require explicit user authorization
+- Push directly to any protected branch (`main`, `master`, `develop/*`, `release/*`) — direct commits and pushes to protected branches are NEVER allowed; changes must go through Pull Requests from non-protected branches
 - Commit directly to a protected branch (`main`, `master`, `develop/*`, `release/*`) — all changes to protected branches MUST go through feature/fix/docs branches and Pull Requests
 - Force-push, rebase-and-push, or otherwise rewrite history without explicit user authorization (the Autonomous Operation Policy does NOT cover history-rewriting pushes)
 - Close, merge, or delete PRs / Issues / comments without explicit user authorization (autonomy covers creation only, not destruction)

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -92,6 +92,7 @@
 - Use `mod.rs` files (deprecated pattern)
 - Commit without user instruction (except Plan Mode approval or the Autonomous Operation Policy for Reinhardt-family repos)
 - Push directly to any protected branch (`main`, `master`, `develop/*`, `release/*`) — even under the Autonomous Operation Policy these require explicit user authorization
+- Commit directly to a protected branch (`main`, `master`, `develop/*`, `release/*`) — all changes to protected branches MUST go through feature/fix/docs branches and Pull Requests
 - Force-push, rebase-and-push, or otherwise rewrite history without explicit user authorization (the Autonomous Operation Policy does NOT cover history-rewriting pushes)
 - Close, merge, or delete PRs / Issues / comments without explicit user authorization (autonomy covers creation only, not destruction)
 - Create release tags or any PR with the `release` label without explicit user authorization

--- a/instructions/STABILITY_POLICY.md
+++ b/instructions/STABILITY_POLICY.md
@@ -736,6 +736,7 @@ Automated SemVer checking is performed on every pull request targeting `main` us
 - Trigger `release-plz-promote.yml` (`workflow_dispatch`) after merging `develop/m.n.l` into `main` to graduate the prerelease suffix to stable (DBR-3)
 
 ### NEVER DO
+- Use `#[cfg(any())]` as a substitute for deleting deprecated code — deprecated code MUST be deleted entirely, not hidden behind an always-false cfg gate
 - Regress from RC back to alpha
 - Add new public APIs during the RC phase without SP-6 approval
 - Add unapproved `feat:` commits during the RC phase (SP-6-approved additions may use `feat:`)


### PR DESCRIPTION
## Summary

This PR adds two new prohibition policies to the instruction files and resolves an internal inconsistency in the protected branch policy:

- **`#[cfg(any())]` prohibition**: Explicitly forbids using `#[cfg(any())]` to gate deprecated code — dead code must be deleted, never cfg-gated
- **Protected branch direct commit prohibition**: Explicitly forbids committing directly to protected branches (`main`, `master`, `develop/*`, `release/*`) — all changes must go through Pull Requests from non-protected branches
- **Policy consistency fix**: Resolves internal contradiction where "commit/push always require explicit user authorization" implied protected branch commits were *possible* with authorization, conflicting with the absolute prohibition

## Type of Change

- [x] Documentation update
- [x] Code quality improvements

## Motivation and Context

- The `#[cfg(any())]` prohibition was added to prevent hiding deprecated code instead of properly deleting it
- The protected branch direct commit prohibition closes a policy gap — while push was already forbidden, commit was not explicitly prohibited
- The internal inconsistency in the protected branch policy needed resolution to prevent contradictory guidance between the Commit Policy and the Authorization sections

## How Was This Tested?

- Diff verification between CLAUDE.md and AGENTS.md confirms only mechanical substitutions remain
- All changes are documentation-only; no code compilation required

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] CLAUDE.md ↔ AGENTS.md sync verified (`diff CLAUDE.md AGENTS.md` shows only mechanical substitutions)

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

### Scope Label (select all that apply)
- [x] `ci-cd` — policy enforcement / CI guard rules

---

**Additional Context:**

Files changed:
- `CLAUDE.md` — Added `#[cfg(any())]` prohibition + protected branch commit prohibition + policy consistency fix
- `AGENTS.md` — Mirror of CLAUDE.md changes
- `instructions/QUICK_REFERENCE.md` — Added both prohibitions to MUST DO / NEVER DO sections
- `instructions/ANTI_PATTERNS.md` — Added `#[cfg(any())]` and Committing Directly to Protected Branches anti-pattern sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines requiring deprecated code to be fully removed rather than conditionally gated
  * Strengthened branch protection policies, mandating Pull Requests for all changes to protected branches
  * Enhanced anti-pattern guidance to maintain code quality standards

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->