### PR TITLE
fix(ci): gate develop release-plz publish on release PR merges

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -229,23 +229,22 @@ jobs:
 
   release-plz-release:
     name: Release
-    # On main, always run on push — the existing two-stage workflow with
-    # release_always=true (KI-5 phantom-version-bump fix) means release-plz
-    # itself decides whether to publish based on Cargo.toml vs crates.io.
+    # Publish only after a verified Release PR merge. The release-plz-pr job
+    # above still runs on every main/develop push, so routine feature merges
+    # keep the next Release PR up to date without entering the publish path.
     #
-    # On develop/**, only squash-merge Release PR commits with a PR number
-    # ("chore: release (#N)") trigger the job. The merge-commit trigger is
-    # intentionally NOT included because startsWith(commit.message,
-    # 'Merge pull request #') would also match regular feature-PR merges on
-    # develop/**, which would then fail at the branch-name verification step.
-    # Release-plz PRs should be squash-merged (MP-2), producing the numbered
-    # "chore: release (#N)" shape covered here.
-    #
-    # release-plz-pr (above) still runs on every develop/** push, so the
-    # next Release PR is always kept up to date.
+    # Accepted Release PR merge shapes:
+    # - merge commit from release-plz-* or develop-release-plz-* branch
+    # - squash commit titled "chore: release (#N)"
     if: |
       github.event_name == 'push' && (
-        github.ref == 'refs/heads/main' ||
+        (
+          startsWith(github.event.head_commit.message, 'Merge pull request #') &&
+          (
+            contains(github.event.head_commit.message, '/release-plz-') ||
+            contains(github.event.head_commit.message, '/develop-release-plz-')
+          )
+        ) ||
         (
           startsWith(github.event.head_commit.message, 'chore: release ') &&
           contains(github.event.head_commit.message, '(#')


### PR DESCRIPTION
## Summary

This PR addresses:

- Release-plz publish job gating on `develop/0.2.0` so routine feature/fix merges do not enter the crates.io publish path.
- Support for both release-plz merge commits and numbered `chore: release (#N)` squash commits as verified Release PR merge shapes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The release workflow should regenerate Release PRs on routine `develop/0.2.0` pushes, but publishing should only run after a verified Release PR merge. This aligns the develop release path with the release branch guard used for publish operations while preserving Release PR regeneration for normal pushes.

Fixes: N/A

Related to: #4919, #4922

## How Was This Tested?

- [x] `actionlint -shellcheck= .github/workflows/release-plz.yml`
- [x] `git diff --check`
- [x] Local gate simulation for a routine develop feature merge commit: `skip`
- [x] Local gate simulation for `develop-release-plz-*`, `release-plz-*`, and `chore: release (#N)`: `publish`

## Performance Impact

N/A - CI workflow gate only.

## Screenshots

N/A - no UI changes.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to release PR: #4919
- Related to main-branch counterpart: #4922

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Generated with [Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to improve handling of release merge commits from release branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->