### PR TITLE
refactor(examples): use Result<User, SessionError> and rename UserManager

### DIFF
--- a/examples/examples-tutorial-basis/README.md
+++ b/examples/examples-tutorial-basis/README.md
@@ -20,7 +20,7 @@ This example corresponds to the basis tutorial parts 1-7:
 
 - **`Question`** (`src/apps/polls/models.rs`) — poll question with `question_text`, `pub_date` (`auto_now_add`), and an `author` foreign key to `User` (`#[rel(foreign_key, related_name = "questions")]`).
 - **`Choice`** (`src/apps/polls/models.rs`) — answer option with a `question` foreign key (`#[rel(foreign_key, related_name = "choices")]`), `choice_text`, and a `votes` counter.
-- **`User`** (`src/apps/users/models.rs`) — minimal authentication model defined with `#[user(hasher = Argon2Hasher, username_field = "username", manager = false)]` on top of `#[model(app_label = "users", table_name = "users")]`. `manager = false` opts out of the auto-generated user manager so the example can register a project-local `UserManager` via `#[injectable_factory(scope = "transient")]`.
+- **`User`** (`src/apps/users/models.rs`) — minimal authentication model defined with `#[user(hasher = Argon2Hasher, username_field = "username", manager = false)]` on top of `#[model(app_label = "users", table_name = "users")]`. `manager = false` opts out of the auto-generated user manager so the example can register a project-local `AuthUserManager` via `#[injectable_factory(scope = "transient")]`.
 
 ### Views
 
@@ -170,7 +170,7 @@ examples-tutorial-basis/
 │   │   ├── users.rs                # `pub mod models (cfg native); server_fn; urls`
 │   │   └── users/
 │   │       ├── models.rs           # `#[user(…)]` User + `#[injectable_factory]`
-│   │       │                       # UserManager
+│   │       │                       # AuthUserManager
 │   │       ├── server_fn.rs        # `login`, `register`, `logout`, `current_user`
 │   │       ├── urls.rs             # Declares `server_urls` + `client_router`
 │   │       └── urls/

--- a/examples/examples-tutorial-basis/src/apps/polls/di.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/di.rs
@@ -7,7 +7,7 @@
 //! lets `server_fn.rs` stay focused on handler bodies and gives every
 //! DI contribution a single, greppable home per app.
 //!
-//! ## Why a hand-rolled `SessionUser` instead of `reinhardt_auth::AuthUser<User>`?
+//! ## Why a hand-rolled session-user factory instead of `reinhardt_auth::AuthUser<User>`?
 //!
 //! `AuthUser<U>`
 //! (`crates/reinhardt-auth/src/auth_user.rs:43`) is the **canonical
@@ -37,34 +37,20 @@
 //! Both gaps are tracked as a `rc-migration` proposal in
 //! [#4652](https://github.com/kent8192/reinhardt-web/issues/4652).
 //! Once that ships, this whole module collapses — handlers swap
-//! `#[inject] session_user: Depends<SessionUser>` /
-//! `session_user.require_active()?` for the upstream
-//! `#[inject] AuthUser(user): AuthUser<User>` (plus an inline
+//! `#[inject] user: Depends<Result<User, SessionError>>` /
+//! `let user = user.as_ref().map_err(ServerFnError::from)?` for the
+//! upstream `#[inject] AuthUser(user): AuthUser<User>` (plus an inline
 //! `is_active` check) and `apps/polls/di.rs` is deleted entirely.
 //!
-//! The type is named `SessionUser` (not `CurrentUser`) for two reasons:
-//!
-//! - **Name-clash avoidance** — `reinhardt_auth::CurrentUser<U>` is
-//!   `#[deprecated]` and scheduled to become `pub type CurrentUser<U> =
-//!   AuthUser<U>` in 0.2.0
-//!   (`crates/reinhardt-auth/src/current_user.rs:53-56`). Reusing the
-//!   name would shadow that alias once #4652 lands.
-//! - **Honest intent** — this factory is explicitly *session-derived*.
-//!   The `SessionUser` name signals that it is the session-only fallback
-//!   for the `AuthUser`-shaped story.
-//!
-//! ## Why not `Result<SessionUser, ServerFnError>` as the factory return?
+//! ## Factory return type: `Result<User, SessionError>`
 //!
 //! `#[injectable_factory]` registers its **literal return type** as the
 //! DI key (`crates/reinhardt-di/macros/src/injectable_factory.rs:182`
-//! `register_async::<#return_type, _, _>`). Returning
-//! `Result<SessionUser, ServerFnError>` would force every handler's
-//! `#[inject]` parameter to spell out
-//! `Depends<Result<SessionUser, ServerFnError>>`, which is bulky and
-//! moves error semantics into the type signature. Instead we use a
-//! four-state enum (`Authenticated` / `Inactive` / `Anonymous` /
-//! `Unavailable`) — handlers spell `Depends<SessionUser>` and dispatch
-//! with a single `.require_active()?` call, and the enum keeps the
+//! `register_async::<#return_type, _, _>`). The factory returns
+//! `Result<User, SessionError>`, so handlers spell
+//! `Depends<Result<User, SessionError>>` and convert to a
+//! `ServerFnError` via `From<&SessionError>`. The three `SessionError`
+//! variants (`Anonymous` / `Inactive` / `Unavailable`) keep the
 //! "DB outage" branch separate from "user is anonymous" so an
 //! availability problem cannot be silently rewritten into a fake 401.
 //!
@@ -116,59 +102,58 @@ use reinhardt::pages::server_fn::ServerFnError;
 #[cfg(native)]
 use crate::apps::users::models::User;
 
-/// Request-scoped wrapper around the user resolved from the session,
-/// mirroring Django's `request.user`.
+/// Error variants for the session-based user lookup factory.
 ///
-/// Four states are surfaced so handlers can distinguish the kind of
-/// failure without re-running session/database lookups *and* so that an
-/// operational outage (DB connection drop, query timeout) does not get
-/// silently rewritten into a fake 401:
+/// Three failure modes are distinguished so handlers can surface the
+/// correct HTTP status *and* so that an operational outage (DB
+/// connection drop, query timeout) does not get silently rewritten into
+/// a fake 401:
 ///
-/// - [`SessionUser::Authenticated`] — a row exists for the session's
-///   `user_id` and `is_active = true`.
-/// - [`SessionUser::Inactive`] — a row exists but `is_active = false`.
-///   Surfaced as **403** by [`SessionUser::require_active`].
-/// - [`SessionUser::Anonymous`] — no `user_id` in the session, or the
-///   row has been deleted between login and request. Surfaced as **401**.
-/// - [`SessionUser::Unavailable`] — the user-lookup query itself failed
+/// - [`SessionError::Anonymous`] — no `user_id` in the session, or the
+///   row has been deleted between login and request. Surfaced as **401**
+///   via `From<&SessionError> for ServerFnError`.
+/// - [`SessionError::Inactive`] — a row exists but `is_active = false`.
+///   Surfaced as **403**.
+/// - [`SessionError::Unavailable`] — the user-lookup query itself failed
 ///   (DB down, pool exhausted, schema mismatch, …). Surfaced as **500**
-///   by [`SessionUser::require_active`] so the client sees an operational
-///   error instead of being pushed into a misleading re-auth loop.
+///   so the client sees an operational error instead of being pushed
+///   into a misleading re-auth loop.
 ///
 /// The split between `Anonymous` and `Unavailable` matters: collapsing a
 /// DB error into `Anonymous` would hide the outage from monitoring, and
 /// the recommended client behaviour (a redirect to the login page) would
 /// punish callers for an availability problem on the server.
 ///
-/// `Clone` is derived so handlers can pull an owned `SessionUser` out of
-/// `Depends<_>` with `(*session_user).clone()` when needed.
+/// `Clone` and `Debug` are derived so handlers can inspect and clone the
+/// error out of `Depends<Result<User, SessionError>>` when needed.
 #[cfg(native)]
