### PR TITLE
test(admin-cli): cover migrate manouche v2 command

### DIFF
--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(admin-cli)* keep `migrate-manouche-v2` idempotent for already wrapped page expression slots.
 - *(admin-cli)* preserve item attributes when `migrate-manouche-v2` rewrites attributed items.
 - *(admin-cli)* avoid treating control-flow syntax variables as page children in `migrate-manouche-v2`.
+- *(admin-cli)* keep `migrate-manouche-v2` from rewriting `match` patterns and `let` bindings as page children.
 
 ## [0.2.0-rc.2](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.3...reinhardt-admin-cli@v0.2.0-rc.2) - 2026-06-03
 

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(admin-cli)* keep `migrate-manouche-v2` idempotent for already wrapped page expression slots.
+
 ## [0.2.0-rc.2](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.3...reinhardt-admin-cli@v0.2.0-rc.2) - 2026-06-03
 
 ### Fixed

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(admin-cli)* preserve item attributes when `migrate-manouche-v2` rewrites attributed items.
 - *(admin-cli)* avoid treating control-flow syntax variables as page children in `migrate-manouche-v2`.
 - *(admin-cli)* keep `migrate-manouche-v2` from rewriting `match` patterns and `let` bindings as page children.
+- *(admin-cli)* preserve inner module docs and migrate element bodies inside `let` initializers in `migrate-manouche-v2`.
 
 ## [0.2.0-rc.2](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.3...reinhardt-admin-cli@v0.2.0-rc.2) - 2026-06-03
 

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - *(admin-cli)* keep `migrate-manouche-v2` idempotent for already wrapped page expression slots.
+- *(admin-cli)* preserve item attributes when `migrate-manouche-v2` rewrites attributed items.
+- *(admin-cli)* avoid treating control-flow syntax variables as page children in `migrate-manouche-v2`.
 
 ## [0.2.0-rc.2](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.3...reinhardt-admin-cli@v0.2.0-rc.2) - 2026-06-03
 

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -31,6 +31,7 @@ anyhow = { workspace = true }
 [dev-dependencies]
 tempfile = "3.8"
 rstest = { workspace = true }
+proptest = { workspace = true }
 walkdir = "2.5"
 
 [features]

--- a/crates/reinhardt-admin-cli/src/migrate_v2.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2.rs
@@ -185,10 +185,31 @@ fn find_item_in_source(src: &str, search_from: usize, item_tokens: &str) -> (usi
 		Some(pos) => search_from + pos,
 		None => return (search_from, search_from),
 	};
+	let start = find_item_start_with_prefix(src, search_from, start);
 
 	let after_start = &src[start..];
 	let end_offset = find_item_end_offset(after_start);
 	(start, start + end_offset)
+}
+
+fn find_item_start_with_prefix(src: &str, search_from: usize, item_start: usize) -> usize {
+	let mut start = line_start(src, item_start);
+	while start > search_from {
+		let previous_end = start.saturating_sub(1);
+		let previous_start = line_start(src, previous_end);
+		let line = &src[previous_start..start];
+		let trimmed = line.trim();
+		if trimmed.starts_with("#[") || trimmed.starts_with("///") || trimmed.starts_with("//!") {
+			start = previous_start;
+		} else {
+			break;
+		}
+	}
+	start
+}
+
+fn line_start(src: &str, pos: usize) -> usize {
+	src[..pos].rfind('\n').map_or(0, |idx| idx + 1)
 }
 
 /// Find the byte offset past the end of an item starting at `src[0]`.

--- a/crates/reinhardt-admin-cli/src/migrate_v2.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2.rs
@@ -199,7 +199,7 @@ fn find_item_start_with_prefix(src: &str, search_from: usize, item_start: usize)
 		let previous_start = line_start(src, previous_end);
 		let line = &src[previous_start..start];
 		let trimmed = line.trim();
