### PR TITLE
feat(di)!: enforce scope hierarchy at resolution time

### DIFF
--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -74,6 +74,10 @@ proptest = { workspace = true }
 rstest = { workspace = true }
 trybuild = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
+[[test]]
+name = "scope_hierarchy_tests"
+required-features = ["testing"]
+
 [[bench]]
 name = "cache_performance"
 harness = false

--- a/crates/reinhardt-di/src/context.rs
+++ b/crates/reinhardt-di/src/context.rs
@@ -605,8 +605,8 @@ impl InjectionContext {
 	/// ```
 	pub async fn resolve<T: Any + Send + Sync + 'static>(&self) -> crate::DiResult<Arc<T>> {
 		use crate::cycle_detection::{
-			begin_scoped_resolution, current_dependent_scope, register_type_name,
-			with_cycle_detection_scope,
+			begin_scoped_resolution, current_dependent_scope, current_dependent_type_name,
+			register_type_name, with_cycle_detection_scope,
 		};
 		use crate::registry::{DependencyScope, global_registry};
 
@@ -634,10 +634,11 @@ impl InjectionContext {
 					if let Some(cached) = self.get_request::<T>() {
 						if !DependencyScope::Request.outlives(current_dependent_scope()) {
 							return Err(crate::DiError::ScopeError(format!(
-								"Scope violation: {:?}-scoped dependent cannot resolve \
+								"Scope violation: {:?}-scoped '{}' cannot resolve \
 								 Request-scoped '{}' (pre-seeded); the dependency would \
 								 be captured with a shorter lifetime",
 								current_dependent_scope(),
+								current_dependent_type_name(),
 								type_name,
 							)));
 						}
@@ -654,10 +655,11 @@ impl InjectionContext {
 			// even if that dependency is already cached from a prior request.
 			if !scope.outlives(current_dependent_scope()) {
 				return Err(crate::DiError::ScopeError(format!(
-					"Scope violation: {:?}-scoped dependent cannot resolve \
+					"Scope violation: {:?}-scoped '{}' cannot resolve \
 					 {:?}-scoped '{}'; the dependency would be captured with \
 					 a shorter lifetime",
 					current_dependent_scope(),
+					current_dependent_type_name(),
 					scope,
 					type_name,
 				)));
@@ -707,7 +709,7 @@ impl InjectionContext {
 	pub async fn __resolve_from_registry<T: Any + Send + Sync + 'static>(
 		&self,
 	) -> crate::DiResult<Arc<T>> {
-		use crate::cycle_detection::current_dependent_scope;
+		use crate::cycle_detection::{current_dependent_scope, current_dependent_type_name};
 		use crate::registry::{DependencyScope, global_registry};
 
 		let registry = global_registry();
@@ -722,10 +724,11 @@ impl InjectionContext {
 				if let Some(cached) = self.get_request::<T>() {
 					if !DependencyScope::Request.outlives(current_dependent_scope()) {
 						return Err(crate::DiError::ScopeError(format!(
-							"Scope violation: {:?}-scoped dependent cannot resolve \
+							"Scope violation: {:?}-scoped '{}' cannot resolve \
 							 Request-scoped '{}' (pre-seeded); the dependency would \
 							 be captured with a shorter lifetime",
 							current_dependent_scope(),
+							current_dependent_type_name(),
 							type_name,
 						)));
 					}
@@ -740,10 +743,11 @@ impl InjectionContext {
 		// Scope hierarchy check — same as resolve()
 		if !scope.outlives(current_dependent_scope()) {
 			return Err(crate::DiError::ScopeError(format!(
-				"Scope violation: {:?}-scoped dependent cannot resolve \
+				"Scope violation: {:?}-scoped '{}' cannot resolve \
 				 {:?}-scoped '{}'; the dependency would be captured with \
 				 a shorter lifetime",
 				current_dependent_scope(),
+				current_dependent_type_name(),
 				scope,
 				type_name,
 			)));

--- a/crates/reinhardt-di/src/context.rs
+++ b/crates/reinhardt-di/src/context.rs
@@ -605,7 +605,8 @@ impl InjectionContext {
 	/// ```
 	pub async fn resolve<T: Any + Send + Sync + 'static>(&self) -> crate::DiResult<Arc<T>> {
 		use crate::cycle_detection::{
-			begin_scoped_resolution, register_type_name, with_cycle_detection_scope,
+			begin_scoped_resolution, current_dependent_scope, register_type_name,
+			with_cycle_detection_scope,
 		};
 		use crate::registry::{DependencyScope, global_registry};
 
@@ -635,6 +636,21 @@ impl InjectionContext {
 					});
 				}
 			};
+
+			// Scope hierarchy check — runs on EVERY resolution (cache hit or miss).
+			// A singleton dependent must not resolve a request-scoped dependency,
+			// even if that dependency is already cached from a prior request.
+			if !scope.outlives(current_dependent_scope()) {
+				return Err(crate::DiError::ScopeError(format!(
+					"Scope violation: {:?}-scoped dependent cannot resolve \
+					 {:?}-scoped '{}'; the dependency would be captured with \
+					 a shorter lifetime",
+					current_dependent_scope(),
+					scope,
+					type_name,
+				)));
+			}
+
 			match scope {
 				DependencyScope::Singleton => {
 					if let Some(cached) = self.get_singleton::<T>() {

--- a/crates/reinhardt-di/src/context.rs
+++ b/crates/reinhardt-di/src/context.rs
@@ -625,10 +625,22 @@ impl InjectionContext {
 					// Fallback: check scope caches for types pre-seeded via
 					// SingletonScope::set() / InjectionContext::set_request()
 					// (e.g., types registered through DiRegistrationList).
+					// Singleton pre-seeds are safe for any dependent scope.
 					if let Some(cached) = self.get_singleton::<T>() {
 						return Ok(cached);
 					}
+					// Request pre-seeds are request-scoped: apply the same
+					// hierarchy check as registry-registered types.
 					if let Some(cached) = self.get_request::<T>() {
+						if !DependencyScope::Request.outlives(current_dependent_scope()) {
+							return Err(crate::DiError::ScopeError(format!(
+								"Scope violation: {:?}-scoped dependent cannot resolve \
+								 Request-scoped '{}' (pre-seeded); the dependency would \
+								 be captured with a shorter lifetime",
+								current_dependent_scope(),
+								type_name,
+							)));
+						}
 						return Ok(cached);
 					}
 					return Err(crate::DiError::DependencyNotRegistered {
@@ -695,6 +707,7 @@ impl InjectionContext {
 	pub async fn __resolve_from_registry<T: Any + Send + Sync + 'static>(
 		&self,
 	) -> crate::DiResult<Arc<T>> {
+		use crate::cycle_detection::current_dependent_scope;
 		use crate::registry::{DependencyScope, global_registry};
 
 		let registry = global_registry();
@@ -707,6 +720,15 @@ impl InjectionContext {
 					return Ok(cached);
 				}
 				if let Some(cached) = self.get_request::<T>() {
+					if !DependencyScope::Request.outlives(current_dependent_scope()) {
+						return Err(crate::DiError::ScopeError(format!(
+							"Scope violation: {:?}-scoped dependent cannot resolve \
+							 Request-scoped '{}' (pre-seeded); the dependency would \
+							 be captured with a shorter lifetime",
+							current_dependent_scope(),
+							type_name,
+						)));
+					}
 					return Ok(cached);
 				}
 				return Err(crate::DiError::DependencyNotRegistered {
@@ -714,6 +736,18 @@ impl InjectionContext {
 				});
 			}
 		};
+
+		// Scope hierarchy check — same as resolve()
+		if !scope.outlives(current_dependent_scope()) {
+			return Err(crate::DiError::ScopeError(format!(
+				"Scope violation: {:?}-scoped dependent cannot resolve \
+				 {:?}-scoped '{}'; the dependency would be captured with \
+				 a shorter lifetime",
+				current_dependent_scope(),
+				scope,
+				type_name,
+			)));
+		}
 
 		// Fast cache check (same as resolve)
 		match scope {

--- a/crates/reinhardt-di/src/context.rs
+++ b/crates/reinhardt-di/src/context.rs
@@ -605,7 +605,7 @@ impl InjectionContext {
 	/// ```
 	pub async fn resolve<T: Any + Send + Sync + 'static>(&self) -> crate::DiResult<Arc<T>> {
 		use crate::cycle_detection::{
-			begin_resolution, register_type_name, with_cycle_detection_scope,
+			begin_scoped_resolution, register_type_name, with_cycle_detection_scope,
 		};
 		use crate::registry::{DependencyScope, global_registry};
 
@@ -649,9 +649,15 @@ impl InjectionContext {
 				_ => {}
 			}
 
-			// [Slow path] Execute circular detection only on cache miss
-			let _guard = begin_resolution(type_id, type_name)
-				.map_err(|e| crate::DiError::CircularDependency(e.to_string()))?;
+			// [Slow path] Scope-aware resolution with cycle detection
+			let _guard = begin_scoped_resolution(type_id, type_name, scope).map_err(|e| {
+				match e {
+					crate::cycle_detection::CycleError::ScopeViolation { .. } => {
+						crate::DiError::ScopeError(e.to_string())
+					}
+					other => crate::DiError::CircularDependency(other.to_string()),
+				}
+			})?;
 
 			// Actual resolution processing (existing logic)
 			self.resolve_internal::<T>(scope).await

--- a/crates/reinhardt-di/src/cycle_detection.rs
+++ b/crates/reinhardt-di/src/cycle_detection.rs
@@ -241,6 +241,22 @@ pub fn current_dependent_scope() -> DependencyScope {
 		.unwrap_or(DependencyScope::Transient)
 }
 
+/// Returns the type name of the current dependent (the type at the top of
+/// the resolution stack), or `"<root>"` if no resolution is in progress.
+pub fn current_dependent_type_name() -> String {
+	CYCLE_STATE
+		.try_with(|state| {
+			state
+				.borrow()
+				.resolution_path
+				.last()
+				.map(|(_, name)| name.to_string())
+		})
+		.ok()
+		.flatten()
+		.unwrap_or_else(|| "<root>".to_string())
+}
+
 /// Begin a scope-aware resolution, checking the scope hierarchy before proceeding.
 ///
 /// This is the scope-aware counterpart of [`begin_resolution`]. It:

--- a/crates/reinhardt-di/src/cycle_detection.rs
+++ b/crates/reinhardt-di/src/cycle_detection.rs
@@ -22,6 +22,8 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 
+use crate::registry::DependencyScope;
+
 /// Maximum resolution depth (prevents pathological cases)
 const MAX_RESOLUTION_DEPTH: usize = 100;
 
@@ -35,6 +37,10 @@ struct CycleDetectionState {
 	type_names: HashMap<TypeId, &'static str>,
 	/// Resolution path (for displaying circular paths)
 	resolution_path: Vec<(TypeId, &'static str)>,
+	/// Stack of scopes for the types currently being resolved.
+	/// The top is the scope of the type whose factory is currently executing
+	/// (the "dependent" in scope-hierarchy checks).
+	scope_stack: Vec<DependencyScope>,
 }
 
 impl CycleDetectionState {
@@ -44,6 +50,7 @@ impl CycleDetectionState {
 			resolution_depth: 0,
 			type_names: HashMap::new(),
 			resolution_path: Vec::new(),
+			scope_stack: Vec::new(),
 		}
 	}
 }
@@ -155,13 +162,18 @@ pub fn begin_resolution(
 /// When resolution is complete, the type is removed from the stack.
 #[derive(Debug)]
 pub enum ResolutionGuard {
-	/// Tracking circular detection
+	/// Tracking circular detection only (no scope push)
 	Tracked(TypeId),
+	/// Tracking circular detection AND scope hierarchy
+	TrackedWithScope(TypeId),
 }
 
 impl Drop for ResolutionGuard {
 	fn drop(&mut self) {
-		let ResolutionGuard::Tracked(type_id) = self;
+		let (type_id, pop_scope) = match self {
+			ResolutionGuard::Tracked(id) => (id, false),
+			ResolutionGuard::TrackedWithScope(id) => (id, true),
+		};
 		let _ = CYCLE_STATE.try_with(|state| {
 			let mut s = state.borrow_mut();
 			s.resolution_set.remove(type_id);
@@ -169,6 +181,9 @@ impl Drop for ResolutionGuard {
 				s.resolution_path.remove(pos);
 			}
 			s.resolution_depth = s.resolution_depth.saturating_sub(1);
+			if pop_scope {
+				s.scope_stack.pop();
+			}
 		});
 	}
 }
@@ -209,6 +224,70 @@ fn build_cycle_path_inner(state: &CycleDetectionState, current_type_id: TypeId) 
 	}
 }
 
+/// Returns the scope of the type currently being resolved (the dependent).
+///
+/// If no resolution is in progress (root call from a handler), returns
+/// [`DependencyScope::Transient`] (most permissive — allows resolving anything).
+pub fn current_dependent_scope() -> DependencyScope {
+	CYCLE_STATE
+		.try_with(|state| {
+			state
+				.borrow()
+				.scope_stack
+				.last()
+				.copied()
+				.unwrap_or(DependencyScope::Transient)
+		})
+		.unwrap_or(DependencyScope::Transient)
+}
+
+/// Begin a scope-aware resolution, checking the scope hierarchy before proceeding.
+///
+/// This is the scope-aware counterpart of [`begin_resolution`]. It:
+/// 1. Checks that the dependency's scope is compatible with the current
+///    dependent's scope (the top of the scope stack).
+/// 2. Delegates to [`begin_resolution`] for cycle detection.
+/// 3. Pushes the dependency's scope onto the scope stack.
+///
+/// The returned [`ResolutionGuard::TrackedWithScope`] pops the scope on drop.
+pub fn begin_scoped_resolution(
+	type_id: TypeId,
+	type_name: &'static str,
+	dependency_scope: DependencyScope,
+) -> Result<ResolutionGuard, CycleError> {
+	let dependent_scope = current_dependent_scope();
+	if !dependency_scope.outlives(dependent_scope) {
+		let dependent_type = CYCLE_STATE
+			.try_with(|state| {
+				state
+					.borrow()
+					.resolution_path
+					.last()
+					.map(|(_, name)| name.to_string())
+			})
+			.ok()
+			.flatten()
+			.unwrap_or_else(|| "<root>".to_string());
+		return Err(CycleError::ScopeViolation {
+			dependent_type,
+			dependent_scope,
+			dependency_type: type_name.to_string(),
+			dependency_scope,
+		});
+	}
+
+	let guard = begin_resolution(type_id, type_name)?;
+
+	with_state(|state| {
+		state.borrow_mut().scope_stack.push(dependency_scope);
+	})?;
+
+	// Prevent the Tracked guard from running its Drop (which would undo cycle detection).
+	// Return a TrackedWithScope that cleans up both cycle state and scope stack.
+	std::mem::forget(guard);
+	Ok(ResolutionGuard::TrackedWithScope(type_id))
+}
+
 /// Circular dependency error
 #[derive(Debug, thiserror::Error)]
 pub enum CycleError {
@@ -234,6 +313,23 @@ pub enum CycleError {
 		"Cycle detection called outside of a task-local scope. Use `with_cycle_detection_scope` to initialize."
 	)]
 	NoScope,
+
+	/// Scope hierarchy violation: a longer-lived type resolved a shorter-lived dependency
+	#[error(
+		"Scope violation: {dependent_scope:?}-scoped '{dependent_type}' cannot resolve \
+		 {dependency_scope:?}-scoped '{dependency_type}'; \
+		 the dependency would be captured with a shorter lifetime"
+	)]
+	ScopeViolation {
+		/// The type name of the dependent
+		dependent_type: String,
+		/// The scope of the dependent
+		dependent_scope: DependencyScope,
+		/// The type name of the dependency
+		dependency_type: String,
+		/// The scope of the dependency
+		dependency_scope: DependencyScope,
+	},
 }
 
 #[cfg(test)]

--- a/crates/reinhardt-di/src/lib.rs
+++ b/crates/reinhardt-di/src/lib.rs
@@ -295,7 +295,8 @@ use thiserror::Error;
 
 pub use context::{InjectionContext, InjectionContextBuilder, RequestContext};
 pub use cycle_detection::{
-	CycleError, ResolutionGuard, begin_resolution, register_type_name, with_cycle_detection_scope,
+	CycleError, ResolutionGuard, begin_resolution, begin_scoped_resolution,
+	current_dependent_scope, register_type_name, with_cycle_detection_scope,
 };
 pub use function_handle::FunctionHandle;
 pub use override_registry::OverrideRegistry;

--- a/crates/reinhardt-di/src/registry.rs
+++ b/crates/reinhardt-di/src/registry.rs
@@ -24,6 +24,22 @@ pub enum DependencyScope {
 	Transient,
 }
 
+impl DependencyScope {
+	/// Returns `true` if a type at scope `self` (the dependency being resolved)
+	/// lives at least as long as a type at scope `dependent` (the type
+	/// requesting resolution).
+	///
+	/// The only prohibited combination is a `Singleton`-scoped dependent
+	/// resolving a `Request`-scoped dependency, because the singleton would
+	/// capture a stale, request-bound value for the entire process lifetime.
+	pub fn outlives(&self, dependent: DependencyScope) -> bool {
+		!matches!(
+			(dependent, *self),
+			(DependencyScope::Singleton, DependencyScope::Request)
+		)
+	}
+}
+
 /// Factory trait for creating dependencies
 ///
 /// Factories are async functions that can resolve dependencies from an InjectionContext

--- a/crates/reinhardt-di/tests/scope_hierarchy_tests.rs
+++ b/crates/reinhardt-di/tests/scope_hierarchy_tests.rs
@@ -1,0 +1,237 @@
+//! Tests for DI scope hierarchy enforcement (Issue #4651)
+
+use reinhardt_di::{
+	DependencyScope, DiError, InjectionContext, SingletonScope, global_registry,
+};
+use rstest::rstest;
+use serial_test::serial;
+use std::sync::Arc;
+
+// --- outlives() unit tests ---
+
+#[rstest]
+#[case::singleton_resolves_singleton(DependencyScope::Singleton, DependencyScope::Singleton, true)]
+#[case::singleton_resolves_request(DependencyScope::Request, DependencyScope::Singleton, false)]
+#[case::singleton_resolves_transient(DependencyScope::Transient, DependencyScope::Singleton, true)]
+#[case::request_resolves_singleton(DependencyScope::Singleton, DependencyScope::Request, true)]
+#[case::request_resolves_request(DependencyScope::Request, DependencyScope::Request, true)]
+#[case::request_resolves_transient(DependencyScope::Transient, DependencyScope::Request, true)]
+#[case::transient_resolves_singleton(DependencyScope::Singleton, DependencyScope::Transient, true)]
+#[case::transient_resolves_request(DependencyScope::Request, DependencyScope::Transient, true)]
+#[case::transient_resolves_transient(DependencyScope::Transient, DependencyScope::Transient, true)]
+fn outlives_returns_expected(
+	#[case] dependency_scope: DependencyScope,
+	#[case] dependent_scope: DependencyScope,
+	#[case] expected: bool,
+) {
+	// Act
+	let result = dependency_scope.outlives(dependent_scope);
+
+	// Assert
+	assert_eq!(
+		result, expected,
+		"{dependency_scope:?}.outlives({dependent_scope:?}) should be {expected}"
+	);
+}
+
+// --- Runtime scope enforcement tests ---
+
+#[derive(Clone, Debug, Default)]
+struct RequestConfig;
+
+#[derive(Clone, Debug, Default)]
+struct SingletonService;
+
+#[derive(Clone, Debug, Default)]
+struct TransientWidget;
+
+#[rstest]
+#[tokio::test]
+#[serial(di_registry)]
+async fn singleton_resolving_singleton_succeeds() {
+	// Arrange
+	let registry = global_registry();
+	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
+		Ok(SingletonService)
+	});
+
+	let singleton_scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(singleton_scope).build();
+
+	// Act
+	let result = ctx.resolve::<SingletonService>().await;
+
+	// Assert
+	assert!(result.is_ok());
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(di_registry)]
+async fn singleton_resolving_request_returns_scope_error() {
+	// Arrange
+	let registry = global_registry();
+	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+		Ok(RequestConfig::default())
+	});
+	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
+		// This singleton factory tries to resolve a request-scoped dependency
+		let _config = ctx.resolve::<RequestConfig>().await?;
+		Ok(SingletonService)
+	});
+
+	let singleton_scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(singleton_scope).build();
+
+	// Act
+	let result = ctx.resolve::<SingletonService>().await;
+
+	// Assert
+	assert!(
+		matches!(result, Err(DiError::ScopeError(_))),
+		"Expected ScopeError, got: {result:?}"
+	);
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(di_registry)]
+async fn request_resolving_singleton_succeeds() {
+	// Arrange
+	let registry = global_registry();
+	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
+		Ok(SingletonService)
+	});
+	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |ctx| async move {
+		let _service = ctx.resolve::<SingletonService>().await?;
+		Ok(RequestConfig::default())
+	});
+
+	let singleton_scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(singleton_scope).build();
+
+	// Act
+	let result = ctx.resolve::<RequestConfig>().await;
+
+	// Assert
+	assert!(result.is_ok());
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(di_registry)]
+async fn request_resolving_request_succeeds() {
+	// Arrange
+	#[derive(Clone, Default)]
+	struct RequestConfigB;
+
+	let registry = global_registry();
+	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+		Ok(RequestConfig::default())
+	});
+	registry.register_async::<RequestConfigB, _, _>(DependencyScope::Request, |ctx| async move {
+		let _config = ctx.resolve::<RequestConfig>().await?;
+		Ok(RequestConfigB)
+	});
+
+	let singleton_scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(singleton_scope).build();
+
+	// Act
+	let result = ctx.resolve::<RequestConfigB>().await;
+
+	// Assert
+	assert!(result.is_ok());
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(di_registry)]
+async fn root_resolving_any_scope_succeeds() {
+	// Arrange
+	let registry = global_registry();
+	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
+		Ok(SingletonService)
+	});
+	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+		Ok(RequestConfig::default())
+	});
+	registry.register_async::<TransientWidget, _, _>(DependencyScope::Transient, |_ctx| async {
+		Ok(TransientWidget)
+	});
+
+	let singleton_scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(singleton_scope).build();
+
+	// Act & Assert
+	assert!(ctx.resolve::<SingletonService>().await.is_ok());
+	assert!(ctx.resolve::<RequestConfig>().await.is_ok());
+	assert!(ctx.resolve::<TransientWidget>().await.is_ok());
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(di_registry)]
+async fn transient_resolving_any_scope_succeeds() {
+	// Arrange
+	#[derive(Clone, Default)]
+	struct TransientConsumer;
+
+	let registry = global_registry();
+	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
+		Ok(SingletonService)
+	});
+	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+		Ok(RequestConfig::default())
+	});
+	registry.register_async::<TransientConsumer, _, _>(
+		DependencyScope::Transient,
+		|ctx| async move {
+			let _singleton = ctx.resolve::<SingletonService>().await?;
+			let _request = ctx.resolve::<RequestConfig>().await?;
+			Ok(TransientConsumer)
+		},
+	);
+
+	let singleton_scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(singleton_scope).build();
+
+	// Act
+	let result = ctx.resolve::<TransientConsumer>().await;
+
+	// Assert
+	assert!(result.is_ok());
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(di_registry)]
+async fn scope_error_message_contains_type_names() {
+	// Arrange
+	let registry = global_registry();
+	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+		Ok(RequestConfig::default())
+	});
+	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
+		let _config = ctx.resolve::<RequestConfig>().await?;
+		Ok(SingletonService)
+	});
+
+	let singleton_scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(singleton_scope).build();
+
+	// Act
+	let result = ctx.resolve::<SingletonService>().await;
+
+	// Assert
+	let err = result.unwrap_err();
+	let msg = err.to_string();
+	assert!(
+		msg.contains("Singleton"),
+		"Error should mention Singleton scope: {msg}"
+	);
+	assert!(
+		msg.contains("Request"),
+		"Error should mention Request scope: {msg}"
+	);
+}

