### PR TITLE
fix(ci): unescape bash negation in detect-affected-packages examples gate

### DIFF
--- a/.github/workflows/detect-affected-packages.yml
+++ b/.github/workflows/detect-affected-packages.yml
@@ -88,7 +88,7 @@ jobs:
             echo "run-examples=true" >> "$GITHUB_OUTPUT"
           else
             if [[ -n "${PR_NUMBER:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
-              if \! GH_OUT=$(gh api \
+              if ! GH_OUT=$(gh api \
                   "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
                   --paginate --jq '.[].filename'); then
                 echo "::error::gh api call failed: repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" >&2


### PR DESCRIPTION
## Summary

This PR addresses:

- Remove the erroneous backslash in `if \! GH_OUT=$(gh api ...)` (now `if ! ...`) in `.github/workflows/detect-affected-packages.yml`, restoring the bash negation operator in the `Detect examples changes` step.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

No. This is a CI workflow fix with no public API impact.

## Motivation and Context

The `Detect examples changes` step escaped the bash negation operator as `\!`. Bash parses `\!` as a literal command named `!`, which caused three failures:

1. `! GH_OUT=$(gh api ...)` set `GH_OUT` only in the failed command's environment, so the outer shell's `GH_OUT` was always empty.
2. `!` exits 127 (command not found), so the `if` condition was always false and the intended `exit 1` gh-api error guard became dead code.
3. `CHANGED=$(echo "$GH_OUT" | grep '^examples/' ...)` therefore always evaluated empty, yielding `run-examples=false`.

Net effect: for any non-release PR that changes only `examples/**`, the **Examples Tests** job was silently skipped, so example-side regressions (formatting drift, compile errors) were never caught on those PRs and only surfaced on `develop-release-plz-*` / `release-plz-*` regeneration runs (which force `run-all=true`).

Introduced in `d4766a54fa` ("ci: fail explicitly on gh api errors instead of silently swallowing them"); the escaping defeated the very behavior that commit intended to add.

Fixes #5062

Related to: #1828

## How Was This Tested?

Reproduced the bash parsing difference locally:

```bash
# Broken (current main): prints "!: command not found", OUT empty -> run-examples=false
bash -ec 'if \! OUT=$(printf "examples/x\n"); then echo ERR; fi; echo "[$OUT]"'

# Fixed (this PR): OUT captured -> CHANGED non-empty -> run-examples=true
bash -ec 'if ! OUT=$(printf "examples/x\n"); then echo ERR; fi; echo "[$OUT]"'
```

Confirmed the live failure in run 26686064633 (PR #5060): the `Detect examples changes` step logged `!: command not found` and set `RUN_EXAMPLES: false` despite 7 changed files all under `examples/`, so `Examples Tests` was skipped.

`detect-affected-packages.yml` parses as valid YAML after the change (`yaml.safe_load`).

## Related Issues

- Fixes #5062
- Related to #1828 (introduced the `run-examples` gating logic)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label
- [x] `high` - Important fix or feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration for improved build process reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-web/pull/5063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->