### PR TITLE
fix(ci): allow syn major-version duplicates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -136,6 +136,7 @@ skip = [
   { crate = "sync_wrapper@0.1.2", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "system-configuration@0.5.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "system-configuration-sys@0.5.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
+  { crate = "syn:>=2,<3", reason = "Workspace macro crates use syn 2 while upstream proc-macro dependencies retain the incompatible syn 3 line." },
   { crate = "tinystr@0.7.6", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "toml@0.8.23", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "toml_datetime@0.6.11", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- Allowing the workspace's `syn 2.x` dependency line to coexist with the incompatible `syn 3.x` line selected by upstream proc-macro dependencies.
- Restoring the shared Security Audit check for PRs #5709, #5710, and #5711.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The Security Audit job for PRs #5709, #5710, and #5711 fails in cargo-deny's `bans` check because fresh dependency resolution selects both `syn 2.0.119` and `syn 3.0.0`. These major versions are retained by independent workspace and upstream dependency requirements, so the policy needs a documented PackageSpec exception.

Fixes #

Related to: #5709, #5710, #5711

## How Was This Tested?

- [x] `cargo deny --workspace --all-features check all` with a fresh dependency resolution
- [x] `actionlint .github/workflows/security-audit.yml`
- [x] `git diff --check`
- [ ] `cargo make fmt-check` (blocked by `No space left on device` in the shared local Cargo build cache; no Rust source files changed)

## Performance Impact

- No runtime or performance impact.

## Breaking Changes

- None.

## Related Issues

- #5709
- #5710
- #5711

## Labels to Apply

- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `ci-cd` - CI/CD workflow changes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with the applicable checks
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

### Additional Context

The exception uses `syn:>=2,<3` instead of an exact patch version so future fresh resolutions remain covered across compatible `syn 2.x` updates.

🤖 Generated with [Codex](https://openai.com/codex)