### PR TITLE
docs(wiki): sync CLAUDE.md/AGENTS.md Obsidian section with OW-7 policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,19 +329,21 @@ See instructions/RELEASE_PROCESS.md for detailed release procedures.
 
 **Vault:** Discovered via Obsidian MCP server (`obsidian-vault`). Call `obsidian_list_files_in_vault` to verify connectivity and resolve the vault root.
 
-At the end of a meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned), update the Obsidian wiki:
+Update the Obsidian wiki **frequently and proactively** — at the end of every meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned, module/component studied, dependency assessed, flow traced, concept clarified, options compared, question answered) and whenever you learn something worth preserving. When in doubt, write a short page (OW-1):
 
 1. Check Obsidian MCP availability — if unavailable, **skip entirely** (do NOT block primary work)
 2. Use `/wiki-query` to retrieve relevant existing knowledge before answering or deciding (OW-5)
 3. Read `wiki/hot.md` to check for duplicates
-4. Create/update pages under the appropriate category
+4. Create/update pages under the **most specific** category, drawing on the vault's full category set (`modules/`, `components/`, `knowledge/{patterns,troubleshooting,learnings}/`, `decisions/`, `dependencies/`, `flows/`, `concepts/`, `entities/`, `domains/`, `comparisons/`, `questions/`) — never default everything to `knowledge/troubleshooting/` (OW-2, OW-7)
 5. Update meta pages: `wiki/index.md`, `wiki/hot.md`, `wiki/log.md`
+
+**Distribute (OW-7):** Spread knowledge across categories — a single work unit often yields several cross-linked pages. Proactively populate under-used categories instead of concentrating in one.
 
 **Dual-write rule (OW-6):** When saving to any memory system (claude-mem, auto-memory, Serena), simultaneously invoke `/wiki-ingest` to persist the same knowledge in the Obsidian wiki.
 
 **Skip when:** MCP unavailable, trivial changes, work in progress, or emergency/hotfix work.
 
-See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-6).
+See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-7).
 
 ### Workflow Best Practices
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,19 +329,21 @@ See instructions/RELEASE_PROCESS.md for detailed release procedures.
 
 **Vault:** Discovered via Obsidian MCP server (`obsidian-vault`). Call `obsidian_list_files_in_vault` to verify connectivity and resolve the vault root.
 
-At the end of a meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned), update the Obsidian wiki:
+Update the Obsidian wiki **frequently and proactively** — at the end of every meaningful work unit (architectural decision, new pattern, troubleshooting solution, lesson learned, module/component studied, dependency assessed, flow traced, concept clarified, options compared, question answered) and whenever you learn something worth preserving. When in doubt, write a short page (OW-1):
 
 1. Check Obsidian MCP availability — if unavailable, **skip entirely** (do NOT block primary work)
 2. Use `/wiki-query` to retrieve relevant existing knowledge before answering or deciding (OW-5)
 3. Read `wiki/hot.md` to check for duplicates
-4. Create/update pages under the appropriate category
+4. Create/update pages under the **most specific** category, drawing on the vault's full category set (`modules/`, `components/`, `knowledge/{patterns,troubleshooting,learnings}/`, `decisions/`, `dependencies/`, `flows/`, `concepts/`, `entities/`, `domains/`, `comparisons/`, `questions/`) — never default everything to `knowledge/troubleshooting/` (OW-2, OW-7)
 5. Update meta pages: `wiki/index.md`, `wiki/hot.md`, `wiki/log.md`
+
+**Distribute (OW-7):** Spread knowledge across categories — a single work unit often yields several cross-linked pages. Proactively populate under-used categories instead of concentrating in one.
 
 **Dual-write rule (OW-6):** When saving to any memory system (claude-mem, auto-memory, Serena), simultaneously invoke `/wiki-ingest` to persist the same knowledge in the Obsidian wiki.
 
 **Skip when:** MCP unavailable, trivial changes, work in progress, or emergency/hotfix work.
 
-See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-6).
+See instructions/OBSIDIAN_WIKI.md for detailed standards (OW-1 ~ OW-7).
 
 ### Workflow Best Practices
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Follow-up to merged PRs #5030 (`main`) / #5031 (`develop/0.2.0`), which added the OW-7 distribution rule and broadened OW-1 capture frequency in `instructions/OBSIDIAN_WIKI.md` but left the primary-agent summary in `CLAUDE.md` and `AGENTS.md` stale.

### What changed (`CLAUDE.md` + `AGENTS.md`, kept in sync)

- Reframe the trigger sentence toward *frequent, proactive* capture and list the broader trigger set (OW-1).
- Step 4 now routes to the **most specific** category across the vault's full category set instead of "the appropriate category", and forbids defaulting to `knowledge/troubleshooting/` (OW-2, OW-7).
- Add a **Distribute (OW-7)** note.
- Update the cross-reference from "OW-1 ~ OW-6" to "OW-1 ~ OW-7".

## Type of Change

- [x] Documentation update

## Motivation and Context

- The primary-agent instruction files summarize the Obsidian policy that lives in `instructions/OBSIDIAN_WIKI.md`. After OW-7 merged, those summaries still described the old narrow triggers and an outdated rule range ("OW-1 ~ OW-6"), so an agent reading only `CLAUDE.md`/`AGENTS.md` would not apply the new distribution/frequency policy.
- Per the `CLAUDE.md` ↔ `AGENTS.md` sync policy, both files are updated in the same commit.

## How Was This Tested?

- Documentation-only change. Verified `diff CLAUDE.md AGENTS.md` shows only the documented Claude Code ↔ Codex / CLAUDE ↔ AGENTS substitutions (no new divergence) and that the edited block is byte-identical between the two files.

## Checklist

- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation
- [x] My changes generate no new warnings

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

---

**Additional Context:**

- Companion PR applies the identical change to the `main` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Obsidian wiki maintenance guidelines with more frequent and proactive update triggers
  * Enhanced procedures including duplicate detection, category-based organization, and explicit meta page maintenance requirements
  * Added knowledge distribution rules for better information organization across the vault

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->