### PR TITLE
perf!: lazy-parse request query params

### DIFF
--- a/crates/reinhardt-http/README.md
+++ b/crates/reinhardt-http/README.md
@@ -14,7 +14,7 @@ Core HTTP abstractions for the Reinhardt framework. Provides comprehensive reque
 
 - **Complete HTTP request representation** with all standard components
   - HTTP method, URI, version, headers, body
-  - Path parameters (`path_params`) and query string parsing (`query_params`)
+  - Path parameters (`path_params`) and lazy query string parsing (`query_params`)
   - HTTPS detection (`is_secure`)
   - Remote address tracking (`remote_addr`)
   - Type-safe extensions system (`Extensions`)
@@ -299,7 +299,7 @@ let response = StreamingResponse::with_status(
 - `version: Version` - HTTP version
 - `headers: HeaderMap` - HTTP headers
 - `path_params: HashMap<String, String>` - Path parameters from URL routing
-- `query_params: HashMap<String, String>` - Query string parameters
+- `query_params: QueryParams` - Lazily parsed query string parameters
 - `is_secure: bool` - Whether request is over HTTPS
 - `remote_addr: Option<SocketAddr>` - Client's remote address
 - `extensions: Extensions` - Type-safe extension storage

--- a/crates/reinhardt-http/src/lib.rs
+++ b/crates/reinhardt-http/src/lib.rs
@@ -114,7 +114,7 @@ pub use middleware::{
 	ExcludeMiddleware, Handler, Middleware, MiddlewareChain, MiddlewareDiRegistration,
 };
 pub use path_params::PathParams;
-pub use request::{Request, RequestBuilder, TrustedProxies};
+pub use request::{QueryParams, Request, RequestBuilder, TrustedProxies};
 pub use response::{Response, SafeErrorResponse, StreamBody, StreamingResponse};
 pub use response_cookies::{ResponseCookies, SharedResponseCookies};
 pub use upload::{FileUploadError, FileUploadHandler, MemoryFileUpload, TemporaryFileUpload};

--- a/crates/reinhardt-http/src/request.rs
+++ b/crates/reinhardt-http/src/request.rs
@@ -6,9 +6,9 @@ use crate::extensions::Extensions;
 use crate::path_params::PathParams;
 use bytes::Bytes;
 use hyper::{HeaderMap, Method, Uri, Version};
+pub use params::QueryParams;
 #[cfg(feature = "parsers")]
 use reinhardt_core::parsers::parser::{ParsedData, Parser};
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::AtomicBool;
@@ -67,8 +67,8 @@ pub struct Request {
 	///
 	/// Stored in URL pattern declaration order (see [`PathParams`]).
 	pub path_params: PathParams,
-	/// Query string parameters parsed from the URI.
-	pub query_params: HashMap<String, String>,
+	/// Query string parameters parsed lazily from the URI.
+	pub query_params: QueryParams,
 	/// Indicates if this request came over HTTPS
 	pub is_secure: bool,
 	/// Remote address of the client (if available)
@@ -165,7 +165,7 @@ impl RequestBuilder {
 
 	/// Set the request URI.
 	///
-	/// Accepts either a `&str` or `Uri`. Query parameters will be automatically parsed.
+	/// Accepts either a `&str` or `Uri`. Query parameters are parsed on first access.
 	///
 	/// # Examples
 	///
@@ -444,7 +444,7 @@ impl RequestBuilder {
 			return Err(err);
 		}
 		let uri = self.uri.ok_or_else(|| "URI is required".to_string())?;
-		let query_params = Request::parse_query_params(&uri);
+		let query_params = QueryParams::from_uri(&uri);
 
 		Ok(Request {
 			method: self.method,
@@ -947,7 +947,7 @@ impl Request {
 	/// assert!(result.is_err());
 	/// ```
 	pub fn query_as<T: serde::de::DeserializeOwned>(&self) -> crate::Result<T> {
-		// Convert HashMap<String, String> to Vec<(String, String)> for serde_urlencoded
+		// Convert query parameters to pairs for serde_urlencoded.
 		let params: Vec<(String, String)> = self
 			.query_params
 			.iter()

--- a/crates/reinhardt-http/src/request/params.rs
+++ b/crates/reinhardt-http/src/request/params.rs
@@ -2,26 +2,158 @@ use super::Request;
 use hyper::Uri;
 use percent_encoding::percent_decode_str;
 use std::collections::HashMap;
+use std::collections::hash_map::Iter;
+use std::ops::Deref;
+use std::sync::OnceLock;
 
-impl Request {
-	/// Parse query parameters from URI
-	pub(super) fn parse_query_params(uri: &Uri) -> HashMap<String, String> {
-		uri.query()
-			.map(|q| {
-				q.split('&')
-					.filter_map(|pair| {
-						// Split on first '=' only to preserve '=' in values (e.g., Base64)
-						let mut parts = pair.splitn(2, '=');
-						Some((
-							parts.next()?.to_string(),
-							parts.next().unwrap_or("").to_string(),
-						))
-					})
-					.collect()
-			})
-			.unwrap_or_default()
+/// Lazily parsed query string parameters.
+///
+/// `QueryParams` stores the raw query string captured when the request is
+/// built and parses it only when parameter values are read. This keeps
+/// request construction cheap for handlers that do not inspect query
+/// parameters while preserving the common `HashMap`-like read API.
+#[derive(Debug)]
+pub struct QueryParams {
+	raw_query: Option<Box<str>>,
+	parsed: OnceLock<HashMap<String, String>>,
+}
+
+impl QueryParams {
+	/// Create an empty query parameter set.
+	pub fn empty() -> Self {
+		Self {
+			raw_query: None,
+			parsed: OnceLock::new(),
+		}
 	}
 
+	/// Capture query parameters from a URI without parsing them.
+	pub fn from_uri(uri: &Uri) -> Self {
+		Self {
+			raw_query: uri.query().map(Into::into),
+			parsed: OnceLock::new(),
+		}
+	}
+
+	/// Return the raw query string captured from the URI, if present.
+	pub fn raw_query(&self) -> Option<&str> {
+		self.raw_query.as_deref()
+	}
+
+	/// Return the parsed query parameters as a map.
+	///
+	/// Calling this method initializes the parsed map on first access.
+	pub fn as_map(&self) -> &HashMap<String, String> {
+		self.parsed.get_or_init(|| match self.raw_query.as_deref() {
+			Some(query) => Self::parse_raw(query),
+			None => HashMap::new(),
+		})
+	}
+
+	/// Return a cloned `HashMap` of the parsed query parameters.
+	pub fn to_hash_map(&self) -> HashMap<String, String> {
+		self.as_map().clone()
+	}
+
+	/// Return the value for a query parameter key.
+	pub fn get(&self, key: &str) -> Option<&String> {
+		self.as_map().get(key)
+	}
+
+	/// Return `true` when the query parameter key exists.
+	pub fn contains_key(&self, key: &str) -> bool {
+		self.as_map().contains_key(key)
+	}
+
+	/// Return `true` when there are no query parameters.
+	pub fn is_empty(&self) -> bool {
+		self.as_map().is_empty()
+	}
+
+	/// Return the number of query parameters.
+	pub fn len(&self) -> usize {
+		self.as_map().len()
+	}
+
+	/// Iterate over parsed query parameter key-value pairs.
+	pub fn iter(&self) -> Iter<'_, String, String> {
+		self.as_map().iter()
+	}
+
+	fn parse_raw(query: &str) -> HashMap<String, String> {
+		query
+			.split('&')
+			.filter_map(|pair| {
+				// Split on first '=' only to preserve '=' in values (e.g., Base64).
+				let mut parts = pair.splitn(2, '=');
+				Some((
+					parts.next()?.to_string(),
+					parts.next().unwrap_or("").to_string(),
+				))
+			})
+			.collect()
+	}
+
+	#[cfg(test)]
+	fn is_parsed(&self) -> bool {
+		self.parsed.get().is_some()
+	}
+}
+
+impl Clone for QueryParams {
+	fn clone(&self) -> Self {
+		let parsed = OnceLock::new();
+		if let Some(map) = self.parsed.get() {
+			parsed
+				.set(map.clone())
+				.expect("new OnceLock must accept initial query params");
+		}
+
+		Self {
+			raw_query: self.raw_query.clone(),
+			parsed,
+		}
+	}
+}
+
+impl Default for QueryParams {
+	fn default() -> Self {
+		Self::empty()
+	}
+}
+
+impl Deref for QueryParams {
+	type Target = HashMap<String, String>;
+
+	fn deref(&self) -> &Self::Target {
+		self.as_map()
+	}
+}
+
+impl AsRef<HashMap<String, String>> for QueryParams {
+	fn as_ref(&self) -> &HashMap<String, String> {
+		self.as_map()
+	}
+}
+
+impl PartialEq for QueryParams {
+	fn eq(&self, other: &Self) -> bool {
+		self.as_map() == other.as_map()
+	}
+}
+
+impl Eq for QueryParams {}
+
+impl<'a> IntoIterator for &'a QueryParams {
+	type IntoIter = Iter<'a, String, String>;
+	type Item = (&'a String, &'a String);
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.iter()
+	}
+}
+
+impl Request {
 	/// Get the request path
 	///
 	/// # Examples
@@ -331,9 +463,63 @@ mod tests {
 	use super::*;
 	use rstest::rstest;
 
+	fn parse_query_params(uri: &hyper::Uri) -> HashMap<String, String> {
+		uri.query().map(QueryParams::parse_raw).unwrap_or_default()
+	}
+
 	// =================================================================
 	// Query parameter '=' preservation tests (Issue #362)
 	// =================================================================
+
+	#[rstest]
+	fn test_query_params_parse_lazily() {
+		// Arrange
+		let uri: hyper::Uri = "/test?key=value".parse().unwrap();
+		let params = QueryParams::from_uri(&uri);
+
+		// Assert
+		assert_eq!(params.raw_query(), Some("key=value"));
+		assert!(!params.is_parsed());
+
+		// Act
+		let value = params.get("key");
+
+		// Assert
+		assert_eq!(value, Some(&"value".to_string()));
+		assert!(params.is_parsed());
+	}
+
+	#[rstest]
+	fn test_query_params_clone_preserves_unparsed_state() {
+		// Arrange
+		let uri: hyper::Uri = "/test?key=value".parse().unwrap();
+		let params = QueryParams::from_uri(&uri);
+
+		// Act
+		let cloned = params.clone();
+
+		// Assert
+		assert!(!params.is_parsed());
+		assert!(!cloned.is_parsed());
+		assert_eq!(cloned.get("key"), Some(&"value".to_string()));
+		assert!(!params.is_parsed());
+		assert!(cloned.is_parsed());
+	}
+
+	#[rstest]
+	fn test_query_params_clone_preserves_parsed_state() {
+		// Arrange
+		let uri: hyper::Uri = "/test?key=value".parse().unwrap();
+		let params = QueryParams::from_uri(&uri);
+		assert_eq!(params.get("key"), Some(&"value".to_string()));
+
+		// Act
+		let cloned = params.clone();
+
+		// Assert
+		assert!(cloned.is_parsed());
+		assert_eq!(cloned.get("key"), Some(&"value".to_string()));
+	}
 
 	#[rstest]
 	fn test_parse_query_params_preserves_equals_in_value() {
@@ -341,7 +527,7 @@ mod tests {
 		let uri: hyper::Uri = "/test?token=abc==".parse().unwrap();
 
 		// Act
-		let params = Request::parse_query_params(&uri);
+		let params = parse_query_params(&uri);
 
 		// Assert
 		assert_eq!(params.get("token"), Some(&"abc==".to_string()));
@@ -353,7 +539,7 @@ mod tests {
 		let uri: hyper::Uri = "/test?data=dGVzdA==".parse().unwrap();
 
 		// Act
-		let params = Request::parse_query_params(&uri);
+		let params = parse_query_params(&uri);
 
 		// Assert
 		assert_eq!(params.get("data"), Some(&"dGVzdA==".to_string()));
@@ -365,7 +551,7 @@ mod tests {
 		let uri: hyper::Uri = "/test?formula=a=b=c".parse().unwrap();
 
 		// Act
-		let params = Request::parse_query_params(&uri);
+		let params = parse_query_params(&uri);
 
 		// Assert
 		assert_eq!(params.get("formula"), Some(&"a=b=c".to_string()));
@@ -377,7 +563,7 @@ mod tests {
 		let uri: hyper::Uri = "/test?key=value".parse().unwrap();
 
 		// Act
-		let params = Request::parse_query_params(&uri);
+		let params = parse_query_params(&uri);
 
 		// Assert
 		assert_eq!(params.get("key"), Some(&"value".to_string()));
@@ -389,7 +575,7 @@ mod tests {
 		let uri: hyper::Uri = "/test?key=".parse().unwrap();
 
 		// Act
-		let params = Request::parse_query_params(&uri);
+		let params = parse_query_params(&uri);
 
 		// Assert
 		assert_eq!(params.get("key"), Some(&"".to_string()));
@@ -401,7 +587,7 @@ mod tests {
 		let uri: hyper::Uri = "/test".parse().unwrap();
 
 		// Act
-		let params = Request::parse_query_params(&uri);
+		let params = parse_query_params(&uri);
 
 		// Assert
 		assert!(params.is_empty());
@@ -413,7 +599,7 @@ mod tests {
 		let uri: hyper::Uri = "/test?a=1&b=x=y=z&c=3".parse().unwrap();
 
 		// Act
-		let params = Request::parse_query_params(&uri);
+		let params = parse_query_params(&uri);
 
 		// Assert
 		assert_eq!(params.get("a"), Some(&"1".to_string()));

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -191,6 +191,16 @@ request path instead of idle worker-thread stacks.
 | `server_router_two_params_build_plus_handle` | 11 alloc/request | 10 alloc/request | 9.1% |
 | `server_router_one_middleware_build_plus_handle` | 15 alloc/request | 12 alloc/request | 20.0% |
 
+The 2026-06-29 measurement compared `develop/0.4.0` with lazy request query
+parameter parsing:
+
+| Probe | Baseline | Optimized | Reduction |
+|---|---:|---:|---:|
+| `request_build_empty_path` | 2 alloc/request | 2 alloc/request | 0.0% |
+| `request_build_two_query_params` | 7 alloc/request | 3 alloc/request | 57.1% |
+| `clone_for_di_empty_path` | 1 alloc/request | 1 alloc/request | 0.0% |
+| `clone_for_di_two_query_params` | 6 alloc/request | 2 alloc/request | 66.7% |
+
 ## Admin List Query Count Measurements
 
 Use the admin database mock tests before claiming query-count reductions on the


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds `QueryParams`, a lazily parsed query parameter wrapper for `reinhardt-http::Request`.
- Changes `Request.query_params` from `HashMap<String, String>` to `QueryParams` so request construction no longer parses query strings until first read.
- Documents the public API change and the request allocation probe results.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [x] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [ ] **No** - This change is backward compatible
- [x] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- `RequestBuilder::build()` eagerly parsed query strings into a `HashMap` even when handlers never inspected query parameters.
- Framework comparison benchmarks emphasize request construction and simple routing hot paths, so avoidable per-request parsing work should be removed from the default path.

Fixes: N/A

Related to: #5456, #5524

## How Was This Tested?

- `cargo test -p reinhardt-http query_params --lib`
- `cargo check -p reinhardt-http --all-features`
- `cargo make fmt-fix`
- `cargo make fmt-check`
- `git diff --check`
- `cargo check --workspace --all-features`
- `cargo clippy -p reinhardt-http --all-features --all-targets -- -D warnings`
- Baseline allocation probe on `develop/0.4.0`: `cargo run --release -p reinhardt-benchmarks --bin request_alloc_probe`
- Optimized allocation probe on this branch: `cargo run --release -p reinhardt-benchmarks --bin request_alloc_probe`

## Performance Impact

Allocation probe comparison against `develop/0.4.0`:

| Probe | Baseline | Optimized | Reduction |
|---|---:|---:|---:|
| `request_build_empty_path` | 2 alloc/request | 2 alloc/request | 0.0% |
| `request_build_two_query_params` | 7 alloc/request | 3 alloc/request | 57.1% |
| `clone_for_di_empty_path` | 1 alloc/request | 1 alloc/request | 0.0% |
| `clone_for_di_two_query_params` | 6 alloc/request | 2 alloc/request | 66.7% |

No-query router probe allocation counts remained unchanged.

## Breaking Changes

- `reinhardt_http::Request::query_params` now has type `QueryParams` instead of `HashMap<String, String>`.
- Common read usage remains available through `get`, `contains_key`, `is_empty`, `len`, and `iter`.
- Code requiring a concrete `HashMap<String, String>` must call `as_map()` or `to_hash_map()`.

**Migration Guide:**

1. Keep read-only access such as `request.query_params.get("page")` unchanged.
2. Replace `&request.query_params` where a concrete map is required with `request.query_params.as_map()`.
3. Replace owned map extraction with `request.query_params.to_hash_map()`.
4. Import `reinhardt_http::QueryParams` for APIs that need to name the new field type.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5456
- #5524

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [x] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [x] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [x] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- This is intended for the `develop/0.4.0` breaking-change line.
- The commit uses a `BREAKING CHANGE` footer for release tooling compatibility.