### PR TITLE
fix(examples): resolve DATABASE_URL via db_url.sh for the management CLI

### DIFF
--- a/examples/examples-tutorial-basis/Makefile.toml
+++ b/examples/examples-tutorial-basis/Makefile.toml
@@ -51,8 +51,15 @@ dependencies = ["infra-down", "infra-up"]
 [tasks.runserver]
 description = "Start the development server (auto-reloads on changes). Forwards extra args, e.g. `cargo make runserver -- -vv` for verbose output. Auto-starts PostgreSQL/Redis via `infra-up` (transitively through `migrate`)."
 dependencies = ["migrate"]
-command = "cargo"
-args = ["run", "--bin", "manage", "--", "runserver", "--with-pages", "${@}"]
+# `DATABASE_URL` is resolved via `db_url.sh` because the management CLI cannot
+# read `settings/*.toml` for an example crate (its command context has no
+# settings). See scripts/db_url.sh for the full rationale.
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+eval "$(bash scripts/db_url.sh)"
+cargo run --bin manage -- runserver --with-pages "${@}"
+'''
 
 # ============================================================================
 # Database Migrations
@@ -60,14 +67,30 @@ args = ["run", "--bin", "manage", "--", "runserver", "--with-pages", "${@}"]
 
 [tasks.makemigrations]
 description = "Create new migrations based on model changes"
-command = "cargo"
-args = ["run", "--bin", "manage", "makemigrations"]
+# `DATABASE_URL` is resolved via `db_url.sh` (see scripts/db_url.sh): the
+# management CLI has no project settings in its command context, so it relies
+# on the env var for the connection string.
+dependencies = ["infra-up"]
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+eval "$(bash scripts/db_url.sh)"
+cargo run --bin manage makemigrations
+'''
 
 [tasks.migrate]
 description = "Apply database migrations (auto-starts PostgreSQL/Redis via `infra-up`)"
 dependencies = ["infra-up"]
