### PR TITLE
docs(release): enforce public API doc coverage

### DIFF
--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -43,3 +43,4 @@ path = "src/lib.rs"
 [[bin]]
 name = "reinhardt-admin"
 path = "src/main.rs"
+doc = false

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -12,6 +12,11 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[[bin]]
+name = "createsuperuser"
+path = "src/bin/createsuperuser.rs"
+doc = false
+
 [features]
 default = ["params", "basic"]
 

--- a/crates/reinhardt-auth/macros/src/lib.rs
+++ b/crates/reinhardt-auth/macros/src/lib.rs
@@ -26,6 +26,8 @@
 //! | `(A \| B) & C` | Parenthesized grouping |
 //! | `mod::Type` | Qualified type paths |
 
+#![warn(missing_docs)]
+
 mod guard_codegen;
 mod guard_parser;
 

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -8,6 +8,11 @@ repository.workspace = true
 authors.workspace = true
 description = "Django-style management command framework for Reinhardt"
 
+[[bin]]
+name = "runserver"
+path = "src/bin/runserver.rs"
+doc = false
+
 [dependencies]
 reinhardt-apps = { workspace = true }
 reinhardt-mail = { workspace = true }

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -11,6 +11,8 @@
 //! - `#[permission_required]` - Permission decorator
 //!
 
+#![warn(missing_docs)]
+
 use proc_macro::TokenStream;
 use syn::{ItemFn, ItemStruct, parse_macro_input};
 

--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -12,6 +12,7 @@ description = "Dependency injection system for Reinhardt, inspired by FastAPI"
 [[bin]]
 name = "check-di"
 path = "src/bin/check-di.rs"
+doc = false
 
 [dependencies]
 reinhardt-http = { workspace = true }

--- a/crates/reinhardt-di/macros/src/lib.rs
+++ b/crates/reinhardt-di/macros/src/lib.rs
@@ -4,6 +4,8 @@
 //! - `#[injectable]` - Mark a struct as injectable with automatic registration
 //! - `#[injectable_factory]` - Mark an async function as a dependency factory
 
+#![warn(missing_docs)]
+
 use proc_macro::TokenStream;
 use syn::{DeriveInput, ItemFn, parse_macro_input};
 

--- a/crates/reinhardt-graphql/macros/src/lib.rs
+++ b/crates/reinhardt-graphql/macros/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate provides derive macros to simplify gRPC ↔ GraphQL integration
 //! and dependency injection support.
 
+#![warn(missing_docs)]
+
 use proc_macro::TokenStream;
 use syn::{DeriveInput, parse_macro_input};
 

--- a/crates/reinhardt-grpc/macros/src/lib.rs
+++ b/crates/reinhardt-grpc/macros/src/lib.rs
@@ -1,5 +1,7 @@
 //! Procedural macros for Reinhardt gRPC DI integration
 
+#![warn(missing_docs)]
+
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
 

--- a/crates/reinhardt-pages/ast/src/lib.rs
+++ b/crates/reinhardt-pages/ast/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! This crate now re-exports types from `reinhardt-manouche` for backward compatibility.
 
+#![warn(missing_docs)]
 #![deprecated(
 	since = "0.1.0-alpha.2",
 	note = "Use reinhardt-manouche instead. This crate will be removed in a future version."

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -59,6 +59,8 @@
 //! // On server, this expands to a route handler
 //! ```
 
+#![warn(missing_docs)]
+
 use proc_macro::TokenStream;
 
 mod crate_paths;

--- a/crates/reinhardt-query/macros/src/lib.rs
+++ b/crates/reinhardt-query/macros/src/lib.rs
@@ -84,6 +84,8 @@
 //! assert_eq!(user.verifieden(), "verified");
 //! ```
 
+#![warn(missing_docs)]
+
 use heck::ToSnakeCase;
 use proc_macro::TokenStream;
 use quote::quote;

--- a/crates/reinhardt-rest/openapi-macros/src/lib.rs
+++ b/crates/reinhardt-rest/openapi-macros/src/lib.rs
@@ -4,6 +4,8 @@
 //! OpenAPI schema generation from Rust types.
 //!
 
+#![warn(missing_docs)]
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, Fields, parse_macro_input};

--- a/crates/reinhardt-router/src/lib.rs
+++ b/crates/reinhardt-router/src/lib.rs
@@ -13,6 +13,7 @@
 //! See <https://github.com/kent8192/reinhardt-web/issues/4321>.
 
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod router;

