### PR TITLE
fix(ci): allow auto-fix on non-fast-forward-only branches

### DIFF
--- a/.github/scripts/auto-fix-style-target.cjs
+++ b/.github/scripts/auto-fix-style-target.cjs
@@ -64,7 +64,7 @@ async function runAutoFixTargetPolicy({ github, context, core, noticePrefix }) {
 		let rules = [];
 
 		if (branch.protected) {
-			const rulesResponse = await github.request(
+			rules = await github.paginate(
 				'GET /repos/{owner}/{repo}/rules/branches/{branch}',
 				{
 					owner: context.repo.owner,
@@ -72,7 +72,6 @@ async function runAutoFixTargetPolicy({ github, context, core, noticePrefix }) {
 					branch: headRef,
 				},
 			);
-			rules = rulesResponse.data;
 		}
 
 		const result = classifyBranchProtection(branch, rules);

--- a/.github/scripts/auto-fix-style-target.cjs
+++ b/.github/scripts/auto-fix-style-target.cjs
@@ -1,0 +1,89 @@
+'use strict';
+
+const NON_WRITE_BLOCKING_RULES = new Set(['non_fast_forward']);
+
+function classifyBranchProtection(branch, rules) {
+	if (!branch.protected) {
+		return { eligible: true, reason: 'eligible' };
+	}
+
+	const classicProtectionEnabled = branch.protection?.enabled !== false;
+	const onlyNonWriteBlockingRules =
+		Array.isArray(rules) &&
+		rules.length > 0 &&
+		rules.every((rule) => NON_WRITE_BLOCKING_RULES.has(rule.type));
+
+	// reinhardt-web#5695: GitHub reports branches covered only by the
+	// non-fast-forward ruleset as protected even though normal commits remain valid.
+	if (!classicProtectionEnabled && onlyNonWriteBlockingRules) {
+		return { eligible: true, reason: 'eligible-non-fast-forward-only' };
+	}
+
+	return { eligible: false, reason: 'protected-branch' };
+}
+
+function isProjectReadOnlyBranch(headRef) {
+	return (
+		headRef === 'main' ||
+		headRef === 'master' ||
+		headRef.startsWith('develop/') ||
+		headRef.startsWith('release/') ||
+		headRef.startsWith('release-plz-') ||
+		headRef.startsWith('develop-release-plz-')
+	);
+}
+
+async function runAutoFixTargetPolicy({ github, context, core, noticePrefix }) {
+	const pr = context.payload.pull_request;
+	const headRef = pr.head.ref;
+	const repository = `${context.repo.owner}/${context.repo.repo}`;
+
+	function finish(eligible, reason) {
+		core.setOutput('eligible', eligible ? 'true' : 'false');
+		core.setOutput('reason', reason);
+		core.notice(`${noticePrefix}: ${reason}`);
+	}
+
+	if (pr.head.repo.full_name !== repository) {
+		finish(false, 'fork-pull-request');
+		return;
+	}
+
+	if (isProjectReadOnlyBranch(headRef)) {
+		finish(false, 'project-read-only-branch');
+		return;
+	}
+
+	try {
+		const branchResponse = await github.rest.repos.getBranch({
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			branch: headRef,
+		});
+		const branch = branchResponse.data;
+		let rules = [];
+
+		if (branch.protected) {
+			const rulesResponse = await github.request(
+				'GET /repos/{owner}/{repo}/rules/branches/{branch}',
+				{
+					owner: context.repo.owner,
+					repo: context.repo.repo,
+					branch: headRef,
+				},
+			);
+			rules = rulesResponse.data;
+		}
+
+		const result = classifyBranchProtection(branch, rules);
+		finish(result.eligible, result.reason);
+	} catch (error) {
+		core.warning(`Failed to evaluate branch protection for ${headRef}: ${error.message}`);
+		finish(false, 'branch-protection-check-failed');
+	}
+}
+
+module.exports = {
+	classifyBranchProtection,
+	runAutoFixTargetPolicy,
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,54 +131,28 @@ jobs:
       eligible: ${{ steps.target.outputs.eligible }}
       reason: ${{ steps.target.outputs.reason }}
     steps:
+      - name: Checkout trusted auto-fix policy
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/auto-fix-style-target.cjs
+          sparse-checkout-cone-mode: false
+          path: .auto-fix-policy
+
       - name: Check auto-fix target branch
         id: target
         uses: actions/github-script@v8
         with:
           script: |
-            const pr = context.payload.pull_request;
-            const headRef = pr.head.ref;
-            const repository = `${context.repo.owner}/${context.repo.repo}`;
-
-            function finish(eligible, reason) {
-              core.setOutput('eligible', eligible ? 'true' : 'false');
-              core.setOutput('reason', reason);
-              core.notice(`Auto-fix style target: ${reason}`);
-            }
-
-            if (pr.head.repo.full_name !== repository) {
-              finish(false, 'fork-pull-request');
-              return;
-            }
-
-            const projectReadOnlyBranch =
-              headRef === 'main' ||
-              headRef === 'master' ||
-              headRef.startsWith('develop/') ||
-              headRef.startsWith('release/') ||
-              headRef.startsWith('release-plz-') ||
-              headRef.startsWith('develop-release-plz-');
-
-            if (projectReadOnlyBranch) {
-              finish(false, 'project-read-only-branch');
-              return;
-            }
-
-            let branch;
-            try {
-              const response = await github.rest.repos.getBranch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                branch: headRef,
-              });
-              branch = response.data;
-            } catch (error) {
-              core.warning(`Failed to read branch protection for ${headRef}: ${error.message}`);
-              finish(false, 'branch-protection-check-failed');
-              return;
-            }
-
-            finish(!branch.protected, branch.protected ? 'protected-branch' : 'eligible');
+            const { runAutoFixTargetPolicy } = require('./.auto-fix-policy/.github/scripts/auto-fix-style-target.cjs');
+            await runAutoFixTargetPolicy({
+              github,
+              context,
+              core,
+              noticePrefix: 'Auto-fix style target',
+            });
 
   auto-fix-style:
     name: Auto-Fix Style
@@ -298,6 +272,16 @@ jobs:
           repository: ${{ github.repository }}
           persist-credentials: false
 
+      - name: Checkout trusted auto-fix policy
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/auto-fix-style-target.cjs
+          sparse-checkout-cone-mode: false
+          path: .auto-fix-policy
+
       - name: Download auto-fix patch
         uses: actions/download-artifact@v4
         with:
@@ -321,49 +305,13 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const pr = context.payload.pull_request;
-            const headRef = pr.head.ref;
-            const repository = `${context.repo.owner}/${context.repo.repo}`;
-
-            function finish(eligible, reason) {
-              core.setOutput('eligible', eligible ? 'true' : 'false');
-              core.setOutput('reason', reason);
-              core.notice(`Auto-fix style write target: ${reason}`);
-            }
-
-            if (pr.head.repo.full_name !== repository) {
-              finish(false, 'fork-pull-request');
-              return;
-            }
-
-            const projectReadOnlyBranch =
-              headRef === 'main' ||
-              headRef === 'master' ||
-              headRef.startsWith('develop/') ||
-              headRef.startsWith('release/') ||
-              headRef.startsWith('release-plz-') ||
-              headRef.startsWith('develop-release-plz-');
-
-            if (projectReadOnlyBranch) {
-              finish(false, 'project-read-only-branch');
-              return;
-            }
-
-            let branch;
-            try {
-              const response = await github.rest.repos.getBranch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                branch: headRef,
-              });
-              branch = response.data;
-            } catch (error) {
-              core.warning(`Failed to read branch protection for ${headRef}: ${error.message}`);
-              finish(false, 'branch-protection-check-failed');
-              return;
-            }
-
-            finish(!branch.protected, branch.protected ? 'protected-branch' : 'eligible');
+            const { runAutoFixTargetPolicy } = require('./.auto-fix-policy/.github/scripts/auto-fix-style-target.cjs');
+            await runAutoFixTargetPolicy({
+              github,
+              context,
+              core,
+              noticePrefix: 'Auto-fix style write target',
+            });
 
       - name: Generate GitHub token
         if: steps.recheck-target.outputs.eligible == 'true'