-command = "cargo"
-args = ["run", "--bin", "manage", "migrate"]
+# `DATABASE_URL` is resolved via `db_url.sh` (see scripts/db_url.sh): the
+# management CLI has no project settings in its command context, so the
+# connection string must be supplied through the environment. `infra-up`
+# provisions the container from the same settings, so the credentials match.
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+eval "$(bash scripts/db_url.sh)"
+cargo run --bin manage migrate
+'''
 
 # ============================================================================
 # Static Files

--- a/examples/examples-tutorial-basis/scripts/db_url.sh
+++ b/examples/examples-tutorial-basis/scripts/db_url.sh
@@ -6,7 +6,7 @@
 # `DatabaseConnection::database_url_from(ctx.settings, $DATABASE_URL)`. For an
 # example crate `ctx.settings` is always `None` — the framework does not wire
 # the project's own `get_settings()` into the command context (tracked in
-# kent8192/reinhardt-web#5040; the management runtime would otherwise read
+# kent8192/reinhardt-web#5042; the management runtime would otherwise read
 # `settings/*.toml` directly). The CLI therefore falls back to the `DATABASE_URL` environment
 # variable, which nothing sets, producing:
 #   "No database URL available. Set DATABASE_URL environment variable."

--- a/examples/examples-tutorial-basis/scripts/db_url.sh
+++ b/examples/examples-tutorial-basis/scripts/db_url.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Emit a shell-evaluable `export DATABASE_URL=...` line for the active profile.
+#
+# Why this exists: the management CLI (`manage migrate` / `makemigrations` /
+# `runserver`) resolves its database connection via
+# `DatabaseConnection::database_url_from(ctx.settings, $DATABASE_URL)`. For an
+# example crate `ctx.settings` is always `None` — the framework does not wire
+# the project's own `get_settings()` into the command context (tracked in
+# kent8192/reinhardt-web#5040; the management runtime would otherwise read
+# `settings/*.toml` directly). The CLI therefore falls back to the `DATABASE_URL` environment
+# variable, which nothing sets, producing:
+#   "No database URL available. Set DATABASE_URL environment variable."
+#
+# cargo-make runs each task in its own process, so exporting from
+# `infra_up.sh` (a separate `infra-up` dependency task) would not reach the
+# `cargo run` in the `migrate` task. Instead, the cargo-running tasks
+# `eval "$(bash scripts/db_url.sh)"` in their own shell, so the URL is set in
+# the same process that launches `cargo run`. Credentials come from the same
+# settings TOML the container is provisioned from, keeping the connection
+# string in lockstep with `infra_up.sh` (both consume `parse_local_toml.py`).
+#
+# Usage (from the crate root, inside a cargo-make task):
+#   eval "$(bash scripts/db_url.sh)" && cargo run --bin manage migrate
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRATE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROFILE="${REINHARDT_ENV:-local}"
+CONFIG="$CRATE_DIR/settings/${PROFILE}.toml"
+
+if [ ! -f "$CONFIG" ]; then
+	echo "Error: settings file for profile '${PROFILE}' not found at: $CONFIG" >&2
+	exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+	echo "Error: python3 (>=3.11, for tomllib) is required to parse $CONFIG" >&2
+	exit 1
+fi
+
+# parse_local_toml.py emits shell-quoted PG_* / RD_* assignments (the same
+# ones infra_up.sh consumes), so the resolved host/port/credentials match the
+# provisioned container exactly.
+SETTINGS=$(python3 "$SCRIPT_DIR/parse_local_toml.py" "$CONFIG") || exit $?
+eval "$SETTINGS"
+
+# Reuse python3's URL-encoding so passwords containing URL-reserved characters
+# (`@`, `:`, `/`, ...) survive being embedded in the DATABASE_URL authority.
+ENCODED_USER=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$PG_USER")
+ENCODED_PASS=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$PG_PASS")
+
+DATABASE_URL="postgresql://${ENCODED_USER}:${ENCODED_PASS}@${PG_HOST}:${PG_PORT}/${PG_DB}"
+
+# Shell-quote the final value so the `eval` in the caller is safe.
+printf 'export DATABASE_URL=%q\n' "$DATABASE_URL"

--- a/examples/examples-tutorial-basis/scripts/run-dev-release-server.sh
+++ b/examples/examples-tutorial-basis/scripts/run-dev-release-server.sh
@@ -5,5 +5,10 @@
 # behind `--noreload` and `--no-override-wasm`.
 set -euo pipefail
 
+# Resolve DATABASE_URL the same way the `migrate` / `runserver` tasks do: the
+# management CLI cannot read settings/*.toml for an example crate, so it needs
+# the connection string from the environment (see scripts/db_url.sh).
+eval "$(bash "$(dirname "${BASH_SOURCE[0]}")/db_url.sh")"
+
 echo "🚀 Starting server with optimized WASM frontend..."
 cargo run --release --bin manage -- runserver --with-pages --noreload --no-override-wasm

--- a/examples/examples-tutorial-basis/scripts/run-dev-server.sh
+++ b/examples/examples-tutorial-basis/scripts/run-dev-server.sh
@@ -22,5 +22,10 @@ if [ "$CURRENT_DIR" != "examples-tutorial-basis" ]; then
 	exit 1
 fi
 
+# Resolve DATABASE_URL the same way the `migrate` / `runserver` tasks do: the
+# management CLI cannot read settings/*.toml for an example crate, so it needs
+# the connection string from the environment (see scripts/db_url.sh).
+eval "$(bash "$(dirname "${BASH_SOURCE[0]}")/db_url.sh")"
+
 echo "🚀 Starting development server with WASM frontend..."
 cargo run --bin manage -- runserver --with-pages --noreload --no-override-wasm

--- a/examples/examples-tutorial-rest/Makefile.toml
+++ b/examples/examples-tutorial-rest/Makefile.toml
@@ -51,8 +51,15 @@ dependencies = ["infra-down", "infra-up"]
 [tasks.runserver]
 description = "Start the development server (auto-starts PostgreSQL/Redis via `infra-up` transitively through `migrate`)"
 dependencies = ["migrate"]
-command = "cargo"
-args = ["run", "--bin", "manage", "--", "runserver"]
+# `DATABASE_URL` is resolved via `db_url.sh` because the management CLI cannot
+# read `settings/*.toml` for an example crate (its command context has no
+# settings). See scripts/db_url.sh for the full rationale.
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+eval "$(bash scripts/db_url.sh)"
+cargo run --bin manage -- runserver "${@}"
+'''
 
 # ============================================================================
 # Database Migrations
