### PR TITLE
feat: deprecate XxxConfig structs in favor of #[settings] fragments

### DIFF
--- a/crates/reinhardt-apps/src/lib.rs
+++ b/crates/reinhardt-apps/src/lib.rs
@@ -112,7 +112,11 @@ pub use reinhardt_http::{Request, Response, StreamBody, StreamingResponse};
 
 // Re-export from reinhardt-conf (native-only: pulls in tokio runtime).
 #[cfg(native)]
-pub use reinhardt_conf::settings::{DatabaseConfig, MiddlewareConfig, TemplateConfig};
+pub use reinhardt_conf::settings::{DatabaseConfig, MiddlewareConfig};
+// `TemplateConfig` is deprecated in favor of the `TemplateSettings` fragment;
+// keep the re-export available during the 0.2 compatibility window.
+#[allow(deprecated)]
+pub use reinhardt_conf::settings::TemplateConfig;
 
 // Re-export from reinhardt-core::exception (cross-target).
 pub use reinhardt_core::exception::{Error, Result};

--- a/crates/reinhardt-apps/src/lib.rs
+++ b/crates/reinhardt-apps/src/lib.rs
@@ -115,6 +115,7 @@ pub use reinhardt_http::{Request, Response, StreamBody, StreamingResponse};
 pub use reinhardt_conf::settings::{DatabaseConfig, MiddlewareConfig};
 // `TemplateConfig` is deprecated in favor of the `TemplateSettings` fragment;
 // keep the re-export available during the 0.2 compatibility window.
+#[cfg(native)]
 #[allow(deprecated)]
 pub use reinhardt_conf::settings::TemplateConfig;
 

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -67,6 +67,7 @@ full = [
 
 [dependencies]
 reinhardt-auth-macros = { workspace = true }
+reinhardt-conf = { workspace = true }
 reinhardt-core = { workspace = true, features = ["exception", "macros", "types"] }
 reinhardt-di = { workspace = true }
 reinhardt-db = { workspace = true, features = ["migrations", "orm"] }

--- a/crates/reinhardt-auth/src/lib.rs
+++ b/crates/reinhardt-auth/src/lib.rs
@@ -174,6 +174,9 @@ pub mod token_storage;
 /// User CRUD management.
 pub mod user_management;
 
+/// Settings fragments for authentication backends.
+pub mod settings;
+
 pub use advanced_permissions::{ObjectPermission as AdvancedObjectPermission, RoleBasedPermission};
 pub use base_user_manager::BaseUserManager;
 pub use basic::BasicAuthentication as HttpBasicAuth;
@@ -234,7 +237,17 @@ pub use token_blacklist::{
 	InMemoryTokenBlacklist, RefreshToken, RefreshTokenStore, TokenBlacklist, TokenRotationManager,
 };
 #[cfg(any(feature = "jwt", feature = "token"))]
+#[allow(deprecated)] // Re-export keeps the compatibility API discoverable during the 0.2 line.
 pub use token_rotation::{AutoTokenRotationManager, TokenRotationConfig, TokenRotationRecord};
+
+#[cfg(feature = "sessions")]
+pub use settings::SessionSettings;
+
+#[cfg(feature = "jwt")]
+pub use settings::{JwtSessionSettings, create_jwt_session_backend_from_settings};
+
+#[cfg(feature = "token")]
+pub use settings::{TokenRotationSettings, create_token_rotation_manager_from_settings};
 #[cfg(all(feature = "database", any(feature = "jwt", feature = "token")))]
 pub use token_storage::DatabaseTokenStorage;
 #[cfg(any(feature = "jwt", feature = "token"))]

--- a/crates/reinhardt-auth/src/sessions.rs
+++ b/crates/reinhardt-auth/src/sessions.rs
@@ -75,6 +75,7 @@ pub use backends::DatabaseSessionBackend;
 pub use backends::FileSessionBackend;
 
 #[cfg(feature = "jwt")]
+#[allow(deprecated)] // Re-export keeps the compatibility API discoverable during the 0.2 line.
 pub use backends::{JwtConfig, JwtSessionBackend};
 
 pub use cleanup::{CleanupConfig, CleanupableBackend, SessionCleanupTask, SessionMetadata};

--- a/crates/reinhardt-auth/src/sessions/backends.rs
+++ b/crates/reinhardt-auth/src/sessions/backends.rs
@@ -76,4 +76,5 @@ pub use file::FileSessionBackend;
 pub use cookie::CookieSessionBackend;
 
 #[cfg(feature = "jwt")]
+#[allow(deprecated)] // Re-export keeps the compatibility API discoverable during the 0.2 line.
 pub use jwt::{JwtConfig, JwtSessionBackend};

--- a/crates/reinhardt-auth/src/sessions/backends/jwt.rs
+++ b/crates/reinhardt-auth/src/sessions/backends/jwt.rs
@@ -44,6 +44,8 @@
 //! # }
 //! ```
 
+#![allow(deprecated)] // JwtSessionBackend holds a JwtConfig during the compatibility window.
+
 use async_trait::async_trait;
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use serde::{Deserialize, Serialize};
@@ -128,6 +130,10 @@ fn validate_hmac_key_length(algorithm: Algorithm, secret: &str) -> Result<(), Jw
 ///     .with_issuer("my-app".to_string())
 ///     .with_audience("web-users".to_string());
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `JwtSessionSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct JwtConfig {
 	/// Secret key for signing tokens (for HS256, HS512, etc.)

--- a/crates/reinhardt-auth/src/sessions/config.rs
+++ b/crates/reinhardt-auth/src/sessions/config.rs
@@ -29,6 +29,8 @@
 //! assert!(config.cookie_secure());
 //! ```
 
+#![allow(deprecated)] // SessionConfigBuilder builds the deprecated SessionConfig during the compatibility window.
+
 use std::time::Duration;
 
 /// SameSite cookie attribute
@@ -104,6 +106,10 @@ impl SameSite {
 ///     .cookie_secure(true)
 ///     .build();
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `SessionSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct SessionConfig {
 	/// Name of the session cookie

--- a/crates/reinhardt-auth/src/settings.rs
+++ b/crates/reinhardt-auth/src/settings.rs
@@ -1,0 +1,414 @@
+//! Settings fragments for authentication backends.
+//!
+//! These fragments map authentication configuration onto the Reinhardt
+//! `#[settings]` macro. Each fragment owns a globally unique section (prefixed
+//! with `auth_`) and converts into the matching legacy `XxxConfig` value during
+//! the 0.2 compatibility window. New code should prefer the fragments and the
+//! `create_*_from_settings` constructors.
+
+#![allow(deprecated)] // Conversions target legacy config types during the compatibility window.
+
+#[cfg(any(feature = "sessions", feature = "jwt", feature = "token"))]
+use serde::{Deserialize, Serialize};
+
+// --- session --------------------------------------------------------------
+
+#[cfg(feature = "sessions")]
+mod session_settings {
+	use super::*;
+	use crate::sessions::config::{SameSite, SessionConfig};
+	use reinhardt_core::macros::settings;
+	use std::time::Duration;
+
+	fn default_cookie_name() -> String {
+		"sessionid".to_string()
+	}
+
+	fn default_cookie_path() -> String {
+		"/".to_string()
+	}
+
+	fn default_cookie_secure() -> bool {
+		true
+	}
+
+	fn default_cookie_httponly() -> bool {
+		true
+	}
+
+	fn default_cookie_samesite() -> String {
+		"lax".to_string()
+	}
+
+	/// Parse a SameSite policy string into the legacy [`SameSite`] enum.
+	///
+	/// Unknown values fall back to the secure default (`Lax`).
+	fn parse_samesite(value: &str) -> SameSite {
+		match value.to_ascii_lowercase().as_str() {
+			"strict" => SameSite::Strict,
+			"none" => SameSite::None,
+			_ => SameSite::Lax,
+		}
+	}
+
+	/// Session configuration fragment.
+	///
+	/// Maps to the `[auth_session]` section and composes with the `#[settings]`
+	/// macro. Convert into the deprecated [`SessionConfig`] via [`to_config`].
+	///
+	/// The session cookie max age is expressed as `cookie_age_secs` (an integer
+	/// number of seconds). `None` means a browser-session cookie.
+	///
+	/// [`to_config`]: SessionSettings::to_config
+	#[settings(fragment = true, section = "auth_session")]
+	#[derive(Clone, Debug, Serialize, Deserialize)]
+	pub struct SessionSettings {
+		/// Name of the session cookie.
+		#[serde(default = "default_cookie_name")]
+		pub cookie_name: String,
+		/// Maximum cookie age, in seconds. `None` yields a session cookie.
+		#[serde(default)]
+		pub cookie_age_secs: Option<u64>,
+		/// Cookie path.
+		#[serde(default = "default_cookie_path")]
+		pub cookie_path: String,
+		/// Cookie domain. `None` uses the current domain.
+		#[serde(default)]
+		pub cookie_domain: Option<String>,
+		/// Whether the cookie sets the `Secure` flag (HTTPS only).
+		#[serde(default = "default_cookie_secure")]
+		pub cookie_secure: bool,
+		/// Whether the cookie sets the `HttpOnly` flag.
+		#[serde(default = "default_cookie_httponly")]
+		pub cookie_httponly: bool,
+		/// SameSite policy: `"strict"`, `"lax"`, or `"none"`.
+		#[serde(default = "default_cookie_samesite")]
+		pub cookie_samesite: String,
+		/// Whether to save the session on every request.
+		#[serde(default)]
+		pub save_every_request: bool,
+	}
+
+	impl Default for SessionSettings {
+		fn default() -> Self {
+			Self {
+				cookie_name: default_cookie_name(),
+				cookie_age_secs: None,
+				cookie_path: default_cookie_path(),
+				cookie_domain: None,
+				cookie_secure: default_cookie_secure(),
+				cookie_httponly: default_cookie_httponly(),
+				cookie_samesite: default_cookie_samesite(),
+				save_every_request: false,
+			}
+		}
+	}
+
+	impl SessionSettings {
+		/// Convert these settings into the deprecated compatibility config.
+		///
+		/// The legacy [`SessionConfig`] uses private fields, so the conversion
+		/// rebuilds it through [`SessionConfig::builder`].
+		pub fn to_config(&self) -> SessionConfig {
+			let mut builder = SessionConfig::builder()
+				.cookie_name(self.cookie_name.clone())
+				.cookie_path(self.cookie_path.clone())
+				.cookie_secure(self.cookie_secure)
+				.cookie_httponly(self.cookie_httponly)
+				.cookie_samesite(parse_samesite(&self.cookie_samesite))
+				.save_every_request(self.save_every_request);
+			if let Some(secs) = self.cookie_age_secs {
+				builder = builder.cookie_age(Duration::from_secs(secs));
+			}
+			if let Some(domain) = &self.cookie_domain {
+				builder = builder.cookie_domain(domain.clone());
+			}
+			builder.build()
+		}
+	}
+
+	impl From<&SessionSettings> for SessionConfig {
+		fn from(settings: &SessionSettings) -> Self {
+			settings.to_config()
+		}
+	}
+}
+
+#[cfg(feature = "sessions")]
+pub use session_settings::SessionSettings;
+
+// --- jwt session backend --------------------------------------------------
+
+#[cfg(feature = "jwt")]
+mod jwt_session_settings {
+	use super::*;
+	use crate::sessions::backends::jwt::{JwtConfig, JwtSessionBackend, JwtSessionError};
+	use jsonwebtoken::Algorithm;
+	use reinhardt_core::macros::settings;
+
+	fn default_algorithm() -> String {
+		"HS256".to_string()
+	}
+
+	fn default_expiration() -> u64 {
+		3600 // 1 hour
+	}
+
+	/// Parse a JWT algorithm string into the [`Algorithm`] enum.
+	///
+	/// `jsonwebtoken::Algorithm` is not `serde`-serializable in this version,
+	/// so the fragment stores the algorithm as a string and maps it here.
+	/// Unknown values fall back to the default `HS256`.
+	fn parse_algorithm(value: &str) -> Algorithm {
+		match value.to_ascii_uppercase().as_str() {
+			"HS384" => Algorithm::HS384,
+			"HS512" => Algorithm::HS512,
+			_ => Algorithm::HS256,
+		}
+	}
+
+	/// JWT session backend configuration fragment.
+	///
+	/// Maps to the `[auth_jwt_session]` section and composes with the
+	/// `#[settings]` macro. Convert into the deprecated [`JwtConfig`] via
+	/// [`to_config`].
+	///
+	/// The HMAC secret length is validated when the backend is constructed
+	/// (see [`create_jwt_session_backend_from_settings`]), not when the
+	/// fragment is parsed, matching the legacy [`JwtSessionBackend::new`]
+	/// behavior.
+	///
+	/// [`to_config`]: JwtSessionSettings::to_config
+	#[settings(fragment = true, section = "auth_jwt_session")]
+	#[derive(Clone, Debug, Serialize, Deserialize)]
+	pub struct JwtSessionSettings {
+		/// Secret key used for HMAC signing.
+		#[serde(default)]
+		pub secret: String,
+		/// JWT signing algorithm: `"HS256"`, `"HS384"`, or `"HS512"`.
+		#[serde(default = "default_algorithm")]
+		pub algorithm: String,
+		/// Default token expiration, in seconds.
+		#[serde(default = "default_expiration")]
+		pub expiration: u64,
+		/// Token issuer.
+		#[serde(default)]
+		pub issuer: Option<String>,
+		/// Token audience.
+		#[serde(default)]
+		pub audience: Option<String>,
+	}
+
+	impl Default for JwtSessionSettings {
+		fn default() -> Self {
+			Self {
+				secret: String::new(),
+				algorithm: default_algorithm(),
+				expiration: default_expiration(),
+				issuer: None,
+				audience: None,
+			}
+		}
+	}
+
+	impl JwtSessionSettings {
+		/// Convert these settings into the deprecated compatibility config.
+		pub fn to_config(&self) -> JwtConfig {
+			JwtConfig {
+				secret: self.secret.clone(),
+				algorithm: parse_algorithm(&self.algorithm),
+				expiration: self.expiration,
+				issuer: self.issuer.clone(),
+				audience: self.audience.clone(),
+			}
+		}
+	}
+
+	impl From<&JwtSessionSettings> for JwtConfig {
+		fn from(settings: &JwtSessionSettings) -> Self {
+			settings.to_config()
+		}
+	}
+
+	/// Build a [`JwtSessionBackend`] from a [`JwtSessionSettings`] fragment.
+	///
+	/// Returns an error if the configured HMAC secret is too short for the
+	/// selected algorithm, preserving the legacy validation performed by
+	/// [`JwtSessionBackend::new`].
+	pub fn create_jwt_session_backend_from_settings(
+		settings: &JwtSessionSettings,
+	) -> Result<JwtSessionBackend, JwtSessionError> {
+		JwtSessionBackend::new(settings.to_config())
+	}
+}
+
+#[cfg(feature = "jwt")]
+pub use jwt_session_settings::{JwtSessionSettings, create_jwt_session_backend_from_settings};
+
+// --- token rotation -------------------------------------------------------
+
+#[cfg(feature = "token")]
+mod token_rotation_settings {
+	use super::*;
+	use crate::token_rotation::{AutoTokenRotationManager, TokenRotationConfig};
+	use reinhardt_core::macros::settings;
+
+	fn default_rotation_interval() -> i64 {
+		3600 // 1 hour
+	}
+
+	fn default_grace_period() -> i64 {
+		300 // 5 minutes
+	}
+
+	fn default_max_active_tokens() -> usize {
+		5
+	}
+
+	/// Token rotation configuration fragment.
+	///
+	/// Maps to the `[auth_token_rotation]` section and composes with the
+	/// `#[settings]` macro. Convert into the deprecated [`TokenRotationConfig`]
+	/// via [`to_config`].
+	///
+	/// [`to_config`]: TokenRotationSettings::to_config
+	#[settings(fragment = true, section = "auth_token_rotation")]
+	#[derive(Clone, Debug, Serialize, Deserialize)]
+	pub struct TokenRotationSettings {
+		/// Interval, in seconds, between rotations.
+		#[serde(default = "default_rotation_interval")]
+		pub rotation_interval: i64,
+		/// Grace period, in seconds, during which the old token stays valid.
+		#[serde(default = "default_grace_period")]
+		pub grace_period: i64,
+		/// Maximum number of active tokens per user.
+		#[serde(default = "default_max_active_tokens")]
+		pub max_active_tokens: usize,
+		/// Whether to rotate the token on every use.
+		#[serde(default)]
+		pub rotate_on_use: bool,
+	}
+
+	impl Default for TokenRotationSettings {
+		fn default() -> Self {
+			Self {
+				rotation_interval: default_rotation_interval(),
+				grace_period: default_grace_period(),
+				max_active_tokens: default_max_active_tokens(),
+				rotate_on_use: false,
+			}
+		}
+	}
+
+	impl TokenRotationSettings {
+		/// Convert these settings into the deprecated compatibility config.
+		pub fn to_config(&self) -> TokenRotationConfig {
+			TokenRotationConfig {
+				rotation_interval: self.rotation_interval,
+				grace_period: self.grace_period,
+				max_active_tokens: self.max_active_tokens,
+				rotate_on_use: self.rotate_on_use,
+			}
+		}
+	}
+
+	impl From<&TokenRotationSettings> for TokenRotationConfig {
+		fn from(settings: &TokenRotationSettings) -> Self {
+			settings.to_config()
+		}
+	}
+
+	/// Build an [`AutoTokenRotationManager`] from a [`TokenRotationSettings`]
+	/// fragment.
+	pub fn create_token_rotation_manager_from_settings(
+		settings: &TokenRotationSettings,
+	) -> AutoTokenRotationManager {
+		AutoTokenRotationManager::new(settings.to_config())
+	}
+}
+
+#[cfg(feature = "token")]
+pub use token_rotation_settings::{
+	TokenRotationSettings, create_token_rotation_manager_from_settings,
+};
+
+#[cfg(test)]
+mod tests {
+	#[cfg(feature = "sessions")]
+	#[test]
+	fn session_settings_default_matches_legacy_config() {
+		use super::SessionSettings;
+		use crate::sessions::config::SessionConfig;
+
+		let from_settings = SessionSettings::default().to_config();
+		let legacy = SessionConfig::default();
+
+		assert_eq!(from_settings.cookie_name(), legacy.cookie_name());
+		assert_eq!(from_settings.cookie_age(), legacy.cookie_age());
+		assert_eq!(from_settings.cookie_path(), legacy.cookie_path());
+		assert_eq!(from_settings.cookie_domain(), legacy.cookie_domain());
+		assert_eq!(from_settings.cookie_secure(), legacy.cookie_secure());
+		assert_eq!(from_settings.cookie_httponly(), legacy.cookie_httponly());
+		assert_eq!(from_settings.cookie_samesite(), legacy.cookie_samesite());
+		assert_eq!(
+			from_settings.save_every_request(),
+			legacy.save_every_request()
+		);
+	}
+
+	#[cfg(feature = "sessions")]
+	#[test]
+	fn session_settings_round_trips_samesite_and_age() {
+		use super::SessionSettings;
+		use crate::sessions::config::SameSite;
+		use std::time::Duration;
+
+		let settings = SessionSettings {
+			cookie_samesite: "strict".to_string(),
+			cookie_age_secs: Some(7200),
+			cookie_domain: Some("example.com".to_string()),
+			..SessionSettings::default()
+		};
+
+		let config = settings.to_config();
+		assert_eq!(config.cookie_samesite(), SameSite::Strict);
+		assert_eq!(config.cookie_age(), Some(Duration::from_secs(7200)));
+		assert_eq!(config.cookie_domain(), Some("example.com"));
+	}
+
+	#[cfg(feature = "jwt")]
+	#[test]
+	fn jwt_session_settings_default_matches_legacy_config() {
+		use super::JwtSessionSettings;
+		use crate::sessions::backends::jwt::JwtConfig;
+		use jsonwebtoken::Algorithm;
+
+		let settings = JwtSessionSettings::default();
+		let config = settings.to_config();
+		// The legacy `JwtConfig::new` default carries the same algorithm,
+		// expiration, and empty optional fields.
+		let legacy = JwtConfig::new(String::new());
+
+		assert_eq!(config.secret, settings.secret);
+		assert_eq!(config.algorithm, Algorithm::HS256);
+		assert_eq!(config.algorithm, legacy.algorithm);
+		assert_eq!(config.expiration, legacy.expiration);
+		assert_eq!(config.issuer, legacy.issuer);
+		assert_eq!(config.audience, legacy.audience);
+	}
+
+	#[cfg(feature = "token")]
+	#[test]
+	fn token_rotation_settings_default_matches_legacy_config() {
+		use super::TokenRotationSettings;
+		use crate::token_rotation::TokenRotationConfig;
+
+		let from_settings = TokenRotationSettings::default().to_config();
+		let legacy = TokenRotationConfig::default();
+
+		assert_eq!(from_settings.rotation_interval, legacy.rotation_interval);
+		assert_eq!(from_settings.grace_period, legacy.grace_period);
+		assert_eq!(from_settings.max_active_tokens, legacy.max_active_tokens);
+		assert_eq!(from_settings.rotate_on_use, legacy.rotate_on_use);
+	}
+}

--- a/crates/reinhardt-auth/src/token_rotation.rs
+++ b/crates/reinhardt-auth/src/token_rotation.rs
@@ -3,6 +3,8 @@
 //! Provides automatic token rotation capabilities to enhance security
 //! by regularly refreshing authentication tokens.
 
+#![allow(deprecated)] // AutoTokenRotationManager holds a TokenRotationConfig during the compatibility window.
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -19,6 +21,10 @@ use tokio::sync::RwLock;
 ///     .rotation_interval(3600)  // 1 hour
 ///     .grace_period(300);       // 5 minutes
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `TokenRotationSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenRotationConfig {
 	/// Interval in seconds between rotations

--- a/crates/reinhardt-conf/src/lib.rs
+++ b/crates/reinhardt-conf/src/lib.rs
@@ -70,7 +70,12 @@ pub mod settings;
 
 // Re-export commonly used types at the crate root for convenience
 #[cfg(feature = "settings")]
-pub use settings::{DatabaseConfig, MiddlewareConfig, TemplateConfig};
+pub use settings::{DatabaseConfig, MiddlewareConfig};
+// `TemplateConfig` is deprecated in favor of the `TemplateSettings` fragment;
+// keep the re-export discoverable during the compatibility window.
+#[cfg(feature = "settings")]
+#[allow(deprecated)]
+pub use settings::TemplateConfig;
 
 // Re-export third-party types used in macro-generated code.
 // The `#[settings(...)]` composition macro generates `ComposedSettings` impls

--- a/crates/reinhardt-conf/src/settings.rs
+++ b/crates/reinhardt-conf/src/settings.rs
@@ -3,6 +3,10 @@
 //! Django-inspired settings system for Reinhardt projects.
 //! This module provides configuration management for Reinhardt applications.
 
+// The `From<&FragmentTemplateConfig>` bridge below names the deprecated
+// `TemplateConfig` during the 0.2 compatibility window.
+#![allow(deprecated)]
+
 pub mod advanced;
 pub mod builder;
 pub mod cache;
@@ -129,6 +133,15 @@ pub use composed::ComposedSettings;
 pub use builder::MergeStrategy;
 
 /// Template engine configuration
+///
+/// Deprecated in favor of the [`TemplateSettings`](template_settings::TemplateSettings)
+/// fragment (and its nested [`FragmentTemplateConfig`](template_settings::FragmentTemplateConfig)
+/// value object), which compose with the `#[settings]` macro. A
+/// [`From<&FragmentTemplateConfig>`] bridge is provided for migration.
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `TemplateSettings` with the `#[settings]` macro instead."
+)]
 #[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TemplateConfig {
