### PR TITLE
fix(ci): skip release-pr job on release merges

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -65,14 +65,31 @@ jobs:
   # With release_always = true in release-plz.toml:
   # - Regular pushes: release-plz keeps the next Release PR up to date
   # - Release PR merge: release-plz publishes every workspace crate whose
-  #   local version differs from crates.io
+  #   local version differs from crates.io, without regenerating another
+  #   Release PR on the same push
   #
   # Runner: Always uses self-hosted AWS runner for release operations
   # (faster builds, no disk space issues, no dpkg lock contention)
 
   release-plz-pr:
     name: Release PR
-    if: github.event_name == 'push'
+    # Skip Release PR merge pushes. Those pushes are handled by
+    # release-plz-release below; running release-pr in parallel creates a
+    # short-lived follow-up Release PR before crates.io publication completes.
+    if: |
+      github.event_name == 'push' && !(
+        (
+          startsWith(github.event.head_commit.message, 'Merge pull request #') &&
+          (
+            contains(github.event.head_commit.message, '/release-plz-') ||
+            contains(github.event.head_commit.message, '/develop-release-plz-')
+          )
+        ) ||
+        (
+          startsWith(github.event.head_commit.message, 'chore: release ') &&
+          contains(github.event.head_commit.message, '(#')
+        )
+      )
     runs-on: ["self-hosted","linux","arm64","reinhardt-ci"]
     timeout-minutes: 360
     concurrency:
@@ -280,8 +297,9 @@ jobs:
   release-plz-release:
     name: Release
     # Publish only after a verified Release PR merge. The release-plz-pr job
-    # above still runs on every main/develop push, so routine feature merges
-    # keep the next Release PR up to date without entering the publish path.
+    # above uses the inverse guard, so routine feature merges keep the next
+    # Release PR up to date while Release PR merges enter only this publish
+    # path.
     #
     # Accepted Release PR merge shapes:
     # - merge commit from release-plz-* or develop-release-plz-* branch

--- a/instructions/RELEASE_PROCESS.md
+++ b/instructions/RELEASE_PROCESS.md
@@ -236,7 +236,8 @@ git push origin main
 
 ### Step 3: release-plz Creates Release PR
 
-When changes are pushed to main, release-plz automatically:
+When ordinary changes are pushed to `main` or `develop/*`, release-plz
+automatically:
 
 1. Analyzes commits since last release
 2. Determines version bumps for affected crates
@@ -258,7 +259,12 @@ When changes are pushed to main, release-plz automatically:
 
 ### Step 5: Automatic Publishing
 
-Upon merge, release-plz:
+Upon merging a generated Release PR, the workflow runs only the publish path.
+It intentionally skips the Release PR regeneration job for that push, so
+publication cannot create a short-lived follow-up Release PR while crates.io is
+still catching up.
+
+During this publish path, release-plz:
 
 1. Publishes crates to crates.io (in dependency order)
    - Automatically skips already-published versions


### PR DESCRIPTION
## Summary

This PR addresses:

- Skip the `Release PR` job when the push is a generated release-plz Release PR merge on `develop/0.3.0`.
- Keep ordinary `develop/0.3.0` pushes updating the next prerelease Release PR as before.
- Document that Release PR merges enter only the publish path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Merging release-plz PR #5432 into `develop/0.3.0` started both `Release PR` and `Release` jobs. The `Release PR` job created #5433 shortly after the release merge, then the generated follow-up PR was closed shortly afterward.

Fixes #5445

Related to: #5432, #5433, #5447

## How Was This Tested?

- `actionlint -ignore SC2094 -ignore SC2016 -ignore SC2129 .github/workflows/release-plz.yml`
- `git diff --check HEAD^ HEAD`
- Node guard-case check for release-plz merge commits, release squash commits, ordinary PR merges, and ordinary direct commits

## Performance Impact

N/A - CI workflow guard only.

## Related Issues

- #5445
- #5447

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

This is the `develop/0.3.0` companion to #5447 for `main`.