### PR TITLE
fix(test): stabilize WASM MSW server_fn transport

### DIFF
--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -85,6 +85,7 @@ web-sys-full = [
 	"web-sys/HtmlDocument",
 	"web-sys/History",
 	"web-sys/Location",
+	"web-sys/Url",
 	"web-sys/WebSocket",
 	"web-sys/MessageEvent",
 	"web-sys/CloseEvent",
@@ -180,6 +181,7 @@ web-sys = { version = "0.3.83", features = [
 	# History API (for router)
 	"History",
 	"Location",
+	"Url",
 	# Storage API (for JWT token management)
 	"Storage",
 	# WebSocket API

--- a/crates/reinhardt-pages/src/server_fn.rs
+++ b/crates/reinhardt-pages/src/server_fn.rs
@@ -156,10 +156,11 @@ pub fn resolve_endpoint(path: &str) -> String {
 			let prefix = prefix.trim_end_matches('/');
 			format!("{}{}", prefix, path)
 		};
-		// reqwest requires absolute URLs; prepend the page origin for WASM.
+
 		web_sys::window()
-			.and_then(|w| w.location().origin().ok())
-			.map(|origin| format!("{}{}", origin, relative))
+			.and_then(|w| w.location().href().ok())
+			.and_then(|base| web_sys::Url::new_with_base(&relative, &base).ok())
+			.map(|url| url.href())
 			.unwrap_or(relative)
 	})
 }

--- a/crates/reinhardt-pages/tests/wasm/server_fn_wasm_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/server_fn_wasm_test.rs
@@ -12,6 +12,7 @@ use wasm_bindgen_test::*;
 wasm_bindgen_test_configure!(run_in_browser);
 
 use reinhardt_pages::csrf::{CSRF_HEADER_NAME, csrf_headers};
+use reinhardt_pages::server_fn::resolve_endpoint;
 use reinhardt_pages::testing::{cleanup_csrf_fixtures, setup_csrf_cookie, setup_csrf_meta_tag};
 
 // ============================================================================
@@ -133,6 +134,23 @@ fn test_csrf_headers_fallback_to_meta() {
 // ============================================================================
 // Server Function Client Stub Verification
 // ============================================================================
+
+#[wasm_bindgen_test]
+fn test_resolve_endpoint_absolutizes_wasm_path() {
+	let endpoint = resolve_endpoint("/api/server_fn/example");
+	assert!(
+		web_sys::Url::new(&endpoint).is_ok(),
+		"endpoint should be absolute for reqwest: {endpoint}"
+	);
+	assert!(
+		endpoint.starts_with("http://") || endpoint.starts_with("https://"),
+		"endpoint should include a browser HTTP origin: {endpoint}"
+	);
+	assert!(
+		endpoint.ends_with("/api/server_fn/example"),
+		"endpoint should preserve the server_fn path: {endpoint}"
+	);
+}
 
 /// Test that automatic CSRF injection produces valid header format
 ///

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -106,6 +106,7 @@ web-sys = { version = "0.3.83", optional = true, features = [
   "Attr",
   "HtmlDocument",
   "Location",
+  "Url",
   "History",
   "Headers",
   "Request",

--- a/crates/reinhardt-test/src/msw/handler.rs
+++ b/crates/reinhardt-test/src/msw/handler.rs
@@ -185,18 +185,7 @@ impl<S: MockableServerFn> ErasedHandler for ServerFnHandler<S> {
 					body,
 				})
 			}
-			Err(err) => {
-				let body = serde_json::to_string(&err).unwrap_or_default();
-				Some(MockResponse {
-					status: 500,
-					headers: {
-						let mut h = HashMap::new();
-						h.insert("content-type".to_string(), "application/json".to_string());
-						h
-					},
-					body,
-				})
-			}
+			Err(err) => Some(server_fn_error_response(err)),
 		}
 	}
 
@@ -269,18 +258,7 @@ impl<S: MockableServerFn> ErasedHandler for ServerFnContextHandler<S> {
 					body,
 				})
 			}
