### PR TITLE
fix(ci): format examples and run Examples Tests on self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,96 +72,13 @@ jobs:
             const infraChanged = files.some(f => f.filename.startsWith('infra/'));
             core.setOutput('infra-changed', infraChanged.toString());
 
-  # Determine runner type for CI jobs.
-  # Priority: Mac local → AWS Spot (opt-in) → GitHub-hosted (fallback)
-  #
-  # Mac local: auto-assigned when MAC_RUNNER_ENABLED=true and actor is trusted.
-  #   Trusted = repo owner, release-plz branch, workflow_dispatch.
-  #   Fork PRs are always excluded (security: untrusted code on local machine).
-  #
-  # AWS Spot: opt-in via PR checkbox when SELF_HOSTED_ENABLED=true.
-  #   Budget circuit breaker sets SELF_HOSTED_ENABLED to "false" when exceeded.
-  #
-  # GitHub-hosted: fallback for fork PRs or when self-hosted is unavailable.
+  # Determine runner type for CI jobs. The selection logic (Mac local -> AWS
+  # Spot -> GitHub-hosted, with fork exclusion and budget circuit breaker) lives
+  # in the reusable determine-runner.yml so it is shared with the standalone
+  # example workflow (examples-test-standalone.yml) instead of being duplicated.
   determine-runner:
     name: Determine Runner
