### PR TITLE
feat(pages): add explicit asset loading helpers

### DIFF
--- a/crates/reinhardt-core/src/types/page/head.rs
+++ b/crates/reinhardt-core/src/types/page/head.rs
@@ -201,9 +201,9 @@ impl LinkTag {
 		Self::preload(href, "image")
 	}
 
-	/// Creates a font preload link.
+	/// Creates a font preload link with anonymous CORS.
 	pub fn preload_font(href: impl Into<Cow<'static, str>>) -> Self {
-		Self::preload(href, "font")
+		Self::preload(href, "font").with_crossorigin("anonymous")
 	}
 
 	/// Creates a module preload link.
@@ -657,7 +657,7 @@ impl Head {
 		self.link(LinkTag::preload_image(href))
 	}
 
-	/// Adds a font preload link.
+	/// Adds a font preload link with anonymous CORS.
 	pub fn preload_font(self, href: impl Into<Cow<'static, str>>) -> Self {
 		self.link(LinkTag::preload_font(href))
 	}
@@ -896,7 +896,7 @@ mod tests {
 		);
 		assert_eq!(
 			LinkTag::preload_font("/static/font.woff2").to_html(),
-			"<link rel=\"preload\" href=\"/static/font.woff2\" as=\"font\">"
+			"<link rel=\"preload\" href=\"/static/font.woff2\" as=\"font\" crossorigin=\"anonymous\">"
 		);
 	}
 
