### PR TITLE
fix(ci): strengthen release-plz publish gate with branch name and PR label verification

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -232,22 +232,17 @@ jobs:
     # On develop/**, gate the job on Release-PR-merge commits to avoid
     # spinning up a self-hosted runner + cargo registry sync for every
     # routine feat/fix push (where Cargo.toml is unchanged and publish would
-    # always skip). Two commit-message shapes are accepted to cover both
-    # GitHub merge strategies:
+    # always skip). Three commit-message shapes are accepted:
     #
     #   - squash-merge → `chore: release ...` or `chore: release (develop) ...`
     #     (release-plz's `pr_name`; develop uses "chore: release (develop)" to
-    #     distinguish Release PR titles from main)
-    #   - regular merge → `Merge pull request #N from .../release-plz-...` or
-    #     `.../develop-release-plz-...` (branch-specific `pr_branch_prefix`;
-    #     both contain `release-plz-` so the `contains()` check matches both)
-    #
-    # `startsWith()` is used for the squash-merge form so we don't false-match
-    # arbitrary commits that happen to contain the substring `chore: release`
-    # in their body (e.g. `feat: add release-plz-compatible versioning`).
-    # `contains()` is retained for the merge-commit form because the GitHub
-    # default subject is `Merge pull request #N from <repo>/release-plz-...`,
-    # which doesn't start with the release-plz marker.
+    #     distinguish Release PR titles from main). `startsWith()` avoids
+    #     false-matching `feat: add release-plz-compatible versioning`.
+    #   - regular merge → `Merge pull request #N from owner/BRANCH` where
+    #     BRANCH starts with `release-plz-` or `develop-release-plz-`.
+    #     The `if:` condition only checks the `Merge pull request #` prefix;
+    #     the actual branch name prefix is validated in the "Verify release
+    #     branch name" step below using `grep -oP` + `case` matching.
     #
     # release-plz-pr (above) still runs on every develop/** push, so the
     # next Release PR is always kept up to date.
@@ -255,7 +250,7 @@ jobs:
       github.event_name == 'push' && (
         github.ref == 'refs/heads/main' ||
         startsWith(github.event.head_commit.message, 'chore: release') ||
-        contains(github.event.head_commit.message, 'release-plz-')
+        startsWith(github.event.head_commit.message, 'Merge pull request #')
       )
     runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
     timeout-minutes: 360
@@ -297,6 +292,52 @@ jobs:
             sudo apt-get update -qq -o DPkg::Lock::Timeout=120
             sudo apt-get install -y -o DPkg::Lock::Timeout=120 gh
           fi
+
+      - name: Verify release branch name
+        if: github.ref != 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore: release')
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          # Extract branch name from merge commit message.
+          # Format: "Merge pull request #N from owner/BRANCH_NAME"
+          BRANCH=$(echo "$COMMIT_MSG" | grep -oP 'from [^/]+/\K.+$' || true)
+          if [ -z "$BRANCH" ]; then
+            echo "::error::Could not extract branch name from commit message"
+            exit 1
+          fi
+          echo "Extracted branch name: $BRANCH"
+          case "$BRANCH" in
+            release-plz-*|develop-release-plz-*)
+              echo "Branch '$BRANCH' matches release branch pattern"
+              ;;
+            *)
+              echo "::error::Branch '$BRANCH' does not start with 'release-plz-' or 'develop-release-plz-'"
+              echo "::error::This push does not originate from a release-plz branch. Refusing to publish."
+              exit 1
+              ;;
+          esac
+
+      - name: Verify release PR label
+        if: github.ref != 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore: release')
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          # Extract PR number from merge commit message.
+          # Format: "Merge pull request #N from owner/BRANCH_NAME"
+          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '^Merge pull request #\K\d+' || true)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Could not extract PR number from commit message"
+            exit 1
+          fi
+          echo "Verifying PR #$PR_NUMBER has the 'release' label..."
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+          if ! echo "$LABELS" | grep -qx 'release'; then
+            echo "::error::PR #$PR_NUMBER does not have the 'release' label. Labels found: $LABELS"
+            echo "::error::Only PRs with the 'release' label are allowed to publish. Refusing to publish."
+            exit 1
+          fi
+          echo "PR #$PR_NUMBER has the 'release' label — proceeding with publish"
 
       # Workaround for gix slotmap overflow (GitoxideLabs/gitoxide#1788)
       - name: Clear cargo registry git index cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0...reinhardt-web@v0.1.1) - 2026-05-24
+
+### Added
+
+- *(admin-cli)* scaffold migrate-manouche-v2 subcommand
+- *(admin-cli)* codemod pipeline scaffolding (walker + rule trait + review fixes)
+- *(admin)* add form! macro DSL formatting support
+
+### Fixed
+
+- *(templates)* add server_only, no_ws_resolvers to RESTful project url template
+- *(admin)* preserve blank lines inside page! macro DSL when formatting
+- *(admin)* preserve comments and blank lines in codemod rewriting
+- *(admin)* use text-based item search for codemod formatting preservation
+- *(admin-cli)* address CodeRabbit review on form! detection, char/lifetime scan, temp file, and codemod rules
+- *(admin-cli)* use unique temp filename in target directory for atomic rename
+- *(admin-cli)* ensure temp file cleanup runs on rename failure
+- *(admin)* clean up temp file when std::fs::write fails in write_developer_file
+- *(admin-cli)* revert version to 0.1.0
+
+### Styling
+
+- *(admin)* fix indentation in write_developer_file write-error handler
+- *(admin-cli)* apply rustfmt to migrate_v2 codemod tests
+
 ## [0.1.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.0-rc.30...reinhardt-web@v0.1.0) - 2026-05-22
 
 First stable release of `reinhardt-web`, after 19 alpha and 30 rc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -445,67 +445,67 @@ module_name_repetitions = "allow"
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.0" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.1.1" }
 
 # Internal crates
-reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.0" }
-reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.1.0" }
-reinhardt-core = { path = "crates/reinhardt-core", version = "0.1.0" }
-reinhardt-di = { path = "crates/reinhardt-di", version = "0.1.0" }
-reinhardt-http = { path = "crates/reinhardt-http", version = "0.1.0" }
-reinhardt-server = { path = "crates/reinhardt-server", version = "0.1.0" }
-reinhardt-views = { path = "crates/reinhardt-views", version = "0.1.0" }
-reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.1.0" }
-reinhardt-router = { path = "crates/reinhardt-router", version = "0.1.0" }
-reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.1.0" }
-reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.0" }
-reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.1.0" }
-reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.0" }
-reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.1.0" }
-reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.0" }
-reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.1.0" }
+reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.1.1" }
+reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.1.1" }
+reinhardt-core = { path = "crates/reinhardt-core", version = "0.1.1" }
+reinhardt-di = { path = "crates/reinhardt-di", version = "0.1.1" }
+reinhardt-http = { path = "crates/reinhardt-http", version = "0.1.1" }
+reinhardt-server = { path = "crates/reinhardt-server", version = "0.1.1" }
+reinhardt-views = { path = "crates/reinhardt-views", version = "0.1.1" }
+reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.1.1" }
+reinhardt-router = { path = "crates/reinhardt-router", version = "0.1.1" }
+reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.1.1" }
+reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.1.1" }
+reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.1.1" }
+reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.1.1" }
+reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.1.1" }
+reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.1.1" }
+reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.1.1" }
 reinhardt-testkit-macros = { path = "crates/reinhardt-testkit-macros", version = "0.1.0" }
-reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.0" }
-reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.0" }
-reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.1.0" }
-reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.0" }
-reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.0" }
-reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.0" }
-reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.0" }
-reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.1.0" }
-reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.0" }
-reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.0" }
-reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.0" }
-reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.0" }
-reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.0" }
-reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.0" }
-reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.0" }
-reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.1.0" }
-reinhardt-query = { path = "crates/reinhardt-query", version = "0.1.0" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.0" }
-reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.0" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.0" }
-reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.0" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.0" }
-reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.0" }
-reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.0" }
-reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.0" }
-reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.0" }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.1.1" }
+reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.1.1" }
+reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.1.1" }
+reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.1.1" }
+reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.1.1" }
+reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.1.1" }
+reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.1.1" }
+reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.1.1" }
+reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.1.1" }
+reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.1.1" }
+reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.1.1" }
+reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.1.1" }
+reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.1.1" }
+reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.1.1" }
+reinhardt-db = { path = "crates/reinhardt-db", version = "0.1.1" }
+reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.1.1" }
+reinhardt-query = { path = "crates/reinhardt-query", version = "0.1.1" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.1.1" }
+reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.1.1" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.1.1" }
+reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.1.1" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.1.1" }
+reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.1.1" }
+reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.1.1" }
+reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.1.1" }
+reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.1.1" }
 
 # Query subcrates
-reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.1.0" }
+reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.1.1" }
 
 # Core subcrates
-reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.0" }
+reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.1.1" }
 
 # DI subcrates
-reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.1.0" }
+reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.1.1" }
 
 # REST subcrates
-reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.1.0" }
+reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.1.1" }
 
 # REST subcrates (continued)
-reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.1.0" }
+reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.1.1" }
 
 # Streaming
 rskafka = { version = "0.5" }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you have written `ModelSerializer` or `Depends()` before, Reinhardt will feel
 
 <!-- reinhardt-version-sync -->
 ```bash
-# Currently a pre-release: --version is required. Once 0.1.0 stable ships,
+# Currently a pre-release: --version is required. Once 0.1.1 stable ships,
 # --version becomes optional (and acts as an opt-in reproducibility pin).
 cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
 
@@ -103,7 +103,7 @@ Reinhardt follows a **three-phase lifecycle** for every crate:
 | **Stable** (`0.x.0`) | Full SemVer 2.0 guarantees. |
 
 <!-- reinhardt-version-sync -->
-**Current status:** Reinhardt is at `0.1.0-rc.30`. From `0.1.0` onward, all
+**Current status:** Reinhardt is at `0.1.1`. From `0.1.0` onward, all
 public APIs follow SemVer 2.0; breaking changes ship in a future
 `0.2.0-rc.N` series coordinated through the `develop/0.2.0` branch.
 
@@ -127,7 +127,7 @@ Get a well-balanced feature set with zero configuration:
 [dependencies]
 # Import as 'reinhardt', published as 'reinhardt-web'
 # Default enables the "standard" preset (balanced feature set)
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web" }
+reinhardt = { version = "0.1.1", package = "reinhardt-web" }
 ```
 
 **Includes:** Core, Database (PostgreSQL), REST API (serializers, parsers, pagination, filters, throttling, versioning, metadata, content negotiation), Auth, Middleware (sessions), Pages (WASM Frontend with SSR), Signals
@@ -147,7 +147,7 @@ For projects that need every available component:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", default-features = false, features = ["full"] }
+reinhardt = { version = "0.1.1", package = "reinhardt-web", default-features = false, features = ["full"] }
 ```
 
 **Includes:** Everything in Standard, plus Admin, GraphQL, WebSockets, Cache, i18n, Mail, Static Files, Storage, and more
@@ -161,7 +161,7 @@ Lightweight and fast, perfect for simple APIs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+reinhardt = { version = "0.1.1", package = "reinhardt-web", default-features = false, features = ["minimal"] }
 ```
 
 **Includes:** HTTP, routing, DI, parameter extraction, server
@@ -176,24 +176,24 @@ Install only the components you need:
 ```toml
 [dependencies]
 # Core components
-reinhardt-http = "0.1.0-rc.30"
-reinhardt-urls = "0.1.0-rc.30"
+reinhardt-http = "0.1.1"
+reinhardt-urls = "0.1.1"
 
 # Optional: Database
-reinhardt-db = "0.1.0-rc.30"
+reinhardt-db = "0.1.1"
 
 # Optional: Authentication
-reinhardt-auth = "0.1.0-rc.30"
+reinhardt-auth = "0.1.1"
 
 # Optional: REST API features
-reinhardt-rest = "0.1.0-rc.30"
+reinhardt-rest = "0.1.1"
 
 # Optional: Admin panel
-reinhardt-admin = "0.1.0-rc.30"
+reinhardt-admin = "0.1.1"
 
 # Optional: Advanced features
-reinhardt-graphql = "0.1.0-rc.30"
-reinhardt-websockets = "0.1.0-rc.30"
+reinhardt-graphql = "0.1.1"
+reinhardt-websockets = "0.1.1"
 ```
 
 **Note on Crate Naming:**
