### PR TITLE
refactor!: remove 0.3 deprecated public APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING**: Removed the 0.2 compatibility extractor `AuthUser<U>`.
+  Use `CurrentUser<U>` for full authenticated-user extraction.
+- **BREAKING**: Removed the deprecated Pages resource constructors
+  `create_resource` and `create_resource_with_deps`. Use
+  `use_resource(fetcher, deps)`.
+- **BREAKING**: Removed the deprecated Pages hooks `use_effect_event` and
+  `use_effect_event_with`. Use `use_callback` / `use_callback_with` or read
+  latest signal values with `.get_untracked()` inside effects.
+
+### Migration Guide
+
+- Follow [`instructions/MIGRATION_0.3.md`](instructions/MIGRATION_0.3.md) for
+  the 0.2 to 0.3 compatibility-removal checklist.
+
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.1.3...reinhardt-web@v0.2.0) - 2026-06-11
 
 Stable 0.2.0 is the first release of the Reinhardt 0.2 line. It

--- a/crates/reinhardt-auth/CHANGELOG.md
+++ b/crates/reinhardt-auth/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING**: Removed the 0.2 compatibility extractor `AuthUser<U>`.
+  Use `CurrentUser<U>` for full authenticated-user extraction.
+
 ## [0.2.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-auth@v0.1.3...reinhardt-auth@v0.2.0) - 2026-06-11
 
 Stable release of `reinhardt-auth` for the Reinhardt 0.2.0 line. This

--- a/crates/reinhardt-auth/src/auth_user.rs
+++ b/crates/reinhardt-auth/src/auth_user.rs
@@ -42,18 +42,6 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct CurrentUser<U: BaseUser>(pub U);
 
-/// Deprecated compatibility name for [`CurrentUser`].
-///
-/// Use [`CurrentUser`] in new code. This wrapper has the same tuple-struct
-/// shape and injection behavior so existing `AuthUser(user): AuthUser<U>`
-/// patterns continue to compile until the 0.3 removal.
-#[deprecated(
-	since = "0.2.0",
-	note = "use CurrentUser; AuthUser will be removed in 0.3"
-)]
-#[derive(Debug, Clone)]
-pub struct AuthUser<U: BaseUser>(pub U);
-
 #[cfg(feature = "params")]
 async fn resolve_current_user<U>(ctx: &InjectionContext) -> DiResult<U>
 where
@@ -156,42 +144,9 @@ where
 	}
 }
 
-#[cfg(feature = "params")]
-#[allow(deprecated)]
-#[async_trait]
-impl<U> Injectable for AuthUser<U>
-where
-	U: BaseUser + Model + Clone + Send + Sync + 'static,
-	<U as BaseUser>::PrimaryKey: std::str::FromStr + ToString + Send + Sync,
-	<<U as BaseUser>::PrimaryKey as std::str::FromStr>::Err: std::fmt::Debug,
-	<U as Model>::PrimaryKey: From<<U as BaseUser>::PrimaryKey>,
-{
-	async fn inject(ctx: &InjectionContext) -> DiResult<Self> {
-		resolve_current_user(ctx).await.map(AuthUser)
-	}
-}
-
-#[cfg(not(feature = "params"))]
-#[allow(deprecated)]
-#[async_trait]
-impl<U> Injectable for AuthUser<U>
-where
-	U: BaseUser + Model + Clone + Send + Sync + 'static,
-	<U as BaseUser>::PrimaryKey: std::str::FromStr + ToString + Send + Sync,
-	<<U as BaseUser>::PrimaryKey as std::str::FromStr>::Err: std::fmt::Debug,
-	<U as Model>::PrimaryKey: From<<U as BaseUser>::PrimaryKey>,
-{
-	async fn inject(_ctx: &InjectionContext) -> DiResult<Self> {
-		Err(DiError::NotFound(
-			"AuthUser requires the 'params' feature to be enabled".to_string(),
-		))
-	}
-}
-
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
-	use super::{AuthUser, CurrentUser};
+	use super::CurrentUser;
 	use crate::{BaseUser, PasswordHasher};
 	use chrono::{DateTime, Utc};
 	use serde::{Deserialize, Serialize};
@@ -268,13 +223,5 @@ mod tests {
 		let CurrentUser(user): CurrentUser<TestUser> = CurrentUser(test_user("alice"));
 
 		assert_eq!(user.get_username(), "alice");
-	}
-
-	#[allow(deprecated)]
-	#[test]
-	fn deprecated_auth_user_keeps_tuple_struct_destructuring() {
-		let AuthUser(user): AuthUser<TestUser> = AuthUser(test_user("bob"));
-
-		assert_eq!(user.get_username(), "bob");
 	}
 }

--- a/crates/reinhardt-auth/src/lib.rs
+++ b/crates/reinhardt-auth/src/lib.rs
@@ -77,8 +77,7 @@ pub use reinhardt_auth_macros::guard;
 
 // Authenticated user extractors
 pub mod auth_user;
-#[allow(deprecated)]
-pub use auth_user::{AuthUser, CurrentUser};
+pub use auth_user::CurrentUser;
 
 // Startup validation for auth extractors
 pub mod auth_extractors;

