### PR TITLE
perf(db): reduce pool acquire overhead

### DIFF
--- a/crates/reinhardt-db/src/backends_pool/pool.rs
+++ b/crates/reinhardt-db/src/backends_pool/pool.rs
@@ -5,16 +5,56 @@ use super::errors::{PoolError, PoolResult};
 use super::events::{PoolEvent, PoolEventListener};
 use sqlx::{Database, MySql, Pool, Postgres, Sqlite};
 use std::mem::ManuallyDrop;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 use tokio::sync::RwLock;
+
+fn generate_connection_id() -> String {
+	uuid::Uuid::now_v7().to_string()
+}
+
+struct PoolEventHub {
+	listeners: RwLock<Vec<Arc<dyn PoolEventListener>>>,
+	listener_count: AtomicUsize,
+}
+
+impl PoolEventHub {
+	fn new() -> Self {
+		Self {
+			listeners: RwLock::new(Vec::new()),
+			listener_count: AtomicUsize::new(0),
+		}
+	}
+
+	fn has_listeners(&self) -> bool {
+		self.listener_count.load(Ordering::Acquire) > 0
+	}
+
+	async fn add_listener(&self, listener: Arc<dyn PoolEventListener>) {
+		let mut listeners = self.listeners.write().await;
+		listeners.push(listener);
+		self.listener_count
+			.store(listeners.len(), Ordering::Release);
+	}
+
+	async fn emit_event(&self, event: PoolEvent) {
+		if !self.has_listeners() {
+			return;
+		}
+
+		let listeners = self.listeners.read().await;
+		for listener in listeners.iter() {
+			listener.on_event(event.clone()).await;
+		}
+	}
+}
 
 /// A database connection pool
 pub struct ConnectionPool<DB: Database> {
 	pool: Pool<DB>,
 	config: PoolConfig,
 	url: String,
-	listeners: Arc<RwLock<Vec<Arc<dyn PoolEventListener>>>>,
+	events: Arc<PoolEventHub>,
 	first_connect_fired: Arc<AtomicBool>,
 }
 
@@ -52,7 +92,7 @@ impl ConnectionPool<Postgres> {
 			pool,
 			config,
 			url: url.to_string(),
-			listeners: Arc::new(RwLock::new(Vec::new())),
+			events: Arc::new(PoolEventHub::new()),
 			first_connect_fired: Arc::new(AtomicBool::new(false)),
 		})
 	}
@@ -92,7 +132,7 @@ impl ConnectionPool<MySql> {
 			pool,
 			config,
 			url: url.to_string(),
-			listeners: Arc::new(RwLock::new(Vec::new())),
+			events: Arc::new(PoolEventHub::new()),
 			first_connect_fired: Arc::new(AtomicBool::new(false)),
 		})
 	}
@@ -132,7 +172,7 @@ impl ConnectionPool<Sqlite> {
 			pool,
 			config,
 			url: url.to_string(),
-			listeners: Arc::new(RwLock::new(Vec::new())),
+			events: Arc::new(PoolEventHub::new()),
 			first_connect_fired: Arc::new(AtomicBool::new(false)),
 		})
 	}
@@ -145,16 +185,12 @@ where
 	/// Add an event listener
 	///
 	pub async fn add_listener(&self, listener: Arc<dyn PoolEventListener>) {
-		let mut listeners = self.listeners.write().await;
-		listeners.push(listener);
+		self.events.add_listener(listener).await;
 	}
 
 	/// Emit an event to all listeners
 	pub(crate) async fn emit_event(&self, event: PoolEvent) {
-		let listeners = self.listeners.read().await;
-		for listener in listeners.iter() {
-			listener.on_event(event.clone()).await;
-		}
+		self.events.emit_event(event).await;
 	}
 	/// Acquire a connection from the pool with event emission
 	///
@@ -182,33 +218,25 @@ where
 		let is_first = !self.first_connect_fired.swap(true, Ordering::SeqCst);
 
 		let conn = self.pool.acquire().await?;
