### PR TITLE
fix(ci): strengthen release-plz publish gate with branch name and PR label verification

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -232,22 +232,17 @@ jobs:
     # On develop/**, gate the job on Release-PR-merge commits to avoid
     # spinning up a self-hosted runner + cargo registry sync for every
     # routine feat/fix push (where Cargo.toml is unchanged and publish would
-    # always skip). Two commit-message shapes are accepted to cover both
-    # GitHub merge strategies:
+    # always skip). Three commit-message shapes are accepted:
     #
     #   - squash-merge → `chore: release ...` or `chore: release (develop) ...`
     #     (release-plz's `pr_name`; develop uses "chore: release (develop)" to
-    #     distinguish Release PR titles from main)
-    #   - regular merge → `Merge pull request #N from .../release-plz-...` or
-    #     `.../develop-release-plz-...` (branch-specific `pr_branch_prefix`;
-    #     both contain `release-plz-` so the `contains()` check matches both)
-    #
-    # `startsWith()` is used for the squash-merge form so we don't false-match
-    # arbitrary commits that happen to contain the substring `chore: release`
-    # in their body (e.g. `feat: add release-plz-compatible versioning`).
-    # `contains()` is retained for the merge-commit form because the GitHub
-    # default subject is `Merge pull request #N from <repo>/release-plz-...`,
-    # which doesn't start with the release-plz marker.
+    #     distinguish Release PR titles from main). `startsWith()` avoids
+    #     false-matching `feat: add release-plz-compatible versioning`.
+    #   - regular merge → `Merge pull request #N from owner/BRANCH` where
+    #     BRANCH starts with `release-plz-` or `develop-release-plz-`.
+    #     The `if:` condition only checks the `Merge pull request #` prefix;
+    #     the actual branch name prefix is validated in the "Verify release
+    #     branch name" step below using `grep -oP` + `case` matching.
     #
     # release-plz-pr (above) still runs on every develop/** push, so the
     # next Release PR is always kept up to date.
@@ -255,7 +250,7 @@ jobs:
       github.event_name == 'push' && (
         github.ref == 'refs/heads/main' ||
         startsWith(github.event.head_commit.message, 'chore: release') ||
-        contains(github.event.head_commit.message, 'release-plz-')
+        startsWith(github.event.head_commit.message, 'Merge pull request #')
       )
     runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
     timeout-minutes: 360
@@ -297,6 +292,52 @@ jobs:
             sudo apt-get update -qq -o DPkg::Lock::Timeout=120
             sudo apt-get install -y -o DPkg::Lock::Timeout=120 gh
           fi
+
+      - name: Verify release branch name
+        if: github.ref != 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore: release')
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          # Extract branch name from merge commit message.
+          # Format: "Merge pull request #N from owner/BRANCH_NAME"
+          BRANCH=$(echo "$COMMIT_MSG" | grep -oP 'from [^/]+/\K.+$' || true)
+          if [ -z "$BRANCH" ]; then
+            echo "::error::Could not extract branch name from commit message"
+            exit 1
+          fi
+          echo "Extracted branch name: $BRANCH"
+          case "$BRANCH" in
+            release-plz-*|develop-release-plz-*)
+              echo "Branch '$BRANCH' matches release branch pattern"
+              ;;
+            *)
+              echo "::error::Branch '$BRANCH' does not start with 'release-plz-' or 'develop-release-plz-'"
+              echo "::error::This push does not originate from a release-plz branch. Refusing to publish."
+              exit 1
+              ;;
+          esac
+
+      - name: Verify release PR label
+        if: github.ref != 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore: release')
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          # Extract PR number from merge commit message.
+          # Format: "Merge pull request #N from owner/BRANCH_NAME"
+          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '^Merge pull request #\K\d+' || true)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Could not extract PR number from commit message"
+            exit 1
+          fi
+          echo "Verifying PR #$PR_NUMBER has the 'release' label..."
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+          if ! echo "$LABELS" | grep -qx 'release'; then
+            echo "::error::PR #$PR_NUMBER does not have the 'release' label. Labels found: $LABELS"
+            echo "::error::Only PRs with the 'release' label are allowed to publish. Refusing to publish."
+            exit 1
+          fi
+          echo "PR #$PR_NUMBER has the 'release' label — proceeding with publish"
 
       # Workaround for gix slotmap overflow (GitoxideLabs/gitoxide#1788)
       - name: Clear cargo registry git index cache

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -294,7 +294,7 @@ jobs:
           fi
 
       - name: Verify release branch name
-        if: github.ref != 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore: release')
+        if: "github.ref != 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore: release')"
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
@@ -318,7 +318,7 @@ jobs:
           esac
 
       - name: Verify release PR label
-        if: github.ref != 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore: release')
+        if: "github.ref != 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore: release')"
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -229,28 +229,19 @@ jobs:
     # release_always=true (KI-5 phantom-version-bump fix) means release-plz
     # itself decides whether to publish based on Cargo.toml vs crates.io.
     #
