### PR TITLE
fix(commands): resolve management-command database URL from project settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,13 +447,14 @@ For a complete step-by-step guide, see [Getting Started](https://reinhardt-web.d
 
 ### With Database
 
-Configure database in `settings/base.toml`:
+Configure the database in `settings/base.toml` under `[core.databases.default]`:
 
 ```toml
+[core]
 debug = true
 secret_key = "your-secret-key-for-development"
 
-[database]
+[core.databases.default]
 engine = "postgresql"
 host = "localhost"
 port = 5432
@@ -462,27 +463,28 @@ user = "postgres"
 password = "postgres"
 ```
 
-Settings are automatically loaded in `src/config/settings.rs`:
+Settings are automatically composed in `src/config/settings.rs` — this is what
+`reinhardt-admin startproject` generates:
 
 ```rust
 // src/config/settings.rs
 use reinhardt::prelude::*;
 
-// Compose built-in settings fragments with | — field names are inferred from type names
-// (e.g., CoreSettings → core, AuthSettings → auth, DatabaseSettings → database)
-#[settings(CoreSettings | AuthSettings | DatabaseSettings)]
+// `CoreSettings` is registered under the `core` section, so its fields —
+// including the `[core.databases.default]` connection that `migrate` /
+// `runserver` resolve — live under `[core]` in the TOML above.
+#[settings(core: CoreSettings)]
 pub struct ProjectSettings;
 ```
 
-The `|` syntax composes settings fragments into `ProjectSettings`. Each type must be a `#[settings(fragment = true, ...)]` struct. Built-in fragments:
-- **`CoreSettings`** — `debug`, `secret_key`, `language_code`, `time_zone`, `allowed_hosts`
-- **`AuthSettings`** — `jwt_secret`, `token_expiry`, `password_hashers`
-- **`DatabaseSettings`** — `engine`, `host`, `port`, `name`, `user`, `password`
-
-Add project-specific fragments with explicit field names using `key: Type` syntax:
+`#[settings(...)]` composes settings fragments into `ProjectSettings` using the
+`key: Type` syntax. Each fragment is a `#[settings(fragment = true, section = "...")]`
+struct mounted under its declared section. `CoreSettings` (section `core`) carries
+`debug`, `secret_key`, `allowed_hosts`, the `databases` map, and `security`. Add
+project-specific fragments the same way:
 
 ```rust
-#[settings(CoreSettings | AuthSettings | DatabaseSettings | mail: MailSettings)]
+#[settings(core: CoreSettings | cache: CacheSettings)]
 pub struct ProjectSettings;
 ```
 

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1234,11 +1234,19 @@ impl BaseCommand for MakeMigrationsCommand {
 
 			let is_verbose = ctx.has_option("verbose");
 
-			// Get database URL from context option or environment
+			// Get database URL from context option or environment, falling back
+			// to the project's composed settings (`[core.databases.default]`)
+			// when neither is provided (#5042). An empty string preserves the
+			// TestContainers `from_state` path for offline runs.
 			let database_url = ctx
 				.option("database")
 				.map(|s| s.to_string())
 				.or_else(|| std::env::var("DATABASE_URL").ok())
+				.or_else(|| {
+					ctx.settings
+						.as_ref()
+						.and_then(|s| DatabaseConnection::database_url_from(s.as_ref(), None).ok())
+				})
 				.unwrap_or_default();
 
 			// 2. Build from_state from database history or TestContainers
@@ -3474,11 +3482,15 @@ pub(crate) async fn initialize_orm_database(
 			.map_err(|e| {
 				crate::CommandError::ExecutionError(format!("Failed to get database URL: {}", e))
 			})?,
-			None => env_database_url.clone().ok_or_else(|| {
-				crate::CommandError::ExecutionError(
-					"No database URL available. Set DATABASE_URL environment variable.".to_string(),
-				)
-			})?,
+			None => match env_database_url.clone() {
+				Some(url) => url,
+				// No `ctx.settings` and no `DATABASE_URL`: fall back to the disk
+				// loader that reads `settings/*.toml` directly. This restores
+				// parity with the pre-refactor behaviour and is symmetric with
+				// `sync_database_url_to_env`, which already re-resolves from
+				// settings on its `None` arm (#5042).
+				None => get_database_url_from_settings()?,
+			},
 		};
 
 	sync_database_url_to_env(env_database_url.as_deref(), &url, ctx);

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -3559,9 +3559,19 @@ pub(crate) fn get_database_url_from_settings() -> Result<String, crate::CommandE
 			crate::CommandError::ExecutionError(format!("Failed to load settings: {}", e))
 		})?;
 