@@ -206,6 +219,31 @@ impl Default for TemplateConfig {
 			options,
 		}
 	}
+}
+
+impl From<&template_settings::FragmentTemplateConfig> for TemplateConfig {
+	/// Bridge a settings-fragment template config into the deprecated
+	/// compatibility [`TemplateConfig`] during the 0.2 migration window.
+	fn from(settings: &template_settings::FragmentTemplateConfig) -> Self {
+		Self {
+			backend: settings.backend.clone(),
+			dirs: settings.dirs.clone(),
+			app_dirs: settings.app_dirs,
+			options: settings.options.clone(),
+		}
+	}
+}
+
+/// Build the deprecated [`TemplateConfig`] list from a [`TemplateSettings`]
+/// fragment.
+///
+/// Prefer the [`TemplateSettings`](template_settings::TemplateSettings) fragment
+/// directly in new code; this helper exists to ease migration off the legacy
+/// `TemplateConfig` type.
+pub fn create_template_configs_from_settings(
+	settings: &template_settings::TemplateSettings,
+) -> Vec<TemplateConfig> {
+	settings.configs.iter().map(TemplateConfig::from).collect()
 }
 
 /// Middleware configuration

--- a/crates/reinhardt-conf/src/settings.rs
+++ b/crates/reinhardt-conf/src/settings.rs
@@ -234,8 +234,8 @@ impl From<&template_settings::FragmentTemplateConfig> for TemplateConfig {
 	}
 }
 
-/// Build the deprecated [`TemplateConfig`] list from a [`TemplateSettings`]
-/// fragment.
+/// Build the deprecated [`TemplateConfig`] list from a
+/// [`TemplateSettings`](template_settings::TemplateSettings) fragment.
 ///
 /// Prefer the [`TemplateSettings`](template_settings::TemplateSettings) fragment
 /// directly in new code; this helper exists to ease migration off the legacy

--- a/crates/reinhardt-conf/src/settings/prelude.rs
+++ b/crates/reinhardt-conf/src/settings/prelude.rs
@@ -25,7 +25,11 @@ pub use super::validation::{
 	ChoiceValidator, PatternValidator, RangeValidator, RequiredValidator, SecurityValidator,
 	SettingsValidator, ValidationError, ValidationResult, Validator,
 };
-pub use super::{DatabaseConfig, MiddlewareConfig, TemplateConfig};
+pub use super::{DatabaseConfig, MiddlewareConfig};
+// `TemplateConfig` is deprecated in favor of the `TemplateSettings` fragment;
+// keep it in the prelude for the compatibility window.
+#[allow(deprecated)]
+pub use super::TemplateConfig;
 
 // Dynamic settings (async feature)
 #[cfg(feature = "async")]

--- a/crates/reinhardt-conf/tests/settings_builder.rs
+++ b/crates/reinhardt-conf/tests/settings_builder.rs
@@ -2,6 +2,10 @@
 // Covers: default values, overrides, validation, database config, middleware config,
 // installed apps, profile, and error cases.
 
+// `TemplateConfig` is deprecated in favor of the `TemplateSettings` fragment;
+// these tests still exercise the legacy type during the compatibility window.
+#![allow(deprecated)]
+
 use reinhardt_conf::settings::builder::SettingsBuilder;
 use reinhardt_conf::settings::profile::Profile;
 use reinhardt_conf::settings::sources::DefaultSource;

--- a/crates/reinhardt-deeplink/Cargo.toml
+++ b/crates/reinhardt-deeplink/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 
 [dependencies]
 # Core framework
+reinhardt-conf = { workspace = true, features = ["settings"] }
 reinhardt-core = { workspace = true }
 reinhardt-http = { workspace = true }
 reinhardt-urls = { workspace = true }

--- a/crates/reinhardt-deeplink/src/config.rs
+++ b/crates/reinhardt-deeplink/src/config.rs
@@ -7,6 +7,9 @@
 //! - [`CustomSchemeConfig`] - Custom URL scheme configuration
 //! - [`DeeplinkConfig`] - Unified configuration combining all platforms
 
+// `DeeplinkConfig` (defined below) is deprecated in favor of the `#[settings]`
+// fragments but is still defined and constructed in this module during the 0.2
+// compatibility window. Remove this allowance once `DeeplinkConfig` is deleted.
 #![allow(deprecated)]
 
 pub mod android;

--- a/crates/reinhardt-deeplink/src/config.rs
+++ b/crates/reinhardt-deeplink/src/config.rs
@@ -7,6 +7,8 @@
 //! - [`CustomSchemeConfig`] - Custom URL scheme configuration
 //! - [`DeeplinkConfig`] - Unified configuration combining all platforms
 
+#![allow(deprecated)]
+
 pub mod android;
 pub mod custom;
 pub mod ios;
