### PR TITLE
fix(release): publish reinhardt-formatter

### DIFF
--- a/crates/reinhardt-formatter/Cargo.toml
+++ b/crates/reinhardt-formatter/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 description = "Formatter for Reinhardt page!, form!, and head! DSL macros"
-publish = false
+publish = true
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -121,6 +121,10 @@ name = "reinhardt-forms"
 version_group = "reinhardt"
 
 [[package]]
+name = "reinhardt-formatter"
+version_group = "reinhardt"
+
+[[package]]
 name = "reinhardt-graphql"
 version_group = "reinhardt"
 
@@ -249,11 +253,6 @@ name = "reinhardt-websockets"
 version_group = "reinhardt"
 
 # Non-published packages (tests, examples, internal tools)
-[[package]]
-name = "reinhardt-formatter"
-release = false
-publish = false
-
 [[package]]
 name = "reinhardt-test-support"
 release = false


### PR DESCRIPTION
## Summary

This PR addresses:

- Move `reinhardt-formatter` from the non-published release-plz package list into the `reinhardt` version group on `develop/0.2.0`.
- Enable Cargo publishing for `crates/reinhardt-formatter`.
- Restore release-plz coverage so the next develop Release PR can publish `reinhardt-formatter` as `0.2.0-rc.2`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

`reinhardt-formatter` was split from `reinhardt-admin-cli`, but release-plz still treated it as an internal non-published package and the crate manifest disabled Cargo publishing. PR #5091 therefore omitted `reinhardt-formatter` from the `develop/0.2.0` release.

Fixes #5092

Related to: #5091, #5088

## How Was This Tested?

- [x] `cargo publish --dry-run --no-verify --allow-dirty -p reinhardt-formatter`
- [x] `cargo fmt --package reinhardt-formatter --check`
- [x] `cargo check -p reinhardt-formatter`
- [x] `git diff --check`

## Performance Impact

Not performance-related.

## Breaking Changes

None.

## Screenshots

Not UI-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5092
- #5091
- #5088

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement request
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

After this lands, release-plz must regenerate the develop Release PR so `reinhardt-formatter` appears in the release list.

🤖 Generated with [Codex](https://openai.com/codex)