### PR TITLE
fix(storages): prevent Azure SAS credential exposure

### DIFF
--- a/crates/reinhardt-storages/README.md
+++ b/crates/reinhardt-storages/README.md
@@ -189,9 +189,11 @@ prefix = "uploads/"
 access_key = { secret = "base64-account-key" }
 ```
 
-`endpoint` is available for Azurite or custom endpoints. Temporary URLs use a
-configured `sas_token` when present, otherwise `access_key` or
-`connection_string` is used to generate a service SAS URL.
+`endpoint` is available for Azurite or custom endpoints. A configured
+`sas_token` is used only as a backend operation credential and is never returned
+from temporary URL generation. Temporary URLs require `access_key` or
+`connection_string` so Reinhardt can generate a per-blob read-only service SAS
+URL with the requested expiry.
 
 ### Local
 

--- a/crates/reinhardt-storages/src/backends/azure.rs
+++ b/crates/reinhardt-storages/src/backends/azure.rs
@@ -272,10 +272,6 @@ impl AzureStorage {
 	}
 
 	fn sas_url(&self, blob: &str, expiry_secs: u64) -> Result<String> {
-		if self.config.sas_token.is_some() {
-			return Ok(self.append_sas(self.blob_url(blob)));
-		}
-
 		let expiry = Utc::now() + Duration::seconds(i64::try_from(expiry_secs).unwrap_or(i64::MAX));
 		let se = expiry.format("%Y-%m-%dT%H:%M:%SZ").to_string();
 		let sp = "r";
@@ -304,8 +300,13 @@ impl AzureStorage {
 			"",
 		]
 		.join("\n");
+		let access_key = self.config.access_key.as_ref().ok_or_else(|| {
+			StorageError::ConfigError(
+				"Azure access_key is required to generate temporary URLs".to_string(),
+			)
+		})?;
 		let key = STANDARD
-			.decode(self.access_key()?)
+			.decode(access_key.expose_secret())
 			.map_err(|err| StorageError::ConfigError(err.to_string()))?;
 		let mut mac = HmacSha256::new_from_slice(&key)
 			.map_err(|err| StorageError::ConfigError(err.to_string()))?;
@@ -442,5 +443,34 @@ impl StorageBackend for AzureStorage {
 		DateTime::parse_from_rfc2822(last_modified)
 			.map(|time| time.with_timezone(&Utc))
 			.map_err(|err| StorageError::Other(err.to_string()))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn sas_url_requires_access_key_instead_of_exposing_configured_sas_token() {
+		let storage = AzureStorage {
+			config: AzureConfig {
+				account: "testaccount".to_string(),
+				container: "testcontainer".to_string(),
+				prefix: None,
+				endpoint: Some("https://example.test/testaccount".to_string()),
+				access_key: None,
+				sas_token: Some("sp=rwdlac&sig=SECRET_CONTAINER_SIGNATURE".into()),
+				connection_string: None,
+			},
+			http: reqwest::Client::new(),
+		};
+
+		let err = storage
+			.sas_url("private.txt", 60)
+			.expect_err("temporary URLs must not expose configured SAS credentials");
+
+		assert!(
+			matches!(err, StorageError::ConfigError(message) if message == "Azure access_key is required to generate temporary URLs")
+		);
 	}
 }

--- a/crates/reinhardt-storages/src/config.rs
+++ b/crates/reinhardt-storages/src/config.rs
@@ -105,7 +105,7 @@ pub struct AzureConfig {
 	pub endpoint: Option<String>,
 	/// Account access key used for Shared Key and SAS signing.
 	pub access_key: Option<SecretString>,
-	/// Pre-generated SAS token appended to generated URLs.
+	/// Pre-generated SAS token used only for backend operations.
 	pub sas_token: Option<SecretString>,
 	/// Azure Storage connection string.
 	pub connection_string: Option<SecretString>,

--- a/crates/reinhardt-storages/src/settings.rs
+++ b/crates/reinhardt-storages/src/settings.rs
@@ -142,7 +142,7 @@ pub struct AzureStorageSettings {
 	#[setting(optional)]
 	#[serde(default)]
 	pub access_key: Option<SecretString>,
-	/// Pre-generated SAS token.
+	/// Pre-generated SAS token used only for backend operations.
 	#[setting(optional)]
 	#[serde(default)]
 	pub sas_token: Option<SecretString>,


### PR DESCRIPTION
### Motivation
- Prevent leaking a configured container-scoped Azure SAS token via generated temporary URLs, which could expose broad read/write/delete credentials to callers.
- Ensure temporary download URLs are scoped and time-limited by requiring a signing key when generating per-blob SAS URLs.

### Description
- Remove the code path that returned the configured `sas_token` from `sas_url()` so configured SAS tokens are no longer appended to generated URLs.
- Require an Azure `access_key` when generating per-blob temporary URLs and use it to sign the service SAS instead of exposing the backend SAS credential.
- Update configuration and settings comments and `README.md` to clarify that a configured `sas_token` is intended only for backend operations and is never returned by temporary URL generation.
- Add a regression unit test that asserts generating a temporary URL with only a configured `sas_token` is rejected (ensures the configured token is not exposed).

### Testing
- Ran the new unit test: `cargo test -p reinhardt-storages --features azure sas_url_requires_access_key_instead_of_exposing_configured_sas_token` and it passed.
- Ran broader package tests with Azure feature: `cargo test -p reinhardt-storages --features azure` and the test run completed with no failing tests (many integration tests are gated/filtered by features and environment).
- Code style checks: `cargo fmt --check --package reinhardt-storages` succeeded and `git diff --check` reported no issues.
- Note: `cargo make fmt-check` was not executed because `cargo-make` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a352507b73483279afda70fe4289e2c)