### PR TITLE
docs: fold rc6 changelogs into stable notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,63 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.2.0-rc.5...reinhardt-web@v0.2.0-rc.6) - 2026-06-13
-
-### Added
-
-- *(macros)* expose model info companions to wasm
-
-### Changed
-
-- *(examples)* aggregate tutorial route contracts
-- *(examples)* inline tutorial route contracts
-
-### Documentation
-
-- add release announcement(s)
-- *(tutorial)* align basis docs with route contracts
-- *(tutorial)* document contacts settings fragment
-- *(tutorial)* align basis modules with pages template
-- *(tutorial)* address CodeRabbit review comments
-- *(tutorial)* align cfg recap with pages template
-- *(tutorial)* align typed form examples
-- *(tutorial)* aggregate app URL routers
-- *(tutorial)* trim duplicate client router snippet
-- *(tutorial)* restore users client router snippet
-- *(tutorial)* describe generated model info companions
-
-### Fixed
-
-- *(forms)* omit unreachable focus path for empty forms
-- *(commands)* add pages app reverse template
-- *(ci)* patch aws-runtime event-stream signer
-- *(commands)* align startproject scaffold defaults
-- *(commands)* use collectstatic no-input in pages template
-- *(commands)* make generated model placeholders tutorial-safe
-- *(ci)* pin broken upstream transitive releases
-- *(commands)* ignore sqlite database in project templates
-
-### Maintenance
-
-- drop vendored aws-runtime patch
-
-### Testing
-
-- *(examples)* fix tutorial basis CI tests
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.3...reinhardt-web@v0.2.0) - 2026-06-11
 
 Stable 0.2.0 is the first release of the Reinhardt 0.2 line. It
-promotes the `0.2.0-rc.2` through `0.2.0-rc.5` train into one upgrade
+promotes the `0.2.0-rc.2` through `0.2.0-rc.6` train into one upgrade
 story: remove the 0.1.x compatibility layer, adopt the final Manouche
 v2 page/form model, move application configuration to typed settings
 fragments, and make routing, testing, and local development more
 explicit.
 
 This release is not a patch-style rollup. It is a migration release for
-applications that stayed on 0.1.x while the 0.2 APIs stabilized. The RC
-entries below preserve the detailed history; this section is the
-upgrade-oriented summary.
+applications that stayed on 0.1.x while the 0.2 APIs stabilized. Earlier
+RC entries below preserve the detailed history; final release-polish
+changes are folded into this upgrade-oriented summary.
 
 ### Upgrade Impact
 
@@ -164,6 +120,8 @@ database migrations, then run the verification commands in the guide.
   Azure-style storage flows.
 - Interactive admin dependency configuration and refreshed project
   templates for 0.2.0 projects.
+- Generated model-info companion types are exported for WASM targets so
+  tutorial and admin-style flows can share the same model metadata.
 
 ### Changed
 
@@ -175,6 +133,8 @@ database migrations, then run the verification commands in the guide.
   model-construction contract.
 - Formatter responsibilities are split out of the admin CLI and routed
   through the published `reinhardt-formatter` crate.
+- Tutorial route contracts are aggregated or inlined where appropriate so
+  the example apps match the final route and page-template structure.
 
 ### Deprecated
 
@@ -193,6 +153,12 @@ database migrations, then run the verification commands in the guide.
   template dependency wiring.
 - Migration generation, model companion derives, query expectations, and
   backend-specific SQL behavior.
+- Empty-form focus handling no longer emits unreachable focus paths.
+- Project templates now include pages app reverse helpers, collectstatic
+  no-input defaults, tutorial-safe model placeholders, and sqlite database
+  ignores.
+- Release-branch CI is stabilized against the aws-runtime event-stream
+  signer issue and broken upstream transitive releases.
 
 ### Security
 
@@ -218,14 +184,21 @@ database migrations, then run the verification commands in the guide.
   stale generated release branches, and release announcements was hardened.
 - Public API documentation coverage, docs.rs links, website channel routing,
   and release website deployment were aligned for stable publication.
+- Release announcements and tutorial documentation were synchronized with
+  route-contract, settings-fragment, typed-form, generated model-info, and
+  pages-template guidance.
 - Examples and generated templates were refreshed against the local 0.2.0
   workspace instead of published RC assumptions.
