### PR TITLE
fix(ci): restrict wasm cache seed to main pushes

### DIFF
--- a/.github/workflows/wasm-check-standalone.yml
+++ b/.github/workflows/wasm-check-standalone.yml
@@ -2,7 +2,10 @@ name: WASM Check (Standalone)
 
 # Re-exposes wasm-check.yml on push to main so the WASM regression suite runs
 # after a PR merges. ci.yml already invokes wasm-check.yml on pull_request, so
-# this wrapper is push-to-main only to avoid duplicate runs (Fixes #4093).
+# this wrapper is push-to-main by default to avoid duplicate runs (Fixes #4093).
+# workflow_dispatch remains available for the GitHub-hosted reusable check, but
+# cache seeding is restricted to trusted push-to-main runs because it restores and
+# builds repository code on CI runners.
 
 on:
   push:
@@ -38,6 +41,7 @@ jobs:
   # (linux-x64 and linux-arm64); each consumer restores the matching one
   # without any change required on the consumer side. (Fixes #4207)
   cache-seed:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     name: Cache Seed (wasm-feature-check, ${{ matrix.arch.name }})
     strategy:
       fail-fast: false
@@ -96,6 +100,7 @@ jobs:
   wasm-check:
     name: WASM Check
     needs: [cache-seed]
+    if: ${{ always() && needs.cache-seed.result != 'failure' && needs.cache-seed.result != 'cancelled' }}
     uses: ./.github/workflows/wasm-check.yml
     with:
       runner: '"ubuntu-latest"'


### PR DESCRIPTION
### Motivation

- A manually-dispatchable standalone WASM workflow could run the `cache-seed` job on a selected ref using a self-hosted runner, which allowed repository-controlled composite actions or build scripts to execute on CI and posed an arbitrary-code risk.

### Description

- Added a job-level guard `if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}` to the `cache-seed` job in `.github/workflows/wasm-check-standalone.yml` to ensure cache seeding only runs for trusted `push` events to `main`.
- Added an `if: ${{ always() && needs.cache-seed.result != 'failure' && needs.cache-seed.result != 'cancelled' }}` to the `wasm-check` job so the reusable GitHub-hosted WASM check can still run when `cache-seed` is skipped while avoiding progression on failed/cancelled cache seeds.
- Updated the workflow header comments to document that `workflow_dispatch` remains available for the GitHub-hosted reusable check while cache seeding is restricted to push-to-main.

### Testing

- Ran an automated assertion script that verified the workflow still exposes `workflow_dispatch`, the `cache-seed` job contains the trusted push-to-main guard, and the workflow still calls the reusable `wasm-check` workflow, and the script succeeded.
- Ran `git diff --check` to validate there are no whitespace/patch errors and it succeeded.
- Verified the updated workflow file (`.github/workflows/wasm-check-standalone.yml`) contains the new guards via automated checks and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35df32a3f483279b164d560f7930b4)