### PR TITLE
perf(admin): combine admin list count query

### DIFF
--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -945,7 +945,7 @@ impl AdminDatabase {
 			.map_err(|e| AdminError::DatabaseError(e.to_string()))?;
 
 		if rows.is_empty() {
-			if offset == 0 {
+			if offset == 0 && limit > 0 {
 				return Ok((Vec::new(), 0));
 			}
 

--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -19,6 +19,9 @@ use reinhardt_query::prelude::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+const ADMIN_LIST_TOTAL_COUNT_ALIAS: &str = "__reinhardt_total_count";
+const SENSITIVE_FIELDS: &[&str] = &["password_hash", "password_salt"];
+
 /// Converts a `serde_json::Value` into a reinhardt-query `Value`.
 ///
 /// String values are inspected for ISO 8601 date/time patterns and converted
@@ -623,6 +626,53 @@ pub fn build_composite_filter_condition_with_depth(
 	}
 }
 
+fn build_combined_filter_condition(
+	filter_condition: Option<&FilterCondition>,
+	additional_filters: &[Filter],
+) -> AdminResult<(Condition, bool)> {
+	let mut combined = Condition::all();
+
+	if let Some(fc) = filter_condition
+		&& let Some(cond) = build_composite_filter_condition(fc)?
+	{
+		combined = combined.add(cond);
+	}
+
+	if let Some(simple_cond) = build_filter_condition(additional_filters) {
+		combined = combined.add(simple_cond);
+	}
+
+	Ok((
+		combined,
+		!additional_filters.is_empty() || filter_condition.is_some(),
+	))
+}
+
+fn extract_admin_list_total_count(
+	map: &serde_json::Map<String, serde_json::Value>,
+) -> AdminResult<u64> {
+	let count_value = map.get(ADMIN_LIST_TOTAL_COUNT_ALIAS).ok_or_else(|| {
+		AdminError::DatabaseError(format!(
+			"Admin list query result missing '{}' key",
+			ADMIN_LIST_TOTAL_COUNT_ALIAS
+		))
+	})?;
+
+	if let Some(count) = count_value.as_u64() {
+		return Ok(count);
+	}
+
+	count_value
+		.as_i64()
+		.and_then(|count| if count >= 0 { Some(count as u64) } else { None })
+		.ok_or_else(|| {
+			AdminError::DatabaseError(format!(
+				"Admin list query returned invalid total count: {}",
+				count_value
+			))
+		})
+}
+
 /// Admin database interface
 ///
 /// Provides CRUD operations for admin panel, leveraging reinhardt-orm.
@@ -784,23 +834,10 @@ impl AdminDatabase {
 			.column(ColumnRef::Asterisk)
 			.to_owned();
 
-		// Build combined condition
-		let mut combined = Condition::all();
+		let (combined, has_filter) =
+			build_combined_filter_condition(filter_condition, &additional_filters)?;
 
-		// Add composite filter condition (e.g., OR search across fields)
-		if let Some(fc) = filter_condition
-			&& let Some(cond) = build_composite_filter_condition(fc)?
-		{
-			combined = combined.add(cond);
-		}
-
-		// Add simple filters (AND logic)
-		if let Some(simple_cond) = build_filter_condition(&additional_filters) {
-			combined = combined.add(simple_cond);
-		}
-
-		// Only add condition if we have actual filters
-		if !additional_filters.is_empty() || filter_condition.is_some() {
+		if has_filter {
 			query.cond_where(combined);
 		}
 
@@ -832,9 +869,6 @@ impl AdminDatabase {
 			.await
 			.map_err(|e| AdminError::DatabaseError(e.to_string()))?;
 
-		// Sensitive fields that must never be exposed in admin API responses
-		const SENSITIVE_FIELDS: &[&str] = &["password_hash", "password_salt"];
-
 		// Convert QueryRow to HashMap
 		Ok(rows
 			.into_iter()
@@ -850,6 +884,106 @@ impl AdminDatabase {
 				}
 			})
 			.collect())
+	}
+
+	/// List items and return the filtered total count with one query for non-empty pages.
+	///
+	/// This uses a windowed `COUNT(*) OVER()` expression so the admin list endpoint
+	/// can fetch page rows and pagination metadata without issuing a separate count
+	/// query on the common path.
+	pub async fn list_with_condition_and_count<M: Model>(
+		&self,
+		table_name: &str,
+		filter_condition: Option<&FilterCondition>,
+		additional_filters: Vec<Filter>,
+		sort_by: Option<&str>,
+		offset: u64,
+		limit: u64,
+	) -> AdminResult<(Vec<HashMap<String, serde_json::Value>>, u64)> {
+		// SELECT * is intentional: admin panel operates on dynamic schemas where
+		// the column set is not known at compile time. The synthetic total-count
+		// column is removed before returning API rows.
+		let mut query = Query::select()
+			.from(Alias::new(table_name))
+			.column(ColumnRef::Asterisk)
+			.expr_as(
+				Expr::cust("COUNT(*) OVER()"),
+				Alias::new(ADMIN_LIST_TOTAL_COUNT_ALIAS),
+			)
+			.to_owned();
+
+		let (combined, has_filter) =
+			build_combined_filter_condition(filter_condition, &additional_filters)?;
+
+		if has_filter {
+			query.cond_where(combined);
+		}
+
+		if let Some(sort_str) = sort_by {
+			let (field, is_desc) = if let Some(stripped) = sort_str.strip_prefix('-') {
+				(stripped, true)
+			} else {
+				(sort_str, false)
+			};
+
+			let col = Alias::new(field);
+			if is_desc {
+				query.order_by(col, Order::Desc);
+			} else {
+				query.order_by(col, Order::Asc);
+			}
+		}
+
+		query.limit(limit).offset(offset);
+
+		let (sql, values) = query.build(PostgresQueryBuilder);
+		let params = convert_values(values);
+		let rows = self
+			.connection
+			.query(&sql, params)
+			.await
+			.map_err(|e| AdminError::DatabaseError(e.to_string()))?;
+
+		if rows.is_empty() {
+			if offset == 0 {
+				return Ok((Vec::new(), 0));
+			}
+
+			let count = self
+				.count_with_condition::<M>(table_name, filter_condition, additional_filters)
+				.await?;
+			return Ok((Vec::new(), count));
+		}
+
+		let mut total_count = None;
+		let results = rows
+			.into_iter()
+			.filter_map(|row| {
+				if let serde_json::Value::Object(mut map) = row.data {
+					if total_count.is_none() {
+						total_count = Some(extract_admin_list_total_count(&map));
+					}
+
+					map.remove(ADMIN_LIST_TOTAL_COUNT_ALIAS);
+
+					Some(
+						map.into_iter()
+							.filter(|(key, _)| !SENSITIVE_FIELDS.contains(&key.as_str()))
+							.collect::<HashMap<String, serde_json::Value>>(),
+					)
+				} else {
+					None
+				}
+			})
+			.collect::<Vec<_>>();
+
+		let total_count = total_count.unwrap_or_else(|| {
+			Err(AdminError::DatabaseError(
+				"Admin list query returned no object rows".to_string(),
+			))
+		})?;
+
+		Ok((results, total_count))
 	}
 
 	/// Count items with composite filter conditions (supports AND/OR logic)
@@ -870,23 +1004,10 @@ impl AdminDatabase {
 			.expr(Expr::cust("COUNT(*) AS count"))
 			.to_owned();
 
-		// Build combined condition
-		let mut combined = Condition::all();
+		let (combined, has_filter) =
+			build_combined_filter_condition(filter_condition, &additional_filters)?;
 
-		// Add composite filter condition
-		if let Some(fc) = filter_condition
-			&& let Some(cond) = build_composite_filter_condition(fc)?
-		{
-			combined = combined.add(cond);
-		}
-
-		// Add simple filters
-		if let Some(simple_cond) = build_filter_condition(&additional_filters) {
-			combined = combined.add(simple_cond);
-		}
-
-		// Only add condition if we have actual filters
-		if !additional_filters.is_empty() || filter_condition.is_some() {
+		if has_filter {
 			query.cond_where(combined);
 		}
 

--- a/crates/reinhardt-admin/src/server/list.rs
+++ b/crates/reinhardt-admin/src/server/list.rs
@@ -190,25 +190,15 @@ pub async fn get_list(
 		.min(MAX_PAGE_SIZE); // Enforce maximum page size to prevent memory exhaustion
 	let offset = (page - 1) * page_size;
 
-	// Fetch data
-	let results = db
-		.list_with_condition::<AdminRecord>(
-			model_admin.table_name(),
-			filter_condition.as_ref(),
-			additional_filters.clone(),
-			sort_by,
-			offset,
-			page_size,
-		)
-		.await
-		.map_server_fn_error()?;
-
-	// Count total records
-	let count = db
-		.count_with_condition::<AdminRecord>(
+	// Fetch page data and total count in one query for the common non-empty page path.
+	let (results, count) = db
+		.list_with_condition_and_count::<AdminRecord>(
 			model_admin.table_name(),
 			filter_condition.as_ref(),
 			additional_filters,
+			sort_by,
+			offset,
+			page_size,
 		)
 		.await
 		.map_server_fn_error()?;

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -126,6 +126,26 @@ skips response-cookie jar creation for body-only server functions, and
 deserializes JSON server-function requests directly from bytes when content
 negotiation is not required.
 
+## Admin List Query Count Measurements
+
+Use the admin database mock tests before claiming query-count reductions on the
+admin list endpoint:
+
+```bash
+cargo test -p reinhardt-integration-tests test_list_with_condition_and_count -- --nocapture
+```
+
+The non-empty admin list path now uses `COUNT(*) OVER()` to return page rows and
+filtered pagination count from one SQL statement. Empty first pages also finish
+with the same single query. Empty out-of-range pages still issue the existing
+count query as a fallback so pagination metadata remains correct.
+
+| Request shape | Baseline DB calls | Current DB calls | Reduction |
+|---|---:|---:|---:|
+| Non-empty admin list page | 2 | 1 | 50.0% |
+| Empty first admin list page | 2 | 1 | 50.0% |
+| Empty out-of-range admin list page | 2 | 2 | 0.0% |
+
 Static `page!(|| { ... })` edits under WASM-owned client source paths can use
 the compile-free development hot patch path. The HMR payload replaces `#app`
 contents, preserving the development script and page shell. Dynamic Rust

--- a/tests/integration/tests/admin/admin_database_tests.rs
+++ b/tests/integration/tests/admin/admin_database_tests.rs
@@ -7,6 +7,10 @@ use reinhardt_admin::core::database::{
 	AdminDatabase, build_composite_filter_condition, build_single_filter_expr,
 	filter_value_to_sea_value,
 };
+use reinhardt_db::backends::{
+	connection::DatabaseConnection as BackendsConnection,
+	types::{QueryValue, Row},
+};
 use reinhardt_db::orm::annotation::Expression;
 use reinhardt_db::orm::expressions::{F, OuterRef};
 use reinhardt_db::orm::{
@@ -15,6 +19,7 @@ use reinhardt_db::orm::{
 use reinhardt_query::{
 	Alias, ColumnRef, Condition, PostgresQueryBuilder, Query, QueryStatementBuilder, Value,
 };
+use reinhardt_test::fixtures::mock::MockDatabaseBackend;
 use reinhardt_test::fixtures::mock_connection;
 use rstest::*;
 use std::collections::HashMap;
@@ -28,6 +33,12 @@ struct User {
 }
 
 reinhardt_test::impl_test_model!(User, i64, "users");
+
+fn admin_database_from_mock(mock: MockDatabaseBackend) -> AdminDatabase {
+	let backends_conn = BackendsConnection::new(Arc::new(mock));
+	let conn = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
+	AdminDatabase::new(conn)
+}
 
 // ==================== AdminDatabase CRUD tests ====================
 
@@ -505,6 +516,101 @@ async fn test_count_with_condition_combined(mock_connection: DatabaseConnection)
 
 	// Assert
 	assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_list_with_condition_and_count_uses_single_query_for_non_empty_page() {
+	// Arrange
+	let mut mock = MockDatabaseBackend::new();
+	mock.expect_fetch_all()
+		.withf(|sql, _| {
+			sql.contains("COUNT(*) OVER()")
+				&& sql.contains("__reinhardt_total_count")
+				&& sql.contains("ORDER BY")
+		})
+		.times(1)
+		.returning(|_, _| {
+			let mut row = Row::new();
+			row.data.insert("id".to_string(), QueryValue::Int(42));
+			row.data
+				.insert("name".to_string(), QueryValue::String("Alice".to_string()));
+			row.data.insert(
+				"password_hash".to_string(),
+				QueryValue::String("secret".to_string()),
+			);
+			row.data
+				.insert("__reinhardt_total_count".to_string(), QueryValue::Int(3));
+			Ok(vec![row])
+		});
+	mock.expect_fetch_one().times(0);
+
+	let db = admin_database_from_mock(mock);
+
+	// Act
+	let (rows, count) = db
+		.list_with_condition_and_count::<User>("users", None, vec![], Some("-id"), 0, 50)
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(count, 3);
+	assert_eq!(rows.len(), 1);
+	assert_eq!(rows[0].get("name"), Some(&serde_json::json!("Alice")));
+	assert!(!rows[0].contains_key("__reinhardt_total_count"));
+	assert!(!rows[0].contains_key("password_hash"));
+}
+
+#[tokio::test]
+async fn test_list_with_condition_and_count_empty_first_page_uses_single_query() {
+	// Arrange
+	let mut mock = MockDatabaseBackend::new();
+	mock.expect_fetch_all()
+		.withf(|sql, _| sql.contains("COUNT(*) OVER()") && sql.contains("__reinhardt_total_count"))
+		.times(1)
+		.returning(|_, _| Ok(Vec::new()));
+	mock.expect_fetch_one().times(0);
+
+	let db = admin_database_from_mock(mock);
+
+	// Act
+	let (rows, count) = db
+		.list_with_condition_and_count::<User>("users", None, vec![], None, 0, 50)
+		.await
+		.unwrap();
+
+	// Assert
+	assert!(rows.is_empty());
+	assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn test_list_with_condition_and_count_empty_later_page_counts_for_pagination() {
+	// Arrange
+	let mut mock = MockDatabaseBackend::new();
+	mock.expect_fetch_all()
+		.withf(|sql, _| sql.contains("COUNT(*) OVER()") && sql.contains("__reinhardt_total_count"))
+		.times(1)
+		.returning(|_, _| Ok(Vec::new()));
+	mock.expect_fetch_one()
+		.withf(|sql, _| sql.contains("COUNT(*) AS count"))
+		.times(1)
+		.returning(|_, _| {
+			let mut row = Row::new();
+			row.data.insert("count".to_string(), QueryValue::Int(5));
+			Ok(row)
+		});
+
+	let db = admin_database_from_mock(mock);
+
+	// Act
+	let (rows, count) = db
+		.list_with_condition_and_count::<User>("users", None, vec![], None, 50, 50)
+		.await
+		.unwrap();
+
+	// Assert
+	assert!(rows.is_empty());
+	assert_eq!(count, 5);
 }
 
 // ==================== FieldRef/OuterRef/Expression filter tests ====================

--- a/tests/integration/tests/admin/admin_database_tests.rs
+++ b/tests/integration/tests/admin/admin_database_tests.rs
@@ -584,6 +584,36 @@ async fn test_list_with_condition_and_count_empty_first_page_uses_single_query()
 }
 
 #[tokio::test]
+async fn test_list_with_condition_and_count_zero_limit_first_page_counts_for_pagination() {
+	// Arrange
+	let mut mock = MockDatabaseBackend::new();
+	mock.expect_fetch_all()
+		.withf(|sql, _| sql.contains("COUNT(*) OVER()") && sql.contains("__reinhardt_total_count"))
+		.times(1)
+		.returning(|_, _| Ok(Vec::new()));
+	mock.expect_fetch_one()
+		.withf(|sql, _| sql.contains("COUNT(*) AS count"))
+		.times(1)
+		.returning(|_, _| {
+			let mut row = Row::new();
+			row.data.insert("count".to_string(), QueryValue::Int(5));
+			Ok(row)
+		});
+
+	let db = admin_database_from_mock(mock);
+
+	// Act
+	let (rows, count) = db
+		.list_with_condition_and_count::<User>("users", None, vec![], None, 0, 0)
+		.await
+		.unwrap();
+
+	// Assert
+	assert!(rows.is_empty());
+	assert_eq!(count, 5);
+}
+
+#[tokio::test]
 async fn test_list_with_condition_and_count_empty_later_page_counts_for_pagination() {
 	// Arrange
 	let mut mock = MockDatabaseBackend::new();


### PR DESCRIPTION
## Summary

This PR addresses:

- Combines the admin list row fetch and filtered pagination count with `COUNT(*) OVER()`.
- Keeps the existing count fallback for empty out-of-range pages so pagination metadata remains correct.
- Documents the admin list query-count measurement and reproduction command.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [x] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Admin list requests previously issued separate list and count SQL statements for the same filter set. The common non-empty page path now gets rows and total count in one backend fetch.

Fixes: N/A

Related to: N/A

## How Was This Tested?

- `cargo fmt --check`
- `cargo test -p reinhardt-integration-tests test_list_with_condition_and_count -- --nocapture`
- `cargo clippy -p reinhardt-admin --all-features -- -D warnings`
- `git diff --check`

## Performance Impact

- Non-empty admin list page: 2 DB calls -> 1 DB call, 50.0% reduction.
- Empty first admin list page: 2 DB calls -> 1 DB call, 50.0% reduction.
- Empty out-of-range admin list page: remains 2 DB calls to preserve pagination metadata.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- N/A

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [x] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [x] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- The unchecked clippy checkbox is intentional because this PR ran targeted clippy for `reinhardt-admin`, not the full `cargo make clippy-check` workspace command.