@@ -60,14 +67,30 @@ args = ["run", "--bin", "manage", "--", "runserver"]
 
 [tasks.makemigrations]
 description = "Create new migrations based on model changes"
-command = "cargo"
-args = ["run", "--bin", "manage", "makemigrations"]
+# `DATABASE_URL` is resolved via `db_url.sh` (see scripts/db_url.sh): the
+# management CLI has no project settings in its command context, so it relies
+# on the env var for the connection string.
+dependencies = ["infra-up"]
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+eval "$(bash scripts/db_url.sh)"
+cargo run --bin manage makemigrations
+'''
 
 [tasks.migrate]
 description = "Apply database migrations (auto-starts PostgreSQL/Redis via `infra-up`)"
 dependencies = ["infra-up"]
-command = "cargo"
-args = ["run", "--bin", "manage", "migrate"]
+# `DATABASE_URL` is resolved via `db_url.sh` (see scripts/db_url.sh): the
+# management CLI has no project settings in its command context, so the
+# connection string must be supplied through the environment. `infra-up`
+# provisions the container from the same settings, so the credentials match.
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+eval "$(bash scripts/db_url.sh)"
+cargo run --bin manage migrate
+'''
 
 # ============================================================================
 # Testing

--- a/examples/examples-tutorial-rest/README.md
+++ b/examples/examples-tutorial-rest/README.md
@@ -61,7 +61,7 @@ cargo test
 ### Run the Development Server
 
 ```bash
-cargo run --bin manage runserver
+cargo make runserver
 ```
 
 The server will start at `http://127.0.0.1:8000/`.
@@ -347,7 +347,7 @@ cargo test -- --nocapture
 This example demonstrates both function-based views (Tutorial 1-5) and ViewSet-based views (Tutorial 6). **Both are mounted simultaneously** on the same running server — there is no toggle between them. The two endpoint sets coexist under separate URL prefixes:
 
 ```bash
-cargo run --bin manage runserver
+cargo make runserver
 
 # Function-based endpoints (Tutorial 1-5)
 curl http://127.0.0.1:8000/api/snippets/
@@ -365,8 +365,8 @@ The Bruno collection under `bruno/` contains a `Snippets CRUD` folder for the fu
 > first:
 >
 > ```bash
