### PR TITLE
refactor(examples): make examples-twitter url aggregators cfg-free via delegates

### DIFF
--- a/examples/examples-twitter/src/apps/auth/urls.rs
+++ b/examples/examples-twitter/src/apps/auth/urls.rs
@@ -1,41 +1,18 @@
 //! URL configuration for auth application
 //!
-//! Defines unified routes for authentication with both server and client routing.
+//! Defines unified routes for authentication with both server and client
+//! routing. The per-target builder bodies live in the `server_urls` and
+//! `client_router` submodules, so this aggregator stays free of `#[cfg]`
+//! branches (issue #4569).
 
 use reinhardt::UnifiedRouter;
 
-#[cfg(native)]
-use reinhardt::pages::server_fn::ServerFnRouterExt;
-
-#[cfg(native)]
-use crate::apps::auth::shared::server_fn::{current_user, login, logout, register};
-
-#[cfg(wasm)]
-use crate::apps::auth::client::components::{login_form, register_form};
+pub mod client_router;
+pub mod server_urls;
 
 /// Unified routes for auth application (client + server)
 pub fn routes() -> UnifiedRouter {
 	UnifiedRouter::new()
-		// Server-side routes (server functions)
-		.server(|s| {
-			#[cfg(native)]
-			{
-				s.server_fn(login::marker)
-					.server_fn(register::marker)
-					.server_fn(logout::marker)
-					.server_fn(current_user::marker)
-			}
-			#[cfg(wasm)]
-			s
-		})
-		// Client-side routes (SPA)
-		.client(|c| {
-			#[cfg(wasm)]
-			{
-				c.route("login", "/login", || login_form())
-					.route("register", "/register", || register_form())
-			}
-			#[cfg(native)]
-			c
-		})
+		.server(server_urls::server_url_patterns)
+		.client(client_router::client_url_patterns)
 }

--- a/examples/examples-twitter/src/apps/auth/urls/client_router.rs
+++ b/examples/examples-twitter/src/apps/auth/urls/client_router.rs
@@ -1,0 +1,25 @@
+//! Client-side routing for the auth application (SPA pages).
+//!
+//! The per-target builder body lives here so the `urls::routes()` aggregator
+//! stays free of `#[cfg]` branches (issue #4569). The page components are
+//! wasm-only, so the route registration becomes a no-op on native.
+
+use reinhardt::ClientRouter;
+
+#[cfg(wasm)]
+use crate::apps::auth::client::components::{login_form, register_form};
+
+/// Register the auth client routes onto the client router.
+///
+/// On native this is a no-op: the page components only exist on wasm.
+pub fn client_url_patterns(c: ClientRouter) -> ClientRouter {
+	#[cfg(wasm)]
+	{
+		c.route("login", "/login", || login_form())
+			.route("register", "/register", || register_form())
+	}
+	#[cfg(not(wasm))]
+	{
+		c
+	}
+}

--- a/examples/examples-twitter/src/apps/auth/urls/server_urls.rs
+++ b/examples/examples-twitter/src/apps/auth/urls/server_urls.rs
@@ -1,0 +1,31 @@
+//! Server-side URL patterns for the auth application.
+//!
+//! The per-target builder body lives here so the `urls::routes()` aggregator
+//! stays free of `#[cfg]` branches (issue #4569). The `server_fn` markers are
+//! native-only, so the registration becomes a no-op on wasm.
+
+use reinhardt::ServerRouter;
+
+#[cfg(native)]
+use reinhardt::pages::server_fn::ServerFnRouterExt;
+
+#[cfg(native)]
+use crate::apps::auth::shared::server_fn::{current_user, login, logout, register};
+
+/// Register the auth server functions onto the server router.
+///
+/// On wasm this is a no-op: the server-fn markers do not exist on that target,
+/// and the no-op `ServerRouter` discards the result anyway.
+pub fn server_url_patterns(s: ServerRouter) -> ServerRouter {
+	#[cfg(native)]
+	{
+		s.server_fn(login::marker)
+			.server_fn(register::marker)
+			.server_fn(logout::marker)
+			.server_fn(current_user::marker)
+	}
+	#[cfg(not(native))]
+	{
+		s
+	}
+}

