### PR TITLE
fix(reactive): restore develop CI compatibility

### DIFF
--- a/crates/reinhardt-core/src/reactive/effect.rs
+++ b/crates/reinhardt-core/src/reactive/effect.rs
@@ -231,11 +231,11 @@ impl Effect {
 			if let Some(cleanup) = next {
 				*cleanup_for_closure.borrow_mut() = Some(Box::new(cleanup));
 			}
-			if find_node_key(effect_id, NodeKind::Effect).is_some() {
-				if let Some(deps) = &deps {
-					for &dep in deps {
-						super::runtime::subscribe_node_to_observer(dep, effect_id);
-					}
+			if find_node_key(effect_id, NodeKind::Effect).is_some()
+				&& let Some(deps) = &deps
+			{
+				for &dep in deps {
+					super::runtime::subscribe_node_to_observer(dep, effect_id);
 				}
 			}
 		};

--- a/crates/reinhardt-core/src/reactive/runtime.rs
+++ b/crates/reinhardt-core/src/reactive/runtime.rs
@@ -569,6 +569,7 @@ pub(crate) fn subscribe_node_to_observer(node: NodeId, observer: NodeId) {
 mod tests {
 	use super::*;
 	use serial_test::serial;
+	use std::{cell::Cell, rc::Rc};
 
 	#[test]
 	#[serial]
@@ -647,29 +648,31 @@ mod tests {
 	}
 
 	#[test]
-	#[serial]
+	#[serial(reactive_runtime)]
 	fn test_notify_signal_change() {
-		let runtime = Runtime::new();
+		crate::reactive::ReactiveScope::run(|| {
+			let signal = crate::reactive::Signal::new(0_i32);
+			let run_count = Rc::new(Cell::new(0));
+			let signal_for_effect = signal;
+			let run_count_for_effect = Rc::clone(&run_count);
+			let effect = crate::reactive::Effect::new(move || {
+				let _ = signal_for_effect.get();
+				run_count_for_effect.set(run_count_for_effect.get() + 1);
+			});
+			assert_eq!(run_count.get(), 1);
 
-		let signal_id = NodeId::new();
-		let effect_id = NodeId::new();
+			with_runtime(|runtime| {
+				let graph = runtime.dependency_graph.borrow();
+				assert!(graph[&signal.id()].subscribers.contains(&effect.id()));
+				assert!(graph[&effect.id()].dependencies.contains(&signal.id()));
+				drop(graph);
 
-		// Manually add dependency
-		{
-			let mut graph = runtime.dependency_graph.borrow_mut();
-			graph
-				.entry(signal_id)
-				.or_default()
-				.subscribers
-				.push(effect_id);
-		}
-
-		// Notify change
-		runtime.notify_signal_change(signal_id);
-
-		// Verify update was scheduled
-		let pending = runtime.pending_updates.borrow();
-		assert!(pending.contains(&effect_id));
+				runtime.notify_signal_change(signal.id());
+				assert!(runtime.pending_updates.borrow().contains(&effect.id()));
+				runtime.flush_updates();
+			});
+			assert_eq!(run_count.get(), 2);
+		});
 	}
 
 	#[test]

--- a/crates/reinhardt-core/src/reactive/signal.rs
+++ b/crates/reinhardt-core/src/reactive/signal.rs
@@ -521,26 +521,18 @@ mod tests {
 	fn test_signal_change_notification() {
 		crate::reactive::ReactiveScope::run(|| {
 			let signal = Signal::new(0);
+			let signal_for_effect = signal;
+			let effect = crate::reactive::Effect::new(move || {
+				let _ = signal_for_effect.get();
+			});
 
+			// Change the signal
+			signal.set(42);
+
+			// Verify the effect was scheduled for update
 			with_runtime(|rt| {
-				let effect_id = NodeId::new();
-
-				// Manually set up dependency
-				{
-					let mut graph = rt.dependency_graph.borrow_mut();
-					graph
-						.entry(signal.id())
-						.or_default()
-						.subscribers
-						.push(effect_id);
-				}
-
-				// Change the signal
-				signal.set(42);
-
-				// Verify the effect was scheduled for update
 				let pending = rt.pending_updates.borrow();
-				assert!(pending.contains(&effect_id));
+				assert!(pending.contains(&effect.id()));
 			});
 		});
 	}

--- a/crates/reinhardt-pages/src/hydration/runtime.rs
+++ b/crates/reinhardt-pages/src/hydration/runtime.rs
@@ -1066,7 +1066,7 @@ mod tests {
 								Some(move || effect_log.borrow_mut().push("cleanup".to_string()))
 							}
 						},
-						(effect_signal.clone(),),
+						crate::deps![effect_signal],
 					);
 					PageElement::new("span")
 						.child(format!("value:{render_value}"))
@@ -1121,7 +1121,7 @@ mod tests {
 									})
 								}
 							},
