### PR TITLE
fix(ci): install node before website deploy

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -5,10 +5,12 @@ on:
     branches: [main, 'develop/**']
     paths:
       - "website/**"
+      - ".github/workflows/deploy-website.yml"
   pull_request:
     types: [opened, synchronize, reopened, closed]
     paths:
       - "website/**"
+      - ".github/workflows/deploy-website.yml"
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -190,6 +190,14 @@ jobs:
             -d '{"production_branch": "main"}' \
             | jq -r '"Production branch set to: \(.result.production_branch)"'
 
+      # The AWS Packer AMI does not put Node.js/npm on PATH. The runner agent's
+      # bundled Node only executes JS actions, so Wrangler's npm-based install
+      # needs an explicit Node setup. Issue #4694.
+      - name: Setup Node.js for Wrangler
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       # NOTE: Still on Node.js 20 - update when Node.js 24 version becomes available
       - name: Deploy to Cloudflare Pages
         id: deploy


### PR DESCRIPTION
## Summary

This PR addresses:

- Restores explicit Node.js setup before Cloudflare Pages deployment so `cloudflare/wrangler-action` can install Wrangler on AWS self-hosted runners.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The `develop/0.2.0` website deploy run failed after Zola completed because `cloudflare/wrangler-action` could not find `npm` on the AWS self-hosted runner. The runner agent can execute JavaScript actions, but its bundled Node is not exposed as a normal `npm` toolchain for Wrangler's install path.

Fixes #

Related to: #4694

## How Was This Tested?

- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/deploy-website.yml")); print("YAML OK")'`
- `git diff --check`
- `actionlint .github/workflows/deploy-website.yml`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #4694
- Failed deploy job: https://github.com/kent8192/reinhardt-web/actions/runs/27113913932/job/80016966864

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

This mirrors the previous workflow fix that installed Node before website deployment for self-hosted runners.
