### PR TITLE
feat(pages): accept unit-returning effects

### DIFF
--- a/crates/reinhardt-pages/docs/react_to_reinhardt.md
+++ b/crates/reinhardt-pages/docs/react_to_reinhardt.md
@@ -13,7 +13,7 @@ application.
 | Function component | Rust function returning `Page` | Props are normal typed Rust arguments or structs. |
 | Fragment | Multiple top-level `page!` nodes or `Page::fragment` | The output is a `Page::Fragment`, not a virtual DOM fragment. |
 | `useState` | `use_state` returning `(Signal<T>, SetState<T>)` | Reads use `signal.get()`, writes use `set(value)` or `signal.update(...)`. |
-| `useEffect` | `use_effect(f, deps)` | Dependencies are explicit Rust tuples, for example `(count.clone(),)`. |
+| `useEffect` | `use_effect(f, deps)` | Return `()` for no cleanup or `Option<C>` for cleanup; dependencies are explicit Rust tuples, for example `(count.clone(),)`. |
 | `useLayoutEffect` | `use_layout_effect(f, deps)` | Same dependency model, layout timing. |
 | `useMemo` | `use_memo(f, deps)` | Returns `Memo<T>`; read it with `.get()`. |
 | `useCallback` | `use_callback(f, deps)` / `use_callback_with(f, deps)` | Returns a typed `Callback`, usually for event handlers. |
@@ -227,7 +227,6 @@ use_effect(
         let count = count.clone();
         move || {
             log::info!("count = {}", count.get());
-            None::<fn()>
         }
     },
     (count.clone(),),

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -21,7 +21,8 @@
 //!
 //! `use_effect`, `use_layout_effect`, `use_memo`, `use_callback`, and
 //! `use_callback_with` take an explicit dependency tuple as the second
-//! argument:
+//! argument. Effect closures return `()` when no cleanup is needed, or
+//! `Option<C>` when they register cleanup:
 //!
 //! ```ignore
 //! use reinhardt_pages::prelude::*;
@@ -31,7 +32,6 @@
 //! let _eff = use_effect(
 //!     move || {
 //!         println!("count = {}", count_for_effect.get());
-//!         None::<fn()>
 //!     },
 //!     (count.clone(),),
 //! );
@@ -217,7 +217,7 @@
 //! The `use_websocket` hook provides reactive WebSocket connections:
 //!
 //! ```ignore
-//! use reinhardt_pages::reactive::hooks::{use_websocket, use_effect, UseWebSocketOptions};
+//! use reinhardt_pages::reactive::hooks::{use_effect, use_websocket, UseWebSocketOptions};
 //! use reinhardt_pages::reactive::hooks::{ConnectionState, WebSocketMessage};
 //!
 //! fn chat_component() -> Page {
@@ -225,34 +225,34 @@
 //!     let ws = use_websocket("ws://localhost:8000/ws/chat", UseWebSocketOptions::default());
 //!
 //!     // Monitor connection state reactively
+//!     let connection_state = ws.connection_state().clone();
 //!     use_effect(
 //!         {
-//!             let ws = ws.clone();
+//!             let connection_state = connection_state.clone();
 //!             move || {
-//!                 match ws.connection_state().get() {
+//!                 match connection_state.get() {
 //!                     ConnectionState::Open => log!("Connected to chat"),
 //!                     ConnectionState::Closed => log!("Disconnected from chat"),
 //!                     ConnectionState::Error(e) => log!("Connection error: {}", e),
 //!                     _ => {}
 //!                 }
-//!                 None::<fn()>
 //!             }
 //!         },
-//!         (),
+//!         (connection_state,),
 //!     );
 //!
 //!     // Handle incoming messages
+//!     let latest_message = ws.latest_message().clone();
 //!     use_effect(
 //!         {
-//!             let ws = ws.clone();
+//!             let latest_message = latest_message.clone();
 //!             move || {
-//!                 if let Some(WebSocketMessage::Text(text)) = ws.latest_message().get() {
+//!                 if let Some(WebSocketMessage::Text(text)) = latest_message.get() {
 //!                     log!("Received: {}", text);
 //!                 }