-							(effect_signal.clone(),),
+							crate::deps![effect_signal],
 						);
 						PageElement::new("span").child("value:0").into_page()
 					}

--- a/crates/reinhardt-pages/src/reactive/hooks/action.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/action.rs
@@ -39,9 +39,7 @@ impl<T: Clone + 'static> OptimisticState<T> {
 		if self.value.try_set(value).is_err() {
 			return;
 		}
-		if self.is_optimistic.try_set(false).is_err() {
-			return;
-		}
+		let _ = self.is_optimistic.try_set(false);
 	}
 
 	/// Reverts to the confirmed value (called on error).
@@ -52,9 +50,7 @@ impl<T: Clone + 'static> OptimisticState<T> {
 		if self.value.try_set(value).is_err() {
 			return;
 		}
-		if self.is_optimistic.try_set(false).is_err() {
-			return;
-		}
+		let _ = self.is_optimistic.try_set(false);
 	}
 }
 

--- a/crates/reinhardt-pages/src/reactive/hooks/memo.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/memo.rs
@@ -33,7 +33,10 @@ use crate::reactive::{ExplicitDeps, Memo, ReactiveDeps};
 /// # Example
 ///
 /// ```no_run
-/// use reinhardt_pages::reactive::hooks::{use_state, use_memo};
+/// use reinhardt_pages::{
+///     deps,
+///     reactive::hooks::{use_memo, use_state},
+/// };
 ///
 /// let (items, _set_items) = use_state(vec![1, 2, 3, 4, 5]);
 /// let (filter, _set_filter) = use_state(2);
@@ -46,7 +49,7 @@ use crate::reactive::{ExplicitDeps, Memo, ReactiveDeps};
 ///             .filter(|&x| x > filter.get())
 ///             .collect::<Vec<_>>()
 ///     },
-///     (items, filter),
+///     deps![items, filter],
 /// );
 ///
 /// // Reading the memoized value

--- a/crates/reinhardt-pages/src/reactive/hooks/state.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/state.rs
@@ -53,9 +53,7 @@ struct RegisteredSetState<T: 'static> {
 
 impl<T: 'static> RegisteredSetState<T> {
 	fn set(&self, value: T) {
-		if self.signal.try_set(value).is_err() {
-			return;
-		}
+		let _ = self.signal.try_set(value);
 	}
 }
 
@@ -99,9 +97,7 @@ impl<T: Clone + 'static> SetStateExt<T> for SetState<T> {
 		let Ok(current) = signal.try_get_untracked() else {
 			return;
 		};
-		if signal.try_set(f(&current)).is_err() {
-			return;
-		}
+		let _ = signal.try_set(f(&current));
 	}
 }
 
@@ -250,9 +246,7 @@ where
 				return;
 			};
 			let new_state = reducer(&current, action);
-			if state.try_set(new_state).is_err() {
-				return;
-			}
+			let _ = state.try_set(new_state);
 		})
 	};
 	(state, dispatch)

--- a/crates/reinhardt-pages/src/reactive/hooks/websocket.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/websocket.rs
@@ -308,23 +308,13 @@ pub fn use_websocket(url: &str, options: UseWebSocketOptions) -> WebSocketHandle
 				// Try text message first
 				if let Ok(txt) = e.data().dyn_into::<js_sys::JsString>() {
 					let text = txt.as_string().unwrap_or_default();
-					if latest_message_recv
-						.try_set(Some(WebSocketMessage::Text(text)))
-						.is_err()
-					{
-						return;
-					}
+					let _ = latest_message_recv.try_set(Some(WebSocketMessage::Text(text)));
 				}
 				// Try binary message (ArrayBuffer)
 				else if let Ok(array_buffer) = e.data().dyn_into::<js_sys::ArrayBuffer>() {
 					let array = js_sys::Uint8Array::new(&array_buffer);
 					let vec = array.to_vec();
-					if latest_message_recv
-						.try_set(Some(WebSocketMessage::Binary(vec)))
-						.is_err()
-					{
-						return;
-					}
+					let _ = latest_message_recv.try_set(Some(WebSocketMessage::Binary(vec)));
 				}
 			}) as Box<dyn FnMut(MessageEvent)>);
 			ws.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));