--- a/examples/examples-twitter/src/apps/dm/urls.rs
+++ b/examples/examples-twitter/src/apps/dm/urls.rs
@@ -1,51 +1,21 @@
 //! URL configuration for dm application
 //!
-//! Defines unified routes for direct messaging with both server and client routing.
+//! Defines unified routes for direct messaging with both server and client
+//! routing. The per-target builder bodies live in the `server_urls` and
+//! `client_router` submodules, so this aggregator stays free of `#[cfg]`
+//! branches (issue #4569).
+//!
+//! Server functions handle REST API access. WebSocket handlers are registered
+//! separately through the WebSocket middleware.
 
 use reinhardt::UnifiedRouter;
 
-#[cfg(native)]
-use reinhardt::pages::server_fn::ServerFnRouterExt;
-
-#[cfg(native)]
-use crate::apps::dm::shared::server_fn::{
-	create_room, get_room, list_messages, list_rooms, mark_as_read, send_message,
-};
-
-#[cfg(wasm)]
-use {crate::core::client::pages::dm_chat_page, reinhardt::ClientPath};
+pub mod client_router;
+pub mod server_urls;
 
 /// Unified routes for dm application (client + server)
-///
-/// Server functions handle REST API access.
-/// WebSocket handlers are registered separately through the WebSocket middleware.
 pub fn routes() -> UnifiedRouter {
 	UnifiedRouter::new()
-		// Server-side routes (server functions)
-		.server(|s| {
-			#[cfg(native)]
-			{
-				s.server_fn(create_room::marker)
-					.server_fn(list_rooms::marker)
-					.server_fn(get_room::marker)
-					.server_fn(send_message::marker)
-					.server_fn(list_messages::marker)
-					.server_fn(mark_as_read::marker)
-			}
-			#[cfg(wasm)]
-			s
-		})
-		// Client-side routes (SPA)
-		.client(|c| {
-			#[cfg(wasm)]
-			{
-				c.route_path(
-					"dm_chat",
-					"/dm/{room_id}",
-					|ClientPath(room_id): ClientPath<String>| dm_chat_page(room_id),
-				)
-			}
-			#[cfg(native)]
-			c
-		})
+		.server(server_urls::server_url_patterns)
+		.client(client_router::client_url_patterns)
 }

--- a/examples/examples-twitter/src/apps/dm/urls/client_router.rs
+++ b/examples/examples-twitter/src/apps/dm/urls/client_router.rs
@@ -1,0 +1,28 @@
+//! Client-side routing for the dm application (SPA pages).
+//!
+//! The per-target builder body lives here so the `urls::routes()` aggregator
+//! stays free of `#[cfg]` branches (issue #4569). The page components are
+//! wasm-only, so the route registration becomes a no-op on native.
+
+use reinhardt::ClientRouter;
+
+#[cfg(wasm)]
+use {crate::core::client::pages::dm_chat_page, reinhardt::ClientPath};
+
+/// Register the dm client routes onto the client router.
+///
+/// On native this is a no-op: the page components only exist on wasm.
+pub fn client_url_patterns(c: ClientRouter) -> ClientRouter {
+	#[cfg(wasm)]
+	{
+		c.route_path(
+			"dm_chat",
+			"/dm/{room_id}",
+			|ClientPath(room_id): ClientPath<String>| dm_chat_page(room_id),
+		)
+	}
+	#[cfg(not(wasm))]
+	{
+		c
+	}
+}

