### PR TITLE
docs(di,auth): fix rustdoc link warnings on nightly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -550,7 +550,7 @@ cat .testcontainers.properties
 
 **CI Failure Diagnosis (Known Patterns):**
 - Check these recurring patterns first:
-  1. rustdoc intra-doc link errors with `-D warnings`
+  1. rustdoc intra-doc link errors with `-D warnings` (broken links, redundant explicit targets, private item links — see RD-8/RD-9/RD-10 in instructions/DOCUMENTATION_STANDARDS.md)
   2. docs.rs build issues from empty code blocks
   3. SemVer compatibility with `cargo-semver-checks`
   4. Windows CI-specific failures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,7 +550,7 @@ cat .testcontainers.properties
 
 **CI Failure Diagnosis (Known Patterns):**
 - Check these recurring patterns first:
-  1. rustdoc intra-doc link errors with `-D warnings`
+  1. rustdoc intra-doc link errors with `-D warnings` (broken links, redundant explicit targets, private item links — see RD-8/RD-9/RD-10 in instructions/DOCUMENTATION_STANDARDS.md)
   2. docs.rs build issues from empty code blocks
   3. SemVer compatibility with `cargo-semver-checks`
   4. Windows CI-specific failures

--- a/crates/reinhardt-auth/src/core/auth_identity.rs
+++ b/crates/reinhardt-auth/src/core/auth_identity.rs
@@ -1,8 +1,8 @@
-/// Authentication identity trait - replacement for the deprecated [`User`](crate::User) trait.
+/// Authentication identity trait - replacement for the deprecated `User` trait.
 ///
 /// Provides identity and authentication status methods. Use with
-/// [`BaseUser`](crate::BaseUser)/[`FullUser`](crate::FullUser) +
-/// [`PermissionsMixin`](crate::PermissionsMixin) for full user functionality.
+/// `BaseUser`/`FullUser` +
+/// `PermissionsMixin` for full user functionality.
 ///
 /// # Examples
 ///

