### PR TITLE
docs: recommend Result return types for injectable factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,42 @@ async fn database_connection(
 with `#[inject]`.** There is no way to pass runtime arguments; factories only
 compose over other injectables.
 
+When a factory can fail, prefer returning `Result<T, E>` where `T` is the
+dependency you want and `E` is an error type used only by that factory. The DI
+registry key is the literal return type's `TypeId`, so `Result<T,
+DatabaseConnectionError>` and `Result<T, OtherFactoryError>` are distinct even
+when both factories produce the same successful `T`. Inject that dependency as
+`DependsResult<T, E>` (or `Depends<Result<T, E>>`) and handle the factory-local
+error at the call site.
+
+```rust
+use reinhardt::db::DatabaseConnection;
+use reinhardt::{get, Response, StatusCode, ViewResult};
+use reinhardt::di::{Depends, DependsResult, injectable_factory};
+
+#[derive(Debug)]
+struct DatabaseConnectionError;
+
+#[injectable_factory(scope = "singleton")]
+async fn database_connection_result(
+    #[inject] config: Depends<Config>,
+) -> Result<DatabaseConnection, DatabaseConnectionError> {
+    DatabaseConnection::connect(&config.database_url)
+        .await
+        .map_err(|_| DatabaseConnectionError)
+}
+
+#[get("/database/health", name = "database_health")]
+async fn database_health(
+    #[inject] db: DependsResult<DatabaseConnection, DatabaseConnectionError>,
+) -> ViewResult<Response> {
+    match db.into_inner() {
+        Ok(_) => Ok(Response::new(StatusCode::OK)),
+        Err(_) => Ok(Response::new(StatusCode::SERVICE_UNAVAILABLE)),
+    }
+}
+```
+
 **The pseudo orphan rule.** To prevent user factories from silently shadowing
 framework-owned types (e.g., `reinhardt_di::InjectionContext`, routers,
 middleware bindings), Reinhardt validates every registered factory at startup.

--- a/crates/reinhardt-di/README.md
+++ b/crates/reinhardt-di/README.md
@@ -510,6 +510,13 @@ async fn factory_function(#[inject] dep: Arc<Dependency>) -> ReturnType {
 }
 ```
 
+When initialization can fail, prefer `Result<T, E>` as the return type. `T` is
+the dependency you want, and `E` should be an error type used only by that
+factory. Reinhardt registers the literal return type, so `Result<T, E1>` and
+`Result<T, E2>` have different `TypeId` values even when `T` is the same.
+Consumers can request the factory output as `DependsResult<T, E>` or
+`Depends<Result<T, E>>`.
+
 **Attributes:**
 
 Scope is passed as a macro argument in key-value form.
@@ -524,13 +531,30 @@ supplied.
 **Example:**
 ```rust
 use reinhardt::di::macros::injectable_factory;
+use reinhardt::di::DependsResult;
+use reinhardt::{get, Response, StatusCode, ViewResult};
 use std::sync::Arc;
 
+#[derive(Debug)]
+struct DatabaseConnectionError;
+
 #[injectable_factory(scope = "singleton")]
-async fn create_database(#[inject] config: Arc<Config>) -> DatabaseConnection {
+async fn create_database(
+    #[inject] config: Arc<Config>,
+) -> Result<DatabaseConnection, DatabaseConnectionError> {
     DatabaseConnection::connect(&config.database_url)
         .await
-        .expect("Failed to connect to database")
+        .map_err(|_| DatabaseConnectionError)
+}
+
+#[get("/database/health", name = "database_health")]
+async fn database_health(
+    #[inject] db: DependsResult<DatabaseConnection, DatabaseConnectionError>,
+) -> ViewResult<Response> {
+    match db.into_inner() {
+        Ok(_) => Ok(Response::new(StatusCode::OK)),
+        Err(_) => Ok(Response::new(StatusCode::SERVICE_UNAVAILABLE)),
+    }
 }
 ```
 

--- a/crates/reinhardt-di/macros/src/lib.rs
+++ b/crates/reinhardt-di/macros/src/lib.rs
@@ -79,13 +79,29 @@ pub fn injectable(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// ```ignore
 /// use reinhardt_di::Depends;
+/// use reinhardt_di::DependsResult;
 /// use reinhardt_di_macros::injectable_factory;
 ///
+/// #[derive(Debug)]
+/// struct DatabaseConnectionError;
+///
 /// #[injectable_factory(scope = "singleton")]
-/// async fn create_database(#[inject] config: Depends<Config>) -> DatabaseConnection {
-///     DatabaseConnection::connect(&config.database_url).await.unwrap()
+/// async fn create_database(
+///     #[inject] config: Depends<Config>,
+/// ) -> Result<DatabaseConnection, DatabaseConnectionError> {
+///     DatabaseConnection::connect(&config.database_url)
+///         .await
+///         .map_err(|_| DatabaseConnectionError)
 /// }
+///
+/// type DatabaseDependency = DependsResult<DatabaseConnection, DatabaseConnectionError>;
 /// ```
+///
+/// When a factory can fail, prefer returning `Result<T, E>` where `T` is
+/// the desired dependency and `E` is an error type used only by that
+/// factory. The DI registry key is the literal return type's `TypeId`, so
+/// `Result<T, E1>` and `Result<T, E2>` are different keys even when `T` is
+/// the same.
 ///
 /// # Attributes
 ///


### PR DESCRIPTION
## Summary

This PR addresses:

- Documents the recommended `Result<T, E>` return pattern for fallible `#[injectable_factory]` registrations.
- Explains that factory-local error types make `Result<T, E>` produce distinct DI `TypeId` keys even when `T` is shared.
- Adds `DependsResult<T, E>` examples at the root README, `reinhardt-di` README, and macro rustdoc entry points.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- `DependsResult<T, E>` already documents that `Result<T, E>` keeps a distinct DI registry key from `T`, but users looking at `#[injectable_factory]` examples still saw direct `T` returns first.
- The factory API docs now recommend local error types for fallible factories, making the TypeId behavior visible where users choose the factory signature.

Related to: `DependsResult<T, E>` / `#[injectable_factory]` documentation consistency.

## How Was This Tested?

- `cargo fmt --check --package reinhardt-di-macros`
- `git diff --check`

`cargo check -p reinhardt-di-macros` was attempted but stopped after it remained blocked on the build directory lock held by existing unrelated `cargo make runserver` / `cargo run --bin manage migrate` processes.

## Performance Impact

- None. Documentation-only change.

## Screenshots

Not applicable. No UI changes.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [x] `low` - Minor fix or enhancement

---

**Additional Context:**

GitWhy context saved locally as `ctx_68ab3573`.

Codex-Generated-By: GPT-5