### PR TITLE
docs(release): document branch-specific pr_branch_prefix convention

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -73,10 +73,11 @@ jobs:
     timeout-minutes: 360
     concurrency:
       # Cancel any in-flight Release PR regeneration when a newer push lands
-      # on the same ref. release-plz rebuilds the release-plz-* branch from
-      # the latest Cargo.toml each run, so older runs are stale the moment
-      # a newer commit appears. Safe because this job only writes to the
-      # release-plz-* branch (idempotent regeneration), not to crates.io.
+      # on the same ref. release-plz rebuilds the release branch (release-plz-*
+      # or release-plz-develop-*) from the latest Cargo.toml each run, so older
+      # runs are stale the moment a newer commit appears. Safe because this job
+      # only writes to the release branch (idempotent regeneration), not to
+      # crates.io.
       # The publish job (release-plz-release) intentionally keeps
       # cancel-in-progress: false to avoid mid-publish interruption.
       group: release-plz-${{ github.ref }}
@@ -234,9 +235,12 @@ jobs:
     # always skip). Two commit-message shapes are accepted to cover both
     # GitHub merge strategies:
     #
-    #   - squash-merge → `chore: release ...` (release-plz's `pr_name`)
-    #   - regular merge → `Merge pull request #N from .../release-plz-...`
-    #     (release-plz's `pr_branch_prefix = "release-plz-"`)
+    #   - squash-merge → `chore: release ...` or `chore: release (develop) ...`
+    #     (release-plz's `pr_name`; develop uses "chore: release (develop)" to
+    #     distinguish Release PR titles from main)
+    #   - regular merge → `Merge pull request #N from .../release-plz-...` or
+    #     `.../release-plz-develop-...` (branch-specific `pr_branch_prefix`;
+    #     both contain `release-plz-` so the `contains()` check matches both)
     #
     # `startsWith()` is used for the squash-merge form so we don't false-match
     # arbitrary commits that happen to contain the substring `chore: release`

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -74,7 +74,7 @@ jobs:
     concurrency:
       # Cancel any in-flight Release PR regeneration when a newer push lands
       # on the same ref. release-plz rebuilds the release branch (release-plz-*
-      # or release-plz-develop-*) from the latest Cargo.toml each run, so older
+      # or develop-release-plz-*) from the latest Cargo.toml each run, so older
       # runs are stale the moment a newer commit appears. Safe because this job
       # only writes to the release branch (idempotent regeneration), not to
       # crates.io.
@@ -239,7 +239,7 @@ jobs:
     #     (release-plz's `pr_name`; develop uses "chore: release (develop)" to
     #     distinguish Release PR titles from main)
     #   - regular merge → `Merge pull request #N from .../release-plz-...` or
-    #     `.../release-plz-develop-...` (branch-specific `pr_branch_prefix`;
+    #     `.../develop-release-plz-...` (branch-specific `pr_branch_prefix`;
     #     both contain `release-plz-` so the `contains()` check matches both)
     #
     # `startsWith()` is used for the squash-merge form so we don't false-match

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -115,7 +115,7 @@
 - Skip reviewing Release PRs before merging
 - Use `reinhardt-test = { workspace = true }` in functional crate `[dev-dependencies]` (workspace deps include version, causing publish failures; use optional dep or path-only dev-dep instead)
 - Omit `version` field from `reinhardt-test` workspace dependency (causes publish failure for dependents)
-- Change `pr_branch_prefix` from `"release-plz-"` (breaks two-step release workflow)
+- Change `pr_branch_prefix` from `"release-plz-"` on `main` (breaks two-step release workflow); on `develop/*` the prefix MUST be `"release-plz-develop-"` to prevent cross-branch PR closure
 - Merge Release PR without rolling back unpublished crate versions after partial release failure
 - Write vague commit descriptions that are unclear as CHANGELOG entries (e.g., "fix issue", "update code")
 - Start commit description with uppercase letter

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -115,7 +115,7 @@
 - Skip reviewing Release PRs before merging
 - Use `reinhardt-test = { workspace = true }` in functional crate `[dev-dependencies]` (workspace deps include version, causing publish failures; use optional dep or path-only dev-dep instead)
 - Omit `version` field from `reinhardt-test` workspace dependency (causes publish failure for dependents)