-		let connection_id = uuid::Uuid::now_v7().to_string();
+		let connection_id = OnceLock::new();
 
-		if is_first {
-			// Emit first_connect event (using ConnectionCreated as proxy)
-			self.emit_event(PoolEvent::connection_created(connection_id.clone()))
-				.await;
+		if self.events.has_listeners() {
+			let id = connection_id.get_or_init(generate_connection_id).clone();
+
+			if is_first {
+				// Emit first_connect event (using ConnectionCreated as proxy)
+				self.emit_event(PoolEvent::connection_created(id.clone()))
+					.await;
+			}
+
+			// Emit checkout event
+			self.emit_event(PoolEvent::connection_acquired(id)).await;
 		}
-
-		// Emit checkout event
-		self.emit_event(PoolEvent::connection_acquired(connection_id.clone()))
-			.await;
 
 		Ok(PooledConnection {
 			conn: ManuallyDrop::new(conn),
-			pool_ref: self.clone_arc(),
+			events: self.events.clone(),
 			connection_id,
-		})
-	}
-
-	/// Clone as Arc for sharing with PooledConnection
-	fn clone_arc(&self) -> Arc<Self> {
-		Arc::new(Self {
-			pool: self.pool.clone(),
-			config: self.config.clone(),
-			url: self.url.clone(),
-			listeners: self.listeners.clone(),
-			first_connect_fired: self.first_connect_fired.clone(),
 		})
 	}
 	/// Get the underlying pool
@@ -381,8 +409,8 @@ pub struct PooledConnection<DB: sqlx::Database> {
 	// When no tokio runtime is available, we detach the connection
 	// to avoid sqlx's PoolConnection::Drop calling rt::spawn().
 	conn: ManuallyDrop<sqlx::pool::PoolConnection<DB>>,
-	pool_ref: Arc<ConnectionPool<DB>>,
-	connection_id: String,
+	events: Arc<PoolEventHub>,
+	connection_id: OnceLock<String>,
 }
 
 impl<DB: sqlx::Database> PooledConnection<DB> {
@@ -413,34 +441,49 @@ impl<DB: sqlx::Database> PooledConnection<DB> {
 	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());
 	/// ```
 	pub fn connection_id(&self) -> &str {
-		&self.connection_id
+		self.connection_id
+			.get_or_init(generate_connection_id)
+			.as_str()
 	}
 	/// Invalidate this connection (hard invalidation - connection is unusable)
 	///
 	pub async fn invalidate(self, reason: String) {
-		self.pool_ref
-			.emit_event(PoolEvent::connection_invalidated(
-				self.connection_id.clone(),
-				reason,
-			))
-			.await;
+		if self.events.has_listeners() {
+			let connection_id = self
+				.connection_id
+				.get_or_init(generate_connection_id)
+				.clone();
+			self.events
+				.emit_event(PoolEvent::connection_invalidated(connection_id, reason))
+				.await;
+		}
 		// Connection will be dropped and not returned to pool
 	}
 	/// Soft invalidate this connection (can complete current operation)
 	///
 	pub async fn soft_invalidate(&mut self) {
-		self.pool_ref
-			.emit_event(PoolEvent::connection_soft_invalidated(
-				self.connection_id.clone(),
-			))
-			.await;
+		if self.events.has_listeners() {
+			let connection_id = self
+				.connection_id
+				.get_or_init(generate_connection_id)
+				.clone();
+			self.events
+				.emit_event(PoolEvent::connection_soft_invalidated(connection_id))
+				.await;
+		}
 	}
 	/// Reset this connection
 	///
 	pub async fn reset(&mut self) {
-		self.pool_ref
-			.emit_event(PoolEvent::connection_reset(self.connection_id.clone()))
-			.await;
+		if self.events.has_listeners() {
+			let connection_id = self
+				.connection_id
+				.get_or_init(generate_connection_id)
+				.clone();
+			self.events
+				.emit_event(PoolEvent::connection_reset(connection_id))
+				.await;
+		}
 	}
 }
 
