### PR TITLE
feat!: emit shared model info for wasm parity

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -59,6 +59,8 @@ struct ModelAttributesParsed {
 	/// Whether to generate Info companion struct (Issue #4194).
 	/// `None` means not specified (defaults to `true` in `ModelConfig`).
 	info: Option<bool>,
+	/// Whether this model is only available on the native/server side.
+	server_only: bool,
 	/// Whether the original model has `#[derive(serde::Serialize)]`.
 	/// Passed from the attribute macro since derive macros cannot see `#[derive()]`.
 	serde_serialize: bool,
@@ -143,6 +145,8 @@ struct ModelConfig {
 	/// Whether to generate an `{Model}Info` companion struct (Issue #4194).
 	/// Defaults to `true`. Set `#[model(info = false)]` to opt out.
 	info: bool,
+	/// Whether this model should skip shared data/info output.
+	server_only: bool,
 	/// Whether the original model derives `serde::Serialize`.
 	serde_serialize: bool,
 	/// Whether the original model derives `serde::Deserialize`.
@@ -157,6 +161,7 @@ impl ModelConfig {
 		let mut constraints = Vec::new();
 		let mut manager: Option<syn::Path> = None;
 		let mut info: Option<bool> = None;
+		let mut server_only = false;
 		let mut serde_serialize = false;
 		let mut serde_deserialize = false;
 
@@ -204,6 +209,9 @@ impl ModelConfig {
 			if let Some(i) = model_attr.info {
 				info = Some(i);
 			}
+			if model_attr.server_only {
+				server_only = true;
+			}
 			if model_attr.serde_serialize {
 				serde_serialize = true;
 			}
@@ -225,6 +233,7 @@ impl ModelConfig {
 			constraints,
 			manager,
 			info: info.unwrap_or(true),
+			server_only,
 			serde_serialize,
 			serde_deserialize,
 		})
@@ -240,6 +249,7 @@ impl ModelConfig {
 		let mut unique_together = Vec::new();
 		let mut manager: Option<syn::Path> = None;
 		let mut info: Option<bool> = None;
+		let mut server_only = false;
 		let mut serde_serialize = false;
 		let mut serde_deserialize = false;
 
@@ -257,6 +267,14 @@ impl ModelConfig {
 				continue;
 			} else if ident == "serde_deserialize" {
 				serde_deserialize = true;
+				if input.peek(Token![,]) {
+					input.parse::<Token![,]>()?;
+				} else {
+					break;
+				}
+				continue;
+			} else if ident == "server_only" {
+				server_only = true;
 				if input.peek(Token![,]) {
 					input.parse::<Token![,]>()?;
 				} else {
@@ -326,6 +344,7 @@ impl ModelConfig {
 			unique_together,
 			manager,
 			info,
+			server_only,
 			serde_serialize,
 			serde_deserialize,
 		})
@@ -2198,18 +2217,26 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 		}
 	};
 
-	// Conditionally generate Info companion struct (Issue #4194)
-	let info_struct = if model_config.info {
-		generate_info_struct(
-			struct_name,
-			generics,
-			&field_infos,
-			&fk_field_infos,
-			model_config.serde_serialize,
-			model_config.serde_deserialize,
-		)?
-	} else {
+	let shared_info_output = if model_config.server_only {
 		quote! {}
+	} else {
+		// Conditionally generate Info companion struct (Issue #4194)
+		let info_struct = if model_config.info {
+			generate_info_struct(
+				struct_name,
+				generics,
+				&field_infos,
+				&fk_field_infos,
+				model_config.serde_serialize,
+				model_config.serde_deserialize,
+			)?
+		} else {
+			quote! {}
+		};
+		quote! {
+			#info_model_impl
+			#info_struct
+		}
 	};
 
 	// Determine the `type Objects` associated type for the Model impl.
@@ -2226,7 +2253,7 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 			// Generate composite PK type definition if needed
 			#composite_pk_type_def
 
-			#info_model_impl
+			#shared_info_output
 
 			// Generate new() as a zero-arg alias of build()
 			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
@@ -2338,9 +2365,6 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 
 			// Generate field selector struct for type-safe JOIN/GROUP BY/HAVING operations
 			#field_selector_struct
-
-		// Generate Info companion struct (Issue #4194)
-		#info_struct
 	};
 
 	Ok(expanded)

--- a/crates/reinhardt-core/macros/tests/ui.rs
+++ b/crates/reinhardt-core/macros/tests/ui.rs
@@ -167,6 +167,20 @@ fn test_user_macro_fail() {
 	t.compile_fail("tests/ui/user/fail/*.rs");
 }
 
+// ===== Model Parity =====
+
+#[test]
+fn test_model_macro_parity_pass() {
+	let t = trybuild::TestCases::new();
+	t.pass("tests/ui/model/pass/*.rs");
+}
+
+#[test]
+fn test_model_macro_parity_fail() {
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/ui/model/fail/*.rs");
+}
+
 // ===== DTO (Issue #4478) =====
 
 #[test]

--- a/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.rs
@@ -1,0 +1,16 @@
+use reinhardt_macros::model;
+
+include!("../support.rs");
+
+#[model(table_name = "secrets", server_only)]
+struct Secret {
+	#[field(primary_key = true)]
+	id: i64,
+}
+
+fn assert_info_model<T: model_info::InfoModel<PrimaryKey = i64>>() {}
+
+fn main() {
+	assert_info_model::<Secret>();
+	let _ = SecretInfo { id: 1 };
+}

--- a/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.stderr
@@ -1,0 +1,27 @@
+error[E0422]: cannot find struct, variant or union type `SecretInfo` in this scope
+  --> tests/ui/model/fail/server_only_info.rs:15:10
+   |
+15 |     let _ = SecretInfo { id: 1 };
+   |             ^^^^^^^^^^ not found in this scope
+
+error[E0277]: the trait bound `Secret: InfoModel` is not satisfied
+  --> tests/ui/model/fail/server_only_info.rs:14:22
+   |
+14 |     assert_info_model::<Secret>();
+   |                         ^^^^^^ unsatisfied trait bound
+   |
+help: the trait `InfoModel` is not implemented for `Secret`
+  --> tests/ui/model/fail/server_only_info.rs:6:1
+   |
+ 6 | struct Secret {
+   | ^^^^^^^^^^^^^
+help: this trait has no implementations, consider adding one
+  --> tests/ui/model/fail/../support.rs
+   |
+   |     pub trait InfoModel {
+   |     ^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `assert_info_model`
+  --> tests/ui/model/fail/server_only_info.rs:11:25
+   |
+11 | fn assert_info_model<T: model_info::InfoModel<PrimaryKey = i64>>() {}
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_info_model`

--- a/crates/reinhardt-core/macros/tests/ui/model/pass/wasm_shared_info.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/pass/wasm_shared_info.rs
@@ -1,0 +1,23 @@
+use reinhardt_macros::model;
+use serde::{Deserialize, Serialize};
+
+include!("../support.rs");
+
+#[model(table_name = "books")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Book {
+	#[field(primary_key = true)]
+	id: i64,
+	#[field(max_length = 120)]
+	title: String,
+}
+
+fn assert_info_model<T: model_info::InfoModel<PrimaryKey = i64>>() {}
+
+fn main() {
+	assert_info_model::<Book>();
+	let _ = BookInfo {
+		id: 1,
+		title: "hello".to_string(),
+	};
+}

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -1,0 +1,301 @@
+extern crate self as reinhardt;
+extern crate self as reinhardt_core;
+
+pub mod macros {
+	pub use reinhardt_macros::Model;
+}
+
+pub mod model_info {
+	pub trait InfoModel {
+		type PrimaryKey;
+	}
+
+	#[derive(Debug, Clone, PartialEq)]
+	pub struct RelationInfo<T: InfoModel> {
+		pub id: T::PrimaryKey,
+	}
+
+	impl<T: InfoModel> RelationInfo<T> {
+		pub const fn new(id: T::PrimaryKey) -> Self {
+			Self { id }
+		}
+
+		pub fn into_id(self) -> T::PrimaryKey {
+			self.id
+		}
+	}
+
+	#[derive(Debug, Clone, PartialEq)]
+	pub struct ManyToManyInfo<Source, Target: InfoModel> {
+		pub target_ids: Vec<Target::PrimaryKey>,
+		_source: core::marker::PhantomData<Source>,
+	}
+
+	impl<Source, Target: InfoModel> ManyToManyInfo<Source, Target> {
+		pub fn new<I>(target_ids: I) -> Self
+		where
+			I: IntoIterator<Item = Target::PrimaryKey>,
+		{
+			Self {
+				target_ids: target_ids.into_iter().collect(),
+				_source: core::marker::PhantomData,
+			}
+		}
+
+		pub const fn empty() -> Self {
+			Self {
+				target_ids: Vec::new(),
+				_source: core::marker::PhantomData,
+			}
+		}
+	}
+}
+
+pub mod db {
+	pub mod orm {
+		pub struct Manager<T>(core::marker::PhantomData<T>);
+
+		pub trait FieldSelector: Sized {
+			fn with_alias(self, _alias: &str) -> Self {
+				self
+			}
+		}
+
+		pub trait Model {
+			type PrimaryKey;
+			type Fields;
+			type Objects;
+
+			fn table_name() -> &'static str;
+			fn new_fields() -> Self::Fields;
+			fn app_label() -> &'static str;
+			fn primary_key_field() -> &'static str;
+			fn primary_key(&self) -> Option<Self::PrimaryKey>;
+			fn set_primary_key(&mut self, value: Self::PrimaryKey);
+			fn field_metadata() -> Vec<inspection::FieldInfo>;
+			fn index_metadata() -> Vec<inspection::IndexInfo>;
+			fn constraint_metadata() -> Vec<inspection::ConstraintInfo>;
+			fn relationship_metadata() -> Vec<inspection::RelationInfo>;
+		}
+
+		pub mod expressions {
+			#[derive(Debug, Clone)]
+			pub struct FieldRef<Model, Type> {
+				pub name: &'static str,
+				_marker: core::marker::PhantomData<(Model, Type)>,
+			}
+
+			impl<Model, Type> FieldRef<Model, Type> {
+				pub const fn new(name: &'static str) -> Self {
+					Self {
+						name,
+						_marker: core::marker::PhantomData,
+					}
+				}
+			}
+		}
+
+		pub mod query_fields {
+			#[derive(Debug, Clone)]
+			pub struct Field<Model, Type> {
+				pub names: Vec<String>,
+				pub alias: Option<String>,
+				_marker: core::marker::PhantomData<(Model, Type)>,
+			}
+
+			impl<Model, Type> Field<Model, Type> {
+				pub fn new<S: Into<String>>(names: Vec<S>) -> Self {
+					Self {
+						names: names.into_iter().map(Into::into).collect(),
+						alias: None,
+						_marker: core::marker::PhantomData,
+					}
+				}
+
+				pub fn with_alias(mut self, alias: &str) -> Self {
+					self.alias = Some(alias.to_string());
+					self
+				}
+			}
+		}
+
+		pub mod fields {
+			#[derive(Debug, Clone, PartialEq)]
+			pub enum FieldKwarg {
+				Bool(bool),
+				Int(i64),
+				Uint(u64),
+				String(String),
+			}
+		}
+
+		pub mod inspection {
+			use super::fields::FieldKwarg;
+			use std::collections::HashMap;
+
+			#[derive(Debug, Clone, PartialEq)]
+			pub struct FieldInfo {
+				pub name: String,
+				pub field_type: String,
+				pub nullable: bool,
+				pub primary_key: bool,
+				pub unique: bool,
+				pub blank: bool,
+				pub editable: bool,
+				pub default: Option<String>,
+				pub db_default: Option<String>,
+				pub db_column: Option<String>,
+				pub choices: Option<Vec<String>>,
+				pub attributes: HashMap<String, FieldKwarg>,
+			}
+
+			#[derive(Debug, Clone, PartialEq)]
+			pub struct IndexInfo {
+				pub name: String,
+				pub fields: Vec<String>,
+				pub unique: bool,
+				pub condition: Option<String>,
+			}
+
+			#[derive(Debug, Clone, PartialEq)]
+			pub enum ConstraintType {
+				Check,
+				Unique,
+			}
+
+			#[derive(Debug, Clone, PartialEq)]
+			pub struct ConstraintInfo {
+				pub name: String,
+				pub constraint_type: ConstraintType,
+				pub definition: String,
+			}
+
+			#[derive(Debug, Clone, PartialEq)]
+			pub struct RelationInfo;
+		}
+
+		pub mod registry {
+			#[derive(Debug, Clone, PartialEq)]
+			pub struct ModelInfo {
+				pub app_label: String,
+				pub model_name: String,
+				pub type_path: String,
+				pub table_name: String,
+			}
+
+			pub struct Registry;
+
+			impl Registry {
+				pub fn register(&self, _info: ModelInfo) {}
+			}
+
+			pub fn global_model_registry() -> Registry {
+				Registry
+			}
+		}
+	}
+
+	pub mod migrations {
+		#[derive(Debug, Clone, PartialEq)]
+		pub enum FieldType {
+			Integer,
+			BigInteger,
+			VarChar(u32),
+			Boolean,
+			TimestampTz,
+			Date,
+			Time,
+			Float,
+			Double,
+			Uuid,
+		}
+
+		#[derive(Debug, Clone, PartialEq)]
+		pub struct ConstraintDefinition {
+			pub name: String,
+			pub constraint_type: String,
+			pub fields: Vec<String>,
+			pub expression: Option<String>,
+			pub foreign_key_info: Option<ForeignKeyInfo>,
+		}
+
+		#[derive(Debug, Clone, PartialEq)]
+		pub struct ForeignKeyInfo {
+			pub referenced_table: String,
+			pub referenced_column: String,
+			pub on_delete: ForeignKeyAction,
+			pub on_update: ForeignKeyAction,
+		}
+
+		#[derive(Debug, Clone, PartialEq)]
+		pub enum ForeignKeyAction {
+			Cascade,
+		}
+
+		pub fn to_snake_case(value: &str) -> String {
+			value.to_ascii_lowercase()
+		}
+
+		pub mod model_registry {
+			use super::{ConstraintDefinition, FieldType, ForeignKeyInfo};
+
+			#[derive(Debug, Clone, PartialEq)]
+			pub struct FieldMetadata {
+				pub field_type: FieldType,
+			}
+
+			impl FieldMetadata {
+				pub const fn new(field_type: FieldType) -> Self {
+					Self { field_type }
+				}
+
+				pub fn with_param(self, _key: &str, _value: &str) -> Self {
+					self
+				}
+
+				pub fn with_nullable(self, _nullable: bool) -> Self {
+					self
+				}
+
+				pub fn with_foreign_key(self, _foreign_key: ForeignKeyInfo) -> Self {
+					self
+				}
+			}
+
+			#[derive(Debug, Clone, PartialEq)]
+			pub struct ManyToManyMetadata {
+				pub field_name: String,
+				pub to_model: String,
+				pub related_name: Option<String>,
+				pub through: Option<String>,
+				pub source_field: Option<String>,
+				pub target_field: Option<String>,
+				pub db_constraint_prefix: Option<String>,
+			}
+
+			pub struct ModelMetadata;
+
+			impl ModelMetadata {
+				pub const fn new(_app_label: &str, _model_name: &str, _table_name: &str) -> Self {
+					Self
+				}
+
+				pub fn add_field(&mut self, _name: String, _metadata: FieldMetadata) {}
+
+				pub fn add_many_to_many(&mut self, _metadata: ManyToManyMetadata) {}
+
+				pub fn add_constraint(&mut self, _constraint: ConstraintDefinition) {}
+			}
+
+			pub struct Registry;
+
+			impl Registry {
+				pub fn register_model(&self, _metadata: ModelMetadata) {}
+			}
+
+			pub fn global_registry() -> Registry {
+				Registry
+			}
+		}
+	}
+}

--- a/instructions/MACRO_USAGE.md
+++ b/instructions/MACRO_USAGE.md
@@ -152,7 +152,9 @@ let choice = Choice::build()
 
 The `#[model]` macro automatically generates a `{Model}Info` companion struct — a plain data carrier with model data fields, lightweight relationship fields, `pub` visibility, and bidirectional `From` conversions.
 
-**Generated for every model by default.** Opt out with `#[model(info = false)]`.
+**Generated for every model by default.** Opt out of only the companion struct
+with `#[model(info = false)]`. Use `#[model(server_only)]` for models that
+must not expose shared `InfoModel` / `{Model}Info` output on WASM.
 
 ```rust
 #[model(app_label = "blog", table_name = "posts")]
@@ -247,7 +249,8 @@ Validation attributes are derived from `#[field(...)]` config and emitted as `#[
 - Pass FK values via `.<related>(&model)` in `build()` setters when the related instance is already in scope (composes with #4398)
 - Use `{Model}Info` for API DTOs and cross-layer data transfer instead of hand-writing parallel structs (MU-4)
 - Use `#[field(skip_info = true)]` to exclude sensitive fields (e.g., password hashes) from the Info struct
-- Use `#[model(info = false)]` only when the Info struct would be genuinely unused
+- Use `#[model(info = false)]` only when the Info struct would be genuinely unused, but the model may still be referenced by shared relationship metadata
+- Use `#[model(server_only)]` only for models that are intentionally native-only and should not participate in WASM/shared type contracts
 
 ### ❌ NEVER DO
 - Initialize `#[model(...)]` structs via struct-literal syntax in production code (use `build()` or zero-argument `new()`)


### PR DESCRIPTION
## Summary

This PR addresses:

- Emits shared `#[model]` data and info companions on WASM while keeping ORM behavior native-only.
- Adds model macro UI coverage for shared info and `server_only` behavior.
- Verifies the tutorial basis WASM client-router build against generated model info.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [ ] **No** - This change is backward compatible
- [x] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Completes the model parity portion of the API parity umbrella by making generated model data surfaces target-neutral and keeping database behavior P0 native-only.

Fixes #5003

Related to: #5001, #5339

## How Was This Tested?

- `cargo fmt`
- `git diff --check`
- `cargo test -p reinhardt-macros --test ui model -- --nocapture`
- `cargo check -p reinhardt-db --target wasm32-unknown-unknown --no-default-features --features model-info`
- `cargo check --target wasm32-unknown-unknown --lib` in `examples/examples-tutorial-basis`
- `.github/scripts/check-wasm-native-deps.sh reinhardt-db model-info`

## Performance Impact

- Not performance-related.

## Breaking Changes

The model macro now treats target-neutral data/info output and native ORM output as distinct parity surfaces. Application code that relied on native-only generated ORM symbols being available in WASM must move those calls behind native-only runtime boundaries.

**Migration Guide:**

Keep shared model data, generated info companions, DTO conversions, and route/client declarations cfg-free. Move ORM calls, database access, and model registry behavior into native-only functions or framework internals.

## Screenshots

- Not UI-related.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5001
- #5003
- #5339

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

### Additional Labels
- [x] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [x] `orm` - ORM layer, models, query builder

## Additional Context

- Draft PR; stacked on #5339.
