### PR TITLE
test(views): cover manager filters in generic list paths

### DIFF
--- a/crates/reinhardt-views/src/generic/composite.rs
+++ b/crates/reinhardt-views/src/generic/composite.rs
@@ -795,7 +795,7 @@ mod tests {
 	use super::*;
 	use crate::generic::test_support::{
 		ManagedArticle, assert_default_manager_queryset, assert_explicit_queryset,
-		explicit_queryset,
+		assert_manager_and_request_filters, explicit_queryset,
 	};
 	use reinhardt_rest::serializers::JsonSerializer;
 
@@ -812,6 +812,19 @@ mod tests {
 			.with_queryset(explicit_queryset());
 
 		assert_explicit_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn list_create_filtered_queryset_preserves_model_objects_filters() {
+		let request = Request::builder()
+			.method(Method::GET)
+			.uri("/managed-articles?tenant_id=7")
+			.build()
+			.unwrap();
+		let view = ListCreateAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new()
+			.with_filter_config(FilterConfig::new().with_filterable_fields(vec!["tenant_id"]));
+
+		assert_manager_and_request_filters(view.get_filtered_queryset(&request));
 	}
 
 	#[test]

--- a/crates/reinhardt-views/src/generic/list_api.rs
+++ b/crates/reinhardt-views/src/generic/list_api.rs
@@ -357,7 +357,7 @@ mod tests {
 	use super::*;
 	use crate::generic::test_support::{
 		ManagedArticle, assert_default_manager_queryset, assert_explicit_queryset,
-		explicit_queryset,
+		assert_manager_and_request_filters, explicit_queryset,
 	};
 	use reinhardt_rest::serializers::JsonSerializer;
 
@@ -374,6 +374,19 @@ mod tests {
 			.with_queryset(explicit_queryset());
 
 		assert_explicit_queryset(view.get_queryset());
+	}
+
+	#[test]
+	fn filtered_queryset_preserves_model_objects_filters() {
+		let request = Request::builder()
+			.method(Method::GET)
+			.uri("/managed-articles?tenant_id=7")
+			.build()
+			.unwrap();
+		let view = ListAPIView::<ManagedArticle, JsonSerializer<ManagedArticle>>::new()
+			.with_filter_config(FilterConfig::new().with_filterable_fields(vec!["tenant_id"]));
+
+		assert_manager_and_request_filters(view.get_filtered_queryset(&request));
 	}
 }
 

--- a/crates/reinhardt-views/src/generic/test_support.rs
+++ b/crates/reinhardt-views/src/generic/test_support.rs
@@ -94,3 +94,22 @@ pub(crate) fn assert_explicit_queryset(queryset: QuerySet<ManagedArticle>) {
 		"expected Integer(42) value, got: {debug}"
 	);
 }
+
+pub(crate) fn assert_manager_and_request_filters(queryset: QuerySet<ManagedArticle>) {
+	let filters = queryset.filters();
+	assert_eq!(filters.len(), 2);
+	assert_eq!(filters[0].field, "is_archived");
+	assert_eq!(filters[1].field, "tenant_id");
+
+	let manager_debug = format!("{:?}", filters[0]);
+	assert!(
+		manager_debug.contains("Boolean(false)"),
+		"expected manager filter value Boolean(false), got: {manager_debug}"
+	);
+
+	let request_debug = format!("{:?}", filters[1]);
+	assert!(
+		request_debug.contains("String(\"7\")"),
+		"expected request filter value String(\"7\"), got: {request_debug}"
+	);
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- Adds stacked test coverage for the generic list filtering path introduced in #4975.
- Verifies `ListAPIView` and `ListCreateAPIView` preserve `Model::objects().all()` manager filters when request query filters are applied.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] Other (please describe): test coverage

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Issue #4877 depends on generic list views consistently using the model manager queryset even after request-level filters are applied.
- This PR is stacked on #4975 and adds focused regression coverage for that behavior.

Fixes: none (test coverage only)

Related to: #4877, #4975

## How Was This Tested?

- `cargo test -p reinhardt-views filtered_queryset_preserves_model_objects_filters --lib`
- `cargo test -p reinhardt-views --lib`
- `cargo fmt --all --check`
- `git diff --check`

## Performance Impact

- Not performance-related; tests only.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage (AWS Spot instances),
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #4877
- Stacked on #4975

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)

- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- This PR intentionally targets `feature/issue-4876-to-4877-view-queryset-objects` so reviewers can see the focused regression coverage separately from the implementation in #4975.

🤖 Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for list/filtering behavior to ensure request query filters are correctly combined with existing manager-applied filters.
  * Added a test helper to assert the order and presence of both manager and request-derived filters, and new tests that validate this combined filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->