### PR TITLE
fix(storages): replace LocalStack with wiremock mock S3 server

### DIFF
--- a/crates/reinhardt-storages/Cargo.toml
+++ b/crates/reinhardt-storages/Cargo.toml
@@ -27,7 +27,7 @@ azure_storage_blobs = { version = "0.20", optional = true }
 azure_core = { version = "0.20", optional = true }
 
 [dev-dependencies]
-testcontainers = { workspace = true }
+wiremock = "0.6"
 tokio = { version = "1", features = ["full"] }
 tempfile = "3"
 rstest = "0.23"

--- a/crates/reinhardt-storages/README.md
+++ b/crates/reinhardt-storages/README.md
@@ -153,7 +153,7 @@ export STORAGE_BACKEND=s3  # or: local, gcs, azure
 # S3 Configuration
 export S3_BUCKET=my-bucket
 export S3_REGION=us-east-1
-export S3_ENDPOINT=http://localhost:4566  # Optional (for LocalStack)
+export S3_ENDPOINT=http://localhost:4566  # Optional (for S3-compatible servers)
 export S3_PREFIX=uploads/                  # Optional
 
 # Local Configuration
@@ -232,7 +232,7 @@ cargo test
 # Local storage tests only
 cargo test --test local_storage
 
-# S3 integration tests (requires Docker for LocalStack)
+# S3 integration tests (uses wiremock mock server, no Docker required)
 cargo test --test s3_storage
 ```
 

--- a/crates/reinhardt-storages/tests.rs
+++ b/crates/reinhardt-storages/tests.rs
@@ -1,7 +1,7 @@
 //! Reinhardt Storages Test Suite
 //!
 //! Comprehensive tests for the reinhardt-storages crate covering:
-//! - S3 backend (with LocalStack/MinIO via TestContainers)
+//! - S3 backend (with wiremock mock S3 server)
 //! - Local filesystem backend
 //! - Configuration parsing
 //! - Factory pattern

--- a/crates/reinhardt-storages/tests/factory_tests.rs
+++ b/crates/reinhardt-storages/tests/factory_tests.rs
@@ -80,7 +80,7 @@ mod backend_creation_tests {
 			prefix: None,
 		});
 
-		// This will fail without LocalStack running, but we're testing the factory pattern
+		// This may fail without an S3-compatible server, but we're testing the factory pattern
 		let result = create_storage(config).await;
 		// We expect either success or network error (not config error)
 		match result {
@@ -88,7 +88,7 @@ mod backend_creation_tests {
 				// Success - backend created
 			}
 			Err(StorageError::NetworkError(_)) => {
-				// Expected if LocalStack is not running
+				// Expected if no S3-compatible server is running
 			}
 			Err(StorageError::ConfigError(_)) => {
 				panic!("Should not get ConfigError for valid config");
@@ -129,7 +129,7 @@ mod backend_creation_tests {
 				// Success
 			}
 			Err(StorageError::NetworkError(_)) => {
-				// Expected if LocalStack is not running
+				// Expected if no S3-compatible server is running
 			}
 			Err(e) => {
 				panic!("Unexpected error: {:?}", e);
@@ -296,7 +296,7 @@ mod s3_feature_tests {
 				// Success
 			}
 			Err(StorageError::NetworkError(_)) => {
-				// Expected if LocalStack is not running
+				// Expected if no S3-compatible server is running
 			}
 			Err(StorageError::ConfigError(_)) => {
 				panic!("Should not get ConfigError - S3 feature should be enabled");

--- a/crates/reinhardt-storages/tests/fixtures.rs
+++ b/crates/reinhardt-storages/tests/fixtures.rs
@@ -6,18 +6,15 @@
 #![allow(dead_code)]
 #![allow(unreachable_pub)]
 
-use aws_config::Region;
-use aws_sdk_s3::config::Credentials;
+use chrono::{DateTime, Utc};
 use reinhardt_storages::{StorageBackend, StorageConfig};
 use rstest::fixture;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
-use testcontainers::{
-	ContainerAsync, GenericImage,
-	core::{IntoContainerPort, WaitFor},
-	runners::AsyncRunner,
-};
+use wiremock::matchers::any;
+use wiremock::{Mock, MockServer, Respond, ResponseTemplate};
 
 // ============================================================================
 // Test Data (inline to avoid super::utils dependency issues)
@@ -167,8 +164,6 @@ impl LocalTestDir {
 /// This is acceptable for test code since OS cleans up temp directories.
 #[fixture]
 pub async fn local_backend() -> Arc<dyn StorageBackend> {
-	// Use keep() to prevent automatic cleanup when TempDir is dropped.
-	// This ensures the directory stays alive for the entire test.
 	let temp_dir = TempDir::new().expect("Failed to create temp dir");
 	let base_path_str = temp_dir.path().to_str().unwrap().to_string();
 	let _ = temp_dir.keep();
@@ -189,63 +184,176 @@ pub async fn local_temp_dir() -> LocalTestDir {
 }
 
 // ============================================================================
-// S3 Storage Fixtures (using LocalStack)
+// S3 Storage Fixtures (using wiremock Mock S3 Server)
 // ============================================================================
 
-/// S3 test container wrapper.
-pub struct S3TestContainer {
-	/// LocalStack container
-	#[allow(dead_code)]
-	container: ContainerAsync<GenericImage>,
-	/// S3 endpoint URL
-	pub endpoint: String,
-	/// S3 bucket name
-	pub bucket: String,
-	/// AWS region
-	pub region: String,
+/// An object stored in the mock S3 server.
+struct StoredObject {
+	content: Vec<u8>,
+	last_modified: DateTime<Utc>,
 }
 
-impl S3TestContainer {
-	/// Create a new S3 test container with LocalStack.
-	///
-	/// This starts a LocalStack container and creates a test bucket.
-	pub async fn new() -> Self {
-		// Use LocalStack image
-		let container = GenericImage::new("localstack/localstack", "latest")
-			.with_exposed_port(4566.tcp())
-			.with_wait_for(WaitFor::message_on_stdout("Ready."))
-			.start()
-			.await
-			.expect("Failed to start LocalStack container");
+/// In-memory state for the mock S3 server.
+struct MockS3State {
+	objects: HashMap<String, StoredObject>,
+	buckets: HashSet<String>,
+}
 
-		let port = container
-			.get_host_port_ipv4(4566)
-			.await
-			.expect("Failed to get host port");
-		let endpoint = format!("http://localhost:{}", port);
+/// Stateful responder that mimics the AWS S3 REST API.
+///
+/// Routes requests based on HTTP method and URL path (path-style addressing):
+/// - `PUT /{bucket}` -> CreateBucket
+/// - `PUT /{bucket}/{key}` -> PutObject
+/// - `GET /{bucket}/{key}` -> GetObject
+/// - `HEAD /{bucket}/{key}` -> HeadObject
+/// - `DELETE /{bucket}/{key}` -> DeleteObject
+struct MockS3Responder {
+	state: Arc<Mutex<MockS3State>>,
+}
+
+/// Parse a path-style S3 URL path into (bucket, optional key).
+fn parse_s3_path(path: &str) -> (String, Option<String>) {
+	let trimmed = path.trim_start_matches('/');
+	if let Some(idx) = trimmed.find('/') {
+		let bucket = trimmed[..idx].to_string();
+		let key = trimmed[idx + 1..].to_string();
+		(bucket, Some(key))
+	} else {
+		(trimmed.to_string(), None)
+	}
+}
+
+impl Respond for MockS3Responder {
+	fn respond(&self, request: &wiremock::Request) -> ResponseTemplate {
+		let path = request.url.path();
+		let (bucket, key) = parse_s3_path(&path);
+		let method = request.method.as_str();
+
+		match (method, key) {
+			("PUT", None) => {
+				// CreateBucket
+				let mut state = self.state.lock().unwrap();
+				state.buckets.insert(bucket.clone());
+				ResponseTemplate::new(200).insert_header("Location", format!("/{}", bucket))
+			}
+			("PUT", Some(key)) => {
+				// PutObject
+				let full_key = format!("{}/{}", bucket, key);
+				let mut state = self.state.lock().unwrap();
+				state.objects.insert(
+					full_key,
+					StoredObject {
+						content: request.body.clone(),
+						last_modified: Utc::now(),
+					},
+				);
+				ResponseTemplate::new(200)
+					.insert_header("ETag", "\"mock-etag\"")
+					.insert_header("Content-Length", "0")
+			}
+			("GET", Some(key)) => {
+				// GetObject
+				let full_key = format!("{}/{}", bucket, key);
+				let state = self.state.lock().unwrap();
+				match state.objects.get(&full_key) {
+					Some(obj) => {
+						let last_modified = obj.last_modified.format("%a, %d %b %Y %H:%M:%S GMT");
+						ResponseTemplate::new(200)
+							.set_body_bytes(obj.content.clone())
+							.insert_header("Content-Length", obj.content.len().to_string())
+							.insert_header("Content-Type", "application/octet-stream")
+							.insert_header("ETag", "\"mock-etag\"")
+							.insert_header("Last-Modified", last_modified.to_string())
+							.insert_header("Accept-Ranges", "bytes")
+					}
+					None => {
+						let xml = format!(
+							"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+							<Error>\
+								<Code>NoSuchKey</Code>\
+								<Message>The specified key does not exist.</Message>\
+								<Key>{}</Key>\
+							</Error>",
+							key
+						);
+						ResponseTemplate::new(404)
+							.set_body_string(xml)
+							.insert_header("Content-Type", "application/xml")
+					}
+				}
+			}
+			("HEAD", Some(key)) => {
+				// HeadObject
+				let full_key = format!("{}/{}", bucket, key);
+				let state = self.state.lock().unwrap();
+				match state.objects.get(&full_key) {
+					Some(obj) => {
+						let last_modified = obj.last_modified.format("%a, %d %b %Y %H:%M:%S GMT");
+						ResponseTemplate::new(200)
+							.insert_header("Content-Length", obj.content.len().to_string())
+							.insert_header("Content-Type", "application/octet-stream")
+							.insert_header("ETag", "\"mock-etag\"")
+							.insert_header("Last-Modified", last_modified.to_string())
+							.insert_header("Accept-Ranges", "bytes")
+					}
+					None => ResponseTemplate::new(404),
+				}
+			}
+			("DELETE", Some(key)) => {
+				// DeleteObject
+				let full_key = format!("{}/{}", bucket, key);
+				let mut state = self.state.lock().unwrap();
+				state.objects.remove(&full_key);
+				ResponseTemplate::new(204)
+			}
+			_ => ResponseTemplate::new(400).set_body_string("Bad Request"),
+		}
+	}
+}
+
+/// Mock S3 server using wiremock with AWS S3-standard responses.
+///
+/// Replaces the previous LocalStack-based `S3TestContainer`.
+/// The actual `S3Storage` production code is exercised end-to-end through
+/// this mock server, without requiring Docker.
+pub struct MockS3Server {
+	#[allow(dead_code)]
+	server: MockServer,
+	#[allow(dead_code)]
+	state: Arc<Mutex<MockS3State>>,
+	endpoint: String,
+	bucket: String,
+	region: String,
+}
+
+impl MockS3Server {
+	/// Create a new mock S3 server with a pre-created test bucket.
+	pub async fn new() -> Self {
+		let server = MockServer::start().await;
+		let endpoint = server.uri();
 		let bucket = "test-bucket".to_string();
 		let region = "us-east-1".to_string();
 
-		// Create the bucket using AWS SDK
-		let credentials = Credentials::new("test", "test", None, None, "test");
-		let s3_config = aws_sdk_s3::Config::builder()
-			.behavior_version_latest()
-			.region(Region::new(region.clone()))
-			.endpoint_url(&endpoint)
-			.credentials_provider(credentials)
-			.force_path_style(true)
-			.build();
-		let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+		let mut buckets = HashSet::new();
+		buckets.insert(bucket.clone());
 
-		s3_client
-			.create_bucket()
-			.bucket(&bucket)
-			.send()
-			.await
-			.expect("Failed to create test bucket");
+		let state = Arc::new(Mutex::new(MockS3State {
+			objects: HashMap::new(),
+			buckets,
+		}));
+
+		let responder = MockS3Responder {
+			state: Arc::clone(&state),
+		};
+
+		Mock::given(any())
+			.respond_with(responder)
+			.mount(&server)
+			.await;
 
 		Self {
-			container,
+			server,
+			state,
 			endpoint,
 			bucket,
 			region,
@@ -267,7 +375,7 @@ impl S3TestContainer {
 		&self.region
 	}
 
-	/// Create S3 storage backend from this container.
+	/// Create S3 storage backend from this mock server.
 	pub async fn create_backend(&self) -> Arc<dyn StorageBackend> {
 		// SAFETY: Setting environment variables for test-only AWS credentials.
 		// These tests run serially and the env vars are required by aws-config
@@ -289,7 +397,7 @@ impl S3TestContainer {
 			.expect("Failed to create S3 backend")
 	}
 
-	/// Create S3 storage backend with prefix from this container.
+	/// Create S3 storage backend with prefix from this mock server.
 	pub async fn create_backend_with_prefix(&self, prefix: &str) -> Arc<dyn StorageBackend> {
 		// SAFETY: Setting environment variables for test-only AWS credentials.
 		// These tests run serially and the env vars are required by aws-config
@@ -312,33 +420,29 @@ impl S3TestContainer {
 	}
 }
 
-/// S3 backend fixture using LocalStack container.
+/// S3 backend fixture using wiremock mock server.
 ///
-/// This fixture creates a new LocalStack container for each test.
-/// Note: The container is leaked to keep it alive for the duration of the test.
+/// This fixture creates a new mock S3 server for each test.
+/// Note: The server is leaked to keep it alive for the duration of the test.
 #[fixture]
 pub async fn s3_backend() -> Arc<dyn StorageBackend> {
-	// Leak the container to keep it alive for the entire test.
-	// Without this, the container would be stopped when it goes out of scope,
-	// causing network errors when the backend tries to communicate with S3.
-	let container = Box::leak(Box::new(S3TestContainer::new().await));
-	container.create_backend().await
+	let mock = Box::leak(Box::new(MockS3Server::new().await));
+	mock.create_backend().await
 }
 
 /// S3 backend fixture with path prefix.
 ///
-/// Note: The container is leaked to keep it alive for the duration of the test.
+/// Note: The server is leaked to keep it alive for the duration of the test.
 #[fixture]
 pub async fn s3_backend_with_prefix() -> Arc<dyn StorageBackend> {
-	// Leak the container to keep it alive for the entire test.
-	let container = Box::leak(Box::new(S3TestContainer::new().await));
-	container.create_backend_with_prefix("test-prefix").await
+	let mock = Box::leak(Box::new(MockS3Server::new().await));
+	mock.create_backend_with_prefix("test-prefix").await
 }
 
-/// S3 test container fixture.
+/// Mock S3 server fixture.
 #[fixture]
-pub async fn s3_container() -> S3TestContainer {
-	S3TestContainer::new().await
+pub async fn s3_container() -> MockS3Server {
+	MockS3Server::new().await
 }
 
 // ============================================================================
@@ -437,8 +541,8 @@ mod tests {
 	// S3 fixture tests
 	#[tokio::test]
 	async fn test_s3_container_creation() {
-		let container = S3TestContainer::new().await;
-		assert!(container.endpoint().contains("localhost"));
+		let container = MockS3Server::new().await;
+		assert!(container.endpoint().contains("127.0.0.1"));
 		assert_eq!(container.bucket(), "test-bucket");
 		assert_eq!(container.region(), "us-east-1");
 	}

--- a/crates/reinhardt-storages/tests/fixtures.rs
+++ b/crates/reinhardt-storages/tests/fixtures.rs
@@ -317,8 +317,10 @@ impl Respond for MockS3Responder {
 /// The actual `S3Storage` production code is exercised end-to-end through
 /// this mock server, without requiring Docker.
 pub struct MockS3Server {
+	// Kept alive so wiremock continues serving HTTP requests for the test duration.
 	#[allow(dead_code)]
 	server: MockServer,
+	// Kept alive so the MockS3Responder's Arc reference remains valid.
 	#[allow(dead_code)]
 	state: Arc<Mutex<MockS3State>>,
 	endpoint: String,
@@ -420,23 +422,37 @@ impl MockS3Server {
 	}
 }
 
+/// Owns a `MockS3Server` alongside the backend it created, keeping the
+/// mock HTTP server alive for the test lifetime without leaking memory.
+pub struct S3BackendOwner {
+	pub backend: Arc<dyn StorageBackend>,
+	#[allow(dead_code)]
+	// Dropped at end of test, cleaning up the wiremock listener.
+	mock: MockS3Server,
+}
+
+impl std::ops::Deref for S3BackendOwner {
+	type Target = dyn StorageBackend;
+
+	fn deref(&self) -> &Self::Target {
+		&*self.backend
+	}
+}
+
 /// S3 backend fixture using wiremock mock server.
-///
-/// This fixture creates a new mock S3 server for each test.
-/// Note: The server is leaked to keep it alive for the duration of the test.
 #[fixture]
-pub async fn s3_backend() -> Arc<dyn StorageBackend> {
-	let mock = Box::leak(Box::new(MockS3Server::new().await));
-	mock.create_backend().await
+pub async fn s3_backend() -> S3BackendOwner {
+	let mock = MockS3Server::new().await;
+	let backend = mock.create_backend().await;
+	S3BackendOwner { backend, mock }
 }
 
 /// S3 backend fixture with path prefix.
-///
-/// Note: The server is leaked to keep it alive for the duration of the test.
 #[fixture]
-pub async fn s3_backend_with_prefix() -> Arc<dyn StorageBackend> {
-	let mock = Box::leak(Box::new(MockS3Server::new().await));
-	mock.create_backend_with_prefix("test-prefix").await
+pub async fn s3_backend_with_prefix() -> S3BackendOwner {
+	let mock = MockS3Server::new().await;
+	let backend = mock.create_backend_with_prefix("test-prefix").await;
+	S3BackendOwner { backend, mock }
 }
 
 /// Mock S3 server fixture.
@@ -542,7 +558,11 @@ mod tests {
 	#[tokio::test]
 	async fn test_s3_container_creation() {
 		let container = MockS3Server::new().await;
-		assert!(container.endpoint().contains("127.0.0.1"));
+		assert!(
+			container.endpoint().starts_with("http://127.0.0.1:"),
+			"endpoint should bind to 127.0.0.1: {}",
+			container.endpoint()
+		);
 		assert_eq!(container.bucket(), "test-bucket");
 		assert_eq!(container.region(), "us-east-1");
 	}

--- a/crates/reinhardt-storages/tests/s3_tests.rs
+++ b/crates/reinhardt-storages/tests/s3_tests.rs
@@ -4,11 +4,11 @@ mod fixtures;
 mod utils;
 
 use fixtures::{
-	MockS3Server, generate_unique_name, s3_backend, s3_backend_with_prefix, s3_container,
+	MockS3Server, S3BackendOwner, generate_unique_name, s3_backend, s3_backend_with_prefix,
+	s3_container,
 };
-use reinhardt_storages::{StorageBackend, StorageError};
+use reinhardt_storages::StorageError;
 use rstest::rstest;
-use std::sync::Arc;
 use utils::{assert_presigned_url, assert_storage_exists, assert_storage_not_exists};
 
 // ============================================================================
@@ -20,7 +20,7 @@ mod crud_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_save_file(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_save_file(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_save.txt";
 		let content = b"Hello, S3!";
 
@@ -40,7 +40,7 @@ mod crud_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_open_file(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_open_file(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_open.txt";
 		let content = b"Hello, S3 Storage!";
 
@@ -59,7 +59,7 @@ mod crud_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_delete_file(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_delete_file(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_delete.txt";
 		s3_backend
 			.save(name, b"temporary")
@@ -82,7 +82,7 @@ mod crud_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_exists_true(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_exists_true(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_exists_true.txt";
 		s3_backend
 			.save(name, b"content")
@@ -101,7 +101,7 @@ mod crud_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_exists_false(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_exists_false(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_nonexistent.txt";
 		let exists = s3_backend
 			.exists(name)
@@ -112,7 +112,7 @@ mod crud_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_roundtrip(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_roundtrip(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_roundtrip.bin";
 		let content = vec![0u8, 1, 2, 3, 255, 254, 253];
 
@@ -131,7 +131,7 @@ mod crud_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_overwrite_file(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_overwrite_file(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_overwrite.txt";
 		let content1 = b"Original content";
 		let content2 = b"New content";
@@ -155,7 +155,7 @@ mod crud_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_empty_file(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_empty_file(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_empty.txt";
 		let content: Vec<u8> = vec![];
 
@@ -173,7 +173,7 @@ mod crud_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_binary_data(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_binary_data(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_binary.bin";
 		let content: Vec<u8> = (0u8..=255).collect();
 
@@ -191,7 +191,7 @@ mod crud_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_nested_path(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_nested_path(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "path/to/nested/file.txt";
 		let content = b"Nested file content";
 
@@ -218,7 +218,7 @@ mod url_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_presigned_url_format(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_presigned_url_format(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_url.txt";
 		s3_backend
 			.save(name, b"content")
@@ -235,7 +235,7 @@ mod url_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_presigned_url_custom_expiry(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_presigned_url_custom_expiry(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_expiry.txt";
 		s3_backend
 			.save(name, b"content")
@@ -252,7 +252,7 @@ mod url_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_url_not_found(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_url_not_found(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "nonexistent.txt";
 
 		let result = s3_backend.url(name, 3600).await;
@@ -262,7 +262,7 @@ mod url_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_url_contains_bucket(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_url_contains_bucket(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_bucket_in_url.txt";
 		s3_backend
 			.save(name, b"content")
@@ -291,9 +291,7 @@ mod prefix_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_prefix_applied_to_save(
-		#[future(awt)] s3_backend_with_prefix: Arc<dyn StorageBackend>,
-	) {
+	async fn test_prefix_applied_to_save(#[future(awt)] s3_backend_with_prefix: S3BackendOwner) {
 		let name = "test_prefix_save.txt";
 		let content = b"Prefix test content";
 
@@ -315,9 +313,7 @@ mod prefix_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_prefix_applied_to_open(
-		#[future(awt)] s3_backend_with_prefix: Arc<dyn StorageBackend>,
-	) {
+	async fn test_prefix_applied_to_open(#[future(awt)] s3_backend_with_prefix: S3BackendOwner) {
 		let name = "test_prefix_open.txt";
 		let content = b"Prefix open test";
 
@@ -362,9 +358,7 @@ mod prefix_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_prefix_with_nested_path(
-		#[future(awt)] s3_backend_with_prefix: Arc<dyn StorageBackend>,
-	) {
+	async fn test_prefix_with_nested_path(#[future(awt)] s3_backend_with_prefix: S3BackendOwner) {
 		let name = "nested/path/file.txt";
 		let content = b"Prefix with nested path";
 
@@ -393,7 +387,7 @@ mod metadata_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_file_size(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_file_size(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_size.txt";
 		let content = b"Hello, S3 Size!";
 
@@ -411,7 +405,7 @@ mod metadata_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_modified_time(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_modified_time(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_time.txt";
 
 		s3_backend
@@ -432,7 +426,7 @@ mod metadata_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_size_updates_after_overwrite(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_size_updates_after_overwrite(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_size_update.txt";
 		let content1 = b"Small";
 		let content2 = b"This is much larger content";
@@ -460,7 +454,7 @@ mod metadata_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_empty_file_size(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_empty_file_size(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "test_empty_size.txt";
 		let content: Vec<u8> = vec![];
 
@@ -486,7 +480,7 @@ mod error_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_open_not_found(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_open_not_found(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "nonexistent_open.txt";
 
 		let result = s3_backend.open(name).await;
@@ -496,7 +490,7 @@ mod error_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_delete_not_found(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_delete_not_found(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "nonexistent_delete.txt";
 
 		let result = s3_backend.delete(name).await;
@@ -506,7 +500,7 @@ mod error_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_size_not_found(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_size_not_found(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "nonexistent_size.txt";
 
 		let result = s3_backend.size(name).await;
@@ -516,7 +510,7 @@ mod error_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_url_not_found(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_url_not_found(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "nonexistent_url.txt";
 
 		let result = s3_backend.url(name, 3600).await;
@@ -526,7 +520,7 @@ mod error_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_special_characters_in_name(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_special_characters_in_name(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "file with spaces & symbols!.txt";
 		let content = b"Special chars";
 
@@ -544,7 +538,7 @@ mod error_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_unicode_filename(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_unicode_filename(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "ファイル.txt"; // Japanese filename
 		let content = "Unicode content".as_bytes();
 
@@ -566,7 +560,7 @@ mod error_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_modified_time_not_found(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_modified_time_not_found(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name = "nonexistent_time.txt";
 
 		let result = s3_backend.get_modified_time(name).await;
@@ -584,7 +578,7 @@ mod multiple_operations_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_multiple_files(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_multiple_files(#[future(awt)] s3_backend: S3BackendOwner) {
 		let files: Vec<(&str, &[u8])> = vec![
 			("file1.txt", b"content1"),
 			("file2.txt", b"content2"),
@@ -620,7 +614,7 @@ mod multiple_operations_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_unique_names(#[future(awt)] s3_backend: Arc<dyn StorageBackend>) {
+	async fn test_unique_names(#[future(awt)] s3_backend: S3BackendOwner) {
 		let name1 = generate_unique_name("test");
 		let name2 = generate_unique_name("test");
 

--- a/crates/reinhardt-storages/tests/s3_tests.rs
+++ b/crates/reinhardt-storages/tests/s3_tests.rs
@@ -1,10 +1,10 @@
-//! Integration tests for S3 storage backend using LocalStack.
+//! Integration tests for S3 storage backend using wiremock mock server.
 
 mod fixtures;
 mod utils;
 
 use fixtures::{
-	S3TestContainer, generate_unique_name, s3_backend, s3_backend_with_prefix, s3_container,
+	MockS3Server, generate_unique_name, s3_backend, s3_backend_with_prefix, s3_container,
 };
 use reinhardt_storages::{StorageBackend, StorageError};
 use rstest::rstest;
@@ -339,7 +339,7 @@ mod prefix_tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_prefix_trailing_slash(#[future(awt)] s3_container: S3TestContainer) {
+	async fn test_prefix_trailing_slash(#[future(awt)] s3_container: MockS3Server) {
 		// Create a new backend with trailing slash in prefix
 		let container = s3_container;
 		let backend = container


### PR DESCRIPTION
## Summary

- Replace LocalStack/TestContainers-based S3 test infrastructure with a stateful wiremock mock server
- The mock server returns AWS S3-standard HTTP responses (PutObject, GetObject, HeadObject, DeleteObject)
- Eliminates Docker dependency for S3 storage tests, making them faster and more reliable in CI

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #4911 (release-plz Release PR) has CI failures because LocalStack containers fail to start in the `reinhardt-storages` S3 tests. All S3 tests panic at `fixtures.rs:219` (`Failed to start LocalStack container`).

The reinhardt-web MSW system is WASM-only and cannot intercept native AWS SDK HTTP calls. A separate enhancement Issue #4916 was created for MSW external URL support.

Refs #4916

## How Was This Tested

- All 260 tests in `reinhardt-storages` pass: `cargo nextest run --package reinhardt-storages --all-features`
- `cargo make fmt-check` clean
- S3 CRUD, URL/presigning, prefix, metadata, and error handling tests all exercise the real `S3Storage` production code through the wiremock mock server

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] All new and existing tests pass
- [x] I have updated the documentation accordingly

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched S3 test infrastructure from container-based to an in-process Wiremock-backed mock server, streamlining and speeding tests.
* **Tests**
  * Updated fixtures and test suites to use the in-process mock S3 server; test behavior remains the same though test harness interfaces were adjusted to keep the mock server alive during tests.
* **Documentation**
  * Clarified README and test comments: S3 endpoint is optional for S3-compatible servers and integration tests no longer require Docker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->