### PR TITLE
test(ci): refresh release CI expectations

### DIFF
--- a/crates/reinhardt-commands/tests/runserver_hot_reload.rs
+++ b/crates/reinhardt-commands/tests/runserver_hot_reload.rs
@@ -723,17 +723,21 @@ async fn hr_9_run_watcher_broadcasts_reload_after_server_rebuild() {
 	// Arrange: fixture + initial server child + cwd switched so cargo
 	// resolves the fixture's manifest. Mirrors `run_server_pipeline`.
 	let fixture = Fixture::new("hr9_fixture", 900);
-	let initial_child = spawn_long_running_child(&fixture).await;
+	let addr = reserve_loopback_addr();
+	let initial_child = spawn_listening_child(&fixture, &addr).await;
+	assert_addr_reachable(&addr).await;
 	let saved_cwd = std::env::current_dir().expect("current dir");
 	std::env::set_current_dir(fixture.path()).expect("set fixture cwd");
 
 	let bin_path = fixture.manage_bin();
 	let respawn_count = Arc::new(AtomicUsize::new(0));
 	let respawn_count_for_closure = Arc::clone(&respawn_count);
+	let respawn_addr = addr.clone();
 	let respawn = move || -> std::io::Result<tokio::process::Child> {
 		respawn_count_for_closure.fetch_add(1, Ordering::SeqCst);
 		tokio::process::Command::new(&bin_path)
 			.kill_on_drop(true)
+			.env("HOT_RELOAD_LISTEN_ADDR", &respawn_addr)
 			.spawn()
 	};
 
@@ -741,13 +745,13 @@ async fn hr_9_run_watcher_broadcasts_reload_after_server_rebuild() {
 	let ctx = CommandContext::default();
 	let config = WatcherConfig {
 		bin_name: "manage".to_string(),
-		address: "127.0.0.1:0".to_string(),
+		address: addr.clone(),
 		roots: SourceRoots {
 			src_dirs: vec![fixture.path().join("src")],
 			manifest_files: vec![fixture.path().join("Cargo.toml")],
 			lockfile: None,
 		},
-		server_address: None,
+		server_address: Some(addr),
 		no_wasm_rebuild: true,
 		pages_enabled: true,
 		hmr_tx: Some(hmr_tx),

--- a/crates/reinhardt-pages/macros/src/page/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/page/codegen.rs
@@ -946,7 +946,7 @@ mod tests {
 		let output_str = output.to_string();
 
 		// TokenStream stringification adds spaces between tokens
-		assert!(output_str.contains(". attr"));
+		assert!(output_str.contains(". with_attrs"));
 		assert!(output_str.contains("\"class\""));
 		assert!(output_str.contains("\"container\""));
 	}


### PR DESCRIPTION
## Summary

This PR addresses:

- Updates the Pages macro attr codegen unit assertion to match the current `.with_attrs(...)` output.
- Makes the hot-reload HMR broadcast test use an actual reserved loopback listener address instead of probing `127.0.0.1:0`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

PR #5223 failed the release CI unit and intra-crate test shards. The failures were stale test expectations, not generated release-branch code that should be edited directly.

Fixes: N/A

Related to: #5223

## How Was This Tested?

- `cargo test -p reinhardt-pages-macros page::codegen::tests::test_generate_element_with_attr`
- `cargo test -p reinhardt-commands --test runserver_hot_reload hr_9_run_watcher_broadcasts_reload_after_server_rebuild --features server,autoreload,pages`
- `cargo fmt --all -- --check`

## Performance Impact

N/A

## Breaking Changes

N/A

## Screenshots

N/A

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to release PR #5223

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Generated release branches are disposable; this fix targets `develop/0.2.0` so release-plz can regenerate a clean release PR.
