### PR TITLE
ci(doc-test): link doctests with mold to cut documentation-test wall time

### DIFF
--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -78,6 +78,42 @@ jobs:
         with:
           tool: cargo-make
 
+      # Doc tests are dominated by linking: rustdoc compiles each doctest into
+      # its own binary that links the full (all-features) crate, so the default
+      # bfd/lld linker is the bottleneck. mold cuts that link time the same way
+      # unit-test.yml already does for the test binaries.
+      - name: Install mold linker and build dependencies
+        run: |
+          sudo systemctl stop unattended-upgrades || true
+          sudo apt-get update -o DPkg::Lock::Timeout=120
+          sudo apt-get install -y -o DPkg::Lock::Timeout=120 mold clang lld build-essential
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+
+      # Scope mold to the host target only. A global `RUSTFLAGS=...-fuse-ld=mold`
+      # leaks into wasm32 builds and clang rejects `-fuse-ld=mold` for that
+      # target. See reinhardt-web#4147. `RUSTDOCFLAGS` carries the linker into
+      # the rustdoc doctest compilation, which is where the doc-test link cost
+      # actually lives (cargo does not forward the target linker to rustdoc).
+      - name: Configure mold linker (host target only)
+        run: |
+          cat > /tmp/clang-mold-wrapper << 'WRAPPER'
+          #!/bin/sh
+          exec clang -fuse-ld=mold "$@"
+          WRAPPER
+          chmod +x /tmp/clang-mold-wrapper
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            ENV_KEY="CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER"
+          elif [ "$ARCH" = "x86_64" ]; then
+            ENV_KEY="CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER"
+          else
+            echo "Unsupported architecture for mold linker configuration: $ARCH" >&2
+            exit 1
+          fi
+          echo "${ENV_KEY}=/tmp/clang-mold-wrapper" >> "$GITHUB_ENV"
+          echo "RUSTDOCFLAGS=-Clinker=/tmp/clang-mold-wrapper" >> "$GITHUB_ENV"
+
       - name: Additional disk cleanup before tests
         if: ${{ !contains(inputs.runner, 'self-hosted') }}
         run: |


### PR DESCRIPTION
## Summary

This PR addresses:

- Speed up the **Documentation Tests** job, which is link-bound, by linking doctest binaries with **mold** (the job previously used the default linker, unlike unit-test.yml).

## Type of Change

- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The Documentation Tests job's cost is dominated by **linking**, not test execution. rustdoc compiles each crate's doctests into a binary that links the full `--all-features` crate; the heaviest crate (`reinhardt-db`, ~1.3k doctests spanning every DB backend) makes that link the bottleneck. Trivial doctests (e.g. `Value::int(42)`) showing "has been running for over 60 seconds" are the symptom: the time is compile+link, not runtime.

`unit-test.yml` already links with mold; `doc-test.yml` did not. This change installs mold + clang and routes the host-target linker through the same clang/mold wrapper. Because **doctest binaries are linked by rustdoc** (and cargo does not forward the target linker to rustdoc), the wrapper is also exported via `RUSTDOCFLAGS=-Clinker=...` so the doctest link itself benefits.

### On "merged doctests"

Merged doctests (one binary per crate instead of one-per-doctest) is **already enabled by default**: the workspace is Rust 2024 edition and CI pins Rust 1.94.1 (merged doctests has been the edition-2024 default since 1.85). A static scan found **zero `compile_fail` doctests** anywhere in the workspace and **zero crate-level inner attributes** in `reinhardt-db`'s doctests — i.e. nothing forces a standalone fallback — so `auto` already merges everything mergeable. Forcing `--merge-doctests=yes` is nightly-gated, collapses per-doctest failure reporting, and would not improve on `auto` here, so no source change is made to "enable" merging. mold is the actionable speedup.

Fixes #

Related to: #5035

## How Was This Tested?

- Verified on the pinned toolchain (1.94.1) that edition-2024 crates merge doctests by default (`merged doctests compilation took …`).
- Confirmed the workspace has no `compile_fail` doctests (which would defeat merging) and `reinhardt-db` doctests carry no crate-level inner attributes.
- mold steps mirror the already-CI-proven setup in `unit-test.yml`; CI on this PR exercises the doc-test job end-to-end.

## Breaking Changes

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to optimize documentation test execution speed through linker configuration improvements.

**Note:** This release contains only internal infrastructure updates with no impact on end-user functionality or features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->