### PR TITLE
docs(pages): document WASM server fn resolver

### DIFF
--- a/crates/reinhardt-pages/src/server_fn.rs
+++ b/crates/reinhardt-pages/src/server_fn.rs
@@ -109,31 +109,6 @@ pub use server_fn_trait::{ServerFn, ServerFnError, parse_server_error_message};
 // Re-export the macro for convenience
 pub use reinhardt_pages_macros::server_fn;
 
-/// Resolves a server function endpoint path by prepending the mount prefix.
-///
-/// On WASM targets, reads the `<meta name="server-fn-prefix">` tag from the
-/// document to determine the mount prefix. The prefix is cached after the first
-/// DOM lookup for performance. Only same-origin absolute path prefixes are
-/// honored; absolute URLs, scheme-relative URLs, relative prefixes, parser
-/// slash equivalents, query or fragment delimiters, and dot-segment prefixes
-/// are ignored so credentialed server function requests cannot be redirected
-/// by DOM-controlled metadata.
-///
-/// On non-WASM targets, returns the path unchanged (server-side routing handles
-/// prefix resolution via router mounting).
-///
-/// # Examples
-///
-/// ```ignore
-/// // With <meta name="server-fn-prefix" content="/admin"> in the document:
-/// assert_eq!(resolve_endpoint("/api/server_fn/get_list"), "/admin/api/server_fn/get_list");
-///
-/// // Without the meta tag:
-/// assert_eq!(resolve_endpoint("/api/server_fn/get_list"), "/api/server_fn/get_list");
-///
-/// // Cross-origin prefixes are ignored:
-/// assert_eq!(resolve_endpoint("/api/server_fn/get_list"), "/api/server_fn/get_list");
-/// ```
 #[cfg(any(wasm, test))]
 fn prefixed_same_origin_path(prefix: &str, path: &str) -> String {
 	let prefix = prefix.trim();
@@ -196,6 +171,28 @@ fn hex_value(byte: u8) -> Option<u8> {
 	}
 }
 
+/// Resolves a server function endpoint path by prepending the client mount prefix.
+///
+/// Reads the `<meta name="server-fn-prefix">` tag from the document to
+/// determine the mount prefix. The prefix is cached after the first DOM lookup
+/// for performance. Only same-origin absolute path prefixes are honored;
+/// absolute URLs, scheme-relative URLs, relative prefixes, parser slash
+/// equivalents, query or fragment delimiters, and dot-segment prefixes are
+/// ignored so credentialed server function requests cannot be redirected by
+/// DOM-controlled metadata.
+///
+/// # Examples
+///
+/// ```ignore
+/// // With <meta name="server-fn-prefix" content="/admin"> in the document:
+/// assert_eq!(resolve_endpoint("/api/server_fn/get_list"), "/admin/api/server_fn/get_list");
+///
+/// // Without the meta tag:
+/// assert_eq!(resolve_endpoint("/api/server_fn/get_list"), "/api/server_fn/get_list");
+///
+/// // Cross-origin prefixes are ignored:
+/// assert_eq!(resolve_endpoint("/api/server_fn/get_list"), "/api/server_fn/get_list");
+/// ```
 #[cfg(wasm)]
 pub fn resolve_endpoint(path: &str) -> String {
 	use std::cell::RefCell;


### PR DESCRIPTION
## Summary

This PR addresses:

- Move the WASM `resolve_endpoint` documentation onto the public `#[cfg(wasm)]` function so `-D missing-docs` accepts the exported API.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Release-plz PR #5505 failed three WASM Clippy jobs because the WASM-only public `resolve_endpoint` function lacked attached documentation under `-D missing-docs`.
- The intended resolver docs already existed but were attached to the private `prefixed_same_origin_path` helper, so this moves that documentation onto the exported WASM API.

Related to: #5505

## How Was This Tested?

- `CARGO_TARGET_DIR=/tmp/reinhardt-release-plz-5505-target cargo clippy --target wasm32-unknown-unknown -p reinhardt-pages --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/reinhardt-release-plz-5505-target cargo clippy --target wasm32-unknown-unknown -p reinhardt-web --lib -- -D warnings`
- `cargo make fmt-check`

## Performance Impact

- Not performance-related.

## Breaking Changes

- None.

## Screenshots

- Not applicable.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #5505.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- After this lands on `develop/0.3.0`, the release-plz PR should be regenerated or rerun against the updated base rather than patched directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and relocated endpoint-resolution guidance so it appears alongside the relevant browser-side implementation.
  * Updated wording to refer to the **client mount prefix**, while keeping the described behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->