### PR TITLE
fix(examples): compose ContactSettings and re-format drifted example files

### DIFF
--- a/examples/examples-tutorial-basis/README.md
+++ b/examples/examples-tutorial-basis/README.md
@@ -136,7 +136,7 @@ examples-tutorial-basis/
 │   ├── bin/
 │   │   └── manage.rs               # Native CLI; `required-features = ["with-reinhardt"]`
 │   ├── config/
-│   │   ├── settings.rs             # `#[settings(core: CoreSettings)] ProjectSettings`
+│   │   ├── settings.rs             # `#[settings(core: CoreSettings | contacts: ContactSettings)] ProjectSettings`
 │   │   │                           # + `SettingsBuilder` composition
 │   │   ├── apps.rs                 # `installed_apps! { polls: "polls", users: "users" }`
 │   │   ├── urls.rs                 # `#[routes(standalone)] routes()` — registers every
@@ -353,7 +353,7 @@ The `mode = client` macro namespaces every `named_route` under `polls:`, so SPA 
 
 ### 4. Configuration (`src/config/*`)
 
-- **`settings.rs`** — `#[settings(core: CoreSettings)] ProjectSettings` composed via `SettingsBuilder` from `DefaultSource`, `LowPriorityEnvSource`, and `TomlFileSource` overlays (`base.toml` + a profile-specific file).
+- **`settings.rs`** — `#[settings(core: CoreSettings | contacts: ContactSettings)] ProjectSettings` composed via `SettingsBuilder` from `DefaultSource`, `LowPriorityEnvSource`, and `TomlFileSource` overlays (`base.toml` + a profile-specific file).
 - **`apps.rs`** — `installed_apps! { polls: "polls", users: "users" }` generates the `InstalledApp` enum consumed by every `#[url_patterns(InstalledApp::<app>, …)]`.
 - **`urls.rs`** — `#[routes(standalone)] routes()` registers all server functions, mounts `/admin/` and `/static/admin/`, and applies `SessionMiddleware` with a two-week TTL.
 - **`wasm.rs`** — submits an `AppStaticFilesConfig` pointing at `dist-wasm/` so `cargo make collectstatic` picks up the WASM bundle.

--- a/examples/examples-tutorial-basis/src/config/settings.rs
+++ b/examples/examples-tutorial-basis/src/config/settings.rs
@@ -6,7 +6,7 @@ use reinhardt::settings;
 use std::env;
 use std::path::PathBuf;
 