--- a/crates/reinhardt-di/tests/scope_hierarchy_tests.rs
+++ b/crates/reinhardt-di/tests/scope_hierarchy_tests.rs
@@ -265,3 +265,28 @@ async fn singleton_resolving_cached_request_still_returns_scope_error() {
 		"Cached request-scoped dep must still fail for singleton: {result:?}"
 	);
 }
+
+#[rstest]
+#[tokio::test]
+#[serial(di_registry)]
+async fn singleton_resolving_preseeded_request_returns_scope_error() {
+	// Arrange: pre-seed request cache directly (no registry entry)
+	let registry = global_registry();
+	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
+		let _config = ctx.resolve::<RequestConfig>().await?;
+		Ok(SingletonService)
+	});
+
+	let singleton_scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(singleton_scope).build();
+	ctx.set_request(RequestConfig);
+
+	// Act: singleton factory resolves pre-seeded request-scoped type
+	let result = ctx.resolve::<SingletonService>().await;
+
+	// Assert
+	assert!(
+		matches!(result, Err(DiError::ScopeError(_))),
+		"Pre-seeded request dep must still fail for singleton: {result:?}"
+	);
+}

--- a/crates/reinhardt-di/tests/scope_hierarchy_tests.rs
+++ b/crates/reinhardt-di/tests/scope_hierarchy_tests.rs
@@ -51,7 +51,7 @@ struct TransientWidget;
 async fn singleton_resolving_singleton_succeeds() {
 	// Arrange
 	let registry = global_registry();
-	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
+	let _guard = registry.register_override::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
 		Ok(SingletonService)
 	});
 
