### PR TITLE
perf(http): reduce router allocation hot path

### DIFF
--- a/crates/reinhardt-http/Cargo.toml
+++ b/crates/reinhardt-http/Cargo.toml
@@ -18,6 +18,7 @@ hyper = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = { workspace = true }
+smallvec = { workspace = true }
 futures = "0.3.31"
 thiserror = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/reinhardt-http/src/middleware.rs
+++ b/crates/reinhardt-http/src/middleware.rs
@@ -283,6 +283,25 @@ impl Handler for MiddlewareChain {
 			return self.handler.handle(request).await;
 		}
 
+		if self.middlewares.len() == 1 {
+			let middleware = &self.middlewares[0];
+			if !middleware.should_continue(&request) {
+				return match self.handler.handle(request).await {
+					Ok(response) => Ok(response),
+					Err(e) => Ok(Response::from(e)),
+				};
+			}
+
+			let next: Arc<dyn Handler> = Arc::new(ErrorToResponseHandler {
+				inner: self.handler.clone(),
+			});
+			let response = match middleware.process(request, next).await {
+				Ok(response) => response,
+				Err(e) => Response::from(e),
+			};
+			return Ok(response);
+		}
+
 		// Build nested handler chain using composition with optimizations:
 		// 1. Conditional execution (skip middleware based on should_continue)
 		// 2. Short-circuiting (early return if response.should_stop_chain() is true)

--- a/crates/reinhardt-http/src/path_params.rs
+++ b/crates/reinhardt-http/src/path_params.rs
@@ -134,10 +134,10 @@ where
 
 impl IntoIterator for PathParams {
 	type Item = (String, String);
-	type IntoIter = smallvec::IntoIter<[(String, String); INLINE_PARAM_CAPACITY]>;
+	type IntoIter = std::vec::IntoIter<(String, String)>;
 
 	fn into_iter(self) -> Self::IntoIter {
-		self.inner.into_iter()
+		self.inner.into_vec().into_iter()
 	}
 }
 
@@ -253,5 +253,18 @@ mod tests {
 		// Assert
 		let order: Vec<&str> = params.iter().map(|(k, _)| k.as_str()).collect();
 		assert_eq!(order, vec!["z", "a"]);
+	}
+
+	#[rstest]
+	fn consuming_iterator_keeps_public_vec_iterator_type() {
+		// Arrange
+		let params = PathParams::from(vec![("org".to_string(), "myslug".to_string())]);
+
+		// Act
+		let mut iter: std::vec::IntoIter<(String, String)> = params.into_iter();
+
+		// Assert
+		assert_eq!(iter.next(), Some(("org".to_string(), "myslug".to_string())));
+		assert_eq!(iter.next(), None);
 	}
 }

--- a/crates/reinhardt-http/src/path_params.rs
+++ b/crates/reinhardt-http/src/path_params.rs
@@ -2,22 +2,27 @@
 //!
 //! `PathParams` preserves the order in which path parameters appear in the URL
 //! pattern, which is essential for correct tuple-based extraction such as
-//! `Path<(T1, T2)>`. Internally it is a `Vec<(String, String)>`, but it exposes
-//! a small subset of the `HashMap`-like API (`get`, `iter`, `len`, `is_empty`,
-//! `insert`, `values`) so existing callers can continue to look up parameters
-//! by name without any code changes.
+//! `Path<(T1, T2)>`. Internally it uses inline storage for the common small
+//! parameter sets, but it exposes a small subset of the `HashMap`-like API
+//! (`get`, `iter`, `len`, `is_empty`, `insert`, `values`) so existing callers
+//! can continue to look up parameters by name without any code changes.
 //!
-//! # Why a `Vec` and not a `HashMap`?
+//! # Why ordered storage and not a `HashMap`?
 //!
 //! `HashMap` iteration order is non-deterministic. URL routers (matchit in
 //! particular) yield parameters in URL declaration order, which is the order
-//! users expect when destructuring `Path<(T1, T2)>`. Storing parameters in a
-//! `Vec<(String, String)>` preserves that order all the way from the router to
-//! the extractor.
+//! users expect when destructuring `Path<(T1, T2)>`. Storing parameters as an
+//! ordered sequence preserves that order all the way from the router to the
+//! extractor.
 //!
 //! See issue #4013 for details.
 
 use std::collections::HashMap;
+
+use smallvec::SmallVec;
+
+const INLINE_PARAM_CAPACITY: usize = 4;
+type PathParamStorage = SmallVec<[(String, String); INLINE_PARAM_CAPACITY]>;
 
 /// Ordered collection of path parameters extracted from a URL pattern.
 ///