--- a/docs/rfc/2026-06-30-ci-style-auto-fix-design.md
+++ b/docs/rfc/2026-06-30-ci-style-auto-fix-design.md
@@ -32,7 +32,9 @@ Keep the write boundary narrow:
 
 - only same-repository pull requests are eligible;
 - fork pull requests remain read-only;
-- protected branches remain read-only;
+- branches with classic or write-blocking protection remain read-only;
+- a non-fast-forward-only ruleset remains eligible because it permits the
+  normal commit used by auto-fix while still rejecting history rewrites;
 - release-managed branches remain read-only;
 - no pull-request comments are posted by the auto-fix workflow.
 
@@ -57,9 +59,13 @@ Add three downstream jobs to `.github/workflows/ci.yml`:
 
 The target job runs only when the reusable `fmt` or `clippy` job fails. It is
 gated to `pull_request` events where the pull-request head repository is the
-same as the base repository. It also checks the repository branch API so the
-write path is disabled when the PR head branch is actually protected, not just
-when its name matches a local denylist.
+same as the base repository. It checks the repository branch summary and active
+branch rules so the write path is disabled for classic or write-blocking
+protection, not just when a name matches a local denylist. GitHub's aggregate
+`protected` flag also covers non-fast-forward-only rulesets, so that
+force-push-only case remains eligible. Both target checks load the shared
+policy from the pull request's base commit, so a pull-request head cannot alter
+the eligibility code that guards the write path.
 
 The fix job checks out the pull-request head branch, installs the same tools
 used by the style gates, runs the matching fix command, and uploads a binary
