### PR TITLE
feat(db)!: unify foreign key id accessors

### DIFF
--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -704,9 +704,11 @@ pub fn injectable(args: TokenStream, input: TokenStream) -> TokenStream {
 /// bidirectional `From` conversions, and a typestate builder. Relationship
 /// fields use lightweight `RelationInfo<T>` and `ManyToManyInfo<Source, Target>`
 /// payloads instead of ORM marker fields or flattened `*_id` fields. FK and
-/// OneToOne builder setters accept `impl IntoPrimaryKey<T>`. Validation
-/// attributes are derived from `#[field(...)]` config. Opt out with
-/// `#[model(info = false)]`. Exclude individual fields with
+/// OneToOne builder setters accept `impl IntoPrimaryKey<T>`, and generated
+/// `*_id()` accessors return the related primary-key value rather than a
+/// reference so shared native/WASM model code can call the same method.
+/// Validation attributes are derived from `#[field(...)]` config. Opt out
+/// with `#[model(info = false)]`. Exclude individual fields with
 /// `#[field(skip_info = true)]`.
 ///
 /// # Model Attributes

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -1599,7 +1599,7 @@ fn generate_fk_accessor_methods(
 				) -> #core_crate::exception::Result<Option<#target_ty>> {
 					use #orm_crate::Model;
 
-					// Get FK _id value (getter returns &PrimaryKey)
+					// Get FK _id value.
 					let fk_id = self.#fk_id_field_name();
 
 					// Query the target model using the FK _id via the typed
@@ -1735,8 +1735,15 @@ fn is_copy_type(ty: &Type) -> bool {
 	)
 }
 
-/// Generate getter methods for all fields
-fn generate_getter_methods(struct_name: &syn::Ident, field_infos: &[FieldInfo]) -> TokenStream {
+/// Generate getter methods for selected fields.
+fn generate_getter_methods<F>(
+	struct_name: &syn::Ident,
+	field_infos: &[FieldInfo],
+	include_field: F,
+) -> TokenStream
+where
+	F: Fn(&FieldInfo) -> bool,
+{
 	let getter_methods: Vec<_> = field_infos
 		.iter()
 		// Exclude ForeignKey, OneToOne, and skip_getter fields
@@ -1744,14 +1751,23 @@ fn generate_getter_methods(struct_name: &syn::Ident, field_infos: &[FieldInfo]) 
 			!is_foreign_key_field_type(&field.ty)
 				&& !is_one_to_one_field_type(&field.ty)
 				&& !field.config.skip_getter
+				&& include_field(field)
 		})
 		.map(|field| {
 			let field_name = &field.name;
 			let field_type = &field.ty;
 			let method_name = field_name;
 
-			// Copy types return value, others return reference
-			if is_copy_type(field_type) {
+			// FK id fields use target-model primary-key projections. Return
+			// them by value so native and WASM callers share the same API.
+			if field.is_fk_id_field {
+				quote! {
+					#[doc = concat!("Get ", stringify!(#field_name))]
+					pub fn #method_name(&self) -> #field_type {
+						self.#field_name.clone()
+					}
+				}
+			} else if is_copy_type(field_type) {
 				quote! {
 					#[doc = concat!("Get ", stringify!(#field_name))]
 					pub fn #method_name(&self) -> #field_type {
@@ -2217,7 +2233,10 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 	let build_fn_impl = generate_build_function(struct_name, &field_infos, &fk_id_field_names);
 
 	// Generate getter/setter methods
-	let getters = generate_getter_methods(struct_name, &field_infos);
+	let shared_fk_id_getters =
+		generate_getter_methods(struct_name, &field_infos, |field| field.is_fk_id_field);
+	let native_getters =
+		generate_getter_methods(struct_name, &field_infos, |field| !field.is_fk_id_field);
 	let setters = generate_setter_methods(struct_name, &field_infos);
 
 	// Generate static FK accessor methods for type-safe reverse relationship access
@@ -2288,9 +2307,12 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 			// Generate typestate build() builder (see #4400)
 			#build_fn_impl
 
-			// Generate getter methods for all fields
+			// Generate FK id getter methods for shared native/WASM code.
+			#shared_fk_id_getters
+
+			// Generate getter methods for native-only ORM model fields.
 			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-			#getters
+			#native_getters
 
 			// Generate setter methods for user-defined fields
 			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]

--- a/crates/reinhardt-core/macros/tests/fixtures/model_wasm_parity/src/lib.rs
+++ b/crates/reinhardt-core/macros/tests/fixtures/model_wasm_parity/src/lib.rs
@@ -1,0 +1,35 @@
+#![deny(unexpected_cfgs)]
+
+use reinhardt::model;
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "projects", table_name = "projects", info = false)]
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct Project {
+	#[field(primary_key = true)]
+	pub id: i64,
+
+	#[field(max_length = 120)]
+	pub name: String,
+}
+
+#[model(app_label = "jobs", table_name = "jobs", info = false)]
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct Job {
+	#[field(primary_key = true)]
+	pub id: i64,
+
+	#[rel(foreign_key)]
+	pub project: reinhardt::db::associations::ForeignKeyField<Project>,
+
+	#[field(max_length = 120)]
+	pub job_type: String,
+}
+
+pub fn retry_preserves_project(job: &Job, retry: &Job) -> bool {
+	job.project_id() == retry.project_id()
+}
+
+pub fn accepts_foreign_key_id(job: &Job) -> i64 {
+	job.project_id()
+}

--- a/crates/reinhardt-core/macros/tests/model_wasm_parity.rs
+++ b/crates/reinhardt-core/macros/tests/model_wasm_parity.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn model_foreign_key_id_accessor_compiles_on_wasm() {
+	let crate_dir = tempfile::tempdir().expect("create temporary fixture directory");
+	let target_dir = tempfile::tempdir().expect("create temporary target directory");
+	let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+	let repo_root = manifest_dir
+		.join("../../..")
+		.canonicalize()
+		.expect("resolve repository root");
+	let fixture_dir = manifest_dir.join("tests/fixtures/model_wasm_parity");
+
+	fs::create_dir(crate_dir.path().join("src")).expect("create fixture src directory");
+	fs::write(
+		crate_dir.path().join("Cargo.toml"),
+		format!(
+			r#"[package]
+name = "reinhardt-model-wasm-parity-fixture"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[dependencies]
+reinhardt = {{ path = "{}", package = "reinhardt-web", default-features = false }}
+serde = {{ version = "1.0", features = ["derive"] }}
+"#,
+			repo_root.display()
+		),
+	)
+	.expect("write fixture manifest");
+	fs::write(
+		crate_dir.path().join("build.rs"),
+		r#"fn main() {
+	println!("cargo::rustc-check-cfg=cfg(native)");
+}
+"#,
+	)
+	.expect("write fixture build script");
+	fs::copy(
+		fixture_dir.join("src/lib.rs"),
+		crate_dir.path().join("src/lib.rs"),
+	)
+	.expect("copy fixture source");
+
+	let output = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+		.arg("check")
+		.arg("--manifest-path")
+		.arg(crate_dir.path().join("Cargo.toml"))
+		.arg("--target")
+		.arg("wasm32-unknown-unknown")
+		.arg("--target-dir")
+		.arg(target_dir.path())
+		.arg("--offline")
+		.output()
+		.expect("run wasm model macro parity fixture");
+
+	assert!(
+		output.status.success(),
+		"WASM model macro parity fixture should compile\nstdout:\n{}\nstderr:\n{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr),
+	);
+}

