### PR TITLE
docs: align RC website docs.rs links

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -119,17 +119,38 @@ jobs:
           tool: zola@0.22.1
 
       - name: Configure version switcher
+        id: website-config
         working-directory: website
         env:
+          EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           VERSION=$(grep 'reinhardt_version' config.toml | sed 's/.*= *"\(.*\)"/\1/')
-          if [[ "$REF_NAME" == develop/* ]]; then
+          BRANCH_NAME="${HEAD_REF:-$REF_NAME}"
+          BRANCH_SLUG=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '.' '-')
+          PREVIEW_URL="https://${BRANCH_SLUG}.reinhardt-web.pages.dev"
+          STABLE_URL="https://reinhardt-web.dev"
+          DEV_URL="https://rc.reinhardt-web.dev"
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            CURRENT_LABEL="v${VERSION} (Preview)"
+            IS_STABLE="false"
+            CHANNEL_LABEL="Preview"
+            CURRENT_URL="${PREVIEW_URL}"
+            BUILD_BASE_URL="${PREVIEW_URL}"
+          elif [[ "$REF_NAME" == develop/* ]]; then
             CURRENT_LABEL="v${VERSION} (Dev)"
             IS_STABLE="false"
+            CHANNEL_LABEL="Dev"
+            CURRENT_URL="${DEV_URL}"
+            BUILD_BASE_URL="${DEV_URL}"
           else
             CURRENT_LABEL="v${VERSION}"
             IS_STABLE="true"
+            CHANNEL_LABEL="Dev"
+            CURRENT_URL="${STABLE_URL}"
+            BUILD_BASE_URL="${STABLE_URL}"
           fi
           sed -i '/^\[extra\.version_switcher\]/,$d' config.toml
           cat >> config.toml << TOML
@@ -140,24 +161,21 @@ jobs:
 
           [[extra.version_switcher.versions]]
           label = "Stable"
-          url = "https://reinhardt-web.dev"
+          url = "${STABLE_URL}"
 
           [[extra.version_switcher.versions]]
-          label = "Dev"
-          url = "https://rc.reinhardt-web.dev"
+          label = "${CHANNEL_LABEL}"
+          url = "${CURRENT_URL}"
           TOML
-          echo "Version switcher configured: ${CURRENT_LABEL} (stable=${IS_STABLE})"
+          echo "build_base_url=${BUILD_BASE_URL}" >> "$GITHUB_OUTPUT"
+          echo "Version switcher configured: ${CURRENT_LABEL} (stable=${IS_STABLE}, url=${CURRENT_URL})"
 
       - name: Build
         working-directory: website
         env:
-          REF_NAME: ${{ github.ref_name }}
+          BUILD_BASE_URL: ${{ steps.website-config.outputs.build_base_url }}
         run: |
-          if [[ "$REF_NAME" == develop/* ]]; then
-            zola build --base-url "https://rc.reinhardt-web.dev"
-          else
-            zola build
-          fi
+          zola build --base-url "${BUILD_BASE_URL}"
 
       - name: Set production branch via Cloudflare API
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -149,7 +149,7 @@ jobs:
             CURRENT_LABEL="v${VERSION}"
             IS_STABLE="true"
             CHANNEL_LABEL="Dev"
-            CURRENT_URL="${STABLE_URL}"
+            CURRENT_URL="${DEV_URL}"
             BUILD_BASE_URL="${STABLE_URL}"
           fi
           sed -i '/^\[extra\.version_switcher\]/,$d' config.toml

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ If you have written `ModelSerializer` or `Depends()` before, Reinhardt will feel
 
 ## Quick Start
 
-<!-- reinhardt-version-sync -->
+<!-- reinhardt-version-sync:2 -->
 ```bash
 # Currently a pre-release: --version is required. Once 0.2.0-rc.4 stable ships,
 # --version becomes optional (and acts as an opt-in reproducibility pin).
-cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
+cargo install reinhardt-admin-cli --version "0.2.0-rc.4"
 
 reinhardt-admin startproject my-api && cd my-api
 cargo run --bin manage runserver  # Visit http://127.0.0.1:8000

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -35,11 +35,11 @@ use reinhardt::commands::{BaseCommand, CommandRegistry};
 For creating new projects and apps, use the separate `reinhardt-admin-cli`
 package:
 
-<!-- reinhardt-version-sync -->
+<!-- reinhardt-version-sync:2 -->
 ```bash
 # Pre-release: --version is required. Once 0.2.0-rc.4 stable ships, --version
 # becomes optional. The literal below is auto-bumped by release-plz.
-cargo install reinhardt-admin-cli --version "0.1.0-rc.30"
+cargo install reinhardt-admin-cli --version "0.2.0-rc.4"
 ```
 
 This installs the `reinhardt-admin` command:

--- a/scripts/tests/test-update-version-refs.sh
+++ b/scripts/tests/test-update-version-refs.sh
@@ -224,4 +224,23 @@ run_case "06 counter marker default N=1" \
 	"0.1.0-rc.99" \
 	"counter1.md"
 
+# Fixture 07: docs.rs URL keeps the package path and rewrites only the version
+cat > "$fx_dir/07-input.toml" <<'EOF'
+[extra]
+# reinhardt-version-sync
+docs_rs = "https://docs.rs/reinhardt-web/0.2.0-rc.4/reinhardt/"
+EOF
+
+cat > "$fx_dir/07-expected.toml" <<'EOF'
+[extra]
+# reinhardt-version-sync
+docs_rs = "https://docs.rs/reinhardt-web/0.2.0-rc.5/reinhardt/"
+EOF
+
+run_case "07 docs.rs versioned URL" \
+	"$fx_dir/07-input.toml" \
+	"$fx_dir/07-expected.toml" \
+	"0.2.0-rc.5" \
+	"website/config.toml"
+
 exit "$FAIL"

--- a/scripts/tests/test-update-version-refs.sh
+++ b/scripts/tests/test-update-version-refs.sh
@@ -141,6 +141,31 @@ run_case "03 multi-version block" \
 	"0.1.0-rc.99" \
 	"multi.md"
 
+# Fixture 04: Markdown marker outside a bash block updates comment and command
+cat > "$fx_dir/04-input.md" <<'MD_EOF'
+<!-- reinhardt-version-sync:2 -->
+```bash
+# Pre-release: --version is required. Once 0.1.0-rc.17 stable ships, --version
+# becomes optional. The literal below is auto-bumped by release-plz.
+cargo install reinhardt-admin-cli --version "0.1.0-rc.17"
+```
+MD_EOF
+
+cat > "$fx_dir/04-expected.md" <<'MD_EOF'
+<!-- reinhardt-version-sync:2 -->
+```bash
+# Pre-release: --version is required. Once 0.1.0-rc.99 stable ships, --version
+# becomes optional. The literal below is auto-bumped by release-plz.
+cargo install reinhardt-admin-cli --version "0.1.0-rc.99"
+```
+MD_EOF
+
+run_case "04 markdown bash block counted marker" \
+	"$fx_dir/04-input.md" \
+	"$fx_dir/04-expected.md" \
+	"0.1.0-rc.99" \
+	"install.md"
+
 # Orphan marker case (expects non-zero exit)
 
 run_orphan_case() {
@@ -170,16 +195,16 @@ run_orphan_case() {
 	rm -rf "$tmpdir"
 }
 
-# Fixture 04: marker with no following version
-cat > "$fx_dir/04-input.md" <<'MD_EOF'
+# Fixture 05: marker with no following version
+cat > "$fx_dir/05-input.md" <<'MD_EOF'
 <!-- reinhardt-version-sync -->
 This paragraph has no version on the next line.
 MD_EOF
 
-run_orphan_case "04 orphan marker" "$fx_dir/04-input.md" "bad.md"
+run_orphan_case "05 orphan marker" "$fx_dir/05-input.md" "bad.md"
 
-# Fixture 05: counter marker N=3 — HTML comment arms three replacements
-cat > "$fx_dir/05-input.md" <<'MD_EOF'
+# Fixture 06: counter marker N=3 — HTML comment arms three replacements
+cat > "$fx_dir/06-input.md" <<'MD_EOF'
 <!-- reinhardt-version-sync:3 -->
 ```toml
 reinhardt-http = "0.1.0-rc.17"
@@ -188,7 +213,7 @@ reinhardt-db   = "0.1.0-rc.17"
 ```
 MD_EOF
 
-cat > "$fx_dir/05-expected.md" <<'MD_EOF'
+cat > "$fx_dir/06-expected.md" <<'MD_EOF'
 <!-- reinhardt-version-sync:3 -->
 ```toml
 reinhardt-http = "0.1.0-rc.99"
@@ -197,49 +222,49 @@ reinhardt-db   = "0.1.0-rc.99"
 ```
 MD_EOF
 
-run_case "05 counter marker N=3" \
-	"$fx_dir/05-input.md" \
-	"$fx_dir/05-expected.md" \
+run_case "06 counter marker N=3" \
+	"$fx_dir/06-input.md" \
+	"$fx_dir/06-expected.md" \
 	"0.1.0-rc.99" \
 	"counter3.md"
 
-# Fixture 06: counter marker default (N=1, no colon) — equivalent to original HTML marker
-cat > "$fx_dir/06-input.md" <<'MD_EOF'
+# Fixture 07: counter marker default (N=1, no colon) — equivalent to original HTML marker
+cat > "$fx_dir/07-input.md" <<'MD_EOF'
 <!-- reinhardt-version-sync -->
 ```toml
 reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
 ```
 MD_EOF
 
-cat > "$fx_dir/06-expected.md" <<'MD_EOF'
+cat > "$fx_dir/07-expected.md" <<'MD_EOF'
 <!-- reinhardt-version-sync -->
 ```toml
 reinhardt = { version = "0.1.0-rc.99", package = "reinhardt-web" }
 ```
 MD_EOF
 
-run_case "06 counter marker default N=1" \
-	"$fx_dir/06-input.md" \
-	"$fx_dir/06-expected.md" \
+run_case "07 counter marker default N=1" \
+	"$fx_dir/07-input.md" \
+	"$fx_dir/07-expected.md" \
 	"0.1.0-rc.99" \
 	"counter1.md"
 
-# Fixture 07: docs.rs URL keeps the package path and rewrites only the version
-cat > "$fx_dir/07-input.toml" <<'EOF'
+# Fixture 08: docs.rs URL keeps the package path and rewrites only the version
+cat > "$fx_dir/08-input.toml" <<'EOF'
 [extra]
 # reinhardt-version-sync
 docs_rs = "https://docs.rs/reinhardt-web/0.2.0-rc.4/reinhardt/"
 EOF
 
-cat > "$fx_dir/07-expected.toml" <<'EOF'
+cat > "$fx_dir/08-expected.toml" <<'EOF'
 [extra]
 # reinhardt-version-sync
 docs_rs = "https://docs.rs/reinhardt-web/0.2.0-rc.5/reinhardt/"
 EOF
 
-run_case "07 docs.rs versioned URL" \
-	"$fx_dir/07-input.toml" \
-	"$fx_dir/07-expected.toml" \
+run_case "08 docs.rs versioned URL" \
+	"$fx_dir/08-input.toml" \
+	"$fx_dir/08-expected.toml" \
 	"0.2.0-rc.5" \
 	"website/config.toml"
 

--- a/website/config.toml
+++ b/website/config.toml
@@ -23,7 +23,8 @@ internal_level = "warn"
 og_image    = "https://reinhardt-web.dev/og-image.png"
 github_repo = "https://github.com/kent8192/reinhardt-web"
 crates_io   = "https://crates.io/crates/reinhardt-web"
-docs_rs     = "https://docs.rs/reinhardt-web"
+# reinhardt-version-sync
+docs_rs     = "https://docs.rs/reinhardt-web/0.2.0-rc.4/reinhardt/"
 changelog   = "https://github.com/kent8192/reinhardt-web/blob/main/CHANGELOG.md"
 deepwiki    = "https://deepwiki.com/kent8192/reinhardt-web"
 # reinhardt-version-sync

--- a/website/content/docs/api/_index.md
+++ b/website/content/docs/api/_index.md
@@ -13,8 +13,9 @@ sidebar_weight = 10
 
 Welcome to the Reinhardt API reference documentation. This guide provides comprehensive information about Reinhardt's APIs, modules, and components.
 
-> **Note**: Full API documentation will be available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web) once published to crates.io.
-> In the meantime, comprehensive documentation is available in each crate's `lib.rs` file.
+<!-- reinhardt-version-sync -->
+> **Note**: Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.2.0-rc.4/reinhardt/).
+> Comprehensive documentation is also available in each crate's `lib.rs` file.
 
 ## Reinhardt Crate Structure
 
@@ -938,7 +939,8 @@ Main package that re-exports all components based on feature flags.
 
 **Documentation:**
 
-- [Main documentation](https://docs.rs/reinhardt-web) (available after crates.io publish)
+<!-- reinhardt-version-sync -->
+- [Main documentation](https://docs.rs/reinhardt-web/0.2.0-rc.4/reinhardt/)
 - [Feature Flags Guide](/docs/feature-flags/)
 
 ## Common Patterns
@@ -1003,4 +1005,5 @@ Found an error in the documentation? Want to improve it?
 
 ---
 
-**Note**: This is a high-level overview. Full API documentation will be available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web) once published to crates.io. In the meantime, comprehensive documentation is available in each crate's `lib.rs` file.
+<!-- reinhardt-version-sync -->
+**Note**: This is a high-level overview. Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.2.0-rc.4/reinhardt/). Comprehensive documentation is also available in each crate's `lib.rs` file.

--- a/website/content/docs/cookbook/_index.md
+++ b/website/content/docs/cookbook/_index.md
@@ -37,6 +37,7 @@ The Cookbook provides practical guides for solving common tasks.
 
 ## See Also
 
-- [API Reference](https://docs.rs/reinhardt-web/)
+<!-- reinhardt-version-sync -->
+- [API Reference](https://docs.rs/reinhardt-web/0.2.0-rc.4/reinhardt/)
 - [Migration Guides](/quickstart/migration-guides/)
 - [Troubleshooting](../troubleshooting/)

--- a/website/content/docs/troubleshooting/_index.md
+++ b/website/content/docs/troubleshooting/_index.md
@@ -29,6 +29,7 @@ Troubleshooting guides provide solutions to common problems encountered during d
 
 ## See Also
 
-- [API Reference](https://docs.rs/reinhardt-web/)
+<!-- reinhardt-version-sync -->
+- [API Reference](https://docs.rs/reinhardt-web/0.2.0-rc.4/reinhardt/)
 - [Cookbook](../cookbook/)
 - [Migration Guides](/quickstart/migration-guides/)

--- a/website/content/quickstart/getting-started.md
+++ b/website/content/quickstart/getting-started.md
@@ -384,7 +384,8 @@ Check out the [ORM documentation](/docs/api/) for more details.
 
 ## Getting Help
 
-- 📖 [API Reference](https://docs.rs/reinhardt-web/latest/reinhardt_web/)
+<!-- reinhardt-version-sync -->
+- 📖 [API Reference](https://docs.rs/reinhardt-web/0.2.0-rc.4/reinhardt/)
 - 🗺️ [DeepWiki](https://deepwiki.com/kent8192/reinhardt-web) - AI-generated codebase documentation
 - 💬 [GitHub Discussions](https://github.com/kent8192/reinhardt-web/discussions)
 - 🐛 [Report Issues](https://github.com/kent8192/reinhardt-web/issues)

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -1,12 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-{%- set crate_data = load_data(url="https://crates.io/api/v1/crates/reinhardt-web", format="json", headers=["User-Agent=reinhardt-web-site (zola)"], required=false) -%}
-{%- if crate_data and crate_data.crate -%}
-	{%- set latest_version = crate_data.crate.max_version -%}
-{%- else -%}
-	{%- set latest_version = config.extra.reinhardt_version -%}
-{%- endif -%}
+{%- set latest_version = config.extra.reinhardt_version -%}
 <section class="hero" aria-labelledby="hero-title">
 	<div class="hero-inner container">
 		<h1 id="hero-title" class="hero-title">

--- a/website/templates/shortcodes/crate_version.html
+++ b/website/templates/shortcodes/crate_version.html
@@ -1,6 +1,1 @@
-{%- set data = load_data(url="https://crates.io/api/v1/crates/reinhardt-web", format="json", headers=["User-Agent=reinhardt-web-site (zola)"], required=false) -%}
-{%- if data and data.crate -%}
-{{- data.crate.max_version -}}
-{%- else -%}
 {{- config.extra.reinhardt_version -}}
-{%- endif -%}

--- a/website/templates/shortcodes/versioned_code.html
+++ b/website/templates/shortcodes/versioned_code.html
@@ -1,9 +1,4 @@
-{%- set data = load_data(url="https://crates.io/api/v1/crates/reinhardt-web", format="json", headers=["User-Agent=reinhardt-web-site (zola)"], required=false) -%}
-{%- if data and data.crate -%}
-{%- set version = data.crate.max_version -%}
-{%- else -%}
 {%- set version = config.extra.reinhardt_version -%}
-{%- endif -%}
 {%- set lang = args.lang | default(value="toml") -%}
 {%- set replaced = body | replace(from="LATEST_VERSION", to=version) -%}
 {%- set code = "```" ~ lang ~ "\n" ~ replaced ~ "\n```" -%}


### PR DESCRIPTION
## Summary

This PR addresses:

- Aligns the RC website's main docs.rs links with the visible `0.2.0-rc.4` release channel.
- Points footer, API reference, cookbook, troubleshooting, and Quickstart help links to the versioned RC docs URL.
- Aligns remaining README-level `reinhardt-admin-cli` install examples with `0.2.0-rc.4`.
- Adds version-sync coverage so future release bumps update docs.rs URLs and counted Markdown install snippets together.
- Treats Cloudflare Pages PR deployments as `Preview` channel builds instead of stable builds, with the branch alias as the generated base URL.
- Uses `config.extra.reinhardt_version` as the website release-channel source of truth instead of querying crates.io during Zola builds.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- The RC website showed `0.2.0-rc.4` guidance while main docs.rs links still routed users to unversioned/latest stable documentation.
- Some README-level CLI install snippets still used `reinhardt-admin-cli --version "0.1.0-rc.30"`, even though `reinhardt-admin-cli 0.2.0-rc.4` is published.
- The counted `reinhardt-version-sync` marker prevents future release bumps from updating only the explanatory comment while leaving the install command stale.
- PR previews were built from `github.ref_name` values like `5208/merge`, so the old workflow classified them as stable and generated a `Dev` menu link to `https://rc.reinhardt-web.dev`, which can be unavailable for PR previews.

Fixes #5206

Related to: #

## How Was This Tested?

- `bash scripts/tests/run-all.sh`
- `./scripts/validate-version-markers.sh`
- `git diff --check`
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/deploy-website.yml")); print("YAML OK")'`
- `./scripts/update-version-refs.sh 0.2.0-rc.99 --dry-run`
- `rg -n '0\.1\.0-rc\.30|https://docs\.rs/reinhardt-web(/latest|/0\.1\.3)' README.md crates/reinhardt-commands/README.md website -g '!public/**'`
- `cargo search reinhardt-admin-cli --limit 5`
- `curl -I -L --max-time 15 https://docs.rs/reinhardt-web/0.2.0-rc.4/reinhardt/`
- `curl -I -L --max-time 20 https://658951b7.reinhardt-web.pages.dev/`
- `curl -I -L --max-time 20 https://fix-issue-5206-rc-docs-links.reinhardt-web.pages.dev/`
- Simulated a PR preview build in `/tmp` and confirmed generated HTML contains `v0.2.0-rc.4 (Preview)` and a `Preview` channel link to the branch alias.
- `cd website && zola build`

`cd website && zola check` was also attempted before this follow-up, but it still fails on pre-existing external links unrelated to this PR.

## Performance Impact

- Not performance-related.

## Screenshots

Not applicable; documentation link/install guidance and website channel metadata update only.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5206

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- GitWhy context: `ctx_136ebe69`
- GitWhy follow-up context: `ctx_21f09820`
- GitWhy preview-channel context: `ctx_21e48e14`

🤖 Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped documentation and install snippets to 0.2.0-rc.4.
  * Updated deployment workflow to set build base URL and handle preview/dev/stable channels.
  * Switched site templates and links to use configured, version-pinned docs URLs instead of runtime fetching.

* **Tests**
  * Extended and reorganized version-sync test fixtures to cover additional marker and rewriting cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->