### PR TITLE
fix(utils): verify vendor asset integrity before install

### DIFF
--- a/crates/reinhardt-utils/src/staticfiles/vendor/downloader.rs
+++ b/crates/reinhardt-utils/src/staticfiles/vendor/downloader.rs
@@ -153,6 +153,17 @@ pub async fn download_assets(
 			path: dest.display().to_string(),
 			source: std::io::Error::other("destination has no parent directory"),
 		})?;
+		let mut h = Sha256::new();
+		h.update(&bytes);
+		let computed = format!("{:x}", h.finalize());
+		if !asset.sha256.is_empty() && !computed.eq_ignore_ascii_case(asset.sha256) {
+			return Err(VendorDownloadError::IntegrityMismatch {
+				path: dest.display().to_string(),
+				expected: asset.sha256.to_string(),
+				actual: computed,
+			});
+		}
+
 		let mut tmp = tempfile::NamedTempFile::new_in(parent_dir).map_err(|source| {
 			VendorDownloadError::Io {
 				path: parent_dir.display().to_string(),
@@ -169,27 +180,15 @@ pub async fn download_assets(
 			source: e.error,
 		})?;
 
-		// Verify post-download. Empty SHA is short-circuited inside verify_integrity.
-		match verify_integrity(&dest, asset.sha256) {
-			Ok(()) => {
-				if asset.sha256.is_empty() {
-					// Compute and log the SHA so the developer can pin it.
-					if let Ok(content) = std::fs::read(&dest) {
-						let mut h = Sha256::new();
-						h.update(&content);
-						let computed = format!("{:x}", h.finalize());
-						if verbosity != Verbosity::Silent {
-							println!(
-								"vendor asset {} downloaded; computed sha256 = {}",
-								asset.target, computed
-							);
-						}
-					}
-				} else if verbosity == Verbosity::Verbose {
-					println!("verified: {}", asset.target);
-				}
+		if asset.sha256.is_empty() {
+			if verbosity != Verbosity::Silent {
+				println!(
+					"vendor asset {} downloaded; computed sha256 = {}",
+					asset.target, computed
+				);
 			}
-			Err(e) => return Err(e),
+		} else if verbosity == Verbosity::Verbose {
+			println!("verified: {}", asset.target);
 		}
 	}
 
@@ -236,16 +235,7 @@ pub async fn ensure_vendor_assets_for_app(
 		}
 		Err(e) => {
 			tracing::error!("vendor asset download for {} failed: {}", app_label, e);
-			if fail_hard() {
-				Err(e)
-			} else {
-				// Soft-fail: still mark as ensured so we do not retry every request.
-				ensured_set()
-					.lock()
-					.expect("ensured_set mutex poisoned")
-					.insert(key);
-				Ok(())
-			}
+			if fail_hard() { Err(e) } else { Ok(()) }
 		}
 	}
 }

--- a/crates/reinhardt-utils/tests/vendor_pipeline.rs
+++ b/crates/reinhardt-utils/tests/vendor_pipeline.rs
@@ -142,7 +142,51 @@ async fn download_errors_on_sha_mismatch() {
 	// Act
 	let result = download_assets(tmp.path(), &assets, Verbosity::Silent).await;
 
-	// Assert — the function attempts the download, then fails the post-write SHA check.
+	// Assert — the function attempts the download, then rejects it before install.
 	assert!(result.is_err(), "expected SHA mismatch error");
 	assert_eq!(request_count.load(Ordering::SeqCst), 1, "URL fetched once");
+	assert!(
+		!tmp.path().join("vendor/x.js").exists(),
+		"mismatching download must not be installed"
+	);
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn download_preserves_existing_file_on_sha_mismatch() {
+	// Arrange — an existing local file must not be replaced by a mismatching response.
+	let server = MockServer::start().await;
+	let request_count = Arc::new(AtomicUsize::new(0));
+
+	Mock::given(method("GET"))
+		.and(path("/x.js"))
+		.respond_with(CountingResponder {
+			counter: request_count.clone(),
+			body: b"attacker-controlled",
+		})
+		.mount(&server)
+		.await;
+
+	let tmp = tempfile::tempdir().expect("tempdir");
+	let target = tmp.path().join("vendor/x.js");
+	std::fs::create_dir_all(target.parent().expect("target parent")).expect("create vendor dir");
+	std::fs::write(&target, b"known previous contents").expect("write existing asset");
+
+	let url: &'static str = Box::leak(format!("{}/x.js", server.uri()).into_boxed_str());
+	let wrong_sha = "0000000000000000000000000000000000000000000000000000000000000000";
+	let assets = vec![AppVendorAsset {
+		app_label: "test",
+		url,
+		target: "vendor/x.js",
+		sha256: wrong_sha,
+	}];
+
+	// Act
+	let result = download_assets(tmp.path(), &assets, Verbosity::Silent).await;
+
+	// Assert
+	assert!(result.is_err(), "expected SHA mismatch error");
+	assert_eq!(request_count.load(Ordering::SeqCst), 1, "URL fetched once");
+	let contents = std::fs::read(&target).expect("existing asset remains readable");
+	assert_eq!(contents, b"known previous contents");
 }


### PR DESCRIPTION
### Motivation
- Prevent a critical TOCTOU where downloaded vendor bytes were persisted to the static tree before SHA-256 verification, allowing a mismatched (potentially malicious) response to replace served assets.
- Ensure the lazy first-request helper does not permanently suppress retries by marking an app/base_dir as "ensured" when a download or integrity check fails.

### Description
- Compute SHA-256 over the downloaded `bytes` and return `VendorDownloadError::IntegrityMismatch` if the computed digest does not match the pinned `sha256` before creating/persisting any file on disk (changes in `download_assets`).
- Preserve the existing behavior of logging a computed digest for empty/pinned-unknown assets while reusing the pre-install computed digest (no extra read from disk).
- Change `ensure_vendor_assets_for_app` so that on download/integrity error the ensured set is not updated in the soft-fail path, allowing retries on subsequent calls (soft-fail still returns `Ok(())` unless `REINHARDT_VENDOR_ASSETS_REQUIRED=1`).
- Add regression tests that assert a mismatching download is not installed and that existing files are not overwritten by mismatching responses (updates to `crates/reinhardt-utils/tests/vendor_pipeline.rs`).

### Testing
- Ran formatting check with `cargo fmt --all --check` (passed).
- Ran the vendor pipeline tests with mock HTTP server: `NO_PROXY=127.0.0.1,localhost cargo test -p reinhardt-utils --test vendor_pipeline -- --nocapture` and observed all `vendor_pipeline` tests passed.
- Performed `cargo check -p reinhardt-utils --all-features` and `cargo clippy -p reinhardt-utils --all-features -- -D warnings` (both passed).
- Note: a plain `cargo test -p reinhardt-utils --test vendor_pipeline -- --nocapture` in this environment initially failed due to local HTTP requests being proxied (HTTP 403), the same tests passed when `NO_PROXY` was set for localhost.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35de4fc6a883279056e99732281b43)