### PR TITLE
fix(scaffolding): repair Pages tutorial scaffold gaps

### DIFF
--- a/crates/reinhardt-commands/src/project_config.rs
+++ b/crates/reinhardt-commands/src/project_config.rs
@@ -265,10 +265,22 @@ fn should_add_required_feature(features: &[String], feature: &str) -> bool {
 	if features.iter().any(|existing| existing == feature) {
 		return false;
 	}
+	if feature == "minimal" && has_minimal_preset_feature(features) {
+		return false;
+	}
 	if feature == "db-postgres" && has_database_backend_feature(features) {
 		return false;
 	}
 	true
+}
+
+fn has_minimal_preset_feature(features: &[String]) -> bool {
+	features.iter().any(|feature| {
+		matches!(
+			feature.as_str(),
+			"standard" | "full" | "api-only" | "graphql-server"
+		)
+	})
 }
 
 fn has_database_backend_feature(features: &[String]) -> bool {
@@ -399,6 +411,25 @@ mod tests {
 
 		assert!(!should_add_required_feature(&features, "db-postgres"));
 		assert!(should_add_required_feature(&features, "commands"));
+	}
+
+	#[rstest::rstest]
+	fn required_minimal_runtime_respects_presets_but_repairs_explicit_pages_list() {
+		let default_pages_features = vec!["standard".to_string()];
+		assert!(!should_add_required_feature(
+			&default_pages_features,
+			"minimal"
+		));
+
+		let explicit_pages_features = vec![
+			"pages".to_string(),
+			"admin".to_string(),
+			"db-sqlite".to_string(),
+		];
+		assert!(should_add_required_feature(
+			&explicit_pages_features,
+			"minimal"
+		));
 	}
 
 	#[test]

--- a/crates/reinhardt-commands/src/start_commands.rs
+++ b/crates/reinhardt-commands/src/start_commands.rs
@@ -121,7 +121,14 @@ impl BaseCommand for StartProjectCommand {
 		// Generate a random secret key
 		let secret_key = format!("insecure-{}", generate_secret_key());
 		let required_features = if with_pages {
-			&["pages", "admin", "conf", "commands", "db-postgres"][..]
+			&[
+				"minimal",
+				"pages",
+				"admin",
+				"conf",
+				"commands",
+				"db-postgres",
+			][..]
 		} else {
 			&["conf", "commands", "db-postgres", "api"][..]
 		};

--- a/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
@@ -19,6 +19,7 @@ crate-type = ["cdylib", "rlib"]  # cdylib for WASM, rlib for server
 [[bin]]
 name = "manage"
 path = "src/bin/manage.rs"
+required-features = ["with-reinhardt"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
@@ -55,6 +56,12 @@ tokio = { version = "1", features = ["full"] }
 
 [build-dependencies]
 cfg_aliases = "0.2"
+
+[features]
+default = ["with-reinhardt", "client-router"]
+client-router = []
+with-reinhardt = []
+msw = ["reinhardt/msw"]
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/crates/reinhardt-commands/templates/project_pages_template/Makefile.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/Makefile.toml.tpl
@@ -16,7 +16,6 @@ skip_core_tasks = true
 # Use local target directory for each example (independent from workspace)
 CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = ["CARGO_TARGET_DIR"] } }
 WASM_TARGET = "wasm32-unknown-unknown"
-WASM_BINDGEN_VERSION = "0.2.122"
 
 # ============================================================================
 # Tooling
@@ -29,7 +28,7 @@ script = '''
 set -euo pipefail
 
 rustup target add "${WASM_TARGET}"
-cargo install wasm-bindgen-cli --version "${WASM_BINDGEN_VERSION}" --locked
+cargo install wasm-pack --locked
 cargo install cargo-watch --locked
 
 echo "Development tools installed"
@@ -50,20 +49,12 @@ dependencies = ["wasm-build-dev"]
 # WASM Build
 # ============================================================================
 
-[tasks.wasm-bindgen-check]
-description = "Check wasm-bindgen-cli version"
+[tasks.wasm-tool-check]
+description = "Check wasm-pack installation"
 script = '''
-if ! command -v wasm-bindgen >/dev/null 2>&1; then
-	echo "❌ wasm-bindgen-cli not installed"
-	echo "Run: cargo install wasm-bindgen-cli --version ${WASM_BINDGEN_VERSION}"
-	exit 1
-fi
-
-ACTUAL_VERSION=$(wasm-bindgen --version | awk '{print $2}')
-if [ "$ACTUAL_VERSION" != "${WASM_BINDGEN_VERSION}" ]; then
-	echo "❌ wasm-bindgen-cli version mismatch"
-	echo "Rust dependencies use wasm-bindgen ${WASM_BINDGEN_VERSION}, but installed wasm-bindgen-cli is ${ACTUAL_VERSION}"
-	echo "Run: cargo install -f wasm-bindgen-cli --version ${WASM_BINDGEN_VERSION}"
+if ! command -v wasm-pack >/dev/null 2>&1; then
+	echo "❌ wasm-pack not installed"
+	echo "Run: cargo install wasm-pack --locked"
 	exit 1
 fi
 '''
@@ -71,34 +62,29 @@ fi
 [tasks.wasm-compile-dev]
 description = "Compile WASM binary (debug mode)"
 command = "cargo"
-args = ["build", "--target", "wasm32-unknown-unknown"]
-dependencies = ["wasm-bindgen-check"]
+args = ["build", "--target", "wasm32-unknown-unknown", "--lib"]
+dependencies = ["wasm-tool-check"]
 
 [tasks.collectstatic-wasm]
 description = "Collect static files to dist/ for WASM frontend"
 command = "cargo"
 args = ["run", "--bin", "manage", "collectstatic", "--no-input"]
-dependencies = ["wasm-compile-dev"]
 
 [tasks.wasm-bindgen-dev]
-description = "Generate WASM bindings (debug mode)"
-script = '''
-WASM_FILE=$(ls target/wasm32-unknown-unknown/debug/*.wasm 2>/dev/null | head -1)
-if [ -n "$WASM_FILE" ]; then
-	wasm-bindgen --target web "$WASM_FILE" --out-dir dist --debug
-	echo "✓ WASM bindings generated"
-else
-	echo "❌ No WASM file found"
-	exit 1
-fi
-'''
-dependencies = ["collectstatic-wasm"]
+description = "Generate WASM bindings using wasm-pack (debug mode)"
+command = "wasm-pack"
+args = [
+	"build",
+	"--target", "web",
+	"--out-dir", "dist-wasm",
+	"--dev",
+	"--no-typescript"
+]
+dependencies = ["wasm-compile-dev"]
 
 [tasks.wasm-finalize-dev]
 description = "Finalize WASM build"
-script = '''
-echo "✓ WASM build completed: dist/"
-'''
+script = { file = "scripts/wasm-build-dev.sh" }
 dependencies = ["wasm-bindgen-dev"]
 
 [tasks.wasm-build-dev]
@@ -108,40 +94,24 @@ dependencies = ["wasm-finalize-dev"]
 [tasks.wasm-compile-release]
 description = "Compile WASM binary (release mode)"
 command = "cargo"
-args = ["build", "--target", "wasm32-unknown-unknown", "--release"]
-dependencies = ["wasm-bindgen-check"]
+args = ["build", "--target", "wasm32-unknown-unknown", "--release", "--lib"]
+dependencies = ["wasm-tool-check"]
 
 [tasks.wasm-bindgen-release]
-description = "Generate WASM bindings (release mode)"
-script = '''
-WASM_FILE=$(ls target/wasm32-unknown-unknown/release/*.wasm 2>/dev/null | head -1)
-if [ -n "$WASM_FILE" ]; then
-	wasm-bindgen --target web "$WASM_FILE" --out-dir dist
-	echo "✓ WASM bindings generated"
-else
-	echo "❌ No WASM file found"
-	exit 1
-fi
-'''
-dependencies = ["collectstatic-wasm"]
+description = "Generate WASM bindings using wasm-pack (release mode)"
+command = "wasm-pack"
+args = [
+	"build",
+	"--target", "web",
+	"--out-dir", "dist-wasm",
+	"--release",
+	"--no-typescript"
+]
+dependencies = ["wasm-compile-release"]
 
 [tasks.wasm-finalize-release]
 description = "Finalize WASM build (optimize with wasm-opt)"
-script = '''
-# Optimize with wasm-opt if available
-if command -v wasm-opt &> /dev/null; then
-	echo "Running wasm-opt..."
-	WASM_BG=$(ls dist/*_bg.wasm 2>/dev/null | head -1)
-	if [ -n "$WASM_BG" ]; then
-		wasm-opt -O3 "$WASM_BG" -o "$WASM_BG"
-		echo "✓ WASM optimized"
-	fi
-else
-	echo "⚠️  wasm-opt not found, skipping optimization"
-fi
-
-echo "✓ WASM build completed: dist/"
-'''
+script = { file = "scripts/wasm-build-release.sh" }
 dependencies = ["wasm-bindgen-release"]
 
 [tasks.wasm-build-release]

--- a/crates/reinhardt-commands/templates/project_pages_template/README.md.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/README.md.tpl
@@ -6,7 +6,7 @@ A Reinhardt Pages project with WASM frontend and server-side rendering.
 
 - Rust 1.96.0 or later (2024 Edition)
 - cargo-make: `cargo install cargo-make`
-- wasm-bindgen-cli matching the project version (installed by `cargo make install-tools`)
+- wasm-pack for the browser bundle (installed by `cargo make install-tools`)
 - PostgreSQL (optional, for database features)
 
 ## Getting Started
@@ -62,7 +62,9 @@ cargo build --release
 │   │   └── forms.rs
 │   └── config/       # Server configuration
 ├── dist/             # WASM build output
+├── dist-wasm/        # wasm-pack output copied into dist/
 ├── index.html        # WASM entry HTML
+├── scripts/          # cargo-make helper scripts
 └── Cargo.toml
 ```
 
@@ -96,4 +98,4 @@ cargo make wasm-clean          # Clean WASM build artifacts
 
 - [Reinhardt Documentation](https://github.com/kent8192/reinhardt-rs)
 - [Reinhardt Pages Guide](https://github.com/kent8192/reinhardt-rs/tree/main/docs)
-- [wasm-bindgen Documentation](https://rustwasm.github.io/wasm-bindgen/)
+- [wasm-pack Documentation](https://rustwasm.github.io/wasm-pack/)

--- a/crates/reinhardt-commands/templates/project_pages_template/scripts/wasm-build-dev.sh
+++ b/crates/reinhardt-commands/templates/project_pages_template/scripts/wasm-build-dev.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running collectstatic..."
+cargo run --bin manage collectstatic --no-input
+mkdir -p dist
+find dist-wasm -maxdepth 1 -type f \( -name '*.js' -o -name '*.wasm' -o -name '*.d.ts' \) -exec cp -f {} dist/ \;
+echo "✓ WASM build and collectstatic completed"

--- a/crates/reinhardt-commands/templates/project_pages_template/scripts/wasm-build-release.sh
+++ b/crates/reinhardt-commands/templates/project_pages_template/scripts/wasm-build-release.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running collectstatic..."
+cargo run --bin manage collectstatic --no-input
+mkdir -p dist
+find dist-wasm -maxdepth 1 -type f \( -name '*.js' -o -name '*.wasm' -o -name '*.d.ts' \) -exec cp -f {} dist/ \;
+
+if command -v wasm-opt >/dev/null 2>&1; then
+	echo "Running wasm-opt..."
+	WASM_BG=$(find dist -maxdepth 1 -type f -name '*_bg.wasm' -print -quit)
+	if [ -n "$WASM_BG" ]; then
+		wasm-opt -O3 "$WASM_BG" -o "$WASM_BG.opt"
+		mv "$WASM_BG.opt" "$WASM_BG"
+		echo "✓ WASM optimized"
+	fi
+else
+	echo "⚠️  wasm-opt not found, skipping optimization"
+fi
+
+echo "✓ WASM release build and collectstatic completed"

--- a/crates/reinhardt-commands/tests/cli_tests.rs
+++ b/crates/reinhardt-commands/tests/cli_tests.rs
@@ -876,7 +876,7 @@ fn test_collectstatic_decision_flag_combinations(
 /// Verifies that multiple ignore patterns are correctly handled.
 #[rstest]
 fn test_collectstatic_multiple_ignore_patterns() {
-	let patterns = vec![
+	let patterns = [
 		"*.map".to_string(),
 		"*.log".to_string(),
 		"*.tmp".to_string(),

--- a/crates/reinhardt-commands/tests/collectstatic_tests.rs
+++ b/crates/reinhardt-commands/tests/collectstatic_tests.rs
@@ -20,10 +20,10 @@ fn count_files_recursive(dir: &std::path::Path) -> usize {
 		let entry = entry.unwrap();
 		let path = entry.path();
 		// Skip hidden files (starting with '.') to match collectstatic's should_ignore()
-		if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-			if name.starts_with('.') {
-				continue;
-			}
+		if let Some(name) = path.file_name().and_then(|n| n.to_str())
+			&& name.starts_with('.')
+		{
+			continue;
 		}
 		if path.is_file() {
 			count += 1;

--- a/crates/reinhardt-commands/tests/e2e_pages.rs
+++ b/crates/reinhardt-commands/tests/e2e_pages.rs
@@ -125,6 +125,20 @@ async fn project_pages_layout_matches_tutorial() {
 		makefile.contains("[tasks.install-tools]"),
 		"Pages project Makefile.toml must include the install-tools task advertised by startproject:\n{makefile}"
 	);
+	assert!(
+		makefile.contains("command = \"wasm-pack\"")
+			&& makefile.contains("\"--out-dir\", \"dist-wasm\""),
+		"Pages project Makefile.toml must build browser artifacts through wasm-pack:\n{makefile}"
+	);
+	assert!(
+		!makefile.contains("ls target/wasm32-unknown-unknown") && !makefile.contains("head -1"),
+		"Pages project Makefile.toml must not select an arbitrary .wasm artifact:\n{makefile}"
+	);
+	assert!(
+		project.join("scripts/wasm-build-dev.sh").exists()
+			&& project.join("scripts/wasm-build-release.sh").exists(),
+		"Pages project must include WASM post-build helper scripts"
+	);
 
 	let settings_rs =
 		fs::read_to_string(src.join("config").join("settings.rs")).expect("read settings.rs");

--- a/crates/reinhardt-commands/tests/embedded_startproject.rs
+++ b/crates/reinhardt-commands/tests/embedded_startproject.rs
@@ -134,6 +134,15 @@ async fn startproject_pages_from_embedded_only() {
 	assert!(cargo_toml.contains(
 		"features = [\"standard\", \"pages\", \"admin\", \"conf\", \"commands\", \"db-postgres\"]"
 	));
+	assert!(
+		cargo_toml.contains("required-features = [\"with-reinhardt\"]"),
+		"generated pages manage binary must be native-feature gated:\n{cargo_toml}"
+	);
+	assert!(
+		cargo_toml.contains("default = [\"with-reinhardt\", \"client-router\"]")
+			&& cargo_toml.contains("msw = [\"reinhardt/msw\"]"),
+		"generated pages Cargo.toml must declare local feature gates used by WASM tests:\n{cargo_toml}"
+	);
 	let makefile_toml = std::fs::read_to_string(generated.join("Makefile.toml")).unwrap();
 	assert!(
 		makefile_toml.contains("\"--no-input\""),
@@ -142,6 +151,29 @@ async fn startproject_pages_from_embedded_only() {
 	assert!(
 		!makefile_toml.contains("\"--noinput\""),
 		"generated pages Makefile must not use the createsuperuser-only --noinput spelling"
+	);
+	assert!(
+		makefile_toml.contains("command = \"wasm-pack\"")
+			&& makefile_toml.contains("\"--out-dir\", \"dist-wasm\""),
+		"generated pages Makefile must build the browser bundle with wasm-pack into dist-wasm:\n{makefile_toml}"
+	);
+	assert!(
+		makefile_toml
+			.contains("args = [\"build\", \"--target\", \"wasm32-unknown-unknown\", \"--lib\"]")
+			&& makefile_toml.contains(
+				"args = [\"build\", \"--target\", \"wasm32-unknown-unknown\", \"--release\", \"--lib\"]"
+			),
+		"generated pages Makefile must compile only the library for WASM pre-checks:\n{makefile_toml}"
+	);
+	assert!(
+		!makefile_toml.contains("ls target/wasm32-unknown-unknown")
+			&& !makefile_toml.contains("head -1"),
+		"generated pages Makefile must not pick an arbitrary .wasm file such as manage.wasm:\n{makefile_toml}"
+	);
+	assert!(
+		generated.join("scripts/wasm-build-dev.sh").exists()
+			&& generated.join("scripts/wasm-build-release.sh").exists(),
+		"generated pages project must include WASM post-build scripts"
 	);
 	let build_rs = std::fs::read_to_string(generated.join("build.rs")).unwrap();
 	for cfg in ["client", "server", "wasm", "native"] {
@@ -207,4 +239,43 @@ async fn startproject_pages_adds_required_pages_features() {
 		"explicit db-sqlite selection must not be overwritten by db-postgres:\n{cargo_toml}"
 	);
 	assert_manifest_parses(&tmp.path().join("pages_feature_proj/Cargo.toml"));
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(cwd)]
+async fn startproject_pages_explicit_tutorial_features_get_minimal_runtime() {
+	let tmp = TempDir::new().unwrap();
+	let prev = std::env::current_dir().unwrap();
+	std::env::set_current_dir(tmp.path()).unwrap();
+
+	let mut ctx = CommandContext::new(vec!["pages_tutorial_proj".to_string()]);
+	let mut opts = HashMap::new();
+	opts.insert("with-pages".to_string(), vec!["true".to_string()]);
+	opts.insert(
+		"features".to_string(),
+		vec![
+			"pages,admin,conf,commands-server,commands-autoreload,db-sqlite,forms,auth-session,middleware,argon2-hasher,static-files"
+				.to_string(),
+		],
+	);
+	opts.insert("default-features".to_string(), vec!["false".to_string()]);
+	opts.insert("no-interactive".to_string(), vec!["true".to_string()]);
+	ctx = ctx.with_options(opts);
+
+	let res = StartProjectCommand.execute(&ctx).await;
+
+	std::env::set_current_dir(prev).unwrap();
+	res.expect("startproject --with-pages succeeds with tutorial-style explicit features");
+	let cargo_toml =
+		std::fs::read_to_string(tmp.path().join("pages_tutorial_proj/Cargo.toml")).unwrap();
+	assert!(
+		cargo_toml.contains("\"minimal\""),
+		"explicit Pages feature selections must be augmented with the minimal runtime facade:\n{cargo_toml}"
+	);
+	assert!(
+		cargo_toml.contains("\"db-sqlite\"") && !cargo_toml.contains("\"db-postgres\""),
+		"explicit SQLite selection must not be overwritten by db-postgres:\n{cargo_toml}"
+	);
+	assert_manifest_parses(&tmp.path().join("pages_tutorial_proj/Cargo.toml"));
 }

--- a/crates/reinhardt-commands/tests/ui.rs
+++ b/crates/reinhardt-commands/tests/ui.rs
@@ -139,7 +139,7 @@ fn test_command_decision_attribute_combinations(
 #[case(50, true)]
 #[case(100, true)]
 fn test_command_name_length_boundaries(#[case] length: usize, #[case] expected_valid: bool) {
-	let name: String = std::iter::repeat('a').take(length).collect();
+	let name = "a".repeat(length);
 	let is_valid = is_valid_command_name(&name);
 	assert_eq!(
 		is_valid, expected_valid,

--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -24,11 +24,11 @@ cargo install reinhardt-admin-cli --version "0.3.0-rc.2"
 
 The installed binary is `reinhardt-admin`.
 
-The pages template also needs the WASM target, `cargo-make`, and `wasm-pack`:
+Install `cargo-make`; the generated project can install the WASM target,
+`wasm-pack`, and the file watcher through its own `install-tools` task:
 
 ```bash
-rustup target add wasm32-unknown-unknown
-cargo install cargo-make wasm-pack
+cargo install cargo-make
 ```
 
 ## Create a Pages Project
@@ -38,6 +38,7 @@ Create a new project from the pages template:
 ```bash
 reinhardt-admin startproject tutorial --template pages
 cd tutorial
+cargo make install-tools
 ```
 
 The completed tutorial will eventually add `polls` and `users` apps. Do not create them yet. The first milestone is a project that can compile the browser entry point and serve the SPA shell.
@@ -87,7 +88,10 @@ Open `Cargo.toml`. The pages example builds an `rlib` for the native server and 
 crate-type = ["cdylib", "rlib"]  # cdylib for WASM, rlib for server
 ```
 
-The management command is native-only, so the binary is gated behind the `with-reinhardt` feature:
+The management command is native-only, so the binary is gated behind the
+`with-reinhardt` feature. The generated project enables that feature by default
+for native development, while `wasm-pack test -- --no-default-features` can skip
+the native-only binary:
 
 ```toml
 [[bin]]
@@ -96,27 +100,40 @@ path = "src/bin/manage.rs"
 required-features = ["with-reinhardt"]
 ```
 
-The dependency split is the important design. WASM gets pages and client routing; the server gets the full framework, database backends, forms, commands, and session auth:
+The generated feature section keeps those local gates explicit:
+
+```toml
+[features]
+default = ["with-reinhardt", "client-router"]
+client-router = []
+with-reinhardt = []
+msw = ["reinhardt/msw"]
+```
+
+The dependency split is the important design. WASM gets pages and client
+routing; the server gets the framework, database backend, commands, admin, and
+configuration features selected by `startproject`:
 
 ```toml
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-reinhardt = { workspace = true, features = ["pages", "client-router"] }
-wasm-bindgen = "0.2.106"
+reinhardt = { version = "0.3.0-rc.2", package = "reinhardt-web", default-features = false, features = ["pages", "client-router"] }
+wasm-bindgen = "=0.2.122"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reinhardt = { workspace = true, features = [
-    "full",
+reinhardt = { version = "0.3.0-rc.2", package = "reinhardt-web", default-features = false, features = [
+    "standard",
     "pages",
+    "admin",
     "conf",
     "commands",
     "db-postgres",
-    "db-sqlite",
-    "forms",
-    "client-router",
-    "auth-session",
 ] }
-tokio = { version = "1.48.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 ```
+
+If you pass an explicit SQLite feature list, keep the Pages runtime facade in
+place. Current `startproject` adds the required `minimal` feature automatically
+when a custom Pages list lacks a preset such as `standard`.
 
 In an example project, import Reinhardt APIs through the `reinhardt` facade. Do not depend on internal `reinhardt-*` crates directly.
 
@@ -244,6 +261,7 @@ Open `http://127.0.0.1:8000/`. At this point the application is only the shell. 
 
 Before continuing:
 
+- `cargo make install-tools` has installed the WASM target and `wasm-pack`.
 - `cargo make dev` starts the server.
 - The browser reaches `http://127.0.0.1:8000/`.
 - `settings/base.toml` contains `[core]`, `[core.databases.default]`, and `[contacts]`.


### PR DESCRIPTION
## Summary

This PR addresses:

- Repairing Pages scaffold feature selection so explicit custom feature lists get the required `minimal` facade runtime without overriding an explicit database backend.
- Switching generated Pages WASM builds from hand-picked `wasm-bindgen` input files to `wasm-pack` library builds, then copying the browser bundle into `dist/` after `collectstatic`.
- Updating the generated Pages README and basis tutorial project setup docs to match the current `0.3.0-rc.2` scaffold behavior.
- Keeping the touched `reinhardt-commands` test surface clean under Rust 1.96 clippy.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The basis tutorial validation found two scaffold gaps: custom Pages feature lists could omit the facade runtime required by generated code, and `cargo make wasm-build-dev` could bind the wrong `.wasm` file when the native `manage` binary was present.

Fixes #5420

Related to: #5398

## How Was This Tested?

- `cargo test -p reinhardt-commands --test embedded_startproject`
- `cargo test -p reinhardt-commands --test e2e_pages`
- `cargo test -p reinhardt-commands required_minimal_runtime_respects_presets_but_repairs_explicit_pages_list`
- Generated a fresh Pages project with `reinhardt-admin startproject tutorial --template pages --no-interactive`; ran `cargo make check` and `cargo make wasm-build-dev`; verified `dist/tutorial.js` and `dist/tutorial_bg.wasm` are produced.
- Generated the public-tutorial-style explicit SQLite feature project with `--default-features false`; verified `minimal` is added and `db-postgres` is not added; ran `cargo make check`.
- `zola build` in `website/`
- `cargo make fmt-check`
- `cargo clippy -p reinhardt-commands --all-targets --all-features -- -D warnings`
- `cargo test -p reinhardt-commands --test cli_tests test_collectstatic_multiple_ignore_patterns`
- `cargo test -p reinhardt-commands --test ui test_command_name_length_boundaries`
- `cargo test -p reinhardt-commands --test collectstatic_tests`

## Performance Impact

N/A

## Breaking Changes

N/A

## Screenshots

N/A

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5420
- Related to #5398

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [x] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This is intentionally opened as a draft because full workspace `cargo make clippy-check` was not run; the affected `reinhardt-commands` clippy surface was checked directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated WASM build helper scripts for development and release pipelines.

* **Bug Fixes**
  * Improved Pages project feature selection and dependency resolution logic.

* **Documentation**
  * Updated setup guides and project templates to reflect new WASM tooling and build structure.

* **Tests**
  * Enhanced test coverage for Pages project generation and feature handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->