### PR TITLE
docs: define wasm/native API parity contract

### DIFF
--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -1317,6 +1317,9 @@ fn generate_server_handler(
 	// active (#4711). The struct + ServerFnMetadata impl are always present;
 	// the optional `Args` struct and `MockableServerFn` impl live behind the
 	// inner `feature = "msw"` cfg (see `msw_wasm_inner_tokens` above).
+	// Parity: the marker module is P1. WASM emits the marker so
+	// `.server_fn(function_name::marker)` remains nameable in shared route
+	// declarations, but route registration is native-only behavior.
 	let wasm_marker_tokens = quote! {
 		#[cfg(all(target_family = "wasm", target_os = "unknown"))]
 		#vis mod #marker_module_name {

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -1336,7 +1336,11 @@ fn generate_server_handler(
 			#[allow(unused_imports)]
 			use super::*;
 
-			#[doc = concat!("Marker struct for server function `", #name_str, "` (use with `.server_fn()`)")]
+			#[doc = concat!("Marker struct for server function `", #name_str, "` (use with `.server_fn()`).")]
+			#[doc = ""]
+			#[doc = "Parity: P1."]
+			#[doc = ""]
+			#[doc = "The marker is emitted on WASM so shared route declarations can name it, but server route registration is native-only behavior."]
 			pub struct marker;
 
 			impl #pages_crate::server_fn::ServerFnMetadata for marker {
@@ -1457,7 +1461,11 @@ fn generate_server_handler(
 		#vis mod #marker_module_name {
 			use super::*;
 
-			#[doc = concat!("Marker struct for server function `", #name_str, "` (use with `.server_fn()`)")]
+			#[doc = concat!("Marker struct for server function `", #name_str, "` (use with `.server_fn()`).")]
+			#[doc = ""]
+			#[doc = "Parity: P1."]
+			#[doc = ""]
+			#[doc = "The marker is emitted on both native and WASM so shared route declarations can name it. Native builds register the server handler; WASM builds keep the marker metadata inert."]
 			pub struct marker;
 
 			// Cross-target metadata. ServerFnMetadata lives in reinhardt-pages

--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -37,6 +37,9 @@
 //!   `.server()` and `.client()` methods available.
 //! - When `client-router` feature is **disabled**: Server-only [`UnifiedRouter`] with
 //!   only `.server()` method available.
+//!
+//! Cross-target behavior follows the P0/P1/P2 contract documented in
+//! `instructions/API_PARITY.md`.
 
 #[cfg(native)]
 use crate::routers::server_router::ServerRouter;
@@ -105,6 +108,12 @@ impl UnifiedRouter {
 	/// Configure server-side routing with a closure.
 	///
 	/// The closure receives a [`ServerRouter`] and should return a configured router.
+	///
+	/// Parity: P1 on WASM and P2 on native.
+	///
+	/// Native builds execute the closure and store the configured `ServerRouter`.
+	/// WASM builds accept the same closure shape for type checking and return the
+	/// router unchanged without registration side effects.
 	///
 	/// # Example
 	///
@@ -456,6 +465,12 @@ impl UnifiedRouter {
 	}
 
 	/// Configure server-side routing with a closure.
+	///
+	/// Parity: P1 on WASM and P2 on native.
+	///
+	/// Native builds execute the closure and store the configured `ServerRouter`.
+	/// WASM builds accept the same closure shape for type checking and return the
+	/// router unchanged without registration side effects.
 	pub fn server<F>(mut self, f: F) -> Self
 	where
 		F: FnOnce(ServerRouter) -> ServerRouter,
@@ -811,6 +826,12 @@ impl UnifiedRouter {
 	}
 
 	/// Accept and discard server-side routing configuration.
+	///
+	/// Parity: P1 on WASM and P2 on native.
+	///
+	/// Native builds execute the closure and store the configured `ServerRouter`.
+	/// WASM builds accept the same closure shape for type checking and return the
+	/// router unchanged without registration side effects.
 	///
 	/// On WASM, server routing is not available. The closure is accepted for
 	/// cross-target type-checking — its `ServerRouter` parameter type is unified

--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -109,7 +109,7 @@ impl UnifiedRouter {
 	///
 	/// The closure receives a [`ServerRouter`] and should return a configured router.
 	///
-	/// Parity: P1 on WASM and P2 on native.
+	/// Parity: P1.
 	///
 	/// Native builds execute the closure and store the configured `ServerRouter`.
 	/// WASM builds accept the same closure shape for type checking and return the
@@ -466,7 +466,7 @@ impl UnifiedRouter {
 
 	/// Configure server-side routing with a closure.
 	///
-	/// Parity: P1 on WASM and P2 on native.
+	/// Parity: P1.
 	///
 	/// Native builds execute the closure and store the configured `ServerRouter`.
 	/// WASM builds accept the same closure shape for type checking and return the
@@ -827,7 +827,7 @@ impl UnifiedRouter {
 
 	/// Accept and discard server-side routing configuration.
 	///
-	/// Parity: P1 on WASM and P2 on native.
+	/// Parity: P1.
 	///
 	/// Native builds execute the closure and store the configured `ServerRouter`.
 	/// WASM builds accept the same closure shape for type checking and return the

--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -466,11 +466,11 @@ impl UnifiedRouter {
 
 	/// Configure server-side routing with a closure.
 	///
-	/// Parity: P1.
+	/// Parity: P0 native-only.
 	///
-	/// Native builds execute the closure and store the configured `ServerRouter`.
-	/// WASM builds accept the same closure shape for type checking and return the
-	/// router unchanged without registration side effects.
+	/// This arm only exists when `client-router` is disabled, and `routers.rs`
+	/// only re-exports it on native targets. WASM builds require the
+	/// `client-router` feature for the P1 no-op `server` closure shape.
 	pub fn server<F>(mut self, f: F) -> Self
 	where
 		F: FnOnce(ServerRouter) -> ServerRouter,

--- a/instructions/API_PARITY.md
+++ b/instructions/API_PARITY.md
@@ -1,0 +1,42 @@
+# WASM/Native API Parity Contract
+
+Public APIs that can be named by normal application code in both native and
+`wasm32-unknown-unknown` builds must declare one parity level.
+
+## Parity Levels
+
+| Level | Name | Contract | Call-site result |
+|---|---|---|---|
+| P2 | Behavioral parity | The symbol exists and performs meaningful target-specific behavior on both targets. | cfg-free use on both targets |
+| P1 | Symbol parity | The symbol exists on both targets, and one target is inert by design. | cfg-free naming and type-checking |
+| P0 | Target-only behavior | The behavior is intentionally absent from the other target. | misuse fails at compile time |
+
+The level applies per symbol. A type can be P1 while selected methods are P0.
+
+## Stub Taxonomy
+
+- Mirror: the same user-facing operation is meaningful on both targets.
+- No-op passthrough: the inert side accepts the same call shape and returns the builder unchanged.
+- Marker stub: a zero-sized symbol exists for type checking and registration syntax.
+- Inert data: data and metadata compile on both targets while runtime behavior stays native-only.
+- Native page stub: a client page function returns `Page::empty()` on native for route-table construction.
+
+## Accepted Application Paths
+
+The strict cfg-free acceptance scope is:
+
+- `examples/**/src/apps/**`
+- `examples/**/src/config/**`
+- `examples/**/src/shared/**`
+
+The scan excludes `#[cfg(test)]`, `build.rs`, binary entrypoints, and framework internals.
+
+## Review Checklist
+
+When adding a public API that can cross the client/server boundary:
+
+1. Declare P0, P1, or P2 in rustdoc.
+2. For P1, document the inert side and prove it has no network, database, filesystem, or registration side effect.
+3. For P0, keep the absent target unnameable so misuse fails at compile time.
+4. For WASM-visible symbols, verify that native-only dependencies do not enter the WASM graph.
+5. Add at least one compile test or example check for the parity surface.

--- a/instructions/DOCUMENTATION_STANDARDS.md
+++ b/instructions/DOCUMENTATION_STANDARDS.md
@@ -132,6 +132,13 @@ flowchart TD
     B -->|"Planned features"| H["lib.rs header<br/>(NOT README.md)"]
 ```
 
+### Cross-target API parity
+
+Public symbols that can be named from both native and WASM application code
+MUST document their parity level from `instructions/API_PARITY.md`.
+P1 symbols MUST state the inert-side behavior in rustdoc. P0 behavior MUST stay
+absent on the unsupported target so misuse fails during compilation.
+
 ---
 
 ## Documentation Consistency

--- a/instructions/QUICK_REFERENCE.md
+++ b/instructions/QUICK_REFERENCE.md
@@ -68,6 +68,8 @@
 - Check known CI failure patterns before deep investigation
 - Run `cargo doc --no-deps` locally before pushing doc-related fixes
 - Run `cargo make semver-check` locally and post the output as a PR comment with the `<!-- local-semver-check -->` marker before converting Draft → Ready on any PR touching public API (see instructions/PR_GUIDELINE.md § RP-1a)
+- Cross-target APIs must declare P0/P1/P2 parity and follow
+  `instructions/API_PARITY.md`.
 - Execute merge/conflict resolution and straightforward operations immediately without Plan Mode
 - Update the Obsidian wiki frequently and proactively — at the end of every meaningful work unit and whenever you learn, decide, or discover something worth preserving; when in doubt, write a short page (OW-1)
 - Check Obsidian MCP availability before attempting wiki updates; skip entirely if unavailable (OW-2, OW-3)


### PR DESCRIPTION
## Summary

This PR addresses:

- Documents the WASM/native API parity contract and P0/P1/P2 vocabulary.
- Links the contract from project documentation standards and quick reference.
- Adds parity documentation for existing router and server function marker surfaces.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Establishes the reviewable parity contract required by the API parity umbrella.

Fixes #5002

Related to: #5001

## How Was This Tested?

- `cargo fmt`
- `git diff --check`
- `cargo test -p reinhardt-routers-macros --test ui -- --nocapture`
- `cargo test -p reinhardt-pages --test ui -- --nocapture`
- `cargo test --doc`

## Performance Impact

- Not performance-related.

## Screenshots

- Not UI-related.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5001
- #5002

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

### Scope Label (select all that apply)
- [x] `routing` - URL routing, path matching

## Additional Context

- Draft PR; part 1 of the API parity stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added API parity standards documentation for cross-target behavior clarification
  * Updated server function and router documentation to clarify native and WASM compatibility expectations
  * Established new documentation standards requiring public APIs declare their parity level across compilation targets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->