@@ -26,6 +28,7 @@ pub use ios::{
 /// # Example
 ///
 /// ```rust
+/// # #![allow(deprecated)]
 /// use reinhardt_deeplink::{DeeplinkConfig, IosConfig, AndroidConfig};
 ///
 /// let config = DeeplinkConfig::builder()
@@ -46,6 +49,10 @@ pub use ios::{
 ///
 /// assert!(config.is_configured());
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `DeeplinkSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone, Default)]
 pub struct DeeplinkConfig {
 	/// iOS Universal Links configuration.

--- a/crates/reinhardt-deeplink/src/lib.rs
+++ b/crates/reinhardt-deeplink/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![allow(deprecated)]
 
 //! Deeplink support for Reinhardt framework.
 //!
@@ -11,6 +12,7 @@
 //! # Quick Start
 //!
 //! ```rust
+//! # #![allow(deprecated)]
 //! use reinhardt_deeplink::{DeeplinkConfig, IosConfig, AndroidConfig};
 //!
 //! let config = DeeplinkConfig::builder()
@@ -45,8 +47,10 @@ pub mod config;
 pub mod endpoints;
 pub mod error;
 pub mod router;
+pub mod settings;
 
 // Re-export main types for convenience
+#[allow(deprecated)]
 pub use config::{
 	AndroidConfig, AndroidConfigBuilder, AppClipsConfig, AppLinkComponent, AppLinkDetail,
 	AppLinksConfig, AssetStatement, AssetTarget, CustomScheme, CustomSchemeBuilder,
@@ -59,6 +63,10 @@ pub use error::{
 	validate_package_name, validate_scheme_name,
 };
 pub use router::{DeeplinkRouter, DeeplinkRouterExt};
+pub use settings::{
+	AndroidSettings, CustomSchemeSettings, DeeplinkSettings, IosSettings,
+	create_deeplink_config_from_settings,
+};
 
 /// Result type for deeplink operations.
 pub type DeeplinkResult<T> = Result<T, DeeplinkError>;

--- a/crates/reinhardt-deeplink/src/lib.rs
+++ b/crates/reinhardt-deeplink/src/lib.rs
@@ -1,4 +1,8 @@
 #![warn(missing_docs)]
+// The deprecated `DeeplinkConfig` is re-exported (`pub use`) and referenced
+// throughout this crate during the 0.2 compatibility window; a crate-level
+// allowance keeps the re-export and the per-module definitions warning-free
+// until the type is removed.
 #![allow(deprecated)]
 
 //! Deeplink support for Reinhardt framework.

--- a/crates/reinhardt-deeplink/src/router.rs
+++ b/crates/reinhardt-deeplink/src/router.rs
@@ -3,6 +3,8 @@
 //! This module provides router types and extension traits for integrating
 //! deeplink handlers with the Reinhardt routing system.
 
+#![allow(deprecated)]
+
 use hyper::Method;
 use reinhardt_urls::routers::{ServerRouter, UnifiedRouter};
 
@@ -21,6 +23,7 @@ use crate::error::DeeplinkError;
 /// # Example
 ///
 /// ```rust
+/// # #![allow(deprecated)]
 /// use reinhardt_deeplink::{DeeplinkRouter, DeeplinkConfig, IosConfig, AndroidConfig};
 ///
 /// let config = DeeplinkConfig::builder()

--- a/crates/reinhardt-deeplink/src/router.rs
+++ b/crates/reinhardt-deeplink/src/router.rs
@@ -3,6 +3,8 @@
 //! This module provides router types and extension traits for integrating
 //! deeplink handlers with the Reinhardt routing system.
 
+// The router stores and consumes the deprecated `DeeplinkConfig` during the 0.2
+// compatibility window. Remove this allowance once `DeeplinkConfig` is deleted.
 #![allow(deprecated)]
 
 use hyper::Method;

--- a/crates/reinhardt-deeplink/src/settings.rs
+++ b/crates/reinhardt-deeplink/src/settings.rs
@@ -1,0 +1,283 @@
+//! Settings fragment for the deeplink subsystem.
+//!
+//! This module defines the [`DeeplinkSettings`] fragment, which is the
+//! settings-based replacement for the deprecated [`crate::config::DeeplinkConfig`].
+//!
+//! The fragment integrates with `reinhardt-conf`'s layered settings system and
+//! can be loaded from configuration files, environment variables, and other
+//! sources via the `#[settings]` macro.
+
+#![allow(deprecated)]
+
+use reinhardt_core::macros::settings;
+use serde::{Deserialize, Serialize};
+
+use crate::config::{
+	AndroidConfig, AndroidConfigBuilder, CustomScheme, DeeplinkConfig, IosConfig, IosConfigBuilder,
+};
+
+/// iOS Universal Links configuration for the [`DeeplinkSettings`] fragment.
+///
+/// This is a nested value object embedded in [`DeeplinkSettings`]; it is never
+/// loaded from its own configuration section. Its fields mirror the inputs
+/// accepted by [`IosConfigBuilder`], and it is converted into an [`IosConfig`]
+/// through that builder.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IosSettings {
+	/// The app identifier in the format `TEAMID.BUNDLEID`.
+	#[serde(default)]
+	pub app_id: String,
+	/// URL paths that should open the app.
+	#[serde(default)]
+	pub paths: Vec<String>,
+	/// URL paths that should NOT open the app.
+	#[serde(default)]
+	pub exclude_paths: Vec<String>,
+	/// App Clip bundle identifiers (usually ending in `.Clip`).
+	#[serde(default)]
+	pub app_clips: Vec<String>,
+	/// Whether to enable web credentials (password autofill) for the app id.
+	#[serde(default)]
+	pub web_credentials: bool,
+}
+
+/// Android App Links configuration for the [`DeeplinkSettings`] fragment.
+///
+/// This is a nested value object embedded in [`DeeplinkSettings`]; it is never
+/// loaded from its own configuration section. Its fields mirror the inputs
+/// accepted by [`AndroidConfigBuilder`], and it is converted into an
+/// [`AndroidConfig`] through that builder.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AndroidSettings {
+	/// The Android app package name (e.g., `com.example.app`).
+	#[serde(default)]
+	pub package_name: String,
+	/// SHA-256 certificate fingerprints.
+	#[serde(default)]
+	pub sha256_cert_fingerprints: Vec<String>,
+}
+
+/// A single custom URL scheme for the [`DeeplinkSettings`] fragment.
+///
+/// This is a nested value object embedded in [`DeeplinkSettings`]; it is never
+/// loaded from its own configuration section.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CustomSchemeSettings {
+	/// The scheme name (e.g., `myapp`).
+	#[serde(default)]
+	pub name: String,
+	/// Allowed hosts for the scheme.
+	#[serde(default)]
+	pub hosts: Vec<String>,
+	/// Allowed paths for the scheme.
+	#[serde(default)]
+	pub paths: Vec<String>,
+}
+
+/// Settings fragment for configuring the deeplink subsystem.
+///
+/// This fragment unifies the iOS, Android, and custom-scheme configuration into
+/// a single loadable section and replaces the deprecated
+/// [`crate::config::DeeplinkConfig`].
+#[settings(fragment = true, section = "deeplink_app")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeeplinkSettings {
+	/// iOS Universal Links configuration (optional).
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub ios: Option<IosSettings>,
+	/// Android App Links configuration (optional).
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub android: Option<AndroidSettings>,
+	/// Custom URL scheme configurations.
+	#[serde(default)]
+	pub custom_schemes: Vec<CustomSchemeSettings>,
+}
+
+impl Default for DeeplinkSettings {
+	fn default() -> Self {
+		Self {
+			ios: None,
+			android: None,
+			custom_schemes: Vec::new(),
+		}
+	}
+}
+
+impl IosSettings {
+	/// Builds an [`IosConfig`] from these settings via [`IosConfigBuilder`].
+	fn to_config(&self) -> IosConfig {
+		let path_refs: Vec<&str> = self.paths.iter().map(String::as_str).collect();
+		let exclude_refs: Vec<&str> = self.exclude_paths.iter().map(String::as_str).collect();
+
+		let mut builder = IosConfigBuilder::new()
+			.app_id(self.app_id.clone())
+			.paths(&path_refs)
+			.exclude_paths(&exclude_refs);
+
+		for app_clip in &self.app_clips {
+			builder = builder.app_clip(app_clip.clone());
+		}
+
+		if self.web_credentials {
+			builder = builder.with_web_credentials();
+		}
+
+		builder.build()
+	}
+}
+
+impl AndroidSettings {
+	/// Builds an [`AndroidConfig`] from these settings via
+	/// [`AndroidConfigBuilder`].
+	///
+	/// This uses the builder's unchecked path; fingerprint and package-name
+	/// validation are performed by the settings/configuration layer rather than
+	/// at conversion time.
+	fn to_config(&self) -> AndroidConfig {
+		let fingerprint_refs: Vec<&str> = self
+			.sha256_cert_fingerprints
+			.iter()
+			.map(String::as_str)
+			.collect();
+
+		AndroidConfigBuilder::new()
+			.package_name(self.package_name.clone())
+			.sha256_fingerprints(&fingerprint_refs)
+			.build_unchecked()
+	}
+}
+
+impl From<&CustomSchemeSettings> for CustomScheme {
+	fn from(settings: &CustomSchemeSettings) -> Self {
+		CustomScheme {
+			name: settings.name.clone(),
+			hosts: settings.hosts.clone(),
+			paths: settings.paths.clone(),
+		}
+	}
+}
+
+impl From<&DeeplinkSettings> for DeeplinkConfig {
+	fn from(settings: &DeeplinkSettings) -> Self {
+		DeeplinkConfig {
+			ios: settings.ios.as_ref().map(IosSettings::to_config),
+			android: settings.android.as_ref().map(AndroidSettings::to_config),
+			custom_schemes: settings
+				.custom_schemes
+				.iter()
+				.map(CustomScheme::from)
+				.collect(),
+		}
+	}
+}
+
+/// Creates a deeplink configuration from the settings fragment.
+pub fn create_deeplink_config_from_settings(settings: &DeeplinkSettings) -> DeeplinkConfig {
+	DeeplinkConfig::from(settings)
+}
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+
+	use super::*;
+
+	const VALID_FINGERPRINT: &str = "FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C";
+
+	#[rstest]
+	fn test_default_settings() {
+		let settings = DeeplinkSettings::default();
+		assert!(settings.ios.is_none());
+		assert!(settings.android.is_none());
+		assert!(settings.custom_schemes.is_empty());
+	}
+
+	#[rstest]
+	fn test_default_settings_bridge_to_empty_config() {
+		let settings = DeeplinkSettings::default();
+		let config = create_deeplink_config_from_settings(&settings);
+		assert!(!config.is_configured());
+	}
+
+	#[rstest]
+	fn test_ios_bridge() {
+		let settings = DeeplinkSettings {
+			ios: Some(IosSettings {
+				app_id: "TEAM.com.example".to_string(),
+				paths: vec!["/products/*".to_string()],
+				exclude_paths: vec!["/api/*".to_string()],
+				app_clips: vec!["TEAM.com.example.Clip".to_string()],
+				web_credentials: true,
+			}),
+			..Default::default()
+		};
+		let config = DeeplinkConfig::from(&settings);
+		assert!(config.has_ios());
+		let ios = config.ios.expect("ios config present");
+		let json = serde_json::to_string(&ios).expect("serialize ios config");
+		assert!(json.contains("TEAM.com.example"));
+		assert!(json.contains("/products/*"));
+		assert!(json.contains("/api/*"));
+		assert!(json.contains("webcredentials"));
+		assert!(json.contains("appclips"));
+	}
+
+	#[rstest]
+	fn test_android_bridge() {
+		let settings = DeeplinkSettings {
+			android: Some(AndroidSettings {
+				package_name: "com.example.app".to_string(),
+				sha256_cert_fingerprints: vec![VALID_FINGERPRINT.to_string()],
+			}),
+			..Default::default()
+		};
+		let config = DeeplinkConfig::from(&settings);
+		assert!(config.has_android());
+		let android = config.android.expect("android config present");
+		assert_eq!(android.statements.len(), 1);
+		assert_eq!(android.statements[0].target.package_name, "com.example.app");
+		assert_eq!(
+			android.statements[0].target.sha256_cert_fingerprints,
+			vec![VALID_FINGERPRINT.to_string()]
+		);
+	}
+
+	#[rstest]
+	fn test_custom_schemes_bridge() {
+		let settings = DeeplinkSettings {
+			custom_schemes: vec![CustomSchemeSettings {
+				name: "myapp".to_string(),
+				hosts: vec!["open".to_string()],
+				paths: vec!["/products/*".to_string()],
+			}],
+			..Default::default()
+		};
+		let config = DeeplinkConfig::from(&settings);
+		assert!(config.has_custom_schemes());
+		assert_eq!(config.custom_schemes.len(), 1);
+		assert_eq!(config.custom_schemes[0].name, "myapp");
+		assert_eq!(config.custom_schemes[0].hosts, vec!["open".to_string()]);
+		assert_eq!(
+			config.custom_schemes[0].paths,
+			vec!["/products/*".to_string()]
+		);
+	}
+
+	#[rstest]
+	fn test_settings_roundtrip_serde() {
+		let settings = DeeplinkSettings {
+			ios: Some(IosSettings {
+				app_id: "TEAM.com.example".to_string(),
+				paths: vec!["/".to_string()],
+				exclude_paths: Vec::new(),
+				app_clips: Vec::new(),
+				web_credentials: false,
+			}),
+			android: None,
+			custom_schemes: Vec::new(),
+		};
+		let json = serde_json::to_string(&settings).expect("serialize settings");
+		let parsed: DeeplinkSettings = serde_json::from_str(&json).expect("deserialize settings");
+		assert_eq!(settings, parsed);
+	}
+}

--- a/crates/reinhardt-deeplink/src/settings.rs
+++ b/crates/reinhardt-deeplink/src/settings.rs
@@ -7,6 +7,9 @@
 //! can be loaded from configuration files, environment variables, and other
 //! sources via the `#[settings]` macro.
 
+// The conversions in this module bridge the `#[settings]` fragments into the
+// deprecated `DeeplinkConfig` for backward compatibility during the 0.2 window.
+// Remove this allowance once `DeeplinkConfig` is deleted.
 #![allow(deprecated)]
 
 use reinhardt_core::macros::settings;

--- a/crates/reinhardt-deeplink/src/settings.rs
+++ b/crates/reinhardt-deeplink/src/settings.rs
@@ -80,7 +80,7 @@ pub struct CustomSchemeSettings {
 /// a single loadable section and replaces the deprecated
 /// [`crate::config::DeeplinkConfig`].
 #[settings(fragment = true, section = "deeplink_app")]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeeplinkSettings {
 	/// iOS Universal Links configuration (optional).
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -91,16 +91,6 @@ pub struct DeeplinkSettings {
 	/// Custom URL scheme configurations.
 	#[serde(default)]
 	pub custom_schemes: Vec<CustomSchemeSettings>,
-}
-
-impl Default for DeeplinkSettings {
-	fn default() -> Self {
-		Self {
-			ios: None,
-			android: None,
-			custom_schemes: Vec::new(),
-		}
-	}
 }
 
 impl IosSettings {

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -19,6 +19,11 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
+serde = { workspace = true }
+
+# Settings fragment support
+reinhardt-conf = { workspace = true, features = ["settings"] }
+reinhardt-core = { workspace = true }
 
 # DI support (optional)
 reinhardt-di = { workspace = true, optional = true }
@@ -37,3 +42,4 @@ insta = { workspace = true }
 tokio-test = { workspace = true }
 rstest = { workspace = true }
 tracing = { workspace = true }
+toml = { workspace = true }

--- a/crates/reinhardt-grpc/src/lib.rs
+++ b/crates/reinhardt-grpc/src/lib.rs
@@ -67,6 +67,7 @@ pub mod adapter;
 pub mod depth_limit;
 pub mod error;
 pub mod server;
+pub mod settings;
 pub mod validation;
 
 #[cfg(feature = "di")]
@@ -92,7 +93,10 @@ pub mod proto {
 pub use adapter::{GrpcServiceAdapter, GrpcSubscriptionAdapter};
 pub use depth_limit::{DepthLimitError, DepthLimitedDecoder};
 pub use error::{ErrorSanitizer, GrpcError, GrpcResult};
-pub use server::{GrpcServerConfig, GrpcServerConfigBuilder, MessageSizeLimiter};
+#[allow(deprecated)] // Re-export keeps the compatibility API discoverable during the 0.2 line.
+pub use server::GrpcServerConfig;
+pub use server::{GrpcServerConfigBuilder, MessageSizeLimiter};
+pub use settings::{GrpcServerSettings, create_grpc_server_config_from_settings};
 pub use validation::{FieldRule, ProtoValidator, ValidationError, ValidationRuleSet};
 
 #[cfg(feature = "di")]

--- a/crates/reinhardt-grpc/src/server.rs
+++ b/crates/reinhardt-grpc/src/server.rs
@@ -59,6 +59,10 @@
 //!     .await?;
 //! ```
 
+// The builder, impls, trait, doctests, and tests in this module all name the
+// deprecated `GrpcServerConfig` during the 0.2 compatibility window.
+#![allow(deprecated)]
+
 use std::time::Duration;
 
 /// Default maximum decoding (incoming) message size: 4MB
@@ -108,6 +112,10 @@ const DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 1000;
 /// assert_eq!(config.request_timeout(), Duration::from_secs(60));
 /// assert_eq!(config.max_concurrent_connections(), 500);
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `GrpcServerSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct GrpcServerConfig {
 	max_decoding_message_size: usize,

--- a/crates/reinhardt-grpc/src/settings.rs
+++ b/crates/reinhardt-grpc/src/settings.rs
@@ -1,0 +1,187 @@
+//! Settings fragment for the gRPC server configuration.
+//!
+//! This module provides [`GrpcServerSettings`], a `#[settings]` fragment that
+//! maps to the `[grpc_server]` configuration section. It is the settings-first
+//! replacement for the deprecated [`GrpcServerConfig`] DoS-protection config.
+//!
+//! Durations are stored as integer seconds in the fragment so they can be
+//! expressed naturally in TOML, and are converted back into [`std::time::Duration`]
+//! by the [`From`] bridge.
+
+#![allow(deprecated)] // Settings conversion targets the legacy config during the compatibility window.
+
+use crate::server::GrpcServerConfig;
+use reinhardt_core::macros::settings;
+use serde::{Deserialize, Serialize};
+
+/// Default maximum decoding (incoming) message size: 4MB.
+const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+
+/// Default maximum encoding (outgoing) message size: 4MB.
+const DEFAULT_MAX_ENCODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+
+/// Default request timeout in seconds: 30 seconds.
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Default maximum concurrent connections: 1000.
+const DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 1000;
+
+fn default_max_decoding_message_size() -> usize {
+	DEFAULT_MAX_DECODING_MESSAGE_SIZE
+}
+
+fn default_max_encoding_message_size() -> usize {
+	DEFAULT_MAX_ENCODING_MESSAGE_SIZE
+}
+
+fn default_request_timeout_secs() -> u64 {
+	DEFAULT_REQUEST_TIMEOUT_SECS
+}
+
+fn default_max_concurrent_connections() -> usize {
+	DEFAULT_MAX_CONCURRENT_CONNECTIONS
+}
+
+/// gRPC server configuration fragment.
+///
+/// This fragment maps to the `[grpc_server]` section and can be composed with
+/// the `#[settings]` macro from downstream applications. It configures
+/// DoS-protection limits for gRPC services: message size limits, request
+/// timeouts, and connection limits.
+///
+/// # Example
+///
+/// ```rust
+/// use reinhardt_grpc::GrpcServerSettings;
+///
+/// let settings: GrpcServerSettings = toml::from_str(r#"
+/// max_decoding_message_size = 8388608
+/// request_timeout_secs = 60
+/// max_concurrent_connections = 500
+/// "#).unwrap();
+///
+/// assert_eq!(settings.max_decoding_message_size, 8 * 1024 * 1024);
+/// assert_eq!(settings.request_timeout_secs, 60);
+/// assert_eq!(settings.max_concurrent_connections, 500);
+/// ```
+#[settings(fragment = true, section = "grpc_server")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GrpcServerSettings {
+	/// Maximum decoding (incoming) message size in bytes.
+	#[serde(default = "default_max_decoding_message_size")]
+	pub max_decoding_message_size: usize,
+	/// Maximum encoding (outgoing) message size in bytes.
+	#[serde(default = "default_max_encoding_message_size")]
+	pub max_encoding_message_size: usize,
+	/// Request timeout in seconds.
+	#[serde(default = "default_request_timeout_secs")]
+	pub request_timeout_secs: u64,
+	/// Maximum number of concurrent connections allowed.
+	#[serde(default = "default_max_concurrent_connections")]
+	pub max_concurrent_connections: usize,
+}
+
+impl Default for GrpcServerSettings {
+	fn default() -> Self {
+		Self {
+			max_decoding_message_size: DEFAULT_MAX_DECODING_MESSAGE_SIZE,
+			max_encoding_message_size: DEFAULT_MAX_ENCODING_MESSAGE_SIZE,
+			request_timeout_secs: DEFAULT_REQUEST_TIMEOUT_SECS,
+			max_concurrent_connections: DEFAULT_MAX_CONCURRENT_CONNECTIONS,
+		}
+	}
+}
+
+impl From<&GrpcServerSettings> for GrpcServerConfig {
+	fn from(settings: &GrpcServerSettings) -> Self {
+		// `GrpcServerConfig` has private fields, so rebuild it through its builder.
+		GrpcServerConfig::builder()
+			.max_decoding_message_size(settings.max_decoding_message_size)
+			.max_encoding_message_size(settings.max_encoding_message_size)
+			.request_timeout(std::time::Duration::from_secs(
+				settings.request_timeout_secs,
+			))
+			.max_concurrent_connections(settings.max_concurrent_connections)
+			.build()
+	}
+}
+
+/// Create a [`GrpcServerConfig`] from a [`GrpcServerSettings`] fragment.
+///
+/// This is the settings-first entry point that replaces direct construction of
+/// the deprecated [`GrpcServerConfig`].
+pub fn create_grpc_server_config_from_settings(settings: &GrpcServerSettings) -> GrpcServerConfig {
+	GrpcServerConfig::from(settings)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::time::Duration;
+
+	#[test]
+	fn default_settings_match_config_defaults() {
+		// Arrange & Act
+		let settings = GrpcServerSettings::default();
+		let config = GrpcServerConfig::from(&settings);
+		let default_config = GrpcServerConfig::default();
+
+		// Assert
+		assert_eq!(
+			config.max_decoding_message_size(),
+			default_config.max_decoding_message_size()
+		);
+		assert_eq!(
+			config.max_encoding_message_size(),
+			default_config.max_encoding_message_size()
+		);
+		assert_eq!(config.request_timeout(), default_config.request_timeout());
+		assert_eq!(
+			config.max_concurrent_connections(),
+			default_config.max_concurrent_connections()
+		);
+	}
+
+	#[test]
+	fn custom_settings_convert_to_config() {
+		// Arrange
+		let settings = GrpcServerSettings {
+			max_decoding_message_size: 8 * 1024 * 1024,
+			max_encoding_message_size: 16 * 1024 * 1024,
+			request_timeout_secs: 60,
+			max_concurrent_connections: 500,
+		};
+
+		// Act
+		let config = create_grpc_server_config_from_settings(&settings);
+
+		// Assert
+		assert_eq!(config.max_decoding_message_size(), 8 * 1024 * 1024);
+		assert_eq!(config.max_encoding_message_size(), 16 * 1024 * 1024);
+		assert_eq!(config.request_timeout(), Duration::from_secs(60));
+		assert_eq!(config.max_concurrent_connections(), 500);
+	}
+
+	#[test]
+	fn settings_deserialize_from_toml_with_partial_fields() {
+		// Arrange & Act
+		let settings: GrpcServerSettings = toml::from_str(
+			r#"
+			max_decoding_message_size = 2097152
+			"#,
+		)
+		.expect("settings should deserialize");
+
+		// Assert: provided field is honored, missing fields fall back to defaults.
+		assert_eq!(settings.max_decoding_message_size, 2 * 1024 * 1024);
+		assert_eq!(
+			settings.max_encoding_message_size,
+			DEFAULT_MAX_ENCODING_MESSAGE_SIZE
+		);
+		assert_eq!(settings.request_timeout_secs, DEFAULT_REQUEST_TIMEOUT_SECS);
+		assert_eq!(
+			settings.max_concurrent_connections,
+			DEFAULT_MAX_CONCURRENT_CONNECTIONS
+		);
+	}
+}

--- a/crates/reinhardt-mail/src/backends.rs
+++ b/crates/reinhardt-mail/src/backends.rs
@@ -348,7 +348,7 @@ impl SmtpConfig {
 	}
 }
 
-/// Build an [`SmtpConfig`] from an [`EmailSettings`] fragment.
+/// Build an [`SmtpConfig`] from an [`EmailSettings`](reinhardt_conf::settings::EmailSettings) fragment.
 ///
 /// This mirrors the SMTP branch of [`backend_from_settings`]: the security mode
 /// is derived from the `use_tls`/`use_ssl` flags, the timeout defaults to 60
@@ -379,7 +379,7 @@ impl From<&reinhardt_conf::settings::EmailSettings> for SmtpConfig {
 	}
 }
 
