### PR TITLE
fix(ci): add reinhardt-testkit-macros to release-plz version group

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -225,6 +225,10 @@ name = "reinhardt-testkit"
 version_group = "reinhardt"
 
 [[package]]
+name = "reinhardt-testkit-macros"
+version_group = "reinhardt"
+
+[[package]]
 name = "reinhardt-throttling"
 version_group = "reinhardt"
 


### PR DESCRIPTION
## Summary

- Add missing `reinhardt-testkit-macros` entry to `release-plz.toml` version group
- The crate was skipped during the 0.1.1 stable release because it was not listed in the `reinhardt` version group

## Test plan

- [x] TOML syntax validated (`python3 -c "import tomllib; ..."`)
- [x] Entry placed alphabetically after `reinhardt-testkit` in the version group
- [ ] Next release-plz run includes `reinhardt-testkit-macros` in the Release PR

Fixes #4833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new package component to the release management configuration, enabling synchronized versioning across the package group for coordinated releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->