--- a/examples/examples-twitter/src/apps/dm/urls/server_urls.rs
+++ b/examples/examples-twitter/src/apps/dm/urls/server_urls.rs
@@ -1,0 +1,35 @@
+//! Server-side URL patterns for the dm application.
+//!
+//! The per-target builder body lives here so the `urls::routes()` aggregator
+//! stays free of `#[cfg]` branches (issue #4569). The `server_fn` markers are
+//! native-only, so the registration becomes a no-op on wasm.
+
+use reinhardt::ServerRouter;
+
+#[cfg(native)]
+use reinhardt::pages::server_fn::ServerFnRouterExt;
+
+#[cfg(native)]
+use crate::apps::dm::shared::server_fn::{
+	create_room, get_room, list_messages, list_rooms, mark_as_read, send_message,
+};
+
+/// Register the dm server functions onto the server router.
+///
+/// On wasm this is a no-op: the server-fn markers do not exist on that target,
+/// and the no-op `ServerRouter` discards the result anyway.
+pub fn server_url_patterns(s: ServerRouter) -> ServerRouter {
+	#[cfg(native)]
+	{
+		s.server_fn(create_room::marker)
+			.server_fn(list_rooms::marker)
+			.server_fn(get_room::marker)
+			.server_fn(send_message::marker)
+			.server_fn(list_messages::marker)
+			.server_fn(mark_as_read::marker)
+	}
+	#[cfg(not(native))]
+	{
+		s
+	}
+}

--- a/examples/examples-twitter/src/apps/profile/urls.rs
+++ b/examples/examples-twitter/src/apps/profile/urls.rs
@@ -1,52 +1,18 @@
 //! URL configuration for profile application
 //!
-//! Defines unified routes for user profiles with both server and client routing.
+//! Defines unified routes for user profiles with both server and client
+//! routing. The per-target builder bodies live in the `server_urls` and
+//! `client_router` submodules, so this aggregator stays free of `#[cfg]`
+//! branches (issue #4569).
 
 use reinhardt::UnifiedRouter;
 
-#[cfg(native)]
-use reinhardt::pages::server_fn::ServerFnRouterExt;
-
-#[cfg(native)]
-use crate::apps::profile::shared::server_fn::{fetch_profile, update_profile, update_profile_form};
-
-#[cfg(wasm)]
-use {
-	crate::core::client::pages::{profile_edit_page, profile_page},
-	reinhardt::ClientPath,
-	uuid::Uuid,
-};
+pub mod client_router;
+pub mod server_urls;
 
 /// Unified routes for profile application (client + server)
 pub fn routes() -> UnifiedRouter {
 	UnifiedRouter::new()
-		// Server-side routes (server functions)
-		.server(|s| {
-			#[cfg(native)]
-			{
-				s.server_fn(fetch_profile::marker)
-					.server_fn(update_profile::marker)
-					.server_fn(update_profile_form::marker)
-			}
-			#[cfg(wasm)]
-			s
-		})
-		// Client-side routes (SPA) with typed path parameters
-		.client(|c| {
-			#[cfg(wasm)]
-			{
-				c.route_path(
-					"profile_edit",
-					"/profile/{user_id}/edit",
-					|ClientPath(user_id): ClientPath<Uuid>| profile_edit_page(user_id),
-				)
-				.route_path(
-					"profile_detail",
-					"/profile/{user_id}",
-					|ClientPath(user_id): ClientPath<Uuid>| profile_page(user_id),
-				)
-			}
-			#[cfg(native)]
-			c
-		})
+		.server(server_urls::server_url_patterns)
+		.client(client_router::client_url_patterns)
 }

--- a/examples/examples-twitter/src/apps/profile/urls/client_router.rs
+++ b/examples/examples-twitter/src/apps/profile/urls/client_router.rs
@@ -1,0 +1,37 @@
+//! Client-side routing for the profile application (SPA pages).
+//!
+//! The per-target builder body lives here so the `urls::routes()` aggregator
+//! stays free of `#[cfg]` branches (issue #4569). The page components are
+//! wasm-only, so the route registration becomes a no-op on native.
+
+use reinhardt::ClientRouter;
+
+#[cfg(wasm)]
+use {
+	crate::core::client::pages::{profile_edit_page, profile_page},
+	reinhardt::ClientPath,
+	uuid::Uuid,
+};
+
+/// Register the profile client routes onto the client router.
+///
+/// On native this is a no-op: the page components only exist on wasm.
+pub fn client_url_patterns(c: ClientRouter) -> ClientRouter {
+	#[cfg(wasm)]
+	{
+		c.route_path(
+			"profile_edit",
+			"/profile/{user_id}/edit",
+			|ClientPath(user_id): ClientPath<Uuid>| profile_edit_page(user_id),
+		)
+		.route_path(
+			"profile_detail",
+			"/profile/{user_id}",
+			|ClientPath(user_id): ClientPath<Uuid>| profile_page(user_id),
+		)
+	}
+	#[cfg(not(wasm))]
+	{
+		c
+	}
+}