@@ -71,10 +71,10 @@ async fn singleton_resolving_singleton_succeeds() {
 async fn singleton_resolving_request_returns_scope_error() {
 	// Arrange
 	let registry = global_registry();
-	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+	let _guard1 = registry.register_override::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
 		Ok(RequestConfig::default())
 	});
-	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
+	let _guard2 = registry.register_override::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
 		// This singleton factory tries to resolve a request-scoped dependency
 		let _config = ctx.resolve::<RequestConfig>().await?;
 		Ok(SingletonService)
@@ -99,10 +99,10 @@ async fn singleton_resolving_request_returns_scope_error() {
 async fn request_resolving_singleton_succeeds() {
 	// Arrange
 	let registry = global_registry();
-	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
+	let _guard1 = registry.register_override::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
 		Ok(SingletonService)
 	});
-	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |ctx| async move {
+	let _guard2 = registry.register_override::<RequestConfig, _, _>(DependencyScope::Request, |ctx| async move {
 		let _service = ctx.resolve::<SingletonService>().await?;
 		Ok(RequestConfig::default())
 	});
@@ -126,10 +126,10 @@ async fn request_resolving_request_succeeds() {
 	struct RequestConfigB;
 
 	let registry = global_registry();
-	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+	let _guard1 = registry.register_override::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
 		Ok(RequestConfig::default())
 	});
