### PR TITLE
fix(commands): verify runserver reachability after hot reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ cargo run --bin manage -- runserver --with-pages
 Edit any Rust source file (server-side or wasm-side) and the bundle
 plus the server are rebuilt in place. Pass `--noreload` to disable
 auto-reload entirely, or `--no-wasm-rebuild` to keep server reload
-but manage the wasm build yourself.
+but manage the wasm build yourself. A successful server restart log is
+emitted only after the respawned child accepts connections at the
+advertised development address.
 
 ### 4. Create Your First App
 

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -2657,6 +2657,7 @@ impl RunServerCommand {
 
 		let cfg = crate::debounced_watcher::WatcherConfig {
 			bin_name,
+			address: address.to_string(),
 			roots,
 			no_wasm_rebuild,
 			#[cfg(feature = "pages")]

--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -101,6 +101,8 @@ pub async fn debounce_next(rx: &mut Receiver<Event>, window: Duration) -> Option
 pub struct WatcherConfig {
 	/// Bin name passed to `cargo build --bin`.
 	pub bin_name: String,
+	/// Advertised runserver address that must be reachable after restart.
+	pub address: String,
 	/// Source directories and manifest files to subscribe to.
 	pub roots: SourceRoots,
 	/// When `true`, suppress the WASM rebuild pipeline.
@@ -222,10 +224,11 @@ pub async fn run_watcher(
 						}
 					}
 				};
-				let server_fut = crate::server_rebuild_pipeline::ServerRebuildPipeline::run(
+				let server_fut = crate::server_rebuild_pipeline::ServerRebuildPipeline::run_with_readiness(
 					&config.bin_name,
 					&mut current_child,
 					&respawn,
+					&config.address,
 				);
 				let ((), (_outcome, new_child)) = tokio::join!(wasm_fut, server_fut);
 				if let Some(child) = new_child {

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -115,7 +115,8 @@
 //! Edit any Rust source file (server-side or wasm-side) and the bundle plus
 //! the server are rebuilt in place. Pass `--noreload` to disable auto-reload
 //! entirely, or `--no-wasm-rebuild` to keep server reload but manage the wasm
-//! build yourself.
+//! build yourself. The server restart success log is emitted only after the
+//! respawned child accepts connections at the advertised development address.
 //!
 //! See [`runserver_hooks`] for the full hot-reload runbook and failure modes.
 

--- a/crates/reinhardt-commands/src/server_rebuild_pipeline.rs
+++ b/crates/reinhardt-commands/src/server_rebuild_pipeline.rs
@@ -4,9 +4,15 @@
 //! server child process for a freshly spawned one. Emits the structured
 //! `[hot-reload] ...` log lines the watcher contract requires.
 
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 use std::time::{Duration, Instant};
 
 use tokio::process::{Child, Command};
+use tokio::time::{sleep, timeout};
+
+const READINESS_TIMEOUT: Duration = Duration::from_secs(5);
+const READINESS_INTERVAL: Duration = Duration::from_millis(50);
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Outcome of a single server rebuild attempt triggered by the hot-reload loop.
 #[derive(Debug)]
@@ -48,6 +54,31 @@ impl ServerRebuildPipeline {
 		bin_name: &str,
 		current_child: &mut Child,
 		respawn: impl FnOnce() -> std::io::Result<Child>,
+	) -> (ServerRebuildOutcome, Option<Child>) {
+		Self::run_inner(bin_name, current_child, respawn, None).await
+	}
+
+	/// Run `cargo build --bin <bin_name>`, swap the child, then wait until
+	/// the advertised server address accepts TCP connections.
+	///
+	/// If the new child starts but never becomes reachable, the failure is
+	/// reported as `SpawnFailed` while the child is still returned so the
+	/// watcher can keep owning and eventually replace or kill it.
+	pub async fn run_with_readiness(
+		bin_name: &str,
+		current_child: &mut Child,
+		respawn: impl FnOnce() -> std::io::Result<Child>,
+		address: &str,
+	) -> (ServerRebuildOutcome, Option<Child>) {
+		let readiness = ServerReadinessProbe::new(address);
+		Self::run_inner(bin_name, current_child, respawn, Some(readiness)).await
+	}
+
+	async fn run_inner(
+		bin_name: &str,
+		current_child: &mut Child,
+		respawn: impl FnOnce() -> std::io::Result<Child>,
+		readiness: Option<ServerReadinessProbe>,
 	) -> (ServerRebuildOutcome, Option<Child>) {
 		let start = Instant::now();
 
@@ -106,6 +137,19 @@ impl ServerRebuildPipeline {
 
 		match respawn() {
 			Ok(new_child) => {
+				if let Some(readiness) = readiness
+					&& let Err(e) = readiness.wait_until_ready().await
+				{
+					let duration = start.elapsed();
+					let outcome = ServerRebuildOutcome::SpawnFailed {
+						duration,
+						message: format!("server did not become reachable: {}", e),
+					};
+					eprintln!("{}", Self::format_log_line(&outcome));
+					eprintln!("[hot-reload] watching for next change...");
+					return (outcome, Some(new_child));
+				}
+
 				let duration = start.elapsed();
 				let outcome = ServerRebuildOutcome::Ok { duration };
 				eprintln!("{}", Self::format_log_line(&outcome));
@@ -153,6 +197,87 @@ impl ServerRebuildPipeline {
 		let lines: Vec<&str> = stderr.split('\n').collect();
 		let start = lines.len().saturating_sub(n);
 		lines[start..].join("\n")
+	}
+}
+
+struct ServerReadinessProbe {
+	address: String,
+	timeout: Duration,
+	interval: Duration,
+	connect_timeout: Duration,
+}
+
+impl ServerReadinessProbe {
+	fn new(address: &str) -> Self {
+		Self {
+			address: address.to_string(),
+			timeout: READINESS_TIMEOUT,
+			interval: READINESS_INTERVAL,
+			connect_timeout: CONNECT_TIMEOUT,
+		}
+	}
+
+	async fn wait_until_ready(&self) -> std::io::Result<()> {
+		let addrs = Self::probe_addrs(&self.address)?;
+		let deadline = Instant::now() + self.timeout;
+		let mut last_error = String::from("no connection attempt made");
+
+		loop {
+			for addr in &addrs {
+				match timeout(self.connect_timeout, tokio::net::TcpStream::connect(addr)).await {
+					Ok(Ok(_stream)) => return Ok(()),
+					Ok(Err(e)) => {
+						last_error = format!("connect to {} failed: {}", addr, e);
+					}
+					Err(_) => {
+						last_error = format!("connect to {} timed out", addr);
+					}
+				}
+			}
+
+			if Instant::now() >= deadline {
+				return Err(std::io::Error::new(
+					std::io::ErrorKind::TimedOut,
+					format!(
+						"{} did not accept connections within {}; {}",
+						self.address,
+						format_duration(self.timeout),
+						last_error
+					),
+				));
+			}
+
+			sleep(self.interval).await;
+		}
+	}
+
+	fn probe_addrs(address: &str) -> std::io::Result<Vec<SocketAddr>> {
+		let addrs: Vec<SocketAddr> = address
+			.to_socket_addrs()?
+			.map(|addr| {
+				if addr.ip().is_unspecified() {
+					match addr {
+						SocketAddr::V4(addr) => {
+							SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), addr.port())
+						}
+						SocketAddr::V6(addr) => {
+							SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), addr.port())
+						}
+					}
+				} else {
+					addr
+				}
+			})
+			.collect();
+
+		if addrs.is_empty() {
+			return Err(std::io::Error::new(
+				std::io::ErrorKind::InvalidInput,
+				format!("server address {address:?} did not resolve to any socket addresses"),
+			));
+		}
+
+		Ok(addrs)
 	}
 }
 
@@ -219,5 +344,23 @@ mod tests {
 
 		// Assert
 		assert_eq!(tail, "only-line-1\nonly-line-2");
+	}
+
+	#[test]
+	fn readiness_probe_rewrites_unspecified_ipv4_to_loopback() {
+		// Act
+		let addrs = ServerReadinessProbe::probe_addrs("0.0.0.0:8000").unwrap();
+
+		// Assert
+		assert_eq!(addrs, vec!["127.0.0.1:8000".parse().unwrap()]);
+	}
+
+	#[test]
+	fn readiness_probe_rewrites_unspecified_ipv6_to_loopback() {
+		// Act
+		let addrs = ServerReadinessProbe::probe_addrs("[::]:8000").unwrap();
+
+		// Assert
+		assert_eq!(addrs, vec!["[::1]:8000".parse().unwrap()]);
 	}
 }

--- a/crates/reinhardt-commands/tests/fixtures/hot_reload_fixture/src/main.rs.tpl
+++ b/crates/reinhardt-commands/tests/fixtures/hot_reload_fixture/src/main.rs.tpl
@@ -1,10 +1,22 @@
 //! Test-fixture `manage` binary.
 //!
 //! Prints a marker line so test code can confirm which build of the binary
-//! is currently running, then sleeps for an hour so the hot-reload test can
-//! "kill and respawn" us at will.
+//! is currently running. By default it sleeps for an hour so the hot-reload
+//! test can "kill and respawn" us at will. When `HOT_RELOAD_LISTEN_ADDR` is
+//! set, it instead binds a tiny TCP listener at that address.
 
 fn main() {
 	println!("server marker: {{MARKER}}");
+	if let Ok(addr) = std::env::var("HOT_RELOAD_LISTEN_ADDR") {
+		let listener = std::net::TcpListener::bind(&addr).expect("bind hot-reload fixture listener");
+		for stream in listener.incoming() {
+			let mut stream = stream.expect("accept hot-reload fixture connection");
+			let _ = std::io::Write::write_all(
+				&mut stream,
+				b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK",
+			);
+		}
+		return;
+	}
 	std::thread::sleep(std::time::Duration::from_secs(3600));
 }

--- a/crates/reinhardt-commands/tests/runserver_hot_reload.rs
+++ b/crates/reinhardt-commands/tests/runserver_hot_reload.rs
@@ -40,7 +40,9 @@
 #![cfg(all(feature = "server", feature = "autoreload", feature = "pages"))]
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::time::Duration;
+use std::time::Instant;
 
 use reinhardt_commands::__hot_reload_test_api::{
 	DEBOUNCE_WINDOW, ServerRebuildOutcome, ServerRebuildPipeline, SourceRoots, WatcherConfig,
@@ -61,6 +63,7 @@ struct Fixture {
 	root: tempfile::TempDir,
 	#[allow(dead_code)] // Retained for diagnostic prints; surfaces in panic messages.
 	name: String,
+	manage_bin: Mutex<Option<PathBuf>>,
 }
 
 impl Fixture {
@@ -84,11 +87,55 @@ impl Fixture {
 		Self {
 			root,
 			name: crate_name.to_string(),
+			manage_bin: Mutex::new(None),
 		}
 	}
 
 	fn path(&self) -> &Path {
 		self.root.path()
+	}
+
+	/// Build the fixture `manage` binary and remember Cargo's executable path.
+	fn build_manage_bin(&self) -> PathBuf {
+		let output = std::process::Command::new("cargo")
+			.args(["build", "--bin", "manage", "--manifest-path"])
+			.arg(self.root.path().join("Cargo.toml"))
+			.args(["--message-format=json"])
+			.output()
+			.expect("invoke cargo build for fixture manage bin");
+		assert!(
+			output.status.success(),
+			"fixture manage bin must build: {}",
+			String::from_utf8_lossy(&output.stderr)
+		);
+
+		let executable = output
+			.stdout
+			.split(|b| *b == b'\n')
+			.filter_map(|line| serde_json::from_slice::<serde_json::Value>(line).ok())
+			.find_map(|value| {
+				let reason = value.get("reason").and_then(|v| v.as_str())?;
+				let target_name = value
+					.get("target")
+					.and_then(|v| v.get("name"))
+					.and_then(|v| v.as_str())?;
+				let executable = value.get("executable").and_then(|v| v.as_str())?;
+				(reason == "compiler-artifact" && target_name == "manage")
+					.then(|| PathBuf::from(executable))
+			})
+			.expect("cargo must report fixture manage executable path");
+
+		*self.manage_bin.lock().expect("manage_bin lock") = Some(executable.clone());
+		executable
+	}
+
+	/// Return the already-built fixture `manage` executable path.
+	fn manage_bin(&self) -> PathBuf {
+		self.manage_bin
+			.lock()
+			.expect("manage_bin lock")
+			.clone()
+			.expect("fixture manage bin must be built before use")
 	}
 
 	/// Rewrite the cdylib `{{MARKER}}` slot to the given value.
@@ -157,47 +204,47 @@ fn build_wasm(
 	WasmBuilder::new(config).build()
 }
 
-/// Resolve the cargo target directory cargo will use for `fixture`.
-///
-/// Honours user-level config redirections such as `build.build-dir` and
-/// `CARGO_TARGET_DIR`. Returned path is the *root* target dir; binaries
-/// land under `<root>/debug/`.
-fn fixture_target_dir(fixture: &Fixture) -> PathBuf {
-	let output = std::process::Command::new("cargo")
-		.args(["metadata", "--no-deps", "--format-version=1"])
-		.current_dir(fixture.path())
-		.output()
-		.expect("cargo metadata for fixture");
-	let json: serde_json::Value =
-		serde_json::from_slice(&output.stdout).expect("cargo metadata json parse");
-	let target_dir = json
-		.get("target_directory")
-		.and_then(|v| v.as_str())
-		.expect("cargo metadata.target_directory");
-	PathBuf::from(target_dir)
-}
-
-/// Path to the `manage` binary inside `fixture`'s effective target dir.
-fn fixture_manage_bin(fixture: &Fixture) -> PathBuf {
-	fixture_target_dir(fixture).join("debug").join("manage")
-}
-
 /// Spawn a long-running `manage` child for `fixture` after building it.
 /// The child sleeps for an hour and is killed by the test on drop.
 async fn spawn_long_running_child(fixture: &Fixture) -> tokio::process::Child {
-	// Pre-build the manage bin so the spawned child has something to exec.
-	let status = std::process::Command::new("cargo")
-		.args(["build", "--bin", "manage", "--manifest-path"])
-		.arg(fixture.path().join("Cargo.toml"))
-		.status()
-		.expect("invoke cargo build for fixture manage bin");
-	assert!(status.success(), "fixture manage bin must build");
-
-	let bin_path = fixture_manage_bin(fixture);
+	let bin_path = fixture.build_manage_bin();
 	tokio::process::Command::new(&bin_path)
 		.kill_on_drop(true)
 		.spawn()
 		.expect("spawn fixture manage bin")
+}
+
+/// Reserve a local TCP address that can be reused by the fixture child.
+fn reserve_loopback_addr() -> String {
+	let listener =
+		std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral loopback port");
+	let addr = listener.local_addr().expect("read local addr");
+	addr.to_string()
+}
+
+/// Spawn a fixture child that binds `addr` and responds to TCP/HTTP probes.
+async fn spawn_listening_child(fixture: &Fixture, addr: &str) -> tokio::process::Child {
+	let bin_path = fixture.build_manage_bin();
+	tokio::process::Command::new(&bin_path)
+		.kill_on_drop(true)
+		.env("HOT_RELOAD_LISTEN_ADDR", addr)
+		.spawn()
+		.expect("spawn fixture manage listener")
+}
+
+/// Poll until the fixture accepts TCP connections at `addr`.
+async fn assert_addr_reachable(addr: &str) {
+	let deadline = Instant::now() + Duration::from_secs(10);
+	loop {
+		if std::net::TcpStream::connect(addr).is_ok() {
+			return;
+		}
+		assert!(
+			Instant::now() < deadline,
+			"fixture must accept TCP connections at {addr}"
+		);
+		tokio::time::sleep(Duration::from_millis(50)).await;
+	}
 }
 
 /// Run `ServerRebuildPipeline::run` against `fixture` with a respawn closure
@@ -215,7 +262,7 @@ async fn run_server_pipeline(
 	std::env::set_current_dir(fixture.path()).expect("set fixture cwd");
 
 	let bin_name = "manage".to_string();
-	let bin_path = fixture_manage_bin(fixture);
+	let bin_path = fixture.manage_bin();
 	let respawn = move || -> std::io::Result<tokio::process::Child> {
 		tokio::process::Command::new(&bin_path)
 			.kill_on_drop(true)
@@ -223,6 +270,39 @@ async fn run_server_pipeline(
 	};
 
 	let (outcome, new_child) = ServerRebuildPipeline::run(&bin_name, current_child, respawn).await;
+
+	std::env::set_current_dir(&saved_cwd).expect("restore cwd");
+
+	if let Some(c) = new_child {
+		*current_child = c;
+	}
+	outcome
+}
+
+/// Run `ServerRebuildPipeline::run_with_readiness` against `fixture` with a
+/// respawn closure that boots a fresh listener at the same advertised address.
+async fn run_server_pipeline_with_readiness(
+	fixture: &Fixture,
+	current_child: &mut tokio::process::Child,
+	addr: &str,
+) -> ServerRebuildOutcome {
+	// `ServerRebuildPipeline::run_with_readiness` shells to `cargo build --bin
+	// <bin>` with the parent process's cwd. Mirror `run_server_pipeline`.
+	let saved_cwd = std::env::current_dir().expect("current dir");
+	std::env::set_current_dir(fixture.path()).expect("set fixture cwd");
+
+	let bin_name = "manage".to_string();
+	let bin_path = fixture.manage_bin();
+	let listen_addr = addr.to_string();
+	let respawn = move || -> std::io::Result<tokio::process::Child> {
+		tokio::process::Command::new(&bin_path)
+			.kill_on_drop(true)
+			.env("HOT_RELOAD_LISTEN_ADDR", &listen_addr)
+			.spawn()
+	};
+
+	let (outcome, new_child) =
+		ServerRebuildPipeline::run_with_readiness(&bin_name, current_child, respawn, addr).await;
 
 	std::env::set_current_dir(&saved_cwd).expect("restore cwd");
 
@@ -281,6 +361,34 @@ async fn hr_2_server_change_triggers_server_rebuild() {
 }
 
 // ---------------------------------------------------------------------------
+// HR-9: a successful server restart must leave the advertised address reachable.
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread")]
+#[serial(server_pipeline)]
+async fn hr_9_server_restart_accepts_connections_after_pipeline_ok() {
+	// Arrange
+	let fixture = Fixture::new("hr9_fixture", 900);
+	let addr = reserve_loopback_addr();
+	let mut child = spawn_listening_child(&fixture, &addr).await;
+	assert_addr_reachable(&addr).await;
+
+	// Act
+	let outcome = run_server_pipeline_with_readiness(&fixture, &mut child, &addr).await;
+
+	// Assert
+	match outcome {
+		ServerRebuildOutcome::Ok { duration } => {
+			assert!(duration > Duration::ZERO, "duration must be positive");
+		}
+		other => panic!("expected ServerRebuildOutcome::Ok, got {other:?}"),
+	}
+	assert_addr_reachable(&addr).await;
+
+	// Cleanup
+	let _ = child.kill().await;
+}
+
+// ---------------------------------------------------------------------------
 // HR-3: --no-wasm-rebuild flag plumbing skips the WASM pipeline.
 //
 // This test asserts the dispatch-time configuration the watcher reads:
@@ -294,6 +402,7 @@ async fn hr_3_no_wasm_rebuild_flag_skips_wasm_pipeline() {
 	// Arrange: a config with the flag set, plus an empty SourceRoots.
 	let config = WatcherConfig {
 		bin_name: "manage".to_string(),
+		address: "127.0.0.1:0".to_string(),
 		roots: SourceRoots {
 			src_dirs: Vec::new(),
 			manifest_files: Vec::new(),
@@ -481,7 +590,7 @@ async fn hr_7_run_watcher_processes_events() {
 	let saved_cwd = std::env::current_dir().expect("current dir");
 	std::env::set_current_dir(fixture.path()).expect("set fixture cwd");
 
-	let bin_path = fixture_manage_bin(&fixture);
+	let bin_path = fixture.manage_bin();
 	let respawn_count = Arc::new(AtomicUsize::new(0));
 	let respawn_count_for_closure = Arc::clone(&respawn_count);
 	let respawn = move || -> std::io::Result<tokio::process::Child> {
@@ -494,6 +603,7 @@ async fn hr_7_run_watcher_processes_events() {
 	let ctx = CommandContext::default();
 	let config = WatcherConfig {
 		bin_name: "manage".to_string(),
+		address: "127.0.0.1:0".to_string(),
 		roots: SourceRoots {
 			src_dirs: vec![fixture.path().join("src")],
 			manifest_files: vec![fixture.path().join("Cargo.toml")],


### PR DESCRIPTION
## Summary

This PR addresses:

- Waits for the respawned `runserver` child to accept TCP connections at the advertised address before logging hot-reload restart success.
- Keeps the respawned child owned by the watcher when readiness fails so a later reload or shutdown can replace or reap it.
- Adds regression coverage with a lightweight hot-reload fixture listener.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Hot-reload restart success could be reported immediately after child respawn, before confirming that the newly spawned development server was reachable at the advertised address. This made bind races, stale listeners, and failed post-respawn readiness invisible to the success path.

Fixes #5119

Related to: #4164

## How Was This Tested?

- [x] `cargo test -p reinhardt-commands --features server,autoreload,pages --test runserver_hot_reload hr_9_server_restart_accepts_connections_after_pipeline_ok`
- [x] `cargo test -p reinhardt-commands --features server,autoreload,pages server_rebuild_pipeline`
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`

## Performance Impact

This adds a short TCP readiness wait only after successful hot-reload server respawn. It does not affect normal request handling or `--noreload` serving.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5119
- Related to #4164

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The readiness probe rewrites unspecified bind addresses such as `0.0.0.0:8000` and `[::]:8000` to loopback for local probing.