-	// Extract database configuration from settings
-	let db_config: reinhardt_conf::settings::DatabaseConfig =
-		if let Some(db_val) = merged.get_raw("database") {
+	// Locate the database configuration. Prefer the legacy/Django-style
+	// top-level `[database]` block, then fall back to the canonical
+	// `[core.databases.default]` nested schema so this disk loader understands
+	// the same shape `database_url_from` reads from composed settings (#5042).
+	let db_val = merged.get_raw("database").or_else(|| {
+		merged
+			.get_raw("core")
+			.and_then(|core| core.get("databases"))
+			.and_then(|databases| databases.get("default"))
+	});
+
+	let db_config: reinhardt_conf::settings::DatabaseConfig = db_val
+		.and_then(|db_val| {
 			serde_json::from_value(db_val.clone()).ok().or_else(|| {
 				if let serde_json::Value::Object(db_map) = db_val {
 					let engine = db_map
@@ -3593,9 +3603,7 @@ pub(crate) fn get_database_url_from_settings() -> Result<String, crate::CommandE
 					None
 				}
 			})
-		} else {
-			None
-		}
+		})
 		.ok_or_else(|| {
 			crate::CommandError::ExecutionError(
 				"No database configuration found in settings files".to_string(),
@@ -4506,6 +4514,62 @@ port = 5432
 				url
 			);
 			assert!(url.contains("testdb"), "URL should contain database name");
+
+			// Cleanup
+			if let Some(db_url) = original_db_url {
+				unsafe { std::env::set_var("DATABASE_URL", db_url) };
+			}
+			std::env::set_current_dir(original_dir).unwrap();
+		}
+
+		#[rstest]
+		#[serial(env_database_url)]
+		fn test_get_database_url_from_settings_with_core_databases_default() {
+			// Arrange: the canonical nested schema (`[core.databases.default]`)
+			// rather than the legacy flat top-level `[database]` block (#5042).
+			let temp_dir = tempfile::TempDir::new().unwrap();
+			let settings_dir = temp_dir.path().join("settings");
+			std::fs::create_dir_all(&settings_dir).unwrap();
+
+			let toml_content = r#"
+[core]
+secret_key = "test-secret"
+
+[core.databases.default]
+engine = "postgresql"
+name = "nesteddb"
+user = "testuser"
+password = "testpass"
+host = "localhost"
+port = 5432
+"#;
+			std::fs::write(settings_dir.join("base.toml"), toml_content).unwrap();
+			std::fs::write(settings_dir.join("local.toml"), "").unwrap();
+
+			// Change to the temp directory
+			let original_dir = std::env::current_dir().unwrap();
+			std::env::set_current_dir(temp_dir.path()).unwrap();
+
+			// Remove DATABASE_URL to ensure settings-only resolution
+			let original_db_url = std::env::var("DATABASE_URL").ok();
+			unsafe { std::env::remove_var("DATABASE_URL") };
+
+			// Act
+			let result = get_database_url_from_settings();
+
+			// Assert
+			assert!(
+				result.is_ok(),
+				"get_database_url_from_settings failed for nested schema: {:?}",
+				result.err()
+			);
+			let url = result.unwrap();
+			assert!(
+				url.starts_with("postgresql://"),
+				"Expected postgresql:// URL, got: {}",
+				url
+			);
+			assert!(url.contains("nesteddb"), "URL should contain database name");
 
 			// Cleanup
 			if let Some(db_url) = original_db_url {

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -370,8 +370,20 @@ pub async fn execute_from_command_line() -> Result<(), Box<dyn std::error::Error
 ///
 /// ```rust,no_run
 /// use reinhardt_commands::execute_from_command_line_with_settings;
-/// # use reinhardt_conf::HasCommonSettings;
-/// # fn get_settings() -> impl HasCommonSettings + 'static { unimplemented!() }
+/// # use reinhardt_conf::settings::contacts::ContactSettings;
+/// # use reinhardt_conf::settings::core_settings::CoreSettings;
+/// # use reinhardt_conf::settings::fragment::HasSettings;
+/// # // Stands in for the project's `#[settings(...)]`-generated `ProjectSettings`.
+/// # struct ProjectSettings { core: CoreSettings, contacts: ContactSettings }
+/// # impl HasSettings<CoreSettings> for ProjectSettings {
+/// #     fn get_settings(&self) -> &CoreSettings { &self.core }
+/// # }
+/// # impl HasSettings<ContactSettings> for ProjectSettings {
+/// #     fn get_settings(&self) -> &ContactSettings { &self.contacts }
+/// # }
+/// # fn get_settings() -> ProjectSettings {
+/// #     ProjectSettings { core: CoreSettings::default(), contacts: ContactSettings::default() }
+/// # }
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -12,6 +12,7 @@ use crate::{CheckCommand, CommandContext, MigrateCommand, RunServerCommand, Shel
 #[cfg(feature = "introspect")]
 use clap::ValueEnum;
 use clap::{Parser, Subcommand};
+use reinhardt_conf::HasCommonSettings;
 use reinhardt_conf::settings::builder::SettingsBuilder;
 use reinhardt_conf::settings::profile::Profile;
 use reinhardt_conf::settings::sources::{DefaultSource, LowPriorityEnvSource, TomlFileSource};
@@ -20,6 +21,7 @@ use serde_json::Value;
 use std::env;
 #[allow(unused)]
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[cfg(feature = "routers")]
 use crate::builtin::ShowUrlsCommand;
@@ -344,6 +346,51 @@ pub async fn execute_from_command_line() -> Result<(), Box<dyn std::error::Error
 	execute_from_command_line_with_registry(CommandRegistry::new()).await
 }
 
+/// Execute commands from command-line arguments with the project's composed settings.
+///
+/// This is the settings-aware counterpart of [`execute_from_command_line`]. The
+/// project's generated `src/bin/manage.rs` calls this with its own
+/// `get_settings()` result so that database-requiring commands (`migrate`,
+/// `makemigrations`, `runserver`, `createsuperuser`) can resolve the database
+/// connection from `settings/*.toml` (the `[core.databases.default]` block) when
+/// `DATABASE_URL` is not set. Without settings, those commands fall back to the
+/// `DATABASE_URL` environment variable (see [`execute_from_command_line`]).
+///
+/// # Arguments
+///
+/// * `settings` - The composed application settings, typically a
+///   `ProjectSettings` value built via `#[settings(...)]` + `SettingsBuilder`.
+///   Any type implementing [`HasCommonSettings`] is accepted.
+///
+/// # Returns
+///
+/// Returns `Ok(())` on success, or an error message on failure.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use reinhardt_commands::execute_from_command_line_with_settings;
+/// # use reinhardt_conf::HasCommonSettings;
+/// # fn get_settings() -> impl HasCommonSettings + 'static { unimplemented!() }
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     if let Err(e) = execute_from_command_line_with_settings(get_settings()).await {
+///         eprintln!("Error: {}", e);
+///         std::process::exit(1);
+///     }
+///     Ok(())
+/// }
+/// ```
+pub async fn execute_from_command_line_with_settings<S>(
+	settings: S,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+	S: HasCommonSettings + 'static,
+{
+	execute_from_command_line_with_registry_and_settings(CommandRegistry::new(), settings).await
+}
+
 /// Execute commands from command-line arguments with a custom command registry.
 ///
 /// This entry point works like [`execute_from_command_line`] but additionally
@@ -383,6 +430,45 @@ pub async fn execute_from_command_line() -> Result<(), Box<dyn std::error::Error
 pub async fn execute_from_command_line_with_registry(
 	registry: CommandRegistry,
 ) -> Result<(), Box<dyn std::error::Error>> {
+	execute_with_registry_and_optional_settings(registry, None).await
+}
+
+/// Execute commands from CLI arguments with a custom command registry **and** the
+/// project's composed settings.
+///
+/// Combines [`execute_from_command_line_with_registry`] (custom commands) with
+/// [`execute_from_command_line_with_settings`] (settings-aware database
+/// resolution). See those for details.
+///
+/// # Arguments
+///
+/// * `registry` - A [`CommandRegistry`] holding custom commands to make available.
+/// * `settings` - The composed application settings (any [`HasCommonSettings`]).
+///
+/// # Returns
+///
+/// Returns `Ok(())` on success, or an error message on failure.
+pub async fn execute_from_command_line_with_registry_and_settings<S>(
+	registry: CommandRegistry,
+	settings: S,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+	S: HasCommonSettings + 'static,
+{
+	execute_with_registry_and_optional_settings(
+		registry,
+		Some(Arc::new(settings) as Arc<dyn HasCommonSettings>),
+	)
+	.await
+}
+
+/// Shared driver: parse CLI arguments, perform pre-dispatch registration, and run
+/// the resolved command with the optional composed settings threaded into the
+/// command context.
+async fn execute_with_registry_and_optional_settings(
+	registry: CommandRegistry,
+	settings: Option<Arc<dyn HasCommonSettings>>,
+) -> Result<(), Box<dyn std::error::Error>> {
 	// Attempt normal clap parsing first. If it fails (e.g., unknown subcommand),
 	// fall back to checking the registry for a matching custom command.
 	let (command, verbosity) = match Cli::try_parse() {
@@ -418,7 +504,7 @@ pub async fn execute_from_command_line_with_registry(
 	#[cfg(feature = "auth")]
 	reinhardt_auth::auto_register_superuser_creator();
 
-	run_command_with_registry(command, verbosity, registry).await
+	run_command_core(command, verbosity, registry, settings).await
 }
 
 /// Returns `true` for commands that need URL patterns registered **before**
@@ -503,6 +589,24 @@ pub async fn run_command_with_registry(
 	verbosity: u8,
 	registry: CommandRegistry,
 ) -> Result<(), Box<dyn std::error::Error>> {
+	run_command_core(command, verbosity, registry, None).await
+}
+
+/// Execute a command with optional composed settings threaded into the context.
+///
+/// This settings-aware core backs both the no-settings entry points
+/// ([`run_command`], [`run_command_with_registry`]) and the settings-aware ones
+/// ([`execute_from_command_line_with_settings`]). When `settings` is `Some`, the
+/// database-init context receives the composed `ProjectSettings`, so
+/// [`initialize_orm_database`](crate::builtin::initialize_orm_database) can
+/// resolve the URL from `[core.databases.default]` even when `DATABASE_URL` is
+/// unset (#5042).
+async fn run_command_core(
+	command: Commands,
+	verbosity: u8,
+	registry: CommandRegistry,
+	settings: Option<Arc<dyn HasCommonSettings>>,
+) -> Result<(), Box<dyn std::error::Error>> {
 	// Initialize ORM database for commands that require it.
 	// This must happen before command dispatch so that commands like
 	// createsuperuser can use the ORM connection pool. (#3186)
@@ -510,8 +614,20 @@ pub async fn run_command_with_registry(
 	if requires_database(&command) {
 		let mut ctx = crate::CommandContext::new(vec![]);
 		ctx.verbosity = verbosity;
+		// Thread the project's composed settings into the ORM-init context so the
+		// database URL can be resolved from `settings/*.toml`
+		// (`[core.databases.default]`) when `DATABASE_URL` is unset (#5042).
+		if let Some(s) = settings.clone() {
+			ctx = ctx.with_settings(s);
+		}
 		crate::builtin::initialize_orm_database(&ctx).await?;
 	}
+
+	// `settings` is consumed by the database-init block above and the
+	// `makemigrations` arm below; bind it in feature combinations where neither
+	// path is compiled so it does not trip the unused-variable lint.
+	#[cfg(not(any(feature = "reinhardt-db", feature = "migrations")))]
+	let _ = &settings;
 
 	match command {
 		#[cfg(feature = "migrations")]
@@ -534,6 +650,7 @@ pub async fn run_command_with_registry(
 				merge,
 				force_empty_state,
 				verbosity,
+				settings.clone(),
 			)
 			.await
 		}
@@ -733,9 +850,17 @@ async fn execute_makemigrations(
 	merge: bool,
 	force_empty_state: bool,
 	verbosity: u8,
+	settings: Option<Arc<dyn HasCommonSettings>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
 	let mut ctx = CommandContext::default();
 	ctx.set_verbosity(verbosity);
+	// Attach the project's composed settings so `makemigrations` can resolve the
+	// database URL from `settings/*.toml` when no `--database`/`DATABASE_URL` is
+	// provided (#5042). `makemigrations` does not flow through
+	// `initialize_orm_database`, so it carries its own settings handle.
+	if let Some(s) = settings {
+		ctx = ctx.with_settings(s);
+	}
 
 	if !app_labels.is_empty() {
 		for label in app_labels {

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -220,7 +220,8 @@ pub use builtin::{CheckCommand, CheckDiCommand, MigrateCommand, RunServerCommand
 pub use cli::start_server;
 pub use cli::{
 	Cli, Commands, auto_register_router, execute_from_command_line,
-	execute_from_command_line_with_registry, run_command, run_command_with_registry,
+	execute_from_command_line_with_registry, execute_from_command_line_with_registry_and_settings,
+	execute_from_command_line_with_settings, run_command, run_command_with_registry,
 };
 pub use collectstatic::{CollectStaticCommand, CollectStaticOptions, CollectStaticStats};
 pub use context::CommandContext;

--- a/crates/reinhardt-commands/templates/project_pages_template/src/bin/manage.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/bin/manage.rs.tpl
@@ -17,8 +17,13 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
+	// Force-link the parent library so its `#[routes]` / `#[model]`
+	// `inventory::submit!` registrations survive dead-code elimination.
+	// Referencing `get_settings` alone does not guarantee the whole crate
+	// (and thus every inventory entry) is linked.
 	use {{ crate_name }} as _;
-	use reinhardt::commands::execute_from_command_line;
+	use {{ crate_name }}::config::settings::get_settings;
+	use reinhardt::commands::execute_from_command_line_with_settings;
 	use std::process;
 
 	#[tokio::main]
@@ -29,9 +34,13 @@ mod native {
 			std::env::set_var("REINHARDT_SETTINGS_MODULE", "{{ project_name }}.config.settings");
 		}
 
-		// Router registration happens automatically inside execute_from_command_line()
-		// via the #[routes] attribute macro in src/config/urls.rs
-		if let Err(e) = execute_from_command_line().await {
+		// Hand the project's composed settings to the runtime so that
+		// database-requiring commands (migrate, makemigrations, runserver,
+		// createsuperuser) resolve the connection from settings/*.toml
+		// (`[core.databases.default]`) without requiring DATABASE_URL.
+		// Router registration still happens automatically inside the runtime
+		// via the #[routes] attribute macro in src/config/urls.rs.
+		if let Err(e) = execute_from_command_line_with_settings(get_settings()).await {
 			eprintln!("Error: {}", e);
 			process::exit(1);
 		}

--- a/crates/reinhardt-commands/templates/project_restful_template/src/bin/manage.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/src/bin/manage.rs.tpl
@@ -17,8 +17,13 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
+	// Force-link the parent library so its `#[routes]` / `#[model]`
+	// `inventory::submit!` registrations survive dead-code elimination.
+	// Referencing `get_settings` alone does not guarantee the whole crate
+	// (and thus every inventory entry) is linked.
 	use {{ crate_name }} as _;
-	use reinhardt::commands::execute_from_command_line;
+	use {{ crate_name }}::config::settings::get_settings;
+	use reinhardt::commands::execute_from_command_line_with_settings;
 	use std::process;
 
 	#[tokio::main]
@@ -29,9 +34,13 @@ mod native {
 			std::env::set_var("REINHARDT_SETTINGS_MODULE", "{{ project_name }}.config.settings");
 		}
 
-		// Router registration happens automatically inside execute_from_command_line()
-		// via the #[routes] attribute macro in src/config/urls.rs
-		if let Err(e) = execute_from_command_line().await {
+		// Hand the project's composed settings to the runtime so that
+		// database-requiring commands (migrate, makemigrations, runserver,
+		// createsuperuser) resolve the connection from settings/*.toml
+		// (`[core.databases.default]`) without requiring DATABASE_URL.
+		// Router registration still happens automatically inside the runtime
+		// via the #[routes] attribute macro in src/config/urls.rs.
+		if let Err(e) = execute_from_command_line_with_settings(get_settings()).await {
 			eprintln!("Error: {}", e);
 			process::exit(1);
 		}

--- a/crates/reinhardt-commands/tests/test_settings_database_url_resolution.rs
+++ b/crates/reinhardt-commands/tests/test_settings_database_url_resolution.rs
@@ -1,0 +1,104 @@
+//! Regression test for issue #5042.
+//!
+//! Database-requiring management commands (`migrate`, `makemigrations`,
+//! `runserver`, `createsuperuser`) must resolve the database connection from a
+//! project's composed settings (`[core.databases.default]`) when `DATABASE_URL`
+//! is not set. Before #5042 the command runtime built `CommandContext` without
+//! any settings, so the settings-aware resolution arm of
+//! `initialize_orm_database` was unreachable and the only working path was the
+//! `DATABASE_URL` environment variable.
+//!
+//! This test pins the behaviour the fix makes reachable: given a
+//! `CommandContext` carrying composed settings with a `[core.databases.default]`
+//! block, `DatabaseConnection::database_url_from(ctx.settings, None)` resolves
+//! the connection URL without consulting any environment variable (the `None`
+//! `env_override` argument means "do not override from the environment").
+
+#![cfg(feature = "reinhardt-db")]
+
+use reinhardt_commands::CommandContext;
+use reinhardt_conf::HasCommonSettings;
+use reinhardt_conf::settings::DatabaseConfig;
+use reinhardt_conf::settings::contacts::ContactSettings;
+use reinhardt_conf::settings::core_settings::CoreSettings;
+use reinhardt_conf::settings::fragment::HasSettings;
+use reinhardt_db::backends::DatabaseConnection;
+use rstest::rstest;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Minimal stub satisfying [`HasCommonSettings`] without going through the
+/// `#[settings(...)]` proc-macro, mirroring the pattern used in
+/// `test_sendtestemail.rs`. A real project would hand `with_settings()` the
+/// `ProjectSettings` value returned by its own `get_settings()`.
+struct StubProjectSettings {
+	core: CoreSettings,
+	contacts: ContactSettings,
+}
+
+impl HasSettings<CoreSettings> for StubProjectSettings {
+	fn get_settings(&self) -> &CoreSettings {
+		&self.core
+	}
+}
+
+impl HasSettings<ContactSettings> for StubProjectSettings {
+	fn get_settings(&self) -> &ContactSettings {
+		&self.contacts
+	}
+}
+
+/// Build composed settings whose `[core.databases.default]` entry points at a
+/// PostgreSQL database, exactly as a project's `settings/base.toml` would.
+fn settings_with_postgres_default() -> Arc<dyn HasCommonSettings> {
+	let mut databases = HashMap::new();
+	databases.insert(
+		"default".to_string(),
+		DatabaseConfig::postgresql("myapp", "reinhardt", "reinhardt", "localhost", 5432),
+	);
+
+	Arc::new(StubProjectSettings {
+		core: CoreSettings {
+			secret_key: "stub-secret".to_string(),
+			databases,
+			..Default::default()
+		},
+		contacts: ContactSettings::default(),
+	})
+}
+
+#[rstest]
+fn settings_context_resolves_database_url_without_env_override() {
+	// Arrange: a command context carrying the project's composed settings,
+	// as the runtime now builds for DB-requiring commands (#5042).
+	let settings = settings_with_postgres_default();
+	let ctx = CommandContext::new(vec![]).with_settings(settings);
+
+	// Act: resolve exactly as `initialize_orm_database`'s now-reachable
+	// `Some(settings)` arm does — `None` means "no environment override".
+	let resolved = DatabaseConnection::database_url_from(
+		ctx.settings
+			.as_ref()
+			.expect("settings were attached to the context")
+			.as_ref(),
+		None,
+	)
+	.expect("settings-based database URL resolution should succeed");
+
+	// Assert: the URL comes straight from `[core.databases.default]`.
+	assert_eq!(
+		resolved,
+		"postgresql://reinhardt:reinhardt@localhost:5432/myapp"
+	);
+}
+
+#[rstest]
+fn context_without_settings_leaves_settings_none() {
+	// Arrange & Act: the no-settings constructor still yields an empty handle,
+	// documenting that the settings-aware arm is only taken when a project
+	// hands its settings to the runtime.
+	let ctx = CommandContext::new(vec![]);
+
+	// Assert
+	assert!(ctx.settings.is_none());
+}

--- a/examples/examples-tutorial-basis/settings/base.toml
+++ b/examples/examples-tutorial-basis/settings/base.toml
@@ -22,8 +22,11 @@ session_cookie_secure = false
 csrf_cookie_secure = false
 append_slash = true
 
-# Top-level [database] is the canonical schema consumed by
-# `reinhardt_db::connection::get_database_url_from_env_or_settings`.
+# `[core.databases.default]` is the canonical database schema: it is consumed
+# by the composed `ProjectSettings` (`#[settings(core: CoreSettings)]`, where
+# `CoreSettings` is registered under section "core"), and the management
+# runtime resolves the connection from it via
+# `reinhardt_db::backends::DatabaseConnection::database_url_from`.
 # See README "With Database" section and reinhardt_conf::settings::DatabaseConfig.
 #
 # The example targets the disposable PostgreSQL container provisioned by
@@ -31,7 +34,7 @@ append_slash = true
 # `migrate`). Override the credentials in `settings/local.toml` if you
 # point this crate at an existing Postgres instance instead.
 
-[database]
+[core.databases.default]
 engine = "postgresql"
 host = "localhost"
 port = 5432

--- a/examples/examples-tutorial-basis/settings/ci.toml
+++ b/examples/examples-tutorial-basis/settings/ci.toml
@@ -2,12 +2,14 @@
 #
 # `CoreSettings` is registered as `#[settings(section = "core")]`, so its
 # fields must live under `[core]` to override values from base.toml. The
-# `[database]` section is consumed at the top level by reinhardt-db.
+# database lives under `[core.databases.default]` (the same fragment),
+# deep-merging onto base.toml's Postgres config — here switching the engine
+# to an in-memory SQLite database for CI.
 
 [core]
 debug = false
 secret_key = "ci-testing-secret-key-not-for-production"
 
-[database]
+[core.databases.default]
 engine = "sqlite"
 name = ":memory:"

--- a/examples/examples-tutorial-basis/settings/local.toml
+++ b/examples/examples-tutorial-basis/settings/local.toml
@@ -10,6 +10,8 @@
 debug = true
 secret_key = "local-development-secret-key"
 
-[database]
+# Overrides deep-merge onto base.toml's `[core.databases.default]`, so only the
+# changed keys need to appear here.
+[core.databases.default]
 port = 5433
 redis_url = "redis://localhost:6380/0"

--- a/examples/examples-tutorial-basis/src/bin/manage.rs
+++ b/examples/examples-tutorial-basis/src/bin/manage.rs
@@ -18,7 +18,8 @@ mod native {
 	// returns an empty set, which the framework surfaces as
 	// "No URL patterns registered" at runtime.
 	use examples_tutorial_basis as _;
-	use reinhardt::commands::execute_from_command_line;
+	use examples_tutorial_basis::config::settings::get_settings;
+	use reinhardt::commands::execute_from_command_line_with_settings;
 	use std::process;
 
 	#[tokio::main]
@@ -38,7 +39,7 @@ mod native {
 		// `inventory::submit!`, so no manual `register_superuser_creator`
 		// call is required here.
 
-		if let Err(e) = execute_from_command_line().await {
+		if let Err(e) = execute_from_command_line_with_settings(get_settings()).await {
 			eprintln!("Error: {e}");
 			process::exit(1);
 		}

--- a/examples/examples-tutorial-rest/settings/base.toml
+++ b/examples/examples-tutorial-rest/settings/base.toml
@@ -22,15 +22,18 @@ session_cookie_secure = false
 csrf_cookie_secure = false
 append_slash = true
 
-# Top-level [database] is the canonical schema consumed by
-# `reinhardt_db::connection::get_database_url_from_env_or_settings`.
+# `[core.databases.default]` is the canonical database schema: it is consumed
+# by the composed `ProjectSettings` (`#[settings(core: CoreSettings)]`, where
+# `CoreSettings` is registered under section "core"), and the management
+# runtime resolves the connection from it via
+# `reinhardt_db::backends::DatabaseConnection::database_url_from`.
 # See README "With Database" section and reinhardt_conf::settings::DatabaseConfig.
 #
 # The example targets the disposable PostgreSQL container provisioned by
 # `scripts/infra_up.sh` (auto-started as a `runserver` dependency via
 # `migrate`). Override the credentials in `settings/local.toml` if you
 # point this crate at an existing Postgres instance instead.
-[database]
+[core.databases.default]
 engine = "postgresql"
 host = "localhost"
 port = 5432

--- a/examples/examples-tutorial-rest/settings/ci.toml
+++ b/examples/examples-tutorial-rest/settings/ci.toml
@@ -2,12 +2,14 @@
 #
 # `CoreSettings` is registered as `#[settings(section = "core")]`, so its
 # fields must live under `[core]` to override values from base.toml. The
-# `[database]` section is consumed at the top level by reinhardt-db.
+# database lives under `[core.databases.default]` (the same fragment),
+# deep-merging onto base.toml's Postgres config — here switching the engine
+# to an in-memory SQLite database for CI.
 
 [core]
 debug = false
 secret_key = "ci-testing-secret-key-not-for-production"
 
-[database]
+[core.databases.default]
 engine = "sqlite"
 name = ":memory:"

--- a/examples/examples-tutorial-rest/src/bin/manage.rs
+++ b/examples/examples-tutorial-rest/src/bin/manage.rs
@@ -1,7 +1,7 @@
 //! Reinhardt Project Management CLI for examples-tutorial-rest
 
 use examples_tutorial_rest::config;
-use reinhardt::commands::execute_from_command_line;
+use reinhardt::commands::execute_from_command_line_with_settings;
 use reinhardt::core::tokio;
 use std::process;
 
@@ -19,8 +19,10 @@ async fn main() {
 	// Ensure config module is loaded (triggers #[routes] macro)
 	let _ = &config::urls::routes;
 
-	// Execute command from command line
-	if let Err(e) = execute_from_command_line().await {
+	// Execute command from command line, handing the project's composed
+	// settings to the runtime so database-requiring commands resolve the
+	// connection from settings/*.toml (`[core.databases.default]`).
+	if let Err(e) = execute_from_command_line_with_settings(config::settings::get_settings()).await {
 		eprintln!("Error: {}", e);
 		process::exit(1);
 	}

--- a/examples/examples-twitter/settings/ci.toml
+++ b/examples/examples-twitter/settings/ci.toml
@@ -3,6 +3,8 @@
 debug = false
 secret_key = "ci-testing-secret-key-not-for-production"
 
-[database]
+# Deep-merges onto base.toml's `[core.databases.default]` Postgres config,
+# switching the engine to an in-memory SQLite database for CI.
+[core.databases.default]
 engine = "sqlite"
 name = ":memory:"

--- a/examples/examples-twitter/src/bin/manage.rs
+++ b/examples/examples-twitter/src/bin/manage.rs
@@ -1,7 +1,8 @@
 //! Reinhardt Project Management CLI for examples-twitter
 
 use examples_twitter as _;
-use reinhardt::commands::execute_from_command_line;
+use examples_twitter::config::settings::get_settings;
+use reinhardt::commands::execute_from_command_line_with_settings;
 use std::process;
 
 #[tokio::main]
@@ -14,7 +15,7 @@ async fn main() {
 		);
 	}
 
-	if let Err(e) = execute_from_command_line().await {
+	if let Err(e) = execute_from_command_line_with_settings(get_settings()).await {
 		eprintln!("Error: {e}");
 		process::exit(1);
 	}


### PR DESCRIPTION
## Summary

This PR addresses:

- Database-requiring management commands (`migrate`, `makemigrations`, `runserver`, `createsuperuser`) built `CommandContext` with **no settings**, so the settings-aware resolution arm of `initialize_orm_database` (`crates/reinhardt-commands/src/builtin.rs`) was unreachable. Projects configured purely through `settings/*.toml` failed at runtime with `No database URL available. Set DATABASE_URL environment variable`.
- Adds `execute_from_command_line_with_settings` (+ a registry variant) so the project's `manage.rs` hands its composed `get_settings()` to the runtime; the runtime threads those settings into the command context and resolves the DB URL from `[core.databases.default]` when `DATABASE_URL` is unset.
- Hardens the no-settings path of `initialize_orm_database` to fall back to the `settings/*.toml` disk loader, and teaches that loader (`get_database_url_from_settings`) to read **both** the legacy flat `[database]` block and the canonical `[core.databases.default]` nested schema.
- Conforms the tutorial examples (and the project templates / README) to the canonical `[core.databases.default]` schema that `#[settings(core: CoreSettings)]` actually reads.

This is a regression specific to `develop/0.2.0`: on `main`, `initialize_orm_database` still resolves from disk via `get_database_url()`. The fix therefore branches from and targets `develop/0.2.0`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

Purely additive: existing entry points (`execute_from_command_line`, `execute_from_command_line_with_registry`, `run_command`, `run_command_with_registry`) keep their signatures and behaviour; the new `*_with_settings` functions are added alongside them.

## Motivation and Context

The README "With Database" section implies a project can configure its database entirely through `settings/*.toml`, but the command runtime never wired the project's `get_settings()` into `CommandContext`, leaving `ctx.settings == None` and the env-var fallback as the only working path. `reinhardt-db`'s `database_url_from()` already resolves `core.databases.default` once it receives populated settings — it just never did.

Fixes #5042

## How Was This Tested?

Local verification on this branch (all passed):

- `cargo check -p reinhardt-commands --all-features` — clean.
- `cargo nextest run -p reinhardt-commands --all-features` for the new + loader tests:
  - `test_settings_database_url_resolution` (settings-context resolution + empty-context guard)
  - `get_database_url_from_settings` loader for both the flat `[database]` and nested `[core.databases.default]` schemas — all pass.
- `cargo test --doc -p reinhardt-commands --all-features` — 18 passed (incl. the new `execute_from_command_line_with_settings` example).
- `cargo fmt -p reinhardt-commands --check` and `cargo clippy -p reinhardt-commands --all-features --all-targets` — no warnings in changed code.
- `semgrep scan --config .semgrep/` on the changed files — 0 findings.

The Docker-backed end-to-end (`cargo make migrate` / `runserver` in `examples/examples-tutorial-basis` with `DATABASE_URL` unset) is left to CI / reviewer; the settings-based resolution path it exercises is covered by the unit tests above.

## Breaking Changes

N/A — see Breaking Change Assessment.

## Related Issues

Refs #5042

## Additional Context

- The separate `fix/examples-db-url-resolution` workaround branch (`scripts/db_url.sh`) is superseded by this fix and should not be merged.
- `scripts/parse_local_toml.py` already accepts both the flat and nested schemas, so container provisioning via `infra_up.sh` is unaffected by the example TOML migration.

## Labels to Apply

- `bug`
- `database`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI commands now resolve database configuration from settings files when environment variables are unset, enabling settings-based database URL composition.

* **Documentation**
  * Updated documentation and examples to reflect new `[core.databases.default]` database configuration structure in settings files, replacing the legacy top-level `[database]` block.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->