### PR TITLE
fix(ci): include develop-release-plz-* branches in self-hosted runner selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ permissions:
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
-      (startsWith(github.head_ref || '', 'release-plz-') || startsWith(github.head_ref || '', 'develop-release-plz-'))
-        && 'release-plz'
+      startsWith(github.head_ref || '', 'develop-release-plz-')
+        && 'develop-release-plz'
+        || startsWith(github.head_ref || '', 'release-plz-')
+          && 'release-plz'
         || github.head_ref
         || github.run_id
     }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
-      startsWith(github.head_ref || '', 'release-plz-')
+      startsWith(github.head_ref || '', 'release-plz-') || startsWith(github.head_ref || '', 'develop-release-plz-')
         && 'release-plz'
         || github.head_ref
         || github.run_id
@@ -125,7 +125,7 @@ jobs:
               USE_MAC=true
             elif [[ "$EVENT_NAME" == "pull_request" ]]; then
               # release-plz PRs: trusted (only push-access users create these branches)
-              if [[ "$HEAD_REF" == release-plz-* ]]; then
+              if [[ "$HEAD_REF" == release-plz-* || "$HEAD_REF" == develop-release-plz-* ]]; then
                 USE_MAC=true
               # Repo owner PRs: trusted
               elif [[ "$ACTOR" == "$REPO_OWNER" ]]; then
@@ -137,7 +137,7 @@ jobs:
 
           # --- AWS Spot runner selection (opt-in) ---
           if [[ "$USE_MAC" == "false" ]] && [[ "$SELF_HOSTED_ENABLED" == "true" ]]; then
-            if [[ "$HEAD_REF" == release-plz-* ]]; then
+            if [[ "$HEAD_REF" == release-plz-* || "$HEAD_REF" == develop-release-plz-* ]]; then
               USE_AWS=true
             elif [[ "$ACTOR" == "$REPO_OWNER" ]]; then
               if [[ "$EVENT_NAME" == "pull_request" ]]; then
@@ -267,7 +267,7 @@ jobs:
     if: >-
       ${{
         needs.check-branch-status.outputs.has-conflicts != 'true' &&
-        startsWith(github.head_ref || '', 'release-plz-')
+        (startsWith(github.head_ref || '', 'release-plz-') || startsWith(github.head_ref || '', 'develop-release-plz-'))
       }}
     uses: ./.github/workflows/reinhardt-feature-check.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
             if [[ "$EVENT_NAME" == "workflow_dispatch" ]] && [[ "$ACTOR" == "$REPO_OWNER" ]]; then
               USE_MAC=true
             elif [[ "$EVENT_NAME" == "pull_request" ]]; then
-              # release-plz PRs: trusted (only push-access users create these branches)
+              # release-plz / develop-release-plz PRs: trusted (only push-access users create these branches)
               if [[ "$HEAD_REF" == release-plz-* || "$HEAD_REF" == develop-release-plz-* ]]; then
                 USE_MAC=true
               # Repo owner PRs: trusted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
-      startsWith(github.head_ref || '', 'release-plz-') || startsWith(github.head_ref || '', 'develop-release-plz-')
+      (startsWith(github.head_ref || '', 'release-plz-') || startsWith(github.head_ref || '', 'develop-release-plz-'))
         && 'release-plz'
         || github.head_ref
         || github.run_id

--- a/.github/workflows/cleanup-release-branch.yml
+++ b/.github/workflows/cleanup-release-branch.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   cleanup-release-branch:
-    name: Delete release-plz branch
+    name: Delete release-plz / develop-release-plz branch
     if: >-
       github.event.pull_request.merged == false &&
       (startsWith(github.event.pull_request.head.ref, 'release-plz-') || startsWith(github.event.pull_request.head.ref, 'develop-release-plz-'))

--- a/.github/workflows/cleanup-release-branch.yml
+++ b/.github/workflows/cleanup-release-branch.yml
@@ -16,7 +16,7 @@ jobs:
     name: Delete release-plz branch
     if: >-
       github.event.pull_request.merged == false &&
