### PR TITLE
fix(views): align viewset serializer examples

### DIFF
--- a/crates/reinhardt-views/src/openapi_inspector.rs
+++ b/crates/reinhardt-views/src/openapi_inspector.rs
@@ -24,6 +24,7 @@ use utoipa::openapi::schema::{ObjectBuilder, SchemaType, Type};
 /// # use reinhardt_views::openapi_inspector::ViewSetInspector;
 /// # use reinhardt_views::viewsets::ModelViewSet;
 /// # use reinhardt_db::orm::{FieldSelector, Model};
+/// # use reinhardt_rest::serializers::JsonSerializer;
 /// # use serde::{Deserialize, Serialize};
 /// #
 /// # #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,10 +45,7 @@ use utoipa::openapi::schema::{ObjectBuilder, SchemaType, Type};
 /// #     fn new_fields() -> Self::Fields { UserFields }
 /// # }
 /// #
-/// # #[derive(Debug, Clone)]
-/// # struct UserSerializer;
-/// #
-/// # let viewset = ModelViewSet::<User, UserSerializer>::new("users");
+/// # let viewset = ModelViewSet::<User, JsonSerializer<User>>::new("users");
 /// let inspector = ViewSetInspector::new();
 ///
 /// // Extract path information
@@ -122,6 +120,7 @@ impl ViewSetInspector {
 	/// # use reinhardt_views::openapi_inspector::ViewSetInspector;
 	/// # use reinhardt_views::viewsets::ModelViewSet;
 	/// # use reinhardt_db::orm::{FieldSelector, Model};
+	/// # use reinhardt_rest::serializers::JsonSerializer;
 	/// # use serde::{Deserialize, Serialize};
 	/// #
 	/// # #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -137,10 +136,7 @@ impl ViewSetInspector {
 	/// #     fn set_primary_key(&mut self, v: i64) { self.id = Some(v); }
 	/// #     fn new_fields() -> Self::Fields { UserFields }
 	/// # }
-	/// # #[derive(Debug, Clone)]
-	/// # struct UserSerializer;
-	/// #
-	/// # let viewset = ModelViewSet::<User, UserSerializer>::new("users");
+	/// # let viewset = ModelViewSet::<User, JsonSerializer<User>>::new("users");
 	/// let inspector = ViewSetInspector::new();
 	/// let paths = inspector.extract_paths(&viewset, "/api/users");
 	///
@@ -260,6 +256,7 @@ impl ViewSetInspector {
 	/// # use reinhardt_views::openapi_inspector::ViewSetInspector;
 	/// # use reinhardt_views::viewsets::ModelViewSet;
 	/// # use reinhardt_db::orm::{FieldSelector, Model};
+	/// # use reinhardt_rest::serializers::JsonSerializer;
 	/// # use serde::{Deserialize, Serialize};
 	/// #
 	/// # #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -275,10 +272,7 @@ impl ViewSetInspector {
 	/// #     fn set_primary_key(&mut self, v: i64) { self.id = Some(v); }
 	/// #     fn new_fields() -> Self::Fields { UserFields }
 	/// # }
-	/// # #[derive(Debug, Clone)]
-	/// # struct UserSerializer;
-	/// #
-	/// # let viewset = ModelViewSet::<User, UserSerializer>::new("users");
+	/// # let viewset = ModelViewSet::<User, JsonSerializer<User>>::new("users");
 	/// let inspector = ViewSetInspector::new();
 	/// let operations = inspector.extract_operations(&viewset);
 	///

--- a/crates/reinhardt-views/src/viewsets/cached.rs
+++ b/crates/reinhardt-views/src/viewsets/cached.rs
@@ -141,6 +141,7 @@ impl CachedResponse {
 ///
 /// ```
 /// use reinhardt_views::viewsets::{CachedViewSet, CacheConfig, ModelViewSet};
+/// use reinhardt_rest::serializers::JsonSerializer;
 /// use reinhardt_utils::cache::InMemoryCache;
 /// use reinhardt_db::orm::{FieldSelector, Model};
 /// use std::time::Duration;
@@ -164,12 +165,9 @@ impl CachedResponse {
 ///     fn new_fields() -> Self::Fields { UserFields }
 /// }
 ///
-/// #[derive(Debug, Clone)]
-/// struct UserSerializer;
-///
 /// # async fn example() {
 /// let cache = InMemoryCache::new();
-/// let inner_viewset = ModelViewSet::<User, UserSerializer>::new("users");
+/// let inner_viewset = ModelViewSet::<User, JsonSerializer<User>>::new("users");
 /// let config = CacheConfig::new("users")
 ///     .with_ttl(Duration::from_secs(300))
 ///     .cache_all();

--- a/examples/examples-tutorial-rest/src/apps/snippets/views.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/views.rs
@@ -286,11 +286,11 @@ pub async fn delete(
 /// database, so both observe an empty list until rows are inserted into the
 /// `snippets` table.
 #[reinhardt::viewset(basename = "snippet")]
-pub fn viewset() -> reinhardt::ModelViewSet<Snippet, SnippetSerializer> {
+pub fn viewset() -> reinhardt::ModelViewSet<Snippet, reinhardt::JsonSerializer<Snippet>> {
 	use reinhardt::ModelViewSet;
 	use reinhardt::views::viewsets::{FilterConfig, OrderingConfig, PaginationConfig};
 
-	ModelViewSet::new("snippet")
+	ModelViewSet::<Snippet, reinhardt::JsonSerializer<Snippet>>::new("snippet")
 		.with_pagination(PaginationConfig::page_number(10, Some(100)))
 		.with_filters(
 			FilterConfig::new()


### PR DESCRIPTION
## Summary

This PR addresses:

- Aligns `ModelViewSet` doctests with the current `Serializer + Default` type bounds by using `JsonSerializer<User>`.
- Updates `examples-tutorial-rest` viewset wiring to use `JsonSerializer<Snippet>` for model-backed CRUD serialization.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The generated release PR #5397 fails CI because doctests and the REST tutorial still instantiate `ModelViewSet` with placeholder/request DTO serializers that do not satisfy the current model serializer contract.

Related to: #5397

## How Was This Tested?

- `cargo test -p reinhardt-views --doc`
- `cargo check -p examples-tutorial-rest --all-features` from `examples/`
- `cargo build --all-features` from `examples/examples-tutorial-rest/`
- `cargo clippy --all-features -- -D warnings` from `examples/examples-tutorial-rest/`
- `cargo fmt --all --check`

## Checklist

- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] New and existing targeted tests pass locally with my changes
- [x] I have formatted the code with `cargo fmt --all --check`
- [x] I have checked the affected example with `cargo clippy --all-features -- -D warnings`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #5397

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update

### Scope Label (select all that apply)
- [x] `api` - REST API, serializers, views

---

**Additional Context:**

This intentionally fixes the base branch rather than pushing to the generated `release-plz-*` branch, so release-plz can regenerate the release PR after this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Rustdoc examples for viewset inspector and caching components with current usage patterns.

* **Chores**
  * Updated tutorial code examples to demonstrate consistent viewset configuration and serialization practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->