### PR TITLE
docs: add Obsidian wiki maintenance instructions (OW-1 ~ OW-4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,7 +335,7 @@ At the end of a meaningful work unit (architectural decision, new pattern, troub
 3. Create/update pages under the appropriate category
 4. Update meta pages: `wiki/index.md`, `wiki/hot.md`, `wiki/log.md`
 
-**Skip when:** MCP unavailable, trivial changes, work in progress, or user requests skip.
+**Skip when:** MCP unavailable, trivial changes, work in progress, or emergency/hotfix work.
 
 See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-4).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,6 +307,11 @@ This project uses [release-plz](https://release-plz.ieni.dev/) for automated rel
 - Edit Release PR to adjust CHANGELOG entries or versions if needed
 - Release PRs can be modified before merging
 
+**Release PR Branch Policy:**
+- **NEVER** push fixes or changes directly to a release-plz branch (`release-plz-*` or `develop-release-plz-*`)
+- If a fix is needed before merging a Release PR, create a `fix/` or `hotfix/` branch from the Release PR's **base branch** (e.g., `main` or `develop/*`), open a PR targeting that base branch, and merge it — release-plz will regenerate the Release PR automatically
+- Direct pushes to release-plz branches bypass the normal review workflow and may be overwritten when release-plz regenerates the PR
+
 **Critical Rules:**
 - **MUST** use conventional commit format for proper version detection
 - **MUST** review Release PRs before merging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,21 @@ This project uses [release-plz](https://release-plz.ieni.dev/) for automated rel
 
 See instructions/RELEASE_PROCESS.md for detailed release procedures.
 
+### Obsidian Wiki Maintenance
+
+**Vault:** `/Users/kent8192/obsidian/reinhardt-wiki` (Obsidian MCP: `obsidian-vault`)
+
+At the end of a meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned), update the Obsidian wiki:
+
+1. Check Obsidian MCP availability — if unavailable, **skip entirely** (do NOT block primary work)
+2. Read `wiki/hot.md` to check for duplicates
+3. Create/update pages under the appropriate category
+4. Update meta pages: `wiki/index.md`, `wiki/hot.md`, `wiki/log.md`
+
+**Skip when:** MCP unavailable, trivial changes, work in progress, or user requests skip.
+
+See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-4).
+
 ### Workflow Best Practices
 
 - Run dry-run for ALL batch operations before actual execution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,13 +331,16 @@ See instructions/RELEASE_PROCESS.md for detailed release procedures.
 At the end of a meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned), update the Obsidian wiki:
 
 1. Check Obsidian MCP availability — if unavailable, **skip entirely** (do NOT block primary work)
-2. Read `wiki/hot.md` to check for duplicates
-3. Create/update pages under the appropriate category
-4. Update meta pages: `wiki/index.md`, `wiki/hot.md`, `wiki/log.md`
+2. Use `/wiki-query` to retrieve relevant existing knowledge before answering or deciding (OW-5)
+3. Read `wiki/hot.md` to check for duplicates
+4. Create/update pages under the appropriate category
+5. Update meta pages: `wiki/index.md`, `wiki/hot.md`, `wiki/log.md`
+
+**Dual-write rule (OW-6):** When saving to any memory system (claude-mem, auto-memory, Serena), simultaneously invoke `/wiki-ingest` to persist the same knowledge in the Obsidian wiki.
 
 **Skip when:** MCP unavailable, trivial changes, work in progress, or emergency/hotfix work.
 
