### PR TITLE
style(examples): fix twitter fmt drift blocking Format Check

### DIFF
--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -626,11 +626,17 @@ pub fn theme_toggle() -> Page {
 ///
 /// Displays an empty div (useful for conditional rendering).
 pub fn empty() -> Page {
-	page!(|| { div {} })()
+	page!(|| {
+		div {}
+	})()
 }
 /// Divider component
 pub fn divider() -> Page {
-	page!(|| { div { class: "divider" } })()
+	page!(|| {
+		div {
+			class: "divider"
+		}
+	})()
 }
 /// Badge component
 pub fn badge(text: &str, primary: bool) -> Page {

--- a/examples/examples-twitter/src/core/client/components/layout.rs
+++ b/examples/examples-twitter/src/core/client/components/layout.rs
@@ -95,9 +95,7 @@ pub fn header(site_name: &str, current_user: Option<&UserInfo>, nav_items: &[Nav
 		})
 		.collect();
 	let nav_links_view = page!(|nav_links: Vec<Page>| {
-		for link in nav_links {
-			{ link }
-		}
+		for link in nav_links { { link } }
 	})(nav_links);
 	let brand_link = Link::new("/".to_string(), site_name.to_string())
 		.class("text-xl font-bold text-content-primary hover:text-brand transition-colors")
@@ -207,9 +205,7 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|topics_list: Vec<Page>| {
-			for topic in topics_list {
-				{ topic }
-			}
+			for topic in topics_list { { topic } }
 		})(topics_list)
 	};
 	let users_list: Vec<Page> = suggested_users
@@ -274,9 +270,7 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|users_list: Vec<Page>| {
-			for user in users_list {
-				{ user }
-			}
+			for user in users_list { { user } }
 		})(users_list)
 	};
 	page!(|topics_view: Page, users_view: Page| {


### PR DESCRIPTION
## Summary

Fixes the GATING CI Format Check (`cargo run -p reinhardt-admin-cli -- fmt-all --check`)
on `develop/0.2.0`. Two files were left in a format produced by a stale
`reinhardt-admin-cli` version; the rc.2 CLI built from current develop source
reports them as needing reformatting:

- `examples/examples-twitter/src/core/client/components/layout.rs`
- `examples/examples-twitter/src/core/client/components/common.rs`

Reformatted with the current develop CLI (`fmt-all` reports `0 would be
formatted` afterward).

## Type of Change

- [x] Bug fix (CI / formatting)

## Breaking Change Assessment

- [x] No

## Motivation and Context

The Format Check is a gating job: when it fails, downstream jobs (Intra-Crate
Integration Tests, etc.) are SKIPPED. This drift blocked Format Check on every
open PR targeting develop/0.2.0 (#4953, #4959, #4960, #4974) and the release
PR #4933. This is the documented "reinhardt-admin fmt version skew" issue —
fmt must be run with the CLI built from current develop source.

## How Was This Tested

- `cargo run -p reinhardt-admin-cli -- fmt-all --check` → `0 would be formatted, 0 errors`

## Checklist

- [x] Formatting-only change (no logic)
- [x] Verified clean against current develop reinhardt-admin-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted UI component implementations for improved code consistency.

* **Refactor**
  * Simplified internal loop syntax in navigation and sidebar components.

**Note:** No changes to user-facing functionality or component output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->