### PR TITLE
fix(examples): keep tutorial poll radio selection stable

### DIFF
--- a/examples/examples-tutorial-basis/Makefile.toml
+++ b/examples/examples-tutorial-basis/Makefile.toml
@@ -212,7 +212,7 @@ args = ["clean"]
 [tasks.wasm-test]
 description = "Run WASM tests in headless Chrome"
 command = "wasm-pack"
-args = ["test", "--headless", "--chrome", "--", "--no-default-features", "--features", "client-router"]
+args = ["test", "--headless", "--chrome", "--", "--no-default-features", "--features", "client-router,msw"]
 
 [tasks.wasm-compile-dev]
 description = "Compile WASM binary (debug mode)"

--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -151,8 +151,35 @@ pub fn polls_index() -> Page {
 	})(load_questions, new_question_href)
 }
 
-fn build_voting_form_page(qid: i64, choices: &[ChoiceInfo]) -> Page {
-	// Voting form via the `form!` macro.
+/// Poll detail page - Show question and voting form
+///
+/// Displays a question with its choices and allows the user to vote.
+/// Uses form! macro with Dynamic ChoiceField for declarative form handling.
+/// CSRF protection is automatically injected for POST method.
+pub fn polls_detail(question_id: i64) -> Page {
+	let qid = question_id;
+
+	// Load the question detail once on mount.
+	let load_detail = use_resource(
+		move || async move { get_question_detail(qid).await.map_err(|e| e.to_string()) },
+		(),
+	);
+
+	// Resolve the viewer so the render branch can hide owner-only controls
+	// (Edit / Delete / Add choice) for non-authors and unauthenticated
+	// viewers (issue #4703). `current_user` returns `Ok(None)` when the
+	// session has no authenticated user, so any non-`Some(Some(u))` shape
+	// disables the controls. Server-side `require_question_author` still
+	// rejects unauthorized mutations as defense in depth.
+	let load_current_user = use_resource(
+		|| async move { current_user().await.map_err(|e| e.to_string()) },
+		(),
+	);
+
+	// Voting form via the `form!` macro. Keep this instance stable for the
+	// lifetime of the route component; recreating it inside the reactive render
+	// path resets the selected radio value immediately after a change event
+	// (reinhardt-web#5169).
 	//
 	// - `server_fn: submit_vote` binds the form to the server function whose
 	//   typed signature is `(question_id, choice_id)`.
@@ -224,44 +251,12 @@ fn build_voting_form_page(qid: i64, choices: &[ChoiceInfo]) -> Page {
 			},
 		}
 	};
