### PR TITLE
fix(ci): exclude fork PRs from AWS runners

### DIFF
--- a/.github/workflows/determine-runner.yml
+++ b/.github/workflows/determine-runner.yml
@@ -13,6 +13,7 @@ name: Determine Runner
 #   Fork PRs are always excluded (security: untrusted code on local machine).
 #
 # AWS Spot: opt-in via PR checkbox when SELF_HOSTED_ENABLED=true.
+#   Fork PRs are always excluded (security: untrusted code on cloud runners).
 #   Budget circuit breaker sets SELF_HOSTED_ENABLED to "false" when exceeded.
 #
 # GitHub-hosted: fallback for fork PRs or when self-hosted is unavailable.
@@ -86,7 +87,7 @@ jobs:
           fi
 
           # --- AWS Spot runner selection (opt-in) ---
-          if [[ "$USE_MAC" == "false" ]] && [[ "$SELF_HOSTED_ENABLED" == "true" ]]; then
+          if [[ "$USE_MAC" == "false" ]] && [[ "$SELF_HOSTED_ENABLED" == "true" ]] && [[ "$IS_FORK" != "true" ]]; then
             if [[ "$HEAD_REF" == release-plz-* ]]; then
               USE_AWS=true
             elif [[ "$ACTOR" == "$REPO_OWNER" ]]; then


### PR DESCRIPTION
### Motivation
- Prevent fork pull requests (including forged `release-plz-*` branch names) from selecting self-hosted AWS runners so untrusted PR code cannot execute on internal CI infrastructure.

### Description
- Add a fork-exclusion guard to the AWS Spot/self-hosted selection in `.github/workflows/determine-runner.yml` by requiring `[[ "$IS_FORK" != "true" ]]` on the AWS path and add a clarifying comment about excluding fork PRs for cloud runners.

### Testing
- Executed automated checks: a `python` assertion verified the inserted `[[ "$IS_FORK" != "true" ]]` guard and comment are present, and a runner-selection simulation script validated that fork PRs now fall back to `"ubuntu-latest"` while trusted in-repo release/owner flows may select the `reinhardt-ci` runner, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356d690b5c8327a4be7d81ff91060b)