### PR TITLE
fix(core): drop disposed-flag clone from Memo compute closure

### DIFF
--- a/crates/reinhardt-core/src/reactive/memo.rs
+++ b/crates/reinhardt-core/src/reactive/memo.rs
@@ -183,18 +183,18 @@ impl<T: Clone + 'static> Memo<T> {
 		let id = NodeId::new();
 		let disposed = Rc::new(RefCell::new(false));
 
-		// Store the computation function
-		let disposed_clone = disposed.clone();
+		// Store the computation function.
+		//
+		// The stored closure must NOT capture a clone of `disposed`. `Drop`
+		// uses `Rc::strong_count(&self.disposed) == 1` to detect the last live
+		// clone; a strong reference held by this long-lived closure would keep
+		// the count above 1 forever, so `dispose()` would never run and the
+		// memo node would leak in the runtime. `dispose()` removes the
+		// `MEMO_FUNCTIONS` entry, so this closure is never invoked after
+		// disposal and needs no disposed-flag guard.
 		MEMO_FUNCTIONS.with(|storage| {
 			let mut storage = storage.borrow_mut();
-			let boxed: Box<dyn core::any::Any> = Box::new(Box::new(move || {
-				if !*disposed_clone.borrow() {
-					f()
-				} else {
-					// Return default value if disposed (this should never be called)
-					panic!("Attempted to compute a disposed Memo");
-				}
-			}) as MemoFn<T>);
+			let boxed: Box<dyn core::any::Any> = Box::new(Box::new(f) as MemoFn<T>);
 			storage.insert(id, boxed);
 		});
 
@@ -244,16 +244,11 @@ impl<T: Clone + 'static> Memo<T> {
 		// requires Signal reads inside f to NOT auto-subscribe. The
 		// `run_without_observer` call detaches the stack for the duration
 		// of f.
-		let disposed_for_closure = disposed.clone();
-		let f_wrapped = move || {
-			if *disposed_for_closure.borrow() {
-				// Compute MUST NOT happen after dispose; the call site of
-				// `compute_value` is guarded by EFFECT_TIMING / MEMO_VALUES
-				// presence so this branch is defensive only.
-				panic!("Attempted to compute a disposed Memo");
-			}
-			super::runtime::run_without_observer(&mut f)
-		};
+		// See `Memo::new`: the wrapped closure must not hold a strong clone of
+		// `disposed`, or `Drop`'s `strong_count == 1` last-clone check can
+		// never fire. `dispose()` removes the `MEMO_FUNCTIONS` entry, so this
+		// closure is never run after disposal.
+		let f_wrapped = move || super::runtime::run_without_observer(&mut f);
 
 		MEMO_FUNCTIONS.with(|storage| {
 			let boxed: Box<dyn core::any::Any> = Box::new(Box::new(f_wrapped) as MemoFn<T>);


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix the `Intra-Crate Integration Tests` failure on the develop release PR (#5019): `test_memo_cleanup_on_drop` panicked on `assert!(!rt.has_node(memo_id))` because a dropped `Memo` leaked its node in the reactive runtime.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`Memo<T>` is `Clone`; its `Drop` impl disposes only when `Rc::strong_count(&self.disposed) == 1` (last live clone). The compute closure stored in `MEMO_FUNCTIONS` captured a **strong** clone of `disposed` to guard a defensive panic, which permanently held the strong count at `>= 2`. The last-clone check therefore never fired, `dispose()` was never called, and the memo node leaked.

The closure's disposed guard was dead code: `dispose()` removes the `MEMO_FUNCTIONS` entry in the same call that sets `disposed = true`, so the closure can never run after disposal. This PR removes the captured clone (and the unreachable guard) from both `Memo::new` and `Memo::new_with_deps`. `disposed` is still used by `get`/`get_untracked` (early panic on access-after-dispose) and by `Drop`'s last-clone count.

Root cause was surfaced by the recent "dispose Memo only on last clone drop" change, which added the `strong_count == 1` gate that the closure's strong reference defeats.

Related to: #5019

## How Was This Tested?

Reproduced and verified on a `develop/0.2.0` worktree:

- Before: `cargo test -p reinhardt-pages --test reactive_system_tests test_memo_cleanup_on_drop` failed deterministically (3/3 runs).
- After: all 12 `reactive_system_tests` pass — `test result: ok. 12 passed; 0 failed` — including `test_memo_cleanup_on_drop`, the `Signal`/`Effect` cleanup-on-drop tests, and `test_memo_caching` (memo recompute), confirming no regression.

## Checklist

- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Related Issues

Related to release PR #5019 (`develop-release-plz`). Fixing the base branch; release-plz will regenerate the release PR automatically.

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the reactive memo system's internal memory management and disposal mechanisms. Enhanced how reactive computations are tracked, stored, and cleaned up to improve resource lifecycle handling and prevent potential memory leaks. Streamlined the cleanup process to ensure more efficient resource utilization without affecting end-user reactive functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->