### PR TITLE
feat(commands): add interactive dependency configuration

### DIFF
--- a/.github/scripts/patch-fixture-cargo-toml.py
+++ b/.github/scripts/patch-fixture-cargo-toml.py
@@ -43,7 +43,11 @@ def enable_features(manifest: Path, extra_features: list[str]) -> None:
 	if not additions:
 		return
 	insertion = "".join(f'\t"{f}",\n' for f in additions)
-	new_body = body.rstrip() + "\n" + insertion
+	stripped_body = body.rstrip()
+	separator = ""
+	if stripped_body and not stripped_body.endswith(","):
+		separator = ","
+	new_body = stripped_body + separator + "\n" + insertion
 	manifest.write_text(text[: match.start()] + prefix + new_body + suffix + text[match.end() :])
 
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,22 @@ reinhardt-admin startproject my-api
 cd my-api
 ```
 
+Interactive terminals can choose the Reinhardt version and feature flags
+during project creation. Scripts can pass them explicitly:
+
+```bash
+reinhardt-admin startproject my-api \
+  --reinhardt-version "0.2.0-rc.4" \
+  --features standard,admin \
+  --no-interactive
+```
+
+For an existing project, update the `reinhardt` dependency in `Cargo.toml`:
+
+```bash
+reinhardt-admin configure --features minimal,db-sqlite --no-interactive
+```
+
 This generates a complete project structure:
 
 ```

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -57,6 +57,9 @@ Per-prerelease history is in the [Release Discussions](https://github.com/kent81
   new Reinhardt project (matching the per-app layout from
   [#4476](https://github.com/kent8192/reinhardt-web/discussions/4476)), `startapp` adds an application module, and both
   accept `--template-dir` to override the embedded templates.
+- **Interactive dependency selection** — `startproject` can prompt
+  for the Reinhardt version and feature flags, and `configure`
+  applies the same dependency selection to an existing project.
 - **Template selection via `ArgGroup`** — `--template /
   --with-pages / --with-rest` replaces the previous
   `--template-type` flag; the selection is enforced by a `clap`

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -16,6 +16,7 @@ aquamarine = "0.5"
 reinhardt-commands = { workspace = true, features = ["plugins"] }
 reinhardt-dentdelion = { workspace = true, features = ["cli"] }
 clap = { version = "4.5", features = ["derive", "cargo"] }
+dialoguer = "0.12.0"
 tokio = { workspace = true }
 walkdir = "2.5"
 syn = { version = "2.0", features = ["full", "parsing", "visit-mut"] }

--- a/crates/reinhardt-admin-cli/README.md
+++ b/crates/reinhardt-admin-cli/README.md
@@ -27,8 +27,8 @@ This installs the `reinhardt-admin` command.
 ### Create a New Project
 
 ```bash
-# Create a RESTful API project
-reinhardt-admin startproject myproject --with-rest
+# Create a RESTful API project (default in non-interactive shells)
+reinhardt-admin startproject myproject
 
 # Create a Pages (WASM + SSR) project
 reinhardt-admin startproject myproject --with-pages
@@ -39,6 +39,29 @@ reinhardt-admin startproject myproject --template pages
 
 # Create project in a specific directory
 reinhardt-admin startproject myproject --with-rest /path/to/directory
+
+# Pin the generated Reinhardt dependency
+reinhardt-admin startproject myproject --with-rest \
+  --reinhardt-version 0.2.0-rc.4 \
+  --features standard,admin \
+  --no-interactive
+```
+
+When run from an interactive terminal, `startproject` prompts for the
+project type, Reinhardt version, and feature flags when those choices are
+not provided as flags. Non-interactive runs use deterministic defaults.
+
+### Configure an Existing Project
+
+```bash
+# Interactively update ./Cargo.toml
+reinhardt-admin configure
+
+# Update a project without prompts
+reinhardt-admin configure /path/to/project \
+  --reinhardt-version 0.2.0-rc.4 \
+  --features minimal,db-sqlite \
+  --no-interactive
 ```
 
 ### Create a New App

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -34,11 +34,14 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use colored::Colorize;
+use dialoguer::Select;
 use reinhardt_commands::{
-	BaseCommand, CommandContext, CommandResult, PluginDisableCommand, PluginEnableCommand,
-	PluginInfoCommand, PluginInstallCommand, PluginListCommand, PluginRemoveCommand,
-	PluginSearchCommand, PluginUpdateCommand, StartAppCommand, StartProjectCommand,
+	BaseCommand, CommandContext, CommandResult, ConfigureCommand, PluginDisableCommand,
+	PluginEnableCommand, PluginInfoCommand, PluginInstallCommand, PluginListCommand,
+	PluginRemoveCommand, PluginSearchCommand, PluginUpdateCommand, StartAppCommand,
+	StartProjectCommand,
 };
+use std::io::IsTerminal;
 use std::process;
 
 /// Project/app architecture type used with `--template`.
@@ -67,12 +70,11 @@ fn resolve_project_type(
 	template: Option<TemplateType>,
 	with_pages: bool,
 	with_rest: bool,
-) -> ResolvedProjectType {
+) -> Option<ResolvedProjectType> {
 	match (template, with_pages, with_rest) {
-		(Some(TemplateType::Pages), _, _) | (_, true, _) => ResolvedProjectType::Pages,
-		(Some(TemplateType::Rest), _, _) | (_, _, true) => ResolvedProjectType::Rest,
-		// ArgGroup required=true guarantees one branch above is taken (#3842)
-		_ => unreachable!(),
+		(Some(TemplateType::Pages), _, _) | (_, true, _) => Some(ResolvedProjectType::Pages),
+		(Some(TemplateType::Rest), _, _) | (_, _, true) => Some(ResolvedProjectType::Rest),
+		_ => None,
 	}
 }
 
@@ -94,7 +96,6 @@ enum Commands {
 	/// Create a new Reinhardt project
 	#[command(group(
 		clap::ArgGroup::new("project_type")
-			.required(true)
 			.args(["template", "with_pages", "with_rest"])
 	))]
 	Startproject {
@@ -122,6 +123,26 @@ enum Commands {
 		/// Also reads the REINHARDT_TEMPLATE_DIR environment variable.
 		#[arg(long, value_name = "DIR")]
 		template_dir: Option<String>,
+
+		/// Reinhardt version requirement to write into Cargo.toml.
+		#[arg(long, value_name = "VERSION")]
+		reinhardt_version: Option<String>,
+
+		/// Reinhardt feature to enable. Can be repeated.
+		#[arg(long = "feature", value_name = "FEATURE")]
+		feature: Vec<String>,
+
+		/// Comma-separated Reinhardt features to enable.
+		#[arg(long, value_name = "CSV")]
+		features: Option<String>,
+
+		/// Whether to keep Cargo default features enabled for the Reinhardt dependency.
+		#[arg(long, action = clap::ArgAction::Set)]
+		default_features: Option<bool>,
+
+		/// Disable prompts and use deterministic defaults for omitted choices.
+		#[arg(long)]
+		no_interactive: bool,
 	},
 
 	/// Create a new Reinhardt app
@@ -161,6 +182,33 @@ enum Commands {
 	Plugin {
 		#[command(subcommand)]
 		subcommand: PluginCommands,
+	},
+
+	/// Configure Reinhardt version and features in an existing project
+	Configure {
+		/// Project directory containing Cargo.toml (defaults to current directory)
+		#[arg(value_name = "DIRECTORY")]
+		directory: Option<String>,
+
+		/// Reinhardt version requirement to write into Cargo.toml.
+		#[arg(long, value_name = "VERSION")]
+		reinhardt_version: Option<String>,
+
+		/// Reinhardt feature to enable. Can be repeated.
+		#[arg(long = "feature", value_name = "FEATURE")]
+		feature: Vec<String>,
+
+		/// Comma-separated Reinhardt features to enable.
+		#[arg(long, value_name = "CSV")]
+		features: Option<String>,
+
+		/// Whether to keep Cargo default features enabled for the Reinhardt dependency.
+		#[arg(long, action = clap::ArgAction::Set)]
+		default_features: Option<bool>,
+
+		/// Disable prompts and use deterministic defaults for omitted choices.
+		#[arg(long)]
+		no_interactive: bool,
 	},
 
 	/// Format Rust code and page!/form!/head! macro DSL in source files
@@ -392,6 +440,11 @@ async fn main() {
 			with_pages,
 			with_rest,
 			template_dir,
+			reinhardt_version,
+			feature,
+			features,
+			default_features,
+			no_interactive,
 		} => {
 			run_startproject(
 				name,
@@ -400,6 +453,11 @@ async fn main() {
 				with_pages,
 				with_rest,
 				template_dir,
+				reinhardt_version,
+				feature,
+				features,
+				default_features,
+				no_interactive,
 				cli.verbosity,
 			)
 			.await
@@ -424,6 +482,25 @@ async fn main() {
 			.await
 		}
 		Commands::Plugin { subcommand } => run_plugin(subcommand, cli.verbosity).await,
+		Commands::Configure {
+			directory,
+			reinhardt_version,
+			feature,
+			features,
+			default_features,
+			no_interactive,
+		} => {
+			run_configure(
+				directory,
+				reinhardt_version,
+				feature,
+				features,
+				default_features,
+				no_interactive,
+				cli.verbosity,
+			)
+			.await
+		}
 		Commands::Fmt {
 			path,
 			check,
@@ -486,6 +563,11 @@ async fn run_startproject(
 	with_pages: bool,
 	with_rest: bool,
 	template_dir: Option<String>,
+	reinhardt_version: Option<String>,
+	feature: Vec<String>,
+	features: Option<String>,
+	default_features: Option<bool>,
+	no_interactive: bool,
 	verbosity: u8,
 ) -> CommandResult<()> {
 	let mut ctx = CommandContext::default();
@@ -494,13 +576,26 @@ async fn run_startproject(
 	if let Some(dir) = directory {
 		ctx.add_arg(dir);
 	}
-	match resolve_project_type(template, with_pages, with_rest) {
+	let project_type = match resolve_project_type(template, with_pages, with_rest) {
+		Some(project_type) => project_type,
+		None if should_prompt(no_interactive) => prompt_project_type()?,
+		None => ResolvedProjectType::Rest,
+	};
+	match project_type {
 		ResolvedProjectType::Pages => ctx.set_option("with-pages".to_string(), "true".to_string()),
 		ResolvedProjectType::Rest => ctx.set_option("restful".to_string(), "true".to_string()),
 	}
 	if let Some(td) = template_dir {
 		ctx.set_option("template-dir".to_string(), td);
 	}
+	push_dependency_options(
+		&mut ctx,
+		reinhardt_version,
+		feature,
+		features,
+		default_features,
+		no_interactive,
+	);
 
 	let cmd = StartProjectCommand;
 	cmd.execute(&ctx).await
@@ -522,8 +617,13 @@ async fn run_startapp(
 		ctx.add_arg(dir);
 	}
 	match resolve_project_type(template, with_pages, with_rest) {
-		ResolvedProjectType::Pages => ctx.set_option("with-pages".to_string(), "true".to_string()),
-		ResolvedProjectType::Rest => ctx.set_option("restful".to_string(), "true".to_string()),
+		Some(ResolvedProjectType::Pages) => {
+			ctx.set_option("with-pages".to_string(), "true".to_string())
+		}
+		Some(ResolvedProjectType::Rest) => {
+			ctx.set_option("restful".to_string(), "true".to_string())
+		}
+		None => unreachable!("clap requires a startapp project type"),
 	}
 	if let Some(td) = template_dir {
 		ctx.set_option("template-dir".to_string(), td);
@@ -531,6 +631,81 @@ async fn run_startapp(
 
 	let cmd = StartAppCommand;
 	cmd.execute(&ctx).await
+}
+
+async fn run_configure(
+	directory: Option<String>,
+	reinhardt_version: Option<String>,
+	feature: Vec<String>,
+	features: Option<String>,
+	default_features: Option<bool>,
+	no_interactive: bool,
+	verbosity: u8,
+) -> CommandResult<()> {
+	let mut ctx = CommandContext::default();
+	ctx.set_verbosity(verbosity);
+	if let Some(directory) = directory {
+		ctx.add_arg(directory);
+	}
+	push_dependency_options(
+		&mut ctx,
+		reinhardt_version,
+		feature,
+		features,
+		default_features,
+		no_interactive,
+	);
+
+	ConfigureCommand.execute(&ctx).await
+}
+
+fn push_dependency_options(
+	ctx: &mut CommandContext,
+	reinhardt_version: Option<String>,
+	feature: Vec<String>,
+	features: Option<String>,
+	default_features: Option<bool>,
+	no_interactive: bool,
+) {
+	if let Some(version) = reinhardt_version {
+		ctx.set_option("reinhardt-version".to_string(), version);
+	}
+	if !feature.is_empty() {
+		ctx.set_option_multi("feature".to_string(), feature);
+	}
+	if let Some(features) = features {
+		ctx.set_option("features".to_string(), features);
+	}
+	if let Some(default_features) = default_features {
+		ctx.set_option("default-features".to_string(), default_features.to_string());
+	}
+	if no_interactive {
+		ctx.set_option("no-interactive".to_string(), "true".to_string());
+	}
+}
+
+fn should_prompt(no_interactive: bool) -> bool {
+	!cfg!(test)
+		&& !no_interactive
+		&& std::env::var("REINHARDT_TEST_MODE").is_err()
+		&& std::io::stdin().is_terminal()
+}
+
+fn prompt_project_type() -> CommandResult<ResolvedProjectType> {
+	let choices = ["RESTful API", "Pages (WASM + SSR)"];
+	let selected = Select::new()
+		.with_prompt("Select Reinhardt project type")
+		.items(choices)
+		.default(0)
+		.interact()
+		.map_err(|error| {
+			reinhardt_commands::CommandError::ExecutionError(format!("Prompt failed: {error}"))
+		})?;
+	if selected == 1 {
+		Ok(ResolvedProjectType::Pages)
+	} else {
+		Ok(ResolvedProjectType::Rest)
+	}
 }
 
 async fn run_plugin(subcommand: PluginCommands, verbosity: u8) -> CommandResult<()> {
@@ -765,7 +940,7 @@ mod resolve_project_type_tests {
 	fn with_pages_bool_resolves_to_pages() {
 		assert!(matches!(
 			resolve_project_type(None, true, false),
-			ResolvedProjectType::Pages
+			Some(ResolvedProjectType::Pages)
 		));
 	}
 
@@ -773,7 +948,7 @@ mod resolve_project_type_tests {
 	fn with_rest_bool_resolves_to_rest() {
 		assert!(matches!(
 			resolve_project_type(None, false, true),
-			ResolvedProjectType::Rest
+			Some(ResolvedProjectType::Rest)
 		));
 	}
 
@@ -781,7 +956,7 @@ mod resolve_project_type_tests {
 	fn template_pages_resolves_to_pages() {
 		assert!(matches!(
 			resolve_project_type(Some(TemplateType::Pages), false, false),
-			ResolvedProjectType::Pages
+			Some(ResolvedProjectType::Pages)
 		));
 	}
 
@@ -789,7 +964,7 @@ mod resolve_project_type_tests {
 	fn template_rest_resolves_to_rest() {
 		assert!(matches!(
 			resolve_project_type(Some(TemplateType::Rest), false, false),
-			ResolvedProjectType::Rest
+			Some(ResolvedProjectType::Rest)
 		));
 	}
 
@@ -798,7 +973,7 @@ mod resolve_project_type_tests {
 		// --template pages takes precedence, both bools false
 		assert!(matches!(
 			resolve_project_type(Some(TemplateType::Pages), false, false),
-			ResolvedProjectType::Pages
+			Some(ResolvedProjectType::Pages)
 		));
 	}
 
@@ -807,16 +982,19 @@ mod resolve_project_type_tests {
 		// --template rest takes precedence, both bools false
 		assert!(matches!(
 			resolve_project_type(Some(TemplateType::Rest), false, false),
-			ResolvedProjectType::Rest
+			Some(ResolvedProjectType::Rest)
 		));
+	}
+
+	#[test]
+	fn omitted_type_resolves_to_none() {
+		assert!(resolve_project_type(None, false, false).is_none());
 	}
 }
 
 #[cfg(test)]
 mod arg_group_tests {
 	use super::*;
-	use clap::error::ErrorKind;
-
 	fn try_parse(args: &[&str]) -> Result<Cli, clap::Error> {
 		Cli::try_parse_from(args)
 	}
@@ -868,13 +1046,9 @@ mod arg_group_tests {
 	}
 
 	#[test]
-	fn startproject_missing_type_is_error() {
+	fn startproject_missing_type_is_accepted_for_interactive_or_default() {
 		let result = try_parse(&["reinhardt-admin", "startproject", "myproj"]);
-		assert!(result.is_err(), "expected Err when type flag omitted");
-		assert_eq!(
-			result.err().unwrap().kind(),
-			ErrorKind::MissingRequiredArgument
-		);
+		assert!(result.is_ok(), "type flag can be omitted");
 	}
 
 	#[test]
@@ -922,7 +1096,24 @@ mod arg_group_tests {
 		assert!(result.is_err(), "expected Err when type flag omitted");
 		assert_eq!(
 			result.err().unwrap().kind(),
-			ErrorKind::MissingRequiredArgument
+			clap::error::ErrorKind::MissingRequiredArgument
+		);
+	}
+
+	#[test]
+	fn configure_dependency_flags_are_accepted() {
+		assert!(
+			try_parse(&[
+				"reinhardt-admin",
+				"configure",
+				"--reinhardt-version",
+				"0.2.0-rc.4",
+				"--features",
+				"minimal,db-sqlite",
+				"--no-interactive",
+			])
+			.is_ok(),
+			"configure dependency flags should parse"
 		);
 	}
 }

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -300,6 +300,22 @@ enum Commands {
 	MigrateManoucheV2(migrate_v2::MigrateV2Args),
 }
 
+#[derive(Debug)]
+struct DependencyOptions {
+	reinhardt_version: Option<String>,
+	feature: Vec<String>,
+	features: Option<String>,
+	default_features: Option<bool>,
+	no_interactive: bool,
+}
+
+#[derive(Debug)]
+struct ProjectTypeOptions {
+	template: Option<TemplateType>,
+	with_pages: bool,
+	with_rest: bool,
+}
+
 /// Plugin management subcommands
 #[derive(Subcommand)]
 enum PluginCommands {
@@ -446,18 +462,24 @@ async fn main() {
 			default_features,
 			no_interactive,
 		} => {
-			run_startproject(
-				name,
-				directory,
+			let project_type_options = ProjectTypeOptions {
 				template,
 				with_pages,
 				with_rest,
-				template_dir,
+			};
+			let dependency_options = DependencyOptions {
 				reinhardt_version,
 				feature,
 				features,
 				default_features,
 				no_interactive,
+			};
+			run_startproject(
+				name,
+				directory,
+				project_type_options,
+				template_dir,
+				dependency_options,
 				cli.verbosity,
 			)
 			.await
@@ -490,16 +512,14 @@ async fn main() {
 			default_features,
 			no_interactive,
 		} => {
-			run_configure(
-				directory,
+			let dependency_options = DependencyOptions {
 				reinhardt_version,
 				feature,
 				features,
 				default_features,
 				no_interactive,
-				cli.verbosity,
-			)
-			.await
+			};
+			run_configure(directory, dependency_options, cli.verbosity).await
 		}
 		Commands::Fmt {
 			path,
@@ -559,15 +579,9 @@ async fn main() {
 async fn run_startproject(
 	name: String,
 	directory: Option<String>,
-	template: Option<TemplateType>,
-	with_pages: bool,
-	with_rest: bool,
+	project_type_options: ProjectTypeOptions,
 	template_dir: Option<String>,
-	reinhardt_version: Option<String>,
-	feature: Vec<String>,
-	features: Option<String>,
-	default_features: Option<bool>,
-	no_interactive: bool,
+	dependency_options: DependencyOptions,
 	verbosity: u8,
 ) -> CommandResult<()> {
 	let mut ctx = CommandContext::default();
@@ -576,9 +590,13 @@ async fn run_startproject(
 	if let Some(dir) = directory {
 		ctx.add_arg(dir);
 	}
-	let project_type = match resolve_project_type(template, with_pages, with_rest) {
+	let project_type = match resolve_project_type(
+		project_type_options.template,
+		project_type_options.with_pages,
+		project_type_options.with_rest,
+	) {
 		Some(project_type) => project_type,
-		None if should_prompt(no_interactive) => prompt_project_type()?,
+		None if should_prompt(dependency_options.no_interactive) => prompt_project_type()?,
 		None => ResolvedProjectType::Rest,
 	};
 	match project_type {
@@ -588,14 +606,7 @@ async fn run_startproject(
 	if let Some(td) = template_dir {
 		ctx.set_option("template-dir".to_string(), td);
 	}
-	push_dependency_options(
-		&mut ctx,
-		reinhardt_version,
-		feature,
-		features,
-		default_features,
-		no_interactive,
-	);
+	push_dependency_options(&mut ctx, dependency_options);
 
 	let cmd = StartProjectCommand;
 	cmd.execute(&ctx).await
@@ -635,11 +646,7 @@ async fn run_startapp(
 
 async fn run_configure(
 	directory: Option<String>,
-	reinhardt_version: Option<String>,
-	feature: Vec<String>,
-	features: Option<String>,
-	default_features: Option<bool>,
-	no_interactive: bool,
+	dependency_options: DependencyOptions,
 	verbosity: u8,
 ) -> CommandResult<()> {
 	let mut ctx = CommandContext::default();
@@ -647,39 +654,25 @@ async fn run_configure(
 	if let Some(directory) = directory {
 		ctx.add_arg(directory);
 	}
-	push_dependency_options(
-		&mut ctx,
-		reinhardt_version,
-		feature,
-		features,
-		default_features,
-		no_interactive,
-	);
+	push_dependency_options(&mut ctx, dependency_options);
 
 	ConfigureCommand.execute(&ctx).await
 }
 
-fn push_dependency_options(
-	ctx: &mut CommandContext,
-	reinhardt_version: Option<String>,
-	feature: Vec<String>,
-	features: Option<String>,
-	default_features: Option<bool>,
-	no_interactive: bool,
-) {
-	if let Some(version) = reinhardt_version {
+fn push_dependency_options(ctx: &mut CommandContext, options: DependencyOptions) {
+	if let Some(version) = options.reinhardt_version {
 		ctx.set_option("reinhardt-version".to_string(), version);
 	}
-	if !feature.is_empty() {
-		ctx.set_option_multi("feature".to_string(), feature);
+	if !options.feature.is_empty() {
+		ctx.set_option_multi("feature".to_string(), options.feature);
 	}
-	if let Some(features) = features {
+	if let Some(features) = options.features {
 		ctx.set_option("features".to_string(), features);
 	}
-	if let Some(default_features) = default_features {
+	if let Some(default_features) = options.default_features {
 		ctx.set_option("default-features".to_string(), default_features.to_string());
 	}
-	if no_interactive {
+	if options.no_interactive {
 		ctx.set_option("no-interactive".to_string(), "true".to_string());
 	}
 }

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -33,12 +33,14 @@ thiserror = { workspace = true }
 colored = { workspace = true }
 console = "0.16.1"
 dialoguer = "0.12.0"
+crates_io_api = "0.12.0"
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 http-body-util = { workspace = true }
 tera = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml_edit = "0.25.10"
 walkdir = "2.5"
 rand = { workspace = true }
 regex = { workspace = true }

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -442,6 +442,21 @@ impl BaseCommand for PluginInstallCommand {
 
 ```bash
 reinhardt-admin startproject myproject --template rest
+reinhardt-admin startproject myproject --template pages
+reinhardt-admin startproject myproject --features standard,admin --no-interactive
+```
+
+Interactive terminals can choose the project type, Reinhardt version, and
+feature flags during `startproject`. Use `--reinhardt-version`,
+`--feature`, `--features`, `--default-features`, and `--no-interactive`
+for reproducible scripts.
+
+Existing projects can update their `reinhardt` dependency through the same
+selection flow:
+
+```bash
+reinhardt-admin configure
+reinhardt-admin configure /path/to/project --features minimal,db-sqlite --no-interactive
 ```
 
 ### App Templates

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -71,6 +71,7 @@ impl BaseCommand for MigrateCommand {
 		let target = ctx.arg(1).map(|s| s.to_string());
 		let is_fake = ctx.has_option("fake");
 		let _is_fake_initial = ctx.has_option("fake-initial");
+		#[cfg_attr(not(feature = "migrations"), allow(unused_variables))]
 		let is_plan = ctx.has_option("plan");
 		let _database = ctx
 			.option("database")
@@ -1942,9 +1943,15 @@ impl BaseCommand for RunServerCommand {
 		}
 
 		let address = ctx.arg(0).map(|s| s.as_str()).unwrap_or("127.0.0.1:8000");
+		#[cfg_attr(not(feature = "server"), allow(unused_variables))]
 		let noreload = ctx.has_option("noreload");
+		#[cfg_attr(not(feature = "server"), allow(unused_variables))]
 		let no_wasm_rebuild = ctx.has_option("no-wasm-rebuild");
 		let insecure = ctx.has_option("insecure");
+		#[cfg_attr(
+			not(any(feature = "server", feature = "openapi-router")),
+			allow(unused_variables)
+		)]
 		let no_docs = ctx.has_option("no_docs");
 		let with_pages = ctx.has_option("with-pages");
 		let static_dir_raw = ctx
@@ -1952,6 +1959,7 @@ impl BaseCommand for RunServerCommand {
 			.map(|s| s.to_string())
 			.unwrap_or_else(|| "dist".to_string());
 		let no_spa = ctx.has_option("no-spa");
+		#[cfg_attr(not(feature = "server"), allow(unused_variables))]
 		let no_project_static = ctx.has_option("no-project-static");
 		// Build WASM frontend if --with-pages and not --no-wasm
 		#[cfg(feature = "pages")]

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -153,6 +153,8 @@ pub mod output;
 /// Plugin management commands.
 #[cfg(feature = "plugins")]
 pub mod plugin_commands;
+/// Project dependency configuration commands.
+pub mod project_config;
 /// Command registry for discovery and dispatch.
 pub mod registry;
 /// Runserver lifecycle hooks for concurrent services and pre-listen validation.
@@ -231,6 +233,7 @@ pub use i18n_commands::{CompileMessagesCommand, MakeMessagesCommand};
 pub use introspect::IntrospectCommand;
 pub use mail_commands::SendTestEmailCommand;
 pub use output::OutputWrapper;
+pub use project_config::{ConfigureCommand, ReinhardtDependencySelection};
 pub use registry::CommandRegistry;
 #[cfg(feature = "server")]
 pub use runserver_hooks::{RunserverContext, RunserverHook, RunserverHookRegistration};

--- a/crates/reinhardt-commands/src/project_config.rs
+++ b/crates/reinhardt-commands/src/project_config.rs
@@ -1,0 +1,385 @@
+//! Interactive Reinhardt dependency configuration for generated and existing projects.
+
+use crate::{BaseCommand, CommandContext, CommandError, CommandResult};
+use async_trait::async_trait;
+use crates_io_api::AsyncClient;
+use dialoguer::{Input, MultiSelect, Select};
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use toml_edit::{Array, DocumentMut, InlineTable, Item, Table, Value};
+
+const CRATE_NAME: &str = "reinhardt-web";
+const DEPENDENCY_NAME: &str = "reinhardt";
+const DEFAULT_USER_AGENT: &str = "reinhardt-admin (https://github.com/kent8192/reinhardt-web)";
+
+const PRESETS: &[&str] = &[
+	"standard",
+	"minimal",
+	"full",
+	"api-only",
+	"graphql-server",
+	"websocket-server",
+	"cli-tools",
+];
+
+const ADDITIVE_FEATURES: &[&str] = &[
+	"admin",
+	"pages",
+	"database",
+	"db-postgres",
+	"db-sqlite",
+	"db-mysql",
+	"auth",
+	"sessions",
+	"static-files",
+	"openapi",
+	"openapi-swagger-ui",
+	"browsable-api",
+	"websockets",
+	"cache",
+	"i18n",
+	"mail",
+	"tasks",
+	"commands-autoreload",
+	"middleware-compression",
+	"image-validation",
+];
+
+/// Resolved dependency selection for the `reinhardt` facade crate.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReinhardtDependencySelection {
+	/// Version requirement written to Cargo.toml.
+	pub version: String,
+	/// Whether Cargo default features should remain enabled.
+	pub default_features: bool,
+	/// Explicit feature list written to Cargo.toml.
+	pub features: Vec<String>,
+}
+
+impl ReinhardtDependencySelection {
+	/// Returns a TOML array literal suitable for embedded Tera templates.
+	pub fn features_toml(&self) -> String {
+		let quoted = self
+			.features
+			.iter()
+			.map(|feature| format!("\"{}\"", feature))
+			.collect::<Vec<_>>();
+		format!("[{}]", quoted.join(", "))
+	}
+}
+
+/// Resolve Reinhardt dependency options from explicit flags, prompts, or defaults.
+pub async fn resolve_dependency_selection(
+	ctx: &CommandContext,
+	required_features: &[&str],
+) -> CommandResult<ReinhardtDependencySelection> {
+	let current_version = env!("CARGO_PKG_VERSION").to_string();
+	let explicit_version = ctx.option("reinhardt-version").cloned();
+	let explicit_features = explicit_feature_values(ctx)?;
+	let explicit_default_features = ctx
+		.option("default-features")
+		.map(|value| parse_bool_option("default-features", value))
+		.transpose()?;
+
+	let interactive = should_prompt(ctx);
+	let version_candidates = if interactive {
+		fetch_versions()
+			.await
+			.unwrap_or_else(|_| vec![current_version.clone()])
+	} else {
+		Vec::new()
+	};
+
+	let version = if let Some(version) = explicit_version {
+		version
+	} else if interactive {
+		prompt_version(&version_candidates, &current_version)?
+	} else {
+		default_version(&version_candidates, &current_version)
+	};
+
+	let default_features = explicit_default_features.unwrap_or(false);
+	let mut features = if explicit_features.is_empty() {
+		if interactive {
+			prompt_features()?
+		} else {
+			vec!["standard".to_string()]
+		}
+	} else {
+		explicit_features
+	};
+
+	for feature in required_features {
+		if !features.iter().any(|existing| existing == feature) {
+			features.push((*feature).to_string());
+		}
+	}
+
+	Ok(ReinhardtDependencySelection {
+		version,
+		default_features,
+		features: normalize_features(features),
+	})
+}
+
+fn should_prompt(ctx: &CommandContext) -> bool {
+	if cfg!(test)
+		|| ctx.has_option("no-interactive")
+		|| std::env::var("REINHARDT_TEST_MODE").is_ok()
+	{
+		return false;
+	}
+	std::io::stdin().is_terminal()
+}
+
+fn default_version(candidates: &[String], current_version: &str) -> String {
+	if candidates.iter().any(|version| version == current_version) {
+		current_version.to_string()
+	} else {
+		candidates
+			.first()
+			.cloned()
+			.unwrap_or_else(|| current_version.to_string())
+	}
+}
+
+async fn fetch_versions() -> CommandResult<Vec<String>> {
+	let client =
+		AsyncClient::new(DEFAULT_USER_AGENT, Duration::from_millis(1000)).map_err(|e| {
+			CommandError::ExecutionError(format!("Failed to create crates.io client: {e}"))
+		})?;
+	let response = client.get_crate(CRATE_NAME).await.map_err(|e| {
+		CommandError::ExecutionError(format!("Failed to fetch '{CRATE_NAME}' versions: {e}"))
+	})?;
+	let versions = response
+		.versions
+		.into_iter()
+		.filter(|version| !version.yanked)
+		.map(|version| version.num)
+		.take(20)
+		.collect::<Vec<_>>();
+	if versions.is_empty() {
+		return Err(CommandError::ExecutionError(format!(
+			"crates.io returned no usable versions for '{CRATE_NAME}'"
+		)));
+	}
+	Ok(versions)
+}
+
+fn prompt_version(candidates: &[String], current_version: &str) -> CommandResult<String> {
+	let default = default_version(candidates, current_version);
+	let mut choices = candidates.to_vec();
+	choices.push("Custom version".to_string());
+	let default_index = choices
+		.iter()
+		.position(|version| version == &default)
+		.unwrap_or(0);
+	let selected = Select::new()
+		.with_prompt("Select Reinhardt version")
+		.items(&choices)
+		.default(default_index)
+		.interact()
+		.map_err(dialoguer_error)?;
+
+	if choices[selected] == "Custom version" {
+		Input::<String>::new()
+			.with_prompt("Reinhardt version")
+			.default(default)
+			.interact()
+			.map_err(dialoguer_error)
+	} else {
+		Ok(choices[selected].clone())
+	}
+}
+
+fn prompt_features() -> CommandResult<Vec<String>> {
+	let preset_index = Select::new()
+		.with_prompt("Select Reinhardt feature preset")
+		.items(PRESETS)
+		.default(0)
+		.interact()
+		.map_err(dialoguer_error)?;
+	let mut features = vec![PRESETS[preset_index].to_string()];
+
+	let selected = MultiSelect::new()
+		.with_prompt("Select additional Reinhardt features")
+		.items(ADDITIVE_FEATURES)
+		.interact()
+		.map_err(dialoguer_error)?;
+	for index in selected {
+		features.push(ADDITIVE_FEATURES[index].to_string());
+	}
+
+	Ok(features)
+}
+
+fn dialoguer_error(error: dialoguer::Error) -> CommandError {
+	CommandError::ExecutionError(format!("Prompt failed: {error}"))
+}
+
+fn explicit_feature_values(ctx: &CommandContext) -> CommandResult<Vec<String>> {
+	let mut features = Vec::new();
+	for key in ["feature", "features"] {
+		if let Some(values) = ctx.option_values(key) {
+			for value in values {
+				for feature in value.split(',') {
+					let trimmed = feature.trim();
+					if !trimmed.is_empty() {
+						features.push(trimmed.to_string());
+					}
+				}
+			}
+		}
+	}
+	if features
+		.iter()
+		.any(|feature| feature.contains(char::is_whitespace))
+	{
+		return Err(CommandError::InvalidArguments(
+			"Feature names must not contain whitespace.".to_string(),
+		));
+	}
+	Ok(normalize_features(features))
+}
+
+fn normalize_features(features: Vec<String>) -> Vec<String> {
+	let mut normalized = Vec::new();
+	for feature in features {
+		if !normalized.iter().any(|existing| existing == &feature) {
+			normalized.push(feature);
+		}
+	}
+	normalized
+}
+
+fn parse_bool_option(name: &str, value: &str) -> CommandResult<bool> {
+	match value {
+		"true" | "1" | "yes" => Ok(true),
+		"false" | "0" | "no" => Ok(false),
+		_ => Err(CommandError::InvalidArguments(format!(
+			"--{name} must be true or false, got '{value}'"
+		))),
+	}
+}
+
+/// Configure the `reinhardt` dependency in an existing Cargo project.
+pub struct ConfigureCommand;
+
+#[async_trait]
+impl BaseCommand for ConfigureCommand {
+	fn name(&self) -> &str {
+		"configure"
+	}
+
+	fn description(&self) -> &str {
+		"Configures the Reinhardt dependency version and feature flags for an existing project."
+	}
+
+	async fn execute(&self, ctx: &CommandContext) -> CommandResult<()> {
+		let root = ctx
+			.arg(0)
+			.map(PathBuf::from)
+			.unwrap_or_else(|| PathBuf::from("."));
+		let selection = resolve_dependency_selection(ctx, &[]).await?;
+		update_reinhardt_dependency(&root, &selection)?;
+		ctx.success(&format!(
+			"Configured Reinhardt {} with features {} in {}",
+			selection.version,
+			selection.features_toml(),
+			root.join("Cargo.toml").display()
+		));
+		Ok(())
+	}
+}
+
+/// Update or insert the `reinhardt` dependency in `Cargo.toml`.
+pub fn update_reinhardt_dependency(
+	project_root: &Path,
+	selection: &ReinhardtDependencySelection,
+) -> CommandResult<()> {
+	let cargo_path = project_root.join("Cargo.toml");
+	let content = std::fs::read_to_string(&cargo_path)?;
+	let updated = update_reinhardt_dependency_content(&content, selection)?;
+	std::fs::write(&cargo_path, updated)?;
+	Ok(())
+}
+
+/// Update or insert the `reinhardt` dependency in TOML content.
+pub fn update_reinhardt_dependency_content(
+	content: &str,
+	selection: &ReinhardtDependencySelection,
+) -> CommandResult<String> {
+	let mut doc: DocumentMut = content
+		.parse()
+		.map_err(|e| CommandError::ParseError(format!("Failed to parse Cargo.toml: {e}")))?;
+	let deps = doc
+		.entry("dependencies")
+		.or_insert(Item::Table(Table::new()))
+		.as_table_mut()
+		.ok_or_else(|| {
+			CommandError::ParseError("[dependencies] must be a TOML table".to_string())
+		})?;
+
+	deps.insert(DEPENDENCY_NAME, dependency_item(selection));
+	Ok(doc.to_string())
+}
+
+fn dependency_item(selection: &ReinhardtDependencySelection) -> Item {
+	let mut table = InlineTable::new();
+	table.insert("version", Value::from(selection.version.as_str()));
+	table.insert("package", Value::from(CRATE_NAME));
+	table.insert("default-features", Value::from(selection.default_features));
+	let mut features = Array::default();
+	for feature in &selection.features {
+		features.push(feature.as_str());
+	}
+	table.insert("features", Value::Array(features));
+	Item::Value(Value::InlineTable(table))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn selection() -> ReinhardtDependencySelection {
+		ReinhardtDependencySelection {
+			version: "0.2.0-rc.4".to_string(),
+			default_features: false,
+			features: vec!["minimal".to_string(), "db-sqlite".to_string()],
+		}
+	}
+
+	#[test]
+	fn features_toml_formats_array_literal() {
+		assert_eq!(selection().features_toml(), "[\"minimal\", \"db-sqlite\"]");
+	}
+
+	#[test]
+	fn update_dependency_inserts_missing_dependency() {
+		let updated = update_reinhardt_dependency_content(
+			"[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+			&selection(),
+		)
+		.unwrap();
+
+		assert!(updated.contains("[dependencies]"));
+		assert!(updated.contains("reinhardt = { version = \"0.2.0-rc.4\""));
+		assert!(updated.contains("package = \"reinhardt-web\""));
+		assert!(updated.contains("features = [\"minimal\", \"db-sqlite\"]"));
+	}
+
+	#[test]
+	fn update_dependency_replaces_existing_dependency() {
+		let updated = update_reinhardt_dependency_content(
+			"[dependencies]\nreinhardt = { version = \"0.1.0\", package = \"reinhardt-web\", features = [\"full\"] }\nserde = \"1\"\n",
+			&selection(),
+		)
+		.unwrap();
+
+		assert!(updated.contains("serde = \"1\""));
+		assert!(updated.contains("version = \"0.2.0-rc.4\""));
+		assert!(updated.contains("features = [\"minimal\", \"db-sqlite\"]"));
+		assert!(!updated.contains("\"full\""));
+	}
+}

--- a/crates/reinhardt-commands/src/start_commands.rs
+++ b/crates/reinhardt-commands/src/start_commands.rs
@@ -9,7 +9,7 @@
 use crate::template_source::{EmbeddedSource, FilesystemSource, MergedSource, TemplateSource};
 use crate::{
 	BaseCommand, CommandArgument, CommandContext, CommandError, CommandOption, CommandResult,
-	TemplateCommand, TemplateContext, generate_secret_key, to_camel_case,
+	TemplateCommand, TemplateContext, generate_secret_key, project_config, to_camel_case,
 };
 use async_trait::async_trait;
 use std::env;
@@ -120,6 +120,13 @@ impl BaseCommand for StartProjectCommand {
 
 		// Generate a random secret key
 		let secret_key = format!("insecure-{}", generate_secret_key());
+		let required_features = if with_pages {
+			&["pages", "admin"][..]
+		} else {
+			&[][..]
+		};
+		let dependency_selection =
+			project_config::resolve_dependency_selection(ctx, required_features).await?;
 
 		// Prepare template context
 		let mut context = TemplateContext::new();
@@ -131,7 +138,15 @@ impl BaseCommand for StartProjectCommand {
 			"CHANGE_THIS_IN_PRODUCTION_MUST_BE_KEPT_SECRET",
 		)?;
 		context.insert("camel_case_project_name", to_camel_case(&project_name))?;
-		context.insert("reinhardt_version", env!("CARGO_PKG_VERSION"))?;
+		context.insert("reinhardt_version", &dependency_selection.version)?;
+		context.insert(
+			"reinhardt_default_features",
+			dependency_selection.default_features,
+		)?;
+		context.insert(
+			"reinhardt_features_toml",
+			dependency_selection.features_toml(),
+		)?;
 		context.insert("is_restful", if !with_pages { "true" } else { "false" })?;
 		context.insert("with_pages", if with_pages { "true" } else { "false" })?;
 

--- a/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
@@ -12,10 +12,7 @@ name = "manage"
 path = "src/bin/manage.rs"
 
 [dependencies]
-reinhardt = { version = "{{ reinhardt_version }}", package = "reinhardt-web", features = [
-	"full",
-	"admin",  # Admin panel functionality (includes reinhardt-pages)
-] }
+reinhardt = { version = "{{ reinhardt_version }}", package = "reinhardt-web", default-features = {{ reinhardt_default_features }}, features = {{ reinhardt_features_toml }} }
 
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.11", features = ["v4", "serde"] }

--- a/crates/reinhardt-commands/templates/project_restful_template/Cargo.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/Cargo.toml.tpl
@@ -8,7 +8,7 @@ name = "manage"
 path = "src/bin/manage.rs"
 
 [dependencies]
-reinhardt = { version = "{{ reinhardt_version }}", package = "reinhardt-web", features = ["full"] }
+reinhardt = { version = "{{ reinhardt_version }}", package = "reinhardt-web", default-features = {{ reinhardt_default_features }}, features = {{ reinhardt_features_toml }} }
 ctor = "0.6"
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/crates/reinhardt-commands/tests/embedded_startproject.rs
+++ b/crates/reinhardt-commands/tests/embedded_startproject.rs
@@ -149,4 +149,5 @@ async fn startproject_pages_adds_required_pages_features() {
 	let cargo_toml =
 		std::fs::read_to_string(tmp.path().join("pages_feature_proj/Cargo.toml")).unwrap();
 	assert!(cargo_toml.contains("features = [\"minimal\", \"pages\", \"admin\"]"));
+	assert_manifest_parses(&tmp.path().join("pages_feature_proj/Cargo.toml"));
 }

--- a/crates/reinhardt-commands/tests/embedded_startproject.rs
+++ b/crates/reinhardt-commands/tests/embedded_startproject.rs
@@ -66,6 +66,38 @@ async fn startproject_restful_from_embedded_only() {
 #[rstest]
 #[tokio::test]
 #[serial(cwd)]
+async fn startproject_restful_honors_dependency_selection_flags() {
+	let tmp = TempDir::new().unwrap();
+	let prev = std::env::current_dir().unwrap();
+	std::env::set_current_dir(tmp.path()).unwrap();
+
+	let mut ctx = CommandContext::new(vec!["feature_proj".to_string()]);
+	let mut opts = HashMap::new();
+	opts.insert("restful".to_string(), vec!["true".to_string()]);
+	opts.insert(
+		"reinhardt-version".to_string(),
+		vec!["0.2.0-rc.4".to_string()],
+	);
+	opts.insert(
+		"features".to_string(),
+		vec!["minimal,db-sqlite".to_string()],
+	);
+	opts.insert("no-interactive".to_string(), vec!["true".to_string()]);
+	ctx = ctx.with_options(opts);
+
+	let res = StartProjectCommand.execute(&ctx).await;
+
+	std::env::set_current_dir(prev).unwrap();
+	res.expect("startproject succeeds with dependency selection flags");
+	let cargo_toml = std::fs::read_to_string(tmp.path().join("feature_proj/Cargo.toml")).unwrap();
+	assert!(cargo_toml.contains("version = \"0.2.0-rc.4\""));
+	assert!(cargo_toml.contains("default-features = false"));
+	assert!(cargo_toml.contains("features = [\"minimal\", \"db-sqlite\"]"));
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(cwd)]
 async fn startproject_pages_from_embedded_only() {
 	// Arrange
 	let tmp = TempDir::new().unwrap();
@@ -93,4 +125,28 @@ async fn startproject_pages_from_embedded_only() {
 		"src/ directory must be generated"
 	);
 	assert_manifest_parses(&generated.join("Cargo.toml"));
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(cwd)]
+async fn startproject_pages_adds_required_pages_features() {
+	let tmp = TempDir::new().unwrap();
+	let prev = std::env::current_dir().unwrap();
+	std::env::set_current_dir(tmp.path()).unwrap();
+
+	let mut ctx = CommandContext::new(vec!["pages_feature_proj".to_string()]);
+	let mut opts = HashMap::new();
+	opts.insert("with-pages".to_string(), vec!["true".to_string()]);
+	opts.insert("features".to_string(), vec!["minimal".to_string()]);
+	opts.insert("no-interactive".to_string(), vec!["true".to_string()]);
+	ctx = ctx.with_options(opts);
+
+	let res = StartProjectCommand.execute(&ctx).await;
+
+	std::env::set_current_dir(prev).unwrap();
+	res.expect("startproject --with-pages succeeds with dependency selection flags");
+	let cargo_toml =
+		std::fs::read_to_string(tmp.path().join("pages_feature_proj/Cargo.toml")).unwrap();
+	assert!(cargo_toml.contains("features = [\"minimal\", \"pages\", \"admin\"]"));
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Interactive `reinhardt-admin startproject` dependency selection for Reinhardt version and feature flags
- `reinhardt-admin configure` for updating existing project `Cargo.toml` dependency settings
- Template and documentation updates for explicit `reinhardt-web` version/features

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Generated projects previously hard-coded `features = ["full"]`, which made scaffolds heavier than the documented `standard` recommendation and gave scripts no direct way to pin Reinhardt versions/features. Existing projects also had no matching CLI flow to update the facade dependency.

Related to: #5215

## How Was This Tested?

- `cargo check -p reinhardt-commands --tests`
- `cargo check -p reinhardt-admin-cli --tests`
- `cargo test -p reinhardt-commands project_config`
- `cargo test -p reinhardt-commands --test embedded_startproject`
- `cargo fmt --all --check`
- `cargo make fmt-check`
- `git diff --check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Stacked on #5215

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This PR intentionally keeps crates.io lookup in the interactive path only. Non-interactive runs use deterministic defaults unless version/features are passed explicitly.
