### PR TITLE
feat!: gate native-only admin and DI behavior for wasm parity

### DIFF
--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -27,6 +27,7 @@ reinhardt-urls = { workspace = true, features = ["routers"] }
 sha2 = "0.10"
 subtle = "2"
 getrandom = { workspace = true }
+async-trait = { workspace = true }
 
 # Server-only dependencies (native target)
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
@@ -43,7 +44,6 @@ reinhardt-query = { workspace = true }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
-async-trait = { workspace = true }
 futures = { workspace = true }
 bytes = { workspace = true }
 hyper = { workspace = true }

--- a/crates/reinhardt-admin/src/adapters.rs
+++ b/crates/reinhardt-admin/src/adapters.rs
@@ -11,15 +11,15 @@
 // Server-side: Use actual implementations
 #[cfg(server)]
 pub use crate::core::{
-	AdminDatabase, AdminRecord, AdminSite, ExportFormat, ImportBuilder, ImportError, ImportFormat,
-	ImportResult, ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder,
+	AdminDatabase, AdminRecord, AdminSite, AdminUser, ExportFormat, ImportBuilder, ImportError,
+	ImportFormat, ImportResult, ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder,
 };
 
 // WASM: Use stub types
 #[cfg(client)]
 pub use crate::types::{
-	AdminDatabase, AdminRecord, AdminSite, ExportFormat, ImportBuilder, ImportError, ImportFormat,
-	ImportResult, ModelAdmin,
+	AdminDatabase, AdminRecord, AdminSite, AdminUser, ExportFormat, ImportBuilder, ImportError,
+	ImportFormat, ImportResult, ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder,
 };
 
 // Re-export shared types (DTOs) that are always from reinhardt-admin-types.

--- a/crates/reinhardt-admin/src/lib.rs
+++ b/crates/reinhardt-admin/src/lib.rs
@@ -31,6 +31,19 @@
 pub mod adapters;
 #[cfg(server)]
 pub mod core;
+#[cfg(client)]
+pub mod core {
+	//! Client-side admin core type stubs.
+	//!
+	//! The server target exposes the real admin core module. The client target
+	//! keeps the same import path available for shared code that names admin
+	//! core types in signatures erased by server functions or native-only macros.
+
+	pub use crate::types::{
+		AdminDatabase, AdminRecord, AdminSite, AdminUser, ExportFormat, ImportBuilder, ImportError,
+		ImportFormat, ImportResult, ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder,
+	};
+}
 pub mod pages;
 pub mod server;
 #[cfg(server)]

--- a/crates/reinhardt-admin/src/types.rs
+++ b/crates/reinhardt-admin/src/types.rs
@@ -28,6 +28,6 @@ pub use responses::*;
 // These stubs allow Server Function client code to type-check correctly
 #[cfg(client)]
 pub use wasm_stubs::{
-	AdminDatabase, AdminRecord, AdminSite, ExportFormat, ImportBuilder, ImportError, ImportFormat,
-	ImportResult, ModelAdmin,
+	AdminDatabase, AdminRecord, AdminSite, AdminUser, ExportFormat, ImportBuilder, ImportError,
+	ImportFormat, ImportResult, ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder,
 };

