### PR TITLE
docs: mandate RAII pattern for resource management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ See instructions/MODULE_SYSTEM.md for comprehensive module system standards incl
 - NO relative paths beyond `../` (use absolute paths)
 - Mark ALL placeholders with `todo!()` or `// TODO:` comment
 - Document ALL `#[allow(...)]` attributes with explanatory comments (see @instructions/ANTI_PATTERNS.md)
+- **MUST manage all resources via RAII** (Drop-based guard types); NO manual `close()`/`release()`/`cleanup()` that can be skipped on an early `return`, `?`, or panic; NO `mem::forget` / `ManuallyDrop` / immediate-drop `let _ = lock()` without a justifying comment (see @instructions/ANTI_PATTERNS.md)
 
 **Unimplemented Features Notation:**
 - `todo!()` - Features that WILL be implemented

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ See instructions/MODULE_SYSTEM.md for comprehensive module system standards incl
 - NO relative paths beyond `../` (use absolute paths)
 - Mark ALL placeholders with `todo!()` or `// TODO:` comment
 - Document ALL `#[allow(...)]` attributes with explanatory comments (see @instructions/ANTI_PATTERNS.md)
+- **MUST manage all resources via RAII** (Drop-based guard types); NO manual `close()`/`release()`/`cleanup()` that can be skipped on an early `return`, `?`, or panic; NO `mem::forget` / `ManuallyDrop` / immediate-drop `let _ = lock()` without a justifying comment (see @instructions/ANTI_PATTERNS.md)
 
 **Unimplemented Features Notation:**
 - `todo!()` - Features that WILL be implemented

--- a/instructions/ANTI_PATTERNS.md
+++ b/instructions/ANTI_PATTERNS.md
@@ -22,6 +22,11 @@ mindmap
       Alternative TODO notations
       Undocumented allow attrs
       cfg(any()) gate
+    Resource Management
+      Manual cleanup
+      mem::forget leaks
+      Immediate-drop guard
+      Missing Drop impl
     Testing
       Skeleton tests
       No Reinhardt components
@@ -431,6 +436,110 @@ suppression must be justified with a clear comment explaining:
    requirements
 5. **Intentionally Excluded**: Features marked with `unimplemented!()` for
    architectural reasons
+
+---
+
+## Resource Management Anti-Patterns
+
+### ❌ Manual Resource Cleanup Instead of RAII
+
+**MUST: All resources MUST be managed via the RAII pattern** — acquiring a
+resource binds it to a value whose `Drop` implementation releases it. Manual
+release that can be skipped on an early `return`, a `?` propagation, or a panic
+is forbidden.
+
+Resources that MUST be wrapped in an RAII guard type include:
+
+- Locks and guards (`Mutex`, `RwLock`, semaphores)
+- Open files and file descriptors
+- Database connections and **transactions** (roll back on drop unless committed)
+- Spawned tasks, threads, and `JoinHandle`s that require teardown
+- Temporary files and directories
+- FFI / raw OS handles, sockets
+- Any external resource that needs an explicit `release`/`close`/`cleanup` step
+
+**DON'T** (manual cleanup leaks on early return / `?` / panic):
+
+```rust
+let conn = pool.acquire().await?;
+conn.begin().await?;
+do_work(&conn).await?;   // ❌ on Err, control returns here — commit/release never run
+conn.commit().await?;
+conn.release();          // ❌ unreachable on the error path -> leaked transaction
+```
+
+**DO** (RAII guarantees release via `Drop`):
+
+```rust
+let mut tx = pool.begin().await?;  // guard: Drop rolls back if not committed
+do_work(&mut tx).await?;           // ✅ early return still rolls back via Drop
+tx.commit().await?;                // explicit success path
+// connection is returned to the pool when `tx` is dropped
+```
+
+**Why?** Rust enforces RAII through ownership and `Drop`; manual cleanup throws
+that guarantee away and reintroduces the leak-on-error class of bugs.
+
+### ❌ Dropping a Guard Immediately with `let _ =`
+
+```rust
+let _ = mutex.lock().unwrap();  // ❌ guard dropped at end of statement — lock released at once
+shared.modify();                // ❌ NOT protected by the lock
+```
+
+**DO** — bind the guard to a named variable so it lives to the end of the scope:
+
+```rust
+let _guard = mutex.lock().unwrap();  // ✅ held until `_guard` leaves scope
+shared.modify();                     // ✅ protected
+```
+
+**Why?** `let _ = expr;` discards the value at the end of the statement. For a
+guard, that releases the resource on the next line. Use a named binding such as
+`let _guard = ...` to hold it.
+
+### ❌ Bypassing `Drop` with `mem::forget` / `ManuallyDrop` / `Box::leak`
+
+`std::mem::forget`, `ManuallyDrop`, and `Box::leak` skip `Drop` and leak the
+resource. They are FORBIDDEN unless ownership is genuinely transferred elsewhere
+(e.g., handing a buffer to FFI). Every use MUST carry a comment stating **why**
+`Drop` must be skipped and **where** the resource is actually released.
+
+```rust
+// ❌ Silent leak — no justification
+std::mem::forget(file);
+```
+
+```rust
+// ✅ Ownership transferred to the C side, which releases it on shutdown.
+// Dropping here would double-free. See ffi::register_handle.
+std::mem::forget(handle);
+```
+
+### ❌ Owning an External Resource Without a `Drop` impl
+
+A type that owns an external resource (raw handle, connection, spawned task,
+temporary path) MUST implement `Drop` to release it. Do not rely on callers to
+remember a `close()` / `shutdown()` call.
+
+```rust
+// ❌ Caller must remember `.shutdown()` — easy to forget, skipped on panic
+struct Worker { handle: RawHandle }
+```
+
+```rust
+// ✅ Release is automatic and panic-safe
+struct Worker { handle: RawHandle }
+impl Drop for Worker {
+    fn drop(&mut self) {
+        // SAFETY: `handle` is owned and released exactly once here.
+        unsafe { release_handle(self.handle) };
+    }
+}
+```
+
+**Exceptions:** Any deviation from RAII MUST be documented with a comment that
+explains why RAII is not used and how release is otherwise guaranteed.
 
 ---
 

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -16,6 +16,7 @@
 - Convert Draft PRs to Ready for Review autonomously once the implementation is complete (CI completion is NOT required under the Autonomous Operation Policy) OR upon explicit user instruction (see instructions/PR_GUIDELINE.md § PC-4a)
 - Mark placeholders with `todo!()` or `// TODO:`
 - Use `#[serial(group_name)]` for global state tests
