### PR TITLE
fix(staticfiles): inject wasm loader without spa mode

### DIFF
--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -470,12 +470,11 @@ impl StaticFilesMiddleware {
 			Ok(file) => {
 				// Refs #5186: directory index responses must receive the same
 				// WASM bootstrap as SPA fallback responses.
-				if self.config.spa_mode
-					&& file
-						.path
-						.file_name()
-						.and_then(|n| n.to_str())
-						.is_some_and(|name| name == "index.html")
+				if file
+					.path
+					.file_name()
+					.and_then(|n| n.to_str())
+					.is_some_and(|name| name == "index.html")
 				{
 					return self.build_spa_response(file.content, &file.path);
 				}
@@ -1543,7 +1542,7 @@ mod tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_try_serve_directory_index_respects_spa_mode_false() {
+	async fn test_try_serve_directory_index_auto_injects_wasm_without_spa_mode() {
 		// Arrange
 		let dir = tempfile::tempdir().unwrap();
 		let html = "<html><body><h1>App</h1></body></html>";
@@ -1560,8 +1559,11 @@ mod tests {
 		// Assert
 		let response = response.expect("directory index should be served");
 		let body = std::str::from_utf8(&response.body).unwrap();
-		assert!(!body.contains("Reinhardt WASM Auto-Loader"));
-		assert_eq!(body, html);
+		assert!(body.contains("<!-- Reinhardt WASM Auto-Loader -->"));
+		assert!(body.contains("await import('/my_app.js')"));
+		assert!(body.contains("await init({ module_or_path: '/my_app_bg.wasm' })"));
+		assert!(body.contains("<h1>App</h1>"));
+		assert!(body.contains("</body></html>"));
 	}
 
 	#[rstest]


### PR DESCRIPTION
## Summary

This PR addresses:

- Direct directory `index.html` responses now receive the WASM auto-loader even when SPA fallback routing is disabled.
- The regression test now covers `spa_mode(false)` with a valid wasm-bindgen JS/WASM pair.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes functional behavior nor adds functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #5187 did not improve the observed loading-shell symptom because the follow-up `spa_mode` guard made direct directory index injection depend on fallback routing. That couples two separate concerns:

- `spa_mode`: whether a missing static path falls back to `index.html`.
- `auto_inject_wasm`: whether a served `index.html` should get the WASM bootstrap when a bundle is detected.

Apps can disable fallback routing while still serving `/` as a concrete directory index. In that case, the raw loading shell still needs the WASM auto-loader.

Fixes #5186

Related to: #5187
Related to: kent8192/reinhardt-cloud#646

## How Was This Tested?

- `cargo fmt --check --package reinhardt-utils`
- `cargo test -p reinhardt-utils staticfiles::middleware --lib`
- `cargo test -p reinhardt-utils --lib`

## Performance Impact

Not performance-related. Only direct `index.html` static responses use the existing SPA response builder when a WASM entry is detected.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5186
- Related to #5187
- Related to kent8192/reinhardt-cloud#646

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `http` - HTTP layer, handlers, middleware

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

GitWhy context: `ctx_3170e0fe`