@@ -42,19 +47,21 @@ use std::collections::HashMap;
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PathParams {
-	inner: Vec<(String, String)>,
+	inner: PathParamStorage,
 }
 
 impl PathParams {
 	/// Create a new, empty `PathParams`.
 	pub fn new() -> Self {
-		Self { inner: Vec::new() }
+		Self {
+			inner: PathParamStorage::new(),
+		}
 	}
 
 	/// Create an empty `PathParams` with capacity for `capacity` entries.
 	pub fn with_capacity(capacity: usize) -> Self {
 		Self {
-			inner: Vec::with_capacity(capacity),
+			inner: PathParamStorage::with_capacity(capacity),
 		}
 	}
 
@@ -107,7 +114,7 @@ impl PathParams {
 
 	/// Consume the wrapper and return the inner ordered `Vec`.
 	pub fn into_vec(self) -> Vec<(String, String)> {
-		self.inner
+		self.inner.into_vec()
 	}
 }
 
@@ -127,7 +134,7 @@ where
 
 impl IntoIterator for PathParams {
 	type Item = (String, String);
-	type IntoIter = std::vec::IntoIter<(String, String)>;
+	type IntoIter = smallvec::IntoIter<[(String, String); INLINE_PARAM_CAPACITY]>;
 
 	fn into_iter(self) -> Self::IntoIter {
 		self.inner.into_iter()
@@ -146,7 +153,9 @@ impl<'a> IntoIterator for &'a PathParams {
 impl From<Vec<(String, String)>> for PathParams {
 	fn from(inner: Vec<(String, String)>) -> Self {
 		// Caller is responsible for the ordering of the supplied vector.
-		Self { inner }
+		Self {
+			inner: PathParamStorage::from_vec(inner),
+		}
 	}
 }
 

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -126,6 +126,24 @@ skips response-cookie jar creation for body-only server functions, and
 deserializes JSON server-function requests directly from bytes when content
 negotiation is not required.
 
+### Request Allocation Probe
+
+Use the allocation probe before claiming request-allocation changes:
+
+```bash
+cargo run --release -p reinhardt-benchmarks --bin request_alloc_probe
+```
+
+The 2026-06-25 measurement compared `origin/develop/0.3.0` with the same probe
+after inlining small path-parameter sets and adding the single-middleware chain
+fast path:
+
+| Probe | Baseline | Optimized | Reduction |
+|---|---:|---:|---:|
+| `server_router_static_build_plus_handle` | 6 alloc/request | 6 alloc/request | 0.0% |
+| `server_router_two_params_build_plus_handle` | 11 alloc/request | 10 alloc/request | 9.1% |
+| `server_router_one_middleware_build_plus_handle` | 15 alloc/request | 12 alloc/request | 20.0% |
+
 Static `page!(|| { ... })` edits under WASM-owned client source paths can use
 the compile-free development hot patch path. The HMR payload replaces `#app`
 contents, preserving the development script and page shell. Dynamic Rust


### PR DESCRIPTION
## Summary

This PR addresses:

- Stores common small `PathParams` sets inline with `smallvec` while preserving ordered extraction semantics.
- Adds a single-middleware `MiddlewareChain` fast path that avoids one composed handler allocation per request.
- Documents the request allocation probe command and measured results.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [x] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Reduce request-dispatch allocations without changing public request or router APIs.
- Preserve `Path<(T1, T2)>` declaration-order extraction while avoiding heap allocation for the common small path-parameter set.

Fixes: N/A

Related to: N/A

## How Was This Tested?

- `cargo fmt --check`
- `cargo test -p reinhardt-http path_params -- --nocapture` -> 5 passed
- `cargo test -p reinhardt-http middleware -- --nocapture` -> 27 passed
- `cargo run --release -p reinhardt-benchmarks --bin request_alloc_probe`
- `cargo test -p reinhardt-urls --lib server_router -- --nocapture` -> 98 passed
- `cargo clippy -p reinhardt-http --all-features -- -D warnings`
- `cargo clippy -p reinhardt-urls --lib --all-features -- -D warnings`
- `git diff --check`

Note: `cargo test -p reinhardt-urls server_router -- --nocapture` was also attempted, but Cargo built unrelated integration tests that require the `client-router` feature and failed before running the filtered tests. The targeted lib command above covers the server router tests successfully.

## Performance Impact

`cargo run --release -p reinhardt-benchmarks --bin request_alloc_probe`:

| Probe | Baseline | Current | Reduction |
|---|---:|---:|---:|
| `server_router_static_build_plus_handle` | 6 alloc/request | 6 alloc/request | 0.0% |
| `server_router_two_params_build_plus_handle` | 11 alloc/request | 10 alloc/request | 9.1% |
| `server_router_one_middleware_build_plus_handle` | 15 alloc/request | 12 alloc/request | 20.0% |

## Breaking Changes

None.

## Screenshots

N/A

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- N/A

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [x] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [x] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Generated with Codex