-
-	let choice_options: Vec<(String, String)> = choices
-		.iter()
-		.map(|c| (c.id.to_string(), c.choice_text.clone()))
-		.collect();
-	voting_form.choice_id_choices().set(choice_options);
-
-	voting_form.into_page()
-}
-
-/// Poll detail page - Show question and voting form
-///
-/// Displays a question with its choices and allows the user to vote.
-/// Uses form! macro with Dynamic ChoiceField for declarative form handling.
-/// CSRF protection is automatically injected for POST method.
-pub fn polls_detail(question_id: i64) -> Page {
-	let qid = question_id;
-
-	// Load the question detail once on mount.
-	let load_detail = use_resource(
-		move || async move { get_question_detail(qid).await.map_err(|e| e.to_string()) },
-		(),
-	);
-
-	// Resolve the viewer so the render branch can hide owner-only controls
-	// (Edit / Delete / Add choice) for non-authors and unauthenticated
-	// viewers (issue #4703). `current_user` returns `Ok(None)` when the
-	// session has no authenticated user, so any non-`Some(Some(u))` shape
-	// disables the controls. Server-side `require_question_author` still
-	// rejects unauthorized mutations as defense in depth.
-	let load_current_user = use_resource(
-		|| async move { current_user().await.map_err(|e| e.to_string()) },
-		(),
-	);
+	let choice_options_signal = voting_form.choice_id_choices().clone();
+	let voting_form_page = voting_form.into_page();
 
 	// Render reactively in the canonical shape (see module-level docs):
-	// outer `div` + single `watch{}` block + the `Action<..>` signal and
-	// the route id flow into `page!` as typed parameters.
+	// outer `div` + auto-wrapped body expression + the route resources,
+	// voting form state/view, and route id flow into `page!` as typed parameters.
 	//
 	// The `load_detail_signal.result().is_some()` branch renders either the
 	// voting form or an empty-state message, depending on whether the
@@ -270,7 +265,7 @@ pub fn polls_detail(question_id: i64) -> Page {
 	// `RadioSelect` group for choiceless questions, so any submit emitted
 	// `choice_id=""` and `submit_vote` rejected the request with the
 	// runtime `Invalid choice_id` application error.
-	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>, load_current_user: Resource<Option<UserInfo>, String>, question_id: i64| {
+	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>, load_current_user: Resource<Option<UserInfo>, String>, choice_options_signal: Signal<Vec<(String, String) >>, voting_form_page: Page, question_id: i64| {
 		div { {
 			match load_detail.get() {
 				ResourceState::Loading => page!(|| {
@@ -322,7 +317,11 @@ pub fn polls_detail(question_id: i64) -> Page {
 							}
 						})()
 					} else {
-						self::build_voting_form_page(question_id, &choices)
+						let choice_options: Vec<(String, String) > = choices.iter().map(|c|(c.id.to_string(), c.choice_text.clone())).collect();
+						if choice_options_signal.get_untracked() != choice_options {
+							choice_options_signal.set(choice_options);
+						}
+						voting_form_page.clone()
 					};
 					page!(|q: QuestionInfo, is_author: bool, choices_view: Page, question_id: i64| {
 						div {
@@ -369,7 +368,13 @@ pub fn polls_detail(question_id: i64) -> Page {
 				}
 			}
 		} }
-	})(load_detail, load_current_user, question_id)
+	})(
+		load_detail,
+		load_current_user,
+		choice_options_signal,
+		voting_form_page,
+		question_id,
+	)
 }
 
 /// Poll results page - Show voting results

--- a/examples/examples-tutorial-basis/tests/wasm/polls_mock_test.rs
+++ b/examples/examples-tutorial-basis/tests/wasm/polls_mock_test.rs
@@ -32,6 +32,7 @@ use reinhardt::pages::prelude::defer_yield;
 use reinhardt::pages::server_fn::ServerFnError;
 use reinhardt::pages::{Element as DomElement, document};
 use reinhardt::test::msw::MockServiceWorker;
+use wasm_bindgen::JsCast;
 
 // ============================================================================
 // Test Fixtures
@@ -447,6 +448,46 @@ async fn test_polls_detail_renders_loaded_choice_radios() {
 	worker
 		.calls_to_server_fn::<get_question_detail::marker>()
 		.assert_called();
+}
+
+/// Selecting a poll choice must survive the reactive re-render triggered by the
+/// form field signal update.
+#[wasm_bindgen_test]
+async fn test_polls_detail_keeps_clicked_radio_checked() {
+	let worker = MockServiceWorker::new();
+	worker.handle_server_fn::<get_question_detail::marker>(|_args| {
+		Ok((mock_question(), mock_choices()))
+	});
+	worker.handle_server_fn::<current_user::marker>(|_args| Ok(None));
+	worker.start().await;
+
+	let root = install_poll_test_root();
+	polls_detail(1).mount(&root).expect("mount polls detail");
+
+	let selector = "input[type='radio'][name='choice_id'][value='1']";
+	let input = await_selector(selector)
+		.await
+		.as_web_sys()
+		.clone()
+		.dyn_into::<web_sys::HtmlInputElement>()
+		.expect("choice radio should be an input element");
+	input.click();
+
+	defer_yield().await;
+	defer_yield().await;
+
+	let current_input = document()
+		.query_selector(selector)
+		.expect("query selected radio")
+		.expect("selected radio should still exist")
+		.as_web_sys()
+		.clone()
+		.dyn_into::<web_sys::HtmlInputElement>()
+		.expect("current choice radio should be an input element");
+	assert!(
+		current_input.checked(),
+		"clicked choice radio should stay checked after reactive update"
+	);
 }
 
 /// `polls_results(qid)` constructs cleanly with MSW intercepting

--- a/examples/examples-tutorial-basis/tests/wasm/users_mock_test.rs
+++ b/examples/examples-tutorial-basis/tests/wasm/users_mock_test.rs
@@ -139,13 +139,9 @@ async fn test_login_returns_mocked_user() {
 	});
 	worker.start().await;
 
