### PR TITLE
fix(views): route generic queryset fallback through objects

### DIFF
--- a/crates/reinhardt-views/src/generic.rs
+++ b/crates/reinhardt-views/src/generic.rs
@@ -17,6 +17,13 @@
 //! - [`RetrieveDestroyAPIView`] - Retrieve and delete (GET, DELETE)
 //! - [`RetrieveUpdateDestroyAPIView`] - Full CRUD except list (GET, PUT, PATCH, DELETE)
 //!
+//! # QuerySet Defaults
+//!
+//! Generic views use an explicitly configured queryset when `.with_queryset(...)`
+//! is provided. Without an explicit queryset, they start from
+//! `Model::objects().all()` so model-level custom manager filters apply to list
+//! and lookup paths.
+//!
 //! # Examples
 //!
 //! ```rust,no_run
@@ -63,6 +70,8 @@ mod destroy_api;
 mod list_api;
 pub(crate) mod patch_utils;
 mod retrieve_api;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod update_api;
 
 // Re-export all API views

--- a/crates/reinhardt-views/src/generic/composite.rs
+++ b/crates/reinhardt-views/src/generic/composite.rs
@@ -113,7 +113,7 @@ where
 
 	/// Gets the queryset, creating a default one if not set
 	fn get_queryset(&self) -> QuerySet<M> {
-		self.queryset.clone().unwrap_or_default()
+		self.queryset.clone().unwrap_or_else(|| M::objects().all())
 	}
 
 	/// Builds a filtered queryset with ordering applied, before pagination.
@@ -404,7 +404,7 @@ where
 
 	/// Gets the queryset, creating a default one if not set
 	fn get_queryset(&self) -> QuerySet<M> {
-		self.queryset.clone().unwrap_or_default()
+		self.queryset.clone().unwrap_or_else(|| M::objects().all())
 	}
 
 	/// Gets a single object by lookup field value from request path params
@@ -605,7 +605,7 @@ where
 
 	/// Gets the queryset, creating a default one if not set
 	fn get_queryset(&self) -> QuerySet<M> {
-		self.queryset.clone().unwrap_or_default()
+		self.queryset.clone().unwrap_or_else(|| M::objects().all())
 	}
 
 	/// Gets a single object by lookup field value from request path params
@@ -748,7 +748,7 @@ where
 
 	/// Gets the queryset, creating a default one if not set
 	fn get_queryset(&self) -> QuerySet<M> {
-		self.queryset.clone().unwrap_or_default()
+		self.queryset.clone().unwrap_or_else(|| M::objects().all())
 	}
 
 	/// Gets a single object by lookup field value from request path params
