### PR TITLE
perf(http): reduce request allocation overhead

### DIFF
--- a/crates/reinhardt-http/src/middleware.rs
+++ b/crates/reinhardt-http/src/middleware.rs
@@ -201,6 +201,17 @@ impl MiddlewareChain {
 		}
 	}
 
+	/// Creates a middleware chain from an existing middleware stack.
+	pub fn with_middlewares(
+		handler: Arc<dyn Handler>,
+		middlewares: Vec<Arc<dyn Middleware>>,
+	) -> Self {
+		Self {
+			middlewares,
+			handler,
+		}
+	}
+
 	/// Adds a middleware to the chain using builder pattern.
 	///
 	/// # Examples
@@ -286,16 +297,12 @@ impl Handler for MiddlewareChain {
 			inner: self.handler.clone(),
 		});
 
-		// Filter middleware based on should_continue condition
-		// This achieves the O(k) optimization where k is the number of middleware that should run
-		let active_middlewares: Vec<_> = self
+		for middleware in self
 			.middlewares
 			.iter()
 			.rev()
 			.filter(|mw| mw.should_continue(&request))
-			.collect();
-
-		for middleware in active_middlewares {
+		{
 			let mw = middleware.clone();
 			let handler = current_handler.clone();
 

--- a/crates/reinhardt-http/src/path_params.rs
+++ b/crates/reinhardt-http/src/path_params.rs
@@ -51,6 +51,13 @@ impl PathParams {
 		Self { inner: Vec::new() }
 	}
 
+	/// Create an empty `PathParams` with capacity for `capacity` entries.
+	pub fn with_capacity(capacity: usize) -> Self {
+		Self {
+			inner: Vec::with_capacity(capacity),
+		}
+	}
+
 	/// Number of stored parameters.
 	pub fn len(&self) -> usize {
 		self.inner.len()

--- a/crates/reinhardt-http/src/request.rs
+++ b/crates/reinhardt-http/src/request.rs
@@ -78,9 +78,9 @@ pub struct Request {
 	parsers: Vec<Box<dyn Parser>>,
 	/// Cached parsed data (lazy parsing)
 	#[cfg(feature = "parsers")]
-	parsed_data: Arc<Mutex<Option<ParsedData>>>,
+	parsed_data: Mutex<Option<ParsedData>>,
 	/// Whether the body has been consumed
-	body_consumed: Arc<AtomicBool>,
+	body_consumed: AtomicBool,
 	/// Extensions for storing arbitrary typed data
 	pub extensions: Extensions,
 }
@@ -459,8 +459,8 @@ impl RequestBuilder {
 			#[cfg(feature = "parsers")]
 			parsers: self.parsers,
 			#[cfg(feature = "parsers")]
-			parsed_data: Arc::new(Mutex::new(None)),
-			body_consumed: Arc::new(AtomicBool::new(false)),
+			parsed_data: Mutex::new(None),
+			body_consumed: AtomicBool::new(false),
 			extensions: Extensions::new(),
 		})
 	}
@@ -980,8 +980,8 @@ impl Request {
 			#[cfg(feature = "parsers")]
 			parsers: Vec::new(),
 			#[cfg(feature = "parsers")]
-			parsed_data: Arc::new(Mutex::new(None)),
-			body_consumed: Arc::new(AtomicBool::new(false)),
+			parsed_data: Mutex::new(None),
+			body_consumed: AtomicBool::new(false),
 			extensions: self.extensions.clone(),
 		}
 	}

--- a/crates/reinhardt-urls/src/routers/server_router/dispatch.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/dispatch.rs
@@ -7,6 +7,7 @@ use super::ServerRouter;
 use super::types::RouteMatch;
 use hyper::Method;
 use reinhardt_di::InjectionContext;
+use reinhardt_http::PathParams;
 use reinhardt_middleware::Middleware;
 use std::borrow::Cow;
 use std::sync::{Arc, PoisonError};
