### PR TITLE
docs(reinhardt-rest): fix ModelSerializer doctests after DefaultUser removal

### DIFF
--- a/crates/reinhardt-rest/src/serializers/model_serializer.rs
+++ b/crates/reinhardt-rest/src/serializers/model_serializer.rs
@@ -25,20 +25,40 @@ use std::sync::Arc;
 ///
 /// ```no_run
 /// # use reinhardt_rest::serializers::{ModelSerializer, Serializer};
-/// # use reinhardt_db::orm::Engine;
-/// # use reinhardt_auth::DefaultUser;
+/// # use reinhardt_db::orm::Model;
+/// # use serde::{Serialize, Deserialize};
 /// # use uuid::Uuid;
+/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+/// # struct User {
+/// #     id: Uuid,
+/// #     username: String,
+/// #     email: String,
+/// # }
+/// # impl Model for User {
+/// #     type PrimaryKey = Uuid;
+/// #     type Fields = UserFields;
+/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+/// #     fn table_name() -> &'static str { "users" }
+/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+/// #     fn new_fields() -> Self::Fields { UserFields }
+/// # }
+/// # #[derive(Clone)]
+/// # struct UserFields;
+/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+/// #     fn with_alias(self, _alias: &str) -> Self { self }
+/// # }
 /// #
 /// # fn example() {
-/// let serializer = ModelSerializer::<DefaultUser>::new();
+/// let serializer = ModelSerializer::<User>::new();
 ///
 /// // With Meta configuration
-/// let serializer = ModelSerializer::<DefaultUser>::new()
+/// let serializer = ModelSerializer::<User>::new()
 ///     .with_fields(vec!["id".to_string(), "username".to_string()])
 ///     .with_read_only_fields(vec!["id".to_string()]);
 ///
 /// // Serialize a user
-/// let user = DefaultUser {
+/// let user = User {
 ///     id: Uuid::now_v7(),
 ///     username: "alice".to_string(),
 ///     email: "alice@example.com".to_string(),
