### PR TITLE
fix(ci): exclude organizations from Terraform automation

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -29,11 +29,12 @@ jobs:
           # Note: `bootstrap` is intentionally excluded — its local backend
           # does not persist across CI runs, so apply would always fail with
           # `BucketAlreadyExists`. Apply manually. See reinhardt-web#4145.
+          # Note: `organizations` is also intentionally excluded. It uses local
+          # state plus AWS Organizations management-account credentials, so CI
+          # cannot safely preserve state or create/import the account. Apply
+          # manually with state in hand. See reinhardt-web#5393.
           - module: website
             dir: infra/website
-            backend: local
-          - module: organizations
-            dir: infra/organizations
             backend: local
           - module: repository
             dir: infra/repository
@@ -153,7 +154,6 @@ jobs:
           TF_VAR_dns_record_notes_id: ${{ secrets.TF_DNS_RECORD_NOTES_ID }}
           TF_VAR_dns_record_rc_id: ${{ secrets.TF_DNS_RECORD_RC_ID }}
           TF_VAR_dns_record_google_verification_id: ${{ secrets.TF_DNS_RECORD_GOOGLE_VERIFICATION_ID }}
-          TF_VAR_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
           TF_VAR_environment_reviewer_user_id: ${{ secrets.TF_ENVIRONMENT_REVIEWER_USER_ID }}
         run: |
           terraform plan -no-color -input=false -out=tfplan 2>&1 | tee plan-output.txt
@@ -185,11 +185,9 @@ jobs:
             dir: infra/github-runners
             backend: s3
           # Note: `bootstrap` is intentionally excluded. See reinhardt-web#4145.
+          # Note: `organizations` is intentionally excluded. See reinhardt-web#5393.
           - module: website
             dir: infra/website
-            backend: local
-          - module: organizations
-            dir: infra/organizations
             backend: local
           - module: repository
             dir: infra/repository
@@ -267,7 +265,6 @@ jobs:
           TF_VAR_dns_record_notes_id: ${{ secrets.TF_DNS_RECORD_NOTES_ID }}
           TF_VAR_dns_record_rc_id: ${{ secrets.TF_DNS_RECORD_RC_ID }}
           TF_VAR_dns_record_google_verification_id: ${{ secrets.TF_DNS_RECORD_GOOGLE_VERIFICATION_ID }}
-          TF_VAR_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
           TF_VAR_environment_reviewer_user_id: ${{ secrets.TF_ENVIRONMENT_REVIEWER_USER_ID }}
         run: |
           terraform apply -no-color -input=false tfplan

--- a/.github/workflows/terraform-plan-privileged.yml
+++ b/.github/workflows/terraform-plan-privileged.yml
@@ -163,11 +163,12 @@ jobs:
             dir: infra/github-runners
             backend: s3
           # Note: `bootstrap` is intentionally excluded. See reinhardt-web#4145.
+          # Note: `organizations` is intentionally excluded from privileged
+          # plans. Backend-free validation still covers it above; applying or
+          # planning it with real state remains a manual management-account
+          # operation. See reinhardt-web#5393.
           - module: website
             dir: infra/website
-            backend: local
-          - module: organizations
-            dir: infra/organizations
             backend: local
           - module: repository
             dir: infra/repository
@@ -313,7 +314,6 @@ jobs:
           TF_VAR_dns_record_notes_id: ${{ secrets.TF_DNS_RECORD_NOTES_ID }}
           TF_VAR_dns_record_rc_id: ${{ secrets.TF_DNS_RECORD_RC_ID }}
           TF_VAR_dns_record_google_verification_id: ${{ secrets.TF_DNS_RECORD_GOOGLE_VERIFICATION_ID }}
-          TF_VAR_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
           TF_VAR_organizations_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
           TF_VAR_environment_reviewer_user_id: ${{ secrets.TF_ENVIRONMENT_REVIEWER_USER_ID }}
         run: |

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -34,11 +34,12 @@ jobs:
           # as a new resource and fail apply with `BucketAlreadyExists`.
           # Bootstrap is run-once and must be applied manually with state in
           # hand. See reinhardt-web#4145.
+          # Note: `organizations` is also intentionally excluded from automatic
+          # plans. It uses local state plus AWS Organizations management-account
+          # credentials, so CI cannot produce a durable plan for it. Apply
+          # manually with state in hand. See reinhardt-web#5393.
           - module: website
             dir: infra/website
-            backend: local
-          - module: organizations
-            dir: infra/organizations
             backend: local
           - module: repository
             dir: infra/repository
@@ -90,14 +91,11 @@ jobs:
         if: env.SKIP_PLAN != 'true'
         env:
           TF_VAR_aws_account_id: ${{ secrets.TF_AWS_ACCOUNT_ID }}