--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -227,7 +227,7 @@ enum AuthProtectionKind {
 /// The first matching rule wins (rules are checked in priority order):
 ///
 /// - Contains `"Guard"` → `Protected`; also captures `guard_description`
-/// - Contains `"CurrentUser"` or `"AuthUser"` → `Protected`
+/// - Contains `"CurrentUser"` → `Protected`
 /// - Contains both `"Option"` and `"AuthInfo"` → `Optional`
 /// - Contains `"AuthInfo"` (alone) → `Protected`
 /// - Contains `"Public"` → `Public`
@@ -251,7 +251,7 @@ fn detect_auth_from_type_strings(type_strings: &[String]) -> AuthDetection {
 			continue;
 		}
 
-		if ty_str.contains("CurrentUser") || ty_str.contains("AuthUser") {
+		if ty_str.contains("CurrentUser") {
 			found_protected = true;
 			continue;
 		}
@@ -1321,17 +1321,6 @@ mod url_resolver_tests {
 	#[test]
 	fn detect_auth_marks_current_user_as_protected() {
 		let detection = detect_auth_from_type_strings(&["CurrentUser < User >".to_string()]);
-
-		assert!(matches!(
-			detection.protection,
-			AuthProtectionKind::Protected
-		));
-		assert!(detection.guard_description.is_none());
-	}
-
-	#[test]
-	fn detect_auth_keeps_auth_user_compatibility_as_protected() {
-		let detection = detect_auth_from_type_strings(&["AuthUser < User >".to_string()]);
 
 		assert!(matches!(
 			detection.protection,

--- a/crates/reinhardt-core/src/endpoint/auth_protection.rs
+++ b/crates/reinhardt-core/src/endpoint/auth_protection.rs
@@ -16,9 +16,9 @@ use super::EndpointMetadata;
 /// gap detectable at startup via [`validate_endpoint_security`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthProtection {
-	/// Endpoint requires authentication (e.g., handler accepts `AuthUser`).
+	/// Endpoint requires authentication (e.g., handler accepts `CurrentUser`).
 	Protected,
-	/// Authentication is optional (e.g., handler accepts `Option<AuthUser>`).
+	/// Authentication is optional (e.g., handler accepts `Option<AuthInfo>`).
 	Optional,
 	/// Endpoint is explicitly marked public (no auth required by design).
 	Public,

--- a/crates/reinhardt-core/src/reactive/effect.rs
+++ b/crates/reinhardt-core/src/reactive/effect.rs
@@ -912,8 +912,8 @@ mod tests {
 		// `use_resource` stores its `new_with_deps` Effect inside an `Rc<Effect>`
 		// (`Resource::effect_guard`) so dependency-change refetch keeps firing for
 		// the Resource's lifetime. An Effect disposes on drop, so a handle that is
-		// created and immediately dropped — the original `create_resource_with_deps`
-		// bug — would stop tracking right after its first run.
+		// created and immediately dropped would stop tracking right after its
+		// first run.
 		let s = Signal::new(0_i32);
 		let runs = Rc::new(RefCell::new(0_i32));
 		let runs_for_effect = runs.clone();

--- a/crates/reinhardt-di/src/lib.rs
+++ b/crates/reinhardt-di/src/lib.rs
@@ -251,7 +251,7 @@
 //! specific DI context configuration. Understanding these requirements is essential
 //! for proper authentication integration.
 //!
-//! ### `CurrentUser<U>` (recommended)
+//! ### `CurrentUser<U>`
 //!
 //! Loads the full user model from the database. Requires:
 //!
@@ -280,12 +280,6 @@
 //!
 //! - **`AuthState`** present in request extensions (set by authentication middleware)
 //! - No `DatabaseConnection` needed
-//!
-//! ### `AuthUser<U>` (deprecated)
-//!
-//! Deprecated in favor of `CurrentUser<U>` and scheduled for removal in 0.3.
-//! It retains the same fail-fast behavior as `CurrentUser<U>` for 0.2
-//! compatibility.
 //!
 //! ### Startup Validation
 //!

--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING**: Removed the deprecated resource constructors
+  `create_resource` and `create_resource_with_deps`. Use
+  `use_resource(fetcher, deps)`.
+- **BREAKING**: Removed the deprecated hooks `use_effect_event` and
+  `use_effect_event_with`. Use `use_callback` / `use_callback_with` or read
+  latest signal values with `.get_untracked()` inside effects.
+
 ### Added
 
 - Added route-backed component macro support via `#[component("/path", "name")]`,

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -334,7 +334,7 @@ The prelude includes:
 ### Hooks
 - `use_state`, `use_effect`, `use_memo`, `use_callback`, `use_context`
 - `use_ref`, `use_reducer`, `use_transition`, `use_deferred_value`
-- `use_id`, `use_layout_effect`, `use_effect_event`, `use_debug_value`
+- `use_id`, `use_layout_effect`, `use_debug_value`
 - `use_optimistic`, `use_action`, `Action::with_optimistic`, `use_shared_state`, `use_sync_external_store`
 - `use_resource` (async data fetching; `use_resource(fetcher, deps)` with `()` fetches once on WASM, while non-WASM targets drop the `fetcher` future, ignore `deps`, and stay `Loading` until hydration/client execution)
 
@@ -384,7 +384,6 @@ The prelude includes:
 
 ### WASM-specific
 - `spawn_local` (re-exported from wasm_bindgen_futures; **deprecated** — use `spawn_task`)
-- `create_resource`, `create_resource_with_deps` (**deprecated** — use the cross-target `use_resource`)
 
 ## Example
 

--- a/crates/reinhardt-pages/src/integ/static_context.rs
+++ b/crates/reinhardt-pages/src/integ/static_context.rs
@@ -118,6 +118,8 @@ mod tests {
 	#[test]
 	#[serial(static_context)]
 	fn test_resolve_with_manifest() {
+		reset_static_context();
+
 		let mut manifest = HashMap::new();
 		manifest.insert(
 			"images/logo.png".to_string(),
@@ -128,7 +130,7 @@ mod tests {
 			"css/style.def456.css".to_string(),
 		);
 
-		let _ = init_static_context(manifest);
+		init_static_context(manifest).expect("static context should initialize");
 
 		assert_eq!(
 			resolve_static_url("images/logo.png").unwrap(),
@@ -143,8 +145,8 @@ mod tests {
 	#[test]
 	#[serial(static_context)]
 	fn test_resolve_fallback() {
-		// Initialize context if not already initialized (OnceLock can only be set once)
-		let _ = STATIC_MANIFEST.set(HashMap::new());
+		reset_static_context();
+		init_static_context(HashMap::new()).expect("static context should initialize");
 
 		assert_eq!(
 			resolve_static_url("unknown.png").unwrap(),

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -379,12 +379,6 @@ pub use form_state::{
 pub use hydration::{HydrationContext, HydrationError, hydrate};
 pub use portal::{Portal, PortalError, PortalHandle, PortalTarget, mount_portal};
 pub use reactive::{Effect, Memo, Resource, ResourceState, Signal, use_resource};
-#[cfg(wasm)]
-#[allow(
-	deprecated,
-	reason = "re-export kept until removal in v0.3.0; use use_resource instead"
-)]
-pub use reactive::{create_resource, create_resource_with_deps};
 // Re-export Context system
 pub use reactive::{
 	Context, ContextGuard, create_context, get_context, provide_context, remove_context,
@@ -392,12 +386,11 @@ pub use reactive::{
 // Re-export Hooks API
 pub use app::{ClientLauncher, LaunchCtx, PathCtx, PathParams};
 pub use reactive::{Action, ActionPhase, use_action};
-#[allow(deprecated)] // Intentional: re-exporting deprecated items for backward compatibility
 pub use reactive::{
 	Dispatch, OptimisticState, Ref, SetState, SharedSetState, SharedSignal, TransitionState,
-	use_callback, use_context, use_debug_value, use_deferred_value, use_effect, use_effect_event,
-	use_id, use_layout_effect, use_memo, use_optimistic, use_reducer, use_ref, use_shared_state,
-	use_state, use_sync_external_store, use_transition,
+	use_callback, use_context, use_debug_value, use_deferred_value, use_effect, use_id,
+	use_layout_effect, use_memo, use_optimistic, use_reducer, use_ref, use_shared_state, use_state,
+	use_sync_external_store, use_transition,
 };
 #[cfg(native)]
 pub use reinhardt_forms::{

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -34,7 +34,7 @@
 //! ## Hooks
 //! - [`use_state`], [`use_effect`], [`use_memo`], [`use_callback`], [`use_context`]
 //! - [`use_ref`], [`use_reducer`], [`use_transition`], [`use_deferred_value`]
-//! - [`use_id`], [`use_layout_effect`], [`use_effect_event`], [`use_debug_value`]
+//! - [`use_id`], [`use_layout_effect`], [`use_debug_value`]
 //! - [`use_optimistic`], [`use_shared_state`]
 //! - [`use_action`], [`use_sync_external_store`]
 //!
@@ -84,26 +84,15 @@ pub use crate::reactive::{
 
 // Hooks API
 pub use crate::reactive::{Action, ActionPhase, use_action};
-#[allow(
-	deprecated,
-	reason = "re-export kept until removal in v0.3.0 (Refs #4195)"
-)]
 pub use crate::reactive::{
 	Dispatch, OptimisticState, Ref, SetState, SharedSetState, SharedSignal, TransitionState,
-	use_callback, use_context, use_debug_value, use_deferred_value, use_effect, use_effect_event,
-	use_id, use_layout_effect, use_memo, use_optimistic, use_reducer, use_ref, use_shared_state,
-	use_state, use_sync_external_store, use_transition,
+	use_callback, use_context, use_debug_value, use_deferred_value, use_effect, use_id,
+	use_layout_effect, use_memo, use_optimistic, use_reducer, use_ref, use_shared_state, use_state,
+	use_sync_external_store, use_transition,
 };
 
 // Unified resource hook (available on all targets)
 pub use crate::reactive::use_resource;
-// Deprecated resource constructors, kept until removal in v0.3.0
-#[cfg(wasm)]
-#[allow(
-	deprecated,
-	reason = "re-export kept until removal in v0.3.0; use use_resource instead"
-)]
-pub use crate::reactive::{create_resource, create_resource_with_deps};
 
 // ============================================================================
 // Component System

--- a/crates/reinhardt-pages/src/reactive.rs
+++ b/crates/reinhardt-pages/src/reactive.rs
@@ -108,18 +108,11 @@ pub use trackable::Trackable;
 
 // Re-export resource types and the unified hook (available on all targets)
 pub use resource::{Resource, ResourceState, use_resource};
-#[cfg(wasm)]
-#[allow(
-	deprecated,
-	reason = "re-export kept until removal in v0.3.0; use use_resource instead"
-)]
-pub use resource::{create_resource, create_resource_with_deps};
 
 // Re-export hooks
-#[allow(deprecated)] // Intentional: re-exporting deprecated items for backward compatibility
 pub use hooks::{
 	Action, ActionPhase, Dispatch, OptimisticState, Ref, SetState, SharedSetState, SharedSignal,
 	TransitionState, use_action, use_callback, use_context, use_debug_value, use_deferred_value,
-	use_effect, use_effect_event, use_id, use_layout_effect, use_memo, use_optimistic, use_reducer,
-	use_ref, use_shared_state, use_state, use_sync_external_store, use_transition,
+	use_effect, use_id, use_layout_effect, use_memo, use_optimistic, use_reducer, use_ref,
+	use_shared_state, use_state, use_sync_external_store, use_transition,
 };

--- a/crates/reinhardt-pages/src/reactive/hooks.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks.rs
@@ -55,7 +55,6 @@
 //! - [`use_websocket`] - WebSocket connections (WASM only)
 //! - [`use_optimistic`] - Optimistic UI updates
 //! - [`use_debug_value`] - DevTools labels
-//! - [`use_effect_event`] - Non-reactive event handlers
 //!
 //! ## Example
 //!
@@ -111,11 +110,7 @@ pub use reinhardt_core::reactive::batch;
 pub use action::{OptimisticState, use_optimistic};
 pub use async_action::{Action, ActionPhase, use_action};
 pub use context::use_context;
-#[allow(
-	deprecated,
-	reason = "re-export kept until removal in v0.3.0 (Refs #4195)"
-)]
-pub use debug::{use_debug_value, use_effect_event};
+pub use debug::use_debug_value;
 pub use effect::{use_effect, use_layout_effect};
 pub use id::use_id;
 pub use memo::{use_callback, use_memo};

--- a/crates/reinhardt-pages/src/reactive/hooks.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks.rs
@@ -113,7 +113,7 @@ pub use context::use_context;
 pub use debug::use_debug_value;
 pub use effect::{use_effect, use_layout_effect};
 pub use id::use_id;
-pub use memo::{use_callback, use_memo};
+pub use memo::{use_callback, use_callback_with, use_memo};
 pub use refs::{Ref, use_ref};
 pub use router::{NavigateError, RouterHandle, use_router};
 pub use state::{

--- a/crates/reinhardt-pages/src/reactive/hooks/debug.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/debug.rs
@@ -1,14 +1,6 @@
-//! Debug hooks: use_debug_value and use_effect_event
+//! Debug hooks.
 //!
-//! These hooks provide debugging and event handling utilities.
-
-use crate::callback::Callback;
-
-#[cfg(wasm)]
-type EventArg = web_sys::Event;
-
-#[cfg(native)]
-type EventArg = crate::component::DummyEvent;
+//! These hooks provide debugging utilities.
 
 /// Adds a label to a custom hook in DevTools.
 ///
@@ -94,147 +86,6 @@ where
 	}
 }
 
-/// Creates an event handler that always sees the latest props and state.
-///
-/// This is the React-like equivalent of `useEffectEvent` (experimental).
-/// It allows you to extract non-reactive logic from Effects while still
-/// reading the latest values.
-///
-/// # Use Case
-///
-/// When you have an Effect that needs to call a function with the latest
-/// props/state, but you don't want changes to that function to re-run the Effect.
-///
-/// # Type Parameters
-///
-/// * `F` - The function type
-///
-/// # Arguments
-///
-/// * `f` - The function to wrap
-///
-/// # Returns
-///
-/// A `Callback` that always calls the latest version of `f`
-///
-/// # Example
-///
-/// ```ignore
-/// use reinhardt_pages::reactive::hooks::{use_state, use_effect, use_effect_event};
-///
-/// let (url, set_url) = use_state("https://api.example.com".to_string());
-/// let (item_id, set_item_id) = use_state(1);
-///
-/// // This callback always sees the latest url, but won't cause
-/// // the effect to re-run when url changes
-/// let on_fetch = use_effect_event({
-///     let url = url.clone();
-///     move |data: &str| {
-///         log!("Fetched from {}: {}", url.get(), data);
-///     }
-/// });
-///
-/// // Effect only re-runs when item_id changes
-/// use_effect({
-///     let item_id = item_id.clone();
-///     let on_fetch = on_fetch.clone();
-///     move || {
-///         let id = item_id.get();
-///         // fetch(id).then(|data| on_fetch.call(data));
-///     }
-/// });
-/// ```
-///
-/// # Note
-///
-/// Implementation note: Unlike React's experimental useEffectEvent, this
-/// implementation does not prevent dependency tracking within the callback.
-/// The callback provides stable identity but Signals accessed inside will
-/// still be tracked if called within an Effect context.
-#[cfg(wasm)]
-#[deprecated(
-	since = "0.2.0",
-	note = "Option A semantics make use_effect_event structurally redundant — \
-	the wrapped closure of use_effect/use_layout_effect already runs without \
-	auto-tracking. Use use_callback(f, deps) for stable identity or read \
-	the latest Signal value via .get_untracked() inside the effect. \
-	Scheduled for removal in v0.3.0 (Refs #4195)."
-)]
-pub fn use_effect_event<F>(f: F) -> Callback<EventArg, ()>
-where
-	F: Fn(EventArg) + 'static,
-{
-	Callback::new(f)
-}
-
-/// Creates an event handler that always sees the latest props and state (server-side version).
-///
-/// See the WASM version for full documentation.
-#[cfg(native)]
-#[deprecated(
-	since = "0.2.0",
-	note = "Option A semantics make use_effect_event structurally redundant — \
-	the wrapped closure of use_effect/use_layout_effect already runs without \
-	auto-tracking. Use use_callback(f, deps) for stable identity or read \
-	the latest Signal value via .get_untracked() inside the effect. \
-	Scheduled for removal in v0.3.0 (Refs #4195)."
-)]
-pub fn use_effect_event<F>(f: F) -> Callback<EventArg, ()>
-where
-	F: Fn(EventArg) + Send + Sync + 'static,
-{
-	Callback::new(f)
-}
-
-/// Creates an effect event handler with custom argument types.
-///
-/// This is a more flexible version that allows specifying custom argument types.
-#[cfg(wasm)]
-#[deprecated(
-	since = "0.2.0",
-	note = "Option A semantics make use_effect_event_with structurally \
-	redundant. Use use_callback_with(f, deps) or .get_untracked() instead. \
-	Scheduled for removal in v0.3.0 (Refs #4195)."
-)]
-pub fn use_effect_event_with<Args, Ret, F>(f: F) -> Callback<Args, Ret>
-where
-	F: Fn(Args) -> Ret + 'static,
-{
-	Callback::new(f)
-}
-
-/// Creates an effect event handler with custom argument types (server-side version).
-///
-/// This is a more flexible version that allows specifying custom argument and return types.
-/// Requires `Send + Sync` bounds for thread-safe server-side usage.
-///
-/// # Type Parameters
-///
-/// * `Args` - The argument type
-/// * `Ret` - The return type
-/// * `F` - The callback function type
-///
-/// # Arguments
-///
-/// * `f` - The function to wrap
-///
-/// # Returns
-///
-/// A `Callback<Args, Ret>` that always calls the latest version of `f`
-#[cfg(native)]
-#[deprecated(
-	since = "0.2.0",
-	note = "Option A semantics make use_effect_event_with structurally \
-	redundant. Use use_callback_with(f, deps) or .get_untracked() instead. \
-	Scheduled for removal in v0.3.0 (Refs #4195)."
-)]
-pub fn use_effect_event_with<Args, Ret, F>(f: F) -> Callback<Args, Ret>
-where
-	F: Fn(Args) -> Ret + Send + Sync + 'static,
-{
-	Callback::new(f)
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -251,31 +102,5 @@ mod tests {
 	fn test_use_debug_value_with() {
 		// Should not panic
 		use_debug_value_with(vec![1, 2, 3], |v| format!("len: {}", v.len()));
-	}
-
-	#[cfg(native)]
-	#[test]
-	fn test_use_effect_event() {
-		use std::sync::{Arc, Mutex};
-
-		// Use Arc<Mutex<T>> for thread-safe state (required for Send + Sync on non-WASM)
-		let called = Arc::new(Mutex::new(false));
-
-		let handler = use_effect_event({
-			let called = Arc::clone(&called);
-			move |_: crate::component::DummyEvent| {
-				*called.lock().unwrap() = true;
-			}
-		});
-
-		handler.call(crate::component::DummyEvent::default());
-		assert!(*called.lock().unwrap());
-	}
-
-	#[cfg(native)]
-	#[test]
-	fn test_use_effect_event_with() {
-		let add_one = use_effect_event_with(|x: i32| x + 1);
-		assert_eq!(add_one.call(5), 6);
 	}
 }

--- a/crates/reinhardt-pages/src/reactive/resource.rs
+++ b/crates/reinhardt-pages/src/reactive/resource.rs
@@ -1,8 +1,8 @@
 //! Resource - Async data fetching primitive
 //!
 //! This module provides `Resource<T>`, a reactive primitive for handling async operations.
-//! Similar to Leptos's `create_resource`, it manages Loading/Success/Error states
-//! and integrates with the Signal-based reactivity system.
+//! It manages Loading/Success/Error states and integrates with the Signal-based
+//! reactivity system.
 
 use super::{Effect, Signal};
 use serde::{Deserialize, Serialize};
@@ -283,55 +283,6 @@ where
 		refetch_fn,
 		effect_guard: Rc::new(effect),
 	}
