### PR TITLE
fix(di): resolve DependsResult macro injection

### DIFF
--- a/crates/reinhardt-core/macros/src/routes_registration.rs
+++ b/crates/reinhardt-core/macros/src/routes_registration.rs
@@ -158,23 +158,48 @@ fn is_inject_attr(attr: &syn::Attribute) -> bool {
 	attr.path().is_ident("inject")
 }
 
-/// Extract the inner type `T` from `Depends<T>`.
+/// Extract the inner type from a Depends-family wrapper.
 ///
-/// Returns `Some(T)` if the type is `Depends<T>`, `None` otherwise.
+/// Recognises three shapes and returns the type that should be passed to
+/// `Depends::<...>::resolve_from_registry`:
+///
+/// - `Depends<T>` → `T`
+/// - `DependsResult<T, E>` → `Result<T, E>`
+/// - `DependsOption<T>` → `Option<T>`
+///
 /// A sibling copy lives in `crates/reinhardt-pages/macros/src/server_fn.rs`;
 /// the two proc-macro crates cannot share code directly, so keep both copies
 /// in sync.
-pub(crate) fn extract_depends_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
-	if let syn::Type::Path(type_path) = ty {
-		let last_segment = type_path.path.segments.last()?;
-		if last_segment.ident == "Depends"
-			&& let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
-			&& args.args.len() == 1
-			&& let syn::GenericArgument::Type(inner) = args.args.first()?
-		{
-			return Some(inner);
-		}
+pub(crate) fn extract_depends_inner_type(ty: &syn::Type) -> Option<syn::Type> {
+	let syn::Type::Path(type_path) = ty else {
+		return None;
+	};
+	let last_segment = type_path.path.segments.last()?;
+	let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments else {
+		return None;
+	};
+
+	if last_segment.ident == "Depends"
+		&& args.args.len() == 1
+		&& let syn::GenericArgument::Type(inner) = args.args.first()?
+	{
+		return Some(inner.clone());
 	}
+
+	if last_segment.ident == "DependsResult" && args.args.len() == 2 {
+		let mut iter = args.args.iter();
+		let t = iter.next()?;
+		let e = iter.next()?;
+		return Some(syn::parse_quote! { ::core::result::Result<#t, #e> });
+	}
+
+	if last_segment.ident == "DependsOption"
+		&& args.args.len() == 1
+		&& let Some(t) = args.args.first()
+	{
+		return Some(syn::parse_quote! { ::core::option::Option<#t> });
+	}
+
 	None
 }
 

--- a/crates/reinhardt-di/macros/src/injectable.rs
+++ b/crates/reinhardt-di/macros/src/injectable.rs
@@ -40,6 +40,11 @@ enum InjectionType {
 	Depends(Type),
 	/// `Option<Depends<T>>` - optional dependency (preferred)
 	OptionalDepends(Type),
+	/// `DependsResult<T, E>` / `DependsOption<T>` - factory-produced inner type
+	/// (`Result<T, E>` / `Option<T>`) resolved from the registry only. These
+	/// inner types are produced by `#[injectable_factory]` and never implement
+	/// `Injectable`, so resolution must NOT require `T: Injectable`.
+	DependsFromRegistry(Type),
 }
 
 /// Check whether a type path likely originates from the `reinhardt_di` crate.
@@ -120,7 +125,9 @@ fn classify_injection_type(ty: &Type) -> Option<InjectionType> {
 			return Some(InjectionType::Depends(inner_ty.clone()));
 		}
 
-		// Check for DependsResult<T, E> (sugar for Depends<Result<T, E>>)
+		// Check for DependsResult<T, E> (sugar for Depends<Result<T, E>>).
+		// The inner Result<T, E> is factory-produced and never Injectable, so
+		// it must resolve from the registry only (DependsFromRegistry).
 		if ident == "DependsResult"
 			&& is_likely_reinhardt_di_path(segments)
 			&& let PathArguments::AngleBracketed(args) = &last_segment.arguments
@@ -130,17 +137,19 @@ fn classify_injection_type(ty: &Type) -> Option<InjectionType> {
 			let t = iter.next()?;
 			let e = iter.next()?;
 			let inner: Type = syn::parse_quote! { ::core::result::Result<#t, #e> };
-			return Some(InjectionType::Depends(inner));
+			return Some(InjectionType::DependsFromRegistry(inner));
 		}
 
-		// Check for DependsOption<T> (sugar for Depends<Option<T>>)
+		// Check for DependsOption<T> (sugar for Depends<Option<T>>).
+		// The inner Option<T> is factory-produced and never Injectable, so
+		// it must resolve from the registry only (DependsFromRegistry).
 		if ident == "DependsOption"
 			&& is_likely_reinhardt_di_path(segments)
 			&& let PathArguments::AngleBracketed(args) = &last_segment.arguments
 			&& let Some(GenericArgument::Type(inner_ty)) = args.args.first()
 		{
 			let inner: Type = syn::parse_quote! { ::core::option::Option<#inner_ty> };
-			return Some(InjectionType::Depends(inner));
+			return Some(InjectionType::DependsFromRegistry(inner));
 		}
 
 		// Check for Option<Injected<T>> or Option<Depends<T>>
@@ -267,6 +276,15 @@ pub(crate) fn injectable_impl(args: TokenStream, input: DeriveInput) -> Result<T
 								#di_crate::Depends::<#inner_ty>::resolve(__di_ctx, false)
 									.await?
 							}
+						}
+					}
+					InjectionType::DependsFromRegistry(inner_ty) => {
+						// resolve_from_registry has no `T: Injectable` bound, so it
+						// works for factory-produced inner types (Result<T, E> /
+						// Option<T>) that are registered without an Injectable impl.
+						quote! {
+							#di_crate::Depends::<#inner_ty>::resolve_from_registry(__di_ctx, #use_cache)
+								.await?
 						}
 					}
 					InjectionType::OptionalDepends(inner_ty) => {

--- a/crates/reinhardt-di/tests/injectable_field_depends_sugar_tests.rs
+++ b/crates/reinhardt-di/tests/injectable_field_depends_sugar_tests.rs
@@ -1,0 +1,151 @@
+//! Regression tests for kent8192/reinhardt-web#4937.
+//!
+//! `DependsResult<T, E>` / `DependsOption<T>` are sugar aliases for
+//! `Depends<Result<T, E>>` / `Depends<Option<T>>`. Their primary use case is a
+//! factory that returns `Result<T, E>` / `Option<T>` to obtain a distinct DI
+//! registry key (`TypeId`) from `T` while preserving `T`'s trait impls.
+//!
+//! Those inner types (`Result<T, E>` / `Option<T>`) are produced by
+//! `#[injectable_factory]` and never implement `Injectable`. Therefore field
+//! injection through `#[injectable]` MUST resolve them via
+//! `Depends::resolve_from_registry` (no `T: Injectable` bound), not
+//! `Depends::resolve` (which requires `T: Injectable`).
+//!
+//! These tests are both a compile-time guard (if the macro routed the sugar
+//! aliases through `Depends::resolve`, the `#[injectable]` structs below would
+//! fail to compile because `Result<..>` / `Option<..>` are not `Injectable`)
+//! and a runtime guard (the only DI surface for the inner type is the
+//! registry).
+
+#![cfg(all(feature = "macros", feature = "testing"))]
+
+use rstest::*;
+use serial_test::serial;
+use std::sync::Arc;
+
+use reinhardt_di::{
+	DependencyScope, DependsOption, DependsResult, Injectable, InjectionContext, SingletonScope,
+	global_registry, injectable,
+};
+
+/// Factory-produced user type. No `impl Injectable` on purpose — it is only
+/// ever produced wrapped in a `Result` by a factory and read back through a
+/// `DependsResult` field.
+#[derive(Clone, Debug, PartialEq)]
+struct SessionUser {
+	id: i64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct SessionError {
+	reason: String,
+}
+
+/// `#[injectable]` service whose field is the sugar alias over a
+/// factory-produced `Result`. If `DependsResult` field injection routed
+/// through `Depends::resolve` (which requires `Result<..>: Injectable`), this
+/// struct would not compile.
+#[injectable]
+struct AuthService {
+	#[inject]
+	user: DependsResult<SessionUser, SessionError>,
+}
+
+#[rstest]
+#[serial(di_registry)]
+#[tokio::test]
+async fn injectable_field_depends_result_resolves_from_registry() {
+	// Arrange — register the factory-produced `Result<SessionUser, SessionError>`.
+	// This is the only DI surface available for the inner type.
+	let registry = global_registry();
+	let _guard = registry.register_override::<Result<SessionUser, SessionError>, _, _>(
+		DependencyScope::Transient,
+		|_ctx| async { Ok(Ok(SessionUser { id: 42 })) },
+	);
+	let scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(scope).build();
+
+	// Act — invoke the generated `inject` directly to exercise the field codegen.
+	let service = <AuthService as Injectable>::inject(&ctx)
+		.await
+		.expect("AuthService `DependsResult` field must resolve from the registry");
+
+	// Assert — the `DependsResult` field derefs to `Result<SessionUser, SessionError>`.
+	assert_eq!(*service.user, Ok(SessionUser { id: 42 }));
+}
+
+#[rstest]
+#[serial(di_registry)]
+#[tokio::test]
+async fn injectable_field_depends_result_preserves_err_variant() {
+	// Arrange — the registered factory yields the Err variant.
+	let registry = global_registry();
+	let _guard = registry.register_override::<Result<SessionUser, SessionError>, _, _>(
+		DependencyScope::Transient,
+		|_ctx| async {
+			Ok(Err(SessionError {
+				reason: "anonymous".to_string(),
+			}))
+		},
+	);
+	let scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(scope).build();
+
+	// Act
+	let service = <AuthService as Injectable>::inject(&ctx)
+		.await
+		.expect("AuthService `DependsResult` field must resolve from the registry");
+
+	// Assert — the error state is preserved inside the resolved `Result`.
+	assert_eq!(
+		*service.user,
+		Err(SessionError {
+			reason: "anonymous".to_string(),
+		})
+	);
+}
+
+/// Factory-produced optional dependency. No `impl Injectable`.
+#[derive(Clone, Debug, PartialEq)]
+struct CacheBackend {
+	url: String,
+}
+
+/// `#[injectable]` service with a `DependsOption` field over a factory-produced
+/// `Option`. Same compile-time + runtime guard as `AuthService`.
+#[injectable]
+struct CacheConsumer {
+	#[inject]
+	cache: DependsOption<CacheBackend>,
+}
+
+#[rstest]
+#[serial(di_registry)]
+#[tokio::test]
+async fn injectable_field_depends_option_resolves_from_registry() {
+	// Arrange — register the factory-produced `Option<CacheBackend>`.
+	let registry = global_registry();
+	let _guard = registry.register_override::<Option<CacheBackend>, _, _>(
+		DependencyScope::Transient,
+		|_ctx| async {
+			Ok(Some(CacheBackend {
+				url: "redis://localhost".to_string(),
+			}))
+		},
+	);
+	let scope = Arc::new(SingletonScope::new());
+	let ctx = InjectionContext::builder(scope).build();
+
+	// Act
+	let consumer = <CacheConsumer as Injectable>::inject(&ctx)
+		.await
+		.expect("CacheConsumer `DependsOption` field must resolve from the registry");
+
+	// Assert — the `DependsOption` field derefs to `Option<CacheBackend>`.
+	assert_eq!(
+		*consumer.cache,
+		Some(CacheBackend {
+			url: "redis://localhost".to_string(),
+		})
+	);
+}

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -23,24 +23,49 @@ use crate::crate_paths::{
 	get_reinhardt_pages_crate, get_reinhardt_pages_crate_info,
 };
 
-/// Extract the inner type `T` from `Depends<T>`.
+/// Extract the inner type from a Depends-family wrapper.
 ///
-/// Returns `Some(T)` if the type is `Depends<T>`, `None` otherwise.
+/// Recognises three shapes and returns the type that should be passed to
+/// `Depends::<...>::resolve_from_registry`:
+///
+/// - `Depends<T>` → `T`
+/// - `DependsResult<T, E>` → `Result<T, E>`
+/// - `DependsOption<T>` → `Option<T>`
+///
 /// Mirrors the helper in `crates/reinhardt-core/macros/src/routes_registration.rs`.
 /// Keep this implementation in sync with that file; the two proc-macro crates
 /// cannot share code directly without introducing a new non-proc-macro helper
 /// crate, and the helper is small enough that duplication is preferred.
-fn extract_depends_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
-	if let syn::Type::Path(type_path) = ty {
-		let last_segment = type_path.path.segments.last()?;
-		if last_segment.ident == "Depends"
-			&& let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
-			&& args.args.len() == 1
-			&& let syn::GenericArgument::Type(inner) = args.args.first()?
-		{
-			return Some(inner);
-		}
+fn extract_depends_inner_type(ty: &syn::Type) -> Option<syn::Type> {
+	let syn::Type::Path(type_path) = ty else {
+		return None;
+	};
+	let last_segment = type_path.path.segments.last()?;
+	let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments else {
+		return None;
+	};
+
+	if last_segment.ident == "Depends"
+		&& args.args.len() == 1
+		&& let syn::GenericArgument::Type(inner) = args.args.first()?
+	{
+		return Some(inner.clone());
 	}
+
+	if last_segment.ident == "DependsResult" && args.args.len() == 2 {
+		let mut iter = args.args.iter();
+		let t = iter.next()?;
+		let e = iter.next()?;
+		return Some(syn::parse_quote! { ::core::result::Result<#t, #e> });
+	}
+
+	if last_segment.ident == "DependsOption"
+		&& args.args.len() == 1
+		&& let Some(t) = args.args.first()
+	{
+		return Some(syn::parse_quote! { ::core::option::Option<#t> });
+	}
+
 	None
 }
 

--- a/tests/integration/tests/di/ui.rs
+++ b/tests/integration/tests/di/ui.rs
@@ -75,6 +75,12 @@ fn test_injectable_compile_pass_cases() {
 
 	// Test: Depends<FactoryType> in #[server_fn] (regression guard for #3723)
 	t.pass("tests/di/ui/pass/factory_depends_in_server_fn.rs");
+
+	// Test: DependsResult<T, E> in #[get] route macro (regression guard for #4937)
+	t.pass("tests/di/ui/pass/depends_result_in_route_macro.rs");
+
+	// Test: DependsResult<T, E> in #[server_fn] (regression guard for #4937)
+	t.pass("tests/di/ui/pass/depends_result_in_server_fn.rs");
 }
 
 // Note: Compile-pass tests for #[injectable_factory] are NOT possible via trybuild

--- a/tests/integration/tests/di/ui/pass/depends_result_in_route_macro.rs
+++ b/tests/integration/tests/di/ui/pass/depends_result_in_route_macro.rs
@@ -1,0 +1,40 @@
+//! Compile-pass test: `DependsResult<T, E>` in `#[get]` handler.
+//!
+//! Regression guard for issue #4937. `DependsResult<T, E>` is sugar for
+//! `Depends<Result<T, E>>`. The `#[get]` route macro must recognize the
+//! alias and route it through `resolve_from_registry()` against the
+//! expanded inner type `Result<T, E>` — never wrapping the alias in another
+//! `Depends<...>` and never adding a `T: Injectable` bound. The inner
+//! `Result<AppConfig, ConfigError>` is factory-produced and deliberately
+//! has no `Injectable` impl, so any regression in the macro's alias handling
+//! causes this test to fail to compile.
+
+use reinhardt_di::{DependsResult, injectable_factory};
+use reinhardt_http::{Response, ViewResult};
+use reinhardt_macros::get;
+
+#[derive(Clone, Debug)]
+struct AppConfig {
+	host: String,
+}
+
+#[derive(Clone, Debug)]
+struct ConfigError;
+
+// Factory-registered Result type: deliberately no `impl Injectable`.
+#[injectable_factory(scope = "transient")]
+async fn make_app_config() -> Result<AppConfig, ConfigError> {
+	Ok(AppConfig {
+		host: "localhost".to_string(),
+	})
+}
+
+#[get("/hello", name = "hello_depends_result")]
+async fn hello(#[inject] cfg: DependsResult<AppConfig, ConfigError>) -> ViewResult<Response> {
+	match &*cfg {
+		Ok(c) => Ok(Response::ok().with_body(c.host.clone())),
+		Err(_) => Ok(Response::ok().with_body("config error".to_string())),
+	}
+}
+
+fn main() {}

--- a/tests/integration/tests/di/ui/pass/depends_result_in_server_fn.rs
+++ b/tests/integration/tests/di/ui/pass/depends_result_in_server_fn.rs
@@ -1,0 +1,41 @@
+//! Compile-pass test: `DependsResult<T, E>` in `#[server_fn]`.
+//!
+//! Regression guard for issue #4937. `DependsResult<T, E>` is sugar for
+//! `Depends<Result<T, E>>`. The `#[server_fn]` macro must recognize the
+//! alias and route it through `resolve_from_registry()` against the
+//! expanded inner type `Result<T, E>` — never wrapping the alias in another
+//! `Depends<...>` and never adding a `T: Injectable` bound. The inner
+//! `Result<AppConfig, ConfigError>` is factory-produced and deliberately
+//! has no `Injectable` impl, so any regression in the macro's alias handling
+//! causes this test to fail to compile.
+
+use reinhardt_di::{DependsResult, injectable_factory};
+use reinhardt_pages::server_fn::{ServerFnError, server_fn};
+
+#[derive(Clone, Debug)]
+struct AppConfig {
+	host: String,
+}
+
+#[derive(Clone, Debug)]
+struct ConfigError;
+
+// Factory-registered Result type: deliberately no `impl Injectable`.
+#[injectable_factory(scope = "transient")]
+async fn make_app_config() -> Result<AppConfig, ConfigError> {
+	Ok(AppConfig {
+		host: "localhost".to_string(),
+	})
+}
+
+#[server_fn]
+async fn get_host(
+	#[inject] cfg: DependsResult<AppConfig, ConfigError>,
+) -> Result<String, ServerFnError> {
+	match &*cfg {
+		Ok(c) => Ok(c.host.clone()),
+		Err(_) => Ok("config error".to_string()),
+	}
+}
+
+fn main() {}


### PR DESCRIPTION
## Summary

This PR addresses:

- Extends route macro dependency extraction to resolve `DependsResult<T, E>` as `Result<T, E>` and `DependsOption<T>` as `Option<T>`.
- Applies the same alias expansion to `#[server_fn]` injection handling.
- Adds trybuild compile-pass coverage for `DependsResult<T, E>` in route and server function macros.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

`DependsResult<T, E>` and `DependsOption<T>` are aliases for `Depends<Result<T, E>>` and `Depends<Option<T>>`. Route and server function macros must resolve those aliases against the expanded registry key instead of treating the alias type itself as an injectable value.

Fixes #4937

Related to: #4938

## How Was This Tested?

- Not run locally before publishing; opened as a draft PR for CI validation.

## Performance Impact

Not performance-related.

## Breaking Changes

None.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4937
- Related to #4938

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Generated-With: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended dependency injection system to support `DependsResult<T, E>` and `DependsOption<T>` wrapper types in route macros and server functions.

* **Tests**
  * Added regression test coverage for the new DI wrapper types in route handlers and server functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->