### PR TITLE
fix(admin-cli): skip nested workspaces in fmt-all to resolve formatter conflict

### DIFF
--- a/crates/reinhardt-admin-cli/src/formatter.rs
+++ b/crates/reinhardt-admin-cli/src/formatter.rs
@@ -88,6 +88,82 @@ pub(crate) fn collect_rust_files(path: &PathBuf) -> Result<Vec<PathBuf>, String>
 	Ok(files)
 }
 
+/// Find separate (nested) cargo workspace roots beneath `project_root`.
+///
+/// A directory qualifies as a nested workspace root when it contains a
+/// `Cargo.toml` that declares its own `[workspace]` table and is not
+/// `project_root` itself, for example `examples/` and the trybuild fixture
+/// crates.
+///
+/// The `fmt-all` command runs `cargo fmt --all` only over the root workspace,
+/// so these independent workspaces never receive the rustfmt pass. Formatting
+/// only their DSL macros (and skipping rustfmt) diverges from the output of
+/// their own `fmt`/`cargo fmt` tasks (such as `fmt-check-examples`), which
+/// yields contradictory results between `fmt-all` and per-workspace formatting.
+/// Callers rely on this list to exclude those files so that each sub-workspace
+/// is formatted solely by its dedicated task.
+pub(crate) fn nested_workspace_roots(project_root: &Path) -> Vec<PathBuf> {
+	let mut roots = Vec::new();
+
+	for entry in WalkDir::new(project_root)
+		.follow_links(false)
+		.into_iter()
+		.filter_map(Result::ok)
+	{
+		// Symlinked entries are ignored, mirroring `collect_rust_files`.
+		if entry.path_is_symlink() {
+			continue;
+		}
+
+		let path = entry.path();
+		let is_manifest = path.is_file()
+			&& path.file_name().and_then(|name| name.to_str()) == Some("Cargo.toml");
+		if !is_manifest {
+			continue;
+		}
+
+		// Build output and VCS metadata never hold workspace roots of interest.
+		if path
+			.components()
+			.any(|component| component.as_os_str() == "target" || component.as_os_str() == ".git")
+		{
+			continue;
+		}
+
+		let Some(dir) = path.parent() else {
+			continue;
+		};
+
+		// The root workspace itself is not a nested workspace.
+		if dir == project_root {
+			continue;
+		}
+
+		if manifest_declares_workspace(path) {
+			roots.push(dir.to_path_buf());
+		}
+	}
+
+	roots
+}
+
+/// Returns `true` when the given `Cargo.toml` declares a `[workspace]` table.
+///
+/// Only workspace root manifests contain a `[workspace]` (or `[workspace.*]`)
+/// table; member crates reference the workspace through `workspace = true`
+/// keys without declaring the table. This distinction reliably separates a
+/// nested workspace root from an ordinary member crate.
+fn manifest_declares_workspace(manifest: &Path) -> bool {
+	let Ok(content) = std::fs::read_to_string(manifest) else {
+		return false;
+	};
+
+	content.lines().any(|line| {
+		let trimmed = line.trim_start();
+		trimmed == "[workspace]" || trimmed.starts_with("[workspace.")
+	})
+}
+
 /// Sanitize a path for error messages to prevent information leakage.
 ///
 /// Returns only the filename to avoid exposing full file system paths.
@@ -212,5 +288,52 @@ mod tests {
 		// Assert
 		assert!(result.is_err());
 		assert!(result.unwrap_err().contains("symlink"));
+	}
+
+	#[rstest]
+	fn nested_workspace_roots_flags_only_separate_workspaces() {
+		// Arrange
+		use std::io::Write;
+		let temp_dir = tempfile::TempDir::new().unwrap();
+		let root = temp_dir.path();
+
+		// Root workspace manifest (must never be reported as nested).
+		{
+			let mut file = std::fs::File::create(root.join("Cargo.toml")).unwrap();
+			writeln!(file, "[workspace]\nmembers = [\"member-crate\"]").unwrap();
+		}
+
+		// An ordinary member crate (no `[workspace]` table) must not be flagged.
+		let member = root.join("member-crate");
+		std::fs::create_dir_all(&member).unwrap();
+		{
+			let mut file = std::fs::File::create(member.join("Cargo.toml")).unwrap();
+			writeln!(file, "[package]\nname = \"member-crate\"").unwrap();
+		}
+
+		// A separate nested workspace (examples-like) must be flagged.
+		let examples = root.join("examples");
+		std::fs::create_dir_all(&examples).unwrap();
+		{
+			let mut file = std::fs::File::create(examples.join("Cargo.toml")).unwrap();
+			writeln!(file, "[workspace]\nmembers = [\"demo\"]").unwrap();
+		}
+
+		// A workspace root declared only via `[workspace.dependencies]`.
+		let tooling = root.join("tooling");
+		std::fs::create_dir_all(&tooling).unwrap();
+		{
+			let mut file = std::fs::File::create(tooling.join("Cargo.toml")).unwrap();
+			writeln!(file, "[workspace.dependencies]\nserde = \"1\"").unwrap();
+		}
+
+		// Act
+		let mut roots = nested_workspace_roots(root);
+		roots.sort();
+
+		// Assert
+		let mut expected = vec![examples, tooling];
+		expected.sort();
+		assert_eq!(roots, expected);
 	}
 }

--- a/crates/reinhardt-admin-cli/src/formatter.rs
+++ b/crates/reinhardt-admin-cli/src/formatter.rs
@@ -116,8 +116,8 @@ pub(crate) fn nested_workspace_roots(project_root: &Path) -> Vec<PathBuf> {
 		}
 
 		let path = entry.path();