-			Err(err) => {
-				let body = serde_json::to_string(&err).unwrap_or_default();
-				Some(MockResponse {
-					status: 500,
-					headers: {
-						let mut h = HashMap::new();
-						h.insert("content-type".to_string(), "application/json".to_string());
-						h
-					},
-					body,
-				})
-			}
+			Err(err) => Some(server_fn_error_response(err)),
 		}
 	}
 
@@ -294,6 +272,22 @@ impl<S: MockableServerFn> ErasedHandler for ServerFnContextHandler<S> {
 
 	fn is_network_error(&self) -> bool {
 		false
+	}
+}
+
+fn server_fn_error_response(err: ServerFnError) -> MockResponse {
+	let (status, body) = match err {
+		ServerFnError::Server { status, message } => (status, message),
+		other => (500, other.message().to_string()),
+	};
+	MockResponse {
+		status,
+		headers: {
+			let mut h = HashMap::new();
+			h.insert("content-type".to_string(), "text/plain".to_string());
+			h
+		},
+		body,
 	}
 }
 

--- a/crates/reinhardt-test/src/msw/interceptor.rs
+++ b/crates/reinhardt-test/src/msw/interceptor.rs
@@ -45,7 +45,7 @@ mod wasm_impl {
 			let original = original_for_passthrough.clone();
 
 			wasm_bindgen_futures::future_to_promise(async move {
-				let intercepted = extract_request_info(&input, &init)?;
+				let intercepted = extract_request_info(&input, &init).await?;
 
 				// Record the request
 				recorder.borrow_mut().record(RecordedRequest {
@@ -79,7 +79,7 @@ mod wasm_impl {
 						if let Some(duration) = delay {
 							gloo_timers::future::sleep(duration).await;
 						}
-						build_js_response(&mock_response)
+						build_js_response(&mock_response, &intercepted.url)
 					}
 					Some((false, _, None)) => {
 						let error_response = MockResponse {
@@ -97,7 +97,7 @@ mod wasm_impl {
 								intercepted.method, intercepted.url
 							),
 						};
-						build_js_response(&error_response)
+						build_js_response(&error_response, &intercepted.url)
 					}
 					None => match policy {
 						UnhandledPolicy::Error => {
@@ -138,7 +138,7 @@ mod wasm_impl {
 			.expect("MSW: failed to restore window.fetch");
 	}
 
-	fn extract_request_info(
+	async fn extract_request_info(
 		input: &JsValue,
 		init: &JsValue,
 	) -> Result<InterceptedRequest, JsValue> {
@@ -152,7 +152,7 @@ mod wasm_impl {
 					.ok()
 					.and_then(|b| b.as_string())
 			} else {
-				None
+				read_request_body(&request).await?
 			};
 			(url, method, headers, body)
 		} else {
@@ -216,6 +216,12 @@ mod wasm_impl {
 		})
 	}
 
+	async fn read_request_body(request: &Request) -> Result<Option<String>, JsValue> {
+		let request = request.clone()?;
+		let text = JsFuture::from(request.text()?).await?;
+		Ok(text.as_string())
+	}
+
 	fn extract_headers(headers: &Headers) -> std::collections::HashMap<String, String> {
 		let mut map = std::collections::HashMap::new();
 		for name in [
@@ -232,7 +238,7 @@ mod wasm_impl {
 		map
 	}
 
-	fn build_js_response(mock: &MockResponse) -> Result<JsValue, JsValue> {
+	fn build_js_response(mock: &MockResponse, url: &str) -> Result<JsValue, JsValue> {
 		let init = ResponseInit::new();
 		init.set_status(mock.status);
 
@@ -251,7 +257,19 @@ mod wasm_impl {
 			&init,
 		)?;
 
+		define_response_url(&response, url)?;
+
 		Ok(response.into())
+	}
+
+	fn define_response_url(response: &Response, url: &str) -> Result<(), JsValue> {
+		let descriptor = js_sys::Object::new();
+		Reflect::set(&descriptor, &"value".into(), &JsValue::from_str(url))?;
+		Reflect::set(&descriptor, &"configurable".into(), &JsValue::TRUE)?;
+		Reflect::set(&descriptor, &"enumerable".into(), &JsValue::FALSE)?;
+		let response_obj: &js_sys::Object = response.unchecked_ref();
+		js_sys::Object::define_property(response_obj, &"url".into(), &descriptor);
+		Ok(())
 	}
 
 	async fn call_original_fetch(

--- a/crates/reinhardt-test/src/msw/worker.rs
+++ b/crates/reinhardt-test/src/msw/worker.rs
@@ -16,11 +16,43 @@ use super::interceptor;
 use super::matcher::UrlMatcher;
 use super::recorder::{CallQuery, RecordedRequest, RequestRecorder, ServerFnCallQuery};
 
-// Global guard to prevent multiple concurrent MockServiceWorker instances from
-// overriding `window.fetch`. Without this, a second worker would capture the
-// *already-overridden* fetch as its "original", leading to incorrect restoration.
+struct ActiveInterceptor {
+	owner_id: u64,
+	original_fetch: JsValue,
+	_closure: Closure<dyn FnMut(JsValue, JsValue) -> Promise>,
+}
+
 thread_local! {
-	static ACTIVE_WORKER_COUNT: Cell<u32> = const { Cell::new(0) };
+	static NEXT_WORKER_ID: Cell<u64> = const { Cell::new(1) };
+	static ACTIVE_INTERCEPTOR: RefCell<Option<ActiveInterceptor>> = const { RefCell::new(None) };
+}
+
+fn next_worker_id() -> u64 {
+	NEXT_WORKER_ID.with(|next| {
+		let id = next.get();
+		next.set(id.wrapping_add(1).max(1));
+		id
+	})
+}
+
+fn restore_active_interceptor() {
+	ACTIVE_INTERCEPTOR.with(|active| {
+		if let Some(active) = active.borrow_mut().take() {
+			interceptor::restore_fetch(&active.original_fetch);
+		}
+	});
+}
+
+fn restore_interceptor_if_owned(owner_id: u64) {
+	ACTIVE_INTERCEPTOR.with(|active| {
+		let should_restore = active
+			.borrow()
+			.as_ref()
+			.is_some_and(|active| active.owner_id == owner_id);
+		if should_restore && let Some(active) = active.borrow_mut().take() {
+			interceptor::restore_fetch(&active.original_fetch);
+		}
+	});
 }
 
 /// Policy for requests that don't match any registered handler.
@@ -62,14 +94,11 @@ impl From<&UnhandledPolicy> for interceptor::UnhandledPolicy {
 /// // worker.stop() called automatically on drop
 /// ```
 pub struct MockServiceWorker {
+	worker_id: u64,
 	handlers: Rc<RefCell<Vec<Box<dyn ErasedHandler>>>>,
 	recorder: Rc<RefCell<RequestRecorder>>,
 	unhandled_policy: UnhandledPolicy,
 	active: Cell<bool>,
-	original_fetch: RefCell<Option<JsValue>>,
-	#[allow(clippy::type_complexity)]
-	// Store the closure to prevent deallocation while the override is active
-	closure: RefCell<Option<Closure<dyn FnMut(JsValue, JsValue) -> Promise>>>,
 }
 
 impl MockServiceWorker {
@@ -81,12 +110,11 @@ impl MockServiceWorker {
 	/// Create a new worker with a custom unhandled request policy.
 	pub fn with_policy(policy: UnhandledPolicy) -> Self {
 		Self {
+			worker_id: next_worker_id(),
 			handlers: Rc::new(RefCell::new(Vec::new())),
 			recorder: Rc::new(RefCell::new(RequestRecorder::new())),
 			unhandled_policy: policy,
 			active: Cell::new(false),
-			original_fetch: RefCell::new(None),
-			closure: RefCell::new(None),
 		}
 	}
 
@@ -101,15 +129,7 @@ impl MockServiceWorker {
 			"MockServiceWorker: already started. Call stop() before starting again."
 		);
 
-		ACTIVE_WORKER_COUNT.with(|count| {
-			assert!(
-				count.get() == 0,
-				"MockServiceWorker: another worker is already active. \
-				 Only one MockServiceWorker can override window.fetch at a time. \
-				 Call stop() on the existing worker first."
-			);
-			count.set(count.get() + 1);
-		});
+		restore_active_interceptor();
 
 		let original = interceptor::save_original_fetch();
 		let closure = interceptor::install_fetch_override(
@@ -119,22 +139,21 @@ impl MockServiceWorker {
 			original.clone(),
 		);
 
-		*self.original_fetch.borrow_mut() = Some(original);
-		*self.closure.borrow_mut() = Some(closure);
+		ACTIVE_INTERCEPTOR.with(|active| {
+			*active.borrow_mut() = Some(ActiveInterceptor {
+				owner_id: self.worker_id,
+				original_fetch: original,
+				_closure: closure,
+			});
+		});
 		self.active.set(true);
 	}
 
 	/// Restore original `window.fetch` and clean up.
 	pub async fn stop(&self) {
 		if self.active.get() {
-			if let Some(original) = self.original_fetch.borrow().as_ref() {
-				interceptor::restore_fetch(original);
-			}
-			self.closure.borrow_mut().take();
+			restore_interceptor_if_owned(self.worker_id);
 			self.active.set(false);
-			ACTIVE_WORKER_COUNT.with(|count| {
-				count.set(count.get().saturating_sub(1));
-			});
 		}
 	}
 
@@ -212,12 +231,7 @@ impl MockServiceWorker {
 impl Drop for MockServiceWorker {
 	fn drop(&mut self) {
 		if self.active.get() {
-			if let Some(original) = self.original_fetch.borrow().as_ref() {
-				interceptor::restore_fetch(original);
-			}
-			ACTIVE_WORKER_COUNT.with(|count| {
-				count.set(count.get().saturating_sub(1));
-			});
+			restore_interceptor_if_owned(self.worker_id);
 		}
 	}
 }

--- a/crates/reinhardt-test/tests/wasm_msw.rs
+++ b/crates/reinhardt-test/tests/wasm_msw.rs
@@ -12,6 +12,7 @@ use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 use web_sys::{RequestInit, Response};
 
+use reinhardt_pages::server_fn::{ServerFnError, ServerFnMetadata, server_fn};
 use reinhardt_test::msw::MockResponse;
 use reinhardt_test::msw::MockServiceWorker;
 use reinhardt_test::msw::UnhandledPolicy;
@@ -19,9 +20,14 @@ use reinhardt_test::msw::rest;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
+#[server_fn]
+async fn msw_echo(value: String) -> Result<String, ServerFnError> {
+	Ok(value)
+}
+
 async fn do_fetch(url: &str, method: &str, body: Option<&str>) -> (u16, String) {
 	let window = web_sys::window().unwrap();
-	let mut opts = RequestInit::new();
+	let opts = RequestInit::new();
 	opts.set_method(method);
 	if let Some(b) = body {
 		opts.set_body(&JsValue::from_str(b));
@@ -42,7 +48,7 @@ async fn do_fetch(url: &str, method: &str, body: Option<&str>) -> (u16, String) 
 
 async fn do_fetch_expect_error(url: &str, method: &str) {
 	let window = web_sys::window().unwrap();
-	let mut opts = RequestInit::new();
+	let opts = RequestInit::new();
 	opts.set_method(method);
 	let result = JsFuture::from(window.fetch_with_str_and_init(url, &opts)).await;
 	assert!(
@@ -181,6 +187,69 @@ async fn msw_integration_tests() {
 
 		let (status, _) = do_fetch("/api/once", "GET", None).await;
 		assert_eq!(status, 200);
+		worker.stop().await;
+	}
+
+	// === Scenario 10: Starting a new worker recovers stale global fetch state ===
+	{
+		let stale = MockServiceWorker::new();
+		stale.handle(rest::get("/api/stale").respond(MockResponse::text("stale")));
+		stale.start().await;
+
+		let replacement = MockServiceWorker::new();
+		replacement.handle(rest::get("/api/recovered").respond(MockResponse::text("recovered")));
+		replacement.start().await;
+
+		let (status, body) = do_fetch("/api/recovered", "GET", None).await;
+		assert_eq!(status, 200);
+		assert_eq!(body, "recovered");
+		replacement.stop().await;
+	}
+
+	// === Scenario 11: Generated server_fn clients reach MSW with absolute URLs ===
+	{
+		let worker = MockServiceWorker::new();
+		worker.handle_server_fn::<msw_echo::marker>(|args| Ok(args.value));
+		worker.start().await;
+
+		let endpoint = reinhardt_pages::server_fn::resolve_endpoint(
+			<msw_echo::marker as ServerFnMetadata>::PATH,
+		);
+		assert!(
+			web_sys::Url::new(&endpoint).is_ok(),
+			"resolved server_fn endpoint should be absolute: {endpoint}"
+		);
+		assert!(
+			endpoint.starts_with("http://") || endpoint.starts_with("https://"),
+			"resolved server_fn endpoint should include browser HTTP origin: {endpoint}"
+		);
+
+		let manual_response = reinhardt_pages::__private::reqwest::Client::new()
+			.post(&endpoint)
+			.header("Content-Type", "application/json")
+			.body(r#"{"value":"manual"}"#)
+			.send()
+			.await
+			.expect("manual reqwest POST should accept resolved endpoint");
+		assert!(manual_response.status().is_success());
+
+		let response = msw_echo("pong".to_string())
+			.await
+			.expect("server_fn should be handled by MSW");
+		assert_eq!(response, "pong");
+
+		let calls = worker.all_calls();
+		assert_eq!(calls.len(), 2);
+		assert!(
+			calls[0]
+				.url
+				.ends_with(<msw_echo::marker as ServerFnMetadata>::PATH)
+		);
+		assert!(
+			web_sys::Url::new(&calls[0].url).is_ok(),
+			"recorded server_fn URL should be absolute: {}",
+			calls[0].url
+		);
 		worker.stop().await;
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Resolves WASM server_fn endpoints against the browser document URL so generated clients pass absolute URLs to reqwest.
- Makes the MSW fetch interceptor compatible with reqwest's WASM backend by preserving `Response.url` and reading bodies from `fetch(Request)` inputs.
- Restores stale MSW fetch overrides before installing a replacement worker.
- Maps mocked `ServerFnError::Server` values to HTTP status plus text body, matching generated client error handling.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- The tutorial-basis WASM MSW tests hit `RelativeUrlWithoutBase` when generated server_fn clients used the MSW harness.
- The failure belonged in the shared WASM transport/MSW test support boundary, not in the example application.

Fixes #5167

Related to: #5169

## How Was This Tested?

- `cargo fmt --check`
- `cargo check -p reinhardt-pages -p reinhardt-test --all-features`
- `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER="$HOME/.cargo/bin/wasm-bindgen-test-runner" CHROMEDRIVER="/opt/homebrew/bin/chromedriver" WASM_BINDGEN_TEST_ONLY_WEB=1 cargo test -p reinhardt-pages --target wasm32-unknown-unknown --test server_fn_wasm_test test_resolve_endpoint_absolutizes_wasm_path`
- `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER="$HOME/.cargo/bin/wasm-bindgen-test-runner" CHROMEDRIVER="/opt/homebrew/bin/chromedriver" WASM_BINDGEN_TEST_ONLY_WEB=1 cargo test -p reinhardt-test --target wasm32-unknown-unknown --features msw --test wasm_msw msw_integration_tests`
- From `examples/examples-tutorial-basis`: `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER="$HOME/.cargo/bin/wasm-bindgen-test-runner" CHROMEDRIVER="/opt/homebrew/bin/chromedriver" WASM_BINDGEN_TEST_ONLY_WEB=1 cargo test --target wasm32-unknown-unknown --no-default-features --features client-router,msw --test polls_mock_test test_get_questions_returns_mocked_list`
- From `examples/examples-tutorial-basis`: focused error tests for `test_get_questions_surfaces_server_error`, `test_get_question_detail_surfaces_not_found`, and `test_vote_surfaces_invalid_choice`

Full `polls_mock_test` now passes 28/30. Remaining failures are existing UI assertions outside this transport fix:

- `test_polls_index_has_container`: expected Bootstrap container class
- `test_polls_detail_renders_loaded_choice_radios`: timed out waiting for radio input selector

## Performance Impact

- Not performance-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5167
- Related to #5169

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [x] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- Local GitWhy context saved as `ctx_6d17303d`; cloud sync was skipped because the connected repo limit has been reached.