+- Temporary vendored AWS runtime overrides were removed once the release
+  train no longer needed them.
 
 ### Testing
 
 - Release CI expectations, WASM fixtures, trybuild output, migration
   boundaries, HMR reload behavior, and auth clock-boundary tests were
   refreshed for the stable line.
+- Tutorial basis CI now exercises the polling tests against the fixed
+  runtime expectations.
 
 
 ## [0.2.0-rc.5](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.2.0-rc.4...reinhardt-web@v0.2.0-rc.5) - 2026-06-11

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.2.0-rc.5...reinhardt-admin-cli@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
-### Fixed
-
-- *(commands)* align startproject scaffold defaults
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.1.3...reinhardt-admin-cli@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-admin-cli` for the Reinhardt 0.2.0 line. This
@@ -54,6 +43,8 @@ RC entries remain below as detailed history.
 - *(admin-cli)* update migrate_v2 expected fixtures to match prettyplease output
 - *(admin-cli)* reject commented-out `#![rustfmt::skip]` in `rustfmt_skip_attr_matches`
 - split formatter from admin cli
+
+- *(commands)* align startproject scaffold defaults
 
 ### Documentation
 

--- a/crates/reinhardt-admin/CHANGELOG.md
+++ b/crates/reinhardt-admin/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin@v0.2.0-rc.5...reinhardt-admin@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin@v0.1.3...reinhardt-admin@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-admin` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-apps/CHANGELOG.md
+++ b/crates/reinhardt-apps/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-apps@v0.2.0-rc.5...reinhardt-apps@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-apps@v0.1.3...reinhardt-apps@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-apps` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-auth/CHANGELOG.md
+++ b/crates/reinhardt-auth/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-auth@v0.2.0-rc.5...reinhardt-auth@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-auth@v0.1.3...reinhardt-auth@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-auth` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-auth/macros/CHANGELOG.md
+++ b/crates/reinhardt-auth/macros/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-auth-macros@v0.2.0-rc.5...reinhardt-auth-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-auth-macros@v0.1.3...reinhardt-auth-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-auth-macros` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-commands/CHANGELOG.md
+++ b/crates/reinhardt-commands/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.2.0-rc.5...reinhardt-commands@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(tutorial)* aggregate app URL routers
-
-### Fixed
-
-- *(commands)* add pages app reverse template
-- *(commands)* align startproject scaffold defaults
-- *(commands)* use collectstatic no-input in pages template
-- *(commands)* make generated model placeholders tutorial-safe
-- *(commands)* ignore sqlite database in project templates
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.1.3...reinhardt-commands@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-commands` for the Reinhardt 0.2.0 line. This
@@ -64,6 +50,12 @@ RC entries remain below as detailed history.
 - *(commands)* align wasm bindgen template
 - *(commands)* verify runserver reachability after hot reload
 
+- *(commands)* add pages app reverse template
+- *(commands)* align startproject scaffold defaults
+- *(commands)* use collectstatic no-input in pages template
+- *(commands)* make generated model placeholders tutorial-safe
+- *(commands)* ignore sqlite database in project templates
+
 ### Performance
 
 - *(commands)* skip unrelated hot reload rebuilds
@@ -79,6 +71,8 @@ RC entries remain below as detailed history.
 - *(commands)* document migrate-with-target semantics
 - *(commands)* clarify APP_LABEL/MIGRATION_NAME dependency
 - *(commands)* make execute_from_command_line_with_settings doc example compile
+
+- *(tutorial)* aggregate app URL routers
 
 ### Maintenance
 

--- a/crates/reinhardt-conf/CHANGELOG.md
+++ b/crates/reinhardt-conf/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-conf@v0.2.0-rc.5...reinhardt-conf@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
-### Fixed
-
-- *(ci)* pin broken upstream transitive releases
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-conf@v0.1.3...reinhardt-conf@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-conf` for the Reinhardt 0.2.0 line. This
@@ -62,6 +51,8 @@ RC entries remain below as detailed history.
   `BuildError::MissingRequiredField` for missing direct section fields.
 - *(conf)* [**breaking**] remove legacy advanced settings types
 - *(conf)* emit fragment self settings impls