-      startsWith(github.event.pull_request.head.ref, 'release-plz-')
+      (startsWith(github.event.pull_request.head.ref, 'release-plz-') || startsWith(github.event.pull_request.head.ref, 'develop-release-plz-'))
     runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
     timeout-minutes: 360
     steps:

--- a/.github/workflows/detect-affected-packages.yml
+++ b/.github/workflows/detect-affected-packages.yml
@@ -57,7 +57,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ "$HEAD_REF" == release-plz-* ]]; then
+          if [[ "$HEAD_REF" == release-plz-* || "$HEAD_REF" == develop-release-plz-* ]]; then
             echo "Release PR detected — running all tests"
             echo "run-all=true" >> "$GITHUB_OUTPUT"
             echo "has-affected=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -29,7 +29,7 @@ jobs:
     name: Publish Dry-Run Check
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
     timeout-minutes: 360
-    # Skip for release-plz branches and release-fix branches - versions may not yet be on crates.io
+    # Skip for release-plz / develop-release-plz branches and release-fix branches - versions may not yet be on crates.io
     if: >-
       ${{
         !startsWith(github.head_ref || github.ref_name, 'release-plz-') &&

--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -33,6 +33,7 @@ jobs:
     if: >-
       ${{
         !startsWith(github.head_ref || github.ref_name, 'release-plz-') &&
+        !startsWith(github.head_ref || github.ref_name, 'develop-release-plz-') &&
         !startsWith(github.head_ref || github.ref_name, 'fix/release-plz')
       }}
     steps:

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -156,7 +156,7 @@ jobs:
           # On those, release-plz bumps versions in Cargo.toml so cargo-semver-checks
           # can auto-detect the intended release type without --release-type.
           IS_RELEASE_PR="false"
-          if [[ "$HEAD_REF" == release-plz-* ]]; then
+          if [[ "$HEAD_REF" == release-plz-* || "$HEAD_REF" == develop-release-plz-* ]]; then
             IS_RELEASE_PR="true"
           fi
           echo "is-release-pr=$IS_RELEASE_PR" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Extend `release-plz-*` glob patterns in CI workflows to also match `develop-release-plz-*` branches
- Ensures develop-targeted Release PRs get the same CI treatment as main-targeted ones

### Files changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | 4 locations: concurrency group, Mac local runner, AWS Spot runner, feature-check condition |
| `.github/workflows/detect-affected-packages.yml` | Release PR detection for running all tests |
| `.github/workflows/semver-check.yml` | `IS_RELEASE_PR` detection for semver validation |
| `.github/workflows/publish-check.yml` | Skip publish-check for develop-release-plz branches |
| `.github/workflows/cleanup-release-branch.yml` | Branch cleanup after PR close |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The bash glob pattern `release-plz-*` does not match branches starting with `develop-release-plz-*`. As a result, `develop-release-plz-*` PRs (e.g., PR #4804) were:
1. Assigned to GitHub-hosted runners instead of self-hosted runners
2. Skipping full test suites (not recognized as release PRs)
3. Potentially skipping semver validation
4. Not cleaned up after PR close

## How Was This Tested

- [x] `git diff main...fix/issue-4806-develop-release-plz-self-hosted-runner` shows only intended changes
- [x] All `develop-release-plz-*` references verified with `grep -rn`

## Checklist

- [x] I have followed the project's coding and commit guidelines
- [x] I have written or updated documentation (if applicable)
- [x] This PR is linked to related issues

## Related Issues

Fixes #4806

## Labels to Apply

- `bug`
- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflows updated to treat "develop-release-plz-*" branches the same as existing release branches.
  * Concurrency grouping and runner-selection behavior aligned across both branch families.
  * Release-detection, publish checks, affected-package detection, and cleanup logic extended to include the new branch prefix.
  * No runtime or product behavior changes beyond branch-handling logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->