-		let is_manifest = path.is_file()
-			&& path.file_name().and_then(|name| name.to_str()) == Some("Cargo.toml");
+		let is_manifest =
+			path.is_file() && path.file_name().and_then(|name| name.to_str()) == Some("Cargo.toml");
 		if !is_manifest {
 			continue;
 		}

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -214,9 +214,13 @@ enum Commands {
 	/// Format all code: Reinhardt DSL macros via Topiary + Rust via rustfmt
 	///
 	/// This command formats page!/form!/head! macros first, then runs
-	/// `cargo fmt --all` on the full workspace.
+	/// `cargo fmt --all` on the root workspace.
 	///
-	/// Formats all Rust files in the project (searches for Cargo.toml to find project root).
+	/// Files that belong to a separate (nested) cargo workspace, such as
+	/// `examples/` or the trybuild fixture crates, are skipped. `cargo fmt
+	/// --all` only formats the root workspace, so formatting their DSL macros
+	/// without the rustfmt pass would leave them inconsistent. Format those
+	/// sub-workspaces with their own task (e.g. `cargo make fmt-check-examples`).
 	FmtAll {
 		/// Check if files are formatted without modifying them
 		#[arg(long)]
@@ -945,7 +949,7 @@ fn run_fmt_all(
 	verbosity: u8,
 ) -> CommandResult<()> {
 	use format_engine::FormatEngine;
-	use formatter::collect_rust_files;
+	use formatter::{collect_rust_files, nested_workspace_roots};
 	use std::collections::HashMap;
 	use std::process::{Command, Stdio};
 
@@ -975,6 +979,18 @@ fn run_fmt_all(
 			sanitize_error(&e)
 		))
 	})?;
+
+	// Exclude files that belong to a separate (nested) cargo workspace such as
+	// `examples/` or the trybuild fixture crates. The `cargo fmt --all` pass
+	// below only formats the root workspace, so applying just the DSL pass to
+	// these files would leave them rustfmt-unformatted and contradict their own
+	// `fmt`/`cargo fmt` tasks (e.g. `cargo make fmt-check-examples`). Each
+	// sub-workspace is formatted by its dedicated task instead. Refs #5051.
+	let nested_roots = nested_workspace_roots(&project_root);
+	let files: Vec<PathBuf> = files
+		.into_iter()
+		.filter(|file| !nested_roots.iter().any(|root| file.starts_with(root)))
+		.collect();
 
 	if files.is_empty() {
 		if verbosity > 0 {

--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -664,18 +664,12 @@ pub fn theme_toggle() -> Page {
 ///
 /// Displays an empty div (useful for conditional rendering).
 pub fn empty() -> Page {
-	page!(|| {
-		div {}
-	})()
+	page!(|| { div {} })()
 }
 
 /// Divider component
 pub fn divider() -> Page {
-	page!(|| {
-		div {
-			class: "divider"
-		}
-	})()
+	page!(|| { div { class: "divider" } })()
 }
 
 /// Badge component


### PR DESCRIPTION
## Summary

- `fmt-all` (`cargo make fmt-check` / `fmt-fix`) and `fmt examples` (`cargo make fmt-check-examples`, the Examples Tests CI) demanded **opposite** formatting for the same `examples/` file, so the **Format Check** and **Examples Tests** CIs could never both be green.
- Root cause: `fmt-all` walks the whole repo via `WalkDir`, but its rustfmt phase (`cargo fmt --all`) only formats the **root** workspace. Files in separate nested workspaces (`examples/`, trybuild fixtures) thus got the DSL pass **without** rustfmt, while `fmt` (DSL + rustfmt) re-collapsed short `page!` bodies — producing contradictory canonical forms.
- Fix: exclude files under nested workspace roots (directories with their own `[workspace]` `Cargo.toml`) from `fmt-all`. Each sub-workspace is formatted solely by its dedicated task, matching the contract already documented in `Makefile.toml`.
- Also collapses `examples-twitter/.../common.rs` to the canonical `fmt examples` form (main carried the expanded form, which failed `fmt-check-examples`).

| `common.rs` form | `fmt-all` (Format Check) before | after this PR | `fmt examples` (Examples Tests) |
|---|---|---|---|
| collapsed | ❌ wanted expand | ✅ skips examples | ✅ pass |
| expanded | ✅ pass | ✅ skips examples | ❌ wanted collapse |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

PR #5037 expanded the bodies "to satisfy fmt-all"; PR #5049 (closed) collapsed them "to match formatter". The oscillation was a symptom of this tooling bug — no file content can satisfy both checks. This PR fixes the tool so the two checks stop contradicting each other.

## How Was This Tested

- `cargo make fmt-check` (root `fmt-all`) — now passes (examples/ skipped).
- `cargo make fmt-check-examples` (`fmt examples`) — passes (collapsed canonical form).
- New unit test `formatter::tests::nested_workspace_roots_flags_only_separate_workspaces` (rstest, AAA): verifies separate `[workspace]` roots are flagged while ordinary member crates are not.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have commented my code where needed (rationale + `Refs #5051`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] Documentation updated (`FmtAll` doc comment reflects nested-workspace skipping)

## Related Issues

Fixes #5051

## Labels to Apply

- `bug`
- `ci-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `fmt-all` command now excludes nested Cargo workspaces from formatting operations.

* **Chores**
  * Refactored UI component implementations for improved code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->