### PR TITLE
fix: repair release examples tests

### DIFF
--- a/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
@@ -26,7 +26,7 @@ serde_json = "1.0"
 inventory = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2"
+wasm-bindgen = "=0.2.122"
 web-sys = { version = "0.3", features = [
 	"Window",
 	"Document",

--- a/crates/reinhardt-commands/templates/project_pages_template/Makefile.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/Makefile.toml.tpl
@@ -16,7 +16,7 @@ skip_core_tasks = true
 # Use local target directory for each example (independent from workspace)
 CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = ["CARGO_TARGET_DIR"] } }
 WASM_TARGET = "wasm32-unknown-unknown"
-WASM_BINDGEN_VERSION = "0.2.100"
+WASM_BINDGEN_VERSION = "0.2.122"
 
 # ============================================================================
 # Development Server
@@ -33,10 +33,29 @@ dependencies = ["wasm-build-dev"]
 # WASM Build
 # ============================================================================
 
+[tasks.wasm-bindgen-check]
+description = "Check wasm-bindgen-cli version"
+script = '''
+if ! command -v wasm-bindgen >/dev/null 2>&1; then
+	echo "❌ wasm-bindgen-cli not installed"
+	echo "Run: cargo install wasm-bindgen-cli --version ${WASM_BINDGEN_VERSION}"
+	exit 1
+fi
+
+ACTUAL_VERSION=$(wasm-bindgen --version | awk '{print $2}')
+if [ "$ACTUAL_VERSION" != "${WASM_BINDGEN_VERSION}" ]; then
+	echo "❌ wasm-bindgen-cli version mismatch"
+	echo "Rust dependencies use wasm-bindgen ${WASM_BINDGEN_VERSION}, but installed wasm-bindgen-cli is ${ACTUAL_VERSION}"
+	echo "Run: cargo install -f wasm-bindgen-cli --version ${WASM_BINDGEN_VERSION}"
+	exit 1
+fi
+'''
+
 [tasks.wasm-compile-dev]
 description = "Compile WASM binary (debug mode)"
 command = "cargo"
 args = ["build", "--target", "wasm32-unknown-unknown"]
+dependencies = ["wasm-bindgen-check"]
 
 [tasks.collectstatic-wasm]
 description = "Collect static files to dist/ for WASM frontend"
@@ -73,6 +92,7 @@ dependencies = ["wasm-finalize-dev"]
 description = "Compile WASM binary (release mode)"
 command = "cargo"
 args = ["build", "--target", "wasm32-unknown-unknown", "--release"]
+dependencies = ["wasm-bindgen-check"]
 
 [tasks.wasm-bindgen-release]
 description = "Generate WASM bindings (release mode)"

