### PR TITLE
fix(ci): unblock quick-xml security audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -17,4 +17,11 @@ ignore = [
 	"RUSTSEC-2026-0098",
 	"RUSTSEC-2026-0099",
 	"RUSTSEC-2026-0104",
+
+	# Direct quick-xml dependencies are pinned to 0.41.0. Remaining vulnerable
+	# quick-xml versions are held by upstream crates that have not yet admitted
+	# 0.41.x: legacy azure_core 0.21, Azure SDK 1.0 typespec XML support, and
+	# plist 1.9 through syntect.
+	"RUSTSEC-2026-0194",
+	"RUSTSEC-2026-0195",
 ]

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -33,7 +33,7 @@ multer = "3.0"
 mime = "0.3"
 futures-util = "0.3"
 urlencoding = "2.1"
-quick-xml = { version = "0.38.3", optional = true }
+quick-xml = { version = "0.41.0", optional = true }
 serde_yaml = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 alloc-stdlib = { workspace = true, optional = true }

--- a/crates/reinhardt-core/src/parsers/xml.rs
+++ b/crates/reinhardt-core/src/parsers/xml.rs
@@ -8,8 +8,8 @@ use crate::exception::Error;
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::HeaderMap;
-use quick_xml::Reader;
 use quick_xml::events::{Event, attributes::Attributes};
+use quick_xml::{Reader, XmlVersion};
 use serde_json::{Map, Value, json};
 
 /// XML parser configuration
