### PR TITLE
feat(pages): add native stubs for client page functions

### DIFF
--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -315,6 +315,7 @@ The prelude includes:
 - `ApiModel`, `ApiQuerySet`, `Filter`, `FilterOp`
 - `ServerFn`, `ServerFnError`
 - See [Server Function Macro Guide](docs/server_fn_macro.md) for detailed usage and migration information
+- Use `#[client_page]` for client page functions that must also compile as native route-table stubs
 - See [WASM/server API Parity Macro](docs/wasm_server_api.md) for APIs that need matching public surfaces with target-specific implementations
 - See [React-to-Reinhardt Guide](docs/react_to_reinhardt.md) for React hooks, JSX, actions, routing, SSR, and hydration mappings
 
@@ -334,6 +335,7 @@ The prelude includes:
 - `page!`
 - `head!`
 - `form!`
+- `client_page`
 - `wasm_server_api`
 
 ### Task spawning (cross-target)

--- a/crates/reinhardt-pages/macros/src/client_page.rs
+++ b/crates/reinhardt-pages/macros/src/client_page.rs
@@ -1,0 +1,63 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{ItemFn, ReturnType, Type, parse_macro_input};
+
+use crate::crate_paths::get_reinhardt_pages_crate;
+
+pub(crate) fn client_page_impl(_args: TokenStream, input: TokenStream) -> TokenStream {
+	let input = parse_macro_input!(input as ItemFn);
+	expand_client_page(input)
+		.unwrap_or_else(|err| err.to_compile_error())
+		.into()
+}
+
+fn expand_client_page(input: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
+	if input.sig.asyncness.is_some() {
+		return Err(syn::Error::new_spanned(
+			input.sig.asyncness,
+			"#[client_page] functions must not be async",
+		));
+	}
+
+	match &input.sig.output {
+		ReturnType::Type(_, ty) if is_page_type(ty) => {}
+		_ => {
+			return Err(syn::Error::new_spanned(
+				&input.sig,
+				"#[client_page] functions must return Page",
+			));
+		}
+	}
+
+	let pages_crate = get_reinhardt_pages_crate();
+	let attrs = &input.attrs;
+	let vis = &input.vis;
+	let sig = &input.sig;
+	let block = &input.block;
+
+	Ok(quote! {
+		#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+		#(#attrs)*
+		#vis #sig #block
+
+		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+		#(#attrs)*
+		// Native stubs preserve the client page signature but intentionally
+		// ignore arguments while building route tables.
+		#[allow(unused_variables)]
+		#vis #sig {
+			#pages_crate::Page::empty()
+		}
+	})
+}
+
+fn is_page_type(ty: &Type) -> bool {
+	let Type::Path(type_path) = ty else {
+		return false;
+	};
+	type_path
+		.path
+		.segments
+		.last()
+		.is_some_and(|segment| segment.ident == "Page")
+}

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -8,6 +8,7 @@
 //! - `head!` - HTML head section DSL macro
 //! - `form!` - Type-safe form component macro with reactive bindings
 //! - `#[server_fn]` - Server Functions (RPC) macro
+//! - `#[client_page]` - Client page function macro with native route-table stubs
 //! - `#[wasm_server_api]` - API parity guard for matching WASM/server surfaces
 //!
 //! ## Form Design
@@ -64,6 +65,7 @@
 
 use proc_macro::TokenStream;
 
+mod client_page;
 mod component;
 mod crate_paths;
 mod form;
@@ -105,6 +107,12 @@ mod wasm_server_api;
 #[proc_macro_attribute]
 pub fn server_fn(args: TokenStream, input: TokenStream) -> TokenStream {
 	server_fn::server_fn_impl(args, input)
+}
+
+/// Declares a client page function with a native route-table stub.
+#[proc_macro_attribute]
+pub fn client_page(args: TokenStream, input: TokenStream) -> TokenStream {
+	client_page::client_page_impl(args, input)
 }
 
 /// Derives `FromRequest` for named props structs with extractor fields.

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -105,6 +105,7 @@
 //! - [`page!`]: JSX-like macro for defining view components
 //! - [`head!`]: JSX-like macro for defining HTML head sections
 //! - [`form!`]: Type-safe form component macro
+//! - [`client_page`]: Client page function macro with native route-table stubs
 //! - [`wasm_server_api`]: WASM/server API parity macro
 //!
 //! See `docs/wasm_server_api.md` for the target-specific API parity contract.
