### PR TITLE
fix(tests): align viewset serializer fixtures

### DIFF
--- a/crates/reinhardt-views/src/openapi_inspector.rs
+++ b/crates/reinhardt-views/src/openapi_inspector.rs
@@ -24,6 +24,7 @@ use utoipa::openapi::schema::{ObjectBuilder, SchemaType, Type};
 /// # use reinhardt_views::openapi_inspector::ViewSetInspector;
 /// # use reinhardt_views::viewsets::ModelViewSet;
 /// # use reinhardt_db::orm::{FieldSelector, Model};
+/// # use reinhardt_rest::serializers::JsonSerializer;
 /// # use serde::{Deserialize, Serialize};
 /// #
 /// # #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,8 +45,7 @@ use utoipa::openapi::schema::{ObjectBuilder, SchemaType, Type};
 /// #     fn new_fields() -> Self::Fields { UserFields }
 /// # }
 /// #
-/// # #[derive(Debug, Clone)]
-/// # struct UserSerializer;
+/// # type UserSerializer = JsonSerializer<User>;
 /// #
 /// # let viewset = ModelViewSet::<User, UserSerializer>::new("users");
 /// let inspector = ViewSetInspector::new();
@@ -122,6 +122,7 @@ impl ViewSetInspector {
 	/// # use reinhardt_views::openapi_inspector::ViewSetInspector;
 	/// # use reinhardt_views::viewsets::ModelViewSet;
 	/// # use reinhardt_db::orm::{FieldSelector, Model};
+	/// # use reinhardt_rest::serializers::JsonSerializer;
 	/// # use serde::{Deserialize, Serialize};
 	/// #
 	/// # #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -137,8 +138,7 @@ impl ViewSetInspector {
 	/// #     fn set_primary_key(&mut self, v: i64) { self.id = Some(v); }
 	/// #     fn new_fields() -> Self::Fields { UserFields }
 	/// # }
-	/// # #[derive(Debug, Clone)]
-	/// # struct UserSerializer;
+	/// # type UserSerializer = JsonSerializer<User>;
 	/// #
 	/// # let viewset = ModelViewSet::<User, UserSerializer>::new("users");
 	/// let inspector = ViewSetInspector::new();
@@ -260,6 +260,7 @@ impl ViewSetInspector {
 	/// # use reinhardt_views::openapi_inspector::ViewSetInspector;
 	/// # use reinhardt_views::viewsets::ModelViewSet;
 	/// # use reinhardt_db::orm::{FieldSelector, Model};
+	/// # use reinhardt_rest::serializers::JsonSerializer;
 	/// # use serde::{Deserialize, Serialize};
 	/// #
 	/// # #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -275,8 +276,7 @@ impl ViewSetInspector {
 	/// #     fn set_primary_key(&mut self, v: i64) { self.id = Some(v); }
 	/// #     fn new_fields() -> Self::Fields { UserFields }
 	/// # }
-	/// # #[derive(Debug, Clone)]
-	/// # struct UserSerializer;
+	/// # type UserSerializer = JsonSerializer<User>;
 	/// #
 	/// # let viewset = ModelViewSet::<User, UserSerializer>::new("users");
 	/// let inspector = ViewSetInspector::new();

--- a/crates/reinhardt-views/src/viewsets/cached.rs
+++ b/crates/reinhardt-views/src/viewsets/cached.rs
@@ -143,6 +143,7 @@ impl CachedResponse {
 /// use reinhardt_views::viewsets::{CachedViewSet, CacheConfig, ModelViewSet};
 /// use reinhardt_utils::cache::InMemoryCache;
 /// use reinhardt_db::orm::{FieldSelector, Model};
+/// use reinhardt_rest::serializers::JsonSerializer;
 /// use std::time::Duration;
 ///
 /// #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -164,8 +165,7 @@ impl CachedResponse {
 ///     fn new_fields() -> Self::Fields { UserFields }
 /// }
 ///
-/// #[derive(Debug, Clone)]
-/// struct UserSerializer;
+/// type UserSerializer = JsonSerializer<User>;
 ///
 /// # async fn example() {
 /// let cache = InMemoryCache::new();

--- a/crates/reinhardt-views/tests/viewset_routing.rs
+++ b/crates/reinhardt-views/tests/viewset_routing.rs
@@ -6,6 +6,7 @@ use bytes::Bytes;
 use hyper::{HeaderMap, Method, StatusCode, Version};
 use reinhardt_db::orm::{FieldSelector, Model};
 use reinhardt_http::Request;
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_views::viewset_actions;
 use reinhardt_views::viewsets::{
 	Action, ActionMetadata, ActionType, FilterConfig, GenericViewSet, ModelViewSet, NestedResource,
@@ -56,8 +57,7 @@ impl Model for TestModel {
 	}
 }
 
-#[derive(Debug, Clone)]
-struct TestSerializer;
+type TestSerializer = JsonSerializer<TestModel>;
 
 fn make_request(method: Method, uri: &str) -> Request {
 	Request::builder()

--- a/examples/examples-tutorial-rest/src/apps/snippets/views.rs
+++ b/examples/examples-tutorial-rest/src/apps/snippets/views.rs
@@ -303,7 +303,7 @@ pub async fn delete(
 /// database, so both observe an empty list until rows are inserted into the
 /// `snippets` table.
 #[reinhardt::viewset(basename = "snippet")]
-pub fn viewset() -> reinhardt::ModelViewSet<Snippet, SnippetSerializer> {
+pub fn viewset() -> reinhardt::ModelViewSet<Snippet, reinhardt::JsonSerializer<Snippet>> {
 	use reinhardt::ModelViewSet;
 	use reinhardt::views::viewsets::{FilterConfig, OrderingConfig, PaginationConfig};
 

--- a/tests/integration/tests/routing/nested_router_integration.rs
+++ b/tests/integration/tests/routing/nested_router_integration.rs
@@ -1,6 +1,7 @@
 //! Nested router implementation tests
 
 use reinhardt_macros::model;
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_urls::routers::ServerRouter;
 use reinhardt_views::viewsets::{ModelViewSet, NestedResource, NestedViewSet, nested_url};
 use serde::{Deserialize, Serialize};
@@ -26,11 +27,8 @@ struct Post {
 	title: String,
 }
 
-#[derive(Debug, Clone)]
-struct UserSerializer;
-
-#[derive(Debug, Clone)]
-struct PostSerializer;
+type UserSerializer = JsonSerializer<User>;
+type PostSerializer = JsonSerializer<Post>;
 
 #[tokio::test]
 async fn test_nested_router_basic_structure() {

--- a/tests/integration/tests/routing/router_viewset_integration.rs
+++ b/tests/integration/tests/routing/router_viewset_integration.rs
@@ -5,6 +5,7 @@ use bytes::Bytes;
 use hyper::{HeaderMap, Method, StatusCode, Version};
 use reinhardt_http::Request;
 use reinhardt_macros::model;
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_urls::routers::{DefaultRouter, Router};
 use reinhardt_views::viewsets::ModelViewSet;
 use serde::{Deserialize, Serialize};
@@ -20,8 +21,7 @@ struct TestModel {
 	name: String,
 }
 
-#[derive(Debug, Clone)]
-struct TestSerializer;
+type TestSerializer = JsonSerializer<TestModel>;
 
 // Test: ViewSet registration with router (inspired by DRF's TestSimpleRouter)
 #[tokio::test]

--- a/tests/integration/tests/routing/viewset_register_to_integration.rs
+++ b/tests/integration/tests/routing/viewset_register_to_integration.rs
@@ -2,6 +2,7 @@
 
 use hyper::Method;
 use reinhardt_macros::model;
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_urls::routers::ServerRouter;
 use reinhardt_views::viewsets::ModelViewSet;
 use serde::{Deserialize, Serialize};
@@ -16,8 +17,7 @@ struct TestUser {
 	name: String,
 }
 
-#[derive(Debug, Clone)]
-struct TestSerializer;
+type TestSerializer = JsonSerializer<TestUser>;
 
 #[tokio::test]
 async fn test_viewset_register_to() {

--- a/tests/integration/tests/routing/viewset_router_integration.rs
+++ b/tests/integration/tests/routing/viewset_router_integration.rs
@@ -3,6 +3,7 @@ use hyper::{HeaderMap, Method, StatusCode, Version};
 use reinhardt_http::Handler;
 use reinhardt_http::Request;
 use reinhardt_macros::model;
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_urls::routers::{DefaultRouter, Router};
 use reinhardt_views::viewsets::{GenericViewSet, ModelViewSet, ViewSet};
 use serde::{Deserialize, Serialize};
@@ -18,8 +19,7 @@ struct TestModel {
 	name: String,
 }
 
-#[derive(Debug, Clone)]
-struct TestSerializer;
+type TestSerializer = JsonSerializer<TestModel>;
 
 /// Test viewset registration with router
 #[tokio::test]

--- a/tests/integration/tests/viewsets/as_view_integration.rs
+++ b/tests/integration/tests/viewsets/as_view_integration.rs
@@ -6,6 +6,7 @@
 use hyper::{HeaderMap, Method, Uri, Version};
 use reinhardt_http::Request;
 use reinhardt_macros::model;
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_views::viewsets::viewset::ModelViewSet;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -50,7 +51,7 @@ fn create_test_request_with_body(method: Method, path: &str, body: &'static str)
 
 #[tokio::test]
 async fn test_viewset_handler_attribute_tracking() {
-	let viewset = ModelViewSet::<TestModel, ()>::new("test");
+	let viewset = ModelViewSet::<TestModel, JsonSerializer<TestModel>>::new("test");
 	let mut actions = HashMap::new();
 	actions.insert(Method::GET, "list".to_string());
 
@@ -67,7 +68,7 @@ async fn test_viewset_handler_attribute_tracking() {
 
 #[tokio::test]
 async fn test_viewset_handler_action_mapping() {
-	let viewset = ModelViewSet::<TestModel, ()>::new("test");
+	let viewset = ModelViewSet::<TestModel, JsonSerializer<TestModel>>::new("test");
 	let mut actions = HashMap::new();
 	actions.insert(Method::GET, "list".to_string());
 	actions.insert(Method::POST, "create".to_string());

--- a/tests/integration/tests/viewsets/filtering_viewsets_integration.rs
+++ b/tests/integration/tests/viewsets/filtering_viewsets_integration.rs
@@ -26,6 +26,7 @@ use reinhardt_rest::filters::{
 	DatabaseDialect, FilterBackend, FuzzyAlgorithm, FuzzySearchFilter, RangeFilter,
 	SimpleOrderingBackend, SimpleSearchBackend,
 };
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_test::fixtures::testcontainers::{ContainerAsync, GenericImage, postgres_container};
 use reinhardt_views::viewsets::{
 	FilterConfig, FilterableViewSet, ModelViewSet, OrderingConfig, ReadOnlyModelViewSet,
@@ -55,8 +56,7 @@ struct TestModel {
 	created_at: i64,
 }
 
-#[derive(Debug, Clone)]
-struct TestSerializer;
+type TestSerializer = JsonSerializer<TestModel>;
 
 // ========================================================================
 // Custom Fixtures

--- a/tests/integration/tests/viewsets/model_viewset_crud_e2e.rs
+++ b/tests/integration/tests/viewsets/model_viewset_crud_e2e.rs
@@ -15,6 +15,7 @@ use hyper::{HeaderMap, Method, StatusCode, Version};
 use reinhardt_apps::Request;
 use reinhardt_db::orm::query_types::DbBackend;
 use reinhardt_macros::model;
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_test::fixtures::testcontainers::{ContainerAsync, GenericImage, postgres_container};
 use reinhardt_urls::routers::{DefaultRouter, Router};
 use reinhardt_views::viewsets::{ModelViewSet, ReadOnlyModelViewSet};
@@ -34,8 +35,7 @@ struct Item {
 	name: String,
 }
 
-#[derive(Debug, Clone)]
-struct ItemSerializer;
+type ItemSerializer = JsonSerializer<Item>;
 
 /// Convert the typed `PgPool` from the shared fixture into the type-erased
 /// `AnyPool` that `ModelViewSetHandler::with_pool` expects, then create the

--- a/tests/integration/tests/viewsets/pagination_viewsets_integration.rs
+++ b/tests/integration/tests/viewsets/pagination_viewsets_integration.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use hyper::{HeaderMap, Method, StatusCode, Version};
 use reinhardt_http::{Request, Response};
 use reinhardt_macros::model;
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_views::viewsets::ReadOnlyModelViewSet;
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
@@ -21,8 +22,7 @@ struct Product {
 	category: String,
 }
 
-#[derive(Debug, Clone)]
-struct ProductSerializer;
+type ProductSerializer = JsonSerializer<Product>;
 
 // ============================================================================
 // Pagination Traits

--- a/tests/integration/tests/viewsets/permissions_integration.rs
+++ b/tests/integration/tests/viewsets/permissions_integration.rs
@@ -20,6 +20,7 @@
 use bytes::Bytes;
 use hyper::{HeaderMap, Method, StatusCode, Version};
 use reinhardt_http::{Request, Response};
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_test::fixtures::postgres_container;
 use reinhardt_views::viewsets::{ModelViewSet, ReadOnlyModelViewSet};
 use rstest::*;
@@ -42,8 +43,7 @@ struct Article {
 
 reinhardt_test::impl_test_model!(Article, i64, "articles");
 
-#[derive(Debug, Clone)]
-struct ArticleSerializer;
+type ArticleSerializer = JsonSerializer<Article>;
 
 // ============================================================================
 // Permission Classes

--- a/tests/integration/tests/viewsets/router_tests.rs
+++ b/tests/integration/tests/viewsets/router_tests.rs
@@ -2,6 +2,7 @@ use bytes::Bytes;
 use hyper::{HeaderMap, Method, StatusCode, Uri, Version};
 use reinhardt_apps::{Handler, Request};
 use reinhardt_macros::model;
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_urls::routers::{DefaultRouter, Router};
 use reinhardt_views::viewsets::{GenericViewSet, ModelViewSet, ViewSet};
 use serde::{Deserialize, Serialize};
@@ -17,8 +18,7 @@ struct TestModel {
 	name: String,
 }
 
-#[derive(Debug, Clone)]
-struct TestSerializer;
+type TestSerializer = JsonSerializer<TestModel>;
 
 /// Test viewset registration with router
 #[tokio::test]

--- a/tests/integration/tests/viewsets/viewset_initialization_integration.rs
+++ b/tests/integration/tests/viewsets/viewset_initialization_integration.rs
@@ -2,6 +2,7 @@ use bytes::Bytes;
 use hyper::{HeaderMap, Method, StatusCode, Version};
 use reinhardt_http::Request;
 use reinhardt_macros::model;
+use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_views::viewsets::{
 	Action, GenericViewSet, ModelViewSet, ReadOnlyModelViewSet, ViewSet,
 };
@@ -17,8 +18,7 @@ struct TestModel {
 	name: String,
 }
 
-#[derive(Debug, Clone)]
-struct TestSerializer;
+type TestSerializer = JsonSerializer<TestModel>;
 
 /// Test initializing viewset with action mapping
 #[tokio::test]


### PR DESCRIPTION
## Summary

This PR addresses:

- Aligns ViewSet routing and integration test fixtures with the current `ModelViewSet` and `ReadOnlyModelViewSet` serializer bounds by using concrete `JsonSerializer<T>` type aliases.
- Fixes the `Check / Cargo Check (tests)` failure observed on release PR #5404.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Release PR #5404 fails `Check / Cargo Check (tests)` because stale empty serializer marker structs do not implement the `Serializer + Default` bounds now required by ViewSet types.

Related to: #5404

## How Was This Tested?

- `cargo check -p reinhardt-integration-tests --all-features --tests --quiet`
- `cargo check --workspace --all-features --tests --quiet`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Performance Impact

- Not performance-related.

## Breaking Changes

- None.

**Migration Guide:**

- Not applicable.

## Screenshots

### Before

- Not applicable.

### After

- Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #5404

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- The generated release branch was left untouched; this fix targets the real base branch (`main`) so release-plz can regenerate the release PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration and unit test modules to use production `JsonSerializer` implementations for test models instead of placeholder types, improving test realism across the test suite.

* **Documentation**
  * Corrected rustdoc examples and tutorial code to properly import and demonstrate serializer usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->