-		if trimmed.starts_with("#[") || trimmed.starts_with("///") || trimmed.starts_with("//!") {
+		if trimmed.starts_with("#[") || trimmed.starts_with("///") {
 			start = previous_start;
 		} else {
 			break;

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
@@ -7,6 +7,7 @@
 
 use proc_macro2::{Delimiter, Group, TokenStream, TokenTree};
 use quote::quote;
+use std::iter::Peekable;
 use syn::visit_mut::{self, VisitMut};
 
 use crate::migrate_v2::rewriter::FileRewriter;
@@ -66,6 +67,38 @@ fn rewrite_brace_body(input: TokenStream) -> TokenStream {
 	let mut previous_token_can_own_brace_body = false;
 
 	while let Some(tt) = iter.next() {
+		if let TokenTree::Ident(id) = &tt {
+			match id.to_string().as_str() {
+				"if" | "for" | "match" | "while" => {
+					out.push(tt);
+					push_control_prefix_and_rewrite_body(&mut iter, &mut out);
+					previous_token_can_own_brace_body = false;
+					continue;
+				}
+				"else" => {
+					out.push(tt);
+					if let Some(TokenTree::Ident(next)) = iter.peek()
+						&& next == "if"
+					{
+						let if_token = iter.next().expect("peeked token disappeared");
+						out.push(if_token);
+						push_control_prefix_and_rewrite_body(&mut iter, &mut out);
+					} else {
+						push_immediate_body_if_present(&mut iter, &mut out);
+					}
+					previous_token_can_own_brace_body = false;
+					continue;
+				}
+				"loop" | "unsafe" | "async" => {
+					out.push(tt);
+					push_immediate_body_if_present(&mut iter, &mut out);
+					previous_token_can_own_brace_body = false;
+					continue;
+				}
+				_ => {}
+			}
+		}
+
 		// Look for `Ident` followed by something that is NOT one of:
 		//   `{` — element body
 		//   `(` — component call or function call
@@ -128,6 +161,38 @@ fn rewrite_brace_body(input: TokenStream) -> TokenStream {
 	}
 
 	out.into_iter().collect()
+}
+
+fn push_control_prefix_and_rewrite_body(
+	iter: &mut Peekable<proc_macro2::token_stream::IntoIter>,
+	out: &mut Vec<TokenTree>,
+) {
+	for next in iter.by_ref() {
+		if let TokenTree::Group(g) = &next
+			&& g.delimiter() == Delimiter::Brace
+		{
+			let inner = rewrite_brace_body(g.stream());
+			out.push(TokenTree::Group(Group::new(Delimiter::Brace, inner)));
+			return;
+		}
+		out.push(next);
+	}
+}
+
+fn push_immediate_body_if_present(
+	iter: &mut Peekable<proc_macro2::token_stream::IntoIter>,
+	out: &mut Vec<TokenTree>,
+) {
+	if let Some(TokenTree::Group(g)) = iter.peek()
+		&& g.delimiter() == Delimiter::Brace
+	{
+		let body = match iter.next() {
+			Some(TokenTree::Group(g)) => g,
+			_ => unreachable!("peek matched but next did not"),
+		};
+		let inner = rewrite_brace_body(body.stream());
+		out.push(TokenTree::Group(Group::new(Delimiter::Brace, inner)));
+	}
 }
 
 fn starts_lowercase(s: &str) -> bool {

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
@@ -69,9 +69,21 @@ fn rewrite_brace_body(input: TokenStream) -> TokenStream {
 	while let Some(tt) = iter.next() {
 		if let TokenTree::Ident(id) = &tt {
 			match id.to_string().as_str() {
-				"if" | "for" | "match" | "while" => {
+				"if" | "for" | "while" => {
 					out.push(tt);
 					push_control_prefix_and_rewrite_body(&mut iter, &mut out);
+					previous_token_can_own_brace_body = false;
+					continue;
+				}
+				"match" => {
+					out.push(tt);
+					push_match_prefix_and_rewrite_body(&mut iter, &mut out);
+					previous_token_can_own_brace_body = false;
+					continue;
+				}
+				"let" => {
+					out.push(tt);
+					push_statement_until_semicolon(&mut iter, &mut out);
 					previous_token_can_own_brace_body = false;
 					continue;
 				}
@@ -176,6 +188,81 @@ fn push_control_prefix_and_rewrite_body(
 			return;
 		}
 		out.push(next);
+	}
+}
+
+fn push_match_prefix_and_rewrite_body(
+	iter: &mut Peekable<proc_macro2::token_stream::IntoIter>,
+	out: &mut Vec<TokenTree>,
+) {
+	for next in iter.by_ref() {
+		if let TokenTree::Group(g) = &next
+			&& g.delimiter() == Delimiter::Brace
+		{
+			let inner = rewrite_match_body(g.stream());
+			out.push(TokenTree::Group(Group::new(Delimiter::Brace, inner)));
+			return;
+		}
+		out.push(next);
+	}
+}
+
+fn rewrite_match_body(input: TokenStream) -> TokenStream {
+	let mut out: Vec<TokenTree> = Vec::new();
+	let mut arm_value: Vec<TokenTree> = Vec::new();
+	let mut iter = input.into_iter().peekable();
+	let mut in_arm_value = false;
+
+	while let Some(tt) = iter.next() {
+		if !in_arm_value {
+			if is_fat_arrow_start(&tt, iter.peek()) {
+				out.push(tt);
+				if let Some(next) = iter.next() {
+					out.push(next);
+				}
+				in_arm_value = true;
+			} else {
+				out.push(tt);
+			}
+			continue;
+		}
+
+		if is_top_level_comma(&tt) {
+			out.extend(rewrite_brace_body(arm_value.into_iter().collect()));
+			arm_value = Vec::new();
+			out.push(tt);
+			in_arm_value = false;
+		} else {
+			arm_value.push(tt);
+		}
+	}
+
+	if in_arm_value {
+		out.extend(rewrite_brace_body(arm_value.into_iter().collect()));
+	}
+
+	out.into_iter().collect()
+}
+
+fn is_fat_arrow_start(tt: &TokenTree, next: Option<&TokenTree>) -> bool {
+	matches!(tt, TokenTree::Punct(p) if p.as_char() == '=')
+		&& matches!(next, Some(TokenTree::Punct(p)) if p.as_char() == '>')
+}
+
+fn is_top_level_comma(tt: &TokenTree) -> bool {
+	matches!(tt, TokenTree::Punct(p) if p.as_char() == ',')
+}
+
+fn push_statement_until_semicolon(
+	iter: &mut Peekable<proc_macro2::token_stream::IntoIter>,
+	out: &mut Vec<TokenTree>,
+) {
+	for next in iter.by_ref() {
+		let is_semicolon = matches!(&next, TokenTree::Punct(p) if p.as_char() == ';');
+		out.push(next);
+		if is_semicolon {
+			return;
+		}
 	}
 }
 

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
@@ -257,13 +257,74 @@ fn push_statement_until_semicolon(
 	iter: &mut Peekable<proc_macro2::token_stream::IntoIter>,
 	out: &mut Vec<TokenTree>,
 ) {
+	let mut initializer: Vec<TokenTree> = Vec::new();
+	let mut in_initializer = false;
+
 	for next in iter.by_ref() {
 		let is_semicolon = matches!(&next, TokenTree::Punct(p) if p.as_char() == ';');
+		let is_assignment = matches!(&next, TokenTree::Punct(p) if p.as_char() == '=');
+
+		if in_initializer {
+			if is_semicolon {
+				out.extend(rewrite_let_initializer(initializer.into_iter().collect()));
+				out.push(next);
+				return;
+			}
+			initializer.push(next);
+			continue;
+		}
+
 		out.push(next);
+		if is_assignment {
+			in_initializer = true;
+		}
 		if is_semicolon {
 			return;
 		}
 	}
+
+	if in_initializer {
+		out.extend(rewrite_let_initializer(initializer.into_iter().collect()));
+	}
+}
+
+fn rewrite_let_initializer(input: TokenStream) -> TokenStream {
+	let mut out: Vec<TokenTree> = Vec::new();
+	let mut previous_token_can_own_brace_body = false;
+
+	for tt in input {
+		match tt {
+			TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => {
+				let inner = if previous_token_can_own_brace_body {
+					rewrite_brace_body(g.stream())
+				} else {
+					rewrite_let_initializer(g.stream())
+				};
+				out.push(TokenTree::Group(Group::new(Delimiter::Brace, inner)));
+				previous_token_can_own_brace_body = false;
+			}
+			TokenTree::Group(g) => {
+				let delimiter = g.delimiter();
+				let inner = rewrite_let_initializer(g.stream());
+				out.push(TokenTree::Group(Group::new(delimiter, inner)));
+				previous_token_can_own_brace_body = false;
+			}
+			other => {
+				previous_token_can_own_brace_body = token_can_own_let_initializer_body(&other);
+				out.push(other);
+			}
+		}
+	}
+
+	out.into_iter().collect()
+}
+
+fn token_can_own_let_initializer_body(tt: &TokenTree) -> bool {
+	matches!(
+		tt,
+		TokenTree::Ident(id)
+			if starts_lowercase(&id.to_string()) && !is_reserved_keyword(&id.to_string())
+	)
 }
 
 fn push_immediate_body_if_present(

--- a/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
+++ b/crates/reinhardt-admin-cli/src/migrate_v2/rules/bare_ident.rs
@@ -63,6 +63,7 @@ fn rewrite_page_body(input: TokenStream) -> TokenStream {
 fn rewrite_brace_body(input: TokenStream) -> TokenStream {
 	let mut out: Vec<TokenTree> = Vec::new();
 	let mut iter = input.into_iter().peekable();
+	let mut previous_token_can_own_brace_body = false;
 
 	while let Some(tt) = iter.next() {
 		// Look for `Ident` followed by something that is NOT one of:
@@ -96,44 +97,37 @@ fn rewrite_brace_body(input: TokenStream) -> TokenStream {
 				let ident = id.clone();
 				let wrapped = quote! { #ident };
 				out.push(TokenTree::Group(Group::new(Delimiter::Brace, wrapped)));
+				previous_token_can_own_brace_body = false;
 				continue;
 			}
 		}
 
 		// Recurse into any nested braced group (could be a child element body) —
-		// UNLESS the group is already in v2 expression-slot shape (`{ expr }`
-		// where the inner stream is itself wrapped in a single brace group).
-		// Recursing into such a body would re-wrap the inner ident on every
-		// pass, breaking idempotency.
+		// UNLESS it is a standalone expression slot created by a prior run.
+		// Element/control-flow bodies are owned by the previous token, while
+		// expression slots appear as standalone brace groups in child position.
 		if let TokenTree::Group(g) = &tt
 			&& g.delimiter() == Delimiter::Brace
 		{
-			if is_already_wrapped_expression_slot(&g.stream()) {
-				out.push(tt);
-			} else {
+			if previous_token_can_own_brace_body {
 				let inner = rewrite_brace_body(g.stream());
 				out.push(TokenTree::Group(Group::new(Delimiter::Brace, inner)));
+			} else {
+				out.push(tt);
 			}
+			previous_token_can_own_brace_body = false;
 			continue;
 		}
 
+		previous_token_can_own_brace_body = match &tt {
+			TokenTree::Ident(id) => !is_reserved_keyword(&id.to_string()),
+			TokenTree::Punct(p) => matches!(p.as_char(), ')' | ']'),
+			_ => false,
+		};
 		out.push(tt);
 	}
 
 	out.into_iter().collect()
-}
-
-/// True when a brace body's entire contents are themselves a single brace
-/// group — i.e. the surrounding braces are already the v2 expression-slot
-/// wrapping (`{ {expr} }`) introduced by a prior run of this rule.
-fn is_already_wrapped_expression_slot(stream: &TokenStream) -> bool {
-	let mut iter = stream.clone().into_iter();
-	let first = iter.next();
-	let rest = iter.next();
-	match (first, rest) {
-		(Some(TokenTree::Group(g)), None) => g.delimiter() == Delimiter::Brace,
-		_ => false,
-	}
 }
 
 fn starts_lowercase(s: &str) -> bool {

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_e2e.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_e2e.rs
@@ -173,6 +173,33 @@ pub struct CardProps {
 }
 
 #[rstest]
+fn preserves_inner_module_docs_when_rewriting_first_item() {
+	let tmp = TempDir::new().expect("tempdir");
+	let file = tmp.path().join("page.rs");
+	write(
+		&file,
+		r#"//! Module docs stay outside the rewritten item.
+fn view(title: String) {
+    page! { div { title } };
+}
+"#,
+	);
+
+	let output = run_migrate(tmp.path(), &[]);
+	assert_success(&output);
+
+	let after = fs::read_to_string(&file).expect("read rewritten file");
+	assert!(
+		after.starts_with("//! Module docs stay outside the rewritten item."),
+		"inner module docs should not be replaced with the first item:\n{after}"
+	);
+	assert!(
+		compact_ws(&after).contains("{title}"),
+		"first item should still be migrated:\n{after}"
+	);
+}
+
+#[rstest]
 fn dry_run_reports_changes_without_writing_files() {
 	let tmp = TempDir::new().expect("tempdir");
 	let file = tmp.path().join("page.rs");
@@ -360,13 +387,15 @@ fn match_patterns_and_let_statements_are_not_wrapped_as_page_children() {
 	write(
 		&file,
 		r#"
-fn view(value: Option<String>, fallback: String) {
+fn view(value: Option<String>, fallback: String, title: String) {
     page! {
         section {
             match value {
                 item => div { fallback }
             }
             let local = fallback;
+            let child = div { title };
+            child
         }
     };
 }
@@ -387,8 +416,20 @@ fn view(value: Option<String>, fallback: String) {
 		"let binding pattern should not be wrapped:\n{after_first}"
 	);
 	assert!(
+		!compact.contains("let{child}="),
+		"let binding with element initializer should not be wrapped:\n{after_first}"
+	);
+	assert!(
 		compact.contains("div{{fallback}}") || compact.contains("div{{{fallback}}}"),
 		"match arm page body should still be migrated:\n{after_first}"
+	);
+	assert!(
+		compact.contains("div{{title}}"),
+		"let initializer element body should still be migrated:\n{after_first}"
+	);
+	assert!(
+		compact.contains("{child}"),
+		"page child following let statement should still be migrated:\n{after_first}"
 	);
 
 	let second = run_migrate(tmp.path(), &[]);

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_e2e.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_e2e.rs
@@ -29,6 +29,10 @@ fn stderr(output: &Output) -> String {
 	String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
+fn compact_ws(input: &str) -> String {
+	input.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
 fn assert_success(output: &Output) {
 	assert!(
 		output.status.success(),
@@ -209,6 +213,154 @@ fn view(name: String) {
 	let after_second = fs::read_to_string(&file).expect("read after second run");
 
 	assert_eq!(after_second, after_first, "second run changed the file");
+	assert!(
+		stdout(&second).contains("Done. 0 file(s) changed."),
+		"unexpected stdout:\n{}",
+		stdout(&second)
+	);
+}
+
+#[rstest]
+fn complex_page_syntax_rewrites_nested_control_flow_without_rewrapping_expression_slots() {
+	let tmp = TempDir::new().expect("tempdir");
+	let file = tmp.path().join("complex_page.rs");
+	write(
+		&file,
+		r#"
+fn view(
+    ready: bool,
+    title: String,
+    fallback_name: String,
+    already_wrapped: String,
+    items: Vec<Item>,
+    count: usize,
+) {
+    page! {
+        section {
+            { already_wrapped }
+            if (ready) {
+                h1 { title }
+            } else {
+                p { fallback_name }
+            }
+            for item in items {
+                Row {
+                    item_name
+                    span { count }
+                }
+            }
+            loop {
+                span { count }
+                break;
+            }
+        }
+    };
+}
+"#,
+	);
+
+	let first = run_migrate(tmp.path(), &[]);
+	assert_success(&first);
+	let after_first = fs::read_to_string(&file).expect("read after first run");
+	let compact = compact_ws(&after_first);
+
+	assert!(
+		compact.contains("{already_wrapped}"),
+		"existing expression slot should remain a single expression slot:\n{after_first}"
+	);
+	assert!(
+		compact.contains("{title}"),
+		"bare identifier inside parenthesized if body was not wrapped:\n{after_first}"
+	);
+	assert!(
+		compact.contains("{fallback_name}"),
+		"bare identifier inside else body was not wrapped:\n{after_first}"
+	);
+	assert!(
+		compact.contains("{item_name}"),
+		"bare identifier inside component body was not wrapped:\n{after_first}"
+	);
+	assert!(
+		!after_first.contains("for { item } in"),
+		"for-loop pattern variable should not be treated as a page child:\n{after_first}"
+	);
+	assert!(
+		compact.contains("{count}"),
+		"bare identifier inside loop or nested element body was not wrapped:\n{after_first}"
+	);
+	assert!(
+		after_first.contains("break"),
+		"reserved control-flow keyword should not be wrapped:\n{after_first}"
+	);
+
+	let second = run_migrate(tmp.path(), &[]);
+	assert_success(&second);
+	let after_second = fs::read_to_string(&file).expect("read after second run");
+
+	assert_eq!(
+		after_second, after_first,
+		"complex migrated page changed on rerun"
+	);
+	assert!(
+		stdout(&second).contains("Done. 0 file(s) changed."),
+		"unexpected stdout:\n{}",
+		stdout(&second)
+	);
+}
+
+#[rstest]
+fn complex_props_migration_preserves_non_default_derives_and_existing_builder_defaults() {
+	let tmp = TempDir::new().expect("tempdir");
+	let file = tmp.path().join("props.rs");
+	write(
+		&file,
+		r#"
+#[repr(C)]
+#[derive(Clone)]
+#[derive(Debug, Default, PartialEq)]
+pub struct PanelProps {
+    pub id: String,
+    #[builder(default)]
+    pub existing: Option<String>,
+    pub count: usize,
+    pub subtitle: Option<String>,
+}
+"#,
+	);
+
+	let first = run_migrate(tmp.path(), &[]);
+	assert_success(&first);
+	let after_first = fs::read_to_string(&file).expect("read after first run");
+
+	assert!(
+		after_first.contains("#[repr(C)]"),
+		"non-derive attributes should be preserved:\n{after_first}"
+	);
+	assert!(
+		after_first.contains("Clone")
+			&& after_first.contains("Debug")
+			&& after_first.contains("PartialEq")
+			&& after_first.contains("bon::Builder"),
+		"derive list should preserve non-Default derives and add bon::Builder:\n{after_first}"
+	);
+	assert!(
+		!after_first.contains("Default"),
+		"Default derive should be removed:\n{after_first}"
+	);
+	let builder_default_count = after_first.matches("#[builder(default)]").count();
+	assert_eq!(
+		builder_default_count, 3,
+		"expected exactly one builder default for existing, count, and subtitle:\n{after_first}"
+	);
+
+	let second = run_migrate(tmp.path(), &[]);
+	assert_success(&second);
+	let after_second = fs::read_to_string(&file).expect("read after second run");
+
+	assert_eq!(
+		after_second, after_first,
+		"complex Props migration changed on rerun"
+	);
 	assert!(
 		stdout(&second).contains("Done. 0 file(s) changed."),
 		"unexpected stdout:\n{}",

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_e2e.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_e2e.rs
@@ -1,0 +1,348 @@
+//! End-to-end tests for the `migrate-manouche-v2` command.
+//!
+//! These tests spawn the compiled `reinhardt-admin` binary and inspect real
+//! files on disk, covering command-line behavior that rule-level snapshot
+//! tests cannot validate.
+
+use rstest::rstest;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+const REINHARDT_ADMIN: &str = env!("CARGO_BIN_EXE_reinhardt-admin");
+
+fn run_migrate(root: &Path, args: &[&str]) -> Output {
+	Command::new(REINHARDT_ADMIN)
+		.arg("migrate-manouche-v2")
+		.args(args)
+		.arg(root)
+		.output()
+		.expect("failed to spawn reinhardt-admin migrate-manouche-v2")
+}
+
+fn stdout(output: &Output) -> String {
+	String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+	String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn assert_success(output: &Output) {
+	assert!(
+		output.status.success(),
+		"command failed with exit {:?}\nstdout:\n{}\nstderr:\n{}",
+		output.status.code(),
+		stdout(output),
+		stderr(output)
+	);
+}
+
+fn assert_failure(output: &Output) {
+	assert!(
+		!output.status.success(),
+		"command unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+		stdout(output),
+		stderr(output)
+	);
+}
+
+fn write(path: &Path, content: &str) {
+	if let Some(parent) = path.parent() {
+		fs::create_dir_all(parent).expect("create parent dir");
+	}
+	fs::write(path, content).expect("write fixture");
+}
+
+#[rstest]
+fn rewrites_multiple_files_and_reports_changed_count() {
+	let tmp = TempDir::new().expect("tempdir");
+	let page_file = tmp.path().join("src/page.rs");
+	let props_file = tmp.path().join("src/components.rs");
+
+	write(
+		&page_file,
+		r#"
+fn view(name: String, count: usize) {
+    page! {
+        div {
+            name
+            watch {
+                span { count }
+            }
+        }
+    };
+    use_effect(move || {
+        let _ = count;
+    });
+}
+"#,
+	);
+	write(
+		&props_file,
+		r#"
+#[derive(Clone, Default)]
+pub struct CardProps {
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub count: usize,
+}
+"#,
+	);
+
+	let output = run_migrate(tmp.path(), &[]);
+	assert_success(&output);
+
+	let page = fs::read_to_string(&page_file).expect("read page file");
+	let props = fs::read_to_string(&props_file).expect("read props file");
+	assert!(
+		page.contains("{ name }") || page.contains("{name}"),
+		"bare identifier was not wrapped:\n{page}"
+	);
+	assert!(
+		!page.contains("watch"),
+		"watch wrapper should be removed:\n{page}"
+	);
+	assert!(
+		page.contains("compile_error!"),
+		"use_effect placeholder deps were not inserted:\n{page}"
+	);
+	assert!(
+		props.contains("bon::Builder"),
+		"Props derive was not migrated:\n{props}"
+	);
+	assert!(
+		props.contains("#[builder(default)]"),
+		"default builder attributes were not inserted:\n{props}"
+	);
+	assert!(
+		stdout(&output).contains("Done. 2 file(s) changed."),
+		"unexpected stdout:\n{}",
+		stdout(&output)
+	);
+}
+
+#[rstest]
+fn dry_run_reports_changes_without_writing_files() {
+	let tmp = TempDir::new().expect("tempdir");
+	let file = tmp.path().join("page.rs");
+	let original = r#"
+fn view(name: String) {
+    page! { div { name } };
+}
+"#;
+	write(&file, original);
+
+	let output = run_migrate(tmp.path(), &["--dry-run"]);
+	assert_success(&output);
+
+	let after = fs::read_to_string(&file).expect("read file after dry-run");
+	assert_eq!(after, original, "dry-run must not rewrite files");
+	assert!(
+		stdout(&output).contains("would rewrite:"),
+		"dry-run should list pending rewrite:\n{}",
+		stdout(&output)
+	);
+	assert!(
+		stdout(&output).contains("Done. 1 file(s) would change."),
+		"unexpected stdout:\n{}",
+		stdout(&output)
+	);
+}
+
+#[rstest]
+fn skip_rule_leaves_that_rule_unapplied_but_runs_others() {
+	let tmp = TempDir::new().expect("tempdir");
+	let file = tmp.path().join("page.rs");
+	write(
+		&file,
+		r#"
+fn view(name: String, count: usize) {
+    page! {
+        div {
+            name
+            watch { span { count } }
+        }
+    };
+}
+"#,
+	);
+
+	let output = run_migrate(tmp.path(), &["--skip", "bare_ident"]);
+	assert_success(&output);
+
+	let after = fs::read_to_string(&file).expect("read rewritten file");
+	assert!(
+		after.contains("name"),
+		"source should still contain the bare identifier:\n{after}"
+	);
+	assert!(
+		!after.contains("{ name }") && !after.contains("{name}"),
+		"bare_ident should have been skipped:\n{after}"
+	);
+	assert!(
+		!after.contains("watch"),
+		"watch_unwrap should still run when bare_ident is skipped:\n{after}"
+	);
+}
+
+#[rstest]
+fn rerunning_on_migrated_tree_is_idempotent() {
+	let tmp = TempDir::new().expect("tempdir");
+	let file = tmp.path().join("page.rs");
+	write(
+		&file,
+		r#"
+fn view(name: String) {
+    page! { div { name } };
+}
+"#,
+	);
+
+	let first = run_migrate(tmp.path(), &[]);
+	assert_success(&first);
+	let after_first = fs::read_to_string(&file).expect("read after first run");
+
+	let second = run_migrate(tmp.path(), &[]);
+	assert_success(&second);
+	let after_second = fs::read_to_string(&file).expect("read after second run");
+
+	assert_eq!(after_second, after_first, "second run changed the file");
+	assert!(
+		stdout(&second).contains("Done. 0 file(s) changed."),
+		"unexpected stdout:\n{}",
+		stdout(&second)
+	);
+}
+
+#[rstest]
+fn unknown_skip_rule_fails() {
+	let tmp = TempDir::new().expect("tempdir");
+	write(&tmp.path().join("page.rs"), "fn view() {}\n");
+
+	let output = run_migrate(tmp.path(), &["--skip", "not_a_rule"]);
+	assert_failure(&output);
+	assert!(
+		stderr(&output).contains("unknown --skip rule(s): not_a_rule"),
+		"unexpected stderr:\n{}",
+		stderr(&output)
+	);
+}
+
+#[rstest]
+fn missing_path_fails() {
+	let tmp = TempDir::new().expect("tempdir");
+	let missing = tmp.path().join("does-not-exist");
+
+	let output = run_migrate(&missing, &[]);
+	assert_failure(&output);
+	assert!(
+		stderr(&output).contains("No such file")
+			|| stderr(&output).contains("does-not-exist")
+			|| stderr(&output).contains("not found"),
+		"unexpected stderr:\n{}",
+		stderr(&output)
+	);
+}
+
+#[rstest]
+fn invalid_rust_file_is_skipped_while_valid_files_are_rewritten() {
+	let tmp = TempDir::new().expect("tempdir");
+	let valid = tmp.path().join("valid.rs");
+	let invalid = tmp.path().join("invalid.rs");
+	let invalid_source = "fn broken(\n";
+	write(
+		&valid,
+		r#"
+fn view(name: String) {
+    page! { div { name } };
+}
+"#,
+	);
+	write(&invalid, invalid_source);
+
+	let output = run_migrate(tmp.path(), &[]);
+	assert_success(&output);
+
+	let valid_after = fs::read_to_string(&valid).expect("read valid file");
+	let invalid_after = fs::read_to_string(&invalid).expect("read invalid file");
+	assert!(
+		valid_after.contains("{ name }") || valid_after.contains("{name}"),
+		"valid file was not rewritten:\n{valid_after}"
+	);
+	assert_eq!(
+		invalid_after, invalid_source,
+		"invalid Rust file should be skipped unchanged"
+	);
+	assert!(
+		stdout(&output).contains("Done. 1 file(s) changed."),
+		"unexpected stdout:\n{}",
+		stdout(&output)
+	);
+}
+
+#[rstest]
+fn skips_target_and_hidden_directories() {
+	let tmp = TempDir::new().expect("tempdir");
+	let source = tmp.path().join("src/page.rs");
+	let target = tmp.path().join("target/generated.rs");
+	let hidden = tmp.path().join(".git/ignored.rs");
+	let body = r#"
+fn view(name: String) {
+    page! { div { name } };
+}
+"#;
+	write(&source, body);
+	write(&target, body);
+	write(&hidden, body);
+
+	let output = run_migrate(tmp.path(), &[]);
+	assert_success(&output);
+
+	let source_after = fs::read_to_string(&source).expect("read source file");
+	let target_after = fs::read_to_string(&target).expect("read target file");
+	let hidden_after = fs::read_to_string(&hidden).expect("read hidden file");
+	assert!(
+		source_after.contains("{ name }") || source_after.contains("{name}"),
+		"source file should be rewritten:\n{source_after}"
+	);
+	assert_eq!(target_after, body, "target/ file should be skipped");
+	assert_eq!(
+		hidden_after, body,
+		"hidden directory file should be skipped"
+	);
+	assert!(
+		stdout(&output).contains("Done. 1 file(s) changed."),
+		"unexpected stdout:\n{}",
+		stdout(&output)
+	);
+}
+
+#[rstest]
+fn single_rs_file_path_is_rewritten() {
+	let tmp = TempDir::new().expect("tempdir");
+	let file = tmp.path().join("single.rs");
+	write(
+		&file,
+		r#"
+fn view(name: String) {
+    page! { div { name } };
+}
+"#,
+	);
+
+	let output = run_migrate(&file, &[]);
+	assert_success(&output);
+
+	let after = fs::read_to_string(&file).expect("read rewritten file");
+	assert!(
+		after.contains("{ name }") || after.contains("{name}"),
+		"single file path was not rewritten:\n{after}"
+	);
+	assert!(
+		stdout(&output).contains("Done. 1 file(s) changed."),
+		"unexpected stdout:\n{}",
+		stdout(&output)
+	);
+}

--- a/crates/reinhardt-admin-cli/tests/migrate_v2_e2e.rs
+++ b/crates/reinhardt-admin-cli/tests/migrate_v2_e2e.rs
@@ -4,6 +4,7 @@
 //! files on disk, covering command-line behavior that rule-level snapshot
 //! tests cannot validate.
 
+use proptest::prelude::*;
 use rstest::rstest;
 use std::fs;
 use std::path::Path;
@@ -57,6 +58,50 @@ fn write(path: &Path, content: &str) {
 		fs::create_dir_all(parent).expect("create parent dir");
 	}
 	fs::write(path, content).expect("write fixture");
+}
+
+fn generated_control_flow_page() -> impl Strategy<Value = String> {
+	let match_body = prop_oneof![
+		Just("match value { item => div { title } }"),
+		Just("match value { Some(entry) => div { title }, None => span { fallback } }"),
+		Just(
+			"match result { Ok(entry) if ready => div { title }, Err(error_name) => span { fallback } }"
+		),
+		Just(
+			"match value { Some(entry) => if (ready) { h1 { title } } else { p { fallback } }, None => span { fallback } }"
+		),
+	];
+
+	(
+		match_body,
+		prop::sample::select(vec![
+			"for item in items { Row { title } }",
+			"while (ready) { span { title } break; }",
+			"loop { span { fallback } break; }",
+		]),
+	)
+		.prop_map(|(match_body, loop_body)| {
+			format!(
+				r#"
+fn view(
+    value: Option<String>,
+    result: Result<String, String>,
+    ready: bool,
+    title: String,
+    fallback: String,
+    items: Vec<String>,
+) {{
+    page! {{
+        section {{
+            let local_value = fallback;
+            {match_body}
+            {loop_body}
+        }}
+    }};
+}}
+"#
+			)
+		})
 }
 
 #[rstest]
@@ -306,6 +351,116 @@ fn view(
 		"unexpected stdout:\n{}",
 		stdout(&second)
 	);
+}
+
+#[rstest]
+fn match_patterns_and_let_statements_are_not_wrapped_as_page_children() {
+	let tmp = TempDir::new().expect("tempdir");
+	let file = tmp.path().join("match_and_let.rs");
+	write(
+		&file,
+		r#"
+fn view(value: Option<String>, fallback: String) {
+    page! {
+        section {
+            match value {
+                item => div { fallback }
+            }
+            let local = fallback;
+        }
+    };
+}
+"#,
+	);
+
+	let first = run_migrate(tmp.path(), &[]);
+	assert_success(&first);
+	let after_first = fs::read_to_string(&file).expect("read after first run");
+	let compact = compact_ws(&after_first);
+
+	assert!(
+		!compact.contains("{{item}}=>") && !compact.contains("{item}=>"),
+		"match arm pattern should not be wrapped:\n{after_first}"
+	);
+	assert!(
+		!compact.contains("let{local}="),
+		"let binding pattern should not be wrapped:\n{after_first}"
+	);
+	assert!(
+		compact.contains("div{{fallback}}") || compact.contains("div{{{fallback}}}"),
+		"match arm page body should still be migrated:\n{after_first}"
+	);
+
+	let second = run_migrate(tmp.path(), &[]);
+	assert_success(&second);
+	let after_second = fs::read_to_string(&file).expect("read after second run");
+	assert_eq!(
+		after_second, after_first,
+		"match and let migration changed on rerun"
+	);
+}
+
+proptest! {
+	#![proptest_config(ProptestConfig::with_cases(24))]
+
+	#[test]
+	fn fuzz_migrate_page_control_syntax_preserves_rust_patterns_and_is_idempotent(
+		source in generated_control_flow_page(),
+	) {
+		let tmp = TempDir::new().expect("tempdir");
+		let file = tmp.path().join("fuzz_page.rs");
+		write(&file, &source);
+
+		let first = run_migrate(tmp.path(), &[]);
+		prop_assert!(
+			first.status.success(),
+			"command failed with exit {:?}\nstdout:\n{}\nstderr:\n{}\nsource:\n{}",
+			first.status.code(),
+			stdout(&first),
+			stderr(&first),
+			source
+		);
+		let after_first = fs::read_to_string(&file).expect("read after first run");
+		let compact = compact_ws(&after_first);
+
+		prop_assert!(
+			!compact.contains("let{local_value}="),
+			"let binding was wrapped as a page child:\n{after_first}"
+		);
+		for invalid in [
+			"{item}=>",
+			"{entry}=>",
+			"{entry}ifready=>",
+			"{ready}=>",
+			"{error_name}=>",
+			"for{item}in",
+		] {
+			prop_assert!(
+				!compact.contains(invalid),
+				"Rust pattern/control syntax was wrapped as a page child ({invalid}):\n{after_first}"
+			);
+		}
+		prop_assert!(
+			compact.contains("{title}") || compact.contains("{fallback}"),
+			"generated page children were not migrated:\n{after_first}"
+		);
+
+		let second = run_migrate(tmp.path(), &[]);
+		prop_assert!(
+			second.status.success(),
+			"second command failed with exit {:?}\nstdout:\n{}\nstderr:\n{}\nsource:\n{}",
+			second.status.code(),
+			stdout(&second),
+			stderr(&second),
+			source
+		);
+		let after_second = fs::read_to_string(&file).expect("read after second run");
+		prop_assert_eq!(
+			after_second,
+			after_first,
+			"fuzz-generated page changed on rerun"
+		);
+	}
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds real binary E2E coverage for `reinhardt-admin migrate-manouche-v2` command behavior.
- Expands coverage to complex Manouche syntax: nested control flow, existing expression slots, component bodies, loop bodies, `match` arms, `let` statements, and attributed Props structs.
- Adds property-based fuzz E2E coverage that generates control-flow-heavy `page!` bodies and runs the real CLI against each case.
- Fixes rerun idempotency, control-flow variable misclassification, match/let syntax rewriting, and attributed-item replacement bugs found by the new E2E/fuzz cases.
- Documents the admin-cli codemod fixes in the crate changelog.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The existing coverage only exercised individual codemod rules and the walker. It did not prove command-line behavior such as dry-run non-mutating behavior, skip validation, invalid Rust file handling, skipped directories, single-file roots, rerun idempotency, or realistic nested syntax.

The new E2E and fuzz tests exposed four codemod gaps:

- `bare_ident` recursively wrapped expression slots produced by the previous run.
- `bare_ident` treated `for` pattern variables as page children and missed some control-flow bodies such as `else` and `loop`.
- `bare_ident` rewrote `match` arm patterns/guards and `let` bindings as page children.
- Changed attributed items could duplicate attributes because the replacement range started at the item keyword instead of the contiguous attribute/doc-comment prefix.

Fixes #5245
Fixes #5248

Related to: #4748

## How Was This Tested?

- `cargo test -p reinhardt-admin-cli --test migrate_v2_e2e` — 13 E2E cases, including 24 generated fuzz cases inside the proptest case
- `cargo test -p reinhardt-admin-cli --test migrate_v2_snapshot --test migrate_v2_walker`
- `cargo make fmt-check`
- `CARGO_TARGET_DIR=/tmp/reinhardt-admin-cli-clippy... cargo clippy -p reinhardt-admin-cli --all-targets --all-features -- -D warnings`

Note: a full `cargo make clippy-check` rerun after the fuzz commit was blocked by an unrelated workspace-wide `cargo check` holding the shared build lock. The earlier PR revision had passed `cargo make clippy-check`; the latest changes were verified with focused admin-cli clippy in a separate target dir.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5245
- Fixes #5248
- Related to #4748

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [x] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Generated with Codex