### PR TITLE
feat(pages): unify resource hooks into use_resource(fetcher, deps)

### DIFF
--- a/crates/reinhardt-admin/src/pages.rs
+++ b/crates/reinhardt-admin/src/pages.rs
@@ -15,7 +15,7 @@
 //!
 //! All components are built using reinhardt-pages' reactive system with:
 //! - `Signal<T>` for reactive state
-//! - `create_resource` for Server Function calls
+//! - `use_resource` for Server Function calls
 //! - `view!` macro for declarative UI
 //!
 //! # Example

--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -26,7 +26,7 @@ use reinhardt_pages::component::{Component, Page};
 use reinhardt_pages::page;
 use reinhardt_pages::router::Link;
 #[cfg(client)]
-use reinhardt_pages::{ResourceState, create_resource};
+use reinhardt_pages::{ResourceState, use_resource};
 use reinhardt_urls::routers::ClientRouter;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -170,8 +170,10 @@ where
 /// Dashboard view component for router
 #[cfg(client)]
 fn dashboard_view() -> Page {
-	let dashboard_resource =
-		create_resource(|| async { get_dashboard().await.map_err(|e| e.to_string()) });
+	let dashboard_resource = use_resource(
+		|| async { get_dashboard().await.map_err(|e| e.to_string()) },
+		(),
+	);
 
 	let reactive_content = Page::reactive({
 		let resource = dashboard_resource.clone();
@@ -221,15 +223,18 @@ fn dashboard_view() -> Page {
 fn list_view_component(model_name: String) -> Page {
 	use reinhardt_pages::use_effect;
 
-	let list_resource = create_resource(move || {
-		let model_name = model_name.clone();
-		async move {
-			let params = ListQueryParams::default();
-			get_list(model_name, params)
-				.await
-				.map_err(|e| e.to_string())
-		}
-	});
+	let list_resource = use_resource(
+		move || {
+			let model_name = model_name.clone();
+			async move {
+				let params = ListQueryParams::default();
+				get_list(model_name, params)
+					.await
+					.map_err(|e| e.to_string())
+			}
+		},
+		(),
+	);
 
 	// Create signals outside the reactive closure so they persist across re-renders
 	let page_signal = Signal::new(1u64);
@@ -348,15 +353,18 @@ fn list_view_component(model_name: String) -> Page {
 fn detail_view_component(model_name: String, record_id: String) -> Page {
 	let model_name_for_view = model_name.clone();
 	let record_id_for_view = record_id.clone();
-	let detail_resource = create_resource(move || {
-		let model_name = model_name.clone();
-		let record_id = record_id.clone();
-		async move {
-			get_detail(model_name, record_id)
-				.await
-				.map_err(|e| e.to_string())
-		}
-	});
+	let detail_resource = use_resource(
+		move || {
+			let model_name = model_name.clone();
+			let record_id = record_id.clone();
+			async move {
+				get_detail(model_name, record_id)
+					.await
+					.map_err(|e| e.to_string())
+			}
+		},
+		(),
+	);
 
 	let reactive_content = Page::reactive({
 		let resource = detail_resource.clone();
@@ -399,14 +407,17 @@ fn detail_view_component(model_name: String, record_id: String) -> Page {
 #[cfg(client)]
 fn create_view_component(model_name: String) -> Page {
 	let model_name_for_view = model_name.clone();
-	let fields_resource = create_resource(move || {
-		let model_name = model_name.clone();
-		async move {
-			get_fields(model_name, None)
-				.await
-				.map_err(|e| e.to_string())
-		}
-	});
+	let fields_resource = use_resource(
+		move || {
+			let model_name = model_name.clone();
+			async move {
+				get_fields(model_name, None)
+					.await
+					.map_err(|e| e.to_string())
+			}
+		},
+		(),
+	);
 
 	let reactive_content = Page::reactive({
 		let resource = fields_resource.clone();
@@ -472,15 +483,18 @@ fn create_view_component(model_name: String) -> Page {
 fn edit_view_component(model_name: String, record_id: String) -> Page {
 	let model_name_for_view = model_name.clone();
 	let record_id_for_view = record_id.clone();
-	let fields_resource = create_resource(move || {
-		let model_name = model_name.clone();
-		let record_id = record_id.clone();
-		async move {
-			get_fields(model_name, Some(record_id))
-				.await
-				.map_err(|e| e.to_string())
-		}
-	});
+	let fields_resource = use_resource(
+		move || {
+			let model_name = model_name.clone();
+			let record_id = record_id.clone();
+			async move {
+				get_fields(model_name, Some(record_id))
+					.await
+					.map_err(|e| e.to_string())
+			}
+		},
+		(),
+	);
 
 	let reactive_content = Page::reactive({
 		let resource = fields_resource.clone();

--- a/crates/reinhardt-core/src/reactive/effect.rs
+++ b/crates/reinhardt-core/src/reactive/effect.rs
@@ -835,7 +835,7 @@ mod tests {
 	}
 
 	#[test]
-	#[serial]
+	#[serial(reactive_runtime)]
 	fn new_with_deps_effect_in_rc_survives_until_rc_dropped() {
 		// Regression for the resource dependency-tracking lifetime invariant.
 		// `use_resource` stores its `new_with_deps` Effect inside an `Rc<Effect>`

--- a/crates/reinhardt-core/src/reactive/effect.rs
+++ b/crates/reinhardt-core/src/reactive/effect.rs
@@ -833,4 +833,55 @@ mod tests {
 		let recorded = log.borrow().clone();
 		assert_eq!(recorded, alloc::vec!["run", "cleanup", "run"]);
 	}
+
+	#[test]
+	#[serial]
+	fn new_with_deps_effect_in_rc_survives_until_rc_dropped() {
+		// Regression for the resource dependency-tracking lifetime invariant.
+		// `use_resource` stores its `new_with_deps` Effect inside an `Rc<Effect>`
+		// (`Resource::effect_guard`) so dependency-change refetch keeps firing for
+		// the Resource's lifetime. An Effect disposes on drop, so a handle that is
+		// created and immediately dropped — the original `create_resource_with_deps`
+		// bug — would stop tracking right after its first run.
+		let s = Signal::new(0_i32);
+		let runs = Rc::new(RefCell::new(0_i32));
+		let runs_for_effect = runs.clone();
+		let s_for_effect = s.clone();
+		let deps = crate::reactive::deps::Deps::from_signals(&[s.id()]);
+
+		let effect = Effect::new_with_deps::<_, fn()>(
+			move || {
+				let _ = s_for_effect.get();
+				*runs_for_effect.borrow_mut() += 1;
+				None
+			},
+			deps,
+		);
+		// Mirror `Resource::effect_guard`: move the Effect into an Rc keep-alive anchor.
+		let guard = Rc::new(effect);
+		assert_eq!(*runs.borrow(), 1, "effect runs once on creation");
+
+		// While the Rc is held, listed-dep changes keep re-running the effect.
+		s.set(1);
+		with_runtime(|rt| rt.flush_updates());
+		assert_eq!(
+			*runs.borrow(),
+			2,
+			"effect held via Rc must re-run on dependency change"
+		);
+
+		s.set(2);
+		with_runtime(|rt| rt.flush_updates());
+		assert_eq!(*runs.borrow(), 3, "effect held via Rc must keep re-running");
+
+		// Dropping the only Rc disposes the Effect; further dep changes do nothing.
+		drop(guard);
+		s.set(3);
+		with_runtime(|rt| rt.flush_updates());
+		assert_eq!(
+			*runs.borrow(),
+			3,
+			"disposed effect must not re-run after its Rc anchor is dropped"
+		);
+	}
 }

--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -63,6 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `reinhardt_pages::router::PathParam` (deprecated since `0.1.0-rc.27`)
   is unrelated and remains in place during its deprecation cycle.
   (Refs #4668)
+- `use_resource(fetcher, deps)` — unified async data-fetching hook, the
+  resource counterpart of `use_effect`. `()` deps fetch once on mount; listed
+  `Trackable` deps (`Signal` / `Memo` / `Resource`) drive automatic refetch.
+  Available on all targets: the native/SSR path renders the `Loading` state and
+  the client performs the real fetch after hydration, mirroring `use_action`.
+  Supersedes the deprecated `create_resource` / `create_resource_with_deps`.
 
 ### Changed (BREAKING)
 
@@ -103,6 +109,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   auto-tracking. Use `use_callback(f, deps)` for stable identity, or
   read latest values via `.get_untracked()` inside the closure.
   Scheduled for removal in v0.3.0.
+- `create_resource` and `create_resource_with_deps` are deprecated in favor of
+  the unified, cross-target `use_resource(fetcher, deps)` (`()` deps = fetch
+  once; `(signal,)` deps = refetch on change). Thin forwarding shims are kept;
+  scheduled for removal in v0.3.0.
 
 ### Removed
 
@@ -133,6 +143,18 @@ Removed in this PR (8 items):
   (PathPattern). Use `reinhardt_urls::routers::ClientPathPattern`.
 - **`src/router/params.rs`** (1 item, `0.1.0-rc.27`) — `Path` extractor.
   Use `reinhardt_urls::routers::Path`.
+
+### Fixed
+
+- Resource dependency-change refetch now actually fires. The old
+  `create_resource_with_deps` dropped its tracking `Effect` handle immediately
+  after creation, so the `Effect` was disposed and never re-ran — automatic
+  refetch on dependency change silently never happened (and the only covering
+  test was excluded on every target by a contradictory `cfg`). The unified
+  `use_resource` stores the `Effect` inside the returned `Resource` so it stays
+  alive for the Resource's lifetime, and applies the `defer_yield` microtask
+  deferral (#3316) on the dependency-driven path as well, not only the
+  fetch-once path.
 
 ## [0.1.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.1.0-rc.30...reinhardt-pages@v0.1.0) - 2026-05-22
 

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -259,6 +259,7 @@ The prelude includes:
 - `use_ref`, `use_reducer`, `use_transition`, `use_deferred_value`
 - `use_id`, `use_layout_effect`, `use_effect_event`, `use_debug_value`
 - `use_optimistic`, `use_action`, `Action::with_optimistic`, `use_shared_state`, `use_sync_external_store`
+- `use_resource` (async data fetching; `use_resource(fetcher, deps)` with `()` = fetch once, cross-target with an SSR loading no-op)
 
 ### Component System
 - `Component`, `ElementView`, `IntoView`, `View`, `Props`, `ViewEventHandler`
@@ -300,7 +301,7 @@ The prelude includes:
 
 ### WASM-specific
 - `spawn_local` (re-exported from wasm_bindgen_futures; **deprecated** — use `spawn_task`)
-- `create_resource`, `create_resource_with_deps`
+- `create_resource`, `create_resource_with_deps` (**deprecated** — use the cross-target `use_resource`)
 
 ## Example
 

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -259,7 +259,7 @@ The prelude includes:
 - `use_ref`, `use_reducer`, `use_transition`, `use_deferred_value`
 - `use_id`, `use_layout_effect`, `use_effect_event`, `use_debug_value`
 - `use_optimistic`, `use_action`, `Action::with_optimistic`, `use_shared_state`, `use_sync_external_store`
-- `use_resource` (async data fetching; `use_resource(fetcher, deps)` with `()` = fetch once, cross-target with an SSR loading no-op)
+- `use_resource` (async data fetching; `use_resource(fetcher, deps)` with `()` fetches once on WASM, while non-WASM targets drop the `fetcher` future, ignore `deps`, and stay `Loading` until hydration/client execution)
 
 ### Component System
 - `Component`, `ElementView`, `IntoView`, `View`, `Props`, `ViewEventHandler`

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -279,8 +279,12 @@ pub use form::{FormBinding, FormComponent};
 // Static form metadata types (always available, used by form! macro)
 pub use form_generated::{StaticFieldMetadata, StaticFormMetadata};
 pub use hydration::{HydrationContext, HydrationError, hydrate};
-pub use reactive::{Effect, Memo, Resource, ResourceState, Signal};
+pub use reactive::{Effect, Memo, Resource, ResourceState, Signal, use_resource};
 #[cfg(wasm)]
+#[allow(
+	deprecated,
+	reason = "re-export kept until removal in v0.3.0; use use_resource instead"
+)]
 pub use reactive::{create_resource, create_resource_with_deps};
 // Re-export Context system
 pub use reactive::{

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -90,8 +90,14 @@ pub use crate::reactive::{
 	use_state, use_sync_external_store, use_transition,
 };
 
-// WASM-only resource creation functions
+// Unified resource hook (available on all targets)
+pub use crate::reactive::use_resource;
+// Deprecated resource constructors, kept until removal in v0.3.0
 #[cfg(wasm)]
+#[allow(
+	deprecated,
+	reason = "re-export kept until removal in v0.3.0; use use_resource instead"
+)]
 pub use crate::reactive::{create_resource, create_resource_with_deps};
 
 // ============================================================================

--- a/crates/reinhardt-pages/src/reactive.rs
+++ b/crates/reinhardt-pages/src/reactive.rs
@@ -106,9 +106,13 @@ pub mod trackable;
 
 pub use trackable::Trackable;
 
-// Re-export resource types
-pub use resource::{Resource, ResourceState};
+// Re-export resource types and the unified hook (available on all targets)
+pub use resource::{Resource, ResourceState, use_resource};
 #[cfg(wasm)]
+#[allow(
+	deprecated,
+	reason = "re-export kept until removal in v0.3.0; use use_resource instead"
+)]
 pub use resource::{create_resource, create_resource_with_deps};
 
 // Re-export hooks

--- a/crates/reinhardt-pages/src/reactive/resource.rs
+++ b/crates/reinhardt-pages/src/reactive/resource.rs
@@ -4,14 +4,14 @@
 //! Similar to Leptos's `create_resource`, it manages Loading/Success/Error states
 //! and integrates with the Signal-based reactivity system.
 
-use super::Signal;
+use super::{Effect, Signal};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::fmt;
 use std::rc::Rc;
 
-#[cfg(wasm)]
 use crate::platform::{defer_yield, spawn_task};
+use reinhardt_core::reactive::deps::IntoDeps;
 
 /// Type alias for the refetch callback function
 ///
@@ -86,13 +86,13 @@ impl<T: fmt::Display, E: fmt::Display> fmt::Display for ResourceState<T, E> {
 /// # Example
 ///
 /// ```ignore
-/// use reinhardt_pages::reactive::{Resource, create_resource};
+/// use reinhardt_pages::reactive::{Resource, use_resource};
 ///
 /// async fn fetch_user(id: u32) -> Result<User, String> {
 ///     // Fetch from API...
 /// }
 ///
-/// let resource = create_resource(|| fetch_user(42));
+/// let resource = use_resource(|| fetch_user(42), ());
 ///
 /// match resource.get() {
 ///     ResourceState::Loading => println!("Loading..."),
@@ -103,6 +103,12 @@ impl<T: fmt::Display, E: fmt::Display> fmt::Display for ResourceState<T, E> {
 pub struct Resource<T: Clone + 'static, E: Clone + 'static = String> {
 	state: Signal<ResourceState<T, E>>,
 	refetch_fn: RefetchCallback,
+	/// RAII anchor that keeps the dependency-tracking `Effect` alive for the
+	/// lifetime of the `Resource`. An `Effect` disposes itself on drop (removing
+	/// its node from the runtime graph), so without holding the handle here the
+	/// effect would be torn down immediately after creation and dependency-change
+	/// refetch would never fire.
+	effect_guard: Rc<Effect>,
 }
 
 impl<T: Clone + 'static, E: Clone + 'static> Clone for Resource<T, E> {
@@ -110,6 +116,7 @@ impl<T: Clone + 'static, E: Clone + 'static> Clone for Resource<T, E> {
 		Resource {
 			state: self.state.clone(),
 			refetch_fn: Rc::clone(&self.refetch_fn),
+			effect_guard: Rc::clone(&self.effect_guard),
 		}
 	}
 }
@@ -166,27 +173,129 @@ impl<T: Clone + 'static, E: Clone + 'static> reinhardt_core::reactive::deps::Tra
 	}
 }
 
-/// Create a resource from an async function
+/// Reactive async data hook — the resource counterpart of `use_effect`.
 ///
-/// This function takes an async fetcher and returns a `Resource<T>`.
-/// The fetcher is immediately executed, and the Resource state transitions
-/// from Loading → Success/Error based on the result.
+/// `use_resource(fetcher, deps)` runs `fetcher` and tracks its result as a
+/// [`Resource`] (`Loading → Success/Error`). The `deps` argument follows the
+/// same [`IntoDeps`] convention as [`use_effect`](super::hooks::use_effect):
 ///
-/// # WASM-only
+/// - `()` → fetch once on mount (never automatically refetches).
+/// - `(signal,)` / `(a, b, ..)` → refetch whenever any listed dependency
+///   changes. Dependencies are the explicitly listed [`Trackable`]s
+///   (`Signal`/`Memo`/`Resource`); signals merely *read* inside the async
+///   `fetcher` do not subscribe (they cross an `await` boundary), so list
+///   everything that should drive a refetch — the same stale-deps rule as
+///   `use_effect`.
 ///
-/// This function is only available on WASM targets, as it uses `spawn_local`
-/// for async execution.
+/// The initial fetch and every dependency-driven refetch are deferred one
+/// microtask (`defer_yield`) so they cannot hang when created during WASM
+/// initialization before the event loop is running (#3316).
+///
+/// [`Trackable`]: reinhardt_core::reactive::deps::Trackable
+/// [`IntoDeps`]: reinhardt_core::reactive::deps::IntoDeps
+///
+/// # Dual-target behavior
+///
+/// Like [`use_action`](super::hooks::use_action), this hook is available on all
+/// targets:
+///
+/// - **WASM**: the fetcher runs via `spawn_task` on the browser event loop.
+/// - **Non-WASM (SSR)**: `spawn_task` drops the future, so the fetcher never
+///   runs and the `Resource` stays `Loading`. The server renders the loading
+///   state and the client performs the real fetch after hydration.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use reinhardt_pages::reactive::create_resource;
+/// use reinhardt_pages::reactive::{Signal, use_resource};
 ///
-/// let user_resource = create_resource(|| async {
-///     fetch_user_from_api(42).await
-/// });
+/// // Fetch once on mount:
+/// let user = use_resource(|| async { fetch_user_from_api(42).await }, ());
+///
+/// // Refetch whenever `user_id` changes:
+/// let user_id = Signal::new(42u32);
+/// let user = use_resource(
+///     {
+///         let user_id = user_id.clone();
+///         move || {
+///             let id = user_id.get();
+///             async move { fetch_user_from_api(id).await }
+///         }
+///     },
+///     (user_id.clone(),),
+/// );
+/// user_id.set(100); // triggers a refetch
 /// ```
+pub fn use_resource<T, E, F, Fut, D>(fetcher: F, deps: D) -> Resource<T, E>
+where
+	T: Clone + 'static,
+	E: Clone + 'static,
+	F: Fn() -> Fut + 'static,
+	Fut: std::future::Future<Output = Result<T, E>> + 'static,
+	D: IntoDeps,
+{
+	let state = Signal::new(ResourceState::Loading);
+	let fetcher = Rc::new(fetcher);
+
+	// Single fetch routine shared by the dependency-driven Effect and manual
+	// refetch. `defer_yield` runs on every path (initial, dependency change, and
+	// manual refetch) so the fetch cannot hang when spawned during WASM
+	// initialization before the event loop ticks (#3316).
+	let run: Rc<dyn Fn()> = {
+		let state = state.clone();
+		let fetcher = Rc::clone(&fetcher);
+		Rc::new(move || {
+			state.set(ResourceState::Loading);
+			let state = state.clone();
+			let fetcher = Rc::clone(&fetcher);
+			spawn_task(async move {
+				defer_yield().await;
+				match fetcher().await {
+					Ok(data) => state.set(ResourceState::Success(data)),
+					Err(err) => state.set(ResourceState::Error(err)),
+				}
+			});
+		})
+	};
+
+	// Drive the initial fetch and dependency-change refetches. `new_with_deps`
+	// (not `new`) means only the explicitly listed `deps` trigger re-runs; the
+	// Effect is stored in the returned `Resource` (see `effect_guard`) so it
+	// stays alive for the Resource's lifetime instead of being disposed on drop.
+	let effect = {
+		let run = Rc::clone(&run);
+		Effect::new_with_deps(
+			move || {
+				run();
+				None::<fn()>
+			},
+			deps.into_deps(),
+		)
+	};
+
+	let refetch_fn: RefetchCallback = Rc::new(RefCell::new(Some(Box::new({
+		let run = Rc::clone(&run);
+		move || run()
+	}))));
+
+	Resource {
+		state,
+		refetch_fn,
+		effect_guard: Rc::new(effect),
+	}
+}
+
+/// Create a resource from an async function (deprecated).
+///
+/// # WASM-only
+///
+/// This function is only available on WASM targets.
 #[cfg(wasm)]
+#[deprecated(
+	since = "0.2.0-rc.2",
+	note = "Renamed for naming consistency with use_effect/use_memo/use_callback. \
+	Use `use_resource(fetcher, ())` for fetch-on-mount. Scheduled for removal in v0.3.0."
+)]
 pub fn create_resource<T, E, F, Fut>(fetcher: F) -> Resource<T, E>
 where
 	T: Clone + 'static,
@@ -194,76 +303,21 @@ where
 	F: Fn() -> Fut + 'static,
 	Fut: std::future::Future<Output = Result<T, E>> + 'static,
 {
-	let state = Signal::new(ResourceState::Loading);
-	let refetch_fn: RefetchCallback = Rc::new(RefCell::new(None));
-
-	let state_for_fetch = state.clone();
-	let fetcher_for_initial = Rc::new(fetcher);
-	let fetcher_for_refetch = Rc::clone(&fetcher_for_initial);
-
-	// Defer initial fetch to the next microtask so the JS event loop can tick first.
-	// Without this, JsFuture from fetch/Response.text() hangs when spawned during
-	// WASM initialization (inside main()) before the event loop is running. (#3316)
-	spawn_task({
-		let state = state_for_fetch.clone();
-		let fetcher = Rc::clone(&fetcher_for_initial);
-		async move {
-			defer_yield().await;
-			match fetcher().await {
-				Ok(data) => state.set(ResourceState::Success(data)),
-				Err(err) => state.set(ResourceState::Error(err)),
-			}
-		}
-	});
-
-	// Setup refetch function
-	let state_for_refetch = state.clone();
-	*refetch_fn.borrow_mut() = Some(Box::new(move || {
-		state_for_refetch.set(ResourceState::Loading);
-
-		spawn_task({
-			let state = state_for_refetch.clone();
-			let fetcher = Rc::clone(&fetcher_for_refetch);
-			async move {
-				match fetcher().await {
-					Ok(data) => state.set(ResourceState::Success(data)),
-					Err(err) => state.set(ResourceState::Error(err)),
-				}
-			}
-		});
-	}));
-
-	Resource { state, refetch_fn }
+	use_resource(fetcher, ())
 }
 
-/// Create a resource with dependency tracking
-///
-/// This function creates a Resource that automatically refetches when
-/// the dependency Signal changes. The fetcher receives the current value
-/// of the dependency.
+/// Create a resource with dependency tracking (deprecated).
 ///
 /// # WASM-only
 ///
 /// This function is only available on WASM targets.
-///
-/// # Example
-///
-/// ```ignore
-/// use reinhardt_pages::reactive::{Signal, create_resource_with_deps};
-///
-/// let user_id = Signal::new(42u32);
-///
-/// let user_resource = create_resource_with_deps(
-///     user_id.clone(),
-///     |id| async move {
-///         fetch_user_from_api(id).await
-///     }
-/// );
-///
-/// // When user_id changes, the resource automatically refetches
-/// user_id.set(100);
-/// ```
 #[cfg(wasm)]
+#[deprecated(
+	since = "0.2.0-rc.2",
+	note = "Unified into use_resource. Use \
+	`use_resource(move || { let v = dep.get(); async move { .. } }, (dep,))`. \
+	Scheduled for removal in v0.3.0."
+)]
 pub fn create_resource_with_deps<T, E, D, F, Fut>(deps: Signal<D>, fetcher: F) -> Resource<T, E>
 where
 	T: Clone + 'static,
@@ -272,53 +326,12 @@ where
 	F: Fn(D) -> Fut + 'static,
 	Fut: std::future::Future<Output = Result<T, E>> + 'static,
 {
-	let state = Signal::new(ResourceState::Loading);
-	let refetch_fn: RefetchCallback = Rc::new(RefCell::new(None));
-
-	let fetcher = Rc::new(fetcher);
-	let fetcher_for_effect = Rc::clone(&fetcher);
-	let state_for_effect = state.clone();
-	let deps_for_effect = deps.clone();
-
-	// Setup effect to track dependency changes
-	use super::Effect;
-	Effect::new(move || {
-		let deps_value = deps_for_effect.get();
-		let state = state_for_effect.clone();
-		let fetcher = Rc::clone(&fetcher_for_effect);
-
-		state.set(ResourceState::Loading);
-
-		spawn_task(async move {
-			match fetcher(deps_value).await {
-				Ok(data) => state.set(ResourceState::Success(data)),
-				Err(err) => state.set(ResourceState::Error(err)),
-			}
-		});
-	});
-
-	// Setup refetch function (refetches with current deps value)
-	let state_for_refetch = state.clone();
-	let deps_for_refetch = deps.clone();
-	let fetcher_for_refetch = Rc::clone(&fetcher);
-
-	*refetch_fn.borrow_mut() = Some(Box::new(move || {
-		state_for_refetch.set(ResourceState::Loading);
-
-		spawn_task({
-			let state = state_for_refetch.clone();
-			let deps_value = deps_for_refetch.get();
-			let fetcher = Rc::clone(&fetcher_for_refetch);
-			async move {
-				match fetcher(deps_value).await {
-					Ok(data) => state.set(ResourceState::Success(data)),
-					Err(err) => state.set(ResourceState::Error(err)),
-				}
-			}
-		});
-	}));
-
-	Resource { state, refetch_fn }
+	// Forward to the unified hook: subscribe to `deps` and read its current
+	// value inside the fetcher. This also fixes the original behavior — the old
+	// implementation disposed its tracking Effect immediately, so dependency
+	// changes never triggered a refetch.
+	let dep_for_fetch = deps.clone();
+	use_resource(move || fetcher(dep_for_fetch.get()), (deps,))
 }
 
 #[cfg(test)]

--- a/crates/reinhardt-pages/tests/resource_integration.rs
+++ b/crates/reinhardt-pages/tests/resource_integration.rs
@@ -34,7 +34,7 @@ use rstest::*;
 use serde::{Deserialize, Serialize};
 
 #[cfg(wasm)]
-use reinhardt_pages::reactive::{Resource, Signal, create_resource, create_resource_with_deps};
+use reinhardt_pages::reactive::{Resource, Signal, use_resource};
 
 #[cfg(wasm)]
 use wasm_bindgen_test::*;
@@ -128,8 +128,10 @@ fn test_resource_state_error_basic() {
 #[cfg(wasm)]
 #[wasm_bindgen_test]
 async fn test_resource_fetch_error() {
-	let resource: Resource<User, String> =
-		create_resource(|| async { Err::<User, String>("Network timeout".to_string()) });
+	let resource: Resource<User, String> = use_resource(
+		|| async { Err::<User, String>("Network timeout".to_string()) },
+		(),
+	);
 
 	// Wait for async operation to complete
 	wasm_bindgen_futures::JsFuture::from(js_sys::Promise::new(&mut |resolve, _reject| {
@@ -208,13 +210,16 @@ async fn test_resource_manual_refetch() {
 	let counter = Rc::new(RefCell::new(0));
 	let counter_clone = Rc::clone(&counter);
 
-	let resource: Resource<u32, String> = create_resource(move || {
-		let counter = Rc::clone(&counter_clone);
-		async move {
-			*counter.borrow_mut() += 1;
-			Ok::<u32, String>(*counter.borrow())
-		}
-	});
+	let resource: Resource<u32, String> = use_resource(
+		move || {
+			let counter = Rc::clone(&counter_clone);
+			async move {
+				*counter.borrow_mut() += 1;
+				Ok::<u32, String>(*counter.borrow())
+			}
+		},
+		(),
+	);
 
 	// Wait for initial fetch
 	wasm_bindgen_futures::JsFuture::from(js_sys::Promise::new(&mut |resolve, _reject| {
@@ -253,10 +258,13 @@ async fn test_resource_manual_refetch() {
 #[wasm_bindgen_test]
 async fn test_resource_use_case_api_call(test_user: User) {
 	let user = test_user.clone();
-	let resource: Resource<User, String> = create_resource(move || {
-		let user = user.clone();
-		async move { Ok::<User, String>(user) }
-	});
+	let resource: Resource<User, String> = use_resource(
+		move || {
+			let user = user.clone();
+			async move { Ok::<User, String>(user) }
+		},
+		(),
+	);
 
 	// Wait for fetch
 	wasm_bindgen_futures::JsFuture::from(js_sys::Promise::new(&mut |resolve, _reject| {
@@ -314,10 +322,16 @@ fn test_resource_refetch_idempotency_property() {
 async fn test_resource_with_signal_dependency() {
 	let user_id = Signal::new(1u32);
 
-	let resource: Resource<String, String> =
-		create_resource_with_deps(user_id.clone(), |id| async move {
-			Ok::<String, String>(format!("User {}", id))
-		});
+	let resource: Resource<String, String> = use_resource(
+		{
+			let user_id = user_id.clone();
+			move || {
+				let id = user_id.get();
+				async move { Ok::<String, String>(format!("User {}", id)) }
+			}
+		},
+		(user_id.clone(),),
+	);
 
 	// Wait for initial fetch
 	wasm_bindgen_futures::JsFuture::from(js_sys::Promise::new(&mut |resolve, _reject| {

--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -5,33 +5,32 @@
 //!
 //! ## Reactive page shape (canonical template)
 //!
-//! Every async-loading view in this module (`polls_detail`,
-//! `polls_results`, `question_edit`, `question_delete_confirm`) follows
-//! the same reactive shape as `polls_results`:
+//! Every async-loading view in this module (`polls_index`, `polls_detail`,
+//! `polls_results`, `question_edit`, `question_delete_confirm`) follows the
+//! same page! v2 shape:
 //!
-//! - An outer `div` wraps a single `watch{}` block so the function
-//!   returns a top-level `Page::Element` (matching the
-//!   `matches!(view, Page::Element(_))` assertion in
-//!   `tests/wasm/polls_mock_test.rs`).
-//! - Only the reactive `Signal` (`Action<..>`) and the route id flow
-//!   into `page!` as typed parameters. Forms (whose types live inside
-//!   the `form!` macro's block expression and are therefore not
-//!   nameable as `page!` parameter types) and static hrefs are
-//!   captured from the surrounding scope by the implicit `move` of
-//!   the `watch` closure.
-//!
-//! **Anti-pattern**: returning a static `Page`
-//! (e.g. `return page!(|| spinner)();`) from outside the `watch{}` block
-//! strands the SPA on the spinner forever — the reactive subscription is
-//! never established. Every loading branch MUST stay inside the single
-//! outer `watch{}` block.
+//! - Data is loaded with `use_resource(fetcher, ())` and flows into `page!`
+//!   as a `Resource<T, String>` parameter. The view branches on it inside a
+//!   single `{ match resource.get() { Loading => .., Error(e) => .., Success(v)
+//!   => .. } }` block. Reading the resource exactly once matters: `page!`
+//!   auto-wraps each `{ .. }` / `if` / `for` in `Page::reactive(move || ..)`
+//!   (`Fn() -> Page`), and a non-`Copy` handle consumed by two sibling blocks
+//!   would be moved out of that `Fn` closure twice (`E0507`).
+//! - An outer `div` wraps that block so the function returns a top-level
+//!   `Page::Element` (matching the `matches!(view, Page::Element(_))` assertion
+//!   in `tests/wasm/polls_mock_test.rs`).
+//! - page! v2 forbids implicit captures, so every value used in the body is a
+//!   declared parameter and free functions are called through a multi-segment
+//!   path (`self::format_server_error`, `links::detail`). Form sub-views that
+//!   depend on the form's `error` / `loading` signals are rendered inline as
+//!   `{ .. }` blocks that read each signal exactly once.
 
 use crate::shared::types::{ChoiceInfo, QuestionInfo, UserInfo};
 use reinhardt::pages::component::Page;
 use reinhardt::pages::form;
 use reinhardt::pages::page;
-use reinhardt::pages::reactive::hooks::{Action, use_action, use_effect};
-use reinhardt::pages::resolve_static;
+use reinhardt::pages::reactive::hooks::use_effect;
+use reinhardt::pages::reactive::{Resource, ResourceState, Signal, use_resource};
 
 // Alias the `urls` module as `links` to keep call sites concise.
 use crate::apps::polls::server_fn::{
@@ -76,15 +75,13 @@ fn format_server_error(raw: &str) -> String {
 /// Displays a list of available polls with links to vote.
 /// Uses watch blocks for reactive UI updates when async data loads.
 pub fn polls_index() -> Page {
-	let load_questions =
-		use_action(|_: ()| async move { get_questions().await.map_err(|e| e.to_string()) });
-	load_questions.dispatch(());
-
-	let load_questions_error = load_questions.clone();
-	let load_questions_signal = load_questions.clone();
+	let load_questions = use_resource(
+		|| async move { get_questions().await.map_err(|e| e.to_string()) },
+		(),
+	);
 	let new_question_href = links::question_new();
 
-	page!(| load_questions_error : Action<Vec<QuestionInfo>, String>, load_questions_signal : Action<Vec<QuestionInfo>, String>, new_question_href : String | {
+	page!(|load_questions: Resource<Vec<QuestionInfo>, String>, new_question_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			div {
@@ -96,61 +93,58 @@ pub fn polls_index() -> Page {
 					"New Question"
 				}
 			}
-			if load_questions_error.error().is_some() {
-				div {
-					class: "alert-danger",
-					{
-						format_server_error(&load_questions_error.error().unwrap_or_default())
-					}
-				}
-			}
-			if load_questions_signal.is_pending() {
-				div {
-					class: "text-center",
-					div {
-						class: "spinner w-8 h-8",
-						role: "status",
-						span {
-							class: "sr-only",
-							"Loading..."
-						}
-					}
-				}
-			} else if load_questions_signal.result().unwrap_or_default().is_empty() {
-				p {
-					class: "text-muted",
-					"No polls are available."
-				}
-			} else {
-				div {
-					class: "space-y-2",
-					for { question }
-					in load_questions_signal.result().unwrap_or_default() {
-						a {
-							href: links::detail(question.id),
-							class: "block p-4 border border-border rounded-lg bg-surface-primary hover:bg-surface-secondary transition-colors",
+			{
+				match load_questions.get() {
+					ResourceState::Loading => page!(|| {
+						div {
+							class: "text-center",
 							div {
-								class: "flex w-full justify-between",
-								h5 {
-									class: "mb-1",
-									{
-										question.question_text.clone()
-									}
+								class: "spinner w-8 h-8",
+								role: "status",
+								span {
+									class: "sr-only",
+									"Loading..."
 								}
-								small { {
-									question.pub_date.format("%Y-%m-%d %H:%M").to_string()
-								} }
 							}
 						}
-					}
+					})(),
+					ResourceState::Error(error) => page!(|error: String| {
+						div {
+							class: "alert-danger",
+							{ self::format_server_error(&error) }
+						}
+					})(error),
+					ResourceState::Success(questions) if questions.is_empty() => page!(|| {
+						p {
+							class: "text-muted",
+							"No polls are available."
+						}
+					})(),
+					ResourceState::Success(questions) => page!(|questions: Vec<QuestionInfo>| {
+						div {
+							class: "space-y-2",
+							for question in questions {
+								a {
+									href: links::detail(question.id),
+									class: "block p-4 border border-border rounded-lg bg-surface-primary hover:bg-surface-secondary transition-colors",
+									div {
+										class: "flex w-full justify-between",
+										h5 {
+											class: "mb-1",
+											{ question.question_text.clone() }
+										}
+										small { {
+											question.pub_date.format("%Y-%m-%d %H:%M").to_string()
+										} }
+									}
+								}
+							}
+						}
+					})(questions),
 				}
 			}
 		}
-	})(
-		load_questions_error,
-		load_questions_signal,
-		new_question_href,
-	)
+	})(load_questions, new_question_href)
 }
 
 /// Poll detail page - Show question and voting form
@@ -161,11 +155,11 @@ pub fn polls_index() -> Page {
 pub fn polls_detail(question_id: i64) -> Page {
 	let qid = question_id;
 
-	// Create action for loading question detail
-	let load_detail =
-		use_action(
-			|qid: i64| async move { get_question_detail(qid).await.map_err(|e| e.to_string()) },
-		);
+	// Load the question detail once on mount.
+	let load_detail = use_resource(
+		move || async move { get_question_detail(qid).await.map_err(|e| e.to_string()) },
+		(),
+	);
 
 	// Resolve the viewer so the render branch can hide owner-only controls
 	// (Edit / Delete / Add choice) for non-authors and unauthenticated
@@ -173,9 +167,10 @@ pub fn polls_detail(question_id: i64) -> Page {
 	// session has no authenticated user, so any non-`Some(Some(u))` shape
 	// disables the controls. Server-side `require_question_author` still
 	// rejects unauthorized mutations as defense in depth.
-	let load_current_user =
-		use_action(|_: ()| async move { current_user().await.map_err(|e| e.to_string()) });
-	load_current_user.dispatch(());
+	let load_current_user = use_resource(
+		|| async move { current_user().await.map_err(|e| e.to_string()) },
+		(),
+	);
 
 	// Voting form via the `form!` macro.
 	//
@@ -247,41 +242,43 @@ pub fn polls_detail(question_id: i64) -> Page {
 			error_display: |form| {
 				let err = form.error().get();
 				page!(|err: Option<String>| {
-					if let Some(e) = err.clone() {
-						div {
-							class: "alert-danger mt-3",
-							{
-								format_server_error(&e)
+					{
+						err.clone().map(|e| page!(|e: String| {
+							div {
+								class: "alert-danger mt-3",
+								{ self::format_server_error(&e) }
 							}
-						}
+						})(e)).unwrap_or(Page::Empty)
 					}
 				})(err)
 			},
 		}
 	};
 
-	// Bridge load_detail results to form choices via use_effect
+	// Bridge load_detail results to the form's choices, re-running whenever the
+	// `load_detail` resource state changes.
 	{
 		let load_detail_for_effect = load_detail.clone();
+		let load_detail_for_deps = load_detail.clone();
 		let voting_form_for_effect = voting_form.clone();
-		use_effect(move || {
-			if let Some((_, ref choices)) = load_detail_for_effect.result() {
-				let choice_options: Vec<(String, String)> = choices
-					.iter()
-					.map(|c| (c.id.to_string(), c.choice_text.clone()))
-					.collect();
-				voting_form_for_effect
-					.choice_id_choices()
-					.set(choice_options);
-			}
-		});
+		use_effect(
+			move || {
+				if let ResourceState::Success((_, choices)) = load_detail_for_effect.get() {
+					let choice_options: Vec<(String, String)> = choices
+						.iter()
+						.map(|c| (c.id.to_string(), c.choice_text.clone()))
+						.collect();
+					voting_form_for_effect
+						.choice_id_choices()
+						.set(choice_options);
+				}
+				None::<fn()>
+			},
+			(load_detail_for_deps,),
+		);
 	}
 
-	// Dispatch the action to load question data
-	load_detail.dispatch(qid);
-
-	let load_detail_signal = load_detail.clone();
-	let load_current_user_signal = load_current_user.clone();
+	let voting_form_page = voting_form.into_page();
 
 	// Render reactively in the canonical shape (see module-level docs):
 	// outer `div` + single `watch{}` block + the `Action<..>` signal and
@@ -295,119 +292,112 @@ pub fn polls_detail(question_id: i64) -> Page {
 	// `RadioSelect` group for choiceless questions, so any submit emitted
 	// `choice_id=""` and `submit_vote` rejected the request with the
 	// runtime `Invalid choice_id` application error.
-	page!(| load_detail_signal : Action<(QuestionInfo, Vec<ChoiceInfo>), String>, load_current_user_signal : Action<Option<UserInfo>, String>, question_id : i64 | {
+	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>, load_current_user: Resource<Option<UserInfo>, String>, voting_form_page: Page, question_id: i64| {
 		div {
-			if load_detail_signal.is_pending() {
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12 text-center",
-					div {
-						class: "spinner w-8 h-8",
-						role: "status",
-						span {
-							class: "sr-only",
-							"Loading..."
-						}
-					}
-				}
-			} else if load_detail_signal.error().is_some() {
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12",
-					div {
-						class: "alert-danger",
-						{
-							format_server_error(&load_detail_signal.error().unwrap_or_default())
-						}
-					}
-					a {
-						href: links::detail(question_id),
-						class: "btn-secondary",
-						"Try Again"
-					}
-					a {
-						href: links::index(),
-						class: "btn-primary ml-2",
-						"Back to Polls"
-					}
-				}
-			} else if let Some((ref q, ref choices)) = load_detail_signal.result() {
-				// Bind the result once: `Action::result()` clones the
-				// underlying `(QuestionInfo, Vec<ChoiceInfo>)` on every
-				// call, so reusing `q`/`choices` here avoids redundant
-				// allocations on each reactive render.
-				//
-				// Owner-only controls (Edit / Delete / Add choice) are
-				// hidden for non-authors and unauthenticated viewers
-				// (issue #4703). The `current_user` action returns
-				// `Ok(None)` when no session user is present; any
-				// non-`Some(Some(u))` shape (pending, error, or
-				// unauthenticated) leaves `is_author` as `false`.
-				let is_author = match load_current_user_signal.result() {
-					Some(Some(ref u)) => u.id == q.author_id,
-					_ => false,
-				};
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12",
-					div {
-						class: "flex justify-between items-center mb-4",
-						h1 { {
-							q.question_text.clone()
-						} }
+			{
+				match load_detail.get() {
+					ResourceState::Loading => page!(|| {
 						div {
-							class: "flex gap-2",
-							a {
-								href: links::results(question_id),
-								class: "btn-secondary",
-								"View results"
-							}
-							if is_author {
-								a {
-									href: links::question_edit(question_id),
-									class: "btn-secondary",
-									"Edit"
-								}
-								a {
-									href: links::question_delete(question_id),
-									class: "btn-danger",
-									"Delete"
+							class: "max-w-4xl mx-auto px-4 mt-12 text-center",
+							div {
+								class: "spinner w-8 h-8",
+								role: "status",
+								span {
+									class: "sr-only",
+									"Loading..."
 								}
 							}
 						}
-					}
-					if ! choices.is_empty() { {
-						voting_form.clone().into_page()
-					} } else {
+					})(),
+					ResourceState::Error(error) => page!(|error: String, question_id: i64| {
 						div {
-							class: "alert-warning",
-							"This question has no choices yet. Add one below to start voting."
-						}
-					}
-					if is_author {
-						div {
-							class: "mt-4",
+							class: "max-w-4xl mx-auto px-4 mt-12",
+							div {
+								class: "alert-danger",
+								{ self::format_server_error(&error) }
+							}
 							a {
-								href: links::choice_new(question_id),
+								href: links::detail(question_id),
 								class: "btn-secondary",
-								"Add choice"
+								"Try Again"
+							}
+							a {
+								href: links::index(),
+								class: "btn-primary ml-2",
+								"Back to Polls"
 							}
 						}
-					}
-				}
-			} else {
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12",
-					div {
-						class: "alert-warning",
-						"Question not found"
-					}
-					a {
-						href: links::index(),
-						class: "btn-primary",
-						"Back to Polls"
+					})(error, question_id),
+					ResourceState::Success((q, choices)) => {
+						// Owner-only controls (Edit / Delete / Add choice) are hidden for
+						// non-authors and unauthenticated viewers (issue #4703). Any
+						// non-`Success(Some(u))` shape leaves `is_author` as `false`.
+						let is_author = matches!(
+							load_current_user.get(),
+							ResourceState::Success(Some(ref u)) if u.id == q.author_id
+						);
+						// Render the voting form only when the question has choices;
+						// otherwise show an empty-state prompt (reinhardt-web#4686).
+						let choices_view = if choices.is_empty() {
+							page!(|| {
+								div {
+									class: "alert-warning",
+									"This question has no choices yet. Add one below to start voting."
+								}
+							})()
+						} else {
+							voting_form_page.clone()
+						};
+						page!(|q: QuestionInfo, is_author: bool, choices_view: Page, question_id: i64| {
+							div {
+								class: "max-w-4xl mx-auto px-4 mt-12",
+								div {
+									class: "flex justify-between items-center mb-4",
+									h1 { { q.question_text.clone() } }
+									div {
+										class: "flex gap-2",
+										a {
+											href: links::results(question_id),
+											class: "btn-secondary",
+											"View results"
+										}
+										if is_author {
+											a {
+												href: links::question_edit(question_id),
+												class: "btn-secondary",
+												"Edit"
+											}
+											a {
+												href: links::question_delete(question_id),
+												class: "btn-danger",
+												"Delete"
+											}
+										}
+									}
+								}
+								{ choices_view }
+								if is_author {
+									div {
+										class: "mt-4",
+										a {
+											href: links::choice_new(question_id),
+											class: "btn-secondary",
+											"Add choice"
+										}
+									}
+								}
+							}
+						})(q, is_author, choices_view, question_id)
 					}
 				}
 			}
 		}
-	})(load_detail_signal, load_current_user_signal, question_id)
+	})(
+		load_detail,
+		load_current_user,
+		voting_form_page,
+		question_id,
+	)
 }
 
 /// Poll results page - Show voting results
@@ -420,174 +410,150 @@ pub fn polls_detail(question_id: i64) -> Page {
 /// viewer is the question's author (issue #4703). Server-side
 /// `require_question_author` checks remain in place as defense in depth.
 pub fn polls_results(question_id: i64) -> Page {
-	let load_results =
-		use_action(
-			|qid: i64| async move { get_question_results(qid).await.map_err(|e| e.to_string()) },
-		);
-	load_results.dispatch(question_id);
+	let load_results = use_resource(
+		move || async move {
+			get_question_results(question_id)
+				.await
+				.map_err(|e| e.to_string())
+		},
+		(),
+	);
+	let load_current_user = use_resource(
+		|| async move { current_user().await.map_err(|e| e.to_string()) },
+		(),
+	);
 
-	let load_current_user =
-		use_action(|_: ()| async move { current_user().await.map_err(|e| e.to_string()) });
-	load_current_user.dispatch(());
-
-	let load_results_signal = load_results.clone();
-	let load_current_user_signal = load_current_user.clone();
-
-	page!(| load_results_signal : Action<(QuestionInfo, Vec<ChoiceInfo>, i32), String>, load_current_user_signal : Action<Option<UserInfo>, String>, question_id : i64 | {
+	page!(|load_results: Resource<(QuestionInfo, Vec<ChoiceInfo>, i32), String>, load_current_user: Resource<Option<UserInfo>, String>, question_id: i64| {
 		div {
-			if load_results_signal.is_pending() {
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12 text-center",
-					div {
-						class: "spinner w-8 h-8",
-						role: "status",
-						span {
-							class: "sr-only",
-							"Loading..."
-						}
-					}
-				}
-			} else if load_results_signal.error().is_some() {
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12",
-					div {
-						class: "alert-danger",
-						{
-							format_server_error(&load_results_signal.error().unwrap_or_default())
-						}
-					}
-					a {
-						href: links::index(),
-						class: "btn-primary",
-						"Back to Polls"
-					}
-				}
-			} else if load_results_signal.result().is_some() {
-				// Owner-only controls (Edit / Delete) are hidden for
-				// non-authors and unauthenticated viewers (issue #4703).
-				// `current_user` returns `Ok(None)` when no session user
-				// is present; any non-`Some(Some(u))` shape (pending,
-				// error, or unauthenticated) leaves `is_author` as
-				// `false`. Server-side `require_question_author` still
-				// rejects unauthorized mutations as defense in depth.
-				let is_author = match(load_results_signal.result(), load_current_user_signal.result(), ) {
-					(Some((ref q, _, _)), Some(Some(ref u))) => u.id == q.author_id,
-					_ => false,
-				};
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12",
-					h1 {
-						class: "mb-4",
-						{
-							load_results_signal.result().map(|(q, _, _)| q.question_text.clone()).unwrap_or_default()
-						}
-					}
-					div {
-						class: "card",
+			{
+				match load_results.get() {
+					ResourceState::Loading => page!(|| {
 						div {
-							class: "card-body",
-							h5 {
-								class: "text-xl font-bold",
-								"Results"
-							}
+							class: "max-w-4xl mx-auto px-4 mt-12 text-center",
 							div {
-								class: "divide-y divide-border",
-								{
-									if let Some((_, choices, total)) = load_results_signal.result() {
-										page!(| choices : Vec<ChoiceInfo>, total : i32 | {
-											for choice in choices { { {
-												let percentage = if total > 0 {
-													(choice.votes as f64 / total as f64 * 100.0) as i32
-												} else { 0 };
-												page!(| choice : ChoiceInfo, percentage : i32 | {
-													div {
-														class: "py-4",
-														div {
-															class: "flex justify-between items-center mb-2",
-															strong { {
-																choice.choice_text.clone()
-															} }
-															span {
-																class: "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
-																{
-																	format!("{} votes", choice.votes)
-																}
-															}
-														}
-														div {
-															class: "w-full bg-surface-tertiary rounded-full h-2.5",
-															div {
-																class: "bg-brand h-2.5 rounded-full",
-																role: "progressbar",
-																style: format!("width: {}%", percentage),
-																aria_valuenow: percentage.to_string(),
-																aria_valuemin: "0",
-																aria_valuemax: "100",
-																{
-																	format!("{}%", percentage)
-																}
-															}
-														}
-													}
-												})(choice, percentage)
-											} } }
-										})(choices, total)
-									} else { Page::Empty }
+								class: "spinner w-8 h-8",
+								role: "status",
+								span {
+									class: "sr-only",
+									"Loading..."
 								}
 							}
+						}
+					})(),
+					ResourceState::Error(error) => page!(|error: String| {
+						div {
+							class: "max-w-4xl mx-auto px-4 mt-12",
 							div {
-								class: "mt-3",
-								p {
-									class: "text-muted",
-									{
-										format!("Total votes: {}", load_results_signal.result().map(|(_, _, total)| total).unwrap_or(0))
+								class: "alert-danger",
+								{ self::format_server_error(&error) }
+							}
+							a {
+								href: links::index(),
+								class: "btn-primary",
+								"Back to Polls"
+							}
+						}
+					})(error),
+					ResourceState::Success((q, choices, total)) => {
+						// Owner-only controls (Edit / Delete) are hidden for non-authors
+						// and unauthenticated viewers (issue #4703).
+						let is_author = matches!(
+							load_current_user.get(),
+							ResourceState::Success(Some(ref u)) if u.id == q.author_id
+						);
+						page!(|q: QuestionInfo, choices: Vec<ChoiceInfo>, total: i32, is_author: bool, question_id: i64| {
+							div {
+								class: "max-w-4xl mx-auto px-4 mt-12",
+								h1 {
+									class: "mb-4",
+									{ q.question_text.clone() }
+								}
+								div {
+									class: "card",
+									div {
+										class: "card-body",
+										h5 {
+											class: "text-xl font-bold",
+											"Results"
+										}
+										div {
+											class: "divide-y divide-border",
+											for choice in choices {
+												{
+													let percentage = if total > 0 {
+														(choice.votes as f64 / total as f64 * 100.0) as i32
+													} else {
+														0
+													};
+													page!(|choice: ChoiceInfo, percentage: i32| {
+														div {
+															class: "py-4",
+															div {
+																class: "flex justify-between items-center mb-2",
+																strong { { choice.choice_text.clone() } }
+																span {
+																	class: "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
+																	{ format!("{} votes", choice.votes) }
+																}
+															}
+															div {
+																class: "w-full bg-surface-tertiary rounded-full h-2.5",
+																div {
+																	class: "bg-brand h-2.5 rounded-full",
+																	role: "progressbar",
+																	style: format!("width: {}%", percentage),
+																	aria_valuenow: percentage.to_string(),
+																	aria_valuemin: "0",
+																	aria_valuemax: "100",
+																	{ format!("{}%", percentage) }
+																}
+															}
+														}
+													})(choice.clone(), percentage)
+												}
+											}
+										}
+										div {
+											class: "mt-3",
+											p {
+												class: "text-muted",
+												{ format!("Total votes: {}", total) }
+											}
+										}
+									}
+								}
+								div {
+									class: "mt-3 flex flex-wrap gap-2",
+									a {
+										href: links::detail(question_id),
+										class: "btn-primary",
+										"Vote Again"
+									}
+									if is_author {
+										a {
+											href: links::question_edit(question_id),
+											class: "btn-secondary",
+											"Edit question"
+										}
+										a {
+											href: links::question_delete(question_id),
+											class: "btn-danger",
+											"Delete question"
+										}
+									}
+									a {
+										href: links::index(),
+										class: "btn-secondary",
+										"Back to Polls"
 									}
 								}
 							}
-						}
-					}
-					div {
-						class: "mt-3 flex flex-wrap gap-2",
-						a {
-							href: links::detail(question_id),
-							class: "btn-primary",
-							"Vote Again"
-						}
-						if is_author {
-							a {
-								href: links::question_edit(question_id),
-								class: "btn-secondary",
-								"Edit question"
-							}
-							a {
-								href: links::question_delete(question_id),
-								class: "btn-danger",
-								"Delete question"
-							}
-						}
-						a {
-							href: links::index(),
-							class: "btn-secondary",
-							"Back to Polls"
-						}
-					}
-				}
-			} else {
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12",
-					div {
-						class: "alert-warning",
-						"Question not found"
-					}
-					a {
-						href: links::index(),
-						class: "btn-primary",
-						"Back to Polls"
+						})(q, choices, total, is_author, question_id)
 					}
 				}
 			}
 		}
-	})(load_results_signal, load_current_user_signal, question_id)
+	})(load_results, load_current_user, question_id)
 }
 
 /// Example component demonstrating static URL resolution
@@ -596,20 +562,18 @@ pub fn polls_results(question_id: i64) -> Page {
 /// This function is identical to polls_index() but adds poll icons using
 /// static URL resolution.
 pub fn polls_index_with_logo() -> Page {
-	let load_questions =
-		use_action(|_: ()| async move { get_questions().await.map_err(|e| e.to_string()) });
-	load_questions.dispatch(());
+	let load_questions = use_resource(
+		|| async move { get_questions().await.map_err(|e| e.to_string()) },
+		(),
+	);
 
-	let load_questions_error = load_questions.clone();
-	let load_questions_signal = load_questions.clone();
-
-	page!(| load_questions_error : Action<Vec<QuestionInfo>, String>, load_questions_signal : Action<Vec<QuestionInfo>, String> | {
+	page!(|load_questions: Resource<Vec<QuestionInfo>, String>| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			div {
 				class: "text-center mb-6",
 				img {
-					src: resolve_static("images/poll-icon.svg"),
+					src: reinhardt::pages::resolve_static("images/poll-icon.svg"),
 					alt: "Polls App",
 					class: "mx-auto w-16 h-16",
 				}
@@ -618,65 +582,66 @@ pub fn polls_index_with_logo() -> Page {
 				class: "mb-4 text-center",
 				"Polls"
 			}
-			if load_questions_error.error().is_some() {
-				div {
-					class: "alert-danger",
-					{
-						format_server_error(&load_questions_error.error().unwrap_or_default())
-					}
-				}
-			}
-			if load_questions_signal.is_pending() {
-				div {
-					class: "text-center",
-					div {
-						class: "spinner w-8 h-8",
-						role: "status",
-						span {
-							class: "sr-only",
-							"Loading..."
-						}
-					}
-				}
-			} else if load_questions_signal.result().unwrap_or_default().is_empty() {
-				p {
-					class: "text-muted",
-					"No polls are available."
-				}
-			} else {
-				div {
-					class: "space-y-2",
-					for { question }
-					in load_questions_signal.result().unwrap_or_default() {
-						a {
-							href: format!("/polls/{}/", question.id),
-							class: "block p-4 border border-border rounded-lg bg-surface-primary hover:bg-surface-secondary transition-colors",
+			{
+				match load_questions.get() {
+					ResourceState::Loading => page!(|| {
+						div {
+							class: "text-center",
 							div {
-								class: "flex w-full justify-between items-center",
-								img {
-									src: resolve_static("images/poll-icon.svg"),
-									alt: "Poll",
-									class: "w-8 h-8 mr-3",
+								class: "spinner w-8 h-8",
+								role: "status",
+								span {
+									class: "sr-only",
+									"Loading..."
 								}
-								div {
-									class: "flex-1",
-									h5 {
-										class: "mb-1",
-										{
-											question.question_text.clone()
-										}
-									}
-								}
-								small { {
-									question.pub_date.format("%Y-%m-%d %H:%M").to_string()
-								} }
 							}
 						}
-					}
+					})(),
+					ResourceState::Error(error) => page!(|error: String| {
+						div {
+							class: "alert-danger",
+							{ self::format_server_error(&error) }
+						}
+					})(error),
+					ResourceState::Success(questions) if questions.is_empty() => page!(|| {
+						p {
+							class: "text-muted",
+							"No polls are available."
+						}
+					})(),
+					ResourceState::Success(questions) => page!(|questions: Vec<QuestionInfo>| {
+						div {
+							class: "space-y-2",
+							for question in questions {
+								a {
+									href: format!("/polls/{}/", question.id),
+									class: "block p-4 border border-border rounded-lg bg-surface-primary hover:bg-surface-secondary transition-colors",
+									div {
+										class: "flex w-full justify-between items-center",
+										img {
+											src: reinhardt::pages::resolve_static("images/poll-icon.svg"),
+											alt: "Poll",
+											class: "w-8 h-8 mr-3",
+										}
+										div {
+											class: "flex-1",
+											h5 {
+												class: "mb-1",
+												{ question.question_text.clone() }
+											}
+										}
+										small { {
+											question.pub_date.format("%Y-%m-%d %H:%M").to_string()
+										} }
+									}
+								}
+							}
+						}
+					})(questions),
 				}
 			}
 		}
-	})(load_questions_error, load_questions_signal)
+	})(load_questions)
 }
 
 // =========================================================================
@@ -718,39 +683,35 @@ pub fn question_new() -> Page {
 	let form_view = new_form.into_page();
 	let cancel_href = links::index();
 
-	page!(|loading_signal: reinhardt::pages::reactive::Signal<bool>, error_signal: reinhardt::pages::reactive::Signal<Option<String>>, form_view: Page, cancel_href: String| {
+	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, cancel_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {
 				class: "mb-4",
 				"New Question"
 			}
-			if error_signal.get().is_some() {
-				div {
-					class: "alert-danger mb-3",
-					{
-						format_server_error(&error_signal.get().unwrap_or_default())
+			{
+				error_signal.get().map(|message| page!(|message: String| {
+					div {
+						class: "alert-danger mb-3",
+						{ self::format_server_error(&message) }
 					}
-				}
+				})(message)).unwrap_or(Page::Empty)
 			}
 			{ form_view }
 			div {
 				class: "mt-3",
-				if loading_signal.get() {
-					button {
-						type: "submit",
-						class: "btn-primary opacity-50 cursor-not-allowed",
-						disabled: true,
-						form: "new-question-form",
-						"Creating..."
-					}
-				} else {
-					button {
-						type: "submit",
-						class: "btn-primary",
-						form: "new-question-form",
-						"Create"
-					}
+				{
+					let is_loading = loading_signal.get();
+					page!(|is_loading: bool| {
+						button {
+							type: "submit",
+							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
+							disabled: is_loading,
+							form: "new-question-form",
+							{ if is_loading { "Creating..." } else { "Create" } }
+						}
+					})(is_loading)
 				}
 				a {
 					href: cancel_href,
@@ -770,11 +731,10 @@ pub fn question_new() -> Page {
 pub fn question_edit(question_id: i64) -> Page {
 	let qid = question_id;
 
-	let load_detail =
-		use_action(
-			|qid: i64| async move { get_question_detail(qid).await.map_err(|e| e.to_string()) },
-		);
-	load_detail.dispatch(qid);
+	let load_detail = use_resource(
+		move || async move { get_question_detail(qid).await.map_err(|e| e.to_string()) },
+		(),
+	);
 
 	let edit_form = form! {
 		name: EditQuestionForm,
@@ -801,124 +761,120 @@ pub fn question_edit(question_id: i64) -> Page {
 		}
 	};
 
-	// Prefill the question_text input once the load_detail action resolves.
+	// Prefill the question_text input once the load_detail resource resolves,
+	// re-running whenever its state changes.
 	{
 		let load_detail_for_effect = load_detail.clone();
+		let load_detail_for_deps = load_detail.clone();
 		let edit_form_for_effect = edit_form.clone();
-		use_effect(move || {
-			if let Some((ref question, _)) = load_detail_for_effect.result() {
-				edit_form_for_effect
-					.question_text()
-					.set(question.question_text.clone());
-			}
-		});
+		use_effect(
+			move || {
+				if let ResourceState::Success((question, _)) = load_detail_for_effect.get() {
+					edit_form_for_effect
+						.question_text()
+						.set(question.question_text.clone());
+				}
+				None::<fn()>
+			},
+			(load_detail_for_deps,),
+		);
 	}
 
-	let load_detail_signal = load_detail.clone();
-
-	// Render reactively. The previous shape used an outer `watch{}` on
-	// `load_detail_signal` with *nested* `watch{}` blocks on
-	// `edit_form.error()` / `edit_form.loading()`. Each `watch{}` lowers
-	// to `Page::reactive(move || ...)` (`Fn() -> Page + 'static`); the
-	// inner closures each tried to take the non-`Copy`
-	// `EditQuestionForm` out of the outer closure a second time, which
-	// rustc rejects with `E0507` (issue #4515,
-	// `crates/reinhardt-pages/docs/watch_semantics.md` § "Fix 1").
-	//
-	// The DSL does not accept Rust `let` statements between `} else {`
-	// and the next node, so the doc's "Fix 2" (clone the form into
-	// outer-scope locals inside the `else` branch) is not currently
-	// expressible. Apply "Fix 1" (preferred): a single `watch{}` already
-	// subscribes to every signal it reads, so collapsing all three
-	// `watch{}` blocks into the outer one removes the nested-capture
-	// move and still re-renders on `load_detail_signal`,
-	// `edit_form.error()`, and `edit_form.loading()` changes.
-	page!(|load_detail_signal: Action<(QuestionInfo, Vec<ChoiceInfo>), String>, question_id: i64| {
+	// Build the edit-form view once; its internal `{ ... }` blocks subscribe to
+	// the form's error/loading signals so it stays reactive when embedded below.
+	let edit_form_error = edit_form.error().clone();
+	let edit_form_loading = edit_form.loading().clone();
+	let edit_form_page = edit_form.into_page();
+	let edit_form_view = page!(|edit_form_error: Signal<Option<String>>, edit_form_loading: Signal<bool>, edit_form_page: Page, question_id: i64| {
 		div {
-			if load_detail_signal.is_pending() {
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12 text-center",
+			class: "max-w-4xl mx-auto px-4 mt-12",
+			h1 {
+				class: "mb-4",
+				"Edit Question"
+			}
+			{
+				edit_form_error.get().map(|message| page!(|message: String| {
 					div {
-						class: "spinner w-8 h-8",
-						role: "status",
-						span {
-							class: "sr-only",
-							"Loading..."
-						}
+						class: "alert-danger mb-3",
+						{ self::format_server_error(&message) }
 					}
-				}
-			} else if load_detail_signal.error().is_some() {
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12",
-					div {
-						class: "alert-danger",
-						{
-							format_server_error(&load_detail_signal.error().unwrap_or_default())
-						}
-					}
-					a {
-						href: links::index(),
-						class: "btn-primary",
-						"Back to Polls"
-					}
-				}
-			} else {
-				div {
-					class: "max-w-4xl mx-auto px-4 mt-12",
-					h1 {
-						class: "mb-4",
-						"Edit Question"
-					}
-					if edit_form.error().get().is_some() {
-						div {
-							class: "alert-danger mb-3",
-							{
-								format_server_error(&edit_form.error().get().unwrap_or_default())
-							}
-						}
-					}
-					{
-						edit_form.clone().into_page()
-					}
-					div {
-						class: "mt-3",
-						if edit_form.loading().get() {
-							button {
-								type: "submit",
-								class: "btn-primary opacity-50 cursor-not-allowed",
-								disabled: true,
-								form: "edit-question-form",
-								"Saving..."
-							}
-						} else {
-							button {
-								type: "submit",
-								class: "btn-primary",
-								form: "edit-question-form",
-								"Save"
-							}
+				})(message)).unwrap_or(Page::Empty)
+			}
+			{ edit_form_page }
+			div {
+				class: "mt-3",
+				{
+					let is_loading = edit_form_loading.get();
+					page!(|is_loading: bool, question_id: i64| {
+						button {
+							type: "submit",
+							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
+							disabled: is_loading,
+							form: "edit-question-form",
+							{ if is_loading { "Saving..." } else { "Save" } }
 						}
 						a {
 							href: links::detail(question_id),
 							class: "btn-secondary ml-2",
 							"Cancel"
 						}
-					}
+					})(is_loading, question_id)
 				}
 			}
 		}
-	})(load_detail_signal, question_id)
+	})(
+		edit_form_error,
+		edit_form_loading,
+		edit_form_page,
+		question_id,
+	);
+
+	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>, edit_form_view: Page, question_id: i64| {
+		div {
+			{
+				match load_detail.get() {
+					ResourceState::Loading => page!(|| {
+						div {
+							class: "max-w-4xl mx-auto px-4 mt-12 text-center",
+							div {
+								class: "spinner w-8 h-8",
+								role: "status",
+								span {
+									class: "sr-only",
+									"Loading..."
+								}
+							}
+						}
+					})(),
+					ResourceState::Error(error) => page!(|error: String| {
+						div {
+							class: "max-w-4xl mx-auto px-4 mt-12",
+							div {
+								class: "alert-danger",
+								{ self::format_server_error(&error) }
+							}
+							a {
+								href: links::index(),
+								class: "btn-primary",
+								"Back to Polls"
+							}
+						}
+					})(error),
+					ResourceState::Success(_) => edit_form_view.clone(),
+				}
+			}
+		}
+	})(load_detail, edit_form_view, question_id)
 }
 
 /// Delete confirmation page (`/polls/{question_id}/delete/`).
 pub fn question_delete_confirm(question_id: i64) -> Page {
 	let qid = question_id;
 
-	let load_detail =
-		use_action(
-			|qid: i64| async move { get_question_detail(qid).await.map_err(|e| e.to_string()) },
-		);
-	load_detail.dispatch(qid);
+	let load_detail = use_resource(
+		move || async move { get_question_detail(qid).await.map_err(|e| e.to_string()) },
+		(),
+	);
 
 	let delete_form = form! {
 		name: DeleteQuestionForm,
@@ -942,84 +898,81 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 	let loading_signal = delete_form.loading().clone();
 	let error_signal = delete_form.error().clone();
 	let form_view = delete_form.into_page();
-	let load_detail_signal = load_detail.clone();
 	let cancel_href = links::detail(question_id);
 
-	page!(|load_detail_signal: Action<(QuestionInfo, Vec<ChoiceInfo>), String>, loading_signal: reinhardt::pages::reactive::Signal<bool>, error_signal: reinhardt::pages::reactive::Signal<Option<String>>, form_view: Page, cancel_href: String| {
+	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>, error_signal: Signal<Option<String>>, loading_signal: Signal<bool>, form_view: Page, cancel_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {
 				class: "mb-4",
 				"Delete Question?"
 			}
-			if load_detail_signal.is_pending() {
-				div {
-					class: "text-center",
-					"Loading..."
-				}
-			} else if let Some((ref q, _)) = load_detail_signal.result() {
-				div {
-					class: "card",
-					div {
-						class: "card-body",
-						p {
-							class: "text-muted",
-							"You are about to delete the following question. This action cannot be undone."
+			{
+				match load_detail.get() {
+					ResourceState::Loading => page!(|| {
+						div {
+							class: "text-center",
+							"Loading..."
 						}
-						blockquote {
-							class: "border-l-4 border-border-secondary pl-4 italic my-3",
-							{
-								q.question_text.clone()
+					})(),
+					ResourceState::Success((q, _)) => page!(|q: QuestionInfo| {
+						div {
+							class: "card",
+							div {
+								class: "card-body",
+								p {
+									class: "text-muted",
+									"You are about to delete the following question. This action cannot be undone."
+								}
+								blockquote {
+									class: "border-l-4 border-border-secondary pl-4 italic my-3",
+									{ q.question_text.clone() }
+								}
 							}
 						}
-					}
-				}
-			} else if load_detail_signal.error().is_some() {
-				div {
-					class: "alert-danger",
-					{
-						format_server_error(&load_detail_signal.error().unwrap_or_default())
-					}
+					})(q),
+					ResourceState::Error(error) => page!(|error: String| {
+						div {
+							class: "alert-danger",
+							{ self::format_server_error(&error) }
+						}
+					})(error),
 				}
 			}
-			if error_signal.get().is_some() {
-				div {
-					class: "alert-danger mt-3",
-					{
-						format_server_error(&error_signal.get().unwrap_or_default())
+			{
+				error_signal.get().map(|message| page!(|message: String| {
+					div {
+						class: "alert-danger mt-3",
+						{ self::format_server_error(&message) }
 					}
-				}
+				})(message)).unwrap_or(Page::Empty)
 			}
 			{ form_view }
 			div {
 				class: "mt-3",
-				if loading_signal.get() {
-					button {
-						type: "submit",
-						class: "btn-primary opacity-50 cursor-not-allowed",
-						disabled: true,
-						form: "delete-question-form",
-						"Deleting..."
-					}
-				} else {
-					button {
-						type: "submit",
-						class: "btn-danger",
-						form: "delete-question-form",
-						"Delete"
-					}
-				}
-				a {
-					href: cancel_href,
-					class: "btn-secondary ml-2",
-					"Cancel"
+				{
+					let is_loading = loading_signal.get();
+					page!(|is_loading: bool, cancel_href: String| {
+						button {
+							type: "submit",
+							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-danger" },
+							disabled: is_loading,
+							form: "delete-question-form",
+							{ if is_loading { "Deleting..." } else { "Delete" } }
+						}
+						a {
+							href: cancel_href,
+							class: "btn-secondary ml-2",
+							"Cancel"
+						}
+					})(is_loading, cancel_href.clone())
 				}
 			}
 		}
 	})(
-		load_detail_signal,
-		loading_signal,
+		load_detail,
 		error_signal,
+		loading_signal,
 		form_view,
 		cancel_href,
 	)
@@ -1057,7 +1010,7 @@ pub fn choice_new(question_id: i64) -> Page {
 			loading,
 			error
 		},
-		redirect_on_success: links::detail(qid),
+		success_url: |_form| links::detail(qid),
 		fields: {
 			question_id: HiddenField {
 				initial: qid_str,
@@ -1080,39 +1033,35 @@ pub fn choice_new(question_id: i64) -> Page {
 	let form_view = new_form.into_page();
 	let back_href = links::detail(qid);
 
-	page!(|loading_signal: reinhardt::pages::reactive::Signal<bool>, error_signal: reinhardt::pages::reactive::Signal<Option<String>>, form_view: Page, back_href: String| {
+	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, back_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {
 				class: "mb-4",
 				"Add a Choice"
 			}
-			if error_signal.get().is_some() {
-				div {
-					class: "alert-danger mb-3",
-					{
-						format_server_error(&error_signal.get().unwrap_or_default())
+			{
+				error_signal.get().map(|message| page!(|message: String| {
+					div {
+						class: "alert-danger mb-3",
+						{ self::format_server_error(&message) }
 					}
-				}
+				})(message)).unwrap_or(Page::Empty)
 			}
 			{ form_view }
 			div {
 				class: "mt-3",
-				if loading_signal.get() {
-					button {
-						type: "submit",
-						class: "btn-primary opacity-50 cursor-not-allowed",
-						disabled: true,
-						form: "new-choice-form",
-						"Adding..."
-					}
-				} else {
-					button {
-						type: "submit",
-						class: "btn-primary",
-						form: "new-choice-form",
-						"Add Choice"
-					}
+				{
+					let is_loading = loading_signal.get();
+					page!(|is_loading: bool| {
+						button {
+							type: "submit",
+							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
+							disabled: is_loading,
+							form: "new-choice-form",
+							{ if is_loading { "Adding..." } else { "Add Choice" } }
+						}
+					})(is_loading)
 				}
 				a {
 					href: back_href,
@@ -1162,39 +1111,35 @@ pub fn choice_edit(question_id: i64, choice_id: i64) -> Page {
 	let error_signal = edit_form.error().clone();
 	let form_view = edit_form.into_page();
 
-	page!(|loading_signal: reinhardt::pages::reactive::Signal<bool>, error_signal: reinhardt::pages::reactive::Signal<Option<String>>, form_view: Page, cancel_href: String| {
+	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, cancel_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {
 				class: "mb-4",
 				"Edit Choice"
 			}
-			if error_signal.get().is_some() {
-				div {
-					class: "alert-danger mb-3",
-					{
-						format_server_error(&error_signal.get().unwrap_or_default())
+			{
+				error_signal.get().map(|message| page!(|message: String| {
+					div {
+						class: "alert-danger mb-3",
+						{ self::format_server_error(&message) }
 					}
-				}
+				})(message)).unwrap_or(Page::Empty)
 			}
 			{ form_view }
 			div {
 				class: "mt-3",
-				if loading_signal.get() {
-					button {
-						type: "submit",
-						class: "btn-primary opacity-50 cursor-not-allowed",
-						disabled: true,
-						form: "edit-choice-form",
-						"Saving..."
-					}
-				} else {
-					button {
-						type: "submit",
-						class: "btn-primary",
-						form: "edit-choice-form",
-						"Save"
-					}
+				{
+					let is_loading = loading_signal.get();
+					page!(|is_loading: bool| {
+						button {
+							type: "submit",
+							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
+							disabled: is_loading,
+							form: "edit-choice-form",
+							{ if is_loading { "Saving..." } else { "Save" } }
+						}
+					})(is_loading)
 				}
 				a {
 					href: cancel_href,
@@ -1238,7 +1183,7 @@ pub fn choice_delete_confirm(question_id: i64, choice_id: i64) -> Page {
 	let error_signal = delete_form.error().clone();
 	let form_view = delete_form.into_page();
 
-	page!(|loading_signal: reinhardt::pages::reactive::Signal<bool>, error_signal: reinhardt::pages::reactive::Signal<Option<String>>, form_view: Page, cancel_href: String| {
+	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, cancel_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {
@@ -1249,32 +1194,28 @@ pub fn choice_delete_confirm(question_id: i64, choice_id: i64) -> Page {
 				class: "mb-3",
 				"This action cannot be undone."
 			}
-			if error_signal.get().is_some() {
-				div {
-					class: "alert-danger mt-3",
-					{
-						format_server_error(&error_signal.get().unwrap_or_default())
+			{
+				error_signal.get().map(|message| page!(|message: String| {
+					div {
+						class: "alert-danger mt-3",
+						{ self::format_server_error(&message) }
 					}
-				}
+				})(message)).unwrap_or(Page::Empty)
 			}
 			{ form_view }
 			div {
 				class: "mt-3",
-				if loading_signal.get() {
-					button {
-						type: "submit",
-						class: "btn-primary opacity-50 cursor-not-allowed",
-						disabled: true,
-						form: "delete-choice-form",
-						"Deleting..."
-					}
-				} else {
-					button {
-						type: "submit",
-						class: "btn-danger",
-						form: "delete-choice-form",
-						"Delete"
-					}
+				{
+					let is_loading = loading_signal.get();
+					page!(|is_loading: bool| {
+						button {
+							type: "submit",
+							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-danger" },
+							disabled: is_loading,
+							form: "delete-choice-form",
+							{ if is_loading { "Deleting..." } else { "Delete" } }
+						}
+					})(is_loading)
 				}
 				a {
 					href: cancel_href,

--- a/examples/examples-tutorial-basis/src/apps/polls/urls/client_router.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/urls/client_router.rs
@@ -104,7 +104,7 @@ fn error_page(message: &str) -> Page {
 			class: "layout-page",
 			div {
 				class: "alert-danger mb-4",
-				{ { message } }
+				{ message }
 			}
 			a {
 				href: "/",

--- a/examples/examples-tutorial-basis/src/apps/users/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/client/components.rs
@@ -20,7 +20,11 @@ pub fn login_form() -> Page {
 	let login_form = form! {
 		name: LoginForm,
 		server_fn: login,
+		method: Post,
 		redirect_on_success: "/",
+		strip_arguments: {
+			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
+		},
 		state: {
 			loading,
 			error,
@@ -44,6 +48,7 @@ pub fn login_form() -> Page {
 	let form_view = login_form.into_page();
 	let polls_index_href = polls_links::index();
 	let signup_href = links::signup();
+
 	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, polls_index_href: String, signup_href: String| {
 		div {
 			class: "max-w-md mx-auto px-4 mt-12",
@@ -55,32 +60,32 @@ pub fn login_form() -> Page {
 						class: "card-title",
 						"Sign in"
 					}
-					if error_signal.get().is_some() {
-						div {
-							class: "alert-danger mb-3",
-							{
-								error_signal.get().unwrap_or_default()
+					{
+						error_signal.get().map(|message| page!(|message: String| {
+							div {
+								class: "alert-danger mb-3",
+								{ message }
 							}
-						}
+						})(message)).unwrap_or(Page::Empty)
 					}
-					{ { form_view } }
+					{ form_view }
 					div {
 						class: "mt-4",
-						if loading_signal.get() {
-							button {
-								type: "submit",
-								class: "btn-primary w-full",
-								disabled: loading_signal.get(),
-								form: "login-form",
-								"Signing in..."
-							}
-						} else {
-							button {
-								type: "submit",
-								class: "btn-primary w-full",
-								form: "login-form",
-								"Sign in"
-							}
+						{
+							let is_loading = loading_signal.get();
+							page!(|is_loading: bool| {
+								button {
+									type: "submit",
+									class: if is_loading {
+										"btn-primary w-full opacity-50 cursor-not-allowed"
+									} else {
+										"btn-primary w-full"
+									},
+									disabled: is_loading,
+									form: "login-form",
+									{ if is_loading { "Signing in..." } else { "Sign in" } }
+								}
+							})(is_loading)
 						}
 					}
 				}
@@ -113,7 +118,11 @@ pub fn logout_form() -> Page {
 	let logout_form = form! {
 		name: LogoutForm,
 		server_fn: logout,
+		method: Post,
 		redirect_on_success: "/",
+		strip_arguments: {
+			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
+		},
 		state: {
 			loading,
 			error,
@@ -123,6 +132,7 @@ pub fn logout_form() -> Page {
 	let error_signal = logout_form.error().clone();
 	let form_view = logout_form.into_page();
 	let polls_index_href = polls_links::index();
+
 	page!(|error_signal: Signal<Option<String>>, form_view: Page, polls_index_href: String| {
 		div {
 			class: "max-w-md mx-auto px-4 mt-12",
@@ -138,15 +148,15 @@ pub fn logout_form() -> Page {
 						class: "text-muted mb-4",
 						"Click the button below to end your session."
 					}
-					if error_signal.get().is_some() {
-						div {
-							class: "alert-danger mb-3",
-							{
-								error_signal.get().unwrap_or_default()
+					{
+						error_signal.get().map(|message| page!(|message: String| {
+							div {
+								class: "alert-danger mb-3",
+								{ message }
 							}
-						}
+						})(message)).unwrap_or(Page::Empty)
 					}
-					{ { form_view } }
+					{ form_view }
 					button {
 						type: "submit",
 						class: "btn-secondary w-full",
@@ -177,7 +187,11 @@ pub fn signup_form() -> Page {
 	let signup_form = form! {
 		name: SignupForm,
 		server_fn: register,
+		method: Post,
 		redirect_on_success: "/",
+		strip_arguments: {
+			csrf_token: ::reinhardt::reinhardt_pages::csrf::get_csrf_token().unwrap_or_default(),
+		},
 		state: {
 			loading,
 			error,
@@ -206,6 +220,7 @@ pub fn signup_form() -> Page {
 	let form_view = signup_form.into_page();
 	let polls_index_href = polls_links::index();
 	let login_href = links::login();
+
 	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, polls_index_href: String, login_href: String| {
 		div {
 			class: "max-w-md mx-auto px-4 mt-12",
@@ -217,32 +232,32 @@ pub fn signup_form() -> Page {
 						class: "card-title",
 						"Create account"
 					}
-					if error_signal.get().is_some() {
-						div {
-							class: "alert-danger mb-3",
-							{
-								error_signal.get().unwrap_or_default()
+					{
+						error_signal.get().map(|message| page!(|message: String| {
+							div {
+								class: "alert-danger mb-3",
+								{ message }
 							}
-						}
+						})(message)).unwrap_or(Page::Empty)
 					}
-					{ { form_view } }
+					{ form_view }
 					div {
 						class: "mt-4",
-						if loading_signal.get() {
-							button {
-								type: "submit",
-								class: "btn-primary w-full",
-								disabled: loading_signal.get(),
-								form: "signup-form",
-								"Creating account..."
-							}
-						} else {
-							button {
-								type: "submit",
-								class: "btn-primary w-full",
-								form: "signup-form",
-								"Create account"
-							}
+						{
+							let is_loading = loading_signal.get();
+							page!(|is_loading: bool| {
+								button {
+									type: "submit",
+									class: if is_loading {
+										"btn-primary w-full opacity-50 cursor-not-allowed"
+									} else {
+										"btn-primary w-full"
+									},
+									disabled: is_loading,
+									form: "signup-form",
+									{ if is_loading { "Creating account..." } else { "Create account" } }
+								}
+							})(is_loading)
 						}
 					}
 				}

--- a/examples/examples-tutorial-basis/src/client/components/nav.rs
+++ b/examples/examples-tutorial-basis/src/client/components/nav.rs
@@ -105,7 +105,7 @@ pub fn nav_bar() -> Page {
 pub fn with_nav(body: Page) -> Page {
 	page!(|body: Page| {
 		{
-			nav_bar()
+			self::nav_bar()
 		}
 		{ body }
 	})(body)

--- a/examples/examples-twitter/src/apps/dm/client/hooks.rs
+++ b/examples/examples-twitter/src/apps/dm/client/hooks.rs
@@ -119,14 +119,17 @@ pub fn use_dm_chat(room_id: Uuid) -> DmChatHandle {
 	let (is_loading, set_loading) = use_state(true);
 	let (error, set_error) = use_state(None::<String>);
 
-	// Initial message loading via create_resource
+	// Initial message loading via use_resource
 	#[cfg(wasm)]
 	{
-		let initial_messages = reinhardt::pages::create_resource(move || async move {
-			crate::apps::dm::shared::server_fn::list_messages(room_id, Some(50), None)
-				.await
-				.map_err(|e| format!("Failed to load messages: {}", e))
-		});
+		let initial_messages = reinhardt::pages::use_resource(
+			move || async move {
+				crate::apps::dm::shared::server_fn::list_messages(room_id, Some(50), None)
+					.await
+					.map_err(|e| format!("Failed to load messages: {}", e))
+			},
+			(),
+		);
 
 		let set_messages_for_resource = set_messages.clone();
 		let set_loading_for_resource = set_loading.clone();
@@ -245,14 +248,17 @@ pub fn use_dm_room_list() -> DmRoomListHandle {
 	let (is_loading, set_loading) = use_state(true);
 	let (error, set_error) = use_state(None::<String>);
 
-	// Initial room list loading via create_resource
+	// Initial room list loading via use_resource
 	#[cfg(wasm)]
 	{
-		let initial_rooms = reinhardt::pages::create_resource(move || async move {
-			crate::apps::dm::shared::server_fn::list_rooms()
-				.await
-				.map_err(|e| format!("Failed to load rooms: {}", e))
-		});
+		let initial_rooms = reinhardt::pages::use_resource(
+			move || async move {
+				crate::apps::dm::shared::server_fn::list_rooms()
+					.await
+					.map_err(|e| format!("Failed to load rooms: {}", e))
+			},
+			(),
+		);
 
 		let set_rooms_for_resource = set_rooms.clone();
 		let set_loading_for_resource = set_loading.clone();

--- a/examples/examples-twitter/src/apps/profile/client/components.rs
+++ b/examples/examples-twitter/src/apps/profile/client/components.rs
@@ -22,8 +22,8 @@ use uuid::Uuid;
 #[cfg(wasm)]
 use {
 	crate::apps::profile::shared::server_fn::{fetch_profile, update_profile_form},
-	reinhardt::pages::create_resource,
 	reinhardt::pages::reactive::ResourceState,
+	reinhardt::pages::use_resource,
 };
 /// Profile view component using hooks
 ///
@@ -36,9 +36,10 @@ pub fn profile_view(user_id: Uuid) -> Page {
 	let (error, _set_error) = use_state(None::<String>);
 	#[cfg(wasm)]
 	{
-		let resource = create_resource(move || async move {
-			fetch_profile(user_id).await.map_err(|e| e.to_string())
-		});
+		let resource = use_resource(
+			move || async move { fetch_profile(user_id).await.map_err(|e| e.to_string()) },
+			(),
+		);
 		let profile_setter = _set_profile.clone();
 		let loading_setter = _set_loading.clone();
 		let error_setter = _set_error.clone();

--- a/examples/examples-twitter/src/apps/relationship/client/components.rs
+++ b/examples/examples-twitter/src/apps/relationship/client/components.rs
@@ -14,9 +14,9 @@ use {
 	crate::apps::relationship::shared::server_fn::{
 		fetch_followers, fetch_following, follow_user, unfollow_user,
 	},
-	reinhardt::pages::create_resource,
 	reinhardt::pages::reactive::ResourceState,
 	reinhardt::pages::reactive::hooks::{Action, use_action, use_effect},
+	reinhardt::pages::use_resource,
 };
 
 /// Type of user list to display
@@ -239,13 +239,16 @@ pub fn user_list(user_id: Uuid, list_type: UserListType) -> Page {
 
 	#[cfg(wasm)]
 	{
-		let resource = create_resource(move || async move {
-			let result = match list_type {
-				UserListType::Followers => fetch_followers(user_id).await,
-				UserListType::Following => fetch_following(user_id).await,
-			};
-			result.map_err(|e| e.to_string())
-		});
+		let resource = use_resource(
+			move || async move {
+				let result = match list_type {
+					UserListType::Followers => fetch_followers(user_id).await,
+					UserListType::Following => fetch_following(user_id).await,
+				};
+				result.map_err(|e| e.to_string())
+			},
+			(),
+		);
 
 		let users_clone = users.clone();
 		let loading_clone = loading.clone();

--- a/examples/examples-twitter/src/apps/tweet/client/components.rs
+++ b/examples/examples-twitter/src/apps/tweet/client/components.rs
@@ -16,8 +16,8 @@ use uuid::Uuid;
 #[cfg(wasm)]
 use {
 	crate::apps::tweet::shared::server_fn::{create_tweet, delete_tweet, list_tweets},
-	reinhardt::pages::create_resource,
 	reinhardt::pages::reactive::ResourceState,
+	reinhardt::pages::use_resource,
 };
 
 #[cfg(native)]
@@ -447,9 +447,10 @@ pub fn tweet_list(user_id: Option<Uuid>) -> Page {
 
 	#[cfg(wasm)]
 	{
-		let resource = create_resource(move || async move {
-			list_tweets(user_id, 0).await.map_err(|e| e.to_string())
-		});
+		let resource = use_resource(
+			move || async move { list_tweets(user_id, 0).await.map_err(|e| e.to_string()) },
+			(),
+		);
 
 		// Bridge resource state to individual signals for page! macro compatibility
 		let tweets_setter = _set_tweets.clone();


### PR DESCRIPTION
## Summary

Unifies the two resource primitives (`create_resource` / `create_resource_with_deps`) into a single React-aligned `use_resource(fetcher, deps)` hook, fixes a latent dependency-refetch bug, and migrates the admin panel and example apps onto the new API.

## Core (`reinhardt-pages` / `reinhardt-core`)

- **New hook**: `use_resource(fetcher, deps)` — the resource counterpart of `use_effect`. `()` deps = fetch once on mount; listed `Trackable` deps (`Signal`/`Memo`/`Resource`) drive automatic refetch. Available on all targets (native/SSR renders the loading state; the client fetches after hydration, mirroring `use_action`).
- **Bug fix**: `create_resource_with_deps` dropped its tracking `Effect` handle immediately after creation, so the effect was disposed and dependency-change refetch never fired (the only covering test was excluded on every target by a contradictory `cfg`). `use_resource` stores the `Effect` in the returned `Resource`, and applies the `defer_yield` microtask deferral (#3316) on the dependency path as well as the fetch-once path.
- **Deprecation**: `create_resource` / `create_resource_with_deps` are kept as deprecated thin shims forwarding to `use_resource`; scheduled for removal in v0.3.0.
- Native regression test for the effect-lifetime invariant; README + CHANGELOG updated.

## Migrations

- `reinhardt-admin`: 5 call sites → `use_resource`.
- `examples-twitter`: `create_resource` → `use_resource` (tweet / profile / relationship / dm).
- `examples-tutorial-basis`: full migration of the polls / users / urls components to the current API — `use_resource` data loading with `{ match resource.get() { .. } }` views, page! v2 (declared params, multi-segment free-fn paths, single read of each reactive handle), form! CSRF (`method: Post` + `strip_arguments`; dynamic redirect via `success_url`), and 2-arg `use_effect` bridges.

## Verification

- `reinhardt-pages` + `reinhardt-admin`: native & wasm `clippy --all-targets -- -D warnings` clean.
- `reinhardt-core` lib tests: 757 passing (incl. the new regression test).
- `cargo fmt --check` clean.
- `examples-twitter` + `examples-tutorial-basis`: `cargo check --target wasm32-unknown-unknown` clean; tutorial `clippy` reports no issues; examples `fmt --check` clean. (Built against local `reinhardt` via the `examples/.cargo/config.toml` patch.)

> Note: runtime/browser tests were not run locally; verification is compile + clippy + conformance to the working admin/twitter idioms. The `tests/wasm/polls_mock_test.rs` top-level `Page::Element` shape is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified use_resource hook for consistent async data loading and ResourceState-driven UI rendering across targets.

* **Bug Fixes**
  * Reliable dependency-driven refetching for resources.

* **Refactor**
  * Example apps and UI pages migrated to resource-based loading (Loading/Error/Success flows) and cleaner reactive patterns; forms now show reactive loading/error states and explicit CSRF submission.

* **Tests**
  * Added regression test for effect lifecycle management.

* **Documentation**
  * Updated README/CHANGELOG and prelude notes with migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->