-	registry.register_async::<RequestConfigB, _, _>(DependencyScope::Request, |ctx| async move {
+	let _guard2 = registry.register_override::<RequestConfigB, _, _>(DependencyScope::Request, |ctx| async move {
 		let _config = ctx.resolve::<RequestConfig>().await?;
 		Ok(RequestConfigB)
 	});
@@ -150,13 +150,13 @@ async fn request_resolving_request_succeeds() {
 async fn root_resolving_any_scope_succeeds() {
 	// Arrange
 	let registry = global_registry();
-	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
+	let _guard1 = registry.register_override::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
 		Ok(SingletonService)
 	});
-	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+	let _guard2 = registry.register_override::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
 		Ok(RequestConfig::default())
 	});
-	registry.register_async::<TransientWidget, _, _>(DependencyScope::Transient, |_ctx| async {
+	let _guard3 = registry.register_override::<TransientWidget, _, _>(DependencyScope::Transient, |_ctx| async {
 		Ok(TransientWidget)
 	});
 
@@ -178,13 +178,13 @@ async fn transient_resolving_any_scope_succeeds() {
 	struct TransientConsumer;
 
 	let registry = global_registry();
-	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
+	let _guard1 = registry.register_override::<SingletonService, _, _>(DependencyScope::Singleton, |_ctx| async {
 		Ok(SingletonService)
 	});
-	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+	let _guard2 = registry.register_override::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
 		Ok(RequestConfig::default())
 	});
-	registry.register_async::<TransientConsumer, _, _>(
+	let _guard3 = registry.register_override::<TransientConsumer, _, _>(
 		DependencyScope::Transient,
 		|ctx| async move {
 			let _singleton = ctx.resolve::<SingletonService>().await?;
@@ -209,10 +209,10 @@ async fn transient_resolving_any_scope_succeeds() {
 async fn scope_error_message_contains_type_names() {
 	// Arrange
 	let registry = global_registry();
-	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+	let _guard1 = registry.register_override::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
 		Ok(RequestConfig::default())
 	});
-	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
+	let _guard2 = registry.register_override::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
 		let _config = ctx.resolve::<RequestConfig>().await?;
 		Ok(SingletonService)
 	});
@@ -242,10 +242,10 @@ async fn scope_error_message_contains_type_names() {
 async fn singleton_resolving_cached_request_still_returns_scope_error() {
 	// Arrange: pre-populate the request cache so the singleton hits the fast path
 	let registry = global_registry();
-	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+	let _guard1 = registry.register_override::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
 		Ok(RequestConfig)
 	});
-	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
+	let _guard2 = registry.register_override::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
 		let _config = ctx.resolve::<RequestConfig>().await?;
 		Ok(SingletonService)
 	});
