### PR TITLE
fix(examples): use kebab-case URL names in tutorial-rest snippets

### DIFF
--- a/examples/examples-tutorial-rest/README.md
+++ b/examples/examples-tutorial-rest/README.md
@@ -173,12 +173,12 @@ pub struct SnippetSerializer {
 // available since rc.5). The macro extracts `Json<SnippetSerializer>`, calls
 // `Validate::validate` on the dereferenced value, and returns HTTP 400 with
 // JSON error details on failure — all before this function body runs.
-#[get("/snippets/", name = "snippets_list")]
+#[get("/snippets/", name = "snippets-list")]
 pub async fn list() -> ViewResult<Response> {
     // List all snippets — return JSON via `Response::new(StatusCode::OK).with_body(...)`.
 }
 
-#[post("/snippets/", name = "snippets_create", pre_validate = true)]
+#[post("/snippets/", name = "snippets-create", pre_validate = true)]
 pub async fn create(Json(serializer): Json<SnippetSerializer>) -> ViewResult<Response> {
     // `serializer` is already validated. Just persist and return 201.
 }
@@ -191,7 +191,7 @@ The snippets app exposes a single `url_patterns()` entry point in
 `#[url_patterns(InstalledApp::snippets, mode = server)]` macro (rc.18+,
 discussion #3770), which binds the router to its owning app at compile
 time via the `AppLabel` trait and applies `.with_namespace("snippets")`
-for URL reversal (e.g. `"snippets:snippets_list"`) without changing the
+for URL reversal (e.g. `"snippets:snippets-list"`) without changing the
 request path. Both the function-based endpoints (Tutorial 1-5) and the
 ViewSet endpoints (Tutorial 6) are registered on the same router:
 
@@ -321,7 +321,7 @@ pub struct SnippetSerializer { /* ... */ }
 // Manual `serializer.validate()?` is no longer needed inside the handler
 // body — the macro generates the call for you and converts failures into
 // a HTTP 400 JSON response.
-#[post("/snippets/", name = "snippets_create", pre_validate = true)]
+#[post("/snippets/", name = "snippets-create", pre_validate = true)]
 pub async fn create(Json(serializer): Json<SnippetSerializer>) -> ViewResult<Response> {
     /* serializer is already validated here */
 }

--- a/examples/examples-tutorial-rest/src/apps/snippets/views.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/views.rs
@@ -56,7 +56,7 @@ fn get_sample_snippets() -> Vec<Snippet> {
 ///
 /// GET /snippets/
 /// Success response: 200 OK with array of snippets
-#[get("/snippets/", name = "snippets_list")]
+#[get("/snippets/", name = "snippets-list")]
 pub async fn list() -> ViewResult<Response> {
 	// Production ORM usage:
 	// let snippets = Manager::<Snippet>::new().all().await?;
@@ -85,7 +85,7 @@ pub async fn list() -> ViewResult<Response> {
 /// - 400 Bad Request: Validation errors (emitted by the `pre_validate = true`
 ///   macro option below — the macro returns HTTP 400 with a JSON error body
 ///   before this function body runs)
-#[post("/snippets/", name = "snippets_create", pre_validate = true)]
+#[post("/snippets/", name = "snippets-create", pre_validate = true)]
 pub async fn create(Json(serializer): Json<SnippetSerializer>) -> ViewResult<Response> {
 	// `pre_validate = true` on the route macro extracts `Json<SnippetSerializer>`
 	// into a temporary, calls `Validate::validate(&__tmp)`, then re-destructures
@@ -126,7 +126,7 @@ pub async fn create(Json(serializer): Json<SnippetSerializer>) -> ViewResult<Res
 /// Success response: 200 OK with snippet data
 /// Error responses:
 /// - 404 Not Found: Snippet not found
-#[get("/snippets/{id}/", name = "snippets_retrieve")]
+#[get("/snippets/{id}/", name = "snippets-retrieve")]
 pub async fn retrieve(Path(snippet_id): Path<i64>) -> ViewResult<Response> {
 	// Production ORM usage:
 	// let snippet = Manager::<Snippet>::new().get(snippet_id).await?;
@@ -164,7 +164,7 @@ pub async fn retrieve(Path(snippet_id): Path<i64>) -> ViewResult<Response> {
 ///   below — `pre_validate = true` would force `Path<i64>` through `Validate`
 ///   as well, which `i64` does not implement; see the module-level comment
 ///   on the `Validate` import for details)
-#[put("/snippets/{id}/", name = "snippets_update")]
+#[put("/snippets/{id}/", name = "snippets-update")]
 pub async fn update(
 	Path(snippet_id): Path<i64>,
 	Json(serializer): Json<SnippetSerializer>,
@@ -220,7 +220,7 @@ pub async fn update(
 /// Success response: 204 No Content
 /// Error responses:
 /// - 404 Not Found: Snippet not found
-#[delete("/snippets/{id}/", name = "snippets_delete")]
+#[delete("/snippets/{id}/", name = "snippets-delete")]
 pub async fn delete(Path(snippet_id): Path<i64>) -> ViewResult<Response> {
 	// Production ORM usage:
 	// Manager::<Snippet>::new().delete(snippet_id).await?;


### PR DESCRIPTION
## What

Fixes the `examples-tutorial-rest` failure in the **Examples Tests (Standalone)** workflow (e.g. [run #26702573263](https://github.com/kent8192/reinhardt-web/actions/runs/26702573263), surfaced on the release PR #5070).

Under `-D warnings`, reinhardt-web 0.2.0's URL-name deprecation lint turns the macro-generated `__non_kebab_url_name_*` markers into hard errors:

```
error: use of deprecated constant `apps::snippets::views::__non_kebab_url_name_list::REASON`:
URL name "snippets_list" is not kebab-case; prefer "snippets-list" to match
ViewSet-generated names (e.g. "users-list").
```

(5 errors: `snippets_list`, `snippets_create`, `snippets_retrieve`, `snippets_update`, `snippets_delete`.)

## Changes

- **`src/apps/snippets/views.rs`** — rename the five route names to kebab-case (`snippets-list` / `snippets-create` / `snippets-retrieve` / `snippets-update` / `snippets-delete`).
- **`README.md`** — update the URL-reversal documentation to match, including the namespaced reverse string `"snippets:snippets-list"`.

### Note on typed accessors / URL resolve

The generated typed `ResolvedUrls::server().snippets().snippets_list()` accessor methods **stay snake_case** — the framework converts kebab-case route names into valid Rust identifiers (the same way a ViewSet `users-list` route yields a `users_list()` accessor). Only the **string-based** reverse reference (`"snippets:snippets_list"` → `"snippets:snippets-list"`) changes, since that string must match the registered route name. The request paths (`/snippets/`, `/snippets/{id}/`) are unchanged, so the integration tests and Bruno collections are unaffected.

## Verification

Built against the in-repo `reinhardt-web 0.2.0-rc.2` source via the `examples/.cargo/config.local.toml` patch (the same mechanism CI uses):

- `cargo clippy --all-features -- -D warnings` → **pass** (no deprecation)
- `cargo fmt --check` → **pass**

## Out of scope

The sibling `examples-twitter` job fails for a **separate** deprecation (`CorsConfig` → `CorsSettings`), which is a different crate and fix pattern. It is intentionally left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)