-#[settings(core: CoreSettings)]
+#[settings(core: CoreSettings | contacts: ContactSettings)]
 pub struct ProjectSettings;
 
 fn profile_name() -> String {

--- a/examples/examples-tutorial-rest/src/bin/manage.rs
+++ b/examples/examples-tutorial-rest/src/bin/manage.rs
@@ -22,7 +22,8 @@ async fn main() {
 	// Execute command from command line, handing the project's composed
 	// settings to the runtime so database-requiring commands resolve the
 	// connection from settings/*.toml (`[core.databases.default]`).
-	if let Err(e) = execute_from_command_line_with_settings(config::settings::get_settings()).await {
+	if let Err(e) = execute_from_command_line_with_settings(config::settings::get_settings()).await
+	{
 		eprintln!("Error: {}", e);
 		process::exit(1);
 	}

--- a/examples/examples-tutorial-rest/src/config/settings.rs
+++ b/examples/examples-tutorial-rest/src/config/settings.rs
@@ -6,7 +6,7 @@ use reinhardt::settings;
 use std::env;
 use std::path::PathBuf;
 
-#[settings(core: CoreSettings)]
+#[settings(core: CoreSettings | contacts: ContactSettings)]
 pub struct ProjectSettings;
 
 fn profile_name() -> String {

--- a/examples/examples-twitter/src/apps/tweet/client/components.rs
+++ b/examples/examples-twitter/src/apps/tweet/client/components.rs
@@ -34,60 +34,74 @@ fn like_button(liked: Signal<bool>, like_count: Signal<i32>) -> Page {
 	let liked_for_click_else = liked.clone();
 	let like_count_for_click_else = like_count.clone();
 
-	page!(|liked: Signal<bool>, like_count: Signal<i32>, liked_for_click_if: Signal<bool>, like_count_for_click_if: Signal<i32>, liked_for_click_else: Signal<bool>, like_count_for_click_else: Signal<i32>| { {
-		// Read the Copy signal values to local Copy values once in this
-		// single reactive scope, then build the markup via an inner
-		// `page!` that receives the Copy values and handler-signal clones.
-		let is_liked = liked.get();
-		let count = like_count.get();
-		page!(|is_liked: bool, count: i32, liked_for_click_if: Signal<bool>, like_count_for_click_if: Signal<i32>, liked_for_click_else: Signal<bool>, like_count_for_click_else: Signal<i32>| {
-			if is_liked {
-				button {
-					class: "tweet-action-btn text-danger",
-					type: "button",
-					aria_label: "Like",
-					@click: {
-						let liked_for_click = liked_for_click_if.clone();
-						let like_count_for_click = like_count_for_click_if.clone();
-						move |_event| {
-							let current_liked = liked_for_click.get();
-							let current_count = like_count_for_click.get();
-							liked_for_click.set(!current_liked);
-							like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+	page!(|liked: Signal<bool>,
+	       like_count: Signal<i32>,
+	       liked_for_click_if: Signal<bool>,
+	       like_count_for_click_if: Signal<i32>,
+	       liked_for_click_else: Signal<bool>,
+	       like_count_for_click_else: Signal<i32>| {
+		{
+			// Read the Copy signal values to local Copy values once in this
+			// single reactive scope, then build the markup via an inner
+			// `page!` that receives the Copy values and handler-signal clones.
+			let is_liked = liked.get();
+			let count = like_count.get();
+			page!(|is_liked: bool, count: i32, liked_for_click_if: Signal<bool>, like_count_for_click_if: Signal<i32>, liked_for_click_else: Signal<bool>, like_count_for_click_else: Signal<i32>| {
+				if is_liked {
+					button {
+						class: "tweet-action-btn text-danger",
+						type: "button",
+						aria_label: "Like",
+						@click: {
+							let liked_for_click = liked_for_click_if.clone();
+							let like_count_for_click = like_count_for_click_if.clone();
+							move |_event| {
+								let current_liked = liked_for_click.get();
+								let current_count = like_count_for_click.get();
+								liked_for_click.set(!current_liked);
+								like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+							}
+						},
+						{
+							icons::heart_icon_filled()
 						}
-					},
-					{
-						icons::heart_icon_filled()
+						span { {
+							format!("{}", count)
+						} }
 					}
-					span { {
-						format!("{}", count)
-					} }
-				}
-			} else {
-				button {
-					class: "tweet-action-btn hover:text-danger",
-					type: "button",
-					aria_label: "Like",
-					@click: {
-						let liked_for_click = liked_for_click_else.clone();
-						let like_count_for_click = like_count_for_click_else.clone();
-						move |_event| {
-							let current_liked = liked_for_click.get();
-							let current_count = like_count_for_click.get();
-							liked_for_click.set(!current_liked);
-							like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+				} else {
+					button {
+						class: "tweet-action-btn hover:text-danger",
+						type: "button",
+						aria_label: "Like",
+						@click: {
+							let liked_for_click = liked_for_click_else.clone();
+							let like_count_for_click = like_count_for_click_else.clone();
+							move |_event| {
+								let current_liked = liked_for_click.get();
+								let current_count = like_count_for_click.get();
+								liked_for_click.set(!current_liked);
+								like_count_for_click.set(if current_liked { current_count - 1 } else { current_count + 1 });
+							}
+						},
+						{
+							icons::heart_icon_outline()
 						}
-					},
-					{
-						icons::heart_icon_outline()
+						span { {
+							format!("{}", count)
+						} }
 					}
-					span { {
-						format!("{}", count)
-					} }
 				}
-			}
-		})(is_liked, count, liked_for_click_if.clone(), like_count_for_click_if.clone(), liked_for_click_else.clone(), like_count_for_click_else.clone(), )
-	} })(
+			})(
+				is_liked,
+				count,
+				liked_for_click_if.clone(),
+				like_count_for_click_if.clone(),
+				liked_for_click_else.clone(),
+				like_count_for_click_else.clone(),
+			)
+		}
+	})(
 		liked,
 		like_count,
 		liked_for_click_if,
@@ -128,18 +142,23 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 	// Clone for error display watch block (separate closure from main watch block)
 	let delete_action_for_error = delete_action.clone();
 
-	page!(|delete_action: Action<(), String>, show_delete: bool, username: String, content: String, created_at: String, tweet_id: Uuid, liked_signal: Signal<bool>, like_count_signal: Signal<i32>, delete_action_for_click: Action<(), String>, delete_action_for_error: Action<(), String>| {
+	page!(|delete_action: Action<(), String>,
+	       show_delete: bool,
+	       username: String,
+	       content: String,
+	       created_at: String,
+	       tweet_id: Uuid,
+	       liked_signal: Signal<bool>,
+	       like_count_signal: Signal<i32>,
+	       delete_action_for_click: Action<(), String>,
+	       delete_action_for_error: Action<(), String>| {
 		// Main card body: a single reactive scope that reads the Copy
 		// `is_success` flag once and builds each branch via an inner
 		// `page!`, passing the owned String/Signal/Action values as the
 		// inner closure's own parameters (avoids E0507 from nested scopes).
 		{
 			if delete_action.is_success() {
-				page!(|| {
-					div {
-						class: "hidden"
-					}
-				})()
+				page!(|| { div { class: "hidden" } })()
 			} else {
 				page!(|show_delete: bool, username_avatar: String, username_name: String, username_handle: String, content: String, created_at: String, tweet_id: Uuid, liked_signal: Signal<bool>, like_count_signal: Signal<i32>, delete_action_for_click: Action<(), String>| {
 					div {
@@ -242,20 +261,34 @@ pub fn tweet_card(tweet: &TweetInfo, show_delete: bool) -> Page {
 							}
 						}
 					}
-				})(show_delete, username.clone(), username.clone(), username.clone(), content.clone(), created_at.clone(), tweet_id, liked_signal.clone(), like_count_signal.clone(), delete_action_for_click.clone(), )
+				})(
+					show_delete,
+					username.clone(),
+					username.clone(),
+					username.clone(),
+					content.clone(),
+					created_at.clone(),
+					tweet_id,
+					liked_signal.clone(),
+					like_count_signal.clone(),
+					delete_action_for_click.clone(),
+				)
 			}
-		}// Error alert: a single optional banner built via `.map(...)`.
+		} // Error alert: a single optional banner built via `.map(...)`.
 		{
-			delete_action_for_error.error().map(|error_message| {
-				page!(|error_message: String| {
-					div {
-						class: "alert-danger mt-3",
-						{ {
-							error_message.clone()
-						} }
-					}
-				})(error_message)
-			}).unwrap_or_else(Page::empty)
+			delete_action_for_error
+				.error()
+				.map(|error_message| {
+					page!(|error_message: String| {
+						div {
+							class: "alert-danger mt-3",
+							{ {
+								error_message.clone()
+							} }
+						}
+					})(error_message)
+				})
+				.unwrap_or_else(Page::empty)
 		}
 	})(
 		delete_action,

--- a/examples/examples-twitter/src/config/settings.rs
+++ b/examples/examples-twitter/src/config/settings.rs
@@ -40,7 +40,7 @@ use reinhardt::settings;
 use std::env;
 use std::path::PathBuf;
 
-#[settings(core: CoreSettings)]
+#[settings(core: CoreSettings | contacts: ContactSettings)]
 pub struct ProjectSettings;
 
 /// Get the active environment profile name.

--- a/examples/examples-twitter/src/core/client/components/layout.rs
+++ b/examples/examples-twitter/src/core/client/components/layout.rs
@@ -95,9 +95,9 @@ pub fn header(site_name: &str, current_user: Option<&UserInfo>, nav_items: &[Nav
 		})
 		.collect();
 	let nav_links_view = page!(|nav_links: Vec<Page>| {
-		for link in nav_links.clone() { {
-			link.clone()
-		} }
+		for link in nav_links.clone() {
+			{ link.clone() }
+		}
 	})(nav_links);
 	let brand_link = Link::new("/".to_string(), site_name.to_string())
 		.class("text-xl font-bold text-content-primary hover:text-brand transition-colors")
@@ -229,9 +229,9 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|topics_list: Vec<Page>| {
-			for topic in topics_list.clone() { {
-				topic.clone()
-			} }
+			for topic in topics_list.clone() {
+				{ topic.clone() }
+			}
 		})(topics_list)
 	};
 	let users_list: Vec<Page> = suggested_users
@@ -303,9 +303,9 @@ pub fn sidebar(trending_topics: &[TrendingTopic], suggested_users: &[SuggestedUs
 		})()
 	} else {
 		page!(|users_list: Vec<Page>| {
-			for user in users_list.clone() { {
-				user.clone()
-			} }
+			for user in users_list.clone() {
+				{ user.clone() }
+			}
 		})(users_list)
 	};
 	page!(|topics_view: Page, users_view: Page| {


### PR DESCRIPTION
## Summary

This PR addresses:

- The 0.2.0 management-command entry point `execute_from_command_line_with_settings` requires `S: HasCommonSettings` (= `HasCoreSettings + HasContactSettings`). All three examples composed only `#[settings(core: CoreSettings)]`, so `ProjectSettings` lacked `HasSettings<ContactSettings>` and `bin/manage.rs` failed to compile (`E0277`). Added the `contacts: ContactSettings` fragment to each example's composed settings.
- Three example source files had drifted from `reinhardt-admin fmt` output (the formatter run by the Examples Tests CI). Re-formatted them so `fmt-check` passes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

This PR only fixes the example applications and one example README; it changes no public API.

## Motivation and Context

The Examples Tests (Standalone) workflow on the release-plz PR #5058 (run 26683210416) failed across all three example jobs:

- `examples-tutorial-basis` — `E0277: ProjectSettings: HasCommonSettings is not satisfied` at `bin/manage.rs` (the missing fragment is `HasSettings<ContactSettings>`).
- `examples-tutorial-rest` / `examples-twitter` — `reinhardt-admin fmt . --check` reported drifted files (`manage.rs`; `layout.rs` + `tweet/client/components.rs`). These jobs fail at the fmt step before reaching compile, but their settings would hit the same `E0277` once fmt passes, so the fragment is added to all three.

Related to: #5058

## How Was This Tested?

- `reinhardt-admin fmt examples/<each> --check` (the exact command the CI runs, built from this branch's `reinhardt-admin-cli` source) reports `0 would be formatted` for all three examples.
- The `contacts: ContactSettings` composition was verified against the framework source: `HasCommonSettings` blanket-impls for `HasCoreSettings + HasContactSettings + Send + Sync + 'static`, and `#[settings(... | contacts: ContactSettings)]` generates the bridging `HasSettings<ContactSettings>` impl, satisfying the `execute_from_command_line_with_settings` bound. The framework's own `cli.rs` doc example uses both `core` and `contacts`.
- Formatter changes preserve token content (identical non-whitespace character counts); only whitespace/brace placement changed.

## Checklist

- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`

## Related Issues

- Unblocks the Examples Tests on release-plz PR #5058

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `examples`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Configuration schemas updated to include contact settings alongside core settings across example projects.
  * Component templates and error handling blocks restructured with explicit multiline formatting.

* **Style**
  * Code formatting standardized throughout components and configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->