@@ -208,6 +208,7 @@ impl XMLParser {
 		let mut reader = Reader::from_reader(bytes);
 		let mut stack: Vec<(String, Map<String, Value>)> = Vec::new();
 		let mut current_text = String::new();
+		let mut xml_version = XmlVersion::default();
 
 		loop {
 			match reader.read_event() {
@@ -247,7 +248,7 @@ impl XMLParser {
 
 				Ok(Event::Text(e)) => {
 					let text = e
-						.xml_content()
+						.xml_content(xml_version)
 						.map_err(|e| Error::Validation(format!("XML decode error: {}", e)))?;
 
 					if self.config.trim_text {
@@ -289,6 +290,12 @@ impl XMLParser {
 					} else {
 						return Ok(json!({ name: value }));
 					}
+				}
+
+				Ok(Event::Decl(e)) => {
+					xml_version = e
+						.xml_version()
+						.map_err(|e| Error::Validation(format!("XML declaration error: {}", e)))?;
 				}
 
 				Ok(Event::Eof) => break,
@@ -412,6 +419,26 @@ mod tests {
 				assert!(value.is_object());
 				let root = value.get("root").unwrap();
 				assert_eq!(root.get("#text"), None);
+			}
+			_ => panic!("Expected XML"),
+		}
+	}
+
+	#[tokio::test]
+	async fn test_xml_parser_with_declaration() {
+		let parser = XMLParser::new();
+		let xml = Bytes::from(r#"<?xml version="1.1"?><root>John</root>"#);
+
+		let headers = HeaderMap::new();
+
+		let result = parser
+			.parse(Some("application/xml"), xml, &headers)
+			.await
+			.unwrap();
+		match result {
+			ParsedData::Xml(value) => {
+				let root = value.get("root").unwrap();
+				assert_eq!(root.get("#text").unwrap(), "John");
 			}
 			_ => panic!("Expected XML"),
 		}

--- a/crates/reinhardt-rest/Cargo.toml
+++ b/crates/reinhardt-rest/Cargo.toml
@@ -102,7 +102,7 @@ sqlx = { workspace = true }
 multer = "3.0"
 
 # Rendering
-quick-xml = { version = "0.38.3", features = ["serialize"] }
+quick-xml = { version = "0.41.0", features = ["serialize"] }
 csv = "1.3"
 utoipa = { version = "5.4", features = ["url", "uuid", "yaml"], optional = true }
 tera = { workspace = true, optional = true }

--- a/crates/reinhardt-views/Cargo.toml
+++ b/crates/reinhardt-views/Cargo.toml
@@ -16,7 +16,7 @@ reinhardt-http = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-quick-xml = { version = "0.38.3", features = ["serialize"] }
+quick-xml = { version = "0.41.0", features = ["serialize"] }
 serde_yaml = "0.9.33"
 thiserror = { workspace = true }
 http-body-util = "0.1"

--- a/docs/security-audit-0.3.0.md
+++ b/docs/security-audit-0.3.0.md
@@ -30,6 +30,8 @@ publish CVSS scores in the local RustSec advisory data.
 | [`RUSTSEC-2026-0098`](https://rustsec.org/advisories/RUSTSEC-2026-0098) | `rustls-webpki` | `0.101.7` | `>=0.103.12` | AWS SDK rustls 0.21 transport and `rskafka` TLS transport | Accepted temporarily. The issue requires otherwise properly issued certificates with URI name constraints and is reachable after signature verification. Remove when upstream AWS SDK/rskafka transport dependencies move off rustls-webpki 0.101.x. |
 | [`RUSTSEC-2026-0099`](https://rustsec.org/advisories/RUSTSEC-2026-0099) | `rustls-webpki` | `0.101.7` | `>=0.103.12` | AWS SDK rustls 0.21 transport and `rskafka` TLS transport | Accepted temporarily. The issue requires certificate misissuance around DNS name constraints and wildcard names. Remove with the same rustls-webpki transport upgrade tracked in #5492. |
 | [`RUSTSEC-2026-0104`](https://rustsec.org/advisories/RUSTSEC-2026-0104) | `rustls-webpki` | `0.101.7` | `>=0.103.13` | AWS SDK rustls 0.21 transport and `rskafka` TLS transport | Accepted temporarily. Applications that do not parse CRLs through rustls-webpki are not affected by the CRL parsing panic described by the advisory. Remove with the same rustls-webpki transport upgrade tracked in #5492. |
+| [`RUSTSEC-2026-0194`](https://rustsec.org/advisories/RUSTSEC-2026-0194) | `quick-xml` | `0.31.0`, `0.39.4` | `>=0.41.0` | legacy `azure_core 0.21`, Azure SDK 1.0 `typespec` XML support, and `syntect -> plist 1.9` | Accepted temporarily. Reinhardt's direct `quick-xml` dependencies are pinned to `0.41.0`; the remaining vulnerable versions are held by upstream dependency constraints. Remove when the Azure SDK and `plist` release dependency ranges that admit `quick-xml >=0.41.0`, or when the legacy Azure staticfiles backend is removed. |
+| [`RUSTSEC-2026-0195`](https://rustsec.org/advisories/RUSTSEC-2026-0195) | `quick-xml` | `0.31.0`, `0.39.4` | `>=0.41.0` | legacy `azure_core 0.21`, Azure SDK 1.0 `typespec` XML support, and `syntect -> plist 1.9` | Accepted temporarily. This shares the same upstream-bound paths as RUSTSEC-2026-0194. Direct Reinhardt dependencies are remediated; remove with the same upstream quick-xml dependency refresh tracked in #5492. |
 
 ## Allowed Warnings Reviewed
 
@@ -64,4 +66,5 @@ issue in [#5492](https://github.com/kent8192/reinhardt-web/issues/5492):
   dependency graph;
 - upgrade, isolate, or feature-gate the `sqlx-mysql -> rsa 0.9.10` path;
 - move AWS/Kafka TLS transports off `rustls-webpki 0.101.7`;
+- move upstream-constrained Azure SDK and `plist` paths off `quick-xml <0.41.0`;
 - remove `.cargo/audit.toml` entries as each advisory is remediated.


### PR DESCRIPTION
## Summary

This PR addresses:

- Bumps Reinhardt's direct `quick-xml` dependencies to the patched `0.41.0` line.
- Allows `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` only for remaining upstream-constrained dependency paths.
- Documents the temporary audit exception rationale and removal conditions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Security Audit on #5547 fails after RustSec advisories `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` landed for `quick-xml <0.41.0`.

Related to: #5547, #5492

## How Was This Tested?

- `cargo audit`
- `cargo check -p reinhardt-core --features xml`
- `cargo check -p reinhardt-rest --features xml`
- `cargo check -p reinhardt-views --all-features`
- `git diff --check`

## Performance Impact

Not performance-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #5547
- Related to #5492

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

Created as a separate PR so #5547 can remain focused on formatter behavior. The remaining `quick-xml` vulnerable versions are upstream-bound paths documented in `docs/security-audit-0.3.0.md`.

Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML parsing for documents that include an XML declaration, helping text content be read more reliably.
  * Updated XML-related dependencies to a newer version.

* **Chores**
  * Added temporary security exceptions for known upstream advisories while longer-term fixes are being worked through.
  * Updated security audit documentation to reflect the current dependency status and follow-up plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->