### PR TITLE
fix(ci): allow release-plz examples lockfile updates

### DIFF
--- a/instructions/RELEASE_PROCESS.md
+++ b/instructions/RELEASE_PROCESS.md
@@ -337,6 +337,7 @@ git_release_type = "auto"
 semver_check = true
 publish_timeout = "10m"
 dependencies_update = true
+allow_dirty = true
 release_always = true
 publish_no_verify = true
 
@@ -423,6 +424,10 @@ During `cargo publish`, Cargo attempts to build the crate including dev-dependen
 
 Enables release-plz to automatically update explicit `version` fields in workspace dependency declarations when a dependent crate's version is bumped. Without this, workspace members that pin explicit versions would become out-of-sync after a release, causing the next Release PR to carry stale dependency versions. (Ref: [#223](https://github.com/kent8192/reinhardt-web/pull/223))
 
+**`allow_dirty = true`**
+
+Allows release-plz to include generated working-tree changes in the Release PR update. Reinhardt tracks `examples/Cargo.lock` for the independent examples workspace; when release-plz bumps package versions and dependency versions, that lockfile can refresh before the Release PR branch is created. Without `allow_dirty`, `release-plz release-pr` aborts with a dirty tree instead of carrying the lockfile update into the generated Release PR.
+
 **`release_always = true`**
 
 Ensures `release-plz release` publishes ALL crates whose local version differs from crates.io, not just those with actual code changes. This prevents the phantom version issue described in [KI-5](#ki-5-phantom-version-bumps-from-dependencies_update): when `dependencies_update = true` bumps versions for dependency-only changes, `release_always = false` would skip publishing those crates, creating versions in git that don't exist on crates.io. Normal code pushes are unaffected since local versions match crates.io; only after a Release PR merge will version differences trigger publishing. (Ref: [#185](https://github.com/kent8192/reinhardt-web/pull/185), [#186](https://github.com/kent8192/reinhardt-web/pull/186), [#246](https://github.com/kent8192/reinhardt-web/issues/246))
@@ -446,6 +451,7 @@ flowchart TD
     B -->|gix cache panic| F["RP-3: Re-run release-plz<br/>(transient error)"]
     B -->|Phantom version bump| G["KI-5: Set release_always = true"]
     B -->|Yanked prerelease| H["KI-7: Advance to fresh prerelease<br/>do not reuse yanked version"]
+    B -->|examples/Cargo.lock dirty| I["KI-8: Keep allow_dirty = true<br/>include generated lockfile diff"]
 ```
 
 ### KI-1: Circular Publish Dependencies
@@ -594,6 +600,25 @@ release-plz step succeeded, so the root release-plz failure is not hidden by a
 secondary expression error.
 
 (Ref: [#4828](https://github.com/kent8192/reinhardt-web/issues/4828))
+
+### KI-8: Examples Lockfile Dirty During `release-pr`
+
+**Problem**: `release-plz release-pr` updates package versions and versioned
+workspace dependencies before opening or updating the generated Release PR.
+The independent examples workspace tracks `examples/Cargo.lock`, and its path
+dependency on the root `reinhardt-web` package can cause that lockfile to
+refresh during the release-pr update.
+
+**Symptoms**:
+- The Release-plz workflow fails in the `release-plz release-pr` step
+- The error reports a dirty working tree with `["examples/Cargo.lock"]`
+- No Release PR update is created for the pushed commit
+
+**Resolution**: Keep `allow_dirty = true` in `release-plz.toml` so release-plz
+includes the generated `examples/Cargo.lock` change in the Release PR instead
+of aborting. Do not edit generated `release-plz-*` or
+`develop-release-plz-*` branches directly; fix the base branch configuration and
+let release-plz regenerate the Release PR.
 
 ---
 
@@ -765,7 +790,8 @@ cargo publish --dry-run -p reinhardt-web  # root crate depends on reinhardt-test
 - **Partial Failure**: See [KI-3: Partial Release Failure Deadlock](#ki-3-partial-release-failure-deadlock) and [RP-1](#rp-1-partial-release-failure-recovery)
 - **gix Panic**: See [KI-4: gix/gitoxide Slotmap Overflow](#ki-4-gixgitoxide-slotmap-overflow) and [RP-3](#rp-3-gix-cache-failure-recovery)
 - **Phantom Version (dependency not found)**: See [KI-5: Phantom Version Bumps from `dependencies_update`](#ki-5-phantom-version-bumps-from-dependencies_update)
-    - **Rate Limit (429)**: See [KI-6: crates.io Rate Limit](#ki-6-cratesio-rate-limit-429-too-many-requests)
+- **Rate Limit (429)**: See [KI-6: crates.io Rate Limit](#ki-6-cratesio-rate-limit-429-too-many-requests)
+- **Examples lockfile dirty**: See [KI-8: Examples Lockfile Dirty During `release-pr`](#ki-8-examples-lockfile-dirty-during-release-pr)
 
 **CHANGELOG Not Updated:**
 - Ensure `changelog_update = true` in config

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -33,6 +33,10 @@ git_release_type = "auto"
 semver_check = true
 publish_timeout = "10m"
 dependencies_update = true
+# The examples workspace has a tracked Cargo.lock. Release PR version and
+# dependency updates can refresh that lockfile before release-plz creates the
+# branch, so include the generated lockfile diff instead of aborting.
+allow_dirty = true
 
 # Two-stage release workflow (native release-plz control):
 # - Stage 1: Push to main -> `release-plz release-pr` creates Release PR (branch: release-plz-*)


### PR DESCRIPTION
## Summary

This PR addresses:

- Allow `release-plz release-pr` to include generated `examples/Cargo.lock` updates instead of aborting on a dirty working tree.
- Document the Release-plz failure pattern and the `allow_dirty = true` rationale in the release process guide.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The Release-plz workflow failed in `release-plz release-pr` for run 28732595947 / job 85200949731 because Release PR generation left `examples/Cargo.lock` dirty before the generated PR update could be created:

```text
the working directory of this project has uncommitted changes
["examples/Cargo.lock"]
```

`examples/Cargo.lock` is tracked for the independent examples workspace. During release-pr generation, package version and dependency updates can refresh that lockfile. `allow_dirty = true` lets release-plz include that generated lockfile diff in the Release PR rather than aborting.

Fixes: N/A

Related to: #5585

## How Was This Tested?

- `git diff --check`
- `python3 -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("release-plz.toml").read_text())'`
- `release-plz release-pr --help | rg -n "allow-dirty|config"`

Full `release-plz release-pr` was not run locally because it can create or update Release PRs.

## Performance Impact

N/A

## Screenshots

N/A

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #5585
- Failed workflow job: https://github.com/kent8192/reinhardt-web/actions/runs/28732595947/job/85200949731

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- release-plz documents `allow_dirty` as a workspace setting for carrying generated dirty-tree updates into Release PR generation.