@@ -455,14 +498,19 @@ impl<DB: sqlx::Database> Drop for PooledConnection<DB> {
 				// and emit the connection-returned event.
 				drop(conn);
 
-				let pool_ref = self.pool_ref.clone();
-				let connection_id = self.connection_id.clone();
+				if self.events.has_listeners() {
+					let events = self.events.clone();
+					let connection_id = self
+						.connection_id
+						.get_or_init(generate_connection_id)
+						.clone();
 
-				handle.spawn(async move {
-					pool_ref
-						.emit_event(PoolEvent::connection_returned(connection_id))
-						.await;
-				});
+					handle.spawn(async move {
+						events
+							.emit_event(PoolEvent::connection_returned(connection_id))
+							.await;
+					});
+				}
 			}
 			Err(_) => {
 				// No runtime available: prevent sqlx's PoolConnection::Drop
@@ -479,6 +527,31 @@ impl<DB: sqlx::Database> Drop for PooledConnection<DB> {
 mod tests {
 	use super::*;
 	use rstest::rstest;
+	use std::sync::Mutex;
+
+	struct RecordingListener {
+		events: Arc<Mutex<Vec<&'static str>>>,
+	}
+
+	#[async_trait::async_trait]
+	impl PoolEventListener for RecordingListener {
+		async fn on_event(&self, event: PoolEvent) {
+			let name = match event {
+				PoolEvent::ConnectionAcquired { .. } => "acquired",
+				PoolEvent::ConnectionReturned { .. } => "returned",
+				PoolEvent::ConnectionCreated { .. } => "created",
+				PoolEvent::ConnectionClosed { .. } => "closed",
+				PoolEvent::ConnectionTestFailed { .. } => "test_failed",
+				PoolEvent::ConnectionInvalidated { .. } => "invalidated",
+				PoolEvent::ConnectionSoftInvalidated { .. } => "soft_invalidated",
+				PoolEvent::ConnectionReset { .. } => "reset",
+			};
+			self.events
+				.lock()
+				.expect("events mutex should not be poisoned")
+				.push(name);
+		}
+	}
 
 	#[rstest]
 	fn handle_try_current_returns_err_outside_runtime() {
@@ -553,5 +626,31 @@ mod tests {
 
 		// Also drop the pool to ensure cleanup does not panic outside a runtime.
 		drop(pool);
+	}
+
+	#[tokio::test]
+	async fn pool_events_are_emitted_when_listener_registered() {
+		// Arrange
+		let events = Arc::new(Mutex::new(Vec::new()));
+		let listener = Arc::new(RecordingListener {
+			events: events.clone(),
+		});
+		let pool = ConnectionPool::new_sqlite("sqlite::memory:", PoolConfig::default())
+			.await
+			.expect("failed to create ConnectionPool");
+		pool.add_listener(listener).await;
+
+		// Act
+		let conn = pool.acquire().await.expect("failed to acquire connection");
+		drop(conn);
+		tokio::task::yield_now().await;
+
+		// Assert
+		let recorded = events.lock().expect("events mutex should not be poisoned");
+		assert_eq!(
+			recorded.as_slice(),
+			["created", "acquired", "returned"],
+			"pool listener should observe the first acquire and return events"
+		);
 	}
 }

--- a/crates/reinhardt-db/src/pool/pool.rs
+++ b/crates/reinhardt-db/src/pool/pool.rs
@@ -5,8 +5,8 @@ use super::errors::{PoolError, PoolResult};
 use super::events::{PoolEvent, PoolEventListener};
 use sqlx::{Database, MySql, Pool, Postgres, Sqlite};
 use std::mem::ManuallyDrop;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 use tokio::sync::RwLock;
 
 /// Mask the password in a database URL for safe display.
@@ -37,12 +37,52 @@ pub(crate) fn mask_url_password(url: &str) -> String {
 	url.to_string()
 }
 
+fn generate_connection_id() -> String {
+	uuid::Uuid::now_v7().to_string()
+}
+
+struct PoolEventHub {
+	listeners: RwLock<Vec<Arc<dyn PoolEventListener>>>,
+	listener_count: AtomicUsize,
+}
+
+impl PoolEventHub {
+	fn new() -> Self {
+		Self {
+			listeners: RwLock::new(Vec::new()),
+			listener_count: AtomicUsize::new(0),
+		}
+	}
+
+	fn has_listeners(&self) -> bool {
+		self.listener_count.load(Ordering::Acquire) > 0
+	}
+
+	async fn add_listener(&self, listener: Arc<dyn PoolEventListener>) {
+		let mut listeners = self.listeners.write().await;
+		listeners.push(listener);
+		self.listener_count
+			.store(listeners.len(), Ordering::Release);
+	}
+
+	async fn emit_event(&self, event: PoolEvent) {
+		if !self.has_listeners() {
+			return;
+		}
+
+		let listeners = self.listeners.read().await;
+		for listener in listeners.iter() {
+			listener.on_event(event.clone()).await;
+		}
+	}
+}
+
 /// A database connection pool
 pub struct ConnectionPool<DB: Database> {
 	pool: Pool<DB>,
 	config: PoolConfig,
 	url: String,
-	listeners: Arc<RwLock<Vec<Arc<dyn PoolEventListener>>>>,
+	events: Arc<PoolEventHub>,
 	first_connect_fired: Arc<AtomicBool>,
 }
 
@@ -80,7 +120,7 @@ impl ConnectionPool<Postgres> {
 			pool,
 			config,
 			url: url.to_string(),
-			listeners: Arc::new(RwLock::new(Vec::new())),
+			events: Arc::new(PoolEventHub::new()),
 			first_connect_fired: Arc::new(AtomicBool::new(false)),
 		})
 	}
@@ -120,7 +160,7 @@ impl ConnectionPool<MySql> {
 			pool,
 			config,
 			url: url.to_string(),
-			listeners: Arc::new(RwLock::new(Vec::new())),
+			events: Arc::new(PoolEventHub::new()),
 			first_connect_fired: Arc::new(AtomicBool::new(false)),
 		})
 	}
