### PR TITLE
refactor(pages): normalize cfg notation to wasm/native aliases

### DIFF
--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -27,7 +27,7 @@ ast = []
 # Enables the `tests/integration/spa_navigation_e2e_test.rs` integration
 # test (Refs #4088). This is a marker feature: the actual test deps
 # (`reinhardt-test`, `axum`, `tower-http`) live as native-only path
-# dev-dependencies (see `[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]`).
+# dev-dependencies (see `[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]`).
 # Per CLAUDE.md KI-2, `reinhardt-test` is a path-only dev-dep here to avoid
 # both cyclic publishable dependencies and release-plz publish ordering
 # breakage. Cargo dev-dependencies cannot be optional, so feature gating
@@ -243,12 +243,12 @@ tempfile = { workspace = true }
 # `chrono` resolvable in the generated fixture binary.
 chrono = { workspace = true }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 # Used by tests/wasm/client_launcher_navigation_test.rs (Refs #4075) to
 # yield to the reactive scheduler between `Router::push` calls.
 gloo-timers = { version = "0.3", features = ["futures"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 criterion = { workspace = true }
 proptest = { workspace = true }
 hyper-util = { workspace = true }

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -59,8 +59,9 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(native)");
 
     cfg_aliases! {
-        wasm: { target_arch = "wasm32" },
-        native: { not(target_arch = "wasm32") },
+        // Browser-WASM only (wasm32-unknown-unknown); excludes WASI / emscripten.
+        wasm: { all(target_family = "wasm", target_os = "unknown") },
+        native: { not(all(target_family = "wasm", target_os = "unknown")) },
     }
 }
 ```

--- a/crates/reinhardt-pages/src/component/suspense.rs
+++ b/crates/reinhardt-pages/src/component/suspense.rs
@@ -182,7 +182,7 @@ impl SuspenseBoundary {
 	/// On non-WASM targets (SSR), this always returns the content,
 	/// since the server can pre-fetch data before rendering.
 	pub fn render(&self) -> Page {
-		#[cfg(target_arch = "wasm32")]
+		#[cfg(wasm)]
 		{
 			if self.any_loading() {
 				return self.render_fallback();
@@ -190,7 +190,7 @@ impl SuspenseBoundary {
 			self.render_content()
 		}
 
-		#[cfg(not(target_arch = "wasm32"))]
+		#[cfg(native)]
 		{
 			// SSR: always render the actual content (server pre-fetches data)
 			self.render_content()
@@ -198,7 +198,7 @@ impl SuspenseBoundary {
 	}
 
 	/// Renders the fallback wrapped in a marker div.
-	#[cfg(target_arch = "wasm32")]
+	#[cfg(wasm)]
 	fn render_fallback(&self) -> Page {
 		let fallback = (self.fallback_fn)();
 		PageElement::new("div")

--- a/crates/reinhardt-pages/src/hydration/events.rs
+++ b/crates/reinhardt-pages/src/hydration/events.rs
@@ -440,7 +440,7 @@ fn test_attach_options_full_hydration() {
 	assert!(!options.skip_static);
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(native)]
 #[test]
 fn test_attach_events_recursive_non_wasm() {
 	let mut registry = EventRegistry::new();
@@ -453,7 +453,7 @@ fn test_attach_events_recursive_non_wasm() {
 	assert!(result.is_ok());
 	assert!(!registry.is_empty());
 }
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, native))]
 mod tests {
 	use super::*;
 

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -229,7 +229,7 @@ pub mod testing;
 pub mod static_resolver;
 
 // Hot Module Replacement (server-side only, feature-gated)
-#[cfg(all(not(target_arch = "wasm32"), feature = "hmr"))]
+#[cfg(all(native, feature = "hmr"))]
 pub mod hmr;
 
 // Table utilities (django-tables2 equivalent)
@@ -307,10 +307,11 @@ pub mod __private {
 
 	// `tracing` is enabled for all targets *except* browser wasm (wasm32-unknown-unknown).
 	// Browser wasm uses a different logging mechanism, so tracing is intentionally excluded there.
-	// The cfg condition `not(all(target_family = "wasm", target_os = "unknown"))` precisely
-	// targets browser wasm, which reports target_family = "wasm" and target_os = "unknown".
-	// This is intentionally different from the `reqwest` cfg above.
-	#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+	// The `native` cfg alias (defined in build.rs as
+	// `not(all(target_family = "wasm", target_os = "unknown"))`) precisely targets every
+	// non-browser-wasm platform.
+	// This is intentionally different from the `reqwest` cfg above, which spans all wasm targets.
+	#[cfg(native)]
 	pub use tracing;
 }
 

--- a/crates/reinhardt-pages/src/testing/mock_fetch.rs
+++ b/crates/reinhardt-pages/src/testing/mock_fetch.rs
@@ -146,7 +146,7 @@ pub async fn fetch_with_mock(
 	)))
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, native))]
 mod tests {
 	use super::*;
 	use crate::testing::mock_http::{clear_mocks, get_call_history};


### PR DESCRIPTION
## Summary

Stage 3 of the four-stage refactor tracked by #4362. **Stacked on #5009 (Stage 2)** — the base branch is `refactor/issue-4365-unify-spawn-into-platform` so the diff shows only the cfg-notation changes; GitHub will auto-retarget this PR to `develop/0.2.0` once #5009 merges.

- Replace browser-WASM `#[cfg(target_arch = "wasm32")]` / `#[cfg(not(target_arch = "wasm32"))]` with the `wasm` / `native` cfg aliases (defined in `build.rs`) across `reinhardt-pages/src/`.
- Switch the `Cargo.toml` dev-dependency target tables to the canonical `cfg(all(target_family = "wasm", target_os = "unknown"))` form (Cargo.toml does not support cfg aliases).
- Sync the README `cfg_aliases!` example to the canonical browser-WASM definition.

## Type of Change

- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

Pure internal `#[cfg]` notation normalization; no public API or behavior change.

## Motivation and Context

Consistently expresses "browser-WASM vs everything-else" through the `wasm` / `native` aliases, narrowing browser-only branches away from WASI/emscripten and keeping conditional compilation readable. Aligns with the cfg notation policy in #4362.

Refs #4362

## Case-by-case audit (deliberately NOT changed)

- `src/lib.rs` `__private::reqwest` (`#[cfg(target_arch = "wasm32")]`) — genuinely spans **all** wasm targets incl. WASI per its comment; kept as-is.
- `macros/src/server_fn.rs` `#[cfg(target_arch = "wasm32")]` — emitted into **user** crates that do not have reinhardt-pages's cfg aliases; must stay portable.
- `tests/**` crate-level `#![cfg(not(target_arch = "wasm32"))]` — left untouched: a crate-root `#![cfg(alias)]` that fails to resolve would silently exclude the whole test file (false-green risk), and the acceptance criteria scope the source sweep to `src/`. Can be a follow-up once alias propagation to integration-test crates is confirmed.
- `tests/fixtures/**` independent fixture crates (own `client`/`server` aliases) and `docs/server_fn_macro.md` generated-code examples — out of scope.

## How Was This Tested?

Verification commands (run locally after Draft PR creation):

- [ ] `cargo check -p reinhardt-pages` (native)
- [ ] `cargo check -p reinhardt-pages --target wasm32-unknown-unknown`
- [ ] `cargo nextest run -p reinhardt-pages`
- [ ] No `unexpected_cfgs` warnings

## Checklist

- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (README cfg example)
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

## Related Issues

Fixes #4366
Refs #4362

## Labels to Apply

### Type Label
- [x] `enhancement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored build system architecture and internal platform detection logic for improved code compilation across different target environments. Updated conditional compilation attributes and build configuration to use more precise and consistent platform identification criteria, enhancing overall maintainability of platform-specific code paths for WebAssembly and native builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->