### PR TITLE
fix(docs): resolve remaining cross-crate intra-doc link errors

### DIFF
--- a/crates/reinhardt-apps/src/lib.rs
+++ b/crates/reinhardt-apps/src/lib.rs
@@ -73,11 +73,11 @@
 //!
 //! This crate re-exports commonly used types from other Reinhardt crates:
 //!
-//! - From `reinhardt-http`: [`Request`], [`Response`], [`StreamBody`]
-//! - From `reinhardt-conf`: [`Settings`], [`DatabaseConfig`], [`MiddlewareConfig`]
-//! - From `reinhardt-core::exception`: [`Error`], [`Result`]
-//! - From `reinhardt-server`: [`HttpServer`], [`serve`]
-//! - From `reinhardt-http`: [`Handler`], [`Middleware`], [`MiddlewareChain`]
+//! - From `reinhardt-http`: `Request`, `Response`, `StreamBody`
+//! - From `reinhardt-conf`: `Settings`, `DatabaseConfig`, `MiddlewareConfig`
+//! - From `reinhardt-core::exception`: `Error`, `Result`
+//! - From `reinhardt-server`: `HttpServer`, `serve`
+//! - From `reinhardt-http`: `Handler`, `Middleware`, `MiddlewareChain`
 
 #![warn(missing_docs)]
 

--- a/crates/reinhardt-db/src/orm/manager.rs
+++ b/crates/reinhardt-db/src/orm/manager.rs
@@ -203,7 +203,7 @@ impl<M: Model> Manager<M> {
 	/// The intended call style is the fluent builder produced by the
 	/// `#[model]`-generated field accessors (`FieldRef::eq()` / `.gt()` / ...)
 	/// or the parallel `Field::eq()` builder, which returns a `Lookup<M>`
-	/// (convertible into [`Filter`] via its `Into` impl).
+	/// (convertible into `Filter` via its `Into` impl).
 	///
 	/// # Examples
 	///


### PR DESCRIPTION
## Summary

Follow-up to #4934. The merged #4934 resolved most Docs.rs Build Check
failures, but a full `cargo +nightly doc --workspace --all-features --no-deps`
(mirroring the docs.rs CI environment with `-D warnings`) surfaced two
remaining cross-crate intra-doc link errors that were not visible until the
earlier per-crate failures were cleared:

- `crates/reinhardt-apps/src/lib.rs` — the re-export inventory listed
  `Settings`, `DatabaseConfig`, `MiddlewareConfig` (and siblings) as
  intra-doc links, but `Settings` does not resolve in the `reinhardt-apps`
  scope, breaking the build with `-D warnings`.
- `crates/reinhardt-db/src/orm/manager.rs` — `Filter` referenced as an
  intra-doc link does not resolve in the `reinhardt-db` doc scope.

Both are converted to plain backticks (descriptive references), consistent
with RD-9/RD-10.

## Type of Change

- [x] Bug fix (documentation / CI)

## Breaking Change Assessment

- [x] No

## Motivation and Context

Unblocks the Docs.rs Build Check on the develop/0.2.0 release PR (#4933).
rustdoc stops at the first failing crate, so these errors were masked until
#4934 cleared the earlier crates.

## How Was This Tested

- `cargo +nightly doc --workspace --all-features --no-deps` with
  `RUSTDOCFLAGS="--cfg docsrs -D warnings"` (mirrors docs.rs CI).

## Checklist

- [x] Code comments in English
- [x] Docs updated alongside code
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation formatting for improved readability across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4953?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->