### PR TITLE
feat: warn when a URL reverse name is not kebab-case (#4901)

### DIFF
--- a/crates/reinhardt-core/macros/CHANGELOG.md
+++ b/crates/reinhardt-core/macros/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The HTTP route macros (`#[get]`, `#[post]`, `#[put]`, `#[patch]`,
+  `#[delete]`) now emit a compile-time warning when an explicit `name = "..."`
+  is not kebab-case, suggesting the kebab-case form to match ViewSet-generated
+  names. Prefix the name with `!` to opt out, or set
+  `REINHARDT_URL_NAME_WARNINGS=0` to silence it. Names that default to the
+  function identifier are exempt. Refs
+  [#4901](https://github.com/kent8192/reinhardt-web/issues/4901).
+
+### Removed
+
+- Removed the vestigial per-route URL-resolver metadata codegen
+  (`generate_url_resolver_tokens` / `__url_resolver_meta_*`) from the HTTP route
+  macros. Its consumer (`ResolvedUrls` / `__for_each_url_resolver`) was removed
+  with the URL routing simplification (#4784), and the leftover codegen also
+  rejected hyphenated (kebab-case) route names with a hard `compile_error!`.
+  Route names passed to `#[get]` and friends may now be kebab-case. Refs
+  [#4901](https://github.com/kent8192/reinhardt-web/issues/4901).
+
 ## [0.1.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-macros@v0.1.0-rc.30...reinhardt-macros@v0.1.0) - 2026-05-22
 
 Initial stable release of `reinhardt-macros` as part of the

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -99,7 +99,20 @@ pub fn action(args: TokenStream, input: TokenStream) -> TokenStream {
 		.into()
 }
 
-/// GET method decorator
+/// GET method decorator.
+///
+/// # Route name (`name = "..."`)
+///
+/// The optional `name` selects the identifier used for URL reversal
+/// (`reverse(...)`). Prefer kebab-case (e.g. `name = "users-list"`) to match
+/// ViewSet-generated names; a non-kebab name (snake_case / camelCase) emits a
+/// warning at compile time and again when routes are registered. Prefix the
+/// name with `!` (e.g. `name = "!legacy_name"`) to opt out — the sigil is
+/// stripped before storage, so reverse lookups use the clean name — or set
+/// `REINHARDT_URL_NAME_WARNINGS=0` to silence all such warnings. When omitted,
+/// the route name defaults to the function name and is exempt from the warning.
+/// The same convention applies to `#[post]`, `#[put]`, `#[patch]`, and
+/// `#[delete]`. Refs Issue #4901.
 #[proc_macro_attribute]
 pub fn get(args: TokenStream, input: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(input as ItemFn);

--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -628,11 +628,14 @@ fn generate_view_type(
 		None => quote! {},
 	};
 
-	// Generate inventory submission for endpoint metadata
-	let metadata_name = if metadata_clean.is_empty() {
-		quote! { None }
-	} else {
+	// Generate inventory submission for endpoint metadata. Strip the `!`
+	// exemption sigil from the metadata name (Issue #4901); unnamed handlers
+	// keep their `None` metadata name (mirrors the simple-path logic so both
+	// codegen paths produce identical EndpointMetadata.name behavior).
+	let metadata_name = if options.name.is_some() {
 		quote! { Some(#metadata_clean) }
+	} else {
+		quote! { None }
 	};
 
 	// Extract request body information

--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -201,14 +201,6 @@ fn validate_extractors(extractors: &[ExtractorInfo]) -> Result<()> {
 	Ok(())
 }
 
-/// Convert `Option<String>` to TokenStream for `Option<&'static str>` literal
-fn option_to_lit(opt: &Option<String>) -> TokenStream {
-	match opt {
-		Some(s) => quote! { Some(#s) },
-		None => quote! { None },
-	}
-}
-
 /// Result of auth parameter detection for a handler.
 struct AuthDetection {
 	/// The detected protection level for the endpoint.
@@ -598,7 +590,6 @@ fn generate_view_type(
 	input: &ItemFn,
 	method: &str,
 	path: &str,
-	route_name: &str,
 	extractors: &[ExtractorInfo],
 	inject_params: &[InjectInfo],
 	options: &RouteOptions,
@@ -628,11 +619,20 @@ fn generate_view_type(
 
 	let route_doc = format!("Route: {} {}", method, path);
 
+	// Resolve the reverse name (carries the `!` exemption sigil) and the clean
+	// metadata name, and emit a compile-time kebab-case warning for an explicit
+	// non-kebab name (Issue #4901).
+	let (name_method_value, metadata_clean) = resolve_route_names(&options.name, fn_name);
+	let kebab_name_warning = match &options.name {
+		Some(name) => emit_non_kebab_name_warning(fn_name, name),
+		None => quote! {},
+	};
+
 	// Generate inventory submission for endpoint metadata
-	let metadata_name = if route_name.is_empty() {
+	let metadata_name = if metadata_clean.is_empty() {
 		quote! { None }
 	} else {
-		quote! { Some(#route_name) }
+		quote! { Some(#metadata_clean) }
 	};
 
 	// Extract request body information
@@ -666,12 +666,12 @@ fn generate_view_type(
 		}
 	};
 
-	let url_resolver_tokens =
-		generate_url_resolver_tokens(&options.name, &fn_name.to_string(), path, &reinhardt_crate);
-
 	Ok(quote! {
 		// Submit endpoint metadata to global inventory
 		#metadata_submission
+
+		// Compile-time kebab-case warning marker (empty unless triggered).
+		#kebab_name_warning
 
 		#original_fn
 
@@ -689,7 +689,7 @@ fn generate_view_type(
 			}
 
 			fn name() -> &'static str {
-				#route_name
+				#name_method_value
 			}
 		}
 
@@ -714,8 +714,6 @@ fn generate_view_type(
 		#fn_vis fn #fn_name() -> #view_type_name {
 			#view_type_name
 		}
-
-		#url_resolver_tokens
 	})
 }
 
@@ -768,92 +766,114 @@ pub(crate) fn extract_url_params(path: &str) -> Vec<String> {
 	params
 }
 
-/// Generate per-endpoint URL resolver metadata tokens.
-///
-/// Each endpoint gets a uniquely named `__url_resolver_<fn_name>` module that
-/// contains a metadata macro consumed by the
-/// `__for_each_url_resolver!` / `__build_namespaced_resolvers!` machinery.
-/// The resolver modules are referenced by deriving the module name from
-/// the last segment of the endpoint path.
-///
-/// The legacy per-route resolver trait surface was removed (refs #4520); only
-/// the metadata macro/module remains.
-///
-/// Returns empty tokens if:
-/// - No route name is set
-/// - The path contains a wildcard
-fn generate_url_resolver_tokens(
-	route_name: &Option<String>,
-	fn_name: &str,
-	path: &str,
-	_reinhardt_crate: &TokenStream,
-) -> TokenStream {
-	let Some(name) = route_name.as_ref() else {
-		return quote! {};
-	};
+/// Returns `true` when `name` follows the kebab-case convention used by reverse
+/// URL names: no underscores and no ASCII-uppercase letters. Mirrors the runtime
+/// `is_kebab_case` helper in `reinhardt-urls` (a proc-macro crate cannot depend
+/// on it, so the small check is duplicated). Refs Issue #4901.
+fn is_kebab_route_name(name: &str) -> bool {
+	!name.chars().any(|c| c == '_' || c.is_ascii_uppercase())
+}
 
-	// Skip wildcard routes
-	if path.contains('*') {
-		return quote! {};
-	}
-
-	// Validate that the route name is a valid Rust identifier before creating
-	// Ident values. `syn::Ident::new` panics on invalid identifiers, so we
-	// catch that early and emit a readable compile error instead.
-	if syn::parse_str::<syn::Ident>(name).is_err() {
-		let msg = format!(
-			"Route name `{name}` is not a valid Rust identifier. \
-			 Route names used with url-resolver must be valid identifiers \
-			 (no hyphens, dots, or leading digits)."
-		);
-		return quote! { ::core::compile_error!(#msg); };
-	}
-
-	let method_ident = syn::Ident::new(name, Span::call_site());
-	let resolver_mod_ident =
-		syn::Ident::new(&format!("__url_resolver_{fn_name}"), Span::call_site());
-	let meta_macro_ident =
-		syn::Ident::new(&format!("__url_resolver_meta_{fn_name}"), Span::call_site());
-	let params = extract_url_params(path);
-	let param_strs: Vec<&str> = params.iter().map(|s| s.as_str()).collect();
-
-	// Gate with raw platform check (not `native` alias) because this code
-	// expands in consuming crates that do not have cfg_aliases.
-	//
-	// Emits only the metadata macro consumed by `__for_each_url_resolver`
-	// → `__build_namespaced_resolvers` (Issue #3526). The deprecated flat
-	// per-route resolver trait (`Resolve<Name>`) that produced
-	// `urls.<name>(...)` accessors was removed in 0.2.0 per Issue #4520.
-	if params.is_empty() {
-		quote! {
-			#[doc(hidden)]
-			pub mod #resolver_mod_ident {
-				// Metadata macro for per-app resolver struct generation (Issue #3526).
-				// Consumed by __for_each_url_resolver! → __build_namespaced_resolvers!
-				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-				macro_rules! #meta_macro_ident {
-					($callback:ident, $app:ident) => {
-						$callback!($app, #method_ident, #name, );
-					};
-				}
-				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-				pub(crate) use #meta_macro_ident;
+/// Convert a snake_case / camelCase / PascalCase `name` to kebab-case for the
+/// non-kebab-case warning suggestion. Mirrors the runtime `to_kebab_case` helper
+/// in `reinhardt-urls`. Refs Issue #4901.
+fn suggest_kebab_route_name(name: &str) -> String {
+	let mut out = String::with_capacity(name.len() + 4);
+	// Treat the start as a boundary so we never emit a leading '-'.
+	let mut prev_is_boundary = true;
+	for c in name.chars() {
+		if c == '_' || c == '-' {
+			if !prev_is_boundary {
+				out.push('-');
+				prev_is_boundary = true;
 			}
+		} else if c.is_ascii_uppercase() {
+			if !prev_is_boundary {
+				out.push('-');
+			}
+			out.push(c.to_ascii_lowercase());
+			prev_is_boundary = false;
+		} else {
+			out.push(c);
+			prev_is_boundary = false;
 		}
-	} else {
-		quote! {
-			#[doc(hidden)]
-			pub mod #resolver_mod_ident {
-				// Metadata macro for per-app resolver struct generation (Issue #3526).
-				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-				macro_rules! #meta_macro_ident {
-					($callback:ident, $app:ident) => {
-						$callback!($app, #method_ident, #name, #(#param_strs),* );
-					};
-				}
-				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-				pub(crate) use #meta_macro_ident;
-			}
+	}
+	out
+}
+
+/// Whether the kebab-case URL-name warning is enabled at macro-expansion time.
+///
+/// Honors the same `REINHARDT_URL_NAME_WARNINGS` global toggle as the runtime
+/// reverser (`0`/`false`/`off`/`no` disables it). Note: cargo may cache
+/// proc-macro output, so toggling this env var might not re-trigger expansion —
+/// the per-route `!` opt-out sigil is the robust, build-cache-independent
+/// control. Refs Issue #4901.
+fn url_name_warnings_enabled() -> bool {
+	match std::env::var("REINHARDT_URL_NAME_WARNINGS") {
+		Ok(v) => !matches!(
+			v.trim().to_ascii_lowercase().as_str(),
+			"0" | "false" | "off" | "no"
+		),
+		Err(_) => true,
+	}
+}
+
+/// Resolve the route-name strings for a generated endpoint (Issue #4901).
+///
+/// Returns `(reverse_name, metadata_name)`:
+/// - `reverse_name` is what `EndpointInfo::name()` returns and what the URL
+///   reverser registers. It carries the `!` exemption sigil so the runtime
+///   kebab-case warning is suppressed for auto-derived (fn-name) defaults — the
+///   user did not choose those names — and for explicit opt-outs. The reverser
+///   strips the sigil before storage, so reverse lookups use the clean name.
+/// - `metadata_name` is the clean name (sigil stripped) used for endpoint
+///   metadata such as OpenAPI.
+fn resolve_route_names(explicit: &Option<String>, fn_name: &syn::Ident) -> (String, String) {
+	match explicit {
+		Some(name) => {
+			let clean = name.strip_prefix('!').unwrap_or(name).to_string();
+			(name.clone(), clean)
+		}
+		None => {
+			let derived = fn_name.to_string();
+			(format!("!{derived}"), derived)
+		}
+	}
+}
+
+/// Emit a compile-time `deprecated`-lint warning when an explicit route `name`
+/// is not kebab-case (Issue #4901).
+///
+/// The marker reuses the const-read-of-`#[deprecated]` pattern from
+/// `viewset_macro::emit_basename_fallback_deprecation` (Issue #4549) — the only
+/// stable way to surface a non-error warning from a proc-macro. A leading `!`
+/// opts out (and is consumed by the runtime reverser). Returns empty tokens when
+/// the name is exempt, already kebab-case, or warnings are globally disabled.
+fn emit_non_kebab_name_warning(fn_name: &syn::Ident, name: &str) -> TokenStream {
+	if name.starts_with('!') || is_kebab_route_name(name) || !url_name_warnings_enabled() {
+		return quote! {};
+	}
+	let suggestion = suggest_kebab_route_name(name);
+	let note = format!(
+		"URL name \"{name}\" is not kebab-case; prefer \"{suggestion}\" to match \
+		 ViewSet-generated names (e.g. \"users-list\"). Prefix the name with '!' \
+		 (name = \"!{name}\") to opt out, or set REINHARDT_URL_NAME_WARNINGS=0."
+	);
+	let module_ident = syn::Ident::new(
+		&format!("__non_kebab_url_name_{fn_name}"),
+		Span::call_site(),
+	);
+	quote! {
+		#[doc(hidden)]
+		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+		#[allow(non_snake_case)]
+		mod #module_ident {
+			#[deprecated(note = #note)]
+			pub const REASON: () = ();
+			// Reading the `#[deprecated]` const is what fires the lint at the
+			// route macro's call site.
+			#[allow(deprecated_in_future, clippy::no_effect)]
+			const _: () = REASON;
 		}
 	}
 }
@@ -1014,16 +1034,10 @@ fn route_impl(method: &str, args: TokenStream, input: ItemFn) -> Result<TokenStr
 			.as_ref()
 			.map(|(p, _)| p.clone())
 			.unwrap_or_else(|| "/".to_string());
-		let route_name = options
-			.name
-			.clone()
-			.unwrap_or_else(|| input.sig.ident.to_string());
-
 		return generate_view_type(
 			&input,
 			method,
 			&path_str,
-			&route_name,
 			&extractors,
 			&inject_params,
 			&options,
@@ -1045,7 +1059,14 @@ fn route_impl(method: &str, args: TokenStream, input: ItemFn) -> Result<TokenStr
 		.as_ref()
 		.map(|(p, _)| p.clone())
 		.unwrap_or_else(|| "/".to_string());
-	let route_name = options.name.clone().unwrap_or_else(|| fn_name.to_string());
+	// Resolve the reverse name (carries the `!` exemption sigil) and the clean
+	// metadata name, and emit a compile-time kebab-case warning for an explicit
+	// non-kebab name (Issue #4901).
+	let (name_method_value, metadata_clean) = resolve_route_names(&options.name, fn_name);
+	let kebab_name_warning = match &options.name {
+		Some(name) => emit_non_kebab_name_warning(fn_name, name),
+		None => quote! {},
+	};
 	let view_type_name =
 		syn::Ident::new(&fn_name_to_view_type(&fn_name.to_string()), fn_name.span());
 	let method_ident = syn::Ident::new(method, Span::call_site());
@@ -1069,8 +1090,14 @@ fn route_impl(method: &str, args: TokenStream, input: ItemFn) -> Result<TokenStr
 		)
 	};
 
-	// Generate inventory submission for endpoint metadata
-	let metadata_name = option_to_lit(&options.name);
+	// Generate inventory submission for endpoint metadata. Strip the `!`
+	// exemption sigil from the metadata name (Issue #4901); unnamed handlers
+	// keep their `None` metadata name.
+	let metadata_name = if options.name.is_some() {
+		quote! { Some(#metadata_clean) }
+	} else {
+		quote! { None }
+	};
 
 	// Extract request body information
 	let (request_body_type, request_content_type) = extract_request_body_info(&input.sig.inputs)
@@ -1103,16 +1130,12 @@ fn route_impl(method: &str, args: TokenStream, input: ItemFn) -> Result<TokenStr
 		}
 	};
 
-	let url_resolver_tokens = generate_url_resolver_tokens(
-		&options.name,
-		&fn_name.to_string(),
-		&path_str,
-		&reinhardt_crate,
-	);
-
 	Ok(quote! {
 		// Submit endpoint metadata to global inventory
 		#metadata_submission
+
+		// Compile-time kebab-case warning marker (empty unless triggered).
+		#kebab_name_warning
 
 		// Original function (renamed, private)
 		#(#fn_attrs)*
@@ -1134,7 +1157,7 @@ fn route_impl(method: &str, args: TokenStream, input: ItemFn) -> Result<TokenStr
 			}
 
 			fn name() -> &'static str {
-				#route_name
+				#name_method_value
 			}
 		}
 
@@ -1159,8 +1182,6 @@ fn route_impl(method: &str, args: TokenStream, input: ItemFn) -> Result<TokenStr
 		#fn_vis fn #fn_name() -> #view_type_name {
 			#view_type_name
 		}
-
-		#url_resolver_tokens
 	})
 }
 
@@ -1234,5 +1255,75 @@ mod url_resolver_tests {
 			to_resolver_trait_name("deployment_logs"),
 			"ResolveDeploymentLogs"
 		);
+	}
+
+	// --- Kebab-case URL name convention (Issue #4901) ---
+
+	fn ident(name: &str) -> syn::Ident {
+		syn::Ident::new(name, Span::call_site())
+	}
+
+	#[test]
+	fn is_kebab_route_name_classifies_names() {
+		assert!(is_kebab_route_name("users-list"));
+		assert!(is_kebab_route_name("detail"));
+		assert!(is_kebab_route_name("v2"));
+		assert!(!is_kebab_route_name("user_detail"));
+		assert!(!is_kebab_route_name("userDetail"));
+		assert!(!is_kebab_route_name("UserDetail"));
+	}
+
+	#[test]
+	fn suggest_kebab_route_name_converts_names() {
+		assert_eq!(suggest_kebab_route_name("user_detail"), "user-detail");
+		assert_eq!(suggest_kebab_route_name("userDetail"), "user-detail");
+		assert_eq!(suggest_kebab_route_name("UserDetail"), "user-detail");
+		assert_eq!(suggest_kebab_route_name("users-list"), "users-list");
+	}
+
+	#[test]
+	fn resolve_route_names_marks_fallback_and_strips_optout() {
+		// Explicit name: reverse name kept verbatim, metadata identical.
+		assert_eq!(
+			resolve_route_names(&Some("users-list".to_string()), &ident("list_users")),
+			("users-list".to_string(), "users-list".to_string())
+		);
+		// Explicit opt-out: `!` kept on the reverse name, stripped for metadata.
+		assert_eq!(
+			resolve_route_names(&Some("!user_detail".to_string()), &ident("get_user")),
+			("!user_detail".to_string(), "user_detail".to_string())
+		);
+		// Fallback to fn name: reverse name is exempt (`!`-prefixed), metadata clean.
+		assert_eq!(
+			resolve_route_names(&None, &ident("get_user")),
+			("!get_user".to_string(), "get_user".to_string())
+		);
+	}
+
+	#[test]
+	fn emit_non_kebab_name_warning_is_empty_for_exempt_names() {
+		// Already kebab-case: no marker regardless of the global toggle.
+		assert!(
+			emit_non_kebab_name_warning(&ident("list_users"), "users-list")
+				.to_string()
+				.is_empty()
+		);
+		// Explicit opt-out: no marker.
+		assert!(
+			emit_non_kebab_name_warning(&ident("get_user"), "!user_detail")
+				.to_string()
+				.is_empty()
+		);
+	}
+
+	#[test]
+	fn emit_non_kebab_name_warning_emits_marker_for_snake_case() {
+		// The marker only fires when warnings are enabled (default unless the
+		// REINHARDT_URL_NAME_WARNINGS toggle disables them in this environment).
+		if url_name_warnings_enabled() {
+			let marker = emit_non_kebab_name_warning(&ident("get_user"), "user_detail").to_string();
+			assert!(marker.contains("deprecated"));
+			assert!(marker.contains("user-detail"));
+		}
 	}
 }

--- a/crates/reinhardt-urls/CHANGELOG.md
+++ b/crates/reinhardt-urls/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#4637](https://github.com/kent8192/reinhardt-web/issues/4637).
 ### Added
 
+- Emit a `tracing::warn!` when a route name registered for URL reversal is not
+  kebab-case (e.g. `user_detail`), suggesting the kebab-case form
+  (`user-detail`) to match ViewSet-generated names. The warning is advisory, not
+  an error: prefix the route-name segment with `!` to opt out (the sigil is
+  stripped before storage, so reverse lookups use the clean name) or set
+  `REINHARDT_URL_NAME_WARNINGS=0` to silence it globally. Refs
+  [#4901](https://github.com/kent8192/reinhardt-web/issues/4901).
 - `ClientRouter::page<F, P>(pattern, handler)` and
   `ClientRouter::named_page<F, P>(name, pattern, handler)` accepting any
   handler `Fn(P) -> Page` where `P: FromRequest`. The same Props struct

--- a/crates/reinhardt-urls/src/routers/reverse/reverser.rs
+++ b/crates/reinhardt-urls/src/routers/reverse/reverser.rs
@@ -41,7 +41,13 @@ impl UrlReverser {
 	///
 	/// Returns `Err` with a descriptive message if a route with the same
 	/// fully-qualified name has already been registered.
-	pub fn register(&mut self, route: Route) -> std::result::Result<(), String> {
+	pub fn register(&mut self, mut route: Route) -> std::result::Result<(), String> {
+		// Validate the route-name segment against the kebab-case convention.
+		// A leading `!` opts out of the warning and is stripped before storage,
+		// so reverse lookups still use the clean name.
+		if let Some(name) = route.name.take() {
+			route.name = Some(normalize_route_name(&name));
+		}
 		if let Some(full_name) = route.full_name() {
 			use std::collections::hash_map::Entry;
 			match self.routes.entry(full_name.clone()) {
@@ -82,6 +88,31 @@ impl UrlReverser {
 	/// let url = reverser.reverse_with("v1:users:detail", &[("id", "123")]).unwrap();
 	/// assert_eq!(url, "/api/v1/users/123/");
 	/// ```
+	///
+	/// # Naming convention
+	///
+	/// The route-name segment (the part after the last `:` namespace separator)
+	/// should be kebab-case (e.g. `users-detail`), matching ViewSet
+	/// auto-generated names. A segment containing `_` or uppercase letters emits
+	/// a `tracing::warn!` at registration time suggesting the kebab-case form.
+	/// The warning is advisory, not an error. Prefix the segment with `!` to opt
+	/// out, or set the `REINHARDT_URL_NAME_WARNINGS=0` environment variable to
+	/// silence the warning globally. The `!` sigil is stripped before storage, so
+	/// reverse lookups use the clean name:
+	///
+	/// ```
+	/// use reinhardt_urls::routers::UrlReverser;
+	///
+	/// let mut reverser = UrlReverser::new();
+	/// // The leading `!` suppresses the kebab-case warning for this intentional
+	/// // snake_case name; it is stored (and reversed) as "user_detail".
+	/// reverser.register_path("!user_detail", "/users/{id}/").unwrap();
+	///
+	/// assert!(reverser.has_route("user_detail"));
+	/// assert!(!reverser.has_route("!user_detail"));
+	/// let url = reverser.reverse_with("user_detail", &[("id", "7")]).unwrap();
+	/// assert_eq!(url, "/users/7/");
+	/// ```
 	pub fn register_path(&mut self, name: &str, path: &str) -> std::result::Result<(), String> {
 		// Create a dummy handler for the route
 		// The handler is never used for URL reversal
@@ -100,16 +131,22 @@ impl UrlReverser {
 			}
 		}
 
-		// Parse the name to extract namespace (if any)
-		let parts: Vec<&str> = name.rsplitn(2, ':').collect();
-		let (route_name, namespace) = if parts.len() == 2 {
-			(parts[0].to_string(), Some(parts[1].to_string()))
-		} else {
-			(name.to_string(), None)
+		// Parse the name to extract namespace (if any). Only the segment after
+		// the last ':' namespace separator is validated against the kebab-case
+		// convention; a leading `!` on that segment opts out of the warning and
+		// is stripped before storage.
+		let (namespace, raw_segment) = match name.rsplit_once(':') {
+			Some((ns, seg)) => (Some(ns.to_string()), seg),
+			None => (None, name),
+		};
+		let route_name = normalize_route_name(raw_segment);
+		let qualified_name = match &namespace {
+			Some(ns) => format!("{ns}:{route_name}"),
+			None => route_name.clone(),
 		};
 
 		let mut route = Route::new(path, Arc::new(DummyHandler));
-		route.name = Some(route_name.clone());
+		route.name = Some(route_name);
 
 		let route = if let Some(ns) = namespace {
 			route.with_namespace(&ns)
@@ -118,10 +155,10 @@ impl UrlReverser {
 		};
 
 		use std::collections::hash_map::Entry;
-		match self.routes.entry(name.to_string()) {
+		match self.routes.entry(qualified_name.clone()) {
 			Entry::Occupied(existing) => Err(format!(
 				"Duplicate route name '{}': path '{}' conflicts with existing path '{}'",
-				name,
+				qualified_name,
 				path,
 				existing.get().path
 			)),
@@ -332,4 +369,159 @@ pub fn reverse(
 	reverser: &UrlReverser,
 ) -> ReverseResult<String> {
 	reverser.reverse(name, params)
+}
+
+/// Returns `true` if `segment` follows the kebab-case convention.
+///
+/// A segment is kebab-case when it contains no underscores and no ASCII
+/// uppercase letters. Hyphens and digits are allowed; leading/trailing hyphens
+/// are intentionally not flagged, to avoid false positives.
+fn is_kebab_case(segment: &str) -> bool {
+	!segment.chars().any(|c| c == '_' || c.is_ascii_uppercase())
+}
+
+/// Convert a snake_case, camelCase, or PascalCase `segment` to kebab-case.
+///
+/// Used only to build the suggestion shown in the non-kebab-case warning.
+fn to_kebab_case(segment: &str) -> String {
+	let mut out = String::with_capacity(segment.len() + 4);
+	// Treat the start as a boundary so we never emit a leading '-'.
+	let mut prev_is_boundary = true;
+	for c in segment.chars() {
+		if c == '_' || c == '-' {
+			if !prev_is_boundary {
+				out.push('-');
+				prev_is_boundary = true;
+			}
+		} else if c.is_ascii_uppercase() {
+			if !prev_is_boundary {
+				out.push('-');
+			}
+			out.push(c.to_ascii_lowercase());
+			prev_is_boundary = false;
+		} else {
+			out.push(c);
+			prev_is_boundary = false;
+		}
+	}
+	out
+}
+
+/// Environment variable that globally toggles the kebab-case URL-name warning.
+///
+/// Set it to `0`, `false`, `off`, or `no` (case-insensitive) to silence the
+/// warning for every route name. Any other value — or leaving it unset — keeps
+/// the warning enabled. The per-route `!` opt-out sigil remains the robust,
+/// build-cache-independent way to suppress a single name.
+const URL_NAME_WARNINGS_ENV: &str = "REINHARDT_URL_NAME_WARNINGS";
+
+/// Parse a `REINHARDT_URL_NAME_WARNINGS` value into an enabled/disabled flag.
+///
+/// Split out from [`url_name_warnings_enabled`] so the precedence rules can be
+/// unit-tested without mutating process-global environment state.
+fn warnings_enabled_from_env(value: Option<&str>) -> bool {
+	match value {
+		Some(v) => !matches!(
+			v.trim().to_ascii_lowercase().as_str(),
+			"0" | "false" | "off" | "no"
+		),
+		None => true,
+	}
+}
+
+/// Returns `true` when the kebab-case URL-name warning is enabled for this
+/// process, honoring the [`URL_NAME_WARNINGS_ENV`] global toggle.
+fn url_name_warnings_enabled() -> bool {
+	warnings_enabled_from_env(std::env::var(URL_NAME_WARNINGS_ENV).ok().as_deref())
+}
+
+/// Normalize a bare route-name segment against the kebab-case convention.
+///
+/// If the segment begins with the `!` opt-out sigil, the sigil is stripped and
+/// no warning is emitted. Otherwise a non-kebab-case segment triggers a
+/// `tracing::warn!` suggesting the kebab-case form, unless the global toggle
+/// ([`URL_NAME_WARNINGS_ENV`]) disables it. Returns the cleaned segment to be
+/// stored and reversed against.
+fn normalize_route_name(segment: &str) -> String {
+	if let Some(stripped) = segment.strip_prefix('!') {
+		return stripped.to_string();
+	}
+	if !is_kebab_case(segment) && url_name_warnings_enabled() {
+		let suggestion = to_kebab_case(segment);
+		tracing::warn!(
+			target: "reinhardt_urls::reverse",
+			"URL name '{segment}' is not kebab-case; suggestion: use '{suggestion}'. \
+			 To suppress this warning, prefix the name with '!' (e.g. name = \"!{segment}\") \
+			 or set {URL_NAME_WARNINGS_ENV}=0."
+		);
+	}
+	segment.to_string()
+}
+
+#[cfg(test)]
+mod kebab_convention_tests {
+	use super::{is_kebab_case, normalize_route_name, to_kebab_case, warnings_enabled_from_env};
+	use rstest::rstest;
+
+	#[rstest]
+	#[case(None, true)]
+	#[case(Some("1"), true)]
+	#[case(Some("true"), true)]
+	#[case(Some("anything"), true)]
+	#[case(Some("0"), false)]
+	#[case(Some("false"), false)]
+	#[case(Some("OFF"), false)]
+	#[case(Some(" no "), false)]
+	fn warnings_enabled_from_env_honors_disable_values(
+		#[case] value: Option<&str>,
+		#[case] expected: bool,
+	) {
+		// Act
+		let result = warnings_enabled_from_env(value);
+
+		// Assert
+		assert_eq!(result, expected);
+	}
+
+	#[rstest]
+	#[case("users-list", true)]
+	#[case("users-detail", true)]
+	#[case("detail", true)]
+	#[case("v2", true)]
+	#[case("user_detail", false)]
+	#[case("userDetail", false)]
+	#[case("UserDetail", false)]
+	fn is_kebab_case_classifies_segments(#[case] segment: &str, #[case] expected: bool) {
+		// Act
+		let result = is_kebab_case(segment);
+
+		// Assert
+		assert_eq!(result, expected);
+	}
+
+	#[rstest]
+	#[case("user_detail", "user-detail")]
+	#[case("userDetail", "user-detail")]
+	#[case("UserDetail", "user-detail")]
+	#[case("users-list", "users-list")]
+	fn to_kebab_case_converts_segments(#[case] segment: &str, #[case] expected: &str) {
+		// Act
+		let result = to_kebab_case(segment);
+
+		// Assert
+		assert_eq!(result, expected);
+	}
+
+	#[rstest]
+	#[case("!user_detail", "user_detail")]
+	#[case("!users-list", "users-list")]
+	#[case("user_detail", "user_detail")]
+	#[case("users-list", "users-list")]
+	fn normalize_route_name_strips_optout_sigil(#[case] segment: &str, #[case] expected: &str) {
+		// Act
+		let result = normalize_route_name(segment);
+
+		// Assert
+		assert_eq!(result, expected);
+	}
 }

--- a/crates/reinhardt-urls/src/routers/reverse/tests.rs
+++ b/crates/reinhardt-urls/src/routers/reverse/tests.rs
@@ -902,3 +902,82 @@ fn test_try_reverse_single_pass_ok_on_valid_params() {
 	// Assert
 	assert_eq!(result, "/users/123/");
 }
+
+#[rstest]
+fn register_path_accepts_non_kebab_name_and_reverses() {
+	// Arrange
+	let mut reverser = UrlReverser::new();
+
+	// Act
+	// A snake_case name emits a (non-fatal) kebab-case warning but is still
+	// registered and reversible under its given name.
+	reverser
+		.register_path("user_detail", "/users/{id}/")
+		.unwrap();
+	let url = reverser
+		.reverse_with("user_detail", &[("id", "42")])
+		.unwrap();
+
+	// Assert
+	assert!(reverser.has_route("user_detail"));
+	assert_eq!(url, "/users/42/");
+}
+
+#[rstest]
+fn register_path_strips_optout_sigil_from_name() {
+	// Arrange
+	let mut reverser = UrlReverser::new();
+
+	// Act
+	reverser
+		.register_path("!user_detail", "/users/{id}/")
+		.unwrap();
+	let url = reverser
+		.reverse_with("user_detail", &[("id", "7")])
+		.unwrap();
+
+	// Assert
+	assert!(reverser.has_route("user_detail"));
+	assert!(!reverser.has_route("!user_detail"));
+	assert_eq!(url, "/users/7/");
+}
+
+#[rstest]
+fn register_path_strips_optout_sigil_from_namespaced_name() {
+	// Arrange
+	let mut reverser = UrlReverser::new();
+
+	// Act
+	// Only the segment after the last ':' carries the opt-out sigil; the
+	// namespace prefix is preserved.
+	reverser
+		.register_path("v1:users:!detail", "/api/v1/users/{id}/")
+		.unwrap();
+	let url = reverser
+		.reverse_with("v1:users:detail", &[("id", "9")])
+		.unwrap();
+
+	// Assert
+	assert!(reverser.has_route("v1:users:detail"));
+	assert!(!reverser.has_route("v1:users:!detail"));
+	assert_eq!(url, "/api/v1/users/9/");
+}
+
+#[rstest]
+fn register_route_strips_optout_sigil_from_name() {
+	// Arrange
+	let mut reverser = UrlReverser::new();
+	let mut route = Route::new(path!("/users/{id}/"), Arc::new(TestHandler));
+	route.name = Some("!user_detail".to_string());
+
+	// Act
+	reverser.register(route).unwrap();
+	let url = reverser
+		.reverse_with("user_detail", &[("id", "3")])
+		.unwrap();
+
+	// Assert
+	assert!(reverser.has_route("user_detail"));
+	assert!(!reverser.has_route("!user_detail"));
+	assert_eq!(url, "/users/3/");
+}


### PR DESCRIPTION
## Summary

Warns when a URL route name used for `reverse()` resolution is not kebab-case, so manually defined names stay consistent with ViewSet-generated names (`users-list`, `users-detail`). Implements issue #4901 with **two advisory layers** plus a per-route and a global opt-out — never a hard error (Design Philosophy #3: CoC is a right, not an obligation).

## What changed

**Runtime (`reinhardt-urls`)** — `UrlReverser::register_path()` / `register()` emit a `tracing::warn!` when the route-name segment (after the last `:` namespace separator) contains `_` or uppercase letters, suggesting the kebab-case form. Covers ViewSet-composed and direct registrations.

**Compile-time (`reinhardt-macros`)** — `#[get]`/`#[post]`/`#[put]`/`#[patch]`/`#[delete]` emit a compile-time `deprecated`-lint warning when an explicit `name = "..."` is not kebab-case (reusing the `#[deprecated]`-marker pattern from #4549). This is the earliest catch point (Design Philosophy #4: fail early).

**Opt-out (both)**
- Per route: prefix the name with `!` (e.g. `name = "!legacy_name"`). The sigil is stripped before storage, so `reverse("legacy_name")` still resolves.
- Globally: `REINHARDT_URL_NAME_WARNINGS=0`.

**No flood for unnamed handlers** — when `name=` is omitted the route name defaults to the (snake_case) function identifier. The macro marks these auto-derived names exempt (`EndpointInfo::name()` carries the `!` sigil, stripped by the reverser), so they reverse exactly as before without warning.

**Enabling cleanup** — removed the vestigial per-route URL-resolver metadata codegen (`generate_url_resolver_tokens` / `__url_resolver_meta_*`). Its consumer (`ResolvedUrls` / `__for_each_url_resolver`) was already removed with the URL routing simplification (#4784), and the leftover codegen rejected hyphenated route names with a hard `compile_error!` — which would have blocked the kebab-case names this change encourages. `extract_url_params` / `to_resolver_trait_name` (still used by `#[websocket]`) are retained.

## Test plan

- `cargo test -p reinhardt-urls` — reverse module (88) incl. non-kebab-still-registers, `!` strip (plain + namespaced), `register()` parity, env-toggle parsing; lib (451), `route_pattern_matching` (102), `url_resolver_extension_trait` (3, exercises `#[get]` → reverse end-to-end), doctests (346).
- `cargo test -p reinhardt-macros` — lib (154) incl. new `is_kebab_route_name` / `suggest_kebab_route_name` / `resolve_route_names` / warning-marker tests; trybuild UI (25).
- `cargo fmt --check` clean; `cargo clippy -p reinhardt-macros --all-targets -- -D warnings` and `cargo clippy -p reinhardt-urls --lib -- -D warnings` clean. (Pre-existing `--all-targets` `function_named` deprecation errors are unrelated and reproduce on a clean `develop/0.2.0`.)

Fixes #4901

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compile-time and runtime warnings for non‑kebab-case route names; kebab-case names are now accepted where previously rejected.
  * Opt-out available via a leading "!" on route names or by disabling warnings with an environment toggle.

* **Documentation**
  * Updated macro and URL docs to describe route‑naming rules and opt-out behavior.

* **Tests**
  * Added unit and integration tests covering name normalization, opt-out handling, and warning behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->