### PR TITLE
feat(pages-macros)!: compile-time hook deps verification (spec §4.5)

### DIFF
--- a/crates/reinhardt-pages/macros/src/page.rs
+++ b/crates/reinhardt-pages/macros/src/page.rs
@@ -119,6 +119,7 @@
 mod codegen;
 pub(crate) mod hook_deps_validator;
 pub(crate) mod html_spec;
+mod scope_utils;
 mod validator;
 
 use proc_macro::TokenStream;
@@ -141,11 +142,10 @@ pub(crate) fn page_impl(input: TokenStream) -> TokenStream {
 		Err(err) => return err.to_compile_error().into(),
 	};
 
-	// 1a. Hook deps verification (pre-codegen pass, Refs #4195).
-	// Today this emits an empty TokenStream; once the follow-up
-	// implementation lands, it will surface `compile_error!` for any
-	// Signal read inside a hook closure that is missing from the
-	// hook's deps tuple.
+	// 1a. Hook deps verification (pre-codegen pass, Refs #4195 / #4721 / #4746).
+	// Emits a `compile_error!` for every Signal read inside a hook closure
+	// (written directly in this `page!` body) that is missing from the hook's
+	// deps tuple. Empty when no such mistake is found.
 	let hook_deps_diagnostics = hook_deps_validator::verify_hook_deps(&untyped_ast);
 
 	// 2. Validate + Transform: Untyped AST → Typed AST
