### PR TITLE
feat: expose social auth and runserver facade features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ streaming = ["dep:reinhardt-streaming", "reinhardt-streaming/kafka"]
 server = ["reinhardt-server"]
 commands = ["reinhardt-commands", "reinhardt-commands/migrations"]
 commands-autoreload = ["commands", "reinhardt-commands/autoreload"]
+commands-server = ["commands", "reinhardt-commands/server"]
 introspect = ["reinhardt-commands/introspect"]
 
 # Parent crate features (new module structure)
@@ -286,6 +287,7 @@ test-utils = ["reinhardt-test", "reinhardt-test/testcontainers", "database"]
 auth-jwt = ["auth", "reinhardt-auth/jwt"]
 auth-session = ["auth", "reinhardt-auth/sessions", "sessions"]
 auth-oauth = ["auth", "reinhardt-auth/oauth"]
+auth-social = ["auth-oauth", "reinhardt-auth/social"]
 auth-token = ["auth", "reinhardt-auth/token"]
 
 # Fine-grained database support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //! - `auth-jwt` - JWT authentication
 //! - `auth-session` - Session-based authentication
 //! - `auth-oauth` - OAuth2 support
+//! - `auth-social` - Social authentication providers
 //! - `auth-token` - Token authentication
 //!
 //! #### Database Backends ✅


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- Exposes social authentication through the `reinhardt-web` facade as `auth-social`.
- Exposes runserver hook types through the facade as `commands-server`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The facade crate already has hidden module bridges for framework internals, but consumers cannot enable the social auth and runserver hook surfaces without depending directly on implementation crates. These feature aliases let downstream applications use only `reinhardt-web` while still accessing those optional surfaces through the facade.

Related to: kent8192/reinhardt-cloud#667

## How Was This Tested?

- `cargo check -p reinhardt-web --features "auth-social commands-server static-files"`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- kent8192/reinhardt-cloud#667

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [x] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- Downstream validation is in kent8192/reinhardt-cloud#667.
