### PR TITLE
perf!: lazy-initialize request extensions

### DIFF
--- a/crates/reinhardt-http/README.md
+++ b/crates/reinhardt-http/README.md
@@ -73,7 +73,7 @@ Core HTTP abstractions for the Reinhardt framework. Provides comprehensive reque
 - **Type-safe request extensions** for storing arbitrary typed data
   - `request.extensions.insert::<T>(value)` - Store typed data
   - `request.extensions.get::<T>()` - Retrieve typed data
-  - Thread-safe with `Arc<Mutex<TypeMap>>`
+  - Thread-safe with lazily initialized `Arc<Mutex<TypeMap>>`
   - Common use cases: authentication context, request ID, user data
 
 #### Error Integration

--- a/crates/reinhardt-http/src/extensions.rs
+++ b/crates/reinhardt-http/src/extensions.rs
@@ -5,7 +5,11 @@
 
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
+
+type ExtensionValue = Box<dyn Any + Send + Sync>;
+type ExtensionMap = HashMap<TypeId, ExtensionValue>;
+type SharedExtensionMap = Arc<Mutex<ExtensionMap>>;
 
 /// Whether the current user is authenticated.
 /// Newtype wrapper to avoid `TypeId` collision with other bool values in extensions.
@@ -26,13 +30,22 @@ pub struct IsActive(pub bool);
 ///
 /// # Clone semantics
 ///