-/// Build an [`SmtpBackend`] from an [`EmailSettings`] fragment.
+/// Build an [`SmtpBackend`] from an [`EmailSettings`](reinhardt_conf::settings::EmailSettings) fragment.
 ///
 /// This is the settings-first entry point for constructing an SMTP backend.
 /// Prefer it over building an [`SmtpConfig`] manually.

--- a/crates/reinhardt-mail/src/backends.rs
+++ b/crates/reinhardt-mail/src/backends.rs
@@ -1,3 +1,8 @@
+// `SmtpConfig` is deprecated in favour of the `EmailSettings` fragment, but this
+// module still defines, constructs, and bridges to it during the compatibility
+// window. Allow deprecated usages crate-internally so `-D warnings` stays clean.
+#![allow(deprecated)]
+
 use crate::headers::{
 	ListUnsubscribe, ListUnsubscribePost, Precedence, XEntityRefId, XMailer, XPriority,
 };
@@ -248,6 +253,16 @@ pub enum SmtpAuthMechanism {
 }
 
 /// Configuration for SMTP backend
+///
+/// Deprecated: configure the SMTP backend through the
+/// [`EmailSettings`](reinhardt_conf::settings::EmailSettings) fragment and the
+/// `#[settings]` macro instead. Use [`create_smtp_backend_from_settings`] (or
+/// [`backend_from_settings`]) to build a backend from settings, or
+/// `SmtpConfig::from(&settings)` for the bridge.
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `EmailSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct SmtpConfig {
 	/// SMTP server hostname.
@@ -333,6 +348,51 @@ impl SmtpConfig {
 	}
 }
 
+/// Build an [`SmtpConfig`] from an [`EmailSettings`] fragment.
+///
+/// This mirrors the SMTP branch of [`backend_from_settings`]: the security mode
+/// is derived from the `use_tls`/`use_ssl` flags, the timeout defaults to 60
+/// seconds when unset, and credentials are populated only when both username and
+/// password are present.
+impl From<&reinhardt_conf::settings::EmailSettings> for SmtpConfig {
+	fn from(settings: &reinhardt_conf::settings::EmailSettings) -> Self {
+		let security = match (settings.use_tls, settings.use_ssl) {
+			(true, _) => SmtpSecurity::StartTls,
+			(_, true) => SmtpSecurity::Tls,
+			_ => SmtpSecurity::None,
+		};
+
+		let timeout = settings
+			.timeout
+			.map(Duration::from_secs)
+			.unwrap_or_else(|| Duration::from_secs(60));
+
+		let mut config = SmtpConfig::new(&settings.host, settings.port)
+			.with_security(security)
+			.with_timeout(timeout);
+
+		if let (Some(username), Some(password)) = (&settings.username, &settings.password) {
+			config = config.with_credentials(username.clone(), password.clone());
+		}
+
+		config
+	}
+}
+
+/// Build an [`SmtpBackend`] from an [`EmailSettings`] fragment.
+///
+/// This is the settings-first entry point for constructing an SMTP backend.
+/// Prefer it over building an [`SmtpConfig`] manually.
+///
+/// # Errors
+/// Returns [`EmailError`] if the resulting configuration fails validation (for
+/// example, an email-formatted username that is not a valid address).
+pub fn create_smtp_backend_from_settings(
+	settings: &reinhardt_conf::settings::EmailSettings,
+) -> EmailResult<SmtpBackend> {
+	SmtpBackend::new(SmtpConfig::from(settings))
+}
+
 /// Zeroize SMTP credentials on drop to prevent sensitive data from lingering in memory.
 ///
 /// This ensures that username and password fields are securely erased when
@@ -354,6 +414,7 @@ impl Drop for SmtpConfig {
 /// # Examples
 ///
 /// ```rust,no_run
+/// # #![allow(deprecated)]
 /// # use reinhardt_mail::{SmtpBackend, SmtpConfig, SmtpSecurity};
 /// # use std::time::Duration;
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/reinhardt-mail/src/lib.rs
+++ b/crates/reinhardt-mail/src/lib.rs
@@ -132,18 +132,24 @@
 //!
 //! ### SMTP with TLS
 //!
+//! Configure the SMTP backend through the `EmailSettings` fragment and build it
+//! with [`create_smtp_backend_from_settings`].
+//!
 //! ```rust,no_run
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use reinhardt_mail::{SmtpBackend, SmtpConfig, SmtpSecurity, EmailMessage};
-//! use std::time::Duration;
+//! use reinhardt_mail::{create_smtp_backend_from_settings, EmailMessage};
+//! use reinhardt_conf::settings::EmailSettings;
 //!
-//! let config = SmtpConfig::new("smtp.gmail.com", 587)
-//!     .with_credentials("user@gmail.com".to_string(), "password".to_string())
-//!     .with_security(SmtpSecurity::StartTls)
-//!     .with_timeout(Duration::from_secs(30));
+//! let mut settings = EmailSettings::default();
+//! settings.host = "smtp.gmail.com".to_string();
+//! settings.port = 587;
+//! settings.username = Some("user@gmail.com".to_string());
+//! settings.password = Some("password".to_string());
+//! settings.use_tls = true;
+//! settings.timeout = Some(30);
 //!
-//! let backend = SmtpBackend::new(config)?;
+//! let backend = create_smtp_backend_from_settings(&settings)?;
 //!
 //! let email = EmailMessage::builder()
 //!     .from("sender@gmail.com")
@@ -160,6 +166,7 @@
 //! ### Bulk Sending with Connection Pool
 //!
 //! ```rust,no_run
+//! # #![allow(deprecated)]
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use reinhardt_mail::pooling::{EmailPool, PoolConfig};
@@ -204,8 +211,12 @@ use thiserror::Error;
 
 pub use backends::{
 	ConsoleBackend, EmailBackend, FileBackend, MemoryBackend, SmtpAuthMechanism, SmtpBackend,
-	SmtpConfig, SmtpSecurity, backend_from_settings,
+	SmtpSecurity, backend_from_settings, create_smtp_backend_from_settings,
 };
+// `SmtpConfig` is deprecated in favour of the `EmailSettings` fragment; re-export
+// it separately so the deprecation lint is suppressed only at the re-export site.
+#[allow(deprecated)]
+pub use backends::SmtpConfig;
 pub use message::{Alternative, Attachment, EmailMessage, EmailMessageBuilder};
 pub use utils::{mail_admins, mail_managers, send_mail, send_mail_with_backend, send_mass_mail};
 pub use validation::MAX_EMAIL_LENGTH;

--- a/crates/reinhardt-mail/src/pooling.rs
+++ b/crates/reinhardt-mail/src/pooling.rs
@@ -4,6 +4,11 @@
 //! bulk email sending operations, reducing the overhead of establishing
 //! new SMTP connections for each message.
 
+// The pool and batch sender embed the deprecated `SmtpConfig` directly; the
+// settings-first surface lives in `backends`. Allow deprecated usages here so
+// `-D warnings` stays clean during the compatibility window.
+#![allow(deprecated)]
+
 use crate::backends::{EmailBackend, SmtpBackend, SmtpConfig};
 use crate::message::EmailMessage;
 use crate::{EmailError, EmailResult};