@@ -377,7 +378,7 @@ pub use reinhardt_pages_macros::form;
 pub use reinhardt_pages_macros::head;
 pub use reinhardt_pages_macros::page;
 pub use reinhardt_pages_macros::wasm_server_api;
-pub use reinhardt_pages_macros::{FromRequest, component, page_props};
+pub use reinhardt_pages_macros::{FromRequest, client_page, component, page_props};
 
 // Private re-exports used by macro-generated code. Not part of the public API.
 #[doc(hidden)]

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -200,6 +200,7 @@ pub use reinhardt_forms::{
 // Macros
 // ============================================================================
 
+pub use crate::client_page;
 pub use crate::form;
 pub use crate::head;
 pub use crate::page;

--- a/crates/reinhardt-pages/tests/ui.rs
+++ b/crates/reinhardt-pages/tests/ui.rs
@@ -108,3 +108,15 @@ fn test_component_macro_fail() {
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/ui/component/fail/*.rs");
 }
+
+#[test]
+fn test_client_page_macro_pass() {
+	let t = trybuild::TestCases::new();
+	t.pass("tests/ui/client_page/pass/*.rs");
+}
+
+#[test]
+fn test_client_page_macro_fail() {
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/ui/client_page/fail/*.rs");
+}

--- a/crates/reinhardt-pages/tests/ui/client_page/fail/async_fn.rs
+++ b/crates/reinhardt-pages/tests/ui/client_page/fail/async_fn.rs
@@ -1,0 +1,8 @@
+use reinhardt_pages::client_page;
+
+#[client_page]
+pub async fn home_page() -> reinhardt_pages::Page {
+	reinhardt_pages::Page::empty()
+}
+
+fn main() {}

--- a/crates/reinhardt-pages/tests/ui/client_page/fail/async_fn.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_page/fail/async_fn.stderr
@@ -1,0 +1,5 @@
+error: #[client_page] functions must not be async
+ --> tests/ui/client_page/fail/async_fn.rs:4:5
+  |
+4 | pub async fn home_page() -> reinhardt_pages::Page {
+  |     ^^^^^

--- a/crates/reinhardt-pages/tests/ui/client_page/fail/non_page_return.rs
+++ b/crates/reinhardt-pages/tests/ui/client_page/fail/non_page_return.rs
@@ -1,0 +1,8 @@
+use reinhardt_pages::client_page;
+
+#[client_page]
+pub fn home_page() -> String {
+	String::new()
+}
+
+fn main() {}

--- a/crates/reinhardt-pages/tests/ui/client_page/fail/non_page_return.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_page/fail/non_page_return.stderr
@@ -1,0 +1,5 @@
+error: #[client_page] functions must return Page
+ --> tests/ui/client_page/fail/non_page_return.rs:4:5
+  |
+4 | pub fn home_page() -> String {
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/client_page/pass/basic.rs
+++ b/crates/reinhardt-pages/tests/ui/client_page/pass/basic.rs
@@ -1,0 +1,20 @@
+use reinhardt_pages::{Page, client_page};
+
+#[client_page]
+pub fn home_page() -> Page {
+	reinhardt_pages::page!(|| {
+		div { "Home" }
+	})()
+}
+
+#[client_page]
+pub fn detail_page(id: i64) -> Page {
+	reinhardt_pages::page!(|id: i64| {
+		div { { id.to_string() } }
+	})(id)
+}
+
+fn main() {
+	let _: Page = home_page();
+	let _: Page = detail_page(7);
+}

--- a/crates/reinhardt-pages/tests/ui/client_page/pass/prelude.rs
+++ b/crates/reinhardt-pages/tests/ui/client_page/pass/prelude.rs
@@ -1,0 +1,12 @@
+use reinhardt_pages::prelude::*;
+
+#[client_page]
+pub fn prelude_page() -> Page {
+	page!(|| {
+		div { "Prelude" }
+	})()
+}
+
+fn main() {
+	let _: Page = prelude_page();
+}

--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -671,16 +671,19 @@ pub fn question_new() -> Page {
 				class: "mb-4",
 				"New Question"
 			}
-			{
-				error_signal.get().map(|message| page!(|message: String| {
+			{ error_signal
+			.get()
+			.map(|message| {
+				page!(|message: String| {
 					div {
 						class: "alert-danger mb-3",
 						{
 							self::format_server_error(&message)
 						}
 					}
-				})(message)).unwrap_or(Page::Empty)
-			}
+				})(message)
+			})
+			.unwrap_or(Page::Empty) }
 			{ form_view }
 			div {
 				class: "mt-3",
@@ -697,8 +700,7 @@ pub fn question_new() -> Page {
 							}
 						}
 					})(is_loading)
-				}
-				a {
+				}a {
 					href: cancel_href,
 					class: "btn-secondary ml-2",
 					"Cancel"
@@ -769,16 +771,19 @@ pub fn question_edit(question_id: i64) -> Page {
 				class: "mb-4",
 				"Edit Question"
 			}
-			{
-				edit_form_error.get().map(|message| page!(|message: String| {
+			{ edit_form_error
+			.get()
+			.map(|message| {
+				page!(|message: String| {
 					div {
 						class: "alert-danger mb-3",
 						{
 							self::format_server_error(&message)
 						}
 					}
-				})(message)).unwrap_or(Page::Empty)
-			}
+				})(message)
+			})
+			.unwrap_or(Page::Empty) }
 			{ edit_form_page }
 			div {
 				class: "mt-3",
@@ -831,9 +836,7 @@ pub fn question_edit(question_id: i64) -> Page {
 						class: "max-w-4xl mx-auto px-4 mt-12",
 						div {
 							class: "alert-danger",
-							{
-								self::format_server_error(&error)
-							}
+							{ self::format_server_error(&error) }
 						}
 						a {
 							href: polls_routes::reverse("index", &[]),
@@ -882,8 +885,7 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 			h1 {
 				class: "mb-4",
 				"Delete Question?"
-			}
-			{
+			} {
 				match load_detail.get() {
 					ResourceState::Loading => page!(|| {
 						div {
@@ -902,9 +904,7 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 								}
 								blockquote {
 									class: "border-l-4 border-border-secondary pl-4 italic my-3",
-									{
-										q.question_text.clone()
-									}
+									{ q.question_text.clone() }
 								}
 							}
 						}
@@ -912,23 +912,24 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 					ResourceState::Error(error) => page!(|error: String| {
 						div {
 							class: "alert-danger",
-							{
-								self::format_server_error(&error)
-							}
+							{ self::format_server_error(&error) }
 						}
 					})(error),
 				}
 			}
-			{
-				error_signal.get().map(|message| page!(|message: String| {
+			{ error_signal
+			.get()
+			.map(|message| {
+				page!(|message: String| {
 					div {
 						class: "alert-danger mt-3",
 						{
 							self::format_server_error(&message)
 						}
 					}
-				})(message)).unwrap_or(Page::Empty)
-			}
+				})(message)
+			})
+			.unwrap_or(Page::Empty) }
 			{ form_view }
 			div {
 				class: "mt-3",
@@ -1016,16 +1017,19 @@ pub fn choice_new(question_id: i64) -> Page {
 				class: "mb-4",
 				"Add a Choice"
 			}
-			{
-				error_signal.get().map(|message| page!(|message: String| {
+			{ error_signal
+			.get()
+			.map(|message| {
+				page!(|message: String| {
 					div {
 						class: "alert-danger mb-3",
 						{
 							self::format_server_error(&message)
 						}
 					}
-				})(message)).unwrap_or(Page::Empty)
-			}
+				})(message)
+			})
+			.unwrap_or(Page::Empty) }
 			{ form_view }
 			div {
 				class: "mt-3",
@@ -1042,8 +1046,7 @@ pub fn choice_new(question_id: i64) -> Page {
 							}
 						}
 					})(is_loading)
-				}
-				a {
+				}a {
 					href: back_href,
 					class: "btn-secondary ml-2",
 					"Back to poll"
@@ -1093,16 +1096,19 @@ pub fn choice_edit(question_id: i64, choice_id: i64) -> Page {
 				class: "mb-4",
 				"Edit Choice"
 			}
-			{
-				error_signal.get().map(|message| page!(|message: String| {
+			{ error_signal
+			.get()
+			.map(|message| {
+				page!(|message: String| {
 					div {
 						class: "alert-danger mb-3",
 						{
 							self::format_server_error(&message)
 						}
 					}
-				})(message)).unwrap_or(Page::Empty)
-			}
+				})(message)
+			})
+			.unwrap_or(Page::Empty) }
 			{ form_view }
 			div {
 				class: "mt-3",
@@ -1119,8 +1125,7 @@ pub fn choice_edit(question_id: i64, choice_id: i64) -> Page {
 							}
 						}
 					})(is_loading)
-				}
-				a {
+				}a {
 					href: cancel_href,
 					class: "btn-secondary ml-2",
 					"Cancel"
@@ -1168,16 +1173,19 @@ pub fn choice_delete_confirm(question_id: i64, choice_id: i64) -> Page {
 				class: "mb-3",
 				"This action cannot be undone."
 			}
-			{
-				error_signal.get().map(|message| page!(|message: String| {
+			{ error_signal
+			.get()
+			.map(|message| {
+				page!(|message: String| {
 					div {
 						class: "alert-danger mt-3",
 						{
 							self::format_server_error(&message)
 						}
 					}
-				})(message)).unwrap_or(Page::Empty)
-			}
+				})(message)
+			})
+			.unwrap_or(Page::Empty) }
 			{ form_view }
 			div {
 				class: "mt-3",
@@ -1194,8 +1202,7 @@ pub fn choice_delete_confirm(question_id: i64, choice_id: i64) -> Page {
 							}
 						}
 					})(is_loading)
-				}
-				a {
+				}a {
 					href: cancel_href,
 					class: "btn-secondary ml-2",
 					"Cancel"

--- a/examples/examples-tutorial-basis/src/apps/polls/urls.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/urls.rs
@@ -6,7 +6,6 @@
 #[cfg(server)]
 pub mod server_urls;
 
-#[cfg(client)]
 pub mod client_router;
 
 #[cfg(server)]
@@ -14,7 +13,6 @@ pub fn server_url_patterns() -> reinhardt::ServerRouter {
 	server_urls::server_url_patterns()
 }
 
-#[cfg(client)]
 pub fn client_url_patterns() -> reinhardt::ClientRouter {
 	client_router::client_url_patterns()
 }

--- a/examples/examples-tutorial-basis/src/apps/polls/urls/client_router.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/urls/client_router.rs
@@ -10,8 +10,8 @@ use crate::client::pages::{
 };
 use reinhardt::ClientPath;
 use reinhardt::ClientRouter;
+use reinhardt::pages::client_page;
 use reinhardt::pages::component::Page;
-use reinhardt::pages::page;
 
 pub fn client_url_patterns() -> ClientRouter {
 	ClientRouter::new()
@@ -66,9 +66,10 @@ pub fn reverse(name: &str, params: &[(&str, &str)]) -> String {
 }
 
 /// Error page used as the `not_found` fallback.
+#[client_page]
 fn error_page(message: &str) -> Page {
 	let message = message.to_string();
-	page!(|message: String| {
+	reinhardt::pages::page!(|message: String| {
 		div {
 			class: "layout-page",
 			div {

--- a/examples/examples-tutorial-basis/src/apps/users/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/client/components.rs
@@ -53,14 +53,17 @@ pub fn login_form() -> Page {
 						class: "card-title",
 						"Sign in"
 					}
-					{
-						error_signal.get().map(|message| page!(|message: String| {
+					{ error_signal
+					.get()
+					.map(|message| {
+						page!(|message: String| {
 							div {
 								class: "alert-danger mb-3",
 								{ message }
 							}
-						})(message)).unwrap_or(Page::Empty)
-					}
+						})(message)
+					})
+					.unwrap_or(Page::Empty) }
 					{ form_view }
 					div {
 						class: "mt-4",
@@ -132,14 +135,17 @@ pub fn logout_form() -> Page {
 						class: "text-muted mb-4",
 						"Click the button below to end your session."
 					}
-					{
-						error_signal.get().map(|message| page!(|message: String| {
+					{ error_signal
+					.get()
+					.map(|message| {
+						page!(|message: String| {
 							div {
 								class: "alert-danger mb-3",
 								{ message }
 							}
-						})(message)).unwrap_or(Page::Empty)
-					}
+						})(message)
+					})
+					.unwrap_or(Page::Empty) }
 					{ form_view }
 					button {
 						type: "submit",
@@ -209,14 +215,17 @@ pub fn signup_form() -> Page {
 						class: "card-title",
 						"Create account"
 					}
-					{
-						error_signal.get().map(|message| page!(|message: String| {
+					{ error_signal
+					.get()
+					.map(|message| {
+						page!(|message: String| {
 							div {
 								class: "alert-danger mb-3",
 								{ message }
 							}
-						})(message)).unwrap_or(Page::Empty)
-					}
+						})(message)
+					})
+					.unwrap_or(Page::Empty) }
 					{ form_view }
 					div {
 						class: "mt-4",

--- a/examples/examples-tutorial-basis/src/apps/users/urls.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/urls.rs
@@ -6,7 +6,6 @@
 #[cfg(server)]
 pub mod server_urls;
 
-#[cfg(client)]
 pub mod client_router;
 
 #[cfg(server)]
@@ -14,7 +13,6 @@ pub fn server_url_patterns() -> reinhardt::ServerRouter {
 	server_urls::server_url_patterns()
 }
 
-#[cfg(client)]
 pub fn client_url_patterns() -> reinhardt::ClientRouter {
 	client_router::client_url_patterns()
 }

--- a/examples/examples-tutorial-basis/src/client.rs
+++ b/examples/examples-tutorial-basis/src/client.rs
@@ -10,8 +10,10 @@
 //! (`lib::main`), the SPA `pages` aggregator that wraps every routed page
 //! with the shared nav bar, and the `components::nav` shell itself.
 
+#[cfg(client)]
 pub mod lib;
 
 pub mod pages;
 
+#[cfg(client)]
 pub mod components;

--- a/examples/examples-tutorial-basis/src/client/components/nav.rs
+++ b/examples/examples-tutorial-basis/src/client/components/nav.rs
@@ -60,9 +60,7 @@ pub fn nav_bar() -> Page {
 					class: "flex items-center gap-3",
 					span {
 						class: "text-sm text-muted",
-						{
-							format!("Signed in as {}", user.username)
-						}
+						{ format!("Signed in as {}", user.username) }
 					}
 					a {
 						href: logout_href.clone(),

--- a/examples/examples-tutorial-basis/src/client/pages.rs
+++ b/examples/examples-tutorial-basis/src/client/pages.rs
@@ -8,16 +8,20 @@
 //! it. Body components in `client::components::polls` / `::users` stay focused
 //! on page-specific markup.
 
+use reinhardt::pages::client_page;
 use reinhardt::pages::component::Page;
 
+#[cfg(client)]
 use crate::client::components::nav::with_nav;
 
 /// Index page - List all polls
+#[client_page]
 pub fn index_page() -> Page {
 	with_nav(crate::apps::polls::client::components::polls_index())
 }
 
 /// Poll detail page - Show question and voting form
+#[client_page]
 pub fn polls_detail_page(question_id: i64) -> Page {
 	with_nav(crate::apps::polls::client::components::polls_detail(
 		question_id,
@@ -25,6 +29,7 @@ pub fn polls_detail_page(question_id: i64) -> Page {
 }
 
 /// Poll results page - Show voting results
+#[client_page]
 pub fn polls_results_page(question_id: i64) -> Page {
 	with_nav(crate::apps::polls::client::components::polls_results(
 		question_id,
@@ -32,11 +37,13 @@ pub fn polls_results_page(question_id: i64) -> Page {
 }
 
 /// New question page - Create a new poll question
+#[client_page]
 pub fn question_new_page() -> Page {
 	with_nav(crate::apps::polls::client::components::question_new())
 }
 
 /// Edit question page - Update an existing poll question (author only)
+#[client_page]
 pub fn question_edit_page(question_id: i64) -> Page {
 	with_nav(crate::apps::polls::client::components::question_edit(
 		question_id,
@@ -44,11 +51,13 @@ pub fn question_edit_page(question_id: i64) -> Page {
 }
 
 /// Delete question confirmation page - Author-only deletion
+#[client_page]
 pub fn question_delete_page(question_id: i64) -> Page {
 	with_nav(crate::apps::polls::client::components::question_delete_confirm(question_id))
 }
 
 /// New choice page - Add a choice to an existing question (Phase 3)
+#[client_page]
 pub fn choice_new_page(question_id: i64) -> Page {
 	with_nav(crate::apps::polls::client::components::choice_new(
 		question_id,
@@ -56,6 +65,7 @@ pub fn choice_new_page(question_id: i64) -> Page {
 }
 
 /// Edit choice page - Update a choice's text (Phase 3)
+#[client_page]
 pub fn choice_edit_page(question_id: i64, choice_id: i64) -> Page {
 	with_nav(crate::apps::polls::client::components::choice_edit(
 		question_id,
@@ -64,21 +74,25 @@ pub fn choice_edit_page(question_id: i64, choice_id: i64) -> Page {
 }
 
 /// Delete choice confirmation page - Confirm before deletion (Phase 3)
+#[client_page]
 pub fn choice_delete_page(question_id: i64, choice_id: i64) -> Page {
 	with_nav(crate::apps::polls::client::components::choice_delete_confirm(question_id, choice_id))
 }
 
 /// Login page - Username + password form
+#[client_page]
 pub fn login_page() -> Page {
 	with_nav(crate::apps::users::client::components::login_form())
 }
 
 /// Logout page - Single-button session termination
+#[client_page]
 pub fn logout_page() -> Page {
 	with_nav(crate::apps::users::client::components::logout_form())
 }
 
 /// Sign-up page - Create a new account
+#[client_page]
 pub fn signup_page() -> Page {
 	with_nav(crate::apps::users::client::components::signup_form())
 }

--- a/examples/examples-tutorial-basis/src/config/urls.rs
+++ b/examples/examples-tutorial-basis/src/config/urls.rs
@@ -51,18 +51,14 @@ pub fn routes() -> UnifiedRouter {
 			.mount("/", crate::apps::users::urls::server_url_patterns())
 	});
 
-	// Aggregate every app's client routes on wasm so the SPA route table
-	// carries every app's client-side URL patterns.
+	// Aggregate every app's client routes so both native route-table
+	// construction and the WASM SPA see the same URL patterns.
 	//
 	// Each `client_url_patterns()` already namespaces its routes
 	// (`polls:` / `users:`). We compose them by wrapping each in a single-purpose
 	// `UnifiedRouter` and stitching with `mount_unified`, which uses
 	// `ClientRouter::merge` internally.
 	//
-	// The aggregation is `#[cfg(client)]` because the per-app `client_router`
-	// submodules are themselves wasm-only (they import `crate::client::pages::*`,
-	// which is wasm-only).
-	#[cfg(client)]
 	let router = router
 		.mount_unified(
 			"/",

--- a/examples/examples-tutorial-basis/src/lib.rs
+++ b/examples/examples-tutorial-basis/src/lib.rs
@@ -27,8 +27,8 @@ pub mod apps;
 // Configuration (urls unconditional, rest server-only)
 pub mod config;
 
-// Client-only modules (WASM)
-#[cfg(client)]
+// Cross-target page stubs live under `client::pages`; executable browser
+// modules inside `client` remain cfg-gated.
 pub mod client;
 
 // Shared modules (both WASM and server)


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds the `#[client_page]` macro for client page functions.
- Emits native `Page::empty()` route-table stubs while preserving WASM page bodies.
- Updates the tutorial basis route modules so client URL patterns can be named cfg-free.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Gives client route-table construction the same cfg-free shape as server function marker parity, removing native-only page function blockers from accepted app/config paths.

Fixes #4997

Related to: #5001

## How Was This Tested?

- `cargo fmt`
- `git diff --check`
- `cargo test -p reinhardt-pages --test ui test_client_page_macro_pass -- --nocapture`
- `cargo test -p reinhardt-pages --test ui test_client_page_macro_fail -- --nocapture`
- `cargo test -p reinhardt-pages --test ui -- --nocapture`
- `cargo check --target wasm32-unknown-unknown --lib` in `examples/examples-tutorial-basis`
- `cargo check --lib` in `examples/examples-tutorial-basis`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p reinhardt-pages --no-deps`

## Performance Impact

- Not performance-related.

## Screenshots

- Not UI-related.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #4997
- #5001

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

### Scope Label (select all that apply)
- [x] `routing` - URL routing, path matching
- [x] `forms` - Form handling, validation, rendering

## Additional Context

- Draft PR; part 5 of the API parity stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `#[client_page]` macro for defining client page functions that compile as both WASM pages and native route stubs

* **Documentation**
  * Updated documentation to include the new `#[client_page]` macro in library prelude and API reference

* **Tests**
  * Added comprehensive UI test suite for `#[client_page]` macro validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->