### PR TITLE
fix(ci): pin standalone examples time resolution

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,6 +19,16 @@ members = [
 # reinhardt-version-sync
 reinhardt = { path = "..", version = "0.3.0", package = "reinhardt-web" }
 
+# The examples workspace is resolved independently in standalone CI, so it must
+# carry the same resolver workaround as the root workspace.
+#
+# Workaround for time-rs/time#783 (tracked in reinhardt-web#5541).
+# Remove when time 0.3.48+ no longer causes downstream compatibility failures.
+#
+# Ideal implementation:
+#   time = { version = "0.3" }
+time = { version = ">=0.3, <0.3.48" }
+
 # Testing
 testcontainers = { version = "0.27.2", features = ["blocking"] }
 tokio = { version = "1.48.0", features = ["full"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,6 +57,8 @@ cargo make local-examples-test
 
 - `examples/Cargo.toml` declares `reinhardt` with `path = ".."` and the expected version
 - Cargo uses the local checkout while still checking that the example version stays in sync
+- The standalone examples workspace mirrors the root `time` compatibility
+  constraint so fresh CI resolution stays aligned with the main workspace
 - `.cargo/config.local.toml` remains as a compatibility template for workflows that need an explicit `[patch.crates-io]` override
 
 ## Testing

--- a/examples/examples-tutorial-basis/Cargo.toml
+++ b/examples/examples-tutorial-basis/Cargo.toml
@@ -23,6 +23,8 @@ required-features = ["with-reinhardt"]
 # Common dependencies (both WASM and server)
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+# Participates in the standalone examples resolver constraint from examples/Cargo.toml.
+time = { workspace = true }
 
 # WASM-specific dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples/examples-tutorial-rest/Cargo.toml
+++ b/examples/examples-tutorial-rest/Cargo.toml
@@ -26,6 +26,8 @@ reinhardt = { workspace = true, features = [
 tokio = { version = "1.48.0", features = ["full"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+# Participates in the standalone examples resolver constraint from examples/Cargo.toml.
+time = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 syntect = "5.2"
 ctor = "0.6.1"


### PR DESCRIPTION
## Summary

This PR addresses:

- Mirrors the root `time` upper-bound workaround in the standalone examples workspace.
- Adds a direct `time` workspace dependency to both tutorial examples so fresh standalone CI resolution cannot pair `cookie 0.18.1` with incompatible newer `time` releases.
- Documents the standalone examples resolver alignment in `examples/README.md`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Release PR #5538 fails in `Examples Tests (Standalone)` for both `examples-tutorial-basis` and `examples-tutorial-rest`. The failing jobs resolve `time 0.3.52` in the standalone examples workspace, while `cookie 0.18.1` still calls the older one-argument `Parsable::parse` API.

The root workspace already carries a `time` upper-bound workaround, but the separate examples workspace did not participate in that constraint during fresh CI resolution.

Fixes #5541

Related to: #5538

## How Was This Tested?

- `CARGO_TARGET_DIR=/tmp/reinhardt-examples-target-5541 cargo tree -p examples-tutorial-basis --all-features -i time`
- `CARGO_TARGET_DIR=/tmp/reinhardt-examples-target-5541 cargo tree -p examples-tutorial-rest --all-features -i time`
- `cargo make fmt-check` from `examples/examples-tutorial-basis`
- `CARGO_TARGET_DIR=/tmp/reinhardt-examples-basis-target-5541 cargo make clippy-check` from `examples/examples-tutorial-basis`
- `cargo make fmt-check` from `examples/examples-tutorial-rest`
- `CARGO_TARGET_DIR=/tmp/reinhardt-examples-basis-target-5541 cargo test --no-run --all-features` from `examples/examples-tutorial-rest`

The rest test build emitted an existing future-incompatibility warning for `examples-tutorial-rest`; the compile completed successfully.

## Performance Impact

Not performance-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5538
- #5541

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This PR targets `main` instead of the generated `release-plz-*` branch. After merge, release-plz should regenerate the release PR with the corrected examples resolver constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Aligned the examples workspace with the main project’s dependency constraints to keep builds and CI resolution consistent.
  * Added a shared `time` dependency for example projects so they use the same workspace-managed version.

* **Documentation**
  * Updated the examples guide with a note about the matching compatibility rule used by the standalone examples workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->