--- a/crates/reinhardt-pages/src/reactive/resource.rs
+++ b/crates/reinhardt-pages/src/reactive/resource.rs
@@ -17,6 +17,7 @@ use std::task::{Context, Poll};
 
 use crate::platform::{defer_yield, spawn_task};
 use crate::reactive::pages_arena::{PageNodeKey, PageNodeKind, allocate_page_node, with_page_node};
+#[cfg(native)]
 use reinhardt_core::deps;
 use reinhardt_core::reactive::{ScopeId, current_scope_id, scope::enter_scope};
 

--- a/crates/reinhardt-pages/src/testing/component/tests.rs
+++ b/crates/reinhardt-pages/src/testing/component/tests.rs
@@ -123,7 +123,7 @@ fn effect_cleanup_can_use_page_handles_until_scope_disposal_finishes() {
 				let callback = callback;
 				Some(move || callback.call(()))
 			},
-			(),
+			crate::deps![],
 		);
 	});
 

--- a/crates/reinhardt-pages/tests/hooks_deps_integration.rs
+++ b/crates/reinhardt-pages/tests/hooks_deps_integration.rs
@@ -5,7 +5,7 @@
 //! consumed by an Effect) under Option A semantics:
 //!
 //! - Closure runs with no active reactive Observer.
-//! - Subscriptions are derived exclusively from the deps tuple.
+//! - Subscriptions are derived exclusively from the explicit dependency list.
 //! - Cleanup functions run before re-execution and on dispose.
 
 #![cfg(not(target_arch = "wasm32"))]
@@ -14,6 +14,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use reinhardt_core::reactive::{ReactiveScope, Signal};
+use reinhardt_pages::deps;
 use reinhardt_pages::reactive::hooks::{use_action, use_callback, use_effect, use_memo};
 use serial_test::serial;
 
@@ -35,7 +36,7 @@ fn callback_accepts_copy_handles_without_clone_ceremony() {
 				search_action.reset();
 				upload_action.dispatch(route_project_id.get());
 			},
-			(route_project_id,),
+			deps![route_project_id],
 		);
 
 		upload_click.call(());
@@ -44,7 +45,7 @@ fn callback_accepts_copy_handles_without_clone_ceremony() {
 	});
 }
 
-/// Verifies that a Memo wired into an Effect's deps tuple re-runs the
+/// Verifies that a Memo wired into an Effect's dependency list re-runs the
 /// Effect when the Memo's listed deps change.
 #[test]
 #[serial(hooks_deps_integration)]
@@ -54,11 +55,11 @@ fn memo_feeding_effect_propagates_listed_dep_changes() {
 		let count = Signal::new(1_i32);
 		let runs = Rc::new(RefCell::new(0_i32));
 
-		// Memo doubles the count; listed deps = (count,).
+		// Memo doubles the count; listed deps = [count].
 		let count_for_memo = count.clone();
-		let doubled = use_memo(move || count_for_memo.get() * 2, (count.clone(),));
+		let doubled = use_memo(move || count_for_memo.get() * 2, deps![count]);
 
-		// Effect re-runs when the memo changes; listed deps = (doubled,).
+		// Effect re-runs when the memo changes; listed deps = [doubled].
 		let runs_for_effect = runs.clone();
 		let doubled_for_effect = doubled.clone();
 		let _eff = use_effect(
@@ -67,7 +68,7 @@ fn memo_feeding_effect_propagates_listed_dep_changes() {
 				*runs_for_effect.borrow_mut() += 1;
 				None::<fn()>
 			},
-			(doubled.clone(),),
+			deps![doubled],
 		);
 
 		// Act — change the upstream Signal; both Memo and Effect must
@@ -116,7 +117,7 @@ fn effect_does_not_subscribe_to_unlisted_signal_read() {
 				*runs_for_effect.borrow_mut() += 1;
 				None::<fn()>
 			},
-			(listed.clone(),),
+			deps![listed],
 		);
 
 		let runs_after_mount = *runs.borrow();
@@ -153,7 +154,7 @@ fn effect_cleanup_runs_before_rerun() {
 				let log_inner = log_for_effect.clone();
 				Some(move || log_inner.borrow_mut().push("cleanup"))
 			},
-			(s.clone(),),
+			deps![s],
 		);
 
 		// Act — trigger one re-run.
@@ -166,7 +167,7 @@ fn effect_cleanup_runs_before_rerun() {
 	});
 }
 