-	let user = login(
-		"alice".to_string(),
-		"hunter2".to_string(),
-		String::new(), // csrf token; verified by middleware before handler
-	)
-	.await
-	.expect("login should succeed");
+	let user = login("alice".to_string(), "hunter2".to_string())
+		.await
+		.expect("login should succeed");
 
 	assert_eq!(user.id, mocked.id);
 	assert_eq!(user.username, "alice");
@@ -161,7 +157,7 @@ async fn test_login_surfaces_invalid_credentials() {
 	});
 	worker.start().await;
 
-	let err = login("alice".to_string(), "wrong".to_string(), String::new())
+	let err = login("alice".to_string(), "wrong".to_string())
 		.await
 		.expect_err("expected invalid-credentials error");
 	match err {
@@ -191,7 +187,6 @@ async fn test_register_returns_mocked_user() {
 		"alice".to_string(),
 		"hunter2".to_string(),
 		"hunter2".to_string(),
-		String::new(),
 	)
 	.await
 	.expect("register should succeed");
@@ -216,7 +211,6 @@ async fn test_register_surfaces_validation_error() {
 		"alice".to_string(),
 		"hunter2".to_string(),
 		"hunter2".to_string(),
-		String::new(),
 	)
 	.await
 	.expect_err("expected validation error");
@@ -238,7 +232,7 @@ async fn test_logout_succeeds() {
 	worker.handle_server_fn::<logout::marker>(|_args| Ok(()));
 	worker.start().await;
 
-	logout(String::new()).await.expect("logout should succeed");
+	logout().await.expect("logout should succeed");
 	worker
 		.calls_to_server_fn::<logout::marker>()
 		.assert_called();


### PR DESCRIPTION
## Summary

This PR addresses:

- Keeps the tutorial polls voting `form!` instance stable for the route component lifetime so radio selection survives `page!` auto-wrapped rerenders.
- Adds a WASM regression test for clicked poll radio checked state.
- Enables the example `wasm-test` task to compile the declared MSW mock test targets and refreshes stale users mock calls exposed by that stricter test path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The poll detail page was rebuilding the generated voting form inside the reactive render path. Selecting a radio updates the generated form signal, which can trigger rerendering and recreate the form with an empty `choice_id` value.

The fix preserves the intended `page!` v2 auto-wrap contract while moving the stateful form instance outside the reactive body.

Fixes #5169

Related to: #5167

## How Was This Tested?

- `git diff --check origin/develop/0.2.0...HEAD` - pass
- `cargo make fmt-check` in `examples/examples-tutorial-basis` - pass
- `cargo check` in `examples/examples-tutorial-basis` - pass
- `cargo make clippy-check` in `examples/examples-tutorial-basis` - pass
- `cargo make dev` in `examples/examples-tutorial-basis` - server started after WASM build, collectstatic, infra-up, and migrations; existing `LogoutForm` macro expansion warning is still present outside this PR's changed code path
- Browser verification at `http://127.0.0.1:8000/polls/1/`:
  - seeded local question with choices `C1` and `C2`
  - found 2 `choice_id` radio inputs
  - clicking `C1` left `choice_id=1` checked
  - re-querying the DOM and clicking `C2` left `choice_id=2` checked
- `cargo make wasm-test` in `examples/examples-tutorial-basis` - known to fail on existing framework/test-fixture issue #5167 after enabling the MSW test targets

## Performance Impact

Not performance-related.

## Screenshots

Not included. The change was verified through DOM checked-state inspection in the local browser.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-check`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5169
- Related to #5167

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The PR deliberately avoids manual top-level `Page::reactive` wrapping. `page!` remains responsible for auto-wrapping the reactive body.