-/// `Extensions` uses `Arc<Mutex<HashMap>>` internally. Cloning an
-/// `Extensions` creates a **shared** reference to the same backing
-/// store — it does NOT deep-copy the stored values. Mutations through
-/// one clone are visible through all other clones.
-#[derive(Clone, Default)]
+/// `Extensions` lazily initializes an `Arc<Mutex<HashMap>>` backing store.
+/// Cloning an `Extensions` creates a **shared** reference to the same backing
+/// store — it does NOT deep-copy the stored values. Mutations through one
+/// clone are visible through all other clones.
+#[derive(Default)]
 pub struct Extensions {
-	map: Arc<Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>>,
+	map: OnceLock<SharedExtensionMap>,
+}
+
+impl Clone for Extensions {
+	fn clone(&self) -> Self {
+		let map = self.shared_map();
+		let cloned = Self::new();
+		let _ = cloned.map.set(Arc::clone(map));
+		cloned
+	}
 }
 
 impl Extensions {
@@ -48,9 +61,24 @@ impl Extensions {
 	/// ```
 	pub fn new() -> Self {
 		Self {
-			map: Arc::new(Mutex::new(HashMap::new())),
+			map: OnceLock::new(),
 		}
 	}
+
+	fn shared_map(&self) -> &SharedExtensionMap {
+		self.map
+			.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+	}
+
+	/// Clone only the initialized backing store.
+	pub(crate) fn clone_if_initialized(&self) -> Self {
+		let cloned = Self::new();
+		if let Some(map) = self.map.get() {
+			let _ = cloned.map.set(Arc::clone(map));
+		}
+		cloned
+	}
+
 	/// Insert a value into extensions
 	///
 	/// # Examples
@@ -66,7 +94,7 @@ impl Extensions {
 	/// assert!(extensions.contains::<String>());
 	/// ```
 	pub fn insert<T: Send + Sync + 'static>(&self, value: T) {
-		let mut map = self.map.lock().unwrap_or_else(|e| e.into_inner());
+		let mut map = self.shared_map().lock().unwrap_or_else(|e| e.into_inner());
 		map.insert(TypeId::of::<T>(), Box::new(value));
 	}
 	/// Get a cloned value from extensions
@@ -86,7 +114,8 @@ impl Extensions {
 	where
 		T: Clone + Send + Sync + 'static,
 	{
-		let map = self.map.lock().unwrap_or_else(|e| e.into_inner());
+		let map = self.map.get()?;
+		let map = map.lock().unwrap_or_else(|e| e.into_inner());
 		map.get(&TypeId::of::<T>())
 			.and_then(|boxed| boxed.downcast_ref::<T>())
 			.cloned()
@@ -105,7 +134,10 @@ impl Extensions {
 	/// assert!(!extensions.contains::<u32>());
 	/// ```
 	pub fn contains<T: Send + Sync + 'static>(&self) -> bool {
-		let map = self.map.lock().unwrap_or_else(|e| e.into_inner());
+		let Some(map) = self.map.get() else {
+			return false;
+		};
+		let map = map.lock().unwrap_or_else(|e| e.into_inner());
 		map.contains_key(&TypeId::of::<T>())
 	}
 	/// Remove a value from extensions and return it
@@ -126,7 +158,8 @@ impl Extensions {
 	where
 		T: Send + Sync + 'static,
 	{
-		let mut map = self.map.lock().unwrap_or_else(|e| e.into_inner());
+		let map = self.map.get()?;
+		let mut map = map.lock().unwrap_or_else(|e| e.into_inner());
 		let boxed = map.remove(&TypeId::of::<T>())?;
 		match boxed.downcast::<T>() {
 			Ok(val) => Some(*val),
@@ -157,8 +190,10 @@ impl Extensions {
 	/// assert!(!extensions.contains::<String>());
 	/// ```
 	pub fn clear(&self) {
-		let mut map = self.map.lock().unwrap_or_else(|e| e.into_inner());
-		map.clear();
+		if let Some(map) = self.map.get() {
+			let mut map = map.lock().unwrap_or_else(|e| e.into_inner());
+			map.clear();
+		}
 	}
 }
 
@@ -210,6 +245,18 @@ mod tests {
 		let retrieved = extensions.get::<TestData>();
 
 		assert_eq!(retrieved, None);
+	}
+
+	#[test]
+	fn test_empty_read_methods_do_not_initialize_backing_store() {
+		let extensions = Extensions::new();
+
+		assert!(!extensions.contains::<TestData>());
+		assert_eq!(extensions.get::<TestData>(), None);
+		assert_eq!(extensions.remove::<TestData>(), None);
+		extensions.clear();
+
+		assert!(extensions.map.get().is_none());
 	}
 
 	#[test]
@@ -303,5 +350,24 @@ mod tests {
 		// Assert - clone no longer sees it
 		assert_eq!(removed, Some(42));
 		assert!(!cloned.contains::<u32>());
+	}
+
+	#[test]
+	fn test_clone_initializes_shared_backing_store() {
+		// Arrange
+		let original = Extensions::new();
+
+		// Act
+		let cloned = original.clone();
+
+		// Assert
+		assert!(original.map.get().is_some());
+		assert!(cloned.map.get().is_some());
+
+		// Act - insert via original
+		original.insert(42u32);
+
+		// Assert - clone sees the value
+		assert_eq!(cloned.get::<u32>(), Some(42));
 	}
 }

--- a/crates/reinhardt-http/src/request.rs
+++ b/crates/reinhardt-http/src/request.rs
@@ -962,9 +962,10 @@ impl Request {
 
 	/// Creates a lightweight copy of this request for dependency injection.
 	///
-	/// The clone shares the same extensions store (via internal `Arc`),
-	/// so `AuthState` and other extensions set on the original request
-	/// are accessible in the clone. Body and parsers are not copied
+	/// The clone shares the same initialized extensions store (via internal
+	/// `Arc`), so `AuthState` and other extensions set on the original request
+	/// are accessible in the clone. Empty extension stores stay uninitialized
+	/// until either request writes an extension. Body and parsers are not copied
 	/// as they are not needed for DI resolution.
 	pub fn clone_for_di(&self) -> Self {
 		Request {
@@ -982,7 +983,7 @@ impl Request {
 			#[cfg(feature = "parsers")]
 			parsed_data: Mutex::new(None),
 			body_consumed: AtomicBool::new(false),
-			extensions: self.extensions.clone(),
+			extensions: self.extensions.clone_if_initialized(),
 		}
 	}
 }
@@ -1238,7 +1239,7 @@ mod tests {
 	}
 
 	#[rstest]
-	fn test_clone_for_di_shares_extensions_bidirectionally() {
+	fn test_clone_for_di_keeps_empty_extensions_independent_until_used() {
 		// Arrange
 		let request = Request::builder()
 			.method(Method::GET)
@@ -1251,9 +1252,10 @@ mod tests {
 		// Act - insert into cloned extensions
 		cloned.extensions.insert("from_clone".to_string());
 
-		// Assert - original also sees it (shared backing store)
+		// Assert - empty stores are not initialized solely by clone_for_di
+		assert_eq!(request.extensions.get::<String>(), None);
 		assert_eq!(
-			request.extensions.get::<String>(),
+			cloned.extensions.get::<String>(),
 			Some("from_clone".to_string())
 		);
 	}

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -191,6 +191,21 @@ request path instead of idle worker-thread stacks.
 | `server_router_two_params_build_plus_handle` | 11 alloc/request | 10 alloc/request | 9.1% |
 | `server_router_one_middleware_build_plus_handle` | 15 alloc/request | 12 alloc/request | 20.0% |
 
+The 2026-06-29 measurement compared `develop/0.4.0` with lazy request extension
+backing-store initialization:
+
+| Probe | Baseline | Optimized | Reduction |
+|---|---:|---:|---:|
+| `request_build_empty_path` | 2 alloc/request | 1 alloc/request | 50.0% |
+| `request_build_two_query_params` | 7 alloc/request | 6 alloc/request | 14.3% |
+| `direct_handler_build_plus_handle` | 4 alloc/request | 3 alloc/request | 25.0% |
+| `direct_handler_handle_only` | 2 alloc/request | 2 alloc/request | 0.0% |
+| `clone_for_di_empty_path` | 1 alloc/request | 1 alloc/request | 0.0% |
+| `clone_for_di_two_query_params` | 6 alloc/request | 6 alloc/request | 0.0% |
+| `server_router_static_build_plus_handle` | 6 alloc/request | 5 alloc/request | 16.7% |
+| `server_router_two_params_build_plus_handle` | 10 alloc/request | 9 alloc/request | 10.0% |
+| `server_router_one_middleware_build_plus_handle` | 12 alloc/request | 11 alloc/request | 8.3% |
+
 ## Admin List Query Count Measurements
 
 Use the admin database mock tests before claiming query-count reductions on the


### PR DESCRIPTION
## Summary

This PR addresses:

- Lazily initializes the `Extensions` typed backing store so requests that never write extensions avoid the `Arc<Mutex<HashMap<...>>>` allocation.
- Keeps `Extensions::clone()` sharing semantics intact for direct extension clones.
- Changes `Request::clone_for_di()` to preserve initialized extension stores without forcing empty stores to allocate.
- Documents the measured allocation impact in `docs/build-perf/README.md`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [x] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [ ] **No** - This change is backward compatible
- [x] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Empty request extension storage currently allocates even when no extension value is ever written.
- Reinhardt benchmarks show per-request overhead matters most in hot routing and middleware paths, so avoiding cold-path storage allocation directly reduces request construction cost.

Related to: #5456
Related to: #5524
Related to: #5525

## How Was This Tested?

- `cargo test -p reinhardt-http extensions --lib`
- `cargo test -p reinhardt-http clone_for_di --lib`
- `cargo check -p reinhardt-http --all-features`
- `cargo check --workspace --all-features`
- `cargo make fmt-fix`
- `cargo make fmt-check`
- `cargo clippy -p reinhardt-http --all-features --all-targets -- -D warnings`
- `git diff --check`
- `cargo run --release -p reinhardt-benchmarks --bin request_alloc_probe`

## Performance Impact

The 2026-06-29 allocation probe compared `develop/0.4.0` with this branch:

| Probe | Baseline | Optimized | Reduction |
|---|---:|---:|---:|
| `request_build_empty_path` | 2 alloc/request | 1 alloc/request | 50.0% |
| `request_build_two_query_params` | 7 alloc/request | 6 alloc/request | 14.3% |
| `direct_handler_build_plus_handle` | 4 alloc/request | 3 alloc/request | 25.0% |
| `direct_handler_handle_only` | 2 alloc/request | 2 alloc/request | 0.0% |
| `clone_for_di_empty_path` | 1 alloc/request | 1 alloc/request | 0.0% |
| `clone_for_di_two_query_params` | 6 alloc/request | 6 alloc/request | 0.0% |
| `server_router_static_build_plus_handle` | 6 alloc/request | 5 alloc/request | 16.7% |
| `server_router_two_params_build_plus_handle` | 10 alloc/request | 9 alloc/request | 10.0% |
| `server_router_one_middleware_build_plus_handle` | 12 alloc/request | 11 alloc/request | 8.3% |

## Breaking Changes

`Request::clone_for_di()` no longer initializes and shares an empty extension store. If the original request already has an initialized extension store, the DI clone still shares it, so auth and middleware state already attached to the request remains visible during dependency resolution.

**Migration Guide:**

Code that relied on writing a new extension into a `clone_for_di()` result and then observing that extension on the original empty request must write the extension to the original request before cloning, or pass that state through an explicit DI/input value. Code that reads existing extensions from a DI clone requires no change.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5456
- #5524
- #5525

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [x] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [x] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `http` - HTTP layer, handlers, middleware

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

This is the second implementation PR in the 0.4 performance refactor line after #5525.