--- a/crates/reinhardt-storages/src/lib.rs
+++ b/crates/reinhardt-storages/src/lib.rs
@@ -42,6 +42,8 @@
 //! `StorageConfig` and provider-specific `XxxConfig` structs are deprecated.
 //! Use `StorageSettings` with `create_storage_from_settings()` for new code.
 
+#![warn(missing_docs)]
+
 pub mod backend;
 pub mod backends;
 pub mod config;

--- a/crates/reinhardt-streaming/src/error.rs
+++ b/crates/reinhardt-streaming/src/error.rs
@@ -3,16 +3,22 @@ use thiserror::Error;
 /// Errors that can occur in the streaming layer.
 #[derive(Debug, Error)]
 pub enum StreamingError {
+	/// The client could not connect to a streaming backend.
 	#[error("connection failed: {0}")]
 	Connection(String),
+	/// A payload could not be serialized or deserialized.
 	#[error("serialization error: {0}")]
 	Serialization(String),
+	/// The requested topic is not known to the backend.
 	#[error("topic not found: {0}")]
 	TopicNotFound(String),
+	/// The operation failed with a condition that may succeed on retry.
 	#[error("retryable error: {0}")]
 	Retryable(String),
+	/// The operation failed with a non-retryable backend condition.
 	#[error("fatal error: {0}")]
 	Fatal(String),
+	/// Backend-specific error that does not fit a narrower category.
 	#[error("backend error: {0}")]
 	Backend(String),
 }

