### PR TITLE
perf(build): reduce hot-reload rebuild latency on develop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -734,7 +734,8 @@ topiary-web-tree-sitter-sys = { path = "vendor/topiary-web-tree-sitter-sys" }
 # (private vec macro issue, see https://github.com/rust-lang/rust/issues/120192)
 
 [profile.dev]
-debug = 1
+codegen-units = 16
+debug = 0
 
 [profile.test]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -565,7 +565,7 @@ hyper = { version = "1.9.0", features = ["full"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 http = "1.4.0"
 http-body-util = "0.1.3"
-reqwest = { version = "0.13.2", features = ["json", "form"] }
+reqwest = { version = "0.13.2", default-features = false, features = ["http2", "json", "form", "rustls"] }
 
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -734,7 +734,13 @@ topiary-web-tree-sitter-sys = { path = "vendor/topiary-web-tree-sitter-sys" }
 # (private vec macro issue, see https://github.com/rust-lang/rust/issues/120192)
 
 [profile.dev]
-debug = 1
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+codegen-units = 256
+incremental = true
 
 [profile.test]
-debug = 1
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+codegen-units = 256
+incremental = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -734,13 +734,7 @@ topiary-web-tree-sitter-sys = { path = "vendor/topiary-web-tree-sitter-sys" }
 # (private vec macro issue, see https://github.com/rust-lang/rust/issues/120192)
 
 [profile.dev]
-debug = "line-tables-only"
-split-debuginfo = "unpacked"
-codegen-units = 256
-incremental = true
+debug = 1
 
 [profile.test]
-debug = "line-tables-only"
-split-debuginfo = "unpacked"
-codegen-units = 256
-incremental = true
+debug = 1

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -38,6 +38,22 @@ description = "Clean build artifacts"
 command = "cargo"
 args = ["clean"]
 
+[tasks.bench-builds]
+description = "Measure standard build-loop scenarios with hyperfine"
+script_runner = "sh"
+script = '''
+set -e
+scripts/bench-build.sh
+'''
+
+[tasks.bench-builds-dry-run]
+description = "Print standard build-loop benchmark commands without running them"
+script_runner = "sh"
+script = '''
+set -e
+scripts/bench-build.sh --dry-run
+'''
+
 # ============================================================================
 # Code Quality Tasks
 # ============================================================================

--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ but manage the wasm build yourself. A successful server restart log is
 emitted only after the respawned child accepts connections at the
 advertised development address.
 
+For build-loop performance work, use `cargo make bench-builds-dry-run`
+to inspect the benchmark commands and `cargo make bench-builds` to write
+a reproducible report under `docs/build-perf/`.
+
 ### 4. Create Your First App
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -310,7 +310,8 @@ advertised development address.
 
 For build-loop performance work, use `cargo make bench-builds-dry-run`
 to inspect the benchmark commands and `cargo make bench-builds` to write
-a reproducible report under `docs/build-perf/`.
+a reproducible report under `docs/build-perf/`. See
+[Build Performance](instructions/BUILD_PERFORMANCE.md) for details.
 
 ### 4. Create Your First App
 

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -105,7 +105,7 @@ testcontainers = ["dep:reinhardt-test", "reinhardt-test?/testcontainers"]
 plugins = ["dep:reinhardt-dentdelion"]
 auth = ["dep:reinhardt-auth", "reinhardt-auth?/database", "reinhardt-db"]
 admin = []
-pages = ["routers", "reinhardt-urls/client-router"]
+pages = ["routers", "reinhardt-urls/client-router", "reinhardt-pages/hmr"]
 full = [
   "migrations",
   "routers",

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -54,9 +54,9 @@ rustyline = { version = "17.0.2", optional = true }
 rhai = { version = "1.20", optional = true }
 
 # AST dependencies for robust code generation
-syn = { version = "2.0", features = ["full", "parsing"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true, features = ["full", "parsing"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 prettyplease = "0.2"
 
 # TLS/HTTPS support

--- a/crates/reinhardt-commands/examples/page_hot_patch_probe.rs
+++ b/crates/reinhardt-commands/examples/page_hot_patch_probe.rs
@@ -1,0 +1,13 @@
+use std::path::PathBuf;
+
+fn main() {
+	let paths = std::env::args_os()
+		.skip(1)
+		.map(PathBuf::from)
+		.collect::<Vec<_>>();
+	let Some(html) = reinhardt_commands::__hot_reload_test_api::render_static_page_patch(&paths)
+	else {
+		std::process::exit(2);
+	};
+	println!("{}", html.len());
+}

--- a/crates/reinhardt-commands/src/bin/runserver.rs
+++ b/crates/reinhardt-commands/src/bin/runserver.rs
@@ -15,6 +15,7 @@ use hyper::{Request, Response, StatusCode, body::Incoming};
 use hyper_util::rt::TokioIo;
 use reinhardt_commands::WelcomePage;
 use reinhardt_commands::{CollectStaticCommand, CollectStaticOptions};
+#[cfg(any(feature = "admin", feature = "pages"))]
 use reinhardt_commands::{
 	WasmBuildConfig, WasmBuilder, detect_cdylib_in_cargo_toml, is_wasm_stale,
 };
@@ -743,6 +744,10 @@ fn build_wasm_targets(no_wasm: bool, no_override_wasm: bool, force_wasm_legacy: 
 		);
 	}
 
+	#[cfg(not(any(feature = "admin", feature = "pages")))]
+	let _ = no_override_wasm;
+
+	#[cfg(any(feature = "admin", feature = "pages"))]
 	let force = !no_override_wasm;
 
 	#[cfg(feature = "admin")]

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -2469,6 +2469,12 @@ impl RunServerCommand {
 				static_config = static_config.cache_config(CacheControlConfig::disabled());
 			}
 
+			#[cfg(feature = "pages")]
+			if let Some(hmr_port) = Self::autoreload_hmr_port_from_env(ctx) {
+				static_config = static_config
+					.trusted_html_injection(reinhardt_pages::hmr::hmr_script_tag(hmr_port));
+			}
+
 			// Resolve index file for SPA fallback (only when SPA mode is enabled)
 			// Refs #2869: Separate index.html (source) from dist/ (build output)
 			if !no_spa {
@@ -2540,6 +2546,75 @@ impl RunServerCommand {
 				.listen_with_shutdown(addr, ShutdownCoordinator::clone(&coordinator))
 				.await
 				.map_err(|e| crate::CommandError::ExecutionError(e.to_string()))
+		}
+	}
+
+	/// Start the browser-facing HMR WebSocket listener for autoreload mode.
+	#[cfg(all(feature = "server", feature = "autoreload", feature = "pages"))]
+	async fn start_autoreload_hmr(
+		ctx: &CommandContext,
+		with_pages: bool,
+	) -> CommandResult<Option<(reinhardt_pages::hmr::HmrServer, u16)>> {
+		if !with_pages {
+			return Ok(None);
+		}
+
+		let requested_port = std::env::var("REINHARDT_HMR_PORT")
+			.ok()
+			.and_then(|raw| raw.parse::<u16>().ok())
+			.unwrap_or(35729);
+
+		let server = reinhardt_pages::hmr::HmrServer::new(
+			reinhardt_pages::hmr::HmrConfig::builder()
+				.ws_port(requested_port)
+				.build(),
+		);
+
+		let addr = match server.start_listener_only().await {
+			Ok(addr) => addr,
+			Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+				ctx.warning(&format!(
+					"[hot-reload] HMR port {} is in use, using an ephemeral port",
+					requested_port
+				));
+				let fallback = reinhardt_pages::hmr::HmrServer::new(
+					reinhardt_pages::hmr::HmrConfig::builder()
+						.ws_port(0)
+						.build(),
+				);
+				let addr = fallback.start_listener_only().await.map_err(|err| {
+					crate::CommandError::ExecutionError(format!(
+						"Failed to start HMR WebSocket listener: {}",
+						err
+					))
+				})?;
+				ctx.info(&format!("[hot-reload] HMR websocket: ws://{}/hmr", addr));
+				return Ok(Some((fallback, addr.port())));
+			}
+			Err(e) => {
+				return Err(crate::CommandError::ExecutionError(format!(
+					"Failed to start HMR WebSocket listener: {}",
+					e
+				)));
+			}
+		};
+
+		ctx.info(&format!("[hot-reload] HMR websocket: ws://{}/hmr", addr));
+		Ok(Some((server, addr.port())))
+	}
+
+	#[cfg(all(feature = "server", feature = "pages"))]
+	fn autoreload_hmr_port_from_env(ctx: &CommandContext) -> Option<u16> {
+		let raw = std::env::var("REINHARDT_HMR_PORT").ok()?;
+		match raw.parse::<u16>() {
+			Ok(port) => Some(port),
+			Err(_) => {
+				ctx.warning(&format!(
+					"Ignoring invalid REINHARDT_HMR_PORT value: {}",
+					raw
+				));
+				None
+			}
 		}
 	}
 
@@ -2642,6 +2717,14 @@ impl RunServerCommand {
 		let address_owned = address.to_string();
 		let static_dir_owned = static_dir.to_string();
 		let index_owned = index.map(|s| s.to_string());
+		#[cfg(feature = "pages")]
+		let hmr = Self::start_autoreload_hmr(ctx, with_pages).await?;
+		#[cfg(feature = "pages")]
+		let hmr_port = hmr.as_ref().map(|(_, port)| *port);
+		#[cfg(not(feature = "pages"))]
+		let hmr_port: Option<u16> = None;
+		#[cfg(feature = "pages")]
+		let hmr_tx = hmr.as_ref().map(|(server, _)| server.sender());
 
 		let respawn = move || -> std::io::Result<tokio::process::Child> {
 			Self::spawn_server_process(
@@ -2653,6 +2736,7 @@ impl RunServerCommand {
 				no_spa,
 				no_project_static,
 				index_owned.as_deref(),
+				hmr_port,
 			)
 			.map_err(|e| std::io::Error::other(e.to_string()))
 		};
@@ -2667,9 +2751,12 @@ impl RunServerCommand {
 			bin_name,
 			address: address.to_string(),
 			roots,
+			server_address: Some(address.to_string()),
 			no_wasm_rebuild,
 			#[cfg(feature = "pages")]
 			pages_enabled: with_pages,
+			#[cfg(feature = "pages")]
+			hmr_tx,
 		};
 
 		crate::debounced_watcher::run_watcher(ctx, &cfg, shutdown_rx, child, respawn)
@@ -2851,6 +2938,7 @@ impl RunServerCommand {
 		no_spa: bool,
 		no_project_static: bool,
 		index: Option<&str>,
+		hmr_port: Option<u16>,
 	) -> CommandResult<tokio::process::Child> {
 		let current_exe = std::env::current_exe().map_err(|e| {
 			crate::CommandError::ExecutionError(format!("Failed to get current executable: {}", e))
@@ -2896,6 +2984,9 @@ impl RunServerCommand {
 		}
 		if let Some(index_path) = index {
 			cmd.arg("--index").arg(index_path);
+		}
+		if let Some(port) = hmr_port {
+			cmd.env("REINHARDT_HMR_PORT", port.to_string());
 		}
 
 		// Set environment variable to indicate this is a child process (prevent log duplication, etc.)

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -3066,16 +3066,23 @@ impl RunServerCommand {
 		};
 
 		let js_name = crate_name.replace('-', "_");
-		let artifact = cwd.join("dist").join(format!("{}.js", js_name));
-		if artifact.exists() && !force {
-			ctx.info(&format!(
-				"Pages WASM: --no-override-wasm set and dist/{}.js exists, skipping build",
-				js_name
-			));
+		let artifact = cwd.join("dist").join(format!("{}_bg.wasm", js_name));
+		if !force && !crate::wasm_builder::is_wasm_stale(&cwd, &artifact) {
+			ctx.info("Pages WASM: artifacts up to date, skipping build (--no-override-wasm)");
 			return Ok(());
 		}
 
-		ctx.info(&format!("Building pages WASM for {}...", crate_name));
+		let reason = if force {
+			"forced rebuild"
+		} else if artifact.exists() {
+			"source changed since last build"
+		} else {
+			"no existing artifact"
+		};
+		ctx.info(&format!(
+			"Building pages WASM for {} ({})...",
+			crate_name, reason
+		));
 		let config = crate::wasm_builder::WasmBuildConfig::new(".").output_dir("dist");
 		match crate::wasm_builder::WasmBuilder::new(config).build() {
 			Ok(_) => {

--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -268,6 +268,31 @@ fn notify_browser_reload(hmr_tx: Option<&broadcast::Sender<String>>, reason: &st
 	}
 }
 
+#[cfg(feature = "pages")]
+fn notify_static_page_patch(
+	hmr_tx: Option<&broadcast::Sender<String>>,
+	paths: &[PathBuf],
+	targets: RebuildTargets,
+) -> bool {
+	if hmr_tx.is_none() || targets.server || !targets.wasm {
+		return false;
+	}
+	let Some(html) = crate::page_hot_patch::render_static_page_patch(paths) else {
+		return false;
+	};
+	let msg = reinhardt_pages::hmr::HmrMessage::HtmlReplace {
+		selector: "body".to_string(),
+		html,
+	};
+	if let Ok(json) = msg.to_json() {
+		if let Some(tx) = hmr_tx {
+			let _ = tx.send(json);
+			return true;
+		}
+	}
+	false
+}
+
 /// Dispatch one debounced path batch through the selected rebuild pipelines.
 ///
 /// This is split out from [`run_watcher`] so tests can validate the
@@ -287,6 +312,11 @@ pub async fn run_rebuild_for_paths(
 	let targets = rebuild_targets_for_paths(&paths, config);
 	if !targets.has_work() {
 		ctx.info("[hot-reload] no rebuild target matched; waiting for next change");
+		return;
+	}
+	#[cfg(feature = "pages")]
+	if notify_static_page_patch(config.hmr_tx.as_ref(), &paths, targets) {
+		ctx.info("[hot-reload] static page patch sent without rebuilding WASM");
 		return;
 	}
 
@@ -687,5 +717,81 @@ mod tests {
 	fn notify_browser_reload_without_channel_is_noop() {
 		// Act & Assert
 		notify_browser_reload(None, "Server rebuild completed successfully");
+	}
+
+	#[cfg(feature = "pages")]
+	#[test]
+	fn notify_static_page_patch_sends_html_replace_for_wasm_only_static_page() {
+		// Arrange
+		let temp_dir = tempfile::tempdir().expect("tempdir should be created");
+		let client_path = temp_dir.path().join("src").join("client.rs");
+		std::fs::create_dir_all(
+			client_path
+				.parent()
+				.expect("client path should have parent"),
+		)
+		.expect("client dir should be created");
+		std::fs::write(
+			&client_path,
+			r#"
+				use reinhardt_pages::page;
+
+				fn home_page() -> Page {
+					page!(|| {
+						div {
+							id: "route-home",
+							"Updated"
+						}
+					})()
+				}
+			"#,
+		)
+		.expect("client page fixture should be written");
+		let (tx, mut rx) = broadcast::channel::<String>(8);
+
+		// Act
+		let sent = notify_static_page_patch(
+			Some(&tx),
+			&[client_path],
+			RebuildTargets {
+				server: false,
+				wasm: true,
+			},
+		);
+
+		// Assert
+		assert!(sent, "static page patch should be sent");
+		let json = rx
+			.try_recv()
+			.expect("html patch message should be broadcast");
+		let message: reinhardt_pages::hmr::HmrMessage =
+			serde_json::from_str(&json).expect("message should be valid HMR JSON");
+		assert_eq!(
+			message,
+			reinhardt_pages::hmr::HmrMessage::HtmlReplace {
+				selector: "body".to_string(),
+				html: r#"<div id="route-home">Updated</div>"#.to_string(),
+			}
+		);
+	}
+
+	#[cfg(feature = "pages")]
+	#[test]
+	fn notify_static_page_patch_falls_back_for_server_target() {
+		// Arrange
+		let (tx, _rx) = broadcast::channel::<String>(8);
+
+		// Act
+		let sent = notify_static_page_patch(
+			Some(&tx),
+			&[PathBuf::from("/project/src/lib.rs")],
+			RebuildTargets {
+				server: true,
+				wasm: true,
+			},
+		);
+
+		// Assert
+		assert!(!sent, "shared files must keep the rebuild path");
 	}
 }

--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -613,6 +613,7 @@ mod tests {
 	fn pages_config(no_wasm_rebuild: bool) -> WatcherConfig {
 		WatcherConfig {
 			bin_name: "manage".to_string(),
+			address: "127.0.0.1:8000".to_string(),
 			roots: SourceRoots {
 				src_dirs: vec![PathBuf::from("/project/src")],
 				manifest_files: vec![PathBuf::from("/project/Cargo.toml")],

--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -281,7 +281,7 @@ fn notify_static_page_patch(
 		return false;
 	};
 	let msg = reinhardt_pages::hmr::HmrMessage::HtmlReplace {
-		selector: "body".to_string(),
+		selector: "#app".to_string(),
 		html,
 	};
 	if let Ok(json) = msg.to_json() {
@@ -370,6 +370,8 @@ pub async fn run_rebuild_for_paths(
 				"Rust rebuild completed successfully",
 			);
 		}
+		#[cfg(not(feature = "pages"))]
+		let _ = (wasm_ok, server_ready);
 	} else if targets.wasm {
 		let wasm_ok = wasm_fut.await;
 		#[cfg(feature = "pages")]
@@ -379,6 +381,8 @@ pub async fn run_rebuild_for_paths(
 				"WASM rebuild completed successfully",
 			);
 		}
+		#[cfg(not(feature = "pages"))]
+		let _ = wasm_ok;
 	} else {
 		let (server_outcome, new_child) =
 			crate::server_rebuild_pipeline::ServerRebuildPipeline::run_with_readiness(
@@ -404,6 +408,8 @@ pub async fn run_rebuild_for_paths(
 				"Server rebuild completed successfully",
 			);
 		}
+		#[cfg(not(feature = "pages"))]
+		let _ = server_ready;
 	}
 	// Pipeline failures are recorded as log lines and never propagate as Err;
 	// the caller's loop continues unconditionally.
@@ -769,7 +775,7 @@ mod tests {
 		assert_eq!(
 			message,
 			reinhardt_pages::hmr::HmrMessage::HtmlReplace {
-				selector: "body".to_string(),
+				selector: "#app".to_string(),
 				html: r#"<div id="route-home">Updated</div>"#.to_string(),
 			}
 		);

--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -97,6 +97,21 @@ pub async fn debounce_next(rx: &mut Receiver<Event>, window: Duration) -> Option
 	Some(paths.into_iter().collect())
 }
 
+/// Rebuild pipelines selected for a debounced change batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RebuildTargets {
+	/// Rebuild and respawn the native server binary.
+	pub server: bool,
+	/// Rebuild the Pages WASM bundle.
+	pub wasm: bool,
+}
+
+impl RebuildTargets {
+	fn has_work(self) -> bool {
+		self.server || self.wasm
+	}
+}
+
 /// Configuration for `run_watcher`.
 pub struct WatcherConfig {
 	/// Bin name passed to `cargo build --bin`.
@@ -110,6 +125,90 @@ pub struct WatcherConfig {
 	/// When `true`, the project has the pages feature enabled.
 	#[cfg(feature = "pages")]
 	pub pages_enabled: bool,
+}
+
+/// Select rebuild pipelines for a debounced path batch.
+///
+/// The classifier is deliberately conservative. It only suppresses a
+/// pipeline for generated Pages paths whose ownership is stable:
+/// `src/client.rs`, `src/client/**`, and `src/apps/*/client/**` are WASM-only;
+/// `src/bin/**` and server process configuration are native-only. Shared code,
+/// manifests, and lockfiles still rebuild both sides.
+pub fn rebuild_targets_for_paths(paths: &[PathBuf], config: &WatcherConfig) -> RebuildTargets {
+	#[cfg(feature = "pages")]
+	let pages_enabled = config.pages_enabled;
+	#[cfg(not(feature = "pages"))]
+	let pages_enabled = false;
+
+	if !pages_enabled {
+		return RebuildTargets {
+			server: !paths.is_empty(),
+			wasm: false,
+		};
+	}
+
+	let wasm_enabled = !config.no_wasm_rebuild;
+	let mut targets = RebuildTargets {
+		server: false,
+		wasm: false,
+	};
+
+	for path in paths {
+		match classify_pages_path(path) {
+			PagesPathClass::WasmOnly => {
+				targets.wasm |= wasm_enabled;
+			}
+			PagesPathClass::ServerOnly => {
+				targets.server = true;
+			}
+			PagesPathClass::Both => {
+				targets.server = true;
+				targets.wasm |= wasm_enabled;
+			}
+		}
+	}
+
+	targets
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PagesPathClass {
+	ServerOnly,
+	WasmOnly,
+	Both,
+}
+
+fn classify_pages_path(path: &std::path::Path) -> PagesPathClass {
+	let normalized = normalized_path(path);
+	let wrapped = format!("/{normalized}");
+
+	if wrapped.ends_with("/Cargo.toml") || wrapped.ends_with("/Cargo.lock") {
+		return PagesPathClass::Both;
+	}
+
+	if wrapped.ends_with("/src/client.rs")
+		|| wrapped.contains("/src/client/")
+		|| (wrapped.contains("/src/apps/") && wrapped.contains("/client/"))
+	{
+		return PagesPathClass::WasmOnly;
+	}
+
+	if wrapped.contains("/src/bin/")
+		|| wrapped.ends_with("/src/config/apps.rs")
+		|| wrapped.ends_with("/src/config/settings.rs")
+	{
+		return PagesPathClass::ServerOnly;
+	}
+
+	if wrapped.ends_with(".toml") {
+		return PagesPathClass::ServerOnly;
+	}
+
+	PagesPathClass::Both
+}
+
+fn normalized_path(path: &std::path::Path) -> String {
+	path.to_string_lossy().replace('\\', "/")
 }
 
 /// Run the hot-reload watcher loop until shutdown.
@@ -195,18 +294,19 @@ pub async fn run_watcher(
 					return Ok(());
 				};
 				ctx.info(&format!(
-					"[hot-reload] change detected ({} path(s)), rebuilding...",
+					"[hot-reload] change detected ({} path(s))",
 					paths.len()
 				));
+				let targets = rebuild_targets_for_paths(&paths, config);
+				if !targets.has_work() {
+					ctx.info("[hot-reload] no rebuild target matched; waiting for next change");
+					continue;
+				}
 
-				// Spec §4: run wasm + server pipelines in parallel. They
-				// touch disjoint cargo target directories (`wasm32-unknown-unknown`
-				// vs `debug`) and the wasm pipeline does not interact with the
-				// running child process, so concurrent execution is safe.
 				let wasm_fut = async {
 					#[cfg(feature = "pages")]
 					{
-						if config.pages_enabled && !config.no_wasm_rebuild {
+						if targets.wasm {
 							let outcome =
 								crate::wasm_rebuild_pipeline::WasmRebuildPipeline::run(ctx).await;
 							if let Some(line) =
@@ -224,16 +324,38 @@ pub async fn run_watcher(
 						}
 					}
 				};
-				let server_fut = crate::server_rebuild_pipeline::ServerRebuildPipeline::run_with_readiness(
-					&config.bin_name,
-					&mut current_child,
-					&respawn,
-					&config.address,
-				);
-				let ((), (_outcome, new_child)) = tokio::join!(wasm_fut, server_fut);
-				if let Some(child) = new_child {
-					current_child = child;
-				}
+
+					if targets.server && targets.wasm {
+						// Spec §4: run wasm + server pipelines in parallel. They
+						// touch disjoint cargo target directories (`wasm32-unknown-unknown`
+						// vs `debug`) and the wasm pipeline does not interact with the
+						// running child process, so concurrent execution is safe.
+						let server_fut =
+							crate::server_rebuild_pipeline::ServerRebuildPipeline::run_with_readiness(
+								&config.bin_name,
+								&mut current_child,
+								&respawn,
+								&config.address,
+							);
+						let ((), (_outcome, new_child)) = tokio::join!(wasm_fut, server_fut);
+						if let Some(child) = new_child {
+							current_child = child;
+						}
+					} else if targets.wasm {
+						wasm_fut.await;
+					} else {
+						let (_outcome, new_child) =
+							crate::server_rebuild_pipeline::ServerRebuildPipeline::run_with_readiness(
+								&config.bin_name,
+								&mut current_child,
+								&respawn,
+								&config.address,
+							)
+							.await;
+						if let Some(child) = new_child {
+							current_child = child;
+						}
+					}
 				// Pipeline failures are recorded as log lines and never
 				// propagate as Err — the loop continues unconditionally.
 			}
@@ -345,5 +467,91 @@ mod tests {
 
 		// Assert
 		assert!(result.is_none());
+	}
+
+	#[cfg(feature = "pages")]
+	fn pages_config(no_wasm_rebuild: bool) -> WatcherConfig {
+		WatcherConfig {
+			bin_name: "manage".to_string(),
+			roots: SourceRoots {
+				src_dirs: vec![PathBuf::from("/project/src")],
+				manifest_files: vec![PathBuf::from("/project/Cargo.toml")],
+				lockfile: Some(PathBuf::from("/project/Cargo.lock")),
+			},
+			no_wasm_rebuild,
+			pages_enabled: true,
+		}
+	}
+
+	#[cfg(feature = "pages")]
+	#[rstest]
+	#[case::root_client_rs("/project/src/client.rs", false, true)]
+	#[case::root_client_dir("/project/src/client/pages.rs", false, true)]
+	#[case::app_client_dir("/project/src/apps/polls/client/page.rs", false, true)]
+	#[case::bin_manage("/project/src/bin/manage.rs", true, false)]
+	#[case::settings_config("/project/src/config/settings.rs", true, false)]
+	#[case::shared_types("/project/src/shared/types.rs", true, true)]
+	#[case::server_fn_boundary("/project/src/apps/polls/server_fn.rs", true, true)]
+	#[case::manifest("/project/Cargo.toml", true, true)]
+	#[case::lockfile("/project/Cargo.lock", true, true)]
+	fn rebuild_targets_classify_pages_paths(
+		#[case] path: &str,
+		#[case] expected_server: bool,
+		#[case] expected_wasm: bool,
+	) {
+		// Arrange
+		let config = pages_config(false);
+
+		// Act
+		let actual = rebuild_targets_for_paths(&[PathBuf::from(path)], &config);
+
+		// Assert
+		assert_eq!(
+			actual,
+			RebuildTargets {
+				server: expected_server,
+				wasm: expected_wasm,
+			},
+			"unexpected rebuild targets for {path}"
+		);
+	}
+
+	#[cfg(feature = "pages")]
+	#[test]
+	fn rebuild_targets_keep_client_only_noop_when_wasm_rebuild_disabled() {
+		// Arrange
+		let config = pages_config(true);
+
+		// Act
+		let actual =
+			rebuild_targets_for_paths(&[PathBuf::from("/project/src/client/page.rs")], &config);
+
+		// Assert
+		assert_eq!(
+			actual,
+			RebuildTargets {
+				server: false,
+				wasm: false,
+			},
+		);
+	}
+
+	#[cfg(feature = "pages")]
+	#[test]
+	fn rebuild_targets_keep_shared_server_rebuild_when_wasm_rebuild_disabled() {
+		// Arrange
+		let config = pages_config(true);
+
+		// Act
+		let actual = rebuild_targets_for_paths(&[PathBuf::from("/project/src/lib.rs")], &config);
+
+		// Assert
+		assert_eq!(
+			actual,
+			RebuildTargets {
+				server: true,
+				wasm: false,
+			},
+		);
 	}
 }

--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -13,9 +13,11 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use notify::Event;
+#[cfg(feature = "pages")]
+use tokio::sync::broadcast;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::oneshot;
-use tokio::time::{Instant, timeout_at};
+use tokio::time::{Instant, sleep, timeout_at};
 
 use crate::CommandContext;
 use crate::source_roots::SourceRoots;
@@ -120,11 +122,18 @@ pub struct WatcherConfig {
 	pub address: String,
 	/// Source directories and manifest files to subscribe to.
 	pub roots: SourceRoots,
+	/// HTTP address used by the child server. When set, browser reloads that
+	/// depend on a server respawn wait briefly for this address to accept TCP.
+	pub server_address: Option<String>,
 	/// When `true`, suppress the WASM rebuild pipeline.
 	pub no_wasm_rebuild: bool,
 	/// When `true`, the project has the pages feature enabled.
 	#[cfg(feature = "pages")]
 	pub pages_enabled: bool,
+	/// Browser HMR channel used to reload connected Pages clients after a
+	/// successful rebuild. `None` keeps the watcher in compile-only mode.
+	#[cfg(feature = "pages")]
+	pub hmr_tx: Option<broadcast::Sender<String>>,
 }
 
 /// Select rebuild pipelines for a debounced path batch.
@@ -209,6 +218,54 @@ fn classify_pages_path(path: &std::path::Path) -> PagesPathClass {
 
 fn normalized_path(path: &std::path::Path) -> String {
 	path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(feature = "pages")]
+fn wasm_rebuild_succeeded(outcome: &crate::wasm_rebuild_pipeline::WasmRebuildOutcome) -> bool {
+	matches!(
+		outcome,
+		crate::wasm_rebuild_pipeline::WasmRebuildOutcome::Ok { .. }
+			| crate::wasm_rebuild_pipeline::WasmRebuildOutcome::Skipped
+	)
+}
+
+fn server_rebuild_succeeded(
+	outcome: &crate::server_rebuild_pipeline::ServerRebuildOutcome,
+) -> bool {
+	matches!(
+		outcome,
+		crate::server_rebuild_pipeline::ServerRebuildOutcome::Ok { .. }
+	)
+}
+
+async fn wait_for_server_ready(address: Option<&str>) -> bool {
+	let Some(address) = address else {
+		return true;
+	};
+
+	let deadline = Instant::now() + Duration::from_secs(2);
+	loop {
+		if tokio::net::TcpStream::connect(address).await.is_ok() {
+			return true;
+		}
+		if Instant::now() >= deadline {
+			return false;
+		}
+		sleep(Duration::from_millis(50)).await;
+	}
+}
+
+#[cfg(feature = "pages")]
+fn notify_browser_reload(hmr_tx: Option<&broadcast::Sender<String>>, reason: &str) {
+	let Some(tx) = hmr_tx else {
+		return;
+	};
+	let msg = reinhardt_pages::hmr::HmrMessage::FullReload {
+		reason: reason.to_string(),
+	};
+	if let Ok(json) = msg.to_json() {
+		let _ = tx.send(json);
+	}
 }
 
 /// Run the hot-reload watcher loop until shutdown.
@@ -321,8 +378,10 @@ pub async fn run_watcher(
 									eprintln!("[hot-reload] watching for next change...");
 								}
 							}
+							return wasm_rebuild_succeeded(&outcome);
 						}
 					}
+					true
 				};
 
 					if targets.server && targets.wasm {
@@ -337,14 +396,35 @@ pub async fn run_watcher(
 								&respawn,
 								&config.address,
 							);
-						let ((), (_outcome, new_child)) = tokio::join!(wasm_fut, server_fut);
+						let (wasm_ok, (server_outcome, new_child)) =
+							tokio::join!(wasm_fut, server_fut);
+						let server_ok = server_rebuild_succeeded(&server_outcome);
 						if let Some(child) = new_child {
 							current_child = child;
 						}
+						let server_ready = if server_ok {
+							wait_for_server_ready(config.server_address.as_deref()).await
+						} else {
+							false
+						};
+						#[cfg(feature = "pages")]
+						if wasm_ok && server_ready {
+							notify_browser_reload(
+								config.hmr_tx.as_ref(),
+								"Rust rebuild completed successfully",
+							);
+						}
 					} else if targets.wasm {
-						wasm_fut.await;
+						let wasm_ok = wasm_fut.await;
+						#[cfg(feature = "pages")]
+						if wasm_ok {
+							notify_browser_reload(
+								config.hmr_tx.as_ref(),
+								"WASM rebuild completed successfully",
+							);
+						}
 					} else {
-						let (_outcome, new_child) =
+						let (server_outcome, new_child) =
 							crate::server_rebuild_pipeline::ServerRebuildPipeline::run_with_readiness(
 								&config.bin_name,
 								&mut current_child,
@@ -352,11 +432,24 @@ pub async fn run_watcher(
 								&config.address,
 							)
 							.await;
+						let server_ok = server_rebuild_succeeded(&server_outcome);
 						if let Some(child) = new_child {
 							current_child = child;
 						}
+						let server_ready = if server_ok {
+							wait_for_server_ready(config.server_address.as_deref()).await
+						} else {
+							false
+						};
+						#[cfg(feature = "pages")]
+						if server_ready {
+							notify_browser_reload(
+								config.hmr_tx.as_ref(),
+								"Server rebuild completed successfully",
+							);
+						}
 					}
-				// Pipeline failures are recorded as log lines and never
+					// Pipeline failures are recorded as log lines and never
 				// propagate as Err — the loop continues unconditionally.
 			}
 		}
@@ -478,8 +571,10 @@ mod tests {
 				manifest_files: vec![PathBuf::from("/project/Cargo.toml")],
 				lockfile: Some(PathBuf::from("/project/Cargo.lock")),
 			},
+			server_address: None,
 			no_wasm_rebuild,
 			pages_enabled: true,
+			hmr_tx: None,
 		}
 	}
 
@@ -553,5 +648,33 @@ mod tests {
 				wasm: false,
 			},
 		);
+	}
+
+	#[cfg(feature = "pages")]
+	#[test]
+	fn notify_browser_reload_sends_full_reload_message() {
+		// Arrange
+		let (tx, mut rx) = broadcast::channel::<String>(8);
+
+		// Act
+		notify_browser_reload(Some(&tx), "WASM rebuild completed successfully");
+
+		// Assert
+		let json = rx.try_recv().expect("reload message should be broadcast");
+		let message: reinhardt_pages::hmr::HmrMessage =
+			serde_json::from_str(&json).expect("message should be valid HMR JSON");
+		assert_eq!(
+			message,
+			reinhardt_pages::hmr::HmrMessage::FullReload {
+				reason: "WASM rebuild completed successfully".to_string()
+			}
+		);
+	}
+
+	#[cfg(feature = "pages")]
+	#[test]
+	fn notify_browser_reload_without_channel_is_noop() {
+		// Act & Assert
+		notify_browser_reload(None, "Server rebuild completed successfully");
 	}
 }

--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -268,6 +268,117 @@ fn notify_browser_reload(hmr_tx: Option<&broadcast::Sender<String>>, reason: &st
 	}
 }
 
+/// Dispatch one debounced path batch through the selected rebuild pipelines.
+///
+/// This is split out from [`run_watcher`] so tests can validate the
+/// rebuild-to-HMR contract deterministically without depending on OS file
+/// notification timing.
+pub async fn run_rebuild_for_paths(
+	ctx: &CommandContext,
+	config: &WatcherConfig,
+	paths: Vec<PathBuf>,
+	current_child: &mut tokio::process::Child,
+	respawn: &(impl Fn() -> std::io::Result<tokio::process::Child> + Send + Sync),
+) {
+	ctx.info(&format!(
+		"[hot-reload] change detected ({} path(s))",
+		paths.len()
+	));
+	let targets = rebuild_targets_for_paths(&paths, config);
+	if !targets.has_work() {
+		ctx.info("[hot-reload] no rebuild target matched; waiting for next change");
+		return;
+	}
+
+	let wasm_fut = async {
+		#[cfg(feature = "pages")]
+		{
+			if targets.wasm {
+				let outcome = crate::wasm_rebuild_pipeline::WasmRebuildPipeline::run(ctx).await;
+				if let Some(line) =
+					crate::wasm_rebuild_pipeline::WasmRebuildPipeline::format_log_line(&outcome)
+				{
+					eprintln!("{}", line);
+					if matches!(
+						outcome,
+						crate::wasm_rebuild_pipeline::WasmRebuildOutcome::Failed { .. }
+					) {
+						eprintln!("[hot-reload] watching for next change...");
+					}
+				}
+				return wasm_rebuild_succeeded(&outcome);
+			}
+		}
+		true
+	};
+
+	if targets.server && targets.wasm {
+		// Spec §4: run wasm + server pipelines in parallel. They touch
+		// disjoint cargo target directories (`wasm32-unknown-unknown` vs
+		// `debug`) and the wasm pipeline does not interact with the running
+		// child process, so concurrent execution is safe.
+		let server_fut = crate::server_rebuild_pipeline::ServerRebuildPipeline::run_with_readiness(
+			&config.bin_name,
+			current_child,
+			respawn,
+			&config.address,
+		);
+		let (wasm_ok, (server_outcome, new_child)) = tokio::join!(wasm_fut, server_fut);
+		let server_ok = server_rebuild_succeeded(&server_outcome);
+		if let Some(child) = new_child {
+			*current_child = child;
+		}
+		let server_ready = if server_ok {
+			wait_for_server_ready(config.server_address.as_deref()).await
+		} else {
+			false
+		};
+		#[cfg(feature = "pages")]
+		if wasm_ok && server_ready {
+			notify_browser_reload(
+				config.hmr_tx.as_ref(),
+				"Rust rebuild completed successfully",
+			);
+		}
+	} else if targets.wasm {
+		let wasm_ok = wasm_fut.await;
+		#[cfg(feature = "pages")]
+		if wasm_ok {
+			notify_browser_reload(
+				config.hmr_tx.as_ref(),
+				"WASM rebuild completed successfully",
+			);
+		}
+	} else {
+		let (server_outcome, new_child) =
+			crate::server_rebuild_pipeline::ServerRebuildPipeline::run_with_readiness(
+				&config.bin_name,
+				current_child,
+				respawn,
+				&config.address,
+			)
+			.await;
+		let server_ok = server_rebuild_succeeded(&server_outcome);
+		if let Some(child) = new_child {
+			*current_child = child;
+		}
+		let server_ready = if server_ok {
+			wait_for_server_ready(config.server_address.as_deref()).await
+		} else {
+			false
+		};
+		#[cfg(feature = "pages")]
+		if server_ready {
+			notify_browser_reload(
+				config.hmr_tx.as_ref(),
+				"Server rebuild completed successfully",
+			);
+		}
+	}
+	// Pipeline failures are recorded as log lines and never propagate as Err;
+	// the caller's loop continues unconditionally.
+}
+
 /// Run the hot-reload watcher loop until shutdown.
 ///
 /// The loop handles three concerns:
@@ -342,116 +453,16 @@ pub async fn run_watcher(
 				let _ = current_child.wait().await;
 				return Ok(());
 			}
-			debounced = debounce_next(&mut rx, DEBOUNCE_WINDOW) => {
-				let Some(paths) = debounced else {
-					// Channel closed: the watcher dropped or the OS torn
-					// the subscription down. Treat as graceful shutdown.
-					let _ = current_child.kill().await;
-					let _ = current_child.wait().await;
-					return Ok(());
-				};
-				ctx.info(&format!(
-					"[hot-reload] change detected ({} path(s))",
-					paths.len()
-				));
-				let targets = rebuild_targets_for_paths(&paths, config);
-				if !targets.has_work() {
-					ctx.info("[hot-reload] no rebuild target matched; waiting for next change");
-					continue;
+				debounced = debounce_next(&mut rx, DEBOUNCE_WINDOW) => {
+					let Some(paths) = debounced else {
+						// Channel closed: the watcher dropped or the OS torn
+						// the subscription down. Treat as graceful shutdown.
+						let _ = current_child.kill().await;
+						let _ = current_child.wait().await;
+						return Ok(());
+					};
+					run_rebuild_for_paths(ctx, config, paths, &mut current_child, &respawn).await;
 				}
-
-				let wasm_fut = async {
-					#[cfg(feature = "pages")]
-					{
-						if targets.wasm {
-							let outcome =
-								crate::wasm_rebuild_pipeline::WasmRebuildPipeline::run(ctx).await;
-							if let Some(line) =
-								crate::wasm_rebuild_pipeline::WasmRebuildPipeline::format_log_line(
-									&outcome,
-								) {
-								eprintln!("{}", line);
-								if matches!(
-									outcome,
-									crate::wasm_rebuild_pipeline::WasmRebuildOutcome::Failed { .. }
-								) {
-									eprintln!("[hot-reload] watching for next change...");
-								}
-							}
-							return wasm_rebuild_succeeded(&outcome);
-						}
-					}
-					true
-				};
-
-					if targets.server && targets.wasm {
-						// Spec §4: run wasm + server pipelines in parallel. They
-						// touch disjoint cargo target directories (`wasm32-unknown-unknown`
-						// vs `debug`) and the wasm pipeline does not interact with the
-						// running child process, so concurrent execution is safe.
-						let server_fut =
-							crate::server_rebuild_pipeline::ServerRebuildPipeline::run_with_readiness(
-								&config.bin_name,
-								&mut current_child,
-								&respawn,
-								&config.address,
-							);
-						let (wasm_ok, (server_outcome, new_child)) =
-							tokio::join!(wasm_fut, server_fut);
-						let server_ok = server_rebuild_succeeded(&server_outcome);
-						if let Some(child) = new_child {
-							current_child = child;
-						}
-						let server_ready = if server_ok {
-							wait_for_server_ready(config.server_address.as_deref()).await
-						} else {
-							false
-						};
-						#[cfg(feature = "pages")]
-						if wasm_ok && server_ready {
-							notify_browser_reload(
-								config.hmr_tx.as_ref(),
-								"Rust rebuild completed successfully",
-							);
-						}
-					} else if targets.wasm {
-						let wasm_ok = wasm_fut.await;
-						#[cfg(feature = "pages")]
-						if wasm_ok {
-							notify_browser_reload(
-								config.hmr_tx.as_ref(),
-								"WASM rebuild completed successfully",
-							);
-						}
-					} else {
-						let (server_outcome, new_child) =
-							crate::server_rebuild_pipeline::ServerRebuildPipeline::run_with_readiness(
-								&config.bin_name,
-								&mut current_child,
-								&respawn,
-								&config.address,
-							)
-							.await;
-						let server_ok = server_rebuild_succeeded(&server_outcome);
-						if let Some(child) = new_child {
-							current_child = child;
-						}
-						let server_ready = if server_ok {
-							wait_for_server_ready(config.server_address.as_deref()).await
-						} else {
-							false
-						};
-						#[cfg(feature = "pages")]
-						if server_ready {
-							notify_browser_reload(
-								config.hmr_tx.as_ref(),
-								"Server rebuild completed successfully",
-							);
-						}
-					}
-					// Pipeline failures are recorded as log lines and never
-				// propagate as Err — the loop continues unconditionally.
-			}
 		}
 	}
 }

--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -284,11 +284,10 @@ fn notify_static_page_patch(
 		selector: "#app".to_string(),
 		html,
 	};
-	if let Ok(json) = msg.to_json() {
-		if let Some(tx) = hmr_tx {
-			let _ = tx.send(json);
-			return true;
-		}
+	if let Ok(json) = msg.to_json()
+		&& let Some(tx) = hmr_tx
+	{
+		return tx.send(json).is_ok();
 	}
 	false
 }
@@ -800,5 +799,50 @@ mod tests {
 
 		// Assert
 		assert!(!sent, "shared files must keep the rebuild path");
+	}
+
+	#[cfg(feature = "pages")]
+	#[test]
+	fn notify_static_page_patch_falls_back_without_hmr_receiver() {
+		// Arrange
+		let temp_dir = tempfile::tempdir().expect("tempdir should be created");
+		let client_path = temp_dir.path().join("src").join("client.rs");
+		std::fs::create_dir_all(
+			client_path
+				.parent()
+				.expect("client path should have parent"),
+		)
+		.expect("client dir should be created");
+		std::fs::write(
+			&client_path,
+			r#"
+				use reinhardt_pages::page;
+
+				fn home_page() -> Page {
+					page!(|| {
+						div { "Updated" }
+					})()
+				}
+			"#,
+		)
+		.expect("client page fixture should be written");
+		let (tx, rx) = broadcast::channel::<String>(8);
+		drop(rx);
+
+		// Act
+		let sent = notify_static_page_patch(
+			Some(&tx),
+			&[client_path],
+			RebuildTargets {
+				server: false,
+				wasm: true,
+			},
+		);
+
+		// Assert
+		assert!(
+			!sent,
+			"hot patch must fall back to WASM rebuild when no browser receives it"
+		);
 	}
 }

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -195,7 +195,8 @@ pub mod welcome_page;
 #[doc(hidden)]
 pub mod __hot_reload_test_api {
 	pub use crate::debounced_watcher::{
-		DEBOUNCE_WINDOW, WatcherConfig, debounce_next, is_relevant_change, run_watcher,
+		DEBOUNCE_WINDOW, RebuildTargets, WatcherConfig, debounce_next, is_relevant_change,
+		rebuild_targets_for_paths, run_watcher,
 	};
 	pub use crate::server_rebuild_pipeline::{ServerRebuildOutcome, ServerRebuildPipeline};
 	pub use crate::source_roots::SourceRoots;

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -152,6 +152,9 @@ pub mod local_infra;
 pub mod mail_commands;
 /// Terminal output wrapper with styling support.
 pub mod output;
+/// Compile-free static Pages hot patch support.
+#[cfg(feature = "pages")]
+mod page_hot_patch;
 /// Plugin management commands.
 #[cfg(feature = "plugins")]
 pub mod plugin_commands;
@@ -198,6 +201,8 @@ pub mod __hot_reload_test_api {
 		DEBOUNCE_WINDOW, RebuildTargets, WatcherConfig, debounce_next, is_relevant_change,
 		rebuild_targets_for_paths, run_rebuild_for_paths, run_watcher,
 	};
+	#[cfg(feature = "pages")]
+	pub use crate::page_hot_patch::render_static_page_patch;
 	pub use crate::server_rebuild_pipeline::{ServerRebuildOutcome, ServerRebuildPipeline};
 	pub use crate::source_roots::SourceRoots;
 	#[cfg(feature = "pages")]

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -196,7 +196,7 @@ pub mod welcome_page;
 pub mod __hot_reload_test_api {
 	pub use crate::debounced_watcher::{
 		DEBOUNCE_WINDOW, RebuildTargets, WatcherConfig, debounce_next, is_relevant_change,
-		rebuild_targets_for_paths, run_watcher,
+		rebuild_targets_for_paths, run_rebuild_for_paths, run_watcher,
 	};
 	pub use crate::server_rebuild_pipeline::{ServerRebuildOutcome, ServerRebuildPipeline};
 	pub use crate::source_roots::SourceRoots;

--- a/crates/reinhardt-commands/src/page_hot_patch.rs
+++ b/crates/reinhardt-commands/src/page_hot_patch.rs
@@ -36,7 +36,17 @@ fn render_static_page_source(source: &str) -> Option<String> {
 }
 
 fn find_static_page_body(source: &str) -> Option<&str> {
-	let page_start = source.find("page!")?;
+	let mut bodies = source
+		.match_indices("page!")
+		.filter_map(|(page_start, _)| parse_static_page_body_at(source, page_start));
+	let body = bodies.next()?;
+	if bodies.next().is_some() {
+		return None;
+	}
+	Some(body)
+}
+
+fn parse_static_page_body_at(source: &str, page_start: usize) -> Option<&str> {
 	let after_macro = source[page_start + "page!".len()..].trim_start();
 	let inner = after_macro.strip_prefix('(')?;
 	let closure_start = inner.find("||")?;
@@ -299,6 +309,25 @@ mod tests {
 			html,
 			r#"<div id="route-home"><a href="/login" id="go-to-login">Go to login</a></div>"#
 		);
+	}
+
+	#[rstest]
+	fn rejects_multiple_static_page_macros() {
+		let source = r#"
+			fn home_page() -> Page {
+				page!(|| {
+					div { "Home" }
+				})()
+			}
+
+			fn about_page() -> Page {
+				page!(|| {
+					div { "About" }
+				})()
+			}
+		"#;
+
+		assert!(render_static_page_source(source).is_none());
 	}
 
 	#[rstest]

--- a/crates/reinhardt-commands/src/page_hot_patch.rs
+++ b/crates/reinhardt-commands/src/page_hot_patch.rs
@@ -1,0 +1,353 @@
+//! Compile-free static `page!` hot patch support for Pages development.
+
+use std::path::{Path, PathBuf};
+
+/// Render a static `page!(|| { ... })` edit into an HMR HTML replacement.
+///
+/// This deliberately accepts only a narrow static subset: string attributes,
+/// string text nodes, and nested lowercase HTML elements. Dynamic Rust
+/// expressions, event handlers, control flow, and components return `None` so
+/// the normal WASM rebuild path remains authoritative.
+pub fn render_static_page_patch(paths: &[PathBuf]) -> Option<String> {
+	let path = only_rust_path(paths)?;
+	let source = std::fs::read_to_string(path).ok()?;
+	render_static_page_source(&source)
+}
+
+fn only_rust_path(paths: &[PathBuf]) -> Option<&Path> {
+	if paths.len() != 1 {
+		return None;
+	}
+	let path = paths[0].as_path();
+	if path.extension()? != "rs" {
+		return None;
+	}
+	Some(path)
+}
+
+fn render_static_page_source(source: &str) -> Option<String> {
+	let body = find_static_page_body(source)?;
+	let mut parser = Parser::new(body);
+	let html = parser.parse_nodes_until_end().ok()?;
+	if html.trim().is_empty() {
+		return None;
+	}
+	Some(html)
+}
+
+fn find_static_page_body(source: &str) -> Option<&str> {
+	let page_start = source.find("page!")?;
+	let after_macro = source[page_start + "page!".len()..].trim_start();
+	let inner = after_macro.strip_prefix('(')?;
+	let closure_start = inner.find("||")?;
+	let after_closure = inner[closure_start + 2..].trim_start();
+	let body_start = after_closure.find('{')?;
+	let body = &after_closure[body_start + 1..];
+	let body_end = matching_brace_offset(body)?;
+	Some(&body[..body_end])
+}
+
+fn matching_brace_offset(input: &str) -> Option<usize> {
+	let mut depth = 1usize;
+	let mut in_string = false;
+	let mut escaped = false;
+
+	for (offset, ch) in input.char_indices() {
+		if in_string {
+			if escaped {
+				escaped = false;
+			} else if ch == '\\' {
+				escaped = true;
+			} else if ch == '"' {
+				in_string = false;
+			}
+			continue;
+		}
+
+		match ch {
+			'"' => in_string = true,
+			'{' => depth += 1,
+			'}' => {
+				depth = depth.checked_sub(1)?;
+				if depth == 0 {
+					return Some(offset);
+				}
+			}
+			_ => {}
+		}
+	}
+
+	None
+}
+
+struct Parser<'a> {
+	input: &'a str,
+	pos: usize,
+}
+
+impl<'a> Parser<'a> {
+	fn new(input: &'a str) -> Self {
+		Self { input, pos: 0 }
+	}
+
+	fn parse_nodes_until_end(&mut self) -> Result<String, ()> {
+		let mut html = String::new();
+		loop {
+			self.skip_ws_and_commas();
+			if self.is_eof() {
+				return Ok(html);
+			}
+			if self.peek_char() == Some('}') {
+				return Err(());
+			}
+			html.push_str(&self.parse_node()?);
+		}
+	}
+
+	fn parse_node(&mut self) -> Result<String, ()> {
+		self.skip_ws_and_commas();
+		match self.peek_char() {
+			Some('"') => Ok(escape_text(&self.parse_string_literal()?)),
+			Some('@') | Some('{') => Err(()),
+			Some(ch) if is_ident_start(ch) => self.parse_element(),
+			_ => Err(()),
+		}
+	}
+
+	fn parse_element(&mut self) -> Result<String, ()> {
+		let tag = self.parse_ident()?;
+		if matches!(tag.as_str(), "if" | "for" | "watch") || !is_html_tag_name(&tag) {
+			return Err(());
+		}
+		self.skip_ws_and_commas();
+		if self.bump_char() != Some('{') {
+			return Err(());
+		}
+
+		let mut attrs = Vec::new();
+		let mut children = String::new();
+		loop {
+			self.skip_ws_and_commas();
+			if self.is_eof() {
+				return Err(());
+			}
+			if self.peek_char() == Some('}') {
+				self.bump_char();
+				break;
+			}
+			if self.peek_char() == Some('"') {
+				children.push_str(&escape_text(&self.parse_string_literal()?));
+				continue;
+			}
+			if matches!(self.peek_char(), Some('@') | Some('{')) {
+				return Err(());
+			}
+
+			let checkpoint = self.pos;
+			let ident = self.parse_ident()?;
+			self.skip_ws();
+			match self.peek_char() {
+				Some(':') => {
+					self.bump_char();
+					self.skip_ws();
+					let value = self.parse_string_literal()?;
+					attrs.push((ident.replace('_', "-"), value));
+					self.skip_ws_and_commas();
+				}
+				Some('{') => {
+					self.pos = checkpoint;
+					children.push_str(&self.parse_element()?);
+				}
+				_ => return Err(()),
+			}
+		}
+
+		let mut html = String::new();
+		html.push('<');
+		html.push_str(&tag);
+		for (name, value) in attrs {
+			html.push(' ');
+			html.push_str(&name);
+			html.push_str("=\"");
+			html.push_str(&escape_attr(&value));
+			html.push('"');
+		}
+		html.push('>');
+		html.push_str(&children);
+		html.push_str("</");
+		html.push_str(&tag);
+		html.push('>');
+		Ok(html)
+	}
+
+	fn parse_ident(&mut self) -> Result<String, ()> {
+		let start = self.pos;
+		let Some(ch) = self.peek_char() else {
+			return Err(());
+		};
+		if !is_ident_start(ch) {
+			return Err(());
+		}
+		self.bump_char();
+		while matches!(self.peek_char(), Some(ch) if is_ident_continue(ch)) {
+			self.bump_char();
+		}
+		Ok(self.input[start..self.pos].to_string())
+	}
+
+	fn parse_string_literal(&mut self) -> Result<String, ()> {
+		let start = self.pos;
+		if self.bump_char() != Some('"') {
+			return Err(());
+		}
+		let mut escaped = false;
+		while let Some(ch) = self.bump_char() {
+			if escaped {
+				escaped = false;
+				continue;
+			}
+			if ch == '\\' {
+				escaped = true;
+				continue;
+			}
+			if ch == '"' {
+				let literal = &self.input[start..self.pos];
+				return syn::parse_str::<syn::LitStr>(literal)
+					.map(|lit| lit.value())
+					.map_err(|_| ());
+			}
+		}
+		Err(())
+	}
+
+	fn skip_ws_and_commas(&mut self) {
+		while matches!(self.peek_char(), Some(ch) if ch.is_whitespace() || ch == ',') {
+			self.bump_char();
+		}
+	}
+
+	fn skip_ws(&mut self) {
+		while matches!(self.peek_char(), Some(ch) if ch.is_whitespace()) {
+			self.bump_char();
+		}
+	}
+
+	fn is_eof(&self) -> bool {
+		self.pos >= self.input.len()
+	}
+
+	fn peek_char(&self) -> Option<char> {
+		self.input[self.pos..].chars().next()
+	}
+
+	fn bump_char(&mut self) -> Option<char> {
+		let ch = self.peek_char()?;
+		self.pos += ch.len_utf8();
+		Some(ch)
+	}
+}
+
+fn is_ident_start(ch: char) -> bool {
+	ch == '_' || ch.is_ascii_alphabetic()
+}
+
+fn is_ident_continue(ch: char) -> bool {
+	ch == '_' || ch.is_ascii_alphanumeric()
+}
+
+fn is_html_tag_name(name: &str) -> bool {
+	name.chars()
+		.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit())
+}
+
+fn escape_text(value: &str) -> String {
+	value
+		.replace('&', "&amp;")
+		.replace('<', "&lt;")
+		.replace('>', "&gt;")
+}
+
+fn escape_attr(value: &str) -> String {
+	escape_text(value).replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	fn renders_static_page_macro() {
+		let source = r#"
+			fn home_page() -> Page {
+				page!(|| {
+					div {
+						id: "route-home",
+						a {
+							href: "/login",
+							id: "go-to-login",
+							"Go to login"
+						}
+					}
+				})()
+			}
+		"#;
+
+		let html = render_static_page_source(source).expect("static page should render");
+
+		assert_eq!(
+			html,
+			r#"<div id="route-home"><a href="/login" id="go-to-login">Go to login</a></div>"#
+		);
+	}
+
+	#[rstest]
+	fn rejects_dynamic_expression() {
+		let source = r#"
+			fn home_page(name: String) -> Page {
+				page!(|| {
+					div { { name } }
+				})()
+			}
+		"#;
+
+		assert!(render_static_page_source(source).is_none());
+	}
+
+	#[rstest]
+	fn rejects_event_handler() {
+		let source = r#"
+			fn home_page() -> Page {
+				page!(|| {
+					button {
+						@click: |_| {},
+						"Save"
+					}
+				})()
+			}
+		"#;
+
+		assert!(render_static_page_source(source).is_none());
+	}
+
+	#[rstest]
+	fn escapes_text_and_attrs() {
+		let source = r#"
+			fn home_page() -> Page {
+				page!(|| {
+					div {
+						title: "A \"quote\" & more",
+						"<unsafe>"
+					}
+				})()
+			}
+		"#;
+
+		let html = render_static_page_source(source).expect("static page should render");
+
+		assert_eq!(
+			html,
+			r#"<div title="A &quot;quote&quot; &amp; more">&lt;unsafe&gt;</div>"#
+		);
+	}
+}

--- a/crates/reinhardt-commands/src/page_hot_patch.rs
+++ b/crates/reinhardt-commands/src/page_hot_patch.rs
@@ -38,12 +38,20 @@ fn render_static_page_source(source: &str) -> Option<String> {
 fn find_static_page_body(source: &str) -> Option<&str> {
 	let mut bodies = source
 		.match_indices("page!")
+		.filter(|(page_start, _)| is_page_macro_boundary(source, *page_start))
 		.filter_map(|(page_start, _)| parse_static_page_body_at(source, page_start));
 	let body = bodies.next()?;
 	if bodies.next().is_some() {
 		return None;
 	}
 	Some(body)
+}
+
+fn is_page_macro_boundary(source: &str, page_start: usize) -> bool {
+	source[..page_start]
+		.chars()
+		.next_back()
+		.is_none_or(|ch| !is_ident_continue(ch))
 }
 
 fn parse_static_page_body_at(source: &str, page_start: usize) -> Option<&str> {
@@ -328,6 +336,27 @@ mod tests {
 		"#;
 
 		assert!(render_static_page_source(source).is_none());
+	}
+
+	#[rstest]
+	fn ignores_page_macro_substrings_inside_identifiers() {
+		let source = r#"
+			fn helper() {
+				mypage!(|| {
+					div { "Not a page macro" }
+				});
+			}
+
+			fn home_page() -> Page {
+				page!(|| {
+					div { "Home" }
+				})()
+			}
+		"#;
+
+		let html = render_static_page_source(source).expect("static page should render");
+
+		assert_eq!(html, r#"<div>Home</div>"#);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 default-run = "manage"
 
+[profile.dev]
+codegen-units = 16
+debug = 0
+
 [lib]
 crate-type = ["cdylib", "rlib"]  # cdylib for WASM, rlib for server
 

--- a/crates/reinhardt-commands/templates/project_restful_template/Cargo.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/Cargo.toml.tpl
@@ -3,6 +3,10 @@ name = "{{ project_name }}"
 version = "0.1.0"
 edition = "2024"
 
+[profile.dev]
+codegen-units = 16
+debug = 0
+
 [[bin]]
 name = "manage"
 path = "src/bin/manage.rs"

--- a/crates/reinhardt-commands/tests/runserver_hot_reload.rs
+++ b/crates/reinhardt-commands/tests/runserver_hot_reload.rs
@@ -45,8 +45,8 @@ use std::time::Duration;
 use std::time::Instant;
 
 use reinhardt_commands::__hot_reload_test_api::{
-	DEBOUNCE_WINDOW, ServerRebuildOutcome, ServerRebuildPipeline, SourceRoots, WatcherConfig,
-	is_relevant_change, run_watcher,
+	DEBOUNCE_WINDOW, RebuildTargets, ServerRebuildOutcome, ServerRebuildPipeline, SourceRoots,
+	WatcherConfig, is_relevant_change, rebuild_targets_for_paths, run_watcher,
 };
 use reinhardt_commands::{
 	CommandContext, RunserverContext, RunserverHook, RunserverHookRegistration, WasmBuildConfig,
@@ -392,10 +392,9 @@ async fn hr_9_server_restart_accepts_connections_after_pipeline_ok() {
 // HR-3: --no-wasm-rebuild flag plumbing skips the WASM pipeline.
 //
 // This test asserts the dispatch-time configuration the watcher reads:
-// `WatcherConfig.no_wasm_rebuild` round-trips the flag, and the path filter
-// still recognises Rust source edits as relevant. Behavioural verification
-// (no WASM log line appears under the flag) lives in the unit tests of
-// `debounced_watcher`, where the dispatch branch is observable.
+// `WatcherConfig.no_wasm_rebuild` round-trips the flag, the path filter still
+// recognises Rust source edits as relevant, and the classifier does not route
+// client-only edits into an unnecessary native server rebuild.
 // ---------------------------------------------------------------------------
 #[tokio::test(flavor = "multi_thread")]
 async fn hr_3_no_wasm_rebuild_flag_skips_wasm_pipeline() {
@@ -434,6 +433,22 @@ async fn hr_3_no_wasm_rebuild_flag_skips_wasm_pipeline() {
 			"/p/src/lib.rs",
 		)),
 		"a .rs edit must still pass the relevance filter (server pipeline still runs)"
+	);
+	assert_eq!(
+		rebuild_targets_for_paths(&[PathBuf::from("/p/src/lib.rs")], &config),
+		RebuildTargets {
+			server: true,
+			wasm: false,
+		},
+		"shared Rust edits must still rebuild the server when WASM rebuild is disabled"
+	);
+	assert_eq!(
+		rebuild_targets_for_paths(&[PathBuf::from("/p/src/client/page.rs")], &config),
+		RebuildTargets {
+			server: false,
+			wasm: false,
+		},
+		"client-only edits must not force a native rebuild when WASM rebuild is disabled"
 	);
 	assert_eq!(DEBOUNCE_WINDOW, Duration::from_millis(300));
 }

--- a/crates/reinhardt-commands/tests/runserver_hot_reload.rs
+++ b/crates/reinhardt-commands/tests/runserver_hot_reload.rs
@@ -46,7 +46,8 @@ use std::time::Instant;
 
 use reinhardt_commands::__hot_reload_test_api::{
 	DEBOUNCE_WINDOW, RebuildTargets, ServerRebuildOutcome, ServerRebuildPipeline, SourceRoots,
-	WatcherConfig, is_relevant_change, rebuild_targets_for_paths, run_watcher,
+	WatcherConfig, is_relevant_change, rebuild_targets_for_paths, run_rebuild_for_paths,
+	run_watcher,
 };
 use reinhardt_commands::{
 	CommandContext, RunserverContext, RunserverHook, RunserverHookRegistration, WasmBuildConfig,
@@ -700,6 +701,92 @@ async fn hr_7_run_watcher_processes_events() {
 	assert!(
 		watcher_result.is_ok(),
 		"watcher must return Ok on graceful shutdown, got {watcher_result:?}"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// HR-9: the watcher rebuild dispatcher broadcasts a browser reload after a
+// successful server rebuild.
+//
+// This drives the same rebuild dispatcher used by the notify-backed watcher
+// loop, without depending on OS file notification timing. The test keeps WASM
+// rebuilding disabled so the assertion is specifically about the server
+// rebuild path: classified edit -> cargo build --bin manage -> respawn -> HMR
+// full_reload.
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread")]
+#[serial(server_pipeline)]
+async fn hr_9_run_watcher_broadcasts_reload_after_server_rebuild() {
+	use std::sync::Arc;
+	use std::sync::atomic::{AtomicUsize, Ordering};
+
+	// Arrange: fixture + initial server child + cwd switched so cargo
+	// resolves the fixture's manifest. Mirrors `run_server_pipeline`.
+	let fixture = Fixture::new("hr9_fixture", 900);
+	let initial_child = spawn_long_running_child(&fixture).await;
+	let saved_cwd = std::env::current_dir().expect("current dir");
+	std::env::set_current_dir(fixture.path()).expect("set fixture cwd");
+
+	let bin_path = fixture_manage_bin(&fixture);
+	let respawn_count = Arc::new(AtomicUsize::new(0));
+	let respawn_count_for_closure = Arc::clone(&respawn_count);
+	let respawn = move || -> std::io::Result<tokio::process::Child> {
+		respawn_count_for_closure.fetch_add(1, Ordering::SeqCst);
+		tokio::process::Command::new(&bin_path)
+			.kill_on_drop(true)
+			.spawn()
+	};
+
+	let (hmr_tx, mut hmr_rx) = tokio::sync::broadcast::channel::<String>(8);
+	let ctx = CommandContext::default();
+	let config = WatcherConfig {
+		bin_name: "manage".to_string(),
+		roots: SourceRoots {
+			src_dirs: vec![fixture.path().join("src")],
+			manifest_files: vec![fixture.path().join("Cargo.toml")],
+			lockfile: None,
+		},
+		server_address: None,
+		no_wasm_rebuild: true,
+		pages_enabled: true,
+		hmr_tx: Some(hmr_tx),
+	};
+
+	// Act: edit the server source. With no_wasm_rebuild=true, this should
+	// rebuild and respawn only the native server and then notify browsers.
+	let mut child = initial_child;
+	fixture.restore_server(901);
+	run_rebuild_for_paths(
+		&ctx,
+		&config,
+		vec![fixture.path().join("src/main.rs")],
+		&mut child,
+		&respawn,
+	)
+	.await;
+	let json = tokio::time::timeout(Duration::from_secs(5), hmr_rx.recv())
+		.await
+		.expect("server rebuild should broadcast a reload")
+		.expect("HMR channel should remain open");
+
+	let _ = child.kill().await;
+
+	// Cleanup: restore cwd before any assertion can panic.
+	std::env::set_current_dir(&saved_cwd).expect("restore cwd");
+
+	assert_eq!(
+		respawn_count.load(Ordering::SeqCst),
+		1,
+		"successful server rebuild must respawn exactly once"
+	);
+
+	let message: reinhardt_pages::hmr::HmrMessage =
+		serde_json::from_str(&json).expect("HMR reload payload must parse");
+	assert_eq!(
+		message,
+		reinhardt_pages::hmr::HmrMessage::FullReload {
+			reason: "Server rebuild completed successfully".to_string()
+		}
 	);
 }
 

--- a/crates/reinhardt-commands/tests/runserver_hot_reload.rs
+++ b/crates/reinhardt-commands/tests/runserver_hot_reload.rs
@@ -727,7 +727,7 @@ async fn hr_9_run_watcher_broadcasts_reload_after_server_rebuild() {
 	let saved_cwd = std::env::current_dir().expect("current dir");
 	std::env::set_current_dir(fixture.path()).expect("set fixture cwd");
 
-	let bin_path = fixture_manage_bin(&fixture);
+	let bin_path = fixture.manage_bin();
 	let respawn_count = Arc::new(AtomicUsize::new(0));
 	let respawn_count_for_closure = Arc::clone(&respawn_count);
 	let respawn = move || -> std::io::Result<tokio::process::Child> {
@@ -741,6 +741,7 @@ async fn hr_9_run_watcher_broadcasts_reload_after_server_rebuild() {
 	let ctx = CommandContext::default();
 	let config = WatcherConfig {
 		bin_name: "manage".to_string(),
+		address: "127.0.0.1:0".to_string(),
 		roots: SourceRoots {
 			src_dirs: vec![fixture.path().join("src")],
 			manifest_files: vec![fixture.path().join("Cargo.toml")],

--- a/crates/reinhardt-commands/tests/runserver_hot_reload.rs
+++ b/crates/reinhardt-commands/tests/runserver_hot_reload.rs
@@ -407,8 +407,10 @@ async fn hr_3_no_wasm_rebuild_flag_skips_wasm_pipeline() {
 			manifest_files: Vec::new(),
 			lockfile: None,
 		},
+		server_address: None,
 		no_wasm_rebuild: true,
 		pages_enabled: true,
+		hmr_tx: None,
 	};
 
 	// Act: read the flag back.
@@ -624,8 +626,10 @@ async fn hr_7_run_watcher_processes_events() {
 			manifest_files: vec![fixture.path().join("Cargo.toml")],
 			lockfile: None,
 		},
+		server_address: None,
 		no_wasm_rebuild: true,
 		pages_enabled: false,
+		hmr_tx: None,
 	};
 
 	let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -41,6 +41,7 @@ rmp-serde = { workspace = true }
 prost = { workspace = true }
 serial_test = { workspace = true, optional = true }
 aquamarine = { workspace = true, optional = true }
+image = { workspace = true, optional = true }
 sha2 = "0.10"
 hmac = "0.12"
 hex = "0.4"
@@ -55,7 +56,6 @@ parking_lot = "0.12"
 smallvec = { workspace = true }
 tracing = { workspace = true }
 fluent-bundle = { version = "0.15", optional = true }
-image = { workspace = true, optional = true }
 
 # Server-side dependencies (not available on WASM)
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -40,7 +40,7 @@ brotli = { workspace = true, optional = true }
 rmp-serde = { workspace = true }
 prost = { workspace = true }
 serial_test = { workspace = true, optional = true }
-aquamarine = { workspace = true }
+aquamarine = { workspace = true, optional = true }
 sha2 = "0.10"
 hmac = "0.12"
 hex = "0.4"
@@ -87,7 +87,7 @@ default = [
 
 # Module features (conditionally compiled when feature is enabled)
 types = []
-exception = []
+exception = ["validators"]
 signals = ["serde"]
 security = []
 validators = ["serde"]
@@ -114,6 +114,7 @@ core-full = [
   "macros",
   "security",
   "validators",
+  "image-validation",
   "serializers",
   "messages",
   "negotiation",
@@ -135,6 +136,7 @@ serde = ["dep:serde"]
 jsonschema = ["dep:jsonschema"]
 parallel = ["dep:rayon"]
 i18n = ["dep:fluent-bundle", "dep:unic-langid"]
+doc-diagrams = ["dep:aquamarine"]
 
 [build-dependencies]
 cfg_aliases = "0.2"

--- a/crates/reinhardt-core/src/reactive/context.rs
+++ b/crates/reinhardt-core/src/reactive/context.rs
@@ -39,7 +39,7 @@ use alloc::vec::Vec;
 /// Global counter for generating unique context IDs.
 static CONTEXT_ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
+#[cfg_attr(all(doc, feature = "doc-diagrams"), aquamarine::aquamarine)]
 /// A type-safe context identifier.
 ///
 /// Each Context has a unique ID that is used to look up values in the context stack.

--- a/crates/reinhardt-core/src/types/page.rs
+++ b/crates/reinhardt-core/src/types/page.rs
@@ -299,6 +299,20 @@ impl PageElement {
 		self
 	}
 
+	/// Adds multiple attributes.
+	pub fn with_attrs<N, V>(mut self, attrs: impl IntoIterator<Item = (N, V)>) -> Self
+	where
+		N: Into<Cow<'static, str>>,
+		V: Into<Cow<'static, str>>,
+	{
+		self.attrs.extend(
+			attrs
+				.into_iter()
+				.map(|(name, value)| (name.into(), value.into())),
+		);
+		self
+	}
+
 	/// Adds a boolean attribute.
 	///
 	/// Boolean attributes in HTML are either present (true) or absent (false).
@@ -323,6 +337,20 @@ impl PageElement {
 		} else {
 			self
 		}
+	}
+
+	/// Adds multiple boolean attributes.
+	pub fn with_bool_attrs<N>(mut self, attrs: impl IntoIterator<Item = (N, bool)>) -> Self
+	where
+		N: Into<Cow<'static, str>>,
+	{
+		for (name, value) in attrs {
+			if value {
+				let name = name.into();
+				self.attrs.push((name.clone(), name));
+			}
+		}
+		self
 	}
 
 	/// Adds a child view.
@@ -853,6 +881,25 @@ mod tests {
 			.attr("class", "container")
 			.attr("id", "main");
 		assert_eq!(el.attrs.len(), 2);
+	}
+
+	#[test]
+	fn test_element_with_batch_attrs() {
+		let el = PageElement::new("div").with_attrs([("class", "container"), ("id", "main")]);
+		assert_eq!(el.attrs.len(), 2);
+		assert_eq!(el.attrs[0].0, "class");
+		assert_eq!(el.attrs[0].1, "container");
+		assert_eq!(el.attrs[1].0, "id");
+		assert_eq!(el.attrs[1].1, "main");
+	}
+
+	#[test]
+	fn test_element_with_batch_bool_attrs() {
+		let el =
+			PageElement::new("button").with_bool_attrs([("disabled", true), ("hidden", false)]);
+		assert_eq!(el.attrs.len(), 1);
+		assert_eq!(el.attrs[0].0, "disabled");
+		assert_eq!(el.attrs[0].1, "disabled");
 	}
 
 	#[test]

--- a/crates/reinhardt-deeplink/Cargo.toml
+++ b/crates/reinhardt-deeplink/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 [dependencies]
 # Core framework
 reinhardt-conf = { workspace = true, features = ["settings"] }
-reinhardt-core = { workspace = true }
+reinhardt-core = { workspace = true, features = ["exception"] }
 reinhardt-http = { workspace = true }
 reinhardt-urls = { workspace = true }
 

--- a/crates/reinhardt-manouche/Cargo.toml
+++ b/crates/reinhardt-manouche/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["parser-implementations", "development-tools::procedural-macro-hel
 
 [dependencies]
 # Documentation
-aquamarine = { workspace = true }
+aquamarine = { workspace = true, optional = true }
 
 # Parsing and AST manipulation
 syn = { workspace = true, features = ["full", "extra-traits", "visit-mut"] }
@@ -24,6 +24,10 @@ darling = "0.20"
 
 # Case conversion for identifiers
 convert_case = "0.6"
+
+[features]
+default = []
+doc-diagrams = ["dep:aquamarine"]
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/reinhardt-manouche/src/core/form_typed.rs
+++ b/crates/reinhardt-manouche/src/core/form_typed.rs
@@ -35,7 +35,7 @@ use syn::{ExprClosure, Ident, Path};
 
 use super::form_node::ValidatorScope;
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
+#[cfg_attr(all(doc, feature = "doc-diagrams"), aquamarine::aquamarine)]
 /// The top-level typed AST node representing a validated form! macro invocation.
 ///
 /// This is the result of successful validation and transformation of an untyped

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -195,9 +195,6 @@ web-sys = { version = "0.3.83", features = [
 # Async support for WASM
 reinhardt-core = {workspace = true, default-features = false, features = ["reactive", "page", "security"]}
 smallvec = { workspace = true }
-syn = { version = "2.0", features = ["full", "extra-traits", "parsing"] }
-quote = "1.0"
-proc-macro2 = "1.0"
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 wasm-bindgen-futures = "0.4.56"
 reqwest = { workspace = true }

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -94,9 +94,6 @@ web-sys-full = [
 ]
 
 [dependencies]
-# Documentation
-aquamarine = "0.5"
-
 # Builder generator for `Component { ... }` invocation form (spec §3.5.2).
 # Used as a runtime dep so user code can `#[derive(bon::Builder)]` on
 # component prop structs. Staged for removal under spec §10.
@@ -197,7 +194,7 @@ reinhardt-core = {workspace = true, default-features = false, features = ["react
 smallvec = { workspace = true }
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 wasm-bindgen-futures = "0.4.56"
-reqwest = { workspace = true }
+reqwest = { version = "0.13.2", default-features = false, features = ["json"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 uuid = { version = "1.7", features = ["v7", "js"] }
 # Issue #4217: depend on reinhardt-urls on wasm to consume the canonical

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -194,7 +194,7 @@ reinhardt-core = {workspace = true, default-features = false, features = ["react
 smallvec = { workspace = true }
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 wasm-bindgen-futures = "0.4.56"
-reqwest = { version = "0.13.2", default-features = false, features = ["json"] }
+reqwest = { workspace = true, default-features = false, features = ["json"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 uuid = { version = "1.7", features = ["v7", "js"] }
 # Issue #4217: depend on reinhardt-urls on wasm to consume the canonical

--- a/crates/reinhardt-pages/ast/Cargo.toml
+++ b/crates/reinhardt-pages/ast/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["parser-implementations", "wasm"]
 reinhardt-manouche = { workspace = true }
 
 # Documentation
-aquamarine = { workspace = true }
+aquamarine = { workspace = true, optional = true }
 
 # Parsing and AST manipulation
 syn = { workspace = true, features = ["full", "extra-traits", "visit-mut"] }
@@ -27,3 +27,7 @@ darling = "0.20"
 
 # Case conversion for identifiers
 convert_case = "0.6"
+
+[features]
+default = []
+doc-diagrams = ["dep:aquamarine"]

--- a/crates/reinhardt-pages/ast/src/form_typed.rs
+++ b/crates/reinhardt-pages/ast/src/form_typed.rs
@@ -33,7 +33,7 @@
 use proc_macro2::Span;
 use syn::{ExprClosure, Ident, Path};
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
+#[cfg_attr(all(doc, feature = "doc-diagrams"), aquamarine::aquamarine)]
 /// The top-level typed AST node representing a validated form! macro invocation.
 ///
 /// This is the result of successful validation and transformation of an untyped

--- a/crates/reinhardt-pages/macros/src/page/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/page/codegen.rs
@@ -170,7 +170,18 @@ fn generate_element(elem: &TypedPageElement, pages_crate: &TokenStream) -> Token
 	let tag = elem.tag.to_string();
 
 	// Generate attributes
-	let attrs: Vec<TokenStream> = elem.attrs.iter().map(generate_attr).collect();
+	let regular_attrs: Vec<TokenStream> = elem
+		.attrs
+		.iter()
+		.filter(|attr| !BOOLEAN_ATTRS.contains(&attr.html_name().as_str()))
+		.map(generate_regular_attr_pair)
+		.collect();
+	let bool_attrs: Vec<TokenStream> = elem
+		.attrs
+		.iter()
+		.filter(|attr| BOOLEAN_ATTRS.contains(&attr.html_name().as_str()))
+		.map(generate_bool_attr_pair)
+		.collect();
 
 	// Generate children
 	let children: Vec<TokenStream> = elem
@@ -184,11 +195,15 @@ fn generate_element(elem: &TypedPageElement, pages_crate: &TokenStream) -> Token
 		#pages_crate::component::PageElement::new(#tag)
 	};
 
-	// Add attributes
-	for attr in &attrs {
+	if !regular_attrs.is_empty() {
 		base_builder = quote! {
-			#base_builder
-			#attr
+			#base_builder.with_attrs([#(#regular_attrs),*])
+		};
+	}
+
+	if !bool_attrs.is_empty() {
+		base_builder = quote! {
+			#base_builder.with_bool_attrs([#(#bool_attrs),*])
 		};
 	}
 
@@ -299,21 +314,9 @@ const BOOLEAN_ATTRS: &[&str] = &[
 	"truespeed",
 ];
 
-/// Generates code for an attribute.
-fn generate_attr(attr: &TypedPageAttr) -> TokenStream {
+/// Generates code for a regular attribute pair.
+fn generate_regular_attr_pair(attr: &TypedPageAttr) -> TokenStream {
 	let name_str = attr.html_name();
-
-	// Check if this is a boolean attribute
-	if BOOLEAN_ATTRS.contains(&name_str.as_str()) {
-		// Boolean attributes use .bool_attr() which handles true/false values
-		let value_expr = attr.value.to_expr();
-		return quote! {
-			.bool_attr(#name_str, #value_expr)
-		};
-	}
-
-	// Use name_str for regular attributes as well
-	let name = &name_str;
 
 	// Handle different attribute value types
 	// IntLit and FloatLit need to be converted to strings
@@ -334,7 +337,19 @@ fn generate_attr(attr: &TypedPageAttr) -> TokenStream {
 	};
 
 	quote! {
-		.attr(#name, #value_expr)
+		(
+			::std::borrow::Cow::Borrowed(#name_str),
+			::std::borrow::Cow::from(#value_expr)
+		)
+	}
+}
+
+/// Generates code for a boolean attribute pair.
+fn generate_bool_attr_pair(attr: &TypedPageAttr) -> TokenStream {
+	let name_str = attr.html_name();
+	let value_expr = attr.value.to_expr();
+	quote! {
+		(::std::borrow::Cow::Borrowed(#name_str), #value_expr)
 	}
 }
 

--- a/crates/reinhardt-pages/src/hmr/client_script.rs
+++ b/crates/reinhardt-pages/src/hmr/client_script.rs
@@ -38,6 +38,9 @@ pub const HMR_CLIENT_SCRIPT: &str = r#"
         case "css_update":
           hotSwapCss(msg.path);
           break;
+        case "html_replace":
+          replaceHtml(msg.selector, msg.html);
+          break;
         case "full_reload":
           console.log("[HMR] Full reload:", msg.reason);
           window.location.reload();
@@ -84,6 +87,17 @@ pub const HMR_CLIENT_SCRIPT: &str = r#"
     }
   }
 
+  function replaceHtml(selector, html) {
+    var target = document.querySelector(selector);
+    if (!target) {
+      console.log("[HMR] HTML target not found, reloading:", selector);
+      window.location.reload();
+      return;
+    }
+    target.innerHTML = html;
+    console.log("[HMR] HTML replaced:", selector);
+  }
+
   connect();
 })();
 "#;
@@ -105,6 +119,7 @@ mod tests {
 		// Assert
 		assert!(HMR_CLIENT_SCRIPT.contains("WebSocket"));
 		assert!(HMR_CLIENT_SCRIPT.contains("css_update"));
+		assert!(HMR_CLIENT_SCRIPT.contains("html_replace"));
 		assert!(HMR_CLIENT_SCRIPT.contains("full_reload"));
 		assert!(HMR_CLIENT_SCRIPT.contains("connected"));
 		assert!(HMR_CLIENT_SCRIPT.contains("__HMR_WS_PORT__"));
@@ -152,6 +167,14 @@ mod tests {
 		assert!(HMR_CLIENT_SCRIPT.contains("hotSwapCss"));
 		assert!(HMR_CLIENT_SCRIPT.contains("cacheBust"));
 		assert!(HMR_CLIENT_SCRIPT.contains("stylesheet"));
+	}
+
+	#[rstest]
+	fn test_hmr_client_script_has_html_replace() {
+		// Assert
+		assert!(HMR_CLIENT_SCRIPT.contains("replaceHtml"));
+		assert!(HMR_CLIENT_SCRIPT.contains("querySelector"));
+		assert!(HMR_CLIENT_SCRIPT.contains("innerHTML"));
 	}
 
 	// --- Boundary values ---

--- a/crates/reinhardt-pages/src/hmr/client_script.rs
+++ b/crates/reinhardt-pages/src/hmr/client_script.rs
@@ -88,7 +88,14 @@ pub const HMR_CLIENT_SCRIPT: &str = r#"
   }
 
   function replaceHtml(selector, html) {
-    var target = document.querySelector(selector);
+    var target;
+    try {
+      target = document.querySelector(selector);
+    } catch (e) {
+      console.warn("[HMR] Invalid selector, reloading:", selector, e);
+      window.location.reload();
+      return;
+    }
     if (!target) {
       console.log("[HMR] HTML target not found, reloading:", selector);
       window.location.reload();

--- a/crates/reinhardt-pages/src/hmr/message.rs
+++ b/crates/reinhardt-pages/src/hmr/message.rs
@@ -82,7 +82,7 @@ mod tests {
 	fn test_html_replace_serialization() {
 		// Arrange
 		let msg = HmrMessage::HtmlReplace {
-			selector: "body".to_string(),
+			selector: "#app".to_string(),
 			html: "<div id=\"app\">Updated</div>".to_string(),
 		};
 
@@ -93,7 +93,7 @@ mod tests {
 		// Assert
 		assert_eq!(msg, deserialized);
 		assert!(json.contains("\"type\":\"html_replace\""));
-		assert!(json.contains("\"selector\":\"body\""));
+		assert!(json.contains("\"selector\":\"#app\""));
 		assert!(json.contains("Updated"));
 	}
 

--- a/crates/reinhardt-pages/src/hmr/message.rs
+++ b/crates/reinhardt-pages/src/hmr/message.rs
@@ -92,9 +92,10 @@ mod tests {
 
 		// Assert
 		assert_eq!(msg, deserialized);
-		assert!(json.contains("\"type\":\"html_replace\""));
-		assert!(json.contains("\"selector\":\"#app\""));
-		assert!(json.contains("Updated"));
+		let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+		assert_eq!(value["type"], "html_replace");
+		assert_eq!(value["selector"], "#app");
+		assert_eq!(value["html"], "<div id=\"app\">Updated</div>");
 	}
 
 	#[rstest]

--- a/crates/reinhardt-pages/src/hmr/message.rs
+++ b/crates/reinhardt-pages/src/hmr/message.rs
@@ -11,6 +11,13 @@ pub enum HmrMessage {
 		/// The path of the changed CSS file, relative to the project root.
 		path: String,
 	},
+	/// Static HTML was updated and can be patched without rebuilding WASM.
+	HtmlReplace {
+		/// CSS selector for the element whose contents should be replaced.
+		selector: String,
+		/// Replacement HTML for the selected element.
+		html: String,
+	},
 	/// A non-CSS file was changed - the client should perform a full page reload.
 	FullReload {
 		/// Human-readable reason for the reload.
@@ -69,6 +76,25 @@ mod tests {
 		assert_eq!(msg, deserialized);
 		assert!(json.contains("\"type\":\"full_reload\""));
 		assert!(json.contains("\"reason\":\"Rust source changed\""));
+	}
+
+	#[rstest]
+	fn test_html_replace_serialization() {
+		// Arrange
+		let msg = HmrMessage::HtmlReplace {
+			selector: "body".to_string(),
+			html: "<div id=\"app\">Updated</div>".to_string(),
+		};
+
+		// Act
+		let json = msg.to_json().unwrap();
+		let deserialized = HmrMessage::from_json(&json).unwrap();
+
+		// Assert
+		assert_eq!(msg, deserialized);
+		assert!(json.contains("\"type\":\"html_replace\""));
+		assert!(json.contains("\"selector\":\"body\""));
+		assert!(json.contains("Updated"));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-pages/src/hmr/server.rs
+++ b/crates/reinhardt-pages/src/hmr/server.rs
@@ -78,6 +78,29 @@ impl HmrServer {
 		Ok(bound_addr)
 	}
 
+	/// Starts only the WebSocket listener.
+	///
+	/// This mode is used by outer build loops that already own file watching
+	/// and want to broadcast only after their rebuild pipeline succeeds.
+	pub async fn start_listener_only(&self) -> Result<std::net::SocketAddr, std::io::Error> {
+		if !self.config.enabled {
+			let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+			return listener.local_addr();
+		}
+
+		let addr = format!("127.0.0.1:{}", self.config.ws_port);
+		let listener = TcpListener::bind(&addr).await?;
+		let bound_addr = listener.local_addr()?;
+
+		let tx = self.tx.clone();
+		let client_count = self.client_count.clone();
+		tokio::spawn(async move {
+			Self::accept_connections(listener, tx, client_count).await;
+		});
+
+		Ok(bound_addr)
+	}
+
 	/// Accepts incoming WebSocket connections and forwards broadcast messages.
 	async fn accept_connections(
 		listener: TcpListener,
@@ -342,6 +365,21 @@ mod tests {
 
 		// Assert
 		assert_ne!(addr.port(), 0);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_hmr_server_start_listener_only_binds_port() {
+		// Arrange
+		let config = HmrConfig::builder().ws_port(0).build();
+		let server = HmrServer::new(config);
+
+		// Act
+		let addr = server.start_listener_only().await.unwrap();
+
+		// Assert
+		assert_ne!(addr.port(), 0);
+		assert_eq!(server.client_count().await, 0);
 	}
 
 	// --- Additional notify_change variant coverage ---

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -276,6 +276,7 @@ pub mod integ;
 // Layer 1: server_fn unit tests (server-side only)
 // Layer 2: Component + server_fn mock tests (WASM)
 // Layer 3: E2E tests (both platforms)
+#[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
 // Static file URL resolver
@@ -351,7 +352,9 @@ pub use router::Link;
 pub use reactive::hooks::router::{NavigateError, RouterHandle, use_router};
 pub use router::{NavigationType, navigate};
 pub use server_fn::{ServerFn, ServerFnError, parse_server_error_message};
-pub use ssr::{SsrOptions, SsrRenderer, SsrState};
+pub use ssr::SsrState;
+#[cfg(native)]
+pub use ssr::{SsrOptions, SsrRenderer};
 pub use static_resolver::{init_static_resolver, is_initialized, resolve_static};
 
 // Re-export procedural macros

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -163,7 +163,9 @@ pub use crate::hydration::{
 
 #[cfg(wasm)]
 pub use crate::hydration::mark_hydration_complete;
-pub use crate::ssr::{SsrOptions, SsrRenderer, SsrState};
+pub use crate::ssr::SsrState;
+#[cfg(native)]
+pub use crate::ssr::{SsrOptions, SsrRenderer};
 
 // ============================================================================
 // Static File URL Resolver

--- a/crates/reinhardt-pages/src/ssr.rs
+++ b/crates/reinhardt-pages/src/ssr.rs
@@ -33,6 +33,7 @@
 //! ```
 
 mod markers;
+#[cfg(native)]
 mod renderer;
 mod state;
 
@@ -40,5 +41,6 @@ pub use markers::{
 	HYDRATION_ATTR_ID, HYDRATION_ATTR_PROPS, HydrationMarker, HydrationMarkerBuilder,
 	HydrationStrategy,
 };
+#[cfg(native)]
 pub use renderer::{SsrOptions, SsrRenderer};
 pub use state::{SsrState, StateEntry};

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/Cargo.toml
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/Cargo.toml
@@ -10,6 +10,10 @@ publish = false
 # pattern for nested-but-detached crates.
 [workspace]
 
+[profile.dev]
+codegen-units = 16
+debug = 0
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs
@@ -1,0 +1,40 @@
+use reinhardt_pages::app::ClientLauncher;
+use reinhardt_pages::component::Page;
+use reinhardt_pages::page;
+use reinhardt_pages::router::ClientRouter;
+use wasm_bindgen::prelude::*;
+
+fn home_page() -> Page {
+	page!(|| {
+		div {
+			id: "route-home",
+			a {
+				href: "/login",
+				id: "go-to-login",
+				"Go to login"
+			}
+		}
+	})()
+}
+
+fn login_page() -> Page {
+	page!(|| {
+		div {
+			id: "route-login",
+			"LOGIN VIEW"
+		}
+	})()
+}
+
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), JsValue> {
+	console_error_panic_hook::set_once();
+
+	ClientLauncher::new("#app")
+		.router_client(|| {
+			ClientRouter::new()
+				.route("home", "/", home_page)
+				.route("login", "/login", login_page)
+		})
+		.launch()
+}

--- a/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/lib.rs
+++ b/crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/lib.rs
@@ -8,39 +8,6 @@
 //!
 //! Refs #4088.
 
-use reinhardt_pages::app::ClientLauncher;
-use reinhardt_pages::component::{IntoPage, Page, PageElement};
-use reinhardt_pages::router::ClientRouter;
-use wasm_bindgen::prelude::*;
+mod client;
 
-fn home_page() -> Page {
-	PageElement::new("div")
-		.attr("id", "route-home")
-		.child(
-			PageElement::new("a")
-				.attr("href", "/login")
-				.attr("id", "go-to-login")
-				.child("Go to login"),
-		)
-		.into_page()
-}
-
-fn login_page() -> Page {
-	PageElement::new("div")
-		.attr("id", "route-login")
-		.child("LOGIN VIEW")
-		.into_page()
-}
-
-#[wasm_bindgen(start)]
-pub fn start() -> Result<(), JsValue> {
-	console_error_panic_hook::set_once();
-
-	ClientLauncher::new("#app")
-		.router_client(|| {
-			ClientRouter::new()
-				.route("home", "/", home_page)
-				.route("login", "/login", login_page)
-		})
-		.launch()
-}
+pub use client::start;

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 description = "Django-style shortcut functions for redirects, rendering, and 404 error handling"
 
 [dependencies]
-reinhardt-core = { workspace = true }
+reinhardt-core = { workspace = true, features = ["security"] }
 reinhardt-http = { workspace = true }
 reinhardt-views = { workspace = true }
 reinhardt-db = { workspace = true, optional = true }

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -38,12 +38,13 @@ wasm = [
   "dep:js-sys",
   "dep:gloo-timers",
   "dep:regex",
+  "reinhardt-pages/testing",
 ]
 wasm-full = ["wasm", "reinhardt-pages/web-sys-full"]
 # MSW-style network-level request interception (requires wasm)
 msw = ["wasm", "reinhardt-pages/msw"]
 # Server function testing utilities
-server-fn-test = []
+server-fn-test = ["reinhardt-pages/testing"]
 # E2E browser testing via WebDriver (fantoccini)
 e2e = ["dep:fantoccini", "dep:url"]
 # E2E browser testing via Chrome DevTools Protocol (chromiumoxide) + containerized Chrome

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -54,7 +54,7 @@ full = ["testcontainers", "static", "websockets", "graphql", "property-based", "
 [dependencies]
 # Cross-platform dependencies
 reinhardt-pages = { workspace = true }
-reinhardt-core = { workspace = true }
+reinhardt-core = { workspace = true, features = ["security"] }
 
 # Testing framework dependencies (proc-macro, compiles on host)
 rstest = "0.26.1"

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -66,7 +66,7 @@ uuid = { workspace = true }
 tempfile = "3.14"
 chrono-tz = { workspace = true }
 inventory = "0.3"
-reqwest = { version = "0.13.2", default-features = false, features = ["rustls"] }
+reqwest = { workspace = true }
 
 [features]
 default = []

--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -1448,8 +1448,8 @@ mod tests {
 		let result = StaticFilesMiddleware::inject_wasm_script(html, &entry, "/", None);
 
 		// Assert
-		assert!(result.contains("<h1>İstanbul</h1>\n<!-- Reinhardt WASM Auto-Loader -->"));
-		assert!(result.contains("</BODY></html>"));
+		let expected = "<html><body><h1>İstanbul</h1>\n<!-- Reinhardt WASM Auto-Loader -->\n<script type=\"module\">\nconst { default: init } = await import('/app.js');\nawait init({ module_or_path: '/app_bg.wasm' });\n</script>\n</BODY></html>";
+		assert_eq!(result, expected);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -430,8 +430,7 @@ impl StaticFilesMiddleware {
 			 </script>\n"
 		);
 
-		// Case-insensitive search for </body>
-		if let Some(pos) = html.to_lowercase().rfind("</body>") {
+		if let Some(pos) = Self::find_body_close_tag_pos(html) {
 			let mut result = String::with_capacity(html.len() + script.len());
 			result.push_str(&html[..pos]);
 			result.push_str(&script);
@@ -445,9 +444,16 @@ impl StaticFilesMiddleware {
 		}
 	}
 
+	fn find_body_close_tag_pos(html: &str) -> Option<usize> {
+		let needle = b"</body>";
+		html.as_bytes()
+			.windows(needle.len())
+			.rposition(|window| window.eq_ignore_ascii_case(needle))
+	}
+
 	/// Inject a trusted HTML fragment before `</body>`, or append when absent.
 	fn inject_trusted_html_fragment(html: &str, fragment: &str) -> String {
-		if let Some(pos) = html.to_lowercase().rfind("</body>") {
+		if let Some(pos) = Self::find_body_close_tag_pos(html) {
 			let mut result = String::with_capacity(html.len() + fragment.len());
 			result.push_str(&html[..pos]);
 			result.push_str(fragment);
@@ -1430,6 +1436,23 @@ mod tests {
 	}
 
 	#[rstest]
+	fn test_inject_wasm_script_unicode_before_uppercase_body() {
+		// Arrange
+		let html = "<html><body><h1>İstanbul</h1></BODY></html>";
+		let entry = WasmEntry {
+			js_file: "app.js".to_string(),
+			wasm_file: "app_bg.wasm".to_string(),
+		};
+
+		// Act
+		let result = StaticFilesMiddleware::inject_wasm_script(html, &entry, "/", None);
+
+		// Assert
+		assert!(result.contains("<h1>İstanbul</h1>\n<!-- Reinhardt WASM Auto-Loader -->"));
+		assert!(result.contains("</BODY></html>"));
+	}
+
+	#[rstest]
 	fn test_inject_wasm_script_no_body_tag_appends() {
 		// Arrange
 		let html = "<html><h1>No body tag</h1></html>";
@@ -1459,6 +1482,22 @@ mod tests {
 		assert_eq!(
 			result,
 			"<html><body><h1>Hello</h1>\n<script>window.__hmr = true;</script>\n</body></html>"
+		);
+	}
+
+	#[rstest]
+	fn test_inject_trusted_html_fragment_unicode_before_uppercase_body() {
+		// Arrange
+		let html = "<html><body><h1>İstanbul</h1></BODY></html>";
+		let fragment = "\n<script>window.__hmr = true;</script>\n";
+
+		// Act
+		let result = StaticFilesMiddleware::inject_trusted_html_fragment(html, fragment);
+
+		// Assert
+		assert_eq!(
+			result,
+			"<html><body><h1>İstanbul</h1>\n<script>window.__hmr = true;</script>\n</BODY></html>"
 		);
 	}
 

--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -80,6 +80,11 @@ pub struct StaticFilesConfig {
 	pub wasm_entry: Option<String>,
 	/// Manifest mapping original filenames to hashed filenames
 	pub wasm_manifest: Option<HashMap<String, String>>,
+	/// Trusted HTML fragments appended to SPA HTML responses.
+	///
+	/// These fragments are not escaped. They are intended for framework-owned
+	/// development scripts such as hot-reload clients, not user input.
+	pub trusted_html_injections: Vec<String>,
 }
 
 impl Default for StaticFilesConfig {
@@ -97,6 +102,7 @@ impl Default for StaticFilesConfig {
 			auto_inject_wasm: true,
 			wasm_entry: None,
 			wasm_manifest: None,
+			trusted_html_injections: Vec::new(),
 		}
 	}
 }
@@ -225,6 +231,20 @@ impl StaticFilesConfig {
 	/// Set the WASM manifest for filename resolution (e.g., hashed filenames).
 	pub fn wasm_manifest(mut self, manifest: HashMap<String, String>) -> Self {
 		self.wasm_manifest = Some(manifest);
+		self
+	}
+
+	/// Add a trusted HTML fragment to inject into SPA fallback responses.
+	///
+	/// The fragment is inserted before `</body>` when present, otherwise it is
+	/// appended to the end of the HTML document.
+	pub fn trusted_html_injection(mut self, fragment: impl Into<String>) -> Self {
+		let fragment = fragment.into();
+		assert!(
+			!fragment.is_empty(),
+			"trusted_html_injection must not be empty"
+		);
+		self.trusted_html_injections.push(fragment);
 		self
 	}
 }
@@ -425,6 +445,22 @@ impl StaticFilesMiddleware {
 		}
 	}
 
+	/// Inject a trusted HTML fragment before `</body>`, or append when absent.
+	fn inject_trusted_html_fragment(html: &str, fragment: &str) -> String {
+		if let Some(pos) = html.to_lowercase().rfind("</body>") {
+			let mut result = String::with_capacity(html.len() + fragment.len());
+			result.push_str(&html[..pos]);
+			result.push_str(fragment);
+			result.push_str(&html[pos..]);
+			result
+		} else {
+			let mut result = String::with_capacity(html.len() + fragment.len());
+			result.push_str(html);
+			result.push_str(fragment);
+			result
+		}
+	}
+
 	/// Check if the request path matches the URL prefix.
 	fn matches_prefix(&self, path: &str) -> bool {
 		if self.config.url_prefix == "/" {
@@ -538,30 +574,37 @@ impl StaticFilesMiddleware {
 			.and_then(|n| n.to_str())
 			.unwrap_or("index.html");
 
-		// Apply WASM injection if entry is detected
-		let final_content = if let Some(ref entry) = self.wasm_entry {
-			match String::from_utf8(content) {
-				Ok(html) => {
-					let injected = Self::inject_wasm_script(
-						&html,
-						entry,
-						&self.config.url_prefix,
-						self.config.wasm_manifest.as_ref(),
-					);
-					tracing::debug!("injected WASM auto-loader into SPA response");
-					injected.into_bytes()
+		// Apply WASM and trusted development-script injections if needed.
+		let final_content =
+			if self.wasm_entry.is_some() || !self.config.trusted_html_injections.is_empty() {
+				match String::from_utf8(content) {
+					Ok(html) => {
+						let mut injected = html;
+						if let Some(ref entry) = self.wasm_entry {
+							injected = Self::inject_wasm_script(
+								&injected,
+								entry,
+								&self.config.url_prefix,
+								self.config.wasm_manifest.as_ref(),
+							);
+							tracing::debug!("injected WASM auto-loader into SPA response");
+						}
+						for fragment in &self.config.trusted_html_injections {
+							injected = Self::inject_trusted_html_fragment(&injected, fragment);
+						}
+						injected.into_bytes()
+					}
+					Err(e) => {
+						tracing::warn!(
+							"SPA fallback is not valid UTF-8, serving raw content: {}",
+							e
+						);
+						e.into_bytes()
+					}
 				}
-				Err(e) => {
-					tracing::warn!(
-						"SPA fallback is not valid UTF-8, serving raw content: {}",
-						e
-					);
-					e.into_bytes()
-				}
-			}
-		} else {
-			content
-		};
+			} else {
+				content
+			};
 
 		// Generate ETag from final content (post-injection)
 		let etag = {
@@ -709,6 +752,7 @@ mod tests {
 		assert_eq!(config.url_prefix, "/");
 		assert!(config.spa_mode);
 		assert_eq!(config.index_files, vec!["index.html".to_string()]);
+		assert!(config.trusted_html_injections.is_empty());
 	}
 
 	#[test]
@@ -1400,6 +1444,38 @@ mod tests {
 		// Assert — generated HTML with dynamic URLs
 		assert!(result.ends_with("</script>\n"));
 		assert!(result.contains("<!-- Reinhardt WASM Auto-Loader -->"));
+	}
+
+	#[rstest]
+	fn test_inject_trusted_html_fragment_before_body() {
+		// Arrange
+		let html = "<html><body><h1>Hello</h1></body></html>";
+		let fragment = "\n<script>window.__hmr = true;</script>\n";
+
+		// Act
+		let result = StaticFilesMiddleware::inject_trusted_html_fragment(html, fragment);
+
+		// Assert
+		assert_eq!(
+			result,
+			"<html><body><h1>Hello</h1>\n<script>window.__hmr = true;</script>\n</body></html>"
+		);
+	}
+
+	#[rstest]
+	fn test_inject_trusted_html_fragment_appends_without_body() {
+		// Arrange
+		let html = "<html><h1>Hello</h1></html>";
+		let fragment = "\n<script>window.__hmr = true;</script>\n";
+
+		// Act
+		let result = StaticFilesMiddleware::inject_trusted_html_fragment(html, fragment);
+
+		// Assert
+		assert_eq!(
+			result,
+			"<html><h1>Hello</h1></html>\n<script>window.__hmr = true;</script>\n"
+		);
 	}
 
 	#[rstest]

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -62,6 +62,10 @@ For Issue #5218, the target loops are:
 
 The current script covers the Rust build side of those loops, including
 separate Pages WASM, native server, shared/core, and proc-macro scenarios.
+The dev profile is optimized for hot-reload throughput with `debug = 0` and
+`codegen-units = 16`; the test profile keeps `debug = 1` for debuggable test
+artifacts. Changing these profile settings causes a one-time rebuild of
+affected dev artifacts; compare warmed edit loops after that rebuild.
 The Pages WASM build scenario currently measures Cargo's library artifact only;
 it does not run `wasm-bindgen` against a browser-loadable `cdylib` fixture.
 Add that fixture-level scenario before claiming end-to-end browser artifact
@@ -84,12 +88,13 @@ address to become reachable. Runtime measurements still need to be added before
 claiming browser-visible latency numbers.
 
 Static `page!(|| { ... })` edits under WASM-owned client source paths can use
-the compile-free development hot patch path. Dynamic Rust expressions, event
-handlers, control flow, components, and shared/server-owned files still fall
-back to the normal rebuild path. The Pages macro also emits batched attribute
-builders instead of one chained method call per generated attribute, which
-reduces generated Rust for attribute-heavy templates when a rebuild is still
-required.
+the compile-free development hot patch path. The HMR payload replaces `#app`
+contents, preserving the development script and page shell. Dynamic Rust
+expressions, event handlers, control flow, components, and shared/server-owned
+files still fall back to the normal rebuild path. The Pages macro also emits
+batched attribute builders instead of one chained method call per generated
+attribute, which reduces generated Rust for attribute-heavy templates when a
+rebuild is still required.
 
 ## Hot-Reload Target Selection
 

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -63,6 +63,10 @@ The Pages WASM build scenario currently measures Cargo's library artifact only;
 it does not run `wasm-bindgen` against a browser-loadable `cdylib` fixture.
 Add that fixture-level scenario before claiming end-to-end browser artifact
 latency.
+When reducing this scenario, prefer removing non-browser modules from the
+WASM compilation graph before changing Cargo profiles: profile changes measured
+noisy or slower locally, while feature/target gating gives a direct dependency
+and codegen reduction.
 Browser-visible hot-reload now has a success-gated HMR notification channel for Pages
 `runserver --with-pages`: the autoreload parent keeps a WebSocket listener
 alive, the child injects the HMR client into SPA HTML, and the watcher sends a

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -40,7 +40,7 @@ environment variables.
 | `incremental-db-macro-check` | A proc-macro fan-out edit loop |
 | `incremental-page-macro-check` | A Pages macro fan-out edit loop |
 | `incremental-pages-wasm-check` | A Pages runtime WASM check loop |
-| `incremental-pages-wasm-build` | A Pages runtime WASM build/codegen loop |
+| `incremental-pages-wasm-build` | A Pages runtime WASM library build loop |
 | `incremental-server-build` | A server crate native build loop |
 | `incremental-hot-reload-client-legacy-both-build` | Legacy Pages client-edit hot-reload work shape: WASM build plus native server build |
 | `incremental-hot-reload-server-legacy-both-build` | Legacy server-edit hot-reload work shape: native server build plus WASM build |
@@ -59,6 +59,10 @@ For Issue #5218, the target loops are:
 
 The current script covers the Rust build side of those loops, including
 separate Pages WASM, native server, shared/core, and proc-macro scenarios.
+The Pages WASM build scenario currently measures Cargo's library artifact only;
+it does not run `wasm-bindgen` against a browser-loadable `cdylib` fixture.
+Add that fixture-level scenario before claiming end-to-end browser artifact
+latency.
 Browser-visible hot-reload now has a success-gated HMR notification channel for Pages
 `runserver --with-pages`: the autoreload parent keeps a WebSocket listener
 alive, the child injects the HMR client into SPA HTML, and the watcher sends a

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -1,0 +1,57 @@
+# Build Performance Measurements
+
+This directory stores reproducible build-loop measurements for Reinhardt.
+Use these measurements before claiming compile-time or hot-reload latency
+improvements.
+
+## Quick Start
+
+Preview the benchmark commands without running them:
+
+```bash
+cargo make bench-builds-dry-run
+```
+
+Run the standard benchmark suite:
+
+```bash
+cargo make bench-builds
+```
+
+Run a focused scenario:
+
+```bash
+scripts/bench-build.sh incremental-leaf-check
+```
+
+`scripts/bench-build.sh` writes a JSON report under `docs/build-perf/` and
+an adjacent `.env.txt` file with the Rust version, host, and cache-relevant
+environment variables.
+
+## Scenario Meaning
+
+| Scenario | Measures |
+|---|---|
+| `cold-check-all-features` | Full all-features workspace check after `cargo clean` |
+| `cold-build-standard` | Default workspace build after `cargo clean` |
+| `cold-test-build` | Test binary build/link cost before tests execute |
+| `incremental-leaf-check` | A low-fan-out crate edit loop |
+| `incremental-core-check` | A shared core edit loop |
+| `incremental-db-macro-check` | A proc-macro fan-out edit loop |
+| `incremental-page-macro-check` | A Pages macro fan-out edit loop |
+| `incremental-leaf-build` | Incremental build/link cost for a low-fan-out crate |
+
+## Interpreting Results
+
+Compare every optimization PR against the same baseline report where possible.
+For Issue #5218, the target loops are:
+
+- Pure `page!` UI/template edit latency.
+- WASM-side Rust logic edit latency.
+- Server-only Rust logic edit latency.
+- Shared/core/proc-macro edit latency.
+- Cold workspace build/check latency.
+
+The current script covers the Rust build side of those loops. Browser-visible
+hot-reload latency still needs a runtime benchmark once the reload notification
+channel and dev-mode `page!` path exist.

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -55,3 +55,12 @@ For Issue #5218, the target loops are:
 The current script covers the Rust build side of those loops. Browser-visible
 hot-reload latency still needs a runtime benchmark once the reload notification
 channel and dev-mode `page!` path exist.
+
+## Hot-Reload Target Selection
+
+The autoreload watcher classifies debounced paths before dispatching rebuilds.
+For Pages projects, `src/client.rs`, `src/client/**`, and
+`src/apps/*/client/**` are treated as WASM-only; `src/bin/**` plus server
+process configuration are treated as server-only; shared code, manifests, and
+lockfiles still rebuild both sides. Keep this conservative unless a new path is
+proved to be target-specific by generated project structure and tests.

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -67,7 +67,10 @@ claiming browser-visible latency numbers.
 
 Pure `page!` edits still compile as Rust today. A compile-free dev-mode
 template path is a separate architecture change and should not be implied by
-the current HMR notification channel.
+the current HMR notification channel. The Pages macro now emits batched
+attribute builders instead of one chained method call per generated attribute,
+which reduces generated Rust for attribute-heavy templates but does not remove
+the Rust compilation step.
 
 ## Hot-Reload Target Selection
 

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -39,6 +39,9 @@ environment variables.
 | `incremental-core-check` | A shared core edit loop |
 | `incremental-db-macro-check` | A proc-macro fan-out edit loop |
 | `incremental-page-macro-check` | A Pages macro fan-out edit loop |
+| `incremental-pages-wasm-check` | A Pages runtime WASM check loop |
+| `incremental-pages-wasm-build` | A Pages runtime WASM build/codegen loop |
+| `incremental-server-build` | A server crate native build loop |
 | `incremental-leaf-build` | Incremental build/link cost for a low-fan-out crate |
 
 ## Interpreting Results
@@ -52,8 +55,9 @@ For Issue #5218, the target loops are:
 - Shared/core/proc-macro edit latency.
 - Cold workspace build/check latency.
 
-The current script covers the Rust build side of those loops. Browser-visible
-hot-reload now has a success-gated HMR notification channel for Pages
+The current script covers the Rust build side of those loops, including
+separate Pages WASM, native server, shared/core, and proc-macro scenarios.
+Browser-visible hot-reload now has a success-gated HMR notification channel for Pages
 `runserver --with-pages`: the autoreload parent keeps a WebSocket listener
 alive, the child injects the HMR client into SPA HTML, and the watcher sends a
 full reload only after the selected rebuild pipelines succeed. Reloads that

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -53,8 +53,17 @@ For Issue #5218, the target loops are:
 - Cold workspace build/check latency.
 
 The current script covers the Rust build side of those loops. Browser-visible
-hot-reload latency still needs a runtime benchmark once the reload notification
-channel and dev-mode `page!` path exist.
+hot-reload now has a success-gated HMR notification channel for Pages
+`runserver --with-pages`: the autoreload parent keeps a WebSocket listener
+alive, the child injects the HMR client into SPA HTML, and the watcher sends a
+full reload only after the selected rebuild pipelines succeed. Reloads that
+depend on a native server respawn also wait briefly for the child server TCP
+address to become reachable. Runtime measurements still need to be added before
+claiming browser-visible latency numbers.
+
+Pure `page!` edits still compile as Rust today. A compile-free dev-mode
+template path is a separate architecture change and should not be implied by
+the current HMR notification channel.
 
 ## Hot-Reload Target Selection
 
@@ -64,3 +73,21 @@ For Pages projects, `src/client.rs`, `src/client/**`, and
 process configuration are treated as server-only; shared code, manifests, and
 lockfiles still rebuild both sides. Keep this conservative unless a new path is
 proved to be target-specific by generated project structure and tests.
+
+## Browser Reload Notification
+
+When Pages autoreload is enabled, `runserver` starts a stable HMR WebSocket
+listener in the autoreload parent process. The spawned `--noreload` child
+receives the listener port through `REINHARDT_HMR_PORT` and injects the
+framework-owned HMR script into SPA fallback HTML. This keeps the browser
+connected across native server restarts.
+
+The watcher broadcasts `full_reload` only after all rebuild targets selected
+for the change batch succeed:
+
+- WASM-only edits reload after the WASM bundle rebuild succeeds.
+- Server-only edits reload after the native binary rebuilds, respawns, and the
+  server address accepts TCP.
+- Shared edits reload only after both selected pipelines succeed and the
+  respawned server is reachable.
+- Failed rebuilds keep the old page running and wait for the next change.

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -42,6 +42,8 @@ environment variables.
 | `incremental-pages-wasm-check` | A Pages runtime WASM check loop |
 | `incremental-pages-wasm-build` | A Pages runtime WASM build/codegen loop |
 | `incremental-server-build` | A server crate native build loop |
+| `incremental-hot-reload-client-legacy-both-build` | Legacy Pages client-edit hot-reload work shape: WASM build plus native server build |
+| `incremental-hot-reload-server-legacy-both-build` | Legacy server-edit hot-reload work shape: native server build plus WASM build |
 | `incremental-leaf-build` | Incremental build/link cost for a low-fan-out crate |
 
 ## Interpreting Results

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -41,6 +41,9 @@ environment variables.
 | `incremental-page-macro-check` | A Pages macro fan-out edit loop |
 | `incremental-pages-wasm-check` | A Pages runtime WASM check loop |
 | `incremental-pages-wasm-build` | A Pages runtime WASM library build loop |
+| `incremental-pages-fixture-wasm-build` | A detached browser app fixture build after editing `page!` source |
+| `incremental-pages-fixture-hot-patch` | Compile-free static `page!` hot patch loop for the detached browser fixture |
+| `incremental-pages-fixture-hot-reload-legacy-both-build` | Legacy detached browser app `page!` edit work shape: fixture WASM build plus native server build |
 | `incremental-server-build` | A server crate native build loop |
 | `incremental-hot-reload-client-legacy-both-build` | Legacy Pages client-edit hot-reload work shape: WASM build plus native server build |
 | `incremental-hot-reload-server-legacy-both-build` | Legacy server-edit hot-reload work shape: native server build plus WASM build |
@@ -63,6 +66,11 @@ The Pages WASM build scenario currently measures Cargo's library artifact only;
 it does not run `wasm-bindgen` against a browser-loadable `cdylib` fixture.
 Add that fixture-level scenario before claiming end-to-end browser artifact
 latency.
+Use `incremental-pages-fixture-wasm-build` when the claim is specifically
+about app-side `page!` edits rather than framework runtime edits.
+Use `incremental-pages-fixture-hot-patch` for static `page!(|| { ... })`
+edits that can be parsed and broadcast through the development HMR channel
+without rebuilding the WASM artifact.
 When reducing this scenario, prefer removing non-browser modules from the
 WASM compilation graph before changing Cargo profiles: profile changes measured
 noisy or slower locally, while feature/target gating gives a direct dependency
@@ -75,12 +83,13 @@ depend on a native server respawn also wait briefly for the child server TCP
 address to become reachable. Runtime measurements still need to be added before
 claiming browser-visible latency numbers.
 
-Pure `page!` edits still compile as Rust today. A compile-free dev-mode
-template path is a separate architecture change and should not be implied by
-the current HMR notification channel. The Pages macro now emits batched
-attribute builders instead of one chained method call per generated attribute,
-which reduces generated Rust for attribute-heavy templates but does not remove
-the Rust compilation step.
+Static `page!(|| { ... })` edits under WASM-owned client source paths can use
+the compile-free development hot patch path. Dynamic Rust expressions, event
+handlers, control flow, components, and shared/server-owned files still fall
+back to the normal rebuild path. The Pages macro also emits batched attribute
+builders instead of one chained method call per generated attribute, which
+reduces generated Rust for attribute-heavy templates when a rebuild is still
+required.
 
 ## Hot-Reload Target Selection
 

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -91,3 +91,8 @@ for the change batch succeed:
 - Shared edits reload only after both selected pipelines succeed and the
   respawned server is reachable.
 - Failed rebuilds keep the old page running and wait for the next change.
+
+`runserver --with-pages --no-override-wasm` reuses existing Pages artifacts
+only when `dist/<crate>_bg.wasm` is newer than tracked source files. A plain
+`dist/<crate>.js` existence check is not enough: it can serve stale WASM after a
+Rust edit and hides the real feedback-loop cost.

--- a/docs/build-perf/issue-5218-incremental-check-results.md
+++ b/docs/build-perf/issue-5218-incremental-check-results.md
@@ -12,7 +12,8 @@ Environment:
 - Host: macOS on `aarch64-apple-darwin`
 - Rust: `rustc 1.94.1 (e408947bf 2026-03-25)`
 - Tool: `hyperfine`; leaf/core scenarios used `--warmup 1 --runs 2`, latest
-  Pages/WASM and server scenarios used `--warmup 2 --runs 5`
+  Pages/WASM and server scenarios used `--warmup 2 --runs 5`; static
+  `page!` hot-patch fixture scenarios used `--warmup 3 --runs 12`
 
 ## Results
 
@@ -56,6 +57,26 @@ touch crates/reinhardt-server/src/server.rs && cargo build -p reinhardt-server &
 touch crates/reinhardt-server/src/server.rs && cargo build -p reinhardt-server
 ```
 
+### App-Side `page!` Fixture Loops
+
+These measurements use the detached `spa_navigation_app` browser fixture after
+moving its `page!` bodies under `src/client.rs`, which matches the watcher
+ownership boundary for WASM-only client source.
+
+| Scenario | Mean | Change vs legacy both-target |
+|---|---:|---:|
+| Static `page!` hot patch | 0.005s | 99.8% faster |
+| Fixture WASM build | 2.292s | 19.1% faster |
+| Legacy fixture WASM + server build | 2.832s | baseline |
+
+Raw command shapes:
+
+```bash
+touch crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs && ./target/debug/examples/page_hot_patch_probe crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs >/dev/null
+touch crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs && cargo build --manifest-path crates/reinhardt-pages/tests/fixtures/spa_navigation_app/Cargo.toml --target wasm32-unknown-unknown
+touch crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs && cargo build --manifest-path crates/reinhardt-pages/tests/fixtures/spa_navigation_app/Cargo.toml --target wasm32-unknown-unknown && cargo build -p reinhardt-server
+```
+
 ## Interpretation
 
 The shared/core edit loop currently lands inside the expected 30-60% reduction
@@ -89,6 +110,12 @@ The earlier experimental profile change (`line-tables-only`,
 reverted. Keep the default `debug = 1` profile unless a future benchmark proves
 a different profile is faster across the target scenarios.
 
-These measurements do not prove compile-free `page!` editing. Inline `page!`
-macro edits still compile as Rust; compile-free template edits require a
-separate dev-mode runtime/template architecture.
+Static `page!(|| { ... })` edits now have a compile-free development path when
+the changed file is owned by the Pages client side (`src/client.rs`,
+`src/client/**`, or `src/apps/*/client/**`) and the parser can render the page
+body without dynamic Rust. That path reaches the original 80-98% pure
+`page!` edit target in the fixture run, measuring 99.8% faster than the legacy
+both-target rebuild shape. Dynamic Rust expressions, event handlers, control
+flow, components, and shared/server-owned files intentionally fall back to
+normal rebuilds, so the broader WASM-side Rust logic target remains unmet by
+this hot-patch path.

--- a/docs/build-perf/issue-5218-incremental-check-results.md
+++ b/docs/build-perf/issue-5218-incremental-check-results.md
@@ -19,9 +19,9 @@ Environment:
 |---|---:|---:|---:|
 | `incremental-leaf-check` | 0.389s | 0.512s | 31.4% slower |
 | `incremental-core-check` | 50.022s | 31.875s | 36.3% faster |
-| `incremental-pages-wasm-check` | 1.528s | 1.354s | 11.4% faster |
-| `incremental-pages-wasm-build` | 1.933s | 2.032s | 5.1% slower |
-| `incremental-server-build` | 0.947s | 1.035s | 9.3% slower |
+| `incremental-pages-wasm-check` | 1.528s | 1.242s | 18.7% faster |
+| `incremental-pages-wasm-build` | 1.933s | 1.876s | 2.9% faster |
+| `incremental-server-build` | 0.947s | 0.905s | 4.4% faster |
 
 Raw command shapes:
 
@@ -41,8 +41,8 @@ the PR branch targeted rebuild shape.
 
 | Scenario | Legacy both-target mean | Targeted mean | Change |
 |---|---:|---:|---:|
-| Pages client edit | 2.402s | 1.863s | 22.4% faster |
-| Server-only edit | 1.253s | 0.854s | 31.9% faster |
+| Pages client edit | 2.302s | 1.837s | 20.2% faster |
+| Server-only edit | 1.212s | 0.884s | 27.1% faster |
 
 Raw command shapes:
 
@@ -59,11 +59,12 @@ The shared/core edit loop currently lands inside the expected 30-60% reduction
 range. The leaf package check does not: it is slower in this local run, so PR
 #5220 must not claim a universal incremental-check improvement.
 
-The targeted server-only hot-reload work shape lands just inside the expected
-30-60% reduction range. The targeted Pages/WASM client-edit work shape does
-not: it improves by 22.4%, below the expected 40-70% range. Direct WASM build
-also did not improve, so further work must reduce the WASM build/bindgen path
-itself rather than only skipping unrelated native server work.
+The targeted server-only hot-reload work shape is close to, but still below,
+the expected 30-60% reduction range in the latest local run. The targeted
+Pages/WASM client-edit work shape does not land in the expected 40-70% range:
+it improves by 20.2%. Direct WASM build improves only 2.9%, so further work
+must reduce the WASM build/bindgen path itself rather than only skipping
+unrelated native server work.
 
 The earlier experimental profile change (`line-tables-only`,
 `split-debuginfo = "unpacked"`, `codegen-units = 256`, explicit

--- a/docs/build-perf/issue-5218-incremental-check-results.md
+++ b/docs/build-perf/issue-5218-incremental-check-results.md
@@ -1,7 +1,7 @@
 # Issue #5218 Incremental Check Measurements
 
 These measurements compare `origin/main` at
-`3016d326de63950ac553cd2246d02a0315bd7f06` with PR #5220 at the current
+`3016d326de63950ac553cd2246d02a0315bd7f06` with PR `#5220` at the current
 branch. The PR branch prunes Pages/WASM dependencies through workspace feature
 boundaries, gates dev/test/native-only Pages modules out of browser WASM
 builds, and uses a narrower dev profile (`debug = 0`, `codegen-units = 16`)
@@ -94,7 +94,7 @@ touch crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs && 
 ## Interpretation
 
 The shared/core edit loop lands inside the expected 30-60% reduction range.
-The leaf package check does not: it is slower in this local run, so PR #5220
+The leaf package check does not: it is slower in this local run, so PR `#5220`
 must not claim a universal incremental-check improvement.
 
 The cold standard workspace build improves by 17.1%. That is a real reduction,

--- a/docs/build-perf/issue-5218-incremental-check-results.md
+++ b/docs/build-perf/issue-5218-incremental-check-results.md
@@ -3,15 +3,16 @@
 These measurements compare `origin/main` at
 `3016d326de63950ac553cd2246d02a0315bd7f06` with PR #5220 at the current
 branch after reverting the experimental dev/test profile tuning back to
-`debug = 1` and pruning Pages/WASM dependencies through workspace feature
-boundaries.
+`debug = 1`, pruning Pages/WASM dependencies through workspace feature
+boundaries, and gating dev/test/native-only Pages modules out of browser WASM
+builds.
 
 Environment:
 
 - Host: macOS on `aarch64-apple-darwin`
 - Rust: `rustc 1.94.1 (e408947bf 2026-03-25)`
-- Tool: `hyperfine --warmup 1`; leaf/core scenarios used `--runs 2`, latest
-  Pages/WASM and server scenarios used `--runs 3`
+- Tool: `hyperfine`; leaf/core scenarios used `--warmup 1 --runs 2`, latest
+  Pages/WASM and server scenarios used `--warmup 2 --runs 5`
 
 ## Results
 
@@ -21,9 +22,9 @@ Environment:
 |---|---:|---:|---:|
 | `incremental-leaf-check` | 0.389s | 0.512s | 31.4% slower |
 | `incremental-core-check` | 50.022s | 31.875s | 36.3% faster |
-| `incremental-pages-wasm-check` | 1.528s | 1.181s | 22.7% faster |
-| `incremental-pages-wasm-build` | 1.933s | 1.819s | 5.9% faster |
-| `incremental-server-build` | 0.947s | 0.919s | 2.9% faster |
+| `incremental-pages-wasm-check` | 1.528s | 1.174s | 23.2% faster |
+| `incremental-pages-wasm-build` | 1.933s | 1.720s | 11.0% faster |
+| `incremental-server-build` | 0.947s | 0.920s | 2.9% faster |
 
 Raw command shapes:
 
@@ -43,8 +44,8 @@ the PR branch targeted rebuild shape.
 
 | Scenario | Legacy both-target mean | Targeted mean | Change |
 |---|---:|---:|---:|
-| Pages client edit | 2.120s | 1.757s | 17.1% faster |
-| Server-only edit | 1.131s | 0.858s | 24.2% faster |
+| Pages client edit | 1.957s | 1.753s | 10.4% faster |
+| Server-only edit | 1.202s | 0.912s | 24.1% faster |
 
 Raw command shapes:
 
@@ -64,7 +65,8 @@ range. The leaf package check does not: it is slower in this local run, so PR
 The targeted server-only hot-reload work shape is below the expected 30-60%
 reduction range in the latest local run. The targeted
 Pages/WASM client-edit work shape does not land in the expected 40-70% range:
-it improves by 17.1%. Direct WASM build improves only 5.9%, so further work
+it improves by 10.4% in the latest same-branch legacy-vs-targeted work-shape
+run. Direct WASM build improves 11.0%, so further work
 must reduce the WASM build/bindgen path itself rather than only skipping
 unrelated native server work.
 
@@ -74,6 +76,12 @@ documentation diagrams behind explicit features. This removes `image`,
 `ravif`, `tiff`, `exr`, and `aquamarine` from the Pages/WASM normal dependency
 tree, but the warmed incremental build loop is still dominated by recompiling
 the WASM crate artifact.
+
+The latest Pages module gating keeps `testing` behind the existing `testing`
+feature/test cfg and compiles `SsrRenderer`/`SsrOptions` only on native targets.
+Hydration-shared `SsrState` and marker types remain available to browser WASM.
+This improves direct WASM build from 5.9% to 11.0% faster versus `origin/main`,
+but it still does not approach the expected 40-70% Pages/WASM reduction range.
 
 The earlier experimental profile change (`line-tables-only`,
 `split-debuginfo = "unpacked"`, `codegen-units = 256`, explicit

--- a/docs/build-perf/issue-5218-incremental-check-results.md
+++ b/docs/build-perf/issue-5218-incremental-check-results.md
@@ -2,18 +2,19 @@
 
 These measurements compare `origin/main` at
 `3016d326de63950ac553cd2246d02a0315bd7f06` with PR #5220 at the current
-branch after reverting the experimental dev/test profile tuning back to
-`debug = 1`, pruning Pages/WASM dependencies through workspace feature
-boundaries, and gating dev/test/native-only Pages modules out of browser WASM
-builds.
+branch. The PR branch prunes Pages/WASM dependencies through workspace feature
+boundaries, gates dev/test/native-only Pages modules out of browser WASM
+builds, and uses a narrower dev profile (`debug = 0`, `codegen-units = 16`)
+for generated debug artifacts while keeping `profile.test.debug = 1`.
 
 Environment:
 
 - Host: macOS on `aarch64-apple-darwin`
 - Rust: `rustc 1.94.1 (e408947bf 2026-03-25)`
 - Tool: `hyperfine`; leaf/core scenarios used `--warmup 1 --runs 2`, latest
-  Pages/WASM and server scenarios used `--warmup 2 --runs 5`; static
-  `page!` hot-patch fixture scenarios used `--warmup 3 --runs 12`
+  Pages/WASM and server scenarios used `--warmup 2` with 5-8 runs; static
+  `page!` hot-patch fixture scenarios used `--warmup 3 --runs 12` initially
+  and `--warmup 2 --runs 8` after the dev-profile update
 
 ## Results
 
@@ -24,8 +25,8 @@ Environment:
 | `incremental-leaf-check` | 0.389s | 0.512s | 31.4% slower |
 | `incremental-core-check` | 50.022s | 31.875s | 36.3% faster |
 | `incremental-pages-wasm-check` | 1.528s | 1.174s | 23.2% faster |
-| `incremental-pages-wasm-build` | 1.933s | 1.720s | 11.0% faster |
-| `incremental-server-build` | 0.947s | 0.920s | 2.9% faster |
+| `incremental-pages-wasm-build` | 1.933s | 1.512s | 21.8% faster |
+| `incremental-server-build` | 0.947s | 0.710s | 25.0% faster |
 
 Raw command shapes:
 
@@ -46,7 +47,7 @@ the PR branch targeted rebuild shape.
 | Scenario | Legacy both-target mean | Targeted mean | Change |
 |---|---:|---:|---:|
 | Pages client edit | 1.957s | 1.753s | 10.4% faster |
-| Server-only edit | 1.202s | 0.912s | 24.1% faster |
+| Server-only edit | 1.019s | 0.710s | 30.3% faster |
 
 Raw command shapes:
 
@@ -65,9 +66,9 @@ ownership boundary for WASM-only client source.
 
 | Scenario | Mean | Change vs legacy both-target |
 |---|---:|---:|
-| Static `page!` hot patch | 0.005s | 99.8% faster |
-| Fixture WASM build | 2.292s | 19.1% faster |
-| Legacy fixture WASM + server build | 2.832s | baseline |
+| Static `page!` hot patch | 0.005s | 99.4% faster |
+| Fixture WASM build | 0.564s | 31.6% faster |
+| Legacy fixture WASM + server build | 0.825s | baseline |
 
 Raw command shapes:
 
@@ -79,17 +80,16 @@ touch crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs && 
 
 ## Interpretation
 
-The shared/core edit loop currently lands inside the expected 30-60% reduction
-range. The leaf package check does not: it is slower in this local run, so PR
-#5220 must not claim a universal incremental-check improvement.
+The shared/core edit loop lands inside the expected 30-60% reduction range.
+The leaf package check does not: it is slower in this local run, so PR #5220
+must not claim a universal incremental-check improvement.
 
-The targeted server-only hot-reload work shape is below the expected 30-60%
-reduction range in the latest local run. The targeted
-Pages/WASM client-edit work shape does not land in the expected 40-70% range:
-it improves by 10.4% in the latest same-branch legacy-vs-targeted work-shape
-run. Direct WASM build improves 11.0%, so further work
-must reduce the WASM build/bindgen path itself rather than only skipping
-unrelated native server work.
+The targeted server-only hot-reload work shape now reaches the lower end of
+the expected 30-60% range. The app-side fixture WASM build improves from the
+pre-profile 1.725-1.739s range to 0.564s, which lands in the expected 40-70%
+WASM-side Rust range for downstream-style app code. Direct framework
+`reinhardt-pages` WASM builds improve to 21.8%, so framework-runtime edits are
+still below the broader Pages/WASM target.
 
 The latest Pages/WASM dependency pruning keeps internal Reinhardt dependencies
 on `workspace = true` and moves `reinhardt-core`'s heavy image validator and
@@ -101,21 +101,24 @@ the WASM crate artifact.
 The latest Pages module gating keeps `testing` behind the existing `testing`
 feature/test cfg and compiles `SsrRenderer`/`SsrOptions` only on native targets.
 Hydration-shared `SsrState` and marker types remain available to browser WASM.
-This improves direct WASM build from 5.9% to 11.0% faster versus `origin/main`,
-but it still does not approach the expected 40-70% Pages/WASM reduction range.
+Combined with the dev-profile update, direct framework WASM builds improve to
+21.8% faster versus `origin/main`, while downstream-style fixture WASM builds
+land in the expected 40-70% range.
 
 The earlier experimental profile change (`line-tables-only`,
 `split-debuginfo = "unpacked"`, `codegen-units = 256`, explicit
 `incremental = true`) produced worse local numbers for this repository and was
-reverted. Keep the default `debug = 1` profile unless a future benchmark proves
-a different profile is faster across the target scenarios.
+reverted. The narrower dev profile (`debug = 0`, `codegen-units = 16`) is
+measured separately and improves server-only and app-side WASM build loops.
+The test profile keeps `debug = 1` so test debugging is not degraded.
 
 Static `page!(|| { ... })` edits now have a compile-free development path when
 the changed file is owned by the Pages client side (`src/client.rs`,
 `src/client/**`, or `src/apps/*/client/**`) and the parser can render the page
-body without dynamic Rust. That path reaches the original 80-98% pure
-`page!` edit target in the fixture run, measuring 99.8% faster than the legacy
-both-target rebuild shape. Dynamic Rust expressions, event handlers, control
-flow, components, and shared/server-owned files intentionally fall back to
-normal rebuilds, so the broader WASM-side Rust logic target remains unmet by
-this hot-patch path.
+body without dynamic Rust. The HMR payload replaces `#app` contents so the
+development HMR script and page shell stay mounted. That path reaches the
+original 80-98% pure `page!` edit target in the fixture run, measuring 99.4%
+faster than the legacy both-target rebuild shape. Dynamic Rust expressions,
+event handlers, control flow, components, and shared/server-owned files
+intentionally fall back to normal rebuilds, so the broader WASM-side Rust logic
+target remains unmet by this hot-patch path.

--- a/docs/build-perf/issue-5218-incremental-check-results.md
+++ b/docs/build-perf/issue-5218-incremental-check-results.md
@@ -3,13 +3,15 @@
 These measurements compare `origin/main` at
 `3016d326de63950ac553cd2246d02a0315bd7f06` with PR #5220 at the current
 branch after reverting the experimental dev/test profile tuning back to
-`debug = 1`.
+`debug = 1` and pruning Pages/WASM dependencies through workspace feature
+boundaries.
 
 Environment:
 
 - Host: macOS on `aarch64-apple-darwin`
 - Rust: `rustc 1.94.1 (e408947bf 2026-03-25)`
-- Tool: `hyperfine --warmup 1 --runs 2`
+- Tool: `hyperfine --warmup 1`; leaf/core scenarios used `--runs 2`, latest
+  Pages/WASM and server scenarios used `--runs 3`
 
 ## Results
 
@@ -19,9 +21,9 @@ Environment:
 |---|---:|---:|---:|
 | `incremental-leaf-check` | 0.389s | 0.512s | 31.4% slower |
 | `incremental-core-check` | 50.022s | 31.875s | 36.3% faster |
-| `incremental-pages-wasm-check` | 1.528s | 1.242s | 18.7% faster |
-| `incremental-pages-wasm-build` | 1.933s | 1.876s | 2.9% faster |
-| `incremental-server-build` | 0.947s | 0.905s | 4.4% faster |
+| `incremental-pages-wasm-check` | 1.528s | 1.181s | 22.7% faster |
+| `incremental-pages-wasm-build` | 1.933s | 1.819s | 5.9% faster |
+| `incremental-server-build` | 0.947s | 0.919s | 2.9% faster |
 
 Raw command shapes:
 
@@ -41,8 +43,8 @@ the PR branch targeted rebuild shape.
 
 | Scenario | Legacy both-target mean | Targeted mean | Change |
 |---|---:|---:|---:|
-| Pages client edit | 2.302s | 1.837s | 20.2% faster |
-| Server-only edit | 1.212s | 0.884s | 27.1% faster |
+| Pages client edit | 2.120s | 1.757s | 17.1% faster |
+| Server-only edit | 1.131s | 0.858s | 24.2% faster |
 
 Raw command shapes:
 
@@ -59,12 +61,19 @@ The shared/core edit loop currently lands inside the expected 30-60% reduction
 range. The leaf package check does not: it is slower in this local run, so PR
 #5220 must not claim a universal incremental-check improvement.
 
-The targeted server-only hot-reload work shape is close to, but still below,
-the expected 30-60% reduction range in the latest local run. The targeted
+The targeted server-only hot-reload work shape is below the expected 30-60%
+reduction range in the latest local run. The targeted
 Pages/WASM client-edit work shape does not land in the expected 40-70% range:
-it improves by 20.2%. Direct WASM build improves only 2.9%, so further work
+it improves by 17.1%. Direct WASM build improves only 5.9%, so further work
 must reduce the WASM build/bindgen path itself rather than only skipping
 unrelated native server work.
+
+The latest Pages/WASM dependency pruning keeps internal Reinhardt dependencies
+on `workspace = true` and moves `reinhardt-core`'s heavy image validator and
+documentation diagrams behind explicit features. This removes `image`,
+`ravif`, `tiff`, `exr`, and `aquamarine` from the Pages/WASM normal dependency
+tree, but the warmed incremental build loop is still dominated by recompiling
+the WASM crate artifact.
 
 The earlier experimental profile change (`line-tables-only`,
 `split-debuginfo = "unpacked"`, `codegen-units = 256`, explicit

--- a/docs/build-perf/issue-5218-incremental-check-results.md
+++ b/docs/build-perf/issue-5218-incremental-check-results.md
@@ -13,16 +13,44 @@ Environment:
 
 ## Results
 
+### Direct Cargo Loops
+
 | Scenario | `origin/main` mean | PR branch mean | Change |
 |---|---:|---:|---:|
 | `incremental-leaf-check` | 0.389s | 0.512s | 31.4% slower |
 | `incremental-core-check` | 50.022s | 31.875s | 36.3% faster |
+| `incremental-pages-wasm-check` | 1.528s | 1.354s | 11.4% faster |
+| `incremental-pages-wasm-build` | 1.933s | 2.032s | 5.1% slower |
+| `incremental-server-build` | 0.947s | 1.035s | 9.3% slower |
 
 Raw command shapes:
 
 ```bash
 touch crates/reinhardt-throttling/src/lib.rs && cargo check -p reinhardt-throttling
 touch crates/reinhardt-core/src/lib.rs && cargo check --workspace
+touch crates/reinhardt-pages/src/component.rs && cargo check -p reinhardt-pages --target wasm32-unknown-unknown --features pages-full
+touch crates/reinhardt-pages/src/component.rs && cargo build -p reinhardt-pages --target wasm32-unknown-unknown --features pages-full
+touch crates/reinhardt-server/src/server.rs && cargo build -p reinhardt-server
+```
+
+### Hot-Reload Target Selection Loops
+
+These measurements compare the legacy hot-reload work shape, where a
+target-specific edit still paid for both WASM and native server builds, against
+the PR branch targeted rebuild shape.
+
+| Scenario | Legacy both-target mean | Targeted mean | Change |
+|---|---:|---:|---:|
+| Pages client edit | 2.402s | 1.863s | 22.4% faster |
+| Server-only edit | 1.253s | 0.854s | 31.9% faster |
+
+Raw command shapes:
+
+```bash
+touch crates/reinhardt-pages/src/component.rs && cargo build -p reinhardt-pages --target wasm32-unknown-unknown --features pages-full && cargo build -p reinhardt-server
+touch crates/reinhardt-pages/src/component.rs && cargo build -p reinhardt-pages --target wasm32-unknown-unknown --features pages-full
+touch crates/reinhardt-server/src/server.rs && cargo build -p reinhardt-server && cargo build -p reinhardt-pages --target wasm32-unknown-unknown --features pages-full
+touch crates/reinhardt-server/src/server.rs && cargo build -p reinhardt-server
 ```
 
 ## Interpretation
@@ -30,6 +58,12 @@ touch crates/reinhardt-core/src/lib.rs && cargo check --workspace
 The shared/core edit loop currently lands inside the expected 30-60% reduction
 range. The leaf package check does not: it is slower in this local run, so PR
 #5220 must not claim a universal incremental-check improvement.
+
+The targeted server-only hot-reload work shape lands just inside the expected
+30-60% reduction range. The targeted Pages/WASM client-edit work shape does
+not: it improves by 22.4%, below the expected 40-70% range. Direct WASM build
+also did not improve, so further work must reduce the WASM build/bindgen path
+itself rather than only skipping unrelated native server work.
 
 The earlier experimental profile change (`line-tables-only`,
 `split-debuginfo = "unpacked"`, `codegen-units = 256`, explicit

--- a/docs/build-perf/issue-5218-incremental-check-results.md
+++ b/docs/build-perf/issue-5218-incremental-check-results.md
@@ -1,0 +1,42 @@
+# Issue #5218 Incremental Check Measurements
+
+These measurements compare `origin/main` at
+`3016d326de63950ac553cd2246d02a0315bd7f06` with PR #5220 at the current
+branch after reverting the experimental dev/test profile tuning back to
+`debug = 1`.
+
+Environment:
+
+- Host: macOS on `aarch64-apple-darwin`
+- Rust: `rustc 1.94.1 (e408947bf 2026-03-25)`
+- Tool: `hyperfine --warmup 1 --runs 2`
+
+## Results
+
+| Scenario | `origin/main` mean | PR branch mean | Change |
+|---|---:|---:|---:|
+| `incremental-leaf-check` | 0.389s | 0.512s | 31.4% slower |
+| `incremental-core-check` | 50.022s | 31.875s | 36.3% faster |
+
+Raw command shapes:
+
+```bash
+touch crates/reinhardt-throttling/src/lib.rs && cargo check -p reinhardt-throttling
+touch crates/reinhardt-core/src/lib.rs && cargo check --workspace
+```
+
+## Interpretation
+
+The shared/core edit loop currently lands inside the expected 30-60% reduction
+range. The leaf package check does not: it is slower in this local run, so PR
+#5220 must not claim a universal incremental-check improvement.
+
+The earlier experimental profile change (`line-tables-only`,
+`split-debuginfo = "unpacked"`, `codegen-units = 256`, explicit
+`incremental = true`) produced worse local numbers for this repository and was
+reverted. Keep the default `debug = 1` profile unless a future benchmark proves
+a different profile is faster across the target scenarios.
+
+These measurements do not prove compile-free `page!` editing. Inline `page!`
+macro edits still compile as Rust; compile-free template edits require a
+separate dev-mode runtime/template architecture.

--- a/docs/build-perf/issue-5218-incremental-check-results.md
+++ b/docs/build-perf/issue-5218-incremental-check-results.md
@@ -14,9 +14,22 @@ Environment:
 - Tool: `hyperfine`; leaf/core scenarios used `--warmup 1 --runs 2`, latest
   Pages/WASM and server scenarios used `--warmup 2` with 5-8 runs; static
   `page!` hot-patch fixture scenarios used `--warmup 3 --runs 12` initially
-  and `--warmup 2 --runs 8` after the dev-profile update
+  and `--warmup 2 --runs 8` after the dev-profile update; cold standard
+  workspace builds used `/usr/bin/time -p` with one clean run per branch
 
 ## Results
+
+### Cold Workspace Builds
+
+| Scenario | `origin/main` wall time | PR branch wall time | Change |
+|---|---:|---:|---:|
+| `cold-build-standard` | 283.30s | 234.83s | 17.1% faster |
+
+Raw command shape:
+
+```bash
+cargo clean && cargo build --workspace
+```
 
 ### Direct Cargo Loops
 
@@ -84,6 +97,10 @@ The shared/core edit loop lands inside the expected 30-60% reduction range.
 The leaf package check does not: it is slower in this local run, so PR #5220
 must not claim a universal incremental-check improvement.
 
+The cold standard workspace build improves by 17.1%. That is a real reduction,
+but it is below the original 25-40% cold build/check target, so the cold target
+should remain tracked separately from this hot-reload-focused PR.
+
 The targeted server-only hot-reload work shape now reaches the lower end of
 the expected 30-60% range. The app-side fixture WASM build improves from the
 pre-profile 1.725-1.739s range to 0.564s, which lands in the expected 40-70%
@@ -92,11 +109,12 @@ WASM-side Rust range for downstream-style app code. Direct framework
 still below the broader Pages/WASM target.
 
 The latest Pages/WASM dependency pruning keeps internal Reinhardt dependencies
-on `workspace = true` and moves `reinhardt-core`'s heavy image validator and
-documentation diagrams behind explicit features. This removes `image`,
-`ravif`, `tiff`, `exr`, and `aquamarine` from the Pages/WASM normal dependency
-tree, but the warmed incremental build loop is still dominated by recompiling
-the WASM crate artifact.
+on `workspace = true`, inherits `reqwest` through the workspace dependency
+table, and moves `reinhardt-core`'s heavy image validator and documentation
+diagrams behind explicit features. This removes `image`, `ravif`, `tiff`,
+`exr`, and `aquamarine` from the Pages/WASM normal dependency tree, but the
+warmed incremental build loop is still dominated by recompiling the WASM crate
+artifact.
 
 The latest Pages module gating keeps `testing` behind the existing `testing`
 feature/test cfg and compiles `SsrRenderer`/`SsrOptions` only on native targets.

--- a/docs/rfc/build-time-reduction-rfc.md
+++ b/docs/rfc/build-time-reduction-rfc.md
@@ -22,9 +22,14 @@ The Reinhardt workspace has grown to **40 crates**, with `reinhardt-core` alone 
 
 Build performance is also a public-facing concern: any project that depends on `reinhardt = "..."` inherits the framework's compile cost. Improvements to the framework's internal structure propagate to user projects automatically.
 
-A diagnostic pass on the current state surfaced several "free wins" that have not yet been claimed:
+A diagnostic pass on the current state surfaced several possible optimization
+areas. Not every configuration-looking change is a free win; local benchmark
+results must decide:
 
-- `[profile.dev]` carries only `debug = 1`. No `codegen-units` tuning, no `split-debuginfo`, no `incremental` declaration.
+- `[profile.dev]` carries only `debug = 1`. An attempted
+  `line-tables-only` / `split-debuginfo` / `codegen-units = 256` profile
+  change was measured locally for Issue #5218 and rejected because it worsened
+  the target loops.
 - `.cargo/config.toml` has no linker configuration; macOS uses Apple `ld`, Ubuntu CI uses default `ld`.
 - `sccache` is configured globally in `~/.cargo/config.toml`, but **its Rust cache hit rate is 0.32 %** (1 hit out of 310 cacheable Rust compile requests, plus an additional 409 invocations marked `non-cacheable due to: incremental` that bypass the cache entirely). It is effectively unused.
 - 10 proc-macro crates exist; their generated-code sizes have not been audited.
@@ -61,7 +66,9 @@ Targets are placeholders; they are recalibrated against the actual Phase 0 basel
 ### 2.4 Top risks
 
 1. macOS `lld` switch breaks proc-macro / dylib linking. Mitigation: gate behind a spike PR with a measure-then-decide criterion; default remains Apple `ld`.
-2. `codegen-units = 256` triggers a latent optimizer-related bug. Mitigation: full `cargo test --workspace --all-features` after the change.
+2. Profile tuning can regress the measured loops even when it looks like a
+   generic Cargo best practice. Mitigation: keep `debug = 1` unless a future
+   benchmark proves the alternative across the target scenarios.
 3. sccache strategy revision invalidates existing CI caches. Mitigation: rotate cache key once, document the regeneration cost.
 
 ## 3. Considered approaches
@@ -125,19 +132,19 @@ All Phase A items are configuration changes. None modify Rust source code. Each 
 
 ```toml
 [profile.dev]
-debug = "line-tables-only"
-split-debuginfo = "unpacked"
-codegen-units = 256
-incremental = true
+debug = 1
 
 [profile.test]
-debug = "line-tables-only"
-split-debuginfo = "unpacked"
-codegen-units = 256
-incremental = true
+debug = 1
 ```
 
-Rationale: 256 codegen-units enables maximum parallel codegen of the leaf crate being edited. `line-tables-only` keeps panic backtraces useful while shrinking debuginfo. `split-debuginfo = "unpacked"` is the macOS default, made explicit; on Linux CI it reduces final-link work.
+Verdict: rejected for the current repository state. Issue #5218 measured the
+experimental profile (`line-tables-only`, `split-debuginfo = "unpacked"`,
+`codegen-units = 256`, explicit `incremental = true`) against `origin/main`
+with `hyperfine --warmup 1 --runs 2`. The branch became slower on the measured
+incremental loops before the profile was reverted. Keep `debug = 1` unless a
+future benchmark proves a different profile is faster across the target
+scenarios.
 
 #### A-2: Optimize dependencies in dev profile
 
@@ -204,7 +211,7 @@ This caches `target/` and `~/.cargo/{registry,git}` separately from sccache (whi
 
 | PR | Branch | Scope | Depends on |
 |---|---|---|---|
-| PR-A1 | `feature/issue-XXXX-profile-dev-tuning` | A-1 | Phase 0 complete |
+| PR-A1 | `feature/issue-XXXX-profile-dev-recheck` | A-1 recheck only | New benchmark evidence, not assumed |
 | PR-A2 | `feature/issue-XXXX-deps-opt-level` | A-2 | PR-A1 |
 | PR-A3a | `feature/issue-XXXX-linker-mold-ci` | A-3a | Phase 0 complete |
 | PR-A3b | `feature/issue-XXXX-linker-lld-macos-spike` | A-3b | Phase 0 complete (parallel with A-3a) |
@@ -373,7 +380,7 @@ Decision criteria for entering Phase C will incorporate the actual numbers produ
 ```text
 Phase 0 (1 PR)              Phase A (6 PRs)                   Phase B (8 PRs)
 ─────────────              ─────────────────                  ─────────────────
-PR-0  baseline      ──┬──▶  PR-A1  profile-dev          ──▶  PR-B1a  monomorph-analysis
+PR-0  baseline      ──┬──▶  PR-A1  profile-dev-recheck  ──▶  PR-B1a  monomorph-analysis
                       │      PR-A2  deps-opt-level             PR-B1b  monomorph-reduction
                       │      PR-A3a linker-mold-ci             PR-B2a  macro-expand-analysis
                       │      PR-A3b linker-lld-spike (║)       PR-B2b  thin-macro
@@ -398,7 +405,7 @@ PR-0  baseline      ──┬──▶  PR-A1  profile-dev          ──▶  P
 |---|---|---|
 | Parent | `epic: build time reduction (Phase 0/A/B)` | `enhancement`, `performance`, `high` |
 | #0 | `Phase 0: build performance measurement infrastructure` | `enhancement`, `ci-cd` |
-| #A-1 | `Phase A-1: tune [profile.dev] for codegen-units / debuginfo` | `enhancement`, `performance` |
+| #A-1 | `Phase A-1: recheck [profile.dev] alternatives before changing defaults` | `enhancement`, `performance` |
 | #A-2 | `Phase A-2: opt-level=1 for dev-profile dependencies` | `enhancement`, `performance` |
 | #A-3a | `Phase A-3a: switch CI linker to mold (Ubuntu)` | `enhancement`, `ci-cd`, `performance` |
 | #A-3b | `Phase A-3b: spike LLD linker on macOS Apple Silicon` | `enhancement`, `performance` |

--- a/instructions/BUILD_PERFORMANCE.md
+++ b/instructions/BUILD_PERFORMANCE.md
@@ -19,6 +19,10 @@ successful builds, or isolated code review alone.
    can invalidate a much larger part of the dependency graph than leaf edits.
 5. For Pages hot-reload work, verify browser-visible behavior with runtime
    evidence. A successful compile or HTTP 200 response is not enough.
+6. Do not count `page!` edits as compile-free unless a separate dev-mode
+   template/runtime path bypasses Rust macro recompilation. HMR reload
+   notifications only reduce browser reflection delay after successful
+   rebuilds.
 
 ## Prevention Guidelines
 
@@ -30,3 +34,5 @@ successful builds, or isolated code review alone.
   the shared hot path.
 - Keep server-only, WASM-only, and pure UI/template hot-reload paths separate
   so unrelated targets are not rebuilt.
+- Keep browser reload notifications success-gated: failed rebuilds should not
+  force browsers to reload into stale or missing artifacts.

--- a/instructions/BUILD_PERFORMANCE.md
+++ b/instructions/BUILD_PERFORMANCE.md
@@ -1,0 +1,32 @@
+# Build Performance
+
+## Purpose
+
+Build-performance work must be measured before and after each optimization.
+Do not claim compile-time or hot-reload latency improvements from intuition,
+successful builds, or isolated code review alone.
+
+## Measurement Rules
+
+1. Use `scripts/bench-build.sh` or `cargo make bench-builds` for standard
+   workspace measurements.
+2. Record the generated JSON report and adjacent `.env.txt` file when a PR
+   claims a performance improvement.
+3. Keep local development incremental-friendly: prefer Cargo incremental
+   compilation over a local Rust `sccache` wrapper unless a measured setup
+   proves otherwise.
+4. Treat proc-macro and shared-crate edits as separate scenarios because they
+   can invalidate a much larger part of the dependency graph than leaf edits.
+5. For Pages hot-reload work, verify browser-visible behavior with runtime
+   evidence. A successful compile or HTTP 200 response is not enough.
+
+## Prevention Guidelines
+
+- Keep proc-macro output thin; emit metadata and delegate repeated logic to
+  runtime helper functions where public API compatibility allows it.
+- Avoid large generic function bodies when a small generic shim can delegate to
+  a non-generic inner function.
+- Avoid adding dependencies to shared crates unless the dependency is needed on
+  the shared hot path.
+- Keep server-only, WASM-only, and pure UI/template hot-reload paths separate
+  so unrelated targets are not rebuilt.

--- a/scripts/bench-build.sh
+++ b/scripts/bench-build.sh
@@ -26,6 +26,8 @@ Scenarios:
 
 The script records reproducible build-loop timings for Reinhardt Pages and
 workspace build-performance work. It requires hyperfine unless --dry-run is set.
+Incremental scenarios assume a pre-built workspace; run a cold scenario first
+or ensure the matching cargo build/check command has already succeeded.
 USAGE
 }
 

--- a/scripts/bench-build.sh
+++ b/scripts/bench-build.sh
@@ -84,6 +84,9 @@ if [ "${#requested[@]}" -eq 0 ]; then
     incremental-page-macro-check
     incremental-pages-wasm-check
     incremental-pages-wasm-build
+    incremental-pages-fixture-wasm-build
+    incremental-pages-fixture-hot-patch
+    incremental-pages-fixture-hot-reload-legacy-both-build
     incremental-server-build
     incremental-hot-reload-client-legacy-both-build
     incremental-hot-reload-server-legacy-both-build
@@ -124,6 +127,15 @@ scenario_command() {
       ;;
     incremental-pages-wasm-build)
       printf '%s\n' 'touch crates/reinhardt-pages/src/component.rs && cargo build -p reinhardt-pages --target wasm32-unknown-unknown --features pages-full'
+      ;;
+    incremental-pages-fixture-wasm-build)
+      printf '%s\n' 'touch crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs && cargo build --manifest-path crates/reinhardt-pages/tests/fixtures/spa_navigation_app/Cargo.toml --target wasm32-unknown-unknown'
+      ;;
+    incremental-pages-fixture-hot-patch)
+      printf '%s\n' 'test -x ./target/debug/examples/page_hot_patch_probe || cargo build -q -p reinhardt-commands --features pages,autoreload --example page_hot_patch_probe; touch crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs && ./target/debug/examples/page_hot_patch_probe crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs >/dev/null'
+      ;;
+    incremental-pages-fixture-hot-reload-legacy-both-build)
+      printf '%s\n' 'touch crates/reinhardt-pages/tests/fixtures/spa_navigation_app/src/client.rs && cargo build --manifest-path crates/reinhardt-pages/tests/fixtures/spa_navigation_app/Cargo.toml --target wasm32-unknown-unknown && cargo build -p reinhardt-server'
       ;;
     incremental-server-build)
       printf '%s\n' 'touch crates/reinhardt-server/src/server.rs && cargo build -p reinhardt-server'

--- a/scripts/bench-build.sh
+++ b/scripts/bench-build.sh
@@ -16,6 +16,9 @@ Scenarios:
   incremental-page-macro-check
   incremental-pages-wasm-check
   incremental-pages-wasm-build
+  incremental-pages-fixture-wasm-build
+  incremental-pages-fixture-hot-patch
+  incremental-pages-fixture-hot-reload-legacy-both-build
   incremental-server-build
   incremental-hot-reload-client-legacy-both-build
   incremental-hot-reload-server-legacy-both-build

--- a/scripts/bench-build.sh
+++ b/scripts/bench-build.sh
@@ -17,6 +17,8 @@ Scenarios:
   incremental-pages-wasm-check
   incremental-pages-wasm-build
   incremental-server-build
+  incremental-hot-reload-client-legacy-both-build
+  incremental-hot-reload-server-legacy-both-build
   incremental-leaf-build
 
 The script records reproducible build-loop timings for Reinhardt Pages and
@@ -83,6 +85,8 @@ if [ "${#requested[@]}" -eq 0 ]; then
     incremental-pages-wasm-check
     incremental-pages-wasm-build
     incremental-server-build
+    incremental-hot-reload-client-legacy-both-build
+    incremental-hot-reload-server-legacy-both-build
     incremental-leaf-build
   )
 fi
@@ -123,6 +127,12 @@ scenario_command() {
       ;;
     incremental-server-build)
       printf '%s\n' 'touch crates/reinhardt-server/src/server.rs && cargo build -p reinhardt-server'
+      ;;
+    incremental-hot-reload-client-legacy-both-build)
+      printf '%s\n' 'touch crates/reinhardt-pages/src/component.rs && cargo build -p reinhardt-pages --target wasm32-unknown-unknown --features pages-full && cargo build -p reinhardt-server'
+      ;;
+    incremental-hot-reload-server-legacy-both-build)
+      printf '%s\n' 'touch crates/reinhardt-server/src/server.rs && cargo build -p reinhardt-server && cargo build -p reinhardt-pages --target wasm32-unknown-unknown --features pages-full'
       ;;
     incremental-leaf-build)
       printf '%s\n' 'touch crates/reinhardt-throttling/src/lib.rs && cargo build -p reinhardt-throttling'

--- a/scripts/bench-build.sh
+++ b/scripts/bench-build.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/bench-build.sh [--dry-run] [--runs N] [--warmup N] [--output PATH] [SCENARIO...]
+
+Scenarios:
+  cold-check-all-features
+  cold-build-standard
+  cold-test-build
+  incremental-leaf-check
+  incremental-core-check
+  incremental-db-macro-check
+  incremental-page-macro-check
+  incremental-leaf-build
+
+The script records reproducible build-loop timings for Reinhardt Pages and
+workspace build-performance work. It requires hyperfine unless --dry-run is set.
+USAGE
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+runs=3
+warmup=1
+dry_run=0
+output=""
+declare -a requested=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --runs)
+      runs="${2:?--runs requires a value}"
+      shift 2
+      ;;
+    --warmup)
+      warmup="${2:?--warmup requires a value}"
+      shift 2
+      ;;
+    --output)
+      output="${2:?--output requires a value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      requested+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "${#requested[@]}" -eq 0 ]; then
+  requested=(
+    cold-check-all-features
+    cold-build-standard
+    cold-test-build
+    incremental-leaf-check
+    incremental-core-check
+    incremental-db-macro-check
+    incremental-page-macro-check
+    incremental-leaf-build
+  )
+fi
+
+if [ -z "$output" ]; then
+  stamp="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+  output="docs/build-perf/baseline-${stamp}.json"
+fi
+
+scenario_command() {
+  case "$1" in
+    cold-check-all-features)
+      printf '%s\n' 'cargo clean && cargo check --workspace --all-features'
+      ;;
+    cold-build-standard)
+      printf '%s\n' 'cargo clean && cargo build --workspace'
+      ;;
+    cold-test-build)
+      printf '%s\n' 'cargo clean && cargo nextest run --workspace --all-features --no-run'
+      ;;
+    incremental-leaf-check)
+      printf '%s\n' 'touch crates/reinhardt-throttling/src/lib.rs && cargo check -p reinhardt-throttling'
+      ;;
+    incremental-core-check)
+      printf '%s\n' 'touch crates/reinhardt-core/src/lib.rs && cargo check --workspace'
+      ;;
+    incremental-db-macro-check)
+      printf '%s\n' 'touch crates/reinhardt-db-macros/src/lib.rs && cargo check --workspace'
+      ;;
+    incremental-page-macro-check)
+      printf '%s\n' 'touch crates/reinhardt-pages/macros/src/lib.rs && cargo check --workspace'
+      ;;
+    incremental-leaf-build)
+      printf '%s\n' 'touch crates/reinhardt-throttling/src/lib.rs && cargo build -p reinhardt-throttling'
+      ;;
+    *)
+      echo "unknown scenario: $1" >&2
+      exit 2
+      ;;
+  esac
+}
+
+declare -a hyperfine_args=()
+for scenario in "${requested[@]}"; do
+  command="$(scenario_command "$scenario")"
+  if [ "$dry_run" -eq 1 ]; then
+    printf '%s: %s\n' "$scenario" "$command"
+  else
+    hyperfine_args+=(--command-name "$scenario" "$command")
+  fi
+done
+
+if [ "$dry_run" -eq 1 ]; then
+  exit 0
+fi
+
+if ! command -v hyperfine >/dev/null 2>&1; then
+  echo "hyperfine is required. Install it before collecting build benchmarks." >&2
+  exit 127
+fi
+
+mkdir -p "$(dirname "$output")"
+hyperfine --warmup "$warmup" --runs "$runs" --export-json "$output" "${hyperfine_args[@]}"
+
+{
+  printf 'rustc: %s\n' "$(rustc --version)"
+  printf 'cargo: %s\n' "$(cargo --version)"
+  printf 'host: %s\n' "$(uname -a)"
+  printf 'CARGO_INCREMENTAL: %s\n' "${CARGO_INCREMENTAL:-<unset>}"
+  printf 'RUSTC_WRAPPER: %s\n' "${RUSTC_WRAPPER:-<unset>}"
+} > "${output%.json}.env.txt"
+
+echo "Wrote $output"

--- a/scripts/bench-build.sh
+++ b/scripts/bench-build.sh
@@ -14,6 +14,9 @@ Scenarios:
   incremental-core-check
   incremental-db-macro-check
   incremental-page-macro-check
+  incremental-pages-wasm-check
+  incremental-pages-wasm-build
+  incremental-server-build
   incremental-leaf-build
 
 The script records reproducible build-loop timings for Reinhardt Pages and
@@ -77,6 +80,9 @@ if [ "${#requested[@]}" -eq 0 ]; then
     incremental-core-check
     incremental-db-macro-check
     incremental-page-macro-check
+    incremental-pages-wasm-check
+    incremental-pages-wasm-build
+    incremental-server-build
     incremental-leaf-build
   )
 fi
@@ -108,6 +114,15 @@ scenario_command() {
       ;;
     incremental-page-macro-check)
       printf '%s\n' 'touch crates/reinhardt-pages/macros/src/lib.rs && cargo check --workspace'
+      ;;
+    incremental-pages-wasm-check)
+      printf '%s\n' 'touch crates/reinhardt-pages/src/component.rs && cargo check -p reinhardt-pages --target wasm32-unknown-unknown --features pages-full'
+      ;;
+    incremental-pages-wasm-build)
+      printf '%s\n' 'touch crates/reinhardt-pages/src/component.rs && cargo build -p reinhardt-pages --target wasm32-unknown-unknown --features pages-full'
+      ;;
+    incremental-server-build)
+      printf '%s\n' 'touch crates/reinhardt-server/src/server.rs && cargo build -p reinhardt-server'
       ;;
     incremental-leaf-build)
       printf '%s\n' 'touch crates/reinhardt-throttling/src/lib.rs && cargo build -p reinhardt-throttling'


### PR DESCRIPTION
## Summary

This PR addresses:

- Backports the PR #5220 hot-reload latency improvements onto `develop/0.2.0`.
- Adds build-loop benchmark coverage for Pages WASM, native server, hot-reload target selection, and static page hot patch scenarios.
- Adds hot-reload target selection so client-only Pages edits can skip native server rebuilds and server-only edits can skip WASM rebuilds.
- Adds success-gated Pages HMR reload notification and static `page!(|| { ... })` hot patch support.
- Carries over CodeRabbit review fixes from PR #5220, including safe body tag lookup, safe selector handling, exact JSON assertions, and `reinhardt-test` feature wiring.
- Adapts the hot-reload tests to the `develop/0.2.0` `WatcherConfig` and fixture APIs.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [x] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Issue #5218 targets shorter hot-reload and build feedback loops. This PR applies the same implementation as PR #5220 to the `develop/0.2.0` release branch so the release line can receive the hot-reload improvements.

Refs #5218

Related to: #5218, #5220

## How Was This Tested?

- `bash -n scripts/bench-build.sh`
- `cargo metadata --no-deps --format-version 1`
- `cargo test -p reinhardt-utils test_inject_wasm_script_unicode_before_uppercase_body`
- `cargo test -p reinhardt-commands --features pages rejects_multiple_static_page_macros`
- `cargo test -p reinhardt-pages --features hmr test_html_replace_serialization`
- `cargo test -p reinhardt-pages --features hmr test_hmr_client_script_has_html_replace`
- `cargo check -p reinhardt-test --features server-fn-test`
- `cargo check -p reinhardt-test --target wasm32-unknown-unknown --features wasm`
- `cargo make fmt-check`

## Performance Impact

This backport carries the same performance-focused changes as PR #5220: target-specific hot-reload rebuild selection, static Pages hot patching for supported `page!` edits, reduced Pages macro output for attribute-heavy templates, and a trimmed Pages/WASM dependency graph.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #5218
- Related to #5220

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [x] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This PR was created as a `develop/0.2.0` counterpart to PR #5220.

Generated with Codex