### PR TITLE
fix(admin-cli): reject commented-out `#![rustfmt::skip]` in `rustfmt_skip_attr_matches`

### DIFF
--- a/crates/reinhardt-admin-cli/src/format_engine.rs
+++ b/crates/reinhardt-admin-cli/src/format_engine.rs
@@ -570,10 +570,12 @@ fn marker_matches(line: &str, compact_marker: &str) -> bool {
 }
 
 fn rustfmt_skip_attr_matches(line: &str) -> bool {
-	line.chars()
-		.filter(|ch| !ch.is_whitespace())
-		.collect::<String>()
-		.contains("#![rustfmt::skip]")
+	let trimmed = line.trim_start();
+	if !trimmed.starts_with("#![") {
+		return false;
+	}
+	let compact: String = trimmed.chars().filter(|ch| !ch.is_whitespace()).collect();
+	compact.starts_with("#![rustfmt::skip]")
 }
 
 #[cfg(test)]
@@ -802,6 +804,70 @@ mod tests {
 	}
 
 	// -----------------------------------------------------------------------
+	// rustfmt_skip_attr_matches tests
+	// -----------------------------------------------------------------------
+
+	#[rstest]
+	fn rustfmt_skip_attr_matches_true_for_actual_attribute() {
+		// Arrange
+		let line = "#![rustfmt::skip]";
+
+		// Act
+		let result = rustfmt_skip_attr_matches(line);
+
+		// Assert
+		assert!(result);
+	}
+
+	#[rstest]
+	fn rustfmt_skip_attr_matches_true_for_indented_attribute() {
+		// Arrange
+		let line = "  #![rustfmt::skip]";
+
+		// Act
+		let result = rustfmt_skip_attr_matches(line);
+
+		// Assert
+		assert!(result);
+	}
+
+	#[rstest]
+	fn rustfmt_skip_attr_matches_false_for_line_comment() {
+		// Arrange
+		let line = "// #![rustfmt::skip]";
+
+		// Act
+		let result = rustfmt_skip_attr_matches(line);
+
+		// Assert
+		assert!(!result);
+	}
+
+	#[rstest]
+	fn rustfmt_skip_attr_matches_false_for_block_comment() {
+		// Arrange
+		let line = "/* #![rustfmt::skip] */";
+
+		// Act
+		let result = rustfmt_skip_attr_matches(line);
+
+		// Assert
+		assert!(!result);
+	}
+
+	#[rstest]
+	fn rustfmt_skip_attr_matches_false_for_empty_line() {
+		// Arrange
+		let line = "";
+
+		// Act
+		let result = rustfmt_skip_attr_matches(line);
+
+		// Assert
+		assert!(!result);
+	}
+
+	// -----------------------------------------------------------------------
 	// has_ignore_all_marker tests
 	// -----------------------------------------------------------------------
 
@@ -881,6 +947,19 @@ fn main() {}";
 
 		// Assert
 		assert!(result);
+	}
+
+	#[rstest]
+	fn has_ignore_all_marker_rejects_commented_out_rustfmt_skip() {
+		// Arrange
+		let formatter = FormatEngine::new();
+		let content = "// #![rustfmt::skip]\nfn main() {\n\tpage!(|| { div { \"x\" } });\n}";
+
+		// Act
+		let result = formatter.has_ignore_all_marker(content);
+
+		// Assert
+		assert!(!result);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR addresses:

- `rustfmt_skip_attr_matches()` incorrectly matching `#![rustfmt::skip]` inside comment text (e.g., `// #![rustfmt::skip]`), causing false file-wide format skipping

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

`rustfmt_skip_attr_matches()` (added in PR #4926) strips all whitespace and uses `.contains("#![rustfmt::skip]")`. A commented-out line like `// #![rustfmt::skip]` becomes `//#![rustfmt::skip]` after stripping, which contains the target string — incorrectly triggering file-wide ignore.

The fix adds a `starts_with("#![")` guard on the trimmed line to reject comment lines, and uses `starts_with` instead of `contains` for more precise matching.

Fixes #4931

Related to: #4926

## How Was This Tested?

- `cargo nextest run --package reinhardt-admin-cli --all-features` — 105/105 passed
- `cargo make fmt-check` — passed
- `cargo make clippy-check` — passed

New tests added:
- 5 unit tests for `rustfmt_skip_attr_matches` (actual attr, indented attr, line comment, block comment, empty line)
- 1 integration test for `has_ignore_all_marker` (commented-out `#![rustfmt::skip]` must not trigger file-wide skip)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of code formatting directives to correctly handle indented and commented patterns, ensuring more reliable formatting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->