### PR TITLE
fix(exports,pages): unblock develop/0.2.0 release CI (WASM cfg gates, clippy, fmt)

### DIFF
--- a/crates/reinhardt-pages/src/hydration/reconcile.rs
+++ b/crates/reinhardt-pages/src/hydration/reconcile.rs
@@ -508,8 +508,10 @@ fn collect_expected_child(
 			}
 		}
 		Page::KeyedFragment(keyed_children) => {
-			let child_views: Vec<Page> =
-				keyed_children.iter().map(|(_, view)| view.clone()).collect();
+			let child_views: Vec<Page> = keyed_children
+				.iter()
+				.map(|(_, view)| view.clone())
+				.collect();
 			collect_expected_children(&child_views, &path, children);
 		}
 		_ => children.push((path, view.clone())),
@@ -646,7 +648,10 @@ fn reconcile_options_children_at_path(
 		Page::Element(el_view) => el_view.child_views(),
 		Page::Fragment(views) => views,
 		Page::KeyedFragment(views) => {
-			keyed_child_views = views.iter().map(|(_, view)| view.clone()).collect::<Vec<_>>();
+			keyed_child_views = views
+				.iter()
+				.map(|(_, view)| view.clone())
+				.collect::<Vec<_>>();
 			&keyed_child_views
 		}
 		Page::WithHead { view, .. } => {

--- a/crates/reinhardt-pages/src/hydration/reconcile.rs
+++ b/crates/reinhardt-pages/src/hydration/reconcile.rs
@@ -613,10 +613,8 @@ fn reconcile_with_options_at_path(
 	};
 
 	// Perform reconciliation if applicable
-	if should_reconcile {
-		if let Err(err) = reconcile_at_path(element, view, path.clone()) {
-			handle_reconcile_error(err, options)?;
-		}
+	if should_reconcile && let Err(err) = reconcile_at_path(element, view, path.clone()) {
+		handle_reconcile_error(err, options)?;
 	}
 
 	// Recursively process children, unless this is an island boundary
@@ -696,12 +694,11 @@ fn reconcile_options_children_at_path(
 				options,
 				child_path.clone(),
 			)?;
-		} else if matches!(child_view, Page::Element(_)) {
-			if let Err(err) =
+		} else if matches!(child_view, Page::Element(_))
+			&& let Err(err) =
 				reconcile_dom_node_at_path(actual_node, child_view, child_path.clone())
-			{
-				handle_reconcile_error(err, options)?;
-			}
+		{
+			handle_reconcile_error(err, options)?;
 		}
 	}
 

--- a/crates/reinhardt-pages/tests/page_keyed_for_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/page_keyed_for_integration_tests.rs
@@ -13,7 +13,9 @@ fn keyed_for_lowers_to_keyed_fragment() {
 	let render = page!(|todos: Vec<Todo>| {
 		ul {
 			for todo in todos @key(todo.id.clone()) {
-				li { { todo.title.clone() } }
+				li { {
+					todo.title.clone()
+				} }
 			}
 		}
 	});

--- a/crates/reinhardt-pages/tests/ui/form/fail/char_field_with_generic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/char_field_with_generic.rs
@@ -8,7 +8,7 @@ fn main() {
 		name: BadForm,
 		action: "/x",
 		fields: {
-			username: CharField<i32> { },
+			username: CharField<i32> {},
 		}
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/fail/hidden_field_no_default.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/hidden_field_no_default.rs
@@ -27,7 +27,7 @@ fn main() {
 		name: BadForm,
 		action: "/x",
 		fields: {
-			data: HiddenField<NoDefault> { },
+			data: HiddenField<NoDefault> {},
 		}
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/form/fail/ip_address_with_generic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/ip_address_with_generic.rs
@@ -8,7 +8,7 @@ fn main() {
 		name: BadForm,
 		action: "/x",
 		fields: {
-			client_ip: IpAddressField<i32> { },
+			client_ip: IpAddressField<i32> {},
 		}
 	};
 }

--- a/crates/reinhardt-pages/tests/ui/page/pass/keyed_for.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/keyed_for.rs
@@ -18,7 +18,9 @@ fn main() {
 						r#type: "checkbox",
 						checked: todo.completed,
 					}
-					span { { todo.title.clone() } }
+					span { {
+						todo.title.clone()
+					} }
 				}
 			}
 		}

