### PR TITLE
fix(staticfiles): inject wasm loader for directory index

### DIFF
--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -468,6 +468,17 @@ impl StaticFilesMiddleware {
 	async fn try_serve(&self, path: &str) -> Option<Response> {
 		match self.handler.serve(path).await {
 			Ok(file) => {
+				// Refs #5186: directory index responses must receive the same
+				// WASM bootstrap as SPA fallback responses.
+				if file
+					.path
+					.file_name()
+					.and_then(|n| n.to_str())
+					.is_some_and(|name| name == "index.html")
+				{
+					return self.build_spa_response(file.content, &file.path);
+				}
+
 				let mut response = Response::ok()
 					.with_header("Content-Type", &file.mime_type)
 					.with_header("ETag", &file.etag());
@@ -1500,6 +1511,33 @@ mod tests {
 		assert!(body.contains("await import('/my_app.js')"));
 		assert!(body.contains("await init({ module_or_path: '/my_app_bg.wasm' })"));
 		assert!(body.contains("</body></html>"));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_try_serve_directory_index_auto_injects_wasm() {
+		// Arrange
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(
+			dir.path().join("index.html"),
+			"<html><body><h1>App</h1></body></html>",
+		)
+		.unwrap();
+		std::fs::write(dir.path().join("my_app.js"), "// js").unwrap();
+		std::fs::write(dir.path().join("my_app_bg.wasm"), [0u8; 4]).unwrap();
+
+		let config = StaticFilesConfig::new(dir.path());
+		let middleware = StaticFilesMiddleware::new(config);
+
+		// Act
+		let response = middleware.try_serve("/").await;
+
+		// Assert
+		let response = response.expect("directory index should be served");
+		let body = std::str::from_utf8(&response.body).unwrap();
+		assert!(body.contains("<!-- Reinhardt WASM Auto-Loader -->"));
+		assert!(body.contains("await import('/my_app.js')"));
+		assert!(body.contains("await init({ module_or_path: '/my_app_bg.wasm' })"));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -470,11 +470,12 @@ impl StaticFilesMiddleware {
 			Ok(file) => {
 				// Refs #5186: directory index responses must receive the same
 				// WASM bootstrap as SPA fallback responses.
-				if file
-					.path
-					.file_name()
-					.and_then(|n| n.to_str())
-					.is_some_and(|name| name == "index.html")
+				if self.config.spa_mode
+					&& file
+						.path
+						.file_name()
+						.and_then(|n| n.to_str())
+						.is_some_and(|name| name == "index.html")
 				{
 					return self.build_spa_response(file.content, &file.path);
 				}
@@ -1538,6 +1539,29 @@ mod tests {
 		assert!(body.contains("<!-- Reinhardt WASM Auto-Loader -->"));
 		assert!(body.contains("await import('/my_app.js')"));
 		assert!(body.contains("await init({ module_or_path: '/my_app_bg.wasm' })"));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_try_serve_directory_index_respects_spa_mode_false() {
+		// Arrange
+		let dir = tempfile::tempdir().unwrap();
+		let html = "<html><body><h1>App</h1></body></html>";
+		std::fs::write(dir.path().join("index.html"), html).unwrap();
+		std::fs::write(dir.path().join("my_app.js"), "// js").unwrap();
+		std::fs::write(dir.path().join("my_app_bg.wasm"), [0u8; 4]).unwrap();
+
+		let config = StaticFilesConfig::new(dir.path()).spa_mode(false);
+		let middleware = StaticFilesMiddleware::new(config);
+
+		// Act
+		let response = middleware.try_serve("/").await;
+
+		// Assert
+		let response = response.expect("directory index should be served");
+		let body = std::str::from_utf8(&response.body).unwrap();
+		assert!(!body.contains("Reinhardt WASM Auto-Loader"));
+		assert_eq!(body, html);
 	}
 
 	#[rstest]


### PR DESCRIPTION
## Summary

This PR addresses:

- Direct `index.html` static responses now use the same WASM auto-loader injection path as SPA fallback responses.
- Added a regression test for `/` resolving to a directory `index.html` with a wasm-bindgen JS/WASM pair.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`StaticFilesMiddleware` injected the Reinhardt WASM auto-loader only through `serve_spa_fallback()`. When `/` resolved directly to a directory `index.html`, `try_serve()` returned the raw loading shell and the browser never requested the wasm-bindgen JS/WASM bundle.

Fixes #5186

Related to: kent8192/reinhardt-cloud#646

## How Was This Tested?

- `cargo fmt --check --package reinhardt-utils`
- `cargo test -p reinhardt-utils staticfiles::middleware --lib`
- `cargo test -p reinhardt-utils --lib`
- `cargo test -p reinhardt-utils staticfiles::middleware::tests::test_try_serve_directory_index_auto_injects_wasm --lib`

## Performance Impact

Not performance-related. Only resolved `index.html` responses are routed through the existing SPA response builder.

## Screenshots

Not applicable; this is static middleware bootstrap behavior.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5186
- Related to kent8192/reinhardt-cloud#646

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [x] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The deployed Reinhardt Cloud dashboard had valid `reinhardt_cloud_dashboard.js` and `reinhardt_cloud_dashboard_bg.wasm` files in the static root, but `/` returned the raw loading shell because directory index serving bypassed SPA fallback injection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of directory index responses to include WASM auto-loader injection and consistent cache header generation, matching behavior with SPA fallbacks.

* **Tests**
  * Added regression test ensuring directory index requests properly handle WASM loader injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->