### PR TITLE
style(examples): format twitter common page components

### DIFF
--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -664,18 +664,12 @@ pub fn theme_toggle() -> Page {
 ///
 /// Displays an empty div (useful for conditional rendering).
 pub fn empty() -> Page {
-	page!(|| {
-		div {}
-	})()
+	page!(|| { div {} })()
 }
 
 /// Divider component
 pub fn divider() -> Page {
-	page!(|| {
-		div {
-			class: "divider"
-		}
-	})()
+	page!(|| { div { class: "divider" } })()
 }
 
 /// Badge component


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix the `Examples Tests / examples-twitter` → `Check Format` failure on the main release PR (#5017).

## Type of Change

- [x] Other (please describe): formatting-only (`style`)

## Motivation and Context

On the main release PR (#5017), the `examples-twitter` job failed at the Check Format step: `reinhardt-admin fmt . --check` reported `examples-twitter/src/core/client/components/common.rs` as unformatted (`1 would be formatted`). The `examples-tutorial-basis` and `examples-tutorial-rest` jobs passed, so this is the only blocking diff. (The `cargo metadata` `reinhardt-web ^0.1.3` message in the same log is non-fatal noise — it also appears in the passing jobs.)

Reformatted with `reinhardt-admin` built from the current `main` source (matching CI's `cargo install --path crates/reinhardt-admin-cli`, avoiding version skew): the short single-element `page!` blocks in `empty()` and `divider()` are collapsed onto one line. Formatting only — no behavior change.

Related to: #5017

## How Was This Tested?

- Reproduced locally: `reinhardt-admin fmt . --check` in `examples/examples-twitter` reported `common.rs` would be formatted (matching the CI log).
- After `reinhardt-admin fmt .`: `--check` reports `0 would be formatted, 104 unchanged` (clean).

## Checklist

- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] I have formatted the code with `reinhardt-admin fmt`

## Related Issues

Related to release PR #5017 (`release-plz`). Fixing the base branch (`main`); release-plz will regenerate the release PR automatically.

## Labels to Apply

### Type Label
- [x] `documentation` (formatting / examples; no functional change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized common UI component implementations for improved code maintainability and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->