### PR TITLE
test(pages): sync trybuild .stderr with rustfmt-collapsed empty braces

### DIFF
--- a/crates/reinhardt-pages/tests/ui/form/fail/char_field_with_generic.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/char_field_with_generic.stderr
@@ -1,5 +1,5 @@
 error: CharField does not accept a type parameter
   --> tests/ui/form/fail/char_field_with_generic.rs:11:14
    |
-11 |             username: CharField<i32> { },
+11 |             username: CharField<i32> {},
    |                       ^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/ip_address_with_generic.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/ip_address_with_generic.stderr
@@ -1,5 +1,5 @@
 error: IpAddressField does not accept a type parameter
   --> tests/ui/form/fail/ip_address_with_generic.rs:11:15
    |
-11 |             client_ip: IpAddressField<i32> { },
+11 |             client_ip: IpAddressField<i32> {},
    |                        ^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix the `test_form_macro_fail` trybuild failure in the **UI Tests** job (2 of 9 form/fail cases) caused by a `.stderr` snapshot that drifted out of sync with its `.rs` source after a rustfmt pass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The fmt-all pass (`f3ac9766b1`) collapsed the empty struct-init braces in
`tests/ui/form/fail/{char_field_with_generic,ip_address_with_generic}.rs`
from `{ }` to `{}`, but the matching `.stderr` snapshots still echoed the old
`{ }` source line. trybuild renders the *actual* source span in its diagnostic,
so expected vs actual diverged only on that whitespace:

```
EXPECTED: username: CharField<i32> { },
ACTUAL:   username: CharField<i32> {},
```

Docs-only PRs skip the reinhardt-pages trybuild suite via Detect Affected
Packages, so `develop/0.2.0` HEAD stayed green; the desync only surfaces on a
full run such as the release PR (#5035). This change re-syncs the two `.stderr`
snapshots to `{}` to match the formatted sources. No other ui `.stderr` files
carry the same drift (the rest of `test_*_macro_fail` passed in the same run).

Fixes #

Related to: #5035

## How Was This Tested?

- Compared the two updated `.stderr` files byte-for-byte against the **ACTUAL OUTPUT** block reported by the failing UI Tests job — the only delta was the `{ } -> {}` whitespace now corrected.
- CI on this PR re-runs `test_form_macro_fail` to confirm the snapshots match.

## Breaking Changes

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertion output for form field type parameter validation tests to reflect current compiler error formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->