### PR TITLE
fix(admin-cli): pass ignore-all files through rustfmt in fmt command

### DIFF
--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -753,8 +753,11 @@ fn run_fmt(
 			))
 		})?;
 
-		// Check for file-wide ignore marker BEFORE any processing
-		if formatter.has_ignore_all_marker(&original_content) {
+		// Check for file-wide ignore marker BEFORE any processing.
+		// When with_rustfmt is enabled, skip only the DSL pass but still
+		// run rustfmt below so plain Rust formatting is applied.
+		let ignore_all = formatter.has_ignore_all_marker(&original_content);
+		if ignore_all && !with_rustfmt {
 			ignored_count += 1;
 			if verbosity > 0 {
 				println!(
@@ -767,35 +770,40 @@ fn run_fmt(
 			continue;
 		}
 
-		let dsl_result = match formatter.format(&original_content) {
-			Ok(result) => {
-				if let Some(reason) = &result.skipped {
-					if !with_rustfmt {
-						ignored_count += 1;
-						println!(
-							"{} {} {} ({})",
-							progress.bright_blue(),
-							"Ignored:".yellow(),
-							display_path(file_path),
-							reason
-						);
-						continue;
+		let dsl_result = if ignore_all {
+			// ignore-all with rustfmt: skip DSL pass, feed original to rustfmt
+			original_content.clone()
+		} else {
+			match formatter.format(&original_content) {
+				Ok(result) => {
+					if let Some(reason) = &result.skipped {
+						if !with_rustfmt {
+							ignored_count += 1;
+							println!(
+								"{} {} {} ({})",
+								progress.bright_blue(),
+								"Ignored:".yellow(),
+								display_path(file_path),
+								reason
+							);
+							continue;
+						}
+						original_content.clone()
+					} else {
+						result.content
 					}
-					original_content.clone()
-				} else {
-					result.content
 				}
-			}
-			Err(e) => {
-				eprintln!(
-					"{} {} {}: {}",
-					progress.bright_blue(),
-					"Error".red(),
-					display_path(file_path),
-					sanitize_error(&e.to_string())
-				);
-				error_count += 1;
-				continue;
+				Err(e) => {
+					eprintln!(
+						"{} {} {}: {}",
+						progress.bright_blue(),
+						"Error".red(),
+						display_path(file_path),
+						sanitize_error(&e.to_string())
+					);
+					error_count += 1;
+					continue;
+				}
 			}
 		};
 


### PR DESCRIPTION
## Summary

- Fix `reinhardt-admin fmt` to run rustfmt on files with the `reinhardt-fmt:ignore-all` marker when `--with-rustfmt` is enabled
- The ignore-all marker should only suppress the DSL formatting pass, not rustfmt
- Cherry-pick of the same fix from PR #4890 (targeting main)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #4887 fixed the `AllMacrosIgnored` skip path but missed the `ignore-all` early return. Files with `// reinhardt-fmt:ignore-all` were completely skipped (no DSL formatting AND no rustfmt), even when `--with-rustfmt=true`.

Fixes #4885

Related to: #4890 (same fix targeting main)

## How Was This Tested?

- Traced all code paths in `run_fmt()` through `FormatEngine::format()` return values
- Verified `fmt-all` is unaffected (Phase 2 runs `cargo fmt --all` independently)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

Fixes #4885
Related to: #4890

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of the "ignore-all" formatting marker. When rustfmt is disabled, marked files are skipped entirely; when enabled, DSL formatting is bypassed but rustfmt processing continues, ensuring consistent behavior based on configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->