@@ -68,8 +74,10 @@ patch only when the fix command leaves a worktree diff.
 ## 5. Execution Flow
 
 1. `ci.yml` runs the existing `fmt` and `clippy` reusable workflows.
-2. If either job fails, `auto-fix-style-target` evaluates the same-repository,
-   release-managed, project read-only branch, and branch-protection gates.
+2. If either job fails, `auto-fix-style-target` loads the shared policy from the
+   trusted base commit and evaluates the same-repository, release-managed,
+   project read-only branch, classic protection, and active branch-rule gates.
+   A `non_fast_forward`-only ruleset remains eligible.
 3. If the pull request is ineligible, the downstream fix and write jobs are
    skipped.
 4. If eligible, `auto-fix-style` checks out the PR head branch.
@@ -83,8 +91,9 @@ patch only when the fix command leaves a worktree diff.
 8. If there is a diff, the fix job uploads a binary patch artifact.
 9. `commit-auto-fix-style` checks out a clean copy of the PR head branch and
    applies the patch without executing PR-controlled build or make code.
-10. The write job rechecks the target branch protection state before generating
-    a write-capable token.
+10. The write job reloads the policy from the trusted base commit and rechecks
+    the target branch protection and active rule state before generating a
+    write-capable token.
 11. If the branch is still eligible, the write job creates the commit with
     GitHub GraphQL `createCommitOnBranch`.
 
@@ -96,11 +105,13 @@ the job exports only a patch artifact.
 
 The write job starts from a clean checkout, downloads the patch, and applies it
 with `git apply --index`. It does not run `cargo make`, build scripts,
-proc-macros, or repository hooks before generating the write token.
+proc-macros, repository hooks, or policy code from the pull-request head before
+generating the write token. The eligibility policy is sparse-checked out from
+the pull request's base commit into an isolated path.
 
 The GitHub App token is generated only in the write job after the patch is
-applied and the target branch protection state is rechecked. The token requests
-only `permission-contents: write`.
+applied and the target branch protection and active rules are rechecked. The
+token requests only `permission-contents: write`.
 
 The write job uses the existing repository pattern based on GraphQL
 `createCommitOnBranch`, instead of local `git commit` plus `git push`. This