@@ -71,9 +91,31 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::ModelSerializer;
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
-	/// let serializer = ModelSerializer::<DefaultUser>::new();
+	/// let serializer = ModelSerializer::<User>::new();
 	/// ```
 	pub fn new() -> Self {
 		Self {
@@ -91,9 +133,31 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::ModelSerializer;
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_fields(vec!["id".to_string(), "username".to_string()]);
 	/// ```
 	pub fn with_fields(mut self, fields: Vec<String>) -> Self {
@@ -107,9 +171,31 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::ModelSerializer;
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_exclude(vec!["password_hash".to_string()]);
 	/// ```
 	pub fn with_exclude(mut self, exclude: Vec<String>) -> Self {
@@ -123,9 +209,31 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::ModelSerializer;
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_read_only_fields(vec!["id".to_string()]);
 	/// ```
 	pub fn with_read_only_fields(mut self, fields: Vec<String>) -> Self {
@@ -139,9 +247,31 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::ModelSerializer;
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_write_only_fields(vec!["password_hash".to_string()]);
 	/// ```
 	pub fn with_write_only_fields(mut self, fields: Vec<String>) -> Self {
@@ -242,13 +372,35 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::{ModelSerializer, introspection::{FieldIntrospector, FieldInfo}};
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
 	/// let mut introspector = FieldIntrospector::new();
 	/// introspector.register_field(FieldInfo::new("id", "Uuid").primary_key());
 	/// introspector.register_field(FieldInfo::new("username", "String"));
 	///
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_introspector(introspector);
 	/// ```
 	pub fn with_introspector(mut self, introspector: FieldIntrospector) -> Self {
@@ -270,13 +422,35 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::{ModelSerializer, introspection::{FieldIntrospector, FieldInfo}};
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
 	/// let mut introspector = FieldIntrospector::new();
 	/// introspector.register_field(FieldInfo::new("id", "Uuid"));
 	/// introspector.register_field(FieldInfo::new("username", "String"));
 	///
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_introspector(introspector);
 	///
 	/// let fields = serializer.field_names();
@@ -300,13 +474,35 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::{ModelSerializer, introspection::{FieldIntrospector, FieldInfo}};
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
 	/// let mut introspector = FieldIntrospector::new();
 	/// introspector.register_field(FieldInfo::new("id", "Uuid"));
 	/// introspector.register_field(FieldInfo::new("username", "String"));
 	///
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_introspector(introspector);
 	///
 	/// let required = serializer.required_fields();
@@ -328,13 +524,35 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::{ModelSerializer, introspection::{FieldIntrospector, FieldInfo}};
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
 	/// let mut introspector = FieldIntrospector::new();
 	/// introspector.register_field(FieldInfo::new("email", "String").optional());
 	/// introspector.register_field(FieldInfo::new("username", "String"));
 	///
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_introspector(introspector);
 	///
 	/// let optional = serializer.optional_fields();
@@ -355,13 +573,35 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::{ModelSerializer, introspection::{FieldIntrospector, FieldInfo}};
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
 	/// let mut introspector = FieldIntrospector::new();
 	/// introspector.register_field(FieldInfo::new("id", "Uuid").primary_key());
 	/// introspector.register_field(FieldInfo::new("username", "String"));
 	///
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_introspector(introspector);
 	///
 	/// let pk = serializer.primary_key_field();
@@ -380,9 +620,31 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::{ModelSerializer, validators::UniqueValidator};
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_unique_validator(UniqueValidator::new("username"));
 	/// ```
 	pub fn with_unique_validator(mut self, validator: UniqueValidator<M>) -> Self {
@@ -396,9 +658,31 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::{ModelSerializer, validators::UniqueTogetherValidator};
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_unique_together_validator(
 	///         UniqueTogetherValidator::new(vec!["username", "email"])
 	///     );
@@ -429,9 +713,31 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::{ModelSerializer, validators::UniqueValidator};
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
+	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
-	/// let serializer = ModelSerializer::<DefaultUser>::new()
+	/// let serializer = ModelSerializer::<User>::new()
 	///     .with_unique_validator(UniqueValidator::new("username"));
 	///
 	/// let validators = serializer.validators();
@@ -456,11 +762,32 @@ where
 	///
 	/// ```
 	/// # use reinhardt_rest::serializers::ModelSerializer;
-	/// # use reinhardt_auth::DefaultUser;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
 	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
 	/// #
-	/// let serializer = ModelSerializer::<DefaultUser>::new();
-	/// let user = DefaultUser {
+	/// let serializer = ModelSerializer::<User>::new();
+	/// let user = User {
 	///     id: Uuid::now_v7(),
 	///     username: "alice".to_string(),
 	///     ..Default::default()
@@ -492,14 +819,35 @@ where
 	///
 	/// ```no_run
 	/// # use reinhardt_rest::serializers::ModelSerializer;
-	/// # use reinhardt_auth::DefaultUser;
-	/// # use reinhardt_db::backends::DatabaseConnection;
+	/// # use reinhardt_db::orm::Model;
+	/// # use serde::{Serialize, Deserialize};
 	/// # use uuid::Uuid;
+	/// # #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+	/// # struct User {
+	/// #     id: Uuid,
+	/// #     username: String,
+	/// #     email: String,
+	/// # }
+	/// # impl Model for User {
+	/// #     type PrimaryKey = Uuid;
+	/// #     type Fields = UserFields;
+	/// #     type Objects = reinhardt_db::orm::Manager<Self>;
+	/// #     fn table_name() -> &'static str { "users" }
+	/// #     fn primary_key(&self) -> Option<Self::PrimaryKey> { Some(self.id) }
+	/// #     fn set_primary_key(&mut self, value: Self::PrimaryKey) { self.id = value; }
+	/// #     fn new_fields() -> Self::Fields { UserFields }
+	/// # }
+	/// # #[derive(Clone)]
+	/// # struct UserFields;
+	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
+	/// #     fn with_alias(self, _alias: &str) -> Self { self }
+	/// # }
+	/// # use reinhardt_db::backends::DatabaseConnection;
 	/// #
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 	/// # let connection = DatabaseConnection::connect_postgres("postgres://localhost/test").await?;
-	/// let serializer = ModelSerializer::<DefaultUser>::new();
-	/// let user = DefaultUser {
+	/// let serializer = ModelSerializer::<User>::new();
+	/// let user = User {
 	///     id: Uuid::now_v7(),
 	///     username: "alice".to_string(),
 	///     ..Default::default()


### PR DESCRIPTION
## Summary

The `Documentation Tests` CI job (CI workflow) was failing with 16 doctest
compilation errors in `crates/reinhardt-rest/src/serializers/model_serializer.rs`:
`error[E0432]: unresolved import reinhardt_auth::DefaultUser`. The
`reinhardt_auth::DefaultUser` struct was removed in 0.2.0 (Issue #4520), but the
`ModelSerializer` doctests still imported it.

This was surfaced by the release-plz branch CI for `develop/0.2.0`.

## Type of Change

- [x] Documentation update

## Related Issues

Refs the failing `doc-test` CI job on `develop/0.2.0`:
https://github.com/kent8192/reinhardt-web/actions/runs/26679182551

## Changes Made

- Replace the removed `reinhardt_auth::DefaultUser` in every `ModelSerializer`
  doctest with an inline hidden demo `User` model, mirroring the existing hidden
  `Post` doctest fixture already used elsewhere in the same file.
- Drop the now-unused `reinhardt_db::orm::Engine` import and de-duplicate the
  `uuid::Uuid` import (now provided by the inline model block).
- No runtime/source-logic changes — doc-comment example code only.

## How Has This Been Tested?

- `cargo test -p reinhardt-rest --doc --all-features ModelSerializer` (run locally; doctests now compile)
- Diff verified: changes confined to doc comments.

## Breaking Change Assessment

- [x] This PR does NOT introduce breaking changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- `documentation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API documentation examples for the model serializer with improved code samples and clearer usage illustrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->