### PR TITLE
feat(website): add version switcher and multi-branch deployment

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -188,22 +188,32 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref_name, 'develop/')
         env:
           CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           BRANCH_SLUG=$(echo "$REF_NAME" | tr '/' '-' | tr '.' '-')
           CNAME_TARGET="${BRANCH_SLUG}.reinhardt-web.pages.dev"
 
+          ZONE_ID=$(curl -sf \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/zones?name=reinhardt-web.dev&account.id=${CF_ACCOUNT_ID}" \
+            | jq -r '.result[0].id // empty')
+
+          if [ -z "$ZONE_ID" ]; then
+            echo "Warning: could not resolve zone ID for reinhardt-web.dev"
+            exit 0
+          fi
+
           echo "Updating rc.reinhardt-web.dev CNAME → ${CNAME_TARGET} ..."
 
           RECORD_ID=$(curl -sf \
             -H "Authorization: Bearer ${CF_API_TOKEN}" \
-            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records?name=rc.reinhardt-web.dev&type=CNAME" \
+            "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=rc.reinhardt-web.dev&type=CNAME" \
             | jq -r '.result[0].id // empty')
 
           if [ -n "$RECORD_ID" ]; then
             curl -sf -X PATCH \
-              "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records/${RECORD_ID}" \
+              "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RECORD_ID}" \
               -H "Authorization: Bearer ${CF_API_TOKEN}" \
               -H "Content-Type: application/json" \
               -d "{\"content\":\"${CNAME_TARGET}\",\"proxied\":true}" \

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -131,6 +131,7 @@ jobs:
             CURRENT_LABEL="v${VERSION}"
             IS_STABLE="true"
           fi
+          sed -i '/^\[extra\.version_switcher\]/,$d' config.toml
           cat >> config.toml << TOML
 
           [extra.version_switcher]

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -2,7 +2,7 @@ name: Deploy Website
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'develop/**']
     paths:
       - "website/**"
   pull_request:
@@ -118,9 +118,45 @@ jobs:
         with:
           tool: zola@0.22.1
 
+      - name: Configure version switcher
+        working-directory: website
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION=$(grep 'reinhardt_version' config.toml | sed 's/.*= *"\(.*\)"/\1/')
+          if [[ "$REF_NAME" == develop/* ]]; then
+            CURRENT_LABEL="v${VERSION} (Dev)"
+            IS_STABLE="false"
+          else
+            CURRENT_LABEL="v${VERSION}"
+            IS_STABLE="true"
+          fi
+          cat >> config.toml << TOML
+
+          [extra.version_switcher]
+          current_label = "${CURRENT_LABEL}"
+          current_is_stable = ${IS_STABLE}
+
+          [[extra.version_switcher.versions]]
+          label = "Stable"
+          url = "https://reinhardt-web.dev"
+
+          [[extra.version_switcher.versions]]
+          label = "Dev"
+          url = "https://rc.reinhardt-web.dev"
+          TOML
+          echo "Version switcher configured: ${CURRENT_LABEL} (stable=${IS_STABLE})"
+
       - name: Build
         working-directory: website
-        run: zola build
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$REF_NAME" == develop/* ]]; then
+            zola build --base-url "https://rc.reinhardt-web.dev"
+          else
+            zola build
+          fi
 
       - name: Set production branch via Cloudflare API
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -184,6 +184,35 @@ jobs:
             --project-name=reinhardt-web
             --branch=${{ github.head_ref || github.ref_name }}
 
+      - name: Update rc.reinhardt-web.dev CNAME
+        if: github.event_name == 'push' && startsWith(github.ref_name, 'develop/')
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          BRANCH_SLUG=$(echo "$REF_NAME" | tr '/' '-' | tr '.' '-')
+          CNAME_TARGET="${BRANCH_SLUG}.reinhardt-web.pages.dev"
+
+          echo "Updating rc.reinhardt-web.dev CNAME → ${CNAME_TARGET} ..."
+
+          RECORD_ID=$(curl -sf \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records?name=rc.reinhardt-web.dev&type=CNAME" \
+            | jq -r '.result[0].id // empty')
+
+          if [ -n "$RECORD_ID" ]; then
+            curl -sf -X PATCH \
+              "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records/${RECORD_ID}" \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "{\"content\":\"${CNAME_TARGET}\",\"proxied\":true}" \
+              | jq -r '"  CNAME updated: \(.result.name) → \(.result.content)"'
+          else
+            echo "Warning: CNAME record for rc.reinhardt-web.dev not found."
+            echo "Create it manually in Cloudflare Dashboard first."
+          fi
+
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v3

--- a/scripts/init-develop-branch.sh
+++ b/scripts/init-develop-branch.sh
@@ -112,3 +112,32 @@ echo "Next steps:"
 echo "  1. Review the diff:    git diff"
 echo "  2. Commit:             git commit -am 'chore(release): initialize $EXPECTED_BRANCH at $NEW'"
 echo "  3. Push:               git push -u origin $EXPECTED_BRANCH"
+
+# --- Update rc.reinhardt-web.dev CNAME to point to new develop branch ---
+if [ -n "${CF_API_TOKEN:-}" ] && [ -n "${CF_ZONE_ID:-}" ]; then
+  BRANCH_SLUG=$(echo "develop/${TARGET}" | tr '/' '-' | tr '.' '-')
+  CNAME_TARGET="${BRANCH_SLUG}.reinhardt-web.pages.dev"
+
+  echo "Updating rc.reinhardt-web.dev CNAME → ${CNAME_TARGET} ..."
+
+  RECORD_ID=$(curl -sf \
+    -H "Authorization: Bearer ${CF_API_TOKEN}" \
+    "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records?name=rc.reinhardt-web.dev&type=CNAME" \
+    | jq -r '.result[0].id // empty')
+
+  if [ -n "$RECORD_ID" ]; then
+    curl -sf -X PATCH \
+      "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records/${RECORD_ID}" \
+      -H "Authorization: Bearer ${CF_API_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "{\"content\":\"${CNAME_TARGET}\",\"proxied\":true}" \
+      | jq -r '"  CNAME updated: \(.result.name) → \(.result.content)"'
+  else
+    echo "  Warning: CNAME record for rc.reinhardt-web.dev not found."
+    echo "  Create it manually in Cloudflare Dashboard first."
+  fi
+else
+  echo
+  echo "Skipping rc.reinhardt-web.dev CNAME update (CF_API_TOKEN or CF_ZONE_ID not set)."
+  echo "To enable, export CF_API_TOKEN and CF_ZONE_ID before running this script."
+fi

--- a/scripts/init-develop-branch.sh
+++ b/scripts/init-develop-branch.sh
@@ -112,32 +112,6 @@ echo "Next steps:"
 echo "  1. Review the diff:    git diff"
 echo "  2. Commit:             git commit -am 'chore(release): initialize $EXPECTED_BRANCH at $NEW'"
 echo "  3. Push:               git push -u origin $EXPECTED_BRANCH"
-
-# --- Update rc.reinhardt-web.dev CNAME to point to new develop branch ---
-if [ -n "${CF_API_TOKEN:-}" ] && [ -n "${CF_ZONE_ID:-}" ]; then
-  BRANCH_SLUG=$(echo "develop/${TARGET}" | tr '/' '-' | tr '.' '-')
-  CNAME_TARGET="${BRANCH_SLUG}.reinhardt-web.pages.dev"
-
-  echo "Updating rc.reinhardt-web.dev CNAME → ${CNAME_TARGET} ..."
-
-  RECORD_ID=$(curl -sf \
-    -H "Authorization: Bearer ${CF_API_TOKEN}" \
-    "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records?name=rc.reinhardt-web.dev&type=CNAME" \
-    | jq -r '.result[0].id // empty')
-
-  if [ -n "$RECORD_ID" ]; then
-    curl -sf -X PATCH \
-      "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records/${RECORD_ID}" \
-      -H "Authorization: Bearer ${CF_API_TOKEN}" \
-      -H "Content-Type: application/json" \
-      -d "{\"content\":\"${CNAME_TARGET}\",\"proxied\":true}" \
-      | jq -r '"  CNAME updated: \(.result.name) → \(.result.content)"'
-  else
-    echo "  Warning: CNAME record for rc.reinhardt-web.dev not found."
-    echo "  Create it manually in Cloudflare Dashboard first."
-  fi
-else
-  echo
-  echo "Skipping rc.reinhardt-web.dev CNAME update (CF_API_TOKEN or CF_ZONE_ID not set)."
-  echo "To enable, export CF_API_TOKEN and CF_ZONE_ID before running this script."
-fi
+echo
+echo "After push, the deploy-website workflow will automatically update"
+echo "the rc.reinhardt-web.dev CNAME to point to this branch."

--- a/scripts/init-develop-branch.sh
+++ b/scripts/init-develop-branch.sh
@@ -107,11 +107,15 @@ if [ "$CHANGED" -eq 0 ]; then
 	exit 2
 fi
 echo "Done: $CHANGED Cargo.toml file(s) bumped to '$NEW'."
+
+# Update version-sync markers (website/config.toml, docs, README, etc.)
+# so the first push includes website/ changes and triggers deploy-website.yml.
+echo
+echo "Updating version-sync markers to '$NEW' ..."
+"$SCRIPT_DIR/update-version-refs.sh" "$NEW"
+
 echo
 echo "Next steps:"
 echo "  1. Review the diff:    git diff"
 echo "  2. Commit:             git commit -am 'chore(release): initialize $EXPECTED_BRANCH at $NEW'"
 echo "  3. Push:               git push -u origin $EXPECTED_BRANCH"
-echo
-echo "After push, the deploy-website workflow will automatically update"
-echo "the rc.reinhardt-web.dev CNAME to point to this branch."

--- a/website/config.toml
+++ b/website/config.toml
@@ -28,3 +28,10 @@ changelog   = "https://github.com/kent8192/reinhardt-web/blob/main/CHANGELOG.md"
 deepwiki    = "https://deepwiki.com/kent8192/reinhardt-web"
 # reinhardt-version-sync
 reinhardt_version = "0.1.0-rc.30"
+
+# Populated at build time by deploy-website.yml.
+# Local dev: no version selector is shown (empty versions list).
+[extra.version_switcher]
+current_label = "Local Dev"
+current_is_stable = true
+versions = []

--- a/website/config.toml
+++ b/website/config.toml
@@ -31,6 +31,7 @@ reinhardt_version = "0.1.0-rc.30"
 
 # Populated at build time by deploy-website.yml.
 # Local dev: no version selector is shown (empty versions list).
+# MUST remain the last section: deploy-website.yml deletes from here to EOF.
 [extra.version_switcher]
 current_label = "Local Dev"
 current_is_stable = true

--- a/website/sass/_variables.scss
+++ b/website/sass/_variables.scss
@@ -20,6 +20,10 @@
 	--color-link-visited: #551a8b;
 	--color-accent-gradient: linear-gradient(135deg, #ce422b 0%, #b45309 100%);
 	--color-sidebar-active-border: #ce422b;
+	--color-warning-bg: #fff3cd;
+	--color-warning-text: #664d03;
+	--color-warning-border: #ffecb5;
+	--color-warning-link: #533f03;
 
 	--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, sans-serif;
 	--font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
@@ -61,4 +65,8 @@
 	--color-link-visited: #c8a0e0;
 	--color-accent-gradient: linear-gradient(135deg, #e06040 0%, #c4820a 100%);
 	--color-sidebar-active-border: #e06040;
+	--color-warning-bg: #332701;
+	--color-warning-text: #ffda6a;
+	--color-warning-border: #664d03;
+	--color-warning-link: #ffda6a;
 }

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -669,6 +669,95 @@ table {
 	a { color: var(--color-text-muted); }
 }
 
+// Dev version banner (shown on rc.reinhardt-web.dev)
+.dev-banner {
+	background: var(--color-warning-bg);
+	color: var(--color-warning-text);
+	border-bottom: 1px solid var(--color-warning-border);
+	text-align: center;
+	padding: 0.5rem var(--spacing-md);
+	font-size: 0.85rem;
+	font-weight: 500;
+
+	a {
+		color: var(--color-warning-link);
+		font-weight: 600;
+		text-decoration: underline;
+		text-underline-offset: 2px;
+
+		&:hover {
+			text-decoration-thickness: 2px;
+		}
+	}
+}
+
+// Version selector dropdown
+.version-selector {
+	position: relative;
+	margin-left: auto;
+}
+
+.version-btn {
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius);
+	padding: 0.25rem 0.6rem;
+	cursor: pointer;
+	color: var(--color-text-muted);
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	font-weight: 500;
+	white-space: nowrap;
+	transition: color 0.15s, background 0.15s, border-color 0.15s;
+
+	&:hover {
+		color: var(--color-text);
+		background: var(--color-surface-hover);
+		border-color: var(--color-text-muted);
+	}
+}
+
+.version-menu {
+	display: none;
+	position: absolute;
+	top: calc(100% + 4px);
+	right: 0;
+	list-style: none;
+	margin: 0;
+	padding: 0.25rem 0;
+	background: var(--color-bg);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius);
+	box-shadow: var(--shadow-md);
+	z-index: 200;
+	min-width: 120px;
+
+	&.version-menu-open {
+		display: block;
+	}
+}
+
+.version-item {
+	display: block;
+	padding: 0.35rem 0.75rem;
+	font-size: 0.82rem;
+	text-decoration: none;
+	color: var(--color-text-muted);
+	white-space: nowrap;
+	transition: background 0.1s, color 0.1s;
+
+	&:hover {
+		background: var(--color-surface);
+		color: var(--color-text);
+		text-decoration: none;
+	}
+
+	&.version-current {
+		color: var(--color-primary);
+		font-weight: 600;
+	}
+}
+
 // Responsive
 @media (max-width: 600px) {
 	.hamburger {

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -101,6 +101,26 @@
 					</a>
 				</li>
 			</ul>
+			{% if config.extra.version_switcher.versions | length > 0 %}
+			<div class="version-selector">
+				<button class="version-btn" type="button"
+								aria-expanded="false" aria-controls="version-menu"
+								aria-label="Switch documentation version">
+					{{ config.extra.version_switcher.current_label }} ▾
+				</button>
+				<ul class="version-menu" id="version-menu" role="list">
+					{% for v in config.extra.version_switcher.versions %}
+					<li>
+						<a class="version-item{% if current_url is starting_with(v.url) %} version-current{% endif %}"
+							 href="{{ v.url }}"
+							 {% if current_url is starting_with(v.url) %}aria-current="true"{% endif %}>
+							{{ v.label }}
+						</a>
+					</li>
+					{% endfor %}
+				</ul>
+			</div>
+			{% endif %}
 			<button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle dark mode">
 				<span aria-hidden="true">☾</span>
 			</button>
@@ -335,6 +355,31 @@
 				if (!btn.contains(e.target) && !nav.contains(e.target)) {
 					btn.setAttribute('aria-expanded', 'false');
 					nav.classList.remove('nav-open');
+				}
+			});
+		})();
+	</script>
+	<script>
+		(function() {
+			var btn = document.querySelector('.version-btn');
+			var menu = document.getElementById('version-menu');
+			if (!btn || !menu) return;
+			btn.addEventListener('click', function() {
+				var expanded = btn.getAttribute('aria-expanded') === 'true';
+				btn.setAttribute('aria-expanded', String(!expanded));
+				menu.classList.toggle('version-menu-open');
+			});
+			document.addEventListener('click', function(e) {
+				if (!btn.contains(e.target) && !menu.contains(e.target)) {
+					btn.setAttribute('aria-expanded', 'false');
+					menu.classList.remove('version-menu-open');
+				}
+			});
+			document.addEventListener('keydown', function(e) {
+				if (e.key === 'Escape' && menu.classList.contains('version-menu-open')) {
+					btn.setAttribute('aria-expanded', 'false');
+					menu.classList.remove('version-menu-open');
+					btn.focus();
 				}
 			});
 		})();

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -6,6 +6,9 @@
 	<title>{% block title %}{{ config.title }}{% endblock %} — Reinhardt&#8482;</title>
 	<meta name="description" content="{% block description %}{{ config.description }}{% endblock %}">
 	<meta name="theme-color" content="#ce422b" id="meta-theme-color">
+	{% if not config.extra.version_switcher.current_is_stable %}
+	<meta name="robots" content="noindex, nofollow">
+	{% endif %}
 	<link rel="canonical" href="{{ current_url | safe }}">
 
 	{# OGP #}
@@ -103,6 +106,13 @@
 			</button>
 		</nav>
 	</header>
+
+	{% if not config.extra.version_switcher.current_is_stable %}
+	<div class="dev-banner" role="alert">
+		⚠ This is documentation for an unreleased version.
+		<a href="https://reinhardt-web.dev">View stable docs →</a>
+	</div>
+	{% endif %}
 
 	<main id="main-content">
 		{% block content %}{% endblock %}


### PR DESCRIPTION
## Summary

Enable version-switching between `reinhardt-web.dev` (stable/main) and `rc.reinhardt-web.dev` (develop) by deploying branch-specific documentation with a header version selector.

- Add version selector dropdown to the website header navigation
- Display a dev-banner warning on the RC site with link to stable docs
- Inject `noindex` meta tag on dev site to prevent SEO duplicate content
- Extend `deploy-website.yml` to trigger on `develop/**` branches with dynamic `base_url` and version switcher config injection
- Automate CNAME rotation for `rc.reinhardt-web.dev` as a post-deploy step
- Ensure `init-develop-branch.sh` calls `update-version-refs.sh` so the first push includes `website/` changes that trigger the deploy workflow

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The Reinhardt project has a `develop/0.2.0` branch with breaking changes and new APIs. Users need documentation for both the stable release and the upcoming development version, similar to how Django and React handle versioned docs.

Design spec: `docs/superpowers/specs/2026-05-27-versioned-website-deployment-design.md`

## How Was This Tested?

- Local Zola build in stable mode: no version selector, no dev banner, no noindex tag
- Simulated develop branch build (config append + `--base-url`): version selector rendered, dev banner displayed, noindex meta tag present, all links point to `rc.reinhardt-web.dev`
- YAML validation of workflow file
- Bash syntax validation of init script
- SCSS compilation verified via Zola build

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

Post-merge manual steps:
1. **Cloudflare Dashboard (one-time):** Create a proxied CNAME record `rc.reinhardt-web.dev` → `develop-0-2-0.reinhardt-web.pages.dev`
2. **Push a `website/` change on `develop/0.2.0`** to trigger the first RC deployment
3. **Verify** `rc.reinhardt-web.dev` shows the dev banner and version selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation version switcher dropdown and dev-version banner for unreleased docs
  * Prevented search engines from indexing pre-release documentation builds

* **Style**
  * New theme variables and styles for the version banner and selector UI

* **Chores**
  * Build pipeline now supports staging deployments for development branches to a separate URL
  * Automated setup updates site version references and includes build-populated version metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->