### PR TITLE
fix(pages): use keyword type in page fixtures

### DIFF
--- a/crates/reinhardt-manouche/src/validator/page.rs
+++ b/crates/reinhardt-manouche/src/validator/page.rs
@@ -2975,7 +2975,7 @@ mod tests {
 		// Arrange
 		let ast: PageMacro = syn::parse2(quote::quote! {
 			|| {
-				input { id: "email", r#type: "email", name: "email" }
+				input { id: "email", type: "email", name: "email" }
 				label { r#for: "email", "Email" }
 			}
 		})
@@ -2993,7 +2993,7 @@ mod tests {
 		// Arrange
 		let ast: PageMacro = syn::parse2(quote::quote! {
 			|| {
-				input { r#type: "text", name: "q" }
+				input { type: "text", name: "q" }
 			}
 		})
 		.unwrap();
@@ -3016,7 +3016,7 @@ mod tests {
 		let ast: PageMacro = syn::parse2(quote::quote! {
 			|show_input: bool| {
 				if show_input {
-					input { id: "query", r#type: "text", name: "query" }
+					input { id: "query", type: "text", name: "query" }
 				} else {
 					label { r#for: "query", "Query" }
 				}
@@ -3041,7 +3041,7 @@ mod tests {
 		// Arrange
 		let ast: PageMacro = syn::parse2(quote::quote! {
 			|| {
-				input { r#type: "range", name: "decorative", a11y: off }
+				input { type: "range", name: "decorative", a11y: off }
 			}
 		})
 		.unwrap();

--- a/crates/reinhardt-pages/tests/ui/page/fail/accessibility_validation.rs
+++ b/crates/reinhardt-pages/tests/ui/page/fail/accessibility_validation.rs
@@ -19,7 +19,7 @@ fn wrapper(_p: WrapperProps) -> Page {
 fn main() {
 	let _unlabelled_input = page!(|| {
 		input {
-			r#type: "text",
+			type: "text",
 			name: "query",
 		}
 	});
@@ -27,7 +27,7 @@ fn main() {
 	let _empty_wrapping_label = page!(|| {
 		label {
 			input {
-				r#type: "text",
+				type: "text",
 				name: "email",
 			}
 		}
@@ -39,7 +39,7 @@ fn main() {
 		}
 		input {
 			id: "email-empty",
-			r#type: "text",
+			type: "text",
 			name: "email",
 		}
 	});
@@ -53,7 +53,7 @@ fn main() {
 		}
 		input {
 			id: "component-email",
-			r#type: "text",
+			type: "text",
 			name: "email",
 		}
 	});
@@ -68,14 +68,14 @@ fn main() {
 		}
 		input {
 			id: "hidden-label-email",
-			r#type: "text",
+			type: "text",
 			name: "email",
 		}
 	});
 
 	let _missing_aria_labelledby_target = page!(|| {
 		input {
-			r#type: "text",
+			type: "text",
 			name: "search",
 			aria_labelledby: "missing-label",
 		}
@@ -87,7 +87,7 @@ fn main() {
 
 	let _input_button_without_value = page!(|| {
 		input {
-			r#type: "button",
+			type: "button",
 		}
 	});
 
@@ -115,7 +115,7 @@ fn main() {
 
 	let _invalid_opt_out = page!(|| {
 		input {
-			r#type: "range",
+			type: "range",
 			name: "decorative",
 			a11y: true,
 		}

--- a/crates/reinhardt-pages/tests/ui/page/pass/accessibility_validation.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/accessibility_validation.rs
@@ -8,7 +8,7 @@ fn main() {
 	let labelled_by_for_after_control = page!(|| {
 		input {
 			id: "search",
-			r#type: "search",
+			type: "search",
 			name: "search",
 		}
 		label {
@@ -21,7 +21,7 @@ fn main() {
 		label {
 			"Volume"
 			input {
-				r#type: "range",
+				type: "range",
 				name: "volume",
 			}
 		}
@@ -59,17 +59,17 @@ fn main() {
 
 	let input_button_names = page!(|| {
 		input {
-			r#type: "submit",
+			type: "submit",
 			value: "Save",
 		}
 		input {
-			r#type: "submit",
+			type: "submit",
 		}
 		input {
-			r#type: "reset",
+			type: "reset",
 		}
 		input {
-			r#type: "image",
+			type: "image",
 			src: "/icons/save.svg",
 			alt: "Save",
 		}
@@ -86,7 +86,7 @@ fn main() {
 		div {
 			hidden: true,
 			input {
-				r#type: "text",
+				type: "text",
 				name: "hidden-query",
 			}
 			select {
@@ -121,7 +121,7 @@ fn main() {
 
 	let opt_out = page!(|| {
 		input {
-			r#type: "range",
+			type: "range",
 			name: "decorative",
 			a11y: off,
 		}


### PR DESCRIPTION
## Summary

This PR addresses:

- Replaces `r#type` with direct `type` attributes in the `page!` accessibility validation fixtures added by PR #5585.
- Leaves Rust raw identifier handling and non-`page!` `r#type` usages unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The `page!` DSL accepts the HTML `type` attribute directly, so accessibility fixtures should use `type:` rather than Rust raw identifier spelling. This keeps the examples aligned with the public DSL style.

Fixes #5564

Related to: #5585

## How Was This Tested?

- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/reinhardt-target-5585-type cargo test -p reinhardt-manouche validator::page::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/reinhardt-target-5585-type cargo test -p reinhardt-pages-macros page::validator::tests -- --nocapture`
- `cargo fmt --all --check`

Not run locally:

- Full `cargo make clippy-check`
- Full `cargo test -p reinhardt-pages --test ui test_page_macro`

## Performance Impact

Not performance-related. This only changes compile-time test fixtures.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #5564
- Follow-up to #5585

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This PR is intentionally draft while remote CI runs.