--- a/examples/examples-twitter/src/apps/profile/urls/server_urls.rs
+++ b/examples/examples-twitter/src/apps/profile/urls/server_urls.rs
@@ -1,0 +1,30 @@
+//! Server-side URL patterns for the profile application.
+//!
+//! The per-target builder body lives here so the `urls::routes()` aggregator
+//! stays free of `#[cfg]` branches (issue #4569). The `server_fn` markers are
+//! native-only, so the registration becomes a no-op on wasm.
+
+use reinhardt::ServerRouter;
+
+#[cfg(native)]
+use reinhardt::pages::server_fn::ServerFnRouterExt;
+
+#[cfg(native)]
+use crate::apps::profile::shared::server_fn::{fetch_profile, update_profile, update_profile_form};
+
+/// Register the profile server functions onto the server router.
+///
+/// On wasm this is a no-op: the server-fn markers do not exist on that target,
+/// and the no-op `ServerRouter` discards the result anyway.
+pub fn server_url_patterns(s: ServerRouter) -> ServerRouter {
+	#[cfg(native)]
+	{
+		s.server_fn(fetch_profile::marker)
+			.server_fn(update_profile::marker)
+			.server_fn(update_profile_form::marker)
+	}
+	#[cfg(not(native))]
+	{
+		s
+	}
+}

--- a/examples/examples-twitter/src/apps/relationship/urls.rs
+++ b/examples/examples-twitter/src/apps/relationship/urls.rs
@@ -1,34 +1,17 @@
 //! URL configuration for relationship application
 //!
-//! Defines unified routes for user relationships (follow/unfollow).
+//! Defines unified routes for user relationships (follow/unfollow). The
+//! server-side builder body lives in the `server_urls` submodule, so this
+//! aggregator stays free of `#[cfg]` branches (issue #4569).
+//!
+//! This app currently only has server-side routes; client-side relationship
+//! management is handled through profile components.
 
 use reinhardt::UnifiedRouter;
 
-#[cfg(native)]
-use reinhardt::pages::server_fn::ServerFnRouterExt;
-
-#[cfg(native)]
-use crate::apps::relationship::shared::server_fn::{
-	fetch_followers, fetch_following, follow_user, unfollow_user,
-};
+pub mod server_urls;
 
 /// Unified routes for relationship application (server only)
-///
-/// This app currently only has server-side routes.
-/// Client-side relationship management is handled through profile components.
 pub fn routes() -> UnifiedRouter {
-	UnifiedRouter::new()
-		// Server-side routes (server functions)
-		.server(|s| {
-			#[cfg(native)]
-			{
-				s.server_fn(follow_user::marker)
-					.server_fn(unfollow_user::marker)
-					.server_fn(fetch_followers::marker)
-					.server_fn(fetch_following::marker)
-			}
-			#[cfg(wasm)]
-			s
-		})
-	// No client-side routes - relationship UI is embedded in profile components
+	UnifiedRouter::new().server(server_urls::server_url_patterns)
 }

