### PR TITLE
fix(ci): restore release PR format and wasm clippy

### DIFF
--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -626,11 +626,17 @@ pub fn theme_toggle() -> Page {
 ///
 /// Displays an empty div (useful for conditional rendering).
 pub fn empty() -> Page {
-	page!(|| { div {} })()
+	page!(|| {
+		div {}
+	})()
 }
 /// Divider component
 pub fn divider() -> Page {
-	page!(|| { div { class: "divider" } })()
+	page!(|| {
+		div {
+			class: "divider"
+		}
+	})()
 }
 /// Badge component
 pub fn badge(text: &str, primary: bool) -> Page {

--- a/examples/examples-twitter/src/core/client/components/layout.rs
+++ b/examples/examples-twitter/src/core/client/components/layout.rs
@@ -95,9 +95,7 @@ pub fn header(site_name: &str, current_user: Option<&UserInfo>, nav_items: &[Nav
 		})
 		.collect();
 	let nav_links_view = page!(|nav_links: Vec<Page>| {
-		for link in nav_links {
-			{ link }
-		}
+		for link in nav_links { { link } }
 	})(nav_links);
 	let brand_link = Link::new("/".to_string(), site_name.to_string())
 		.class("text-xl font-bold text-content-primary hover:text-brand transition-colors")
@@ -207,9 +205,7 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|topics_list: Vec<Page>| {
-			for topic in topics_list {
-				{ topic }
-			}
+			for topic in topics_list { { topic } }
 		})(topics_list)
 	};
 	let users_list: Vec<Page> = suggested_users
@@ -274,9 +270,7 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|users_list: Vec<Page>| {
-			for user in users_list {
-				{ user }
-			}
+			for user in users_list { { user } }
 		})(users_list)
 	};
 	page!(|topics_view: Page, users_view: Page| {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,13 +13,8 @@
 /// the `client-router` feature; the module is empty when that feature is
 /// disabled). Native builds keep using the full server-side prelude below.
 #[cfg(all(not(native), target_family = "wasm"))]
-mod wasm {
-	#[cfg(feature = "client-router")]
-	pub use crate::urls::prelude::UnifiedRouter;
-}
-
-#[cfg(all(not(native), target_family = "wasm"))]
-pub use wasm::*;
+#[cfg(feature = "client-router")]
+pub use crate::urls::prelude::UnifiedRouter;
 
 #[cfg(native)]
 mod server {


### PR DESCRIPTION
## Summary

This PR addresses:

- Fixes #4962
- Formats the two `examples-twitter` component files reported by `fmt-all --check` on release PR #4958.
- Removes the empty wasm prelude shim re-export that Clippy flags when `client-router` is disabled, while preserving the `UnifiedRouter` prelude re-export when `client-router` is enabled.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Release PR #4958 targets `develop/0.2.0` and is blocked by `Format / Format Check` and `WASM Check / WASM Clippy (reinhardt-web)`. Code fixes should not be pushed directly to generated `develop-release-plz-*` branches, so this fix targets the release PR base branch.

Fixes #4962

Related to: #4958

## How Was This Tested?

- `cargo make fmt-check`
- `cargo clippy --target wasm32-unknown-unknown -p reinhardt-web --lib -- -D warnings`
- `cargo clippy --target wasm32-unknown-unknown -p reinhardt-web --no-default-features --features pages,client-router,pages-web-sys-full,di --lib -- -D warnings`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4962
- Related to #4958

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The release-plz PR should regenerate after this lands on `develop/0.2.0`.

🤖 Generated with [Codex](https://openai.com/codex)

Co-Authored-By: Codex <noreply@openai.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code restructuring for improved maintainability. Reformatted component declarations and simplified export patterns with no impact on functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->