### PR TITLE
test(examples): guard polls question FK migration type

### DIFF
--- a/examples/examples-tutorial-basis/tests/integration.rs
+++ b/examples/examples-tutorial-basis/tests/integration.rs
@@ -20,6 +20,51 @@
 #![cfg(server)]
 
 #[cfg(with_reinhardt)]
+#[path = "../migrations/polls/0001_initial.rs"]
+mod polls_initial_migration;
+
+#[cfg(with_reinhardt)]
+mod migration_regression_tests {
+	use reinhardt::db::migrations::{FieldType, Operation};
+	use std::path::Path;
+
+	#[test]
+	fn polls_choice_question_id_starts_as_big_integer() {
+		let migration = crate::polls_initial_migration::migration();
+
+		let choices_columns = migration
+			.operations
+			.iter()
+			.find_map(|operation| match operation {
+				Operation::CreateTable { name, columns, .. } if name == "choices" => Some(columns),
+				_ => None,
+			})
+			.expect("polls 0001_initial should create the choices table");
+
+		let question_id = choices_columns
+			.iter()
+			.find(|column| column.name == "question_id")
+			.expect("choices.question_id should be present in polls 0001_initial");
+
+		assert_eq!(question_id.type_definition, FieldType::BigInteger);
+		assert!(question_id.not_null);
+
+		let polls_migrations_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations/polls");
+		for obsolete_migration in [
+			"0002_alter_choices_question_id.rs",
+			"0003_questions_author_id_alter_choices_question__and_more.rs",
+		] {
+			let path = polls_migrations_dir.join(obsolete_migration);
+			assert!(
+				!path.exists(),
+				"obsolete uuid-to-bigint migration step should not exist: {}",
+				path.display()
+			);
+		}
+	}
+}
+
+#[cfg(with_reinhardt)]
 mod database_tests {
 	use rstest::*;
 	use sqlx::SqlitePool;


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds a regression test for `examples-tutorial-basis` polls migrations.
- Asserts `choices.question_id` starts as `FieldType::BigInteger` in `polls.0001_initial`.
- Guards against reintroducing the obsolete uuid-to-bigint alter migration files.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Issue #5076 reported a PostgreSQL migration failure when `choices.question_id` moved from UUID to bigint.
- The current `develop/0.3.0` migration files already encode the correct bigint type, so this PR locks that behavior with regression coverage.

Fixes #5076

Related to: #5045

## How Was This Tested?

- [x] `reinhardt-formatter fmt tests/integration.rs --check`
- [x] `git diff --check HEAD~1..HEAD`
- [x] `cargo test --test integration polls_choice_question_id_starts_as_big_integer --all-features`
- [x] `cargo make infra-reset`
- [x] `cargo make migrate` against fresh PostgreSQL infra
- [x] `cargo clippy --test integration --all-features -- -D warnings`

## Performance Impact

Not performance-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5076
- Related to #5045

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- Full `cargo make fmt-check` / `cargo make clippy-check` were not run; this PR used targeted checks for the touched integration test and migration path.

🤖 Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration reliability by adding coverage for an important database schema case.

- **Tests**
  - Added a regression test to confirm the `choices` table keeps the expected non-null numeric relationship field and to prevent obsolete migration files from remaining in the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->