### PR TITLE
fix(urls): plumb matched path into route context

### DIFF
--- a/crates/reinhardt-urls/src/routers/client_router/core.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/core.rs
@@ -82,6 +82,8 @@ impl NavigationSubscription {
 pub struct ClientRouteMatch {
 	/// The matched route.
 	pub route: ClientRoute,
+	/// Matched path without the query string.
+	pub path: String,
 	/// Extracted path parameters.
 	pub params: HashMap<String, String>,
 	/// Parameter values in the order they appear in the pattern.
@@ -744,6 +746,7 @@ impl ClientRouter {
 			if let Some((params, param_values)) = route.pattern.matches(path_only) {
 				let route_match = ClientRouteMatch {
 					route: route.clone(),
+					path: path_only.to_string(),
 					params,
 					param_values,
 					query: query.clone(),
@@ -1004,6 +1007,7 @@ impl ClientRouter {
 		if let Some(route_match) = self.match_path(&path) {
 			let ctx =
 				ParamContext::new(route_match.params.clone(), route_match.param_values.clone())
+					.with_path(route_match.path.clone())
 					.with_query(route_match.query.clone());
 
 			match route_match.route.handler.handle(&ctx) {

--- a/crates/reinhardt-urls/src/routers/client_router/handler.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/handler.rs
@@ -310,10 +310,7 @@ where
 {
 	fn handle(&self, ctx: &ParamContext) -> Result<Page, RouterError> {
 		let route_ctx = RouteContext::new(
-			// The matched path is not directly available to RouteHandler;
-			// pass an empty placeholder. Handlers that need the path can
-			// read it from the router's `current_path` signal.
-			String::new(),
+			ctx.path().unwrap_or("").to_string(),
 			ctx.params().clone(),
 			ctx.query().unwrap_or("").to_string(),
 		);

--- a/crates/reinhardt-urls/src/routers/client_router/params.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/params.rs
@@ -14,6 +14,21 @@ use super::error::PathError;
 /// and ordered parameter values (for tuple extraction).
 #[derive(Debug, Clone)]
 pub struct ParamContext {
+	/// Matched path without the query string.
+	///
+	/// Populated by [`ClientRouter::render_current`] for routes registered
+	/// via [`ClientRouter::page`] so [`RouteContext::path`] can expose the
+	/// router's matched path to [`FromRequest`] implementations.
+	///
+	/// `None` for direct test construction and for routes registered via
+	/// the legacy `route` / `route_params` / `route_result` / `route_path*`
+	/// APIs (those handlers do not read the path through `RouteContext`).
+	///
+	/// [`ClientRouter::render_current`]: super::core::ClientRouter::render_current
+	/// [`ClientRouter::page`]: super::core::ClientRouter::page
+	/// [`RouteContext::path`]: super::from_request::RouteContext::path
+	/// [`FromRequest`]: super::from_request::FromRequest
+	pub(crate) path: Option<String>,
 	/// Named parameters extracted from the path.
 	pub(crate) params: HashMap<String, String>,
 	/// Parameter values in the order they appear in the pattern.
@@ -39,10 +54,25 @@ impl ParamContext {
 	/// Creates a new parameter context.
 	pub fn new(params: HashMap<String, String>, param_values: Vec<String>) -> Self {
 		Self {
+			path: None,
 			params,
 			param_values,
 			query: None,
 		}
+	}
+
+	/// Creates a new parameter context with an attached matched path.
+	///
+	/// Used by [`ClientRouter::render_current`] when dispatching a
+	/// [`ClientRouter::page`] handler so [`RouteContext::path`] exposes
+	/// the matched path without any query string.
+	///
+	/// [`ClientRouter::render_current`]: super::core::ClientRouter::render_current
+	/// [`ClientRouter::page`]: super::core::ClientRouter::page
+	/// [`RouteContext::path`]: super::from_request::RouteContext::path
+	pub fn with_path(mut self, path: String) -> Self {
+		self.path = Some(path);
+		self
 	}
 
 	/// Creates a new parameter context with an attached query string.
@@ -63,6 +93,11 @@ impl ParamContext {
 	/// route pattern, keyed by their `{name}` placeholder).
 	pub fn params(&self) -> &HashMap<String, String> {
 		&self.params
+	}
+
+	/// Returns the matched path (without the query string), if present.
+	pub fn path(&self) -> Option<&str> {
+		self.path.as_deref()
 	}
 
 	/// Returns the raw query string (without the leading `?`), if any.

--- a/crates/reinhardt-urls/tests/clientrouter_page_integration_tests.rs
+++ b/crates/reinhardt-urls/tests/clientrouter_page_integration_tests.rs
@@ -45,6 +45,23 @@ fn search_page(props: SearchPageProps) -> Page {
 	Page::Text(format!("search: {}", props.q.into_inner()).into())
 }
 
+#[derive(Debug)]
+struct PathEchoProps {
+	path: String,
+}
+
+impl FromRequest for PathEchoProps {
+	fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError> {
+		Ok(Self {
+			path: ctx.path().to_string(),
+		})
+	}
+}
+
+fn path_echo_page(props: PathEchoProps) -> Page {
+	Page::Text(props.path.into())
+}
+
 // --- Helpers ---------------------------------------------------------------
 
 /// Render the router for a path by driving the public `current_path` signal
@@ -90,6 +107,32 @@ fn page_method_extracts_query_param() {
 	// Assert
 	let s = page_text(&view);
 	assert_eq!(s, "search: rust", "expected `search: rust`, got: {s}");
+}
+
+#[rstest]
+fn page_method_exposes_matched_path_to_from_request() {
+	// Arrange
+	let router = ClientRouter::new().page("path-echo", "/users/{id}/", path_echo_page);
+
+	// Act
+	let view = router_render(&router, "/users/42/");
+
+	// Assert
+	let s = page_text(&view);
+	assert_eq!(s, "/users/42/", "expected matched path, got: {s}");
+}
+
+#[rstest]
+fn page_method_exposes_matched_path_without_query() {
+	// Arrange
+	let router = ClientRouter::new().page("path-echo-query", "/search/", path_echo_page);
+
+	// Act
+	let view = router_render(&router, "/search/?q=rust");
+
+	// Assert
+	let s = page_text(&view);
+	assert_eq!(s, "/search/", "expected query-free matched path, got: {s}");
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

This PR addresses:

- Threads the query-free matched client route path through `ClientRouteMatch` and `ParamContext`.
- Uses that path when constructing `RouteContext` for `FromRequest` page handlers.
- Adds regression coverage for `RouteContext::path()` with and without a query string.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`FromRequestHandler` previously constructed `RouteContext` with an empty path because the matched path was not carried through `ParamContext`. This made `RouteContext::path()` unreliable for client-router page handlers.

Fixes #4758

Related to: #4668, #4753

## How Was This Tested?

- `git diff --check`
- `cargo test -p reinhardt-urls --features client-router --test clientrouter_page_integration_tests`
- `cargo test -p reinhardt-urls --features client-router --lib`
- `cargo make fmt-check`

Note: `cargo test -p reinhardt-urls --features client-router` was started and passed the lib tests plus early integration tests, but was stopped after the unrelated `page_ui` trybuild phase ran for a long time after completing its trybuild build. The focused integration test and lib test gates above passed.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4758
- Related to #4668
- Related to #4753

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- `RouteContext::path()` now receives the same query-free path that `ClientRouter::match_path` matched against.