### PR TITLE
fix(db): gate contenttypes registry test target

### DIFF
--- a/crates/reinhardt-db/Cargo.toml
+++ b/crates/reinhardt-db/Cargo.toml
@@ -231,6 +231,11 @@ trybuild = "1.0"
 ctor = "0.6.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[[test]]
+name = "contenttypes_registry"
+path = "tests/contenttypes_registry.rs"
+required-features = ["contenttypes"]
+
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 tokio-test = "0.4"
 sqlx = { workspace = true, features = ["runtime-tokio", "postgres"] }


### PR DESCRIPTION
## Summary

This PR addresses:

- Gates the `contenttypes_registry` integration test behind the `contenttypes` feature.
- Keeps default-feature `reinhardt-db` test runs from compiling APIs that are intentionally feature-gated.
- Preserves coverage by running the registry test target when `--features contenttypes` is enabled.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`crates/reinhardt-db/tests/contenttypes_registry.rs` imports `reinhardt_db::contenttypes`, but that module is only compiled when the `contenttypes` feature is enabled. Default-feature test runs therefore failed while compiling the integration test target before reaching unrelated generated-column tests.

Fixes #5617

Related to: #5615

## How Was This Tested?

- [x] `cargo test -p reinhardt-db contenttypes_registry`
- [x] `cargo test -p reinhardt-db --features contenttypes --test contenttypes_registry`
- [x] `cargo test -p reinhardt-query -p reinhardt-db -p reinhardt-macros generated`
- [x] `cargo make fmt-check`

## Performance Impact

Not performance-related.

## Screenshots

Not UI-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5617
- Related to #5615

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The first local reproduction attempt was blocked by an unrelated macOS linker `Interrupted system call` under `/Volumes/cache/cargo-build`; rerunning after the manifest change completed successfully.

🤖 Generated with [Codex](https://openai.com/codex)