### PR TITLE
feat(middleware): populate AuthState from sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ let mut perms = ObjectPermissionManager::new();
 perms.grant_permission("alice", "article:123", "edit").await;
 ```
 
-Use JWT authentication in your app's `views/profile.rs`:
+Use authentication in your app's `views/profile.rs`:
 
 ```rust
 // users/views/profile.rs
@@ -816,7 +816,8 @@ use reinhardt::{Response, StatusCode, ViewResult, get};
 use reinhardt::auth::CurrentUser;
 use crate::models::User;
 
-// JwtAuthMiddleware must be registered in urls.rs to populate AuthState in request extensions
+// SessionMiddleware or JwtAuthMiddleware must be registered in urls.rs to
+// populate AuthState in request extensions.
 #[get("/profile", name = "get_profile")]
 pub async fn get_profile(
 	#[inject] CurrentUser(user): CurrentUser<User>,

--- a/crates/reinhardt-middleware/README.md
+++ b/crates/reinhardt-middleware/README.md
@@ -256,6 +256,15 @@ The `session` module ships three companion helpers for the
 `#[server_fn]` / `#[inject]` patterns used by authenticated handlers
 (introduced in [#4446](https://github.com/kent8192/reinhardt-web/issues/4446)):
 
+`SessionMiddleware` is the recommended single middleware for cookie-backed
+session authentication. It loads the active `SessionData`, publishes the
+middleware-owned `SessionStore` to DI, and derives `AuthState` from
+`USER_ID_SESSION_KEY` when the session is authenticated. Handlers can therefore
+combine `SessionAuthExt::login` / `logout` with `CurrentUser<U>` without adding
+`CookieSessionAuthMiddleware` as a second layer. `CookieSessionAuthMiddleware`
+remains available for applications that use a custom `AsyncSessionBackend`
+directly.
+
 - `USER_ID_SESSION_KEY` — the canonical session-store key (`"user_id"`)
   every handler should read from / write to instead of hardcoding a literal.
 - `SessionValue<T>` / `OptionalSessionValue<T>` — typed extractors that

--- a/crates/reinhardt-middleware/src/lib.rs
+++ b/crates/reinhardt-middleware/src/lib.rs
@@ -132,8 +132,8 @@
 //! 3. `TracingMiddleware` - Start tracing span
 //! 4. `SecurityMiddleware` - Apply security headers
 //! 5. `CorsMiddleware` - Handle CORS preflight
-//! 6. `SessionMiddleware` - Load session
-//! 7. `AuthenticationMiddleware` or `JwtAuthMiddleware` - Authenticate user
+//! 6. `SessionMiddleware` - Load session and populate `AuthState`
+//! 7. `AuthenticationMiddleware` or `JwtAuthMiddleware` - Authenticate non-session credentials
 //! 8. `LoginRequiredMiddleware` - Enforce login (optional)
 //! 9. `CsrfMiddleware` - Validate CSRF token
 //! 10. `RateLimitMiddleware` - Apply rate limits

--- a/crates/reinhardt-middleware/src/session/middleware.rs
+++ b/crates/reinhardt-middleware/src/session/middleware.rs
@@ -1,13 +1,16 @@
 //! `SessionMiddleware`: cookie parsing, store wiring, and `Set-Cookie` writeback.
 
 use async_trait::async_trait;
-use reinhardt_http::{Handler, Middleware, MiddlewareDiRegistration, Request, Response, Result};
+use reinhardt_http::{
+	AuthState, Handler, IsActive, IsAdmin, IsAuthenticated, Middleware, MiddlewareDiRegistration,
+	Request, Response, Result,
+};
 use std::any::TypeId;
 use std::sync::Arc;
 
 use super::config::SessionConfig;
 use super::cookie::find_cookie_value;
-use super::data::SessionData;
+use super::data::{SessionData, USER_ID_SESSION_KEY};
 use super::id::{ActiveSessionId, SessionCookieName, SessionId};
 use super::store::{SessionStore, SessionStoreKey};
 
@@ -148,6 +151,49 @@ impl SessionMiddleware {
 
 		parts.join("; ")
 	}
+
+	fn user_id_from_session(session: &SessionData) -> Option<String> {
+		let value = session.data.get(USER_ID_SESSION_KEY)?;
+		let user_id = match value {
+			serde_json::Value::String(s) => s.clone(),
+			serde_json::Value::Number(n) => n.to_string(),
+			serde_json::Value::Bool(b) => b.to_string(),
+			_ => return None,
+		};
+
+		if user_id.is_empty() {
+			None
+		} else {
+			Some(user_id)
+		}
+	}
+
+	fn populate_auth_extensions(request: &Request, session: &SessionData) {
+		if request.extensions.contains::<AuthState>() {
+			return;
+		}
+
+		let Some(user_id) = Self::user_id_from_session(session) else {
+			request.extensions.insert(IsAuthenticated(false));
+			request.extensions.insert(IsAdmin(false));
+			request.extensions.insert(IsActive(false));
+			request.extensions.insert(AuthState::anonymous());
+			return;
+		};
+
+		let is_staff = session.get::<bool>("is_staff").unwrap_or(false);
+		let is_superuser = session.get::<bool>("is_superuser").unwrap_or(false);
+		let is_admin = is_staff || is_superuser;
+		let is_active = true;
+
+		request.extensions.insert(user_id.clone());
+		request.extensions.insert(IsAuthenticated(true));
+		request.extensions.insert(IsAdmin(is_admin));
+		request.extensions.insert(IsActive(is_active));
+		request
+			.extensions
+			.insert(AuthState::authenticated(user_id, is_admin, is_active));
+	}
 }
 
 impl Default for SessionMiddleware {
@@ -212,6 +258,7 @@ impl Middleware for SessionMiddleware {
 		// (`SessionData::regenerate_id`) keep `Set-Cookie` in sync. See #3827.
 		let active_id = ActiveSessionId::new(session.id.clone());
 		request.extensions.insert(active_id.clone());
+		Self::populate_auth_extensions(&request, &session);
 
 		// Call the handler
 		// Convert errors to responses so post-processing (e.g., security headers)
@@ -244,8 +291,39 @@ impl Middleware for SessionMiddleware {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use bytes::Bytes;
+	use hyper::{HeaderMap, Method, Version};
+	use reinhardt_http::{AuthState, Handler, Request};
 	use rstest::rstest;
+	use std::sync::Mutex;
 	use std::time::Duration;
+
+	#[derive(Default)]
+	struct CapturedAuth {
+		auth_state: Option<AuthState>,
+		user_id: Option<String>,
+		is_authenticated: Option<IsAuthenticated>,
+		is_admin: Option<IsAdmin>,
+		is_active: Option<IsActive>,
+	}
+
+	struct CaptureAuthHandler {
+		captured: Arc<Mutex<CapturedAuth>>,
+	}
+
+	#[async_trait]
+	impl Handler for CaptureAuthHandler {
+		async fn handle(&self, request: Request) -> Result<Response> {
+			*self.captured.lock().unwrap() = CapturedAuth {
+				auth_state: request.extensions.get::<AuthState>(),
+				user_id: request.extensions.get::<String>(),
+				is_authenticated: request.extensions.get::<IsAuthenticated>(),
+				is_admin: request.extensions.get::<IsAdmin>(),
+				is_active: request.extensions.get::<IsActive>(),
+			};
+			Ok(Response::ok())
+		}
+	}
 
 	/// Returns a `SessionMiddleware` with a fixed cookie name and TTL for
 	/// deterministic tests.
@@ -254,6 +332,41 @@ mod tests {
 			"sessionid".to_string(),
 			Duration::from_secs(3600),
 		))
+	}
+
+	fn request_with_cookie(session_id: &str) -> Request {
+		let mut headers = HeaderMap::new();
+		headers.insert(
+			hyper::header::COOKIE,
+			hyper::header::HeaderValue::from_str(&format!("sessionid={}", session_id)).unwrap(),
+		);
+		Request::builder()
+			.method(Method::GET)
+			.uri("/")
+			.version(Version::HTTP_11)
+			.headers(headers)
+			.body(Bytes::new())
+			.build()
+			.unwrap()
+	}
+
+	fn request_without_cookie() -> Request {
+		Request::builder()
+			.method(Method::GET)
+			.uri("/")
+			.version(Version::HTTP_11)
+			.headers(HeaderMap::new())
+			.body(Bytes::new())
+			.build()
+			.unwrap()
+	}
+
+	fn capture_handler() -> (Arc<Mutex<CapturedAuth>>, Arc<dyn Handler>) {
+		let captured = Arc::new(Mutex::new(CapturedAuth::default()));
+		let handler = Arc::new(CaptureAuthHandler {
+			captured: Arc::clone(&captured),
+		});
+		(captured, handler)
 	}
 
 	#[rstest]
@@ -318,6 +431,86 @@ mod tests {
 			Arc::ptr_eq(&resolved, &store_arc),
 			"resolved Arc<SessionStore> must point at the same allocation the middleware owns"
 		);
+	}
+
+	#[tokio::test]
+	async fn session_middleware_populates_auth_state_from_session_user_id() {
+		let middleware = make_middleware();
+		let store = middleware.store_arc();
+		let mut session = SessionData::new(Duration::from_secs(3600));
+		session
+			.set(USER_ID_SESSION_KEY.to_string(), 42_i64)
+			.unwrap();
+		session.set("is_staff".to_string(), true).unwrap();
+		let session_id = session.id.clone();
+		store.save(session);
+
+		let (captured, handler) = capture_handler();
+		middleware
+			.process(request_with_cookie(&session_id), handler)
+			.await
+			.unwrap();
+
+		let captured = captured.lock().unwrap();
+		let auth_state = captured
+			.auth_state
+			.as_ref()
+			.expect("SessionMiddleware must insert AuthState");
+		assert!(auth_state.is_authenticated());
+		assert_eq!(auth_state.user_id(), "42");
+		assert!(auth_state.is_admin());
+		assert!(auth_state.is_active());
+		assert_eq!(captured.user_id.as_deref(), Some("42"));
+		assert_eq!(captured.is_authenticated, Some(IsAuthenticated(true)));
+		assert_eq!(captured.is_admin, Some(IsAdmin(true)));
+		assert_eq!(captured.is_active, Some(IsActive(true)));
+	}
+
+	#[tokio::test]
+	async fn session_middleware_populates_anonymous_auth_state_without_user_id() {
+		let middleware = make_middleware();
+		let (captured, handler) = capture_handler();
+
+		middleware
+			.process(request_without_cookie(), handler)
+			.await
+			.unwrap();
+
+		let captured = captured.lock().unwrap();
+		let auth_state = captured
+			.auth_state
+			.as_ref()
+			.expect("SessionMiddleware must insert anonymous AuthState");
+		assert!(auth_state.is_anonymous());
+		assert!(captured.user_id.is_none());
+		assert_eq!(captured.is_authenticated, Some(IsAuthenticated(false)));
+		assert_eq!(captured.is_admin, Some(IsAdmin(false)));
+		assert_eq!(captured.is_active, Some(IsActive(false)));
+	}
+
+	#[tokio::test]
+	async fn session_middleware_preserves_existing_auth_state() {
+		let middleware = make_middleware();
+		let request = request_without_cookie();
+		request
+			.extensions
+			.insert(AuthState::authenticated("jwt-user", true, true));
+		let (captured, handler) = capture_handler();
+
+		middleware.process(request, handler).await.unwrap();
+
+		let captured = captured.lock().unwrap();
+		let auth_state = captured
+			.auth_state
+			.as_ref()
+			.expect("pre-existing AuthState must remain visible");
+		assert_eq!(auth_state.user_id(), "jwt-user");
+		assert!(auth_state.is_authenticated());
+		assert!(auth_state.is_admin());
+		assert!(auth_state.is_active());
+		assert!(captured.is_authenticated.is_none());
+		assert!(captured.is_admin.is_none());
+		assert!(captured.is_active.is_none());
 	}
 
 	/// End-to-end injection test: drives the same path a handler with

--- a/examples/examples-tutorial-basis/src/config/urls.rs
+++ b/examples/examples-tutorial-basis/src/config/urls.rs
@@ -4,7 +4,7 @@
 //!
 //! Middleware stack (server-only):
 //! 1. `SessionMiddleware` — cookie-based session management used by the
-//!    `users` app's login/logout server functions
+//!    `users` app's login/logout server functions and `CurrentUser` auth state
 
 use reinhardt::UnifiedRouter;
 #[cfg(server)]
@@ -89,8 +89,11 @@ pub fn routes() -> UnifiedRouter {
 	// `#[inject] session: SessionData` or
 	// `#[inject] store: Depends<SessionStoreKey, Arc<SessionStore>>`
 	// can resolve the same store the middleware writes to without a parallel
-	// `with_di_registrations(...)` call. See #4426 (and the original #4423
-	// regression that motivated the auto-registration hook).
+	// `with_di_registrations(...)` call. The same middleware also derives
+	// `AuthState` from `USER_ID_SESSION_KEY`, so authenticated handlers can use
+	// `CurrentUser<U>` without adding a second cookie-session auth layer.
+	// See #4426 (and the original #4423 regression that motivated the
+	// auto-registration hook) and #4740.
 	#[cfg(server)]
 	let router = router.with_middleware(create_session_middleware());
 

--- a/instructions/MIGRATION_0.3.md
+++ b/instructions/MIGRATION_0.3.md
@@ -36,6 +36,19 @@ async fn profile(CurrentUser(user): CurrentUser<MyUser>) -> Response {
 }
 ```
 
+## Session Auth Middleware Wiring
+
+Cookie-backed session apps should register `SessionMiddleware` once in
+`urls.rs`. The 0.3 line uses Option A from issue #4740: `SessionMiddleware`
+derives `AuthState` from `USER_ID_SESSION_KEY` when the active session is
+authenticated, while preserving any `AuthState` already inserted by another
+auth middleware. This keeps the common cookie-session setup to one middleware
+without introducing a separate `SessionAuthMiddleware` bundle type.
+
+`CookieSessionAuthMiddleware` remains available for projects that plug a custom
+`AsyncSessionBackend` directly, but it is not required for the standard
+`SessionData` + `SessionAuthExt` + `CurrentUser<U>` flow.
+
 ## Resource Hooks
 
 Use `use_resource(fetcher, deps)` for both mount-only and dependency-driven


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds Option A from #4740: `SessionMiddleware` now derives `AuthState` from `USER_ID_SESSION_KEY` for authenticated cookie sessions.
- Preserves any pre-existing `AuthState` so JWT/custom auth middleware is not overwritten by session fallback behavior.
- Documents the single-`SessionMiddleware` wiring pattern and updates `examples-tutorial-basis` comments to reflect it.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`CurrentUser<U>` requires `AuthState` in request extensions. Before this change, apps using only `SessionMiddleware` had session data and DI wiring but still needed a second cookie-session auth layer to populate `AuthState`. The current codebase stores `AuthState` in `reinhardt-http`, which `SessionMiddleware` already depends on, so Option A keeps the common cookie-session stack to one middleware without introducing another public bundle type.

Fixes #4740

Related to: #4652, #4520, #4731

## How Was This Tested?

- [x] `cargo make fmt-fix`
- [x] `cargo test -p reinhardt-middleware --features sessions --lib session::middleware::tests`
- [x] `cargo check -p reinhardt-middleware --all-features`
- [x] `cargo make fmt-check`
- [x] `cargo clippy -p reinhardt-auth -p reinhardt-middleware --all-features --lib -- -D warnings`
- [ ] `cargo make clippy-check` was attempted, but the full workspace run was terminated with exit 143 before producing a Rust diagnostic.

## Performance Impact

Not performance-related. Per request, `SessionMiddleware` performs a small in-memory lookup against the already-loaded `SessionData` map.

## Breaking Changes

None.

## Screenshots

Not UI-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #4740
- Related to #4652
- Related to #4520
- Related to #4731

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [x] `auth` - Authentication, authorization, sessions
- [x] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

`CookieSessionAuthMiddleware` remains available for custom `AsyncSessionBackend` users. The standard `SessionData` + `SessionAuthExt` flow now uses `SessionMiddleware` alone.

🤖 Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SessionMiddleware now automatically populates authentication state (authenticated status, admin/staff flags) directly from session data, simplifying authentication setup

* **Documentation**
  * Enhanced authentication configuration examples and setup guidance
  * Added migration guide covering session authentication wiring, configuration patterns, and upgrade considerations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->