@@ -160,7 +200,7 @@ impl ConnectionPool<Sqlite> {
 			pool,
 			config,
 			url: url.to_string(),
-			listeners: Arc::new(RwLock::new(Vec::new())),
+			events: Arc::new(PoolEventHub::new()),
 			first_connect_fired: Arc::new(AtomicBool::new(false)),
 		})
 	}
@@ -173,16 +213,12 @@ where
 	/// Add an event listener
 	///
 	pub async fn add_listener(&self, listener: Arc<dyn PoolEventListener>) {
-		let mut listeners = self.listeners.write().await;
-		listeners.push(listener);
+		self.events.add_listener(listener).await;
 	}
 
 	/// Emit an event to all listeners
 	pub(crate) async fn emit_event(&self, event: PoolEvent) {
-		let listeners = self.listeners.read().await;
-		for listener in listeners.iter() {
-			listener.on_event(event.clone()).await;
-		}
+		self.events.emit_event(event).await;
 	}
 	/// Acquire a connection from the pool with event emission
 	///
@@ -207,33 +243,25 @@ where
 		let is_first = !self.first_connect_fired.swap(true, Ordering::SeqCst);
 
 		let conn = self.pool.acquire().await?;
-		let connection_id = uuid::Uuid::now_v7().to_string();
+		let connection_id = OnceLock::new();
 
