### PR TITLE
fix(commands): repair pages quickstart scaffold defaults

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -3428,12 +3428,36 @@ impl CheckCommand {
 	///
 	/// Returns `None` when neither source produces a URL.
 	fn resolve_database_url(ctx: &CommandContext) -> Option<String> {
+		let env_database_url = std::env::var("DATABASE_URL").ok();
+
+		#[cfg(feature = "reinhardt-db")]
+		if let Some(settings) = ctx.settings.as_ref()
+			&& let Ok(url) = DatabaseConnection::database_url_from(
+				settings.as_ref(),
+				env_database_url.as_deref(),
+			) {
+			sync_database_url_to_env(env_database_url.as_deref(), &url, ctx);
+			return Some(url);
+		}
+
+		#[cfg(not(feature = "reinhardt-db"))]
 		if let Some(settings) = ctx.settings.as_ref()
 			&& let Some(db) = settings.core().databases.get("default")
 		{
 			return Some(db.to_url());
 		}
-		std::env::var("DATABASE_URL").ok()
+
+		if let Some(url) = env_database_url {
+			return Some(url);
+		}
+
+		#[cfg(feature = "reinhardt-db")]
+		if let Ok(url) = get_database_url_from_settings() {
+			sync_database_url_to_env(None, &url, ctx);
+			return Some(url);
+		}
+
+		None
 	}
 
 	/// Returns true when a static-files root is configured, either via
@@ -4254,6 +4278,56 @@ fn detect_database_type(url: &str) -> Result<DatabaseType, crate::CommandError> 
 mod tests {
 	use super::*;
 
+	#[cfg(feature = "reinhardt-db")]
+	struct EnvVarGuard {
+		key: &'static str,
+		original: Option<std::ffi::OsString>,
+	}
+
+	#[cfg(feature = "reinhardt-db")]
+	impl EnvVarGuard {
+		fn capture(key: &'static str) -> Self {
+			Self {
+				key,
+				original: std::env::var_os(key),
+			}
+		}
+	}
+
+	#[cfg(feature = "reinhardt-db")]
+	impl Drop for EnvVarGuard {
+		fn drop(&mut self) {
+			// SAFETY: tests that mutate process environment are serial-protected.
+			unsafe {
+				match &self.original {
+					Some(value) => std::env::set_var(self.key, value),
+					None => std::env::remove_var(self.key),
+				}
+			}
+		}
+	}
+
+	#[cfg(feature = "reinhardt-db")]
+	struct CurrentDirGuard {
+		original: std::path::PathBuf,
+	}
+
+	#[cfg(feature = "reinhardt-db")]
+	impl CurrentDirGuard {
+		fn enter(path: &std::path::Path) -> Self {
+			let original = std::env::current_dir().expect("read current directory");
+			std::env::set_current_dir(path).expect("set current directory");
+			Self { original }
+		}
+	}
+
+	#[cfg(feature = "reinhardt-db")]
+	impl Drop for CurrentDirGuard {
+		fn drop(&mut self) {
+			let _ = std::env::set_current_dir(&self.original);
+		}
+	}
+
 	#[tokio::test]
 	async fn test_check_command_basic() {
 		let cmd = CheckCommand;
@@ -4263,6 +4337,49 @@ mod tests {
 		let result = cmd.execute(&ctx).await;
 		// May fail if environment has strict checks, but should handle gracefully
 		assert!(result.is_ok() || result.is_err());
+	}
+
+	#[test]
+	#[cfg(feature = "reinhardt-db")]
+	#[serial_test::serial(env)]
+	fn test_check_resolves_database_url_from_settings_files() {
+		// Arrange
+		let _database_url = EnvVarGuard::capture("DATABASE_URL");
+		let _reinhardt_env = EnvVarGuard::capture("REINHARDT_ENV");
+		// SAFETY: env mutation in this test is protected by #[serial(env)].
+		unsafe {
+			std::env::remove_var("DATABASE_URL");
+			std::env::set_var("REINHARDT_ENV", "local");
+		}
+
+		let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+		let settings_dir = temp_dir.path().join("settings");
+		std::fs::create_dir_all(&settings_dir).expect("create settings dir");
+		std::fs::write(
+			settings_dir.join("base.toml"),
+			r#"
+[core]
+secret_key = "test-secret"
+
+[core.databases.default]
+engine = "sqlite"
+name = "db.sqlite3"
+"#,
+		)
+		.expect("write base settings");
+		std::fs::write(settings_dir.join("local.toml"), "").expect("write local settings");
+		let _cwd = CurrentDirGuard::enter(temp_dir.path());
+
+		// Act
+		let resolved = CheckCommand::resolve_database_url(&CommandContext::default())
+			.expect("database URL should resolve from settings files");
+
+		// Assert
+		assert_eq!(resolved, "sqlite:db.sqlite3");
+		assert_eq!(
+			std::env::var("DATABASE_URL").expect("DATABASE_URL should be synced"),
+			resolved
+		);
 	}
 
 	#[tokio::test]

--- a/crates/reinhardt-commands/src/start_commands.rs
+++ b/crates/reinhardt-commands/src/start_commands.rs
@@ -121,7 +121,17 @@ impl BaseCommand for StartProjectCommand {
 		// Generate a random secret key
 		let secret_key = format!("insecure-{}", generate_secret_key());
 		let required_features = if with_pages {
-			&["minimal", "pages", "admin", "conf", "commands", "db-sqlite"][..]
+			&[
+				"minimal",
+				"pages",
+				"admin",
+				"conf",
+				"commands",
+				"commands-server",
+				"commands-autoreload",
+				"server",
+				"db-sqlite",
+			][..]
 		} else {
 			&["conf", "commands", "db-postgres", "api"][..]
 		};

--- a/crates/reinhardt-commands/tests/e2e_pages.rs
+++ b/crates/reinhardt-commands/tests/e2e_pages.rs
@@ -120,6 +120,26 @@ async fn project_pages_layout_matches_tutorial() {
 		cargo_toml.contains("members = ["),
 		"Pages project Cargo.toml must include a members array for startapp --workspace:\n{cargo_toml}"
 	);
+	for feature in [
+		"minimal",
+		"pages",
+		"admin",
+		"conf",
+		"commands",
+		"commands-server",
+		"commands-autoreload",
+		"server",
+		"db-sqlite",
+	] {
+		assert!(
+			cargo_toml.contains(&format!("\"{feature}\"")),
+			"Pages project native dependency must include `{feature}` for the generated dev workflow:\n{cargo_toml}"
+		);
+	}
+	assert!(
+		!cargo_toml.contains("\"db-postgres\""),
+		"Pages project native dependency must keep the SQLite default:\n{cargo_toml}"
+	);
 	let makefile = fs::read_to_string(project.join("Makefile.toml")).expect("read Makefile.toml");
 	assert!(
 		makefile.contains("[tasks.install-tools]"),

--- a/crates/reinhardt-commands/tests/embedded_startproject.rs
+++ b/crates/reinhardt-commands/tests/embedded_startproject.rs
@@ -151,7 +151,7 @@ async fn startproject_pages_from_embedded_only() {
 		"package = \"reinhardt-web\", default-features = false, features = [\"pages\", \"client-router\"]"
 	));
 	assert!(cargo_toml.contains(
-		"features = [\"minimal\", \"pages\", \"admin\", \"conf\", \"commands\", \"db-sqlite\"]"
+		"features = [\"minimal\", \"pages\", \"admin\", \"conf\", \"commands\", \"commands-server\", \"commands-autoreload\", \"server\", \"db-sqlite\"]"
 	));
 	assert!(
 		!cargo_toml.contains("\"standard\"") && !cargo_toml.contains("\"db-postgres\""),
@@ -254,7 +254,7 @@ async fn startproject_pages_adds_required_pages_features() {
 	let cargo_toml =
 		std::fs::read_to_string(tmp.path().join("pages_feature_proj/Cargo.toml")).unwrap();
 	assert!(cargo_toml.contains(
-		"features = [\"minimal\", \"pages\", \"client-router\", \"db-sqlite\", \"admin\", \"conf\", \"commands\"]"
+		"features = [\"minimal\", \"pages\", \"client-router\", \"db-sqlite\", \"admin\", \"conf\", \"commands\", \"commands-server\", \"commands-autoreload\", \"server\"]"
 	));
 	assert!(
 		!cargo_toml.contains("\"server-fn\""),
@@ -298,6 +298,10 @@ async fn startproject_pages_explicit_tutorial_features_get_minimal_runtime() {
 	assert!(
 		cargo_toml.contains("\"minimal\""),
 		"explicit Pages feature selections must be augmented with the minimal runtime facade:\n{cargo_toml}"
+	);
+	assert!(
+		cargo_toml.contains("\"server\""),
+		"explicit Pages feature selections must be augmented with the HTTP server facade:\n{cargo_toml}"
 	);
 	assert!(
 		cargo_toml.contains("\"db-sqlite\"") && !cargo_toml.contains("\"db-postgres\""),

--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -125,6 +125,9 @@ reinhardt = { version = "0.3.0-rc.4", package = "reinhardt-web", default-feature
     "admin",
     "conf",
     "commands",
+    "commands-server",
+    "commands-autoreload",
+    "server",
     "db-sqlite",
 ] }
 tokio = { version = "1", features = ["full"] }
@@ -132,9 +135,11 @@ tokio = { version = "1", features = ["full"] }
 
 The generated native target uses SQLite by default so the first run does not
 require a PostgreSQL container. If you pass an explicit SQLite feature list,
-keep the Pages runtime facade in place. Current `startproject` adds the
-required `minimal` feature automatically when a custom Pages list lacks a
-preset such as `standard`.
+keep the Pages runtime and command facades in place: `commands-server` enables
+`manage runserver`, `commands-autoreload` powers the generated dev watcher, and
+`server` provides the HTTP server facade. Current `startproject` adds the
+required `minimal` and server-side Pages features automatically when a custom
+Pages list lacks them.
 
 In an example project, import Reinhardt APIs through the `reinhardt` facade. Do not depend on internal `reinhardt-*` crates directly.
 
@@ -250,10 +255,10 @@ Start the dev workflow:
 cargo make dev
 ```
 
-In the reference example, `dev` runs the WASM build, applies migrations, and starts the pages server. The underlying `runserver` command passes `--with-pages`:
+In the generated project, `dev` runs the quality checks, builds the WASM bundle, and starts the pages server. Run `cargo make migrate` separately when you add migrations. The underlying `runserver` command passes `--with-pages` and reuses the bundle that `wasm-build-dev` just produced:
 
 ```bash
-cargo run --bin manage -- runserver --with-pages
+cargo run --bin manage -- runserver --with-pages --no-override-wasm
 ```
 
 Open `http://127.0.0.1:8000/`. At this point the application is only the shell. If the page loads without a missing-WASM error and the server logs show the pages runtime starting, the setup slice is complete.

--- a/website/content/quickstart/tutorials/basis/2-poll-index.md
+++ b/website/content/quickstart/tutorials/basis/2-poll-index.md
@@ -335,12 +335,13 @@ Then paste:
 BEGIN;
 
 INSERT INTO questions (question_text, pub_date)
-VALUES ('What should we build next?', datetime('now'));
+VALUES ('What should we build next?', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
 
+WITH inserted_question(id) AS (SELECT last_insert_rowid())
 INSERT INTO choices (question_id, choice_text, votes)
-SELECT last_insert_rowid(), 'More tutorials', 0
+SELECT id, 'More tutorials', 0 FROM inserted_question
 UNION ALL
-SELECT last_insert_rowid(), 'More examples', 0;
+SELECT id, 'More examples', 0 FROM inserted_question;
 
 COMMIT;
 ```

--- a/website/content/quickstart/tutorials/basis/2-poll-index.md
+++ b/website/content/quickstart/tutorials/basis/2-poll-index.md
@@ -323,27 +323,29 @@ The final example adds a "Create new poll" button and owner-only controls. Leave
 
 ## Seed a Poll
 
-Until the admin arrives in Part 6, the quickest local seed is SQL. Use the same PostgreSQL database that `cargo make dev` points at. In the example profile, open it with:
+Until the admin arrives in Part 6, the quickest local seed is SQL. The generated tutorial project uses SQLite by default, so open the local database created by `cargo make migrate`:
 
 ```bash
-PGPASSWORD=reinhardt psql -h localhost -p 5433 -U reinhardt -d examples_tutorial_basis
+sqlite3 db.sqlite3
 ```
 
 Then paste:
 
 ```sql
-WITH inserted_question AS (
-    INSERT INTO questions (question_text, pub_date)
-    VALUES ('What should we build next?', NOW())
-    RETURNING id
-)
+BEGIN;
+
+INSERT INTO questions (question_text, pub_date)
+VALUES ('What should we build next?', datetime('now'));
+
 INSERT INTO choices (question_id, choice_text, votes)
-SELECT id, 'More tutorials', 0 FROM inserted_question
+SELECT last_insert_rowid(), 'More tutorials', 0
 UNION ALL
-SELECT id, 'More examples', 0 FROM inserted_question;
+SELECT last_insert_rowid(), 'More examples', 0;
+
+COMMIT;
 ```
 
-If you switch the tutorial profile to SQLite, open that database with `sqlite3 <path-to-db.sqlite3>` and use SQLite's inserted-ID syntax instead of `RETURNING`.
+If you switch the tutorial profile to PostgreSQL, open that database with `psql` and use PostgreSQL's `RETURNING` syntax instead of `last_insert_rowid()`.
 
 ## Checkpoint
 

--- a/website/content/quickstart/tutorials/basis/6-admin-and-static-files.md
+++ b/website/content/quickstart/tutorials/basis/6-admin-and-static-files.md
@@ -202,8 +202,8 @@ args = [
 
 ```toml
 [tasks.dev]
-description = "Build WASM and start development server with frontend (auto-starts PostgreSQL/Redis via `migrate` -> `infra-up`)"
-dependencies = ["wasm-build-dev", "migrate", "run-dev-server"]
+description = "Start development environment (checks, builds WASM, runs server with auto-reload)"
+dependencies = ["clean-cache", "quality", "wasm-build-dev", "runserver"]
 ```
 
 ## Follow the Dev Build Path
@@ -221,7 +221,7 @@ echo "WASM build and collectstatic completed"
 The final `cargo make dev` step starts the server with pages enabled and avoids rebuilding over the just-created bundle:
 
 ```bash
-cargo run --bin manage -- runserver --with-pages --noreload --no-override-wasm
+cargo run --bin manage -- runserver --with-pages --no-override-wasm
 ```
 
 Release-mode local testing uses:


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds the generated Pages project native features required for `manage runserver` and autoreload.
- Lets `manage check` resolve `[core.databases.default]` from `settings/*.toml` when no settings object is attached to the command context.
- Aligns the basics tutorial with the SQLite-first scaffold and current `cargo make dev` flow.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The Pages quickstart scaffold still generated a native dependency feature set that could build WASM but could not run the generated `manage runserver` workflow. The tutorial also mixed SQLite-first generated settings with PostgreSQL seeding instructions.

Fixes #5454

Related to: #

## How Was This Tested?

- `cargo fmt`
- `cargo test -p reinhardt-commands --features 'migrations sqlite' test_check_resolves_database_url_from_settings_files`
- `cargo test -p reinhardt-commands --test embedded_startproject --test e2e_pages`
- Fresh scaffold from this branch with local `[patch.crates-io]`:
  - `cargo +1.96.0 run --bin manage -- check`
  - `cargo +1.96.0 run --bin manage -- migrate --plan`
  - `RUSTUP_TOOLCHAIN=1.96.0 CARGO_TARGET_DIR=/tmp/reinhardt-issue-5454-fixed-target cargo make wasm-build-dev`
  - `cargo +1.96.0 run --bin manage -- runserver --with-pages --no-override-wasm 127.0.0.1:8019`
  - `curl` verified `/`, `/tutorial.js`, and `/tutorial_bg.wasm` returned HTTP 200
- `cargo make fmt-check`

Note: `cargo test -p reinhardt-commands --features migrations ...` was not a valid standalone backend combination and failed in pre-existing code before rerunning with `migrations sqlite`.

## Performance Impact

Not performance-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5454

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [x] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)

- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Created from `develop/0.3.0` at `e8afec7ec0`.

Generated with Codex