-}
-
-/// Create a resource from an async function (deprecated).
-///
-/// # WASM-only
-///
-/// This function is only available on WASM targets.
-#[cfg(wasm)]
-#[deprecated(
-	since = "0.2.0-rc.2",
-	note = "Renamed for naming consistency with use_effect/use_memo/use_callback. \
-	Use `use_resource(fetcher, ())` for fetch-on-mount. Scheduled for removal in v0.3.0."
-)]
-pub fn create_resource<T, E, F, Fut>(fetcher: F) -> Resource<T, E>
-where
-	T: Clone + 'static,
-	E: Clone + 'static,
-	F: Fn() -> Fut + 'static,
-	Fut: std::future::Future<Output = Result<T, E>> + 'static,
-{
-	use_resource(fetcher, ())
-}
-
-/// Create a resource with dependency tracking (deprecated).
-///
-/// # WASM-only
-///
-/// This function is only available on WASM targets.
-#[cfg(wasm)]
-#[deprecated(
-	since = "0.2.0-rc.2",
-	note = "Unified into use_resource. Use \
-	`use_resource(move || { let v = dep.get(); async move { .. } }, (dep,))`. \
-	Scheduled for removal in v0.3.0."
-)]
-pub fn create_resource_with_deps<T, E, D, F, Fut>(deps: Signal<D>, fetcher: F) -> Resource<T, E>
-where
-	T: Clone + 'static,
-	E: Clone + 'static,
-	D: Clone + PartialEq + 'static,
-	F: Fn(D) -> Fut + 'static,
-	Fut: std::future::Future<Output = Result<T, E>> + 'static,
-{
-	// Forward to the unified hook: subscribe to `deps` and read its current
-	// value inside the fetcher. This also fixes the original behavior — the old
-	// implementation disposed its tracking Effect immediately, so dependency
-	// changes never triggered a refetch.
-	let dep_for_fetch = deps.clone();
-	use_resource(move || fetcher(dep_for_fetch.get()), (deps,))
 }
 
 #[cfg(test)]