-/// Verifies that an empty deps tuple `()` makes the effect mount-only —
+/// Verifies that an empty `deps![]` list makes the effect mount-only —
 /// no re-run regardless of which signals change in the environment.
 #[test]
 #[serial(hooks_deps_integration)]
@@ -180,12 +181,12 @@ fn effect_with_empty_deps_is_mount_only() {
 
 		let _eff = use_effect(
 			move || {
-				// Even though we read s.get(), `()` deps means no subscriptions.
+				// Even though we read s.get(), `deps![]` means no subscriptions.
 				let _ = s_for_effect.get();
 				*runs_for_effect.borrow_mut() += 1;
 				None::<fn()>
 			},
-			(),
+			deps![],
 		);
 
 		assert_eq!(*runs.borrow(), 1, "effect must run once at mount");
@@ -198,7 +199,7 @@ fn effect_with_empty_deps_is_mount_only() {
 		assert_eq!(
 			*runs.borrow(),
 			1,
-			"empty deps `()` must make the effect mount-only"
+			"empty deps `deps![]` must make the effect mount-only"
 		);
 	});
 }

--- a/crates/reinhardt-pages/tests/hooks_integration.rs
+++ b/crates/reinhardt-pages/tests/hooks_integration.rs
@@ -32,8 +32,9 @@
 #[cfg(not(target_arch = "wasm32"))]
 use proptest::prelude::*;
 use reinhardt_core::reactive::ReactiveScope;
-use reinhardt_pages::reactive::Signal;
+use reinhardt_pages::deps;
 use reinhardt_pages::reactive::hooks::{use_effect, use_memo, use_ref, use_state};
+use reinhardt_pages::reactive::{ExplicitDeps, Signal};
 use rstest::*;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -80,7 +81,7 @@ fn test_hooks_use_effect_dependency_tracking() {
 				*effect_counter_clone.borrow_mut() += 1;
 				None::<fn()>
 			},
-			(counter_signal.clone(),),
+			deps![counter_signal],
 		);
 
 		// Effect should run at least once
@@ -108,7 +109,7 @@ fn test_hooks_use_memo_caching() {
 				*computation_count_clone.borrow_mut() += 1;
 				counter_clone.get() * 2
 			},
-			(counter_signal.clone(),),
+			deps![counter_signal],
 		);
 
 		let _value1 = memoized.get();
@@ -142,7 +143,7 @@ fn test_hooks_circular_dependency_detection() {
 				signal_b_clone.set(a + 1);
 				None::<fn()>
 			},
-			(signal_a.clone(),),
+			deps![signal_a],
 		);
 
 		// If circular dependencies are properly handled, this should not hang
@@ -169,7 +170,7 @@ fn test_hooks_infinite_loop_protection(effect_counter: Rc<RefCell<usize>>) {
 				}
 				None::<fn()>
 			},
-			(signal.clone(),),
+			deps![signal],
 		);
 
 		// Effect should have run but stopped before reaching 1000 iterations
@@ -193,7 +194,7 @@ fn test_hooks_effect_empty_dependencies(effect_counter: Rc<RefCell<usize>>) {
 				*effect_counter_clone.borrow_mut() += 1;
 				None::<fn()>
 			},
-			(),
+			deps![],
 		);
 
 		let initial_count = *effect_counter.borrow();
@@ -228,7 +229,7 @@ fn test_hooks_all_dependencies(effect_counter: Rc<RefCell<usize>>) {
 				*effect_counter_clone.borrow_mut() += 1;
 				None::<fn()>
 			},
-			(signal1.clone(), signal2.clone(), signal3.clone()),
+			deps![signal1, signal2, signal3],
 		);
 
 		// Effect should track all three signals
@@ -252,7 +253,7 @@ fn test_hooks_memo_expensive_computation() {
 				let value = signal_clone.get();
 				(1..=value).product::<i32>()
 			},
-			(signal.clone(),),
+			deps![signal],
 		);
 
 		let result = memoized.get();
@@ -283,7 +284,7 @@ fn test_hooks_state_update_triggers_effect(effect_counter: Rc<RefCell<usize>>) {
 				*effect_counter_clone.borrow_mut() += 1;
 				None::<fn()>
 			},
-			(signal.clone(),),
+			deps![signal],
 		);
 
 		let initial_count = *effect_counter.borrow();
@@ -318,7 +319,7 @@ fn test_hooks_cleanup_on_unmount() {
 				}
 				None::<fn()>
 			},