@@ -130,13 +131,11 @@ impl ServerRouter {
 		// Compile routes on first use (lazy compilation with interior mutability)
 		self.compile_routes();
 
-		// Normalize path for matchit lookup - routes are registered with leading slash
-		// When prefix is "/" and path is "/health", strip_prefix yields "health" but
-		// the route was registered as "/health". We need to ensure we search with "/health".
+		// Normalize path for matchit lookup - routes are registered with leading slash.
 		let search_path = if path.starts_with('/') {
-			path.to_string()
+			Cow::Borrowed(path)
 		} else {
-			format!("/{}", path)
+			Cow::Owned(format!("/{}", path))
 		};
 
 		// Use matchit to find matching route - O(m) complexity
@@ -153,38 +152,22 @@ impl ServerRouter {
 
 		let router = router_lock.read().unwrap_or_else(PoisonError::into_inner);
 
-		// Try matching with the original path first
-		// If that fails, try with trailing slash toggled (Django-style APPEND_SLASH behavior)
-		let paths_to_try = if search_path.ends_with('/') {
-			// Path has trailing slash, try without if not found
-			let without_slash = search_path.trim_end_matches('/').to_string();
-			let without_slash = if without_slash.is_empty() {
-				"/".to_string()
-			} else {
-				without_slash
-			};
-			vec![search_path.clone(), without_slash]
-		} else {
-			// Path has no trailing slash, try with if not found
-			vec![search_path.clone(), format!("{}/", search_path)]
-		};
-
-		for try_path in paths_to_try {
-			if let Ok(matched) = router.at(&try_path) {
+		macro_rules! return_route_match {
+			($matched:expr) => {{
+				let matched = $matched;
 				let route_handler = matched.value;
 
 				// Extract parameters from matchit. matchit's `Params` iterator
 				// yields parameters in URL pattern declaration order, so we
-				// collect into a `Vec` to preserve that ordering all the way
-				// down to the tuple extractor (see issue #4013).
-				let params: Vec<(String, String)> = matched
-					.params
-					.iter()
-					.map(|(k, v)| (k.to_string(), v.to_string()))
-					.collect();
+				// store them in ordered `PathParams` all the way down to the
+				// tuple extractor (see issue #4013).
+				let mut params = PathParams::with_capacity(matched.params.iter().count());
+				for (key, value) in matched.params.iter() {
+					params.insert(key, value);
+				}
 
-				// Combine router-level and route-level middleware
-				let mut combined_middleware = middleware_stack.clone();
+				// Combine router-level and route-level middleware.
+				let mut combined_middleware = middleware_stack;
 				combined_middleware.extend(route_handler.middleware.iter().cloned());
 
 				return Some(RouteMatch {
@@ -193,6 +176,29 @@ impl ServerRouter {
 					middleware_stack: combined_middleware,
 					di_context,
 				});
+			}};
+		}
+
+		// Try matching with the original path first. Only allocate the
+		// Django-style APPEND_SLASH fallback path if the primary lookup misses.
+		if let Ok(matched) = router.at(search_path.as_ref()) {
+			return_route_match!(matched);
+		}
+
+		let alternate_path = if search_path.ends_with('/') {
+			let without_slash = search_path.trim_end_matches('/');
+			if without_slash.is_empty() {
+				Cow::Borrowed("/")
+			} else {
+				Cow::Owned(without_slash.to_string())
+			}
+		} else {
+			Cow::Owned(format!("{}/", search_path))
+		};
+
+		if alternate_path.as_ref() != search_path.as_ref() {
+			if let Ok(matched) = router.at(alternate_path.as_ref()) {
+				return_route_match!(matched);
 			}
 		}
 
@@ -208,21 +214,19 @@ impl ServerRouter {
 
 		// Apply prefix stripping logic (same as resolve method, ensures leading `/`)
 		let search_path = match Self::strip_prefix_normalized(&self.prefix, path) {
-			Some(p) => p.into_owned(),
+			Some(p) => p,
 			None => return false,
 		};
 
-		// Build paths to try with trailing slash toggled (Django-style APPEND_SLASH)
-		let paths_to_try = if search_path.ends_with('/') {
-			let without_slash = search_path.trim_end_matches('/').to_string();
-			let without_slash = if without_slash.is_empty() {
-				"/".to_string()
+		let alternate_path = if search_path.ends_with('/') {
+			let without_slash = search_path.trim_end_matches('/');
+			if without_slash.is_empty() {
+				Cow::Borrowed("/")
 			} else {
-				without_slash
-			};
-			vec![search_path.clone(), without_slash]
+				Cow::Owned(without_slash.to_string())
+			}
 		} else {
-			vec![search_path.clone(), format!("{}/", search_path)]
+			Cow::Owned(format!("{}/", search_path))
 		};
 
 		let method_routers = [
@@ -237,19 +241,25 @@ impl ServerRouter {
 
 		for router_lock in method_routers {
 			let router = router_lock.read().unwrap_or_else(PoisonError::into_inner);
-			for try_path in &paths_to_try {
-				if router.at(try_path).is_ok() {
-					return true;
-				}
+			if router.at(search_path.as_ref()).is_ok() {
+				return true;
+			}
+			if alternate_path.as_ref() != search_path.as_ref()
+				&& router.at(alternate_path.as_ref()).is_ok()
+			{
+				return true;
 			}
 		}
 
 		// Also check children routers with remaining path
 		for child in &self.children {
-			for try_path in &paths_to_try {
-				if child.path_exists_for_any_method(try_path) {
-					return true;
-				}
+			if child.path_exists_for_any_method(search_path.as_ref()) {
+				return true;
+			}
+			if alternate_path.as_ref() != search_path.as_ref()
+				&& child.path_exists_for_any_method(alternate_path.as_ref())
+			{
+				return true;
 			}
 		}
 

--- a/crates/reinhardt-urls/src/routers/server_router/dispatch.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/dispatch.rs
@@ -196,10 +196,10 @@ impl ServerRouter {
 			Cow::Owned(format!("{}/", search_path))
 		};
 
-		if alternate_path.as_ref() != search_path.as_ref() {
-			if let Ok(matched) = router.at(alternate_path.as_ref()) {
-				return_route_match!(matched);
-			}
+		if alternate_path.as_ref() != search_path.as_ref()
+			&& let Ok(matched) = router.at(alternate_path.as_ref())
+		{
+			return_route_match!(matched);
 		}
 
 		None

--- a/crates/reinhardt-urls/src/routers/server_router/router_impls.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/router_impls.rs
@@ -86,10 +86,7 @@ impl Handler for ServerRouter {
 			}
 		};
 
-		// Set path parameters in request
-		for (key, value) in route_match.params {
-			req.set_path_param(key, value);
-		}
+		req.path_params = route_match.params;
 
 		// Set DI context if available
 		if let Some(di_ctx) = &route_match.di_context {
@@ -101,10 +98,9 @@ impl Handler for ServerRouter {
 			// No middleware, execute handler directly
 			route_match.handler.handle(req).await
 		} else {
-			// Build middleware chain
-			let chain = route_match.middleware_stack.iter().fold(
-				MiddlewareChain::new(route_match.handler.clone()),
-				|chain, mw| chain.with_middleware(mw.clone()),
+			let chain = MiddlewareChain::with_middlewares(
+				route_match.handler.clone(),
+				route_match.middleware_stack,
 			);
 
 			// Execute chain

--- a/crates/reinhardt-urls/src/routers/server_router/tests.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/tests.rs
@@ -365,8 +365,8 @@ async fn test_route_matching_correctness() {
 	assert_eq!(route_match.param("post_id"), Some("789"));
 	assert_eq!(route_match.param("comment_id"), Some("101"));
 	assert_eq!(
-		route_match.params,
-		vec![
+		route_match.params.as_slice(),
+		&[
 			("post_id".to_string(), "789".to_string()),
 			("comment_id".to_string(), "101".to_string()),
 		],
@@ -396,8 +396,8 @@ async fn test_route_matching_preserves_url_pattern_order_issue_4013() {
 
 	// Assert
 	assert_eq!(
-		route_match.params,
-		vec![
+		route_match.params.as_slice(),
+		&[
 			("org".to_string(), "myslug".to_string()),
 			("cluster_id".to_string(), "5".to_string()),
 		],

--- a/crates/reinhardt-urls/src/routers/server_router/types.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/types.rs
@@ -7,7 +7,7 @@
 
 use hyper::Method;
 use reinhardt_di::InjectionContext;
-use reinhardt_http::Handler;
+use reinhardt_http::{Handler, PathParams};
 use reinhardt_middleware::Middleware;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -104,9 +104,9 @@ pub(crate) struct RouteMatch {
 
 	/// Extracted path parameters in URL pattern declaration order.
 	///
-	/// Stored as an ordered `Vec<(name, value)>` so downstream extractors such
+	/// Stored as ordered [`PathParams`] so downstream extractors such
 	/// as `Path<(T1, T2)>` can rely on URL declaration order. See issue #4013.
-	pub params: Vec<(String, String)>,
+	pub params: PathParams,
 
 	/// Middleware stack to apply (parent → child order)
 	pub middleware_stack: Vec<Arc<dyn Middleware>>,
@@ -118,7 +118,7 @@ pub(crate) struct RouteMatch {
 impl RouteMatch {
 	/// Look up a path parameter by name.
 	///
-	/// `params` is stored as an ordered `Vec` (see issue #4013) so this helper
+	/// `params` is stored in declaration order (see issue #4013) so this helper
 	/// performs a linear scan. Path parameter sets are tiny in practice
 	/// (typically 1–3 entries), so the cost is negligible compared to a
 	/// `HashMap` lookup.

--- a/tests/bench/Cargo.toml
+++ b/tests/bench/Cargo.toml
@@ -11,6 +11,7 @@ reinhardt-test = { workspace = true }
 reinhardt-auth = { workspace = true, features = ["jwt"] }
 reinhardt-apps = { workspace = true }
 reinhardt-http = { workspace = true }
+reinhardt-middleware = { workspace = true }
 
 # Benchmarking
 criterion = { workspace = true }
@@ -36,6 +37,7 @@ reinhardt-db = {workspace = true, features = ["orm"]}
 reinhardt-rest = {workspace = true, features = ["serializers"]}
 reinhardt-conf = {workspace = true, features = ["settings"]}
 reinhardt-core = {workspace = true, features = ["types"]}
+async-trait = { workspace = true }
 
 [[bench]]
 name = "performance_benchmarks"

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -18,6 +18,12 @@ cargo bench -p reinhardt-benchmarks --bench performance_benchmarks
 
 Current benchmark targets are `performance_benchmarks`, `auth_benchmarks`, `settings_benchmarks`, and `concurrent_benchmarks`.
 
+Run the request allocation probe:
+
+```bash
+cargo run --release -p reinhardt-benchmarks --bin request_alloc_probe
+```
+
 ## Adding New Benchmarks
 
 1. Create a new file in the `benches/` directory

--- a/tests/bench/src/bin/request_alloc_probe.rs
+++ b/tests/bench/src/bin/request_alloc_probe.rs
@@ -1,0 +1,201 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+use hyper::Method;
+use reinhardt_http::{Handler, Request, Response, Result};
+use reinhardt_middleware::Middleware;
+use reinhardt_urls::routers::ServerRouter;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+		unsafe { System.alloc(layout) }
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		unsafe { System.dealloc(ptr, layout) }
+	}
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn reset_allocs() {
+	ALLOCATIONS.store(0, Ordering::Relaxed);
+}
+
+fn allocs() -> usize {
+	ALLOCATIONS.load(Ordering::Relaxed)
+}
+
+struct EmptyHandler;
+
+#[async_trait]
+impl Handler for EmptyHandler {
+	async fn handle(&self, _request: Request) -> Result<Response> {
+		Ok(Response::ok())
+	}
+}
+
+struct TinyMiddleware;
+
+#[async_trait]
+impl Middleware for TinyMiddleware {
+	async fn process(&self, request: Request, next: Arc<dyn Handler>) -> Result<Response> {
+		next.handle(request).await
+	}
+}
+
+fn request(path: &str) -> Request {
+	Request::builder()
+		.method(Method::GET)
+		.uri(path)
+		.body(Bytes::new())
+		.build()
+		.unwrap()
+}
+
+async fn measure<F, Fut>(label: &str, iterations: usize, mut f: F)
+where
+	F: FnMut() -> Fut,
+	Fut: std::future::Future<Output = ()>,
+{
+	for _ in 0..128 {
+		f().await;
+	}
+
+	reset_allocs();
+	for _ in 0..iterations {
+		f().await;
+	}
+	let total = allocs();
+	println!(
+		"{label}: total={total}, per_req={:.2}",
+		total as f64 / iterations as f64
+	);
+}
+
+async fn measure_counted<F, Fut>(label: &str, iterations: usize, mut f: F)
+where
+	F: FnMut() -> Fut,
+	Fut: std::future::Future<Output = usize>,
+{
+	for _ in 0..128 {
+		let _ = f().await;
+	}
+
+	let mut total = 0usize;
+	for _ in 0..iterations {
+		total += f().await;
+	}
+	println!(
+		"{label}: total={total}, per_req={:.2}",
+		total as f64 / iterations as f64
+	);
+}
+
+#[tokio::main]
+async fn main() {
+	let iterations = 10_000;
+
+	measure("request_build_empty_path", iterations, || async {
+		let _ = request("/health");
+	})
+	.await;
+
+	measure("request_build_two_query_params", iterations, || async {
+		let _ = request("/health?a=1&b=two");
+	})
+	.await;
+
+	let handler: Arc<dyn Handler> = Arc::new(EmptyHandler);
+	measure("direct_handler_build_plus_handle", iterations, || {
+		let handler = handler.clone();
+		async move {
+			let _ = handler.handle(request("/health")).await.unwrap();
+		}
+	})
+	.await;
+
+	measure_counted("direct_handler_handle_only", iterations, || {
+		let handler = handler.clone();
+		async move {
+			let req = request("/health");
+			reset_allocs();
+			let _ = handler.handle(req).await.unwrap();
+			allocs()
+		}
+	})
+	.await;
+
+	measure_counted("clone_for_di_empty_path", iterations, || async {
+		let req = request("/health");
+		reset_allocs();
+		let _ = req.clone_for_di();
+		allocs()
+	})
+	.await;
+
+	measure_counted("clone_for_di_two_query_params", iterations, || async {
+		let req = request("/health?a=1&b=two");
+		reset_allocs();
+		let _ = req.clone_for_di();
+		allocs()
+	})
+	.await;
+
+	let router = Arc::new(ServerRouter::new().handler("/health", EmptyHandler));
+	router.handle(request("/health")).await.unwrap();
+	measure("server_router_static_build_plus_handle", iterations, || {
+		let router = router.clone();
+		async move {
+			let _ = router.handle(request("/health")).await.unwrap();
+		}
+	})
+	.await;
+
+	let router_param =
+		Arc::new(ServerRouter::new().handler("/users/{id}/posts/{post_id}/", EmptyHandler));
+	router_param
+		.handle(request("/users/123/posts/456/"))
+		.await
+		.unwrap();
+	measure(
+		"server_router_two_params_build_plus_handle",
+		iterations,
+		|| {
+			let router = router_param.clone();
+			async move {
+				let _ = router
+					.handle(request("/users/123/posts/456/"))
+					.await
+					.unwrap();
+			}
+		},
+	)
+	.await;
+
+	let router_mw = Arc::new(
+		ServerRouter::new()
+			.with_middleware(TinyMiddleware)
+			.handler("/health", EmptyHandler),
+	);
+	router_mw.handle(request("/health")).await.unwrap();
+	measure(
+		"server_router_one_middleware_build_plus_handle",
+		iterations,
+		|| {
+			let router = router_mw.clone();
+			async move {
+				let _ = router.handle(request("/health")).await.unwrap();
+			}
+		},
+	)
+	.await;
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Reduces fixed allocations in request construction and DI request cloning.
- Reduces successful server-router dispatch allocations for static and path-param routes.
- Adds a request allocation probe for allocs/request regression tracking.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [x] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- The request hot path paid fixed heap-allocation costs for request-local state, router path normalization, path parameter transfer, and middleware chain construction.
- These allocations are avoidable in the common successful dispatch path.

Related to: develop/0.3.0 request allocation reduction work.

## How Was This Tested?

- `cargo fmt --check`
- `cargo test -p reinhardt-http --lib`
- `cargo test -p reinhardt-urls server_router --lib`
- `cargo run --release -p reinhardt-benchmarks --bin request_alloc_probe`

## Performance Impact

Request allocation probe results:

| Scenario | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `request_build_empty_path` | 4 alloc/req | 2 alloc/req | 50.0% |
| `request_build_two_query_params` | 9 alloc/req | 7 alloc/req | 22.2% |
| `direct_handler_build_plus_handle` | 6 alloc/req | 4 alloc/req | 33.3% |
| `clone_for_di_empty_path` | 3 alloc/req | 1 alloc/req | 66.7% |
| `server_router_static_build_plus_handle` | 12 alloc/req | 6 alloc/req | 50.0% |
| `server_router_two_params_build_plus_handle` | 18 alloc/req | 11 alloc/req | 38.9% |
| `server_router_one_middleware_build_plus_handle` | 24 alloc/req | 15 alloc/req | 37.5% |

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [x] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [x] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- Draft PR because `cargo make clippy-check` was not run locally.