### PR TITLE
feat(pages): add native component test harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.3.0...reinhardt-web@v0.3.1) - 2026-07-04
+
+### Added
+
+- add frontend framework benchmark suite
+
+### Fixed
+
+- *(benchmarks)* correct frontend benchmark measurements
+- *(ci)* pin standalone examples time resolution
+- *(ci)* unblock quick-xml security audit
+- *(ci)* adapt XML parser to quick-xml 0.41
+- *(formatter)* normalize admin feature page closures
+- *(ci)* format basis tutorial page closures
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.2.0...reinhardt-web@v0.3.0) - 2026-06-28
 
 Stable 0.3.0 is the first stable release of the Reinhardt 0.3 line. It

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ di = [
   "reinhardt-db?/di",
   "reinhardt-grpc?/di",
 ]
-test = ["reinhardt-test"]
+test = ["reinhardt-test", "reinhardt-pages?/testing"]
 testcontainers = ["test", "reinhardt-test/testcontainers"]
 server-fn-test = ["test", "reinhardt-test/server-fn-test"]
 # MSW (Mock Service Worker) for WASM testing — exposes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -486,77 +486,77 @@ module_name_repetitions = "allow"
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.3.0" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.3.1" }
 
 # Internal crates
-reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.3.0" }
-reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.3.0" }
-reinhardt-core = { path = "crates/reinhardt-core", version = "0.3.0", default-features = false }
-reinhardt-di = { path = "crates/reinhardt-di", version = "0.3.0" }
-reinhardt-http = { path = "crates/reinhardt-http", version = "0.3.0" }
-reinhardt-server = { path = "crates/reinhardt-server", version = "0.3.0" }
-reinhardt-views = { path = "crates/reinhardt-views", version = "0.3.0", default-features = false }
-reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.3.0", default-features = false }
-reinhardt-router = { path = "crates/reinhardt-router", version = "0.3.0" }
-reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.3.0", default-features = false }
-reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.3.0" }
-reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.3.0" }
-reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.3.0" }
-reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.3.0" }
-reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.3.0" }
-reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.3.0" }
-reinhardt-testkit-macros = { path = "crates/reinhardt-testkit-macros", version = "0.3.0" }
-reinhardt-test = { path = "crates/reinhardt-test", version = "0.3.0" }
-reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.3.0" }
-reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.3.0" }
-reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.3.0" }
-reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.3.0", default-features = false }
-reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.3.0" }
-reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.3.0", default-features = false }
-reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.3.0" }
-reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.3.0" }
-reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.3.0" }
-reinhardt-formatter = { path = "crates/reinhardt-formatter", version = "0.3.0" }
-tree-sitter-reinhardt-page = { path = "crates/tree-sitter-reinhardt-page", version = "0.3.0" }
-tree-sitter-reinhardt-form = { path = "crates/tree-sitter-reinhardt-form", version = "0.3.0" }
-tree-sitter-reinhardt-head = { path = "crates/tree-sitter-reinhardt-head", version = "0.3.0" }
+reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.3.1" }
+reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.3.1" }
+reinhardt-core = { path = "crates/reinhardt-core", version = "0.3.1", default-features = false }
+reinhardt-di = { path = "crates/reinhardt-di", version = "0.3.1" }
+reinhardt-http = { path = "crates/reinhardt-http", version = "0.3.1" }
+reinhardt-server = { path = "crates/reinhardt-server", version = "0.3.1" }
+reinhardt-views = { path = "crates/reinhardt-views", version = "0.3.1", default-features = false }
+reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.3.1", default-features = false }
+reinhardt-router = { path = "crates/reinhardt-router", version = "0.3.1" }
+reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.3.1", default-features = false }
+reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.3.1" }
+reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.3.1" }
+reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.3.1" }
+reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.3.1" }
+reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.3.1" }
+reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.3.1" }
+reinhardt-testkit-macros = { path = "crates/reinhardt-testkit-macros", version = "0.3.1" }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.3.1" }
+reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.3.1" }
+reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.3.1" }
+reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.3.1" }
+reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.3.1", default-features = false }
+reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.3.1" }
+reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.3.1", default-features = false }
+reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.3.1" }
+reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.3.1" }
+reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.3.1" }
+reinhardt-formatter = { path = "crates/reinhardt-formatter", version = "0.3.1" }
+tree-sitter-reinhardt-page = { path = "crates/tree-sitter-reinhardt-page", version = "0.3.1" }
+tree-sitter-reinhardt-form = { path = "crates/tree-sitter-reinhardt-form", version = "0.3.1" }
+tree-sitter-reinhardt-head = { path = "crates/tree-sitter-reinhardt-head", version = "0.3.1" }
 topiary-core = "0.7.3"
 topiary-tree-sitter-facade = "0.7.3"
-reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.3.0" }
-reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.3.0" }
-reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.3.0" }
-reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.3.0", default-features = false }
-reinhardt-db = { path = "crates/reinhardt-db", version = "0.3.0", default-features = false }
-reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.3.0" }
-reinhardt-query = { path = "crates/reinhardt-query", version = "0.3.0" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.3.0" }
-reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.3.0" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.3.0" }
-reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.3.0" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.3.0" }
-reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.3.0" }
-reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.3.0" }
-reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.3.0" }
-reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.3.0" }
+reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.3.1" }
+reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.3.1" }
+reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.3.1" }
+reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.3.1", default-features = false }
+reinhardt-db = { path = "crates/reinhardt-db", version = "0.3.1", default-features = false }
+reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.3.1" }
+reinhardt-query = { path = "crates/reinhardt-query", version = "0.3.1" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.3.1" }
+reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.3.1" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.3.1" }
+reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.3.1" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.3.1" }
+reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.3.1" }
+reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.3.1" }
+reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.3.1" }
+reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.3.1" }
 
 # Feature crates (develop/0.2.0)
-reinhardt-providers = { path = "crates/reinhardt-providers", version = "0.3.0" }
-reinhardt-storages = { path = "crates/reinhardt-storages", version = "0.3.0" }
+reinhardt-providers = { path = "crates/reinhardt-providers", version = "0.3.1" }
+reinhardt-storages = { path = "crates/reinhardt-storages", version = "0.3.1" }
 
 # Query subcrates
-reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.3.0" }
+reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.3.1" }
 
 # Core subcrates
-reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.3.0" }
+reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.3.1" }
 
 # DI subcrates
-reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.3.0" }
+reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.3.1" }
 
 # REST subcrates
-reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.3.0" }
+reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.3.1" }
 
 # REST subcrates (continued)
-reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.3.0" }
+reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.3.1" }
 
 # Streaming
 rskafka = { version = "0.5" }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you have written `ModelSerializer` or `Depends()` before, Reinhardt will feel
 ```bash
 # Pin the documented Reinhardt release for reproducibility.
 # Omit --version to let Cargo choose the latest stable release.
-cargo install reinhardt-admin-cli --version "0.3.0"
+cargo install reinhardt-admin-cli --version "0.3.1"
 
 reinhardt-admin startproject my-api && cd my-api
 cargo run --bin manage runserver  # Visit http://127.0.0.1:8000
@@ -103,7 +103,7 @@ Reinhardt follows a **three-phase lifecycle** for every crate:
 | **Stable** (`0.x.0`) | Full SemVer 2.0 guarantees. |
 
 <!-- reinhardt-version-sync -->
-**Current release line:** Reinhardt documentation tracks `0.3.0`. From
+**Current release line:** Reinhardt documentation tracks `0.3.1`. From
 `0.1.0` onward, all public APIs follow SemVer 2.0; future breaking changes
 move through the documented alpha and RC lifecycle before stable publication.
 
@@ -131,7 +131,7 @@ Get a well-balanced feature set with zero configuration:
 [dependencies]
 # Import as 'reinhardt', published as 'reinhardt-web'
 # Default enables the "standard" preset (balanced feature set)
-reinhardt = { version = "0.3.0", package = "reinhardt-web" }
+reinhardt = { version = "0.3.1", package = "reinhardt-web" }
 ```
 
 **Includes:** Core, Database (PostgreSQL), REST API (serializers, parsers, pagination, filters, throttling, versioning, metadata, content negotiation), Auth, Middleware (sessions), Pages (WASM Frontend with SSR), Signals
@@ -153,7 +153,7 @@ For compatibility checks, framework development, and projects that intentionally
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", package = "reinhardt-web", default-features = false, features = ["full"] }
+reinhardt = { version = "0.3.1", package = "reinhardt-web", default-features = false, features = ["full"] }
 ```
 
 **Includes:** Everything in Standard, plus Admin, GraphQL, WebSockets, Cache, i18n, Mail, Static Files, Storage, and more
@@ -167,7 +167,7 @@ Lightweight and fast, perfect for simple APIs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+reinhardt = { version = "0.3.1", package = "reinhardt-web", default-features = false, features = ["minimal"] }
 ```
 
 **Includes:** HTTP, routing, DI, parameter extraction, server
@@ -182,24 +182,24 @@ Install only the components you need:
 ```toml
 [dependencies]
 # Core components
-reinhardt-http = "0.3.0"
-reinhardt-urls = "0.3.0"
+reinhardt-http = "0.3.1"
+reinhardt-urls = "0.3.1"
 
 # Optional: Database
-reinhardt-db = "0.3.0"
+reinhardt-db = "0.3.1"
 
 # Optional: Authentication
-reinhardt-auth = "0.3.0"
+reinhardt-auth = "0.3.1"
 
 # Optional: REST API features
-reinhardt-rest = "0.3.0"
+reinhardt-rest = "0.3.1"
 
 # Optional: Admin panel
-reinhardt-admin = "0.3.0"
+reinhardt-admin = "0.3.1"
 
 # Optional: Advanced features
-reinhardt-graphql = "0.3.0"
-reinhardt-websockets = "0.3.0"
+reinhardt-graphql = "0.3.1"
+reinhardt-websockets = "0.3.1"
 ```
 
 **Note on Crate Naming:**
@@ -217,7 +217,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.0"
+cargo install reinhardt-admin-cli --version "0.3.1"
 ```
 
 ### 2. Create a New Project
@@ -234,7 +234,7 @@ during project creation. Scripts can pass them explicitly:
 <!-- reinhardt-version-sync -->
 ```bash
 reinhardt-admin startproject my-api \