--- a/examples/examples-twitter/src/apps/relationship/urls/server_urls.rs
+++ b/examples/examples-twitter/src/apps/relationship/urls/server_urls.rs
@@ -1,0 +1,33 @@
+//! Server-side URL patterns for the relationship application.
+//!
+//! The per-target builder body lives here so the `urls::routes()` aggregator
+//! stays free of `#[cfg]` branches (issue #4569). The `server_fn` markers are
+//! native-only, so the registration becomes a no-op on wasm.
+
+use reinhardt::ServerRouter;
+
+#[cfg(native)]
+use reinhardt::pages::server_fn::ServerFnRouterExt;
+
+#[cfg(native)]
+use crate::apps::relationship::shared::server_fn::{
+	fetch_followers, fetch_following, follow_user, unfollow_user,
+};
+
+/// Register the relationship server functions onto the server router.
+///
+/// On wasm this is a no-op: the server-fn markers do not exist on that target,
+/// and the no-op `ServerRouter` discards the result anyway.
+pub fn server_url_patterns(s: ServerRouter) -> ServerRouter {
+	#[cfg(native)]
+	{
+		s.server_fn(follow_user::marker)
+			.server_fn(unfollow_user::marker)
+			.server_fn(fetch_followers::marker)
+			.server_fn(fetch_following::marker)
+	}
+	#[cfg(not(native))]
+	{
+		s
+	}
+}

--- a/examples/examples-twitter/src/apps/tweet/urls.rs
+++ b/examples/examples-twitter/src/apps/tweet/urls.rs
@@ -1,40 +1,17 @@
 //! URL configuration for tweet application
 //!
-//! Defines unified routes for tweets with both server and client routing.
+//! Defines unified routes for tweets with both server and client routing. The
+//! per-target builder bodies live in the `server_urls` and `client_router`
+//! submodules, so this aggregator stays free of `#[cfg]` branches (issue #4569).
 
 use reinhardt::UnifiedRouter;
 
-#[cfg(native)]
-use reinhardt::pages::server_fn::ServerFnRouterExt;
-
-#[cfg(native)]
-use crate::apps::tweet::shared::server_fn::{create_tweet, delete_tweet, list_tweets};
-
-#[cfg(wasm)]
-use crate::core::client::pages::{home_page, timeline_page};
+pub mod client_router;
+pub mod server_urls;
 
 /// Unified routes for tweet application (client + server)
 pub fn routes() -> UnifiedRouter {
 	UnifiedRouter::new()
-		// Server-side routes (server functions)
-		.server(|s| {
-			#[cfg(native)]
-			{
-				s.server_fn(create_tweet::marker)
-					.server_fn(list_tweets::marker)
-					.server_fn(delete_tweet::marker)
-			}
-			#[cfg(wasm)]
-			s
-		})
-		// Client-side routes (SPA)
-		.client(|c| {
-			#[cfg(wasm)]
-			{
-				c.route("home", "/", || home_page())
-					.route("timeline", "/timeline", || timeline_page())
-			}
-			#[cfg(native)]
-			c
-		})
+		.server(server_urls::server_url_patterns)
+		.client(client_router::client_url_patterns)
 }

--- a/examples/examples-twitter/src/apps/tweet/urls/client_router.rs
+++ b/examples/examples-twitter/src/apps/tweet/urls/client_router.rs
@@ -1,0 +1,25 @@
+//! Client-side routing for the tweet application (SPA pages).
+//!
+//! The per-target builder body lives here so the `urls::routes()` aggregator
+//! stays free of `#[cfg]` branches (issue #4569). The page components are
+//! wasm-only, so the route registration becomes a no-op on native.
+
+use reinhardt::ClientRouter;
+
+#[cfg(wasm)]
+use crate::core::client::pages::{home_page, timeline_page};
+
+/// Register the tweet client routes onto the client router.
+///
+/// On native this is a no-op: the page components only exist on wasm.
+pub fn client_url_patterns(c: ClientRouter) -> ClientRouter {
+	#[cfg(wasm)]
+	{
+		c.route("home", "/", || home_page())
+			.route("timeline", "/timeline", || timeline_page())
+	}
+	#[cfg(not(wasm))]
+	{
+		c
+	}
+}

