### PR TITLE
ci: create release announcement PRs for develop trains

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -462,16 +462,23 @@ jobs:
 
   release-announcement-pr:
     name: Create Release Announcement PR
-    # Announcements are produced only for releases originating from main.
-    # Pre-release tags from develop/** push are skipped by the branch guard
-    # below (github.ref == 'refs/heads/main'). The previous stable-only tag
-    # filter was removed in #4692 because the branch guard already enforces
-    # the intent of #4541, and the regex also prevented legitimate RC
-    # releases on main (e.g. v0.1.0-rc.30) from receiving announcements.
+    # Announcements are produced for release tags originating from stable main
+    # and active develop release trains. Other branch pushes are skipped by the
+    # branch guard below. The previous stable-only tag filter was removed in
+    # #4692 because branch origin is the intent boundary for announcements, and
+    # the regex also prevented legitimate RC releases from receiving
+    # announcements.
     if: |
       always() &&
       (
-        (github.event_name == 'push' && needs.release-plz-release.outputs.released == 'true' && github.ref == 'refs/heads/main') ||
+        (
+          github.event_name == 'push' &&
+          needs.release-plz-release.outputs.released == 'true' &&
+          (
+            github.ref == 'refs/heads/main' ||
+            startsWith(github.ref, 'refs/heads/develop/')
+          )
+        ) ||
         (github.event_name == 'workflow_dispatch')
       )
     needs: [release-plz-release]

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,6 +27,9 @@ on:
         default: release
   pull_request:
     types: [closed]
+    branches:
+      - main
+      - 'develop/**'
     paths: ['announcements/**']
 
 # Serialize per-base-branch but never cancel an in-flight release-plz run;
@@ -737,9 +740,16 @@ jobs:
 
   post-announcement:
     name: Post Announcement to Discussions
+    # Announcement PRs may be reviewed and merged on either stable main or an
+    # active develop release train. Keep this aligned with the pull_request
+    # trigger branch filter above.
     if: >
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
+      (
+        github.event.pull_request.base.ref == 'main' ||
+        startsWith(github.event.pull_request.base.ref, 'develop/')
+      ) &&
       contains(github.event.pull_request.labels.*.name, 'announcement')
     runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

This PR addresses:

- Allow `Create Release Announcement PR` to run for release publishes from `develop/*` branches, not only `main`.
- Allow `Post Announcement to Discussions` to run when announcement PRs are merged into `develop/*` branches.
- Update the release announcement workflow comments so they match the intended branch policy.

## Type of Change

- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The release-plz run for `develop/0.2.0` published `reinhardt-web@v0.2.0-rc.2`, but `Create Release Announcement PR` was skipped because the job-level condition required `github.ref == 'refs/heads/main'`.

Release trains use `develop/*` branches for prerelease publishing, so announcement PR automation should treat `refs/heads/develop/*` as valid release origins alongside `main`. The discussion-posting job also needs the same branch policy after the generated announcement PR is reviewed and merged.

Related to: #5140

## How Was This Tested?

- `git diff --check`
- `actionlint -ignore 'SC2094' -ignore 'SC2016' .github/workflows/release-plz.yml`

`actionlint .github/workflows/release-plz.yml` still reports pre-existing shellcheck info in unrelated script blocks (`SC2094` at line 138 and `SC2016` at line 559). Ignoring those existing info codes leaves the workflow clean.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to release PR #5140

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

GitWhy contexts: `ctx_fd8d6c76`, `ctx_71ae4c54`

Codex-Generated-By: GPT-5
