### PR TITLE
fix(conf): support secret source maps

### DIFF
--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -134,6 +134,31 @@ port = "${REINHARDT_DB_PORT:-5432}"
 db_password = "${DB_PASSWORD:?Set DB_PASSWORD via direnv or 1Password CLI}"
 ```
 
+Secret fields backed by `SecretString` also accept explicit source maps:
+
+```toml
+[database.default]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "app"
+user = "app"
+password = { env = "DATABASE_PASSWORD" }
+
+[database.replica]
+engine = "postgresql"
+host = "replica.internal"
+port = 5432
+name = "app"
+user = "readonly"
+password = { file = "/run/secrets/db-replica-password" }
+```
+
+Use `{ secret = "literal" }` for inline values, `{ env = "NAME" }` for process
+environment variables, and `{ file = "path" }` for file-backed secrets. File
+sources trim trailing CR/LF so Docker/Kubernetes-style secret files work without
+leaking the final newline into connection strings.
+
 #### Behavior Notes
 
 - **Strict empty handling**: an empty environment-variable value is treated identically

--- a/crates/reinhardt-conf/src/settings/database_config.rs
+++ b/crates/reinhardt-conf/src/settings/database_config.rs
@@ -555,6 +555,7 @@ mod tests {
 		std::fs::write(temp_file.path(), "replica-secret\n").unwrap();
 		// SAFETY: This test is serialized with other environment-mutating tests.
 		unsafe { std::env::set_var("REINHARDT_DEFAULT_DB_PASSWORD", "default-secret") };
+		let file_path = temp_file.path().to_string_lossy().replace('\\', "\\\\");
 		let toml = format!(
 			r#"
 [default]
@@ -573,7 +574,7 @@ name = "app"
 user = "readonly"
 password = {{ file = "{}" }}
 "#,
-			temp_file.path().display()
+			file_path
 		);
 
 		let databases: HashMap<String, DatabaseConfig> = toml::from_str(&toml).unwrap();

--- a/crates/reinhardt-conf/src/settings/database_config.rs
+++ b/crates/reinhardt-conf/src/settings/database_config.rs
@@ -377,6 +377,7 @@ pub fn validate_database_url_scheme(url: &str) -> Result<(), String> {
 mod tests {
 	use super::*;
 	use rstest::rstest;
+	use serial_test::serial;
 
 	#[rstest]
 	fn test_settings_db_config_sqlite() {
@@ -545,6 +546,54 @@ mod tests {
 		assert_eq!(password.expose_secret(), "my-secret-pw");
 		// Display should not reveal the password
 		assert_eq!(format!("{}", password), "[REDACTED]");
+	}
+
+	#[rstest]
+	#[serial(env)]
+	fn test_database_password_deserializes_from_secret_sources() {
+		let temp_file = tempfile::NamedTempFile::new().unwrap();
+		std::fs::write(temp_file.path(), "replica-secret\n").unwrap();
+		// SAFETY: This test is serialized with other environment-mutating tests.
+		unsafe { std::env::set_var("REINHARDT_DEFAULT_DB_PASSWORD", "default-secret") };
+		let toml = format!(
+			r#"
+[default]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "app"
+user = "app"
+password = {{ env = "REINHARDT_DEFAULT_DB_PASSWORD" }}
+
+[replica]
+engine = "postgresql"
+host = "replica.internal"
+port = 5432
+name = "app"
+user = "readonly"
+password = {{ file = "{}" }}
+"#,
+			temp_file.path().display()
+		);
+
+		let databases: HashMap<String, DatabaseConfig> = toml::from_str(&toml).unwrap();
+
+		assert_eq!(
+			databases["default"]
+				.password
+				.as_ref()
+				.map(|password| password.expose_secret()),
+			Some("default-secret")
+		);
+		assert_eq!(
+			databases["replica"]
+				.password
+				.as_ref()
+				.map(|password| password.expose_secret()),
+			Some("replica-secret")
+		);
+		// SAFETY: This test is serialized with other environment-mutating tests.
+		unsafe { std::env::remove_var("REINHARDT_DEFAULT_DB_PASSWORD") };
 	}
 
 	#[rstest]

--- a/crates/reinhardt-conf/src/settings/secret_types.rs
+++ b/crates/reinhardt-conf/src/settings/secret_types.rs
@@ -394,7 +394,10 @@ mod tests {
 	fn test_secret_string_deserializes_from_file_source() {
 		let temp_file = tempfile::NamedTempFile::new().unwrap();
 		std::fs::write(temp_file.path(), "file-secret\n").unwrap();
-		let json = format!(r#"{{"file":"{}"}}"#, temp_file.path().display());
+		let json = serde_json::json!({
+			"file": temp_file.path().to_string_lossy(),
+		})
+		.to_string();
 
 		let deserialized: SecretString = serde_json::from_str(&json).unwrap();
 

--- a/crates/reinhardt-conf/src/settings/secret_types.rs
+++ b/crates/reinhardt-conf/src/settings/secret_types.rs
@@ -25,7 +25,7 @@ impl<'de> Deserialize<'de> for SecretString {
 			type Value = SecretString;
 
 			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-				formatter.write_str("a string or a map with a 'secret' key")
+				formatter.write_str("a string or a map with a 'secret', 'env', or 'file' key")
 			}
 
 			fn visit_str<E>(self, value: &str) -> Result<SecretString, E>
@@ -43,20 +43,77 @@ impl<'de> Deserialize<'de> for SecretString {
 			{
 				let mut secret = None;
 				while let Some(key) = map.next_key::<String>()? {
-					if key == "secret" {
-						secret = Some(map.next_value::<String>()?);
-					} else {
-						let _ = map.next_value::<serde::de::IgnoredAny>()?;
+					match key.as_str() {
+						"secret" => {
+							set_secret_source(&mut secret, map.next_value::<String>()?)?;
+						}
+						"env" => {
+							let name = map.next_value::<String>()?;
+							ensure_no_secret_source(&secret)?;
+							let value = std::env::var(&name).map_err(|error| {
+								serde::de::Error::custom(format!(
+									"failed to read secret from environment variable `{name}`: {error}"
+								))
+							})?;
+							set_secret_source(&mut secret, value)?;
+						}
+						"file" => {
+							let path = map.next_value::<String>()?;
+							ensure_no_secret_source(&secret)?;
+							let value = std::fs::read_to_string(&path).map_err(|error| {
+								serde::de::Error::custom(format!(
+									"failed to read secret from file `{path}`: {error}"
+								))
+							})?;
+							set_secret_source(&mut secret, trim_secret_file_newline(value))?;
+						}
+						_ => {
+							let _ = map.next_value::<serde::de::IgnoredAny>()?;
+						}
 					}
 				}
 				secret
 					.map(|s| SecretString { inner: s })
-					.ok_or_else(|| serde::de::Error::missing_field("secret"))
+					.ok_or_else(|| serde::de::Error::missing_field("secret, env, or file"))
 			}
 		}
 
 		deserializer.deserialize_any(SecretStringVisitor)
 	}
+}
+
+fn ensure_no_secret_source<E>(secret: &Option<String>) -> Result<(), E>
+where
+	E: serde::de::Error,
+{
+	if secret.is_some() {
+		return Err(duplicate_secret_source_error());
+	}
+	Ok(())
+}
+
+fn set_secret_source<E>(secret: &mut Option<String>, value: String) -> Result<(), E>
+where
+	E: serde::de::Error,
+{
+	if secret.replace(value).is_some() {
+		return Err(duplicate_secret_source_error());
+	}
+	Ok(())
+}
+
+fn duplicate_secret_source_error<E>() -> E
+where
+	E: serde::de::Error,
+{
+	E::custom("secret source maps must contain only one of `secret`, `env`, or `file`")
+}
+
+fn trim_secret_file_newline(mut value: String) -> String {
+	while value.ends_with('\n') || value.ends_with('\r') {
+		value.pop();
+	}
+	value
 }
 
 impl Serialize for SecretString {
@@ -216,6 +273,7 @@ impl<T: Zeroize + AsRef<[u8]> + Eq> Eq for SecretValue<T> {}
 mod tests {
 	use super::*;
 	use rstest::rstest;
+	use serial_test::serial;
 
 	#[rstest]
 	fn test_secret_string_debug() {
@@ -316,6 +374,44 @@ mod tests {
 		let json = r#"{"secret":"test-secret"}"#;
 		let deserialized: SecretString = serde_json::from_str(json).unwrap();
 		assert_eq!(deserialized.expose_secret(), "test-secret");
+	}
+
+	#[rstest]
+	#[serial(env)]
+	fn test_secret_string_deserializes_from_env_source() {
+		// SAFETY: This test is serialized with other environment-mutating tests.
+		unsafe { std::env::set_var("REINHARDT_TEST_SECRET_SOURCE", "env-secret") };
+		let json = r#"{"env":"REINHARDT_TEST_SECRET_SOURCE"}"#;
+
+		let deserialized: SecretString = serde_json::from_str(json).unwrap();
+
+		assert_eq!(deserialized.expose_secret(), "env-secret");
+		// SAFETY: This test is serialized with other environment-mutating tests.
+		unsafe { std::env::remove_var("REINHARDT_TEST_SECRET_SOURCE") };
+	}
+
+	#[rstest]
+	fn test_secret_string_deserializes_from_file_source() {
+		let temp_file = tempfile::NamedTempFile::new().unwrap();
+		std::fs::write(temp_file.path(), "file-secret\n").unwrap();
+		let json = format!(r#"{{"file":"{}"}}"#, temp_file.path().display());
+
+		let deserialized: SecretString = serde_json::from_str(&json).unwrap();
+
+		assert_eq!(deserialized.expose_secret(), "file-secret");
+	}
+
+	#[rstest]
+	fn test_secret_string_rejects_multiple_sources() {
+		let json = r#"{"secret":"inline","env":"IGNORED"}"#;
+
+		let error = serde_json::from_str::<SecretString>(json).unwrap_err();
+
+		assert!(
+			error
+				.to_string()
+				.contains("must contain only one of `secret`, `env`, or `file`")
+		);
 	}
 
 	#[rstest]


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds `SecretString` deserialization support for `{ env = "NAME" }` and `{ file = "path" }` source maps.
- Preserves existing plain string and `{ secret = "literal" }` formats while rejecting ambiguous maps with multiple sources.
- Adds database password TOML regression coverage for env/file-backed secrets and documents the syntax.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #5182 added typed schema refs for secret fields, but the runtime `SecretString` deserializer still only accepted plain strings and `{ secret = "..." }`. TOML like `password = { env = "DATABASE_PASSWORD" }` or `password = { file = "/run/secrets/db-replica-password" }` therefore failed during config deserialization instead of loading the secret source.

Fixes: none

Related to: #5182

## How Was This Tested?

- `cargo fmt --check`
- `cargo test -p reinhardt-conf settings::secret_types::tests`
- `cargo test -p reinhardt-conf settings::database_config::tests::test_database_password_deserializes_from_secret_sources`
- `cargo check -p reinhardt-conf --all-features`
- `cargo clippy -p reinhardt-conf --all-features -- -D warnings`
- `git diff --check`

## Performance Impact

- Not performance-related.

## Screenshots

- Not UI-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #5182

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- File-backed secrets trim trailing CR/LF so Docker/Kubernetes-style secret files do not leak the final newline into connection strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for environment variable and file-backed secrets in TOML configuration for database credentials.

* **Documentation**
  * Updated documentation with examples showing how to configure per-database secrets using environment variables and file sources. File sources automatically trim trailing newlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->