### PR TITLE
feat(orm): allow builder overrides for generated fields

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3850,6 +3850,25 @@ fn is_auto_generated_field(field: &FieldInfo) -> bool {
 	false
 }
 
+/// Determine whether an auto-generated field should get an optional builder setter.
+fn is_builder_optional_auto_field(field: &FieldInfo) -> bool {
+	if !is_auto_generated_field(field) {
+		return false;
+	}
+	if field.config.skip || field.is_fk_id_field {
+		return false;
+	}
+	if is_many_to_many_field_type(&field.ty) || is_relationship_field_type(&field.ty) {
+		return false;
+	}
+	if let Some(rel) = &field.rel
+		&& matches!(rel.rel_type, crate::rel::RelationType::ManyToMany)
+	{
+		return false;
+	}
+	true
+}
+
 /// Get the default value expression for an auto-generated field
 fn get_auto_field_default_value(field: &FieldInfo) -> TokenStream {
 	let config = &field.config;
@@ -4004,9 +4023,10 @@ fn generate_new_alias(
 /// FK setters accept any `IntoPrimaryKey<Related>` value — callers can pass
 /// `&user` (the FK shortcut from #4398) or a raw primary-key value.
 ///
-/// Auto-generated fields (`auto_now_add`, integer/UUID primary keys, FK relation
-/// fields, etc.) and fields with `include_in_new = false` are filled in by
-/// `finish()` — they require no setter.
+/// Auto-generated fields (`auto_now_add`, integer/UUID primary keys, identity
+/// columns, generated columns, etc.) and fields with `include_in_new = false`
+/// are optional builder inputs: omitting them uses the macro-managed default,
+/// while calling their named setter stores the supplied value.
 fn generate_build_function(
 	struct_name: &syn::Ident,
 	field_infos: &[FieldInfo],
@@ -4024,6 +4044,12 @@ fn generate_build_function(
 	let auto_fields: Vec<_> = field_infos
 		.iter()
 		.filter(|f| is_auto_generated_field(f))
+		.collect();
+
+	let optional_auto_fields: Vec<_> = auto_fields
+		.iter()
+		.copied()
+		.filter(|f| is_builder_optional_auto_field(f))
 		.collect();
 
 	// Map of `*_id` (in field_infos / fk_id_field_names) -> related FK field name
@@ -4184,13 +4210,22 @@ fn generate_build_function(
 		.map(|i| syn::Ident::new(&format!("B{}", i), struct_name.span()))
 		.collect();
 
-	// Builder struct fields: one Option<StorageTy> per required field, plus the
-	// PhantomData state marker.
+	// Builder struct fields: one Option<StorageTy> per required field, one
+	// Option<StorageTy> per optional auto-generated field, plus the PhantomData
+	// state marker.
 	let builder_struct_fields: Vec<TokenStream> = required
 		.iter()
 		.map(|r| {
 			let name = &r.storage_name;
 			let ty = r.storage_ty;
+			quote! { #name: ::std::option::Option<#ty> }
+		})
+		.collect();
+	let optional_builder_struct_fields: Vec<TokenStream> = optional_auto_fields
+		.iter()
+		.map(|f| {
+			let name = &f.name;
+			let ty = &f.ty;
 			quote! { #name: ::std::option::Option<#ty> }
 		})
 		.collect();
@@ -4200,6 +4235,13 @@ fn generate_build_function(
 		.iter()
 		.map(|r| {
 			let name = &r.storage_name;
+			quote! { #name: ::std::option::Option::None }
+		})
+		.collect();
+	let optional_init_struct_field_assignments: Vec<TokenStream> = optional_auto_fields
+		.iter()
+		.map(|f| {
+			let name = &f.name;
 			quote! { #name: ::std::option::Option::None }
 		})
 		.collect();
@@ -4255,6 +4297,13 @@ fn generate_build_function(
 				} else {
 					quote! { #n: self.#n, }
 				}
+			})
+			.collect();
+		let optional_copy_fields: Vec<TokenStream> = optional_auto_fields
+			.iter()
+			.map(|f| {
+				let name = &f.name;
+				quote! { #name: self.#name, }
 			})
 			.collect();
 
@@ -4328,6 +4377,7 @@ fn generate_build_function(
 				{
 					#builder_name {
 						#(#copy_fields)*
+						#(#optional_copy_fields)*
 						#storage_name: ::std::option::Option::Some(#value_expr),
 						__state: ::std::marker::PhantomData,
 					}
@@ -4405,7 +4455,11 @@ fn generate_build_function(
 		.map(|f| {
 			let name = &f.name;
 			let default_value = get_auto_field_default_value(f);
-			quote! { #name: #default_value }
+			if is_builder_optional_auto_field(f) {
+				quote! { #name: self.#name.unwrap_or_else(|| #default_value) }
+			} else {
+				quote! { #name: #default_value }
+			}
 		})
 		.collect();
 
@@ -4422,6 +4476,25 @@ fn generate_build_function(
 	} else {
 		quote! { <#(#state_params),*> }
 	};
+	let optional_setter_impls: Vec<TokenStream> = optional_auto_fields
+		.iter()
+		.map(|f| {
+			let name = &f.name;
+			let ty = &f.ty;
+			quote! {
+				impl #state_param_list #builder_name #state_param_list {
+					/// Override this macro-managed field for this builder instance.
+					///
+					/// If this setter is not called, `finish()` uses the field's
+					/// macro-managed default value.
+					pub fn #name(mut self, value: #ty) -> Self {
+						self.#name = ::std::option::Option::Some(value);
+						self
+					}
+				}
+			}
+		})
+		.collect();
 	let initial_unset_states: Vec<TokenStream> = state_params
 		.iter()
 		.map(|_| quote! { #unset_marker })
@@ -4472,6 +4545,7 @@ fn generate_build_function(
 		#allow_dead
 		pub struct #builder_name #state_param_list {
 			#(#builder_struct_fields,)*
+			#(#optional_builder_struct_fields,)*
 			__state: ::std::marker::PhantomData<#phantom_tuple_ty>,
 		}
 
@@ -4486,20 +4560,22 @@ fn generate_build_function(
 			pub fn build() -> #initial_builder_type {
 				#builder_name {
 					#(#init_struct_field_assignments,)*
+					#(#optional_init_struct_field_assignments,)*
 					__state: ::std::marker::PhantomData,
 				}
 			}
 		}
 
 		#(#setter_impls)*
+		#(#optional_setter_impls)*
 
 		impl #all_set_builder_type {
 			/// Finalize the builder and construct the model instance.
 			///
 			/// Auto-generated fields (`auto_now_add` timestamps, UUID / integer
-			/// primary keys, identity columns, FK relation fields, etc.) are
-			/// initialized by the same macro-managed defaults used for every
-			/// builder construction path.
+			/// primary keys, identity columns, generated columns, etc.) are
+			/// initialized by their macro-managed defaults unless their optional
+			/// builder setter supplied an explicit value.
 			pub fn finish(self) -> #struct_name {
 				#struct_name {
 					#(#user_field_assignments,)*
@@ -5104,5 +5180,52 @@ mod tests {
 		assert!(output_str.contains("pub fn new () -> EmptyRequiredModelBuilder"));
 		assert!(output_str.contains("pub fn build () -> EmptyRequiredModelBuilder"));
 		assert!(!output_str.contains("EmptyRequiredModelBuilder < >"));
+	}
+
+	#[test]
+	fn test_builder_optional_auto_field_setters_do_not_affect_typestate() {
+		let input = quote! {
+			#[model(app_label = "test", table_name = "test")]
+			pub struct TestModel {
+				#[field(primary_key = true, include_in_new = false)]
+				pub id: Uuid,
+				#[field(max_length = 255)]
+				pub name: String,
+				#[field(auto_now_add = true)]
+				pub created_at: DateTime<Utc>,
+				#[field(include_in_new = false)]
+				pub external_state: i32,
+			}
+		};
+
+		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
+		let output_str = output.to_string();
+
+		assert!(output_str.contains("id : :: std :: option :: Option < Uuid >"));
+		assert!(output_str.contains("pub fn id (mut self , value : Uuid) -> Self"));
+		assert!(
+			output_str.contains("pub fn created_at (mut self , value : DateTime < Utc >) -> Self")
+		);
+		assert!(output_str.contains("pub fn external_state (mut self , value : i32) -> Self"));
+		assert!(
+			output_str
+				.contains("id : self . id . unwrap_or_else (|| :: uuid :: Uuid :: now_v7 ())")
+		);
+		assert!(output_str.contains(
+			"created_at : self . created_at . unwrap_or_else (|| :: chrono :: Utc :: now ())"
+		));
+		assert!(output_str.contains(
+			"external_state : self . external_state . unwrap_or_else (|| :: std :: default :: Default :: default ())"
+		));
+
+		assert!(
+			output_str.contains("pub fn build () -> TestModelBuilder < TestModelBuilderUnset >")
+		);
+		assert!(
+			!output_str
+				.contains("TestModelBuilder < TestModelBuilderUnset , TestModelBuilderUnset")
+		);
+		assert!(!output_str.contains("pub fn set_id"));
+		assert!(!output_str.contains("pub fn set_created_at"));
 	}
 }

--- a/instructions/MACRO_USAGE.md
+++ b/instructions/MACRO_USAGE.md
@@ -60,6 +60,13 @@ let person = Person::new()
     .name("Alice")
     .finish();
 
+// ✅ Correct — opt in to overriding a macro-managed field when importing or
+// bridging an externally supplied identity.
+let person = Person::build()
+    .id(existing_id)
+    .name("Alice")
+    .finish();
+
 // ❌ Incorrect — bypasses macro-generated initialization
 let person = Person {
     id: 1,
@@ -69,6 +76,7 @@ let person = Person {
 
 **Rationale:**
 - The generated builder accepts only the fields the user must supply and auto-fills macro-managed fields (auto-generated primary keys, foreign-key id columns, timestamps, relationship markers). Struct-literal initialization forces the caller to spell out every field, including those the builder would have filled — which is brittle.
+- Macro-managed database fields also get optional builder setters. Call those setters only when the caller intentionally needs to preserve an externally supplied value, such as an imported primary key or fixed timestamp; omitting the setter keeps the normal generated/default path.
 - Centralizing initialization through the builder keeps call sites stable as the macro evolves: adding a required field surfaces as a named setter instead of changing positional argument order.
 - Today the generated builder does not perform validation; this rule is about future-proofing and field coverage, not about a current invariant guarantee.
 

--- a/website/content/docs/field-attributes.md
+++ b/website/content/docs/field-attributes.md
@@ -775,6 +775,19 @@ the `build()` builder and zero-argument `new()` alias.
 internal_state: i32,
 ```
 
+Fields excluded from the required builder path remain available as optional
+builder overrides. If the setter is omitted, `finish()` uses the normal
+macro-managed default. If the setter is called, the supplied value is stored in
+the model; manager create paths that serialize the model include that explicit
+value instead of falling back to the generated/default value.
+
+```rust
+let imported = ImportedAccount::build()
+    .id(existing_id)
+    .internal_state(restored_state)
+    .finish();
+```
+
 #### `skip_getter: bool`
 
 **Supported DBMS**: All **Feature Flag**: None


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds opt-in builder setters for macro-managed/generated model fields.
- Keeps generated/default values when those setters are omitted.
- Documents explicit override usage for import and data-bridge flows.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`#[model]` builders previously treated macro-managed fields as fully internal, so callers could not use the supported builder API when they needed to preserve externally supplied identities or timestamps. The builder should remain ergonomic for normal creation while allowing explicit opt-in overrides.

Fixes #5201

Related to: #

## How Was This Tested?

- `cargo test -p reinhardt-macros model_derive::tests --no-default-features`
- `cargo test -p reinhardt-macros --no-default-features`
- `cargo clippy -p reinhardt-macros --no-default-features -- -D warnings`
- `cargo make fmt-check`

## Performance Impact

Not performance-related.

## Screenshots

Not UI-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5201

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- Optional auto-field setters do not affect typestate arity. `finish()` uses the explicit builder value when supplied and the macro-managed default otherwise.