--- a/crates/reinhardt-admin/src/types/wasm_stubs.rs
+++ b/crates/reinhardt-admin/src/types/wasm_stubs.rs
@@ -29,10 +29,106 @@ mod wasm_only {
 	/// This type is never actually used in WASM code.
 	pub struct AdminRecord;
 
-	/// Dummy ModelAdmin type for WASM type checking
+	/// Admin user trait stub for WASM type checking.
+	///
+	/// This trait is never actually used in WASM code.
+	pub trait AdminUser: Send + Sync {
+		/// Whether the user account is active.
+		fn is_active(&self) -> bool;
+
+		/// Whether the user is a staff member.
+		fn is_staff(&self) -> bool;
+
+		/// Whether the user is a superuser.
+		fn is_superuser(&self) -> bool;
+
+		/// The username for audit logging.
+		fn get_username(&self) -> &str;
+	}
+
+	/// Model admin trait stub for WASM type checking.
+	///
+	/// This trait is never actually used in WASM code.
+	#[async_trait::async_trait]
+	pub trait ModelAdmin: Send + Sync {
+		/// Get the model name.
+		fn model_name(&self) -> &str;
+
+		/// Get the database table name.
+		fn table_name(&self) -> &str {
+			""
+		}
+
+		/// Get the primary key field name.
+		fn pk_field(&self) -> &str {
+			"id"
+		}
+
+		/// Fields to display in list view.
+		fn list_display(&self) -> Vec<&str> {
+			vec!["id"]
+		}
+
+		/// Fields that can be used for filtering.
+		fn list_filter(&self) -> Vec<&str> {
+			vec![]
+		}
+
+		/// Fields that can be searched.
+		fn search_fields(&self) -> Vec<&str> {
+			vec![]
+		}
+
+		/// Fields to display in forms.
+		fn fields(&self) -> Option<Vec<&str>> {
+			None
+		}
+
+		/// Read-only fields.
+		fn readonly_fields(&self) -> Vec<&str> {
+			vec![]
+		}
+
+		/// Ordering for list view.
+		fn ordering(&self) -> Vec<&str> {
+			vec!["-id"]
+		}
+
+		/// Number of items per page.
+		fn list_per_page(&self) -> Option<usize> {
+			None
+		}
+
+		/// Check if user has permission to view this model.
+		async fn has_view_permission(&self, _user: &dyn AdminUser) -> bool {
+			false
+		}
+
+		/// Check if user has permission to add records for this model.
+		async fn has_add_permission(&self, _user: &dyn AdminUser) -> bool {
+			false
+		}
+
+		/// Check if user has permission to change records for this model.
+		async fn has_change_permission(&self, _user: &dyn AdminUser) -> bool {
+			false
+		}
+
+		/// Check if user has permission to delete records for this model.
+		async fn has_delete_permission(&self, _user: &dyn AdminUser) -> bool {
+			false
+		}
+	}
+
+	/// Dummy ModelAdminConfig type for WASM type checking
 	///
 	/// This type is never actually used in WASM code.
-	pub struct ModelAdmin;
+	pub struct ModelAdminConfig;
+
+	/// Dummy ModelAdminConfigBuilder type for WASM type checking
+	///
+	/// This type is never actually used in WASM code.
+	pub struct ModelAdminConfigBuilder;
 
 	/// Dummy ExportFormat type for WASM type checking
 	///
@@ -60,4 +156,7 @@ mod wasm_only {
 	///
 	/// This type is never actually used in WASM code.
 	pub struct ImportResult;
+
+	#[allow(dead_code)]
+	fn assert_admin_trait_shapes(_admin: &dyn ModelAdmin, _user: &dyn AdminUser) {}
 }

--- a/crates/reinhardt-admin/src/types/wasm_stubs.rs
+++ b/crates/reinhardt-admin/src/types/wasm_stubs.rs
@@ -157,6 +157,8 @@ mod wasm_only {
 	/// This type is never actually used in WASM code.
 	pub struct ImportResult;
 
+	// The assertion function is intentionally never called; compiling its
+	// signature keeps the WASM trait-object shapes in sync with the native API.
 	#[allow(dead_code)]
 	fn assert_admin_trait_shapes(_admin: &dyn ModelAdmin, _user: &dyn AdminUser) {}
 }

--- a/crates/reinhardt-core/macros/src/admin.rs
+++ b/crates/reinhardt-core/macros/src/admin.rs
@@ -454,10 +454,12 @@ pub(crate) fn admin_impl(args: TokenStream, input: ItemStruct) -> Result<TokenSt
 		#struct_vis struct #struct_name;
 
 		// Compile-time field validation
+		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 		const _: () = {
 			#(#field_checks)*
 		};
 
+		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 		#[#async_trait::async_trait]
 		impl #admin_api::ModelAdmin for #struct_name {
 			fn model_name(&self) -> &str {

--- a/crates/reinhardt-core/macros/src/app_config_derive.rs
+++ b/crates/reinhardt-core/macros/src/app_config_derive.rs
@@ -164,6 +164,7 @@ fn derive_impl(input: DeriveInput) -> Result<TokenStream> {
 		let target = &entry.target;
 		let sha256 = entry.sha256.clone().unwrap_or_default();
 		quote! {
+			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 			#apps_crate::inventory::submit! {
 				#apps_crate::AppVendorAsset {
 					app_label: #label,

--- a/crates/reinhardt-core/macros/src/injectable_fn.rs
+++ b/crates/reinhardt-core/macros/src/injectable_fn.rs
@@ -168,6 +168,7 @@ pub(crate) fn injectable_fn_impl(_args: TokenStream, input: ItemFn) -> Result<To
 	// Generate the expanded code with override support
 	let expanded = quote! {
 		// Original function implementation (renamed, private)
+		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 		#impl_fn
 
 		/// Returns the function pointer for this injectable function.
@@ -195,6 +196,7 @@ pub(crate) fn injectable_fn_impl(_args: TokenStream, input: ItemFn) -> Result<To
 		}
 
 		// Injectable trait implementation for the return type
+		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 		#[#async_trait::async_trait]
 		impl #di_crate::Injectable for #return_type {
 			async fn inject(__di_ctx: &#di_crate::InjectionContext)

--- a/crates/reinhardt-core/macros/src/injectable_struct.rs
+++ b/crates/reinhardt-core/macros/src/injectable_struct.rs
@@ -382,6 +382,7 @@ pub(crate) fn injectable_struct_impl(
 		);
 		let register_fn_name = format_ident!("__reinhardt_register_{}", struct_name);
 		quote! {
+			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 			#[allow(non_snake_case)]
 			async fn #factory_fn_name(
 				ctx: ::std::sync::Arc<#di_crate::InjectionContext>,
@@ -389,6 +390,7 @@ pub(crate) fn injectable_struct_impl(
 				<#struct_name as #di_crate::Injectable>::inject(&ctx).await
 			}
 
+			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 			#[allow(non_snake_case)]
 			fn #register_fn_name(registry: &#di_crate::DependencyRegistry) {
 				registry.register_async::<#struct_name, _, _>(#scope_tokens, #factory_fn_name);
@@ -398,6 +400,7 @@ pub(crate) fn injectable_struct_impl(
 				);
 			}
 
+			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 			#di_crate::inventory::submit! {
 				#di_crate::DependencyRegistration::new::<#struct_name>(
 					#type_name_str,
@@ -414,6 +417,7 @@ pub(crate) fn injectable_struct_impl(
 	let expanded = quote! {
 		#input
 
+		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 		#[#async_trait::async_trait]
 		impl #generics #di_crate::Injectable for #struct_name #generics #where_clause {
 			async fn inject(__di_ctx: &#di_crate::InjectionContext)

--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -15,12 +15,12 @@ path = "src/bin/check-di.rs"
 doc = false
 
 [dependencies]
-reinhardt-http = { workspace = true }
+reinhardt-http = { workspace = true, optional = true }
 
 # Internal crates
 reinhardt-di-macros = { workspace = true, optional = true }
 
-tokio = { workspace = true }
+tokio = { version = "1.51.0", default-features = false, features = ["rt", "sync"] }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 dashmap = "6.1"
@@ -43,7 +43,7 @@ uuid = { workspace = true, optional = true }
 
 [features]
 default = []
-params = []
+params = ["dep:reinhardt-http"]
 macros = ["dep:reinhardt-di-macros"]
 dev-tools = ["dep:indexmap"]
 generator = ["dep:genawaiter"]
@@ -56,25 +56,27 @@ di-full = [
 ]
 validation = ["reinhardt-core/validators"]
 multi-value-arrays = []
-multipart = ["multer", "futures-util"]
+multipart = ["params", "multer", "futures-util"]
 uuid = ["dep:uuid"]
 full = ["validation", "multi-value-arrays", "multipart", "uuid"]
 testing = []
 
 [dev-dependencies]
 insta = { workspace = true }
-tokio = { workspace = true }
+tokio = { version = "1.51.0", default-features = false, features = ["macros", "rt", "sync", "time"] }
 futures = "0.3"
 bytes.workspace = true
-hyper.workspace = true
 serial_test = { workspace = true }
 reinhardt-core = { workspace = true, features = ["types", "exception"] }
 reinhardt-macros = { workspace = true }
 serde = { workspace = true }
-proptest = { workspace = true }
 rstest = { workspace = true }
-trybuild = { workspace = true }
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
+hyper = { version = "1.9.0", default-features = false }
+proptest = { workspace = true }
+trybuild = { workspace = true }
 [[test]]
 name = "scope_hierarchy_tests"
 required-features = ["testing"]

--- a/crates/reinhardt-di/src/context.rs
+++ b/crates/reinhardt-di/src/context.rs
@@ -3,6 +3,7 @@
 use crate::function_handle::FunctionHandle;
 use crate::override_registry::OverrideRegistry;
 use crate::scope::{RequestScope, SingletonScope};
+#[cfg(feature = "params")]
 use reinhardt_http::Request as HttpRequest;
 use std::any::Any;
 use std::sync::Arc;
@@ -445,6 +446,7 @@ impl InjectionContext {
 	/// `request_scope` (for [`get_request::<HttpRequest>()`](Self::get_request)),
 	/// ensuring that `Injectable` types such as `ServerFnRequest` can
 	/// retrieve it via either accessor.
+	#[cfg(feature = "params")]
 	pub fn fork_for_request(&self, request: HttpRequest) -> InjectionContext {
 		let request_arc = Arc::new(request);
 
@@ -886,7 +888,7 @@ impl RequestContext {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "params"))]
 mod tests {
 	use super::*;
 	use rstest::rstest;
@@ -932,7 +934,6 @@ mod tests {
 		assert!(forked.get_request::<String>().is_none());
 	}
 
-	#[cfg(feature = "params")]
 	#[rstest]
 	fn test_fork_for_request_sets_http_request() {
 		// Arrange

--- a/crates/reinhardt-di/tests/auto_injectable_tests.rs
+++ b/crates/reinhardt-di/tests/auto_injectable_tests.rs
@@ -3,6 +3,8 @@
 //! This module tests the `#[injectable]` macro for automatic dependency injection
 //! on structs with `#[inject]` and `#[no_inject]` fields.
 
+#![cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+
 use reinhardt_di::{Depends, Injectable, InjectionContext, SingletonScope};
 use reinhardt_macros::injectable;
 use std::sync::Arc;

--- a/crates/reinhardt-di/tests/trybuild_tests.rs
+++ b/crates/reinhardt-di/tests/trybuild_tests.rs
@@ -5,6 +5,8 @@
 //!   pulling in extra crates (notably `async-trait`, regression test for
 //!   issue #4445).
 
+#![cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+
 #[test]
 fn injectable_compile_fail() {
 	let t = trybuild::TestCases::new();

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -50,7 +50,6 @@ pub mod adapters {
 }
 
 /// Core admin registration and configuration types.
-#[cfg(native)]
 pub mod core {
 	pub use reinhardt_admin::core::*;
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Makes `#[app_config]`, admin symbols, and DI macro symbols nameable from WASM-visible application code.
- Gates native-only registrations, admin runtime behavior, and DI resolution code behind native-only output.
- Adds compile coverage for the native/WASM symbol boundary.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [ ] **No** - This change is backward compatible
- [x] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Removes accepted-path cfg pressure from application modules by giving framework macros and admin/DI symbols explicit P1/P0 parity behavior.

Fixes #5004

Related to: #5001

## How Was This Tested?

- `cargo fmt`
- `git diff --check`
- `cargo check -p reinhardt-admin --target wasm32-unknown-unknown --no-default-features`
- `cargo check -p reinhardt-admin --all-features`
- `cargo test -p reinhardt-macros --test ui -- --nocapture`
- `cargo check --target wasm32-unknown-unknown --lib` in `examples/examples-tutorial-basis`
- `cargo check --lib` in `examples/examples-tutorial-basis`

## Performance Impact

- Not performance-related.

## Breaking Changes

Native-only registration and resolution behavior is no longer emitted on WASM. Shared application code can name the symbols, but runtime side effects remain native-only by design.

**Migration Guide:**

Keep declarations and imports cfg-free in shared app/config modules. Move actual registration, admin route mounting, and dependency resolution work to native runtime wiring or framework internals.

## Screenshots

- Not UI-related.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5001
- #5004

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

### Additional Labels
- [x] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `admin` - Admin interface, admin panels
- [x] `api` - REST API, serializers, views

## Additional Context

- Draft PR; part 4 of the API parity stack.
