### PR TITLE
feat(di): add DependsResult and DependsOption sugar type aliases

### DIFF
--- a/crates/reinhardt-di/macros/src/injectable.rs
+++ b/crates/reinhardt-di/macros/src/injectable.rs
@@ -120,6 +120,29 @@ fn classify_injection_type(ty: &Type) -> Option<InjectionType> {
 			return Some(InjectionType::Depends(inner_ty.clone()));
 		}
 
+		// Check for DependsResult<T, E> (sugar for Depends<Result<T, E>>)
+		if ident == "DependsResult"
+			&& is_likely_reinhardt_di_path(segments)
+			&& let PathArguments::AngleBracketed(args) = &last_segment.arguments
+			&& args.args.len() == 2
+		{
+			let mut iter = args.args.iter();
+			let t = iter.next()?;
+			let e = iter.next()?;
+			let inner: Type = syn::parse_quote! { ::core::result::Result<#t, #e> };
+			return Some(InjectionType::Depends(inner));
+		}
+
+		// Check for DependsOption<T> (sugar for Depends<Option<T>>)
+		if ident == "DependsOption"
+			&& is_likely_reinhardt_di_path(segments)
+			&& let PathArguments::AngleBracketed(args) = &last_segment.arguments
+			&& let Some(GenericArgument::Type(inner_ty)) = args.args.first()
+		{
+			let inner: Type = syn::parse_quote! { ::core::option::Option<#inner_ty> };
+			return Some(InjectionType::Depends(inner));
+		}
+
 		// Check for Option<Injected<T>> or Option<Depends<T>>
 		if ident == "Option"
 			&& let PathArguments::AngleBracketed(args) = &last_segment.arguments
@@ -220,7 +243,7 @@ pub(crate) fn injectable_impl(args: TokenStream, input: DeriveInput) -> Result<T
 				let injection_type = classify_injection_type(ty).ok_or_else(|| {
 					syn::Error::new_spanned(
 						field,
-						"#[inject] field must have type Depends<T>, Option<Depends<T>>, Injected<T>, or OptionalInjected<T>",
+						"#[inject] field must have type Depends<T>, DependsResult<T, E>, DependsOption<T>, Option<Depends<T>>, Injected<T>, or OptionalInjected<T>",
 					)
 				})?;
 

--- a/crates/reinhardt-di/macros/src/utils.rs
+++ b/crates/reinhardt-di/macros/src/utils.rs
@@ -92,21 +92,44 @@ impl Parse for MacroArgs {
 	}
 }
 
-/// Extract the inner type `T` from `Depends<T>`.
+/// Extract the inner type from a Depends-family wrapper.
 ///
-/// Returns `Some(T)` if the type is `Depends<T>` (or a fully qualified path ending in `Depends`),
-/// `None` otherwise.
-pub(crate) fn extract_depends_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
-	if let syn::Type::Path(type_path) = ty {
-		let last_segment = type_path.path.segments.last()?;
-		if last_segment.ident == "Depends"
-			&& let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
-			&& args.args.len() == 1
-			&& let syn::GenericArgument::Type(inner) = args.args.first()?
-		{
-			return Some(inner);
-		}
+/// Recognises three shapes and returns the type that should be passed to
+/// `Depends::<...>::resolve_from_registry`:
+///
+/// - `Depends<T>` → `T`
+/// - `DependsResult<T, E>` → `Result<T, E>`
+/// - `DependsOption<T>` → `Option<T>`
+pub(crate) fn extract_depends_inner_type(ty: &syn::Type) -> Option<syn::Type> {
+	let syn::Type::Path(type_path) = ty else {
+		return None;
+	};
+	let last_segment = type_path.path.segments.last()?;
+	let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments else {
+		return None;
+	};
+
+	if last_segment.ident == "Depends"
+		&& args.args.len() == 1
+		&& let syn::GenericArgument::Type(inner) = args.args.first()?
+	{
+		return Some(inner.clone());
 	}
+
+	if last_segment.ident == "DependsResult" && args.args.len() == 2 {
+		let mut iter = args.args.iter();
+		let t = iter.next()?;
+		let e = iter.next()?;
+		return Some(syn::parse_quote! { ::core::result::Result<#t, #e> });
+	}
+
+	if last_segment.ident == "DependsOption"
+		&& args.args.len() == 1
+		&& let Some(t) = args.args.first()
+	{
+		return Some(syn::parse_quote! { ::core::option::Option<#t> });
+	}
+
 	None
 }
 

--- a/crates/reinhardt-di/src/depends.rs
+++ b/crates/reinhardt-di/src/depends.rs
@@ -386,6 +386,36 @@ impl<T: Clone + Send + Sync + 'static> Depends<T> {
 	}
 }
 
+/// Sugar for `Depends<Result<T, E>>` — commonly used with
+/// `#[injectable_factory]` factories that return `Result<T, E>` to maintain
+/// a distinct DI registry key from `T`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // Before: verbose inner type
+/// #[inject] session_user: Depends<Result<User, SessionError>>
+///
+/// // After: sugar alias
+/// #[inject] session_user: DependsResult<User, SessionError>
+/// ```
+pub type DependsResult<T, E> = Depends<Result<T, E>>;
+
+/// Sugar for `Depends<Option<T>>` — used with `#[injectable_factory]`
+/// factories that return `Option<T>` to represent an optionally-available
+/// dependency with a distinct DI registry key from `T`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // Before: verbose inner type
+/// #[inject] cache: Depends<Option<CacheBackend>>
+///
+/// // After: sugar alias
+/// #[inject] cache: DependsOption<CacheBackend>
+/// ```
+pub type DependsOption<T> = Depends<Option<T>>;
+
 /// Builder for Depends to support FastAPI-style API.
 pub struct DependsBuilder<T: Send + Sync + 'static> {
 	use_cache: bool,
@@ -929,5 +959,60 @@ mod tests {
 				prefix: "/api".to_string()
 			}
 		);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_depends_result_type_alias_ok_variant() {
+		// Arrange
+		let ok_value: Result<String, String> = Ok("success".to_string());
+
+		// Act
+		let depends: DependsResult<String, String> = Depends::from_value(ok_value);
+
+		// Assert
+		assert!(depends.is_ok());
+		assert_eq!(depends.as_ref().as_ref().unwrap(), "success");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_depends_result_type_alias_err_variant() {
+		// Arrange
+		let err_value: Result<String, String> = Err("failure".to_string());
+
+		// Act
+		let depends: DependsResult<String, String> = Depends::from_value(err_value);
+
+		// Assert
+		assert!(depends.is_err());
+		assert_eq!(depends.as_ref().as_ref().unwrap_err(), "failure");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_depends_option_type_alias_some_variant() {
+		// Arrange
+		let some_value: Option<String> = Some("present".to_string());
+
+		// Act
+		let depends: DependsOption<String> = Depends::from_value(some_value);
+
+		// Assert
+		assert!(depends.is_some());
+		assert_eq!(depends.as_ref().as_ref().unwrap(), "present");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_depends_option_type_alias_none_variant() {
+		// Arrange
+		let none_value: Option<String> = None;
+
+		// Act
+		let depends: DependsOption<String> = Depends::from_value(none_value);
+
+		// Assert
+		assert!(depends.is_none());
 	}
 }

--- a/crates/reinhardt-di/src/lib.rs
+++ b/crates/reinhardt-di/src/lib.rs
@@ -302,7 +302,7 @@ pub use override_registry::OverrideRegistry;
 
 #[cfg(feature = "params")]
 pub use context::{ParamContext, Request};
-pub use depends::{Depends, DependsBuilder};
+pub use depends::{Depends, DependsBuilder, DependsOption, DependsResult};
 pub use injectable::Injectable;
 #[allow(deprecated)]
 pub use injected::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1196,8 +1196,8 @@ pub use reinhardt_di::injected::{Injected, OptionalInjected};
 pub use reinhardt_di::scope::{RequestScope, Scope, SingletonScope};
 #[cfg(all(feature = "di", native))]
 pub use reinhardt_di::{
-	Depends, DependsBuilder, DiError, DiResult, Injectable, InjectionContext,
-	InjectionContextBuilder, InjectionMetadata, RequestContext,
+	Depends, DependsBuilder, DependsOption, DependsResult, DiError, DiResult, Injectable,
+	InjectionContext, InjectionContextBuilder, InjectionMetadata, RequestContext,
 };
 
 // Re-export DI params - available in minimal, standard, and di features


### PR DESCRIPTION
## Summary

This PR addresses:

- Add `DependsResult<T, E>` = `Depends<Result<T, E>>` and `DependsOption<T>` = `Depends<Option<T>>` sugar type aliases to `reinhardt-di`
- Extend the `#[injectable_factory]` and `#[injectable]` macro type matchers so the aliases work end-to-end with `#[inject]` parameters and fields
- Re-export both aliases from the `reinhardt` facade alongside `Depends`

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

When using `#[injectable_factory]` with a `Result<T, E>` return type, handlers must spell out `Depends<Result<T, E>>` in their parameter types, which is verbose. The DI registry uses `TypeId` as the sole registry key, so `Result`/`Option` wrapping produces a distinct key from `T` while preserving `T`'s trait implementations inside `Ok(t)` / `Some(t)`.

The type aliases alone are not sufficient: the DI macros identify injectable parameters by matching the literal type-name token (`Depends`). Without extending the matchers, `DependsResult<...>` / `DependsOption<...>` would fall through to the `T: Injectable` resolution path and fail. This PR adds matcher support so the sugar resolves via `Depends::<Result<T, E>>::resolve_from_registry` (and the `#[injectable]` field path) correctly.

Fixes #4937

Related to: #4938

## How Was This Tested?

- [x] `cargo check -p reinhardt-di -p reinhardt-di-macros -p reinhardt-web --all-features`
- [x] `cargo test -p reinhardt-di --all-features` — 4 new alias tests pass (Ok/Err/Some/None variants)
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`

Note: one pre-existing test (`test_depends_resolve_uncached`) is flaky under parallel execution due to a global-registry duplicate-registration race (`registry.rs:174`); it passes with `--test-threads=1` and is unrelated to this change.

## Related Issues

- #4938 — follow-up to replace hardcoded type-name matching with a trait-based `#[inject]` resolution mechanism

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DependsResult<T, E> and DependsOption<T> for injection and re-exported them in the public API.
* **Improvements**
  * Macro support extended so those wrapper forms are accepted as valid injectables.
  * Validation messages updated to list the new wrapper forms among accepted injection types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->