+
+- *(ci)* pin broken upstream transitive releases
 
 ### Performance
 

--- a/crates/reinhardt-core/CHANGELOG.md
+++ b/crates/reinhardt-core/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-core@v0.2.0-rc.5...reinhardt-core@v0.2.0-rc.6) - 2026-06-13
-
-### Added
-
-- *(macros)* expose model info companions to wasm
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-core@v0.1.3...reinhardt-core@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-core` for the Reinhardt 0.2.0 line. This
@@ -52,6 +41,8 @@ RC entries remain below as detailed history.
   invalidation by a hidden Layout-timing Effect that subscribes to the deps.
 - `impl Trackable for Signal<T>` and `impl Trackable for Memo<T>`, enabling
   these primitives to participate in hook deps tuples.
+
+- *(macros)* expose model info companions to wasm
 
 ### Removed
 

--- a/crates/reinhardt-core/macros/CHANGELOG.md
+++ b/crates/reinhardt-core/macros/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-macros@v0.2.0-rc.5...reinhardt-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Added
-
-- *(macros)* expose model info companions to wasm
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-macros@v0.1.3...reinhardt-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-macros` for the Reinhardt 0.2.0 line. This
@@ -56,6 +45,8 @@ RC entries remain below as detailed history.
   `REINHARDT_URL_NAME_WARNINGS=0` to silence it. Names that default to the
   function identifier are exempt. Refs
   [#4901](https://github.com/kent8192/reinhardt-web/issues/4901).
+
+- *(macros)* expose model info companions to wasm
 
 ### Changed
 

--- a/crates/reinhardt-db-macros/CHANGELOG.md
+++ b/crates/reinhardt-db-macros/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db-macros@v0.2.0-rc.5...reinhardt-db-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db-macros@v0.1.3...reinhardt-db-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-db-macros` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-db/CHANGELOG.md
+++ b/crates/reinhardt-db/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db@v0.2.0-rc.5...reinhardt-db@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
-### Fixed
-
-- *(ci)* pin broken upstream transitive releases
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db@v0.1.3...reinhardt-db@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-db` for the Reinhardt 0.2.0 line. This
@@ -65,6 +54,8 @@ RC entries remain below as detailed history.
 - *(db)* qualify Manager in rustdoc examples and add missing Objects type
 - *(docs)* resolve remaining cross-crate intra-doc link errors
 - repair release examples tests
+
+- *(ci)* pin broken upstream transitive releases
 
 ### Performance
 

--- a/crates/reinhardt-deeplink/CHANGELOG.md
+++ b/crates/reinhardt-deeplink/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-deeplink@v0.2.0-rc.5...reinhardt-deeplink@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-deeplink@v0.1.3...reinhardt-deeplink@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-deeplink` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-dentdelion/CHANGELOG.md
+++ b/crates/reinhardt-dentdelion/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dentdelion@v0.2.0-rc.5...reinhardt-dentdelion@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dentdelion@v0.1.3...reinhardt-dentdelion@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-dentdelion` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-di/CHANGELOG.md
+++ b/crates/reinhardt-di/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-di@v0.2.0-rc.5...reinhardt-di@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-di@v0.1.3...reinhardt-di@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-di` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-di/macros/CHANGELOG.md
+++ b/crates/reinhardt-di/macros/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-di-macros@v0.2.0-rc.5...reinhardt-di-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-di-macros@v0.1.3...reinhardt-di-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-di-macros` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-dispatch/CHANGELOG.md
+++ b/crates/reinhardt-dispatch/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dispatch@v0.2.0-rc.5...reinhardt-dispatch@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dispatch@v0.1.3...reinhardt-dispatch@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-dispatch` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-formatter/CHANGELOG.md
+++ b/crates/reinhardt-formatter/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-formatter@v0.2.0-rc.5...reinhardt-formatter@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-formatter@v0.1.3...reinhardt-formatter@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-formatter` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-forms/CHANGELOG.md
+++ b/crates/reinhardt-forms/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-forms@v0.2.0-rc.5...reinhardt-forms@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-forms@v0.1.3...reinhardt-forms@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-forms` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-graphql/CHANGELOG.md
+++ b/crates/reinhardt-graphql/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.2.0-rc.5...reinhardt-graphql@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.1.3...reinhardt-graphql@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-graphql` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-graphql/macros/CHANGELOG.md
+++ b/crates/reinhardt-graphql/macros/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql-macros@v0.2.0-rc.5...reinhardt-graphql-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql-macros@v0.1.3...reinhardt-graphql-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-graphql-macros` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-grpc/CHANGELOG.md
+++ b/crates/reinhardt-grpc/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.2.0-rc.5...reinhardt-grpc@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.1.3...reinhardt-grpc@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-grpc` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-grpc/macros/CHANGELOG.md
+++ b/crates/reinhardt-grpc/macros/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc-macros@v0.2.0-rc.5...reinhardt-grpc-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc-macros@v0.1.3...reinhardt-grpc-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-grpc-macros` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-http/CHANGELOG.md
+++ b/crates/reinhardt-http/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-http@v0.2.0-rc.5...reinhardt-http@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-http@v0.1.3...reinhardt-http@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-http` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-i18n/CHANGELOG.md
+++ b/crates/reinhardt-i18n/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.2.0-rc.5...reinhardt-i18n@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.1.3...reinhardt-i18n@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-i18n` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-mail/CHANGELOG.md
+++ b/crates/reinhardt-mail/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-mail@v0.2.0-rc.5...reinhardt-mail@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-mail@v0.1.3...reinhardt-mail@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-mail` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-manouche/CHANGELOG.md
+++ b/crates/reinhardt-manouche/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-manouche@v0.2.0-rc.5...reinhardt-manouche@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-manouche@v0.1.3...reinhardt-manouche@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-manouche` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-middleware/CHANGELOG.md
+++ b/crates/reinhardt-middleware/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-middleware@v0.2.0-rc.5...reinhardt-middleware@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-middleware@v0.1.3...reinhardt-middleware@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-middleware` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-openapi/CHANGELOG.md
+++ b/crates/reinhardt-openapi/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-openapi@v0.2.0-rc.5...reinhardt-openapi@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-openapi@v0.1.3...reinhardt-openapi@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-openapi` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.2.0-rc.5...reinhardt-pages@v0.2.0-rc.6) - 2026-06-13
-
-### Fixed
-
-- *(commands)* align startproject scaffold defaults
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.1.3...reinhardt-pages@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-pages` for the Reinhardt 0.2.0 line. This
@@ -192,6 +186,8 @@ RC entries remain below as detailed history.
   alive for the Resource's lifetime, and applies the `defer_yield` microtask
   deferral (#3316) on the dependency-driven path as well, not only the
   fetch-once path.
+
+- *(commands)* align startproject scaffold defaults
 
 ### Performance
 

--- a/crates/reinhardt-pages/ast/CHANGELOG.md
+++ b/crates/reinhardt-pages/ast/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages-ast@v0.2.0-rc.5...reinhardt-pages-ast@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages-ast@v0.1.3...reinhardt-pages-ast@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-pages-ast` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-pages/macros/CHANGELOG.md
+++ b/crates/reinhardt-pages/macros/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages-macros@v0.2.0-rc.5...reinhardt-pages-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Fixed
-
-- *(forms)* omit unreachable focus path for empty forms
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages-macros@v0.1.3...reinhardt-pages-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-pages-macros` for the Reinhardt 0.2.0 line. This
@@ -60,6 +54,8 @@ RC entries remain below as detailed history.
 - *(auth)* replace InternalUser in UserManager public API with ManagedUser
 - *(pages)* render dynamic radio choices
 - *(forms)* stabilize form runtime and validator parity
+
+- *(forms)* omit unreachable focus path for empty forms
 
 ### Performance
 

--- a/crates/reinhardt-providers/CHANGELOG.md
+++ b/crates/reinhardt-providers/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-providers@v0.2.0-rc.5...reinhardt-providers@v0.2.0-rc.6) - 2026-06-13
+## [0.2.0](https://github.com/kent8192/reinhardt-web/releases/tag/reinhardt-providers@v0.2.0) - 2026-06-11
+
+Stable release of `reinhardt-providers` for the Reinhardt 0.2.0 line.
 
 ### Added
 
@@ -18,7 +20,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(providers)* preserve AWS credential chain
 - *(providers)* address CodeRabbit review
 - *(ci)* pin broken upstream transitive releases
-# Changelog
-
-All notable changes to this crate are documented by the workspace release
-process.

--- a/crates/reinhardt-query/CHANGELOG.md
+++ b/crates/reinhardt-query/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-query@v0.2.0-rc.5...reinhardt-query@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-query@v0.1.3...reinhardt-query@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-query` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-query/macros/CHANGELOG.md
+++ b/crates/reinhardt-query/macros/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-query-macros@v0.2.0-rc.5...reinhardt-query-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-query-macros@v0.1.3...reinhardt-query-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-query-macros` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-rest/CHANGELOG.md
+++ b/crates/reinhardt-rest/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-rest@v0.2.0-rc.5...reinhardt-rest@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-rest@v0.1.3...reinhardt-rest@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-rest` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-rest/openapi-macros/CHANGELOG.md
+++ b/crates/reinhardt-rest/openapi-macros/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-openapi-macros@v0.2.0-rc.5...reinhardt-openapi-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-openapi-macros@v0.1.3...reinhardt-openapi-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-openapi-macros` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-router/CHANGELOG.md
+++ b/crates/reinhardt-router/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-router@v0.2.0-rc.5...reinhardt-router@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-router@v0.1.3...reinhardt-router@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-router` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-server/CHANGELOG.md
+++ b/crates/reinhardt-server/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-server@v0.2.0-rc.5...reinhardt-server@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-server@v0.1.3...reinhardt-server@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-server` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-shortcuts/CHANGELOG.md
+++ b/crates/reinhardt-shortcuts/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.2.0-rc.5...reinhardt-shortcuts@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.1.3...reinhardt-shortcuts@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-shortcuts` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-storages/CHANGELOG.md
+++ b/crates/reinhardt-storages/CHANGELOG.md
@@ -7,22 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-storages@v0.2.0-rc.5...reinhardt-storages@v0.2.0-rc.6) - 2026-06-13
-
-### Added
-
-- *(providers)* add minimal S3 provider client
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
-### Fixed
-
-- *(providers)* preserve AWS credential chain
-- *(providers)* address CodeRabbit review
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/releases/tag/reinhardt-storages@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-storages` for the Reinhardt 0.2.0 line. This
@@ -49,6 +33,8 @@ RC entries remain below as detailed history.
 - local, S3-compatible, GCS, and Azure backend feature surfaces for storage
   integrations.
 
+- *(providers)* add minimal S3 provider client
+
 ### Changed
 
 - *(storages)* consolidate test fixture submodules into single file
@@ -72,6 +58,9 @@ RC entries remain below as detailed history.
 - *(storages)* make StorageSettings::default() convertible in non-local builds
 - *(storages)* escape #[settings] in deprecation notes for rustdoc
 - *(storages)* gate gcs/azure integration tests behind their features
+
+- *(providers)* preserve AWS credential chain
+- *(providers)* address CodeRabbit review
 
 ### Security
 

--- a/crates/reinhardt-streaming/CHANGELOG.md
+++ b/crates/reinhardt-streaming/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-streaming@v0.2.0-rc.5...reinhardt-streaming@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-streaming@v0.1.3...reinhardt-streaming@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-streaming` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-tasks/CHANGELOG.md
+++ b/crates/reinhardt-tasks/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-tasks@v0.2.0-rc.5...reinhardt-tasks@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
-### Fixed
-
-- *(ci)* pin broken upstream transitive releases
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-tasks@v0.1.3...reinhardt-tasks@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-tasks` for the Reinhardt 0.2.0 line. This
@@ -45,6 +34,8 @@ RC entries remain below as detailed history.
 
 - *(settings)* require explicit nested settings nodes
 - *(tasks)* [**breaking**] remove misleading create_queue_from_settings API
+
+- *(ci)* pin broken upstream transitive releases
 
 ### Documentation
 

--- a/crates/reinhardt-test/CHANGELOG.md
+++ b/crates/reinhardt-test/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-test@v0.2.0-rc.5...reinhardt-test@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-test@v0.1.3...reinhardt-test@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-test` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-testkit-macros/CHANGELOG.md
+++ b/crates/reinhardt-testkit-macros/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-testkit-macros@v0.2.0-rc.5...reinhardt-testkit-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-testkit-macros@v0.1.3...reinhardt-testkit-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-testkit-macros` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-testkit/CHANGELOG.md
+++ b/crates/reinhardt-testkit/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-testkit@v0.2.0-rc.5...reinhardt-testkit@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-testkit@v0.1.3...reinhardt-testkit@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-testkit` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-throttling/CHANGELOG.md
+++ b/crates/reinhardt-throttling/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-throttling@v0.2.0-rc.5...reinhardt-throttling@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-throttling@v0.1.3...reinhardt-throttling@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-throttling` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-urls/CHANGELOG.md
+++ b/crates/reinhardt-urls/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-urls@v0.2.0-rc.5...reinhardt-urls@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-urls@v0.1.3...reinhardt-urls@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-urls` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-urls/routers-macros/CHANGELOG.md
+++ b/crates/reinhardt-urls/routers-macros/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-routers-macros@v0.2.0-rc.5...reinhardt-routers-macros@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-routers-macros@v0.1.3...reinhardt-routers-macros@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-routers-macros` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-utils/CHANGELOG.md
+++ b/crates/reinhardt-utils/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-utils@v0.2.0-rc.5...reinhardt-utils@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
-### Fixed
-
-- *(ci)* pin broken upstream transitive releases
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-utils@v0.1.3...reinhardt-utils@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-utils` for the Reinhardt 0.2.0 line. This
@@ -35,6 +24,8 @@ RC entries remain below as detailed history.
 - *(staticfiles)* inject wasm loader for directory index
 - *(staticfiles)* preserve raw index in non-spa mode
 - *(staticfiles)* inject wasm loader for directory index without spa mode
+
+- *(ci)* pin broken upstream transitive releases
 
 ### Performance
 

--- a/crates/reinhardt-views/CHANGELOG.md
+++ b/crates/reinhardt-views/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-views@v0.2.0-rc.5...reinhardt-views@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-views@v0.1.3...reinhardt-views@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-views` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-websockets/CHANGELOG.md
+++ b/crates/reinhardt-websockets/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-rc.6](https://github.com/kent8192/reinhardt-web/compare/reinhardt-websockets@v0.2.0-rc.5...reinhardt-websockets@v0.2.0-rc.6) - 2026-06-13
-
-### Documentation
-
-- *(release)* finalize 0.2.0 changelog
-- *(release)* refine 0.2.0 changelog narrative
-
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-websockets@v0.1.3...reinhardt-websockets@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-websockets` for the Reinhardt 0.2.0 line. This


### PR DESCRIPTION
## Summary

This PR addresses:

- Folds top-level and crate `0.2.0-rc.6` CHANGELOG entries from PR #5287 into the stable `## [0.2.0]` entries.
- Removes release-note maintenance bullets that only describe changelog editing from crate-level release notes.
- Adds the missing stable `0.2.0` heading for `reinhardt-providers` so every affected crate lands on the same release heading.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #5287 is a release-plz release PR. The final stable top-level and crate CHANGELOG entries should not expose a separate `0.2.0-rc.6` section, so the user-facing rc.6 changes are folded into `## [0.2.0]`.

Fixes: N/A

Related to: #5287

## How Was This Tested?

- Verified no top-level or crate CHANGELOG retains `## [0.2.0-rc.6]`.
- Verified no crate CHANGELOG retains the release-only finalize/refine changelog meta bullets.
- Verified all non-dropped crate rc.6 bullet lines from the original PR head are present in the stable `## [0.2.0]` body.
- Verified the top-level stable `0.2.0` entry now covers the rc.6 train and key rc.6 topics.
- Ran `git diff --check -- CHANGELOG.md 'crates/**/CHANGELOG.md'`.
- Verified `git diff --name-only` only includes `CHANGELOG.md` and `crates/**/CHANGELOG.md`.

## Performance Impact

N/A - documentation-only release metadata change.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

Docs-only CHANGELOG normalization; Cargo tests, formatting, clippy, and database backend checks are not applicable.

## Related Issues

- Related to #5287

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

## Additional Context

This PR intentionally targets the generated release-plz branch instead of pushing directly to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and consolidated changelog entries across the Reinhardt project ecosystem, consolidating release candidate information into stable release documentation and establishing structured `Unreleased` sections for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
