### PR TITLE
fix(macros): stop propagating serde skip to Info relation fields

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -4841,7 +4841,14 @@ fn generate_info_struct(
 			info_fields.push(InfoFieldSpec {
 				name: name.clone(),
 				ty,
-				serde_attrs: f.serde_attrs.clone(),
+				// Relation payloads (`RelationInfo`/`ManyToManyInfo`) are lightweight,
+				// serializable DTOs (Issue #5272). They must NOT inherit the model
+				// field's serde attrs: the `#[model]` attribute macro injects
+				// `#[serde(skip)]` onto relation model fields (only the `*_id` column
+				// serializes for the model), and propagating it here would both demand
+				// an unimplemented `Default` for `RelationInfo` and wrongly drop the
+				// payload during `{Model}Info` (de)serialization.
+				serde_attrs: Vec::new(),
 				validate_attrs: Vec::new(),
 				setter_kind: InfoSetterKind::Relation { target_ty },
 				from_model: quote! {
@@ -4864,7 +4871,8 @@ fn generate_info_struct(
 			info_fields.push(InfoFieldSpec {
 				name: name.clone(),
 				ty,
-				serde_attrs: f.serde_attrs.clone(),
+				// Relation payloads do not inherit model serde attrs (see FK branch above).
+				serde_attrs: Vec::new(),
 				validate_attrs: Vec::new(),
 				setter_kind: InfoSetterKind::ManyToMany { target_ty },
 				from_model: quote! {


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

Generated `{Model}Info` relation fields no longer inherit the model field's `#[serde(...)]` attributes (notably the macro-injected `#[serde(skip)]`), which unblocks the `Cargo Check (tests)` job currently failing on `develop/0.3.0` and blocking release-plz PR #5502.

This PR addresses:

- `generate_info_struct` now emits `serde_attrs: Vec::new()` for the FK/OneToOne and ManyToMany branches instead of `f.serde_attrs.clone()`. The plain-field branch is unchanged, so the redaction feature from `6df8c7ae2b` (e.g. `#[serde(skip_serializing)]` on a `password_hash` field) is preserved.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

The prior state (`6df8c7ae2b`) did not compile for any model with an FK/OneToOne Info field, so there is no working behavior to break. The fix restores the pre-`6df8c7ae2b` semantics where relation payloads serialize normally (Issue #5272).

## Motivation and Context

`cargo check --workspace --all-features --tests` fails on `develop/0.3.0`:

```
error[E0277]: the trait bound `reinhardt_db::model_info::RelationInfo<InfoAuthor>: std::default::Default` is not satisfied
   --> tests/integration/tests/macros/model_info_integration.rs:280:1
```

Root cause chain:

1. The `#[model]` attribute macro (`model_attribute.rs`) injects `#[serde(skip)]` onto relation model fields so only the `*_id` column serializes on the model.
2. Commit `6df8c7ae2b` copied the model field's `#[serde(...)]` attrs onto generated `{Model}Info` companion fields, including relation fields.
3. `#[serde(skip)]` demands `Default`. `ManyToManyInfo` implements `Default`; `RelationInfo<T>` does not, so every FK/OneToOne Info field fails E0277.
4. It is also semantically wrong: relation payloads are lightweight serializable DTOs that must round-trip (`test_info_relation_serde_shape` asserts `json["author"]["id"]`).

Introduced when `6df8c7ae2b` (from `main`) was forward-merged into `develop/0.3.0`. Surfaced by release-plz PR #5502.

Fixes #5503

Related to: #5502, #5272

## How Was This Tested?

- `cargo expand --test macros -p reinhardt-integration-tests --all-features` confirms the generated `InfoPostInfo.author`/`InfoProfileInfo.user` fields no longer carry `#[serde(skip)]`.
- `cargo test --test macros -p reinhardt-integration-tests --all-features model_info` — all 18 `model_info_integration` tests pass, including:
  - `test_info_relation_serde_shape` (relation payload round-trips via serde)
  - `test_info_fk_relation_field_generated` / `test_info_one_to_one_relation_field_generated`
  - `test_info_many_to_many_uses_lightweight_payload`
  - `test_info_preserves_serde_field_redaction` / `test_info_preserves_serde_deserialization_redaction` (plain-field redaction preserved)
- `cargo clippy -p reinhardt-macros --all-features -- -D warnings` clean; `rustfmt --check` clean.

Local reproduction (before fix): `git checkout develop/0.3.0 && cargo check --workspace --all-features --tests` → E0277. After this fix the same command succeeds for the `macros` test target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated model companion data so relationship fields no longer inherit the original model field’s serialization settings.
  * This makes relationship payloads behave more consistently for foreign key, one-to-one, and many-to-many fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->