### PR TITLE
fix(core): only dispose Memo on last-clone drop

### DIFF
--- a/crates/reinhardt-core/src/reactive/memo.rs
+++ b/crates/reinhardt-core/src/reactive/memo.rs
@@ -526,7 +526,19 @@ impl<T: Clone + 'static> Memo<T> {
 
 impl<T: Clone + 'static> Drop for Memo<T> {
 	fn drop(&mut self) {
-		self.dispose();
+		// Only dispose when this is the last live clone. `Memo<T>` is `Clone`
+		// and every clone shares the same `disposed` Rc (and the same `id` /
+		// global storage entry). Disposing on every clone drop would set the
+		// shared `disposed` flag and clear `MEMO_FUNCTIONS` / `MEMO_VALUES`
+		// while sibling clones are still in use, causing a spurious
+		// "Attempted to access a disposed Memo" panic on the next `get()`.
+		//
+		// `strong_count == 1` means this is the only remaining reference, so
+		// cleanup is safe. Mirrors the last-clone-cleanup guard in
+		// `Signal<T>`'s `Drop` impl.
+		if Rc::strong_count(&self.disposed) == 1 {
+			self.dispose();
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a real bug surfaced by the failing test
`memo_feeding_effect_propagates_listed_dep_changes` (was panicking at
`crates/reinhardt-core/src/reactive/memo.rs`).

`Memo<T>` is `Clone`, and every clone shares the same `disposed` `Rc`, `id`,
and global storage entry. The previous `Drop` impl called `dispose()` on
**every** clone drop, which set the shared `disposed` flag and cleared
`MEMO_FUNCTIONS` / `MEMO_VALUES` while sibling clones were still live —
causing a spurious "Attempted to access a disposed Memo" panic on the next
`get()`.

The fix guards cleanup behind `Rc::strong_count(&self.disposed) == 1`,
mirroring the existing last-clone-cleanup guard in `Signal<T>`'s `Drop` impl
(`crates/reinhardt-core/src/reactive/signal.rs:278-281`).

## Type of Change

- [x] Bug fix

## Breaking Change Assessment

- [x] No

## Motivation and Context

Pre-existing failure on `develop/0.2.0` (full CI never ran on the branch).
Unblocks the Intra-Crate Integration Tests for the release PR (#4933).

## How Was This Tested

- Targeted test: `cargo test -p reinhardt-core memo_feeding_effect_propagates_listed_dep_changes`
- Fix mirrors the proven `Signal<T>` Drop pattern.

## Checklist

- [x] Code comments in English
- [x] Follows project conventions (rstest, existing reactive patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)