### PR TITLE
chore(release): group tree-sitter crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -661,6 +661,14 @@ image = "0.25.10"
 
 # Compression
 flate2 = "1.1.9"
+# Workaround for dropbox/rust-alloc-no-stdlib#22 (tracked in reinhardt-web#5304).
+# Remove these pins when alloc-stdlib and brotli-decompressor no longer
+# permit incompatible alloc-no-stdlib 2.x / 3.x selections.
+#
+# Ideal implementation (without workaround):
+#   no direct alloc-stdlib or brotli-decompressor dependency is needed.
+alloc-stdlib = "=0.2.2"
+brotli-decompressor = "=5.0.1"
 brotli = "8.0.2"
 
 # Collections & data structures

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -59,7 +59,7 @@ cbor = ["dep:ciborium"]
 bincode = ["dep:bincode"]
 compression-zstd = ["dep:zstd"]
 compression-gzip = ["dep:flate2"]
-compression-brotli = ["dep:brotli"]
+compression-brotli = ["dep:alloc-stdlib", "dep:brotli-decompressor", "dep:brotli"]
 compression = ["compression-zstd", "compression-gzip", "compression-brotli"]
 analytics-prometheus = ["dep:prometheus"]
 analytics = ["analytics-prometheus"]
@@ -121,6 +121,8 @@ ciborium = { version = "0.2", optional = true }
 bincode = { version = "2.0.1", optional = true, features = ["serde"] }
 zstd = { version = "0.13", optional = true }
 flate2 = { version = "1.0", optional = true }
+alloc-stdlib = { workspace = true, optional = true }
+brotli-decompressor = { workspace = true, optional = true }
 brotli = { version = "8.0.2", optional = true }
 prometheus = { version = "0.14.0", optional = true }
 

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -36,6 +36,8 @@ urlencoding = "2.1"
 quick-xml = { version = "0.38.3", optional = true }
 serde_yaml = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
+alloc-stdlib = { workspace = true, optional = true }
+brotli-decompressor = { workspace = true, optional = true }
 brotli = { workspace = true, optional = true }
 rmp-serde = { workspace = true }
 prost = { workspace = true }
@@ -96,7 +98,7 @@ serializers = ["serde"]
 messages = ["serde"]
 negotiation = []
 parsers = []
-compressed-parsers = ["parsers", "dep:brotli", "dep:flate2"]
+compressed-parsers = ["parsers", "dep:alloc-stdlib", "dep:brotli-decompressor", "dep:brotli", "dep:flate2"]
 pagination = ["serde"]
 reactive = []
 

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -17,7 +17,7 @@ default = ["broken-link-email"]
 
 # Fine-grained middleware features
 cors = []
-compression = ["dep:brotli", "dep:flate2"]
+compression = ["dep:alloc-stdlib", "dep:brotli-decompressor", "dep:brotli", "dep:flate2"]
 security = []
 rate-limit = []
 sessions = ["dep:reinhardt-auth", "reinhardt-auth/sessions"]
@@ -56,6 +56,8 @@ hyper = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 flate2 = { workspace = true, optional = true }
+alloc-stdlib = { workspace = true, optional = true }
+brotli-decompressor = { workspace = true, optional = true }
 brotli = { version = "8.0.2", optional = true }
 sha2 = { workspace = true }
 hex = "0.4"

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -45,6 +45,8 @@ walkdir = "2.4"
 glob = "0.3"
 notify = { version = "8.2.0", optional = true }
 flate2 = { version = "1.0", optional = true }
+alloc-stdlib = { workspace = true, optional = true }
+brotli-decompressor = { workspace = true, optional = true }
 brotli = { version = "8.0.2", optional = true }
 base64 = "0.22"
 sourcemap = "9.0"
@@ -103,7 +105,7 @@ gcs = ["dep:cloud-storage"]
 processing = []
 image-optimization = ["processing", "dep:oxipng", "dep:image", "dep:webp"]
 source-maps = ["processing"]
-compression = ["processing", "dep:brotli", "dep:flate2"]
+compression = ["processing", "dep:alloc-stdlib", "dep:brotli-decompressor", "dep:brotli", "dep:flate2"]
 advanced-minification = [
   "processing",
   "dep:oxc_allocator",

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -256,6 +256,18 @@ version_group = "reinhardt"
 name = "reinhardt-websockets"
 version_group = "reinhardt"
 
+[[package]]
+name = "tree-sitter-reinhardt-form"
+version_group = "reinhardt"
+
+[[package]]
+name = "tree-sitter-reinhardt-head"
+version_group = "reinhardt"
+
+[[package]]
+name = "tree-sitter-reinhardt-page"
+version_group = "reinhardt"
+
 # Non-published packages (tests, examples, internal tools)
 [[package]]
 name = "reinhardt-test-support"


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds `tree-sitter-reinhardt-form`, `tree-sitter-reinhardt-head`, and `tree-sitter-reinhardt-page` to the shared `reinhardt` release-plz version group.
- Keeps the publishable grammar crates on the same release train as the rest of the workspace.
- Pins the brotli allocator dependency stack for brotli-enabled crates so lockfile-less CI resolves compatible `alloc-no-stdlib` versions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- These three grammar crates are publishable crates, but they were not explicitly included in release-plz package configuration.
- release-plz applies `version_group` through package-level entries, so the crates need explicit entries to share the workspace version bump behavior.
- CI was resolving `alloc-stdlib` and `brotli-decompressor` to incompatible allocator trait versions without a tracked `Cargo.lock` constraint.

Fixes #5304

Related to: dropbox/rust-alloc-no-stdlib#22

## How Was This Tested?

- `cargo metadata --format-version 1 --no-deps`
- `cargo make fmt-check`
- lockfile-less `cargo check --workspace --all-features --lib --quiet`
- lockfile-less `cargo check --workspace --all-features --tests --quiet`
- lockfile-less `cargo check --workspace --all-features --bins --examples --benches --quiet`
- lockfile-less `cargo make clippy-todo-check`
- lockfile-less `cargo check --target wasm32-unknown-unknown -p reinhardt-core --no-default-features -F core-full --quiet`

## Performance Impact

- N/A

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5304

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- Context7 documentation confirms release-plz version groups are configured with package-level `version_group` entries.
- The brotli allocator pin is a workaround for upstream dependency version bounds that allow incompatible `alloc-no-stdlib` 2.x / 3.x selections in fresh resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Resolved dependency compatibility issues affecting compression functionality across multiple components.
  * Enhanced compression support infrastructure with improved dependency management.
  * Updated release configuration to include additional packages in the publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->