### PR TITLE
fix(ci): cancel semver-check and examples-test on merged PRs

### DIFF
--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -40,7 +40,9 @@ jobs:
               });
 
               const staleRuns = data.workflow_runs.filter(r =>
-                r.status !== 'completed'
+                r.status !== 'completed' &&
+                Array.isArray(r.pull_requests) &&
+                r.pull_requests.some(p => p.number === pr.number)
               );
 
               for (const run of staleRuns) {

--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -1,4 +1,4 @@
-name: Cancel Stale Runs on PR Close
+name: Cancel Stale Runs on PR Close/Merge
 
 on:
   pull_request:
@@ -23,8 +23,11 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const branch = context.payload.pull_request.head.ref;
-            const targetWorkflows = ['ci.yml', 'examples-test-standalone.yml'];
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+            const merged = pr.merged;
+            console.log(`PR #${pr.number} ${merged ? 'merged' : 'closed'} — cancelling stale runs on branch: ${branch}`);
+            const targetWorkflows = ['ci.yml', 'examples-test-standalone.yml', 'semver-check-standalone.yml'];
 
             // Phase 1: Find and cancel all non-completed runs
             const cancelledRunIds = [];


### PR DESCRIPTION
## Summary

- Add `semver-check-standalone.yml` to the cancel-on-pr-close target list (alongside existing `ci.yml` and `examples-test-standalone.yml`)
- Log whether the PR was merged or closed for better observability
- Workflow name updated to reflect merged PR coverage

Mirror of #4912 for the `develop/0.2.0` branch.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Breaking Change Assessment

- No

## Motivation and Context

When PRs are merged, the standalone SemVer Check and Examples Tests workflows continue running on the now-stale branch. These consume self-hosted runner capacity for no benefit. The `pull_request: closed` event already fires for both close and merge — we just needed to expand the target workflow list.

## How Was This Tested

- Verified `pull_request: types: [closed]` fires on both close and merge per [GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request)
- Confirmed workflow filenames match: `semver-check-standalone.yml`

## Checklist

- [x] Code follows the project style guidelines
- [x] Comments are in English

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed CI workflow to cover both pull request close and merge events.
  * Improved cancellation logic to only stop stale runs associated with the specific pull request.
  * Expanded the set of targeted workflows and added clearer logging for visibility into cancellations and state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->