-			(),
+			deps![],
 		);
 
 		// Simulate unmount
@@ -372,7 +373,7 @@ fn test_hooks_use_case_form_validation() {
 				let email_value = email_clone.get();
 				email_value.contains('@') && email_value.contains('.')
 			},
-			(email.clone(),),
+			deps![email],
 		);
 
 		set_email("invalid".to_string());
@@ -402,7 +403,7 @@ fn test_hooks_property_memo_deterministic() {
 
 			let memoized = use_memo(
 				move || signal_clone.get() * 2,
-				(signal.clone(),),
+				deps![signal],
 			);
 
 			let result1 = memoized.get();
@@ -435,7 +436,7 @@ fn test_hooks_combination_effect_state(effect_counter: Rc<RefCell<usize>>) {
 				*effect_counter_clone.borrow_mut() += 1;
 				None::<fn()>
 			},
-			(count.clone(),),
+			deps![count],
 		);
 
 		let initial_count = *effect_counter.borrow();
@@ -456,7 +457,7 @@ fn test_hooks_combination_memo_state() {
 		let (count, set_count) = use_state(5);
 
 		let count_clone = count.clone();
-		let doubled = use_memo(move || count_clone.get() * 2, (count.clone(),));
+		let doubled = use_memo(move || count_clone.get() * 2, deps![count]);
 
 		let first_value = doubled.get();
 		assert_eq!(first_value, 10);
@@ -485,7 +486,7 @@ fn test_hooks_sanity() {
 		assert_eq!(*ref_val.current(), 100);
 
 		// use_memo
-		let memoized = use_memo(|| 2 + 2, ());
+		let memoized = use_memo(|| 2 + 2, deps![]);
 		assert_eq!(memoized.get(), 4);
 
 		// All hooks work independently
@@ -548,7 +549,7 @@ fn test_hooks_partition_hook_types_effect(effect_counter: Rc<RefCell<usize>>) {
 				*effect_counter_clone.borrow_mut() += 1;
 				None::<fn()>
 			},
-			(),
+			deps![],
 		);
 
 		assert!(*effect_counter.borrow() >= 1);
@@ -583,10 +584,8 @@ fn test_hooks_boundary_dependency_array_size(
 				*effect_counter_clone.borrow_mut() += 1;
 				None::<fn()>
 			},
-			// Dynamic deps construction — opaque to the compile-time verifier.
-			reinhardt_core::reactive::deps::Deps::from_signals(
-				&signals_for_deps.iter().map(|s| s.id()).collect::<Vec<_>>(),
-			),
+			// Dynamic dependency construction is opaque to the compile-time verifier.
+			ExplicitDeps::from_node_ids(signals_for_deps.iter().map(|signal| signal.id())),
 		);
 
 		assert!(*effect_counter.borrow() >= 1);
@@ -630,7 +629,7 @@ fn test_hooks_decision_table_case3_effect_runs_once(effect_counter: Rc<RefCell<u
 				*effect_counter_clone.borrow_mut() += 1;
 				None::<fn()>
 			},
-			(),
+			deps![],
 		);
 
 		assert_eq!(*effect_counter.borrow(), 1);
@@ -651,7 +650,7 @@ fn test_hooks_decision_table_case4_memo_no_recompute() {
 				*computation_count_clone.borrow_mut() += 1;
 				signal_clone.get() * 2
 			},
-			(signal.clone(),),
+			deps![signal],
 		);
 
 		let _value1 = memoized.get();
@@ -676,7 +675,7 @@ fn test_hooks_decision_table_case5_memo_with_recompute() {
 				*computation_count_clone.borrow_mut() += 1;
 				signal_clone.get() * 2
 			},
-			(signal.clone(),),
+			deps![signal],
 		);
 
 		let count_before = *computation_count.borrow();

--- a/crates/reinhardt-pages/tests/ui/hooks/pass/cleanup_generic_turbofish.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/pass/cleanup_generic_turbofish.rs
@@ -1,11 +1,12 @@
-//! Compile-pass: explicit cleanup-type turbofish calls keep the pre-existing
-//! `use_effect::<_, C, _>` and `use_layout_effect::<_, C, _>` shape.
+//! Compile-pass: explicit cleanup-type turbofish calls specify the two public
+//! generic parameters and an explicit empty dependency list.
 
