### PR TITLE
fix(examples): build against local 0.2.0-rc.2 framework in CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ database = [
   "reinhardt-shortcuts?/database",
 ]
 api = [
+  "rest",
   "reinhardt-rest",
   "reinhardt-rest/serializers",
   "reinhardt-views/viewsets",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 [workspace.dependencies]
 # Reinhardt framework (crates.io published versions)
 # reinhardt-version-sync
-reinhardt = { version = "0.1.0", package = "reinhardt-web" }
+reinhardt = { version = "0.2.0-rc.2", package = "reinhardt-web" }
 
 # Testing
 testcontainers = { version = "0.27.2", features = ["blocking"] }

--- a/examples/examples-tutorial-rest/src/apps/snippets/views.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/views.rs
@@ -281,7 +281,7 @@ pub async fn delete(Path(snippet_id): Path<i64>) -> ViewResult<Response> {
 /// Unlike the function-based views above (which fall back to in-memory
 /// `get_sample_snippets()` data for demonstration), the ViewSet path will
 /// observe an empty list until rows are inserted into the `snippets` table.
-#[reinhardt::viewset]
+#[reinhardt::viewset(basename = "snippet")]
 pub fn viewset() -> reinhardt::ModelViewSet<Snippet, SnippetSerializer> {
 	use reinhardt::ModelViewSet;
 	use reinhardt::views::viewsets::{FilterConfig, OrderingConfig, PaginationConfig};

--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -626,17 +626,11 @@ pub fn theme_toggle() -> Page {
 ///
 /// Displays an empty div (useful for conditional rendering).
 pub fn empty() -> Page {
-	page!(|| {
-		div {}
-	})()
+	page!(|| { div {} })()
 }
 /// Divider component
 pub fn divider() -> Page {
-	page!(|| {
-		div {
-			class: "divider",
-		}
-	})()
+	page!(|| { div { class: "divider" } })()
 }
 /// Badge component
 pub fn badge(text: &str, primary: bool) -> Page {

--- a/examples/examples-twitter/src/core/client/components/layout.rs
+++ b/examples/examples-twitter/src/core/client/components/layout.rs
@@ -95,7 +95,9 @@ pub fn header(site_name: &str, current_user: Option<&UserInfo>, nav_items: &[Nav
 		})
 		.collect();
 	let nav_links_view = page!(|nav_links: Vec<Page>| {
-		for link in nav_links { { link } }
+		for link in nav_links {
+			{ link }
+		}
 	})(nav_links);
 	let brand_link = Link::new("/".to_string(), site_name.to_string())
 		.class("text-xl font-bold text-content-primary hover:text-brand transition-colors")
@@ -205,7 +207,9 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|topics_list: Vec<Page>| {
-			for topic in topics_list { { topic } }
+			for topic in topics_list {
+				{ topic }
+			}
 		})(topics_list)
 	};
 	let users_list: Vec<Page> = suggested_users
@@ -270,7 +274,9 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|users_list: Vec<Page>| {
-			for user in users_list { { user } }
+			for user in users_list {
+				{ user }
+			}
 		})(users_list)
 	};
 	page!(|topics_view: Page, users_view: Page| {


### PR DESCRIPTION
## Summary

This PR addresses:

- Restores the examples reinhardt version pin to `0.2.0-rc.2` so the
  `[patch.crates-io]` override used by Examples Tests CI actually applies,
  making the examples build against the post-#4784 local framework instead
  of the stale published crates.io 0.1.2 crates.
- Adds the `rest` facade feature to the `api` preset so `reinhardt::rest`
  resolves for `#[model]`-generated code.
- Adds an explicit `basename` to the snippets viewset and reformats the
  twitter `page!` macros to satisfy the clippy / format-check gates.

Complements #4936 (which carries the `api`→`rest`, viewset-basename, and
twitter page! formatting fixes but, critically, did **not** bump the
examples version pin — so #4936 on its own cannot make CI green because
its examples still resolve the old published framework).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

ALL three example projects (examples-tutorial-basis, examples-tutorial-rest,
examples-twitter) failed Examples Tests CI with:

```
error[E0432]: unresolved import `crate`
error[E0433]: failed to resolve: could not find `url_resolvers` in `urls`
error[E0433]: failed to resolve: could not find `ws_urls` in `urls`
error[E0433]: failed to resolve: could not find `client_url_resolvers` in `urls`
note: this error originates in the attribute macro `routes`
```

Root cause: the examples workspace pinned `reinhardt = "0.1.0"`. A prior
main→develop forward-merge reset this line (managed by the
`# reinhardt-version-sync` marker) from the develop-appropriate
`0.2.0-rc.2` back to the published-stable `0.1.0`. With a `^0.1.0`
requirement, Cargo cannot satisfy it with the local `0.2.0-rc.2`
workspace, so the `[patch.crates-io] reinhardt-web = { path = ".." }`
override in `.cargo/config.local.toml` is silently inert and the
examples resolve published crates.io 0.1.2 crates instead. The 0.1.2
`#[routes]` macro (pre-#4784) emits per-app `url_resolvers` / `ws_urls` /
`client_url_resolvers` module references that the already-migrated
post-#4784 example apps no longer provide — hence the E0433 errors.

The post-#4784 `#[routes]` macro (in `crates/reinhardt-core/macros/src/routes_registration.rs`)
no longer emits any of those references; it only performs inventory
registration. The examples were already migrated to the new layout
(`server_urls` / `client_router` / `#[server_fn]`); they just need to
build against the local framework. The other errors (`reinhardt::rest`,
viewset basename, twitter `page!` formatting) only surface once the
local framework is actually in use.

## How Was This Tested?

With `examples/.cargo/config.local.toml` copied to `config.toml` (the CI
setup) and `reinhardt-admin` reinstalled from the worktree
(`cargo install --path crates/reinhardt-admin-cli`, version 0.2.0-rc.2),
all three examples pass both CI gates:

- `reinhardt-admin fmt . --check` → exit 0 (all three)
- `cargo clippy --all-features -- -D warnings` → exit 0 (all three)
- `cargo check --all-features` → 0 errors (all three)
- `cargo check -p reinhardt-web --features api --no-default-features` →
  0 errors (framework still builds with the `api` preset change)

## Checklist

- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] New and existing checks pass locally with my changes
- [x] I have formatted the code with `reinhardt-admin fmt`
- [x] I have checked the code with `cargo clippy --all-features -- -D warnings`

## Related Issues

Related to: #4784 (url-routing-simplification)
Complements: #4936

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated feature configuration and workspace dependencies to version 0.2.0-rc.2.

* **Style**
  * Simplified code formatting in example components for improved readability.

* **Refactor**
  * Restructured iterator patterns in layout components for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->