### PR TITLE
Cherry-pick #5603 into develop/0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ di = [
   "reinhardt-db?/di",
   "reinhardt-grpc?/di",
 ]
-test = ["reinhardt-test"]
+test = ["reinhardt-test", "reinhardt-pages?/testing"]
 testcontainers = ["test", "reinhardt-test/testcontainers"]
 server-fn-test = ["test", "reinhardt-test/server-fn-test"]
 # MSW (Mock Service Worker) for WASM testing — exposes

--- a/benchmarks/frontend/runner/servers.ts
+++ b/benchmarks/frontend/runner/servers.ts
@@ -50,7 +50,9 @@ export async function startServer(command: string, cwd: string, url: string, tim
       throw new Error(`server failed to start: ${spawnError.message}`);
     }
     if (child.exitCode !== null) {
-      throw new Error(`server exited before readiness: ${logExcerpt(server.stdout, server.stderr)}`);
+      const output = logExcerpt(server.stdout, server.stderr);
+      await stopServer(server);
+      throw new Error(`server exited before readiness: ${output}`);
     }
     try {
       const response = await fetch(url);

--- a/crates/reinhardt-admin/src/core/model_admin.rs
+++ b/crates/reinhardt-admin/src/core/model_admin.rs
@@ -624,7 +624,7 @@ mod tests {
 		let result = admin.has_view_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(result, false);
+		assert!(!result);
 	}
 
 	#[rstest]
@@ -638,7 +638,7 @@ mod tests {
 		let result = admin.has_add_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(result, false);
+		assert!(!result);
 	}
 
 	#[rstest]
@@ -652,7 +652,7 @@ mod tests {
 		let result = admin.has_change_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(result, false);
+		assert!(!result);
 	}
 
 	#[rstest]
@@ -666,7 +666,7 @@ mod tests {
 		let result = admin.has_delete_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(result, false);
+		assert!(!result);
 	}
 
 	#[rstest]
@@ -683,10 +683,10 @@ mod tests {
 		let delete = admin.has_delete_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(view, true);
-		assert_eq!(add, true);
-		assert_eq!(change, true);
-		assert_eq!(delete, true);
+		assert!(view);
+		assert!(add);
+		assert!(change);
+		assert!(delete);
 	}
 
 	#[rstest]
@@ -703,10 +703,10 @@ mod tests {
 		let delete = admin.has_delete_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(view, false);
-		assert_eq!(add, false);
-		assert_eq!(change, false);
-		assert_eq!(delete, false);
+		assert!(!view);
+		assert!(!add);
+		assert!(!change);
+		assert!(!delete);
 	}
 
 	// ==================== ModelAdminConfig field tests ====================
@@ -789,8 +789,8 @@ mod tests {
 		let add = admin.has_add_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(view, false);
-		assert_eq!(add, false);
+		assert!(!view);
+		assert!(!add);
 	}
 
 	#[rstest]
@@ -809,8 +809,8 @@ mod tests {
 		let add = admin.has_add_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(view, true);
-		assert_eq!(add, false);
+		assert!(view);
+		assert!(!add);
 	}
 
 	#[rstest]
@@ -831,10 +831,10 @@ mod tests {
 		let delete = admin.has_delete_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(view, true);
-		assert_eq!(add, true);
-		assert_eq!(change, true);
-		assert_eq!(delete, true);
+		assert!(view);
+		assert!(add);
+		assert!(change);
+		assert!(delete);
 	}
 
 	#[rstest]
@@ -853,8 +853,8 @@ mod tests {
 		let add = admin.has_add_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(view, false);
-		assert_eq!(add, false);
+		assert!(!view);
+		assert!(!add);
 	}
 
 	#[rstest]
@@ -878,10 +878,10 @@ mod tests {
 		let delete = admin.has_delete_permission(&user as &dyn AdminUser).await;
 
 		// Assert
-		assert_eq!(view, true);
-		assert_eq!(add, true);
-		assert_eq!(change, false);
-		assert_eq!(delete, false);
+		assert!(view);
+		assert!(add);
+		assert!(!change);
+		assert!(!delete);
 	}
 
 	// ==================== Decision table: allow_all controls permissions ====================

--- a/crates/reinhardt-admin/src/server/limits.rs
+++ b/crates/reinhardt-admin/src/server/limits.rs
@@ -89,8 +89,10 @@ mod tests {
 	#[rstest]
 	fn default_page_size_does_not_exceed_max() {
 		// Act & Assert
-		assert!(DEFAULT_PAGE_SIZE > 0);
-		assert!(DEFAULT_PAGE_SIZE <= MAX_PAGE_SIZE);
+		const {
+			assert!(DEFAULT_PAGE_SIZE > 0);
+			assert!(DEFAULT_PAGE_SIZE <= MAX_PAGE_SIZE);
+		}
 	}
 
 	#[rstest]

--- a/crates/reinhardt-admin/src/server/security.rs
+++ b/crates/reinhardt-admin/src/server/security.rs
@@ -939,7 +939,7 @@ mod tests {
 
 		// Assert
 		assert_eq!(data.get("age").unwrap().as_i64().unwrap(), 25);
-		assert_eq!(data.get("active").unwrap().as_bool().unwrap(), true);
+		assert!(data.get("active").unwrap().as_bool().unwrap());
 		assert!(data.get("tags").unwrap().is_null());
 	}
 

--- a/crates/reinhardt-admin/src/types/requests.rs
+++ b/crates/reinhardt-admin/src/types/requests.rs
@@ -19,7 +19,7 @@ const MAX_FILTER_STRING_LENGTH: usize = 500;
 /// Filter parameters are explicitly provided via the `filters` field rather than
 /// captured via `serde(flatten)`, preventing unrecognized query parameters from
 /// silently becoming database filters.
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ListQueryParams {
 	/// Page number (1-indexed)
 	pub page: Option<u64>,
@@ -110,7 +110,7 @@ pub struct MutationRequest {
 }
 
 /// Request body for bulk delete
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BulkDeleteRequest {
 	/// CSRF token for mutation verification (double-submit cookie pattern).
 	///

--- a/crates/reinhardt-core/src/lib.rs
+++ b/crates/reinhardt-core/src/lib.rs
@@ -329,6 +329,8 @@ pub use crate::types::page;
 
 #[cfg(feature = "macros")]
 pub use reinhardt_macros as macros;
+#[cfg(feature = "macros")]
+pub use reinhardt_macros::Validate;
 
 // Re-export rate limiting types
 pub use crate::rate_limit::RateLimitStrategy;

--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add native component testing utilities under
+  `reinhardt_pages::testing::component`, including in-memory `Page` rendering,
+  role/text/label queries, event helpers, async settling, pretty DOM output,
+  and in-process `server_fn` mocks for `MockableServerFn` markers.
+
 ### Changed
 
 - **BREAKING**: Route-backed component macros now require the route name as

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -319,6 +319,32 @@ fn error_display() -> View {
 3. **Clone captured handles**: direct `page!({ ... })` clones captured values into generated closures
 4. **Use closure form for factories**: keep `page!(|props: Props| { ... })` when the page must be called later
 
+## Testing
+
+### Native Component Tests
+
+Use `reinhardt_pages::testing::component::render` for fast interaction tests
+that do not need a browser:
+
+```rust
+use reinhardt_pages::testing::component::{Role, render};
+
+#[tokio::test]
+async fn refresh_loads_jobs() {
+    let screen = render(jobs_page);
+    screen.mock_server_fn::<load_jobs::marker>(|_args| Ok(vec!["Index job".to_string()]));
+
+    screen.get_by_role(Role::Button, "Refresh").click();
+    screen.settle().await;
+
+    assert!(screen.query_by_text("Index job").is_some());
+}
+```
+
+The mock API uses `MockableServerFn` markers and therefore requires the
+`msw` feature. Use direct `server_fn` calls for business logic tests and
+WASM/browser tests for hydration or browser API coverage.
+
 ## Architecture
 
 This framework consists of several key modules:

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -570,23 +570,28 @@ fn add_native_mock_probe(
 	let pages_crate = &pages_crate_info.ident;
 	let name = info.name();
 	let original_block = func.block;
-	func.block = Box::new(syn::parse_quote!({
-		#pages_use_statement
-		#[cfg(all(any(test, feature = "testing"), feature = "msw"))]
-		#[allow(unexpected_cfgs)]
-		{
-			let __args = #name::Args {
-				#(#param_idents: #param_idents.clone()),*
-			};
-			if let Some(__mock_result) =
-				#pages_crate::server_fn::try_call_active_mock::<#name::marker>(__args)
+	let native_mock_probe = if cfg!(feature = "msw") {
+		quote! {
 			{
-				match __mock_result {
-					Ok(__mock_value) => return Ok(__mock_value),
-					Err(__mock_error) => return Err(__mock_error),
+				let __args = #name::Args {
+					#(#param_idents: #param_idents.clone()),*
+				};
+				if let Some(__mock_result) =
+					#pages_crate::server_fn::try_call_active_mock::<#name::marker>(__args)
+				{
+					match __mock_result {
+						Ok(__mock_value) => return Ok(__mock_value),
+						Err(__mock_error) => return Err(__mock_error),
+					}
 				}
 			}
 		}
+	} else {
+		quote! {}
+	};
+	func.block = Box::new(syn::parse_quote!({
+		#pages_use_statement
+		#native_mock_probe
 		#original_block
 	}));
 	Ok(func)

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -583,7 +583,7 @@ fn add_native_mock_probe(
 			{
 				match __mock_result {
 					Ok(__mock_value) => return Ok(__mock_value),
-					Err(__mock_error) => panic!("server function mock failed: {}", __mock_error),
+					Err(__mock_error) => return Err(__mock_error),
 				}
 			}
 		}

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -572,19 +572,23 @@ fn add_native_mock_probe(
 	let original_block = func.block;
 	let native_mock_probe = if cfg!(feature = "msw") {
 		quote! {
-			#[cfg(all(native, feature = "msw", feature = "testing"))]
-			// The consumer crate may not declare the testing feature outside component-test builds.
-			#[allow(unexpected_cfgs)]
 			{
-				let __args = #name::Args {
-					#(#param_idents: #param_idents.clone()),*
-				};
-				if let Some(__mock_result) =
-					#pages_crate::server_fn::try_call_active_mock::<#name::marker>(__args)
+				// Generated server functions may expand into consumer crates that do not
+				// declare an `msw` feature, even when the dependency feature is active.
+				#![allow(unexpected_cfgs)]
+
+				#[cfg(all(native, feature = "msw"))]
 				{
-					match __mock_result {
-						Ok(__mock_value) => return Ok(__mock_value),
-						Err(__mock_error) => return Err(__mock_error),
+					let __args = #name::Args {
+						#(#param_idents: #param_idents.clone()),*
+					};
+					if let Some(__mock_result) =
+						#pages_crate::server_fn::try_call_active_mock::<#name::marker>(__args)
+					{
+						match __mock_result {
+							Ok(__mock_value) => return Ok(__mock_value),
+							Err(__mock_error) => return Err(__mock_error),
+						}
 					}
 				}
 			}
@@ -1366,13 +1370,14 @@ fn generate_server_handler(
 	let msw_server_tokens = if msw_enabled {
 		quote! {
 			mod __msw {
+				// Generated MSW support may expand in crates that do not declare every
+				// optional cfg name used by this framework.
+				#![allow(unexpected_cfgs)]
+
 				use ::serde::{Serialize, Deserialize};
 
 				/// Public Args struct for MSW type-safe mocking.
-				#[derive(Serialize, Deserialize)]
-				#[cfg_attr(all(native, feature = "testing"), derive(Clone))]
-				// The generated Args type only derives Clone for native component-test builds.
-				#[allow(unexpected_cfgs)]
+				#[derive(Serialize, Deserialize, Clone)]
 				pub struct Args {
 					#(pub #regular_param_names: #regular_param_types),*
 				}
@@ -1400,33 +1405,37 @@ fn generate_server_handler(
 	// that don't themselves declare an `msw` feature.
 	let msw_wasm_inner_tokens = if msw_enabled {
 		quote! {
-			#[cfg(feature = "msw")]
-			#[allow(unexpected_cfgs)]
-			mod __msw_args {
-				#[allow(unused_imports)]
-				use super::*;
-				use ::serde::{Serialize, Deserialize};
+			mod __msw {
+				// Generated MSW support may expand in crates that do not declare every
+				// optional cfg name used by this framework.
+				#![allow(unexpected_cfgs)]
 
-				/// Public Args struct for MSW type-safe mocking.
-				#[derive(Serialize, Deserialize)]
-				#[cfg_attr(all(native, feature = "testing"), derive(Clone))]
-				// The generated Args type only derives Clone for native component-test builds.
-				#[allow(unexpected_cfgs)]
-				pub struct Args {
-					#(pub #regular_param_names: #regular_param_types),*
+				#[cfg(feature = "msw")]
+				mod args {
+					// The generated args module reuses caller-local type paths from the
+					// original server function signature.
+					#[allow(unused_imports)]
+					use super::super::*;
+					use ::serde::{Serialize, Deserialize};
+
+					/// Public Args struct for MSW type-safe mocking.
+					#[derive(Serialize, Deserialize, Clone)]
+					pub struct Args {
+						#(pub #regular_param_names: #regular_param_types),*
+					}
+				}
+
+				#[cfg(feature = "msw")]
+				pub use args::Args;
+
+				#[cfg(feature = "msw")]
+				impl #pages_crate::server_fn::MockableServerFn for super::marker {
+					type Args = Args;
+					type Response = #response_type;
 				}
 			}
 
-			#[cfg(feature = "msw")]
-			#[allow(unexpected_cfgs)]
-			pub use __msw_args::Args;
-
-			#[cfg(feature = "msw")]
-			#[allow(unexpected_cfgs)]
-			impl #pages_crate::server_fn::MockableServerFn for marker {
-				type Args = Args;
-				type Response = #response_type;
-			}
+			pub use __msw::*;
 		}
 	} else {
 		quote! {}

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -532,6 +532,66 @@ pub(crate) fn server_fn_impl(args: TokenStream, input: TokenStream) -> TokenStre
 	generate_server_fn(&info).into()
 }
 
+fn regular_server_fn_params(inputs: &Punctuated<FnArg, Token![,]>) -> Vec<&syn::PatType> {
+	inputs
+		.iter()
+		.filter_map(|arg| {
+			if let syn::FnArg::Typed(pat_type) = arg {
+				let has_inject = pat_type.attrs.iter().any(is_inject_attr);
+				if has_inject || is_extractor_type(&pat_type.ty) {
+					return None;
+				}
+				Some(pat_type)
+			} else {
+				None
+			}
+		})
+		.collect()
+}
+
+fn add_native_mock_probe(
+	info: &ServerFnInfo,
+	clean_func: &ItemFn,
+	regular_params: &[&syn::PatType],
+	pages_crate_info: &CratePathInfo,
+) -> Result<ItemFn, proc_macro2::TokenStream> {
+	let mut param_idents = Vec::new();
+	for param in regular_params {
+		let syn::Pat::Ident(pat_ident) = &*param.pat else {
+			return Err(quote! {
+				compile_error!("server_fn component-test mocks require identifier parameters");
+			});
+		};
+		param_idents.push(pat_ident.ident.clone());
+	}
+
+	let mut func = clean_func.clone();
+	let pages_use_statement = &pages_crate_info.use_statement;
+	let pages_crate = &pages_crate_info.ident;
+	let name = info.name();
+	let original_block = func.block;
+	func.block = Box::new(syn::parse_quote!({
+		#pages_use_statement
+		#[cfg(all(any(test, feature = "testing"), feature = "msw"))]
+		#[allow(unexpected_cfgs)]
+		{
+			let __args = #name::Args {
+				#(#param_idents: #param_idents.clone()),*
+			};
+			if let Some(__mock_result) =
+				#pages_crate::server_fn::try_call_active_mock::<#name::marker>(__args)
+			{
+				match __mock_result {
+					Ok(__mock_value) => return Ok(__mock_value),
+					Err(__mock_error) => panic!("server function mock failed: {}", __mock_error),
+				}
+			}
+		}
+		#original_block
+	}));
+	Ok(func)
+}
+
 /// Generate server function code
 ///
 /// This generates both client and server code with conditional compilation.
@@ -575,6 +635,12 @@ fn generate_server_fn(info: &ServerFnInfo) -> proc_macro2::TokenStream {
 
 	// Dynamically resolve reinhardt_pages crate path for client stub
 	let pages_crate_info = get_reinhardt_pages_crate_info();
+	let regular_params = regular_server_fn_params(&func.sig.inputs);
+	let native_clean_func =
+		match add_native_mock_probe(info, &clean_func, &regular_params, &pages_crate_info) {
+			Ok(func) => quote! { #func },
+			Err(err) => err,
+		};
 
 	// Generate client stub (with DI and extractor parameter filtering)
 	let client_stub =
@@ -589,7 +655,7 @@ fn generate_server_fn(info: &ServerFnInfo) -> proc_macro2::TokenStream {
 
 		// Server-side: Original function (with #[inject] attributes removed)
 		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-		#clean_func
+		#native_clean_func
 
 		// Client-side: HTTP request stub
 		#client_stub
@@ -1295,7 +1361,7 @@ fn generate_server_handler(
 				use ::serde::{Serialize, Deserialize};
 
 				/// Public Args struct for MSW type-safe mocking.
-				#[derive(Serialize, Deserialize)]
+				#[derive(Serialize, Deserialize, Clone)]
 				pub struct Args {
 					#(pub #regular_param_names: #regular_param_types),*
 				}
@@ -1331,7 +1397,7 @@ fn generate_server_handler(
 				use ::serde::{Serialize, Deserialize};
 
 				/// Public Args struct for MSW type-safe mocking.
-				#[derive(Serialize, Deserialize)]
+				#[derive(Serialize, Deserialize, Clone)]
 				pub struct Args {
 					#(pub #regular_param_names: #regular_param_types),*
 				}

--- a/crates/reinhardt-pages/macros/src/server_fn.rs
+++ b/crates/reinhardt-pages/macros/src/server_fn.rs
@@ -572,6 +572,9 @@ fn add_native_mock_probe(
 	let original_block = func.block;
 	let native_mock_probe = if cfg!(feature = "msw") {
 		quote! {
+			#[cfg(all(native, feature = "msw", feature = "testing"))]
+			// The consumer crate may not declare the testing feature outside component-test builds.
+			#[allow(unexpected_cfgs)]
 			{
 				let __args = #name::Args {
 					#(#param_idents: #param_idents.clone()),*
@@ -1366,7 +1369,10 @@ fn generate_server_handler(
 				use ::serde::{Serialize, Deserialize};
 
 				/// Public Args struct for MSW type-safe mocking.
-				#[derive(Serialize, Deserialize, Clone)]
+				#[derive(Serialize, Deserialize)]
+				#[cfg_attr(all(native, feature = "testing"), derive(Clone))]
+				// The generated Args type only derives Clone for native component-test builds.
+				#[allow(unexpected_cfgs)]
 				pub struct Args {
 					#(pub #regular_param_names: #regular_param_types),*
 				}
@@ -1402,7 +1408,10 @@ fn generate_server_handler(
 				use ::serde::{Serialize, Deserialize};
 
 				/// Public Args struct for MSW type-safe mocking.
-				#[derive(Serialize, Deserialize, Clone)]
+				#[derive(Serialize, Deserialize)]
+				#[cfg_attr(all(native, feature = "testing"), derive(Clone))]
+				// The generated Args type only derives Clone for native component-test builds.
+				#[allow(unexpected_cfgs)]
 				pub struct Args {
 					#(pub #regular_param_names: #regular_param_types),*
 				}

--- a/crates/reinhardt-pages/src/callback.rs
+++ b/crates/reinhardt-pages/src/callback.rs
@@ -546,7 +546,7 @@ mod tests {
 
 		let handler: PageEventHandler = into_event_handler(|_: DummyEvent| {});
 		// Verify it's callable
-		handler(DummyEvent::default());
+		handler(DummyEvent);
 	}
 }
 

--- a/crates/reinhardt-pages/src/callback.rs
+++ b/crates/reinhardt-pages/src/callback.rs
@@ -31,7 +31,6 @@ use std::future::Future;
 use std::sync::Arc;
 
 use crate::component::PageEventHandler;
-#[cfg(wasm)]
 use crate::platform::spawn_task;
 
 #[cfg(wasm)]
@@ -472,8 +471,7 @@ where
 	Fut: Future<Output = ()> + Send + 'static,
 {
 	Arc::new(move |event| {
-		// Non-WASM stub: drop the future without awaiting
-		std::mem::drop(f(event));
+		spawn_task(f(event));
 	})
 }
 

--- a/crates/reinhardt-pages/src/platform/native.rs
+++ b/crates/reinhardt-pages/src/platform/native.rs
@@ -6,9 +6,50 @@
 //! and task spawning degrades to a no-op since there is no browser event
 //! loop.
 
+use std::cell::RefCell;
 use std::future::Future;
+use std::pin::Pin;
 
 pub use crate::component::DummyEvent as Event;
+
+type BoxedTask = Pin<Box<dyn Future<Output = ()> + 'static>>;
+type TaskSink = Box<dyn Fn(BoxedTask) + 'static>;
+
+thread_local! {
+	static TASK_SINK: RefCell<Option<TaskSink>> = const { RefCell::new(None) };
+}
+
+pub(crate) struct NativeTaskSinkGuard {
+	previous: Option<TaskSink>,
+}
+
+impl Drop for NativeTaskSinkGuard {
+	fn drop(&mut self) {
+		let previous = self.previous.take();
+		TASK_SINK.with(|slot| {
+			*slot.borrow_mut() = previous;
+		});
+	}
+}
+
+pub(crate) fn install_task_sink(sink: impl Fn(BoxedTask) + 'static) -> NativeTaskSinkGuard {
+	let previous = TASK_SINK.with(|slot| slot.borrow_mut().replace(Box::new(sink)));
+	NativeTaskSinkGuard { previous }
+}
+
+pub(crate) fn try_spawn_task<F>(fut: F) -> bool
+where
+	F: Future<Output = ()> + 'static,
+{
+	TASK_SINK.with(|slot| {
+		if let Some(sink) = slot.borrow().as_ref() {
+			sink(Box::pin(fut));
+			true
+		} else {
+			false
+		}
+	})
+}
 
 /// Stub Window type for SSR compatibility.
 #[derive(Debug, Clone, Default)]
@@ -82,11 +123,11 @@ pub struct HtmlButtonElement;
 /// is dropped. Keeping `spawn_task` cross-target lets `form!`-generated
 /// submission handlers and reactive hooks compile identically on both
 /// targets.
-pub fn spawn_task<F>(_fut: F)
+pub fn spawn_task<F>(fut: F)
 where
 	F: Future<Output = ()> + 'static,
 {
-	// Non-WASM: no browser event loop; drop the future.
+	let _ = try_spawn_task(fut);
 }
 
 /// No-op microtask yield for native targets.

--- a/crates/reinhardt-pages/src/platform/native.rs
+++ b/crates/reinhardt-pages/src/platform/native.rs
@@ -19,10 +19,12 @@ thread_local! {
 	static TASK_SINK: RefCell<Option<TaskSink>> = const { RefCell::new(None) };
 }
 
+#[cfg(feature = "testing")]
 pub(crate) struct NativeTaskSinkGuard {
 	previous: Option<TaskSink>,
 }
 
+#[cfg(feature = "testing")]
 impl Drop for NativeTaskSinkGuard {
 	fn drop(&mut self) {
 		let previous = self.previous.take();
@@ -32,6 +34,7 @@ impl Drop for NativeTaskSinkGuard {
 	}
 }
 
+#[cfg(feature = "testing")]
 pub(crate) fn install_task_sink(sink: impl Fn(BoxedTask) + 'static) -> NativeTaskSinkGuard {
 	let previous = TASK_SINK.with(|slot| slot.borrow_mut().replace(Box::new(sink)));
 	NativeTaskSinkGuard { previous }

--- a/crates/reinhardt-pages/src/reactive/hooks/async_action.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/async_action.rs
@@ -532,6 +532,12 @@ where
 	let on_success_for_dispatch = Rc::clone(&on_success);
 	#[cfg(wasm)]
 	let reset_on_success_for_dispatch = Rc::clone(&reset_on_success);
+	#[cfg(native)]
+	let on_error_for_dispatch = Rc::clone(&on_error);
+	#[cfg(native)]
+	let on_success_for_dispatch = Rc::clone(&on_success);
+	#[cfg(native)]
+	let reset_on_success_for_dispatch = Rc::clone(&reset_on_success);
 
 	let dispatch_fn: Rc<dyn Fn()> = {
 		let state = state.clone();
@@ -580,9 +586,35 @@ where
 
 			#[cfg(native)]
 			{
-				// Non-WASM: drop the future, reset to Idle
-				let _fut = action_fn(*payload);
-				state.set(ActionPhase::Idle);
+				let task_state = state.clone();
+				let on_error = Rc::clone(&on_error_for_dispatch);
+				let on_success = Rc::clone(&on_success_for_dispatch);
+				let reset_on_success = Rc::clone(&reset_on_success_for_dispatch);
+				let fut = action_fn(*payload);
+				let spawned = crate::platform::try_spawn_task(async move {
+					match fut.await {
+						Ok(val) => {
+							let on_success = on_success.borrow().clone();
+							crate::reactive::batch(|| {
+								task_state.set(ActionPhase::Success(val.clone()));
+								on_success(&val);
+								if reset_on_success.get() {
+									task_state.set(ActionPhase::Idle);
+								}
+							});
+						}
+						Err(err) => {
+							let on_error = on_error.borrow().clone();
+							crate::reactive::batch(|| {
+								task_state.set(ActionPhase::Error(err.clone()));
+								on_error(&err);
+							});
+						}
+					}
+				});
+				if !spawned {
+					state.set(ActionPhase::Idle);
+				}
 			}
 		})
 	};

--- a/crates/reinhardt-pages/src/reactive/hooks/memo.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/memo.rs
@@ -251,7 +251,7 @@ mod tests {
 		use crate::component::DummyEvent;
 
 		let callback = use_callback(|_: DummyEvent| {}, ());
-		callback.call(DummyEvent::default());
+		callback.call(DummyEvent);
 	}
 
 	#[cfg(native)]

--- a/crates/reinhardt-pages/src/reactive/hooks/sync.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/sync.rs
@@ -296,7 +296,8 @@ mod tests {
 	#[test]
 	fn test_use_sync_external_store_with_update() {
 		let store_value = Rc::new(RefCell::new(0));
-		let on_change_fn: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
+		type OnChangeSlot = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
+		let on_change_fn: OnChangeSlot = Rc::new(RefCell::new(None));
 
 		let signal_with_sub = use_sync_external_store(
 			{

--- a/crates/reinhardt-pages/src/server_fn.rs
+++ b/crates/reinhardt-pages/src/server_fn.rs
@@ -88,6 +88,8 @@ pub mod router_ext;
 pub mod server_fn_trait;
 
 // Re-exports
+#[cfg(all(native, any(test, feature = "testing"), feature = "msw"))]
+pub use crate::testing::component::server_fn_mock::try_call_active_mock;
 #[cfg(feature = "msgpack")]
 pub use codec::MessagePackCodec;
 pub use codec::{Codec, JsonCodec, UrlCodec};

--- a/crates/reinhardt-pages/src/server_fn.rs
+++ b/crates/reinhardt-pages/src/server_fn.rs
@@ -106,15 +106,15 @@ pub use registry::{ServerFnHandler, ServerFnRoute};
 pub use router_ext::ServerFnRouterExt;
 pub use server_fn_trait::{ServerFn, ServerFnError, parse_server_error_message};
 
-#[cfg(all(native, any(test, feature = "testing"), feature = "msw"))]
+#[cfg(all(native, feature = "testing", feature = "msw"))]
 pub use crate::testing::component::server_fn_mock::try_call_active_mock;
 
-#[cfg(all(native, feature = "msw", not(any(test, feature = "testing"))))]
+#[cfg(all(native, feature = "msw", not(feature = "testing")))]
 /// No-op native server-function mock probe outside component-test builds.
 pub fn try_call_active_mock<S>(_: S::Args) -> Option<Result<S::Response, ServerFnError>>
 where
 	S: MockableServerFn + 'static,
-	S::Args: Clone + 'static,
+	S::Args: 'static,
 	S::Response: 'static,
 {
 	None

--- a/crates/reinhardt-pages/src/server_fn.rs
+++ b/crates/reinhardt-pages/src/server_fn.rs
@@ -88,8 +88,6 @@ pub mod router_ext;
 pub mod server_fn_trait;
 
 // Re-exports
-#[cfg(all(native, any(test, feature = "testing"), feature = "msw"))]
-pub use crate::testing::component::server_fn_mock::try_call_active_mock;
 #[cfg(feature = "msgpack")]
 pub use codec::MessagePackCodec;
 pub use codec::{Codec, JsonCodec, UrlCodec};
@@ -107,6 +105,20 @@ pub use registry::{ServerFnHandler, ServerFnRoute};
 #[cfg(native)]
 pub use router_ext::ServerFnRouterExt;
 pub use server_fn_trait::{ServerFn, ServerFnError, parse_server_error_message};
+
+#[cfg(all(native, any(test, feature = "testing"), feature = "msw"))]
+pub use crate::testing::component::server_fn_mock::try_call_active_mock;
+
+#[cfg(all(native, feature = "msw", not(any(test, feature = "testing"))))]
+/// No-op native server-function mock probe outside component-test builds.
+pub fn try_call_active_mock<S>(_: S::Args) -> Option<Result<S::Response, ServerFnError>>
+where
+	S: MockableServerFn + 'static,
+	S::Args: Clone + 'static,
+	S::Response: 'static,
+{
+	None
+}
 
 // Re-export the macro for convenience
 pub use reinhardt_pages_macros::server_fn;

--- a/crates/reinhardt-pages/src/testing.rs
+++ b/crates/reinhardt-pages/src/testing.rs
@@ -20,7 +20,17 @@
 //! }
 //! ```
 //!
-//! ## Layer 2: WASM Component Tests with Mocked HTTP
+//! ## Layer 2: Native Component Tests
+//!
+//! Native component tests use `component::render` to render component
+//! functions or `Page` values into an in-memory DOM and interact with them
+//! through role/text/label queries, event helpers, `settle()`, and in-process
+//! `server_fn` mocks.
+//!
+//! These tests run without a browser and are intended for component logic,
+//! query behavior, async hook settling, and typed server function mock flows.
+//!
+//! ## Layer 3: WASM Component Tests with Mocked HTTP
 //!
 //! Tests WASM components with mocked server function responses.
 //! Uses the mock HTTP infrastructure for predictable testing.
@@ -37,7 +47,7 @@
 //! }
 //! ```
 //!
-//! ## Layer 3: End-to-End Tests
+//! ## Layer 4: End-to-End Tests
 //!
 //! Full integration tests with real server and WASM frontend.
 //! Uses E2E test infrastructure for complete flow testing.
@@ -73,6 +83,10 @@ pub mod server_fn_test;
 
 #[cfg(native)]
 pub use server_fn_test::*;
+
+// Native component testing utilities.
+#[cfg(all(native, feature = "testing"))]
+pub mod component;
 
 // WASM DOM testing utilities (Layer 2 and 3)
 #[cfg(wasm)]

--- a/crates/reinhardt-pages/src/testing/component.rs
+++ b/crates/reinhardt-pages/src/testing/component.rs
@@ -1,0 +1,25 @@
+//! Native component testing harness.
+
+mod error;
+mod events;
+mod pretty;
+mod query;
+mod role;
+mod scheduler;
+mod screen;
+#[cfg(feature = "msw")]
+pub(crate) mod server_fn_mock;
+mod text_match;
+mod tree;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::{EventError, QueryError};
+pub use events::ElementHandle;
+pub use role::Role;
+pub use scheduler::SettleError;
+pub use screen::{Screen, TestRender, render};
+#[cfg(feature = "msw")]
+pub use server_fn_mock::{RecordedServerFnCall, ServerFnCallQuery};
+pub use text_match::TextMatch;

--- a/crates/reinhardt-pages/src/testing/component/error.rs
+++ b/crates/reinhardt-pages/src/testing/component/error.rs
@@ -1,0 +1,46 @@
+//! Error types for native component testing.
+
+use std::fmt;
+
+/// Error returned when a DOM query cannot identify one element.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryError {
+	/// No matching element was found.
+	NotFound,
+	/// More than one matching element was found.
+	MultipleMatches,
+}
+
+impl fmt::Display for QueryError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::NotFound => write!(f, "no matching element found"),
+			Self::MultipleMatches => write!(f, "multiple matching elements found"),
+		}
+	}
+}
+
+impl std::error::Error for QueryError {}
+
+/// Error returned when a synthetic event cannot be dispatched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventError {
+	/// The handle no longer points at a node in the screen tree.
+	DetachedElement,
+	/// The element has no handler for the requested event.
+	MissingHandler,
+	/// The requested event is not supported for this node.
+	UnsupportedElement,
+}
+
+impl fmt::Display for EventError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::DetachedElement => write!(f, "element is detached from the screen"),
+			Self::MissingHandler => write!(f, "element has no handler for the requested event"),
+			Self::UnsupportedElement => write!(f, "event is not supported for this element"),
+		}
+	}
+}
+
+impl std::error::Error for EventError {}

--- a/crates/reinhardt-pages/src/testing/component/events.rs
+++ b/crates/reinhardt-pages/src/testing/component/events.rs
@@ -1,0 +1,114 @@
+//! Stable element handles and synthetic event dispatch.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use reinhardt_core::types::page::{DummyEvent, EventType};
+
+use super::error::EventError;
+use super::tree::{NodeId, ScreenInner};
+
+/// Stable handle to an element in a rendered native test screen.
+#[derive(Clone)]
+pub struct ElementHandle {
+	pub(crate) inner: Rc<RefCell<ScreenInner>>,
+	pub(crate) node_id: NodeId,
+}
+
+impl ElementHandle {
+	pub(crate) fn new(inner: Rc<RefCell<ScreenInner>>, node_id: NodeId) -> Self {
+		Self { inner, node_id }
+	}
+
+	/// Dispatches a click event and panics when dispatch fails.
+	pub fn click(&self) {
+		self.try_click().expect("click dispatch failed");
+	}
+
+	/// Dispatches a click event.
+	pub fn try_click(&self) -> Result<(), EventError> {
+		self.dispatch(EventType::Click)
+	}
+
+	/// Updates the element value and dispatches an input event.
+	pub fn input(&self, value: impl Into<String>) {
+		self.try_input(value).expect("input dispatch failed");
+	}
+
+	/// Updates the element value and dispatches an input event.
+	pub fn try_input(&self, value: impl Into<String>) -> Result<(), EventError> {
+		self.dispatch_value(EventType::Input, value.into())
+	}
+
+	/// Updates the element value and dispatches a change event.
+	pub fn change(&self, value: impl Into<String>) {
+		self.try_change(value).expect("change dispatch failed");
+	}
+
+	/// Updates the element value and dispatches a change event.
+	pub fn try_change(&self, value: impl Into<String>) -> Result<(), EventError> {
+		self.dispatch_value(EventType::Change, value.into())
+	}
+
+	/// Returns the element text content.
+	pub fn text(&self) -> String {
+		self.inner.borrow().dom.text_content(self.node_id)
+	}
+
+	/// Returns the element tag name.
+	pub fn tag_name(&self) -> String {
+		self.inner
+			.borrow()
+			.dom
+			.element(self.node_id)
+			.map(|node| node.tag.clone())
+			.unwrap_or_default()
+	}
+
+	/// Returns the current internal form value for value-bearing elements.
+	pub fn value(&self) -> Option<String> {
+		self.inner.borrow().dom.value(self.node_id)
+	}
+
+	fn dispatch(&self, event_type: EventType) -> Result<(), EventError> {
+		let handler = {
+			let borrowed = self.inner.borrow();
+			if !borrowed.dom.contains(self.node_id) {
+				return Err(EventError::DetachedElement);
+			}
+			if borrowed.dom.element(self.node_id).is_none() {
+				return Err(EventError::UnsupportedElement);
+			}
+			borrowed.dom.event_handler(self.node_id, event_type)
+		};
+
+		let handler = handler.ok_or(EventError::MissingHandler)?;
+		handler(DummyEvent);
+		Ok(())
+	}
+
+	fn dispatch_value(&self, event_type: EventType, value: String) -> Result<(), EventError> {
+		let handler = {
+			let mut borrowed = self.inner.borrow_mut();
+			if !borrowed.dom.contains(self.node_id) {
+				return Err(EventError::DetachedElement);
+			}
+			if !borrowed.dom.set_value(self.node_id, value) {
+				return Err(EventError::UnsupportedElement);
+			}
+			borrowed.dom.event_handler(self.node_id, event_type)
+		};
+
+		let handler = handler.ok_or(EventError::MissingHandler)?;
+		handler(DummyEvent);
+		Ok(())
+	}
+}
+
+impl std::fmt::Debug for ElementHandle {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ElementHandle")
+			.field("node_id", &self.node_id)
+			.finish_non_exhaustive()
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/events.rs
+++ b/crates/reinhardt-pages/src/testing/component/events.rs
@@ -32,6 +32,16 @@ impl ElementHandle {
 		self.dispatch(EventType::Click)
 	}
 
+	/// Dispatches a submit event and panics when dispatch fails.
+	pub fn submit(&self) {
+		self.try_submit().expect("submit dispatch failed");
+	}
+
+	/// Dispatches a submit event.
+	pub fn try_submit(&self) -> Result<(), EventError> {
+		self.dispatch(EventType::Submit)
+	}
+
 	/// Updates the element value and dispatches an input event.
 	pub fn input(&self, value: impl Into<String>) {
 		self.try_input(value).expect("input dispatch failed");
@@ -73,7 +83,7 @@ impl ElementHandle {
 	}
 
 	fn dispatch(&self, event_type: EventType) -> Result<(), EventError> {
-		let (handler, scheduler) = {
+		let (handlers, scheduler) = {
 			let borrowed = self.inner.borrow();
 			if !borrowed.dom.contains(self.node_id) {
 				return Err(EventError::DetachedElement);
@@ -85,26 +95,37 @@ impl ElementHandle {
 				return Ok(());
 			}
 			(
-				borrowed.dom.event_handler(self.node_id, event_type),
+				borrowed.dom.event_handlers(self.node_id, event_type),
 				Rc::clone(&borrowed.scheduler),
 			)
 		};
 		#[cfg(feature = "msw")]
 		let mocks = self.inner.borrow().mocks.clone();
 
-		let handler = handler.ok_or(EventError::MissingHandler)?;
+		if handlers.is_empty() {
+			return Err(EventError::MissingHandler);
+		}
 		#[cfg(feature = "msw")]
 		{
-			let _mock_scope = server_fn_mock::activate(mocks);
-			scheduler.with_current(|| handler(DummyEvent));
+			server_fn_mock::with_active(mocks, || {
+				scheduler.with_current(|| {
+					for handler in handlers {
+						handler(DummyEvent);
+					}
+				});
+			});
 		}
 		#[cfg(not(feature = "msw"))]
-		scheduler.with_current(|| handler(DummyEvent));
+		scheduler.with_current(|| {
+			for handler in handlers {
+				handler(DummyEvent);
+			}
+		});
 		Ok(())
 	}
 
 	fn dispatch_value(&self, event_type: EventType, value: String) -> Result<(), EventError> {
-		let (handler, scheduler) = {
+		let (handlers, scheduler) = {
 			let mut borrowed = self.inner.borrow_mut();
 			if !borrowed.dom.contains(self.node_id) {
 				return Err(EventError::DetachedElement);
@@ -116,21 +137,32 @@ impl ElementHandle {
 				return Err(EventError::UnsupportedElement);
 			}
 			(
-				borrowed.dom.event_handler(self.node_id, event_type),
+				borrowed.dom.event_handlers(self.node_id, event_type),
 				Rc::clone(&borrowed.scheduler),
 			)
 		};
 		#[cfg(feature = "msw")]
 		let mocks = self.inner.borrow().mocks.clone();
 
-		let handler = handler.ok_or(EventError::MissingHandler)?;
+		if handlers.is_empty() {
+			return Err(EventError::MissingHandler);
+		}
 		#[cfg(feature = "msw")]
 		{
-			let _mock_scope = server_fn_mock::activate(mocks);
-			scheduler.with_current(|| handler(DummyEvent));
+			server_fn_mock::with_active(mocks, || {
+				scheduler.with_current(|| {
+					for handler in handlers {
+						handler(DummyEvent);
+					}
+				});
+			});
 		}
 		#[cfg(not(feature = "msw"))]
-		scheduler.with_current(|| handler(DummyEvent));
+		scheduler.with_current(|| {
+			for handler in handlers {
+				handler(DummyEvent);
+			}
+		});
 		Ok(())
 	}
 }

--- a/crates/reinhardt-pages/src/testing/component/events.rs
+++ b/crates/reinhardt-pages/src/testing/component/events.rs
@@ -64,22 +64,48 @@ impl ElementHandle {
 
 	/// Returns the element text content.
 	pub fn text(&self) -> String {
-		self.inner.borrow().dom.text_content(self.node_id)
+		self.try_text().expect("element text read failed")
+	}
+
+	/// Tries to return the element text content.
+	pub fn try_text(&self) -> Result<String, EventError> {
+		let borrowed = self.inner.borrow();
+		if !borrowed.dom.contains(self.node_id) {
+			return Err(EventError::DetachedElement);
+		}
+		Ok(borrowed.dom.text_content(self.node_id))
 	}
 
 	/// Returns the element tag name.
 	pub fn tag_name(&self) -> String {
-		self.inner
-			.borrow()
+		self.try_tag_name().expect("element tag read failed")
+	}
+
+	/// Tries to return the element tag name.
+	pub fn try_tag_name(&self) -> Result<String, EventError> {
+		let borrowed = self.inner.borrow();
+		if !borrowed.dom.contains(self.node_id) {
+			return Err(EventError::DetachedElement);
+		}
+		borrowed
 			.dom
 			.element(self.node_id)
 			.map(|node| node.tag.clone())
-			.unwrap_or_default()
+			.ok_or(EventError::UnsupportedElement)
 	}
 
 	/// Returns the current internal form value for value-bearing elements.
 	pub fn value(&self) -> Option<String> {
-		self.inner.borrow().dom.value(self.node_id)
+		self.try_value().expect("element value read failed")
+	}
+
+	/// Tries to return the current internal form value for value-bearing elements.
+	pub fn try_value(&self) -> Result<Option<String>, EventError> {
+		let borrowed = self.inner.borrow();
+		if !borrowed.dom.contains(self.node_id) {
+			return Err(EventError::DetachedElement);
+		}
+		Ok(borrowed.dom.value(self.node_id))
 	}
 
 	fn dispatch(&self, event_type: EventType) -> Result<(), EventError> {

--- a/crates/reinhardt-pages/src/testing/component/events.rs
+++ b/crates/reinhardt-pages/src/testing/component/events.rs
@@ -6,6 +6,8 @@ use std::rc::Rc;
 use reinhardt_core::types::page::{DummyEvent, EventType};
 
 use super::error::EventError;
+#[cfg(feature = "msw")]
+use super::server_fn_mock;
 use super::tree::{NodeId, ScreenInner};
 
 /// Stable handle to an element in a rendered native test screen.
@@ -71,7 +73,7 @@ impl ElementHandle {
 	}
 
 	fn dispatch(&self, event_type: EventType) -> Result<(), EventError> {
-		let handler = {
+		let (handler, scheduler) = {
 			let borrowed = self.inner.borrow();
 			if !borrowed.dom.contains(self.node_id) {
 				return Err(EventError::DetachedElement);
@@ -79,16 +81,27 @@ impl ElementHandle {
 			if borrowed.dom.element(self.node_id).is_none() {
 				return Err(EventError::UnsupportedElement);
 			}
-			borrowed.dom.event_handler(self.node_id, event_type)
+			(
+				borrowed.dom.event_handler(self.node_id, event_type),
+				Rc::clone(&borrowed.scheduler),
+			)
 		};
+		#[cfg(feature = "msw")]
+		let mocks = self.inner.borrow().mocks.clone();
 
 		let handler = handler.ok_or(EventError::MissingHandler)?;
-		handler(DummyEvent);
+		#[cfg(feature = "msw")]
+		{
+			let _mock_scope = server_fn_mock::activate(mocks);
+			scheduler.with_current(|| handler(DummyEvent));
+		}
+		#[cfg(not(feature = "msw"))]
+		scheduler.with_current(|| handler(DummyEvent));
 		Ok(())
 	}
 
 	fn dispatch_value(&self, event_type: EventType, value: String) -> Result<(), EventError> {
-		let handler = {
+		let (handler, scheduler) = {
 			let mut borrowed = self.inner.borrow_mut();
 			if !borrowed.dom.contains(self.node_id) {
 				return Err(EventError::DetachedElement);
@@ -96,11 +109,22 @@ impl ElementHandle {
 			if !borrowed.dom.set_value(self.node_id, value) {
 				return Err(EventError::UnsupportedElement);
 			}
-			borrowed.dom.event_handler(self.node_id, event_type)
+			(
+				borrowed.dom.event_handler(self.node_id, event_type),
+				Rc::clone(&borrowed.scheduler),
+			)
 		};
+		#[cfg(feature = "msw")]
+		let mocks = self.inner.borrow().mocks.clone();
 
 		let handler = handler.ok_or(EventError::MissingHandler)?;
-		handler(DummyEvent);
+		#[cfg(feature = "msw")]
+		{
+			let _mock_scope = server_fn_mock::activate(mocks);
+			scheduler.with_current(|| handler(DummyEvent));
+		}
+		#[cfg(not(feature = "msw"))]
+		scheduler.with_current(|| handler(DummyEvent));
 		Ok(())
 	}
 }

--- a/crates/reinhardt-pages/src/testing/component/events.rs
+++ b/crates/reinhardt-pages/src/testing/component/events.rs
@@ -81,6 +81,9 @@ impl ElementHandle {
 			if borrowed.dom.element(self.node_id).is_none() {
 				return Err(EventError::UnsupportedElement);
 			}
+			if borrowed.dom.suppresses_events(self.node_id) {
+				return Ok(());
+			}
 			(
 				borrowed.dom.event_handler(self.node_id, event_type),
 				Rc::clone(&borrowed.scheduler),
@@ -105,6 +108,9 @@ impl ElementHandle {
 			let mut borrowed = self.inner.borrow_mut();
 			if !borrowed.dom.contains(self.node_id) {
 				return Err(EventError::DetachedElement);
+			}
+			if borrowed.dom.suppresses_events(self.node_id) {
+				return Ok(());
 			}
 			if !borrowed.dom.set_value(self.node_id, value) {
 				return Err(EventError::UnsupportedElement);

--- a/crates/reinhardt-pages/src/testing/component/pretty.rs
+++ b/crates/reinhardt-pages/src/testing/component/pretty.rs
@@ -1,0 +1,57 @@
+//! Pretty-printer for native component test DOM trees.
+
+use super::tree::{NodeId, TestDom};
+
+pub(crate) fn pretty_dom(dom: &TestDom) -> String {
+	let mut output = String::new();
+	for child in dom.children(dom.root()) {
+		write_node(dom, *child, 0, &mut output);
+	}
+	output
+}
+
+fn write_node(dom: &TestDom, node_id: NodeId, depth: usize, output: &mut String) {
+	if let Some(text) = dom.text_node(node_id) {
+		output.push_str(&"  ".repeat(depth));
+		output.push_str(text);
+		output.push('\n');
+		return;
+	}
+
+	let Some(element) = dom.element(node_id) else {
+		for child in dom.children(node_id) {
+			write_node(dom, *child, depth, output);
+		}
+		return;
+	};
+
+	output.push_str(&"  ".repeat(depth));
+	output.push('<');
+	output.push_str(&element.tag);
+	for (name, value) in element.attrs() {
+		output.push(' ');
+		output.push_str(name);
+		output.push_str("=\"");
+		output.push_str(&escape_attr(value));
+		output.push('"');
+	}
+	output.push_str(">\n");
+
+	if !dom.is_void(node_id) {
+		for child in dom.children(node_id) {
+			write_node(dom, *child, depth + 1, output);
+		}
+		output.push_str(&"  ".repeat(depth));
+		output.push_str("</");
+		output.push_str(&element.tag);
+		output.push_str(">\n");
+	}
+}
+
+fn escape_attr(value: &str) -> String {
+	value
+		.replace('&', "&amp;")
+		.replace('"', "&quot;")
+		.replace('<', "&lt;")
+		.replace('>', "&gt;")
+}

--- a/crates/reinhardt-pages/src/testing/component/query.rs
+++ b/crates/reinhardt-pages/src/testing/component/query.rs
@@ -1,0 +1,129 @@
+//! Query engine for the native component test DOM.
+
+use super::error::QueryError;
+use super::events::ElementHandle;
+use super::role::{Role, accessible_name, role_for};
+use super::text_match::TextMatch;
+use super::tree::{NodeId, ScreenInner};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub(crate) fn by_text(
+	inner: &Rc<RefCell<ScreenInner>>,
+	text: TextMatch,
+) -> Result<ElementHandle, QueryError> {
+	one(inner, find_by_text(&inner.borrow(), &text))
+}
+
+pub(crate) fn query_by_text(
+	inner: &Rc<RefCell<ScreenInner>>,
+	text: TextMatch,
+) -> Result<Option<ElementHandle>, QueryError> {
+	let matches = find_by_text(&inner.borrow(), &text);
+	match matches.len() {
+		0 => Ok(None),
+		1 => Ok(Some(ElementHandle::new(inner.clone(), matches[0]))),
+		_ => Err(QueryError::MultipleMatches),
+	}
+}
+
+pub(crate) fn by_role_named(
+	inner: &Rc<RefCell<ScreenInner>>,
+	role: Role,
+	name: TextMatch,
+) -> Result<ElementHandle, QueryError> {
+	one(inner, find_by_role(&inner.borrow(), role, Some(&name)))
+}
+
+pub(crate) fn by_label(
+	inner: &Rc<RefCell<ScreenInner>>,
+	label: TextMatch,
+) -> Result<ElementHandle, QueryError> {
+	let borrowed = inner.borrow();
+	let matches = borrowed
+		.dom
+		.visible_elements()
+		.into_iter()
+		.filter(|node_id| {
+			borrowed.dom.element(*node_id).is_some_and(|node| {
+				node.supports_value()
+					&& accessible_name(&borrowed.dom, *node_id)
+						.as_deref()
+						.is_some_and(|name| label.matches(name))
+			})
+		})
+		.collect();
+	one(inner, matches)
+}
+
+pub(crate) fn by_placeholder(
+	inner: &Rc<RefCell<ScreenInner>>,
+	placeholder: TextMatch,
+) -> Result<ElementHandle, QueryError> {
+	let borrowed = inner.borrow();
+	let matches = borrowed
+		.dom
+		.visible_elements()
+		.into_iter()
+		.filter(|node_id| {
+			borrowed.dom.element(*node_id).is_some_and(|node| {
+				node.supports_value()
+					&& node
+						.attr("placeholder")
+						.is_some_and(|value| placeholder.matches(value))
+			})
+		})
+		.collect();
+	one(inner, matches)
+}
+
+fn one(
+	inner: &Rc<RefCell<ScreenInner>>,
+	matches: Vec<NodeId>,
+) -> Result<ElementHandle, QueryError> {
+	match matches.len() {
+		0 => Err(QueryError::NotFound),
+		1 => Ok(ElementHandle::new(inner.clone(), matches[0])),
+		_ => Err(QueryError::MultipleMatches),
+	}
+}
+
+fn find_by_text(inner: &ScreenInner, text: &TextMatch) -> Vec<NodeId> {
+	inner
+		.dom
+		.visible_elements()
+		.into_iter()
+		.filter(|node_id| element_has_exact_text_without_duplicate_child(inner, *node_id, text))
+		.collect()
+}
+
+fn find_by_role(inner: &ScreenInner, role: Role, name: Option<&TextMatch>) -> Vec<NodeId> {
+	inner
+		.dom
+		.visible_elements()
+		.into_iter()
+		.filter(|node_id| role_for(&inner.dom, *node_id) == Some(role))
+		.filter(|node_id| {
+			name.is_none_or(|name| {
+				accessible_name(&inner.dom, *node_id)
+					.as_deref()
+					.is_some_and(|candidate| name.matches(candidate))
+			})
+		})
+		.collect()
+}
+
+fn element_has_exact_text_without_duplicate_child(
+	inner: &ScreenInner,
+	node_id: NodeId,
+	text: &TextMatch,
+) -> bool {
+	if !text.matches(&inner.dom.text_content(node_id)) {
+		return false;
+	}
+	!inner.dom.children(node_id).iter().any(|child| {
+		inner.dom.element(*child).is_some()
+			&& !inner.dom.is_hidden(*child)
+			&& text.matches(&inner.dom.text_content(*child))
+	})
+}

--- a/crates/reinhardt-pages/src/testing/component/query.rs
+++ b/crates/reinhardt-pages/src/testing/component/query.rs
@@ -118,12 +118,12 @@ fn element_has_exact_text_without_duplicate_child(
 	node_id: NodeId,
 	text: &TextMatch,
 ) -> bool {
-	if !text.matches(&inner.dom.text_content(node_id)) {
+	if !text.matches(&inner.dom.visible_text_content(node_id)) {
 		return false;
 	}
 	!inner.dom.children(node_id).iter().any(|child| {
 		inner.dom.element(*child).is_some()
 			&& !inner.dom.is_hidden(*child)
-			&& text.matches(&inner.dom.text_content(*child))
+			&& text.matches(&inner.dom.visible_text_content(*child))
 	})
 }

--- a/crates/reinhardt-pages/src/testing/component/query.rs
+++ b/crates/reinhardt-pages/src/testing/component/query.rs
@@ -20,11 +20,7 @@ pub(crate) fn query_by_text(
 	text: TextMatch,
 ) -> Result<Option<ElementHandle>, QueryError> {
 	let matches = find_by_text(&inner.borrow(), &text);
-	match matches.len() {
-		0 => Ok(None),
-		1 => Ok(Some(ElementHandle::new(inner.clone(), matches[0]))),
-		_ => Err(QueryError::MultipleMatches),
-	}
+	optional_one(inner, matches)
 }
 
 pub(crate) fn by_role_named(
@@ -33,6 +29,14 @@ pub(crate) fn by_role_named(
 	name: TextMatch,
 ) -> Result<ElementHandle, QueryError> {
 	one(inner, find_by_role(&inner.borrow(), role, Some(&name)))
+}
+
+pub(crate) fn query_by_role_named(
+	inner: &Rc<RefCell<ScreenInner>>,
+	role: Role,
+	name: TextMatch,
+) -> Result<Option<ElementHandle>, QueryError> {
+	optional_one(inner, find_by_role(&inner.borrow(), role, Some(&name)))
 }
 
 pub(crate) fn by_label(
@@ -56,6 +60,27 @@ pub(crate) fn by_label(
 	one(inner, matches)
 }
 
+pub(crate) fn query_by_label(
+	inner: &Rc<RefCell<ScreenInner>>,
+	label: TextMatch,
+) -> Result<Option<ElementHandle>, QueryError> {
+	let borrowed = inner.borrow();
+	let matches = borrowed
+		.dom
+		.visible_elements()
+		.into_iter()
+		.filter(|node_id| {
+			borrowed.dom.element(*node_id).is_some_and(|node| {
+				node.supports_value()
+					&& accessible_name(&borrowed.dom, *node_id)
+						.as_deref()
+						.is_some_and(|name| label.matches(name))
+			})
+		})
+		.collect();
+	optional_one(inner, matches)
+}
+
 pub(crate) fn by_placeholder(
 	inner: &Rc<RefCell<ScreenInner>>,
 	placeholder: TextMatch,
@@ -77,6 +102,27 @@ pub(crate) fn by_placeholder(
 	one(inner, matches)
 }
 
+pub(crate) fn query_by_placeholder(
+	inner: &Rc<RefCell<ScreenInner>>,
+	placeholder: TextMatch,
+) -> Result<Option<ElementHandle>, QueryError> {
+	let borrowed = inner.borrow();
+	let matches = borrowed
+		.dom
+		.visible_elements()
+		.into_iter()
+		.filter(|node_id| {
+			borrowed.dom.element(*node_id).is_some_and(|node| {
+				node.supports_value()
+					&& node
+						.attr("placeholder")
+						.is_some_and(|value| placeholder.matches(value))
+			})
+		})
+		.collect();
+	optional_one(inner, matches)
+}
+
 fn one(
 	inner: &Rc<RefCell<ScreenInner>>,
 	matches: Vec<NodeId>,
@@ -84,6 +130,17 @@ fn one(
 	match matches.len() {
 		0 => Err(QueryError::NotFound),
 		1 => Ok(ElementHandle::new(inner.clone(), matches[0])),
+		_ => Err(QueryError::MultipleMatches),
+	}
+}
+
+fn optional_one(
+	inner: &Rc<RefCell<ScreenInner>>,
+	matches: Vec<NodeId>,
+) -> Result<Option<ElementHandle>, QueryError> {
+	match matches.len() {
+		0 => Ok(None),
+		1 => Ok(Some(ElementHandle::new(inner.clone(), matches[0]))),
 		_ => Err(QueryError::MultipleMatches),
 	}
 }

--- a/crates/reinhardt-pages/src/testing/component/role.rs
+++ b/crates/reinhardt-pages/src/testing/component/role.rs
@@ -68,8 +68,8 @@ impl Role {
 		}
 	}
 
-	pub(crate) fn from_role_attr(value: &str) -> Option<Self> {
-		match value.split_whitespace().next()? {
+	fn from_role_token(value: &str) -> Option<Self> {
+		match value {
 			"alert" => Some(Self::Alert),
 			"button" => Some(Self::Button),
 			"checkbox" => Some(Self::Checkbox),
@@ -101,14 +101,14 @@ impl std::fmt::Display for Role {
 
 pub(crate) fn role_for(dom: &TestDom, node_id: NodeId) -> Option<Role> {
 	let node = dom.element(node_id)?;
-	if let Some(role_attr) = node.attr("role")
-		&& let Some(first_role) = role_attr.split_whitespace().next()
-	{
-		if matches!(first_role, "presentation" | "none") {
-			return None;
-		}
-		if let Some(role) = Role::from_role_attr(role_attr) {
-			return Some(role);
+	if let Some(role_attr) = node.attr("role") {
+		for token in role_attr.split_whitespace() {
+			if matches!(token, "presentation" | "none") {
+				return None;
+			}
+			if let Some(role) = Role::from_role_token(token) {
+				return Some(role);
+			}
 		}
 	}
 
@@ -154,30 +154,53 @@ pub(crate) fn accessible_name(dom: &TestDom, node_id: NodeId) -> Option<String> 
 	if let Some(id) = node.attr("id")
 		&& let Some(label) = dom.label_for(id)
 	{
-		return non_empty(&dom.text_content(label));
+		return non_empty(&dom.visible_text_content(label));
 	}
 
 	if let Some(label) = dom.closest_label(node_id) {
-		return non_empty(&dom.text_content(label));
+		return non_empty(&dom.visible_text_content(label));
+	}
+
+	if let Some(name) = input_button_name(node) {
+		return Some(name);
 	}
 
 	if matches!(
 		role_for(dom, node_id),
 		Some(Role::Button | Role::Link | Role::Heading)
 	) {
-		return non_empty(&dom.text_content(node_id));
+		return non_empty(&dom.visible_text_content(node_id));
 	}
 
 	None
 }
 
 fn input_role(input_type: &str) -> Option<Role> {
-	match input_type {
+	match input_type.to_ascii_lowercase().as_str() {
 		"button" | "image" | "reset" | "submit" => Some(Role::Button),
 		"checkbox" => Some(Role::Checkbox),
 		"radio" => Some(Role::Radio),
-		"hidden" => None,
-		_ => Some(Role::Textbox),
+		"" | "email" | "search" | "tel" | "text" | "url" => Some(Role::Textbox),
+		_ => None,
+	}
+}
+
+fn input_button_name(node: &super::tree::ElementNode) -> Option<String> {
+	if node.tag != "input" {
+		return None;
+	}
+	match node
+		.attr("type")
+		.unwrap_or("text")
+		.to_ascii_lowercase()
+		.as_str()
+	{
+		"button" | "reset" | "submit" => node.attr("value").and_then(non_empty),
+		"image" => node
+			.attr("alt")
+			.or_else(|| node.attr("value"))
+			.and_then(non_empty),
+		_ => None,
 	}
 }
 

--- a/crates/reinhardt-pages/src/testing/component/role.rs
+++ b/crates/reinhardt-pages/src/testing/component/role.rs
@@ -1,0 +1,183 @@
+//! Accessible role support for native component queries.
+
+use super::tree::{NodeId, TestDom};
+
+/// ARIA role supported by the native component test harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Role {
+	/// Alert role.
+	Alert,
+	/// Button role.
+	Button,
+	/// Checkbox role.
+	Checkbox,
+	/// Combobox role.
+	Combobox,
+	/// Dialog role.
+	Dialog,
+	/// Form role.
+	Form,
+	/// Heading role.
+	Heading,
+	/// Link role.
+	Link,
+	/// List role.
+	List,
+	/// Listbox role.
+	Listbox,
+	/// List item role.
+	ListItem,
+	/// Main landmark role.
+	Main,
+	/// Navigation landmark role.
+	Navigation,
+	/// Option role.
+	Option,
+	/// Progressbar role.
+	Progressbar,
+	/// Radio role.
+	Radio,
+	/// Status role.
+	Status,
+	/// Textbox role.
+	Textbox,
+}
+
+impl Role {
+	/// Returns the canonical ARIA role name.
+	pub fn as_str(self) -> &'static str {
+		match self {
+			Self::Alert => "alert",
+			Self::Button => "button",
+			Self::Checkbox => "checkbox",
+			Self::Combobox => "combobox",
+			Self::Dialog => "dialog",
+			Self::Form => "form",
+			Self::Heading => "heading",
+			Self::Link => "link",
+			Self::List => "list",
+			Self::Listbox => "listbox",
+			Self::ListItem => "listitem",
+			Self::Main => "main",
+			Self::Navigation => "navigation",
+			Self::Option => "option",
+			Self::Progressbar => "progressbar",
+			Self::Radio => "radio",
+			Self::Status => "status",
+			Self::Textbox => "textbox",
+		}
+	}
+
+	pub(crate) fn from_role_attr(value: &str) -> Option<Self> {
+		match value.split_whitespace().next()? {
+			"alert" => Some(Self::Alert),
+			"button" => Some(Self::Button),
+			"checkbox" => Some(Self::Checkbox),
+			"combobox" => Some(Self::Combobox),
+			"dialog" => Some(Self::Dialog),
+			"form" => Some(Self::Form),
+			"heading" => Some(Self::Heading),
+			"link" => Some(Self::Link),
+			"list" => Some(Self::List),
+			"listbox" => Some(Self::Listbox),
+			"listitem" => Some(Self::ListItem),
+			"main" => Some(Self::Main),
+			"navigation" => Some(Self::Navigation),
+			"option" => Some(Self::Option),
+			"progressbar" => Some(Self::Progressbar),
+			"radio" => Some(Self::Radio),
+			"status" => Some(Self::Status),
+			"textbox" => Some(Self::Textbox),
+			_ => None,
+		}
+	}
+}
+
+impl std::fmt::Display for Role {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.write_str(self.as_str())
+	}
+}
+
+pub(crate) fn role_for(dom: &TestDom, node_id: NodeId) -> Option<Role> {
+	let node = dom.element(node_id)?;
+	if let Some(role) = node.attr("role").and_then(Role::from_role_attr) {
+		return Some(role);
+	}
+
+	match node.tag.as_str() {
+		"a" if node.attr("href").is_some() => Some(Role::Link),
+		"button" => Some(Role::Button),
+		"dialog" => Some(Role::Dialog),
+		"form" => Some(Role::Form),
+		"h1" | "h2" | "h3" | "h4" | "h5" | "h6" => Some(Role::Heading),
+		"input" => input_role(node.attr("type").unwrap_or("text")),
+		"li" => Some(Role::ListItem),
+		"main" => Some(Role::Main),
+		"nav" => Some(Role::Navigation),
+		"ol" | "ul" => Some(Role::List),
+		"option" => Some(Role::Option),
+		"progress" => Some(Role::Progressbar),
+		"select" if node.has_attr("multiple") => Some(Role::Listbox),
+		"select" => Some(Role::Combobox),
+		"textarea" => Some(Role::Textbox),
+		_ => None,
+	}
+}
+
+pub(crate) fn accessible_name(dom: &TestDom, node_id: NodeId) -> Option<String> {
+	let node = dom.element(node_id)?;
+	if let Some(label) = node.attr("aria-label") {
+		return non_empty(label);
+	}
+
+	if let Some(labelledby) = node.attr("aria-labelledby") {
+		let label = labelledby
+			.split_whitespace()
+			.filter_map(|id| dom.find_element_by_id(id))
+			.map(|id| dom.text_content(id))
+			.filter(|text| !text.is_empty())
+			.collect::<Vec<_>>()
+			.join(" ");
+		if !label.is_empty() {
+			return Some(label);
+		}
+	}
+
+	if let Some(id) = node.attr("id")
+		&& let Some(label) = dom.label_for(id)
+	{
+		return non_empty(&dom.text_content(label));
+	}
+
+	if let Some(label) = dom.closest_label(node_id) {
+		return non_empty(&dom.text_content(label));
+	}
+
+	if matches!(
+		role_for(dom, node_id),
+		Some(Role::Button | Role::Link | Role::Heading)
+	) {
+		return non_empty(&dom.text_content(node_id));
+	}
+
+	node.attr("placeholder").and_then(non_empty)
+}
+
+fn input_role(input_type: &str) -> Option<Role> {
+	match input_type {
+		"button" | "image" | "reset" | "submit" => Some(Role::Button),
+		"checkbox" => Some(Role::Checkbox),
+		"radio" => Some(Role::Radio),
+		"hidden" => None,
+		_ => Some(Role::Textbox),
+	}
+}
+
+fn non_empty(value: &str) -> Option<String> {
+	if value.is_empty() {
+		None
+	} else {
+		Some(value.to_string())
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/role.rs
+++ b/crates/reinhardt-pages/src/testing/component/role.rs
@@ -101,8 +101,15 @@ impl std::fmt::Display for Role {
 
 pub(crate) fn role_for(dom: &TestDom, node_id: NodeId) -> Option<Role> {
 	let node = dom.element(node_id)?;
-	if let Some(role) = node.attr("role").and_then(Role::from_role_attr) {
-		return Some(role);
+	if let Some(role_attr) = node.attr("role")
+		&& let Some(first_role) = role_attr.split_whitespace().next()
+	{
+		if matches!(first_role, "presentation" | "none") {
+			return None;
+		}
+		if let Some(role) = Role::from_role_attr(role_attr) {
+			return Some(role);
+		}
 	}
 
 	match node.tag.as_str() {
@@ -161,7 +168,7 @@ pub(crate) fn accessible_name(dom: &TestDom, node_id: NodeId) -> Option<String> 
 		return non_empty(&dom.text_content(node_id));
 	}
 
-	node.attr("placeholder").and_then(non_empty)
+	None
 }
 
 fn input_role(input_type: &str) -> Option<Role> {

--- a/crates/reinhardt-pages/src/testing/component/scheduler.rs
+++ b/crates/reinhardt-pages/src/testing/component/scheduler.rs
@@ -6,10 +6,13 @@ use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll, Waker};
+use std::time::Duration;
 
 use crate::platform;
 
 type BoxedTask = Pin<Box<dyn Future<Output = ()> + 'static>>;
+const SETTLE_BACKOFF_AFTER_YIELDS: usize = 4;
+const SETTLE_BACKOFF: Duration = Duration::from_millis(1);
 
 /// Error returned when the native component scheduler cannot settle.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,7 +86,11 @@ impl SchedulerScope {
 			if pending_tasks == 0 {
 				return Ok(());
 			}
-			tokio::task::yield_now().await;
+			if iteration < SETTLE_BACKOFF_AFTER_YIELDS {
+				tokio::task::yield_now().await;
+			} else {
+				tokio::time::sleep(SETTLE_BACKOFF).await;
+			}
 			if iteration == 99 {
 				return Err(SettleError::DidNotQuiesce {
 					iterations: 100,

--- a/crates/reinhardt-pages/src/testing/component/scheduler.rs
+++ b/crates/reinhardt-pages/src/testing/component/scheduler.rs
@@ -1,0 +1,94 @@
+//! Native async scheduler for component tests.
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll, Waker};
+
+use crate::platform;
+
+type BoxedTask = Pin<Box<dyn Future<Output = ()> + 'static>>;
+
+/// Error returned when the native component scheduler cannot settle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettleError {
+	/// Pending work did not quiesce before the harness limit.
+	DidNotQuiesce {
+		/// Number of settle iterations attempted.
+		iterations: usize,
+		/// Number of tasks still pending after the last iteration.
+		pending_tasks: usize,
+		/// Pretty DOM output captured when settle failed.
+		dom: String,
+	},
+}
+
+impl std::fmt::Display for SettleError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::DidNotQuiesce {
+				iterations,
+				pending_tasks,
+				dom,
+			} => write!(
+				f,
+				"scheduled work did not quiesce after {iterations} iterations with {pending_tasks} pending tasks\n\n{dom}"
+			),
+		}
+	}
+}
+
+impl std::error::Error for SettleError {}
+
+#[derive(Default)]
+pub(crate) struct TestScheduler {
+	tasks: VecDeque<BoxedTask>,
+}
+
+pub(crate) struct SchedulerScope {
+	scheduler: Rc<RefCell<TestScheduler>>,
+	_guard: platform::NativeTaskSinkGuard,
+}
+
+impl SchedulerScope {
+	pub(crate) fn new() -> Self {
+		let scheduler = Rc::new(RefCell::new(TestScheduler::default()));
+		let scheduler_for_sink = Rc::clone(&scheduler);
+		let guard = platform::install_task_sink(move |task| {
+			scheduler_for_sink.borrow_mut().tasks.push_back(task);
+		});
+		Self {
+			scheduler,
+			_guard: guard,
+		}
+	}
+
+	pub(crate) async fn settle(&self, dom: impl Fn() -> String) -> Result<(), SettleError> {
+		let mut cx = Context::from_waker(Waker::noop());
+		for iteration in 0..100 {
+			let mut pending = VecDeque::new();
+			while let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() {
+				match task.as_mut().poll(&mut cx) {
+					Poll::Ready(()) => {}
+					Poll::Pending => pending.push_back(task),
+				}
+			}
+			let pending_tasks = pending.len();
+			self.scheduler.borrow_mut().tasks = pending;
+			if pending_tasks == 0 {
+				return Ok(());
+			}
+			tokio::task::yield_now().await;
+			if iteration == 99 {
+				return Err(SettleError::DidNotQuiesce {
+					iterations: 100,
+					pending_tasks,
+					dom: dom(),
+				});
+			}
+		}
+		unreachable!("settle loop returns inside fixed iteration range")
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/scheduler.rs
+++ b/crates/reinhardt-pages/src/testing/component/scheduler.rs
@@ -68,26 +68,33 @@ impl SchedulerScope {
 		f()
 	}
 
-	pub(crate) async fn settle(&self, dom: impl Fn() -> String) -> Result<(), SettleError> {
+	pub(crate) async fn settle_with_context(
+		&self,
+		dom: impl Fn() -> String,
+		mut with_context: impl FnMut(&mut dyn FnMut() -> usize) -> usize,
+	) -> Result<(), SettleError> {
 		let mut cx = Context::from_waker(Waker::noop());
 		for iteration in 0..100 {
-			let mut pending = VecDeque::new();
-			let pending_tasks = self.with_current(|| {
-				loop {
-					let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() else {
-						break;
-					};
-					match task.as_mut().poll(&mut cx) {
-						Poll::Ready(()) => {}
-						Poll::Pending => pending.push_back(task),
+			let mut poll_tasks = || {
+				self.with_current(|| {
+					let mut pending = VecDeque::new();
+					loop {
+						let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() else {
+							break;
+						};
+						match task.as_mut().poll(&mut cx) {
+							Poll::Ready(()) => {}
+							Poll::Pending => pending.push_back(task),
+						}
 					}
-				}
-				let mut scheduler = self.scheduler.borrow_mut();
-				pending.extend(std::mem::take(&mut scheduler.tasks));
-				let pending_tasks = pending.len();
-				scheduler.tasks = pending;
-				pending_tasks
-			});
+					let mut scheduler = self.scheduler.borrow_mut();
+					pending.extend(std::mem::take(&mut scheduler.tasks));
+					let pending_tasks = pending.len();
+					scheduler.tasks = pending;
+					pending_tasks
+				})
+			};
+			let pending_tasks = with_context(&mut poll_tasks);
 			if pending_tasks == 0 {
 				return Ok(());
 			}

--- a/crates/reinhardt-pages/src/testing/component/scheduler.rs
+++ b/crates/reinhardt-pages/src/testing/component/scheduler.rs
@@ -73,14 +73,19 @@ impl SchedulerScope {
 		for iteration in 0..100 {
 			let mut pending = VecDeque::new();
 			let pending_tasks = self.with_current(|| {
-				while let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() {
+				loop {
+					let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() else {
+						break;
+					};
 					match task.as_mut().poll(&mut cx) {
 						Poll::Ready(()) => {}
 						Poll::Pending => pending.push_back(task),
 					}
 				}
+				let mut scheduler = self.scheduler.borrow_mut();
+				pending.extend(std::mem::take(&mut scheduler.tasks));
 				let pending_tasks = pending.len();
-				self.scheduler.borrow_mut().tasks = pending;
+				scheduler.tasks = pending;
 				pending_tasks
 			});
 			if pending_tasks == 0 {
@@ -100,5 +105,9 @@ impl SchedulerScope {
 			}
 		}
 		unreachable!("settle loop returns inside fixed iteration range")
+	}
+
+	pub(crate) fn pending_task_count(&self) -> usize {
+		self.scheduler.borrow().tasks.len()
 	}
 }

--- a/crates/reinhardt-pages/src/testing/component/scheduler.rs
+++ b/crates/reinhardt-pages/src/testing/component/scheduler.rs
@@ -49,34 +49,37 @@ pub(crate) struct TestScheduler {
 
 pub(crate) struct SchedulerScope {
 	scheduler: Rc<RefCell<TestScheduler>>,
-	_guard: platform::NativeTaskSinkGuard,
 }
 
 impl SchedulerScope {
 	pub(crate) fn new() -> Self {
 		let scheduler = Rc::new(RefCell::new(TestScheduler::default()));
-		let scheduler_for_sink = Rc::clone(&scheduler);
-		let guard = platform::install_task_sink(move |task| {
-			scheduler_for_sink.borrow_mut().tasks.push_back(task);
+		Self { scheduler }
+	}
+
+	pub(crate) fn with_current<R>(&self, f: impl FnOnce() -> R) -> R {
+		let scheduler = Rc::clone(&self.scheduler);
+		let _guard = platform::install_task_sink(move |task| {
+			scheduler.borrow_mut().tasks.push_back(task);
 		});
-		Self {
-			scheduler,
-			_guard: guard,
-		}
+		f()
 	}
 
 	pub(crate) async fn settle(&self, dom: impl Fn() -> String) -> Result<(), SettleError> {
 		let mut cx = Context::from_waker(Waker::noop());
 		for iteration in 0..100 {
 			let mut pending = VecDeque::new();
-			while let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() {
-				match task.as_mut().poll(&mut cx) {
-					Poll::Ready(()) => {}
-					Poll::Pending => pending.push_back(task),
+			let pending_tasks = self.with_current(|| {
+				while let Some(mut task) = self.scheduler.borrow_mut().tasks.pop_front() {
+					match task.as_mut().poll(&mut cx) {
+						Poll::Ready(()) => {}
+						Poll::Pending => pending.push_back(task),
+					}
 				}
-			}
-			let pending_tasks = pending.len();
-			self.scheduler.borrow_mut().tasks = pending;
+				let pending_tasks = pending.len();
+				self.scheduler.borrow_mut().tasks = pending;
+				pending_tasks
+			});
 			if pending_tasks == 0 {
 				return Ok(());
 			}

--- a/crates/reinhardt-pages/src/testing/component/screen.rs
+++ b/crates/reinhardt-pages/src/testing/component/screen.rs
@@ -1,0 +1,261 @@
+//! Rendered native component screen.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use reinhardt_core::types::page::{IntoPage, Page, PageElement};
+
+use super::error::QueryError;
+use super::events::ElementHandle;
+use super::pretty::pretty_dom;
+use super::query;
+use super::role::Role;
+use super::scheduler::{SchedulerScope, SettleError};
+#[cfg(feature = "msw")]
+use super::server_fn_mock::{self, ServerFnCallQuery, SharedServerFnMocks};
+use super::text_match::TextMatch;
+use super::tree::{ScreenInner, TestDom, shared_screen_inner};
+
+/// Rendered native component test screen.
+#[derive(Clone)]
+pub struct Screen {
+	inner: Rc<RefCell<ScreenInner>>,
+}
+
+/// Input accepted by [`render`] and [`Screen::render`].
+pub trait TestRender {
+	/// Builds the page while the native test harness scopes are active.
+	fn render_page(self) -> Page;
+}
+
+impl TestRender for Page {
+	fn render_page(self) -> Page {
+		self
+	}
+}
+
+impl TestRender for PageElement {
+	fn render_page(self) -> Page {
+		self.into_page()
+	}
+}
+
+impl<F, P> TestRender for F
+where
+	F: FnOnce() -> P,
+	P: IntoPage,
+{
+	fn render_page(self) -> Page {
+		self().into_page()
+	}
+}
+
+/// Renders a Page into a native component test screen.
+pub fn render(view: impl TestRender) -> Screen {
+	Screen::render(view)
+}
+
+impl Screen {
+	/// Renders a Page into a native component test screen.
+	pub fn render(view: impl TestRender) -> Self {
+		let scheduler = Rc::new(SchedulerScope::new());
+		#[cfg(feature = "msw")]
+		{
+			let mocks = SharedServerFnMocks::default();
+			let mock_scope = server_fn_mock::activate(mocks.clone());
+			let page = view.render_page();
+			let dom = TestDom::render(page);
+			Self {
+				inner: shared_screen_inner(dom, scheduler, mocks, mock_scope),
+			}
+		}
+		#[cfg(not(feature = "msw"))]
+		{
+			let page = view.render_page();
+			Self {
+				inner: shared_screen_inner(TestDom::render(page), scheduler),
+			}
+		}
+	}
+
+	/// Returns a stable pretty representation of the rendered DOM.
+	pub fn pretty(&self) -> String {
+		pretty_dom(&self.inner.borrow().dom)
+	}
+
+	/// Returns exactly one element by exact text.
+	pub fn get(&self, text: impl Into<TextMatch>) -> ElementHandle {
+		self.get_by_text(text)
+	}
+
+	/// Tries to return exactly one element by exact text.
+	pub fn try_get(&self, text: impl Into<TextMatch>) -> Result<ElementHandle, QueryError> {
+		self.try_get_by_text(text)
+	}
+
+	/// Returns exactly one element by exact text.
+	pub fn get_by_text(&self, text: impl Into<TextMatch>) -> ElementHandle {
+		self.try_get_by_text(text).expect("text query failed")
+	}
+
+	/// Tries to return exactly one element by exact text.
+	pub fn try_get_by_text(&self, text: impl Into<TextMatch>) -> Result<ElementHandle, QueryError> {
+		query::by_text(&self.inner, text.into())
+	}
+
+	/// Returns zero or one element by exact text.
+	pub fn query_by_text(&self, text: impl Into<TextMatch>) -> Option<ElementHandle> {
+		match query::query_by_text(&self.inner, text.into()) {
+			Ok(handle) => handle,
+			Err(QueryError::NotFound) => None,
+			Err(err) => panic!("{err}"),
+		}
+	}
+
+	/// Returns exactly one element by accessible role and name.
+	pub fn get_by_role(&self, role: Role, name: impl Into<TextMatch>) -> ElementHandle {
+		self.try_get_by_role(role, name)
+			.expect("named role query failed")
+	}
+
+	/// Tries to return exactly one element by accessible role and name.
+	pub fn try_get_by_role(
+		&self,
+		role: Role,
+		name: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		query::by_role_named(&self.inner, role, name.into())
+	}
+
+	/// Returns exactly one element by accessible role and name.
+	pub fn get_by_role_named(&self, role: Role, name: impl Into<TextMatch>) -> ElementHandle {
+		self.get_by_role(role, name)
+	}
+
+	/// Tries to return exactly one element by accessible role and name.
+	pub fn try_get_by_role_named(
+		&self,
+		role: Role,
+		name: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		self.try_get_by_role(role, name)
+	}
+
+	/// Returns exactly one element by accessible label.
+	pub fn get_by_label(&self, label: impl Into<TextMatch>) -> ElementHandle {
+		self.try_get_by_label(label).expect("label query failed")
+	}
+
+	/// Tries to return exactly one element by accessible label.
+	pub fn try_get_by_label(
+		&self,
+		label: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		query::by_label(&self.inner, label.into())
+	}
+
+	/// Returns exactly one element by placeholder text.
+	pub fn get_by_placeholder(&self, placeholder: impl Into<TextMatch>) -> ElementHandle {
+		self.try_get_by_placeholder(placeholder)
+			.expect("placeholder query failed")
+	}
+
+	/// Tries to return exactly one element by placeholder text.
+	pub fn try_get_by_placeholder(
+		&self,
+		placeholder: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		query::by_placeholder(&self.inner, placeholder.into())
+	}
+
+	/// Waits for scheduled native component work and rerenders reactive anchors.
+	pub async fn settle(&self) {
+		self.try_settle()
+			.await
+			.unwrap_or_else(|err| panic!("{err}"));
+	}
+
+	/// Tries to settle scheduled native component work.
+	pub async fn try_settle(&self) -> Result<(), SettleError> {
+		let scheduler = Rc::clone(&self.inner.borrow().scheduler);
+		scheduler.settle(|| self.pretty()).await?;
+		self.inner.borrow_mut().dom.rerender_reactive_anchors();
+		Ok(())
+	}
+
+	/// Finds an element by text after settling scheduled work.
+	pub async fn find_by_text(&self, text: impl Into<TextMatch>) -> ElementHandle {
+		self.try_find_by_text(text)
+			.await
+			.unwrap_or_else(|err| panic!("{err}"))
+	}
+
+	/// Tries to find an element by text after settling scheduled work.
+	pub async fn try_find_by_text(
+		&self,
+		text: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		let text = text.into();
+		for _ in 0..50 {
+			match self.try_get_by_text(text.clone()) {
+				Ok(handle) => return Ok(handle),
+				Err(QueryError::NotFound) => {
+					self.try_settle().await.map_err(|_| QueryError::NotFound)?;
+				}
+				Err(err) => return Err(err),
+			}
+			tokio::task::yield_now().await;
+		}
+		Err(QueryError::NotFound)
+	}
+
+	/// Finds an element by role and accessible name after settling scheduled work.
+	pub async fn find_by_role(&self, role: Role, name: impl Into<TextMatch>) -> ElementHandle {
+		self.try_find_by_role(role, name)
+			.await
+			.unwrap_or_else(|err| panic!("{err}"))
+	}
+
+	/// Tries to find an element by role and accessible name after settling scheduled work.
+	pub async fn try_find_by_role(
+		&self,
+		role: Role,
+		name: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		let name = name.into();
+		for _ in 0..50 {
+			match self.try_get_by_role(role, name.clone()) {
+				Ok(handle) => return Ok(handle),
+				Err(QueryError::NotFound) => {
+					self.try_settle().await.map_err(|_| QueryError::NotFound)?;
+				}
+				Err(err) => return Err(err),
+			}
+			tokio::task::yield_now().await;
+		}
+		Err(QueryError::NotFound)
+	}
+
+	/// Registers a typed server function mock for this screen.
+	#[cfg(feature = "msw")]
+	pub fn mock_server_fn<S>(
+		&self,
+		handler: impl Fn(S::Args) -> Result<S::Response, crate::server_fn::ServerFnError> + 'static,
+	) where
+		S: crate::server_fn::MockableServerFn + 'static,
+		S::Args: Clone + 'static,
+		S::Response: 'static,
+	{
+		self.inner.borrow().mocks.mock_server_fn::<S>(handler);
+	}
+
+	/// Returns recorded calls for a typed server function mock.
+	#[cfg(feature = "msw")]
+	pub fn calls_to_server_fn<S>(&self) -> ServerFnCallQuery<S>
+	where
+		S: crate::server_fn::MockableServerFn + 'static,
+		S::Args: Clone + 'static,
+	{
+		self.inner.borrow().mocks.calls_to_server_fn::<S>()
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/screen.rs
+++ b/crates/reinhardt-pages/src/testing/component/screen.rs
@@ -62,18 +62,18 @@ impl Screen {
 		#[cfg(feature = "msw")]
 		{
 			let mocks = SharedServerFnMocks::default();
-			let mock_scope = server_fn_mock::activate(mocks.clone());
-			let page = view.render_page();
-			let dom = TestDom::render(page);
+			let dom = scheduler.with_current(|| {
+				server_fn_mock::with_active(mocks.clone(), || TestDom::render(view.render_page()))
+			});
 			Self {
-				inner: shared_screen_inner(dom, scheduler, mocks, mock_scope),
+				inner: shared_screen_inner(dom, scheduler, mocks),
 			}
 		}
 		#[cfg(not(feature = "msw"))]
 		{
-			let page = view.render_page();
+			let dom = scheduler.with_current(|| TestDom::render(view.render_page()));
 			Self {
-				inner: shared_screen_inner(TestDom::render(page), scheduler),
+				inner: shared_screen_inner(dom, scheduler),
 			}
 		}
 	}
@@ -177,9 +177,21 @@ impl Screen {
 
 	/// Tries to settle scheduled native component work.
 	pub async fn try_settle(&self) -> Result<(), SettleError> {
+		#[cfg(feature = "msw")]
+		let (scheduler, mocks) = {
+			let inner = self.inner.borrow();
+			(Rc::clone(&inner.scheduler), inner.mocks.clone())
+		};
+		#[cfg(not(feature = "msw"))]
 		let scheduler = Rc::clone(&self.inner.borrow().scheduler);
+
+		#[cfg(feature = "msw")]
+		let _mock_scope = server_fn_mock::activate(mocks);
+
 		scheduler.settle(|| self.pretty()).await?;
-		self.inner.borrow_mut().dom.rerender_reactive_anchors();
+		scheduler.with_current(|| {
+			self.inner.borrow_mut().dom.rerender_reactive_anchors();
+		});
 		Ok(())
 	}
 
@@ -206,7 +218,7 @@ impl Screen {
 			}
 			tokio::task::yield_now().await;
 		}
-		Err(QueryError::NotFound)
+		self.try_get_by_text(text)
 	}
 
 	/// Finds an element by role and accessible name after settling scheduled work.
@@ -233,7 +245,7 @@ impl Screen {
 			}
 			tokio::task::yield_now().await;
 		}
-		Err(QueryError::NotFound)
+		self.try_get_by_role(role, name)
 	}
 
 	/// Registers a typed server function mock for this screen.

--- a/crates/reinhardt-pages/src/testing/component/screen.rs
+++ b/crates/reinhardt-pages/src/testing/component/screen.rs
@@ -188,12 +188,22 @@ impl Screen {
 		#[cfg(feature = "msw")]
 		let _mock_scope = server_fn_mock::activate(mocks);
 
-		let result = scheduler.settle(|| self.pretty()).await;
-		scheduler.with_current(|| {
-			self.inner.borrow_mut().dom.rerender_reactive_anchors();
-		});
-		result?;
-		Ok(())
+		for _ in 0..100 {
+			let result = scheduler.settle(|| self.pretty()).await;
+			scheduler.with_current(|| {
+				self.inner.borrow_mut().dom.rerender_reactive_anchors();
+			});
+			match result {
+				Ok(()) if scheduler.pending_task_count() == 0 => return Ok(()),
+				Ok(()) => {}
+				Err(err) => return Err(err),
+			}
+		}
+		Err(SettleError::DidNotQuiesce {
+			iterations: 100,
+			pending_tasks: scheduler.pending_task_count(),
+			dom: self.pretty(),
+		})
 	}
 
 	/// Finds an element by text after settling scheduled work.

--- a/crates/reinhardt-pages/src/testing/component/screen.rs
+++ b/crates/reinhardt-pages/src/testing/component/screen.rs
@@ -188,10 +188,11 @@ impl Screen {
 		#[cfg(feature = "msw")]
 		let _mock_scope = server_fn_mock::activate(mocks);
 
-		scheduler.settle(|| self.pretty()).await?;
+		let result = scheduler.settle(|| self.pretty()).await;
 		scheduler.with_current(|| {
 			self.inner.borrow_mut().dom.rerender_reactive_anchors();
 		});
+		result?;
 		Ok(())
 	}
 
@@ -212,7 +213,7 @@ impl Screen {
 			match self.try_get_by_text(text.clone()) {
 				Ok(handle) => return Ok(handle),
 				Err(QueryError::NotFound) => {
-					self.try_settle().await.map_err(|_| QueryError::NotFound)?;
+					let _ = self.try_settle().await;
 				}
 				Err(err) => return Err(err),
 			}
@@ -239,7 +240,7 @@ impl Screen {
 			match self.try_get_by_role(role, name.clone()) {
 				Ok(handle) => return Ok(handle),
 				Err(QueryError::NotFound) => {
-					self.try_settle().await.map_err(|_| QueryError::NotFound)?;
+					let _ = self.try_settle().await;
 				}
 				Err(err) => return Err(err),
 			}

--- a/crates/reinhardt-pages/src/testing/component/screen.rs
+++ b/crates/reinhardt-pages/src/testing/component/screen.rs
@@ -185,14 +185,30 @@ impl Screen {
 		#[cfg(not(feature = "msw"))]
 		let scheduler = Rc::clone(&self.inner.borrow().scheduler);
 
-		#[cfg(feature = "msw")]
-		let _mock_scope = server_fn_mock::activate(mocks);
-
 		for _ in 0..100 {
-			let result = scheduler.settle(|| self.pretty()).await;
-			scheduler.with_current(|| {
-				self.inner.borrow_mut().dom.rerender_reactive_anchors();
+			#[cfg(feature = "msw")]
+			let result = scheduler
+				.settle_with_context(
+					|| self.pretty(),
+					|poll_tasks| server_fn_mock::with_active(mocks.clone(), poll_tasks),
+				)
+				.await;
+			#[cfg(not(feature = "msw"))]
+			let result = scheduler
+				.settle_with_context(|| self.pretty(), |poll_tasks| poll_tasks())
+				.await;
+			#[cfg(feature = "msw")]
+			server_fn_mock::with_active(mocks.clone(), || {
+				scheduler.with_current(|| {
+					self.inner.borrow_mut().dom.rerender_reactive_anchors();
+				});
 			});
+			#[cfg(not(feature = "msw"))]
+			{
+				scheduler.with_current(|| {
+					self.inner.borrow_mut().dom.rerender_reactive_anchors();
+				});
+			}
 			match result {
 				Ok(()) if scheduler.pending_task_count() == 0 => return Ok(()),
 				Ok(()) => {}

--- a/crates/reinhardt-pages/src/testing/component/screen.rs
+++ b/crates/reinhardt-pages/src/testing/component/screen.rs
@@ -132,6 +132,24 @@ impl Screen {
 		self.get_by_role(role, name)
 	}
 
+	/// Returns zero or one element by accessible role and name.
+	pub fn query_by_role(&self, role: Role, name: impl Into<TextMatch>) -> Option<ElementHandle> {
+		match query::query_by_role_named(&self.inner, role, name.into()) {
+			Ok(handle) => handle,
+			Err(QueryError::NotFound) => None,
+			Err(err) => panic!("{err}"),
+		}
+	}
+
+	/// Returns zero or one element by accessible role and name.
+	pub fn query_by_role_named(
+		&self,
+		role: Role,
+		name: impl Into<TextMatch>,
+	) -> Option<ElementHandle> {
+		self.query_by_role(role, name)
+	}
+
 	/// Tries to return exactly one element by accessible role and name.
 	pub fn try_get_by_role_named(
 		&self,
@@ -154,6 +172,15 @@ impl Screen {
 		query::by_label(&self.inner, label.into())
 	}
 
+	/// Returns zero or one element by accessible label.
+	pub fn query_by_label(&self, label: impl Into<TextMatch>) -> Option<ElementHandle> {
+		match query::query_by_label(&self.inner, label.into()) {
+			Ok(handle) => handle,
+			Err(QueryError::NotFound) => None,
+			Err(err) => panic!("{err}"),
+		}
+	}
+
 	/// Returns exactly one element by placeholder text.
 	pub fn get_by_placeholder(&self, placeholder: impl Into<TextMatch>) -> ElementHandle {
 		self.try_get_by_placeholder(placeholder)
@@ -166,6 +193,15 @@ impl Screen {
 		placeholder: impl Into<TextMatch>,
 	) -> Result<ElementHandle, QueryError> {
 		query::by_placeholder(&self.inner, placeholder.into())
+	}
+
+	/// Returns zero or one element by placeholder text.
+	pub fn query_by_placeholder(&self, placeholder: impl Into<TextMatch>) -> Option<ElementHandle> {
+		match query::query_by_placeholder(&self.inner, placeholder.into()) {
+			Ok(handle) => handle,
+			Err(QueryError::NotFound) => None,
+			Err(err) => panic!("{err}"),
+		}
 	}
 
 	/// Waits for scheduled native component work and rerenders reactive anchors.
@@ -273,6 +309,76 @@ impl Screen {
 			tokio::task::yield_now().await;
 		}
 		self.try_get_by_role(role, name)
+	}
+
+	/// Finds an element by role and accessible name after settling scheduled work.
+	pub async fn find_by_role_named(
+		&self,
+		role: Role,
+		name: impl Into<TextMatch>,
+	) -> ElementHandle {
+		self.find_by_role(role, name).await
+	}
+
+	/// Tries to find an element by role and accessible name after settling scheduled work.
+	pub async fn try_find_by_role_named(
+		&self,
+		role: Role,
+		name: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		self.try_find_by_role(role, name).await
+	}
+
+	/// Finds an element by label after settling scheduled work.
+	pub async fn find_by_label(&self, label: impl Into<TextMatch>) -> ElementHandle {
+		self.try_find_by_label(label)
+			.await
+			.unwrap_or_else(|err| panic!("{err}"))
+	}
+
+	/// Tries to find an element by label after settling scheduled work.
+	pub async fn try_find_by_label(
+		&self,
+		label: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		let label = label.into();
+		for _ in 0..50 {
+			match self.try_get_by_label(label.clone()) {
+				Ok(handle) => return Ok(handle),
+				Err(QueryError::NotFound) => {
+					let _ = self.try_settle().await;
+				}
+				Err(err) => return Err(err),
+			}
+			tokio::task::yield_now().await;
+		}
+		self.try_get_by_label(label)
+	}
+
+	/// Finds an element by placeholder after settling scheduled work.
+	pub async fn find_by_placeholder(&self, placeholder: impl Into<TextMatch>) -> ElementHandle {
+		self.try_find_by_placeholder(placeholder)
+			.await
+			.unwrap_or_else(|err| panic!("{err}"))
+	}
+
+	/// Tries to find an element by placeholder after settling scheduled work.
+	pub async fn try_find_by_placeholder(
+		&self,
+		placeholder: impl Into<TextMatch>,
+	) -> Result<ElementHandle, QueryError> {
+		let placeholder = placeholder.into();
+		for _ in 0..50 {
+			match self.try_get_by_placeholder(placeholder.clone()) {
+				Ok(handle) => return Ok(handle),
+				Err(QueryError::NotFound) => {
+					let _ = self.try_settle().await;
+				}
+				Err(err) => return Err(err),
+			}
+			tokio::task::yield_now().await;
+		}
+		self.try_get_by_placeholder(placeholder)
 	}
 
 	/// Registers a typed server function mock for this screen.

--- a/crates/reinhardt-pages/src/testing/component/server_fn_mock.rs
+++ b/crates/reinhardt-pages/src/testing/component/server_fn_mock.rs
@@ -1,0 +1,182 @@
+//! In-process server function mocks for native component tests.
+
+use std::any::{Any, TypeId};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use crate::server_fn::{MockableServerFn, ServerFnError};
+
+type ErasedHandler = Box<dyn Fn(Box<dyn Any>) -> Result<Box<dyn Any>, ServerFnError>>;
+
+#[derive(Default)]
+pub(crate) struct ServerFnMockRegistry {
+	handlers: HashMap<TypeId, ErasedHandler>,
+	calls: HashMap<TypeId, Vec<Box<dyn Any>>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct SharedServerFnMocks {
+	inner: Rc<RefCell<ServerFnMockRegistry>>,
+}
+
+impl Default for SharedServerFnMocks {
+	fn default() -> Self {
+		Self {
+			inner: Rc::new(RefCell::new(ServerFnMockRegistry::default())),
+		}
+	}
+}
+
+thread_local! {
+	static ACTIVE_MOCKS: RefCell<Option<SharedServerFnMocks>> = const { RefCell::new(None) };
+}
+
+pub(crate) struct ServerFnMockScope {
+	previous: Option<SharedServerFnMocks>,
+}
+
+impl Drop for ServerFnMockScope {
+	fn drop(&mut self) {
+		let previous = self.previous.take();
+		ACTIVE_MOCKS.with(|slot| {
+			*slot.borrow_mut() = previous;
+		});
+	}
+}
+
+pub(crate) fn activate(mocks: SharedServerFnMocks) -> ServerFnMockScope {
+	let previous = ACTIVE_MOCKS.with(|slot| slot.borrow_mut().replace(mocks));
+	ServerFnMockScope { previous }
+}
+
+/// Calls the active native test mock for `S`, recording the typed arguments.
+pub fn try_call_active_mock<S>(args: S::Args) -> Option<Result<S::Response, ServerFnError>>
+where
+	S: MockableServerFn + 'static,
+	S::Args: Clone + 'static,
+	S::Response: 'static,
+{
+	ACTIVE_MOCKS.with(|slot| {
+		let mocks = slot.borrow().clone()?;
+		let mut registry = mocks.inner.borrow_mut();
+		let type_id = TypeId::of::<S>();
+		registry
+			.calls
+			.entry(type_id)
+			.or_default()
+			.push(Box::new(args.clone()));
+		let handler = registry.handlers.get(&type_id)?;
+		let response = handler(Box::new(args));
+		Some(response.and_then(|value| {
+			value
+				.downcast::<S::Response>()
+				.map(|boxed| *boxed)
+				.map_err(|_| ServerFnError::application("mock response type mismatch"))
+		}))
+	})
+}
+
+impl SharedServerFnMocks {
+	pub(crate) fn mock_server_fn<S>(
+		&self,
+		handler: impl Fn(S::Args) -> Result<S::Response, ServerFnError> + 'static,
+	) where
+		S: MockableServerFn + 'static,
+		S::Args: Clone + 'static,
+		S::Response: 'static,
+	{
+		self.inner.borrow_mut().handlers.insert(
+			TypeId::of::<S>(),
+			Box::new(move |args| {
+				let args = args
+					.downcast::<S::Args>()
+					.map_err(|_| ServerFnError::application("mock args type mismatch"))?;
+				handler(*args).map(|response| Box::new(response) as Box<dyn Any>)
+			}),
+		);
+	}
+
+	pub(crate) fn calls_to_server_fn<S>(&self) -> ServerFnCallQuery<S>
+	where
+		S: MockableServerFn + 'static,
+		S::Args: Clone + 'static,
+	{
+		let calls = self
+			.inner
+			.borrow()
+			.calls
+			.get(&TypeId::of::<S>())
+			.map(|values| {
+				values
+					.iter()
+					.filter_map(|value| value.downcast_ref::<S::Args>().cloned())
+					.map(|args| RecordedServerFnCall {
+						path: S::PATH.to_string(),
+						args,
+						_marker: PhantomData,
+					})
+					.collect()
+			})
+			.unwrap_or_default();
+		ServerFnCallQuery { calls }
+	}
+}
+
+/// Recorded server function call.
+pub struct RecordedServerFnCall<S: MockableServerFn> {
+	/// Server function path.
+	pub path: String,
+	/// Typed argument payload passed to the server function.
+	pub args: S::Args,
+	_marker: PhantomData<S>,
+}
+
+impl<S> Clone for RecordedServerFnCall<S>
+where
+	S: MockableServerFn,
+	S::Args: Clone,
+{
+	fn clone(&self) -> Self {
+		Self {
+			path: self.path.clone(),
+			args: self.args.clone(),
+			_marker: PhantomData,
+		}
+	}
+}
+
+/// Queryable collection of recorded server function calls.
+pub struct ServerFnCallQuery<S: MockableServerFn> {
+	calls: Vec<RecordedServerFnCall<S>>,
+}
+
+impl<S> Clone for ServerFnCallQuery<S>
+where
+	S: MockableServerFn,
+	S::Args: Clone,
+{
+	fn clone(&self) -> Self {
+		Self {
+			calls: self.calls.clone(),
+		}
+	}
+}
+
+impl<S: MockableServerFn> ServerFnCallQuery<S> {
+	/// Returns the number of recorded calls.
+	pub fn len(&self) -> usize {
+		self.calls.len()
+	}
+
+	/// Returns true when no calls were recorded.
+	pub fn is_empty(&self) -> bool {
+		self.calls.is_empty()
+	}
+
+	/// Returns all recorded calls.
+	pub fn all(&self) -> &[RecordedServerFnCall<S>] {
+		&self.calls
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/server_fn_mock.rs
+++ b/crates/reinhardt-pages/src/testing/component/server_fn_mock.rs
@@ -74,7 +74,12 @@ where
 				.or_default()
 				.push(Box::new(args.clone()));
 			registry.handlers.get(&type_id).cloned()
-		}?;
+		};
+		let Some(handler) = handler else {
+			return Some(Err(ServerFnError::application(
+				"no mock registered for active server function",
+			)));
+		};
 		let response = handler(Box::new(args));
 		Some(response.and_then(|value| {
 			value

--- a/crates/reinhardt-pages/src/testing/component/server_fn_mock.rs
+++ b/crates/reinhardt-pages/src/testing/component/server_fn_mock.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use crate::server_fn::{MockableServerFn, ServerFnError};
 
-type ErasedHandler = Box<dyn Fn(Box<dyn Any>) -> Result<Box<dyn Any>, ServerFnError>>;
+type ErasedHandler = Rc<dyn Fn(Box<dyn Any>) -> Result<Box<dyn Any>, ServerFnError>>;
 
 #[derive(Default)]
 pub(crate) struct ServerFnMockRegistry {
@@ -51,6 +51,11 @@ pub(crate) fn activate(mocks: SharedServerFnMocks) -> ServerFnMockScope {
 	ServerFnMockScope { previous }
 }
 
+pub(crate) fn with_active<R>(mocks: SharedServerFnMocks, f: impl FnOnce() -> R) -> R {
+	let _scope = activate(mocks);
+	f()
+}
+
 /// Calls the active native test mock for `S`, recording the typed arguments.
 pub fn try_call_active_mock<S>(args: S::Args) -> Option<Result<S::Response, ServerFnError>>
 where
@@ -60,14 +65,16 @@ where
 {
 	ACTIVE_MOCKS.with(|slot| {
 		let mocks = slot.borrow().clone()?;
-		let mut registry = mocks.inner.borrow_mut();
 		let type_id = TypeId::of::<S>();
-		registry
-			.calls
-			.entry(type_id)
-			.or_default()
-			.push(Box::new(args.clone()));
-		let handler = registry.handlers.get(&type_id)?;
+		let handler = {
+			let mut registry = mocks.inner.borrow_mut();
+			registry
+				.calls
+				.entry(type_id)
+				.or_default()
+				.push(Box::new(args.clone()));
+			registry.handlers.get(&type_id).cloned()
+		}?;
 		let response = handler(Box::new(args));
 		Some(response.and_then(|value| {
 			value
@@ -89,7 +96,7 @@ impl SharedServerFnMocks {
 	{
 		self.inner.borrow_mut().handlers.insert(
 			TypeId::of::<S>(),
-			Box::new(move |args| {
+			Rc::new(move |args| {
 				let args = args
 					.downcast::<S::Args>()
 					.map_err(|_| ServerFnError::application("mock args type mismatch"))?;

--- a/crates/reinhardt-pages/src/testing/component/tests.rs
+++ b/crates/reinhardt-pages/src/testing/component/tests.rs
@@ -107,7 +107,7 @@ fn input_updates_internal_value_before_dispatch() {
 			.attr("placeholder", "Job name")
 			.listener("input", move |_| called_for_handler.set(true)),
 	);
-	let input = screen.get_by_role(Role::Textbox, "Job name");
+	let input = screen.get_by_placeholder("Job name");
 
 	input.input("new");
 

--- a/crates/reinhardt-pages/src/testing/component/tests.rs
+++ b/crates/reinhardt-pages/src/testing/component/tests.rs
@@ -1,6 +1,8 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
+use reinhardt_core::page::IntoPage;
+use reinhardt_core::reactive::Signal;
 use reinhardt_core::types::page::{Page, PageElement};
 
 use super::{EventError, QueryError, Role, render};
@@ -49,6 +51,58 @@ fn queries_by_text_role_label_and_placeholder() {
 	assert_eq!(screen.get_by_label("Email").tag_name(), "input");
 	assert_eq!(
 		screen.get_by_placeholder("name@example.com").tag_name(),
+		"input"
+	);
+}
+
+#[tokio::test]
+async fn optional_and_async_queries_cover_role_label_and_placeholder() {
+	let screen = render(
+		PageElement::new("form")
+			.child(
+				PageElement::new("label")
+					.attr("for", "email")
+					.child("Email"),
+			)
+			.child(
+				PageElement::new("input")
+					.attr("id", "email")
+					.attr("placeholder", "name@example.com"),
+			)
+			.child(PageElement::new("button").child("Submit")),
+	);
+
+	assert_eq!(
+		screen
+			.query_by_role(Role::Button, "Submit")
+			.expect("button should be found")
+			.tag_name(),
+		"button"
+	);
+	assert!(screen.query_by_role(Role::Button, "Missing").is_none());
+	assert_eq!(
+		screen
+			.query_by_label("Email")
+			.expect("label should be found")
+			.tag_name(),
+		"input"
+	);
+	assert!(screen.query_by_label("Missing").is_none());
+	assert_eq!(
+		screen
+			.query_by_placeholder("name@example.com")
+			.expect("placeholder should be found")
+			.tag_name(),
+		"input"
+	);
+	assert!(screen.query_by_placeholder("Missing").is_none());
+	assert_eq!(screen.find_by_label("Email").await.tag_name(), "input");
+	assert_eq!(
+		screen
+			.try_find_by_placeholder("name@example.com")
+			.await
+			.unwrap()
+			.tag_name(),
 		"input"
 	);
 }
@@ -113,6 +167,27 @@ fn input_updates_internal_value_before_dispatch() {
 
 	assert!(called.get());
 	assert_eq!(input.value().as_deref(), Some("new"));
+}
+
+#[tokio::test]
+async fn detached_element_reads_return_error() {
+	let show = Signal::new(true);
+	let show_for_render = show.clone();
+	let screen = render(Page::reactive(move || {
+		if show_for_render.get() {
+			PageElement::new("button").child("Save").into_page()
+		} else {
+			Page::Empty
+		}
+	}));
+	let button = screen.get_by_role(Role::Button, "Save");
+
+	show.set(false);
+	screen.settle().await;
+
+	assert_eq!(button.try_text(), Err(EventError::DetachedElement));
+	assert_eq!(button.try_tag_name(), Err(EventError::DetachedElement));
+	assert_eq!(button.try_value(), Err(EventError::DetachedElement));
 }
 
 #[test]

--- a/crates/reinhardt-pages/src/testing/component/tests.rs
+++ b/crates/reinhardt-pages/src/testing/component/tests.rs
@@ -1,0 +1,126 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
+use reinhardt_core::types::page::{Page, PageElement};
+
+use super::{EventError, QueryError, Role, render};
+
+#[test]
+fn renders_page_tree_and_pretty_output() {
+	let screen = render(
+		PageElement::new("section")
+			.attr("id", "hero")
+			.child(PageElement::new("h1").child("Hello"))
+			.child(Page::fragment([Page::text("Intro")])),
+	);
+
+	assert_eq!(
+		screen.pretty(),
+		"<section id=\"hero\">\n  <h1>\n    Hello\n  </h1>\n  Intro\n</section>\n"
+	);
+}
+
+#[test]
+fn pretty_text_only_screen_has_trailing_newline() {
+	let screen = render(Page::text("Hello"));
+
+	assert_eq!(screen.pretty(), "Hello\n");
+}
+
+#[test]
+fn queries_by_text_role_label_and_placeholder() {
+	let screen = render(
+		PageElement::new("form")
+			.child(
+				PageElement::new("label")
+					.attr("for", "email")
+					.child("Email"),
+			)
+			.child(
+				PageElement::new("input")
+					.attr("id", "email")
+					.attr("placeholder", "name@example.com"),
+			)
+			.child(PageElement::new("button").child("Submit")),
+	);
+
+	assert_eq!(screen.get_by_text("Submit").tag_name(), "button");
+	assert_eq!(screen.get_by_role(Role::Button, "Submit").text(), "Submit");
+	assert_eq!(screen.get_by_label("Email").tag_name(), "input");
+	assert_eq!(
+		screen.get_by_placeholder("name@example.com").tag_name(),
+		"input"
+	);
+}
+
+#[test]
+fn hidden_elements_are_excluded_from_queries() {
+	let screen = render(
+		PageElement::new("div")
+			.child(
+				PageElement::new("button")
+					.attr("aria-hidden", "true")
+					.child("Save"),
+			)
+			.child(PageElement::new("button").child("Save")),
+	);
+
+	assert_eq!(screen.get_by_text("Save").tag_name(), "button");
+}
+
+#[test]
+fn multiple_matches_return_query_error() {
+	let screen = render(
+		PageElement::new("div")
+			.child(PageElement::new("button").child("Save"))
+			.child(PageElement::new("button").child("Save")),
+	);
+
+	assert!(matches!(
+		screen.try_get_by_text("Save"),
+		Err(QueryError::MultipleMatches)
+	));
+}
+
+#[test]
+fn click_dispatches_native_dummy_event() {
+	let clicked = Rc::new(Cell::new(false));
+	let clicked_for_handler = clicked.clone();
+	let screen = render(
+		PageElement::new("button")
+			.listener("click", move |_| clicked_for_handler.set(true))
+			.child("Save"),
+	);
+
+	screen.get_by_role(Role::Button, "Save").click();
+
+	assert!(clicked.get());
+}
+
+#[test]
+fn input_updates_internal_value_before_dispatch() {
+	let called = Rc::new(Cell::new(false));
+	let called_for_handler = called.clone();
+	let screen = render(
+		PageElement::new("input")
+			.attr("value", "old")
+			.attr("placeholder", "Job name")
+			.listener("input", move |_| called_for_handler.set(true)),
+	);
+	let input = screen.get_by_role(Role::Textbox, "Job name");
+
+	input.input("new");
+
+	assert!(called.get());
+	assert_eq!(input.value().as_deref(), Some("new"));
+}
+
+#[test]
+fn missing_event_handler_returns_error() {
+	let screen = render(PageElement::new("button").child("Save"));
+
+	assert_eq!(
+		screen.get_by_role(Role::Button, "Save").try_click(),
+		Err(EventError::MissingHandler)
+	);
+}

--- a/crates/reinhardt-pages/src/testing/component/text_match.rs
+++ b/crates/reinhardt-pages/src/testing/component/text_match.rs
@@ -1,0 +1,38 @@
+//! Text matching support for native component queries.
+
+/// Exact text matcher used by native component queries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextMatch {
+	needle: String,
+}
+
+impl TextMatch {
+	/// Creates a new exact text matcher.
+	pub fn exact(text: impl Into<String>) -> Self {
+		Self {
+			needle: text.into(),
+		}
+	}
+
+	pub(crate) fn matches(&self, text: &str) -> bool {
+		text == self.needle
+	}
+}
+
+impl From<&str> for TextMatch {
+	fn from(value: &str) -> Self {
+		Self::exact(value)
+	}
+}
+
+impl From<String> for TextMatch {
+	fn from(value: String) -> Self {
+		Self::exact(value)
+	}
+}
+
+impl From<&String> for TextMatch {
+	fn from(value: &String) -> Self {
+		Self::exact(value.clone())
+	}
+}

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -7,7 +7,7 @@ use reinhardt_core::types::page::{EventType, Page, PageEventHandler};
 
 use super::scheduler::SchedulerScope;
 #[cfg(feature = "msw")]
-use super::server_fn_mock::{ServerFnMockScope, SharedServerFnMocks};
+use super::server_fn_mock::SharedServerFnMocks;
 
 /// Stable identifier for a node in the native test DOM.
 pub(crate) type NodeId = usize;
@@ -21,8 +21,6 @@ pub(crate) struct ScreenInner {
 	/// Server function mocks registered for this screen.
 	#[cfg(feature = "msw")]
 	pub mocks: SharedServerFnMocks,
-	#[cfg(feature = "msw")]
-	_mock_scope: ServerFnMockScope,
 }
 
 pub(crate) struct TestDom {
@@ -389,13 +387,11 @@ pub(crate) fn shared_screen_inner(
 	dom: TestDom,
 	scheduler: Rc<SchedulerScope>,
 	mocks: SharedServerFnMocks,
-	mock_scope: ServerFnMockScope,
 ) -> Rc<RefCell<ScreenInner>> {
 	Rc::new(RefCell::new(ScreenInner {
 		dom,
 		scheduler,
 		mocks,
-		_mock_scope: mock_scope,
 	}))
 }
 

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -333,6 +333,9 @@ impl TestDom {
 			.collect::<Vec<_>>();
 
 		for (anchor, render) in anchors {
+			if !self.contains(anchor) {
+				continue;
+			}
 			self.clear_children(anchor);
 			self.append_page(anchor, render());
 		}

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -312,6 +312,11 @@ impl TestDom {
 				);
 				self.append_page(anchor, render());
 			}
+			Page::Outlet(outlet) => {
+				if let Some(child) = outlet.into_child() {
+					self.append_page(parent, child);
+				}
+			}
 		}
 	}
 

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -278,6 +278,28 @@ impl TestDom {
 					self.append_page(parent, child);
 				}
 			}
+			Page::Outlet(outlet) => {
+				let id = outlet.id().map(str::to_string);
+				if let Some(child) = outlet.into_child() {
+					self.append_page(parent, child);
+				} else if let Some(id) = id {
+					self.push_node(
+						parent,
+						TestNode::Element(ElementNode {
+							tag: "reinhardt-outlet".to_string(),
+							attrs: vec![
+								("data-rh-outlet-id".to_string(), id),
+								("style".to_string(), "display: contents;".to_string()),
+							],
+							children: Vec::new(),
+							parent: Some(parent),
+							is_void: false,
+							event_handlers: Default::default(),
+							value: None,
+						}),
+					);
+				}
+			}
 			Page::Empty => {}
 			Page::WithHead { view, .. } => self.append_page(parent, *view),
 			Page::ReactiveIf(reactive_if) => {

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -101,7 +101,7 @@ impl TestDom {
 		match self.nodes.get(node_id) {
 			Some(TestNode::Removed) => String::new(),
 			Some(TestNode::Root { children }) => self.children_visible_text(children),
-			Some(TestNode::Element(node)) if self.is_hidden(node_id) => String::new(),
+			Some(TestNode::Element(_node)) if self.is_hidden(node_id) => String::new(),
 			Some(TestNode::Element(node)) => self.children_visible_text(&node.children),
 			Some(TestNode::Text { text, .. }) => text.clone(),
 			Some(TestNode::ReactiveAnchor { children, .. }) => self.children_visible_text(children),
@@ -334,11 +334,6 @@ impl TestDom {
 				);
 				self.append_page(anchor, render());
 			}
-			Page::Outlet(outlet) => {
-				if let Some(child) = outlet.into_child() {
-					self.append_page(parent, child);
-				}
-			}
 		}
 	}
 
@@ -449,6 +444,7 @@ impl ElementNode {
 
 	pub(crate) fn supports_value(&self) -> bool {
 		matches!(self.tag.as_str(), "input" | "textarea" | "select")
+			&& !(self.tag == "input" && self.attr("type") == Some("hidden"))
 	}
 
 	pub(crate) fn is_disabled_form_control(&self) -> bool {

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -97,6 +97,18 @@ impl TestDom {
 		}
 	}
 
+	pub(crate) fn visible_text_content(&self, node_id: NodeId) -> String {
+		match self.nodes.get(node_id) {
+			Some(TestNode::Removed) => String::new(),
+			Some(TestNode::Root { children }) => self.children_visible_text(children),
+			Some(TestNode::Element(node)) if self.is_hidden(node_id) => String::new(),
+			Some(TestNode::Element(node)) => self.children_visible_text(&node.children),
+			Some(TestNode::Text { text, .. }) => text.clone(),
+			Some(TestNode::ReactiveAnchor { children, .. }) => self.children_visible_text(children),
+			None => String::new(),
+		}
+	}
+
 	pub(crate) fn all_elements(&self) -> Vec<NodeId> {
 		let mut nodes = Vec::new();
 		self.collect_elements(self.root, &mut nodes);
@@ -155,12 +167,33 @@ impl TestDom {
 		node_id: NodeId,
 		event_type: EventType,
 	) -> Option<PageEventHandler> {
-		self.element(node_id).and_then(|node| {
-			node.event_handlers
-				.iter()
-				.find(|(candidate, _)| *candidate == event_type)
-				.map(|(_, handler)| handler.clone())
-		})
+		let mut current = Some(node_id);
+		while let Some(id) = current {
+			if let Some(node) = self.element(id)
+				&& let Some((_, handler)) = node
+					.event_handlers
+					.iter()
+					.find(|(candidate, _)| *candidate == event_type)
+			{
+				return Some(handler.clone());
+			}
+			current = self.parent(id);
+		}
+		None
+	}
+
+	pub(crate) fn suppresses_events(&self, node_id: NodeId) -> bool {
+		let mut current = Some(node_id);
+		while let Some(id) = current {
+			if self
+				.element(id)
+				.is_some_and(ElementNode::is_disabled_form_control)
+			{
+				return true;
+			}
+			current = self.parent(id);
+		}
+		false
 	}
 
 	pub(crate) fn set_value(&mut self, node_id: NodeId, value: String) -> bool {
@@ -302,6 +335,13 @@ impl TestDom {
 			.collect::<String>()
 	}
 
+	fn children_visible_text(&self, children: &[NodeId]) -> String {
+		children
+			.iter()
+			.map(|child| self.visible_text_content(*child))
+			.collect::<String>()
+	}
+
 	fn collect_elements(&self, node_id: NodeId, output: &mut Vec<NodeId>) {
 		if self.element(node_id).is_some() {
 			output.push(node_id);
@@ -382,6 +422,14 @@ impl ElementNode {
 
 	pub(crate) fn supports_value(&self) -> bool {
 		matches!(self.tag.as_str(), "input" | "textarea" | "select")
+	}
+
+	pub(crate) fn is_disabled_form_control(&self) -> bool {
+		self.has_attr("disabled")
+			&& matches!(
+				self.tag.as_str(),
+				"button" | "fieldset" | "input" | "optgroup" | "option" | "select" | "textarea"
+			)
 	}
 }
 

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -162,24 +162,25 @@ impl TestDom {
 		None
 	}
 
-	pub(crate) fn event_handler(
+	pub(crate) fn event_handlers(
 		&self,
 		node_id: NodeId,
 		event_type: EventType,
-	) -> Option<PageEventHandler> {
+	) -> Vec<PageEventHandler> {
+		let mut handlers = Vec::new();
 		let mut current = Some(node_id);
 		while let Some(id) = current {
-			if let Some(node) = self.element(id)
-				&& let Some((_, handler)) = node
-					.event_handlers
-					.iter()
-					.find(|(candidate, _)| *candidate == event_type)
-			{
-				return Some(handler.clone());
+			if let Some(node) = self.element(id) {
+				handlers.extend(
+					node.event_handlers
+						.iter()
+						.filter(|(candidate, _)| *candidate == event_type)
+						.map(|(_, handler)| handler.clone()),
+				);
 			}
 			current = self.parent(id);
 		}
-		None
+		handlers
 	}
 
 	pub(crate) fn suppresses_events(&self, node_id: NodeId) -> bool {

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -1,0 +1,408 @@
+//! In-memory Page-backed tree for native component testing.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use reinhardt_core::types::page::{EventType, Page, PageEventHandler};
+
+use super::scheduler::SchedulerScope;
+#[cfg(feature = "msw")]
+use super::server_fn_mock::{ServerFnMockScope, SharedServerFnMocks};
+
+/// Stable identifier for a node in the native test DOM.
+pub(crate) type NodeId = usize;
+
+/// Shared mutable screen state used by handles.
+pub(crate) struct ScreenInner {
+	/// Rendered native test DOM.
+	pub dom: TestDom,
+	/// Harness scheduler active for this screen.
+	pub scheduler: Rc<SchedulerScope>,
+	/// Server function mocks registered for this screen.
+	#[cfg(feature = "msw")]
+	pub mocks: SharedServerFnMocks,
+	#[cfg(feature = "msw")]
+	_mock_scope: ServerFnMockScope,
+}
+
+pub(crate) struct TestDom {
+	nodes: Vec<TestNode>,
+	root: NodeId,
+}
+
+#[derive(Clone)]
+pub(crate) struct ElementNode {
+	pub tag: String,
+	attrs: Vec<(String, String)>,
+	pub children: Vec<NodeId>,
+	parent: Option<NodeId>,
+	is_void: bool,
+	event_handlers: Vec<(EventType, PageEventHandler)>,
+	value: Option<String>,
+}
+
+enum TestNode {
+	Removed,
+	Root {
+		children: Vec<NodeId>,
+	},
+	Element(ElementNode),
+	Text {
+		text: String,
+		parent: Option<NodeId>,
+	},
+	ReactiveAnchor {
+		children: Vec<NodeId>,
+		parent: Option<NodeId>,
+		render: Rc<dyn Fn() -> Page + 'static>,
+	},
+}
+
+impl TestDom {
+	/// Renders a Page into an in-memory native test DOM.
+	pub(crate) fn render(page: Page) -> Self {
+		let mut dom = Self {
+			nodes: vec![TestNode::Root {
+				children: Vec::new(),
+			}],
+			root: 0,
+		};
+		dom.append_page(dom.root, page);
+		dom
+	}
+
+	pub(crate) fn root(&self) -> NodeId {
+		self.root
+	}
+
+	pub(crate) fn contains(&self, node_id: NodeId) -> bool {
+		self.nodes
+			.get(node_id)
+			.is_some_and(|node| !matches!(node, TestNode::Removed))
+	}
+
+	pub(crate) fn element(&self, node_id: NodeId) -> Option<&ElementNode> {
+		match self.nodes.get(node_id)? {
+			TestNode::Element(node) => Some(node),
+			_ => None,
+		}
+	}
+
+	pub(crate) fn text_content(&self, node_id: NodeId) -> String {
+		match self.nodes.get(node_id) {
+			Some(TestNode::Removed) => String::new(),
+			Some(TestNode::Root { children }) => self.children_text(children),
+			Some(TestNode::Element(node)) => self.children_text(&node.children),
+			Some(TestNode::Text { text, .. }) => text.clone(),
+			Some(TestNode::ReactiveAnchor { children, .. }) => self.children_text(children),
+			None => String::new(),
+		}
+	}
+
+	pub(crate) fn all_elements(&self) -> Vec<NodeId> {
+		let mut nodes = Vec::new();
+		self.collect_elements(self.root, &mut nodes);
+		nodes
+	}
+
+	pub(crate) fn visible_elements(&self) -> Vec<NodeId> {
+		self.all_elements()
+			.into_iter()
+			.filter(|node_id| !self.is_hidden(*node_id))
+			.collect()
+	}
+
+	pub(crate) fn is_hidden(&self, node_id: NodeId) -> bool {
+		let mut current = Some(node_id);
+		while let Some(id) = current {
+			if let Some(node) = self.element(id) {
+				if node.has_attr("hidden") || node.attr("aria-hidden") == Some("true") {
+					return true;
+				}
+				current = node.parent;
+			} else {
+				current = self.parent(id);
+			}
+		}
+		false
+	}
+
+	pub(crate) fn find_element_by_id(&self, id: &str) -> Option<NodeId> {
+		self.all_elements()
+			.into_iter()
+			.find(|node_id| self.element(*node_id).and_then(|node| node.attr("id")) == Some(id))
+	}
+
+	pub(crate) fn label_for(&self, id: &str) -> Option<NodeId> {
+		self.all_elements().into_iter().find(|node_id| {
+			self.element(*node_id).is_some_and(|node| {
+				node.tag == "label" && node.attr("for") == Some(id) && !self.is_hidden(*node_id)
+			})
+		})
+	}
+
+	pub(crate) fn closest_label(&self, node_id: NodeId) -> Option<NodeId> {
+		let mut current = self.parent(node_id);
+		while let Some(id) = current {
+			if self.element(id).is_some_and(|node| node.tag == "label") {
+				return Some(id);
+			}
+			current = self.parent(id);
+		}
+		None
+	}
+
+	pub(crate) fn event_handler(
+		&self,
+		node_id: NodeId,
+		event_type: EventType,
+	) -> Option<PageEventHandler> {
+		self.element(node_id).and_then(|node| {
+			node.event_handlers
+				.iter()
+				.find(|(candidate, _)| *candidate == event_type)
+				.map(|(_, handler)| handler.clone())
+		})
+	}
+
+	pub(crate) fn set_value(&mut self, node_id: NodeId, value: String) -> bool {
+		match self.nodes.get_mut(node_id) {
+			Some(TestNode::Element(node)) if node.supports_value() => {
+				node.value = Some(value);
+				true
+			}
+			_ => false,
+		}
+	}
+
+	pub(crate) fn value(&self, node_id: NodeId) -> Option<String> {
+		self.element(node_id).and_then(|node| node.value.clone())
+	}
+
+	pub(crate) fn children(&self, node_id: NodeId) -> &[NodeId] {
+		match self.nodes.get(node_id) {
+			Some(TestNode::Removed) => &[],
+			Some(TestNode::Root { children }) => children,
+			Some(TestNode::Element(node)) => &node.children,
+			Some(TestNode::ReactiveAnchor { children, .. }) => children,
+			_ => &[],
+		}
+	}
+
+	pub(crate) fn text_node(&self, node_id: NodeId) -> Option<&str> {
+		match self.nodes.get(node_id) {
+			Some(TestNode::Text { text, .. }) => Some(text),
+			_ => None,
+		}
+	}
+
+	pub(crate) fn is_void(&self, node_id: NodeId) -> bool {
+		self.element(node_id).is_some_and(|node| node.is_void)
+	}
+
+	fn append_page(&mut self, parent: NodeId, page: Page) {
+		match page {
+			Page::Element(element) => {
+				let (tag, attrs, children, is_void, event_handlers) = element.into_parts();
+				let attrs = attrs
+					.into_iter()
+					.map(|(name, value)| (name.into_owned(), value.into_owned()))
+					.collect::<Vec<_>>();
+				let value = attrs
+					.iter()
+					.find(|(name, _)| name == "value")
+					.map(|(_, value)| value.clone());
+				let node_id = self.push_node(
+					parent,
+					TestNode::Element(ElementNode {
+						tag: tag.into_owned(),
+						attrs,
+						children: Vec::new(),
+						parent: Some(parent),
+						is_void,
+						event_handlers,
+						value,
+					}),
+				);
+				for child in children {
+					self.append_page(node_id, child);
+				}
+			}
+			Page::Text(text) => {
+				self.push_node(
+					parent,
+					TestNode::Text {
+						text: text.into_owned(),
+						parent: Some(parent),
+					},
+				);
+			}
+			Page::Fragment(children) => {
+				for child in children {
+					self.append_page(parent, child);
+				}
+			}
+			Page::KeyedFragment(children) => {
+				for (_, child) in children {
+					self.append_page(parent, child);
+				}
+			}
+			Page::Empty => {}
+			Page::WithHead { view, .. } => self.append_page(parent, *view),
+			Page::ReactiveIf(reactive_if) => {
+				let (condition, then_view, else_view) = reactive_if.into_parts();
+				let render: Rc<dyn Fn() -> Page + 'static> = Rc::new(move || {
+					if condition() {
+						then_view()
+					} else {
+						else_view()
+					}
+				});
+				let anchor = self.push_node(
+					parent,
+					TestNode::ReactiveAnchor {
+						children: Vec::new(),
+						parent: Some(parent),
+						render: Rc::clone(&render),
+					},
+				);
+				self.append_page(anchor, render());
+			}
+			Page::Reactive(reactive) => {
+				let render_arc = reactive.into_render();
+				let render: Rc<dyn Fn() -> Page + 'static> = Rc::new(move || render_arc());
+				let anchor = self.push_node(
+					parent,
+					TestNode::ReactiveAnchor {
+						children: Vec::new(),
+						parent: Some(parent),
+						render: Rc::clone(&render),
+					},
+				);
+				self.append_page(anchor, render());
+			}
+		}
+	}
+
+	fn push_node(&mut self, parent: NodeId, node: TestNode) -> NodeId {
+		let node_id = self.nodes.len();
+		self.nodes.push(node);
+		match self.nodes.get_mut(parent) {
+			Some(TestNode::Removed) => {}
+			Some(TestNode::Root { children }) => children.push(node_id),
+			Some(TestNode::Element(element)) => element.children.push(node_id),
+			Some(TestNode::ReactiveAnchor { children, .. }) => children.push(node_id),
+			_ => {}
+		}
+		node_id
+	}
+
+	fn children_text(&self, children: &[NodeId]) -> String {
+		children
+			.iter()
+			.map(|child| self.text_content(*child))
+			.collect::<String>()
+	}
+
+	fn collect_elements(&self, node_id: NodeId, output: &mut Vec<NodeId>) {
+		if self.element(node_id).is_some() {
+			output.push(node_id);
+		}
+		for child in self.children(node_id) {
+			self.collect_elements(*child, output);
+		}
+	}
+
+	fn parent(&self, node_id: NodeId) -> Option<NodeId> {
+		match self.nodes.get(node_id) {
+			Some(TestNode::Removed) => None,
+			Some(TestNode::Element(node)) => node.parent,
+			Some(TestNode::Text { parent, .. }) => *parent,
+			Some(TestNode::ReactiveAnchor { parent, .. }) => *parent,
+			_ => None,
+		}
+	}
+
+	pub(crate) fn rerender_reactive_anchors(&mut self) {
+		let anchors = self
+			.nodes
+			.iter()
+			.enumerate()
+			.filter_map(|(node_id, node)| match node {
+				TestNode::ReactiveAnchor { render, .. } => Some((node_id, Rc::clone(render))),
+				_ => None,
+			})
+			.collect::<Vec<_>>();
+
+		for (anchor, render) in anchors {
+			self.clear_children(anchor);
+			self.append_page(anchor, render());
+		}
+	}
+
+	fn clear_children(&mut self, node_id: NodeId) {
+		let children = match self.nodes.get_mut(node_id) {
+			Some(TestNode::Root { children }) => std::mem::take(children),
+			Some(TestNode::Element(node)) => std::mem::take(&mut node.children),
+			Some(TestNode::ReactiveAnchor { children, .. }) => std::mem::take(children),
+			_ => Vec::new(),
+		};
+		for child in children {
+			self.remove_subtree(child);
+		}
+	}
+
+	fn remove_subtree(&mut self, node_id: NodeId) {
+		let children = self.children(node_id).to_vec();
+		for child in children {
+			self.remove_subtree(child);
+		}
+		if let Some(node) = self.nodes.get_mut(node_id) {
+			*node = TestNode::Removed;
+		}
+	}
+}
+
+impl ElementNode {
+	pub(crate) fn attr(&self, name: &str) -> Option<&str> {
+		self.attrs
+			.iter()
+			.find(|(candidate, _)| candidate == name)
+			.map(|(_, value)| value.as_str())
+	}
+
+	pub(crate) fn attrs(&self) -> &[(String, String)] {
+		&self.attrs
+	}
+
+	pub(crate) fn has_attr(&self, name: &str) -> bool {
+		self.attr(name).is_some()
+	}
+
+	pub(crate) fn supports_value(&self) -> bool {
+		matches!(self.tag.as_str(), "input" | "textarea" | "select")
+	}
+}
+
+#[cfg(feature = "msw")]
+pub(crate) fn shared_screen_inner(
+	dom: TestDom,
+	scheduler: Rc<SchedulerScope>,
+	mocks: SharedServerFnMocks,
+	mock_scope: ServerFnMockScope,
+) -> Rc<RefCell<ScreenInner>> {
+	Rc::new(RefCell::new(ScreenInner {
+		dom,
+		scheduler,
+		mocks,
+		_mock_scope: mock_scope,
+	}))
+}
+
+#[cfg(not(feature = "msw"))]
+pub(crate) fn shared_screen_inner(
+	dom: TestDom,
+	scheduler: Rc<SchedulerScope>,
+) -> Rc<RefCell<ScreenInner>> {
+	Rc::new(RefCell::new(ScreenInner { dom, scheduler }))
+}

--- a/crates/reinhardt-pages/tests/component_system_integration.rs
+++ b/crates/reinhardt-pages/tests/component_system_integration.rs
@@ -248,7 +248,7 @@ fn test_component_state_transitions() {
 /// Tests list rendering use case
 #[rstest]
 fn test_component_use_case_list() {
-	let items = vec!["Apple", "Banana", "Cherry"];
+	let items = ["Apple", "Banana", "Cherry"];
 	let view = PageElement::new("ul")
 		.children(items.iter().map(|item| {
 			PageElement::new("li")
@@ -440,7 +440,7 @@ fn test_component_equivalence_int_props(#[case] value: i32) {
 
 /// Tests with float props
 #[rstest]
-#[case::float_props(3.14)]
+#[case::float_props(std::f64::consts::PI)]
 fn test_component_equivalence_float_props(#[case] value: f64) {
 	let comp = PropsComponent { value };
 	let html = comp.render().render_to_string();

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -4,7 +4,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 use std::time::Duration;
 
-use reinhardt_core::types::page::{EventType, IntoPage, Page, PageElement};
+use reinhardt_core::types::page::{EventType, IntoPage, Outlet, Page, PageElement};
 use reinhardt_pages::callback::async_handler;
 use reinhardt_pages::page;
 use reinhardt_pages::prelude::spawn_task;
@@ -153,6 +153,17 @@ fn text_queries_ignore_hidden_descendant_text() {
 	);
 
 	assert!(screen.try_get_by_text("Secret").is_err());
+}
+
+#[test]
+fn outlet_pages_render_inline_children_and_placeholders() {
+	let inline = render(Page::outlet(Outlet::inline(text_page("Nested"))));
+	assert!(inline.query_by_text("Nested").is_some());
+
+	let placeholder = render(Page::outlet(Outlet::placeholder("main")));
+	let pretty = placeholder.pretty();
+	assert!(pretty.contains("<reinhardt-outlet"));
+	assert!(pretty.contains("data-rh-outlet-id=\"main\""));
 }
 
 #[test]

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -1,0 +1,142 @@
+#![cfg(all(native, feature = "testing"))]
+
+use reinhardt_core::types::page::{IntoPage, Page, PageElement};
+use reinhardt_pages::page;
+use reinhardt_pages::reactive::hooks::use_action;
+use reinhardt_pages::reactive::{ResourceState, use_resource};
+#[cfg(feature = "msw")]
+use reinhardt_pages::server_fn::{ServerFnError, server_fn};
+use reinhardt_pages::testing::component::{Role, render};
+
+fn text_page(text: impl Into<String>) -> Page {
+	PageElement::new("div").child(text.into()).into_page()
+}
+
+fn string_resource_page(state: ResourceState<String, String>) -> Page {
+	match state {
+		ResourceState::Loading => text_page("Loading"),
+		ResourceState::Success(value) => text_page(value),
+		ResourceState::Error(error) => text_page(error),
+	}
+}
+
+fn index_job_component() -> Page {
+	let resource = use_resource(
+		|| async { Ok::<String, String>("Index job".to_string()) },
+		(),
+	);
+	Page::reactive(move || string_resource_page(resource.get()))
+}
+
+fn ready_component() -> Page {
+	let resource = use_resource(|| async { Ok::<String, String>("Ready".to_string()) }, ());
+	Page::reactive(move || string_resource_page(resource.get()))
+}
+
+fn save_component() -> Page {
+	let action = use_action(|_: ()| async { Ok::<String, String>("Saved".to_string()) });
+	let button_action = action.clone();
+	PageElement::new("div")
+		.child(
+			PageElement::new("button")
+				.listener("click", move |_| button_action.dispatch(()))
+				.child("Save"),
+		)
+		.child(Page::reactive(move || match action.result() {
+			Some(value) => text_page(value),
+			None => text_page("Idle"),
+		}))
+		.into_page()
+}
+
+#[test]
+fn native_component_testing_public_surface_is_available() {
+	let screen = render(
+		PageElement::new("main")
+			.attr("aria-label", "Dashboard")
+			.child(PageElement::new("h1").child("Dashboard"))
+			.child(PageElement::new("button").child("Refresh")),
+	);
+
+	assert_eq!(
+		screen.get_by_role(Role::Main, "Dashboard").tag_name(),
+		"main"
+	);
+	assert_eq!(
+		screen.get_by_role(Role::Button, "Refresh").text(),
+		"Refresh"
+	);
+}
+
+#[tokio::test]
+async fn settle_runs_use_resource_on_native() {
+	let screen = render(index_job_component);
+
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Index job").is_some());
+}
+
+#[tokio::test]
+async fn click_action_settles_to_success() {
+	let screen = render(save_component);
+
+	screen.get_by_role(Role::Button, "Save").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Saved").is_some());
+}
+
+#[tokio::test]
+async fn find_by_text_waits_for_resource() {
+	let screen = render(ready_component);
+
+	let element = screen.find_by_text("Ready").await;
+
+	assert_eq!(element.text(), "Ready");
+}
+
+#[test]
+fn pretty_dom_snapshot_is_stable() {
+	let screen = render(page!(|| {
+		main {
+			aria_label: "Jobs",
+			button { "Refresh" }
+		}
+	}));
+
+	insta::assert_snapshot!(screen.pretty());
+}
+
+#[cfg(feature = "msw")]
+#[server_fn]
+async fn load_jobs() -> Result<Vec<String>, ServerFnError> {
+	Ok(vec!["real job".to_string()])
+}
+
+#[cfg(feature = "msw")]
+fn jobs_resource_page(state: ResourceState<Vec<String>, ServerFnError>) -> Page {
+	match state {
+		ResourceState::Loading => text_page("Loading"),
+		ResourceState::Success(values) => text_page(values.join(", ")),
+		ResourceState::Error(error) => text_page(error.to_string()),
+	}
+}
+
+#[cfg(feature = "msw")]
+fn jobs_component() -> Page {
+	let jobs = use_resource(|| async { load_jobs().await }, ());
+	Page::reactive(move || jobs_resource_page(jobs.get()))
+}
+
+#[cfg(feature = "msw")]
+#[tokio::test]
+async fn server_fn_mock_feeds_resource() {
+	let screen = render(jobs_component);
+	screen.mock_server_fn::<load_jobs::marker>(|_args| Ok(vec!["Index job".to_string()]));
+
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Index job").is_some());
+	assert_eq!(screen.calls_to_server_fn::<load_jobs::marker>().len(), 1);
+}

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -88,6 +88,19 @@ async fn click_action_settles_to_success() {
 }
 
 #[tokio::test]
+async fn click_action_uses_own_screen_scheduler() {
+	let first = render(save_component);
+	let second = render(save_component);
+
+	first.get_by_role(Role::Button, "Save").click();
+	first.settle().await;
+
+	assert!(first.query_by_text("Saved").is_some());
+	assert!(second.query_by_text("Saved").is_none());
+	assert!(second.query_by_text("Idle").is_some());
+}
+
+#[tokio::test]
 async fn find_by_text_waits_for_resource() {
 	let screen = render(ready_component);
 
@@ -139,4 +152,59 @@ async fn server_fn_mock_feeds_resource() {
 
 	assert!(screen.query_by_text("Index job").is_some());
 	assert_eq!(screen.calls_to_server_fn::<load_jobs::marker>().len(), 1);
+}
+
+#[cfg(feature = "msw")]
+#[tokio::test]
+async fn server_fn_mocks_are_scoped_per_screen() {
+	let first = render(jobs_component);
+	first.mock_server_fn::<load_jobs::marker>(|_args| Ok(vec!["First job".to_string()]));
+	let second = render(jobs_component);
+	second.mock_server_fn::<load_jobs::marker>(|_args| Ok(vec!["Second job".to_string()]));
+
+	first.settle().await;
+	second.settle().await;
+
+	assert!(first.query_by_text("First job").is_some());
+	assert!(first.query_by_text("Second job").is_none());
+	assert!(second.query_by_text("Second job").is_some());
+	assert!(second.query_by_text("First job").is_none());
+}
+
+#[cfg(feature = "msw")]
+#[tokio::test]
+async fn server_fn_mock_errors_render_resource_errors() {
+	let screen = render(jobs_component);
+	screen.mock_server_fn::<load_jobs::marker>(|_args| {
+		Err(ServerFnError::application("mock failed"))
+	});
+
+	screen.settle().await;
+
+	assert!(
+		screen
+			.query_by_text("Application error: mock failed")
+			.is_some()
+	);
+	assert_eq!(screen.calls_to_server_fn::<load_jobs::marker>().len(), 1);
+}
+
+#[cfg(feature = "msw")]
+#[tokio::test]
+async fn server_fn_mock_handler_can_inspect_recorded_calls() {
+	let screen = render(jobs_component);
+	let screen_for_handler = screen.clone();
+	screen.mock_server_fn::<load_jobs::marker>(move |_args| {
+		assert_eq!(
+			screen_for_handler
+				.calls_to_server_fn::<load_jobs::marker>()
+				.len(),
+			1
+		);
+		Ok(vec!["Inspectable job".to_string()])
+	});
+
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Inspectable job").is_some());
 }

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -1,9 +1,10 @@
 #![cfg(all(native, feature = "testing"))]
 
-use reinhardt_core::types::page::{IntoPage, Page, PageElement};
+use reinhardt_core::types::page::{EventType, IntoPage, Page, PageElement};
+use reinhardt_pages::callback::async_handler;
 use reinhardt_pages::page;
 use reinhardt_pages::reactive::hooks::use_action;
-use reinhardt_pages::reactive::{ResourceState, use_resource};
+use reinhardt_pages::reactive::{ResourceState, Signal, use_resource};
 #[cfg(feature = "msw")]
 use reinhardt_pages::server_fn::{ServerFnError, server_fn};
 use reinhardt_pages::testing::component::{Role, render};
@@ -58,6 +59,27 @@ fn save_component() -> Page {
 		.into_page()
 }
 
+fn async_click_component() -> Page {
+	let message = Signal::new("Idle".to_string());
+	let click_message = message.clone();
+	PageElement::new("div")
+		.child(
+			PageElement::new("button")
+				.on(
+					EventType::Click,
+					async_handler(move |_| {
+						let click_message = click_message.clone();
+						async move {
+							click_message.set("Clicked".to_string());
+						}
+					}),
+				)
+				.child("Run"),
+		)
+		.child(Page::reactive(move || text_page(message.get())))
+		.into_page()
+}
+
 #[test]
 fn native_component_testing_public_surface_is_available() {
 	let screen = render(
@@ -107,6 +129,16 @@ async fn click_action_uses_own_screen_scheduler() {
 	assert!(first.query_by_text("Saved").is_some());
 	assert!(second.query_by_text("Saved").is_none());
 	assert!(second.query_by_text("Idle").is_some());
+}
+
+#[tokio::test]
+async fn async_click_handler_settles_to_updated_ui() {
+	let screen = render(async_click_component);
+
+	screen.get_by_role(Role::Button, "Run").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Clicked").is_some());
 }
 
 #[tokio::test]

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -33,6 +33,15 @@ fn ready_component() -> Page {
 	Page::reactive(move || string_resource_page(resource.get()))
 }
 
+fn mixed_resource_component() -> Page {
+	let pending = use_resource(|| std::future::pending::<Result<String, String>>(), ());
+	let ready = use_resource(|| async { Ok::<String, String>("Ready".to_string()) }, ());
+	Page::reactive(move || {
+		let _ = pending.get();
+		string_resource_page(ready.get())
+	})
+}
+
 fn save_component() -> Page {
 	let action = use_action(|_: ()| async { Ok::<String, String>("Saved".to_string()) });
 	let button_action = action.clone();
@@ -103,6 +112,15 @@ async fn click_action_uses_own_screen_scheduler() {
 #[tokio::test]
 async fn find_by_text_waits_for_resource() {
 	let screen = render(ready_component);
+
+	let element = screen.find_by_text("Ready").await;
+
+	assert_eq!(element.text(), "Ready");
+}
+
+#[tokio::test]
+async fn find_by_text_rerenders_completed_work_with_pending_tasks() {
+	let screen = render(mixed_resource_component);
 
 	let element = screen.find_by_text("Ready").await;
 

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -1,6 +1,6 @@
 #![cfg(all(native, feature = "testing"))]
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -367,6 +367,47 @@ async fn click_events_bubble_from_descendant_handles() {
 	assert!(screen.query_by_text("Clicked").is_some());
 }
 
+#[test]
+fn click_events_invoke_each_handler_in_bubbling_path() {
+	let calls = Rc::new(RefCell::new(Vec::new()));
+	let outer_calls = Rc::clone(&calls);
+	let button_calls = Rc::clone(&calls);
+	let screen = render(
+		PageElement::new("div")
+			.listener("click", move |_| outer_calls.borrow_mut().push("outer"))
+			.child(
+				PageElement::new("button")
+					.listener("click", move |_| button_calls.borrow_mut().push("button"))
+					.child(
+						PageElement::new("span")
+							.attr("role", "status")
+							.attr("aria-label", "Nested status")
+							.child("Nested label"),
+					),
+			),
+	);
+
+	screen.get_by_role(Role::Status, "Nested status").click();
+
+	assert_eq!(calls.borrow().as_slice(), ["button", "outer"]);
+}
+
+#[test]
+fn submit_helper_dispatches_submit_event() {
+	let submitted = Rc::new(Cell::new(false));
+	let submitted_for_handler = Rc::clone(&submitted);
+	let screen = render(
+		PageElement::new("form")
+			.attr("aria-label", "Job form")
+			.listener("submit", move |_| submitted_for_handler.set(true))
+			.child(PageElement::new("input").attr("name", "job")),
+	);
+
+	screen.get_by_role(Role::Form, "Job form").submit();
+
+	assert!(submitted.get());
+}
+
 #[tokio::test]
 async fn parent_rerender_skips_removed_child_anchors() {
 	let show_child = Signal::new(true);
@@ -493,6 +534,21 @@ async fn server_fn_mock_errors_render_resource_errors() {
 	assert!(
 		screen
 			.query_by_text("Application error: mock failed")
+			.is_some()
+	);
+	assert_eq!(screen.calls_to_server_fn::<load_jobs::marker>().len(), 1);
+}
+
+#[cfg(feature = "msw")]
+#[tokio::test]
+async fn active_server_fn_mock_scope_requires_registered_handler() {
+	let screen = render(jobs_component);
+
+	screen.settle().await;
+
+	assert!(
+		screen
+			.query_by_text("Application error: no mock registered for active server function")
 			.is_some()
 	);
 	assert_eq!(screen.calls_to_server_fn::<load_jobs::marker>().len(), 1);

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use reinhardt_core::types::page::{EventType, IntoPage, Page, PageElement};
 use reinhardt_pages::callback::async_handler;
 use reinhardt_pages::page;
+use reinhardt_pages::prelude::spawn_task;
 use reinhardt_pages::reactive::hooks::use_action;
 use reinhardt_pages::reactive::{ResourceState, Signal, use_resource};
 #[cfg(feature = "msw")]
@@ -145,6 +146,51 @@ fn presentation_role_suppresses_implicit_role_queries() {
 	assert!(screen.query_by_text("Save").is_some());
 }
 
+#[test]
+fn text_queries_ignore_hidden_descendant_text() {
+	let screen = render(
+		PageElement::new("div").child(PageElement::new("span").attr("hidden", "").child("Secret")),
+	);
+
+	assert!(screen.try_get_by_text("Secret").is_err());
+}
+
+#[test]
+fn role_queries_follow_fallback_tokens_and_input_rules() {
+	let screen = render(Page::fragment([
+		PageElement::new("div")
+			.attr("role", "foo button")
+			.child("Fallback button")
+			.into_page(),
+		PageElement::new("div")
+			.attr("role", "switch checkbox")
+			.attr("aria-label", "Power")
+			.into_page(),
+		PageElement::new("label")
+			.child("Password")
+			.child(PageElement::new("input").attr("type", "password"))
+			.into_page(),
+		PageElement::new("input")
+			.attr("type", "submit")
+			.attr("value", "Save")
+			.into_page(),
+	]));
+
+	assert_eq!(
+		screen
+			.get_by_role(Role::Button, "Fallback button")
+			.tag_name(),
+		"div"
+	);
+	assert_eq!(
+		screen.get_by_role(Role::Checkbox, "Power").tag_name(),
+		"div"
+	);
+	assert!(screen.try_get_by_role(Role::Textbox, "Password").is_err());
+	assert_eq!(screen.get_by_label("Password").tag_name(), "input");
+	assert_eq!(screen.get_by_role(Role::Button, "Save").tag_name(), "input");
+}
+
 #[tokio::test]
 async fn settle_runs_use_resource_on_native() {
 	let screen = render(index_job_component);
@@ -195,6 +241,119 @@ async fn settle_waits_for_timer_backed_tasks() {
 	screen.settle().await;
 
 	assert!(screen.query_by_text("Delayed").is_some());
+}
+
+#[tokio::test]
+async fn settle_continues_when_rerender_mounts_async_work() {
+	let show_child = Signal::new(false);
+	let message = Signal::new("Idle".to_string());
+	let spawned = Rc::new(Cell::new(false));
+	let screen = render({
+		let show_child = show_child.clone();
+		let message = message.clone();
+		let spawned = Rc::clone(&spawned);
+		move || {
+			let show_child = show_child.clone();
+			let message = message.clone();
+			let spawned = Rc::clone(&spawned);
+			Page::reactive(move || {
+				if show_child.get() && !spawned.replace(true) {
+					let spawned_message = message.clone();
+					spawn_task(async move {
+						spawned_message.set("Mounted work".to_string());
+					});
+				}
+				text_page(message.get())
+			})
+		}
+	});
+
+	show_child.set(true);
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Mounted work").is_some());
+}
+
+#[tokio::test]
+async fn settle_preserves_tasks_spawned_by_polled_tasks() {
+	let message = Signal::new("Idle".to_string());
+	let click_message = message.clone();
+	let screen = render(move || {
+		let message = message.clone();
+		let click_message = click_message.clone();
+		PageElement::new("div")
+			.child(
+				PageElement::new("button")
+					.on(
+						EventType::Click,
+						async_handler(move |_| {
+							let click_message = click_message.clone();
+							async move {
+								tokio::task::yield_now().await;
+								spawn_task(async move {
+									click_message.set("Nested".to_string());
+								});
+							}
+						}),
+					)
+					.child("Run nested"),
+			)
+			.child(Page::reactive(move || text_page(message.get())))
+			.into_page()
+	});
+
+	screen.get_by_role(Role::Button, "Run nested").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Nested").is_some());
+}
+
+#[tokio::test]
+async fn disabled_controls_suppress_click_handlers() {
+	let message = Signal::new("Idle".to_string());
+	let click_message = message.clone();
+	let screen = render(move || {
+		let message = message.clone();
+		let click_message = click_message.clone();
+		PageElement::new("div")
+			.child(
+				PageElement::new("button")
+					.attr("disabled", "")
+					.listener("click", move |_| click_message.set("Clicked".to_string()))
+					.child("Save"),
+			)
+			.child(Page::reactive(move || text_page(message.get())))
+			.into_page()
+	});
+
+	screen.get_by_role(Role::Button, "Save").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Idle").is_some());
+	assert!(screen.query_by_text("Clicked").is_none());
+}
+
+#[tokio::test]
+async fn click_events_bubble_from_descendant_handles() {
+	let message = Signal::new("Idle".to_string());
+	let click_message = message.clone();
+	let screen = render(move || {
+		let message = message.clone();
+		let click_message = click_message.clone();
+		PageElement::new("div")
+			.child(
+				PageElement::new("button")
+					.listener("click", move |_| click_message.set("Clicked".to_string()))
+					.child(PageElement::new("span").child("Nested label")),
+			)
+			.child(Page::reactive(move || text_page(message.get())))
+			.into_page()
+	});
+
+	screen.get_by_text("Nested label").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Clicked").is_some());
 }
 
 #[tokio::test]

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -1,5 +1,9 @@
 #![cfg(all(native, feature = "testing"))]
 
+use std::cell::Cell;
+use std::rc::Rc;
+use std::time::Duration;
+
 use reinhardt_core::types::page::{EventType, IntoPage, Page, PageElement};
 use reinhardt_pages::callback::async_handler;
 use reinhardt_pages::page;
@@ -80,6 +84,28 @@ fn async_click_component() -> Page {
 		.into_page()
 }
 
+fn delayed_async_click_component() -> Page {
+	let message = Signal::new("Idle".to_string());
+	let click_message = message.clone();
+	PageElement::new("div")
+		.child(
+			PageElement::new("button")
+				.on(
+					EventType::Click,
+					async_handler(move |_| {
+						let click_message = click_message.clone();
+						async move {
+							tokio::time::sleep(Duration::from_millis(1)).await;
+							click_message.set("Delayed".to_string());
+						}
+					}),
+				)
+				.child("Run"),
+		)
+		.child(Page::reactive(move || text_page(message.get())))
+		.into_page()
+}
+
 #[test]
 fn native_component_testing_public_surface_is_available() {
 	let screen = render(
@@ -97,6 +123,26 @@ fn native_component_testing_public_surface_is_available() {
 		screen.get_by_role(Role::Button, "Refresh").text(),
 		"Refresh"
 	);
+}
+
+#[test]
+fn label_query_does_not_match_placeholder_only_inputs() {
+	let screen = render(PageElement::new("input").attr("placeholder", "Email"));
+
+	assert!(screen.try_get_by_label("Email").is_err());
+	assert_eq!(screen.get_by_placeholder("Email").tag_name(), "input");
+}
+
+#[test]
+fn presentation_role_suppresses_implicit_role_queries() {
+	let screen = render(
+		PageElement::new("button")
+			.attr("role", "presentation")
+			.child("Save"),
+	);
+
+	assert!(screen.try_get_by_role(Role::Button, "Save").is_err());
+	assert!(screen.query_by_text("Save").is_some());
 }
 
 #[tokio::test]
@@ -139,6 +185,49 @@ async fn async_click_handler_settles_to_updated_ui() {
 	screen.settle().await;
 
 	assert!(screen.query_by_text("Clicked").is_some());
+}
+
+#[tokio::test]
+async fn settle_waits_for_timer_backed_tasks() {
+	let screen = render(delayed_async_click_component);
+
+	screen.get_by_role(Role::Button, "Run").click();
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Delayed").is_some());
+}
+
+#[tokio::test]
+async fn parent_rerender_skips_removed_child_anchors() {
+	let show_child = Signal::new(true);
+	let child_renders = Rc::new(Cell::new(0));
+	let screen = {
+		let show_child = show_child.clone();
+		let child_renders = Rc::clone(&child_renders);
+		render(move || {
+			let show_child = show_child.clone();
+			let child_renders = Rc::clone(&child_renders);
+			Page::reactive(move || {
+				if show_child.get() {
+					let child_renders = Rc::clone(&child_renders);
+					Page::reactive(move || {
+						child_renders.set(child_renders.get() + 1);
+						text_page("Child")
+					})
+				} else {
+					text_page("Gone")
+				}
+			})
+		})
+	};
+
+	assert_eq!(child_renders.get(), 1);
+	show_child.set(false);
+	screen.settle().await;
+
+	assert_eq!(child_renders.get(), 1);
+	assert!(screen.query_by_text("Gone").is_some());
+	assert!(screen.query_by_text("Child").is_none());
 }
 
 #[tokio::test]

--- a/crates/reinhardt-pages/tests/context_api_integration.rs
+++ b/crates/reinhardt-pages/tests/context_api_integration.rs
@@ -190,7 +190,7 @@ fn test_context_use_case_auth_state() {
 	assert!(auth_state.is_some());
 	if let Some((email, is_authenticated)) = auth_state {
 		assert_eq!(email, "user@example.com");
-		assert_eq!(is_authenticated, true);
+		assert!(is_authenticated);
 	}
 }
 

--- a/crates/reinhardt-pages/tests/hooks_integration.rs
+++ b/crates/reinhardt-pages/tests/hooks_integration.rs
@@ -144,7 +144,7 @@ fn test_hooks_circular_dependency_detection() {
 	);
 
 	// If circular dependencies are properly handled, this should not hang
-	assert!(true);
+	assert_eq!(signal_b.get(), 1);
 }
 
 /// Tests infinite loop protection in effects
@@ -313,7 +313,7 @@ fn test_hooks_cleanup_on_unmount() {
 	// Cleanup may or may not have been called immediately
 	// (depends on when effect runs)
 	// Just verify the ref was updated
-	assert_eq!(*component_ref.current(), false);
+	assert!(!*component_ref.current());
 }
 
 // ============================================================================
@@ -364,9 +364,8 @@ fn test_hooks_use_case_form_validation() {
 
 	set_email("user@example.com".to_string());
 	// Memo may not have recomputed yet
-	let is_valid2 = is_valid_email.get();
-	// Could be old value or new value depending on timing
-	assert!(is_valid2 || !is_valid2); // Always true, but documents the behavior
+	let _is_valid2 = is_valid_email.get();
+	assert_eq!(email.get(), "user@example.com");
 }
 
 // ============================================================================
@@ -391,8 +390,9 @@ fn test_hooks_property_memo_deterministic() {
 
 		// Results should be the same (memoization)
 		prop_assert_eq!(result1, result2);
-		// Result should be input * 2 (may vary by timing)
-		prop_assert!(result1 == input * 2 || result1 == 0 * 2);
+		// Result should be input * 2 once memoized; some native timing paths can still expose the initial value.
+		let initial_result = 0;
+		prop_assert!(result1 == input * 2 || result1 == initial_result);
 	});
 }
 

--- a/crates/reinhardt-pages/tests/hydration_execution_integration.rs
+++ b/crates/reinhardt-pages/tests/hydration_execution_integration.rs
@@ -417,7 +417,7 @@ fn test_hydration_context_signal_count_boundary(#[case] count: usize) {
 	let mut state = SsrState::new();
 
 	for i in 0..count {
-		state.add_signal(&format!("signal-{}", i), json!(i));
+		state.add_signal(format!("signal-{}", i), json!(i));
 	}
 
 	let context = HydrationContext::from_state(state);
@@ -441,7 +441,7 @@ fn test_hydration_context_nesting_depth_boundary(#[case] depth: usize) {
 	let mut state = SsrState::new();
 
 	for i in 0..depth {
-		state.add_props(&format!("comp-level-{}", i), json!({"depth": i}));
+		state.add_props(format!("comp-level-{}", i), json!({"depth": i}));
 	}
 
 	let context = HydrationContext::from_state(state);

--- a/crates/reinhardt-pages/tests/snapshots/component_testing__pretty_dom_snapshot_is_stable.snap
+++ b/crates/reinhardt-pages/tests/snapshots/component_testing__pretty_dom_snapshot_is_stable.snap
@@ -1,0 +1,9 @@
+---
+source: crates/reinhardt-pages/tests/component_testing.rs
+expression: screen.pretty()
+---
+<main aria-label="Jobs">
+  <button>
+    Refresh
+  </button>
+</main>

--- a/crates/reinhardt-pages/tests/ssr_renderer_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_renderer_integration_tests.rs
@@ -159,7 +159,7 @@ fn test_conditional_rendering() {
 
 #[test]
 fn test_list_rendering() {
-	let items = vec!["Apple", "Banana", "Cherry"];
+	let items = ["Apple", "Banana", "Cherry"];
 	let list = PageElement::new("ul");
 
 	let list_with_items = items.iter().fold(list, |acc, item| {

--- a/crates/reinhardt-pages/tests/static_asset_decision_table_tests.rs
+++ b/crates/reinhardt-pages/tests/static_asset_decision_table_tests.rs
@@ -222,7 +222,7 @@ mod decision_table_tests {
 
 		let result = resolve_static(filename);
 
-		assert!(result.ends_with(filename.split('.').last().unwrap()));
+		assert!(result.ends_with(filename.split('.').next_back().unwrap()));
 	}
 
 	/// Decision table: Base URL Types

--- a/docs/superpowers/specs/2026-07-04-native-component-test-harness-design.md
+++ b/docs/superpowers/specs/2026-07-04-native-component-test-harness-design.md
@@ -1,0 +1,435 @@
+# Native Component Test Harness
+
+**Issue**: [#5583](https://github.com/kent8192/reinhardt-web/issues/5583)
+**Date**: 2026-07-04
+**Status**: Approved design (pending implementation plan)
+
+## Summary
+
+Add a native component testing harness for `reinhardt-pages` that can render a
+`Page` into an in-memory interactive DOM, query it with Testing
+Library-inspired role/text/label helpers, dispatch common events, mock
+`server_fn` calls per test, and await reactive settling without a browser or
+WASM toolchain.
+
+The first public surface lives in `reinhardt_pages::testing::component` and is
+re-exported through the `reinhardt` facade as `reinhardt::test::pages`.
+
+## Motivation
+
+Meaningful component behavior tests currently need the WASM path: browser
+execution, `wasm-pack`, mocked fetch, and a headless runtime. That path remains
+valuable for hydration and browser API coverage, but it is too expensive for
+the majority of component interaction tests.
+
+The framework already has a native `Page` representation, native event handler
+storage via `DummyEvent`, SSR rendering, native client API stubs, and
+MSW-style `MockableServerFn` metadata. The missing layer is an interactive
+test runtime that uses those native structures directly.
+
+## Goals
+
+- Render a `Page` under plain `cargo test` with no browser, no `wasm-pack`, and
+  no loopback server for the component harness itself.
+- Query rendered output by user-facing semantics: role, accessible name, label,
+  placeholder, and text.
+- Dispatch common events against stored `Page` event handlers.
+- Let `screen.settle().await` drive test-scoped async work and reactive
+  rerendering deterministically.
+- Mock `server_fn` calls in process, per test, using generated
+  `MockableServerFn` marker metadata.
+- Produce stable pretty output suitable for diagnostic messages and snapshots.
+
+## Non-Goals
+
+- Browser E2E, hydration correctness, layout, CSS, focus ring, scrolling, and
+  visual assertions.
+- Full DOM, `web-sys`, or ARIA implementation parity.
+- Replacing the WASM smoke-test path.
+- Replacing native direct `server_fn` unit tests for business logic.
+- Intercepting arbitrary HTTP clients, `reqwest`, `hyper`, AWS SDK calls, or
+  OS-level network traffic.
+
+## Recommended Approach
+
+Build a native interactive DOM from the `Page` tree itself.
+
+Alternatives considered:
+
+| Approach | Trade-off |
+|---|---|
+| Native `TestNode` tree from `Page` | Fast, preserves event handlers and reactive structure, matches existing types |
+| SSR HTML parse plus event sidecar | Reuses HTML output but makes event and reactive mapping fragile |
+| Broad native pseudo-`web-sys` DOM | Browser-like, but far beyond the accepted scope |
+
+The `Page` tree is the authoritative structure for this harness. HTML parsing
+would discard exactly the event and reactive metadata the harness needs.
+
+## Public API
+
+Primary module:
+
+```rust
+reinhardt_pages::testing::component
+```
+
+Facade re-export:
+
+```rust
+reinhardt::test::pages
+```
+
+Representative usage:
+
+```rust
+use reinhardt::test::pages::{Role, render};
+
+#[rstest]
+#[tokio::test]
+async fn refresh_loads_jobs() {
+    let screen = render(jobs(Path(1)));
+    screen.mock_server_fn::<load_jobs::marker>(|args| Ok(vec![job("Index job")]));
+
+    screen.get_by_role(Role::Button, "Refresh").click();
+    screen.settle().await;
+
+    assert!(screen.query_by_text("Index job").is_some());
+}
+```
+
+Initial stable types:
+
+| Type | Purpose |
+|---|---|
+| `Screen` | Owns the rendered test DOM, query engine, scheduler, and server function mocks |
+| `ElementHandle` | Refers to a node inside a `Screen` by stable node id |
+| `Role` | Typed role query input |
+| `TextMatch` | Exact text matching for queries |
+| `QueryError` | Structured query failure diagnostics |
+| `EventError` | Structured event dispatch failure diagnostics |
+| `SettleError` | Structured async settling failure diagnostics |
+
+Initial query methods:
+
+| Method family | Behavior |
+|---|---|
+| `get_by_role`, `get_by_text`, `get_by_label`, `get_by_placeholder` | Panic with rich diagnostics on zero or multiple matches |
+| `try_get_by_*` | Return `Result<ElementHandle, QueryError>` |
+| `query_by_*` | Return `Option<ElementHandle>` on zero or one match; panic on multiple matches |
+| `find_by_*` | Await `settle()` loops until one match or timeout |
+| `try_find_by_*` | Async `Result` variant for helper code |
+
+Initial event methods:
+
+| Method | Event type |
+|---|---|
+| `click()` / `try_click()` | `click` |
+| `submit()` / `try_submit()` | `submit` |
+| `input(value)` / `try_input(value)` | `input`, updates test element value first |
+| `change(value)` / `try_change(value)` | `change`, updates test element value first |
+
+Snapshot support starts with:
+
+```rust
+screen.pretty()
+```
+
+The returned string must be stable enough for `insta` snapshots.
+
+## Architecture
+
+`Screen` owns four coordinated subsystems:
+
+1. **In-memory DOM tree**: `TestNode` values built from `Page`.
+2. **Query engine**: role, accessible-name, label, placeholder, and text
+   matching over `TestNode`.
+3. **Test scheduler**: harness-scoped async task queue and reactive rerender
+   queue.
+4. **Server function mocks**: per-screen registry keyed by
+   `MockableServerFn::PATH` and marker type.
+
+The render pipeline is:
+
+```text
+Page -> TestNode tree -> query/event -> scheduler -> rerender
+```
+
+`ElementHandle` stores the owning screen reference and a node id. It does not
+own nodes directly. After rerendering, a handle remains usable if the node id is
+still present. If the node has been removed, event and read operations fail
+with `DetachedElement`.
+
+## Test DOM Model
+
+`TestNode` stores:
+
+- node id
+- optional parent id
+- node kind: element, text, fragment root, reactive anchor
+- tag name for element nodes
+- attributes
+- children
+- current form value for input-like nodes
+- event handlers copied from `PageElement`
+- source role/name cache invalidated on rerender
+
+Fragments do not appear as queryable elements. They only group children under
+the screen root. `Page::WithHead` renders only the view portion. Head metadata
+is outside component interaction scope.
+
+Reactive nodes are represented as anchors whose current child subtree is
+replaceable. This keeps rerendering local and avoids rebuilding the full screen
+for every signal change.
+
+## Reactive Rendering
+
+`Page::Reactive` and `Page::ReactiveIf` are evaluated inside a harness render
+scope. The scope records which reactive anchor produced which subtree.
+
+When signals or effects mark a reactive anchor dirty, the screen schedules that
+anchor for rerender. Rerendering replaces the anchor's current child subtree
+with a fresh `Page -> TestNode` expansion.
+
+Normal native and SSR behavior must not change. Outside a component harness,
+native task spawning remains a no-op and native resources stay in their
+existing SSR-oriented loading behavior.
+
+## Scheduler
+
+The native platform layer gains an internal test hook point. Under a `Screen`
+RAII guard, `platform::native::spawn_task` enqueues futures into the active
+harness scheduler. Without the guard, it keeps the current no-op behavior.
+
+`screen.settle().await` repeats this loop:
+
+1. poll queued tasks until no immediately-ready work remains;
+2. apply pending signal/effect notifications;
+3. rerender dirty reactive anchors;
+4. enqueue any new tasks produced by rerendered hooks;
+5. stop when task and rerender queues are both empty.
+
+`settle()` has a timeout and maximum iteration count. A self-triggering effect
+or infinite refetch loop returns `SettleError::DidNotQuiesce` with pending task
+counts and `screen.pretty()` output.
+
+The first implementation requires an async test context such as
+`#[tokio::test]` or async `rstest`. Blocking settle helpers are out of scope
+for the first release.
+
+## Server Function Mocks
+
+The harness adds an in-process mock registry for generated native client stubs.
+`screen.mock_server_fn::<S>(handler)` registers a handler where
+`S: MockableServerFn` and the handler accepts `S::Args` and returns
+`Result<S::Response, ServerFnError>`.
+
+Generated native client stubs check the active harness registry before taking
+their normal native path. When a matching handler exists, the stub:
+
+1. serializes the original call arguments into `S::Args`;
+2. records the call;
+3. calls the registered handler;
+4. returns the handler response using the same `ServerFnError` type as normal
+   server functions.
+
+If a component harness is active and no mock exists for a called server
+function, the stub returns a deterministic `ServerFnError` that names the
+missing path. It must not perform external HTTP or use the native
+`MockServiceWorker` loopback runtime.
+
+Call inspection:
+
+```rust
+let calls = screen.calls_to_server_fn::<load_jobs::marker>();
+assert_eq!(calls.len(), 1);
+```
+
+The existing `MockServiceWorker` remains the right tool for native tests that
+explicitly exercise HTTP clients against a loopback server. The component
+harness registry is for in-process component tests only.
+
+## Queries And Accessibility
+
+Query priority follows Testing Library's user-centric model:
+
+1. role plus accessible name;
+2. label for form controls;
+3. placeholder for inputs;
+4. text for non-interactive content.
+
+Initial `Role` variants:
+
+- `Alert`
+- `Button`
+- `Checkbox`
+- `Combobox`
+- `Dialog`
+- `Form`
+- `Heading`
+- `Link`
+- `List`
+- `Listbox`
+- `ListItem`
+- `Main`
+- `Navigation`
+- `Option`
+- `Progressbar`
+- `Radio`
+- `Status`
+- `Textbox`
+
+`Role::Custom(String)` is intentionally not included in the first release.
+Unknown roles should become explicit enum additions so test semantics stay
+auditable.
+
+Role resolution order:
+
+1. explicit `role` attribute;
+2. supported HTML implicit roles.
+
+Initial implicit role coverage:
+
+| HTML | Role |
+|---|---|
+| `button` | `Button` |
+| `a[href]` | `Link` |
+| `input[type=text/search/email/password/url/tel]` | `Textbox` |
+| `input[type=checkbox]` | `Checkbox` |
+| `input[type=radio]` | `Radio` |
+| `textarea` | `Textbox` |
+| `select` | `Combobox` or `Listbox` based on attributes |
+| `form` | `Form` when it has an accessible name |
+| `nav` | `Navigation` |
+| `main` | `Main` |
+| `h1` through `h6` | `Heading` |
+| `dialog` | `Dialog` |
+| `ul` / `ol` | `List` |
+| `li` | `ListItem` |
+| `option` | `Option` |
+| `progress` | `Progressbar` |
+
+Accessible name resolution for MVP:
+
+1. `aria-label`;
+2. `aria-labelledby` references;
+3. `label[for=id]` for form controls;
+4. nearest parent `label`;
+5. button/link/heading text content;
+6. input placeholder as a fallback for input-centric queries.
+
+Elements with `hidden` or `aria-hidden="true"` are excluded by default.
+Hidden opt-in can be added later.
+
+`TextMatch` starts with exact string matching. Regex, predicate matching, and
+case-insensitive matching are deferred.
+
+Diagnostics include the failed query, candidate roles/names, and pretty DOM.
+
+## Event Dispatch
+
+Event methods invoke stored `PageEventHandler` values with `DummyEvent`.
+
+For input-like events, the test node stores a current value before dispatching
+the handler. The event object remains `DummyEvent` in the first release; richer
+event payloads can be added when the framework has a cross-target event value
+abstraction.
+
+Event bubbling is out of scope for the first release. The handler attached to
+the target element is called directly. This matches the current `PageElement`
+storage model and keeps the first harness deterministic.
+
+## Error Handling
+
+The API provides both panic-first test ergonomics and `Result`-returning helper
+variants.
+
+| Error | Examples |
+|---|---|
+| `QueryError::NotFound` | no matching role/text/label/placeholder |
+| `QueryError::MultipleMatches` | `get_by_*` found more than one element |
+| `EventError::DetachedElement` | stale handle after rerender removed node |
+| `EventError::MissingHandler` | `click()` on an element without a click handler |
+| `SettleError::DidNotQuiesce` | timeout or max iteration count exceeded |
+| `SettleError::TaskFailed` | scheduler task failed or panicked |
+
+Panic messages should include the structured error plus `screen.pretty()`.
+`Result` variants should carry enough data for framework tests to assert on the
+failure without string matching.
+
+## Testing Strategy
+
+Tests live primarily in `crates/reinhardt-pages`.
+
+Required coverage:
+
+| Area | Coverage |
+|---|---|
+| Render tree | element, text, fragment, keyed fragment, `WithHead` view content |
+| Queries | role/name, label, placeholder, text, hidden exclusion, multiple match error |
+| Events | `click`, `submit`, `input`, `change`, missing handler, detached handle |
+| Reactivity | signal-driven rerender after event |
+| Async hooks | `use_action` success/error and `use_resource` success/error/refetch |
+| Server functions | registered mock, unregistered mock error, call recording |
+| Settling | quiescent case, timeout/non-quiescent diagnostic |
+| Snapshots | stable `screen.pretty()` output |
+| Facade | `reinhardt::test::pages` re-export compiles in a downstream-style test |
+
+Validation commands for the implementation phase should include at least:
+
+```bash
+cargo test -p reinhardt-pages component_testing --all-features
+cargo test -p reinhardt-pages --test ui --all-features
+cargo make fmt-check
+cargo clippy -p reinhardt-pages --all-features --tests -- -D warnings
+```
+
+If public API changes affect semver checks, run the repository's local semver
+check workflow before marking the eventual PR ready.
+
+## Documentation
+
+Update these documentation surfaces with implementation:
+
+- `crates/reinhardt-pages/src/testing.rs`
+- `crates/reinhardt-pages/README.md`
+- `crates/reinhardt-pages/CHANGELOG.md`
+- the `reinhardt` facade docs or README surface that exports
+  `reinhardt::test::pages`
+
+The docs should position this as the native component testing layer. They
+should keep direct `server_fn` invocation as the default for business logic and
+WASM/browser tests as the default for hydration and browser API coverage.
+
+## Performance Acceptance
+
+The harness should make a representative interaction test at least one order
+of magnitude faster than the equivalent WASM/browser path. The first
+implementation should record the measured native command and representative
+duration in the PR notes or a small benchmark note; timing should not become a
+brittle unit-test assertion. The acceptance target is browser-toolchain-free
+execution in the single-digit to low-double-digit millisecond range for a
+small component interaction.
+
+## Implementation Boundaries
+
+The implementation should stay within these boundaries:
+
+- Keep normal native `spawn_task` behavior unchanged outside active component
+  test scopes.
+- Use RAII guards for scheduler and mock registry activation.
+- Avoid introducing broad browser DOM abstractions.
+- Avoid adding new unresolved placeholder markers.
+- Keep query semantics explicit and documented rather than silently accepting
+  unsupported ARIA behavior.
+- Preserve existing WASM MSW behavior and native `MockServiceWorker` behavior.
+
+## Open Design Decisions Closed By This Spec
+
+| Decision | Choice |
+|---|---|
+| MVP scope | Full vertical slice: render, query, event, settle, server_fn mock |
+| API location | `reinhardt_pages::testing::component`, facade as `reinhardt::test::pages` |
+| Async model | async tests using `screen.settle().await` |
+| Server function mocking | in-process registry keyed by `MockableServerFn` metadata |
+| DOM model | `Page` to native `TestNode`, not parsed SSR HTML |
+| Snapshot model | `screen.pretty()` stable text output |

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -515,15 +515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,15 +1120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,12 +1325,6 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1808,18 +1784,6 @@ name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -2338,7 +2302,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2418,15 +2382,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,20 +2420,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -3307,15 +3248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3692,12 +3624,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "oncemutex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
-
-[[package]]
 name = "onig"
 version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,7 +3766,7 @@ checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
 dependencies = [
  "parse-display-derive",
  "regex",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3852,7 +3778,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "regex-syntax 0.8.11",
+ "regex-syntax",
  "structmeta",
  "syn 2.0.118",
 ]
@@ -4072,26 +3998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phonenumber"
-version = "0.3.9+9.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9114f9c1683dd09c5f4fa024c89fdad783eaae21d3d52dd23ddaaffa29ffb168"
-dependencies = [
- "either",
- "fnv",
- "nom 7.1.3",
- "once_cell",
- "postcard",
- "quick-xml 0.38.4",
- "regex",
- "regex-cache",
- "serde",
- "serde_derive",
- "strum",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,19 +4149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
 ]
 
 [[package]]
@@ -4518,15 +4411,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4902,7 +4786,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4913,26 +4797,8 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-cache"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7b62d69743b8b94f353b6b7c3deb4c5582828328bcb8d5fedf214373808793"
-dependencies = [
- "lru-cache",
- "oncemutex",
- "regex",
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4942,7 +4808,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reinhardt-admin"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4992,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-apps"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5021,7 +4887,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5066,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5076,7 +4942,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-commands"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bollard",
@@ -5135,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-conf"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "chrono",
@@ -5162,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5206,7 +5072,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-db"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -5229,7 +5095,6 @@ dependencies = [
  "paste",
  "petgraph",
  "pg_escape",
- "phonenumber",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -5258,7 +5123,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5281,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5291,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-forms"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -5307,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-grpc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5329,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-grpc-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5339,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-http"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5360,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -5373,7 +5238,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-mail"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5393,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-manouche"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -5404,7 +5269,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-middleware"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -5435,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bon",
@@ -5477,7 +5342,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-ast"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -5489,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -5502,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -5515,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5525,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-rest"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5571,11 +5436,11 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-router"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "reinhardt-routers-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5584,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5604,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-shortcuts"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "hyper",
@@ -5621,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-test"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5651,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "astral-tokio-tar",
  "async-dropper",
@@ -5707,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5716,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-throttling"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5726,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-urls"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -5759,7 +5624,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-utils"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5794,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-views"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5827,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-web"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7006,27 +6871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7086,7 +6930,7 @@ dependencies = [
  "once_cell",
  "onig",
  "plist",
- "regex-syntax 0.8.11",
+ "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,3 +10,9 @@
 
 #[cfg(feature = "test")]
 pub use reinhardt_test::*;
+
+/// Pages component testing utilities.
+#[cfg(all(feature = "test", feature = "pages"))]
+pub mod pages {
+	pub use reinhardt_pages::testing::component::*;
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -12,7 +12,7 @@
 pub use reinhardt_test::*;
 
 /// Pages component testing utilities.
-#[cfg(all(feature = "test", feature = "pages"))]
+#[cfg(all(native, feature = "test", feature = "pages"))]
 pub mod pages {
 	pub use reinhardt_pages::testing::component::*;
 }


### PR DESCRIPTION
## Summary

Cherry-picks the native component test harness work from PR #5603 onto `develop/0.4.0` as a standalone branch.

## Validation

- `cargo fmt --check`
- conflict marker scan with `rg -n "^(<<<<<<<( |$)|=======$|>>>>>>>( |$))"`
- `RUSTFLAGS='--cfg native' cargo test -p reinhardt-pages --features testing --test component_testing` (19 passed)

## Source

- Source PR: #5603