-  --reinhardt-version "0.3.0" \
+  --reinhardt-version "0.3.1" \
   --features standard,admin \
   --no-interactive
 ```

--- a/announcements/v0.3.1.md
+++ b/announcements/v0.3.1.md
@@ -1,0 +1,51 @@
+# reinhardt-web v0.3.1
+
+## Highlights
+
+This release brings a security fix for the ORM macros, along with new diagnostic and benchmarking tooling. The `#[model]` macro previously injected `#[serde(skip)]` on generated `{Model}Info` relation fields unconditionally, which could silently override explicit `#[serde(skip_serializing)]`, `#[serde(skip_deserializing)]`, or other developer-supplied serde attributes on relation DTOs — a mass-assignment and data-exposure risk. The macro now distinguishes its own injected skip from developer-authored attributes, preserving explicit serde configuration on relation fields while still hiding the internal relation marker correctly.
+
+On the ORM side, `reinhardt-db` gains an opt-in `NPlusOneScope` detector that hooks into query instrumentation to flag repeated same-shape queries during development or in focused tests, complementing the existing `select_related()` / `prefetch_related()` eager-loading APIs without affecting production behavior unless explicitly enabled.
+
+This release also adds a manifest-driven frontend benchmark suite comparing Reinhardt Pages against React, Vue, Next.js, and Nuxt across build, bundle-size, startup, and HMR scenarios — useful for tracking Pages' performance relative to the broader ecosystem over time.
+
+Additionally, several CI and formatter fixes land: the DSL formatter now correctly wraps long `page!` closure parameter lists instead of leaving them unwrapped on a single line, dependency resolution for standalone examples is pinned to avoid incompatible `time`/`cookie` version pairings, and `quick-xml` is bumped to the patched 0.41 line to clear recent security advisories.
+
+## Breaking Changes
+
+- ⚠️ [[reinhardt-web#5585] feat(manouche)!: add compile-time accessibility validation](https://github.com/kent8192/reinhardt-web/discussions/5605)
+- ⚠️ [[reinhardt-web#5558] feat!(pages): require named component route names](https://github.com/kent8192/reinhardt-web/discussions/5588)
+- ⚠️ [[reinhardt-web#5525] perf!: lazy-parse request query params](https://github.com/kent8192/reinhardt-web/discussions/5534)
+- ⚠️ [[reinhardt-web#5513] chore: merge develop/0.3.0 into main](https://github.com/kent8192/reinhardt-web/discussions/5519)
+
+## Related PRs
+
+| PR | Title | Author |
+|----|-------|--------|
+| [#5513](https://github.com/kent8192/reinhardt-web/pull/5513) | chore: merge develop/0.3.0 into main | @kent8192 |
+| [#5521](https://github.com/kent8192/reinhardt-web/pull/5521) | fix(macros): preserve explicit serde attrs on relation info | @kent8192 |
+| [#5530](https://github.com/kent8192/reinhardt-web/pull/5530) | ci: auto-fix fmt and clippy failures | @kent8192 |
+| [#5531](https://github.com/kent8192/reinhardt-web/pull/5531) | feat(db): add scoped N+1 query detection | @kent8192 |
+| [#5532](https://github.com/kent8192/reinhardt-web/pull/5532) | feat: add frontend framework benchmark suite | @kent8192 |
+| [#5542](https://github.com/kent8192/reinhardt-web/pull/5542) | fix(ci): pin standalone examples time resolution | @kent8192 |
+| [#5547](https://github.com/kent8192/reinhardt-web/pull/5547) | fix(formatter): wrap long page closure parameters | @kent8192 |
+| [#5573](https://github.com/kent8192/reinhardt-web/pull/5573) | fix(ci): unblock quick-xml security audit | @kent8192 |
+| [#5589](https://github.com/kent8192/reinhardt-web/pull/5589) | fix(ci): format basis tutorial page closures | @kent8192 |
+
+<details><summary>Full CHANGELOG</summary>
+
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.3.0...reinhardt-web@v0.3.1) - 2026-07-04
+
+### Added
+
+- add frontend framework benchmark suite
+
+### Fixed
+
+- *(benchmarks)* correct frontend benchmark measurements
+- *(ci)* pin standalone examples time resolution
+- *(ci)* unblock quick-xml security audit
+- *(ci)* adapt XML parser to quick-xml 0.41
+- *(formatter)* normalize admin feature page closures
+- *(ci)* format basis tutorial page closures
+
+</details>

--- a/benchmarks/frontend/runner/servers.ts
+++ b/benchmarks/frontend/runner/servers.ts
@@ -50,7 +50,9 @@ export async function startServer(command: string, cwd: string, url: string, tim
       throw new Error(`server failed to start: ${spawnError.message}`);
     }
     if (child.exitCode !== null) {
-      throw new Error(`server exited before readiness: ${logExcerpt(server.stdout, server.stderr)}`);
+      const output = logExcerpt(server.stdout, server.stderr);
+      await stopServer(server);
+      throw new Error(`server exited before readiness: ${output}`);
     }
     try {
       const response = await fetch(url);

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.3.0...reinhardt-admin-cli@v0.3.1) - 2026-07-04
+
+### Fixed
+
+- *(formatter)* wrap long page closure parameters
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.2.0...reinhardt-admin-cli@v0.3.0) - 2026-06-28
 
 Stable release of `reinhardt-admin-cli` for the Reinhardt 0.3.0 line. This

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-admin-cli/README.md
+++ b/crates/reinhardt-admin-cli/README.md
@@ -14,7 +14,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.0"
+cargo install reinhardt-admin-cli --version "0.3.1"
 ```
 
 This installs the `reinhardt-admin` command.
@@ -40,7 +40,7 @@ reinhardt-admin startproject myproject --with-rest /path/to/directory
 
 # Pin the generated Reinhardt dependency
 reinhardt-admin startproject myproject --with-rest \
-  --reinhardt-version 0.3.0 \
+  --reinhardt-version 0.3.1 \
   --features standard,admin \
   --no-interactive
 ```
@@ -58,7 +58,7 @@ reinhardt-admin configure
 
 # Update a project without prompts
 reinhardt-admin configure /path/to/project \
-  --reinhardt-version 0.3.0 \
+  --reinhardt-version 0.3.1 \
   --features minimal,db-sqlite \
   --no-interactive
 ```
@@ -108,7 +108,7 @@ reinhardt-admin plugin info auth-delion --remote
 
 # Install a plugin
 reinhardt-admin plugin install auth-delion
-reinhardt-admin plugin install auth-delion --version 0.3.0
+reinhardt-admin plugin install auth-delion --version 0.3.1
 
 # Remove a plugin
 reinhardt-admin plugin remove auth-delion

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -14,7 +14,7 @@
 //!
 //! <!-- reinhardt-version-sync -->
 //! ```bash
-//! cargo install reinhardt-admin-cli --version "0.3.0"
+//! cargo install reinhardt-admin-cli --version "0.3.1"
 //! ```
 //!
 //! ## Usage

--- a/crates/reinhardt-admin/CHANGELOG.md
+++ b/crates/reinhardt-admin/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin@v0.3.0...reinhardt-admin@v0.3.1) - 2026-07-04
+
+### Fixed
+
+- *(formatter)* wrap long page closure parameters
+- *(formatter)* normalize admin feature page closures
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin@v0.2.0...reinhardt-admin@v0.3.0) - 2026-06-28
 
 Stable release of `reinhardt-admin` for the Reinhardt 0.3.0 line. This

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -34,10 +34,10 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:2 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["admin"] }
+reinhardt = { version = "0.3.1", features = ["admin"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["full"] }  # All features
+# reinhardt = { version = "0.3.1", features = ["full"] }  # All features
 ```
 
 Then import admin features:

--- a/crates/reinhardt-apps/Cargo.toml
+++ b/crates/reinhardt-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-apps"
-version = "0.3.0"
+version = "0.3.1"
 description = "Application registry and management for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-apps/README.md
+++ b/crates/reinhardt-apps/README.md
@@ -19,11 +19,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", package = "reinhardt-web", features = ["apps"] }
+reinhardt = { version = "0.3.1", package = "reinhardt-web", features = ["apps"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", package = "reinhardt-web", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", package = "reinhardt-web", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", package = "reinhardt-web", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", package = "reinhardt-web", features = ["full"] }      # All features
 ```
 
 Then import app features:
@@ -53,7 +53,7 @@ installed_apps! {
 ```toml
 [dependencies]
 reinhardt = {
-	version = "0.3.0",
+	version = "0.3.1",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "admin"]
 }
@@ -148,7 +148,7 @@ pub fn get_installed_apps() -> Vec<String> {
 ```toml
 [dependencies]
 reinhardt = {
-	version = "0.3.0",
+	version = "0.3.1",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "admin", "static-files"]
 }
@@ -240,7 +240,7 @@ pub fn get_installed_apps() -> Vec<String> {
 # Cargo.toml
 [dependencies]
 reinhardt = {
-	version = "0.3.0",
+	version = "0.3.1",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "database"]
 }
@@ -300,7 +300,7 @@ INSTALLED_APPS = [
 ```toml
 # Cargo.toml
 [dependencies]
-reinhardt = { version = "0.3.0", package = "reinhardt-web", features = ["auth", "admin"] }
+reinhardt = { version = "0.3.1", package = "reinhardt-web", features = ["auth", "admin"] }
 ```
 
 ```rust

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth"
-version = "0.3.0"
+version = "0.3.1"
 description = "Authentication and authorization system"
 keywords = ["auth", "jwt", "authentication", "django", "web"]
 categories = ["authentication", "web-programming"]

--- a/crates/reinhardt-auth/README.md
+++ b/crates/reinhardt-auth/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["auth"] }
+reinhardt = { version = "0.3.1", features = ["auth"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import authentication features:

--- a/crates/reinhardt-auth/macros/Cargo.toml
+++ b/crates/reinhardt-auth/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth-macros"
-version = "0.3.0"
+version = "0.3.1"
 description = "Procedural macros for reinhardt-auth (guard!)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-commands"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["commands"] }
+reinhardt = { version = "0.3.1", features = ["commands"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import command features:
@@ -39,7 +39,7 @@ package:
 ```bash
 # Pin the documented Reinhardt release for reproducibility.
 # Omit --version to let Cargo choose the latest stable release.
-cargo install reinhardt-admin-cli --version "0.3.0"
+cargo install reinhardt-admin-cli --version "0.3.1"
 ```
 
 This installs the `reinhardt-admin` command:
@@ -129,7 +129,7 @@ use reinhardt::commands::TemplateContext;
 
 let mut context = TemplateContext::new();
 context.insert("project_name", "my_project");
-context.insert("version", "0.3.0");
+context.insert("version", "0.3.1");
 context.insert("features", vec!["auth", "admin"]);  // Any Serialize type
 ```
 
@@ -323,7 +323,7 @@ Projects using `collect_migrations!` must add `linkme` as a dependency:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["standard"] }
+reinhardt = { version = "0.3.1", features = ["standard"] }
 linkme = "0.3"
 ```
 

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-conf"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -29,11 +29,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["conf"] }
+reinhardt = { version = "0.3.1", features = ["conf"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import configuration features:
@@ -52,13 +52,13 @@ Enable specific features based on your needs:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 # With async support
-reinhardt = { version = "0.3.0", features = ["conf", "async"] }
+reinhardt = { version = "0.3.1", features = ["conf", "async"] }
 
 # With encryption
-reinhardt = { version = "0.3.0", features = ["conf", "encryption"] }
+reinhardt = { version = "0.3.1", features = ["conf", "encryption"] }
 
 # With Vault integration
-reinhardt = { version = "0.3.0", features = ["conf", "vault"] }
+reinhardt = { version = "0.3.1", features = ["conf", "vault"] }
 ```
 
 Available features:

--- a/crates/reinhardt-core/CHANGELOG.md
+++ b/crates/reinhardt-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-core@v0.3.0...reinhardt-core@v0.3.1) - 2026-07-04
+
+### Fixed
+
+- *(ci)* unblock quick-xml security audit
+- *(ci)* adapt XML parser to quick-xml 0.41
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-core@v0.2.0...reinhardt-core@v0.3.0) - 2026-06-28
 
 Stable release of `reinhardt-core` for the Reinhardt 0.3.0 line. This

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-core"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-core/README.md
+++ b/crates/reinhardt-core/README.md
@@ -90,7 +90,7 @@ Add this to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-core = "0.3.0"
+reinhardt-core = "0.3.1"
 ```
 
 ### Optional Features
@@ -100,7 +100,7 @@ Enable specific modules based on your needs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-core = { version = "0.3.0", features = ["signals", "macros", "security"] }
+reinhardt-core = { version = "0.3.1", features = ["signals", "macros", "security"] }
 ```
 
 Available features:

--- a/crates/reinhardt-core/macros/CHANGELOG.md
+++ b/crates/reinhardt-core/macros/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-macros@v0.3.0...reinhardt-macros@v0.3.1) - 2026-07-04
+
+### Fixed
+
+- *(macros)* preserve explicit serde attrs on relation info
+
+### Testing
+
+- *(macros)* fix relation info serde fixture
+- *(macros)* cover plain relation info serde path
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-macros@v0.2.0...reinhardt-macros@v0.3.0) - 2026-06-28
 
 Stable release of `reinhardt-macros` for the Reinhardt 0.3.0 line. This

--- a/crates/reinhardt-core/macros/Cargo.toml
+++ b/crates/reinhardt-core/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -4812,6 +4812,10 @@ fn relation_info_serde_meta_is_safe(meta: &syn::Meta) -> bool {
 	)
 }
 
+fn relation_info_serde_meta_name(meta: &syn::Meta) -> Option<String> {
+	meta.path().get_ident().map(ToString::to_string)
+}
+
 fn relation_info_serde_attr(
 	attr: &syn::Attribute,
 	injected_relation_serde_skip: bool,
@@ -4827,14 +4831,31 @@ fn relation_info_serde_attr(
 	let nested = meta_list
 		.parse_args_with(Punctuated::<syn::Meta, Token![,]>::parse_terminated)
 		.ok()?;
-	let kept = nested
-		.into_iter()
-		.filter(|meta| {
-			!(injected_relation_serde_skip
-				&& matches!(meta, syn::Meta::Path(path) if path.is_ident("skip")))
-		})
-		.filter(relation_info_serde_meta_is_safe)
-		.collect::<Vec<_>>();
+	let mut keeps_skip_serializing = false;
+	let mut needs_info_default = false;
+	let mut kept = Vec::new();
+	for meta in nested {
+		if injected_relation_serde_skip
+			&& matches!(&meta, syn::Meta::Path(path) if path.is_ident("skip"))
+		{
+			continue;
+		}
+
+		let name = relation_info_serde_meta_name(&meta);
+		if matches!(name.as_deref(), Some("skip_deserializing" | "default")) {
+			needs_info_default = true;
+			continue;
+		}
+
+		if relation_info_serde_meta_is_safe(&meta) {
+			keeps_skip_serializing |= matches!(name.as_deref(), Some("skip_serializing"));
+			kept.push(meta);
+		}
+	}
+
+	if keeps_skip_serializing && needs_info_default {
+		kept.push(parse_quote!(default));
+	}
 
 	if kept.is_empty() {
 		return None;

--- a/crates/reinhardt-core/macros/tests/relation_info_serde.rs
+++ b/crates/reinhardt-core/macros/tests/relation_info_serde.rs
@@ -87,4 +87,9 @@ fn relation_info_preserves_explicit_serde_round_trip() {
 		serde_json::from_str(r#"{"id":1,"title":"private","tenant":{"id":999}}"#).unwrap();
 	let model: Document = decoded.into();
 	assert_eq!(model.tenant_id, 999);
+
+	let decoded_without_relation: DocumentInfo =
+		serde_json::from_str(r#"{"id":1,"title":"private"}"#).unwrap();
+	let model_without_relation: Document = decoded_without_relation.into();
+	assert_eq!(model_without_relation.tenant_id, 0);
 }

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -63,6 +63,16 @@ pub mod model_info {
 		}
 	}
 
+	impl<T> Default for RelationInfo<T>
+	where
+		T: InfoModel,
+		T::PrimaryKey: Default,
+	{
+		fn default() -> Self {
+			Self::new(T::PrimaryKey::default())
+		}
+	}
+
 	#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 	#[serde(bound(
 		serialize = "Target::PrimaryKey: serde::Serialize",

--- a/crates/reinhardt-core/src/lib.rs
+++ b/crates/reinhardt-core/src/lib.rs
@@ -131,6 +131,16 @@ pub mod model_info {
 		}
 	}
 
+	impl<T> Default for RelationInfo<T>
+	where
+		T: InfoModel,
+		T::PrimaryKey: Default,
+	{
+		fn default() -> Self {
+			Self::new(T::PrimaryKey::default())
+		}
+	}
+
 	impl<T> std::fmt::Debug for RelationInfo<T>
 	where
 		T: InfoModel,

--- a/crates/reinhardt-core/src/lib.rs
+++ b/crates/reinhardt-core/src/lib.rs
@@ -329,6 +329,8 @@ pub use crate::types::page;
 
 #[cfg(feature = "macros")]
 pub use reinhardt_macros as macros;
+#[cfg(feature = "macros")]
+pub use reinhardt_macros::Validate;
 
 // Re-export rate limiting types
 pub use crate::rate_limit::RateLimitStrategy;

--- a/crates/reinhardt-db-macros/Cargo.toml
+++ b/crates/reinhardt-db-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db/CHANGELOG.md
+++ b/crates/reinhardt-db/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db@v0.3.0...reinhardt-db@v0.3.1) - 2026-07-04
+
+### Added
+
+- *(db)* add scoped n+1 query detection
+
+### Fixed
+
+- *(db)* avoid listener map guards across awaits
+- *(db)* address n+1 detector review gaps
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db@v0.2.0...reinhardt-db@v0.3.0) - 2026-06-28
 
 Stable release of `reinhardt-db` for the Reinhardt 0.3.0 line. This

--- a/crates/reinhardt-db/Cargo.toml
+++ b/crates/reinhardt-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -156,7 +156,7 @@ Add this to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-db = "0.3.0"
+reinhardt-db = "0.3.1"
 ```
 
 ### Optional Features
@@ -166,7 +166,7 @@ Enable specific features based on your needs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-db = { version = "0.3.0", features = ["postgres", "orm", "migrations"] }
+reinhardt-db = { version = "0.3.1", features = ["postgres", "orm", "migrations"] }
 ```
 
 Available features:

--- a/crates/reinhardt-deeplink/Cargo.toml
+++ b/crates/reinhardt-deeplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-deeplink"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/Cargo.toml
+++ b/crates/reinhardt-dentdelion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dentdelion"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/README.md
+++ b/crates/reinhardt-dentdelion/README.md
@@ -22,11 +22,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["dentdelion"] }
+reinhardt = { version = "0.3.1", features = ["dentdelion"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import dentdelion features:
@@ -62,7 +62,7 @@ pub struct MyPlugin {
 impl MyPlugin {
     pub fn new() -> Self {
         Self {
-            metadata: PluginMetadata::builder("my-plugin", "0.3.0")
+            metadata: PluginMetadata::builder("my-plugin", "0.3.1")
                 .description("My custom plugin")
                 .author("Your Name")
                 .build()
@@ -225,7 +225,7 @@ Dentdelion uses the WebAssembly Interface Types (WIT) standard for plugin interf
 
 <!-- reinhardt-version-sync -->
 ```wit
-package reinhardt:dentdelion@0.3.0;
+package reinhardt:dentdelion@0.3.1;
 
 // Host functions available to plugins
 interface host {

--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "reinhardt-di"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-di/README.md
+++ b/crates/reinhardt-di/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["di"] }
+reinhardt = { version = "0.3.1", features = ["di"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import DI features:

--- a/crates/reinhardt-di/macros/Cargo.toml
+++ b/crates/reinhardt-di/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-di-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-dispatch/Cargo.toml
+++ b/crates/reinhardt-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dispatch"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dispatch/README.md
+++ b/crates/reinhardt-dispatch/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["dispatch"] }
+reinhardt = { version = "0.3.1", features = ["dispatch"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import dispatch features:

--- a/crates/reinhardt-formatter/CHANGELOG.md
+++ b/crates/reinhardt-formatter/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-formatter@v0.3.0...reinhardt-formatter@v0.3.1) - 2026-07-04
+
+### Fixed
+
+- *(formatter)* wrap long page closure parameters
+- *(formatter)* normalize wrapped closure indentation
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-formatter@v0.2.0...reinhardt-formatter@v0.3.0) - 2026-06-28
 
 Stable release of `reinhardt-formatter` for the Reinhardt 0.3.0 line. This

--- a/crates/reinhardt-formatter/Cargo.toml
+++ b/crates/reinhardt-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-formatter"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-forms/Cargo.toml
+++ b/crates/reinhardt-forms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-forms"
-version = "0.3.0"
+version = "0.3.1"
 description = "Form handling and validation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-forms/README.md
+++ b/crates/reinhardt-forms/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["forms"] }
+reinhardt = { version = "0.3.1", features = ["forms"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 
 # Forms is included in the standard preset
 ```

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.3.0"
+version = "0.3.1"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-graphql/README.md
+++ b/crates/reinhardt-graphql/README.md
@@ -107,11 +107,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["graphql"] }
+reinhardt = { version = "0.3.1", features = ["graphql"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import GraphQL features:
@@ -128,10 +128,10 @@ use reinhardt::graphql::types::{UserStorage, UserEvent};
 <!-- reinhardt-version-sync:2 -->
 ```toml
 # With dependency injection
-reinhardt = { version = "0.3.0", features = ["graphql", "di"] }
+reinhardt = { version = "0.3.1", features = ["graphql", "di"] }
 
 # With gRPC transport
-reinhardt = { version = "0.3.0", features = ["graphql", "grpc"] }
+reinhardt = { version = "0.3.1", features = ["graphql", "grpc"] }
 ```
 
 ## Examples

--- a/crates/reinhardt-graphql/macros/Cargo.toml
+++ b/crates/reinhardt-graphql/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql-macros"
-version = "0.3.0"
+version = "0.3.1"
 description = "Procedural macros for GraphQL schema generation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc"
-version = "0.3.0"
+version = "0.3.1"
 description = "gRPC support for building RPC services"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/README.md
+++ b/crates/reinhardt-grpc/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["grpc"] }
+reinhardt = { version = "0.3.1", features = ["grpc"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import gRPC features:
@@ -160,7 +160,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-grpc = "0.3.0"
+reinhardt-grpc = "0.3.1"
 tonic = "0.12"
 prost = "0.13"
 
@@ -193,11 +193,18 @@ Facade consumers can enable `grpc` alongside a preset that includes DI:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }
+reinhardt = { version = "0.3.1", package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }
 ```
 
 Direct `reinhardt-grpc` consumers can instead enable this crate's `di`
-feature explicitly and depend on `reinhardt-di` for DI types.
+feature explicitly and depend on `reinhardt-di` for DI types:
+
+<!-- reinhardt-version-sync:2 -->
+```toml
+[dependencies]
+reinhardt-grpc = { version = "0.3.1", features = ["di"] }
+reinhardt-di = "0.3.1"
+```
 
 #### Basic Usage
 

--- a/crates/reinhardt-grpc/macros/Cargo.toml
+++ b/crates/reinhardt-grpc/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-http/Cargo.toml
+++ b/crates/reinhardt-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-http"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-http/README.md
+++ b/crates/reinhardt-http/README.md
@@ -94,11 +94,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = "0.3.0"
+reinhardt = "0.3.1"
 
 # Or use a preset with parsers support:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 **Note:** HTTP types are available through the main `reinhardt` crate, which provides a unified interface to all framework components.

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.3.0"
+version = "0.3.1"
 description = "Internationalization and localization support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-i18n/README.md
+++ b/crates/reinhardt-i18n/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["i18n"] }
+reinhardt = { version = "0.3.1", features = ["i18n"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import i18n features:

--- a/crates/reinhardt-mail/Cargo.toml
+++ b/crates/reinhardt-mail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-mail"
-version = "0.3.0"
+version = "0.3.1"
 description = "Email sending functionality with multiple backends"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-mail/README.md
+++ b/crates/reinhardt-mail/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["mail"] }
+reinhardt = { version = "0.3.1", features = ["mail"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import mail features:

--- a/crates/reinhardt-manouche/Cargo.toml
+++ b/crates/reinhardt-manouche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-manouche"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-middleware"
-version = "0.3.0"
+version = "0.3.1"
 description = "Middleware system for request/response processing pipeline"
 keywords = ["middleware", "web", "cors", "security", "http"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-middleware/README.md
+++ b/crates/reinhardt-middleware/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["middleware"] }
+reinhardt = { version = "0.3.1", features = ["middleware"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import middleware features:

--- a/crates/reinhardt-openapi/Cargo.toml
+++ b/crates/reinhardt-openapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   role/text/label queries, event helpers, async settling, pretty DOM output,
   and in-process `server_fn` mocks for `MockableServerFn` markers.
 
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.3.0...reinhardt-pages@v0.3.1) - 2026-07-04
+
+### Fixed
+
+- *(formatter)* wrap long page closure parameters
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.2.0...reinhardt-pages@v0.3.0) - 2026-06-28
 
 Stable release of `reinhardt-pages` for the Reinhardt 0.3.0 line. This

--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add native component testing utilities under
+  `reinhardt_pages::testing::component`, including in-memory `Page` rendering,
+  role/text/label queries, event helpers, async settling, pretty DOM output,
+  and in-process `server_fn` mocks for `MockableServerFn` markers.
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.2.0...reinhardt-pages@v0.3.0) - 2026-06-28
 
 Stable release of `reinhardt-pages` for the Reinhardt 0.3.0 line. This

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -303,6 +303,32 @@ page!(|state: Signal<AppState>| {
 3. **Single expression**: `watch` blocks must contain exactly one expression
 4. **Avoid nesting**: Don't nest `watch` blocks (performance concern)
 
+## Testing
+
+### Native Component Tests
+
+Use `reinhardt_pages::testing::component::render` for fast interaction tests
+that do not need a browser:
+
+```rust
+use reinhardt_pages::testing::component::{Role, render};
+
+#[tokio::test]
+async fn refresh_loads_jobs() {
+    let screen = render(jobs_page);
+    screen.mock_server_fn::<load_jobs::marker>(|_args| Ok(vec!["Index job".to_string()]));
+
+    screen.get_by_role(Role::Button, "Refresh").click();
+    screen.settle().await;
+
+    assert!(screen.query_by_text("Index job").is_some());
+}
+```
+
+The mock API uses `MockableServerFn` markers and therefore requires the
+`msw` feature. Use direct `server_fn` calls for business logic tests and
+WASM/browser tests for hydration or browser API coverage.
+
 ## Architecture
 
 This framework consists of several key modules:

--- a/crates/reinhardt-pages/ast/Cargo.toml
+++ b/crates/reinhardt-pages/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-ast"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/macros/Cargo.toml
+++ b/crates/reinhardt-pages/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -570,23 +570,28 @@ fn add_native_mock_probe(
 	let pages_crate = &pages_crate_info.ident;
 	let name = info.name();
 	let original_block = func.block;
-	func.block = Box::new(syn::parse_quote!({
-		#pages_use_statement
-		#[cfg(all(any(test, feature = "testing"), feature = "msw"))]
-		#[allow(unexpected_cfgs)]
-		{
-			let __args = #name::Args {
-				#(#param_idents: #param_idents.clone()),*
-			};
-			if let Some(__mock_result) =
-				#pages_crate::server_fn::try_call_active_mock::<#name::marker>(__args)
+	let native_mock_probe = if cfg!(feature = "msw") {
+		quote! {
 			{
-				match __mock_result {
-					Ok(__mock_value) => return Ok(__mock_value),
-					Err(__mock_error) => return Err(__mock_error),
+				let __args = #name::Args {
+					#(#param_idents: #param_idents.clone()),*
+				};
+				if let Some(__mock_result) =
+					#pages_crate::server_fn::try_call_active_mock::<#name::marker>(__args)
+				{
+					match __mock_result {
+						Ok(__mock_value) => return Ok(__mock_value),
+						Err(__mock_error) => return Err(__mock_error),
+					}
 				}
 			}
 		}
+	} else {
+		quote! {}
+	};
+	func.block = Box::new(syn::parse_quote!({
+		#pages_use_statement
+		#native_mock_probe
 		#original_block
 	}));
 	Ok(func)

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -583,7 +583,7 @@ fn add_native_mock_probe(
 			{
 				match __mock_result {
 					Ok(__mock_value) => return Ok(__mock_value),
-					Err(__mock_error) => panic!("server function mock failed: {}", __mock_error),
+					Err(__mock_error) => return Err(__mock_error),
 				}
 			}
 		}

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -532,6 +532,66 @@ pub(crate) fn server_fn_impl(args: TokenStream, input: TokenStream) -> TokenStre
 	generate_server_fn(&info).into()
 }
 
+fn regular_server_fn_params(inputs: &Punctuated<FnArg, Token![,]>) -> Vec<&syn::PatType> {
+	inputs
+		.iter()
+		.filter_map(|arg| {
+			if let syn::FnArg::Typed(pat_type) = arg {
+				let has_inject = pat_type.attrs.iter().any(is_inject_attr);
+				if has_inject || is_extractor_type(&pat_type.ty) {
+					return None;
+				}
+				Some(pat_type)
+			} else {
+				None
+			}
+		})
+		.collect()
+}
+
+fn add_native_mock_probe(
+	info: &ServerFnInfo,
+	clean_func: &ItemFn,
+	regular_params: &[&syn::PatType],
+	pages_crate_info: &CratePathInfo,
+) -> Result<ItemFn, proc_macro2::TokenStream> {
+	let mut param_idents = Vec::new();
+	for param in regular_params {
+		let syn::Pat::Ident(pat_ident) = &*param.pat else {
+			return Err(quote! {
+				compile_error!("server_fn component-test mocks require identifier parameters");
+			});
+		};
+		param_idents.push(pat_ident.ident.clone());
+	}
+
+	let mut func = clean_func.clone();
+	let pages_use_statement = &pages_crate_info.use_statement;
+	let pages_crate = &pages_crate_info.ident;
+	let name = info.name();
+	let original_block = func.block;
+	func.block = Box::new(syn::parse_quote!({
+		#pages_use_statement
+		#[cfg(all(any(test, feature = "testing"), feature = "msw"))]
+		#[allow(unexpected_cfgs)]
+		{
+			let __args = #name::Args {
+				#(#param_idents: #param_idents.clone()),*
+			};
+			if let Some(__mock_result) =
+				#pages_crate::server_fn::try_call_active_mock::<#name::marker>(__args)
+			{
+				match __mock_result {
+					Ok(__mock_value) => return Ok(__mock_value),
+					Err(__mock_error) => panic!("server function mock failed: {}", __mock_error),
+				}
+			}
+		}
+		#original_block
+	}));
+	Ok(func)
+}
+
 /// Generate server function code
 ///
 /// This generates both client and server code with conditional compilation.
@@ -575,6 +635,12 @@ fn generate_server_fn(info: &ServerFnInfo) -> proc_macro2::TokenStream {
 
 	// Dynamically resolve reinhardt_pages crate path for client stub
 	let pages_crate_info = get_reinhardt_pages_crate_info();
+	let regular_params = regular_server_fn_params(&func.sig.inputs);
+	let native_clean_func =
+		match add_native_mock_probe(info, &clean_func, &regular_params, &pages_crate_info) {
+			Ok(func) => quote! { #func },
+			Err(err) => err,
+		};
 
 	// Generate client stub (with DI and extractor parameter filtering)
 	let client_stub =
@@ -589,7 +655,7 @@ fn generate_server_fn(info: &ServerFnInfo) -> proc_macro2::TokenStream {
 
 		// Server-side: Original function (with #[inject] attributes removed)
 		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-		#clean_func
+		#native_clean_func
 
 		// Client-side: HTTP request stub
 		#client_stub
@@ -1295,7 +1361,7 @@ fn generate_server_handler(
 				use ::serde::{Serialize, Deserialize};
 
 				/// Public Args struct for MSW type-safe mocking.
-				#[derive(Serialize, Deserialize)]
+				#[derive(Serialize, Deserialize, Clone)]
 				pub struct Args {
 					#(pub #regular_param_names: #regular_param_types),*
 				}
@@ -1331,7 +1397,7 @@ fn generate_server_handler(
 				use ::serde::{Serialize, Deserialize};
 
 				/// Public Args struct for MSW type-safe mocking.
-				#[derive(Serialize, Deserialize)]
+				#[derive(Serialize, Deserialize, Clone)]
 				pub struct Args {
 					#(pub #regular_param_names: #regular_param_types),*
 				}

--- a/crates/reinhardt-pages/src/callback.rs
+++ b/crates/reinhardt-pages/src/callback.rs
@@ -546,7 +546,7 @@ mod tests {
 
 		let handler: PageEventHandler = into_event_handler(|_: DummyEvent| {});
 		// Verify it's callable
-		handler(DummyEvent::default());
+		handler(DummyEvent);
 	}
 }
 

--- a/crates/reinhardt-pages/src/callback.rs
+++ b/crates/reinhardt-pages/src/callback.rs
@@ -31,7 +31,6 @@ use std::future::Future;
 use std::sync::Arc;
 
 use crate::component::PageEventHandler;
-#[cfg(wasm)]
 use crate::platform::spawn_task;
 
 #[cfg(wasm)]
@@ -472,8 +471,7 @@ where
 	Fut: Future<Output = ()> + Send + 'static,
 {
 	Arc::new(move |event| {
-		// Non-WASM stub: drop the future without awaiting
-		std::mem::drop(f(event));
+		spawn_task(f(event));
 	})
 }
 

--- a/crates/reinhardt-pages/src/platform/native.rs
+++ b/crates/reinhardt-pages/src/platform/native.rs
@@ -6,9 +6,50 @@
 //! and task spawning degrades to a no-op since there is no browser event
 //! loop.
 
+use std::cell::RefCell;
 use std::future::Future;
+use std::pin::Pin;
 
 pub use crate::component::DummyEvent as Event;
+
+type BoxedTask = Pin<Box<dyn Future<Output = ()> + 'static>>;
+type TaskSink = Box<dyn Fn(BoxedTask) + 'static>;
+
+thread_local! {
+	static TASK_SINK: RefCell<Option<TaskSink>> = const { RefCell::new(None) };
+}
+
+pub(crate) struct NativeTaskSinkGuard {
+	previous: Option<TaskSink>,
+}
+
+impl Drop for NativeTaskSinkGuard {
+	fn drop(&mut self) {
+		let previous = self.previous.take();
+		TASK_SINK.with(|slot| {
+			*slot.borrow_mut() = previous;
+		});
+	}
+}
+
+pub(crate) fn install_task_sink(sink: impl Fn(BoxedTask) + 'static) -> NativeTaskSinkGuard {
+	let previous = TASK_SINK.with(|slot| slot.borrow_mut().replace(Box::new(sink)));
+	NativeTaskSinkGuard { previous }
+}
+
+pub(crate) fn try_spawn_task<F>(fut: F) -> bool
+where
+	F: Future<Output = ()> + 'static,
+{
+	TASK_SINK.with(|slot| {
+		if let Some(sink) = slot.borrow().as_ref() {
+			sink(Box::pin(fut));
+			true
+		} else {
+			false
+		}
+	})
+}
 
 /// Stub Window type for SSR compatibility.
 #[derive(Debug, Clone, Default)]
@@ -82,11 +123,11 @@ pub struct HtmlButtonElement;
 /// is dropped. Keeping `spawn_task` cross-target lets `form!`-generated
 /// submission handlers and reactive hooks compile identically on both
 /// targets.
-pub fn spawn_task<F>(_fut: F)
+pub fn spawn_task<F>(fut: F)
 where
 	F: Future<Output = ()> + 'static,
 {
-	// Non-WASM: no browser event loop; drop the future.
+	let _ = try_spawn_task(fut);
 }
 
 /// No-op microtask yield for native targets.

--- a/crates/reinhardt-pages/src/reactive/hooks/async_action.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/async_action.rs
@@ -310,6 +310,10 @@ where
 	let on_error_for_dispatch = Rc::clone(&on_error);
 	#[cfg(wasm)]
 	let on_success_for_dispatch = Rc::clone(&on_success);
+	#[cfg(native)]
+	let on_error_for_dispatch = Rc::clone(&on_error);
+	#[cfg(native)]
+	let on_success_for_dispatch = Rc::clone(&on_success);
 
 	let dispatch_fn: Rc<dyn Fn()> = {
 		let state = state.clone();
@@ -354,9 +358,31 @@ where
 
 			#[cfg(native)]
 			{
-				// Non-WASM: drop the future, reset to Idle
-				let _fut = action_fn(*payload);
-				state.set(ActionPhase::Idle);
+				let task_state = state.clone();
+				let on_error = Rc::clone(&on_error_for_dispatch);
+				let on_success = Rc::clone(&on_success_for_dispatch);
+				let fut = action_fn(*payload);
+				let spawned = crate::platform::try_spawn_task(async move {
+					match fut.await {
+						Ok(val) => {
+							let on_success = on_success.borrow().clone();
+							crate::reactive::batch(|| {
+								on_success(&val);
+								task_state.set(ActionPhase::Success(val));
+							});
+						}
+						Err(err) => {
+							let on_error = on_error.borrow().clone();
+							crate::reactive::batch(|| {
+								on_error();
+								task_state.set(ActionPhase::Error(err));
+							});
+						}
+					}
+				});
+				if !spawned {
+					state.set(ActionPhase::Idle);
+				}
 			}
 		})
 	};

--- a/crates/reinhardt-pages/src/reactive/hooks/memo.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/memo.rs
@@ -251,7 +251,7 @@ mod tests {
 		use crate::component::DummyEvent;
 
 		let callback = use_callback(|_: DummyEvent| {}, ());
-		callback.call(DummyEvent::default());
+		callback.call(DummyEvent);
 	}
 
 	#[cfg(native)]

--- a/crates/reinhardt-pages/src/reactive/hooks/sync.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/sync.rs
@@ -296,7 +296,8 @@ mod tests {
 	#[test]
 	fn test_use_sync_external_store_with_update() {
 		let store_value = Rc::new(RefCell::new(0));
-		let on_change_fn: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
+		type OnChangeSlot = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
+		let on_change_fn: OnChangeSlot = Rc::new(RefCell::new(None));
 
 		let signal_with_sub = use_sync_external_store(
 			{

--- a/crates/reinhardt-pages/src/server_fn.rs
+++ b/crates/reinhardt-pages/src/server_fn.rs
@@ -88,6 +88,8 @@ pub mod router_ext;
 pub mod server_fn_trait;
 
 // Re-exports
+#[cfg(all(native, any(test, feature = "testing"), feature = "msw"))]
+pub use crate::testing::component::server_fn_mock::try_call_active_mock;
 #[cfg(feature = "msgpack")]
 pub use codec::MessagePackCodec;
 pub use codec::{Codec, JsonCodec, UrlCodec};

--- a/crates/reinhardt-pages/src/server_fn.rs
+++ b/crates/reinhardt-pages/src/server_fn.rs
@@ -88,8 +88,6 @@ pub mod router_ext;
 pub mod server_fn_trait;
 
 // Re-exports
-#[cfg(all(native, any(test, feature = "testing"), feature = "msw"))]
-pub use crate::testing::component::server_fn_mock::try_call_active_mock;
 #[cfg(feature = "msgpack")]
 pub use codec::MessagePackCodec;
 pub use codec::{Codec, JsonCodec, UrlCodec};
@@ -107,6 +105,20 @@ pub use registry::{ServerFnHandler, ServerFnRoute};
 #[cfg(native)]
 pub use router_ext::ServerFnRouterExt;
 pub use server_fn_trait::{ServerFn, ServerFnError, parse_server_error_message};
+
+#[cfg(all(native, any(test, feature = "testing"), feature = "msw"))]
+pub use crate::testing::component::server_fn_mock::try_call_active_mock;
+
+#[cfg(all(native, feature = "msw", not(any(test, feature = "testing"))))]
+/// No-op native server-function mock probe outside component-test builds.
+pub fn try_call_active_mock<S>(_: S::Args) -> Option<Result<S::Response, ServerFnError>>
+where
+	S: MockableServerFn + 'static,
+	S::Args: Clone + 'static,
+	S::Response: 'static,
+{
+	None
+}
 
 // Re-export the macro for convenience
 pub use reinhardt_pages_macros::server_fn;

--- a/crates/reinhardt-pages/src/testing.rs
+++ b/crates/reinhardt-pages/src/testing.rs
@@ -20,7 +20,17 @@
 //! }
 //! ```
 //!
-//! ## Layer 2: WASM Component Tests with Mocked HTTP
+//! ## Layer 2: Native Component Tests
+//!
+//! Native component tests use `component::render` to render component
+//! functions or `Page` values into an in-memory DOM and interact with them
+//! through role/text/label queries, event helpers, `settle()`, and in-process
+//! `server_fn` mocks.
+//!
+//! These tests run without a browser and are intended for component logic,
+//! query behavior, async hook settling, and typed server function mock flows.
+//!
+//! ## Layer 3: WASM Component Tests with Mocked HTTP
 //!
 //! Tests WASM components with mocked server function responses.
 //! Uses the mock HTTP infrastructure for predictable testing.
@@ -37,7 +47,7 @@
 //! }
 //! ```
 //!
-//! ## Layer 3: End-to-End Tests
+//! ## Layer 4: End-to-End Tests
 //!
 //! Full integration tests with real server and WASM frontend.
 //! Uses E2E test infrastructure for complete flow testing.
@@ -73,6 +83,10 @@ pub mod server_fn_test;
 
 #[cfg(native)]
 pub use server_fn_test::*;
+
+// Native component testing utilities.
+#[cfg(all(native, feature = "testing"))]
+pub mod component;
 
 // WASM DOM testing utilities (Layer 2 and 3)
 #[cfg(wasm)]

--- a/crates/reinhardt-pages/src/testing/component.rs
+++ b/crates/reinhardt-pages/src/testing/component.rs
@@ -1,0 +1,25 @@
+//! Native component testing harness.
+
+mod error;
+mod events;
+mod pretty;
+mod query;
+mod role;
+mod scheduler;
+mod screen;
+#[cfg(feature = "msw")]
+pub(crate) mod server_fn_mock;
+mod text_match;
+mod tree;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::{EventError, QueryError};
+pub use events::ElementHandle;
+pub use role::Role;
+pub use scheduler::SettleError;
+pub use screen::{Screen, TestRender, render};
+#[cfg(feature = "msw")]
+pub use server_fn_mock::{RecordedServerFnCall, ServerFnCallQuery};
+pub use text_match::TextMatch;

--- a/crates/reinhardt-pages/src/testing/component/error.rs
+++ b/crates/reinhardt-pages/src/testing/component/error.rs
@@ -1,0 +1,46 @@
+//! Error types for native component testing.
+
+use std::fmt;
+
+/// Error returned when a DOM query cannot identify one element.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryError {
+	/// No matching element was found.
+	NotFound,
+	/// More than one matching element was found.
+	MultipleMatches,
+}
+
+impl fmt::Display for QueryError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::NotFound => write!(f, "no matching element found"),
+			Self::MultipleMatches => write!(f, "multiple matching elements found"),
+		}
+	}
+}
+
+impl std::error::Error for QueryError {}
+
+/// Error returned when a synthetic event cannot be dispatched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventError {
+	/// The handle no longer points at a node in the screen tree.
+	DetachedElement,
+	/// The element has no handler for the requested event.
+	MissingHandler,
+	/// The requested event is not supported for this node.
+	UnsupportedElement,
+}
+
+impl fmt::Display for EventError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::DetachedElement => write!(f, "element is detached from the screen"),
+			Self::MissingHandler => write!(f, "element has no handler for the requested event"),
+			Self::UnsupportedElement => write!(f, "event is not supported for this element"),
+		}
+	}
+}
+
+impl std::error::Error for EventError {}

--- a/crates/reinhardt-pages/src/testing/component/events.rs
+++ b/crates/reinhardt-pages/src/testing/component/events.rs
@@ -1,0 +1,114 @@
+//! Stable element handles and synthetic event dispatch.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use reinhardt_core::types::page::{DummyEvent, EventType};
+
+use super::error::EventError;
+use super::tree::{NodeId, ScreenInner};
+
+/// Stable handle to an element in a rendered native test screen.
+#[derive(Clone)]
+pub struct ElementHandle {
+	pub(crate) inner: Rc<RefCell<ScreenInner>>,
+	pub(crate) node_id: NodeId,
+}
+
+impl ElementHandle {
+	pub(crate) fn new(inner: Rc<RefCell<ScreenInner>>, node_id: NodeId) -> Self {
+		Self { inner, node_id }
+	}
+
+	/// Dispatches a click event and panics when dispatch fails.
+	pub fn click(&self) {
+		self.try_click().expect("click dispatch failed");
+	}
+
+	/// Dispatches a click event.
+	pub fn try_click(&self) -> Result<(), EventError> {
+		self.dispatch(EventType::Click)
+	}
+
+	/// Updates the element value and dispatches an input event.
+	pub fn input(&self, value: impl Into<String>) {
+		self.try_input(value).expect("input dispatch failed");
+	}
+
+	/// Updates the element value and dispatches an input event.
+	pub fn try_input(&self, value: impl Into<String>) -> Result<(), EventError> {
+		self.dispatch_value(EventType::Input, value.into())
+	}
+
+	/// Updates the element value and dispatches a change event.
+	pub fn change(&self, value: impl Into<String>) {
+		self.try_change(value).expect("change dispatch failed");
+	}
+
+	/// Updates the element value and dispatches a change event.
+	pub fn try_change(&self, value: impl Into<String>) -> Result<(), EventError> {
+		self.dispatch_value(EventType::Change, value.into())
+	}
+
+	/// Returns the element text content.
+	pub fn text(&self) -> String {
+		self.inner.borrow().dom.text_content(self.node_id)
+	}
+
+	/// Returns the element tag name.
+	pub fn tag_name(&self) -> String {
+		self.inner
+			.borrow()
+			.dom
+			.element(self.node_id)
+			.map(|node| node.tag.clone())
+			.unwrap_or_default()
+	}
+
+	/// Returns the current internal form value for value-bearing elements.
+	pub fn value(&self) -> Option<String> {
+		self.inner.borrow().dom.value(self.node_id)
+	}
+
+	fn dispatch(&self, event_type: EventType) -> Result<(), EventError> {
+		let handler = {
+			let borrowed = self.inner.borrow();
+			if !borrowed.dom.contains(self.node_id) {
+				return Err(EventError::DetachedElement);
+			}
+			if borrowed.dom.element(self.node_id).is_none() {
+				return Err(EventError::UnsupportedElement);
+			}
+			borrowed.dom.event_handler(self.node_id, event_type)
+		};
+
+		let handler = handler.ok_or(EventError::MissingHandler)?;
+		handler(DummyEvent);
+		Ok(())
+	}
+
+	fn dispatch_value(&self, event_type: EventType, value: String) -> Result<(), EventError> {
+		let handler = {
+			let mut borrowed = self.inner.borrow_mut();
+			if !borrowed.dom.contains(self.node_id) {
+				return Err(EventError::DetachedElement);
+			}
+			if !borrowed.dom.set_value(self.node_id, value) {
+				return Err(EventError::UnsupportedElement);
+			}
+			borrowed.dom.event_handler(self.node_id, event_type)
+		};
+
+		let handler = handler.ok_or(EventError::MissingHandler)?;
+		handler(DummyEvent);
+		Ok(())
+	}
+}
+
+impl std::fmt::Debug for ElementHandle {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ElementHandle")
+			.field("node_id", &self.node_id)
+			.finish_non_exhaustive()
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/events.rs
+++ b/crates/reinhardt-pages/src/testing/component/events.rs
@@ -6,6 +6,8 @@ use std::rc::Rc;
 use reinhardt_core::types::page::{DummyEvent, EventType};
 
 use super::error::EventError;
+#[cfg(feature = "msw")]
+use super::server_fn_mock;
 use super::tree::{NodeId, ScreenInner};
 
 /// Stable handle to an element in a rendered native test screen.
@@ -71,7 +73,7 @@ impl ElementHandle {
 	}
 
 	fn dispatch(&self, event_type: EventType) -> Result<(), EventError> {
-		let handler = {
+		let (handler, scheduler) = {
 			let borrowed = self.inner.borrow();
 			if !borrowed.dom.contains(self.node_id) {
 				return Err(EventError::DetachedElement);
@@ -79,16 +81,27 @@ impl ElementHandle {
 			if borrowed.dom.element(self.node_id).is_none() {
 				return Err(EventError::UnsupportedElement);
 			}
-			borrowed.dom.event_handler(self.node_id, event_type)
+			(
+				borrowed.dom.event_handler(self.node_id, event_type),
+				Rc::clone(&borrowed.scheduler),
+			)
 		};
+		#[cfg(feature = "msw")]
+		let mocks = self.inner.borrow().mocks.clone();
 
 		let handler = handler.ok_or(EventError::MissingHandler)?;
-		handler(DummyEvent);
+		#[cfg(feature = "msw")]
+		{
+			let _mock_scope = server_fn_mock::activate(mocks);
+			scheduler.with_current(|| handler(DummyEvent));
+		}
+		#[cfg(not(feature = "msw"))]
+		scheduler.with_current(|| handler(DummyEvent));
 		Ok(())
 	}
 
 	fn dispatch_value(&self, event_type: EventType, value: String) -> Result<(), EventError> {
-		let handler = {
+		let (handler, scheduler) = {
 			let mut borrowed = self.inner.borrow_mut();
 			if !borrowed.dom.contains(self.node_id) {
 				return Err(EventError::DetachedElement);
@@ -96,11 +109,22 @@ impl ElementHandle {
 			if !borrowed.dom.set_value(self.node_id, value) {
 				return Err(EventError::UnsupportedElement);
 			}
-			borrowed.dom.event_handler(self.node_id, event_type)
+			(
+				borrowed.dom.event_handler(self.node_id, event_type),
+				Rc::clone(&borrowed.scheduler),
+			)
 		};
+		#[cfg(feature = "msw")]
+		let mocks = self.inner.borrow().mocks.clone();
 
 		let handler = handler.ok_or(EventError::MissingHandler)?;
-		handler(DummyEvent);
+		#[cfg(feature = "msw")]
+		{
+			let _mock_scope = server_fn_mock::activate(mocks);
+			scheduler.with_current(|| handler(DummyEvent));
+		}
+		#[cfg(not(feature = "msw"))]
+		scheduler.with_current(|| handler(DummyEvent));
 		Ok(())
 	}
 }

--- a/crates/reinhardt-pages/src/testing/component/events.rs
+++ b/crates/reinhardt-pages/src/testing/component/events.rs
@@ -81,6 +81,9 @@ impl ElementHandle {
 			if borrowed.dom.element(self.node_id).is_none() {
 				return Err(EventError::UnsupportedElement);
 			}
+			if borrowed.dom.suppresses_events(self.node_id) {
+				return Ok(());
+			}
 			(
 				borrowed.dom.event_handler(self.node_id, event_type),
 				Rc::clone(&borrowed.scheduler),
@@ -105,6 +108,9 @@ impl ElementHandle {
 			let mut borrowed = self.inner.borrow_mut();
 			if !borrowed.dom.contains(self.node_id) {
 				return Err(EventError::DetachedElement);
+			}
+			if borrowed.dom.suppresses_events(self.node_id) {
+				return Ok(());
 			}
 			if !borrowed.dom.set_value(self.node_id, value) {
 				return Err(EventError::UnsupportedElement);

--- a/crates/reinhardt-pages/src/testing/component/pretty.rs
+++ b/crates/reinhardt-pages/src/testing/component/pretty.rs
@@ -1,0 +1,57 @@
+//! Pretty-printer for native component test DOM trees.
+
+use super::tree::{NodeId, TestDom};
+
+pub(crate) fn pretty_dom(dom: &TestDom) -> String {
+	let mut output = String::new();
+	for child in dom.children(dom.root()) {
+		write_node(dom, *child, 0, &mut output);
+	}
+	output
+}
+
+fn write_node(dom: &TestDom, node_id: NodeId, depth: usize, output: &mut String) {
+	if let Some(text) = dom.text_node(node_id) {
+		output.push_str(&"  ".repeat(depth));
+		output.push_str(text);
+		output.push('\n');
+		return;
+	}
+
+	let Some(element) = dom.element(node_id) else {
+		for child in dom.children(node_id) {
+			write_node(dom, *child, depth, output);
+		}
+		return;
+	};
+
+	output.push_str(&"  ".repeat(depth));
+	output.push('<');
+	output.push_str(&element.tag);
+	for (name, value) in element.attrs() {
+		output.push(' ');
+		output.push_str(name);
+		output.push_str("=\"");
+		output.push_str(&escape_attr(value));
+		output.push('"');
+	}
+	output.push_str(">\n");
+
+	if !dom.is_void(node_id) {
+		for child in dom.children(node_id) {
+			write_node(dom, *child, depth + 1, output);
+		}
+		output.push_str(&"  ".repeat(depth));
+		output.push_str("</");
+		output.push_str(&element.tag);
+		output.push_str(">\n");
+	}
+}
+
+fn escape_attr(value: &str) -> String {
+	value
+		.replace('&', "&amp;")
+		.replace('"', "&quot;")
+		.replace('<', "&lt;")
+		.replace('>', "&gt;")
+}

--- a/crates/reinhardt-pages/src/testing/component/query.rs
+++ b/crates/reinhardt-pages/src/testing/component/query.rs
@@ -1,0 +1,129 @@
+//! Query engine for the native component test DOM.
+
+use super::error::QueryError;
+use super::events::ElementHandle;
+use super::role::{Role, accessible_name, role_for};
+use super::text_match::TextMatch;
+use super::tree::{NodeId, ScreenInner};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub(crate) fn by_text(
+	inner: &Rc<RefCell<ScreenInner>>,
+	text: TextMatch,
+) -> Result<ElementHandle, QueryError> {
+	one(inner, find_by_text(&inner.borrow(), &text))
+}
+
+pub(crate) fn query_by_text(
+	inner: &Rc<RefCell<ScreenInner>>,
+	text: TextMatch,
+) -> Result<Option<ElementHandle>, QueryError> {
+	let matches = find_by_text(&inner.borrow(), &text);
+	match matches.len() {
+		0 => Ok(None),
+		1 => Ok(Some(ElementHandle::new(inner.clone(), matches[0]))),
+		_ => Err(QueryError::MultipleMatches),
+	}
+}
+
+pub(crate) fn by_role_named(
+	inner: &Rc<RefCell<ScreenInner>>,
+	role: Role,
+	name: TextMatch,
+) -> Result<ElementHandle, QueryError> {
+	one(inner, find_by_role(&inner.borrow(), role, Some(&name)))
+}
+
+pub(crate) fn by_label(
+	inner: &Rc<RefCell<ScreenInner>>,
+	label: TextMatch,
+) -> Result<ElementHandle, QueryError> {
+	let borrowed = inner.borrow();
+	let matches = borrowed
+		.dom
+		.visible_elements()
+		.into_iter()
+		.filter(|node_id| {
+			borrowed.dom.element(*node_id).is_some_and(|node| {
+				node.supports_value()
+					&& accessible_name(&borrowed.dom, *node_id)
+						.as_deref()
+						.is_some_and(|name| label.matches(name))
+			})
+		})
+		.collect();
+	one(inner, matches)
+}
+
+pub(crate) fn by_placeholder(
+	inner: &Rc<RefCell<ScreenInner>>,
+	placeholder: TextMatch,
+) -> Result<ElementHandle, QueryError> {
+	let borrowed = inner.borrow();
+	let matches = borrowed
+		.dom
+		.visible_elements()
+		.into_iter()
+		.filter(|node_id| {
+			borrowed.dom.element(*node_id).is_some_and(|node| {
+				node.supports_value()
+					&& node
+						.attr("placeholder")
+						.is_some_and(|value| placeholder.matches(value))
+			})
+		})
+		.collect();
+	one(inner, matches)
+}
+
+fn one(
+	inner: &Rc<RefCell<ScreenInner>>,
+	matches: Vec<NodeId>,
+) -> Result<ElementHandle, QueryError> {
+	match matches.len() {
+		0 => Err(QueryError::NotFound),
+		1 => Ok(ElementHandle::new(inner.clone(), matches[0])),
+		_ => Err(QueryError::MultipleMatches),
+	}
+}
+
+fn find_by_text(inner: &ScreenInner, text: &TextMatch) -> Vec<NodeId> {
+	inner
+		.dom
+		.visible_elements()
+		.into_iter()
+		.filter(|node_id| element_has_exact_text_without_duplicate_child(inner, *node_id, text))
+		.collect()
+}
+
+fn find_by_role(inner: &ScreenInner, role: Role, name: Option<&TextMatch>) -> Vec<NodeId> {
+	inner
+		.dom
+		.visible_elements()
+		.into_iter()
+		.filter(|node_id| role_for(&inner.dom, *node_id) == Some(role))
+		.filter(|node_id| {
+			name.is_none_or(|name| {
+				accessible_name(&inner.dom, *node_id)
+					.as_deref()
+					.is_some_and(|candidate| name.matches(candidate))
+			})
+		})
+		.collect()
+}
+
+fn element_has_exact_text_without_duplicate_child(
+	inner: &ScreenInner,
+	node_id: NodeId,
+	text: &TextMatch,
+) -> bool {
+	if !text.matches(&inner.dom.text_content(node_id)) {
+		return false;
+	}
+	!inner.dom.children(node_id).iter().any(|child| {
+		inner.dom.element(*child).is_some()
+			&& !inner.dom.is_hidden(*child)
+			&& text.matches(&inner.dom.text_content(*child))
+	})
+}

--- a/crates/reinhardt-pages/src/testing/component/query.rs
+++ b/crates/reinhardt-pages/src/testing/component/query.rs
@@ -118,12 +118,12 @@ fn element_has_exact_text_without_duplicate_child(
 	node_id: NodeId,
 	text: &TextMatch,
 ) -> bool {
-	if !text.matches(&inner.dom.text_content(node_id)) {
+	if !text.matches(&inner.dom.visible_text_content(node_id)) {
 		return false;
 	}
 	!inner.dom.children(node_id).iter().any(|child| {
 		inner.dom.element(*child).is_some()
 			&& !inner.dom.is_hidden(*child)
-			&& text.matches(&inner.dom.text_content(*child))
+			&& text.matches(&inner.dom.visible_text_content(*child))
 	})
 }

--- a/crates/reinhardt-pages/src/testing/component/role.rs
+++ b/crates/reinhardt-pages/src/testing/component/role.rs
@@ -68,8 +68,8 @@ impl Role {
 		}
 	}
 
-	pub(crate) fn from_role_attr(value: &str) -> Option<Self> {
-		match value.split_whitespace().next()? {
+	fn from_role_token(value: &str) -> Option<Self> {
+		match value {
 			"alert" => Some(Self::Alert),
 			"button" => Some(Self::Button),
 			"checkbox" => Some(Self::Checkbox),
@@ -101,14 +101,14 @@ impl std::fmt::Display for Role {
 
 pub(crate) fn role_for(dom: &TestDom, node_id: NodeId) -> Option<Role> {
 	let node = dom.element(node_id)?;
-	if let Some(role_attr) = node.attr("role")
-		&& let Some(first_role) = role_attr.split_whitespace().next()
-	{
-		if matches!(first_role, "presentation" | "none") {
-			return None;
-		}
-		if let Some(role) = Role::from_role_attr(role_attr) {
-			return Some(role);
+	if let Some(role_attr) = node.attr("role") {
+		for token in role_attr.split_whitespace() {
+			if matches!(token, "presentation" | "none") {
+				return None;
+			}
+			if let Some(role) = Role::from_role_token(token) {
+				return Some(role);
+			}
 		}
 	}
 
@@ -154,30 +154,53 @@ pub(crate) fn accessible_name(dom: &TestDom, node_id: NodeId) -> Option<String> 
 	if let Some(id) = node.attr("id")
 		&& let Some(label) = dom.label_for(id)
 	{
-		return non_empty(&dom.text_content(label));
+		return non_empty(&dom.visible_text_content(label));
 	}
 
 	if let Some(label) = dom.closest_label(node_id) {
-		return non_empty(&dom.text_content(label));
+		return non_empty(&dom.visible_text_content(label));
+	}
+
+	if let Some(name) = input_button_name(node) {
+		return Some(name);
 	}
 
 	if matches!(
 		role_for(dom, node_id),
 		Some(Role::Button | Role::Link | Role::Heading)
 	) {
-		return non_empty(&dom.text_content(node_id));
+		return non_empty(&dom.visible_text_content(node_id));
 	}
 
 	None
 }
 
 fn input_role(input_type: &str) -> Option<Role> {
-	match input_type {
+	match input_type.to_ascii_lowercase().as_str() {
 		"button" | "image" | "reset" | "submit" => Some(Role::Button),
 		"checkbox" => Some(Role::Checkbox),
 		"radio" => Some(Role::Radio),
-		"hidden" => None,
-		_ => Some(Role::Textbox),
+		"" | "email" | "search" | "tel" | "text" | "url" => Some(Role::Textbox),
+		_ => None,
+	}
+}
+
+fn input_button_name(node: &super::tree::ElementNode) -> Option<String> {
+	if node.tag != "input" {
+		return None;
+	}
+	match node
+		.attr("type")
+		.unwrap_or("text")
+		.to_ascii_lowercase()
+		.as_str()
+	{
+		"button" | "reset" | "submit" => node.attr("value").and_then(non_empty),
+		"image" => node
+			.attr("alt")
+			.or_else(|| node.attr("value"))
+			.and_then(non_empty),
+		_ => None,
 	}
 }
 

--- a/crates/reinhardt-pages/src/testing/component/role.rs
+++ b/crates/reinhardt-pages/src/testing/component/role.rs
@@ -1,0 +1,183 @@
+//! Accessible role support for native component queries.
+
+use super::tree::{NodeId, TestDom};
+
+/// ARIA role supported by the native component test harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Role {
+	/// Alert role.
+	Alert,
+	/// Button role.
+	Button,
+	/// Checkbox role.
+	Checkbox,
+	/// Combobox role.
+	Combobox,
+	/// Dialog role.
+	Dialog,
+	/// Form role.
+	Form,
+	/// Heading role.
+	Heading,
+	/// Link role.
+	Link,
+	/// List role.
+	List,
+	/// Listbox role.
+	Listbox,
+	/// List item role.
+	ListItem,
+	/// Main landmark role.
+	Main,
+	/// Navigation landmark role.
+	Navigation,
+	/// Option role.
+	Option,
+	/// Progressbar role.
+	Progressbar,
+	/// Radio role.
+	Radio,
+	/// Status role.
+	Status,
+	/// Textbox role.
+	Textbox,
+}
+
+impl Role {
+	/// Returns the canonical ARIA role name.
+	pub fn as_str(self) -> &'static str {
+		match self {
+			Self::Alert => "alert",
+			Self::Button => "button",
+			Self::Checkbox => "checkbox",
+			Self::Combobox => "combobox",
+			Self::Dialog => "dialog",
+			Self::Form => "form",
+			Self::Heading => "heading",
+			Self::Link => "link",
+			Self::List => "list",
+			Self::Listbox => "listbox",
+			Self::ListItem => "listitem",
+			Self::Main => "main",
+			Self::Navigation => "navigation",
+			Self::Option => "option",
+			Self::Progressbar => "progressbar",
+			Self::Radio => "radio",
+			Self::Status => "status",
+			Self::Textbox => "textbox",
+		}
+	}
+
+	pub(crate) fn from_role_attr(value: &str) -> Option<Self> {
+		match value.split_whitespace().next()? {
+			"alert" => Some(Self::Alert),
+			"button" => Some(Self::Button),
+			"checkbox" => Some(Self::Checkbox),
+			"combobox" => Some(Self::Combobox),
+			"dialog" => Some(Self::Dialog),
+			"form" => Some(Self::Form),
+			"heading" => Some(Self::Heading),
+			"link" => Some(Self::Link),
+			"list" => Some(Self::List),
+			"listbox" => Some(Self::Listbox),
+			"listitem" => Some(Self::ListItem),
+			"main" => Some(Self::Main),
+			"navigation" => Some(Self::Navigation),
+			"option" => Some(Self::Option),
+			"progressbar" => Some(Self::Progressbar),
+			"radio" => Some(Self::Radio),
+			"status" => Some(Self::Status),
+			"textbox" => Some(Self::Textbox),
+			_ => None,
+		}
+	}
+}
+
+impl std::fmt::Display for Role {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.write_str(self.as_str())
+	}
+}
+
+pub(crate) fn role_for(dom: &TestDom, node_id: NodeId) -> Option<Role> {
+	let node = dom.element(node_id)?;
+	if let Some(role) = node.attr("role").and_then(Role::from_role_attr) {
+		return Some(role);
+	}
+
+	match node.tag.as_str() {
+		"a" if node.attr("href").is_some() => Some(Role::Link),
+		"button" => Some(Role::Button),
+		"dialog" => Some(Role::Dialog),
+		"form" => Some(Role::Form),
+		"h1" | "h2" | "h3" | "h4" | "h5" | "h6" => Some(Role::Heading),
+		"input" => input_role(node.attr("type").unwrap_or("text")),
+		"li" => Some(Role::ListItem),
+		"main" => Some(Role::Main),
+		"nav" => Some(Role::Navigation),
+		"ol" | "ul" => Some(Role::List),
+		"option" => Some(Role::Option),
+		"progress" => Some(Role::Progressbar),
+		"select" if node.has_attr("multiple") => Some(Role::Listbox),
+		"select" => Some(Role::Combobox),
+		"textarea" => Some(Role::Textbox),
+		_ => None,
+	}
+}
+
+pub(crate) fn accessible_name(dom: &TestDom, node_id: NodeId) -> Option<String> {
+	let node = dom.element(node_id)?;
+	if let Some(label) = node.attr("aria-label") {
+		return non_empty(label);
+	}
+
+	if let Some(labelledby) = node.attr("aria-labelledby") {
+		let label = labelledby
+			.split_whitespace()
+			.filter_map(|id| dom.find_element_by_id(id))
+			.map(|id| dom.text_content(id))
+			.filter(|text| !text.is_empty())
+			.collect::<Vec<_>>()
+			.join(" ");
+		if !label.is_empty() {
+			return Some(label);
+		}
+	}
+
+	if let Some(id) = node.attr("id")
+		&& let Some(label) = dom.label_for(id)
+	{
+		return non_empty(&dom.text_content(label));
+	}
+
+	if let Some(label) = dom.closest_label(node_id) {
+		return non_empty(&dom.text_content(label));
+	}
+
+	if matches!(
+		role_for(dom, node_id),
+		Some(Role::Button | Role::Link | Role::Heading)
+	) {
+		return non_empty(&dom.text_content(node_id));
+	}
+
+	node.attr("placeholder").and_then(non_empty)
+}
+
+fn input_role(input_type: &str) -> Option<Role> {
+	match input_type {
+		"button" | "image" | "reset" | "submit" => Some(Role::Button),
+		"checkbox" => Some(Role::Checkbox),
+		"radio" => Some(Role::Radio),
+		"hidden" => None,
+		_ => Some(Role::Textbox),
+	}
+}
+
+fn non_empty(value: &str) -> Option<String> {
+	if value.is_empty() {
+		None
+	} else {
+		Some(value.to_string())
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/role.rs
+++ b/crates/reinhardt-pages/src/testing/component/role.rs
@@ -101,8 +101,15 @@ impl std::fmt::Display for Role {
 
 pub(crate) fn role_for(dom: &TestDom, node_id: NodeId) -> Option<Role> {
 	let node = dom.element(node_id)?;
-	if let Some(role) = node.attr("role").and_then(Role::from_role_attr) {
-		return Some(role);
+	if let Some(role_attr) = node.attr("role")
+		&& let Some(first_role) = role_attr.split_whitespace().next()
+	{
+		if matches!(first_role, "presentation" | "none") {
+			return None;
+		}
+		if let Some(role) = Role::from_role_attr(role_attr) {
+			return Some(role);
+		}
 	}
 
 	match node.tag.as_str() {
@@ -161,7 +168,7 @@ pub(crate) fn accessible_name(dom: &TestDom, node_id: NodeId) -> Option<String> 
 		return non_empty(&dom.text_content(node_id));
 	}
 
-	node.attr("placeholder").and_then(non_empty)
+	None
 }
 
 fn input_role(input_type: &str) -> Option<Role> {

--- a/crates/reinhardt-pages/src/testing/component/scheduler.rs
+++ b/crates/reinhardt-pages/src/testing/component/scheduler.rs
@@ -6,10 +6,13 @@ use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll, Waker};
+use std::time::Duration;
 
 use crate::platform;
 
 type BoxedTask = Pin<Box<dyn Future<Output = ()> + 'static>>;
+const SETTLE_BACKOFF_AFTER_YIELDS: usize = 4;
+const SETTLE_BACKOFF: Duration = Duration::from_millis(1);
 
 /// Error returned when the native component scheduler cannot settle.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,7 +86,11 @@ impl SchedulerScope {
 			if pending_tasks == 0 {
 				return Ok(());
 			}
-			tokio::task::yield_now().await;
+			if iteration < SETTLE_BACKOFF_AFTER_YIELDS {
+				tokio::task::yield_now().await;
+			} else {
+				tokio::time::sleep(SETTLE_BACKOFF).await;
+			}
 			if iteration == 99 {
 				return Err(SettleError::DidNotQuiesce {
 					iterations: 100,

--- a/crates/reinhardt-pages/src/testing/component/scheduler.rs
+++ b/crates/reinhardt-pages/src/testing/component/scheduler.rs
@@ -1,0 +1,94 @@
+//! Native async scheduler for component tests.
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll, Waker};
+
+use crate::platform;
+
+type BoxedTask = Pin<Box<dyn Future<Output = ()> + 'static>>;
+
+/// Error returned when the native component scheduler cannot settle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettleError {
+	/// Pending work did not quiesce before the harness limit.
+	DidNotQuiesce {
+		/// Number of settle iterations attempted.
+		iterations: usize,
+		/// Number of tasks still pending after the last iteration.
+		pending_tasks: usize,
+		/// Pretty DOM output captured when settle failed.
+		dom: String,
+	},
+}
+
+impl std::fmt::Display for SettleError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::DidNotQuiesce {
+				iterations,
+				pending_tasks,
+				dom,
+			} => write!(
+				f,
+				"scheduled work did not quiesce after {iterations} iterations with {pending_tasks} pending tasks\n\n{dom}"
+			),
+		}
+	}
+}
+
+impl std::error::Error for SettleError {}
+
+#[derive(Default)]
+pub(crate) struct TestScheduler {
+	tasks: VecDeque<BoxedTask>,
+}
+
+pub(crate) struct SchedulerScope {
+	scheduler: Rc<RefCell<TestScheduler>>,
+	_guard: platform::NativeTaskSinkGuard,
+}
+
+impl SchedulerScope {
+	pub(crate) fn new() -> Self {
+		let scheduler = Rc::new(RefCell::new(TestScheduler::default()));
+		let scheduler_for_sink = Rc::clone(&scheduler);
+		let guard = platform::install_task_sink(move |task| {
+			scheduler_for_sink.borrow_mut().tasks.push_back(task);
+		});
+		Self {
+			scheduler,
+			_guard: guard,
+		}
+	}
+
+	pub(crate) async fn settle(&self, dom: impl Fn() -> String) -> Result<(), SettleError> {
+		let mut cx = Context::from_waker(Waker::noop());
+		for iteration in 0..100 {
+			let mut pending = VecDeque::new();
+			while let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() {
+				match task.as_mut().poll(&mut cx) {
+					Poll::Ready(()) => {}
+					Poll::Pending => pending.push_back(task),
+				}
+			}
+			let pending_tasks = pending.len();
+			self.scheduler.borrow_mut().tasks = pending;
+			if pending_tasks == 0 {
+				return Ok(());
+			}
+			tokio::task::yield_now().await;
+			if iteration == 99 {
+				return Err(SettleError::DidNotQuiesce {
+					iterations: 100,
+					pending_tasks,
+					dom: dom(),
+				});
+			}
+		}
+		unreachable!("settle loop returns inside fixed iteration range")
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/scheduler.rs
+++ b/crates/reinhardt-pages/src/testing/component/scheduler.rs
@@ -73,14 +73,19 @@ impl SchedulerScope {
 		for iteration in 0..100 {
 			let mut pending = VecDeque::new();
 			let pending_tasks = self.with_current(|| {
-				while let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() {
+				loop {
+					let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() else {
+						break;
+					};
 					match task.as_mut().poll(&mut cx) {
 						Poll::Ready(()) => {}
 						Poll::Pending => pending.push_back(task),
 					}
 				}
+				let mut scheduler = self.scheduler.borrow_mut();
+				pending.extend(std::mem::take(&mut scheduler.tasks));
 				let pending_tasks = pending.len();
-				self.scheduler.borrow_mut().tasks = pending;
+				scheduler.tasks = pending;
 				pending_tasks
 			});
 			if pending_tasks == 0 {
@@ -100,5 +105,9 @@ impl SchedulerScope {
 			}
 		}
 		unreachable!("settle loop returns inside fixed iteration range")
+	}
+
+	pub(crate) fn pending_task_count(&self) -> usize {
+		self.scheduler.borrow().tasks.len()
 	}
 }

--- a/crates/reinhardt-pages/src/testing/component/scheduler.rs
+++ b/crates/reinhardt-pages/src/testing/component/scheduler.rs
@@ -49,34 +49,37 @@ pub(crate) struct TestScheduler {
 
 pub(crate) struct SchedulerScope {
 	scheduler: Rc<RefCell<TestScheduler>>,
-	_guard: platform::NativeTaskSinkGuard,
 }
 
 impl SchedulerScope {
 	pub(crate) fn new() -> Self {
 		let scheduler = Rc::new(RefCell::new(TestScheduler::default()));
-		let scheduler_for_sink = Rc::clone(&scheduler);
-		let guard = platform::install_task_sink(move |task| {
-			scheduler_for_sink.borrow_mut().tasks.push_back(task);
+		Self { scheduler }
+	}
+
+	pub(crate) fn with_current<R>(&self, f: impl FnOnce() -> R) -> R {
+		let scheduler = Rc::clone(&self.scheduler);
+		let _guard = platform::install_task_sink(move |task| {
+			scheduler.borrow_mut().tasks.push_back(task);
 		});
-		Self {
-			scheduler,
-			_guard: guard,
-		}
+		f()
 	}
 
 	pub(crate) async fn settle(&self, dom: impl Fn() -> String) -> Result<(), SettleError> {
 		let mut cx = Context::from_waker(Waker::noop());
 		for iteration in 0..100 {
 			let mut pending = VecDeque::new();
-			while let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() {
-				match task.as_mut().poll(&mut cx) {
-					Poll::Ready(()) => {}
-					Poll::Pending => pending.push_back(task),
+			let pending_tasks = self.with_current(|| {
+				while let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() {
+					match task.as_mut().poll(&mut cx) {
+						Poll::Ready(()) => {}
+						Poll::Pending => pending.push_back(task),
+					}
 				}
-			}
-			let pending_tasks = pending.len();
-			self.scheduler.borrow_mut().tasks = pending;
+				let pending_tasks = pending.len();
+				self.scheduler.borrow_mut().tasks = pending;
+				pending_tasks
+			});
 			if pending_tasks == 0 {
 				return Ok(());
 			}

--- a/crates/reinhardt-pages/src/testing/component/screen.rs
+++ b/crates/reinhardt-pages/src/testing/component/screen.rs
@@ -1,0 +1,261 @@
+//! Rendered native component screen.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use reinhardt_core::types::page::{IntoPage, Page, PageElement};
+
+use super::error::QueryError;
+use super::events::ElementHandle;
+use super::pretty::pretty_dom;
+use super::query;
+use super::role::Role;
+use super::scheduler::{SchedulerScope, SettleError};
+#[cfg(feature = "msw")]
+use super::server_fn_mock::{self, ServerFnCallQuery, SharedServerFnMocks};
+use super::text_match::TextMatch;
+use super::tree::{ScreenInner, TestDom, shared_screen_inner};
+
+/// Rendered native component test screen.
+#[derive(Clone)]
+pub struct Screen {
+	inner: Rc<RefCell<ScreenInner>>,
+}
+
+/// Input accepted by [`render`] and [`Screen::render`].
+pub trait TestRender {
+	/// Builds the page while the native test harness scopes are active.
+	fn render_page(self) -> Page;
+}
+
+impl TestRender for Page {
+	fn render_page(self) -> Page {
+		self
+	}
+}
+
+impl TestRender for PageElement {
+	fn render_page(self) -> Page {
+		self.into_page()
+	}
+}
+
+impl<F, P> TestRender for F
+where
+	F: FnOnce() -> P,
+	P: IntoPage,
+{
+	fn render_page(self) -> Page {
+		self().into_page()
+	}
+}
+
+/// Renders a Page into a native component test screen.
+pub fn render(view: impl TestRender) -> Screen {
+	Screen::render(view)
+}
+
+impl Screen {
+	/// Renders a Page into a native component test screen.
+	pub fn render(view: impl TestRender) -> Self {
+		let scheduler = Rc::new(SchedulerScope::new());
+		#[cfg(feature = "msw")]
+		{
+			let mocks = SharedServerFnMocks::default();
+			let mock_scope = server_fn_mock::activate(mocks.clone());
+			let page = view.render_page();
+			let dom = TestDom::render(page);
+			Self {
+				inner: shared_screen_inner(dom, scheduler, mocks, mock_scope),
+			}
+		}
+		#[cfg(not(feature = "msw"))]
+		{
+			let page = view.render_page();
+			Self {
+				inner: shared_screen_inner(TestDom::render(page), scheduler),
+			}
+		}
+	}
+
+	/// Returns a stable pretty representation of the rendered DOM.
+	pub fn pretty(&self) -> String {
+		pretty_dom(&self.inner.borrow().dom)
+	}
+
+	/// Returns exactly one element by exact text.
+	pub fn get(&self, text: impl Into<TextMatch>) -> ElementHandle {
+		self.get_by_text(text)
+	}
+
+	/// Tries to return exactly one element by exact text.
+	pub fn try_get(&self, text: impl Into<TextMatch>) -> Result<ElementHandle, QueryError> {
+		self.try_get_by_text(text)
+	}
+
+	/// Returns exactly one element by exact text.
+	pub fn get_by_text(&self, text: impl Into<TextMatch>) -> ElementHandle {
+		self.try_get_by_text(text).expect("text query failed")
+	}
+
+	/// Tries to return exactly one element by exact text.
+	pub fn try_get_by_text(&self, text: impl Into<TextMatch>) -> Result<ElementHandle, QueryError> {
+		query::by_text(&self.inner, text.into())
+	}
+
+	/// Returns zero or one element by exact text.
+	pub fn query_by_text(&self, text: impl Into<TextMatch>) -> Option<ElementHandle> {
+		match query::query_by_text(&self.inner, text.into()) {
+			Ok(handle) => handle,
+			Err(QueryError::NotFound) => None,
+			Err(err) => panic!("{err}"),
+		}
+	}
+
+	/// Returns exactly one element by accessible role and name.
+	pub fn get_by_role(&self, role: Role, name: impl Into<TextMatch>) -> ElementHandle {
+		self.try_get_by_role(role, name)
+			.expect("named role query failed")
+	}
+
+	/// Tries to return exactly one element by accessible role and name.
+	pub fn try_get_by_role(
+		&self,
+		role: Role,
+		name: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		query::by_role_named(&self.inner, role, name.into())
+	}
+
+	/// Returns exactly one element by accessible role and name.
+	pub fn get_by_role_named(&self, role: Role, name: impl Into<TextMatch>) -> ElementHandle {
+		self.get_by_role(role, name)
+	}
+
+	/// Tries to return exactly one element by accessible role and name.
+	pub fn try_get_by_role_named(
+		&self,
+		role: Role,
+		name: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		self.try_get_by_role(role, name)
+	}
+
+	/// Returns exactly one element by accessible label.
+	pub fn get_by_label(&self, label: impl Into<TextMatch>) -> ElementHandle {
+		self.try_get_by_label(label).expect("label query failed")
+	}
+
+	/// Tries to return exactly one element by accessible label.
+	pub fn try_get_by_label(
+		&self,
+		label: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		query::by_label(&self.inner, label.into())
+	}
+
+	/// Returns exactly one element by placeholder text.
+	pub fn get_by_placeholder(&self, placeholder: impl Into<TextMatch>) -> ElementHandle {
+		self.try_get_by_placeholder(placeholder)
+			.expect("placeholder query failed")
+	}
+
+	/// Tries to return exactly one element by placeholder text.
+	pub fn try_get_by_placeholder(
+		&self,
+		placeholder: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		query::by_placeholder(&self.inner, placeholder.into())
+	}
+
+	/// Waits for scheduled native component work and rerenders reactive anchors.
+	pub async fn settle(&self) {
+		self.try_settle()
+			.await
+			.unwrap_or_else(|err| panic!("{err}"));
+	}
+
+	/// Tries to settle scheduled native component work.
+	pub async fn try_settle(&self) -> Result<(), SettleError> {
+		let scheduler = Rc::clone(&self.inner.borrow().scheduler);
+		scheduler.settle(|| self.pretty()).await?;
+		self.inner.borrow_mut().dom.rerender_reactive_anchors();
+		Ok(())
+	}
+
+	/// Finds an element by text after settling scheduled work.
+	pub async fn find_by_text(&self, text: impl Into<TextMatch>) -> ElementHandle {
+		self.try_find_by_text(text)
+			.await
+			.unwrap_or_else(|err| panic!("{err}"))
+	}
+
+	/// Tries to find an element by text after settling scheduled work.
+	pub async fn try_find_by_text(
+		&self,
+		text: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		let text = text.into();
+		for _ in 0..50 {
+			match self.try_get_by_text(text.clone()) {
+				Ok(handle) => return Ok(handle),
+				Err(QueryError::NotFound) => {
+					self.try_settle().await.map_err(|_| QueryError::NotFound)?;
+				}
+				Err(err) => return Err(err),
+			}
+			tokio::task::yield_now().await;
+		}
+		Err(QueryError::NotFound)
+	}
+
+	/// Finds an element by role and accessible name after settling scheduled work.
+	pub async fn find_by_role(&self, role: Role, name: impl Into<TextMatch>) -> ElementHandle {
+		self.try_find_by_role(role, name)
+			.await
+			.unwrap_or_else(|err| panic!("{err}"))
+	}
+
+	/// Tries to find an element by role and accessible name after settling scheduled work.
+	pub async fn try_find_by_role(
+		&self,
+		role: Role,
+		name: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		let name = name.into();
+		for _ in 0..50 {
+			match self.try_get_by_role(role, name.clone()) {
+				Ok(handle) => return Ok(handle),
+				Err(QueryError::NotFound) => {
+					self.try_settle().await.map_err(|_| QueryError::NotFound)?;
+				}
+				Err(err) => return Err(err),
+			}
+			tokio::task::yield_now().await;
+		}
+		Err(QueryError::NotFound)
+	}
+
+	/// Registers a typed server function mock for this screen.
+	#[cfg(feature = "msw")]
+	pub fn mock_server_fn<S>(
+		&self,
+		handler: impl Fn(S::Args) -> Result<S::Response, crate::server_fn::ServerFnError> + 'static,
+	) where
+		S: crate::server_fn::MockableServerFn + 'static,
+		S::Args: Clone + 'static,
+		S::Response: 'static,
+	{
+		self.inner.borrow().mocks.mock_server_fn::<S>(handler);
+	}
+
+	/// Returns recorded calls for a typed server function mock.
+	#[cfg(feature = "msw")]
+	pub fn calls_to_server_fn<S>(&self) -> ServerFnCallQuery<S>
+	where
+		S: crate::server_fn::MockableServerFn + 'static,
+		S::Args: Clone + 'static,
+	{
+		self.inner.borrow().mocks.calls_to_server_fn::<S>()
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/screen.rs
+++ b/crates/reinhardt-pages/src/testing/component/screen.rs
@@ -62,18 +62,18 @@ impl Screen {
 		#[cfg(feature = "msw")]
 		{
 			let mocks = SharedServerFnMocks::default();
-			let mock_scope = server_fn_mock::activate(mocks.clone());
-			let page = view.render_page();
-			let dom = TestDom::render(page);
+			let dom = scheduler.with_current(|| {
+				server_fn_mock::with_active(mocks.clone(), || TestDom::render(view.render_page()))
+			});
 			Self {
-				inner: shared_screen_inner(dom, scheduler, mocks, mock_scope),
+				inner: shared_screen_inner(dom, scheduler, mocks),
 			}
 		}
 		#[cfg(not(feature = "msw"))]
 		{
-			let page = view.render_page();
+			let dom = scheduler.with_current(|| TestDom::render(view.render_page()));
 			Self {
-				inner: shared_screen_inner(TestDom::render(page), scheduler),
+				inner: shared_screen_inner(dom, scheduler),
 			}
 		}
 	}
@@ -177,9 +177,21 @@ impl Screen {
 
 	/// Tries to settle scheduled native component work.
 	pub async fn try_settle(&self) -> Result<(), SettleError> {
+		#[cfg(feature = "msw")]
+		let (scheduler, mocks) = {
+			let inner = self.inner.borrow();
+			(Rc::clone(&inner.scheduler), inner.mocks.clone())
+		};
+		#[cfg(not(feature = "msw"))]
 		let scheduler = Rc::clone(&self.inner.borrow().scheduler);
+
+		#[cfg(feature = "msw")]
+		let _mock_scope = server_fn_mock::activate(mocks);
+
 		scheduler.settle(|| self.pretty()).await?;
-		self.inner.borrow_mut().dom.rerender_reactive_anchors();
+		scheduler.with_current(|| {
+			self.inner.borrow_mut().dom.rerender_reactive_anchors();
+		});
 		Ok(())
 	}
 
@@ -206,7 +218,7 @@ impl Screen {
 			}
 			tokio::task::yield_now().await;
 		}
-		Err(QueryError::NotFound)
+		self.try_get_by_text(text)
 	}
 
 	/// Finds an element by role and accessible name after settling scheduled work.
@@ -233,7 +245,7 @@ impl Screen {
 			}
 			tokio::task::yield_now().await;
 		}
-		Err(QueryError::NotFound)
+		self.try_get_by_role(role, name)
 	}
 
 	/// Registers a typed server function mock for this screen.

--- a/crates/reinhardt-pages/src/testing/component/screen.rs
+++ b/crates/reinhardt-pages/src/testing/component/screen.rs
@@ -188,12 +188,22 @@ impl Screen {
 		#[cfg(feature = "msw")]
 		let _mock_scope = server_fn_mock::activate(mocks);
 
-		let result = scheduler.settle(|| self.pretty()).await;
-		scheduler.with_current(|| {
-			self.inner.borrow_mut().dom.rerender_reactive_anchors();
-		});
-		result?;
-		Ok(())
+		for _ in 0..100 {
+			let result = scheduler.settle(|| self.pretty()).await;
+			scheduler.with_current(|| {
+				self.inner.borrow_mut().dom.rerender_reactive_anchors();
+			});
+			match result {
+				Ok(()) if scheduler.pending_task_count() == 0 => return Ok(()),
+				Ok(()) => {}
+				Err(err) => return Err(err),
+			}
+		}
+		Err(SettleError::DidNotQuiesce {
+			iterations: 100,
+			pending_tasks: scheduler.pending_task_count(),
+			dom: self.pretty(),
+		})
 	}
 
 	/// Finds an element by text after settling scheduled work.

--- a/crates/reinhardt-pages/src/testing/component/screen.rs
+++ b/crates/reinhardt-pages/src/testing/component/screen.rs
@@ -188,10 +188,11 @@ impl Screen {
 		#[cfg(feature = "msw")]
 		let _mock_scope = server_fn_mock::activate(mocks);
 
-		scheduler.settle(|| self.pretty()).await?;
+		let result = scheduler.settle(|| self.pretty()).await;
 		scheduler.with_current(|| {
 			self.inner.borrow_mut().dom.rerender_reactive_anchors();
 		});
+		result?;
 		Ok(())
 	}
 
@@ -212,7 +213,7 @@ impl Screen {
 			match self.try_get_by_text(text.clone()) {
 				Ok(handle) => return Ok(handle),
 				Err(QueryError::NotFound) => {
-					self.try_settle().await.map_err(|_| QueryError::NotFound)?;
+					let _ = self.try_settle().await;
 				}
 				Err(err) => return Err(err),
 			}
@@ -239,7 +240,7 @@ impl Screen {
 			match self.try_get_by_role(role, name.clone()) {
 				Ok(handle) => return Ok(handle),
 				Err(QueryError::NotFound) => {
-					self.try_settle().await.map_err(|_| QueryError::NotFound)?;
+					let _ = self.try_settle().await;
 				}
 				Err(err) => return Err(err),
 			}

--- a/crates/reinhardt-pages/src/testing/component/server_fn_mock.rs
+++ b/crates/reinhardt-pages/src/testing/component/server_fn_mock.rs
@@ -1,0 +1,182 @@
+//! In-process server function mocks for native component tests.
+
+use std::any::{Any, TypeId};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use crate::server_fn::{MockableServerFn, ServerFnError};
+
+type ErasedHandler = Box<dyn Fn(Box<dyn Any>) -> Result<Box<dyn Any>, ServerFnError>>;
+
+#[derive(Default)]
+pub(crate) struct ServerFnMockRegistry {
+	handlers: HashMap<TypeId, ErasedHandler>,
+	calls: HashMap<TypeId, Vec<Box<dyn Any>>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct SharedServerFnMocks {
+	inner: Rc<RefCell<ServerFnMockRegistry>>,
+}
+
+impl Default for SharedServerFnMocks {
+	fn default() -> Self {
+		Self {
+			inner: Rc::new(RefCell::new(ServerFnMockRegistry::default())),
+		}
+	}
+}
+
+thread_local! {
+	static ACTIVE_MOCKS: RefCell<Option<SharedServerFnMocks>> = const { RefCell::new(None) };
+}
+
+pub(crate) struct ServerFnMockScope {
+	previous: Option<SharedServerFnMocks>,
+}
+
+impl Drop for ServerFnMockScope {
+	fn drop(&mut self) {
+		let previous = self.previous.take();
+		ACTIVE_MOCKS.with(|slot| {
+			*slot.borrow_mut() = previous;
+		});
+	}
+}
+
+pub(crate) fn activate(mocks: SharedServerFnMocks) -> ServerFnMockScope {
+	let previous = ACTIVE_MOCKS.with(|slot| slot.borrow_mut().replace(mocks));
+	ServerFnMockScope { previous }
+}
+
+/// Calls the active native test mock for `S`, recording the typed arguments.
+pub fn try_call_active_mock<S>(args: S::Args) -> Option<Result<S::Response, ServerFnError>>
+where
+	S: MockableServerFn + 'static,
+	S::Args: Clone + 'static,
+	S::Response: 'static,
+{
+	ACTIVE_MOCKS.with(|slot| {
+		let mocks = slot.borrow().clone()?;
+		let mut registry = mocks.inner.borrow_mut();
+		let type_id = TypeId::of::<S>();
+		registry
+			.calls
+			.entry(type_id)
+			.or_default()
+			.push(Box::new(args.clone()));
+		let handler = registry.handlers.get(&type_id)?;
+		let response = handler(Box::new(args));
+		Some(response.and_then(|value| {
+			value
+				.downcast::<S::Response>()
+				.map(|boxed| *boxed)
+				.map_err(|_| ServerFnError::application("mock response type mismatch"))
+		}))
+	})
+}
+
+impl SharedServerFnMocks {
+	pub(crate) fn mock_server_fn<S>(
+		&self,
+		handler: impl Fn(S::Args) -> Result<S::Response, ServerFnError> + 'static,
+	) where
+		S: MockableServerFn + 'static,
+		S::Args: Clone + 'static,
+		S::Response: 'static,
+	{
+		self.inner.borrow_mut().handlers.insert(
+			TypeId::of::<S>(),
+			Box::new(move |args| {
+				let args = args
+					.downcast::<S::Args>()
+					.map_err(|_| ServerFnError::application("mock args type mismatch"))?;
+				handler(*args).map(|response| Box::new(response) as Box<dyn Any>)
+			}),
+		);
+	}
+
+	pub(crate) fn calls_to_server_fn<S>(&self) -> ServerFnCallQuery<S>
+	where
+		S: MockableServerFn + 'static,
+		S::Args: Clone + 'static,
+	{
+		let calls = self
+			.inner
+			.borrow()
+			.calls
+			.get(&TypeId::of::<S>())
+			.map(|values| {
+				values
+					.iter()
+					.filter_map(|value| value.downcast_ref::<S::Args>().cloned())
+					.map(|args| RecordedServerFnCall {
+						path: S::PATH.to_string(),
+						args,
+						_marker: PhantomData,
+					})
+					.collect()
+			})
+			.unwrap_or_default();
+		ServerFnCallQuery { calls }
+	}
+}
+
+/// Recorded server function call.
+pub struct RecordedServerFnCall<S: MockableServerFn> {
+	/// Server function path.
+	pub path: String,
+	/// Typed argument payload passed to the server function.
+	pub args: S::Args,
+	_marker: PhantomData<S>,
+}
+
+impl<S> Clone for RecordedServerFnCall<S>
+where
+	S: MockableServerFn,
+	S::Args: Clone,
+{
+	fn clone(&self) -> Self {
+		Self {
+			path: self.path.clone(),
+			args: self.args.clone(),
+			_marker: PhantomData,
+		}
+	}
+}
+
+/// Queryable collection of recorded server function calls.
+pub struct ServerFnCallQuery<S: MockableServerFn> {
+	calls: Vec<RecordedServerFnCall<S>>,
+}
+
+impl<S> Clone for ServerFnCallQuery<S>
+where
+	S: MockableServerFn,
+	S::Args: Clone,
+{
+	fn clone(&self) -> Self {
+		Self {
+			calls: self.calls.clone(),
+		}
+	}
+}
+
+impl<S: MockableServerFn> ServerFnCallQuery<S> {
+	/// Returns the number of recorded calls.
+	pub fn len(&self) -> usize {
+		self.calls.len()
+	}
+
+	/// Returns true when no calls were recorded.
+	pub fn is_empty(&self) -> bool {
+		self.calls.is_empty()
+	}
+
+	/// Returns all recorded calls.
+	pub fn all(&self) -> &[RecordedServerFnCall<S>] {
+		&self.calls
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/server_fn_mock.rs
+++ b/crates/reinhardt-pages/src/testing/component/server_fn_mock.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use crate::server_fn::{MockableServerFn, ServerFnError};
 
-type ErasedHandler = Box<dyn Fn(Box<dyn Any>) -> Result<Box<dyn Any>, ServerFnError>>;
+type ErasedHandler = Rc<dyn Fn(Box<dyn Any>) -> Result<Box<dyn Any>, ServerFnError>>;
 
 #[derive(Default)]
 pub(crate) struct ServerFnMockRegistry {
@@ -51,6 +51,11 @@ pub(crate) fn activate(mocks: SharedServerFnMocks) -> ServerFnMockScope {
 	ServerFnMockScope { previous }
 }
 
+pub(crate) fn with_active<R>(mocks: SharedServerFnMocks, f: impl FnOnce() -> R) -> R {
+	let _scope = activate(mocks);
+	f()
+}
+
 /// Calls the active native test mock for `S`, recording the typed arguments.
 pub fn try_call_active_mock<S>(args: S::Args) -> Option<Result<S::Response, ServerFnError>>
 where
@@ -60,14 +65,16 @@ where
 {
 	ACTIVE_MOCKS.with(|slot| {
 		let mocks = slot.borrow().clone()?;
-		let mut registry = mocks.inner.borrow_mut();
 		let type_id = TypeId::of::<S>();
-		registry
-			.calls
-			.entry(type_id)
-			.or_default()
-			.push(Box::new(args.clone()));
-		let handler = registry.handlers.get(&type_id)?;
+		let handler = {
+			let mut registry = mocks.inner.borrow_mut();
+			registry
+				.calls
+				.entry(type_id)
+				.or_default()
+				.push(Box::new(args.clone()));
+			registry.handlers.get(&type_id).cloned()
+		}?;
 		let response = handler(Box::new(args));
 		Some(response.and_then(|value| {
 			value
@@ -89,7 +96,7 @@ impl SharedServerFnMocks {
 	{
 		self.inner.borrow_mut().handlers.insert(
 			TypeId::of::<S>(),
-			Box::new(move |args| {
+			Rc::new(move |args| {
 				let args = args
 					.downcast::<S::Args>()
 					.map_err(|_| ServerFnError::application("mock args type mismatch"))?;

--- a/crates/reinhardt-pages/src/testing/component/tests.rs
+++ b/crates/reinhardt-pages/src/testing/component/tests.rs
@@ -1,0 +1,126 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
+use reinhardt_core::types::page::{Page, PageElement};
+
+use super::{EventError, QueryError, Role, render};
+
+#[test]
+fn renders_page_tree_and_pretty_output() {
+	let screen = render(
+		PageElement::new("section")
+			.attr("id", "hero")
+			.child(PageElement::new("h1").child("Hello"))
+			.child(Page::fragment([Page::text("Intro")])),
+	);
+
+	assert_eq!(
+		screen.pretty(),
+		"<section id=\"hero\">\n  <h1>\n    Hello\n  </h1>\n  Intro\n</section>\n"
+	);
+}
+
+#[test]
+fn pretty_text_only_screen_has_trailing_newline() {
+	let screen = render(Page::text("Hello"));
+
+	assert_eq!(screen.pretty(), "Hello\n");
+}
+
+#[test]
+fn queries_by_text_role_label_and_placeholder() {
+	let screen = render(
+		PageElement::new("form")
+			.child(
+				PageElement::new("label")
+					.attr("for", "email")
+					.child("Email"),
+			)
+			.child(
+				PageElement::new("input")
+					.attr("id", "email")
+					.attr("placeholder", "name@example.com"),
+			)
+			.child(PageElement::new("button").child("Submit")),
+	);
+
+	assert_eq!(screen.get_by_text("Submit").tag_name(), "button");
+	assert_eq!(screen.get_by_role(Role::Button, "Submit").text(), "Submit");
+	assert_eq!(screen.get_by_label("Email").tag_name(), "input");
+	assert_eq!(
+		screen.get_by_placeholder("name@example.com").tag_name(),
+		"input"
+	);
+}
+
+#[test]
+fn hidden_elements_are_excluded_from_queries() {
+	let screen = render(
+		PageElement::new("div")
+			.child(
+				PageElement::new("button")
+					.attr("aria-hidden", "true")
+					.child("Save"),
+			)
+			.child(PageElement::new("button").child("Save")),
+	);
+
+	assert_eq!(screen.get_by_text("Save").tag_name(), "button");
+}
+
+#[test]
+fn multiple_matches_return_query_error() {
+	let screen = render(
+		PageElement::new("div")
+			.child(PageElement::new("button").child("Save"))
+			.child(PageElement::new("button").child("Save")),
+	);
+
+	assert!(matches!(
+		screen.try_get_by_text("Save"),
+		Err(QueryError::MultipleMatches)
+	));
+}
+
+#[test]
+fn click_dispatches_native_dummy_event() {
+	let clicked = Rc::new(Cell::new(false));
+	let clicked_for_handler = clicked.clone();
+	let screen = render(
+		PageElement::new("button")
+			.listener("click", move |_| clicked_for_handler.set(true))
+			.child("Save"),
+	);
+
+	screen.get_by_role(Role::Button, "Save").click();
+
+	assert!(clicked.get());
+}
+
+#[test]
+fn input_updates_internal_value_before_dispatch() {
+	let called = Rc::new(Cell::new(false));
+	let called_for_handler = called.clone();
+	let screen = render(
+		PageElement::new("input")
+			.attr("value", "old")
+			.attr("placeholder", "Job name")
+			.listener("input", move |_| called_for_handler.set(true)),
+	);
+	let input = screen.get_by_role(Role::Textbox, "Job name");
+
+	input.input("new");
+
+	assert!(called.get());
+	assert_eq!(input.value().as_deref(), Some("new"));
+}
+
+#[test]
+fn missing_event_handler_returns_error() {
+	let screen = render(PageElement::new("button").child("Save"));
+
+	assert_eq!(
+		screen.get_by_role(Role::Button, "Save").try_click(),
+		Err(EventError::MissingHandler)
+	);
+}

--- a/crates/reinhardt-pages/src/testing/component/text_match.rs
+++ b/crates/reinhardt-pages/src/testing/component/text_match.rs
@@ -1,0 +1,38 @@
+//! Text matching support for native component queries.
+
+/// Exact text matcher used by native component queries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextMatch {
+	needle: String,
+}
+
+impl TextMatch {
+	/// Creates a new exact text matcher.
+	pub fn exact(text: impl Into<String>) -> Self {
+		Self {
+			needle: text.into(),
+		}
+	}
+
+	pub(crate) fn matches(&self, text: &str) -> bool {
+		text == self.needle
+	}
+}
+
+impl From<&str> for TextMatch {
+	fn from(value: &str) -> Self {
+		Self::exact(value)
+	}
+}
+
+impl From<String> for TextMatch {
+	fn from(value: String) -> Self {
+		Self::exact(value)
+	}
+}
+
+impl From<&String> for TextMatch {
+	fn from(value: &String) -> Self {
+		Self::exact(value.clone())
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -7,7 +7,7 @@ use reinhardt_core::types::page::{EventType, Page, PageEventHandler};
 
 use super::scheduler::SchedulerScope;
 #[cfg(feature = "msw")]
-use super::server_fn_mock::{ServerFnMockScope, SharedServerFnMocks};
+use super::server_fn_mock::SharedServerFnMocks;
 
 /// Stable identifier for a node in the native test DOM.
 pub(crate) type NodeId = usize;
@@ -21,8 +21,6 @@ pub(crate) struct ScreenInner {
 	/// Server function mocks registered for this screen.
 	#[cfg(feature = "msw")]
 	pub mocks: SharedServerFnMocks,
-	#[cfg(feature = "msw")]
-	_mock_scope: ServerFnMockScope,
 }
 
 pub(crate) struct TestDom {
@@ -389,13 +387,11 @@ pub(crate) fn shared_screen_inner(
 	dom: TestDom,
 	scheduler: Rc<SchedulerScope>,
 	mocks: SharedServerFnMocks,
-	mock_scope: ServerFnMockScope,
 ) -> Rc<RefCell<ScreenInner>> {
 	Rc::new(RefCell::new(ScreenInner {
 		dom,
 		scheduler,
 		mocks,
-		_mock_scope: mock_scope,
 	}))
 }
 

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -333,6 +333,9 @@ impl TestDom {
 			.collect::<Vec<_>>();
 
 		for (anchor, render) in anchors {
+			if !self.contains(anchor) {
+				continue;
+			}
 			self.clear_children(anchor);
 			self.append_page(anchor, render());
 		}

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -97,6 +97,18 @@ impl TestDom {
 		}
 	}
 
+	pub(crate) fn visible_text_content(&self, node_id: NodeId) -> String {
+		match self.nodes.get(node_id) {
+			Some(TestNode::Removed) => String::new(),
+			Some(TestNode::Root { children }) => self.children_visible_text(children),
+			Some(TestNode::Element(node)) if self.is_hidden(node_id) => String::new(),
+			Some(TestNode::Element(node)) => self.children_visible_text(&node.children),
+			Some(TestNode::Text { text, .. }) => text.clone(),
+			Some(TestNode::ReactiveAnchor { children, .. }) => self.children_visible_text(children),
+			None => String::new(),
+		}
+	}
+
 	pub(crate) fn all_elements(&self) -> Vec<NodeId> {
 		let mut nodes = Vec::new();
 		self.collect_elements(self.root, &mut nodes);
@@ -155,12 +167,33 @@ impl TestDom {
 		node_id: NodeId,
 		event_type: EventType,
 	) -> Option<PageEventHandler> {
-		self.element(node_id).and_then(|node| {
-			node.event_handlers
-				.iter()
-				.find(|(candidate, _)| *candidate == event_type)
-				.map(|(_, handler)| handler.clone())
-		})
+		let mut current = Some(node_id);
+		while let Some(id) = current {
+			if let Some(node) = self.element(id)
+				&& let Some((_, handler)) = node
+					.event_handlers
+					.iter()
+					.find(|(candidate, _)| *candidate == event_type)
+			{
+				return Some(handler.clone());
+			}
+			current = self.parent(id);
+		}
+		None
+	}
+
+	pub(crate) fn suppresses_events(&self, node_id: NodeId) -> bool {
+		let mut current = Some(node_id);
+		while let Some(id) = current {
+			if self
+				.element(id)
+				.is_some_and(ElementNode::is_disabled_form_control)
+			{
+				return true;
+			}
+			current = self.parent(id);
+		}
+		false
 	}
 
 	pub(crate) fn set_value(&mut self, node_id: NodeId, value: String) -> bool {
@@ -302,6 +335,13 @@ impl TestDom {
 			.collect::<String>()
 	}
 
+	fn children_visible_text(&self, children: &[NodeId]) -> String {
+		children
+			.iter()
+			.map(|child| self.visible_text_content(*child))
+			.collect::<String>()
+	}
+
 	fn collect_elements(&self, node_id: NodeId, output: &mut Vec<NodeId>) {
 		if self.element(node_id).is_some() {
 			output.push(node_id);
@@ -382,6 +422,14 @@ impl ElementNode {
 
 	pub(crate) fn supports_value(&self) -> bool {
 		matches!(self.tag.as_str(), "input" | "textarea" | "select")
+	}
+
+	pub(crate) fn is_disabled_form_control(&self) -> bool {
+		self.has_attr("disabled")
+			&& matches!(
+				self.tag.as_str(),
+				"button" | "fieldset" | "input" | "optgroup" | "option" | "select" | "textarea"
+			)
 	}
 }
 

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -1,0 +1,408 @@
+//! In-memory Page-backed tree for native component testing.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use reinhardt_core::types::page::{EventType, Page, PageEventHandler};
+
+use super::scheduler::SchedulerScope;
+#[cfg(feature = "msw")]
+use super::server_fn_mock::{ServerFnMockScope, SharedServerFnMocks};
+
+/// Stable identifier for a node in the native test DOM.
+pub(crate) type NodeId = usize;
+
+/// Shared mutable screen state used by handles.
+pub(crate) struct ScreenInner {
+	/// Rendered native test DOM.
+	pub dom: TestDom,
+	/// Harness scheduler active for this screen.
+	pub scheduler: Rc<SchedulerScope>,
+	/// Server function mocks registered for this screen.
+	#[cfg(feature = "msw")]
+	pub mocks: SharedServerFnMocks,
+	#[cfg(feature = "msw")]
+	_mock_scope: ServerFnMockScope,
+}
+
+pub(crate) struct TestDom {
+	nodes: Vec<TestNode>,
+	root: NodeId,
+}
+
+#[derive(Clone)]
+pub(crate) struct ElementNode {
+	pub tag: String,
+	attrs: Vec<(String, String)>,
+	pub children: Vec<NodeId>,
+	parent: Option<NodeId>,
+	is_void: bool,
+	event_handlers: Vec<(EventType, PageEventHandler)>,
+	value: Option<String>,
+}
+
+enum TestNode {
+	Removed,
+	Root {
+		children: Vec<NodeId>,
+	},
+	Element(ElementNode),
+	Text {
+		text: String,
+		parent: Option<NodeId>,
+	},
+	ReactiveAnchor {
+		children: Vec<NodeId>,
+		parent: Option<NodeId>,
+		render: Rc<dyn Fn() -> Page + 'static>,
+	},
+}
+
+impl TestDom {
+	/// Renders a Page into an in-memory native test DOM.
+	pub(crate) fn render(page: Page) -> Self {
+		let mut dom = Self {
+			nodes: vec![TestNode::Root {
+				children: Vec::new(),
+			}],
+			root: 0,
+		};
+		dom.append_page(dom.root, page);
+		dom
+	}
+
+	pub(crate) fn root(&self) -> NodeId {
+		self.root
+	}
+
+	pub(crate) fn contains(&self, node_id: NodeId) -> bool {
+		self.nodes
+			.get(node_id)
+			.is_some_and(|node| !matches!(node, TestNode::Removed))
+	}
+
+	pub(crate) fn element(&self, node_id: NodeId) -> Option<&ElementNode> {
+		match self.nodes.get(node_id)? {
+			TestNode::Element(node) => Some(node),
+			_ => None,
+		}
+	}
+
+	pub(crate) fn text_content(&self, node_id: NodeId) -> String {
+		match self.nodes.get(node_id) {
+			Some(TestNode::Removed) => String::new(),
+			Some(TestNode::Root { children }) => self.children_text(children),
+			Some(TestNode::Element(node)) => self.children_text(&node.children),
+			Some(TestNode::Text { text, .. }) => text.clone(),
+			Some(TestNode::ReactiveAnchor { children, .. }) => self.children_text(children),
+			None => String::new(),
+		}
+	}
+
+	pub(crate) fn all_elements(&self) -> Vec<NodeId> {
+		let mut nodes = Vec::new();
+		self.collect_elements(self.root, &mut nodes);
+		nodes
+	}
+
+	pub(crate) fn visible_elements(&self) -> Vec<NodeId> {
+		self.all_elements()
+			.into_iter()
+			.filter(|node_id| !self.is_hidden(*node_id))
+			.collect()
+	}
+
+	pub(crate) fn is_hidden(&self, node_id: NodeId) -> bool {
+		let mut current = Some(node_id);
+		while let Some(id) = current {
+			if let Some(node) = self.element(id) {
+				if node.has_attr("hidden") || node.attr("aria-hidden") == Some("true") {
+					return true;
+				}
+				current = node.parent;
+			} else {
+				current = self.parent(id);
+			}
+		}
+		false
+	}
+
+	pub(crate) fn find_element_by_id(&self, id: &str) -> Option<NodeId> {
+		self.all_elements()
+			.into_iter()
+			.find(|node_id| self.element(*node_id).and_then(|node| node.attr("id")) == Some(id))
+	}
+
+	pub(crate) fn label_for(&self, id: &str) -> Option<NodeId> {
+		self.all_elements().into_iter().find(|node_id| {
+			self.element(*node_id).is_some_and(|node| {
+				node.tag == "label" && node.attr("for") == Some(id) && !self.is_hidden(*node_id)
+			})
+		})
+	}
+
+	pub(crate) fn closest_label(&self, node_id: NodeId) -> Option<NodeId> {
+		let mut current = self.parent(node_id);
+		while let Some(id) = current {
+			if self.element(id).is_some_and(|node| node.tag == "label") {
+				return Some(id);
+			}
+			current = self.parent(id);
+		}
+		None
+	}
+
+	pub(crate) fn event_handler(
+		&self,
+		node_id: NodeId,
+		event_type: EventType,
+	) -> Option<PageEventHandler> {
+		self.element(node_id).and_then(|node| {
+			node.event_handlers
+				.iter()
+				.find(|(candidate, _)| *candidate == event_type)
+				.map(|(_, handler)| handler.clone())
+		})
+	}
+
+	pub(crate) fn set_value(&mut self, node_id: NodeId, value: String) -> bool {
+		match self.nodes.get_mut(node_id) {
+			Some(TestNode::Element(node)) if node.supports_value() => {
+				node.value = Some(value);
+				true
+			}
+			_ => false,
+		}
+	}
+
+	pub(crate) fn value(&self, node_id: NodeId) -> Option<String> {
+		self.element(node_id).and_then(|node| node.value.clone())
+	}
+
+	pub(crate) fn children(&self, node_id: NodeId) -> &[NodeId] {
+		match self.nodes.get(node_id) {
+			Some(TestNode::Removed) => &[],
+			Some(TestNode::Root { children }) => children,
+			Some(TestNode::Element(node)) => &node.children,
+			Some(TestNode::ReactiveAnchor { children, .. }) => children,
+			_ => &[],
+		}
+	}
+
+	pub(crate) fn text_node(&self, node_id: NodeId) -> Option<&str> {
+		match self.nodes.get(node_id) {
+			Some(TestNode::Text { text, .. }) => Some(text),
+			_ => None,
+		}
+	}
+
+	pub(crate) fn is_void(&self, node_id: NodeId) -> bool {
+		self.element(node_id).is_some_and(|node| node.is_void)
+	}
+
+	fn append_page(&mut self, parent: NodeId, page: Page) {
+		match page {
+			Page::Element(element) => {
+				let (tag, attrs, children, is_void, event_handlers) = element.into_parts();
+				let attrs = attrs
+					.into_iter()
+					.map(|(name, value)| (name.into_owned(), value.into_owned()))
+					.collect::<Vec<_>>();
+				let value = attrs
+					.iter()
+					.find(|(name, _)| name == "value")
+					.map(|(_, value)| value.clone());
+				let node_id = self.push_node(
+					parent,
+					TestNode::Element(ElementNode {
+						tag: tag.into_owned(),
+						attrs,
+						children: Vec::new(),
+						parent: Some(parent),
+						is_void,
+						event_handlers,
+						value,
+					}),
+				);
+				for child in children {
+					self.append_page(node_id, child);
+				}
+			}
+			Page::Text(text) => {
+				self.push_node(
+					parent,
+					TestNode::Text {
+						text: text.into_owned(),
+						parent: Some(parent),
+					},
+				);
+			}
+			Page::Fragment(children) => {
+				for child in children {
+					self.append_page(parent, child);
+				}
+			}
+			Page::KeyedFragment(children) => {
+				for (_, child) in children {
+					self.append_page(parent, child);
+				}
+			}
+			Page::Empty => {}
+			Page::WithHead { view, .. } => self.append_page(parent, *view),
+			Page::ReactiveIf(reactive_if) => {
+				let (condition, then_view, else_view) = reactive_if.into_parts();
+				let render: Rc<dyn Fn() -> Page + 'static> = Rc::new(move || {
+					if condition() {
+						then_view()
+					} else {
+						else_view()
+					}
+				});
+				let anchor = self.push_node(
+					parent,
+					TestNode::ReactiveAnchor {
+						children: Vec::new(),
+						parent: Some(parent),
+						render: Rc::clone(&render),
+					},
+				);
+				self.append_page(anchor, render());
+			}
+			Page::Reactive(reactive) => {
+				let render_arc = reactive.into_render();
+				let render: Rc<dyn Fn() -> Page + 'static> = Rc::new(move || render_arc());
+				let anchor = self.push_node(
+					parent,
+					TestNode::ReactiveAnchor {
+						children: Vec::new(),
+						parent: Some(parent),
+						render: Rc::clone(&render),
+					},
+				);
+				self.append_page(anchor, render());
+			}
+		}
+	}
+
+	fn push_node(&mut self, parent: NodeId, node: TestNode) -> NodeId {
+		let node_id = self.nodes.len();
+		self.nodes.push(node);
+		match self.nodes.get_mut(parent) {
+			Some(TestNode::Removed) => {}
+			Some(TestNode::Root { children }) => children.push(node_id),
+			Some(TestNode::Element(element)) => element.children.push(node_id),
+			Some(TestNode::ReactiveAnchor { children, .. }) => children.push(node_id),
+			_ => {}
+		}
+		node_id
+	}
+
+	fn children_text(&self, children: &[NodeId]) -> String {
+		children
+			.iter()
+			.map(|child| self.text_content(*child))
+			.collect::<String>()
+	}
+
+	fn collect_elements(&self, node_id: NodeId, output: &mut Vec<NodeId>) {
+		if self.element(node_id).is_some() {
+			output.push(node_id);
+		}
+		for child in self.children(node_id) {
+			self.collect_elements(*child, output);
+		}
+	}
+
+	fn parent(&self, node_id: NodeId) -> Option<NodeId> {
+		match self.nodes.get(node_id) {
+			Some(TestNode::Removed) => None,
+			Some(TestNode::Element(node)) => node.parent,
+			Some(TestNode::Text { parent, .. }) => *parent,
+			Some(TestNode::ReactiveAnchor { parent, .. }) => *parent,
+			_ => None,
+		}
+	}
+
+	pub(crate) fn rerender_reactive_anchors(&mut self) {
+		let anchors = self
+			.nodes
+			.iter()
+			.enumerate()
+			.filter_map(|(node_id, node)| match node {
+				TestNode::ReactiveAnchor { render, .. } => Some((node_id, Rc::clone(render))),
+				_ => None,
+			})
+			.collect::<Vec<_>>();
+
+		for (anchor, render) in anchors {
+			self.clear_children(anchor);
+			self.append_page(anchor, render());
+		}
+	}
+
+	fn clear_children(&mut self, node_id: NodeId) {
+		let children = match self.nodes.get_mut(node_id) {
+			Some(TestNode::Root { children }) => std::mem::take(children),
+			Some(TestNode::Element(node)) => std::mem::take(&mut node.children),
+			Some(TestNode::ReactiveAnchor { children, .. }) => std::mem::take(children),
+			_ => Vec::new(),
+		};
+		for child in children {
+			self.remove_subtree(child);
+		}
+	}
+
+	fn remove_subtree(&mut self, node_id: NodeId) {
+		let children = self.children(node_id).to_vec();
+		for child in children {
+			self.remove_subtree(child);
+		}
+		if let Some(node) = self.nodes.get_mut(node_id) {
+			*node = TestNode::Removed;
+		}
+	}
+}
+
+impl ElementNode {
+	pub(crate) fn attr(&self, name: &str) -> Option<&str> {
+		self.attrs
+			.iter()
+			.find(|(candidate, _)| candidate == name)
+			.map(|(_, value)| value.as_str())
+	}
+
+	pub(crate) fn attrs(&self) -> &[(String, String)] {
+		&self.attrs
+	}
+
+	pub(crate) fn has_attr(&self, name: &str) -> bool {
+		self.attr(name).is_some()
+	}
+
+	pub(crate) fn supports_value(&self) -> bool {
+		matches!(self.tag.as_str(), "input" | "textarea" | "select")
+	}
+}
+
+#[cfg(feature = "msw")]
+pub(crate) fn shared_screen_inner(
+	dom: TestDom,
+	scheduler: Rc<SchedulerScope>,
+	mocks: SharedServerFnMocks,
+	mock_scope: ServerFnMockScope,
+) -> Rc<RefCell<ScreenInner>> {
+	Rc::new(RefCell::new(ScreenInner {
+		dom,
+		scheduler,
+		mocks,
+		_mock_scope: mock_scope,
+	}))
+}
+
+#[cfg(not(feature = "msw"))]
+pub(crate) fn shared_screen_inner(
+	dom: TestDom,
+	scheduler: Rc<SchedulerScope>,
+) -> Rc<RefCell<ScreenInner>> {
+	Rc::new(RefCell::new(ScreenInner { dom, scheduler }))
+}

--- a/crates/reinhardt-pages/tests/component_system_integration.rs
+++ b/crates/reinhardt-pages/tests/component_system_integration.rs
@@ -248,7 +248,7 @@ fn test_component_state_transitions() {
 /// Tests list rendering use case
 #[rstest]
 fn test_component_use_case_list() {
-	let items = vec!["Apple", "Banana", "Cherry"];
+	let items = ["Apple", "Banana", "Cherry"];
 	let view = PageElement::new("ul")
 		.children(items.iter().map(|item| {
 			PageElement::new("li")
@@ -440,7 +440,7 @@ fn test_component_equivalence_int_props(#[case] value: i32) {
 
 /// Tests with float props
 #[rstest]
-#[case::float_props(3.14)]
+#[case::float_props(std::f64::consts::PI)]
 fn test_component_equivalence_float_props(#[case] value: f64) {
 	let comp = PropsComponent { value };
 	let html = comp.render().render_to_string();

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -1,0 +1,142 @@
+#![cfg(all(native, feature = "testing"))]
+
+use reinhardt_core::types::page::{IntoPage, Page, PageElement};
+use reinhardt_pages::page;
+use reinhardt_pages::reactive::hooks::use_action;
+use reinhardt_pages::reactive::{ResourceState, use_resource};
+#[cfg(feature = "msw")]
+use reinhardt_pages::server_fn::{ServerFnError, server_fn};
+use reinhardt_pages::testing::component::{Role, render};
+
+fn text_page(text: impl Into<String>) -> Page {
+	PageElement::new("div").child(text.into()).into_page()
+}
+
+fn string_resource_page(state: ResourceState<String, String>) -> Page {
+	match state {
+		ResourceState::Loading => text_page("Loading"),
+		ResourceState::Success(value) => text_page(value),
+		ResourceState::Error(error) => text_page(error),
+	}
+}
+
+fn index_job_component() -> Page {
+	let resource = use_resource(
+		|| async { Ok::<String, String>("Index job".to_string()) },
+		(),
+	);
+	Page::reactive(move || string_resource_page(resource.get()))
+}
+
+fn ready_component() -> Page {
+	let resource = use_resource(|| async { Ok::<String, String>("Ready".to_string()) }, ());
+	Page::reactive(move || string_resource_page(resource.get()))
+}
+
+fn save_component() -> Page {
+	let action = use_action(|_: ()| async { Ok::<String, String>("Saved".to_string()) });
+	let button_action = action.clone();
+	PageElement::new("div")
+		.child(
+			PageElement::new("button")
+				.listener("click", move |_| button_action.dispatch(()))
+				.child("Save"),
+		)
+		.child(Page::reactive(move || match action.result() {
+			Some(value) => text_page(value),
+			None => text_page("Idle"),
+		}))
+		.into_page()
+}
+
+#[test]
+fn native_component_testing_public_surface_is_available() {
+	let screen = render(
+		PageElement::new("main")
+			.attr("aria-label", "Dashboard")
+			.child(PageElement::new("h1").child("Dashboard"))
+			.child(PageElement::new("button").child("Refresh")),
+	);
+
+	assert_eq!(
+		screen.get_by_role(Role::Main, "Dashboard").tag_name(),
+		"main"
+	);
+	assert_eq!(
+		screen.get_by_role(Role::Button, "Refresh").text(),
+		"Refresh"
+	);
+}
+
+#[tokio::test]
+async fn settle_runs_use_resource_on_native() {
+	let screen = render(index_job_component);
+
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Index job").is_some());
+}
+
+#[tokio::test]
+async fn click_action_settles_to_success() {
+	let screen = render(save_component);
+
+	screen.get_by_role(Role::Button, "Save").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Saved").is_some());
+}
+
+#[tokio::test]
+async fn find_by_text_waits_for_resource() {
+	let screen = render(ready_component);
+
+	let element = screen.find_by_text("Ready").await;
+
+	assert_eq!(element.text(), "Ready");
+}
+
+#[test]
+fn pretty_dom_snapshot_is_stable() {
+	let screen = render(page!(|| {
+		main {
+			aria_label: "Jobs",
+			button { "Refresh" }
+		}
+	}));
+
+	insta::assert_snapshot!(screen.pretty());
+}
+
+#[cfg(feature = "msw")]
+#[server_fn]
+async fn load_jobs() -> Result<Vec<String>, ServerFnError> {
+	Ok(vec!["real job".to_string()])
+}
+
+#[cfg(feature = "msw")]
+fn jobs_resource_page(state: ResourceState<Vec<String>, ServerFnError>) -> Page {
+	match state {
+		ResourceState::Loading => text_page("Loading"),
+		ResourceState::Success(values) => text_page(values.join(", ")),
+		ResourceState::Error(error) => text_page(error.to_string()),
+	}
+}
+
+#[cfg(feature = "msw")]
+fn jobs_component() -> Page {
+	let jobs = use_resource(|| async { load_jobs().await }, ());
+	Page::reactive(move || jobs_resource_page(jobs.get()))
+}
+
+#[cfg(feature = "msw")]
+#[tokio::test]
+async fn server_fn_mock_feeds_resource() {
+	let screen = render(jobs_component);
+	screen.mock_server_fn::<load_jobs::marker>(|_args| Ok(vec!["Index job".to_string()]));
+
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Index job").is_some());
+	assert_eq!(screen.calls_to_server_fn::<load_jobs::marker>().len(), 1);
+}

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -88,6 +88,19 @@ async fn click_action_settles_to_success() {
 }
 
 #[tokio::test]
+async fn click_action_uses_own_screen_scheduler() {
+	let first = render(save_component);
+	let second = render(save_component);
+
+	first.get_by_role(Role::Button, "Save").click();
+	first.settle().await;
+
+	assert!(first.query_by_text("Saved").is_some());
+	assert!(second.query_by_text("Saved").is_none());
+	assert!(second.query_by_text("Idle").is_some());
+}
+
+#[tokio::test]
 async fn find_by_text_waits_for_resource() {
 	let screen = render(ready_component);
 
@@ -139,4 +152,59 @@ async fn server_fn_mock_feeds_resource() {
 
 	assert!(screen.query_by_text("Index job").is_some());
 	assert_eq!(screen.calls_to_server_fn::<load_jobs::marker>().len(), 1);
+}
+
+#[cfg(feature = "msw")]
+#[tokio::test]
+async fn server_fn_mocks_are_scoped_per_screen() {
+	let first = render(jobs_component);
+	first.mock_server_fn::<load_jobs::marker>(|_args| Ok(vec!["First job".to_string()]));
+	let second = render(jobs_component);
+	second.mock_server_fn::<load_jobs::marker>(|_args| Ok(vec!["Second job".to_string()]));
+
+	first.settle().await;
+	second.settle().await;
+
+	assert!(first.query_by_text("First job").is_some());
+	assert!(first.query_by_text("Second job").is_none());
+	assert!(second.query_by_text("Second job").is_some());
+	assert!(second.query_by_text("First job").is_none());
+}
+
+#[cfg(feature = "msw")]
+#[tokio::test]
+async fn server_fn_mock_errors_render_resource_errors() {
+	let screen = render(jobs_component);
+	screen.mock_server_fn::<load_jobs::marker>(|_args| {
+		Err(ServerFnError::application("mock failed"))
+	});
+
+	screen.settle().await;
+
+	assert!(
+		screen
+			.query_by_text("Application error: mock failed")
+			.is_some()
+	);
+	assert_eq!(screen.calls_to_server_fn::<load_jobs::marker>().len(), 1);
+}
+
+#[cfg(feature = "msw")]
+#[tokio::test]
+async fn server_fn_mock_handler_can_inspect_recorded_calls() {
+	let screen = render(jobs_component);
+	let screen_for_handler = screen.clone();
+	screen.mock_server_fn::<load_jobs::marker>(move |_args| {
+		assert_eq!(
+			screen_for_handler
+				.calls_to_server_fn::<load_jobs::marker>()
+				.len(),
+			1
+		);
+		Ok(vec!["Inspectable job".to_string()])
+	});
+
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Inspectable job").is_some());
 }

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -1,9 +1,10 @@
 #![cfg(all(native, feature = "testing"))]
 
-use reinhardt_core::types::page::{IntoPage, Page, PageElement};
+use reinhardt_core::types::page::{EventType, IntoPage, Page, PageElement};
+use reinhardt_pages::callback::async_handler;
 use reinhardt_pages::page;
 use reinhardt_pages::reactive::hooks::use_action;
-use reinhardt_pages::reactive::{ResourceState, use_resource};
+use reinhardt_pages::reactive::{ResourceState, Signal, use_resource};
 #[cfg(feature = "msw")]
 use reinhardt_pages::server_fn::{ServerFnError, server_fn};
 use reinhardt_pages::testing::component::{Role, render};
@@ -58,6 +59,27 @@ fn save_component() -> Page {
 		.into_page()
 }
 
+fn async_click_component() -> Page {
+	let message = Signal::new("Idle".to_string());
+	let click_message = message.clone();
+	PageElement::new("div")
+		.child(
+			PageElement::new("button")
+				.on(
+					EventType::Click,
+					async_handler(move |_| {
+						let click_message = click_message.clone();
+						async move {
+							click_message.set("Clicked".to_string());
+						}
+					}),
+				)
+				.child("Run"),
+		)
+		.child(Page::reactive(move || text_page(message.get())))
+		.into_page()
+}
+
 #[test]
 fn native_component_testing_public_surface_is_available() {
 	let screen = render(
@@ -107,6 +129,16 @@ async fn click_action_uses_own_screen_scheduler() {
 	assert!(first.query_by_text("Saved").is_some());
 	assert!(second.query_by_text("Saved").is_none());
 	assert!(second.query_by_text("Idle").is_some());
+}
+
+#[tokio::test]
+async fn async_click_handler_settles_to_updated_ui() {
+	let screen = render(async_click_component);
+
+	screen.get_by_role(Role::Button, "Run").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Clicked").is_some());
 }
 
 #[tokio::test]

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -33,6 +33,15 @@ fn ready_component() -> Page {
 	Page::reactive(move || string_resource_page(resource.get()))
 }
 
+fn mixed_resource_component() -> Page {
+	let pending = use_resource(|| std::future::pending::<Result<String, String>>(), ());
+	let ready = use_resource(|| async { Ok::<String, String>("Ready".to_string()) }, ());
+	Page::reactive(move || {
+		let _ = pending.get();
+		string_resource_page(ready.get())
+	})
+}
+
 fn save_component() -> Page {
 	let action = use_action(|_: ()| async { Ok::<String, String>("Saved".to_string()) });
 	let button_action = action.clone();
@@ -103,6 +112,15 @@ async fn click_action_uses_own_screen_scheduler() {
 #[tokio::test]
 async fn find_by_text_waits_for_resource() {
 	let screen = render(ready_component);
+
+	let element = screen.find_by_text("Ready").await;
+
+	assert_eq!(element.text(), "Ready");
+}
+
+#[tokio::test]
+async fn find_by_text_rerenders_completed_work_with_pending_tasks() {
+	let screen = render(mixed_resource_component);
 
 	let element = screen.find_by_text("Ready").await;
 

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use reinhardt_core::types::page::{EventType, IntoPage, Page, PageElement};
 use reinhardt_pages::callback::async_handler;
 use reinhardt_pages::page;
+use reinhardt_pages::prelude::spawn_task;
 use reinhardt_pages::reactive::hooks::use_action;
 use reinhardt_pages::reactive::{ResourceState, Signal, use_resource};
 #[cfg(feature = "msw")]
@@ -145,6 +146,51 @@ fn presentation_role_suppresses_implicit_role_queries() {
 	assert!(screen.query_by_text("Save").is_some());
 }
 
+#[test]
+fn text_queries_ignore_hidden_descendant_text() {
+	let screen = render(
+		PageElement::new("div").child(PageElement::new("span").attr("hidden", "").child("Secret")),
+	);
+
+	assert!(screen.try_get_by_text("Secret").is_err());
+}
+
+#[test]
+fn role_queries_follow_fallback_tokens_and_input_rules() {
+	let screen = render(Page::fragment([
+		PageElement::new("div")
+			.attr("role", "foo button")
+			.child("Fallback button")
+			.into_page(),
+		PageElement::new("div")
+			.attr("role", "switch checkbox")
+			.attr("aria-label", "Power")
+			.into_page(),
+		PageElement::new("label")
+			.child("Password")
+			.child(PageElement::new("input").attr("type", "password"))
+			.into_page(),
+		PageElement::new("input")
+			.attr("type", "submit")
+			.attr("value", "Save")
+			.into_page(),
+	]));
+
+	assert_eq!(
+		screen
+			.get_by_role(Role::Button, "Fallback button")
+			.tag_name(),
+		"div"
+	);
+	assert_eq!(
+		screen.get_by_role(Role::Checkbox, "Power").tag_name(),
+		"div"
+	);
+	assert!(screen.try_get_by_role(Role::Textbox, "Password").is_err());
+	assert_eq!(screen.get_by_label("Password").tag_name(), "input");
+	assert_eq!(screen.get_by_role(Role::Button, "Save").tag_name(), "input");
+}
+
 #[tokio::test]
 async fn settle_runs_use_resource_on_native() {
 	let screen = render(index_job_component);
@@ -195,6 +241,119 @@ async fn settle_waits_for_timer_backed_tasks() {
 	screen.settle().await;
 
 	assert!(screen.query_by_text("Delayed").is_some());
+}
+
+#[tokio::test]
+async fn settle_continues_when_rerender_mounts_async_work() {
+	let show_child = Signal::new(false);
+	let message = Signal::new("Idle".to_string());
+	let spawned = Rc::new(Cell::new(false));
+	let screen = render({
+		let show_child = show_child.clone();
+		let message = message.clone();
+		let spawned = Rc::clone(&spawned);
+		move || {
+			let show_child = show_child.clone();
+			let message = message.clone();
+			let spawned = Rc::clone(&spawned);
+			Page::reactive(move || {
+				if show_child.get() && !spawned.replace(true) {
+					let spawned_message = message.clone();
+					spawn_task(async move {
+						spawned_message.set("Mounted work".to_string());
+					});
+				}
+				text_page(message.get())
+			})
+		}
+	});
+
+	show_child.set(true);
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Mounted work").is_some());
+}
+
+#[tokio::test]
+async fn settle_preserves_tasks_spawned_by_polled_tasks() {
+	let message = Signal::new("Idle".to_string());
+	let click_message = message.clone();
+	let screen = render(move || {
+		let message = message.clone();
+		let click_message = click_message.clone();
+		PageElement::new("div")
+			.child(
+				PageElement::new("button")
+					.on(
+						EventType::Click,
+						async_handler(move |_| {
+							let click_message = click_message.clone();
+							async move {
+								tokio::task::yield_now().await;
+								spawn_task(async move {
+									click_message.set("Nested".to_string());
+								});
+							}
+						}),
+					)
+					.child("Run nested"),
+			)
+			.child(Page::reactive(move || text_page(message.get())))
+			.into_page()
+	});
+
+	screen.get_by_role(Role::Button, "Run nested").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Nested").is_some());
+}
+
+#[tokio::test]
+async fn disabled_controls_suppress_click_handlers() {
+	let message = Signal::new("Idle".to_string());
+	let click_message = message.clone();
+	let screen = render(move || {
+		let message = message.clone();
+		let click_message = click_message.clone();
+		PageElement::new("div")
+			.child(
+				PageElement::new("button")
+					.attr("disabled", "")
+					.listener("click", move |_| click_message.set("Clicked".to_string()))
+					.child("Save"),
+			)
+			.child(Page::reactive(move || text_page(message.get())))
+			.into_page()
+	});
+
+	screen.get_by_role(Role::Button, "Save").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Idle").is_some());
+	assert!(screen.query_by_text("Clicked").is_none());
+}
+
+#[tokio::test]
+async fn click_events_bubble_from_descendant_handles() {
+	let message = Signal::new("Idle".to_string());
+	let click_message = message.clone();
+	let screen = render(move || {
+		let message = message.clone();
+		let click_message = click_message.clone();
+		PageElement::new("div")
+			.child(
+				PageElement::new("button")
+					.listener("click", move |_| click_message.set("Clicked".to_string()))
+					.child(PageElement::new("span").child("Nested label")),
+			)
+			.child(Page::reactive(move || text_page(message.get())))
+			.into_page()
+	});
+
+	screen.get_by_text("Nested label").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Clicked").is_some());
 }
 
 #[tokio::test]

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -1,5 +1,9 @@
 #![cfg(all(native, feature = "testing"))]
 
+use std::cell::Cell;
+use std::rc::Rc;
+use std::time::Duration;
+
 use reinhardt_core::types::page::{EventType, IntoPage, Page, PageElement};
 use reinhardt_pages::callback::async_handler;
 use reinhardt_pages::page;
@@ -80,6 +84,28 @@ fn async_click_component() -> Page {
 		.into_page()
 }
 
+fn delayed_async_click_component() -> Page {
+	let message = Signal::new("Idle".to_string());
+	let click_message = message.clone();
+	PageElement::new("div")
+		.child(
+			PageElement::new("button")
+				.on(
+					EventType::Click,
+					async_handler(move |_| {
+						let click_message = click_message.clone();
+						async move {
+							tokio::time::sleep(Duration::from_millis(1)).await;
+							click_message.set("Delayed".to_string());
+						}
+					}),
+				)
+				.child("Run"),
+		)
+		.child(Page::reactive(move || text_page(message.get())))
+		.into_page()
+}
+
 #[test]
 fn native_component_testing_public_surface_is_available() {
 	let screen = render(
@@ -97,6 +123,26 @@ fn native_component_testing_public_surface_is_available() {
 		screen.get_by_role(Role::Button, "Refresh").text(),
 		"Refresh"
 	);
+}
+
+#[test]
+fn label_query_does_not_match_placeholder_only_inputs() {
+	let screen = render(PageElement::new("input").attr("placeholder", "Email"));
+
+	assert!(screen.try_get_by_label("Email").is_err());
+	assert_eq!(screen.get_by_placeholder("Email").tag_name(), "input");
+}
+
+#[test]
+fn presentation_role_suppresses_implicit_role_queries() {
+	let screen = render(
+		PageElement::new("button")
+			.attr("role", "presentation")
+			.child("Save"),
+	);
+
+	assert!(screen.try_get_by_role(Role::Button, "Save").is_err());
+	assert!(screen.query_by_text("Save").is_some());
 }
 
 #[tokio::test]
@@ -139,6 +185,49 @@ async fn async_click_handler_settles_to_updated_ui() {
 	screen.settle().await;
 
 	assert!(screen.query_by_text("Clicked").is_some());
+}
+
+#[tokio::test]
+async fn settle_waits_for_timer_backed_tasks() {
+	let screen = render(delayed_async_click_component);
+
+	screen.get_by_role(Role::Button, "Run").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Delayed").is_some());
+}
+
+#[tokio::test]
+async fn parent_rerender_skips_removed_child_anchors() {
+	let show_child = Signal::new(true);
+	let child_renders = Rc::new(Cell::new(0));
+	let screen = {
+		let show_child = show_child.clone();
+		let child_renders = Rc::clone(&child_renders);
+		render(move || {
+			let show_child = show_child.clone();
+			let child_renders = Rc::clone(&child_renders);
+			Page::reactive(move || {
+				if show_child.get() {
+					let child_renders = Rc::clone(&child_renders);
+					Page::reactive(move || {
+						child_renders.set(child_renders.get() + 1);
+						text_page("Child")
+					})
+				} else {
+					text_page("Gone")
+				}
+			})
+		})
+	};
+
+	assert_eq!(child_renders.get(), 1);
+	show_child.set(false);
+	screen.settle().await;
+
+	assert_eq!(child_renders.get(), 1);
+	assert!(screen.query_by_text("Gone").is_some());
+	assert!(screen.query_by_text("Child").is_none());
 }
 
 #[tokio::test]

--- a/crates/reinhardt-pages/tests/context_api_integration.rs
+++ b/crates/reinhardt-pages/tests/context_api_integration.rs
@@ -190,7 +190,7 @@ fn test_context_use_case_auth_state() {
 	assert!(auth_state.is_some());
 	if let Some((email, is_authenticated)) = auth_state {
 		assert_eq!(email, "user@example.com");
-		assert_eq!(is_authenticated, true);
+		assert!(is_authenticated);
 	}
 }
 

--- a/crates/reinhardt-pages/tests/hooks_integration.rs
+++ b/crates/reinhardt-pages/tests/hooks_integration.rs
@@ -144,7 +144,7 @@ fn test_hooks_circular_dependency_detection() {
 	);
 
 	// If circular dependencies are properly handled, this should not hang
-	assert!(true);
+	assert_eq!(signal_b.get(), 1);
 }
 
 /// Tests infinite loop protection in effects
@@ -313,7 +313,7 @@ fn test_hooks_cleanup_on_unmount() {
 	// Cleanup may or may not have been called immediately
 	// (depends on when effect runs)
 	// Just verify the ref was updated
-	assert_eq!(*component_ref.current(), false);
+	assert!(!*component_ref.current());
 }
 
 // ============================================================================
@@ -364,9 +364,8 @@ fn test_hooks_use_case_form_validation() {
 
 	set_email("user@example.com".to_string());
 	// Memo may not have recomputed yet
-	let is_valid2 = is_valid_email.get();
-	// Could be old value or new value depending on timing
-	assert!(is_valid2 || !is_valid2); // Always true, but documents the behavior
+	let _is_valid2 = is_valid_email.get();
+	assert_eq!(email.get(), "user@example.com");
 }
 
 // ============================================================================
@@ -391,8 +390,9 @@ fn test_hooks_property_memo_deterministic() {
 
 		// Results should be the same (memoization)
 		prop_assert_eq!(result1, result2);
-		// Result should be input * 2 (may vary by timing)
-		prop_assert!(result1 == input * 2 || result1 == 0 * 2);
+		// Result should be input * 2 once memoized; some native timing paths can still expose the initial value.
+		let initial_result = 0;
+		prop_assert!(result1 == input * 2 || result1 == initial_result);
 	});
 }
 

--- a/crates/reinhardt-pages/tests/hydration_execution_integration.rs
+++ b/crates/reinhardt-pages/tests/hydration_execution_integration.rs
@@ -417,7 +417,7 @@ fn test_hydration_context_signal_count_boundary(#[case] count: usize) {
 	let mut state = SsrState::new();
 
 	for i in 0..count {
-		state.add_signal(&format!("signal-{}", i), json!(i));
+		state.add_signal(format!("signal-{}", i), json!(i));
 	}
 
 	let context = HydrationContext::from_state(state);
@@ -441,7 +441,7 @@ fn test_hydration_context_nesting_depth_boundary(#[case] depth: usize) {
 	let mut state = SsrState::new();
 
 	for i in 0..depth {
-		state.add_props(&format!("comp-level-{}", i), json!({"depth": i}));
+		state.add_props(format!("comp-level-{}", i), json!({"depth": i}));
 	}
 
 	let context = HydrationContext::from_state(state);

--- a/crates/reinhardt-pages/tests/snapshots/component_testing__pretty_dom_snapshot_is_stable.snap
+++ b/crates/reinhardt-pages/tests/snapshots/component_testing__pretty_dom_snapshot_is_stable.snap
@@ -1,0 +1,9 @@
+---
+source: crates/reinhardt-pages/tests/component_testing.rs
+expression: screen.pretty()
+---
+<main aria-label="Jobs">
+  <button>
+    Refresh
+  </button>
+</main>

--- a/crates/reinhardt-pages/tests/ssr_renderer_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_renderer_integration_tests.rs
@@ -159,7 +159,7 @@ fn test_conditional_rendering() {
 
 #[test]
 fn test_list_rendering() {
-	let items = vec!["Apple", "Banana", "Cherry"];
+	let items = ["Apple", "Banana", "Cherry"];
 	let list = PageElement::new("ul");
 
 	let list_with_items = items.iter().fold(list, |acc, item| {

--- a/crates/reinhardt-pages/tests/static_asset_decision_table_tests.rs
+++ b/crates/reinhardt-pages/tests/static_asset_decision_table_tests.rs
@@ -222,7 +222,7 @@ mod decision_table_tests {
 
 		let result = resolve_static(filename);
 
-		assert!(result.ends_with(filename.split('.').last().unwrap()));
+		assert!(result.ends_with(filename.split('.').next_back().unwrap()));
 	}
 
 	/// Decision table: Base URL Types

--- a/crates/reinhardt-providers/Cargo.toml
+++ b/crates/reinhardt-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-providers"
-version = "0.3.0"
+version = "0.3.1"
 description = "Cloud provider integrations for Reinhardt"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-query/Cargo.toml
+++ b/crates/reinhardt-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-query/README.md
+++ b/crates/reinhardt-query/README.md
@@ -44,7 +44,7 @@ Add to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-query = { version = "0.3.0" }
+reinhardt-query = { version = "0.3.1" }
 ```
 
 ## Quick Start

--- a/crates/reinhardt-query/macros/Cargo.toml
+++ b/crates/reinhardt-query/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-rest/CHANGELOG.md
+++ b/crates/reinhardt-rest/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-rest@v0.3.0...reinhardt-rest@v0.3.1) - 2026-07-04
+
+### Added
+
+- *(db)* add scoped n+1 query detection
+
+### Fixed
+
+- *(rest)* keep validator doctests feature neutral
+- *(ci)* unblock quick-xml security audit
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-rest@v0.2.0...reinhardt-rest@v0.3.0) - 2026-06-28
 
 Stable release of `reinhardt-rest` for the Reinhardt 0.3.0 line. This

--- a/crates/reinhardt-rest/Cargo.toml
+++ b/crates/reinhardt-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-rest"
-version = "0.3.0"
+version = "0.3.1"
 description = "REST API framework aggregator for Reinhardt"
 keywords = ["rest", "api", "web", "framework", "django"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-rest/README.md
+++ b/crates/reinhardt-rest/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["rest"] }
+reinhardt = { version = "0.3.1", features = ["rest"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import REST features:

--- a/crates/reinhardt-rest/openapi-macros/Cargo.toml
+++ b/crates/reinhardt-rest/openapi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-router/Cargo.toml
+++ b/crates/reinhardt-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-router"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-server/Cargo.toml
+++ b/crates/reinhardt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-server"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-server/README.md
+++ b/crates/reinhardt-server/README.md
@@ -45,17 +45,17 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:5 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["server"] }
+reinhardt = { version = "0.3.1", features = ["server"] }
 
 # For WebSocket support:
-# reinhardt = { version = "0.3.0", features = ["server", "websocket"] }
+# reinhardt = { version = "0.3.1", features = ["server", "websocket"] }
 
 # For GraphQL support:
-# reinhardt = { version = "0.3.0", features = ["server", "graphql"] }
+# reinhardt = { version = "0.3.1", features = ["server", "graphql"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import server features:

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-shortcuts/README.md
+++ b/crates/reinhardt-shortcuts/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["shortcuts"] }
+reinhardt = { version = "0.3.1", features = ["shortcuts"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import shortcuts features:

--- a/crates/reinhardt-storages/Cargo.toml
+++ b/crates/reinhardt-storages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-storages"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Reinhardt Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/reinhardt-streaming/Cargo.toml
+++ b/crates/reinhardt-streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-streaming"
-version = "0.3.0"
+version = "0.3.1"
 description = "Backend-agnostic streaming abstraction with Kafka support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-tasks/Cargo.toml
+++ b/crates/reinhardt-tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-tasks"
-version = "0.3.0"
+version = "0.3.1"
 description = "Background task execution and scheduling"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-tasks/README.md
+++ b/crates/reinhardt-tasks/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["tasks"] }
+reinhardt = { version = "0.3.1", features = ["tasks"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import task features:

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-test"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-test/README.md
+++ b/crates/reinhardt-test/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["test"] }
+reinhardt = { version = "0.3.1", features = ["test"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import testing features:

--- a/crates/reinhardt-testkit-macros/Cargo.toml
+++ b/crates/reinhardt-testkit-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-testkit/Cargo.toml
+++ b/crates/reinhardt-testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-throttling/Cargo.toml
+++ b/crates/reinhardt-throttling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-throttling"
-version = "0.3.0"
+version = "0.3.1"
 description = "Throttling and rate limiting for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-urls"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-urls/README.md
+++ b/crates/reinhardt-urls/README.md
@@ -54,14 +54,14 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:4 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["urls"] }
+reinhardt = { version = "0.3.1", features = ["urls"] }
 
 # For specific sub-features:
-# reinhardt = { version = "0.3.0", features = ["urls-routers", "urls-proxy"] }
+# reinhardt = { version = "0.3.1", features = ["urls-routers", "urls-proxy"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import URLs features:

--- a/crates/reinhardt-urls/routers-macros/Cargo.toml
+++ b/crates/reinhardt-urls/routers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-routers-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-utils"
-version = "0.3.0"
+version = "0.3.1"
 description = "Utility functions aggregator for Reinhardt"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-utils/README.md
+++ b/crates/reinhardt-utils/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["utils"] }
+reinhardt = { version = "0.3.1", features = ["utils"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import utility features:

--- a/crates/reinhardt-views/CHANGELOG.md
+++ b/crates/reinhardt-views/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kent8192/reinhardt-web/compare/reinhardt-views@v0.3.0...reinhardt-views@v0.3.1) - 2026-07-04
+
+### Fixed
+
+- *(ci)* unblock quick-xml security audit
+
 ## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-views@v0.2.0...reinhardt-views@v0.3.0) - 2026-06-28
 
 Stable release of `reinhardt-views` for the Reinhardt 0.3.0 line. This

--- a/crates/reinhardt-views/Cargo.toml
+++ b/crates/reinhardt-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-views"
-version = "0.3.0"
+version = "0.3.1"
 description = "View layer aggregator for viewsets and views-core"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-views/README.md
+++ b/crates/reinhardt-views/README.md
@@ -17,11 +17,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["views"] }
+reinhardt = { version = "0.3.1", features = ["views"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import view features:
@@ -263,7 +263,7 @@ use reinhardt::views::{OpenAPISpec, Info, PathItem, Operation};
 
 let spec = OpenAPISpec::new(Info::new(
     "My API".into(),
-    "0.3.0".into()
+    "0.3.1".into()
 ));
 ```
 

--- a/crates/reinhardt-websockets/Cargo.toml
+++ b/crates/reinhardt-websockets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-websockets"
-version = "0.3.0"
+version = "0.3.1"
 description = "WebSocket support for real-time bidirectional communication"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-websockets/README.md
+++ b/crates/reinhardt-websockets/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", features = ["websockets"] }
+reinhardt = { version = "0.3.1", features = ["websockets"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.0", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.0", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.1", features = ["full"] }      # All features
 ```
 
 Then import WebSocket features:

--- a/crates/tree-sitter-reinhardt-form/Cargo.toml
+++ b/crates/tree-sitter-reinhardt-form/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-reinhardt-form"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/tree-sitter-reinhardt-head/Cargo.toml
+++ b/crates/tree-sitter-reinhardt-head/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-reinhardt-head"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/tree-sitter-reinhardt-page/Cargo.toml
+++ b/crates/tree-sitter-reinhardt-page/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-reinhardt-page"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/docs/superpowers/specs/2026-07-04-native-component-test-harness-design.md
+++ b/docs/superpowers/specs/2026-07-04-native-component-test-harness-design.md
@@ -1,0 +1,435 @@
+# Native Component Test Harness
+
+**Issue**: [#5583](https://github.com/kent8192/reinhardt-web/issues/5583)
+**Date**: 2026-07-04
+**Status**: Approved design (pending implementation plan)
+
+## Summary
+
+Add a native component testing harness for `reinhardt-pages` that can render a
+`Page` into an in-memory interactive DOM, query it with Testing
+Library-inspired role/text/label helpers, dispatch common events, mock
+`server_fn` calls per test, and await reactive settling without a browser or
+WASM toolchain.
+
+The first public surface lives in `reinhardt_pages::testing::component` and is
+re-exported through the `reinhardt` facade as `reinhardt::test::pages`.
+
+## Motivation
+
+Meaningful component behavior tests currently need the WASM path: browser
+execution, `wasm-pack`, mocked fetch, and a headless runtime. That path remains
+valuable for hydration and browser API coverage, but it is too expensive for
+the majority of component interaction tests.
+
+The framework already has a native `Page` representation, native event handler
+storage via `DummyEvent`, SSR rendering, native client API stubs, and
+MSW-style `MockableServerFn` metadata. The missing layer is an interactive
+test runtime that uses those native structures directly.
+
+## Goals
+
+- Render a `Page` under plain `cargo test` with no browser, no `wasm-pack`, and
+  no loopback server for the component harness itself.
+- Query rendered output by user-facing semantics: role, accessible name, label,
+  placeholder, and text.
+- Dispatch common events against stored `Page` event handlers.
+- Let `screen.settle().await` drive test-scoped async work and reactive
+  rerendering deterministically.
+- Mock `server_fn` calls in process, per test, using generated
+  `MockableServerFn` marker metadata.
+- Produce stable pretty output suitable for diagnostic messages and snapshots.
+
+## Non-Goals
+
+- Browser E2E, hydration correctness, layout, CSS, focus ring, scrolling, and
+  visual assertions.
+- Full DOM, `web-sys`, or ARIA implementation parity.
+- Replacing the WASM smoke-test path.
+- Replacing native direct `server_fn` unit tests for business logic.
+- Intercepting arbitrary HTTP clients, `reqwest`, `hyper`, AWS SDK calls, or
+  OS-level network traffic.
+
+## Recommended Approach
+
+Build a native interactive DOM from the `Page` tree itself.
+
+Alternatives considered:
+
+| Approach | Trade-off |
+|---|---|
+| Native `TestNode` tree from `Page` | Fast, preserves event handlers and reactive structure, matches existing types |
+| SSR HTML parse plus event sidecar | Reuses HTML output but makes event and reactive mapping fragile |
+| Broad native pseudo-`web-sys` DOM | Browser-like, but far beyond the accepted scope |
+
+The `Page` tree is the authoritative structure for this harness. HTML parsing
+would discard exactly the event and reactive metadata the harness needs.
+
+## Public API
+
+Primary module:
+
+```rust
+reinhardt_pages::testing::component
+```
+
+Facade re-export:
+
+```rust
+reinhardt::test::pages
+```
+
+Representative usage:
+
+```rust
+use reinhardt::test::pages::{Role, render};
+
+#[rstest]
+#[tokio::test]
+async fn refresh_loads_jobs() {
+    let screen = render(jobs(Path(1)));
+    screen.mock_server_fn::<load_jobs::marker>(|args| Ok(vec![job("Index job")]));
+
+    screen.get_by_role(Role::Button, "Refresh").click();
+    screen.settle().await;
+
+    assert!(screen.query_by_text("Index job").is_some());
+}
+```
+
+Initial stable types:
+
+| Type | Purpose |
+|---|---|
+| `Screen` | Owns the rendered test DOM, query engine, scheduler, and server function mocks |
+| `ElementHandle` | Refers to a node inside a `Screen` by stable node id |
+| `Role` | Typed role query input |
+| `TextMatch` | Exact text matching for queries |
+| `QueryError` | Structured query failure diagnostics |
+| `EventError` | Structured event dispatch failure diagnostics |
+| `SettleError` | Structured async settling failure diagnostics |
+
+Initial query methods:
+
+| Method family | Behavior |
+|---|---|
+| `get_by_role`, `get_by_text`, `get_by_label`, `get_by_placeholder` | Panic with rich diagnostics on zero or multiple matches |
+| `try_get_by_*` | Return `Result<ElementHandle, QueryError>` |
+| `query_by_*` | Return `Option<ElementHandle>` on zero or one match; panic on multiple matches |
+| `find_by_*` | Await `settle()` loops until one match or timeout |
+| `try_find_by_*` | Async `Result` variant for helper code |
+
+Initial event methods:
+
+| Method | Event type |
+|---|---|
+| `click()` / `try_click()` | `click` |
+| `submit()` / `try_submit()` | `submit` |
+| `input(value)` / `try_input(value)` | `input`, updates test element value first |
+| `change(value)` / `try_change(value)` | `change`, updates test element value first |
+
+Snapshot support starts with:
+
+```rust
+screen.pretty()
+```
+
+The returned string must be stable enough for `insta` snapshots.
+
+## Architecture
+
+`Screen` owns four coordinated subsystems:
+
+1. **In-memory DOM tree**: `TestNode` values built from `Page`.
+2. **Query engine**: role, accessible-name, label, placeholder, and text
+   matching over `TestNode`.
+3. **Test scheduler**: harness-scoped async task queue and reactive rerender
+   queue.
+4. **Server function mocks**: per-screen registry keyed by
+   `MockableServerFn::PATH` and marker type.
+
+The render pipeline is:
+
+```text
+Page -> TestNode tree -> query/event -> scheduler -> rerender
+```
+
+`ElementHandle` stores the owning screen reference and a node id. It does not
+own nodes directly. After rerendering, a handle remains usable if the node id is
+still present. If the node has been removed, event and read operations fail
+with `DetachedElement`.
+
+## Test DOM Model
+
+`TestNode` stores:
+
+- node id
+- optional parent id
+- node kind: element, text, fragment root, reactive anchor
+- tag name for element nodes
+- attributes
+- children
+- current form value for input-like nodes
+- event handlers copied from `PageElement`
+- source role/name cache invalidated on rerender
+
+Fragments do not appear as queryable elements. They only group children under
+the screen root. `Page::WithHead` renders only the view portion. Head metadata
+is outside component interaction scope.
+
+Reactive nodes are represented as anchors whose current child subtree is
+replaceable. This keeps rerendering local and avoids rebuilding the full screen
+for every signal change.
+
+## Reactive Rendering
+
+`Page::Reactive` and `Page::ReactiveIf` are evaluated inside a harness render
+scope. The scope records which reactive anchor produced which subtree.
+
+When signals or effects mark a reactive anchor dirty, the screen schedules that
+anchor for rerender. Rerendering replaces the anchor's current child subtree
+with a fresh `Page -> TestNode` expansion.
+
+Normal native and SSR behavior must not change. Outside a component harness,
+native task spawning remains a no-op and native resources stay in their
+existing SSR-oriented loading behavior.
+
+## Scheduler
+
+The native platform layer gains an internal test hook point. Under a `Screen`
+RAII guard, `platform::native::spawn_task` enqueues futures into the active
+harness scheduler. Without the guard, it keeps the current no-op behavior.
+
+`screen.settle().await` repeats this loop:
+
+1. poll queued tasks until no immediately-ready work remains;
+2. apply pending signal/effect notifications;
+3. rerender dirty reactive anchors;
+4. enqueue any new tasks produced by rerendered hooks;
+5. stop when task and rerender queues are both empty.
+
+`settle()` has a timeout and maximum iteration count. A self-triggering effect
+or infinite refetch loop returns `SettleError::DidNotQuiesce` with pending task
+counts and `screen.pretty()` output.
+
+The first implementation requires an async test context such as
+`#[tokio::test]` or async `rstest`. Blocking settle helpers are out of scope
+for the first release.
+
+## Server Function Mocks
+
+The harness adds an in-process mock registry for generated native client stubs.
+`screen.mock_server_fn::<S>(handler)` registers a handler where
+`S: MockableServerFn` and the handler accepts `S::Args` and returns
+`Result<S::Response, ServerFnError>`.
+
+Generated native client stubs check the active harness registry before taking
+their normal native path. When a matching handler exists, the stub:
+
+1. serializes the original call arguments into `S::Args`;
+2. records the call;
+3. calls the registered handler;
+4. returns the handler response using the same `ServerFnError` type as normal
+   server functions.
+
+If a component harness is active and no mock exists for a called server
+function, the stub returns a deterministic `ServerFnError` that names the
+missing path. It must not perform external HTTP or use the native
+`MockServiceWorker` loopback runtime.
+
+Call inspection:
+
+```rust
+let calls = screen.calls_to_server_fn::<load_jobs::marker>();
+assert_eq!(calls.len(), 1);
+```
+
+The existing `MockServiceWorker` remains the right tool for native tests that
+explicitly exercise HTTP clients against a loopback server. The component
+harness registry is for in-process component tests only.
+
+## Queries And Accessibility
+
+Query priority follows Testing Library's user-centric model:
+
+1. role plus accessible name;
+2. label for form controls;
+3. placeholder for inputs;
+4. text for non-interactive content.
+
+Initial `Role` variants:
+
+- `Alert`
+- `Button`
+- `Checkbox`
+- `Combobox`
+- `Dialog`
+- `Form`
+- `Heading`
+- `Link`
+- `List`
+- `Listbox`
+- `ListItem`
+- `Main`
+- `Navigation`
+- `Option`
+- `Progressbar`
+- `Radio`
+- `Status`
+- `Textbox`
+
+`Role::Custom(String)` is intentionally not included in the first release.
+Unknown roles should become explicit enum additions so test semantics stay
+auditable.
+
+Role resolution order:
+
+1. explicit `role` attribute;
+2. supported HTML implicit roles.
+
+Initial implicit role coverage:
+
+| HTML | Role |
+|---|---|
+| `button` | `Button` |
+| `a[href]` | `Link` |
+| `input[type=text/search/email/password/url/tel]` | `Textbox` |
+| `input[type=checkbox]` | `Checkbox` |
+| `input[type=radio]` | `Radio` |
+| `textarea` | `Textbox` |
+| `select` | `Combobox` or `Listbox` based on attributes |
+| `form` | `Form` when it has an accessible name |
+| `nav` | `Navigation` |
+| `main` | `Main` |
+| `h1` through `h6` | `Heading` |
+| `dialog` | `Dialog` |
+| `ul` / `ol` | `List` |
+| `li` | `ListItem` |
+| `option` | `Option` |
+| `progress` | `Progressbar` |
+
+Accessible name resolution for MVP:
+
+1. `aria-label`;
+2. `aria-labelledby` references;
+3. `label[for=id]` for form controls;
+4. nearest parent `label`;
+5. button/link/heading text content;
+6. input placeholder as a fallback for input-centric queries.
+
+Elements with `hidden` or `aria-hidden="true"` are excluded by default.
+Hidden opt-in can be added later.
+
+`TextMatch` starts with exact string matching. Regex, predicate matching, and
+case-insensitive matching are deferred.
+
+Diagnostics include the failed query, candidate roles/names, and pretty DOM.
+
+## Event Dispatch
+
+Event methods invoke stored `PageEventHandler` values with `DummyEvent`.
+
+For input-like events, the test node stores a current value before dispatching
+the handler. The event object remains `DummyEvent` in the first release; richer
+event payloads can be added when the framework has a cross-target event value
+abstraction.
+
+Event bubbling is out of scope for the first release. The handler attached to
+the target element is called directly. This matches the current `PageElement`
+storage model and keeps the first harness deterministic.
+
+## Error Handling
+
+The API provides both panic-first test ergonomics and `Result`-returning helper
+variants.
+
+| Error | Examples |
+|---|---|
+| `QueryError::NotFound` | no matching role/text/label/placeholder |
+| `QueryError::MultipleMatches` | `get_by_*` found more than one element |
+| `EventError::DetachedElement` | stale handle after rerender removed node |
+| `EventError::MissingHandler` | `click()` on an element without a click handler |
+| `SettleError::DidNotQuiesce` | timeout or max iteration count exceeded |
+| `SettleError::TaskFailed` | scheduler task failed or panicked |
+
+Panic messages should include the structured error plus `screen.pretty()`.
+`Result` variants should carry enough data for framework tests to assert on the
+failure without string matching.
+
+## Testing Strategy
+
+Tests live primarily in `crates/reinhardt-pages`.
+
+Required coverage:
+
+| Area | Coverage |
+|---|---|
+| Render tree | element, text, fragment, keyed fragment, `WithHead` view content |
+| Queries | role/name, label, placeholder, text, hidden exclusion, multiple match error |
+| Events | `click`, `submit`, `input`, `change`, missing handler, detached handle |
+| Reactivity | signal-driven rerender after event |
+| Async hooks | `use_action` success/error and `use_resource` success/error/refetch |
+| Server functions | registered mock, unregistered mock error, call recording |
+| Settling | quiescent case, timeout/non-quiescent diagnostic |
+| Snapshots | stable `screen.pretty()` output |
+| Facade | `reinhardt::test::pages` re-export compiles in a downstream-style test |
+
+Validation commands for the implementation phase should include at least:
+
+```bash
+cargo test -p reinhardt-pages component_testing --all-features
+cargo test -p reinhardt-pages --test ui --all-features
+cargo make fmt-check
+cargo clippy -p reinhardt-pages --all-features --tests -- -D warnings
+```
+
+If public API changes affect semver checks, run the repository's local semver
+check workflow before marking the eventual PR ready.
+
+## Documentation
+
+Update these documentation surfaces with implementation:
+
+- `crates/reinhardt-pages/src/testing.rs`
+- `crates/reinhardt-pages/README.md`
+- `crates/reinhardt-pages/CHANGELOG.md`
+- the `reinhardt` facade docs or README surface that exports
+  `reinhardt::test::pages`
+
+The docs should position this as the native component testing layer. They
+should keep direct `server_fn` invocation as the default for business logic and
+WASM/browser tests as the default for hydration and browser API coverage.
+
+## Performance Acceptance
+
+The harness should make a representative interaction test at least one order
+of magnitude faster than the equivalent WASM/browser path. The first
+implementation should record the measured native command and representative
+duration in the PR notes or a small benchmark note; timing should not become a
+brittle unit-test assertion. The acceptance target is browser-toolchain-free
+execution in the single-digit to low-double-digit millisecond range for a
+small component interaction.
+
+## Implementation Boundaries
+
+The implementation should stay within these boundaries:
+
+- Keep normal native `spawn_task` behavior unchanged outside active component
+  test scopes.
+- Use RAII guards for scheduler and mock registry activation.
+- Avoid introducing broad browser DOM abstractions.
+- Avoid adding new unresolved placeholder markers.
+- Keep query semantics explicit and documented rather than silently accepting
+  unsupported ARIA behavior.
+- Preserve existing WASM MSW behavior and native `MockServiceWorker` behavior.
+
+## Open Design Decisions Closed By This Spec
+
+| Decision | Choice |
+|---|---|
+| MVP scope | Full vertical slice: render, query, event, settle, server_fn mock |
+| API location | `reinhardt_pages::testing::component`, facade as `reinhardt::test::pages` |
+| Async model | async tests using `screen.settle().await` |
+| Server function mocking | in-process registry keyed by `MockableServerFn` metadata |
+| DOM model | `Page` to native `TestNode`, not parsed SSR HTML |
+| Snapshot model | `screen.pretty()` stable text output |

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -35,7 +35,7 @@ By default, examples use the parent Reinhardt checkout through the examples work
 <!-- reinhardt-version-sync -->
 ```toml
 [workspace.dependencies]
-reinhardt = { path = "..", version = "0.3.0", package = "reinhardt-web" }
+reinhardt = { path = "..", version = "0.3.1", package = "reinhardt-web" }
 ```
 
 ### Explicit Patch Mode
@@ -69,7 +69,7 @@ rm -f .cargo/config.toml
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
-reinhardt = { version = "0.3.0", package = "reinhardt-web", features = ["core", "database"] }
+reinhardt = { version = "0.3.1", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine
 tokio = { workspace = true }
@@ -85,7 +85,7 @@ rstest = "0.26.1"
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", package = "reinhardt-web", features = ["core"] }
+reinhardt = { version = "0.3.1", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER
 reinhardt-di = { path = "../../../crates/reinhardt-di" }          # ❌ NEVER

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -35,7 +35,7 @@ By default, examples use the parent Reinhardt checkout through the examples work
 <!-- reinhardt-version-sync -->
 ```toml
 [workspace.dependencies]
-reinhardt = { path = "..", version = "0.3.0", package = "reinhardt-web" }
+reinhardt = { path = "..", version = "0.3.1", package = "reinhardt-web" }
 ```
 
 ### Explicit Patch Mode
@@ -69,7 +69,7 @@ rm -f .cargo/config.toml
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
-reinhardt = { version = "0.3.0", package = "reinhardt-web", features = ["core", "database"] }
+reinhardt = { version = "0.3.1", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine
 tokio = { workspace = true }
@@ -85,7 +85,7 @@ rstest = "0.26.1"
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.0", package = "reinhardt-web", features = ["core"] }
+reinhardt = { version = "0.3.1", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER
 reinhardt-di = { path = "../../../crates/reinhardt-di" }          # ❌ NEVER

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [workspace.dependencies]
 # Reinhardt framework from this repository.
 # reinhardt-version-sync
-reinhardt = { path = "..", version = "0.3.0", package = "reinhardt-web" }
+reinhardt = { path = "..", version = "0.3.1", package = "reinhardt-web" }
 
 # The examples workspace is resolved independently in standalone CI, so it must
 # carry the same resolver workaround as the root workspace.

--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -699,7 +699,10 @@ pub fn question_new() -> Page {
 	let form_view = new_form.into_page();
 	let cancel_href = polls_routes::reverse("index", &[]);
 
-	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, cancel_href: String| {
+	page!(|loading_signal: Signal<bool>,
+	 error_signal: Signal<Option<String>>,
+	 form_view: Page,
+	 cancel_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {
@@ -799,7 +802,10 @@ pub fn question_edit(question_id: i64) -> Page {
 	let edit_form_error = edit_form.error().clone();
 	let edit_form_loading = edit_form.loading().clone();
 	let edit_form_page = edit_form.into_page();
-	let edit_form_view = page!(|edit_form_error: Signal<Option<String>>, edit_form_loading: Signal<bool>, edit_form_page: Page, question_id: i64| {
+	let edit_form_view = page!(|edit_form_error: Signal<Option<String>>,
+	 edit_form_loading: Signal<bool>,
+	 edit_form_page: Page,
+	 question_id: i64| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {
@@ -850,7 +856,9 @@ pub fn question_edit(question_id: i64) -> Page {
 		question_id,
 	);
 
-	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>, edit_form_view: Page, question_id: i64| {
+	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>,
+	 edit_form_view: Page,
+	 question_id: i64| {
 		div { {
 			match load_detail.get() {
 				ResourceState::Loading => page!(|| {
@@ -914,7 +922,11 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 		&[("question_id", question_id.to_string().as_str())],
 	);
 
-	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>, error_signal: Signal<Option<String>>, loading_signal: Signal<bool>, form_view: Page, cancel_href: String| {
+	page!(|load_detail: Resource<(QuestionInfo, Vec<ChoiceInfo>), String>,
+	 error_signal: Signal<Option<String>>,
+	 loading_signal: Signal<bool>,
+	 form_view: Page,
+	 cancel_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {
@@ -1045,7 +1057,10 @@ pub fn choice_new(question_id: i64) -> Page {
 	let form_view = new_form.into_page();
 	let back_href = polls_routes::reverse("detail", &[("question_id", qid.to_string().as_str())]);
 
-	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, back_href: String| {
+	page!(|loading_signal: Signal<bool>,
+	 error_signal: Signal<Option<String>>,
+	 form_view: Page,
+	 back_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {
@@ -1124,7 +1139,10 @@ pub fn choice_edit(question_id: i64, choice_id: i64) -> Page {
 	let error_signal = edit_form.error().clone();
 	let form_view = edit_form.into_page();
 
-	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, cancel_href: String| {
+	page!(|loading_signal: Signal<bool>,
+	 error_signal: Signal<Option<String>>,
+	 form_view: Page,
+	 cancel_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {
@@ -1197,7 +1215,10 @@ pub fn choice_delete_confirm(question_id: i64, choice_id: i64) -> Page {
 	let error_signal = delete_form.error().clone();
 	let form_view = delete_form.into_page();
 
-	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, cancel_href: String| {
+	page!(|loading_signal: Signal<bool>,
+	 error_signal: Signal<Option<String>>,
+	 form_view: Page,
+	 cancel_href: String| {
 		div {
 			class: "max-w-4xl mx-auto px-4 mt-12",
 			h1 {

--- a/examples/examples-tutorial-basis/src/apps/users/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/client/components.rs
@@ -45,7 +45,11 @@ pub fn login_form() -> Page {
 	let polls_index_href = polls_routes::reverse("index", &[]);
 	let signup_href = users_routes::reverse("signup", &[]);
 
-	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, polls_index_href: String, signup_href: String| {
+	page!(|loading_signal: Signal<bool>,
+	 error_signal: Signal<Option<String>>,
+	 form_view: Page,
+	 polls_index_href: String,
+	 signup_href: String| {
 		div {
 			class: "max-w-md mx-auto px-4 mt-12",
 			div {
@@ -207,7 +211,11 @@ pub fn signup_form() -> Page {
 	let polls_index_href = polls_routes::reverse("index", &[]);
 	let login_href = users_routes::reverse("login", &[]);
 
-	page!(|loading_signal: Signal<bool>, error_signal: Signal<Option<String>>, form_view: Page, polls_index_href: String, login_href: String| {
+	page!(|loading_signal: Signal<bool>,
+	 error_signal: Signal<Option<String>>,
+	 form_view: Page,
+	 polls_index_href: String,
+	 login_href: String| {
 		div {
 			class: "max-w-md mx-auto px-4 mt-12",
 			div {

--- a/examples/examples-tutorial-basis/src/client/components/nav.rs
+++ b/examples/examples-tutorial-basis/src/client/components/nav.rs
@@ -30,7 +30,11 @@ pub fn nav_bar() -> Page {
 	let login_href = users_routes::reverse("login", &[]);
 	let logout_href = users_routes::reverse("logout", &[]);
 	let signup_href = users_routes::reverse("signup", &[]);
-	page!(|auth_signal: Action<Option<UserInfo>, String>, polls_index_href: String, login_href: String, logout_href: String, signup_href: String| {
+	page!(|auth_signal: Action<Option<UserInfo>, String>,
+	 polls_index_href: String,
+	 login_href: String,
+	 logout_href: String,
+	 signup_href: String| {
 		nav {
 			class: "nav-bar",
 			a {

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,3 +10,9 @@
 
 #[cfg(feature = "test")]
 pub use reinhardt_test::*;
+
+/// Pages component testing utilities.
+#[cfg(all(feature = "test", feature = "pages"))]
+pub mod pages {
+	pub use reinhardt_pages::testing::component::*;
+}

--- a/website/config.toml
+++ b/website/config.toml
@@ -24,11 +24,11 @@ og_image    = "https://reinhardt-web.dev/og-image.png"
 github_repo = "https://github.com/kent8192/reinhardt-web"
 crates_io   = "https://crates.io/crates/reinhardt-web"
 # reinhardt-version-sync
-docs_rs     = "https://docs.rs/reinhardt-web/0.3.0/reinhardt/"
+docs_rs     = "https://docs.rs/reinhardt-web/0.3.1/reinhardt/"
 changelog   = "https://github.com/kent8192/reinhardt-web/blob/main/CHANGELOG.md"
 deepwiki    = "https://deepwiki.com/kent8192/reinhardt-web"
 # reinhardt-version-sync
-reinhardt_version = "0.3.0"
+reinhardt_version = "0.3.1"
 
 # Populated at build time by deploy-website.yml.
 # Local dev: no version selector is shown (empty versions list).

--- a/website/content/docs/api/_index.md
+++ b/website/content/docs/api/_index.md
@@ -14,7 +14,7 @@ sidebar_weight = 10
 Welcome to the Reinhardt API reference documentation. This guide provides comprehensive information about Reinhardt's APIs, modules, and components.
 
 <!-- reinhardt-version-sync -->
-> **Note**: Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.3.0/reinhardt/).
+> **Note**: Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.3.1/reinhardt/).
 > Comprehensive documentation is also available in each crate's `lib.rs` file.
 
 ## Reinhardt Crate Structure
@@ -930,7 +930,7 @@ Main package that re-exports all components based on feature flags.
 **Documentation:**
 
 <!-- reinhardt-version-sync -->
-- [Main documentation](https://docs.rs/reinhardt-web/0.3.0/reinhardt/)
+- [Main documentation](https://docs.rs/reinhardt-web/0.3.1/reinhardt/)
 - [Feature Flags Guide](/docs/feature-flags/)
 
 ## Common Patterns
@@ -996,4 +996,4 @@ Found an error in the documentation? Want to improve it?
 ---
 
 <!-- reinhardt-version-sync -->
-**Note**: This is a high-level overview. Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.3.0/reinhardt/). Comprehensive documentation is also available in each crate's `lib.rs` file.
+**Note**: This is a high-level overview. Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.3.1/reinhardt/). Comprehensive documentation is also available in each crate's `lib.rs` file.

--- a/website/content/docs/cookbook/_index.md
+++ b/website/content/docs/cookbook/_index.md
@@ -38,6 +38,6 @@ The Cookbook provides practical guides for solving common tasks.
 ## See Also
 
 <!-- reinhardt-version-sync -->
-- [API Reference](https://docs.rs/reinhardt-web/0.3.0/reinhardt/)
+- [API Reference](https://docs.rs/reinhardt-web/0.3.1/reinhardt/)
 - [Migration Guides](/quickstart/migration-guides/)
 - [Troubleshooting](../troubleshooting/)

--- a/website/content/docs/troubleshooting/_index.md
+++ b/website/content/docs/troubleshooting/_index.md
@@ -30,6 +30,6 @@ Troubleshooting guides provide solutions to common problems encountered during d
 ## See Also
 
 <!-- reinhardt-version-sync -->
-- [API Reference](https://docs.rs/reinhardt-web/0.3.0/reinhardt/)
+- [API Reference](https://docs.rs/reinhardt-web/0.3.1/reinhardt/)
 - [Cookbook](../cookbook/)
 - [Migration Guides](/quickstart/migration-guides/)

--- a/website/content/quickstart/_index.md
+++ b/website/content/quickstart/_index.md
@@ -17,7 +17,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.0"
+cargo install reinhardt-admin-cli --version "0.3.1"
 ```
 
 ## 2. Create your project

--- a/website/content/quickstart/getting-started.md
+++ b/website/content/quickstart/getting-started.md
@@ -31,7 +31,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.0"
+cargo install reinhardt-admin-cli --version "0.3.1"
 ```
 
 **Note:** After installation, the command is `reinhardt-admin`, not
@@ -381,7 +381,7 @@ Check out the [ORM documentation](/docs/api/) for more details.
 ## Getting Help
 
 <!-- reinhardt-version-sync -->
-- 📖 [API Reference](https://docs.rs/reinhardt-web/0.3.0/reinhardt/)
+- 📖 [API Reference](https://docs.rs/reinhardt-web/0.3.1/reinhardt/)
 - 🗺️ [DeepWiki](https://deepwiki.com/kent8192/reinhardt-web) - AI-generated codebase documentation
 - 💬 [GitHub Discussions](https://github.com/kent8192/reinhardt-web/discussions)
 - 🐛 [Report Issues](https://github.com/kent8192/reinhardt-web/issues)

--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -19,13 +19,13 @@ Use Rust 1.96.0 or newer. The generated Rust 2024 project requires that
 toolchain level.
 
 <!-- reinhardt-version-sync -->
-This tutorial uses the `0.3.0` Reinhardt generator.
+This tutorial uses the `0.3.1` Reinhardt generator.
 
 Install the Reinhardt project generator:
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.0"
+cargo install reinhardt-admin-cli --version "0.3.1"
 ```
 
 The installed binary is `reinhardt-admin`.
@@ -121,14 +121,14 @@ features used by later parts of this tutorial:
 <!-- reinhardt-version-sync -->
 ```toml
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-reinhardt = { version = "0.3.0", package = "reinhardt-web", default-features = false, features = ["pages", "client-router"] }
+reinhardt = { version = "0.3.1", package = "reinhardt-web", default-features = false, features = ["pages", "client-router"] }
 wasm-bindgen = "=0.2.122"
 ```
 
 <!-- reinhardt-version-sync -->
 ```toml
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reinhardt = { version = "0.3.0", package = "reinhardt-web", default-features = false, features = [
+reinhardt = { version = "0.3.1", package = "reinhardt-web", default-features = false, features = [
     "minimal",
     "pages",
     "client-router",

--- a/website/content/quickstart/tutorials/rest/1-project-setup.md
+++ b/website/content/quickstart/tutorials/rest/1-project-setup.md
@@ -19,7 +19,7 @@ Install `reinhardt-admin-cli` once:
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.0"
+cargo install reinhardt-admin-cli --version "0.3.1"
 ```
 
 The installed command is named `reinhardt-admin`.

--- a/website/content/quickstart/tutorials/rest/_index.md
+++ b/website/content/quickstart/tutorials/rest/_index.md
@@ -51,7 +51,7 @@ Install the Reinhardt project generator before starting Part 1:
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.0"
+cargo install reinhardt-admin-cli --version "0.3.1"
 ```
 
 After installation, the command is `reinhardt-admin`.


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds a native component testing harness for `reinhardt-pages`, exposed through `reinhardt_pages::testing::component` and `reinhardt::test::pages`.
- Implements Testing Library-style render, query, interaction, async settle, and pretty DOM helpers for native `cargo test` workflows.
- Adds per-test native `server_fn` mocks behind the existing `msw` feature and wires native task scheduling into the harness.
- Documents the harness in the pages README and CHANGELOG.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Native component tests should be able to validate accessible markup, user-style interactions, and mocked server functions without requiring a browser, wasm-pack, or a server process. This gives pages users a faster unit-test layer before heavier WASM or browser coverage.

Fixes #5583

Related to: N/A

## How Was This Tested?

- `env -u RUSTC_WRAPPER -u SCCACHE_DIR CARGO_TARGET_DIR=/Users/kent8192/Projects/reinhardt/target CARGO_BUILD_BUILD_DIR=/Users/kent8192/Projects/reinhardt/target/cargo-build cargo make fmt-check`
- `env -u RUSTC_WRAPPER -u SCCACHE_DIR CARGO_TARGET_DIR=/Users/kent8192/Projects/reinhardt/target CARGO_BUILD_BUILD_DIR=/Users/kent8192/Projects/reinhardt/target/cargo-build cargo clippy -p reinhardt-pages --all-features --tests -- -D warnings`
- `env -u RUSTC_WRAPPER -u SCCACHE_DIR CARGO_TARGET_DIR=/Users/kent8192/Projects/reinhardt/target CARGO_BUILD_BUILD_DIR=/Users/kent8192/Projects/reinhardt/target/cargo-build cargo test -p reinhardt-pages --test component_testing --features testing,msw`
- `env -u RUSTC_WRAPPER -u SCCACHE_DIR CARGO_TARGET_DIR=/Users/kent8192/Projects/reinhardt/target CARGO_BUILD_BUILD_DIR=/Users/kent8192/Projects/reinhardt/target/cargo-build cargo test -p reinhardt-pages testing::component --features testing,msw --lib`
- `env -u RUSTC_WRAPPER -u SCCACHE_DIR CARGO_TARGET_DIR=/Users/kent8192/Projects/reinhardt/target CARGO_BUILD_BUILD_DIR=/Users/kent8192/Projects/reinhardt/target/cargo-build cargo test -p reinhardt-pages reactive::hooks::async_action::tests::test_use_action_dispatch_native --features testing --lib -- --exact`
- `env -u RUSTC_WRAPPER -u SCCACHE_DIR CARGO_TARGET_DIR=/Users/kent8192/Projects/reinhardt/target CARGO_BUILD_BUILD_DIR=/Users/kent8192/Projects/reinhardt/target/cargo-build cargo test -p reinhardt-pages --test ui --all-features`
- `/usr/bin/time -p env -u RUSTC_WRAPPER -u SCCACHE_DIR CARGO_TARGET_DIR=/Users/kent8192/Projects/reinhardt/target CARGO_BUILD_BUILD_DIR=/Users/kent8192/Projects/reinhardt/target/cargo-build cargo test -p reinhardt-pages --test component_testing --features testing,msw server_fn_mock_feeds_resource -- --exact`

## Performance Impact

The focused native mock/resource test completed with `real 0.46` seconds locally. The harness runs under plain native `cargo test` and does not invoke browser or WASM tooling. Production task behavior is unchanged outside an active native component test harness.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage (AWS Spot instances),
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5583

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This PR is intentionally opened as a draft because the public testing API additions should still receive normal CI and semver validation before being marked ready.