### PR TITLE
fix(ci): generalize release dry-run false positive handling

### DIFF
--- a/.github/workflows/release-plz-dry-run.yml
+++ b/.github/workflows/release-plz-dry-run.yml
@@ -105,10 +105,25 @@ jobs:
           #
           # Ideal implementation (without workaround):
           #   release-plz release --dry-run --no-verify --git-token "$GITHUB_TOKEN"
-          if grep -Fq 'reinhardt-grpc-macros 0.1.3: due to dry, skipping' "$log" \
-            && grep -Fq 'failed to publish reinhardt-grpc' "$log" \
-            && grep -Fq 'failed to select a version for the requirement `reinhardt-grpc-macros = "^0.1.3"`' "$log"
-          then
+          declare -A dry_skipped_crates=()
+          while IFS= read -r line; do
+            if [[ "$line" =~ ^(reinhardt-[A-Za-z0-9_-]+)[[:space:]]+([^:[:space:]]+):[[:space:]]+due[[:space:]]+to[[:space:]]+dry,[[:space:]]+skipping ]]; then
+              dry_skipped_crates["${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"]=1
+            fi
+          done < "$log"
+
+          known_same_release_dependency_failure=false
+          while IFS= read -r requirement; do
+            if [[ "$requirement" =~ ^(reinhardt-[A-Za-z0-9_-]+)[[:space:]]*=[[:space:]]*\"\^?([^\"]+)\"$ ]] \
+              && [[ -n "${dry_skipped_crates["${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"]+set}" ]]
+            then
+              known_same_release_dependency_failure=true
+              echo "::warning::release-plz dry-run skipped ${BASH_REMATCH[1]} ${BASH_REMATCH[2]} and later failed to resolve that same-release workspace dependency."
+              break
+            fi
+          done < <(sed -nE 's/.*failed to select a version for the requirement `([^`]+)`.*/\1/p' "$log")
+
+          if [[ "$known_same_release_dependency_failure" == "true" ]]; then
             echo "::warning::Ignoring known release-plz dry-run same-release dependency false positive (release-plz/release-plz#2878, reinhardt-web#5089)."
             exit 0
           fi

--- a/instructions/RELEASE_PROCESS.md
+++ b/instructions/RELEASE_PROCESS.md
@@ -431,6 +431,7 @@ flowchart TD
     B -->|Partial failure| E["RP-1: Identify published/unpublished<br/>rollback unpublished versions<br/>new Release PR and merge"]
     B -->|gix cache panic| F["RP-3: Re-run release-plz<br/>(transient error)"]
     B -->|Phantom version bump| G["KI-5: Set release_always = true"]
+    B -->|Dry-run same-release dep false positive| H["KI-7: release-plz dry-run<br/>workspace dependency limitation"]
 ```
 
 ### KI-1: Circular Publish Dependencies
@@ -549,6 +550,25 @@ exceeds the burst limit, resulting in HTTP 429 errors.
 - Alternatively, increase the delay or add more retry rounds
 
 **Reference**: `<https://github.com/rust-lang/crates.io/issues/1643>`
+
+### KI-7: release-plz Dry-Run Same-Release Dependency Limitation
+
+**Status**: Mitigated in CI; upstream issue remains open.
+
+**Problem**: `release-plz release --dry-run` can fail when a workspace crate
+depends on another workspace crate at the same not-yet-published version. In a
+real release, release-plz publishes the dependency first. During dry-run, that
+upload is skipped, so the dependent crate may still resolve the version from
+crates.io and fail.
+
+**Mitigation**: `release-plz-dry-run.yml` treats this specific upstream false
+positive as a warning only when the log shows both:
+- a Reinhardt workspace crate skipped because of dry-run mode
+- a later failed requirement for the same skipped crate and version
+
+All other release-plz dry-run failures remain hard CI failures.
+
+**Tracking**: [release-plz#2878](https://github.com/release-plz/release-plz/issues/2878), [reinhardt-web#5089](https://github.com/kent8192/reinhardt-web/issues/5089)
 
 ---
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Generalizes the release-plz dry-run false-positive detector from a hard-coded crate/version to log-derived same-release workspace dependency matching.
- Documents the known upstream release-plz dry-run limitation and CI mitigation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

`release-plz release --dry-run` can skip uploading a workspace crate because of dry-run mode, then fail when a dependent workspace crate tries to resolve that same version from crates.io. The existing mitigation only matched one fixed crate/version, so the same upstream false positive could recur on the next release pair.

Refs #5089
Related to: release-plz/release-plz#2878

## How Was This Tested?

- Sample bash classifier accepted the known false-positive shape and rejected an unrelated `serde` resolution failure.
- `actionlint -shellcheck= .github/workflows/release-plz-dry-run.yml`
- YAML parse for `.github/workflows/release-plz-dry-run.yml` and `.github/workflows/ci.yml`
- `git diff --check`
- Extracted workflow `run:` block passed `shellcheck -S warning -s bash`

## Performance Impact

Not performance-related.

## Breaking Changes

None.

## Screenshots

Not UI-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #5089
- release-plz/release-plz#2878

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The workflow still hard-fails release-plz dry-run errors unless the missing requirement exactly matches a Reinhardt workspace crate/version that release-plz already logged as skipped because of dry-run mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to better detect and handle same-release workspace dependency failures during dry-run builds, improving release process reliability.

* **Documentation**
  * Added known issues & pitfalls section to release process documentation, including troubleshooting guidance for dry-run dependency resolution edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->