### PR TITLE
test(migrations): cover mysql enum check expressions

### DIFF
--- a/tests/integration/tests/migrations/model_enum_migration_integration.rs
+++ b/tests/integration/tests/migrations/model_enum_migration_integration.rs
@@ -128,12 +128,13 @@ fn project_state_with_domain(values: &[&str]) -> ProjectState {
 }
 
 #[rstest]
-#[case::postgres(SqlDialect::Postgres, '"')]
-#[case::mysql(SqlDialect::Mysql, '`')]
-#[case::sqlite(SqlDialect::Sqlite, '"')]
+#[case::postgres(SqlDialect::Postgres, '"', "")]
+#[case::mysql(SqlDialect::Mysql, '`', "BINARY ")]
+#[case::sqlite(SqlDialect::Sqlite, '"', "")]
 fn model_enum_create_table_renders_string_i32_and_nullable_checks_for_each_backend(
 	#[case] dialect: SqlDialect,
 	#[case] quote: char,
+	#[case] string_enum_column_prefix: &str,
 ) {
 	// Arrange
 	let metadata = reinhardt_db::migrations::global_registry()
@@ -214,9 +215,13 @@ fn model_enum_create_table_renders_string_i32_and_nullable_checks_for_each_backe
 		);
 	}
 	for fragment in [
-		format!("CHECK ({quote}job_status{quote} IN ('queued', 'running'))"),
+		format!(
+			"CHECK ({string_enum_column_prefix}{quote}job_status{quote} IN ('queued', 'running'))"
+		),
 		format!("CHECK ({quote}job_priority{quote} IN (10, 20))"),
-		format!("CHECK ({quote}fallback_status{quote} IN ('queued', 'running'))"),
+		format!(
+			"CHECK ({string_enum_column_prefix}{quote}fallback_status{quote} IN ('queued', 'running'))"
+		),
 	] {
 		assert!(
 			sql.contains(&fragment),


### PR DESCRIPTION
## Summary

This PR addresses:

- aligning the model-enum migration integration fixture with the MySQL string-domain CHECK expression.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

MySQL renders string model-enum checks with a BINARY column expression to preserve case-sensitive enum values. The cross-crate integration fixture expected the generic quoted-column form, even though generated SQL contained the named CHECK constraints.

Related to: #5708

## How Was This Tested?

- cargo fmt --all -- --check
- git diff --check
- Reviewed the failed Cross-Crate Integration log from PR #5708 and the existing MySQL migration renderer unit tests.
- The focused integration test was not run locally because no current matching test target was available and free workspace storage was below the safe threshold for starting a new large Cargo build.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with cargo fmt --all -- --check
- [ ] I have checked the code with cargo make clippy-check
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5708

## Labels to Apply

### Type Label (select one)
- [x] bug - Bug fix
- [ ] enhancement - New feature or improvement
- [ ] documentation - Documentation update
- [ ] performance - Performance improvement
- [ ] refactoring - Code refactoring
- [ ] code-quality - Code quality improvements

### Scope Label (select all that apply)
- [x] database - Database layer, schema, migrations

---

**Additional Context:**

The fixture now asserts BINARY only for MySQL string enum columns. PostgreSQL and SQLite retain their previous expression, and the MySQL i32 enum check remains unprefixed.

🤖 Generated with [Codex](https://openai.com/codex)