--- a/examples/examples-twitter/src/apps/tweet/urls/server_urls.rs
+++ b/examples/examples-twitter/src/apps/tweet/urls/server_urls.rs
@@ -1,0 +1,30 @@
+//! Server-side URL patterns for the tweet application.
+//!
+//! The per-target builder body lives here so the `urls::routes()` aggregator
+//! stays free of `#[cfg]` branches (issue #4569). The `server_fn` markers are
+//! native-only, so the registration becomes a no-op on wasm.
+
+use reinhardt::ServerRouter;
+
+#[cfg(native)]
+use reinhardt::pages::server_fn::ServerFnRouterExt;
+
+#[cfg(native)]
+use crate::apps::tweet::shared::server_fn::{create_tweet, delete_tweet, list_tweets};
+
+/// Register the tweet server functions onto the server router.
+///
+/// On wasm this is a no-op: the server-fn markers do not exist on that target,
+/// and the no-op `ServerRouter` discards the result anyway.
+pub fn server_url_patterns(s: ServerRouter) -> ServerRouter {
+	#[cfg(native)]
+	{
+		s.server_fn(create_tweet::marker)
+			.server_fn(list_tweets::marker)
+			.server_fn(delete_tweet::marker)
+	}
+	#[cfg(not(native))]
+	{
+		s
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Each `examples-twitter` app's `routes()` aggregator previously inlined `#[cfg(native)]`/`#[cfg(wasm)]` arms inside the `.server(|s| …)` / `.client(|c| …)` closures. This PR extracts those per-target builder bodies into cross-target delegate functions — `urls/server_urls.rs::server_url_patterns(s: ServerRouter)` and `urls/client_router.rs::client_url_patterns(c: ClientRouter)` — so each aggregator becomes a `#[cfg]`-free `.server(server_url_patterns).client(client_url_patterns)`.
- Aligns examples-twitter with the existing examples-tutorial-basis module-split structure.

**Stacked on #4994** (base branch is `feat/issue-4569-unify-server-router-closure-type`). The cross-target delegate signatures `fn(ServerRouter) -> ServerRouter` / `fn(ClientRouter) -> ClientRouter` are only possible because #4994 unifies the `ServerRouter` type across targets. Once #4994 merges into `develop/0.2.0`, this PR's base will retarget to `develop/0.2.0`.

## Type of Change

- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible (examples only; runtime routing behavior is unchanged)

## Motivation and Context

The inline cfg scaffolding obscures routing structure and violates DESIGN_PHILOSOPHY items 1, 5, 7, 8. Moving it into per-target delegate functions makes the aggregator a one-liner and satisfies the #4712 acceptance criterion (zero `#[cfg]` inside the `.server()`/`.client()` arms).

Related to: #4569, #4712, #4711

## How Was This Tested?

- `cargo check --all-features` for `examples-twitter` (native) — **passes** (895 crates).
- `semgrep --config .semgrep/ --baseline-commit origin/develop/0.2.0` — **0 findings** (RD-7 / commented-out-code clean).
- WASM library check (`cargo check --target wasm32-unknown-unknown --lib`): the refactored delegate files (`apps/*/urls/**`) compile with **zero errors**. The example WASM lib build currently fails with 61 pre-existing errors in untouched client-SPA code (`page!` closures, `reinhardt::core` import, server-fn arg counts); these are **identical with and without this PR** (verified against a clean `develop/0.2.0` baseline) and are tracked separately in **#4995**. Full WASM verification of the example is therefore blocked until #4995 is resolved.

## Notes on residual cfg

cfg is **relocated**, not eliminated:
- `client_url_patterns` keeps a `#[cfg(wasm)]` body because page components are intrinsically wasm-only (no native SSR).
- `server_url_patterns` keeps a conservative `#[cfg(native)]` body. Since #4711 (landed) makes `#[server_fn]` markers cross-target-visible, this server-side `#[cfg]` could be dropped to make the body fully cross-target; that simplification is deferred because the example WASM build is currently blocked by #4995, preventing verification of the un-gated server path.

## Checklist

- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] New and existing native checks pass locally
- [ ] WASM verification blocked by pre-existing #4995
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `refactoring` - Code refactoring

### Scope Label (select all that apply)
- [x] `routing` - URL routing, path matching

---

**Additional Context:**

- Base branch is PR #4994's branch (stacked PR); this PR's diff shows only the examples-twitter changes.
- examples-tutorial-basis already uses the module-split delegate structure; this PR brings examples-twitter in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal routing architecture across applications for improved code maintainability and structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->