@@ -65,6 +70,7 @@ impl PoolConfig {
 /// # Examples
 ///
 /// ```rust,no_run
+/// # #![allow(deprecated)]
 /// use reinhardt_mail::pooling::{EmailPool, PoolConfig};
 /// use reinhardt_mail::{SmtpConfig, EmailMessage};
 ///
@@ -212,6 +218,7 @@ impl EmailPool {
 /// # Examples
 ///
 /// ```rust,no_run
+/// # #![allow(deprecated)]
 /// use reinhardt_mail::pooling::{BatchSender, PoolConfig};
 /// use reinhardt_mail::{SmtpConfig, EmailMessage};
 /// use std::time::Duration;

--- a/crates/reinhardt-mail/tests/smtp_integration.rs
+++ b/crates/reinhardt-mail/tests/smtp_integration.rs
@@ -3,6 +3,11 @@
 //! Tests SMTP email sending with Mailpit container, covering basic send, authentication,
 //! TLS, attachments, HTML email, encoding, error handling, retry, queue, and BCC/CC.
 
+// These tests exercise the legacy `SmtpConfig` builder API directly, which is
+// deprecated in favour of the `EmailSettings` fragment. Allow deprecated usage
+// so `clippy --all-targets -D warnings` stays clean.
+#![allow(deprecated)]
+
 use reinhardt_mail::{EmailBackend, EmailMessage, SmtpBackend, SmtpConfig, SmtpSecurity};
 use reinhardt_testkit::containers::MailpitContainer;
 use rstest::*;

--- a/crates/reinhardt-middleware/src/broken_link.rs
+++ b/crates/reinhardt-middleware/src/broken_link.rs
@@ -300,6 +300,10 @@ impl BrokenLinkEmailsMiddleware {
 				// Schedule email sending in a separate task to avoid blocking
 				// Note: Uses default SMTP config (localhost:25). Configure via SmtpConfig for production.
 				tokio::spawn(async move {
+					// `SmtpConfig` is deprecated in favor of the `EmailSettings`
+					// fragment; this placeholder default is kept during the 0.2
+					// compatibility window.
+					#[allow(deprecated)]
 					let config = reinhardt_mail::SmtpConfig::default();
 					let backend = match reinhardt_mail::SmtpBackend::new(config) {
 						Ok(backend) => backend,

--- a/crates/reinhardt-middleware/src/cors.rs
+++ b/crates/reinhardt-middleware/src/cors.rs
@@ -1,8 +1,21 @@
+// The deprecated `CorsConfig` is still referenced internally (constructor,
+// `Default`, bridge, and tests) during the compatibility window.
+#![allow(deprecated)]
+
 use async_trait::async_trait;
+use reinhardt_conf::CorsSettings;
 use reinhardt_http::{Handler, Middleware, Request, Response, Result};
 use std::sync::Arc;
 
-/// CORS middleware configuration
+/// CORS middleware configuration.
+///
+/// Deprecated in favor of the [`CorsSettings`] fragment (the `[cors]` settings
+/// section). Construct middleware from settings with
+/// [`create_cors_middleware_from_settings`].
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `CorsSettings` with the `#[settings]` macro instead."
+)]
 #[non_exhaustive]
 pub struct CorsConfig {
 	/// Origins allowed to make cross-origin requests (e.g., `"*"` or specific domains).
@@ -34,6 +47,28 @@ impl Default for CorsConfig {
 			max_age: Some(3600),
 		}
 	}
+}
+
+impl From<&CorsSettings> for CorsConfig {
+	fn from(settings: &CorsSettings) -> Self {
+		Self {
+			allow_origins: settings.allow_origins.clone(),
+			allow_methods: settings.allow_methods.clone(),
+			allow_headers: settings.allow_headers.clone(),
+			allow_credentials: settings.allow_credentials,
+			// `CorsSettings::max_age` is a required `u64`; the legacy config
+			// models the absence of a max-age as `None`.
+			max_age: Some(settings.max_age),
+		}
+	}
+}
+
+/// Build a [`CorsMiddleware`] from a [`CorsSettings`] fragment.
+///
+/// This is the settings-first entry point for CORS middleware. It maps the
+/// `[cors]` settings section onto the middleware configuration.
+pub fn create_cors_middleware_from_settings(settings: &CorsSettings) -> CorsMiddleware {
+	CorsMiddleware::new(CorsConfig::from(settings))
 }
 
 /// CORS middleware

--- a/crates/reinhardt-middleware/src/lib.rs
+++ b/crates/reinhardt-middleware/src/lib.rs
@@ -208,7 +208,10 @@ pub use conditional::ConditionalGetMiddleware;
 #[cfg(feature = "sessions")]
 pub use cookie_session_auth::{CookieSessionAuthMiddleware, CookieSessionConfig};
 #[cfg(feature = "cors")]
-pub use cors::CorsMiddleware;
+#[allow(deprecated)]
+pub use cors::CorsConfig;
+#[cfg(feature = "cors")]
+pub use cors::{CorsMiddleware, create_cors_middleware_from_settings};
 pub use csp::{CspConfig, CspMiddleware, CspNonce};
 pub use csp_helpers::{csp_nonce_attr, get_csp_nonce};
 pub use csrf::{
@@ -256,6 +259,8 @@ pub use xframe::{XFrameOptions, XFrameOptionsMiddleware};
 pub use xss::{XssConfig, XssError, XssProtector};
 
 #[cfg(all(test, feature = "cors"))]
+// The deprecated `CorsConfig` is exercised here during the compatibility window.
+#[allow(deprecated)]
 mod tests {
 	use super::*;
 	use bytes::Bytes;

--- a/crates/reinhardt-middleware/tests/combination_integration.rs
+++ b/crates/reinhardt-middleware/tests/combination_integration.rs
@@ -11,6 +11,9 @@
 //! - Protection stacks (RateLimit + CircuitBreaker)
 //! - Observability stacks (Logging + Tracing + Metrics)
 
+// The deprecated `CorsConfig` is exercised here during the compatibility window.
+#![allow(deprecated)]
+
 mod fixtures;
 
 use fixtures::{ConfigurableTestHandler, create_request_with_headers, create_test_request};

--- a/crates/reinhardt-middleware/tests/decision_table_integration.rs
+++ b/crates/reinhardt-middleware/tests/decision_table_integration.rs
@@ -8,6 +8,9 @@
 //! - CircuitBreaker decision table (State, Request result, Min requests combinations)
 //! - RateLimit decision table (Strategy, Tokens, Cost combinations)
 
+// The deprecated `CorsConfig` is exercised here during the compatibility window.
+#![allow(deprecated)]
+
 mod fixtures;
 
 use async_trait::async_trait;

--- a/crates/reinhardt-middleware/tests/equivalence_partitioning_integration.rs
+++ b/crates/reinhardt-middleware/tests/equivalence_partitioning_integration.rs
@@ -13,6 +13,9 @@
 //! - Cache key partitions
 //! - Compression encoding partitions
 
+// The deprecated `CorsConfig` is exercised here during the compatibility window.
+#![allow(deprecated)]
+
 mod fixtures;
 
 use fixtures::*;

--- a/crates/reinhardt-middleware/tests/fuzz_integration.rs
+++ b/crates/reinhardt-middleware/tests/fuzz_integration.rs
@@ -12,6 +12,9 @@
 //! - X-Forwarded-For IP extraction with injection attempts
 //! - Session ID validation with collision attempts
 
+// The deprecated `CorsConfig` is exercised here during the compatibility window.
+#![allow(deprecated)]
+
 mod fixtures;
 
 use fixtures::{ConfigurableTestHandler, create_request_with_headers, create_test_request};

--- a/crates/reinhardt-middleware/tests/happy_path_integration.rs
+++ b/crates/reinhardt-middleware/tests/happy_path_integration.rs
@@ -10,6 +10,9 @@
 //!
 //! Run with all features: `cargo test --features full`
 
+// The deprecated `CorsConfig` is exercised here during the compatibility window.
+#![allow(deprecated)]
+
 mod fixtures;
 
 use bytes::Bytes;

--- a/crates/reinhardt-middleware/tests/sanity_integration.rs
+++ b/crates/reinhardt-middleware/tests/sanity_integration.rs
@@ -11,6 +11,9 @@
 //! - Config builder patterns chain correctly
 //! - Thread safety for shared middleware
 
+// The deprecated `CorsConfig` is exercised here during the compatibility window.
+#![allow(deprecated)]
+
 mod fixtures;
 
 use fixtures::{ConfigurableTestHandler, create_test_request};

--- a/crates/reinhardt-middleware/tests/use_cases_integration.rs
+++ b/crates/reinhardt-middleware/tests/use_cases_integration.rs
@@ -14,6 +14,9 @@
 //! - Content delivery with compression (GZip + Brotli + ETag)
 //! - Request tracing workflow (RequestId + Tracing + Metrics)
 
+// The deprecated `CorsConfig` is exercised here during the compatibility window.
+#![allow(deprecated)]
+
 mod fixtures;
 
 use fixtures::{ConfigurableTestHandler, create_request_with_headers, create_test_request};

--- a/crates/reinhardt-server/Cargo.toml
+++ b/crates/reinhardt-server/Cargo.toml
@@ -10,8 +10,10 @@ description = "HTTP server implementation for Reinhardt framework"
 
 [dependencies]
 reinhardt-core = { workspace = true, features = ["exception", "types"] }
+reinhardt-conf = { workspace = true }
 reinhardt-http = { workspace = true }
 reinhardt-di = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 bytes = { workspace = true }
 hyper = { workspace = true }
@@ -44,5 +46,4 @@ reqwest = { workspace = true }
 async-graphql = "7.0"
 tokio-tungstenite = "0.28.0"
 futures-util = "0.3"
-serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/reinhardt-server/src/server.rs
+++ b/crates/reinhardt-server/src/server.rs
@@ -39,6 +39,8 @@ pub mod http;
 pub mod http2;
 /// Rate limiting handler for controlling request throughput.
 pub mod rate_limit;
+/// Settings-first configuration fragment for rate limiting.
+pub mod rate_limit_settings;
 /// Graceful shutdown coordination for server instances.
 pub mod shutdown;
 /// Request timeout handler for enforcing maximum execution time.
@@ -54,7 +56,13 @@ pub mod websocket;
 
 pub use http::{HttpServer, serve, serve_with_shutdown};
 pub use http2::{Http2Server, serve_http2, serve_http2_with_shutdown};
-pub use rate_limit::{RateLimitConfig, RateLimitHandler, RateLimitStrategy};
+#[allow(deprecated)] // Re-export keeps the compatibility API discoverable during the 0.2 line.
+pub use rate_limit::RateLimitConfig;
+pub use rate_limit::{RateLimitHandler, RateLimitStrategy};
+// Settings-first configuration API (preferred over the deprecated `RateLimitConfig`).
+pub use rate_limit_settings::{
+	RateLimitSettings, RateLimitStrategyKind, create_rate_limit_handler_from_settings,
+};
 pub use shutdown::{ShutdownCoordinator, shutdown_signal, with_shutdown};
 pub use timeout::TimeoutHandler;
 

--- a/crates/reinhardt-server/src/server/rate_limit.rs
+++ b/crates/reinhardt-server/src/server/rate_limit.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // RateLimitConfig is deprecated but still used by the handler and tests in this module.
+
 use reinhardt_http::Handler;
 use reinhardt_http::{Request, Response};
 use std::collections::HashMap;
@@ -16,6 +18,10 @@ pub enum RateLimitStrategy {
 }
 
 /// Rate limiter configuration
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `RateLimitSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct RateLimitConfig {
 	/// Maximum requests allowed in the window

--- a/crates/reinhardt-server/src/server/rate_limit_settings.rs
+++ b/crates/reinhardt-server/src/server/rate_limit_settings.rs
@@ -1,0 +1,196 @@
+//! Settings-first configuration fragment for rate limiting.
+//!
+//! [`RateLimitSettings`] is the settings-first entry point for the rate limiting
+//! middleware. It maps to the `[server_rate_limit]` TOML section and can be
+//! composed into a project's settings with the `#[settings]` macro. A conversion
+//! into the deprecated compatibility [`RateLimitConfig`] type is provided for the
+//! migration window; new code should prefer the fragment and the
+//! [`create_rate_limit_handler_from_settings`] constructor.
+
+#![allow(deprecated)] // Conversion targets the legacy RateLimitConfig during the compatibility window.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reinhardt_core::macros::settings;
+use reinhardt_http::Handler;
+use serde::{Deserialize, Serialize};
+
+use super::rate_limit::{RateLimitConfig, RateLimitHandler, RateLimitStrategy};
+
+// --- defaults -------------------------------------------------------------
+
+fn default_max_requests() -> usize {
+	60
+}
+
+fn default_window_secs() -> u64 {
+	60
+}
+
+fn default_strategy() -> RateLimitStrategyKind {
+	RateLimitStrategyKind::FixedWindow
+}
+
+/// Serializable mirror of [`RateLimitStrategy`].
+///
+/// [`RateLimitStrategy`] does not derive `Serialize`/`Deserialize`, so this
+/// value object provides the (de)serializable representation used inside
+/// [`RateLimitSettings`]. It is not an independently loadable section.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RateLimitStrategyKind {
+	/// Fixed window rate limiting.
+	#[default]
+	FixedWindow,
+	/// Sliding window rate limiting.
+	SlidingWindow,
+}
+
+impl From<RateLimitStrategyKind> for RateLimitStrategy {
+	fn from(kind: RateLimitStrategyKind) -> Self {
+		match kind {
+			RateLimitStrategyKind::FixedWindow => RateLimitStrategy::FixedWindow,
+			RateLimitStrategyKind::SlidingWindow => RateLimitStrategy::SlidingWindow,
+		}
+	}
+}
+
+impl From<RateLimitStrategy> for RateLimitStrategyKind {
+	fn from(strategy: RateLimitStrategy) -> Self {
+		match strategy {
+			RateLimitStrategy::FixedWindow => RateLimitStrategyKind::FixedWindow,
+			RateLimitStrategy::SlidingWindow => RateLimitStrategyKind::SlidingWindow,
+		}
+	}
+}
+
+/// Rate limiting settings fragment.
+///
+/// Maps to the `[server_rate_limit]` section.
+#[settings(fragment = true, section = "server_rate_limit")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RateLimitSettings {
+	/// Maximum number of requests allowed within the window.
+	#[serde(default = "default_max_requests")]
+	pub max_requests: usize,
+	/// Length of the rate limiting window, in seconds.
+	#[serde(default = "default_window_secs")]
+	pub window_secs: u64,
+	/// Rate limiting strategy.
+	#[serde(default = "default_strategy")]
+	pub strategy: RateLimitStrategyKind,
+	/// Trusted proxy IP addresses/CIDRs.
+	///
+	/// Only requests originating from these addresses will have their
+	/// `X-Forwarded-For`/`X-Real-IP` headers trusted for client IP extraction.
+	#[serde(default)]
+	pub trusted_proxies: Vec<String>,
+}
+
+impl Default for RateLimitSettings {
+	fn default() -> Self {
+		Self {
+			max_requests: default_max_requests(),
+			window_secs: default_window_secs(),
+			strategy: default_strategy(),
+			trusted_proxies: Vec::new(),
+		}
+	}
+}
+
+impl From<&RateLimitSettings> for RateLimitConfig {
+	fn from(settings: &RateLimitSettings) -> Self {
+		RateLimitConfig::new(
+			settings.max_requests,
+			Duration::from_secs(settings.window_secs),
+			settings.strategy.into(),
+		)
+		.with_trusted_proxies(settings.trusted_proxies.clone())
+	}
+}
+
+/// Build a [`RateLimitHandler`] wrapping `inner` from a [`RateLimitSettings`]
+/// fragment.
+pub fn create_rate_limit_handler_from_settings(
+	inner: Arc<dyn Handler>,
+	settings: &RateLimitSettings,
+) -> RateLimitHandler {
+	RateLimitHandler::new(inner, RateLimitConfig::from(settings))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use reinhardt_conf::settings::fragment::SettingsFragment;
+
+	#[rstest::rstest]
+	fn section_name_is_crate_prefixed() {
+		// Arrange / Act / Assert
+		assert_eq!(RateLimitSettings::section(), "server_rate_limit");
+	}
+
+	#[rstest::rstest]
+	fn default_converts_to_config() {
+		// Arrange
+		let settings = RateLimitSettings::default();
+
+		// Act
+		let config = RateLimitConfig::from(&settings);
+
+		// Assert
+		assert_eq!(config.max_requests, 60);
+		assert_eq!(config.window_duration, Duration::from_secs(60));
+		assert_eq!(config.strategy, RateLimitStrategy::FixedWindow);
+		assert!(config.trusted_proxies.is_empty());
+	}
+
+	#[rstest::rstest]
+	fn converts_window_seconds_strategy_and_proxies() {
+		// Arrange
+		let settings = RateLimitSettings {
+			max_requests: 10,
+			window_secs: 3600,
+			strategy: RateLimitStrategyKind::SlidingWindow,
+			trusted_proxies: vec!["10.0.0.0/8".to_string()],
+		};
+
+		// Act
+		let config = RateLimitConfig::from(&settings);
+
+		// Assert
+		assert_eq!(config.max_requests, 10);
+		assert_eq!(config.window_duration, Duration::from_secs(3600));
+		assert_eq!(config.strategy, RateLimitStrategy::SlidingWindow);
+		assert_eq!(config.trusted_proxies, vec!["10.0.0.0/8".to_string()]);
+	}
+
+	#[rstest::rstest]
+	fn deserializes_with_defaults() {
+		// Arrange — only max_requests is provided; everything else uses defaults.
+		let json = r#"{ "max_requests": 100 }"#;
+
+		// Act
+		let settings: RateLimitSettings = serde_json::from_str(json).unwrap();
+		let config = RateLimitConfig::from(&settings);
+
+		// Assert
+		assert_eq!(config.max_requests, 100);
+		assert_eq!(config.window_duration, Duration::from_secs(60));
+		assert_eq!(config.strategy, RateLimitStrategy::FixedWindow);
+		assert!(config.trusted_proxies.is_empty());
+	}
+
+	#[rstest::rstest]
+	fn deserializes_strategy_in_snake_case() {
+		// Arrange
+		let json = r#"{ "strategy": "sliding_window" }"#;
+
+		// Act
+		let settings: RateLimitSettings = serde_json::from_str(json).unwrap();
+
+		// Assert
+		assert_eq!(settings.strategy, RateLimitStrategyKind::SlidingWindow);
+	}
+}

--- a/crates/reinhardt-tasks/Cargo.toml
+++ b/crates/reinhardt-tasks/Cargo.toml
@@ -10,6 +10,8 @@ authors.workspace = true
 
 [dependencies]
 
+reinhardt-core = { workspace = true }
+reinhardt-conf = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/reinhardt-tasks/src/backends.rs
+++ b/crates/reinhardt-tasks/src/backends.rs
@@ -27,9 +27,11 @@ pub use redis::RedisTaskBackend;
 pub use sqlite::SqliteBackend;
 
 #[cfg(feature = "sqs-backend")]
+#[allow(deprecated)] // SqsConfig is deprecated in favor of SqsSettings.
 pub use sqs::{SqsBackend, SqsConfig};
 
 #[cfg(feature = "rabbitmq-backend")]
+#[allow(deprecated)] // RabbitMQConfig is deprecated in favor of RabbitMQSettings.
 pub use rabbitmq::{RabbitMQBackend, RabbitMQConfig};
 
 #[cfg(feature = "kafka-backend")]

--- a/crates/reinhardt-tasks/src/backends/rabbitmq.rs
+++ b/crates/reinhardt-tasks/src/backends/rabbitmq.rs
@@ -35,6 +35,8 @@
 //! # }
 //! ```
 
+#![allow(deprecated)] // RabbitMQConfig is deprecated; it is still constructed internally.
+
 use crate::{
 	Task, TaskId, TaskStatus,
 	backend::{TaskBackend, TaskExecutionError},
@@ -67,6 +69,10 @@ struct QueueMessage {
 ///
 /// let config = RabbitMQConfig::new("amqp://localhost:5672/%2f");
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `RabbitMQSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct RabbitMQConfig {
 	/// AMQP connection URL (e.g., "amqp://localhost:5672/%2f")

--- a/crates/reinhardt-tasks/src/backends/sqs.rs
+++ b/crates/reinhardt-tasks/src/backends/sqs.rs
@@ -1,5 +1,7 @@
 //! AWS SQS-based task backend implementation
 
+#![allow(deprecated)] // SqsConfig is deprecated; it is still constructed internally.
+
 use crate::{
 	Task, TaskExecutionError, TaskId, TaskStatus, registry::SerializedTask, result::ResultBackend,
 	result::TaskResultMetadata,
@@ -30,6 +32,10 @@ struct TaskMetadata {
 ///
 /// let config = SqsConfig::new("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue");
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `SqsSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct SqsConfig {
 	/// SQS queue URL

--- a/crates/reinhardt-tasks/src/lib.rs
+++ b/crates/reinhardt-tasks/src/lib.rs
@@ -89,6 +89,8 @@ pub mod result;
 pub mod retry;
 /// Cron-like task scheduling.
 pub mod scheduler;
+/// Settings-first configuration fragments.
+pub mod settings;
 /// Task trait and execution lifecycle.
 pub mod task;
 /// Webhook notifications for task completion events.
@@ -108,10 +110,16 @@ pub use backends::RedisTaskBackend;
 pub use backends::SqliteBackend;
 
 #[cfg(feature = "sqs-backend")]
-pub use backends::{SqsBackend, SqsConfig};
+pub use backends::SqsBackend;
+#[cfg(feature = "sqs-backend")]
+#[allow(deprecated)] // SqsConfig is deprecated in favor of SqsSettings.
+pub use backends::SqsConfig;
 
 #[cfg(feature = "rabbitmq-backend")]
-pub use backends::{RabbitMQBackend, RabbitMQConfig};
+pub use backends::RabbitMQBackend;
+#[cfg(feature = "rabbitmq-backend")]
+#[allow(deprecated)] // RabbitMQConfig is deprecated in favor of RabbitMQSettings.
+pub use backends::RabbitMQConfig;
 pub use chain::{ChainStatus, TaskChain, TaskChainBuilder};
 pub use dag::{TaskDAG, TaskNode, TaskNodeStatus};
 pub use load_balancer::{LoadBalancer, LoadBalancingStrategy, WorkerId, WorkerInfo, WorkerMetrics};
@@ -121,7 +129,9 @@ pub use locking::{LockToken, MemoryTaskLock, TaskLock};
 pub use locking::RedisTaskLock;
 pub use metrics::{MetricsSnapshot, TaskCounts, TaskMetrics, WorkerStats};
 pub use priority_queue::{Priority, PriorityTaskQueue};
-pub use queue::{QueueConfig, TaskQueue};
+#[allow(deprecated)] // QueueConfig is deprecated in favor of QueueSettings.
+pub use queue::QueueConfig;
+pub use queue::TaskQueue;
 pub use registry::{SerializedTask, TaskFactory, TaskRegistry};
 pub use result::{
 	MemoryResultBackend, ResultBackend, TaskOutput, TaskResult as TaskResultBackend,
@@ -143,10 +153,25 @@ pub use task::{
 	TaskPriority, TaskStatus,
 };
 pub use webhook::{
-	HttpWebhookSender, RetryConfig, TaskStatus as WebhookTaskStatus, WebhookConfig, WebhookError,
-	WebhookEvent, WebhookSender, is_blocked_ip, validate_resolved_ips, validate_webhook_url,
+	HttpWebhookSender, TaskStatus as WebhookTaskStatus, WebhookError, WebhookEvent, WebhookSender,
+	is_blocked_ip, validate_resolved_ips, validate_webhook_url,
 };
-pub use worker::{Worker, WorkerConfig};
+#[allow(deprecated)]
+// RetryConfig/WebhookConfig are deprecated in favor of the *Settings fragments.
+pub use webhook::{RetryConfig, WebhookConfig};
+pub use worker::Worker;
+#[allow(deprecated)] // WorkerConfig is deprecated in favor of WorkerSettings.
+pub use worker::WorkerConfig;
+
+// Settings-first configuration API (preferred over the deprecated `*Config` types).
+pub use settings::{
+	QueueSettings, WebhookRetrySettings, WebhookSettings, WorkerSettings,
+	create_queue_from_settings, create_webhook_sender_from_settings, create_worker_from_settings,
+};
+#[cfg(feature = "rabbitmq-backend")]
+pub use settings::{RabbitMQSettings, create_rabbitmq_backend_from_settings};
+#[cfg(feature = "sqs-backend")]
+pub use settings::{SqsSettings, create_sqs_backend_from_settings};
 
 use thiserror::Error;
 

--- a/crates/reinhardt-tasks/src/queue.rs
+++ b/crates/reinhardt-tasks/src/queue.rs
@@ -1,9 +1,15 @@
 //! Task queue management
 
+#![allow(deprecated)] // QueueConfig is deprecated; it is still constructed internally.
+
 use crate::backend::TaskExecutionError;
 use crate::{Task, TaskBackend, TaskId};
 
 /// Configuration for a task queue.
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `QueueSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct QueueConfig {
 	/// Name of the queue.

--- a/crates/reinhardt-tasks/src/settings.rs
+++ b/crates/reinhardt-tasks/src/settings.rs
@@ -91,6 +91,10 @@ impl From<&QueueSettings> for QueueConfig {
 }
 
 /// Build a [`TaskQueue`] from a [`QueueSettings`] fragment.
+///
+/// Note: [`TaskQueue`] is currently a zero-sized, stateless delegator, so the
+/// queue-level settings (`name`, `max_retries`) are not yet retained or applied
+/// at runtime. Tracked in reinhardt-web#5067.
 pub fn create_queue_from_settings(settings: &QueueSettings) -> TaskQueue {
 	TaskQueue::with_config(QueueConfig::from(settings))
 }

--- a/crates/reinhardt-tasks/src/settings.rs
+++ b/crates/reinhardt-tasks/src/settings.rs
@@ -1,0 +1,520 @@
+//! Settings fragments for task queues, workers, webhooks, and broker backends.
+//!
+//! These fragments are the settings-first configuration entry points for the
+//! task system. Each maps to a `[tasks_*]` TOML section and can be composed
+//! into a project's settings with the `#[settings]` macro. Conversions into the
+//! deprecated compatibility `XxxConfig` types are provided for the migration
+//! window; new code should prefer the fragments and the
+//! `create_*_from_settings` constructors.
+
+#![allow(deprecated)] // Conversions target legacy config types during the compatibility window.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use reinhardt_core::macros::settings;
+use serde::{Deserialize, Serialize};
+
+use crate::queue::{QueueConfig, TaskQueue};
+use crate::webhook::{HttpWebhookSender, RetryConfig, WebhookConfig};
+use crate::worker::{Worker, WorkerConfig};
+
+// --- defaults -------------------------------------------------------------
+
+fn default_queue_name() -> String {
+	"default".to_string()
+}
+fn default_max_retries() -> u32 {
+	3
+}
+fn default_worker_name() -> String {
+	"worker".to_string()
+}
+fn default_concurrency() -> usize {
+	4
+}
+fn default_poll_interval_ms() -> u64 {
+	1000
+}
+fn default_webhook_method() -> String {
+	"POST".to_string()
+}
+fn default_webhook_timeout_secs() -> u64 {
+	5
+}
+fn default_retry_max_retries() -> u32 {
+	3
+}
+fn default_retry_initial_backoff_ms() -> u64 {
+	100
+}
+fn default_retry_max_backoff_ms() -> u64 {
+	30_000
+}
+fn default_retry_backoff_multiplier() -> f64 {
+	2.0
+}
+
+// --- queue ----------------------------------------------------------------
+
+/// Task queue settings fragment.
+///
+/// Maps to the `[tasks_queue]` section.
+#[settings(fragment = true, section = "tasks_queue")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueueSettings {
+	/// The name of the queue.
+	#[serde(default = "default_queue_name")]
+	pub name: String,
+	/// Maximum number of retry attempts for failed tasks.
+	#[serde(default = "default_max_retries")]
+	pub max_retries: u32,
+}
+
+impl Default for QueueSettings {
+	fn default() -> Self {
+		Self {
+			name: default_queue_name(),
+			max_retries: default_max_retries(),
+		}
+	}
+}
+
+impl From<&QueueSettings> for QueueConfig {
+	fn from(settings: &QueueSettings) -> Self {
+		Self {
+			name: settings.name.clone(),
+			max_retries: settings.max_retries,
+		}
+	}
+}
+
+/// Build a [`TaskQueue`] from a [`QueueSettings`] fragment.
+pub fn create_queue_from_settings(settings: &QueueSettings) -> TaskQueue {
+	TaskQueue::with_config(QueueConfig::from(settings))
+}
+
+// --- webhook --------------------------------------------------------------
+
+/// Retry policy value object embedded in [`WebhookSettings`].
+///
+/// This is not an independently loadable section; it is nested under
+/// `[tasks_webhook.retry]`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WebhookRetrySettings {
+	/// Maximum number of retry attempts.
+	#[serde(default = "default_retry_max_retries")]
+	pub max_retries: u32,
+	/// Initial backoff between retries, in milliseconds.
+	#[serde(default = "default_retry_initial_backoff_ms")]
+	pub initial_backoff_ms: u64,
+	/// Maximum backoff between retries, in milliseconds.
+	#[serde(default = "default_retry_max_backoff_ms")]
+	pub max_backoff_ms: u64,
+	/// Backoff multiplier for exponential backoff.
+	#[serde(default = "default_retry_backoff_multiplier")]
+	pub backoff_multiplier: f64,
+}
+
+impl Default for WebhookRetrySettings {
+	fn default() -> Self {
+		Self {
+			max_retries: default_retry_max_retries(),
+			initial_backoff_ms: default_retry_initial_backoff_ms(),
+			max_backoff_ms: default_retry_max_backoff_ms(),
+			backoff_multiplier: default_retry_backoff_multiplier(),
+		}
+	}
+}
+
+impl From<&WebhookRetrySettings> for RetryConfig {
+	fn from(settings: &WebhookRetrySettings) -> Self {
+		Self {
+			max_retries: settings.max_retries,
+			initial_backoff: Duration::from_millis(settings.initial_backoff_ms),
+			max_backoff: Duration::from_millis(settings.max_backoff_ms),
+			backoff_multiplier: settings.backoff_multiplier,
+		}
+	}
+}
+
+/// Webhook delivery settings fragment.
+///
+/// Maps to the `[tasks_webhook]` section.
+#[settings(fragment = true, section = "tasks_webhook")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WebhookSettings {
+	/// Target URL for webhook delivery.
+	#[serde(default)]
+	pub url: String,
+	/// HTTP method to use.
+	#[serde(default = "default_webhook_method")]
+	pub method: String,
+	/// Additional headers to include with each request.
+	#[serde(default)]
+	pub headers: HashMap<String, String>,
+	/// Request timeout, in seconds.
+	#[serde(default = "default_webhook_timeout_secs")]
+	pub timeout_secs: u64,
+	/// Retry policy.
+	#[serde(default)]
+	pub retry: WebhookRetrySettings,
+}
+
+impl Default for WebhookSettings {
+	fn default() -> Self {
+		Self {
+			url: String::new(),
+			method: default_webhook_method(),
+			headers: HashMap::new(),
+			timeout_secs: default_webhook_timeout_secs(),
+			retry: WebhookRetrySettings::default(),
+		}
+	}
+}
+
+impl From<&WebhookSettings> for WebhookConfig {
+	fn from(settings: &WebhookSettings) -> Self {
+		Self {
+			url: settings.url.clone(),
+			method: settings.method.clone(),
+			headers: settings.headers.clone(),
+			timeout: Duration::from_secs(settings.timeout_secs),
+			retry_config: RetryConfig::from(&settings.retry),
+		}
+	}
+}
+
+/// Build an [`HttpWebhookSender`] from a [`WebhookSettings`] fragment.
+pub fn create_webhook_sender_from_settings(settings: &WebhookSettings) -> HttpWebhookSender {
+	HttpWebhookSender::new(WebhookConfig::from(settings))
+}
+
+// --- worker ---------------------------------------------------------------
+
+/// Task worker settings fragment.
+///
+/// Maps to the `[tasks_worker]` section.
+#[settings(fragment = true, section = "tasks_worker")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WorkerSettings {
+	/// Name of this worker instance.
+	#[serde(default = "default_worker_name")]
+	pub name: String,
+	/// Number of concurrent task handlers.
+	#[serde(default = "default_concurrency")]
+	pub concurrency: usize,
+	/// How long to wait between queue polls, in milliseconds.
+	#[serde(default = "default_poll_interval_ms")]
+	pub poll_interval_ms: u64,
+	/// Webhook delivery targets for task completion notifications.
+	#[serde(default)]
+	pub webhooks: Vec<WebhookSettings>,
+}
+
+impl Default for WorkerSettings {
+	fn default() -> Self {
+		Self {
+			name: default_worker_name(),
+			concurrency: default_concurrency(),
+			poll_interval_ms: default_poll_interval_ms(),
+			webhooks: Vec::new(),
+		}
+	}
+}
+
+impl From<&WorkerSettings> for WorkerConfig {
+	fn from(settings: &WorkerSettings) -> Self {
+		Self {
+			name: settings.name.clone(),
+			concurrency: settings.concurrency,
+			poll_interval: Duration::from_millis(settings.poll_interval_ms),
+			webhook_configs: settings.webhooks.iter().map(WebhookConfig::from).collect(),
+		}
+	}
+}
+
+/// Build a [`Worker`] from a [`WorkerSettings`] fragment.
+pub fn create_worker_from_settings(settings: &WorkerSettings) -> Worker {
+	Worker::new(WorkerConfig::from(settings))
+}
+
+// --- sqs backend ----------------------------------------------------------
+
+#[cfg(feature = "sqs-backend")]
+fn default_sqs_visibility_timeout() -> i32 {
+	30
+}
+#[cfg(feature = "sqs-backend")]
+fn default_sqs_max_messages() -> i32 {
+	1
+}
+#[cfg(feature = "sqs-backend")]
+fn default_sqs_wait_time_seconds() -> i32 {
+	0
+}
+
+/// Amazon SQS backend settings fragment.
+///
+/// Maps to the `[tasks_sqs]` section. Available with the `sqs-backend` feature.
+#[cfg(feature = "sqs-backend")]
+#[settings(fragment = true, section = "tasks_sqs")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SqsSettings {
+	/// The SQS queue URL.
+	#[serde(default)]
+	pub queue_url: String,
+	/// Message visibility timeout, in seconds.
+	#[serde(default = "default_sqs_visibility_timeout")]
+	pub visibility_timeout: i32,
+	/// Maximum number of messages to receive per poll (capped at 10 by SQS).
+	#[serde(default = "default_sqs_max_messages")]
+	pub max_messages: i32,
+	/// Wait time for long polling, in seconds.
+	#[serde(default = "default_sqs_wait_time_seconds")]
+	pub wait_time_seconds: i32,
+}
+
+#[cfg(feature = "sqs-backend")]
+impl Default for SqsSettings {
+	fn default() -> Self {
+		Self {
+			queue_url: String::new(),
+			visibility_timeout: default_sqs_visibility_timeout(),
+			max_messages: default_sqs_max_messages(),
+			wait_time_seconds: default_sqs_wait_time_seconds(),
+		}
+	}
+}
+
+#[cfg(feature = "sqs-backend")]
+impl From<&SqsSettings> for crate::backends::sqs::SqsConfig {
+	fn from(settings: &SqsSettings) -> Self {
+		// SqsConfig fields are private; rebuild through the builder API.
+		crate::backends::sqs::SqsConfig::new(settings.queue_url.clone())
+			.with_visibility_timeout(settings.visibility_timeout)
+			.with_max_messages(settings.max_messages)
+			.with_wait_time_seconds(settings.wait_time_seconds)
+	}
+}
+
+/// Build an [`SqsBackend`](crate::backends::sqs::SqsBackend) from an
+/// [`SqsSettings`] fragment.
+#[cfg(feature = "sqs-backend")]
+pub async fn create_sqs_backend_from_settings(
+	settings: &SqsSettings,
+) -> Result<crate::backends::sqs::SqsBackend, crate::TaskExecutionError> {
+	crate::backends::sqs::SqsBackend::new(crate::backends::sqs::SqsConfig::from(settings)).await
+}
+
+// --- rabbitmq backend -----------------------------------------------------
+
+#[cfg(feature = "rabbitmq-backend")]
+fn default_rabbitmq_url() -> String {
+	"amqp://localhost:5672/%2f".to_string()
+}
+#[cfg(feature = "rabbitmq-backend")]
+fn default_rabbitmq_queue_name() -> String {
+	"reinhardt_tasks".to_string()
+}
+#[cfg(feature = "rabbitmq-backend")]
+fn default_rabbitmq_routing_key() -> String {
+	"reinhardt_tasks".to_string()
+}
+
+/// RabbitMQ backend settings fragment.
+///
+/// Maps to the `[tasks_rabbitmq]` section. Available with the
+/// `rabbitmq-backend` feature.
+#[cfg(feature = "rabbitmq-backend")]
+#[settings(fragment = true, section = "tasks_rabbitmq")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RabbitMQSettings {
+	/// The AMQP connection URL.
+	#[serde(default = "default_rabbitmq_url")]
+	pub url: String,
+	/// The queue name to publish to.
+	#[serde(default = "default_rabbitmq_queue_name")]
+	pub queue_name: String,
+	/// The exchange name (empty string for the default exchange).
+	#[serde(default)]
+	pub exchange_name: String,
+	/// The routing key.
+	#[serde(default = "default_rabbitmq_routing_key")]
+	pub routing_key: String,
+}
+
+#[cfg(feature = "rabbitmq-backend")]
+impl Default for RabbitMQSettings {
+	fn default() -> Self {
+		Self {
+			url: default_rabbitmq_url(),
+			queue_name: default_rabbitmq_queue_name(),
+			exchange_name: String::new(),
+			routing_key: default_rabbitmq_routing_key(),
+		}
+	}
+}
+
+#[cfg(feature = "rabbitmq-backend")]
+impl From<&RabbitMQSettings> for crate::backends::rabbitmq::RabbitMQConfig {
+	fn from(settings: &RabbitMQSettings) -> Self {
+		Self {
+			url: settings.url.clone(),
+			queue_name: settings.queue_name.clone(),
+			exchange_name: settings.exchange_name.clone(),
+			routing_key: settings.routing_key.clone(),
+		}
+	}
+}
+
+/// Build a [`RabbitMQBackend`](crate::backends::rabbitmq::RabbitMQBackend) from
+/// a [`RabbitMQSettings`] fragment.
+#[cfg(feature = "rabbitmq-backend")]
+pub async fn create_rabbitmq_backend_from_settings(
+	settings: &RabbitMQSettings,
+) -> Result<crate::backends::rabbitmq::RabbitMQBackend, lapin::Error> {
+	crate::backends::rabbitmq::RabbitMQBackend::new(
+		crate::backends::rabbitmq::RabbitMQConfig::from(settings),
+	)
+	.await
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use reinhardt_conf::settings::fragment::SettingsFragment;
+
+	#[rstest::rstest]
+	fn section_names_are_crate_prefixed() {
+		// Arrange / Act / Assert
+		assert_eq!(QueueSettings::section(), "tasks_queue");
+		assert_eq!(WorkerSettings::section(), "tasks_worker");
+		assert_eq!(WebhookSettings::section(), "tasks_webhook");
+	}
+
+	#[rstest::rstest]
+	fn queue_settings_default_converts_to_config() {
+		// Arrange
+		let settings = QueueSettings::default();
+
+		// Act
+		let config = QueueConfig::from(&settings);
+
+		// Assert
+		assert_eq!(config.name, "default");
+		assert_eq!(config.max_retries, 3);
+	}
+
+	#[rstest::rstest]
+	fn worker_settings_convert_milliseconds_to_duration() {
+		// Arrange
+		let settings = WorkerSettings {
+			name: "ingest".to_string(),
+			concurrency: 8,
+			poll_interval_ms: 2500,
+			webhooks: Vec::new(),
+		};
+
+		// Act
+		let config = WorkerConfig::from(&settings);
+
+		// Assert
+		assert_eq!(config.name, "ingest");
+		assert_eq!(config.concurrency, 8);
+		assert_eq!(config.poll_interval, Duration::from_millis(2500));
+		assert!(config.webhook_configs.is_empty());
+	}
+
+	#[rstest::rstest]
+	fn webhook_settings_convert_seconds_and_nested_retry() {
+		// Arrange
+		let settings = WebhookSettings::default();
+
+		// Act
+		let config = WebhookConfig::from(&settings);
+
+		// Assert
+		assert_eq!(config.method, "POST");
+		assert_eq!(config.timeout, Duration::from_secs(5));
+		assert_eq!(config.retry_config.max_retries, 3);
+		assert_eq!(
+			config.retry_config.initial_backoff,
+			Duration::from_millis(100)
+		);
+		assert_eq!(config.retry_config.max_backoff, Duration::from_secs(30));
+		assert_eq!(config.retry_config.backoff_multiplier, 2.0);
+	}
+
+	#[rstest::rstest]
+	fn worker_settings_map_nested_webhooks() {
+		// Arrange
+		let settings = WorkerSettings {
+			name: "w".to_string(),
+			concurrency: 1,
+			poll_interval_ms: 100,
+			webhooks: vec![WebhookSettings {
+				url: "https://example.com/hook".to_string(),
+				..WebhookSettings::default()
+			}],
+		};
+
+		// Act
+		let config = WorkerConfig::from(&settings);
+
+		// Assert
+		assert_eq!(config.webhook_configs.len(), 1);
+		assert_eq!(config.webhook_configs[0].url, "https://example.com/hook");
+	}
+
+	#[rstest::rstest]
+	fn webhook_settings_deserialize_with_defaults() {
+		// Arrange — only `url` is provided; everything else falls back to defaults.
+		let json = r#"{ "url": "https://example.com/hook", "timeout_secs": 10 }"#;
+
+		// Act
+		let settings: WebhookSettings = serde_json::from_str(json).unwrap();
+		let config = WebhookConfig::from(&settings);
+
+		// Assert
+		assert_eq!(config.url, "https://example.com/hook");
+		assert_eq!(config.method, "POST");
+		assert_eq!(config.timeout, Duration::from_secs(10));
+		assert_eq!(config.retry_config.max_retries, 3);
+	}
+
+	#[cfg(feature = "sqs-backend")]
+	#[rstest::rstest]
+	fn sqs_settings_default_converts_to_config() {
+		// Arrange
+		let settings = SqsSettings {
+			queue_url: "https://sqs.example.com/q".to_string(),
+			..SqsSettings::default()
+		};
+
+		// Act
+		let config = crate::backends::sqs::SqsConfig::from(&settings);
+
+		// Assert — round-trips through the builder, which caps max_messages at 10.
+		assert!(format!("{config:?}").contains("https://sqs.example.com/q"));
+	}
+
+	#[cfg(feature = "rabbitmq-backend")]
+	#[rstest::rstest]
+	fn rabbitmq_settings_default_converts_to_config() {
+		// Arrange
+		let settings = RabbitMQSettings::default();
+
+		// Act
+		let config = crate::backends::rabbitmq::RabbitMQConfig::from(&settings);
+
+		// Assert
+		assert_eq!(config.queue_name, "reinhardt_tasks");
+		assert_eq!(config.routing_key, "reinhardt_tasks");
+	}
+}

--- a/crates/reinhardt-tasks/src/settings.rs
+++ b/crates/reinhardt-tasks/src/settings.rs
@@ -94,7 +94,7 @@ impl From<&QueueSettings> for QueueConfig {
 ///
 /// Note: [`TaskQueue`] is currently a zero-sized, stateless delegator, so the
 /// queue-level settings (`name`, `max_retries`) are not yet retained or applied
-/// at runtime. Tracked in reinhardt-web#5067.
+/// at runtime. Tracked in reinhardt-web#5068.
 pub fn create_queue_from_settings(settings: &QueueSettings) -> TaskQueue {
 	TaskQueue::with_config(QueueConfig::from(settings))
 }

--- a/crates/reinhardt-tasks/src/webhook.rs
+++ b/crates/reinhardt-tasks/src/webhook.rs
@@ -58,6 +58,8 @@
 //! # }
 //! ```
 
+#![allow(deprecated)] // RetryConfig/WebhookConfig are deprecated; still constructed internally.
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use ipnet::IpNet;
@@ -440,6 +442,10 @@ pub struct WebhookEvent {
 /// assert_eq!(config.max_retries, 3);
 /// assert_eq!(config.backoff_multiplier, 2.0);
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `WebhookRetrySettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct RetryConfig {
 	/// Maximum number of retry attempts
@@ -486,6 +492,10 @@ impl Default for RetryConfig {
 /// assert_eq!(config.url, "https://api.example.com/webhooks");
 /// assert_eq!(config.timeout, Duration::from_secs(5));
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `WebhookSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct WebhookConfig {
 	/// Webhook URL

--- a/crates/reinhardt-tasks/src/worker.rs
+++ b/crates/reinhardt-tasks/src/worker.rs
@@ -1,5 +1,7 @@
 //! Task worker
 
+#![allow(deprecated)] // WorkerConfig/WebhookConfig are deprecated; still constructed internally.
+
 use crate::{
 	TaskBackend, TaskStatus,
 	locking::TaskLock,
@@ -29,6 +31,10 @@ use tokio::sync::{Semaphore, broadcast};
 /// assert_eq!(config.name, "my-worker");
 /// assert_eq!(config.concurrency, 8);
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `WorkerSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct WorkerConfig {
 	/// Name of this worker instance.

--- a/crates/reinhardt-tasks/tests/queue_management_tests.rs
+++ b/crates/reinhardt-tasks/tests/queue_management_tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // Exercises the deprecated XxxConfig compatibility API.
+
 //! Task queue management tests
 //!
 //! Tests QueueConfig and TaskQueue implementations.

--- a/crates/reinhardt-tasks/tests/rabbitmq_backend_integration.rs
+++ b/crates/reinhardt-tasks/tests/rabbitmq_backend_integration.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // Exercises the deprecated XxxConfig compatibility API.
+
 //! RabbitMQ backend integration tests
 //!
 //! Tests task enqueue/dequeue, durability, message persistence, and RabbitMQ-specific features.

--- a/crates/reinhardt-testkit/src/fixtures/server.rs
+++ b/crates/reinhardt-testkit/src/fixtures/server.rs
@@ -3,6 +3,10 @@
 //! This module provides rstest fixtures for testing HTTP servers with automatic
 //! cleanup via RAII pattern.
 
+// `RateLimitConfig` is deprecated in favor of the `RateLimitSettings` fragment;
+// these fixtures still build it directly during the 0.2 compatibility window.
+#![allow(deprecated)]
+
 use reinhardt_di::InjectionContext;
 use reinhardt_http::Handler;
 use reinhardt_http::{Request, Response};

--- a/crates/reinhardt-websockets/Cargo.toml
+++ b/crates/reinhardt-websockets/Cargo.toml
@@ -31,6 +31,7 @@ bytes = { workspace = true }
 once_cell = "1.19"
 inventory = { workspace = true }
 reinhardt-core = { workspace = true }
+reinhardt-conf = { workspace = true, features = ["settings"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # Dependency injection (optional)

--- a/crates/reinhardt-websockets/src/connection.rs
+++ b/crates/reinhardt-websockets/src/connection.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // `ConnectionConfig` is deprecated but still used internally during the compatibility window.
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -145,6 +147,10 @@ impl PingPongConfig {
 /// assert_eq!(config.handshake_timeout(), Duration::from_secs(10));
 /// assert_eq!(config.cleanup_interval(), Duration::from_secs(30));
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `ConnectionSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct ConnectionConfig {
 	idle_timeout: Duration,

--- a/crates/reinhardt-websockets/src/handler.rs
+++ b/crates/reinhardt-websockets/src/handler.rs
@@ -1,5 +1,7 @@
 //! WebSocket handler
 
+#![allow(deprecated)] // `ReconnectionConfig` is deprecated but still named here during the compatibility window.
+
 use crate::connection::Message;
 use crate::connection::WebSocketResult;
 use crate::reconnection::ReconnectionConfig;

--- a/crates/reinhardt-websockets/src/lib.rs
+++ b/crates/reinhardt-websockets/src/lib.rs
@@ -180,6 +180,8 @@ pub mod redis_channel;
 pub mod room;
 /// URL-based WebSocket endpoint routing.
 pub mod routing;
+/// Settings-first configuration fragments.
+pub mod settings;
 /// Connection and message rate limiting.
 pub mod throttling;
 
@@ -196,9 +198,11 @@ pub use compression::{
 	CompressionCodec, CompressionConfig, compress_message, decompress_message,
 	decompress_message_with_config,
 };
+#[allow(deprecated)] // `ConnectionConfig` is deprecated in favor of `ConnectionSettings`.
+pub use connection::ConnectionConfig;
 pub use connection::{
-	ConnectionConfig, ConnectionTimeoutMonitor, HeartbeatConfig, HeartbeatMonitor, Message,
-	PingPongConfig, WebSocketConnection, WebSocketError, WebSocketResult,
+	ConnectionTimeoutMonitor, HeartbeatConfig, HeartbeatMonitor, Message, PingPongConfig,
+	WebSocketConnection, WebSocketError, WebSocketResult,
 };
 pub use consumers::{
 	BroadcastConsumer, ConsumerChain, ConsumerContext, EchoConsumer, JsonConsumer,
@@ -216,26 +220,41 @@ pub use middleware::{
 	MessageMiddleware, MessageSizeLimitMiddleware, MiddlewareChain, MiddlewareError,
 	MiddlewareResult,
 };
-pub use origin::{
-	OriginPolicy, OriginValidationConfig, OriginValidationMiddleware, validate_origin,
-};
+#[allow(deprecated)]
+// `OriginValidationConfig` is deprecated in favor of `OriginValidationSettings`.
+pub use origin::OriginValidationConfig;
+pub use origin::{OriginPolicy, OriginValidationMiddleware, validate_origin};
 pub use protocol::{
 	DEFAULT_MAX_FRAME_SIZE, DEFAULT_MAX_MESSAGE_SIZE, default_websocket_config,
 	websocket_config_with_limits,
 };
-pub use reconnection::{
-	AutoReconnectHandler, ReconnectionConfig, ReconnectionState, ReconnectionStrategy,
-};
+#[allow(deprecated)] // `ReconnectionConfig` is deprecated in favor of `ReconnectionSettings`.
+pub use reconnection::ReconnectionConfig;
+pub use reconnection::{AutoReconnectHandler, ReconnectionState, ReconnectionStrategy};
 #[cfg(feature = "redis-channel")]
-pub use redis_channel::{RedisChannelLayer, RedisConfig};
+pub use redis_channel::RedisChannelLayer;
+#[cfg(feature = "redis-channel")]
+#[allow(deprecated)] // `RedisConfig` is deprecated in favor of `RedisChannelSettings`.
+pub use redis_channel::RedisConfig;
 pub use room::{BroadcastResult, Room, RoomError, RoomManager, RoomResult};
 pub use routing::{
 	RouteError, RouteResult, WebSocketRoute, WebSocketRouter, clear_websocket_router,
 	get_websocket_router, register_websocket_router, reverse_websocket_url,
 };
+pub use settings::{
+	ConnectionSettings, OriginPolicySettings, OriginValidationSettings, RateLimitSettings,
+	ReconnectionSettings, create_connection_config_from_settings,
+	create_origin_validation_config_from_settings, create_rate_limit_config_from_settings,
+	create_reconnection_config_from_settings,
+};
+#[cfg(feature = "redis-channel")]
+pub use settings::{RedisChannelSettings, create_redis_config_from_settings};
+#[allow(deprecated)]
+// `WebSocketRateLimitConfig` is deprecated in favor of `RateLimitSettings`.
+pub use throttling::WebSocketRateLimitConfig;
 pub use throttling::{
 	CombinedThrottler, ConnectionRateLimiter, ConnectionThrottler, RateLimitConfig,
-	RateLimitMiddleware, RateLimiter, ThrottleError, ThrottleResult, WebSocketRateLimitConfig,
+	RateLimitMiddleware, RateLimiter, ThrottleError, ThrottleResult,
 };
 
 #[cfg(test)]

--- a/crates/reinhardt-websockets/src/origin.rs
+++ b/crates/reinhardt-websockets/src/origin.rs
@@ -18,6 +18,8 @@
 //! );
 //! ```
 
+#![allow(deprecated)] // `OriginValidationConfig` is deprecated but still used internally during the compatibility window.
+
 use crate::connection::WebSocketConnection;
 use crate::middleware::{
 	ConnectionContext, ConnectionMiddleware, MiddlewareError, MiddlewareResult,
@@ -38,6 +40,10 @@ pub enum OriginPolicy {
 }
 
 /// Configuration for Origin validation behavior
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `OriginValidationSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct OriginValidationConfig {
 	/// The origin policy to apply

--- a/crates/reinhardt-websockets/src/reconnection.rs
+++ b/crates/reinhardt-websockets/src/reconnection.rs
@@ -22,6 +22,8 @@
 //! }
 //! ```
 
+#![allow(deprecated)] // `ReconnectionConfig` is deprecated but still used internally during the compatibility window.
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -54,6 +56,10 @@ pub enum ReconnectionState {
 }
 
 /// Reconnection configuration
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `ReconnectionSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct ReconnectionConfig {
 	/// Maximum number of reconnection attempts (None for unlimited)

--- a/crates/reinhardt-websockets/src/redis_channel.rs
+++ b/crates/reinhardt-websockets/src/redis_channel.rs
@@ -23,6 +23,8 @@
 //! # });
 //! ```
 
+#![allow(deprecated)] // `RedisConfig` is deprecated but still used internally during the compatibility window.
+
 #[cfg(feature = "redis-channel")]
 use crate::channels::{ChannelError, ChannelLayer, ChannelMessage, ChannelResult};
 #[cfg(feature = "redis-channel")]
@@ -36,6 +38,10 @@ use tracing::warn;
 
 /// Redis channel layer configuration
 #[cfg(feature = "redis-channel")]
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `RedisChannelSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct RedisConfig {
 	/// Redis connection URL

--- a/crates/reinhardt-websockets/src/settings.rs
+++ b/crates/reinhardt-websockets/src/settings.rs
@@ -1,0 +1,486 @@
+//! Settings-first configuration fragments for WebSocket support.
+//!
+//! These fragments are the settings-first configuration entry points for the
+//! WebSocket layer. Each public, independently loadable fragment maps to a
+//! `[ws_*]` TOML section and can be composed into a project's settings with the
+//! `#[settings]` macro. Conversions into the deprecated compatibility
+//! `XxxConfig` types are provided for the migration window; new code should
+//! prefer the fragments and the `create_*_from_settings` constructors.
+
+#![allow(deprecated)] // Conversions target legacy config types during the compatibility window.
+
+use std::time::Duration;
+
+use reinhardt_core::macros::settings;
+use serde::{Deserialize, Serialize};
+
+use crate::connection::ConnectionConfig;
+use crate::origin::{OriginPolicy, OriginValidationConfig};
+use crate::reconnection::ReconnectionConfig;
+use crate::throttling::WebSocketRateLimitConfig;
+
+#[cfg(feature = "redis-channel")]
+use crate::redis_channel::RedisConfig;
+
+// --- defaults -------------------------------------------------------------
+
+fn default_idle_timeout_secs() -> u64 {
+	300
+}
+fn default_handshake_timeout_secs() -> u64 {
+	10
+}
+fn default_cleanup_interval_secs() -> u64 {
+	30
+}
+fn default_reconnect_max_attempts() -> Option<u32> {
+	Some(10)
+}
+fn default_reconnect_initial_delay_secs() -> u64 {
+	1
+}
+fn default_reconnect_max_delay_secs() -> u64 {
+	300
+}
+fn default_reconnect_backoff_multiplier() -> f64 {
+	2.0
+}
+fn default_reconnect_jitter_factor() -> f64 {
+	0.1
+}
+fn default_reject_missing_origin() -> bool {
+	true
+}
+fn default_rate_max_connections_per_window() -> usize {
+	20
+}
+fn default_rate_connection_window_secs() -> u64 {
+	60
+}
+fn default_rate_max_concurrent_connections_per_ip() -> usize {
+	10
+}
+fn default_rate_max_messages_per_window() -> usize {
+	100
+}
+fn default_rate_message_window_secs() -> u64 {
+	60
+}
+
+#[cfg(feature = "redis-channel")]
+fn default_redis_url() -> String {
+	"redis://127.0.0.1:6379".to_string()
+}
+#[cfg(feature = "redis-channel")]
+fn default_redis_channel_prefix() -> String {
+	"ws:channel:".to_string()
+}
+#[cfg(feature = "redis-channel")]
+fn default_redis_group_prefix() -> String {
+	"ws:group:".to_string()
+}
+#[cfg(feature = "redis-channel")]
+fn default_redis_message_expiry() -> u64 {
+	60
+}
+#[cfg(feature = "redis-channel")]
+fn default_redis_require_auth() -> bool {
+	true
+}
+
+// --- connection -----------------------------------------------------------
+
+/// WebSocket connection settings fragment.
+///
+/// Maps to the `[ws_connection]` section.
+#[settings(fragment = true, section = "ws_connection")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ConnectionSettings {
+	/// Maximum duration a connection can be idle before being closed, in seconds.
+	#[serde(default = "default_idle_timeout_secs")]
+	pub idle_timeout_secs: u64,
+	/// Maximum duration for the WebSocket handshake to complete, in seconds.
+	#[serde(default = "default_handshake_timeout_secs")]
+	pub handshake_timeout_secs: u64,
+	/// Interval for checking idle connections, in seconds.
+	#[serde(default = "default_cleanup_interval_secs")]
+	pub cleanup_interval_secs: u64,
+	/// Maximum number of concurrent connections allowed (None for unlimited).
+	#[serde(default)]
+	pub max_connections: Option<usize>,
+}
+
+impl Default for ConnectionSettings {
+	fn default() -> Self {
+		Self {
+			idle_timeout_secs: default_idle_timeout_secs(),
+			handshake_timeout_secs: default_handshake_timeout_secs(),
+			cleanup_interval_secs: default_cleanup_interval_secs(),
+			max_connections: None,
+		}
+	}
+}
+
+impl From<&ConnectionSettings> for ConnectionConfig {
+	fn from(settings: &ConnectionSettings) -> Self {
+		// `ConnectionConfig` has private fields, so rebuild through its builder.
+		ConnectionConfig::new()
+			.with_idle_timeout(Duration::from_secs(settings.idle_timeout_secs))
+			.with_handshake_timeout(Duration::from_secs(settings.handshake_timeout_secs))
+			.with_cleanup_interval(Duration::from_secs(settings.cleanup_interval_secs))
+			.with_max_connections(settings.max_connections)
+	}
+}
+
+/// Build a [`ConnectionConfig`] from a [`ConnectionSettings`] fragment.
+pub fn create_connection_config_from_settings(settings: &ConnectionSettings) -> ConnectionConfig {
+	ConnectionConfig::from(settings)
+}
+
+// --- reconnection ---------------------------------------------------------
+
+/// WebSocket reconnection settings fragment.
+///
+/// Maps to the `[ws_reconnection]` section.
+#[settings(fragment = true, section = "ws_reconnection")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReconnectionSettings {
+	/// Maximum number of reconnection attempts (None for unlimited).
+	#[serde(default = "default_reconnect_max_attempts")]
+	pub max_attempts: Option<u32>,
+	/// Initial reconnection delay, in seconds.
+	#[serde(default = "default_reconnect_initial_delay_secs")]
+	pub initial_delay_secs: u64,
+	/// Maximum reconnection delay, in seconds.
+	#[serde(default = "default_reconnect_max_delay_secs")]
+	pub max_delay_secs: u64,
+	/// Backoff multiplier for exponential backoff.
+	#[serde(default = "default_reconnect_backoff_multiplier")]
+	pub backoff_multiplier: f64,
+	/// Jitter factor applied to each delay (0.1 = 10%).
+	#[serde(default = "default_reconnect_jitter_factor")]
+	pub jitter_factor: f64,
+}
+
+impl Default for ReconnectionSettings {
+	fn default() -> Self {
+		Self {
+			max_attempts: default_reconnect_max_attempts(),
+			initial_delay_secs: default_reconnect_initial_delay_secs(),
+			max_delay_secs: default_reconnect_max_delay_secs(),
+			backoff_multiplier: default_reconnect_backoff_multiplier(),
+			jitter_factor: default_reconnect_jitter_factor(),
+		}
+	}
+}
+
+impl From<&ReconnectionSettings> for ReconnectionConfig {
+	fn from(settings: &ReconnectionSettings) -> Self {
+		// `ReconnectionConfig` fields are public, so build it directly.
+		ReconnectionConfig {
+			max_attempts: settings.max_attempts,
+			initial_delay: Duration::from_secs(settings.initial_delay_secs),
+			max_delay: Duration::from_secs(settings.max_delay_secs),
+			backoff_multiplier: settings.backoff_multiplier,
+			jitter_factor: settings.jitter_factor,
+		}
+	}
+}
+
+/// Build a [`ReconnectionConfig`] from a [`ReconnectionSettings`] fragment.
+pub fn create_reconnection_config_from_settings(
+	settings: &ReconnectionSettings,
+) -> ReconnectionConfig {
+	ReconnectionConfig::from(settings)
+}
+
+// --- origin validation ----------------------------------------------------
+
+/// Origin validation policy as a serializable value object.
+///
+/// This mirrors [`OriginPolicy`] but is `Serialize`/`Deserialize` so it can be
+/// loaded from settings. It is nested under [`OriginValidationSettings`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "mode", content = "origins")]
+pub enum OriginPolicySettings {
+	/// Allow only specific origins.
+	AllowList(Vec<String>),
+	/// Allow all origins (disables validation; not recommended for production).
+	AllowAll,
+}
+
+impl Default for OriginPolicySettings {
+	fn default() -> Self {
+		// Mirror `OriginValidationConfig::default()`: an empty allow-list that
+		// rejects every origin until explicitly configured.
+		OriginPolicySettings::AllowList(Vec::new())
+	}
+}
+
+impl From<&OriginPolicySettings> for OriginPolicy {
+	fn from(settings: &OriginPolicySettings) -> Self {
+		match settings {
+			OriginPolicySettings::AllowList(origins) => OriginPolicy::AllowList(origins.clone()),
+			OriginPolicySettings::AllowAll => OriginPolicy::AllowAll,
+		}
+	}
+}
+
+/// Origin validation settings fragment.
+///
+/// Maps to the `[ws_origin]` section and controls Cross-Site WebSocket
+/// Hijacking (CSWSH) protection during the handshake.
+#[settings(fragment = true, section = "ws_origin")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OriginValidationSettings {
+	/// The origin policy to apply.
+	#[serde(default)]
+	pub policy: OriginPolicySettings,
+	/// Whether to reject connections with a missing Origin header.
+	#[serde(default = "default_reject_missing_origin")]
+	pub reject_missing_origin: bool,
+}
+
+impl Default for OriginValidationSettings {
+	fn default() -> Self {
+		Self {
+			policy: OriginPolicySettings::default(),
+			reject_missing_origin: default_reject_missing_origin(),
+		}
+	}
+}
+
+impl From<&OriginValidationSettings> for OriginValidationConfig {
+	fn from(settings: &OriginValidationSettings) -> Self {
+		OriginValidationConfig {
+			policy: OriginPolicy::from(&settings.policy),
+			reject_missing_origin: settings.reject_missing_origin,
+		}
+	}
+}
+
+/// Build an [`OriginValidationConfig`] from an [`OriginValidationSettings`] fragment.
+pub fn create_origin_validation_config_from_settings(
+	settings: &OriginValidationSettings,
+) -> OriginValidationConfig {
+	OriginValidationConfig::from(settings)
+}
+
+// --- rate limiting --------------------------------------------------------
+
+/// WebSocket rate limit settings fragment.
+///
+/// Maps to the `[ws_rate_limit]` section.
+#[settings(fragment = true, section = "ws_rate_limit")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RateLimitSettings {
+	/// Maximum new connections per IP within the connection window.
+	#[serde(default = "default_rate_max_connections_per_window")]
+	pub max_connections_per_window: usize,
+	/// Time window for connection rate limiting, in seconds.
+	#[serde(default = "default_rate_connection_window_secs")]
+	pub connection_window_secs: u64,
+	/// Maximum concurrent connections per IP.
+	#[serde(default = "default_rate_max_concurrent_connections_per_ip")]
+	pub max_concurrent_connections_per_ip: usize,
+	/// Maximum messages per connection within the message window.
+	#[serde(default = "default_rate_max_messages_per_window")]
+	pub max_messages_per_window: usize,
+	/// Time window for message rate limiting, in seconds.
+	#[serde(default = "default_rate_message_window_secs")]
+	pub message_window_secs: u64,
+}
+
+impl Default for RateLimitSettings {
+	fn default() -> Self {
+		Self {
+			max_connections_per_window: default_rate_max_connections_per_window(),
+			connection_window_secs: default_rate_connection_window_secs(),
+			max_concurrent_connections_per_ip: default_rate_max_concurrent_connections_per_ip(),
+			max_messages_per_window: default_rate_max_messages_per_window(),
+			message_window_secs: default_rate_message_window_secs(),
+		}
+	}
+}
+
+impl From<&RateLimitSettings> for WebSocketRateLimitConfig {
+	fn from(settings: &RateLimitSettings) -> Self {
+		// `WebSocketRateLimitConfig` has private fields, so rebuild through its builder.
+		WebSocketRateLimitConfig::default()
+			.with_max_connections_per_window(settings.max_connections_per_window)
+			.with_connection_window(Duration::from_secs(settings.connection_window_secs))
+			.with_max_concurrent_connections_per_ip(settings.max_concurrent_connections_per_ip)
+			.with_max_messages_per_window(settings.max_messages_per_window)
+			.with_message_window(Duration::from_secs(settings.message_window_secs))
+	}
+}
+
+/// Build a [`WebSocketRateLimitConfig`] from a [`RateLimitSettings`] fragment.
+pub fn create_rate_limit_config_from_settings(
+	settings: &RateLimitSettings,
+) -> WebSocketRateLimitConfig {
+	WebSocketRateLimitConfig::from(settings)
+}
+
+// --- redis channel layer --------------------------------------------------
+
+/// Redis channel layer settings fragment.
+///
+/// Maps to the `[ws_redis]` section. Requires the `redis-channel` feature.
+#[cfg(feature = "redis-channel")]
+#[settings(fragment = true, section = "ws_redis")]
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RedisChannelSettings {
+	/// Redis connection URL.
+	#[serde(default = "default_redis_url")]
+	pub url: String,
+	/// Channel key prefix.
+	#[serde(default = "default_redis_channel_prefix")]
+	pub channel_prefix: String,
+	/// Group key prefix.
+	#[serde(default = "default_redis_group_prefix")]
+	pub group_prefix: String,
+	/// Message expiry time, in seconds.
+	#[serde(default = "default_redis_message_expiry")]
+	pub message_expiry: u64,
+	/// Redis password for authentication.
+	#[serde(default)]
+	pub password: Option<String>,
+	/// Redis username for authentication (Redis 6+ ACL).
+	#[serde(default)]
+	pub username: Option<String>,
+	/// Enable TLS for secure connection.
+	#[serde(default)]
+	pub tls: bool,
+	/// Require authentication (warns if disabled without credentials).
+	#[serde(default = "default_redis_require_auth")]
+	pub require_auth: bool,
+}
+
+#[cfg(feature = "redis-channel")]
+impl Default for RedisChannelSettings {
+	fn default() -> Self {
+		Self {
+			url: default_redis_url(),
+			channel_prefix: default_redis_channel_prefix(),
+			group_prefix: default_redis_group_prefix(),
+			message_expiry: default_redis_message_expiry(),
+			password: None,
+			username: None,
+			tls: false,
+			require_auth: default_redis_require_auth(),
+		}
+	}
+}
+
+#[cfg(feature = "redis-channel")]
+impl From<&RedisChannelSettings> for RedisConfig {
+	fn from(settings: &RedisChannelSettings) -> Self {
+		// `RedisConfig` fields are public, so build it directly.
+		RedisConfig {
+			url: settings.url.clone(),
+			channel_prefix: settings.channel_prefix.clone(),
+			group_prefix: settings.group_prefix.clone(),
+			message_expiry: settings.message_expiry,
+			password: settings.password.clone(),
+			username: settings.username.clone(),
+			tls: settings.tls,
+			require_auth: settings.require_auth,
+		}
+	}
+}
+
+/// Build a [`RedisConfig`] from a [`RedisChannelSettings`] fragment.
+#[cfg(feature = "redis-channel")]
+pub fn create_redis_config_from_settings(settings: &RedisChannelSettings) -> RedisConfig {
+	RedisConfig::from(settings)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn connection_settings_default_converts() {
+		let settings = ConnectionSettings::default();
+		let config = ConnectionConfig::from(&settings);
+		assert_eq!(config.idle_timeout(), Duration::from_secs(300));
+		assert_eq!(config.handshake_timeout(), Duration::from_secs(10));
+		assert_eq!(config.cleanup_interval(), Duration::from_secs(30));
+		assert_eq!(config.max_connections(), None);
+	}
+
+	#[test]
+	fn reconnection_settings_default_converts() {
+		let settings = ReconnectionSettings::default();
+		let config = ReconnectionConfig::from(&settings);
+		assert_eq!(config.max_attempts, Some(10));
+		assert_eq!(config.initial_delay, Duration::from_secs(1));
+		assert_eq!(config.max_delay, Duration::from_secs(300));
+		assert_eq!(config.backoff_multiplier, 2.0);
+		assert_eq!(config.jitter_factor, 0.1);
+	}
+
+	#[test]
+	fn origin_settings_default_rejects_all() {
+		let settings = OriginValidationSettings::default();
+		let config = OriginValidationConfig::from(&settings);
+		assert!(config.reject_missing_origin);
+		assert!(matches!(config.policy, OriginPolicy::AllowList(ref v) if v.is_empty()));
+	}
+
+	#[test]
+	fn origin_settings_allow_list_roundtrips() {
+		let settings = OriginValidationSettings {
+			policy: OriginPolicySettings::AllowList(vec!["https://example.com".to_string()]),
+			reject_missing_origin: false,
+		};
+		let config = OriginValidationConfig::from(&settings);
+		assert!(!config.reject_missing_origin);
+		match config.policy {
+			OriginPolicy::AllowList(origins) => {
+				assert_eq!(origins, vec!["https://example.com".to_string()]);
+			}
+			OriginPolicy::AllowAll => panic!("expected AllowList"),
+		}
+	}
+
+	#[test]
+	fn rate_limit_settings_default_converts() {
+		let settings = RateLimitSettings::default();
+		let config = WebSocketRateLimitConfig::from(&settings);
+		assert_eq!(config.max_connections_per_window(), 20);
+		assert_eq!(config.connection_window(), Duration::from_secs(60));
+		assert_eq!(config.max_concurrent_connections_per_ip(), 10);
+		assert_eq!(config.max_messages_per_window(), 100);
+		assert_eq!(config.message_window(), Duration::from_secs(60));
+	}
+
+	#[test]
+	fn origin_policy_settings_serde_roundtrip() {
+		let settings = OriginValidationSettings::default();
+		let json = serde_json::to_string(&settings).expect("serialize");
+		let parsed: OriginValidationSettings = serde_json::from_str(&json).expect("deserialize");
+		assert_eq!(parsed.reject_missing_origin, settings.reject_missing_origin);
+	}
+
+	#[cfg(feature = "redis-channel")]
+	#[test]
+	fn redis_settings_default_converts() {
+		let settings = RedisChannelSettings::default();
+		let config = RedisConfig::from(&settings);
+		assert_eq!(config.url, "redis://127.0.0.1:6379");
+		assert_eq!(config.channel_prefix, "ws:channel:");
+		assert_eq!(config.group_prefix, "ws:group:");
+		assert_eq!(config.message_expiry, 60);
+		assert!(config.password.is_none());
+		assert!(config.username.is_none());
+		assert!(!config.tls);
+		assert!(config.require_auth);
+	}
+}

--- a/crates/reinhardt-websockets/src/throttling.rs
+++ b/crates/reinhardt-websockets/src/throttling.rs
@@ -17,6 +17,8 @@
 //! These can be composed via [`WebSocketRateLimitConfig`] and applied as middleware
 //! through [`RateLimitMiddleware`].
 
+#![allow(deprecated)] // `WebSocketRateLimitConfig` is deprecated but still used internally during the compatibility window.
+
 use crate::connection::{Message, WebSocketConnection};
 use crate::middleware::{
 	ConnectionContext, ConnectionMiddleware, MessageMiddleware, MiddlewareError, MiddlewareResult,
@@ -515,6 +517,10 @@ impl ConnectionRateLimiter {
 /// assert_eq!(config.max_connections_per_window(), 50);
 /// assert_eq!(config.max_messages_per_window(), 200);
 /// ```
+#[deprecated(
+	since = "0.2.0",
+	note = "Use `RateLimitSettings` with the `#[settings]` macro instead."
+)]
 #[derive(Debug, Clone)]
 pub struct WebSocketRateLimitConfig {
 	/// Maximum new connections per IP within the connection window

--- a/src/exports/settings.rs
+++ b/src/exports/settings.rs
@@ -8,6 +8,9 @@ pub use reinhardt_conf::settings::profile::Profile;
 pub use reinhardt_conf::settings::sources::{
 	DefaultSource, EnvSource, LowPriorityEnvSource, TomlFileSource,
 };
+// This block re-exports the deprecated `TemplateConfig` during the 0.2
+// compatibility window; the settings-first replacement is `TemplateSettings`.
+#[allow(deprecated)]
 pub use reinhardt_conf::settings::{
 	CacheSettings, CorsSettings, DatabaseConfig, EmailSettings, LoggingSettings, MediaSettings,
 	MiddlewareConfig, SessionSettings, SettingsError, StaticSettings, TemplateConfig,


### PR DESCRIPTION
## Summary

Makes `#[settings(fragment = true, section = "...")]` fragments the canonical
application-configuration API and **deprecates** the ad-hoc public `XxxConfig`
structs that represent loadable application settings, while staying fully
backward compatible. Implements issue #4978, replicating the pattern already
established by `reinhardt-storages` (#4981).

For each migrated config type:
- a new `XxxSettings` fragment (`#[settings(fragment = true, section = "<crate>_<name>")]`)
  with `serde` defaults and a `Default` impl;
- `#[deprecated(since = "0.2.0", note = "Use \`XxxSettings\` …")]` on the legacy struct;
- a `From<&XxxSettings>` conversion bridge (durations stored as integer
  `*_ms` / `*_secs`, converted in the bridge; private-field configs rebuilt via
  their builder);
- a `create_*_from_settings(...)` constructor;
- `#![allow(deprecated)]` shields on every module / test / re-export that still
  names the legacy type during the compatibility window.

## Crates migrated (9)

| Crate | New sections | Notes |
|-------|-------------|-------|
| reinhardt-tasks | `tasks_queue`, `tasks_worker`, `tasks_webhook`, `tasks_sqs`*, `tasks_rabbitmq`* | pilot; SQS/RabbitMQ feature-gated |
| reinhardt-conf | — | deprecate `TemplateConfig` → existing `TemplateSettings` (BRIDGE) |
| reinhardt-server | `server_rate_limit` | |
| reinhardt-grpc | `grpc_server` | private fields rebuilt via builder |
| reinhardt-deeplink | `deeplink_app` | iOS/Android/custom kept as nested value objects |
| reinhardt-websockets | `ws_connection`, `ws_reconnection`, `ws_origin`, `ws_rate_limit`, `ws_redis`* | `ws_origin` is CSWSH defense; default reject-all preserved |
| reinhardt-auth | `auth_session`, `auth_jwt_session`, `auth_token_rotation` | OAuth/OIDC kept nested; JWT HMAC key-length validation preserved |
| reinhardt-middleware | — | deprecate `CorsConfig` → existing `CorsSettings` (BRIDGE) |
| reinhardt-mail | — | deprecate `SmtpConfig` → existing `EmailSettings` (BRIDGE) |

`*` = feature-gated section. All new sections are crate-prefixed and globally
unique (0 collisions against the reserved set or each other).

A final group of `fix:` commits shields downstream consumers of the newly
deprecated types so the workspace stays warning-clean: `reinhardt-apps` and the
`reinhardt` umbrella re-export `TemplateConfig`;
`reinhardt-middleware::BrokenLinkMiddleware::send_notification` constructs
`SmtpConfig::default()`.

## Verification

- `cargo clippy --workspace -- -D warnings` (default features): **clean** — zero
  `use of deprecated` diagnostics and zero errors across the workspace.
- Per-crate `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
  and unit tests pass for each migrated crate; feature matrices exercised for
  the feature-gated fragments (tasks `sqs-backend`/`rabbitmq-backend`,
  websockets `redis`, grpc `di`).
- New settings round-trip / deserialization unit tests added per crate.

### Pre-existing debt (NOT introduced here, out of scope)

`cargo clippy --all-targets` / `--all-features` surfaces lints present on
pristine `origin/develop/0.2.0` and unrelated to this change (e.g.
`reinhardt-grpc/tests/feature_flags_tests.rs` `assertions_on_constants`, several
`reinhardt-middleware/tests/*` fixture lints, a
`reinhardt-conf/tests/composable/sanity.rs` lint). These belong in a separate
chore PR.

## Deferred follow-ups for #4978

- **reinhardt-utils** and **reinhardt-rest** were not completed in this pass
  (utils has feature-gated storage configs that overlap the reserved
  `storage`/`static_files` sections; rest's `BrowsableApiConfig` plus the
  `VersioningConfig` bridge remain). To be done in a follow-up.
- **reinhardt-core** `CsrfConfig` / `SecurityHeadersConfig` / `HstsConfig`: the
  settings bridge already exists in `reinhardt-middleware::security_middleware`;
  adding `#[deprecated]` to these three is a coordinated, security-sensitive
  multi-crate change deferred to a dedicated follow-up.
- Remaining middleware param/feature configs (cache/rate-limit/metrics/tracing/…)
  were conservatively kept as future NEW-FRAGMENT candidates under `mw_*`.

## Is this a breaking change?

No — backward compatible (SemVer MINOR). Deprecated structs remain available
with conversions; callers receive deprecation warnings pointing at the
replacement fragment.

Refs #4978

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a settings-first configuration system across subsystems with factory helpers to build runtime components from settings.

* **Deprecations**
  * Legacy configuration structs are deprecated in favor of the new settings-fragments; migration helpers provided to ease transition.

* **Documentation & Tests**
  * Examples and tests updated to demonstrate the new settings workflow and compatibility guidance.

* **Chores**
  * Updated workspace dependencies to support the new settings infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->