-		if is_first {
-			// Emit first_connect event (using ConnectionCreated as proxy)
-			self.emit_event(PoolEvent::connection_created(connection_id.clone()))
-				.await;
+		if self.events.has_listeners() {
+			let id = connection_id.get_or_init(generate_connection_id).clone();
+
+			if is_first {
+				// Emit first_connect event (using ConnectionCreated as proxy)
+				self.emit_event(PoolEvent::connection_created(id.clone()))
+					.await;
+			}
+
+			// Emit checkout event
+			self.emit_event(PoolEvent::connection_acquired(id)).await;
 		}
-
-		// Emit checkout event
-		self.emit_event(PoolEvent::connection_acquired(connection_id.clone()))
-			.await;
 
 		Ok(PooledConnection {
 			conn: ManuallyDrop::new(conn),
-			pool_ref: self.clone_arc(),
+			events: self.events.clone(),
 			connection_id,
-		})
-	}
-
-	/// Clone as Arc for sharing with PooledConnection
-	fn clone_arc(&self) -> Arc<Self> {
-		Arc::new(Self {
-			pool: self.pool.clone(),
-			config: self.config.clone(),
-			url: self.url.clone(),
-			listeners: self.listeners.clone(),
-			first_connect_fired: self.first_connect_fired.clone(),
 		})
 	}
 	/// Get the underlying pool
