### PR TITLE
security(ci): keep untrusted PR gates on hosted runners

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -19,8 +19,7 @@ jobs:
   label-by-path:
     name: Label by changed files
     timeout-minutes: 10
-    # See infra/github-runners/hotpath-runner-userdata.sh for the canonical hotpath runner labels.
-    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v6
         with:
@@ -31,7 +30,7 @@ jobs:
   label-by-title:
     name: Label by PR title
     timeout-minutes: 10
-    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,7 @@ jobs:
     name: Check Branch Status
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
-    # See infra/github-runners/hotpath-runner-userdata.sh for the canonical hotpath runner labels.
-    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
+    runs-on: ubuntu-latest
     outputs:
       has-conflicts: ${{ steps.check.outputs.has-conflicts }}
       infra-changed: ${{ steps.check-infra.outputs.infra-changed }}

--- a/.github/workflows/develop-leak-guard.yml
+++ b/.github/workflows/develop-leak-guard.yml
@@ -24,8 +24,7 @@ jobs:
     if: >-
       github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
       github.event.label.name == 'migration-approved'
-    # See infra/github-runners/hotpath-runner-userdata.sh for the canonical hotpath runner labels.
-    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
+    runs-on: ubuntu-latest
     steps:
       - name: Check if migration-approved
         id: label-check

--- a/.github/workflows/develop-merge-guard.yml
+++ b/.github/workflows/develop-merge-guard.yml
@@ -24,8 +24,7 @@ jobs:
     if: >-
       github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
       github.event.label.name == 'migration-approved'
-    # See infra/github-runners/hotpath-runner-userdata.sh for the canonical hotpath runner labels.
-    runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]
+    runs-on: ubuntu-latest
     steps:
       - name: Check if guard applies
         id: guard-scope


### PR DESCRIPTION
### Motivation
- A recent refactor routed PR-triggered and `pull_request_target` jobs to the persistent self-hosted `reinhardt-hotpath` runner, creating a security-boundary regression that exposes persistent runner state and tokens to untrusted PR data. 
- Privileged operations in `pull_request_target` (labeling with write-capable permissions) and a full-history checkout in the leak guard increased the risk of runner compromise if attacker-controlled PR data is processed on a long-lived host. 
- Restore ephemeral isolation by running these lightweight, PR-originated gates on GitHub-hosted runners to remove the token/exposure path while preserving existing checks. 

### Description
- Reverted `runs-on` for `label-by-path` and `label-by-title` in `.github/workflows/auto-label-pr.yml` from the self-hosted hotpath to `ubuntu-latest`. 
- Reverted `runs-on` for the `check-branch-status` job in `.github/workflows/ci.yml` to `ubuntu-latest`. 
- Reverted `runs-on` for the `develop-leak-guard` and `develop-merge-guard` jobs in `.github/workflows/develop-leak-guard.yml` and `.github/workflows/develop-merge-guard.yml` to `ubuntu-latest`. 
- Changes were committed with the message `security(ci): keep untrusted PR gates on hosted runners`. 

### Testing
- Successfully parsed the updated workflow YAML files with `ruby -e 'require "yaml"; ...'` to validate YAML syntax. 
- Verified there are no remaining occurrences of `runs-on: [self-hosted, linux, arm64, reinhardt-hotpath]` using `rg` and the search returned no matches. 
- Ran `git diff --check` to confirm no whitespace or diff issues and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35f9769f0c8327b28b7b7b0eae8dd6)