### PR TITLE
feat(forms): expand generated widget coverage

### DIFF
--- a/crates/reinhardt-manouche/src/core/form_node.rs
+++ b/crates/reinhardt-manouche/src/core/form_node.rs
@@ -142,6 +142,20 @@ pub enum FormFieldEntry {
 	Group(FormFieldGroup),
 	/// A submit button (not a data field — generates no Signal)
 	SubmitButton(FormSubmitButtonDef),
+	/// A reset button (not a data field).
+	ResetButton(FormControlEntryDef),
+	/// A generic button (not a data field).
+	Button(FormControlEntryDef),
+	/// An image submit control (not a generated form value).
+	ImageInput(FormControlEntryDef),
+	/// An output element (not a generated form value).
+	Output(FormControlEntryDef),
+	/// A meter element (not a generated form value).
+	Meter(FormControlEntryDef),
+	/// A progress element (not a generated form value).
+	Progress(FormControlEntryDef),
+	/// A datalist element (not a generated form value).
+	Datalist(FormDatalistDef),
 }
 
 impl FormFieldEntry {
@@ -160,12 +174,24 @@ impl FormFieldEntry {
 		matches!(self, FormFieldEntry::SubmitButton(_))
 	}
 
+	/// Returns true if this is a non-value control entry.
+	pub fn is_control_entry(&self) -> bool {
+		self.as_control_entry().is_some()
+	}
+
 	/// Returns the name of the entry (field name or group name).
 	pub fn name(&self) -> &Ident {
 		match self {
 			FormFieldEntry::Field(f) => &f.name,
 			FormFieldEntry::Group(g) => &g.name,
 			FormFieldEntry::SubmitButton(b) => &b.name,
+			FormFieldEntry::ResetButton(c)
+			| FormFieldEntry::Button(c)
+			| FormFieldEntry::ImageInput(c)
+			| FormFieldEntry::Output(c)
+			| FormFieldEntry::Meter(c)
+			| FormFieldEntry::Progress(c) => &c.name,
+			FormFieldEntry::Datalist(d) => &d.name,
 		}
 	}
 
@@ -175,6 +201,13 @@ impl FormFieldEntry {
 			FormFieldEntry::Field(f) => f.span,
 			FormFieldEntry::Group(g) => g.span,
 			FormFieldEntry::SubmitButton(b) => b.span,
+			FormFieldEntry::ResetButton(c)
+			| FormFieldEntry::Button(c)
+			| FormFieldEntry::ImageInput(c)
+			| FormFieldEntry::Output(c)
+			| FormFieldEntry::Meter(c)
+			| FormFieldEntry::Progress(c) => c.span,
+			FormFieldEntry::Datalist(d) => d.span,
 		}
 	}
 