-See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-4).
+See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-6).
 
 ### Workflow Best Practices
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,14 +303,10 @@ This project uses [release-plz](https://release-plz.ieni.dev/) for automated rel
 4. Review and merge Release PR
 5. release-plz publishes to crates.io and creates Git tags
 
-**Manual Intervention:**
-- Edit Release PR to adjust CHANGELOG entries or versions if needed
-- Release PRs can be modified before merging
-
 **Release PR Branch Policy:**
-- **NEVER** push fixes or changes directly to a release-plz branch (`release-plz-*` or `develop-release-plz-*`)
-- If a fix is needed before merging a Release PR, create a `fix/` or `hotfix/` branch from the Release PR's **base branch** (e.g., `main` or `develop/*`), open a PR targeting that base branch, and merge it — release-plz will regenerate the Release PR automatically
-- Direct pushes to release-plz branches bypass the normal review workflow and may be overwritten when release-plz regenerates the PR
+- **NEVER** push code fixes directly to a release-plz branch (`release-plz-*` or `develop-release-plz-*`) — direct pushes bypass review and may be overwritten when release-plz regenerates the PR
+- If a code fix is needed before merging a Release PR, create a `fix/` or `hotfix/` branch from the Release PR's **base branch** (e.g., `main` or `develop/*`), open a PR targeting that base branch, and merge it — release-plz will regenerate the Release PR automatically
+- CHANGELOG or version edits on the Release PR branch are acceptable via GitHub UI when done immediately before merging (these are release metadata adjustments, not code changes)
 
 **Critical Rules:**
 - **MUST** use conventional commit format for proper version detection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,7 @@ At the end of a meaningful work unit (architectural decision, new pattern, troub
 3. Create/update pages under the appropriate category
 4. Update meta pages: `wiki/index.md`, `wiki/hot.md`, `wiki/log.md`
 
-**Skip when:** MCP unavailable, trivial changes, work in progress, or user requests skip.
+**Skip when:** MCP unavailable, trivial changes, work in progress, or emergency/hotfix work.
 
 See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-4).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,6 +307,11 @@ This project uses [release-plz](https://release-plz.ieni.dev/) for automated rel
 - Edit Release PR to adjust CHANGELOG entries or versions if needed
 - Release PRs can be modified before merging
 
+**Release PR Branch Policy:**
+- **NEVER** push fixes or changes directly to a release-plz branch (`release-plz-*` or `develop-release-plz-*`)
+- If a fix is needed before merging a Release PR, create a `fix/` or `hotfix/` branch from the Release PR's **base branch** (e.g., `main` or `develop/*`), open a PR targeting that base branch, and merge it — release-plz will regenerate the Release PR automatically
+- Direct pushes to release-plz branches bypass the normal review workflow and may be overwritten when release-plz regenerates the PR
+
 **Critical Rules:**
 - **MUST** use conventional commit format for proper version detection
 - **MUST** review Release PRs before merging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,21 @@ This project uses [release-plz](https://release-plz.ieni.dev/) for automated rel
 
 See instructions/RELEASE_PROCESS.md for detailed release procedures.
 
+### Obsidian Wiki Maintenance
+
+**Vault:** `/Users/kent8192/obsidian/reinhardt-wiki` (Obsidian MCP: `obsidian-vault`)
+
+At the end of a meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned), update the Obsidian wiki:
+
+1. Check Obsidian MCP availability — if unavailable, **skip entirely** (do NOT block primary work)
+2. Read `wiki/hot.md` to check for duplicates
+3. Create/update pages under the appropriate category
+4. Update meta pages: `wiki/index.md`, `wiki/hot.md`, `wiki/log.md`
+
+**Skip when:** MCP unavailable, trivial changes, work in progress, or user requests skip.
+
+See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-4).
+
 ### Workflow Best Practices
 
 - Run dry-run for ALL batch operations before actual execution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,13 +331,16 @@ See instructions/RELEASE_PROCESS.md for detailed release procedures.
 At the end of a meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned), update the Obsidian wiki:
 
 1. Check Obsidian MCP availability — if unavailable, **skip entirely** (do NOT block primary work)
-2. Read `wiki/hot.md` to check for duplicates
-3. Create/update pages under the appropriate category
-4. Update meta pages: `wiki/index.md`, `wiki/hot.md`, `wiki/log.md`
+2. Use `/wiki-query` to retrieve relevant existing knowledge before answering or deciding (OW-5)
+3. Read `wiki/hot.md` to check for duplicates
+4. Create/update pages under the appropriate category
+5. Update meta pages: `wiki/index.md`, `wiki/hot.md`, `wiki/log.md`
+
+**Dual-write rule (OW-6):** When saving to any memory system (claude-mem, auto-memory, Serena), simultaneously invoke `/wiki-ingest` to persist the same knowledge in the Obsidian wiki.
 
 **Skip when:** MCP unavailable, trivial changes, work in progress, or emergency/hotfix work.
 
