### PR TITLE
docs(release): expose 0.3 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ move through the documented alpha and RC lifecycle before stable publication.
 
 For per-release detail (changelog summary, upgrade notes, known issues),
 see the [Release category in GitHub Discussions](https://github.com/kent8192/reinhardt-web/discussions/categories/release).
+For 0.2.x applications moving to 0.3.0, use the
+[0.3 migration guide](instructions/MIGRATION_0.3.md).
 The full lifecycle policy lives in
 [Stability Policy](instructions/STABILITY_POLICY.md).
 
@@ -1331,16 +1333,16 @@ Reinhardt offers modular components you can mix and match:
 
 - 📚 [Getting Started Guide](https://reinhardt-web.dev/quickstart/getting-started/) - Step-by-step tutorial for beginners
 - 🎛️ [Feature Flags Guide](https://reinhardt-web.dev/docs/feature-flags/) - Optimize your build with granular feature control
-- 📖 [API Reference](https://docs.rs/reinhardt-web) (Coming soon)
+- 📖 [API Reference](https://docs.rs/reinhardt-web)
 - 📝 [Tutorials](https://reinhardt-web.dev/quickstart/tutorials/) - Learn by building real applications
 
-**For AI Assistants**: See [CLAUDE.md](CLAUDE.md) for project-specific coding standards, testing guidelines, and development conventions.
+For contributor automation and repository-specific development conventions,
+see [CLAUDE.md](CLAUDE.md).
 
 ## 💬 Getting Help
 
 Reinhardt is a community-driven project. Here's where you can get help:
 
-- 💬 **Discord**: Join our Discord server for real-time chat (coming soon)
 - 💭 **GitHub Discussions**: [Ask questions and share ideas](https://github.com/kent8192/reinhardt-web/discussions)
 - 🐛 **Issues**: [Report bugs](https://github.com/kent8192/reinhardt-web/issues)
 - 📖 **Documentation**: [Read the guides](docs/)

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -7,11 +7,10 @@
 //!
 //! ## Installation
 //!
-//! While Reinhardt is on a pre-release (`-rc.*` / `-alpha.*`),
-//! `cargo install` requires an explicit `--version` because pre-releases
-//! are not selected by default. Once `0.1.0` stable ships, `--version`
-//! becomes optional. The literal below is auto-bumped by release-plz on
-//! each release.
+//! Install the current stable CLI with Cargo. The command below pins this
+//! guide to the documented release for reproducibility; omit `--version` to
+//! let Cargo choose the latest stable release. The literal below is
+//! release-managed.
 //!
 //! <!-- reinhardt-version-sync -->
 //! ```bash

--- a/instructions/MIGRATION_0.3.md
+++ b/instructions/MIGRATION_0.3.md
@@ -1,6 +1,7 @@
 # Migration Guide: 0.2.x to 0.3.0
 
-Release blockers: [#5405](https://github.com/kent8192/reinhardt-web/issues/5405),
+Related release-readiness tracking:
+[#5405](https://github.com/kent8192/reinhardt-web/issues/5405) and
 [#5410](https://github.com/kent8192/reinhardt-web/issues/5410).
 
 This guide covers the delta from the public 0.2.x line to the final 0.3.0

--- a/website/content/quickstart/_index.md
+++ b/website/content/quickstart/_index.md
@@ -54,3 +54,6 @@ cargo make runserver
 Visit `http://127.0.0.1:8000/hello` in your browser.
 
 See [Getting Started](/quickstart/getting-started/) for a complete guide, or explore the [Tutorials](/quickstart/tutorials/) to learn by building.
+
+Upgrading an existing 0.2.x application? Follow the
+[0.2.x to 0.3.0 migration guide](/quickstart/migration-guides/0-2-to-0-3/).

--- a/website/content/quickstart/migration-guides/0-2-to-0-3.md
+++ b/website/content/quickstart/migration-guides/0-2-to-0-3.md
@@ -1,0 +1,61 @@
++++
+title = "Migrating from 0.2.x to 0.3.0"
+description = "Upgrade an existing Reinhardt application from the 0.2 release line to 0.3.0."
+weight = 5
++++
+
+# Migrating from 0.2.x to 0.3.0
+
+Reinhardt 0.3.0 removes the remaining 0.2 compatibility APIs and finalizes
+the Pages, dependency injection, routing, model-info, and migration surfaces
+that were stabilized through the release-candidate line.
+
+The repository-level `instructions/MIGRATION_0.3.md` guide remains the source
+of truth for exhaustive project-maintainer checks.
+
+## Recommended Order
+
+1. Update `Cargo.toml` to the target 0.3 release.
+2. Replace removed 0.2 compatibility APIs.
+3. Migrate dependency providers that need explicit keyed identity.
+4. Replace raw server route registration with endpoint metadata.
+5. Review generated model-info relation fields and DTO conversions.
+6. Update Pages apps to the split client/server layout.
+7. Regenerate migrations and review the generated diff.
+8. Run the verification commands from the complete guide.
+
+## Key Changes
+
+| Area | Migration action |
+|---|---|
+| Auth extractors | Replace `AuthUser<U>` with `CurrentUser<U>`. |
+| Pages resources | Replace `create_resource*` with `use_resource(fetcher, deps)`. |
+| Effect callbacks | Replace `use_effect_event*` with `use_callback*` or `.get_untracked()` inside effects. |
+| URL routing | Replace raw `.function(...)`, `.route(...)`, and method handler registration with endpoint macros plus `.endpoint(...)`. |
+| Dependency injection | Use `FactoryOutput<K, T>` and `Depends<K, T>` when the output value type is not a unique dependency identity. |
+| Pages layout | Move route wrappers under app-local `client/components/`, split server/client modules, and use `urls/client_router.rs` plus `urls/server_router.rs`. |
+| Model info | Review relation fields that now expose `RelationInfo<T>` or `ManyToManyInfo<Source, Target>`. |
+| Migrations | Regenerate migrations after relation metadata, field rename, or constraint changes. |
+
+## Verification
+
+Start with narrow scans so removed API references are visible before running
+the full project gates:
+
+```bash
+APP_PATHS="src"
+rg -n "AuthUser|create_resource|create_resource_with_deps|use_effect_event|use_effect_event_with" $APP_PATHS
+rg -n "\\.(function|route|handler_with_method)(_named)?\\(|FunctionHandler|Depends(Result|Option)" $APP_PATHS
+rg -n "pages\\.rs|server_urls|client/pages|src/shared/(forms|types)\\.rs" $APP_PATHS
+./scripts/validate-version-markers.sh
+git diff --check
+```
+
+Then run the relevant Rust documentation and lint gates:
+
+```bash
+cargo make fmt-check
+cargo make clippy-check
+cargo test --doc
+cargo doc --no-deps
+```

--- a/website/content/quickstart/migration-guides/_index.md
+++ b/website/content/quickstart/migration-guides/_index.md
@@ -7,3 +7,18 @@ weight = 30
 [extra]
 sidebar_weight = 30
 +++
+
+# Migration Guides
+
+Use these guides when moving an existing codebase to Reinhardt or between
+Reinhardt release lines.
+
+## Reinhardt Release Lines
+
+- [0.2.x to 0.3.0](0-2-to-0-3/) - Upgrade an existing Reinhardt application to the 0.3 release line.
+
+## From Other Frameworks
+
+- [Migrating from Django](from-django/)
+- [Migrating from Actix-web](from-actix/)
+- [Migrating from Axum](from-axum/)


### PR DESCRIPTION
## Summary

This PR addresses:

- adds a public 0.2.x to 0.3.0 migration guide page and links it from Quickstart
- links the root README to the completed 0.3 migration guide and removes stale stable-readiness wording
- updates the admin CLI rustdoc install text to stable/release-managed wording

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

0.3.0 stable preparation needs a public migration-guide entry point now that the repository-level `instructions/MIGRATION_0.3.md` guide is complete. This keeps the release docs ready without manually editing release-plz-managed version markers before the stable Release PR.

Fixes #5410

Related to: #5405, #5452

## How Was This Tested?

- `git diff --check`
- `./scripts/validate-version-markers.sh`
- `zola build --base-url http://127.0.0.1:1111`
- `zola check` (fails on 27 pre-existing external broken links outside this PR's new page)

## Performance Impact

Not performance-related.

## Screenshots

Not a UI change.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5410
- #5405
- #5452

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Release-plz-managed version markers remain on `0.3.0-rc.5` in this branch. The stable Release PR updates those markers after the prerelease suffix is stripped.