### PR TITLE
style(examples): format twitter common.rs with fmt-all DSL pass

### DIFF
--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -664,12 +664,18 @@ pub fn theme_toggle() -> Page {
 ///
 /// Displays an empty div (useful for conditional rendering).
 pub fn empty() -> Page {
-	page!(|| { div {} })()
+	page!(|| {
+		div {}
+	})()
 }
 
 /// Divider component
 pub fn divider() -> Page {
-	page!(|| { div { class: "divider" } })()
+	page!(|| {
+		div {
+			class: "divider"
+		}
+	})()
 }
 
 /// Badge component


### PR DESCRIPTION
## Summary

- Format `examples/examples-twitter/src/core/client/components/common.rs` with `fmt-all` DSL pass
- Expands inline `page!` macro bodies in `empty()` and `divider()` to multi-line form
- Unblocks Release PR #4930 which fails Format Check CI

## Motivation and Context

Release PR #4930 fails the `Format / Format Check` CI job because `fmt-all --check` reports `common.rs` as needing formatting. The previous fix (PR #4929) used the `fmt` command (per-file), which applies rustfmt after DSL formatting. However, `fmt-all` (used by CI) applies DSL formatting in Phase 1 and then `cargo fmt --all` in Phase 2 — but `cargo fmt --all` does not reach files outside workspace members (e.g., under `examples/`). This leaves the DSL-formatted-only output, which differs from the `fmt`-produced output.

Related: #4930

## Type of Change

- [x] Code quality improvements

## Breaking Change Assessment

No

## How Was This Tested?

- `reinhardt-admin fmt-all --check` from the project root passes after this change
- `git diff` confirms only the expected multi-line expansion in two functions

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] My changes generate no new warnings

## Labels to Apply

- [x] `code-quality` - Code quality improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code restructuring with no changes to user-facing functionality or appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->