### PR TITLE
fix(middleware): amortize session cleanup

### DIFF
--- a/crates/reinhardt-middleware/src/session.rs
+++ b/crates/reinhardt-middleware/src/session.rs
@@ -350,6 +350,35 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn test_session_save_uses_amortized_cleanup_while_above_threshold() {
+		let store = SessionStore::with_cleanup_threshold(2);
+
+		let first_valid_session = SessionData::new(Duration::from_secs(3600));
+		let second_valid_session = SessionData::new(Duration::from_secs(3600));
+		let third_valid_session = SessionData::new(Duration::from_secs(3600));
+		store.save(first_valid_session);
+		store.save(second_valid_session);
+		store.save(third_valid_session);
+
+		let mut first_expired_session = SessionData::new(Duration::from_secs(3600));
+		let first_expired_id = first_expired_session.id.clone();
+		first_expired_session.expires_at = SystemTime::now() - Duration::from_millis(20);
+		store.save(first_expired_session);
+
+		assert_eq!(store.len(), 4);
+		assert!(store.get(&first_expired_id).is_some());
+
+		let mut second_expired_session = SessionData::new(Duration::from_secs(3600));
+		let second_expired_id = second_expired_session.id.clone();
+		second_expired_session.expires_at = SystemTime::now() - Duration::from_millis(20);
+		store.save(second_expired_session);
+
+		assert_eq!(store.len(), 3);
+		assert!(store.get(&first_expired_id).is_none());
+		assert!(store.get(&second_expired_id).is_none());
+	}
+
+	#[tokio::test]
 	async fn test_with_defaults_constructor() {
 		let middleware = SessionMiddleware::with_defaults();
 		let handler = Arc::new(TestHandler);

--- a/crates/reinhardt-middleware/src/session/store.rs
+++ b/crates/reinhardt-middleware/src/session/store.rs
@@ -2,24 +2,33 @@
 
 use std::collections::HashMap;
 use std::sync::RwLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::data::SessionData;
 
 /// Session store with automatic lazy eviction of expired sessions
 ///
 /// Performs threshold-based lazy cleanup of expired sessions to prevent
-/// unbounded memory growth. Cleanup is triggered inside `save` whenever the
-/// total number of stored sessions exceeds the configured threshold; it is
-/// not time-based. The threshold defaults to
+/// unbounded memory growth. Cleanup is triggered inside `save` when the
+/// total number of stored sessions crosses an amortized cleanup boundary; it
+/// is not time-based. The threshold defaults to
 /// `SessionStore::DEFAULT_CLEANUP_THRESHOLD` and can be overridden at
 /// construction via `SessionStore::with_cleanup_threshold` or adjusted at
 /// runtime via `SessionStore::set_cleanup_threshold`.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SessionStore {
 	/// Sessions
 	pub(super) sessions: RwLock<HashMap<String, SessionData>>,
 	/// Maximum number of sessions before triggering automatic cleanup
-	max_sessions_before_cleanup: std::sync::atomic::AtomicUsize,
+	max_sessions_before_cleanup: AtomicUsize,
+	/// Next session count at which `save` should perform cleanup.
+	next_cleanup_session_count: AtomicUsize,
+}
+
+impl Default for SessionStore {
+	fn default() -> Self {
+		Self::new()
+	}
 }
 
 impl SessionStore {
@@ -35,18 +44,21 @@ impl SessionStore {
 	/// Create a new store with a custom cleanup threshold.
 	///
 	/// The store triggers a single `retain` pass inside `save` whenever the
-	/// number of stored sessions exceeds `threshold`.
+	/// number of stored sessions crosses an amortized cleanup boundary.
 	pub fn with_cleanup_threshold(threshold: usize) -> Self {
 		Self {
 			sessions: RwLock::new(HashMap::new()),
-			max_sessions_before_cleanup: std::sync::atomic::AtomicUsize::new(threshold),
+			max_sessions_before_cleanup: AtomicUsize::new(threshold),
+			next_cleanup_session_count: AtomicUsize::new(threshold),
 		}
 	}
 
 	/// Update the cleanup threshold at runtime.
 	pub fn set_cleanup_threshold(&self, threshold: usize) {
 		self.max_sessions_before_cleanup
-			.store(threshold, std::sync::atomic::Ordering::Relaxed);
+			.store(threshold, Ordering::Relaxed);
+		self.next_cleanup_session_count
+			.store(threshold, Ordering::Relaxed);
 	}
 
 	/// Get a session
@@ -57,18 +69,24 @@ impl SessionStore {
 
 	/// Save a session, with automatic cleanup when threshold is exceeded.
 	///
-	/// Cleanup runs whenever the post-save session count exceeds the
-	/// configured threshold, ensuring expired entries are eventually evicted
-	/// even if the store remains above the threshold for an extended period.
+	/// Cleanup runs when the post-save session count exceeds the configured
+	/// threshold and reaches the next amortized cleanup boundary. The boundary
+	/// advances after each pass so a store that remains above the threshold does
+	/// not scan all sessions on every save.
 	pub fn save(&self, session: SessionData) {
 		let mut sessions = self.sessions.write().unwrap_or_else(|e| e.into_inner());
 		sessions.insert(session.id.clone(), session);
 
-		let threshold = self
-			.max_sessions_before_cleanup
-			.load(std::sync::atomic::Ordering::Relaxed);
-		if sessions.len() > threshold {
+		let threshold = self.max_sessions_before_cleanup.load(Ordering::Relaxed);
+		let next_cleanup_session_count = self.next_cleanup_session_count.load(Ordering::Relaxed);
+		if sessions.len() > threshold && sessions.len() >= next_cleanup_session_count {
 			sessions.retain(|_, s| s.is_valid());
+
+			let cleanup_interval = threshold.max(1);
+			self.next_cleanup_session_count.store(
+				sessions.len().saturating_add(cleanup_interval),
+				Ordering::Relaxed,
+			);
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Fix an availability regression where the in-memory session store would run a full `HashMap::retain` on every `save` once the store exceeded the cleanup threshold, causing O(n) per-request scans and writer lock contention that can be triggered remotely.
- Preserve the existing lazy expired-session eviction behavior while preventing recurring full-map scans that degrade throughput under high session counts.

### Description
- Add `next_cleanup_session_count: AtomicUsize` to `SessionStore` to track the next amortized cleanup boundary and initialize/reset it in constructors and `set_cleanup_threshold`.
- Update `save` to perform `sessions.retain(|_, s| s.is_valid())` only when `sessions.len() >= next_cleanup_session_count`, and advance `next_cleanup_session_count` by an interval (`cleanup_interval = threshold.max(1)`) after each cleanup pass.
- Provide a `Default` impl for `SessionStore` and add a regression test `test_session_save_uses_amortized_cleanup_while_above_threshold` that verifies amortized cleanup behavior while above the threshold.

### Testing
- Ran unit tests in the middleware crate and the new/regression tests passed: `cargo test -p reinhardt-middleware --lib` (including `test_session_save_cleans_expired_entries_while_above_threshold` and `test_session_save_uses_amortized_cleanup_while_above_threshold`).
- Ran formatting and diff checks which succeeded: `cargo fmt --check` and `git diff --check`.
- Note: `cargo make fmt-check` (project helper) was not available in the execution environment and therefore was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3607ee47888327acc539d7d8ce669d)