### PR TITLE
fix(formatter): wrap long page closure parameters

### DIFF
--- a/crates/reinhardt-admin-cli/README.md
+++ b/crates/reinhardt-admin-cli/README.md
@@ -130,8 +130,9 @@ reinhardt-admin plugin update --all
 Use `reinhardt-formatter` to format all Rust files in the project. Reinhardt
 DSL macros are formatted with tree-sitter grammars and Topiary queries before
 `cargo fmt --all` formats the surrounding Rust code. For supported `page!`
-Rust expression islands, the formatter also runs rustfmt on the extracted
-expression and reinserts the result conservatively:
+Rust expression islands and closure parameter lists, the formatter also runs
+rustfmt with the configured line-width options and reinserts the result
+conservatively:
 
 ```bash
 # Format all files in the project

--- a/crates/reinhardt-admin/src/pages/components/common.rs
+++ b/crates/reinhardt-admin/src/pages/components/common.rs
@@ -259,7 +259,7 @@ where
 		})(text)
 	} else {
 		let handler: Arc<dyn Fn(Signal<u64>)> = Arc::new(handler);
-		page!(|text: String, _signal: Signal<u64>, _handler: Arc<dyn Fn(Signal<u64>) >| {
+		page!(|text: String, _signal: Signal<u64>, _handler: Arc<dyn Fn(Signal<u64>)>| {
 			a {
 				class: "admin-page-link",
 				href: "#",

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -196,7 +196,12 @@ pub fn list_view(
 			.render()
 	};
 
-	page!(|title: String, add_link: Page, filters_page: Page, summary: String, table_page: Page, pagination_page: Page| {
+	page!(|title: String,
+						   add_link: Page,
+						   filters_page: Page,
+						   summary: String,
+						   table_page: Page,
+						   pagination_page: Page| {
 		div {
 			class: "list-view animate__animated animate__fadeIn",
 			div {
@@ -381,7 +386,13 @@ pub fn detail_view(
 	let delete_id = record_id.to_string();
 	let delete_return_url = list_url.clone();
 
-	page!(|title: String, table_page: Page, edit_link: Page, back_link: Page, delete_model: String, delete_id: String, delete_return_url: String| {
+	page!(|title: String,
+						   table_page: Page,
+						   edit_link: Page,
+						   back_link: Page,
+						   delete_model: String,
+						   delete_id: String,
+						   delete_return_url: String| {
 		div {
 			class: "detail-view animate__animated animate__fadeIn",
 			h1 {
@@ -508,7 +519,13 @@ pub fn model_form(model_name: &str, fields: &[FormField], record_id: Option<&str
 	let submit_record_id = record_id.map(str::to_string);
 	let submit_return_url = list_url.clone();
 
-	page!(|form_title: String, action_url: String, form_groups: Page, cancel_link: Page, submit_model: String, submit_record_id: Option<String>, submit_return_url: String| {
+	page!(|form_title: String,
+						   action_url: String,
+						   form_groups: Page,
+						   cancel_link: Page,
+						   submit_model: String,
+						   submit_record_id: Option<String>,
+						   submit_return_url: String| {
 		div {
 			class: "model-form max-w-2xl animate__animated animate__fadeIn",
 			h1 {
@@ -981,7 +998,9 @@ fn create_filter_select(
 	})(options);
 	let field_str = field.to_string();
 
-	page!(|field_str: String, _filters_signal: Signal<HashMap<String, String>>, options_container: Page| {
+	page!(|field_str: String,
+						   _filters_signal: Signal<HashMap<String, String>>,
+						   options_container: Page| {
 		select {
 			class: "admin-select",
 			data_filter_field: field_str.clone(),

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -197,11 +197,11 @@ pub fn list_view(
 	};
 
 	page!(|title: String,
-						   add_link: Page,
-						   filters_page: Page,
-						   summary: String,
-						   table_page: Page,
-						   pagination_page: Page| {
+	 add_link: Page,
+	 filters_page: Page,
+	 summary: String,
+	 table_page: Page,
+	 pagination_page: Page| {
 		div {
 			class: "list-view animate__animated animate__fadeIn",
 			div {
@@ -387,12 +387,12 @@ pub fn detail_view(
 	let delete_return_url = list_url.clone();
 
 	page!(|title: String,
-						   table_page: Page,
-						   edit_link: Page,
-						   back_link: Page,
-						   delete_model: String,
-						   delete_id: String,
-						   delete_return_url: String| {
+	 table_page: Page,
+	 edit_link: Page,
+	 back_link: Page,
+	 delete_model: String,
+	 delete_id: String,
+	 delete_return_url: String| {
 		div {
 			class: "detail-view animate__animated animate__fadeIn",
 			h1 {
@@ -520,12 +520,12 @@ pub fn model_form(model_name: &str, fields: &[FormField], record_id: Option<&str
 	let submit_return_url = list_url.clone();
 
 	page!(|form_title: String,
-						   action_url: String,
-						   form_groups: Page,
-						   cancel_link: Page,
-						   submit_model: String,
-						   submit_record_id: Option<String>,
-						   submit_return_url: String| {
+	 action_url: String,
+	 form_groups: Page,
+	 cancel_link: Page,
+	 submit_model: String,
+	 submit_record_id: Option<String>,
+	 submit_return_url: String| {
 		div {
 			class: "model-form max-w-2xl animate__animated animate__fadeIn",
 			h1 {
@@ -999,8 +999,8 @@ fn create_filter_select(
 	let field_str = field.to_string();
 
 	page!(|field_str: String,
-						   _filters_signal: Signal<HashMap<String, String>>,
-						   options_container: Page| {
+	 _filters_signal: Signal<HashMap<String, String>>,
+	 options_container: Page| {
 		select {
 			class: "admin-select",
 			data_filter_field: field_str.clone(),

--- a/crates/reinhardt-formatter/src/format_engine.rs
+++ b/crates/reinhardt-formatter/src/format_engine.rs
@@ -409,6 +409,7 @@ fn format_dsl_with_options_preserving_markers(
 	let mut normalized = normalize_dsl_output(formatted.trim());
 	if kind == MacroKind::Page {
 		normalized = format_page_rustfmt_islands(&normalized, rustfmt_options);
+		normalized = format_page_closure_args(&normalized, rustfmt_options);
 	}
 	Ok(FormattedDsl {
 		output: normalized,
@@ -529,6 +530,97 @@ fn format_page_rustfmt_islands(input: &str, rustfmt_options: &RustfmtOptions) ->
 		}
 	}
 	output
+}
+
+fn format_page_closure_args(input: &str, rustfmt_options: &RustfmtOptions) -> String {
+	let mut parser = Parser::new();
+	let language = tree_sitter_reinhardt_page::LANGUAGE.into();
+	if parser.set_language(&language).is_err() {
+		return input.to_string();
+	}
+	let Some(tree) = parser.parse(input, None) else {
+		return input.to_string();
+	};
+	if tree.root_node().has_error() {
+		return input.to_string();
+	}
+
+	let mut ranges = Vec::new();
+	collect_page_closure_arg_ranges(tree.root_node(), &mut ranges);
+	let ranges = non_nested_ranges(ranges);
+
+	let mut output = input.to_string();
+	for (start, end) in ranges.into_iter().rev() {
+		let closure_args = &input[start..end];
+		let line_indent = line_indent_for_offset(input, start);
+		if let Some(formatted) = format_closure_args(closure_args, line_indent, rustfmt_options) {
+			output.replace_range(start..end, &formatted);
+		}
+	}
+	output
+}
+
+fn collect_page_closure_arg_ranges(node: Node<'_>, ranges: &mut Vec<(usize, usize)>) {
+	if node.kind() == "page_closure" {
+		let mut cursor = node.walk();
+		for child in node.children(&mut cursor) {
+			if child.kind() == "closure_args" {
+				let start = child.start_byte();
+				let end = child.end_byte();
+				if start < end {
+					ranges.push((start, end));
+				}
+				break;
+			}
+		}
+		return;
+	}
+
+	let mut cursor = node.walk();
+	for child in node.children(&mut cursor) {
+		collect_page_closure_arg_ranges(child, ranges);
+	}
+}
+
+fn format_closure_args(
+	closure_args: &str,
+	line_indent: &str,
+	rustfmt_options: &RustfmtOptions,
+) -> Option<String> {
+	let wrapped = format!("fn main() {{ let __reinhardt_fmt = {closure_args} (); }}\n");
+	let mut cmd = Command::new("rustfmt");
+	rustfmt_options.apply_to_island_command(&mut cmd);
+	let mut child = cmd
+		.arg("--emit=stdout")
+		.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::null())
+		.spawn()
+		.ok()?;
+	let Some(mut stdin) = child.stdin.take() else {
+		let _ = child.kill();
+		let _ = child.wait();
+		return None;
+	};
+	if stdin.write_all(wrapped.as_bytes()).is_err() {
+		drop(stdin);
+		let _ = child.kill();
+		let _ = child.wait();
+		return None;
+	}
+	drop(stdin);
+
+	let output = child.wait_with_output().ok()?;
+	if !output.status.success() {
+		return None;
+	}
+	let formatted_wrapper = String::from_utf8(output.stdout).ok()?;
+	let (formatted, wrapper_indent) = unwrap_rustfmt_closure_args(&formatted_wrapper)?;
+	Some(reindent_multiline_closure_args(
+		formatted,
+		line_indent,
+		wrapper_indent,
+	))
 }
 
 fn collect_rustfmt_island_ranges(node: Node<'_>, ranges: &mut Vec<(usize, usize)>) {
@@ -759,6 +851,21 @@ fn unwrap_rustfmt_island(formatted_wrapper: &str) -> Option<&str> {
 	value.utf8_text(formatted_wrapper.as_bytes()).ok()
 }
 
+fn unwrap_rustfmt_closure_args(formatted_wrapper: &str) -> Option<(&str, &str)> {
+	let mut parser = Parser::new();
+	let language = tree_sitter_rust::LANGUAGE.into();
+	parser.set_language(&language).ok()?;
+	let tree = parser.parse(formatted_wrapper, None)?;
+	if tree.root_node().has_error() {
+		return None;
+	}
+	let closure = find_first_node_kind(tree.root_node(), "closure_expression")?;
+	let parameters = closure.child_by_field_name("parameters")?;
+	let wrapper_indent = line_indent_for_offset(formatted_wrapper, parameters.start_byte());
+	let formatted = parameters.utf8_text(formatted_wrapper.as_bytes()).ok()?;
+	Some((formatted, wrapper_indent))
+}
+
 fn find_first_node_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
 	if node.kind() == kind {
 		return Some(node);
@@ -787,6 +894,30 @@ fn reindent_multiline_island(input: &str, line_indent: &str) -> String {
 		result.push_str(strip_leading_indent(line, strip_indent));
 	}
 	result
+}
+
+fn reindent_multiline_closure_args(
+	input: &str,
+	line_indent: &str,
+	wrapper_line_indent: &str,
+) -> String {
+	let mut lines = input.lines();
+	let Some(first) = lines.next() else {
+		return String::new();
+	};
+	let mut result = first.to_string();
+	for line in lines {
+		result.push('\n');
+		if !line.is_empty() {
+			result.push_str(line_indent);
+		}
+		result.push_str(strip_leading_exact_indent(line, wrapper_line_indent));
+	}
+	result
+}
+
+fn strip_leading_exact_indent<'a>(line: &'a str, indent: &str) -> &'a str {
+	line.strip_prefix(indent).unwrap_or(line)
 }
 
 fn common_continuation_indent(lines: &[&str]) -> usize {
@@ -1003,6 +1134,46 @@ mod tests {
 
 		// Assert
 		assert_eq!(formatted, "|| {\n\tdiv { \"x\" }\n}");
+	}
+
+	#[rstest]
+	fn formats_long_page_closure_args_as_multiline() {
+		// Arrange
+		let input = concat!(
+			"|project_id: i64, ",
+			"small_box_id: i64, ",
+			"instruction_id: String, ",
+			"generate_pending_action: VersionAction, ",
+			"generate_click: ClickHandler, ",
+			"retake_pending_action: VersionAction, ",
+			"retake_click: ClickHandler, ",
+			"accept_pending_action: VersionAction, ",
+			"accept_click: ClickHandler, ",
+			"compare_pending_action: CompareAction, ",
+			"compare_click: ClickHandler, ",
+			"manuscript_badge_handles: ManuscriptResultHandles, ",
+			"manuscript_summary_handles: ManuscriptResultHandles| ",
+			r#"{ section { class: "grid gap-5 p-6", } }"#,
+		);
+
+		// Act
+		let formatted = format_dsl(MacroKind::Page, input).expect("format page DSL");
+		let second = format_dsl(MacroKind::Page, &formatted).expect("format page DSL again");
+
+		// Assert
+		assert!(
+			formatted.contains("|project_id: i64,\n"),
+			"long closure args should wrap after the first parameter: {formatted}"
+		);
+		assert!(
+			formatted.contains("\n small_box_id: i64,"),
+			"wrapped closure args should keep later parameters on separate lines: {formatted}"
+		);
+		assert!(
+			!formatted.contains("project_id: i64, small_box_id: i64, instruction_id: String"),
+			"long closure args should not stay on one line: {formatted}"
+		);
+		assert_eq!(second, formatted);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-formatter/src/format_engine.rs
+++ b/crates/reinhardt-formatter/src/format_engine.rs
@@ -615,12 +615,8 @@ fn format_closure_args(
 		return None;
 	}
 	let formatted_wrapper = String::from_utf8(output.stdout).ok()?;
-	let (formatted, wrapper_indent) = unwrap_rustfmt_closure_args(&formatted_wrapper)?;
-	Some(reindent_multiline_closure_args(
-		formatted,
-		line_indent,
-		wrapper_indent,
-	))
+	let formatted = unwrap_rustfmt_closure_args(&formatted_wrapper)?;
+	Some(reindent_multiline_closure_args(formatted, line_indent))
 }
 
 fn collect_rustfmt_island_ranges(node: Node<'_>, ranges: &mut Vec<(usize, usize)>) {
@@ -851,7 +847,7 @@ fn unwrap_rustfmt_island(formatted_wrapper: &str) -> Option<&str> {
 	value.utf8_text(formatted_wrapper.as_bytes()).ok()
 }
 
-fn unwrap_rustfmt_closure_args(formatted_wrapper: &str) -> Option<(&str, &str)> {
+fn unwrap_rustfmt_closure_args(formatted_wrapper: &str) -> Option<&str> {
 	let mut parser = Parser::new();
 	let language = tree_sitter_rust::LANGUAGE.into();
 	parser.set_language(&language).ok()?;
@@ -861,9 +857,7 @@ fn unwrap_rustfmt_closure_args(formatted_wrapper: &str) -> Option<(&str, &str)> 
 	}
 	let closure = find_first_node_kind(tree.root_node(), "closure_expression")?;
 	let parameters = closure.child_by_field_name("parameters")?;
-	let wrapper_indent = line_indent_for_offset(formatted_wrapper, parameters.start_byte());
-	let formatted = parameters.utf8_text(formatted_wrapper.as_bytes()).ok()?;
-	Some((formatted, wrapper_indent))
+	parameters.utf8_text(formatted_wrapper.as_bytes()).ok()
 }
 
 fn find_first_node_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
@@ -896,11 +890,7 @@ fn reindent_multiline_island(input: &str, line_indent: &str) -> String {
 	result
 }
 
-fn reindent_multiline_closure_args(
-	input: &str,
-	line_indent: &str,
-	wrapper_line_indent: &str,
-) -> String {
+fn reindent_multiline_closure_args(input: &str, line_indent: &str) -> String {
 	let mut lines = input.lines();
 	let Some(first) = lines.next() else {
 		return String::new();
@@ -908,16 +898,14 @@ fn reindent_multiline_closure_args(
 	let mut result = first.to_string();
 	for line in lines {
 		result.push('\n');
-		if !line.is_empty() {
+		let trimmed = line.trim_start_matches([' ', '\t']);
+		if !trimmed.is_empty() {
 			result.push_str(line_indent);
+			result.push(' ');
+			result.push_str(trimmed);
 		}
-		result.push_str(strip_leading_exact_indent(line, wrapper_line_indent));
 	}
 	result
-}
-
-fn strip_leading_exact_indent<'a>(line: &'a str, indent: &str) -> &'a str {
-	line.strip_prefix(indent).unwrap_or(line)
 }
 
 fn common_continuation_indent(lines: &[&str]) -> usize {
@@ -1169,11 +1157,39 @@ mod tests {
 			formatted.contains("\n small_box_id: i64,"),
 			"wrapped closure args should keep later parameters on separate lines: {formatted}"
 		);
+		let small_box_line = formatted
+			.lines()
+			.find(|line| line.contains("small_box_id: i64,"))
+			.expect("small_box_id line");
+		assert_eq!(
+			small_box_line, " small_box_id: i64,",
+			"wrapped closure args should not preserve rustfmt alignment padding: {formatted}"
+		);
 		assert!(
 			!formatted.contains("project_id: i64, small_box_id: i64, instruction_id: String"),
 			"long closure args should not stay on one line: {formatted}"
 		);
 		assert_eq!(second, formatted);
+
+		let hard_tabs_options = RustfmtOptions {
+			config: Some("hard_tabs=true".to_string()),
+			..RustfmtOptions::default()
+		};
+		let hard_tabs_formatted =
+			format_dsl_with_options(MacroKind::Page, input, &hard_tabs_options)
+				.expect("format page DSL with hard tabs");
+		let hard_tabs_second =
+			format_dsl_with_options(MacroKind::Page, &hard_tabs_formatted, &hard_tabs_options)
+				.expect("format page DSL with hard tabs again");
+		let hard_tabs_small_box_line = hard_tabs_formatted
+			.lines()
+			.find(|line| line.contains("small_box_id: i64,"))
+			.expect("hard-tabs small_box_id line");
+		assert_eq!(
+			hard_tabs_small_box_line, " small_box_id: i64,",
+			"wrapped closure args should normalize hard-tabs rustfmt alignment padding: {hard_tabs_formatted}"
+		);
+		assert_eq!(hard_tabs_second, hard_tabs_formatted);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-pages/tests/ui/page/pass/for_loop.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/for_loop.rs
@@ -16,7 +16,7 @@ fn main() {
 	});
 
 	// For with tuple destructuring
-	let _for_enumerate = page!(|items: Vec<(usize, String) >| {
+	let _for_enumerate = page!(|items: Vec<(usize, String)>| {
 		ul {
 			for(index, item)in items.clone() {
 				li {

--- a/crates/reinhardt-pages/tests/ui/page/pass/nested_for.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/nested_for.rs
@@ -16,7 +16,7 @@ fn main() {
 	});
 
 	// For loop with nested if
-	let _for_if = page!(|items: Vec<(i32, bool) >| {
+	let _for_if = page!(|items: Vec<(i32, bool)>| {
 		ul {
 			for(num, active)in items.clone() {
 				li {


### PR DESCRIPTION
## Summary

This PR addresses:

- Wraps long `page!` closure parameter lists by formatting `closure_args` through rustfmt after Topiary formatting.
- Keeps short closure parameter lists inline while using configured rustfmt line-width options for long typed parameter lists.
- Documents the formatter behavior and refreshes existing `page!` call sites affected by the new rule.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`reinhardt-admin fmt` accepted route-backed `page!` components with very long typed closure parameter lists on a single line. Those lists were preserved as `closure_args` leaves by the DSL formatter, so they did not respect the configured rustfmt line width.

Fixes #5545

Related to: #

## How Was This Tested?

- [x] `cargo test -p reinhardt-formatter`
- [x] `cargo make fmt-check`
- [x] `cargo clippy -p reinhardt-formatter --all-targets --all-features -- -D warnings`
- [x] `git diff --check`

## Performance Impact

Not performance-related.

## Breaking Changes

None.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5545

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [x] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

🤖 Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long `page!` closure arguments are now formatted more cleanly, with multi-line wrapping for readability and stable reformatting on repeat runs.

* **Bug Fixes**
  * Improved handling of spacing in generic type annotations within `page!` closures.
  * Fixed inconsistent formatting in several UI examples and tests.

* **Documentation**
  * Clarified the code formatting guide to better explain what the formatter targets and how it applies line-width settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->