### PR TITLE
fix(storages): repair default-feature build and rustdoc deprecation links

### DIFF
--- a/crates/reinhardt-storages/src/config.rs
+++ b/crates/reinhardt-storages/src/config.rs
@@ -55,7 +55,7 @@ impl FromStr for BackendType {
 #[cfg(feature = "s3")]
 #[deprecated(
 	since = "0.2.0",
-	note = "Use StorageSettings with the #[settings] macro instead."
+	note = "Use `StorageSettings` with the `#[settings]` macro instead."
 )]
 #[derive(Debug, Clone)]
 pub struct S3Config {
@@ -73,7 +73,7 @@ pub struct S3Config {
 #[cfg(feature = "gcs")]
 #[deprecated(
 	since = "0.2.0",
-	note = "Use StorageSettings with the #[settings] macro instead."
+	note = "Use `StorageSettings` with the `#[settings]` macro instead."
 )]
 #[derive(Debug, Clone)]
 pub struct GcsConfig {
@@ -91,7 +91,7 @@ pub struct GcsConfig {
 #[cfg(feature = "azure")]
 #[deprecated(
 	since = "0.2.0",
-	note = "Use StorageSettings with the #[settings] macro instead."
+	note = "Use `StorageSettings` with the `#[settings]` macro instead."
 )]
 #[derive(Debug, Clone)]
 pub struct AzureConfig {
@@ -115,7 +115,7 @@ pub struct AzureConfig {
 #[cfg(feature = "local")]
 #[deprecated(
 	since = "0.2.0",
-	note = "Use StorageSettings with the #[settings] macro instead."
+	note = "Use `StorageSettings` with the `#[settings]` macro instead."
 )]
 #[derive(Debug, Clone)]
 pub struct LocalConfig {
@@ -126,7 +126,7 @@ pub struct LocalConfig {
 /// Compatibility storage configuration.
 #[deprecated(
 	since = "0.2.0",
-	note = "Use StorageSettings with the #[settings] macro instead."
+	note = "Use `StorageSettings` with the `#[settings]` macro instead."
 )]
 #[derive(Debug, Clone)]
 pub enum StorageConfig {
@@ -179,7 +179,7 @@ impl StorageConfig {
 	/// - `LOCAL_BASE_PATH`: Base directory path (required)
 	#[deprecated(
 		since = "0.2.0",
-		note = "Use StorageSettings with the #[settings] macro instead."
+		note = "Use `StorageSettings` with the `#[settings]` macro instead."
 	)]
 	pub fn from_env() -> Result<Self> {
 		let backend_type = env::var("STORAGE_BACKEND").map_err(|_| {

--- a/crates/reinhardt-storages/tests/azure_tests.rs
+++ b/crates/reinhardt-storages/tests/azure_tests.rs
@@ -1,4 +1,8 @@
 //! Integration tests for Azure Blob Storage using Azurite.
+//!
+//! Gated on the `azure` feature: the fixtures and assertions used here are only
+//! compiled when `azure` is enabled, so the whole test binary is conditional.
+#![cfg(feature = "azure")]
 
 mod fixtures;
 mod utils;

--- a/crates/reinhardt-storages/tests/gcs_tests.rs
+++ b/crates/reinhardt-storages/tests/gcs_tests.rs
@@ -1,4 +1,8 @@
 //! Integration tests for Google Cloud Storage using fake-gcs-server.
+//!
+//! Gated on the `gcs` feature: the fixtures and assertions used here are only
+//! compiled when `gcs` is enabled, so the whole test binary is conditional.
+#![cfg(feature = "gcs")]
 
 mod fixtures;
 mod utils;


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix `error: unresolved link to settings` in the Docs.rs Build Check by escaping `#[settings]` (and `StorageSettings`) in the `#[deprecated]` notes of the compatibility config types.
- Fix the UI Tests build failure (`E0432`/`E0282`) by gating `gcs_tests.rs` and `azure_tests.rs` behind their respective backend features.

These are the two `reinhardt-storages` root causes behind the failing checks on the develop-branch release PR (#5019).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

On `develop/0.2.0`, the release PR (#5019) was red on two storages-rooted causes:

1. **Docs.rs Build Check** (`cargo doc --workspace --all-features --no-deps` with `--cfg docsrs -D warnings`): the deprecation notes `note = "Use StorageSettings with the #[settings] macro instead."` on `S3Config`, `GcsConfig`, `AzureConfig`, `LocalConfig`, `StorageConfig`, and `StorageConfig::from_env` were parsed by rustdoc as the intra-doc link `[settings]`, producing six `error: unresolved link to settings`. Wrapping the macro reference in backticks renders it as a code span (no link), matching the existing doc comment on `from_env`.

2. **UI Tests** (`cargo nextest run --workspace`, default features): `gcs_tests.rs` and `azure_tests.rs` unconditionally `use fixtures::{gcs,azure}_fixture`, but those fixtures are `#[cfg(feature = "...")]`-gated and `gcs`/`azure` are non-default. The test binaries therefore failed to compile (unresolved import → cascading type-inference errors). A file-level `#![cfg(feature = "...")]` makes each binary conditional, mirroring the default `s3`/`local` tests that already build.

The Azure/GCS backend tests use testcontainers (Azurite / fake-gcs-server) and are intended to run only when their feature is explicitly enabled, so gating them is the correct behavior (no test coverage is lost from the default build, which never compiled them anyway).

Related to: #5019

## How Was This Tested?

Reproduced and verified locally on a `develop/0.2.0` worktree:

- Before: `cargo test -p reinhardt-storages --no-run` (default features) failed — both `gcs_tests` and `azure_tests` failed with `E0432` + 17 `E0282` each.
- After (default features): `cargo test -p reinhardt-storages --no-run` → `Finished` (gated tests excluded).
- After: `RUSTDOCFLAGS="-D warnings" cargo doc -p reinhardt-storages --no-deps` → `Finished` (no `unresolved link` error). The original Docs.rs CI log enumerated exactly the six identical link errors and no others, and all six notes received the identical backtick fix.

## Checklist

- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`

## Related Issues

Related to release PR #5019 (`develop-release-plz`). Fixing the base branch; release-plz will regenerate the release PR automatically.

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deprecation messages for storage configuration types with improved formatting and clarity.

* **Tests**
  * Azure and GCS integration tests now conditionally compile based on their respective feature flags, reducing unnecessary compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->