--- a/crates/reinhardt-auth/src/repository.rs
+++ b/crates/reinhardt-auth/src/repository.rs
@@ -38,7 +38,7 @@ pub trait UserRepository: Send + Sync {
 
 /// Simple in-memory user repository
 ///
-/// Creates [`InternalUser`] instances on-the-fly without database access.
+/// Creates `InternalUser` instances on-the-fly without database access.
 /// Suitable for testing and development environments.
 ///
 /// # Examples

--- a/crates/reinhardt-di/src/lib.rs
+++ b/crates/reinhardt-di/src/lib.rs
@@ -390,7 +390,7 @@ pub enum DiError {
 	Authentication(String),
 
 	/// An extractor requires HTTP request data, but the `InjectionContext`
-	/// has no [`ParamContext`](crate::ParamContext) attached.
+	/// has no [`ParamContext`] attached.
 	///
 	/// Occurs when a factory or handler takes a request-scoped extractor
 	/// (`Path<T>`, `Query<T>`, `Json<T>`, …) but the DI container was built
@@ -409,7 +409,7 @@ pub enum DiError {
 
 	/// A request-scoped extractor failed during HTTP parameter extraction.
 	///
-	/// Wraps the underlying [`params::ParamError`](crate::params::ParamError)
+	/// Wraps the underlying [`params::ParamError`]
 	/// so that callers can `match` on the inner variant (`MissingParameter`,
 	/// `ParseError`, `DeserializationError`, `Authentication`, …) without
 	/// duplicating the parameter-error taxonomy on `DiError`.

--- a/instructions/DOCUMENTATION_STANDARDS.md
+++ b/instructions/DOCUMENTATION_STANDARDS.md
@@ -608,6 +608,55 @@ docker run --rm -w /src -v "$(pwd):/src" semgrep/semgrep \
 
 The explicit `-w /src` ensures `--config .semgrep/` resolves relative to the mounted repo regardless of the image's default `WORKDIR`.
 
+#### RD-8: Do Not Write Redundant Explicit Link Targets
+
+When an intra-doc link label already resolves to the correct item, do not add an explicit `(crate::...)` target. Nightly rustdoc warns `redundant_explicit_links` (promoted to error by `-D warnings`).
+
+```rust
+// ✅ CORRECT (label resolves on its own)
+/// has no [`ParamContext`] attached.
+/// Wraps the underlying [`params::ParamError`].
+
+// ❌ INCORRECT (explicit target duplicates what the label already resolves to)
+/// has no [`ParamContext`](crate::ParamContext) attached.
+/// Wraps the underlying [`params::ParamError`](crate::params::ParamError).
+```
+
+**When to use explicit targets:**
+- Only when the label text differs from the path: `` [`short name`](crate::long::path::ActualType) ``
+- If label and target resolve to the same item, drop the target
+
+#### RD-9: Removed or Deprecated Items Must Use Backticks
+
+Items that have been removed from the crate (e.g., deprecated and deleted types) cannot be linked via intra-doc links. Use plain backticks instead.
+
+```rust
+// ✅ CORRECT (User was removed — use backtick, not link)
+/// Replacement for the deprecated `User` trait.
+
+// ❌ INCORRECT (causes "unresolved link" error)
+/// Replacement for the deprecated [`User`](crate::User) trait.
+/// Replacement for the deprecated [`User`] trait.
+```
+
+**Rule:** If a type/function/module no longer exists in the crate, any doc reference to it MUST use backticks (`` `RemovedType` ``), not intra-doc link syntax (`` [`RemovedType`] ``).
+
+#### RD-10: Private or Crate-Internal Items Must Use Backticks in Public Docs
+
+Public documentation must not link to `pub(crate)` or private items. Nightly rustdoc warns `private_intra_doc_links` (promoted to error by `-D warnings`). Use plain backticks instead.
+
+```rust
+// ✅ CORRECT (InternalUser is pub(crate) — use backtick)
+/// Creates `InternalUser` instances on-the-fly.
+
+// ❌ INCORRECT (causes "public documentation links to private item" error)
+/// Creates [`InternalUser`] instances on-the-fly.
+```
+
+**Rule:** If an item's visibility is less than `pub` (i.e., `pub(crate)`, `pub(super)`, or private), references from public doc comments MUST use backticks, not intra-doc links.
+
+**Scope awareness:** Intra-doc links resolve relative to the current module scope. A type re-exported at the crate root (e.g., `pub use base_user::BaseUser`) may not resolve when referenced from a deeply nested module. When unsure whether a cross-module link will resolve, prefer backticks for safety.
+
 #### Quick Reference Table
 
 | Pattern | Incorrect | Correct |
@@ -619,6 +668,9 @@ The explicit `-w /src` ensures `--config .semgrep/` resolves relative to the mou
 | Array access | `arr[0]` | `` `arr[0]` `` |
 | Feature-gated items | `` [`TypeName`] `` | `` `TypeName` `` |
 | Keyword-led continuation | `// impl Foo for Bar ...` or `/// fn foo(` | `` // The `impl Foo for Bar` ... `` or `` /// The `fn foo()` ... `` |
+| Redundant explicit target | `` [`Foo`](crate::Foo) `` | `` [`Foo`] `` |
+| Removed/deprecated items | `` [`RemovedType`] `` | `` `RemovedType` `` |
+| Private/internal items | `` [`InternalType`] `` | `` `InternalType` `` |
 
 #### Verification
 

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -49,6 +49,9 @@
 - Specify language for code blocks: ` ```rust `, NOT ` ``` `
 - Wrap bracket patterns in backticks: `` `array[0]` ``, NOT `array[0]`
 - Use backticks (not intra-doc links) for feature-gated types: `` `FeatureType` ``, NOT `` [`FeatureType`] ``
+- Do not write redundant explicit link targets in intra-doc links: `` [`Foo`] ``, NOT `` [`Foo`](crate::Foo) `` when the label already resolves (instructions/DOCUMENTATION_STANDARDS.md § RD-8)
+- Use backticks (not intra-doc links) for removed/deprecated items: `` `RemovedType` ``, NOT `` [`RemovedType`] `` (instructions/DOCUMENTATION_STANDARDS.md § RD-9)
+- Use backticks (not intra-doc links) for private/`pub(crate)` items in public docs: `` `InternalType` ``, NOT `` [`InternalType`] `` (instructions/DOCUMENTATION_STANDARDS.md § RD-10)
 - Avoid starting continuation lines of `//` and `///` comments with a Rust keyword or trigger macro — restructure prose so the token is wrapped in backticks or appears mid-line (Semgrep `rust-commented-out-code` rule trips otherwise; canonical token list in instructions/DOCUMENTATION_STANDARDS.md § RD-7)
 - Use Mermaid diagrams (via `aquamarine`) for architecture documentation instead of ASCII art
 - Ensure `.stderr` files in trybuild tests contain only single error type (no warning/error mixing)
@@ -144,6 +147,9 @@
 - Write macro attributes without backticks in doc comments (causes unresolved link warnings)
 - Write bare URLs in doc comments (causes bare URL warnings)
 - Use intra-doc links for feature-gated items (causes unresolved link warnings)
+- Write redundant explicit link targets in intra-doc links: `` [`Foo`](crate::Foo) `` when `` [`Foo`] `` suffices (nightly `redundant_explicit_links` warning; § RD-8)
+- Use intra-doc links for removed/deprecated items (causes `broken_intra_doc_links` error; use backticks — § RD-9)
+- Use intra-doc links for `pub(crate)` or private items in public docs (causes `private_intra_doc_links` error; use backticks — § RD-10)
 - Start a continuation line of a `//` or `///` comment with a Rust keyword or trigger macro — Semgrep flags the line as commented-out code and blocks the TODO Check CI; wrap the token in backticks or move it mid-line (canonical token list in instructions/DOCUMENTATION_STANDARDS.md § RD-7)
 - Create new ASCII art diagrams in doc comments (use Mermaid instead)
 - Mix warnings and errors in trybuild `.stderr` files


### PR DESCRIPTION
## Summary

Fix Docs.rs Build Check CI failure on PR #4911 (release-plz Release PR) caused by nightly rustdoc warnings treated as errors (`-D warnings`).

**Errors fixed:**
- `reinhardt-di`: redundant explicit link targets (`[`ParamContext`](crate::ParamContext)` → `[`ParamContext`]`)
- `reinhardt-auth`: broken intra-doc link to removed `User` type (replaced with backticks)
- `reinhardt-auth`: public doc linking to private `InternalUser` (replaced with backticks)
- `reinhardt-auth`: cross-module intra-doc links (`BaseUser`, `FullUser`, `PermissionsMixin`) failing scope resolution on nightly (replaced with backticks)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Breaking Change Assessment

**No** — documentation-only changes.

## Motivation and Context

The release-plz PR #4911 fails Docs.rs Build Check because nightly rustdoc (1.98.0-nightly) flags:
1. `rustdoc::redundant_explicit_links` — when an explicit link target matches the label path
2. `rustdoc::broken_intra_doc_links` — when the link target no longer exists (`User` was removed in Issue #4520)
3. `rustdoc::private_intra_doc_links` — when linking to `pub(crate)` items from public docs

## How Was This Tested

- [x] `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --no-deps -p reinhardt-di --all-features` — passes
- [x] `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --no-deps -p reinhardt-auth --all-features` — passes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized rustdoc formatting and intra-doc link usage across the codebase.
  * Added linting rules RD-8, RD-9, RD-10 and updated the quick‑reference guidance to forbid redundant intra-doc targets and require backticks for removed/deprecated or private items.
  * Expanded CI/review guidance to explicitly call out common rustdoc intra-doc link failures and remediation pointers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->