### PR TITLE
docs: make commit attribution model-specific

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -478,9 +478,9 @@ Features:
 - Feature 1
 - Feature 2
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+🤖 Generated with [<Agent Name>](<Agent URL>)
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: <Model Name> <noreply@model-provider.example>
 ```
 
 **Type Values**:
@@ -500,7 +500,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 - Subject line: Be specific, not vague
 - Body: Organize by module/component, list file changes with line counts
-- Footer: Include Claude Code attribution and Co-Authored-By line
+- Footer: Include attribution for the creating agent and a Co-Authored-By line for the creating model
 - Exactly one blank line between body and footer
 
 **Style Reference**:

--- a/docs/rfc/2026-07-10-typed-page-event-payloads-implementation-plan.md
+++ b/docs/rfc/2026-07-10-typed-page-event-payloads-implementation-plan.md
@@ -33,10 +33,11 @@ component testing, `trybuild`, `rstest`, Cargo Make.
   `FIXME`, `todo!()`, `unimplemented!()`, or undocumented `#[allow]`.
 - Use Rust 2024 `module.rs` plus `module/` layouts; never add `mod.rs`.
 - Every task ends with spec review, code-quality review, focused verification,
-  and a small conventional commit. Commit messages must end with:
+  and a small conventional commit. Commit messages must include a model-specific
+  Co-Authored-By footer:
 
   ```text
-  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+  Co-Authored-By: <Model Name> <noreply@model-provider.example>
   ```
 
 ## Task 1: Add the authoritative event catalog

--- a/instructions/COMMIT_GUIDELINE.md
+++ b/instructions/COMMIT_GUIDELINE.md
@@ -404,21 +404,21 @@ or
 | `Fixes` | Fixes related issues | `Fixes #789` |
 | `Reviewed-by` | Reviewer credit | `Reviewed-by: Name <email>` |
 
-**Required Footer for Claude Code:**
+**Required Footer for AI-Assisted Commits:**
 
 ```
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+🤖 Generated with [<Agent Name>](<Agent URL>)
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: <Model Name> <noreply@model-provider.example>
 ```
 
 **Requirements:**
 
 - **EXACTLY one blank line** between body and footer section
 - Footer tokens MUST use `-` in place of whitespace (except `BREAKING CHANGE`)
-- Footer **MUST** include the Claude Code attribution when AI-assisted
-- Footer **MUST** include Co-Authored-By line when AI-assisted
+- Footer **MUST** include attribution for the agent that created the commit when AI-assisted
+- Footer **MUST** include a Co-Authored-By line identifying the model that created the commit; do not use a fixed model name
 
 ---
 


### PR DESCRIPTION
## Summary

Updates commit-message attribution templates so they identify the agent and the model that actually created each commit.

This PR addresses:

- Replaces fixed Claude Code and Claude Opus 4.6 commit-footer examples with agent- and model-specific placeholders.
- States explicitly that AI-assisted commits must not use a fixed model name.

## Type of Change

- [x] Documentation update

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

A fixed model attribution can misrepresent the model that created a commit. The documented footer now requires attribution based on the actual creating agent and model.

## How Was This Tested?

- Ran `git diff --check`.
- Ran `cargo make fmt-check`.
- Confirmed no `Claude Opus 4.6` commit-footer requirement remains in the updated documentation.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable: documentation-only change)
- [ ] New and existing unit tests pass locally with my changes (not run: documentation-only change)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check` (not applicable: documentation-only change)

## Related Issues

- None.

## Labels to Apply

### Type Label

- [x] `documentation` - Documentation update

### Additional Labels

- None.

### Scope Label

- [ ] Not applicable.
