### PR TITLE
fix(ci): run release version sync from trusted checkout

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -213,6 +213,15 @@ jobs:
             exit 0
           fi
 
+          # Copy the version-sync script from the trusted base checkout before
+          # switching to the mutable release branch. The release branch is
+          # generated and later written with this job's App token, so executing
+          # scripts from that branch would give branch contents code execution
+          # with repository write credentials.
+          TRUSTED_VERSION_SYNC_SCRIPT="$RUNNER_TEMP/update-version-refs.sh"
+          cp scripts/update-version-refs.sh "$TRUSTED_VERSION_SYNC_SCRIPT"
+          chmod 700 "$TRUSTED_VERSION_SYNC_SCRIPT"
+
           # Sync the working tree to the release branch HEAD (created by
           # release-plz/action) so update-version-refs.sh edits the right
           # snapshot. We do NOT need a local commit -- the GraphQL mutation
@@ -224,7 +233,7 @@ jobs:
           VERSION=$(grep '^version = ' Cargo.toml | head -1 | \
                     sed 's/version = "\(.*\)"/\1/')
 
-          ./scripts/update-version-refs.sh "$VERSION"
+          REINHARDT_REPO_ROOT="$PWD" "$TRUSTED_VERSION_SYNC_SCRIPT" "$VERSION"
 
           if git diff --quiet; then
             echo "update-version-refs.sh produced no changes; skipping commit."

--- a/scripts/update-version-refs.sh
+++ b/scripts/update-version-refs.sh
@@ -49,7 +49,7 @@ fi
 # --- Resolve paths and target list ---
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="${REINHARDT_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
 if [ -n "${REINHARDT_VERSION_SYNC_TARGETS:-}" ]; then
 	# Space-separated override (for tests only)


### PR DESCRIPTION
### Motivation
- The release workflow executed `scripts/update-version-refs.sh` from the mutable Release PR branch while a repository-write GitHub App token was available, enabling branch-controlled code to run with write privileges. 
- The change isolates executed code to a trusted copy from the original checkout so the release branch cannot inject arbitrary commands while the token is exposed.

### Description
- In `.github/workflows/release-plz.yml` copy `scripts/update-version-refs.sh` to `$RUNNER_TEMP` and `chmod 700` it before checking out the release branch, then execute the copied script instead of the branch copy. 
- Invoke the trusted copy with `REINHARDT_REPO_ROOT="$PWD"` so the script still edits the checked-out release branch snapshot. 
- In `scripts/update-version-refs.sh` allow `REINHARDT_REPO_ROOT` to override the computed `REPO_ROOT` so the trusted temporary script can operate on the release working tree.

### Testing
- Ran `git diff --check` to ensure no index conflicts and observed a clean diff result. 
- Exercised the updated script with `REINHARDT_REPO_ROOT="$tmpdir" REINHARDT_VERSION_SYNC_TARGETS='target.toml' bash scripts/update-version-refs.sh 0.2.0` and confirmed the target file was updated successfully. 
- Validated the modified workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-plz.yml")'` and reported success, while a `python3` YAML parse failed due to missing `PyYAML` in the environment (warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f2870e2c883278de1f4e0be964f2a)