### PR TITLE
docs(reinhardt-db): fix QuerySet doctests for single-argument filter() API

### DIFF
--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -3975,7 +3975,7 @@ where
 	/// # let user_id = 1;
 	/// let db = reinhardt_db::orm::manager::get_connection().await?;
 	/// let user = User::objects()
-	///     .filter(Filter::new("id", reinhardt_db::orm::FilterOperator::Eq, reinhardt_db::orm::FilterValue::Integer(user_id)))
+	///     .filter(reinhardt_db::orm::Filter::new("id", reinhardt_db::orm::FilterOperator::Eq, reinhardt_db::orm::FilterValue::Integer(user_id)))
 	///     .get_with_db(&db)
 	///     .await?;
 	/// # Ok(())
@@ -4027,7 +4027,7 @@ where
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 	/// let db = reinhardt_db::orm::manager::get_connection().await?;
 	/// let user = User::objects()
-	///     .filter(Filter::new("status", reinhardt_db::orm::FilterOperator::Eq, reinhardt_db::orm::FilterValue::String("active".to_string())))
+	///     .filter(reinhardt_db::orm::Filter::new("status", reinhardt_db::orm::FilterOperator::Eq, reinhardt_db::orm::FilterValue::String("active".to_string())))
 	///     .first_with_db(&db)
 	///     .await?;
 	/// # Ok(())

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -3598,11 +3598,11 @@ where
 	///
 	/// // Fetch filtered users with eager loading
 	/// let active_users = User::objects()
-	///     .filter(
+	///     .filter(Filter::new(
 	///         "is_active",
 	///         FilterOperator::Eq,
 	///         FilterValue::Boolean(true),
-	///     )
+	///     ))
 	///     .select_related(&["profile"])
 	///     .all()
 	///     .await?;
@@ -3739,11 +3739,11 @@ where
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 	/// // Fetch first active user
 	/// let user = User::objects()
-	///     .filter(
+	///     .filter(Filter::new(
 	///         "is_active",
 	///         FilterOperator::Eq,
 	///         FilterValue::Boolean(true),
-	///     )
+	///     ))
 	///     .first()
 	///     .await?;
 	///
@@ -3770,7 +3770,7 @@ where
 	///
 	/// ```no_run
 	/// # use reinhardt_db::orm::Model;
-	/// # use reinhardt_db::orm::{FilterOperator, FilterValue};
+	/// # use reinhardt_db::orm::{Filter, FilterOperator, FilterValue};
 	/// # use serde::{Serialize, Deserialize};
 	/// # #[derive(Clone, Serialize, Deserialize)]
 	/// # struct User { id: Option<i64>, email: String }
@@ -3791,11 +3791,11 @@ where
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 	/// // Fetch user with specific email (must be unique)
 	/// let user = User::objects()
-	///     .filter(
+	///     .filter(Filter::new(
 	///         "email",
 	///         FilterOperator::Eq,
 	///         FilterValue::String("alice@example.com".to_string()),
-	///     )
+	///     ))
 	///     .get()
 	///     .await?;
 	/// # Ok(())
@@ -3975,7 +3975,7 @@ where
 	/// # let user_id = 1;
 	/// let db = reinhardt_db::orm::manager::get_connection().await?;
 	/// let user = User::objects()
-	///     .filter("id", reinhardt_db::orm::FilterOperator::Eq, reinhardt_db::orm::FilterValue::Integer(user_id))
+	///     .filter(Filter::new("id", reinhardt_db::orm::FilterOperator::Eq, reinhardt_db::orm::FilterValue::Integer(user_id)))
 	///     .get_with_db(&db)
 	///     .await?;
 	/// # Ok(())
@@ -4027,7 +4027,7 @@ where
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 	/// let db = reinhardt_db::orm::manager::get_connection().await?;
 	/// let user = User::objects()
-	///     .filter("status", reinhardt_db::orm::FilterOperator::Eq, reinhardt_db::orm::FilterValue::String("active".to_string()))
+	///     .filter(Filter::new("status", reinhardt_db::orm::FilterOperator::Eq, reinhardt_db::orm::FilterValue::String("active".to_string())))
 	///     .first_with_db(&db)
 	///     .await?;
 	/// # Ok(())
@@ -4073,11 +4073,11 @@ where
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 	/// // Count active users
 	/// let count = User::objects()
