### PR TITLE
fix(ci): quote if: conditions containing # to prevent YAML comment parsing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -285,7 +285,7 @@ jobs:
           fi
 
       - name: Verify release branch name
-        if: startsWith(github.event.head_commit.message, 'Merge pull request #')
+        if: "startsWith(github.event.head_commit.message, 'Merge pull request #')"
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
@@ -309,7 +309,7 @@ jobs:
           esac
 
       - name: Verify release PR label
-        if: startsWith(github.event.head_commit.message, 'Merge pull request #')
+        if: "startsWith(github.event.head_commit.message, 'Merge pull request #')"
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary

Fix YAML validation error in `.github/workflows/release-plz.yml`:

```
Invalid workflow file: .github/workflows/release-plz.yml#L1
(Line: 288, Col: 13): Unexpected symbol: ''Merge pull request'.
(Line: 312, Col: 13): Unexpected symbol: ''Merge pull request'.
```

## Root Cause

The `#` character in `'Merge pull request #'` inside the `if:` expressions was being interpreted as a YAML comment start, truncating the expression mid-string. In YAML plain scalars (unquoted values), `#` always starts a comment.

## Fix

Wrap both `if:` values in double quotes so the YAML parser treats the entire value as a string literal:

```yaml
# Before (broken):
if: startsWith(github.event.head_commit.message, 'Merge pull request #')

# After (fixed):
if: "startsWith(github.event.head_commit.message, 'Merge pull request #')"
```

## Files Changed

- `.github/workflows/release-plz.yml` — Lines 288, 312

## Test Plan

- [x] YAML syntax validated with `python3 -c "import yaml; yaml.safe_load(...)"`

Fixes #4812

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed GitHub Actions workflow condition syntax in release verification steps to ensure proper evaluation during the automated release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->