### PR TITLE
refactor(examples): rewrite rest tutorial example with DI and real database access

### DIFF
--- a/examples/examples-tutorial-rest/README.md
+++ b/examples/examples-tutorial-rest/README.md
@@ -4,15 +4,14 @@ This example demonstrates the concepts covered in the [Reinhardt REST Tutorial](
 
 ## What This Example Covers
 
-This example corresponds to the REST tutorial Quickstart and Tutorial 1-6:
+This example corresponds to the REST tutorial Parts 1-6:
 
-- **Quickstart** - Project setup, serializers, views, routing
-- **Tutorial 1: Serialization** - serde, validation, JSON serialization
-- **Tutorial 2: Requests and Responses** - Request object, Response builder, parameter extraction
-- **Tutorial 3: Class-Based Views** - Generic views (ListAPIView, CreateAPIView, etc.)
-- **Tutorial 4: Authentication & Permissions** - Authentication systems
-- **Tutorial 5: Relationships and Hyperlinked APIs** - Relationships and hyperlinked APIs
-- **Tutorial 6: ViewSets and Routers** - ViewSets, ModelViewSet, Router
+- **Part 1: Project Setup** - Project structure, settings, the `manage` CLI, the development server
+- **Part 2: Your First Endpoints** - `#[get]` / `#[post]` / `#[put]` / `#[delete]`, route `name = "..."`, `Path` / `Query` / `Json` extractors, `ViewResult`
+- **Part 3: Models and the Database** - `#[model]` `Snippet`, migrations, `migrate`, the builder API
+- **Part 4: Dependency Injection** - `#[inject] Depends<DatabaseConnection>`, `#[injectable]` / `#[injectable_factory]`, scopes, `TypeId`-keyed registration, the `Result<T, NewError>` pattern with `Depends<Result<T, E>>`. This is where the CRUD handlers are wired to the real ORM
+- **Part 5: Serializers and Validation** - `Validate` derive, `pre_validate = true`, error responses and status codes
+- **Part 6: Bonus — ViewSets and Routers** - the same CRUD compressed to ~15 lines with `ModelViewSet`; pagination, filtering, ordering
 
 ## Features
 
@@ -28,20 +27,27 @@ This example corresponds to the REST tutorial Quickstart and Tutorial 1-6:
 ### API Endpoints
 
 ```
-GET    /api/snippets/       - List all snippets
-POST   /api/snippets/       - Create a new snippet
-GET    /api/snippets/<id>/  - Retrieve a specific snippet
-PUT    /api/snippets/<id>/  - Update a snippet
-DELETE /api/snippets/<id>/  - Delete a snippet
+GET    /api/snippets/         - List all snippets
+POST   /api/snippets/         - Create a new snippet
+GET    /api/snippets/config/  - DI demonstration: list configuration (Depends<Result<T, E>>)
+GET    /api/snippets/<id>/    - Retrieve a specific snippet
+PUT    /api/snippets/<id>/    - Update a snippet
+DELETE /api/snippets/<id>/    - Delete a snippet
 ```
+
+All handlers receive a database connection through dependency injection
+(`#[inject] db: Depends<DatabaseConnection>`) and query the real ORM. The
+`/api/snippets/config/` endpoint is a teaching aid for
+`Depends<Result<T, E>>`; see `src/apps/snippets/di.rs`.
 
 ## Setup
 
 ### Prerequisites
 
 - Rust 1.75 or later
-- PostgreSQL (optional, for database features)
-- Docker (optional, for TestContainers in tests)
+- Docker, for the disposable PostgreSQL and Redis containers used by
+  `cargo make migrate` and `cargo make runserver`
+- PostgreSQL, only if you point `settings/local.toml` at an existing database
 
 ### Installation
 
@@ -52,8 +58,11 @@ cd examples/examples-tutorial-rest
 # Build the project
 cargo build
 
+# Apply migrations against the local disposable database
+cargo make migrate
+
 # Run tests
-cargo test
+cargo make test
 ```
 
 ## Usage
@@ -61,6 +70,10 @@ cargo test
 ### Run the Development Server
 
 ```bash
+# Apply migrations first. `runserver` also depends on `migrate`, but running
+# it explicitly makes first-run database problems easier to see.
+cargo make migrate
+
 cargo make runserver
 ```
 
@@ -154,6 +167,7 @@ examples-tutorial-rest/
 ├── src/
 │   ├── apps/
 │   │   ├── snippets/
+│   │   │   ├── di.rs
 │   │   │   ├── models.rs
 │   │   │   ├── serializers.rs
 │   │   │   ├── urls.rs
@@ -176,16 +190,17 @@ examples-tutorial-rest/
 
 This example is designed to be studied alongside the REST tutorial:
 
-1. **Start with the tutorial**: Read [Quickstart](../../website/content/quickstart/tutorials/rest/quickstart.md)
+1. **Start with the tutorial**: Read the [REST tutorial](../../website/content/quickstart/tutorials/rest/)
 2. **Examine the code**: Look at how concepts are implemented in this example
-3. **Run the tests**: `cargo test` to see the functionality in action
+3. **Run the tests**: `cargo make test` to see the functionality in action
 4. **Experiment**: Modify the code and see what happens
 
 ## Key Concepts Demonstrated
 
 - `src/apps/snippets/models.rs` defines the `Snippet` model with `#[model(app_label = "snippets", table_name = "snippets")]`, typed fields, `created_at`, and the `highlighted()` helper.
 - `src/apps/snippets/serializers.rs` defines `SnippetSerializer` with `Validate` length rules and `SnippetResponse::from_model()`.
-- `src/apps/snippets/views.rs` exposes function-based CRUD handlers with `#[get]`, `#[post(pre_validate = true)]`, `#[put]`, and `#[delete]`.
+- `src/apps/snippets/di.rs` registers a plain singleton config and a fallible `Result<SnippetListConfig, ConfigError>` factory to demonstrate TypeId-keyed DI registrations.
+- `src/apps/snippets/views.rs` exposes function-based CRUD handlers with `#[get]`, `#[post(pre_validate = true)]`, `#[put]`, and `#[delete]`, resolving `DatabaseConnection` through `Depends<DatabaseConnection>`.
 - `src/apps/snippets/views.rs` also exposes a `#[reinhardt::viewset(basename = "snippet")]` `ModelViewSet` with pagination, filtering, and ordering.
 - `src/apps/snippets/urls.rs` registers both function-based endpoints and ViewSet endpoints on one `ServerRouter`.
 - `src/config/urls.rs` uses `#[routes]` and mounts the snippets router under the literal `/api/` prefix.
@@ -198,53 +213,45 @@ Run the test suite:
 
 ```bash
 # Run all tests
-cargo test
+cargo make test
 
 # Run specific test
-cargo test test_snippet_model
+cargo nextest run --all-features test_snippet_model
 
 # Run with output
-cargo test -- --nocapture
+cargo nextest run --all-features --no-capture
 ```
 
-## ViewSets (Tutorial 6)
+## ViewSets (Part 6)
 
-This example demonstrates both function-based views (Tutorial 1-5) and ViewSet-based views (Tutorial 6). **Both are mounted simultaneously** on the same running server — there is no toggle between them. The two endpoint sets coexist under separate URL prefixes:
+This example demonstrates both function-based views (Parts 2-5) and
+ViewSet-based views (Part 6). **Both are mounted simultaneously** on the
+same running server; there is no toggle between them. The two endpoint sets
+coexist under separate URL prefixes:
 
 ```bash
+cargo make migrate
 cargo make runserver
 
-# Function-based endpoints (Tutorial 1-5)
+# Function-based endpoints (Parts 2-5)
 curl http://127.0.0.1:8000/api/snippets/
 
-# ViewSet endpoints (Tutorial 6)
+# ViewSet endpoints (Part 6)
 curl http://127.0.0.1:8000/api/snippets-viewset/
 ```
 
 The Bruno collection under `bruno/` contains a `Snippets CRUD` folder for the function-based path and a `Snippets ViewSet` folder for the ViewSet path; both can be exercised back-to-back without restarting the server.
 
-> **rc.23+ runtime behaviour**: Starting with reinhardt-web rc.23,
-> `ModelViewSet` (and `ReadOnlyModelViewSet`) issue **real database
-> queries** instead of returning skeleton `[]` / `{}` responses. To exercise
-> the ViewSet endpoints you must therefore migrate the `snippets` table
-> first:
->
-> ```bash
-> cargo make migrate
-> cargo make runserver
-> ```
->
-> Until rows are inserted, the `/api/snippets-viewset/` endpoints will
-> return an empty list. The function-based path (`/api/snippets/`) is
-> unaffected — it falls back to in-memory sample snippets defined in
-> `views.rs::get_sample_snippets`.
+Both endpoint sets issue real database queries. Until rows are inserted, both
+paths return empty lists. Create rows with either `POST /api/snippets/` or
+`POST /api/snippets-viewset/`, then list or retrieve them through either path.
 
 ### Comparison
 
 | Approach | Code Lines | Features |
 |----------|------------|----------|
-| Function-based (Tutorial 1-5) | ~200 lines | Full control, explicit implementation |
-| ViewSet-based (Tutorial 6) | ~15 lines | CRUD automation, pagination, filtering, ordering |
+| Function-based (Parts 2-5) | ~200 lines | Full control, explicit implementation |
+| ViewSet-based (Part 6) | ~15 lines | CRUD automation, pagination, filtering, ordering |
 
 ### ViewSet Features
 
@@ -273,13 +280,13 @@ curl "http://127.0.0.1:8000/api/snippets-viewset/?language=rust&ordering=-title&
 
 ### When to Use Each Approach
 
-**Function-based views (Tutorial 1-5)**:
+**Function-based views (Parts 2-5)**:
 - Simple endpoints with custom logic
 - Non-standard RESTful patterns
 - When you need fine-grained control
 - Learning HTTP handling basics
 
-**ViewSet-based views (Tutorial 6)**:
+**ViewSet-based views (Part 6)**:
 - Standard RESTful CRUD APIs
 - When pagination, filtering, and ordering are needed
 - Rapid API development
@@ -292,9 +299,8 @@ After understanding this example:
 1. **Compare both approaches**: Try switching between function-based and ViewSet-based
 2. **Understand the trade-offs**: When to use each approach (see above)
 3. **Add custom actions**: Extend ViewSets with `#[action]` decorator for non-CRUD endpoints
-4. **Add database integration**: Implement actual database storage instead of in-memory sample data
-5. **Add authentication**: Implement JWT/Token/Session auth for both approaches
-6. **Add permissions**: Implement permission classes to control access
+4. **Add authentication**: Implement JWT, token, or session auth for both approaches
+5. **Add permissions**: Implement permission classes to control access
 
 ## Related Documentation
 

--- a/examples/examples-tutorial-rest/src/apps/snippets.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets.rs
@@ -8,6 +8,7 @@
 
 use reinhardt::app_config;
 
+pub mod di;
 pub mod models;
 pub mod serializers;
 pub mod urls;

--- a/examples/examples-tutorial-rest/src/apps/snippets/di.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/di.rs
@@ -1,0 +1,63 @@
+//! DI registrations for the snippets app.
+//!
+//! The DI registry keys every factory by the `TypeId` of its literal
+//! return type. Two factories returning the same `T` would collide, so
+//! when a second flavour of a dependency is needed, either introduce a
+//! dedicated newtype or return `Result<T, FactoryLocalError>` — each
+//! distinct error type yields a distinct registry key.
+//!
+//! [`SnippetListConfig`] is registered as a plain `#[injectable]` singleton
+//! (key: `TypeId::of::<SnippetListConfig>()`). `checked_list_config` is a
+//! second factory that also produces a `SnippetListConfig` on success, but
+//! its return type is `Result<SnippetListConfig, ConfigError>`
+//! (key: `TypeId::of::<Result<SnippetListConfig, ConfigError>>()`) — a
+//! distinct registry entry that does not collide with the plain factory
+//! above. `views::config` consumes it via `Depends<Result<SnippetListConfig,
+//! ConfigError>>`.
+
+use reinhardt::di::{Depends, injectable, injectable_factory};
+
+/// Snippet listing configuration resolved through DI.
+///
+/// Registered as a singleton with no `#[inject]` fields, so
+/// `#[injectable]` falls back to `Self::default()` — see the manual
+/// `Default` impl below for the actual default value.
+#[injectable(scope = "singleton")]
+pub struct SnippetListConfig {
+	#[no_inject]
+	pub max_page_size: usize,
+}
+
+impl Default for SnippetListConfig {
+	fn default() -> Self {
+		// A non-zero default so the checked factory below succeeds out of the box.
+		Self { max_page_size: 50 }
+	}
+}
+
+/// Error type local to `checked_list_config`.
+///
+/// Its only job is to make the factory's `Result<SnippetListConfig,
+/// ConfigError>` return type a distinct DI registry key from the plain
+/// `SnippetListConfig` registered above.
+#[derive(Debug)]
+pub struct ConfigError(pub String);
+
+/// Fallible variant of [`SnippetListConfig`], registered under the
+/// `Result<SnippetListConfig, ConfigError>` key.
+///
+/// Re-validates the plain `SnippetListConfig` singleton and surfaces a
+/// [`ConfigError`] if `max_page_size` is not positive, demonstrating how
+/// `#[injectable_factory]` factories can return `Result<T, E>` to obtain a
+/// registry key distinct from `T` while reusing `T`'s public fields.
+#[injectable_factory(scope = "singleton")]
+async fn checked_list_config(
+	#[inject] base: Depends<SnippetListConfig>,
+) -> Result<SnippetListConfig, ConfigError> {
+	if base.max_page_size == 0 {
+		return Err(ConfigError("max_page_size must be positive".into()));
+	}
+	Ok(SnippetListConfig {
+		max_page_size: base.max_page_size,
+	})
+}

--- a/examples/examples-tutorial-rest/src/apps/snippets/urls.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/urls.rs
@@ -30,11 +30,14 @@ pub fn url_patterns() -> ServerRouter {
 		// Function-based endpoints (Tutorial 1-5)
 		// - GET    /snippets/        — views::list
 		// - POST   /snippets/        — views::create
+		// - GET    /snippets/config/ — views::config (registered before
+		//   the `{id}` route below so this literal path is matched first)
 		// - GET    /snippets/{id}/   — views::retrieve
 		// - PUT    /snippets/{id}/   — views::update
 		// - DELETE /snippets/{id}/   — views::delete
 		.endpoint(views::list)
 		.endpoint(views::create)
+		.endpoint(views::config)
 		.endpoint(views::retrieve)
 		.endpoint(views::update)
 		.endpoint(views::delete)

--- a/examples/examples-tutorial-rest/src/apps/snippets/views.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/views.rs
@@ -82,9 +82,12 @@ pub async fn config(
 /// Success response: 200 OK with array of snippets
 #[get("/snippets/", name = "snippets-list")]
 pub async fn list(#[inject] db: Depends<DatabaseConnection>) -> ViewResult<Response> {
-	// `Depends<T>` implements `Deref<Target = T>`, so `&*db` borrows the
-	// underlying `DatabaseConnection` that the DI container resolved.
-	let snippets = Manager::<Snippet>::new().all().all_with_db(&*db).await?;
+	// `Depends<T>` implements `Deref<Target = T>`. `all_with_db` wants a
+	// `&DatabaseConnection`, so passing `&db` lets deref coercion turn
+	// `&Depends<DatabaseConnection>` into `&DatabaseConnection` for free.
+	// (To take the value by reference explicitly you would write `&*db`; the
+	// `config` handler above shows the explicit `*db` form where it is needed.)
+	let snippets = Manager::<Snippet>::new().all().all_with_db(&db).await?;
 	let snippet_responses: Vec<SnippetResponse> =
 		snippets.iter().map(SnippetResponse::from_model).collect();
 
@@ -128,7 +131,7 @@ pub async fn create(
 		.finish();
 
 	let created = Manager::<Snippet>::new()
-		.create_with_conn(&*db, &snippet)
+		.create_with_conn(&db, &snippet)
 		.await?;
 
 	let response_data = json!({
@@ -155,7 +158,7 @@ pub async fn retrieve(
 ) -> ViewResult<Response> {
 	let snippets = Manager::<Snippet>::new()
 		.get(snippet_id)
-		.all_with_db(&*db)
+		.all_with_db(&db)
 		.await?;
 
 	let snippet = match snippets.first() {
@@ -200,7 +203,7 @@ pub async fn update(
 	serializer.validate()?;
 
 	let manager = Manager::<Snippet>::new();
-	let existing = manager.get(snippet_id).all_with_db(&*db).await?;
+	let existing = manager.get(snippet_id).all_with_db(&db).await?;
 
 	let mut snippet = match existing.into_iter().next() {
 		Some(snippet) => snippet,
@@ -216,7 +219,7 @@ pub async fn update(
 	snippet.code = serializer.code.clone();
 	snippet.language = serializer.language.clone();
 
-	let updated = manager.update_with_conn(&*db, &snippet).await?;
+	let updated = manager.update_with_conn(&db, &snippet).await?;
 
 	let response_data = json!({
 		"message": "Snippet updated",
@@ -241,7 +244,7 @@ pub async fn delete(
 	#[inject] db: Depends<DatabaseConnection>,
 ) -> ViewResult<Response> {
 	let manager = Manager::<Snippet>::new();
-	let existing = manager.get(snippet_id).all_with_db(&*db).await?;
+	let existing = manager.get(snippet_id).all_with_db(&db).await?;
 
 	if existing.is_empty() {
 		let error = json::to_string(&json!({"error": "Snippet not found"}))?;
@@ -250,7 +253,7 @@ pub async fn delete(
 			.with_body(error));
 	}
 
-	manager.delete_with_conn(&*db, snippet_id).await?;
+	manager.delete_with_conn(&db, snippet_id).await?;
 
 	// Return 204 No Content for successful deletion
 	Ok(Response::new(StatusCode::NO_CONTENT))

--- a/examples/examples-tutorial-rest/src/apps/snippets/views.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/views.rs
@@ -1,7 +1,9 @@
-use chrono::Utc;
 use json::json;
 use reinhardt::Validate;
 use reinhardt::core::serde::json;
+use reinhardt::db::DatabaseConnection;
+use reinhardt::db::orm::Manager;
+use reinhardt::di::Depends;
 use reinhardt::http::ViewResult;
 use reinhardt::{Json, Path, Response, StatusCode};
 use reinhardt::{delete, get, post, put};
@@ -25,51 +27,19 @@ use reinhardt::{delete, get, post, put};
 use super::models::Snippet;
 use super::serializers::{SnippetResponse, SnippetSerializer};
 
-/// Helper function to get sample snippets for demonstration
-fn get_sample_snippets() -> Vec<Snippet> {
-	vec![
-		Snippet {
-			id: 1,
-			title: "Hello World".to_string(),
-			code: "fn main() {\n    println!(\"Hello, World!\");\n}".to_string(),
-			language: "rust".to_string(),
-			created_at: Utc::now(),
-		},
-		Snippet {
-			id: 2,
-			title: "Fibonacci".to_string(),
-			code: "def fibonacci(n):\n    if n <= 1:\n        return n\n    return fibonacci(n-1) + fibonacci(n-2)".to_string(),
-			language: "python".to_string(),
-			created_at: Utc::now(),
-		},
-		Snippet {
-			id: 3,
-			title: "Quick Sort".to_string(),
-			code: "function quickSort(arr) {\n  if (arr.length <= 1) return arr;\n  const pivot = arr[0];\n  const left = arr.slice(1).filter(x => x < pivot);\n  const right = arr.slice(1).filter(x => x >= pivot);\n  return [...quickSort(left), pivot, ...quickSort(right)];\n}".to_string(),
-			language: "javascript".to_string(),
-			created_at: Utc::now(),
-		},
-	]
-}
-
 /// List all snippets
 ///
 /// GET /snippets/
 /// Success response: 200 OK with array of snippets
 #[get("/snippets/", name = "snippets-list")]
-pub async fn list() -> ViewResult<Response> {
-	// Production ORM usage:
-	// let snippets = Manager::<Snippet>::new().all().await?;
-
-	// Demo mode: Use sample data
-	let snippets = get_sample_snippets();
+pub async fn list(#[inject] db: Depends<DatabaseConnection>) -> ViewResult<Response> {
+	// `Depends<T>` implements `Deref<Target = T>`, so `&*db` borrows the
+	// underlying `DatabaseConnection` that the DI container resolved.
+	let snippets = Manager::<Snippet>::new().all().all_with_db(&*db).await?;
 	let snippet_responses: Vec<SnippetResponse> =
 		snippets.iter().map(SnippetResponse::from_model).collect();
 
-	let response_data = json!({
-		"snippets": snippet_responses
-	});
-
+	let response_data = json!({ "snippets": snippet_responses });
 	let json = json::to_string(&response_data)?;
 	Ok(Response::new(StatusCode::OK)
 		.with_header("Content-Type", "application/json")
@@ -86,32 +56,33 @@ pub async fn list() -> ViewResult<Response> {
 ///   macro option below — the macro returns HTTP 400 with a JSON error body
 ///   before this function body runs)
 #[post("/snippets/", name = "snippets-create", pre_validate = true)]
-pub async fn create(Json(serializer): Json<SnippetSerializer>) -> ViewResult<Response> {
+pub async fn create(
+	Json(serializer): Json<SnippetSerializer>,
+	#[inject] db: Depends<DatabaseConnection>,
+) -> ViewResult<Response> {
 	// `pre_validate = true` on the route macro extracts `Json<SnippetSerializer>`
 	// into a temporary, calls `Validate::validate(&__tmp)`, then re-destructures
 	// into the original `Json(serializer)` binding. No manual `serializer.validate()?`
 	// is needed (the previous explicit call was redundant once `pre_validate`
 	// was introduced in rc.5).
 
-	// Production ORM usage:
-	// let snippet = Manager::<Snippet>::new().create(Snippet {
-	//     id: 0, // Auto-generated
-	//     title: serializer.title.clone(),
-	//     code: serializer.code.clone(),
-	//     language: serializer.language.clone(),
-	//     created_at: Utc::now(),
-	// }).await?;
-
-	// Demo mode: construct a mock snippet via the macro-generated builder.
+	// `Snippet::build()` is the macro-generated typestate builder (see
+	// `#[model]` on `Snippet`). `id` defaults to `0`, which `create_with_conn`
+	// recognizes as "auto-increment" and omits from the INSERT statement, and
+	// `created_at` is populated by the database via `auto_now_add = true`.
 	let snippet = Snippet::build()
 		.title(serializer.title.clone())
 		.code(serializer.code.clone())
 		.language(serializer.language.clone())
 		.finish();
 
+	let created = Manager::<Snippet>::new()
+		.create_with_conn(&*db, &snippet)
+		.await?;
+
 	let response_data = json!({
 		"message": "Snippet created",
-		"snippet": SnippetResponse::from_model(&snippet)
+		"snippet": SnippetResponse::from_model(&created)
 	});
 
 	let json = json::to_string(&response_data)?;
@@ -127,13 +98,16 @@ pub async fn create(Json(serializer): Json<SnippetSerializer>) -> ViewResult<Res
 /// Error responses:
 /// - 404 Not Found: Snippet not found
 #[get("/snippets/{id}/", name = "snippets-retrieve")]
-pub async fn retrieve(Path(snippet_id): Path<i64>) -> ViewResult<Response> {
-	// Production ORM usage:
-	// let snippet = Manager::<Snippet>::new().get(snippet_id).await?;
+pub async fn retrieve(
+	Path(snippet_id): Path<i64>,
+	#[inject] db: Depends<DatabaseConnection>,
+) -> ViewResult<Response> {
+	let snippets = Manager::<Snippet>::new()
+		.get(snippet_id)
+		.all_with_db(&*db)
+		.await?;
 
-	// Demo mode: Find in sample data
-	let snippets = get_sample_snippets();
-	let snippet = match snippets.iter().find(|s| s.id == snippet_id) {
+	let snippet = match snippets.first() {
 		Some(snippet) => snippet,
 		None => {
 			let error = json::to_string(&json!({"error": "Snippet not found"}))?;
@@ -168,21 +142,16 @@ pub async fn retrieve(Path(snippet_id): Path<i64>) -> ViewResult<Response> {
 pub async fn update(
 	Path(snippet_id): Path<i64>,
 	Json(serializer): Json<SnippetSerializer>,
+	#[inject] db: Depends<DatabaseConnection>,
 ) -> ViewResult<Response> {
 	// Manual validation — see module-level comment on why `pre_validate = true`
 	// is not used here.
 	serializer.validate()?;
 
-	// Production ORM usage:
-	// let snippet = Manager::<Snippet>::new().update(snippet_id, |s| {
-	//     s.title = serializer.title.clone();
-	//     s.code = serializer.code.clone();
-	//     s.language = serializer.language.clone();
-	// }).await?;
+	let manager = Manager::<Snippet>::new();
+	let existing = manager.get(snippet_id).all_with_db(&*db).await?;
 
-	// Demo mode: Verify snippet exists and return updated version
-	let snippets = get_sample_snippets();
-	let existing = match snippets.iter().find(|s| s.id == snippet_id) {
+	let mut snippet = match existing.into_iter().next() {
 		Some(snippet) => snippet,
 		None => {
 			let error = json::to_string(&json!({"error": "Snippet not found"}))?;
@@ -192,20 +161,15 @@ pub async fn update(
 		}
 	};
 
-	// Build the updated snippet via the macro-generated builder, then
-	// preserve the original identifier and creation timestamp so the mock
-	// response remains consistent with the stored record.
-	let mut updated_snippet = Snippet::build()
-		.title(serializer.title.clone())
-		.code(serializer.code.clone())
-		.language(serializer.language.clone())
-		.finish();
-	updated_snippet.id = existing.id;
-	updated_snippet.created_at = existing.created_at;
+	snippet.title = serializer.title.clone();
+	snippet.code = serializer.code.clone();
+	snippet.language = serializer.language.clone();
+
+	let updated = manager.update_with_conn(&*db, &snippet).await?;
 
 	let response_data = json!({
 		"message": "Snippet updated",
-		"snippet": SnippetResponse::from_model(&updated_snippet)
+		"snippet": SnippetResponse::from_model(&updated)
 	});
 
 	let json = json::to_string(&response_data)?;
@@ -221,18 +185,21 @@ pub async fn update(
 /// Error responses:
 /// - 404 Not Found: Snippet not found
 #[delete("/snippets/{id}/", name = "snippets-delete")]
-pub async fn delete(Path(snippet_id): Path<i64>) -> ViewResult<Response> {
-	// Production ORM usage:
-	// Manager::<Snippet>::new().delete(snippet_id).await?;
+pub async fn delete(
+	Path(snippet_id): Path<i64>,
+	#[inject] db: Depends<DatabaseConnection>,
+) -> ViewResult<Response> {
+	let manager = Manager::<Snippet>::new();
+	let existing = manager.get(snippet_id).all_with_db(&*db).await?;
 
-	// Demo mode: Verify snippet exists
-	let snippets = get_sample_snippets();
-	if !snippets.iter().any(|s| s.id == snippet_id) {
+	if existing.is_empty() {
 		let error = json::to_string(&json!({"error": "Snippet not found"}))?;
 		return Ok(Response::new(StatusCode::NOT_FOUND)
 			.with_header("Content-Type", "application/json")
 			.with_body(error));
 	}
+
+	manager.delete_with_conn(&*db, snippet_id).await?;
 
 	// Return 204 No Content for successful deletion
 	Ok(Response::new(StatusCode::NO_CONTENT))

--- a/examples/examples-tutorial-rest/src/apps/snippets/views.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/views.rs
@@ -245,9 +245,9 @@ pub async fn delete(
 /// ViewSet endpoints (under `/api/snippets-viewset/`) are served by the
 /// same process — `crate::apps::snippets::urls::url_patterns` registers
 /// them on a single `ServerRouter` with no `USE_VIEWSET`-style toggle.
-/// Unlike the function-based views above (which fall back to in-memory
-/// `get_sample_snippets()` data for demonstration), the ViewSet path will
-/// observe an empty list until rows are inserted into the `snippets` table.
+/// Like the function-based views above, the ViewSet path queries the real
+/// database, so both observe an empty list until rows are inserted into the
+/// `snippets` table.
 #[reinhardt::viewset(basename = "snippet")]
 pub fn viewset() -> reinhardt::ModelViewSet<Snippet, SnippetSerializer> {
 	use reinhardt::ModelViewSet;

--- a/examples/examples-tutorial-rest/src/apps/snippets/views.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/views.rs
@@ -68,8 +68,10 @@ pub async fn create(
 
 	// `Snippet::build()` is the macro-generated typestate builder (see
 	// `#[model]` on `Snippet`). `id` defaults to `0`, which `create_with_conn`
-	// recognizes as "auto-increment" and omits from the INSERT statement, and
-	// `created_at` is populated by the database via `auto_now_add = true`.
+	// recognizes as "auto-increment" and omits from the INSERT statement.
+	// `created_at` is stamped client-side with `Utc::now()` by the builder
+	// because the field is declared `auto_now_add = true`, so it is sent as a
+	// concrete value in the INSERT.
 	let snippet = Snippet::build()
 		.title(serializer.title.clone())
 		.code(serializer.code.clone())

--- a/examples/examples-tutorial-rest/src/apps/snippets/views.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/views.rs
@@ -24,8 +24,57 @@ use reinhardt::{delete, get, post, put};
 // `serializer.validate()?` call below — hence the `use reinhardt::Validate`
 // import above is intentional.
 
+use super::di::{ConfigError, SnippetListConfig};
 use super::models::Snippet;
 use super::serializers::{SnippetResponse, SnippetSerializer};
+
+/// Snippet listing configuration endpoint.
+///
+/// Demonstrates the `Depends<Result<T, E>>` form (the `DependsResult<T, E>`
+/// type alias expands to this, but route handlers must spell it out — see
+/// below): the `checked_list_config` factory in `di.rs` returns
+/// `Result<SnippetListConfig, ConfigError>`, so its registry key
+/// (`TypeId::of::<Result<SnippetListConfig, ConfigError>>()`) is distinct
+/// from the plain `SnippetListConfig` factory's key
+/// (`TypeId::of::<SnippetListConfig>()`) even though the success type is
+/// identical.
+///
+/// `#[get]` resolves `#[inject]` parameters of the literal form
+/// `Depends<T>` via `resolve_from_registry::<T>()` (no `T: Injectable`
+/// bound — see `crates/reinhardt-core/macros/src/routes_registration.rs`).
+/// That single-generic-argument match does not recognise the
+/// `DependsResult<T, E>` / `DependsOption<T>` sugar aliases (those are
+/// resolved by `#[injectable]` struct fields and `#[injectable_factory]`
+/// parameters instead), so route handlers spell out
+/// `Depends<Result<T, E>>` to take this path.
+///
+/// Registered before `retrieve` (`/snippets/{id}/`) in `urls.rs` so this
+/// literal `/snippets/config/` path is matched first.
+///
+/// GET /snippets/config/
+/// Success response: 200 OK with `{ "max_page_size": <usize> }`
+/// Error response: 503 Service Unavailable with `{ "error": <message> }`
+#[get("/snippets/config/", name = "snippets-config")]
+pub async fn config(
+	#[inject] cfg: Depends<Result<SnippetListConfig, ConfigError>>,
+) -> ViewResult<Response> {
+	// `Depends<Result<T, E>>` derefs to `Result<T, E>`. `.as_ref()` matches on
+	// `Result<&SnippetListConfig, &ConfigError>` without consuming `cfg`.
+	match (*cfg).as_ref() {
+		Ok(cfg) => {
+			let body = json::to_string(&json!({ "max_page_size": cfg.max_page_size }))?;
+			Ok(Response::new(StatusCode::OK)
+				.with_header("Content-Type", "application/json")
+				.with_body(body))
+		}
+		Err(ConfigError(msg)) => {
+			let body = json::to_string(&json!({ "error": msg }))?;
+			Ok(Response::new(StatusCode::SERVICE_UNAVAILABLE)
+				.with_header("Content-Type", "application/json")
+				.with_body(body))
+		}
+	}
+}
 
 /// List all snippets
 ///

--- a/examples/examples-tutorial-rest/tests/integration.rs
+++ b/examples/examples-tutorial-rest/tests/integration.rs
@@ -1,42 +1,48 @@
 //! Integration tests for snippets application
+//!
+//! The `snippets` views (`apps::snippets::views::{list, create, retrieve,
+//! update, delete}`) take `#[inject] db: Depends<DatabaseConnection>`, which
+//! requires a resolved DI container to invoke directly. Standing up the full
+//! DI container in a unit test is out of scope here (see Task A3 notes), so
+//! these tests exercise the `Manager::<Snippet>` ORM layer that the handlers
+//! delegate to, against a real `DatabaseConnection` backed by a temporary
+//! SQLite file. This covers the exact data-access path used by every view
+//! (`all_with_db`, `get(..).all_with_db`, `create_with_conn`,
+//! `update_with_conn`, `delete_with_conn`) while satisfying the project rule
+//! that every test uses at least one Reinhardt component.
 
 #[cfg(with_reinhardt)]
 mod tests {
+	use reinhardt::DatabaseConnection;
+	use reinhardt::db::orm::{Filter, FilterOperator, FilterValue, Manager};
+	use reinhardt::test::fixtures::create_table_for_model;
 	use rstest::*;
-	use sqlx::SqlitePool;
-	use std::sync::Arc;
 	use tempfile::NamedTempFile;
 
+	use examples_tutorial_rest::apps::snippets::models::Snippet;
+
+	/// Fixture: temporary SQLite database with the `snippets` table created
+	/// from the `Snippet` model metadata via `create_table_for_model`.
 	#[fixture]
-	async fn sqlite_with_migrations() -> (NamedTempFile, Arc<SqlitePool>) {
+	async fn sqlite_with_migrations() -> (NamedTempFile, DatabaseConnection) {
 		// Create temp file
 		let temp_file = NamedTempFile::new().expect("Failed to create temp file");
 		let db_path = temp_file.path().to_str().unwrap().to_string();
-		let database_url = format!("sqlite://{}?mode=rwc", db_path);
 
-		// Connect to SQLite
-		let pool = SqlitePool::connect(&database_url)
+		// `connect_sqlite` automatically sets `create_if_missing(true)`.
+		let database_url = format!("sqlite:///{}", db_path);
+
+		let conn = DatabaseConnection::connect_sqlite(&database_url)
 			.await
-			.expect("Failed to connect to SQLite");
-		let pool = Arc::new(pool);
+			.expect("Failed to create DatabaseConnection");
 
-		// Manual table creation (SQLite)
-		let create_snippets_table = r#"
-			CREATE TABLE IF NOT EXISTS snippets (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				title VARCHAR(255) NOT NULL,
-				code TEXT NOT NULL,
-				language VARCHAR(50) NOT NULL,
-				created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-			)
-		"#;
-
-		sqlx::query(create_snippets_table)
-			.execute(pool.as_ref())
+		// Create the `snippets` table from the `Snippet` model metadata.
+		// `create_table_for_model` operates on the inner backend connection.
+		create_table_for_model::<Snippet>(conn.inner())
 			.await
 			.expect("Failed to create snippets table");
 
-		(temp_file, pool)
+		(temp_file, conn)
 	}
 
 	// ============================================================================
@@ -91,670 +97,455 @@ mod tests {
 	}
 
 	// ============================================================================
-	// Database Integration Tests - CRUD Operations (4 tests)
+	// Database Integration Tests - CRUD Operations
 	// ============================================================================
 
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_create(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
 	) {
-		let (_file, pool) = sqlite_with_migrations.await;
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Create a snippet
-		let result: (i64, String, String, String) = sqlx::query_as(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES ($1, $2, $3)
-			RETURNING id, title, code, language
-			"#,
-		)
-		.bind("Test Snippet")
-		.bind("fn main() {}")
-		.bind("rust")
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to create snippet");
+		// Arrange
+		let snippet = Snippet::build()
+			.title("Test Snippet")
+			.code("fn main() {}")
+			.language("rust")
+			.finish();
 
-		assert_eq!(result.1, "Test Snippet");
-		assert_eq!(result.2, "fn main() {}");
-		assert_eq!(result.3, "rust");
+		// Act
+		let created = Manager::<Snippet>::new()
+			.create_with_conn(&conn, &snippet)
+			.await
+			.expect("Failed to create snippet");
+
+		// Assert
+		assert_eq!(created.title, "Test Snippet");
+		assert_eq!(created.code, "fn main() {}");
+		assert_eq!(created.language, "rust");
+		assert!(created.id > 0, "created snippet should have an assigned id");
 	}
 
 	#[rstest]
 	#[tokio::test]
-	async fn test_snippet_read(#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>)) {
-		let (_file, pool) = sqlite_with_migrations.await;
+	async fn test_snippet_read(
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+	) {
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Create a snippet
-		let created: (i64,) = sqlx::query_as(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES ($1, $2, $3)
-			RETURNING id
-			"#,
-		)
-		.bind("Read Test")
-		.bind("println!(\"Hello\");")
-		.bind("rust")
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to create snippet");
+		// Arrange
+		let snippet = Snippet::build()
+			.title("Read Test")
+			.code("println!(\"Hello\");")
+			.language("rust")
+			.finish();
+		let created = Manager::<Snippet>::new()
+			.create_with_conn(&conn, &snippet)
+			.await
+			.expect("Failed to create snippet");
 
-		// Read the snippet
-		let result: (i64, String, String, String) = sqlx::query_as(
-			r#"
-			SELECT id, title, code, language
-			FROM snippets
-			WHERE id = $1
-			"#,
-		)
-		.bind(created.0)
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to read snippet");
+		// Act
+		let found = Manager::<Snippet>::new()
+			.get(created.id)
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to read snippet");
 
-		assert_eq!(result.0, created.0);
-		assert_eq!(result.1, "Read Test");
-		assert_eq!(result.2, "println!(\"Hello\");");
-		assert_eq!(result.3, "rust");
+		// Assert
+		assert_eq!(found.len(), 1);
+		assert_eq!(found[0].id, created.id);
+		assert_eq!(found[0].title, "Read Test");
+		assert_eq!(found[0].code, "println!(\"Hello\");");
+		assert_eq!(found[0].language, "rust");
 	}
 
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_update(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
 	) {
-		let (_file, pool) = sqlite_with_migrations.await;
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Create a snippet
-		let created: (i64,) = sqlx::query_as(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES ($1, $2, $3)
-			RETURNING id
-			"#,
-		)
-		.bind("Original Title")
-		.bind("original code")
-		.bind("python")
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to create snippet");
+		// Arrange
+		let snippet = Snippet::build()
+			.title("Original Title")
+			.code("original code")
+			.language("python")
+			.finish();
+		let manager = Manager::<Snippet>::new();
+		let created = manager
+			.create_with_conn(&conn, &snippet)
+			.await
+			.expect("Failed to create snippet");
 
-		// Update the snippet
-		let updated: (i64, String, String, String) = sqlx::query_as(
-			r#"
-			UPDATE snippets
-			SET title = $1, code = $2, language = $3
-			WHERE id = $4
-			RETURNING id, title, code, language
-			"#,
-		)
-		.bind("Updated Title")
-		.bind("updated code")
-		.bind("javascript")
-		.bind(created.0)
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to update snippet");
+		let mut to_update = created.clone();
+		to_update.title = "Updated Title".to_string();
+		to_update.code = "updated code".to_string();
+		to_update.language = "javascript".to_string();
 
-		assert_eq!(updated.0, created.0);
-		assert_eq!(updated.1, "Updated Title");
-		assert_eq!(updated.2, "updated code");
-		assert_eq!(updated.3, "javascript");
+		// Act
+		let updated = manager
+			.update_with_conn(&conn, &to_update)
+			.await
+			.expect("Failed to update snippet");
+
+		// Assert
+		assert_eq!(updated.id, created.id);
+		assert_eq!(updated.title, "Updated Title");
+		assert_eq!(updated.code, "updated code");
+		assert_eq!(updated.language, "javascript");
 	}
 
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_delete(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
 	) {
-		let (_file, pool) = sqlite_with_migrations.await;
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Create a snippet
-		let created: (i64,) = sqlx::query_as(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES ($1, $2, $3)
-			RETURNING id
-			"#,
-		)
-		.bind("To Delete")
-		.bind("delete me")
-		.bind("rust")
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to create snippet");
+		// Arrange
+		let snippet = Snippet::build()
+			.title("To Delete")
+			.code("delete me")
+			.language("rust")
+			.finish();
+		let manager = Manager::<Snippet>::new();
+		let created = manager
+			.create_with_conn(&conn, &snippet)
+			.await
+			.expect("Failed to create snippet");
 
-		// Delete the snippet
-		let deleted_rows = sqlx::query(
-			r#"
-			DELETE FROM snippets
-			WHERE id = $1
-			"#,
-		)
-		.bind(created.0)
-		.execute(pool.as_ref())
-		.await
-		.expect("Failed to delete snippet")
-		.rows_affected();
+		// Act
+		manager
+			.delete_with_conn(&conn, created.id)
+			.await
+			.expect("Failed to delete snippet");
 
-		assert_eq!(deleted_rows, 1);
-
-		// Verify deletion
-		let result: Option<(i64,)> = sqlx::query_as(
-			r#"
-			SELECT id FROM snippets WHERE id = $1
-			"#,
-		)
-		.bind(created.0)
-		.fetch_optional(pool.as_ref())
-		.await
-		.expect("Failed to verify deletion");
-
-		assert!(result.is_none());
+		// Assert
+		let remaining = manager
+			.get(created.id)
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to query after deletion");
+		assert_eq!(remaining.len(), 0);
 	}
 
 	// ============================================================================
-	// Database Integration Tests - Query Operations (4 tests)
+	// Database Integration Tests - Query Operations
 	// ============================================================================
 
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_list_all(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
 	) {
-		let (_file, pool) = sqlite_with_migrations.await;
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Create multiple snippets
-		sqlx::query(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES
-				($1, $2, $3),
-				($4, $5, $6),
-				($7, $8, $9)
-			"#,
-		)
-		.bind("Snippet 1")
-		.bind("code 1")
-		.bind("rust")
-		.bind("Snippet 2")
-		.bind("code 2")
-		.bind("python")
-		.bind("Snippet 3")
-		.bind("code 3")
-		.bind("javascript")
-		.execute(pool.as_ref())
-		.await
-		.expect("Failed to create snippets");
+		// Arrange
+		let manager = Manager::<Snippet>::new();
+		for (title, language) in [
+			("Snippet 1", "rust"),
+			("Snippet 2", "python"),
+			("Snippet 3", "javascript"),
+		] {
+			let snippet = Snippet::build()
+				.title(title)
+				.code(format!("code for {}", title))
+				.language(language)
+				.finish();
+			manager
+				.create_with_conn(&conn, &snippet)
+				.await
+				.expect("Failed to create snippet");
+		}
 
-		// List all snippets
-		let snippets: Vec<(i64, String, String, String)> = sqlx::query_as(
-			r#"
-			SELECT id, title, code, language
-			FROM snippets
-			ORDER BY id
-			"#,
-		)
-		.fetch_all(pool.as_ref())
-		.await
-		.expect("Failed to list snippets");
+		// Act
+		let snippets = manager
+			.all()
+			.order_by(&["id"])
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to list snippets");
 
+		// Assert
 		assert_eq!(snippets.len(), 3);
-		assert_eq!(snippets[0].1, "Snippet 1");
-		assert_eq!(snippets[1].1, "Snippet 2");
-		assert_eq!(snippets[2].1, "Snippet 3");
+		assert_eq!(snippets[0].title, "Snippet 1");
+		assert_eq!(snippets[1].title, "Snippet 2");
+		assert_eq!(snippets[2].title, "Snippet 3");
 	}
 
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_filter_by_language(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
 	) {
-		let (_file, pool) = sqlite_with_migrations.await;
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Create snippets with different languages
-		sqlx::query(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES
-				($1, $2, $3),
-				($4, $5, $6),
-				($7, $8, $9)
-			"#,
-		)
-		.bind("Rust Snippet")
-		.bind("fn main() {}")
-		.bind("rust")
-		.bind("Python Snippet")
-		.bind("print('hello')")
-		.bind("python")
-		.bind("Another Rust")
-		.bind("let x = 5;")
-		.bind("rust")
-		.execute(pool.as_ref())
-		.await
-		.expect("Failed to create snippets");
+		// Arrange
+		let manager = Manager::<Snippet>::new();
+		for (title, code, language) in [
+			("Rust Snippet", "fn main() {}", "rust"),
+			("Python Snippet", "print('hello')", "python"),
+			("Another Rust", "let x = 5;", "rust"),
+		] {
+			let snippet = Snippet::build()
+				.title(title)
+				.code(code)
+				.language(language)
+				.finish();
+			manager
+				.create_with_conn(&conn, &snippet)
+				.await
+				.expect("Failed to create snippet");
+		}
 
-		// Filter by language
-		let rust_snippets: Vec<(i64, String, String, String)> = sqlx::query_as(
-			r#"
-			SELECT id, title, code, language
-			FROM snippets
-			WHERE language = $1
-			ORDER BY id
-			"#,
-		)
-		.bind("rust")
-		.fetch_all(pool.as_ref())
-		.await
-		.expect("Failed to filter snippets");
+		// Act
+		let filter = Filter::new(
+			"language",
+			FilterOperator::Eq,
+			FilterValue::String("rust".to_string()),
+		);
+		let rust_snippets = manager
+			.filter(filter)
+			.order_by(&["id"])
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to filter snippets");
 
+		// Assert
 		assert_eq!(rust_snippets.len(), 2);
-		assert_eq!(rust_snippets[0].1, "Rust Snippet");
-		assert_eq!(rust_snippets[1].1, "Another Rust");
+		assert_eq!(rust_snippets[0].title, "Rust Snippet");
+		assert_eq!(rust_snippets[1].title, "Another Rust");
 	}
 
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_search_by_title(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
 	) {
-		let (_file, pool) = sqlite_with_migrations.await;
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Create snippets with searchable titles
-		sqlx::query(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES
-				($1, $2, $3),
-				($4, $5, $6),
-				($7, $8, $9)
-			"#,
-		)
-		.bind("Hello World")
-		.bind("println!(\"Hello\");")
-		.bind("rust")
-		.bind("Goodbye World")
-		.bind("println!(\"Goodbye\");")
-		.bind("rust")
-		.bind("Unrelated")
-		.bind("some code")
-		.bind("python")
-		.execute(pool.as_ref())
-		.await
-		.expect("Failed to create snippets");
+		// Arrange
+		let manager = Manager::<Snippet>::new();
+		for (title, code, language) in [
+			("Hello World", "println!(\"Hello\");", "rust"),
+			("Goodbye World", "println!(\"Goodbye\");", "rust"),
+			("Unrelated", "some code", "python"),
+		] {
+			let snippet = Snippet::build()
+				.title(title)
+				.code(code)
+				.language(language)
+				.finish();
+			manager
+				.create_with_conn(&conn, &snippet)
+				.await
+				.expect("Failed to create snippet");
+		}
 
-		// Search by title pattern
-		let results: Vec<(i64, String, String, String)> = sqlx::query_as(
-			r#"
-			SELECT id, title, code, language
-			FROM snippets
-			WHERE title LIKE $1
-			ORDER BY id
-			"#,
-		)
-		.bind("%World%")
-		.fetch_all(pool.as_ref())
-		.await
-		.expect("Failed to search snippets");
+		// Act
+		let filter = Filter::new(
+			"title",
+			FilterOperator::Contains,
+			FilterValue::String("World".to_string()),
+		);
+		let results = manager
+			.filter(filter)
+			.order_by(&["id"])
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to search snippets");
 
+		// Assert
 		assert_eq!(results.len(), 2);
-		assert_eq!(results[0].1, "Hello World");
-		assert_eq!(results[1].1, "Goodbye World");
+		assert_eq!(results[0].title, "Hello World");
+		assert_eq!(results[1].title, "Goodbye World");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_snippet_count(
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+	) {
+		let (_file, conn) = sqlite_with_migrations.await;
+
+		// Arrange
+		let manager = Manager::<Snippet>::new();
+		for i in 1..=4 {
+			let snippet = Snippet::build()
+				.title(format!("Snippet {}", i))
+				.code(format!("code {}", i))
+				.language("rust")
+				.finish();
+			manager
+				.create_with_conn(&conn, &snippet)
+				.await
+				.expect("Failed to create snippet");
+		}
+
+		// Act
+		let snippets = manager
+			.all()
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to count snippets");
+
+		// Assert
+		assert_eq!(snippets.len(), 4);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_snippet_order_by_title(
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+	) {
+		let (_file, conn) = sqlite_with_migrations.await;
+
+		// Arrange
+		let manager = Manager::<Snippet>::new();
+		for title in ["Charlie", "Alpha", "Bravo"] {
+			let snippet = Snippet::build()
+				.title(title)
+				.code("fn main() {}")
+				.language("rust")
+				.finish();
+			manager
+				.create_with_conn(&conn, &snippet)
+				.await
+				.expect("Failed to create snippet");
+		}
+
+		// Act
+		let snippets = manager
+			.all()
+			.order_by(&["title"])
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to order snippets by title");
+
+		// Assert
+		assert_eq!(snippets.len(), 3);
+		assert_eq!(snippets[0].title, "Alpha");
+		assert_eq!(snippets[1].title, "Bravo");
+		assert_eq!(snippets[2].title, "Charlie");
 	}
 
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_pagination(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
 	) {
-		let (_file, pool) = sqlite_with_migrations.await;
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Create 5 snippets
+		// Arrange
+		let manager = Manager::<Snippet>::new();
 		for i in 1..=5 {
-			sqlx::query(
-				r#"
-				INSERT INTO snippets (title, code, language)
-				VALUES ($1, $2, $3)
-				"#,
-			)
-			.bind(format!("Snippet {}", i))
-			.bind(format!("code {}", i))
-			.bind("rust")
-			.execute(pool.as_ref())
-			.await
-			.expect("Failed to create snippet");
+			let snippet = Snippet::build()
+				.title(format!("Snippet {}", i))
+				.code(format!("code {}", i))
+				.language("rust")
+				.finish();
+			manager
+				.create_with_conn(&conn, &snippet)
+				.await
+				.expect("Failed to create snippet");
 		}
 
-		// First page (limit 2, offset 0)
-		let page1: Vec<(i64, String, String, String)> = sqlx::query_as(
-			r#"
-			SELECT id, title, code, language
-			FROM snippets
-			ORDER BY id
-			LIMIT $1 OFFSET $2
-			"#,
-		)
-		.bind(2i64)
-		.bind(0i64)
-		.fetch_all(pool.as_ref())
-		.await
-		.expect("Failed to fetch page 1");
+		// Act - first page (limit 2, offset 0)
+		let page1 = manager
+			.all()
+			.order_by(&["id"])
+			.limit(2)
+			.offset(0)
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to fetch page 1");
 
+		// Act - second page (limit 2, offset 2)
+		let page2 = manager
+			.all()
+			.order_by(&["id"])
+			.limit(2)
+			.offset(2)
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to fetch page 2");
+
+		// Assert
 		assert_eq!(page1.len(), 2);
-		assert_eq!(page1[0].1, "Snippet 1");
-		assert_eq!(page1[1].1, "Snippet 2");
-
-		// Second page (limit 2, offset 2)
-		let page2: Vec<(i64, String, String, String)> = sqlx::query_as(
-			r#"
-			SELECT id, title, code, language
-			FROM snippets
-			ORDER BY id
-			LIMIT $1 OFFSET $2
-			"#,
-		)
-		.bind(2i64)
-		.bind(2i64)
-		.fetch_all(pool.as_ref())
-		.await
-		.expect("Failed to fetch page 2");
+		assert_eq!(page1[0].title, "Snippet 1");
+		assert_eq!(page1[1].title, "Snippet 2");
 
 		assert_eq!(page2.len(), 2);
-		assert_eq!(page2[0].1, "Snippet 3");
-		assert_eq!(page2[1].1, "Snippet 4");
+		assert_eq!(page2[0].title, "Snippet 3");
+		assert_eq!(page2[1].title, "Snippet 4");
 	}
 
 	// ============================================================================
-	// Database Integration Tests - Edge Cases (7 tests)
+	// Database Integration Tests - Edge Cases
 	// ============================================================================
 
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_empty_database(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
 	) {
-		let (_file, pool) = sqlite_with_migrations.await;
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Query empty database
-		let snippets: Vec<(i64, String, String, String)> = sqlx::query_as(
-			r#"
-			SELECT id, title, code, language
-			FROM snippets
-			"#,
-		)
-		.fetch_all(pool.as_ref())
-		.await
-		.expect("Failed to query empty database");
+		// Act
+		let snippets = Manager::<Snippet>::new()
+			.all()
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to query empty database");
 
+		// Assert
 		assert_eq!(snippets.len(), 0);
 	}
 
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_nonexistent_id(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
 	) {
-		let (_file, pool) = sqlite_with_migrations.await;
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Query with nonexistent ID
-		let result: Option<(i64, String, String, String)> = sqlx::query_as(
-			r#"
-			SELECT id, title, code, language
-			FROM snippets
-			WHERE id = $1
-			"#,
-		)
-		.bind(99999i64)
-		.fetch_optional(pool.as_ref())
-		.await
-		.expect("Failed to query nonexistent ID");
+		// Act
+		let result = Manager::<Snippet>::new()
+			.get(99999)
+			.all_with_db(&conn)
+			.await
+			.expect("Failed to query nonexistent id");
 
-		assert!(result.is_none());
-	}
-
-	#[rstest]
-	#[tokio::test]
-	async fn test_snippet_duplicate_title_allowed(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
-	) {
-		let (_file, pool) = sqlite_with_migrations.await;
-
-		// Create first snippet
-		sqlx::query(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES ($1, $2, $3)
-			"#,
-		)
-		.bind("Duplicate Title")
-		.bind("code 1")
-		.bind("rust")
-		.execute(pool.as_ref())
-		.await
-		.expect("Failed to create first snippet");
-
-		// Create second snippet with same title (should succeed - no unique constraint)
-		let result: Result<(i64,), _> = sqlx::query_as(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES ($1, $2, $3)
-			RETURNING id
-			"#,
-		)
-		.bind("Duplicate Title")
-		.bind("code 2")
-		.bind("python")
-		.fetch_one(pool.as_ref())
-		.await;
-
-		assert!(result.is_ok());
-
-		// Verify both exist
-		let count: (i64,) = sqlx::query_as(
-			r#"
-			SELECT COUNT(*) as count
-			FROM snippets
-			WHERE title = $1
-			"#,
-		)
-		.bind("Duplicate Title")
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to count snippets");
-
-		assert_eq!(count.0, 2);
-	}
-
-	#[rstest]
-	#[tokio::test]
-	async fn test_snippet_count(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
-	) {
-		let (_file, pool) = sqlite_with_migrations.await;
-
-		// Create 3 snippets
-		sqlx::query(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES
-				($1, $2, $3),
-				($4, $5, $6),
-				($7, $8, $9)
-			"#,
-		)
-		.bind("Snippet 1")
-		.bind("code 1")
-		.bind("rust")
-		.bind("Snippet 2")
-		.bind("code 2")
-		.bind("python")
-		.bind("Snippet 3")
-		.bind("code 3")
-		.bind("rust")
-		.execute(pool.as_ref())
-		.await
-		.expect("Failed to create snippets");
-
-		// Count all snippets
-		let total: (i64,) = sqlx::query_as(
-			r#"
-			SELECT COUNT(*) as count
-			FROM snippets
-			"#,
-		)
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to count all snippets");
-
-		assert_eq!(total.0, 3);
-
-		// Count rust snippets
-		let rust_count: (i64,) = sqlx::query_as(
-			r#"
-			SELECT COUNT(*) as count
-			FROM snippets
-			WHERE language = $1
-			"#,
-		)
-		.bind("rust")
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to count rust snippets");
-
-		assert_eq!(rust_count.0, 2);
-	}
-
-	#[rstest]
-	#[tokio::test]
-	async fn test_snippet_order_by_title(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
-	) {
-		let (_file, pool) = sqlite_with_migrations.await;
-
-		// Create snippets with different titles
-		sqlx::query(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES
-				($1, $2, $3),
-				($4, $5, $6),
-				($7, $8, $9)
-			"#,
-		)
-		.bind("Charlie")
-		.bind("code c")
-		.bind("rust")
-		.bind("Alice")
-		.bind("code a")
-		.bind("python")
-		.bind("Bob")
-		.bind("code b")
-		.bind("javascript")
-		.execute(pool.as_ref())
-		.await
-		.expect("Failed to create snippets");
-
-		// Order by title ascending
-		let results: Vec<(i64, String, String, String)> = sqlx::query_as(
-			r#"
-			SELECT id, title, code, language
-			FROM snippets
-			ORDER BY title ASC
-			"#,
-		)
-		.fetch_all(pool.as_ref())
-		.await
-		.expect("Failed to order snippets");
-
-		assert_eq!(results.len(), 3);
-		assert_eq!(results[0].1, "Alice");
-		assert_eq!(results[1].1, "Bob");
-		assert_eq!(results[2].1, "Charlie");
-	}
-
-	#[rstest]
-	#[tokio::test]
-	async fn test_snippet_language_case_sensitivity(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
-	) {
-		let (_file, pool) = sqlite_with_migrations.await;
-
-		// Create snippets with different case languages
-		sqlx::query(
-			r#"
-			INSERT INTO snippets (title, code, language)
-			VALUES
-				($1, $2, $3),
-				($4, $5, $6)
-			"#,
-		)
-		.bind("Lowercase Rust")
-		.bind("code 1")
-		.bind("rust")
-		.bind("Uppercase Rust")
-		.bind("code 2")
-		.bind("RUST")
-		.execute(pool.as_ref())
-		.await
-		.expect("Failed to create snippets");
-
-		// Exact match (case-sensitive)
-		let exact: (i64,) = sqlx::query_as(
-			r#"
-			SELECT COUNT(*) as count
-			FROM snippets
-			WHERE language = $1
-			"#,
-		)
-		.bind("rust")
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to count exact match");
-
-		assert_eq!(exact.0, 1);
-
-		// Case-insensitive match
-		let case_insensitive: (i64,) = sqlx::query_as(
-			r#"
-			SELECT COUNT(*) as count
-			FROM snippets
-			WHERE LOWER(language) = LOWER($1)
-			"#,
-		)
-		.bind("rust")
-		.fetch_one(pool.as_ref())
-		.await
-		.expect("Failed to count case-insensitive match");
-
-		assert_eq!(case_insensitive.0, 2);
+		// Assert
+		assert_eq!(result.len(), 0);
 	}
 
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_update_nonexistent(
-		#[future] sqlite_with_migrations: (NamedTempFile, Arc<SqlitePool>),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
 	) {
-		let (_file, pool) = sqlite_with_migrations.await;
+		let (_file, conn) = sqlite_with_migrations.await;
 
-		// Try to update nonexistent snippet
-		let updated_rows = sqlx::query(
-			r#"
-			UPDATE snippets
-			SET title = $1
-			WHERE id = $2
-			"#,
-		)
-		.bind("New Title")
-		.bind(99999i64)
-		.execute(pool.as_ref())
-		.await
-		.expect("Failed to update nonexistent snippet")
-		.rows_affected();
+		// Arrange - a model instance whose primary key has no matching row
+		let mut nonexistent = Snippet::build()
+			.title("New Title")
+			.code("code")
+			.language("rust")
+			.finish();
+		nonexistent.id = 99999;
 
-		assert_eq!(updated_rows, 0);
+		// Act
+		let result = Manager::<Snippet>::new()
+			.update_with_conn(&conn, &nonexistent)
+			.await;
+
+		// Assert
+		assert!(
+			result.is_err(),
+			"updating a nonexistent snippet should fail"
+		);
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Rewrites the REST tutorial example function-based handlers to use DI-provided database access instead of mock/sample data.
- Adds a snippets-app DI showcase endpoint for fallible factory registration with `Depends<Result<T, E>>`.
- Updates integration coverage and the example README for the new DI-centric tutorial chapter map.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The redesigned REST tutorial needs the example crate to be the ground truth for real database access and Reinhardt DI. The previous example still demonstrated mock data paths, which would make the tutorial teach outdated behavior.

Fixes: N/A

Related to: `docs/superpowers/plans/2026-06-13-tutorial-redesign.md`

## How Was This Tested?

- `cargo check -p examples-tutorial-rest --all-features` from `examples/`
- `cargo nextest run -p examples-tutorial-rest --all-features` from `examples/`
- `cargo make fmt-check` from `examples/examples-tutorial-rest/`
- `cargo make clippy-check` from `examples/examples-tutorial-rest/`
- `cargo make test` from `examples/examples-tutorial-rest/`
- `git diff --check`

Known existing output: `reinhardt-commands` currently emits unused-variable warnings while compiling as a path dependency, and Cargo reports a future-incompatibility notice for the example crate. Both gates above still pass.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related tutorial redesign plan: `docs/superpowers/plans/2026-06-13-tutorial-redesign.md`

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [x] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

## Additional Context

This is Track A of the approved tutorial redesign. Track C can use this branch as the REST example source once this PR is reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated REST tutorial README with clearer structure, improved setup instructions, and enhanced explanations of core concepts.

* **New Features**
  * Added a new teaching endpoint demonstrating configuration handling and error responses.
  * Tutorial endpoints now use real database operations instead of sample in-memory data.

* **Tests**
  * Updated integration tests to verify database-backed CRUD and query operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->