### PR TITLE
fix(templates): add server_only, no_ws_resolvers to RESTful project url template

### DIFF
--- a/crates/reinhardt-commands/templates/project_restful_template/src/config/urls.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/src/config/urls.rs.tpl
@@ -5,7 +5,7 @@
 use reinhardt::prelude::*;
 use reinhardt::routes;
 
-#[routes]
+#[routes(server_only, no_ws_resolvers)]
 pub fn routes() -> UnifiedRouter {
     let router = UnifiedRouter::new();
 


### PR DESCRIPTION
## Summary

- Fix compilation failure in projects scaffolded with `reinhardt-admin startproject --with-rest`
- Change `#[routes]` to `#[routes(server_only, no_ws_resolvers)]` to prevent resolving non-existent `ws_urls` modules

## Type of Change

- [x] Bug fix (non-breaking change)

## Motivation and Context

Fixes #4779

The `#[routes]` macro, when used without flags, attempts to resolve `ws_urls` modules for each installed app. REST-only scaffolded projects do not have WebSocket modules, causing a compilation error. Adding `server_only` (shorthand for `no_client_resolvers` + `no_ws_resolvers`) configures the project appropriately for REST API servers.

## How Was This Tested

- [x] Verified template file syntax
- [x] `cargo check --workspace --all --all-features` confirms no impact on existing code (template files are not compiled)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] This change is a bug fix targeting `main` (RC phase: DB-3)

## Labels to Apply

- `bug`

## Related Issues

Fixes #4779

🤖 Generated with [Claude Code](https://claude.com/claude-code)