@@ -416,8 +444,8 @@ pub struct PooledConnection<DB: sqlx::Database> {
 	// When no tokio runtime is available, we detach the connection
 	// to avoid sqlx's PoolConnection::Drop calling rt::spawn().
 	conn: ManuallyDrop<sqlx::pool::PoolConnection<DB>>,
-	pool_ref: Arc<ConnectionPool<DB>>,
-	connection_id: String,
+	events: Arc<PoolEventHub>,
+	connection_id: OnceLock<String>,
 }
 
 impl<DB: sqlx::Database> PooledConnection<DB> {
@@ -445,34 +473,49 @@ impl<DB: sqlx::Database> PooledConnection<DB> {
 	/// # }
 	/// ```
 	pub fn connection_id(&self) -> &str {
-		&self.connection_id
+		self.connection_id
+			.get_or_init(generate_connection_id)
+			.as_str()
 	}
 	/// Invalidate this connection (hard invalidation - connection is unusable)
 	///
 	pub async fn invalidate(self, reason: String) {
-		self.pool_ref
-			.emit_event(PoolEvent::connection_invalidated(
-				self.connection_id.clone(),
-				reason,
-			))
-			.await;
+		if self.events.has_listeners() {
+			let connection_id = self
+				.connection_id
+				.get_or_init(generate_connection_id)
+				.clone();
+			self.events
+				.emit_event(PoolEvent::connection_invalidated(connection_id, reason))
+				.await;
+		}
 		// Connection will be dropped and not returned to pool
 	}
 	/// Soft invalidate this connection (can complete current operation)
 	///
 	pub async fn soft_invalidate(&mut self) {
-		self.pool_ref
-			.emit_event(PoolEvent::connection_soft_invalidated(
-				self.connection_id.clone(),
-			))
-			.await;
+		if self.events.has_listeners() {
+			let connection_id = self
+				.connection_id
+				.get_or_init(generate_connection_id)
+				.clone();
+			self.events
+				.emit_event(PoolEvent::connection_soft_invalidated(connection_id))
+				.await;
+		}
 	}
 	/// Reset this connection
 	///
 	pub async fn reset(&mut self) {
-		self.pool_ref
-			.emit_event(PoolEvent::connection_reset(self.connection_id.clone()))
-			.await;
+		if self.events.has_listeners() {
+			let connection_id = self
+				.connection_id
+				.get_or_init(generate_connection_id)
+				.clone();
+			self.events
+				.emit_event(PoolEvent::connection_reset(connection_id))
+				.await;
+		}
 	}
 }
 
@@ -487,14 +530,19 @@ impl<DB: sqlx::Database> Drop for PooledConnection<DB> {
 				// and emit the connection-returned event.
 				drop(conn);
 
-				let pool_ref = self.pool_ref.clone();
-				let connection_id = self.connection_id.clone();
+				if self.events.has_listeners() {
+					let events = self.events.clone();
+					let connection_id = self
+						.connection_id
+						.get_or_init(generate_connection_id)
+						.clone();
 
-				handle.spawn(async move {
-					pool_ref
-						.emit_event(PoolEvent::connection_returned(connection_id))
-						.await;
-				});
+					handle.spawn(async move {
+						events
+							.emit_event(PoolEvent::connection_returned(connection_id))
+							.await;
+					});
+				}
 			}
 			Err(_) => {
 				// No runtime available: prevent sqlx's PoolConnection::Drop
@@ -511,6 +559,31 @@ impl<DB: sqlx::Database> Drop for PooledConnection<DB> {
 mod tests {
 	use super::*;
 	use rstest::rstest;
+	use std::sync::Mutex;
+
+	struct RecordingListener {
+		events: Arc<Mutex<Vec<&'static str>>>,
+	}
+
+	#[async_trait::async_trait]
+	impl PoolEventListener for RecordingListener {
+		async fn on_event(&self, event: PoolEvent) {
+			let name = match event {
+				PoolEvent::ConnectionAcquired { .. } => "acquired",
+				PoolEvent::ConnectionReturned { .. } => "returned",
+				PoolEvent::ConnectionCreated { .. } => "created",
+				PoolEvent::ConnectionClosed { .. } => "closed",
+				PoolEvent::ConnectionTestFailed { .. } => "test_failed",
+				PoolEvent::ConnectionInvalidated { .. } => "invalidated",
+				PoolEvent::ConnectionSoftInvalidated { .. } => "soft_invalidated",
+				PoolEvent::ConnectionReset { .. } => "reset",
+			};
+			self.events
+				.lock()
+				.expect("events mutex should not be poisoned")
+				.push(name);
+		}
+	}
 
 	#[rstest]
 	#[case(
@@ -635,5 +708,31 @@ mod tests {
 
 		// Also drop the pool to ensure cleanup does not panic outside a runtime.
 		drop(pool);
+	}
+
+	#[tokio::test]
+	async fn test_pool_events_are_emitted_when_listener_registered() {
+		// Arrange
+		let events = Arc::new(Mutex::new(Vec::new()));
+		let listener = Arc::new(RecordingListener {
+			events: events.clone(),
+		});
+		let pool = ConnectionPool::new_sqlite("sqlite::memory:", PoolConfig::default())
+			.await
+			.expect("failed to create ConnectionPool");
+		pool.add_listener(listener).await;
+
+		// Act
+		let conn = pool.acquire().await.expect("failed to acquire connection");
+		drop(conn);
+		tokio::task::yield_now().await;
+
+		// Assert
+		let recorded = events.lock().expect("events mutex should not be poisoned");
+		assert_eq!(
+			recorded.as_slice(),
+			["created", "acquired", "returned"],
+			"pool listener should observe the first acquire and return events"
+		);
 	}
 }

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -17,6 +17,9 @@ cargo bench -p reinhardt-benchmarks --bench performance_benchmarks
 ```
 
 Current benchmark targets are `performance_benchmarks`, `auth_benchmarks`, `settings_benchmarks`, and `concurrent_benchmarks`.
+`performance_benchmarks` includes the DB pool acquire/release hot path so
+connection wrapper overhead can be tracked alongside the existing framework
+utility benchmarks.
 
 ## Adding New Benchmarks
 

--- a/tests/bench/benches/performance_benchmarks.rs
+++ b/tests/bench/benches/performance_benchmarks.rs
@@ -7,7 +7,10 @@
 use bytes::Bytes;
 use criterion::{Criterion, criterion_group, criterion_main};
 use http::{HeaderMap, StatusCode};
-use reinhardt_db::orm::{CascadeOption, LoadingStrategy, Relationship, RelationshipType};
+use reinhardt_db::{
+	orm::{CascadeOption, LoadingStrategy, Relationship, RelationshipType},
+	pool::{ConnectionPool, PoolConfig},
+};
 use reinhardt_rest::serializers::{CharField, EmailField, IntegerField, JsonSerializer};
 use reinhardt_test::{APIClient, APIRequestFactory, MockFunction, Spy, TestResponse};
 use reinhardt_urls::proxy::{
@@ -287,6 +290,30 @@ fn benchmark_orm_relationship_operations(c: &mut Criterion) {
 	});
 }
 
+/// Benchmark database pool access overhead.
+fn benchmark_db_pool_access(c: &mut Criterion) {
+	let rt = Runtime::new().unwrap();
+	let pool = rt.block_on(async {
+		let mut config = PoolConfig::default();
+		config.min_connections = 1;
+		config.max_connections = 1;
+		config.test_before_acquire = false;
+
+		ConnectionPool::new_sqlite("sqlite::memory:", config)
+			.await
+			.expect("failed to create sqlite pool")
+	});
+
+	c.bench_function("db_pool_acquire_release_no_listener", |b| {
+		b.iter(|| {
+			rt.block_on(async {
+				let mut conn = pool.acquire().await.expect("failed to acquire connection");
+				black_box(conn.inner());
+			});
+		});
+	});
+}
+
 // For template benchmarks, see template_benchmarks.rs
 
 // For JWT and permission benchmarks, see auth_benchmarks.rs
@@ -341,6 +368,7 @@ criterion_group!(
 	benchmark_test_response_operations,
 	benchmark_proxy_operations,
 	benchmark_orm_relationship_operations,
+	benchmark_db_pool_access,
 	benchmark_serialization_operations,
 	benchmark_memory_usage
 );


### PR DESCRIPTION
## Summary

This PR addresses:

- Reduces listener-free DB pool acquire/release overhead by skipping event bookkeeping when no pool listeners are registered.
- Lazily generates pool connection IDs only when event emission or `connection_id()` actually needs them.
- Adds listener-delivery regression coverage for both pool implementations.
- Adds a Criterion benchmark for the DB pool acquire/release hot path.
- Documents the new DB pool benchmark target.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [x] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

DB pool acquisition currently pays event-wrapper and connection-id costs even when no event listeners are registered. The hot path should avoid those costs by making listener-free acquire/release cheap while preserving event behavior when listeners exist.

## How Was This Tested?

- `cargo bench -p reinhardt-benchmarks --bench performance_benchmarks -- db_pool_acquire_release_no_listener --sample-size 30 --measurement-time 5`
- `cargo test -p reinhardt-db pool --features pool,sqlite,backends-pool --lib`
- `cargo test -p reinhardt-db test_pool_events_are_emitted_when_listener_registered --features pool,sqlite --lib`
- `cargo test -p reinhardt-db test_drop_pooled_connection_outside_runtime_does_not_panic --features pool,sqlite --lib`
- `cargo check -p reinhardt-db --features pool,backends-pool,sqlite --lib`
- `cargo clippy -p reinhardt-db --features pool,backends-pool,sqlite --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Allocation probe: `cargo run --release -- 100000`

## Performance Impact

Benchmark: `db_pool_acquire_release_no_listener`

- Baseline mean: `29.248 us`
- Optimized mean: `17.550 us`
- Mean improvement: `44.1%`
- Median improvement: `45.9%`

Allocation probe for the listener-free acquire/release hot path:

- Baseline Reinhardt pool: `12.00 allocs/iter`, `2075.0 B/iter`
- Optimized Reinhardt pool: `6.00 allocs/iter`, `1288.0 B/iter`
- Raw sqlx pool: `6.00 allocs/iter`, `1288.0 B/iter`
- Allocation count reduction: `50.0%`
- Allocated bytes reduction: `37.9%`
- Remaining overhead versus raw sqlx: `0%` in the measured allocation counters

This exceeds the DB access-time optimization target and removes the measured allocation overhead over raw sqlx for the listener-free pool acquire/release hot path.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [x] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- The implementation keeps event emission intact for pools with registered listeners and adds regression tests for listener delivery.

Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a benchmark covering database pool acquire/release performance.
  * Pool events now emit only when listeners are registered, reducing unnecessary overhead.

* **Bug Fixes**
  * Connection lifecycle events now fire more reliably in the expected order.
  * Connection IDs are now generated lazily to better match actual usage.

* **Documentation**
  * Clarified benchmark coverage to include database pool access overhead.

* **Tests**
  * Added coverage verifying pool event ordering during connection acquisition and release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->