-	///     .filter(
+	///     .filter(Filter::new(
 	///         "is_active",
 	///         FilterOperator::Eq,
 	///         FilterValue::Boolean(true),
-	///     )
+	///     ))
 	///     .count()
 	///     .await?;
 	///
@@ -4149,11 +4149,11 @@ where
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 	/// // Check if any admin users exist
 	/// let has_admin = User::objects()
-	///     .filter(
+	///     .filter(Filter::new(
 	///         "role",
 	///         FilterOperator::Eq,
 	///         FilterValue::String("admin".to_string()),
-	///     )
+	///     ))
 	///     .exists()
 	///     .await?;
 	///
@@ -4276,7 +4276,7 @@ where
 	/// # }
 	/// use std::collections::HashMap;
 	/// let queryset = User::objects()
-	///     .filter("id", FilterOperator::Eq, FilterValue::Integer(1));
+	///     .filter(Filter::new("id", FilterOperator::Eq, FilterValue::Integer(1)));
 	///
 	/// let mut updates = HashMap::new();
 	/// updates.insert("name".to_string(), UpdateValue::String("Alice".to_string()));
@@ -4349,7 +4349,7 @@ where
 	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = Some(value); }
 	/// # }
 	/// let queryset = User::objects()
-	///     .filter("id", FilterOperator::Eq, FilterValue::Integer(1));
+	///     .filter(Filter::new("id", FilterOperator::Eq, FilterValue::Integer(1)));
 	///
 	/// let (sql, params) = queryset.delete_sql();
 	/// // sql: "DELETE FROM users WHERE id = $1"
@@ -5026,7 +5026,7 @@ where
 	///
 	/// // Combine with filters
 	/// let active_user_names = User::objects()
-	///     .filter("is_active", FilterOperator::Eq, FilterValue::Boolean(true))
+	///     .filter(Filter::new("is_active", FilterOperator::Eq, FilterValue::Boolean(true)))
 	///     .values(&["username"])
 	///     .all()
 	///     .await?;
@@ -5287,14 +5287,14 @@ where
 	/// # }
 	/// // Use in IN clause
 	/// let active_user_ids = User::objects()
-	///     .filter("is_active", FilterOperator::Eq, FilterValue::Bool(true))
+	///     .filter(Filter::new("is_active", FilterOperator::Eq, FilterValue::Bool(true)))
 	///     .values(&["id"])
 	///     .as_subquery();
 	/// // Generates: (SELECT id FROM users WHERE is_active = $1)
 	///
 	/// // Use as derived table
 	/// let subquery = Post::objects()
-	///     .filter("published", FilterOperator::Eq, FilterValue::Bool(true))
+	///     .filter(Filter::new("published", FilterOperator::Eq, FilterValue::Bool(true)))
 	///     .as_subquery();
 	/// // Generates: (SELECT * FROM posts WHERE published = $1)
 	/// ```


### PR DESCRIPTION
## Summary

The `Documentation Tests` CI job (CI workflow) was failing with 11 doctest
compilation errors in `crates/reinhardt-db/src/orm/query.rs`. The `QuerySet::filter`
API now takes a single `Filter` argument (`filter(impl Into<Filter>)`), but the
doctests still used the legacy three-argument form
`.filter(field, op, value)`, producing `error[E0277]` (`Filter: From<&str>`
not satisfied) and `error[E0061]` (1 argument expected, 3 supplied).

This was surfaced by the release-plz branch CI for `develop/0.2.0`.

## Type of Change

- [x] Documentation update

## Related Issues

Refs the failing `doc-test` CI job on `develop/0.2.0`:
https://github.com/kent8192/reinhardt-web/actions/runs/26679182551

## Changes Made

- Wrap every legacy 3-argument `.filter(...)` call in the affected doctests with
  `Filter::new(...)` so they match the current single-argument `filter()` API.
  Affected items: `QuerySet::all`, `first`, `get`, `get_with_db`, `first_with_db`,
  `count`, `exists`, `update_sql`, `delete_query`, `values`, `as_subquery`.
- Add the missing `Filter` import to the `get()` example.
- No runtime/source-logic changes — doc-comment example code only.

## How Has This Been Tested?

- `cargo test -p reinhardt-db --doc --all-features QuerySet` (run locally; doctests now compile)
- Diff verified: 18 insertions / 18 deletions, all within doc comments.

## Breaking Change Assessment

- [x] This PR does NOT introduce breaking changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- `documentation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in developer documentation for clarity and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->