@@ -135,14 +146,21 @@ The workflow does not post PR comments. The GraphQL commit is the audit trail.
 Local validation for the workflow change:
 
 - `actionlint -shellcheck= .github/workflows/ci.yml`
+- `bash scripts/tests/test-ci-auto-fix-style-target.sh`
 - shell syntax checks for any extracted multi-line shell script used by the job
-- inspection that the target job uses the branch API before the write-capable
-  path can run
+- inspection that both target checks use the shared branch policy before the
+  write-capable path can run
+- inspection that both policy copies are sparse-checked out from the pull
+  request's base commit rather than the pull-request head
+- unit coverage that non-fast-forward-only protection remains eligible while
+  classic and write-blocking protection remain ineligible
 - inspection that the App token step requests only `permission-contents: write`
 
 Hosted validation:
 
 - create or update a same-repository test PR with intentional formatter drift;
+- confirm a topic branch covered only by the repository-wide non-fast-forward
+  rule reaches the fix and write jobs;
 - confirm the fix job uploads a patch artifact and the write job creates a
   GraphQL commit;
 - confirm the new GraphQL commit triggers a fresh CI run;

--- a/scripts/tests/test-ci-auto-fix-style-target.sh
+++ b/scripts/tests/test-ci-auto-fix-style-target.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+POLICY_FILE="$ROOT_DIR/.github/scripts/auto-fix-style-target.cjs"
+WORKFLOW_FILE="$ROOT_DIR/.github/workflows/ci.yml"
+
+if [[ ! -f "$POLICY_FILE" ]]; then
+	echo "FAIL: expected shared auto-fix target policy at $POLICY_FILE" >&2
+	exit 1
+fi
+
+node - "$POLICY_FILE" "$WORKFLOW_FILE" <<'NODE'
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const policyFile = process.argv[2];
+const workflowFile = process.argv[3];
+const { classifyBranchProtection } = require(policyFile);
+
+assert.deepEqual(
+  classifyBranchProtection({ protected: false }, []),
+  { eligible: true, reason: 'eligible' },
+);
+
+assert.deepEqual(
+  classifyBranchProtection(
+    { protected: true, protection: { enabled: false } },
+    [{ type: 'non_fast_forward' }],
+  ),
+  { eligible: true, reason: 'eligible-non-fast-forward-only' },
+);
+
+assert.deepEqual(
+  classifyBranchProtection(
+    { protected: true, protection: { enabled: false } },
+    [{ type: 'required_pull_request' }],
+  ),
+  { eligible: false, reason: 'protected-branch' },
+);
+
+assert.deepEqual(
+  classifyBranchProtection(
+    { protected: true, protection: { enabled: false } },
+    [],
+  ),
+  { eligible: false, reason: 'protected-branch' },
+);
+
+assert.deepEqual(
+  classifyBranchProtection(
+    { protected: true, protection: { enabled: true } },
+    [{ type: 'non_fast_forward' }],
+  ),
+  { eligible: false, reason: 'protected-branch' },
+);
+
+const workflow = fs.readFileSync(workflowFile, 'utf8');
+const sharedPolicyCalls = workflow.match(/runAutoFixTargetPolicy\(/g) ?? [];
+assert.equal(
+  sharedPolicyCalls.length,
+  2,
+  'initial and pre-commit target checks must share the same policy',
+);
+
+const trustedBaseCheckouts = workflow.match(
+  /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/g,
+) ?? [];
+assert.equal(
+  trustedBaseCheckouts.length,
+  2,
+  'both target checks must load policy code from the trusted base commit',
+);
+
+const trustedPolicyLoads = workflow.match(
+  /require\('\.\/\.auto-fix-policy\/\.github\/scripts\/auto-fix-style-target\.cjs'\)/g,
+) ?? [];
+assert.equal(
+  trustedPolicyLoads.length,
+  2,
+  'both target checks must execute the trusted base policy copy',
+);
+NODE
+
+echo "PASS: CI style auto-fix target policy"

--- a/scripts/tests/test-ci-auto-fix-style-target.sh
+++ b/scripts/tests/test-ci-auto-fix-style-target.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 POLICY_FILE="$ROOT_DIR/.github/scripts/auto-fix-style-target.cjs"
 WORKFLOW_FILE="$ROOT_DIR/.github/workflows/ci.yml"
 
@@ -16,7 +17,9 @@ const fs = require('node:fs');
 
 const policyFile = process.argv[2];
 const workflowFile = process.argv[3];
-const { classifyBranchProtection } = require(policyFile);
+const { classifyBranchProtection, runAutoFixTargetPolicy } = require(policyFile);
+
+async function main() {
 
 assert.deepEqual(
   classifyBranchProtection({ protected: false }, []),
@@ -80,6 +83,63 @@ assert.equal(
   2,
   'both target checks must execute the trusted base policy copy',
 );
+
+const outputs = new Map();
+const paginateCalls = [];
+await runAutoFixTargetPolicy({
+  github: {
+    rest: {
+      repos: {
+        getBranch: async () => ({
+          data: { protected: true, protection: { enabled: false } },
+        }),
+      },
+    },
+    paginate: async (route, parameters) => {
+      paginateCalls.push({ route, parameters });
+      return [
+        { type: 'non_fast_forward' },
+        { type: 'required_pull_request' },
+      ];
+    },
+  },
+  context: {
+    payload: {
+      pull_request: {
+        head: {
+          ref: 'feature/test',
+          repo: { full_name: 'kent8192/reinhardt-web' },
+        },
+      },
+    },
+    repo: { owner: 'kent8192', repo: 'reinhardt-web' },
+  },
+  core: {
+    notice: () => {},
+    setOutput: (name, value) => outputs.set(name, value),
+    warning: () => {},
+  },
+  noticePrefix: 'test',
+});
+
+assert.deepEqual(paginateCalls, [
+  {
+    route: 'GET /repos/{owner}/{repo}/rules/branches/{branch}',
+    parameters: {
+      owner: 'kent8192',
+      repo: 'reinhardt-web',
+      branch: 'feature/test',
+    },
+  },
+]);
+assert.equal(outputs.get('eligible'), 'false');
+assert.equal(outputs.get('reason'), 'protected-branch');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
 NODE
 
 echo "PASS: CI style auto-fix target policy"


### PR DESCRIPTION
## Summary

This PR addresses:

- Allows CI style auto-fix on topic branches whose only active protection rule is `non_fast_forward`.
- Centralizes the initial and pre-write eligibility checks in one fail-closed policy.
- Loads both policy checks from the trusted pull-request base commit so PR-controlled code cannot widen the write boundary.
- Adds regression coverage and updates the CI style auto-fix design documentation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #5688 failed its formatter and clippy gates, but the Auto-Fix Style write path was skipped as `protected-branch`. GitHub's aggregate branch flag includes the repository-wide non-fast-forward rule even though that rule permits the normal GraphQL commit used by auto-fix.

The new classifier keeps classic and write-blocking protection read-only, permits only the explicitly recognized non-fast-forward-only case, and fails closed when branch state cannot be evaluated.

Fixes #5695

Related to: #5688

## How Was This Tested?

- `bash scripts/tests/run-all.sh`
- `bash scripts/tests/test-ci-auto-fix-style-target.sh`
- `actionlint -shellcheck= .github/workflows/ci.yml`
- `node --check .github/scripts/auto-fix-style-target.cjs`
- `shellcheck scripts/tests/test-ci-auto-fix-style-target.sh`
- `git diff --check`
- `cargo make fmt-check`
- `cargo make fmt-fix`
- `cargo make clippy-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5695
- #5688

## Labels to Apply

### Type Label (select one)

- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)

- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)

- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)

- [x] `high` - Important fix or feature

---

**Additional Context:**

The write-capable token is still generated only after the target is rechecked. The PR-head checkout is used to apply the generated patch, while eligibility code is sparse-checked out from the trusted base SHA into an isolated path.

🤖 Generated with [Codex](https://openai.com/codex)
