### PR TITLE
fix(commands): satisfy clippy for local infra fallback

### DIFF
--- a/crates/reinhardt-commands/src/local_infra/command.rs
+++ b/crates/reinhardt-commands/src/local_infra/command.rs
@@ -265,13 +265,8 @@ fn local_infra_env(
 					.and_then(|settings| settings.core().databases.get("default"))
 					.and_then(|database| database.password.as_ref())
 					.map(|password| password.expose_secret());
-				let password = match password {
-					Some(password) => password,
-					None => {
-						// codeql[rust/hard-coded-cryptographic-value] -- Local Docker fallback, not a production credential.
-						"postgres"
-					}
-				};
+				// codeql[rust/hard-coded-cryptographic-value] -- Local Docker fallback for #5300, not a production credential.
+				let password = password.unwrap_or("postgres");
 				env.push((
 					"DATABASE_URL".to_string(),
 					postgres_url(user, password, &service.host, service.host_port, database)?,


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- Replaces a manual `Option` match in local infra database URL generation with `unwrap_or` to satisfy Clippy.
- Keeps the local Docker PostgreSQL fallback CodeQL suppression adjacent to the fallback literal.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #5299 release CI failed in `Clippy / Clippy Lint` because Rust 1.94.1 rejects the manual `Option::unwrap_or` pattern under `-D warnings`.

Fixes #5300

Related to: #5299

## How Was This Tested?

- `cargo make fmt-fix`
- `cargo make fmt-check`
- `git diff --check`
- `cargo make clippy-check`

## Performance Impact

No performance impact expected.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage (AWS Spot instances),
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5300
- Related to #5299

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The release-plz branch is generated, so this source fix targets `main` instead of modifying `release-plz-2026-06-14T01-35-10Z` directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified local infrastructure password selection logic, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->