### PR TITLE
feat(forms): add dynamic FieldArray runtime support

### DIFF
--- a/crates/reinhardt-manouche/src/core/form_node.rs
+++ b/crates/reinhardt-manouche/src/core/form_node.rs
@@ -132,14 +132,16 @@ pub enum FormAction {
 
 /// An entry in the form fields list.
 ///
-/// Can be either a regular field definition or a field group
-/// containing multiple related fields.
+/// Can be a regular field definition, a layout group, a repeatable collection,
+/// or a submit button.
 #[derive(Debug, Clone)]
 pub enum FormFieldEntry {
 	/// A single field definition
 	Field(FormFieldDef),
 	/// A group of related fields
 	Group(FormFieldGroup),
+	/// A repeatable collection of field entries
+	Collection(FormFieldCollection),
 	/// A submit button (not a data field — generates no Signal)
 	SubmitButton(FormSubmitButtonDef),
 }
@@ -148,6 +150,11 @@ impl FormFieldEntry {
 	/// Returns true if this is a field group.
 	pub fn is_group(&self) -> bool {
 		matches!(self, FormFieldEntry::Group(_))
+	}
+
+	/// Returns true if this is a field collection.
+	pub fn is_collection(&self) -> bool {
+		matches!(self, FormFieldEntry::Collection(_))
 	}
 
 	/// Returns true if this is a regular field.
@@ -165,6 +172,7 @@ impl FormFieldEntry {
 		match self {
 			FormFieldEntry::Field(f) => &f.name,
 			FormFieldEntry::Group(g) => &g.name,
+			FormFieldEntry::Collection(collection) => &collection.name,
 			FormFieldEntry::SubmitButton(b) => &b.name,
 		}
 	}
@@ -174,6 +182,7 @@ impl FormFieldEntry {
 		match self {
 			FormFieldEntry::Field(f) => f.span,
 			FormFieldEntry::Group(g) => g.span,
+			FormFieldEntry::Collection(collection) => collection.span,
 			FormFieldEntry::SubmitButton(b) => b.span,
 		}
 	}
@@ -190,6 +199,14 @@ impl FormFieldEntry {
 	pub fn as_group(&self) -> Option<&FormFieldGroup> {
 		match self {
 			FormFieldEntry::Group(g) => Some(g),
+			_ => None,
+		}
+	}
+
+	/// Returns a reference to the inner collection if this is a Collection variant.
+	pub fn as_collection(&self) -> Option<&FormFieldCollection> {
+		match self {
+			FormFieldEntry::Collection(collection) => Some(collection),
 			_ => None,
 		}
 	}
@@ -297,6 +314,29 @@ impl FormFieldGroup {
 	pub fn field_count(&self) -> usize {
 		self.fields.len()
 	}
+}
+
+/// A repeatable collection of fields in the form macro.
+#[derive(Debug, Clone)]
+pub struct FormFieldCollection {
+	/// Collection name identifier
+	pub name: Ident,
+	/// Collection-level label text
+	pub label: Option<LitStr>,
+	/// Collection-level CSS class
+	pub class: Option<LitStr>,
+	/// Minimum number of items to render or accept
+	pub min_items: Option<syn::LitInt>,
+	/// Maximum number of items to render or accept
+	pub max_items: Option<syn::LitInt>,
+	/// Initial data source path
+	pub initial_from: Option<LitStr>,
+	/// Field entries within each collection item
+	pub fields: Vec<FormFieldEntry>,
+	/// Custom item renderer closure
+	pub render_item: Option<ExprClosure>,
+	/// Span for error reporting
+	pub span: Span,
 }
 
 /// A property within a field definition.

--- a/crates/reinhardt-manouche/src/core/form_node.rs
+++ b/crates/reinhardt-manouche/src/core/form_node.rs
@@ -141,7 +141,7 @@ pub enum FormFieldEntry {
 	/// A group of related fields
 	Group(FormFieldGroup),
 	/// A repeatable collection of field entries
-	Collection(FormFieldCollection),
+	Collection(Box<FormFieldCollection>),
 	/// A submit button (not a data field — generates no Signal)
 	SubmitButton(FormSubmitButtonDef),
 }
@@ -206,7 +206,7 @@ impl FormFieldEntry {
 	/// Returns a reference to the inner collection if this is a Collection variant.
 	pub fn as_collection(&self) -> Option<&FormFieldCollection> {
 		match self {
-			FormFieldEntry::Collection(collection) => Some(collection),
+			FormFieldEntry::Collection(collection) => Some(collection.as_ref()),
 			_ => None,
 		}
 	}

--- a/crates/reinhardt-manouche/src/core/form_typed.rs
+++ b/crates/reinhardt-manouche/src/core/form_typed.rs
@@ -585,7 +585,7 @@ pub enum TypedFormFieldEntry {
 	/// A group of related fields
 	Group(TypedFormFieldGroup),
 	/// A repeatable collection of field entries
-	Collection(TypedFormFieldCollection),
+	Collection(Box<TypedFormFieldCollection>),
 	/// A submit button (not a data field — generates no Signal)
 	SubmitButton(TypedSubmitButtonDef),
 }
@@ -650,7 +650,7 @@ impl TypedFormFieldEntry {
 	/// Returns a reference to the inner collection if this is a Collection variant.
 	pub fn as_collection(&self) -> Option<&TypedFormFieldCollection> {
 		match self {
-			TypedFormFieldEntry::Collection(collection) => Some(collection),
+			TypedFormFieldEntry::Collection(collection) => Some(collection.as_ref()),
 			_ => None,
 		}
 	}

--- a/crates/reinhardt-manouche/src/core/form_typed.rs
+++ b/crates/reinhardt-manouche/src/core/form_typed.rs
@@ -14,7 +14,7 @@
 //! | Category | Types |
 //! |----------|-------|
 //! | Core | `TypedFormMacro`, `TypedFormAction`, `FormMethod` |
-//! | Fields | `TypedFormFieldEntry`, `TypedFormFieldDef`, `TypedFormFieldGroup` |
+//! | Fields | `TypedFormFieldEntry`, `TypedFormFieldDef`, `TypedFormFieldGroup`, `TypedFormFieldCollection` |
 //! | Field Types | `TypedFieldType`, `TypedWidget` |
 //! | Properties | `TypedFieldValidation`, `TypedFieldDisplay`, `TypedFieldStyling` |
 //! | State | `TypedFormState`, `TypedFormCallbacks`, `TypedFormWatch` |
@@ -66,10 +66,12 @@ use super::form_node::ValidatorScope;
 ///         <<enumeration>>
 ///         Field~TypedFormFieldDef~
 ///         Group~TypedFormFieldGroup~
+///         Collection~TypedFormFieldCollection~
 ///     }
 ///
 ///     TypedFormFieldEntry --> TypedFormFieldDef
 ///     TypedFormFieldEntry --> TypedFormFieldGroup
+///     TypedFormFieldEntry --> TypedFormFieldCollection
 ///
 ///     class TypedFormFieldDef {
 ///         +TypedFieldType field_type
@@ -117,7 +119,7 @@ pub struct TypedFormMacro {
 	pub choices_loader: Option<Path>,
 	/// Slot definitions for custom UI elements
 	pub slots: Option<TypedFormSlots>,
-	/// Validated field definitions (can include field groups)
+	/// Validated field definitions (can include field groups and collections)
 	pub fields: Vec<TypedFormFieldEntry>,
 	/// Validated unified validators. Each rule carries a `ValidatorScope`
 	/// controlling whether it executes on server, client, or both.
@@ -572,8 +574,8 @@ pub struct TypedFormFieldDef {
 
 /// An entry in the typed form fields list.
 ///
-/// Can be either a regular field definition or a field group
-/// containing multiple related fields.
+/// Can be a regular field definition, a field group, a repeatable collection,
+/// or a submit button.
 #[derive(Debug)]
 pub enum TypedFormFieldEntry {
 	/// A single field definition
@@ -582,6 +584,8 @@ pub enum TypedFormFieldEntry {
 	Field(Box<TypedFormFieldDef>),
 	/// A group of related fields
 	Group(TypedFormFieldGroup),
+	/// A repeatable collection of field entries
+	Collection(TypedFormFieldCollection),
 	/// A submit button (not a data field — generates no Signal)
 	SubmitButton(TypedSubmitButtonDef),
 }
@@ -590,6 +594,11 @@ impl TypedFormFieldEntry {
 	/// Returns true if this is a field group.
 	pub fn is_group(&self) -> bool {
 		matches!(self, TypedFormFieldEntry::Group(_))
+	}
+
+	/// Returns true if this is a field collection.
+	pub fn is_collection(&self) -> bool {
+		matches!(self, TypedFormFieldEntry::Collection(_))
 	}
 
 	/// Returns true if this is a regular field.
@@ -607,6 +616,7 @@ impl TypedFormFieldEntry {
 		match self {
 			TypedFormFieldEntry::Field(f) => &f.as_ref().name,
 			TypedFormFieldEntry::Group(g) => &g.name,
+			TypedFormFieldEntry::Collection(collection) => &collection.name,
 			TypedFormFieldEntry::SubmitButton(b) => &b.name,
 		}
 	}
@@ -616,6 +626,7 @@ impl TypedFormFieldEntry {
 		match self {
 			TypedFormFieldEntry::Field(f) => f.as_ref().span,
 			TypedFormFieldEntry::Group(g) => g.span,
+			TypedFormFieldEntry::Collection(collection) => collection.span,
 			TypedFormFieldEntry::SubmitButton(b) => b.span,
 		}
 	}
@@ -636,6 +647,14 @@ impl TypedFormFieldEntry {
 		}
 	}
 
+	/// Returns a reference to the inner collection if this is a Collection variant.
+	pub fn as_collection(&self) -> Option<&TypedFormFieldCollection> {
+		match self {
+			TypedFormFieldEntry::Collection(collection) => Some(collection),
+			_ => None,
+		}
+	}
+
 	/// Returns a reference to the inner submit button if this is a SubmitButton variant.
 	pub fn as_submit_button(&self) -> Option<&TypedSubmitButtonDef> {
 		match self {
@@ -643,6 +662,29 @@ impl TypedFormFieldEntry {
 			_ => None,
 		}
 	}
+}
+
+/// A validated repeatable collection of field entries.
+#[derive(Debug)]
+pub struct TypedFormFieldCollection {
+	/// Collection name identifier
+	pub name: Ident,
+	/// Collection-level label text
+	pub label: Option<String>,
+	/// Collection-level CSS class
+	pub class: Option<String>,
+	/// Minimum number of collection items
+	pub min_items: Option<usize>,
+	/// Maximum number of collection items
+	pub max_items: Option<usize>,
+	/// Initial value source field name
+	pub initial_from: Option<String>,
+	/// Validated field entries within each collection item
+	pub fields: Vec<TypedFormFieldEntry>,
+	/// Optional custom item renderer closure
+	pub render_item: Option<ExprClosure>,
+	/// Span for error reporting
+	pub span: Span,
 }
 
 /// A validated submit button definition.

--- a/crates/reinhardt-manouche/src/parser/form.rs
+++ b/crates/reinhardt-manouche/src/parser/form.rs
@@ -12,10 +12,10 @@ use syn::{
 
 use crate::{
 	AmbientArgumentsSource, ClientTrigger, CustomAttr, FormAction, FormDerived, FormDerivedItem,
-	FormFieldDef, FormFieldEntry, FormFieldGroup, FormFieldProperty, FormMacro, FormSlots,
-	FormState, FormStateField, FormSubmitButtonDef, FormValidator, FormWatch, FormWatchItem,
-	IconAttr, IconChild, IconElement, IconPosition, StripArgument, ValidatorRule, ValidatorScope,
-	WrapperAttr, WrapperElement,
+	FormFieldCollection, FormFieldDef, FormFieldEntry, FormFieldGroup, FormFieldProperty,
+	FormMacro, FormSlots, FormState, FormStateField, FormSubmitButtonDef, FormValidator, FormWatch,
+	FormWatchItem, IconAttr, IconChild, IconElement, IconPosition, StripArgument, ValidatorRule,
+	ValidatorScope, WrapperAttr, WrapperElement,
 };
 
 /// Parses a `form!` macro invocation into an untyped AST.
@@ -289,9 +289,10 @@ fn parse_optional_comma(input: ParseStream) -> Result<()> {
 
 /// Parses field definitions inside the `fields: { ... }` block.
 ///
-/// Supports both regular fields and field groups:
+/// Supports regular fields, field groups, field collections, and submit buttons:
 /// - Regular field: `username: CharField { required, ... }`
 /// - Field group: `address: FieldGroup { label: "...", fields: { ... } }`
+/// - Field collection: `items: FieldArray { fields: { ... } }`
 fn parse_field_definitions(input: ParseStream) -> Result<Vec<FormFieldEntry>> {
 	let mut entries = Vec::new();
 
@@ -307,6 +308,11 @@ fn parse_field_definitions(input: ParseStream) -> Result<Vec<FormFieldEntry>> {
 			braced!(content in input);
 			let group = parse_field_group(name, &content, span)?;
 			entries.push(FormFieldEntry::Group(group));
+		} else if field_type == "FieldArray" {
+			let content;
+			braced!(content in input);
+			let collection = parse_field_array(name, &content, span)?;
+			entries.push(FormFieldEntry::Collection(collection));
 		} else if field_type == "SubmitButton" {
 			// Parse submit button: SubmitButton { label: "Sign in", class: "btn-primary" }
 			let properties = if input.peek(token::Brace) {
@@ -395,6 +401,59 @@ fn parse_field_group(name: Ident, input: ParseStream, span: Span) -> Result<Form
 		label,
 		class,
 		fields,
+		span,
+	})
+}
+
+/// Parses a field collection definition.
+fn parse_field_array(name: Ident, input: ParseStream, span: Span) -> Result<FormFieldCollection> {
+	let mut label = None;
+	let mut class = None;
+	let mut min_items = None;
+	let mut max_items = None;
+	let mut initial_from = None;
+	let mut fields = Vec::new();
+	let mut render_item = None;
+
+	while !input.is_empty() {
+		let key: Ident = input.parse()?;
+		input.parse::<Token![:]>()?;
+
+		match key.to_string().as_str() {
+			"label" => label = Some(input.parse()?),
+			"class" => class = Some(input.parse()?),
+			"min_items" => min_items = Some(input.parse()?),
+			"max_items" => max_items = Some(input.parse()?),
+			"initial_from" => initial_from = Some(input.parse()?),
+			"fields" => {
+				let content;
+				braced!(content in input);
+				fields = parse_field_definitions(&content)?;
+			}
+			"render_item" => render_item = Some(input.parse()?),
+			_ => {
+				return Err(syn::Error::new(
+					key.span(),
+					format!(
+						"Unknown FieldArray property: '{}'. Expected: label, class, min_items, max_items, initial_from, fields, render_item",
+						key
+					),
+				));
+			}
+		}
+
+		parse_optional_comma(input)?;
+	}
+
+	Ok(FormFieldCollection {
+		name,
+		label,
+		class,
+		min_items,
+		max_items,
+		initial_from,
+		fields,
+		render_item,
 		span,
 	})
 }
@@ -2828,6 +2887,85 @@ mod tests {
 	// =====================================================
 	// field group tests
 	// =====================================================
+
+	#[test]
+	fn test_parse_field_array_entry() {
+		let input: TokenStream = quote! {
+			name: InvoiceForm,
+			fields: {
+				line_items: FieldArray {
+					label: "Line items",
+					min_items: 1,
+					max_items: 10,
+					initial_from: "line_items",
+					fields: {
+						description: CharField { required }
+						quantity: IntegerField { initial: 1, required }
+					},
+					render_item: |item| { item.default_row() }
+				}
+			}
+		};
+
+		let form: FormMacro = syn::parse2(input).expect("FieldArray should parse");
+		let entry = form.fields.first().expect("line_items entry");
+		assert!(entry.is_collection());
+		assert_eq!(entry.name().to_string(), "line_items");
+		let collection = entry.as_collection().expect("collection entry");
+		assert_eq!(
+			collection.label.as_ref().map(LitStr::value),
+			Some("Line items".to_string())
+		);
+		assert_eq!(
+			collection
+				.min_items
+				.as_ref()
+				.map(|lit| lit.base10_parse::<usize>().unwrap()),
+			Some(1)
+		);
+		assert_eq!(
+			collection
+				.max_items
+				.as_ref()
+				.map(|lit| lit.base10_parse::<usize>().unwrap()),
+			Some(10)
+		);
+		assert_eq!(
+			collection.initial_from.as_ref().map(LitStr::value),
+			Some("line_items".to_string())
+		);
+		assert_eq!(collection.fields.len(), 2);
+		assert!(collection.render_item.is_some());
+	}
+
+	#[test]
+	fn test_parse_nested_field_array_entry() {
+		let input: TokenStream = quote! {
+			name: SurveyForm,
+			fields: {
+				sections: FieldArray {
+					fields: {
+						title: CharField { required }
+						questions: FieldArray {
+							fields: {
+								label: CharField { required }
+							}
+						}
+					}
+				}
+			}
+		};
+
+		let form: FormMacro = syn::parse2(input).expect("nested FieldArray should parse");
+		let sections = form.fields.first().unwrap().as_collection().unwrap();
+		let questions = sections
+			.fields
+			.iter()
+			.find(|entry| entry.name().to_string() == "questions")
+			.and_then(FormFieldEntry::as_collection)
+			.expect("questions nested collection");
+		assert_eq!(questions.fields.len(), 1);
+	}
 
 	#[rstest]
 	fn test_parse_field_group_basic() {

--- a/crates/reinhardt-manouche/src/parser/form.rs
+++ b/crates/reinhardt-manouche/src/parser/form.rs
@@ -312,7 +312,7 @@ fn parse_field_definitions(input: ParseStream) -> Result<Vec<FormFieldEntry>> {
 			let content;
 			braced!(content in input);
 			let collection = parse_field_array(name, &content, span)?;
-			entries.push(FormFieldEntry::Collection(collection));
+			entries.push(FormFieldEntry::Collection(Box::new(collection)));
 		} else if field_type == "SubmitButton" {
 			// Parse submit button: SubmitButton { label: "Sign in", class: "btn-primary" }
 			let properties = if input.peek(token::Brace) {

--- a/crates/reinhardt-manouche/src/validator/form.rs
+++ b/crates/reinhardt-manouche/src/validator/form.rs
@@ -535,7 +535,7 @@ fn transform_field_entry(entry: &FormFieldEntry) -> Result<TypedFormFieldEntry> 
 		}
 		FormFieldEntry::Collection(collection) => {
 			let typed_collection = transform_collection(collection)?;
-			Ok(TypedFormFieldEntry::Collection(typed_collection))
+			Ok(TypedFormFieldEntry::Collection(Box::new(typed_collection)))
 		}
 		FormFieldEntry::SubmitButton(btn) => {
 			let typed_btn = transform_submit_button(btn)?;

--- a/crates/reinhardt-manouche/src/validator/form.rs
+++ b/crates/reinhardt-manouche/src/validator/form.rs
@@ -3274,12 +3274,11 @@ mod tests {
 		let result = parse_and_validate(input);
 
 		// Assert
-		assert!(result.is_err());
-		assert!(
+		assert_eq!(
 			result
-				.unwrap_err()
-				.to_string()
-				.contains("min_items cannot be greater than max_items")
+				.expect_err("invalid FieldArray item bounds should fail validation")
+				.to_string(),
+			"min_items cannot be greater than max_items"
 		);
 	}
 
@@ -3304,12 +3303,11 @@ mod tests {
 		let result = parse_and_validate(input);
 
 		// Assert
-		assert!(result.is_err());
-		assert!(
+		assert_eq!(
 			result
-				.unwrap_err()
-				.to_string()
-				.contains("duplicate field name: 'description'")
+				.expect_err("duplicate FieldArray item fields should fail validation")
+				.to_string(),
+			"duplicate field name: 'description' (in collection 'line_items')"
 		);
 	}
 
@@ -3338,12 +3336,11 @@ mod tests {
 		let result = parse_and_validate(input);
 
 		// Assert
-		assert!(result.is_err());
-		assert!(
+		assert_eq!(
 			result
-				.unwrap_err()
-				.to_string()
-				.contains("duplicate field name: 'prompt'")
+				.expect_err("duplicate nested FieldArray item fields should fail validation")
+				.to_string(),
+			"duplicate field name: 'prompt' (in collection 'questions')"
 		);
 	}
 
@@ -3371,12 +3368,11 @@ mod tests {
 		let result = parse_and_validate(input);
 
 		// Assert
-		assert!(result.is_err());
-		assert!(
+		assert_eq!(
 			result
-				.unwrap_err()
-				.to_string()
-				.contains("ambient_arguments key 'line_items' collides with a declared form field")
+				.expect_err("ambient argument colliding with FieldArray should fail validation")
+				.to_string(),
+			"ambient_arguments key 'line_items' collides with a declared form field; either rename the field or remove this ambient entry"
 		);
 	}
 
@@ -3406,12 +3402,11 @@ mod tests {
 		let result = parse_and_validate(input);
 
 		// Assert
-		assert!(result.is_err());
-		assert!(
+		assert_eq!(
 			result
-				.unwrap_err()
-				.to_string()
-				.contains("validator references unknown field: 'line_items'")
+				.expect_err("collection-level validator target should fail validation")
+				.to_string(),
+			"validator references unknown field: 'line_items'"
 		);
 	}
 

--- a/crates/reinhardt-manouche/src/validator/form.rs
+++ b/crates/reinhardt-manouche/src/validator/form.rs
@@ -17,16 +17,16 @@ use std::collections::HashSet;
 use syn::{Error, Result};
 
 use crate::core::{
-	AmbientArgumentsSource, FormAction, FormCallbacks, FormDerived, FormFieldDef, FormFieldEntry,
-	FormFieldGroup, FormFieldProperty, FormMacro, FormMethod, FormSlots, FormState,
-	FormSubmitButtonDef, FormValidator, FormWatch, IconAttr, IconChild, IconPosition,
-	StripArgument, TypedChoicesConfig, TypedCustomAttr, TypedDerivedItem, TypedFieldDisplay,
-	TypedFieldStyling, TypedFieldType, TypedFieldValidation, TypedFormAction, TypedFormCallbacks,
-	TypedFormDerived, TypedFormFieldDef, TypedFormFieldEntry, TypedFormFieldGroup, TypedFormMacro,
-	TypedFormSlots, TypedFormState, TypedFormStyling, TypedFormValidator, TypedFormWatch,
-	TypedFormWatchItem, TypedIcon, TypedIconAttr, TypedIconChild, TypedIconPosition,
-	TypedStripArgument, TypedSubmitButtonDef, TypedValidatorRule, TypedWidget, TypedWrapper,
-	TypedWrapperAttr, ValidatorRule,
+	AmbientArgumentsSource, FormAction, FormCallbacks, FormDerived, FormFieldCollection,
+	FormFieldDef, FormFieldEntry, FormFieldGroup, FormFieldProperty, FormMacro, FormMethod,
+	FormSlots, FormState, FormSubmitButtonDef, FormValidator, FormWatch, IconAttr, IconChild,
+	IconPosition, StripArgument, TypedChoicesConfig, TypedCustomAttr, TypedDerivedItem,
+	TypedFieldDisplay, TypedFieldStyling, TypedFieldType, TypedFieldValidation, TypedFormAction,
+	TypedFormCallbacks, TypedFormDerived, TypedFormFieldCollection, TypedFormFieldDef,
+	TypedFormFieldEntry, TypedFormFieldGroup, TypedFormMacro, TypedFormSlots, TypedFormState,
+	TypedFormStyling, TypedFormValidator, TypedFormWatch, TypedFormWatchItem, TypedIcon,
+	TypedIconAttr, TypedIconChild, TypedIconPosition, TypedStripArgument, TypedSubmitButtonDef,
+	TypedValidatorRule, TypedWidget, TypedWrapper, TypedWrapperAttr, ValidatorRule,
 };
 
 /// Validates and transforms the FormMacro AST into a typed AST.
@@ -173,12 +173,95 @@ fn validate_unique_field_names(entries: &[FormFieldEntry]) -> Result<()> {
 					}
 				}
 			}
+			FormFieldEntry::Collection(collection) => {
+				let name = collection.name.to_string();
+				if !seen.insert(name.clone()) {
+					return Err(Error::new(
+						collection.name.span(),
+						format!("duplicate field/collection name: '{}'", name),
+					));
+				}
+				validate_unique_collection_field_names(collection)?;
+			}
 			FormFieldEntry::SubmitButton(btn) => {
 				let name = btn.name.to_string();
 				if !seen.insert(name.clone()) {
 					return Err(Error::new(
 						btn.name.span(),
 						format!("duplicate field/button name: '{}'", name),
+					));
+				}
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_unique_collection_field_names(collection: &FormFieldCollection) -> Result<()> {
+	let mut seen = HashSet::new();
+
+	for entry in &collection.fields {
+		match entry {
+			FormFieldEntry::Field(field) => {
+				let name = field.name.to_string();
+				if !seen.insert(name.clone()) {
+					return Err(Error::new(
+						field.name.span(),
+						format!(
+							"duplicate field name: '{}' (in collection '{}')",
+							name, collection.name
+						),
+					));
+				}
+			}
+			FormFieldEntry::Group(group) => {
+				let group_name = group.name.to_string();
+				if !seen.insert(group_name.clone()) {
+					return Err(Error::new(
+						group.name.span(),
+						format!(
+							"duplicate field/group name: '{}' (in collection '{}')",
+							group_name, collection.name
+						),
+					));
+				}
+
+				for field in &group.fields {
+					let name = field.name.to_string();
+					if !seen.insert(name.clone()) {
+						return Err(Error::new(
+							field.name.span(),
+							format!(
+								"duplicate field name: '{}' (in group '{}')",
+								name, group_name
+							),
+						));
+					}
+				}
+			}
+			FormFieldEntry::Collection(nested) => {
+				let name = nested.name.to_string();
+				if !seen.insert(name.clone()) {
+					return Err(Error::new(
+						nested.name.span(),
+						format!(
+							"duplicate field/collection name: '{}' (in collection '{}')",
+							name, collection.name
+						),
+					));
+				}
+				validate_unique_collection_field_names(nested)?;
+			}
+			FormFieldEntry::SubmitButton(btn) => {
+				let name = btn.name.to_string();
+				if !seen.insert(name.clone()) {
+					return Err(Error::new(
+						btn.name.span(),
+						format!(
+							"duplicate field/button name: '{}' (in collection '{}')",
+							name, collection.name
+						),
 					));
 				}
 			}
@@ -434,12 +517,12 @@ fn transform_slots(slots: &Option<FormSlots>) -> Result<Option<TypedFormSlots>> 
 	}))
 }
 
-/// Transforms all field entries (fields and field groups).
+/// Transforms all field entries.
 fn transform_fields(entries: &[FormFieldEntry]) -> Result<Vec<TypedFormFieldEntry>> {
 	entries.iter().map(transform_field_entry).collect()
 }
 
-/// Transforms a single field entry (either a field or a group).
+/// Transforms a single field entry.
 fn transform_field_entry(entry: &FormFieldEntry) -> Result<TypedFormFieldEntry> {
 	match entry {
 		FormFieldEntry::Field(field) => {
@@ -449,6 +532,10 @@ fn transform_field_entry(entry: &FormFieldEntry) -> Result<TypedFormFieldEntry> 
 		FormFieldEntry::Group(group) => {
 			let typed_group = transform_field_group(group)?;
 			Ok(TypedFormFieldEntry::Group(typed_group))
+		}
+		FormFieldEntry::Collection(collection) => {
+			let typed_collection = transform_collection(collection)?;
+			Ok(TypedFormFieldEntry::Collection(typed_collection))
 		}
 		FormFieldEntry::SubmitButton(btn) => {
 			let typed_btn = transform_submit_button(btn)?;
@@ -472,6 +559,55 @@ fn transform_field_group(group: &FormFieldGroup) -> Result<TypedFormFieldGroup> 
 		class: group.class.as_ref().map(|c| c.value()),
 		fields: typed_fields,
 		span: group.span,
+	})
+}
+
+/// Transforms a field collection into a typed field collection.
+fn transform_collection(collection: &FormFieldCollection) -> Result<TypedFormFieldCollection> {
+	let min_items = collection
+		.min_items
+		.as_ref()
+		.map(|lit| {
+			lit.base10_parse::<usize>().map_err(|_| {
+				Error::new(lit.span(), "min_items must be a valid non-negative integer")
+			})
+		})
+		.transpose()?;
+	let max_items = collection
+		.max_items
+		.as_ref()
+		.map(|lit| {
+			lit.base10_parse::<usize>().map_err(|_| {
+				Error::new(lit.span(), "max_items must be a valid non-negative integer")
+			})
+		})
+		.transpose()?;
+
+	if let (Some(min_items), Some(max_items)) = (min_items, max_items)
+		&& min_items > max_items
+	{
+		return Err(Error::new(
+			collection.span,
+			"min_items cannot be greater than max_items",
+		));
+	}
+
+	let fields = collection
+		.fields
+		.iter()
+		.map(transform_field_entry)
+		.collect::<Result<Vec<_>>>()?;
+
+	Ok(TypedFormFieldCollection {
+		name: collection.name.clone(),
+		label: collection.label.as_ref().map(|lit| lit.value()),
+		class: collection.class.as_ref().map(|lit| lit.value()),
+		min_items,
+		max_items,
+		initial_from: collection.initial_from.as_ref().map(|lit| lit.value()),
+		fields,
+		render_item: collection.render_item.clone(),
+		span: collection.span,
 	})
 }
 
@@ -1354,7 +1490,7 @@ fn transform_strip_arguments(
 			));
 		}
 
-		if field_exists(fields, &arg.name) {
+		if ambient_argument_surface_entry_exists(fields, &arg.name) {
 			return Err(Error::new(
 				arg.span,
 				format!(
@@ -1394,10 +1530,11 @@ fn ambient_arguments_collision_entry(source: Option<AmbientArgumentsSource>) -> 
 	}
 }
 
-/// Checks if a field with the given name exists in the field entries.
+/// Checks if an ambient argument would collide with a declared form surface entry.
 ///
-/// This checks both top-level fields and fields within groups.
-fn field_exists(entries: &[FormFieldEntry], name: &syn::Ident) -> bool {
+/// This checks top-level fields, fields within groups, and collection names.
+/// Fields inside collections stay scoped to collection items.
+fn ambient_argument_surface_entry_exists(entries: &[FormFieldEntry], name: &syn::Ident) -> bool {
 	for entry in entries {
 		match entry {
 			FormFieldEntry::Field(field) => {
@@ -1410,6 +1547,35 @@ fn field_exists(entries: &[FormFieldEntry], name: &syn::Ident) -> bool {
 					return true;
 				}
 			}
+			FormFieldEntry::Collection(collection) => {
+				if collection.name == *name {
+					return true;
+				}
+			}
+			FormFieldEntry::SubmitButton(_) => {}
+		}
+	}
+	false
+}
+
+/// Checks if a field-level validator target exists.
+///
+/// Collection validators are not implemented yet, so collection names and
+/// fields inside collections are not valid validator targets.
+fn field_validator_target_exists(entries: &[FormFieldEntry], name: &syn::Ident) -> bool {
+	for entry in entries {
+		match entry {
+			FormFieldEntry::Field(field) => {
+				if field.name == *name {
+					return true;
+				}
+			}
+			FormFieldEntry::Group(group) => {
+				if group.fields.iter().any(|f| f.name == *name) {
+					return true;
+				}
+			}
+			FormFieldEntry::Collection(_) => {}
 			FormFieldEntry::SubmitButton(_) => {}
 		}
 	}
@@ -1431,7 +1597,7 @@ fn transform_validators(
 				span,
 			} => {
 				// Validate that field exists (including in groups)
-				if !field_exists(fields, field_name) {
+				if !field_validator_target_exists(fields, field_name) {
 					return Err(Error::new(
 						field_name.span(),
 						format!("validator references unknown field: '{}'", field_name),
@@ -3034,6 +3200,257 @@ mod tests {
 			typed.fields[2].as_field().unwrap().initial_from,
 			Some("bio".to_string())
 		);
+	}
+
+	// =========================================================================
+	// Field Array Tests
+	// =========================================================================
+
+	#[rstest]
+	fn test_validate_field_array_basic() {
+		// Arrange
+		let input = quote! {
+			name: InvoiceForm,
+			action: "/test",
+
+			fields: {
+				line_items: FieldArray {
+					label: "Line items",
+					class: "line-items",
+					min_items: 1,
+					max_items: 10,
+					initial_from: "line_items",
+					fields: {
+						description: CharField { required },
+						quantity: IntegerField { initial: 1, required },
+					},
+					render_item: |item| { item.default_row() },
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_ok());
+		let typed = result.unwrap();
+		assert_eq!(typed.fields.len(), 1);
+		assert!(typed.fields[0].is_collection());
+		assert_eq!(typed.fields[0].name().to_string(), "line_items");
+
+		let collection = typed.fields[0].as_collection().unwrap();
+		assert_eq!(collection.name.to_string(), "line_items");
+		assert_eq!(collection.label, Some("Line items".to_string()));
+		assert_eq!(collection.class, Some("line-items".to_string()));
+		assert_eq!(collection.min_items, Some(1));
+		assert_eq!(collection.max_items, Some(10));
+		assert_eq!(collection.initial_from, Some("line_items".to_string()));
+		assert_eq!(collection.fields.len(), 2);
+		assert!(collection.fields[0].as_field().is_some());
+		assert!(collection.fields[1].as_field().is_some());
+		assert!(collection.render_item.is_some());
+	}
+
+	#[rstest]
+	fn test_validate_field_array_rejects_invalid_item_bounds() {
+		// Arrange
+		let input = quote! {
+			name: InvalidItemsForm,
+			action: "/test",
+
+			fields: {
+				line_items: FieldArray {
+					min_items: 3,
+					max_items: 2,
+					fields: {
+						description: CharField {},
+					},
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert!(
+			result
+				.unwrap_err()
+				.to_string()
+				.contains("min_items cannot be greater than max_items")
+		);
+	}
+
+	#[rstest]
+	fn test_validate_field_array_rejects_duplicate_field_names() {
+		// Arrange
+		let input = quote! {
+			name: DuplicateItemsForm,
+			action: "/test",
+
+			fields: {
+				line_items: FieldArray {
+					fields: {
+						description: CharField {},
+						description: TextField {},
+					},
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert!(
+			result
+				.unwrap_err()
+				.to_string()
+				.contains("duplicate field name: 'description'")
+		);
+	}
+
+	#[rstest]
+	fn test_validate_field_array_rejects_nested_duplicate_field_names() {
+		// Arrange
+		let input = quote! {
+			name: DuplicateNestedItemsForm,
+			action: "/test",
+
+			fields: {
+				sections: FieldArray {
+					fields: {
+						questions: FieldArray {
+							fields: {
+								prompt: CharField {},
+								prompt: TextField {},
+							},
+						},
+					},
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert!(
+			result
+				.unwrap_err()
+				.to_string()
+				.contains("duplicate field name: 'prompt'")
+		);
+	}
+
+	#[rstest]
+	fn test_validate_field_array_rejects_ambient_arguments_collision() {
+		// Arrange
+		let input = quote! {
+			name: AmbientCollectionForm,
+			server_fn: submit_invoice,
+
+			ambient_arguments: {
+				line_items: line_items_context,
+			},
+
+			fields: {
+				line_items: FieldArray {
+					fields: {
+						description: CharField {},
+					},
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert!(
+			result
+				.unwrap_err()
+				.to_string()
+				.contains("ambient_arguments key 'line_items' collides with a declared form field")
+		);
+	}
+
+	#[rstest]
+	fn test_validate_field_array_rejects_collection_name_validator_target() {
+		// Arrange
+		let input = quote! {
+			name: CollectionValidatorForm,
+			action: "/test",
+
+			fields: {
+				line_items: FieldArray {
+					fields: {
+						description: CharField {},
+					},
+				},
+			},
+
+			validators: {
+				line_items: [
+					|v| !v.is_empty() => "Line items are required",
+				],
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert!(
+			result
+				.unwrap_err()
+				.to_string()
+				.contains("validator references unknown field: 'line_items'")
+		);
+	}
+
+	#[rstest]
+	fn test_validate_nested_field_array_entry() {
+		// Arrange
+		let input = quote! {
+			name: SurveyForm,
+			action: "/test",
+
+			fields: {
+				sections: FieldArray {
+					fields: {
+						title: CharField { required },
+						questions: FieldArray {
+							min_items: 1,
+							fields: {
+								prompt: CharField { required },
+							},
+						},
+					},
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_ok());
+		let typed = result.unwrap();
+		let sections = typed.fields[0].as_collection().unwrap();
+		assert_eq!(sections.fields.len(), 2);
+
+		let questions = sections.fields[1].as_collection().unwrap();
+		assert_eq!(questions.name.to_string(), "questions");
+		assert_eq!(questions.min_items, Some(1));
+		assert_eq!(questions.fields.len(), 1);
+		assert_eq!(questions.fields[0].name().to_string(), "prompt");
 	}
 
 	// =========================================================================

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -85,9 +85,13 @@ fn collect_collections(entries: &[TypedFormFieldEntry]) -> Vec<&TypedFormFieldCo
 		.collect()
 }
 
-fn collection_item_values_ident(collection_name: &syn::Ident) -> syn::Ident {
+fn collection_item_values_ident(
+	form_name: &syn::Ident,
+	collection_name: &syn::Ident,
+) -> syn::Ident {
 	format_ident!(
-		"{}ItemValues",
+		"{}{}ItemValues",
+		upper_camel_ident_fragment(form_name),
 		upper_camel_ident_fragment(collection_name),
 		span = collection_name.span()
 	)
@@ -235,7 +239,7 @@ fn generate_form_runtime_contract(
 	let collection_item_value_structs: Vec<TokenStream> = collections
 		.iter()
 		.map(|collection| {
-			let ident = collection_item_values_ident(&collection.name);
+			let ident = collection_item_values_ident(&macro_ast.name, &collection.name);
 			let item_fields = collect_scalar_fields(&collection.fields);
 			let fields: Vec<TokenStream> = item_fields
 				.iter()
@@ -280,7 +284,7 @@ fn generate_form_runtime_contract(
 		.collect();
 	value_fields.extend(collections.iter().map(|collection| {
 		let name = &collection.name;
-		let item_values_ident = collection_item_values_ident(&collection.name);
+		let item_values_ident = collection_item_values_ident(&macro_ast.name, &collection.name);
 		quote! { pub #name: ::std::vec::Vec<#item_values_ident>, }
 	}));
 
@@ -382,7 +386,8 @@ fn generate_form_runtime_contract(
 		.iter()
 		.map(|collection| {
 			format_ident!(
-				"{}Field",
+				"{}{}Field",
+				upper_camel_ident_fragment(&macro_ast.name),
 				upper_camel_ident_fragment(&collection.name),
 				span = collection.name.span()
 			)
@@ -764,7 +769,7 @@ fn generate_form_runtime_contract(
 			.zip(collection_variants.iter())
 			.map(|(collection, variant)| {
 				let name = &collection.name;
-				let item_ident = collection_item_values_ident(&collection.name);
+				let item_ident = collection_item_values_ident(&macro_ast.name, &collection.name);
 				let collection_name = name.to_string();
 				quote! {
 					#collection_ident::#variant => {
@@ -1715,7 +1720,7 @@ pub(super) fn generate(
 	});
 
 	// Generate field declarations
-	let field_decls = generate_field_declarations(&macro_ast.fields, pages_crate);
+	let field_decls = generate_field_declarations(&macro_ast.name, &macro_ast.fields, pages_crate);
 
 	// Generate state field declarations
 	let state_decls = generate_state_declarations(&effective_state, pages_crate);
@@ -1731,7 +1736,7 @@ pub(super) fn generate(
 	let state_inits = generate_state_initializers(&effective_state, pages_crate);
 
 	// Generate field accessor methods
-	let field_accessors = generate_field_accessors(&macro_ast.fields, pages_crate);
+	let field_accessors = generate_field_accessors(&macro_ast.name, &macro_ast.fields, pages_crate);
 
 	// Generate state accessor methods
 	let state_accessors = generate_state_accessors(&effective_state, pages_crate);
@@ -1911,6 +1916,7 @@ pub(super) fn generate(
 
 /// Generates field declarations for the form struct.
 fn generate_field_declarations(
+	form_name: &syn::Ident,
 	entries: &[TypedFormFieldEntry],
 	pages_crate: &TokenStream,
 ) -> TokenStream {
@@ -1929,7 +1935,7 @@ fn generate_field_declarations(
 
 	decls.extend(collections.iter().map(|collection| {
 		let name = &collection.name;
-		let item_ident = collection_item_values_ident(&collection.name);
+		let item_ident = collection_item_values_ident(form_name, &collection.name);
 		quote! {
 			#name: #pages_crate::reactive::Signal<::std::vec::Vec<#pages_crate::CollectionItem<#item_ident>>>,
 		}
@@ -2059,6 +2065,7 @@ fn generate_initial_outer_setup(
 
 /// Generates field accessor methods.
 fn generate_field_accessors(
+	form_name: &syn::Ident,
 	entries: &[TypedFormFieldEntry],
 	pages_crate: &TokenStream,
 ) -> TokenStream {
@@ -2079,7 +2086,7 @@ fn generate_field_accessors(
 
 	for collection in collections {
 		let name = &collection.name;
-		let item_ident = collection_item_values_ident(&collection.name);
+		let item_ident = collection_item_values_ident(form_name, &collection.name);
 		let new_item_method = format_ident!("new_{}_item", name);
 		accessors.push(quote! {
 				pub fn #name(&self) -> &#pages_crate::reactive::Signal<::std::vec::Vec<#pages_crate::CollectionItem<#item_ident>>> {
@@ -3305,7 +3312,9 @@ fn generate_collection_view(
 	quote! {
 		{
 			let __collection_signal = self.#collection_name.clone();
+			let __path_signals = self.__path_signals.clone();
 			#pages_crate::component::Page::reactive(move || {
+				let _ = &__path_signals;
 				let __items = __collection_signal.get();
 				let mut __item_pages = ::std::vec::Vec::new();
 				for item in __items {
@@ -3357,7 +3366,7 @@ fn generate_collection_field_view(
 	let label_class = field.styling.label_class();
 	let input_class = field.styling.input_class();
 	let custom_attrs = generate_custom_attrs(&field.custom_attrs);
-	let listener = generate_collection_bind_listener(field, pages_crate);
+	let listener = generate_collection_bind_listener(field, pages_crate, collection_name);
 	let field_value = collection_field_value_expr(field);
 	let value_attr = if matches!(
 		field.field_type,
@@ -3506,13 +3515,19 @@ fn collection_field_value_expr(field: &TypedFormFieldDef) -> TokenStream {
 		| TypedFieldType::SlugField => quote! { item_value.#field_name.clone() },
 		TypedFieldType::DateField
 		| TypedFieldType::TimeField
-		| TypedFieldType::DateTimeField
 		| TypedFieldType::UuidField
 		| TypedFieldType::IpAddressField => quote! {
 			item_value
 				.#field_name
 				.as_ref()
 				.map(::std::string::ToString::to_string)
+				.unwrap_or_default()
+		},
+		TypedFieldType::DateTimeField => quote! {
+			item_value
+				.#field_name
+				.as_ref()
+				.map(|value| value.format("%Y-%m-%dT%H:%M:%S").to_string())
 				.unwrap_or_default()
 		},
 		TypedFieldType::MultipleChoiceField { .. } => quote! {
@@ -3551,8 +3566,12 @@ fn collection_field_checked_expr(field: &TypedFormFieldDef) -> TokenStream {
 fn generate_collection_bind_listener(
 	field: &TypedFormFieldDef,
 	pages_crate: &TokenStream,
+	collection_name: &str,
 ) -> TokenStream {
 	let field_name = &field.name;
+	let field_name_str = field.name.to_string();
+	let field_type = field_type_to_value_type(&field.field_type);
+	let collection_name_str = collection_name.to_string();
 	let event_name = match field.widget {
 		TypedWidget::Textarea => "input",
 		TypedWidget::Select | TypedWidget::SelectMultiple => "change",
@@ -3576,6 +3595,7 @@ fn generate_collection_bind_listener(
 		{
 			let __item_index = __items[__position].index();
 			let mut __item_value = __items[__position].value().clone();
+			let __path_value = __new_value.clone();
 			__item_value.#field_name = __new_value;
 			__items[__position] = #pages_crate::CollectionItem::new(
 				__item_key,
@@ -3583,6 +3603,23 @@ fn generate_collection_bind_listener(
 				__item_value,
 			);
 			__field_collection_signal.set(__items);
+			let __path_key = ::std::format!(
+				"{}:{:?}:{}",
+				#collection_name_str,
+				__item_key,
+				#field_name_str,
+			);
+			let __path_signal = __field_path_signals
+				.borrow()
+				.get(&__path_key)
+				.and_then(|signal| {
+					signal
+						.downcast_ref::<#pages_crate::reactive::Signal<#field_type>>()
+						.cloned()
+				});
+			if let ::core::option::Option::Some(__path_signal) = __path_signal {
+				__path_signal.set(__path_value);
+			}
 		}
 	};
 	let wasm_update =
@@ -3591,6 +3628,7 @@ fn generate_collection_bind_listener(
 	quote! {
 		.listener(#event_name, {
 			let __field_collection_signal = __collection_signal.clone();
+			let __field_path_signals = __path_signals.clone();
 			let __item_key = item.key();
 			move |event| {
 				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
@@ -3608,6 +3646,7 @@ fn generate_collection_bind_listener(
 				{
 					let _ = event;
 					let _ = &__field_collection_signal;
+					let _ = &__field_path_signals;
 					let _ = __item_key;
 				}
 			}
@@ -3662,11 +3701,7 @@ fn collection_field_wasm_update(
 		TypedFieldType::TimeField => {
 			collection_option_parse_update(element_var, quote! { chrono::NaiveTime }, assignment)
 		}
-		TypedFieldType::DateTimeField => collection_option_parse_update(
-			element_var,
-			quote! { chrono::NaiveDateTime },
-			assignment,
-		),
+		TypedFieldType::DateTimeField => collection_datetime_parse_update(element_var, assignment),
 		TypedFieldType::UuidField => {
 			collection_option_parse_update(element_var, quote! { uuid::Uuid }, assignment)
 		}
@@ -3721,6 +3756,25 @@ fn collection_option_parse_update(
 			#assignment
 		} else if let ::core::result::Result::Ok(__parsed) =
 			__raw.parse::<#value_type>()
+		{
+			let __new_value = ::core::option::Option::Some(__parsed);
+			#assignment
+		}
+	}
+}
+
+fn collection_datetime_parse_update(
+	element_var: &syn::Ident,
+	assignment: TokenStream,
+) -> TokenStream {
+	quote! {
+		let __raw = #element_var.value();
+		if __raw.is_empty() {
+			let __new_value = ::core::option::Option::None;
+			#assignment
+		} else if let ::core::result::Result::Ok(__parsed) =
+			chrono::NaiveDateTime::parse_from_str(&__raw, "%Y-%m-%dT%H:%M:%S")
+				.or_else(|_| chrono::NaiveDateTime::parse_from_str(&__raw, "%Y-%m-%dT%H:%M"))
 		{
 			let __new_value = ::core::option::Option::Some(__parsed);
 			#assignment
@@ -4228,7 +4282,10 @@ fn generate_value_conversion(
 				let raw = #element_var.value();
 				if raw.is_empty() {
 					signal.set(::core::option::Option::None);
-				} else if let Ok(v) = raw.parse::<chrono::NaiveDateTime>() {
+				} else if let Ok(v) =
+					chrono::NaiveDateTime::parse_from_str(&raw, "%Y-%m-%dT%H:%M:%S")
+						.or_else(|_| chrono::NaiveDateTime::parse_from_str(&raw, "%Y-%m-%dT%H:%M"))
+				{
 					signal.set(::core::option::Option::Some(v));
 				}
 			}

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -49,17 +49,17 @@ use quote::{ToTokens, format_ident, quote};
 use crate::crate_paths::get_reinhardt_pages_crate_info;
 use reinhardt_manouche::core::{
 	AmbientArgumentsSource, FormMethod, TypedCustomAttr, TypedFieldType, TypedFormAction,
-	TypedFormCallbacks, TypedFormDerived, TypedFormFieldDef, TypedFormFieldEntry,
-	TypedFormFieldGroup, TypedFormMacro, TypedFormSlots, TypedFormState, TypedFormWatch, TypedIcon,
-	TypedIconChild, TypedIconPosition, TypedSubmitButtonDef, TypedValidatorRule, TypedWidget,
-	TypedWrapper,
+	TypedFormCallbacks, TypedFormDerived, TypedFormFieldCollection, TypedFormFieldDef,
+	TypedFormFieldEntry, TypedFormFieldGroup, TypedFormMacro, TypedFormSlots, TypedFormState,
+	TypedFormWatch, TypedIcon, TypedIconChild, TypedIconPosition, TypedSubmitButtonDef,
+	TypedValidatorRule, TypedWidget, TypedWrapper,
 };
 
-/// Collects all fields from field entries, flattening groups.
+/// Collects scalar fields from field entries, flattening groups.
 ///
 /// This is useful for generating struct declarations and accessors,
 /// where all fields need to be at the same level regardless of grouping.
-fn collect_all_fields(entries: &[TypedFormFieldEntry]) -> Vec<&TypedFormFieldDef> {
+fn collect_scalar_fields(entries: &[TypedFormFieldEntry]) -> Vec<&TypedFormFieldDef> {
 	let mut fields = Vec::new();
 	for entry in entries {
 		match entry {
@@ -67,10 +67,50 @@ fn collect_all_fields(entries: &[TypedFormFieldEntry]) -> Vec<&TypedFormFieldDef
 			TypedFormFieldEntry::Group(group) => {
 				fields.extend(group.fields.iter());
 			}
+			TypedFormFieldEntry::Collection(_) => {}
 			TypedFormFieldEntry::SubmitButton(_) => {} // Not a data field
 		}
 	}
 	fields
+}
+
+/// Collects top-level field collections from field entries.
+fn collect_collections(entries: &[TypedFormFieldEntry]) -> Vec<&TypedFormFieldCollection> {
+	entries
+		.iter()
+		.filter_map(|entry| match entry {
+			TypedFormFieldEntry::Collection(collection) => Some(collection),
+			_ => None,
+		})
+		.collect()
+}
+
+fn collection_item_values_ident(collection_name: &syn::Ident) -> syn::Ident {
+	format_ident!(
+		"{}ItemValues",
+		upper_camel_ident_fragment(collection_name),
+		span = collection_name.span()
+	)
+}
+
+fn upper_camel_ident_fragment(ident: &syn::Ident) -> String {
+	let raw = ident.to_string();
+	let input = raw.strip_prefix("r#").unwrap_or(&raw);
+	let mut out = String::new();
+	let mut upper_next = true;
+	for ch in input.chars() {
+		if ch == '_' {
+			upper_next = true;
+			continue;
+		}
+		if upper_next {
+			out.push(ch.to_ascii_uppercase());
+			upper_next = false;
+		} else {
+			out.push(ch);
+		}
+	}
+	out
 }
 
 fn generate_ambient_argument_deprecation_markers(
@@ -154,8 +194,9 @@ fn generate_form_runtime_contract(
 	let values_ident = format_ident!("{}Values", macro_ast.name);
 	let field_ident = format_ident!("{}Field", macro_ast.name);
 	let form_ident = &macro_ast.name;
-	let all_fields = collect_all_fields(&macro_ast.fields);
-	let unsupported_fields: Vec<String> = all_fields
+	let all_fields = collect_scalar_fields(&macro_ast.fields);
+	let collections = collect_collections(&macro_ast.fields);
+	let mut unsupported_fields: Vec<String> = all_fields
 		.iter()
 		.filter(|field| !supports_generated_form_values(&field.field_type))
 		.map(|field| {
@@ -166,6 +207,21 @@ fn generate_form_runtime_contract(
 			)
 		})
 		.collect();
+	for collection in &collections {
+		unsupported_fields.extend(
+			collect_scalar_fields(&collection.fields)
+				.iter()
+				.filter(|field| !supports_generated_form_values(&field.field_type))
+				.map(|field| {
+					format!(
+						"{}.{} ({})",
+						collection.name,
+						field.name,
+						field_type_to_string(&field.field_type)
+					)
+				}),
+		);
+	}
 	if !unsupported_fields.is_empty() {
 		let message = format!(
 			"form! cannot generate a use_form runtime contract for unsupported field(s): {}.",
@@ -176,7 +232,45 @@ fn generate_form_runtime_contract(
 		};
 	}
 
-	let value_fields: Vec<TokenStream> = all_fields
+	let collection_item_value_structs: Vec<TokenStream> = collections
+		.iter()
+		.map(|collection| {
+			let ident = collection_item_values_ident(&collection.name);
+			let item_fields = collect_scalar_fields(&collection.fields);
+			let fields: Vec<TokenStream> = item_fields
+				.iter()
+				.map(|field| {
+					let name = &field.name;
+					let ty = field_type_to_value_type(&field.field_type);
+					quote! { pub #name: #ty, }
+				})
+				.collect();
+			let default_fields: Vec<TokenStream> = item_fields
+				.iter()
+				.map(|field| {
+					let name = &field.name;
+					let init = field_type_default_value(&field.field_type);
+					quote! { #name: #init, }
+				})
+				.collect();
+			quote! {
+				#[derive(Clone, PartialEq)]
+				struct #ident {
+					#(#fields)*
+				}
+
+				impl ::core::default::Default for #ident {
+					fn default() -> Self {
+						Self {
+							#(#default_fields)*
+						}
+					}
+				}
+			}
+		})
+		.collect();
+
+	let mut value_fields: Vec<TokenStream> = all_fields
 		.iter()
 		.map(|field| {
 			let name = &field.name;
@@ -184,15 +278,31 @@ fn generate_form_runtime_contract(
 			quote! { pub #name: #ty, }
 		})
 		.collect();
+	value_fields.extend(collections.iter().map(|collection| {
+		let name = &collection.name;
+		let item_values_ident = collection_item_values_ident(&collection.name);
+		quote! { pub #name: ::std::vec::Vec<#item_values_ident>, }
+	}));
 
-	let values_fields: Vec<TokenStream> = all_fields
+	let mut values_fields: Vec<TokenStream> = all_fields
 		.iter()
 		.map(|field| {
 			let name = &field.name;
 			quote! { #name: self.#name.get(), }
 		})
 		.collect();
-	let initial_values_fields: Vec<TokenStream> = all_fields
+	values_fields.extend(collections.iter().map(|collection| {
+		let name = &collection.name;
+		quote! {
+			#name: self
+				.#name
+				.get()
+				.into_iter()
+				.map(#pages_crate::CollectionItem::into_value)
+				.collect(),
+		}
+	}));
+	let mut initial_values_fields: Vec<TokenStream> = all_fields
 		.iter()
 		.map(|field| {
 			let name = &field.name;
@@ -200,14 +310,39 @@ fn generate_form_runtime_contract(
 			quote! { #name: #init, }
 		})
 		.collect();
+	initial_values_fields.extend(collections.iter().map(|collection| {
+		let name = &collection.name;
+		quote! { #name: ::std::vec::Vec::new(), }
+	}));
 
-	let apply_values_fields: Vec<TokenStream> = all_fields
+	let mut apply_values_fields: Vec<TokenStream> = all_fields
 		.iter()
 		.map(|field| {
 			let name = &field.name;
 			quote! { self.#name.set(values.#name.clone()); }
 		})
 		.collect();
+	apply_values_fields.extend(collections.iter().map(|collection| {
+		let name = &collection.name;
+		quote! {
+				self.__path_signals.borrow_mut().clear();
+				self.#name.set(
+					values
+						.#name
+					.iter()
+					.cloned()
+					.enumerate()
+					.map(|(index, value)| {
+						#pages_crate::CollectionItem::new(
+							#pages_crate::CollectionItemKey::from_runtime_index(index as u64),
+							index,
+							value,
+						)
+					})
+					.collect(),
+			);
+		}
+	}));
 
 	let field_variants: Vec<syn::Ident> = all_fields
 		.iter()
@@ -225,6 +360,133 @@ fn generate_form_runtime_contract(
 			}
 		})
 		.collect();
+	let collection_ident = format_ident!("{}Collection", macro_ast.name);
+	let field_path_ident = format_ident!("{}FieldPath", macro_ast.name);
+	let collection_variants: Vec<syn::Ident> = collections
+		.iter()
+		.map(|collection| field_variant_ident(&collection.name))
+		.collect();
+	let collection_accessor_methods: Vec<TokenStream> = collections
+		.iter()
+		.zip(collection_variants.iter())
+		.map(|(collection, variant)| {
+			let method = format_ident!("{}_collection", collection.name);
+			quote! {
+				pub fn #method(&self) -> #collection_ident {
+					#collection_ident::#variant
+				}
+			}
+		})
+		.collect();
+	let collection_field_idents: Vec<syn::Ident> = collections
+		.iter()
+		.map(|collection| {
+			format_ident!(
+				"{}Field",
+				upper_camel_ident_fragment(&collection.name),
+				span = collection.name.span()
+			)
+		})
+		.collect();
+	let collection_field_definitions: Vec<TokenStream> = collections
+		.iter()
+		.zip(collection_field_idents.iter())
+		.map(|(collection, field_ident)| {
+			let variants: Vec<syn::Ident> = collect_scalar_fields(&collection.fields)
+				.iter()
+				.map(|field| field_variant_ident(&field.name))
+				.collect();
+			quote! {
+				#[allow(
+					dead_code,
+					reason = "Generated field path variants are constructed only when callers use path accessors."
+				)]
+				#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+				enum #field_ident {
+					#(#variants,)*
+				}
+			}
+		})
+		.collect();
+	let field_path_variants: Vec<TokenStream> = collections
+		.iter()
+		.zip(collection_variants.iter())
+		.zip(collection_field_idents.iter())
+		.map(|((_collection, variant), field_ident)| {
+			quote! {
+				#variant {
+					item: #pages_crate::CollectionItemKey,
+					field: #field_ident,
+				}
+			}
+		})
+		.collect();
+	let field_path_accessor_methods: Vec<TokenStream> = collections
+		.iter()
+		.zip(collection_variants.iter())
+		.zip(collection_field_idents.iter())
+		.flat_map(|((collection, collection_variant), field_ident)| {
+			let field_path_ident = field_path_ident.clone();
+			collect_scalar_fields(&collection.fields)
+				.into_iter()
+				.map(move |field| {
+					let method = format_ident!("{}_{}_path", collection.name, field.name);
+					let field_variant = field_variant_ident(&field.name);
+					quote! {
+						pub fn #method(
+							&self,
+							item: #pages_crate::CollectionItemKey,
+						) -> #field_path_ident {
+							#field_path_ident::#collection_variant {
+								item,
+								field: #field_ident::#field_variant,
+							}
+						}
+					}
+				})
+		})
+		.collect();
+	let collection_token_definition = if collections.is_empty() {
+		quote! {}
+	} else {
+		quote! {
+			#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+			enum #collection_ident {
+				#(#collection_variants,)*
+			}
+
+			impl #form_ident {
+				#(#collection_accessor_methods)*
+			}
+		}
+	};
+	let field_path_token_definition = if collections.is_empty() {
+		quote! {}
+	} else {
+		quote! {
+			#(#collection_field_definitions)*
+
+			#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+			enum #field_path_ident {
+				#(#field_path_variants,)*
+			}
+
+			impl #form_ident {
+				#(#field_path_accessor_methods)*
+			}
+		}
+	};
+	let collection_token_guard = if collections.is_empty() {
+		quote! {}
+	} else {
+		quote! {
+			let _ = ::core::mem::size_of::<#collection_ident>();
+			let _ = ::core::mem::size_of::<#field_path_ident>();
+			#(
+				let _ = ::core::mem::size_of::<#collection_field_idents>();
+			)*
+		}
+	};
 	let field_setters: Vec<TokenStream> = all_fields
 		.iter()
 		.zip(field_variants.iter())
@@ -294,6 +556,655 @@ fn generate_form_runtime_contract(
 			}
 		})
 		.collect();
+	let values_dirty_impl = if collections.is_empty() {
+		quote! {}
+	} else {
+		quote! {
+			fn runtime_values_are_dirty(
+				&self,
+				current: &Self::Values,
+				defaults: &Self::Values,
+			) -> bool {
+				current != defaults
+			}
+		}
+	};
+	let apply_pristine_values_impl = if collections.is_empty() {
+		quote! {}
+	} else {
+		let scalar_pristine_assignments: Vec<TokenStream> = all_fields
+			.iter()
+			.map(|field| {
+				let name = &field.name;
+				quote! {
+					if current.#name == old_defaults.#name {
+						self.#name.set(new_defaults.#name.clone());
+					}
+				}
+			})
+			.collect();
+		let collection_pristine_assignments: Vec<TokenStream> = collections
+			.iter()
+			.map(|collection| {
+				let name = &collection.name;
+				quote! {
+						if current.#name == old_defaults.#name {
+							self.__path_signals.borrow_mut().clear();
+							self.#name.set(
+								new_defaults
+									.#name
+								.iter()
+								.cloned()
+								.enumerate()
+								.map(|(index, value)| {
+									#pages_crate::CollectionItem::new(
+										#pages_crate::CollectionItemKey::from_runtime_index(index as u64),
+										index,
+										value,
+									)
+								})
+								.collect(),
+						);
+					}
+				}
+			})
+			.collect();
+		quote! {
+		fn runtime_apply_pristine_values(
+			&self,
+			current: &Self::Values,
+			old_defaults: &Self::Values,
+			new_defaults: &Self::Values,
+		) {
+			#(#scalar_pristine_assignments)*
+			#(#collection_pristine_assignments)*
+		}
+		}
+	};
+	let path_values_from_values_blocks: Vec<TokenStream> = collections
+		.iter()
+		.map(|collection| {
+			let collection_name = &collection.name;
+			let collection_name_text = collection.name.to_string();
+			let value_inserts: Vec<TokenStream> = collect_scalar_fields(&collection.fields)
+				.iter()
+				.map(|field| {
+					let field_name = &field.name;
+					let field_name_text = field.name.to_string();
+					quote! {
+						{
+							let value: ::std::rc::Rc<dyn ::core::any::Any> =
+								::std::rc::Rc::new(value.#field_name.clone());
+							path_values.insert(
+								::std::format!(
+									"{}:{:?}:{}",
+									#collection_name_text,
+									item.key(),
+									#field_name_text,
+								),
+								value,
+							);
+						}
+					}
+				})
+				.collect();
+			quote! {
+				for item in self.#collection_name.get() {
+					if let ::core::option::Option::Some(value) =
+						values.#collection_name.get(item.index())
+					{
+						#(#value_inserts)*
+					}
+				}
+			}
+		})
+		.collect();
+	let path_exists_blocks: Vec<TokenStream> = collections
+		.iter()
+		.map(|collection| {
+			let collection_name = &collection.name;
+			let collection_name_text = collection.name.to_string();
+			let path_checks: Vec<TokenStream> = collect_scalar_fields(&collection.fields)
+				.iter()
+				.map(|field| {
+					let field_name_text = field.name.to_string();
+					quote! {
+						if path_key
+							== ::std::format!(
+								"{}:{:?}:{}",
+								#collection_name_text,
+								item.key(),
+								#field_name_text,
+							)
+						{
+							return true;
+						}
+					}
+				})
+				.collect();
+			quote! {
+				for item in self.#collection_name.get() {
+					#(#path_checks)*
+				}
+			}
+		})
+		.collect();
+	let path_value_equals_blocks: Vec<TokenStream> = collections
+		.iter()
+		.map(|collection| {
+			let collection_name = &collection.name;
+			let collection_name_text = collection.name.to_string();
+			let value_checks: Vec<TokenStream> = collect_scalar_fields(&collection.fields)
+				.iter()
+				.map(|field| {
+					let field_name = &field.name;
+					let field_name_text = field.name.to_string();
+					let field_type = field_type_to_value_type(&field.field_type);
+					quote! {
+						if path_key
+							== ::std::format!(
+								"{}:{:?}:{}",
+								#collection_name_text,
+								item.key(),
+								#field_name_text,
+							)
+						{
+							return default
+								.downcast_ref::<#field_type>()
+								.map(|default| &item_value.#field_name == default);
+						}
+					}
+				})
+				.collect();
+			quote! {
+				for item in self.#collection_name.get() {
+					let item_value = item.value();
+					#(#value_checks)*
+				}
+			}
+		})
+		.collect();
+	let collection_runtime_impl = if collections.is_empty() {
+		quote! {}
+	} else {
+		let collection_len_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.map(|(collection, variant)| {
+				let name = &collection.name;
+				quote! {
+				#collection_ident::#variant => self.#name.get().len(),
+				}
+			})
+			.collect();
+		let collection_key_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.map(|(collection, variant)| {
+				let name = collection.name.to_string();
+				quote! {
+					#collection_ident::#variant => #name.to_string(),
+				}
+			})
+			.collect();
+		let collection_dirty_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.map(|(collection, variant)| {
+				let name = &collection.name;
+				quote! {
+					#collection_ident::#variant => current.#name != defaults.#name,
+				}
+			})
+			.collect();
+		let collection_insert_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.map(|(collection, variant)| {
+				let name = &collection.name;
+				let item_ident = collection_item_values_ident(&collection.name);
+				let collection_name = name.to_string();
+				quote! {
+					#collection_ident::#variant => {
+						let boxed: ::std::boxed::Box<dyn ::core::any::Any> =
+							::std::boxed::Box::new(value);
+						match boxed.downcast::<#item_ident>() {
+							::core::result::Result::Ok(value) => {
+								let mut items = self.#name.get();
+								let index = index.min(items.len());
+								items.insert(
+									index,
+									#pages_crate::CollectionItem::new(key, index, *value),
+								);
+								self.#name.set(
+									items
+										.into_iter()
+										.enumerate()
+										.map(|(index, item)| {
+											#pages_crate::CollectionItem::new(
+												item.key(),
+												index,
+												item.into_value(),
+											)
+										})
+										.collect(),
+								);
+								self.__path_signals.borrow_mut().clear();
+							}
+							::core::result::Result::Err(_) => panic!(
+								"form! collection '{}' does not accept values of type {}",
+								#collection_name,
+								::core::any::type_name::<T>(),
+							),
+						}
+					}
+				}
+			})
+			.collect();
+		let collection_remove_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.map(|(collection, variant)| {
+				let name = &collection.name;
+				quote! {
+					#collection_ident::#variant => {
+						let mut items = self.#name.get();
+						if let ::core::option::Option::Some(index) =
+							items.iter().position(|item| item.key() == key)
+						{
+							items.remove(index);
+							self.#name.set(
+								items
+									.into_iter()
+									.enumerate()
+									.map(|(index, item)| {
+										#pages_crate::CollectionItem::new(
+											item.key(),
+											index,
+											item.into_value(),
+										)
+									})
+									.collect(),
+							);
+							self.__path_signals.borrow_mut().clear();
+							true
+						} else {
+							false
+						}
+					}
+				}
+			})
+			.collect();
+		let collection_move_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.map(|(collection, variant)| {
+				let name = &collection.name;
+				quote! {
+					#collection_ident::#variant => {
+						let mut items = self.#name.get();
+						if let ::core::option::Option::Some(from_index) =
+							items.iter().position(|item| item.key() == key)
+						{
+							let item = items.remove(from_index);
+							let to_index = target_index.min(items.len());
+							items.insert(to_index, item);
+							self.#name.set(
+								items
+									.into_iter()
+									.enumerate()
+									.map(|(index, item)| {
+										#pages_crate::CollectionItem::new(
+											item.key(),
+											index,
+											item.into_value(),
+										)
+									})
+									.collect(),
+							);
+							self.__path_signals.borrow_mut().clear();
+							::core::option::Option::Some((from_index, to_index))
+						} else {
+							::core::option::Option::None
+						}
+					}
+				}
+			})
+			.collect();
+		let field_path_key_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.zip(collection_field_idents.iter())
+			.flat_map(|((collection, collection_variant), field_ident)| {
+				let collection_name = collection.name.to_string();
+				let field_path_ident = field_path_ident.clone();
+				collect_scalar_fields(&collection.fields)
+					.into_iter()
+					.map(move |field| {
+						let field_name = field.name.to_string();
+						let field_variant = field_variant_ident(&field.name);
+						quote! {
+							#field_path_ident::#collection_variant {
+								item,
+								field: #field_ident::#field_variant,
+							} => ::std::format!("{}:{:?}:{}", #collection_name, item, #field_name),
+						}
+					})
+			})
+			.collect();
+		let field_path_keys_for_item_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.map(|(collection, collection_variant)| {
+				let collection_name = collection.name.to_string();
+				let field_names: Vec<String> = collect_scalar_fields(&collection.fields)
+					.iter()
+					.map(|field| field.name.to_string())
+					.collect();
+				quote! {
+					#collection_ident::#collection_variant => {
+						::std::vec![
+							#(
+								::std::format!("{}:{:?}:{}", #collection_name, key, #field_names)
+							),*
+						]
+					}
+				}
+			})
+			.collect();
+		let watch_path_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.zip(collection_field_idents.iter())
+			.flat_map(|((collection, collection_variant), field_ident)| {
+				let collection_name = &collection.name;
+				let field_path_ident = field_path_ident.clone();
+				collect_scalar_fields(&collection.fields)
+					.into_iter()
+					.map(move |field| {
+						let field_name = &field.name;
+						let field_type = field_type_to_value_type(&field.field_type);
+						let field_variant = field_variant_ident(&field.name);
+						quote! {
+							#field_path_ident::#collection_variant {
+								item,
+								field: #field_ident::#field_variant,
+							} => {
+								let path_key = Self::runtime_field_path_key(
+									&#field_path_ident::#collection_variant {
+										item,
+										field: #field_ident::#field_variant,
+									},
+								);
+								let value = self
+									.#collection_name
+									.get()
+									.into_iter()
+									.find(|entry| entry.key() == item)
+									.map(|entry| entry.value().#field_name.clone())?;
+								if let ::core::option::Option::Some(signal) = {
+									self.__path_signals
+										.borrow()
+										.get(&path_key)
+										.and_then(|signal| {
+											signal
+												.downcast_ref::<#pages_crate::reactive::Signal<#field_type>>()
+												.cloned()
+										})
+								} {
+									let boxed: ::std::boxed::Box<dyn ::core::any::Any> =
+										::std::boxed::Box::new(signal.clone());
+									match boxed.downcast::<#pages_crate::reactive::Signal<T>>() {
+										::core::result::Result::Ok(typed_signal) => {
+											signal.set(value);
+											return ::core::option::Option::Some(*typed_signal);
+										}
+										::core::result::Result::Err(_) => {
+											return ::core::option::Option::None;
+										}
+									}
+								}
+
+								let signal = #pages_crate::reactive::Signal::new(value);
+								let boxed: ::std::boxed::Box<dyn ::core::any::Any> =
+									::std::boxed::Box::new(signal);
+								let signal = match boxed
+									.downcast::<#pages_crate::reactive::Signal<T>>()
+								{
+									::core::result::Result::Ok(signal) => *signal,
+									::core::result::Result::Err(_) => {
+										return ::core::option::Option::None;
+									}
+								};
+								self.__path_signals
+									.borrow_mut()
+									.insert(path_key, ::std::boxed::Box::new(signal.clone()));
+								::core::option::Option::Some(signal)
+							}
+						}
+					})
+			})
+			.collect();
+		let set_path_value_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.zip(collection_field_idents.iter())
+			.flat_map(|((collection, collection_variant), field_ident)| {
+				let collection_name = &collection.name;
+				let field_path_ident = field_path_ident.clone();
+				collect_scalar_fields(&collection.fields)
+					.into_iter()
+					.map(move |field| {
+						let field_name = &field.name;
+						let field_type = field_type_to_value_type(&field.field_type);
+						let field_variant = field_variant_ident(&field.name);
+						quote! {
+							#field_path_ident::#collection_variant {
+								item,
+								field: #field_ident::#field_variant,
+							} => {
+								let boxed: ::std::boxed::Box<dyn ::core::any::Any> =
+									::std::boxed::Box::new(value);
+								match boxed.downcast::<#field_type>() {
+									::core::result::Result::Ok(value) => {
+										let value = *value;
+										let mut items = self.#collection_name.get();
+											if let ::core::option::Option::Some(index) =
+												items.iter().position(|entry| entry.key() == item)
+											{
+												let item_index = items[index].index();
+											let mut item_value = items[index].value().clone();
+											item_value.#field_name = value.clone();
+											items[index] = #pages_crate::CollectionItem::new(
+												item,
+												item_index,
+												item_value,
+											);
+											self.#collection_name.set(items);
+											let signal = self
+												.__path_signals
+												.borrow()
+												.get(&path_key)
+												.and_then(|signal| {
+													signal
+														.downcast_ref::<
+															#pages_crate::reactive::Signal<#field_type>,
+														>()
+														.cloned()
+												});
+											if let ::core::option::Option::Some(signal) = signal {
+												signal.set(value);
+											}
+											true
+											} else {
+												false
+											}
+										}
+									::core::result::Result::Err(_) => panic!(
+										"form! field path {:?} does not accept values of type {}",
+										#field_path_ident::#collection_variant {
+											item,
+											field: #field_ident::#field_variant,
+										},
+										::core::any::type_name::<T>(),
+									),
+								}
+							}
+						}
+					})
+			})
+			.collect();
+		let path_dirty_arms: Vec<TokenStream> = collections
+			.iter()
+			.zip(collection_variants.iter())
+			.zip(collection_field_idents.iter())
+			.flat_map(|((collection, collection_variant), field_ident)| {
+				let collection_name = &collection.name;
+				let field_path_ident = field_path_ident.clone();
+				collect_scalar_fields(&collection.fields)
+					.into_iter()
+					.map(move |field| {
+						let field_name = &field.name;
+						let field_variant = field_variant_ident(&field.name);
+						quote! {
+							#field_path_ident::#collection_variant {
+								item,
+								field: #field_ident::#field_variant,
+							} => {
+								let items = self.#collection_name.get();
+								if let ::core::option::Option::Some(index) =
+									items.iter().position(|entry| entry.key() == item)
+								{
+									current
+										.#collection_name
+										.get(index)
+										.map(|item| &item.#field_name)
+										!= defaults
+											.#collection_name
+											.get(index)
+											.map(|item| &item.#field_name)
+								} else {
+									false
+								}
+							}
+						}
+					})
+			})
+			.collect();
+		quote! {
+				impl #pages_crate::form_state::FormCollectionRuntimeSource for #form_ident {
+					type Collection = #collection_ident;
+					type FieldPath = #field_path_ident;
+
+					fn runtime_field_path_key(path: &Self::FieldPath) -> ::std::string::String {
+						match path.clone() {
+							#(#field_path_key_arms)*
+						}
+					}
+
+					fn runtime_collection_key(collection: Self::Collection) -> ::std::string::String {
+						match collection {
+							#(#collection_key_arms)*
+						}
+					}
+
+					fn runtime_field_path_keys_for_item(
+						collection: Self::Collection,
+					key: #pages_crate::CollectionItemKey,
+				) -> ::std::vec::Vec<::std::string::String> {
+					match collection {
+						#(#field_path_keys_for_item_arms)*
+					}
+				}
+
+					fn runtime_collection_len(&self, collection: Self::Collection) -> usize {
+						match collection {
+							#(#collection_len_arms)*
+						}
+					}
+
+					fn runtime_collection_is_dirty(
+						&self,
+						collection: Self::Collection,
+						current: &Self::Values,
+						defaults: &Self::Values,
+					) -> bool {
+						match collection {
+							#(#collection_dirty_arms)*
+						}
+					}
+
+					fn runtime_insert_collection_item<T>(
+					&self,
+					collection: Self::Collection,
+					index: usize,
+					key: #pages_crate::CollectionItemKey,
+					value: T,
+				)
+				where
+					T: ::core::any::Any + ::core::clone::Clone + 'static,
+				{
+					match collection {
+						#(#collection_insert_arms)*
+					}
+				}
+
+				fn runtime_remove_collection_item(
+					&self,
+					collection: Self::Collection,
+					key: #pages_crate::CollectionItemKey,
+				) -> bool {
+					match collection {
+						#(#collection_remove_arms)*
+					}
+				}
+
+				fn runtime_move_collection_item(
+					&self,
+					collection: Self::Collection,
+					key: #pages_crate::CollectionItemKey,
+					target_index: usize,
+				) -> ::core::option::Option<(usize, usize)> {
+					match collection {
+						#(#collection_move_arms)*
+					}
+				}
+
+				fn runtime_watch_path<T>(
+					&self,
+					path: Self::FieldPath,
+				) -> ::core::option::Option<#pages_crate::reactive::Signal<T>>
+				where
+					T: ::core::clone::Clone + 'static,
+				{
+					match path {
+						#(#watch_path_arms)*
+					}
+				}
+
+					fn runtime_set_path_value<T>(&self, path: Self::FieldPath, value: T) -> bool
+					where
+						T: ::core::any::Any + 'static,
+					{
+						let path_key = Self::runtime_field_path_key(&path);
+						match path {
+						#(#set_path_value_arms)*
+					}
+				}
+
+				fn runtime_path_is_dirty(
+					&self,
+					path: &Self::FieldPath,
+					current: &Self::Values,
+					defaults: &Self::Values,
+					) -> bool {
+						match path.clone() {
+							#(#path_dirty_arms)*
+						}
+					}
+				}
+		}
+	};
 	let required_validation_checks: Vec<TokenStream> = all_fields
 		.iter()
 		.zip(field_variants.iter())
@@ -309,6 +1220,99 @@ fn generate_form_runtime_contract(
 					error.add_field_error(#field_ident::#variant, #message);
 				}
 			})
+		})
+		.collect();
+	let collection_constraints_validation_checks: Vec<TokenStream> = collections
+		.iter()
+		.zip(collection_variants.iter())
+		.flat_map(|(collection, collection_variant)| {
+			let collection_name = &collection.name;
+			let collection_name_text = collection.name.to_string();
+			let mut checks = Vec::new();
+			if let Some(min_items) = collection.min_items {
+				let message = format!(
+					"{} requires at least {} item{}",
+					collection_name_text,
+					min_items,
+					if min_items == 1 { "" } else { "s" }
+				);
+				checks.push(quote! {
+					{
+						let __len = self.#collection_name.get().len();
+						if __len < #min_items {
+							error.add_collection_error(
+								<#form_ident as #pages_crate::form_state::FormCollectionRuntimeSource>::runtime_collection_key(
+									#collection_ident::#collection_variant,
+								),
+								#message,
+							);
+						}
+					}
+				});
+			}
+			if let Some(max_items) = collection.max_items {
+				let message = format!(
+					"{} allows at most {} item{}",
+					collection_name_text,
+					max_items,
+					if max_items == 1 { "" } else { "s" }
+				);
+				checks.push(quote! {
+					{
+						let __len = self.#collection_name.get().len();
+						if __len > #max_items {
+							error.add_collection_error(
+								<#form_ident as #pages_crate::form_state::FormCollectionRuntimeSource>::runtime_collection_key(
+									#collection_ident::#collection_variant,
+								),
+								#message,
+							);
+						}
+					}
+				});
+			}
+			checks
+		})
+		.collect();
+	let collection_required_validation_checks: Vec<TokenStream> = collections
+		.iter()
+		.zip(collection_variants.iter())
+		.zip(collection_field_idents.iter())
+		.flat_map(|((collection, collection_variant), field_ident)| {
+			let collection_name = collection.name.clone();
+			let collection_name_text = collection.name.to_string();
+			let collection_variant = collection_variant.clone();
+			let field_ident = field_ident.clone();
+			let field_path_ident = field_path_ident.clone();
+			collect_scalar_fields(&collection.fields)
+				.into_iter()
+				.filter_map(move |field| {
+					if !field.validation.required {
+						return None;
+					}
+					let field_name = field.name.clone();
+					let field_name_text = field.name.to_string();
+					let field_variant = field_variant_ident(&field.name);
+					let message = format!("{}.{} is required", collection_name_text, field_name_text);
+					let empty_check =
+						runtime_collection_required_empty_check(&field_name, &field.field_type)?;
+					Some(quote! {
+						for item in self.#collection_name.get() {
+							let item_value = item.value();
+							if #empty_check {
+								let path = #field_path_ident::#collection_variant {
+									item: item.key(),
+									field: #field_ident::#field_variant,
+								};
+								error.add_path_error(
+									<#form_ident as #pages_crate::form_state::FormCollectionRuntimeSource>::runtime_field_path_key(&path),
+									#message,
+								);
+							}
+						}
+					})
+				})
+				.collect::<Vec<_>>()
 		})
 		.collect();
 	let wasm_focus_body = if all_fields.is_empty() {
@@ -339,6 +1343,8 @@ fn generate_form_runtime_contract(
 	};
 
 	quote! {
+		#(#collection_item_value_structs)*
+
 		#[derive(Clone, PartialEq)]
 		struct #values_ident {
 			#(#value_fields)*
@@ -348,6 +1354,9 @@ fn generate_form_runtime_contract(
 		enum #field_ident {
 			#(#field_variants,)*
 		}
+
+		#collection_token_definition
+		#field_path_token_definition
 
 		impl #form_ident {
 			#(#field_accessor_methods)*
@@ -386,31 +1395,63 @@ fn generate_form_runtime_contract(
 				}
 			}
 
-			fn runtime_field_is_dirty(
-				&self,
-				field: Self::Field,
-				current: &Self::Values,
-				defaults: &Self::Values,
-			) -> bool {
-				match field {
-					#(#field_dirty_arms)*
+				fn runtime_field_is_dirty(
+					&self,
+					field: Self::Field,
+					current: &Self::Values,
+					defaults: &Self::Values,
+				) -> bool {
+					match field {
+						#(#field_dirty_arms)*
+					}
 				}
-			}
 
-			fn runtime_watch_field<T>(&self, field: Self::Field) -> ::core::option::Option<#pages_crate::reactive::Signal<T>>
-			where
-				T: ::core::clone::Clone + 'static,
+					#values_dirty_impl
+
+					#apply_pristine_values_impl
+
+					fn runtime_watch_field<T>(&self, field: Self::Field) -> ::core::option::Option<#pages_crate::reactive::Signal<T>>
+					where
+						T: ::core::clone::Clone + 'static,
 			{
-				match field {
-					#(#watch_field_arms)*
+					match field {
+						#(#watch_field_arms)*
+					}
 				}
-			}
 
-			fn runtime_validate(&self) -> ::core::result::Result<(), #pages_crate::FormValidationError<Self::Field>> {
-				let mut error = #pages_crate::FormValidationError::new();
-				#(#required_validation_checks)*
-				match self.validate() {
-					::core::result::Result::Ok(()) => {}
+				fn runtime_path_values_from_values(
+					&self,
+					values: &Self::Values,
+				) -> ::std::collections::HashMap<
+					::std::string::String,
+					::std::rc::Rc<dyn ::core::any::Any>,
+				> {
+					let mut path_values = ::std::collections::HashMap::new();
+					#(#path_values_from_values_blocks)*
+					path_values
+				}
+
+				fn runtime_path_exists(&self, path_key: &str) -> bool {
+					#(#path_exists_blocks)*
+					false
+				}
+
+				fn runtime_path_value_equals(
+					&self,
+					path_key: &str,
+					default: &dyn ::core::any::Any,
+				) -> ::core::option::Option<bool> {
+					#(#path_value_equals_blocks)*
+					::core::option::Option::None
+				}
+
+				fn runtime_validate(&self) -> ::core::result::Result<(), #pages_crate::FormValidationError<Self::Field>> {
+					let mut error = #pages_crate::FormValidationError::new();
+					#(#required_validation_checks)*
+					#(#collection_constraints_validation_checks)*
+					#(#collection_required_validation_checks)*
+					match self.validate() {
+						::core::result::Result::Ok(()) => {}
 					::core::result::Result::Err(errors) => {
 						for (field, message) in errors {
 							match field {
@@ -445,14 +1486,17 @@ fn generate_form_runtime_contract(
 					let _ = field;
 					::core::result::Result::Err(#pages_crate::FocusError::Unsupported)
 				}
+				}
 			}
-		}
 
-		let _ = #values_ident {
-			#(#initial_values_fields)*
-		};
+			#collection_runtime_impl
+
+			let _ = #values_ident {
+				#(#initial_values_fields)*
+			};
 		let _ = ::core::mem::size_of::<#values_ident>();
 		let _ = ::core::mem::size_of::<#field_ident>();
+		#collection_token_guard
 	}
 }
 
@@ -517,6 +1561,41 @@ fn runtime_required_empty_check(
 	}
 }
 
+fn runtime_collection_required_empty_check(
+	name: &syn::Ident,
+	field_type: &TypedFieldType,
+) -> Option<TokenStream> {
+	match field_type {
+		TypedFieldType::CharField
+		| TypedFieldType::TextField
+		| TypedFieldType::EmailField
+		| TypedFieldType::PasswordField
+		| TypedFieldType::UrlField
+		| TypedFieldType::SlugField => Some(quote! {
+			item_value.#name.trim().is_empty()
+		}),
+		TypedFieldType::DateField
+		| TypedFieldType::TimeField
+		| TypedFieldType::DateTimeField
+		| TypedFieldType::FileField
+		| TypedFieldType::ImageField
+		| TypedFieldType::UuidField
+		| TypedFieldType::IpAddressField => Some(quote! {
+			item_value.#name.is_none()
+		}),
+		TypedFieldType::MultipleChoiceField { .. } => Some(quote! {
+			item_value.#name.is_empty()
+		}),
+		TypedFieldType::IntegerField
+		| TypedFieldType::FloatField
+		| TypedFieldType::DecimalField
+		| TypedFieldType::BooleanField
+		| TypedFieldType::HiddenField { .. }
+		| TypedFieldType::ChoiceField { .. }
+		| TypedFieldType::JsonField { .. } => None,
+	}
+}
+
 fn supports_generated_form_values(field_type: &TypedFieldType) -> bool {
 	match field_type {
 		TypedFieldType::HiddenField { inner }
@@ -527,9 +1606,15 @@ fn supports_generated_form_values(field_type: &TypedFieldType) -> bool {
 }
 
 fn supports_form_runtime_contract(entries: &[TypedFormFieldEntry]) -> bool {
-	collect_all_fields(entries)
+	let scalar_supported = collect_scalar_fields(entries)
 		.iter()
-		.all(|field| supports_generated_form_values(&field.field_type))
+		.all(|field| supports_generated_form_values(&field.field_type));
+	let collection_items_supported = collect_collections(entries).iter().all(|collection| {
+		collect_scalar_fields(&collection.fields)
+			.iter()
+			.all(|field| supports_generated_form_values(&field.field_type))
+	});
+	scalar_supported && collection_items_supported
 }
 
 fn is_basic_form_value_type(ty: &syn::Type) -> bool {
@@ -577,25 +1662,32 @@ pub(super) fn generate(
 	} else {
 		quote! {}
 	};
-	let runtime_initial_values_field_default_init = if runtime_contract_supported {
-		let initial_fields: Vec<TokenStream> = collect_all_fields(&macro_ast.fields)
-			.iter()
-			.map(|field| {
-				let name = &field.name;
-				let init = field_type_default_value(&field.field_type);
-				quote! { #name: #init, }
-			})
-			.collect();
-		quote! {
-			__initial_values: ::std::rc::Rc::new(
-				::std::cell::RefCell::new(#values_ident {
-					#(#initial_fields)*
-				}),
-			),
-		}
-	} else {
-		quote! {}
-	};
+	let runtime_initial_values_field_default_init =
+		if runtime_contract_supported {
+			let mut initial_fields: Vec<TokenStream> = collect_scalar_fields(&macro_ast.fields)
+				.iter()
+				.map(|field| {
+					let name = &field.name;
+					let init = field_type_default_value(&field.field_type);
+					quote! { #name: #init, }
+				})
+				.collect();
+			initial_fields.extend(collect_collections(&macro_ast.fields).iter().map(
+				|collection| {
+					let name = &collection.name;
+					quote! { #name: ::std::vec::Vec::new(), }
+				},
+			));
+			quote! {
+				__initial_values: ::std::rc::Rc::new(
+					::std::cell::RefCell::new(#values_ident {
+						#(#initial_fields)*
+					}),
+				),
+			}
+		} else {
+			quote! {}
+		};
 	let runtime_initial_values_outer_refresh = if runtime_contract_supported {
 		quote! {
 			*__reinhardt_form.__initial_values.borrow_mut() =
@@ -731,7 +1823,10 @@ pub(super) fn generate(
 	// TokenStream, so the macro output is unchanged for such forms. See
 	// `build_typed_field_where_clause` below for the bound list and the
 	// rationale (issue #4397, Task 9).
-	let all_fields_for_bounds = collect_all_fields(&macro_ast.fields);
+	let mut all_fields_for_bounds = collect_scalar_fields(&macro_ast.fields);
+	for collection in collect_collections(&macro_ast.fields) {
+		all_fields_for_bounds.extend(collect_scalar_fields(&collection.fields));
+	}
 	let where_clause = build_typed_field_where_clause(&all_fields_for_bounds);
 
 	quote! {
@@ -809,7 +1904,8 @@ fn generate_field_declarations(
 	entries: &[TypedFormFieldEntry],
 	pages_crate: &TokenStream,
 ) -> TokenStream {
-	let fields = collect_all_fields(entries);
+	let fields = collect_scalar_fields(entries);
+	let collections = collect_collections(entries);
 	let mut decls: Vec<TokenStream> = fields
 		.iter()
 		.map(|field| {
@@ -820,6 +1916,26 @@ fn generate_field_declarations(
 			}
 		})
 		.collect();
+
+	decls.extend(collections.iter().map(|collection| {
+		let name = &collection.name;
+		let item_ident = collection_item_values_ident(&collection.name);
+		quote! {
+			#name: #pages_crate::reactive::Signal<::std::vec::Vec<#pages_crate::CollectionItem<#item_ident>>>,
+		}
+	}));
+	if !collections.is_empty() {
+		decls.push(quote! {
+			__path_signals: ::std::rc::Rc<
+				::std::cell::RefCell<
+					::std::collections::HashMap<
+						::std::string::String,
+						::std::boxed::Box<dyn ::core::any::Any>,
+					>,
+				>,
+			>,
+		});
+	}
 
 	// Add choices signal fields for dynamic choice fields
 	let choices_decls: Vec<TokenStream> = fields
@@ -847,7 +1963,8 @@ fn generate_field_initializers(
 	entries: &[TypedFormFieldEntry],
 	pages_crate: &TokenStream,
 ) -> TokenStream {
-	let fields = collect_all_fields(entries);
+	let fields = collect_scalar_fields(entries);
+	let collections = collect_collections(entries);
 	// `new()` is a `fn` item, so any `initial: <expr>` referencing enclosing-scope
 	// locals fails to compile with `E0434: can't capture dynamic environment in
 	// a fn item` (issue #4420). To preserve closure-like capture semantics for
@@ -865,6 +1982,20 @@ fn generate_field_initializers(
 			}
 		})
 		.collect();
+
+	inits.extend(collections.iter().map(|collection| {
+		let name = &collection.name;
+		quote! {
+			#name: #pages_crate::reactive::Signal::new(::std::vec::Vec::new()),
+		}
+	}));
+	if !collections.is_empty() {
+		inits.push(quote! {
+			__path_signals: ::std::rc::Rc::new(
+				::std::cell::RefCell::new(::std::collections::HashMap::new()),
+			),
+		});
+	}
 
 	// Add choices signal initializers for dynamic choice fields
 	let choices_inits: Vec<TokenStream> = fields
@@ -900,7 +2031,7 @@ fn generate_initial_outer_setup(
 	entries: &[TypedFormFieldEntry],
 	pages_crate: &TokenStream,
 ) -> TokenStream {
-	let fields = collect_all_fields(entries);
+	let fields = collect_scalar_fields(entries);
 	let assigns: Vec<TokenStream> = fields
 		.iter()
 		.filter_map(|field| {
@@ -921,7 +2052,8 @@ fn generate_field_accessors(
 	entries: &[TypedFormFieldEntry],
 	pages_crate: &TokenStream,
 ) -> TokenStream {
-	let fields = collect_all_fields(entries);
+	let fields = collect_scalar_fields(entries);
+	let collections = collect_collections(entries);
 	let mut accessors: Vec<TokenStream> = fields
 		.iter()
 		.map(|field| {
@@ -934,6 +2066,22 @@ fn generate_field_accessors(
 			}
 		})
 		.collect();
+
+	for collection in collections {
+		let name = &collection.name;
+		let item_ident = collection_item_values_ident(&collection.name);
+		let new_item_method = format_ident!("new_{}_item", name);
+		accessors.push(quote! {
+				pub fn #name(&self) -> &#pages_crate::reactive::Signal<::std::vec::Vec<#pages_crate::CollectionItem<#item_ident>>> {
+					&self.#name
+				}
+			});
+		accessors.push(quote! {
+			pub fn #new_item_method(&self) -> #item_ident {
+				#item_ident::default()
+			}
+		});
+	}
 
 	// Add choices accessors for dynamic choice fields
 	let choices_accessors: Vec<TokenStream> = fields
@@ -1287,7 +2435,7 @@ fn generate_on_success_ref_artifacts(
 			// Replicate `generate_submit_method`'s argument count
 			// computation (codegen.rs ~L1698-1725) so that the dead-code
 			// call below matches whatever signature the runtime call uses.
-			let all_fields = collect_all_fields(&macro_ast.fields);
+			let all_fields = collect_scalar_fields(&macro_ast.fields);
 			let field_count = all_fields.len();
 			let strip_arg_count = macro_ast.strip_arguments.len();
 			let extra_count = strip_arg_count;
@@ -1550,7 +2698,7 @@ fn generate_metadata_function(
 		.unwrap_or("reinhardt-form");
 
 	// Collect all fields (including those in groups) for metadata
-	let all_fields = collect_all_fields(&macro_ast.fields);
+	let all_fields = collect_scalar_fields(&macro_ast.fields);
 	let field_metadata: Vec<TokenStream> = all_fields
 		.iter()
 		.map(|field| {
@@ -1599,7 +2747,7 @@ fn generate_metadata_function(
 /// Generates the into_view implementation.
 fn generate_into_page(macro_ast: &TypedFormMacro, pages_crate: &TokenStream) -> TokenStream {
 	// Collect all fields for signal bindings
-	let all_fields = collect_all_fields(&macro_ast.fields);
+	let all_fields = collect_scalar_fields(&macro_ast.fields);
 
 	// Generate signal bindings for fields with bind: true
 	let signal_bindings: Vec<TokenStream> = all_fields
@@ -1653,7 +2801,7 @@ fn generate_onsubmit_handler(macro_ast: &TypedFormMacro, pages_crate: &TokenStre
 		.unwrap_or("reinhardt-form");
 
 	// Collect all fields for use in onsubmit handler
-	let all_fields = collect_all_fields(&macro_ast.fields);
+	let all_fields = collect_scalar_fields(&macro_ast.fields);
 
 	// Generate before_fields slot if present
 	let before_fields_slot = generate_before_fields_slot(&macro_ast.slots);
@@ -2038,6 +3186,9 @@ fn generate_field_entry_view(
 		TypedFormFieldEntry::Group(group) => {
 			generate_field_group_view(group, pages_crate, all_fields)
 		}
+		TypedFormFieldEntry::Collection(collection) => {
+			generate_collection_view(collection, pages_crate)
+		}
 		TypedFormFieldEntry::SubmitButton(btn) => generate_submit_button_view(btn),
 	}
 }
@@ -2109,10 +3260,461 @@ fn generate_field_group_view(
 	};
 
 	quote! {
-		PageElement::new("fieldset")
-			.attr("class", #group_class)
-			#label_element
+	PageElement::new("fieldset")
+		.attr("class", #group_class)
+		#label_element
 			#(.child(#field_views))*
+	}
+}
+
+fn generate_collection_view(
+	collection: &TypedFormFieldCollection,
+	pages_crate: &TokenStream,
+) -> TokenStream {
+	let collection_name = &collection.name;
+	let collection_name_str = collection.name.to_string();
+	let collection_class = collection
+		.class
+		.as_deref()
+		.unwrap_or("reinhardt-field-array");
+	let item_fields = collect_scalar_fields(&collection.fields);
+	let item_field_views: Vec<TokenStream> = item_fields
+		.iter()
+		.map(|field| generate_collection_field_view(field, pages_crate, &collection_name_str))
+		.collect();
+	let legend = collection.label.as_deref().unwrap_or(&collection_name_str);
+	let min_items_attr = collection.min_items.map(|min| {
+		let value = min.to_string();
+		quote! { .attr("data-reinhardt-min-items", #value) }
+	});
+	let max_items_attr = collection.max_items.map(|max| {
+		let value = max.to_string();
+		quote! { .attr("data-reinhardt-max-items", #value) }
+	});
+
+	quote! {
+		{
+			let __collection_signal = self.#collection_name.clone();
+			#pages_crate::component::Page::reactive(move || {
+				let __items = __collection_signal.get();
+				let mut __item_pages = ::std::vec::Vec::new();
+				for item in __items {
+					let item_value = item.value().clone();
+					let __item_key = ::std::format!("{:?}", item.key());
+					__item_pages.push((
+						__item_key.clone(),
+						PageElement::new("div")
+							.attr("class", "reinhardt-field-array-item")
+							.attr("data-reinhardt-field-array-item", #collection_name_str)
+							.attr("data-reinhardt-item-index", item.index().to_string())
+							.attr("data-reinhardt-item-key", __item_key)
+							#(.child(#item_field_views))*
+							.into_page(),
+					));
+				}
+
+				PageElement::new("fieldset")
+					.attr("class", #collection_class)
+					.attr("data-reinhardt-field-array", #collection_name_str)
+					#min_items_attr
+					#max_items_attr
+					.child(
+						PageElement::new("legend")
+							.attr("class", "reinhardt-field-array-label")
+							.child(#legend)
+					)
+					.child(#pages_crate::component::Page::keyed_fragment(__item_pages))
+					.into_page()
+			})
+		}
+	}
+}
+
+fn generate_collection_field_view(
+	field: &TypedFormFieldDef,
+	pages_crate: &TokenStream,
+	collection_name: &str,
+) -> TokenStream {
+	let field_name_str = field.name.to_string();
+	let input_type = widget_to_input_type(&field.widget);
+	let label_text = field.display.label.as_deref().unwrap_or(&field_name_str);
+	let placeholder = field.display.placeholder.as_deref().unwrap_or("");
+	let required = field.validation.required;
+	let autocomplete_attr = field.display.autocomplete.as_deref().map(|val| {
+		quote! { .attr("autocomplete", #val) }
+	});
+	let wrapper_class = field.styling.wrapper_class();
+	let label_class = field.styling.label_class();
+	let input_class = field.styling.input_class();
+	let custom_attrs = generate_custom_attrs(&field.custom_attrs);
+	let listener = generate_collection_bind_listener(field, pages_crate);
+	let field_value = collection_field_value_expr(field);
+	let value_attr = if matches!(
+		field.field_type,
+		TypedFieldType::FileField | TypedFieldType::ImageField
+	) {
+		quote! {}
+	} else {
+		quote! { .attr("value", #field_value) }
+	};
+	let checked_attr = if matches!(field.widget, TypedWidget::CheckboxInput) {
+		let checked = collection_field_checked_expr(field);
+		quote! { .bool_attr("checked", #checked) }
+	} else {
+		quote! {}
+	};
+
+	let input_element = match &field.widget {
+		TypedWidget::Textarea => {
+			quote! {
+				PageElement::new("textarea")
+					.attr("name", __field_name.clone())
+					.attr("id", __field_id.clone())
+					.attr("class", #input_class)
+					.attr("placeholder", #placeholder)
+					.bool_attr("required", #required)
+					#autocomplete_attr
+					#custom_attrs
+					#listener
+					.child(#field_value)
+			}
+		}
+		TypedWidget::Select | TypedWidget::SelectMultiple => {
+			let multiple = matches!(field.widget, TypedWidget::SelectMultiple);
+			quote! {
+				PageElement::new("select")
+					.attr("name", __field_name.clone())
+					.attr("id", __field_id.clone())
+					.attr("class", #input_class)
+					.bool_attr("required", #required)
+					.bool_attr("multiple", #multiple)
+					#autocomplete_attr
+					#custom_attrs
+					#listener
+			}
+		}
+		TypedWidget::CheckboxInput => {
+			quote! {
+				PageElement::new("input")
+					.attr("type", "checkbox")
+					.attr("name", __field_name.clone())
+					.attr("id", __field_id.clone())
+					.attr("class", #input_class)
+					.attr("value", "true")
+					.bool_attr("required", #required)
+					#checked_attr
+					#custom_attrs
+					#listener
+			}
+		}
+		_ => {
+			quote! {
+				PageElement::new("input")
+					.attr("type", #input_type)
+					.attr("name", __field_name.clone())
+					.attr("id", __field_id.clone())
+					.attr("class", #input_class)
+					.attr("placeholder", #placeholder)
+					.bool_attr("required", #required)
+					#value_attr
+					#autocomplete_attr
+					#custom_attrs
+					#listener
+			}
+		}
+	};
+
+	let label_element = if matches!(field.widget, TypedWidget::HiddenInput) {
+		quote! {}
+	} else {
+		quote! {
+			.child(
+				PageElement::new("label")
+					.attr("for", __field_id.clone())
+					.attr("class", #label_class)
+					.child(#label_text)
+			)
+		}
+	};
+
+	if matches!(field.widget, TypedWidget::HiddenInput) {
+		quote! {
+			{
+				let __field_name = ::std::format!(
+					"{}[{}][{}]",
+					#collection_name,
+					item.index(),
+					#field_name_str,
+				);
+				let __field_id = ::std::format!(
+					"{}_{}_{}",
+					#collection_name,
+					item.index(),
+					#field_name_str,
+				);
+				#input_element
+			}
+		}
+	} else {
+		let wrapper_attrs = generate_wrapper_attrs(&field.wrapper, wrapper_class);
+		let wrapper_tag = field
+			.wrapper
+			.as_ref()
+			.map(|w| w.tag.as_str())
+			.unwrap_or("div");
+		quote! {
+			{
+				let __field_name = ::std::format!(
+					"{}[{}][{}]",
+					#collection_name,
+					item.index(),
+					#field_name_str,
+				);
+				let __field_id = ::std::format!(
+					"{}_{}_{}",
+					#collection_name,
+					item.index(),
+					#field_name_str,
+				);
+				PageElement::new(#wrapper_tag)
+					#wrapper_attrs
+					#label_element
+					.child(#input_element)
+			}
+		}
+	}
+}
+
+fn collection_field_value_expr(field: &TypedFormFieldDef) -> TokenStream {
+	let field_name = &field.name;
+	match &field.field_type {
+		TypedFieldType::CharField
+		| TypedFieldType::TextField
+		| TypedFieldType::EmailField
+		| TypedFieldType::PasswordField
+		| TypedFieldType::UrlField
+		| TypedFieldType::SlugField => quote! { item_value.#field_name.clone() },
+		TypedFieldType::DateField
+		| TypedFieldType::TimeField
+		| TypedFieldType::DateTimeField
+		| TypedFieldType::UuidField
+		| TypedFieldType::IpAddressField => quote! {
+			item_value
+				.#field_name
+				.as_ref()
+				.map(::std::string::ToString::to_string)
+				.unwrap_or_default()
+		},
+		TypedFieldType::MultipleChoiceField { .. } => quote! {
+			item_value
+				.#field_name
+				.iter()
+				.map(::std::string::ToString::to_string)
+				.collect::<::std::vec::Vec<_>>()
+				.join(",")
+		},
+		TypedFieldType::JsonField { .. } => quote! {
+			::serde_json::to_string(&item_value.#field_name).unwrap_or_default()
+		},
+		TypedFieldType::FileField | TypedFieldType::ImageField => {
+			quote! { ::std::string::String::new() }
+		}
+		TypedFieldType::IntegerField
+		| TypedFieldType::FloatField
+		| TypedFieldType::DecimalField
+		| TypedFieldType::BooleanField
+		| TypedFieldType::HiddenField { .. }
+		| TypedFieldType::ChoiceField { .. } => {
+			quote! { item_value.#field_name.to_string() }
+		}
+	}
+}
+
+fn collection_field_checked_expr(field: &TypedFormFieldDef) -> TokenStream {
+	let field_name = &field.name;
+	match &field.field_type {
+		TypedFieldType::BooleanField => quote! { item_value.#field_name },
+		_ => quote! { false },
+	}
+}
+
+fn generate_collection_bind_listener(
+	field: &TypedFormFieldDef,
+	pages_crate: &TokenStream,
+) -> TokenStream {
+	let field_name = &field.name;
+	let event_name = match field.widget {
+		TypedWidget::Textarea => "input",
+		TypedWidget::Select | TypedWidget::SelectMultiple => "change",
+		TypedWidget::CheckboxInput | TypedWidget::RadioSelect => "change",
+		_ => "input",
+	};
+	let element_type = match field.widget {
+		TypedWidget::Textarea => quote! { HtmlTextAreaElement },
+		TypedWidget::Select | TypedWidget::SelectMultiple => quote! { HtmlSelectElement },
+		_ => quote! { HtmlInputElement },
+	};
+	let element_var = match field.widget {
+		TypedWidget::Textarea => quote::format_ident!("textarea"),
+		TypedWidget::Select | TypedWidget::SelectMultiple => quote::format_ident!("select"),
+		_ => quote::format_ident!("input"),
+	};
+	let assignment = quote! {
+		let mut __items = __field_collection_signal.get();
+		if let ::core::option::Option::Some(__position) =
+			__items.iter().position(|entry| entry.key() == __item_key)
+		{
+			let __item_index = __items[__position].index();
+			let mut __item_value = __items[__position].value().clone();
+			__item_value.#field_name = __new_value;
+			__items[__position] = #pages_crate::CollectionItem::new(
+				__item_key,
+				__item_index,
+				__item_value,
+			);
+			__field_collection_signal.set(__items);
+		}
+	};
+	let wasm_update =
+		collection_field_wasm_update(&field.field_type, &field.widget, &element_var, assignment);
+
+	quote! {
+		.listener(#event_name, {
+			let __field_collection_signal = __collection_signal.clone();
+			let __item_key = item.key();
+			move |event| {
+				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+				{
+					use wasm_bindgen::JsCast;
+					if let ::core::option::Option::Some(target) = event.target() {
+						if let ::core::result::Result::Ok(#element_var) =
+							target.dyn_into::<web_sys::#element_type>()
+						{
+							#wasm_update
+						}
+					}
+				}
+				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+				{
+					let _ = event;
+					let _ = &__field_collection_signal;
+					let _ = __item_key;
+				}
+			}
+		})
+	}
+}
+
+fn collection_field_wasm_update(
+	field_type: &TypedFieldType,
+	widget: &TypedWidget,
+	element_var: &syn::Ident,
+	assignment: TokenStream,
+) -> TokenStream {
+	match field_type {
+		TypedFieldType::CharField
+		| TypedFieldType::TextField
+		| TypedFieldType::EmailField
+		| TypedFieldType::PasswordField
+		| TypedFieldType::UrlField
+		| TypedFieldType::SlugField => quote! {
+			let __new_value = #element_var.value();
+			#assignment
+		},
+		TypedFieldType::BooleanField if matches!(widget, TypedWidget::CheckboxInput) => quote! {
+			let __new_value = #element_var.checked();
+			#assignment
+		},
+		TypedFieldType::BooleanField => quote! {
+			if let ::core::result::Result::Ok(__new_value) =
+				#element_var.value().parse::<bool>()
+			{
+				#assignment
+			}
+		},
+		TypedFieldType::IntegerField => quote! {
+			if let ::core::result::Result::Ok(__new_value) =
+				#element_var.value().parse::<i64>()
+			{
+				#assignment
+			}
+		},
+		TypedFieldType::FloatField | TypedFieldType::DecimalField => quote! {
+			if let ::core::result::Result::Ok(__new_value) =
+				#element_var.value().parse::<f64>()
+			{
+				#assignment
+			}
+		},
+		TypedFieldType::DateField => {
+			collection_option_parse_update(element_var, quote! { chrono::NaiveDate }, assignment)
+		}
+		TypedFieldType::TimeField => {
+			collection_option_parse_update(element_var, quote! { chrono::NaiveTime }, assignment)
+		}
+		TypedFieldType::DateTimeField => collection_option_parse_update(
+			element_var,
+			quote! { chrono::NaiveDateTime },
+			assignment,
+		),
+		TypedFieldType::UuidField => {
+			collection_option_parse_update(element_var, quote! { uuid::Uuid }, assignment)
+		}
+		TypedFieldType::IpAddressField => {
+			collection_option_parse_update(element_var, quote! { ::std::net::IpAddr }, assignment)
+		}
+		TypedFieldType::HiddenField { inner } | TypedFieldType::ChoiceField { inner } => quote! {
+			if let ::core::result::Result::Ok(__new_value) =
+				#element_var.value().parse::<#inner>()
+			{
+				#assignment
+			}
+		},
+		TypedFieldType::JsonField { inner } => quote! {
+			if let ::core::result::Result::Ok(__new_value) =
+				::serde_json::from_str::<#inner>(&#element_var.value())
+			{
+				#assignment
+			}
+		},
+		TypedFieldType::MultipleChoiceField { inner } => quote! {
+			let __options = #element_var.selected_options();
+			let mut __new_value = ::std::vec::Vec::new();
+			for __i in 0..__options.length() {
+				if let ::core::option::Option::Some(__option) = __options.item(__i) {
+					if let ::core::result::Result::Ok(__option_el) =
+						__option.dyn_into::<web_sys::HtmlOptionElement>()
+					{
+						if let ::core::result::Result::Ok(__parsed) =
+							__option_el.value().parse::<#inner>()
+						{
+							__new_value.push(__parsed);
+						}
+					}
+				}
+			}
+			#assignment
+		},
+		TypedFieldType::FileField | TypedFieldType::ImageField => quote! {},
+	}
+}
+
+fn collection_option_parse_update(
+	element_var: &syn::Ident,
+	value_type: TokenStream,
+	assignment: TokenStream,
+) -> TokenStream {
+	quote! {
+		let __raw = #element_var.value();
+		if __raw.is_empty() {
+			let __new_value = ::core::option::Option::None;
+			#assignment
+		} else if let ::core::result::Result::Ok(__parsed) =
+			__raw.parse::<#value_type>()
+		{
+			let __new_value = ::core::option::Option::Some(__parsed);
+			#assignment
+		}
 	}
 }
 
@@ -2796,7 +4398,7 @@ fn generate_submit_method(
 	match &macro_ast.action {
 		TypedFormAction::ServerFn(server_fn_ident) => {
 			// Generate submit that calls the server_fn with callbacks
-			let all_fields = collect_all_fields(&macro_ast.fields);
+			let all_fields = collect_scalar_fields(&macro_ast.fields);
 			let field_names: Vec<&syn::Ident> = all_fields.iter().map(|f| &f.name).collect();
 
 			let strip_arg_exprs: Vec<&syn::Expr> = macro_ast
@@ -2994,7 +4596,7 @@ fn generate_load_initial_values(
 	};
 
 	// Collect fields that have initial_from specified (including from groups)
-	let all_fields = collect_all_fields(&macro_ast.fields);
+	let all_fields = collect_scalar_fields(&macro_ast.fields);
 	let field_setters: Vec<TokenStream> = all_fields
 		.iter()
 		.filter_map(|field| {
@@ -3104,7 +4706,7 @@ fn generate_load_choices(macro_ast: &TypedFormMacro, pages_crate: &TokenStream) 
 	};
 
 	// Collect fields that have choices_config specified (including from groups)
-	let all_fields = collect_all_fields(&macro_ast.fields);
+	let all_fields = collect_scalar_fields(&macro_ast.fields);
 	let field_setters: Vec<TokenStream> = all_fields
 		.iter()
 		.filter_map(|field| {

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -79,7 +79,7 @@ fn collect_collections(entries: &[TypedFormFieldEntry]) -> Vec<&TypedFormFieldCo
 	entries
 		.iter()
 		.filter_map(|entry| match entry {
-			TypedFormFieldEntry::Collection(collection) => Some(collection),
+			TypedFormFieldEntry::Collection(collection) => Some(collection.as_ref()),
 			_ => None,
 		})
 		.collect()
@@ -426,6 +426,8 @@ fn generate_form_runtime_contract(
 		.zip(collection_variants.iter())
 		.zip(collection_field_idents.iter())
 		.flat_map(|((collection, collection_variant), field_ident)| {
+			let collection_variant = collection_variant.clone();
+			let field_ident = field_ident.clone();
 			let field_path_ident = field_path_ident.clone();
 			collect_scalar_fields(&collection.fields)
 				.into_iter()
@@ -876,6 +878,8 @@ fn generate_form_runtime_contract(
 			.zip(collection_variants.iter())
 			.zip(collection_field_idents.iter())
 			.flat_map(|((collection, collection_variant), field_ident)| {
+				let collection_variant = collection_variant.clone();
+				let field_ident = field_ident.clone();
 				let collection_name = collection.name.to_string();
 				let field_path_ident = field_path_ident.clone();
 				collect_scalar_fields(&collection.fields)
@@ -917,6 +921,8 @@ fn generate_form_runtime_contract(
 			.zip(collection_variants.iter())
 			.zip(collection_field_idents.iter())
 			.flat_map(|((collection, collection_variant), field_ident)| {
+				let collection_variant = collection_variant.clone();
+				let field_ident = field_ident.clone();
 				let collection_name = &collection.name;
 				let field_path_ident = field_path_ident.clone();
 				collect_scalar_fields(&collection.fields)
@@ -990,6 +996,8 @@ fn generate_form_runtime_contract(
 			.zip(collection_variants.iter())
 			.zip(collection_field_idents.iter())
 			.flat_map(|((collection, collection_variant), field_ident)| {
+				let collection_variant = collection_variant.clone();
+				let field_ident = field_ident.clone();
 				let collection_name = &collection.name;
 				let field_path_ident = field_path_ident.clone();
 				collect_scalar_fields(&collection.fields)
@@ -1059,6 +1067,8 @@ fn generate_form_runtime_contract(
 			.zip(collection_variants.iter())
 			.zip(collection_field_idents.iter())
 			.flat_map(|((collection, collection_variant), field_ident)| {
+				let collection_variant = collection_variant.clone();
+				let field_ident = field_ident.clone();
 				let collection_name = &collection.name;
 				let field_path_ident = field_path_ident.clone();
 				collect_scalar_fields(&collection.fields)

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -731,6 +731,65 @@ fn generate_form_runtime_contract(
 			}
 		})
 		.collect();
+	let path_signal_sync_blocks: Vec<TokenStream> = collections
+		.iter()
+		.map(|collection| {
+			let collection_name = &collection.name;
+			let collection_name_text = collection.name.to_string();
+			let signal_updates: Vec<TokenStream> = collect_scalar_fields(&collection.fields)
+				.iter()
+				.map(|field| {
+					let field_name = &field.name;
+					let field_name_text = field.name.to_string();
+					let field_type = field_type_to_value_type(&field.field_type);
+					quote! {
+						{
+							let path_key = ::std::format!(
+								"{}:{:?}:{}",
+								#collection_name_text,
+								item.key(),
+								#field_name_text,
+							);
+							let path_signal = self
+								.__path_signals
+								.borrow()
+								.get(&path_key)
+								.and_then(|signal| {
+									signal
+										.downcast_ref::<#pages_crate::reactive::Signal<#field_type>>()
+										.cloned()
+								});
+							if let ::core::option::Option::Some(path_signal) = path_signal {
+								path_signal.set(item_value.#field_name.clone());
+							}
+						}
+					}
+				})
+				.collect();
+			quote! {
+				for item in self.#collection_name.get() {
+					let item_value = item.value();
+					#(#signal_updates)*
+				}
+			}
+		})
+		.collect();
+	let changed_collection_key_checks: Vec<TokenStream> = collections
+		.iter()
+		.zip(collection_variants.iter())
+		.map(|(collection, variant)| {
+			let collection_name = &collection.name;
+			quote! {
+				if current.#collection_name != previous.#collection_name {
+					keys.push(
+						<Self as #pages_crate::form_state::FormCollectionRuntimeSource>::runtime_collection_key(
+							#collection_ident::#variant,
+						),
+					);
+				}
+			}
+		})
+		.collect();
 	let collection_runtime_impl = if collections.is_empty() {
 		quote! {}
 	} else {
@@ -1451,16 +1510,30 @@ fn generate_form_runtime_contract(
 					false
 				}
 
-				fn runtime_path_value_equals(
-					&self,
-					path_key: &str,
-					default: &dyn ::core::any::Any,
-				) -> ::core::option::Option<bool> {
-					#(#path_value_equals_blocks)*
-					::core::option::Option::None
-				}
+					fn runtime_path_value_equals(
+						&self,
+						path_key: &str,
+						default: &dyn ::core::any::Any,
+					) -> ::core::option::Option<bool> {
+						#(#path_value_equals_blocks)*
+						::core::option::Option::None
+					}
 
-				fn runtime_validate(&self) -> ::core::result::Result<(), #pages_crate::FormValidationError<Self::Field>> {
+					fn runtime_sync_path_signals(&self) {
+						#(#path_signal_sync_blocks)*
+					}
+
+					fn runtime_changed_collection_keys(
+						&self,
+						current: &Self::Values,
+						previous: &Self::Values,
+					) -> ::std::vec::Vec<::std::string::String> {
+						let mut keys = ::std::vec::Vec::new();
+						#(#changed_collection_key_checks)*
+						keys
+					}
+
+					fn runtime_validate(&self) -> ::core::result::Result<(), #pages_crate::FormValidationError<Self::Field>> {
 					let mut error = #pages_crate::FormValidationError::new();
 					#(#required_validation_checks)*
 					#(#collection_constraints_validation_checks)*

--- a/crates/reinhardt-pages/macros/src/form/validator.rs
+++ b/crates/reinhardt-pages/macros/src/form/validator.rs
@@ -551,7 +551,7 @@ fn transform_field_entry(entry: &FormFieldEntry) -> Result<TypedFormFieldEntry> 
 		}
 		FormFieldEntry::Collection(collection) => {
 			let typed_collection = transform_collection(collection)?;
-			Ok(TypedFormFieldEntry::Collection(typed_collection))
+			Ok(TypedFormFieldEntry::Collection(Box::new(typed_collection)))
 		}
 		FormFieldEntry::SubmitButton(btn) => {
 			let typed_btn = transform_submit_button(btn)?;

--- a/crates/reinhardt-pages/macros/src/form/validator.rs
+++ b/crates/reinhardt-pages/macros/src/form/validator.rs
@@ -187,6 +187,15 @@ pub(super) fn validate(
 	let strip_arguments =
 		transform_strip_arguments(&ast.strip_arguments, &ast.fields, ambient_arguments_source)?;
 
+	if let TypedFormAction::ServerFn(_) = &action
+		&& let Some(collection) = first_field_array_entry(&ast.fields)
+	{
+		return Err(Error::new(
+			collection.span,
+			"FieldArray is not supported with server_fn forms by reinhardt-pages macro codegen yet",
+		));
+	}
+
 	// The parser guarantees that `name` is Some after successful parsing.
 	let name = ast
 		.name
@@ -210,6 +219,13 @@ pub(super) fn validate(
 	typed.strip_arguments = strip_arguments;
 
 	Ok(typed)
+}
+
+fn first_field_array_entry(entries: &[FormFieldEntry]) -> Option<&FormFieldCollection> {
+	entries.iter().find_map(|entry| match entry {
+		FormFieldEntry::Collection(collection) => Some(collection.as_ref()),
+		_ => None,
+	})
 }
 
 /// Validates that all field names are unique.
@@ -4286,6 +4302,28 @@ mod tests {
 		assert_eq!(
 			err.to_string(),
 			"strip_arguments key 'line_items' collides with a declared form field; either rename the field or remove this strip entry; use ambient_arguments for new code"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_server_fn_rejects_field_array() {
+		let input = quote! {
+			name: InvoiceForm,
+			server_fn: submit_invoice,
+			fields: {
+				customer_name: CharField {},
+				line_items: FieldArray {
+					fields: {
+						description: CharField {},
+					},
+				},
+			},
+		};
+
+		let err = parse_and_validate(input).expect_err("server_fn FieldArray must fail");
+		assert_eq!(
+			err.to_string(),
+			"FieldArray is not supported with server_fn forms by reinhardt-pages macro codegen yet"
 		);
 	}
 

--- a/crates/reinhardt-pages/macros/src/form/validator.rs
+++ b/crates/reinhardt-pages/macros/src/form/validator.rs
@@ -17,14 +17,15 @@ use std::collections::HashSet;
 use syn::{Error, Result};
 
 use reinhardt_manouche::core::{
-	AmbientArgumentsSource, FormAction, FormCallbacks, FormDerived, FormFieldDef, FormFieldEntry,
-	FormFieldGroup, FormFieldProperty, FormMacro, FormMethod, FormSlots, FormState,
-	FormSubmitButtonDef, FormValidator, FormWatch, IconPosition, StripArgument, TypedChoicesConfig,
-	TypedCustomAttr, TypedDerivedItem, TypedFieldDisplay, TypedFieldStyling, TypedFieldType,
-	TypedFieldValidation, TypedFormAction, TypedFormCallbacks, TypedFormDerived, TypedFormFieldDef,
-	TypedFormFieldEntry, TypedFormFieldGroup, TypedFormMacro, TypedFormSlots, TypedFormState,
-	TypedFormStyling, TypedFormValidator, TypedFormWatch, TypedFormWatchItem, TypedIcon,
-	TypedIconAttr, TypedIconChild, TypedIconPosition, TypedStripArgument, TypedSubmitButtonDef,
+	AmbientArgumentsSource, FormAction, FormCallbacks, FormDerived, FormFieldCollection,
+	FormFieldDef, FormFieldEntry, FormFieldGroup, FormFieldProperty, FormMacro, FormMethod,
+	FormSlots, FormState, FormSubmitButtonDef, FormValidator, FormWatch, IconPosition,
+	StripArgument, TypedChoicesConfig, TypedCustomAttr, TypedDerivedItem, TypedFieldDisplay,
+	TypedFieldStyling, TypedFieldType, TypedFieldValidation, TypedFormAction, TypedFormCallbacks,
+	TypedFormDerived, TypedFormFieldCollection, TypedFormFieldDef, TypedFormFieldEntry,
+	TypedFormFieldGroup, TypedFormMacro, TypedFormSlots, TypedFormState, TypedFormStyling,
+	TypedFormValidator, TypedFormWatch, TypedFormWatchItem, TypedIcon, TypedIconAttr,
+	TypedIconChild, TypedIconPosition, TypedStripArgument, TypedSubmitButtonDef,
 	TypedValidatorRule, TypedWidget, TypedWrapper, TypedWrapperAttr, ValidatorRule,
 };
 
@@ -250,12 +251,95 @@ fn validate_unique_field_names(entries: &[FormFieldEntry]) -> Result<()> {
 					}
 				}
 			}
+			FormFieldEntry::Collection(collection) => {
+				let name = collection.name.to_string();
+				if !seen.insert(name.clone()) {
+					return Err(Error::new(
+						collection.name.span(),
+						format!("duplicate field/collection name: '{}'", name),
+					));
+				}
+				validate_unique_collection_field_names(collection)?;
+			}
 			FormFieldEntry::SubmitButton(btn) => {
 				let name = btn.name.to_string();
 				if !seen.insert(name.clone()) {
 					return Err(Error::new(
 						btn.name.span(),
 						format!("duplicate field/button name: '{}'", name),
+					));
+				}
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_unique_collection_field_names(collection: &FormFieldCollection) -> Result<()> {
+	let mut seen = HashSet::new();
+
+	for entry in &collection.fields {
+		match entry {
+			FormFieldEntry::Field(field) => {
+				let name = field.name.to_string();
+				if !seen.insert(name.clone()) {
+					return Err(Error::new(
+						field.name.span(),
+						format!(
+							"duplicate field name: '{}' (in collection '{}')",
+							name, collection.name
+						),
+					));
+				}
+			}
+			FormFieldEntry::Group(group) => {
+				let group_name = group.name.to_string();
+				if !seen.insert(group_name.clone()) {
+					return Err(Error::new(
+						group.name.span(),
+						format!(
+							"duplicate field/group name: '{}' (in collection '{}')",
+							group_name, collection.name
+						),
+					));
+				}
+
+				for field in &group.fields {
+					let name = field.name.to_string();
+					if !seen.insert(name.clone()) {
+						return Err(Error::new(
+							field.name.span(),
+							format!(
+								"duplicate field name: '{}' (in group '{}')",
+								name, group_name
+							),
+						));
+					}
+				}
+			}
+			FormFieldEntry::Collection(nested) => {
+				let name = nested.name.to_string();
+				if !seen.insert(name.clone()) {
+					return Err(Error::new(
+						nested.name.span(),
+						format!(
+							"duplicate field/collection name: '{}' (in collection '{}')",
+							name, collection.name
+						),
+					));
+				}
+				validate_unique_collection_field_names(nested)?;
+			}
+			FormFieldEntry::SubmitButton(btn) => {
+				let name = btn.name.to_string();
+				if !seen.insert(name.clone()) {
+					return Err(Error::new(
+						btn.name.span(),
+						format!(
+							"duplicate field/button name: '{}' (in collection '{}')",
+							name, collection.name
+						),
 					));
 				}
 			}
@@ -465,6 +549,10 @@ fn transform_field_entry(entry: &FormFieldEntry) -> Result<TypedFormFieldEntry> 
 			let typed_group = transform_field_group(group)?;
 			Ok(TypedFormFieldEntry::Group(typed_group))
 		}
+		FormFieldEntry::Collection(collection) => {
+			let typed_collection = transform_collection(collection)?;
+			Ok(TypedFormFieldEntry::Collection(typed_collection))
+		}
 		FormFieldEntry::SubmitButton(btn) => {
 			let typed_btn = transform_submit_button(btn)?;
 			Ok(TypedFormFieldEntry::SubmitButton(typed_btn))
@@ -488,6 +576,141 @@ fn transform_field_group(group: &FormFieldGroup) -> Result<TypedFormFieldGroup> 
 		fields: typed_fields,
 		span: group.span,
 	})
+}
+
+/// Transforms a field collection into a typed field collection.
+fn transform_collection(collection: &FormFieldCollection) -> Result<TypedFormFieldCollection> {
+	let min_items = collection
+		.min_items
+		.as_ref()
+		.map(|lit| {
+			lit.base10_parse::<usize>().map_err(|_| {
+				Error::new(lit.span(), "min_items must be a valid non-negative integer")
+			})
+		})
+		.transpose()?;
+	let max_items = collection
+		.max_items
+		.as_ref()
+		.map(|lit| {
+			lit.base10_parse::<usize>().map_err(|_| {
+				Error::new(lit.span(), "max_items must be a valid non-negative integer")
+			})
+		})
+		.transpose()?;
+
+	if let (Some(min_items), Some(max_items)) = (min_items, max_items)
+		&& min_items > max_items
+	{
+		return Err(Error::new(
+			collection.span,
+			"min_items cannot be greater than max_items",
+		));
+	}
+
+	validate_collection_codegen_surface(collection)?;
+
+	if let Some(nested) = collection.fields.iter().find_map(|entry| match entry {
+		FormFieldEntry::Collection(nested) => Some(nested),
+		_ => None,
+	}) {
+		return Err(Error::new(
+			nested.span,
+			"nested FieldArray is not supported by reinhardt-pages macro codegen yet",
+		));
+	}
+
+	let fields = collection
+		.fields
+		.iter()
+		.map(transform_field_entry)
+		.collect::<Result<Vec<_>>>()?;
+
+	Ok(TypedFormFieldCollection {
+		name: collection.name.clone(),
+		label: collection.label.as_ref().map(|lit| lit.value()),
+		class: collection.class.as_ref().map(|lit| lit.value()),
+		min_items,
+		max_items,
+		initial_from: collection.initial_from.as_ref().map(|lit| lit.value()),
+		fields,
+		render_item: collection.render_item.clone(),
+		span: collection.span,
+	})
+}
+
+fn validate_collection_codegen_surface(collection: &FormFieldCollection) -> Result<()> {
+	if let Some(initial_from) = &collection.initial_from {
+		return Err(Error::new(
+			initial_from.span(),
+			"FieldArray initial_from is not supported by reinhardt-pages macro codegen yet",
+		));
+	}
+	if collection.render_item.is_some() {
+		return Err(Error::new(
+			collection.span,
+			"FieldArray render_item is not supported by reinhardt-pages macro codegen yet",
+		));
+	}
+
+	for entry in &collection.fields {
+		match entry {
+			FormFieldEntry::Field(field) => validate_collection_codegen_field(field)?,
+			FormFieldEntry::Group(group) => {
+				return Err(Error::new(
+					group.span,
+					"FieldGroup inside FieldArray is not supported by reinhardt-pages macro codegen yet",
+				));
+			}
+			FormFieldEntry::Collection(_) => {}
+			FormFieldEntry::SubmitButton(button) => {
+				return Err(Error::new(
+					button.span,
+					"SubmitButton inside FieldArray is not supported by reinhardt-pages macro codegen yet",
+				));
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_collection_codegen_field(field: &FormFieldDef) -> Result<()> {
+	let field_type = field.field_type.to_string();
+	if field_type == "FileField" || field_type == "ImageField" {
+		return Err(Error::new(
+			field.span,
+			"FileField and ImageField inside FieldArray are not supported by reinhardt-pages macro codegen yet",
+		));
+	}
+
+	for property in &field.properties {
+		match property {
+			FormFieldProperty::Named { name, span, .. } if name == "initial" => {
+				return Err(Error::new(
+					*span,
+					"initial is not supported inside FieldArray item fields yet",
+				));
+			}
+			FormFieldProperty::InitialFrom { span, .. } => {
+				return Err(Error::new(
+					*span,
+					"initial_from is not supported inside FieldArray item fields yet",
+				));
+			}
+			FormFieldProperty::ChoicesFrom { span, .. }
+			| FormFieldProperty::ChoiceValue { span, .. }
+			| FormFieldProperty::ChoiceLabel { span, .. } => {
+				return Err(Error::new(
+					*span,
+					"dynamic choices are not supported inside FieldArray item fields yet",
+				));
+			}
+			_ => {}
+		}
+	}
+
+	Ok(())
 }
 
 /// Transforms a submit button definition into a typed submit button.
@@ -1375,7 +1598,7 @@ fn transform_strip_arguments(
 			));
 		}
 
-		if field_exists(fields, &arg.name) {
+		if ambient_argument_surface_entry_exists(fields, &arg.name) {
 			return Err(Error::new(
 				arg.span,
 				format!(
@@ -1415,10 +1638,12 @@ fn ambient_arguments_collision_entry(source: Option<AmbientArgumentsSource>) -> 
 	}
 }
 
-/// Checks if a field with the given name exists in the field entries.
+/// Checks if an ambient argument collides with a declared form surface entry.
 ///
-/// This checks both top-level fields and fields within groups.
-fn field_exists(entries: &[FormFieldEntry], name: &syn::Ident) -> bool {
+/// Ambient arguments share the form's top-level submission surface, so this
+/// includes top-level fields, group fields, and top-level collection names.
+/// Collection item fields are not part of that surface.
+fn ambient_argument_surface_entry_exists(entries: &[FormFieldEntry], name: &syn::Ident) -> bool {
 	for entry in entries {
 		match entry {
 			FormFieldEntry::Field(field) => {
@@ -1431,7 +1656,36 @@ fn field_exists(entries: &[FormFieldEntry], name: &syn::Ident) -> bool {
 					return true;
 				}
 			}
+			FormFieldEntry::Collection(collection) => {
+				if collection.name == *name {
+					return true;
+				}
+			}
 			FormFieldEntry::SubmitButton(_) => {}
+		}
+	}
+	false
+}
+
+/// Checks if a field-level validator targets a declared scalar field.
+///
+/// Field validators can target top-level fields and fields within groups.
+/// Collection names and collection item fields are intentionally excluded
+/// until collection validation semantics are implemented.
+fn validator_target_field_exists(entries: &[FormFieldEntry], name: &syn::Ident) -> bool {
+	for entry in entries {
+		match entry {
+			FormFieldEntry::Field(field) => {
+				if field.name == *name {
+					return true;
+				}
+			}
+			FormFieldEntry::Group(group) => {
+				if group.fields.iter().any(|f| f.name == *name) {
+					return true;
+				}
+			}
+			FormFieldEntry::Collection(_) | FormFieldEntry::SubmitButton(_) => {}
 		}
 	}
 	false
@@ -1452,7 +1706,7 @@ fn transform_validators(
 				span,
 			} => {
 				// Validate that field exists (including in groups)
-				if !field_exists(fields, field_name) {
+				if !validator_target_field_exists(fields, field_name) {
 					return Err(Error::new(
 						field_name.span(),
 						format!("validator references unknown field: '{}'", field_name),
@@ -4009,6 +4263,171 @@ mod tests {
 		};
 
 		assert_validator_parity_for(input);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_strip_argument_rejects_field_array_collision() {
+		let input = quote! {
+			name: InvoiceForm,
+			server_fn: submit_invoice,
+			strip_arguments: {
+				line_items: ambient_line_items(),
+			},
+			fields: {
+				line_items: FieldArray {
+					fields: {
+						description: CharField {},
+					},
+				},
+			},
+		};
+
+		let err = parse_and_validate(input).expect_err("FieldArray name collision must fail");
+		assert_eq!(
+			err.to_string(),
+			"strip_arguments key 'line_items' collides with a declared form field; either rename the field or remove this strip entry; use ambient_arguments for new code"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_field_validator_rejects_field_array_name() {
+		let input = quote! {
+			name: InvoiceForm,
+			action: "/invoices",
+			fields: {
+				line_items: FieldArray {
+					fields: {
+						description: CharField {},
+					},
+				},
+			},
+			validators: {
+				line_items: [|_v| true => "Line items are invalid"],
+			},
+		};
+
+		let err = parse_and_validate(input).expect_err("collection validator target must fail");
+		assert_eq!(
+			err.to_string(),
+			"validator references unknown field: 'line_items'"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_nested_field_array_rejected() {
+		let input = quote! {
+			name: InvoiceForm,
+			action: "/invoices",
+			fields: {
+				line_items: FieldArray {
+					fields: {
+						description: CharField {},
+						discounts: FieldArray {
+							fields: {
+								amount: IntegerField {},
+							},
+						},
+					},
+				},
+			},
+		};
+
+		let err = parse_and_validate(input).expect_err("nested FieldArray must fail");
+		assert_eq!(
+			err.to_string(),
+			"nested FieldArray is not supported by reinhardt-pages macro codegen yet"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_field_array_rejects_initial_on_item_field() {
+		let input = quote! {
+			name: InvoiceForm,
+			action: "/invoices",
+			fields: {
+				line_items: FieldArray {
+					fields: {
+						quantity: IntegerField {
+							initial: 1,
+						},
+					},
+				},
+			},
+		};
+
+		let err = parse_and_validate(input).expect_err("FieldArray item initial must fail");
+		assert_eq!(
+			err.to_string(),
+			"initial is not supported inside FieldArray item fields yet"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_field_array_rejects_file_fields() {
+		let input = quote! {
+			name: UploadForm,
+			action: "/uploads",
+			fields: {
+				attachments: FieldArray {
+					fields: {
+						document: FileField {},
+					},
+				},
+			},
+		};
+
+		let err = parse_and_validate(input).expect_err("FieldArray FileField must fail");
+		assert_eq!(
+			err.to_string(),
+			"FileField and ImageField inside FieldArray are not supported by reinhardt-pages macro codegen yet"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_field_array_rejects_field_groups() {
+		let input = quote! {
+			name: InvoiceForm,
+			action: "/invoices",
+			fields: {
+				line_items: FieldArray {
+					fields: {
+						details: FieldGroup {
+							fields: {
+								description: CharField {},
+							},
+						},
+					},
+				},
+			},
+		};
+
+		let err = parse_and_validate(input).expect_err("FieldArray FieldGroup must fail");
+		assert_eq!(
+			err.to_string(),
+			"FieldGroup inside FieldArray is not supported by reinhardt-pages macro codegen yet"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_field_array_rejects_render_item() {
+		let input = quote! {
+			name: InvoiceForm,
+			action: "/invoices",
+			fields: {
+				line_items: FieldArray {
+					fields: {
+						description: CharField {},
+					},
+					render_item: |item| { item.default_row() },
+				},
+			},
+		};
+
+		let err = parse_and_validate(input).expect_err("FieldArray render_item must fail");
+		assert_eq!(
+			err.to_string(),
+			"FieldArray render_item is not supported by reinhardt-pages macro codegen yet"
+		);
 	}
 
 	#[rstest::rstest]

--- a/crates/reinhardt-pages/src/form_state.rs
+++ b/crates/reinhardt-pages/src/form_state.rs
@@ -36,6 +36,65 @@ pub enum RevalidateOn {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct NoDeps;
 
+/// Opaque runtime key for a collection item.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CollectionItemKey(u64);
+
+impl CollectionItemKey {
+	const GENERATED_KEY_FLAG: u64 = 1 << 63;
+
+	/// Creates a collection item key from a generated runtime index.
+	#[doc(hidden)]
+	pub fn from_runtime_index(value: u64) -> Self {
+		Self(value | Self::GENERATED_KEY_FLAG)
+	}
+
+	fn next(counter: &Cell<u64>) -> Self {
+		let value = counter.get();
+		assert!(
+			value < Self::GENERATED_KEY_FLAG,
+			"collection item key counter exhausted runtime key namespace"
+		);
+		counter.set(value + 1);
+		Self(value)
+	}
+}
+
+/// Runtime value paired with its collection item key and current index.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CollectionItem<T> {
+	key: CollectionItemKey,
+	index: usize,
+	value: T,
+}
+
+impl<T> CollectionItem<T> {
+	/// Creates a runtime collection item.
+	pub fn new(key: CollectionItemKey, index: usize, value: T) -> Self {
+		Self { key, index, value }
+	}
+
+	/// Returns the runtime key for this collection item.
+	pub fn key(&self) -> CollectionItemKey {
+		self.key
+	}
+
+	/// Returns the current positional index for this collection item.
+	pub fn index(&self) -> usize {
+		self.index
+	}
+
+	/// Returns the current value for this collection item.
+	pub fn value(&self) -> &T {
+		&self.value
+	}
+
+	/// Consumes this collection item and returns its value.
+	pub fn into_value(self) -> T {
+		self.value
+	}
+}
+
 /// A field-level error.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FieldError {
@@ -63,6 +122,8 @@ where
 	Field: Copy + Eq + Hash,
 {
 	field_errors: HashMap<Field, FieldError>,
+	collection_errors: HashMap<String, FieldError>,
+	path_errors: HashMap<String, FieldError>,
 	form_error: Option<String>,
 }
 
@@ -74,6 +135,8 @@ where
 	pub fn new() -> Self {
 		Self {
 			field_errors: HashMap::new(),
+			collection_errors: HashMap::new(),
+			path_errors: HashMap::new(),
 			form_error: None,
 		}
 	}
@@ -84,6 +147,8 @@ where
 		field_errors.insert(field, FieldError::new(message));
 		Self {
 			field_errors,
+			collection_errors: HashMap::new(),
+			path_errors: HashMap::new(),
 			form_error: None,
 		}
 	}
@@ -92,6 +157,8 @@ where
 	pub fn form(message: impl Into<String>) -> Self {
 		Self {
 			field_errors: HashMap::new(),
+			collection_errors: HashMap::new(),
+			path_errors: HashMap::new(),
 			form_error: Some(message.into()),
 		}
 	}
@@ -99,6 +166,16 @@ where
 	/// Returns field errors.
 	pub fn field_errors(&self) -> &HashMap<Field, FieldError> {
 		&self.field_errors
+	}
+
+	/// Returns generated collection validation errors.
+	pub fn collection_errors(&self) -> &HashMap<String, FieldError> {
+		&self.collection_errors
+	}
+
+	/// Returns nested collection path errors.
+	pub fn path_errors(&self) -> &HashMap<String, FieldError> {
+		&self.path_errors
 	}
 
 	/// Returns the form-level error, if any.
@@ -111,14 +188,33 @@ where
 		self.field_errors.insert(field, FieldError::new(message));
 	}
 
+	/// Adds or replaces one generated collection validation error.
+	pub fn add_collection_error(
+		&mut self,
+		collection_key: impl Into<String>,
+		message: impl Into<String>,
+	) {
+		self.collection_errors
+			.insert(collection_key.into(), FieldError::new(message));
+	}
+
+	/// Adds or replaces one nested collection path validation error.
+	pub fn add_path_error(&mut self, path_key: impl Into<String>, message: impl Into<String>) {
+		self.path_errors
+			.insert(path_key.into(), FieldError::new(message));
+	}
+
 	/// Sets the form-level validation error.
 	pub fn set_form_error(&mut self, message: impl Into<String>) {
 		self.form_error = Some(message.into());
 	}
 
-	/// Returns whether this error contains no field or form error.
+	/// Returns whether this error contains no field, path, or form error.
 	pub fn is_empty(&self) -> bool {
-		self.field_errors.is_empty() && self.form_error.is_none()
+		self.field_errors.is_empty()
+			&& self.collection_errors.is_empty()
+			&& self.path_errors.is_empty()
+			&& self.form_error.is_none()
 	}
 }
 
@@ -163,6 +259,30 @@ pub struct FieldState {
 	/// Whether this field was changed through the runtime.
 	pub is_touched: bool,
 	/// Current field-level error.
+	pub error: Option<FieldError>,
+}
+
+/// Snapshot for a nested field path inside a generated collection field.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FieldPathState {
+	/// Whether this field path differs from its default value.
+	pub is_dirty: bool,
+	/// Whether this field path was changed through the runtime.
+	pub is_touched: bool,
+	/// Current field path-level error.
+	pub error: Option<FieldError>,
+}
+
+/// Snapshot for a generated collection field.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CollectionState {
+	/// Number of items currently present in the collection.
+	pub len: usize,
+	/// Whether the collection differs from its default value.
+	pub is_dirty: bool,
+	/// Whether the collection was changed through the runtime.
+	pub is_touched: bool,
+	/// Current collection-level error.
 	pub error: Option<FieldError>,
 }
 
@@ -241,10 +361,56 @@ pub trait FormRuntimeSource: Clone + 'static {
 		defaults: &Self::Values,
 	) -> bool;
 
+	/// Returns whether the generated values differ from the comparison baseline.
+	fn runtime_values_are_dirty(&self, current: &Self::Values, defaults: &Self::Values) -> bool {
+		self.runtime_fields()
+			.iter()
+			.copied()
+			.any(|field| self.runtime_field_is_dirty(field, current, defaults))
+	}
+
+	/// Applies new defaults to pristine runtime values while preserving dirty values.
+	fn runtime_apply_pristine_values(
+		&self,
+		current: &Self::Values,
+		old_defaults: &Self::Values,
+		new_defaults: &Self::Values,
+	) {
+		for field in self.runtime_fields() {
+			let field = *field;
+			if !self.runtime_field_is_dirty(field, current, old_defaults) {
+				self.runtime_apply_field_value(field, new_defaults);
+			}
+		}
+	}
+
 	/// Returns the generated signal for a field when `T` matches the field type.
 	fn runtime_watch_field<T>(&self, field: Self::Field) -> Option<Signal<T>>
 	where
 		T: Clone + 'static;
+
+	/// Captures nested collection field values using the current runtime item keys.
+	fn runtime_path_values_from_values(
+		&self,
+		_values: &Self::Values,
+	) -> HashMap<String, Rc<dyn Any>> {
+		HashMap::new()
+	}
+
+	/// Captures current nested collection field values using runtime item keys.
+	fn runtime_path_values(&self) -> HashMap<String, Rc<dyn Any>> {
+		self.runtime_path_values_from_values(&self.runtime_current_values())
+	}
+
+	/// Returns whether a stable nested path key currently exists.
+	fn runtime_path_exists(&self, _path_key: &str) -> bool {
+		false
+	}
+
+	/// Compares a current nested path value with a captured default value.
+	fn runtime_path_value_equals(&self, _path_key: &str, _default: &dyn Any) -> Option<bool> {
+		None
+	}
 
 	/// Runs generated validation.
 	fn runtime_validate(&self) -> Result<(), FormValidationError<Self::Field>> {
@@ -258,6 +424,80 @@ pub trait FormRuntimeSource: Clone + 'static {
 
 	/// Returns generated field tokens in source order.
 	fn runtime_fields(&self) -> &'static [Self::Field];
+}
+
+/// Trait implemented by `form!` generated forms that expose runtime collections.
+pub trait FormCollectionRuntimeSource: FormRuntimeSource {
+	/// Generated collection token enum for this form.
+	type Collection: Copy + Eq + Hash + Debug + 'static;
+	/// Generated field path token enum for nested collection fields.
+	type FieldPath: Clone + Eq + Hash + Debug + 'static;
+
+	/// Returns the stable runtime map key for a generated field path.
+	fn runtime_field_path_key(path: &Self::FieldPath) -> String;
+
+	/// Returns the stable runtime map key for a generated collection.
+	fn runtime_collection_key(collection: Self::Collection) -> String;
+
+	/// Returns stable runtime map keys for every nested field path in an item.
+	fn runtime_field_path_keys_for_item(
+		collection: Self::Collection,
+		key: CollectionItemKey,
+	) -> Vec<String>;
+
+	/// Returns the current length for a generated collection.
+	fn runtime_collection_len(&self, collection: Self::Collection) -> usize;
+
+	/// Returns whether one generated collection differs between values and defaults.
+	fn runtime_collection_is_dirty(
+		&self,
+		collection: Self::Collection,
+		current: &Self::Values,
+		defaults: &Self::Values,
+	) -> bool;
+
+	/// Inserts one collection item value at the requested index.
+	fn runtime_insert_collection_item<T>(
+		&self,
+		collection: Self::Collection,
+		index: usize,
+		key: CollectionItemKey,
+		value: T,
+	) where
+		T: Any + Clone + 'static;
+
+	/// Removes one collection item by key.
+	fn runtime_remove_collection_item(
+		&self,
+		collection: Self::Collection,
+		key: CollectionItemKey,
+	) -> bool;
+
+	/// Moves one collection item by key.
+	fn runtime_move_collection_item(
+		&self,
+		collection: Self::Collection,
+		key: CollectionItemKey,
+		target_index: usize,
+	) -> Option<(usize, usize)>;
+
+	/// Returns the generated signal for a nested field path when `T` matches.
+	fn runtime_watch_path<T>(&self, path: Self::FieldPath) -> Option<Signal<T>>
+	where
+		T: Clone + 'static;
+
+	/// Applies one typed value to a generated nested field path.
+	fn runtime_set_path_value<T>(&self, path: Self::FieldPath, value: T) -> bool
+	where
+		T: Any + 'static;
+
+	/// Returns whether one nested field path differs between values and defaults.
+	fn runtime_path_is_dirty(
+		&self,
+		path: &Self::FieldPath,
+		current: &Self::Values,
+		defaults: &Self::Values,
+	) -> bool;
 }
 
 /// Builder returned by `use_form(&form)`.
@@ -284,10 +524,7 @@ fn form_values_are_dirty<Form>(form: &Form, current: &Form::Values, defaults: &F
 where
 	Form: FormRuntimeSource,
 {
-	form.runtime_fields()
-		.iter()
-		.copied()
-		.any(|field| form.runtime_field_is_dirty(field, current, defaults))
+	form.runtime_values_are_dirty(current, defaults)
 }
 
 #[allow(
@@ -299,6 +536,8 @@ fn build_signal_sync_effect<Form>(
 	default_values: Rc<RefCell<Form::Values>>,
 	state: FormState<Form::Field>,
 	touched_fields: Rc<RefCell<HashMap<Form::Field, bool>>>,
+	collection_errors: Signal<HashMap<String, FieldError>>,
+	path_errors: Signal<HashMap<String, FieldError>>,
 	values_signal: Signal<Form::Values>,
 	subscribers: SubscriberSlots<Form>,
 	observed_values: Rc<RefCell<Form::Values>>,
@@ -318,9 +557,10 @@ where
 				.copied()
 				.filter(|field| form.runtime_field_is_dirty(*field, &current, &previous))
 				.collect();
+			let values_changed = form.runtime_values_are_dirty(&current, &previous);
 			*observed_values.borrow_mut() = current.clone();
 
-			if signal_sync_suppressed.get() || changed_fields.is_empty() {
+			if signal_sync_suppressed.get() || (changed_fields.is_empty() && !values_changed) {
 				return;
 			}
 
@@ -337,7 +577,7 @@ where
 
 			if revalidate_on == RevalidateOn::Change {
 				let result = form.runtime_validate();
-				apply_validation_result_to_state(&state, &result);
+				apply_validation_result_to_state(&state, &collection_errors, &path_errors, &result);
 				notify_subscribers(&subscribers, FormEvent::Validated);
 			}
 			for field in changed_fields {
@@ -365,9 +605,15 @@ where
 			revalidate_on: handle.revalidate_on,
 			state: handle.state.clone(),
 			touched_fields: Rc::clone(&handle.touched_fields),
+			touched_collections: Rc::clone(&handle.touched_collections),
+			touched_paths: Rc::clone(&handle.touched_paths),
+			collection_errors: handle.collection_errors.clone(),
+			path_errors: handle.path_errors.clone(),
+			path_default_values: Rc::clone(&handle.path_default_values),
 			values_signal: handle.values_signal.clone(),
 			subscribers: Rc::clone(&handle.subscribers),
 			observed_values: Rc::clone(&handle.observed_values),
+			next_collection_item_key: Rc::clone(&handle.next_collection_item_key),
 			signal_sync_suppressed: Rc::clone(&handle.signal_sync_suppressed),
 			_signal_sync_effect: Rc::clone(&handle._signal_sync_effect),
 			on_submit_start: None,
@@ -380,6 +626,8 @@ where
 
 fn apply_validation_result_to_state<Field>(
 	state: &FormState<Field>,
+	collection_errors: &Signal<HashMap<String, FieldError>>,
+	path_errors: &Signal<HashMap<String, FieldError>>,
 	result: &Result<(), FormValidationError<Field>>,
 ) where
 	Field: Copy + Eq + Hash + 'static,
@@ -387,19 +635,26 @@ fn apply_validation_result_to_state<Field>(
 	match result {
 		Ok(()) => {
 			state.field_errors.set(HashMap::new());
+			collection_errors.set(HashMap::new());
+			path_errors.set(HashMap::new());
 			state.form_error.set(None);
-			sync_first_error_in_state(state);
+			sync_first_error_in_state(state, collection_errors, path_errors);
 		}
 		Err(error) => {
 			state.field_errors.set(error.field_errors().clone());
+			collection_errors.set(error.collection_errors().clone());
+			path_errors.set(error.path_errors().clone());
 			state.form_error.set(error.form_error().map(str::to_string));
-			sync_first_error_in_state(state);
+			sync_first_error_in_state(state, collection_errors, path_errors);
 		}
 	}
 }
 
-fn sync_first_error_in_state<Field>(state: &FormState<Field>)
-where
+fn sync_first_error_in_state<Field>(
+	state: &FormState<Field>,
+	collection_errors: &Signal<HashMap<String, FieldError>>,
+	path_errors: &Signal<HashMap<String, FieldError>>,
+) where
 	Field: Copy + Eq + Hash + 'static,
 {
 	let first_field_error = state
@@ -408,8 +663,20 @@ where
 		.values()
 		.next()
 		.map(|error| error.message().to_string());
+	let first_collection_error = collection_errors
+		.get()
+		.values()
+		.next()
+		.map(|error| error.message().to_string());
+	let first_path_error = path_errors
+		.get()
+		.values()
+		.next()
+		.map(|error| error.message().to_string());
 	state.error.set(
 		first_field_error
+			.or(first_collection_error)
+			.or(first_path_error)
 			.or_else(|| state.form_error.get())
 			.or_else(|| state.submit_error.get()),
 	);
@@ -502,6 +769,9 @@ where
 		let current_values = self.form.runtime_current_values();
 		let is_dirty = form_values_are_dirty(&self.form, &current_values, &default_values);
 		let form = self.form;
+		let path_default_values = Rc::new(RefCell::new(
+			form.runtime_path_values_from_values(&default_values),
+		));
 		let default_values = Rc::new(RefCell::new(default_values));
 		let deps = Rc::new(RefCell::new(self.deps));
 		let state = FormState {
@@ -515,15 +785,22 @@ where
 			is_submit_successful: Signal::new(false),
 		};
 		let touched_fields = Rc::new(RefCell::new(HashMap::new()));
+		let touched_collections = Rc::new(RefCell::new(HashMap::new()));
+		let touched_paths = Rc::new(RefCell::new(HashMap::new()));
+		let collection_errors = Signal::new(HashMap::new());
+		let path_errors = Signal::new(HashMap::new());
 		let values_signal = Signal::new(current_values.clone());
 		let subscribers = Rc::new(RefCell::new(Vec::new()));
 		let observed_values = Rc::new(RefCell::new(current_values));
+		let next_collection_item_key = Rc::new(Cell::new(1));
 		let signal_sync_suppressed = Rc::new(Cell::new(false));
 		let signal_sync_effect = build_signal_sync_effect(
 			form.clone(),
 			Rc::clone(&default_values),
 			state.clone(),
 			Rc::clone(&touched_fields),
+			collection_errors.clone(),
+			path_errors.clone(),
 			values_signal.clone(),
 			Rc::clone(&subscribers),
 			Rc::clone(&observed_values),
@@ -539,9 +816,15 @@ where
 			revalidate_on: self.revalidate_on,
 			state,
 			touched_fields,
+			touched_collections,
+			touched_paths,
+			collection_errors,
+			path_errors,
+			path_default_values,
 			values_signal,
 			subscribers,
 			observed_values,
+			next_collection_item_key,
 			signal_sync_suppressed,
 			_signal_sync_effect: signal_sync_effect,
 			on_submit_start: self.on_submit_start,
@@ -565,9 +848,15 @@ where
 	revalidate_on: RevalidateOn,
 	state: FormState<Form::Field>,
 	touched_fields: Rc<RefCell<HashMap<Form::Field, bool>>>,
+	touched_collections: Rc<RefCell<HashMap<String, bool>>>,
+	touched_paths: Rc<RefCell<HashMap<String, bool>>>,
+	collection_errors: Signal<HashMap<String, FieldError>>,
+	path_errors: Signal<HashMap<String, FieldError>>,
+	path_default_values: Rc<RefCell<HashMap<String, Rc<dyn Any>>>>,
 	values_signal: Signal<Form::Values>,
 	subscribers: SubscriberSlots<Form>,
 	observed_values: Rc<RefCell<Form::Values>>,
+	next_collection_item_key: Rc<Cell<u64>>,
 	signal_sync_suppressed: Rc<Cell<bool>>,
 	_signal_sync_effect: Rc<Effect>,
 	on_submit_start: Option<SubmitCallback<Form, Deps>>,
@@ -590,9 +879,15 @@ where
 			revalidate_on: self.revalidate_on,
 			state: self.state.clone(),
 			touched_fields: Rc::clone(&self.touched_fields),
+			touched_collections: Rc::clone(&self.touched_collections),
+			touched_paths: Rc::clone(&self.touched_paths),
+			collection_errors: self.collection_errors.clone(),
+			path_errors: self.path_errors.clone(),
+			path_default_values: Rc::clone(&self.path_default_values),
 			values_signal: self.values_signal.clone(),
 			subscribers: Rc::clone(&self.subscribers),
 			observed_values: Rc::clone(&self.observed_values),
+			next_collection_item_key: Rc::clone(&self.next_collection_item_key),
 			signal_sync_suppressed: Rc::clone(&self.signal_sync_suppressed),
 			_signal_sync_effect: Rc::clone(&self._signal_sync_effect),
 			on_submit_start: self.on_submit_start.clone(),
@@ -677,8 +972,14 @@ where
 		self.form.runtime_apply_values(&values);
 		self.state.is_touched.set(true);
 		self.refresh_dirty();
+		self.touched_collections.borrow_mut().clear();
+		self.touched_paths.borrow_mut().clear();
+		self.rebuild_path_default_values();
+		self.collection_errors.set(HashMap::new());
+		self.path_errors.set(HashMap::new());
 		self.values_signal.set(values);
 		self.sync_observed_values();
+		self.sync_first_error();
 		if self.revalidate_on == RevalidateOn::Change {
 			let _ = self.trigger();
 		}
@@ -695,6 +996,8 @@ where
 	/// Clears all validation and submit errors.
 	pub fn clear_errors(&self) {
 		self.state.field_errors.set(HashMap::new());
+		self.collection_errors.set(HashMap::new());
+		self.path_errors.set(HashMap::new());
 		self.state.form_error.set(None);
 		self.state.submit_error.set(None);
 		self.state.error.set(None);
@@ -740,10 +1043,13 @@ where
 		let _guard = self.suppress_signal_sync();
 		self.form.runtime_apply_values(&defaults);
 		self.touched_fields.borrow_mut().clear();
+		self.touched_collections.borrow_mut().clear();
+		self.touched_paths.borrow_mut().clear();
 		self.state.is_touched.set(false);
 		self.state.is_dirty.set(false);
 		self.state.is_submitting.set(false);
 		self.state.is_submit_successful.set(false);
+		self.rebuild_path_default_values();
 		self.clear_errors();
 		self.values_signal.set(defaults);
 		self.sync_observed_values();
@@ -762,7 +1068,9 @@ where
 
 	/// Makes the current values the defaults and clears dirty state.
 	pub fn reset_default_values(&self) {
-		*self.default_values.borrow_mut() = self.get_values();
+		let values = self.get_values();
+		*self.default_values.borrow_mut() = values.clone();
+		*self.path_default_values.borrow_mut() = self.form.runtime_path_values_from_values(&values);
 		self.state.is_dirty.set(false);
 	}
 
@@ -831,31 +1139,37 @@ where
 
 		let old_defaults = self.default_values.borrow().clone();
 		let current = self.get_values();
+		let resets_all_values = matches!(self.reset_on_deps, ResetOnDeps::ResetAll);
 
 		match self.reset_on_deps {
 			ResetOnDeps::KeepDirtyValues => {
 				let _guard = self.suppress_signal_sync();
-				for field in self.form.runtime_fields() {
-					let field = *field;
-					if !self
-						.form
-						.runtime_field_is_dirty(field, &current, &old_defaults)
-					{
-						self.form.runtime_apply_field_value(field, &new_defaults);
-					}
-				}
+				self.form
+					.runtime_apply_pristine_values(&current, &old_defaults, &new_defaults);
 			}
 			ResetOnDeps::ResetAll => {
 				let _guard = self.suppress_signal_sync();
 				self.form.runtime_apply_values(&new_defaults);
 				self.touched_fields.borrow_mut().clear();
+				self.touched_collections.borrow_mut().clear();
+				self.touched_paths.borrow_mut().clear();
 			}
 			ResetOnDeps::ExplicitOnly => {}
 		}
 
 		*self.default_values.borrow_mut() = new_defaults;
+		if resets_all_values {
+			self.rebuild_path_default_values();
+		} else {
+			self.merge_missing_path_default_values();
+		}
+		self.prune_path_state_to_current_paths();
 		if !self.keep_errors {
 			self.clear_errors();
+		} else {
+			self.collection_errors.set(HashMap::new());
+			self.path_errors.set(HashMap::new());
+			self.sync_first_error();
 		}
 		self.refresh_dirty();
 		self.values_signal.set(self.get_values());
@@ -870,11 +1184,16 @@ where
 		match result {
 			Ok(()) => {
 				self.state.field_errors.set(HashMap::new());
+				self.collection_errors.set(HashMap::new());
+				self.path_errors.set(HashMap::new());
 				self.state.form_error.set(None);
 				self.sync_first_error();
 			}
 			Err(error) => {
 				self.state.field_errors.set(error.field_errors().clone());
+				self.collection_errors
+					.set(error.collection_errors().clone());
+				self.path_errors.set(error.path_errors().clone());
 				self.state
 					.form_error
 					.set(error.form_error().map(str::to_string));
@@ -901,8 +1220,22 @@ where
 			.values()
 			.next()
 			.map(|error| error.message().to_string());
+		let first_path_error = self
+			.path_errors
+			.get()
+			.values()
+			.next()
+			.map(|error| error.message().to_string());
+		let first_collection_error = self
+			.collection_errors
+			.get()
+			.values()
+			.next()
+			.map(|error| error.message().to_string());
 		self.state.error.set(
 			first_field_error
+				.or(first_collection_error)
+				.or(first_path_error)
 				.or_else(|| self.state.form_error.get())
 				.or_else(|| self.state.submit_error.get()),
 		);
@@ -923,6 +1256,244 @@ where
 
 	fn sync_observed_values(&self) {
 		*self.observed_values.borrow_mut() = self.get_values();
+	}
+
+	fn rebuild_path_default_values(&self) {
+		*self.path_default_values.borrow_mut() = self
+			.form
+			.runtime_path_values_from_values(&self.default_values.borrow());
+	}
+
+	fn merge_missing_path_default_values(&self) {
+		let defaults = self.default_values.borrow();
+		let missing_defaults = self.form.runtime_path_values_from_values(&defaults);
+		let mut path_default_values = self.path_default_values.borrow_mut();
+		for (path_key, value) in missing_defaults {
+			path_default_values.entry(path_key).or_insert(value);
+		}
+	}
+
+	fn prune_path_state_to_current_paths(&self) {
+		let current_paths = self.form.runtime_path_values();
+		self.touched_paths
+			.borrow_mut()
+			.retain(|path_key, _| current_paths.contains_key(path_key));
+
+		let mut path_errors = self.path_errors.get();
+		path_errors.retain(|path_key, _| current_paths.contains_key(path_key));
+		self.path_errors.set(path_errors);
+
+		self.path_default_values
+			.borrow_mut()
+			.retain(|path_key, _| current_paths.contains_key(path_key));
+	}
+}
+
+impl<Form, Deps> UseFormReturn<Form, Deps>
+where
+	Form: FormCollectionRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+{
+	/// Returns a typed signal for a nested collection field path.
+	pub fn watch_path<T>(&self, path: Form::FieldPath) -> Signal<T>
+	where
+		T: Clone + 'static,
+	{
+		self.form
+			.runtime_watch_path(path.clone())
+			.unwrap_or_else(|| {
+				panic!(
+					"field path {:?} is not compatible with requested Signal<{}>",
+					path,
+					type_name::<T>()
+				)
+			})
+	}
+
+	/// Applies one typed value to a nested collection field path.
+	pub fn set_path_value<T>(&self, path: Form::FieldPath, value: T)
+	where
+		T: Any + 'static,
+	{
+		let path_key = Form::runtime_field_path_key(&path);
+		let _guard = self.suppress_signal_sync();
+		if !self.form.runtime_set_path_value(path.clone(), value) {
+			panic!(
+				"field path {:?} does not exist in the current collection state",
+				path
+			);
+		}
+		self.touched_paths.borrow_mut().insert(path_key, true);
+		self.state.is_touched.set(true);
+		self.refresh_dirty();
+		self.values_signal.set(self.get_values());
+		self.sync_observed_values();
+		if self.revalidate_on == RevalidateOn::Change {
+			let _ = self.trigger();
+		}
+	}
+
+	/// Sets one nested collection field path error.
+	pub fn set_path_error(&self, path: Form::FieldPath, error: FieldError) {
+		let path_key = Form::runtime_field_path_key(&path);
+		let mut errors = self.path_errors.get();
+		errors.insert(path_key, error);
+		self.path_errors.set(errors);
+		self.sync_first_error();
+	}
+
+	/// Clears one nested collection field path error.
+	pub fn clear_path_error(&self, path: Form::FieldPath) {
+		let path_key = Form::runtime_field_path_key(&path);
+		let mut errors = self.path_errors.get();
+		errors.remove(&path_key);
+		self.path_errors.set(errors);
+		self.sync_first_error();
+	}
+
+	/// Returns state for one nested collection field path.
+	pub fn get_path_state(&self, path: Form::FieldPath) -> FieldPathState {
+		let path_key = Form::runtime_field_path_key(&path);
+		let current = self.get_values();
+		let defaults = self.default_values.borrow();
+		let errors = self.path_errors.get();
+		let is_dirty = match self.path_default_values.borrow().get(&path_key) {
+			Some(default) => self
+				.form
+				.runtime_path_value_equals(&path_key, default.as_ref())
+				.map(|matches_default| !matches_default)
+				.unwrap_or(false),
+			None => {
+				self.form.runtime_path_exists(&path_key)
+					|| self.form.runtime_path_is_dirty(&path, &current, &defaults)
+			}
+		};
+		FieldPathState {
+			is_dirty,
+			is_touched: self
+				.touched_paths
+				.borrow()
+				.get(&path_key)
+				.copied()
+				.unwrap_or(false),
+			error: errors.get(&path_key).cloned(),
+		}
+	}
+
+	/// Returns state for one generated collection field.
+	pub fn get_collection_state(&self, collection: Form::Collection) -> CollectionState {
+		let collection_key = Form::runtime_collection_key(collection);
+		let current = self.get_values();
+		let defaults = self.default_values.borrow();
+		let errors = self.collection_errors.get();
+		CollectionState {
+			len: self.form.runtime_collection_len(collection),
+			is_dirty: self
+				.form
+				.runtime_collection_is_dirty(collection, &current, &defaults),
+			is_touched: self
+				.touched_collections
+				.borrow()
+				.get(&collection_key)
+				.copied()
+				.unwrap_or(false),
+			error: errors.get(&collection_key).cloned(),
+		}
+	}
+
+	/// Appends one item to a generated collection.
+	pub fn push_item<T>(&self, collection: Form::Collection, value: T) -> CollectionItemKey
+	where
+		T: Any + Clone + 'static,
+	{
+		let index = self.form.runtime_collection_len(collection);
+		self.insert_item(collection, index, value)
+	}
+
+	/// Inserts one item into a generated collection.
+	pub fn insert_item<T>(
+		&self,
+		collection: Form::Collection,
+		index: usize,
+		value: T,
+	) -> CollectionItemKey
+	where
+		T: Any + Clone + 'static,
+	{
+		let key = CollectionItemKey::next(&self.next_collection_item_key);
+		let _guard = self.suppress_signal_sync();
+		self.form
+			.runtime_insert_collection_item(collection, index, key, value);
+		self.sync_after_collection_change(collection);
+		key
+	}
+
+	/// Removes one item from a generated collection.
+	pub fn remove_item(&self, collection: Form::Collection, key: CollectionItemKey) -> bool {
+		let _guard = self.suppress_signal_sync();
+		let removed = self.form.runtime_remove_collection_item(collection, key);
+		if removed {
+			self.clear_item_path_state(collection, key);
+			self.sync_after_collection_change(collection);
+			self.sync_first_error();
+		}
+		removed
+	}
+
+	/// Moves one item in a generated collection.
+	pub fn move_item(
+		&self,
+		collection: Form::Collection,
+		key: CollectionItemKey,
+		target_index: usize,
+	) -> Option<(usize, usize)> {
+		let _guard = self.suppress_signal_sync();
+		let movement = self
+			.form
+			.runtime_move_collection_item(collection, key, target_index);
+		if movement.is_some() {
+			self.sync_after_collection_change(collection);
+		}
+		movement
+	}
+
+	fn sync_after_collection_change(&self, collection: Form::Collection) {
+		let values = self.get_values();
+		let is_dirty = {
+			let defaults = self.default_values.borrow();
+			self.form.runtime_values_are_dirty(&values, &defaults)
+		};
+		self.touched_collections
+			.borrow_mut()
+			.insert(Form::runtime_collection_key(collection), true);
+		self.state.is_touched.set(true);
+		self.state.is_dirty.set(is_dirty);
+		self.values_signal.set(values.clone());
+		*self.observed_values.borrow_mut() = values;
+		if self.revalidate_on == RevalidateOn::Change {
+			let _ = self.trigger();
+		}
+	}
+
+	fn clear_item_path_state(&self, collection: Form::Collection, key: CollectionItemKey) {
+		let path_keys = Form::runtime_field_path_keys_for_item(collection, key);
+		if path_keys.is_empty() {
+			return;
+		}
+
+		{
+			let mut touched_paths = self.touched_paths.borrow_mut();
+			for path_key in &path_keys {
+				touched_paths.remove(path_key);
+			}
+		}
+
+		let mut path_errors = self.path_errors.get();
+		for path_key in path_keys {
+			path_errors.remove(&path_key);
+			self.path_default_values.borrow_mut().remove(&path_key);
+		}
+		self.path_errors.set(path_errors);
 	}
 }
 
@@ -972,5 +1543,68 @@ where
 		on_submit_start: None,
 		on_submit_success: None,
 		on_submit_error: None,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{CollectionItem, CollectionItemKey, CollectionState, FieldError, FieldPathState};
+
+	#[test]
+	fn collection_item_key_is_opaque_and_stable() {
+		let first_key = CollectionItemKey(1);
+		let second_key = CollectionItemKey(2);
+		let generated_key = CollectionItemKey::from_runtime_index(1);
+		let runtime_boundary_key = CollectionItemKey(CollectionItemKey::GENERATED_KEY_FLAG - 1);
+		let exhausted_counter = ::std::cell::Cell::new(runtime_boundary_key.0);
+
+		assert_ne!(first_key, second_key);
+		assert_ne!(generated_key, first_key);
+		assert_ne!(
+			CollectionItemKey::next(&exhausted_counter),
+			CollectionItemKey::from_runtime_index(runtime_boundary_key.0)
+		);
+		assert_eq!(
+			exhausted_counter.get(),
+			CollectionItemKey::GENERATED_KEY_FLAG
+		);
+		assert!(
+			::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+				CollectionItemKey::next(&exhausted_counter);
+			}))
+			.is_err()
+		);
+		assert!(format!("{first_key:?}").contains("CollectionItemKey"));
+
+		let item = CollectionItem::new(first_key, 3, "Ada".to_string());
+
+		assert_eq!(item.key(), first_key);
+		assert_eq!(item.index(), 3);
+		assert_eq!(item.value().as_str(), "Ada");
+		assert_eq!(item.into_value(), "Ada".to_string());
+
+		let error = FieldError::new("collection item is required");
+		let collection_state = CollectionState {
+			len: 2,
+			is_dirty: true,
+			is_touched: false,
+			error: Some(error.clone()),
+		};
+		let field_path_state = FieldPathState {
+			is_dirty: false,
+			is_touched: true,
+			error: Some(error.clone()),
+		};
+
+		assert_eq!(collection_state.len, 2);
+		assert!(collection_state.is_dirty);
+		assert!(!collection_state.is_touched);
+		assert_eq!(
+			collection_state.error.as_ref().map(FieldError::message),
+			Some("collection item is required")
+		);
+		assert!(!field_path_state.is_dirty);
+		assert!(field_path_state.is_touched);
+		assert_eq!(field_path_state.error, Some(error));
 	}
 }

--- a/crates/reinhardt-pages/src/form_state.rs
+++ b/crates/reinhardt-pages/src/form_state.rs
@@ -412,6 +412,18 @@ pub trait FormRuntimeSource: Clone + 'static {
 		None
 	}
 
+	/// Synchronizes cached nested field path signals from current form values.
+	fn runtime_sync_path_signals(&self) {}
+
+	/// Returns collection keys whose values changed between two value snapshots.
+	fn runtime_changed_collection_keys(
+		&self,
+		_current: &Self::Values,
+		_previous: &Self::Values,
+	) -> Vec<String> {
+		Vec::new()
+	}
+
 	/// Runs generated validation.
 	fn runtime_validate(&self) -> Result<(), FormValidationError<Self::Field>> {
 		Ok(())
@@ -536,6 +548,8 @@ fn build_signal_sync_effect<Form>(
 	default_values: Rc<RefCell<Form::Values>>,
 	state: FormState<Form::Field>,
 	touched_fields: Rc<RefCell<HashMap<Form::Field, bool>>>,
+	touched_collections: Rc<RefCell<HashMap<String, bool>>>,
+	touched_paths: Rc<RefCell<HashMap<String, bool>>>,
 	collection_errors: Signal<HashMap<String, FieldError>>,
 	path_errors: Signal<HashMap<String, FieldError>>,
 	values_signal: Signal<Form::Values>,
@@ -558,6 +572,22 @@ where
 				.filter(|field| form.runtime_field_is_dirty(*field, &current, &previous))
 				.collect();
 			let values_changed = form.runtime_values_are_dirty(&current, &previous);
+			let current_path_values = form.runtime_path_values_from_values(&current);
+			let previous_path_values = form.runtime_path_values_from_values(&previous);
+			let changed_path_keys: Vec<String> = current_path_values
+				.keys()
+				.filter(|path_key| {
+					previous_path_values
+						.get(*path_key)
+						.and_then(|previous_value| {
+							form.runtime_path_value_equals(path_key, previous_value.as_ref())
+						})
+						.map(|matches_current| !matches_current)
+						.unwrap_or(true)
+				})
+				.cloned()
+				.collect();
+			let changed_collection_keys = form.runtime_changed_collection_keys(&current, &previous);
 			*observed_values.borrow_mut() = current.clone();
 
 			if signal_sync_suppressed.get() || (changed_fields.is_empty() && !values_changed) {
@@ -567,6 +597,22 @@ where
 			for field in &changed_fields {
 				touched_fields.borrow_mut().insert(*field, true);
 			}
+			for collection_key in changed_collection_keys {
+				touched_collections
+					.borrow_mut()
+					.insert(collection_key, true);
+			}
+			{
+				let mut touched_paths = touched_paths.borrow_mut();
+				touched_paths.retain(|path_key, _| current_path_values.contains_key(path_key));
+				for path_key in changed_path_keys {
+					touched_paths.insert(path_key, true);
+				}
+			}
+			let mut path_errors_map = path_errors.get();
+			path_errors_map.retain(|path_key, _| current_path_values.contains_key(path_key));
+			path_errors.set(path_errors_map);
+			form.runtime_sync_path_signals();
 			state.is_touched.set(true);
 			state.is_dirty.set(form_values_are_dirty(
 				&form,
@@ -799,6 +845,8 @@ where
 			Rc::clone(&default_values),
 			state.clone(),
 			Rc::clone(&touched_fields),
+			Rc::clone(&touched_collections),
+			Rc::clone(&touched_paths),
 			collection_errors.clone(),
 			path_errors.clone(),
 			values_signal.clone(),

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -327,9 +327,10 @@ pub use form::{FormBinding, FormComponent};
 // Static form metadata types (always available, used by form! macro)
 pub use form_generated::{StaticFieldMetadata, StaticFormMetadata};
 pub use form_state::{
-	FieldError, FieldState, FocusError, FormEvent, FormRuntimeSource, FormState, FormSubscription,
-	FormValidationError, NoDeps, ResetOnDeps, RevalidateOn, UseFormBuilder, UseFormReturn,
-	UseFormSubmitOutcome, use_form,
+	CollectionItem, CollectionItemKey, CollectionState, FieldError, FieldPathState, FieldState,
+	FocusError, FormCollectionRuntimeSource, FormEvent, FormRuntimeSource, FormState,
+	FormSubscription, FormValidationError, NoDeps, ResetOnDeps, RevalidateOn, UseFormBuilder,
+	UseFormReturn, UseFormSubmitOutcome, use_form,
 };
 pub use hydration::{HydrationContext, HydrationError, hydrate};
 pub use portal::{Portal, PortalError, PortalHandle, PortalTarget, mount_portal};

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -182,9 +182,10 @@ pub use crate::static_resolver::{init_static_resolver, is_initialized, resolve_s
 // ============================================================================
 
 pub use crate::form_state::{
-	FieldError, FieldState, FocusError, FormEvent, FormRuntimeSource, FormState, FormSubscription,
-	FormValidationError, NoDeps, ResetOnDeps, RevalidateOn, UseFormBuilder, UseFormReturn,
-	UseFormSubmitOutcome, use_form,
+	CollectionItem, CollectionItemKey, CollectionState, FieldError, FieldPathState, FieldState,
+	FocusError, FormCollectionRuntimeSource, FormEvent, FormRuntimeSource, FormState,
+	FormSubscription, FormValidationError, NoDeps, ResetOnDeps, RevalidateOn, UseFormBuilder,
+	UseFormReturn, UseFormSubmitOutcome, use_form,
 };
 
 #[cfg(native)]

--- a/crates/reinhardt-pages/tests/ui/form/pass/field_array_values.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/field_array_values.rs
@@ -1,0 +1,43 @@
+//! form! emits collection value scaffolding for FieldArray.
+
+use reinhardt_pages::{form, use_form};
+
+fn main() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			customer_name: CharField {
+				required,
+			}
+			line_items: FieldArray {
+				fields: {
+					description: CharField {
+						required,
+					}
+					quantity: IntegerField {
+						required,
+					}
+				}
+			}
+		}
+	};
+
+	let runtime = use_form(&invoice).build();
+	let values = runtime.get_values();
+	let _customer_name: &String = &values.customer_name;
+	let _line_items_len = values.line_items.len();
+	let _item_fields = values.line_items.first().map(|item| {
+		let _description: &String = &item.description;
+		let _quantity: i64 = item.quantity;
+	});
+	let line_item_signals = invoice.line_items().get();
+	assert!(line_item_signals.is_empty());
+	let _signal_item_fields = line_item_signals.first().map(|item| {
+		let _key = item.key();
+		let _index: usize = item.index();
+		let _description: &String = &item.value().description;
+		let _quantity: i64 = item.value().quantity;
+	});
+	let _collection = invoice.line_items_collection();
+}

--- a/crates/reinhardt-pages/tests/ui/form/pass/field_array_values.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/field_array_values.rs
@@ -32,12 +32,27 @@ fn main() {
 		let _quantity: i64 = item.quantity;
 	});
 	let line_item_signals = invoice.line_items().get();
-	assert!(line_item_signals.is_empty());
-	let _signal_item_fields = line_item_signals.first().map(|item| {
+	let _line_item_signals: Vec<_> = line_item_signals;
+	let _signal_item_fields = _line_item_signals.first().map(|item| {
 		let _key = item.key();
 		let _index: usize = item.index();
 		let _description: &String = &item.value().description;
 		let _quantity: i64 = item.value().quantity;
 	});
 	let _collection = invoice.line_items_collection();
+
+	let addresses = form! {
+		name: Addresses,
+		action: "/addresses",
+		fields: {
+			addresses: FieldArray {
+				fields: {
+					street: CharField {}
+				}
+			}
+		}
+	};
+	let _addresses_runtime = use_form(&addresses).build();
+	let _address_item = addresses.new_addresses_item();
+	let _addresses_collection = addresses.addresses_collection();
 }

--- a/crates/reinhardt-pages/tests/use_form_integration.rs
+++ b/crates/reinhardt-pages/tests/use_form_integration.rs
@@ -656,11 +656,11 @@ fn collection_path_state_follows_item_key_across_reorder() {
 		fields: {
 			line_items: FieldArray {
 				fields: {
-						description: CharField {}
-						quantity: IntegerField {}
-					}
+					description: CharField {}
+					quantity: IntegerField {}
 				}
 			}
+		}
 	};
 	let runtime = use_form(&invoice).build();
 	let collection = invoice.line_items_collection();

--- a/crates/reinhardt-pages/tests/use_form_integration.rs
+++ b/crates/reinhardt-pages/tests/use_form_integration.rs
@@ -4,7 +4,8 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use reinhardt_pages::{
-	FieldError, FormEvent, ResetOnDeps, RevalidateOn, UseFormSubmitOutcome, form, use_form,
+	CollectionItem, CollectionItemKey, FieldError, FormEvent, ResetOnDeps, RevalidateOn,
+	UseFormSubmitOutcome, form, use_form,
 };
 
 #[test]
@@ -225,6 +226,802 @@ fn use_form_accepts_json_field_runtime_contracts() {
 		runtime.get_values().payload,
 		::serde_json::json!({"theme": "dark"})
 	);
+}
+
+#[test]
+fn use_form_pushes_inserts_removes_and_moves_collection_items() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			customer_name: CharField {
+				initial: "Ada",
+			}
+			line_items: FieldArray {
+				fields: {
+					description: CharField {
+						required,
+					}
+					quantity: IntegerField {
+						required,
+					}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice).build();
+	let values = runtime.watch();
+	let collection = invoice.line_items_collection();
+	let new_line_item = |description: &str, quantity: i64| {
+		let mut item = invoice.new_line_items_item();
+		item.description = description.to_string();
+		item.quantity = quantity;
+		item
+	};
+
+	assert!(runtime.get_values().line_items.is_empty());
+	assert!(!runtime.form_state().is_dirty.get());
+	assert!(!runtime.form_state().is_touched.get());
+
+	let keyboard_key = runtime.push_item(collection, new_line_item("Keyboard", 2));
+	let mouse_key = runtime.push_item(collection, new_line_item("Mouse", 1));
+	let monitor_key = runtime.insert_item(collection, 1, new_line_item("Monitor", 3));
+
+	assert_eq!(
+		runtime
+			.get_values()
+			.line_items
+			.iter()
+			.map(|item| item.description.as_str())
+			.collect::<Vec<_>>(),
+		vec!["Keyboard", "Monitor", "Mouse"]
+	);
+	assert_eq!(
+		invoice
+			.line_items()
+			.get()
+			.iter()
+			.map(|item| (item.key(), item.index()))
+			.collect::<Vec<_>>(),
+		vec![(keyboard_key, 0), (monitor_key, 1), (mouse_key, 2)]
+	);
+	assert_eq!(values.get().line_items.len(), 3);
+	assert!(runtime.form_state().is_dirty.get());
+	assert!(runtime.form_state().is_touched.get());
+
+	assert_eq!(runtime.move_item(collection, mouse_key, 0), Some((2, 0)));
+	assert_eq!(
+		runtime
+			.get_values()
+			.line_items
+			.iter()
+			.map(|item| item.description.as_str())
+			.collect::<Vec<_>>(),
+		vec!["Mouse", "Keyboard", "Monitor"]
+	);
+	assert_eq!(
+		invoice
+			.line_items()
+			.get()
+			.iter()
+			.map(|item| (item.key(), item.index()))
+			.collect::<Vec<_>>(),
+		vec![(mouse_key, 0), (keyboard_key, 1), (monitor_key, 2)]
+	);
+
+	assert!(runtime.remove_item(collection, keyboard_key));
+	assert!(!runtime.remove_item(collection, keyboard_key));
+	assert_eq!(runtime.move_item(collection, keyboard_key, 0), None);
+	assert_eq!(
+		runtime
+			.get_values()
+			.line_items
+			.iter()
+			.map(|item| item.description.as_str())
+			.collect::<Vec<_>>(),
+		vec!["Mouse", "Monitor"]
+	);
+	assert_eq!(
+		invoice
+			.line_items()
+			.get()
+			.iter()
+			.map(|item| (item.key(), item.index()))
+			.collect::<Vec<_>>(),
+		vec![(mouse_key, 0), (monitor_key, 1)]
+	);
+
+	assert!(runtime.remove_item(collection, mouse_key));
+	assert!(runtime.remove_item(collection, monitor_key));
+	assert!(runtime.get_values().line_items.is_empty());
+	assert!(values.get().line_items.is_empty());
+	assert!(!runtime.form_state().is_dirty.get());
+	assert!(runtime.form_state().is_touched.get());
+
+	let seeded_runtime = use_form(&invoice).build();
+	let mut seeded_values = seeded_runtime.get_values();
+	seeded_values
+		.line_items
+		.push(new_line_item("Replacement cable", 4));
+	seeded_values
+		.line_items
+		.push(new_line_item("Docking station", 1));
+	seeded_runtime.set_values(seeded_values);
+	assert!(seeded_runtime.form_state().is_dirty.get());
+	assert_eq!(seeded_runtime.watch().get().line_items.len(), 2);
+
+	let generated_keys = invoice
+		.line_items()
+		.get()
+		.iter()
+		.map(|item| item.key())
+		.collect::<Vec<_>>();
+	let extra_key = seeded_runtime.push_item(collection, new_line_item("Stand", 2));
+	assert!(!generated_keys.contains(&extra_key));
+
+	let keys = invoice
+		.line_items()
+		.get()
+		.iter()
+		.map(|item| item.key())
+		.collect::<Vec<_>>();
+	for (index, key) in keys.iter().enumerate() {
+		assert!(!keys[index + 1..].contains(key));
+	}
+}
+
+#[test]
+fn field_array_renders_runtime_items_with_deterministic_names() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			customer_name: CharField {
+				initial: "Ada",
+			}
+			line_items: FieldArray {
+				label: "Line items",
+				class: "invoice-lines",
+				min_items: 1,
+				max_items: 3,
+				fields: {
+					description: CharField {
+						label: "Description",
+						required,
+					}
+					quantity: IntegerField {
+						label: "Quantity",
+						required,
+					}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice).build();
+	let collection = invoice.line_items_collection();
+	let mut first = invoice.new_line_items_item();
+	first.description = "Keyboard".to_string();
+	first.quantity = 2;
+	let mut second = invoice.new_line_items_item();
+	second.description = "Mouse".to_string();
+	second.quantity = 1;
+
+	let first_key = runtime.push_item(collection, first);
+	let second_key = runtime.push_item(collection, second);
+	let html = invoice.clone().into_page().render_to_string();
+
+	assert!(html.contains(r#"<fieldset class="invoice-lines""#));
+	assert!(html.contains(r#"data-reinhardt-field-array="line_items""#));
+	assert!(html.contains(r#"data-reinhardt-min-items="1""#));
+	assert!(html.contains(r#"data-reinhardt-max-items="3""#));
+	assert!(html.contains(r#"<legend class="reinhardt-field-array-label">Line items</legend>"#));
+	assert!(html.contains(&format!(r#"data-reinhardt-item-key="{first_key:?}""#)));
+	assert!(html.contains(&format!(r#"data-reinhardt-item-key="{second_key:?}""#)));
+	assert!(html.contains(r#"name="line_items[0][description]""#));
+	assert!(html.contains(r#"id="line_items_0_description""#));
+	assert!(html.contains(r#"value="Keyboard""#));
+	assert!(html.contains(r#"name="line_items[1][quantity]""#));
+	assert!(html.contains(r#"id="line_items_1_quantity""#));
+	assert!(html.contains(r#"value="1""#));
+
+	assert_eq!(runtime.move_item(collection, second_key, 0), Some((1, 0)));
+	let moved_html = invoice.into_page().render_to_string();
+	assert!(moved_html.contains(r#"name="line_items[0][description]""#));
+	assert!(moved_html.contains(r#"value="Mouse""#));
+	assert!(moved_html.contains(r#"name="line_items[1][description]""#));
+	assert!(moved_html.contains(r#"value="Keyboard""#));
+}
+
+#[test]
+fn field_array_required_validation_sets_path_errors_by_item_key() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			line_items: FieldArray {
+				fields: {
+					description: CharField {
+						required,
+					}
+					quantity: IntegerField {
+						required,
+					}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice).build();
+	let collection = invoice.line_items_collection();
+	let mut first = invoice.new_line_items_item();
+	first.quantity = 2;
+	let mut second = invoice.new_line_items_item();
+	second.description = "Mouse".to_string();
+	second.quantity = 1;
+
+	let first_key = runtime.push_item(collection, first);
+	let second_key = runtime.push_item(collection, second);
+	let first_description_path = invoice.line_items_description_path(first_key);
+	let second_description_path = invoice.line_items_description_path(second_key);
+
+	let result = runtime
+		.trigger()
+		.expect_err("empty required collection field should fail validation");
+	assert!(result.field_errors().is_empty());
+	assert_eq!(result.path_errors().len(), 1);
+	assert_eq!(
+		runtime
+			.get_path_state(first_description_path.clone())
+			.error
+			.as_ref()
+			.map(FieldError::message),
+		Some("line_items.description is required"),
+	);
+	assert!(
+		runtime
+			.get_path_state(second_description_path)
+			.error
+			.is_none()
+	);
+
+	assert_eq!(runtime.move_item(collection, first_key, 1), Some((0, 1)));
+	let result = runtime
+		.trigger()
+		.expect_err("reordered empty required collection field should still fail validation");
+	assert_eq!(result.path_errors().len(), 1);
+	assert_eq!(
+		runtime
+			.get_path_state(first_description_path.clone())
+			.error
+			.as_ref()
+			.map(FieldError::message),
+		Some("line_items.description is required"),
+	);
+
+	runtime.set_path_value(first_description_path.clone(), "Keyboard".to_string());
+	runtime
+		.trigger()
+		.expect("filled required collection field should pass validation");
+	assert!(
+		runtime
+			.get_path_state(first_description_path)
+			.error
+			.is_none()
+	);
+}
+
+#[test]
+fn field_array_min_and_max_items_set_collection_errors() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			line_items: FieldArray {
+				min_items: 1,
+				max_items: 2,
+				fields: {
+					description: CharField {}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice).build();
+	let collection = invoice.line_items_collection();
+
+	let result = runtime
+		.trigger()
+		.expect_err("empty collection should fail min_items validation");
+	assert_eq!(result.collection_errors().len(), 1);
+	assert_eq!(
+		runtime
+			.get_collection_state(collection)
+			.error
+			.as_ref()
+			.map(FieldError::message),
+		Some("line_items requires at least 1 item"),
+	);
+
+	for description in ["A", "B", "C"] {
+		let mut item = invoice.new_line_items_item();
+		item.description = description.to_string();
+		runtime.push_item(collection, item);
+	}
+
+	let result = runtime
+		.trigger()
+		.expect_err("oversized collection should fail max_items validation");
+	assert_eq!(result.collection_errors().len(), 1);
+	let collection_state = runtime.get_collection_state(collection);
+	assert_eq!(collection_state.len, 3);
+	assert!(collection_state.is_touched);
+	assert!(collection_state.is_dirty);
+	assert_eq!(
+		collection_state.error.as_ref().map(FieldError::message),
+		Some("line_items allows at most 2 items"),
+	);
+}
+
+#[test]
+fn use_form_watches_and_sets_collection_field_paths() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			line_items: FieldArray {
+				fields: {
+					description: CharField {
+						required,
+					}
+					quantity: IntegerField {
+						required,
+					}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice).build();
+	let collection = invoice.line_items_collection();
+	let mut item = invoice.new_line_items_item();
+	item.description = "Keyboard".to_string();
+	item.quantity = 2;
+
+	let key = runtime.push_item(collection, item);
+	let quantity_path = invoice.line_items_quantity_path(key);
+	let description_path = invoice.line_items_description_path(key);
+	let quantity = runtime.watch_path::<i64>(quantity_path.clone());
+	let description = runtime.watch_path::<String>(description_path.clone());
+
+	assert_eq!(quantity.get(), 2);
+	assert_eq!(description.get(), "Keyboard".to_string());
+	assert!(runtime.get_path_state(quantity_path.clone()).is_dirty);
+	assert!(!runtime.get_path_state(quantity_path.clone()).is_touched);
+
+	runtime.reset_default_values();
+
+	assert!(!runtime.get_path_state(quantity_path.clone()).is_dirty);
+
+	runtime.set_path_value(quantity_path.clone(), 3_i64);
+
+	assert_eq!(quantity.get(), 3);
+	assert_eq!(runtime.get_values().line_items[0].quantity, 3);
+	assert_eq!(runtime.watch().get().line_items[0].quantity, 3);
+	assert!(runtime.get_path_state(quantity_path.clone()).is_touched);
+	assert!(runtime.get_path_state(quantity_path.clone()).is_dirty);
+
+	let updated_item = invoice
+		.line_items()
+		.get()
+		.into_iter()
+		.next()
+		.map(|item| {
+			let mut value = item.into_value();
+			value.quantity = 5;
+			CollectionItem::new(key, 0, value)
+		})
+		.expect("line item exists");
+	invoice.line_items().set(vec![updated_item]);
+
+	let quantity_after_direct_set = runtime.watch_path::<i64>(quantity_path.clone());
+	assert_eq!(quantity_after_direct_set.get(), 5);
+	assert_eq!(quantity.get(), 5);
+
+	runtime.set_path_value(description_path.clone(), "Mechanical keyboard".to_string());
+
+	assert_eq!(description.get(), "Mechanical keyboard".to_string());
+	assert_eq!(
+		runtime.get_values().line_items[0].description,
+		"Mechanical keyboard".to_string()
+	);
+	assert!(runtime.get_path_state(description_path.clone()).is_touched);
+
+	assert!(runtime.remove_item(collection, key));
+	assert!(
+		::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+			runtime.watch_path::<String>(description_path.clone());
+		}))
+		.is_err()
+	);
+	assert!(
+		::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+			runtime.set_path_value(quantity_path.clone(), 4_i64);
+		}))
+		.is_err()
+	);
+}
+
+#[test]
+fn collection_path_state_follows_item_key_across_reorder() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			line_items: FieldArray {
+				fields: {
+						description: CharField {}
+						quantity: IntegerField {}
+					}
+				}
+			}
+	};
+	let runtime = use_form(&invoice).build();
+	let collection = invoice.line_items_collection();
+	let new_line_item = |description: &str, quantity: i64| {
+		let mut item = invoice.new_line_items_item();
+		item.description = description.to_string();
+		item.quantity = quantity;
+		item
+	};
+
+	let first = runtime.push_item(collection, new_line_item("Compiler", 1));
+	let second = runtime.push_item(collection, new_line_item("Notebook", 2));
+	let first_quantity = invoice.line_items_quantity_path(first);
+
+	runtime.reset_default_values();
+	assert!(!runtime.get_path_state(first_quantity.clone()).is_dirty);
+	assert_eq!(runtime.move_item(collection, first, 1), Some((0, 1)));
+	assert_eq!(runtime.get_values().line_items[1].quantity, 1);
+	assert!(!runtime.get_path_state(first_quantity.clone()).is_dirty);
+
+	runtime.set_path_value(first_quantity.clone(), 5_i64);
+	runtime.set_path_error(first_quantity.clone(), FieldError::new("invalid quantity"));
+
+	assert_eq!(runtime.get_values().line_items[1].quantity, 5);
+	let first_quantity_state = runtime.get_path_state(first_quantity.clone());
+	assert!(first_quantity_state.is_dirty);
+	assert!(first_quantity_state.is_touched);
+	assert_eq!(
+		first_quantity_state.error.as_ref().map(FieldError::message),
+		Some("invalid quantity")
+	);
+
+	let removed_quantity = invoice.line_items_quantity_path(second);
+	runtime.set_path_value(removed_quantity.clone(), 3_i64);
+	runtime.set_path_error(
+		removed_quantity.clone(),
+		FieldError::new("removed quantity"),
+	);
+
+	assert!(runtime.remove_item(collection, second));
+	assert_eq!(runtime.get_values().line_items.len(), 1);
+	let removed_quantity_state = runtime.get_path_state(removed_quantity);
+	assert!(!removed_quantity_state.is_touched);
+	assert_eq!(removed_quantity_state.error, None);
+}
+
+#[test]
+fn reconcile_defaults_preserves_path_defaults_across_dirty_reorder() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			line_items: FieldArray {
+				fields: {
+					description: CharField {}
+					quantity: IntegerField {}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice)
+		.deps(0_u8)
+		.reset_on_deps(ResetOnDeps::KeepDirtyValues)
+		.build();
+	let collection = invoice.line_items_collection();
+	let new_line_item = |description: &str, quantity: i64| {
+		let mut item = invoice.new_line_items_item();
+		item.description = description.to_string();
+		item.quantity = quantity;
+		item
+	};
+
+	let first = runtime.push_item(collection, new_line_item("Compiler", 1));
+	let second = runtime.push_item(collection, new_line_item("Notebook", 2));
+	let first_quantity = invoice.line_items_quantity_path(first);
+	runtime.reset_default_values();
+	let defaults = runtime.default_values();
+
+	assert_eq!(runtime.move_item(collection, first, 1), Some((0, 1)));
+	assert_eq!(
+		runtime
+			.get_values()
+			.line_items
+			.iter()
+			.map(|item| item.description.as_str())
+			.collect::<Vec<_>>(),
+		vec!["Notebook", "Compiler"]
+	);
+	runtime.reconcile_defaults(defaults, 1_u8);
+
+	assert_eq!(runtime.get_values().line_items[1].quantity, 1);
+	assert!(!runtime.get_path_state(first_quantity).is_dirty);
+	assert_eq!(runtime.move_item(collection, second, 0), Some((0, 0)));
+}
+
+#[test]
+fn set_values_clears_replaced_collection_path_state() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			line_items: FieldArray {
+				fields: {
+					description: CharField {}
+					quantity: IntegerField {}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice).build();
+	let collection = invoice.line_items_collection();
+	let mut item = invoice.new_line_items_item();
+	item.description = "Compiler".to_string();
+	item.quantity = 1;
+	let key = runtime.push_item(collection, item);
+	let quantity_path = invoice.line_items_quantity_path(key);
+
+	runtime.set_path_value(quantity_path.clone(), 2_i64);
+	runtime.set_path_error(quantity_path.clone(), FieldError::new("stale quantity"));
+	assert_eq!(
+		runtime.form_state().error.get(),
+		Some("stale quantity".to_string())
+	);
+
+	let mut values = runtime.get_values();
+	values.line_items.clear();
+	runtime.set_values(values);
+
+	assert_eq!(runtime.form_state().error.get(), None);
+	let quantity_state = runtime.get_path_state(quantity_path.clone());
+	assert!(!quantity_state.is_touched);
+	assert_eq!(quantity_state.error, None);
+	assert!(
+		::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+			runtime.watch_path::<i64>(quantity_path.clone());
+		}))
+		.is_err()
+	);
+}
+
+#[test]
+fn reconcile_defaults_clears_collection_path_errors_when_errors_are_kept() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			line_items: FieldArray {
+				fields: {
+					description: CharField {}
+					quantity: IntegerField {}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice)
+		.deps(0_u8)
+		.reset_on_deps(ResetOnDeps::ResetAll)
+		.keep_errors(true)
+		.build();
+	let collection = invoice.line_items_collection();
+	let mut item = invoice.new_line_items_item();
+	item.description = "Compiler".to_string();
+	item.quantity = 1;
+	let key = runtime.push_item(collection, item);
+	let quantity_path = invoice.line_items_quantity_path(key);
+
+	runtime.set_path_error(quantity_path.clone(), FieldError::new("old path error"));
+	assert_eq!(
+		runtime.form_state().error.get(),
+		Some("old path error".to_string())
+	);
+
+	let mut defaults = runtime.get_values();
+	defaults.line_items.clear();
+	runtime.reconcile_defaults(defaults, 1_u8);
+
+	assert_eq!(runtime.form_state().error.get(), None);
+	assert_eq!(runtime.get_values().line_items.len(), 0);
+	assert_eq!(runtime.get_path_state(quantity_path).error, None);
+}
+
+#[test]
+fn use_form_marks_collection_only_set_values_dirty() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			customer_name: CharField {
+				initial: "Ada",
+			}
+			line_items: FieldArray {
+				fields: {
+					description: CharField {
+						required,
+					}
+					quantity: IntegerField {
+						required,
+					}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice).build();
+	let _collection = invoice.line_items_collection();
+	let watched_values = runtime.watch();
+	let mut values = runtime.get_values();
+	let mut item = invoice.new_line_items_item();
+	item.description = "Replacement cable".to_string();
+	item.quantity = 4;
+
+	values.line_items.push(item);
+	runtime.set_values(values);
+
+	assert_eq!(runtime.get_values().customer_name, "Ada".to_string());
+	assert_eq!(runtime.get_values().line_items.len(), 1);
+	assert_eq!(watched_values.get().line_items.len(), 1);
+	assert!(runtime.form_state().is_dirty.get());
+	assert!(runtime.form_state().is_touched.get());
+}
+
+#[test]
+fn use_form_syncs_direct_collection_signal_changes() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			customer_name: CharField {
+				initial: "Ada",
+			}
+			line_items: FieldArray {
+				fields: {
+					description: CharField {
+						required,
+					}
+					quantity: IntegerField {
+						required,
+					}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice)
+		.revalidate_on(RevalidateOn::Change)
+		.build();
+	let _collection = invoice.line_items_collection();
+	let watched_values = runtime.watch();
+	let event_count = Rc::new(Cell::new(0));
+	let event_count_for_subscription = Rc::clone(&event_count);
+	let validated_count = Rc::new(Cell::new(0));
+	let validated_count_for_subscription = Rc::clone(&validated_count);
+	let _subscription = runtime.subscribe(move |event| {
+		if matches!(event, FormEvent::ValueChanged { .. }) {
+			event_count_for_subscription.set(event_count_for_subscription.get() + 1);
+		}
+		if matches!(event, FormEvent::Validated) {
+			validated_count_for_subscription.set(validated_count_for_subscription.get() + 1);
+		}
+	});
+	let mut item = invoice.new_line_items_item();
+	item.description = "Docking station".to_string();
+	item.quantity = 1;
+
+	invoice.line_items().set(vec![CollectionItem::new(
+		CollectionItemKey::from_runtime_index(0),
+		0,
+		item,
+	)]);
+
+	assert_eq!(runtime.get_values().customer_name, "Ada".to_string());
+	assert_eq!(
+		runtime.get_values().line_items[0].description,
+		"Docking station".to_string()
+	);
+	assert_eq!(watched_values.get().line_items.len(), 1);
+	assert!(runtime.form_state().is_dirty.get());
+	assert!(runtime.form_state().is_touched.get());
+	assert_eq!(event_count.get(), 0);
+	assert_eq!(validated_count.get(), 1);
+}
+
+#[test]
+fn deps_reconciliation_updates_pristine_collections_and_preserves_dirty_collections() {
+	let pristine_invoice = form! {
+		name: PristineInvoiceForm,
+		action: "/invoices",
+		fields: {
+			customer_name: CharField {
+				initial: "Ada",
+			}
+			line_items: FieldArray {
+				fields: {
+					description: CharField {}
+					quantity: IntegerField {}
+				}
+			}
+		}
+	};
+	let pristine_runtime = use_form(&pristine_invoice)
+		.deps((1_u64,))
+		.reset_on_deps(ResetOnDeps::KeepDirtyValues)
+		.build();
+	let _pristine_collection = pristine_invoice.line_items_collection();
+	let mut refreshed_defaults = pristine_runtime.default_values();
+	let mut default_item = pristine_invoice.new_line_items_item();
+	default_item.description = "Default cable".to_string();
+	default_item.quantity = 2;
+	refreshed_defaults.line_items.push(default_item);
+
+	pristine_runtime.reconcile_defaults(refreshed_defaults, (2_u64,));
+
+	assert_eq!(
+		pristine_runtime.get_values().line_items[0].description,
+		"Default cable".to_string()
+	);
+	assert_eq!(pristine_runtime.watch().get().line_items.len(), 1);
+	assert!(!pristine_runtime.form_state().is_dirty.get());
+
+	let dirty_invoice = form! {
+		name: DirtyInvoiceForm,
+		action: "/invoices",
+		fields: {
+			customer_name: CharField {
+				initial: "Ada",
+			}
+			line_items: FieldArray {
+				fields: {
+					description: CharField {}
+					quantity: IntegerField {}
+				}
+			}
+		}
+	};
+	let dirty_runtime = use_form(&dirty_invoice)
+		.deps((1_u64,))
+		.reset_on_deps(ResetOnDeps::KeepDirtyValues)
+		.build();
+	let dirty_collection = dirty_invoice.line_items_collection();
+	let mut user_item = dirty_invoice.new_line_items_item();
+	user_item.description = "User stand".to_string();
+	user_item.quantity = 1;
+	dirty_runtime.push_item(dirty_collection, user_item);
+
+	let mut dirty_refreshed_defaults = dirty_runtime.default_values();
+	let mut changed_default_item = dirty_invoice.new_line_items_item();
+	changed_default_item.description = "Default dock".to_string();
+	changed_default_item.quantity = 4;
+	dirty_refreshed_defaults
+		.line_items
+		.push(changed_default_item);
+
+	dirty_runtime.reconcile_defaults(dirty_refreshed_defaults, (2_u64,));
+
+	assert_eq!(
+		dirty_runtime.get_values().line_items[0].description,
+		"User stand".to_string()
+	);
+	assert_eq!(
+		dirty_runtime.default_values().line_items[0].description,
+		"Default dock".to_string()
+	);
+	assert!(dirty_runtime.form_state().is_dirty.get());
 }
 
 #[test]

--- a/crates/reinhardt-pages/tests/use_form_integration.rs
+++ b/crates/reinhardt-pages/tests/use_form_integration.rs
@@ -796,6 +796,54 @@ fn use_form_watches_and_sets_collection_field_paths() {
 }
 
 #[test]
+fn direct_collection_signal_set_syncs_path_watchers_and_state() {
+	let invoice = form! {
+		name: InvoiceForm,
+		action: "/invoices",
+		fields: {
+			line_items: FieldArray {
+				fields: {
+					description: CharField {}
+					quantity: IntegerField {}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&invoice).build();
+	let collection = invoice.line_items_collection();
+	let key = CollectionItemKey::from_runtime_index(0);
+	let mut item = invoice.new_line_items_item();
+	item.description = "Keyboard".to_string();
+	item.quantity = 2;
+
+	invoice
+		.line_items()
+		.set(vec![CollectionItem::new(key, 0, item)]);
+
+	let quantity_path = invoice.line_items_quantity_path(key);
+	let quantity = runtime.watch_path::<i64>(quantity_path.clone());
+	assert_eq!(quantity.get(), 2);
+	assert!(runtime.get_collection_state(collection).is_touched);
+	assert!(runtime.get_path_state(quantity_path.clone()).is_touched);
+
+	let mut updated_item = invoice
+		.line_items()
+		.get()
+		.into_iter()
+		.next()
+		.expect("line item exists")
+		.into_value();
+	updated_item.quantity = 5;
+	invoice
+		.line_items()
+		.set(vec![CollectionItem::new(key, 0, updated_item)]);
+
+	assert_eq!(quantity.get(), 5);
+	assert_eq!(runtime.get_values().line_items[0].quantity, 5);
+	assert!(runtime.get_path_state(quantity_path).is_touched);
+}
+
+#[test]
 fn collection_path_state_follows_item_key_across_reorder() {
 	let invoice = form! {
 		name: InvoiceForm,

--- a/crates/reinhardt-pages/tests/use_form_integration.rs
+++ b/crates/reinhardt-pages/tests/use_form_integration.rs
@@ -8,6 +8,87 @@ use reinhardt_pages::{
 	UseFormSubmitOutcome, form, use_form,
 };
 
+fn first_tag_html(html: &str, tag: &str) -> String {
+	let start = format!("<{tag}");
+	let start_index = html
+		.find(&start)
+		.expect("tag should exist in rendered HTML");
+	let tag_html = &html[start_index..];
+	let end_index = tag_html
+		.find('>')
+		.expect("tag should close in rendered HTML");
+	tag_html[..=end_index].to_string()
+}
+
+fn first_element_html(html: &str, tag: &str) -> String {
+	let start = format!("<{tag}");
+	let end = format!("</{tag}>");
+	let start_index = html
+		.find(&start)
+		.expect("element should exist in rendered HTML");
+	let element_html = &html[start_index..];
+	let end_index = element_html
+		.find(&end)
+		.expect("element should close in rendered HTML")
+		+ end.len();
+	element_html[..end_index].to_string()
+}
+
+fn attr_values(html: &str, attr: &str) -> Vec<String> {
+	let pattern = format!("{attr}=\"");
+	let mut values = Vec::new();
+	let mut rest = html;
+	while let Some((_, after_pattern)) = rest.split_once(&pattern) {
+		let (value, after_value) = after_pattern
+			.split_once('"')
+			.expect("attribute value should close in rendered HTML");
+		values.push(value.to_string());
+		rest = after_value;
+	}
+	values
+}
+
+fn input_tags(html: &str) -> Vec<String> {
+	let mut tags = Vec::new();
+	let mut rest = html;
+	while let Some(start_index) = rest.find("<input") {
+		let after_start = &rest[start_index..];
+		let end_index = after_start
+			.find('>')
+			.expect("input tag should close in rendered HTML");
+		tags.push(after_start[..=end_index].to_string());
+		rest = &after_start[end_index + 1..];
+	}
+	tags
+}
+
+fn attr_value(tag: &str, attr: &str) -> Option<String> {
+	let pattern = format!("{attr}=\"");
+	let (_, after_pattern) = tag.split_once(&pattern)?;
+	let (value, _) = after_pattern.split_once('"')?;
+	Some(value.to_string())
+}
+
+fn input_attr_values_for_name_prefix(html: &str, prefix: &str, attr: &str) -> Vec<String> {
+	input_tags(html)
+		.into_iter()
+		.filter(|tag| {
+			attr_value(tag, "name")
+				.as_deref()
+				.is_some_and(|name| name.starts_with(prefix))
+		})
+		.map(|tag| {
+			attr_value(&tag, attr).unwrap_or_else(|| {
+				panic!("input tag with matching name should have {attr} attribute")
+			})
+		})
+		.collect()
+}
+
+fn string_values(values: &[&str]) -> Vec<String> {
+	values.iter().map(|value| (*value).to_string()).collect()
+}
+
 #[test]
 fn use_form_builds_runtime_from_generated_form_contract() {
 	let profile = form! {
@@ -410,26 +491,92 @@ fn field_array_renders_runtime_items_with_deterministic_names() {
 	let second_key = runtime.push_item(collection, second);
 	let html = invoice.clone().into_page().render_to_string();
 
-	assert!(html.contains(r#"<fieldset class="invoice-lines""#));
-	assert!(html.contains(r#"data-reinhardt-field-array="line_items""#));
-	assert!(html.contains(r#"data-reinhardt-min-items="1""#));
-	assert!(html.contains(r#"data-reinhardt-max-items="3""#));
-	assert!(html.contains(r#"<legend class="reinhardt-field-array-label">Line items</legend>"#));
-	assert!(html.contains(&format!(r#"data-reinhardt-item-key="{first_key:?}""#)));
-	assert!(html.contains(&format!(r#"data-reinhardt-item-key="{second_key:?}""#)));
-	assert!(html.contains(r#"name="line_items[0][description]""#));
-	assert!(html.contains(r#"id="line_items_0_description""#));
-	assert!(html.contains(r#"value="Keyboard""#));
-	assert!(html.contains(r#"name="line_items[1][quantity]""#));
-	assert!(html.contains(r#"id="line_items_1_quantity""#));
-	assert!(html.contains(r#"value="1""#));
+	assert_eq!(
+		first_tag_html(&html, "fieldset"),
+		r#"<fieldset class="invoice-lines" data-reinhardt-field-array="line_items" data-reinhardt-min-items="1" data-reinhardt-max-items="3">"#
+	);
+	assert_eq!(
+		first_element_html(&html, "legend"),
+		r#"<legend class="reinhardt-field-array-label">Line items</legend>"#
+	);
+	assert_eq!(
+		attr_values(&html, "data-reinhardt-item-key"),
+		vec![format!("{first_key:?}"), format!("{second_key:?}"),]
+	);
+	assert_eq!(
+		input_attr_values_for_name_prefix(&html, "line_items[", "name"),
+		string_values(&[
+			"line_items[0][description]",
+			"line_items[0][quantity]",
+			"line_items[1][description]",
+			"line_items[1][quantity]",
+		])
+	);
+	assert_eq!(
+		input_attr_values_for_name_prefix(&html, "line_items[", "id"),
+		string_values(&[
+			"line_items_0_description",
+			"line_items_0_quantity",
+			"line_items_1_description",
+			"line_items_1_quantity",
+		])
+	);
+	assert_eq!(
+		input_attr_values_for_name_prefix(&html, "line_items[", "value"),
+		string_values(&["Keyboard", "2", "Mouse", "1"])
+	);
 
 	assert_eq!(runtime.move_item(collection, second_key, 0), Some((1, 0)));
 	let moved_html = invoice.into_page().render_to_string();
-	assert!(moved_html.contains(r#"name="line_items[0][description]""#));
-	assert!(moved_html.contains(r#"value="Mouse""#));
-	assert!(moved_html.contains(r#"name="line_items[1][description]""#));
-	assert!(moved_html.contains(r#"value="Keyboard""#));
+	assert_eq!(
+		input_attr_values_for_name_prefix(&moved_html, "line_items[", "name"),
+		string_values(&[
+			"line_items[0][description]",
+			"line_items[0][quantity]",
+			"line_items[1][description]",
+			"line_items[1][quantity]",
+		])
+	);
+	assert_eq!(
+		input_attr_values_for_name_prefix(&moved_html, "line_items[", "value"),
+		string_values(&["Mouse", "1", "Keyboard", "2"])
+	);
+}
+
+#[test]
+fn field_array_renders_datetime_local_values() {
+	let schedule = form! {
+		name: ScheduleForm,
+		action: "/schedule",
+		fields: {
+			slots: FieldArray {
+				fields: {
+					starts_at: DateTimeField {}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&schedule).build();
+	let collection = schedule.slots_collection();
+	let mut slot = schedule.new_slots_item();
+	slot.starts_at = Some(
+		chrono::NaiveDate::from_ymd_opt(2026, 6, 16)
+			.expect("valid date")
+			.and_hms_opt(8, 30, 45)
+			.expect("valid time"),
+	);
+
+	runtime.push_item(collection, slot);
+	let html = schedule.into_page().render_to_string();
+
+	assert_eq!(
+		input_attr_values_for_name_prefix(&html, "slots[", "type"),
+		string_values(&["datetime-local"])
+	);
+	assert_eq!(
+		input_attr_values_for_name_prefix(&html, "slots[", "value"),
+		string_values(&["2026-06-16T08:30:45"])
+	);
 }
 
 #[test]

--- a/docs/migration/0.2.0-form-runtime-builder.md
+++ b/docs/migration/0.2.0-form-runtime-builder.md
@@ -62,3 +62,67 @@ let runtime = use_form(&profile_form)
     .deps((user_id, profile_version))
     .build();
 ```
+
+## FieldArray Collections
+
+`FieldArray` creates a typed collection token, typed item value struct, and
+stable item keys for each generated form. Use the runtime handle to add, insert,
+remove, and reorder items. Nested item fields can be watched or updated through
+generated path accessors, and validation errors for required item fields are
+stored against the stable item key rather than the rendered index.
+
+```rust,ignore
+let invoice_form = form! {
+    name: InvoiceForm,
+    action: "/invoices",
+    fields: {
+        line_items: FieldArray {
+            fields: {
+                description: CharField { required }
+                quantity: IntegerField { required }
+            }
+        }
+    }
+};
+
+let runtime = use_form(&invoice_form).build();
+let mut item = invoice_form.new_line_items_item();
+item.description = "Keyboard".to_string();
+item.quantity = 2;
+
+let key = runtime.push_item(invoice_form.line_items_collection(), item);
+runtime.set_path_value(
+    invoice_form.line_items_quantity_path(key),
+    3_i64,
+);
+```
+
+When defaults come from `use_resource(fetcher, deps)`, pass the same dependency
+identity to `.deps(...)` and reconcile the runtime after the resource produces a
+new generated form or value struct. With the default
+`ResetOnDeps::KeepDirtyValues`, dirty collection values keep their current item
+keys and path state, while pristine collections receive refreshed defaults.
+`ResetOnDeps::ResetAll` rebuilds collection items from the new defaults and
+therefore replaces runtime item keys and clears nested path state.
+
+```rust,ignore
+let profile_resource = use_resource(fetch_profile, user_id);
+let invoice_form = build_invoice_form(profile_resource.get());
+let runtime = use_form(&invoice_form)
+    .deps(user_id)
+    .reset_on_deps(ResetOnDeps::KeepDirtyValues)
+    .build();
+
+// After the resource refreshes:
+runtime.reconcile_from(&invoice_form, user_id);
+```
+
+`min_items` and `max_items` validate the collection length and expose failures
+as collection-level state through `get_collection_state(...)`. Required fields
+inside each item continue to use path-level errors keyed by the stable item key.
+
+The 0.2.0 FieldArray renderer supports basic scalar item fields. It rejects
+nested `FieldArray`, `FieldGroup`, `SubmitButton`, `render_item`,
+`initial_from`, item-field `initial`, dynamic choices, and file/image fields
+inside a collection until those surfaces have generated rendering and runtime
+binding semantics.


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds generated `FieldArray` value structs, collection tokens, stable item keys, and field path accessors.
- Adds runtime collection operations for add, insert, remove, and reorder flows.
- Tracks nested field path state and collection-level validation state across reset and dependency reconciliation.
- Documents the supported FieldArray surface and `use_resource(fetcher, deps)` reconciliation guidance.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

FieldArray parsing existed, but generated forms did not expose a usable runtime model for dynamic repeated field groups. This adds the typed value model, stable runtime keys, collection operations, nested validation addressing, and docs needed for the staged FieldArray runtime support.

Fixes #5337

Related to: #

## How Was This Tested?

- `cargo fmt -p reinhardt-pages -p reinhardt-pages-macros`
- `cargo test -p reinhardt-pages --test use_form_integration --config 'build.build-dir="/tmp/reinhardt-task11-build"' --target-dir /tmp/reinhardt-task11-target`
- `cargo test -p reinhardt-pages-macros test_validate_field_array --config 'build.build-dir="/tmp/reinhardt-task11-build"' --target-dir /tmp/reinhardt-task11-target`
- `cargo check -p reinhardt-pages-macros --config 'build.build-dir="/tmp/reinhardt-task11-build"' --target-dir /tmp/reinhardt-task11-target`
- `CARGO_TARGET_DIR=/tmp/reinhardt-task11-trybuild-target CARGO_BUILD_BUILD_DIR=/tmp/reinhardt-task11-trybuild-build cargo test -p reinhardt-pages --test ui test_form_macro_pass`
- `git diff --check`
- `rg -n "TODO|FIXME|todo!\(|dbg!\(" <changed files>`

## Performance Impact

Not performance-related.

## Breaking Changes

None.

**Migration Guide:**

No migration required.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5337

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The PR is opened as draft because full workspace clippy and the exact `cargo make fmt-fix` workflow were not run locally. Existing trybuild pass fixtures still emit their expected deprecation warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added repeatable field collections to forms—users can now define groups of fields that repeat multiple times at runtime.
  * Collection management operations: add, insert, remove, and reorder items while maintaining stable item tracking.
  * Min/max item constraints for collection-level validation.
  * Enhanced form state management with nested field path support and collection-specific error handling.

* **Documentation**
  * Added migration guide covering field collection usage and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->