### PR TITLE
fix(middleware): keep session cleanup active above threshold

### DIFF
--- a/crates/reinhardt-middleware/src/session.rs
+++ b/crates/reinhardt-middleware/src/session.rs
@@ -325,6 +325,31 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn test_session_save_cleans_expired_entries_while_above_threshold() {
+		let store = SessionStore::with_cleanup_threshold(1);
+
+		let first_valid_session = SessionData::new(Duration::from_secs(3600));
+		let first_valid_id = first_valid_session.id.clone();
+		store.save(first_valid_session);
+
+		let second_valid_session = SessionData::new(Duration::from_secs(3600));
+		let second_valid_id = second_valid_session.id.clone();
+		store.save(second_valid_session);
+
+		assert_eq!(store.len(), 2);
+
+		let mut expired_session = SessionData::new(Duration::from_secs(3600));
+		let expired_id = expired_session.id.clone();
+		expired_session.expires_at = SystemTime::now() - Duration::from_millis(20);
+		store.save(expired_session);
+
+		assert_eq!(store.len(), 2);
+		assert!(store.get(&expired_id).is_none());
+		assert!(store.get(&first_valid_id).is_some());
+		assert!(store.get(&second_valid_id).is_some());
+	}
+
+	#[tokio::test]
 	async fn test_with_defaults_constructor() {
 		let middleware = SessionMiddleware::with_defaults();
 		let handler = Arc::new(TestHandler);

--- a/crates/reinhardt-middleware/src/session/store.rs
+++ b/crates/reinhardt-middleware/src/session/store.rs
@@ -57,23 +57,17 @@ impl SessionStore {
 
 	/// Save a session, with automatic cleanup when threshold is exceeded.
 	///
-	/// Cleanup is amortized: a full `retain` scan only runs when crossing
-	/// the threshold from below, not on every subsequent insert.
+	/// Cleanup runs whenever the post-save session count exceeds the
+	/// configured threshold, ensuring expired entries are eventually evicted
+	/// even if the store remains above the threshold for an extended period.
 	pub fn save(&self, session: SessionData) {
 		let mut sessions = self.sessions.write().unwrap_or_else(|e| e.into_inner());
-		let was_at_or_below = sessions.len()
-			<= self
-				.max_sessions_before_cleanup
-				.load(std::sync::atomic::Ordering::Relaxed);
 		sessions.insert(session.id.clone(), session);
 
-		// Lazy eviction: clean up expired sessions only on the transition
-		// from "<= threshold" to "> threshold" to avoid repeated full-map
-		// scans under the write lock on every subsequent save.
 		let threshold = self
 			.max_sessions_before_cleanup
 			.load(std::sync::atomic::Ordering::Relaxed);
-		if was_at_or_below && sessions.len() > threshold {
+		if sessions.len() > threshold {
 			sessions.retain(|_, s| s.is_valid());
 		}
 	}


### PR DESCRIPTION
### Motivation
- A recent refactor made `SessionStore::save` only run eviction when the map crossed the cleanup threshold from below, which can permanently disable automatic eviction if the first retain leaves the store above the threshold and later saves skip cleanup, enabling unbounded memory growth from repeated cookieless requests.

### Description
- Replace the transition-only gate in `SessionStore::save` so expired-session retention runs whenever the post-save session count exceeds the configured threshold. 
- Update the `save` doc comment to describe the corrected behavior. 
- Add a regression unit test `test_session_save_cleans_expired_entries_while_above_threshold` that verifies saving an expired session while the store is already above the threshold causes eviction of the expired entry while leaving valid sessions intact.

### Testing
- Ran `cargo test --package reinhardt-middleware --lib session_save_cleans_expired_entries_while_above_threshold`, which passed. 
- Ran `cargo fmt --package reinhardt-middleware --check`, which passed. 
- An attempt to run the broader targeted test invocation `cargo test --package reinhardt-middleware session_save_cleans_expired_entries_while_above_threshold` failed earlier before the unit test ran because integration tests import `security_middleware` while the `security` feature was not enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35c80ff49c8327a272fd7a7a1647b1)