### PR TITLE
feat(pages): add wasm server API parity macro

### DIFF
--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -315,6 +315,7 @@ The prelude includes:
 - `ApiModel`, `ApiQuerySet`, `Filter`, `FilterOp`
 - `ServerFn`, `ServerFnError`
 - See [Server Function Macro Guide](docs/server_fn_macro.md) for detailed usage and migration information
+- See [WASM/server API Parity Macro](docs/wasm_server_api.md) for APIs that need matching public surfaces with target-specific implementations
 - See [React-to-Reinhardt Guide](docs/react_to_reinhardt.md) for React hooks, JSX, actions, routing, SSR, and hydration mappings
 
 ### Authentication and Security
@@ -331,6 +332,9 @@ The prelude includes:
 
 ### Macros
 - `page!`
+- `head!`
+- `form!`
+- `wasm_server_api`
 
 ### Task spawning (cross-target)
 - `spawn_task`, `defer_yield` (no-op on native)

--- a/crates/reinhardt-pages/docs/wasm_server_api.md
+++ b/crates/reinhardt-pages/docs/wasm_server_api.md
@@ -1,0 +1,82 @@
+# wasm_server_api Macro
+
+`#[wasm_server_api]` declares public APIs that must keep the same Rust surface
+on browser WASM and server/native targets while allowing target-specific
+implementations.
+
+Use it when a Reinhardt Pages API needs different runtime behavior across the
+WASM/server boundary but must expose one public name, signature, visibility, and
+documentation contract. The macro is a compile-time guard against drift.
+
+## When to Use It
+
+Use `#[wasm_server_api]` for small public functions where:
+
+- The WASM implementation needs browser APIs, hydration state, or client-side
+  scheduling.
+- The server implementation needs SSR behavior, native I/O, or an explicit
+  unsupported-target branch.
+- Reviewers should be able to see both implementations next to each other.
+- A signature, visibility, or documentation mismatch would be a public API bug.
+
+Do not use it for:
+
+- APIs whose behavior is identical on every target. A normal function is clearer.
+- Large modules where target-specific submodules are easier to review.
+- `#[server_fn]` RPC functions. Those already generate a WASM client stub and a
+  server handler contract.
+- Private helper functions that do not define public cross-target API shape.
+
+## Syntax
+
+Apply the macro to an inline module. Each target-specific public function must
+have exactly one `#[wasm]` or `#[server]` marker, and every marked function must
+have a matching counterpart with the same name and signature.
+
+```rust
+use reinhardt_pages::wasm_server_api;
+
+#[wasm_server_api]
+pub mod platform_api {
+    #[doc = "Returns the active target family name."]
+    #[wasm]
+    pub fn target_name() -> &'static str {
+        "wasm"
+    }
+
+    #[doc = "Returns the active target family name."]
+    #[server]
+    pub fn target_name() -> &'static str {
+        "server"
+    }
+}
+```
+
+The expansion emits the WASM variant behind:
+
+```rust
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+```
+
+and the server/native variant behind:
+
+```rust
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+```
+
+Unmarked module items are preserved unchanged.
+
+## Validation
+
+The macro rejects:
+
+- Missing `#[wasm]` or `#[server]` counterparts.
+- Duplicate variants for the same target.
+- Non-public target variants.
+- Mismatched signatures.
+- Mismatched non-target attributes.
+- `#[wasm]` or `#[server]` markers on non-function items.
+
+This keeps unsupported target behavior explicit: if a target cannot support the
+operation, write the unsupported branch as the matching implementation rather
+than omitting it.

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -8,6 +8,7 @@
 //! - `head!` - HTML head section DSL macro
 //! - `form!` - Type-safe form component macro with reactive bindings
 //! - `#[server_fn]` - Server Functions (RPC) macro
+//! - `#[wasm_server_api]` - API parity guard for matching WASM/server surfaces
 //!
 //! ## Form Design
 //!
@@ -68,6 +69,7 @@ mod form;
 mod head;
 mod page;
 mod server_fn;