@@ -1027,7 +1027,9 @@ mod tests {
 		assert!(html.contains("<link rel=\"preload\" href=\"/static/app.js\" as=\"script\">"));
 		assert!(html.contains("<link rel=\"preload\" href=\"/static/app.css\" as=\"style\">"));
 		assert!(html.contains("<link rel=\"preload\" href=\"/static/hero.png\" as=\"image\">"));
-		assert!(html.contains("<link rel=\"preload\" href=\"/static/font.woff2\" as=\"font\">"));
+		assert!(html.contains(
+			"<link rel=\"preload\" href=\"/static/font.woff2\" as=\"font\" crossorigin=\"anonymous\">"
+		));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-core/src/types/page/head.rs
+++ b/crates/reinhardt-core/src/types/page/head.rs
@@ -25,6 +25,7 @@
 //! ```
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use super::util::html_escape;
 
@@ -183,6 +184,41 @@ impl LinkTag {
 		let mut link = Self::new("preload", href);
 		link.as_attr = Some(as_type.into());
 		link
+	}
+
+	/// Creates a script preload link.
+	pub fn preload_script(href: impl Into<Cow<'static, str>>) -> Self {
+		Self::preload(href, "script")
+	}
+
+	/// Creates a style preload link.
+	pub fn preload_style(href: impl Into<Cow<'static, str>>) -> Self {
+		Self::preload(href, "style")
+	}
+
+	/// Creates an image preload link.
+	pub fn preload_image(href: impl Into<Cow<'static, str>>) -> Self {
+		Self::preload(href, "image")
+	}
+
+	/// Creates a font preload link.
+	pub fn preload_font(href: impl Into<Cow<'static, str>>) -> Self {
+		Self::preload(href, "font")
+	}
+
+	/// Creates a module preload link.
+	pub fn module_preload(href: impl Into<Cow<'static, str>>) -> Self {
+		Self::new("modulepreload", href)
+	}
+
+	/// Creates a preconnect link.
+	pub fn preconnect(href: impl Into<Cow<'static, str>>) -> Self {
+		Self::new("preconnect", href)
+	}
+
+	/// Creates a DNS prefetch link.
+	pub fn dns_prefetch(href: impl Into<Cow<'static, str>>) -> Self {
+		Self::new("dns-prefetch", href)
 	}
 
 	/// Sets the type attribute.
@@ -606,6 +642,41 @@ impl Head {
 		self.link(LinkTag::preload(href, as_type))
 	}
 
+	/// Adds a script preload link.
+	pub fn preload_script(self, href: impl Into<Cow<'static, str>>) -> Self {
+		self.link(LinkTag::preload_script(href))
+	}
+
+	/// Adds a style preload link.
+	pub fn preload_style(self, href: impl Into<Cow<'static, str>>) -> Self {
+		self.link(LinkTag::preload_style(href))
+	}
+
+	/// Adds an image preload link.
+	pub fn preload_image(self, href: impl Into<Cow<'static, str>>) -> Self {
+		self.link(LinkTag::preload_image(href))
+	}
+
+	/// Adds a font preload link.
+	pub fn preload_font(self, href: impl Into<Cow<'static, str>>) -> Self {
+		self.link(LinkTag::preload_font(href))
+	}
+
+	/// Adds a module preload link.
+	pub fn module_preload(self, href: impl Into<Cow<'static, str>>) -> Self {
+		self.link(LinkTag::module_preload(href))
+	}
+
+	/// Adds a preconnect link.
+	pub fn preconnect(self, href: impl Into<Cow<'static, str>>) -> Self {
+		self.link(LinkTag::preconnect(href))
+	}
+
+	/// Adds a DNS prefetch link.
+	pub fn dns_prefetch(self, href: impl Into<Cow<'static, str>>) -> Self {
+		self.link(LinkTag::dns_prefetch(href))
+	}
+
 	/// Adds a canonical URL link.
 	pub fn canonical(self, href: impl Into<Cow<'static, str>>) -> Self {
 		self.link(LinkTag::new("canonical", href))
@@ -677,40 +748,66 @@ impl Head {
 		self
 	}
 
+	/// Returns a copy with exact duplicate head entries removed.
+	///
+	/// Deduplication is intentionally conservative: only entries with identical
+	/// rendered HTML are collapsed. Distinct Open Graph images, media-specific
+	/// stylesheets, or crossorigin variants stay separate.
+	pub fn deduplicated(&self) -> Self {
+		let mut head = self.clone();
+		head.dedup_in_place();
+		head
+	}
+
+	/// Removes exact duplicate head entries and returns this head.
+	pub fn dedup(mut self) -> Self {
+		self.dedup_in_place();
+		self
+	}
+
+	/// Removes exact duplicate head entries in place.
+	pub fn dedup_in_place(&mut self) {
+		retain_unique_by(&mut self.meta_tags, MetaTag::to_html);
+		retain_unique_by(&mut self.links, LinkTag::to_html);
+		retain_unique_by(&mut self.styles, StyleTag::to_html);
+		retain_unique_by(&mut self.scripts, ScriptTag::to_html);
+	}
+
 	/// Renders the head section to HTML string.
 	///
 	/// This method generates the complete `<head>` tag content,
 	/// including all meta tags, links, scripts, and styles.
 	pub fn to_html(&self) -> String {
+		let head = self.deduplicated();
 		let mut parts = Vec::new();
 
 		// Base tag
-		if let Some(ref base) = self.base {
+		if let Some(ref base) = head.base {
 			parts.push(format!("<base href=\"{}\">", html_escape(base)));
 		}
 
 		// Meta tags
-		for meta in &self.meta_tags {
+		for meta in &head.meta_tags {
 			parts.push(meta.to_html());
 		}
 
 		// Title
-		if let Some(ref title) = self.title {
+		if let Some(ref title) = head.title {
 			parts.push(format!("<title>{}</title>", html_escape(title)));
 		}
 
 		// Link tags
-		for link in &self.links {
+		for link in &head.links {
 			parts.push(link.to_html());
 		}
 
 		// Style tags
-		for style in &self.styles {
+		for style in &head.styles {
 			parts.push(style.to_html());
 		}
 
 		// Script tags
-		for script in &self.scripts {
+		for script in &head.scripts {
 			parts.push(script.to_html());
 		}
 
@@ -726,6 +823,11 @@ impl Head {
 			&& self.styles.is_empty()
 			&& self.base.is_none()
 	}
+}
+
+fn retain_unique_by<T>(items: &mut Vec<T>, mut key: impl FnMut(&T) -> String) {
+	let mut seen = BTreeSet::new();
+	items.retain(|item| seen.insert(key(item)));
 }
 
 #[cfg(test)]
@@ -763,6 +865,38 @@ mod tests {
 		assert_eq!(
 			link.to_html(),
 			"<link rel=\"stylesheet\" href=\"/static/css/style.css\">"
+		);
+	}
+
+	#[rstest]
+	fn test_link_tag_asset_hints() {
+		assert_eq!(
+			LinkTag::preconnect("https://cdn.example.com").to_html(),
+			"<link rel=\"preconnect\" href=\"https://cdn.example.com\">"
+		);
+		assert_eq!(
+			LinkTag::dns_prefetch("https://cdn.example.com").to_html(),
+			"<link rel=\"dns-prefetch\" href=\"https://cdn.example.com\">"
+		);
+		assert_eq!(
+			LinkTag::module_preload("/static/app.mjs").to_html(),
+			"<link rel=\"modulepreload\" href=\"/static/app.mjs\">"
+		);
+		assert_eq!(
+			LinkTag::preload_script("/static/app.js").to_html(),
+			"<link rel=\"preload\" href=\"/static/app.js\" as=\"script\">"
+		);
+		assert_eq!(
+			LinkTag::preload_style("/static/app.css").to_html(),
+			"<link rel=\"preload\" href=\"/static/app.css\" as=\"style\">"
+		);
+		assert_eq!(
+			LinkTag::preload_image("/static/hero.png").to_html(),
+			"<link rel=\"preload\" href=\"/static/hero.png\" as=\"image\">"
+		);
+		assert_eq!(
+			LinkTag::preload_font("/static/font.woff2").to_html(),
+			"<link rel=\"preload\" href=\"/static/font.woff2\" as=\"font\">"
 		);
 	}
 
@@ -872,6 +1006,67 @@ mod tests {
 		assert_eq!(merged.title, Some(Cow::Borrowed("Override Title")));
 		assert_eq!(merged.meta_tags.len(), 2); // charset + description
 		assert_eq!(merged.links.len(), 2); // base.css + overlay.css
+	}
+
+	#[rstest]
+	fn test_head_asset_hint_helpers() {
+		let head = Head::new()
+			.preconnect("https://cdn.example.com")
+			.dns_prefetch("https://cdn.example.com")
+			.module_preload("/static/app.mjs")
+			.preload_script("/static/app.js")
+			.preload_style("/static/app.css")
+			.preload_image("/static/hero.png")
+			.preload_font("/static/font.woff2");
+
+		let html = head.to_html();
+
+		assert!(html.contains("<link rel=\"preconnect\" href=\"https://cdn.example.com\">"));
+		assert!(html.contains("<link rel=\"dns-prefetch\" href=\"https://cdn.example.com\">"));
+		assert!(html.contains("<link rel=\"modulepreload\" href=\"/static/app.mjs\">"));
+		assert!(html.contains("<link rel=\"preload\" href=\"/static/app.js\" as=\"script\">"));
+		assert!(html.contains("<link rel=\"preload\" href=\"/static/app.css\" as=\"style\">"));
+		assert!(html.contains("<link rel=\"preload\" href=\"/static/hero.png\" as=\"image\">"));
+		assert!(html.contains("<link rel=\"preload\" href=\"/static/font.woff2\" as=\"font\">"));
+	}
+
+	#[rstest]
+	fn test_head_to_html_deduplicates_exact_entries() {
+		let head = Head::new()
+			.meta_description("Repeated")
+			.meta_description("Repeated")
+			.preconnect("https://cdn.example.com")
+			.preconnect("https://cdn.example.com")
+			.inline_css("body { color: black; }")
+			.inline_css("body { color: black; }")
+			.js_defer("/static/app.js")
+			.js_defer("/static/app.js");
+
+		let html = head.to_html();
+
+		assert_eq!(html.matches("name=\"description\"").count(), 1);
+		assert_eq!(html.matches("rel=\"preconnect\"").count(), 1);
+		assert_eq!(
+			html.matches("<style>body { color: black; }</style>")
+				.count(),
+			1
+		);
+		assert_eq!(
+			html.matches("<script src=\"/static/app.js\" defer></script>")
+				.count(),
+			1
+		);
+	}
+
+	#[rstest]
+	fn test_head_dedup_preserves_distinct_asset_variants() {
+		let head = Head::new()
+			.link(LinkTag::preconnect("https://cdn.example.com"))
+			.link(LinkTag::preconnect("https://cdn.example.com").with_crossorigin("anonymous"));
+
+		let deduplicated = head.deduplicated();
+
+		assert_eq!(deduplicated.links.len(), 2);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-pages/docs/react_to_reinhardt.md
+++ b/crates/reinhardt-pages/docs/react_to_reinhardt.md
@@ -87,12 +87,16 @@ fn document_head() -> Head {
 }
 ```
 
+`preload_font` emits `crossorigin="anonymous"` by default so CSS `@font-face`
+loads can reuse the preload instead of issuing a second font request.
+
 During SSR, Reinhardt removes exact duplicate head entries after rendering each
-entry to HTML. The deduplication is conservative: entries with different
-attributes, media conditions, `crossorigin` values, or Open Graph payloads remain
-separate. Hydration does not scan component bodies for metadata or run a
-browser-only imperative asset loader; the server-rendered head remains the
-deterministic source of document-level metadata and hints.
+entry to HTML, including duplicates between renderer defaults and a supplied
+`Head`. The deduplication is conservative: entries with different attributes,
+media conditions, `crossorigin` values, or Open Graph payloads remain separate.
+Hydration does not scan component bodies for metadata or run a browser-only
+imperative asset loader; the server-rendered head remains the deterministic
+source of document-level metadata and hints.
 
 ## Components, props, and children
 

--- a/crates/reinhardt-pages/docs/react_to_reinhardt.md
+++ b/crates/reinhardt-pages/docs/react_to_reinhardt.md
@@ -41,8 +41,8 @@ React API names.
 | React Server Components and RSC/Flight transport | Explicit non-goal. Reinhardt does not provide React-compatible component transport. | #5311 |
 | `"use client"` / `"use server"` directives | Explicit non-goal. Reinhardt uses Rust/WASM targets and `#[server_fn]`, not directive strings. | #5311 |
 | Server reference passing | Explicit non-goal. `#[server_fn]` generates typed client stubs but does not serialize server function references into client components. | #5311 |
-| Automatic metadata hoisting | Candidate follow-up. Current Reinhardt metadata is explicit through `head!` and `Head`. | #5312 |
-| React DOM asset APIs such as `preinit`, `preload`, `preconnect`, and `prefetchDNS` | Candidate follow-up for explicit `Head` / `LinkTag` helpers and deduplication decisions. | #5312 |
+| Automatic metadata hoisting | Explicit non-goal. Reinhardt metadata stays explicit through `head!` and `Head`; component body nodes are not hoisted into the document head. | #5312 |
+| React DOM asset APIs such as `preinit`, `preload`, `preconnect`, and `prefetchDNS` | Reinhardt-native explicit `Head` / `LinkTag` asset hint helpers with exact duplicate SSR deduplication; no browser-only imperative asset API. | #5312 |
 | `createPortal` | Candidate follow-up. `ClientLauncher::ensure_portal` is a launcher helper, not a general portal API. | #5313 |
 | Custom element property, attribute, and event interop | Candidate follow-up against `page!` attributes, typed events, and DOM abstraction. | #5314 |
 | `ref` as a regular prop | Candidate follow-up. Current guidance is `use_ref` and typed component props. | #5314 |
@@ -51,6 +51,48 @@ React API names.
 
 The umbrella tracker for this classification is #5198. It should close only
 after this table reflects the final outcome of each focused follow-up.
+
+## Metadata and asset loading
+
+React 19 allows metadata such as `<title>`, `<meta>`, and `<link>` to appear in
+component bodies and be hoisted into the document head. Reinhardt Pages keeps
+that contract explicit. Document metadata belongs in `head!` or in a `Head`
+value attached to the page; ordinary `page!` body nodes render where they are
+declared.
+
+Asset loading hints use the same explicit head model. `Head` and `LinkTag`
+provide helpers for common browser hints:
+
+- `preconnect`
+- `dns_prefetch`
+- `module_preload`
+- `preload_script`
+- `preload_style`
+- `preload_image`
+- `preload_font`
+
+```rust,ignore
+use reinhardt::pages::prelude::*;
+
+fn document_head() -> Head {
+    Head::new()
+        .title("Dashboard")
+        .preconnect("https://cdn.example.com")
+        .dns_prefetch("https://cdn.example.com")
+        .module_preload("/static/app.mjs")
+        .preload_script("/static/app.js")
+        .preload_style("/static/app.css")
+        .preload_image("/static/hero.png")
+        .preload_font("/static/font.woff2")
+}
+```
+
+During SSR, Reinhardt removes exact duplicate head entries after rendering each
+entry to HTML. The deduplication is conservative: entries with different
+attributes, media conditions, `crossorigin` values, or Open Graph payloads remain
+separate. Hydration does not scan component bodies for metadata or run a
+browser-only imperative asset loader; the server-rendered head remains the
+deterministic source of document-level metadata and hints.
 
 ## Components, props, and children
 

--- a/crates/reinhardt-pages/src/ssr/renderer.rs
+++ b/crates/reinhardt-pages/src/ssr/renderer.rs
@@ -259,6 +259,7 @@ impl SsrRenderer {
 	/// * `content` - The rendered body content
 	/// * `view_head` - Optional head extracted from a View
 	fn wrap_in_html_with_head(&self, content: &str, view_head: Option<&Head>) -> String {
+		let view_head = view_head.map(Head::deduplicated);
 		let mut html = String::with_capacity(content.len() + 1024);
 
 		// DOCTYPE and html opening
@@ -276,7 +277,7 @@ impl SsrRenderer {
 		);
 
 		// Add View's head elements
-		if let Some(head) = view_head {
+		if let Some(head) = view_head.as_ref() {
 			// Title from View's head
 			if let Some(ref title) = head.title {
 				html.push_str(&format!("<title>{}</title>\n", html_escape(title)));

--- a/crates/reinhardt-pages/src/ssr/renderer.rs
+++ b/crates/reinhardt-pages/src/ssr/renderer.rs
@@ -1,5 +1,7 @@
 //! SSR Renderer for Component-based server-side rendering.
 
+use std::collections::BTreeSet;
+
 use super::markers::{HydrationMarker, HydrationStrategy};
 use super::state::SsrState;
 use crate::auth::AuthData;
@@ -260,6 +262,7 @@ impl SsrRenderer {
 	/// * `view_head` - Optional head extracted from a View
 	fn wrap_in_html_with_head(&self, content: &str, view_head: Option<&Head>) -> String {
 		let view_head = view_head.map(Head::deduplicated);
+		let mut seen_head_entries = BTreeSet::new();
 		let mut html = String::with_capacity(content.len() + 1024);
 
 		// DOCTYPE and html opening
@@ -271,9 +274,15 @@ impl SsrRenderer {
 
 		// Head section
 		html.push_str("<head>\n");
-		html.push_str("<meta charset=\"UTF-8\">\n");
-		html.push_str(
-			"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n",
+		push_unique_head_entry(
+			&mut html,
+			&mut seen_head_entries,
+			"<meta charset=\"UTF-8\">",
+		);
+		push_unique_head_entry(
+			&mut html,
+			&mut seen_head_entries,
+			"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">",
 		);
 
 		// Add View's head elements
@@ -285,22 +294,22 @@ impl SsrRenderer {
 
 			// View's meta tags
 			for meta in &head.meta_tags {
-				html.push_str(&meta.to_html());
+				push_unique_head_entry(&mut html, &mut seen_head_entries, meta.to_html());
 			}
 
 			// View's links
 			for link in &head.links {
-				html.push_str(&link.to_html());
+				push_unique_head_entry(&mut html, &mut seen_head_entries, link.to_html());
 			}
 
 			// View's styles
 			for style in &head.styles {
-				html.push_str(&style.to_html());
+				push_unique_head_entry(&mut html, &mut seen_head_entries, style.to_html());
 			}
 
 			// View's scripts (in head)
 			for script in &head.scripts {
-				html.push_str(&script.to_html());
+				push_unique_head_entry(&mut html, &mut seen_head_entries, script.to_html());
 			}
 		}
 
@@ -461,6 +470,20 @@ fn html_escape(s: &str) -> String {
 /// context - they will see `</script>` and close the tag, allowing XSS.
 fn escape_json_for_script(json: &str) -> String {
 	json.replace("</", "<\\/")
+}
+
+fn push_unique_head_entry(
+	html: &mut String,
+	seen: &mut BTreeSet<String>,
+	entry: impl Into<String>,
+) {
+	let entry = entry.into();
+	if seen.contains(&entry) {
+		return;
+	}
+	html.push_str(&entry);
+	html.push('\n');
+	seen.insert(entry);
 }
 
 /// Maximum input size for HTML minification (1 MiB).

--- a/crates/reinhardt-pages/tests/ssr_head_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_head_integration_tests.rs
@@ -12,10 +12,10 @@
 //! Test Categories:
 //! - View Head Only: 2 tests
 //! - No Head: 1 test
-//! - Multiple Elements: 3 tests
+//! - Multiple Elements: 4 tests
 //! - Edge Cases: 2 tests
 //!
-//! Total: 8 tests
+//! Total: 9 tests
 
 #[cfg(native)]
 mod ssr_tests {
@@ -134,6 +134,34 @@ mod ssr_tests {
 
 		assert!(html.contains("<title>My Page</title>"));
 		assert!(html.contains("<meta name=\"description\" content=\"Page description\""));
+	}
+
+	/// Tests exact duplicate asset hints are deduplicated during SSR.
+	#[rstest]
+	fn test_duplicate_asset_hints_are_deduplicated_during_ssr() {
+		let view_head = Head::new()
+			.preconnect("https://cdn.example.com")
+			.preconnect("https://cdn.example.com")
+			.preload_script("/static/app.js")
+			.preload_script("/static/app.js");
+		let view = PageElement::new("div")
+			.child("Content")
+			.into_page()
+			.with_head(view_head);
+
+		let mut renderer = SsrRenderer::new();
+		let html = renderer.render_page_with_view_head(view);
+
+		assert_eq!(
+			html.matches("<link rel=\"preconnect\" href=\"https://cdn.example.com\">")
+				.count(),
+			1
+		);
+		assert_eq!(
+			html.matches("<link rel=\"preload\" href=\"/static/app.js\" as=\"script\">")
+				.count(),
+			1
+		);
 	}
 
 	// ============================================================================

--- a/crates/reinhardt-pages/tests/ssr_head_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_head_integration_tests.rs
@@ -164,6 +164,28 @@ mod ssr_tests {
 		);
 	}
 
+	/// Tests exact duplicate default meta tags are deduplicated during SSR.
+	#[rstest]
+	fn test_default_meta_tags_are_deduplicated_during_ssr() {
+		let view_head = Head::with_defaults();
+		let view = PageElement::new("div")
+			.child("Content")
+			.into_page()
+			.with_head(view_head);
+
+		let mut renderer = SsrRenderer::new();
+		let html = renderer.render_page_with_view_head(view);
+
+		assert_eq!(html.matches("<meta charset=\"UTF-8\">").count(), 1);
+		assert_eq!(
+			html.matches(
+				"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">"
+			)
+			.count(),
+			1
+		);
+	}
+
 	// ============================================================================
 	// Edge Case Tests
 	// ============================================================================


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds explicit `Head` / `LinkTag` helpers for `preconnect`, `dns_prefetch`, `module_preload`, and typed preload hints.
- Applies conservative exact duplicate deduplication to `Head::to_html()` and the SSR `render_page_with_view_head` path.
- Documents the #5312 decision: metadata remains explicit through `head!` / `Head`, with no automatic component-body hoisting or browser-only imperative asset loader.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- React 19 provides metadata hoisting and React DOM asset loading APIs, but Reinhardt needs a deterministic Rust/WASM/SSR contract.
- This keeps document metadata explicit and adds Reinhardt-native helper methods for common asset hints.
- Exact duplicate head entries are collapsed only after rendering to HTML, preserving distinct media, crossorigin, and metadata variants.

Fixes #5312

Related to: #5198

## How Was This Tested?

- `cargo test -p reinhardt-core --lib --features page test_link_tag_asset_hints -- --nocapture`
- `cargo test -p reinhardt-core --lib --features page test_head_asset_hint_helpers -- --nocapture`
- `cargo test -p reinhardt-core --lib --features page test_head_to_html_deduplicates_exact_entries -- --nocapture`
- `cargo test -p reinhardt-core --lib --features page test_head_dedup_preserves_distinct_asset_variants -- --nocapture`
- `cargo test -p reinhardt-pages --test ssr_head_integration_tests -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --doc -p reinhardt-pages`
- `cargo doc -p reinhardt-pages --no-deps`
- `cargo doc -p reinhardt-core --features page --no-deps` (passes; existing feature-gated link warnings in `reinhardt-core/src/lib.rs` remain unrelated)

## Performance Impact

- No measured runtime impact. Deduplication only renders and compares head entries when a `Head` is converted to HTML or rendered through SSR.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5198
- #5312

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Generated with [Codex](https://openai.com/codex)