### PR TITLE
fix(ci): skip arm64 browser WASM steps in examples-test

### DIFF
--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -138,21 +138,27 @@ jobs:
         if: ${{ matrix.needs-wasm }}
         run: cargo check --target wasm32-unknown-unknown -p reinhardt-core -p reinhardt-urls --features reinhardt-core/full,reinhardt-urls/client-router
 
+      # browser-actions/setup-chrome@v2 does not support linux/arm64, so the
+      # headless-browser WASM steps are skipped on self-hosted (arm64) runners
+      # (release-plz-* branches are routed there by determine-runner.yml). The
+      # wasm32-unknown-unknown compilation check above still runs on arm64;
+      # browser WASM coverage is provided on GitHub-hosted x86_64 via
+      # wasm-check.yml (forced to x86_64 by #3492). Tracked in #5012.
       - name: Install Chrome
-        if: ${{ matrix.needs-wasm }}
+        if: ${{ matrix.needs-wasm && !contains(inputs.runner, 'self-hosted') }}
         uses: browser-actions/setup-chrome@v2
         with:
           chrome-version: stable
           install-chromedriver: true
 
       - name: Install wasm-pack
-        if: ${{ matrix.needs-wasm }}
+        if: ${{ matrix.needs-wasm && !contains(inputs.runner, 'self-hosted') }}
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
 
       - name: Run WASM tests
-        if: ${{ matrix.needs-wasm }}
+        if: ${{ matrix.needs-wasm && !contains(inputs.runner, 'self-hosted') }}
         working-directory: examples/${{ matrix.example }}
         run: cargo make wasm-test || echo "No WASM tests found, skipping"
 


### PR DESCRIPTION
## Summary

This PR addresses:

- `examples-test.yml` jobs fail at the **`Install Chrome`** step
  (`browser-actions/setup-chrome@v2`, which has no linux/arm64 support) when they
  run on the self-hosted arm64 runners that `determine-runner.yml` assigns to
  `release-plz-*` branches.
- Guards the `Install Chrome`, `Install wasm-pack`, and `Run WASM tests` steps
  with `!contains(inputs.runner, 'self-hosted')` so they execute only on
  GitHub-hosted x86_64 runners.
- The `wasm32-unknown-unknown` compilation check keeps running on arm64; browser
  WASM coverage is unchanged on x86_64 (also covered by `wasm-check.yml`, which
  PR #3492 forced to x86_64).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

`determine-runner.yml` deterministically routes `release-plz-*` (and
`develop-release-plz-*`) branches to the self-hosted arm64 fleet. Because the
Release PR bumps `examples/Cargo.toml`, `detect-affected` enables the Examples
Tests, which then die on `Install Chrome` (`Unsupported platform: linux arm64`).
This made every release-plz Release PR (e.g. #5007) red on
`Examples Tests / examples-tutorial-basis` and `examples-twitter`.

PR #3492 fixed the same class of failure for `wasm-check.yml` but never patched
`examples-test.yml`.

Fixes #5012

Related to: #5007, #3492

## How Was This Tested?

- `python3 -c "yaml.safe_load(...)"` confirms the workflow YAML is valid.
- The guard expression `!contains(inputs.runner, 'self-hosted')` mirrors the
  pre-#3492 pattern already used in this repo.
- End-to-end validation happens when release-plz regenerates PR #5007 on the
  arm64 runner: the three Chrome/browser-WASM steps are now skipped, while the
  native build, clippy, `wasm32` compile check, and `cargo nextest` continue to
  run. On GitHub-hosted x86_64 PRs the browser WASM steps run exactly as before.

> Note: this PR changes only a workflow definition, so `detect-affected` skips
> the Examples Tests on this PR's own CI. The fix is exercised by the regenerated
> release-plz PR (arm64) and by any x86_64 example run.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if applicable) — N/A (inline workflow comment added)
- [ ] I have added tests — N/A (CI workflow guard; validated via YAML parse + regenerated release PR)
- [ ] New and existing unit tests pass locally — N/A (no Rust changed)
- [ ] I have tested with all affected database backends — N/A
- [ ] I have formatted the code with `cargo make fmt-fix` — N/A (no Rust changed)
- [ ] I have checked the code with `cargo make clippy-check` — N/A (no Rust changed)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5012
- Unblocks release-plz Release PR #5007
- Follows up on #3492 (`wasm-check.yml` arm64 Chrome fix)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

Additional: `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test workflow to improve efficiency on self-hosted runners by skipping architecture-incompatible steps while preserving essential build verification checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->