### PR TITLE
test(commands): drop stale InstalledApp assertions in e2e_pages

### DIFF
--- a/crates/reinhardt-commands/tests/e2e_pages.rs
+++ b/crates/reinhardt-commands/tests/e2e_pages.rs
@@ -553,21 +553,20 @@ async fn workspace_app_pages_uses_unified_template() {
 		"workspace lib.rs doc comment must say 'crate':\n{lib_rs}"
 	);
 
-	// 5. InstalledApp import uses project_crate_name, not crate::
-	let expected_workspace_import = format!("use {}::config::apps::InstalledApp;", project_name);
+	// 5. No `InstalledApp` import is generated. Since the `#[url_patterns]`
+	//    attribute macro was removed (feat!: remove #[url_patterns]), the
+	//    generated routers no longer reference `InstalledApp`, so neither the
+	//    `crate::` form nor the project-crate form is emitted (an unused import
+	//    would otherwise fail to compile under `-D warnings`).
+	let crate_import = "use crate::config::apps::InstalledApp;";
+	let project_import = format!("use {}::config::apps::InstalledApp;", project_name);
 	let server_urls =
 		fs::read_to_string(src.join("urls").join("server_urls.rs")).expect("read server_urls.rs");
 	assert!(
 		!server_urls
 			.lines()
-			.any(|l| l.trim() == "use crate::config::apps::InstalledApp;"),
-		"workspace server_urls.rs must NOT use crate:: import:\n{server_urls}"
-	);
-	assert!(
-		server_urls
-			.lines()
-			.any(|l| l.trim() == expected_workspace_import),
-		"workspace server_urls.rs must import InstalledApp from project crate:\n{server_urls}"
+			.any(|l| l.trim() == crate_import || l.trim() == project_import),
+		"workspace server_urls.rs must NOT import InstalledApp:\n{server_urls}"
 	);
 
 	let client_router = fs::read_to_string(src.join("urls").join("client_router.rs"))
@@ -575,14 +574,8 @@ async fn workspace_app_pages_uses_unified_template() {
 	assert!(
 		!client_router
 			.lines()
-			.any(|l| l.trim() == "use crate::config::apps::InstalledApp;"),
-		"workspace client_router.rs must NOT use crate:: import:\n{client_router}"
-	);
-	assert!(
-		client_router
-			.lines()
-			.any(|l| l.trim() == expected_workspace_import),
-		"workspace client_router.rs must import InstalledApp from project crate:\n{client_router}"
+			.any(|l| l.trim() == crate_import || l.trim() == project_import),
+		"workspace client_router.rs must NOT import InstalledApp:\n{client_router}"
 	);
 
 	// 6. client/pages.rs imports with_nav from project crate, not crate::
@@ -659,24 +652,27 @@ async fn module_app_pages_does_not_generate_workspace_files() {
 		"module app must NOT have its own build.rs"
 	);
 
-	// InstalledApp import uses crate::, not project_crate_name::
-	let expected_module_import = "use crate::config::apps::InstalledApp;";
+	// No `InstalledApp` import is generated. The `#[url_patterns]` attribute
+	// macro that previously consumed `InstalledApp` was removed, so the module
+	// app routers no longer reference it (an unused import would otherwise fail
+	// to compile under `-D warnings`).
+	let unwanted_module_import = "use crate::config::apps::InstalledApp;";
 	let server_urls = fs::read_to_string(apps.join("baz").join("urls").join("server_urls.rs"))
 		.expect("read server_urls.rs");
 	assert!(
-		server_urls
+		!server_urls
 			.lines()
-			.any(|l| l.trim() == expected_module_import),
-		"module server_urls.rs must use crate:: import:\n{server_urls}"
+			.any(|l| l.trim() == unwanted_module_import),
+		"module server_urls.rs must NOT import InstalledApp:\n{server_urls}"
 	);
 
 	let client_router = fs::read_to_string(apps.join("baz").join("urls").join("client_router.rs"))
 		.expect("read client_router.rs");
 	assert!(
-		client_router
+		!client_router
 			.lines()
-			.any(|l| l.trim() == expected_module_import),
-		"module client_router.rs must use crate:: import:\n{client_router}"
+			.any(|l| l.trim() == unwanted_module_import),
+		"module client_router.rs must NOT import InstalledApp:\n{client_router}"
 	);
 
 	// client/pages.rs with_nav import uses crate::, not project_crate_name::


### PR DESCRIPTION
## Summary

Fixes two failing Intra-Crate Integration Tests on `develop/0.2.0`:
- `workspace_app_pages_uses_unified_template` (e2e_pages.rs:566)
- `module_app_pages_does_not_generate_workspace_files` (e2e_pages.rs:666)

The `#[url_patterns]` attribute macro was removed (`feat!: remove
#[url_patterns]`), so the scaffolding-generated `server_urls.rs` /
`client_router.rs` no longer reference `InstalledApp` (an unused import
would fail to compile under `-D warnings`). The tests still asserted that an
`InstalledApp` import was generated. Updated the assertions to verify that
NO `InstalledApp` import is emitted (neither `crate::` nor project-crate
form).

## Type of Change

- [x] Bug fix (test assertion alignment)

## Breaking Change Assessment

- [x] No

## Motivation and Context

Pre-existing failure on `develop/0.2.0` (full CI never ran on the branch).
Unblocks Intra-Crate Integration Tests for release PR #4933.

## How Was This Tested

- `cargo test -p reinhardt-commands --test e2e_pages` (both tests)

## Checklist

- [x] Code comments in English
- [x] Follows project test conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end page test assertions to verify generated routers align with updated code generation behavior. Tests confirm that router source files no longer include references to specific framework components. Changes apply to both workspace and module app generators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->