-> cargo run --bin manage -- migrate
-> cargo run --bin manage runserver
+> cargo make migrate
+> cargo make runserver
 > ```
 >
 > Until rows are inserted, the `/api/snippets-viewset/` endpoints will

--- a/examples/examples-tutorial-rest/scripts/db_url.sh
+++ b/examples/examples-tutorial-rest/scripts/db_url.sh
@@ -6,7 +6,7 @@
 # `DatabaseConnection::database_url_from(ctx.settings, $DATABASE_URL)`. For an
 # example crate `ctx.settings` is always `None` — the framework does not wire
 # the project's own `get_settings()` into the command context (tracked in
-# kent8192/reinhardt-web#5040; the management runtime would otherwise read
+# kent8192/reinhardt-web#5042; the management runtime would otherwise read
 # `settings/*.toml` directly). The CLI therefore falls back to the `DATABASE_URL` environment
 # variable, which nothing sets, producing:
 #   "No database URL available. Set DATABASE_URL environment variable."

--- a/examples/examples-tutorial-rest/scripts/db_url.sh
+++ b/examples/examples-tutorial-rest/scripts/db_url.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Emit a shell-evaluable `export DATABASE_URL=...` line for the active profile.
+#
+# Why this exists: the management CLI (`manage migrate` / `makemigrations` /
+# `runserver`) resolves its database connection via
+# `DatabaseConnection::database_url_from(ctx.settings, $DATABASE_URL)`. For an
+# example crate `ctx.settings` is always `None` — the framework does not wire
+# the project's own `get_settings()` into the command context (tracked in
+# kent8192/reinhardt-web#5040; the management runtime would otherwise read
+# `settings/*.toml` directly). The CLI therefore falls back to the `DATABASE_URL` environment
+# variable, which nothing sets, producing:
+#   "No database URL available. Set DATABASE_URL environment variable."
+#
+# cargo-make runs each task in its own process, so exporting from
+# `infra_up.sh` (a separate `infra-up` dependency task) would not reach the
+# `cargo run` in the `migrate` task. Instead, the cargo-running tasks
+# `eval "$(bash scripts/db_url.sh)"` in their own shell, so the URL is set in
+# the same process that launches `cargo run`. Credentials come from the same
+# settings TOML the container is provisioned from, keeping the connection
+# string in lockstep with `infra_up.sh` (both consume `parse_local_toml.py`).
+#
+# Usage (from the crate root, inside a cargo-make task):
+#   eval "$(bash scripts/db_url.sh)" && cargo run --bin manage migrate
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRATE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROFILE="${REINHARDT_ENV:-local}"
+CONFIG="$CRATE_DIR/settings/${PROFILE}.toml"
+
+if [ ! -f "$CONFIG" ]; then
+	echo "Error: settings file for profile '${PROFILE}' not found at: $CONFIG" >&2
+	exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+	echo "Error: python3 (>=3.11, for tomllib) is required to parse $CONFIG" >&2
+	exit 1
+fi
+
+# parse_local_toml.py emits shell-quoted PG_* / RD_* assignments (the same
+# ones infra_up.sh consumes), so the resolved host/port/credentials match the
+# provisioned container exactly.
+SETTINGS=$(python3 "$SCRIPT_DIR/parse_local_toml.py" "$CONFIG") || exit $?
+eval "$SETTINGS"
+
+# Reuse python3's URL-encoding so passwords containing URL-reserved characters
+# (`@`, `:`, `/`, ...) survive being embedded in the DATABASE_URL authority.
+ENCODED_USER=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$PG_USER")
+ENCODED_PASS=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$PG_PASS")
+
+DATABASE_URL="postgresql://${ENCODED_USER}:${ENCODED_PASS}@${PG_HOST}:${PG_PORT}/${PG_DB}"
+
+# Shell-quote the final value so the `eval` in the caller is safe.
+printf 'export DATABASE_URL=%q\n' "$DATABASE_URL"

--- a/examples/examples-twitter/Makefile.toml
+++ b/examples/examples-twitter/Makefile.toml
@@ -23,8 +23,15 @@ CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = ["CARGO_TARGE
 [tasks.runserver]
 description = "Start the development server (auto-starts PostgreSQL/Redis via `infra-up` transitively through `migrate`)"
 dependencies = ["migrate"]
-command = "cargo"
-args = ["run", "--bin", "examples-twitter", "--", "runserver", "--with-pages"]
+# `DATABASE_URL` is resolved via `db_url.sh` because the management CLI cannot
+# read `settings/*.toml` for an example crate (its command context has no
+# settings). See scripts/db_url.sh for the full rationale.
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+eval "$(bash scripts/db_url.sh)"
+cargo run --bin examples-twitter -- runserver --with-pages
+'''
 
 # ============================================================================
 # Infrastructure (disposable PostgreSQL + Redis containers)
@@ -60,19 +67,40 @@ dependencies = ["infra-down", "infra-up"]
 
 [tasks.makemigrations]
 description = "Create new migrations based on model changes"
-command = "cargo"
-args = ["run", "--bin", "examples-twitter", "makemigrations"]
+# `DATABASE_URL` is resolved via `db_url.sh` (see scripts/db_url.sh): the
+# management CLI has no project settings in its command context, so it relies
+# on the env var for the connection string.
+dependencies = ["infra-up"]
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+eval "$(bash scripts/db_url.sh)"
+cargo run --bin examples-twitter makemigrations
+'''
 
 [tasks.makemigrations-app]
 description = "Create new migrations for a specific app (usage: cargo make makemigrations-app -- <app_label>)"
-command = "cargo"
-args = ["run", "--bin", "examples-twitter", "makemigrations", "${@}"]
+dependencies = ["infra-up"]
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+eval "$(bash scripts/db_url.sh)"
+cargo run --bin examples-twitter makemigrations "${@}"
+'''
 
 [tasks.migrate]
 description = "Apply database migrations (auto-starts PostgreSQL/Redis via `infra-up`)"
 dependencies = ["infra-up"]
-command = "cargo"
-args = ["run", "--bin", "examples-twitter", "migrate"]
+# `DATABASE_URL` is resolved via `db_url.sh` (see scripts/db_url.sh): the
+# management CLI has no project settings in its command context, so the
+# connection string must be supplied through the environment. `infra-up`
+# provisions the container from the same settings, so the credentials match.
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+eval "$(bash scripts/db_url.sh)"
+cargo run --bin examples-twitter migrate
+'''
 
 # ============================================================================
 # Static Files
@@ -317,6 +345,11 @@ if [ "$CURRENT_DIR" != "examples-twitter" ]; then
 	exit 1
 fi
 
+# Resolve DATABASE_URL: the management CLI cannot read settings/*.toml for an
+# example crate, so it needs the connection string from the environment
+# (see scripts/db_url.sh).
+eval "$(bash scripts/db_url.sh)"
+
 echo "🚀 Starting development server with WASM frontend..."
 # wasm-build-dev already produced fresh artifacts; skip runserver's own rebuild.
 cargo run --bin examples-twitter -- runserver --with-pages --noreload --no-override-wasm
@@ -329,6 +362,11 @@ dependencies = ["wasm-build-release", "collectstatic", "migrate", "run-dev-relea
 [tasks.run-dev-release-server]
 script = '''
 #!/bin/bash
+# Resolve DATABASE_URL: the management CLI cannot read settings/*.toml for an
+# example crate, so it needs the connection string from the environment
+# (see scripts/db_url.sh).
+eval "$(bash scripts/db_url.sh)"
+
 echo "🚀 Starting server with optimized WASM frontend..."
 # wasm-build-release already produced optimized artifacts; skip runserver's own rebuild.
 cargo run --release --bin examples-twitter -- runserver --with-pages --noreload --no-override-wasm

--- a/examples/examples-twitter/README.md
+++ b/examples/examples-twitter/README.md
@@ -220,7 +220,9 @@ cargo make dev
 ### Environment Variables
 
 ```bash
-# Database connection
+# Database connection. The `cargo make` tasks resolve this automatically from
+# settings/<profile>.toml via scripts/db_url.sh; set it manually only when you
+# invoke `cargo run --bin manage ...` (or `cargo run`) directly.
 export DATABASE_URL="postgres://postgres:password@localhost:5432/twitter_dev"
 
 # JWT secret (for token signing)
@@ -259,15 +261,16 @@ cargo run -- --port 3000
 ### Management Commands
 
 ```bash
-# Database migrations
-cargo run --bin manage makemigrations
-cargo run --bin manage migrate
+# Database migrations (cargo-make tasks auto-resolve DATABASE_URL via db_url.sh)
+cargo make makemigrations
+cargo make migrate
 
-# Create new app
+# Create new app (no cargo-make task; resolve DATABASE_URL first)
+eval "$(bash scripts/db_url.sh)"
 cargo run --bin manage startapp myapp --restful
 
 # Development server
-cargo run --bin manage runserver
+cargo make runserver
 ```
 
 ## Testing
@@ -745,10 +748,12 @@ cat ../../../.testcontainers.properties
 ### Database Migration Errors
 
 ```bash
-# Reset database and rerun migrations
+# Reset database and rerun migrations (resolve DATABASE_URL first)
+eval "$(bash scripts/db_url.sh)"
 cargo run --bin manage migrate --reset
 
-# Create fresh migration
+# Create fresh migration (resolve DATABASE_URL first)
+eval "$(bash scripts/db_url.sh)"
 cargo run --bin manage makemigrations --name initial_schema
 ```
 

--- a/examples/examples-twitter/README.md
+++ b/examples/examples-twitter/README.md
@@ -222,7 +222,7 @@ cargo make dev
 ```bash
 # Database connection. The `cargo make` tasks resolve this automatically from
 # settings/<profile>.toml via scripts/db_url.sh; set it manually only when you
-# invoke `cargo run --bin manage ...` (or `cargo run`) directly.
+# invoke `cargo run --bin examples-twitter ...` (or `cargo run`) directly.
 export DATABASE_URL="postgres://postgres:password@localhost:5432/twitter_dev"
 
 # JWT secret (for token signing)
@@ -267,7 +267,7 @@ cargo make migrate
 
 # Create new app (no cargo-make task; resolve DATABASE_URL first)
 eval "$(bash scripts/db_url.sh)"
-cargo run --bin manage startapp myapp --restful
+cargo run --bin examples-twitter startapp myapp --restful
 
 # Development server
 cargo make runserver
@@ -750,11 +750,11 @@ cat ../../../.testcontainers.properties
 ```bash
 # Reset database and rerun migrations (resolve DATABASE_URL first)
 eval "$(bash scripts/db_url.sh)"
-cargo run --bin manage migrate --reset
+cargo run --bin examples-twitter migrate --reset
 
 # Create fresh migration (resolve DATABASE_URL first)
 eval "$(bash scripts/db_url.sh)"
-cargo run --bin manage makemigrations --name initial_schema
+cargo run --bin examples-twitter makemigrations --name initial_schema
 ```
 
 ### Test Failures

--- a/examples/examples-twitter/scripts/db_url.sh
+++ b/examples/examples-twitter/scripts/db_url.sh
@@ -6,7 +6,7 @@
 # `DatabaseConnection::database_url_from(ctx.settings, $DATABASE_URL)`. For an
 # example crate `ctx.settings` is always `None` — the framework does not wire
 # the project's own `get_settings()` into the command context (tracked in
-# kent8192/reinhardt-web#5040; the management runtime would otherwise read
+# kent8192/reinhardt-web#5042; the management runtime would otherwise read
 # `settings/*.toml` directly). The CLI therefore falls back to the `DATABASE_URL` environment
 # variable, which nothing sets, producing:
 #   "No database URL available. Set DATABASE_URL environment variable."

--- a/examples/examples-twitter/scripts/db_url.sh
+++ b/examples/examples-twitter/scripts/db_url.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Emit a shell-evaluable `export DATABASE_URL=...` line for the active profile.
+#
+# Why this exists: the management CLI (`manage migrate` / `makemigrations` /
+# `runserver`) resolves its database connection via
+# `DatabaseConnection::database_url_from(ctx.settings, $DATABASE_URL)`. For an
+# example crate `ctx.settings` is always `None` — the framework does not wire
+# the project's own `get_settings()` into the command context (tracked in
+# kent8192/reinhardt-web#5040; the management runtime would otherwise read
+# `settings/*.toml` directly). The CLI therefore falls back to the `DATABASE_URL` environment
+# variable, which nothing sets, producing:
+#   "No database URL available. Set DATABASE_URL environment variable."
+#
+# cargo-make runs each task in its own process, so exporting from
+# `infra_up.sh` (a separate `infra-up` dependency task) would not reach the
+# `cargo run` in the `migrate` task. Instead, the cargo-running tasks
+# `eval "$(bash scripts/db_url.sh)"` in their own shell, so the URL is set in
+# the same process that launches `cargo run`. Credentials come from the same
+# settings TOML the container is provisioned from, keeping the connection
+# string in lockstep with `infra_up.sh` (both consume `parse_local_toml.py`).
+#
+# Usage (from the crate root, inside a cargo-make task):
+#   eval "$(bash scripts/db_url.sh)" && cargo run --bin manage migrate
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRATE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROFILE="${REINHARDT_ENV:-local}"
+CONFIG="$CRATE_DIR/settings/${PROFILE}.toml"
+
+if [ ! -f "$CONFIG" ]; then
+	echo "Error: settings file for profile '${PROFILE}' not found at: $CONFIG" >&2
+	exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+	echo "Error: python3 (>=3.11, for tomllib) is required to parse $CONFIG" >&2
+	exit 1
+fi
+
+# parse_local_toml.py emits shell-quoted PG_* / RD_* assignments (the same
+# ones infra_up.sh consumes), so the resolved host/port/credentials match the
+# provisioned container exactly.
+SETTINGS=$(python3 "$SCRIPT_DIR/parse_local_toml.py" "$CONFIG") || exit $?
+eval "$SETTINGS"
+
+# Reuse python3's URL-encoding so passwords containing URL-reserved characters
+# (`@`, `:`, `/`, ...) survive being embedded in the DATABASE_URL authority.
+ENCODED_USER=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$PG_USER")
+ENCODED_PASS=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$PG_PASS")
+
+DATABASE_URL="postgresql://${ENCODED_USER}:${ENCODED_PASS}@${PG_HOST}:${PG_PORT}/${PG_DB}"
+
+# Shell-quote the final value so the `eval` in the caller is safe.
+printf 'export DATABASE_URL=%q\n' "$DATABASE_URL"


### PR DESCRIPTION
## Summary

- Add `scripts/db_url.sh` to the `examples-tutorial-basis`, `examples-tutorial-rest`, and `examples-twitter` crates. It derives an `export DATABASE_URL=...` line from the active `settings/<profile>.toml` using the same `parse_local_toml.py` that provisions the infra container.
- Wire `eval "$(bash scripts/db_url.sh)"` into the cargo-running cargo-make tasks (`runserver`, `makemigrations`, `migrate`, and twitter's `makemigrations-app`) and into the `run-dev-server.sh` / `run-dev-release-server.sh` scripts, so `DATABASE_URL` is set in the same process that launches `cargo run`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Breaking Change Assessment

- [x] No — this change is **not** a breaking change.

## Motivation and Context

The example management CLI resolves its database connection from `ctx.settings`, which is always `None` for an example crate (the framework does not wire the project's `get_settings()` into the command context), then falls back to the `DATABASE_URL` environment variable. Nothing set that variable, so `cargo make migrate` / `makemigrations` / `runserver` failed with:

> No database URL available. Set DATABASE_URL environment variable.

`cargo-make` runs each task in its own process, so exporting from the separate `infra-up` task does not reach the `cargo run` task. Resolving and `eval`-ing `db_url.sh` inside each cargo-running task sets the variable in the same process. Credentials stay in lockstep with `infra_up.sh` because both consume the same `settings/<profile>.toml` via `parse_local_toml.py`.

## How Was This Tested?

- Verified `parse_local_toml.py` (the script `db_url.sh` depends on) exists in all three crates.
- Confirmed `db_url.sh` emits a shell-quoted `export DATABASE_URL=...` (URL-encoding the user/password) and is invoked via `eval` in the same shell as `cargo run`.
- The three `db_url.sh` copies are byte-identical across crates.
- Note: an end-to-end `cargo make migrate` against a live container was not run in this session.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have commented the code where non-obvious (rationale in `db_url.sh` and each task)
- [ ] I have run the example commands end-to-end against a live container
- [x] No new `todo!()` / `// TODO:` introduced

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development instructions to use standardized build commands across all examples.

* **Chores**
  * Improved database configuration resolution to automatically derive connection settings from environment profiles.
  * Simplified development server startup by centralizing database setup across multiple example projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->