@@ -272,7 +272,7 @@ async fn singleton_resolving_cached_request_still_returns_scope_error() {
 async fn singleton_resolving_preseeded_request_returns_scope_error() {
 	// Arrange: pre-seed request cache directly (no registry entry)
 	let registry = global_registry();
-	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
+	let _guard = registry.register_override::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
 		let _config = ctx.resolve::<RequestConfig>().await?;
 		Ok(SingletonService)
 	});

--- a/crates/reinhardt-di/tests/scope_hierarchy_tests.rs
+++ b/crates/reinhardt-di/tests/scope_hierarchy_tests.rs
@@ -235,3 +235,33 @@ async fn scope_error_message_contains_type_names() {
 		"Error should mention Request scope: {msg}"
 	);
 }
+
+#[rstest]
+#[tokio::test]
+#[serial(di_registry)]
+async fn singleton_resolving_cached_request_still_returns_scope_error() {
+	// Arrange: pre-populate the request cache so the singleton hits the fast path
+	let registry = global_registry();
+	registry.register_async::<RequestConfig, _, _>(DependencyScope::Request, |_ctx| async {
+		Ok(RequestConfig)
+	});
+	registry.register_async::<SingletonService, _, _>(DependencyScope::Singleton, |ctx| async move {
+		let _config = ctx.resolve::<RequestConfig>().await?;
+		Ok(SingletonService)
+	});
+
+	let singleton_scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(singleton_scope).build();
+
+	// Warm the request cache from a root (Transient) context — this succeeds
+	let _ = ctx.resolve::<RequestConfig>().await.expect("root can resolve request");
+
+	// Act: singleton factory tries to resolve the now-cached RequestConfig
+	let result = ctx.resolve::<SingletonService>().await;
+
+	// Assert: scope violation must still be detected even on cache hit
+	assert!(
+		matches!(result, Err(DiError::ScopeError(_))),
+		"Cached request-scoped dep must still fail for singleton: {result:?}"
+	);
+}