--- a/examples/examples-twitter/src/apps/tweet/client/components.rs
+++ b/examples/examples-twitter/src/apps/tweet/client/components.rs
@@ -34,74 +34,60 @@ fn like_button(liked: Signal<bool>, like_count: Signal<i32>) -> Page {
 	let liked_for_click_else = liked.clone();
 	let like_count_for_click_else = like_count.clone();
 
-	page!(|liked: Signal<bool>,
-	       like_count: Signal<i32>,
-	       liked_for_click_if: Signal<bool>,
-	       like_count_for_click_if: Signal<i32>,
-	       liked_for_click_else: Signal<bool>,
-	       like_count_for_click_else: Signal<i32>| {
-		{
-			// Read the Copy signal values to local Copy values once in this
-			// single reactive scope, then build the markup via an inner
-			// `page!` that receives the Copy values and handler-signal clones.
-			let is_liked = liked.get();
-			let count = like_count.get();
-			page!(|is_liked: bool, count: i32, liked_for_click_if: Signal<bool>, like_count_for_click_if: Signal<i32>, liked_for_click_else: Signal<bool>, like_count_for_click_else: Signal<i32>| {
-				if is_liked {
-					button {
-						class: "tweet-action-btn text-danger",
-						type: "button",
-						aria_label: "Like",
-						@click: {
-							let liked_for_click = liked_for_click_if.clone();
-							let like_count_for_click = like_count_for_click_if.clone();
-							move |_event| {
-								let current_liked = liked_for_click.get();
-								let current_count = like_count_for_click.get();
-								liked_for_click.set(!current_liked);
-								like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
-							}
-						},
-						{
-							icons::heart_icon_filled()
+	page!(|liked: Signal<bool>, like_count: Signal<i32>, liked_for_click_if: Signal<bool>, like_count_for_click_if: Signal<i32>, liked_for_click_else: Signal<bool>, like_count_for_click_else: Signal<i32>| { {
+		// Read the Copy signal values to local Copy values once in this
+		// single reactive scope, then build the markup via an inner
+		// `page!` that receives the Copy values and handler-signal clones.
+		let is_liked = liked.get();
+		let count = like_count.get();
+		page!(|is_liked: bool, count: i32, liked_for_click_if: Signal<bool>, like_count_for_click_if: Signal<i32>, liked_for_click_else: Signal<bool>, like_count_for_click_else: Signal<i32>| {
+			if is_liked {
+				button {
+					class: "tweet-action-btn text-danger",
+					type: "button",
+					aria_label: "Like",
+					@click: {
+						let liked_for_click = liked_for_click_if.clone();
+						let like_count_for_click = like_count_for_click_if.clone();
+						move |_event| {
+							let current_liked = liked_for_click.get();
+							let current_count = like_count_for_click.get();
+							liked_for_click.set(!current_liked);
+							like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
 						}
-						span { {
-							format!("{}", count)
-						} }
+					},
+					{
+						icons::heart_icon_filled()
 					}
-				} else {
-					button {
-						class: "tweet-action-btn hover:text-danger",
-						type: "button",
-						aria_label: "Like",
-						@click: {
-							let liked_for_click = liked_for_click_else.clone();
-							let like_count_for_click = like_count_for_click_else.clone();
-							move |_event| {
-								let current_liked = liked_for_click.get();
-								let current_count = like_count_for_click.get();
-								liked_for_click.set(!current_liked);
-								like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
-							}
-						},
-						{
-							icons::heart_icon_outline()
-						}
-						span { {
-							format!("{}", count)
-						} }
-					}
+					span { {
+						format!("{}", count)
+					} }
 				}
-			})(
-				is_liked,
-				count,
-				liked_for_click_if.clone(),
-				like_count_for_click_if.clone(),
-				liked_for_click_else.clone(),
-				like_count_for_click_else.clone(),
-			)
-		}
-	})(
+			} else {
+				button {
+					class: "tweet-action-btn hover:text-danger",
+					type: "button",
+					aria_label: "Like",
+					@click: {
+						let liked_for_click = liked_for_click_else.clone();
+						let like_count_for_click = like_count_for_click_else.clone();
+						move |_event| {
+							let current_liked = liked_for_click.get();
+							let current_count = like_count_for_click.get();
+							liked_for_click.set(!current_liked);
+							like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+						}
+					},
+					{
+						icons::heart_icon_outline()
+					}
+					span { {
+						format!("{}", count)
+					} }
+				}
+			}
+		})(is_liked, count, liked_for_click_if.clone(), like_count_for_click_if.clone(), liked_for_click_else.clone(), like_count_for_click_else.clone(), )
+	} })(
 		liked,
 		like_count,
 		liked_for_click_if,
@@ -142,23 +128,18 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 	// Clone for error display watch block (separate closure from main watch block)
 	let delete_action_for_error = delete_action.clone();
 
-	page!(|delete_action: Action<(), String>,
-	       show_delete: bool,
-	       username: String,
-	       content: String,
-	       created_at: String,
-	       tweet_id: Uuid,
-	       liked_signal: Signal<bool>,
-	       like_count_signal: Signal<i32>,
-	       delete_action_for_click: Action<(), String>,
-	       delete_action_for_error: Action<(), String>| {
+	page!(|delete_action: Action<(), String>, show_delete: bool, username: String, content: String, created_at: String, tweet_id: Uuid, liked_signal: Signal<bool>, like_count_signal: Signal<i32>, delete_action_for_click: Action<(), String>, delete_action_for_error: Action<(), String>| {
 		// Main card body: a single reactive scope that reads the Copy
 		// `is_success` flag once and builds each branch via an inner
 		// `page!`, passing the owned String/Signal/Action values as the
 		// inner closure's own parameters (avoids E0507 from nested scopes).
 		{
 			if delete_action.is_success() {
-				page!(|| { div { class: "hidden" } })()
+				page!(|| {
+					div {
+						class: "hidden"
+					}
+				})()
 			} else {
 				page!(|show_delete: bool, username_avatar: String, username_name: String, username_handle: String, content: String, created_at: String, tweet_id: Uuid, liked_signal: Signal<bool>, like_count_signal: Signal<i32>, delete_action_for_click: Action<(), String>| {
 					div {
@@ -261,34 +242,20 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 							}
 						}
 					}
-				})(
-					show_delete,
-					username.clone(),
-					username.clone(),
-					username.clone(),
-					content.clone(),
-					created_at.clone(),
-					tweet_id,
-					liked_signal.clone(),
-					like_count_signal.clone(),
-					delete_action_for_click.clone(),
-				)
+				})(show_delete, username.clone(), username.clone(), username.clone(), content.clone(), created_at.clone(), tweet_id, liked_signal.clone(), like_count_signal.clone(), delete_action_for_click.clone(), )
 			}
-		} // Error alert: a single optional banner built via `.map(...)`.
+		}// Error alert: a single optional banner built via `.map(...)`.
 		{
-			delete_action_for_error
-				.error()
-				.map(|error_message| {
-					page!(|error_message: String| {
-						div {
-							class: "alert-danger mt-3",
-							{ {
-								error_message.clone()
-							} }
-						}
-					})(error_message)
-				})
-				.unwrap_or_else(Page::empty)
+			delete_action_for_error.error().map(|error_message| {
+				page!(|error_message: String| {
+					div {
+						class: "alert-danger mt-3",
+						{ {
+							error_message.clone()
+						} }
+					}
+				})(error_message)
+			}).unwrap_or_else(Page::empty)
 		}
 	})(
 		delete_action,

--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -660,11 +660,17 @@ pub fn theme_toggle() -> Page {
 ///
 /// Displays an empty div (useful for conditional rendering).
 pub fn empty() -> Page {
-	page!(|| { div {} })()
+	page!(|| {
+		div {}
+	})()
 }
 /// Divider component
 pub fn divider() -> Page {
-	page!(|| { div { class: "divider" } })()
+	page!(|| {
+		div {
+			class: "divider"
+		}
+	})()
 }
 /// Badge component
 pub fn badge(text: &str, primary: bool) -> Page {

--- a/examples/examples-twitter/src/core/client/components/layout.rs
+++ b/examples/examples-twitter/src/core/client/components/layout.rs
@@ -95,9 +95,9 @@ pub fn header(site_name: &str, current_user: Option<&UserInfo>, nav_items: &[Nav
 		})
 		.collect();
 	let nav_links_view = page!(|nav_links: Vec<Page>| {
-		for link in nav_links.clone() {
-			{ link.clone() }
-		}
+		for link in nav_links.clone() { {
+			link.clone()
+		} }
 	})(nav_links);
 	let brand_link = Link::new("/".to_string(), site_name.to_string())
 		.class("text-xl font-bold text-content-primary hover:text-brand transition-colors")
@@ -229,9 +229,9 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|topics_list: Vec<Page>| {
-			for topic in topics_list.clone() {
-				{ topic.clone() }
-			}
+			for topic in topics_list.clone() { {
+				topic.clone()
+			} }
 		})(topics_list)
 	};
 	let users_list: Vec<Page> = suggested_users
@@ -303,9 +303,9 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|users_list: Vec<Page>| {
-			for user in users_list.clone() {
-				{ user.clone() }
-			}
+			for user in users_list.clone() { {
+				user.clone()
+			} }
 		})(users_list)
 	};
 	page!(|topics_view: Page, users_view: Page| {

--- a/src/exports/misc.rs
+++ b/src/exports/misc.rs
@@ -11,27 +11,37 @@ pub use async_trait::async_trait;
 #[cfg(all(feature = "core", native))]
 pub use crate::core::serde::{Deserialize, Serialize};
 
-#[cfg(feature = "tasks")]
+// `reinhardt-tasks`, `reinhardt-test`, `reinhardt-utils`, and `reinhardt-auth`
+// are declared as dependencies only under
+// `[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]`
+// (see Cargo.toml), i.e. they are native-only crates. Their feature flags
+// (`tasks`, `test`, `storage`, `cache`, `sessions`, ...) can still be enabled on
+// WASM, so each re-export below must be gated by `native` in addition to its
+// feature — otherwise the path resolves to an unlinked crate and the build fails
+// on `wasm32-unknown-unknown` (regression guarded by the WASM consumer fixture,
+// reinhardt-web#4161).
+#[cfg(all(feature = "tasks", native))]
 pub use reinhardt_tasks::{Scheduler, Task, TaskExecutor, TaskQueue};
 
-#[cfg(feature = "test")]
+#[cfg(all(feature = "test", native))]
 pub use reinhardt_test::{APIClient, APIRequestFactory, APITestCase, TestResponse};
 
-#[cfg(feature = "storage")]
+#[cfg(all(feature = "storage", native))]
 pub use reinhardt_utils::storage::{InMemoryStorage, LocalStorage, Storage};
 
-#[cfg(feature = "cache")]
+#[cfg(all(feature = "cache", native))]
 pub use reinhardt_utils::cache::{Cache, CacheKeyBuilder, InMemoryCache};
 
-#[cfg(all(feature = "cache", feature = "redis-backend"))]
+#[cfg(all(feature = "cache", feature = "redis-backend", native))]
 pub use reinhardt_utils::cache::RedisCache;
 
 // Sessions (gated by `sessions` feature, NOT `auth` — sessions can be
-// used independently of the auth module)
-#[cfg(feature = "sessions")]
+// used independently of the auth module). Still native-only: `reinhardt-auth`
+// is a native-only dependency (see the note above).
+#[cfg(all(feature = "sessions", native))]
 pub use reinhardt_auth::sessions::{
 	CacheSessionBackend, InMemorySessionBackend, Session, SessionBackend, SessionError,
 };
 
-#[cfg(all(feature = "sessions", feature = "middleware"))]
+#[cfg(all(feature = "sessions", feature = "middleware", native))]
 pub use reinhardt_auth::sessions::{HttpSessionConfig, SameSite, SessionMiddleware};


### PR DESCRIPTION
## Summary

This PR addresses:

- Fixes the CI failures blocking the `develop/0.2.0` release PR (#5006). All four failing checks (`Format Check`, three `WASM Clippy` jobs, and `WASM Consumer Fixture (#4161 regression)`) trace to source-code issues on `develop/0.2.0`, not to release-plz-generated changes — so they are fixed here on the base branch (release-plz will regenerate #5006 once this merges).

Three independent fixes:

1. **`fix(exports)`** — `src/exports/misc.rs` re-exports for `tasks`/`test`/`storage`/`cache`/`sessions` were gated only by feature flag. The backing crates (`reinhardt-tasks`, `reinhardt-test`, `reinhardt-utils`, `reinhardt-auth`) are declared only in the native-only target dependency table, so on `wasm32-unknown-unknown` these `pub use` paths resolved to unlinked crates (E0432/E0433). Added the `native` cfg to each, matching the existing `crate::core::serde` precedent. This is what the WASM Consumer Fixture (the reinhardt-web#4161 regression guard) caught.
2. **`fix(pages)`** — the `#[cfg(wasm)]` reconcile hydration helpers tripped `clippy::collapsible_if` under clippy 1.94 (`-D warnings`). Only WASM Clippy caught it because native Clippy never compiles the WASM-only function. Collapsed both sites into let-chains; behavior unchanged.
3. **`style`** — ran `reinhardt-admin fmt-all` over the 9 files flagged by Format Check (twitter example client components + several reinhardt-pages UI/keyed-for tests + residual formatting in the reconcile module).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes
- [x] Code quality improvements

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The `develop/0.2.0` release PR #5006 (`chore: release`, branch `develop-release-plz-2026-05-29T09-13-07Z`) is red. Per the release-plz branch policy (CLAUDE.md), code fixes must not be pushed directly to the release-plz branch; instead they go to the base branch (`develop/0.2.0`) via a normal PR, after which release-plz regenerates the Release PR.

`src/exports/misc.rs` does not exist on `main` (exports were restructured in 0.2.0), so the cfg fix is develop-only. The reconcile.rs module is heavily develop-specific.

Related to: #5006
Refs #4161

## How Was This Tested?

- `reinhardt-admin fmt-all --check` → `0 would be formatted, 2988 unchanged, 0 errors` (built from this branch's `reinhardt-admin-cli` v0.2.0-rc.2 to match CI exactly)
- WASM Clippy and the WASM Consumer Fixture are verified by CI on this PR (they require the wasm toolchain build that CI runs).

## Checklist

- [x] My code follows the project style guidelines
- [x] Commits are split by intent (exports fix / clippy fix / formatting)
- [x] No new `todo!()` / `// TODO:` introduced
- [x] Targets the correct base branch (`develop/0.2.0`)

## Labels to Apply

- `bug`
- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WASM builds to properly exclude native-only dependencies, preventing build failures.

* **Refactor**
  * Improved internal reconciliation logic formatting and error handling patterns.
  * Updated template iteration syntax for consistency across components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->