@@ -198,6 +231,27 @@ impl FormFieldEntry {
 	pub fn as_submit_button(&self) -> Option<&FormSubmitButtonDef> {
 		match self {
 			FormFieldEntry::SubmitButton(b) => Some(b),
+			_ => None,
+		}
+	}
+
+	/// Returns a reference to the inner control entry if this is a non-value entry.
+	pub fn as_control_entry(&self) -> Option<&FormControlEntryDef> {
+		match self {
+			FormFieldEntry::ResetButton(c)
+			| FormFieldEntry::Button(c)
+			| FormFieldEntry::ImageInput(c)
+			| FormFieldEntry::Output(c)
+			| FormFieldEntry::Meter(c)
+			| FormFieldEntry::Progress(c) => Some(c),
+			_ => None,
+		}
+	}
+
+	/// Returns a reference to the inner datalist if this is a Datalist variant.
+	pub fn as_datalist(&self) -> Option<&FormDatalistDef> {
+		match self {
+			FormFieldEntry::Datalist(d) => Some(d),
 			_ => None,
 		}
 	}
@@ -249,6 +303,82 @@ pub struct FormSubmitButtonDef {
 	pub span: Span,
 }
 
+/// Non-value form control entry kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FormControlEntryKind {
+	/// `<button type="reset">`.
+	ResetButton,
+	/// `<button type="button">`.
+	Button,
+	/// `<input type="image">`.
+	ImageInput,
+	/// `<output>`.
+	Output,
+	/// `<meter>`.
+	Meter,
+	/// `<progress>`.
+	Progress,
+}
+
+/// A non-value form control entry definition in the form macro.
+#[derive(Debug, Clone)]
+pub struct FormControlEntryDef {
+	/// Entry name identifier.
+	pub name: Ident,
+	/// Control entry kind.
+	pub kind: FormControlEntryKind,
+	/// Control properties.
+	pub properties: Vec<FormFieldProperty>,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
+/// A datalist entry definition in the form macro.
+#[derive(Debug, Clone)]
+pub struct FormDatalistDef {
+	/// Datalist identifier. Referenced by field `list: name`.
+	pub name: Ident,
+	/// Datalist option properties.
+	pub properties: Vec<FormFieldProperty>,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
+/// A static choice item.
+#[derive(Debug, Clone)]
+pub enum FormChoiceItem {
+	/// A single `<option>`.
+	Option(Box<FormChoiceOption>),
+	/// An `<optgroup>` containing options.
+	Group(FormChoiceGroup),
+}
+
+/// A static option definition.
+#[derive(Debug, Clone)]
+pub struct FormChoiceOption {
+	/// Option value expression.
+	pub value: Expr,
+	/// Optional label expression. Defaults to `value`.
+	pub label: Option<Expr>,
+	/// Whether the option is disabled.
+	pub disabled: bool,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
+/// A static optgroup definition.
+#[derive(Debug, Clone)]
+pub struct FormChoiceGroup {
+	/// Group label.
+	pub label: LitStr,
+	/// Whether the entire group is disabled.
+	pub disabled: bool,
+	/// Grouped options.
+	pub options: Vec<FormChoiceItem>,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
 /// A group of related fields in the form macro.
 ///
 /// Field groups allow organizing multiple fields under a common container
@@ -277,7 +407,7 @@ pub struct FormFieldGroup {
 	/// Group-level CSS class
 	pub class: Option<LitStr>,
 	/// Fields within the group
-	pub fields: Vec<FormFieldDef>,
+	pub fields: Vec<FormFieldEntry>,
 	/// Span for error reporting
 	pub span: Span,
 }
@@ -293,10 +423,35 @@ impl FormFieldGroup {
 		self.class.as_ref().map(|c| c.value())
 	}
 
-	/// Returns the number of fields in this group.
+	/// Returns the number of value fields in this group.
 	pub fn field_count(&self) -> usize {
-		self.fields.len()
+		self.fields
+			.iter()
+			.filter(|entry| matches!(entry, FormFieldEntry::Field(_)))
+			.count()
 	}
+}
+
+/// A widget specification before semantic validation.
+#[derive(Debug, Clone)]
+pub enum FormWidgetSpec {
+	/// Built-in widget identifier, e.g. `TextInput`.
+	Builtin(Ident),
+	/// Experimental custom widget adapter specification.
+	Custom(FormCustomWidgetSpec),
+}
+
+/// Experimental custom widget metadata before semantic validation.
+#[derive(Debug, Clone)]
+pub struct FormCustomWidgetSpec {
+	/// Component function or constructor path.
+	pub component: Path,
+	/// Whether the `experimental` marker was present.
+	pub experimental: bool,
+	/// Adapter type path.
+	pub adapter: Option<Path>,
+	/// Source location span.
+	pub span: Span,
 }
 
 /// A property within a field definition.
@@ -318,10 +473,10 @@ pub enum FormFieldProperty {
 		/// Source location span.
 		span: Span,
 	},
-	/// Widget specification: `widget: PasswordInput`
+	/// Widget specification: `widget: PasswordInput` or experimental `CustomWidget(...)`.
 	Widget {
-		/// Widget type identifier.
-		widget_type: Ident,
+		/// Widget specification.
+		widget: FormWidgetSpec,
 		/// Source location span.
 		span: Span,
 	},
@@ -385,6 +540,13 @@ pub enum FormFieldProperty {
 		/// Source location span.
 		span: Span,
 	},
+	/// Static select/datalist choices: `choices: [("a", "A")]`
+	Choices {
+		/// Static choice items.
+		choices: Vec<FormChoiceItem>,
+		/// Source location span.
+		span: Span,
+	},
 	/// Choice value path: `choice_value: "id"`
 	///
 	/// Specifies which property of each choice item to use as the form value.
@@ -401,6 +563,27 @@ pub enum FormFieldProperty {
 	/// The default is "label" if not specified.
 	ChoiceLabel {
 		/// Property path for the choice display label.
+		path: LitStr,
+		/// Source location span.
+		span: Span,
+	},
+	/// Choice disabled path: `choice_disabled: "disabled"`
+	ChoiceDisabled {
+		/// Property path for the disabled flag.
+		path: LitStr,
+		/// Source location span.
+		span: Span,
+	},
+	/// Choice group path: `choice_group: "group"`
+	ChoiceGroup {
+		/// Property path for the choice group label.
+		path: LitStr,
+		/// Source location span.
+		span: Span,
+	},
+	/// Choice group disabled path: `choice_group_disabled: "group_disabled"`
+	ChoiceGroupDisabled {
+		/// Property path for the group disabled flag.
 		path: LitStr,
 		/// Source location span.
 		span: Span,
@@ -625,8 +808,12 @@ impl FormFieldProperty {
 			FormFieldProperty::Bind { span, .. } => *span,
 			FormFieldProperty::InitialFrom { span, .. } => *span,
 			FormFieldProperty::ChoicesFrom { span, .. } => *span,
+			FormFieldProperty::Choices { span, .. } => *span,
 			FormFieldProperty::ChoiceValue { span, .. } => *span,
 			FormFieldProperty::ChoiceLabel { span, .. } => *span,
+			FormFieldProperty::ChoiceDisabled { span, .. } => *span,
+			FormFieldProperty::ChoiceGroup { span, .. } => *span,
+			FormFieldProperty::ChoiceGroupDisabled { span, .. } => *span,
 		}
 	}
 
@@ -1144,11 +1331,11 @@ impl FormFieldDef {
 		})
 	}
 
-	/// Gets the widget type if specified.
-	pub fn get_widget(&self) -> Option<&Ident> {
+	/// Gets the widget specification if specified.
+	pub fn get_widget(&self) -> Option<&FormWidgetSpec> {
 		self.properties.iter().find_map(|p| {
-			if let FormFieldProperty::Widget { widget_type, .. } = p {
-				Some(widget_type)
+			if let FormFieldProperty::Widget { widget, .. } = p {
+				Some(widget)
 			} else {
 				None
 			}
@@ -1340,6 +1527,39 @@ impl FormFieldDef {
 		})
 	}
 
+	/// Gets the choice_disabled path if specified.
+	pub fn get_choice_disabled(&self) -> Option<&LitStr> {
+		self.properties.iter().find_map(|p| {
+			if let FormFieldProperty::ChoiceDisabled { path, .. } = p {
+				Some(path)
+			} else {
+				None
+			}
+		})
+	}
+
+	/// Gets the choice_group path if specified.
+	pub fn get_choice_group(&self) -> Option<&LitStr> {
+		self.properties.iter().find_map(|p| {
+			if let FormFieldProperty::ChoiceGroup { path, .. } = p {
+				Some(path)
+			} else {
+				None
+			}
+		})
+	}
+
+	/// Gets the choice_group_disabled path if specified.
+	pub fn get_choice_group_disabled(&self) -> Option<&LitStr> {
+		self.properties.iter().find_map(|p| {
+			if let FormFieldProperty::ChoiceGroupDisabled { path, .. } = p {
+				Some(path)
+			} else {
+				None
+			}
+		})
+	}
+
 	/// Returns true if this is a dynamic choice field (has choices_from configured).
 	pub fn is_dynamic_choice_field(&self) -> bool {
 		self.has_choices_from()
@@ -1441,7 +1661,7 @@ mod tests {
 	fn test_form_field_property_name_returns_none_for_structural_variants() {
 		// Arrange
 		let widget = FormFieldProperty::Widget {
-			widget_type: Ident::new("PasswordInput", Span::call_site()),
+			widget: FormWidgetSpec::Builtin(Ident::new("PasswordInput", Span::call_site())),
 			span: Span::call_site(),
 		};
 		let wrapper = FormFieldProperty::Wrapper {
@@ -1476,12 +1696,28 @@ mod tests {
 			field_name: LitStr::new("choices", Span::call_site()),
 			span: Span::call_site(),
 		};
+		let choices = FormFieldProperty::Choices {
+			choices: Vec::new(),
+			span: Span::call_site(),
+		};
 		let choice_value = FormFieldProperty::ChoiceValue {
 			path: LitStr::new("id", Span::call_site()),
 			span: Span::call_site(),
 		};
 		let choice_label = FormFieldProperty::ChoiceLabel {
 			path: LitStr::new("label", Span::call_site()),
+			span: Span::call_site(),
+		};
+		let choice_disabled = FormFieldProperty::ChoiceDisabled {
+			path: LitStr::new("disabled", Span::call_site()),
+			span: Span::call_site(),
+		};
+		let choice_group = FormFieldProperty::ChoiceGroup {
+			path: LitStr::new("group", Span::call_site()),
+			span: Span::call_site(),
+		};
+		let choice_group_disabled = FormFieldProperty::ChoiceGroupDisabled {
+			path: LitStr::new("group_disabled", Span::call_site()),
 			span: Span::call_site(),
 		};
 
@@ -1494,8 +1730,12 @@ mod tests {
 		assert!(bind.name().is_none());
 		assert!(initial_from.name().is_none());
 		assert!(choices_from.name().is_none());
+		assert!(choices.name().is_none());
 		assert!(choice_value.name().is_none());
 		assert!(choice_label.name().is_none());
+		assert!(choice_disabled.name().is_none());
+		assert!(choice_group.name().is_none());
+		assert!(choice_group_disabled.name().is_none());
 	}
 
 	#[rstest]

--- a/crates/reinhardt-manouche/src/core/form_typed.rs
+++ b/crates/reinhardt-manouche/src/core/form_typed.rs
@@ -494,6 +494,12 @@ pub struct TypedChoicesConfig {
 	/// e.g., "choice_text" extracts `choice.choice_text` for display.
 	/// Defaults to "label" if not specified.
 	pub choice_label: String,
+	/// Optional property path for extracting a disabled flag from each choice item.
+	pub choice_disabled: Option<String>,
+	/// Optional property path for extracting a group label from each choice item.
+	pub choice_group: Option<String>,
+	/// Optional property path for extracting a group disabled flag from each choice item.
+	pub choice_group_disabled: Option<String>,
 	/// Span for error reporting
 	pub span: Span,
 }
@@ -505,6 +511,9 @@ impl TypedChoicesConfig {
 			choices_from,
 			choice_value: "value".to_string(),
 			choice_label: "label".to_string(),
+			choice_disabled: None,
+			choice_group: None,
+			choice_group_disabled: None,
 			span,
 		}
 	}
@@ -514,15 +523,56 @@ impl TypedChoicesConfig {
 		choices_from: String,
 		choice_value: String,
 		choice_label: String,
+		choice_disabled: Option<String>,
+		choice_group: Option<String>,
+		choice_group_disabled: Option<String>,
 		span: Span,
 	) -> Self {
 		Self {
 			choices_from,
 			choice_value,
 			choice_label,
+			choice_disabled,
+			choice_group,
+			choice_group_disabled,
 			span,
 		}
 	}
+}
+
+/// A typed static choice item.
+#[derive(Debug, Clone)]
+pub enum TypedChoiceItem {
+	/// A single `<option>`.
+	Option(Box<TypedChoiceOption>),
+	/// An `<optgroup>`.
+	Group(TypedChoiceGroup),
+}
+
+/// A typed static choice option.
+#[derive(Debug, Clone)]
+pub struct TypedChoiceOption {
+	/// Option value expression.
+	pub value: syn::Expr,
+	/// Option label expression.
+	pub label: syn::Expr,
+	/// Whether the option is disabled.
+	pub disabled: bool,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
+/// A typed static option group.
+#[derive(Debug, Clone)]
+pub struct TypedChoiceGroup {
+	/// Group label.
+	pub label: String,
+	/// Whether the group is disabled.
+	pub disabled: bool,
+	/// Group options.
+	pub options: Vec<TypedChoiceOption>,
+	/// Span for error reporting.
+	pub span: Span,
 }
 
 /// A validated field definition with typed properties.
@@ -540,6 +590,8 @@ pub struct TypedFormFieldDef {
 	pub styling: TypedFieldStyling,
 	/// Widget type
 	pub widget: TypedWidget,
+	/// Native HTML attributes for the generated form control
+	pub native_attrs: TypedFieldNativeAttrs,
 	/// Custom wrapper element for the field container
 	pub wrapper: Option<TypedWrapper>,
 	/// SVG icon for the field
@@ -566,7 +618,22 @@ pub struct TypedFormFieldDef {
 	/// When specified, the field will load choices from a `choices_loader`
 	/// server_fn and render them dynamically.
 	pub choices_config: Option<TypedChoicesConfig>,
+	/// Static choice options for select-like widgets.
+	pub static_choices: Vec<TypedChoiceItem>,
 	/// Span for error reporting
+	pub span: Span,
+}
+
+/// A validated datalist definition.
+#[derive(Debug)]
+pub struct TypedDatalistDef {
+	/// Datalist identifier.
+	pub name: Ident,
+	/// Static datalist options.
+	pub static_choices: Vec<TypedChoiceItem>,
+	/// Dynamic choices configuration.
+	pub choices_config: Option<TypedChoicesConfig>,
+	/// Span for error reporting.
 	pub span: Span,
 }
 
@@ -584,6 +651,20 @@ pub enum TypedFormFieldEntry {
 	Group(TypedFormFieldGroup),
 	/// A submit button (not a data field — generates no Signal)
 	SubmitButton(TypedSubmitButtonDef),
+	/// A reset button (not a data field).
+	ResetButton(TypedButtonControlDef),
+	/// A generic button (not a data field).
+	Button(TypedButtonControlDef),
+	/// An image submit control (not a generated form value).
+	ImageInput(TypedImageInputDef),
+	/// An output element (not a generated form value).
+	Output(TypedOutputDef),
+	/// A meter element (not a generated form value).
+	Meter(Box<TypedMeterDef>),
+	/// A progress element (not a generated form value).
+	Progress(Box<TypedProgressDef>),
+	/// A datalist element (not a generated form value).
+	Datalist(Box<TypedDatalistDef>),
 }
 
 impl TypedFormFieldEntry {
@@ -608,6 +689,12 @@ impl TypedFormFieldEntry {
 			TypedFormFieldEntry::Field(f) => &f.as_ref().name,
 			TypedFormFieldEntry::Group(g) => &g.name,
 			TypedFormFieldEntry::SubmitButton(b) => &b.name,
+			TypedFormFieldEntry::ResetButton(b) | TypedFormFieldEntry::Button(b) => &b.name,
+			TypedFormFieldEntry::ImageInput(i) => &i.name,
+			TypedFormFieldEntry::Output(o) => &o.name,
+			TypedFormFieldEntry::Meter(m) => &m.name,
+			TypedFormFieldEntry::Progress(p) => &p.name,
+			TypedFormFieldEntry::Datalist(d) => &d.name,
 		}
 	}
 
@@ -617,6 +704,12 @@ impl TypedFormFieldEntry {
 			TypedFormFieldEntry::Field(f) => f.as_ref().span,
 			TypedFormFieldEntry::Group(g) => g.span,
 			TypedFormFieldEntry::SubmitButton(b) => b.span,
+			TypedFormFieldEntry::ResetButton(b) | TypedFormFieldEntry::Button(b) => b.span,
+			TypedFormFieldEntry::ImageInput(i) => i.span,
+			TypedFormFieldEntry::Output(o) => o.span,
+			TypedFormFieldEntry::Meter(m) => m.span,
+			TypedFormFieldEntry::Progress(p) => p.span,
+			TypedFormFieldEntry::Datalist(d) => d.span,
 		}
 	}
 
@@ -643,6 +736,14 @@ impl TypedFormFieldEntry {
 			_ => None,
 		}
 	}
+
+	/// Returns a reference to the inner datalist if this is a Datalist variant.
+	pub fn as_datalist(&self) -> Option<&TypedDatalistDef> {
+		match self {
+			TypedFormFieldEntry::Datalist(d) => Some(d.as_ref()),
+			_ => None,
+		}
+	}
 }
 
 /// A validated submit button definition.
@@ -665,6 +766,120 @@ pub struct TypedSubmitButtonDef {
 	pub span: Span,
 }
 
+/// Typed button control kind for non-submit buttons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypedButtonKind {
+	/// `<button type="reset">`.
+	Reset,
+	/// `<button type="button">`.
+	Button,
+}
+
+/// A validated non-submit button control.
+#[derive(Debug)]
+pub struct TypedButtonControlDef {
+	/// Button name identifier.
+	pub name: Ident,
+	/// Button behavior.
+	pub kind: TypedButtonKind,
+	/// Button text.
+	pub label: String,
+	/// Optional CSS class.
+	pub class: Option<String>,
+	/// Optional HTML id attribute.
+	pub id: Option<String>,
+	/// Whether the button is disabled.
+	pub disabled: bool,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
+/// A validated image input control.
+#[derive(Debug)]
+pub struct TypedImageInputDef {
+	/// Input name identifier.
+	pub name: Ident,
+	/// Image source URL.
+	pub src: String,
+	/// Image alt text.
+	pub alt: String,
+	/// Optional CSS class.
+	pub class: Option<String>,
+	/// Optional HTML id attribute.
+	pub id: Option<String>,
+	/// Whether the input is disabled.
+	pub disabled: bool,
+	/// Optional width attribute.
+	pub width: Option<i64>,
+	/// Optional height attribute.
+	pub height: Option<i64>,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
+/// A validated output element.
+#[derive(Debug)]
+pub struct TypedOutputDef {
+	/// Output name identifier.
+	pub name: Ident,
+	/// Optional visible label content.
+	pub label: Option<String>,
+	/// Field ids referenced by the output element.
+	pub for_fields: Vec<Ident>,
+	/// Optional CSS class.
+	pub class: Option<String>,
+	/// Optional HTML id attribute.
+	pub id: Option<String>,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
+/// A validated meter element.
+#[derive(Debug)]
+pub struct TypedMeterDef {
+	/// Meter name identifier.
+	pub name: Ident,
+	/// Optional visible label content.
+	pub label: Option<String>,
+	/// Current value expression.
+	pub value: syn::Expr,
+	/// Optional minimum expression.
+	pub min: Option<syn::Expr>,
+	/// Optional maximum expression.
+	pub max: Option<syn::Expr>,
+	/// Optional low threshold expression.
+	pub low: Option<syn::Expr>,
+	/// Optional high threshold expression.
+	pub high: Option<syn::Expr>,
+	/// Optional optimum expression.
+	pub optimum: Option<syn::Expr>,
+	/// Optional CSS class.
+	pub class: Option<String>,
+	/// Optional HTML id attribute.
+	pub id: Option<String>,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
+/// A validated progress element.
+#[derive(Debug)]
+pub struct TypedProgressDef {
+	/// Progress name identifier.
+	pub name: Ident,
+	/// Optional visible label content.
+	pub label: Option<String>,
+	/// Optional current value expression.
+	pub value: Option<syn::Expr>,
+	/// Optional maximum expression.
+	pub max: Option<syn::Expr>,
+	/// Optional CSS class.
+	pub class: Option<String>,
+	/// Optional HTML id attribute.
+	pub id: Option<String>,
+	/// Span for error reporting.
+	pub span: Span,
+}
+
 /// A validated group of related fields.
 ///
 /// Field groups allow organizing multiple fields under a common container
@@ -677,16 +892,19 @@ pub struct TypedFormFieldGroup {
 	pub label: Option<String>,
 	/// Group CSS class
 	pub class: Option<String>,
-	/// Validated fields within the group
-	pub fields: Vec<TypedFormFieldDef>,
+	/// Validated entries within the group.
+	pub fields: Vec<TypedFormFieldEntry>,
 	/// Span for error reporting
 	pub span: Span,
 }
 
 impl TypedFormFieldGroup {
-	/// Returns the number of fields in this group.
+	/// Returns the number of value fields in this group.
 	pub fn field_count(&self) -> usize {
-		self.fields.len()
+		self.fields
+			.iter()
+			.filter(|entry| matches!(entry, TypedFormFieldEntry::Field(_)))
+			.count()
 	}
 }
 
@@ -867,6 +1085,8 @@ impl TypedFieldType {
 /// | `PasswordInput` | `<input>` | `password` |
 /// | `NumberInput` | `<input>` | `number` |
 /// | `DateInput` | `<input>` | `date` |
+/// | `MonthInput` | `<input>` | `month` |
+/// | `WeekInput` | `<input>` | `week` |
 /// | `TimeInput` | `<input>` | `time` |
 /// | `DateTimeInput` | `<input>` | `datetime-local` |
 /// | `CheckboxInput` | `<input>` | `checkbox` |
@@ -876,6 +1096,26 @@ impl TypedFieldType {
 /// | `Textarea` | `<textarea>` | - |
 /// | `Select` | `<select>` | - |
 /// | `SelectMultiple` | `<select multiple>` | - |
+/// Experimental custom widget metadata after validation.
+#[derive(Debug, Clone)]
+pub struct TypedCustomWidget {
+	/// Component function or constructor path.
+	pub component: syn::Path,
+	/// Adapter type path implementing the experimental runtime adapter trait.
+	pub adapter: syn::Path,
+	/// Source location span.
+	pub span: Span,
+}
+
+impl PartialEq for TypedCustomWidget {
+	fn eq(&self, other: &Self) -> bool {
+		self.component == other.component && self.adapter == other.adapter
+	}
+}
+
+impl Eq for TypedCustomWidget {}
+
+/// Supported widget renderers after semantic validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypedWidget {
 	/// Standard text input (`<input type="text">`).
@@ -892,6 +1132,10 @@ pub enum TypedWidget {
 	TelInput,
 	/// Date picker input (`<input type="date">`).
 	DateInput,
+	/// Month picker input (`<input type="month">`).
+	MonthInput,
+	/// Week picker input (`<input type="week">`).
+	WeekInput,
 	/// Time picker input (`<input type="time">`).
 	TimeInput,
 	/// Date and time picker input (`<input type="datetime-local">`).
@@ -918,6 +1162,8 @@ pub enum TypedWidget {
 	FileInput,
 	/// Search input (`<input type="search">`).
 	SearchInput,
+	/// Experimental custom widget with an adapter.
+	CustomExperimental(TypedCustomWidget),
 }
 
 impl TypedWidget {
@@ -931,6 +1177,8 @@ impl TypedWidget {
 			TypedWidget::UrlInput => "url",
 			TypedWidget::TelInput => "tel",
 			TypedWidget::DateInput => "date",
+			TypedWidget::MonthInput => "month",
+			TypedWidget::WeekInput => "week",
 			TypedWidget::TimeInput => "time",
 			TypedWidget::DateTimeInput => "datetime-local",
 			TypedWidget::ColorInput => "color",
@@ -940,6 +1188,7 @@ impl TypedWidget {
 			TypedWidget::RadioInput | TypedWidget::RadioSelect => "radio",
 			TypedWidget::FileInput => "file",
 			TypedWidget::SearchInput => "search",
+			TypedWidget::CustomExperimental(_) => "text",
 			// These are not input types
 			TypedWidget::Textarea => "text",
 			TypedWidget::Select => "text",
@@ -951,7 +1200,10 @@ impl TypedWidget {
 	pub fn is_input(&self) -> bool {
 		!matches!(
 			self,
-			TypedWidget::Textarea | TypedWidget::Select | TypedWidget::SelectMultiple
+			TypedWidget::Textarea
+				| TypedWidget::Select
+				| TypedWidget::SelectMultiple
+				| TypedWidget::CustomExperimental(_)
 		)
 	}
 
@@ -960,6 +1212,7 @@ impl TypedWidget {
 		match self {
 			TypedWidget::Textarea => "textarea",
 			TypedWidget::Select | TypedWidget::SelectMultiple => "select",
+			TypedWidget::CustomExperimental(_) => "custom",
 			_ => "input",
 		}
 	}
@@ -1025,6 +1278,27 @@ pub struct TypedFieldDisplay {
 	pub autofocus: bool,
 	/// Autocomplete hint for the browser
 	pub autocomplete: Option<String>,
+}
+
+/// Native HTML attributes for a generated form control.
+#[derive(Debug, Clone, Default)]
+pub struct TypedFieldNativeAttrs {
+	/// Native `min` attribute expression.
+	pub min: Option<syn::Expr>,
+	/// Native `max` attribute expression.
+	pub max: Option<syn::Expr>,
+	/// Native `step` attribute expression.
+	pub step: Option<syn::Expr>,
+	/// Native `multiple` boolean attribute.
+	pub multiple: Option<bool>,
+	/// Native `accept` attribute for file inputs.
+	pub accept: Option<String>,
+	/// Native `capture` attribute for file inputs.
+	pub capture: Option<String>,
+	/// Native `list` datalist id reference.
+	pub list: Option<Ident>,
+	/// Native `size` attribute.
+	pub size: Option<i64>,
 }
 
 /// Styling-related properties of a field.
@@ -1426,6 +1700,7 @@ impl TypedFormFieldDef {
 			display: TypedFieldDisplay::default(),
 			styling: TypedFieldStyling::default(),
 			widget,
+			native_attrs: TypedFieldNativeAttrs::default(),
 			wrapper: None,
 			icon: None,
 			custom_attrs: Vec::new(),
@@ -1433,6 +1708,7 @@ impl TypedFormFieldDef {
 			initial_from: None,
 			initial_expr: None,
 			choices_config: None,
+			static_choices: Vec::new(),
 			span,
 		}
 	}
@@ -1614,6 +1890,8 @@ mod tests {
 		let password_input = TypedWidget::PasswordInput;
 		let number_input = TypedWidget::NumberInput;
 		let date_input = TypedWidget::DateInput;
+		let month_input = TypedWidget::MonthInput;
+		let week_input = TypedWidget::WeekInput;
 		let file_input = TypedWidget::FileInput;
 
 		// Act
@@ -1622,6 +1900,8 @@ mod tests {
 		let password_type = password_input.html_type();
 		let number_type = number_input.html_type();
 		let date_type = date_input.html_type();
+		let month_type = month_input.html_type();
+		let week_type = week_input.html_type();
 		let file_type = file_input.html_type();
 
 		// Assert
@@ -1630,6 +1910,8 @@ mod tests {
 		assert_eq!(password_type, "password");
 		assert_eq!(number_type, "number");
 		assert_eq!(date_type, "date");
+		assert_eq!(month_type, "month");
+		assert_eq!(week_type, "week");
 		assert_eq!(file_type, "file");
 	}
 
@@ -1638,6 +1920,8 @@ mod tests {
 		// Arrange
 		let text_input = TypedWidget::TextInput;
 		let email_input = TypedWidget::EmailInput;
+		let month_input = TypedWidget::MonthInput;
+		let week_input = TypedWidget::WeekInput;
 		let file_input = TypedWidget::FileInput;
 		let textarea = TypedWidget::Textarea;
 		let select = TypedWidget::Select;
@@ -1645,6 +1929,8 @@ mod tests {
 		// Act
 		let text_is_input = text_input.is_input();
 		let email_is_input = email_input.is_input();
+		let month_is_input = month_input.is_input();
+		let week_is_input = week_input.is_input();
 		let file_is_input = file_input.is_input();
 		let textarea_is_input = textarea.is_input();
 		let select_is_input = select.is_input();
@@ -1652,6 +1938,8 @@ mod tests {
 		// Assert
 		assert!(text_is_input);
 		assert!(email_is_input);
+		assert!(month_is_input);
+		assert!(week_is_input);
 		assert!(file_is_input);
 		assert!(!textarea_is_input);
 		assert!(!select_is_input);
@@ -1661,18 +1949,24 @@ mod tests {
 	fn test_typed_widget_html_tag() {
 		// Arrange
 		let text_input = TypedWidget::TextInput;
+		let month_input = TypedWidget::MonthInput;
+		let week_input = TypedWidget::WeekInput;
 		let textarea = TypedWidget::Textarea;
 		let select = TypedWidget::Select;
 		let file_input = TypedWidget::FileInput;
 
 		// Act
 		let text_tag = text_input.html_tag();
+		let month_tag = month_input.html_tag();
+		let week_tag = week_input.html_tag();
 		let textarea_tag = textarea.html_tag();
 		let select_tag = select.html_tag();
 		let file_tag = file_input.html_tag();
 
 		// Assert
 		assert_eq!(text_tag, "input");
+		assert_eq!(month_tag, "input");
+		assert_eq!(week_tag, "input");
 		assert_eq!(textarea_tag, "textarea");
 		assert_eq!(select_tag, "select");
 		assert_eq!(file_tag, "input");

--- a/crates/reinhardt-manouche/src/parser/form.rs
+++ b/crates/reinhardt-manouche/src/parser/form.rs
@@ -5,17 +5,20 @@
 
 use proc_macro2::{Span, TokenStream, TokenTree};
 use syn::{
-	Expr, ExprClosure, Ident, LitStr, Path, Result, Token, braced,
+	Expr, ExprClosure, Ident, LitStr, Path, Result, Token, braced, bracketed,
+	ext::IdentExt,
+	parenthesized,
 	parse::{Parse, ParseStream},
 	token,
 };
 
 use crate::{
-	AmbientArgumentsSource, ClientTrigger, CustomAttr, FormAction, FormDerived, FormDerivedItem,
-	FormFieldDef, FormFieldEntry, FormFieldGroup, FormFieldProperty, FormMacro, FormSlots,
-	FormState, FormStateField, FormSubmitButtonDef, FormValidator, FormWatch, FormWatchItem,
-	IconAttr, IconChild, IconElement, IconPosition, StripArgument, ValidatorRule, ValidatorScope,
-	WrapperAttr, WrapperElement,
+	AmbientArgumentsSource, ClientTrigger, CustomAttr, FormAction, FormChoiceGroup, FormChoiceItem,
+	FormChoiceOption, FormControlEntryDef, FormControlEntryKind, FormCustomWidgetSpec,
+	FormDatalistDef, FormDerived, FormDerivedItem, FormFieldDef, FormFieldEntry, FormFieldGroup,
+	FormFieldProperty, FormMacro, FormSlots, FormState, FormStateField, FormSubmitButtonDef,
+	FormValidator, FormWatch, FormWatchItem, FormWidgetSpec, IconAttr, IconChild, IconElement,
+	IconPosition, StripArgument, ValidatorRule, ValidatorScope, WrapperAttr, WrapperElement,
 };
 
 /// Parses a `form!` macro invocation into an untyped AST.
@@ -322,10 +325,50 @@ fn parse_field_definitions(input: ParseStream) -> Result<Vec<FormFieldEntry>> {
 				properties,
 				span,
 			}));
+		} else if field_type == "Datalist" {
+			let generics = parse_optional_field_type_generics(input, field_type.span())?;
+			if generics.is_some() {
+				return Err(syn::Error::new(
+					field_type.span(),
+					"Datalist does not accept generic arguments",
+				));
+			}
+
+			let properties = if input.peek(token::Brace) {
+				let content;
+				braced!(content in input);
+				parse_field_properties(&content)?
+			} else {
+				Vec::new()
+			};
+
+			entries.push(FormFieldEntry::Datalist(FormDatalistDef {
+				name,
+				properties,
+				span,
+			}));
+		} else if let Some(kind) = parse_control_entry_kind(&field_type) {
+			let generics = parse_optional_field_type_generics(input, field_type.span())?;
+			if generics.is_some() {
+				return Err(syn::Error::new(
+					field_type.span(),
+					format!("{field_type} does not accept generic arguments"),
+				));
+			}
+
+			let properties = if input.peek(token::Brace) {
+				let content;
+				braced!(content in input);
+				parse_field_properties(&content)?
+			} else {
+				Vec::new()
+			};
+
+			entries.push(control_entry_from_kind(name, kind, properties, span));
 		} else {
 			// Optionally consume `<T1, T2, ...>` generic arguments before the
 			// property block. Only regular fields support generics; FieldGroup
-			// and SubmitButton are handled in the branches above.
+			// and non-value entries are handled in the branches above.
 			let generics = parse_optional_field_type_generics(input, field_type.span())?;
 
 			// Parse regular field properties in braces: { required, max_length: 100, ... }
@@ -350,6 +393,41 @@ fn parse_field_definitions(input: ParseStream) -> Result<Vec<FormFieldEntry>> {
 	}
 
 	Ok(entries)
+}
+
+fn parse_control_entry_kind(ident: &Ident) -> Option<FormControlEntryKind> {
+	match ident.to_string().as_str() {
+		"ResetButton" => Some(FormControlEntryKind::ResetButton),
+		"Button" => Some(FormControlEntryKind::Button),
+		"ImageInput" => Some(FormControlEntryKind::ImageInput),
+		"Output" => Some(FormControlEntryKind::Output),
+		"Meter" => Some(FormControlEntryKind::Meter),
+		"Progress" => Some(FormControlEntryKind::Progress),
+		_ => None,
+	}
+}
+
+fn control_entry_from_kind(
+	name: Ident,
+	kind: FormControlEntryKind,
+	properties: Vec<FormFieldProperty>,
+	span: Span,
+) -> FormFieldEntry {
+	let def = FormControlEntryDef {
+		name,
+		kind,
+		properties,
+		span,
+	};
+
+	match kind {
+		FormControlEntryKind::ResetButton => FormFieldEntry::ResetButton(def),
+		FormControlEntryKind::Button => FormFieldEntry::Button(def),
+		FormControlEntryKind::ImageInput => FormFieldEntry::ImageInput(def),
+		FormControlEntryKind::Output => FormFieldEntry::Output(def),
+		FormControlEntryKind::Meter => FormFieldEntry::Meter(def),
+		FormControlEntryKind::Progress => FormFieldEntry::Progress(def),
+	}
 }
 
 /// Parses a field group definition.
@@ -399,50 +477,18 @@ fn parse_field_group(name: Ident, input: ParseStream, span: Span) -> Result<Form
 	})
 }
 
-/// Parses fields inside a field group (no nested groups allowed).
-fn parse_group_fields(input: ParseStream) -> Result<Vec<FormFieldDef>> {
-	let mut fields = Vec::new();
-
-	while !input.is_empty() {
-		let span = input.span();
-		let name: Ident = input.parse()?;
-		input.parse::<Token![:]>()?;
-		let field_type: Ident = input.parse()?;
-
-		// Nested FieldGroups are not allowed
-		if field_type == "FieldGroup" {
+/// Parses entries inside a field group (no nested groups allowed).
+fn parse_group_fields(input: ParseStream) -> Result<Vec<FormFieldEntry>> {
+	let entries = parse_field_definitions(input)?;
+	for entry in &entries {
+		if matches!(entry, FormFieldEntry::Group(_)) {
 			return Err(syn::Error::new(
-				field_type.span(),
+				entry.span(),
 				"nested field groups are not allowed",
 			));
 		}
-
-		// Optionally consume `<T1, T2, ...>` generic arguments before the
-		// property block. Mirrors the top-level field parser; nested FieldGroup
-		// is rejected above so this only runs for regular field types.
-		let generics = parse_optional_field_type_generics(input, field_type.span())?;
-
-		// Parse properties in braces: { required, max_length: 100, ... }
-		let properties = if input.peek(token::Brace) {
-			let content;
-			braced!(content in input);
-			parse_field_properties(&content)?
-		} else {
-			Vec::new()
-		};
-
-		fields.push(FormFieldDef {
-			name,
-			field_type,
-			generics,
-			properties,
-			span,
-		});
-
-		parse_optional_comma(input)?;
 	}
-
-	Ok(fields)
+	Ok(entries)
 }
 
 /// Parses field properties inside braces.
@@ -453,14 +499,19 @@ fn parse_field_properties(input: ParseStream) -> Result<Vec<FormFieldProperty>> 
 		let span = input.span();
 
 		// Check for widget keyword
-		if input.peek(Ident) {
-			let name: Ident = input.parse()?;
+		if input.peek(Ident::peek_any) {
+			let name: Ident = input.call(Ident::parse_any)?;
 
 			if name == "widget" {
 				// widget: WidgetType
 				input.parse::<Token![:]>()?;
 				let widget_type: Ident = input.parse()?;
-				properties.push(FormFieldProperty::Widget { widget_type, span });
+				let widget = if widget_type == "CustomWidget" {
+					FormWidgetSpec::Custom(parse_custom_widget_spec(input, span)?)
+				} else {
+					FormWidgetSpec::Builtin(widget_type)
+				};
+				properties.push(FormFieldProperty::Widget { widget, span });
 			} else if name == "wrapper" {
 				// wrapper: element { attr: value, ... }
 				input.parse::<Token![:]>()?;
@@ -546,6 +597,12 @@ fn parse_field_properties(input: ParseStream) -> Result<Vec<FormFieldProperty>> 
 				input.parse::<Token![:]>()?;
 				let field_name: LitStr = input.parse()?;
 				properties.push(FormFieldProperty::ChoicesFrom { field_name, span });
+			} else if name == "choices" || name == "options" {
+				input.parse::<Token![:]>()?;
+				let content;
+				bracketed!(content in input);
+				let choices = parse_choice_items(&content)?;
+				properties.push(FormFieldProperty::Choices { choices, span });
 			} else if name == "choice_value" {
 				// choice_value: "id" - specifies property path for value extraction from each choice
 				input.parse::<Token![:]>()?;
@@ -556,6 +613,18 @@ fn parse_field_properties(input: ParseStream) -> Result<Vec<FormFieldProperty>> 
 				input.parse::<Token![:]>()?;
 				let path: LitStr = input.parse()?;
 				properties.push(FormFieldProperty::ChoiceLabel { path, span });
+			} else if name == "choice_disabled" {
+				input.parse::<Token![:]>()?;
+				let path: LitStr = input.parse()?;
+				properties.push(FormFieldProperty::ChoiceDisabled { path, span });
+			} else if name == "choice_group" {
+				input.parse::<Token![:]>()?;
+				let path: LitStr = input.parse()?;
+				properties.push(FormFieldProperty::ChoiceGroup { path, span });
+			} else if name == "choice_group_disabled" {
+				input.parse::<Token![:]>()?;
+				let path: LitStr = input.parse()?;
+				properties.push(FormFieldProperty::ChoiceGroupDisabled { path, span });
 			} else if input.peek(Token![:]) {
 				// name: value
 				input.parse::<Token![:]>()?;
@@ -571,6 +640,178 @@ fn parse_field_properties(input: ParseStream) -> Result<Vec<FormFieldProperty>> 
 	}
 
 	Ok(properties)
+}
+
+fn parse_custom_widget_spec(input: ParseStream, span: Span) -> Result<FormCustomWidgetSpec> {
+	let component_content;
+	parenthesized!(component_content in input);
+	let component: Path = component_content.parse()?;
+	if !component_content.is_empty() {
+		return Err(syn::Error::new(
+			component_content.span(),
+			"expected a single CustomWidget component path",
+		));
+	}
+
+	if !input.peek(token::Brace) {
+		return Err(syn::Error::new(
+			span,
+			"CustomWidget requires a property body",
+		));
+	}
+
+	let body;
+	braced!(body in input);
+	let mut experimental = false;
+	let mut adapter = None;
+
+	while !body.is_empty() {
+		let property_span = body.span();
+		let property: Ident = body.call(Ident::parse_any)?;
+
+		if property == "experimental" {
+			experimental = true;
+		} else if property == "adapter" {
+			body.parse::<Token![:]>()?;
+			adapter = Some(body.parse()?);
+		} else {
+			return Err(syn::Error::new(
+				property_span,
+				"unknown CustomWidget property",
+			));
+		}
+
+		parse_optional_comma(&body)?;
+	}
+
+	Ok(FormCustomWidgetSpec {
+		component,
+		experimental,
+		adapter,
+		span,
+	})
+}
+
+fn parse_choice_items(input: ParseStream) -> Result<Vec<FormChoiceItem>> {
+	let mut choices = Vec::new();
+
+	while !input.is_empty() {
+		choices.push(parse_choice_item(input)?);
+		parse_optional_comma(input)?;
+	}
+
+	Ok(choices)
+}
+
+fn parse_choice_item(input: ParseStream) -> Result<FormChoiceItem> {
+	if input.peek(Ident) {
+		let fork = input.fork();
+		let ident: Ident = fork.call(Ident::parse_any)?;
+		if ident == "OptGroup" {
+			return parse_choice_group(input).map(FormChoiceItem::Group);
+		}
+	}
+
+	parse_choice_option(input).map(|option| FormChoiceItem::Option(Box::new(option)))
+}
+
+fn parse_choice_option(input: ParseStream) -> Result<FormChoiceOption> {
+	let span = input.span();
+	let content;
+	parenthesized!(content in input);
+
+	let value: Expr = content.parse()?;
+	let label = if content.peek(Token![,]) {
+		content.parse::<Token![,]>()?;
+		if content.is_empty() {
+			None
+		} else {
+			Some(content.parse()?)
+		}
+	} else {
+		None
+	};
+
+	if !content.is_empty() {
+		return Err(content.error("choice option tuple accepts one or two expressions"));
+	}
+
+	let disabled = parse_choice_disabled_block(input)?;
+
+	Ok(FormChoiceOption {
+		value,
+		label,
+		disabled,
+		span,
+	})
+}
+
+fn parse_choice_group(input: ParseStream) -> Result<FormChoiceGroup> {
+	let span = input.span();
+	let ident: Ident = input.call(Ident::parse_any)?;
+	if ident != "OptGroup" {
+		return Err(syn::Error::new(ident.span(), "expected OptGroup"));
+	}
+
+	let label_content;
+	parenthesized!(label_content in input);
+	let label: LitStr = label_content.parse()?;
+	if !label_content.is_empty() {
+		return Err(label_content.error("OptGroup accepts exactly one string label"));
+	}
+
+	let content;
+	braced!(content in input);
+
+	let mut disabled = false;
+	let mut options = Vec::new();
+
+	while !content.is_empty() {
+		if content.peek(Ident) {
+			let fork = content.fork();
+			let flag: Ident = fork.call(Ident::parse_any)?;
+			if flag == "disabled" {
+				let flag: Ident = content.call(Ident::parse_any)?;
+				if flag != "disabled" {
+					return Err(syn::Error::new(flag.span(), "expected disabled"));
+				}
+				disabled = true;
+				parse_optional_comma(&content)?;
+				continue;
+			}
+		}
+
+		options.push(parse_choice_item(&content)?);
+		parse_optional_comma(&content)?;
+	}
+
+	Ok(FormChoiceGroup {
+		label,
+		disabled,
+		options,
+		span,
+	})
+}
+
+fn parse_choice_disabled_block(input: ParseStream) -> Result<bool> {
+	if !input.peek(token::Brace) {
+		return Ok(false);
+	}
+
+	let content;
+	braced!(content in input);
+	let mut disabled = false;
+
+	while !content.is_empty() {
+		let flag: Ident = content.call(Ident::parse_any)?;
+		if flag != "disabled" {
+			return Err(syn::Error::new(flag.span(), "unknown choice option flag"));
+		}
+		disabled = true;
+		parse_optional_comma(&content)?;
+	}
+
+	Ok(disabled)
 }
 
 /// Parses custom attributes for aria-* and data-*.
@@ -1561,7 +1802,13 @@ mod tests {
 			})
 		);
 		assert!(field.properties.iter().any(|p| {
-			matches!(p, FormFieldProperty::Widget { widget_type, .. } if widget_type == "PasswordInput")
+			matches!(
+				p,
+				FormFieldProperty::Widget {
+					widget: FormWidgetSpec::Builtin(widget_type),
+					..
+				} if widget_type == "PasswordInput"
+			)
 		}));
 		assert!(
 			field
@@ -2862,8 +3109,11 @@ mod tests {
 		assert_eq!(group.label_text(), Some("Address".to_string()));
 		assert!(group.class_name().is_none());
 		assert_eq!(group.fields.len(), 2);
-		assert_eq!(group.fields[0].name.to_string(), "street");
-		assert_eq!(group.fields[1].name.to_string(), "city");
+		assert_eq!(
+			group.fields[0].as_field().unwrap().name.to_string(),
+			"street"
+		);
+		assert_eq!(group.fields[1].as_field().unwrap().name.to_string(), "city");
 	}
 
 	#[rstest]
@@ -3133,12 +3383,12 @@ mod tests {
 		assert!(result.is_ok());
 		let form = result.unwrap();
 		let group = form.fields[0].as_group().unwrap();
-		let street = &group.fields[0];
+		let street = group.fields[0].as_field().unwrap();
 		assert!(street.is_required());
 		assert!(street.get_label().is_some());
 		assert!(street.get_class().is_some());
 		assert!(street.get_placeholder().is_some());
-		let city = &group.fields[1];
+		let city = group.fields[1].as_field().unwrap();
 		assert!(city.is_required());
 		assert!(city.get_label().is_some());
 	}

--- a/crates/reinhardt-manouche/src/validator/form.rs
+++ b/crates/reinhardt-manouche/src/validator/form.rs
@@ -17,16 +17,20 @@ use std::collections::HashSet;
 use syn::{Error, Result};
 
 use crate::core::{
-	AmbientArgumentsSource, FormAction, FormCallbacks, FormDerived, FormFieldDef, FormFieldEntry,
-	FormFieldGroup, FormFieldProperty, FormMacro, FormMethod, FormSlots, FormState,
-	FormSubmitButtonDef, FormValidator, FormWatch, IconAttr, IconChild, IconPosition,
-	StripArgument, TypedChoicesConfig, TypedCustomAttr, TypedDerivedItem, TypedFieldDisplay,
+	AmbientArgumentsSource, FormAction, FormCallbacks, FormChoiceItem, FormControlEntryDef,
+	FormControlEntryKind, FormCustomWidgetSpec, FormDatalistDef, FormDerived, FormFieldDef,
+	FormFieldEntry, FormFieldGroup, FormFieldProperty, FormMacro, FormMethod, FormSlots, FormState,
+	FormSubmitButtonDef, FormValidator, FormWatch, FormWidgetSpec, IconAttr, IconChild,
+	IconPosition, StripArgument, TypedButtonControlDef, TypedButtonKind, TypedChoiceGroup,
+	TypedChoiceItem, TypedChoiceOption, TypedChoicesConfig, TypedCustomAttr, TypedCustomWidget,
+	TypedDatalistDef, TypedDerivedItem, TypedFieldDisplay, TypedFieldNativeAttrs,
 	TypedFieldStyling, TypedFieldType, TypedFieldValidation, TypedFormAction, TypedFormCallbacks,
 	TypedFormDerived, TypedFormFieldDef, TypedFormFieldEntry, TypedFormFieldGroup, TypedFormMacro,
 	TypedFormSlots, TypedFormState, TypedFormStyling, TypedFormValidator, TypedFormWatch,
 	TypedFormWatchItem, TypedIcon, TypedIconAttr, TypedIconChild, TypedIconPosition,
-	TypedStripArgument, TypedSubmitButtonDef, TypedValidatorRule, TypedWidget, TypedWrapper,
-	TypedWrapperAttr, ValidatorRule,
+	TypedImageInputDef, TypedMeterDef, TypedOutputDef, TypedProgressDef, TypedStripArgument,
+	TypedSubmitButtonDef, TypedValidatorRule, TypedWidget, TypedWrapper, TypedWrapperAttr,
+	ValidatorRule,
 };
 
 /// Validates and transforms the FormMacro AST into a typed AST.
@@ -99,6 +103,7 @@ pub fn validate_form_with_ambient_arguments_source(
 
 	// Transform fields
 	let fields = transform_fields(&ast.fields)?;
+	validate_list_references(&fields)?;
 
 	// Transform unified validators (scope filtering happens at codegen)
 	let validators = transform_validators(&ast.validators, &ast.fields)?;
@@ -139,49 +144,149 @@ fn validate_unique_field_names(entries: &[FormFieldEntry]) -> Result<()> {
 	let mut seen = HashSet::new();
 
 	for entry in entries {
-		match entry {
-			FormFieldEntry::Field(field) => {
-				let name = field.name.to_string();
-				if !seen.insert(name.clone()) {
-					return Err(Error::new(
-						field.name.span(),
-						format!("duplicate field name: '{}'", name),
-					));
-				}
-			}
-			FormFieldEntry::Group(group) => {
-				// Check group name is unique
-				let group_name = group.name.to_string();
-				if !seen.insert(group_name.clone()) {
-					return Err(Error::new(
-						group.name.span(),
-						format!("duplicate field/group name: '{}'", group_name),
-					));
-				}
+		validate_unique_entry_name(entry, &mut seen, None)?;
+	}
 
-				// Check fields within the group
-				for field in &group.fields {
-					let name = field.name.to_string();
-					if !seen.insert(name.clone()) {
+	Ok(())
+}
+
+fn validate_unique_entry_name(
+	entry: &FormFieldEntry,
+	seen: &mut HashSet<String>,
+	group_name: Option<&str>,
+) -> Result<()> {
+	match entry {
+		FormFieldEntry::Field(field) => {
+			let name = field.name.to_string();
+			if !seen.insert(name.clone()) {
+				let message = if let Some(group_name) = group_name {
+					format!(
+						"duplicate field name: '{}' (in group '{}')",
+						name, group_name
+					)
+				} else {
+					format!("duplicate field name: '{}'", name)
+				};
+				return Err(Error::new(field.name.span(), message));
+			}
+		}
+		FormFieldEntry::Group(group) => {
+			let name = group.name.to_string();
+			if !seen.insert(name.clone()) {
+				return Err(Error::new(
+					group.name.span(),
+					format!("duplicate field/group name: '{}'", name),
+				));
+			}
+
+			for child in &group.fields {
+				validate_unique_entry_name(child, seen, Some(&name))?;
+			}
+		}
+		FormFieldEntry::SubmitButton(btn) => {
+			let name = btn.name.to_string();
+			if !seen.insert(name.clone()) {
+				return Err(Error::new(
+					btn.name.span(),
+					format!("duplicate field/button name: '{}'", name),
+				));
+			}
+		}
+		FormFieldEntry::ResetButton(control)
+		| FormFieldEntry::Button(control)
+		| FormFieldEntry::ImageInput(control)
+		| FormFieldEntry::Output(control)
+		| FormFieldEntry::Meter(control)
+		| FormFieldEntry::Progress(control) => {
+			let name = control.name.to_string();
+			if !seen.insert(name.clone()) {
+				let message = if let Some(group_name) = group_name {
+					format!(
+						"duplicate field/control name: '{}' (in group '{}')",
+						name, group_name
+					)
+				} else {
+					format!("duplicate field/control name: '{}'", name)
+				};
+				return Err(Error::new(control.name.span(), message));
+			}
+		}
+		FormFieldEntry::Datalist(datalist) => {
+			let name = datalist.name.to_string();
+			if !seen.insert(name.clone()) {
+				let message = if let Some(group_name) = group_name {
+					format!(
+						"duplicate field/datalist name: '{}' (in group '{}')",
+						name, group_name
+					)
+				} else {
+					format!("duplicate field/datalist name: '{}'", name)
+				};
+				return Err(Error::new(datalist.name.span(), message));
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_list_references(entries: &[TypedFormFieldEntry]) -> Result<()> {
+	let mut datalist_names = HashSet::new();
+	collect_datalist_names(entries, &mut datalist_names);
+	validate_entry_list_references(entries, &datalist_names)
+}
+
+fn collect_datalist_names(entries: &[TypedFormFieldEntry], datalist_names: &mut HashSet<String>) {
+	for entry in entries {
+		match entry {
+			TypedFormFieldEntry::Group(group) => {
+				collect_datalist_names(&group.fields, datalist_names);
+			}
+			TypedFormFieldEntry::Datalist(datalist) => {
+				datalist_names.insert(datalist.name.to_string());
+			}
+			TypedFormFieldEntry::Field(_)
+			| TypedFormFieldEntry::SubmitButton(_)
+			| TypedFormFieldEntry::ResetButton(_)
+			| TypedFormFieldEntry::Button(_)
+			| TypedFormFieldEntry::ImageInput(_)
+			| TypedFormFieldEntry::Output(_)
+			| TypedFormFieldEntry::Meter(_)
+			| TypedFormFieldEntry::Progress(_) => {}
+		}
+	}
+}
+
+fn validate_entry_list_references(
+	entries: &[TypedFormFieldEntry],
+	datalist_names: &HashSet<String>,
+) -> Result<()> {
+	for entry in entries {
+		match entry {
+			TypedFormFieldEntry::Field(field) => {
+				if let Some(list) = &field.native_attrs.list {
+					let list_name = list.to_string();
+					if !datalist_names.contains(&list_name) {
 						return Err(Error::new(
-							field.name.span(),
+							list.span(),
 							format!(
-								"duplicate field name: '{}' (in group '{}')",
-								name, group_name
+								"list reference '{list_name}' must resolve to a Datalist entry",
 							),
 						));
 					}
 				}
 			}
-			FormFieldEntry::SubmitButton(btn) => {
-				let name = btn.name.to_string();
-				if !seen.insert(name.clone()) {
-					return Err(Error::new(
-						btn.name.span(),
-						format!("duplicate field/button name: '{}'", name),
-					));
-				}
+			TypedFormFieldEntry::Group(group) => {
+				validate_entry_list_references(&group.fields, datalist_names)?;
 			}
+			TypedFormFieldEntry::SubmitButton(_)
+			| TypedFormFieldEntry::ResetButton(_)
+			| TypedFormFieldEntry::Button(_)
+			| TypedFormFieldEntry::ImageInput(_)
+			| TypedFormFieldEntry::Output(_)
+			| TypedFormFieldEntry::Meter(_)
+			| TypedFormFieldEntry::Progress(_)
+			| TypedFormFieldEntry::Datalist(_) => {}
 		}
 	}
 
@@ -436,34 +541,70 @@ fn transform_slots(slots: &Option<FormSlots>) -> Result<Option<TypedFormSlots>> 
 
 /// Transforms all field entries (fields and field groups).
 fn transform_fields(entries: &[FormFieldEntry]) -> Result<Vec<TypedFormFieldEntry>> {
-	entries.iter().map(transform_field_entry).collect()
+	entries
+		.iter()
+		.map(|entry| transform_field_entry(entry, entries))
+		.collect()
 }
 
 /// Transforms a single field entry (either a field or a group).
-fn transform_field_entry(entry: &FormFieldEntry) -> Result<TypedFormFieldEntry> {
+fn transform_field_entry(
+	entry: &FormFieldEntry,
+	all_entries: &[FormFieldEntry],
+) -> Result<TypedFormFieldEntry> {
 	match entry {
 		FormFieldEntry::Field(field) => {
 			let typed_field = transform_field(field)?;
 			Ok(TypedFormFieldEntry::Field(Box::new(typed_field)))
 		}
 		FormFieldEntry::Group(group) => {
-			let typed_group = transform_field_group(group)?;
+			let typed_group = transform_field_group(group, all_entries)?;
 			Ok(TypedFormFieldEntry::Group(typed_group))
 		}
 		FormFieldEntry::SubmitButton(btn) => {
 			let typed_btn = transform_submit_button(btn)?;
 			Ok(TypedFormFieldEntry::SubmitButton(typed_btn))
 		}
+		FormFieldEntry::ResetButton(control) => {
+			let typed_control = transform_button_control(control)?;
+			Ok(TypedFormFieldEntry::ResetButton(typed_control))
+		}
+		FormFieldEntry::Button(control) => {
+			let typed_control = transform_button_control(control)?;
+			Ok(TypedFormFieldEntry::Button(typed_control))
+		}
+		FormFieldEntry::ImageInput(control) => {
+			let typed_control = transform_image_input(control)?;
+			Ok(TypedFormFieldEntry::ImageInput(typed_control))
+		}
+		FormFieldEntry::Output(control) => {
+			let typed_control = transform_output(control, all_entries)?;
+			Ok(TypedFormFieldEntry::Output(typed_control))
+		}
+		FormFieldEntry::Meter(control) => {
+			let typed_control = transform_meter(control)?;
+			Ok(TypedFormFieldEntry::Meter(Box::new(typed_control)))
+		}
+		FormFieldEntry::Progress(control) => {
+			let typed_control = transform_progress(control)?;
+			Ok(TypedFormFieldEntry::Progress(Box::new(typed_control)))
+		}
+		FormFieldEntry::Datalist(datalist) => {
+			let typed_datalist = transform_datalist(datalist)?;
+			Ok(TypedFormFieldEntry::Datalist(Box::new(typed_datalist)))
+		}
 	}
 }
 
 /// Transforms a field group into a typed field group.
-fn transform_field_group(group: &FormFieldGroup) -> Result<TypedFormFieldGroup> {
-	// Transform each field in the group
-	let typed_fields: Vec<TypedFormFieldDef> = group
+fn transform_field_group(
+	group: &FormFieldGroup,
+	all_entries: &[FormFieldEntry],
+) -> Result<TypedFormFieldGroup> {
+	let typed_fields: Vec<TypedFormFieldEntry> = group
 		.fields
 		.iter()
-		.map(transform_field)
+		.map(|entry| transform_field_entry(entry, all_entries))
 		.collect::<Result<_>>()?;
 
 	Ok(TypedFormFieldGroup {
@@ -571,6 +712,424 @@ fn transform_submit_button(btn: &FormSubmitButtonDef) -> Result<TypedSubmitButto
 	})
 }
 
+fn transform_button_control(control: &FormControlEntryDef) -> Result<TypedButtonControlDef> {
+	let kind_name = control_entry_kind_name(control.kind);
+	let mut label = None;
+	let mut class = None;
+	let mut id = None;
+	let mut disabled = false;
+
+	for prop in &control.properties {
+		match prop {
+			FormFieldProperty::Named { name, value, span } => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"label" => label = Some(expect_string_literal(value, *span, "label")?),
+					"class" => class = Some(expect_string_literal(value, *span, "class")?),
+					"id" => id = Some(expect_string_literal(value, *span, "id")?),
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown {kind_name} property: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			FormFieldProperty::Flag { name, span } => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"disabled" => disabled = true,
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown {kind_name} flag: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			_ => {
+				return Err(unknown_control_property_error(control.kind, prop));
+			}
+		}
+	}
+
+	let (kind, default_label) = match control.kind {
+		FormControlEntryKind::ResetButton => (TypedButtonKind::Reset, "Reset"),
+		FormControlEntryKind::Button => (TypedButtonKind::Button, "Button"),
+		_ => {
+			return Err(Error::new(
+				control.span,
+				format!("{kind_name} cannot be transformed as a button control"),
+			));
+		}
+	};
+
+	Ok(TypedButtonControlDef {
+		name: control.name.clone(),
+		kind,
+		label: label.unwrap_or_else(|| default_label.to_string()),
+		class,
+		id,
+		disabled,
+		span: control.span,
+	})
+}
+
+fn transform_image_input(control: &FormControlEntryDef) -> Result<TypedImageInputDef> {
+	let mut src = None;
+	let mut alt = None;
+	let mut class = None;
+	let mut id = None;
+	let mut disabled = false;
+	let mut width = None;
+	let mut height = None;
+
+	for prop in &control.properties {
+		match prop {
+			FormFieldProperty::Named { name, value, span } => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"src" => src = Some(expect_string_literal(value, *span, "src")?),
+					"alt" => alt = Some(expect_string_literal(value, *span, "alt")?),
+					"class" => class = Some(expect_string_literal(value, *span, "class")?),
+					"id" => id = Some(expect_string_literal(value, *span, "id")?),
+					"width" => {
+						width = Some(expect_positive_i64_literal(value, *span, "width")?);
+					}
+					"height" => {
+						height = Some(expect_positive_i64_literal(value, *span, "height")?);
+					}
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown ImageInput property: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			FormFieldProperty::Flag { name, span } => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"disabled" => disabled = true,
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown ImageInput flag: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			_ => return Err(unknown_control_property_error(control.kind, prop)),
+		}
+	}
+
+	Ok(TypedImageInputDef {
+		name: control.name.clone(),
+		src: src.ok_or_else(|| Error::new(control.span, "ImageInput requires src"))?,
+		alt: alt.ok_or_else(|| Error::new(control.span, "ImageInput requires alt"))?,
+		class,
+		id,
+		disabled,
+		width,
+		height,
+		span: control.span,
+	})
+}
+
+fn transform_output(
+	control: &FormControlEntryDef,
+	all_entries: &[FormFieldEntry],
+) -> Result<TypedOutputDef> {
+	let mut label = None;
+	let mut for_fields = Vec::new();
+	let mut class = None;
+	let mut id = None;
+
+	for prop in &control.properties {
+		match prop {
+			FormFieldProperty::Named { name, value, span } => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"label" => label = Some(expect_string_literal(value, *span, "label")?),
+					"for" => for_fields = expect_ident_array(value, *span, "for")?,
+					"class" => class = Some(expect_string_literal(value, *span, "class")?),
+					"id" => id = Some(expect_string_literal(value, *span, "id")?),
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown Output property: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			FormFieldProperty::Flag { name, span } => {
+				let prop_name = name.to_string();
+				return Err(Error::new(
+					*span,
+					format!("unknown Output flag: '{prop_name}'"),
+				));
+			}
+			_ => return Err(unknown_control_property_error(control.kind, prop)),
+		}
+	}
+
+	for field in &for_fields {
+		if !field_exists(all_entries, field) {
+			return Err(Error::new(
+				field.span(),
+				format!("Output for references unknown value field: '{}'", field),
+			));
+		}
+	}
+
+	Ok(TypedOutputDef {
+		name: control.name.clone(),
+		label,
+		for_fields,
+		class,
+		id,
+		span: control.span,
+	})
+}
+
+fn transform_meter(control: &FormControlEntryDef) -> Result<TypedMeterDef> {
+	let mut label = None;
+	let mut value = None;
+	let mut min = None;
+	let mut max = None;
+	let mut low = None;
+	let mut high = None;
+	let mut optimum = None;
+	let mut class = None;
+	let mut id = None;
+
+	for prop in &control.properties {
+		match prop {
+			FormFieldProperty::Named {
+				name,
+				value: expr,
+				span,
+			} => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"label" => label = Some(expect_string_literal(expr, *span, "label")?),
+					"value" => value = Some(expr.clone()),
+					"min" => min = Some(expr.clone()),
+					"max" => max = Some(expr.clone()),
+					"low" => low = Some(expr.clone()),
+					"high" => high = Some(expr.clone()),
+					"optimum" => optimum = Some(expr.clone()),
+					"class" => class = Some(expect_string_literal(expr, *span, "class")?),
+					"id" => id = Some(expect_string_literal(expr, *span, "id")?),
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown Meter property: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			FormFieldProperty::Flag { name, span } => {
+				let prop_name = name.to_string();
+				return Err(Error::new(
+					*span,
+					format!("unknown Meter flag: '{prop_name}'"),
+				));
+			}
+			_ => return Err(unknown_control_property_error(control.kind, prop)),
+		}
+	}
+
+	Ok(TypedMeterDef {
+		name: control.name.clone(),
+		label,
+		value: value.ok_or_else(|| Error::new(control.span, "Meter requires value"))?,
+		min,
+		max,
+		low,
+		high,
+		optimum,
+		class,
+		id,
+		span: control.span,
+	})
+}
+
+fn transform_progress(control: &FormControlEntryDef) -> Result<TypedProgressDef> {
+	let mut label = None;
+	let mut value = None;
+	let mut max = None;
+	let mut class = None;
+	let mut id = None;
+
+	for prop in &control.properties {
+		match prop {
+			FormFieldProperty::Named {
+				name,
+				value: expr,
+				span,
+			} => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"label" => label = Some(expect_string_literal(expr, *span, "label")?),
+					"value" => value = Some(expr.clone()),
+					"max" => max = Some(expr.clone()),
+					"class" => class = Some(expect_string_literal(expr, *span, "class")?),
+					"id" => id = Some(expect_string_literal(expr, *span, "id")?),
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown Progress property: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			FormFieldProperty::Flag { name, span } => {
+				let prop_name = name.to_string();
+				return Err(Error::new(
+					*span,
+					format!("unknown Progress flag: '{prop_name}'"),
+				));
+			}
+			_ => return Err(unknown_control_property_error(control.kind, prop)),
+		}
+	}
+
+	Ok(TypedProgressDef {
+		name: control.name.clone(),
+		label,
+		value,
+		max,
+		class,
+		id,
+		span: control.span,
+	})
+}
+
+fn transform_datalist(datalist: &FormDatalistDef) -> Result<TypedDatalistDef> {
+	validate_datalist_properties(datalist)?;
+
+	let static_choices = extract_static_choices(&datalist.properties)?;
+	let choices_config = extract_choices_config(&datalist.properties);
+
+	if !static_choices.is_empty() && choices_config.is_some() {
+		return Err(Error::new(
+			datalist.span,
+			"Datalist cannot specify both options and choices_from",
+		));
+	}
+
+	if static_choices.is_empty() && choices_config.is_none() {
+		return Err(Error::new(
+			datalist.span,
+			"Datalist requires either options or choices_from",
+		));
+	}
+
+	let static_choices = transform_static_choices(&static_choices, false, true)?;
+
+	Ok(TypedDatalistDef {
+		name: datalist.name.clone(),
+		static_choices,
+		choices_config,
+		span: datalist.span,
+	})
+}
+
+fn validate_datalist_properties(datalist: &FormDatalistDef) -> Result<()> {
+	for prop in &datalist.properties {
+		match prop {
+			FormFieldProperty::Choices { .. }
+			| FormFieldProperty::ChoicesFrom { .. }
+			| FormFieldProperty::ChoiceValue { .. }
+			| FormFieldProperty::ChoiceLabel { .. }
+			| FormFieldProperty::ChoiceDisabled { .. } => {}
+			FormFieldProperty::ChoiceGroup { .. }
+			| FormFieldProperty::ChoiceGroupDisabled { .. } => {
+				let prop_name = property_name(prop);
+				return Err(Error::new(
+					property_span(prop),
+					format!("Datalist does not support {prop_name}; datalist options must be flat",),
+				));
+			}
+			_ => {
+				let prop_name = property_name(prop);
+				return Err(Error::new(
+					property_span(prop),
+					format!("unknown Datalist property: '{prop_name}'"),
+				));
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn control_entry_kind_name(kind: FormControlEntryKind) -> &'static str {
+	match kind {
+		FormControlEntryKind::ResetButton => "ResetButton",
+		FormControlEntryKind::Button => "Button",
+		FormControlEntryKind::ImageInput => "ImageInput",
+		FormControlEntryKind::Output => "Output",
+		FormControlEntryKind::Meter => "Meter",
+		FormControlEntryKind::Progress => "Progress",
+	}
+}
+
+fn property_name(prop: &FormFieldProperty) -> String {
+	match prop {
+		FormFieldProperty::Named { name, .. } | FormFieldProperty::Flag { name, .. } => {
+			name.to_string()
+		}
+		FormFieldProperty::Widget { .. } => "widget".to_string(),
+		FormFieldProperty::Wrapper { .. } => "wrapper".to_string(),
+		FormFieldProperty::Icon { .. } => "icon".to_string(),
+		FormFieldProperty::IconPosition { .. } => "icon_position".to_string(),
+		FormFieldProperty::Attrs { .. } => "attrs".to_string(),
+		FormFieldProperty::Bind { .. } => "bind".to_string(),
+		FormFieldProperty::InitialFrom { .. } => "initial_from".to_string(),
+		FormFieldProperty::ChoicesFrom { .. } => "choices_from".to_string(),
+		FormFieldProperty::Choices { .. } => "choices".to_string(),
+		FormFieldProperty::ChoiceValue { .. } => "choice_value".to_string(),
+		FormFieldProperty::ChoiceLabel { .. } => "choice_label".to_string(),
+		FormFieldProperty::ChoiceDisabled { .. } => "choice_disabled".to_string(),
+		FormFieldProperty::ChoiceGroup { .. } => "choice_group".to_string(),
+		FormFieldProperty::ChoiceGroupDisabled { .. } => "choice_group_disabled".to_string(),
+	}
+}
+
+fn property_span(prop: &FormFieldProperty) -> Span {
+	match prop {
+		FormFieldProperty::Named { span, .. }
+		| FormFieldProperty::Flag { span, .. }
+		| FormFieldProperty::Widget { span, .. }
+		| FormFieldProperty::Wrapper { span, .. }
+		| FormFieldProperty::Icon { span, .. }
+		| FormFieldProperty::IconPosition { span, .. }
+		| FormFieldProperty::Attrs { span, .. }
+		| FormFieldProperty::Bind { span, .. }
+		| FormFieldProperty::InitialFrom { span, .. }
+		| FormFieldProperty::ChoicesFrom { span, .. }
+		| FormFieldProperty::Choices { span, .. }
+		| FormFieldProperty::ChoiceValue { span, .. }
+		| FormFieldProperty::ChoiceLabel { span, .. }
+		| FormFieldProperty::ChoiceDisabled { span, .. }
+		| FormFieldProperty::ChoiceGroup { span, .. }
+		| FormFieldProperty::ChoiceGroupDisabled { span, .. } => *span,
+	}
+}
+
+fn unknown_control_property_error(kind: FormControlEntryKind, prop: &FormFieldProperty) -> Error {
+	Error::new(
+		property_span(prop),
+		format!(
+			"unknown {} property: '{}'",
+			control_entry_kind_name(kind),
+			property_name(prop)
+		),
+	)
+}
+
 /// Transforms a single field definition.
 ///
 /// All property extraction errors are annotated with the field name for context.
@@ -595,6 +1154,9 @@ fn transform_field(field: &FormFieldDef) -> Result<TypedFormFieldDef> {
 	let display = extract_display_properties(&field.properties).map_err(&annotate)?;
 	let styling = extract_styling_properties(&field.properties).map_err(&annotate)?;
 	let widget = extract_widget(&field.properties, &field_type).map_err(&annotate)?;
+	validate_widget_field_compatibility(&field_type, &widget, field.span).map_err(&annotate)?;
+	let native_attrs =
+		extract_native_attrs(&field.properties, &field_type, &widget).map_err(&annotate)?;
 	let wrapper = extract_wrapper(&field.properties).map_err(&annotate)?;
 	let icon = extract_icon(&field.properties).map_err(&annotate)?;
 	let custom_attrs = extract_custom_attrs(&field.properties).map_err(&annotate)?;
@@ -602,11 +1164,48 @@ fn transform_field(field: &FormFieldDef) -> Result<TypedFormFieldDef> {
 	let initial_from = extract_initial_from(&field.properties);
 	let initial_expr = extract_initial_expr(&field.properties);
 	let choices_config = extract_choices_config(&field.properties);
+	let static_choices_source = extract_static_choices(&field.properties).map_err(&annotate)?;
+
+	validate_radio_select_choice_group_properties(&field.properties, &widget).map_err(&annotate)?;
+
+	if !static_choices_source.is_empty() && choices_config.is_some() {
+		return Err(annotate(Error::new(
+			field.span,
+			"field cannot specify both choices and choices_from",
+		)));
+	}
+
+	if choices_config.is_some() && !field_type_accepts_choices(&field_type) {
+		return Err(annotate(Error::new(
+			field.span,
+			"choices_from can only be used with ChoiceField or MultipleChoiceField",
+		)));
+	}
+
+	if !static_choices_source.is_empty() && !field_type_accepts_choices(&field_type) {
+		return Err(annotate(Error::new(
+			field.span,
+			"choices can only be used with ChoiceField or MultipleChoiceField",
+		)));
+	}
+
+	if !static_choices_source.is_empty()
+		&& !matches!(widget, TypedWidget::Select | TypedWidget::SelectMultiple)
+	{
+		return Err(annotate(Error::new(
+			field.span,
+			"choices require Select or SelectMultiple widget",
+		)));
+	}
+
+	let static_choices =
+		transform_static_choices(&static_choices_source, true, false).map_err(&annotate)?;
 
 	Ok(TypedFormFieldDef {
 		name: field.name.clone(),
 		field_type,
 		widget,
+		native_attrs,
 		validation,
 		display,
 		styling,
@@ -617,8 +1216,132 @@ fn transform_field(field: &FormFieldDef) -> Result<TypedFormFieldDef> {
 		initial_from,
 		initial_expr,
 		choices_config,
+		static_choices,
 		span: field.span,
 	})
+}
+
+fn field_type_accepts_choices(field_type: &TypedFieldType) -> bool {
+	matches!(
+		field_type,
+		TypedFieldType::ChoiceField { .. } | TypedFieldType::MultipleChoiceField { .. }
+	)
+}
+
+fn validate_radio_select_choice_group_properties(
+	properties: &[FormFieldProperty],
+	widget: &TypedWidget,
+) -> Result<()> {
+	if !matches!(widget, TypedWidget::RadioSelect) {
+		return Ok(());
+	}
+
+	for prop in properties {
+		match prop {
+			FormFieldProperty::ChoiceGroup { .. } => {
+				return Err(Error::new(
+					property_span(prop),
+					"choice_group is only supported on Select and SelectMultiple widgets",
+				));
+			}
+			FormFieldProperty::ChoiceGroupDisabled { .. } => {
+				return Err(Error::new(
+					property_span(prop),
+					"choice_group_disabled is only supported on Select and SelectMultiple widgets",
+				));
+			}
+			_ => {}
+		}
+	}
+
+	Ok(())
+}
+
+fn extract_static_choices(properties: &[FormFieldProperty]) -> Result<Vec<FormChoiceItem>> {
+	let mut choices = None;
+
+	for prop in properties {
+		if let FormFieldProperty::Choices {
+			choices: items,
+			span,
+		} = prop
+		{
+			if choices.is_some() {
+				return Err(Error::new(
+					*span,
+					"choices/options specified more than once",
+				));
+			}
+			choices = Some(items.clone());
+		}
+	}
+
+	Ok(choices.unwrap_or_default())
+}
+
+fn transform_static_choices(
+	choices: &[FormChoiceItem],
+	allow_groups: bool,
+	datalist: bool,
+) -> Result<Vec<TypedChoiceItem>> {
+	choices
+		.iter()
+		.map(|choice| transform_static_choice_item(choice, allow_groups, datalist))
+		.collect()
+}
+
+fn transform_static_choice_item(
+	choice: &FormChoiceItem,
+	allow_groups: bool,
+	datalist: bool,
+) -> Result<TypedChoiceItem> {
+	match choice {
+		FormChoiceItem::Option(option) => Ok(TypedChoiceItem::Option(Box::new(
+			transform_static_choice_option(option),
+		))),
+		FormChoiceItem::Group(group) => {
+			if datalist {
+				return Err(Error::new(
+					group.span,
+					"Datalist options cannot contain OptGroup",
+				));
+			}
+			if !allow_groups {
+				return Err(Error::new(
+					group.span,
+					"OptGroup is only supported by Select and SelectMultiple widgets",
+				));
+			}
+
+			let mut options = Vec::with_capacity(group.options.len());
+			for option in &group.options {
+				match option {
+					FormChoiceItem::Option(option) => {
+						options.push(transform_static_choice_option(option));
+					}
+					FormChoiceItem::Group(group) => {
+						return Err(Error::new(group.span, "nested OptGroup is not supported"));
+					}
+				}
+			}
+
+			Ok(TypedChoiceItem::Group(TypedChoiceGroup {
+				label: group.label.value(),
+				disabled: group.disabled,
+				options,
+				span: group.span,
+			}))
+		}
+	}
+}
+
+fn transform_static_choice_option(option: &crate::core::FormChoiceOption) -> TypedChoiceOption {
+	TypedChoiceOption {
+		value: option.value.clone(),
+		label: option.label.clone().unwrap_or_else(|| option.value.clone()),
+		disabled: option.disabled,
+		span: option.span,
+	}
 }
 
 /// Parses field type identifier into TypedFieldType enum.
@@ -825,8 +1548,12 @@ fn extract_validation_properties(properties: &[FormFieldProperty]) -> Result<Typ
 			FormFieldProperty::Bind { .. } => {}   // Ignore bind properties
 			FormFieldProperty::InitialFrom { .. } => {} // Ignore initial_from properties
 			FormFieldProperty::ChoicesFrom { .. } => {} // Ignore choices_from properties
+			FormFieldProperty::Choices { .. } => {} // Ignore static choice properties
 			FormFieldProperty::ChoiceValue { .. } => {} // Ignore choice_value properties
 			FormFieldProperty::ChoiceLabel { .. } => {} // Ignore choice_label properties
+			FormFieldProperty::ChoiceDisabled { .. } => {} // Ignore choice_disabled properties
+			FormFieldProperty::ChoiceGroup { .. } => {} // Ignore choice_group properties
+			FormFieldProperty::ChoiceGroupDisabled { .. } => {} // Ignore choice_group_disabled properties
 		}
 	}
 
@@ -914,8 +1641,12 @@ fn extract_display_properties(properties: &[FormFieldProperty]) -> Result<TypedF
 			FormFieldProperty::Bind { .. } => {}   // Ignore bind properties
 			FormFieldProperty::InitialFrom { .. } => {} // Ignore initial_from properties
 			FormFieldProperty::ChoicesFrom { .. } => {} // Ignore choices_from properties
+			FormFieldProperty::Choices { .. } => {} // Ignore static choice properties
 			FormFieldProperty::ChoiceValue { .. } => {} // Ignore choice_value properties
 			FormFieldProperty::ChoiceLabel { .. } => {} // Ignore choice_label properties
+			FormFieldProperty::ChoiceDisabled { .. } => {} // Ignore choice_disabled properties
+			FormFieldProperty::ChoiceGroup { .. } => {} // Ignore choice_group properties
+			FormFieldProperty::ChoiceGroupDisabled { .. } => {} // Ignore choice_group_disabled properties
 		}
 	}
 
@@ -980,11 +1711,11 @@ fn extract_widget(
 	// Look for explicit widget property
 	for prop in properties {
 		match prop {
-			FormFieldProperty::Widget {
-				widget_type,
-				span: _,
-			} => {
-				return parse_widget(widget_type);
+			FormFieldProperty::Widget { widget, span: _ } => {
+				return match widget {
+					FormWidgetSpec::Builtin(widget_type) => parse_widget(widget_type),
+					FormWidgetSpec::Custom(custom) => validate_custom_widget(custom),
+				};
 			}
 			FormFieldProperty::Named { name, value, span } if name == "widget" => {
 				// Handle widget specified as named property: widget: PasswordInput
@@ -1006,6 +1737,26 @@ fn extract_widget(
 	Ok(field_type.default_widget())
 }
 
+fn validate_custom_widget(custom: &FormCustomWidgetSpec) -> Result<TypedWidget> {
+	if !custom.experimental {
+		return Err(Error::new(
+			custom.span,
+			"CustomWidget requires the experimental marker",
+		));
+	}
+
+	let adapter = custom
+		.adapter
+		.clone()
+		.ok_or_else(|| Error::new(custom.span, "CustomWidget requires adapter"))?;
+
+	Ok(TypedWidget::CustomExperimental(TypedCustomWidget {
+		component: custom.component.clone(),
+		adapter,
+		span: custom.span,
+	}))
+}
+
 /// Parses widget identifier into TypedWidget enum.
 fn parse_widget(ident: &syn::Ident) -> Result<TypedWidget> {
 	let widget_str = ident.to_string();
@@ -1020,6 +1771,8 @@ fn parse_widget(ident: &syn::Ident) -> Result<TypedWidget> {
 		"Select" => Ok(TypedWidget::Select),
 		"SelectMultiple" => Ok(TypedWidget::SelectMultiple),
 		"DateInput" => Ok(TypedWidget::DateInput),
+		"MonthInput" => Ok(TypedWidget::MonthInput),
+		"WeekInput" => Ok(TypedWidget::WeekInput),
 		"TimeInput" => Ok(TypedWidget::TimeInput),
 		"DateTimeInput" => Ok(TypedWidget::DateTimeInput),
 		"FileInput" => Ok(TypedWidget::FileInput),
@@ -1033,13 +1786,326 @@ fn parse_widget(ident: &syn::Ident) -> Result<TypedWidget> {
 			ident.span(),
 			format!(
 				"unknown widget type: '{}'. Expected one of: TextInput, PasswordInput, \
-				EmailInput, NumberInput, Textarea, CheckboxInput, RadioSelect, Select, \
-				SelectMultiple, DateInput, TimeInput, DateTimeInput, FileInput, HiddenInput, \
-				ColorInput, RangeInput, UrlInput, TelInput, SearchInput",
+					EmailInput, NumberInput, Textarea, CheckboxInput, RadioSelect, Select, \
+					SelectMultiple, DateInput, MonthInput, WeekInput, TimeInput, DateTimeInput, \
+					FileInput, HiddenInput, ColorInput, RangeInput, UrlInput, TelInput, SearchInput",
 				widget_str
 			),
 		)),
 	}
+}
+
+#[derive(Default)]
+struct NativeAttrSpans {
+	min: Option<Span>,
+	max: Option<Span>,
+	step: Option<Span>,
+	multiple: Option<Span>,
+	accept: Option<Span>,
+	capture: Option<Span>,
+	list: Option<Span>,
+	size: Option<Span>,
+}
+
+fn validate_widget_field_compatibility(
+	field_type: &TypedFieldType,
+	widget: &TypedWidget,
+	span: Span,
+) -> Result<()> {
+	match widget {
+		TypedWidget::MonthInput if !is_string_valued_field(field_type) => Err(Error::new(
+			span,
+			"MonthInput is only supported on string-valued fields",
+		)),
+		TypedWidget::WeekInput if !is_string_valued_field(field_type) => Err(Error::new(
+			span,
+			"WeekInput is only supported on string-valued fields",
+		)),
+		_ => Ok(()),
+	}
+}
+
+fn extract_native_attrs(
+	properties: &[FormFieldProperty],
+	field_type: &TypedFieldType,
+	widget: &TypedWidget,
+) -> Result<TypedFieldNativeAttrs> {
+	let mut attrs = TypedFieldNativeAttrs::default();
+	let mut spans = NativeAttrSpans::default();
+
+	for prop in properties {
+		match prop {
+			FormFieldProperty::Named { name, value, span } => match name.to_string().as_str() {
+				"min" => {
+					attrs.min = Some(value.clone());
+					spans.min = Some(*span);
+				}
+				"max" => {
+					attrs.max = Some(value.clone());
+					spans.max = Some(*span);
+				}
+				"step" => {
+					attrs.step = Some(value.clone());
+					spans.step = Some(*span);
+				}
+				"multiple" => {
+					attrs.multiple = Some(expect_bool_literal(value, *span, "multiple")?);
+					spans.multiple = Some(*span);
+				}
+				"accept" => {
+					attrs.accept = Some(expect_string_literal(value, *span, "accept")?);
+					spans.accept = Some(*span);
+				}
+				"capture" => {
+					attrs.capture = Some(expect_string_literal(value, *span, "capture")?);
+					spans.capture = Some(*span);
+				}
+				"list" => {
+					attrs.list = Some(expect_ident_expr(value, *span, "list")?);
+					spans.list = Some(*span);
+				}
+				"size" => {
+					attrs.size = Some(expect_positive_i64_literal(value, *span, "size")?);
+					spans.size = Some(*span);
+				}
+				_ => {}
+			},
+			FormFieldProperty::Flag { name, span } if name == "multiple" => {
+				attrs.multiple = Some(true);
+				spans.multiple = Some(*span);
+			}
+			_ => {}
+		}
+	}
+
+	validate_native_attrs(field_type, widget, &attrs, &spans)?;
+	Ok(attrs)
+}
+
+fn validate_native_attrs(
+	field_type: &TypedFieldType,
+	widget: &TypedWidget,
+	attrs: &TypedFieldNativeAttrs,
+	spans: &NativeAttrSpans,
+) -> Result<()> {
+	if attrs.accept.is_some() && !is_file_like_input(field_type, widget) {
+		return Err(Error::new(
+			spans.accept.unwrap_or_else(Span::call_site),
+			"accept is only supported on file-like inputs",
+		));
+	}
+	if attrs.capture.is_some() && !is_file_like_input(field_type, widget) {
+		return Err(Error::new(
+			spans.capture.unwrap_or_else(Span::call_site),
+			"capture is only supported on file-like inputs",
+		));
+	}
+	if attrs.multiple.is_some() && !is_file_like_input(field_type, widget) {
+		return Err(Error::new(
+			spans.multiple.unwrap_or_else(Span::call_site),
+			"multiple is only supported on file-like inputs",
+		));
+	}
+	if attrs.list.is_some() && !is_text_like_input(widget) {
+		return Err(Error::new(
+			spans.list.unwrap_or_else(Span::call_site),
+			"list is only supported on text-like inputs",
+		));
+	}
+	if attrs.size.is_some() && !supports_size_attr(widget) {
+		return Err(Error::new(
+			spans.size.unwrap_or_else(Span::call_site),
+			"size is only supported on text-like inputs",
+		));
+	}
+	if attrs.min.is_some() && !supports_value_bound_attrs(widget) {
+		return Err(Error::new(
+			spans.min.unwrap_or_else(Span::call_site),
+			"min is only supported on native value inputs",
+		));
+	}
+	if attrs.max.is_some() && !supports_value_bound_attrs(widget) {
+		return Err(Error::new(
+			spans.max.unwrap_or_else(Span::call_site),
+			"max is only supported on native value inputs",
+		));
+	}
+	if attrs.step.is_some() && !supports_value_bound_attrs(widget) {
+		return Err(Error::new(
+			spans.step.unwrap_or_else(Span::call_site),
+			"step is only supported on native value inputs",
+		));
+	}
+
+	Ok(())
+}
+
+fn expect_string_literal(value: &syn::Expr, span: Span, prop_name: &str) -> Result<String> {
+	if let syn::Expr::Lit(lit) = value
+		&& let syn::Lit::Str(str_lit) = &lit.lit
+	{
+		return Ok(str_lit.value());
+	}
+
+	Err(Error::new(
+		span,
+		format!("{prop_name} must be a string literal"),
+	))
+}
+
+fn expect_bool_literal(value: &syn::Expr, span: Span, prop_name: &str) -> Result<bool> {
+	if let syn::Expr::Lit(lit) = value
+		&& let syn::Lit::Bool(bool_lit) = &lit.lit
+	{
+		return Ok(bool_lit.value);
+	}
+
+	Err(Error::new(
+		span,
+		format!("{prop_name} must be true or false"),
+	))
+}
+
+fn expect_ident_expr(value: &syn::Expr, span: Span, prop_name: &str) -> Result<syn::Ident> {
+	if let syn::Expr::Path(path) = value
+		&& path.path.leading_colon.is_none()
+		&& path.path.segments.len() == 1
+		&& let Some(ident) = path.path.get_ident()
+	{
+		return Ok(ident.clone());
+	}
+
+	Err(Error::new(
+		span,
+		format!("{prop_name} must be an identifier"),
+	))
+}
+
+fn expect_ident_array(value: &syn::Expr, span: Span, prop_name: &str) -> Result<Vec<syn::Ident>> {
+	let syn::Expr::Array(array) = value else {
+		return Err(Error::new(
+			span,
+			format!("{prop_name} must be an array of field identifiers"),
+		));
+	};
+
+	array
+		.elems
+		.iter()
+		.map(|elem| expect_ident_expr(elem, span, prop_name))
+		.collect()
+}
+
+fn expect_i64_literal(value: &syn::Expr, span: Span, prop_name: &str) -> Result<i64> {
+	match value {
+		syn::Expr::Lit(lit) => {
+			if let syn::Lit::Int(int_lit) = &lit.lit {
+				int_lit.base10_parse::<i64>().map_err(|_| {
+					Error::new(span, format!("{prop_name} must be an integer literal"))
+				})
+			} else {
+				Err(Error::new(
+					span,
+					format!("{prop_name} must be an integer literal"),
+				))
+			}
+		}
+		syn::Expr::Unary(unary) => {
+			if let syn::UnOp::Neg(_) = unary.op
+				&& let syn::Expr::Lit(lit) = &*unary.expr
+				&& let syn::Lit::Int(int_lit) = &lit.lit
+			{
+				let value = int_lit.base10_parse::<i64>().map_err(|_| {
+					Error::new(span, format!("{prop_name} must be an integer literal"))
+				})?;
+				Ok(-value)
+			} else {
+				Err(Error::new(
+					span,
+					format!("{prop_name} must be an integer literal"),
+				))
+			}
+		}
+		_ => Err(Error::new(
+			span,
+			format!("{prop_name} must be an integer literal"),
+		)),
+	}
+}
+
+fn expect_positive_i64_literal(value: &syn::Expr, span: Span, prop_name: &str) -> Result<i64> {
+	let parsed = expect_i64_literal(value, span, prop_name)?;
+	if parsed > 0 {
+		return Ok(parsed);
+	}
+
+	Err(Error::new(
+		span,
+		format!("{prop_name} must be a positive integer literal"),
+	))
+}
+
+fn is_string_valued_field(field_type: &TypedFieldType) -> bool {
+	matches!(
+		field_type,
+		TypedFieldType::CharField
+			| TypedFieldType::EmailField
+			| TypedFieldType::UrlField
+			| TypedFieldType::SlugField
+			| TypedFieldType::PasswordField
+			| TypedFieldType::TextField
+			| TypedFieldType::UuidField
+			| TypedFieldType::IpAddressField
+	)
+}
+
+fn is_file_like_input(field_type: &TypedFieldType, widget: &TypedWidget) -> bool {
+	matches!(
+		(field_type, widget),
+		(
+			TypedFieldType::FileField | TypedFieldType::ImageField,
+			TypedWidget::FileInput
+		)
+	)
+}
+
+fn is_text_like_input(widget: &TypedWidget) -> bool {
+	matches!(
+		widget,
+		TypedWidget::TextInput
+			| TypedWidget::SearchInput
+			| TypedWidget::UrlInput
+			| TypedWidget::TelInput
+			| TypedWidget::EmailInput
+			| TypedWidget::PasswordInput
+			| TypedWidget::MonthInput
+			| TypedWidget::WeekInput
+	)
+}
+
+fn supports_size_attr(widget: &TypedWidget) -> bool {
+	matches!(
+		widget,
+		TypedWidget::TextInput
+			| TypedWidget::SearchInput
+			| TypedWidget::UrlInput
+			| TypedWidget::TelInput
+			| TypedWidget::EmailInput
+			| TypedWidget::PasswordInput
+	)
+}
+
+fn supports_value_bound_attrs(widget: &TypedWidget) -> bool {
+	matches!(
+		widget,
+		TypedWidget::NumberInput
+			| TypedWidget::RangeInput
+			| TypedWidget::DateInput
+			| TypedWidget::TimeInput
+			| TypedWidget::DateTimeInput
+			| TypedWidget::MonthInput
+			| TypedWidget::WeekInput
+	)
 }
 
 /// Extracts wrapper property and transforms it into `TypedWrapper`.
@@ -1297,6 +2363,9 @@ fn extract_choices_config(properties: &[FormFieldProperty]) -> Option<TypedChoic
 	let mut choices_from: Option<(String, Span)> = None;
 	let mut choice_value: Option<String> = None;
 	let mut choice_label: Option<String> = None;
+	let mut choice_disabled: Option<String> = None;
+	let mut choice_group: Option<String> = None;
+	let mut choice_group_disabled: Option<String> = None;
 
 	for prop in properties {
 		match prop {
@@ -1309,6 +2378,15 @@ fn extract_choices_config(properties: &[FormFieldProperty]) -> Option<TypedChoic
 			FormFieldProperty::ChoiceLabel { path, .. } => {
 				choice_label = Some(path.value());
 			}
+			FormFieldProperty::ChoiceDisabled { path, .. } => {
+				choice_disabled = Some(path.value());
+			}
+			FormFieldProperty::ChoiceGroup { path, .. } => {
+				choice_group = Some(path.value());
+			}
+			FormFieldProperty::ChoiceGroupDisabled { path, .. } => {
+				choice_group_disabled = Some(path.value());
+			}
 			_ => {}
 		}
 	}
@@ -1319,6 +2397,9 @@ fn extract_choices_config(properties: &[FormFieldProperty]) -> Option<TypedChoic
 			from,
 			choice_value.unwrap_or_else(|| "value".to_string()),
 			choice_label.unwrap_or_else(|| "label".to_string()),
+			choice_disabled,
+			choice_group,
+			choice_group_disabled,
 			span,
 		)
 	})
@@ -1406,11 +2487,18 @@ fn field_exists(entries: &[FormFieldEntry], name: &syn::Ident) -> bool {
 				}
 			}
 			FormFieldEntry::Group(group) => {
-				if group.fields.iter().any(|f| f.name == *name) {
+				if field_exists(&group.fields, name) {
 					return true;
 				}
 			}
-			FormFieldEntry::SubmitButton(_) => {}
+			FormFieldEntry::SubmitButton(_)
+			| FormFieldEntry::ResetButton(_)
+			| FormFieldEntry::Button(_)
+			| FormFieldEntry::ImageInput(_)
+			| FormFieldEntry::Output(_)
+			| FormFieldEntry::Meter(_)
+			| FormFieldEntry::Progress(_)
+			| FormFieldEntry::Datalist(_) => {}
 		}
 	}
 	false
@@ -3073,9 +4161,10 @@ mod tests {
 		assert_eq!(group.fields.len(), 2);
 
 		// Check fields within the group
-		assert_eq!(group.fields[0].name.to_string(), "street");
-		assert!(group.fields[0].validation.required);
-		assert_eq!(group.fields[1].name.to_string(), "city");
+		let street = group.fields[0].as_field().unwrap();
+		assert_eq!(street.name.to_string(), "street");
+		assert!(street.validation.required);
+		assert_eq!(group.fields[1].as_field().unwrap().name.to_string(), "city");
 	}
 
 	#[rstest]
@@ -3337,8 +4426,14 @@ mod tests {
 		assert!(result.is_ok());
 		let typed = result.unwrap();
 		let group = typed.fields[0].as_group().unwrap();
-		assert_eq!(group.fields[0].initial_from, Some("name".to_string()));
-		assert_eq!(group.fields[1].initial_from, Some("biography".to_string()));
+		assert_eq!(
+			group.fields[0].as_field().unwrap().initial_from,
+			Some("name".to_string())
+		);
+		assert_eq!(
+			group.fields[1].as_field().unwrap().initial_from,
+			Some("biography".to_string())
+		);
 	}
 
 	#[rstest]
@@ -3424,7 +4519,7 @@ mod tests {
 		let group = typed.fields[0].as_group().unwrap();
 
 		// Check email field properties
-		let email = &group.fields[0];
+		let email = group.fields[0].as_field().unwrap();
 		assert!(email.validation.required);
 		assert_eq!(email.display.label, Some("Email Address".to_string()));
 		assert_eq!(
@@ -3434,7 +4529,7 @@ mod tests {
 		assert!(email.has_wrapper());
 
 		// Check password field properties
-		let password = &group.fields[1];
+		let password = group.fields[1].as_field().unwrap();
 		assert!(password.validation.required);
 		assert!(matches!(password.widget, TypedWidget::PasswordInput));
 		assert!(!password.bind);
@@ -3823,6 +4918,64 @@ mod tests {
 	}
 
 	#[rstest]
+	fn test_validate_radio_select_rejects_dynamic_choice_group() {
+		// Arrange
+		let input = quote! {
+			name: RadioSelectGroupForm,
+			action: "/test",
+			choices_loader: load_options,
+
+			fields: {
+				selected: ChoiceField {
+					widget: RadioSelect,
+					choices_from: "options",
+					choice_value: "id",
+					choice_label: "name",
+					choice_group: "group",
+				},
+			},
+		};
+
+		// Act
+		let err = parse_and_validate(input).unwrap_err().to_string();
+
+		// Assert
+		assert_eq!(
+			err,
+			"choice_group is only supported on Select and SelectMultiple widgets"
+		);
+	}
+
+	#[rstest]
+	fn test_validate_radio_select_rejects_dynamic_choice_group_disabled() {
+		// Arrange
+		let input = quote! {
+			name: RadioSelectGroupDisabledForm,
+			action: "/test",
+			choices_loader: load_options,
+
+			fields: {
+				selected: ChoiceField {
+					widget: RadioSelect,
+					choices_from: "options",
+					choice_value: "id",
+					choice_label: "name",
+					choice_group_disabled: "group_disabled",
+				},
+			},
+		};
+
+		// Act
+		let err = parse_and_validate(input).unwrap_err().to_string();
+
+		// Assert
+		assert_eq!(
+			err,
+			"choice_group_disabled is only supported on Select and SelectMultiple widgets"
+		);
+	}
+
+	#[rstest]
 	fn test_validate_choices_loader_with_initial_loader() {
 		// Arrange
 		let input = quote! {
@@ -3906,19 +5059,158 @@ mod tests {
 		// Check fields within the group
 		assert_eq!(group.fields.len(), 2);
 
-		let category_field = &group.fields[0];
+		let category_field = group.fields[0].as_field().unwrap();
 		assert!(category_field.choices_config.is_some());
 		assert_eq!(
 			category_field.choices_config.as_ref().unwrap().choices_from,
 			"categories"
 		);
 
-		let status_field = &group.fields[1];
+		let status_field = group.fields[1].as_field().unwrap();
 		assert!(status_field.choices_config.is_some());
 		assert_eq!(
 			status_field.choices_config.as_ref().unwrap().choices_from,
 			"statuses"
 		);
+	}
+
+	#[rstest]
+	fn test_validate_dynamic_datalist_and_list_reference() {
+		// Arrange
+		let input = quote! {
+			name: DynamicDatalistForm,
+			action: "/search",
+			choices_loader: load_suggestions,
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					list: suggestions,
+				},
+				suggestions: Datalist {
+					choices_from: "items",
+					choice_value: "value",
+					choice_label: "label",
+					choice_disabled: "disabled",
+				},
+			},
+		};
+
+		// Act
+		let typed = parse_and_validate(input).unwrap();
+
+		// Assert
+		let field = typed.fields[0].as_field().unwrap();
+		assert_eq!(
+			field.native_attrs.list.as_ref().unwrap().to_string(),
+			"suggestions"
+		);
+
+		let datalist = typed.fields[1].as_datalist().unwrap();
+		let config = datalist.choices_config.as_ref().unwrap();
+		assert_eq!(config.choices_from, "items");
+		assert_eq!(config.choice_value, "value");
+		assert_eq!(config.choice_label, "label");
+		assert_eq!(config.choice_disabled.as_deref(), Some("disabled"));
+		assert!(datalist.static_choices.is_empty());
+	}
+
+	#[rstest]
+	fn test_validate_list_rejects_missing_datalist() {
+		// Arrange
+		let input = quote! {
+			name: MissingDatalistForm,
+			action: "/search",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					list: suggestions,
+				},
+			},
+		};
+
+		// Act
+		let err = parse_and_validate(input).unwrap_err().to_string();
+
+		// Assert
+		assert_eq!(
+			err,
+			"list reference 'suggestions' must resolve to a Datalist entry"
+		);
+	}
+
+	#[rstest]
+	fn test_validate_list_rejects_value_field_reference() {
+		// Arrange
+		let input = quote! {
+			name: ValueFieldListForm,
+			action: "/search",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					list: suggestions,
+				},
+				suggestions: CharField {},
+			},
+		};
+
+		// Act
+		let err = parse_and_validate(input).unwrap_err().to_string();
+
+		// Assert
+		assert_eq!(
+			err,
+			"list reference 'suggestions' must resolve to a Datalist entry"
+		);
+	}
+
+	#[rstest]
+	fn test_validate_datalist_rejects_choice_group() {
+		// Arrange
+		let input = quote! {
+			name: InvalidDatalistGroupForm,
+			action: "/search",
+
+			fields: {
+				suggestions: Datalist {
+					choices_from: "items",
+					choice_group: "group",
+				},
+			},
+		};
+
+		// Act
+		let err = parse_and_validate(input).unwrap_err().to_string();
+
+		// Assert
+		assert_eq!(
+			err,
+			"Datalist does not support choice_group; datalist options must be flat"
+		);
+	}
+
+	#[rstest]
+	fn test_validate_datalist_rejects_unknown_property() {
+		// Arrange
+		let input = quote! {
+			name: InvalidDatalistPropertyForm,
+			action: "/search",
+
+			fields: {
+				suggestions: Datalist {
+					options: [("a", "A")],
+					label: "Suggestions",
+				},
+			},
+		};
+
+		// Act
+		let err = parse_and_validate(input).unwrap_err().to_string();
+
+		// Assert
+		assert_eq!(err, "unknown Datalist property: 'label'");
 	}
 
 	// =========================================================================
@@ -4244,5 +5536,83 @@ mod tests {
 		assert!(result.is_ok());
 		let typed = result.unwrap();
 		assert!(typed.redirect_on_success.is_none());
+	}
+
+	#[rstest]
+	fn test_typed_widget_size_rejects_zero() {
+		// Arrange
+		let input = quote! {
+			name: SearchForm,
+			action: "/search",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					size: 0,
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert_eq!(
+			result.unwrap_err().to_string(),
+			"size must be a positive integer literal"
+		);
+	}
+
+	#[rstest]
+	fn test_typed_widget_size_rejects_negative() {
+		// Arrange
+		let input = quote! {
+			name: SearchForm,
+			action: "/search",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					size: -1,
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert_eq!(
+			result.unwrap_err().to_string(),
+			"size must be a positive integer literal"
+		);
+	}
+
+	#[rstest]
+	fn test_typed_widget_size_rejects_non_integer() {
+		// Arrange
+		let input = quote! {
+			name: SearchForm,
+			action: "/search",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					size: "32",
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert_eq!(
+			result.unwrap_err().to_string(),
+			"size must be an integer literal"
+		);
 	}
 }

--- a/crates/reinhardt-manouche/src/validator/form.rs
+++ b/crates/reinhardt-manouche/src/validator/form.rs
@@ -1130,6 +1130,57 @@ fn unknown_control_property_error(kind: FormControlEntryKind, prop: &FormFieldPr
 	)
 }
 
+const ALLOWED_FIELD_PROPERTIES: &[&str] = &[
+	"accept",
+	"autocomplete",
+	"autofocus",
+	"capture",
+	"class",
+	"disabled",
+	"error_class",
+	"help_text",
+	"initial",
+	"label",
+	"label_class",
+	"list",
+	"max",
+	"max_length",
+	"max_value",
+	"min",
+	"min_length",
+	"min_value",
+	"multiple",
+	"pattern",
+	"placeholder",
+	"readonly",
+	"required",
+	"size",
+	"step",
+	"widget",
+	"wrapper_class",
+];
+
+fn validate_known_field_properties(properties: &[FormFieldProperty]) -> Result<()> {
+	for prop in properties {
+		let (name, span) = match prop {
+			FormFieldProperty::Named { name, span, .. }
+			| FormFieldProperty::Flag { name, span } => (name.to_string(), *span),
+			_ => continue,
+		};
+
+		if !ALLOWED_FIELD_PROPERTIES.contains(&name.as_str()) {
+			return Err(Error::new(
+				span,
+				format!(
+					"unknown field property: '{name}'. Use typed field properties for native form behavior (min, max, step, accept, capture, list, size), and use attrs only for aria_* or data_* custom attributes"
+				),
+			));
+		}
+	}
+
+	Ok(())
+}
+
 /// Transforms a single field definition.
 ///
 /// All property extraction errors are annotated with the field name for context.
@@ -1167,6 +1218,7 @@ fn transform_field(field: &FormFieldDef) -> Result<TypedFormFieldDef> {
 	let static_choices_source = extract_static_choices(&field.properties).map_err(&annotate)?;
 
 	validate_radio_select_choice_group_properties(&field.properties, &widget).map_err(&annotate)?;
+	validate_known_field_properties(&field.properties).map_err(&annotate)?;
 
 	if !static_choices_source.is_empty() && choices_config.is_some() {
 		return Err(annotate(Error::new(
@@ -1900,10 +1952,10 @@ fn validate_native_attrs(
 			"capture is only supported on file-like inputs",
 		));
 	}
-	if attrs.multiple.is_some() && !is_file_like_input(field_type, widget) {
+	if attrs.multiple.is_some() {
 		return Err(Error::new(
 			spans.multiple.unwrap_or_else(Span::call_site),
-			"multiple is only supported on file-like inputs",
+			"multiple field property is not supported yet. Use SelectMultiple for multi-select fields; multi-file inputs require a future Vec<File> value contract",
 		));
 	}
 	if attrs.list.is_some() && !is_text_like_input(widget) {
@@ -2054,8 +2106,6 @@ fn is_string_valued_field(field_type: &TypedFieldType) -> bool {
 			| TypedFieldType::SlugField
 			| TypedFieldType::PasswordField
 			| TypedFieldType::TextField
-			| TypedFieldType::UuidField
-			| TypedFieldType::IpAddressField
 	)
 }
 

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -169,6 +169,47 @@ contract as `Option<web_sys::File>` values. File values are browser-owned and
 are tracked for dirty/touched state without treating the file payload as a
 serializable scalar.
 
+Stable native widget coverage includes the following `form!` DSL items:
+
+| DSL item | HTML output | Value state |
+|---|---|---|
+| `MonthInput` | `<input type="month">` | string field |
+| `WeekInput` | `<input type="week">` | string field |
+| `ResetButton` | `<button type="reset">` | none |
+| `Button` | `<button type="button">` | none |
+| `ImageInput` | `<input type="image">` | none |
+| `Datalist` | `<datalist>` | option source only |
+| `OptGroup` | `<optgroup>` | choice grouping only |
+| `Output` | `<output>` | none |
+| `Meter` | `<meter>` | none |
+| `Progress` | `<progress>` | none |
+
+Typed native attributes are accepted for the controls that support them:
+
+| Attribute | Compatible controls |
+|---|---|
+| `min` / `max` / `step` | number, range, date, time, datetime-local, month, week |
+| `size` | text-like inputs |
+| `accept` / `capture` | file-like inputs |
+| `multiple` | file-like inputs and multi-select |
+| `list` | datalist-compatible text-like inputs |
+
+`FieldGroup` renders as semantic `<fieldset>` output. When `label` is
+present, the label is rendered as a `<legend>` inside the fieldset.
+
+`CustomWidget` is experimental and must opt in explicitly:
+
+```rust,ignore
+date_range: CharField {
+    widget: CustomWidget(crate::widgets::DateRangePicker) {
+        experimental,
+        adapter: crate::widgets::DateRangeAdapter,
+    },
+}
+```
+
+The adapter API may change in a minor release with a documented migration path.
+
 Arguments supplied from ambient context use `ambient_arguments`. The old
 `strip_arguments` name remains as a deprecated alias. CSRF should stay at the
 transport layer: `#[server_fn]` client stubs attach `X-CSRFToken`, while

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -103,6 +103,18 @@ fn collect_all_datalists(entries: &[TypedFormFieldEntry]) -> Vec<&TypedDatalistD
 	datalists
 }
 
+fn custom_widget_touched_ident(field: &TypedFormFieldDef) -> Option<syn::Ident> {
+	if matches!(field.widget, TypedWidget::CustomExperimental(_)) {
+		Some(format_ident!(
+			"__{}_custom_widget_touched",
+			field.name,
+			span = field.name.span()
+		))
+	} else {
+		None
+	}
+}
+
 fn generate_ambient_argument_deprecation_markers(
 	macro_ast: &TypedFormMacro,
 	ambient_arguments_source: Option<AmbientArgumentsSource>,
@@ -235,7 +247,14 @@ fn generate_form_runtime_contract(
 		.iter()
 		.map(|field| {
 			let name = &field.name;
-			quote! { self.#name.set(values.#name.clone()); }
+			let custom_widget_touched_reset =
+				custom_widget_touched_ident(field).map(|touched_name| {
+					quote! { self.#touched_name.set(false); }
+				});
+			quote! {
+				self.#name.set(values.#name.clone());
+				#custom_widget_touched_reset
+			}
 		})
 		.collect();
 
@@ -261,12 +280,19 @@ fn generate_form_runtime_contract(
 		.map(|(field, variant)| {
 			let name = &field.name;
 			let ty = field_type_to_value_type(&field.field_type);
+			let custom_widget_touched_set =
+				custom_widget_touched_ident(field).map(|touched_name| {
+					quote! { self.#touched_name.set(true); }
+				});
 			quote! {
 				#field_ident::#variant => {
 					let boxed: ::std::boxed::Box<dyn ::core::any::Any> =
 						::std::boxed::Box::new(value);
 					match boxed.downcast::<#ty>() {
-						Ok(value) => self.#name.set(*value),
+						Ok(value) => {
+							self.#name.set(*value);
+							#custom_widget_touched_set
+						}
 						Err(_) => panic!(
 							"form! field {:?} does not accept values of type {}",
 							field,
@@ -282,8 +308,15 @@ fn generate_form_runtime_contract(
 		.zip(field_variants.iter())
 		.map(|(field, variant)| {
 			let name = &field.name;
+			let custom_widget_touched_reset =
+				custom_widget_touched_ident(field).map(|touched_name| {
+					quote! { self.#touched_name.set(false); }
+				});
 			quote! {
-				#field_ident::#variant => self.#name.set(values.#name.clone()),
+				#field_ident::#variant => {
+					self.#name.set(values.#name.clone());
+					#custom_widget_touched_reset
+				}
 			}
 		})
 		.collect();
@@ -1019,6 +1052,19 @@ fn generate_field_declarations(
 		.collect();
 
 	decls.extend(custom_widget_error_decls);
+
+	let custom_widget_touched_decls: Vec<TokenStream> = fields
+		.iter()
+		.filter_map(|field| {
+			custom_widget_touched_ident(field).map(|touched_name| {
+				quote! {
+					#touched_name: #pages_crate::reactive::Signal<bool>,
+				}
+			})
+		})
+		.collect();
+
+	decls.extend(custom_widget_touched_decls);
 	quote! { #(#decls)* }
 }
 
@@ -1103,6 +1149,19 @@ fn generate_field_initializers(
 		.collect();
 
 	inits.extend(custom_widget_error_inits);
+
+	let custom_widget_touched_inits: Vec<TokenStream> = fields
+		.iter()
+		.filter_map(|field| {
+			custom_widget_touched_ident(field).map(|touched_name| {
+				quote! {
+					#touched_name: #pages_crate::reactive::Signal::new(false),
+				}
+			})
+		})
+		.collect();
+
+	inits.extend(custom_widget_touched_inits);
 	quote! { #(#inits)* }
 }
 
@@ -2615,26 +2674,34 @@ fn generate_field_view(
 			let component = &custom.component;
 			let adapter = &custom.adapter;
 			let value_type = field_type_to_value_type(&field.field_type);
+			let disabled = field.display.disabled;
 			let custom_widget_error_name = format_ident!(
 				"__{}_custom_widget_error",
 				field_name,
 				span = field_name.span()
 			);
+			let custom_widget_touched_name =
+				custom_widget_touched_ident(field).expect("custom widget touched signal");
 			quote! {
-				{
-					let __field_signal = self.#field_name.clone();
-					let __custom_widget_error_signal = self.#custom_widget_error_name.clone();
-					let mut __ctx: #pages_crate::CustomWidgetContext<#value_type> =
-						#pages_crate::CustomWidgetContext::new(
-							__field_signal.get(),
-							::std::rc::Rc::new({
-								let __field_signal = __field_signal.clone();
-								let __custom_widget_error_signal =
-									__custom_widget_error_signal.clone();
-								move |__raw: #pages_crate::CustomWidgetRawValue| {
-									match <#adapter as #pages_crate::FormWidgetAdapter<#value_type>>::parse(__raw) {
-										::core::result::Result::Ok(__value) => {
-											__custom_widget_error_signal
+					{
+						let __field_signal = self.#field_name.clone();
+						let __custom_widget_error_signal = self.#custom_widget_error_name.clone();
+						let __custom_widget_touched_signal =
+							self.#custom_widget_touched_name.clone();
+						let mut __ctx: #pages_crate::CustomWidgetContext<#value_type> =
+							#pages_crate::CustomWidgetContext::new(
+								__field_signal.get(),
+								::std::rc::Rc::new({
+									let __field_signal = __field_signal.clone();
+									let __custom_widget_error_signal =
+										__custom_widget_error_signal.clone();
+									let __custom_widget_touched_signal =
+										__custom_widget_touched_signal.clone();
+									move |__raw: #pages_crate::CustomWidgetRawValue| {
+										__custom_widget_touched_signal.set(true);
+										match <#adapter as #pages_crate::FormWidgetAdapter<#value_type>>::parse(__raw) {
+											::core::result::Result::Ok(__value) => {
+												__custom_widget_error_signal
 												.set(::core::option::Option::None);
 											__field_signal.set(__value);
 											::core::result::Result::Ok(())
@@ -2648,14 +2715,14 @@ fn generate_field_view(
 											::core::result::Result::Err(__error)
 										}
 									}
-								}
-							}),
-						);
-					__ctx.disabled = false;
-					__ctx.required = #required;
-					__ctx.touched = false;
-					__ctx.error = __custom_widget_error_signal.get();
-					__ctx.name = #field_name_str.to_string();
+									}
+								}),
+							);
+						__ctx.disabled = #disabled;
+						__ctx.required = #required;
+						__ctx.touched = __custom_widget_touched_signal.get();
+						__ctx.error = __custom_widget_error_signal.get();
+						__ctx.name = #field_name_str.to_string();
 					__ctx.id = #field_name_str.to_string();
 					let __props =
 						<#adapter as #pages_crate::FormWidgetAdapter<#value_type>>::props(__ctx);
@@ -3142,11 +3209,6 @@ fn generate_native_attrs(attrs: &TypedFieldNativeAttrs) -> TokenStream {
 	if let Some(step) = &attrs.step {
 		result.extend(quote! {
 			.attr("step", (#step).to_string())
-		});
-	}
-	if let Some(multiple) = attrs.multiple {
-		result.extend(quote! {
-			.bool_attr("multiple", #multiple)
 		});
 	}
 	if let Some(accept) = &attrs.accept {
@@ -5481,28 +5543,27 @@ mod tests {
 	#[rstest::rstest]
 	fn test_generate_native_attrs() {
 		let input = quote! {
-			name: NativeAttrsForm,
-			action: "/test",
+		name: NativeAttrsForm,
+		action: "/test",
 
-			fields: {
-				billing_month: CharField {
-					widget: MonthInput,
-					min: "2026-01",
-					max: "2026-12",
-					step: 1,
-				}
-				search: CharField {
-					widget: SearchInput,
-					list: suggestions,
-					size: 32,
-				}
-				suggestions: Datalist {
-					options: [("term", "Term")],
-				}
+		fields: {
+			billing_month: CharField {
+				widget: MonthInput,
+				min: "2026-01",
+				max: "2026-12",
+				step: 1,
+			}
+			search: CharField {
+				widget: SearchInput,
+				list: suggestions,
+				size: 32,
+			}
+			suggestions: Datalist {
+				options: [("term", "Term")],
+			}
 				avatar: FileField {
 					accept: "image/png",
 					capture: "environment",
-					multiple,
 				}
 			},
 		};
@@ -5519,7 +5580,6 @@ mod tests {
 		assert!(output_str.contains(". attr (\"size\" , \"32\")"));
 		assert!(output_str.contains(". attr (\"accept\" , \"image/png\")"));
 		assert!(output_str.contains(". attr (\"capture\" , \"environment\")"));
-		assert!(output_str.contains(". bool_attr (\"multiple\" , true)"));
 	}
 
 	#[rstest::rstest]

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -48,11 +48,12 @@ use quote::{ToTokens, format_ident, quote};
 
 use crate::crate_paths::get_reinhardt_pages_crate_info;
 use reinhardt_manouche::core::{
-	AmbientArgumentsSource, FormMethod, TypedCustomAttr, TypedFieldType, TypedFormAction,
-	TypedFormCallbacks, TypedFormDerived, TypedFormFieldDef, TypedFormFieldEntry,
+	AmbientArgumentsSource, FormMethod, TypedButtonControlDef, TypedButtonKind, TypedChoiceItem,
+	TypedChoiceOption, TypedCustomAttr, TypedDatalistDef, TypedFieldNativeAttrs, TypedFieldType,
+	TypedFormAction, TypedFormCallbacks, TypedFormDerived, TypedFormFieldDef, TypedFormFieldEntry,
 	TypedFormFieldGroup, TypedFormMacro, TypedFormSlots, TypedFormState, TypedFormWatch, TypedIcon,
-	TypedIconChild, TypedIconPosition, TypedSubmitButtonDef, TypedValidatorRule, TypedWidget,
-	TypedWrapper,
+	TypedIconChild, TypedIconPosition, TypedImageInputDef, TypedMeterDef, TypedOutputDef,
+	TypedProgressDef, TypedSubmitButtonDef, TypedValidatorRule, TypedWidget, TypedWrapper,
 };
 
 /// Collects all fields from field entries, flattening groups.
@@ -65,12 +66,41 @@ fn collect_all_fields(entries: &[TypedFormFieldEntry]) -> Vec<&TypedFormFieldDef
 		match entry {
 			TypedFormFieldEntry::Field(field) => fields.push(field.as_ref()),
 			TypedFormFieldEntry::Group(group) => {
-				fields.extend(group.fields.iter());
+				fields.extend(collect_all_fields(&group.fields));
 			}
-			TypedFormFieldEntry::SubmitButton(_) => {} // Not a data field
+			TypedFormFieldEntry::SubmitButton(_)
+			| TypedFormFieldEntry::ResetButton(_)
+			| TypedFormFieldEntry::Button(_)
+			| TypedFormFieldEntry::ImageInput(_)
+			| TypedFormFieldEntry::Output(_)
+			| TypedFormFieldEntry::Meter(_)
+			| TypedFormFieldEntry::Progress(_)
+			| TypedFormFieldEntry::Datalist(_) => {}
 		}
 	}
 	fields
+}
+
+/// Collects all datalist entries from field entries, flattening groups.
+fn collect_all_datalists(entries: &[TypedFormFieldEntry]) -> Vec<&TypedDatalistDef> {
+	let mut datalists = Vec::new();
+	for entry in entries {
+		match entry {
+			TypedFormFieldEntry::Group(group) => {
+				datalists.extend(collect_all_datalists(&group.fields));
+			}
+			TypedFormFieldEntry::Datalist(datalist) => datalists.push(datalist.as_ref()),
+			TypedFormFieldEntry::Field(_)
+			| TypedFormFieldEntry::SubmitButton(_)
+			| TypedFormFieldEntry::ResetButton(_)
+			| TypedFormFieldEntry::Button(_)
+			| TypedFormFieldEntry::ImageInput(_)
+			| TypedFormFieldEntry::Output(_)
+			| TypedFormFieldEntry::Meter(_)
+			| TypedFormFieldEntry::Progress(_) => {}
+		}
+	}
+	datalists
 }
 
 fn generate_ambient_argument_deprecation_markers(
@@ -294,6 +324,73 @@ fn generate_form_runtime_contract(
 			}
 		})
 		.collect();
+	let custom_widget_error_arms: Vec<TokenStream> = all_fields
+		.iter()
+		.zip(field_variants.iter())
+		.map(|(field, variant)| {
+			if matches!(field.widget, TypedWidget::CustomExperimental(_)) {
+				let error_name = format_ident!(
+					"__{}_custom_widget_error",
+					field.name,
+					span = field.name.span()
+				);
+				quote! {
+					#field_ident::#variant => self.#error_name.get(),
+				}
+			} else {
+				quote! {
+					#field_ident::#variant => ::core::option::Option::None,
+				}
+			}
+		})
+		.collect();
+	let custom_widget_error_setters: Vec<TokenStream> = all_fields
+		.iter()
+		.zip(field_variants.iter())
+		.map(|(field, variant)| {
+			if matches!(field.widget, TypedWidget::CustomExperimental(_)) {
+				let error_name = format_ident!(
+					"__{}_custom_widget_error",
+					field.name,
+					span = field.name.span()
+				);
+				quote! {
+					#field_ident::#variant => self.#error_name.set(error),
+				}
+			} else {
+				quote! {
+					#field_ident::#variant => {
+						let _ = error;
+					}
+				}
+			}
+		})
+		.collect();
+	let custom_widget_validation_checks: Vec<TokenStream> = all_fields
+		.iter()
+		.zip(field_variants.iter())
+		.filter_map(|(field, variant)| {
+			if matches!(field.widget, TypedWidget::CustomExperimental(_)) {
+				let error_name = format_ident!(
+					"__{}_custom_widget_error",
+					field.name,
+					span = field.name.span()
+				);
+				Some(quote! {
+					if let ::core::option::Option::Some(__custom_widget_error) =
+						self.#error_name.get()
+					{
+						error.add_field_error(
+							#field_ident::#variant,
+							__custom_widget_error.message(),
+						);
+					}
+				})
+			} else {
+				None
+			}
+		})
+		.collect();
 	let required_validation_checks: Vec<TokenStream> = all_fields
 		.iter()
 		.zip(field_variants.iter())
@@ -406,6 +503,22 @@ fn generate_form_runtime_contract(
 				}
 			}
 
+			fn runtime_custom_widget_error(&self, field: Self::Field) -> ::core::option::Option<#pages_crate::FieldError> {
+				match field {
+					#(#custom_widget_error_arms)*
+				}
+			}
+
+			fn runtime_set_custom_widget_error(
+				&self,
+				field: Self::Field,
+				error: ::core::option::Option<#pages_crate::FieldError>,
+			) {
+				match field {
+					#(#custom_widget_error_setters)*
+				}
+			}
+
 			fn runtime_validate(&self) -> ::core::result::Result<(), #pages_crate::FormValidationError<Self::Field>> {
 				let mut error = #pages_crate::FormValidationError::new();
 				#(#required_validation_checks)*
@@ -424,6 +537,7 @@ fn generate_form_runtime_contract(
 						}
 					}
 				}
+				#(#custom_widget_validation_checks)*
 				if error.is_empty() {
 					::core::result::Result::Ok(())
 				} else {
@@ -721,6 +835,7 @@ pub(super) fn generate(
 
 	// Generate load_choices method if choices_loader is specified
 	let load_choices_method = generate_load_choices(macro_ast, pages_crate);
+	let dynamic_choice_item_type = generate_dynamic_choice_item_type(macro_ast);
 
 	// Collect every field (including group children) and compute the
 	// struct-level where clause for generic-capable inner types. The clause
@@ -739,6 +854,7 @@ pub(super) fn generate(
 			#use_statement
 			#ambient_argument_deprecation_markers
 			#form_runtime_contract
+			#dynamic_choice_item_type
 
 			#[derive(Clone)]
 			struct #struct_name
@@ -804,6 +920,30 @@ pub(super) fn generate(
 	}
 }
 
+fn generate_dynamic_choice_item_type(macro_ast: &TypedFormMacro) -> TokenStream {
+	let has_dynamic_field_choices = collect_all_fields(&macro_ast.fields)
+		.iter()
+		.any(|field| field.choices_config.is_some());
+	let has_dynamic_datalist_choices = collect_all_datalists(&macro_ast.fields)
+		.iter()
+		.any(|datalist| datalist.choices_config.is_some());
+
+	if !has_dynamic_field_choices && !has_dynamic_datalist_choices {
+		return TokenStream::new();
+	}
+
+	quote! {
+		#[derive(Clone, Debug)]
+		struct __ReinhardtChoiceItem<T> {
+			value: T,
+			label: String,
+			disabled: bool,
+			group: ::core::option::Option<String>,
+			group_disabled: bool,
+		}
+	}
+}
+
 /// Generates field declarations for the form struct.
 fn generate_field_declarations(
 	entries: &[TypedFormFieldEntry],
@@ -821,16 +961,19 @@ fn generate_field_declarations(
 		})
 		.collect();
 
-	// Add choices signal fields for dynamic choice fields
+	// Add public tuple choices and internal metadata signals for dynamic choice fields.
 	let choices_decls: Vec<TokenStream> = fields
 		.iter()
 		.filter_map(|field| {
 			if field.choices_config.is_some() {
 				let choices_name =
 					syn::Ident::new(&format!("{}_choices", field.name), field.name.span());
+				let choice_items_name =
+					syn::Ident::new(&format!("{}_choice_items", field.name), field.name.span());
 				let choice_value_ty = choice_value_type(&field.field_type);
 				Some(quote! {
 					#choices_name: #pages_crate::reactive::Signal<Vec<(#choice_value_ty, String)>>,
+					#choice_items_name: #pages_crate::reactive::Signal<Vec<__ReinhardtChoiceItem<#choice_value_ty>>>,
 				})
 			} else {
 				None
@@ -839,6 +982,43 @@ fn generate_field_declarations(
 		.collect();
 
 	decls.extend(choices_decls);
+
+	let datalist_choices_decls: Vec<TokenStream> = collect_all_datalists(entries)
+		.iter()
+		.filter_map(|datalist| {
+			if datalist.choices_config.is_some() {
+				let choices_name =
+					syn::Ident::new(&format!("{}_choices", datalist.name), datalist.name.span());
+				Some(quote! {
+					#choices_name: #pages_crate::reactive::Signal<Vec<__ReinhardtChoiceItem<::std::string::String>>>,
+				})
+			} else {
+				None
+			}
+		})
+		.collect();
+
+	decls.extend(datalist_choices_decls);
+
+	let custom_widget_error_decls: Vec<TokenStream> = fields
+		.iter()
+		.filter_map(|field| {
+			if matches!(field.widget, TypedWidget::CustomExperimental(_)) {
+				let error_name = format_ident!(
+					"__{}_custom_widget_error",
+					field.name,
+					span = field.name.span()
+				);
+				Some(quote! {
+					#error_name: #pages_crate::reactive::Signal<::core::option::Option<#pages_crate::FieldError>>,
+				})
+			} else {
+				None
+			}
+		})
+		.collect();
+
+	decls.extend(custom_widget_error_decls);
 	quote! { #(#decls)* }
 }
 
@@ -866,13 +1046,33 @@ fn generate_field_initializers(
 		})
 		.collect();
 
-	// Add choices signal initializers for dynamic choice fields
+	// Add public tuple choices and internal metadata signal initializers.
 	let choices_inits: Vec<TokenStream> = fields
 		.iter()
 		.filter_map(|field| {
 			if field.choices_config.is_some() {
 				let choices_name =
 					syn::Ident::new(&format!("{}_choices", field.name), field.name.span());
+				let choice_items_name =
+					syn::Ident::new(&format!("{}_choice_items", field.name), field.name.span());
+				Some(quote! {
+					#choices_name: #pages_crate::reactive::Signal::new(Vec::new()),
+					#choice_items_name: #pages_crate::reactive::Signal::new(Vec::new()),
+				})
+			} else {
+				None
+			}
+		})
+		.collect();
+
+	inits.extend(choices_inits);
+
+	let datalist_choices_inits: Vec<TokenStream> = collect_all_datalists(entries)
+		.iter()
+		.filter_map(|datalist| {
+			if datalist.choices_config.is_some() {
+				let choices_name =
+					syn::Ident::new(&format!("{}_choices", datalist.name), datalist.name.span());
 				Some(quote! {
 					#choices_name: #pages_crate::reactive::Signal::new(Vec::new()),
 				})
@@ -882,7 +1082,27 @@ fn generate_field_initializers(
 		})
 		.collect();
 
-	inits.extend(choices_inits);
+	inits.extend(datalist_choices_inits);
+
+	let custom_widget_error_inits: Vec<TokenStream> = fields
+		.iter()
+		.filter_map(|field| {
+			if matches!(field.widget, TypedWidget::CustomExperimental(_)) {
+				let error_name = format_ident!(
+					"__{}_custom_widget_error",
+					field.name,
+					span = field.name.span()
+				);
+				Some(quote! {
+					#error_name: #pages_crate::reactive::Signal::new(::core::option::Option::None),
+				})
+			} else {
+				None
+			}
+		})
+		.collect();
+
+	inits.extend(custom_widget_error_inits);
 	quote! { #(#inits)* }
 }
 
@@ -935,7 +1155,7 @@ fn generate_field_accessors(
 		})
 		.collect();
 
-	// Add choices accessors for dynamic choice fields
+	// Add public tuple choices accessors for dynamic choice fields.
 	let choices_accessors: Vec<TokenStream> = fields
 		.iter()
 		.filter_map(|field| {
@@ -1604,7 +1824,7 @@ fn generate_into_page(macro_ast: &TypedFormMacro, pages_crate: &TokenStream) -> 
 	// Generate signal bindings for fields with bind: true
 	let signal_bindings: Vec<TokenStream> = all_fields
 		.iter()
-		.filter(|field| field.bind)
+		.filter(|field| field.bind && !matches!(field.widget, TypedWidget::CustomExperimental(_)))
 		.map(|field| {
 			let field_name = &field.name;
 			let signal_ident = quote::format_ident!("{}_signal", field_name);
@@ -2039,6 +2259,14 @@ fn generate_field_entry_view(
 			generate_field_group_view(group, pages_crate, all_fields)
 		}
 		TypedFormFieldEntry::SubmitButton(btn) => generate_submit_button_view(btn),
+		TypedFormFieldEntry::ResetButton(btn) | TypedFormFieldEntry::Button(btn) => {
+			generate_button_control_view(btn)
+		}
+		TypedFormFieldEntry::ImageInput(input) => generate_image_input_view(input),
+		TypedFormFieldEntry::Output(output) => generate_output_view(output),
+		TypedFormFieldEntry::Meter(meter) => generate_meter_view(meter),
+		TypedFormFieldEntry::Progress(progress) => generate_progress_view(progress),
+		TypedFormFieldEntry::Datalist(datalist) => generate_datalist_view(datalist, pages_crate),
 	}
 }
 
@@ -2048,6 +2276,7 @@ fn generate_field_entry_view(
 /// No wrapper div or label — just the bare button element.
 fn generate_submit_button_view(btn: &TypedSubmitButtonDef) -> TokenStream {
 	let label = &btn.label;
+	let disabled = btn.disabled;
 
 	let class_attr = btn.class.as_deref().map(|c| {
 		quote! { .attr("class", #c) }
@@ -2057,19 +2286,254 @@ fn generate_submit_button_view(btn: &TypedSubmitButtonDef) -> TokenStream {
 		quote! { .attr("id", #id) }
 	});
 
-	let disabled_attr = if btn.disabled {
-		Some(quote! { .attr("disabled", "disabled") })
-	} else {
-		None
-	};
-
 	quote! {
 		PageElement::new("button")
 			.attr("type", "submit")
 			#class_attr
 			#id_attr
-			#disabled_attr
+			.bool_attr("disabled", #disabled)
 			.child(#label)
+	}
+}
+
+fn generate_button_control_view(btn: &TypedButtonControlDef) -> TokenStream {
+	let label = &btn.label;
+	let button_type = match btn.kind {
+		TypedButtonKind::Reset => "reset",
+		TypedButtonKind::Button => "button",
+	};
+	let disabled = btn.disabled;
+	let class_attr = btn.class.as_deref().map(|c| quote! { .attr("class", #c) });
+	let id_attr = btn.id.as_deref().map(|id| quote! { .attr("id", #id) });
+
+	quote! {
+		PageElement::new("button")
+			.attr("type", #button_type)
+			#class_attr
+			#id_attr
+			.bool_attr("disabled", #disabled)
+			.child(#label)
+	}
+}
+
+fn generate_image_input_view(input: &TypedImageInputDef) -> TokenStream {
+	let name = input.name.to_string();
+	let src = &input.src;
+	let alt = &input.alt;
+	let disabled = input.disabled;
+	let class_attr = input
+		.class
+		.as_deref()
+		.map(|c| quote! { .attr("class", #c) });
+	let id_attr = input.id.as_deref().map(|id| quote! { .attr("id", #id) });
+	let width_attr = input.width.map(|width| {
+		let width = width.to_string();
+		quote! { .attr("width", #width) }
+	});
+	let height_attr = input.height.map(|height| {
+		let height = height.to_string();
+		quote! { .attr("height", #height) }
+	});
+
+	quote! {
+		PageElement::new("input")
+			.attr("type", "image")
+			.attr("name", #name)
+			.attr("src", #src)
+			.attr("alt", #alt)
+			#class_attr
+			#id_attr
+			.bool_attr("disabled", #disabled)
+			#width_attr
+			#height_attr
+	}
+}
+
+fn generate_output_view(output: &TypedOutputDef) -> TokenStream {
+	let name = output.name.to_string();
+	let for_attr = if output.for_fields.is_empty() {
+		None
+	} else {
+		let for_value = output
+			.for_fields
+			.iter()
+			.map(ToString::to_string)
+			.collect::<Vec<_>>()
+			.join(" ");
+		Some(quote! { .attr("for", #for_value) })
+	};
+	let class_attr = output
+		.class
+		.as_deref()
+		.map(|c| quote! { .attr("class", #c) });
+	let id_attr = output.id.as_deref().map(|id| quote! { .attr("id", #id) });
+	let label_child = output
+		.label
+		.as_deref()
+		.map(|label| quote! { .child(#label) });
+
+	quote! {
+		PageElement::new("output")
+			.attr("name", #name)
+			#for_attr
+			#class_attr
+			#id_attr
+			#label_child
+	}
+}
+
+fn generate_meter_view(meter: &TypedMeterDef) -> TokenStream {
+	let name = meter.name.to_string();
+	let value = &meter.value;
+	let min_attr = meter
+		.min
+		.as_ref()
+		.map(|expr| quote! { .attr("min", (#expr).to_string()) });
+	let max_attr = meter
+		.max
+		.as_ref()
+		.map(|expr| quote! { .attr("max", (#expr).to_string()) });
+	let low_attr = meter
+		.low
+		.as_ref()
+		.map(|expr| quote! { .attr("low", (#expr).to_string()) });
+	let high_attr = meter
+		.high
+		.as_ref()
+		.map(|expr| quote! { .attr("high", (#expr).to_string()) });
+	let optimum_attr = meter
+		.optimum
+		.as_ref()
+		.map(|expr| quote! { .attr("optimum", (#expr).to_string()) });
+	let class_attr = meter
+		.class
+		.as_deref()
+		.map(|c| quote! { .attr("class", #c) });
+	let id_attr = meter.id.as_deref().map(|id| quote! { .attr("id", #id) });
+	let label_child = meter
+		.label
+		.as_deref()
+		.map(|label| quote! { .child(#label) });
+
+	quote! {
+		PageElement::new("meter")
+			.attr("name", #name)
+			.attr("value", (#value).to_string())
+			#min_attr
+			#max_attr
+			#low_attr
+			#high_attr
+			#optimum_attr
+			#class_attr
+			#id_attr
+			#label_child
+	}
+}
+
+fn generate_progress_view(progress: &TypedProgressDef) -> TokenStream {
+	let name = progress.name.to_string();
+	let value_attr = progress
+		.value
+		.as_ref()
+		.map(|expr| quote! { .attr("value", (#expr).to_string()) });
+	let max_attr = progress
+		.max
+		.as_ref()
+		.map(|expr| quote! { .attr("max", (#expr).to_string()) });
+	let class_attr = progress
+		.class
+		.as_deref()
+		.map(|c| quote! { .attr("class", #c) });
+	let id_attr = progress.id.as_deref().map(|id| quote! { .attr("id", #id) });
+	let label_child = progress
+		.label
+		.as_deref()
+		.map(|label| quote! { .child(#label) });
+
+	quote! {
+		PageElement::new("progress")
+			.attr("name", #name)
+			#value_attr
+			#max_attr
+			#class_attr
+			#id_attr
+			#label_child
+	}
+}
+
+fn generate_datalist_view(datalist: &TypedDatalistDef, pages_crate: &TokenStream) -> TokenStream {
+	let id = datalist.name.to_string();
+	if datalist.choices_config.is_some() {
+		let choices_name =
+			syn::Ident::new(&format!("{}_choices", datalist.name), datalist.name.span());
+		return quote! {
+			{
+				let __choices_signal = self.#choices_name.clone();
+				PageElement::new("datalist")
+					.attr("id", #id)
+					.child(#pages_crate::component::Page::reactive(move || {
+						let __choices = __choices_signal.get();
+						let mut __children = ::std::vec::Vec::new();
+						for choice in __choices.into_iter() {
+							__children.push(
+								PageElement::new("option")
+									.attr("value", choice.value)
+									.bool_attr("disabled", choice.disabled)
+									.child(choice.label)
+									.into_page(),
+							);
+						}
+						#pages_crate::component::Page::Fragment(__children)
+					}))
+			}
+		};
+	}
+
+	let option_children: Vec<TokenStream> = datalist
+		.static_choices
+		.iter()
+		.map(generate_static_choice_item_view)
+		.collect();
+
+	quote! {
+		PageElement::new("datalist")
+			.attr("id", #id)
+			#(.child(#option_children))*
+	}
+}
+
+fn generate_static_choice_item_view(choice: &TypedChoiceItem) -> TokenStream {
+	match choice {
+		TypedChoiceItem::Option(option) => generate_static_choice_option_view(option),
+		TypedChoiceItem::Group(group) => {
+			let label = &group.label;
+			let disabled = group.disabled;
+			let option_children: Vec<TokenStream> = group
+				.options
+				.iter()
+				.map(generate_static_choice_option_view)
+				.collect();
+
+			quote! {
+				PageElement::new("optgroup")
+					.attr("label", #label)
+					.bool_attr("disabled", #disabled)
+					#(.child(#option_children))*
+			}
+		}
+	}
+}
+
+fn generate_static_choice_option_view(option: &TypedChoiceOption) -> TokenStream {
+	let value = &option.value;
+	let label = &option.label;
+	let disabled = option.disabled;
+
+	quote! {
+		PageElement::new("option")
+			.attr("value", (#value).to_string())
+			.bool_attr("disabled", #disabled)
+			.child((#label).to_string())
 	}
 }
 
@@ -2079,7 +2543,7 @@ fn generate_submit_button_view(btn: &TypedSubmitButtonDef) -> TokenStream {
 fn generate_field_group_view(
 	group: &TypedFormFieldGroup,
 	pages_crate: &TokenStream,
-	_all_fields: &[&TypedFormFieldDef],
+	all_fields: &[&TypedFormFieldDef],
 ) -> TokenStream {
 	let group_class = group.class.as_deref().unwrap_or("reinhardt-field-group");
 
@@ -2087,14 +2551,7 @@ fn generate_field_group_view(
 	let field_views: Vec<TokenStream> = group
 		.fields
 		.iter()
-		.map(|field| {
-			let signal_ident = if field.bind {
-				Some(quote::format_ident!("{}_signal", field.name))
-			} else {
-				None
-			};
-			generate_field_view(field, pages_crate, signal_ident.as_ref())
-		})
+		.map(|entry| generate_field_entry_view(entry, pages_crate, all_fields))
 		.collect();
 
 	// Generate optional label
@@ -2146,6 +2603,7 @@ fn generate_field_view(
 
 	// Generate custom attributes (aria-*, data-*)
 	let custom_attrs = generate_custom_attrs(&field.custom_attrs);
+	let native_attrs = generate_native_attrs(&field.native_attrs);
 
 	// Generate event listener for two-way binding
 	let event_listener =
@@ -2153,6 +2611,58 @@ fn generate_field_view(
 
 	// Generate input element based on widget type
 	let input_element = match &field.widget {
+		TypedWidget::CustomExperimental(custom) => {
+			let component = &custom.component;
+			let adapter = &custom.adapter;
+			let value_type = field_type_to_value_type(&field.field_type);
+			let custom_widget_error_name = format_ident!(
+				"__{}_custom_widget_error",
+				field_name,
+				span = field_name.span()
+			);
+			quote! {
+				{
+					let __field_signal = self.#field_name.clone();
+					let __custom_widget_error_signal = self.#custom_widget_error_name.clone();
+					let mut __ctx: #pages_crate::CustomWidgetContext<#value_type> =
+						#pages_crate::CustomWidgetContext::new(
+							__field_signal.get(),
+							::std::rc::Rc::new({
+								let __field_signal = __field_signal.clone();
+								let __custom_widget_error_signal =
+									__custom_widget_error_signal.clone();
+								move |__raw: #pages_crate::CustomWidgetRawValue| {
+									match <#adapter as #pages_crate::FormWidgetAdapter<#value_type>>::parse(__raw) {
+										::core::result::Result::Ok(__value) => {
+											__custom_widget_error_signal
+												.set(::core::option::Option::None);
+											__field_signal.set(__value);
+											::core::result::Result::Ok(())
+										}
+										::core::result::Result::Err(__error) => {
+											__custom_widget_error_signal.set(
+												::core::option::Option::Some(
+													#pages_crate::FieldError::new(__error.message()),
+												),
+											);
+											::core::result::Result::Err(__error)
+										}
+									}
+								}
+							}),
+						);
+					__ctx.disabled = false;
+					__ctx.required = #required;
+					__ctx.touched = false;
+					__ctx.error = __custom_widget_error_signal.get();
+					__ctx.name = #field_name_str.to_string();
+					__ctx.id = #field_name_str.to_string();
+					let __props =
+						<#adapter as #pages_crate::FormWidgetAdapter<#value_type>>::props(__ctx);
+					#component(__props)
+				}
+			}
+		}
 		TypedWidget::Textarea => {
 			quote! {
 				PageElement::new("textarea")
@@ -2160,14 +2670,151 @@ fn generate_field_view(
 					.attr("id", #field_name_str)
 					.attr("class", #input_class)
 					.attr("placeholder", #placeholder)
-					.bool_attr("required", #required)
-					#autocomplete_attr
-					#custom_attrs
-					#event_listener
+						.bool_attr("required", #required)
+						#autocomplete_attr
+						#native_attrs
+						#custom_attrs
+						#event_listener
 			}
 		}
 		TypedWidget::Select | TypedWidget::SelectMultiple => {
 			let multiple = matches!(field.widget, TypedWidget::SelectMultiple);
+			let choice_children = if field.choices_config.is_some() {
+				let choices_name =
+					syn::Ident::new(&format!("{}_choices", field.name), field.name.span());
+				let choice_items_name =
+					syn::Ident::new(&format!("{}_choice_items", field.name), field.name.span());
+				quote! {
+						.child({
+							let __choices_signal = self.#choices_name.clone();
+							let __choice_items_signal = self.#choice_items_name.clone();
+							#pages_crate::component::Page::reactive(move || {
+								let __choice_items = __choice_items_signal.get();
+								let __choices: ::std::vec::Vec<_> = __choices_signal
+									.get()
+									.into_iter()
+									.enumerate()
+									.map(|(i, (value, label))| {
+										match __choice_items.get(i) {
+											::core::option::Option::Some(__metadata)
+												if __metadata.value.to_string() == value.to_string()
+													&& __metadata.label.as_str() == label.as_str() =>
+											{
+												__ReinhardtChoiceItem {
+													value,
+													label,
+													disabled: __metadata.disabled,
+													group: __metadata.group.clone(),
+													group_disabled: __metadata.group_disabled,
+												}
+											}
+											_ => __ReinhardtChoiceItem {
+												value,
+												label,
+												disabled: false,
+												group: ::core::option::Option::None,
+												group_disabled: false,
+											},
+										}
+									})
+									.collect();
+								let mut __children = ::std::vec::Vec::new();
+								let mut __current_group: ::core::option::Option<(
+									::std::string::String,
+								bool,
+								::std::vec::Vec<#pages_crate::component::Page>,
+							)> = ::core::option::Option::None;
+
+							for choice in __choices.into_iter() {
+								let __option = PageElement::new("option")
+									.attr("value", choice.value.to_string())
+									.bool_attr("disabled", choice.disabled)
+									.child(choice.label)
+									.into_page();
+
+								if let ::core::option::Option::Some(__group_label) = choice.group {
+									let __same_group = __current_group
+										.as_ref()
+										.is_some_and(|(__label, __disabled, _)| {
+											__label == &__group_label
+												&& *__disabled == choice.group_disabled
+										});
+
+									if __same_group {
+										if let ::core::option::Option::Some((_, _, __options)) =
+											__current_group.as_mut()
+										{
+											__options.push(__option);
+										}
+									} else {
+										if let ::core::option::Option::Some((
+											__label,
+											__disabled,
+											__options,
+										)) = __current_group.take()
+										{
+											__children.push(
+												PageElement::new("optgroup")
+													.attr("label", __label)
+													.bool_attr("disabled", __disabled)
+													.children(__options)
+													.into_page(),
+											);
+										}
+										__current_group = ::core::option::Option::Some((
+											__group_label,
+											choice.group_disabled,
+											::std::vec![__option],
+										));
+									}
+								} else {
+									if let ::core::option::Option::Some((
+										__label,
+										__disabled,
+										__options,
+									)) = __current_group.take()
+									{
+										__children.push(
+											PageElement::new("optgroup")
+												.attr("label", __label)
+												.bool_attr("disabled", __disabled)
+												.children(__options)
+												.into_page(),
+										);
+									}
+									__children.push(__option);
+								}
+							}
+
+							if let ::core::option::Option::Some((
+								__label,
+								__disabled,
+								__options,
+							)) = __current_group.take()
+							{
+								__children.push(
+									PageElement::new("optgroup")
+										.attr("label", __label)
+										.bool_attr("disabled", __disabled)
+										.children(__options)
+										.into_page(),
+								);
+							}
+
+							#pages_crate::component::Page::Fragment(__children)
+						})
+					})
+				}
+			} else {
+				let choice_children: Vec<TokenStream> = field
+					.static_choices
+					.iter()
+					.map(generate_static_choice_item_view)
+					.collect();
+				quote! {
+					#(.child(#choice_children))*
+				}
+			};
 			quote! {
 				PageElement::new("select")
 					.attr("name", #field_name_str)
@@ -2176,8 +2823,10 @@ fn generate_field_view(
 					.bool_attr("required", #required)
 					.bool_attr("multiple", #multiple)
 					#autocomplete_attr
+					#native_attrs
 					#custom_attrs
 					#event_listener
+					#choice_children
 			}
 		}
 		TypedWidget::CheckboxInput => {
@@ -2186,32 +2835,64 @@ fn generate_field_view(
 					.attr("type", "checkbox")
 					.attr("name", #field_name_str)
 					.attr("id", #field_name_str)
-					.attr("class", #input_class)
-					.bool_attr("required", #required)
-					#custom_attrs
-					#event_listener
+						.attr("class", #input_class)
+						.bool_attr("required", #required)
+						#native_attrs
+						#custom_attrs
+						#event_listener
 			}
 		}
 		TypedWidget::RadioSelect if field.choices_config.is_some() => {
 			let choices_name =
 				syn::Ident::new(&format!("{}_choices", field.name), field.name.span());
+			let choice_items_name =
+				syn::Ident::new(&format!("{}_choice_items", field.name), field.name.span());
 			let checked_attr = signal_ident.map(|signal_ident| {
 				quote! {
-					.bool_attr(
+						.bool_attr(
 						"checked",
 						#signal_ident.get().to_string() == choice_value.to_string(),
 					)
 				}
 			});
 			quote! {
-				{
-					let __choices_signal = self.#choices_name.clone();
-					#pages_crate::component::Page::reactive(move || {
-						let __choices = __choices_signal.get();
-						let mut __children = ::std::vec::Vec::new();
-						for (i, (choice_value, choice_label)) in
-							__choices.into_iter().enumerate()
-						{
+					{
+						let __choices_signal = self.#choices_name.clone();
+						let __choice_items_signal = self.#choice_items_name.clone();
+						#pages_crate::component::Page::reactive(move || {
+							let __choice_items = __choice_items_signal.get();
+							let __choices: ::std::vec::Vec<_> = __choices_signal
+								.get()
+								.into_iter()
+								.enumerate()
+								.map(|(i, (value, label))| {
+									match __choice_items.get(i) {
+										::core::option::Option::Some(__metadata)
+											if __metadata.value.to_string() == value.to_string()
+												&& __metadata.label.as_str() == label.as_str() =>
+										{
+											__ReinhardtChoiceItem {
+												value,
+												label,
+												disabled: __metadata.disabled,
+												group: __metadata.group.clone(),
+												group_disabled: __metadata.group_disabled,
+											}
+										}
+										_ => __ReinhardtChoiceItem {
+											value,
+											label,
+											disabled: false,
+											group: ::core::option::Option::None,
+											group_disabled: false,
+										},
+									}
+								})
+								.collect();
+							let mut __children = ::std::vec::Vec::new();
+							for (i, choice) in __choices.into_iter().enumerate() {
+							let _ = (&choice.group, choice.group_disabled);
+							let choice_value = choice.value;
 							let __choice_id =
 								::std::format!("{}_{}", #field_name_str, i);
 							__children.push(
@@ -2225,11 +2906,13 @@ fn generate_field_view(
 											.attr("value", choice_value.to_string())
 											.attr("class", #input_class)
 											.bool_attr("required", #required)
+											.bool_attr("disabled", choice.disabled)
 											#checked_attr
+											#native_attrs
 											#custom_attrs
 											#event_listener
 									)
-									.child(choice_label)
+									.child(choice.label)
 									.into_page(),
 							);
 						}
@@ -2244,10 +2927,11 @@ fn generate_field_view(
 					.attr("type", "radio")
 					.attr("name", #field_name_str)
 					.attr("id", #field_name_str)
-					.attr("class", #input_class)
-					.bool_attr("required", #required)
-					#custom_attrs
-					#event_listener
+						.attr("class", #input_class)
+						.bool_attr("required", #required)
+						#native_attrs
+						#custom_attrs
+						#event_listener
 			}
 		}
 		_ => {
@@ -2258,11 +2942,12 @@ fn generate_field_view(
 					.attr("name", #field_name_str)
 					.attr("id", #field_name_str)
 					.attr("class", #input_class)
-					.attr("placeholder", #placeholder)
-					.bool_attr("required", #required)
-					#autocomplete_attr
-					#custom_attrs
-					#event_listener
+						.attr("placeholder", #placeholder)
+						.bool_attr("required", #required)
+						#autocomplete_attr
+						#native_attrs
+						#custom_attrs
+						#event_listener
 			}
 		}
 	};
@@ -2437,6 +3122,56 @@ fn generate_custom_attrs(attrs: &[TypedCustomAttr]) -> TokenStream {
 			.attr(#html_name, #value)
 		});
 	}
+	result
+}
+
+/// Generates native HTML attribute code for form field input elements.
+fn generate_native_attrs(attrs: &TypedFieldNativeAttrs) -> TokenStream {
+	let mut result = TokenStream::new();
+
+	if let Some(min) = &attrs.min {
+		result.extend(quote! {
+			.attr("min", (#min).to_string())
+		});
+	}
+	if let Some(max) = &attrs.max {
+		result.extend(quote! {
+			.attr("max", (#max).to_string())
+		});
+	}
+	if let Some(step) = &attrs.step {
+		result.extend(quote! {
+			.attr("step", (#step).to_string())
+		});
+	}
+	if let Some(multiple) = attrs.multiple {
+		result.extend(quote! {
+			.bool_attr("multiple", #multiple)
+		});
+	}
+	if let Some(accept) = &attrs.accept {
+		result.extend(quote! {
+			.attr("accept", #accept)
+		});
+	}
+	if let Some(capture) = &attrs.capture {
+		result.extend(quote! {
+			.attr("capture", #capture)
+		});
+	}
+	if let Some(list) = &attrs.list {
+		let list_id = list.to_string();
+		result.extend(quote! {
+			.attr("list", #list_id)
+		});
+	}
+	if let Some(size) = attrs.size {
+		let size_value = size.to_string();
+		result.extend(quote! {
+			.attr("size", #size_value)
+		});
+	}
+
 	result
 }
 
@@ -3069,7 +3804,8 @@ fn generate_load_initial_values(
 /// - Is async and returns `Result<(), ServerFnError>`
 /// - Calls the choices_loader server_fn to fetch choice data
 /// - Uses field access syntax to extract choices based on `choices_from` mapping
-/// - Transforms each choice item to (value, label) tuple based on `choice_value` and `choice_label`
+/// - Transforms each choice item to the public (value, label) tuple based on `choice_value` and `choice_label`
+/// - Stores disabled and group metadata in internal choice-item signals for rendering
 ///
 /// # Example
 ///
@@ -3094,6 +3830,7 @@ fn generate_load_initial_values(
 ///             (item.id.to_string(), item.choice_text.clone())
 ///         }).collect()
 ///     );
+///     self.choice_choice_items.set(...);
 ///     Ok(())
 /// }
 /// ```
@@ -3105,15 +3842,38 @@ fn generate_load_choices(macro_ast: &TypedFormMacro, pages_crate: &TokenStream) 
 
 	// Collect fields that have choices_config specified (including from groups)
 	let all_fields = collect_all_fields(&macro_ast.fields);
-	let field_setters: Vec<TokenStream> = all_fields
+	let mut choice_setters: Vec<TokenStream> = all_fields
 		.iter()
 		.filter_map(|field| {
 			field.choices_config.as_ref().map(|config| {
 				let choices_signal_name =
 					syn::Ident::new(&format!("{}_choices", field.name), field.name.span());
+				let choice_items_signal_name =
+					syn::Ident::new(&format!("{}_choice_items", field.name), field.name.span());
 				let from_ident = syn::Ident::new(&config.choices_from, field.name.span());
 				let value_ident = syn::Ident::new(&config.choice_value, field.name.span());
 				let label_ident = syn::Ident::new(&config.choice_label, field.name.span());
+				let disabled_expr = config.choice_disabled.as_ref().map_or_else(
+					|| quote!(false),
+					|path| {
+						let ident = syn::Ident::new(path, field.name.span());
+						quote!(item.#ident)
+					},
+				);
+				let group_expr = config.choice_group.as_ref().map_or_else(
+					|| quote!(::core::option::Option::None),
+					|path| {
+						let ident = syn::Ident::new(path, field.name.span());
+						quote!(::core::option::Option::Some(item.#ident.clone()))
+					},
+				);
+				let group_disabled_expr = config.choice_group_disabled.as_ref().map_or_else(
+					|| quote!(false),
+					|path| {
+						let ident = syn::Ident::new(path, field.name.span());
+						quote!(item.#ident)
+					},
+				);
 				// When the field carries a generic type parameter (e.g.
 				// ChoiceField<i64>), clone the value rather than
 				// stringifying so the tuple type matches the choices
@@ -3123,10 +3883,23 @@ fn generate_load_choices(macro_ast: &TypedFormMacro, pages_crate: &TokenStream) 
 				} else {
 					quote!(item.#value_ident.clone())
 				};
+				let tuple_value_expr = value_expr.clone();
+				let item_value_expr = value_expr;
 				quote! {
-					self.#choices_signal_name.set(
-						data.#from_ident.iter().map(|item| {
-							(#value_expr, item.#label_ident.clone())
+						self.#choices_signal_name.set(
+							data.#from_ident.iter().map(|item| {
+								(#tuple_value_expr, item.#label_ident.clone())
+							}).collect()
+						);
+						self.#choice_items_signal_name.set(
+							data.#from_ident.iter().map(|item| {
+								__ReinhardtChoiceItem {
+									value: #item_value_expr,
+									label: item.#label_ident.clone(),
+									disabled: #disabled_expr,
+									group: #group_expr,
+								group_disabled: #group_disabled_expr,
+							}
 						}).collect()
 					);
 				}
@@ -3134,8 +3907,43 @@ fn generate_load_choices(macro_ast: &TypedFormMacro, pages_crate: &TokenStream) 
 		})
 		.collect();
 
+	let datalist_setters: Vec<TokenStream> = collect_all_datalists(&macro_ast.fields)
+		.iter()
+		.filter_map(|datalist| {
+			datalist.choices_config.as_ref().map(|config| {
+				let choices_signal_name =
+					syn::Ident::new(&format!("{}_choices", datalist.name), datalist.name.span());
+				let from_ident = syn::Ident::new(&config.choices_from, datalist.name.span());
+				let value_ident = syn::Ident::new(&config.choice_value, datalist.name.span());
+				let label_ident = syn::Ident::new(&config.choice_label, datalist.name.span());
+				let disabled_expr = config.choice_disabled.as_ref().map_or_else(
+					|| quote!(false),
+					|path| {
+						let ident = syn::Ident::new(path, datalist.name.span());
+						quote!(item.#ident)
+					},
+				);
+				quote! {
+					self.#choices_signal_name.set(
+						data.#from_ident.iter().map(|item| {
+							__ReinhardtChoiceItem {
+								value: item.#value_ident.to_string(),
+								label: item.#label_ident.clone(),
+								disabled: #disabled_expr,
+								group: ::core::option::Option::None,
+								group_disabled: false,
+							}
+						}).collect()
+					);
+				}
+			})
+		})
+		.collect();
+
+	choice_setters.extend(datalist_setters);
+
 	// If no fields have choices_config, just call the loader but don't set anything
-	if field_setters.is_empty() {
+	if choice_setters.is_empty() {
 		quote! {
 			/// Loads choices from the choices_loader server function.
 			///
@@ -3156,14 +3964,15 @@ fn generate_load_choices(macro_ast: &TypedFormMacro, pages_crate: &TokenStream) 
 		}
 	} else {
 		quote! {
-			/// Loads choices from the choices_loader server function.
-			///
-			/// Calls the configured choices_loader and populates the choices signals
-			/// for fields that have `choices_from` specified.
+				/// Loads choices from the choices_loader server function.
+				///
+				/// Calls the configured choices_loader and populates the public choices
+				/// signals plus internal rendering metadata for fields that have
+				/// `choices_from` specified.
 			#[cfg(all(target_family = "wasm", target_os = "unknown"))]
 			pub async fn load_choices(&self) -> Result<(), #pages_crate::ServerFnError> {
 				let data = #choices_loader().await?;
-				#(#field_setters)*
+				#(#choice_setters)*
 				Ok(())
 			}
 
@@ -4019,6 +4828,8 @@ fn widget_to_string(widget: &TypedWidget) -> &'static str {
 		TypedWidget::Select => "Select",
 		TypedWidget::SelectMultiple => "SelectMultiple",
 		TypedWidget::DateInput => "DateInput",
+		TypedWidget::MonthInput => "MonthInput",
+		TypedWidget::WeekInput => "WeekInput",
 		TypedWidget::TimeInput => "TimeInput",
 		TypedWidget::DateTimeInput => "DateTimeInput",
 		TypedWidget::FileInput => "FileInput",
@@ -4028,6 +4839,7 @@ fn widget_to_string(widget: &TypedWidget) -> &'static str {
 		TypedWidget::UrlInput => "UrlInput",
 		TypedWidget::TelInput => "TelInput",
 		TypedWidget::SearchInput => "SearchInput",
+		TypedWidget::CustomExperimental(_) => "CustomWidget",
 	}
 }
 
@@ -4045,6 +4857,8 @@ fn widget_to_input_type(widget: &TypedWidget) -> &'static str {
 		TypedWidget::Select => "select",         // Not used directly
 		TypedWidget::SelectMultiple => "select", // Not used directly
 		TypedWidget::DateInput => "date",
+		TypedWidget::MonthInput => "month",
+		TypedWidget::WeekInput => "week",
 		TypedWidget::TimeInput => "time",
 		TypedWidget::DateTimeInput => "datetime-local",
 		TypedWidget::FileInput => "file",
@@ -4054,6 +4868,7 @@ fn widget_to_input_type(widget: &TypedWidget) -> &'static str {
 		TypedWidget::UrlInput => "url",
 		TypedWidget::TelInput => "tel",
 		TypedWidget::SearchInput => "search",
+		TypedWidget::CustomExperimental(_) => "custom",
 	}
 }
 
@@ -4663,6 +5478,157 @@ mod tests {
 		assert!(output_str.contains("\"data-autoresize\""));
 	}
 
+	#[rstest::rstest]
+	fn test_generate_native_attrs() {
+		let input = quote! {
+			name: NativeAttrsForm,
+			action: "/test",
+
+			fields: {
+				billing_month: CharField {
+					widget: MonthInput,
+					min: "2026-01",
+					max: "2026-12",
+					step: 1,
+				}
+				search: CharField {
+					widget: SearchInput,
+					list: suggestions,
+					size: 32,
+				}
+				suggestions: Datalist {
+					options: [("term", "Term")],
+				}
+				avatar: FileField {
+					accept: "image/png",
+					capture: "environment",
+					multiple,
+				}
+			},
+		};
+
+		let output = parse_validate_generate(input);
+		let output_str = output.to_string();
+
+		assert!(output_str.contains(". attr (\"type\" , \"month\")"));
+		assert!(output_str.contains(". attr (\"min\" , (\"2026-01\") . to_string ())"));
+		assert!(output_str.contains(". attr (\"max\" , (\"2026-12\") . to_string ())"));
+		assert!(output_str.contains(". attr (\"step\" , (1) . to_string ())"));
+		assert!(output_str.contains(". attr (\"type\" , \"search\")"));
+		assert!(output_str.contains(". attr (\"list\" , \"suggestions\")"));
+		assert!(output_str.contains(". attr (\"size\" , \"32\")"));
+		assert!(output_str.contains(". attr (\"accept\" , \"image/png\")"));
+		assert!(output_str.contains(". attr (\"capture\" , \"environment\")"));
+		assert!(output_str.contains(". bool_attr (\"multiple\" , true)"));
+	}
+
+	#[rstest::rstest]
+	fn test_generate_month_and_week_native_input_attrs() {
+		let input = quote! {
+			name: MonthWeekAttrsForm,
+			action: "/test",
+
+			fields: {
+				billing_month: CharField {
+					widget: MonthInput,
+					min: "2026-01",
+				}
+				sprint_week: CharField {
+					widget: WeekInput,
+					max: "2026-W52",
+				}
+			},
+		};
+
+		let output = parse_validate_generate(input);
+		let output_str = output.to_string();
+
+		assert!(output_str.contains(". attr (\"type\" , \"month\")"));
+		assert!(output_str.contains(". attr (\"min\" , (\"2026-01\") . to_string ())"));
+		assert!(output_str.contains(". attr (\"type\" , \"week\")"));
+		assert!(output_str.contains(". attr (\"max\" , (\"2026-W52\") . to_string ())"));
+	}
+
+	#[rstest::rstest]
+	fn test_generate_control_entries_without_value_accessors() {
+		let input = quote! {
+			name: ControlEntryCodegenForm,
+			action: "/test",
+
+			fields: {
+				title: CharField {}
+				reset: ResetButton {
+					label: "Reset",
+				}
+				preview: Button {
+					label: "Preview",
+				}
+				progress: Progress {
+					value: 3,
+					max: 10,
+				}
+			},
+		};
+
+		let output = parse_validate_generate(input);
+		let output_str = output.to_string();
+
+		assert!(output_str.contains("PageElement :: new (\"button\")"));
+		assert!(output_str.contains(". attr (\"type\" , \"reset\")"));
+		assert!(output_str.contains(". attr (\"type\" , \"button\")"));
+		assert!(output_str.contains("PageElement :: new (\"progress\")"));
+		assert!(output_str.contains(". attr (\"name\" , \"progress\")"));
+		assert!(output_str.contains("pub fn title"));
+		assert!(output_str.contains("title :"));
+		assert!(output_str.contains("& self . title"));
+		assert!(!output_str.contains("pub fn reset"));
+		assert!(!output_str.contains("pub fn preview"));
+		assert!(!output_str.contains("pub fn progress"));
+		assert!(!output_str.contains("reset : :: reinhardt_pages :: reactive :: Signal"));
+		assert!(!output_str.contains("preview : :: reinhardt_pages :: reactive :: Signal"));
+		assert!(!output_str.contains("progress : :: reinhardt_pages :: reactive :: Signal"));
+	}
+
+	#[rstest::rstest]
+	fn test_generate_datalist_and_optgroup_entries() {
+		let input = quote! {
+			name: DatalistOptGroupCodegenForm,
+			action: "/test",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					list: suggestions,
+				}
+				suggestions: Datalist {
+					options: [("a", "A"), ("b", "B") { disabled }],
+				}
+				status: ChoiceField<String> {
+					widget: Select,
+					choices: [OptGroup("Active") {
+						("open", "Open"),
+					}],
+				}
+			},
+		};
+
+		let output = parse_validate_generate(input);
+		let output_str = output.to_string();
+
+		assert!(output_str.contains(". attr (\"type\" , \"search\")"));
+		assert!(output_str.contains(". attr (\"list\" , \"suggestions\")"));
+		assert!(output_str.contains("PageElement :: new (\"datalist\")"));
+		assert!(output_str.contains(". attr (\"id\" , \"suggestions\")"));
+		assert!(output_str.contains("PageElement :: new (\"option\")"));
+		assert!(output_str.contains(". attr (\"value\" , (\"a\") . to_string ())"));
+		assert!(output_str.contains(". attr (\"value\" , (\"b\") . to_string ())"));
+		assert!(output_str.contains(". bool_attr (\"disabled\" , true)"));
+		assert!(output_str.contains("PageElement :: new (\"select\")"));
+		assert!(output_str.contains("PageElement :: new (\"optgroup\")"));
+		assert!(output_str.contains(". attr (\"label\" , \"Active\")"));
+		assert!(output_str.contains(". attr (\"value\" , (\"open\") . to_string ())"));
+	}
+
 	// ========================================
 	// Two-way binding (bind) tests
 	// ========================================
@@ -4803,11 +5769,56 @@ mod tests {
 		assert!(output_str.contains("Page :: reactive"));
 		assert!(output_str.contains("let __choices_signal = self . choice_id_choices . clone ()"));
 		assert!(output_str.contains("__choices_signal . get ()"));
-		assert!(output_str.contains("for (i , (choice_value , choice_label)) in"));
+		assert!(output_str.contains("for (i , choice) in __choices . into_iter () . enumerate ()"));
+		assert!(output_str.contains("let choice_value = choice . value"));
 		assert!(output_str.contains(". attr (\"type\" , \"radio\")"));
 		assert!(output_str.contains(". attr (\"value\" , choice_value . to_string ())"));
-		assert!(output_str.contains(". child (choice_label)"));
+		assert!(output_str.contains(". bool_attr (\"disabled\" , choice . disabled)"));
+		assert!(output_str.contains(". child (choice . label)"));
 		assert!(output_str.contains(". listener (\"change\""));
+	}
+
+	#[rstest::rstest]
+	fn test_generate_load_choices_non_string_value_sets_tuple_and_metadata() {
+		let input = quote! {
+			name: NonStringChoiceLoaderForm,
+			server_fn: submit_choice,
+			choices_loader: load_options,
+
+			fields: {
+				choice_id: ChoiceField<i64> {
+					choices_from: "choices",
+					choice_value: "id",
+					choice_label: "name",
+					choice_disabled: "disabled",
+				},
+				selected_ids: MultipleChoiceField<i64> {
+					widget: SelectMultiple,
+					choices_from: "choices",
+					choice_value: "id",
+					choice_label: "name",
+					choice_group: "group",
+					choice_group_disabled: "group_disabled",
+				},
+			},
+		};
+
+		let output = parse_validate_generate(input);
+		let output_str = output.to_string();
+
+		assert!(output_str.contains("self . choice_id_choices . set"));
+		assert!(output_str.contains("self . choice_id_choice_items . set"));
+		assert!(output_str.contains("self . selected_ids_choices . set"));
+		assert!(output_str.contains("self . selected_ids_choice_items . set"));
+		assert!(output_str.contains("item . id . clone ()"));
+		assert!(!output_str.contains("item . id . to_string ()"));
+		assert!(output_str.contains("__ReinhardtChoiceItem"));
+		assert!(output_str.contains("value : item . id . clone ()"));
+		assert!(
+			output_str
+				.contains("group : :: core :: option :: Option :: Some (item . group . clone ())")
+		);
+		assert!(output_str.contains("group_disabled : item . group_disabled"));
 	}
 
 	#[rstest::rstest]

--- a/crates/reinhardt-pages/macros/src/form/validator.rs
+++ b/crates/reinhardt-pages/macros/src/form/validator.rs
@@ -1142,6 +1142,57 @@ fn unknown_control_property_error(kind: FormControlEntryKind, prop: &FormFieldPr
 	)
 }
 
+const ALLOWED_FIELD_PROPERTIES: &[&str] = &[
+	"accept",
+	"autocomplete",
+	"autofocus",
+	"capture",
+	"class",
+	"disabled",
+	"error_class",
+	"help_text",
+	"initial",
+	"label",
+	"label_class",
+	"list",
+	"max",
+	"max_length",
+	"max_value",
+	"min",
+	"min_length",
+	"min_value",
+	"multiple",
+	"pattern",
+	"placeholder",
+	"readonly",
+	"required",
+	"size",
+	"step",
+	"widget",
+	"wrapper_class",
+];
+
+fn validate_known_field_properties(properties: &[FormFieldProperty]) -> Result<()> {
+	for prop in properties {
+		let (name, span) = match prop {
+			FormFieldProperty::Named { name, span, .. }
+			| FormFieldProperty::Flag { name, span } => (name.to_string(), *span),
+			_ => continue,
+		};
+
+		if !ALLOWED_FIELD_PROPERTIES.contains(&name.as_str()) {
+			return Err(Error::new(
+				span,
+				format!(
+					"unknown field property: '{name}'. Use typed field properties for native form behavior (min, max, step, accept, capture, list, size), and use attrs only for aria_* or data_* custom attributes"
+				),
+			));
+		}
+	}
+
+	Ok(())
+}
+
 /// Transforms a single field definition.
 fn transform_field(field: &FormFieldDef) -> Result<TypedFormFieldDef> {
 	// Parse field type
@@ -1164,6 +1215,7 @@ fn transform_field(field: &FormFieldDef) -> Result<TypedFormFieldDef> {
 	let static_choices_source = extract_static_choices(&field.properties)?;
 
 	validate_radio_select_choice_group_properties(&field.properties, &widget)?;
+	validate_known_field_properties(&field.properties)?;
 
 	if !static_choices_source.is_empty() && choices_config.is_some() {
 		return Err(Error::new(
@@ -1913,10 +1965,10 @@ fn validate_native_attrs(
 			"capture is only supported on file-like inputs",
 		));
 	}
-	if attrs.multiple.is_some() && !is_file_like_input(field_type, widget) {
+	if attrs.multiple.is_some() {
 		return Err(Error::new(
 			spans.multiple.unwrap_or_else(Span::call_site),
-			"multiple is only supported on file-like inputs",
+			"multiple field property is not supported yet. Use SelectMultiple for multi-select fields; multi-file inputs require a future Vec<File> value contract",
 		));
 	}
 	if attrs.list.is_some() && !is_text_like_input(widget) {
@@ -2067,8 +2119,6 @@ fn is_string_valued_field(field_type: &TypedFieldType) -> bool {
 			| TypedFieldType::SlugField
 			| TypedFieldType::PasswordField
 			| TypedFieldType::TextField
-			| TypedFieldType::UuidField
-			| TypedFieldType::IpAddressField
 	)
 }
 

--- a/crates/reinhardt-pages/macros/src/form/validator.rs
+++ b/crates/reinhardt-pages/macros/src/form/validator.rs
@@ -17,15 +17,19 @@ use std::collections::HashSet;
 use syn::{Error, Result};
 
 use reinhardt_manouche::core::{
-	AmbientArgumentsSource, FormAction, FormCallbacks, FormDerived, FormFieldDef, FormFieldEntry,
-	FormFieldGroup, FormFieldProperty, FormMacro, FormMethod, FormSlots, FormState,
-	FormSubmitButtonDef, FormValidator, FormWatch, IconPosition, StripArgument, TypedChoicesConfig,
-	TypedCustomAttr, TypedDerivedItem, TypedFieldDisplay, TypedFieldStyling, TypedFieldType,
+	AmbientArgumentsSource, FormAction, FormCallbacks, FormChoiceItem, FormControlEntryDef,
+	FormControlEntryKind, FormCustomWidgetSpec, FormDatalistDef, FormDerived, FormFieldDef,
+	FormFieldEntry, FormFieldGroup, FormFieldProperty, FormMacro, FormMethod, FormSlots, FormState,
+	FormSubmitButtonDef, FormValidator, FormWatch, FormWidgetSpec, IconPosition, StripArgument,
+	TypedButtonControlDef, TypedButtonKind, TypedChoiceGroup, TypedChoiceItem, TypedChoiceOption,
+	TypedChoicesConfig, TypedCustomAttr, TypedCustomWidget, TypedDatalistDef, TypedDerivedItem,
+	TypedFieldDisplay, TypedFieldNativeAttrs, TypedFieldStyling, TypedFieldType,
 	TypedFieldValidation, TypedFormAction, TypedFormCallbacks, TypedFormDerived, TypedFormFieldDef,
 	TypedFormFieldEntry, TypedFormFieldGroup, TypedFormMacro, TypedFormSlots, TypedFormState,
 	TypedFormStyling, TypedFormValidator, TypedFormWatch, TypedFormWatchItem, TypedIcon,
-	TypedIconAttr, TypedIconChild, TypedIconPosition, TypedStripArgument, TypedSubmitButtonDef,
-	TypedValidatorRule, TypedWidget, TypedWrapper, TypedWrapperAttr, ValidatorRule,
+	TypedIconAttr, TypedIconChild, TypedIconPosition, TypedImageInputDef, TypedMeterDef,
+	TypedOutputDef, TypedProgressDef, TypedStripArgument, TypedSubmitButtonDef, TypedValidatorRule,
+	TypedWidget, TypedWrapper, TypedWrapperAttr, ValidatorRule,
 };
 
 /// Allowlist of safe HTML tag names for wrapper and icon child elements.
@@ -178,6 +182,7 @@ pub(super) fn validate(
 
 	// Transform fields
 	let fields = transform_fields(&ast.fields)?;
+	validate_list_references(&fields)?;
 
 	// Transform unified validators (scope filtering happens at codegen)
 	let validators = transform_validators(&ast.validators, &ast.fields)?;
@@ -216,49 +221,149 @@ fn validate_unique_field_names(entries: &[FormFieldEntry]) -> Result<()> {
 	let mut seen = HashSet::new();
 
 	for entry in entries {
-		match entry {
-			FormFieldEntry::Field(field) => {
-				let name = field.name.to_string();
-				if !seen.insert(name.clone()) {
-					return Err(Error::new(
-						field.name.span(),
-						format!("duplicate field name: '{}'", name),
-					));
-				}
-			}
-			FormFieldEntry::Group(group) => {
-				// Check group name is unique
-				let group_name = group.name.to_string();
-				if !seen.insert(group_name.clone()) {
-					return Err(Error::new(
-						group.name.span(),
-						format!("duplicate field/group name: '{}'", group_name),
-					));
-				}
+		validate_unique_entry_name(entry, &mut seen, None)?;
+	}
 
-				// Check fields within the group
-				for field in &group.fields {
-					let name = field.name.to_string();
-					if !seen.insert(name.clone()) {
+	Ok(())
+}
+
+fn validate_unique_entry_name(
+	entry: &FormFieldEntry,
+	seen: &mut HashSet<String>,
+	group_name: Option<&str>,
+) -> Result<()> {
+	match entry {
+		FormFieldEntry::Field(field) => {
+			let name = field.name.to_string();
+			if !seen.insert(name.clone()) {
+				let message = if let Some(group_name) = group_name {
+					format!(
+						"duplicate field name: '{}' (in group '{}')",
+						name, group_name
+					)
+				} else {
+					format!("duplicate field name: '{}'", name)
+				};
+				return Err(Error::new(field.name.span(), message));
+			}
+		}
+		FormFieldEntry::Group(group) => {
+			let name = group.name.to_string();
+			if !seen.insert(name.clone()) {
+				return Err(Error::new(
+					group.name.span(),
+					format!("duplicate field/group name: '{}'", name),
+				));
+			}
+
+			for child in &group.fields {
+				validate_unique_entry_name(child, seen, Some(&name))?;
+			}
+		}
+		FormFieldEntry::SubmitButton(btn) => {
+			let name = btn.name.to_string();
+			if !seen.insert(name.clone()) {
+				return Err(Error::new(
+					btn.name.span(),
+					format!("duplicate field/button name: '{}'", name),
+				));
+			}
+		}
+		FormFieldEntry::ResetButton(control)
+		| FormFieldEntry::Button(control)
+		| FormFieldEntry::ImageInput(control)
+		| FormFieldEntry::Output(control)
+		| FormFieldEntry::Meter(control)
+		| FormFieldEntry::Progress(control) => {
+			let name = control.name.to_string();
+			if !seen.insert(name.clone()) {
+				let message = if let Some(group_name) = group_name {
+					format!(
+						"duplicate field/control name: '{}' (in group '{}')",
+						name, group_name
+					)
+				} else {
+					format!("duplicate field/control name: '{}'", name)
+				};
+				return Err(Error::new(control.name.span(), message));
+			}
+		}
+		FormFieldEntry::Datalist(datalist) => {
+			let name = datalist.name.to_string();
+			if !seen.insert(name.clone()) {
+				let message = if let Some(group_name) = group_name {
+					format!(
+						"duplicate field/datalist name: '{}' (in group '{}')",
+						name, group_name
+					)
+				} else {
+					format!("duplicate field/datalist name: '{}'", name)
+				};
+				return Err(Error::new(datalist.name.span(), message));
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_list_references(entries: &[TypedFormFieldEntry]) -> Result<()> {
+	let mut datalist_names = HashSet::new();
+	collect_datalist_names(entries, &mut datalist_names);
+	validate_entry_list_references(entries, &datalist_names)
+}
+
+fn collect_datalist_names(entries: &[TypedFormFieldEntry], datalist_names: &mut HashSet<String>) {
+	for entry in entries {
+		match entry {
+			TypedFormFieldEntry::Group(group) => {
+				collect_datalist_names(&group.fields, datalist_names);
+			}
+			TypedFormFieldEntry::Datalist(datalist) => {
+				datalist_names.insert(datalist.name.to_string());
+			}
+			TypedFormFieldEntry::Field(_)
+			| TypedFormFieldEntry::SubmitButton(_)
+			| TypedFormFieldEntry::ResetButton(_)
+			| TypedFormFieldEntry::Button(_)
+			| TypedFormFieldEntry::ImageInput(_)
+			| TypedFormFieldEntry::Output(_)
+			| TypedFormFieldEntry::Meter(_)
+			| TypedFormFieldEntry::Progress(_) => {}
+		}
+	}
+}
+
+fn validate_entry_list_references(
+	entries: &[TypedFormFieldEntry],
+	datalist_names: &HashSet<String>,
+) -> Result<()> {
+	for entry in entries {
+		match entry {
+			TypedFormFieldEntry::Field(field) => {
+				if let Some(list) = &field.native_attrs.list {
+					let list_name = list.to_string();
+					if !datalist_names.contains(&list_name) {
 						return Err(Error::new(
-							field.name.span(),
+							list.span(),
 							format!(
-								"duplicate field name: '{}' (in group '{}')",
-								name, group_name
+								"list reference '{list_name}' must resolve to a Datalist entry",
 							),
 						));
 					}
 				}
 			}
-			FormFieldEntry::SubmitButton(btn) => {
-				let name = btn.name.to_string();
-				if !seen.insert(name.clone()) {
-					return Err(Error::new(
-						btn.name.span(),
-						format!("duplicate field/button name: '{}'", name),
-					));
-				}
+			TypedFormFieldEntry::Group(group) => {
+				validate_entry_list_references(&group.fields, datalist_names)?;
 			}
+			TypedFormFieldEntry::SubmitButton(_)
+			| TypedFormFieldEntry::ResetButton(_)
+			| TypedFormFieldEntry::Button(_)
+			| TypedFormFieldEntry::ImageInput(_)
+			| TypedFormFieldEntry::Output(_)
+			| TypedFormFieldEntry::Meter(_)
+			| TypedFormFieldEntry::Progress(_)
+			| TypedFormFieldEntry::Datalist(_) => {}
 		}
 	}
 
@@ -451,34 +556,70 @@ fn transform_slots(slots: &Option<FormSlots>) -> Result<Option<TypedFormSlots>> 
 
 /// Transforms all field entries (fields and field groups).
 fn transform_fields(entries: &[FormFieldEntry]) -> Result<Vec<TypedFormFieldEntry>> {
-	entries.iter().map(transform_field_entry).collect()
+	entries
+		.iter()
+		.map(|entry| transform_field_entry(entry, entries))
+		.collect()
 }
 
 /// Transforms a single field entry (either a field or a group).
-fn transform_field_entry(entry: &FormFieldEntry) -> Result<TypedFormFieldEntry> {
+fn transform_field_entry(
+	entry: &FormFieldEntry,
+	all_entries: &[FormFieldEntry],
+) -> Result<TypedFormFieldEntry> {
 	match entry {
 		FormFieldEntry::Field(field) => {
 			let typed_field = transform_field(field)?;
 			Ok(TypedFormFieldEntry::Field(Box::new(typed_field)))
 		}
 		FormFieldEntry::Group(group) => {
-			let typed_group = transform_field_group(group)?;
+			let typed_group = transform_field_group(group, all_entries)?;
 			Ok(TypedFormFieldEntry::Group(typed_group))
 		}
 		FormFieldEntry::SubmitButton(btn) => {
 			let typed_btn = transform_submit_button(btn)?;
 			Ok(TypedFormFieldEntry::SubmitButton(typed_btn))
 		}
+		FormFieldEntry::ResetButton(control) => {
+			let typed_control = transform_button_control(control)?;
+			Ok(TypedFormFieldEntry::ResetButton(typed_control))
+		}
+		FormFieldEntry::Button(control) => {
+			let typed_control = transform_button_control(control)?;
+			Ok(TypedFormFieldEntry::Button(typed_control))
+		}
+		FormFieldEntry::ImageInput(control) => {
+			let typed_control = transform_image_input(control)?;
+			Ok(TypedFormFieldEntry::ImageInput(typed_control))
+		}
+		FormFieldEntry::Output(control) => {
+			let typed_control = transform_output(control, all_entries)?;
+			Ok(TypedFormFieldEntry::Output(typed_control))
+		}
+		FormFieldEntry::Meter(control) => {
+			let typed_control = transform_meter(control)?;
+			Ok(TypedFormFieldEntry::Meter(Box::new(typed_control)))
+		}
+		FormFieldEntry::Progress(control) => {
+			let typed_control = transform_progress(control)?;
+			Ok(TypedFormFieldEntry::Progress(Box::new(typed_control)))
+		}
+		FormFieldEntry::Datalist(datalist) => {
+			let typed_datalist = transform_datalist(datalist)?;
+			Ok(TypedFormFieldEntry::Datalist(Box::new(typed_datalist)))
+		}
 	}
 }
 
 /// Transforms a field group into a typed field group.
-fn transform_field_group(group: &FormFieldGroup) -> Result<TypedFormFieldGroup> {
-	// Transform each field in the group
-	let typed_fields: Vec<TypedFormFieldDef> = group
+fn transform_field_group(
+	group: &FormFieldGroup,
+	all_entries: &[FormFieldEntry],
+) -> Result<TypedFormFieldGroup> {
+	let typed_fields: Vec<TypedFormFieldEntry> = group
 		.fields
 		.iter()
-		.map(transform_field)
+		.map(|entry| transform_field_entry(entry, all_entries))
 		.collect::<Result<_>>()?;
 
 	Ok(TypedFormFieldGroup {
@@ -583,6 +724,424 @@ fn transform_submit_button(btn: &FormSubmitButtonDef) -> Result<TypedSubmitButto
 	})
 }
 
+fn transform_button_control(control: &FormControlEntryDef) -> Result<TypedButtonControlDef> {
+	let kind_name = control_entry_kind_name(control.kind);
+	let mut label = None;
+	let mut class = None;
+	let mut id = None;
+	let mut disabled = false;
+
+	for prop in &control.properties {
+		match prop {
+			FormFieldProperty::Named { name, value, span } => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"label" => label = Some(expect_string_literal(value, *span, "label")?),
+					"class" => class = Some(expect_string_literal(value, *span, "class")?),
+					"id" => id = Some(expect_string_literal(value, *span, "id")?),
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown {kind_name} property: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			FormFieldProperty::Flag { name, span } => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"disabled" => disabled = true,
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown {kind_name} flag: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			_ => {
+				return Err(unknown_control_property_error(control.kind, prop));
+			}
+		}
+	}
+
+	let (kind, default_label) = match control.kind {
+		FormControlEntryKind::ResetButton => (TypedButtonKind::Reset, "Reset"),
+		FormControlEntryKind::Button => (TypedButtonKind::Button, "Button"),
+		_ => {
+			return Err(Error::new(
+				control.span,
+				format!("{kind_name} cannot be transformed as a button control"),
+			));
+		}
+	};
+
+	Ok(TypedButtonControlDef {
+		name: control.name.clone(),
+		kind,
+		label: label.unwrap_or_else(|| default_label.to_string()),
+		class,
+		id,
+		disabled,
+		span: control.span,
+	})
+}
+
+fn transform_image_input(control: &FormControlEntryDef) -> Result<TypedImageInputDef> {
+	let mut src = None;
+	let mut alt = None;
+	let mut class = None;
+	let mut id = None;
+	let mut disabled = false;
+	let mut width = None;
+	let mut height = None;
+
+	for prop in &control.properties {
+		match prop {
+			FormFieldProperty::Named { name, value, span } => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"src" => src = Some(expect_string_literal(value, *span, "src")?),
+					"alt" => alt = Some(expect_string_literal(value, *span, "alt")?),
+					"class" => class = Some(expect_string_literal(value, *span, "class")?),
+					"id" => id = Some(expect_string_literal(value, *span, "id")?),
+					"width" => {
+						width = Some(expect_positive_i64_literal(value, *span, "width")?);
+					}
+					"height" => {
+						height = Some(expect_positive_i64_literal(value, *span, "height")?);
+					}
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown ImageInput property: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			FormFieldProperty::Flag { name, span } => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"disabled" => disabled = true,
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown ImageInput flag: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			_ => return Err(unknown_control_property_error(control.kind, prop)),
+		}
+	}
+
+	Ok(TypedImageInputDef {
+		name: control.name.clone(),
+		src: src.ok_or_else(|| Error::new(control.span, "ImageInput requires src"))?,
+		alt: alt.ok_or_else(|| Error::new(control.span, "ImageInput requires alt"))?,
+		class,
+		id,
+		disabled,
+		width,
+		height,
+		span: control.span,
+	})
+}
+
+fn transform_output(
+	control: &FormControlEntryDef,
+	all_entries: &[FormFieldEntry],
+) -> Result<TypedOutputDef> {
+	let mut label = None;
+	let mut for_fields = Vec::new();
+	let mut class = None;
+	let mut id = None;
+
+	for prop in &control.properties {
+		match prop {
+			FormFieldProperty::Named { name, value, span } => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"label" => label = Some(expect_string_literal(value, *span, "label")?),
+					"for" => for_fields = expect_ident_array(value, *span, "for")?,
+					"class" => class = Some(expect_string_literal(value, *span, "class")?),
+					"id" => id = Some(expect_string_literal(value, *span, "id")?),
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown Output property: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			FormFieldProperty::Flag { name, span } => {
+				let prop_name = name.to_string();
+				return Err(Error::new(
+					*span,
+					format!("unknown Output flag: '{prop_name}'"),
+				));
+			}
+			_ => return Err(unknown_control_property_error(control.kind, prop)),
+		}
+	}
+
+	for field in &for_fields {
+		if !field_exists(all_entries, field) {
+			return Err(Error::new(
+				field.span(),
+				format!("Output for references unknown value field: '{}'", field),
+			));
+		}
+	}
+
+	Ok(TypedOutputDef {
+		name: control.name.clone(),
+		label,
+		for_fields,
+		class,
+		id,
+		span: control.span,
+	})
+}
+
+fn transform_meter(control: &FormControlEntryDef) -> Result<TypedMeterDef> {
+	let mut label = None;
+	let mut value = None;
+	let mut min = None;
+	let mut max = None;
+	let mut low = None;
+	let mut high = None;
+	let mut optimum = None;
+	let mut class = None;
+	let mut id = None;
+
+	for prop in &control.properties {
+		match prop {
+			FormFieldProperty::Named {
+				name,
+				value: expr,
+				span,
+			} => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"label" => label = Some(expect_string_literal(expr, *span, "label")?),
+					"value" => value = Some(expr.clone()),
+					"min" => min = Some(expr.clone()),
+					"max" => max = Some(expr.clone()),
+					"low" => low = Some(expr.clone()),
+					"high" => high = Some(expr.clone()),
+					"optimum" => optimum = Some(expr.clone()),
+					"class" => class = Some(expect_string_literal(expr, *span, "class")?),
+					"id" => id = Some(expect_string_literal(expr, *span, "id")?),
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown Meter property: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			FormFieldProperty::Flag { name, span } => {
+				let prop_name = name.to_string();
+				return Err(Error::new(
+					*span,
+					format!("unknown Meter flag: '{prop_name}'"),
+				));
+			}
+			_ => return Err(unknown_control_property_error(control.kind, prop)),
+		}
+	}
+
+	Ok(TypedMeterDef {
+		name: control.name.clone(),
+		label,
+		value: value.ok_or_else(|| Error::new(control.span, "Meter requires value"))?,
+		min,
+		max,
+		low,
+		high,
+		optimum,
+		class,
+		id,
+		span: control.span,
+	})
+}
+
+fn transform_progress(control: &FormControlEntryDef) -> Result<TypedProgressDef> {
+	let mut label = None;
+	let mut value = None;
+	let mut max = None;
+	let mut class = None;
+	let mut id = None;
+
+	for prop in &control.properties {
+		match prop {
+			FormFieldProperty::Named {
+				name,
+				value: expr,
+				span,
+			} => {
+				let prop_name = name.to_string();
+				match prop_name.as_str() {
+					"label" => label = Some(expect_string_literal(expr, *span, "label")?),
+					"value" => value = Some(expr.clone()),
+					"max" => max = Some(expr.clone()),
+					"class" => class = Some(expect_string_literal(expr, *span, "class")?),
+					"id" => id = Some(expect_string_literal(expr, *span, "id")?),
+					_ => {
+						return Err(Error::new(
+							*span,
+							format!("unknown Progress property: '{prop_name}'"),
+						));
+					}
+				}
+			}
+			FormFieldProperty::Flag { name, span } => {
+				let prop_name = name.to_string();
+				return Err(Error::new(
+					*span,
+					format!("unknown Progress flag: '{prop_name}'"),
+				));
+			}
+			_ => return Err(unknown_control_property_error(control.kind, prop)),
+		}
+	}
+
+	Ok(TypedProgressDef {
+		name: control.name.clone(),
+		label,
+		value,
+		max,
+		class,
+		id,
+		span: control.span,
+	})
+}
+
+fn transform_datalist(datalist: &FormDatalistDef) -> Result<TypedDatalistDef> {
+	validate_datalist_properties(datalist)?;
+
+	let static_choices = extract_static_choices(&datalist.properties)?;
+	let choices_config = extract_choices_config(&datalist.properties);
+
+	if !static_choices.is_empty() && choices_config.is_some() {
+		return Err(Error::new(
+			datalist.span,
+			"Datalist cannot specify both options and choices_from",
+		));
+	}
+
+	if static_choices.is_empty() && choices_config.is_none() {
+		return Err(Error::new(
+			datalist.span,
+			"Datalist requires either options or choices_from",
+		));
+	}
+
+	let static_choices = transform_static_choices(&static_choices, false, true)?;
+
+	Ok(TypedDatalistDef {
+		name: datalist.name.clone(),
+		static_choices,
+		choices_config,
+		span: datalist.span,
+	})
+}
+
+fn validate_datalist_properties(datalist: &FormDatalistDef) -> Result<()> {
+	for prop in &datalist.properties {
+		match prop {
+			FormFieldProperty::Choices { .. }
+			| FormFieldProperty::ChoicesFrom { .. }
+			| FormFieldProperty::ChoiceValue { .. }
+			| FormFieldProperty::ChoiceLabel { .. }
+			| FormFieldProperty::ChoiceDisabled { .. } => {}
+			FormFieldProperty::ChoiceGroup { .. }
+			| FormFieldProperty::ChoiceGroupDisabled { .. } => {
+				let prop_name = property_name(prop);
+				return Err(Error::new(
+					property_span(prop),
+					format!("Datalist does not support {prop_name}; datalist options must be flat",),
+				));
+			}
+			_ => {
+				let prop_name = property_name(prop);
+				return Err(Error::new(
+					property_span(prop),
+					format!("unknown Datalist property: '{prop_name}'"),
+				));
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn control_entry_kind_name(kind: FormControlEntryKind) -> &'static str {
+	match kind {
+		FormControlEntryKind::ResetButton => "ResetButton",
+		FormControlEntryKind::Button => "Button",
+		FormControlEntryKind::ImageInput => "ImageInput",
+		FormControlEntryKind::Output => "Output",
+		FormControlEntryKind::Meter => "Meter",
+		FormControlEntryKind::Progress => "Progress",
+	}
+}
+
+fn property_name(prop: &FormFieldProperty) -> String {
+	match prop {
+		FormFieldProperty::Named { name, .. } | FormFieldProperty::Flag { name, .. } => {
+			name.to_string()
+		}
+		FormFieldProperty::Widget { .. } => "widget".to_string(),
+		FormFieldProperty::Wrapper { .. } => "wrapper".to_string(),
+		FormFieldProperty::Icon { .. } => "icon".to_string(),
+		FormFieldProperty::IconPosition { .. } => "icon_position".to_string(),
+		FormFieldProperty::Attrs { .. } => "attrs".to_string(),
+		FormFieldProperty::Bind { .. } => "bind".to_string(),
+		FormFieldProperty::InitialFrom { .. } => "initial_from".to_string(),
+		FormFieldProperty::ChoicesFrom { .. } => "choices_from".to_string(),
+		FormFieldProperty::Choices { .. } => "choices".to_string(),
+		FormFieldProperty::ChoiceValue { .. } => "choice_value".to_string(),
+		FormFieldProperty::ChoiceLabel { .. } => "choice_label".to_string(),
+		FormFieldProperty::ChoiceDisabled { .. } => "choice_disabled".to_string(),
+		FormFieldProperty::ChoiceGroup { .. } => "choice_group".to_string(),
+		FormFieldProperty::ChoiceGroupDisabled { .. } => "choice_group_disabled".to_string(),
+	}
+}
+
+fn property_span(prop: &FormFieldProperty) -> Span {
+	match prop {
+		FormFieldProperty::Named { span, .. }
+		| FormFieldProperty::Flag { span, .. }
+		| FormFieldProperty::Widget { span, .. }
+		| FormFieldProperty::Wrapper { span, .. }
+		| FormFieldProperty::Icon { span, .. }
+		| FormFieldProperty::IconPosition { span, .. }
+		| FormFieldProperty::Attrs { span, .. }
+		| FormFieldProperty::Bind { span, .. }
+		| FormFieldProperty::InitialFrom { span, .. }
+		| FormFieldProperty::ChoicesFrom { span, .. }
+		| FormFieldProperty::Choices { span, .. }
+		| FormFieldProperty::ChoiceValue { span, .. }
+		| FormFieldProperty::ChoiceLabel { span, .. }
+		| FormFieldProperty::ChoiceDisabled { span, .. }
+		| FormFieldProperty::ChoiceGroup { span, .. }
+		| FormFieldProperty::ChoiceGroupDisabled { span, .. } => *span,
+	}
+}
+
+fn unknown_control_property_error(kind: FormControlEntryKind, prop: &FormFieldProperty) -> Error {
+	Error::new(
+		property_span(prop),
+		format!(
+			"unknown {} property: '{}'",
+			control_entry_kind_name(kind),
+			property_name(prop)
+		),
+	)
+}
+
 /// Transforms a single field definition.
 fn transform_field(field: &FormFieldDef) -> Result<TypedFormFieldDef> {
 	// Parse field type
@@ -593,6 +1152,8 @@ fn transform_field(field: &FormFieldDef) -> Result<TypedFormFieldDef> {
 	let display = extract_display_properties(&field.properties)?;
 	let styling = extract_styling_properties(&field.properties)?;
 	let widget = extract_widget(&field.properties, &field_type)?;
+	validate_widget_field_compatibility(&field_type, &widget, field.span)?;
+	let native_attrs = extract_native_attrs(&field.properties, &field_type, &widget)?;
 	let wrapper = extract_wrapper(&field.properties)?;
 	let icon = extract_icon(&field.properties)?;
 	let custom_attrs = extract_custom_attrs(&field.properties)?;
@@ -600,11 +1161,47 @@ fn transform_field(field: &FormFieldDef) -> Result<TypedFormFieldDef> {
 	let initial_from = extract_initial_from(&field.properties);
 	let initial_expr = extract_initial_expr(&field.properties);
 	let choices_config = extract_choices_config(&field.properties);
+	let static_choices_source = extract_static_choices(&field.properties)?;
+
+	validate_radio_select_choice_group_properties(&field.properties, &widget)?;
+
+	if !static_choices_source.is_empty() && choices_config.is_some() {
+		return Err(Error::new(
+			field.span,
+			"field cannot specify both choices and choices_from",
+		));
+	}
+
+	if choices_config.is_some() && !field_type_accepts_choices(&field_type) {
+		return Err(Error::new(
+			field.span,
+			"choices_from can only be used with ChoiceField or MultipleChoiceField",
+		));
+	}
+
+	if !static_choices_source.is_empty() && !field_type_accepts_choices(&field_type) {
+		return Err(Error::new(
+			field.span,
+			"choices can only be used with ChoiceField or MultipleChoiceField",
+		));
+	}
+
+	if !static_choices_source.is_empty()
+		&& !matches!(widget, TypedWidget::Select | TypedWidget::SelectMultiple)
+	{
+		return Err(Error::new(
+			field.span,
+			"choices require Select or SelectMultiple widget",
+		));
+	}
+
+	let static_choices = transform_static_choices(&static_choices_source, true, false)?;
 
 	Ok(TypedFormFieldDef {
 		name: field.name.clone(),
 		field_type,
 		widget,
+		native_attrs,
 		validation,
 		display,
 		styling,
@@ -615,8 +1212,134 @@ fn transform_field(field: &FormFieldDef) -> Result<TypedFormFieldDef> {
 		initial_from,
 		initial_expr,
 		choices_config,
+		static_choices,
 		span: field.span,
 	})
+}
+
+fn field_type_accepts_choices(field_type: &TypedFieldType) -> bool {
+	matches!(
+		field_type,
+		TypedFieldType::ChoiceField { .. } | TypedFieldType::MultipleChoiceField { .. }
+	)
+}
+
+fn validate_radio_select_choice_group_properties(
+	properties: &[FormFieldProperty],
+	widget: &TypedWidget,
+) -> Result<()> {
+	if !matches!(widget, TypedWidget::RadioSelect) {
+		return Ok(());
+	}
+
+	for prop in properties {
+		match prop {
+			FormFieldProperty::ChoiceGroup { .. } => {
+				return Err(Error::new(
+					property_span(prop),
+					"choice_group is only supported on Select and SelectMultiple widgets",
+				));
+			}
+			FormFieldProperty::ChoiceGroupDisabled { .. } => {
+				return Err(Error::new(
+					property_span(prop),
+					"choice_group_disabled is only supported on Select and SelectMultiple widgets",
+				));
+			}
+			_ => {}
+		}
+	}
+
+	Ok(())
+}
+
+fn extract_static_choices(properties: &[FormFieldProperty]) -> Result<Vec<FormChoiceItem>> {
+	let mut choices = None;
+
+	for prop in properties {
+		if let FormFieldProperty::Choices {
+			choices: items,
+			span,
+		} = prop
+		{
+			if choices.is_some() {
+				return Err(Error::new(
+					*span,
+					"choices/options specified more than once",
+				));
+			}
+			choices = Some(items.clone());
+		}
+	}
+
+	Ok(choices.unwrap_or_default())
+}
+
+fn transform_static_choices(
+	choices: &[FormChoiceItem],
+	allow_groups: bool,
+	datalist: bool,
+) -> Result<Vec<TypedChoiceItem>> {
+	choices
+		.iter()
+		.map(|choice| transform_static_choice_item(choice, allow_groups, datalist))
+		.collect()
+}
+
+fn transform_static_choice_item(
+	choice: &FormChoiceItem,
+	allow_groups: bool,
+	datalist: bool,
+) -> Result<TypedChoiceItem> {
+	match choice {
+		FormChoiceItem::Option(option) => Ok(TypedChoiceItem::Option(Box::new(
+			transform_static_choice_option(option),
+		))),
+		FormChoiceItem::Group(group) => {
+			if datalist {
+				return Err(Error::new(
+					group.span,
+					"Datalist options cannot contain OptGroup",
+				));
+			}
+			if !allow_groups {
+				return Err(Error::new(
+					group.span,
+					"OptGroup is only supported by Select and SelectMultiple widgets",
+				));
+			}
+
+			let mut options = Vec::with_capacity(group.options.len());
+			for option in &group.options {
+				match option {
+					FormChoiceItem::Option(option) => {
+						options.push(transform_static_choice_option(option));
+					}
+					FormChoiceItem::Group(group) => {
+						return Err(Error::new(group.span, "nested OptGroup is not supported"));
+					}
+				}
+			}
+
+			Ok(TypedChoiceItem::Group(TypedChoiceGroup {
+				label: group.label.value(),
+				disabled: group.disabled,
+				options,
+				span: group.span,
+			}))
+		}
+	}
+}
+
+fn transform_static_choice_option(
+	option: &reinhardt_manouche::core::FormChoiceOption,
+) -> TypedChoiceOption {
+	TypedChoiceOption {
+		value: option.value.clone(),
+		label: option.label.clone().unwrap_or_else(|| option.value.clone()),
+		disabled: option.disabled,
+		span: option.span,
+	}
 }
 
 /// Parses field type identifier into TypedFieldType enum.
@@ -823,8 +1546,12 @@ fn extract_validation_properties(properties: &[FormFieldProperty]) -> Result<Typ
 			FormFieldProperty::Bind { .. } => {}   // Ignore bind properties
 			FormFieldProperty::InitialFrom { .. } => {} // Ignore initial_from properties
 			FormFieldProperty::ChoicesFrom { .. } => {} // Ignore choices_from properties
+			FormFieldProperty::Choices { .. } => {} // Ignore static choice properties
 			FormFieldProperty::ChoiceValue { .. } => {} // Ignore choice_value properties
 			FormFieldProperty::ChoiceLabel { .. } => {} // Ignore choice_label properties
+			FormFieldProperty::ChoiceDisabled { .. } => {} // Ignore choice_disabled properties
+			FormFieldProperty::ChoiceGroup { .. } => {} // Ignore choice_group properties
+			FormFieldProperty::ChoiceGroupDisabled { .. } => {} // Ignore choice_group_disabled properties
 		}
 	}
 
@@ -927,8 +1654,12 @@ fn extract_display_properties(properties: &[FormFieldProperty]) -> Result<TypedF
 			FormFieldProperty::Bind { .. } => {}   // Ignore bind properties
 			FormFieldProperty::InitialFrom { .. } => {} // Ignore initial_from properties
 			FormFieldProperty::ChoicesFrom { .. } => {} // Ignore choices_from properties
+			FormFieldProperty::Choices { .. } => {} // Ignore static choice properties
 			FormFieldProperty::ChoiceValue { .. } => {} // Ignore choice_value properties
 			FormFieldProperty::ChoiceLabel { .. } => {} // Ignore choice_label properties
+			FormFieldProperty::ChoiceDisabled { .. } => {} // Ignore choice_disabled properties
+			FormFieldProperty::ChoiceGroup { .. } => {} // Ignore choice_group properties
+			FormFieldProperty::ChoiceGroupDisabled { .. } => {} // Ignore choice_group_disabled properties
 		}
 	}
 
@@ -993,11 +1724,11 @@ fn extract_widget(
 	// Look for explicit widget property
 	for prop in properties {
 		match prop {
-			FormFieldProperty::Widget {
-				widget_type,
-				span: _,
-			} => {
-				return parse_widget(widget_type);
+			FormFieldProperty::Widget { widget, span: _ } => {
+				return match widget {
+					FormWidgetSpec::Builtin(widget_type) => parse_widget(widget_type),
+					FormWidgetSpec::Custom(custom) => validate_custom_widget(custom),
+				};
 			}
 			FormFieldProperty::Named { name, value, span } if name == "widget" => {
 				// Handle widget specified as named property: widget: PasswordInput
@@ -1019,6 +1750,26 @@ fn extract_widget(
 	Ok(field_type.default_widget())
 }
 
+fn validate_custom_widget(custom: &FormCustomWidgetSpec) -> Result<TypedWidget> {
+	if !custom.experimental {
+		return Err(Error::new(
+			custom.span,
+			"CustomWidget requires the experimental marker",
+		));
+	}
+
+	let adapter = custom
+		.adapter
+		.clone()
+		.ok_or_else(|| Error::new(custom.span, "CustomWidget requires adapter"))?;
+
+	Ok(TypedWidget::CustomExperimental(TypedCustomWidget {
+		component: custom.component.clone(),
+		adapter,
+		span: custom.span,
+	}))
+}
+
 /// Parses widget identifier into TypedWidget enum.
 fn parse_widget(ident: &syn::Ident) -> Result<TypedWidget> {
 	let widget_str = ident.to_string();
@@ -1033,6 +1784,8 @@ fn parse_widget(ident: &syn::Ident) -> Result<TypedWidget> {
 		"Select" => Ok(TypedWidget::Select),
 		"SelectMultiple" => Ok(TypedWidget::SelectMultiple),
 		"DateInput" => Ok(TypedWidget::DateInput),
+		"MonthInput" => Ok(TypedWidget::MonthInput),
+		"WeekInput" => Ok(TypedWidget::WeekInput),
 		"TimeInput" => Ok(TypedWidget::TimeInput),
 		"DateTimeInput" => Ok(TypedWidget::DateTimeInput),
 		"FileInput" => Ok(TypedWidget::FileInput),
@@ -1046,13 +1799,326 @@ fn parse_widget(ident: &syn::Ident) -> Result<TypedWidget> {
 			ident.span(),
 			format!(
 				"unknown widget type: '{}'. Expected one of: TextInput, PasswordInput, \
-				EmailInput, NumberInput, Textarea, CheckboxInput, RadioSelect, Select, \
-				SelectMultiple, DateInput, TimeInput, DateTimeInput, FileInput, HiddenInput, \
-				ColorInput, RangeInput, UrlInput, TelInput, SearchInput",
+					EmailInput, NumberInput, Textarea, CheckboxInput, RadioSelect, Select, \
+					SelectMultiple, DateInput, MonthInput, WeekInput, TimeInput, DateTimeInput, \
+					FileInput, HiddenInput, ColorInput, RangeInput, UrlInput, TelInput, SearchInput",
 				widget_str
 			),
 		)),
 	}
+}
+
+#[derive(Default)]
+struct NativeAttrSpans {
+	min: Option<Span>,
+	max: Option<Span>,
+	step: Option<Span>,
+	multiple: Option<Span>,
+	accept: Option<Span>,
+	capture: Option<Span>,
+	list: Option<Span>,
+	size: Option<Span>,
+}
+
+fn validate_widget_field_compatibility(
+	field_type: &TypedFieldType,
+	widget: &TypedWidget,
+	span: Span,
+) -> Result<()> {
+	match widget {
+		TypedWidget::MonthInput if !is_string_valued_field(field_type) => Err(Error::new(
+			span,
+			"MonthInput is only supported on string-valued fields",
+		)),
+		TypedWidget::WeekInput if !is_string_valued_field(field_type) => Err(Error::new(
+			span,
+			"WeekInput is only supported on string-valued fields",
+		)),
+		_ => Ok(()),
+	}
+}
+
+fn extract_native_attrs(
+	properties: &[FormFieldProperty],
+	field_type: &TypedFieldType,
+	widget: &TypedWidget,
+) -> Result<TypedFieldNativeAttrs> {
+	let mut attrs = TypedFieldNativeAttrs::default();
+	let mut spans = NativeAttrSpans::default();
+
+	for prop in properties {
+		match prop {
+			FormFieldProperty::Named { name, value, span } => match name.to_string().as_str() {
+				"min" => {
+					attrs.min = Some(value.clone());
+					spans.min = Some(*span);
+				}
+				"max" => {
+					attrs.max = Some(value.clone());
+					spans.max = Some(*span);
+				}
+				"step" => {
+					attrs.step = Some(value.clone());
+					spans.step = Some(*span);
+				}
+				"multiple" => {
+					attrs.multiple = Some(expect_bool_literal(value, *span, "multiple")?);
+					spans.multiple = Some(*span);
+				}
+				"accept" => {
+					attrs.accept = Some(expect_string_literal(value, *span, "accept")?);
+					spans.accept = Some(*span);
+				}
+				"capture" => {
+					attrs.capture = Some(expect_string_literal(value, *span, "capture")?);
+					spans.capture = Some(*span);
+				}
+				"list" => {
+					attrs.list = Some(expect_ident_expr(value, *span, "list")?);
+					spans.list = Some(*span);
+				}
+				"size" => {
+					attrs.size = Some(expect_positive_i64_literal(value, *span, "size")?);
+					spans.size = Some(*span);
+				}
+				_ => {}
+			},
+			FormFieldProperty::Flag { name, span } if name == "multiple" => {
+				attrs.multiple = Some(true);
+				spans.multiple = Some(*span);
+			}
+			_ => {}
+		}
+	}
+
+	validate_native_attrs(field_type, widget, &attrs, &spans)?;
+	Ok(attrs)
+}
+
+fn validate_native_attrs(
+	field_type: &TypedFieldType,
+	widget: &TypedWidget,
+	attrs: &TypedFieldNativeAttrs,
+	spans: &NativeAttrSpans,
+) -> Result<()> {
+	if attrs.accept.is_some() && !is_file_like_input(field_type, widget) {
+		return Err(Error::new(
+			spans.accept.unwrap_or_else(Span::call_site),
+			"accept is only supported on file-like inputs",
+		));
+	}
+	if attrs.capture.is_some() && !is_file_like_input(field_type, widget) {
+		return Err(Error::new(
+			spans.capture.unwrap_or_else(Span::call_site),
+			"capture is only supported on file-like inputs",
+		));
+	}
+	if attrs.multiple.is_some() && !is_file_like_input(field_type, widget) {
+		return Err(Error::new(
+			spans.multiple.unwrap_or_else(Span::call_site),
+			"multiple is only supported on file-like inputs",
+		));
+	}
+	if attrs.list.is_some() && !is_text_like_input(widget) {
+		return Err(Error::new(
+			spans.list.unwrap_or_else(Span::call_site),
+			"list is only supported on text-like inputs",
+		));
+	}
+	if attrs.size.is_some() && !supports_size_attr(widget) {
+		return Err(Error::new(
+			spans.size.unwrap_or_else(Span::call_site),
+			"size is only supported on text-like inputs",
+		));
+	}
+	if attrs.min.is_some() && !supports_value_bound_attrs(widget) {
+		return Err(Error::new(
+			spans.min.unwrap_or_else(Span::call_site),
+			"min is only supported on native value inputs",
+		));
+	}
+	if attrs.max.is_some() && !supports_value_bound_attrs(widget) {
+		return Err(Error::new(
+			spans.max.unwrap_or_else(Span::call_site),
+			"max is only supported on native value inputs",
+		));
+	}
+	if attrs.step.is_some() && !supports_value_bound_attrs(widget) {
+		return Err(Error::new(
+			spans.step.unwrap_or_else(Span::call_site),
+			"step is only supported on native value inputs",
+		));
+	}
+
+	Ok(())
+}
+
+fn expect_string_literal(value: &syn::Expr, span: Span, prop_name: &str) -> Result<String> {
+	if let syn::Expr::Lit(lit) = value
+		&& let syn::Lit::Str(str_lit) = &lit.lit
+	{
+		return Ok(str_lit.value());
+	}
+
+	Err(Error::new(
+		span,
+		format!("{prop_name} must be a string literal"),
+	))
+}
+
+fn expect_bool_literal(value: &syn::Expr, span: Span, prop_name: &str) -> Result<bool> {
+	if let syn::Expr::Lit(lit) = value
+		&& let syn::Lit::Bool(bool_lit) = &lit.lit
+	{
+		return Ok(bool_lit.value);
+	}
+
+	Err(Error::new(
+		span,
+		format!("{prop_name} must be true or false"),
+	))
+}
+
+fn expect_ident_expr(value: &syn::Expr, span: Span, prop_name: &str) -> Result<syn::Ident> {
+	if let syn::Expr::Path(path) = value
+		&& path.path.leading_colon.is_none()
+		&& path.path.segments.len() == 1
+		&& let Some(ident) = path.path.get_ident()
+	{
+		return Ok(ident.clone());
+	}
+
+	Err(Error::new(
+		span,
+		format!("{prop_name} must be an identifier"),
+	))
+}
+
+fn expect_ident_array(value: &syn::Expr, span: Span, prop_name: &str) -> Result<Vec<syn::Ident>> {
+	let syn::Expr::Array(array) = value else {
+		return Err(Error::new(
+			span,
+			format!("{prop_name} must be an array of field identifiers"),
+		));
+	};
+
+	array
+		.elems
+		.iter()
+		.map(|elem| expect_ident_expr(elem, span, prop_name))
+		.collect()
+}
+
+fn expect_i64_literal(value: &syn::Expr, span: Span, prop_name: &str) -> Result<i64> {
+	match value {
+		syn::Expr::Lit(lit) => {
+			if let syn::Lit::Int(int_lit) = &lit.lit {
+				int_lit.base10_parse::<i64>().map_err(|_| {
+					Error::new(span, format!("{prop_name} must be an integer literal"))
+				})
+			} else {
+				Err(Error::new(
+					span,
+					format!("{prop_name} must be an integer literal"),
+				))
+			}
+		}
+		syn::Expr::Unary(unary) => {
+			if let syn::UnOp::Neg(_) = unary.op
+				&& let syn::Expr::Lit(lit) = &*unary.expr
+				&& let syn::Lit::Int(int_lit) = &lit.lit
+			{
+				let value = int_lit.base10_parse::<i64>().map_err(|_| {
+					Error::new(span, format!("{prop_name} must be an integer literal"))
+				})?;
+				Ok(-value)
+			} else {
+				Err(Error::new(
+					span,
+					format!("{prop_name} must be an integer literal"),
+				))
+			}
+		}
+		_ => Err(Error::new(
+			span,
+			format!("{prop_name} must be an integer literal"),
+		)),
+	}
+}
+
+fn expect_positive_i64_literal(value: &syn::Expr, span: Span, prop_name: &str) -> Result<i64> {
+	let parsed = expect_i64_literal(value, span, prop_name)?;
+	if parsed > 0 {
+		return Ok(parsed);
+	}
+
+	Err(Error::new(
+		span,
+		format!("{prop_name} must be a positive integer literal"),
+	))
+}
+
+fn is_string_valued_field(field_type: &TypedFieldType) -> bool {
+	matches!(
+		field_type,
+		TypedFieldType::CharField
+			| TypedFieldType::EmailField
+			| TypedFieldType::UrlField
+			| TypedFieldType::SlugField
+			| TypedFieldType::PasswordField
+			| TypedFieldType::TextField
+			| TypedFieldType::UuidField
+			| TypedFieldType::IpAddressField
+	)
+}
+
+fn is_file_like_input(field_type: &TypedFieldType, widget: &TypedWidget) -> bool {
+	matches!(
+		(field_type, widget),
+		(
+			TypedFieldType::FileField | TypedFieldType::ImageField,
+			TypedWidget::FileInput
+		)
+	)
+}
+
+fn is_text_like_input(widget: &TypedWidget) -> bool {
+	matches!(
+		widget,
+		TypedWidget::TextInput
+			| TypedWidget::SearchInput
+			| TypedWidget::UrlInput
+			| TypedWidget::TelInput
+			| TypedWidget::EmailInput
+			| TypedWidget::PasswordInput
+			| TypedWidget::MonthInput
+			| TypedWidget::WeekInput
+	)
+}
+
+fn supports_size_attr(widget: &TypedWidget) -> bool {
+	matches!(
+		widget,
+		TypedWidget::TextInput
+			| TypedWidget::SearchInput
+			| TypedWidget::UrlInput
+			| TypedWidget::TelInput
+			| TypedWidget::EmailInput
+			| TypedWidget::PasswordInput
+	)
+}
+
+fn supports_value_bound_attrs(widget: &TypedWidget) -> bool {
+	matches!(
+		widget,
+		TypedWidget::NumberInput
+			| TypedWidget::RangeInput
+			| TypedWidget::DateInput
+			| TypedWidget::TimeInput
+			| TypedWidget::DateTimeInput
+			| TypedWidget::MonthInput
+			| TypedWidget::WeekInput
+	)
 }
 
 /// Extracts wrapper property and transforms it into `TypedWrapper`.
@@ -1318,6 +2384,9 @@ fn extract_choices_config(properties: &[FormFieldProperty]) -> Option<TypedChoic
 	let mut choices_from: Option<(String, Span)> = None;
 	let mut choice_value: Option<String> = None;
 	let mut choice_label: Option<String> = None;
+	let mut choice_disabled: Option<String> = None;
+	let mut choice_group: Option<String> = None;
+	let mut choice_group_disabled: Option<String> = None;
 
 	for prop in properties {
 		match prop {
@@ -1330,6 +2399,15 @@ fn extract_choices_config(properties: &[FormFieldProperty]) -> Option<TypedChoic
 			FormFieldProperty::ChoiceLabel { path, .. } => {
 				choice_label = Some(path.value());
 			}
+			FormFieldProperty::ChoiceDisabled { path, .. } => {
+				choice_disabled = Some(path.value());
+			}
+			FormFieldProperty::ChoiceGroup { path, .. } => {
+				choice_group = Some(path.value());
+			}
+			FormFieldProperty::ChoiceGroupDisabled { path, .. } => {
+				choice_group_disabled = Some(path.value());
+			}
 			_ => {}
 		}
 	}
@@ -1340,6 +2418,9 @@ fn extract_choices_config(properties: &[FormFieldProperty]) -> Option<TypedChoic
 			from,
 			choice_value.unwrap_or_else(|| "value".to_string()),
 			choice_label.unwrap_or_else(|| "label".to_string()),
+			choice_disabled,
+			choice_group,
+			choice_group_disabled,
 			span,
 		)
 	})
@@ -1427,11 +2508,18 @@ fn field_exists(entries: &[FormFieldEntry], name: &syn::Ident) -> bool {
 				}
 			}
 			FormFieldEntry::Group(group) => {
-				if group.fields.iter().any(|f| f.name == *name) {
+				if field_exists(&group.fields, name) {
 					return true;
 				}
 			}
-			FormFieldEntry::SubmitButton(_) => {}
+			FormFieldEntry::SubmitButton(_)
+			| FormFieldEntry::ResetButton(_)
+			| FormFieldEntry::Button(_)
+			| FormFieldEntry::ImageInput(_)
+			| FormFieldEntry::Output(_)
+			| FormFieldEntry::Meter(_)
+			| FormFieldEntry::Progress(_)
+			| FormFieldEntry::Datalist(_) => {}
 		}
 	}
 	false
@@ -3052,9 +4140,10 @@ mod tests {
 		assert_eq!(group.fields.len(), 2);
 
 		// Check fields within the group
-		assert_eq!(group.fields[0].name.to_string(), "street");
-		assert!(group.fields[0].validation.required);
-		assert_eq!(group.fields[1].name.to_string(), "city");
+		let street = group.fields[0].as_field().unwrap();
+		assert_eq!(street.name.to_string(), "street");
+		assert!(street.validation.required);
+		assert_eq!(group.fields[1].as_field().unwrap().name.to_string(), "city");
 	}
 
 	#[rstest::rstest]
@@ -3289,8 +4378,14 @@ mod tests {
 
 		let typed = result.unwrap();
 		let group = typed.fields[0].as_group().unwrap();
-		assert_eq!(group.fields[0].initial_from, Some("name".to_string()));
-		assert_eq!(group.fields[1].initial_from, Some("biography".to_string()));
+		assert_eq!(
+			group.fields[0].as_field().unwrap().initial_from,
+			Some("name".to_string())
+		);
+		assert_eq!(
+			group.fields[1].as_field().unwrap().initial_from,
+			Some("biography".to_string())
+		);
 	}
 
 	#[rstest::rstest]
@@ -3370,7 +4465,7 @@ mod tests {
 		let group = typed.fields[0].as_group().unwrap();
 
 		// Check email field properties
-		let email = &group.fields[0];
+		let email = group.fields[0].as_field().unwrap();
 		assert!(email.validation.required);
 		assert_eq!(email.display.label, Some("Email Address".to_string()));
 		assert_eq!(
@@ -3380,7 +4475,7 @@ mod tests {
 		assert!(email.has_wrapper());
 
 		// Check password field properties
-		let password = &group.fields[1];
+		let password = group.fields[1].as_field().unwrap();
 		assert!(password.validation.required);
 		assert!(matches!(password.widget, TypedWidget::PasswordInput));
 		assert!(!password.bind);
@@ -3808,19 +4903,138 @@ mod tests {
 		// Check fields within the group
 		assert_eq!(group.fields.len(), 2);
 
-		let category_field = &group.fields[0];
+		let category_field = group.fields[0].as_field().unwrap();
 		assert!(category_field.choices_config.is_some());
 		assert_eq!(
 			category_field.choices_config.as_ref().unwrap().choices_from,
 			"categories"
 		);
 
-		let status_field = &group.fields[1];
+		let status_field = group.fields[1].as_field().unwrap();
 		assert!(status_field.choices_config.is_some());
 		assert_eq!(
 			status_field.choices_config.as_ref().unwrap().choices_from,
 			"statuses"
 		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_dynamic_datalist_and_list_reference() {
+		let input = quote! {
+			name: DynamicDatalistForm,
+			action: "/search",
+			choices_loader: load_suggestions,
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					list: suggestions,
+				},
+				suggestions: Datalist {
+					choices_from: "items",
+					choice_value: "value",
+					choice_label: "label",
+					choice_disabled: "disabled",
+				},
+			},
+		};
+
+		let typed = parse_and_validate(input).unwrap();
+		let field = typed.fields[0].as_field().unwrap();
+		assert_eq!(
+			field.native_attrs.list.as_ref().unwrap().to_string(),
+			"suggestions"
+		);
+
+		let datalist = typed.fields[1].as_datalist().unwrap();
+		let config = datalist.choices_config.as_ref().unwrap();
+		assert_eq!(config.choices_from, "items");
+		assert_eq!(config.choice_value, "value");
+		assert_eq!(config.choice_label, "label");
+		assert_eq!(config.choice_disabled.as_deref(), Some("disabled"));
+		assert!(datalist.static_choices.is_empty());
+	}
+
+	#[rstest::rstest]
+	fn test_validate_list_rejects_missing_datalist() {
+		let input = quote! {
+			name: MissingDatalistForm,
+			action: "/search",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					list: suggestions,
+				},
+			},
+		};
+
+		let err = parse_and_validate(input).unwrap_err().to_string();
+		assert_eq!(
+			err,
+			"list reference 'suggestions' must resolve to a Datalist entry"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_list_rejects_value_field_reference() {
+		let input = quote! {
+			name: ValueFieldListForm,
+			action: "/search",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					list: suggestions,
+				},
+				suggestions: CharField {},
+			},
+		};
+
+		let err = parse_and_validate(input).unwrap_err().to_string();
+		assert_eq!(
+			err,
+			"list reference 'suggestions' must resolve to a Datalist entry"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_datalist_rejects_choice_group() {
+		let input = quote! {
+			name: InvalidDatalistGroupForm,
+			action: "/search",
+
+			fields: {
+				suggestions: Datalist {
+					choices_from: "items",
+					choice_group: "group",
+				},
+			},
+		};
+
+		let err = parse_and_validate(input).unwrap_err().to_string();
+		assert_eq!(
+			err,
+			"Datalist does not support choice_group; datalist options must be flat"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_datalist_rejects_unknown_property() {
+		let input = quote! {
+			name: InvalidDatalistPropertyForm,
+			action: "/search",
+
+			fields: {
+				suggestions: Datalist {
+					options: [("a", "A")],
+					label: "Suggestions",
+				},
+			},
+		};
+
+		let err = parse_and_validate(input).unwrap_err().to_string();
+		assert_eq!(err, "unknown Datalist property: 'label'");
 	}
 
 	#[test]
@@ -4121,6 +5335,84 @@ mod tests {
 		let field = typed.fields[0].as_field().unwrap();
 		assert!(matches!(field.field_type, TypedFieldType::ImageField));
 		assert!(matches!(field.widget, TypedWidget::FileInput));
+	}
+
+	#[rstest::rstest]
+	fn test_validate_size_rejects_zero() {
+		// Arrange
+		let input = quote! {
+			name: SearchForm,
+			action: "/search",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					size: 0,
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert_eq!(
+			result.unwrap_err().to_string(),
+			"size must be a positive integer literal"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_size_rejects_negative() {
+		// Arrange
+		let input = quote! {
+			name: SearchForm,
+			action: "/search",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					size: -1,
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert_eq!(
+			result.unwrap_err().to_string(),
+			"size must be a positive integer literal"
+		);
+	}
+
+	#[rstest::rstest]
+	fn test_validate_size_rejects_non_integer() {
+		// Arrange
+		let input = quote! {
+			name: SearchForm,
+			action: "/search",
+
+			fields: {
+				query: CharField {
+					widget: SearchInput,
+					size: "32",
+				},
+			},
+		};
+
+		// Act
+		let result = parse_and_validate(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert_eq!(
+			result.unwrap_err().to_string(),
+			"size must be an integer literal"
+		);
 	}
 
 	#[rstest::rstest]

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -962,8 +962,8 @@ pub fn head(input: TokenStream) -> TokenStream {
 /// | `PasswordField` | `String` | `PasswordInput` | Password input (masked) |
 /// | `UrlField` | `String` | `UrlInput` | URL input |
 /// | `SlugField` | `String` | `TextInput` | URL-safe slug |
-/// | `UuidField` | `String` | `TextInput` | UUID input |
-/// | `IpAddressField` | `String` | `TextInput` | IP address |
+/// | `UuidField` | `Option<uuid::Uuid>` | `TextInput` | UUID input |
+/// | `IpAddressField` | `Option<std::net::IpAddr>` | `TextInput` | IP address |
 /// | `JsonField` | `String` | `Textarea` | JSON data |
 /// | `HiddenField` | `String` | `HiddenInput` | Hidden field |
 ///

--- a/crates/reinhardt-pages/src/component/view_transition.rs
+++ b/crates/reinhardt-pages/src/component/view_transition.rs
@@ -260,8 +260,8 @@ fn sanitize_view_transition_name(name: Cow<'static, str>) -> Cow<'static, str> {
 
 fn needs_identifier_prefix(value: &str) -> bool {
 	let mut chars = value.chars();
-	match chars.next() {
-		Some(ch) if ch.is_ascii_alphabetic() || ch == '_' => false,
-		_ => true,
-	}
+	!matches!(
+		chars.next(),
+		Some(ch) if ch.is_ascii_alphabetic() || ch == '_'
+	)
 }

--- a/crates/reinhardt-pages/src/form_state.rs
+++ b/crates/reinhardt-pages/src/form_state.rs
@@ -56,6 +56,119 @@ impl FieldError {
 	}
 }
 
+/// Experimental raw value kind requested by a custom widget adapter.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FormWidgetValueKind {
+	/// A single string value.
+	Value,
+	/// A boolean checked value.
+	Checked,
+	/// A file value. File parsing is not implemented yet.
+	File,
+	/// Multiple string values.
+	MultiValue,
+}
+
+/// Experimental raw value passed between generated forms and custom widget adapters.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CustomWidgetRawValue {
+	/// A single string value.
+	String(String),
+	/// A boolean checked value.
+	Bool(bool),
+	/// Multiple string values.
+	Strings(Vec<String>),
+	/// A raw value kind not supported by the current experimental runtime.
+	Unsupported,
+}
+
+/// Experimental error returned by a custom widget adapter.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FormWidgetError {
+	message: String,
+}
+
+impl FormWidgetError {
+	/// Creates an experimental custom widget adapter error.
+	pub fn new(message: impl Into<String>) -> Self {
+		Self {
+			message: message.into(),
+		}
+	}
+
+	/// Returns the experimental custom widget adapter error message.
+	pub fn message(&self) -> &str {
+		&self.message
+	}
+}
+
+/// Experimental context passed to custom widget adapters.
+#[non_exhaustive]
+#[derive(Clone)]
+pub struct CustomWidgetContext<Value> {
+	/// Current typed field value.
+	pub value: Value,
+	/// Whether the generated field should be disabled.
+	pub disabled: bool,
+	/// Whether the generated field is required.
+	pub required: bool,
+	/// Whether the generated field has been touched.
+	pub touched: bool,
+	/// Current field error, if any.
+	pub error: Option<FieldError>,
+	/// Generated form field name.
+	pub name: String,
+	/// Generated form field id.
+	pub id: String,
+	/// Experimental raw-change callback for custom widget components.
+	///
+	/// The generated form parses raw values through the adapter and updates the
+	/// generated field state when parsing succeeds. Parse failures are returned
+	/// to the caller as experimental adapter errors and surfaced through
+	/// runtime field error state.
+	pub on_raw_change: Rc<dyn Fn(CustomWidgetRawValue) -> Result<(), FormWidgetError>>,
+}
+
+impl<Value> CustomWidgetContext<Value> {
+	/// Creates an experimental custom widget context.
+	pub fn new(
+		value: Value,
+		on_raw_change: Rc<dyn Fn(CustomWidgetRawValue) -> Result<(), FormWidgetError>>,
+	) -> Self {
+		Self {
+			value,
+			disabled: false,
+			required: false,
+			touched: false,
+			error: None,
+			name: String::new(),
+			id: String::new(),
+			on_raw_change,
+		}
+	}
+}
+
+/// Experimental adapter trait for `CustomWidget(...)` generated form fields.
+pub trait FormWidgetAdapter<FieldValue> {
+	/// Props accepted by the custom widget component.
+	type ComponentProps;
+
+	/// Returns the raw value kind consumed by this experimental adapter.
+	fn value_kind() -> FormWidgetValueKind;
+
+	/// Builds component props from the generated field context.
+	fn props(ctx: CustomWidgetContext<FieldValue>) -> Self::ComponentProps;
+
+	/// Parses a raw widget value into the typed field value.
+	fn parse(raw: CustomWidgetRawValue) -> Result<FieldValue, FormWidgetError>;
+
+	/// Formats a typed field value into a raw widget value.
+	fn format(value: &FieldValue) -> CustomWidgetRawValue;
+}
+
 /// Validation failure for a generated form.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FormValidationError<Field>
@@ -246,6 +359,14 @@ pub trait FormRuntimeSource: Clone + 'static {
 	where
 		T: Clone + 'static;
 
+	/// Returns the current custom-widget bridge error for one generated field.
+	fn runtime_custom_widget_error(&self, _field: Self::Field) -> Option<FieldError> {
+		None
+	}
+
+	/// Sets or clears the current custom-widget bridge error for one generated field.
+	fn runtime_set_custom_widget_error(&self, _field: Self::Field, _error: Option<FieldError>) {}
+
 	/// Runs generated validation.
 	fn runtime_validate(&self) -> Result<(), FormValidationError<Self::Field>> {
 		Ok(())
@@ -302,6 +423,7 @@ fn build_signal_sync_effect<Form>(
 	values_signal: Signal<Form::Values>,
 	subscribers: SubscriberSlots<Form>,
 	observed_values: Rc<RefCell<Form::Values>>,
+	custom_widget_error_fields: Rc<RefCell<HashMap<Form::Field, FieldError>>>,
 	signal_sync_suppressed: Rc<Cell<bool>>,
 	revalidate_on: RevalidateOn,
 ) -> Rc<Effect>
@@ -312,6 +434,7 @@ where
 		move || {
 			let current = form.runtime_current_values();
 			let previous = observed_values.borrow().clone();
+			let custom_widget_errors = collect_custom_widget_errors(&form);
 			let changed_fields: Vec<Form::Field> = form
 				.runtime_fields()
 				.iter()
@@ -321,6 +444,13 @@ where
 			*observed_values.borrow_mut() = current.clone();
 
 			if signal_sync_suppressed.get() || changed_fields.is_empty() {
+				if !signal_sync_suppressed.get() {
+					sync_custom_widget_errors_in_state(
+						&state,
+						&custom_widget_error_fields,
+						&custom_widget_errors,
+					);
+				}
 				return;
 			}
 
@@ -340,12 +470,70 @@ where
 				apply_validation_result_to_state(&state, &result);
 				notify_subscribers(&subscribers, FormEvent::Validated);
 			}
+			sync_custom_widget_errors_in_state(
+				&state,
+				&custom_widget_error_fields,
+				&custom_widget_errors,
+			);
 			for field in changed_fields {
 				notify_subscribers(&subscribers, FormEvent::ValueChanged { field });
 			}
 		},
 		EffectTiming::Layout,
 	))
+}
+
+fn collect_custom_widget_errors<Form>(form: &Form) -> HashMap<Form::Field, FieldError>
+where
+	Form: FormRuntimeSource,
+{
+	form.runtime_fields()
+		.iter()
+		.copied()
+		.filter_map(|field| {
+			form.runtime_custom_widget_error(field)
+				.map(|error| (field, error))
+		})
+		.collect()
+}
+
+fn sync_custom_widget_errors_in_state<Field>(
+	state: &FormState<Field>,
+	tracked_fields: &Rc<RefCell<HashMap<Field, FieldError>>>,
+	custom_widget_errors: &HashMap<Field, FieldError>,
+) where
+	Field: Copy + Eq + Hash + 'static,
+{
+	let mut tracked = tracked_fields.borrow_mut();
+	let mut field_errors = state.field_errors.get_untracked();
+	let mut changed = false;
+
+	let previously_tracked: Vec<(Field, FieldError)> = tracked
+		.iter()
+		.map(|(field, error)| (*field, error.clone()))
+		.collect();
+	for (field, previous_error) in previously_tracked {
+		if !custom_widget_errors.contains_key(&field) {
+			tracked.remove(&field);
+			if field_errors.get(&field) == Some(&previous_error) {
+				field_errors.remove(&field);
+				changed = true;
+			}
+		}
+	}
+
+	for (field, error) in custom_widget_errors {
+		if field_errors.get(field) != Some(error) {
+			field_errors.insert(*field, error.clone());
+			changed = true;
+		}
+		tracked.insert(*field, error.clone());
+	}
+
+	if changed {
+		state.field_errors.set(field_errors);
+		sync_first_error_in_state(state);
+	}
 }
 
 fn adapt_no_deps_callback<Form, Deps>(
@@ -368,6 +556,7 @@ where
 			values_signal: handle.values_signal.clone(),
 			subscribers: Rc::clone(&handle.subscribers),
 			observed_values: Rc::clone(&handle.observed_values),
+			custom_widget_error_fields: Rc::clone(&handle.custom_widget_error_fields),
 			signal_sync_suppressed: Rc::clone(&handle.signal_sync_suppressed),
 			_signal_sync_effect: Rc::clone(&handle._signal_sync_effect),
 			on_submit_start: None,
@@ -518,6 +707,7 @@ where
 		let values_signal = Signal::new(current_values.clone());
 		let subscribers = Rc::new(RefCell::new(Vec::new()));
 		let observed_values = Rc::new(RefCell::new(current_values));
+		let custom_widget_error_fields = Rc::new(RefCell::new(HashMap::new()));
 		let signal_sync_suppressed = Rc::new(Cell::new(false));
 		let signal_sync_effect = build_signal_sync_effect(
 			form.clone(),
@@ -527,6 +717,7 @@ where
 			values_signal.clone(),
 			Rc::clone(&subscribers),
 			Rc::clone(&observed_values),
+			Rc::clone(&custom_widget_error_fields),
 			Rc::clone(&signal_sync_suppressed),
 			self.revalidate_on,
 		);
@@ -542,6 +733,7 @@ where
 			values_signal,
 			subscribers,
 			observed_values,
+			custom_widget_error_fields,
 			signal_sync_suppressed,
 			_signal_sync_effect: signal_sync_effect,
 			on_submit_start: self.on_submit_start,
@@ -568,6 +760,7 @@ where
 	values_signal: Signal<Form::Values>,
 	subscribers: SubscriberSlots<Form>,
 	observed_values: Rc<RefCell<Form::Values>>,
+	custom_widget_error_fields: Rc<RefCell<HashMap<Form::Field, FieldError>>>,
 	signal_sync_suppressed: Rc<Cell<bool>>,
 	_signal_sync_effect: Rc<Effect>,
 	on_submit_start: Option<SubmitCallback<Form, Deps>>,
@@ -593,6 +786,7 @@ where
 			values_signal: self.values_signal.clone(),
 			subscribers: Rc::clone(&self.subscribers),
 			observed_values: Rc::clone(&self.observed_values),
+			custom_widget_error_fields: Rc::clone(&self.custom_widget_error_fields),
 			signal_sync_suppressed: Rc::clone(&self.signal_sync_suppressed),
 			_signal_sync_effect: Rc::clone(&self._signal_sync_effect),
 			on_submit_start: self.on_submit_start.clone(),
@@ -694,6 +888,10 @@ where
 
 	/// Clears all validation and submit errors.
 	pub fn clear_errors(&self) {
+		for field in self.form.runtime_fields() {
+			self.form.runtime_set_custom_widget_error(*field, None);
+		}
+		self.custom_widget_error_fields.borrow_mut().clear();
 		self.state.field_errors.set(HashMap::new());
 		self.state.form_error.set(None);
 		self.state.submit_error.set(None);
@@ -702,6 +900,8 @@ where
 
 	/// Clears one field error.
 	pub fn clear_field_error(&self, field: Form::Field) {
+		self.form.runtime_set_custom_widget_error(field, None);
+		self.custom_widget_error_fields.borrow_mut().remove(&field);
 		let mut errors = self.state.field_errors.get();
 		errors.remove(&field);
 		self.state.field_errors.set(errors);
@@ -747,6 +947,18 @@ where
 		self.clear_errors();
 		self.values_signal.set(defaults);
 		self.sync_observed_values();
+	}
+
+	/// Syncs runtime state after a native form reset has restored field values.
+	pub fn sync_after_native_reset(&self) {
+		let current = self.get_values();
+		let is_dirty = form_values_are_dirty(&self.form, &current, &self.default_values.borrow());
+		self.touched_fields.borrow_mut().clear();
+		self.state.is_touched.set(false);
+		self.state.is_dirty.set(is_dirty);
+		self.values_signal.set(current);
+		self.sync_observed_values();
+		self.clear_errors();
 	}
 
 	/// Resets one field to its current default value.

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -95,6 +95,48 @@
 //! tracked for dirty/touched state without treating the file payload as a
 //! serializable scalar.
 //!
+//! Stable native widget coverage includes the following `form!` DSL items:
+//!
+//! | DSL item | HTML output | Value state |
+//! |---|---|---|
+//! | `MonthInput` | `<input type="month">` | string field |
+//! | `WeekInput` | `<input type="week">` | string field |
+//! | `ResetButton` | `<button type="reset">` | none |
+//! | `Button` | `<button type="button">` | none |
+//! | `ImageInput` | `<input type="image">` | none |
+//! | `Datalist` | `<datalist>` | option source only |
+//! | `OptGroup` | `<optgroup>` | choice grouping only |
+//! | `Output` | `<output>` | none |
+//! | `Meter` | `<meter>` | none |
+//! | `Progress` | `<progress>` | none |
+//!
+//! Typed native attributes are accepted for the controls that support them:
+//!
+//! | Attribute | Compatible controls |
+//! |---|---|
+//! | `min` / `max` / `step` | number, range, date, time, datetime-local, month, week |
+//! | `size` | text-like inputs |
+//! | `accept` / `capture` | file-like inputs |
+//! | `multiple` | file-like inputs and multi-select |
+//! | `list` | datalist-compatible text-like inputs |
+//!
+//! `FieldGroup` renders as semantic `<fieldset>` output. When `label` is
+//! present, the label is rendered as a `<legend>` inside the fieldset.
+//!
+//! `CustomWidget` is experimental and must opt in explicitly:
+//!
+//! ```rust,ignore
+//! date_range: CharField {
+//!     widget: CustomWidget(crate::widgets::DateRangePicker) {
+//!         experimental,
+//!         adapter: crate::widgets::DateRangeAdapter,
+//!     },
+//! }
+//! ```
+//!
+//! The adapter API may change in a minor release with a documented migration
+//! path.
+//!
 //! Use `ambient_arguments` for non-field values supplied from surrounding
 //! context. The old `strip_arguments` DSL name remains as a deprecated alias.
 //! CSRF should be supplied by `#[server_fn]` client stubs through the
@@ -327,9 +369,10 @@ pub use form::{FormBinding, FormComponent};
 // Static form metadata types (always available, used by form! macro)
 pub use form_generated::{StaticFieldMetadata, StaticFormMetadata};
 pub use form_state::{
-	FieldError, FieldState, FocusError, FormEvent, FormRuntimeSource, FormState, FormSubscription,
-	FormValidationError, NoDeps, ResetOnDeps, RevalidateOn, UseFormBuilder, UseFormReturn,
-	UseFormSubmitOutcome, use_form,
+	CustomWidgetContext, CustomWidgetRawValue, FieldError, FieldState, FocusError, FormEvent,
+	FormRuntimeSource, FormState, FormSubscription, FormValidationError, FormWidgetAdapter,
+	FormWidgetError, FormWidgetValueKind, NoDeps, ResetOnDeps, RevalidateOn, UseFormBuilder,
+	UseFormReturn, UseFormSubmitOutcome, use_form,
 };
 pub use hydration::{HydrationContext, HydrationError, hydrate};
 pub use portal::{Portal, PortalError, PortalHandle, PortalTarget, mount_portal};

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -182,9 +182,10 @@ pub use crate::static_resolver::{init_static_resolver, is_initialized, resolve_s
 // ============================================================================
 
 pub use crate::form_state::{
-	FieldError, FieldState, FocusError, FormEvent, FormRuntimeSource, FormState, FormSubscription,
-	FormValidationError, NoDeps, ResetOnDeps, RevalidateOn, UseFormBuilder, UseFormReturn,
-	UseFormSubmitOutcome, use_form,
+	CustomWidgetContext, CustomWidgetRawValue, FieldError, FieldState, FocusError, FormEvent,
+	FormRuntimeSource, FormState, FormSubscription, FormValidationError, FormWidgetAdapter,
+	FormWidgetError, FormWidgetValueKind, NoDeps, ResetOnDeps, RevalidateOn, UseFormBuilder,
+	UseFormReturn, UseFormSubmitOutcome, use_form,
 };
 
 #[cfg(native)]

--- a/crates/reinhardt-pages/tests/ui/form/fail/control_entry_rejects_generic.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/control_entry_rejects_generic.rs
@@ -1,0 +1,13 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidControlGenericForm,
+		action: "/invalid",
+		fields: {
+			reset: ResetButton<String> {
+				label: "Reset",
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/control_entry_rejects_generic.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/control_entry_rejects_generic.stderr
@@ -1,0 +1,5 @@
+error: ResetButton does not accept generic arguments
+ --> tests/ui/form/fail/control_entry_rejects_generic.rs:8:11
+  |
+8 |             reset: ResetButton<String> {
+  |                    ^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/control_entry_rejects_unknown_property.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/control_entry_rejects_unknown_property.rs
@@ -1,0 +1,14 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidControlPropertyForm,
+		action: "/invalid",
+		fields: {
+			reset: ResetButton {
+				label: "Reset",
+				accept: "text/csv",
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/control_entry_rejects_unknown_property.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/control_entry_rejects_unknown_property.stderr
@@ -1,0 +1,5 @@
+error: unknown ResetButton property: 'accept'
+  --> tests/ui/form/fail/control_entry_rejects_unknown_property.rs:10:5
+   |
+10 |                 accept: "text/csv",
+   |                 ^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/custom_widget_missing_adapter.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/custom_widget_missing_adapter.rs
@@ -1,0 +1,19 @@
+use reinhardt_pages::form;
+
+fn picker(_: ()) -> reinhardt_pages::Page {
+	reinhardt_pages::Page::Fragment(Vec::new())
+}
+
+fn main() {
+	let _form = form! {
+		name: MissingAdapterForm,
+		action: "/invalid",
+		fields: {
+			value: CharField {
+				widget: CustomWidget(picker) {
+					experimental,
+				},
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/custom_widget_missing_adapter.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/custom_widget_missing_adapter.stderr
@@ -1,0 +1,5 @@
+error: CustomWidget requires adapter
+  --> tests/ui/form/fail/custom_widget_missing_adapter.rs:13:5
+   |
+13 |                 widget: CustomWidget(picker) {
+   |                 ^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/custom_widget_missing_experimental.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/custom_widget_missing_experimental.rs
@@ -1,0 +1,21 @@
+use reinhardt_pages::form;
+
+fn picker(_: ()) -> reinhardt_pages::Page {
+	reinhardt_pages::Page::Fragment(Vec::new())
+}
+
+struct Adapter;
+
+fn main() {
+	let _form = form! {
+		name: MissingExperimentalForm,
+		action: "/invalid",
+		fields: {
+			value: CharField {
+				widget: CustomWidget(picker) {
+					adapter: Adapter,
+				},
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/custom_widget_missing_experimental.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/custom_widget_missing_experimental.stderr
@@ -1,0 +1,5 @@
+error: CustomWidget requires the experimental marker
+  --> tests/ui/form/fail/custom_widget_missing_experimental.rs:15:5
+   |
+15 |                 widget: CustomWidget(picker) {
+   |                 ^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_choice_group.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_choice_group.rs
@@ -1,0 +1,16 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidDatalistChoiceGroupForm,
+		action: "/invalid",
+		fields: {
+			suggestions: Datalist {
+				choices_from: "items",
+				choice_value: "value",
+				choice_label: "label",
+				choice_group: "group",
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_choice_group.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_choice_group.stderr
@@ -1,0 +1,5 @@
+error: Datalist does not support choice_group; datalist options must be flat
+  --> tests/ui/form/fail/datalist_rejects_choice_group.rs:12:5
+   |
+12 |                 choice_group: "group",
+   |                 ^^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_missing_options_source.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_missing_options_source.rs
@@ -1,0 +1,11 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidDatalistSourceForm,
+		action: "/invalid",
+		fields: {
+			suggestions: Datalist {}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_missing_options_source.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_missing_options_source.stderr
@@ -1,0 +1,5 @@
+error: Datalist requires either options or choices_from
+ --> tests/ui/form/fail/datalist_rejects_missing_options_source.rs:8:4
+  |
+8 |             suggestions: Datalist {}
+  |             ^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_unknown_property.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_unknown_property.rs
@@ -1,0 +1,14 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidDatalistPropertyForm,
+		action: "/invalid",
+		fields: {
+			suggestions: Datalist {
+				options: [("a", "A")],
+				label: "Suggestions",
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_unknown_property.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/datalist_rejects_unknown_property.stderr
@@ -1,0 +1,5 @@
+error: unknown Datalist property: 'label'
+  --> tests/ui/form/fail/datalist_rejects_unknown_property.rs:10:5
+   |
+10 |                 label: "Suggestions",
+   |                 ^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/file_attrs_reject_text_input.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/file_attrs_reject_text_input.rs
@@ -1,0 +1,14 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidFileAttrsForm,
+		action: "/invalid",
+		fields: {
+			title: CharField {
+				widget: TextInput,
+				accept: "image/png",
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/file_attrs_reject_text_input.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/file_attrs_reject_text_input.stderr
@@ -1,0 +1,5 @@
+error: accept is only supported on file-like inputs
+  --> tests/ui/form/fail/file_attrs_reject_text_input.rs:10:5
+   |
+10 |                 accept: "image/png",
+   |                 ^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/file_multiple_rejected.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/file_multiple_rejected.rs
@@ -1,0 +1,13 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: FileMultipleForm,
+		action: "/upload",
+		fields: {
+			document: FileField {
+				multiple,
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/file_multiple_rejected.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/file_multiple_rejected.stderr
@@ -1,0 +1,5 @@
+error: multiple field property is not supported yet. Use SelectMultiple for multi-select fields; multi-file inputs require a future Vec<File> value contract
+ --> tests/ui/form/fail/file_multiple_rejected.rs:9:5
+  |
+9 |                 multiple,
+  |                 ^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_checkbox.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_checkbox.rs
@@ -1,0 +1,14 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidListForm,
+		action: "/invalid",
+		fields: {
+			enabled: BooleanField {
+				widget: CheckboxInput,
+				list: suggestions,
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_checkbox.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_checkbox.stderr
@@ -1,0 +1,5 @@
+error: list is only supported on text-like inputs
+  --> tests/ui/form/fail/list_rejects_checkbox.rs:10:5
+   |
+10 |                 list: suggestions,
+   |                 ^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_missing_datalist.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_missing_datalist.rs
@@ -1,0 +1,14 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: MissingDatalistForm,
+		action: "/invalid",
+		fields: {
+			query: CharField {
+				widget: SearchInput,
+				list: suggestions,
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_missing_datalist.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_missing_datalist.stderr
@@ -1,0 +1,5 @@
+error: list reference 'suggestions' must resolve to a Datalist entry
+  --> tests/ui/form/fail/list_rejects_missing_datalist.rs:10:11
+   |
+10 |                 list: suggestions,
+   |                       ^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_value_field.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_value_field.rs
@@ -1,0 +1,15 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: ValueFieldListForm,
+		action: "/invalid",
+		fields: {
+			query: CharField {
+				widget: SearchInput,
+				list: suggestions,
+			}
+			suggestions: CharField {}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_value_field.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/list_rejects_value_field.stderr
@@ -1,0 +1,5 @@
+error: list reference 'suggestions' must resolve to a Datalist entry
+  --> tests/ui/form/fail/list_rejects_value_field.rs:10:11
+   |
+10 |                 list: suggestions,
+   |                       ^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/month_input_rejects_date_field.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/month_input_rejects_date_field.rs
@@ -1,0 +1,13 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidMonthForm,
+		action: "/invalid",
+		fields: {
+			billing_month: DateField {
+				widget: MonthInput,
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/month_input_rejects_date_field.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/month_input_rejects_date_field.stderr
@@ -1,0 +1,5 @@
+error: MonthInput is only supported on string-valued fields
+ --> tests/ui/form/fail/month_input_rejects_date_field.rs:8:4
+  |
+8 |             billing_month: DateField {
+  |             ^^^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/month_input_rejects_uuid_field.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/month_input_rejects_uuid_field.rs
@@ -1,0 +1,13 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidMonthUuidForm,
+		action: "/invalid",
+		fields: {
+			billing_month: UuidField {
+				widget: MonthInput,
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/month_input_rejects_uuid_field.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/month_input_rejects_uuid_field.stderr
@@ -1,0 +1,5 @@
+error: MonthInput is only supported on string-valued fields
+ --> tests/ui/form/fail/month_input_rejects_uuid_field.rs:8:4
+  |
+8 |             billing_month: UuidField {
+  |             ^^^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/optgroup_rejects_datalist.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/optgroup_rejects_datalist.rs
@@ -1,0 +1,15 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidDatalistGroupForm,
+		action: "/invalid",
+		fields: {
+			suggestions: Datalist {
+				options: [OptGroup("Grouped") {
+					("a", "A"),
+				}, ],
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/optgroup_rejects_datalist.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/optgroup_rejects_datalist.stderr
@@ -1,0 +1,5 @@
+error: Datalist options cannot contain OptGroup
+ --> tests/ui/form/fail/optgroup_rejects_datalist.rs:9:15
+  |
+9 |                 options: [OptGroup("Grouped") {
+  |                           ^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/optgroup_rejects_nested_group.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/optgroup_rejects_nested_group.rs
@@ -1,0 +1,18 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidNestedOptGroupForm,
+		action: "/invalid",
+		fields: {
+			status: ChoiceField<String> {
+				widget: Select,
+				choices: [OptGroup("Outer") {
+					OptGroup("Inner") {
+						("open", "Open"),
+					},
+				}, ],
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/optgroup_rejects_nested_group.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/optgroup_rejects_nested_group.stderr
@@ -1,0 +1,5 @@
+error: nested OptGroup is not supported
+  --> tests/ui/form/fail/optgroup_rejects_nested_group.rs:11:6
+   |
+11 |                     OptGroup("Inner") {
+   |                     ^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/radio_rejects_choice_group.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/radio_rejects_choice_group.rs
@@ -1,0 +1,17 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidRadioChoiceGroupForm,
+		action: "/invalid",
+		fields: {
+			choice: ChoiceField {
+				widget: RadioSelect,
+				choices_from: "choices",
+				choice_value: "id",
+				choice_label: "label",
+				choice_group: "group",
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/radio_rejects_choice_group.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/radio_rejects_choice_group.stderr
@@ -1,0 +1,5 @@
+error: choice_group is only supported on Select and SelectMultiple widgets
+  --> tests/ui/form/fail/radio_rejects_choice_group.rs:13:5
+   |
+13 |                 choice_group: "group",
+   |                 ^^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/radio_rejects_choice_group_disabled.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/radio_rejects_choice_group_disabled.rs
@@ -1,0 +1,17 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidRadioChoiceGroupDisabledForm,
+		action: "/invalid",
+		fields: {
+			choice: ChoiceField {
+				widget: RadioSelect,
+				choices_from: "choices",
+				choice_value: "id",
+				choice_label: "label",
+				choice_group_disabled: "disabled",
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/radio_rejects_choice_group_disabled.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/radio_rejects_choice_group_disabled.stderr
@@ -1,0 +1,5 @@
+error: choice_group_disabled is only supported on Select and SelectMultiple widgets
+  --> tests/ui/form/fail/radio_rejects_choice_group_disabled.rs:13:5
+   |
+13 |                 choice_group_disabled: "disabled",
+   |                 ^^^^^^^^^^^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/unknown_native_attr_rejected.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/unknown_native_attr_rejected.rs
@@ -1,0 +1,13 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: UnknownNativeAttrForm,
+		action: "/invalid",
+		fields: {
+			avatar: FileField {
+				captrue: "environment",
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/unknown_native_attr_rejected.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/unknown_native_attr_rejected.stderr
@@ -1,0 +1,5 @@
+error: unknown field property: 'captrue'. Use typed field properties for native form behavior (min, max, step, accept, capture, list, size), and use attrs only for aria_* or data_* custom attributes
+ --> tests/ui/form/fail/unknown_native_attr_rejected.rs:9:5
+  |
+9 |                 captrue: "environment",
+  |                 ^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/fail/week_input_rejects_ip_address_field.rs
+++ b/crates/reinhardt-pages/tests/ui/form/fail/week_input_rejects_ip_address_field.rs
@@ -1,0 +1,13 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: InvalidWeekIpAddressForm,
+		action: "/invalid",
+		fields: {
+			sprint_week: IpAddressField {
+				widget: WeekInput,
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/fail/week_input_rejects_ip_address_field.stderr
+++ b/crates/reinhardt-pages/tests/ui/form/fail/week_input_rejects_ip_address_field.stderr
@@ -1,0 +1,5 @@
+error: WeekInput is only supported on string-valued fields
+ --> tests/ui/form/fail/week_input_rejects_ip_address_field.rs:8:4
+  |
+8 |             sprint_week: IpAddressField {
+  |             ^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/form/pass/choice_choices_accessor_tuple.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/choice_choices_accessor_tuple.rs
@@ -1,0 +1,26 @@
+//! Dynamic choice accessors keep the public `(value, label)` tuple signal.
+
+use reinhardt_pages::form;
+
+fn main() {
+	let form = form! {
+		name: ChoiceAccessorForm,
+		action: "/api/choice-accessor",
+		fields: {
+			choice_id: ChoiceField<i64> {
+				choices_from: "choices",
+				choice_value: "id",
+				choice_label: "label",
+			}
+			tag_ids: MultipleChoiceField<i64> {
+				choices_from: "tags",
+				choice_value: "id",
+				choice_label: "label",
+			}
+		}
+	};
+
+	form.choice_id_choices()
+		.set(vec![(1_i64, "First".to_string())]);
+	form.tag_ids_choices().set(vec![(2_i64, "Second".to_string())]);
+}

--- a/crates/reinhardt-pages/tests/ui/form/pass/custom_widget_adapter.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/custom_widget_adapter.rs
@@ -11,6 +11,7 @@ fn date_range_picker(_props: DateRangeProps) -> Page {
 struct DateRangeProps {
 	value: String,
 	disabled: bool,
+	touched: bool,
 }
 
 struct DateRangeAdapter;
@@ -23,10 +24,11 @@ impl FormWidgetAdapter<String> for DateRangeAdapter {
 	}
 
 	fn props(ctx: CustomWidgetContext<String>) -> Self::ComponentProps {
-		DateRangeProps {
-			value: ctx.value,
-			disabled: ctx.disabled,
-		}
+			DateRangeProps {
+				value: ctx.value,
+				disabled: ctx.disabled,
+				touched: ctx.touched,
+			}
 	}
 
 	fn parse(raw: CustomWidgetRawValue) -> Result<String, FormWidgetError> {
@@ -47,6 +49,7 @@ fn main() {
 		action: "/custom",
 		fields: {
 			date_range: CharField {
+				disabled,
 				widget: CustomWidget(date_range_picker) {
 					experimental,
 					adapter: DateRangeAdapter,

--- a/crates/reinhardt-pages/tests/ui/form/pass/custom_widget_adapter.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/custom_widget_adapter.rs
@@ -1,0 +1,59 @@
+use reinhardt_pages::{
+	CustomWidgetContext, CustomWidgetRawValue, FieldError, FormWidgetAdapter, FormWidgetError,
+	FormWidgetValueKind, Page, form,
+};
+
+fn date_range_picker(_props: DateRangeProps) -> Page {
+	Page::Fragment(Vec::new())
+}
+
+#[derive(Clone)]
+struct DateRangeProps {
+	value: String,
+	disabled: bool,
+}
+
+struct DateRangeAdapter;
+
+impl FormWidgetAdapter<String> for DateRangeAdapter {
+	type ComponentProps = DateRangeProps;
+
+	fn value_kind() -> FormWidgetValueKind {
+		FormWidgetValueKind::Value
+	}
+
+	fn props(ctx: CustomWidgetContext<String>) -> Self::ComponentProps {
+		DateRangeProps {
+			value: ctx.value,
+			disabled: ctx.disabled,
+		}
+	}
+
+	fn parse(raw: CustomWidgetRawValue) -> Result<String, FormWidgetError> {
+		match raw {
+			CustomWidgetRawValue::String(value) => Ok(value),
+			_ => Err(FormWidgetError::new("expected string value")),
+		}
+	}
+
+	fn format(value: &String) -> CustomWidgetRawValue {
+		CustomWidgetRawValue::String(value.clone())
+	}
+}
+
+fn main() {
+	let _form = form! {
+		name: CustomWidgetForm,
+		action: "/custom",
+		fields: {
+			date_range: CharField {
+				widget: CustomWidget(date_range_picker) {
+					experimental,
+					adapter: DateRangeAdapter,
+				},
+			}
+		}
+	};
+
+	let _field_error = FieldError::new("example");
+}

--- a/crates/reinhardt-pages/tests/ui/form/pass/form_choice_options.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/form_choice_options.rs
@@ -1,0 +1,64 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: ChoiceOptionsForm,
+		action: "/choices",
+		choices_loader: load_choice_options,
+		fields: {
+			sprint_week: CharField {
+				widget: WeekInput,
+				list: sprint_weeks,
+			}
+			sprint_weeks: Datalist {
+				choices_from: "weeks",
+				choice_value: "value",
+				choice_label: "label",
+				choice_disabled: "archived",
+			}
+			status: ChoiceField<String> {
+				widget: Select,
+				choices: [OptGroup("Active") {
+					("open", "Open"),
+					("review", "In review"),
+				}, OptGroup("Closed") {
+					disabled,
+					("done", "Done") { disabled },
+				}, ],
+			}
+			labels: MultipleChoiceField<String> {
+				widget: SelectMultiple,
+				choices_from: "labels",
+				choice_value: "value",
+				choice_label: "label",
+				choice_group: "group",
+				choice_group_disabled: "group_disabled",
+				choice_disabled: "disabled",
+			}
+		}
+	};
+}
+
+#[allow(dead_code)]
+async fn load_choice_options() -> Result<ChoiceOptions, reinhardt_pages::ServerFnError> {
+	Ok(ChoiceOptions {
+		weeks: Vec::new(),
+		labels: Vec::new(),
+	})
+}
+
+#[allow(dead_code)]
+struct ChoiceOptions {
+	weeks: Vec<OptionItem>,
+	labels: Vec<OptionItem>,
+}
+
+#[allow(dead_code)]
+struct OptionItem {
+	value: String,
+	label: String,
+	archived: bool,
+	disabled: bool,
+	group: String,
+	group_disabled: bool,
+}

--- a/crates/reinhardt-pages/tests/ui/form/pass/form_control_entries.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/form_control_entries.rs
@@ -1,0 +1,49 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _form = form! {
+		name: ControlEntryForm,
+		action: "/import",
+		fields: {
+			file: FileField {
+				accept: "text/csv",
+			}
+			upload: SubmitButton {
+				label: "Upload",
+			}
+			reset: ResetButton {
+				label: "Reset",
+				class: "secondary",
+			}
+			preview: Button {
+				label: "Preview",
+				id: "preview-button",
+				disabled,
+			}
+			image_submit: ImageInput {
+				src: "/static/submit.png",
+				alt: "Submit",
+				width: 48,
+				height: 48,
+			}
+			import_progress: Progress {
+				value: 7,
+				max: 10,
+				label: "Import progress",
+			}
+			capacity: Meter {
+				value: 0.72,
+				min: 0.0,
+				max: 1.0,
+				low: 0.4,
+				high: 0.8,
+				optimum: 0.6,
+				label: "Capacity usage",
+			}
+			summary: Output {
+				label: "Import summary",
+				for: [file],
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/form/pass/form_widget_native_attrs.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/form_widget_native_attrs.rs
@@ -25,7 +25,6 @@ fn main() {
 			avatar: FileField {
 				accept: "image/png,image/jpeg",
 				capture: "environment",
-				multiple: false,
 			}
 		}
 	};

--- a/crates/reinhardt-pages/tests/ui/form/pass/form_widget_native_attrs.rs
+++ b/crates/reinhardt-pages/tests/ui/form/pass/form_widget_native_attrs.rs
@@ -1,0 +1,32 @@
+use reinhardt_pages::form;
+
+fn main() {
+	let _schedule_form = form! {
+		name: ScheduleForm,
+		action: "/schedule",
+		fields: {
+			billing_month: CharField {
+				widget: MonthInput,
+				required,
+				min: "2026-01",
+				max: "2026-12",
+				step: 1,
+			}
+			sprint_week: CharField {
+				widget: WeekInput,
+				min: "2026-W01",
+				max: "2026-W52",
+				step: 1,
+			}
+			search: CharField {
+				widget: SearchInput,
+				size: 32,
+			}
+			avatar: FileField {
+				accept: "image/png,image/jpeg",
+				capture: "environment",
+				multiple: false,
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/hooks/fail/missing_deps_use_effect.stderr
+++ b/crates/reinhardt-pages/tests/ui/hooks/fail/missing_deps_use_effect.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 9 |     let _ = use_effect(|| {});
   |                           ^^ expected `Option<_>`, found `()`
   |
-  = note:   expected enum `Option<_>`
+  = note:   expected enum `std::option::Option<_>`
           found unit type `()`
 
 error[E0061]: this function takes 2 arguments but 1 argument was supplied

--- a/crates/reinhardt-pages/tests/use_form_integration.rs
+++ b/crates/reinhardt-pages/tests/use_form_integration.rs
@@ -1,11 +1,69 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use reinhardt_pages::{
-	FieldError, FormEvent, ResetOnDeps, RevalidateOn, UseFormSubmitOutcome, form, use_form,
+	CustomWidgetContext, CustomWidgetRawValue, FieldError, FormEvent, FormWidgetAdapter,
+	FormWidgetError, FormWidgetValueKind, Page, ResetOnDeps, RevalidateOn, UseFormSubmitOutcome,
+	form, use_form,
 };
+
+thread_local! {
+	static LAST_CUSTOM_WIDGET_PROPS: RefCell<Option<DateRangeProps>> = const { RefCell::new(None) };
+}
+
+#[derive(Clone)]
+struct DateRangeProps {
+	value: String,
+	error: Option<FieldError>,
+	on_raw_change: Rc<dyn Fn(CustomWidgetRawValue) -> Result<(), FormWidgetError>>,
+}
+
+fn capturing_date_range_picker(props: DateRangeProps) -> Page {
+	LAST_CUSTOM_WIDGET_PROPS.with(|slot| {
+		*slot.borrow_mut() = Some(props);
+	});
+	Page::Fragment(Vec::new())
+}
+
+fn take_last_custom_widget_props() -> DateRangeProps {
+	LAST_CUSTOM_WIDGET_PROPS.with(|slot| {
+		slot.borrow_mut()
+			.take()
+			.expect("custom widget props should be captured")
+	})
+}
+
+struct DateRangeAdapter;
+
+impl FormWidgetAdapter<String> for DateRangeAdapter {
+	type ComponentProps = DateRangeProps;
+
+	fn value_kind() -> FormWidgetValueKind {
+		FormWidgetValueKind::Value
+	}
+
+	fn props(ctx: CustomWidgetContext<String>) -> Self::ComponentProps {
+		DateRangeProps {
+			value: ctx.value,
+			error: ctx.error,
+			on_raw_change: ctx.on_raw_change,
+		}
+	}
+
+	fn parse(raw: CustomWidgetRawValue) -> Result<String, FormWidgetError> {
+		match raw {
+			CustomWidgetRawValue::String(value) if value.contains("..") => Ok(value),
+			CustomWidgetRawValue::String(_) => Err(FormWidgetError::new("invalid date range")),
+			_ => Err(FormWidgetError::new("expected string value")),
+		}
+	}
+
+	fn format(value: &String) -> CustomWidgetRawValue {
+		CustomWidgetRawValue::String(value.clone())
+	}
+}
 
 #[test]
 fn use_form_builds_runtime_from_generated_form_contract() {
@@ -98,6 +156,227 @@ fn use_form_tracks_field_updates_errors_and_resets() {
 	runtime.reset();
 	assert_eq!(runtime.get_values().bio, "COBOL pioneer".to_string());
 	assert!(!runtime.form_state().is_dirty.get());
+}
+
+#[test]
+fn use_form_tracks_month_and_week_as_strings() {
+	let schedule = form! {
+		name: ScheduleForm,
+		action: "/schedule",
+		fields: {
+			billing_month: CharField {
+				widget: MonthInput,
+				initial: "2026-06".to_string(),
+			}
+			sprint_week: CharField {
+				widget: WeekInput,
+				initial: "2026-W24".to_string(),
+			}
+		}
+	};
+
+	let runtime = use_form(&schedule).build();
+	let billing_month = runtime.watch_field::<String>(schedule.billing_month_field());
+	let sprint_week = runtime.watch_field::<String>(schedule.sprint_week_field());
+
+	assert_eq!(runtime.get_values().billing_month, "2026-06".to_string());
+	assert_eq!(runtime.get_values().sprint_week, "2026-W24".to_string());
+	assert_eq!(billing_month.get(), "2026-06".to_string());
+	assert_eq!(sprint_week.get(), "2026-W24".to_string());
+	assert!(!runtime.form_state().is_dirty.get());
+	assert!(
+		!runtime
+			.get_field_state(schedule.billing_month_field())
+			.is_dirty
+	);
+	assert!(
+		!runtime
+			.get_field_state(schedule.sprint_week_field())
+			.is_dirty
+	);
+
+	runtime.set_value(schedule.billing_month_field(), "2026-07".to_string());
+
+	assert_eq!(runtime.get_values().billing_month, "2026-07".to_string());
+	assert!(runtime.form_state().is_dirty.get());
+	assert!(
+		runtime
+			.get_field_state(schedule.billing_month_field())
+			.is_dirty
+	);
+
+	runtime.reset();
+
+	assert_eq!(runtime.get_values().billing_month, "2026-06".to_string());
+	assert_eq!(runtime.get_values().sprint_week, "2026-W24".to_string());
+	assert!(!runtime.form_state().is_dirty.get());
+	assert!(
+		!runtime
+			.get_field_state(schedule.billing_month_field())
+			.is_dirty
+	);
+	assert!(
+		!runtime
+			.get_field_state(schedule.sprint_week_field())
+			.is_dirty
+	);
+}
+
+#[test]
+fn use_form_can_sync_after_native_reset() {
+	let profile = form! {
+		name: NativeResetForm,
+		action: "/profile",
+		fields: {
+			name: CharField {
+				initial: "before".to_string(),
+			}
+			reset: ResetButton {
+				label: "Reset",
+			}
+		}
+	};
+
+	let runtime = use_form(&profile).build();
+
+	runtime.set_value(profile.name_field(), "after".to_string());
+	runtime.set_error(profile.name_field(), FieldError::new("name is invalid"));
+
+	assert_eq!(runtime.get_values().name, "after".to_string());
+	assert!(runtime.form_state().is_dirty.get());
+	assert!(runtime.form_state().is_touched.get());
+	assert!(runtime.get_field_state(profile.name_field()).is_dirty);
+	assert!(runtime.get_field_state(profile.name_field()).is_touched);
+	assert_eq!(
+		runtime
+			.get_field_state(profile.name_field())
+			.error
+			.as_ref()
+			.map(FieldError::message),
+		Some("name is invalid")
+	);
+
+	profile.name().set("before".to_string());
+	runtime.sync_after_native_reset();
+
+	assert_eq!(runtime.get_values().name, "before".to_string());
+	assert!(!runtime.form_state().is_dirty.get());
+	assert!(!runtime.form_state().is_touched.get());
+	assert!(!runtime.get_field_state(profile.name_field()).is_dirty);
+	assert!(!runtime.get_field_state(profile.name_field()).is_touched);
+	assert!(
+		runtime
+			.get_field_state(profile.name_field())
+			.error
+			.is_none()
+	);
+
+	profile.name().set("native value".to_string());
+	runtime.set_value(profile.name_field(), "runtime touched".to_string());
+	profile.name().set("native value".to_string());
+	runtime.set_error(profile.name_field(), FieldError::new("native error"));
+
+	assert_eq!(runtime.get_values().name, "native value".to_string());
+	assert!(runtime.form_state().is_dirty.get());
+	assert!(runtime.form_state().is_touched.get());
+	assert!(runtime.get_field_state(profile.name_field()).is_dirty);
+	assert!(runtime.get_field_state(profile.name_field()).is_touched);
+	assert_eq!(
+		runtime
+			.get_field_state(profile.name_field())
+			.error
+			.as_ref()
+			.map(FieldError::message),
+		Some("native error")
+	);
+
+	runtime.sync_after_native_reset();
+	let name_state = runtime.get_field_state(profile.name_field());
+
+	assert_eq!(runtime.get_values().name, "native value".to_string());
+	assert!(runtime.form_state().is_dirty.get());
+	assert!(name_state.is_dirty);
+	assert_eq!(runtime.form_state().is_dirty.get(), name_state.is_dirty);
+	assert!(!runtime.form_state().is_touched.get());
+	assert!(!name_state.is_touched);
+	assert!(name_state.error.is_none());
+	assert!(runtime.form_state().error.get().is_none());
+}
+
+#[test]
+fn custom_widget_bridge_parse_error_sets_runtime_field_error() {
+	let booking = form! {
+		name: CustomWidgetRuntimeForm,
+		action: "/booking",
+		fields: {
+			date_range: CharField {
+				initial: "2026-06-01..2026-06-02".to_string(),
+				widget: CustomWidget(capturing_date_range_picker) {
+					experimental,
+					adapter: DateRangeAdapter,
+				},
+			}
+		}
+	};
+	let runtime = use_form(&booking).build();
+	let _page = booking.clone().into_page();
+	let props = take_last_custom_widget_props();
+
+	assert_eq!(props.value, "2026-06-01..2026-06-02");
+	assert!(props.error.is_none());
+
+	let invalid_result = (props.on_raw_change)(CustomWidgetRawValue::String("invalid".to_string()));
+
+	assert!(invalid_result.is_err());
+	assert_eq!(
+		invalid_result.err().as_ref().map(FormWidgetError::message),
+		Some("invalid date range")
+	);
+	assert_eq!(
+		runtime
+			.get_field_state(booking.date_range_field())
+			.error
+			.as_ref()
+			.map(FieldError::message),
+		Some("invalid date range")
+	);
+	assert_eq!(
+		runtime.get_values().date_range,
+		"2026-06-01..2026-06-02".to_string()
+	);
+	assert!(runtime.trigger().is_err());
+	assert_eq!(
+		runtime.handle_submit(),
+		UseFormSubmitOutcome::ValidationFailed
+	);
+
+	let _page = booking.clone().into_page();
+	let props = take_last_custom_widget_props();
+	assert_eq!(
+		props.error.as_ref().map(FieldError::message),
+		Some("invalid date range")
+	);
+
+	let valid_result = (props.on_raw_change)(CustomWidgetRawValue::String(
+		"2026-06-03..2026-06-04".to_string(),
+	));
+
+	assert!(valid_result.is_ok());
+	assert_eq!(
+		runtime.get_values().date_range,
+		"2026-06-03..2026-06-04".to_string()
+	);
+	assert!(
+		runtime
+			.get_field_state(booking.date_range_field())
+			.error
+			.is_none()
+	);
+
+	let _page = booking.clone().into_page();
+	let props = take_last_custom_widget_props();
+	assert_eq!(props.value, "2026-06-03..2026-06-04");
+	assert!(props.error.is_none());
 }
 
 #[test]

--- a/crates/reinhardt-pages/tests/use_form_integration.rs
+++ b/crates/reinhardt-pages/tests/use_form_integration.rs
@@ -16,6 +16,8 @@ thread_local! {
 #[derive(Clone)]
 struct DateRangeProps {
 	value: String,
+	disabled: bool,
+	touched: bool,
 	error: Option<FieldError>,
 	on_raw_change: Rc<dyn Fn(CustomWidgetRawValue) -> Result<(), FormWidgetError>>,
 }
@@ -47,6 +49,8 @@ impl FormWidgetAdapter<String> for DateRangeAdapter {
 	fn props(ctx: CustomWidgetContext<String>) -> Self::ComponentProps {
 		DateRangeProps {
 			value: ctx.value,
+			disabled: ctx.disabled,
+			touched: ctx.touched,
 			error: ctx.error,
 			on_raw_change: ctx.on_raw_change,
 		}
@@ -311,6 +315,7 @@ fn custom_widget_bridge_parse_error_sets_runtime_field_error() {
 		fields: {
 			date_range: CharField {
 				initial: "2026-06-01..2026-06-02".to_string(),
+				disabled,
 				widget: CustomWidget(capturing_date_range_picker) {
 					experimental,
 					adapter: DateRangeAdapter,
@@ -323,6 +328,8 @@ fn custom_widget_bridge_parse_error_sets_runtime_field_error() {
 	let props = take_last_custom_widget_props();
 
 	assert_eq!(props.value, "2026-06-01..2026-06-02");
+	assert!(props.disabled);
+	assert!(!props.touched);
 	assert!(props.error.is_none());
 
 	let invalid_result = (props.on_raw_change)(CustomWidgetRawValue::String("invalid".to_string()));
@@ -352,6 +359,8 @@ fn custom_widget_bridge_parse_error_sets_runtime_field_error() {
 
 	let _page = booking.clone().into_page();
 	let props = take_last_custom_widget_props();
+	assert!(props.disabled);
+	assert!(props.touched);
 	assert_eq!(
 		props.error.as_ref().map(FieldError::message),
 		Some("invalid date range")
@@ -376,6 +385,8 @@ fn custom_widget_bridge_parse_error_sets_runtime_field_error() {
 	let _page = booking.clone().into_page();
 	let props = take_last_custom_widget_props();
 	assert_eq!(props.value, "2026-06-03..2026-06-04");
+	assert!(props.disabled);
+	assert!(props.touched);
 	assert!(props.error.is_none());
 }
 

--- a/instructions/MACRO_USAGE.md
+++ b/instructions/MACRO_USAGE.md
@@ -260,6 +260,10 @@ The `form!` DSL exposes the following native HTML coverage as stable API:
 field. `OptGroup` groups choices inside choice controls and does not introduce
 a separate value slot.
 
+`MonthInput` and `WeekInput` are accepted only for raw string fields:
+`CharField`, `TextField`, `EmailField`, `UrlField`, `SlugField`, and
+`PasswordField`.
+
 ### MU-6 (MUST): Validate Typed Native Attributes Against Compatible Controls
 
 Typed native attributes are valid only on controls that support the corresponding
@@ -270,8 +274,12 @@ HTML behavior:
 | `min` / `max` / `step` | number, range, date, time, datetime-local, month, week |
 | `size` | text-like inputs |
 | `accept` / `capture` | file-like inputs |
-| `multiple` | file-like inputs and multi-select |
 | `list` | datalist-compatible text-like inputs |
+
+`multiple` is not accepted as a typed field property yet. Use the
+`SelectMultiple` widget for multi-select fields. File-like multi-select remains
+deferred until the generated value contract can represent `Vec<File>` instead
+of a single `Option<File>`.
 
 ### MU-7 (MUST): Treat `CustomWidget` as Experimental
 

--- a/instructions/MACRO_USAGE.md
+++ b/instructions/MACRO_USAGE.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This file defines the policy for using Reinhardt's procedural macros (notably `#[model(...)]`) consistently across the codebase.
+This file defines the policy for using Reinhardt's macros (notably `#[model(...)]` and `form!`) consistently across the codebase.
 
 ---
 
@@ -237,9 +237,72 @@ Validation attributes are derived from `#[field(...)]` config and emitted as `#[
 
 ---
 
+## `form!` Macro
+
+### MU-5 (MUST): Keep Stable Native Widget Coverage Explicit
+
+The `form!` DSL exposes the following native HTML coverage as stable API:
+
+| DSL item | HTML output | Value state |
+|---|---|---|
+| `MonthInput` | `<input type="month">` | string field |
+| `WeekInput` | `<input type="week">` | string field |
+| `ResetButton` | `<button type="reset">` | none |
+| `Button` | `<button type="button">` | none |
+| `ImageInput` | `<input type="image">` | none |
+| `Datalist` | `<datalist>` | option source only |
+| `OptGroup` | `<optgroup>` | choice grouping only |
+| `Output` | `<output>` | none |
+| `Meter` | `<meter>` | none |
+| `Progress` | `<progress>` | none |
+
+`Datalist` is an option source for compatible inputs, not a value-holding
+field. `OptGroup` groups choices inside choice controls and does not introduce
+a separate value slot.
+
+### MU-6 (MUST): Validate Typed Native Attributes Against Compatible Controls
+
+Typed native attributes are valid only on controls that support the corresponding
+HTML behavior:
+
+| Attribute | Compatible controls |
+|---|---|
+| `min` / `max` / `step` | number, range, date, time, datetime-local, month, week |
+| `size` | text-like inputs |
+| `accept` / `capture` | file-like inputs |
+| `multiple` | file-like inputs and multi-select |
+| `list` | datalist-compatible text-like inputs |
+
+### MU-7 (MUST): Treat `CustomWidget` as Experimental
+
+`CustomWidget` is an experimental extension point. Call sites must opt in with
+the `experimental` marker and provide an adapter:
+
+```rust,ignore
+date_range: CharField {
+    widget: CustomWidget(crate::widgets::DateRangePicker) {
+        experimental,
+        adapter: crate::widgets::DateRangeAdapter,
+    },
+}
+```
+
+The adapter API may change in a minor release with a documented migration path.
+
+### MU-8 (MUST): Render `FieldGroup` as a Semantic Fieldset
+
+`FieldGroup` renders as semantic `<fieldset>` output. When `label` is present,
+the label is rendered as a `<legend>` inside the fieldset.
+
+---
+
 ### ✅ MUST DO
 - Initialize `#[model(...)]` structs via the macro-generated `build()` builder or zero-argument `new()` alias
 - Add unrelated derives (e.g., `Debug`, `Clone`) via a separate `#[derive(...)]`
+- Keep stable `form!` widget coverage aligned with the documented native HTML output and value state
+- Validate typed native form attributes against the compatible control families
+- Treat `CustomWidget` as experimental and require the explicit adapter syntax
+- Render `FieldGroup` as semantic `<fieldset>` output with `label` mapped to `<legend>`
 
 ### ✅ SHOULD DO
 - Use `#[model(...)]` alone (do not also write `#[derive(Model)]`) — the attribute applies the derive for you

--- a/tests/integration/tests/di/ui/fail/missing_injectable_type_trait.stderr
+++ b/tests/integration/tests/di/ui/fail/missing_injectable_type_trait.stderr
@@ -1,11 +1,11 @@
-error[E0599]: the method `__resolve_inject_parameter` exists for struct `__InjectResolver<Broken<AppConfig>>`, but its trait bounds were not satisfied
+error[E0599]: the method `__resolve_inject_parameter` exists for struct `reinhardt_di::__InjectResolver<Broken<AppConfig>>`, but its trait bounds were not satisfied
   --> tests/di/ui/fail/missing_injectable_type_trait.rs:21:1
    |
 17 | struct Broken<T>(reinhardt_di::Depends<T>)
    | ---------------- doesn't satisfy `Broken<AppConfig>: Clone`, `Broken<AppConfig>: InjectableType` or `Broken<AppConfig>: Injectable`
 ...
 21 | #[get("/broken-wrapper", name = "broken-wrapper")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `__InjectResolver<Broken<AppConfig>>` due to unsatisfied trait bounds
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `reinhardt_di::__InjectResolver<Broken<AppConfig>>` due to unsatisfied trait bounds
    |
   ::: $WORKSPACE/crates/reinhardt-di/src/injectable_type.rs
    |
@@ -14,11 +14,11 @@ error[E0599]: the method `__resolve_inject_parameter` exists for struct `__Injec
    |
    = note: the following trait bounds were not satisfied:
            `Broken<AppConfig>: InjectableType`
-           which is required by `__InjectResolver<Broken<AppConfig>>: __InjectWrapperResolver<Broken<AppConfig>>`
+           which is required by `reinhardt_di::__InjectResolver<Broken<AppConfig>>: reinhardt_di::__InjectWrapperResolver<Broken<AppConfig>>`
            `Broken<AppConfig>: Injectable`
-           which is required by `&__InjectResolver<Broken<AppConfig>>: __InjectFallbackResolver<Broken<AppConfig>>`
+           which is required by `&reinhardt_di::__InjectResolver<Broken<AppConfig>>: reinhardt_di::__InjectFallbackResolver<Broken<AppConfig>>`
            `Broken<AppConfig>: Clone`
-           which is required by `&__InjectResolver<Broken<AppConfig>>: __InjectFallbackResolver<Broken<AppConfig>>`
+           which is required by `&reinhardt_di::__InjectResolver<Broken<AppConfig>>: reinhardt_di::__InjectFallbackResolver<Broken<AppConfig>>`
 note: the traits `Injectable` and `InjectableType` must be implemented
   --> $WORKSPACE/crates/reinhardt-di/src/injectable_type.rs
    |
@@ -35,11 +35,3 @@ help: consider annotating `Broken<AppConfig>` with `#[derive(Clone)]`
 17 + #[derive(Clone)]
 18 | struct Broken<T>(reinhardt_di::Depends<T>)
    |
-
-error[E0282]: type annotations needed
-  --> tests/di/ui/fail/missing_injectable_type_trait.rs:21:1
-   |
-21 | #[get("/broken-wrapper", name = "broken-wrapper")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
-   |
-   = note: this error originates in the attribute macro `get` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds stable `form!` coverage for native month/week inputs, typed native attributes, non-value form controls, datalist entries, and grouped choice options.
- Adds an experimental `CustomWidget` adapter boundary with generated props, parse-error propagation, and `use_form` integration.
- Documents the expanded widget matrix, typed native attribute compatibility, `FieldGroup` fieldset semantics, and experimental custom widget syntax.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`form!` lacked several native HTML form controls and did not have a typed boundary for custom design-system widgets to participate in generated form state.

Refs #5258

Related to: #5256

## How Was This Tested?

- `cargo test -p reinhardt-pages --test ui test_form_macro_pass -- --nocapture`
- `cargo test -p reinhardt-pages --test ui test_form_macro_fail -- --nocapture`
- `cargo test -p reinhardt-pages --test use_form_integration -- --nocapture`
- `cargo test -p reinhardt-pages-macros form::validator:: -- --nocapture`
- `cargo test -p reinhardt-pages-macros form::codegen:: -- --nocapture`
- `cargo check -p reinhardt-manouche`
- `cargo check -p reinhardt-pages-macros`
- `cargo check -p reinhardt-pages`
- `cargo test --doc -p reinhardt-pages`
- `cargo doc -p reinhardt-pages --no-deps`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Performance Impact

No runtime performance benchmark was run. The generated runtime work is limited to the new custom widget adapter path and native reset synchronization hook.

## Screenshots

Not applicable. This is a macro/runtime/API change covered by compile-time and runtime tests.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-check`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #5258
- Related to #5256

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The PR is opened as draft while CI runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for form controls: reset buttons, buttons, image inputs, output, meter, progress, and datalist fields.
  * Added native HTML attributes: `min`, `max`, `step`, `accept`, `capture`, `list`, and `size` support.
  * Added `MonthInput` and `WeekInput` widget types.
  * Added experimental `CustomWidget` support for advanced custom form input implementations.

* **Documentation**
  * Expanded form DSL documentation with stable native widget coverage and typed attribute compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->