### PR TITLE
docs(conf): document embedded settings nodes

### DIFF
--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -237,6 +237,48 @@ exists. A missing nested required leaf reports
 `BuildError::MissingRequiredPath` with the full schema path. A missing direct
 required field on the section still reports `BuildError::MissingRequiredField`.
 
+### Embedded-Only Settings Nodes
+
+Use `#[settings(fragment = true)]` without a `section = "..."` argument for a
+settings struct that should participate in schema metadata and validation below
+a root fragment, but should not become a top-level TOML section by itself.
+
+```rust,ignore
+#[settings(fragment = true, section = "database")]
+pub struct DatabaseSettings {
+    pub default: DatabaseConfig,
+    pub replica: Option<DatabaseConfig>,
+}
+
+#[settings(fragment = true, default_policy = "required")]
+pub struct DatabaseConfig {
+    pub engine: DatabaseEngine,
+    pub host: String,
+    pub port: u16,
+    pub name: String,
+    pub user: String,
+    pub password: SecretString,
+}
+```
+
+The corresponding TOML still nests the embedded node under the root fragment:
+
+```toml
+[database.default]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "app"
+user = "app"
+password = { env = "DATABASE_PASSWORD" }
+```
+
+A root fragment with `section = "..."` implements `SettingsFragment` and can be
+used in composed project settings. An embedded-only node implements
+`SettingsNode` for recursive schema and validation support, but does not
+implement `SettingsFragment`, expose `section()`, or register as a root
+composition section.
+
 ## Field Status
 
 The `Settings` struct contains fields that are either actively consumed by the framework or reserved for future implementation.


### PR DESCRIPTION
## Summary

This PR addresses:

- Documents section-less `#[settings(fragment = true)]` structs as embedded-only settings nodes.
- Clarifies the contract difference between root `SettingsFragment` sections and recursive `SettingsNode` schema support.
- Adds a database settings example matching the 0.2 embedded-node behavior implemented in PR #5182.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes nor adds functionality)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The embedded settings node implementation already landed in PR #5182, but the milestone issue was not linked by a `Fixes` reference. This PR adds the missing user-facing contract documentation and links the issue for automatic closure when merged.

Fixes #5176

Related to: #5182

## How Was This Tested?

- `rg -n "Embedded-Only Settings Nodes|SettingsNode|SettingsFragment|DATABASE_PASSWORD" crates/reinhardt-conf/README.md`
- Manual review against the current `SettingsNode` / `SettingsFragment` contract.

## Performance Impact

N/A

## Screenshots

N/A

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5176
- #5182

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [ ] `database`
- [ ] `auth`
- [ ] `orm`
- [ ] `http`
- [ ] `routing`
- [ ] `api`
- [ ] `admin`
- [ ] `forms`
- [ ] `graphql`
- [ ] `websockets`
- [ ] `i18n`
- [ ] `ci-cd`

### Priority Label (for maintainers)
- [ ] `critical`
- [ ] `high`
- [x] `medium`
- [ ] `low`

---

Generated with Codex
Co-Authored-By: Codex <noreply@openai.com>