+use reinhardt_pages::deps;
 use reinhardt_pages::reactive::hooks::{use_effect, use_layout_effect};
 
 fn main() {
 	reinhardt_core::reactive::ReactiveScope::run(|| {
-		let _effect = use_effect::<_, fn(), _>(|| None, ());
-		let _layout_effect = use_layout_effect::<_, fn(), _>(|| None, ());
+		let _effect = use_effect::<_, fn()>(|| None, deps![]);
+		let _layout_effect = use_layout_effect::<_, fn()>(|| None, deps![]);
 	});
 }

--- a/crates/reinhardt-pages/tests/ui/hooks/pass/explicit_deps_use_effect.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/pass/explicit_deps_use_effect.rs
@@ -1,6 +1,7 @@
-//! Compile-pass: `use_effect` with an explicit single-element deps tuple
+//! Compile-pass: `use_effect` with an explicit single-element dependency list
 //! is the canonical React-parity shape (spec §4.2).
 
+use reinhardt_pages::deps;
 use reinhardt_pages::reactive::Signal;
 use reinhardt_pages::reactive::hooks::use_effect;
 
@@ -15,7 +16,7 @@ fn main() {
 					None::<fn()>
 				}
 			},
-			(count,),
+			deps![count],
 		);
 		let _ = count;
 	});

--- a/crates/reinhardt-pages/tests/ui/hooks/pass/hook_outside_page_unaffected.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/pass/hook_outside_page_unaffected.rs
@@ -1,16 +1,17 @@
 //! Compile-pass (scope guarantee): a hook with a missing dep that is called
 //! OUTSIDE a `page!` body is invisible to the `page!` macro and therefore not
 //! checked by the deps validator — it must still compile (spec §4.5 scope
-//! limitation, #4721/#4746). The runtime arity check still guarantees a deps
-//! tuple is present.
+//! limitation, #4721/#4746). The runtime type check still guarantees an
+//! explicit dependency list is present.
 
+use reinhardt_pages::deps;
 use reinhardt_pages::reactive::Signal;
 use reinhardt_pages::reactive::hooks::use_effect;
 
 fn main() {
 	reinhardt_core::reactive::ReactiveScope::run(|| {
 		let count = Signal::new(0_i32);
-		// `count` is read but not listed in the deps tuple. Because this call is
+		// `count` is read but not listed in the dependency list. Because this call is
 		// not inside a `page!` body, the static validator does not see it.
 		let _e = use_effect(
 			{
@@ -20,7 +21,7 @@ fn main() {
 					None::<fn()>
 				}
 			},
-			(),
+			deps![],
 		);
 		let _ = count;
 	});

--- a/crates/reinhardt-pages/tests/ui/hooks/pass/mount_only_unit_deps.rs
+++ b/crates/reinhardt-pages/tests/ui/hooks/pass/mount_only_unit_deps.rs
@@ -1,6 +1,7 @@
-//! Compile-pass: `()` is the React-parity "mount-only" deps shape — the
+//! Compile-pass: `deps![]` is the React-parity "mount-only" deps shape — the
 //! effect runs once on mount and never re-runs (spec §4.2).
 
+use reinhardt_pages::deps;
 use reinhardt_pages::reactive::hooks::use_effect;
 
 fn main() {
@@ -10,7 +11,7 @@ fn main() {
 				// one-time mount work
 				None::<fn()>
 			},
-			(),
+			deps![],
 		);
 	});
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Restores shared reactive CI compatibility on `develop/0.4.0`.
- Replaces obsolete hand-wired notification tests with live Signal/Effect subscriptions.
- Fixes WASM-only reactive lints and updates ExplicitDeps call sites and the memo doctest.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The current `develop/0.4.0` baseline has reactive CI failures shared by several open PRs: stale tests manually schedule non-existent effect IDs, retained-effect tests and the memo example use an obsolete dependency tuple API, and WASM-only lint paths contain warnings promoted to errors.

Related to: #5630, #5641, #5686, #5688

## How Was This Tested?

- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`
- [x] `cargo check --workspace --all-features --lib --quiet`
- [x] `cargo test -p reinhardt-core --lib --features reactive reactive::`
- [x] `cargo test -p reinhardt-pages --doc --all-features`
- [x] `cargo clippy --target wasm32-unknown-unknown -p reinhardt-pages --all-features --lib -- -D warnings`
- [x] `cargo test --target wasm32-unknown-unknown -p reinhardt-pages --features testing --lib --no-run`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5630
- #5641
- #5686
- #5688

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [x] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

This is a shared base repair; consumer PRs still need to merge the updated `develop/0.4.0` branch to receive it.

🤖 Generated with [Codex](https://openai.com/codex)