### PR TITLE
fix(scaffolding): default Pages projects to SQLite on develop

### DIFF
--- a/.github/workflows/release-plz-dry-run.yml
+++ b/.github/workflows/release-plz-dry-run.yml
@@ -105,16 +105,19 @@ jobs:
           #
           # Ideal implementation (without workaround):
           #   release-plz release --dry-run --no-verify --git-token "$GITHUB_TOKEN"
+          skipped_crate_re='(reinhardt-[A-Za-z0-9_-]+)[[:space:]]+([^:[:space:]]+):[[:space:]]+due[[:space:]]+to[[:space:]]+dry,[[:space:]]+skipping'
+          requirement_re='^(reinhardt-[A-Za-z0-9_-]+)[[:space:]]*=[[:space:]]*"\^?([^"]+)"$'
+
           declare -A dry_skipped_crates=()
           while IFS= read -r line; do
-            if [[ "$line" =~ ^(reinhardt-[A-Za-z0-9_-]+)[[:space:]]+([^:[:space:]]+):[[:space:]]+due[[:space:]]+to[[:space:]]+dry,[[:space:]]+skipping ]]; then
+            if [[ "$line" =~ $skipped_crate_re ]]; then
               dry_skipped_crates["${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"]=1
             fi
           done < "$log"
 
           known_same_release_dependency_failure=false
           while IFS= read -r requirement; do
