### PR TITLE
fix(ci): block fork PRs from website self-hosted runners

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -81,8 +81,8 @@ jobs:
             fi
           fi
 
-          # AWS Spot runner selection (opt-in for PRs)
-          if [[ "$USE_MAC" == "false" ]] && [[ "$SELF_HOSTED_ENABLED" == "true" ]]; then
+          # AWS Spot runner selection (opt-in for trusted PRs)
+          if [[ "$USE_MAC" == "false" ]] && [[ "$SELF_HOSTED_ENABLED" == "true" ]] && [[ "$IS_FORK" != "true" ]]; then
             if [[ "$HEAD_REF" == release-plz-* ]]; then
               USE_AWS=true
             elif [[ "$ACTOR" == "$REPO_OWNER" ]]; then


### PR DESCRIPTION
### Motivation

- The website deployment workflow could select an AWS self-hosted runner for pull requests based solely on `github.head_ref` (e.g. `release-plz-*`), which allows forked PR authors to influence runner selection and execute attacker-controlled content on self-hosted infrastructure.

### Description

- Require `IS_FORK != "true"` in the AWS self-hosted selection branch of `determine-runner` in `/.github/workflows/deploy-website.yml`, aligning the AWS path with the existing Mac runner fork exclusion.
- Updated the AWS runner comment to clarify the selection is for trusted PRs only, and preserved same-repository `release-plz-*` and repository-owner opt-in behavior.

### Testing

- Executed a local runner-selection simulation using a Python script that exercises fork and same-repository PR cases and verified fork PRs with `HEAD_REF` like `release-plz-evil` now resolve to `ubuntu-latest` while trusted cases still select the self-hosted runner, and the simulation passed.
- Ran `git diff --check` to validate there are no whitespace or diff errors and it returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a357333abf88327bc455ae0fb189997)