@@ -787,6 +787,62 @@ where
 {
 	fn default() -> Self {
 		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::generic::test_support::{
+		ManagedArticle, assert_default_manager_queryset, assert_explicit_queryset,
+		explicit_queryset,
+	};
+	use reinhardt_rest::serializers::JsonSerializer;
+
+	#[test]
+	fn list_create_default_queryset_uses_model_objects() {
+		let view = ListCreateAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new();
+
+		assert_default_manager_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn list_create_explicit_queryset_overrides_model_objects() {
+		let view = ListCreateAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new()
+			.with_queryset(explicit_queryset());
+
+		assert_explicit_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn retrieve_update_default_queryset_uses_model_objects() {
+		let view = RetrieveUpdateAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new();
+
+		assert_default_manager_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn retrieve_destroy_default_queryset_uses_model_objects() {
+		let view = RetrieveDestroyAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new();
+
+		assert_default_manager_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn retrieve_update_destroy_default_queryset_uses_model_objects() {
+		let view =
+			RetrieveUpdateDestroyAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new();
+
+		assert_default_manager_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn retrieve_update_destroy_explicit_queryset_overrides_model_objects() {
+		let view =
+			RetrieveUpdateDestroyAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new()
+				.with_queryset(explicit_queryset());
+
+		assert_explicit_queryset(view.get_queryset());
 	}
 }
 

--- a/crates/reinhardt-views/src/generic/composite.rs
+++ b/crates/reinhardt-views/src/generic/composite.rs
@@ -822,10 +822,26 @@ mod tests {
 	}
 
 	#[test]
+	fn retrieve_update_explicit_queryset_overrides_model_objects() {
+		let view = RetrieveUpdateAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new()
+			.with_queryset(explicit_queryset());
+
+		assert_explicit_queryset(view.get_queryset());
+	}
+
+	#[test]
 	fn retrieve_destroy_default_queryset_uses_model_objects() {
 		let view = RetrieveDestroyAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new();
 
 		assert_default_manager_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn retrieve_destroy_explicit_queryset_overrides_model_objects() {
+		let view = RetrieveDestroyAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new()
+			.with_queryset(explicit_queryset());
+
+		assert_explicit_queryset(view.get_queryset());
 	}
 
 	#[test]

--- a/crates/reinhardt-views/src/generic/create_api.rs
+++ b/crates/reinhardt-views/src/generic/create_api.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use hyper::Method;
 use reinhardt_core::exception::{Error, Result};
-use reinhardt_db::orm::{Model, QuerySet};
+use reinhardt_db::orm::{CustomManager, Model, QuerySet};
 use reinhardt_http::{Request, Response};
 use reinhardt_rest::serializers::{Serializer, ValidatorConfig};
 use serde::{Deserialize, Serialize};
@@ -116,7 +116,7 @@ where
 
 	/// Gets the queryset, creating a default one if not set
 	fn get_queryset(&self) -> QuerySet<M> {
-		self.queryset.clone().unwrap_or_default()
+		self.queryset.clone().unwrap_or_else(|| M::objects().all())
 	}
 
 	/// Sets the validation configuration
@@ -194,6 +194,31 @@ where
 {
 	fn default() -> Self {
 		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::generic::test_support::{
+		ManagedArticle, assert_default_manager_queryset, assert_explicit_queryset,
+		explicit_queryset,
+	};
+	use reinhardt_rest::serializers::JsonSerializer;
+
+	#[test]
+	fn default_queryset_uses_model_objects() {
+		let view = CreateAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new();
+
+		assert_default_manager_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn explicit_queryset_overrides_model_objects() {
+		let view = CreateAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new()
+			.with_queryset(explicit_queryset());
+
+		assert_explicit_queryset(view.get_queryset());
 	}
 }
 

--- a/crates/reinhardt-views/src/generic/destroy_api.rs
+++ b/crates/reinhardt-views/src/generic/destroy_api.rs
@@ -144,7 +144,7 @@ where
 
 	/// Gets the queryset, creating a default one if not set
 	fn get_queryset(&self) -> QuerySet<M> {
-		self.queryset.clone().unwrap_or_default()
+		self.queryset.clone().unwrap_or_else(|| M::objects().all())
 	}
 
 	/// Retrieves the object to delete by lookup field value from request path params
@@ -203,6 +203,29 @@ where
 {
 	fn default() -> Self {
 		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::generic::test_support::{
+		ManagedArticle, assert_default_manager_queryset, assert_explicit_queryset,
+		explicit_queryset,
+	};
+
+	#[test]
+	fn default_queryset_uses_model_objects() {
+		let view = DestroyAPIView::<ManagedArticle>::new();
+
+		assert_default_manager_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn explicit_queryset_overrides_model_objects() {
+		let view = DestroyAPIView::<ManagedArticle>::new().with_queryset(explicit_queryset());
+
+		assert_explicit_queryset(view.get_queryset());
 	}
 }
 

--- a/crates/reinhardt-views/src/generic/list_api.rs
+++ b/crates/reinhardt-views/src/generic/list_api.rs
@@ -4,7 +4,7 @@ use crate::viewsets::{FilterConfig, PaginationConfig};
 use async_trait::async_trait;
 use hyper::Method;
 use reinhardt_core::exception::{Error, Result};
-use reinhardt_db::orm::{Filter, FilterOperator, FilterValue, Model, QuerySet};
+use reinhardt_db::orm::{CustomManager, Filter, FilterOperator, FilterValue, Model, QuerySet};
 use reinhardt_http::{Request, Response};
 use reinhardt_rest::serializers::Serializer;
 use serde::{Deserialize, Serialize};
@@ -266,7 +266,7 @@ where
 
 	/// Gets the queryset, creating a default one if not set
 	fn get_queryset(&self) -> QuerySet<M> {
-		self.queryset.clone().unwrap_or_default()
+		self.queryset.clone().unwrap_or_else(|| M::objects().all())
 	}
 
 	/// Builds a filtered queryset with ordering applied, before pagination.
@@ -349,6 +349,31 @@ where
 {
 	fn default() -> Self {
 		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::generic::test_support::{
+		ManagedArticle, assert_default_manager_queryset, assert_explicit_queryset,
+		explicit_queryset,
+	};
+	use reinhardt_rest::serializers::JsonSerializer;
+
+	#[test]
+	fn default_queryset_uses_model_objects() {
+		let view = ListAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new();
+
+		assert_default_manager_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn explicit_queryset_overrides_model_objects() {
+		let view = ListAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new()
+			.with_queryset(explicit_queryset());
+
+		assert_explicit_queryset(view.get_queryset());
 	}
 }
 

--- a/crates/reinhardt-views/src/generic/retrieve_api.rs
+++ b/crates/reinhardt-views/src/generic/retrieve_api.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use hyper::Method;
 use reinhardt_core::exception::{Error, Result};
-use reinhardt_db::orm::{Filter, FilterOperator, FilterValue, Model, QuerySet};
+use reinhardt_db::orm::{CustomManager, Filter, FilterOperator, FilterValue, Model, QuerySet};
 use reinhardt_http::{Request, Response};
 use reinhardt_rest::serializers::Serializer;
 use serde::{Deserialize, Serialize};
@@ -151,7 +151,7 @@ where
 
 	/// Gets the queryset, creating a default one if not set
 	fn get_queryset(&self) -> QuerySet<M> {
-		self.queryset.clone().unwrap_or_default()
+		self.queryset.clone().unwrap_or_else(|| M::objects().all())
 	}
 
 	/// Gets a single object by lookup field value from request path params
@@ -190,6 +190,31 @@ where
 {
 	fn default() -> Self {
 		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod queryset_tests {
+	use super::*;
+	use crate::generic::test_support::{
+		ManagedArticle, assert_default_manager_queryset, assert_explicit_queryset,
+		explicit_queryset,
+	};
+	use reinhardt_rest::serializers::JsonSerializer;
+
+	#[test]
+	fn default_queryset_uses_model_objects() {
+		let view = RetrieveAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new();
+
+		assert_default_manager_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn explicit_queryset_overrides_model_objects() {
+		let view = RetrieveAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new()
+			.with_queryset(explicit_queryset());
+
+		assert_explicit_queryset(view.get_queryset());
 	}
 }
 

--- a/crates/reinhardt-views/src/generic/test_support.rs
+++ b/crates/reinhardt-views/src/generic/test_support.rs
@@ -1,0 +1,96 @@
+use reinhardt_db::orm::{
+	CustomManager, FieldSelector, Filter, FilterOperator, FilterValue, Manager, Model, QuerySet,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ManagedArticle {
+	pub(crate) id: Option<i64>,
+	pub(crate) title: String,
+	pub(crate) is_archived: bool,
+	pub(crate) tenant_id: i64,
+}
+
+#[derive(Clone)]
+pub(crate) struct ManagedArticleFields;
+
+impl FieldSelector for ManagedArticleFields {
+	fn with_alias(self, _alias: &str) -> Self {
+		self
+	}
+}
+
+impl Model for ManagedArticle {
+	type PrimaryKey = i64;
+	type Fields = ManagedArticleFields;
+	type Objects = VisibleArticleManager;
+
+	fn table_name() -> &'static str {
+		"managed_articles"
+	}
+
+	fn primary_key(&self) -> Option<Self::PrimaryKey> {
+		self.id
+	}
+
+	fn set_primary_key(&mut self, value: Self::PrimaryKey) {
+		self.id = Some(value);
+	}
+
+	fn new_fields() -> Self::Fields {
+		ManagedArticleFields
+	}
+}
+
+#[derive(Default)]
+pub(crate) struct VisibleArticleManager;
+
+impl CustomManager for VisibleArticleManager {
+	type Model = ManagedArticle;
+
+	fn new() -> Self {
+		Self
+	}
+
+	fn all(&self) -> QuerySet<ManagedArticle> {
+		Manager::<ManagedArticle>::new().all().filter(Filter::new(
+			"is_archived",
+			FilterOperator::Eq,
+			FilterValue::Boolean(false),
+		))
+	}
+}
+
+pub(crate) fn explicit_queryset() -> QuerySet<ManagedArticle> {
+	QuerySet::<ManagedArticle>::new().filter(Filter::new(
+		"tenant_id",
+		FilterOperator::Eq,
+		FilterValue::Integer(42),
+	))
+}
+
+pub(crate) fn assert_default_manager_queryset(queryset: QuerySet<ManagedArticle>) {
+	let filters = queryset.filters();
+	assert_eq!(filters.len(), 1);
+	assert_eq!(filters[0].field, "is_archived");
+
+	let debug = format!("{:?}", filters[0]);
+	assert!(debug.contains("Eq"), "expected Eq operator, got: {debug}");
+	assert!(
+		debug.contains("Boolean(false)"),
+		"expected Boolean(false) value, got: {debug}"
+	);
+}
+
+pub(crate) fn assert_explicit_queryset(queryset: QuerySet<ManagedArticle>) {
+	let filters = queryset.filters();
+	assert_eq!(filters.len(), 1);
+	assert_eq!(filters[0].field, "tenant_id");
+
+	let debug = format!("{:?}", filters[0]);
+	assert!(debug.contains("Eq"), "expected Eq operator, got: {debug}");
+	assert!(
+		debug.contains("Integer(42)"),
+		"expected Integer(42) value, got: {debug}"
+	);
+}

--- a/crates/reinhardt-views/src/generic/test_support.rs
+++ b/crates/reinhardt-views/src/generic/test_support.rs
@@ -74,11 +74,15 @@ pub(crate) fn assert_default_manager_queryset(queryset: QuerySet<ManagedArticle>
 	assert_eq!(filters.len(), 1);
 	assert_eq!(filters[0].field, "is_archived");
 
-	let debug = format!("{:?}", filters[0]);
-	assert!(debug.contains("Eq"), "expected Eq operator, got: {debug}");
 	assert!(
-		debug.contains("Boolean(false)"),
-		"expected Boolean(false) value, got: {debug}"
+		matches!(filters[0].operator, FilterOperator::Eq),
+		"expected Eq operator, got: {:?}",
+		filters[0].operator
+	);
+	assert!(
+		matches!(filters[0].value, FilterValue::Boolean(false)),
+		"expected Boolean(false) value, got: {:?}",
+		filters[0].value
 	);
 }
 
@@ -87,10 +91,14 @@ pub(crate) fn assert_explicit_queryset(queryset: QuerySet<ManagedArticle>) {
 	assert_eq!(filters.len(), 1);
 	assert_eq!(filters[0].field, "tenant_id");
 
-	let debug = format!("{:?}", filters[0]);
-	assert!(debug.contains("Eq"), "expected Eq operator, got: {debug}");
 	assert!(
-		debug.contains("Integer(42)"),
-		"expected Integer(42) value, got: {debug}"
+		matches!(filters[0].operator, FilterOperator::Eq),
+		"expected Eq operator, got: {:?}",
+		filters[0].operator
+	);
+	assert!(
+		matches!(filters[0].value, FilterValue::Integer(42)),
+		"expected Integer(42) value, got: {:?}",
+		filters[0].value
 	);
 }

--- a/crates/reinhardt-views/src/generic/update_api.rs
+++ b/crates/reinhardt-views/src/generic/update_api.rs
@@ -160,7 +160,7 @@ where
 
 	/// Gets the queryset, creating a default one if not set
 	fn get_queryset(&self) -> QuerySet<M> {
-		self.queryset.clone().unwrap_or_default()
+		self.queryset.clone().unwrap_or_else(|| M::objects().all())
 	}
 
 	/// Retrieves the object to update by lookup field value from request path params
@@ -255,6 +255,31 @@ where
 {
 	fn default() -> Self {
 		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::generic::test_support::{
+		ManagedArticle, assert_default_manager_queryset, assert_explicit_queryset,
+		explicit_queryset,
+	};
+	use reinhardt_rest::serializers::JsonSerializer;
+
+	#[test]
+	fn default_queryset_uses_model_objects() {
+		let view = UpdateAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new();
+
+		assert_default_manager_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn explicit_queryset_overrides_model_objects() {
+		let view = UpdateAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new()
+			.with_queryset(explicit_queryset());
+
+		assert_explicit_queryset(view.get_queryset());
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Generic API view default querysets now start from `Model::objects().all()` instead of an empty `QuerySet`.
- Explicit `.with_queryset(...)` still fully overrides the model custom manager queryset.
- Unit coverage now verifies custom-manager default filters and explicit queryset override behavior across generic views.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Generic views previously fell back to `QuerySet::default()` when no explicit queryset was configured, bypassing filters supplied by `Model::objects()` custom managers on list and lookup paths.

Fixes #4876
Fixes #4877

Related to: #4874

## How Was This Tested?

- [x] `cargo test -p reinhardt-views default_queryset_uses_model_objects --lib`
- [x] `cargo test -p reinhardt-views explicit_queryset --lib`
- [x] `cargo test -p reinhardt-views --test generic_views`
- [x] `cargo check -p reinhardt-views --all-features`
- [x] `cargo test -p reinhardt-views --lib`
- [x] `cargo fmt --all --check`
- [x] `git diff --check`

`cargo make fmt-check` was attempted, but local concurrent `reinhardt-admin-cli fmt-all` runs from other worktrees caused the local cargo-make/direct formatter command to terminate before producing a formatter result. The Rust formatting check above passed for this branch.

## Performance Impact

Not performance-related. The fallback creates the same kind of lazy `QuerySet`, but now from the model's default manager.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #4876
- #4877
- #4874

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

🤖 Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently default generic API views to use the model’s manager queryset when no explicit queryset is provided.

* **Tests**
  * Added comprehensive unit tests covering default manager queryset and explicit queryset overrides for all generic view types; included shared test support utilities.

* **Documentation**
  * Added module-level guidance describing default queryset selection behavior.

* **Refactor**
  * Standardized queryset initialization logic across generic views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->