-    timeout-minutes: 360
-    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
-    outputs:
-      runner: ${{ steps.set-runner.outputs.runner }}
-      cargo-build-jobs: ${{ steps.set-runner.outputs.cargo-build-jobs }}
-    steps:
-      - name: Parse PR checkbox for self-hosted
-        if: github.event_name == 'pull_request'
-        id: parse-checkbox
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const body = context.payload.pull_request.body || '';
-            // Default: false (when checkbox is missing or unchecked)
-            const checked = /- \[x\] I use self-hosted runner/i.test(body);
-            core.setOutput('self-hosted-requested', checked.toString());
-
-      - name: Set runner configuration
-        id: set-runner
-        env:
-          ACTOR: ${{ github.actor }}
-          REPO_OWNER: ${{ github.repository_owner }}
-          SELF_HOSTED_ENABLED: ${{ vars.SELF_HOSTED_ENABLED }}
-          EVENT_NAME: ${{ github.event_name }}
-          SELF_HOSTED_REQUESTED: ${{ steps.parse-checkbox.outputs.self-hosted-requested }}
-          HEAD_REF: ${{ github.head_ref }}
-          MAC_RUNNER_ENABLED: ${{ vars.MAC_RUNNER_ENABLED }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
-        run: |
-          USE_MAC=false
-          USE_AWS=false
-
-          # --- Mac local runner selection ---
-          # Security: only trusted actors can use Mac runner.
-          # Fork PRs are ALWAYS excluded regardless of actor.
-          if [[ "$MAC_RUNNER_ENABLED" == "true" ]] && [[ "$IS_FORK" != "true" ]]; then
-            if [[ "$EVENT_NAME" == "workflow_dispatch" ]] && [[ "$ACTOR" == "$REPO_OWNER" ]]; then
-              USE_MAC=true
-            elif [[ "$EVENT_NAME" == "pull_request" ]]; then
-              # release-plz PRs: trusted (only push-access users create these branches)
-              if [[ "$HEAD_REF" == release-plz-* ]]; then
-                USE_MAC=true
-              # Repo owner PRs: trusted
-              elif [[ "$ACTOR" == "$REPO_OWNER" ]]; then
-                USE_MAC=true
-              fi
-              # Other contributors: never use Mac runner
-            fi
-          fi
-
-          # --- AWS Spot runner selection (opt-in) ---
-          if [[ "$USE_MAC" == "false" ]] && [[ "$SELF_HOSTED_ENABLED" == "true" ]]; then
-            if [[ "$HEAD_REF" == release-plz-* ]]; then
-              USE_AWS=true
-            elif [[ "$ACTOR" == "$REPO_OWNER" ]]; then
-              if [[ "$EVENT_NAME" == "pull_request" ]]; then
-                if [[ "$SELF_HOSTED_REQUESTED" == "true" ]]; then
-                  USE_AWS=true
-                fi
-              else
-                USE_AWS=true
-              fi
-            fi
-          fi
-
-          # --- Output runner configuration ---
-          if [[ "$USE_MAC" == "true" ]]; then
-            echo 'runner=["self-hosted","linux","arm64","mac-local"]' >> "$GITHUB_OUTPUT"
-            echo 'cargo-build-jobs=4' >> "$GITHUB_OUTPUT"
-          elif [[ "$USE_AWS" == "true" ]]; then
-            echo 'runner=["self-hosted","linux","arm64","reinhardt-ci"]' >> "$GITHUB_OUTPUT"
-            echo 'cargo-build-jobs=8' >> "$GITHUB_OUTPUT"
-          else
-            # GitHub-hosted: free, slower; CARGO_BUILD_JOBS=1 prevents OOM on 7GB RAM
-            echo 'runner="ubuntu-latest"' >> "$GITHUB_OUTPUT"
-            echo 'cargo-build-jobs=1' >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/determine-runner.yml
 
   # Detect which packages are affected by the PR changes.
   # Runs in parallel with Phase 1 checks to minimize latency.

--- a/.github/workflows/determine-runner.yml
+++ b/.github/workflows/determine-runner.yml
@@ -1,0 +1,114 @@
+name: Determine Runner
+
+# Reusable workflow that selects the runner type and the cargo build
+# parallelism for downstream CI jobs. Extracted from ci.yml so that every
+# workflow needing a runner decision (ci.yml, examples-test-standalone.yml,
+# ...) shares a single source of truth instead of duplicating the selection
+# logic.
+#
+# Priority: Mac local -> AWS Spot (opt-in) -> GitHub-hosted (fallback)
+#
+# Mac local: auto-assigned when MAC_RUNNER_ENABLED=true and actor is trusted.
+#   Trusted = repo owner, release-plz branch, workflow_dispatch.
+#   Fork PRs are always excluded (security: untrusted code on local machine).
+#
+# AWS Spot: opt-in via PR checkbox when SELF_HOSTED_ENABLED=true.
+#   Budget circuit breaker sets SELF_HOSTED_ENABLED to "false" when exceeded.
+#
+# GitHub-hosted: fallback for fork PRs or when self-hosted is unavailable.
+
+on:
+  workflow_call:
+    outputs:
+      runner:
+        description: "Runner label JSON for downstream jobs (e.g. '\"ubuntu-latest\"')"
+        value: ${{ jobs.determine-runner.outputs.runner }}
+      cargo-build-jobs:
+        description: "Parallel cargo build jobs (1=GitHub-hosted OOM safe, 4=Mac, 8=AWS Spot)"
+        value: ${{ jobs.determine-runner.outputs.cargo-build-jobs }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  determine-runner:
+    name: Determine Runner
+    timeout-minutes: 360
+    # See infra/github-runners/hotpath-runner-userdata.sh for the canonical hotpath runner labels.
+    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
+    outputs:
+      runner: ${{ steps.set-runner.outputs.runner }}
+      cargo-build-jobs: ${{ steps.set-runner.outputs.cargo-build-jobs }}
+    steps:
+      - name: Parse PR checkbox for self-hosted
+        if: github.event_name == 'pull_request'
+        id: parse-checkbox
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            // Default: false (when checkbox is missing or unchecked)
+            const checked = /- \[x\] I use self-hosted runner/i.test(body);
+            core.setOutput('self-hosted-requested', checked.toString());
+
+      - name: Set runner configuration
+        id: set-runner
+        env:
+          ACTOR: ${{ github.actor }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          SELF_HOSTED_ENABLED: ${{ vars.SELF_HOSTED_ENABLED }}
+          EVENT_NAME: ${{ github.event_name }}
+          SELF_HOSTED_REQUESTED: ${{ steps.parse-checkbox.outputs.self-hosted-requested }}
+          HEAD_REF: ${{ github.head_ref }}
+          MAC_RUNNER_ENABLED: ${{ vars.MAC_RUNNER_ENABLED }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          USE_MAC=false
+          USE_AWS=false
+
+          # --- Mac local runner selection ---
+          # Security: only trusted actors can use Mac runner.
+          # Fork PRs are ALWAYS excluded regardless of actor.
+          if [[ "$MAC_RUNNER_ENABLED" == "true" ]] && [[ "$IS_FORK" != "true" ]]; then
+            if [[ "$EVENT_NAME" == "workflow_dispatch" ]] && [[ "$ACTOR" == "$REPO_OWNER" ]]; then
+              USE_MAC=true
+            elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+              # release-plz PRs: trusted (only push-access users create these branches)
+              if [[ "$HEAD_REF" == release-plz-* ]]; then
+                USE_MAC=true
+              # Repo owner PRs: trusted
+              elif [[ "$ACTOR" == "$REPO_OWNER" ]]; then
+                USE_MAC=true
+              fi
+              # Other contributors: never use Mac runner
+            fi
+          fi
+
+          # --- AWS Spot runner selection (opt-in) ---
+          if [[ "$USE_MAC" == "false" ]] && [[ "$SELF_HOSTED_ENABLED" == "true" ]]; then
+            if [[ "$HEAD_REF" == release-plz-* ]]; then
+              USE_AWS=true
+            elif [[ "$ACTOR" == "$REPO_OWNER" ]]; then
+              if [[ "$EVENT_NAME" == "pull_request" ]]; then
+                if [[ "$SELF_HOSTED_REQUESTED" == "true" ]]; then
+                  USE_AWS=true
+                fi
+              else
+                USE_AWS=true
+              fi
+            fi
+          fi
+
+          # --- Output runner configuration ---
+          if [[ "$USE_MAC" == "true" ]]; then
+            echo 'runner=["self-hosted","linux","arm64","mac-local"]' >> "$GITHUB_OUTPUT"
+            echo 'cargo-build-jobs=4' >> "$GITHUB_OUTPUT"
+          elif [[ "$USE_AWS" == "true" ]]; then
+            echo 'runner=["self-hosted","linux","arm64","reinhardt-ci"]' >> "$GITHUB_OUTPUT"
+            echo 'cargo-build-jobs=8' >> "$GITHUB_OUTPUT"
+          else
+            # GitHub-hosted: free, slower; CARGO_BUILD_JOBS=1 prevents OOM on 7GB RAM
+            echo 'runner="ubuntu-latest"' >> "$GITHUB_OUTPUT"
+            echo 'cargo-build-jobs=1' >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/examples-test-standalone.yml
+++ b/.github/workflows/examples-test-standalone.yml
@@ -22,14 +22,24 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/detect-affected-packages.yml
 
+  # Select the runner the same way ci.yml does (Mac local -> AWS Spot ->
+  # GitHub-hosted, with fork exclusion and budget circuit breaker) so example
+  # tests run on a self-hosted runner when one is available and safe, falling
+  # back to ubuntu-latest otherwise.
+  determine-runner:
+    name: Determine Runner
+    uses: ./.github/workflows/determine-runner.yml
+
   examples-test:
     name: Examples Tests
-    needs: [detect-affected]
+    needs: [detect-affected, determine-runner]
     if: |
       always() &&
       (github.event_name != 'pull_request' || needs.detect-affected.outputs.run-examples == 'true')
     uses: ./.github/workflows/examples-test.yml
     secrets: inherit
     with:
-      runner: '"ubuntu-latest"'
-      cargo-build-jobs: '1'
+      # Fall back to GitHub-hosted defaults if determine-runner was skipped or
+      # failed, so the example tests never run with an empty runner label.
+      runner: ${{ needs.determine-runner.outputs.runner || '"ubuntu-latest"' }}
+      cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs || '1' }}

--- a/examples/examples-tutorial-basis/src/apps/polls/di.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/di.rs
@@ -150,9 +150,7 @@ impl From<&SessionError> for ServerFnError {
 /// > [#4646](https://github.com/kent8192/reinhardt-web/issues/4646).
 #[cfg(native)]
 #[injectable_factory(scope = "request")]
-async fn session_user_factory(
-	#[inject] session: SessionData,
-) -> Result<User, SessionError> {
+async fn session_user_factory(#[inject] session: SessionData) -> Result<User, SessionError> {
 	let Some(user_id) = session.get::<i64>(USER_ID_SESSION_KEY) else {
 		return Err(SessionError::Anonymous);
 	};

--- a/examples/examples-tutorial-basis/src/apps/users/models.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/models.rs
@@ -123,7 +123,9 @@ mod manager {
 	}
 
 	#[injectable_factory(scope = "transient")]
-	async fn auth_user_manager_factory(#[inject] db: Depends<DatabaseConnection>) -> AuthUserManager {
+	async fn auth_user_manager_factory(
+		#[inject] db: Depends<DatabaseConnection>,
+	) -> AuthUserManager {
 		AuthUserManager { db: (*db).clone() }
 	}
 

--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -664,18 +664,12 @@ pub fn theme_toggle() -> Page {
 ///
 /// Displays an empty div (useful for conditional rendering).
 pub fn empty() -> Page {
-	page!(|| {
-		div {}
-	})()
+	page!(|| { div {} })()
 }
 
 /// Divider component
 pub fn divider() -> Page {
-	page!(|| {
-		div {
-			class: "divider"
-		}
-	})()
+	page!(|| { div { class: "divider" } })()
 }
 
 /// Badge component


### PR DESCRIPTION
## Summary

This PR addresses:

- Fixes the `Examples Tests (Standalone)` CI failures (`examples-tutorial-basis`, `examples-twitter`) caused by the `cargo make fmt-check` (`reinhardt-admin fmt --check`) step flagging unformatted example sources.
- Makes the Examples Tests workflow able to run on self-hosted runners, mirroring how the main `ci.yml` selects runners, instead of being hard-pinned to `ubuntu-latest`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The `Examples Tests (Standalone)` run on the latest release-plz branch failed because three example sources were not formatted according to the in-tree `reinhardt-admin` formatter (rustfmt + `page!`/`form!` DSL):

- `examples-tutorial-basis`: `src/apps/polls/di.rs`, `src/apps/users/models.rs` (2 files)
- `examples-twitter`: `src/core/client/components/common.rs` (1 file)

Reformatting them with the in-tree `reinhardt-admin` (the same binary CI builds from `crates/reinhardt-admin-cli`) makes `fmt-check` pass. The changes are whitespace / line-wrapping only.

Separately, `examples-test-standalone.yml` hard-coded `runner: ubuntu-latest`, so example tests never benefited from the self-hosted runner pool that the main CI uses. Hard-coding a self-hosted label directly would be unsafe (fork PRs would execute untrusted code on self-hosted / Mac runners, and jobs would hang whenever the runner pool is offline). To make this safe and DRY, the runner-selection logic previously inlined in `ci.yml` (Mac local → AWS Spot → GitHub-hosted, with fork exclusion and the budget circuit breaker) is extracted into a reusable `determine-runner.yml` workflow consumed by both `ci.yml` and `examples-test-standalone.yml`.

Per the release-plz branch policy, this fix targets `main`; release-plz regenerates the Release PR automatically once it merges.

Fixes #

Related to: run https://github.com/kent8192/reinhardt-web/actions/runs/26614905429

## How Was This Tested?

- Reinstalled `reinhardt-admin` from the in-tree source (`cargo install --path crates/reinhardt-admin-cli`, version `0.1.2`, matching what CI builds) and ran `reinhardt-admin fmt . --check` in all three examples:
  - `examples-tutorial-basis`: `0 would be formatted, 50 unchanged`
  - `examples-tutorial-rest`: `0 would be formatted, 17 unchanged`
  - `examples-twitter`: `0 would be formatted, 104 unchanged`
- Confirmed no `__reinhardt_placeholder__` artifacts remain in the reformatted `page!` macros.
- Validated `determine-runner.yml`, `ci.yml`, and `examples-test-standalone.yml` with `actionlint` (exit 0).

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow infrastructure by introducing reusable runner configuration logic for improved consistency and maintainability.
  * Updated code formatting across example projects for enhanced readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->