### PR TITLE
test(storages): wait for Azurite readiness log instead of fixed delay

### DIFF
--- a/crates/reinhardt-storages/tests/fixtures.rs
+++ b/crates/reinhardt-storages/tests/fixtures.rs
@@ -563,9 +563,16 @@ pub async fn azure_fixture() -> AzureFixture {
 	use testcontainers::core::{ContainerPort, WaitFor};
 	use testcontainers::{GenericImage, ImageExt, runners::AsyncRunner};
 
+	// Wait for Azurite's readiness log line instead of a fixed delay: a flat
+	// `WaitFor::seconds(1)` races the blob endpoint and intermittently yields
+	// `NetworkError` when `create_storage` issues the container-create request
+	// before Azurite is listening. Azurite 3.35.0 prints this on stdout once
+	// the blob service is accepting connections.
 	let image = GenericImage::new("mcr.microsoft.com/azure-storage/azurite", "3.35.0")
 		.with_exposed_port(ContainerPort::Tcp(10000))
-		.with_wait_for(WaitFor::seconds(1))
+		.with_wait_for(WaitFor::message_on_stdout(
+			"Azurite Blob service successfully listens",
+		))
 		.with_startup_timeout(std::time::Duration::from_secs(120))
 		.with_cmd(vec!["azurite-blob", "--blobHost", "0.0.0.0"]);
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix the intermittent `azure_generates_sas_url_shape` failure in the **Intra-Crate Integration Tests** job by waiting for Azurite's readiness log line instead of a flat 1-second delay.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

`azure_fixture()` used `WaitFor::seconds(1)`, a fixed 1-second delay that races
Azurite's blob endpoint. When `create_storage` issued the container-create
request before Azurite finished binding, the backend failed with:

```
Failed to create Azure backend: NetworkError("error sending request for url
(http://127.0.0.1:<port>/devstoreaccount1/reinhardt-...?restype=container)")
```

This intermittently failed `azure_generates_sas_url_shape` on the release PR
(#5035). Azurite 3.35.0 prints
`Azurite Blob service successfully listens on http://0.0.0.0:10000` to stdout
once it accepts connections; gating on that substring removes the race while
keeping the existing 120s startup timeout as the upper bound.

Fixes #

Related to: #5035

## How Was This Tested?

- Ran the pinned `mcr.microsoft.com/azure-storage/azurite:3.35.0` image locally and confirmed the readiness line is emitted on **stdout** (stderr was empty), so `WaitFor::message_on_stdout` matches the real signal.
- CI on this PR re-runs the `azure` integration suite to confirm the race is gone.

## Breaking Changes

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite reliability by implementing smarter startup detection for test containers, replacing fixed delays with waiting for service readiness signals to ensure services are fully initialized before tests connect.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->