-- Change `pr_branch_prefix` from `"release-plz-"` on `main` (breaks two-step release workflow); on `develop/*` the prefix MUST be `"release-plz-develop-"` to prevent cross-branch PR closure
+- Change `pr_branch_prefix` from `"release-plz-"` on `main` (breaks two-step release workflow); on `develop/*` the prefix MUST be `"develop-release-plz-"` to prevent cross-branch PR closure
 - Merge Release PR without rolling back unpublished crate versions after partial release failure
 - Write vague commit descriptions that are unclear as CHANGELOG entries (e.g., "fix issue", "update code")
 - Start commit description with uppercase letter

--- a/instructions/RELEASE_PROCESS.md
+++ b/instructions/RELEASE_PROCESS.md
@@ -318,6 +318,9 @@ Configuration file at repository root. Key CHANGELOG-related settings:
 ```toml
 [workspace]
 changelog_update = true
+# On main:    pr_branch_prefix = "release-plz-"
+# On develop: pr_branch_prefix = "release-plz-develop-"
+# See "Branch-specific pr_branch_prefix convention" in Configuration Rationale below.
 pr_branch_prefix = "release-plz-"
 pr_labels = ["release", "automated"]
 pr_name = "chore: release"
@@ -386,6 +389,17 @@ Key configuration decisions and the reasons behind them:
 **`pr_branch_prefix = "release-plz-"`**
 
 The branch prefix **must** start with `"release-plz-"` for the native two-step release workflow to function correctly. When `release_always = false`, release-plz determines whether to publish by checking if the latest commit originates from a PR whose branch starts with this prefix. Using a different prefix (e.g., `"release/"`) causes `release-plz release` to skip publishing entirely because it cannot detect the merged Release PR. (Ref: [#186](https://github.com/kent8192/reinhardt-web/pull/186))
+
+**Branch-specific `pr_branch_prefix` convention:**
+
+| Branch | `pr_branch_prefix` | Rationale |
+|---|---|---|
+| `main` | `"release-plz-"` | Default prefix for stable releases |
+| `develop/m.n.l` | `"release-plz-develop-"` | MUST differ from `main` to prevent cross-branch PR closure |
+
+release-plz's `opened_prs()` method (in `forge.rs`) searches ALL open PRs in the repository and filters only by head branch prefix — there is NO base-branch filter. If both `main` and `develop/*` share the same prefix (e.g., `"release-plz-"`), each release-plz run finds and closes the other branch's Release PR. Using distinct prefixes (`"release-plz-"` vs `"release-plz-develop-"`) prevents this collision.
+
+Since `release_always = true` on both branches, the branch prefix is **not** used for publish decisions — it only affects Release PR discovery and naming. The distinct prefixes are safe and do not interfere with the two-step release workflow.
 
 **`publish_no_verify = true`**
 

--- a/instructions/RELEASE_PROCESS.md
+++ b/instructions/RELEASE_PROCESS.md
@@ -319,7 +319,7 @@ Configuration file at repository root. Key CHANGELOG-related settings:
 [workspace]
 changelog_update = true
 # On main:    pr_branch_prefix = "release-plz-"
-# On develop: pr_branch_prefix = "release-plz-develop-"
+# On develop: pr_branch_prefix = "develop-release-plz-"
 # See "Branch-specific pr_branch_prefix convention" in Configuration Rationale below.
 pr_branch_prefix = "release-plz-"
 pr_labels = ["release", "automated"]
@@ -386,18 +386,18 @@ The following packages are excluded from release:
 
 Key configuration decisions and the reasons behind them:
 
-**`pr_branch_prefix = "release-plz-"`**
+**`pr_branch_prefix` (branch-specific)**
 
-The branch prefix **must** start with `"release-plz-"` for the native two-step release workflow to function correctly. When `release_always = false`, release-plz determines whether to publish by checking if the latest commit originates from a PR whose branch starts with this prefix. Using a different prefix (e.g., `"release/"`) causes `release-plz release` to skip publishing entirely because it cannot detect the merged Release PR. (Ref: [#186](https://github.com/kent8192/reinhardt-web/pull/186))
+With `release_always = true`, the branch prefix is used only for Release PR discovery and naming, not for publish decisions. The prefix MUST differ between `main` and `develop/*` because release-plz's `opened_prs()` searches ALL open PRs filtered by head branch prefix with no base-branch filter — identical prefixes cause cross-branch PR closure. See the branch-specific convention table below. (Ref: [#186](https://github.com/kent8192/reinhardt-web/pull/186))
 
 **Branch-specific `pr_branch_prefix` convention:**
 
 | Branch | `pr_branch_prefix` | Rationale |
 |---|---|---|
 | `main` | `"release-plz-"` | Default prefix for stable releases |
-| `develop/m.n.l` | `"release-plz-develop-"` | MUST differ from `main` to prevent cross-branch PR closure |
+| `develop/m.n.l` | `"develop-release-plz-"` | MUST differ from `main` to prevent cross-branch PR closure |
 
-release-plz's `opened_prs()` method (in `forge.rs`) searches ALL open PRs in the repository and filters only by head branch prefix — there is NO base-branch filter. If both `main` and `develop/*` share the same prefix (e.g., `"release-plz-"`), each release-plz run finds and closes the other branch's Release PR. Using distinct prefixes (`"release-plz-"` vs `"release-plz-develop-"`) prevents this collision.
+release-plz's `opened_prs()` method (in `forge.rs`) searches ALL open PRs in the repository and filters only by head branch prefix — there is NO base-branch filter. release-plz uses `starts_with()` to match, so the prefixes must NOT be mutual substrings. `"release-plz-develop-"` would still be matched by main's `"release-plz-"` prefix because it starts with `"release-plz-"`. Using `"develop-release-plz-"` (which does NOT start with `"release-plz-"`) ensures neither prefix matches the other's PRs.
 
 Since `release_always = true` on both branches, the branch prefix is **not** used for publish decisions — it only affects Release PR discovery and naming. The distinct prefixes are safe and do not interfere with the two-step release workflow.
 

--- a/instructions/STABILITY_POLICY.md
+++ b/instructions/STABILITY_POLICY.md
@@ -412,14 +412,16 @@ git push origin --delete develop/0.2.0
 ### DB-6 (MUST): release-plz Interaction
 
 release-plz monitors both `main` and `develop/**`. Each branch follows the
-Cargo.toml version it currently carries, with no branch-specific
-configuration in `release-plz.toml`:
+Cargo.toml version it currently carries. **Branch-specific `pr_branch_prefix`
+values are REQUIRED in `release-plz.toml`** to prevent cross-branch PR closure
+(release-plz's `opened_prs()` searches all open PRs by branch prefix with no
+base-branch filter):
 
-| Branch | Cargo.toml version | Release PR output |
-|---|---|---|
-| `main` | `x.y.z` (stable) | Stable Release PR (`x.y.z` → `x.y.(z+1)` or `x.(y+1).0`) |
-| `develop/m.n.l` (alpha phase) | `m.n.l-alpha.N` | Prerelease Release PR (`alpha.N` → `alpha.(N+1)`) |
-| `develop/m.n.l` (rc phase) | `m.n.l-rc.N` | Prerelease Release PR (`rc.N` → `rc.(N+1)`) |
+| Branch | `pr_branch_prefix` | Cargo.toml version | Release PR output |
+|---|---|---|---|
+| `main` | `"release-plz-"` | `x.y.z` (stable) | Stable Release PR (`x.y.z` → `x.y.(z+1)` or `x.(y+1).0`) |
+| `develop/m.n.l` (alpha phase) | `"release-plz-develop-"` | `m.n.l-alpha.N` | Prerelease Release PR (`alpha.N` → `alpha.(N+1)`) |
+| `develop/m.n.l` (rc phase) | `"release-plz-develop-"` | `m.n.l-rc.N` | Prerelease Release PR (`rc.N` → `rc.(N+1)`) |
 
 **Version management on the develop branch** is operator-controlled at three
 explicit gates (see `instructions/RELEASE_PROCESS.md` § "Develop Branch

--- a/instructions/STABILITY_POLICY.md
+++ b/instructions/STABILITY_POLICY.md
@@ -420,8 +420,8 @@ base-branch filter):
 | Branch | `pr_branch_prefix` | Cargo.toml version | Release PR output |
 |---|---|---|---|
 | `main` | `"release-plz-"` | `x.y.z` (stable) | Stable Release PR (`x.y.z` → `x.y.(z+1)` or `x.(y+1).0`) |
-| `develop/m.n.l` (alpha phase) | `"release-plz-develop-"` | `m.n.l-alpha.N` | Prerelease Release PR (`alpha.N` → `alpha.(N+1)`) |
-| `develop/m.n.l` (rc phase) | `"release-plz-develop-"` | `m.n.l-rc.N` | Prerelease Release PR (`rc.N` → `rc.(N+1)`) |
+| `develop/m.n.l` (alpha phase) | `"develop-release-plz-"` | `m.n.l-alpha.N` | Prerelease Release PR (`alpha.N` → `alpha.(N+1)`) |
+| `develop/m.n.l` (rc phase) | `"develop-release-plz-"` | `m.n.l-rc.N` | Prerelease Release PR (`rc.N` → `rc.(N+1)`) |
 
 **Version management on the develop branch** is operator-controlled at three
 explicit gates (see `instructions/RELEASE_PROCESS.md` § "Develop Branch

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,19 +6,19 @@
 changelog_update = true
 
 # PR settings
-# IMPORTANT: Branch prefix MUST start with "release-plz-" for native two-step release workflow.
-# When release_always = false, release-plz checks if the latest commit is from a PR
-# whose branch starts with "release-plz-" to determine if it should publish.
-# See: https://release-plz.ieni.dev/docs/config#the-release_always-field
+# IMPORTANT: Branch prefix distinguishes main from develop/* Release PRs.
+# release-plz's opened_prs() searches ALL open PRs filtered only by head
+# branch prefix — there is NO base-branch filter.
 #
 # Branch-specific prefix convention:
-# - main:             "release-plz-"         (this branch)
-# - develop/m.n.l:    "release-plz-develop-" (MUST differ to avoid cross-branch PR closure)
+# - main:             "release-plz-"          (this branch)
+# - develop/m.n.l:    "develop-release-plz-"  (MUST NOT start with "release-plz-")
 #
-# Rationale: release-plz's opened_prs() searches ALL open PRs in the repository
-# filtered only by head branch prefix — there is NO base-branch filter. If both
-# main and develop/* share the same prefix, each release-plz run finds and closes
-# the other branch's Release PR. Different prefixes prevent this collision.
+# Rationale: release-plz uses starts_with() to match PR branches. If the
+# develop prefix started with "release-plz-" (e.g., "release-plz-develop-"),
+# main's release-plz would still find and close develop's Release PRs.
+# Using "develop-release-plz-" ensures neither prefix is a prefix of the other,
+# preventing cross-branch PR closure.
 pr_branch_prefix = "release-plz-"
 pr_labels = ["release", "automated"]
 pr_name = "chore: release"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -10,6 +10,15 @@ changelog_update = true
 # When release_always = false, release-plz checks if the latest commit is from a PR
 # whose branch starts with "release-plz-" to determine if it should publish.
 # See: https://release-plz.ieni.dev/docs/config#the-release_always-field
+#
+# Branch-specific prefix convention:
+# - main:             "release-plz-"         (this branch)
+# - develop/m.n.l:    "release-plz-develop-" (MUST differ to avoid cross-branch PR closure)
+#
+# Rationale: release-plz's opened_prs() searches ALL open PRs in the repository
+# filtered only by head branch prefix — there is NO base-branch filter. If both
+# main and develop/* share the same prefix, each release-plz run finds and closes
+# the other branch's Release PR. Different prefixes prevent this collision.
 pr_branch_prefix = "release-plz-"
 pr_labels = ["release", "automated"]
 pr_name = "chore: release"


### PR DESCRIPTION
## Summary

- Document the branch-specific `pr_branch_prefix` convention in `release-plz.toml`: `main` uses `"release-plz-"`, `develop/*` uses `"release-plz-develop-"`
- Update `instructions/STABILITY_POLICY.md` DB-6 table with `pr_branch_prefix` column
- Update `instructions/RELEASE_PROCESS.md` with branch-specific convention table and collision rationale
- Update `instructions/QUICK_REFERENCE.md` NEVER DO item to reflect branch-specific prefixes

## Test plan

- [x] Documentation-only change — no code to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation to clarify branch-specific configuration behavior
  * Enhanced guidance on release branch prefix conventions for main and development branches
  * Improved documentation on release PR matching and closure behavior across different branches
  * Refined instructional materials for consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->