-          TF_VAR_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
           TF_VAR_cloudflare_account_id: ${{ secrets.TF_CLOUDFLARE_ACCOUNT_ID }}
         run: |
           case "${{ matrix.module }}" in
             github-runners)
               [ -z "$TF_VAR_aws_account_id" ] && SKIP=true ;;
-            organizations)
-              [ -z "$TF_VAR_account_email" ] && SKIP=true ;;
             website)
               [ -z "$TF_VAR_cloudflare_account_id" ] && SKIP=true ;;
           esac
@@ -180,7 +178,6 @@ jobs:
           TF_VAR_cloudflare_api_token: ${{ secrets.TF_CLOUDFLARE_API_TOKEN }}
           TF_VAR_cloudflare_account_id: ${{ secrets.TF_CLOUDFLARE_ACCOUNT_ID }}
           TF_VAR_budget_alert_email: ${{ secrets.TF_BUDGET_ALERT_EMAIL }}
-          TF_VAR_account_email: ${{ secrets.TF_ACCOUNT_EMAIL }}
           TF_VAR_pages_project_name: ${{ secrets.TF_PAGES_PROJECT_NAME }}
           TF_VAR_custom_domain: ${{ secrets.TF_CUSTOM_DOMAIN }}
           TF_VAR_google_site_verification: ${{ secrets.TF_GOOGLE_SITE_VERIFICATION }}

--- a/infra/organizations/imports.tf
+++ b/infra/organizations/imports.tf
@@ -1,10 +1,13 @@
-# Always-on import block: brings manually-created Organizations account under Terraform management.
-# Pattern: same as infra/website/imports.tf (idempotent - safe to keep even after initial apply).
+# Import block template for bringing a manually-created Organizations account
+# under Terraform management during manual apply.
 #
 # USAGE:
 #   New account:      Run `terraform apply` to create a new sub-account.
 #   Existing account: Uncomment the import block below with the actual account ID,
 #                     then run `terraform init && terraform apply`.
+#
+# This stack is not planned or applied by CI. Preserve the local state file when
+# running these commands manually. See reinhardt-web#5393.
 #
 # Get account ID: aws organizations list-accounts --query "Accounts[?Name=='reinhardt-ci-runners'].Id"
 

--- a/infra/organizations/main.tf
+++ b/infra/organizations/main.tf
@@ -1,6 +1,11 @@
 # Manages the dedicated CI sub-account in AWS Organizations.
 # Run with master account credentials (the account that owns the Organization).
 # After apply, use outputs.account_id as the target account for all github-runners resources.
+#
+# This stack is intentionally excluded from Terraform plan/apply CI. It uses a
+# local backend and requires management-account credentials, so CI cannot
+# preserve the local state or safely create/import the Organizations account.
+# Apply manually with the state file in hand. See reinhardt-web#5393.
 
 terraform {
   required_version = ">= 1.10"

--- a/infra/organizations/terraform.examples.tfvars
+++ b/infra/organizations/terraform.examples.tfvars
@@ -3,6 +3,10 @@
 #
 # Values marked <like-this> MUST be replaced before running terraform apply.
 # Pre-filled values are sensible defaults and can be changed if needed.
+#
+# This stack is excluded from Terraform plan/apply CI because it uses local state
+# and management-account credentials. Apply it manually with state in hand. See
+# reinhardt-web#5393.
 
 aws_region    = "us-east-1"
 account_name  = "reinhardt-ci-runners"


### PR DESCRIPTION
## Summary

This PR addresses:

- Removes the local-state `infra/organizations` stack from automatic Terraform plan/apply workflows.
- Keeps backend-free validation coverage for `infra/organizations` through the existing validation paths.
- Documents that the Organizations stack must be applied manually with management-account credentials and preserved local state.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`Terraform Apply / Apply (organizations)` failed on `main` because CI planned the AWS Organizations account from empty local state and then attempted `organizations:CreateAccount` with repository Terraform credentials. The Organizations stack requires management-account credentials and preserved local state, so it should be manual-only rather than part of automated plan/apply matrices.

Fixes #5393

Related to: #4145

## How Was This Tested?

- `actionlint .github/workflows/terraform-apply.yml .github/workflows/terraform-plan.yml .github/workflows/terraform-plan-privileged.yml`
- `terraform fmt -check -diff` in `infra/organizations`
- `terraform init -backend=false -input=false` in `infra/organizations`
- `terraform validate` in `infra/organizations`
- `git diff --check`

## Performance Impact

Not performance-related.

## Screenshots

Not UI-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5393
- #4145

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

`infra/organizations` remains covered by backend-free Terraform validation; only automated plan/apply with real state is removed.

Generated with Codex