### PR DESCRIPTION
## Summary

- Enforce DI scope hierarchy at resolution time, preventing singleton-scoped dependents from resolving request-scoped dependencies
- Reuse the existing `DiError::ScopeError` variant (previously declared but never raised in production)
- Add `DependencyScope::outlives()` method and `begin_scoped_resolution()` with RAII cleanup via extended `ResolutionGuard`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes

## Motivation and Context

A singleton-scoped factory can currently resolve a request-scoped dependency without error. The singleton captures whichever request-scoped instance happens to be live at first resolution, then reuses that stale value for the entire process lifetime. This is a silent, hard-to-diagnose bug that violates the "Fail early" design principle (DESIGN_PHILOSOPHY.md #4).

`DiError::ScopeError(String)` was already declared but never raised in production — this PR activates it.

Fixes #4651

## How Was This Tested?

- 16 new tests in `tests/scope_hierarchy_tests.rs`:
  - 9 parametrized `outlives()` unit tests covering all scope combinations
  - Runtime enforcement tests: singleton→singleton (OK), singleton→request (ScopeError), request→singleton (OK), request→request (OK), root→all (OK), transient→all (OK)
  - Error message content validation
- All 387 existing `reinhardt-di` tests pass (1 pre-existing failure unrelated to this change: `injectable_factory_mixes_path_extractor_and_depends`)
- `cargo make fmt-check` passes
- `cargo make clippy-check` passes

## Breaking Changes

User code that currently relies on a singleton factory resolving a request-scoped dependency will now receive `Err(DiError::ScopeError(...))` instead of silently resolving.

**Migration Guide:**

1. Promote the dependency to a longer-lived scope:
   ```diff
   - #[injectable]                                       // Request (default)
   + #[injectable(scope = "singleton")]
     struct Config { /* ... */ }
   ```
2. Or demote the dependent to a matching scope:
   ```diff
   - #[injectable_factory(scope = "singleton")]
   + #[injectable_factory(scope = "request")]
     async fn database_connection(#[inject] config: Depends<Config>) -> DatabaseConnection { /* ... */ }
   ```

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #4651

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement
- [x] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `api` - REST API, serializers, views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced scope-hierarchy checks during dependency resolution and improved cycle detection so invalid dependent→dependency pairings return clear scope-violation errors instead of incorrect circular-dependency outcomes.

* **New Features**
  * Added scope-aware resolution tracking and a public scope-relationship check to validate lifetimes between dependent and dependency.

* **Tests**
  * Added comprehensive tests covering scope outlives rules, cached/pre-seeded resolutions, and scope-violation error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->