### PR TITLE
perf: skip empty HTTP/1 body collection

### DIFF
--- a/crates/reinhardt-server/README.md
+++ b/crates/reinhardt-server/README.md
@@ -19,6 +19,7 @@ This crate provides the following features:
   - Builder pattern for middleware configuration
   - Efficient TCP connection management
   - Automatic request/response conversion
+  - Empty HTTP/1.1 `GET` and `HEAD` requests skip body collection when no body is declared
   - Built-in error handling
 
 - **WebSocket Support** (feature = "websocket"): WebSocket server implementation

--- a/crates/reinhardt-server/src/server.rs
+++ b/crates/reinhardt-server/src/server.rs
@@ -33,6 +33,8 @@
 //! // let handler_clone = server.handler();  // Returns Arc<dyn Handler>
 //! ```
 
+// Shared request body handling for Hyper adapters.
+mod body;
 /// HTTP/1.1 server implementation based on Hyper.
 pub mod http;
 /// HTTP/2 server implementation with TLS support.

--- a/crates/reinhardt-server/src/server/body.rs
+++ b/crates/reinhardt-server/src/server/body.rs
@@ -1,0 +1,104 @@
+use bytes::Bytes;
+use http_body_util::BodyExt;
+use hyper::body::Incoming;
+use hyper::header::{CONTENT_LENGTH, TRANSFER_ENCODING};
+use hyper::{HeaderMap, Method};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+pub(super) async fn collect_request_body(
+	method: &Method,
+	headers: &HeaderMap,
+	body: Incoming,
+	max_body_size: u64,
+) -> Result<Bytes, BoxError> {
+	if can_skip_body_collect(method, headers) {
+		return Ok(Bytes::new());
+	}
+
+	http_body_util::Limited::new(body, max_body_size as usize)
+		.collect()
+		.await
+		.map_err(|_| {
+			Box::new(std::io::Error::new(
+				std::io::ErrorKind::InvalidData,
+				"Request body exceeds size limit",
+			)) as BoxError
+		})
+		.map(|collected| collected.to_bytes())
+}
+
+fn can_skip_body_collect(method: &Method, headers: &HeaderMap) -> bool {
+	is_empty_body_fast_path_method(method) && !has_declared_body(headers)
+}
+
+fn is_empty_body_fast_path_method(method: &Method) -> bool {
+	method == Method::GET || method == Method::HEAD
+}
+
+fn has_declared_body(headers: &HeaderMap) -> bool {
+	if headers.contains_key(TRANSFER_ENCODING) {
+		return true;
+	}
+
+	let Some(content_length) = headers.get(CONTENT_LENGTH) else {
+		return false;
+	};
+
+	match content_length
+		.to_str()
+		.ok()
+		.and_then(|value| value.parse::<u64>().ok())
+	{
+		Some(0) => false,
+		Some(_) | None => true,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use hyper::header::HeaderValue;
+
+	#[test]
+	fn skips_get_without_declared_body() {
+		assert!(can_skip_body_collect(&Method::GET, &HeaderMap::new()));
+	}
+
+	#[test]
+	fn skips_head_with_zero_content_length() {
+		let mut headers = HeaderMap::new();
+		headers.insert(CONTENT_LENGTH, HeaderValue::from_static("0"));
+
+		assert!(can_skip_body_collect(&Method::HEAD, &headers));
+	}
+
+	#[test]
+	fn collects_get_with_positive_content_length() {
+		let mut headers = HeaderMap::new();
+		headers.insert(CONTENT_LENGTH, HeaderValue::from_static("3"));
+
+		assert!(!can_skip_body_collect(&Method::GET, &headers));
+	}
+
+	#[test]
+	fn collects_get_with_transfer_encoding() {
+		let mut headers = HeaderMap::new();
+		headers.insert(TRANSFER_ENCODING, HeaderValue::from_static("chunked"));
+
+		assert!(!can_skip_body_collect(&Method::GET, &headers));
+	}
+
+	#[test]
+	fn collects_post_without_declared_body() {
+		assert!(!can_skip_body_collect(&Method::POST, &HeaderMap::new()));
+	}
+
+	#[test]
+	fn collects_get_with_invalid_content_length() {
+		let mut headers = HeaderMap::new();
+		headers.insert(CONTENT_LENGTH, HeaderValue::from_static("invalid"));
+
+		assert!(!can_skip_body_collect(&Method::GET, &headers));
+	}
+}

--- a/crates/reinhardt-server/src/server/http.rs
+++ b/crates/reinhardt-server/src/server/http.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use http_body_util::{BodyExt, Full};
+use http_body_util::Full;
 use hyper::StatusCode;
 use hyper::body::Incoming;
 use hyper::server::conn::http1;
@@ -15,6 +15,8 @@ use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::shutdown::ShutdownCoordinator;
+
+use super::body::collect_request_body;
 
 /// HTTP Server with middleware support
 pub struct HttpServer {
@@ -364,17 +366,8 @@ impl Service<hyper::Request<Incoming>> for RequestService {
 			// Extract request parts
 			let (parts, body) = req.into_parts();
 
-			// Read body with size limit
-			let body_bytes = http_body_util::Limited::new(body, max_body_size as usize)
-				.collect()
-				.await
-				.map_err(|_| {
-					Box::new(std::io::Error::new(
-						std::io::ErrorKind::InvalidData,
-						"Request body exceeds size limit",
-					)) as Box<dyn std::error::Error + Send + Sync>
-				})?
-				.to_bytes();
+			let body_bytes =
+				collect_request_body(&parts.method, &parts.headers, body, max_body_size).await?;
 
 			// Create reinhardt Request
 			let mut request = Request::builder()

--- a/docs/build-perf/README.md
+++ b/docs/build-perf/README.md
@@ -191,6 +191,14 @@ request path instead of idle worker-thread stacks.
 | `server_router_two_params_build_plus_handle` | 11 alloc/request | 10 alloc/request | 9.1% |
 | `server_router_one_middleware_build_plus_handle` | 15 alloc/request | 12 alloc/request | 20.0% |
 
+The 0.4 HTTP/1 adapter fast path skips request body collection for `GET` and
+`HEAD` requests that declare neither a positive `Content-Length` nor
+`Transfer-Encoding`. HTTP/2 keeps the existing collection path because DATA
+frames can appear without a `Content-Length`. This reduces loopback HTTP
+overhead for the common empty request path, but it is not visible in
+`request_alloc_probe` because that probe starts after Hyper has already produced
+a Reinhardt `Request`.
+
 ## Admin List Query Count Measurements
 
 Use the admin database mock tests before claiming query-count reductions on the


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds a private HTTP/1 request-body helper for the Hyper adapter.
- Skips body collection for HTTP/1.1 `GET` and `HEAD` requests when neither a positive `Content-Length` nor `Transfer-Encoding` is declared.
- Keeps HTTP/2 on the existing collection path because DATA frames can arrive without a `Content-Length` declaration.
- Documents why this optimization is measured in loopback HTTP benchmarks rather than `request_alloc_probe`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [x] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- Empty HTTP/1 `GET` and `HEAD` requests are the dominant runtime benchmark path for lightweight Reinhardt handlers.
- The previous adapter always wrapped and collected the Hyper body before building a Reinhardt `Request`, even when HTTP/1 metadata proved there was no request body to read.
- The optimization is deliberately limited to HTTP/1 because HTTP/2 DATA frames can be sent without a `Content-Length` header.

Related to: #5456
Related to: #5524

## How Was This Tested?

- `cargo test -p reinhardt-server body --lib`
- `cargo check -p reinhardt-server --all-features`
- `cargo clippy -p reinhardt-server --all-features --all-targets -- -D warnings`
- `cargo make fmt-fix`
- `cargo make fmt-check`
- `git diff --check`

## Performance Impact

Expected impact is limited to HTTP/1 loopback request handling before Reinhardt `Request` construction. The existing `request_alloc_probe` does not cover this adapter layer because it starts after Hyper has already produced the framework request.

Attempted local loopback measurement:

- `cargo make benchmark-runtime-http` did not run in this new worktree because `benchmarks/Cargo.lock` would need to be generated while the command passes `--locked`.

## Breaking Changes

None.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5456
- #5524

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [x] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `http` - HTTP layer, handlers, middleware

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

This is a Phase 1 0.4 request-model cleanup that should be measured with the stacked 0.4 scorecard before promotion.