### PR TITLE
chore: migrate Rust toolchain to 1.96.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -60,7 +60,7 @@ body:
       label: Environment
       description: Please provide your environment details
       value: |
-        - Rust version: [e.g., 1.94.1]
+        - Rust version: [e.g., 1.96.0]
         - OS: [e.g., macOS 15.0, Ubuntu 24.04]
         - Crate version: [e.g., reinhardt-core 0.1.0]
       render: markdown

--- a/.github/ISSUE_TEMPLATE/5-performance.yml
+++ b/.github/ISSUE_TEMPLATE/5-performance.yml
@@ -67,7 +67,7 @@ body:
     attributes:
       label: Rust Version
       description: Output of `rustc --version`
-      placeholder: rustc 1.94.1 (e.g., 1.94.1)
+      placeholder: rustc 1.96.0 (e.g., 1.96.0)
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/6-ci_cd.yml
+++ b/.github/ISSUE_TEMPLATE/6-ci_cd.yml
@@ -120,7 +120,7 @@ body:
 				Tests pass locally with:
 				- Docker Desktop running
 				- macOS 14.0
-				- Rust 1.94.1
+				- Rust 1.96.0
 
 				Difference in CI:
 				- CI runner: ubuntu-latest

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -20,8 +20,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install Rust 1.94.1
-      uses: dtolnay/rust-toolchain@1.94.1
+    - name: Install Rust 1.96.0
+      uses: dtolnay/rust-toolchain@1.96.0
       with:
         components: ${{ inputs.components }}
 

--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -68,9 +68,10 @@ jobs:
           token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.91.1
+        uses: ./.github/actions/setup-rust
         with:
           components: rustfmt, clippy
+          cache: 'false'
 
       - name: Setup protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/msrv-test.yml
+++ b/.github/workflows/msrv-test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         # Verify compilation on MSRV (pinned), stable, and beta channels
-        rust: ["1.94.1", "stable", "beta"]
+        rust: ["1.96.0", "stable", "beta"]
 
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Thank you for your interest in contributing to Reinhardt! This document provides
 
 ### Prerequisites
 
-- Rust 1.94.1+ (2024 Edition required)
+- Rust 1.96.0+ (2024 Edition required)
 - Docker (required for TestContainers-based integration tests)
 - PostgreSQL (optional - can use TestContainers instead)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -466,7 +466,7 @@ default-members = [
 [workspace.package]
 version = "0.2.0-rc.2"
 edition = "2024"
-rust-version = "1.94.0"
+rust-version = "1.96.0"
 license = "BSD-3-Clause"
 repository = "https://github.com/kent8192/reinhardt-web"
 homepage = "https://github.com/kent8192/reinhardt-web"

--- a/crates/reinhardt-admin/src/server/validation.rs
+++ b/crates/reinhardt-admin/src/server/validation.rs
@@ -157,25 +157,21 @@ fn validate_value_size(field_name: &str, value: &serde_json::Value) -> Result<()
 				)));
 			}
 		}
-		serde_json::Value::Array(arr) => {
-			if arr.len() > MAX_FIELDS {
-				return Err(AdminError::ValidationError(format!(
-					"Field '{}' array too large: {} elements (max {})",
-					field_name,
-					arr.len(),
-					MAX_FIELDS
-				)));
-			}
+		serde_json::Value::Array(arr) if arr.len() > MAX_FIELDS => {
+			return Err(AdminError::ValidationError(format!(
+				"Field '{}' array too large: {} elements (max {})",
+				field_name,
+				arr.len(),
+				MAX_FIELDS
+			)));
 		}
-		serde_json::Value::Object(obj) => {
-			if obj.len() > MAX_FIELDS {
-				return Err(AdminError::ValidationError(format!(
-					"Field '{}' object too large: {} keys (max {})",
-					field_name,
-					obj.len(),
-					MAX_FIELDS
-				)));
-			}
+		serde_json::Value::Object(obj) if obj.len() > MAX_FIELDS => {
+			return Err(AdminError::ValidationError(format!(
+				"Field '{}' object too large: {} keys (max {})",
+				field_name,
+				obj.len(),
+				MAX_FIELDS
+			)));
 		}
 		_ => {}
 	}

--- a/crates/reinhardt-commands/templates/project_pages_template/README.md.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/README.md.tpl
@@ -4,7 +4,7 @@ A Reinhardt Pages project with WASM frontend and server-side rendering.
 
 ## Prerequisites
 
-- Rust 1.94.1 or later (2024 Edition)
+- Rust 1.96.0 or later (2024 Edition)
 - wasm-bindgen-cli: `cargo install wasm-bindgen-cli`
 - PostgreSQL (optional, for database features)
 

--- a/crates/reinhardt-conf/src/settings/validation.rs
+++ b/crates/reinhardt-conf/src/settings/validation.rs
@@ -261,12 +261,10 @@ impl BaseSettingsValidator for SecurityValidator {
 					));
 				}
 			}
