### PR TITLE
fix(ci): prevent auto-fix patch policy overwrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git add -A
+          git add -A -- ':!.auto-fix-policy/**'
           git diff --cached --binary > "$RUNNER_TEMP/style-auto-fix.patch"
           if [[ ! -s "$RUNNER_TEMP/style-auto-fix.patch" ]]; then
             echo "::error::Auto-fix changed files, but patch export was empty."
@@ -293,9 +293,13 @@ jobs:
           set -euo pipefail
 
           PATCH_FILE="$RUNNER_TEMP/style-auto-fix/style-auto-fix.patch"
-          git apply --index --whitespace=nowarn "$PATCH_FILE"
+          git apply --index --whitespace=nowarn --exclude='.auto-fix-policy/**' "$PATCH_FILE"
           if git diff --cached --quiet; then
             echo "::error::Auto-fix patch applied without staged changes."
+            exit 1
+          fi
+          if git diff --cached --name-only -- .auto-fix-policy | grep -q .; then
+            echo "::error::Auto-fix patch must not modify trusted policy checkout files."
             exit 1
           fi
           git diff --cached --stat

--- a/docs/rfc/2026-06-30-ci-style-auto-fix-design.md
+++ b/docs/rfc/2026-06-30-ci-style-auto-fix-design.md
@@ -69,7 +69,10 @@ the eligibility code that guards the write path.
 
 The fix job checks out the pull-request head branch, installs the same tools
 used by the style gates, runs the matching fix command, and uploads a binary
-patch only when the fix command leaves a worktree diff.
+patch only when the fix command leaves a worktree diff. Patch export and patch
+application both exclude `.auto-fix-policy/**`, and the write job fails closed if
+that trusted policy checkout path is ever staged. This prevents an untrusted
+auto-fix artifact from replacing the policy code that gates token generation.
 
 ## 5. Execution Flow
 
@@ -88,9 +91,12 @@ patch only when the fix command leaves a worktree diff.
    - `cargo make auto-fix` when both failed.
 7. If there is no diff after the fix command, the workflow exits without
    committing.
-8. If there is a diff, the fix job uploads a binary patch artifact.
+8. If there is a diff, the fix job uploads a binary patch artifact excluding
+   `.auto-fix-policy/**`.
 9. `commit-auto-fix-style` checks out a clean copy of the PR head branch and
-   applies the patch without executing PR-controlled build or make code.
+   applies the patch without executing PR-controlled build or make code. The
+   apply step also excludes `.auto-fix-policy/**` and rejects any staged change
+   under that trusted checkout path before policy execution.
 10. The write job reloads the policy from the trusted base commit and rechecks
     the target branch protection and active rule state before generating a
     write-capable token.
@@ -104,10 +110,11 @@ available to the checkout. The checkout uses `persist-credentials: false`, and
 the job exports only a patch artifact.
 
 The write job starts from a clean checkout, downloads the patch, and applies it
-with `git apply --index`. It does not run `cargo make`, build scripts,
-proc-macros, repository hooks, or policy code from the pull-request head before
-generating the write token. The eligibility policy is sparse-checked out from
-the pull request's base commit into an isolated path.
+with `git apply --index --exclude='.auto-fix-policy/**'`. It does not run
+`cargo make`, build scripts, proc-macros, repository hooks, or policy code from
+the pull-request head before generating the write token. The eligibility policy
+is sparse-checked out from the pull request's base commit into an isolated path,
+and the untrusted patch artifact is not allowed to modify that path.
 
 The GitHub App token is generated only in the write job after the patch is
 applied and the target branch protection and active rules are rechecked. The

--- a/scripts/tests/test-ci-auto-fix-style-target.sh
+++ b/scripts/tests/test-ci-auto-fix-style-target.sh
@@ -84,6 +84,24 @@ assert.equal(
   'both target checks must execute the trusted base policy copy',
 );
 
+assert.match(
+  workflow,
+  /git add -A -- ':!\.auto-fix-policy\/\*\*'/,
+  'patch export must exclude the trusted policy checkout path',
+);
+
+assert.match(
+  workflow,
+  /git apply --index --whitespace=nowarn --exclude='\.auto-fix-policy\/\*\*'/,
+  'patch apply must exclude the trusted policy checkout path',
+);
+
+assert.match(
+  workflow,
+  /git diff --cached --name-only -- \.auto-fix-policy \| grep -q \./,
+  'write job must fail closed if trusted policy checkout files are staged',
+);
+
 const outputs = new Map();
 const paginateCalls = [];
 await runAutoFixTargetPolicy({


### PR DESCRIPTION
### Motivation

- A same-repository auto-fix artifact could include changes to `.auto-fix-policy/**` and those changes could be applied after the trusted checkout but before the write-boundary recheck, allowing execution of attacker-controlled policy code and escalation to a write-capable token.
- The change aims to preserve the write-boundary by ensuring the trusted policy checkout path cannot be modified by untrusted auto-fix artifacts.

### Description

- Prevent the patch export from including the trusted policy checkout by changing the export step to exclude `.auto-fix-policy/**` via `git add -A -- ':!.auto-fix-policy/**'` in `/.github/workflows/ci.yml`.
- Prevent the write job from applying any patch bytes that target the trusted policy checkout by adding `--exclude='.auto-fix-policy/**'` to the `git apply --index` invocation and by failing closed if any staged changes under `.auto-fix-policy` are detected in `/.github/workflows/ci.yml`.
- Add regression assertions to `scripts/tests/test-ci-auto-fix-style-target.sh` that verify the workflow contains the new patch-export exclusion, the patch-apply exclusion, and the staged-path fail-closed guard.
- Update the RFC at `docs/rfc/2026-06-30-ci-style-auto-fix-design.md` to document the patch-path security boundary and the fail-closed behavior.

### Testing

- Ran `bash scripts/tests/test-ci-auto-fix-style-target.sh` and the script passed, validating the new workflow checks and policy-loading expectations.
- Ran a shell-syntax check `bash -n scripts/tests/test-ci-auto-fix-style-target.sh` which succeeded.
- Attempted `actionlint -shellcheck= .github/workflows/ci.yml` but `actionlint` was not installed in the environment so that check was not executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59f1dd974c8327b9dc0b3ce7f787c8)