### PR TITLE
ci(examples): pin Bruno runner base image digest

### DIFF
--- a/examples/examples-tutorial-rest/Dockerfile.bruno
+++ b/examples/examples-tutorial-rest/Dockerfile.bruno
@@ -1,7 +1,13 @@
 # Dockerfile for Bruno API test runner.
 # Pre-installs @usebruno/cli into a minimal Node image so the runtime
 # container can run with a read-only root filesystem.
-FROM node:24-alpine
+#
+# Pinned to the current multi-arch node:24-alpine manifest so CI uses a stable
+# Node/Alpine base while still selecting the host platform. Review quarterly
+# or when Node/Alpine CVEs require a base refresh:
+#   docker buildx imagetools inspect docker.io/library/node:24-alpine
+# After bumping the digest, rebuild this Bruno image before opening the PR.
+FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6
 
 # Pinned for reproducibility — bump deliberately when upgrading.
 # Using @latest makes CI failures impossible to bisect against upstream changes.


### PR DESCRIPTION
## Summary

This PR addresses:

- Pins `examples/examples-tutorial-rest/Dockerfile.bruno` to the current multi-arch `node:24-alpine` manifest digest.
- Documents the manual renewal policy: review quarterly or when Node/Alpine CVEs require a base refresh, then rebuild the Bruno image.
- Keeps the existing `@usebruno/cli@3.3.0` pin unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`node:24-alpine` is a moving tag. Pinning the manifest digest makes the Bruno API test runner base image an explicit, reviewable dependency instead of allowing upstream base-image rebuilds to change CI behavior under the pinned Bruno CLI.

Fixes #4506

Related to: #5375

## How Was This Tested?

- [x] `docker build -f Dockerfile.bruno -t reinhardt-bruno-digest-test .`
- [x] `docker compose -f docker-compose.api-tests.yml build bruno`
- [x] `docker run --rm examples-tutorial-rest-bruno --version` -> `3.3.0`
- [x] `git diff --check`

`cargo make api-test` was attempted, but the full compose suite is blocked by the pre-existing app image build / masked exit-status issue tracked separately in #5375.

## Performance Impact

Not applicable.

## Related Issues

- Fixes #4506
- Related to #5375

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `low` - Minor fix/enhancement

---

**Additional Context:**

The digest used here is the Docker Hub multi-arch index digest reported by `docker buildx imagetools inspect docker.io/library/node:24-alpine` on 2026-06-19.