@@ -213,7 +213,7 @@ below is auto-bumped by release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
+cargo install reinhardt-admin-cli --version "0.1.1"
 ```
 
 ### 2. Create a New Project

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.0...reinhardt-admin-cli@v0.1.1) - 2026-05-24
+
+### Fixed
+
+- *(admin-cli)* revert version to 0.1.0
+
+### Styling
+
+- *(admin-cli)* apply rustfmt to migrate_v2 codemod tests
+
 ## [0.1.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.0-rc.30...reinhardt-admin-cli@v0.1.0) - 2026-05-22
 
 Initial stable release of `reinhardt-admin-cli` as part of the

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-admin-cli/README.md
+++ b/crates/reinhardt-admin-cli/README.md
@@ -17,7 +17,7 @@ release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
+cargo install reinhardt-admin-cli --version "0.1.1"
 ```
 
 This installs the `reinhardt-admin` command.
@@ -86,7 +86,7 @@ reinhardt-admin plugin info auth-delion --remote
 
 # Install a plugin
 reinhardt-admin plugin install auth-delion
-reinhardt-admin plugin install auth-delion --version 0.1.0-rc.30
+reinhardt-admin plugin install auth-delion --version 0.1.1
 
 # Remove a plugin
 reinhardt-admin plugin remove auth-delion