--- a/crates/reinhardt-pages/src/static_resolver.rs
+++ b/crates/reinhardt-pages/src/static_resolver.rs
@@ -180,10 +180,14 @@
 //!
 //! ## Thread Safety
 //!
-//! The static resolver uses `OnceLock` for thread-safe lazy initialization.
-//! It can only be initialized once per application lifecycle.
+//! The static resolver uses `OnceLock` for thread-safe lazy initialization in
+//! production builds. It can only be initialized once per application lifecycle.
 
+#[cfg(any(wasm, all(native, not(feature = "testing"))))]
 use std::sync::OnceLock;
+
+#[cfg(all(native, feature = "testing"))]
+use std::{cell::RefCell, sync::RwLock};
 
 #[cfg(native)]
 use reinhardt_utils::staticfiles::TemplateStaticConfig;
@@ -192,8 +196,22 @@ use reinhardt_utils::staticfiles::TemplateStaticConfig;
 ///
 /// This is initialized once at application startup and provides
 /// thread-safe access to the static URL resolver.
-#[cfg(native)]
+#[cfg(all(native, not(feature = "testing")))]
 static STATIC_CONFIG: OnceLock<TemplateStaticConfig> = OnceLock::new();
+
+/// Test-only static configuration storage.
+///
+/// Integration tests exercise many resolver configurations in one process, so
+/// the testing feature uses replaceable storage while production builds keep
+/// one-time initialization.
+#[cfg(all(native, feature = "testing"))]
+static STATIC_CONFIG: RwLock<Option<TemplateStaticConfig>> = RwLock::new(None);
+
+#[cfg(all(native, feature = "testing"))]
+thread_local! {
+	static THREAD_STATIC_CONFIG: RefCell<Option<TemplateStaticConfig>> =
+		const { RefCell::new(None) };
+}
 
 /// WASM-specific static URL prefix.
 ///