+- Manage all resources via RAII (Drop-based guards) — wrap locks, files, DB transactions, spawned tasks, temp dirs, and FFI handles in guard types (see instructions/ANTI_PATTERNS.md)
 - Split commits by specific intent, not features
 - Follow Conventional Commits v1.0.0 format: `<type>[scope]: <description>`
 - Start commit description with lowercase letter (e.g., `feat: add feature`)
@@ -120,6 +121,8 @@
 - Create circular dependencies
 - Leave unmarked placeholder implementations
 - Use `#[allow(...)]` without explanatory comments
+- Release resources manually in a way that can be skipped on an early `return` / `?` / panic (use RAII Drop instead)
+- Bypass Drop with `mem::forget` / `ManuallyDrop` / immediate-drop `let _ = lock()` without a justifying comment
 - Use alternative TODO notations (`FIXME:`, `NOTE:` for unimplemented features)
 - Create batch commits without user confirmation
 - Use relative paths beyond `../`


### PR DESCRIPTION
## Summary

This PR addresses:

- Mandate the RAII pattern for resource management as a strong **MUST** rule across the Reinhardt coding standards — **targeting `develop/0.2.0`** (the develop counterpart of #5020, which targets `main`).
- Add a new **Resource Management Anti-Patterns** section to `instructions/ANTI_PATTERNS.md` enumerating the resources that must be wrapped in Drop-based guard types (locks, files/FDs, DB connections & transactions, spawned tasks/`JoinHandle`s, temp files/dirs, FFI/raw OS handles, sockets) and the prohibitions (manual cleanup that leaks on early `return`/`?`/panic, immediate-drop `let _ = lock()`, bypassing `Drop` via `mem::forget`/`ManuallyDrop`/`Box::leak`, owning an external resource without a `Drop` impl), with DO/DON'T examples.
- Add a Code Style "Key Requirements" bullet to `CLAUDE.md` and `AGENTS.md` (kept in lockstep per the sync policy).
- Add MUST DO / NEVER DO entries to the shared `instructions/QUICK_REFERENCE.md`.
- Add a `Resource Management` branch to the anti-pattern mindmap.

## Type of Change

- [x] Documentation update

## Motivation and Context

RAII / guard patterns were previously documented only for **tests** (`TeardownGuard`, `TestResource` in `instructions/TESTING_STANDARDS.md`). There was no standard mandating RAII for production resource management, leaving the leak-on-error class of bugs (manual `close()`/`release()`/`cleanup()` skipped on early return, `?`, or panic; `mem::forget` leaks; `let _ = lock()` immediate guard drop) unaddressed. This PR closes that gap on the `develop/0.2.0` line with an explicit, enumerated MUST rule.

Related to: #5020 (same change targeting `main`)

## How Was This Tested?

Documentation-only change.

- Verified the new `Resource Management Anti-Patterns` section matches the existing `ANTI_PATTERNS.md` style (`### ❌` headings, ` ```rust ` fenced DO/DON'T examples); code-fence count is balanced (even).
- Confirmed the Code Style bullet is byte-identical in `CLAUDE.md` and `AGENTS.md` per the CLAUDE.md ↔ AGENTS.md sync policy.
- Branch created from and targeting `develop/0.2.0` (RC-phase develop branch); base set explicitly.

## Checklist

- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## Related Issues

-

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

---

**Additional Context:**

This is the `develop/0.2.0` counterpart of #5020 (which targets `main`). `reinhardt-cloud` and `awesome-delions` have no active `develop/*` branch, so no develop-targeting mirror PRs are needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced resource management guidelines across development documentation, including updated anti-pattern guidance and quick reference rules to ensure safer resource lifecycle handling across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->