### PR TITLE
fix(pages): rerender SPA links after cleanup

### DIFF
--- a/crates/reinhardt-core/src/reactive/effect.rs
+++ b/crates/reinhardt-core/src/reactive/effect.rs
@@ -41,6 +41,9 @@ use super::runtime::{EffectTiming, NodeId, NodeType, Observer, try_with_runtime,
 /// Type alias for effect functions
 type EffectFn = Box<dyn FnMut() + 'static>;
 
+/// Type alias for stored effect slots.
+type EffectSlot = Option<EffectFn>;
+
 /// Type alias for the cleanup slot shared between Effect instances and closures
 type CleanupSlot = Rc<RefCell<Option<Box<dyn FnOnce()>>>>;
 
@@ -48,7 +51,7 @@ type CleanupSlot = Rc<RefCell<Option<Box<dyn FnOnce()>>>>;
 //
 // This stores the closures for all Effects so they can be re-executed when dependencies change.
 thread_local! {
-	static EFFECT_FUNCTIONS: RefCell<BTreeMap<NodeId, EffectFn>> = RefCell::new(BTreeMap::new());
+	static EFFECT_FUNCTIONS: RefCell<BTreeMap<NodeId, EffectSlot>> = RefCell::new(BTreeMap::new());
 }
 
 // Global storage for Effect timing information
@@ -140,11 +143,11 @@ impl Effect {
 		EFFECT_FUNCTIONS.with(|storage| {
 			storage.borrow_mut().insert(
 				id,
-				Box::new(move || {
+				Some(Box::new(move || {
 					if !*disposed_clone.borrow() {
 						f();
 					}
-				}),
+				})),
 			);
 		});
 
@@ -197,11 +200,11 @@ impl Effect {
 		EFFECT_FUNCTIONS.with(|storage| {
 			storage.borrow_mut().insert(
 				id,
-				Box::new(move || {
+				Some(Box::new(move || {
 					if !*disposed_clone.borrow() {
 						f();
 					}
-				}),
+				})),
 			);
 		});
 
@@ -267,7 +270,8 @@ impl Effect {
 				return;
 			}
 			// Flush any cleanup from the previous run before re-executing.
-			if let Some(prev) = cleanup_for_closure.borrow_mut().take() {
+			let previous_cleanup = { cleanup_for_closure.borrow_mut().take() };
+			if let Some(prev) = previous_cleanup {
 				prev();
 			}
 			// Run the user's closure with the Observer stack detached so
@@ -283,7 +287,7 @@ impl Effect {
 		};
 
 		EFFECT_FUNCTIONS.with(|storage| {
-			storage.borrow_mut().insert(id, Box::new(wrapped));
+			storage.borrow_mut().insert(id, Some(Box::new(wrapped)));
 		});
 
 		// Insert timing *before* initial execution so the first
@@ -362,7 +366,7 @@ impl Effect {
 					EFFECT_TIMING.with(|storage| storage.borrow().contains_key(&self.effect_id));
 				if still_alive && let Some(f) = self.effect_fn.take() {
 					EFFECT_FUNCTIONS.with(|storage| {
-						storage.borrow_mut().insert(self.effect_id, f);
+						storage.borrow_mut().insert(self.effect_id, Some(f));
 					});
 				}
 			}
@@ -370,7 +374,12 @@ impl Effect {
 
 		let mut guard = EffectFnGuard {
 			effect_id,
-			effect_fn: EFFECT_FUNCTIONS.with(|storage| storage.borrow_mut().remove(&effect_id)),
+			effect_fn: EFFECT_FUNCTIONS.with(|storage| {
+				storage
+					.borrow_mut()
+					.get_mut(&effect_id)
+					.and_then(Option::take)
+			}),
 		};
 		if let Some(ref mut f) = guard.effect_fn {
 			f();
@@ -395,7 +404,8 @@ impl Effect {
 
 		// Flush any pending cleanup from new_with_deps before tearing down
 		// runtime state, matching React's "cleanup runs on unmount" semantics.
-		if let Some(c) = self.cleanup_slot.borrow_mut().take() {
+		let cleanup = { self.cleanup_slot.borrow_mut().take() };
+		if let Some(c) = cleanup {
 			c();
 		}
 
@@ -403,9 +413,13 @@ impl Effect {
 		let _ = try_with_runtime(|rt| rt.remove_node(self.id));
 
 		// Remove from storage (ignore if TLS is destroyed)
+		let mut effect_fn = None;
 		let _ = EFFECT_FUNCTIONS.try_with(|storage| {
-			storage.borrow_mut().remove(&self.id);
+			let mut functions = storage.borrow_mut();
+			effect_fn = functions.get_mut(&self.id).and_then(Option::take);
+			functions.remove(&self.id);
 		});
+		drop(effect_fn);
 
 		// Remove timing entry so the RAII guard in execute_effect() knows not to reinsert
 		let _ = EFFECT_TIMING.try_with(|storage| {
@@ -832,6 +846,63 @@ mod tests {
 		// Assert — sequence should be: run, cleanup, run.
 		let recorded = log.borrow().clone();
 		assert_eq!(recorded, alloc::vec!["run", "cleanup", "run"]);
+	}
+
+	#[test]
+	#[serial(reactive_runtime)]
+	fn new_with_deps_cleanup_can_dispose_same_effect_without_reentrant_borrow() {
+		let s = Signal::new(0_i32);
+		let runs = Rc::new(RefCell::new(0_i32));
+		let effect_holder: Rc<RefCell<Option<Effect>>> = Rc::new(RefCell::new(None));
+		let runs_for_effect = runs.clone();
+		let holder_for_effect = effect_holder.clone();
+		let s_for_effect = s.clone();
+		let deps = crate::reactive::deps::Deps::from_signals(&[s.id()]);
+
+		let effect = Effect::new_with_deps(
+			move || {
+				let _ = s_for_effect.get();
+				*runs_for_effect.borrow_mut() += 1;
+				let holder_for_cleanup = holder_for_effect.clone();
+				Some(move || {
+					if let Some(effect) = holder_for_cleanup.borrow().as_ref() {
+						effect.dispose();
+					}
+				})
+			},
+			deps,
+		);
+		*effect_holder.borrow_mut() = Some(effect);
+
+		s.set(1);
+		with_runtime(|rt| rt.flush_updates());
+		assert_eq!(
+			*runs.borrow(),
+			2,
+			"Refs #5104: cleanup-triggered self-dispose must not panic before the rerun body"
+		);
+
+		s.set(2);
+		with_runtime(|rt| rt.flush_updates());
+		assert_eq!(
+			*runs.borrow(),
+			2,
+			"effect disposed during cleanup must not be reinserted"
+		);
+
+		let effect_to_drop = { effect_holder.borrow_mut().take() };
+		drop(effect_to_drop);
+	}
+
+	#[test]
+	#[serial(reactive_runtime)]
+	fn dispose_can_drop_nested_effect_function_without_reentrant_storage_borrow() {
+		let inner = Effect::new(|| {});
+		let outer = Effect::new(move || {
+			let _ = inner.id();
+		});
+
+		outer.dispose();
 	}
 
 	#[test]

--- a/crates/reinhardt-pages/src/app/launcher.rs
+++ b/crates/reinhardt-pages/src/app/launcher.rs
@@ -474,7 +474,7 @@ impl ClientLauncher {
 impl ClientLauncher {
 	/// Render the current route into the given root element.
 	///
-	/// Performs `Router::render_current` -> `cleanup_reactive_nodes` ->
+	/// Performs `cleanup_reactive_nodes` -> `Router::render_current` ->
 	/// clears `innerHTML` -> `view.mount`. Used by `launch()` for both
 	/// the initial mount (called inline in Phase B) and every
 	/// subsequent re-mount (called from a `Router::on_navigate`
@@ -483,8 +483,13 @@ impl ClientLauncher {
 	/// Refs #4101.
 	fn render_and_mount(root_el: &web_sys::Element) -> Result<(), crate::component::MountError> {
 		RENDER_COUNT.with(|c| c.set(c.get() + 1));
-		let view = with_spa_router(|r| r.render_current());
+		// Refs #5104: tear down the previous route's reactive graph before
+		// constructing the next route. Route construction can create forms,
+		// resources, and reactive blocks that synchronously touch signals; if
+		// stale route effects are still alive, those signal notifications can
+		// re-enter the runtime and abort the navigation before DOM remount.
 		crate::component::cleanup_reactive_nodes();
+		let view = with_spa_router(|r| r.render_current());
 		root_el.set_inner_html("");
 		let wrapper = crate::dom::Element::new(root_el.clone());
 		view.mount(&wrapper)
@@ -520,7 +525,7 @@ impl ClientLauncher {
 	///    `document` when `intercept_links` is `true` (the default).
 	///
 	/// 2. **Phase B — Initial mount.** Inline (no `Effect`):
-	///    `Router::render_current()` -> `cleanup_reactive_nodes()` ->
+	///    `cleanup_reactive_nodes()` -> `Router::render_current()` ->
 	///    clears `innerHTML` -> `view.mount()`. On mount failure
 	///    `launch()` returns `Err` and Phase C is skipped.
 	///

--- a/crates/reinhardt-pages/tests/wasm/client_launcher_navigation_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/client_launcher_navigation_test.rs
@@ -24,6 +24,7 @@ use reinhardt_pages::app::{ClientLauncher, with_spa_router};
 use reinhardt_pages::component::{IntoPage, Page, PageElement};
 use reinhardt_pages::reactive::{Signal, with_runtime};
 use reinhardt_urls::routers::ClientRouter;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -42,6 +43,19 @@ fn page_a() -> Page {
 	PageElement::new("div")
 		.attr("id", "route-a")
 		.child("ROUTE-A-CONTENT")
+		.into_page()
+}
+
+fn page_with_anchor_to_b() -> Page {
+	PageElement::new("div")
+		.attr("id", "route-a")
+		.child("ROUTE-A-CONTENT")
+		.child(
+			PageElement::new("a")
+				.attr("id", "link-to-b")
+				.attr("href", "/b")
+				.child("Go to B"),
+		)
 		.into_page()
 }
 
@@ -142,6 +156,58 @@ async fn client_launcher_re_renders_on_router_push() {
 	assert!(
 		!html_after_b.contains("ROUTE-A-CONTENT"),
 		"expected /a view absent after push('/b'), got: {html_after_b}"
+	);
+}
+
+#[wasm_bindgen_test]
+async fn client_launcher_re_renders_after_intercepted_anchor_click() {
+	let root = install_app_root();
+
+	ClientLauncher::new("#app")
+		.router_client(|| {
+			ClientRouter::new()
+				.route("root", "/", page_root)
+				.route("a", "/a", page_with_anchor_to_b)
+				.route("b", "/b", page_b)
+		})
+		.launch()
+		.expect("launch");
+
+	yield_to_microtasks().await;
+
+	with_spa_router(|r| r.push("/a")).expect("push /a");
+	yield_to_microtasks().await;
+	yield_to_microtasks().await;
+	assert!(
+		root.inner_html().contains("ROUTE-A-CONTENT"),
+		"setup precondition: expected /a before clicking link, got: {}",
+		root.inner_html()
+	);
+
+	let document = web_sys::window().unwrap().document().unwrap();
+	let anchor: web_sys::HtmlElement = document
+		.get_element_by_id("link-to-b")
+		.expect("link-to-b exists")
+		.dyn_into()
+		.expect("link-to-b is HtmlElement");
+	anchor.click();
+	yield_to_microtasks().await;
+	yield_to_microtasks().await;
+
+	let path = web_sys::window()
+		.unwrap()
+		.location()
+		.pathname()
+		.expect("location pathname");
+	let html_after_click = root.inner_html();
+	assert_eq!(path, "/b");
+	assert!(
+		html_after_click.contains("ROUTE-B-CONTENT"),
+		"Refs #5104: intercepted anchor click changed the URL but did not rerender /b, got: {html_after_click}"
+	);
+	assert!(
+		!html_after_click.contains("ROUTE-A-CONTENT"),
+		"Refs #5104: previous /a view should be gone after anchor navigation, got: {html_after_click}"
 	);
 }
 

--- a/examples/examples-tutorial-basis/scripts/wasm-build-dev.sh
+++ b/examples/examples-tutorial-basis/scripts/wasm-build-dev.sh
@@ -7,4 +7,6 @@ set -euo pipefail
 
 echo "Running collectstatic..."
 cargo run --bin manage collectstatic --no-input
+mkdir -p dist
+find dist-wasm -maxdepth 1 -type f \( -name '*.js' -o -name '*.wasm' -o -name '*.d.ts' \) -exec cp -f {} dist/ \;
 echo "✓ WASM build and collectstatic completed"


### PR DESCRIPTION
## Summary

This PR addresses:

- Fixes SPA anchor navigation where the URL changed but the route DOM did not rerender.
- Prevents reactive `Effect` teardown from dropping nested effect closures while the global effect storage is mutably borrowed.
- Ensures `examples-tutorial-basis` dev WASM rebuilds copy the fresh `dist-wasm` bundle into the served `dist` directory.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

SPA link interception could call `history.pushState` successfully, then abort during route cleanup before remounting the new route. The root cause was reentrant `RefCell` borrowing in reactive effect disposal: route cleanup can drop reactive nodes whose closures own resources and nested effects.

Fixes #5104

Related to: #5100

## How Was This Tested?

- `cargo test -p reinhardt-core --features reactive reentrant --lib`
- `wasm-pack test --headless --chrome crates/reinhardt-pages --test client_launcher_navigation_test`
- `cargo fmt --all --check`
- `cargo make fmt-check`
- Playwright manual verification against `examples/examples-tutorial-basis` at `http://127.0.0.1:8000/`: click `Create new poll`, verify URL becomes `/polls/new/` and the `New Question` form is rendered.

## Performance Impact

Not performance-related. The effect storage now uses `Option` slots so disposal can take closures out before dropping them; this is a teardown-only safety change.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5104
- Related to #5100

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The example dev rebuild path produced a fresh WASM bundle under `dist-wasm/`, while the server continued serving stale files from `dist/`. The script now copies the generated JS/WASM artifacts into `dist/` after `collectstatic`.
