### PR TITLE
fix(tests): use fallback service for SPA fixtures

### DIFF
--- a/crates/reinhardt-pages/tests/integration/spa_navigation_e2e_test.rs
+++ b/crates/reinhardt-pages/tests/integration/spa_navigation_e2e_test.rs
@@ -69,10 +69,8 @@ async fn boot_test_server(fixture_dir: &Path) -> (String, ServerGuard) {
 	// `index.html` for directory requests like `/`. This is the documented
 	// default in tower-http but is set explicitly so the test does not rely
 	// on version-specific behavior.
-	let app = Router::new().nest_service(
-		"/",
-		ServeDir::new(fixture_dir).append_index_html_on_directories(true),
-	);
+	let app = Router::new()
+		.fallback_service(ServeDir::new(fixture_dir).append_index_html_on_directories(true));
 
 	// Bind to 0.0.0.0 so the chromedp container can reach the listener via
 	// `host.docker.internal` on Linux CI. With `--add-host=...:host-gateway`

--- a/crates/reinhardt-pages/tests/integration/spa_navigation_full_layout_e2e_test.rs
+++ b/crates/reinhardt-pages/tests/integration/spa_navigation_full_layout_e2e_test.rs
@@ -89,10 +89,8 @@ async fn boot_test_server(fixture_dir: &Path) -> (String, ServerGuard) {
 	use axum::Router;
 	use tower_http::services::ServeDir;
 
-	let app = Router::new().nest_service(
-		"/",
-		ServeDir::new(fixture_dir).append_index_html_on_directories(true),
-	);
+	let app = Router::new()
+		.fallback_service(ServeDir::new(fixture_dir).append_index_html_on_directories(true));
 
 	// Bind to 0.0.0.0 so the chromedp container can reach the listener via
 	// `host.docker.internal` on Linux CI. Refs #4111.


### PR DESCRIPTION
## Summary

This PR addresses:

- Replaces root `Router::nest_service("/")` calls in the SPA fixture servers with `fallback_service`, which is the supported Axum 0.8 route for serving the application at the root path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Axum rejects nesting a service at the root path. The two SPA navigation fixture servers therefore panic before their browser tests begin.

Related to: #5672

## How Was This Tested?

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/reinhardt-spa-fallback-target CARGO_BUILD_RUSTC_WRAPPER='' cargo test -p reinhardt-pages --features e2e-cdp-test --test spa_navigation_e2e_test --test spa_navigation_full_layout_e2e_test -j1`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5672

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Scope Label (select all that apply)
- [x] `routing` - URL routing, path matching

---

**Additional Context:**

This is intentionally a test-fixture-only correction; it does not modify the release branch.