### PR TITLE
fix(scaffolding): default pages projects to sqlite

### DIFF
--- a/.github/workflows/release-plz-dry-run.yml
+++ b/.github/workflows/release-plz-dry-run.yml
@@ -105,16 +105,19 @@ jobs:
           #
           # Ideal implementation (without workaround):
           #   release-plz release --dry-run --no-verify --git-token "$GITHUB_TOKEN"
+          skipped_crate_re='(reinhardt-[A-Za-z0-9_-]+)[[:space:]]+([^:[:space:]]+):[[:space:]]+due[[:space:]]+to[[:space:]]+dry,[[:space:]]+skipping'
+          requirement_re='^(reinhardt-[A-Za-z0-9_-]+)[[:space:]]*=[[:space:]]*"\^?([^"]+)"$'
+
           declare -A dry_skipped_crates=()
           while IFS= read -r line; do
-            if [[ "$line" =~ ^(reinhardt-[A-Za-z0-9_-]+)[[:space:]]+([^:[:space:]]+):[[:space:]]+due[[:space:]]+to[[:space:]]+dry,[[:space:]]+skipping ]]; then
+            if [[ "$line" =~ $skipped_crate_re ]]; then
               dry_skipped_crates["${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"]=1
             fi
           done < "$log"
 
           known_same_release_dependency_failure=false
           while IFS= read -r requirement; do
