### PR TITLE
fix(examples-twitter): repair WASM library compile against develop/0.2.0 page!/form! API

### DIFF
--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -46,6 +46,11 @@ jobs:
           - example: examples-twitter
             needs-docker: true
             needs-wasm: true
+            # Build the example's own WASM library (not just the framework
+            # crates) to catch client-SPA drift from the page!/form! API
+            # (reinhardt-web#4995). Scoped to examples-twitter for now; other
+            # WASM examples can opt in once their client code is verified.
+            wasm-lib-check: true
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -137,6 +142,11 @@ jobs:
       - name: Check WASM compilation (framework crates)
         if: ${{ matrix.needs-wasm }}
         run: cargo check --target wasm32-unknown-unknown -p reinhardt-core -p reinhardt-urls --features reinhardt-core/full,reinhardt-urls/client-router
+
+      - name: Check WASM compilation (example library)
+        if: ${{ matrix.wasm-lib-check }}
+        working-directory: examples/${{ matrix.example }}
+        run: cargo check --target wasm32-unknown-unknown --lib
 
       - name: Install Chrome
         if: ${{ matrix.needs-wasm }}

--- a/examples/examples-twitter/src/apps/auth/client/components.rs
+++ b/examples/examples-twitter/src/apps/auth/client/components.rs
@@ -30,6 +30,12 @@ pub fn login_form() -> Page {
 	let login_form = form! {
 		name: LoginForm,
 		server_fn: login,
+		method: Post,
+		// Route the CSRF token to `login`'s trailing `_csrf_token: String`
+		// argument (server-side middleware performs the actual verification).
+		strip_arguments: {
+			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
+		},
 		redirect_on_success: "/timeline",
 		state: {
 			loading,
@@ -114,21 +120,27 @@ pub fn login_form() -> Page {
 					class: "card animate-fade-in",
 					div {
 						class: "card-body p-6 sm:p-8",
-						if error_signal.get().is_some() {
-							div {
-								class: "alert-danger mb-4",
-								div {
-									class: "flex items-center gap-2",
-									{
-										icons::error_circle_icon()
+						{
+							error_signal.get().map(|error_message| {
+								page!(|error_message: String| {
+									div {
+										class: "alert-danger mb-4",
+										div {
+											class: "flex items-center gap-2",
+											{
+												icons::error_circle_icon()
+											}
+											span { {
+												error_message.clone()
+											} }
+										}
 									}
-									span { {
-										error_signal.get().unwrap_or_default()
-									} }
-								}
-							}
+								})(error_message)
+							}).unwrap_or_else(Page::empty)
 						}
-						{ { form_view } }
+						{ {
+							form_view.clone()
+						} }
 						div {
 							class: "flex items-center justify-between mt-4",
 							label {
@@ -204,6 +216,12 @@ pub fn register_form() -> Page {
 	let register_form = form! {
 		name: RegisterForm,
 		server_fn: register,
+		method: Post,
+		// Route the CSRF token to `register`'s trailing `_csrf_token: String`
+		// argument (server-side middleware performs the actual verification).
+		strip_arguments: {
+			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
+		},
 		redirect_on_success: "/login",
 		state: {
 			loading,
@@ -326,21 +344,27 @@ pub fn register_form() -> Page {
 					class: "card animate-fade-in",
 					div {
 						class: "card-body p-6 sm:p-8",
-						if error_signal.get().is_some() {
-							div {
-								class: "alert-danger mb-4",
-								div {
-									class: "flex items-center gap-2",
-									{
-										icons::error_circle_icon()
+						{
+							error_signal.get().map(|error_message| {
+								page!(|error_message: String| {
+									div {
+										class: "alert-danger mb-4",
+										div {
+											class: "flex items-center gap-2",
+											{
+												icons::error_circle_icon()
+											}
+											span { {
+												error_message.clone()
+											} }
+										}
 									}
-									span { {
-										error_signal.get().unwrap_or_default()
-									} }
-								}
-							}
+								})(error_message)
+							}).unwrap_or_else(Page::empty)
 						}
-						{ { form_view } }
+						{ {
+							form_view.clone()
+						} }
 						div {
 							class: "flex items-start gap-2 mt-4",
 							input {

--- a/examples/examples-twitter/src/apps/dm/client/components.rs
+++ b/examples/examples-twitter/src/apps/dm/client/components.rs
@@ -21,20 +21,26 @@ fn message_input(
 	let input_for_display = input_signal.clone();
 	let input_for_change = input_signal.clone();
 	let input_for_click = input_signal.clone();
-	page!(| input_for_display : Signal < String >, input_for_change : Signal < String >, input_for_click : Signal < String >| {
+	// Box the caller-supplied callback into a concrete `Rc<dyn Fn(String)>`
+	// so it can flow into `page!` as a typed parameter. `impl Fn(..)` is not
+	// expressible as a `page!` closure-parameter type, and the macro forbids
+	// implicit captures, so the callback must be passed explicitly. `Rc` is
+	// `Clone`, matching the `Fn` closure that `page!` generates (WASM is
+	// single-threaded, so `Rc` is sufficient).
+	let send_callback: std::rc::Rc<dyn Fn(String)> = std::rc::Rc::new(send_callback);
+	page!(|input_for_display: Signal<String>, input_for_change: Signal<String>, input_for_click: Signal<String>, send_callback: std::rc::Rc<dyn Fn(String) >| {
 		div {
-			class : "dm-input-container flex gap-2 p-4 border-t border-surface-tertiary",
+			class: "dm-input-container flex gap-2 p-4 border-t border-surface-tertiary",
 			input {
-				type : "text",
-				class : "form-control flex-1",
-				placeholder : "Type a message...",
-				value : input_for_display.get(),
-				@ input : {
-					let { input_signal }
-					=input_for_change.clone();
-					move | event : web_sys::Event | {
-						if let Some(target) =event.target() {
-							if let Ok(input) = target.dyn_into::< web_sys::HtmlInputElement>() {
+				type: "text",
+				class: "form-control flex-1",
+				placeholder: "Type a message...",
+				value: input_for_display.get(),
+				@input: {
+					let input_signal = input_for_change.clone();
+					move |event: web_sys::Event| {
+						if let Some(target) = event.target() {
+							if let Ok(input) = target.dyn_into::<web_sys::HtmlInputElement>() {
 								input_signal.set(input.value());
 							}
 						}
@@ -42,18 +48,15 @@ fn message_input(
 				},
 			}
 			button {
-				class : "btn-primary",
-				type : "button",
-				@ click : {
-					let { input_signal }
-					=input_for_click.clone();
-					let { send_callback }
-					= send_callback.clone();
-					move |_event | {
-						let { content }
-						= input_signal.get();
-						if ! content.trim().is_empty() {
-							send_callback(content);
+				class: "btn-primary",
+				type: "button",
+				@click: {
+					let input_signal = input_for_click.clone();
+					let send_callback = send_callback.clone();
+					move |_event| {
+						let content = input_signal.get();
+						if !content.trim().is_empty() {
+							(*send_callback)(content);
 							input_signal.set(String::new());
 						}
 					}
@@ -61,7 +64,12 @@ fn message_input(
 				"Send"
 			}
 		}
-	})(input_for_display, input_for_change, input_for_click)
+	})(
+		input_for_display,
+		input_for_change,
+		input_for_click,
+		send_callback,
+	)
 }
 /// Single message display component
 fn message_item(message: &MessageInfo, is_own_message: bool) -> Page {
@@ -83,19 +91,29 @@ fn message_item(message: &MessageInfo, is_own_message: bool) -> Page {
 			class: align_class,
 			div {
 				class: bubble_class,
-				if ! is_own_message {
-					div {
-						class: "text-xs font-medium text-content-secondary mb-1",
-						{ { sender } }
-					}
+				{
+					if ! is_own_message {
+						page!(|sender: String| {
+							div {
+								class: "text-xs font-medium text-content-secondary mb-1",
+								{ {
+									sender.clone()
+								} }
+							}
+						})(sender.clone())
+					} else { Page::Empty }
 				}
 				p {
 					class: "text-sm break-words",
-					{ { content } }
+					{ {
+						content.clone()
+					} }
 				}
 				div {
 					class: if is_own_message { "text-xs text-white/70 mt-1 text-right" } else { "text-xs text-content-tertiary mt-1" },
-					{ { timestamp } }
+					{ {
+						timestamp.clone()
+					} }
 				}
 			}
 		}
@@ -150,7 +168,7 @@ pub fn dm_chat(room_id: Uuid, current_user_id: Option<Uuid>) -> Page {
 	let ws_state = chat.ws.connection_state();
 	let input_signal = input.clone();
 	let chat_for_send = chat.clone();
-	page!(|messages_signal: Signal<Vec<MessageInfo>>, is_loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, ws_state: Signal<ConnectionState>, input_signal: Signal<String>, current_user_id: Option<Uuid>, _room_id: Uuid| {
+	page!(|messages_signal: Signal<Vec<MessageInfo>>, is_loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, ws_state: Signal<ConnectionState>, input_signal: Signal<String>, current_user_id: Option<Uuid>, chat_for_send: crate::apps::dm::client::hooks::DmChatHandle, _room_id: Uuid| {
 		div {
 			class: "dm-chat-container flex flex-col h-full",
 			div {
@@ -160,60 +178,76 @@ pub fn dm_chat(room_id: Uuid, current_user_id: Option<Uuid>) -> Page {
 					"Direct Messages"
 				}
 				{
-					connection_status(matches!(ws_state.get(), ConnectionState::Open))
+					self::connection_status(matches!(ws_state.get(), ConnectionState::Open))
 				}
 			}
 			div {
 				class: "dm-messages flex-1 overflow-y-auto p-4 space-y-3",
-				if is_loading_signal.get() {
-					div {
-						class: "flex flex-col items-center justify-center py-12",
-						div {
-							class: "spinner-lg mb-4",
-						}
-						p {
-							class: "text-content-secondary text-sm",
-							"Loading messages..."
-						}
-					}
-				} else if error_signal.get().is_some() {
-					div {
-						class: "alert-danger",
-						role: "alert",
-						{
-							error_signal.get().unwrap_or_default()
-						}
-					}
-				} else if messages_signal.get().is_empty() {
-					div {
-						class: "flex flex-col items-center justify-center py-16 text-center",
-						div {
-							class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
-							{
-								icons::chat_bubble_icon_lg()
+				{
+					// Single reactive scope: signals are borrowed via `.get()`,
+					// and each branch builds its sub-tree with a fresh inner
+					// `page!`. This avoids the nested-reactive-scope move chain
+					// (E0507) that arises when a signal is read inside a `for`
+					// nested in an outer reactive `if`/`else` block.
+					if is_loading_signal.get() {
+						page!(|| {
+							div {
+								class: "flex flex-col items-center justify-center py-12",
+								div {
+									class: "spinner-lg mb-4",
+								}
+								p {
+									class: "text-content-secondary text-sm",
+									"Loading messages..."
+								}
 							}
-						}
-						h3 {
-							class: "text-lg font-semibold text-content-primary mb-1",
-							"No messages yet"
-						}
-						p {
-							class: "text-content-secondary",
-							"Send a message to start the conversation!"
-						}
-					}
-				} else {
-					div {
-						class: "space-y-3",
-						for m in messages_signal.get().iter() { { {
-							let is_own = current_user_id.map(|uid| m.sender_id == uid).unwrap_or(false);
-							message_item(m, is_own)
-						} } }
+						})()
+					} else if let Some(error_message) = error_signal.get() {
+						page!(|error_message: String| {
+							div {
+								class: "alert-danger",
+								role: "alert",
+								{ {
+									error_message.clone()
+								} }
+							}
+						})(error_message)
+					} else if messages_signal.get().is_empty() {
+						page!(|| {
+							div {
+								class: "flex flex-col items-center justify-center py-16 text-center",
+								div {
+									class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
+									{
+										icons::chat_bubble_icon_lg()
+									}
+								}
+								h3 {
+									class: "text-lg font-semibold text-content-primary mb-1",
+									"No messages yet"
+								}
+								p {
+									class: "text-content-secondary",
+									"Send a message to start the conversation!"
+								}
+							}
+						})()
+					} else {
+						page!(|messages: Vec<MessageInfo>, current_user_id: Option<Uuid>| {
+							div {
+								class: "space-y-3",
+								for m in messages.clone() { { {
+									let is_own = current_user_id.map(|uid| m.sender_id == uid).unwrap_or(false);
+									self::message_item(&m, is_own)
+								} } }
+							}
+						})(messages_signal.get(), current_user_id)
 					}
 				}
 			}
 			{
-				message_input(input_signal.clone(), move |content| {
+				let chat_for_send = chat_for_send.clone();
+				self::message_input(input_signal.clone(), move |content| {
 					chat_for_send.send_message(content);
 				})
 			}
@@ -225,69 +259,88 @@ pub fn dm_chat(room_id: Uuid, current_user_id: Option<Uuid>) -> Page {
 		ws_state.clone(),
 		input_signal,
 		current_user_id,
+		chat_for_send,
 		room_id,
 	)
 }
 /// Single room item in the list
-fn room_item(room: &RoomInfo, on_select: impl Fn(Uuid) + Clone + 'static) -> Page {
+fn room_item(room: &RoomInfo, on_select: std::rc::Rc<dyn Fn(Uuid)>) -> Page {
 	let room_id = room.id;
-	let name = room.name.clone();
+	// `name` is rendered in two independent reactive scopes (the avatar
+	// initial and the username label). Each `page!` reactive `{ }` node lowers
+	// to its own `move ||` closure, so a single non-`Copy` `String` parameter
+	// cannot be shared across both without an E0382 use-after-move. Pass two
+	// independent clones as separate parameters (same pattern as the
+	// `input_for_*` split in `message_input`).
+	let name_initial = room.name.clone();
+	let name_label = room.name.clone();
 	let last_message = room.last_message.clone();
 	let last_activity = room.last_activity.clone();
 	let unread_count = room.unread_count;
-	page!(| room_id : Uuid, name : String, last_message : Option < String >, last_activity: Option < String >, unread_count : i32 | {
+	// `on_select` already arrives as a concrete `Rc<dyn Fn(Uuid)>` so it can
+	// flow into `page!` as a typed parameter (`impl Fn(..)` is not a valid
+	// `page!` closure-parameter type and implicit captures are forbidden). The
+	// inner `@click` handler invokes it via deref (`(*on_select)(..)`) because
+	// `Rc<dyn Fn(..)>` is not itself callable, but the `dyn Fn` behind it is.
+	page!(|room_id: Uuid, name_initial: String, name_label: String, last_message: Option<String>, last_activity: Option<String>, unread_count: i32, on_select: std::rc::Rc<dyn Fn(Uuid) >| {
 		div {
-			class : "room-item flex items-center gap-3 p-4 hover:bg-surface-secondary cursor-pointer transition-colors border-b border-surface-tertiary",
-			@ click : {
-				let { on_select }
-				= on_select.clone();
-				move | _event | {
-					on_select(room_id);
+			class: "room-item flex items-center gap-3 p-4 hover:bg-surface-secondary cursor-pointer transition-colors border-b border-surface-tertiary",
+			@click: {
+				let on_select = on_select.clone();
+				move |_event| {
+					(*on_select)(room_id);
 				}
 			},
 			div {
-				class : "flex-shrink-0",
+				class: "flex-shrink-0",
 				div {
-					class : "w-12 h-12 rounded-full bg-brand/20 flex items-center justify-center text-brand font-semibold",
+					class: "w-12 h-12 rounded-full bg-brand/20 flex items-center justify-center text-brand font-semibold",
 					{
-						name.chars().next().unwrap_or('?').to_uppercase().to_string()
+						name_initial.chars().next().unwrap_or('?').to_uppercase().to_string()
 					}
 				}
 			}
 			div {
 				class: "flex-1 min-w-0",
 				div {
-					class : "flex items-center justify-between",
+					class: "flex items-center justify-between",
 					span {
-						class : "font-semibold text-content-primary truncate",
+						class: "font-semibold text-content-primary truncate",
 						{
-							name.clone()
+							name_label.clone()
 						}
 					}
-					iflast_activity.is_some() {
-						span {
-							class : "text-xs text-content-tertiary",
-							{
-								last_activity.clone().unwrap_or_default()
-							}
-						}
+					{
+						last_activity.clone().map(|last_activity| {
+							page!(|last_activity: String| {
+								span {
+									class: "text-xs text-content-tertiary",
+									{
+										last_activity.clone()
+									}
+								}
+							})(last_activity)
+						}).unwrap_or(Page::Empty)
 					}
 				}
-				if last_message.is_some() {
-					p {
-						class : "text-sm text-content-secondary truncate mt-1",
-						{
-							last_message.clone().unwrap_or_default()
-						}
-					}
+				{
+					last_message.clone().map(|last_message| {
+						page!(|last_message: String| {
+							p {
+								class: "text-sm text-content-secondary truncate mt-1",
+								{
+									last_message.clone()
+								}
+							}
+						})(last_message)
+					}).unwrap_or(Page::Empty)
 				}
 			}
-			if { unread_count }
-			> 0 {
+			if unread_count > 0 {
 				div {
-					class : "flex-shrink-0",
+					class: "flex-shrink-0",
 					span {
-						class : "inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-brand rounded-full",
+						class: "inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-brand rounded-full",
 						{
 							format!("{}", unread_count.min(99))
 						}
@@ -295,7 +348,15 @@ fn room_item(room: &RoomInfo, on_select: impl Fn(Uuid) + Clone + 'static) -> Pag
 				}
 			}
 		}
-	})(room_id, name, last_message, last_activity, unread_count)
+	})(
+		room_id,
+		name_initial,
+		name_label,
+		last_message,
+		last_activity,
+		unread_count,
+		on_select,
+	)
 }
 /// DM room list component
 ///
@@ -316,7 +377,11 @@ pub fn dm_room_list(on_room_select: impl Fn(Uuid) + Clone + 'static) -> Page {
 	let rooms_signal = room_list.rooms.clone();
 	let is_loading_signal = room_list.is_loading.clone();
 	let error_signal = room_list.error.clone();
-	page!(|rooms_signal: Signal<Vec<RoomInfo>>, is_loading_signal: Signal<bool>, error_signal: Signal<Option<String>>| {
+	// Box the selection callback into a concrete `Rc<dyn Fn(Uuid)>` so it can
+	// flow into `page!` as a typed parameter (`impl Fn(..)` is not a valid
+	// `page!` closure-parameter type and implicit captures are forbidden).
+	let on_room_select: std::rc::Rc<dyn Fn(Uuid)> = std::rc::Rc::new(on_room_select);
+	page!(|rooms_signal: Signal<Vec<RoomInfo>>, is_loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, on_room_select: std::rc::Rc<dyn Fn(Uuid) >| {
 		div {
 			class: "dm-room-list h-full flex flex-col",
 			div {
@@ -328,54 +393,67 @@ pub fn dm_room_list(on_room_select: impl Fn(Uuid) + Clone + 'static) -> Page {
 			}
 			div {
 				class: "flex-1 overflow-y-auto",
-				if is_loading_signal.get() {
-					div {
-						class: "flex flex-col items-center justify-center py-12",
-						div {
-							class: "spinner-lg mb-4",
-						}
-						p {
-							class: "text-content-secondary text-sm",
-							"Loading conversations..."
-						}
-					}
-				} else if error_signal.get().is_some() {
-					div {
-						class: "p-4",
-						div {
-							class: "alert-danger",
-							role: "alert",
-							{
-								error_signal.get().unwrap_or_default()
+				{
+					if is_loading_signal.get() {
+						page!(|| {
+							div {
+								class: "flex flex-col items-center justify-center py-12",
+								div {
+									class: "spinner-lg mb-4",
+								}
+								p {
+									class: "text-content-secondary text-sm",
+									"Loading conversations..."
+								}
 							}
-						}
-					}
-				} else if rooms_signal.get().is_empty() {
-					div {
-						class: "flex flex-col items-center justify-center py-16 text-center px-4",
-						div {
-							class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
-							{
-								icons::chat_multi_icon_lg()
+						})()
+					} else if let Some(error_message) = error_signal.get() {
+						page!(|error_message: String| {
+							div {
+								class: "p-4",
+								div {
+									class: "alert-danger",
+									role: "alert",
+									{
+										error_message.clone()
+									}
+								}
 							}
-						}
-						h3 {
-							class: "text-lg font-semibold text-content-primary mb-1",
-							"No conversations yet"
-						}
-						p {
-							class: "text-content-secondary",
-							"Start a new conversation with someone!"
-						}
-					}
-				} else {
-					div {
-						for r in rooms_signal.get().iter() { {
-							room_item(r, on_room_select.clone())
-						} }
+						})(error_message)
+					} else if rooms_signal.get().is_empty() {
+						page!(|| {
+							div {
+								class: "flex flex-col items-center justify-center py-16 text-center px-4",
+								div {
+									class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
+									{
+										icons::chat_multi_icon_lg()
+									}
+								}
+								h3 {
+									class: "text-lg font-semibold text-content-primary mb-1",
+									"No conversations yet"
+								}
+								p {
+									class: "text-content-secondary",
+									"Start a new conversation with someone!"
+								}
+							}
+						})()
+					} else {
+						page!(|rooms: Vec<RoomInfo>, on_room_select: std::rc::Rc<dyn Fn(Uuid) >| {
+							div { {
+								Page::fragment(rooms.iter().map(|r| self::room_item(r, on_room_select.clone())), )
+							} }
+						})(rooms_signal.get(), on_room_select.clone())
 					}
 				}
 			}
 		}
-	})(rooms_signal, is_loading_signal, error_signal)
+	})(
+		rooms_signal,
+		is_loading_signal,
+		error_signal,
+		on_room_select,
+	)
 }

--- a/examples/examples-twitter/src/apps/profile/client/components.rs
+++ b/examples/examples-twitter/src/apps/profile/client/components.rs
@@ -74,128 +74,144 @@ pub fn profile_view(user_id: Uuid) -> Page {
 	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, profile_signal: Signal<Option<ProfileResponse>>, user_id_str: String| {
 		div {
 			class: "max-w-2xl mx-auto",
-			if loading_signal.get() {
-				div {
-					class: "flex flex-col items-center justify-center py-16",
-					div {
-						class: "spinner-lg mb-4",
-					}
-					p {
-						class: "text-content-secondary text-sm",
-						"Loading profile..."
-					}
-				}
-			} else if error_signal.get().is_some() {
-				div {
-					class: "p-4",
-					div {
-						class: "alert-danger",
-						role: "alert",
+			{
+				if loading_signal.get() {
+					page!(|| {
 						div {
-							class: "flex items-center gap-2",
-							{
-								icons::error_circle_icon()
-							}
-							span { {
-								error_signal.get().unwrap_or_default()
-							} }
-						}
-					}
-				}
-			} else if profile_signal.get().is_some() {
-				div {
-					class: "card overflow-hidden animate-fade-in",
-					div {
-						class: "h-32 sm:h-48 bg-gradient-to-r from-brand to-brand-dark relative",
-					}
-					div {
-						class: "px-4 pb-4",
-						div {
-							class: "flex justify-between items-end -mt-12 sm:-mt-16 mb-4",
+							class: "flex flex-col items-center justify-center py-16",
 							div {
-								class: "avatar-xl sm:w-32 sm:h-32 rounded-full border-4 border-surface-primary bg-surface-tertiary flex items-center justify-center text-3xl sm:text-4xl font-bold text-content-secondary",
-								span { "👤" }
+								class: "spinner-lg mb-4",
 							}
-							a {
-								href: format!("/profile/{}/edit", user_id_str),
-								class: "btn-outline",
-								"Edit profile"
+							p {
+								class: "text-content-secondary text-sm",
+								"Loading profile..."
 							}
 						}
+					})()
+				} else if let Some(error_message) = error_signal.get() {
+					page!(|error_message: String| {
 						div {
-							class: "mb-4",
-							h1 {
-								class: "text-xl font-bold text-content-primary",
-								"@user"
-							}
-						}
-						if let Some(ref data) = profile_signal.get() {
-							if data.bio.is_some() {
-								p {
-									class: "text-content-primary mb-4 whitespace-pre-wrap",
+							class: "p-4",
+							div {
+								class: "alert-danger",
+								role: "alert",
+								div {
+									class: "flex items-center gap-2",
 									{
-										data.bio.clone().unwrap_or_default()
+										icons::error_circle_icon()
 									}
+									span { {
+										error_message.clone()
+									} }
 								}
 							}
 						}
+					})(error_message)
+				} else if let Some(profile) = profile_signal.get() {
+					page!(|bio: Option<String>, location: Option<String>, website: Option<String>, user_id_str: String| {
 						div {
-							class: "flex flex-wrap gap-4 text-content-secondary text-sm",
-							if let Some(ref data) = profile_signal.get() {
-								if data.location.is_some() {
+							class: "card overflow-hidden animate-fade-in",
+							div {
+								class: "h-32 sm:h-48 bg-gradient-to-r from-brand to-brand-dark relative",
+							}
+							div {
+								class: "px-4 pb-4",
+								div {
+									class: "flex justify-between items-end -mt-12 sm:-mt-16 mb-4",
+									div {
+										class: "avatar-xl sm:w-32 sm:h-32 rounded-full border-4 border-surface-primary bg-surface-tertiary flex items-center justify-center text-3xl sm:text-4xl font-bold text-content-secondary",
+										span { "👤" }
+									}
+									a {
+										href: format!("/profile/{}/edit", user_id_str),
+										class: "btn-outline",
+										"Edit profile"
+									}
+								}
+								div {
+									class: "mb-4",
+									h1 {
+										class: "text-xl font-bold text-content-primary",
+										"@user"
+									}
+								}
+								{
+									bio.clone().map(|bio| {
+										page!(|bio: String| {
+											p {
+												class: "text-content-primary mb-4 whitespace-pre-wrap",
+												{ {
+													bio.clone()
+												} }
+											}
+										})(bio)
+									}).unwrap_or(Page::Empty)
+								}
+								div {
+									class: "flex flex-wrap gap-4 text-content-secondary text-sm",
+									{
+										location.clone().map(|location| {
+											page!(|location: String| {
+												div {
+													class: "flex items-center gap-1",
+													{
+														icons::location_pin_icon()
+													}
+													span { { {
+														location.clone()
+													} } }
+												}
+											})(location)
+										}).unwrap_or(Page::Empty)
+									}
+									{
+										website.clone().map(|website| {
+											page!(|website: String| {
+												a {
+													class: "flex items-center gap-1 text-brand hover:underline",
+													href: website.clone(),
+													target: "_blank",
+													rel: "noopener noreferrer",
+													{
+														icons::link_icon()
+													}
+													span { { {
+														website.clone()
+													} } }
+												}
+											})(website)
+										}).unwrap_or(Page::Empty)
+									}
+								}
+								div {
+									class: "flex gap-6 mt-4 pt-4 border-t border-border",
 									div {
 										class: "flex items-center gap-1",
-										{
-											icons::location_pin_icon()
+										span {
+											class: "font-bold text-content-primary",
+											"0"
 										}
-										span { {
-											data.location.clone().unwrap_or_default()
-										} }
+										span {
+											class: "text-content-secondary text-sm",
+											"Following"
+										}
 									}
-								}
-								if data.website.is_some() {
-									a {
-										class: "flex items-center gap-1 text-brand hover:underline",
-										href: data.website.clone().unwrap_or_default(),
-										target: "_blank",
-										rel: "noopener noreferrer",
-										{
-											icons::link_icon()
+									div {
+										class: "flex items-center gap-1",
+										span {
+											class: "font-bold text-content-primary",
+											"0"
 										}
-										span { {
-											data.website.clone().unwrap_or_default()
-										} }
+										span {
+											class: "text-content-secondary text-sm",
+											"Followers"
+										}
 									}
 								}
 							}
 						}
-						div {
-							class: "flex gap-6 mt-4 pt-4 border-t border-border",
-							div {
-								class: "flex items-center gap-1",
-								span {
-									class: "font-bold text-content-primary",
-									"0"
-								}
-								span {
-									class: "text-content-secondary text-sm",
-									"Following"
-								}
-							}
-							div {
-								class: "flex items-center gap-1",
-								span {
-									class: "font-bold text-content-primary",
-									"0"
-								}
-								span {
-									class: "text-content-secondary text-sm",
-									"Followers"
-								}
-							}
-						}
-					}
-				}
+					})(profile.bio.clone(), profile.location.clone(), profile.website.clone(), user_id_str.clone())
+				} else { Page::Empty }
 			}
 		}
 	})(loading_signal, error_signal, profile_signal, user_id_str)
@@ -215,6 +231,12 @@ pub fn profile_edit(user_id: Uuid) -> Page {
 	let profile_form = form! {
 		name: ProfileEditForm,
 		server_fn: update_profile_form,
+		method: Post,
+		// Route the CSRF token to `update_profile_form`'s trailing
+		// `_csrf_token: String` argument (server-side middleware verifies it).
+		strip_arguments: {
+			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
+		},
 		state: {
 			loading,
 			error,
@@ -351,35 +373,45 @@ pub fn profile_edit(user_id: Uuid) -> Page {
 				}
 				div {
 					class: "card-body",
-					if success_signal.get() {
-						div {
-							class: "alert-success mb-4",
-							role: "alert",
-							div {
-								class: "flex items-center gap-2",
-								{
-									icons::success_check_icon()
+					{
+						if success_signal.get() {
+							page!(|| {
+								div {
+									class: "alert-success mb-4",
+									role: "alert",
+									div {
+										class: "flex items-center gap-2",
+										{
+											icons::success_check_icon()
+										}
+										span { "Profile updated successfully! Redirecting..." }
+									}
 								}
-								span { "Profile updated successfully! Redirecting..." }
-							}
-						}
+							})()
+						} else { Page::Empty }
 					}
-					if error_signal.get().is_some() {
-						div {
-							class: "alert-danger mb-4",
-							role: "alert",
-							div {
-								class: "flex items-center gap-2",
-								{
-									icons::error_circle_icon()
+					{
+						error_signal.get().map(|error_message| {
+							page!(|error_message: String| {
+								div {
+									class: "alert-danger mb-4",
+									role: "alert",
+									div {
+										class: "flex items-center gap-2",
+										{
+											icons::error_circle_icon()
+										}
+										span { {
+											error_message.clone()
+										} }
+									}
 								}
-								span { {
-									error_signal.get().unwrap_or_default()
-								} }
-							}
-						}
+							})(error_message)
+						}).unwrap_or(Page::Empty)
 					}
-					{ form_view }
+					{ {
+						form_view.clone()
+					} }
 					div {
 						class: "flex justify-end gap-3 pt-4 border-t border-border mt-5",
 						a {

--- a/examples/examples-twitter/src/apps/relationship/client/components.rs
+++ b/examples/examples-twitter/src/apps/relationship/client/components.rs
@@ -72,13 +72,13 @@ pub fn follow_button(target_user_id: Uuid, is_following_initial: bool) -> Page {
 
 		let toggle_follow_for_error = toggle_follow.clone();
 
-		page!(|is_following_signal: Signal<bool>, toggle_follow: Action<(), String>, toggle_follow_for_error: Action<(), String>| {
+		page!(|target_user_id: Uuid, is_following_signal: Signal<bool>, toggle_follow: Action<(), String>, toggle_follow_for_error: Action<(), String>| {
 			div {
 				if toggle_follow.is_pending() {
 					button {
 						type: "button",
 						class: "btn-secondary opacity-50 cursor-not-allowed",
-						disabled: { true },
+						disabled: true,
 						aria_label: "Loading",
 						@click: {
 							let toggle_follow = toggle_follow.clone();
@@ -128,16 +128,25 @@ pub fn follow_button(target_user_id: Uuid, is_following_initial: bool) -> Page {
 						"Follow"
 					}
 				}
-				if toggle_follow_for_error.error().is_some() {
-					div {
-						class: "alert-danger mt-2 text-sm",
-						{
-							toggle_follow_for_error.error().unwrap_or_default()
-						}
-					}
+				{
+					toggle_follow_for_error.error().map(|error_message| {
+						page!(|error_message: String| {
+							div {
+								class: "alert-danger mt-2 text-sm",
+								{
+									error_message.clone()
+								}
+							}
+						})(error_message)
+					}).unwrap_or_else(Page::empty)
 				}
 			}
-		})(is_following_signal, toggle_follow, toggle_follow_for_error)
+		})(
+			target_user_id,
+			is_following_signal,
+			toggle_follow,
+			toggle_follow_for_error,
+		)
 	}
 
 	#[cfg(native)]
@@ -305,64 +314,76 @@ pub fn user_list(user_id: Uuid, list_type: UserListType) -> Page {
 				}
 				h2 {
 					class: "text-xl font-bold text-content-primary",
-					{ title }
+					{
+						title.clone()
+					}
 				}
 			}
-			if loading_signal.get() {
-				div {
-					class: "flex flex-col items-center justify-center py-12",
-					div {
-						class: "spinner-lg mb-4",
-					}
-					p {
-						class: "text-content-secondary text-sm",
-						"Loading..."
-					}
-				}
-			} else if error_signal.get().is_some() {
-				div {
-					class: "alert-danger",
-					div {
-						class: "flex items-center gap-2",
-						{
-							icons::error_circle_icon()
-						}
-						span { {
-							error_signal.get().unwrap_or_default()
-						} }
-					}
-				}
-			} else if users_signal.get().is_empty() {
-				div {
-					class: "flex flex-col items-center justify-center py-16 text-center",
-					div {
-						class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
-						svg {
-							class: "w-8 h-8 text-content-tertiary",
-							fill: "none",
-							stroke: "currentColor",
-							viewBox: "0 0 24 24",
-							path {
-								stroke_linecap: "round",
-								stroke_linejoin: "round",
-								stroke_width: "1.5",
-								d: empty_icon.clone(),
+			{
+				if loading_signal.get() {
+					page!(|| {
+						div {
+							class: "flex flex-col items-center justify-center py-12",
+							div {
+								class: "spinner-lg mb-4",
+							}
+							p {
+								class: "text-content-secondary text-sm",
+								"Loading..."
 							}
 						}
-					}
-					p {
-						class: "text-content-secondary",
-						{
-							empty_message.clone()
+					})()
+				} else if let Some(error_message) = error_signal.get() {
+					page!(|error_message: String| {
+						div {
+							class: "alert-danger",
+							div {
+								class: "flex items-center gap-2",
+								{
+									icons::error_circle_icon()
+								}
+								span { {
+									error_message.clone()
+								} }
+							}
 						}
-					}
-				}
-			} else {
-				div {
-					class: "card overflow-hidden",
-					for user in users_signal.get().iter() { {
-						user_card(user)
-					} }
+					})(error_message)
+				} else if users_signal.get().is_empty() {
+					page!(|empty_message: String, empty_icon: String| {
+						div {
+							class: "flex flex-col items-center justify-center py-16 text-center",
+							div {
+								class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
+								svg {
+									class: "w-8 h-8 text-content-tertiary",
+									fill: "none",
+									stroke: "currentColor",
+									viewBox: "0 0 24 24",
+									path {
+										stroke_linecap: "round",
+										stroke_linejoin: "round",
+										stroke_width: "1.5",
+										d: empty_icon.clone(),
+									}
+								}
+							}
+							p {
+								class: "text-content-secondary",
+								{
+									empty_message.clone()
+								}
+							}
+						}
+					})(empty_message.clone(), empty_icon.clone())
+				} else {
+					page!(|users: Vec<UserInfo>| {
+						div {
+							class: "card overflow-hidden",
+							for user in users.clone() { {
+								self::user_card(&user)
+							} }
+						}
+					})(users_signal.get())
 				}
 			}
 		}

--- a/examples/examples-twitter/src/apps/tweet/client/components.rs
+++ b/examples/examples-twitter/src/apps/tweet/client/components.rs
@@ -28,66 +28,82 @@ use crate::apps::tweet::shared::server_fn::{create_tweet, delete_tweet};
 /// This function is separated from tweet_card to avoid nested watch block issues
 /// with closure ownership in the page! macro.
 fn like_button(liked: Signal<bool>, like_count: Signal<i32>) -> Page {
-	// Clone signals for the watch block
-	let liked_signal = liked.clone();
-	let like_count_signal = like_count.clone();
-	let like_count_signal_else = like_count.clone();
 	// Clone signals for event handlers
 	let liked_for_click_if = liked.clone();
 	let like_count_for_click_if = like_count.clone();
 	let liked_for_click_else = liked.clone();
 	let like_count_for_click_else = like_count.clone();
 
-	page!(|liked_signal: Signal<bool>, like_count_signal: Signal<i32>, like_count_signal_else: Signal<i32>, liked_for_click_if: Signal<bool>, like_count_for_click_if: Signal<i32>, liked_for_click_else: Signal<bool>, like_count_for_click_else: Signal<i32>| {
-		if liked_signal.get() {
-			button {
-				class: "tweet-action-btn text-danger",
-				type: "button",
-				aria_label: "Like",
-				@click: {
-					let liked_for_click = liked_for_click_if.clone();
-					let like_count_for_click = like_count_for_click_if.clone();
-					move |_event| {
-						let current_liked = liked_for_click.get();
-						let current_count = like_count_for_click.get();
-						liked_for_click.set(!current_liked);
-						like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+	page!(|liked: Signal<bool>,
+	       like_count: Signal<i32>,
+	       liked_for_click_if: Signal<bool>,
+	       like_count_for_click_if: Signal<i32>,
+	       liked_for_click_else: Signal<bool>,
+	       like_count_for_click_else: Signal<i32>| {
+		{
+			// Read the Copy signal values to local Copy values once in this
+			// single reactive scope, then build the markup via an inner
+			// `page!` that receives the Copy values and handler-signal clones.
+			let is_liked = liked.get();
+			let count = like_count.get();
+			page!(|is_liked: bool, count: i32, liked_for_click_if: Signal<bool>, like_count_for_click_if: Signal<i32>, liked_for_click_else: Signal<bool>, like_count_for_click_else: Signal<i32>| {
+				if is_liked {
+					button {
+						class: "tweet-action-btn text-danger",
+						type: "button",
+						aria_label: "Like",
+						@click: {
+							let liked_for_click = liked_for_click_if.clone();
+							let like_count_for_click = like_count_for_click_if.clone();
+							move |_event| {
+								let current_liked = liked_for_click.get();
+								let current_count = like_count_for_click.get();
+								liked_for_click.set(!current_liked);
+								like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+							}
+						},
+						{
+							icons::heart_icon_filled()
+						}
+						span { {
+							format!("{}", count)
+						} }
 					}
-				},
-				{
-					icons::heart_icon_filled()
-				}
-				span { {
-					format!("{}", like_count_signal.get())
-				} }
-			}
-		} else {
-			button {
-				class: "tweet-action-btn hover:text-danger",
-				type: "button",
-				aria_label: "Like",
-				@click: {
-					let liked_for_click = liked_for_click_else.clone();
-					let like_count_for_click = like_count_for_click_else.clone();
-					move |_event| {
-						let current_liked = liked_for_click.get();
-						let current_count = like_count_for_click.get();
-						liked_for_click.set(!current_liked);
-						like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+				} else {
+					button {
+						class: "tweet-action-btn hover:text-danger",
+						type: "button",
+						aria_label: "Like",
+						@click: {
+							let liked_for_click = liked_for_click_else.clone();
+							let like_count_for_click = like_count_for_click_else.clone();
+							move |_event| {
+								let current_liked = liked_for_click.get();
+								let current_count = like_count_for_click.get();
+								liked_for_click.set(!current_liked);
+								like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+							}
+						},
+						{
+							icons::heart_icon_outline()
+						}
+						span { {
+							format!("{}", count)
+						} }
 					}
-				},
-				{
-					icons::heart_icon_outline()
 				}
-				span { {
-					format!("{}", like_count_signal_else.get())
-				} }
-			}
+			})(
+				is_liked,
+				count,
+				liked_for_click_if.clone(),
+				like_count_for_click_if.clone(),
+				liked_for_click_else.clone(),
+				like_count_for_click_else.clone(),
+			)
 		}
 	})(
-		liked_signal,
-		like_count_signal,
-		like_count_signal_else,
+		liked,
+		like_count,
 		liked_for_click_if,
 		like_count_for_click_if,
 		liked_for_click_else,
@@ -126,120 +142,153 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 	// Clone for error display watch block (separate closure from main watch block)
 	let delete_action_for_error = delete_action.clone();
 
-	page!(|delete_action: Action<(), String>, show_delete: bool, username: String, content: String, created_at: String, tweet_id: Uuid, liked_signal: Signal<bool>, like_count_signal: Signal<i32>, delete_action_for_click: Action<(), String>, delete_action_for_error: Action<(), String>| {
-		if delete_action.is_success() {
-			div {
-				class: "hidden",
-			}
-		} else {
-			div {
-				class: "tweet-card animate-fade-in",
-				div {
-					class: "flex gap-3",
+	page!(|delete_action: Action<(), String>,
+	       show_delete: bool,
+	       username: String,
+	       content: String,
+	       created_at: String,
+	       tweet_id: Uuid,
+	       liked_signal: Signal<bool>,
+	       like_count_signal: Signal<i32>,
+	       delete_action_for_click: Action<(), String>,
+	       delete_action_for_error: Action<(), String>| {
+		// Main card body: a single reactive scope that reads the Copy
+		// `is_success` flag once and builds each branch via an inner
+		// `page!`, passing the owned String/Signal/Action values as the
+		// inner closure's own parameters (avoids E0507 from nested scopes).
+		{
+			if delete_action.is_success() {
+				page!(|| { div { class: "hidden" } })()
+			} else {
+				page!(|show_delete: bool, username_avatar: String, username_name: String, username_handle: String, content: String, created_at: String, tweet_id: Uuid, liked_signal: Signal<bool>, like_count_signal: Signal<i32>, delete_action_for_click: Action<(), String>| {
 					div {
-						class: "flex-shrink-0",
+						class: "tweet-card animate-fade-in",
 						div {
-							class: "tweet-avatar bg-surface-tertiary flex items-center justify-center text-content-secondary font-semibold",
-							{
-								username.clone().chars().next().unwrap_or('U').to_uppercase().to_string()
-							}
-						}
-					}
-					div {
-						class: "flex-1 min-w-0",
-						div {
-							class: "flex items-center justify-between gap-2",
+							class: "flex gap-3",
 							div {
-								class: "flex items-center gap-1 min-w-0",
-								span {
-									class: "tweet-username truncate",
+								class: "flex-shrink-0",
+								div {
+									class: "tweet-avatar bg-surface-tertiary flex items-center justify-center text-content-secondary font-semibold",
 									{
-										username.clone()
-									}
-								}
-								span {
-									class: "tweet-handle truncate",
-									{
-										format!("@{}", username.clone())
-									}
-								}
-								span {
-									class: "text-content-tertiary",
-									"·"
-								}
-								span {
-									class: "tweet-time",
-									{
-										created_at.clone()
+										username_avatar.clone().chars().next().unwrap_or('U').to_uppercase().to_string()
 									}
 								}
 							}
-							if show_delete {
-								button {
-									class: "btn-ghost btn-sm text-danger hover:bg-danger/10",
-									type: "button",
-									aria_label: "Delete tweet",
-									@click: {
-										let delete_action = delete_action_for_click.clone();
-										move |_event| {
-											delete_action.dispatch(tweet_id);
+							div {
+								class: "flex-1 min-w-0",
+								div {
+									class: "flex items-center justify-between gap-2",
+									div {
+										class: "flex items-center gap-1 min-w-0",
+										span {
+											class: "tweet-username truncate",
+											{
+												username_name.clone()
+											}
 										}
-									},
-									{
-										icons::trash_icon()
+										span {
+											class: "tweet-handle truncate",
+											{
+												format!("@{}", username_handle.clone())
+											}
+										}
+										span {
+											class: "text-content-tertiary",
+											"·"
+										}
+										span {
+											class: "tweet-time",
+											{
+												created_at.clone()
+											}
+										}
+									}
+									if show_delete {
+										button {
+											class: "btn-ghost btn-sm text-danger hover:bg-danger/10",
+											type: "button",
+											aria_label: "Delete tweet",
+											@click: {
+												let delete_action = delete_action_for_click.clone();
+												move |_event| {
+													delete_action.dispatch(tweet_id);
+												}
+											},
+											{
+												icons::trash_icon()
+											}
+										}
 									}
 								}
-							}
-						}
-						p {
-							class: "tweet-content",
-							{
-								content.clone()
-							}
-						}
-						div {
-							class: "tweet-actions",
-							button {
-								class: "tweet-action-btn hover:text-brand",
-								type: "button",
-								aria_label: "Reply",
-								{
-									icons::chat_bubble_icon()
+								p {
+									class: "tweet-content",
+									{
+										content.clone()
+									}
 								}
-								span { "0" }
-							}
-							button {
-								class: "tweet-action-btn hover:text-success",
-								type: "button",
-								aria_label: "Retweet",
-								{
-									icons::retweet_icon()
-								}
-								span { "0" }
-							}
-							{
-								like_button(liked_signal.clone(), like_count_signal.clone())
-							}
-							button {
-								class: "tweet-action-btn hover:text-brand",
-								type: "button",
-								aria_label: "Share",
-								{
-									icons::share_icon()
+								div {
+									class: "tweet-actions",
+									button {
+										class: "tweet-action-btn hover:text-brand",
+										type: "button",
+										aria_label: "Reply",
+										{
+											icons::chat_bubble_icon()
+										}
+										span { "0" }
+									}
+									button {
+										class: "tweet-action-btn hover:text-success",
+										type: "button",
+										aria_label: "Retweet",
+										{
+											icons::retweet_icon()
+										}
+										span { "0" }
+									}
+									{
+										self::like_button(liked_signal.clone(), like_count_signal.clone())
+									}
+									button {
+										class: "tweet-action-btn hover:text-brand",
+										type: "button",
+										aria_label: "Share",
+										{
+											icons::share_icon()
+										}
+									}
 								}
 							}
 						}
 					}
-				}
+				})(
+					show_delete,
+					username.clone(),
+					username.clone(),
+					username.clone(),
+					content.clone(),
+					created_at.clone(),
+					tweet_id,
+					liked_signal.clone(),
+					like_count_signal.clone(),
+					delete_action_for_click.clone(),
+				)
 			}
-		}
-		if delete_action_for_error.error().is_some() {
-			div {
-				class: "alert-danger mt-3",
-				{
-					delete_action_for_error.error().unwrap_or_default()
-				}
-			}
+		} // Error alert: a single optional banner built via `.map(...)`.
+		{
+			delete_action_for_error
+				.error()
+				.map(|error_message| {
+					page!(|error_message: String| {
+						div {
+							class: "alert-danger mt-3",
+							{ {
+								error_message.clone()
+							} }
+						}
+					})(error_message)
+				})
+				.unwrap_or_else(Page::empty)
 		}
 	})(
 		delete_action,
@@ -273,6 +322,11 @@ pub fn tweet_form() -> Page {
 		name: TweetFormInner,
 		server_fn: create_tweet,
 		method: Post,
+		// Route the CSRF token to `create_tweet`'s trailing `_csrf_token: String`
+		// argument (server-side middleware performs the actual verification).
+		strip_arguments: {
+			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
+		},
 		state: {
 			loading,
 			error,
@@ -434,55 +488,70 @@ pub fn tweet_list(user_id: Option<Uuid>) -> Page {
 
 	page!(|tweets_signal: Signal<Vec<TweetInfo>>, loading_signal: Signal<bool>, error_signal: Signal<Option<String>>| {
 		div {
-			if loading_signal.get() {
-				div {
-					class: "flex flex-col items-center justify-center py-12",
-					div {
-						class: "spinner-lg mb-4",
-					}
-					p {
-						class: "text-content-secondary text-sm",
-						"Loading tweets..."
-					}
-				}
-			} else if error_signal.get().is_some() {
-				div {
-					class: "alert-danger",
-					role: "alert",
-					div {
-						class: "flex items-center gap-2",
-						{
-							icons::error_circle_icon()
+			// Single reactive scope: read the signals via `.get()` once,
+			// then build each branch from a fresh inner `page!` that
+			// receives its values as its own parameters. This avoids the
+			// nested-reactive-scope E0507 that arises when captured
+			// `Signal`/`Vec`/`String` values are consumed in child nodes.
+			{
+				if loading_signal.get() {
+					page!(|| {
+						div {
+							class: "flex flex-col items-center justify-center py-12",
+							div {
+								class: "spinner-lg mb-4",
+							}
+							p {
+								class: "text-content-secondary text-sm",
+								"Loading tweets..."
+							}
 						}
-						span { {
-							error_signal.get().unwrap_or_default()
-						} }
-					}
-				}
-			} else if tweets_signal.get().is_empty() {
-				div {
-					class: "flex flex-col items-center justify-center py-16 text-center",
-					div {
-						class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
-						{
-							icons::chat_bubble_icon_lg()
+					})()
+				} else if let Some(error_message) = error_signal.get() {
+					page!(|error_message: String| {
+						div {
+							class: "alert-danger",
+							role: "alert",
+							div {
+								class: "flex items-center gap-2",
+								{
+									icons::error_circle_icon()
+								}
+								span { { {
+									error_message.clone()
+								} } }
+							}
 						}
-					}
-					h3 {
-						class: "text-lg font-semibold text-content-primary mb-1",
-						"No tweets yet"
-					}
-					p {
-						class: "text-content-secondary",
-						"Be the first to share something!"
-					}
-				}
-			} else {
-				div {
-					class: "card overflow-hidden",
-					for tweet in tweets_signal.get().iter() { {
-						tweet_card(tweet, false)
-					} }
+					})(error_message)
+				} else if tweets_signal.get().is_empty() {
+					page!(|| {
+						div {
+							class: "flex flex-col items-center justify-center py-16 text-center",
+							div {
+								class: "w-16 h-16 rounded-full bg-surface-tertiary flex items-center justify-center mb-4",
+								{
+									icons::chat_bubble_icon_lg()
+								}
+							}
+							h3 {
+								class: "text-lg font-semibold text-content-primary mb-1",
+								"No tweets yet"
+							}
+							p {
+								class: "text-content-secondary",
+								"Be the first to share something!"
+							}
+						}
+					})()
+				} else {
+					page!(|tweets: Vec<TweetInfo>| {
+						div {
+							class: "card overflow-hidden",
+							for tweet in tweets.clone() { {
+								self::tweet_card(&tweet, false)
+							} }
+						}
+					})(tweets_signal.get())
 				}
 			}
 		}

--- a/examples/examples-twitter/src/apps/tweet/shared/pagination.rs
+++ b/examples/examples-twitter/src/apps/tweet/shared/pagination.rs
@@ -3,7 +3,7 @@
 //! Provides standardized pagination response format following
 //! the cookbook patterns (docs/cookbook/pagination.en.md).
 
-use reinhardt::core::serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// Paginated response wrapper
 ///

--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -113,32 +113,37 @@ pub fn button_with_size(
 	#[cfg(wasm)]
 	{
 		let on_click_clone = on_click.clone();
-		page!(| class : String, text : String, disabled : bool | {
+		page!(| class : String, text : String, disabled : bool, on_click_clone : Signal < bool > | {
 			button {
 				class : class,
 				type : "button",
 				disabled : disabled,
 				@ click : {
-					let { on_click }
-					=on_click_clone.clone();
+					let on_click = on_click_clone.clone();
 					move | _event | {
 						on_click.set(true);
 					}
 				},
-				{ { text } }
+				{ {
+					text.clone()
+				} }
 			}
-		})(class, text, disabled)
+		})(class, text, disabled, on_click_clone)
 	}
 	#[cfg(native)]
 	{
 		let _ = on_click;
 		page!(|class: String, text: String, disabled: bool| {
 			button {
-				class: { { class } },
+				class: { {
+					class.clone()
+				} },
 				type: "button",
 				disabled: disabled,
 				data_reactive: "true",
-				{ { text } }
+				{ {
+					text.clone()
+				} }
 			}
 		})(class, text, disabled)
 	}
@@ -173,7 +178,9 @@ pub fn loading_spinner_large(message: &str) -> Page {
 			}
 			p {
 				class: "text-content-secondary text-sm",
-				{ { message } }
+				{ {
+					message.clone()
+				} }
 			}
 		}
 	})(message)
@@ -200,7 +207,9 @@ pub fn error_alert(message: &str, dismissible: bool) -> Page {
 					}
 					span {
 						class: "flex-1",
-						{ { message } }
+						{ {
+							message.clone()
+						} }
 					}
 					button {
 						type: "button",
@@ -223,7 +232,9 @@ pub fn error_alert(message: &str, dismissible: bool) -> Page {
 					{
 						icons::error_circle_icon_with_class("w-5 h-5 flex-shrink-0 mt-0.5")
 					}
-					span { { message } }
+					span { {
+						message.clone()
+					} }
 				}
 			}
 		})(message)
@@ -247,7 +258,9 @@ pub fn success_alert(message: &str) -> Page {
 				{
 					icons::success_check_icon()
 				}
-				span { { message } }
+				span { {
+					message.clone()
+				} }
 			}
 		}
 	})(message)
@@ -264,7 +277,9 @@ pub fn warning_alert(message: &str) -> Page {
 				{
 					icons::warning_icon()
 				}
-				span { { message } }
+				span { {
+					message.clone()
+				} }
 			}
 		}
 	})(message)
@@ -297,13 +312,15 @@ pub fn text_input(
 	#[cfg(wasm)]
 	{
 		let value_clone = value.clone();
-		page!(| id_owned : String, label_owned : String, input_type_owned : String, placeholder_owned : String, value_signal : Signal < String >, required : bool| {
+		page!(| id_owned : String, label_owned : String, input_type_owned : String, placeholder_owned : String, value_signal : Signal < String >, required : bool, value_clone : Signal < String > | {
 			div {
 				class : "mb-4",
 				label {
 					for : id_owned.clone(),
 					class : "form-label",
-					{ { label_owned } }
+					{ {
+						label_owned.clone()
+					} }
 				}
 				input {
 					type : input_type_owned.clone(),
@@ -314,9 +331,8 @@ pub fn text_input(
 					value : value_signal.get(),
 					required: required,
 					@ input : {
-						let { value }
-						= value_clone.clone();
-						move | event :web_sys::Event | {
+						let value = value_clone.clone();
+						move | event : web_sys::Event | {
 							if let Some(target) = event.target() {
 								if let Ok(input_el) = target.dyn_into::< web_sys::HtmlInputElement >() {
 									value.set(input_el.value());
@@ -333,6 +349,7 @@ pub fn text_input(
 			placeholder_owned,
 			value_signal,
 			required,
+			value_clone,
 		)
 	}
 	#[cfg(native)]
@@ -345,7 +362,9 @@ pub fn text_input(
 						id_owned.clone()
 					},
 					class: "form-label",
-					{ { label_owned } }
+					{ {
+						label_owned.clone()
+					} }
 				}
 				input {
 					type: {
@@ -413,27 +432,28 @@ pub fn textarea(
 	#[cfg(wasm)]
 	{
 		let value_clone = value.clone();
-		page!(| id_owned : String, label_owned : String, rows_str : String, placeholder_owned : String, value_signal : Signal < String >, value_signal_for_count : Signal < String >, maxlength_attr : String, show_count : bool, max_length : usize | {
+		page!(| id_owned : String, label_owned : String, rows_str : String, placeholder_owned : String, value_signal : Signal < String >, value_signal_for_count : Signal < String >, maxlength_attr : String, show_count : bool, max_length : usize, value_clone : Signal < String > | {
 			div {
 				class : "mb-4",
 				label {
-					for :id_owned.clone(),
+					for : id_owned.clone(),
 					class : "form-label",
-					{ { label_owned } }
+					{ {
+						label_owned.clone()
+					} }
 				}
 				textarea {
 					class : "form-textarea",
 					id : id_owned.clone(),
 					name : id_owned.clone(),
-					rows: rows_str.clone(),
+					rows : rows_str.clone(),
 					placeholder : placeholder_owned.clone(),
-					maxlength :maxlength_attr.clone(),
+					maxlength : maxlength_attr.clone(),
 					@ input : {
-						let { value }
-						= value_clone.clone();
-						move| event : web_sys::Event | {
+						let value = value_clone.clone();
+						move | event : web_sys::Event | {
 							if let Some(target) = event.target() {
-								if letOk(textarea_el) = target.dyn_into::< web_sys::HtmlTextAreaElement >() {
+								if let Ok(textarea_el) = target.dyn_into::< web_sys::HtmlTextAreaElement >() {
 									value.set(textarea_el.value());
 								}
 							}
@@ -443,16 +463,24 @@ pub fn textarea(
 						value_signal.get()
 					}
 				}
-				ifshow_count {
-					div {
-						class : "flex justify-end mt-1",
-						span {
-							class : ifvalue_signal_for_count.get().len() > max_length { "text-danger font-medium" } else if value_signal_for_count.get().len() > { max_length }
-							* 9 / 10 { "text-warning font-medium" } else { "text-content-tertiary" },
-							{
-								format!("{}/{}", value_signal_for_count.get().len(), max_length)
+				{
+					if show_count {
+						let char_count = value_signal_for_count.get().len();
+						page!(| char_count : usize, max_length : usize | {
+							div {
+								class : "flex justify-end mt-1",
+								span {
+									class : {
+										if char_count > max_length { "text-danger font-medium" } else if char_count > max_length * 9 / 10 { "text-warning font-medium" } else { "text-content-tertiary" }
+									},
+									{ {
+										format!("{}/{}", char_count, max_length)
+									} }
+								}
 							}
-						}
+						})(char_count, max_length)
+					} else {
+						Page::empty()
 					}
 				}
 			}
@@ -466,11 +494,12 @@ pub fn textarea(
 			maxlength_attr,
 			show_count,
 			max_length,
+			value_clone,
 		)
 	}
 	#[cfg(native)]
 	{
-		page!(| id_owned : String, label_owned : String, rows_str : String, placeholder_owned : String, value_signal : Signal < String >, maxlength_attr: String, show_count : bool, max_length : usize | {
+		page!(| id_owned : String, label_owned : String, rows_str : String, placeholder_owned : String, value_signal : Signal < String >, value_signal_for_count : Signal < String >, maxlength_attr : String, show_count : bool, max_length : usize | {
 			div {
 				class : "mb-4",
 				label {
@@ -478,7 +507,9 @@ pub fn textarea(
 						id_owned.clone()
 					},
 					class : "form-label",
-					{ { label_owned } }
+					{ {
+						label_owned.clone()
+					} }
 				}
 				textarea {
 					class : "form-textarea",
@@ -502,22 +533,24 @@ pub fn textarea(
 						value_signal.get()
 					}
 				}
-				if show_count {
-					let { char_count }
-					= value_signal.get().len();
-					let { count_class }
-					= if { char_count }
-					> max_length { "text-danger font-medium" } else if { char_count }
-					> { max_length }
-					* 9 / 10 { "text-warning font-medium" } else { "text-content-tertiary" };
-					let { count_text }
-					= format!("{}/{}", char_count, max_length);
-					div {
-						class : "flex justify-end mt-1",
-						span {
-							class : { { count_class } },
-							{ { count_text } }
-						}
+				{
+					if show_count {
+						let char_count = value_signal_for_count.get().len();
+						page!(| char_count : usize, max_length : usize | {
+							div {
+								class : "flex justify-end mt-1",
+								span {
+									class : {
+										if char_count > max_length { "text-danger font-medium" } else if char_count > max_length * 9 / 10 { "text-warning font-medium" } else { "text-content-tertiary" }
+									},
+									{ {
+										format!("{}/{}", char_count, max_length)
+									} }
+								}
+							}
+						})(char_count, max_length)
+					} else {
+						Page::empty()
 					}
 				}
 			}
@@ -527,6 +560,7 @@ pub fn textarea(
 			rows_str,
 			placeholder_owned,
 			value_signal,
+			value_signal_for_count,
 			maxlength_attr,
 			show_count,
 			max_length,
@@ -626,17 +660,11 @@ pub fn theme_toggle() -> Page {
 ///
 /// Displays an empty div (useful for conditional rendering).
 pub fn empty() -> Page {
-	page!(|| {
-		div {}
-	})()
+	page!(|| { div {} })()
 }
 /// Divider component
 pub fn divider() -> Page {
-	page!(|| {
-		div {
-			class: "divider"
-		}
-	})()
+	page!(|| { div { class: "divider" } })()
 }
 /// Badge component
 pub fn badge(text: &str, primary: bool) -> Page {
@@ -650,7 +678,9 @@ pub fn badge(text: &str, primary: bool) -> Page {
 	page!(|text: String, class: String| {
 		span {
 			class: class,
-			{ { text } }
+			{ {
+				text.clone()
+			} }
 		}
 	})(text, class)
 }

--- a/examples/examples-twitter/src/core/client/components/layout.rs
+++ b/examples/examples-twitter/src/core/client/components/layout.rs
@@ -95,7 +95,9 @@ pub fn header(site_name: &str, current_user: Option<&UserInfo>, nav_items: &[Nav
 		})
 		.collect();
 	let nav_links_view = page!(|nav_links: Vec<Page>| {
-		for link in nav_links { { link } }
+		for link in nav_links.clone() {
+			{ link.clone() }
+		}
 	})(nav_links);
 	let brand_link = Link::new("/".to_string(), site_name.to_string())
 		.class("text-xl font-bold text-content-primary hover:text-brand transition-colors")
@@ -111,9 +113,13 @@ pub fn header(site_name: &str, current_user: Option<&UserInfo>, nav_items: &[Nav
 				class: "flex items-center gap-3",
 				span {
 					class: "text-content-secondary text-sm hidden md:block",
-					{ { username } }
+					{ {
+						username.clone()
+					} }
 				}
-				{ { profile_link } }
+				{ {
+					profile_link.clone()
+				} }
 				a {
 					href: "/logout",
 					class: "btn-outline btn-sm",
@@ -131,8 +137,12 @@ pub fn header(site_name: &str, current_user: Option<&UserInfo>, nav_items: &[Nav
 		page!(|login_link: Page, register_link: Page| {
 			div {
 				class: "flex items-center gap-2",
-				{ { login_link } }
-				{ { register_link } }
+				{ {
+					login_link.clone()
+				} }
+				{ {
+					register_link.clone()
+				} }
 			}
 		})(login_link, register_link)
 	};
@@ -145,16 +155,24 @@ pub fn header(site_name: &str, current_user: Option<&UserInfo>, nav_items: &[Nav
 					class: "flex items-center justify-between h-14",
 					div {
 						class: "flex items-center gap-6",
-						{ { brand_link } }
+						{ {
+							brand_link.clone()
+						} }
 						nav {
 							class: "hidden md:flex items-center gap-1",
-							{ { nav_links_view } }
+							{ {
+								nav_links_view.clone()
+							} }
 						}
 					}
 					div {
 						class: "flex items-center gap-2",
-						{ { theme_toggle_view } }
-						{ { user_menu } }
+						{ {
+							theme_toggle_view.clone()
+						} }
+						{ {
+							user_menu.clone()
+						} }
 					}
 				}
 			}
@@ -181,15 +199,21 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 					class: "sidebar-item block",
 					div {
 						class: "text-content-tertiary text-xs mb-0.5",
-						{ { category } }
+						{ {
+							category.clone()
+						} }
 					}
 					div {
 						class: "font-semibold text-content-primary",
-						{ { name } }
+						{ {
+							name.clone()
+						} }
 					}
 					div {
 						class: "text-content-tertiary text-xs mt-0.5",
-						{ { tweets_text } }
+						{ {
+							tweets_text.clone()
+						} }
 					}
 				}
 			})(href, name, category, tweets_text)
@@ -205,7 +229,9 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|topics_list: Vec<Page>| {
-			for topic in topics_list { { topic } }
+			for topic in topics_list.clone() {
+				{ topic.clone() }
+			}
 		})(topics_list)
 	};
 	let users_list: Vec<Page> = suggested_users
@@ -213,8 +239,6 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		.map(|user| {
 			let profile_href = format!("/profile/{}", user.id);
 			let username = format!("@{}", user.username);
-			let has_bio = user.bio.is_some();
-			let bio_text = user.bio.clone().unwrap_or_default();
 			let avatar_initial = user
 				.username
 				.chars()
@@ -222,28 +246,43 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 				.unwrap_or('U')
 				.to_uppercase()
 				.to_string();
-			page!(|profile_href: String, username: String, has_bio: bool, bio_text: String, avatar_initial: String| {
+			// Build the optional bio paragraph in this once-evaluated scope so the
+			// reactive page! body only needs to interpolate a ready-made `Page`.
+			let bio_view = if let Some(bio_text) = user.bio.clone() {
+				page!(|bio_text: String| {
+					p {
+						class: "text-content-tertiary text-xs truncate",
+						{ {
+							bio_text.clone()
+						} }
+					}
+				})(bio_text)
+			} else {
+				Page::empty()
+			};
+			page!(|profile_href: String, username: String, avatar_initial: String, bio_view: Page| {
 				div {
 					class: "sidebar-item",
 					div {
 						class: "flex items-center gap-3",
 						div {
 							class: "w-10 h-10 rounded-full bg-surface-tertiary flex items-center justify-center text-content-secondary font-semibold text-sm",
-							{ { avatar_initial } }
+							{ {
+								avatar_initial.clone()
+							} }
 						}
 						div {
 							class: "flex-1 min-w-0",
 							a {
 								href: profile_href,
 								class: "font-semibold text-content-primary hover:underline block truncate",
-								{ { username } }
+								{ {
+									username.clone()
+								} }
 							}
-							if has_bio {
-								p {
-									class: "text-content-tertiary text-xs truncate",
-									{ { bio_text } }
-								}
-							}
+							{ {
+								bio_view.clone()
+							} }
 						}
 						button {
 							class: "btn-outline btn-sm flex-shrink-0",
@@ -251,13 +290,7 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 						}
 					}
 				}
-			})(
-				profile_href,
-				username,
-				has_bio,
-				bio_text,
-				avatar_initial,
-			)
+			})(profile_href, username, avatar_initial, bio_view)
 		})
 		.collect();
 	let users_empty = users_list.is_empty();
@@ -270,7 +303,9 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|users_list: Vec<Page>| {
-			for user in users_list { { user } }
+			for user in users_list.clone() {
+				{ user.clone() }
+			}
 		})(users_list)
 	};
 	page!(|topics_view: Page, users_view: Page| {
@@ -282,7 +317,9 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 					class: "sidebar-header",
 					"Trending"
 				}
-				{ { topics_view } }
+				{ {
+					topics_view.clone()
+				} }
 				a {
 					href: "/explore",
 					class: "block px-4 py-3 text-brand text-sm hover:bg-surface-secondary transition-colors",
@@ -295,7 +332,9 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 					class: "sidebar-header",
 					"Who to follow"
 				}
-				{ { users_view } }
+				{ {
+					users_view.clone()
+				} }
 				a {
 					href: "/explore/users",
 					class: "block px-4 py-3 text-brand text-sm hover:bg-surface-secondary transition-colors",
@@ -495,17 +534,27 @@ pub fn main_layout(
 	page!(|header_view: Page, main_content: Page, footer_view: Page, bottom_nav: Page, fab: Page| {
 		div {
 			class: "layout-main bg-surface-secondary",
-			{ { header_view } }
+			{ {
+				header_view.clone()
+			} }
 			main {
 				class: "flex-1 pt-4 pb-20 md:pb-4",
 				div {
 					class: "layout-container",
-					{ { main_content } }
+					{ {
+						main_content.clone()
+					} }
 				}
 			}
-			{ { footer_view } }
-			{ { bottom_nav } }
-			{ { fab } }
+			{ {
+				footer_view.clone()
+			} }
+			{ {
+				bottom_nav.clone()
+			} }
+			{ {
+				fab.clone()
+			} }
 		}
 	})(header_view, main_content, footer_view, bottom_nav, fab)
 }
@@ -518,18 +567,24 @@ pub fn simple_layout(site_name: &str, nav_items: &[NavItem], content: Page, vers
 	page!(|header_view: Page, content: Page, footer_view: Page| {
 		div {
 			class: "layout-main bg-surface-secondary",
-			{ { header_view } }
+			{ {
+				header_view.clone()
+			} }
 			main {
 				class: "flex-1 py-8",
 				div {
 					class: "layout-container",
 					div {
 						class: "max-w-md mx-auto",
-						{ { content } }
+						{ {
+							content.clone()
+						} }
 					}
 				}
 			}
-			{ { footer_view } }
+			{ {
+				footer_view.clone()
+			} }
 		}
 	})(header_view, content, footer_view)
 }

--- a/examples/examples-twitter/src/core/client/router.rs
+++ b/examples/examples-twitter/src/core/client/router.rs
@@ -73,8 +73,12 @@ pub fn timeline_page_view() -> Page {
 	page!(|form_view: Page, list_view: Page| {
 		div {
 			class: "flex flex-col gap-4",
-			{ { form_view } }
-			{ { list_view } }
+			{ {
+				form_view.clone()
+			} }
+			{ {
+				list_view.clone()
+			} }
 		}
 	})(form_view, list_view)
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- The `examples-twitter` WASM **library** failed to compile on `develop/0.2.0` (`cargo check --target wasm32-unknown-unknown --lib`). Its client SPA had drifted from the current `page!` / `form!` / `reinhardt::core` API and was never built in CI. This PR realigns the client components so the WASM library compiles cleanly, and adds a CI step so the regression is caught going forward.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

- examples-twitter is the reference Pages SPA example, so a non-compiling WASM library is a high-visibility regression. CI never caught it: `examples-test.yml` only WASM-checked the framework crates and built the example **natively**, never WASM-building the example library.
- Root cause: the client SPA components were written against an older `page!`/`form!` API. On `develop/0.2.0` the macros enforce stricter rules (every `{expr}`/`if`/`for` auto-wraps in `Page::reactive(move || ...)` requiring `Fn() -> Page`; implicit captures are forbidden; CSRF is routed via `form!`'s `strip_arguments`). The WASM-only code also carried formatter-mangled syntax that had never been compiled.

Refs #4995

<!-- `Fixes` would not auto-close: this PR targets `develop/0.2.0`, not the default branch. The issue should be closed manually when develop/0.2.0 merges to main. -->

## How Was This Tested?

- `cp examples/.cargo/config.local.toml examples/.cargo/config.toml && cd examples/examples-twitter`
- `cargo check --target wasm32-unknown-unknown --lib` → **0 errors, 0 warnings** (previously 61 errors; the bug).
- `cargo check --all-features` (native) → 0 errors (no native regression).
- `cargo make fmt-check` (reinhardt-admin-cli, rustfmt + page! DSL) → clean.
- `cargo clippy --all-features` (native) → clean.
- The new `examples-test.yml` step (`cargo check --target wasm32-unknown-unknown --lib`, gated on the `wasm-lib-check` matrix flag) turns red on exactly the pre-fix condition.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- Refs #4995

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `examples`
- [x] `wasm`

---

**Additional Context:**

- Scope is **examples-twitter only** (the issue's scope). `examples-tutorial-basis` also has client SPA code and may share the drift; the new CI guard is therefore scoped to examples-twitter via a `wasm-lib-check` matrix flag, and other WASM examples can opt in once verified.
- The large diff in the client component files is mostly `reinhardt-admin-cli fmt` reformatting WASM-only code that had never been formatted/compiled, on top of the functional `page!`/`form!` realignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error and success message rendering across authentication, profile, tweet, and direct message features
  * Enhanced form submission security and stability with improved token-based verification
  * Fixed reactive rendering and state management in chat, user relationship, and content display components
  * Refined component handling to improve overall application stability

* **Chores**
  * Updated CI workflow with additional WASM compilation checks for example projects

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/4999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->