--- a/crates/reinhardt-admin-cli/src/ast_formatter.rs
+++ b/crates/reinhardt-admin-cli/src/ast_formatter.rs
@@ -806,14 +806,14 @@ fn find_matching_brace(source: &str, start: usize) -> Option<usize> {
 			'"' => {
 				// Check for raw strings: r#"..."# or r"..."
 				let raw_start = detect_raw_string_start(substring, offset);
-				if let Some(hash_count) = raw_start {
-					if let Some(end_offset) = skip_raw_string(substring, offset + 1, hash_count) {
-						while i < chars.len() && chars[i].0 < end_offset {
-							i += 1;
-						}
-						i += 1; // skip past end
-						continue;
+				if let Some(hash_count) = raw_start
+					&& let Some(end_offset) = skip_raw_string(substring, offset + 1, hash_count)
+				{
+					while i < chars.len() && chars[i].0 < end_offset {
+						i += 1;
 					}
+					i += 1; // skip past end
+					continue;
 				}
 				in_string = true;
 			}
@@ -1530,7 +1530,7 @@ impl AstPageFormatter {
 
 		// Close brace
 		output.push_str(&self.make_indent(base_indent));
-		output.push_str("}");
+		output.push('}');
 
 		Ok(output)
 	}

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -15,7 +15,7 @@
 //!
 //! <!-- reinhardt-version-sync -->
 //! ```bash
-//! cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
+//! cargo install reinhardt-admin-cli --version "0.1.1"
 //! ```
 //!
 //! ## Usage

--- a/crates/reinhardt-admin-cli/src/migrate_v2.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2.rs
@@ -381,7 +381,7 @@ fn write_developer_file(path: &std::path::Path, content: &str) -> anyhow::Result
 			.duration_since(UNIX_EPOCH)
 			.unwrap_or_default()
 			.subsec_nanos();
-		nanos ^ (std::process::id() as u32)
+		nanos ^ std::process::id()
 	};
 	let tmp = parent.join(format!(".{file_name}.{random_suffix:x}.tmp")); // nosemgrep: path-traversal false positive — developer CLI bounded by --path root
 	if let Err(e) = std::fs::write(&tmp, content) {

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -34,10 +34,10 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:2 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["admin"] }
+reinhardt = { version = "0.1.1", features = ["admin"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }  # All features
+# reinhardt = { version = "0.1.1", features = ["full"] }  # All features
 ```
 
 Then import admin features:

--- a/crates/reinhardt-apps/Cargo.toml
+++ b/crates/reinhardt-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-apps"
-version = "0.1.0"
+version = "0.1.1"
 description = "Application registry and management for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-apps/README.md
+++ b/crates/reinhardt-apps/README.md
@@ -19,11 +19,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", features = ["apps"] }
+reinhardt = { version = "0.1.1", package = "reinhardt-web", features = ["apps"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", package = "reinhardt-web", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", package = "reinhardt-web", features = ["full"] }      # All features
 ```
 
 Then import app features:
@@ -53,7 +53,7 @@ installed_apps! {
 ```toml
 [dependencies]
 reinhardt = {
-	version = "0.1.0-rc.30",
+	version = "0.1.1",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "admin"]
 }
@@ -148,7 +148,7 @@ pub fn get_installed_apps() -> Vec<String> {
 ```toml
 [dependencies]
 reinhardt = {
-	version = "0.1.0-rc.30",
+	version = "0.1.1",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "admin", "static-files"]
 }
@@ -240,7 +240,7 @@ pub fn get_installed_apps() -> Vec<String> {
 # Cargo.toml
 [dependencies]
 reinhardt = {
-	version = "0.1.0-rc.30",
+	version = "0.1.1",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "database"]
 }
@@ -300,7 +300,7 @@ INSTALLED_APPS = [
 ```toml
 # Cargo.toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", features = ["auth", "admin"] }
+reinhardt = { version = "0.1.1", package = "reinhardt-web", features = ["auth", "admin"] }
 ```
 
 ```rust

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth"
-version = "0.1.0"
+version = "0.1.1"
 description = "Authentication and authorization system"
 keywords = ["auth", "jwt", "authentication", "django", "web"]
 categories = ["authentication", "web-programming"]

--- a/crates/reinhardt-auth/README.md
+++ b/crates/reinhardt-auth/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["auth"] }
+reinhardt = { version = "0.1.1", features = ["auth"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import authentication features:

--- a/crates/reinhardt-auth/macros/Cargo.toml
+++ b/crates/reinhardt-auth/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth-macros"
-version = "0.1.0"
+version = "0.1.1"
 description = "Procedural macros for reinhardt-auth (guard!)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-commands/CHANGELOG.md
+++ b/crates/reinhardt-commands/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0...reinhardt-commands@v0.1.1) - 2026-05-24
+
+### Added
+
+- *(commands)* add router dispatch to runserver
+
+### Fixed
+
+- *(commands)* call auto_register_router before runserver starts
+- *(runserver)* address CodeRabbit review — 413 on body overflow + real peer addr
+
 ## [0.1.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.0-rc.30...reinhardt-commands@v0.1.0) - 2026-05-22
 
 Initial stable release of `reinhardt-commands` as part of the

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-commands"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["commands"] }
+reinhardt = { version = "0.1.1", features = ["commands"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import command features:
@@ -37,7 +37,7 @@ package:
 
 <!-- reinhardt-version-sync -->
 ```bash
-# Pre-release: --version is required. Once 0.1.0 stable ships, --version
+# Pre-release: --version is required. Once 0.1.1 stable ships, --version
 # becomes optional. The literal below is auto-bumped by release-plz.
 cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
 ```
@@ -128,7 +128,7 @@ use reinhardt::commands::TemplateContext;
 
 let mut context = TemplateContext::new();
 context.insert("project_name", "my_project");
-context.insert("version", "0.1.0-rc.30");
+context.insert("version", "0.1.1");
 context.insert("features", vec!["auth", "admin"]);  // Any Serialize type
 ```
 
@@ -233,7 +233,7 @@ Projects using `collect_migrations!` must add `linkme` as a dependency:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }
+reinhardt = { version = "0.1.1", features = ["standard"] }
 linkme = "0.3"
 ```
 

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-conf"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -29,11 +29,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["conf"] }
+reinhardt = { version = "0.1.1", features = ["conf"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import configuration features:
@@ -52,13 +52,13 @@ Enable specific features based on your needs:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 # With async support
-reinhardt = { version = "0.1.0-rc.30", features = ["conf", "async"] }
+reinhardt = { version = "0.1.1", features = ["conf", "async"] }
 
 # With encryption
-reinhardt = { version = "0.1.0-rc.30", features = ["conf", "encryption"] }
+reinhardt = { version = "0.1.1", features = ["conf", "encryption"] }
 
 # With Vault integration
-reinhardt = { version = "0.1.0-rc.30", features = ["conf", "vault"] }
+reinhardt = { version = "0.1.1", features = ["conf", "vault"] }
 ```
 
 Available features:

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-core"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-core/README.md
+++ b/crates/reinhardt-core/README.md
@@ -90,7 +90,7 @@ Add this to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-core = "0.1.0-rc.30"
+reinhardt-core = "0.1.1"
 ```
 
 ### Optional Features
@@ -100,7 +100,7 @@ Enable specific modules based on your needs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-core = { version = "0.1.0-rc.30", features = ["signals", "macros", "security"] }
+reinhardt-core = { version = "0.1.1", features = ["signals", "macros", "security"] }
 ```
 
 Available features:

--- a/crates/reinhardt-core/macros/Cargo.toml
+++ b/crates/reinhardt-core/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db-macros/Cargo.toml
+++ b/crates/reinhardt-db-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db/Cargo.toml
+++ b/crates/reinhardt-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -155,7 +155,7 @@ Add this to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-db = "0.1.0-rc.30"
+reinhardt-db = "0.1.1"
 ```
 
 ### Optional Features
@@ -165,7 +165,7 @@ Enable specific features based on your needs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-db = { version = "0.1.0-rc.30", features = ["postgres", "orm", "migrations"] }
+reinhardt-db = { version = "0.1.1", features = ["postgres", "orm", "migrations"] }
 ```
 
 Available features:

--- a/crates/reinhardt-deeplink/Cargo.toml
+++ b/crates/reinhardt-deeplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-deeplink"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/Cargo.toml
+++ b/crates/reinhardt-dentdelion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dentdelion"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/README.md
+++ b/crates/reinhardt-dentdelion/README.md
@@ -22,11 +22,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["dentdelion"] }
+reinhardt = { version = "0.1.1", features = ["dentdelion"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import dentdelion features:
@@ -62,7 +62,7 @@ pub struct MyPlugin {
 impl MyPlugin {
     pub fn new() -> Self {
         Self {
-            metadata: PluginMetadata::builder("my-plugin", "0.1.0-rc.30")
+            metadata: PluginMetadata::builder("my-plugin", "0.1.1")
                 .description("My custom plugin")
                 .author("Your Name")
                 .build()
@@ -225,7 +225,7 @@ Dentdelion uses the WebAssembly Interface Types (WIT) standard for plugin interf
 
 <!-- reinhardt-version-sync -->
 ```wit
-package reinhardt:dentdelion@0.1.0-rc.30;
+package reinhardt:dentdelion@0.1.1;
 
 // Host functions available to plugins
 interface host {

--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "reinhardt-di"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-di/README.md
+++ b/crates/reinhardt-di/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["di"] }
+reinhardt = { version = "0.1.1", features = ["di"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import DI features:

--- a/crates/reinhardt-di/macros/Cargo.toml
+++ b/crates/reinhardt-di/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-di-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-dispatch/Cargo.toml
+++ b/crates/reinhardt-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dispatch"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dispatch/README.md
+++ b/crates/reinhardt-dispatch/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["dispatch"] }
+reinhardt = { version = "0.1.1", features = ["dispatch"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import dispatch features:

--- a/crates/reinhardt-forms/Cargo.toml
+++ b/crates/reinhardt-forms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-forms"
-version = "0.1.0"
+version = "0.1.1"
 description = "Form handling and validation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-forms/README.md
+++ b/crates/reinhardt-forms/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["forms"] }
+reinhardt = { version = "0.1.1", features = ["forms"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 
 # Forms is included in the standard preset
 ```

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.1.0"
+version = "0.1.1"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-graphql/README.md
+++ b/crates/reinhardt-graphql/README.md
@@ -107,11 +107,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["graphql"] }
+reinhardt = { version = "0.1.1", features = ["graphql"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import GraphQL features:
@@ -128,10 +128,10 @@ use reinhardt::graphql::types::{UserStorage, UserEvent};
 <!-- reinhardt-version-sync:2 -->
 ```toml
 # With dependency injection
-reinhardt = { version = "0.1.0-rc.30", features = ["graphql", "di"] }
+reinhardt = { version = "0.1.1", features = ["graphql", "di"] }
 
 # With gRPC transport
-reinhardt = { version = "0.1.0-rc.30", features = ["graphql", "grpc"] }
+reinhardt = { version = "0.1.1", features = ["graphql", "grpc"] }
 ```
 
 ## Examples
@@ -270,7 +270,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Server::builder()
         .add_service(grpc_service)
-        .serve("0.1.0-rc.30:50051".parse()?)
+        .serve("0.1.1:50051".parse()?)
         .await?;
 
     Ok(())
@@ -288,7 +288,7 @@ use reinhardt::grpc::proto::graphql::{
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = GraphQlServiceClient::connect("http://0.1.0-rc.30:50051").await?;
+    let mut client = GraphQlServiceClient::connect("http://0.1.1:50051").await?;
 
     let request = tonic::Request::new(GraphQlRequest {
         query: r#"{ hello(name: "gRPC") }"#.to_string(),

--- a/crates/reinhardt-graphql/macros/Cargo.toml
+++ b/crates/reinhardt-graphql/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql-macros"
-version = "0.1.0"
+version = "0.1.1"
 description = "Procedural macros for GraphQL schema generation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc"
-version = "0.1.0"
+version = "0.1.1"
 description = "gRPC support for building RPC services"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/README.md
+++ b/crates/reinhardt-grpc/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["grpc"] }
+reinhardt = { version = "0.1.1", features = ["grpc"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import gRPC features:
@@ -160,7 +160,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-grpc = "0.1.0-rc.30"
+reinhardt-grpc = "0.1.1"
 tonic = "0.12"
 prost = "0.13"
 
@@ -193,8 +193,8 @@ Enable the `di` feature to use dependency injection in gRPC handlers:
 <!-- reinhardt-version-sync:2 -->
 ```toml
 [dependencies]
-reinhardt-grpc = { version = "0.1.0-rc.30", features = ["di"] }
-reinhardt-di = "0.1.0-rc.30"
+reinhardt-grpc = { version = "0.1.1", features = ["di"] }
+reinhardt-di = "0.1.1"
 ```
 
 #### Basic Usage

--- a/crates/reinhardt-grpc/macros/Cargo.toml
+++ b/crates/reinhardt-grpc/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-http/Cargo.toml
+++ b/crates/reinhardt-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-http"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-http/README.md
+++ b/crates/reinhardt-http/README.md
@@ -87,11 +87,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = "0.1.0-rc.30"
+reinhardt = "0.1.1"
 
 # Or use a preset with parsers support:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 **Note:** HTTP types are available through the main `reinhardt` crate, which provides a unified interface to all framework components.

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.1.0"
+version = "0.1.1"
 description = "Internationalization and localization support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-i18n/README.md
+++ b/crates/reinhardt-i18n/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["i18n"] }
+reinhardt = { version = "0.1.1", features = ["i18n"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import i18n features:

--- a/crates/reinhardt-mail/Cargo.toml
+++ b/crates/reinhardt-mail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-mail"
-version = "0.1.0"
+version = "0.1.1"
 description = "Email sending functionality with multiple backends"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-mail/README.md
+++ b/crates/reinhardt-mail/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["mail"] }
+reinhardt = { version = "0.1.1", features = ["mail"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import mail features:

--- a/crates/reinhardt-manouche/Cargo.toml
+++ b/crates/reinhardt-manouche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-manouche"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-manouche/src/core/head_node.rs
+++ b/crates/reinhardt-manouche/src/core/head_node.rs
@@ -42,7 +42,7 @@ pub enum HeadContent {
 	/// Text content (for title)
 	Text(String),
 	/// Expression content
-	Expr(Expr),
+	Expr(Box<Expr>),
 }
 
 /// Typed version of HeadMacro after validation.
@@ -84,5 +84,5 @@ pub enum TypedHeadContent {
 	/// Static text content
 	Static(String),
 	/// Dynamic expression content
-	Dynamic(Expr),
+	Dynamic(Box<Expr>),
 }

--- a/crates/reinhardt-manouche/src/core/node.rs
+++ b/crates/reinhardt-manouche/src/core/node.rs
@@ -127,9 +127,9 @@ pub enum PageNode {
 	/// A Rust expression that produces IntoView (e.g., `name` or `format!(...)`)
 	Expression(PageExpression),
 	/// Conditional rendering (e.g., `if condition { ... }`)
-	If(PageIf),
+	If(Box<PageIf>),
 	/// List rendering (e.g., `for item in items { ... }`)
-	For(PageFor),
+	For(Box<PageFor>),
 	/// A component call (e.g., `MyButton(label: "Click")`)
 	Component(PageComponent),
 	/// Reactive watch block (e.g., `watch { if signal.get() { ... } }`)

--- a/crates/reinhardt-manouche/src/core/typed_node.rs
+++ b/crates/reinhardt-manouche/src/core/typed_node.rs
@@ -50,9 +50,9 @@ pub enum TypedPageNode {
 	/// A Rust expression
 	Expression(PageExpression),
 	/// Conditional rendering
-	If(TypedPageIf),
+	If(Box<TypedPageIf>),
 	/// List rendering
-	For(TypedPageFor),
+	For(Box<TypedPageFor>),
 	/// A component call with typed children
 	Component(TypedPageComponent),
 	/// Reactive watch block

--- a/crates/reinhardt-manouche/src/core/types.rs
+++ b/crates/reinhardt-manouche/src/core/types.rs
@@ -37,7 +37,7 @@ pub enum AttrValue {
 	FloatLit(LitFloat),
 
 	/// Dynamic expression: variables, function calls, etc.
-	Dynamic(Expr),
+	Dynamic(Box<Expr>),
 }
 
 impl AttrValue {
@@ -78,9 +78,9 @@ impl AttrValue {
 				Lit::Bool(b) => Self::BoolLit(b),
 				Lit::Int(i) => Self::IntLit(i),
 				Lit::Float(f) => Self::FloatLit(f),
-				_ => Self::Dynamic(Expr::Lit(ExprLit { attrs: vec![], lit })),
+				_ => Self::Dynamic(Box::new(Expr::Lit(ExprLit { attrs: vec![], lit }))),
 			},
-			_ => Self::Dynamic(expr),
+			_ => Self::Dynamic(Box::new(expr)),
 		}
 	}
 
@@ -178,7 +178,7 @@ impl AttrValue {
 				attrs: vec![],
 				lit: Lit::Float(f.clone()),
 			}),
-			Self::Dynamic(e) => e.clone(),
+			Self::Dynamic(e) => (**e).clone(),
 		}
 	}
 

--- a/crates/reinhardt-manouche/src/parser/head.rs
+++ b/crates/reinhardt-manouche/src/parser/head.rs
@@ -123,7 +123,7 @@ fn parse_title_content(input: ParseStream) -> syn::Result<(Vec<HeadAttr>, Option
 	{
 		HeadContent::Text(s.value())
 	} else {
-		HeadContent::Expr(expr)
+		HeadContent::Expr(Box::new(expr))
 	};
 
 	Ok((Vec::new(), Some(content)))
@@ -141,7 +141,7 @@ fn parse_style_content(input: ParseStream) -> syn::Result<(Vec<HeadAttr>, Option
 	{
 		HeadContent::Text(s.value())
 	} else {
-		HeadContent::Expr(expr)
+		HeadContent::Expr(Box::new(expr))
 	};
 
 	Ok((Vec::new(), Some(content)))

--- a/crates/reinhardt-manouche/src/parser/page.rs
+++ b/crates/reinhardt-manouche/src/parser/page.rs
@@ -385,7 +385,7 @@ fn parse_if_node(input: ParseStream) -> Result<PageNode> {
 			// else if
 			let else_if = parse_if_node(input)?;
 			match else_if {
-				PageNode::If(if_node) => Some(PageElse::If(Box::new(if_node))),
+				PageNode::If(if_node) => Some(PageElse::If(if_node)),
 				_ => unreachable!(),
 			}
 		} else {
@@ -399,12 +399,12 @@ fn parse_if_node(input: ParseStream) -> Result<PageNode> {
 		None
 	};
 
-	Ok(PageNode::If(PageIf {
+	Ok(PageNode::If(Box::new(PageIf {
 		condition,
 		then_branch,
 		else_branch,
 		span,
-	}))
+	})))
 }
 
 /// Parses a condition expression (stops at opening brace).
@@ -442,12 +442,12 @@ fn parse_for_node(input: ParseStream) -> Result<PageNode> {
 	braced!(content in input);
 	let body = parse_nodes(&content)?;
 
-	Ok(PageNode::For(PageFor {
+	Ok(PageNode::For(Box::new(PageFor {
 		pat,
 		iter,
 		body,
 		span,
-	}))
+	})))
 }
 
 /// Parses a watch node: `watch { expr }`

--- a/crates/reinhardt-manouche/src/validator/page.rs
+++ b/crates/reinhardt-manouche/src/validator/page.rs
@@ -85,8 +85,14 @@ fn transform_node(node: &PageNode, parent_tags: &[String]) -> Result<TypedPageNo
 		)?)),
 		PageNode::Text(text) => Ok(TypedPageNode::Text(text.clone())),
 		PageNode::Expression(expr) => Ok(TypedPageNode::Expression(expr.clone())),
-		PageNode::If(if_node) => Ok(TypedPageNode::If(transform_if(if_node, parent_tags)?)),
-		PageNode::For(for_node) => Ok(TypedPageNode::For(transform_for(for_node, parent_tags)?)),
+		PageNode::If(if_node) => Ok(TypedPageNode::If(Box::new(transform_if(
+			if_node,
+			parent_tags,
+		)?))),
+		PageNode::For(for_node) => Ok(TypedPageNode::For(Box::new(transform_for(
+			for_node,
+			parent_tags,
+		)?))),
 		PageNode::Component(comp) => Ok(TypedPageNode::Component(transform_component(
 			comp,
 			parent_tags,

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-middleware"
-version = "0.1.0"
+version = "0.1.1"
 description = "Middleware system for request/response processing pipeline"
 keywords = ["middleware", "web", "cors", "security", "http"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-middleware/README.md
+++ b/crates/reinhardt-middleware/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["middleware"] }
+reinhardt = { version = "0.1.1", features = ["middleware"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import middleware features:

--- a/crates/reinhardt-openapi/Cargo.toml
+++ b/crates/reinhardt-openapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/ast/Cargo.toml
+++ b/crates/reinhardt-pages/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-ast"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/macros/Cargo.toml
+++ b/crates/reinhardt-pages/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/macros/src/page/validator.rs
+++ b/crates/reinhardt-pages/macros/src/page/validator.rs
@@ -105,8 +105,14 @@ fn transform_node(node: &PageNode, parent_tags: &[String]) -> Result<TypedPageNo
 		)?)),
 		PageNode::Text(text) => Ok(TypedPageNode::Text(text.clone())),
 		PageNode::Expression(expr) => Ok(TypedPageNode::Expression(expr.clone())),
-		PageNode::If(if_node) => Ok(TypedPageNode::If(transform_if(if_node, parent_tags)?)),
-		PageNode::For(for_node) => Ok(TypedPageNode::For(transform_for(for_node, parent_tags)?)),
+		PageNode::If(if_node) => Ok(TypedPageNode::If(Box::new(transform_if(
+			if_node,
+			parent_tags,
+		)?))),
+		PageNode::For(for_node) => Ok(TypedPageNode::For(Box::new(transform_for(
+			for_node,
+			parent_tags,
+		)?))),
 		PageNode::Component(comp) => Ok(TypedPageNode::Component(transform_component(
 			comp,
 			parent_tags,

--- a/crates/reinhardt-query/Cargo.toml
+++ b/crates/reinhardt-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-query/README.md
+++ b/crates/reinhardt-query/README.md
@@ -44,7 +44,7 @@ Add to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-query = { version = "0.1.0-rc.30" }
+reinhardt-query = { version = "0.1.1" }
 ```
 
 ## Quick Start

--- a/crates/reinhardt-query/macros/Cargo.toml
+++ b/crates/reinhardt-query/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-rest/Cargo.toml
+++ b/crates/reinhardt-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-rest"
-version = "0.1.0"
+version = "0.1.1"
 description = "REST API framework aggregator for Reinhardt"
 keywords = ["rest", "api", "web", "framework", "django"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-rest/README.md
+++ b/crates/reinhardt-rest/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["rest"] }
+reinhardt = { version = "0.1.1", features = ["rest"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import REST features:

--- a/crates/reinhardt-rest/openapi-macros/Cargo.toml
+++ b/crates/reinhardt-rest/openapi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-router/Cargo.toml
+++ b/crates/reinhardt-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-router"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-server/Cargo.toml
+++ b/crates/reinhardt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-server"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-server/README.md
+++ b/crates/reinhardt-server/README.md
@@ -44,17 +44,17 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:5 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["server"] }
+reinhardt = { version = "0.1.1", features = ["server"] }
 
 # For WebSocket support:
-# reinhardt = { version = "0.1.0-rc.30", features = ["server", "websocket"] }
+# reinhardt = { version = "0.1.1", features = ["server", "websocket"] }
 
 # For GraphQL support:
-# reinhardt = { version = "0.1.0-rc.30", features = ["server", "graphql"] }
+# reinhardt = { version = "0.1.1", features = ["server", "graphql"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import server features:
@@ -85,7 +85,7 @@ async fn my_handler(req: Request) -> Result<Response, Error> {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let handler = Arc::new(my_handler);
-    serve("0.1.0-rc.30:8000", handler).await?;
+    serve("0.1.1:8000", handler).await?;
     Ok(())
 }
 ```
@@ -128,7 +128,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = HttpServer::new(handler)
         .with_middleware(middleware);
 
-    server.listen("0.1.0-rc.30:8000".parse()?).await?;
+    server.listen("0.1.1:8000".parse()?).await?;
     Ok(())
 }
 ```
@@ -161,7 +161,7 @@ impl WebSocketHandler for EchoHandler {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let handler = Arc::new(EchoHandler);
     let server = WebSocketServer::new(handler);
-    server.listen("0.1.0-rc.30:9001".parse()?).await?;
+    server.listen("0.1.1:9001".parse()?).await?;
     Ok(())
 }
 ```
@@ -199,7 +199,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    server.listen("0.1.0-rc.30:9001".parse()?).await?;
+    server.listen("0.1.1:9001".parse()?).await?;
     Ok(())
 }
 ```
@@ -226,7 +226,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .finish();
 
     let handler = graphql_handler(schema);
-    serve("0.1.0-rc.30:8000", handler).await?;
+    serve("0.1.1:8000", handler).await?;
     Ok(())
 }
 ```

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-shortcuts/README.md
+++ b/crates/reinhardt-shortcuts/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["shortcuts"] }
+reinhardt = { version = "0.1.1", features = ["shortcuts"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import shortcuts features:

--- a/crates/reinhardt-streaming/Cargo.toml
+++ b/crates/reinhardt-streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-streaming"
-version = "0.1.0"
+version = "0.1.1"
 description = "Backend-agnostic streaming abstraction with Kafka support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-tasks/Cargo.toml
+++ b/crates/reinhardt-tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-tasks"
-version = "0.1.0"
+version = "0.1.1"
 description = "Background task execution and scheduling"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-tasks/README.md
+++ b/crates/reinhardt-tasks/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["tasks"] }
+reinhardt = { version = "0.1.1", features = ["tasks"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import task features:

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-test"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-test/README.md
+++ b/crates/reinhardt-test/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["test"] }
+reinhardt = { version = "0.1.1", features = ["test"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import testing features:

--- a/crates/reinhardt-testkit/Cargo.toml
+++ b/crates/reinhardt-testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-throttling/Cargo.toml
+++ b/crates/reinhardt-throttling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-throttling"
-version = "0.1.0"
+version = "0.1.1"
 description = "Throttling and rate limiting for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-urls"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-urls/README.md
+++ b/crates/reinhardt-urls/README.md
@@ -53,14 +53,14 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:4 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["urls"] }
+reinhardt = { version = "0.1.1", features = ["urls"] }
 
 # For specific sub-features:
-# reinhardt = { version = "0.1.0-rc.30", features = ["urls-routers", "urls-proxy"] }
+# reinhardt = { version = "0.1.1", features = ["urls-routers", "urls-proxy"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import URLs features:

--- a/crates/reinhardt-urls/routers-macros/Cargo.toml
+++ b/crates/reinhardt-urls/routers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-routers-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-utils"
-version = "0.1.0"
+version = "0.1.1"
 description = "Utility functions aggregator for Reinhardt"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-utils/README.md
+++ b/crates/reinhardt-utils/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["utils"] }
+reinhardt = { version = "0.1.1", features = ["utils"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import utility features:
@@ -323,7 +323,7 @@ logger.log_security_error(&SecurityError::CsrfViolation);  // ERROR level
 logger.log_csrf_violation("http://evil.com");
 
 // Log rate limit exceeded
-logger.log_rate_limit_exceeded("0.1.0-rc.30", 100);
+logger.log_rate_limit_exceeded("0.1.1", 100);
 
 // Log suspicious file operations
 logger.log_suspicious_file_operation("delete", Path::new("/etc/passwd"));

--- a/crates/reinhardt-views/Cargo.toml
+++ b/crates/reinhardt-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-views"
-version = "0.1.0"
+version = "0.1.1"
 description = "View layer aggregator for viewsets and views-core"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-views/README.md
+++ b/crates/reinhardt-views/README.md
@@ -17,11 +17,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["views"] }
+reinhardt = { version = "0.1.1", features = ["views"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import view features:
@@ -262,7 +262,7 @@ use reinhardt::views::{OpenAPISpec, Info, PathItem, Operation};
 
 let spec = OpenAPISpec::new(Info::new(
     "My API".into(),
-    "0.1.0-rc.30".into()
+    "0.1.1".into()
 ));
 ```
 

--- a/crates/reinhardt-websockets/Cargo.toml
+++ b/crates/reinhardt-websockets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-websockets"
-version = "0.1.0"
+version = "0.1.1"
 description = "WebSocket support for real-time bidirectional communication"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-websockets/README.md
+++ b/crates/reinhardt-websockets/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", features = ["websockets"] }
+reinhardt = { version = "0.1.1", features = ["websockets"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.1.0-rc.30", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.1.0-rc.30", features = ["full"] }      # All features
+# reinhardt = { version = "0.1.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.1.1", features = ["full"] }      # All features
 ```
 
 Then import WebSocket features:

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -36,7 +36,7 @@ By default, examples use published versions from crates.io:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", features = ["standard"] }
+reinhardt = { version = "0.1.1", package = "reinhardt-web", features = ["standard"] }
 ```
 
 ### Local Development Mode
@@ -70,7 +70,7 @@ rm -f .cargo/config.toml
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", features = ["core", "database"] }
+reinhardt = { version = "0.1.1", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine
 tokio = { workspace = true }
@@ -86,7 +86,7 @@ rstest = "0.26.1"
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", features = ["core"] }
+reinhardt = { version = "0.1.1", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER
 reinhardt-di = { path = "../../../crates/reinhardt-di" }          # ❌ NEVER

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 [workspace.dependencies]
 # Reinhardt framework (crates.io published versions)
 # reinhardt-version-sync
-reinhardt = { version = "0.1.0", package = "reinhardt-web" }
+reinhardt = { version = "0.1.1", package = "reinhardt-web" }
 
 # Testing
 testcontainers = { version = "0.27.2", features = ["blocking"] }

--- a/website/config.toml
+++ b/website/config.toml
@@ -27,4 +27,4 @@ docs_rs     = "https://docs.rs/reinhardt-web"
 changelog   = "https://github.com/kent8192/reinhardt-web/blob/main/CHANGELOG.md"
 deepwiki    = "https://deepwiki.com/kent8192/reinhardt-web"
 # reinhardt-version-sync
-reinhardt_version = "0.1.0-rc.30"
+reinhardt_version = "0.1.1"

--- a/website/content/quickstart/_index.md
+++ b/website/content/quickstart/_index.md
@@ -19,7 +19,7 @@ pin). The literal below is auto-bumped by release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
+cargo install reinhardt-admin-cli --version "0.1.1"
 ```
 
 ## 2. Create your project

--- a/website/content/quickstart/getting-started.md
+++ b/website/content/quickstart/getting-started.md
@@ -33,7 +33,7 @@ pin). The literal below is auto-bumped by release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
+cargo install reinhardt-admin-cli --version "0.1.1"
 ```
 
 **Note:** After installation, the command is `reinhardt-admin`, not

--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -33,7 +33,7 @@ Install the global tool for project generation. While Reinhardt is on a pre-rele
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
+cargo install reinhardt-admin-cli --version "0.1.1"
 ```
 
 ## Creating a Project

--- a/website/content/quickstart/tutorials/rest/quickstart.md
+++ b/website/content/quickstart/tutorials/rest/quickstart.md
@@ -21,7 +21,7 @@ release-plz on each release.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
+cargo install reinhardt-admin-cli --version "0.1.1"
 ```
 
 **Note:** After installation, the command is `reinhardt-admin`, not `reinhardt-admin-cli`.


### PR DESCRIPTION
## Summary

Replace the loose `contains(github.event.head_commit.message, 'release-plz-')` check in `release-plz-release` job with three-layer defense to prevent accidental crates.io publishing.

### Problem

The previous `contains()` check matched ANY commit or branch name containing "release-plz-" including:
- `feat: add release-plz config` (feature commit)
- `feature/release-plz-migration` (non-release branch)
- `fix/release-plz-typo` (non-release branch)

This meant any PR merged from a branch whose name happened to contain "release-plz-" would trigger a publish attempt.

### Solution: Three-Layer Defense

1. **`if:` condition** (line 253): `contains(...)` → `startsWith(github.event.head_commit.message, 'Merge pull request #')` — gates on merge commit format only, eliminating false positives from squash-merge commit messages
2. **"Verify release branch name" step** (NEW, lines 296-318): Extracts branch name from merge commit message via `grep -oP` and validates exact prefix match (`release-plz-*` or `develop-release-plz-*`) using `case` pattern matching
3. **"Verify release PR label" step** (NEW, lines 320-340): Extracts PR number from merge commit and verifies the `release` label is present via `gh pr view --json labels`

### Verification Matrix

| Commit Message | Extracted Branch | Branch Check | Label Check | Result |
|---|---|---|---|---|
| `Merge pull request #123 from kent8192/release-plz-v0.2.0` | `release-plz-v0.2.0` | ✅ | ✅ (has `release` label) | ✅ Publish |
| `Merge pull request #123 from kent8192/develop-release-plz-v0.3.0` | `develop-release-plz-v0.3.0` | ✅ | ✅ (has `release` label) | ✅ Publish |
| `Merge pull request #456 from kent8192/feature/release-plz-migration` | `feature/release-plz-migration` | ❌ | — | ❌ Refused |
| `Merge pull request #789 from kent8192/fix/release-plz-typo` | `fix/release-plz-typo` | ❌ | — | ❌ Refused |
| `chore: release v0.2.0` (squash merge) | (skipped) | N/A | N/A | ✅ Publish |
| Push to `main` | (skipped) | N/A | N/A | ✅ Publish |

### Security Hardening

- Uses `env:` to pass `github.event.head_commit.message` into shell scripts instead of direct `${{ }}` interpolation in `run:` blocks

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

Prevents accidental crates.io publishes when non-release branches containing "release-plz-" in their name are merged. release-plz's `release` command publishes all crates whose local version differs from crates.io, so a false-trigger would publish whatever versions are in the workspace at that time.

## How Was This Tested?

- Manual review of the grep patterns against all cases in the verification matrix above
- `if:` condition verified against GitHub Actions expression syntax (`startsWith` is built-in)
- Shell injection hardening: `github.event.head_commit.message` passed via `env:` not direct interpolation

## Checklist

- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (N/A — workflow comments updated)
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added router dispatch to `runserver` command functionality.

* **Bug Fixes**
  * Fixed router auto-registration to occur before `runserver` startup.
  * Improved HTTP request handling for oversized payloads.
  * Corrected server address handling to use actual peer addresses.
  * Applied code formatting standards across codebase.

* **Chores**
  * Released version 0.1.1 across all packages and documentation.
  * Enhanced release workflow verification with additional PR label and branch checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->