-            if [[ "$requirement" =~ ^(reinhardt-[A-Za-z0-9_-]+)[[:space:]]*=[[:space:]]*\"\^?([^\"]+)\"$ ]] \
+            if [[ "$requirement" =~ $requirement_re ]] \
               && [[ -n "${dry_skipped_crates["${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"]+set}" ]]
             then
               known_same_release_dependency_failure=true

--- a/crates/reinhardt-commands/src/project_config.rs
+++ b/crates/reinhardt-commands/src/project_config.rs
@@ -104,7 +104,7 @@ pub async fn resolve_dependency_selection(
 		if interactive {
 			prompt_features()?
 		} else {
-			vec!["standard".to_string()]
+			default_noninteractive_features(required_features)
 		}
 	} else {
 		explicit_features
@@ -121,6 +121,16 @@ pub async fn resolve_dependency_selection(
 		default_features,
 		features: normalize_features(features),
 	})
+}
+
+fn default_noninteractive_features(required_features: &[&str]) -> Vec<String> {
+	if required_features.contains(&"pages") {
+		return required_features
+			.iter()
+			.map(|feature| (*feature).to_string())
+			.collect();
+	}
+	vec!["standard".to_string()]
 }
 
 fn should_prompt(ctx: &CommandContext) -> bool {
@@ -392,6 +402,22 @@ mod tests {
 	#[test]
 	fn features_toml_formats_array_literal() {
 		assert_eq!(selection().features_toml(), "[\"minimal\", \"db-sqlite\"]");
+	}
+
+	#[test]
+	fn noninteractive_pages_default_uses_required_features() {
+		assert_eq!(
+			default_noninteractive_features(&["minimal", "pages", "db-sqlite"]),
+			vec!["minimal", "pages", "db-sqlite"]
+		);
+	}
+
+	#[test]
+	fn noninteractive_non_pages_default_keeps_standard_preset() {
+		assert_eq!(
+			default_noninteractive_features(&["conf", "commands", "db-postgres", "api"]),
+			vec!["standard"]
+		);
 	}
 
 	#[rstest::rstest]

--- a/crates/reinhardt-commands/src/start_commands.rs
+++ b/crates/reinhardt-commands/src/start_commands.rs
@@ -121,14 +121,7 @@ impl BaseCommand for StartProjectCommand {
 		// Generate a random secret key
 		let secret_key = format!("insecure-{}", generate_secret_key());
 		let required_features = if with_pages {
-			&[
-				"minimal",
-				"pages",
-				"admin",
-				"conf",
-				"commands",
-				"db-postgres",
-			][..]
+			&["minimal", "pages", "admin", "conf", "commands", "db-sqlite"][..]
 		} else {
 			&["conf", "commands", "db-postgres", "api"][..]
 		};

--- a/crates/reinhardt-commands/templates/project_pages_template/settings/base.example.toml
+++ b/crates/reinhardt-commands/templates/project_pages_template/settings/base.example.toml
@@ -6,7 +6,7 @@
 # - staging.toml (staging environment)
 # - production.toml (production environment)
 #
-# IMPORTANT: Copy this file to base.toml and update the values.
+# IMPORTANT: Update generated base.toml values before production use.
 # Commit non-secret defaults only when they are meant to be shared.
 
 [core]
@@ -31,12 +31,8 @@ secure_hsts_preload = false
 append_slash = true
 
 [core.databases.default]
-engine = "postgresql"
-host = "localhost"
-port = 5432
-name = "{{ project_name }}_db"
-user = "postgres"
-# password = "uncomment-this-line-and-replace-with-db-password"
+engine = "sqlite"
+name = "db.sqlite3"
 
 [static]
 url = "/static/"

--- a/crates/reinhardt-commands/tests/embedded_startproject.rs
+++ b/crates/reinhardt-commands/tests/embedded_startproject.rs
@@ -31,6 +31,25 @@ fn assert_manifest_parses(manifest: &Path) {
 	);
 }
 
+fn assert_generated_rust_sources_do_not_use_tab_indents(root: &Path) {
+	for relative in [
+		"build.rs",
+		"src/bin/manage.rs",
+		"src/client/components/nav.rs",
+		"src/client/lib.rs",
+		"src/config/settings.rs",
+		"src/config/wasm.rs",
+		"src/lib.rs",
+		"tests/integration.rs",
+	] {
+		let content = std::fs::read_to_string(root.join(relative)).unwrap();
+		assert!(
+			!content.contains('\t'),
+			"generated Rust source should be rustfmt-clean before cargo make dev: {relative}"
+		);
+	}
+}
+
 #[rstest]
 #[tokio::test]
 #[serial(cwd)]
@@ -132,8 +151,19 @@ async fn startproject_pages_from_embedded_only() {
 		"package = \"reinhardt-web\", default-features = false, features = [\"pages\", \"client-router\"]"
 	));
 	assert!(cargo_toml.contains(
-		"features = [\"standard\", \"pages\", \"admin\", \"conf\", \"commands\", \"db-postgres\"]"
+		"features = [\"minimal\", \"pages\", \"admin\", \"conf\", \"commands\", \"db-sqlite\"]"
 	));
+	assert!(
+		!cargo_toml.contains("\"standard\"") && !cargo_toml.contains("\"db-postgres\""),
+		"generated pages manifest must not require PostgreSQL defaults:\n{cargo_toml}"
+	);
+	let base_toml = std::fs::read_to_string(generated.join("settings/base.toml")).unwrap();
+	assert!(
+		base_toml.contains("engine = \"sqlite\"")
+			&& base_toml.contains("name = \"db.sqlite3\"")
+			&& !base_toml.contains("engine = \"postgresql\""),
+		"generated pages settings must match the SQLite feature default:\n{base_toml}"
+	);
 	assert!(
 		cargo_toml.contains("required-features = [\"with-reinhardt\"]"),
 		"generated pages manage binary must be native-feature gated:\n{cargo_toml}"
@@ -195,6 +225,7 @@ async fn startproject_pages_from_embedded_only() {
 		!generated.join("src/shared.rs").exists() && !generated.join("src/shared").exists(),
 		"generated pages project must not create a root shared module"
 	);
+	assert_generated_rust_sources_do_not_use_tab_indents(&generated);
 	assert_manifest_parses(&generated.join("Cargo.toml"));
 }
 

--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -15,6 +15,9 @@ The finished reference for this tutorial is `examples/examples-tutorial-basis`. 
 
 ## Install the Tools
 
+Use Rust 1.96.0 or newer. The `0.3.0-rc.4` generator and the generated Rust
+2024 project require that toolchain level.
+
 Install the Reinhardt project generator:
 
 <!-- reinhardt-version-sync -->
@@ -112,24 +115,26 @@ configuration features selected by `startproject`:
 
 ```toml
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-reinhardt = { version = "0.3.0-rc.3", package = "reinhardt-web", default-features = false, features = ["pages", "client-router"] }
+reinhardt = { version = "0.3.0-rc.4", package = "reinhardt-web", default-features = false, features = ["pages", "client-router"] }
 wasm-bindgen = "=0.2.122"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reinhardt = { version = "0.3.0-rc.3", package = "reinhardt-web", default-features = false, features = [
-    "standard",
+reinhardt = { version = "0.3.0-rc.4", package = "reinhardt-web", default-features = false, features = [
+    "minimal",
     "pages",
     "admin",
     "conf",
     "commands",
-    "db-postgres",
+    "db-sqlite",
 ] }
 tokio = { version = "1", features = ["full"] }
 ```
 
-If you pass an explicit SQLite feature list, keep the Pages runtime facade in
-place. Current `startproject` adds the required `minimal` feature automatically
-when a custom Pages list lacks a preset such as `standard`.
+The generated native target uses SQLite by default so the first run does not
+require a PostgreSQL container. If you pass an explicit SQLite feature list,
+keep the Pages runtime facade in place. Current `startproject` adds the
+required `minimal` feature automatically when a custom Pages list lacks a
+preset such as `standard`.
 
 In an example project, import Reinhardt APIs through the `reinhardt` facade. Do not depend on internal `reinhardt-*` crates directly.
 
@@ -188,24 +193,26 @@ SettingsBuilder::new()
 The matching `settings/base.toml` must include `[contacts]` because `ProjectSettings` includes `ContactSettings`:
 
 ```toml
+[core]
+secret_key = "insecure-..."
+
 [contacts]
 admins = []
 managers = []
 ```
 
-The example's database settings target the disposable PostgreSQL container started by the `cargo make` tasks:
+The tutorial database is a local SQLite file:
 
 ```toml
 [core.databases.default]
-engine = "postgresql"
-host = "localhost"
-port = 5432
-name = "examples_tutorial_basis"
-user = "reinhardt"
-password = "reinhardt"
+engine = "sqlite"
+name = "db.sqlite3"
 ```
 
-Use your own database name if you generated a new project. Keep the schema shape the same.
+`cargo make migrate` and `cargo make dev` run the settings-aware `manage`
+binary, so database commands resolve `[core.databases.default]` and create the
+SQLite file on demand. No PostgreSQL or Redis container is required for this
+tutorial path.
 
 ## See the Browser Mount Point
 

--- a/website/content/quickstart/tutorials/basis/_index.md
+++ b/website/content/quickstart/tutorials/basis/_index.md
@@ -22,9 +22,10 @@ The reference implementation lives in [`examples/examples-tutorial-basis`](https
 
 ## Prerequisites
 
-- Basic Rust and Cargo knowledge.
+- Rust 1.96.0 or newer, plus basic Rust and Cargo knowledge.
 - `cargo make` installed.
-- Docker Desktop running for the disposable PostgreSQL and Redis development containers.
+- `wasm32-unknown-unknown` target and `wasm-pack` installed.
+- SQLite support through the Reinhardt feature flags used in Part 1.
 - A browser capable of running WebAssembly.
 
 ## What You'll Build


### PR DESCRIPTION
## Summary

This PR addresses:

- Backports the Pages scaffold SQLite default from #5435 to `develop/0.3.0`.
- Defaults non-interactive Pages project generation to the explicit minimal SQLite feature set while preserving the non-Pages `standard` preset.
- Aligns generated Pages base settings and the basis tutorial with the SQLite-first path.
- Keeps the release-plz dry-run regex workaround in the same parsing-safe form as `main`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The `develop/0.3.0` Pages scaffold still defaulted generated native projects to the `standard` PostgreSQL preset in the non-interactive path. The main branch fix in #5435 switched that path to a runnable SQLite-first setup; this PR applies the equivalent behavior to `develop/0.3.0` using the feature names available on that branch.

Refs #5420

Related to: #5435

## How Was This Tested?

- `cargo fmt --check`
- `cargo test -p reinhardt-commands project_config --lib`
- `cargo test -p reinhardt-commands --test embedded_startproject -- --nocapture`

## Performance Impact

No runtime performance impact expected.

## Breaking Changes

None.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #5420
- Related to #5435

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- The generated Pages Rust templates were already space-indented on `develop/0.3.0`; this PR adds the embedded startproject assertion so that stays fixed.

Generated with Codex