--- a/crates/reinhardt-core/macros/tests/ui/model/pass/foreign_key_id_accessor.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/pass/foreign_key_id_accessor.rs
@@ -1,0 +1,40 @@
+use reinhardt_macros::model;
+use serde::{Deserialize, Serialize};
+
+include!("../support.rs");
+
+#[model(table_name = "projects")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Project {
+	#[field(primary_key = true)]
+	id: i64,
+	#[field(max_length = 120)]
+	name: String,
+}
+
+#[model(table_name = "jobs")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Job {
+	#[field(primary_key = true)]
+	id: i64,
+	#[rel(foreign_key)]
+	project: db::associations::ForeignKeyField<Project>,
+	#[field(max_length = 120)]
+	job_type: String,
+}
+
+impl Job {
+	fn retry_preserves_input(&self, retry: &Self) -> bool {
+		self.project_id() == retry.project_id() && self.job_type == retry.job_type
+	}
+}
+
+fn assert_i64(_: i64) {}
+
+fn main() {
+	let job = Job::build().project(7_i64).job_type("draft").finish();
+	let retry = Job::build().project(7_i64).job_type("draft").finish();
+
+	assert_i64(job.project_id());
+	assert!(job.retry_preserves_input(&retry));
+}

--- a/examples/examples-tutorial-basis/src/apps/polls/server_fn.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/server_fn.rs
@@ -211,7 +211,7 @@ pub async fn update_question(
 		.map_err(|e| ServerFnError::application(format!("Database error: {}", e)))?
 		.ok_or_else(|| ServerFnError::server(404, "Question not found"))?;
 
-	if *question.author_id() != user.id() {
+	if question.author_id() != user.id() {
 		return Err(ServerFnError::server(
 			403,
 			"Only the question's author can edit it",
@@ -245,7 +245,7 @@ pub async fn delete_question(
 		.map_err(|e| ServerFnError::application(format!("Database error: {}", e)))?
 		.ok_or_else(|| ServerFnError::server(404, "Question not found"))?;
 
-	if *question.author_id() != user.id() {
+	if question.author_id() != user.id() {
 		return Err(ServerFnError::server(
 			403,
 			"Only the question's author can delete it",
@@ -288,7 +288,7 @@ async fn require_question_author(question_id: i64, user: &User) -> Result<Questi
 		.map_err(|e| ServerFnError::application(format!("Database error: {}", e)))?
 		.ok_or_else(|| ServerFnError::server(404, "Question not found"))?;
 
-	if *question.author_id() != user.id() {
+	if question.author_id() != user.id() {
 		return Err(ServerFnError::server(
 			403,
 			"Only the question's author can manage its choices",
@@ -357,7 +357,7 @@ pub async fn update_choice(
 		.map_err(|e| ServerFnError::application(format!("Database error: {}", e)))?
 		.ok_or_else(|| ServerFnError::server(404, "Choice not found"))?;
 
-	let _question = require_question_author(*choice.question_id(), &user).await?;
+	let _question = require_question_author(choice.question_id(), &user).await?;
 
 	choice.choice_text = trimmed.to_string();
 	let updated = manager
@@ -384,7 +384,7 @@ pub async fn delete_choice(
 		.map_err(|e| ServerFnError::application(format!("Database error: {}", e)))?
 		.ok_or_else(|| ServerFnError::server(404, "Choice not found"))?;
 
-	let _question = require_question_author(*choice.question_id(), &user).await?;
+	let _question = require_question_author(choice.question_id(), &user).await?;
 
 	manager
 		.delete(choice.id())

--- a/examples/examples-tutorial-basis/src/apps/polls/services/server.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/services/server.rs
@@ -50,7 +50,7 @@ pub async fn vote_internal(
 			.map_err(|e| anyhow::anyhow!(e.to_string()))?
 			.ok_or_else(|| anyhow::Error::new(VoteRequestError::ChoiceNotFound))?;
 
-		if *choice.question_id() != request.question_id {
+		if choice.question_id() != request.question_id {
 			return Err(anyhow::Error::new(VoteRequestError::ChoiceQuestionMismatch));
 		}
 

--- a/instructions/MACRO_USAGE.md
+++ b/instructions/MACRO_USAGE.md
@@ -184,6 +184,7 @@ struct Post {
 - `ForeignKeyField<T>` and `OneToOneField<T>`: included as `RelationInfo<T>`
 - `ManyToManyField<Source, Target>`: included as `ManyToManyInfo<Source, Target>`
 - FK `_id` fields (auto-generated): not exposed directly; use `info.author.id`
+- Generated FK/OneToOne `*_id()` accessors return the related primary-key value, so shared native/WASM model code can use the same method call.
 - Relationship marker types are not exposed directly because they do not carry values
 - `#[field(skip = true)]` or `#[field(skip_info = true)]` fields: excluded
 

--- a/tests/integration/tests/macros/model_info_integration.rs
+++ b/tests/integration/tests/macros/model_info_integration.rs
@@ -341,7 +341,7 @@ fn test_info_one_to_one_relation_field_generated() {
 	// Assert
 	assert_eq!(info.id, Some(1));
 	assert_eq!(info.user.id, 9);
-	assert_eq!(*model.user_id(), 9);
+	assert_eq!(model.user_id(), 9);
 }
 
 #[test]
@@ -407,5 +407,5 @@ fn test_info_skip_relation_fields() {
 
 	// Assert
 	assert_eq!(*model.id(), Some(1));
-	assert_eq!(*model.author_id(), 0);
+	assert_eq!(model.author_id(), 0);
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Unifies generated FK/OneToOne `*_id()` accessor shape across native and `wasm32-unknown-unknown` targets.
- Changes generated FK id getters to return the related primary-key value by value instead of a native-only reference.
- Updates examples, docs, and focused tests to use the shared method-call API.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [ ] **No** - This change is backward compatible
- [x] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Generated FK id accessors previously differed between native and WASM model code: native callers used a getter returning a reference, while WASM shared code exposed the id as a field. This PR makes the generated accessor available to shared native/WASM code and returns the related primary key by value so shared retry/equality code can use one API shape.

Fixes #5597

Related to: #

## How Was This Tested?

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p reinhardt-macros --test model_wasm_parity`
- `cargo test -p reinhardt-macros --test ui test_model_macro_parity_pass`
- `cargo test -p reinhardt-integration-tests --test macros model_info`

Existing warnings observed during focused tests:

- `unexpected cfg` warnings from existing trybuild model fixtures using `cfg(native)`.
- `unused import` / `unreachable_pub` warnings in `tests/integration/tests/macros/repro_issue_3651.rs`.

## Breaking Changes

Generated FK and OneToOne `*_id()` accessors now return the related primary-key value on native targets instead of a reference. Native code that dereferenced these accessors must remove the dereference.

**Migration Guide:**

```rust
// Before
if *choice.question_id() != request.question_id {
    // ...
}

// After
if choice.question_id() != request.question_id {
    // ...
}
```

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage (AWS Spot instances),
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5597

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [x] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- Full workspace check/clippy were not run locally for this narrow macro/API change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relation ID accessors now return the related primary-key value directly, making them consistent across native and WebAssembly builds.
  * Generated relation setters now accept primary-key-like values in a more flexible way.

* **Bug Fixes**
  * Fixed model-generated accessors so shared code works without extra dereferencing.
  * Updated example authorization and validation checks to use the new accessor behavior.

* **Tests**
  * Added coverage for WebAssembly model compilation and relation ID accessor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->