### PR TITLE
test(di): use non-Depends inject form for manual Injectable AppContext

### DIFF
--- a/crates/reinhardt-di/tests/extractor_factory_tests.rs
+++ b/crates/reinhardt-di/tests/extractor_factory_tests.rs
@@ -12,7 +12,7 @@ use bytes::Bytes;
 use hyper::{HeaderMap, Method, Version, header};
 use reinhardt_di::params::{Json, ParamContext, Path, Query};
 use reinhardt_di::{
-	Depends, DiError, Injectable, InjectionContext, Request, SingletonScope, global_registry,
+	DiError, Injectable, InjectionContext, Request, SingletonScope, global_registry,
 	injectable_factory,
 };
 use reinhardt_http::PathParams;
@@ -239,8 +239,19 @@ async fn injectable_factory_can_consume_path_extractor() {
 	);
 }
 
-// Combined extractor + Depends — proves that the macro fallback path keeps
-// working alongside the new Injectable impls.
+// Combined extractor + Injectable dependency — proves that the macro's
+// `Injectable::inject` fallback path keeps working alongside the new
+// extractor `Injectable` impls.
+//
+// `AppContext` exposes its DI surface through a manual `impl Injectable`
+// only (it is never registered in the global registry). Per the
+// `#[injectable_factory]` contract (kent8192/reinhardt-web#4685), a
+// manually-Injectable, unregistered type MUST be requested via the
+// non-`Depends` `#[inject] T` form, which resolves through
+// `Depends::<T>::resolve` (registry-first + `T::inject` fallback). The
+// `Depends<T>` form is reserved for factory-produced types that resolve via
+// the registry only (`resolve_from_registry`, no `Injectable` bound) — see
+// `injectable_factory_inject_fallback_tests.rs`.
 
 #[derive(Clone, Debug, PartialEq)]
 struct AppContext {
@@ -263,7 +274,7 @@ struct AuthoredItemWithCtx {
 #[injectable_factory(scope = "request")]
 async fn authored_item_with_ctx(
 	#[inject] path: Path<i64>,
-	#[inject] app: Depends<AppContext>,
+	#[inject] app: AppContext,
 ) -> AuthoredItemWithCtx {
 	AuthoredItemWithCtx {
 		id: path.0,


### PR DESCRIPTION
## Summary

Fixes the failing test `injectable_factory_mixes_path_extractor_and_depends`
(extractor_factory_tests.rs:288) on `develop/0.2.0`.

Per the `#[injectable_factory]` contract (#4685), a manually-`Injectable`,
unregistered type (`AppContext`, never added to the global registry) MUST be
requested via the non-`Depends` `#[inject] T` form, which resolves through
`Depends::<T>::resolve` (registry-first + `T::inject` fallback). The
`Depends<T>` form is reserved for factory-produced types resolved via the
registry only. The test fixture used `#[inject] app: Depends<AppContext>`,
which no longer matches the contract; changed to `#[inject] app: AppContext`.

## Type of Change

- [x] Bug fix (test fixture alignment with DI contract)

## Breaking Change Assessment

- [x] No

## Motivation and Context

Pre-existing failure on `develop/0.2.0` (full CI never ran on the branch).
Unblocks Intra-Crate Integration Tests for release PR #4933.

## How Was This Tested

- `cargo test -p reinhardt-di --test extractor_factory_tests`

## Checklist

- [x] Code comments in English
- [x] Follows project test conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test documentation for dependency injection factory scenarios and injectable type resolution patterns.
  * Updated test fixtures to refine dependency resolution patterns for application context handling in factory-based dependency injection testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->