### PR TITLE
fix(examples): drop duplicate auth_group_name_uniq constraint

### DIFF
--- a/examples/examples-tutorial-basis/migrations/auth/0002_alter_auth_permission_id_alter_auth_group_i_and_more.rs
+++ b/examples/examples-tutorial-basis/migrations/auth/0002_alter_auth_permission_id_alter_auth_group_i_and_more.rs
@@ -1,5 +1,16 @@
 use reinhardt::db::migrations::FieldType;
 use reinhardt::db::migrations::prelude::*;
+
+// The `auth_group.name` unique key is already created by `0001_initial.rs`
+// (its `CreateTable` carries a named `Constraint::Unique`
+// "auth_group_name_uniq" on the `name` column). The redundant
+// `Operation::AddConstraint` that `makemigrations` previously emitted here
+// (generator bug reinhardt-web#4448, since fixed) is removed so a fresh
+// migration run does not abort with
+// `relation "auth_group_name_uniq" already exists` on PostgreSQL
+// (reinhardt-web#5045). These files were generated before #4448 was fixed;
+// dropping the duplicate matches what current `makemigrations` produces,
+// mirroring the same correction already applied in `migrations/users/0002_*`.
 pub fn migration() -> Migration {
 	Migration {
 		app_label: "auth".to_string(),
@@ -34,10 +45,6 @@ pub fn migration() -> Migration {
 					default: None,
 				},
 				mysql_options: None,
-			},
-			Operation::AddConstraint {
-				table: "auth_group".to_string(),
-				constraint_sql: "CONSTRAINT auth_group_name_uniq UNIQUE (name)".to_string(),
 			},
 		],
 		dependencies: vec![("auth".to_string(), "0001_initial".to_string())],


### PR DESCRIPTION
## Summary

This PR addresses:

- Remove the redundant `Operation::AddConstraint` for `auth_group_name_uniq` from the auth app's `0002` migration in `examples-tutorial-basis`, so a fresh-database `cargo make migrate` no longer aborts with `relation "auth_group_name_uniq" already exists`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The `auth_group.name` unique key is already created by the auth app's `0001_initial` migration (a named `Constraint::Unique` "auth_group_name_uniq" on the `name` column). The auth `0002` migration re-added the same named constraint via `Operation::AddConstraint`, so applying `0002` after `0001` tried to create a relation that already exists and PostgreSQL rejected it.

The redundant operation was emitted by the `makemigrations` generator bug reinhardt-web#4448 (since fixed); these committed migration files predate that fix. Dropping the duplicate matches what current `makemigrations` produces and mirrors the correction already applied in the users `0002` migration (`migrations/users/0002_*`).

Fixes #5045

Related to: #4448

## How Was This Tested?

- Reset the disposable PostgreSQL 17 container (`scripts/infra_up.sh`) to an empty schema and ran the management CLI `migrate` against it.
- **Before:** migration aborts on auth `0002` with `relation "auth_group_name_uniq" already exists`.
- **After:** the auth `0001`/`0002` migrations apply cleanly; `auth_group` carries exactly `auth_group_pkey` (primary key) and `auth_group_name_uniq` (unique) — no duplicate.
- `semgrep scan --config .semgrep/` reports 0 findings on the changed file.

> Note: with this fix in place, a fresh full `migrate` run now reaches and fails on a **separate, pre-existing** bug in the `polls` migrations (`choices.question_id` is created as `Uuid` in `0001` then `ALTER`ed to `BigInteger` in `0003`, which PostgreSQL cannot auto-cast). That is unrelated to this constraint duplication and is tracked separately.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)

## Related Issues

- Fixes #5045
- Upstream generator bug (fixed): #4448

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a database migration conflict that could prevent schema initialization from completing due to duplicate constraint definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->