-//!                 None::<fn()>
 //!             }
 //!         },
-//!         (),
+//!         (latest_message,),
 //!     );
 //!
 //!     page!(|| {
@@ -411,10 +411,10 @@ pub use reactive::{
 pub use app::{ClientLauncher, LaunchCtx, PathCtx, PathParams};
 pub use reactive::{Action, ActionPhase, ActionStateBuilder, use_action, use_action_state};
 pub use reactive::{
-	Dispatch, OptimisticState, Ref, SetState, SharedSetState, SharedSignal, TransitionState,
-	use_callback, use_context, use_debug_value, use_deferred_value, use_effect, use_id,
-	use_layout_effect, use_memo, use_optimistic, use_reducer, use_ref, use_shared_state, use_state,
-	use_sync_external_store, use_transition,
+	Dispatch, EffectReturn, OptimisticState, Ref, SetState, SharedSetState, SharedSignal,
+	TransitionState, use_callback, use_context, use_debug_value, use_deferred_value, use_effect,
+	use_id, use_layout_effect, use_memo, use_optimistic, use_reducer, use_ref, use_shared_state,
+	use_state, use_sync_external_store, use_transition,
 };
 #[cfg(native)]
 pub use reinhardt_forms::{

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -91,10 +91,10 @@ pub use crate::reactive::{
 // Hooks API
 pub use crate::reactive::{Action, ActionPhase, ActionStateBuilder, use_action, use_action_state};
 pub use crate::reactive::{
-	Dispatch, OptimisticState, Ref, SetState, SharedSetState, SharedSignal, TransitionState,
-	use_callback, use_context, use_debug_value, use_deferred_value, use_effect, use_id,
-	use_layout_effect, use_memo, use_optimistic, use_reducer, use_ref, use_shared_state, use_state,
-	use_sync_external_store, use_transition,
+	Dispatch, EffectReturn, OptimisticState, Ref, SetState, SharedSetState, SharedSignal,
+	TransitionState, use_callback, use_context, use_debug_value, use_deferred_value, use_effect,
+	use_id, use_layout_effect, use_memo, use_optimistic, use_reducer, use_ref, use_shared_state,
+	use_state, use_sync_external_store, use_transition,
 };
 
 // Unified resource hooks (available on all targets)

--- a/crates/reinhardt-pages/src/reactive.rs
+++ b/crates/reinhardt-pages/src/reactive.rs
@@ -53,7 +53,8 @@
 //!
 //! ## Layout Effects
 //!
-//! For DOM measurements and synchronous updates before paint, use `use_layout_effect`:
+//! For DOM measurements and synchronous updates before paint, use
+//! `use_layout_effect`:
 //!
 //! ```ignore
 //! use reinhardt_pages::reactive::{Signal, hooks::{use_layout_effect, use_ref}};
@@ -70,7 +71,7 @@
 //!             width.set(el.offset_width());
 //!         }
 //!     }
-//! });
+//! }, (element_ref,));
 //! ```
 //!
 //! **When to use `use_layout_effect`**:
@@ -115,9 +116,9 @@ pub use resource_value::{
 
 // Re-export hooks
 pub use hooks::{
-	Action, ActionPhase, ActionStateBuilder, Dispatch, OptimisticState, Ref, SetState,
-	SharedSetState, SharedSignal, TransitionState, use_action, use_action_state, use_callback,
-	use_context, use_debug_value, use_deferred_value, use_effect, use_id, use_layout_effect,
-	use_memo, use_optimistic, use_reducer, use_ref, use_shared_state, use_state,
+	Action, ActionPhase, ActionStateBuilder, Dispatch, EffectReturn, OptimisticState, Ref,
+	SetState, SharedSetState, SharedSignal, TransitionState, use_action, use_action_state,
+	use_callback, use_context, use_debug_value, use_deferred_value, use_effect, use_id,
+	use_layout_effect, use_memo, use_optimistic, use_reducer, use_ref, use_shared_state, use_state,
 	use_sync_external_store, use_transition,
 };

--- a/crates/reinhardt-pages/src/reactive/hooks.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks.rs
@@ -73,9 +73,8 @@
 //!         let count = count.clone();
 //!         move || {
 //!             log!("Count changed to: {}", count.get());
-//!             None::<fn()>
 //!         }
-//!     });
+//!     }, (count.clone(),));
 //!
 //!     page!(|| {
 //!         div {
@@ -111,7 +110,7 @@ pub use action::{OptimisticState, use_optimistic};
 pub use async_action::{Action, ActionPhase, ActionStateBuilder, use_action, use_action_state};
 pub use context::use_context;
 pub use debug::use_debug_value;
-pub use effect::{use_effect, use_layout_effect};
+pub use effect::{EffectReturn, use_effect, use_layout_effect};
 pub use id::use_id;
 pub use memo::{use_callback, use_callback_with, use_memo};
 pub use refs::{Ref, use_ref};

--- a/crates/reinhardt-pages/src/reactive/hooks/effect.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/effect.rs
@@ -15,30 +15,53 @@ use crate::reactive::{Effect, runtime::EffectTiming};
 /// `()` means the effect has no cleanup. `Option<C>` preserves the existing
 /// cleanup-capable form, where `Some(cleanup)` runs before the next re-run and
 /// on dispose.
-pub trait EffectReturn {
-	/// Cleanup function type produced by the effect.
-	type Cleanup: FnOnce() + 'static;
-
+pub trait EffectReturn<C>
+where
+	C: FnOnce() + 'static,
+{
 	/// Converts the closure return value into an optional cleanup function.
-	fn into_cleanup(self) -> Option<Self::Cleanup>;
+	fn into_cleanup(self) -> Option<C>;
 }
 
-impl EffectReturn for () {
-	type Cleanup = fn();
-
-	fn into_cleanup(self) -> Option<Self::Cleanup> {
+impl EffectReturn<fn()> for () {
+	fn into_cleanup(self) -> Option<fn()> {
 		None
 	}
 }
 
-impl<C> EffectReturn for Option<C>
+impl<C> EffectReturn<C> for Option<C>
 where
 	C: FnOnce() + 'static,
 {
-	type Cleanup = C;
-
-	fn into_cleanup(self) -> Option<Self::Cleanup> {
+	fn into_cleanup(self) -> Option<C> {
 		self
+	}
+}
+
+/// Internal adapter from effect closures to accepted effect return values.
+///
+/// This keeps the public cleanup type as the second generic parameter while
+/// still allowing closures to return either `()` or `Option<C>`.
+#[doc(hidden)]
+pub trait EffectCallback<C>
+where
+	C: FnOnce() + 'static,
+{
+	type Return: EffectReturn<C>;
+
+	fn call_effect(&mut self) -> Self::Return;
+}
+
+impl<F, R, C> EffectCallback<C> for F
+where
+	F: FnMut() -> R,
+	R: EffectReturn<C>,
+	C: FnOnce() + 'static,
+{
+	type Return = R;
+
+	fn call_effect(&mut self) -> Self::Return {
+		self()
 	}
 }
 
@@ -58,7 +81,7 @@ where
 /// # Type Parameters
 ///
 /// * `F` - The effect function type.
-/// * `R` - The effect return type (`()` or `Option<C>`).
+/// * `C` - The cleanup function type.
 /// * `D` - Any tuple of [`Trackable`]s (or `()`) that implements
 ///   [`IntoDeps`].
 ///
@@ -99,13 +122,14 @@ where
 ///
 /// [`Trackable`]: reinhardt_core::reactive::deps::Trackable
 /// [`IntoDeps`]: reinhardt_core::reactive::deps::IntoDeps
-pub fn use_effect<F, R, D>(mut f: F, deps: D) -> Effect
+pub fn use_effect<F, C, D>(f: F, deps: D) -> Effect
 where
-	F: FnMut() -> R + 'static,
-	R: EffectReturn,
+	F: EffectCallback<C> + 'static,
+	C: FnOnce() + 'static,
 	D: IntoDeps,
 {
-	Effect::new_with_deps(move || f().into_cleanup(), deps.into_deps())
+	let mut f = f;
+	Effect::new_with_deps(move || f.call_effect().into_cleanup(), deps.into_deps())
 }
 
 /// Runs a side effect synchronously before browser paint when any listed
@@ -152,14 +176,15 @@ where
 ///     (element_ref,),
 /// );
 /// ```
-pub fn use_layout_effect<F, R, D>(mut f: F, deps: D) -> Effect
+pub fn use_layout_effect<F, C, D>(f: F, deps: D) -> Effect
 where
-	F: FnMut() -> R + 'static,
-	R: EffectReturn,
+	F: EffectCallback<C> + 'static,
+	C: FnOnce() + 'static,
 	D: IntoDeps,
 {
+	let mut f = f;
 	Effect::new_with_deps_and_timing(
-		move || f().into_cleanup(),
+		move || f.call_effect().into_cleanup(),
 		deps.into_deps(),
 		EffectTiming::Layout,
 	)

--- a/crates/reinhardt-pages/src/reactive/hooks/effect.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/effect.rs
@@ -3,10 +3,44 @@
 //! React-aligned side effect hooks. Both take an explicit dependency tuple
 //! as the second argument; the closure runs with no active reactive Observer
 //! so only the listed deps subscribe (Option A semantics, Refs #4195).
+//! Effect closures can return either `()` for no cleanup or `Option<C>` when
+//! they need to register teardown.
 
 use reinhardt_core::reactive::deps::IntoDeps;
 
 use crate::reactive::{Effect, runtime::EffectTiming};
+
+/// Return value accepted from effect closures.
+///
+/// `()` means the effect has no cleanup. `Option<C>` preserves the existing
+/// cleanup-capable form, where `Some(cleanup)` runs before the next re-run and
+/// on dispose.
+pub trait EffectReturn {
+	/// Cleanup function type produced by the effect.
+	type Cleanup: FnOnce() + 'static;
+
+	/// Converts the closure return value into an optional cleanup function.
+	fn into_cleanup(self) -> Option<Self::Cleanup>;
+}
+
+impl EffectReturn for () {
+	type Cleanup = fn();
+
+	fn into_cleanup(self) -> Option<Self::Cleanup> {
+		None
+	}
+}
+
+impl<C> EffectReturn for Option<C>
+where
+	C: FnOnce() + 'static,
+{
+	type Cleanup = C;
+
+	fn into_cleanup(self) -> Option<Self::Cleanup> {
+		self
+	}
+}
 
 /// Runs a side effect when one of the listed `deps` changes.
 ///
@@ -23,8 +57,8 @@ use crate::reactive::{Effect, runtime::EffectTiming};
 ///
 /// # Type Parameters
 ///
-/// * `F` - The effect function type (returns `Option<C>`).
-/// * `C` - The optional cleanup function type.
+/// * `F` - The effect function type.
+/// * `R` - The effect return type (`()` or `Option<C>`).
 /// * `D` - Any tuple of [`Trackable`]s (or `()`) that implements
 ///   [`IntoDeps`].
 ///
@@ -38,7 +72,7 @@ use crate::reactive::{Effect, runtime::EffectTiming};
 /// # Example
 ///
 /// ```ignore
-/// use reinhardt_pages::reactive::hooks::{use_state, use_effect};
+/// use reinhardt_pages::reactive::hooks::{use_effect, use_state};
 ///
 /// let (count, _set_count) = use_state(0);
 ///
@@ -48,7 +82,6 @@ use crate::reactive::{Effect, runtime::EffectTiming};
 ///         let count = count.clone();
 ///         move || {
 ///             log!("Count is now: {}", count.get());
-///             None::<fn()>
 ///         }
 ///     },
 ///     (count.clone(),),
@@ -66,13 +99,13 @@ use crate::reactive::{Effect, runtime::EffectTiming};
 ///
 /// [`Trackable`]: reinhardt_core::reactive::deps::Trackable
 /// [`IntoDeps`]: reinhardt_core::reactive::deps::IntoDeps
-pub fn use_effect<F, C, D>(f: F, deps: D) -> Effect
+pub fn use_effect<F, R, D>(mut f: F, deps: D) -> Effect
 where
-	F: FnMut() -> Option<C> + 'static,
-	C: FnOnce() + 'static,
+	F: FnMut() -> R + 'static,
+	R: EffectReturn,
 	D: IntoDeps,
 {
-	Effect::new_with_deps(f, deps.into_deps())
+	Effect::new_with_deps(move || f().into_cleanup(), deps.into_deps())
 }
 
 /// Runs a side effect synchronously before browser paint when any listed
@@ -101,7 +134,7 @@ where
 /// # Example
 ///
 /// ```ignore
-/// use reinhardt_pages::reactive::hooks::{use_ref, use_state, use_layout_effect};
+/// use reinhardt_pages::reactive::hooks::{use_layout_effect, use_ref, use_state};
 ///
 /// let element_ref = use_ref(None::<Element>);
 /// let (_width, set_width) = use_state(0);
@@ -114,25 +147,29 @@ where
 ///             if let Some(el) = element_ref.current().as_ref() {
 ///                 set_width(el.offset_width());
 ///             }
-///             None::<fn()>
 ///         }
 ///     },
 ///     (element_ref,),
 /// );
 /// ```
-pub fn use_layout_effect<F, C, D>(f: F, deps: D) -> Effect
+pub fn use_layout_effect<F, R, D>(mut f: F, deps: D) -> Effect
 where
-	F: FnMut() -> Option<C> + 'static,
-	C: FnOnce() + 'static,
+	F: FnMut() -> R + 'static,
+	R: EffectReturn,
 	D: IntoDeps,
 {
-	Effect::new_with_deps_and_timing(f, deps.into_deps(), EffectTiming::Layout)
+	Effect::new_with_deps_and_timing(
+		move || f().into_cleanup(),
+		deps.into_deps(),
+		EffectTiming::Layout,
+	)
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::reactive::Signal;
+	use rstest::rstest;
 	use serial_test::serial;
 	use std::cell::RefCell;
 	use std::rc::Rc;
@@ -177,6 +214,24 @@ mod tests {
 
 		// Initial run
 		assert_eq!(*effect_count.borrow(), 1);
+	}
+
+	#[rstest]
+	#[serial(hooks_effect)]
+	fn test_use_effect_accepts_unit_return() {
+		let called = Rc::new(RefCell::new(false));
+
+		let _effect = use_effect(
+			{
+				let called = Rc::clone(&called);
+				move || {
+					*called.borrow_mut() = true;
+				}
+			},
+			(),
+		);
+
+		assert!(*called.borrow());
 	}
 
 	#[test]
@@ -225,6 +280,31 @@ mod tests {
 		execution_order.borrow_mut().push(100);
 
 		// Layout effect ran synchronously before the push(100)
+		assert_eq!(*execution_order.borrow(), vec![0, 1, 100]);
+	}
+
+	#[rstest]
+	#[serial(hooks_effect)]
+	fn test_use_layout_effect_accepts_unit_return_and_tracks_synchronously() {
+		let signal = Signal::new(0);
+		let execution_order = Rc::new(RefCell::new(Vec::new()));
+
+		let _effect = use_layout_effect(
+			{
+				let signal = signal.clone();
+				let execution_order = Rc::clone(&execution_order);
+				move || {
+					execution_order.borrow_mut().push(signal.get());
+				}
+			},
+			(signal.clone(),),
+		);
+
+		assert_eq!(*execution_order.borrow(), vec![0]);
+
+		signal.set(1);
+		execution_order.borrow_mut().push(100);
+
 		assert_eq!(*execution_order.borrow(), vec![0, 1, 100]);
 	}
 

--- a/crates/reinhardt-pages/src/reactive/hooks/refs.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/refs.rs
@@ -14,15 +14,14 @@ use std::rc::Rc;
 /// ## Example
 ///
 /// ```ignore
-/// use reinhardt_pages::reactive::hooks::{use_ref, use_effect};
+/// use reinhardt_pages::reactive::hooks::{use_effect, use_ref};
 ///
 /// let render_count = use_ref(0);
 ///
 /// use_effect(move || {
 ///     // Increment without triggering reactivity
 ///     *render_count.current_mut() += 1;
-///     None::<fn()>
-/// });
+/// }, ());
 /// ```
 pub struct Ref<T: 'static> {
 	inner: Rc<RefCell<T>>,

--- a/crates/reinhardt-pages/src/reactive/hooks/router.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/router.rs
@@ -147,7 +147,7 @@ impl RouterHandle {
 ///             let _ = router.push("/welcome");
 ///         }
 ///     }
-/// });
+/// }, (should_redirect.clone(),));
 /// ```
 pub fn use_router() -> RouterHandle {
 	RouterHandle

--- a/crates/reinhardt-pages/src/reactive/hooks/websocket.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/websocket.rs
@@ -187,40 +187,40 @@ use {
 /// # Example
 ///
 /// ```ignore
-/// use reinhardt_pages::reactive::hooks::{use_websocket, UseWebSocketOptions, use_effect};
+/// use reinhardt_pages::reactive::hooks::{use_effect, use_websocket, UseWebSocketOptions};
 /// use reinhardt_pages::reactive::hooks::ConnectionState;
 ///
 /// let ws = use_websocket("ws://localhost:8000/ws/chat", UseWebSocketOptions::default());
 ///
 /// // Monitor connection state
+/// let connection_state = ws.connection_state().clone();
 /// use_effect({
-///     let ws = ws.clone();
+///     let connection_state = connection_state.clone();
 ///     move || {
-///         match ws.connection_state().get() {
+///         match connection_state.get() {
 ///             ConnectionState::Open => log!("Connected"),
 ///             ConnectionState::Closed => log!("Disconnected"),
 ///             _ => {}
 ///         }
-///         None::<fn()>
 ///     }
-/// });
+/// }, (connection_state,));
 ///
 /// // Send a message
 /// ws.send_text("Hello, server!".to_string()).ok();
 ///
 /// // Receive messages
+/// let latest_message = ws.latest_message().clone();
 /// use_effect({
-///     let ws = ws.clone();
+///     let latest_message = latest_message.clone();
 ///     move || {
-///         if let Some(msg) = ws.latest_message().get() {
+///         if let Some(msg) = latest_message.get() {
 ///             match msg {
 ///                 WebSocketMessage::Text(text) => log!("Received: {}", text),
 ///                 _ => {}
 ///             }
 ///         }
-///         None::<fn()>
 ///     }
-/// });
+/// }, (latest_message,));
 /// ```
 ///
 /// # Reactivity semantics

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -336,7 +336,16 @@ impl TestDom {
 				self.append_page(anchor, render());
 			}
 			Page::Suspense(node) => {
-				self.append_page(parent, node.render_branch());
+				let render: Rc<dyn Fn() -> Page + 'static> = Rc::new(move || node.render_branch());
+				let anchor = self.push_node(
+					parent,
+					TestNode::ReactiveAnchor {
+						children: Vec::new(),
+						parent: Some(parent),
+						render: Rc::clone(&render),
+					},
+				);
+				self.append_page(anchor, render());
 			}
 			Page::Deferred(node) => {
 				self.append_page(parent, node.content());

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -335,6 +335,12 @@ impl TestDom {
 				);
 				self.append_page(anchor, render());
 			}
+			Page::Suspense(node) => {
+				self.append_page(parent, node.render_branch());
+			}
+			Page::Deferred(node) => {
+				self.append_page(parent, node.content());
+			}
 		}
 	}
 

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -4,7 +4,9 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::time::Duration;
 
-use reinhardt_core::types::page::{EventType, IntoPage, Outlet, Page, PageElement};
+use reinhardt_core::types::page::{
+	DeferredNode, EventType, IntoPage, Outlet, Page, PageElement, SuspenseNode,
+};
 use reinhardt_pages::callback::async_handler;
 use reinhardt_pages::page;
 use reinhardt_pages::prelude::spawn_task;
@@ -164,6 +166,35 @@ fn outlet_pages_render_inline_children_and_placeholders() {
 	let pretty = placeholder.pretty();
 	assert!(pretty.contains("<reinhardt-outlet"));
 	assert!(pretty.contains("data-rh-outlet-id=\"main\""));
+}
+
+#[test]
+fn suspense_pages_render_active_branch() {
+	let pending = Rc::new(Cell::new(true));
+	let screen = {
+		let pending = Rc::clone(&pending);
+		render(Page::Suspense(SuspenseNode::new(
+			None,
+			move || pending.get(),
+			|| text_page("Loading"),
+			|| text_page("Ready"),
+		)))
+	};
+
+	assert!(screen.query_by_text("Loading").is_some());
+	assert!(screen.query_by_text("Ready").is_none());
+}
+
+#[test]
+fn deferred_pages_render_content_branch() {
+	let screen = render(Page::Deferred(DeferredNode::new(
+		"component-test",
+		|| text_page("Loading"),
+		|| text_page("Ready"),
+	)));
+
+	assert!(screen.query_by_text("Ready").is_some());
+	assert!(screen.query_by_text("Loading").is_none());
 }
 
 #[test]

--- a/crates/reinhardt-pages/tests/component_testing.rs
+++ b/crates/reinhardt-pages/tests/component_testing.rs
@@ -8,6 +8,7 @@ use reinhardt_core::types::page::{
 	DeferredNode, EventType, IntoPage, Outlet, Page, PageElement, SuspenseNode,
 };
 use reinhardt_pages::callback::async_handler;
+use reinhardt_pages::component::suspense::SuspenseBoundary;
 use reinhardt_pages::page;
 use reinhardt_pages::prelude::spawn_task;
 use reinhardt_pages::reactive::hooks::use_action;
@@ -41,8 +42,18 @@ fn ready_component() -> Page {
 	Page::reactive(move || string_resource_page(resource.get()))
 }
 
+fn suspense_resource_component() -> Page {
+	let resource = use_resource(|| async { Ok::<String, String>("Ready".to_string()) }, ());
+	let content_resource = resource.clone();
+	SuspenseBoundary::new()
+		.fallback(|| text_page("Loading"))
+		.track(resource)
+		.content(move || string_resource_page(content_resource.get()))
+		.into_page()
+}
+
 fn mixed_resource_component() -> Page {
-	let pending = use_resource(|| std::future::pending::<Result<String, String>>(), ());
+	let pending = use_resource(std::future::pending::<Result<String, String>>, ());
 	let ready = use_resource(|| async { Ok::<String, String>("Ready".to_string()) }, ());
 	Page::reactive(move || {
 		let _ = pending.get();
@@ -183,6 +194,19 @@ fn suspense_pages_render_active_branch() {
 
 	assert!(screen.query_by_text("Loading").is_some());
 	assert!(screen.query_by_text("Ready").is_none());
+}
+
+#[tokio::test]
+async fn suspense_pages_rerender_resolved_resource_after_settle() {
+	let screen = render(suspense_resource_component);
+
+	assert!(screen.query_by_text("Loading").is_some());
+	assert!(screen.query_by_text("Ready").is_none());
+
+	screen.settle().await;
+
+	assert!(screen.query_by_text("Ready").is_some());
+	assert!(screen.query_by_text("Loading").is_none());
 }
 
 #[test]

--- a/crates/reinhardt-pages/tests/ui/hooks/fail/missing_deps_use_effect.stderr
+++ b/crates/reinhardt-pages/tests/ui/hooks/fail/missing_deps_use_effect.stderr
@@ -1,12 +1,3 @@
-error[E0308]: mismatched types
- --> tests/ui/hooks/fail/missing_deps_use_effect.rs:9:24
-  |
-9 |     let _ = use_effect(|| {});
-  |                           ^^ expected `Option<_>`, found `()`
-  |
-  = note:   expected enum `std::option::Option<_>`
-          found unit type `()`
-
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
  --> tests/ui/hooks/fail/missing_deps_use_effect.rs:9:10
   |
@@ -16,7 +7,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
 note: function defined here
  --> src/reactive/hooks/effect.rs
   |
-  | pub fn use_effect<F, C, D>(f: F, deps: D) -> Effect
+  | pub fn use_effect<F, R, D>(mut f: F, deps: D) -> Effect
   |        ^^^^^^^^^^
 help: provide the argument
   |

--- a/crates/reinhardt-pages/tests/ui/hooks/fail/missing_deps_use_effect.stderr
+++ b/crates/reinhardt-pages/tests/ui/hooks/fail/missing_deps_use_effect.stderr
@@ -7,7 +7,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
 note: function defined here
  --> src/reactive/hooks/effect.rs
   |
-  | pub fn use_effect<F, R, D>(mut f: F, deps: D) -> Effect
+  | pub fn use_effect<F, C, D>(f: F, deps: D) -> Effect
   |        ^^^^^^^^^^
 help: provide the argument
   |

--- a/crates/reinhardt-pages/tests/ui/hooks/pass/cleanup_generic_turbofish.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/pass/cleanup_generic_turbofish.rs
@@ -1,0 +1,9 @@
+//! Compile-pass: explicit cleanup-type turbofish calls keep the pre-existing
+//! `use_effect::<_, C, _>` and `use_layout_effect::<_, C, _>` shape.
+
+use reinhardt_pages::reactive::hooks::{use_effect, use_layout_effect};
+
+fn main() {
+	let _effect = use_effect::<_, fn(), _>(|| None, ());
+	let _layout_effect = use_layout_effect::<_, fn(), _>(|| None, ());
+}

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1327,6 +1327,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow 0.6.26",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4937,7 +4948,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5485,6 +5496,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "reinhardt-tasks"
+version = "0.3.1"
+dependencies = [
+ "aquamarine 0.6.0",
+ "async-trait",
+ "chrono",
+ "cron",
+ "ipnet",
+ "rand 0.9.4",
+ "reinhardt-conf",
+ "reinhardt-core",
+ "reinhardt-di",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "reinhardt-test"
 version = "0.3.1"
 dependencies = [
@@ -5720,6 +5754,7 @@ dependencies = [
  "reinhardt-rest",
  "reinhardt-server",
  "reinhardt-shortcuts",
+ "reinhardt-tasks",
  "reinhardt-test",
  "reinhardt-urls",
  "reinhardt-utils",
@@ -7293,7 +7328,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7315,7 +7350,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7324,7 +7359,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8292,6 +8327,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -791,7 +791,6 @@ pub fn question_edit(question_id: i64) -> Page {
 						.question_text()
 						.set(question.question_text.clone());
 				}
-				None::<fn()>
 			},
 			(load_detail_for_deps,),
 		);


### PR DESCRIPTION
## Summary

This PR addresses:

- Lets `use_effect` and `use_layout_effect` accept closures returning `()` for cleanup-free effects.
- Preserves cleanup-capable effects through `Option<C>` via the new `EffectReturn` return adapter.
- Updates hook docs and the tutorial example so simple effects no longer need `None::<fn()>`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

This removes the noisy `None::<fn()>` artifact from cleanup-free effect examples without adding a public `use_effect_no_cleanup` name. Existing cleanup-capable effects continue to return `Option<C>`.

Fixes #5512

Related to: #5198

## How Was This Tested?

- [x] `cargo make fmt-fix`
- [x] `cargo make fmt-check`
- [x] `cargo check -p reinhardt-pages`
- [x] `cargo test -p reinhardt-pages reactive::hooks::effect::tests --lib`
- [x] `cargo doc -p reinhardt-pages --no-deps`
- [x] `cargo clippy -p reinhardt-pages --lib --tests -- -D warnings`

Note: `cargo clippy -p reinhardt-pages --all-targets -- -D warnings` still fails on pre-existing benchmark warnings in `crates/reinhardt-pages/benches/wasm_framework_benchmarks.rs` (`criterion::black_box` deprecation, doc lazy continuation, and unnecessary cast). This PR does not touch that bench.

## Performance Impact

Not performance-related. The new adapter only normalizes the effect closure return value before passing it to the existing effect runtime.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5512
- Related to #5198

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `api` - REST API, serializers, views

### Priority Label (for maintainers)
- [x] `low` - Minor fix or enhancement

---

**Additional Context:**

Generated with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Effect hooks now accept callbacks that return either nothing or a cleanup function.
  * Effect dependencies are now passed explicitly as tuples.

* **Bug Fixes**
  * Rendering now handles deferred and suspense content more consistently in tests and examples.

* **Documentation**
  * Updated hook guides and examples to show the new dependency-tuple and cleanup conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->