### PR TITLE
fix(docs): neutralize user-specific wording in OBSIDIAN_WIKI.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,7 +326,7 @@ See instructions/RELEASE_PROCESS.md for detailed release procedures.
 
 ### Obsidian Wiki Maintenance
 
-**Vault:** `~/obsidian/reinhardt-wiki` (Obsidian MCP: `obsidian-vault`)
+**Access:** Obsidian MCP server (`obsidian-vault`) — vault path is resolved by the MCP server, not hardcoded
 
 At the end of a meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned), update the Obsidian wiki:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,7 +326,7 @@ See instructions/RELEASE_PROCESS.md for detailed release procedures.
 
 ### Obsidian Wiki Maintenance
 
-**Vault:** `/Users/kent8192/obsidian/reinhardt-wiki` (Obsidian MCP: `obsidian-vault`)
+**Vault:** `~/obsidian/reinhardt-wiki` (Obsidian MCP: `obsidian-vault`)
 
 At the end of a meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned), update the Obsidian wiki:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ See instructions/RELEASE_PROCESS.md for detailed release procedures.
 
 ### Obsidian Wiki Maintenance
 
-**Vault:** `~/obsidian/reinhardt-wiki` (Obsidian MCP: `obsidian-vault`)
+**Access:** Obsidian MCP server (`obsidian-vault`) — vault path is resolved by the MCP server, not hardcoded
 
 At the end of a meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned), update the Obsidian wiki:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ See instructions/RELEASE_PROCESS.md for detailed release procedures.
 
 ### Obsidian Wiki Maintenance
 
-**Vault:** `/Users/kent8192/obsidian/reinhardt-wiki` (Obsidian MCP: `obsidian-vault`)
+**Vault:** `~/obsidian/reinhardt-wiki` (Obsidian MCP: `obsidian-vault`)
 
 At the end of a meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned), update the Obsidian wiki:
 

--- a/instructions/OBSIDIAN_WIKI.md
+++ b/instructions/OBSIDIAN_WIKI.md
@@ -8,7 +8,7 @@ This file defines the policy for maintaining the Reinhardt project knowledge bas
 
 ## Vault Reference
 
-**Vault Path:** `/Users/kent8192/obsidian/reinhardt-wiki`
+**Vault Path:** `~/obsidian/reinhardt-wiki`
 **Access Method:** Obsidian MCP server (`obsidian-vault`)
 **Vault CLAUDE.md:** Contains structure, conventions, and operation instructions
 

--- a/instructions/OBSIDIAN_WIKI.md
+++ b/instructions/OBSIDIAN_WIKI.md
@@ -130,7 +130,7 @@ When saving knowledge to any memory system (claude-mem, Claude Code auto-memory,
 ### Exclusions
 - Do NOT record operational details (which agent ran what, session IDs, timestamps of tool calls)
 - Do NOT duplicate information already in CLAUDE.md, AGENTS.md, or `instructions/`
-- Do NOT record user interactions or conversation details
+- Do NOT record conversation details or session-specific interactions
 - Do NOT create pages for knowledge that is obvious from reading the code
 
 ---
@@ -152,6 +152,6 @@ When saving knowledge to any memory system (claude-mem, Claude Code auto-memory,
 - Block primary work due to Obsidian MCP unavailability (OW-3)
 - Create wiki pages for trivial changes or operational records (OW-1)
 - Duplicate information already in CLAUDE.md or `instructions/` (OW-4)
-- Record user interactions or conversation details in the wiki (OW-4)
+- Record conversation details or session-specific interactions in the wiki (OW-4)
 - Perform partial meta-page updates (update all three or none) (OW-2)
 - Save knowledge to a memory system without simultaneously writing to the wiki (OW-6), unless Obsidian MCP is unavailable

--- a/instructions/OBSIDIAN_WIKI.md
+++ b/instructions/OBSIDIAN_WIKI.md
@@ -8,8 +8,8 @@ This file defines the policy for maintaining the Reinhardt project knowledge bas
 
 ## Vault Reference
 
-**Vault Path:** `~/obsidian/reinhardt-wiki`
 **Access Method:** Obsidian MCP server (`obsidian-vault`)
+**Vault Discovery:** The vault path is managed by the Obsidian MCP server configuration — do NOT hardcode paths. Use `obsidian_list_files_in_vault` to verify connectivity and discover vault contents.
 **Vault CLAUDE.md:** Contains structure, conventions, and operation instructions
 
 ---


### PR DESCRIPTION
## Summary

- Replace "user interactions" with "conversation details or session-specific interactions" in `instructions/OBSIDIAN_WIKI.md` OW-4 exclusions and NEVER DO section

## Type of Change

- [x] Documentation update

## Breaking Change Assessment

**No** — documentation-only change.

## Motivation and Context

Follow-up to PR #4900 (merged). The OW-4 section still contained "user interactions" phrasing which conflicts with the project documentation policy ("NEVER document user requests or AI assistant interactions"). This neutralizes the remaining instances.

## How Was This Tested?

- [x] Verified only OBSIDIAN_WIKI.md OW-4 instances remained (CLAUDE.md/AGENTS.md skip conditions already fixed in #4900)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced guidance on using a hardcoded local vault path with instructions to rely on the MCP-managed vault discovery/resolution.
  * Added explicit guidance to avoid hardcoding paths and to verify vaults via the MCP discovery mechanism.
  * Clarified exclusions: forbid recording “conversation details or session‑specific interactions.”

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->