### PR TITLE
fix(ci): resolve develop/0.2.0 CI failures

### DIFF
--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/bare_ident/expected.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/bare_ident/expected.rs
@@ -3,12 +3,8 @@ fn render(name: String) {
     let _ = page!(|name: String| {
 	div {
 		class: "greeting",
-		h1 {
-			{ name }
-		}
-		p {
-			{ name }
-		}
+		h1 { { name } }
+		p { { name } }
 	}
 })(name);
 }

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/bare_ident/input.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/bare_ident/input.rs
@@ -4,12 +4,8 @@ fn render(name: String) {
 	let _ = page!(|name: String| {
 		div {
 			class: "greeting",
-			h1 {
-				name
-			}
-			p {
-				name
-			}
+			h1 { name }
+			p { name }
 		}
 	})(name);
 }

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/watch_unwrap/expected.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/watch_unwrap/expected.rs
@@ -3,14 +3,10 @@ use reinhardt_pages::reactive::Signal;
 fn r(count: Signal<i32>) {
     let _ = page!(|count: Signal<i32>| {
 	div {
-		if count.get()> 0 {
-			p {
-				"positive"
-			}
+		if count.get() > 0 {
+			p { "positive" }
 		} else {
-			p {
-				"non-positive"
-			}
+			p { "non-positive" }
 		}
 	}
 })(count);

--- a/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/watch_unwrap/input.rs
+++ b/crates/reinhardt-admin-cli/tests/fixtures/migrate_v2/watch_unwrap/input.rs
@@ -5,14 +5,10 @@ fn r(count: Signal<i32>) {
 	let _ = page!(|count: Signal<i32>| {
 		div {
 			watch {
-				if count.get()> 0 {
-					p {
-						"positive"
-					}
+				if count.get() > 0 {
+					p { "positive" }
 				} else {
-					p {
-						"non-positive"
-					}
+					p { "non-positive" }
 				}
 			}
 		}

--- a/crates/reinhardt-admin/src/pages/components/common.rs
+++ b/crates/reinhardt-admin/src/pages/components/common.rs
@@ -80,8 +80,8 @@ pub fn button(text: &str, variant: ButtonVariant, disabled: bool, on_click: Sign
 			class: classes,
 			type: "button",
 			@click: move |_| {
-						_on_click.set(true);
-					},
+				_on_click.set(true);
+			},
 			{ text }
 		}
 	})(classes, text, on_click)
@@ -133,9 +133,7 @@ pub fn error_display(message: &str, dismissible: bool) -> Page {
 			div {
 				class: "admin-alert admin-alert-danger flex items-start justify-between animate__animated animate__shakeX",
 				role: "alert",
-				span {
-					{ message }
-				}
+				span { { message } }
 				button {
 					class: "ml-4 text-red-400 hover:text-red-600 cursor-pointer",
 					type: "button",
@@ -247,7 +245,7 @@ where
 			span {
 				class: "admin-page-link admin-page-link-disabled",
 				aria_disabled: "true",
-				tabindex: (- 1_i32).to_string(),
+				tabindex: (-1_i32).to_string(),
 				{ text }
 			}
 		})(text)
@@ -261,13 +259,13 @@ where
 		})(text)
 	} else {
 		let handler: Arc<dyn Fn(Signal<u64>)> = Arc::new(handler);
-		page!(|text: String, _signal: Signal<u64>, _handler: Arc<dyn Fn(Signal<u64>)>| {
+		page!(|text: String, _signal: Signal<u64>, _handler: Arc<dyn Fn(Signal<u64>) >| {
 			a {
 				class: "admin-page-link",
 				href: "#",
 				@click: move |_| {
-							_handler(_signal.clone());
-						},
+					_handler(_signal.clone());
+				},
 				{ text }
 			}
 		})(text, signal, handler)

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -71,7 +71,9 @@ pub fn dashboard(site_name: &str, models: &[ModelInfo]) -> Page {
 			class: "dashboard animate__animated animate__fadeIn",
 			h1 {
 				class: "font-display text-2xl font-bold text-slate-900 mb-6",
-				{ format!("{} Dashboard", site_name) }
+				{
+					format!("{} Dashboard", site_name)
+				}
 			}
 			{ grid }
 		}
@@ -230,23 +232,17 @@ fn data_table(
 		.map(|col| {
 			let label = col.label.clone();
 			page!(|label: String| {
-				th {
-					{ label }
-				}
+				th { { label } }
 			})(label)
 		})
 		.chain(std::iter::once(page!(|| {
-			th {
-				"Actions"
-			}
+			th { "Actions" }
 		})()))
 		.collect();
 
 	let thead = page!(|header_cells: Vec<Page>| {
 		thead {
-			tr {
-				{ header_cells }
-			}
+			tr { { header_cells } }
 		}
 	})(header_cells);
 
@@ -256,9 +252,7 @@ fn data_table(
 		.collect();
 
 	let tbody = page!(|body_rows: Vec<Page>| {
-		tbody {
-			{ body_rows }
-		}
+		tbody { { body_rows } }
 	})(body_rows);
 
 	page!(|thead: Page, tbody: Page| {
@@ -287,9 +281,7 @@ fn table_row(
 				.cloned()
 				.unwrap_or_else(|| "-".to_string());
 			page!(|value: String| {
-				td {
-					{ value }
-				}
+				td { { value } }
 			})(value)
 		})
 		.collect();
@@ -297,9 +289,7 @@ fn table_row(
 	let record_id = record.get("id").cloned().unwrap_or_else(|| "0".to_string());
 	let actions = action_buttons(model_name, &record_id);
 	let actions_cell = page!(|actions: Page| {
-		td {
-			{ actions }
-		}
+		td { { actions } }
 	})(actions);
 
 	page!(|data_cells: Vec<Page>, actions_cell: Page| {
@@ -435,9 +425,7 @@ fn detail_table(record: &std::collections::HashMap<String, String>) -> Page {
 			class: "overflow-x-auto rounded-lg border border-slate-200",
 			table {
 				class: "admin-table",
-				tbody {
-					{ rows }
-				}
+				tbody { { rows } }
 			}
 		}
 	})(rows)
@@ -788,9 +776,7 @@ fn create_filter_select(
 		})
 		.collect();
 	let options_container = page!(|options: Vec<Page>| {
-		span {
-			{ options }
-		}
+		span { { options } }
 	})(options);
 	let field_str = field.to_string();
 
@@ -799,21 +785,21 @@ fn create_filter_select(
 			class: "admin-select",
 			data_filter_field: field_str.clone(),
 			@change: move |event| {
-						use wasm_bindgen::JsCast;
-						if let Some(target) = event.target() {
-							if let Ok(select_el) = target.dyn_into::<web_sys::HtmlSelectElement>() {
-								let value = select_el.value();
-								let field = field_str.clone();
-								_filters_signal.update(move |map| {
-									if value.is_empty() {
-										map.remove(&field);
-									} else {
-										map.insert(field, value);
-									}
-								});
+				use wasm_bindgen::JsCast;
+				if let Some(target) = event.target() {
+					if let Ok(select_el) = target.dyn_into::<web_sys::HtmlSelectElement>() {
+						let value = select_el.value();
+						let field = field_str.clone();
+						_filters_signal.update(move |map| {
+							if value.is_empty() {
+								map.remove(&field);
+							} else {
+								map.insert(field, value);
 							}
-						}
-					},
+						});
+					}
+				}
+			},
 			{ options_container }
 		}
 	})(field_str, filters_signal, options_container)

--- a/crates/reinhardt-auth/build.rs
+++ b/crates/reinhardt-auth/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+	println!("cargo::rustc-check-cfg=cfg(wasm)");
+	println!("cargo::rustc-check-cfg=cfg(native)");
+}

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -4923,7 +4923,11 @@ fn generate_info_struct(
 		&orm_crate,
 	)?;
 
+	let info_doc = format!("Data-transfer companion for [`{}`].", struct_name);
+
 	Ok(quote! {
+		#[doc = #info_doc]
+		#[allow(missing_docs)]
 		#[derive(Debug, Clone, PartialEq #extra_derives_tokens)]
 		#validate_derive
 		pub struct #info_name #impl_generics #where_clause {
@@ -5100,6 +5104,7 @@ fn generate_info_builder(
 			if let Some(target_type) = fk_target_map.get(&field_name_str) {
 				// FK field: accept impl IntoPrimaryKey<TargetModel>
 				quote! {
+					#[allow(missing_docs)]
 					impl<#(#free_state_params),*> #builder_name<#(#input_states),*> {
 						pub fn #name<__FkArg>(mut self, value: __FkArg)
 							-> #builder_name<#(#output_states),*>
@@ -5119,6 +5124,7 @@ fn generate_info_builder(
 				let is_string = matches!(ty, Type::Path(p) if p.path.segments.last().is_some_and(|s| s.ident == "String"));
 				if is_string {
 					quote! {
+						#[allow(missing_docs)]
 						impl<#(#free_state_params),*> #builder_name<#(#input_states),*> {
 							pub fn #name(mut self, value: impl ::std::convert::Into<String>)
 								-> #builder_name<#(#output_states),*>
@@ -5133,6 +5139,7 @@ fn generate_info_builder(
 					}
 				} else {
 					quote! {
+						#[allow(missing_docs)]
 						impl<#(#free_state_params),*> #builder_name<#(#input_states),*> {
 							pub fn #name(mut self, value: #ty)
 								-> #builder_name<#(#output_states),*>
@@ -5151,11 +5158,13 @@ fn generate_info_builder(
 		.collect();
 
 	Ok(quote! {
+		#[allow(missing_docs)]
 		pub struct #builder_name<#(#state_names = ()),*> {
 			#(#builder_fields)*
 			_state: ::std::marker::PhantomData<(#(#state_names),*)>,
 		}
 
+		#[allow(missing_docs)]
 		impl #info_name #ty_generics #where_clause {
 			pub fn build() -> #builder_name<#(#initial_states),*> {
 				#builder_name {
@@ -5167,6 +5176,7 @@ fn generate_info_builder(
 
 		#(#setter_methods)*
 
+		#[allow(missing_docs)]
 		impl #builder_name<#(#final_states),*> {
 			pub fn finish(self) -> #info_name #ty_generics #where_clause {
 				#info_name {

--- a/crates/reinhardt-di/src/context.rs
+++ b/crates/reinhardt-di/src/context.rs
@@ -602,10 +602,10 @@ impl InjectionContext {
 	)> {
 		use crate::registry::global_registry;
 
-		if let Some(ref reg) = self.registry {
-			if let Some(scope) = reg.get_scope::<T>() {
-				return Some((scope, reg));
-			}
+		if let Some(ref reg) = self.registry
+			&& let Some(scope) = reg.get_scope::<T>()
+		{
+			return Some((scope, reg));
 		}
 		let global = global_registry();
 		global.get_scope::<T>().map(|scope| (scope, global))

--- a/crates/reinhardt-pages/tests/component_invocation_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/component_invocation_integration_tests.rs
@@ -23,10 +23,12 @@ struct CardProps {
 fn card(props: CardProps) -> Page {
 	page!(|p: CardProps| {
 		article {
-			h2 {
-				{ p.item.clone() }
+			h2 { {
+				p.item.clone()
+			} }
+			{
+				p.children.clone().unwrap_or_else(Page::empty)
 			}
-			{ p.children.clone().unwrap_or_else(Page::empty) }
 		}
 	})(props)
 }
@@ -36,7 +38,9 @@ fn brace_invocation_compiles_and_renders() {
 	// Arrange + Act
 	let v = page!(|| {
 		div {
-			Card { item: "hello".to_string() }
+			Card {
+				item: "hello".to_string()
+			}
 		}
 	})();
 
@@ -55,7 +59,10 @@ fn brace_invocation_with_single_child() {
 	// Arrange + Act
 	let v = page!(|| {
 		div {
-			Card { item: "outer".to_string(), p { "inner" } }
+			Card {
+				item: "outer".to_string(),
+				p { "inner" }
+			}
 		}
 	})();
 
@@ -72,7 +79,11 @@ fn brace_invocation_with_multiple_children() {
 	// Arrange + Act
 	let v = page!(|| {
 		div {
-			Card { item: "outer".to_string(), p { "one" }, p { "two" } }
+			Card {
+				item: "outer".to_string(),
+				p { "one" },
+				p { "two" }
+			}
 		}
 	})();
 
@@ -103,9 +114,9 @@ fn nested_component_inside_for_loop() {
 	fn item_card(p: ItemCardProps) -> Page {
 		page!(|p: ItemCardProps| {
 			article {
-				h2 {
-					{ p.title.clone() }
-				}
+				h2 { {
+					p.title.clone()
+				} }
 			}
 		})(p)
 	}
@@ -114,7 +125,9 @@ fn nested_component_inside_for_loop() {
 	let v = page!(|titles: Vec<String>| {
 		div {
 			for t in titles.iter() {
-				ItemCard { title: t.clone() }
+				ItemCard {
+					title: t.clone()
+				}
 			}
 		}
 	})(titles);

--- a/crates/reinhardt-pages/tests/reactive_autowrap_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/reactive_autowrap_integration_tests.rs
@@ -26,9 +26,9 @@ fn expression_rerenders_when_signal_changes() {
 	// Arrange
 	let count = Signal::new(0_i32);
 	let view = page!(|count: Signal<i32>| {
-		div {
-			{ count.get().to_string() }
-		}
+		div { {
+			count.get().to_string()
+		} }
 	})(count.clone());
 
 	let snapshot_a = render(&view);
@@ -56,9 +56,7 @@ fn if_branch_rerenders_when_condition_signal_changes() {
 	let view = page!(|flag: Signal<bool>| {
 		div {
 			if flag.get() {
-				p {
-					"ON"
-				}
+				p { "ON" }
 			}
 		}
 	})(flag.clone());
@@ -84,7 +82,11 @@ fn for_loop_rerenders_when_items_signal_changes() {
 	let items = Signal::new(vec![1_i32, 2, 3]);
 	let view = page!(|items: Signal<Vec<i32>>| {
 		ul {
-			for x in items.get().into_iter() { li { {x.to_string()} } }
+			for x in items.get().into_iter() {
+				li { {
+					x.to_string()
+				} }
+			}
 		}
 	})(items.clone());
 

--- a/crates/reinhardt-pages/tests/ui/form/fail/char_field_with_generic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/char_field_with_generic.rs
@@ -7,10 +7,8 @@ fn main() {
 	let _ = form! {
 		name: BadForm,
 		action: "/x",
-
 		fields: {
 			username: CharField,
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/fail/derived_duplicate_name.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/derived_duplicate_name.rs
@@ -7,7 +7,6 @@ fn main() {
 	let _form = form! {
 		name: DuplicateForm,
 		action: "/api/submit",
-
 		fields: {
 			x: IntegerField {
 				required,
@@ -16,11 +15,9 @@ fn main() {
 				required,
 			}
 		}
-
 		derived: {
 			value: |form| form.x().get() + form.y().get(),
 			value: |form| form.x().get() * form.y().get(),
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/fail/hidden_field_no_default.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/hidden_field_no_default.rs
@@ -26,10 +26,8 @@ fn main() {
 	let _ = form! {
 		name: BadForm,
 		action: "/x",
-
 		fields: {
 			data: HiddenField,
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/fail/hidden_field_zero_args.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/hidden_field_zero_args.rs
@@ -9,9 +9,8 @@ fn main() {
 	let _ = form! {
 		name: BadForm,
 		action: "/x",
-
 		fields: {
-			question_id: HiddenField<> { },
+			question_id: HiddenField<> {},
 		},
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/fail/ip_address_with_generic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/ip_address_with_generic.rs
@@ -7,10 +7,8 @@ fn main() {
 	let _ = form! {
 		name: BadForm,
 		action: "/x",
-
 		fields: {
 			client_ip: IpAddressField,
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_duplicate_key.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_duplicate_key.rs
@@ -12,13 +12,11 @@ fn main() {
 			csrf_token: String::new(),
 			csrf_token: String::from("again"),
 		},
-
 		fields: {
 			payload: CharField {
 				required,
 			}
 		}
-
 	};
 }
 

--- a/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_field_collision.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/strip_arguments_field_collision.rs
@@ -15,13 +15,11 @@ fn main() {
 		strip_arguments: {
 			tenant_id: 0u64,
 		},
-
 		fields: {
 			tenant_id: IntegerField {
 				required,
 			}
 		}
-
 	};
 }
 

--- a/crates/reinhardt-pages/tests/ui/form/pass/basic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/basic.rs
@@ -7,7 +7,6 @@ fn main() {
 	let _login_form = form! {
 		name: LoginForm,
 		action: "/api/login",
-
 		fields: {
 			username: CharField {
 				required,
@@ -17,6 +16,5 @@ fn main() {
 				widget: PasswordInput,
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_boolean_field.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_boolean_field.rs
@@ -6,12 +6,10 @@ fn main() {
 	let _ = form! {
 		name: ToggleForm,
 		action: "/api/toggle",
-
 		fields: {
 			enabled: BooleanField {
 				initial: false,
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_choice_typed.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_choice_typed.rs
@@ -6,7 +6,6 @@ fn main() {
 	let _ = form! {
 		name: TypedChoiceForm,
 		action: "/api/typed-choice",
-
 		fields: {
 			priority: ChoiceField<i64> {
 				required,
@@ -15,6 +14,5 @@ fn main() {
 				choice_label: "name",
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_date_field.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_date_field.rs
@@ -6,10 +6,8 @@ fn main() {
 	let _ = form! {
 		name: EventForm,
 		action: "/api/event",
-
 		fields: {
 			start_date: DateField,
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_integer_field.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_integer_field.rs
@@ -6,12 +6,10 @@ fn main() {
 	let _ = form! {
 		name: CounterForm,
 		action: "/api/counter",
-
 		fields: {
 			count: IntegerField {
 				initial: 0i64,
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_ip_address.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_ip_address.rs
@@ -6,10 +6,8 @@ fn main() {
 	let _ = form! {
 		name: NetworkForm,
 		action: "/api/network",
-
 		fields: {
 			server_ip: IpAddressField,
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_json_field.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_json_field.rs
@@ -22,12 +22,10 @@ fn main() {
 	let _ = form! {
 		name: MetadataForm,
 		action: "/api/metadata",
-
 		fields: {
 			data: JsonField {
 				initial: Metadata::default(),
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_multiple_choice.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/bind_listener_multiple_choice.rs
@@ -6,7 +6,6 @@ fn main() {
 	let _ = form! {
 		name: TagsForm,
 		action: "/api/tags",
-
 		fields: {
 			tag_ids: MultipleChoiceField<i64> {
 				choices_from: "tags",
@@ -14,6 +13,5 @@ fn main() {
 				choice_label: "name",
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/choice_field_typed_i64.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/choice_field_typed_i64.rs
@@ -6,7 +6,6 @@ fn main() {
 	let _ = form! {
 		name: ChoiceForm,
 		action: "/api/choice",
-
 		fields: {
 			choice_id: ChoiceField<i64> {
 				required,
@@ -15,6 +14,5 @@ fn main() {
 				choice_label: "label",
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/choices_loader_basic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/choices_loader_basic.rs
@@ -18,7 +18,6 @@ fn main() {
 				choice_label: "choice_text",
 			}
 		}
-
 	};
 }
 

--- a/crates/reinhardt-pages/tests/ui/form/pass/csrf_auto_injection.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/csrf_auto_injection.rs
@@ -13,7 +13,6 @@ fn main() {
 				required,
 			}
 		}
-
 	};
 
 	// PUT form also includes CSRF token
@@ -26,7 +25,6 @@ fn main() {
 				required,
 			}
 		}
-
 	};
 
 	// PATCH form includes CSRF token
@@ -39,7 +37,6 @@ fn main() {
 				required,
 			}
 		}
-
 	};
 
 	// DELETE form includes CSRF token
@@ -52,7 +49,6 @@ fn main() {
 				required,
 			}
 		}
-
 	};
 
 	// GET form does NOT include CSRF token (safe method)
@@ -65,6 +61,5 @@ fn main() {
 				required,
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/derived_basic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/derived_basic.rs
@@ -10,17 +10,14 @@ fn main() {
 	let _tweet_form = form! {
 		name: TweetForm,
 		action: "/api/tweets",
-
 		fields: {
 			content: CharField {
 				required,
 				bind: true,
 			}
 		}
-
 		derived: {
 			char_count: |form| form.content().get().len(),
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/hidden_field_default_string.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/hidden_field_default_string.rs
@@ -7,12 +7,10 @@ fn main() {
 	let _ = form! {
 		name: LegacyForm,
 		action: "/api/legacy",
-
 		fields: {
 			note: HiddenField {
 				initial: "hello".to_string(),
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/hidden_field_typed_i64.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/hidden_field_typed_i64.rs
@@ -6,12 +6,10 @@ fn main() {
 	let _ = form! {
 		name: NumericForm,
 		action: "/api/numeric",
-
 		fields: {
 			question_id: HiddenField {
 				initial: 42i64,
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/initial_and_inner_watch_capture_outer_local.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/initial_and_inner_watch_capture_outer_local.rs
@@ -22,12 +22,10 @@ fn main() {
 	let _form = form! {
 		name: CaptureFormFourTwoZero,
 		action: "/api/capture-4420",
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			counter: HiddenField {
 				initial: outer_initial.to_string(),
@@ -37,19 +35,17 @@ fn main() {
 				initial: outer_label.clone(),
 			}
 		}
-
 		watch: {
 			submit_button: |form| {
-					let _is_loading = form.loading().get();
-				},
+				let _is_loading = form.loading().get();
+			},
 			error_display: |form| {
-					let _err = form.error().get();
-				},
+				let _err = form.error().get();
+			},
 			success_navigation: |form| {
-					let _is_loading = form.loading().get();
-					let _captured = outer_label.clone();
-				},
+				let _is_loading = form.loading().get();
+				let _captured = outer_label.clone();
+			},
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/ip_address_field_specialized.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/ip_address_field_specialized.rs
@@ -6,10 +6,8 @@ fn main() {
 	let _ = form! {
 		name: NetForm,
 		action: "/api/net",
-
 		fields: {
 			client_ip: IpAddressField,
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/json_field_typed.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/json_field_typed.rs
@@ -31,12 +31,10 @@ fn main() {
 	let _ = form! {
 		name: PrefsForm,
 		action: "/api/prefs",
-
 		fields: {
 			prefs: JsonField {
 				initial: UserPrefs::default(),
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/multiple_choice_typed.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/multiple_choice_typed.rs
@@ -6,7 +6,6 @@ fn main() {
 	let _ = form! {
 		name: TagForm,
 		action: "/api/tags",
-
 		fields: {
 			tag_ids: MultipleChoiceField<i64> {
 				choices_from: "tags",
@@ -14,6 +13,5 @@ fn main() {
 				choice_label: "name",
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/on_success_captures_outer_local.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/on_success_captures_outer_local.rs
@@ -29,7 +29,6 @@ fn main() {
 	let _form = form! {
 		name: OnSuccessCaptureForm,
 		server_fn: submit_vote,
-
 		fields: {
 			_question_id: IntegerField {
 				widget: HiddenInput,
@@ -38,11 +37,9 @@ fn main() {
 				required,
 			}
 		}
-
 		on_success: |_value: i64| {
-				let _captured = target_id;
-			},
-
+			let _captured = target_id;
+		},
 	};
 }
 

--- a/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_and_on_success_coexist.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_and_on_success_coexist.rs
@@ -29,17 +29,15 @@ fn main() {
 	let _form = form! {
 		name: DualCallbackForm,
 		server_fn: update_profile,
-
 		fields: {
 			name: CharField {
 				required,
 			}
 		}
-
 		on_success: |_value| {},
-		on_success_ref: |_form, _updated: &i64| {
-				let _captured = user_id;
-			},
-
+		on_success_ref: |_form,
+		_updated: &i64| {
+			let _captured = user_id;
+		},
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_captures_outer_local.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/on_success_ref_captures_outer_local.rs
@@ -41,16 +41,14 @@ fn main() {
 	let _form = form! {
 		name: ProfileForm,
 		server_fn: update_profile,
-
 		fields: {
 			name: CharField {
 				required,
 			}
 		}
-
-		on_success_ref: |_form, _updated: &i64| {
-				let _captured = user_id;
-			},
-
+		on_success_ref: |_form,
+		_updated: &i64| {
+			let _captured = user_id;
+		},
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/server_fn_action.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/server_fn_action.rs
@@ -15,7 +15,6 @@ fn main() {
 				required,
 			}
 		}
-
 	};
 }
 

--- a/crates/reinhardt-pages/tests/ui/form/pass/server_fn_action_use.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/server_fn_action_use.rs
@@ -25,6 +25,5 @@ fn main() {
 				required,
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/strip_arguments_basic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/strip_arguments_basic.rs
@@ -17,7 +17,6 @@ fn main() {
 		strip_arguments: {
 			csrf_token: String::new(),
 		},
-
 		fields: {
 			_question_id: IntegerField {
 				widget: HiddenInput,
@@ -26,7 +25,6 @@ fn main() {
 				required,
 			}
 		}
-
 	};
 
 	// Multiple stripped arguments append in source order.
@@ -38,13 +36,11 @@ fn main() {
 			csrf_token: String::new(),
 			tenant_id: 0u64,
 		},
-
 		fields: {
 			_payload: CharField {
 				required,
 			}
 		}
-
 	};
 }
 

--- a/crates/reinhardt-pages/tests/ui/form/pass/submit_button.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/submit_button.rs
@@ -9,7 +9,6 @@ fn main() {
 	let _login_form = form! {
 		name: LoginForm,
 		action: "/api/login",
-
 		fields: {
 			username: CharField {
 				required,
@@ -25,28 +24,24 @@ fn main() {
 				class: "btn-primary",
 			}
 		}
-
 	};
 
 	// SubmitButton with minimal properties (defaults to "Submit" label)
 	let _minimal_form = form! {
 		name: MinimalForm,
 		action: "/api/submit",
-
 		fields: {
 			name: CharField {
 				required,
 			}
 			submit: SubmitButton,
 		}
-
 	};
 
 	// SubmitButton with id and disabled
 	let _disabled_form = form! {
 		name: DisabledForm,
 		action: "/api/submit",
-
 		fields: {
 			email: EmailField {
 				required,
@@ -57,6 +52,5 @@ fn main() {
 				disabled,
 			}
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/pass/success_url_captures_outer_local.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/success_url_captures_outer_local.rs
@@ -44,18 +44,15 @@ fn main() {
 		name: SuccessUrlCaptureForm,
 		action: "/api/vote",
 		success_url: |_form| format!("/polls/{qid}/results/"),
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			question_id: HiddenField {
 				initial: qid.to_string(),
 			}
 		}
-
 	};
 }
 

--- a/crates/reinhardt-pages/tests/ui/form/pass/watch_captures_outer_local.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/watch_captures_outer_local.rs
@@ -17,23 +17,19 @@ fn main() {
 	let _form = form! {
 		name: CaptureWatchForm,
 		action: "/api/capture",
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			content: CharField {
 				required,
 			}
 		}
-
 		watch: {
 			captured_view: |_form| {
-					let _captured = outer_local;
-				},
+				let _captured = outer_local;
+			},
 		}
-
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/page/fail/bare_ident_shorthand_in_body.rs
+++ b/crates/reinhardt-pages/tests/ui/page/fail/bare_ident_shorthand_in_body.rs
@@ -8,8 +8,6 @@ use reinhardt_pages::page;
 fn main() {
 	let name = String::from("world");
 	let _ = page!(|name: String| {
-		div {
-			name
-		}
+		div { name }
 	})(name);
 }

--- a/crates/reinhardt-pages/tests/ui/page/fail/component_missing_required_prop.rs
+++ b/crates/reinhardt-pages/tests/ui/page/fail/component_missing_required_prop.rs
@@ -19,7 +19,9 @@ struct CardProps {
 
 fn card(p: CardProps) -> Page {
 	let _ = p;
-	page!(|| { div {} })()
+	page!(|| {
+		div {}
+	})()
 }
 
 fn main() {

--- a/crates/reinhardt-pages/tests/ui/page/fail/implicit_capture_in_event_handler.rs
+++ b/crates/reinhardt-pages/tests/ui/page/fail/implicit_capture_in_event_handler.rs
@@ -6,8 +6,8 @@ fn main() {
 	let _ = page!(|| {
 		button {
 			@click: |_| {
-						let _ = outer.get();
-					},
+				let _ = outer.get();
+			},
 			"x"
 		}
 	});

--- a/crates/reinhardt-pages/tests/ui/page/fail/implicit_capture_lowercase.rs
+++ b/crates/reinhardt-pages/tests/ui/page/fail/implicit_capture_lowercase.rs
@@ -4,9 +4,9 @@ use reinhardt_pages::reactive::Signal;
 fn main() {
 	let outer = Signal::new(0_i32);
 	let _ = page!(|| {
-		div {
-			{ outer.get() }
-		}
+		div { {
+			outer.get()
+		} }
 	});
 	let _ = outer;
 }

--- a/crates/reinhardt-pages/tests/ui/page/fail/watch_block_removed.rs
+++ b/crates/reinhardt-pages/tests/ui/page/fail/watch_block_removed.rs
@@ -5,10 +5,8 @@ fn main() {
 	let _ = page!(|count: Signal<i32>| {
 		div {
 			watch {
-				if count.get()> 0 {
-					p {
-						"x"
-					}
+				if count.get() > 0 {
+					p { "x" }
 				}
 			}
 		}

--- a/crates/reinhardt-pages/tests/ui/page/pass/component_brace_invocation.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/component_brace_invocation.rs
@@ -14,9 +14,9 @@ struct CardProps {
 fn card(p: CardProps) -> Page {
 	page!(|p: CardProps| {
 		article {
-			h2 {
-				{ p.item.clone() }
-			}
+			h2 { {
+				p.item.clone()
+			} }
 		}
 	})(p)
 }

--- a/crates/reinhardt-pages/tests/ui/page/pass/component_brace_with_children.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/component_brace_with_children.rs
@@ -18,10 +18,12 @@ struct CardProps {
 fn card(p: CardProps) -> Page {
 	page!(|p: CardProps| {
 		article {
-			h2 {
-				{ p.item.clone() }
+			h2 { {
+				p.item.clone()
+			} }
+			{
+				p.children.unwrap_or_else(Page::empty)
 			}
-			{ p.children.unwrap_or_else(Page::empty) }
 		}
 	})(p)
 }
@@ -30,12 +32,8 @@ fn main() {
 	let _ = page!(|| {
 		div {
 			Card(item: "outer".to_string()) {
-				p {
-					"child 1"
-				}
-				p {
-					"child 2"
-				}
+				p { "child 1" }
+				p { "child 2" }
 			}
 		}
 	});

--- a/crates/reinhardt-pages/tests/ui/page/pass/component_brace_with_event.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/component_brace_with_event.rs
@@ -18,9 +18,9 @@ struct ButtonProps {
 
 fn button(p: ButtonProps) -> Page {
 	page!(|p: ButtonProps| {
-		button {
-			{ p.label.clone() }
-		}
+		button { {
+			p.label.clone()
+		} }
 	})(p)
 }
 

--- a/crates/reinhardt-pages/tests/ui/page/pass/component_paren_still_works.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/component_paren_still_works.rs
@@ -10,16 +10,16 @@ use reinhardt_pages::page;
 fn my_button(label: String, disabled: bool) -> Page {
 	let _ = disabled;
 	page!(|label: String| {
-		button {
-			{ label.clone() }
-		}
+		button { {
+			label.clone()
+		} }
 	})(label)
 }
 
 fn main() {
 	let _ = page!(|| {
-		div {
-			{ my_button("click".to_string(), false) }
-		}
+		div { {
+			my_button("click".to_string(), false)
+		} }
 	});
 }

--- a/crates/reinhardt-pages/tests/ui/page/pass/explicit_braced_expression.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/explicit_braced_expression.rs
@@ -8,8 +8,6 @@ use reinhardt_pages::page;
 
 fn main() {
 	let _ = page!(|name: String| {
-		div {
-			{ name }
-		}
+		div { { name } }
 	})(String::from("world"));
 }

--- a/crates/reinhardt-pages/tests/ui/page/pass/explicit_param.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/explicit_param.rs
@@ -3,8 +3,8 @@ use reinhardt_pages::reactive::Signal;
 
 fn main() {
 	let _ = page!(|count: Signal<i32>| {
-		div {
-			{ count.get() }
-		}
+		div { {
+			count.get()
+		} }
 	});
 }

--- a/crates/reinhardt-pages/tests/ui/page/pass/for_loop.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/for_loop.rs
@@ -7,24 +7,20 @@ fn main() {
 	let _with_for = page!(|items: Vec<String>| {
 		ul {
 			for item in items {
-				li {
-					{ item }
-				}
+				li { { item } }
 			}
 		}
 	});
 
 	// For with tuple destructuring
-	let _for_enumerate = page!(|items: Vec<(usize, String)>| {
+	let _for_enumerate = page!(|items: Vec<(usize, String) >| {
 		ul {
-			for (index, item) in items {
+			for(index, item)in items {
 				li {
-					span {
-						{ index.to_string() }
-					}
-					span {
-						{ item }
-					}
+					span { {
+						index.to_string()
+					} }
+					span { { item } }
 				}
 			}
 		}

--- a/crates/reinhardt-pages/tests/ui/page/pass/helper_routed_signal.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/helper_routed_signal.rs
@@ -11,8 +11,8 @@ fn show(s: &Signal<i32>) -> i32 {
 
 fn main() {
 	let _ = page!(|count: Signal<i32>, show: fn(&Signal<i32>) -> i32| {
-		p {
-			{ show(&count) }
-		}
+		p { {
+			show(&count)
+		} }
 	});
 }

--- a/crates/reinhardt-pages/tests/ui/page/pass/with_props.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/with_props.rs
@@ -5,28 +5,24 @@ use reinhardt_pages::page;
 fn main() {
 	// Single prop
 	let _greeting = page!(|name: String| {
-		span {
-			{ name }
-		}
+		span { { name } }
 	});
 
 	// Multiple props
 	let _user_card = page!(|name: String, age: i32| {
 		div {
 			class: "user-card",
-			span {
-				{ name }
-			}
-			span {
-				{ age.to_string() }
-			}
+			span { { name } }
+			span { {
+				age.to_string()
+			} }
 		}
 	});
 
 	// Props with trailing comma
 	let _trailing = page!(|x: i32| {
-		div {
-			{ x.to_string() }
-		}
+		div { {
+			x.to_string()
+		} }
 	});
 }

--- a/crates/reinhardt-urls/tests/client_url_resolver.rs
+++ b/crates/reinhardt-urls/tests/client_url_resolver.rs
@@ -29,16 +29,18 @@ fn test_client_url_reverser_round_trip_via_client_router() {
 		);
 
 	// Act & Assert
-	assert_eq!(router.reverse("app:home", &[]), Some("/".to_string()));
+	assert_eq!(router.reverse("app:home", &[]).ok(), Some("/".to_string()));
 	assert_eq!(
-		router.reverse("app:user_detail", &[("id", "42")]),
+		router.reverse("app:user_detail", &[("id", "42")]).ok(),
 		Some("/users/42/".to_string())
 	);
 	assert_eq!(
-		router.reverse("app:user_posts", &[("user_id", "5"), ("post_id", "10")]),
+		router
+			.reverse("app:user_posts", &[("user_id", "5"), ("post_id", "10")])
+			.ok(),
 		Some("/users/5/posts/10/".to_string())
 	);
-	assert_eq!(router.reverse("nonexistent", &[]), None);
+	assert!(router.reverse("nonexistent", &[]).is_err());
 }
 
 /// Test that ClientUrlResolver trait works with ClientRouter
@@ -58,7 +60,7 @@ fn test_client_url_resolver_trait_impl() {
 		fn resolve_client_url(&self, name: &str, params: &[(&str, &str)]) -> String {
 			self.router
 				.reverse(name, params)
-				.unwrap_or_else(|| panic!("Route '{}' not found", name))
+				.unwrap_or_else(|_| panic!("Route '{}' not found", name))
 		}
 	}
 
@@ -86,7 +88,7 @@ fn test_client_url_resolver_panics_on_unknown_route() {
 		fn resolve_client_url(&self, name: &str, params: &[(&str, &str)]) -> String {
 			self.router
 				.reverse(name, params)
-				.unwrap_or_else(|| panic!("Route '{}' not found", name))
+				.unwrap_or_else(|_| panic!("Route '{}' not found", name))
 		}
 	}
 

--- a/crates/reinhardt-urls/tests/clientrouter_page_integration_tests.rs
+++ b/crates/reinhardt-urls/tests/clientrouter_page_integration_tests.rs
@@ -68,7 +68,7 @@ fn page_text(page: &Page) -> String {
 #[rstest]
 fn page_method_registers_and_renders_with_path_param() {
 	// Arrange
-	let router = ClientRouter::new().page("/users/{id}/", user_page);
+	let router = ClientRouter::new().page("user-detail", "/users/{id}/", user_page);
 
 	// Act
 	let view = router_render(&router, "/users/42/");
@@ -81,7 +81,7 @@ fn page_method_registers_and_renders_with_path_param() {
 #[rstest]
 fn page_method_extracts_query_param() {
 	// Arrange
-	let router = ClientRouter::new().page("/search/", search_page);
+	let router = ClientRouter::new().page("search", "/search/", search_page);
 
 	// Act — drive with a query string. The router's `match_path` ignores
 	// the `?...` suffix; the extractor parses it from `RouteContext::query`.
@@ -95,7 +95,7 @@ fn page_method_extracts_query_param() {
 #[rstest]
 fn page_method_surfaces_extract_error_as_page_text() {
 	// Arrange — path matches but `id` cannot parse as i32
-	let router = ClientRouter::new().page("/users/{id}/", user_page);
+	let router = ClientRouter::new().page("user-detail-err", "/users/{id}/", user_page);
 
 	// Act
 	let view = router_render(&router, "/users/abc/");
@@ -112,7 +112,7 @@ fn page_method_surfaces_extract_error_as_page_text() {
 #[rstest]
 fn page_method_returns_not_found_for_unmatched_path() {
 	// Arrange
-	let router = ClientRouter::new().page("/users/{id}/", user_page);
+	let router = ClientRouter::new().page("user-detail-nf", "/users/{id}/", user_page);
 
 	// Act
 	let view = router_render(&router, "/nope/");
@@ -136,7 +136,7 @@ fn props_struct_can_be_constructed_directly_for_component_use() {
 	let props = UserPageProps::from_request(&ctx).expect("FromRequest must succeed");
 	let view_as_component = user_page(props);
 
-	let router = ClientRouter::new().page("/users/{id}/", user_page);
+	let router = ClientRouter::new().page("user-detail-component", "/users/{id}/", user_page);
 	let view_as_page = router_render(&router, "/users/7/");
 
 	// Assert — both paths render identically. This is spec §4.3's

--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -84,70 +84,69 @@ pub fn polls_index() -> Page {
 	let load_questions_signal = load_questions.clone();
 	let new_question_href = links::question_new();
 
-	page!(
-		| load_questions_error : Action<Vec<QuestionInfo>, String>,
-		load_questions_signal : Action<Vec<QuestionInfo>, String>,
-		new_question_href : String | {
+	page!(| load_questions_error : Action<Vec<QuestionInfo>, String>, load_questions_signal : Action<Vec<QuestionInfo>, String>, new_question_href : String | {
+		div {
+			class: "max-w-4xl mx-auto px-4 mt-12",
 			div {
-				class: "max-w-4xl mx-auto px-4 mt-12",
+				class: "flex justify-between items-center mb-4",
+				h1 { "Polls" }
+				a {
+					href: new_question_href,
+					class: "btn-primary",
+					"New Question"
+				}
+			}
+			if load_questions_error.error().is_some() {
 				div {
-					class: "flex justify-between items-center mb-4",
-					h1 {
-						"Polls"
-					}
-					a {
-						href: new_question_href,
-						class: "btn-primary",
-						"New Question"
+					class: "alert-danger",
+					{
+						format_server_error(&load_questions_error.error().unwrap_or_default())
 					}
 				}
-				if load_questions_error.error().is_some() {
+			}
+			if load_questions_signal.is_pending() {
+				div {
+					class: "text-center",
 					div {
-						class: "alert-danger",
-						{ format_server_error(&load_questions_error.error().unwrap_or_default()) }
-					}
-				}
-				if load_questions_signal.is_pending() {
-					div {
-						class: "text-center",
-						div {
-							class: "spinner w-8 h-8",
-							role: "status",
-							span {
-								class: "sr-only",
-								"Loading..."
-							}
+						class: "spinner w-8 h-8",
+						role: "status",
+						span {
+							class: "sr-only",
+							"Loading..."
 						}
 					}
-				} else if load_questions_signal.result().unwrap_or_default().is_empty() {
-					p {
-						class: "text-muted",
-						"No polls are available."
-					}
-				} else {
-					div {
-						class: "space-y-2",
-						for { question } in load_questions_signal.result().unwrap_or_default() {
-							a {
-								href: links::detail(question.id),
-								class: "block p-4 border border-border rounded-lg bg-surface-primary hover:bg-surface-secondary transition-colors",
-								div {
-									class: "flex w-full justify-between",
-									h5 {
-										class: "mb-1",
-										{ question.question_text.clone() }
-									}
-									small {
-										{ question.pub_date.format("%Y-%m-%d %H:%M").to_string() }
+				}
+			} else if load_questions_signal.result().unwrap_or_default().is_empty() {
+				p {
+					class: "text-muted",
+					"No polls are available."
+				}
+			} else {
+				div {
+					class: "space-y-2",
+					for { question }
+					in load_questions_signal.result().unwrap_or_default() {
+						a {
+							href: links::detail(question.id),
+							class: "block p-4 border border-border rounded-lg bg-surface-primary hover:bg-surface-secondary transition-colors",
+							div {
+								class: "flex w-full justify-between",
+								h5 {
+									class: "mb-1",
+									{
+										question.question_text.clone()
 									}
 								}
+								small { {
+									question.pub_date.format("%Y-%m-%d %H:%M").to_string()
+								} }
 							}
 						}
 					}
 				}
 			}
 		}
-	)(
+	})(
 		load_questions_error,
 		load_questions_signal,
 		new_question_href,
@@ -204,12 +203,10 @@ pub fn polls_detail(question_id: i64) -> Page {
 		strip_arguments: {
 			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
 		},
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			question_id: HiddenField {
 				initial: qid.to_string(),
@@ -224,41 +221,43 @@ pub fn polls_detail(question_id: i64) -> Page {
 				choice_label: "choice_text",
 			}
 		}
-
 		watch: {
 			submit_button: |form| {
-					let is_loading = form.loading().get();
-					let back_href = links::index();
-					page!(|is_loading: bool, back_href: String| {
-						div {
-							class: "mt-3",
-							button {
-								type: "submit",
-								class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
-								disabled: is_loading,
-								{ if is_loading { "Voting..." } else { "Vote" } }
-							}
-							a {
-								href: back_href,
-								class: "btn-secondary ml-2",
-								"Back to Polls"
+				let is_loading = form.loading().get();
+				let back_href = links::index();
+				page!(|is_loading: bool, back_href: String| {
+					div {
+						class: "mt-3",
+						button {
+							type: "submit",
+							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
+							disabled: is_loading,
+							{
+								if is_loading { "Voting..." } else { "Vote" }
 							}
 						}
-					})(is_loading, back_href)
-				},
+						a {
+							href: back_href,
+							class: "btn-secondary ml-2",
+							"Back to Polls"
+						}
+					}
+				})(is_loading, back_href)
+			},
 			error_display: |form| {
-					let err = form.error().get();
-					page!(|err: Option<String>| {
-						if let Some(e) = err.clone() {
-							div {
-								class: "alert-danger mt-3",
-								{ format_server_error(&e) }
+				let err = form.error().get();
+				page!(|err: Option<String>| {
+					if let Some(e) = err.clone() {
+						div {
+							class: "alert-danger mt-3",
+							{
+								format_server_error(&e)
 							}
 						}
-					})(err)
-				},
+					}
+				})(err)
+			},
 		}
-
 	};
 
 	// Bridge load_detail results to form choices via use_effect
@@ -296,120 +295,119 @@ pub fn polls_detail(question_id: i64) -> Page {
 	// `RadioSelect` group for choiceless questions, so any submit emitted
 	// `choice_id=""` and `submit_vote` rejected the request with the
 	// runtime `Invalid choice_id` application error.
-	page!(
-		| load_detail_signal : Action<(QuestionInfo, Vec<ChoiceInfo>), String>,
-		load_current_user_signal : Action<Option<UserInfo>, String>, question_id : i64 | {
-			div {
-				if load_detail_signal.is_pending() {
+	page!(| load_detail_signal : Action<(QuestionInfo, Vec<ChoiceInfo>), String>, load_current_user_signal : Action<Option<UserInfo>, String>, question_id : i64 | {
+		div {
+			if load_detail_signal.is_pending() {
+				div {
+					class: "max-w-4xl mx-auto px-4 mt-12 text-center",
 					div {
-						class: "max-w-4xl mx-auto px-4 mt-12 text-center",
-						div {
-							class: "spinner w-8 h-8",
-							role: "status",
-							span {
-								class: "sr-only",
-								"Loading..."
-							}
+						class: "spinner w-8 h-8",
+						role: "status",
+						span {
+							class: "sr-only",
+							"Loading..."
 						}
 					}
-				} else if load_detail_signal.error().is_some() {
+				}
+			} else if load_detail_signal.error().is_some() {
+				div {
+					class: "max-w-4xl mx-auto px-4 mt-12",
 					div {
-						class: "max-w-4xl mx-auto px-4 mt-12",
-						div {
-							class: "alert-danger",
-							{ format_server_error(&load_detail_signal.error().unwrap_or_default()) }
-						}
-						a {
-							href: links::detail(question_id),
-							class: "btn-secondary",
-							"Try Again"
-						}
-						a {
-							href: links::index(),
-							class: "btn-primary ml-2",
-							"Back to Polls"
+						class: "alert-danger",
+						{
+							format_server_error(&load_detail_signal.error().unwrap_or_default())
 						}
 					}
-				} else if let Some((ref q, ref choices)) = load_detail_signal.result() {
-					// Bind the result once: `Action::result()` clones the
-					// underlying `(QuestionInfo, Vec<ChoiceInfo>)` on every
-					// call, so reusing `q`/`choices` here avoids redundant
-					// allocations on each reactive render.
-					//
-					// Owner-only controls (Edit / Delete / Add choice) are
-					// hidden for non-authors and unauthenticated viewers
-					// (issue #4703). The `current_user` action returns
-					// `Ok(None)` when no session user is present; any
-					// non-`Some(Some(u))` shape (pending, error, or
-					// unauthenticated) leaves `is_author` as `false`.
-					let is_author = match load_current_user_signal.result() {
-						Some(Some(ref u)) => u.id == q.author_id,
-						_ => false,
-					};
+					a {
+						href: links::detail(question_id),
+						class: "btn-secondary",
+						"Try Again"
+					}
+					a {
+						href: links::index(),
+						class: "btn-primary ml-2",
+						"Back to Polls"
+					}
+				}
+			} else if let Some((ref q, ref choices)) = load_detail_signal.result() {
+				// Bind the result once: `Action::result()` clones the
+				// underlying `(QuestionInfo, Vec<ChoiceInfo>)` on every
+				// call, so reusing `q`/`choices` here avoids redundant
+				// allocations on each reactive render.
+				//
+				// Owner-only controls (Edit / Delete / Add choice) are
+				// hidden for non-authors and unauthenticated viewers
+				// (issue #4703). The `current_user` action returns
+				// `Ok(None)` when no session user is present; any
+				// non-`Some(Some(u))` shape (pending, error, or
+				// unauthenticated) leaves `is_author` as `false`.
+				let is_author = match load_current_user_signal.result() {
+					Some(Some(ref u)) => u.id == q.author_id,
+					_ => false,
+				};
+				div {
+					class: "max-w-4xl mx-auto px-4 mt-12",
 					div {
-						class: "max-w-4xl mx-auto px-4 mt-12",
+						class: "flex justify-between items-center mb-4",
+						h1 { {
+							q.question_text.clone()
+						} }
 						div {
-							class: "flex justify-between items-center mb-4",
-							h1 {
-								{ q.question_text.clone() }
+							class: "flex gap-2",
+							a {
+								href: links::results(question_id),
+								class: "btn-secondary",
+								"View results"
 							}
-							div {
-								class: "flex gap-2",
+							if is_author {
 								a {
-									href: links::results(question_id),
+									href: links::question_edit(question_id),
 									class: "btn-secondary",
-									"View results"
+									"Edit"
 								}
-								if is_author {
-									a {
-										href: links::question_edit(question_id),
-										class: "btn-secondary",
-										"Edit"
-									}
-									a {
-										href: links::question_delete(question_id),
-										class: "btn-danger",
-										"Delete"
-									}
-								}
-							}
-						}
-						if ! choices.is_empty() {
-							{ voting_form.clone().into_page() }
-						} else {
-							div {
-								class: "alert-warning",
-								"This question has no choices yet. Add one below to start voting."
-							}
-						}
-						if is_author {
-							div {
-								class: "mt-4",
 								a {
-									href: links::choice_new(question_id),
-									class: "btn-secondary",
-									"Add choice"
+									href: links::question_delete(question_id),
+									class: "btn-danger",
+									"Delete"
 								}
 							}
 						}
 					}
-				} else {
-					div {
-						class: "max-w-4xl mx-auto px-4 mt-12",
+					if ! choices.is_empty() { {
+						voting_form.clone().into_page()
+					} } else {
 						div {
 							class: "alert-warning",
-							"Question not found"
+							"This question has no choices yet. Add one below to start voting."
 						}
-						a {
-							href: links::index(),
-							class: "btn-primary",
-							"Back to Polls"
+					}
+					if is_author {
+						div {
+							class: "mt-4",
+							a {
+								href: links::choice_new(question_id),
+								class: "btn-secondary",
+								"Add choice"
+							}
 						}
+					}
+				}
+			} else {
+				div {
+					class: "max-w-4xl mx-auto px-4 mt-12",
+					div {
+						class: "alert-warning",
+						"Question not found"
+					}
+					a {
+						href: links::index(),
+						class: "btn-primary",
+						"Back to Polls"
 					}
 				}
 			}
 		}
-	)(load_detail_signal, load_current_user_signal, question_id)
+	})(load_detail_signal, load_current_user_signal, question_id)
 }
 
 /// Poll results page - Show voting results
@@ -435,182 +433,161 @@ pub fn polls_results(question_id: i64) -> Page {
 	let load_results_signal = load_results.clone();
 	let load_current_user_signal = load_current_user.clone();
 
-	page!(
-		| load_results_signal : Action<(QuestionInfo, Vec<ChoiceInfo>, i32), String>,
-		load_current_user_signal : Action<Option<UserInfo>, String>, question_id : i64 | {
-			div {
-				if load_results_signal.is_pending() {
+	page!(| load_results_signal : Action<(QuestionInfo, Vec<ChoiceInfo>, i32), String>, load_current_user_signal : Action<Option<UserInfo>, String>, question_id : i64 | {
+		div {
+			if load_results_signal.is_pending() {
+				div {
+					class: "max-w-4xl mx-auto px-4 mt-12 text-center",
 					div {
-						class: "max-w-4xl mx-auto px-4 mt-12 text-center",
-						div {
-							class: "spinner w-8 h-8",
-							role: "status",
-							span {
-								class: "sr-only",
-								"Loading..."
-							}
+						class: "spinner w-8 h-8",
+						role: "status",
+						span {
+							class: "sr-only",
+							"Loading..."
 						}
 					}
-				} else if load_results_signal.error().is_some() {
+				}
+			} else if load_results_signal.error().is_some() {
+				div {
+					class: "max-w-4xl mx-auto px-4 mt-12",
 					div {
-						class: "max-w-4xl mx-auto px-4 mt-12",
-						div {
-							class: "alert-danger",
-							{ format_server_error(&load_results_signal.error().unwrap_or_default()) }
-						}
-						a {
-							href: links::index(),
-							class: "btn-primary",
-							"Back to Polls"
+						class: "alert-danger",
+						{
+							format_server_error(&load_results_signal.error().unwrap_or_default())
 						}
 					}
-				} else if load_results_signal.result().is_some() {
-					// Owner-only controls (Edit / Delete) are hidden for
-					// non-authors and unauthenticated viewers (issue #4703).
-					// `current_user` returns `Ok(None)` when no session user
-					// is present; any non-`Some(Some(u))` shape (pending,
-					// error, or unauthenticated) leaves `is_author` as
-					// `false`. Server-side `require_question_author` still
-					// rejects unauthorized mutations as defense in depth.
-					let is_author = match (
-						load_results_signal.result(),
-						load_current_user_signal.result(),
-					) {
-						(Some((ref q, _, _)), Some(Some(ref u))) => u.id == q.author_id,
-						_ => false,
-					};
-					div {
-						class: "max-w-4xl mx-auto px-4 mt-12",
-						h1 {
-							class: "mb-4",
-							{
-								load_results_signal
-										.result()
-										.map(| (q, _, _) | q.question_text.clone())
-										.unwrap_or_default()
-							}
+					a {
+						href: links::index(),
+						class: "btn-primary",
+						"Back to Polls"
+					}
+				}
+			} else if load_results_signal.result().is_some() {
+				// Owner-only controls (Edit / Delete) are hidden for
+				// non-authors and unauthenticated viewers (issue #4703).
+				// `current_user` returns `Ok(None)` when no session user
+				// is present; any non-`Some(Some(u))` shape (pending,
+				// error, or unauthenticated) leaves `is_author` as
+				// `false`. Server-side `require_question_author` still
+				// rejects unauthorized mutations as defense in depth.
+				let is_author = match(load_results_signal.result(), load_current_user_signal.result(), ) {
+					(Some((ref q, _, _)), Some(Some(ref u))) => u.id == q.author_id,
+					_ => false,
+				};
+				div {
+					class: "max-w-4xl mx-auto px-4 mt-12",
+					h1 {
+						class: "mb-4",
+						{
+							load_results_signal.result().map(|(q, _, _)| q.question_text.clone()).unwrap_or_default()
 						}
+					}
+					div {
+						class: "card",
 						div {
-							class: "card",
+							class: "card-body",
+							h5 {
+								class: "text-xl font-bold",
+								"Results"
+							}
 							div {
-								class: "card-body",
-								h5 {
-									class: "text-xl font-bold",
-									"Results"
-								}
-								div {
-									class: "divide-y divide-border",
-									{
-										if let Some((_, choices, total)) = load_results_signal.result() {
-												page!(
-													| choices : Vec<ChoiceInfo>, total : i32 | {
-														for choice in choices {
-															{
+								class: "divide-y divide-border",
+								{
+									if let Some((_, choices, total)) = load_results_signal.result() {
+										page!(| choices : Vec<ChoiceInfo>, total : i32 | {
+											for choice in choices { { {
+												let percentage = if total > 0 {
+													(choice.votes as f64 / total as f64 * 100.0) as i32
+												} else { 0 };
+												page!(| choice : ChoiceInfo, percentage : i32 | {
+													div {
+														class: "py-4",
+														div {
+															class: "flex justify-between items-center mb-2",
+															strong { {
+																choice.choice_text.clone()
+															} }
+															span {
+																class: "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
 																{
-																		let percentage = if total > 0 {
-																			(choice.votes as f64 / total as f64 * 100.0) as i32
-																		} else {
-																			0
-																		};
-																		page!(
-																			| choice : ChoiceInfo, percentage : i32 | {
-																				div {
-																					class: "py-4",
-																					div {
-																						class: "flex justify-between items-center mb-2",
-																						strong {
-																							{ choice.choice_text.clone() }
-																						}
-																						span {
-																							class: "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
-																							{ format!("{} votes", choice.votes) }
-																						}
-																					}
-																					div {
-																						class: "w-full bg-surface-tertiary rounded-full h-2.5",
-																						div {
-																							class: "bg-brand h-2.5 rounded-full",
-																							role: "progressbar",
-																							style: format!("width: {}%", percentage),
-																							aria_valuenow: percentage.to_string(),
-																							aria_valuemin: "0",
-																							aria_valuemax: "100",
-																							{ format!("{}%", percentage) }
-																						}
-																					}
-																				}
-																			}
-																		)(choice, percentage)
-																	}
+																	format!("{} votes", choice.votes)
+																}
+															}
+														}
+														div {
+															class: "w-full bg-surface-tertiary rounded-full h-2.5",
+															div {
+																class: "bg-brand h-2.5 rounded-full",
+																role: "progressbar",
+																style: format!("width: {}%", percentage),
+																aria_valuenow: percentage.to_string(),
+																aria_valuemin: "0",
+																aria_valuemax: "100",
+																{
+																	format!("{}%", percentage)
+																}
 															}
 														}
 													}
-												)(choices, total)
-											} else {
-												Page::Empty
-											}
+												})(choice, percentage)
+											} } }
+										})(choices, total)
+									} else { Page::Empty }
+								}
+							}
+							div {
+								class: "mt-3",
+								p {
+									class: "text-muted",
+									{
+										format!("Total votes: {}", load_results_signal.result().map(|(_, _, total)| total).unwrap_or(0))
 									}
 								}
-								div {
-									class: "mt-3",
-									p {
-										class: "text-muted",
-										{
-											format!(
-													"Total votes: {}",
-													load_results_signal
-														.result()
-														.map(| (_, _, total) | total)
-														.unwrap_or(0)
-												)
-										}
-									}
-								}
-							}
-						}
-						div {
-							class: "mt-3 flex flex-wrap gap-2",
-							a {
-								href: links::detail(question_id),
-								class: "btn-primary",
-								"Vote Again"
-							}
-							if is_author {
-								a {
-									href: links::question_edit(question_id),
-									class: "btn-secondary",
-									"Edit question"
-								}
-								a {
-									href: links::question_delete(question_id),
-									class: "btn-danger",
-									"Delete question"
-								}
-							}
-							a {
-								href: links::index(),
-								class: "btn-secondary",
-								"Back to Polls"
 							}
 						}
 					}
-				} else {
 					div {
-						class: "max-w-4xl mx-auto px-4 mt-12",
-						div {
-							class: "alert-warning",
-							"Question not found"
+						class: "mt-3 flex flex-wrap gap-2",
+						a {
+							href: links::detail(question_id),
+							class: "btn-primary",
+							"Vote Again"
+						}
+						if is_author {
+							a {
+								href: links::question_edit(question_id),
+								class: "btn-secondary",
+								"Edit question"
+							}
+							a {
+								href: links::question_delete(question_id),
+								class: "btn-danger",
+								"Delete question"
+							}
 						}
 						a {
 							href: links::index(),
-							class: "btn-primary",
+							class: "btn-secondary",
 							"Back to Polls"
 						}
 					}
 				}
+			} else {
+				div {
+					class: "max-w-4xl mx-auto px-4 mt-12",
+					div {
+						class: "alert-warning",
+						"Question not found"
+					}
+					a {
+						href: links::index(),
+						class: "btn-primary",
+						"Back to Polls"
+					}
+				}
 			}
 		}
-	)(load_results_signal, load_current_user_signal, question_id)
+	})(load_results_signal, load_current_user_signal, question_id)
 }
 
 /// Example component demonstrating static URL resolution
@@ -626,78 +603,80 @@ pub fn polls_index_with_logo() -> Page {
 	let load_questions_error = load_questions.clone();
 	let load_questions_signal = load_questions.clone();
 
-	page!(
-		| load_questions_error : Action<Vec<QuestionInfo>, String>,
-		load_questions_signal : Action<Vec<QuestionInfo>, String> | {
+	page!(| load_questions_error : Action<Vec<QuestionInfo>, String>, load_questions_signal : Action<Vec<QuestionInfo>, String> | {
+		div {
+			class: "max-w-4xl mx-auto px-4 mt-12",
 			div {
-				class: "max-w-4xl mx-auto px-4 mt-12",
+				class: "text-center mb-6",
+				img {
+					src: resolve_static("images/poll-icon.svg"),
+					alt: "Polls App",
+					class: "mx-auto w-16 h-16",
+				}
+			}
+			h1 {
+				class: "mb-4 text-center",
+				"Polls"
+			}
+			if load_questions_error.error().is_some() {
 				div {
-					class: "text-center mb-6",
-					img {
-						src: resolve_static("images/poll-icon.svg"),
-						alt: "Polls App",
-						class: "mx-auto w-16 h-16",
+					class: "alert-danger",
+					{
+						format_server_error(&load_questions_error.error().unwrap_or_default())
 					}
 				}
-				h1 {
-					class: "mb-4 text-center",
-					"Polls"
-				}
-				if load_questions_error.error().is_some() {
+			}
+			if load_questions_signal.is_pending() {
+				div {
+					class: "text-center",
 					div {
-						class: "alert-danger",
-						{ format_server_error(&load_questions_error.error().unwrap_or_default()) }
-					}
-				}
-				if load_questions_signal.is_pending() {
-					div {
-						class: "text-center",
-						div {
-							class: "spinner w-8 h-8",
-							role: "status",
-							span {
-								class: "sr-only",
-								"Loading..."
-							}
+						class: "spinner w-8 h-8",
+						role: "status",
+						span {
+							class: "sr-only",
+							"Loading..."
 						}
 					}
-				} else if load_questions_signal.result().unwrap_or_default().is_empty() {
-					p {
-						class: "text-muted",
-						"No polls are available."
-					}
-				} else {
-					div {
-						class: "space-y-2",
-						for { question } in load_questions_signal.result().unwrap_or_default() {
-							a {
-								href: format!("/polls/{}/", question.id),
-								class: "block p-4 border border-border rounded-lg bg-surface-primary hover:bg-surface-secondary transition-colors",
+				}
+			} else if load_questions_signal.result().unwrap_or_default().is_empty() {
+				p {
+					class: "text-muted",
+					"No polls are available."
+				}
+			} else {
+				div {
+					class: "space-y-2",
+					for { question }
+					in load_questions_signal.result().unwrap_or_default() {
+						a {
+							href: format!("/polls/{}/", question.id),
+							class: "block p-4 border border-border rounded-lg bg-surface-primary hover:bg-surface-secondary transition-colors",
+							div {
+								class: "flex w-full justify-between items-center",
+								img {
+									src: resolve_static("images/poll-icon.svg"),
+									alt: "Poll",
+									class: "w-8 h-8 mr-3",
+								}
 								div {
-									class: "flex w-full justify-between items-center",
-									img {
-										src: resolve_static("images/poll-icon.svg"),
-										alt: "Poll",
-										class: "w-8 h-8 mr-3",
-									}
-									div {
-										class: "flex-1",
-										h5 {
-											class: "mb-1",
-											{ question.question_text.clone() }
+									class: "flex-1",
+									h5 {
+										class: "mb-1",
+										{
+											question.question_text.clone()
 										}
 									}
-									small {
-										{ question.pub_date.format("%Y-%m-%d %H:%M").to_string() }
-									}
 								}
+								small { {
+									question.pub_date.format("%Y-%m-%d %H:%M").to_string()
+								} }
 							}
 						}
 					}
 				}
 			}
 		}
-	)(load_questions_error, load_questions_signal)
+	})(load_questions_error, load_questions_signal)
 }
 
 // =========================================================================
@@ -720,12 +699,10 @@ pub fn question_new() -> Page {
 		strip_arguments: {
 			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
 		},
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			question_text: CharField {
 				label: "Question",
@@ -734,7 +711,6 @@ pub fn question_new() -> Page {
 				class: "form-control",
 			}
 		}
-
 	};
 
 	let loading_signal = new_form.loading().clone();
@@ -752,7 +728,9 @@ pub fn question_new() -> Page {
 			if error_signal.get().is_some() {
 				div {
 					class: "alert-danger mb-3",
-					{ format_server_error(&error_signal.get().unwrap_or_default()) }
+					{
+						format_server_error(&error_signal.get().unwrap_or_default())
+					}
 				}
 			}
 			{ form_view }
@@ -806,12 +784,10 @@ pub fn question_edit(question_id: i64) -> Page {
 		strip_arguments: {
 			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
 		},
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			question_id: HiddenField {
 				initial: qid.to_string(),
@@ -823,7 +799,6 @@ pub fn question_edit(question_id: i64) -> Page {
 				class: "form-control",
 			}
 		}
-
 	};
 
 	// Prefill the question_text input once the load_detail action resolves.
@@ -877,7 +852,9 @@ pub fn question_edit(question_id: i64) -> Page {
 					class: "max-w-4xl mx-auto px-4 mt-12",
 					div {
 						class: "alert-danger",
-						{ format_server_error(&load_detail_signal.error().unwrap_or_default()) }
+						{
+							format_server_error(&load_detail_signal.error().unwrap_or_default())
+						}
 					}
 					a {
 						href: links::index(),
@@ -895,10 +872,14 @@ pub fn question_edit(question_id: i64) -> Page {
 					if edit_form.error().get().is_some() {
 						div {
 							class: "alert-danger mb-3",
-							{ format_server_error(&edit_form.error().get().unwrap_or_default()) }
+							{
+								format_server_error(&edit_form.error().get().unwrap_or_default())
+							}
 						}
 					}
-					{ edit_form.clone().into_page() }
+					{
+						edit_form.clone().into_page()
+					}
 					div {
 						class: "mt-3",
 						if edit_form.loading().get() {
@@ -947,18 +928,15 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 		strip_arguments: {
 			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
 		},
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			question_id: HiddenField {
 				initial: qid.to_string(),
 			}
 		}
-
 	};
 
 	let loading_signal = delete_form.loading().clone();
@@ -990,20 +968,26 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 						}
 						blockquote {
 							class: "border-l-4 border-border-secondary pl-4 italic my-3",
-							{ q.question_text.clone() }
+							{
+								q.question_text.clone()
+							}
 						}
 					}
 				}
 			} else if load_detail_signal.error().is_some() {
 				div {
 					class: "alert-danger",
-					{ format_server_error(&load_detail_signal.error().unwrap_or_default()) }
+					{
+						format_server_error(&load_detail_signal.error().unwrap_or_default())
+					}
 				}
 			}
 			if error_signal.get().is_some() {
 				div {
 					class: "alert-danger mt-3",
-					{ format_server_error(&error_signal.get().unwrap_or_default()) }
+					{
+						format_server_error(&error_signal.get().unwrap_or_default())
+					}
 				}
 			}
 			{ form_view }
@@ -1069,9 +1053,11 @@ pub fn choice_new(question_id: i64) -> Page {
 		name: NewChoiceForm,
 		server_fn: create_choice,
 		method: Post,
-		state: { loading, error },
+		state: {
+			loading,
+			error
+		},
 		redirect_on_success: links::detail(qid),
-
 		fields: {
 			question_id: HiddenField {
 				initial: qid_str,
@@ -1084,10 +1070,8 @@ pub fn choice_new(question_id: i64) -> Page {
 				class: "form-control",
 			},
 		},
-
 		strip_arguments: {
-			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token()
-				.unwrap_or_default(),
+			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
 		},
 	};
 
@@ -1106,7 +1090,9 @@ pub fn choice_new(question_id: i64) -> Page {
 			if error_signal.get().is_some() {
 				div {
 					class: "alert-danger mb-3",
-					{ format_server_error(&error_signal.get().unwrap_or_default()) }
+					{
+						format_server_error(&error_signal.get().unwrap_or_default())
+					}
 				}
 			}
 			{ form_view }
@@ -1155,12 +1141,10 @@ pub fn choice_edit(question_id: i64, choice_id: i64) -> Page {
 		strip_arguments: {
 			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
 		},
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			choice_id: HiddenField {
 				initial: cid_str,
@@ -1172,7 +1156,6 @@ pub fn choice_edit(question_id: i64, choice_id: i64) -> Page {
 				class: "form-control",
 			}
 		}
-
 	};
 
 	let loading_signal = edit_form.loading().clone();
@@ -1189,7 +1172,9 @@ pub fn choice_edit(question_id: i64, choice_id: i64) -> Page {
 			if error_signal.get().is_some() {
 				div {
 					class: "alert-danger mb-3",
-					{ format_server_error(&error_signal.get().unwrap_or_default()) }
+					{
+						format_server_error(&error_signal.get().unwrap_or_default())
+					}
 				}
 			}
 			{ form_view }
@@ -1238,18 +1223,15 @@ pub fn choice_delete_confirm(question_id: i64, choice_id: i64) -> Page {
 		strip_arguments: {
 			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
 		},
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			choice_id: HiddenField {
 				initial: cid_str,
 			}
 		}
-
 	};
 
 	let loading_signal = delete_form.loading().clone();
@@ -1270,7 +1252,9 @@ pub fn choice_delete_confirm(question_id: i64, choice_id: i64) -> Page {
 			if error_signal.get().is_some() {
 				div {
 					class: "alert-danger mt-3",
-					{ format_server_error(&error_signal.get().unwrap_or_default()) }
+					{
+						format_server_error(&error_signal.get().unwrap_or_default())
+					}
 				}
 			}
 			{ form_view }

--- a/examples/examples-tutorial-basis/src/apps/users/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/client/components.rs
@@ -21,12 +21,10 @@ pub fn login_form() -> Page {
 		name: LoginForm,
 		server_fn: login,
 		redirect_on_success: "/",
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			username: CharField {
 				label: "Username",
@@ -40,7 +38,6 @@ pub fn login_form() -> Page {
 				class: "form-control",
 			}
 		}
-
 	};
 	let loading_signal = login_form.loading().clone();
 	let error_signal = login_form.error().clone();
@@ -61,7 +58,9 @@ pub fn login_form() -> Page {
 					if error_signal.get().is_some() {
 						div {
 							class: "alert-danger mb-3",
-							{ error_signal.get().unwrap_or_default() }
+							{
+								error_signal.get().unwrap_or_default()
+							}
 						}
 					}
 					{ { form_view } }
@@ -115,14 +114,11 @@ pub fn logout_form() -> Page {
 		name: LogoutForm,
 		server_fn: logout,
 		redirect_on_success: "/",
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {}
-
 	};
 	let error_signal = logout_form.error().clone();
 	let form_view = logout_form.into_page();
@@ -145,7 +141,9 @@ pub fn logout_form() -> Page {
 					if error_signal.get().is_some() {
 						div {
 							class: "alert-danger mb-3",
-							{ error_signal.get().unwrap_or_default() }
+							{
+								error_signal.get().unwrap_or_default()
+							}
 						}
 					}
 					{ { form_view } }
@@ -180,12 +178,10 @@ pub fn signup_form() -> Page {
 		name: SignupForm,
 		server_fn: register,
 		redirect_on_success: "/",
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			username: CharField {
 				label: "Username",
@@ -204,7 +200,6 @@ pub fn signup_form() -> Page {
 				class: "form-control",
 			}
 		}
-
 	};
 	let loading_signal = signup_form.loading().clone();
 	let error_signal = signup_form.error().clone();
@@ -225,7 +220,9 @@ pub fn signup_form() -> Page {
 					if error_signal.get().is_some() {
 						div {
 							class: "alert-danger mb-3",
-							{ error_signal.get().unwrap_or_default() }
+							{
+								error_signal.get().unwrap_or_default()
+							}
 						}
 					}
 					{ { form_view } }

--- a/examples/examples-tutorial-basis/src/client/components/nav.rs
+++ b/examples/examples-tutorial-basis/src/client/components/nav.rs
@@ -62,7 +62,9 @@ pub fn nav_bar() -> Page {
 					class: "flex items-center gap-3",
 					span {
 						class: "text-sm text-muted",
-						{ format!("Signed in as {}", user.username) }
+						{
+							format!("Signed in as {}", user.username)
+						}
 					}
 					a {
 						href: logout_href.clone(),
@@ -102,7 +104,9 @@ pub fn nav_bar() -> Page {
 /// their return value the same way.
 pub fn with_nav(body: Page) -> Page {
 	page!(|body: Page| {
-		{ nav_bar() }
+		{
+			nav_bar()
+		}
 		{ body }
 	})(body)
 }

--- a/examples/examples-twitter/src/apps/auth/client/components.rs
+++ b/examples/examples-twitter/src/apps/auth/client/components.rs
@@ -31,12 +31,10 @@ pub fn login_form() -> Page {
 		name: LoginForm,
 		server_fn: login,
 		redirect_on_success: "/timeline",
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			email: EmailField {
 				label: "Email",
@@ -81,14 +79,11 @@ pub fn login_form() -> Page {
 				class: "form-input pl-10",
 			}
 		}
-
 		on_success: |user_info| {
-				#[cfg(wasm)]
-				{
-					set_current_user(Some(user_info));
-				}
-			},
-
+			#[cfg(wasm)] {
+				set_current_user(Some(user_info));
+			}
+		},
 	};
 	let loading_signal = login_form.loading().clone();
 	let error_signal = login_form.error().clone();
@@ -102,7 +97,9 @@ pub fn login_form() -> Page {
 					class: "text-center mb-8",
 					div {
 						class: "inline-flex items-center justify-center w-16 h-16 rounded-full bg-brand/10 mb-4",
-						{ icons::chat_bubble_icon_brand() }
+						{
+							icons::chat_bubble_icon_brand()
+						}
 					}
 					h1 {
 						class: "text-2xl font-bold text-content-primary",
@@ -122,10 +119,12 @@ pub fn login_form() -> Page {
 								class: "alert-danger mb-4",
 								div {
 									class: "flex items-center gap-2",
-									{ icons::error_circle_icon() }
-									span {
-										{ error_signal.get().unwrap_or_default() }
+									{
+										icons::error_circle_icon()
 									}
+									span { {
+										error_signal.get().unwrap_or_default()
+									} }
 								}
 							}
 						}
@@ -206,12 +205,10 @@ pub fn register_form() -> Page {
 		name: RegisterForm,
 		server_fn: register,
 		redirect_on_success: "/login",
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			username: CharField {
 				label: "Username",
@@ -299,7 +296,6 @@ pub fn register_form() -> Page {
 				class: "form-input pl-10",
 			}
 		}
-
 	};
 	let loading_signal = register_form.loading().clone();
 	let error_signal = register_form.error().clone();
@@ -313,7 +309,9 @@ pub fn register_form() -> Page {
 					class: "text-center mb-8",
 					div {
 						class: "inline-flex items-center justify-center w-16 h-16 rounded-full bg-brand/10 mb-4",
-						{ icons::user_add_icon() }
+						{
+							icons::user_add_icon()
+						}
 					}
 					h1 {
 						class: "text-2xl font-bold text-content-primary",
@@ -333,10 +331,12 @@ pub fn register_form() -> Page {
 								class: "alert-danger mb-4",
 								div {
 									class: "flex items-center gap-2",
-									{ icons::error_circle_icon() }
-									span {
-										{ error_signal.get().unwrap_or_default() }
+									{
+										icons::error_circle_icon()
 									}
+									span { {
+										error_signal.get().unwrap_or_default()
+									} }
 								}
 							}
 						}
@@ -351,13 +351,11 @@ pub fn register_form() -> Page {
 							label {
 								for: "terms",
 								class: "text-sm text-content-secondary",
-								"I agree to the "
-								span {
+								"I agree to the " span {
 									class: "text-brand hover:text-brand-hover cursor-pointer",
 									"Terms of Service"
 								}
-								" and "
-								span {
+								" and " span {
 									class: "text-brand hover:text-brand-hover cursor-pointer",
 									"Privacy Policy"
 								}

--- a/examples/examples-twitter/src/apps/dm/client/components.rs
+++ b/examples/examples-twitter/src/apps/dm/client/components.rs
@@ -21,20 +21,47 @@ fn message_input(
 	let input_for_display = input_signal.clone();
 	let input_for_change = input_signal.clone();
 	let input_for_click = input_signal.clone();
-	page!(
-		| input_for_display : Signal < String >, input_for_change : Signal < String >,
-		input_for_click : Signal < String >| { div { class :
-		"dm-input-container flex gap-2 p-4 border-t border-surface-tertiary", input {
-		type : "text", class : "form-control flex-1", placeholder : "Type a message...",
-		value : input_for_display.get(), @ input : { let { input_signal } =
-		input_for_change.clone(); move | event : web_sys::Event | { if let Some(target) =
-		event.target() { if let Ok(input) = target.dyn_into::< web_sys::HtmlInputElement
-		> () { input_signal.set(input.value()); } } } }, } button { class :
-		"btn-primary", type : "button", @ click : { let { input_signal } =
-		input_for_click.clone(); let { send_callback } = send_callback.clone(); move |
-		_event | { let { content } = input_signal.get(); if ! content.trim().is_empty() {
-		send_callback(content); input_signal.set(String::new()); } } }, "Send" } } }
-	)(input_for_display, input_for_change, input_for_click)
+	page!(| input_for_display : Signal < String >, input_for_change : Signal < String >, input_for_click : Signal < String >| {
+		div {
+			class : "dm-input-container flex gap-2 p-4 border-t border-surface-tertiary",
+			input {
+				type : "text",
+				class : "form-control flex-1",
+				placeholder : "Type a message...",
+				value : input_for_display.get(),
+				@ input : {
+					let { input_signal }
+					=input_for_change.clone();
+					move | event : web_sys::Event | {
+						if let Some(target) =event.target() {
+							if let Ok(input) = target.dyn_into::< web_sys::HtmlInputElement>() {
+								input_signal.set(input.value());
+							}
+						}
+					}
+				},
+			}
+			button {
+				class : "btn-primary",
+				type : "button",
+				@ click : {
+					let { input_signal }
+					=input_for_click.clone();
+					let { send_callback }
+					= send_callback.clone();
+					move |_event | {
+						let { content }
+						= input_signal.get();
+						if ! content.trim().is_empty() {
+							send_callback(content);
+							input_signal.set(String::new());
+						}
+					}
+				},
+				"Send"
+			}
+		}
+	})(input_for_display, input_for_change, input_for_click)
 }
 /// Single message display component
 fn message_item(message: &MessageInfo, is_own_message: bool) -> Page {
@@ -91,7 +118,9 @@ fn connection_status(is_connected: bool) -> Page {
 			}
 			span {
 				class: "text-content-secondary",
-				{ if is_connected { "Connected" } else { "Connecting..." } }
+				{
+					if is_connected { "Connected" } else { "Connecting..." }
+				}
 			}
 		}
 	})(is_connected)
@@ -130,7 +159,9 @@ pub fn dm_chat(room_id: Uuid, current_user_id: Option<Uuid>) -> Page {
 					class: "text-lg font-semibold",
 					"Direct Messages"
 				}
-				{ connection_status(matches!(ws_state.get(), ConnectionState::Open)) }
+				{
+					connection_status(matches!(ws_state.get(), ConnectionState::Open))
+				}
 			}
 			div {
 				class: "dm-messages flex-1 overflow-y-auto p-4 space-y-3",
@@ -149,14 +180,18 @@ pub fn dm_chat(room_id: Uuid, current_user_id: Option<Uuid>) -> Page {
 					div {
 						class: "alert-danger",
 						role: "alert",
-						{ error_signal.get().unwrap_or_default() }
+						{
+							error_signal.get().unwrap_or_default()
+						}
 					}
 				} else if messages_signal.get().is_empty() {
 					div {
 						class: "flex flex-col items-center justify-center py-16 text-center",
 						div {
 							class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
-							{ icons::chat_bubble_icon_lg() }
+							{
+								icons::chat_bubble_icon_lg()
+							}
 						}
 						h3 {
 							class: "text-lg font-semibold text-content-primary mb-1",
@@ -170,23 +205,17 @@ pub fn dm_chat(room_id: Uuid, current_user_id: Option<Uuid>) -> Page {
 				} else {
 					div {
 						class: "space-y-3",
-						for m in messages_signal.get().iter() {
-							{
-								{
-										let is_own = current_user_id
-											.map(|uid| m.sender_id == uid)
-											.unwrap_or(false);
-										message_item(m, is_own)
-									}
-							}
-						}
+						for m in messages_signal.get().iter() { { {
+							let is_own = current_user_id.map(|uid| m.sender_id == uid).unwrap_or(false);
+							message_item(m, is_own)
+						} } }
 					}
 				}
 			}
 			{
 				message_input(input_signal.clone(), move |content| {
-						chat_for_send.send_message(content);
-					})
+					chat_for_send.send_message(content);
+				})
 			}
 		}
 	})(
@@ -206,24 +235,67 @@ fn room_item(room: &RoomInfo, on_select: impl Fn(Uuid) + Clone + 'static) -> Pag
 	let last_message = room.last_message.clone();
 	let last_activity = room.last_activity.clone();
 	let unread_count = room.unread_count;
-	page!(
-		| room_id : Uuid, name : String, last_message : Option < String >, last_activity
-		: Option < String >, unread_count : i32 | { div { class :
-		"room-item flex items-center gap-3 p-4 hover:bg-surface-secondary cursor-pointer transition-colors border-b border-surface-tertiary",
-		@ click : { let { on_select } = on_select.clone(); move | _event | {
-		on_select(room_id); } }, div { class : "flex-shrink-0", div { class :
-		"w-12 h-12 rounded-full bg-brand/20 flex items-center justify-center text-brand font-semibold",
-		{ name.chars().next().unwrap_or('?').to_uppercase().to_string() } } } div { class
-		: "flex-1 min-w-0", div { class : "flex items-center justify-between", span {
-		class : "font-semibold text-content-primary truncate", { name.clone() } } if
-		last_activity.is_some() { span { class : "text-xs text-content-tertiary", {
-		last_activity.clone().unwrap_or_default() } } } } if last_message.is_some() { p {
-		class : "text-sm text-content-secondary truncate mt-1", { last_message.clone()
-		.unwrap_or_default() } } } } if { unread_count } > 0 { div { class :
-		"flex-shrink-0", span { class :
-		"inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-brand rounded-full",
-		{ format!("{}", unread_count.min(99)) } } } } } }
-	)(room_id, name, last_message, last_activity, unread_count)
+	page!(| room_id : Uuid, name : String, last_message : Option < String >, last_activity: Option < String >, unread_count : i32 | {
+		div {
+			class : "room-item flex items-center gap-3 p-4 hover:bg-surface-secondary cursor-pointer transition-colors border-b border-surface-tertiary",
+			@ click : {
+				let { on_select }
+				= on_select.clone();
+				move | _event | {
+					on_select(room_id);
+				}
+			},
+			div {
+				class : "flex-shrink-0",
+				div {
+					class : "w-12 h-12 rounded-full bg-brand/20 flex items-center justify-center text-brand font-semibold",
+					{
+						name.chars().next().unwrap_or('?').to_uppercase().to_string()
+					}
+				}
+			}
+			div {
+				class: "flex-1 min-w-0",
+				div {
+					class : "flex items-center justify-between",
+					span {
+						class : "font-semibold text-content-primary truncate",
+						{
+							name.clone()
+						}
+					}
+					iflast_activity.is_some() {
+						span {
+							class : "text-xs text-content-tertiary",
+							{
+								last_activity.clone().unwrap_or_default()
+							}
+						}
+					}
+				}
+				if last_message.is_some() {
+					p {
+						class : "text-sm text-content-secondary truncate mt-1",
+						{
+							last_message.clone().unwrap_or_default()
+						}
+					}
+				}
+			}
+			if { unread_count }
+			> 0 {
+				div {
+					class : "flex-shrink-0",
+					span {
+						class : "inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-brand rounded-full",
+						{
+							format!("{}", unread_count.min(99))
+						}
+					}
+				}
+			}
+		}
+	})(room_id, name, last_message, last_activity, unread_count)
 }
 /// DM room list component
 ///
@@ -273,7 +345,9 @@ pub fn dm_room_list(on_room_select: impl Fn(Uuid) + Clone + 'static) -> Page {
 						div {
 							class: "alert-danger",
 							role: "alert",
-							{ error_signal.get().unwrap_or_default() }
+							{
+								error_signal.get().unwrap_or_default()
+							}
 						}
 					}
 				} else if rooms_signal.get().is_empty() {
@@ -281,7 +355,9 @@ pub fn dm_room_list(on_room_select: impl Fn(Uuid) + Clone + 'static) -> Page {
 						class: "flex flex-col items-center justify-center py-16 text-center px-4",
 						div {
 							class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
-							{ icons::chat_multi_icon_lg() }
+							{
+								icons::chat_multi_icon_lg()
+							}
 						}
 						h3 {
 							class: "text-lg font-semibold text-content-primary mb-1",
@@ -294,9 +370,9 @@ pub fn dm_room_list(on_room_select: impl Fn(Uuid) + Clone + 'static) -> Page {
 					}
 				} else {
 					div {
-						for r in rooms_signal.get().iter() {
-							{ room_item(r, on_room_select.clone()) }
-						}
+						for r in rooms_signal.get().iter() { {
+							room_item(r, on_room_select.clone())
+						} }
 					}
 				}
 			}

--- a/examples/examples-twitter/src/apps/profile/client/components.rs
+++ b/examples/examples-twitter/src/apps/profile/client/components.rs
@@ -93,10 +93,12 @@ pub fn profile_view(user_id: Uuid) -> Page {
 						role: "alert",
 						div {
 							class: "flex items-center gap-2",
-							{ icons::error_circle_icon() }
-							span {
-								{ error_signal.get().unwrap_or_default() }
+							{
+								icons::error_circle_icon()
 							}
+							span { {
+								error_signal.get().unwrap_or_default()
+							} }
 						}
 					}
 				}
@@ -112,9 +114,7 @@ pub fn profile_view(user_id: Uuid) -> Page {
 							class: "flex justify-between items-end -mt-12 sm:-mt-16 mb-4",
 							div {
 								class: "avatar-xl sm:w-32 sm:h-32 rounded-full border-4 border-surface-primary bg-surface-tertiary flex items-center justify-center text-3xl sm:text-4xl font-bold text-content-secondary",
-								span {
-									"👤"
-								}
+								span { "👤" }
 							}
 							a {
 								href: format!("/profile/{}/edit", user_id_str),
@@ -133,7 +133,9 @@ pub fn profile_view(user_id: Uuid) -> Page {
 							if data.bio.is_some() {
 								p {
 									class: "text-content-primary mb-4 whitespace-pre-wrap",
-									{ data.bio.clone().unwrap_or_default() }
+									{
+										data.bio.clone().unwrap_or_default()
+									}
 								}
 							}
 						}
@@ -143,10 +145,12 @@ pub fn profile_view(user_id: Uuid) -> Page {
 								if data.location.is_some() {
 									div {
 										class: "flex items-center gap-1",
-										{ icons::location_pin_icon() }
-										span {
-											{ data.location.clone().unwrap_or_default() }
+										{
+											icons::location_pin_icon()
 										}
+										span { {
+											data.location.clone().unwrap_or_default()
+										} }
 									}
 								}
 								if data.website.is_some() {
@@ -155,10 +159,12 @@ pub fn profile_view(user_id: Uuid) -> Page {
 										href: data.website.clone().unwrap_or_default(),
 										target: "_blank",
 										rel: "noopener noreferrer",
-										{ icons::link_icon() }
-										span {
-											{ data.website.clone().unwrap_or_default() }
+										{
+											icons::link_icon()
 										}
+										span { {
+											data.website.clone().unwrap_or_default()
+										} }
 									}
 								}
 							}
@@ -209,13 +215,11 @@ pub fn profile_edit(user_id: Uuid) -> Page {
 	let profile_form = form! {
 		name: ProfileEditForm,
 		server_fn: update_profile_form,
-
 		state: {
 			loading,
 			error,
 			success,
 		}
-
 		fields: {
 			avatar_url: UrlField {
 				label: "Avatar URL",
@@ -294,7 +298,6 @@ pub fn profile_edit(user_id: Uuid) -> Page {
 				class: "form-input pl-10",
 			}
 		}
-
 	};
 	let load_profile =
 		use_action(
@@ -337,7 +340,9 @@ pub fn profile_edit(user_id: Uuid) -> Page {
 					a {
 						href: format!("/profile/{}", user_id_str.clone()),
 						class: "btn-icon",
-						{ icons::arrow_left_icon() }
+						{
+							icons::arrow_left_icon()
+						}
 					}
 					h1 {
 						class: "text-xl font-bold",
@@ -352,10 +357,10 @@ pub fn profile_edit(user_id: Uuid) -> Page {
 							role: "alert",
 							div {
 								class: "flex items-center gap-2",
-								{ icons::success_check_icon() }
-								span {
-									"Profile updated successfully! Redirecting..."
+								{
+									icons::success_check_icon()
 								}
+								span { "Profile updated successfully! Redirecting..." }
 							}
 						}
 					}
@@ -365,10 +370,12 @@ pub fn profile_edit(user_id: Uuid) -> Page {
 							role: "alert",
 							div {
 								class: "flex items-center gap-2",
-								{ icons::error_circle_icon() }
-								span {
-									{ error_signal.get().unwrap_or_default() }
+								{
+									icons::error_circle_icon()
 								}
+								span { {
+									error_signal.get().unwrap_or_default()
+								} }
 							}
 						}
 					}

--- a/examples/examples-twitter/src/apps/relationship/client/components.rs
+++ b/examples/examples-twitter/src/apps/relationship/client/components.rs
@@ -81,12 +81,12 @@ pub fn follow_button(target_user_id: Uuid, is_following_initial: bool) -> Page {
 						disabled: { true },
 						aria_label: "Loading",
 						@click: {
-									let toggle_follow = toggle_follow.clone();
-									let is_following_signal = is_following_signal.clone();
-									move |_event| {
-										toggle_follow.dispatch((target_user_id, is_following_signal.get()));
-									}
-								},
+							let toggle_follow = toggle_follow.clone();
+							let is_following_signal = is_following_signal.clone();
+							move |_event| {
+								toggle_follow.dispatch((target_user_id, is_following_signal.get()));
+							}
+						},
 						div {
 							class: "flex items-center gap-2",
 							div {
@@ -99,12 +99,12 @@ pub fn follow_button(target_user_id: Uuid, is_following_initial: bool) -> Page {
 						type: "button",
 						class: "btn-outline group",
 						@click: {
-									let toggle_follow = toggle_follow.clone();
-									let is_following_signal = is_following_signal.clone();
-									move |_event| {
-										toggle_follow.dispatch((target_user_id, is_following_signal.get()));
-									}
-								},
+							let toggle_follow = toggle_follow.clone();
+							let is_following_signal = is_following_signal.clone();
+							move |_event| {
+								toggle_follow.dispatch((target_user_id, is_following_signal.get()));
+							}
+						},
 						span {
 							class: "group-hover:hidden",
 							"Following"
@@ -119,19 +119,21 @@ pub fn follow_button(target_user_id: Uuid, is_following_initial: bool) -> Page {
 						type: "button",
 						class: "btn-primary",
 						@click: {
-									let toggle_follow = toggle_follow.clone();
-									let is_following_signal = is_following_signal.clone();
-									move |_event| {
-										toggle_follow.dispatch((target_user_id, is_following_signal.get()));
-									}
-								},
+							let toggle_follow = toggle_follow.clone();
+							let is_following_signal = is_following_signal.clone();
+							move |_event| {
+								toggle_follow.dispatch((target_user_id, is_following_signal.get()));
+							}
+						},
 						"Follow"
 					}
 				}
 				if toggle_follow_for_error.error().is_some() {
 					div {
 						class: "alert-danger mt-2 text-sm",
-						{ toggle_follow_for_error.error().unwrap_or_default() }
+						{
+							toggle_follow_for_error.error().unwrap_or_default()
+						}
 					}
 				}
 			}
@@ -202,7 +204,9 @@ fn user_card(user: &UserInfo) -> Page {
 						{ display_username }
 					}
 				}
-				{ icons::chevron_right_icon() }
+				{
+					icons::chevron_right_icon()
+				}
 			}
 		}
 	})(
@@ -295,7 +299,9 @@ pub fn user_list(user_id: Uuid, list_type: UserListType) -> Page {
 					href: "/",
 					class: "btn-icon",
 					aria_label: "Go back home",
-					{ icons::arrow_left_icon() }
+					{
+						icons::arrow_left_icon()
+					}
 				}
 				h2 {
 					class: "text-xl font-bold text-content-primary",
@@ -318,10 +324,12 @@ pub fn user_list(user_id: Uuid, list_type: UserListType) -> Page {
 					class: "alert-danger",
 					div {
 						class: "flex items-center gap-2",
-						{ icons::error_circle_icon() }
-						span {
-							{ error_signal.get().unwrap_or_default() }
+						{
+							icons::error_circle_icon()
 						}
+						span { {
+							error_signal.get().unwrap_or_default()
+						} }
 					}
 				}
 			} else if users_signal.get().is_empty() {
@@ -344,15 +352,17 @@ pub fn user_list(user_id: Uuid, list_type: UserListType) -> Page {
 					}
 					p {
 						class: "text-content-secondary",
-						{ empty_message.clone() }
+						{
+							empty_message.clone()
+						}
 					}
 				}
 			} else {
 				div {
 					class: "card overflow-hidden",
-					for user in users_signal.get().iter() {
-						{ user_card(user) }
-					}
+					for user in users_signal.get().iter() { {
+						user_card(user)
+					} }
 				}
 			}
 		}

--- a/examples/examples-twitter/src/apps/tweet/client/components.rs
+++ b/examples/examples-twitter/src/apps/tweet/client/components.rs
@@ -45,23 +45,21 @@ fn like_button(liked: Signal<bool>, like_count: Signal<i32>) -> Page {
 				type: "button",
 				aria_label: "Like",
 				@click: {
-							let liked_for_click = liked_for_click_if.clone();
-							let like_count_for_click = like_count_for_click_if.clone();
-							move |_event| {
-								let current_liked = liked_for_click.get();
-								let current_count = like_count_for_click.get();
-								liked_for_click.set(!current_liked);
-								like_count_for_click.set(if current_liked {
-									current_count - 1
-								} else {
-									current_count + 1
-								});
-							}
-						},
-				{ icons::heart_icon_filled() }
-				span {
-					{ format!("{}", like_count_signal.get()) }
+					let liked_for_click = liked_for_click_if.clone();
+					let like_count_for_click = like_count_for_click_if.clone();
+					move |_event| {
+						let current_liked = liked_for_click.get();
+						let current_count = like_count_for_click.get();
+						liked_for_click.set(!current_liked);
+						like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+					}
+				},
+				{
+					icons::heart_icon_filled()
 				}
+				span { {
+					format!("{}", like_count_signal.get())
+				} }
 			}
 		} else {
 			button {
@@ -69,23 +67,21 @@ fn like_button(liked: Signal<bool>, like_count: Signal<i32>) -> Page {
 				type: "button",
 				aria_label: "Like",
 				@click: {
-							let liked_for_click = liked_for_click_else.clone();
-							let like_count_for_click = like_count_for_click_else.clone();
-							move |_event| {
-								let current_liked = liked_for_click.get();
-								let current_count = like_count_for_click.get();
-								liked_for_click.set(!current_liked);
-								like_count_for_click.set(if current_liked {
-									current_count - 1
-								} else {
-									current_count + 1
-								});
-							}
-						},
-				{ icons::heart_icon_outline() }
-				span {
-					{ format!("{}", like_count_signal_else.get()) }
+					let liked_for_click = liked_for_click_else.clone();
+					let like_count_for_click = like_count_for_click_else.clone();
+					move |_event| {
+						let current_liked = liked_for_click.get();
+						let current_count = like_count_for_click.get();
+						liked_for_click.set(!current_liked);
+						like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+					}
+				},
+				{
+					icons::heart_icon_outline()
 				}
+				span { {
+					format!("{}", like_count_signal_else.get())
+				} }
 			}
 		}
 	})(
@@ -145,13 +141,7 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 						div {
 							class: "tweet-avatar bg-surface-tertiary flex items-center justify-center text-content-secondary font-semibold",
 							{
-								username
-										.clone()
-										.chars()
-										.next()
-										.unwrap_or('U')
-										.to_uppercase()
-										.to_string()
+								username.clone().chars().next().unwrap_or('U').to_uppercase().to_string()
 							}
 						}
 					}
@@ -163,11 +153,15 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 								class: "flex items-center gap-1 min-w-0",
 								span {
 									class: "tweet-username truncate",
-									{ username.clone() }
+									{
+										username.clone()
+									}
 								}
 								span {
 									class: "tweet-handle truncate",
-									{ format!("@{}", username.clone()) }
+									{
+										format!("@{}", username.clone())
+									}
 								}
 								span {
 									class: "text-content-tertiary",
@@ -175,7 +169,9 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 								}
 								span {
 									class: "tweet-time",
-									{ created_at.clone() }
+									{
+										created_at.clone()
+									}
 								}
 							}
 							if show_delete {
@@ -184,18 +180,22 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 									type: "button",
 									aria_label: "Delete tweet",
 									@click: {
-												let delete_action = delete_action_for_click.clone();
-												move |_event| {
-													delete_action.dispatch(tweet_id);
-												}
-											},
-									{ icons::trash_icon() }
+										let delete_action = delete_action_for_click.clone();
+										move |_event| {
+											delete_action.dispatch(tweet_id);
+										}
+									},
+									{
+										icons::trash_icon()
+									}
 								}
 							}
 						}
 						p {
 							class: "tweet-content",
-							{ content.clone() }
+							{
+								content.clone()
+							}
 						}
 						div {
 							class: "tweet-actions",
@@ -203,26 +203,30 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 								class: "tweet-action-btn hover:text-brand",
 								type: "button",
 								aria_label: "Reply",
-								{ icons::chat_bubble_icon() }
-								span {
-									"0"
+								{
+									icons::chat_bubble_icon()
 								}
+								span { "0" }
 							}
 							button {
 								class: "tweet-action-btn hover:text-success",
 								type: "button",
 								aria_label: "Retweet",
-								{ icons::retweet_icon() }
-								span {
-									"0"
+								{
+									icons::retweet_icon()
 								}
+								span { "0" }
 							}
-							{ like_button(liked_signal.clone(), like_count_signal.clone()) }
+							{
+								like_button(liked_signal.clone(), like_count_signal.clone())
+							}
 							button {
 								class: "tweet-action-btn hover:text-brand",
 								type: "button",
 								aria_label: "Share",
-								{ icons::share_icon() }
+								{
+									icons::share_icon()
+								}
 							}
 						}
 					}
@@ -232,7 +236,9 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 		if delete_action_for_error.error().is_some() {
 			div {
 				class: "alert-danger mt-3",
-				{ delete_action_for_error.error().unwrap_or_default() }
+				{
+					delete_action_for_error.error().unwrap_or_default()
+				}
 			}
 		}
 	})(
@@ -267,12 +273,10 @@ pub fn tweet_form() -> Page {
 		name: TweetFormInner,
 		server_fn: create_tweet,
 		method: Post,
-
 		state: {
 			loading,
 			error,
 		}
-
 		fields: {
 			content: TextField {
 				widget: Textarea,
@@ -284,89 +288,67 @@ pub fn tweet_form() -> Page {
 				rows: 3,
 			}
 		}
-
 		on_success: |_result| {
-				#[cfg(wasm)]
-				{
-					if let Some(window) = web_sys::window() {
-						let _ = window.location().reload();
-					}
+			#[cfg(wasm)] {
+				if let Some(window) = web_sys::window() {
+					let _ = window.location().reload();
 				}
-			},
-
+			}
+		},
 		watch: {
 			char_counter: |form| {
-					let char_count = form.content().get().len();
-					let progress_percent = (char_count as f64 / 280.0 * 100.0).min(100.0);
-					let width_style = format!("width: {}%", progress_percent);
-					let (text_class, bar_class) = if char_count > 280 {
-						(
-							"text-sm font-medium text-danger".to_string(),
-							"h-full bg-danger transition-all".to_string(),
-						)
-					} else if char_count > 250 {
-						(
-							"text-sm font-medium text-warning".to_string(),
-							"h-full bg-warning transition-all".to_string(),
-						)
-					} else if char_count > 0 {
-						(
-							"text-sm font-medium text-content-tertiary".to_string(),
-							"h-full bg-brand transition-all".to_string(),
-						)
-					} else {
-						(
-							"text-sm font-medium text-content-tertiary".to_string(),
-							"h-full bg-surface-tertiary transition-all".to_string(),
-						)
-					};
-					let display_text = format!("{}/280", char_count);
-					page!(|text_class: String, bar_class: String, width_style: String, display_text: String| {
+				let char_count = form.content().get().len();
+				let progress_percent = (char_count as f64 / 280.0 * 100.0).min(100.0);
+				let width_style = format!("width: {}%", progress_percent);
+				let(text_class, bar_class) = if char_count > 280 { ("text-sm font-medium text-danger".to_string(), "h-full bg-danger transition-all".to_string(), ) } else if char_count > 250 { ("text-sm font-medium text-warning".to_string(), "h-full bg-warning transition-all".to_string(), ) } else if char_count > 0 { ("text-sm font-medium text-content-tertiary".to_string(), "h-full bg-brand transition-all".to_string(), ) } else { ("text-sm font-medium text-content-tertiary".to_string(), "h-full bg-surface-tertiary transition-all".to_string(), ) };
+				let display_text = format!("{}/280", char_count);
+				page!(|text_class: String, bar_class: String, width_style: String, display_text: String| {
+					div {
+						class: "flex items-center gap-2",
 						div {
-							class: "flex items-center gap-2",
+							class: text_class,
+							{ display_text }
+						}
+						div {
+							class: "w-20 h-1 bg-surface-tertiary rounded-full overflow-hidden",
 							div {
-								class: text_class,
-								{ display_text }
-							}
-							div {
-								class: "w-20 h-1 bg-surface-tertiary rounded-full overflow-hidden",
-								div {
-									class: bar_class,
-									style: width_style,
-								}
+								class: bar_class,
+								style: width_style,
 							}
 						}
-					})(text_class, bar_class, width_style, display_text)
-				},
+					}
+				})(text_class, bar_class, width_style, display_text)
+			},
 			submit_button: |form| {
-					let is_loading = form.loading().get();
-					let char_count = form.content().get().len();
-					let is_valid = char_count > 0 && char_count <= 280;
-					let is_disabled = is_loading || !is_valid;
-					page!(|is_loading: bool, is_disabled: bool| {
-						div {
-							button {
-								type: "submit",
-								class: if is_disabled { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
-								disabled: is_disabled,
-								{ if is_loading { "Posting..." } else { "Post" } }
+				let is_loading = form.loading().get();
+				let char_count = form.content().get().len();
+				let is_valid = char_count > 0 && char_count <= 280;
+				let is_disabled = is_loading || !is_valid;
+				page!(|is_loading: bool, is_disabled: bool| {
+					div {
+						button {
+							type: "submit",
+							class: if is_disabled { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
+							disabled: is_disabled,
+							{
+								if is_loading { "Posting..." } else { "Post" }
 							}
 						}
-					})(is_loading, is_disabled)
-				},
+					}
+				})(is_loading, is_disabled)
+			},
 			error_display: |form| {
-					let err = form.error().get();
-					let has_error = err.is_some();
-					let error_msg = err.unwrap_or_default();
-					page!(|has_error: bool, error_msg: String| {
-						div {
-							class: if has_error { "alert-danger mb-3" } else { "hidden" },
-							{ error_msg }
-						}
-					})(has_error, error_msg)
-				},
+				let err = form.error().get();
+				let has_error = err.is_some();
+				let error_msg = err.unwrap_or_default();
+				page!(|has_error: bool, error_msg: String| {
+					div {
+						class: if has_error { "alert-danger mb-3" } else { "hidden" },
+						{ error_msg }
+					}
+				})(has_error, error_msg)
+			},
 		}
-
 	};
 
 	// Wrap form in the card layout
@@ -469,10 +451,12 @@ pub fn tweet_list(user_id: Option<Uuid>) -> Page {
 					role: "alert",
 					div {
 						class: "flex items-center gap-2",
-						{ icons::error_circle_icon() }
-						span {
-							{ error_signal.get().unwrap_or_default() }
+						{
+							icons::error_circle_icon()
 						}
+						span { {
+							error_signal.get().unwrap_or_default()
+						} }
 					}
 				}
 			} else if tweets_signal.get().is_empty() {
@@ -480,7 +464,9 @@ pub fn tweet_list(user_id: Option<Uuid>) -> Page {
 					class: "flex flex-col items-center justify-center py-16 text-center",
 					div {
 						class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
-						{ icons::chat_bubble_icon_lg() }
+						{
+							icons::chat_bubble_icon_lg()
+						}
 					}
 					h3 {
 						class: "text-lg font-semibold text-content-primary mb-1",
@@ -494,9 +480,9 @@ pub fn tweet_list(user_id: Option<Uuid>) -> Page {
 			} else {
 				div {
 					class: "card overflow-hidden",
-					for tweet in tweets_signal.get().iter() {
-						{ tweet_card(tweet, false) }
-					}
+					for tweet in tweets_signal.get().iter() { {
+						tweet_card(tweet, false)
+					} }
 				}
 			}
 		}

--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -113,12 +113,21 @@ pub fn button_with_size(
 	#[cfg(wasm)]
 	{
 		let on_click_clone = on_click.clone();
-		page!(
-			| class : String, text : String, disabled : bool | { button { class : class,
-			type : "button", disabled : disabled, @ click : { let { on_click } =
-			on_click_clone.clone(); move | _event | { on_click.set(true); } }, { { text }
-			} } }
-		)(class, text, disabled)
+		page!(| class : String, text : String, disabled : bool | {
+			button {
+				class : class,
+				type : "button",
+				disabled : disabled,
+				@ click : {
+					let { on_click }
+					=on_click_clone.clone();
+					move | _event | {
+						on_click.set(true);
+					}
+				},
+				{ { text } }
+			}
+		})(class, text, disabled)
 	}
 	#[cfg(native)]
 	{
@@ -186,7 +195,9 @@ pub fn error_alert(message: &str, dismissible: bool) -> Page {
 				role: "alert",
 				div {
 					class: "flex items-start gap-3",
-					{ icons::error_circle_icon_with_class("w-5 h-5 flex-shrink-0 mt-0.5") }
+					{
+						icons::error_circle_icon_with_class("w-5 h-5 flex-shrink-0 mt-0.5")
+					}
 					span {
 						class: "flex-1",
 						{ { message } }
@@ -195,7 +206,9 @@ pub fn error_alert(message: &str, dismissible: bool) -> Page {
 						type: "button",
 						class: "btn-icon text-danger hover:bg-red-100 dark:hover:bg-red-900/30 -mr-2 -mt-1",
 						aria_label: "Close",
-						{ icons::close_icon() }
+						{
+							icons::close_icon()
+						}
 					}
 				}
 			}
@@ -207,10 +220,10 @@ pub fn error_alert(message: &str, dismissible: bool) -> Page {
 				role: "alert",
 				div {
 					class: "flex items-start gap-3",
-					{ icons::error_circle_icon_with_class("w-5 h-5 flex-shrink-0 mt-0.5") }
-					span {
-						{ message }
+					{
+						icons::error_circle_icon_with_class("w-5 h-5 flex-shrink-0 mt-0.5")
 					}
+					span { { message } }
 				}
 			}
 		})(message)
@@ -231,10 +244,10 @@ pub fn success_alert(message: &str) -> Page {
 			role: "alert",
 			div {
 				class: "flex items-start gap-3",
-				{ icons::success_check_icon() }
-				span {
-					{ message }
+				{
+					icons::success_check_icon()
 				}
+				span { { message } }
 			}
 		}
 	})(message)
@@ -248,10 +261,10 @@ pub fn warning_alert(message: &str) -> Page {
 			role: "alert",
 			div {
 				class: "flex items-start gap-3",
-				{ icons::warning_icon() }
-				span {
-					{ message }
+				{
+					icons::warning_icon()
 				}
+				span { { message } }
 			}
 		}
 	})(message)
@@ -284,18 +297,36 @@ pub fn text_input(
 	#[cfg(wasm)]
 	{
 		let value_clone = value.clone();
-		page!(
-			| id_owned : String, label_owned : String, input_type_owned : String,
-			placeholder_owned : String, value_signal : Signal < String >, required : bool
-			| { div { class : "mb-4", label { for : id_owned.clone(), class :
-			"form-label", { { label_owned } } } input { type : input_type_owned.clone(),
-			class : "form-input", id : id_owned.clone(), name : id_owned.clone(),
-			placeholder : placeholder_owned.clone(), value : value_signal.get(), required
-			: required, @ input : { let { value } = value_clone.clone(); move | event :
-			web_sys::Event | { if let Some(target) = event.target() { if let Ok(input_el)
-			= target.dyn_into::< web_sys::HtmlInputElement > () { value.set(input_el
-			.value()); } } } }, } } }
-		)(
+		page!(| id_owned : String, label_owned : String, input_type_owned : String, placeholder_owned : String, value_signal : Signal < String >, required : bool| {
+			div {
+				class : "mb-4",
+				label {
+					for : id_owned.clone(),
+					class : "form-label",
+					{ { label_owned } }
+				}
+				input {
+					type : input_type_owned.clone(),
+					class : "form-input",
+					id : id_owned.clone(),
+					name : id_owned.clone(),
+					placeholder : placeholder_owned.clone(),
+					value : value_signal.get(),
+					required: required,
+					@ input : {
+						let { value }
+						= value_clone.clone();
+						move | event :web_sys::Event | {
+							if let Some(target) = event.target() {
+								if let Ok(input_el) = target.dyn_into::< web_sys::HtmlInputElement >() {
+									value.set(input_el.value());
+								}
+							}
+						}
+					},
+				}
+			}
+		})(
 			id_owned,
 			label_owned,
 			input_type_owned,
@@ -310,17 +341,29 @@ pub fn text_input(
 			div {
 				class: "mb-4",
 				label {
-					for: { id_owned.clone() },
+					for: {
+						id_owned.clone()
+					},
 					class: "form-label",
 					{ { label_owned } }
 				}
 				input {
-					type: { input_type_owned.clone() },
+					type: {
+						input_type_owned.clone()
+					},
 					class: "form-input",
-					id: { id_owned.clone() },
-					name: { id_owned.clone() },
-					placeholder: { placeholder_owned.clone() },
-					value: { value_signal.get() },
+					id: {
+						id_owned.clone()
+					},
+					name: {
+						id_owned.clone()
+					},
+					placeholder: {
+						placeholder_owned.clone()
+					},
+					value: {
+						value_signal.get()
+					},
 					required: required,
 					data_reactive: "true",
 				}
@@ -370,24 +413,50 @@ pub fn textarea(
 	#[cfg(wasm)]
 	{
 		let value_clone = value.clone();
-		page!(
-			| id_owned : String, label_owned : String, rows_str : String,
-			placeholder_owned : String, value_signal : Signal < String >,
-			value_signal_for_count : Signal < String >, maxlength_attr : String,
-			show_count : bool, max_length : usize | { div { class : "mb-4", label { for :
-			id_owned.clone(), class : "form-label", { { label_owned } } } textarea {
-			class : "form-textarea", id : id_owned.clone(), name : id_owned.clone(), rows
-			: rows_str.clone(), placeholder : placeholder_owned.clone(), maxlength :
-			maxlength_attr.clone(), @ input : { let { value } = value_clone.clone(); move
-			| event : web_sys::Event | { if let Some(target) = event.target() { if let
-			Ok(textarea_el) = target.dyn_into::< web_sys::HtmlTextAreaElement > () {
-			value.set(textarea_el.value()); } } } }, { value_signal.get() } } if
-			show_count { div { class : "flex justify-end mt-1", span { class : if
-			value_signal_for_count.get().len() > max_length { "text-danger font-medium" }
-			else if value_signal_for_count.get().len() > { max_length } * 9 / 10 {
-			"text-warning font-medium" } else { "text-content-tertiary" }, {
-			format!("{}/{}", value_signal_for_count.get().len(), max_length) } } } } } }
-		)(
+		page!(| id_owned : String, label_owned : String, rows_str : String, placeholder_owned : String, value_signal : Signal < String >, value_signal_for_count : Signal < String >, maxlength_attr : String, show_count : bool, max_length : usize | {
+			div {
+				class : "mb-4",
+				label {
+					for :id_owned.clone(),
+					class : "form-label",
+					{ { label_owned } }
+				}
+				textarea {
+					class : "form-textarea",
+					id : id_owned.clone(),
+					name : id_owned.clone(),
+					rows: rows_str.clone(),
+					placeholder : placeholder_owned.clone(),
+					maxlength :maxlength_attr.clone(),
+					@ input : {
+						let { value }
+						= value_clone.clone();
+						move| event : web_sys::Event | {
+							if let Some(target) = event.target() {
+								if letOk(textarea_el) = target.dyn_into::< web_sys::HtmlTextAreaElement >() {
+									value.set(textarea_el.value());
+								}
+							}
+						}
+					},
+					{
+						value_signal.get()
+					}
+				}
+				ifshow_count {
+					div {
+						class : "flex justify-end mt-1",
+						span {
+							class : ifvalue_signal_for_count.get().len() > max_length { "text-danger font-medium" } else if value_signal_for_count.get().len() > { max_length }
+							* 9 / 10 { "text-warning font-medium" } else { "text-content-tertiary" },
+							{
+								format!("{}/{}", value_signal_for_count.get().len(), max_length)
+							}
+						}
+					}
+				}
+			}
+		})(
 			id_owned,
 			label_owned,
 			rows_str,
@@ -401,22 +470,58 @@ pub fn textarea(
 	}
 	#[cfg(native)]
 	{
-		page!(
-			| id_owned : String, label_owned : String, rows_str : String,
-			placeholder_owned : String, value_signal : Signal < String >, maxlength_attr
-			: String, show_count : bool, max_length : usize | { div { class : "mb-4",
-			label { for : { id_owned.clone() }, class : "form-label", { { label_owned } }
-			} textarea { class : "form-textarea", id : { id_owned.clone() }, name : {
-			id_owned.clone() }, rows : { rows_str.clone() }, placeholder : {
-			placeholder_owned.clone() }, maxlength : { maxlength_attr.clone() },
-			data_reactive : "true", { value_signal.get() } } if show_count { let {
-			char_count } = value_signal.get().len(); let { count_class } = if {
-			char_count } > max_length { "text-danger font-medium" } else if { char_count
-			} > { max_length } * 9 / 10 { "text-warning font-medium" } else {
-			"text-content-tertiary" }; let { count_text } = format!("{}/{}", char_count,
-			max_length); div { class : "flex justify-end mt-1", span { class : { {
-			count_class } }, { { count_text } } } } } } }
-		)(
+		page!(| id_owned : String, label_owned : String, rows_str : String, placeholder_owned : String, value_signal : Signal < String >, maxlength_attr: String, show_count : bool, max_length : usize | {
+			div {
+				class : "mb-4",
+				label {
+					for : {
+						id_owned.clone()
+					},
+					class : "form-label",
+					{ { label_owned } }
+				}
+				textarea {
+					class : "form-textarea",
+					id : {
+						id_owned.clone()
+					},
+					name : {
+						id_owned.clone()
+					},
+					rows : {
+						rows_str.clone()
+					},
+					placeholder : {
+						placeholder_owned.clone()
+					},
+					maxlength : {
+						maxlength_attr.clone()
+					},
+					data_reactive : "true",
+					{
+						value_signal.get()
+					}
+				}
+				if show_count {
+					let { char_count }
+					= value_signal.get().len();
+					let { count_class }
+					= if { char_count }
+					> max_length { "text-danger font-medium" } else if { char_count }
+					> { max_length }
+					* 9 / 10 { "text-warning font-medium" } else { "text-content-tertiary" };
+					let { count_text }
+					= format!("{}/{}", char_count, max_length);
+					div {
+						class : "flex justify-end mt-1",
+						span {
+							class : { { count_class } },
+							{ { count_text } }
+						}
+					}
+				}
+			}
+		})(
 			id_owned,
 			label_owned,
 			rows_str,
@@ -508,8 +613,12 @@ pub fn theme_toggle() -> Page {
 			type: "button",
 			id: "theme-toggle-btn",
 			aria_label: "Toggle theme",
-			{ icons::sun_icon() }
-			{ icons::moon_icon() }
+			{
+				icons::sun_icon()
+			}
+			{
+				icons::moon_icon()
+			}
 		}
 	})()
 }
@@ -517,7 +626,9 @@ pub fn theme_toggle() -> Page {
 ///
 /// Displays an empty div (useful for conditional rendering).
 pub fn empty() -> Page {
-	page!(|| { div {} })()
+	page!(|| {
+		div {}
+	})()
 }
 /// Divider component
 pub fn divider() -> Page {

--- a/examples/examples-twitter/src/core/client/components/layout.rs
+++ b/examples/examples-twitter/src/core/client/components/layout.rs
@@ -95,9 +95,7 @@ pub fn header(site_name: &str, current_user: Option<&UserInfo>, nav_items: &[Nav
 		})
 		.collect();
 	let nav_links_view = page!(|nav_links: Vec<Page>| {
-		for link in nav_links {
-			{ link }
-		}
+		for link in nav_links { { link } }
 	})(nav_links);
 	let brand_link = Link::new("/".to_string(), site_name.to_string())
 		.class("text-xl font-bold text-content-primary hover:text-brand transition-colors")
@@ -207,9 +205,7 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|topics_list: Vec<Page>| {
-			for topic in topics_list {
-				{ topic }
-			}
+			for topic in topics_list { { topic } }
 		})(topics_list)
 	};
 	let users_list: Vec<Page> = suggested_users
@@ -274,9 +270,7 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|users_list: Vec<Page>| {
-			for user in users_list {
-				{ user }
-			}
+			for user in users_list { { user } }
 		})(users_list)
 	};
 	page!(|topics_view: Page, users_view: Page| {

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,3 +1,3 @@
 //! WASM compatibility shims for native-only types.
 
-pub mod websockets;
+pub(crate) mod websockets;

--- a/src/exports.rs
+++ b/src/exports.rs
@@ -8,7 +8,9 @@ mod settings;
 #[cfg(all(feature = "conf", native))]
 pub use settings::*;
 
+#[cfg(native)]
 mod core_types;
+#[cfg(native)]
 pub use core_types::*;
 
 #[cfg(all(feature = "database", native))]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+	println!("cargo::rustc-check-cfg=cfg(wasm)");
+	println!("cargo::rustc-check-cfg=cfg(native)");
+}

--- a/tests/integration/build.rs
+++ b/tests/integration/build.rs
@@ -3,4 +3,6 @@ fn main() {
 	println!(
 		"cargo:rustc-check-cfg=cfg(feature, values(\"hot-reload\", \"caching\", \"source-maps\", \"image-optimization\", \"graphql\"))"
 	);
+	println!("cargo::rustc-check-cfg=cfg(wasm)");
+	println!("cargo::rustc-check-cfg=cfg(native)");
 }


### PR DESCRIPTION
## Summary

- Fix WASM Clippy: guard `core_types` re-export with `#[cfg(native)]`, restrict `compat::websockets` to `pub(crate)`
- Fix Clippy: collapse nested `if let` into let-chain in `reinhardt-di`
- Fix Cargo Check: update `clientrouter_page_integration_tests` and `client_url_resolver` tests for changed `page()` (3-arg) and `reverse()` (`Result` return) APIs
- Fix macro: add `#[allow(missing_docs)]` to generated Info companion struct, builder, and impl blocks
- Add `check-cfg` declarations for `native`/`wasm` to `reinhardt-auth`, `reinhardt-test-support`, `reinhardt-integration-tests`
- Apply `rustfmt` to 66 unformatted files

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Breaking Change Assessment

- No

## Motivation and Context

PR #4897 (release-plz `chore: release`) is blocked by 5 CI failures on `develop/0.2.0`. These are pre-existing issues on the branch that were partially masked by earlier failures (e.g., `reinhardt-di` Clippy failure hid downstream `reinhardt-auth` errors).

## How Was This Tested

- `cargo make fmt-check` — passes (0 files to format)
- `cargo make clippy-check` — passes (0 errors, 0 warnings)
- `cargo check -p reinhardt-urls --tests --all-features` — passes
- `cargo clippy --target wasm32-unknown-unknown -p reinhardt-web` — passes

## Checklist

- [x] Code follows the project style guidelines
- [x] Comments are in English
- [x] Tests updated where necessary
- [x] Documentation updated where necessary

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to reflect template syntax formatting changes for consistency across macro-generated code.

* **Build**
  * Added build-time configuration declarations for `wasm` and `native` build targets to improve Cargo compatibility checks.

* **Refactor**
  * Improved code organization by refining module visibility and conditional feature exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->