--- a/crates/reinhardt-streaming/src/in_memory.rs
+++ b/crates/reinhardt-streaming/src/in_memory.rs
@@ -11,6 +11,7 @@ pub struct InMemoryStreamingBackend {
 }
 
 impl InMemoryStreamingBackend {
+	/// Create an empty in-memory backend.
 	pub fn new() -> Self {
 		Self {
 			queues: Mutex::new(HashMap::new()),

--- a/crates/reinhardt-streaming/src/kafka.rs
+++ b/crates/reinhardt-streaming/src/kafka.rs
@@ -2,8 +2,11 @@
 //!
 //! Requires feature `kafka`.
 
+/// Kafka connection configuration.
 pub mod config;
+/// Kafka consumer wrapper.
 pub mod consumer;
+/// Kafka producer wrapper.
 pub mod producer;
 
 pub use config::KafkaConfig;

--- a/crates/reinhardt-streaming/src/kafka/config.rs
+++ b/crates/reinhardt-streaming/src/kafka/config.rs
@@ -3,7 +3,9 @@ use std::{num::NonZeroU16, time::Duration};
 /// Configuration for connecting to a Kafka cluster.
 #[derive(Debug, Clone)]
 pub struct KafkaConfig {
+	/// Bootstrap broker addresses used to connect to Kafka.
 	pub brokers: Vec<String>,
+	/// Kafka client identifier used by producer and consumer clients.
 	pub client_id: String,
 	/// Number of partitions to use when creating topics through this config.
 	///
@@ -26,6 +28,7 @@ pub struct KafkaConfig {
 }
 
 impl KafkaConfig {
+	/// Create a Kafka configuration with the supplied broker addresses.
 	pub fn new(brokers: impl IntoIterator<Item = impl Into<String>>) -> Self {
 		Self {
 			brokers: brokers.into_iter().map(Into::into).collect(),
@@ -36,6 +39,7 @@ impl KafkaConfig {
 		}
 	}
 
+	/// Set the Kafka client identifier.
 	pub fn with_client_id(mut self, id: impl Into<String>) -> Self {
 		self.client_id = id.into();
 		self

--- a/crates/reinhardt-streaming/src/lib.rs
+++ b/crates/reinhardt-streaming/src/lib.rs
@@ -17,24 +17,35 @@
 //! producer.send("orders", &order).await?;
 //! ```
 
+#![warn(missing_docs)]
+
+/// Backend trait abstraction for streaming providers.
 pub mod backend;
+/// Error types returned by streaming operations.
 pub mod error;
+/// In-memory streaming backend for tests and local execution.
 pub mod in_memory;
+/// Message envelope types used by streaming backends.
 pub mod message;
 
 #[cfg(feature = "kafka")]
+/// Kafka producer and consumer integration.
 pub mod kafka;
 
 #[cfg(feature = "kafka")]
+/// Dependency-injection bindings for Kafka streaming.
 pub mod di;
 
 #[cfg(feature = "kafka")]
+/// Process-global Kafka producer registration.
 pub mod global;
 
 #[cfg(feature = "kafka")]
 pub use global::{global_producer, set_global_producer};
 
+/// Streaming DSL helper macros.
 pub mod macros;
+/// Router registration types for streaming handlers.
 pub mod router;
 pub use router::{
 	ConsumerFactory, StreamingHandlerKind, StreamingHandlerRegistration, StreamingRouter,
@@ -45,6 +56,7 @@ pub use router::{
 /// Mirrored from `reinhardt_urls::StreamingTopicResolver` to avoid requiring
 /// reinhardt-urls as a direct dependency of reinhardt-streaming.
 pub trait StreamingTopicResolver {
+	/// Resolve a registered logical handler name to its backend topic name.
 	fn resolve_topic(&self, name: &str) -> &'static str;
 }
 
@@ -58,10 +70,15 @@ pub use message::Message;
 /// Used by `resolve_streaming_topic()` to look up topic names at runtime.
 #[derive(Debug)]
 pub struct StreamingHandlerMetadata {
+	/// Logical handler name used for runtime lookup.
 	pub name: &'static str,
+	/// Backend topic name associated with the handler.
 	pub topic: &'static str,
+	/// Whether the handler produces or consumes messages.
 	pub kind: StreamingHandlerKind,
+	/// Consumer group name for consumers.
 	pub group: Option<&'static str>,
+	/// Rust module path where the handler was registered.
 	pub module_path: &'static str,
 }
 

--- a/crates/reinhardt-streaming/src/message.rs
+++ b/crates/reinhardt-streaming/src/message.rs
@@ -3,13 +3,18 @@ use serde::{Deserialize, Serialize};
 /// A streaming message wrapping a typed payload with topic and offset metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message<T> {
+	/// Topic from which the message was received or to which it will be sent.
 	pub topic: String,
+	/// Typed message payload.
 	pub payload: T,
+	/// Backend offset, when provided by the streaming provider.
 	pub offset: Option<i64>,
+	/// Backend partition, when provided by the streaming provider.
 	pub partition: Option<i32>,
 }
 
 impl<T> Message<T> {
+	/// Create a message with topic and payload metadata.
 	pub fn new(topic: impl Into<String>, payload: T) -> Self {
 		Self {
 			topic: topic.into(),
@@ -19,11 +24,13 @@ impl<T> Message<T> {
 		}
 	}
 
+	/// Attach a backend offset to the message.
 	pub fn with_offset(mut self, offset: i64) -> Self {
 		self.offset = Some(offset);
 		self
 	}
 
+	/// Attach a backend partition to the message.
 	pub fn with_partition(mut self, partition: i32) -> Self {
 		self.partition = Some(partition);
 		self

--- a/crates/reinhardt-streaming/src/router.rs
+++ b/crates/reinhardt-streaming/src/router.rs
@@ -3,16 +3,22 @@ use std::sync::Arc;
 /// Whether a streaming handler produces or consumes messages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamingHandlerKind {
+	/// Handler that publishes messages to a topic.
 	Producer,
+	/// Handler that consumes messages from a topic.
 	Consumer,
 }
 
 /// A registered streaming handler (producer or consumer).
 #[derive(Clone)]
 pub struct StreamingHandlerRegistration {
+	/// Topic associated with the handler.
 	pub topic: &'static str,
+	/// Consumer group for consumer handlers.
 	pub group: Option<&'static str>,
+	/// Logical handler name used for registration and lookup.
 	pub name: &'static str,
+	/// Handler direction.
 	pub kind: StreamingHandlerKind,
 	/// Factory for spawning consumer tasks. `None` for producers.
 	pub consumer_factory: Option<Arc<dyn ConsumerFactory>>,
@@ -20,6 +26,7 @@ pub struct StreamingHandlerRegistration {
 
 /// Factory that spawns a Kafka consumer task for a topic.
 pub trait ConsumerFactory: Send + Sync {
+	/// Spawn a consumer task for the supplied brokers, topic, and group.
 	fn spawn(&self, brokers: Vec<String>, topic: &'static str, group: &'static str);
 }
 
@@ -32,6 +39,7 @@ pub struct StreamingRouter {
 }
 
 impl StreamingRouter {
+	/// Create an empty streaming router.
 	pub fn new() -> Self {
 		Self {
 			handlers: Vec::new(),

--- a/crates/reinhardt-testkit-macros/src/lib.rs
+++ b/crates/reinhardt-testkit-macros/src/lib.rs
@@ -3,6 +3,8 @@
 //! See `crates/reinhardt-testkit/src/fixtures/di_overrides.rs` for the
 //! runtime types used by the macros in this crate.
 
+#![warn(missing_docs)]
+
 mod with_di_overrides;
 
 use proc_macro::TokenStream;

--- a/crates/reinhardt-urls/routers-macros/src/lib.rs
+++ b/crates/reinhardt-urls/routers-macros/src/lib.rs
@@ -32,6 +32,8 @@
 //! let pattern = path!("/users/{id/");
 //! ```
 
+#![warn(missing_docs)]
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{LitStr, parse_macro_input};

--- a/crates/tree-sitter-reinhardt-form/src/lib.rs
+++ b/crates/tree-sitter-reinhardt-form/src/lib.rs
@@ -1,5 +1,7 @@
 //! tree-sitter grammar for the Reinhardt `form!` DSL.
 
+#![warn(missing_docs)]
+
 use tree_sitter_language::LanguageFn;
 
 unsafe extern "C" {

--- a/crates/tree-sitter-reinhardt-head/src/lib.rs
+++ b/crates/tree-sitter-reinhardt-head/src/lib.rs
@@ -1,5 +1,7 @@
 //! tree-sitter grammar for the Reinhardt `head!` DSL.
 
+#![warn(missing_docs)]
+
 use tree_sitter_language::LanguageFn;
 
 unsafe extern "C" {

--- a/crates/tree-sitter-reinhardt-page/src/lib.rs
+++ b/crates/tree-sitter-reinhardt-page/src/lib.rs
@@ -1,5 +1,7 @@
 //! tree-sitter grammar for the Reinhardt `page!` DSL.
 
+#![warn(missing_docs)]
+
 use tree_sitter_language::LanguageFn;
 
 unsafe extern "C" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@
 //!     .with_middleware(Arc::new(CorsMiddleware::permissive()));
 //! ```
 
+#![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // ============================================================================
@@ -173,6 +174,7 @@ pub mod reinhardt_di {
 }
 
 #[cfg(all(feature = "auth", native))]
+/// Authentication and authorization APIs re-exported by the facade crate.
 pub mod auth {
 	pub use reinhardt_auth::*;
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Enforces `missing_docs` on remaining publishable public API documentation targets for the 0.2.0 release audit.
- Excludes CLI binary targets from public rustdoc output to avoid command-entrypoint docs and rustdoc filename collisions.
- Documents the remaining `reinhardt-streaming` public items and the root `auth` facade module.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Issue #5149 requires public API documentation completeness for the 0.2.0 release. The previous state left some publishable doc targets without `missing_docs` enforcement and allowed CLI binaries to participate in public rustdoc output, including a rustdoc filename collision. This PR makes missing public docs fail fast and keeps command binaries out of the public API doc surface.

Fixes #5149

Related to: N/A

## How Was This Tested?

- `cargo metadata --no-deps --format-version 1 | jq ...` publishable-target `missing_docs` audit
- `git diff --check`
- `RUSTFLAGS='-D warnings' RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --all-features`
- `RUSTUP_TOOLCHAIN=nightly RUSTFLAGS='-D warnings' RUSTDOCFLAGS='--cfg docsrs -D warnings' cargo doc --workspace --no-deps --all-features`
- `RUSTFLAGS='-D warnings' RUSTDOCFLAGS='-D warnings' cargo test --doc --workspace --all-features`
- `cargo make fmt-check`
- `cargo make fmt-fix`
- `cargo make clippy-check`

## Performance Impact

N/A - documentation and rustdoc configuration only.

## Breaking Changes

None.

**Migration Guide:**

N/A.

## Screenshots

N/A - no UI changes.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A - verified through rustdoc/doctest gates)
- [ ] New and existing unit tests pass locally with my changes (not run; doc tests and clippy passed)
- [ ] I have tested with all affected database backends (N/A)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5149

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [x] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

No remaining public documentation gaps were found for publishable documentation targets in this audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality standards by enabling documentation requirements across the codebase.
  * Updated internal build and tooling configuration for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->