### PR TITLE
fix(ci): restrict orphan detector to managed runner labels

### DIFF
--- a/infra/github-runners/lambda-src/orphan-detector/src/detector.ts
+++ b/infra/github-runners/lambda-src/orphan-detector/src/detector.ts
@@ -1,3 +1,10 @@
+const MANAGED_RUNNER_LABELS = [
+	"self-hosted",
+	"linux",
+	"arm64",
+	"reinhardt-ci",
+] as const;
+
 export interface WorkflowJob {
 	id: number;
 	run_id: number;
@@ -8,6 +15,12 @@ export interface WorkflowJob {
 
 // Generic over the job type so callers with richer types (e.g. QueuedJobExtended
 // in github-client.ts) retain their extra fields through the filter.
+export function hasManagedRunnerLabels(labels: readonly string[]): boolean {
+	if (labels.length !== MANAGED_RUNNER_LABELS.length) return false;
+	const labelSet = new Set(labels);
+	return MANAGED_RUNNER_LABELS.every((label) => labelSet.has(label));
+}
+
 export function filterOrphans<J extends WorkflowJob>(
 	jobs: readonly J[],
 	nowMs: number,
@@ -17,6 +30,7 @@ export function filterOrphans<J extends WorkflowJob>(
 	const cutoffMs = nowMs - stalenessMin * 60_000;
 	return jobs.filter((job) => {
 		if (job.status !== "queued") return false;
+		if (!hasManagedRunnerLabels(job.labels)) return false;
 		if (processed.has(job.id)) return false;
 		const createdMs = Date.parse(job.created_at);
 		if (Number.isNaN(createdMs)) return false;

--- a/infra/github-runners/lambda-src/orphan-detector/src/payload-builder.ts
+++ b/infra/github-runners/lambda-src/orphan-detector/src/payload-builder.ts
@@ -38,10 +38,7 @@ export interface SyntheticWebhook {
 }
 
 export function buildSyntheticWebhook(input: PayloadInput): SyntheticWebhook {
-	// Ensure 'self-hosted' is always in labels (defense against upstream assumptions).
-	const labels = input.job.labels.includes("self-hosted")
-		? [...input.job.labels]
-		: ["self-hosted", ...input.job.labels];
+	const labels = [...input.job.labels];
 
 	return {
 		deliveryId: randomUUID(),

--- a/infra/github-runners/lambda-src/orphan-detector/test/detector.test.ts
+++ b/infra/github-runners/lambda-src/orphan-detector/test/detector.test.ts
@@ -5,7 +5,7 @@ const mkJob = (overrides: Partial<WorkflowJob> = {}): WorkflowJob => ({
 	id: 100,
 	status: "queued",
 	created_at: "2026-04-22T10:00:00Z",
-	labels: ["self-hosted", "reinhardt-ci"],
+	labels: ["self-hosted", "linux", "arm64", "reinhardt-ci"],
 	run_id: 999,
 	...overrides,
 });
@@ -53,5 +53,20 @@ describe("filterOrphans", () => {
 	it("handles ISO 8601 UTC with milliseconds", () => {
 		const jobs = [mkJob({ id: 7, created_at: "2026-04-22T10:00:00.123Z" })];
 		expect(filterOrphans(jobs, now, staleness, new Map())).toHaveLength(1);
+	});
+
+	it("excludes jobs outside the managed runner label set", () => {
+		const jobs = [mkJob({ id: 8, labels: ["ubuntu-latest"] })];
+		expect(filterOrphans(jobs, now, staleness, new Map())).toHaveLength(0);
+	});
+
+	it("excludes jobs with extra self-hosted labels outside the managed fleet", () => {
+		const jobs = [
+			mkJob({
+				id: 9,
+				labels: ["self-hosted", "linux", "arm64", "reinhardt-ci", "gpu"],
+			}),
+		];
+		expect(filterOrphans(jobs, now, staleness, new Map())).toHaveLength(0);
 	});
 });

--- a/infra/github-runners/lambda-src/orphan-detector/test/github-client.test.ts
+++ b/infra/github-runners/lambda-src/orphan-detector/test/github-client.test.ts
@@ -42,7 +42,7 @@ describe("listQueuedJobs", () => {
 							run_id: 999,
 							status: "queued",
 							created_at: "2026-04-22T10:00:00Z",
-							labels: ["self-hosted", "reinhardt-ci"],
+							labels: ["self-hosted", "linux", "arm64", "reinhardt-ci"],
 							workflow_name: "CI",
 							name: "Feature Check",
 						},
@@ -67,7 +67,9 @@ describe("listQueuedJobs", () => {
 	it("getRateLimitRemaining returns remaining count", async () => {
 		server.use(
 			http.get("https://api.github.com/rate_limit", () =>
-				HttpResponse.json({ rate: { limit: 5000, remaining: 4321, reset: 123 } }),
+				HttpResponse.json({
+					rate: { limit: 5000, remaining: 4321, reset: 123 },
+				}),
 			),
 		);
 		const octokit = new Octokit({ auth: "test-token" });
@@ -77,9 +79,7 @@ describe("listQueuedJobs", () => {
 
 	it("getRateLimitRemaining returns -1 on error", async () => {
 		server.use(
-			http.get("https://api.github.com/rate_limit", () =>
-				HttpResponse.error(),
-			),
+			http.get("https://api.github.com/rate_limit", () => HttpResponse.error()),
 		);
 		const octokit = new Octokit({ auth: "test-token" });
 		const remaining = await getRateLimitRemaining(octokit);
@@ -109,8 +109,9 @@ describe("listQueuedJobs", () => {
 					workflow_runs: [{ id: 2, status: "queued" }],
 				});
 			}),
-			http.get("https://api.github.com/repos/o/r/actions/runs/:runId/jobs", () =>
-				HttpResponse.json({ total_count: 0, jobs: [] }),
+			http.get(
+				"https://api.github.com/repos/o/r/actions/runs/:runId/jobs",
+				() => HttpResponse.json({ total_count: 0, jobs: [] }),
 			),
 		);
 		const octokit = new Octokit({ auth: "test-token" });

--- a/infra/github-runners/lambda-src/orphan-detector/test/handler.test.ts
+++ b/infra/github-runners/lambda-src/orphan-detector/test/handler.test.ts
@@ -27,7 +27,8 @@ vi.mock("@aws-sdk/client-ssm", () => ({
 	SSMClient: vi.fn().mockImplementation(() => ({
 		send: vi.fn().mockResolvedValue({
 			Parameter: {
-				Value: "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+				Value:
+					"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
 			},
 		}),
 	})),
@@ -67,7 +68,7 @@ const mkJob = (id: number, minutesAgo: number) => ({
 	run_id: 999,
 	status: "queued" as const,
 	created_at: new Date(Date.now() - minutesAgo * 60_000).toISOString(),
-	labels: ["self-hosted", "reinhardt-ci"],
+	labels: ["self-hosted", "linux", "arm64", "reinhardt-ci"],
 	workflow_name: "CI",
 	name: `Job ${id}`,
 });
@@ -112,12 +113,15 @@ describe("handler", () => {
 
 	it("trips circuit breaker when orphan count > threshold", async () => {
 		const manyJobs = Array.from({ length: 60 }, (_, i) => mkJob(i + 1, 90));
-		(listQueuedJobs as ReturnType<typeof vi.fn>).mockResolvedValueOnce(manyJobs);
+		(listQueuedJobs as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+			manyJobs,
+		);
 
 		await handler();
 
 		expect(publishAlert).toHaveBeenCalledTimes(1);
-		const alertBody = (publishAlert as ReturnType<typeof vi.fn>).mock.calls[0]?.[2];
+		const alertBody = (publishAlert as ReturnType<typeof vi.fn>).mock
+			.calls[0]?.[2];
 		expect(alertBody.orphanCount).toBe(60);
 		expect(alertBody.sampleJobIds.length).toBeLessThanOrEqual(10);
 		expect(postSignedWebhook).not.toHaveBeenCalled();
@@ -153,10 +157,8 @@ describe("handler", () => {
 
 		await handler();
 
-		const savedMap = (saveProcessedState as ReturnType<typeof vi.fn>).mock.calls[0]?.[2] as Map<
-			number,
-			number
-		>;
+		const savedMap = (saveProcessedState as ReturnType<typeof vi.fn>).mock
+			.calls[0]?.[2] as Map<number, number>;
 		expect(savedMap.has(1)).toBe(true);
 		expect(savedMap.has(2)).toBe(false);
 	});

--- a/infra/github-runners/lambda-src/orphan-detector/test/payload-builder.test.ts
+++ b/infra/github-runners/lambda-src/orphan-detector/test/payload-builder.test.ts
@@ -8,7 +8,7 @@ describe("buildSyntheticWebhook", () => {
 			run_id: 98765,
 			status: "queued" as const,
 			created_at: "2026-04-22T10:00:00Z",
-			labels: ["self-hosted", "reinhardt-ci"],
+			labels: ["self-hosted", "linux", "arm64", "reinhardt-ci"],
 			workflow_name: "CI",
 			name: "Feature Check",
 		},
@@ -26,7 +26,12 @@ describe("buildSyntheticWebhook", () => {
 		const { body } = buildSyntheticWebhook(baseInput);
 		expect(body.workflow_job.id).toBe(24772441693);
 		expect(body.workflow_job.run_id).toBe(98765);
-		expect(body.workflow_job.labels).toEqual(["self-hosted", "reinhardt-ci"]);
+		expect(body.workflow_job.labels).toEqual([
+			"self-hosted",
+			"linux",
+			"arm64",
+			"reinhardt-ci",
+		]);
 	});
 
 	it("sets repository.full_name = owner/repo", () => {
@@ -51,13 +56,12 @@ describe("buildSyntheticWebhook", () => {
 		);
 	});
 
-	it("labels include self-hosted when missing (defensive)", () => {
+	it("preserves labels exactly when self-hosted is missing", () => {
 		const input = {
 			...baseInput,
-			job: { ...baseInput.job, labels: ["reinhardt-ci"] },
+			job: { ...baseInput.job, labels: ["ubuntu-latest"] },
 		};
 		const { body } = buildSyntheticWebhook(input);
-		expect(body.workflow_job.labels).toContain("self-hosted");
-		expect(body.workflow_job.labels).toContain("reinhardt-ci");
+		expect(body.workflow_job.labels).toEqual(["ubuntu-latest"]);
 	});
 });


### PR DESCRIPTION
### Motivation
- Prevent the orphan-detector Lambda from transforming and republishing queued jobs that were not originally targeted at the managed self-hosted runner fleet, which could otherwise allow non-fleet jobs to be relabeled as `self-hosted` and provision self-hosted capacity.
- Preserve original job labels when generating synthetic `workflow_job` webhooks so routing and trust boundaries are unchanged.

### Description
- Add `MANAGED_RUNNER_LABELS` and `hasManagedRunnerLabels` and require an exact match to that label set before a job is considered an orphan in `filterOrphans` (`src/detector.ts`).
- Stop injecting `self-hosted` into synthetic payloads; `buildSyntheticWebhook` now preserves the original `job.labels` verbatim (`src/payload-builder.ts`).
- Update unit tests and fixtures to use the full managed label set `["self-hosted","linux","arm64","reinhardt-ci"]` and add regression tests that assert jobs with `['ubuntu-latest']` or with extra unexpected labels are excluded from republishing (tests under `test/`).
- Keep behavior unchanged for jobs that already exactly match the managed fleet labels (they remain eligible when stale and not deduped).

### Testing
- Ran repository checks and formatting: `git diff --check` and `npx prettier --check` succeeded for the modified files.
- Added and formatted tests with `prettier` and updated test fixtures to cover managed-label positive and negative cases (new assertions in `test/detector.test.ts` and `test/payload-builder.test.ts`).
- Attempted to run unit tests (`npm test` / `vitest`) and type/build checks (`npx tsc --noEmit`, `npm run build`) but these could not complete in this environment because local `node_modules` installation was incomplete and external registry access failed (Vitest/esbuild/type deps unavailable), so runtime test execution and build were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f287059c08327b36bbddd6ea03cd5)