+mod wasm_server_api;
 
 /// Server Function macro
 ///
@@ -100,6 +102,32 @@ mod server_fn;
 #[proc_macro_attribute]
 pub fn server_fn(args: TokenStream, input: TokenStream) -> TokenStream {
 	server_fn::server_fn_impl(args, input)
+}
+
+/// Declares public APIs with matching WASM and server-side surfaces.
+///
+/// Apply this attribute to an inline module containing pairs of functions
+/// marked with `#[wasm]` and `#[server]`. The macro validates that each pair
+/// has the same visibility, attributes, name, and signature, then emits
+/// target-gated definitions for browser WASM and non-browser-WASM builds.
+///
+/// ```ignore
+/// #[wasm_server_api]
+/// mod platform {
+///     #[wasm]
+///     pub fn target_name() -> &'static str {
+///         "wasm"
+///     }
+///
+///     #[server]
+///     pub fn target_name() -> &'static str {
+///         "server"
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn wasm_server_api(args: TokenStream, input: TokenStream) -> TokenStream {
+	wasm_server_api::wasm_server_api_impl(args, input)
 }
 
 /// Derives typed field signals and form traits for a form values struct.

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -111,7 +111,9 @@ pub fn server_fn(args: TokenStream, input: TokenStream) -> TokenStream {
 /// has the same visibility, attributes, name, and signature, then emits
 /// target-gated definitions for browser WASM and non-browser-WASM builds.
 ///
-/// ```ignore
+/// ```no_run
+/// use reinhardt_pages_macros::wasm_server_api;
+///
 /// #[wasm_server_api]
 /// mod platform {
 ///     #[wasm]

--- a/crates/reinhardt-pages/macros/src/wasm_server_api.rs
+++ b/crates/reinhardt-pages/macros/src/wasm_server_api.rs
@@ -1,0 +1,301 @@
+//! WASM/server public API parity macro.
+
+use std::collections::BTreeMap;
+
+use proc_macro::TokenStream;
+use quote::{ToTokens, quote};
+use syn::spanned::Spanned;
+use syn::{Attribute, Error, Item, ItemFn, ItemMod, Meta, Visibility, parse_macro_input};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TargetKind {
+	Wasm,
+	Server,
+}
+
+#[derive(Clone)]
+struct Variant {
+	function: ItemFn,
+	attributes_fingerprint: String,
+	visibility_fingerprint: String,
+	signature_fingerprint: String,
+}
+
+#[derive(Default)]
+struct Pair {
+	wasm: Option<Variant>,
+	server: Option<Variant>,
+}
+
+/// Main entry point for the `#[wasm_server_api]` macro.
+pub(crate) fn wasm_server_api_impl(args: TokenStream, input: TokenStream) -> TokenStream {
+	if !args.is_empty() {
+		return Error::new(
+			proc_macro2::TokenStream::from(args).span(),
+			"`#[wasm_server_api]` does not accept arguments",
+		)
+		.to_compile_error()
+		.into();
+	}
+
+	let module = parse_macro_input!(input as ItemMod);
+	match expand_wasm_server_api(module) {
+		Ok(tokens) => tokens.into(),
+		Err(error) => error.to_compile_error().into(),
+	}
+}
+
+fn expand_wasm_server_api(mut module: ItemMod) -> syn::Result<proc_macro2::TokenStream> {
+	let Some((_brace, items)) = module.content.take() else {
+		return Err(Error::new(
+			module.ident.span(),
+			"`#[wasm_server_api]` requires an inline module body",
+		));
+	};
+
+	let mut pairs = BTreeMap::<String, Pair>::new();
+	let mut expanded_items = Vec::with_capacity(items.len());
+
+	for item in items {
+		match split_target_item(item)? {
+			TargetItem::Plain(item) => expanded_items.push(item),
+			TargetItem::Function {
+				target,
+				mut function,
+			} => {
+				let key = function.sig.ident.to_string();
+				let variant = build_variant(function.clone());
+				let pair = pairs.entry(key.clone()).or_default();
+				match target {
+					TargetKind::Wasm => {
+						if pair.wasm.is_some() {
+							return Err(Error::new(
+								function.sig.ident.span(),
+								format!("duplicate `#[wasm]` variant for `{key}`"),
+							));
+						}
+						function.attrs.insert(
+							0,
+							syn::parse_quote!(#[cfg(all(target_family = "wasm", target_os = "unknown"))]),
+						);
+						expanded_items.push(Item::Fn(function));
+						pair.wasm = Some(variant);
+					}
+					TargetKind::Server => {
+						if pair.server.is_some() {
+							return Err(Error::new(
+								function.sig.ident.span(),
+								format!("duplicate `#[server]` variant for `{key}`"),
+							));
+						}
+						function.attrs.insert(
+							0,
+							syn::parse_quote!(#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]),
+						);
+						expanded_items.push(Item::Fn(function));
+						pair.server = Some(variant);
+					}
+				}
+			}
+		}
+	}
+
+	if pairs.is_empty() {
+		return Err(Error::new(
+			module.ident.span(),
+			"`#[wasm_server_api]` must declare at least one `#[wasm]` / `#[server]` function pair",
+		));
+	}
+
+	validate_pairs(&pairs)?;
+
+	let attrs = &module.attrs;
+	let vis = &module.vis;
+	let ident = &module.ident;
+	let unsafety = &module.unsafety;
+	let mod_token = &module.mod_token;
+
+	Ok(quote! {
+		#(#attrs)*
+		#vis #unsafety #mod_token #ident {
+			#(#expanded_items)*
+		}
+	})
+}
+
+enum TargetItem {
+	Plain(Item),
+	Function {
+		target: TargetKind,
+		function: ItemFn,
+	},
+}
+
+fn split_target_item(item: Item) -> syn::Result<TargetItem> {
+	match item {
+		Item::Fn(mut function) => {
+			let (target, retained_attrs) = extract_target_marker(&function.attrs)?;
+			function.attrs = retained_attrs;
+			if let Some(target) = target {
+				if !matches!(function.vis, Visibility::Public(_)) {
+					return Err(Error::new(
+						function.sig.ident.span(),
+						"`#[wasm_server_api]` target variants must be public functions",
+					));
+				}
+				Ok(TargetItem::Function { target, function })
+			} else {
+				Ok(TargetItem::Plain(Item::Fn(function)))
+			}
+		}
+		other => {
+			let (target, _) = extract_target_marker(other.attrs())?;
+			if target.is_some() {
+				return Err(Error::new(
+					other.span(),
+					"`#[wasm]` and `#[server]` markers may only annotate functions",
+				));
+			}
+			Ok(TargetItem::Plain(other))
+		}
+	}
+}
+
+trait ItemAttributes {
+	fn attrs(&self) -> &[Attribute];
+}
+
+impl ItemAttributes for Item {
+	fn attrs(&self) -> &[Attribute] {
+		match self {
+			Item::Const(item) => &item.attrs,
+			Item::Enum(item) => &item.attrs,
+			Item::ExternCrate(item) => &item.attrs,
+			Item::Fn(item) => &item.attrs,
+			Item::ForeignMod(item) => &item.attrs,
+			Item::Impl(item) => &item.attrs,
+			Item::Macro(item) => &item.attrs,
+			Item::Mod(item) => &item.attrs,
+			Item::Static(item) => &item.attrs,
+			Item::Struct(item) => &item.attrs,
+			Item::Trait(item) => &item.attrs,
+			Item::TraitAlias(item) => &item.attrs,
+			Item::Type(item) => &item.attrs,
+			Item::Union(item) => &item.attrs,
+			Item::Use(item) => &item.attrs,
+			Item::Verbatim(_) => &[],
+			_ => &[],
+		}
+	}
+}
+
+fn extract_target_marker(attrs: &[Attribute]) -> syn::Result<(Option<TargetKind>, Vec<Attribute>)> {
+	let mut target = None;
+	let mut retained = Vec::with_capacity(attrs.len());
+
+	for attr in attrs {
+		let kind = if attr.path().is_ident("wasm") {
+			Some(TargetKind::Wasm)
+		} else if attr.path().is_ident("server") {
+			Some(TargetKind::Server)
+		} else {
+			None
+		};
+
+		let Some(kind) = kind else {
+			retained.push(attr.clone());
+			continue;
+		};
+
+		if !matches!(attr.meta, Meta::Path(_)) {
+			return Err(Error::new(
+				attr.span(),
+				"`#[wasm]` and `#[server]` markers do not accept arguments",
+			));
+		}
+
+		if target.replace(kind).is_some() {
+			return Err(Error::new(
+				attr.span(),
+				"only one target marker is allowed per function",
+			));
+		}
+	}
+
+	Ok((target, retained))
+}
+
+fn build_variant(function: ItemFn) -> Variant {
+	Variant {
+		attributes_fingerprint: fingerprint_attrs(&function.attrs),
+		visibility_fingerprint: fingerprint_visibility(&function.vis),
+		signature_fingerprint: function.sig.to_token_stream().to_string(),
+		function,
+	}
+}
+
+fn validate_pairs(pairs: &BTreeMap<String, Pair>) -> syn::Result<()> {
+	for (name, pair) in pairs {
+		let Some(wasm) = &pair.wasm else {
+			let server = pair.server.as_ref().expect("server variant exists");
+			return Err(Error::new(
+				server.function.sig.ident.span(),
+				format!("missing `#[wasm]` variant for `{name}`"),
+			));
+		};
+
+		let Some(server) = &pair.server else {
+			return Err(Error::new(
+				wasm.function.sig.ident.span(),
+				format!("missing `#[server]` variant for `{name}`"),
+			));
+		};
+
+		validate_pair(name, wasm, server)?;
+	}
+
+	Ok(())
+}
+
+fn validate_pair(name: &str, wasm: &Variant, server: &Variant) -> syn::Result<()> {
+	if wasm.visibility_fingerprint != server.visibility_fingerprint {
+		return Err(Error::new(
+			server.function.vis.span(),
+			format!(
+				"`#[wasm]` and `#[server]` variants for `{name}` must have matching visibility"
+			),
+		));
+	}
+
+	if wasm.attributes_fingerprint != server.attributes_fingerprint {
+		return Err(Error::new(
+			server.function.sig.ident.span(),
+			format!(
+				"`#[wasm]` and `#[server]` variants for `{name}` must have matching non-target attributes"
+			),
+		));
+	}
+
+	if wasm.signature_fingerprint != server.signature_fingerprint {
+		return Err(Error::new(
+			server.function.sig.ident.span(),
+			format!(
+				"`#[wasm]` and `#[server]` variants for `{name}` must have matching signatures"
+			),
+		));
+	}
+
+	Ok(())
+}
+
+fn fingerprint_attrs(attrs: &[Attribute]) -> String {
+	attrs
+		.iter()
+		.map(|attr| attr.to_token_stream().to_string())
+		.collect::<Vec<_>>()
+		.join("\n")
+}
+
+fn fingerprint_visibility(vis: &Visibility) -> String {
+	vis.to_token_stream().to_string()
+}

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -103,6 +103,10 @@
 //!
 //! - [`page!`]: JSX-like macro for defining view components
 //! - [`head!`]: JSX-like macro for defining HTML head sections
+//! - [`form!`]: Type-safe form component macro
+//! - [`wasm_server_api`]: WASM/server API parity macro
+//!
+//! See `docs/wasm_server_api.md` for the target-specific API parity contract.
 //!
 //! ## Example
 //!
@@ -366,6 +370,7 @@ pub use static_resolver::{init_static_resolver, is_initialized, resolve_static};
 pub use reinhardt_pages_macros::form;
 pub use reinhardt_pages_macros::head;
 pub use reinhardt_pages_macros::page;
+pub use reinhardt_pages_macros::wasm_server_api;
 
 // Private re-exports used by macro-generated code. Not part of the public API.
 #[doc(hidden)]

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -199,6 +199,7 @@ pub use reinhardt_forms::{
 pub use crate::form;
 pub use crate::head;
 pub use crate::page;
+pub use crate::wasm_server_api;
 
 // ============================================================================
 // WASM-specific utilities

--- a/crates/reinhardt-pages/tests/ui.rs
+++ b/crates/reinhardt-pages/tests/ui.rs
@@ -44,6 +44,18 @@ fn test_server_fn_macro_ui() {
 	t.pass("tests/ui/server_fn/with_extractors.rs");
 }
 
+#[test]
+fn test_wasm_server_api_macro_ui_pass() {
+	let t = trybuild::TestCases::new();
+	t.pass("tests/ui/wasm_server_api/pass/*.rs");
+}
+
+#[test]
+fn test_wasm_server_api_macro_ui_fail() {
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/ui/wasm_server_api/fail/*.rs");
+}
+
 // PR5 / Issue #4195: React-parity hooks require an explicit deps tuple
 // (spec §4.2). These UI tests pin the public signature:
 // - `pass/explicit_deps_use_effect.rs`: canonical (closure, (s,))

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/attribute_mismatch.rs
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/attribute_mismatch.rs
@@ -1,0 +1,19 @@
+//! Compile-fail coverage for divergent public API attributes.
+
+use reinhardt_pages::wasm_server_api;
+
+#[wasm_server_api]
+mod platform_api {
+	#[must_use]
+	#[wasm]
+	pub fn target_name() -> &'static str {
+		"wasm"
+	}
+
+	#[server]
+	pub fn target_name() -> &'static str {
+		"server"
+	}
+}
+
+fn main() {}

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/attribute_mismatch.stderr
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/attribute_mismatch.stderr
@@ -1,0 +1,5 @@
+error: `#[wasm]` and `#[server]` variants for `target_name` must have matching non-target attributes
+  --> tests/ui/wasm_server_api/fail/attribute_mismatch.rs:14:9
+   |
+14 |     pub fn target_name() -> &'static str {
+   |            ^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/marker_on_struct.rs
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/marker_on_struct.rs
@@ -1,0 +1,11 @@
+//! Compile-fail coverage for target markers on non-function items.
+
+use reinhardt_pages::wasm_server_api;
+
+#[wasm_server_api]
+mod platform_api {
+	#[wasm]
+	pub struct PlatformOnly;
+}
+
+fn main() {}

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/marker_on_struct.stderr
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/marker_on_struct.stderr
@@ -1,0 +1,5 @@
+error: `#[wasm]` and `#[server]` markers may only annotate functions
+ --> tests/ui/wasm_server_api/fail/marker_on_struct.rs:7:2
+  |
+7 |     #[wasm]
+  |     ^

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/missing_server.rs
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/missing_server.rs
@@ -1,0 +1,13 @@
+//! Compile-fail coverage for a target variant without its counterpart.
+
+use reinhardt_pages::wasm_server_api;
+
+#[wasm_server_api]
+mod platform_api {
+	#[wasm]
+	pub fn target_name() -> &'static str {
+		"wasm"
+	}
+}
+
+fn main() {}

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/missing_server.stderr
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/missing_server.stderr
@@ -1,0 +1,5 @@
+error: missing `#[server]` variant for `target_name`
+ --> tests/ui/wasm_server_api/fail/missing_server.rs:8:9
+  |
+8 |     pub fn target_name() -> &'static str {
+  |            ^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/non_public.rs
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/non_public.rs
@@ -1,0 +1,18 @@
+//! Compile-fail coverage for non-public target variants.
+
+use reinhardt_pages::wasm_server_api;
+
+#[wasm_server_api]
+mod platform_api {
+	#[wasm]
+	fn target_name() -> &'static str {
+		"wasm"
+	}
+
+	#[server]
+	fn target_name() -> &'static str {
+		"server"
+	}
+}
+
+fn main() {}

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/non_public.stderr
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/non_public.stderr
@@ -1,0 +1,5 @@
+error: `#[wasm_server_api]` target variants must be public functions
+ --> tests/ui/wasm_server_api/fail/non_public.rs:8:5
+  |
+8 |     fn target_name() -> &'static str {
+  |        ^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/signature_mismatch.rs
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/signature_mismatch.rs
@@ -1,0 +1,18 @@
+//! Compile-fail coverage for divergent public API signatures.
+
+use reinhardt_pages::wasm_server_api;
+
+#[wasm_server_api]
+mod platform_api {
+	#[wasm]
+	pub fn target_name(input: &'static str) -> &'static str {
+		input
+	}
+
+	#[server]
+	pub fn target_name() -> &'static str {
+		"server"
+	}
+}
+
+fn main() {}

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/signature_mismatch.stderr
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/fail/signature_mismatch.stderr
@@ -1,0 +1,5 @@
+error: `#[wasm]` and `#[server]` variants for `target_name` must have matching signatures
+  --> tests/ui/wasm_server_api/fail/signature_mismatch.rs:13:9
+   |
+13 |     pub fn target_name() -> &'static str {
+   |            ^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/wasm_server_api/pass/basic.rs
+++ b/crates/reinhardt-pages/tests/ui/wasm_server_api/pass/basic.rs
@@ -1,0 +1,37 @@
+//! Compile-pass coverage for the public `wasm_server_api` re-export.
+
+use reinhardt_pages::wasm_server_api;
+
+#[wasm_server_api]
+pub mod platform_api {
+	pub const SHARED_VALUE: &str = "shared";
+
+	#[doc = "Returns the active target family name."]
+	#[wasm]
+	pub fn target_name(input: &'static str) -> &'static str {
+		let _ = input;
+		"wasm"
+	}
+
+	#[doc = "Returns the active target family name."]
+	#[server]
+	pub fn target_name(input: &'static str) -> &'static str {
+		let _ = input;
+		"server"
+	}
+
+	#[wasm]
+	pub async fn load_count(id: u32) -> Result<u32, &'static str> {
+		Ok(id + 1)
+	}
+
+	#[server]
+	pub async fn load_count(id: u32) -> Result<u32, &'static str> {
+		Ok(id + 2)
+	}
+}
+
+fn main() {
+	let _ = platform_api::SHARED_VALUE;
+	let _ = platform_api::target_name("fixture");
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds `#[wasm_server_api]` for inline modules that declare paired `#[wasm]` and `#[server]` public function variants.
- Validates matching public surfaces across target variants: visibility, non-target attributes, names, and signatures.
- Documents when to use the macro and adds trybuild pass/fail coverage for valid and divergent declarations.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- React parity work needs a single compile-time contract for public APIs that intentionally differ between browser WASM and server/native targets.
- Hand-written cfg branches can drift in signatures, docs, attributes, and export paths.

Fixes #5199

Related to: #5198

## How Was This Tested?

- `cargo check -p reinhardt-pages-macros`
- `cargo check -p reinhardt-pages`
- `cargo test -p reinhardt-pages --test ui test_wasm_server_api_macro_ui_pass -- --nocapture`
- `cargo test -p reinhardt-pages --test ui test_wasm_server_api_macro_ui_fail -- --nocapture`
- `cargo test --doc -p reinhardt-pages`
- `cargo doc -p reinhardt-pages --no-deps`
- `cargo fmt --check`
- `git diff --check`

## Performance Impact

- Not performance-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5198
- #5199

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `api` - REST API, serializers, views

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The trybuild pass fixture uses the public `reinhardt_pages::wasm_server_api` re-export so the macro path and generated target gating are covered together.

🤖 Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `#[wasm_server_api]` macro for declaring paired WASM/browser and server function variants with automatic compile-time validation of matching signatures and visibility.

* **Documentation**
  * Updated README with macro references.
  * Added comprehensive documentation for `#[wasm_server_api]` macro usage and validation rules.

* **Tests**
  * Added UI test suite covering both valid and invalid macro usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->