-            if [[ "$requirement" =~ ^(reinhardt-[A-Za-z0-9_-]+)[[:space:]]*=[[:space:]]*\"\^?([^\"]+)\"$ ]] \
+            if [[ "$requirement" =~ $requirement_re ]] \
               && [[ -n "${dry_skipped_crates["${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"]+set}" ]]
             then
               known_same_release_dependency_failure=true

--- a/crates/reinhardt-commands/src/project_config.rs
+++ b/crates/reinhardt-commands/src/project_config.rs
@@ -110,7 +110,7 @@ pub async fn resolve_dependency_selection(
 		if interactive {
 			prompt_features()?
 		} else {
-			vec!["standard".to_string()]
+			default_noninteractive_features(required_features)
 		}
 	} else {
 		explicit_features
@@ -127,6 +127,16 @@ pub async fn resolve_dependency_selection(
 		default_features,
 		features: normalize_features(features),
 	})
+}
+
+fn default_noninteractive_features(required_features: &[&str]) -> Vec<String> {
+	if required_features.iter().any(|feature| *feature == "pages") {
+		return required_features
+			.iter()
+			.map(|feature| (*feature).to_string())
+			.collect();
+	}
+	vec!["standard".to_string()]
 }
 
 fn should_prompt(ctx: &CommandContext) -> bool {
@@ -359,6 +369,22 @@ mod tests {
 	#[test]
 	fn features_toml_formats_array_literal() {
 		assert_eq!(selection().features_toml(), "[\"minimal\", \"db-sqlite\"]");
+	}
+
+	#[test]
+	fn noninteractive_pages_default_uses_required_features() {
+		assert_eq!(
+			default_noninteractive_features(&["minimal", "pages", "db-sqlite"]),
+			vec!["minimal", "pages", "db-sqlite"]
+		);
+	}
+
+	#[test]
+	fn noninteractive_non_pages_default_keeps_standard_preset() {
+		assert_eq!(
+			default_noninteractive_features(&["conf", "commands", "db-postgres", "api"]),
+			vec!["standard"]
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-commands/src/project_config.rs
+++ b/crates/reinhardt-commands/src/project_config.rs
@@ -130,7 +130,7 @@ pub async fn resolve_dependency_selection(
 }
 
 fn default_noninteractive_features(required_features: &[&str]) -> Vec<String> {
-	if required_features.iter().any(|feature| *feature == "pages") {
+	if required_features.contains(&"pages") {
 		return required_features
 			.iter()
 			.map(|feature| (*feature).to_string())

--- a/crates/reinhardt-commands/src/start_commands.rs
+++ b/crates/reinhardt-commands/src/start_commands.rs
@@ -122,6 +122,7 @@ impl BaseCommand for StartProjectCommand {
 		let secret_key = format!("insecure-{}", generate_secret_key());
 		let required_features = if with_pages {
 			&[
+				"minimal",
 				"pages",
 				"admin",
 				"conf",

--- a/crates/reinhardt-commands/templates/project_pages_template/build.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/build.rs.tpl
@@ -5,20 +5,20 @@
 use cfg_aliases::cfg_aliases;
 
 fn main() {
-	// Rust 2024 edition requires explicit check-cfg declarations
-	println!("cargo::rustc-check-cfg=cfg(client)");
-	println!("cargo::rustc-check-cfg=cfg(server)");
-	println!("cargo::rustc-check-cfg=cfg(wasm)");
-	println!("cargo::rustc-check-cfg=cfg(native)");
+    // Rust 2024 edition requires explicit check-cfg declarations
+    println!("cargo::rustc-check-cfg=cfg(client)");
+    println!("cargo::rustc-check-cfg=cfg(server)");
+    println!("cargo::rustc-check-cfg=cfg(wasm)");
+    println!("cargo::rustc-check-cfg=cfg(native)");
 
-	cfg_aliases! {
-		// Platform aliases for simpler conditional compilation
-		// Use `#[cfg(client)]` instead of `#[cfg(target_arch = "wasm32")]`
-		client: { target_arch = "wasm32" },
-		// Use `#[cfg(server)]` instead of `#[cfg(not(target_arch = "wasm32"))]`
-		server: { not(target_arch = "wasm32") },
-		// Compatibility aliases used by framework macro expansions.
-		wasm: { target_arch = "wasm32" },
-		native: { not(target_arch = "wasm32") },
-	}
+    cfg_aliases! {
+        // Platform aliases for simpler conditional compilation
+        // Use `#[cfg(client)]` instead of `#[cfg(target_arch = "wasm32")]`
+        client: { target_arch = "wasm32" },
+        // Use `#[cfg(server)]` instead of `#[cfg(not(target_arch = "wasm32"))]`
+        server: { not(target_arch = "wasm32") },
+        // Compatibility aliases used by framework macro expansions.
+        wasm: { target_arch = "wasm32" },
+        native: { not(target_arch = "wasm32") },
+    }
 }

--- a/crates/reinhardt-commands/templates/project_pages_template/src/bin/manage.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/bin/manage.rs.tpl
@@ -17,39 +17,39 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
-	// Force-link the parent library so its `#[routes]` / `#[model]`
-	// `inventory::submit!` registrations survive dead-code elimination.
-	// Referencing `get_settings` alone does not guarantee the whole crate
-	// (and thus every inventory entry) is linked.
-	use {{ crate_name }} as _;
-	use {{ crate_name }}::config::settings::get_settings;
-	use reinhardt::commands::execute_from_command_line_with_settings;
-	use std::process;
+    // Force-link the parent library so its `#[routes]` / `#[model]`
+    // `inventory::submit!` registrations survive dead-code elimination.
+    // Referencing `get_settings` alone does not guarantee the whole crate
+    // (and thus every inventory entry) is linked.
+    use reinhardt::commands::execute_from_command_line_with_settings;
+    use std::process;
+    use {{ crate_name }} as _;
+    use {{ crate_name }}::config::settings::get_settings;
 
-	#[tokio::main]
-	pub(super) async fn main() {
-		// Set settings module environment variable
-		// SAFETY: Called at program start before any spawned tasks.
-		unsafe {
-			std::env::set_var("REINHARDT_SETTINGS_MODULE", "{{ project_name }}.config.settings");
-		}
+    #[tokio::main]
+    pub(super) async fn main() {
+        // Set settings module environment variable
+        // SAFETY: Called at program start before any spawned tasks.
+        unsafe {
+            std::env::set_var("REINHARDT_SETTINGS_MODULE", "{{ project_name }}.config.settings");
+        }
 
-		// Hand the project's composed settings to the runtime so that
-		// database-requiring commands (migrate, makemigrations, runserver,
-		// createsuperuser) resolve the connection from settings/*.toml
-		// (`[core.databases.default]`) without requiring DATABASE_URL.
-		// Router registration still happens automatically inside the runtime
-		// via the #[routes] attribute macro in src/config/urls.rs.
-		if let Err(e) = execute_from_command_line_with_settings(get_settings()).await {
-			eprintln!("Error: {}", e);
-			process::exit(1);
-		}
-	}
+        // Hand the project's composed settings to the runtime so that
+        // database-requiring commands (migrate, makemigrations, runserver,
+        // createsuperuser) resolve the connection from settings/*.toml
+        // (`[core.databases.default]`) without requiring DATABASE_URL.
+        // Router registration still happens automatically inside the runtime
+        // via the #[routes] attribute macro in src/config/urls.rs.
+        if let Err(e) = execute_from_command_line_with_settings(get_settings()).await {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-	native::main();
+    native::main();
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/reinhardt-commands/templates/project_pages_template/src/client/components/nav.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/client/components/nav.rs.tpl
@@ -8,15 +8,15 @@ use reinhardt::pages::page;
 
 /// Render the shared navigation bar.
 pub fn nav_bar() -> Page {
-	page!(|| {
-		nav {
-			class: "navbar",
-			"{{ project_name }}"
-		}
-	})()
+    page!(|| {
+        nav {
+            class: "navbar",
+            "{{ project_name }}"
+        }
+    })()
 }
 
 /// Wrap an app body with the shared nav bar.
 pub fn with_nav(body: Page) -> Page {
-	Page::Fragment(vec![nav_bar(), body])
+    Page::Fragment(vec![nav_bar(), body])
 }

--- a/crates/reinhardt-commands/templates/project_pages_template/src/client/lib.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/client/lib.rs.tpl
@@ -11,7 +11,7 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]
 pub fn main() -> Result<(), JsValue> {
-	ClientLauncher::new("#root")
-		.register_routes_from_inventory()
-		.launch()
+    ClientLauncher::new("#root")
+        .register_routes_from_inventory()
+        .launch()
 }

--- a/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/config/settings.rs.tpl
@@ -43,9 +43,7 @@
 
 use reinhardt::conf::settings::builder::SettingsBuilder;
 use reinhardt::conf::settings::profile::Profile;
-use reinhardt::conf::settings::sources::{
-	DefaultSource, HighPriorityEnvSource, TomlFileSource,
-};
+use reinhardt::conf::settings::sources::{DefaultSource, HighPriorityEnvSource, TomlFileSource};
 use reinhardt::settings;
 use std::env;
 
@@ -73,46 +71,46 @@ pub struct ProjectSettings;
 /// - Settings cannot be deserialized
 /// - Required settings are missing
 pub fn get_settings() -> ProjectSettings {
-	let profile_str = env::var("REINHARDT_ENV").unwrap_or_else(|_| "local".to_string());
-	let profile = Profile::parse(&profile_str);
+    let profile_str = env::var("REINHARDT_ENV").unwrap_or_else(|_| "local".to_string());
+    let profile = Profile::parse(&profile_str);
 
-	// Get the project root directory (parent of src/)
-	let base_dir = env::current_dir().expect("Failed to get current directory");
-	let settings_dir = base_dir.join("settings");
+    // Get the project root directory (parent of src/)
+    let base_dir = env::current_dir().expect("Failed to get current directory");
+    let settings_dir = base_dir.join("settings");
 
-	// Build settings by merging sources in priority order.
-	// `build_composed::<T>()` uses `MergeStrategy::Deep` by default, so a
-	// single key in `production.toml` overrides only that key — sibling
-	// entries inside the same nested table inherit from `base.toml`.
-	SettingsBuilder::new()
-		.profile(profile)
-		// Lowest priority: Default values
-		.add_source(DefaultSource::new())
-		// Medium priority: Base TOML file
-		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
-		// Profile priority: Environment-specific TOML file
-		.add_source(TomlFileSource::new(
-			settings_dir.join(format!("{}.toml", profile_str)),
-		))
-		// Highest priority: explicit process environment overrides
-		.add_source(HighPriorityEnvSource::new().with_prefix("REINHARDT_"))
-		.build_composed::<ProjectSettings>()
-		.unwrap_or_else(|err| {
-			panic!("Failed to build/compose settings for profile `{profile_str}`: {err}")
-		})
+    // Build settings by merging sources in priority order.
+    // `build_composed::<T>()` uses `MergeStrategy::Deep` by default, so a
+    // single key in `production.toml` overrides only that key — sibling
+    // entries inside the same nested table inherit from `base.toml`.
+    SettingsBuilder::new()
+        .profile(profile)
+        // Lowest priority: Default values
+        .add_source(DefaultSource::new())
+        // Medium priority: Base TOML file
+        .add_source(TomlFileSource::new(settings_dir.join("base.toml")))
+        // Profile priority: Environment-specific TOML file
+        .add_source(TomlFileSource::new(
+            settings_dir.join(format!("{}.toml", profile_str)),
+        ))
+        // Highest priority: explicit process environment overrides
+        .add_source(HighPriorityEnvSource::new().with_prefix("REINHARDT_"))
+        .build_composed::<ProjectSettings>()
+        .unwrap_or_else(|err| {
+            panic!("Failed to build/compose settings for profile `{profile_str}`: {err}")
+        })
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn test_get_settings() {
-		// Smoke test: ensures settings load without panic and required fields are present
-		let settings = get_settings();
-		assert!(
-			!settings.core.secret_key.is_empty(),
-			"secret_key should be populated from settings sources"
-		);
-	}
+    #[test]
+    fn test_get_settings() {
+        // Smoke test: ensures settings load without panic and required fields are present
+        let settings = get_settings();
+        assert!(
+            !settings.core.secret_key.is_empty(),
+            "secret_key should be populated from settings sources"
+        );
+    }
 }

--- a/crates/reinhardt-commands/templates/project_pages_template/src/config/wasm.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/config/wasm.rs.tpl
@@ -7,9 +7,9 @@
 use reinhardt::reinhardt_apps::AppStaticFilesConfig;
 
 inventory::submit! {
-	AppStaticFilesConfig {
-		app_label: "{{ crate_name }}-wasm",
-		static_dir: "dist-wasm",
-		url_prefix: "",
-	}
+    AppStaticFilesConfig {
+        app_label: "{{ crate_name }}-wasm",
+        static_dir: "dist-wasm",
+        url_prefix: "",
+    }
 }

--- a/crates/reinhardt-commands/templates/project_pages_template/src/lib.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/lib.rs.tpl
@@ -15,11 +15,11 @@
 // of feature combination.
 #[cfg(server)]
 mod server_only {
-	pub use reinhardt::core::async_trait;
-	pub use reinhardt::reinhardt_apps;
-	pub use reinhardt::reinhardt_core;
-	pub use reinhardt::reinhardt_di::params;
-	pub use reinhardt::reinhardt_http;
+    pub use reinhardt::core::async_trait;
+    pub use reinhardt::reinhardt_apps;
+    pub use reinhardt::reinhardt_core;
+    pub use reinhardt::reinhardt_di::params;
+    pub use reinhardt::reinhardt_http;
 }
 #[cfg(server)]
 pub use server_only::*;

--- a/crates/reinhardt-commands/templates/project_pages_template/tests/integration.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/tests/integration.rs.tpl
@@ -15,10 +15,10 @@ use rstest::*;
 
 #[rstest]
 fn smoke_crate_compiles() {
-	// Arrange / Act
-	// The crate links because this binary is part of the same package.
-	let crate_name: &str = env!("CARGO_PKG_NAME");
+    // Arrange / Act
+    // The crate links because this binary is part of the same package.
+    let crate_name: &str = env!("CARGO_PKG_NAME");
 
-	// Assert
-	assert_eq!(crate_name, "{{ crate_name }}");
+    // Assert
+    assert_eq!(crate_name, "{{ crate_name }}");
 }

--- a/crates/reinhardt-commands/tests/embedded_startproject.rs
+++ b/crates/reinhardt-commands/tests/embedded_startproject.rs
@@ -31,6 +31,25 @@ fn assert_manifest_parses(manifest: &Path) {
 	);
 }
 
+fn assert_generated_rust_sources_do_not_use_tab_indents(root: &Path) {
+	for relative in [
+		"build.rs",
+		"src/bin/manage.rs",
+		"src/client/components/nav.rs",
+		"src/client/lib.rs",
+		"src/config/settings.rs",
+		"src/config/wasm.rs",
+		"src/lib.rs",
+		"tests/integration.rs",
+	] {
+		let content = std::fs::read_to_string(root.join(relative)).unwrap();
+		assert!(
+			!content.contains('\t'),
+			"generated Rust source should be rustfmt-clean before cargo make dev: {relative}"
+		);
+	}
+}
+
 #[rstest]
 #[tokio::test]
 #[serial(cwd)]
@@ -131,8 +150,12 @@ async fn startproject_pages_from_embedded_only() {
 		"package = \"reinhardt-web\", default-features = false, features = [\"pages\", \"client-router\"]"
 	));
 	assert!(cargo_toml.contains(
-		"features = [\"standard\", \"pages\", \"admin\", \"conf\", \"commands-server\", \"commands-autoreload\", \"db-sqlite\", \"forms\", \"auth-session\", \"middleware\", \"argon2-hasher\", \"static-files\"]"
+		"features = [\"minimal\", \"pages\", \"admin\", \"conf\", \"commands-server\", \"commands-autoreload\", \"db-sqlite\", \"forms\", \"auth-session\", \"middleware\", \"argon2-hasher\", \"static-files\"]"
 	));
+	assert!(
+		!cargo_toml.contains("\"standard\"") && !cargo_toml.contains("\"db-postgres\""),
+		"generated pages manifest must not require PostgreSQL defaults:\n{cargo_toml}"
+	);
 	assert!(
 		cargo_toml.contains("required-features = [\"with-reinhardt\"]")
 			&& cargo_toml.contains("default = [\"with-reinhardt\"]"),
@@ -210,6 +233,7 @@ async fn startproject_pages_from_embedded_only() {
 		shared_types.contains("// use serde::{Deserialize, Serialize};"),
 		"generated shared types placeholder should keep the serde import in the commented example:\n{shared_types}"
 	);
+	assert_generated_rust_sources_do_not_use_tab_indents(&generated);
 	assert_manifest_parses(&generated.join("Cargo.toml"));
 }
 

--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -15,11 +15,14 @@ The finished reference for this tutorial is `examples/examples-tutorial-basis`. 
 
 ## Install the Tools
 
+Use Rust 1.96.0 or newer. The `0.3.0-rc.4` generator and the generated Rust
+2024 project require that toolchain level.
+
 Install the Reinhardt project generator:
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.2.1"
+cargo install reinhardt-admin-cli --version "0.3.0-rc.4"
 ```
 
 The installed binary is `reinhardt-admin`.
@@ -39,7 +42,7 @@ your `Cargo.toml` matches the reference project:
 
 ```bash
 reinhardt-admin startproject tutorial --template pages \
-  --features pages,admin,conf,commands-server,commands-autoreload,db-sqlite,forms,auth-session,middleware,argon2-hasher,static-files \
+  --features minimal,pages,admin,conf,commands-server,commands-autoreload,db-sqlite,forms,auth-session,middleware,argon2-hasher,static-files \
   --default-features false \
   --no-interactive
 cd tutorial
@@ -115,6 +118,7 @@ wasm-bindgen = "=0.2.122"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 reinhardt = { workspace = true, features = [
+    "minimal",
     "pages",
     "conf",
     "commands-server",

--- a/website/content/quickstart/tutorials/basis/_index.md
+++ b/website/content/quickstart/tutorials/basis/_index.md
@@ -22,7 +22,7 @@ The reference implementation lives in [`examples/examples-tutorial-basis`](https
 
 ## Prerequisites
 
-- Basic Rust and Cargo knowledge.
+- Rust 1.96.0 or newer, plus basic Rust and Cargo knowledge.
 - `cargo make` installed.
 - `wasm32-unknown-unknown` target and `wasm-pack` installed.
 - SQLite support through the Reinhardt feature flags used in Part 1.


### PR DESCRIPTION
## Summary

This PR addresses:

- Default generated Pages projects to the explicit minimal SQLite feature set instead of the `standard` PostgreSQL preset.
- Keep generated Pages Rust templates formatter-clean so `cargo make dev` does not stop during `fmt-check`.
- Update the basis tutorial to install `reinhardt-admin-cli` `0.3.0-rc.4` and require Rust 1.96.0 or newer.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The basis quickstart should produce a runnable Pages project without requiring a PostgreSQL container or manual feature edits. The generated native target already has SQLite settings, so the native `reinhardt` dependency must not retain the `standard` preset that pulls in `db-postgres`.

Fixes #5420

Related to: #5398

## How Was This Tested?

- `cargo fmt --check`
- `cargo test -p reinhardt-commands --test embedded_startproject -- --nocapture`
- `cargo test -p reinhardt-commands project_config --lib`
- Generated a temporary Pages project with the tutorial feature list and `--reinhardt-version 0.3.0-rc.4`, then ran local `reinhardt-admin fmt <project> --check` and confirmed `0 would be formatted`.
- `cargo search reinhardt-admin-cli --limit 3` confirmed `reinhardt-admin-cli = "0.3.0-rc.4"` is now published.

## Performance Impact

No runtime performance impact expected.

## Breaking Changes

None.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5420
- Related to #5398

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This PR intentionally leaves RESTful noninteractive defaults unchanged and only special-cases Pages scaffolding, where the tutorial uses SQLite by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project scaffolding now includes the `minimal` feature for pages-based projects, and non-interactive setup better preserves required feature selections.

* **Bug Fixes**
  * Generated projects now avoid tab-indented Rust source files.
  * Pages project defaults no longer add unexpected feature selections in generated manifests.

* **Documentation**
  * Updated quickstart instructions to require Rust 1.96.0+ and the latest project generator version.
  * Aligned tutorial examples with the new `minimal` feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->