### PR TITLE
fix(commands): remove redundant rustdoc link target

### DIFF
--- a/crates/reinhardt-commands/src/runserver_hooks.rs
+++ b/crates/reinhardt-commands/src/runserver_hooks.rs
@@ -1,7 +1,7 @@
 //! Runserver lifecycle hooks for extending server startup behavior.
 //!
 //! Hooks are auto-discovered via `inventory` and invoked by
-//! [`RunServerCommand`](crate::RunServerCommand) at two lifecycle points:
+//! [`RunServerCommand`] at two lifecycle points:
 //!
 //! 1. **Validation** ([`RunserverHook::validate`]) — before DI setup; return `Err` to abort.
 //! 2. **Startup** ([`RunserverHook::on_server_start`]) — after DI is ready, before listen.


### PR DESCRIPTION
## Summary

This PR addresses:

- Remove a redundant explicit target from the `RunServerCommand` intra-doc link.
- Restore docs.rs-style builds that deny `rustdoc::redundant_explicit_links` warnings.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The docs.rs simulation runs rustdoc with warnings denied. The explicit destination on a link whose label already resolves to `RunServerCommand` triggers `rustdoc::redundant_explicit_links`, causing documentation builds to fail across unrelated pull requests targeting `main`.

This applies the same correction already present on `develop/0.4.0` in commit `1934225df`.

## How Was This Tested?

- `git diff --check origin/main...HEAD`
- Confirmed the resulting `runserver_hooks.rs` matches the corrected file on `origin/develop/0.4.0`.
- The targeted Cargo docs command could not run locally because the repository pre-command security hook requires an authenticated Semgrep Guardian session in this environment; CI will perform the docs.rs simulation.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related implementation on `develop/0.4.0`: `1934225df`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow impact

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The change is limited to one intra-doc link and does not alter public APIs or runtime behavior.
