### PR TITLE
ci(examples-test): skip headless-Chrome WASM steps on ARM64 self-hosted

### DIFF
--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -138,21 +138,29 @@ jobs:
         if: ${{ matrix.needs-wasm }}
         run: cargo check --target wasm32-unknown-unknown -p reinhardt-core -p reinhardt-urls --features reinhardt-core/full,reinhardt-urls/client-router
 
+      # Headless-Chrome WASM tests run on GitHub-hosted x86_64 only:
+      # browser-actions/setup-chrome does not support ARM64 Linux, so on the
+      # self-hosted ARM64 runner it fails with "Unsupported platform: linux
+      # arm64". This mirrors wasm-check.yml's wasm-test job, which is pinned to
+      # ubuntu-latest for the same reason (Fixes #3491). The wasm32 compilation
+      # check above is browser-independent and still runs on every runner.
+      # Example WASM browser tests therefore execute on GitHub-hosted PR runs;
+      # self-hosted runs (release-plz / opted-in PRs) skip them.
       - name: Install Chrome
-        if: ${{ matrix.needs-wasm }}
+        if: ${{ matrix.needs-wasm && !contains(inputs.runner, 'self-hosted') }}
         uses: browser-actions/setup-chrome@v2
         with:
           chrome-version: stable
           install-chromedriver: true
 
       - name: Install wasm-pack
-        if: ${{ matrix.needs-wasm }}
+        if: ${{ matrix.needs-wasm && !contains(inputs.runner, 'self-hosted') }}
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
 
       - name: Run WASM tests
-        if: ${{ matrix.needs-wasm }}
+        if: ${{ matrix.needs-wasm && !contains(inputs.runner, 'self-hosted') }}
         working-directory: examples/${{ matrix.example }}
         run: cargo make wasm-test || echo "No WASM tests found, skipping"
 


### PR DESCRIPTION
## Summary

This PR addresses:

- The Examples Tests workflow gained self-hosted runner support (via the shared `determine-runner.yml`, merged in #5000), but its WASM examples (`examples-tutorial-basis`, `examples-twitter`) install Chrome through `browser-actions/setup-chrome`, which **does not support ARM64 Linux**. On the self-hosted ARM64 runner the **Install Chrome** step fails with `Unsupported platform: linux arm64`, breaking both jobs (observed on release-plz PR #5007, run 26629330541 — every other step, including Check Format / Clippy / Build, passed).
- Gate the Chrome-dependent steps (`Install Chrome`, `Install wasm-pack`, `Run WASM tests`) on a non-self-hosted runner, mirroring `wasm-check.yml`'s `ubuntu-latest` pin for the same constraint (#3491). The browser-independent `wasm32` compilation check still runs on every runner, so self-hosted runs keep WASM compile coverage; the headless-Chrome browser tests run on GitHub-hosted PR runs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

`browser-actions/setup-chrome@v2` has no ARM64 Linux build. The repository already codified the rule "Chrome jobs run on GitHub-hosted x86_64 only" for `wasm-check.yml` (#3491 / #3492), but `examples-test.yml` was never updated. Once examples-test started selecting the self-hosted ARM64 runner (release-plz / owner-opted PRs), the gap surfaced as a hard failure. This change closes that gap so "Examples Tests works on self-hosted" is actually true — the heavy fmt/clippy/build/test steps run on self-hosted, and only the ARM64-incompatible headless-Chrome steps are skipped there.

Fixes #

Related to: #3491, #5000

## How Was This Tested?

- `python3 -c "import yaml; yaml.safe_load(...)"` — `examples-test.yml` parses as valid YAML.
- `actionlint .github/workflows/examples-test.yml` — no findings.
- Pattern parity with the existing `Free Disk Space` step (`if: ${{ matrix.needs-docker && !contains(inputs.runner, 'self-hosted') }}`).
- The default PR run (GitHub-hosted) exercises the unchanged path: `!contains('"ubuntu-latest"', 'self-hosted')` is `true`, so the Chrome/WASM steps still run there. Validating the self-hosted skip path requires running this PR on the self-hosted runner (see note below).

## Checklist

- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] I have checked the workflow with `actionlint`

## Related Issues

- #3491 — original ARM64 Chrome fix for `wasm-check.yml` (the precedent this PR mirrors)
- #5000 — added self-hosted runner support to Examples Tests (which exposed this gap)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)