### PR TITLE
fix(macros): avoid debug logging extractor errors

### DIFF
--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -1035,7 +1035,7 @@ fn generate_server_handler(
 						.await
 						.map_err(|e| {
 							#pages_crate_for_ext::__private::tracing::error!(
-								error = ?e,
+								error = %e,
 								param = stringify!(#ty),
 								"FromRequest extractor failed",
 							);
@@ -1633,6 +1633,34 @@ mod tests {
 		assert!(result.is_err());
 		let err = result.unwrap_err().to_string();
 		assert!(err.contains("fragment identifiers"));
+	}
+
+	/// Tests that generated extractor failure logs use Display formatting so raw
+	/// request data stored for debugging is not emitted through Debug output.
+	#[test]
+	fn test_extractor_error_logging_uses_display_formatting() {
+		use syn::parse_quote;
+
+		let func: syn::ItemFn = parse_quote! {
+			pub async fn login(form: Form<LoginRequest>) -> Result<(), ServerFnError> {
+				Ok(())
+			}
+		};
+		let info = ServerFnInfo {
+			func,
+			options: ServerFnOptions::default(),
+		};
+
+		let generated = generate_server_fn(&info).to_string();
+
+		assert!(
+			generated.contains("error = % e"),
+			"extractor errors should be logged with Display formatting: {generated}"
+		);
+		assert!(
+			!generated.contains("error = ? e"),
+			"extractor errors must not be logged with Debug formatting: {generated}"
+		);
 	}
 
 	/// Tests for `is_extractor_type` — verifies known extractor type detection.


### PR DESCRIPTION
### Motivation

- Prevent accidental leakage of sensitive request data (bodies, headers, cookies, etc.) when `FromRequest` extractor resolution fails because `Debug` formatting of `ParamError` can include raw request values.

### Description

- Change the generated `tracing::error!` invocation in server function extractor resolution to use Display formatting (`error = %e`) instead of Debug (`error = ?e`) in `crates/reinhardt-pages/macros/src/server_fn.rs`.
- Add a regression unit test `test_extractor_error_logging_uses_display_formatting` that generates the server handler and asserts the generated code contains the Display-format marker and does not contain the Debug-format marker in `crates/reinhardt-pages/macros/src/server_fn.rs` tests.
- The change ensures extractor errors are still recorded but prevents raw debug-only fields (like `raw_value`) from being emitted into logs.

### Testing

- Ran `cargo test -p reinhardt-pages-macros test_extractor_error_logging_uses_display_formatting` and the new test passed.
- Ran `cargo fmt --check --package reinhardt-pages-macros` and formatting check passed for the modified file.
- `cargo make fmt-check` was attempted but `cargo-make` is not available in the current environment (not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f28708d4c83278ce505edf9473386)