### PR TITLE
fix: document wasm router stubs

### DIFF
--- a/src/compat/websockets.rs
+++ b/src/compat/websockets.rs
@@ -10,15 +10,18 @@
 //! `WebSocketRouter::new().consumer(my_ws).consumer(other_ws)` body
 //! pattern.
 
+/// WASM-only no-op stand-in for native `WebSocketRouter`.
 pub struct WebSocketRouter {
 	_private: (),
 }
 
 impl WebSocketRouter {
+	/// Creates an empty no-op WebSocket router.
 	pub fn new() -> Self {
 		Self { _private: () }
 	}
 
+	/// Accepts a route namespace and returns the unchanged no-op router.
 	pub fn with_namespace(self, _namespace: impl Into<String>) -> Self {
 		self
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,19 +330,23 @@ pub mod urls {
 			/// Empty stand-in for `reinhardt_urls::routers::client_router::ClientRouter`.
 			pub struct ClientRouter;
 
+			/// WASM-only no-op stand-in for `reinhardt_urls::routers::UnifiedRouter`.
 			pub struct UnifiedRouter {
 				_private: (),
 			}
 
 			impl UnifiedRouter {
+				/// Creates an empty no-op router builder.
 				pub fn new() -> Self {
 					Self { _private: () }
 				}
 
+				/// Accepts a route namespace and returns the unchanged no-op router.
 				pub fn with_namespace(self, _namespace: impl Into<String>) -> Self {
 					self
 				}
 
+				/// Accepts a server router closure and discards its no-op result.
 				pub fn server<F>(self, _f: F) -> Self
 				where
 					F: FnOnce(ServerRouter) -> ServerRouter,
@@ -350,6 +354,7 @@ pub mod urls {
 					self
 				}
 
+				/// Accepts a client router closure and discards its no-op result.
 				pub fn client<F>(self, _f: F) -> Self
 				where
 					F: FnOnce(ClientRouter) -> ClientRouter,


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds missing rustdoc to public WASM-only router compatibility stubs in `reinhardt-web`.
- Fixes the `WASM Check / WASM Clippy (reinhardt-web)` failures on release PR #5255.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The release PR #5255 runs WASM Clippy with `-D warnings`. `reinhardt-web` enables `#![warn(missing_docs)]`, and two WASM-only compatibility stub surfaces were public without rustdoc comments.

Fixes #5260

Related to: #5255

## How Was This Tested?

- `CARGO_TARGET_DIR=/tmp/reinhardt-target-5260 cargo clippy --target wasm32-unknown-unknown -p reinhardt-web --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/reinhardt-target-5260 cargo clippy --target wasm32-unknown-unknown -p reinhardt-web --no-default-features --features pages,client-router,pages-web-sys-full,di --lib -- -D warnings`
- `cargo make fmt-check`
- `cargo make clippy-check`
- `git diff --check`

## Performance Impact

No runtime impact. Documentation-only source change.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5260
- Related to #5255

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [x] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The generated release branch should remain disposable. This fix targets `develop/0.2.0` so release-plz can regenerate the release PR cleanly after merge.

Generated with Codex