### PR TITLE
fix(logging): avoid zero-millisecond request durations

### DIFF
--- a/crates/reinhardt-middleware/src/logging.rs
+++ b/crates/reinhardt-middleware/src/logging.rs
@@ -3,7 +3,7 @@ use chrono::Local;
 use colored::Colorize;
 use reinhardt_http::{Handler, Middleware, Request, Response, Result};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// Configuration for logging middleware
 ///
@@ -45,7 +45,7 @@ impl LoggingConfig {
 /// Django-style request logging middleware with colored output
 ///
 /// Outputs request logs in Django's runserver format with latency:
-/// `[DD/Mon/YYYY HH:MM:SS] "METHOD /path HTTP/1.1" STATUS SIZE LATENCYms`
+/// `[DD/Mon/YYYY HH:MM:SS] "METHOD /path HTTP/1.1" STATUS SIZE LATENCY`
 ///
 /// Status codes are color-coded:
 /// - 2xx: Green (success)
@@ -85,7 +85,7 @@ impl LoggingConfig {
 ///
 /// let response = middleware.process(request, handler).await.unwrap();
 /// assert_eq!(response.status, StatusCode::OK);
-/// // Logs: [15/Dec/2024 10:30:45] "GET /api/users HTTP/1.1" 200 2 0ms
+/// // Logs: [15/Dec/2024 10:30:45] "GET /api/users HTTP/1.1" 200 2 250us
 /// # });
 /// ```
 pub struct LoggingMiddleware {
@@ -148,7 +148,7 @@ impl Middleware for LoggingMiddleware {
 						request_line.white(),
 						status_colored,
 						response.body.len().to_string().cyan(),
-						format!("{}ms", duration.as_millis()).dimmed(),
+						format_request_duration(duration).dimmed(),
 					);
 				} else {
 					println!(
@@ -157,7 +157,7 @@ impl Middleware for LoggingMiddleware {
 						request_line.white(),
 						status_colored,
 						response.body.len().to_string().cyan(),
-						format!("{}ms", duration.as_millis()).dimmed(),
+						format_request_duration(duration).dimmed(),
 					);
 				}
 			}
@@ -176,7 +176,7 @@ impl Middleware for LoggingMiddleware {
 					format!("[{timestamp}]").dimmed(),
 					request_line.white(),
 					status_colored,
-					format!("{}ms", duration.as_millis()).dimmed(),
+					format_request_duration(duration).dimmed(),
 				);
 
 				// Output error details based on configuration
@@ -195,6 +195,23 @@ impl Middleware for LoggingMiddleware {
 
 		result
 	}
+}
+
+fn format_request_duration(duration: Duration) -> String {
+	if duration.is_zero() {
+		return "0ms".to_string();
+	}
+
+	if duration < Duration::from_millis(1) {
+		let micros = duration.as_nanos().div_ceil(1_000);
+		return format!("{micros}us");
+	}
+
+	if duration < Duration::from_secs(1) {
+		return format!("{}ms", duration.as_millis());
+	}
+
+	format!("{:.3}s", duration.as_secs_f64())
 }
 
 fn format_http_version(version: hyper::Version) -> &'static str {
@@ -236,5 +253,39 @@ fn format_error_multiline(
 
 		// All other errors: Simple indented format
 		_ => format!("  {}", err),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::format_request_duration;
+	use std::time::Duration;
+
+	#[test]
+	fn format_request_duration_zero_duration() {
+		assert_eq!(format_request_duration(Duration::ZERO), "0ms");
+	}
+
+	#[test]
+	fn format_request_duration_sub_microsecond_rounds_up() {
+		assert_eq!(format_request_duration(Duration::from_nanos(1)), "1us");
+	}
+
+	#[test]
+	fn format_request_duration_sub_millisecond_uses_microseconds() {
+		assert_eq!(format_request_duration(Duration::from_micros(250)), "250us");
+	}
+
+	#[test]
+	fn format_request_duration_millisecond_scale_uses_milliseconds() {
+		assert_eq!(format_request_duration(Duration::from_millis(15)), "15ms");
+	}
+
+	#[test]
+	fn format_request_duration_second_scale_uses_seconds() {
+		assert_eq!(
+			format_request_duration(Duration::from_millis(1_234)),
+			"1.234s"
+		);
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Centralizes request duration formatting in `LoggingMiddleware`.
- Renders non-zero sub-millisecond durations in microseconds instead of truncating them to `0ms`.
- Updates the logging doctest example and adds focused formatter tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`LoggingMiddleware` used `Duration::as_millis()` directly in request logs, which truncates fast non-zero requests below one millisecond to `0ms`. That makes runserver logs misleading when inspecting fast local routes.

Fixes #5275

## How Was This Tested?

- `cargo test -p reinhardt-middleware --lib format_request_duration`
- `cargo test -p reinhardt-middleware --features security --test sanity_integration sanity_logging_middleware`
- `cargo test -p reinhardt-middleware --doc`
- `cargo make fmt-check`
- `cargo make clippy-check`
- `cargo make fmt-fix`

## Performance Impact

Not performance-related. The formatter only changes request-log display text.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5275

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [x] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `low` - Minor fix or enhancement

---

**Additional Context:**

- Created from `develop/0.3.0` per branch-base instruction.

Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved logging middleware to display request latency in human-friendly units (microseconds, milliseconds, or seconds) instead of always using milliseconds.

* **Tests**
  * Added unit tests validating latency formatting across various duration ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->