### PR TITLE
fix(examples): restore basis poll choice layout

### DIFF
--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -190,7 +190,9 @@ fn build_voting_form_page(qid: i64, choices: &[ChoiceInfo]) -> Page {
 				widget: RadioSelect,
 				required,
 				label: "Select your choice",
-				class: "form-check",
+				class: "poll-choice-input",
+				wrapper_class: "poll-choice-field",
+				label_class: "poll-choice-label",
 				choices_from: "choices",
 				choice_value: "id",
 				choice_label: "choice_text",
@@ -464,37 +466,42 @@ pub fn polls_results(question_id: i64) -> Page {
 											let percentage = if total > 0 {
 												(choice.votes as f64 / total as f64 * 100.0) as i32
 											} else { 0 };
-											page!(|choice: ChoiceInfo, percentage: i32| {
+											let choice_text = choice.choice_text.clone();
+											let votes = choice.votes;
+											let progress_label = format!("{} received {} percent of votes", choice_text, percentage);
+											page!(|choice_text: String, votes: i32, percentage: i32, progress_label: String| {
 												div {
 													class: "py-4",
 													div {
 														class: "flex justify-between items-center mb-2",
-														strong { {
-															choice.choice_text.clone()
-														} }
+														strong { { choice_text } }
 														span {
 															class: "inline-flex items-center bg-brand rounded-full px-2.5 py-0.5 text-xs font-medium text-white",
 															{
-																format!("{} votes", choice.votes)
+																format!("{} votes", votes)
 															}
 														}
 													}
 													div {
-														class: "w-full bg-surface-tertiary rounded-full h-2.5",
+														class: "poll-result-meter-row",
 														div {
-															class: "bg-brand h-2.5 rounded-full",
+															class: "poll-result-meter",
 															role: "progressbar",
+															aria_label: progress_label,
 															style: format!("width: {}%", percentage),
 															aria_valuenow: percentage.to_string(),
 															aria_valuemin: "0",
 															aria_valuemax: "100",
+														}
+														span {
+															class: "poll-result-percent",
 															{
 																format!("{}%", percentage)
 															}
 														}
 													}
 												}
-											})(choice.clone(), percentage)
+											})(choice_text, votes, percentage, progress_label)
 										} }
 									}
 									div {

--- a/examples/examples-tutorial-basis/static/css/style.css
+++ b/examples/examples-tutorial-basis/static/css/style.css
@@ -369,6 +369,80 @@ label {
 	height: 1.05rem;
 }
 
+.poll-choice-field {
+	margin-bottom: 1rem;
+}
+
+.poll-choice-label {
+	display: block;
+	margin-bottom: 0.5rem;
+}
+
+.poll-choice-field > label:not(.poll-choice-label) {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	width: 100%;
+	padding: 0.75rem 1rem;
+	margin-bottom: 0.5rem;
+	border: 1px solid var(--border-color);
+	border-radius: 0.5rem;
+	background-color: var(--bg-primary);
+	cursor: pointer;
+	transition:
+		background-color var(--transition-fast),
+		border-color var(--transition-fast);
+}
+
+.poll-choice-field > label:not(.poll-choice-label):hover {
+	background-color: var(--bg-secondary);
+	border-color: var(--border-secondary);
+}
+
+.poll-choice-input {
+	flex: 0 0 auto;
+	accent-color: var(--brand-primary);
+	width: 1.05rem;
+	height: 1.05rem;
+	margin: 0;
+}
+
+.poll-result-meter-row {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 3rem;
+	align-items: center;
+	gap: 0.75rem;
+	width: 100%;
+}
+
+.poll-result-meter-row::before {
+	content: "";
+	display: block;
+	grid-column: 1;
+	grid-row: 1;
+	width: 100%;
+	height: 0.625rem;
+	border-radius: 9999px;
+	background-color: var(--bg-tertiary);
+}
+
+.poll-result-meter {
+	grid-column: 1;
+	grid-row: 1;
+	height: 0.625rem;
+	border-radius: 9999px;
+	background-color: var(--brand-primary);
+	min-width: 0;
+}
+
+.poll-result-percent {
+	grid-column: 2;
+	grid-row: 1;
+	color: var(--text-secondary);
+	font-size: 0.875rem;
+	text-align: right;
+}
+
 /* Alerts ----------------------------------------------------------- */
 .alert-danger,
 .alert-warning,


### PR DESCRIPTION
## Summary

This PR addresses:

- Restores the examples-tutorial-basis poll detail layout by styling dynamic radio choices as full-width selectable rows.
- Restores the results layout by rendering percentage text outside the progressbar meter instead of inside the short bar.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The dynamic `RadioSelect` choices were rendered as adjacent inline labels, causing the detail page to collapse choices into one line. The results page placed visible percentage text inside a 0.625rem progressbar, causing the label to overlap the meter.

Related to: #5112

## How Was This Tested?

- `PATH="target/debug:$PATH" cargo make fmt-check` from `examples/examples-tutorial-basis`
- `cargo make wasm-test` from `examples/examples-tutorial-basis`
- `cargo check --all-features` from `examples/examples-tutorial-basis`
- `cargo make wasm-build-dev` from `examples/examples-tutorial-basis`
- Playwright against `http://127.0.0.1:8000/polls/1/` and `/polls/1/results/` at desktop and mobile widths
- Playwright vote smoke test: selected `C2`, clicked `Vote`, confirmed navigation to `/polls/1/results/` and two result rows

Note: `wasm-pack test --headless --chrome -- --no-default-features --features client-router,msw` still hits the existing MSW relative-URL / active-worker harness issue outside this layout change.

## Performance Impact

Not performance-related.

## Screenshots

### Before

- Radio labels collapsed into a single inline row.
- Result percentages rendered inside the progressbar and overlapped the meter.

### After

- Radio choices render as separate full-width rows on desktop and mobile.
- Result percentages render in a separate right-hand column; progressbar elements contain no visible text.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #5112

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- The normal `cargo make wasm-test` target does not enable the `msw` feature, so it compiles the example WASM test harness but does not run the MSW-gated polls browser tests.