@@ -221,11 +239,28 @@ static STATIC_URL_PREFIX: OnceLock<String> = OnceLock::new();
 ///
 /// This function does not panic if called multiple times; subsequent
 /// calls are silently ignored.
-#[cfg(native)]
+#[cfg(all(native, not(feature = "testing")))]
 pub fn init_static_resolver(config: TemplateStaticConfig) {
 	// OnceLock::set returns Err if already set, but we ignore this
 	// to allow for idempotent initialization
 	let _ = STATIC_CONFIG.set(config);
+}
+
+/// Initializes or replaces the static resolver configuration in testing builds.
+///
+/// The production resolver is intentionally one-shot. The `testing` feature
+/// allows replacement so integration tests can cover many independent static
+/// URL configurations in the same process.
+#[cfg(all(native, feature = "testing"))]
+pub fn init_static_resolver(config: TemplateStaticConfig) {
+	THREAD_STATIC_CONFIG.with(|slot| {
+		*slot.borrow_mut() = Some(config.clone());
+	});
+
+	let mut slot = STATIC_CONFIG
+		.write()
+		.expect("static resolver testing lock should not be poisoned");
+	*slot = Some(config);
 }
 
 /// Initializes the static resolver with a URL prefix (WASM version).
@@ -281,23 +316,44 @@ pub fn init_static_resolver(static_url: String) {
 /// was missed, though cache busting won't be available.
 #[cfg(native)]
 pub fn resolve_static(path: &str) -> String {
-	STATIC_CONFIG
-		.get()
-		.map(|config| config.resolve_url(path))
-		.unwrap_or_else(|| {
-			// Only warn once to avoid log spam
-			static WARNED: std::sync::atomic::AtomicBool =
-				std::sync::atomic::AtomicBool::new(false);
-			if !WARNED.swap(true, std::sync::atomic::Ordering::SeqCst) {
-				eprintln!(
-					"WARNING: Static resolver not initialized. Call init_static_resolver() at startup."
-				);
-			}
+	resolve_static_from_config(path).unwrap_or_else(|| fallback_static_url(path))
+}
 
-			// Fallback: use simple concatenation
-			let path = path.trim_start_matches('/');
-			format!("/static/{}", path)
-		})
+#[cfg(all(native, not(feature = "testing")))]
+fn resolve_static_from_config(path: &str) -> Option<String> {
+	STATIC_CONFIG.get().map(|config| config.resolve_url(path))
+}
+
+#[cfg(all(native, feature = "testing"))]
+fn resolve_static_from_config(path: &str) -> Option<String> {
+	let thread_config = THREAD_STATIC_CONFIG.with(|slot| {
+		slot.borrow()
+			.as_ref()
+			.map(|config| config.resolve_url(path))
+	});
+
+	thread_config.or_else(|| {
+		STATIC_CONFIG
+			.read()
+			.expect("static resolver testing lock should not be poisoned")
+			.as_ref()
+			.map(|config| config.resolve_url(path))
+	})
+}
+
+#[cfg(native)]
+fn fallback_static_url(path: &str) -> String {
+	// Only warn once to avoid log spam
+	static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+	if !WARNED.swap(true, std::sync::atomic::Ordering::SeqCst) {
+		eprintln!(
+			"WARNING: Static resolver not initialized. Call init_static_resolver() at startup."
+		);
+	}
+
+	// Fallback: use simple concatenation
+	let path = path.trim_start_matches('/');
+	format!("/static/{}", path)
 }
 
 /// Resolves a static file path to its URL (WASM version).
@@ -329,9 +385,24 @@ pub fn resolve_static(path: &str) -> String {
 ///     init_static_resolver(config);
 /// }
 /// ```
-#[cfg(native)]
+#[cfg(all(native, not(feature = "testing")))]
 pub fn is_initialized() -> bool {
 	STATIC_CONFIG.get().is_some()
+}
+
+/// Checks if the testing static resolver has been initialized.
+///
+/// This testing-feature variant reports whether the replaceable test storage
+/// currently contains a static resolver configuration.
+#[cfg(all(native, feature = "testing"))]
+pub fn is_initialized() -> bool {
+	let thread_initialized = THREAD_STATIC_CONFIG.with(|slot| slot.borrow().is_some());
+
+	thread_initialized
+		|| STATIC_CONFIG
+			.read()
+			.expect("static resolver testing lock should not be poisoned")
+			.is_some()
 }
 
 /// Checks if the static resolver has been initialized (WASM version).

--- a/crates/reinhardt-pages/tests/static_resolver_state_transition_tests.rs
+++ b/crates/reinhardt-pages/tests/static_resolver_state_transition_tests.rs
@@ -29,10 +29,11 @@ mod state_transition_tests {
 		);
 	}
 
-	/// Test that multiple initializations are idempotent
-	/// Due to OnceLock semantics, second init should be ignored
+	/// Test that multiple initializations are idempotent in production builds.
+	/// Due to OnceLock semantics, second init should be ignored.
 	#[rstest]
 	#[serial]
+	#[cfg(not(feature = "testing"))]
 	fn test_state_transition_multiple_init_idempotent() {
 		let config1 = TemplateStaticConfig::new("/static/".to_string());
 		init_static_resolver(config1);
@@ -49,6 +50,31 @@ mod state_transition_tests {
 		assert!(
 			!result.contains("/different/"),
 			"Second config should be ignored"
+		);
+	}
+
+	/// Test that the testing feature can replace resolver configuration.
+	///
+	/// Integration tests run many independent resolver cases in one process, so
+	/// `testing` intentionally permits replacement.
+	#[rstest]
+	#[serial]
+	#[cfg(feature = "testing")]
+	fn test_state_transition_multiple_init_replaces_config_in_testing() {
+		let config1 = TemplateStaticConfig::new("/static/".to_string());
+		init_static_resolver(config1);
+
+		let config2 = TemplateStaticConfig::new("/different/".to_string());
+		init_static_resolver(config2);
+
+		let result = resolve_static("test.css");
+		assert!(
+			result.contains("/different/"),
+			"Testing feature should allow config replacement"
+		);
+		assert!(
+			!result.contains("/static/"),
+			"Previous config should be replaced"
 		);
 	}
 

--- a/crates/reinhardt-pages/tests/ui/server_fn/codec_json.rs
+++ b/crates/reinhardt-pages/tests/ui/server_fn/codec_json.rs
@@ -9,13 +9,13 @@ use reinhardt_pages_macros::server_fn;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
-struct User {
+pub struct User {
 	id: u32,
 	name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ServerFnError(String);
+pub struct ServerFnError(String);
 
 impl std::fmt::Display for ServerFnError {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/reinhardt-pages/tests/ui/server_fn/codec_url.rs
+++ b/crates/reinhardt-pages/tests/ui/server_fn/codec_url.rs
@@ -9,13 +9,13 @@ use reinhardt_pages_macros::server_fn;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
-struct SearchResult {
+pub struct SearchResult {
 	title: String,
 	url: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ServerFnError(String);
+pub struct ServerFnError(String);
 
 impl std::fmt::Display for ServerFnError {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/reinhardt-pages/tests/ui/server_fn/no_msw_feature.rs
+++ b/crates/reinhardt-pages/tests/ui/server_fn/no_msw_feature.rs
@@ -9,13 +9,13 @@ use reinhardt_pages_macros::server_fn;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
-struct User {
+pub struct User {
 	id: u32,
 	name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ServerFnError(String);
+pub struct ServerFnError(String);
 
 impl std::fmt::Display for ServerFnError {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/reinhardt-pages/tests/ui/server_fn/with_extractors.rs
+++ b/crates/reinhardt-pages/tests/ui/server_fn/with_extractors.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 // Mock types for testing
 #[derive(Serialize, Deserialize)]
-struct LoginRequest {
+pub struct LoginRequest {
 	email: String,
 	password: String,
 }
@@ -26,13 +26,13 @@ impl reinhardt_core::validators::Validate for LoginRequest {
 }
 
 #[derive(Serialize, Deserialize)]
-struct User {
+pub struct User {
 	id: u32,
 	name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ServerFnError(String);
+pub struct ServerFnError(String);
 
 impl std::fmt::Display for ServerFnError {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/instructions/MIGRATION_0.2.md
+++ b/instructions/MIGRATION_0.2.md
@@ -180,7 +180,8 @@ the closure signature now determines arity.
 
 The final 0.2 line uses `CurrentUser<U>` as the canonical authenticated-user
 extractor. `AuthUser<U>` remains as a deprecated tuple-struct compatibility
-wrapper during the 0.2 cycle and is scheduled for removal in 0.3.
+wrapper during the 0.2 cycle and is removed in 0.3. See
+[`MIGRATION_0.3.md`](MIGRATION_0.3.md) for the 0.3 removal checklist.
 
 ```rust
 // Before
@@ -279,7 +280,8 @@ These are 0.2 behavior changes, not the removed-deprecated list above:
 - bare identifier shorthand in element bodies is removed; write `{name}`,
 - `form!` fields can carry typed generic parameters for server function values,
 - `create_resource` / `create_resource_with_deps` call sites should move to
-  `use_resource(fetcher, deps)`,
+  `use_resource(fetcher, deps)` before 0.3, where the deprecated constructors
+  are removed,
 - `use_form` now starts from a generated form definition and returns a runtime
   builder; do not build runtime state from `FormOptions::new(...)`.
 

--- a/instructions/MIGRATION_0.3.md
+++ b/instructions/MIGRATION_0.3.md
@@ -1,0 +1,64 @@
+# Reinhardt 0.3 Migration Guide
+
+This guide covers compatibility APIs that were deprecated during the 0.2 line
+and removed for 0.3. It assumes the application already follows the 0.2
+migration guide.
+
+## Removed API
+
+| Crate | Removed API | Replacement |
+|---|---|---|
+| `reinhardt-auth` | `AuthUser<U>` | `CurrentUser<U>` |
+| `reinhardt-pages` | `create_resource(fetcher)` | `use_resource(fetcher, ())` |
+| `reinhardt-pages` | `create_resource_with_deps(...)` | `use_resource(fetcher, deps)` |
+| `reinhardt-pages` | `use_effect_event(...)` | `use_callback(f, deps)` or `.get_untracked()` inside the effect |
+| `reinhardt-pages` | `use_effect_event_with(...)` | `use_callback_with(f, deps)` or `.get_untracked()` inside the effect |
+
+## Auth Extractor
+
+`CurrentUser<U>` is the only full authenticated-user extractor.
+
+```rust
+// Before
+use reinhardt_auth::AuthUser;
+
+async fn profile(AuthUser(user): AuthUser<MyUser>) -> Response {
+    let id = user.id();
+    // ...
+}
+
+// After
+use reinhardt_auth::CurrentUser;
+
+async fn profile(CurrentUser(user): CurrentUser<MyUser>) -> Response {
+    let id = user.id();
+    // ...
+}
+```
+
+## Resource Hooks
+
+Use `use_resource(fetcher, deps)` for both mount-only and dependency-driven
+resource loading.
+
+```rust
+// Before
+let questions = create_resource_with_deps(fetch_questions, (page,));
+
+// After
+let questions = use_resource(fetch_questions, (page,));
+```
+
+For mount-only loading, pass `()`:
+
+```rust
+let user = use_resource(fetch_user, ());
+```
+
+## Verification
+
+Search for removed API names before running the full test suite:
+
+```bash
+rg -n "AuthUser|create_resource|create_resource_with_deps|use_effect_event|use_effect_event_with" src crates examples
+```

--- a/src/exports/auth.rs
+++ b/src/exports/auth.rs
@@ -5,9 +5,6 @@ pub use reinhardt_auth::{
 	IsAuthenticated, PasswordHasher, Permission, PermissionsMixin, validate_auth_extractors,
 };
 
-#[allow(deprecated)]
-pub use reinhardt_auth::AuthUser;
-
 #[cfg(feature = "argon2-hasher")]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "auth", feature = "argon2-hasher"))))]
 pub use reinhardt_auth::Argon2Hasher;


### PR DESCRIPTION
## Summary

This PR addresses:

- Removes public APIs deprecated for removal in 0.3.0: `AuthUser`, `create_resource`, `create_resource_with_deps`, `use_effect_event`, and `use_effect_event_with`.
- Updates public exports, route macro auth detection, README/changelog entries, and migration guidance for the 0.3.0 removal.
- Isolates `reinhardt-pages` static resolver test state so all-features tests can run without cross-test configuration leakage.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [ ] **No** - This change is backward compatible
- [x] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- The removed APIs were already deprecated and scheduled for removal in the 0.3.0 line.
- Keeping the compatibility exports would leave stale public API surface in the release train.
- The test-state cleanup keeps `reinhardt-pages` validation reliable under `--all-features`.

Fixes: N/A

Related to: 0.3.0 release cleanup

## How Was This Tested?

- `cargo check -p reinhardt-pages --all-features`
- `cargo check -p reinhardt-auth --all-features`
- `cargo test -p reinhardt-auth --all-features`
- `cargo test -p reinhardt-pages --all-features`
- `cargo fmt --all`
- `cargo make fmt-check`
- `cargo make fmt-fix`
- `cargo make clippy-check`
- `git diff --check`

## Performance Impact

- N/A

## Breaking Changes

- `reinhardt::exports::auth::AuthUser` and `reinhardt_auth::AuthUser` are removed.
- `create_resource` and `create_resource_with_deps` are removed from `reinhardt-pages` exports and prelude.
- `use_effect_event` and `use_effect_event_with` are removed from `reinhardt-pages` hooks exports.

**Migration Guide:**

- Replace `AuthUser<T>` with `CurrentUser<T>`.
- Replace `create_resource(...)` with `use_resource(...)`.
- Replace `create_resource_with_deps(...)` with `use_resource(move || ..., async move |deps| ...)`.
- Replace `use_effect_event` / `use_effect_event_with` with ordinary callbacks and `get_untracked()` at the callback boundary when non-tracking reads are needed.
- See `instructions/MIGRATION_0.3.md` for examples.

## Screenshots

### Before

- N/A

### After

- N/A

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- N/A

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [x] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [x] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [x] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- Target base branch: `develop/0.3.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed deprecated `AuthUser<U>` extractor; use `CurrentUser<U>` instead.
  * Removed deprecated Pages hooks `use_effect_event` and `use_effect_event_with`; use `use_callback` or signal `.get_untracked()` instead.
  * Removed deprecated resource constructors `create_resource` and `create_resource_with_deps`; use `use_resource(fetcher, deps)` instead.

* **Documentation**
  * Added v0.3 migration guide with step-by-step upgrade instructions from v0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->