### PR TITLE
fix(admin-cli): traverse past sub-crate Cargo.toml when searching for rustfmt config

### DIFF
--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -1306,7 +1306,7 @@ fn find_rustfmt_config(start_path: &Path) -> Option<PathBuf> {
 		Some(start_path)
 	}?;
 
-	loop {
+	for _ in 0..MAX_PROJECT_ROOT_DEPTH {
 		let config = current.join("rustfmt.toml");
 		if std::fs::metadata(&config).is_ok() {
 			return Some(config);
@@ -1314,9 +1314,6 @@ fn find_rustfmt_config(start_path: &Path) -> Option<PathBuf> {
 		let hidden_config = current.join(".rustfmt.toml");
 		if std::fs::metadata(&hidden_config).is_ok() {
 			return Some(hidden_config);
-		}
-		if std::fs::metadata(current.join("Cargo.toml")).is_ok() {
-			break;
 		}
 		current = current.parent()?;
 	}


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix `find_rustfmt_config` in `reinhardt-admin fmt <file>` to correctly discover `rustfmt.toml` in workspace layouts (develop/0.2.0 branch)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

`reinhardt-admin fmt <file>` and `fmt-all` produce different output because `find_rustfmt_config` stops searching upward at the first `Cargo.toml` it encounters. In a workspace, a sub-crate's `Cargo.toml` is found before the workspace root's `rustfmt.toml`, so `fmt <file>` falls back to `--edition=2024` only and misses all `rustfmt.toml` settings (`max_width=100`, `hard_tabs=true`, etc.). Meanwhile, `fmt-all` uses `cargo fmt --all` which correctly discovers `rustfmt.toml` from the workspace root.

Fixes #4905

Related to: #4906

## How Was This Tested?

- `cargo check -p reinhardt-admin-cli --all-features` passes
- Manual code review confirms the `Cargo.toml` early-exit is removed and replaced with depth-limited traversal using the existing `MAX_PROJECT_ROOT_DEPTH` constant

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4905
- Mirror of #4906 (main branch)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels

---

**Additional Context:**

This is the develop/0.2.0 branch counterpart of #4906. The fix is identical: replace the unbounded `loop` with a `for _ in 0..MAX_PROJECT_ROOT_DEPTH` loop and remove the three lines that checked for `Cargo.toml` and broke early. This aligns `find_rustfmt_config` with the same traversal pattern used by `find_project_root`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file search with a bounded depth limit to prevent excessive traversal and enhance performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->