@@ -157,11 +157,20 @@ pub(crate) fn page_impl(input: TokenStream) -> TokenStream {
 	// 3. Codegen: Typed AST → Rust code
 	let codegen_output = codegen::generate(&typed_ast);
 
-	// 4. Concatenate verification diagnostics with the codegen output so
-	// any `compile_error!` invocations land in the user's source location.
-	let combined = quote::quote! {
-		#hook_deps_diagnostics
-		#codegen_output
+	// 4. Combine verification diagnostics with the codegen output. The codegen
+	// output is a block expression, so when diagnostics are present we wrap
+	// both in an outer block — this keeps the `compile_error!` invocation in a
+	// valid statement position even when `page!` is used in expression
+	// position, and lands the error at the user's call site.
+	let combined = if hook_deps_diagnostics.is_empty() {
+		codegen_output
+	} else {
+		quote::quote! {
+			{
+				#hook_deps_diagnostics
+				#codegen_output
+			}
+		}
 	};
 
 	combined.into()

--- a/crates/reinhardt-pages/macros/src/page/hook_deps_validator.rs
+++ b/crates/reinhardt-pages/macros/src/page/hook_deps_validator.rs
@@ -1,32 +1,50 @@
 //! Pre-codegen pass that verifies hook deps tuples cover all Signal reads
-//! inside hook closures (Refs #4195, Manouche v2 Layer ② React alignment).
+//! inside hook closures (Refs #4195 / #4721 / #4746, Manouche v2 Layer ②
+//! React alignment).
 //!
-//! See the design spec at
-//! `docs/superpowers/specs/2026-05-22-issue-4195-hooks-deps-array-design.md`
-//! §7 for the verification rules.
+//! # What this checks
 //!
-//! # Implementation status
+//! For every `use_effect` / `use_layout_effect` / `use_memo` / `use_callback`
+//! / `use_callback_with` call written **directly inside a `page!` body**, this
+//! pass walks the hook's closure (positional arg 0) and collects the Signal
+//! reads — `signal.get()`, `signal.with(...)`, `signal.into_value()`. Reads
+//! through the explicit escape hatches `get_untracked` / `with_untracked` are
+//! ignored. It then compares those reads against the deps tuple (positional
+//! arg 1) and emits a `compile_error!` for every read whose base identifier is
+//! missing from the deps tuple. This promotes the React `exhaustive-deps`
+//! lint to a hard compile error (DP #4: fail early).
 //!
-//! This is the **scaffold** phase. The visitor walks the input token stream
-//! and detects `use_effect` / `use_memo` / `use_callback` / `use_callback_with`
-//! / `use_layout_effect` call sites by name. Full Signal-read extraction from
-//! a Manouche `PageBody` (which is NOT a `syn::Block`) requires walking
-//! through the Manouche typed-AST emitter and reparsing the embedded Rust
-//! expressions; that piece is tracked as a follow-up issue.
+//! # Scope and limitations
 //!
-//! The scaffold returns an empty `TokenStream` today, so the macro pipeline
-//! remains unchanged. Once the follow-up lands, this module will start
-//! emitting `compile_error!` diagnostics here without touching the rest of
-//! the codegen path.
+//! This pass only sees hook calls that are **textually inside** a `page!`
+//! invocation. Hooks called in a surrounding component `fn` body or in a
+//! custom hook function — the common case in real code — are invisible to the
+//! `page!` macro and therefore not checked here. The guarantee that a deps
+//! tuple is present *at all* is enforced separately at the type level by the
+//! `*::new_with_deps` constructor arity (a missing deps argument is `E0061`).
+//!
+//! The analysis is intentionally conservative: when a hook call, its closure,
+//! or its deps tuple cannot be matched with confidence (for example, the deps
+//! argument is a runtime expression rather than a tuple literal), the pass
+//! emits nothing rather than risk a false positive. The mirror case from
+//! #4721 — a dependency listed but never read — is deliberately *not* a
+//! compile error: stable proc-macros have no warning channel, an unused dep is
+//! at worst a redundant re-run trigger (never a correctness bug), and our read
+//! detection is coarse enough that erroring would risk breaking correct code.
 
-use proc_macro2::TokenStream;
-use quote::quote;
+use std::collections::HashSet;
 
-use reinhardt_manouche::core::PageMacro;
+use proc_macro2::{Span, TokenStream};
+use quote::quote_spanned;
+use syn::Expr;
+use syn::visit::{self, Visit};
+
+use reinhardt_manouche::core::{PageElse, PageIf, PageMacro, PageNode};
+
+use super::scope_utils::collect_pat_idents;
 
 /// Verified hook names — kept in lockstep with the `use_*(f, deps)`
-/// signatures shipped in this PR.
-#[allow(dead_code)]
+/// signatures shipped in #4195.
 pub(crate) const VERIFIED_HOOKS: &[&str] = &[
 	"use_effect",
 	"use_layout_effect",
@@ -38,20 +56,576 @@ pub(crate) const VERIFIED_HOOKS: &[&str] = &[
 /// Methods that explicitly opt out of deps verification — reading these
 /// returns the latest value WITHOUT subscribing, matching Option A's
 /// `useEffectEvent`-by-construction semantics.
-#[allow(dead_code)]
 pub(crate) const ESCAPE_METHODS: &[&str] = &["get_untracked", "with_untracked"];
 
-/// Run the hook-deps verification pass over a parsed `PageMacro`.
+/// Runs the hook-deps verification pass over a parsed `PageMacro`.
 ///
-/// Today this is a no-op scaffold: it returns an empty `TokenStream` so the
-/// surrounding `page_impl` pipeline is unaffected. Once the follow-up
-/// implementation lands, this function will return one or more
-/// `compile_error!` invocations for each Signal read that is missing from
-/// its enclosing hook's deps tuple.
-pub(crate) fn verify_hook_deps(_input: &PageMacro) -> TokenStream {
-	// TODO: Implement full Signal-read detection against PageBody traversal.
-	// Tracked as follow-up to reinhardt-web#4195. Until then, runtime
-	// behavior is unchanged: explicit-deps semantics are enforced by the
-	// `*::new_with_deps` constructors at the runtime layer.
-	quote! {}
+/// Returns one `compile_error!` invocation per Signal read that is missing
+/// from its enclosing hook's deps tuple, or an empty `TokenStream` when no
+/// such mistake is found.
+pub(crate) fn verify_hook_deps(input: &PageMacro) -> TokenStream {
+	let mut diagnostics: Vec<TokenStream> = Vec::new();
+
+	// The head expression (`page!(head = ..., || { ... })`) can also embed
+	// hook calls, so scan it too.
+	if let Some(head) = &input.head {
+		scan_expr(head, &mut diagnostics);
+	}
+	for node in &input.body.nodes {
+		scan_node(node, &mut diagnostics);
+	}
+
+	let mut out = TokenStream::new();
+	out.extend(diagnostics);
+	out
+}
+
+// --- Layer 1: walk the PageNode tree, reaching every embedded `syn::Expr` ---
+
+fn scan_node(node: &PageNode, out: &mut Vec<TokenStream>) {
+	match node {
+		PageNode::Element(el) => {
+			for attr in &el.attrs {
+				scan_expr(&attr.value, out);
+			}
+			for event in &el.events {
+				scan_expr(&event.handler, out);
+			}
+			for child in &el.children {
+				scan_node(child, out);
+			}
+		}
+		PageNode::Text(_) => {}
+		PageNode::Expression(e) => scan_expr(&e.expr, out),
+		PageNode::If(p) => scan_if(p, out),
+		PageNode::For(p) => {
+			scan_expr(&p.iter, out);
+			if let Some(key) = &p.key {
+				scan_expr(key, out);
+			}
+			for child in &p.body {
+				scan_node(child, out);
+			}
+		}
+		PageNode::Component(c) => {
+			for arg in &c.args {
+				scan_expr(&arg.value, out);
+			}
+			for event in &c.events {
+				scan_expr(&event.handler, out);
+			}
+			if let Some(children) = &c.children {
+				for child in children {
+					scan_node(child, out);
+				}
+			}
+			for slot in &c.named_slots {
+				for child in &slot.children {
+					scan_node(child, out);
+				}
+			}
+		}
+		PageNode::Watch(w) => scan_node(&w.expr, out),
+	}
+}
+
+fn scan_if(p: &PageIf, out: &mut Vec<TokenStream>) {
+	scan_expr(&p.condition, out);
+	for child in &p.then_branch {
+		scan_node(child, out);
+	}
+	if let Some(els) = &p.else_branch {
+		match els {
+			PageElse::Block(nodes) => {
+				for child in nodes {
+					scan_node(child, out);
+				}
+			}
+			PageElse::If(inner) => scan_if(inner, out),
+		}
+	}
+}
+
+fn scan_expr(expr: &Expr, out: &mut Vec<TokenStream>) {
+	let mut visitor = HookCallVisitor { diagnostics: out };
+	visitor.visit_expr(expr);
+}
+
+// --- Layer 2: find hook calls inside an embedded expression ---
+
+/// Walks a `syn::Expr` looking for `use_*(closure, deps)` calls.
+struct HookCallVisitor<'a> {
+	diagnostics: &'a mut Vec<TokenStream>,
+}
+
+impl<'ast> Visit<'ast> for HookCallVisitor<'_> {
+	fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+		if is_verified_hook_call(call) && call.args.len() == 2 {
+			analyze_hook(&call.args[0], &call.args[1], self.diagnostics);
+		}
+		// Always recurse so a hook nested inside another hook's closure is
+		// discovered and validated as its own call.
+		visit::visit_expr_call(self, call);
+	}
+}
+
+/// Returns true when `call` is a free-function call to one of the verified
+/// hooks (matched on the last path segment, so `self::use_effect(..)` counts).
+fn is_verified_hook_call(call: &syn::ExprCall) -> bool {
+	if let Expr::Path(p) = &*call.func
+		&& let Some(seg) = p.path.segments.last()
+	{
+		return VERIFIED_HOOKS.contains(&seg.ident.to_string().as_str());
+	}
+	false
+}
+
+// --- Layer 3: compare closure reads against the deps tuple ---
+
+/// Analyzes a single hook call: emits a `compile_error!` for each Signal read
+/// in the closure whose base identifier is missing from the deps tuple.
+fn analyze_hook(closure_arg: &Expr, deps_arg: &Expr, out: &mut Vec<TokenStream>) {
+	// Fail open when the deps argument is not a tuple literal: we cannot prove
+	// any read is missing without seeing the deps contents.
+	let Some(deps) = collect_dep_bases(deps_arg) else {
+		return;
+	};
+
+	let mut reads = SignalReadVisitor {
+		reads: Vec::new(),
+		locals_stack: Vec::new(),
+	};
+	reads.visit_expr(closure_arg);
+
+	let mut reported: HashSet<String> = HashSet::new();
+	for (base, span) in reads.reads {
+		if deps.contains(&base) {
+			continue;
+		}
+		// Deduplicate so multiple reads of the same signal yield one error.
+		if !reported.insert(base.clone()) {
+			continue;
+		}
+		out.push(missing_dep_error(&base, span));
+	}
+}
+
+/// Collects the base identifiers of every element in a deps tuple literal.
+///
+/// Returns `None` (fail open) when the deps argument is not a tuple literal —
+/// `()` yields an empty set (mount-only).
+fn collect_dep_bases(deps: &Expr) -> Option<HashSet<String>> {
+	if let Expr::Tuple(tuple) = unwrap_paren(deps) {
+		let mut set = HashSet::new();
+		for elem in &tuple.elems {
+			if let Some(base) = base_ident_of(elem) {
+				set.insert(base.to_string());
+			}
+		}
+		Some(set)
+	} else {
+		None
+	}
+}
+
+/// Walks a hook closure collecting Signal reads, tracking lexical scopes so
+/// that locally bound identifiers do not count as reads.
+struct SignalReadVisitor {
+	reads: Vec<(String, Span)>,
+	locals_stack: Vec<HashSet<String>>,
+}
+
+impl SignalReadVisitor {
+	fn is_shadowed(&self, name: &str) -> bool {
+		self.locals_stack.iter().any(|s| s.contains(name))
+	}
+}
+
+impl<'ast> Visit<'ast> for SignalReadVisitor {
+	fn visit_expr_method_call(&mut self, mc: &'ast syn::ExprMethodCall) {
+		let method = mc.method.to_string();
+		let is_read = if ESCAPE_METHODS.contains(&method.as_str()) {
+			// Explicit opt-out: read without subscribing.
+			false
+		} else if method == "get" || method == "into_value" {
+			// Zero-argument accessors. `map.get(&key)` (one arg) is not a read.
+			mc.args.is_empty()
+		} else {
+			method == "with"
+		};
+
+		if is_read && let Some(ident) = base_ident_of(&mc.receiver) {
+			let name = ident.to_string();
+			// `self.signal.get()` cannot be named in a deps tuple; skip.
+			if name != "self" && !self.is_shadowed(&name) {
+				self.reads.push((name, ident.span()));
+			}
+		}
+
+		visit::visit_expr_method_call(self, mc);
+	}
+
+	fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+		// A nested hook call is validated independently; do not attribute its
+		// closure's reads to the enclosing hook.
+		if is_verified_hook_call(call) {
+			return;
+		}
+		visit::visit_expr_call(self, call);
+	}
+
+	fn visit_expr_closure(&mut self, c: &'ast syn::ExprClosure) {
+		let mut locals = HashSet::new();
+		for input in &c.inputs {
+			collect_pat_idents(input, &mut locals);
+		}
+		self.locals_stack.push(locals);
+		visit::visit_expr_closure(self, c);
+		self.locals_stack.pop();
+	}
+
+	fn visit_expr_let(&mut self, l: &'ast syn::ExprLet) {
+		// `if let pat = expr` / `while let pat = expr` in expression position.
+		let mut locals = HashSet::new();
+		collect_pat_idents(&l.pat, &mut locals);
+		self.locals_stack.push(locals);
+		visit::visit_expr_let(self, l);
+		self.locals_stack.pop();
+	}
+
+	fn visit_expr_if(&mut self, i: &'ast syn::ExprIf) {
+		// `if let pat = expr { body }`: pattern bindings are in scope for the
+		// then-branch only, NOT for the matched expression or the else branch.
+		if let syn::Expr::Let(let_expr) = &*i.cond {
+			let mut locals = HashSet::new();
+			collect_pat_idents(&let_expr.pat, &mut locals);
+			self.visit_expr(&let_expr.expr);
+			self.locals_stack.push(locals);
+			self.visit_block(&i.then_branch);
+			self.locals_stack.pop();
+			if let Some((_, else_branch)) = &i.else_branch {
+				self.visit_expr(else_branch);
+			}
+		} else {
+			visit::visit_expr_if(self, i);
+		}
+	}
+
+	fn visit_arm(&mut self, a: &'ast syn::Arm) {
+		// `match expr { pat => body }`: pat bindings are in scope for the arm.
+		let mut locals = HashSet::new();
+		collect_pat_idents(&a.pat, &mut locals);
+		self.locals_stack.push(locals);
+		if let Some((_, guard)) = &a.guard {
+			self.visit_expr(guard);
+		}
+		self.visit_expr(&a.body);
+		self.locals_stack.pop();
+	}
+
+	fn visit_expr_for_loop(&mut self, f: &'ast syn::ExprForLoop) {
+		// `for pat in iter { body }`: pat bindings are in scope for the body.
+		self.visit_expr(&f.expr);
+		let mut locals = HashSet::new();
+		collect_pat_idents(&f.pat, &mut locals);
+		self.locals_stack.push(locals);
+		self.visit_block(&f.body);
+		self.locals_stack.pop();
+	}
+
+	fn visit_block(&mut self, b: &'ast syn::Block) {
+		// Walk statements in order so each `let pat = ...;` extends scope from
+		// the next statement onward.
+		let mut pushed = 0_usize;
+		for stmt in &b.stmts {
+			match stmt {
+				syn::Stmt::Local(local) => {
+					// Visit the initializer first (new bindings not yet in scope).
+					if let Some(init) = &local.init {
+						self.visit_expr(&init.expr);
+						if let Some((_, diverge)) = &init.diverge {
+							self.visit_expr(diverge);
+						}
+						// The idiomatic clone prelude `let count = count.clone();`
+						// rebinds the SAME signal to the same name. Treat such a
+						// self-rebind as an alias (do not shadow) so reads of the
+						// rebound name are still checked against the deps tuple.
+						// Any other initializer is a genuine shadow.
+						if is_self_rebind(&local.pat, &init.expr) {
+							continue;
+						}
+					}
+					let mut locals = HashSet::new();
+					collect_pat_idents(&local.pat, &mut locals);
+					self.locals_stack.push(locals);
+					pushed += 1;
+				}
+				syn::Stmt::Item(_) => {}
+				syn::Stmt::Expr(e, _) => self.visit_expr(e),
+				syn::Stmt::Macro(m) => visit::visit_stmt_macro(self, m),
+			}
+		}
+		for _ in 0..pushed {
+			self.locals_stack.pop();
+		}
+	}
+}
+
+/// Returns true when `pat` is a single identifier `x` and `init` is an
+/// expression whose base identifier is also `x` (e.g. `let count = count.clone()`).
+fn is_self_rebind(pat: &syn::Pat, init: &Expr) -> bool {
+	if let syn::Pat::Ident(pi) = pat
+		&& let Some(base) = base_ident_of(init)
+	{
+		return *base == pi.ident;
+	}
+	false
+}
+
+/// Resolves the left-most single path identifier of a receiver chain, e.g.
+/// `count.get()` → `count`, `count.signal.get()` → `count`. Returns `None`
+/// when the head is not a bare identifier (multi-segment path, index, call
+/// result), so such reads are simply left unchecked (fail open).
+fn base_ident_of(e: &Expr) -> Option<&syn::Ident> {
+	match e {
+		Expr::Path(p) if p.qself.is_none() && p.path.segments.len() == 1 => {
+			Some(&p.path.segments[0].ident)
+		}
+		Expr::MethodCall(mc) => base_ident_of(&mc.receiver),
+		Expr::Field(f) => base_ident_of(&f.base),
+		Expr::Paren(p) => base_ident_of(&p.expr),
+		Expr::Reference(r) => base_ident_of(&r.expr),
+		Expr::Try(t) => base_ident_of(&t.expr),
+		_ => None,
+	}
+}
+
+/// Unwraps nested parentheses around an expression.
+fn unwrap_paren(e: &Expr) -> &Expr {
+	match e {
+		Expr::Paren(p) => unwrap_paren(&p.expr),
+		_ => e,
+	}
+}
+
+/// Builds the missing-dep diagnostic, spanned at the read site.
+fn missing_dep_error(base: &str, span: Span) -> TokenStream {
+	let msg = format!(
+		"`{base}` is read inside this hook closure but is not listed in its deps tuple.\n\n\
+		 help: add `{base}.clone()` to the deps tuple, e.g. `({base}.clone(),)`\n\
+		 note: if this read is intentional and should NOT trigger re-runs, use \
+		 `{base}.get_untracked()` (or `with_untracked`) to opt out of dependency tracking."
+	);
+	quote_spanned! {span=>
+		::core::compile_error!(#msg);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use quote::quote;
+	use rstest::rstest;
+
+	/// Parses a `page!` body and returns the verification output as a string.
+	fn diagnostics(input: TokenStream) -> String {
+		let ast: PageMacro = syn::parse2(input).expect("page! body should parse");
+		verify_hook_deps(&ast).to_string()
+	}
+
+	#[rstest]
+	fn missing_dep_inside_page_emits_error() {
+		// Arrange
+		let input = quote! {
+			|count: Signal<i32>| {
+				p { {
+					use_effect(
+						{
+							let count = count.clone();
+							move || { let _ = count.get(); None::<fn()> }
+						},
+						(),
+					);
+					"x"
+				} }
+			}
+		};
+
+		// Act
+		let out = diagnostics(input);
+
+		// Assert
+		assert!(
+			out.contains("compile_error"),
+			"a missing dep must emit compile_error, got: {out}"
+		);
+		assert!(
+			out.contains("count"),
+			"diagnostic should name the missing dep"
+		);
+	}
+
+	#[rstest]
+	fn covered_dep_is_silent() {
+		// Arrange
+		let input = quote! {
+			|count: Signal<i32>| {
+				p { {
+					use_effect(
+						{
+							let count = count.clone();
+							move || { let _ = count.get(); None::<fn()> }
+						},
+						(count.clone(),),
+					);
+					"x"
+				} }
+			}
+		};
+
+		// Act
+		let out = diagnostics(input);
+
+		// Assert
+		assert_eq!(out, "", "a covered dep must produce no diagnostics");
+	}
+
+	#[rstest]
+	fn get_untracked_is_silent() {
+		// Arrange
+		let input = quote! {
+			|count: Signal<i32>| {
+				p { {
+					use_effect(
+						{
+							let count = count.clone();
+							move || { let _ = count.get_untracked(); None::<fn()> }
+						},
+						(),
+					);
+					"x"
+				} }
+			}
+		};
+
+		// Act
+		let out = diagnostics(input);
+
+		// Assert
+		assert_eq!(out, "", "an untracked read must produce no diagnostics");
+	}
+
+	#[rstest]
+	fn non_tuple_deps_fails_open() {
+		// Arrange — deps is a runtime expression, not a tuple literal.
+		let input = quote! {
+			|count: Signal<i32>, my_deps: Deps| {
+				p { {
+					use_effect(
+						{
+							let count = count.clone();
+							move || { let _ = count.get(); None::<fn()> }
+						},
+						my_deps,
+					);
+					"x"
+				} }
+			}
+		};
+
+		// Act
+		let out = diagnostics(input);
+
+		// Assert
+		assert_eq!(out, "", "non-tuple deps must fail open (no diagnostics)");
+	}
+
+	#[rstest]
+	fn extra_dep_is_not_flagged() {
+		// Arrange — `count` is listed but never read; this must NOT error.
+		let input = quote! {
+			|count: Signal<i32>| {
+				p { {
+					use_effect(move || { None::<fn()> }, (count.clone(),));
+					"x"
+				} }
+			}
+		};
+
+		// Act
+		let out = diagnostics(input);
+
+		// Assert
+		assert_eq!(out, "", "an unread dep must not be a compile error");
+	}
+
+	#[rstest]
+	fn shadowed_local_is_not_a_read() {
+		// Arrange — `value` is a fresh local, not a signal dependency.
+		let input = quote! {
+			|count: Signal<i32>| {
+				p { {
+					use_effect(
+						move || {
+							let value = make();
+							let _ = value.get();
+							None::<fn()>
+						},
+						(),
+					);
+					"x"
+				} }
+			}
+		};
+
+		// Act
+		let out = diagnostics(input);
+
+		// Assert
+		assert_eq!(out, "", "a read of a shadowing local must not be flagged");
+	}
+
+	#[rstest]
+	fn nested_hook_is_validated_independently() {
+		// Arrange — outer effect covers `count`; inner memo is missing `other`.
+		let input = quote! {
+			|count: Signal<i32>, other: Signal<i32>| {
+				p { {
+					use_effect(
+						{
+							let count = count.clone();
+							let other = other.clone();
+							move || {
+								let _ = use_memo(
+									{
+										let other = other.clone();
+										move || other.get()
+									},
+									(),
+								);
+								let _ = count.get();
+								None::<fn()>
+							}
+						},
+						(count.clone(),),
+					);
+					"x"
+				} }
+			}
+		};
+
+		// Act
+		let out = diagnostics(input);
+
+		// Assert — the inner memo's missing `other` is flagged; the outer
+		// effect's covered `count` is not.
+		assert!(
+			out.contains("other"),
+			"inner memo's missing dep must be flagged"
+		);
+		assert!(
+			out.matches("compile_error").count() == 1,
+			"exactly one diagnostic expected, got: {out}"
+		);
+	}
 }

--- a/crates/reinhardt-pages/macros/src/page/scope_utils.rs
+++ b/crates/reinhardt-pages/macros/src/page/scope_utils.rs
@@ -1,0 +1,51 @@
+//! Shared scope-tracking helpers for the `page!` macro validation passes.
+//!
+//! Both the capture-discipline validator and the hook-deps validator need to
+//! enumerate the identifiers a pattern binds (closure params, `let` bindings,
+//! `for` loop variables, match-arm patterns) so they can model lexical scopes
+//! and decide whether a referenced identifier is a local binding.
+
+use std::collections::HashSet;
+
+/// Recursively collects identifier names bound by a pattern.
+///
+/// Handles the pattern shapes that can appear in closure params, `let`
+/// statements, `for` loops, and match arms inside a `page!` body. Unsupported
+/// shapes contribute no bindings (a conservative choice: an unrecognized
+/// pattern simply does not shadow anything).
+pub(crate) fn collect_pat_idents(p: &syn::Pat, out: &mut HashSet<String>) {
+	match p {
+		syn::Pat::Ident(pi) => {
+			out.insert(pi.ident.to_string());
+		}
+		syn::Pat::Tuple(t) => {
+			for el in &t.elems {
+				collect_pat_idents(el, out);
+			}
+		}
+		syn::Pat::TupleStruct(ts) => {
+			for el in &ts.elems {
+				collect_pat_idents(el, out);
+			}
+		}
+		syn::Pat::Struct(ps) => {
+			for f in &ps.fields {
+				collect_pat_idents(&f.pat, out);
+			}
+		}
+		syn::Pat::Reference(r) => collect_pat_idents(&r.pat, out),
+		syn::Pat::Type(t) => collect_pat_idents(&t.pat, out),
+		syn::Pat::Or(o) => {
+			for case in &o.cases {
+				collect_pat_idents(case, out);
+			}
+		}
+		syn::Pat::Slice(s) => {
+			for el in &s.elems {
+				collect_pat_idents(el, out);
+			}
+		}
+		syn::Pat::Paren(p) => collect_pat_idents(&p.pat, out),
+		_ => {}
+	}
+}

--- a/crates/reinhardt-pages/macros/src/page/validator.rs
+++ b/crates/reinhardt-pages/macros/src/page/validator.rs
@@ -41,6 +41,8 @@ use reinhardt_manouche::core::{
 	TypedPageNode, TypedPageWatch, types::AttrValue,
 };
 
+use super::scope_utils::collect_pat_idents;
+
 /// Check if a URL is safe (no dangerous schemes like javascript:).
 ///
 /// Inlined from `reinhardt_core::security::xss::is_safe_url` to avoid
@@ -361,44 +363,6 @@ fn is_value_ident(name: &str) -> bool {
 		.chars()
 		.all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit());
 	starts_lowercase && !all_screaming
-}
-
-/// Recursively collects identifier names bound by a pattern.
-fn collect_pat_idents(p: &syn::Pat, out: &mut HashSet<String>) {
-	match p {
-		syn::Pat::Ident(pi) => {
-			out.insert(pi.ident.to_string());
-		}
-		syn::Pat::Tuple(t) => {
-			for el in &t.elems {
-				collect_pat_idents(el, out);
-			}
-		}
-		syn::Pat::TupleStruct(ts) => {
-			for el in &ts.elems {
-				collect_pat_idents(el, out);
-			}
-		}
-		syn::Pat::Struct(ps) => {
-			for f in &ps.fields {
-				collect_pat_idents(&f.pat, out);
-			}
-		}
-		syn::Pat::Reference(r) => collect_pat_idents(&r.pat, out),
-		syn::Pat::Type(t) => collect_pat_idents(&t.pat, out),
-		syn::Pat::Or(o) => {
-			for case in &o.cases {
-				collect_pat_idents(case, out);
-			}
-		}
-		syn::Pat::Slice(s) => {
-			for el in &s.elems {
-				collect_pat_idents(el, out);
-			}
-		}
-		syn::Pat::Paren(p) => collect_pat_idents(&p.pat, out),
-		_ => {}
-	}
 }
 
 /// Builds the canonical §3.7 diagnostic for an undeclared identifier.

--- a/crates/reinhardt-pages/tests/ui/hooks/fail/missing_deps_inside_page.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/fail/missing_deps_inside_page.rs
@@ -1,0 +1,27 @@
+//! Compile-fail: a Signal read inside a `use_effect` closure written directly
+//! in a `page!` body must be listed in the deps tuple (spec §4.5, #4721/#4746).
+//! Here `count.get()` is read but the deps tuple is empty `()`, so the hook
+//! would silently never re-run — promoted to a hard compile error.
+//!
+//! The hook is called through a qualified path (`hooks::use_effect`) because
+//! `page!` capture discipline (spec §3.7) forbids bare value identifiers that
+//! are not declared parameters; a multi-segment path is exempt.
+
+use reinhardt_pages::page;
+use reinhardt_pages::reactive::Signal;
+use reinhardt_pages::reactive::hooks;
+
+fn main() {
+	let _ = page!(|count: Signal<i32>| {
+		div { {
+			hooks::use_effect({
+				let count = count.clone();
+				move || {
+					let _ = count.get();
+					None::<fn() >
+				}
+			}, (), );
+			"x"
+		} }
+	});
+}

--- a/crates/reinhardt-pages/tests/ui/hooks/fail/missing_deps_inside_page.stderr
+++ b/crates/reinhardt-pages/tests/ui/hooks/fail/missing_deps_inside_page.stderr
@@ -1,0 +1,8 @@
+error: `count` is read inside this hook closure but is not listed in its deps tuple.
+
+       help: add `count.clone()` to the deps tuple, e.g. `(count.clone(),)`
+       note: if this read is intentional and should NOT trigger re-runs, use `count.get_untracked()` (or `with_untracked`) to opt out of dependency tracking.
+  --> tests/ui/hooks/fail/missing_deps_inside_page.rs:20:14
+   |
+20 |                     let _ = count.get();
+   |                             ^^^^^

--- a/crates/reinhardt-pages/tests/ui/hooks/pass/covered_dep_inside_page.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/pass/covered_dep_inside_page.rs
@@ -1,0 +1,23 @@
+//! Compile-pass: a Signal read inside a `use_effect` closure within a `page!`
+//! body whose base identifier IS listed in the deps tuple is accepted
+//! (spec §4.5, #4721/#4746). The hook is called via a qualified path so it is
+//! exempt from `page!` capture discipline (spec §3.7).
+
+use reinhardt_pages::page;
+use reinhardt_pages::reactive::Signal;
+use reinhardt_pages::reactive::hooks;
+
+fn main() {
+	let _ = page!(|count: Signal<i32>| {
+		div { {
+			hooks::use_effect({
+				let count = count.clone();
+				move || {
+					let _ = count.get();
+					None::<fn() >
+				}
+			}, (count.clone(), ), );
+			"x"
+		} }
+	});
+}

--- a/crates/reinhardt-pages/tests/ui/hooks/pass/extra_dep_not_flagged_inside_page.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/pass/extra_dep_not_flagged_inside_page.rs
@@ -1,0 +1,21 @@
+//! Compile-pass (regression guard): a dependency listed in the deps tuple but
+//! never read inside the closure is NOT a compile error (#4721 mirror case).
+//! Stable proc-macros have no warning channel and an unused dep is harmless,
+//! so the validator deliberately stays silent here. The hook is called via a
+//! qualified path so it is exempt from `page!` capture discipline.
+
+use reinhardt_pages::page;
+use reinhardt_pages::reactive::Signal;
+use reinhardt_pages::reactive::hooks;
+
+fn main() {
+	let _ = page!(|count: Signal<i32>| {
+		div { {
+			hooks::use_effect(move || {
+				// `count` is in the deps tuple but never read here.
+				None::<fn() >
+			}, (count.clone(), ), );
+			"x"
+		} }
+	});
+}

--- a/crates/reinhardt-pages/tests/ui/hooks/pass/get_untracked_escape_inside_page.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/pass/get_untracked_escape_inside_page.rs
@@ -1,0 +1,23 @@
+//! Compile-pass: reading a Signal through the `get_untracked` escape hatch
+//! inside a `page!`-embedded hook closure opts out of dependency tracking, so
+//! an empty deps tuple is accepted (spec §4.5, #4721/#4746). The hook is called
+//! via a qualified path so it is exempt from `page!` capture discipline.
+
+use reinhardt_pages::page;
+use reinhardt_pages::reactive::Signal;
+use reinhardt_pages::reactive::hooks;
+
+fn main() {
+	let _ = page!(|count: Signal<i32>| {
+		div { {
+			hooks::use_effect({
+				let count = count.clone();
+				move || {
+					let _ = count.get_untracked();
+					None::<fn() >
+				}
+			}, (), );
+			"x"
+		} }
+	});
+}

--- a/crates/reinhardt-pages/tests/ui/hooks/pass/hook_outside_page_unaffected.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/pass/hook_outside_page_unaffected.rs
@@ -1,0 +1,25 @@
+//! Compile-pass (scope guarantee): a hook with a missing dep that is called
+//! OUTSIDE a `page!` body is invisible to the `page!` macro and therefore not
+//! checked by the deps validator — it must still compile (spec §4.5 scope
+//! limitation, #4721/#4746). The runtime arity check still guarantees a deps
+//! tuple is present.
+
+use reinhardt_pages::reactive::Signal;
+use reinhardt_pages::reactive::hooks::use_effect;
+
+fn main() {
+	let count = Signal::new(0_i32);
+	// `count` is read but not listed in the deps tuple. Because this call is
+	// not inside a `page!` body, the static validator does not see it.
+	let _e = use_effect(
+		{
+			let count = count.clone();
+			move || {
+				let _ = count.get();
+				None::<fn()>
+			}
+		},
+		(),
+	);
+	let _ = count;
+}

--- a/crates/reinhardt-pages/tests/ui/hooks/pass/mount_only_unit_deps_inside_page.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/pass/mount_only_unit_deps_inside_page.rs
@@ -1,0 +1,19 @@
+//! Compile-pass: a `page!`-embedded hook closure that reads no Signals with an
+//! empty `()` deps tuple is the mount-only shape and must not be flagged
+//! (spec §4.5, #4721/#4746). The hook is called via a qualified path so it is
+//! exempt from `page!` capture discipline.
+
+use reinhardt_pages::page;
+use reinhardt_pages::reactive::hooks;
+
+fn main() {
+	let _ = page!(|| {
+		div { {
+			hooks::use_effect(move || {
+				// one-time mount work, no Signal reads
+				None::<fn() >
+			}, (), );
+			"x"
+		} }
+	});
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Implements the `hook_deps_validator` scaffold (previously a no-op) so the `page!` macro performs a compile-time deps-completeness check for reactive hooks (spec §4.5).

For every `use_effect` / `use_layout_effect` / `use_memo` / `use_callback` / `use_callback_with` call written **directly inside a `page!` body**, the pass walks the hook closure (positional arg 0), collects the Signal reads (`get()`, `with(..)`, `into_value()`; ignoring the `get_untracked` / `with_untracked` escape hatches), and emits a `compile_error!` for every read whose base identifier is missing from the deps tuple (positional arg 1). This is the static counterpart to the runtime gate shipped in #4195 and promotes the React `exhaustive-deps` lint to a hard compile error (DP #4: fail early).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking Change Assessment

- [x] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

After #4195, omitting the deps argument entirely is already a compile error (E0061). But a Signal that is *read inside the closure yet missing from the deps tuple* silently slipped past the compiler and produced subtly wrong reactivity (the runtime gate suppresses the re-run). This pass closes that gap at `cargo check` time.

Implementation notes:

- Mirrors the existing two-layer `validator.rs` pattern: a `PageNode` walker reaches every embedded `syn::Expr`, and a `syn::visit::Visit` pass finds hook calls and extracts closure reads vs. deps-tuple identifiers.
- `collect_pat_idents` is factored into a shared `page/scope_utils.rs` used by both the capture-discipline validator and this pass.
- The idiomatic clone prelude (`let count = count.clone();`) is treated as a same-signal alias, so reads of the rebound name are still checked.
- Nested hooks are validated independently (a hook inside another hook's closure is not attributed to the outer hook).
- Conservative by design: any case that cannot be matched with confidence (non-tuple deps, `self.x` receivers, multi-segment paths) fails open (emits nothing) to avoid false positives.

Closes #4721
Closes #4746

## How Was This Tested?

- New in-file unit tests in `hook_deps_validator.rs` (missing dep, covered dep, `get_untracked` escape, non-tuple deps fail-open, shadowing, nested-hook independence, extra-dep-not-flagged).
- New trybuild UI fixtures under `crates/reinhardt-pages/tests/ui/hooks/`:
  - `fail/missing_deps_inside_page.rs` (+ `.stderr`)
  - `pass/covered_dep_inside_page.rs`, `pass/get_untracked_escape_inside_page.rs`, `pass/mount_only_unit_deps_inside_page.rs`, `pass/extra_dep_not_flagged_inside_page.rs`, `pass/hook_outside_page_unaffected.rs`
- `cargo test -p reinhardt-pages-macros`, `cargo nextest run -p reinhardt-pages`, `cargo make fmt-check`, `cargo make clippy-check`.

## Breaking Changes

`page!` bodies that contain a hook call which reads a Signal not listed in its deps tuple now fail to compile.

**Migration Guide:**

- Add the missing dependency to the deps tuple (e.g. `(count.clone(),)`), or
- If the read is intentionally untracked, switch it to `count.get_untracked()` / `count.with_untracked(..)`.

Hooks called *outside* a `page!` body (in component `fn` bodies or custom hooks — the common case) are unaffected; this pass only sees hook calls written textually inside a `page!` invocation.

## Checklist

- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (module docs describe the implemented behavior and scope limitation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

### Additional Labels (apply alongside type label when applicable)
- [x] `breaking-change` - Breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