-See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-4).
+See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-6).
 
 ### Workflow Best Practices
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,14 +303,10 @@ This project uses [release-plz](https://release-plz.ieni.dev/) for automated rel
 4. Review and merge Release PR
 5. release-plz publishes to crates.io and creates Git tags
 
-**Manual Intervention:**
-- Edit Release PR to adjust CHANGELOG entries or versions if needed
-- Release PRs can be modified before merging
-
 **Release PR Branch Policy:**
-- **NEVER** push fixes or changes directly to a release-plz branch (`release-plz-*` or `develop-release-plz-*`)
-- If a fix is needed before merging a Release PR, create a `fix/` or `hotfix/` branch from the Release PR's **base branch** (e.g., `main` or `develop/*`), open a PR targeting that base branch, and merge it — release-plz will regenerate the Release PR automatically
-- Direct pushes to release-plz branches bypass the normal review workflow and may be overwritten when release-plz regenerates the PR
+- **NEVER** push code fixes directly to a release-plz branch (`release-plz-*` or `develop-release-plz-*`) — direct pushes bypass review and may be overwritten when release-plz regenerates the PR
+- If a code fix is needed before merging a Release PR, create a `fix/` or `hotfix/` branch from the Release PR's **base branch** (e.g., `main` or `develop/*`), open a PR targeting that base branch, and merge it — release-plz will regenerate the Release PR automatically
+- CHANGELOG or version edits on the Release PR branch are acceptable via GitHub UI when done immediately before merging (these are release metadata adjustments, not code changes)
 
 **Critical Rules:**
 - **MUST** use conventional commit format for proper version detection

--- a/instructions/OBSIDIAN_WIKI.md
+++ b/instructions/OBSIDIAN_WIKI.md
@@ -92,6 +92,33 @@ When skipping, do NOT:
 
 ---
 
+## Wiki Query and Knowledge Retrieval (OW-5)
+
+Before answering questions or making decisions that may benefit from prior knowledge, query the wiki to improve response quality:
+
+1. Use `/wiki-query` to search for relevant existing knowledge in the vault
+2. Incorporate retrieved context into the current response or decision
+
+This enables accumulated project knowledge to inform ongoing work, reducing repeated investigation and improving consistency.
+
+---
+
+## Wiki Ingest — Synchronized Knowledge Capture (OW-6)
+
+When saving knowledge to any memory system (claude-mem, Claude Code auto-memory, Serena, or equivalent), **simultaneously** invoke `/wiki-ingest` to persist the same knowledge in the Obsidian wiki.
+
+**Trigger conditions (save to wiki at the same time as memory):**
+- claude-mem `memory_add` or `observation_add` — also `/wiki-ingest`
+- Claude Code auto-memory write (`Write` to `~/.claude/projects/.../memory/`) — also `/wiki-ingest`
+- Serena `write_memory` — also `/wiki-ingest`
+- Any other memory persistence operation
+
+**Rationale:** Memory systems are conversation-scoped or tool-scoped. The Obsidian wiki provides a durable, cross-session, human-browsable knowledge base. Dual-writing ensures knowledge is never siloed in a single system.
+
+**Skip conditions:** Same as OW-3 (MCP unavailable, trivial, emergency, or explicitly disabled). If Obsidian MCP is unavailable, proceed with the memory save alone — do NOT block it.
+
+---
+
 ## Quality Standards (OW-4)
 
 ### Content Quality
@@ -118,6 +145,8 @@ When skipping, do NOT:
 - Include YAML frontmatter on all wiki pages (OW-2)
 - Focus on actionable knowledge with "why" and "how" (OW-4)
 - Reference GitHub Issues/PRs for traceability (OW-4)
+- Use `/wiki-query` to retrieve existing knowledge before answering questions or making decisions (OW-5)
+- Dual-write: when saving to any memory system (claude-mem, auto-memory, Serena), simultaneously `/wiki-ingest` to the Obsidian wiki (OW-6)
 
 ### NEVER DO
 - Block primary work due to Obsidian MCP unavailability (OW-3)
@@ -125,3 +154,4 @@ When skipping, do NOT:
 - Duplicate information already in CLAUDE.md or `instructions/` (OW-4)
 - Record user interactions or conversation details in the wiki (OW-4)
 - Perform partial meta-page updates (update all three or none) (OW-2)
+- Save knowledge to a memory system without simultaneously writing to the wiki (OW-6), unless Obsidian MCP is unavailable

--- a/instructions/OBSIDIAN_WIKI.md
+++ b/instructions/OBSIDIAN_WIKI.md
@@ -83,7 +83,7 @@ The wiki update MUST be skipped entirely (no partial updates) when ANY of these 
 - Obsidian MCP server is unavailable or returns connection errors
 - The current work is trivial (no new knowledge generated)
 - The session is focused on emergency/hotfix work where speed is critical
-- The user explicitly requests skipping wiki updates
+- Wiki updates are explicitly disabled via configuration or skip flag
 
 When skipping, do NOT:
 - Report the skip as an error or warning

--- a/instructions/OBSIDIAN_WIKI.md
+++ b/instructions/OBSIDIAN_WIKI.md
@@ -1,0 +1,127 @@
+# Obsidian Wiki Maintenance
+
+## Purpose
+
+This file defines the policy for maintaining the Reinhardt project knowledge base in the Obsidian wiki vault. The wiki captures architecture decisions, development patterns, troubleshooting solutions, and lessons learned that would otherwise be lost between conversations.
+
+---
+
+## Vault Reference
+
+**Vault Path:** `/Users/kent8192/obsidian/reinhardt-wiki`
+**Access Method:** Obsidian MCP server (`obsidian-vault`)
+**Vault CLAUDE.md:** Contains structure, conventions, and operation instructions
+
+---
+
+## When to Update (OW-1)
+
+Update the Obsidian wiki at the **end of a meaningful work unit** — after committing or completing a logical chunk of work. A "meaningful work unit" includes:
+
+| Trigger | Example |
+|---------|---------|
+| Architectural decision made | Chose `Arc<dyn Trait>` over generic parameter for DI container |
+| New pattern discovered | Dead-code typecheck pattern for type-erased closures |
+| Troubleshooting solution found | CI OOM caused by arm64 runner memory limits |
+| Lesson learned from incident | Partial release failure recovery procedure |
+| Cross-cutting knowledge gained | Semgrep false-positive triggers on comment continuation lines |
+
+**DO NOT update for:**
+- Trivial changes (typo fixes, formatting, import reordering)
+- Work still in progress (uncommitted, untested)
+- Information already captured in the wiki (check `wiki/hot.md` first)
+- Operational records (PR creation logs, CI re-run triggers, review thread replies)
+
+---
+
+## Update Procedure (OW-2)
+
+### Step 1: Check Availability
+
+Attempt to call an Obsidian MCP tool (e.g., `obsidian_list_files_in_vault`).
+
+- **If available:** proceed to Step 2
+- **If unavailable (MCP error, connection refused, etc.):** skip the entire wiki update — do NOT block primary work
+
+### Step 2: Read Current Context
+
+1. Read `wiki/hot.md` for recent context
+2. Read `wiki/index.md` for the master catalog
+3. Determine whether the new knowledge is already captured
+
+### Step 3: Create or Update Pages
+
+Create new pages or update existing ones under the appropriate category:
+
+| Knowledge Type | Wiki Location | Template |
+|---------------|---------------|----------|
+| Code pattern / idiom | `wiki/knowledge/patterns/` | Pattern template |
+| Bug fix / workaround | `wiki/knowledge/troubleshooting/` | Troubleshooting template |
+| Lesson learned | `wiki/knowledge/learnings/` | Learning template |
+| Architecture decision | `wiki/decisions/` | ADR template |
+| Domain overview | `wiki/domains/` | Domain template |
+
+**Page Requirements:**
+- YAML frontmatter: `type`, `status`, `created`, `updated`, `tags` (minimum)
+- Use `[[Wikilink]]` format for cross-references
+- Content in English
+
+### Step 4: Update Meta Pages
+
+After creating or updating pages, update these meta pages:
+
+1. **`wiki/index.md`** — Add new page entries under the appropriate section
+2. **`wiki/hot.md`** — Refresh the "Recent Changes" and "Key Recent Facts" sections
+3. **`wiki/log.md`** — Append a new entry at the TOP with: date, mode, pages created/updated, sources
+
+---
+
+## Skip Conditions (OW-3)
+
+The wiki update MUST be skipped entirely (no partial updates) when ANY of these conditions are true:
+
+- Obsidian MCP server is unavailable or returns connection errors
+- The current work is trivial (no new knowledge generated)
+- The session is focused on emergency/hotfix work where speed is critical
+- The user explicitly requests skipping wiki updates
+
+When skipping, do NOT:
+- Report the skip as an error or warning
+- Retry the MCP connection
+- Block or delay primary work
+
+---
+
+## Quality Standards (OW-4)
+
+### Content Quality
+- Each page must provide actionable knowledge (not just a record of what happened)
+- Include the **why** — what constraint or context led to the decision/pattern
+- Include the **how** — concrete code examples or commands when applicable
+- Reference GitHub Issues/PRs for traceability (e.g., `#4624`, `PR #4627`)
+
+### Exclusions
+- Do NOT record operational details (which agent ran what, session IDs, timestamps of tool calls)
+- Do NOT duplicate information already in CLAUDE.md, AGENTS.md, or `instructions/`
+- Do NOT record user interactions or conversation details
+- Do NOT create pages for knowledge that is obvious from reading the code
+
+---
+
+## Quick Reference
+
+### MUST DO
+- Check Obsidian MCP availability before attempting wiki updates (OW-2)
+- Skip wiki update entirely if MCP is unavailable (OW-3)
+- Read `wiki/hot.md` before creating new pages to avoid duplicates (OW-2)
+- Update `wiki/index.md`, `wiki/hot.md`, and `wiki/log.md` after every page creation (OW-2)
+- Include YAML frontmatter on all wiki pages (OW-2)
+- Focus on actionable knowledge with "why" and "how" (OW-4)
+- Reference GitHub Issues/PRs for traceability (OW-4)
+
+### NEVER DO
+- Block primary work due to Obsidian MCP unavailability (OW-3)
+- Create wiki pages for trivial changes or operational records (OW-1)
+- Duplicate information already in CLAUDE.md or `instructions/` (OW-4)
+- Record user interactions or conversation details in the wiki (OW-4)
+- Perform partial meta-page updates (update all three or none) (OW-2)

--- a/instructions/OBSIDIAN_WIKI.md
+++ b/instructions/OBSIDIAN_WIKI.md
@@ -72,7 +72,7 @@ After creating or updating pages, update these meta pages:
 
 1. **`wiki/index.md`** — Add new page entries under the appropriate section
 2. **`wiki/hot.md`** — Refresh the "Recent Changes" and "Key Recent Facts" sections
-3. **`wiki/log.md`** — Append a new entry at the TOP with: date, mode, pages created/updated, sources
+3. **`wiki/log.md`** — Prepend a new entry at the TOP with: date, mode, pages created/updated, sources
 
 ---
 
@@ -114,7 +114,7 @@ When skipping, do NOT:
 - Check Obsidian MCP availability before attempting wiki updates (OW-2)
 - Skip wiki update entirely if MCP is unavailable (OW-3)
 - Read `wiki/hot.md` before creating new pages to avoid duplicates (OW-2)
-- Update `wiki/index.md`, `wiki/hot.md`, and `wiki/log.md` after every page creation (OW-2)
+- Update `wiki/index.md`, `wiki/hot.md`, and `wiki/log.md` after every page creation or update (OW-2)
 - Include YAML frontmatter on all wiki pages (OW-2)
 - Focus on actionable knowledge with "why" and "how" (OW-4)
 - Reference GitHub Issues/PRs for traceability (OW-4)

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -64,6 +64,10 @@
 - Run `cargo doc --no-deps` locally before pushing doc-related fixes
 - Run `cargo make semver-check` locally and post the output as a PR comment with the `<!-- local-semver-check -->` marker before converting Draft → Ready on any PR touching public API (see instructions/PR_GUIDELINE.md § RP-1a)
 - Execute merge/conflict resolution and straightforward operations immediately without Plan Mode
+- Update Obsidian wiki after meaningful work units (architectural decisions, new patterns, troubleshooting solutions) (OW-1)
+- Check Obsidian MCP availability before attempting wiki updates; skip entirely if unavailable (OW-2, OW-3)
+- Read `wiki/hot.md` before creating new pages to avoid duplicates (OW-2)
+- Update all three meta pages (`wiki/index.md`, `wiki/hot.md`, `wiki/log.md`) after every wiki page creation (OW-2)
 - Use worktree-based merge strategy for PR conflict resolution (NOT rebase/force-push)
 - Apply `migration-approved` label to develop/* → main PRs (requires maintainer approval for version transition)
 - Apply `agent-suspect` label to all agent-detected bug Issues
@@ -173,6 +177,10 @@
 - Create upstream issues without corresponding reinhardt-web tracking issues (UR-4)
 - Apply `good first issue` to security, breaking-change, agent-suspect, or high/critical priority issues (GFI-2)
 - Apply `good first issue` without verifying issue description has sufficient guidance for new contributors (GFI-4)
+- Block primary work due to Obsidian MCP unavailability (OW-3)
+- Create wiki pages for trivial changes or operational records (OW-1)
+- Duplicate information already in CLAUDE.md or `instructions/` in the wiki (OW-4)
+- Perform partial meta-page updates (update all three meta pages or none) (OW-2)
 
 ### 📚 Detailed Standards
 
@@ -193,6 +201,7 @@ For comprehensive guidelines, see:
 - **Upstream Issue Reporting**: instructions/UPSTREAM_ISSUE_REPORTING.md
 - **GitHub Interactions**: instructions/GITHUB_INTERACTION.md
 - **Copilot Review Handling**: instructions/GITHUB_INTERACTION.md (CR-1 ~ CR-5)
+- **Obsidian Wiki Maintenance**: instructions/OBSIDIAN_WIKI.md (OW-1 ~ OW-4)
 - **GitHub Discussions**: https://github.com/kent8192/reinhardt-web/discussions
 - **Security Policy**: SECURITY.md
 - **Code of Conduct**: CODE_OF_CONDUCT.md

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -121,7 +121,7 @@
 - Use `reinhardt-test = { workspace = true }` in functional crate `[dev-dependencies]` (workspace deps include version, causing publish failures; use optional dep or path-only dev-dep instead)
 - Omit `version` field from `reinhardt-test` workspace dependency (causes publish failure for dependents)
 - Change `pr_branch_prefix` from `"release-plz-"` on `main` (breaks two-step release workflow); on `develop/*` the prefix MUST be `"develop-release-plz-"` to prevent cross-branch PR closure
-- Push fixes or changes directly to release-plz branches (`release-plz-*` or `develop-release-plz-*`) — create a fix/hotfix branch targeting the base branch instead
+- Push code fixes directly to release-plz branches (`release-plz-*` or `develop-release-plz-*`) — create a fix/hotfix branch targeting the base branch instead (CHANGELOG/version edits via GitHub UI are acceptable)
 - Merge Release PR without rolling back unpublished crate versions after partial release failure
 - Write vague commit descriptions that are unclear as CHANGELOG entries (e.g., "fix issue", "update code")
 - Start commit description with uppercase letter

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -68,7 +68,7 @@
 - Update Obsidian wiki after meaningful work units (architectural decisions, new patterns, troubleshooting solutions) (OW-1)
 - Check Obsidian MCP availability before attempting wiki updates; skip entirely if unavailable (OW-2, OW-3)
 - Read `wiki/hot.md` before creating new pages to avoid duplicates (OW-2)
-- Update all three meta pages (`wiki/index.md`, `wiki/hot.md`, `wiki/log.md`) after every wiki page creation (OW-2)
+- Update all three meta pages (`wiki/index.md`, `wiki/hot.md`, `wiki/log.md`) after every wiki page creation or update (OW-2)
 - Use worktree-based merge strategy for PR conflict resolution (NOT rebase/force-push)
 - Apply `migration-approved` label to develop/* → main PRs (requires maintainer approval for version transition)
 - Apply `agent-suspect` label to all agent-detected bug Issues

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -69,6 +69,8 @@
 - Check Obsidian MCP availability before attempting wiki updates; skip entirely if unavailable (OW-2, OW-3)
 - Read `wiki/hot.md` before creating new pages to avoid duplicates (OW-2)
 - Update all three meta pages (`wiki/index.md`, `wiki/hot.md`, `wiki/log.md`) after every wiki page creation or update (OW-2)
+- Use `/wiki-query` to retrieve existing wiki knowledge before answering questions or making decisions (OW-5)
+- Dual-write: when saving to any memory system (claude-mem, auto-memory, Serena), simultaneously `/wiki-ingest` to the Obsidian wiki (OW-6)
 - Use worktree-based merge strategy for PR conflict resolution (NOT rebase/force-push)
 - Apply `migration-approved` label to develop/* → main PRs (requires maintainer approval for version transition)
 - Apply `agent-suspect` label to all agent-detected bug Issues

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -25,6 +25,7 @@
 - Use `security` type for security vulnerability fixes (dedicated CHANGELOG section)
 - Use `deprecated` type for marking features/APIs as deprecated (dedicated CHANGELOG section)
 - Review Release PRs created by release-plz before merging
+- Fix Release PR issues via a `fix/`/`hotfix/` branch targeting the Release PR's base branch (e.g., `main`), not by pushing to the release-plz branch directly
 - Verify no circular dev-dependency chains exist before publishing (functional crates must not dev-depend on other Reinhardt crates)
 - Include `version` field in `reinhardt-test` workspace dependency (published crate, same as others)
 - Follow RP-1 procedure in instructions/RELEASE_PROCESS.md for partial release failures
@@ -120,6 +121,7 @@
 - Use `reinhardt-test = { workspace = true }` in functional crate `[dev-dependencies]` (workspace deps include version, causing publish failures; use optional dep or path-only dev-dep instead)
 - Omit `version` field from `reinhardt-test` workspace dependency (causes publish failure for dependents)
 - Change `pr_branch_prefix` from `"release-plz-"` on `main` (breaks two-step release workflow); on `develop/*` the prefix MUST be `"develop-release-plz-"` to prevent cross-branch PR closure
+- Push fixes or changes directly to release-plz branches (`release-plz-*` or `develop-release-plz-*`) — create a fix/hotfix branch targeting the base branch instead
 - Merge Release PR without rolling back unpublished crate versions after partial release failure
 - Write vague commit descriptions that are unclear as CHANGELOG entries (e.g., "fix issue", "update code")
 - Start commit description with uppercase letter


### PR DESCRIPTION
## Summary

This PR addresses:

- Add Obsidian wiki maintenance policy as a new instruction file (`instructions/OBSIDIAN_WIKI.md`)
- Add summary section to `CLAUDE.md` and `AGENTS.md` (synced)
- Add MUST DO / NEVER DO items and detailed standards reference to `QUICK_REFERENCE.md`

## Type of Change

- [x] Documentation update

## Breaking Change Assessment

**No** — documentation-only change, no code impact.

## Motivation and Context

The Obsidian wiki vault at `/Users/kent8192/obsidian/reinhardt-wiki` captures architecture decisions, development patterns, troubleshooting solutions, and lessons learned. Previously, there were no instructions for when or how to update it. This PR codifies the maintenance policy so the wiki stays current as the project evolves.

## How Was This Tested?

- [x] Verified `CLAUDE.md` ↔ `AGENTS.md` diff contains only documented substitutions
- [x] Verified instruction file follows existing conventions (rule IDs, section structure)
- [x] Verified `QUICK_REFERENCE.md` additions are consistent with `OBSIDIAN_WIKI.md` rules

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Release PR Branch Policy: require fixes via separate fix/hotfix branches targeting the Release PR base (no direct pushes to release branches); allows CHANGELOG/version edits on the Release PR branch via UI immediately before merging.
  * Added formal Obsidian wiki maintenance standards and a new policy doc: when/how to update, skip rules for tool unavailability, duplicate checks, content-quality exclusions, and mandatory meta-page updates.
  * Updated quick-reference and guidance docs to link and reflect the new policies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->