-    # On develop/**, gate the job on Release-PR-merge commits to avoid
-    # spinning up a self-hosted runner + cargo registry sync for every
-    # routine feat/fix push (where Cargo.toml is unchanged and publish would
-    # always skip). Three commit-message shapes are accepted:
-    #
-    #   - squash-merge → `chore: release ...` or `chore: release (develop) ...`
-    #     (release-plz's `pr_name`; develop uses "chore: release (develop)" to
-    #     distinguish Release PR titles from main). `startsWith()` avoids
-    #     false-matching `feat: add release-plz-compatible versioning`.
-    #   - regular merge → `Merge pull request #N from owner/BRANCH` where
-    #     BRANCH starts with `release-plz-` or `develop-release-plz-`.
-    #     The `if:` condition only checks the `Merge pull request #` prefix;
-    #     the actual branch name prefix is validated in the "Verify release
-    #     branch name" step below using `grep -oP` + `case` matching.
+    # On develop/**, only squash-merge Release PR commits ("chore: release")
+    # trigger the job. The merge-commit trigger is intentionally NOT included
+    # because startsWith(commit.message, 'Merge pull request #') would also
+    # match regular feature-PR merges on develop/**, which would then fail
+    # at the branch-name verification step. Release-plz PRs should be
+    # squash-merged (MP-2), producing "chore: release" covered here.
     #
     # release-plz-pr (above) still runs on every develop/** push, so the
     # next Release PR is always kept up to date.
     if: |
       github.event_name == 'push' && (
         github.ref == 'refs/heads/main' ||
-        startsWith(github.event.head_commit.message, 'chore: release') ||
-        startsWith(github.event.head_commit.message, 'Merge pull request #')
+        startsWith(github.event.head_commit.message, 'chore: release')
       )
     runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
     timeout-minutes: 360
@@ -294,7 +285,7 @@ jobs:
           fi
 
       - name: Verify release branch name
-        if: "github.ref != 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore: release')"
+        if: startsWith(github.event.head_commit.message, 'Merge pull request #')
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
@@ -318,7 +309,7 @@ jobs:
           esac
 
       - name: Verify release PR label
-        if: "github.ref != 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore: release')"
+        if: startsWith(github.event.head_commit.message, 'Merge pull request #')
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary

Replace the loose `contains(github.event.head_commit.message, 'release-plz-')` check in `release-plz-release` job with precise gate conditions and verification for main-branch merge commits.

### Problem

The previous `contains()` check matched ANY commit or branch name containing "release-plz-" including:
- `feat: add release-plz config` (feature commit)
- `feature/release-plz-migration` (non-release branch)
- `fix/release-plz-typo` (non-release branch)

The initial fix used `startsWith(Merge pull request #)` as a pre-filter, but this caused regular feature-PR merges on `develop/**` to trigger the release job and fail at verification (`exit 1`).

### Solution: Two-Path Trigger + Verification for Main Merges

**Job `if:` condition** (two paths):
1. `github.ref == 'refs/heads/main'` — all push shapes to main (safe via `release_always = true`)
2. `startsWith(commit.message, 'chore: release')` — squash-merge of release-plz PRs on any branch

Merge-commit trigger is intentionally NOT included because it would match regular feature-PR merges on `develop/**`, causing false CI failures.

**Verification steps** (run for merge commits only):
1. **"Verify release branch name"**: Extracts branch name from merge commit and validates prefix (`release-plz-*` or `develop-release-plz-*`)
2. **"Verify release PR label"**: Extracts PR number and verifies the `release` label via `gh pr view --json labels`

### Security

Uses `env:` to pass GitHub context into shell scripts instead of direct `${{ }}` interpolation.

### Behavior Matrix

| Push Target | Commit Message | Job Triggers? | Verification? |
|---|---|---|---|
| main | Any | Yes | Merge commits only |
| develop/* | `chore: release` (squash) | Yes | No |
| develop/* | `Merge PR #N` (release-plz branch) | No | N/A |
| develop/* | `Merge PR #N` (feature branch) | No | N/A |

## Type of Change

- [x] Bug fix
- [x] CI/CD changes

## Motivation and Context

Prevent accidental crates.io publishing when non-release branches are merged, and prevent false CI failures on regular develop PR merges.

Fixes #4794

## How Was This Tested?

- Branch name pattern matching verified through case analysis
- YAML syntax validated with Python YAML parser
- PR label check uses standard `gh pr view --json labels` API
- Behavior matrix covers all push/merge scenarios for main and develop branches

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened publish gating so only dedicated release commits trigger publishing.
  * Added pre-publish verification that ensures the source branch follows the release naming pattern.
  * Added pre-publish verification that requires the source pull request to include the "release" label before publishing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->