-#[derive(Clone)]
-pub enum SessionUser {
-	Authenticated(User),
-	Inactive(User),
+#[derive(Clone, Debug)]
+pub enum SessionError {
 	Anonymous,
+	Inactive,
 	/// User-lookup query failed at the database layer. The wrapped
 	/// `String` is the underlying error message — the factory keeps it
-	/// for logging / future propagation; `require_active()` does not
-	/// echo it to the client (only the 500 status + a generic message
-	/// reaches the response body) to avoid leaking schema details.
+	/// for logging / future propagation; the `From<&SessionError>` impl
+	/// does not echo it to the client (only the 500 status + a generic
+	/// message reaches the response body) to avoid leaking schema
+	/// details.
 	Unavailable(String),
 }
 
+/// Convert a `SessionError` reference to a `ServerFnError` with the
+/// appropriate HTTP status code.
+///
+/// Handlers use this via `user.as_ref().map_err(ServerFnError::from)?`
+/// to surface a 401, 403, or 500 depending on the failure mode.
 #[cfg(native)]
-impl SessionUser {
-	/// Borrow the active authenticated user, or surface a 401/403/500
-	/// `ServerFnError`.
-	pub fn require_active(&self) -> std::result::Result<&User, ServerFnError> {
-		match self {
-			Self::Authenticated(u) => Ok(u),
-			Self::Inactive(_) => Err(ServerFnError::server(403, "User account is inactive")),
-			Self::Anonymous => Err(ServerFnError::server(401, "Authentication required")),
-			Self::Unavailable(_) => Err(ServerFnError::server(
-				500,
-				"User lookup temporarily unavailable",
-			)),
+impl From<&SessionError> for ServerFnError {
+	fn from(err: &SessionError) -> Self {
+		match err {
+			SessionError::Anonymous => ServerFnError::server(401, "Authentication required"),
+			SessionError::Inactive => ServerFnError::server(403, "User account is inactive"),
+			SessionError::Unavailable(_) => {
+				ServerFnError::server(500, "User lookup temporarily unavailable")
+			}
 		}
 	}
 }
@@ -189,9 +174,11 @@ impl SessionUser {
 /// > [#4646](https://github.com/kent8192/reinhardt-web/issues/4646).
 #[cfg(native)]
 #[injectable_factory(scope = "request")]
-async fn session_user_factory(#[inject] session: SessionData) -> SessionUser {
+async fn session_user_factory(
+	#[inject] session: SessionData,
+) -> Result<User, SessionError> {
 	let Some(user_id) = session.get::<i64>(USER_ID_SESSION_KEY) else {
-		return SessionUser::Anonymous;
+		return Err(SessionError::Anonymous);
 	};
 
 	// Distinguish the three outcomes explicitly:
@@ -201,38 +188,39 @@ async fn session_user_factory(#[inject] session: SessionData) -> SessionUser {
 	// - `Ok(None)` — the session points at a user_id that no longer
 	//   exists (deleted account, GDPR purge, …). The session itself
 	//   has outlived the user, so the right behaviour is to force
-	//   re-auth → **`Anonymous` (401)**.
+	//   re-auth → **`Err(Anonymous)` (401)**.
 	// - `Err(e)` — the lookup query itself failed (DB outage, pool
 	//   exhaustion, schema drift, etc.). This is an *availability*
 	//   problem, not an *authentication* problem, so collapsing it
 	//   into `Anonymous` would (a) hide the outage from monitoring
 	//   and (b) push callers into a misleading "log in again" loop.
-	//   Surface it as **`Unavailable` (500)** instead.
+	//   Surface it as **`Err(Unavailable)` (500)** instead.
 	//
 	// `tracing::warn!` logs the underlying error for observability
-	// while `require_active()` echoes only a generic 500 message to
-	// the client, so schema details do not leak via error bodies.
+	// while the `From<&SessionError>` impl echoes only a generic 500
+	// message to the client, so schema details do not leak via error
+	// bodies.
 	let user = match User::objects()
 		.filter(User::field_id().eq(user_id))
 		.first()
 		.await
 	{
 		Ok(Some(u)) => u,
-		Ok(None) => return SessionUser::Anonymous,
+		Ok(None) => return Err(SessionError::Anonymous),
 		Err(e) => {
 			::tracing::warn!(
 				user_id = user_id,
 				error = %e,
 				"session_user_factory: user lookup failed"
 			);
-			return SessionUser::Unavailable(e.to_string());
+			return Err(SessionError::Unavailable(e.to_string()));
 		}
 	};
 
 	if user.is_active {
-		SessionUser::Authenticated(user)
+		Ok(user)
 	} else {
-		SessionUser::Inactive(user)
+		Err(SessionError::Inactive)
 	}
 }
 

--- a/examples/examples-tutorial-basis/src/apps/polls/server_fn.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/server_fn.rs
@@ -9,17 +9,17 @@ use reinhardt::pages::server_fn::{ServerFnError, server_fn};
 // at the call site — see the per-handler `use` blocks below for examples.
 #[cfg(native)]
 use {
-	crate::apps::polls::di::SessionUser, crate::apps::users::models::User, reinhardt::Model,
+	crate::apps::polls::di::SessionError, crate::apps::users::models::User, reinhardt::Model,
 	reinhardt::di::Depends,
 };
 
 // The previous request-scoped helper `require_user(&session)` has been
-// replaced by the `SessionUser` factory in `apps::polls::di`. Each
-// authenticated handler now receives `Depends<SessionUser>` from the DI
-// container and calls `.require_active()?` to surface 401/403. The factory
-// also documents the path to `reinhardt_auth::AuthUser<User>` once #4652
-// (the `CurrentUser` → `AuthUser` unification + `SessionMiddleware` →
-// `AuthState` bridge) lands.
+// replaced by the session-user factory in `apps::polls::di`. Each
+// authenticated handler now receives `Depends<Result<User, SessionError>>`
+// from the DI container and calls `.as_ref().map_err(ServerFnError::from)?`
+// to surface 401/403/500. The factory also documents the path to
+// `reinhardt_auth::AuthUser<User>` once #4652 (the `CurrentUser` →
+// `AuthUser` unification + `SessionMiddleware` → `AuthState` bridge) lands.
 
 // WASM-only imports
 // (None needed - all forms logic is server-side)
@@ -223,9 +223,10 @@ async fn vote_internal(
 //   handler. The trailing `_csrf_token: String` parameter is appended by the
 //   `form!` macro for non-GET forms; the CSRF middleware verifies it before
 //   the handler runs.
-// * Authentication is required: `Depends<SessionUser>` is resolved by the
-//   request-scoped factory in `apps::polls::di` and exposes
-//   `.require_active()?` for the 401/403 surface.
+// * Authentication is required: `Depends<Result<User, SessionError>>` is
+//   resolved by the request-scoped factory in `apps::polls::di` and
+//   exposes `.as_ref().map_err(ServerFnError::from)?` for the 401/403/500
+//   surface.
 // * For `update_question` and `delete_question`, ownership is enforced by
 //   comparing `question.author_id()` with the current user's id; mismatched
 //   ownership returns a 403.
@@ -237,18 +238,18 @@ async fn vote_internal(
 ///       question_text: String,
 ///       _csrf_token: String,
 ///       #[inject] _db: reinhardt::DatabaseConnection,
-///       #[inject] session_user: Depends<SessionUser>,
+///       #[inject] session_user: Depends<Result<User, SessionError>>,
 ///   ) -> std::result::Result<QuestionInfo, ServerFnError> { ... }
 #[server_fn]
 pub async fn create_question(
 	question_text: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<QuestionInfo, ServerFnError> {
 	use crate::apps::polls::models::Question;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 
 	let trimmed = question_text.trim();
 	if trimmed.is_empty() || trimmed.len() > 200 {
@@ -286,11 +287,11 @@ pub async fn update_question(
 	question_text: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<QuestionInfo, ServerFnError> {
 	use crate::apps::polls::models::Question;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 
 	let question_id: i64 = question_id
 		.parse()
@@ -342,11 +343,11 @@ pub async fn delete_question(
 	question_id: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<(), ServerFnError> {
 	use crate::apps::polls::models::Question;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 
 	let question_id: i64 = question_id
 		.parse()
@@ -418,11 +419,11 @@ pub async fn create_choice(
 	choice_text: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<ChoiceInfo, ServerFnError> {
 	use crate::apps::polls::models::Choice;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 	let question_id: i64 = question_id
 		.parse()
 		.map_err(|_| ServerFnError::application("Invalid question_id"))?;
@@ -457,11 +458,11 @@ pub async fn update_choice(
 	choice_text: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<ChoiceInfo, ServerFnError> {
 	use crate::apps::polls::models::Choice;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 	let choice_id: i64 = choice_id
 		.parse()
 		.map_err(|_| ServerFnError::application("Invalid choice_id"))?;
@@ -499,11 +500,11 @@ pub async fn delete_choice(
 	choice_id: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<(), ServerFnError> {
 	use crate::apps::polls::models::Choice;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 	let choice_id: i64 = choice_id
 		.parse()
 		.map_err(|_| ServerFnError::application("Invalid choice_id"))?;

--- a/examples/examples-tutorial-basis/src/apps/users/models.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/models.rs
@@ -9,7 +9,7 @@
 //! both the schema and the SignupForm small.
 //!
 //! All registration / authentication-state changes from application code
-//! go through [`UserManager`] (a project-local implementation of
+//! go through [`AuthUserManager`] (a project-local implementation of
 //! `BaseUserManager<User>`) rather than constructing `User` instances
 //! by hand — see the `register` server function in
 //! `crate::apps::users::server_fn`.
@@ -21,7 +21,7 @@
 //! the framework discovers at startup), which calls
 //! `User::objects().create(&user)` directly. That path therefore
 //! **bypasses** the password-length / username trim / uniqueness checks
-//! that [`UserManager::build_user`] performs for the application signup
+//! that [`AuthUserManager::build_user`] performs for the application signup
 //! flow. Acceptable for the tutorial CLI. Auto-registration for minimal
 //! user models without `full = true` is the resolution of
 //! reinhardt-web#4522 — no manual `SuperuserInit` impl or
@@ -33,9 +33,9 @@ use reinhardt::macros::user;
 use reinhardt::prelude::*;
 use serde::{Deserialize, Serialize};
 
-// `manager = false` opts out of the auto-generated `UserManager` that
+// `manager = false` opts out of the auto-generated manager that
 // `#[user(...)]` emits by default since reinhardt-web#4451 — the tutorial
-// keeps its own DB-backed `UserManager` below (registered via
+// keeps its own DB-backed `AuthUserManager` below (registered via
 // `#[injectable_factory]`) which would otherwise be shadowed. The
 // auto-manager is also gated to `Uuid` / `Option<Uuid>` primary keys
 // (issue #4455), and this model uses `i64` to demonstrate auto-increment
@@ -90,9 +90,13 @@ mod manager {
 
 	/// Project-local `BaseUserManager<User>` implementation.
 	///
+	/// Named `AuthUserManager` (rather than `UserManager`) to avoid
+	/// confusion with the auto-generated manager that `#[user(...)]` can
+	/// emit — the tutorial opts out via `manager = false`.
+	///
 	/// Encapsulates the "create + hash + persist" pipeline for the tutorial
 	/// `User`. Server functions receive an injected instance via
-	/// `#[inject] um: Depends<UserManager>` and delegate to `create_user`
+	/// `#[inject] um: Depends<AuthUserManager>` and delegate to `create_user`
 	/// / `create_superuser` so password hashing, uniqueness checks, and
 	/// saves stay in a single place.
 	///
@@ -102,7 +106,7 @@ mod manager {
 	/// shadow this hand-written one — and because the auto-manager is gated
 	/// to `Uuid` / `Option<Uuid>` primary keys (issue #4455) whereas this
 	/// model uses `i64`. `Clone` is derived so a server function can pull an
-	/// owned `UserManager` out of `Depends<_>` and invoke the
+	/// owned `AuthUserManager` out of `Depends<_>` and invoke the
 	/// `BaseUserManager::create_user(&mut self, …)` trait method without
 	/// fighting `Arc` mutability.
 	///
@@ -113,16 +117,16 @@ mod manager {
 	/// `examples/CLAUDE.md` DM-1 ("Reinhardt Dependencies Only"); the
 	/// `#[injectable_factory]` path does not have this issue. See #4445.
 	#[derive(Clone)]
-	pub struct UserManager {
+	pub struct AuthUserManager {
 		db: DatabaseConnection,
 	}
 
 	#[injectable_factory(scope = "transient")]
-	async fn user_manager_factory(#[inject] db: Depends<DatabaseConnection>) -> UserManager {
-		UserManager { db: (*db).clone() }
+	async fn auth_user_manager_factory(#[inject] db: Depends<DatabaseConnection>) -> AuthUserManager {
+		AuthUserManager { db: (*db).clone() }
 	}
 
-	impl UserManager {
+	impl AuthUserManager {
 		async fn build_user(
 			&self,
 			username: &str,
@@ -178,7 +182,7 @@ mod manager {
 	}
 
 	#[async_trait]
-	impl BaseUserManager<User> for UserManager {
+	impl BaseUserManager<User> for AuthUserManager {
 		async fn create_user(
 			&mut self,
 			username: &str,
@@ -209,4 +213,4 @@ mod manager {
 }
 
 #[cfg(native)]
-pub use manager::UserManager;
+pub use manager::AuthUserManager;

--- a/examples/examples-tutorial-basis/src/apps/users/server_fn.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/server_fn.rs
@@ -12,7 +12,7 @@ use reinhardt::pages::server_fn::{ServerFnError, server_fn};
 
 #[cfg(native)]
 use {
-	crate::apps::users::models::{User, UserManager},
+	crate::apps::users::models::{AuthUserManager, User},
 	reinhardt::BaseUser,
 	reinhardt::DatabaseConnection,
 	reinhardt::Validate,
@@ -106,7 +106,7 @@ pub async fn register(
 	password: String,
 	password_confirmation: String,
 	_csrf_token: String,
-	#[inject] user_manager: Depends<UserManager>,
+	#[inject] user_manager: Depends<AuthUserManager>,
 	#[inject] session: SessionData,
 	#[inject] store: Depends<SessionStore>,
 ) -> std::result::Result<UserInfo, ServerFnError> {
@@ -132,18 +132,18 @@ pub async fn register(
 		.validate_passwords_match()
 		.map_err(ServerFnError::application)?;
 
-	// Delegate to `UserManager` — it owns the "validate + hash + persist"
-	// pipeline so this server function stays focused on session handling.
-	// Username length, uniqueness, and password strength are all enforced
-	// inside `create_user`; any failure surfaces as a `reinhardt::Error`
-	// that maps to a 400 via `ServerFnError::application`.
+	// Delegate to `AuthUserManager` — it owns the "validate + hash +
+	// persist" pipeline so this server function stays focused on session
+	// handling. Username length, uniqueness, and password strength are all
+	// enforced inside `create_user`; any failure surfaces as a
+	// `reinhardt::Error` that maps to a 400 via `ServerFnError::application`.
 	//
 	// `BaseUserManager::create_user` takes `&mut self`, but DI hands us a
-	// shared `Depends<UserManager>` (an `Arc` under the hood). Clone the
-	// inner manager — its only field is another `Depends<DatabaseConnection>`,
-	// which is itself an `Arc` clone — so this is cheap and gives us the
-	// `&mut` access the trait method needs.
-	let mut user_manager: UserManager = (*user_manager).clone();
+	// shared `Depends<AuthUserManager>` (an `Arc` under the hood). Clone
+	// the inner manager — its only field is another
+	// `Depends<DatabaseConnection>`, which is itself an `Arc` clone — so
+	// this is cheap and gives us the `&mut` access the trait method needs.
+	let mut user_manager: AuthUserManager = (*user_manager).clone();
 	let saved = user_manager
 		.create_user(
 			request.username.trim(),

--- a/examples/examples-tutorial-basis/tests/integration.rs
+++ b/examples/examples-tutorial-basis/tests/integration.rs
@@ -819,17 +819,18 @@ mod server_fn_tests {
 // Authorization tests for CUD server functions (Phase 4)
 // =========================================================================
 //
-// These tests cover the `SessionUser` DI factory's `require_active()` gate
-// at the entrance of every authenticated mutation (`create_question`,
+// These tests cover the session-user DI factory's `SessionError` gate at
+// the entrance of every authenticated mutation (`create_question`,
 // `update_question`, `delete_question`, and the three Choice mirrors). The
 // gate runs *before* any database access, so these tests do not depend on
 // the schema and can run against an empty SQLite file. They guarantee that:
 //
-//   - An empty `SessionData` (no `user_id` key) → `SessionUser::Anonymous`
-//     → `require_active()` returns 401 Unauthorized.
-//   - The error originates from the `SessionUser` gate, not from the model
-//     layer (i.e. the auth gate is never accidentally bypassed for any of
-//     the six CUD entry points).
+//   - An empty `SessionData` (no `user_id` key) →
+//     `Err(SessionError::Anonymous)` → `From<&SessionError>` returns
+//     401 Unauthorized.
+//   - The error originates from the `SessionError` gate, not from the
+//     model layer (i.e. the auth gate is never accidentally bypassed for
+//     any of the six CUD entry points).
 //
 // Session-positive ("author can update", "non-author gets 403") paths
 // require a `users` table + `author_id` column in the fixture — see the
@@ -840,11 +841,12 @@ mod server_fn_tests {
 
 #[cfg(with_reinhardt)]
 mod auth_tests {
-	use examples_tutorial_basis::apps::polls::di::SessionUser;
+	use examples_tutorial_basis::apps::polls::di::SessionError;
 	use examples_tutorial_basis::apps::polls::server_fn::{
 		create_choice, create_question, delete_choice, delete_question, update_choice,
 		update_question,
 	};
+	use examples_tutorial_basis::apps::users::models::User;
 	use reinhardt::DatabaseConnection;
 	use reinhardt::di::Depends;
 	use rstest::*;
@@ -852,7 +854,7 @@ mod auth_tests {
 
 	/// Fixture: an empty SQLite database + DatabaseConnection wired through
 	/// reinhardt-orm. No tables are created; the authorization tests below
-	/// short-circuit on `session_user.require_active()` before any query runs.
+	/// short-circuit on the `SessionError` gate before any query runs.
 	#[fixture]
 	async fn empty_db_conn() -> (NamedTempFile, DatabaseConnection) {
 		let temp_file = NamedTempFile::new().expect("Failed to create temp file");
@@ -864,14 +866,15 @@ mod auth_tests {
 		(temp_file, db_conn)
 	}
 
-	/// Anonymous `SessionUser` wrapped in `Depends<_>` — the same value the
-	/// request-scoped `session_user_factory` in `apps::polls::di` would
-	/// produce for a `SessionData` without a `user_id` key. We construct it
-	/// directly with `Depends::from_value` so the test does not need to spin
-	/// up the middleware stack or the DI container; the gate under test is
-	/// `SessionUser::require_active()`, not the factory itself.
-	fn anonymous_session_user() -> Depends<SessionUser> {
-		Depends::from_value(SessionUser::Anonymous)
+	/// Anonymous session error wrapped in `Depends<Result<User, SessionError>>`
+	/// — the same value the request-scoped `session_user_factory` in
+	/// `apps::polls::di` would produce for a `SessionData` without a
+	/// `user_id` key. We construct it directly with `Depends::from_value`
+	/// so the test does not need to spin up the middleware stack or the DI
+	/// container; the gate under test is `From<&SessionError> for
+	/// ServerFnError`, not the factory itself.
+	fn anonymous_session_user() -> Depends<Result<User, SessionError>> {
+		Depends::from_value(Err(SessionError::Anonymous))
 	}
 
 	/// Helper: assert that a ServerFnError result represents a 401.
@@ -882,11 +885,11 @@ mod auth_tests {
 		let err = result
 			.err()
 			.unwrap_or_else(|| panic!("{} should reject anonymous callers", operation));
-		// The `SessionUser::require_active()` gate emits
+		// The `From<&SessionError>` impl emits
 		// `ServerFnError::server(401, ...)`. We match on the Debug-formatted
-		// output because ServerFnError does not expose the inner status as a
-		// typed accessor in the public API, and its `Debug` impl is the most
-		// stable representation that includes the numeric status.
+		// output because `ServerFnError` does not expose the inner status as
+		// a typed accessor in the public API, and its `Debug` impl is the
+		// most stable representation that includes the numeric status.
 		let rendered = format!("{:?}", err);
 		assert!(
 			rendered.contains("401") || rendered.contains("Authentication required"),

--- a/website/content/quickstart/tutorials/basis/2-models-and-database.md
+++ b/website/content/quickstart/tutorials/basis/2-models-and-database.md
@@ -8,7 +8,7 @@ sidebar_weight = 20
 
 # Part 2: Models and Database
 
-Part 1 generated the pages project layout and started the dev server against an empty database. In this chapter we fill in the model layer that backs the rest of the tutorial: the `polls` app with `Question` and `Choice`, the `users` app with a session-aware `User` and a project-local `UserManager`, and the migration workflow that turns those Rust definitions into a SQLite schema.
+Part 1 generated the pages project layout and started the dev server against an empty database. In this chapter we fill in the model layer that backs the rest of the tutorial: the `polls` app with `Question` and `Choice`, the `users` app with a session-aware `User` and a project-local `AuthUserManager`, and the migration workflow that turns those Rust definitions into a SQLite schema.
 
 By the end of the chapter your `src/apps/` tree will match [`examples/examples-tutorial-basis/src/apps/`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis/src/apps) — same files, same attributes, same builder shape. Part 3 plugs server functions on top of these models, so resist the urge to skip ahead and "just add the views"; getting the model layer right is what makes the typed `#[server_fn]` story click later.
 
@@ -21,7 +21,7 @@ flowchart LR
     Settings["settings/base.toml<br/>[database]"] -->|loaded by| ConfigSettings["src/config/settings.rs<br/>ProjectSettings"]
     ConfigSettings -->|opens| DB[(SQLite<br/>db.sqlite3)]
     PollsApp["src/apps/polls/models.rs<br/>Question, Choice"] -->|"#[model] schema"| Migrations["migrations/<br/>(generated)"]
-    UsersApp["src/apps/users/models.rs<br/>User + UserManager"] -->|"#[model] schema"| Migrations
+    UsersApp["src/apps/users/models.rs<br/>User + AuthUserManager"] -->|"#[model] schema"| Migrations
     Migrations -->|cargo make migrate| DB
     AppsConfig["src/config/apps.rs<br/>installed_apps!"] -->|InstalledApp enum| PollsApp
     AppsConfig --> UsersApp
@@ -297,7 +297,7 @@ Create `src/apps/users/models.rs`:
 //! both the schema and the SignupForm small.
 //!
 //! All registration / authentication-state changes from application code
-//! go through [`UserManager`] (a project-local implementation of
+//! go through [`AuthUserManager`] (a project-local implementation of
 //! `BaseUserManager<User>`) rather than constructing `User` instances
 //! by hand — see the `register` server function in
 //! `crate::apps::users::server_fn`.
@@ -309,7 +309,7 @@ Create `src/apps/users/models.rs`:
 //! the framework discovers at startup), which calls
 //! `User::objects().create(&user)` directly. That path therefore
 //! **bypasses** the password-length / username trim / uniqueness checks
-//! that [`UserManager::build_user`] performs for the application signup
+//! that [`AuthUserManager::build_user`] performs for the application signup
 //! flow. Acceptable for the tutorial CLI. Auto-registration for minimal
 //! user models without `full = true` is the resolution of
 //! reinhardt-web#4522 — no manual `SuperuserInit` impl or
@@ -321,9 +321,9 @@ use reinhardt::macros::user;
 use reinhardt::prelude::*;
 use serde::{Deserialize, Serialize};
 
-// `manager = false` opts out of the auto-generated `UserManager` that
+// `manager = false` opts out of the auto-generated manager that
 // `#[user(...)]` emits by default since reinhardt-web#4451 — the tutorial
-// keeps its own DB-backed `UserManager` below (registered via
+// keeps its own DB-backed `AuthUserManager` below (registered via
 // `#[injectable_factory]`) which would otherwise be shadowed. The
 // auto-manager is also gated to `Uuid` / `Option<Uuid>` primary keys
 // (issue #4455), and this model uses `i64` to demonstrate auto-increment
@@ -377,7 +377,7 @@ There is one new attribute macro and a handful of new field options. Let's unpac
 - `username_field = "username"` — which field is the identity column. The framework needs to know this so session-based authentication can look users up by username.
 - `manager = false` — **opt out of the auto-generated `UserManager`.** This is the critical flag for the tutorial. Reinhardt-web#4451 added a default `UserManager` so simple projects don't need to write one, but if we want to layer custom validation (username trimming, password length, uniqueness checks) and register the manager through the DI container, the auto-generated manager would shadow ours. Setting `manager = false` makes room for the project-local one we're about to write.
 
-`#[derive(Default, Clone, Serialize, Deserialize)]` is needed for a few reasons: `Default` lets the framework construct a stand-in `User` for the request extensions when no user is logged in; `Clone` lets server functions pull an owned `UserManager` out of `Depends<_>` later; `Serialize`/`Deserialize` are for the DTO conversion in `src/shared/types.rs` (Part 3).
+`#[derive(Default, Clone, Serialize, Deserialize)]` is needed for a few reasons: `Default` lets the framework construct a stand-in `User` for the request extensions when no user is logged in; `Clone` lets server functions pull an owned `AuthUserManager` out of `Depends<_>` later; `Serialize`/`Deserialize` are for the DTO conversion in `src/shared/types.rs` (Part 3).
 
 Notice that we did **not** pass `full = true`. The `full` flag would also implement `FullUser`, which requires `email`, `first_name`, `last_name`, `is_staff`, and `date_joined` fields. The tutorial keeps the schema small on purpose: fewer signup fields, fewer migration columns, less to explain. The doc comment in the example file calls this out explicitly.
 
@@ -395,16 +395,16 @@ Notice that we did **not** pass `full = true`. The `full` flag would also implem
 
 ### How `createsuperuser` Finds This Model
 
-The `cargo run --bin manage createsuperuser` command needs a way to construct a `User` from `(username, email)` without running the application-side `UserManager` validation. That constructor is the `SuperuserInit` trait, and since [reinhardt-web#4522](https://github.com/kent8192/reinhardt-web/pull/4522) the `#[user] + #[model]` macro pair **auto-generates** the `impl SuperuserInit for User` block plus the matching `inventory::submit!(SuperuserCreatorRegistration)` entry. You do not write either by hand.
+The `cargo run --bin manage createsuperuser` command needs a way to construct a `User` from `(username, email)` without running the application-side `AuthUserManager` validation. That constructor is the `SuperuserInit` trait, and since [reinhardt-web#4522](https://github.com/kent8192/reinhardt-web/pull/4522) the `#[user] + #[model]` macro pair **auto-generates** the `impl SuperuserInit for User` block plus the matching `inventory::submit!(SuperuserCreatorRegistration)` entry. You do not write either by hand.
 
 Two details worth knowing:
 
 - The generated `init_superuser(username, _email)` intentionally drops `email` because the tutorial's minimal `User` has no `email` column — the macro inspects the struct fields and only writes back the ones that exist. `full = true` would add the column; we opted out of that on purpose.
 - The primary key is left as `Default::default()` (`0` for `i64`). The database fills it in on insert thanks to `auto_increment`.
 
-The `createsuperuser` path **bypasses** the password-length / username-trim / uniqueness checks that `UserManager::build_user` (below) performs for the application signup flow. That is acceptable for the tutorial CLI, where the operator is trusted.
+The `createsuperuser` path **bypasses** the password-length / username-trim / uniqueness checks that `AuthUserManager::build_user` (below) performs for the application signup flow. That is acceptable for the tutorial CLI, where the operator is trusted.
 
-### The Project-Local `UserManager`
+### The Project-Local `AuthUserManager`
 
 The example file follows the model struct with a `#[cfg(native)] mod manager { ... }` block. The full source is long; here is the shape, with the key registration call highlighted:
 
@@ -424,17 +424,21 @@ mod manager {
     use std::collections::HashMap;
 
     /// Project-local `BaseUserManager<User>` implementation.
+    ///
+    /// Named `AuthUserManager` (rather than `UserManager`) to avoid
+    /// confusion with the auto-generated manager that `#[user(...)]` can
+    /// emit — the tutorial opts out via `manager = false`.
     #[derive(Clone)]
-    pub struct UserManager {
+    pub struct AuthUserManager {
         db: DatabaseConnection,
     }
 
     #[injectable_factory(scope = "transient")]
-    async fn user_manager_factory(#[inject] db: Depends<DatabaseConnection>) -> UserManager {
-        UserManager { db: (*db).clone() }
+    async fn auth_user_manager_factory(#[inject] db: Depends<DatabaseConnection>) -> AuthUserManager {
+        AuthUserManager { db: (*db).clone() }
     }
 
-    impl UserManager {
+    impl AuthUserManager {
         async fn build_user(
             &self,
             username: &str,
@@ -458,7 +462,7 @@ mod manager {
     }
 
     #[async_trait]
-    impl BaseUserManager<User> for UserManager {
+    impl BaseUserManager<User> for AuthUserManager {
         async fn create_user(
             &mut self,
             username: &str,
@@ -489,7 +493,7 @@ mod manager {
 }
 
 #[cfg(native)]
-pub use manager::UserManager;
+pub use manager::AuthUserManager;
 ```
 
 You should copy the manager block verbatim from [`examples/examples-tutorial-basis/src/apps/users/models.rs`](https://github.com/kent8192/reinhardt-web/tree/main/examples/examples-tutorial-basis/src/apps/users/models.rs) — the validation logic (`username.is_empty()`, `chars().count() > 150`, password length checks) is what the `register` server function in Part 3 relies on.
@@ -498,16 +502,16 @@ The mechanism worth understanding here is the registration line:
 
 ```rust
 #[injectable_factory(scope = "transient")]
-async fn user_manager_factory(#[inject] db: Depends<DatabaseConnection>) -> UserManager {
-    UserManager { db: (*db).clone() }
+async fn auth_user_manager_factory(#[inject] db: Depends<DatabaseConnection>) -> AuthUserManager {
+    AuthUserManager { db: (*db).clone() }
 }
 ```
 
-`#[injectable_factory]` is the dependency-injection primitive that makes `UserManager` accessible to server functions. The macro registers the factory at compile time (via `inventory::submit!`), and at request time the DI container resolves any handler parameter declared as `#[inject] um: Depends<UserManager>` by calling this function — which in turn requests a `Depends<DatabaseConnection>`. The chain composes itself; you never write `let db = ctx.get::<DatabaseConnection>();` by hand.
+`#[injectable_factory]` is the dependency-injection primitive that makes `AuthUserManager` accessible to server functions. The macro registers the factory at compile time (via `inventory::submit!`), and at request time the DI container resolves any handler parameter declared as `#[inject] um: Depends<AuthUserManager>` by calling this function — which in turn requests a `Depends<DatabaseConnection>`. The chain composes itself; you never write `let db = ctx.get::<DatabaseConnection>();` by hand.
 
 Two details worth knowing:
 
-- `scope = "transient"` — a fresh `UserManager` per resolution. `BaseUserManager::create_user(&mut self, …)` needs unique mutable access, so we cannot share an `Arc` across requests. Transient is the right scope; the manager itself only holds a cloned `DatabaseConnection` (which is internally an `Arc` over a connection pool), so the cost is trivial.
+- `scope = "transient"` — a fresh `AuthUserManager` per resolution. `BaseUserManager::create_user(&mut self, …)` needs unique mutable access, so we cannot share an `Arc` across requests. Transient is the right scope; the manager itself only holds a cloned `DatabaseConnection` (which is internally an `Arc` over a connection pool), so the cost is trivial.
 - **Why factory, not `#[injectable]` on the struct?** The doc comment on the example calls it out. `#[injectable]` emits `#[async_trait::async_trait]` directly, which would force the consuming crate to add `async-trait` to its `Cargo.toml`. That breaks examples-project rule DM-1 ("Reinhardt Dependencies Only"). `#[injectable_factory]` does not have that requirement. Until reinhardt-web#4445 reworks the macro, the factory form is the right pick for project code.
 
 ## Registering Both Apps in `installed_apps!`
@@ -605,7 +609,7 @@ In this chapter you learned:
 - How `#[model(app_label = ..., table_name = ...)]` plus `#[field(...)]` plus `#[rel(foreign_key, related_name = ...)]` define `Question` and `Choice`, including the rule that `related_name` is required
 - How the `#[model]`-generated typestate `build()` constructor (`Question::build()...finish()`, `Choice::build()...finish()`) keeps call sites stable as the schema grows
 - How `#[user(hasher = Argon2Hasher, username_field = "username", manager = false)]` layers auth traits on top of `#[model]`, and why `manager = false` is the right pick when you have a project-local manager
-- How the `#[user] + #[model]` macro pair auto-generates the `SuperuserInit` impl (plus its `inventory` registration) that makes `cargo run --bin manage createsuperuser` work, and why that path intentionally bypasses the application-side `UserManager` validation
-- How a project-local `UserManager` is registered with the DI container through `#[injectable_factory(scope = "transient")]`, and why the factory form sidesteps the `async-trait` dependency that `#[injectable]` would otherwise force
+- How the `#[user] + #[model]` macro pair auto-generates the `SuperuserInit` impl (plus its `inventory` registration) that makes `cargo run --bin manage createsuperuser` work, and why that path intentionally bypasses the application-side `AuthUserManager` validation
+- How a project-local `AuthUserManager` is registered with the DI container through `#[injectable_factory(scope = "transient")]`, and why the factory form sidesteps the `async-trait` dependency that `#[injectable]` would otherwise force
 - How `installed_apps! { polls: "polls", users: "users" }` generates the typed `InstalledApp::polls` and `InstalledApp::users` identifiers that Part 3 will hand to `#[url_patterns(InstalledApp::<app>, mode = ...)]`
 - How `cargo make makemigrations` + `cargo make migrate` (with `cargo make showurls` as the inspection tool) compile and apply the schema to `db.sqlite3`

--- a/website/content/quickstart/tutorials/basis/3-views-and-urls.md
+++ b/website/content/quickstart/tutorials/basis/3-views-and-urls.md
@@ -291,7 +291,7 @@ function in this section follows the same five conventions:
 - Parameters marked `#[inject]` are resolved by the DI container before
   the body runs. Common injections are `reinhardt::DatabaseConnection`,
   `SessionData`, `Depends<SessionStore>`, and project-local services like
-  `Depends<UserManager>`.
+  `Depends<AuthUserManager>`.
 - The body is implicitly `#[cfg(native)]` — the macro generates a typed
   client stub for the WASM side so callers only see the signature.
 - DTOs at the boundary come from `src/shared/types.rs`, so renaming a
@@ -557,7 +557,7 @@ ships — for example:
 ///       question_text: String,
 ///       _csrf_token: String,
 ///       #[inject] _db: reinhardt::DatabaseConnection,
-///       #[inject] session_user: Depends<SessionUser>,
+///       #[inject] session_user: Depends<Result<User, SessionError>>,
 ///   ) -> std::result::Result<QuestionInfo, ServerFnError> { ... }
 ```
 
@@ -565,41 +565,70 @@ This is the workaround comment convention the project uses everywhere:
 the ideal code is written next to the workaround so that the upgrade path
 is obvious when the upstream issue resolves.
 
-### `SessionUser`: the DI-resolved 401 gate
+### `SessionError`: the DI-resolved 401/403/500 gate
 
 Every authenticated mutation needs the same three steps: pull `user_id`
 out of the session, look up the row, check `is_active`. Putting that
 inline at the top of every handler would be noisy and easy to skip, so
 the project pushes the "load user_id from session, look up the row,
-classify as Anonymous / Authenticated / Unavailable" pipeline into a
-**DI factory** that lives in `apps::polls::di::SessionUser`. Each
-authenticated handler then receives `Depends<SessionUser>` from the DI
-container and calls `.require_active()?` to surface the 401/403:
+classify as `Ok(user)` / `Anonymous` / `Inactive` / `Unavailable`"
+pipeline into a **DI factory** that lives in `apps::polls::di`. The
+factory returns `Result<User, SessionError>`, so each authenticated
+handler receives `Depends<Result<User, SessionError>>` from the DI
+container and calls `(*session_user).as_ref().map_err(ServerFnError::from)?`
+to surface the 401/403/500:
 
 ```rust
 // src/apps/polls/di.rs (excerpt)
 //
 // The factory is registered with `#[injectable_factory(scope = "request")]`
-// so each request resolves its own `SessionUser` once. The classification
-// closes over `SessionData` (cookie-loaded) and `DatabaseConnection` (DI
-// resolved), and returns one of:
+// so each request resolves its own `Result<User, SessionError>` once. The
+// classification closes over `SessionData` (cookie-loaded) and looks the
+// row up through the ORM, returning one of:
 //
-//   - SessionUser::Anonymous            — no `user_id` in session
-//   - SessionUser::Authenticated(User)  — row exists and `is_active`
-//   - SessionUser::Inactive(User)       — row exists but `is_active == false`
-//   - SessionUser::Unavailable          — DB lookup failed (surfaces 503,
-//                                         distinct from "no user")
+//   - Ok(user)                       — row exists and `is_active`
+//   - Err(SessionError::Anonymous)   — no `user_id` in session, or the row
+//                                      no longer exists (surfaces 401)
+//   - Err(SessionError::Inactive)    — row exists but `is_active == false`
+//                                      (surfaces 403)
+//   - Err(SessionError::Unavailable) — DB lookup query failed (surfaces
+//                                      500, distinct from "no user" so an
+//                                      outage is not rewritten into a fake
+//                                      401)
 //
-// `require_active()` returns `Result<User, ServerFnError>` and is what the
-// handlers below call.
+// `From<&SessionError> for ServerFnError` maps each variant to the right
+// HTTP status, and handlers convert via
+// `(*session_user).as_ref().map_err(ServerFnError::from)?`.
+pub enum SessionError {
+	Anonymous,
+	Inactive,
+	Unavailable(String),
+}
+
+impl From<&SessionError> for ServerFnError {
+	fn from(err: &SessionError) -> Self {
+		match err {
+			SessionError::Anonymous => ServerFnError::server(401, "Authentication required"),
+			SessionError::Inactive => ServerFnError::server(403, "User account is inactive"),
+			SessionError::Unavailable(_) => {
+				ServerFnError::server(500, "User lookup temporarily unavailable")
+			}
+		}
+	}
+}
 ```
+
+The three variants keep the "DB outage" branch (`Unavailable`) separate
+from "user is anonymous" (`Anonymous`) so an availability problem cannot
+be silently rewritten into a fake 401: `Unavailable` surfaces a **500**
+while a missing/deleted user surfaces a **401**.
 
 `create_question`, `update_question`, `delete_question`, `create_choice`,
 `update_choice`, and `delete_choice` all start with the same two lines:
-`#[inject] session_user: Depends<SessionUser>` in the signature,
-`let user = session_user.require_active()?;` as the first statement. The
-Question CUD handlers additionally enforce that the caller authored the
-row:
+`#[inject] session_user: Depends<Result<User, SessionError>>` in the
+signature, `let user = (*session_user).as_ref().map_err(ServerFnError::from)?;`
+as the first statement. The Question CUD handlers additionally enforce
+that the caller authored the row:
 
 ```rust
 /// Update a question's text. Only the author may update.
@@ -609,11 +638,11 @@ pub async fn update_question(
 	question_text: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<QuestionInfo, ServerFnError> {
 	use crate::apps::polls::models::Question;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 
 	let question_id: i64 = question_id
 		.parse()
@@ -680,7 +709,7 @@ use reinhardt::pages::server_fn::{ServerFnError, server_fn};
 
 #[cfg(native)]
 use {
-	crate::apps::users::models::{User, UserManager},
+	crate::apps::users::models::{AuthUserManager, User},
 	reinhardt::BaseUser,
 	reinhardt::DatabaseConnection,
 	reinhardt::Validate,
@@ -763,7 +792,7 @@ pub async fn login(
 ```
 
 `register` follows the same shape and delegates to the project-local
-`UserManager` introduced in Part 2:
+`AuthUserManager` introduced in Part 2:
 
 ```rust
 #[server_fn]
@@ -772,7 +801,7 @@ pub async fn register(
 	password: String,
 	password_confirmation: String,
 	_csrf_token: String,
-	#[inject] user_manager: Depends<UserManager>,
+	#[inject] user_manager: Depends<AuthUserManager>,
 	#[inject] session: SessionData,
 	#[inject] store: Depends<SessionStore>,
 ) -> std::result::Result<UserInfo, ServerFnError> {
@@ -795,11 +824,11 @@ pub async fn register(
 		.map_err(ServerFnError::application)?;
 
 	// `BaseUserManager::create_user` takes `&mut self`, but DI hands us a
-	// shared `Depends<UserManager>` (an `Arc` under the hood). Clone the
+	// shared `Depends<AuthUserManager>` (an `Arc` under the hood). Clone the
 	// inner manager — its only field is another `Depends<DatabaseConnection>`,
 	// which is itself an `Arc` clone — so this is cheap and gives us the
 	// `&mut` access the trait method needs.
-	let mut user_manager: UserManager = (*user_manager).clone();
+	let mut user_manager: AuthUserManager = (*user_manager).clone();
 	let saved = user_manager
 		.create_user(
 			request.username.trim(),
@@ -1839,9 +1868,10 @@ the polling application:
   client will call lives in `src/apps/<app>/server_fn.rs`. The DI
   container injects `DatabaseConnection`, `SessionData`,
   `Depends<SessionStore>`, and (for the polls mutations)
-  `Depends<SessionUser>`; `session_user.require_active()?` is the shared
-  401 gate, layered on the `SessionUser` factory in
-  `apps::polls::di`; `atomic(&db, || async { … })` guards
+  `Depends<Result<User, SessionError>>`;
+  `(*session_user).as_ref().map_err(ServerFnError::from)?` is the shared
+  401/403/500 gate, layered on the `Result<User, SessionError>` factory
+  in `apps::polls::di`; `atomic(&db, || async { … })` guards
   read-modify-write; the trailing `_csrf_token: String` parameter is
   verified by middleware before the handler runs.
 - **Server-rendered REST endpoints.** `src/apps/polls/views.rs` exposes

--- a/website/content/quickstart/tutorials/basis/4-forms-and-generic-views.md
+++ b/website/content/quickstart/tutorials/basis/4-forms-and-generic-views.md
@@ -520,7 +520,7 @@ pub async fn submit_vote(
 
 ## Question CUD via `form!`
 
-The voting form is the headline use case, but the same pattern composes naturally for create / update / delete. The Question CUD handlers in `src/apps/polls/server_fn.rs` show what an authenticated mutation looks like when stitched together with the `String`-based ABI and the `SessionUser` DI factory (see Part 3 for the factory definition):
+The voting form is the headline use case, but the same pattern composes naturally for create / update / delete. The Question CUD handlers in `src/apps/polls/server_fn.rs` show what an authenticated mutation looks like when stitched together with the `String`-based ABI and the session-user DI factory (see Part 3 for the factory definition):
 
 ```rust
 // src/apps/polls/server_fn.rs
@@ -538,9 +538,10 @@ The voting form is the headline use case, but the same pattern composes naturall
 //   handler. The trailing `_csrf_token: String` parameter is appended by the
 //   `form!` macro for non-GET forms; the CSRF middleware verifies it before
 //   the handler runs.
-// * Authentication is required: `Depends<SessionUser>` is resolved by the
-//   DI container from `apps::polls::di::SessionUser`, and each handler
-//   calls `.require_active()?` for the 401/403 surface.
+// * Authentication is required: `Depends<Result<User, SessionError>>` is
+//   resolved by the request-scoped factory in `apps::polls::di` and
+//   exposes `.as_ref().map_err(ServerFnError::from)?` for the 401/403/500
+//   surface.
 // * For `update_question` and `delete_question`, ownership is enforced by
 //   comparing `question.author_id()` with the current user's id; mismatched
 //   ownership returns a 403.
@@ -552,18 +553,18 @@ The voting form is the headline use case, but the same pattern composes naturall
 ///       question_text: String,
 ///       _csrf_token: String,
 ///       #[inject] _db: reinhardt::DatabaseConnection,
-///       #[inject] session_user: Depends<SessionUser>,
+///       #[inject] session_user: Depends<Result<User, SessionError>>,
 ///   ) -> std::result::Result<QuestionInfo, ServerFnError> { ... }
 #[server_fn]
 pub async fn create_question(
 	question_text: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<QuestionInfo, ServerFnError> {
 	use crate::apps::polls::models::Question;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 
 	let trimmed = question_text.trim();
 	if trimmed.is_empty() || trimmed.len() > 200 {
@@ -587,36 +588,54 @@ pub async fn create_question(
 }
 ```
 
-`session_user.require_active()?` is the shared 401/403 gate, layered on the `SessionUser` DI factory in `apps::polls::di`. The factory does the "load user_id from session, fetch the row, classify Anonymous / Authenticated / Inactive / Unavailable" dance once per request; each authenticated handler just consumes the result:
+`(*session_user).as_ref().map_err(ServerFnError::from)?` is the shared 401/403/500 gate, layered on the session-user DI factory in `apps::polls::di`. The factory does the "load user_id from session, fetch the row, classify Anonymous / active / Inactive / Unavailable" dance once per request and returns a `Result<User, SessionError>`; each authenticated handler just borrows the result and converts the error via `From<&SessionError>`:
 
 ```rust
 // src/apps/polls/di.rs (extract)
 
-/// Snapshot of the user the current session points at. Carries one of four
-/// states so handlers can decide how to react:
+/// Error variants for the session-based user lookup factory.
 ///
-/// - `Anonymous` — no `user_id` in the session (no cookie / signed out).
-/// - `Authenticated(User)` — user row loaded and `is_active`.
-/// - `Inactive(User)` — user row loaded but `is_active == false`.
-/// - `Unavailable` — the DB lookup itself failed; surfaces a 503 (distinct
-///   from "no user").
+/// Three failure modes are distinguished so handlers can surface the
+/// correct HTTP status *and* so that an operational outage (DB
+/// connection drop, query timeout) does not get silently rewritten into
+/// a fake 401:
 ///
-/// `require_active()` is the convenience accessor every authenticated
-/// mutation calls — it folds the four-way enum into `Result<User, ServerFnError>`
-/// with the appropriate 401 / 403 / 503 codes.
-#[derive(Clone)]
-pub enum SessionUser {
+/// - `Anonymous` — no `user_id` in the session, or the row has been
+///   deleted between login and request. Surfaced as **401** via
+///   `From<&SessionError> for ServerFnError`.
+/// - `Inactive` — a row exists but `is_active = false`. Surfaced as **403**.
+/// - `Unavailable` — the user-lookup query itself failed (DB down, pool
+///   exhausted, schema mismatch, …). Surfaced as **500** so the client sees
+///   an operational error instead of being pushed into a misleading re-auth
+///   loop.
+#[derive(Clone, Debug)]
+pub enum SessionError {
 	Anonymous,
-	Authenticated(User),
-	Inactive(User),
-	Unavailable,
+	Inactive,
+	Unavailable(String),
+}
+
+/// Convert a `SessionError` reference to a `ServerFnError` with the
+/// appropriate HTTP status code.
+///
+/// Handlers use this via `user.as_ref().map_err(ServerFnError::from)?`
+/// to surface a 401, 403, or 500 depending on the failure mode.
+impl From<&SessionError> for ServerFnError {
+	fn from(err: &SessionError) -> Self {
+		match err {
+			SessionError::Anonymous => ServerFnError::server(401, "Authentication required"),
+			SessionError::Inactive => ServerFnError::server(403, "User account is inactive"),
+			SessionError::Unavailable(_) => {
+				ServerFnError::server(500, "User lookup temporarily unavailable")
+			}
+		}
+	}
 }
 
 #[injectable_factory(scope = "request")]
 async fn session_user_factory(
 	#[inject] session: SessionData,
-	#[inject] db: Depends<DatabaseConnection>,
-) -> SessionUser { /* ... */ }
+) -> Result<User, SessionError> { /* ... */ }
 ```
 
 `update_question` and `delete_question` follow the same shape; the only difference is the ownership check after loading the row:
@@ -639,11 +658,11 @@ pub async fn update_question(
 	question_text: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<QuestionInfo, ServerFnError> {
 	use crate::apps::polls::models::Question;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 
 	let question_id: i64 = question_id
 		.parse()
@@ -695,11 +714,11 @@ pub async fn delete_question(
 	question_id: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<(), ServerFnError> {
 	use crate::apps::polls::models::Question;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 
 	let question_id: i64 = question_id
 		.parse()
@@ -855,15 +874,15 @@ pub async fn create_choice(
 	choice_text: String,
 	_csrf_token: String,
 	#[inject] _db: reinhardt::DatabaseConnection,
-	#[inject] session_user: Depends<SessionUser>,
+	#[inject] session_user: Depends<Result<User, SessionError>>,
 ) -> std::result::Result<ChoiceInfo, ServerFnError> {
 	use crate::apps::polls::models::Choice;
 
-	let user = session_user.require_active()?;
+	let user = (*session_user).as_ref().map_err(ServerFnError::from)?;
 	let question_id: i64 = question_id
 		.parse()
 		.map_err(|_| ServerFnError::application("Invalid question_id"))?;
-	let question = require_question_author(question_id, &user).await?;
+	let question = require_question_author(question_id, user).await?;
 
 	let trimmed = choice_text.trim();
 	if trimmed.is_empty() || trimmed.len() > 200 {
@@ -890,7 +909,7 @@ pub async fn create_choice(
 
 Read this top-to-bottom and the layering becomes obvious:
 
-1. `session_user.require_active()?` — authentication, resolved via the `Depends<SessionUser>` DI factory.
+1. `(*session_user).as_ref().map_err(ServerFnError::from)?` — authentication, resolved via the `Depends<Result<User, SessionError>>` DI factory.
 2. `question_id.parse()?` — workaround for the `String`-only ABI.
 3. `require_question_author(question_id, &user).await?` — authorization, *through the parent row*.
 4. Local content validation (length).
@@ -918,7 +937,7 @@ You now have everything Part 4 set out to deliver:
 - DTO field-level validation lives in `src/shared/types.rs`, with `#[dto]` emitting `derive(Validate)` (and OpenAPI `Schema`) behind `cfg(native)` so the WASM bundle stays small.
 - The voting form's metadata + CSRF token are emitted by the `form!` macro itself at expansion time on the client side; the server-only `create_vote_form()` in `src/shared/forms.rs` exists so the same shape can be unit-tested (`test_vote_form_metadata`) without compiling the macro, and the `strip_arguments: { csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token() … }` clause pulls the per-request CSRF token from the page-level helper.
 - The `form!` macro in `src/client/components/polls.rs` declares the UI, dispatches to `submit_vote`, serialises every field as `String`, appends the CSRF token through `strip_arguments`, and surfaces success/error reactively through `state: { loading, error }` and matching `watch` blocks.
-- Question and Choice CUD reuse the same `form!` + `#[server_fn]` shape, composing `session_user.require_active()?` (authentication, via the `Depends<SessionUser>` DI factory) and `require_question_author` (authorization) on top of typed model builders.
+- Question and Choice CUD reuse the same `form!` + `#[server_fn]` shape, composing `(*session_user).as_ref().map_err(ServerFnError::from)?` (authentication, via the `Depends<Result<User, SessionError>>` DI factory) and `require_question_author` (authorization) on top of typed model builders.
 - "Generic views" are not a separate concept in the pages template — they are the page factory functions you already have, glued together with the reactive primitives above.
 
 In the next chapter we put this layer under test: native integration tests with `rstest` + `reinhardt-test` + `sqlx` + `tempfile`, plus a WASM-only target that mocks the server function HTTP calls with MSW.

--- a/website/content/quickstart/tutorials/basis/5-testing.md
+++ b/website/content/quickstart/tutorials/basis/5-testing.md
@@ -342,24 +342,25 @@ Every test in `mod server_fn_tests` that calls `reinitialize_database` carries `
 
 ### Pattern C — authorization tests with no schema
 
-The third module, `auth_tests`, demonstrates that not every native integration test needs a full schema. The CUD `#[server_fn]`s in `apps::polls::server_fn` all start with a `session_user.require_active()?` gate (resolved from the `Depends<SessionUser>` DI factory in `apps::polls::di`); if the session is empty the factory yields `SessionUser::Anonymous` and `require_active()` returns 401 *before* the handler touches the database, so the fixture is an empty SQLite file:
+The third module, `auth_tests`, demonstrates that not every native integration test needs a full schema. The CUD `#[server_fn]`s in `apps::polls::server_fn` all start with a `(*session_user).as_ref().map_err(ServerFnError::from)?` gate (resolved from the `Depends<Result<User, SessionError>>` DI factory in `apps::polls::di`); when the session is empty the factory yields `Err(SessionError::Anonymous)` and the `From<&SessionError> for ServerFnError` conversion returns 401 *before* the handler touches the database, so the fixture is an empty SQLite file:
 
 ```rust
 #[cfg(with_reinhardt)]
 mod auth_tests {
+    use examples_tutorial_basis::apps::polls::di::SessionError;
     use examples_tutorial_basis::apps::polls::server_fn::{
         create_choice, create_question, delete_choice, delete_question, update_choice,
         update_question,
     };
+    use examples_tutorial_basis::apps::users::models::User;
     use reinhardt::DatabaseConnection;
-    use reinhardt::middleware::session::SessionData;
+    use reinhardt::di::Depends;
     use rstest::*;
-    use std::time::Duration;
     use tempfile::NamedTempFile;
 
     /// Fixture: an empty SQLite database + DatabaseConnection wired through
     /// reinhardt-orm. No tables are created; the authorization tests below
-    /// short-circuit on `session_user.require_active()` before any query runs.
+    /// short-circuit on the `SessionError` gate before any query runs.
     #[fixture]
     async fn empty_db_conn() -> (NamedTempFile, DatabaseConnection) {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
@@ -371,11 +372,15 @@ mod auth_tests {
         (temp_file, db_conn)
     }
 
-    /// Empty (anonymous) session — has no `user_id` key, so the
-    /// `SessionUser` DI factory resolves to `SessionUser::Anonymous`
-    /// and every `session_user.require_active()` call rejects it with 401.
-    fn anonymous_session() -> SessionData {
-        SessionData::new(Duration::from_secs(60))
+    /// Anonymous session error wrapped in `Depends<Result<User, SessionError>>`
+    /// — the same value the request-scoped `session_user_factory` in
+    /// `apps::polls::di` would produce for a `SessionData` without a
+    /// `user_id` key. We construct it directly with `Depends::from_value`
+    /// so the test does not need to spin up the middleware stack or the DI
+    /// container; the gate under test is `From<&SessionError> for
+    /// ServerFnError`, not the factory itself.
+    fn anonymous_session_user() -> Depends<Result<User, SessionError>> {
+        Depends::from_value(Err(SessionError::Anonymous))
     }
 
     #[rstest]
@@ -385,14 +390,14 @@ mod auth_tests {
     ) {
         // Arrange
         let (_file, db_conn) = empty_db_conn.await;
-        let session = anonymous_session();
+        let session_user = anonymous_session_user();
 
         // Act
         let result = create_question(
             "Anonymous attempt".to_string(),
             "csrf-token-ignored".to_string(),
             db_conn,
-            session,
+            session_user,
         )
         .await;
 
@@ -405,7 +410,7 @@ mod auth_tests {
 }
 ```
 
-This is the canonical example of a test that follows AAA explicitly: three lines for Arrange, one block for Act, one line for Assert. The named `anonymous_session()` helper hides the only piece of setup shared across all six tests in this module.
+This is the canonical example of a test that follows AAA explicitly: three lines for Arrange, one block for Act, one line for Assert. The named `anonymous_session_user()` helper hides the only piece of setup shared across all six tests in this module.
 
 The `assert_unauthorized` helper near the top of the module shows how to keep brittle string-matching contained:
 
@@ -417,10 +422,11 @@ fn assert_unauthorized<T>(
     let err = result
         .err()
         .unwrap_or_else(|| panic!("{} should reject anonymous callers", operation));
-    // The `SessionUser::require_active()` gate emits
-    // `ServerFnError::server(401, ...)`. We match on the rendered Display
-    // because ServerFnError does not expose the inner status as a typed
-    // accessor in the public API.
+    // The `From<&SessionError>` impl emits
+    // `ServerFnError::server(401, ...)`. We match on the Debug-formatted
+    // output because `ServerFnError` does not expose the inner status as
+    // a typed accessor in the public API, and its `Debug` impl is the
+    // most stable representation that includes the numeric status.
     let rendered = format!("{:?}", err);
     assert!(
         rendered.contains("401") || rendered.contains("Authentication required"),
@@ -635,7 +641,7 @@ A few things from earlier drafts of this chapter are intentionally absent:
 You now have three concentric rings of test coverage:
 
 1. **Inline `#[rstest]` blocks** for the small things — typestate builders, form metadata, anything pure-Rust that does not need a database. They live in the same file as the code, and `cargo make test-unit` runs them.
-2. **`tests/integration.rs`** for the things that need state — raw `sqlx` for full schema control, the reinhardt ORM via `DatabaseConnection::connect_sqlite` for real `#[server_fn]` invocation, `serial_test` to serialise tests that touch `reinitialize_database` or any other process-global, and a deliberately schema-less module for the `SessionUser` DI factory's 401 gate. `cargo make test` and `cargo make test-integration` run it.
+2. **`tests/integration.rs`** for the things that need state — raw `sqlx` for full schema control, the reinhardt ORM via `DatabaseConnection::connect_sqlite` for real `#[server_fn]` invocation, `serial_test` to serialise tests that touch `reinitialize_database` or any other process-global, and a deliberately schema-less module for the session-user DI factory's 401 gate (the `From<&SessionError>` conversion on an `Err(SessionError::Anonymous)`). `cargo make test` and `cargo make test-integration` run it.
 3. **`tests/wasm/polls_mock_test.rs`** for the typed client stubs — MSW intercepts the `window.fetch()` call from `get_questions` / `get_question_detail` / `get_question_results` / `vote`, the test asserts on the typed return value, and the polls components are mounted in headless Chrome to confirm they construct without panicking. `cargo make wasm-test` runs it.
 
 If you change a server function signature, the native integration tests notice. If you change a DTO field, the WASM mock tests notice. If you change a typestate builder field, the in-file unit tests notice. Each ring catches a different class of regression, and the `Cargo.toml` feature flags make sure they only ever compile for the target they belong to.

--- a/website/content/quickstart/tutorials/basis/_index.md
+++ b/website/content/quickstart/tutorials/basis/_index.md
@@ -87,7 +87,7 @@ examples-tutorial-basis/
 │   │   │   ├── admin.rs       # #[admin(model, for = Question, …)] QuestionAdmin / ChoiceAdmin
 │   │   │   └── serializers.rs # QuestionSerializer / ChoiceSerializer with #[validate(...)]
 │   │   └── users/
-│   │       ├── models.rs      # #[user(...)] + #[model] User + project-local UserManager (#[injectable_factory])
+│   │       ├── models.rs      # #[user(...)] + #[model] User + project-local AuthUserManager (#[injectable_factory])
 │   │       ├── server_fn.rs   # #[server_fn] login / register / logout / current_user (session cookie based)
 │   │       └── urls/          # server_urls.rs (empty router) + client_router.rs (login / logout / signup pages)
 │   └── client/                # WASM-only UI layer (declared in crate root via `pub mod client;` under cfg)
@@ -119,7 +119,7 @@ Three rules keep this structure predictable:
 ### [Part 2: Models and Database](2-models-and-database/)
 
 - Define `Question` and `Choice` under `src/apps/polls/models.rs` with `#[model(app_label = "polls", table_name = "...")]`, using `#[field(...)]` and `#[rel(foreign_key, related_name = "...")]` to wire `Question.author -> User` and `Choice.question -> Question`
-- Introduce the `users` app and the `User` model defined with `#[user(hasher = Argon2Hasher, username_field = "username", manager = false)] + #[model(...)]`, plus a project-local `UserManager` registered via `#[injectable_factory(scope = "transient")]`
+- Introduce the `users` app and the `User` model defined with `#[user(hasher = Argon2Hasher, username_field = "username", manager = false)] + #[model(...)]`, plus a project-local `AuthUserManager` registered via `#[injectable_factory(scope = "transient")]`
 - Register both apps in `src/config/apps.rs` via `installed_apps! { polls: "polls", users: "users" }`
 - Generate and apply migrations with `cargo make makemigrations` and `cargo make migrate`
 


### PR DESCRIPTION
## Summary

develop/0.2.0 counterpart of #4952. Same refactor, adapted for the typed-builder filter syntax already on develop (`.filter(User::field_id().eq(user_id))`).

- Replace the hand-rolled `SessionUser` enum with `Result<User, SessionError>` as the `session_user_factory` return type. The `Result` wrapper preserves `User`'s trait implementations inside `Ok(user)` while keeping a **distinct `TypeId`** from `User` for the DI registry key. Error states move to a dedicated `SessionError` enum that converts to `ServerFnError` via `From<&SessionError>` (replacing the previous `require_active()` method).
- Rename the project-local `BaseUserManager<User>` implementation `UserManager` → `AuthUserManager` to avoid confusion with `User::objects()` (the ORM manager from `#[model]`).

## Type of Change

- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Motivation and Context

The previous `SessionUser` enum and `UserManager` struct were "internal" types that lost the original `User` type's trait implementations and risked naming collisions:

1. **`SessionUser` → `Result<User, SessionError>`**: A type alias would share `User`'s `TypeId`, conflicting with the DI registry (which uses `TypeId` as the sole key). A newtype would lose `User`'s trait impls. `Result<User, SessionError>` solves both: distinct `TypeId`, preserved trait impls inside `Ok`.
2. **`UserManager` → `AuthUserManager`**: disambiguates the auth-lifecycle manager from the ORM `objects()` manager.

Related to: #4937 (proposes `DependsResult<T, E>` sugar for the verbose `Depends<Result<T, E>>`)

## How Was This Tested?

- `cargo check --workspace --all-features` (examples workspace, local patch): passes
- `cargo make fmt-check`: passes
- `cargo make clippy-check`: passes
- `examples-tutorial-basis` lib + integration tests compile cleanly; the 6 `auth_tests` updated to use `Err(SessionError::Anonymous)` and the `From<&SessionError>` 401 gate

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Refs #4937
- develop/0.2.0 counterpart of #4952

## Labels to Apply

### Type Label
- [x] `refactoring` - Code refactoring

### Scope Label
- [x] `auth` - Authentication, authorization, sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved session authentication with distinct error handling for anonymous, inactive, and unavailable user states.
  * Renamed authentication manager throughout codebase for enhanced clarity and intent.

* **Documentation**
  * Comprehensive updates to tutorials, examples, and integration tests reflecting the refined authentication approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->