-			"secure_ssl_redirect" => {
-				if value.as_bool() != Some(true) {
-					return Err(reinhardt_core::validators::ValidationError::Custom(
-						"SECURE_SSL_REDIRECT should be true in production".to_string(),
-					));
-				}
+			"secure_ssl_redirect" if value.as_bool() != Some(true) => {
+				return Err(reinhardt_core::validators::ValidationError::Custom(
+					"SECURE_SSL_REDIRECT should be true in production".to_string(),
+				));
 			}
 			_ => {}
 		}

--- a/crates/reinhardt-core/macros/src/installed_apps.rs
+++ b/crates/reinhardt-core/macros/src/installed_apps.rs
@@ -550,7 +550,7 @@ pub(crate) fn installed_apps_impl(input: TokenStream) -> Result<TokenStream> {
 
 	// Write app labels to state file for cross-macro communication with #[routes].
 	// This replaces the __reinhardt_for_each_app #[macro_export] callback pattern
-	// that triggers macro_expanded_macro_exports_accessed_by_absolute_paths on Rust 1.94+.
+	// that triggers macro_expanded_macro_exports_accessed_by_absolute_paths on Rust 1.96+.
 	let label_strings: Vec<String> = labels.iter().map(|l| l.to_string()).collect();
 	if let Err(err) = crate::macro_state::write_installed_apps(&label_strings) {
 		return Err(syn::Error::new(

--- a/crates/reinhardt-core/macros/src/macro_state.rs
+++ b/crates/reinhardt-core/macros/src/macro_state.rs
@@ -8,7 +8,7 @@
 //! - Other macros may read the file for app discovery
 //!
 //! This eliminates the need for the `#[macro_export]` callback pattern that triggers
-//! `macro_expanded_macro_exports_accessed_by_absolute_paths` on Rust 1.94+.
+//! `macro_expanded_macro_exports_accessed_by_absolute_paths` on Rust 1.96+.
 //!
 //! ## Why `CARGO_MANIFEST_DIR/target/` instead of `OUT_DIR`?
 //!

--- a/crates/reinhardt-core/macros/src/schema.rs
+++ b/crates/reinhardt-core/macros/src/schema.rs
@@ -283,11 +283,9 @@ fn extract_serde_attrs(attrs: &[Attribute]) -> syn::Result<SerdeFieldAttrs> {
 					Ok(())
 				})?;
 			}
-			Meta::Path(path) => {
-				// Handle `#[serde(skip)]` without parentheses
-				if path.is_ident("skip") {
-					serde_attrs.skip = true;
-				}
+			// Handle `#[serde(skip)]` without parentheses
+			Meta::Path(path) if path.is_ident("skip") => {
+				serde_attrs.skip = true;
 			}
 			_ => {}
 		}

--- a/crates/reinhardt-core/macros/src/viewset_macro.rs
+++ b/crates/reinhardt-core/macros/src/viewset_macro.rs
@@ -454,7 +454,7 @@ fn viewset_impl_impl(args: TokenStream, item_impl: syn::ItemImpl) -> syn::Result
 /// `const_type_name` feature: `type_name::<T>()` is callable in regular
 /// (non-const) function context, but `inventory::submit!`'s `static`
 /// initializer cannot use it yet (rust-lang/rust#63084 — `const_type_name`
-/// is still unstable as of Rust 1.94).
+/// is still unstable as of Rust 1.96).
 ///
 /// The handler is intentionally left as the `ActionMetadata::new`-default
 /// no-op: the user's method has a free-form signature (e.g.

--- a/crates/reinhardt-core/macros/tests/ui/user/fail/manager_disabled_no_manager.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/user/fail/manager_disabled_no_manager.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `OptOutUserManager`
+error[E0433]: cannot find type `OptOutUserManager` in this scope
   --> tests/ui/user/fail/manager_disabled_no_manager.rs:22:10
    |
 22 |     let _ = OptOutUserManager::new();

--- a/crates/reinhardt-core/src/signals/context.rs
+++ b/crates/reinhardt-core/src/signals/context.rs
@@ -220,11 +220,9 @@ impl MetricsCollector {
 		let min_execution_time_ns = self.min_execution_time_ns.load(Ordering::Relaxed);
 		let max_execution_time_ns = self.max_execution_time_ns.load(Ordering::Relaxed);
 
-		let avg_execution_time_ns = if receiver_executions > 0 {
-			total_execution_time_ns / receiver_executions
-		} else {
-			0
-		};
+		let avg_execution_time_ns = total_execution_time_ns
+			.checked_div(receiver_executions)
+			.unwrap_or(0);
 
 		SignalMetrics {
 			send_count,

--- a/crates/reinhardt-core/src/signals/doc_generator.rs
+++ b/crates/reinhardt-core/src/signals/doc_generator.rs
@@ -187,7 +187,7 @@ impl SignalDocGenerator {
 			output.push_str("### Connected Receivers\n\n");
 
 			let mut receivers = doc.receivers.clone();
-			receivers.sort_by(|a, b| b.priority.cmp(&a.priority));
+			receivers.sort_by_key(|receiver| std::cmp::Reverse(receiver.priority));
 
 			output
 				.push_str("| Receiver | Description | Priority | Critical | Expected Duration |\n");
@@ -299,7 +299,7 @@ impl SignalDocGenerator {
 			output.push_str("    </tr>\n");
 
 			let mut receivers = doc.receivers.clone();
-			receivers.sort_by(|a, b| b.priority.cmp(&a.priority));
+			receivers.sort_by_key(|receiver| std::cmp::Reverse(receiver.priority));
 
 			for receiver in receivers {
 				let critical = if receiver.is_critical {

--- a/crates/reinhardt-core/src/signals/profiler.rs
+++ b/crates/reinhardt-core/src/signals/profiler.rs
@@ -260,7 +260,7 @@ impl<T: Send + Sync + 'static> SignalProfiler<T> {
 	/// ```
 	pub fn slowest_receivers(&self, count: usize) -> Vec<ReceiverProfile> {
 		let mut profiles = self.all_receiver_profiles();
-		profiles.sort_by(|a, b| b.avg_duration.cmp(&a.avg_duration));
+		profiles.sort_by_key(|profile| std::cmp::Reverse(profile.avg_duration));
 		profiles.truncate(count);
 		profiles
 	}
@@ -354,7 +354,7 @@ impl<T: Send + Sync + 'static> SignalProfiler<T> {
 			report.push_str("\nReceiver Profiles:\n");
 
 			let mut sorted_profiles: Vec<_> = profiles.values().collect();
-			sorted_profiles.sort_by(|a, b| b.avg_duration.cmp(&a.avg_duration));
+			sorted_profiles.sort_by_key(|profile| std::cmp::Reverse(profile.avg_duration));
 
 			for profile in sorted_profiles {
 				report.push_str(&format!("\n  {}:\n", profile.dispatch_uid));

--- a/crates/reinhardt-core/src/signals/signal.rs
+++ b/crates/reinhardt-core/src/signals/signal.rs
@@ -170,7 +170,7 @@ impl<T: Send + Sync + 'static> Signal<T> {
 		});
 
 		// Sort by priority (descending - higher priority first)
-		receivers.sort_by(|a, b| b.priority.cmp(&a.priority));
+		receivers.sort_by_key(|receiver| std::cmp::Reverse(receiver.priority));
 	}
 
 	/// Connect a receiver function to this signal (simple version)

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -2188,7 +2188,7 @@ impl ChangeTracker {
 			.cloned()
 			.collect();
 
-		patterns.sort_by(|a, b| b.frequency.cmp(&a.frequency));
+		patterns.sort_by_key(|pattern| std::cmp::Reverse(pattern.frequency));
 		patterns
 	}
 
@@ -2974,11 +2974,11 @@ impl InferenceEngine {
 							evidence.push(format!("Optional field added: {}", field_name_pattern));
 						}
 					}
-					RuleCondition::MultipleModelRenames { min_count } => {
-						if model_renames.len() >= *min_count {
-							optional_matches += 1;
-							evidence.push(format!("Multiple renames: {}", model_renames.len()));
-						}
+					RuleCondition::MultipleModelRenames { min_count }
+						if model_renames.len() >= *min_count =>
+					{
+						optional_matches += 1;
+						evidence.push(format!("Multiple renames: {}", model_renames.len()));
 					}
 					_ => {}
 				}

--- a/crates/reinhardt-di/src/profiling.rs
+++ b/crates/reinhardt-di/src/profiling.rs
@@ -286,7 +286,7 @@ impl ProfileReport {
 	/// ```
 	pub fn slowest_dependencies(&self, n: usize) -> Vec<&DependencyStats> {
 		let mut deps: Vec<_> = self.dependencies.values().collect();
-		deps.sort_by(|a, b| b.avg_duration.cmp(&a.avg_duration));
+		deps.sort_by_key(|dep| std::cmp::Reverse(dep.avg_duration));
 		deps.into_iter().take(n).collect()
 	}
 
@@ -334,7 +334,7 @@ impl fmt::Display for ProfileReport {
 		)?;
 
 		let mut deps: Vec<_> = self.dependencies.values().collect();
-		deps.sort_by(|a, b| b.total_duration.cmp(&a.total_duration));
+		deps.sort_by_key(|dep| std::cmp::Reverse(dep.total_duration));
 
 		writeln!(f, "Per-Dependency Statistics:")?;
 		writeln!(

--- a/crates/reinhardt-pages/tests/ui/form/fail/hidden_field_no_default.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/hidden_field_no_default.stderr
@@ -24,7 +24,6 @@ error[E0277]: the trait bound `NoDefault: Default` is not satisfied
 32 | |     };
    | |_____^ the trait `Default` is not implemented for `NoDefault`
    |
-   = help: see issue #48214
    = note: this error originates in the macro `form` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NoDefault` with `#[derive(Default)]`
    |
@@ -45,7 +44,6 @@ error[E0277]: can't compare `NoDefault` with `NoDefault`
    | |_____^ no implementation for `NoDefault == NoDefault`
    |
    = help: the trait `PartialEq` is not implemented for `NoDefault`
-   = help: see issue #48214
    = note: this error originates in the macro `form` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NoDefault` with `#[derive(PartialEq)]`
    |
@@ -65,7 +63,6 @@ error[E0277]: the trait bound `NoDefault: Default` is not satisfied
 32 | |     };
    | |_____^ the trait `Default` is not implemented for `NoDefault`
    |
-   = help: see issue #48214
 help: consider annotating `NoDefault` with `#[derive(Default)]`
    |
  7 + #[derive(Default)]
@@ -85,7 +82,6 @@ error[E0277]: can't compare `NoDefault` with `NoDefault`
    | |_____^ no implementation for `NoDefault == NoDefault`
    |
    = help: the trait `PartialEq` is not implemented for `NoDefault`
-   = help: see issue #48214
 help: consider annotating `NoDefault` with `#[derive(PartialEq)]`
    |
  7 + #[derive(PartialEq)]
@@ -141,7 +137,7 @@ help: consider annotating `NoDefault` with `#[derive(Default)]`
  8 | struct NoDefault {
    |
 
-error[E0599]: the function or associated item `new` exists for struct `BadForm`, but its trait bounds were not satisfied
+error[E0599]: the associated function or constant `new` exists for struct `BadForm`, but its trait bounds were not satisfied
   --> tests/ui/form/fail/hidden_field_no_default.rs:26:10
    |
  7 |    struct NoDefault {
@@ -152,12 +148,12 @@ error[E0599]: the function or associated item `new` exists for struct `BadForm`,
    | | _____________|
    | ||
 27 | ||         name: BadForm,
-   | ||_____________________- function or associated item `new` not found for this struct
+   | ||_____________________- associated function or constant `new` not found for this struct
 28 | |          action: "/x",
 29 | |          fields: {
 ...  |
 32 | |      };
-   | |______^ function or associated item cannot be called on `BadForm` due to unsatisfied trait bounds
+   | |______^ associated function or constant cannot be called on `BadForm` due to unsatisfied trait bounds
    |
 note: the following trait bounds were not satisfied:
       `NoDefault: Default`

--- a/crates/reinhardt-pages/tests/ui/form/fail/old_use_form_options.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/old_use_form_options.stderr
@@ -2,7 +2,10 @@ error[E0432]: unresolved import `reinhardt_pages::FormOptions`
  --> tests/ui/form/fail/old_use_form_options.rs:1:23
   |
 1 | use reinhardt_pages::{FormOptions, use_form};
-  |                       ^^^^^^^^^^^
-  |                       |
-  |                       no `FormOptions` in the root
-  |                       help: a similar name exists in the module: `SsrOptions`
+  |                       ^^^^^^^^^^^ no `FormOptions` in the root
+  |
+help: a similar name exists in the module
+  |
+1 - use reinhardt_pages::{FormOptions, use_form};
+1 + use reinhardt_pages::{SsrOptions, use_form};
+  |

--- a/crates/reinhardt-pages/tests/ui/page/fail/component_missing_required_prop.stderr
+++ b/crates/reinhardt-pages/tests/ui/page/fail/component_missing_required_prop.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the member `Unset<item>` was not set, but this method requires it to be set
+error[E0277]: the member `bon::__::Unset<item>` was not set, but this method requires it to be set
   --> tests/ui/page/fail/component_missing_required_prop.rs:28:10
    |
 28 |       let _ = page!(|| {
@@ -7,14 +7,15 @@ error[E0277]: the member `Unset<item>` was not set, but this method requires it 
 30 | |             Card {}
 31 | |         }
 32 | |     });
-   | |______^ the member `Unset<item>` was not set, but this method requires it to be set
+   | |______^ the member `bon::__::Unset<item>` was not set, but this method requires it to be set
    |
-   = help: the trait `IsSet` is not implemented for `Unset<item>`
+   = help: the trait `bon::__::IsSet` is not implemented for `bon::__::Unset<item>`
 note: required for `card_props_builder::Empty` to implement `IsComplete`
   --> tests/ui/page/fail/component_missing_required_prop.rs:10:10
    |
 10 | #[derive(bon::Builder)]
-   |          ^^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   |          ^^^^^^^^^^^^ type parameter would need to implement `IsComplete`
+   = help: consider manually implementing `IsComplete` to avoid undesired bounds
 note: required by a bound in `CardPropsBuilder::<S>::build`
   --> tests/ui/page/fail/component_missing_required_prop.rs:10:10
    |

--- a/examples/examples-tutorial-basis/README.md
+++ b/examples/examples-tutorial-basis/README.md
@@ -48,7 +48,7 @@ The project router mounts per-app server routers on native and merges per-app cl
 
 ### Prerequisites
 
-- Rust 1.94 or later (2024 edition, matches the workspace MSRV)
+- Rust 1.96 or later (2024 edition, matches the workspace MSRV)
 - `cargo-make` (`cargo install cargo-make`)
 - `wasm-pack` for the WASM client build
 - Docker (optional, for TestContainers in integration tests)

--- a/examples/examples-tutorial-rest/Dockerfile
+++ b/examples/examples-tutorial-rest/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for examples-tutorial-rest API testing
 # Build context: workspace root (../..)
 
-FROM rust:1.94.1-slim AS builder
+FROM rust:1.96.0-slim AS builder
 
 WORKDIR /app
 

--- a/examples/examples-tutorial-rest/README.md
+++ b/examples/examples-tutorial-rest/README.md
@@ -44,7 +44,7 @@ All handlers receive a database connection through dependency injection
 
 ### Prerequisites
 
-- Rust 1.75 or later
+- Rust 1.96.0 or later
 - Docker, for the disposable PostgreSQL and Redis containers used by
   `cargo make migrate` and `cargo make runserver`
 - PostgreSQL, only if you point `settings/local.toml` at an existing database

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.96.0"
 components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]

--- a/website/content/quickstart/getting-started.md
+++ b/website/content/quickstart/getting-started.md
@@ -16,7 +16,7 @@ project and build a simple REST API.
 
 Before you begin, make sure you have:
 
-- **Rust** 1.94.1 or later (2024 Edition required)
+- **Rust** 1.96.0 or later (2024 Edition required)
   ([Install Rust](https://www.rust-lang.org/tools/install))
 - **PostgreSQL** (included in `standard` and `full` bundles; optional for custom setups)
 - Basic familiarity with Rust and async programming
@@ -394,7 +394,7 @@ Check out the [ORM documentation](/docs/api/) for more details.
 
 **Port Already in Use**: Change the port in `serve()` function
 
-**Compilation Errors**: Ensure Rust 1.94.1+ (`rustc --version`)
+**Compilation Errors**: Ensure Rust 1.96.0+ (`rustc --version`)
 
 **Async Runtime**: Add `#[tokio::main]` to your main function
 

--- a/website/content/quickstart/tutorials/rest/_index.md
+++ b/website/content/quickstart/tutorials/rest/_index.md
@@ -42,7 +42,7 @@ The first group is written by hand so you can see the request extractors, respon
 
 You should have:
 
-- Rust 1.94.0 or later
+- Rust 1.96.0 or later
 - Docker Desktop running, because the example's `cargo make migrate` and `cargo make runserver` tasks start disposable PostgreSQL and Redis containers
 - Basic familiarity with Rust modules, `async fn`, and JSON serialization
 - The `cargo-make` subcommand available as `cargo make`


### PR DESCRIPTION
## Summary

This PR addresses:

- Upgrade the workspace Rust toolchain to 1.96.0 and workspace MSRV to 1.96.0.
- Update CI Rust pins, issue templates, examples, Dockerfile, and user-facing setup docs.
- Apply mechanical Rust 1.96 Clippy cleanup without behavior changes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

The required compiler version changes from Rust 1.94.x to Rust 1.96.0 as requested by the issue. This does not change Reinhardt public API or runtime behavior.

## Motivation and Context

- Keep the project aligned with the requested Rust 1.96.0 stable toolchain.
- Consolidate CI setup around the shared setup-rust action so stale direct pins do not survive future toolchain bumps.
- Fix new Clippy lints exposed by the 1.96.0 toolchain.

Fixes #4862

Related to: N/A

## How Was This Tested?

- `cargo check --workspace --all --all-features`
- `cargo make fmt-check`
- `cargo make clippy-check`
- `cargo make placeholder-check`
- `cargo test --doc`
- `cargo check --target wasm32-unknown-unknown -p reinhardt-web --quiet`
- `cargo check --target wasm32-unknown-unknown -p reinhardt-web --no-default-features --features pages,client-router,pages-web-sys-full,di --quiet`
- `cargo check --target wasm32-unknown-unknown -p reinhardt-pages --all-features --quiet`
- `cargo check --target wasm32-unknown-unknown -p reinhardt-query --no-default-features --quiet`
- `cargo test -p reinhardt-pages --test ui test_form_macro_fail -- --nocapture`
- `cargo test -p reinhardt-pages --test ui test_page_macro_fail -- --nocapture`
- `cargo test -p reinhardt-macros --test ui test_user_macro_fail -- --nocapture`
- `git diff --check`

Full `cargo nextest run --workspace --all-features` built the test profile, then hung during nextest test binary listing (`--list --format terse`) with idle parent/children; I stopped it and left this noted for CI to cover.

## Performance Impact

N/A. This is a toolchain/MSRV and lint cleanup change.

## Screenshots

N/A. No UI changes.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #4862

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- GitWhy contexts: `ctx_ead23e51`, `ctx_afcb7621` (saved locally; sync skipped because the connected repo limit is reached).


