### PR TITLE
fix(core): drop unused mut on Memo::new parameter

### DIFF
--- a/crates/reinhardt-core/src/reactive/memo.rs
+++ b/crates/reinhardt-core/src/reactive/memo.rs
@@ -176,7 +176,7 @@ impl<T: Clone + 'static> Memo<T> {
 	/// let doubled = Memo::new(move || count_clone.get() * 2);
 	/// assert_eq!(doubled.get(), 10);
 	/// ```
-	pub fn new<F>(mut f: F) -> Self
+	pub fn new<F>(f: F) -> Self
 	where
 		F: FnMut() -> T + 'static,
 	{


### PR DESCRIPTION
## Summary

This PR addresses:

- Removes the now-unnecessary `mut` from the `f` parameter of `Memo::new` in `crates/reinhardt-core/src/reactive/memo.rs`, which was breaking the **Clippy / Clippy Lint** check on `develop/0.2.0`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code quality improvements

## Motivation and Context

PR #5022 ("fix(core): drop disposed-flag clone from Memo compute closure") removed the disposed-flag clone that the stored compute closure used to capture. As a result, `f` in `Memo::new` is now only moved into `MEMO_FUNCTIONS` storage (`Box::new(f)`) and is never mutated within `new()`. The leftover `mut` binding triggers `unused_mut`, which is denied under `cargo clippy --workspace --all --all-features -- -D warnings`.

PR #5022 was merged into `develop/0.2.0` despite the failing Clippy check (its pre-merge run [failed here](https://github.com/kent8192/reinhardt-web/actions/runs/26667642033/job/78604396638)), so the error is now live on `develop/0.2.0` HEAD and breaks the Clippy Lint check for the branch and any PR based on it.

`Memo::new_with_deps` keeps its `mut f` because that closure is invoked within the function and the binding is genuinely mutated — only `new()` was flagged.

Related to: #5022

## How Was This Tested?

- `cargo clippy -p reinhardt-core --all-features -- -D warnings` → **No issues found** (previously failed with `error: variable does not need to be mutable`)
- `rustfmt --edition 2024 --check` on the edited file passes

## Checklist

- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] core (reactive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements with no impact on user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->