### PR TITLE
fix(macros): preserve serde field attributes on Info structs

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -1020,6 +1020,8 @@ struct FieldInfo {
 	name: syn::Ident,
 	ty: Type,
 	config: FieldConfig,
+	/// Field-level `#[serde(...)]` attributes copied to generated companion fields.
+	serde_attrs: Vec<syn::Attribute>,
 	/// Optional relationship attribute from `#[rel(...)]`
 	///
 	/// This field is reserved for future accessor generation support.
@@ -1855,6 +1857,12 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 		let ty = field.ty.clone();
 		let config = FieldConfig::from_attrs(&field.attrs)?;
 		config.validate()?;
+		let serde_attrs: Vec<syn::Attribute> = field
+			.attrs
+			.iter()
+			.filter(|attr| attr.path().is_ident("serde"))
+			.cloned()
+			.collect();
 
 		// Parse #[rel(...)] attribute if present
 		let rel = field
@@ -1873,6 +1881,7 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 			name,
 			ty,
 			config,
+			serde_attrs,
 			rel,
 			is_fk_id_field,
 		});
@@ -4776,7 +4785,9 @@ fn generate_info_struct(
 			let name = &f.name;
 			let ty = &f.ty;
 			let validate_attrs = generate_validate_attrs(&f.config);
+			let serde_attrs = &f.serde_attrs;
 			quote! {
+				#(#serde_attrs)*
 				#(#validate_attrs)*
 				pub #name: #ty,
 			}

--- a/tests/integration/tests/macros/model_info_integration.rs
+++ b/tests/integration/tests/macros/model_info_integration.rs
@@ -177,6 +177,65 @@ fn test_info_skip_field_default_on_roundtrip() {
 	assert_eq!(*model.password_hash(), "");
 }
 
+#[model(app_label = "test", table_name = "serde_redacted_users")]
+#[derive(Serialize, Deserialize)]
+struct SerdeRedactedUser {
+	#[field(primary_key = true)]
+	id: Option<i64>,
+
+	#[field(max_length = 100)]
+	username: String,
+
+	#[serde(skip_serializing)]
+	#[field(max_length = 255)]
+	password_hash: String,
+
+	#[serde(skip_deserializing)]
+	is_staff: bool,
+}
+
+#[test]
+fn test_info_preserves_serde_field_redaction() {
+	// Arrange
+	let info = SerdeRedactedUserInfo {
+		id: Some(1),
+		username: "alice".to_string(),
+		password_hash: "HASHED_SECRET".to_string(),
+		is_staff: true,
+	};
+
+	// Act
+	let json = serde_json::to_string(&info).unwrap();
+
+	// Assert
+	let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+	assert_eq!(value.get("password_hash"), None);
+	assert_eq!(value["username"], "alice");
+}
+
+#[test]
+fn test_info_preserves_serde_deserialization_redaction() {
+	// Arrange
+	let json = r#"{
+		"id": 1,
+		"username": "alice",
+		"password_hash": "ATTACKER_HASH",
+		"is_staff": true
+	}"#;
+
+	// Act
+	let info: SerdeRedactedUserInfo = serde_json::from_str(json).unwrap();
+
+	// Assert
+	assert_eq!(info.is_staff, false);
+
+	// Act
+	let model: SerdeRedactedUser = info.into();
+
+	// Assert
+	assert_eq!(model.is_staff(), false);
+}
+
 // --- Builder ---
 
 #[test]


### PR DESCRIPTION
### Motivation

- When the `#[model]` macro propagated `Serialize`/`Deserialize` to generated `{Model}Info` types it did not copy per-field `#[serde(...)]` attributes, which could expose redacted fields or allow mass-assignment through Info deserialization.

### Description

- Add a `serde_attrs: Vec<syn::Attribute>` to `FieldInfo` and collect `#[serde(...)]` attributes from each model field at derive time.
- Emit collected `#[serde(...)]` attributes onto the generated `{Model}Info` struct fields before validation attributes so field-level redaction and deserialization controls are preserved.
- Add integration tests in `tests/integration/tests/macros/model_info_integration.rs` that exercise `#[serde(skip_serializing)]` and `#[serde(skip_deserializing)]` behavior on a generated `SerdeRedactedUserInfo` type to prevent regressions.

### Testing

- Ran the integration test suite with `cargo test --package reinhardt-integration-tests --test macros model_info_integration --all-features`, and the new tests passed (all relevant tests OK).
- Verified formatting with `cargo fmt --check` which completed successfully in this environment.
- Attempted `cargo make fmt-check` (project check task) but it failed because `cargo-make` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35321f2c148327a1db615ff4e7a401)