### PR TITLE
fix(admin-cli): resolve formatting issues in fmt-all output

### DIFF
--- a/crates/reinhardt-admin-cli/src/ast_formatter.rs
+++ b/crates/reinhardt-admin-cli/src/ast_formatter.rs
@@ -1066,9 +1066,8 @@ impl AstPageFormatter {
 						result.push(')');
 					}
 					MacroKind::Form => {
-						result.push_str("form!(");
+						result.push_str("form! ");
 						result.push_str(&formatted);
-						result.push(')');
 					}
 				},
 				Err(_) => {
@@ -1560,8 +1559,7 @@ impl AstPageFormatter {
 		for item in &derived.items {
 			let fi = self.make_indent(inner_ind);
 			let name = item.name.to_string();
-			let closure_str =
-				Self::clean_expression_spaces(&item.closure.to_token_stream().to_string());
+			let closure_str = self.format_closure_expression(&item.closure, inner_ind);
 			output.push_str(&fi);
 			output.push_str(&name);
 			output.push_str(": ");
@@ -1598,7 +1596,7 @@ impl AstPageFormatter {
 		indent: usize,
 	) {
 		let fi = self.make_indent(indent);
-		let expr_str = Self::clean_expression_spaces(&closure.to_token_stream().to_string());
+		let expr_str = self.format_closure_expression(closure, indent);
 		output.push_str(&fi);
 		output.push_str(name);
 		output.push_str(": ");
@@ -1641,7 +1639,7 @@ impl AstPageFormatter {
 		indent: usize,
 	) {
 		let fi = self.make_indent(indent);
-		let expr_str = Self::clean_expression_spaces(&closure.to_token_stream().to_string());
+		let expr_str = self.format_closure_expression(closure, indent);
 		output.push_str(&fi);
 		output.push_str(name);
 		output.push_str(": ");
@@ -1658,8 +1656,7 @@ impl AstPageFormatter {
 		for item in &watch.items {
 			let fi = self.make_indent(inner_ind);
 			let name = item.name.to_string();
-			let closure_str =
-				Self::clean_expression_spaces(&item.closure.to_token_stream().to_string());
+			let closure_str = self.format_closure_expression(&item.closure, inner_ind);
 			output.push_str(&fi);
 			output.push_str(&name);
 			output.push_str(": ");
@@ -1766,6 +1763,11 @@ impl AstPageFormatter {
 	/// Format form field entries (fields, groups, submit buttons).
 	fn format_form_entries(&self, output: &mut String, entries: &[FormFieldEntry], indent: usize) {
 		let ind = self.make_indent(indent);
+		if entries.is_empty() {
+			output.push_str(&ind);
+			output.push_str("fields: {}\n");
+			return;
+		}
 		output.push_str(&ind);
 		output.push_str("fields: {\n");
 		let inner_ind = indent + 1;
@@ -2292,6 +2294,7 @@ impl AstPageFormatter {
 			// to avoid leaving a space before :: (e.g., collect ::<Vec<_>>)
 			.replace(" :: ", "::")
 			.replace(" ::", "::")
+			.replace(":: ", "::")
 
 			// Generic type angle brackets: Vec < String > -> Vec<String>
 			// These handle spaces around < and > in generic type parameters
@@ -2495,6 +2498,33 @@ impl AstPageFormatter {
 		};
 
 		// Apply base indentation
+		self.apply_base_indent(&handler_str, base_indent)
+	}
+	/// Format a closure expression, using rustfmt for block-body closures.
+	fn format_closure_expression(&self, closure: &syn::ExprClosure, base_indent: usize) -> String {
+		// For non-block closures (e.g., |x| x + 1), clean_expression_spaces is sufficient
+		if !matches!(closure.body.as_ref(), syn::Expr::Block(_)) {
+			return Self::clean_expression_spaces(&closure.to_token_stream().to_string());
+		}
+
+		// Wrap the full closure in a valid Rust file for formatting
+		let wrapper_code = format!(
+			"fn _wrapper() {{ let _handler = {}; }}",
+			closure.to_token_stream()
+		);
+
+		let Ok(file) = syn::parse_file(&wrapper_code) else {
+			return Self::clean_expression_spaces(&closure.to_token_stream().to_string());
+		};
+
+		// Format with prettyplease + rustfmt
+		let prettyplease_output = prettyplease::unparse(&file);
+		let formatted = self.format_with_rustfmt(&prettyplease_output);
+
+		let Some(handler_str) = Self::extract_handler_from_wrapper(&formatted) else {
+			return Self::clean_expression_spaces(&closure.to_token_stream().to_string());
+		};
+
 		self.apply_base_indent(&handler_str, base_indent)
 	}
 
@@ -3088,7 +3118,7 @@ impl AstPageFormatter {
 			.ok()?;
 		match kind {
 			MacroKind::Page => Some(format!("page!({})", formatted)),
-			MacroKind::Form => Some(format!("form!({})", formatted)),
+			MacroKind::Form => Some(format!("form! {}", formatted)),
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the following formatting issues in `reinhardt-admin-cli fmt-all` output:

- `:: reinhardt::xxx` → `::reinhardt::xxx` (extra space after `::` not being cleaned — added `.replace(":: ", "::")` in `clean_expression_spaces`)
- Multi-line closure bodies in callbacks/slots/watch/derived sections being collapsed to a single line (added `format_closure_expression()` helper using prettyplease + rustfmt for block-body closures)
- Empty `fields: {}` being expanded to multi-line output (added early return when entries is empty)
- `form!({` incorrect syntax → `form! {` (removed extra parentheses around macro body)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The result of `cargo run -p reinhardt-admin-cli -- fmt-all` (commit 48ce401c56) contained several formatting defects that produced output inconsistent with rustfmt conventions.

Fixes #4815

## How Was This Tested?

- `cargo build -p reinhardt-admin-cli` — compiles successfully
- `cargo make clippy-check` — no new warnings introduced (existing `large_enum_variant` warnings in `reinhardt-manouche` are unrelated)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels

---

**Additional Context:**

- The `callbacks:` wrapping of `on_success`/`on_error` is a pre-existing bug (present in commit 48ce401c56) and is out of scope for this PR
- Comment loss in closures is an inherent limitation of `syn::ExprClosure.to_token_stream()` and is not a regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated formatter syntax for `form!` macros to produce cleaner output
  * Enhanced closure expression formatting with improved code styling
  * Refined spacing consistency and empty field list handling in generated code

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->