### PR TITLE
fix(ci): tolerate spin patch updates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -132,7 +132,7 @@ skip = [
   { crate = "sha1:>=0.10,<0.11", reason = "Upstream dependencies retain sha1 0.10 while AWS SDK components use sha1 0.11." },
   { crate = "simple_asn1@0.4.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "spin@0.5.2", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
-  { crate = "spin@0.9.8", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
+  { crate = "spin:>=0.9,<0.10", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "sync_wrapper@0.1.2", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "system-configuration@0.5.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "system-configuration-sys@0.5.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },


### PR DESCRIPTION
## Summary

This PR addresses:

- Widening the intentional `spin` 0.9 duplicate skip so fresh dependency resolution accepts compatible patch releases.
- Keeping the dependency-policy check green on `develop/0.4.0` after the release PR #5675 failure exposed the stale exact skip.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (code that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`cargo-deny` resolves `spin` 0.9.9 and 0.10.1 in a fresh graph, while the exact `spin@0.9.8` skip becomes unmatched. Using the compatible 0.9 minor range preserves the intentional duplicate policy across patch releases.

Fixes #5677

Related to: #5675

## How Was This Tested?

- `cargo deny --version` → `cargo-deny 0.19.9`
- `cargo deny --workspace --all-features check all`
- Result: `advisories ok, bans ok, licenses ok, sources ok`.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (not applicable to this CI policy-only change)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable to configuration-only change)
- [ ] New and existing unit tests pass locally with my changes (not run; no Rust source changed)
- [ ] I have tested with all affected database backends (not applicable)
- [ ] I have formatted the code with `cargo make fmt-fix` (not applicable to TOML-only change)
- [ ] I have checked the code with `cargo make clippy-check` (not applicable to TOML-only change)

## Related Issues

- #5677
- #5675

## Labels to Apply

### Type Label

- [x] `bug` - Bug fix

### Scope Label

- [x] `ci-cd` - CI/CD workflow and dependency policy change

### Priority Label

- [x] `high` - Keeps the release branch policy check compatible with fresh resolution

**Additional Context:**

This is the `develop/0.4.0` companion PR. The same one-line policy correction is prepared separately for `main`.
