### PR TITLE
fix(web): restore #[cfg(native)] gating on the misc export module

### DIFF
--- a/src/exports.rs
+++ b/src/exports.rs
@@ -51,7 +51,9 @@ mod di;
 #[cfg(native)]
 pub use di::*;
 
+#[cfg(native)]
 mod misc;
+#[cfg(native)]
 pub use misc::*;
 
 // Disambiguate names that appear in multiple export modules via glob.


### PR DESCRIPTION
## Summary

This PR addresses:

- The **WASM Clippy (reinhardt-web)** job is red on `develop/0.2.0` (and therefore on every PR targeting it, e.g. #5041, #5046). A CodeRabbit auto-fix commit (`3afdebc365`, "fix: apply CodeRabbit auto-fixes") removed the `#[cfg(native)]` attributes from both `mod misc;` and `pub use misc::*;` in `src/exports.rs`. The `misc` module is native-only, so under `wasm32-unknown-unknown` the ungated glob re-export pulls in a module with no wasm-reachable items and `cargo clippy --target wasm32-unknown-unknown -p reinhardt-web --lib -- -D warnings` fails:

  ```
  error: unused import: `misc::*`
    --> src/exports.rs:55:9
  error: unreachable `pub` item
    --> src/exports.rs:55:9
  error: could not compile `reinhardt-web` (lib) due to 2 previous errors
  ```

- This PR restores the `#[cfg(native)]` gating (a clean revert of the offending hunk), matching the existing `di` / `views` export pattern. Native builds are unaffected because the `native` cfg (`not(all(target_family = "wasm", target_os = "unknown"))`, see `build.rs`) is true off-wasm.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

The `misc` re-export was native-only before `3afdebc365`; this restores that. Off-wasm (the only target where `misc` was ever exported) the public surface is unchanged.

## Motivation and Context

`misc` is a `#[cfg(native)]` module. Re-exporting it unconditionally exposes native-only items on the wasm target, where they are unused and unreachable — both `-D warnings` clippy lints. The fix re-gates the module and its glob re-export.

## How Was This Tested?

- Reproduced the exact CI command locally on this branch:
  `cargo clippy --target wasm32-unknown-unknown -p reinhardt-web --lib -- -D warnings` → **Finished, 0 warnings**.
- The change is target-cfg based (not feature based), so it also clears the `reinhardt-web (wasm-features)` clippy entry.

## Related Issues

Refs #5041 (whose WASM Clippy failure is caused by this base-branch regression; re-running its CI after this merges into `develop/0.2.0` clears it). Also unblocks #5046.

## Additional Context

Root cause: `3afdebc365` removed two `#[cfg(native)]` attributes during a CodeRabbit auto-fix. This PR reverts only that hunk in `src/exports.rs`.

## Labels to Apply

- `bug`
- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured module exports to be conditionally available for native build environments only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->