### PR TITLE
fix(views): wire declared viewset serializers

### DIFF
--- a/crates/reinhardt-views/src/openapi_inspector.rs
+++ b/crates/reinhardt-views/src/openapi_inspector.rs
@@ -763,9 +763,6 @@ mod tests {
 		}
 	}
 
-	#[derive(Debug, Clone)]
-	struct TestSerializer;
-
 	#[test]
 	fn test_viewset_inspector_new() {
 		let inspector = ViewSetInspector::new();
@@ -775,7 +772,10 @@ mod tests {
 
 	#[test]
 	fn test_extract_paths_returns_collection_and_detail() {
-		let viewset = ModelViewSet::<TestModel, TestSerializer>::new("users");
+		let viewset = ModelViewSet::<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		>::new("users");
 		let inspector = ViewSetInspector::new();
 		let paths = inspector.extract_paths(&viewset, "/api/users");
 
@@ -785,7 +785,10 @@ mod tests {
 
 	#[test]
 	fn test_extract_operations_includes_crud() {
-		let viewset = ModelViewSet::<TestModel, TestSerializer>::new("users");
+		let viewset = ModelViewSet::<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		>::new("users");
 		let inspector = ViewSetInspector::new();
 		let operations = inspector.extract_operations(&viewset);
 

--- a/crates/reinhardt-views/src/viewsets.rs
+++ b/crates/reinhardt-views/src/viewsets.rs
@@ -293,9 +293,6 @@ mod tests {
 		}
 	}
 
-	#[derive(Debug, Clone)]
-	struct TestSerializer;
-
 	#[tokio::test]
 	async fn test_viewset_get_basename() {
 		let viewset = GenericViewSet::new("test", ());
@@ -304,7 +301,10 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_model_viewset_list_action() {
-		let viewset: ModelViewSet<TestModel, TestSerializer> = ModelViewSet::new("users");
+		let viewset: ModelViewSet<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		> = ModelViewSet::new("users");
 		let request = Request::builder()
 			.method(Method::GET)
 			.uri("/users/")
@@ -325,11 +325,13 @@ mod tests {
 		// Provide an in-memory queryset and populate path_params so dispatch
 		// resolves through the embedded ModelViewSetHandler. This guards against
 		// the placeholder regression behind issue #3985.
-		let viewset: ModelViewSet<TestModel, TestSerializer> = ModelViewSet::new("users")
-			.with_queryset(vec![TestModel {
-				id: Some(1),
-				name: "alpha".into(),
-			}]);
+		let viewset: ModelViewSet<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		> = ModelViewSet::new("users").with_queryset(vec![TestModel {
+			id: Some(1),
+			name: "alpha".into(),
+		}]);
 		let mut path_params = HashMap::new();
 		path_params.insert("id".to_string(), "1".to_string());
 		let request = Request::builder()
@@ -354,7 +356,10 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_model_viewset_create_action() {
-		let viewset: ModelViewSet<TestModel, TestSerializer> = ModelViewSet::new("users");
+		let viewset: ModelViewSet<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		> = ModelViewSet::new("users");
 		let request = Request::builder()
 			.method(Method::POST)
 			.uri("/users/")
@@ -372,11 +377,13 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_model_viewset_update_action() {
-		let viewset: ModelViewSet<TestModel, TestSerializer> = ModelViewSet::new("users")
-			.with_queryset(vec![TestModel {
-				id: Some(1),
-				name: "alpha".into(),
-			}]);
+		let viewset: ModelViewSet<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		> = ModelViewSet::new("users").with_queryset(vec![TestModel {
+			id: Some(1),
+			name: "alpha".into(),
+		}]);
 		let mut path_params = HashMap::new();
 		path_params.insert("id".to_string(), "1".to_string());
 		let request = Request::builder()
@@ -397,11 +404,13 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_model_viewset_destroy_action() {
-		let viewset: ModelViewSet<TestModel, TestSerializer> = ModelViewSet::new("users")
-			.with_queryset(vec![TestModel {
-				id: Some(1),
-				name: "alpha".into(),
-			}]);
+		let viewset: ModelViewSet<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		> = ModelViewSet::new("users").with_queryset(vec![TestModel {
+			id: Some(1),
+			name: "alpha".into(),
+		}]);
 		let mut path_params = HashMap::new();
 		path_params.insert("id".to_string(), "1".to_string());
 		let request = Request::builder()
@@ -422,8 +431,10 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_readonly_viewset_list_allowed() {
-		let viewset: ReadOnlyModelViewSet<TestModel, TestSerializer> =
-			ReadOnlyModelViewSet::new("posts");
+		let viewset: ReadOnlyModelViewSet<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		> = ReadOnlyModelViewSet::new("posts");
 		let request = Request::builder()
 			.method(Method::GET)
 			.uri("/posts/")
@@ -441,11 +452,13 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_readonly_viewset_retrieve_allowed() {
-		let viewset: ReadOnlyModelViewSet<TestModel, TestSerializer> =
-			ReadOnlyModelViewSet::new("posts").with_queryset(vec![TestModel {
-				id: Some(1),
-				name: "alpha".into(),
-			}]);
+		let viewset: ReadOnlyModelViewSet<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		> = ReadOnlyModelViewSet::new("posts").with_queryset(vec![TestModel {
+			id: Some(1),
+			name: "alpha".into(),
+		}]);
 		let mut path_params = HashMap::new();
 		path_params.insert("id".to_string(), "1".to_string());
 		let request = Request::builder()
@@ -470,8 +483,10 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_readonly_viewset_create_denied() {
-		let viewset: ReadOnlyModelViewSet<TestModel, TestSerializer> =
-			ReadOnlyModelViewSet::new("posts");
+		let viewset: ReadOnlyModelViewSet<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		> = ReadOnlyModelViewSet::new("posts");
 		let request = Request::builder()
 			.method(Method::POST)
 			.uri("/posts/")
@@ -489,8 +504,10 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_readonly_viewset_delete_denied() {
-		let viewset: ReadOnlyModelViewSet<TestModel, TestSerializer> =
-			ReadOnlyModelViewSet::new("posts");
+		let viewset: ReadOnlyModelViewSet<
+			TestModel,
+			reinhardt_rest::serializers::JsonSerializer<TestModel>,
+		> = ReadOnlyModelViewSet::new("posts");
 		let request = Request::builder()
 			.method(Method::DELETE)
 			.uri("/posts/1/")

--- a/crates/reinhardt-views/src/viewsets/viewset.rs
+++ b/crates/reinhardt-views/src/viewsets/viewset.rs
@@ -208,7 +208,7 @@ impl<T: Send + Sync> ViewSet for GenericViewSet<T> {
 pub struct ModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 	basename: String,
 	lookup_field: String,
@@ -223,7 +223,7 @@ where
 impl<M, S> FilterableViewSet for ModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 	fn get_filter_config(&self) -> Option<FilterConfig> {
 		self.filter_config.clone()
@@ -237,7 +237,7 @@ where
 impl<M, S> ModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 	/// Creates a new `ModelViewSet` with the given basename.
 	///
@@ -281,7 +281,7 @@ where
 			pagination_config: Some(PaginationConfig::default()),
 			filter_config: None,
 			ordering_config: None,
-			handler: ModelViewSetHandler::<M>::new(),
+			handler: ModelViewSetHandler::<M>::new().with_serializer(Arc::new(S::default())),
 			_serializer: PhantomData,
 		}
 	}
@@ -318,7 +318,7 @@ where
 	///     fn new_fields() -> Self::Fields { UserFields }
 	/// }
 	///
-	/// let viewset = ModelViewSet::<User, ()>::new("users")
+	/// let viewset = ModelViewSet::<User, reinhardt_rest::serializers::JsonSerializer<User>>::new("users")
 	///     .with_lookup_field("username");
 	/// assert_eq!(viewset.get_lookup_field(), "username");
 	/// ```
@@ -348,15 +348,15 @@ where
 	/// #     fn new_fields() -> Self::Fields { ItemFields }
 	/// # }
 	/// // Page number pagination with custom page size
-	/// let viewset = ModelViewSet::<Item, ()>::new("items")
+	/// let viewset = ModelViewSet::<Item, reinhardt_rest::serializers::JsonSerializer<Item>>::new("items")
 	///     .with_pagination(PaginationConfig::page_number(20, Some(100)));
 	///
 	/// // Limit/offset pagination
-	/// let viewset = ModelViewSet::<Item, ()>::new("items")
+	/// let viewset = ModelViewSet::<Item, reinhardt_rest::serializers::JsonSerializer<Item>>::new("items")
 	///     .with_pagination(PaginationConfig::limit_offset(25, Some(500)));
 	///
 	/// // Disable pagination
-	/// let viewset = ModelViewSet::<Item, ()>::new("items")
+	/// let viewset = ModelViewSet::<Item, reinhardt_rest::serializers::JsonSerializer<Item>>::new("items")
 	///     .with_pagination(PaginationConfig::none());
 	/// ```
 	pub fn with_pagination(mut self, config: PaginationConfig) -> Self {
@@ -384,7 +384,7 @@ where
 	/// #     fn set_primary_key(&mut self, v: i64) { self.id = Some(v); }
 	/// #     fn new_fields() -> Self::Fields { ItemFields }
 	/// # }
-	/// let viewset = ModelViewSet::<Item, ()>::new("items")
+	/// let viewset = ModelViewSet::<Item, reinhardt_rest::serializers::JsonSerializer<Item>>::new("items")
 	///     .without_pagination();
 	/// ```
 	pub fn without_pagination(mut self) -> Self {
@@ -412,7 +412,7 @@ where
 	/// #     fn set_primary_key(&mut self, v: i64) { self.id = Some(v); }
 	/// #     fn new_fields() -> Self::Fields { ItemFields }
 	/// # }
-	/// let viewset = ModelViewSet::<Item, ()>::new("items")
+	/// let viewset = ModelViewSet::<Item, reinhardt_rest::serializers::JsonSerializer<Item>>::new("items")
 	///     .with_filters(
 	///         FilterConfig::new()
 	///             .with_filterable_fields(vec!["status", "category"])
@@ -444,7 +444,7 @@ where
 	/// #     fn set_primary_key(&mut self, v: i64) { self.id = Some(v); }
 	/// #     fn new_fields() -> Self::Fields { ItemFields }
 	/// # }
-	/// let viewset = ModelViewSet::<Item, ()>::new("items")
+	/// let viewset = ModelViewSet::<Item, reinhardt_rest::serializers::JsonSerializer<Item>>::new("items")
 	///     .with_ordering(
 	///         OrderingConfig::new()
 	///             .with_ordering_fields(vec!["created_at", "title", "id"])
@@ -509,7 +509,7 @@ where
 impl<M, S> ViewSet for ModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 	fn get_basename(&self) -> &str {
 		&self.basename
@@ -550,7 +550,7 @@ where
 impl<M, S> PaginatedViewSet for ModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 	fn get_pagination_config(&self) -> Option<PaginationConfig> {
 		self.pagination_config.clone()
@@ -564,7 +564,7 @@ where
 pub struct ReadOnlyModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 	basename: String,
 	lookup_field: String,
@@ -578,7 +578,7 @@ where
 impl<M, S> ReadOnlyModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 	/// Creates a new `ReadOnlyModelViewSet` with the given basename.
 	///
@@ -622,7 +622,7 @@ where
 			pagination_config: Some(PaginationConfig::default()),
 			filter_config: None,
 			ordering_config: None,
-			handler: ModelViewSetHandler::<M>::new(),
+			handler: ModelViewSetHandler::<M>::new().with_serializer(Arc::new(S::default())),
 			_serializer: PhantomData,
 		}
 	}
@@ -733,7 +733,7 @@ where
 impl<M, S> ViewSet for ReadOnlyModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 	fn get_basename(&self) -> &str {
 		&self.basename
@@ -762,7 +762,7 @@ where
 impl<M, S> PaginatedViewSet for ReadOnlyModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 	fn get_pagination_config(&self) -> Option<PaginationConfig> {
 		self.pagination_config.clone()
@@ -773,7 +773,7 @@ where
 impl<M, S> FilterableViewSet for ReadOnlyModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 	fn get_filter_config(&self) -> Option<FilterConfig> {
 		self.filter_config.clone()
@@ -796,26 +796,26 @@ where
 impl<M, S> std::panic::UnwindSafe for ModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 }
 impl<M, S> std::panic::RefUnwindSafe for ModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 }
 
 impl<M, S> std::panic::UnwindSafe for ReadOnlyModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 }
 impl<M, S> std::panic::RefUnwindSafe for ReadOnlyModelViewSet<M, S>
 where
 	M: Model + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-	S: Send + Sync + 'static,
+	S: Serializer<Input = M, Output = String> + Default + Send + Sync + 'static,
 {
 }
 
@@ -829,11 +829,11 @@ mod tests {
 	use std::sync::Arc;
 
 	/// Minimal `Model` implementation used to satisfy the `ModelViewSet` trait
-	/// bounds in unit tests. The previous tests used `ModelViewSet::<(), ()>`,
-	/// but bare `()` does not implement `Model` once the bounds were tightened.
+	/// bounds in unit tests.
 	#[derive(Debug, Clone, Serialize, Deserialize)]
 	struct DummyModel {
 		id: Option<i64>,
+		secret: String,
 	}
 
 	#[derive(Clone)]
@@ -863,9 +863,71 @@ mod tests {
 		}
 	}
 
+	#[derive(Default)]
+	struct RedactingDummySerializer;
+
+	impl Serializer for RedactingDummySerializer {
+		type Input = DummyModel;
+		type Output = String;
+
+		fn serialize(
+			&self,
+			input: &Self::Input,
+		) -> std::result::Result<Self::Output, reinhardt_rest::serializers::SerializerError> {
+			serde_json::to_string(&serde_json::json!({ "id": input.id })).map_err(|e| {
+				reinhardt_rest::serializers::SerializerError::Serde {
+					message: format!("Serialization error: {}", e),
+				}
+			})
+		}
+
+		fn deserialize(
+			&self,
+			output: &Self::Output,
+		) -> std::result::Result<Self::Input, reinhardt_rest::serializers::SerializerError> {
+			let value: serde_json::Value = serde_json::from_str(output).map_err(|e| {
+				reinhardt_rest::serializers::SerializerError::Serde {
+					message: format!("Deserialization error: {}", e),
+				}
+			})?;
+			if value.get("secret").is_some() {
+				return Err(reinhardt_rest::serializers::SerializerError::Serde {
+					message: "secret is not writable".to_string(),
+				});
+			}
+			Ok(DummyModel {
+				id: value.get("id").and_then(serde_json::Value::as_i64),
+				secret: String::new(),
+			})
+		}
+	}
+
+	#[tokio::test]
+	async fn test_model_viewset_new_wires_declared_serializer() {
+		let viewset = ModelViewSet::<DummyModel, RedactingDummySerializer>::new("test")
+			.with_queryset(vec![DummyModel {
+				id: Some(7),
+				secret: "hidden".to_string(),
+			}]);
+		let request = Request::builder()
+			.method(Method::GET)
+			.uri("/test/")
+			.body(bytes::Bytes::new())
+			.build()
+			.unwrap();
+
+		let response = viewset.dispatch(request, Action::list()).await.unwrap();
+
+		assert_eq!(response.status, hyper::StatusCode::OK);
+		assert_eq!(response.body, bytes::Bytes::from_static(br#"[{"id":7}]"#));
+	}
+
 	#[tokio::test]
 	async fn test_viewset_builder_validation_empty_actions() {
-		let viewset = ModelViewSet::<DummyModel, ()>::new("test");
+		let viewset = ModelViewSet::<
+			DummyModel,
+			reinhardt_rest::serializers::JsonSerializer<DummyModel>,
+		>::new("test");
 		let builder = viewset.as_view();
 
 		// Test that empty actions causes build to fail
@@ -884,7 +946,10 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_viewset_builder_name_suffix_mutual_exclusivity() {
-		let viewset = ModelViewSet::<DummyModel, ()>::new("test");
+		let viewset = ModelViewSet::<
+			DummyModel,
+			reinhardt_rest::serializers::JsonSerializer<DummyModel>,
+		>::new("test");
 		let builder = viewset.as_view();
 
 		// Test that providing both name and suffix fails
@@ -903,7 +968,10 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_viewset_builder_successful_build() {
-		let viewset = ModelViewSet::<DummyModel, ()>::new("test");
+		let viewset = ModelViewSet::<
+			DummyModel,
+			reinhardt_rest::serializers::JsonSerializer<DummyModel>,
+		>::new("test");
 		let mut actions = HashMap::new();
 		actions.insert(Method::GET, "list".to_string());
 
@@ -919,7 +987,10 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_viewset_builder_with_name() {
-		let viewset = ModelViewSet::<DummyModel, ()>::new("test");
+		let viewset = ModelViewSet::<
+			DummyModel,
+			reinhardt_rest::serializers::JsonSerializer<DummyModel>,
+		>::new("test");
 		let mut actions = HashMap::new();
 		actions.insert(Method::GET, "list".to_string());
 
@@ -934,7 +1005,10 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_viewset_builder_with_suffix() {
-		let viewset = ModelViewSet::<DummyModel, ()>::new("test");
+		let viewset = ModelViewSet::<
+			DummyModel,
+			reinhardt_rest::serializers::JsonSerializer<DummyModel>,
+		>::new("test");
 		let mut actions = HashMap::new();
 		actions.insert(Method::GET, "list".to_string());
 

--- a/tests/integration/tests/rest/openapi_parameter_recognition_tests.rs
+++ b/tests/integration/tests/rest/openapi_parameter_recognition_tests.rs
@@ -49,10 +49,6 @@ struct TestUser {
 	is_active: bool,
 }
 
-/// Dummy serializer for ViewSet-based tests
-#[derive(Debug, Clone)]
-struct TestUserSerializer;
-
 /// Fixture: ViewSetInspector with default config
 #[fixture]
 fn inspector() -> ViewSetInspector {
@@ -70,8 +66,8 @@ fn generator() -> SchemaGenerator {
 
 /// Fixture: ModelViewSet for users
 #[fixture]
-fn user_viewset() -> ModelViewSet<TestUser, TestUserSerializer> {
-	ModelViewSet::<TestUser, TestUserSerializer>::new("users")
+fn user_viewset() -> ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>> {
+	ModelViewSet::<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>::new("users")
 }
 
 /// Helper: Create a minimal OpenAPI schema for UI tests
@@ -158,7 +154,7 @@ fn test_path_param_string_type_metadata() {
 #[rstest]
 fn test_viewset_generates_collection_and_detail_paths(
 	inspector: ViewSetInspector,
-	user_viewset: ModelViewSet<TestUser, TestUserSerializer>,
+	user_viewset: ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>,
 ) {
 	// Arrange (fixtures provide inspector and viewset)
 
@@ -193,7 +189,7 @@ fn test_viewset_generates_collection_and_detail_paths(
 #[rstest]
 fn test_viewset_detail_operations_have_id_parameter(
 	inspector: ViewSetInspector,
-	user_viewset: ModelViewSet<TestUser, TestUserSerializer>,
+	user_viewset: ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>,
 ) {
 	// Arrange
 	let paths = inspector.extract_paths(&user_viewset, "/api/users");
@@ -265,7 +261,7 @@ fn test_path_param_trait_various_types() {
 #[rstest]
 fn test_json_output_includes_path_parameters(
 	inspector: ViewSetInspector,
-	user_viewset: ModelViewSet<TestUser, TestUserSerializer>,
+	user_viewset: ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>,
 ) {
 	// Arrange
 	let paths = inspector.extract_paths(&user_viewset, "/api/users");
@@ -313,7 +309,7 @@ fn test_json_output_includes_path_parameters(
 #[rstest]
 fn test_viewset_post_operation_has_request_body(
 	inspector: ViewSetInspector,
-	user_viewset: ModelViewSet<TestUser, TestUserSerializer>,
+	user_viewset: ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>,
 ) {
 	// Arrange
 	let paths = inspector.extract_paths(&user_viewset, "/api/users");
@@ -340,7 +336,7 @@ fn test_viewset_post_operation_has_request_body(
 #[rstest]
 fn test_viewset_put_operation_exists(
 	inspector: ViewSetInspector,
-	user_viewset: ModelViewSet<TestUser, TestUserSerializer>,
+	user_viewset: ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>,
 ) {
 	// Arrange
 	let paths = inspector.extract_paths(&user_viewset, "/api/users");
@@ -360,7 +356,7 @@ fn test_viewset_put_operation_exists(
 #[rstest]
 fn test_viewset_patch_operation_exists(
 	inspector: ViewSetInspector,
-	user_viewset: ModelViewSet<TestUser, TestUserSerializer>,
+	user_viewset: ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>,
 ) {
 	// Arrange
 	let paths = inspector.extract_paths(&user_viewset, "/api/users");
@@ -380,7 +376,7 @@ fn test_viewset_patch_operation_exists(
 #[rstest]
 fn test_viewset_get_operation_has_no_request_body(
 	inspector: ViewSetInspector,
-	user_viewset: ModelViewSet<TestUser, TestUserSerializer>,
+	user_viewset: ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>,
 ) {
 	// Arrange
 	let paths = inspector.extract_paths(&user_viewset, "/api/users");
@@ -402,7 +398,7 @@ fn test_viewset_get_operation_has_no_request_body(
 #[rstest]
 fn test_viewset_delete_operation_has_no_request_body(
 	inspector: ViewSetInspector,
-	user_viewset: ModelViewSet<TestUser, TestUserSerializer>,
+	user_viewset: ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>,
 ) {
 	// Arrange
 	let paths = inspector.extract_paths(&user_viewset, "/api/users");
@@ -487,7 +483,7 @@ fn test_registry_schema_registration_for_body(mut generator: SchemaGenerator) {
 #[rstest]
 fn test_viewset_crud_body_presence(
 	inspector: ViewSetInspector,
-	user_viewset: ModelViewSet<TestUser, TestUserSerializer>,
+	user_viewset: ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>,
 ) {
 	// Arrange
 	let paths = inspector.extract_paths(&user_viewset, "/api/users");
@@ -1512,7 +1508,7 @@ fn test_full_pipeline_json_structure(mut generator: SchemaGenerator) {
 #[rstest]
 fn test_viewset_generator_integration(
 	inspector: ViewSetInspector,
-	user_viewset: ModelViewSet<TestUser, TestUserSerializer>,
+	user_viewset: ModelViewSet<TestUser, reinhardt_rest::serializers::JsonSerializer<TestUser>>,
 	generator: SchemaGenerator,
 ) {
 	// Arrange

--- a/tests/integration/tests/rest/openapi_schema_generation_integration.rs
+++ b/tests/integration/tests/rest/openapi_schema_generation_integration.rs
@@ -37,16 +37,11 @@ struct User {
 	is_active: bool,
 }
 
-/// User serializer for testing
-#[derive(Debug, Clone)]
-struct UserSerializer;
-
 // Note: tests below that need a "second" model reuse `User` with a different
 // basename rather than introducing a separate `Post` struct. The `#[model]`
 // macro currently fails to generate `impl Model` for a second `#[model]`
-// struct in the same module — see Reinhardt #3985 follow-up. Reusing `User`
-// with `ModelViewSet::<User, UserSerializer>::new("posts")` is enough to
-// exercise multi-viewset path generation.
+// struct in the same module — see Reinhardt #3985 follow-up. Reusing `User` with `ModelViewSet::<User, JsonSerializer<User>>::new("posts")`
+// is enough to exercise multi-viewset path generation.
 
 /// Fixture: ViewSetInspector
 #[fixture]
@@ -73,7 +68,8 @@ fn generator() -> SchemaGenerator {
 #[test]
 fn test_model_viewset_openapi_paths_generation(inspector: ViewSetInspector) {
 	// Build ModelViewSet
-	let viewset = ModelViewSet::<User, UserSerializer>::new("users");
+	let viewset =
+		ModelViewSet::<User, reinhardt_rest::serializers::JsonSerializer<User>>::new("users");
 
 	// Extract paths
 	let paths = inspector.extract_paths(&viewset, "/api/users");
@@ -155,7 +151,10 @@ fn test_model_viewset_openapi_paths_generation(inspector: ViewSetInspector) {
 #[test]
 fn test_readonly_viewset_openapi_schema(inspector: ViewSetInspector) {
 	// Build ReadOnlyModelViewSet
-	let viewset = ReadOnlyModelViewSet::<User, UserSerializer>::new("users");
+	let viewset =
+		ReadOnlyModelViewSet::<User, reinhardt_rest::serializers::JsonSerializer<User>>::new(
+			"users",
+		);
 
 	// Extract paths
 	let paths = inspector.extract_paths(&viewset, "/api/users");
@@ -225,7 +224,8 @@ fn test_complete_openapi_schema_generation(
 	generator: SchemaGenerator,
 ) {
 	// Extract path information from ViewSet
-	let viewset = ModelViewSet::<User, UserSerializer>::new("users");
+	let viewset =
+		ModelViewSet::<User, reinhardt_rest::serializers::JsonSerializer<User>>::new("users");
 	let paths = inspector.extract_paths(&viewset, "/api/users");
 
 	// Verify that paths were generated
@@ -268,7 +268,8 @@ fn test_complete_openapi_schema_generation(
 #[rstest]
 #[test]
 fn test_viewset_response_schema_generation(inspector: ViewSetInspector) {
-	let viewset = ModelViewSet::<User, UserSerializer>::new("users");
+	let viewset =
+		ModelViewSet::<User, reinhardt_rest::serializers::JsonSerializer<User>>::new("users");
 	let paths = inspector.extract_paths(&viewset, "/api/users");
 
 	// GET operation on collection endpoint
@@ -333,7 +334,8 @@ fn test_inspector_config_customization() {
 	let inspector = ViewSetInspector::with_config(config);
 
 	// Build ViewSet
-	let viewset = ModelViewSet::<User, UserSerializer>::new("users");
+	let viewset =
+		ModelViewSet::<User, reinhardt_rest::serializers::JsonSerializer<User>>::new("users");
 
 	// Extract paths
 	let paths = inspector.extract_paths(&viewset, "/api/users");
@@ -370,13 +372,15 @@ fn test_inspector_config_customization() {
 #[test]
 fn test_multiple_viewsets_path_generation(inspector: ViewSetInspector) {
 	// User ViewSet
-	let user_viewset = ModelViewSet::<User, UserSerializer>::new("users");
+	let user_viewset =
+		ModelViewSet::<User, reinhardt_rest::serializers::JsonSerializer<User>>::new("users");
 	let user_paths = inspector.extract_paths(&user_viewset, "/api/users");
 
 	// Reuse the User model with a different basename — see file-top note about
 	// the macro limitation that prevents introducing a second `#[model]` struct
 	// in this module.
-	let post_viewset = ModelViewSet::<User, UserSerializer>::new("posts");
+	let post_viewset =
+		ModelViewSet::<User, reinhardt_rest::serializers::JsonSerializer<User>>::new("posts");
 	let post_paths = inspector.extract_paths(&post_viewset, "/api/posts");
 
 	// User paths


### PR DESCRIPTION
### Motivation
- Prevent `ModelViewSet`/`ReadOnlyModelViewSet` from silently falling back to `ModelSerializer` when a serializer type `S` is declared, which leaked raw model fields and allowed mass-assignment of protected fields.

### Description
- Require the viewset serializer type `S` to implement `Serializer<Input = M, Output = String> + Default + Send + Sync + 'static` and store it as a real serializer contract rather than a `PhantomData` placeholder.
- Initialize the embedded `ModelViewSetHandler` in `ModelViewSet::new()` and `ReadOnlyModelViewSet::new()` with `S::default()` via `with_serializer(...)` so the declared serializer is used by default for CRUD operations.
- Update tests and OpenAPI inspector examples to use concrete `JsonSerializer` types where custom serializer behavior is not required, and add a regression unit test (`RedactingDummySerializer`) that verifies `ModelViewSet::new()` honors the declared serializer without an explicit `with_serializer()` call.

### Testing
- Ran `cargo check -p reinhardt-views --all-features` and it completed successfully.
- Ran the new unit test: `cargo test -p reinhardt-views --lib viewsets::viewset::tests::test_model_viewset_new_wires_declared_serializer -- --nocapture` and it passed (`1 passed; 0 failed`).
- Ran formatting check `cargo fmt --all -- --check` and it passed; `cargo make fmt-check` was not available in the environment so `cargo fmt` was used instead.
- Built integration-tests artifact with `cargo test -p reinhardt-integration-tests --test rest --no-run` (compile-only) and it completed successfully.
- Ran `cargo clippy -p reinhardt-views --all-features -- -D warnings` and it completed without warnings (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35f890d7e08327a6041c9143e5c674)