--- a/crates/reinhardt-commands/templates/project_pages_template/index.html.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/index.html.tpl
@@ -6,7 +6,11 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>{{ project_name }} - Reinhardt Pages</title>
-	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+	<link
+		href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+		rel="stylesheet"
+		integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
+		crossorigin="anonymous">
 	<style>
 		body {
 			background-color: #f8f9fa;

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -1042,21 +1042,17 @@ impl ProjectState {
 		// Determine the primary key type for the source and target from the registry
 		let source_pk_type = self.get_primary_key_type(source_app_label, source_model_name);
 		// Extract target app_label from to_model (may be in "app.Model" format)
-		let (target_app, target_model) = if m2m.to_model.contains('.') {
-			let parts: Vec<&str> = m2m.to_model.split('.').collect();
-			(parts[0], parts[1])
-		} else {
-			(source_app_label, m2m.to_model.as_str())
-		};
+		let (target_app, target_model) =
+			self.resolve_model_reference(&m2m.to_model, source_app_label);
 
-		let target_pk_type = self.get_primary_key_type(target_app, target_model);
+		let target_pk_type = self.get_primary_key_type(&target_app, &target_model);
 
 		// Resolve the target table name from ProjectState, falling back to the
 		// `app_label`-prefixed snake_case form as a last-resort heuristic.
 		let target_table_name = self
-			.get_model(target_app, target_model)
+			.get_model(&target_app, &target_model)
 			.map(|m| m.table_name.clone())
-			.unwrap_or_else(|| format!("{}_{}", target_app, to_snake_case(target_model)));
+			.unwrap_or_else(|| format!("{}_{}", target_app, to_snake_case(&target_model)));
 
 		// Default FK column names come from the canonical convention in
 		// `crate::m2m_naming::default_m2m_columns` (single source of truth,
@@ -1113,6 +1109,36 @@ impl ProjectState {
 		model_state.constraints.push(unique_constraint);
 
 		model_state
+	}
+
+	fn resolve_model_reference(&self, reference: &str, current_app: &str) -> (String, String) {
+		let parts: Vec<&str> = reference.split('.').collect();
+		match parts.as_slice() {
+			[app, model] => (app.to_string(), model.to_string()),
+			[model] => {
+				let model = model.to_string();
+				if self.get_model(current_app, &model).is_some() {
+					(current_app.to_string(), model)
+				} else {
+					let app = self
+						.models
+						.keys()
+						.find_map(|(app_label, model_name)| {
+							(model_name == &model).then(|| app_label.clone())
+						})
+						.or_else(|| {
+							super::model_registry::global_registry()
+								.get_models()
+								.iter()
+								.find(|metadata| metadata.model_name == model)
+								.map(|metadata| metadata.app_label.clone())
+						})
+						.unwrap_or_else(|| current_app.to_string());
+					(app, model)
+				}
+			}
+			_ => (current_app.to_string(), reference.to_string()),
+		}
 	}
 
 	/// Load ProjectState from a list of migrations
@@ -5319,9 +5345,8 @@ impl MigrationAutodetector {
 			// "app.Model" string as the model name, miss every
 			// to_state/registry entry, and produce defaults like
 			// "app.model_id".
-			let (parsed_target_app, parsed_target_model) = self
-				.parse_model_reference(&m2m.to_model, app_label)
-				.unwrap_or_else(|| (app_label.to_string(), m2m.to_model.clone()));
+			let (parsed_target_app, parsed_target_model) =
+				self.resolve_model_reference(&m2m.to_model, app_label);
 
 			// Resolve target table name: prefer to_state, then global registry,
 			// finally fall back to the canonical `{app}_{model_lower}` form
@@ -5612,8 +5637,9 @@ impl MigrationAutodetector {
 					.from_state
 					.find_model_by_table(&through_table)
 					.is_some();
+				let exists_in_to = self.to_state.find_model_by_table(&through_table).is_some();
 
-				if !exists_in_from {
+				if !exists_in_from && !exists_in_to {
 					// Add to created_many_to_many
 					changes.created_many_to_many.push((
 						app_label.clone(),
@@ -5835,6 +5861,26 @@ impl MigrationAutodetector {
 			}
 			// Invalid format
 			_ => None,
+		}
+	}
+
+	fn resolve_model_reference(&self, reference: &str, current_app: &str) -> (String, String) {
+		let parts: Vec<&str> = reference.split('.').collect();
+		match parts.as_slice() {
+			[app, model] => (app.to_string(), model.to_string()),
+			[model] => {
+				let model = model.to_string();
+				if self.to_state.get_model(current_app, &model).is_some() {
+					(current_app.to_string(), model)
+				} else {
+					(
+						self.find_model_app(&model)
+							.unwrap_or_else(|| current_app.to_string()),
+						model,
+					)
+				}
+			}
+			_ => (current_app.to_string(), reference.to_string()),
 		}
 	}
 
@@ -6395,6 +6441,98 @@ mod tests {
 			changes.created_many_to_many.is_empty(),
 			"M2M through table already exists in from_state; expected no \
 			 created_many_to_many, got {:?}",
+			changes.created_many_to_many
+		);
+	}
+
+	#[rstest]
+	fn generate_migrations_resolves_unqualified_many_to_many_target_across_apps() {
+		use super::super::Operation;
+		use super::super::model_registry::ManyToManyMetadata;
+		use super::super::operations::Constraint;
+
+		let auth_user =
+			build_model_state_with_table_name("auth", "User", "auth_user", sample_fields());
+		let mut dm_room =
+			build_model_state_with_table_name("dm", "DMRoom", "dm_room", sample_fields());
+		dm_room
+			.many_to_many_fields
+			.push(ManyToManyMetadata::new("members", "User"));
+		let to_state = build_project_state(vec![
+			(("auth".to_string(), "User".to_string()), auth_user),
+			(("dm".to_string(), "DMRoom".to_string()), dm_room),
+		]);
+		let detector = MigrationAutodetector::new(ProjectState::new(), to_state);
+
+		let migrations = detector.generate_migrations();
+		let dm_migration = migrations
+			.iter()
+			.find(|migration| migration.app_label == "dm")
+			.expect("dm migration should be generated");
+		let Operation::CreateTable {
+			name, constraints, ..
+		} = dm_migration
+			.operations
+			.iter()
+			.find(|operation| {
+				matches!(
+					operation,
+					Operation::CreateTable { name, .. } if name == "dm_room_members"
+				)
+			})
+			.expect("dm_room_members through table should be generated")
+		else {
+			panic!("expected CreateTable operation");
+		};
+		assert_eq!(name, "dm_room_members");
+
+		let target_fk = constraints
+			.iter()
+			.find_map(|constraint| match constraint {
+				Constraint::ForeignKey {
+					columns,
+					referenced_table,
+					..
+				} if columns == &vec!["auth_user_id".to_string()] => Some(referenced_table),
+				_ => None,
+			})
+			.expect("auth_user_id foreign key should be generated");
+		assert_eq!(target_fk, "auth_user");
+	}
+
+	#[rstest]
+	fn detect_created_many_to_many_skips_existing_to_state_through_table() {
+		use super::super::model_registry::ManyToManyMetadata;
+
+		let auth_user =
+			build_model_state_with_table_name("auth", "User", "auth_user", sample_fields());
+		let mut dm_room =
+			build_model_state_with_table_name("dm", "DMRoom", "dm_room", sample_fields());
+		dm_room
+			.many_to_many_fields
+			.push(ManyToManyMetadata::new("members", "User"));
+		let dm_room_members = build_model_state_with_table_name(
+			"dm",
+			"DMRoomMembers",
+			"dm_room_members",
+			sample_fields(),
+		);
+		let to_state = build_project_state(vec![
+			(("auth".to_string(), "User".to_string()), auth_user),
+			(("dm".to_string(), "DMRoom".to_string()), dm_room),
+			(
+				("dm".to_string(), "DMRoomMembers".to_string()),
+				dm_room_members,
+			),
+		]);
+		let detector = MigrationAutodetector::new(ProjectState::new(), to_state);
+
+		let changes = detector.detect_changes();
+
+		assert!(
+			changes.created_many_to_many.is_empty(),
+			"to_state already contains the through table model; expected no \
+			 synthetic created_many_to_many, got {:?}",
 			changes.created_many_to_many
 		);
 	}

--- a/crates/reinhardt-db/src/migrations/repository/filesystem.rs
+++ b/crates/reinhardt-db/src/migrations/repository/filesystem.rs
@@ -18,7 +18,7 @@ use syn::parse_quote;
 /// // use reinhardt::db::migrations::prelude::*;
 /// // use reinhardt::db::migrations::FieldType;
 ///
-/// pub fn migration() -> Migration {
+/// pub(super) fn migration() -> Migration {
 ///     Migration::new("0001_initial", "app")
 /// }
 /// ```
@@ -157,7 +157,7 @@ impl FilesystemRepository {
 			use reinhardt::db::migrations::prelude::*;
 			use reinhardt::db::migrations::FieldType;
 
-			pub fn migration() -> Migration {
+			pub(super) fn migration() -> Migration {
 				Migration {
 					app_label: #app_label.to_string(),
 					name: #name.to_string(),
@@ -453,7 +453,7 @@ mod tests {
 		assert!(tokio::fs::try_exists(&path).await.unwrap());
 
 		let content = tokio::fs::read_to_string(&path).await.unwrap();
-		assert!(content.contains("pub fn migration() -> Migration"));
+		assert!(content.contains("pub(super) fn migration() -> Migration"));
 		assert!(content.contains("app_label: \"polls\""));
 		assert!(content.contains("name: \"0001_initial\""));
 	}

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -16,42 +16,42 @@ examples/
 ├── examples-tutorial-rest/        # Snippets tutorial (REST API)
 ├── examples-twitter/              # End-to-end Twitter-clone demo
 ├── .cargo/
-│   └── config.local.toml          # Template for local development
+│   └── config.local.toml          # Compatibility template for explicit local patches
 ├── Cargo.toml                     # Workspace configuration
 └── README.md
 ```
 
 ### Example Projects
 
-Each `examples-*` directory is an independent Cargo project demonstrating specific Reinhardt features. By default, examples use published crates.io versions of Reinhardt.
+Each `examples-*` directory is an independent Cargo project demonstrating specific Reinhardt features. By default, examples resolve Reinhardt from the parent checkout so release candidate examples can be tested before publication.
 
 ---
 
 ## Dependency Management
 
-### Default Mode (crates.io)
+### Default Mode (parent checkout)
 
-By default, examples use published versions from crates.io:
+By default, examples use the parent Reinhardt checkout through the examples workspace dependency:
 
 <!-- reinhardt-version-sync -->
 ```toml
-[dependencies]
-reinhardt = { version = "0.1.0-rc.29", package = "reinhardt-web", features = ["standard"] }
+[workspace.dependencies]
+reinhardt = { path = "..", version = "0.2.0-rc.2", package = "reinhardt-web" }
 ```
 
-### Local Development Mode
+### Explicit Patch Mode
 
-For framework contributors testing against local Reinhardt code:
+For workflows that need an explicit Cargo patch:
 
 1. Copy `.cargo/config.local.toml` to `.cargo/config.toml`
-2. This activates `[patch.crates-io]` overrides pointing to local workspace
+2. This activates `[patch.crates-io]` overrides pointing to the local workspace
 3. `.cargo/config.toml` is gitignored
 
 ```bash
-# Activate local development mode
+# Activate explicit patch mode
 cp .cargo/config.local.toml .cargo/config.toml
 
-# Deactivate (back to crates.io)
+# Deactivate
 rm -f .cargo/config.toml
 ```
 
@@ -70,7 +70,7 @@ rm -f .cargo/config.toml
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
-reinhardt = { version = "0.1.0-rc.29", package = "reinhardt-web", features = ["core", "database"] }
+reinhardt = { version = "0.2.0-rc.2", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine
 tokio = { workspace = true }
@@ -86,7 +86,7 @@ rstest = "0.26.1"
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.29", package = "reinhardt-web", features = ["core"] }
+reinhardt = { version = "0.2.0-rc.2", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER
 reinhardt-di = { path = "../../../crates/reinhardt-di" }          # ❌ NEVER

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -16,42 +16,42 @@ examples/
 ├── examples-tutorial-rest/        # Snippets tutorial (REST API)
 ├── examples-twitter/              # End-to-end Twitter-clone demo
 ├── .cargo/
-│   └── config.local.toml          # Template for local development
+│   └── config.local.toml          # Compatibility template for explicit local patches
 ├── Cargo.toml                     # Workspace configuration
 └── README.md
 ```
 
 ### Example Projects
 
-Each `examples-*` directory is an independent Cargo project demonstrating specific Reinhardt features. By default, examples use published crates.io versions of Reinhardt.
+Each `examples-*` directory is an independent Cargo project demonstrating specific Reinhardt features. By default, examples resolve Reinhardt from the parent checkout so release candidate examples can be tested before publication.
 
 ---
 
 ## Dependency Management
 
-### Default Mode (crates.io)
+### Default Mode (parent checkout)
 
-By default, examples use published versions from crates.io:
+By default, examples use the parent Reinhardt checkout through the examples workspace dependency:
 
 <!-- reinhardt-version-sync -->
 ```toml
-[dependencies]
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", features = ["standard"] }
+[workspace.dependencies]
+reinhardt = { path = "..", version = "0.2.0-rc.2", package = "reinhardt-web" }
 ```
 
-### Local Development Mode
+### Explicit Patch Mode
 
-For framework contributors testing against local Reinhardt code:
+For workflows that need an explicit Cargo patch:
 
 1. Copy `.cargo/config.local.toml` to `.cargo/config.toml`
-2. This activates `[patch.crates-io]` overrides pointing to local workspace
+2. This activates `[patch.crates-io]` overrides pointing to the local workspace
 3. `.cargo/config.toml` is gitignored
 
 ```bash
-# Activate local development mode
+# Activate explicit patch mode
 cp .cargo/config.local.toml .cargo/config.toml
 
-# Deactivate (back to crates.io)
+# Deactivate
 rm -f .cargo/config.toml
 ```
 
@@ -70,7 +70,7 @@ rm -f .cargo/config.toml
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", features = ["core", "database"] }
+reinhardt = { version = "0.2.0-rc.2", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine
 tokio = { workspace = true }
@@ -86,7 +86,7 @@ rstest = "0.26.1"
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.1.0-rc.30", package = "reinhardt-web", features = ["core"] }
+reinhardt = { version = "0.2.0-rc.2", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER
 reinhardt-di = { path = "../../../crates/reinhardt-di" }          # ❌ NEVER

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,13 +12,13 @@ members = [
 #   cd examples-rest-api && cargo run
 #   cd examples-database-integration && cargo run
 #
-# Uses crates.io published versions by default.
-# For local development, copy .cargo/config.local.toml to .cargo/config.toml
+# Resolve Reinhardt from the parent checkout so examples validate the current
+# release candidate before it is published to crates.io.
 
 [workspace.dependencies]
-# Reinhardt framework (crates.io published versions)
+# Reinhardt framework from this repository.
 # reinhardt-version-sync
-reinhardt = { version = "0.2.0-rc.2", package = "reinhardt-web" }
+reinhardt = { path = "..", version = "0.2.0-rc.2", package = "reinhardt-web" }
 
 # Testing
 testcontainers = { version = "0.27.2", features = ["blocking"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -50,22 +50,17 @@ cargo run
 
 ## Dependency Management
 
-By default, examples use **crates.io published versions** of Reinhardt.
+By default, examples use the parent Reinhardt checkout through the
+`examples/Cargo.toml` workspace dependency. This lets example builds validate
+the current release candidate before that version exists on crates.io.
 
-### Local Development (for framework contributors)
+### Local Development
 
-To test examples against your local Reinhardt workspace:
+Run the examples directly from this repository:
 
 ```bash
-# Copy the local development config template
-cp .cargo/config.local.toml .cargo/config.toml
-
-# Build/test with local reinhardt
 cargo build --workspace
 cargo nextest run --workspace
-
-# Clean up when done
-rm -f .cargo/config.toml
 ```
 
 Or use the Makefile.toml task from the main repo:
@@ -77,9 +72,9 @@ cargo make local-examples-test
 
 ### How It Works
 
-- `.cargo/config.local.toml`: Pre-configured template with `[patch.crates-io]` overrides
-- When copied to `.cargo/config.toml`, Cargo uses local workspace paths instead of crates.io
-- `.cargo/config.toml` is gitignored so it won't be committed
+- `examples/Cargo.toml` declares `reinhardt` with `path = ".."` and the expected version
+- Cargo uses the local checkout while still checking that the example version stays in sync
+- `.cargo/config.local.toml` remains as a compatibility template for workflows that need an explicit `[patch.crates-io]` override
 
 ## Testing
 

--- a/examples/examples-tutorial-basis/build.rs
+++ b/examples/examples-tutorial-basis/build.rs
@@ -1,36 +1,9 @@
 use cfg_aliases::cfg_aliases;
 
 fn main() {
-	// Auto-detect: check if reinhardt workspace exists in parent
-	let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-	let examples_dir = std::path::Path::new(&manifest_dir).parent().unwrap();
-	let parent_dir = examples_dir.parent().unwrap();
-	let parent_cargo = parent_dir.join("Cargo.toml");
-
-	let is_local_dev = parent_cargo.exists()
-		&& std::fs::read_to_string(&parent_cargo)
-			.map(|c| c.contains("name = \"reinhardt-web\""))
-			.unwrap_or(false);
-
-	if is_local_dev {
-		// In subtree context - enable integration tests
-		println!("cargo:rustc-cfg=with_reinhardt");
-
-		// Warn if .cargo/config.toml is not set up for local override
-		let config_path = examples_dir.join(".cargo/config.toml");
-		if !config_path.exists() {
-			println!(
-				"cargo:warning=Local reinhardt workspace detected but .cargo/config.toml is missing. \
-				 Copy the template: cp .cargo/config.local.toml .cargo/config.toml"
-			);
-		}
-	} else {
-		// Standalone mode - enable tests if crates.io versions are available
-		println!("cargo:rustc-cfg=with_reinhardt");
-	}
+	println!("cargo:rustc-cfg=with_reinhardt");
 
 	println!("cargo:rerun-if-changed=build.rs");
-	println!("cargo:rerun-if-changed=../.cargo/config.toml");
 
 	// Declare custom cfg to avoid warnings in Rust 2024 edition
 	println!("cargo::rustc-check-cfg=cfg(with_reinhardt)");

--- a/examples/examples-tutorial-basis/index.html
+++ b/examples/examples-tutorial-basis/index.html
@@ -8,8 +8,8 @@
 
 	<!-- UnoCSS Reset (pinned + SRI) -->
 	<link rel="stylesheet"
-		href="https://cdn.jsdelivr.net/npm/@unocss/reset@66.0.0/tailwind.min.css"
-		integrity="sha384-LGhsJsqCgUoTJMa7Fmn8Q0Q5/3WY9D96e4lfXpNTzs54EqijDEpPD13nfjueItEK"
+		href="https://cdn.jsdelivr.net/npm/@unocss/reset@66.7.0/tailwind.min.css"
+		integrity="sha384-T4Gl/JcT72kX7H+XBooHT+j5VH/xPcLgHXROFmUj1HF77ctera3Pu1390b73is5o"
 		crossorigin="anonymous">
 
 	<!-- Hand-written base styles + fallback component CSS.
@@ -109,55 +109,9 @@
 
 	<!-- UnoCSS Runtime (pinned + SRI) -->
 	<script
-		src="https://cdn.jsdelivr.net/npm/@unocss/runtime@66.0.0"
-		integrity="sha384-LYmmhezFyzRAT4ivJD/xzz7PEZ3b+pHHgxsOuSVPG8wKScOK2Bx+itfNE+ziDDEv"
+		src="https://cdn.jsdelivr.net/npm/@unocss/runtime@66.7.0"
+		integrity="sha384-N01yk5TWd3fjp79erm4HVUYQXHk88RIDoYnTenU6JEnUSeIGyR37ZEcN1OQnG0U6"
 		crossorigin="anonymous"></script>
-
-	<!-- Theme toggle handler -->
-	<script>
-	function toggleTheme() {
-		var html = document.documentElement;
-		var current = html.getAttribute('data-theme');
-		var next = current === 'dark' ? 'light' : 'dark';
-		html.setAttribute('data-theme', next);
-		html.classList.toggle('dark', next === 'dark');
-		try {
-			localStorage.setItem('theme', next);
-		} catch (e) {
-			// Persisting the preference is best-effort; ignore storage
-			// failures (private mode, sandboxed iframe, disabled storage).
-		}
-	}
-
-	// Attach to any #theme-toggle-btn rendered by WASM via MutationObserver.
-	// The observer disconnects itself as soon as the button is found and
-	// wired up, so it does not keep reacting to unrelated DOM changes.
-	window.addEventListener('load', function() {
-		function tryAttach() {
-			var btn = document.getElementById('theme-toggle-btn');
-			if (btn && !btn.hasAttribute('data-theme-attached')) {
-				btn.setAttribute('data-theme-attached', 'true');
-				btn.addEventListener('click', toggleTheme);
-				return true;
-			}
-			return false;
-		}
-
-		// Button may already be present (SSR / fast WASM mount).
-		if (tryAttach()) {
-			return;
-		}
-
-		var observer = new MutationObserver(function() {
-			if (tryAttach()) {
-				observer.disconnect();
-			}
-		});
-		if (document.body) {
-			observer.observe(document.body, { childList: true, subtree: true });
-		}
-	});
-	</script>
 </head>
 <body>
 	<div id="root">

--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -111,10 +111,12 @@ pub fn polls_index() -> Page {
 					ResourceState::Error(error) => page!(|error: String| {
 						div {
 							class: "alert-danger",
-							{ self::format_server_error(&error) }
+							{
+								self::format_server_error(&error)
+							}
 						}
 					})(error),
-					ResourceState::Success(questions) if questions.is_empty() => page!(|| {
+					ResourceState::Success(questions)if questions.is_empty() => page!(|| {
 						p {
 							class: "text-muted",
 							"No polls are available."
@@ -131,7 +133,9 @@ pub fn polls_index() -> Page {
 										class: "flex w-full justify-between",
 										h5 {
 											class: "mb-1",
-											{ question.question_text.clone() }
+											{
+												question.question_text.clone()
+											}
 										}
 										small { {
 											question.pub_date.format("%Y-%m-%d %H:%M").to_string()
@@ -241,16 +245,16 @@ pub fn polls_detail(question_id: i64) -> Page {
 			},
 			error_display: |form| {
 				let err = form.error().get();
-				page!(|err: Option<String>| {
-					{
-						err.clone().map(|e| page!(|e: String| {
-							div {
-								class: "alert-danger mt-3",
-								{ self::format_server_error(&e) }
+				page!(|err: Option<String>| { {
+					err.clone().map(|e| page!(|e: String| {
+						div {
+							class: "alert-danger mt-3",
+							{
+								self::format_server_error(&e)
 							}
-						})(e)).unwrap_or(Page::Empty)
-					}
-				})(err)
+						}
+					})(e)).unwrap_or(Page::Empty)
+				} })(err)
 			},
 		}
 	};
@@ -293,105 +297,104 @@ pub fn polls_detail(question_id: i64) -> Page {
 	// `choice_id=""` and `submit_vote` rejected the request with the
 	// runtime `Invalid choice_id` application error.
 	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>, load_current_user: Resource<Option<UserInfo>, String>, voting_form_page: Page, question_id: i64| {
-		div {
-			{
-				match load_detail.get() {
-					ResourceState::Loading => page!(|| {
+		div { {
+			match load_detail.get() {
+				ResourceState::Loading => page!(|| {
+					div {
+						class: "max-w-4xl mx-auto px-4 mt-12 text-center",
 						div {
-							class: "max-w-4xl mx-auto px-4 mt-12 text-center",
-							div {
-								class: "spinner w-8 h-8",
-								role: "status",
-								span {
-									class: "sr-only",
-									"Loading..."
-								}
+							class: "spinner w-8 h-8",
+							role: "status",
+							span {
+								class: "sr-only",
+								"Loading..."
 							}
 						}
-					})(),
-					ResourceState::Error(error) => page!(|error: String, question_id: i64| {
+					}
+				})(),
+				ResourceState::Error(error) => page!(|error: String, question_id: i64| {
+					div {
+						class: "max-w-4xl mx-auto px-4 mt-12",
+						div {
+							class: "alert-danger",
+							{
+								self::format_server_error(&error)
+							}
+						}
+						a {
+							href: links::detail(question_id),
+							class: "btn-secondary",
+							"Try Again"
+						}
+						a {
+							href: links::index(),
+							class: "btn-primary ml-2",
+							"Back to Polls"
+						}
+					}
+				})(error, question_id),
+				ResourceState::Success((q, choices)) => {
+					// Owner-only controls (Edit / Delete / Add choice) are hidden for
+					// non-authors and unauthenticated viewers (issue #4703). Any
+					// non-`Success(Some(u))` shape leaves `is_author` as `false`.
+					let is_author = matches!(load_current_user.get(), ResourceState::Success(Some(ref u))if u.id == q.author_id);
+					// Render the voting form only when the question has choices;
+					// otherwise show an empty-state prompt (reinhardt-web#4686).
+					let choices_view = if choices.is_empty() {
+						page!(|| {
+							div {
+								class: "alert-warning",
+								"This question has no choices yet. Add one below to start voting."
+							}
+						})()
+					} else {
+						voting_form_page.clone()
+					};
+					page!(|q: QuestionInfo, is_author: bool, choices_view: Page, question_id: i64| {
 						div {
 							class: "max-w-4xl mx-auto px-4 mt-12",
 							div {
-								class: "alert-danger",
-								{ self::format_server_error(&error) }
+								class: "flex justify-between items-center mb-4",
+								h1 { {
+									q.question_text.clone()
+								} }
+								div {
+									class: "flex gap-2",
+									a {
+										href: links::results(question_id),
+										class: "btn-secondary",
+										"View results"
+									}
+									if is_author {
+										a {
+											href: links::question_edit(question_id),
+											class: "btn-secondary",
+											"Edit"
+										}
+										a {
+											href: links::question_delete(question_id),
+											class: "btn-danger",
+											"Delete"
+										}
+									}
+								}
 							}
-							a {
-								href: links::detail(question_id),
-								class: "btn-secondary",
-								"Try Again"
-							}
-							a {
-								href: links::index(),
-								class: "btn-primary ml-2",
-								"Back to Polls"
+							{ choices_view }
+							if is_author {
+								div {
+									class: "mt-4",
+									a {
+										href: links::choice_new(question_id),
+										class: "btn-secondary",
+										"Add choice"
+									}
+								}
 							}
 						}
-					})(error, question_id),
-					ResourceState::Success((q, choices)) => {
-						// Owner-only controls (Edit / Delete / Add choice) are hidden for
-						// non-authors and unauthenticated viewers (issue #4703). Any
-						// non-`Success(Some(u))` shape leaves `is_author` as `false`.
-						let is_author = matches!(
-							load_current_user.get(),
-							ResourceState::Success(Some(ref u)) if u.id == q.author_id
-						);
-						// Render the voting form only when the question has choices;
-						// otherwise show an empty-state prompt (reinhardt-web#4686).
-						let choices_view = if choices.is_empty() {
-							page!(|| {
-								div {
-									class: "alert-warning",
-									"This question has no choices yet. Add one below to start voting."
-								}
-							})()
-						} else {
-							voting_form_page.clone()
-						};
-						page!(|q: QuestionInfo, is_author: bool, choices_view: Page, question_id: i64| {
-							div {
-								class: "max-w-4xl mx-auto px-4 mt-12",
-								div {
-									class: "flex justify-between items-center mb-4",
-									h1 { { q.question_text.clone() } }
-									div {
-										class: "flex gap-2",
-										a {
-											href: links::results(question_id),
-											class: "btn-secondary",
-											"View results"
-										}
-										if is_author {
-											a {
-												href: links::question_edit(question_id),
-												class: "btn-secondary",
-												"Edit"
-											}
-											a {
-												href: links::question_delete(question_id),
-												class: "btn-danger",
-												"Delete"
-											}
-										}
-									}
-								}
-								{ choices_view }
-								if is_author {
-									div {
-										class: "mt-4",
-										a {
-											href: links::choice_new(question_id),
-											class: "btn-secondary",
-											"Add choice"
-										}
-									}
-								}
-							}
-						})(q, is_author, choices_view, question_id)
-					}
+					})(q, is_author, choices_view, question_id)
 				}
 			}
-		}
+		} }
 	})(
 		load_detail,
 		load_current_user,
@@ -424,135 +427,138 @@ pub fn polls_results(question_id: i64) -> Page {
 	);
 
 	page!(|load_results: Resource<(QuestionInfo, Vec<ChoiceInfo>, i32), String>, load_current_user: Resource<Option<UserInfo>, String>, question_id: i64| {
-		div {
-			{
-				match load_results.get() {
-					ResourceState::Loading => page!(|| {
+		div { {
+			match load_results.get() {
+				ResourceState::Loading => page!(|| {
+					div {
+						class: "max-w-4xl mx-auto px-4 mt-12 text-center",
 						div {
-							class: "max-w-4xl mx-auto px-4 mt-12 text-center",
-							div {
-								class: "spinner w-8 h-8",
-								role: "status",
-								span {
-									class: "sr-only",
-									"Loading..."
-								}
+							class: "spinner w-8 h-8",
+							role: "status",
+							span {
+								class: "sr-only",
+								"Loading..."
 							}
 						}
-					})(),
-					ResourceState::Error(error) => page!(|error: String| {
+					}
+				})(),
+				ResourceState::Error(error) => page!(|error: String| {
+					div {
+						class: "max-w-4xl mx-auto px-4 mt-12",
+						div {
+							class: "alert-danger",
+							{
+								self::format_server_error(&error)
+							}
+						}
+						a {
+							href: links::index(),
+							class: "btn-primary",
+							"Back to Polls"
+						}
+					}
+				})(error),
+				ResourceState::Success((q, choices, total)) => {
+					// Owner-only controls (Edit / Delete) are hidden for non-authors
+					// and unauthenticated viewers (issue #4703).
+					let is_author = matches!(load_current_user.get(), ResourceState::Success(Some(ref u))if u.id == q.author_id);
+					page!(|q: QuestionInfo, choices: Vec<ChoiceInfo>, total: i32, is_author: bool, question_id: i64| {
 						div {
 							class: "max-w-4xl mx-auto px-4 mt-12",
-							div {
-								class: "alert-danger",
-								{ self::format_server_error(&error) }
-							}
-							a {
-								href: links::index(),
-								class: "btn-primary",
-								"Back to Polls"
-							}
-						}
-					})(error),
-					ResourceState::Success((q, choices, total)) => {
-						// Owner-only controls (Edit / Delete) are hidden for non-authors
-						// and unauthenticated viewers (issue #4703).
-						let is_author = matches!(
-							load_current_user.get(),
-							ResourceState::Success(Some(ref u)) if u.id == q.author_id
-						);
-						page!(|q: QuestionInfo, choices: Vec<ChoiceInfo>, total: i32, is_author: bool, question_id: i64| {
-							div {
-								class: "max-w-4xl mx-auto px-4 mt-12",
-								h1 {
-									class: "mb-4",
-									{ q.question_text.clone() }
+							h1 {
+								class: "mb-4",
+								{
+									q.question_text.clone()
 								}
+							}
+							div {
+								class: "card",
 								div {
-									class: "card",
+									class: "card-body",
+									h5 {
+										class: "text-xl font-bold",
+										"Results"
+									}
 									div {
-										class: "card-body",
-										h5 {
-											class: "text-xl font-bold",
-											"Results"
-										}
-										div {
-											class: "divide-y divide-border",
-											for choice in choices {
-												{
-													let percentage = if total > 0 {
-														(choice.votes as f64 / total as f64 * 100.0) as i32
-													} else {
-														0
-													};
-													page!(|choice: ChoiceInfo, percentage: i32| {
-														div {
-															class: "py-4",
-															div {
-																class: "flex justify-between items-center mb-2",
-																strong { { choice.choice_text.clone() } }
-																span {
-																	class: "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
-																	{ format!("{} votes", choice.votes) }
-																}
-															}
-															div {
-																class: "w-full bg-surface-tertiary rounded-full h-2.5",
-																div {
-																	class: "bg-brand h-2.5 rounded-full",
-																	role: "progressbar",
-																	style: format!("width: {}%", percentage),
-																	aria_valuenow: percentage.to_string(),
-																	aria_valuemin: "0",
-																	aria_valuemax: "100",
-																	{ format!("{}%", percentage) }
-																}
+										class: "divide-y divide-border",
+										for choice in choices { {
+											let percentage = if total > 0 {
+												(choice.votes as f64 / total as f64 * 100.0) as i32
+											} else { 0 };
+											page!(|choice: ChoiceInfo, percentage: i32| {
+												div {
+													class: "py-4",
+													div {
+														class: "flex justify-between items-center mb-2",
+														strong { {
+															choice.choice_text.clone()
+														} }
+														span {
+															class: "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
+															{
+																format!("{} votes", choice.votes)
 															}
 														}
-													})(choice.clone(), percentage)
+													}
+													div {
+														class: "w-full bg-surface-tertiary rounded-full h-2.5",
+														div {
+															class: "bg-brand h-2.5 rounded-full",
+															role: "progressbar",
+															style: format!("width: {}%", percentage),
+															aria_valuenow: percentage.to_string(),
+															aria_valuemin: "0",
+															aria_valuemax: "100",
+															{
+																format!("{}%", percentage)
+															}
+														}
+													}
 												}
+											})(choice.clone(), percentage)
+										} }
+									}
+									div {
+										class: "mt-3",
+										p {
+											class: "text-muted",
+											{
+												format!("Total votes: {}", total)
 											}
 										}
-										div {
-											class: "mt-3",
-											p {
-												class: "text-muted",
-												{ format!("Total votes: {}", total) }
-											}
-										}
-									}
-								}
-								div {
-									class: "mt-3 flex flex-wrap gap-2",
-									a {
-										href: links::detail(question_id),
-										class: "btn-primary",
-										"Vote Again"
-									}
-									if is_author {
-										a {
-											href: links::question_edit(question_id),
-											class: "btn-secondary",
-											"Edit question"
-										}
-										a {
-											href: links::question_delete(question_id),
-											class: "btn-danger",
-											"Delete question"
-										}
-									}
-									a {
-										href: links::index(),
-										class: "btn-secondary",
-										"Back to Polls"
 									}
 								}
 							}
-						})(q, choices, total, is_author, question_id)
-					}
+							div {
+								class: "mt-3 flex flex-wrap gap-2",
+								a {
+									href: links::detail(question_id),
+									class: "btn-primary",
+									"Vote Again"
+								}
+								if is_author {
+									a {
+										href: links::question_edit(question_id),
+										class: "btn-secondary",
+										"Edit question"
+									}
+									a {
+										href: links::question_delete(question_id),
+										class: "btn-danger",
+										"Delete question"
+									}
+								}
+								a {
+									href: links::index(),
+									class: "btn-secondary",
+									"Back to Polls"
+								}
+							}
+						}
+					})(q, choices, total, is_author, question_id)
 				}
 			}
-		}
+		} }
 	})(load_results, load_current_user, question_id)
 }
 
@@ -600,10 +606,12 @@ pub fn polls_index_with_logo() -> Page {
 					ResourceState::Error(error) => page!(|error: String| {
 						div {
 							class: "alert-danger",
-							{ self::format_server_error(&error) }
+							{
+								self::format_server_error(&error)
+							}
 						}
 					})(error),
-					ResourceState::Success(questions) if questions.is_empty() => page!(|| {
+					ResourceState::Success(questions)if questions.is_empty() => page!(|| {
 						p {
 							class: "text-muted",
 							"No polls are available."
@@ -627,7 +635,9 @@ pub fn polls_index_with_logo() -> Page {
 											class: "flex-1",
 											h5 {
 												class: "mb-1",
-												{ question.question_text.clone() }
+												{
+													question.question_text.clone()
+												}
 											}
 										}
 										small { {
@@ -694,7 +704,9 @@ pub fn question_new() -> Page {
 				error_signal.get().map(|message| page!(|message: String| {
 					div {
 						class: "alert-danger mb-3",
-						{ self::format_server_error(&message) }
+						{
+							self::format_server_error(&message)
+						}
 					}
 				})(message)).unwrap_or(Page::Empty)
 			}
@@ -709,7 +721,9 @@ pub fn question_new() -> Page {
 							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
 							disabled: is_loading,
 							form: "new-question-form",
-							{ if is_loading { "Creating..." } else { "Create" } }
+							{
+								if is_loading { "Creating..." } else { "Create" }
+							}
 						}
 					})(is_loading)
 				}
@@ -796,7 +810,9 @@ pub fn question_edit(question_id: i64) -> Page {
 				edit_form_error.get().map(|message| page!(|message: String| {
 					div {
 						class: "alert-danger mb-3",
-						{ self::format_server_error(&message) }
+						{
+							self::format_server_error(&message)
+						}
 					}
 				})(message)).unwrap_or(Page::Empty)
 			}
@@ -811,7 +827,9 @@ pub fn question_edit(question_id: i64) -> Page {
 							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
 							disabled: is_loading,
 							form: "edit-question-form",
-							{ if is_loading { "Saving..." } else { "Save" } }
+							{
+								if is_loading { "Saving..." } else { "Save" }
+							}
 						}
 						a {
 							href: links::detail(question_id),
@@ -830,40 +848,40 @@ pub fn question_edit(question_id: i64) -> Page {
 	);
 
 	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>, edit_form_view: Page, question_id: i64| {
-		div {
-			{
-				match load_detail.get() {
-					ResourceState::Loading => page!(|| {
+		div { {
+			match load_detail.get() {
+				ResourceState::Loading => page!(|| {
+					div {
+						class: "max-w-4xl mx-auto px-4 mt-12 text-center",
 						div {
-							class: "max-w-4xl mx-auto px-4 mt-12 text-center",
-							div {
-								class: "spinner w-8 h-8",
-								role: "status",
-								span {
-									class: "sr-only",
-									"Loading..."
-								}
+							class: "spinner w-8 h-8",
+							role: "status",
+							span {
+								class: "sr-only",
+								"Loading..."
 							}
 						}
-					})(),
-					ResourceState::Error(error) => page!(|error: String| {
+					}
+				})(),
+				ResourceState::Error(error) => page!(|error: String| {
+					div {
+						class: "max-w-4xl mx-auto px-4 mt-12",
 						div {
-							class: "max-w-4xl mx-auto px-4 mt-12",
-							div {
-								class: "alert-danger",
-								{ self::format_server_error(&error) }
-							}
-							a {
-								href: links::index(),
-								class: "btn-primary",
-								"Back to Polls"
+							class: "alert-danger",
+							{
+								self::format_server_error(&error)
 							}
 						}
-					})(error),
-					ResourceState::Success(_) => edit_form_view.clone(),
-				}
+						a {
+							href: links::index(),
+							class: "btn-primary",
+							"Back to Polls"
+						}
+					}
+				})(error),
+				ResourceState::Success(_) => edit_form_view.clone(),
 			}
-		}
+		} }
 	})(load_detail, edit_form_view, question_id)
 }
 
@@ -926,7 +944,9 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 								}
 								blockquote {
 									class: "border-l-4 border-border-secondary pl-4 italic my-3",
-									{ q.question_text.clone() }
+									{
+										q.question_text.clone()
+									}
 								}
 							}
 						}
@@ -934,7 +954,9 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 					ResourceState::Error(error) => page!(|error: String| {
 						div {
 							class: "alert-danger",
-							{ self::format_server_error(&error) }
+							{
+								self::format_server_error(&error)
+							}
 						}
 					})(error),
 				}
@@ -943,7 +965,9 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 				error_signal.get().map(|message| page!(|message: String| {
 					div {
 						class: "alert-danger mt-3",
-						{ self::format_server_error(&message) }
+						{
+							self::format_server_error(&message)
+						}
 					}
 				})(message)).unwrap_or(Page::Empty)
 			}
@@ -958,7 +982,9 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-danger" },
 							disabled: is_loading,
 							form: "delete-question-form",
-							{ if is_loading { "Deleting..." } else { "Delete" } }
+							{
+								if is_loading { "Deleting..." } else { "Delete" }
+							}
 						}
 						a {
 							href: cancel_href,
@@ -1044,7 +1070,9 @@ pub fn choice_new(question_id: i64) -> Page {
 				error_signal.get().map(|message| page!(|message: String| {
 					div {
 						class: "alert-danger mb-3",
-						{ self::format_server_error(&message) }
+						{
+							self::format_server_error(&message)
+						}
 					}
 				})(message)).unwrap_or(Page::Empty)
 			}
@@ -1059,7 +1087,9 @@ pub fn choice_new(question_id: i64) -> Page {
 							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
 							disabled: is_loading,
 							form: "new-choice-form",
-							{ if is_loading { "Adding..." } else { "Add Choice" } }
+							{
+								if is_loading { "Adding..." } else { "Add Choice" }
+							}
 						}
 					})(is_loading)
 				}
@@ -1122,7 +1152,9 @@ pub fn choice_edit(question_id: i64, choice_id: i64) -> Page {
 				error_signal.get().map(|message| page!(|message: String| {
 					div {
 						class: "alert-danger mb-3",
-						{ self::format_server_error(&message) }
+						{
+							self::format_server_error(&message)
+						}
 					}
 				})(message)).unwrap_or(Page::Empty)
 			}
@@ -1137,7 +1169,9 @@ pub fn choice_edit(question_id: i64, choice_id: i64) -> Page {
 							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-primary" },
 							disabled: is_loading,
 							form: "edit-choice-form",
-							{ if is_loading { "Saving..." } else { "Save" } }
+							{
+								if is_loading { "Saving..." } else { "Save" }
+							}
 						}
 					})(is_loading)
 				}
@@ -1198,7 +1232,9 @@ pub fn choice_delete_confirm(question_id: i64, choice_id: i64) -> Page {
 				error_signal.get().map(|message| page!(|message: String| {
 					div {
 						class: "alert-danger mt-3",
-						{ self::format_server_error(&message) }
+						{
+							self::format_server_error(&message)
+						}
 					}
 				})(message)).unwrap_or(Page::Empty)
 			}
@@ -1213,7 +1249,9 @@ pub fn choice_delete_confirm(question_id: i64, choice_id: i64) -> Page {
 							class: if is_loading { "btn-primary opacity-50 cursor-not-allowed" } else { "btn-danger" },
 							disabled: is_loading,
 							form: "delete-choice-form",
-							{ if is_loading { "Deleting..." } else { "Delete" } }
+							{
+								if is_loading { "Deleting..." } else { "Delete" }
+							}
 						}
 					})(is_loading)
 				}

--- a/examples/examples-tutorial-basis/src/apps/users/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/client/components.rs
@@ -76,14 +76,12 @@ pub fn login_form() -> Page {
 							page!(|is_loading: bool| {
 								button {
 									type: "submit",
-									class: if is_loading {
-										"btn-primary w-full opacity-50 cursor-not-allowed"
-									} else {
-										"btn-primary w-full"
-									},
+									class: if is_loading { "btn-primary w-full opacity-50 cursor-not-allowed" } else { "btn-primary w-full" },
 									disabled: is_loading,
 									form: "login-form",
-									{ if is_loading { "Signing in..." } else { "Sign in" } }
+									{
+										if is_loading { "Signing in..." } else { "Sign in" }
+									}
 								}
 							})(is_loading)
 						}
@@ -248,14 +246,12 @@ pub fn signup_form() -> Page {
 							page!(|is_loading: bool| {
 								button {
 									type: "submit",
-									class: if is_loading {
-										"btn-primary w-full opacity-50 cursor-not-allowed"
-									} else {
-										"btn-primary w-full"
-									},
+									class: if is_loading { "btn-primary w-full opacity-50 cursor-not-allowed" } else { "btn-primary w-full" },
 									disabled: is_loading,
 									form: "signup-form",
-									{ if is_loading { "Creating account..." } else { "Create account" } }
+									{
+										if is_loading { "Creating account..." } else { "Create account" }
+									}
 								}
 							})(is_loading)
 						}

--- a/examples/examples-tutorial-rest/build.rs
+++ b/examples/examples-tutorial-rest/build.rs
@@ -1,36 +1,9 @@
 use cfg_aliases::cfg_aliases;
 
 fn main() {
-	// Auto-detect: check if reinhardt workspace exists in parent
-	let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-	let examples_dir = std::path::Path::new(&manifest_dir).parent().unwrap();
-	let parent_dir = examples_dir.parent().unwrap();
-	let parent_cargo = parent_dir.join("Cargo.toml");
-
-	let is_local_dev = parent_cargo.exists()
-		&& std::fs::read_to_string(&parent_cargo)
-			.map(|c| c.contains("name = \"reinhardt-web\""))
-			.unwrap_or(false);
-
-	if is_local_dev {
-		// In subtree context - enable integration tests
-		println!("cargo:rustc-cfg=with_reinhardt");
-
-		// Warn if .cargo/config.toml is not set up for local override
-		let config_path = examples_dir.join(".cargo/config.toml");
-		if !config_path.exists() {
-			println!(
-				"cargo:warning=Local reinhardt workspace detected but .cargo/config.toml is missing. \
-				 Copy the template: cp .cargo/config.local.toml .cargo/config.toml"
-			);
-		}
-	} else {
-		// Standalone mode - enable tests if crates.io versions are available
-		println!("cargo:rustc-cfg=with_reinhardt");
-	}
+	println!("cargo:rustc-cfg=with_reinhardt");
 
 	println!("cargo:rerun-if-changed=build.rs");
-	println!("cargo:rerun-if-changed=../.cargo/config.toml");
 
 	// Declare custom cfg to avoid warnings in Rust 2024 edition
 	println!("cargo::rustc-check-cfg=cfg(with_reinhardt)");

--- a/examples/examples-twitter/build.rs
+++ b/examples/examples-twitter/build.rs
@@ -2,36 +2,9 @@
 use cfg_aliases::cfg_aliases;
 
 fn main() {
-	// Auto-detect: check if reinhardt workspace exists in parent
-	let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-	let examples_dir = std::path::Path::new(&manifest_dir).parent().unwrap();
-	let parent_dir = examples_dir.parent().unwrap();
-	let parent_cargo = parent_dir.join("Cargo.toml");
-
-	let is_local_dev = parent_cargo.exists()
-		&& std::fs::read_to_string(&parent_cargo)
-			.map(|c| c.contains("name = \"reinhardt-web\""))
-			.unwrap_or(false);
-
-	if is_local_dev {
-		// In subtree context - enable integration tests
-		println!("cargo:rustc-cfg=with_reinhardt");
-
-		// Warn if .cargo/config.toml is not set up for local override
-		let config_path = examples_dir.join(".cargo/config.toml");
-		if !config_path.exists() {
-			println!(
-				"cargo:warning=Local reinhardt workspace detected but .cargo/config.toml is missing. \
-				 Copy the template: cp .cargo/config.local.toml .cargo/config.toml"
-			);
-		}
-	} else {
-		// Standalone mode - enable tests if crates.io versions are available
-		println!("cargo:rustc-cfg=with_reinhardt");
-	}
+	println!("cargo:rustc-cfg=with_reinhardt");
 
 	println!("cargo:rerun-if-changed=build.rs");
-	println!("cargo:rerun-if-changed=../.cargo/config.toml");
 
 	// Declare custom cfg to avoid warnings in Rust 2024 edition
 	println!("cargo::rustc-check-cfg=cfg(with_reinhardt)");

--- a/examples/examples-twitter/migrations/auth/0001_initial.rs
+++ b/examples/examples-twitter/migrations/auth/0001_initial.rs
@@ -1,6 +1,6 @@
 use reinhardt::db::migrations::FieldType;
 use reinhardt::db::migrations::prelude::*;
-pub fn migration() -> Migration {
+pub(super) fn migration() -> Migration {
 	Migration {
 		app_label: "auth".to_string(),
 		name: "0001_initial".to_string(),

--- a/examples/examples-twitter/migrations/default/0001_initial.rs
+++ b/examples/examples-twitter/migrations/default/0001_initial.rs
@@ -1,6 +1,6 @@
 use reinhardt::db::migrations::FieldType;
 use reinhardt::db::migrations::prelude::*;
-pub fn migration() -> Migration {
+pub(super) fn migration() -> Migration {
 	Migration {
 		app_label: "default".to_string(),
 		name: "0001_initial".to_string(),

--- a/examples/examples-twitter/migrations/dm/0001_initial.rs
+++ b/examples/examples-twitter/migrations/dm/0001_initial.rs
@@ -1,6 +1,6 @@
 use reinhardt::db::migrations::FieldType;
 use reinhardt::db::migrations::prelude::*;
-pub fn migration() -> Migration {
+pub(super) fn migration() -> Migration {
 	Migration {
 		app_label: "dm".to_string(),
 		name: "0001_initial".to_string(),
@@ -144,7 +144,7 @@ pub fn migration() -> Migration {
 						default: None,
 					},
 					ColumnDefinition {
-						name: "dm_user_id".to_string(),
+						name: "auth_user_id".to_string(),
 						type_definition: FieldType::Uuid,
 						not_null: true,
 						unique: false,
@@ -173,9 +173,9 @@ pub fn migration() -> Migration {
 						deferrable: None,
 					},
 					Constraint::ForeignKey {
-						name: "fk_dm_room_members_dm_user_id".to_string(),
-						columns: vec!["dm_user_id".to_string()],
-						referenced_table: "dm_user".to_string(),
+						name: "fk_dm_room_members_auth_user_id".to_string(),
+						columns: vec!["auth_user_id".to_string()],
+						referenced_table: "auth_user".to_string(),
 						referenced_columns: vec!["id".to_string()],
 						on_delete: ForeignKeyAction::Cascade,
 						on_update: ForeignKeyAction::Cascade,
@@ -183,66 +183,7 @@ pub fn migration() -> Migration {
 					},
 					Constraint::Unique {
 						name: "dm_room_members_unique".to_string(),
-						columns: vec!["dm_room_id".to_string(), "dm_user_id".to_string()],
-					},
-				],
-				without_rowid: None,
-				interleave_in_parent: None,
-				partition: None,
-			},
-			Operation::CreateTable {
-				name: "dm_room_members".to_string(),
-				columns: vec![
-					ColumnDefinition {
-						name: "id".to_string(),
-						type_definition: FieldType::Integer,
-						not_null: true,
-						unique: false,
-						primary_key: true,
-						auto_increment: true,
-						default: None,
-					},
-					ColumnDefinition {
-						name: "dm_room_id".to_string(),
-						type_definition: FieldType::Uuid,
-						not_null: true,
-						unique: false,
-						primary_key: false,
-						auto_increment: false,
-						default: None,
-					},
-					ColumnDefinition {
-						name: "dm_user_id".to_string(),
-						type_definition: FieldType::Uuid,
-						not_null: true,
-						unique: false,
-						primary_key: false,
-						auto_increment: false,
-						default: None,
-					},
-				],
-				constraints: vec![
-					Constraint::ForeignKey {
-						name: "fk_dm_room_members_dm_room_id".to_string(),
-						columns: vec!["dm_room_id".to_string()],
-						referenced_table: "dm_room".to_string(),
-						referenced_columns: vec!["id".to_string()],
-						on_delete: ForeignKeyAction::Cascade,
-						on_update: ForeignKeyAction::Cascade,
-						deferrable: None,
-					},
-					Constraint::ForeignKey {
-						name: "fk_dm_room_members_dm_user_id".to_string(),
-						columns: vec!["dm_user_id".to_string()],
-						referenced_table: "dm_user".to_string(),
-						referenced_columns: vec!["id".to_string()],
-						on_delete: ForeignKeyAction::Cascade,
-						on_update: ForeignKeyAction::Cascade,
-						deferrable: None,
-					},
-					Constraint::Unique {
-						name: "dm_room_members_unique".to_string(),
-						columns: vec!["dm_room_id".to_string(), "dm_user_id".to_string()],
+						columns: vec!["dm_room_id".to_string(), "auth_user_id".to_string()],
 					},
 				],
 				without_rowid: None,

--- a/examples/examples-twitter/migrations/profile/0001_initial.rs
+++ b/examples/examples-twitter/migrations/profile/0001_initial.rs
@@ -1,6 +1,6 @@
 use reinhardt::db::migrations::FieldType;
 use reinhardt::db::migrations::prelude::*;
-pub fn migration() -> Migration {
+pub(super) fn migration() -> Migration {
 	Migration {
 		app_label: "profile".to_string(),
 		name: "0001_initial".to_string(),

--- a/examples/examples-twitter/migrations/tweet/0001_initial.rs
+++ b/examples/examples-twitter/migrations/tweet/0001_initial.rs
@@ -1,6 +1,6 @@
 use reinhardt::db::migrations::FieldType;
 use reinhardt::db::migrations::prelude::*;
-pub fn migration() -> Migration {
+pub(super) fn migration() -> Migration {
 	Migration {
 		app_label: "tweet".to_string(),
 		name: "0001_initial".to_string(),

--- a/examples/examples-twitter/src/apps/auth/lib.rs
+++ b/examples/examples-twitter/src/apps/auth/lib.rs
@@ -16,7 +16,7 @@ pub mod client;
 #[cfg(native)]
 pub mod server;
 
-#[cfg(test)]
+#[cfg(all(test, native))]
 pub mod tests;
 
 #[cfg(native)]

--- a/examples/examples-twitter/src/apps/dm/client/hooks.rs
+++ b/examples/examples-twitter/src/apps/dm/client/hooks.rs
@@ -90,7 +90,7 @@ impl DmRoomListHandle {
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```ignore
 /// use crate::apps::dm::client::hooks::use_dm_chat;
 ///
 /// let chat = use_dm_chat(room_id);
@@ -221,7 +221,7 @@ pub fn use_dm_chat(room_id: Uuid) -> DmChatHandle {
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```ignore
 /// use crate::apps::dm::client::hooks::use_dm_room_list;
 ///
 /// let room_list = use_dm_room_list();

--- a/examples/examples-twitter/src/apps/dm/lib.rs
+++ b/examples/examples-twitter/src/apps/dm/lib.rs
@@ -18,7 +18,7 @@ pub mod client;
 #[cfg(native)]
 pub mod server;
 
-#[cfg(test)]
+#[cfg(all(test, native))]
 pub mod tests;
 
 // DM WebSocket routes are intentionally NOT registered via a `urls/ws_urls.rs`

--- a/examples/examples-twitter/src/apps/profile/lib.rs
+++ b/examples/examples-twitter/src/apps/profile/lib.rs
@@ -18,7 +18,7 @@ pub mod client;
 #[cfg(native)]
 pub mod server;
 
-#[cfg(test)]
+#[cfg(all(test, native))]
 pub mod tests;
 
 #[cfg(native)]

--- a/examples/examples-twitter/src/apps/relationship/lib.rs
+++ b/examples/examples-twitter/src/apps/relationship/lib.rs
@@ -14,7 +14,7 @@ pub mod client;
 #[cfg(native)]
 pub mod server;
 
-#[cfg(test)]
+#[cfg(all(test, native))]
 pub mod tests;
 
 #[cfg(native)]

--- a/examples/examples-twitter/src/apps/tweet/lib.rs
+++ b/examples/examples-twitter/src/apps/tweet/lib.rs
@@ -16,7 +16,7 @@ pub mod client;
 #[cfg(native)]
 pub mod server;
 
-#[cfg(test)]
+#[cfg(all(test, native))]
 pub mod tests;
 
 #[cfg(native)]

--- a/examples/examples-twitter/src/bin/manage.rs
+++ b/examples/examples-twitter/src/bin/manage.rs
@@ -1,22 +1,33 @@
 //! Reinhardt Project Management CLI for examples-twitter
 
-use examples_twitter as _;
-use examples_twitter::config::settings::get_settings;
-use reinhardt::commands::execute_from_command_line_with_settings;
-use std::process;
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+	use examples_twitter as _;
+	use examples_twitter::config::settings::get_settings;
+	use reinhardt::commands::execute_from_command_line_with_settings;
+	use std::process;
 
-#[tokio::main]
-async fn main() {
-	// SAFETY: Called at program start before any spawned tasks.
-	unsafe {
-		std::env::set_var(
-			"REINHARDT_SETTINGS_MODULE",
-			"examples_twitter.config.settings",
-		);
-	}
+	#[tokio::main]
+	pub(super) async fn main() {
+		// SAFETY: Called at program start before any spawned tasks.
+		unsafe {
+			std::env::set_var(
+				"REINHARDT_SETTINGS_MODULE",
+				"examples_twitter.config.settings",
+			);
+		}
 
-	if let Err(e) = execute_from_command_line_with_settings(get_settings()).await {
-		eprintln!("Error: {e}");
-		process::exit(1);
+		if let Err(e) = execute_from_command_line_with_settings(get_settings()).await {
+			eprintln!("Error: {e}");
+			process::exit(1);
+		}
 	}
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+	native::main();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/examples/examples-twitter/src/config/middleware.rs
+++ b/examples/examples-twitter/src/config/middleware.rs
@@ -27,11 +27,15 @@ use std::time::Duration;
 /// - Includes CSRF token header for security
 pub fn create_cors_middleware() -> CorsMiddleware {
 	let mut config = CorsSettings::default();
-	config.allow_origins =
-		["http://localhost:3000", "http://127.0.0.1:3000"].map(str::to_string).to_vec();
-	config.allow_methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"].map(str::to_string).to_vec();
-	config.allow_headers =
-		["Content-Type", "Authorization", "X-CSRF-Token"].map(str::to_string).to_vec();
+	config.allow_origins = ["http://localhost:3000", "http://127.0.0.1:3000"]
+		.map(str::to_string)
+		.to_vec();
+	config.allow_methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+		.map(str::to_string)
+		.to_vec();
+	config.allow_headers = ["Content-Type", "Authorization", "X-CSRF-Token"]
+		.map(str::to_string)
+		.to_vec();
 	config.allow_credentials = true;
 	config.max_age = 3600;
 	create_cors_middleware_from_settings(&config)

--- a/examples/examples-twitter/src/core/client/components/common.rs
+++ b/examples/examples-twitter/src/core/client/components/common.rs
@@ -638,23 +638,69 @@ pub fn avatar_sized(url: Option<&str>, alt: &str, size: AvatarSize) -> Page {
 /// Theme toggle button component
 ///
 /// Displays a button to toggle between light and dark mode.
-/// Uses JavaScript to toggle the theme and persist to localStorage.
-/// The click event is attached via JavaScript in index.html.
+/// Uses a Pages click handler to toggle the theme and persist to localStorage.
 pub fn theme_toggle() -> Page {
-	page!(|| {
-		button {
-			class: "theme-toggle",
-			type: "button",
-			id: "theme-toggle-btn",
-			aria_label: "Toggle theme",
-			{
-				icons::sun_icon()
+	#[cfg(wasm)]
+	{
+		page!(|| {
+			button {
+				class: "theme-toggle",
+				type: "button",
+				id: "theme-toggle-btn",
+				aria_label: "Toggle theme",
+				@click: move |_event| {
+					toggle_theme();
+				},
+				{
+					icons::sun_icon()
+				}
+				{
+					icons::moon_icon()
+				}
 			}
-			{
-				icons::moon_icon()
+		})()
+	}
+	#[cfg(native)]
+	{
+		page!(|| {
+			button {
+				class: "theme-toggle",
+				type: "button",
+				id: "theme-toggle-btn",
+				aria_label: "Toggle theme",
+				{
+					icons::sun_icon()
+				}
+				{
+					icons::moon_icon()
+				}
 			}
-		}
-	})()
+		})()
+	}
+}
+
+#[cfg(wasm)]
+fn toggle_theme() {
+	let Some(window) = web_sys::window() else {
+		return;
+	};
+	let Some(document) = window.document() else {
+		return;
+	};
+	let Some(html) = document.document_element() else {
+		return;
+	};
+
+	let current = html
+		.get_attribute("data-theme")
+		.unwrap_or_else(|| "light".to_string());
+	let next = if current == "dark" { "light" } else { "dark" };
+
+	let _ = html.set_attribute("data-theme", next);
+	let _ = html.class_list().toggle_with_force("dark", next == "dark");
+	if let Ok(Some(storage)) = window.local_storage() {
+		let _ = storage.set_item("theme", next);
+	}
 }
 /// Empty placeholder component
 ///

--- a/examples/examples-twitter/src/core/client/pages.rs
+++ b/examples/examples-twitter/src/core/client/pages.rs
@@ -18,7 +18,7 @@
 //! Pages are typically accessed through the router, but can also be
 //! rendered directly for testing or embedding:
 //!
-//! ```no_run
+//! ```ignore
 //! use crate::core::client::pages::timeline_page;
 //!
 //! let page = timeline_page();

--- a/examples/examples-twitter/src/test_utils/factories/dm.rs
+++ b/examples/examples-twitter/src/test_utils/factories/dm.rs
@@ -114,7 +114,7 @@ impl DMRoomFactory {
 	) -> Result<(), sqlx::Error> {
 		let sql = Query::insert()
 			.into_table(Alias::new("dm_room_members"))
-			.columns([Alias::new("dmroom_id"), Alias::new("user_id")])
+			.columns([Alias::new("dm_room_id"), Alias::new("auth_user_id")])
 			.values_panic([Value::from(room_id), Value::from(user_id)])
 			.to_string(PostgresQueryBuilder);
 
@@ -147,8 +147,8 @@ impl DMRoomFactory {
 	) -> Result<Vec<DMRoom>, sqlx::Error> {
 		let sql = "SELECT r.id, r.name, r.is_group, r.created_at, r.updated_at \
 		           FROM dm_room r \
-		           INNER JOIN dm_room_members m ON r.id = m.dmroom_id \
-		           WHERE m.user_id = $1 \
+		           INNER JOIN dm_room_members m ON r.id = m.dm_room_id \
+		           WHERE m.auth_user_id = $1 \
 		           ORDER BY r.updated_at DESC";
 
 		sqlx::query_as::<_, DMRoom>(sql)
@@ -159,7 +159,7 @@ impl DMRoomFactory {
 
 	/// Count rooms for a user.
 	pub async fn count_by_member(&self, pool: &PgPool, user_id: Uuid) -> Result<i64, sqlx::Error> {
-		sqlx::query_scalar("SELECT COUNT(*) FROM dm_room_members WHERE user_id = $1")
+		sqlx::query_scalar("SELECT COUNT(*) FROM dm_room_members WHERE auth_user_id = $1")
 			.bind(user_id)
 			.fetch_one(pool)
 			.await
@@ -177,7 +177,7 @@ impl DMRoomFactory {
 		// Delete members
 		let sql = Query::delete()
 			.from_table(Alias::new("dm_room_members"))
-			.and_where(Expr::col(Alias::new("dmroom_id")).eq(Expr::val(id)))
+			.and_where(Expr::col(Alias::new("dm_room_id")).eq(Expr::val(id)))
 			.to_string(PostgresQueryBuilder);
 		sqlx::query(&sql).execute(pool).await?;
 

--- a/examples/examples-twitter/static/index.html
+++ b/examples/examples-twitter/static/index.html
@@ -5,14 +5,23 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Twitter Clone - Reinhardt Pages</title>
 
-	<!-- UnoCSS Reset -->
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@unocss/reset/tailwind.min.css">
+	<!-- UnoCSS Reset (pinned + SRI) -->
+	<link rel="stylesheet"
+		href="https://cdn.jsdelivr.net/npm/@unocss/reset@66.7.0/tailwind.min.css"
+		integrity="sha384-T4Gl/JcT72kX7H+XBooHT+j5VH/xPcLgHXROFmUj1HF77ctera3Pu1390b73is5o"
+		crossorigin="anonymous">
 
 	<!-- UnoCSS Runtime -->
 	<script>
 	// Theme detection and toggle support
 	(function() {
-		const stored = localStorage.getItem('theme');
+		let stored = null;
+		try {
+			stored = localStorage.getItem('theme');
+		} catch (e) {
+			// localStorage may be unavailable (private mode, sandboxed iframe,
+			// storage disabled by user). Fall back to OS preference below.
+		}
 		const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 		const theme = stored || (prefersDark ? 'dark' : 'light');
 		document.documentElement.setAttribute('data-theme', theme);
@@ -140,38 +149,13 @@
 		],
 	};
 	</script>
-	<script src="https://cdn.jsdelivr.net/npm/@unocss/runtime"></script>
+	<script
+		src="https://cdn.jsdelivr.net/npm/@unocss/runtime@66.7.0"
+		integrity="sha384-N01yk5TWd3fjp79erm4HVUYQXHk88RIDoYnTenU6JEnUSeIGyR37ZEcN1OQnG0U6"
+		crossorigin="anonymous"></script>
 
 	<!-- Custom styles -->
 	<link rel="stylesheet" href="/css/style.css">
-
-	<!-- Theme toggle script -->
-	<script>
-	function toggleTheme() {
-		const html = document.documentElement;
-		const current = html.getAttribute('data-theme');
-		const next = current === 'dark' ? 'light' : 'dark';
-		html.setAttribute('data-theme', next);
-		html.classList.toggle('dark', next === 'dark');
-		localStorage.setItem('theme', next);
-	}
-
-	// Attach click event to theme toggle button (using MutationObserver for dynamic content)
-	// Use load event instead of DOMContentLoaded to ensure body is fully available
-	window.addEventListener('load', function() {
-		const observer = new MutationObserver(function(mutations) {
-			const btn = document.getElementById('theme-toggle-btn');
-			if (btn && !btn.hasAttribute('data-theme-attached')) {
-				btn.setAttribute('data-theme-attached', 'true');
-				btn.addEventListener('click', toggleTheme);
-			}
-		});
-		// document.body is guaranteed to exist after load event
-		if (document.body) {
-			observer.observe(document.body, { childList: true, subtree: true });
-		}
-	});
-	</script>
 </head>
 <body class="bg-surface-secondary text-content-primary antialiased" un-cloak>
 	<div id="root">

--- a/website/content/quickstart/tutorials/basis/3-views-and-urls.md
+++ b/website/content/quickstart/tutorials/basis/3-views-and-urls.md
@@ -1642,8 +1642,8 @@ worth seeing once in full:
 
 	<!-- UnoCSS Reset (pinned + SRI) -->
 	<link rel="stylesheet"
-		href="https://cdn.jsdelivr.net/npm/@unocss/reset@66.0.0/tailwind.min.css"
-		integrity="sha384-LGhsJsqCgUoTJMa7Fmn8Q0Q5/3WY9D96e4lfXpNTzs54EqijDEpPD13nfjueItEK"
+		href="https://cdn.jsdelivr.net/npm/@unocss/reset@66.7.0/tailwind.min.css"
+		integrity="sha384-T4Gl/JcT72kX7H+XBooHT+j5VH/xPcLgHXROFmUj1HF77ctera3Pu1390b73is5o"
 		crossorigin="anonymous">
 
 	<!-- Hand-written base styles + fallback component CSS.
@@ -1743,55 +1743,9 @@ worth seeing once in full:
 
 	<!-- UnoCSS Runtime (pinned + SRI) -->
 	<script
-		src="https://cdn.jsdelivr.net/npm/@unocss/runtime@66.0.0"
-		integrity="sha384-LYmmhezFyzRAT4ivJD/xzz7PEZ3b+pHHgxsOuSVPG8wKScOK2Bx+itfNE+ziDDEv"
+		src="https://cdn.jsdelivr.net/npm/@unocss/runtime@66.7.0"
+		integrity="sha384-N01yk5TWd3fjp79erm4HVUYQXHk88RIDoYnTenU6JEnUSeIGyR37ZEcN1OQnG0U6"
 		crossorigin="anonymous"></script>
-
-	<!-- Theme toggle handler -->
-	<script>
-	function toggleTheme() {
-		var html = document.documentElement;
-		var current = html.getAttribute('data-theme');
-		var next = current === 'dark' ? 'light' : 'dark';
-		html.setAttribute('data-theme', next);
-		html.classList.toggle('dark', next === 'dark');
-		try {
-			localStorage.setItem('theme', next);
-		} catch (e) {
-			// Persisting the preference is best-effort; ignore storage
-			// failures (private mode, sandboxed iframe, disabled storage).
-		}
-	}
-
-	// Attach to any #theme-toggle-btn rendered by WASM via MutationObserver.
-	// The observer disconnects itself as soon as the button is found and
-	// wired up, so it does not keep reacting to unrelated DOM changes.
-	window.addEventListener('load', function() {
-		function tryAttach() {
-			var btn = document.getElementById('theme-toggle-btn');
-			if (btn && !btn.hasAttribute('data-theme-attached')) {
-				btn.setAttribute('data-theme-attached', 'true');
-				btn.addEventListener('click', toggleTheme);
-				return true;
-			}
-			return false;
-		}
-
-		// Button may already be present (SSR / fast WASM mount).
-		if (tryAttach()) {
-			return;
-		}
-
-		var observer = new MutationObserver(function() {
-			if (tryAttach()) {
-				observer.disconnect();
-			}
-		});
-		if (document.body) {
-			observer.observe(document.body, { childList: true, subtree: true });
-		}
-	});
-	</script>
 </head>
 <body>
 	<div id="root">

--- a/website/content/quickstart/tutorials/basis/6-static-files.md
+++ b/website/content/quickstart/tutorials/basis/6-static-files.md
@@ -292,7 +292,7 @@ A subtle point: under `cargo make dev`, the server is *not* serving from `static
 
 ## `index.html`: The SPA Shell
 
-`index.html` lives at the project root and is copied (verbatim) into the directory that the dev server serves at `/`. It is what the browser fetches when a user visits `http://127.0.0.1:8000/` for the first time. The file is longer than a textbook SPA shell because it also wires up CDN integrity hints, a pre-render theme detector, the UnoCSS configuration, and a `MutationObserver`-based theme-toggle handler — every piece below is loaded directly from `examples/examples-tutorial-basis/index.html`:
+`index.html` lives at the project root and is copied (verbatim) into the directory that the dev server serves at `/`. It is what the browser fetches when a user visits `http://127.0.0.1:8000/` for the first time. The file is longer than a textbook SPA shell because it also wires up CDN integrity hints, a pre-render theme detector, and the UnoCSS configuration — every piece below is loaded directly from `examples/examples-tutorial-basis/index.html`:
 
 ```html
 <!DOCTYPE html>
@@ -305,8 +305,8 @@ A subtle point: under `cargo make dev`, the server is *not* serving from `static
 
 	<!-- UnoCSS Reset (pinned + SRI) -->
 	<link rel="stylesheet"
-		href="https://cdn.jsdelivr.net/npm/@unocss/reset@66.0.0/tailwind.min.css"
-		integrity="sha384-LGhsJsqCgUoTJMa7Fmn8Q0Q5/3WY9D96e4lfXpNTzs54EqijDEpPD13nfjueItEK"
+		href="https://cdn.jsdelivr.net/npm/@unocss/reset@66.7.0/tailwind.min.css"
+		integrity="sha384-T4Gl/JcT72kX7H+XBooHT+j5VH/xPcLgHXROFmUj1HF77ctera3Pu1390b73is5o"
 		crossorigin="anonymous">
 
 	<!-- Hand-written base styles + fallback component CSS.
@@ -406,55 +406,9 @@ A subtle point: under `cargo make dev`, the server is *not* serving from `static
 
 	<!-- UnoCSS Runtime (pinned + SRI) -->
 	<script
-		src="https://cdn.jsdelivr.net/npm/@unocss/runtime@66.0.0"
-		integrity="sha384-LYmmhezFyzRAT4ivJD/xzz7PEZ3b+pHHgxsOuSVPG8wKScOK2Bx+itfNE+ziDDEv"
+		src="https://cdn.jsdelivr.net/npm/@unocss/runtime@66.7.0"
+		integrity="sha384-N01yk5TWd3fjp79erm4HVUYQXHk88RIDoYnTenU6JEnUSeIGyR37ZEcN1OQnG0U6"
 		crossorigin="anonymous"></script>
-
-	<!-- Theme toggle handler -->
-	<script>
-	function toggleTheme() {
-		var html = document.documentElement;
-		var current = html.getAttribute('data-theme');
-		var next = current === 'dark' ? 'light' : 'dark';
-		html.setAttribute('data-theme', next);
-		html.classList.toggle('dark', next === 'dark');
-		try {
-			localStorage.setItem('theme', next);
-		} catch (e) {
-			// Persisting the preference is best-effort; ignore storage
-			// failures (private mode, sandboxed iframe, disabled storage).
-		}
-	}
-
-	// Attach to any #theme-toggle-btn rendered by WASM via MutationObserver.
-	// The observer disconnects itself as soon as the button is found and
-	// wired up, so it does not keep reacting to unrelated DOM changes.
-	window.addEventListener('load', function() {
-		function tryAttach() {
-			var btn = document.getElementById('theme-toggle-btn');
-			if (btn && !btn.hasAttribute('data-theme-attached')) {
-				btn.setAttribute('data-theme-attached', 'true');
-				btn.addEventListener('click', toggleTheme);
-				return true;
-			}
-			return false;
-		}
-
-		// Button may already be present (SSR / fast WASM mount).
-		if (tryAttach()) {
-			return;
-		}
-
-		var observer = new MutationObserver(function() {
-			if (tryAttach()) {
-				observer.disconnect();
-			}
-		});
-		if (document.body) {
-			observer.observe(document.body, { childList: true, subtree: true });
-		}
-	});
-	</script>
 </head>
 <body>
 	<div id="root">
@@ -475,9 +429,9 @@ First, the `#root` `<div>` is where the SPA mounts. Recall from Part 3 that `src
 
 Second, there is no explicit `<script type="module">` here that imports the WASM bundle. The pages template's `ClientLauncher` is responsible for locating and instantiating `examples_tutorial_basis.js` and `examples_tutorial_basis_bg.wasm` from the same origin — the SPA shell does not need to hand-wire `init(wasmUrl)`. This is deliberate: the shell stays static while the framework controls how the bundle is loaded.
 
-Third, UnoCSS is delivered straight from a CDN but with the URL **pinned to `@66.0.0`** and protected by **Subresource Integrity (SRI)** hashes on both the reset stylesheet and the runtime script — `integrity="sha384-…"` + `crossorigin="anonymous"`. The browser refuses to apply or execute either resource if the bytes do not match, which keeps the SPA shell reproducible across visits even though the framework itself never bundles the CDN payload. The accompanying `window.__unocss` configuration pre-declares the `brand`, `surface`, `content`, `success`, `danger`, `warning`, and `border` colour tokens (most of which proxy through `var(--…)` CSS custom properties so light/dark mode flips in one place) plus a richer shortcut catalogue — `layout-container`, `btn-*`, `card`, `card-body`, `card-title`, `form-control`, `form-check`, `form-label`, `alert-*`, `nav-bar`, `spinner`, `text-muted`. Those shortcuts are exactly the class names the `page!` macros in `src/client/components/` reach for, so adding a new shortcut here is the quickest way to keep the markup terse without writing custom CSS files.
+Third, UnoCSS is delivered straight from a CDN but with the URL **pinned to `@66.7.0`** and protected by **Subresource Integrity (SRI)** hashes on both the reset stylesheet and the runtime script — `integrity="sha384-…"` + `crossorigin="anonymous"`. The browser refuses to apply or execute either resource if the bytes do not match, which keeps the SPA shell reproducible across visits even though the framework itself never bundles the CDN payload. The accompanying `window.__unocss` configuration pre-declares the `brand`, `surface`, `content`, `success`, `danger`, `warning`, and `border` colour tokens (most of which proxy through `var(--…)` CSS custom properties so light/dark mode flips in one place) plus a richer shortcut catalogue — `layout-container`, `btn-*`, `card`, `card-body`, `card-title`, `form-control`, `form-check`, `form-label`, `alert-*`, `nav-bar`, `spinner`, `text-muted`. Those shortcuts are exactly the class names the `page!` macros in `src/client/components/` reach for, so adding a new shortcut here is the quickest way to keep the markup terse without writing custom CSS files.
 
-Fourth, the shell preloads `/static/css/style.css` via `<link rel="stylesheet" href="/static/css/style.css">` *before* the blocking UnoCSS runtime script. That file lives at `static/css/style.css` in the example crate (defining the `--bg-primary`, `--text-primary`, `--brand-primary` … CSS custom properties referenced by the `surface-*` / `content-*` / `border` tokens above) and is what gives the first paint a fully-styled view even before the runtime script has had a chance to process the WASM-mounted DOM nodes. One caveat that the "What This Chapter Does Not Cover" section below makes explicit: the project-level `static/` directory is **not** registered with `collectstatic` in the example, so this preload resolves only because `cargo make dev`'s runserver falls back to the source tree — a real production deployment that serves `STATIC_ROOT` alone would return `404` for `/static/css/style.css` until you add an `AppStaticFilesConfig` for `static/`. A short inline `<script>` block higher up reads `localStorage.getItem('theme')` (falling back to `prefers-color-scheme`) and sets `data-theme` + the `dark` class on `<html>` *before* the first render, which is what avoids the flash-of-unstyled-content when the user has chosen dark mode. A second script block at the bottom installs a `MutationObserver` that wires a click handler onto whatever `#theme-toggle-btn` the WASM bundle eventually renders, then disconnects itself.
+Fourth, the shell preloads `/static/css/style.css` via `<link rel="stylesheet" href="/static/css/style.css">` *before* the blocking UnoCSS runtime script. That file lives at `static/css/style.css` in the example crate (defining the `--bg-primary`, `--text-primary`, `--brand-primary` … CSS custom properties referenced by the `surface-*` / `content-*` / `border` tokens above) and is what gives the first paint a fully-styled view even before the runtime script has had a chance to process the WASM-mounted DOM nodes. One caveat that the "What This Chapter Does Not Cover" section below makes explicit: the project-level `static/` directory is **not** registered with `collectstatic` in the example, so this preload resolves only because `cargo make dev`'s runserver falls back to the source tree — a real production deployment that serves `STATIC_ROOT` alone would return `404` for `/static/css/style.css` until you add an `AppStaticFilesConfig` for `static/`. A short inline `<script>` block higher up reads `localStorage.getItem('theme')` (falling back to `prefers-color-scheme`) and sets `data-theme` + the `dark` class on `<html>` *before* the first render, which is what avoids the flash-of-unstyled-content when the user has chosen dark mode.
 
 ## The `msw` Feature
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Fixes the release PR Examples Tests failures that were initially blocked by `examples-tutorial-basis` and `examples-twitter` formatter drift.
- Routes examples formatting through `reinhardt-formatter` and updates the generated migration writer to emit crate-visible migration functions.
- Fixes the hidden `examples-twitter` failures exposed after the format gate: wasm/native target gating, ignored runtime-only doctest snippets, and DM many-to-many migration/test fixture column drift.
- Fixes `reinhardt-db` many-to-many autodetection so unqualified cross-app targets resolve to the real app and synthetic through tables are not duplicated when the through model already exists.
- Resolves the release-candidate dependency failure where examples tried to fetch unpublished `reinhardt-web = 0.2.0-rc.2` from crates.io instead of using the parent checkout.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The release PR Examples Tests were failing at `cargo make fmt-check` because the examples had not been formatted with `reinhardt-formatter`. After applying the expected formatter, the `examples-twitter` standalone job exposed additional pre-existing failures in wasm test compilation, doctests, and native DM database tests.

The DM failures came from generated and hand-written many-to-many table definitions disagreeing about target app/table names and column names. The framework now resolves unqualified many-to-many target models across apps before generating migration state, and avoids emitting a second synthetic through-table when the macro-provided through model already exists.

The examples workspace also needed to validate the current release candidate before publication. Depending on bare crates.io `reinhardt-web = 0.2.0-rc.2` made local `cargo make runserver` / `migrate` fail until that prerelease existed on crates.io, so the examples workspace now points at the parent checkout while retaining the expected version.

Related to: #5096

## How Was This Tested?

- `cargo test -p reinhardt-db --lib many_to_many -- --nocapture`
- `cargo test -p reinhardt-db --lib test_filesystem_repository_save -- --nocapture`
- `cargo check --bin manage` from `examples/examples-tutorial-basis`
- `cargo fmt --manifest-path examples/Cargo.toml --all -- --check`
- `bash scripts/validate-version-markers.sh`
- `cargo make migrate` from `examples/examples-tutorial-basis`
- `cargo make infra-down` from `examples/examples-tutorial-basis`
- From `examples/examples-twitter`:
  - `cargo make fmt-check`
  - `cargo make clippy-check`
  - `cargo build --all-features`
  - `cargo check --manifest-path ../../Cargo.toml --target wasm32-unknown-unknown -p reinhardt-core -p reinhardt-urls --features reinhardt-core/full,reinhardt-urls/client-router`
  - `cargo check --target wasm32-unknown-unknown --lib`
  - `cargo make wasm-test`
  - `cargo nextest run --all-features --no-tests=warn`
  - `cargo test --doc --all-features`
- From `examples/examples-tutorial-basis`:
  - `cargo make fmt-check`
  - `cargo make clippy-check`
  - `cargo build --all-features`
  - `cargo check --manifest-path ../../Cargo.toml --target wasm32-unknown-unknown -p reinhardt-core -p reinhardt-urls --features reinhardt-core/full,reinhardt-urls/client-router`
  - `cargo make wasm-test`
  - `cargo nextest run --all-features --no-tests=warn`
  - `cargo test --doc --all-features`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to release PR #5096 and its failing Examples Tests job.

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This branch intentionally targets `develop/0.2.0` rather than editing the release-plz branch directly.

🤖 Generated with [Codex](https://openai.com/codex)