### PR TITLE
test(macros): update model UI fixtures

### DIFF
--- a/crates/reinhardt-core/macros/tests/ui/model/pass/fixture_projection_preserves_deserializer.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/pass/fixture_projection_preserves_deserializer.rs
@@ -63,7 +63,7 @@ mod optional_uuid_serde {
 	}
 }
 
-#[model(table_name = "fixture_projection_models")]
+#[model(app_label = "fixtures", table_name = "fixture_projection_models")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct FixtureProjectionModel {
 	#[field(primary_key = true)]

--- a/crates/reinhardt-core/macros/tests/ui/model/pass/foreign_key_string_pk_accessor.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/pass/foreign_key_string_pk_accessor.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 include!("../support.rs");
 
-#[model(table_name = "projects")]
+#[model(app_label = "default", table_name = "projects")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Project {
 	#[field(primary_key = true, db_column = "project_key", max_length = 64)]
@@ -12,7 +12,7 @@ struct Project {
 	name: String,
 }
 
-#[model(table_name = "jobs")]
+#[model(app_label = "default", table_name = "jobs")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Job {
 	#[field(primary_key = true)]
@@ -26,5 +26,5 @@ fn assert_string(_: String) {}
 fn main() {
 	let job_id = String::from("project-alpha");
 	assert_string(job_id);
-	let _load_project = Job::project;
+	let _load_project = Job::project_accessor;
 }

--- a/crates/reinhardt-core/macros/tests/ui/model/pass/native_model_without_serde.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/pass/native_model_without_serde.rs
@@ -4,7 +4,7 @@ include!("../support.rs");
 
 use db::orm::Model;
 
-#[model(table_name = "native_models")]
+#[model(app_label = "default", table_name = "native_models")]
 #[derive(Debug, Clone)]
 struct NativeModel {
 	#[field(primary_key = true)]

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -1,5 +1,6 @@
 extern crate self as reinhardt;
 extern crate self as reinhardt_core;
+extern crate self as reinhardt_db;
 
 pub mod macros {
 	pub use reinhardt_macros::Model;
@@ -232,11 +233,7 @@ pub mod db {
 		pub struct ManyToManyAccessor<Source, Target>(core::marker::PhantomData<(Source, Target)>);
 
 		impl<Source, Target> ManyToManyAccessor<Source, Target> {
-			pub fn new(
-				_source: &Source,
-				_field_name: &str,
-				_db: super::orm::connection::DatabaseConnection,
-			) -> Self {
+			pub fn new(_source: &Source, _field_name: &str) -> Self {
 				Self(core::marker::PhantomData)
 			}
 		}
@@ -305,11 +302,15 @@ pub mod db {
 			fn field_is_none(&self, field_name: &str) -> bool;
 			fn encode_database_fields(
 				&self,
-			) -> Result<std::collections::BTreeMap<String, DatabaseValue>, FieldCodecError>;
+			) -> Result<std::collections::BTreeMap<String, DatabaseValue>, FieldCodecError> {
+				Ok(std::collections::BTreeMap::new())
+			}
 			fn decode_database_field(
-				field_name: &str,
+				_field_name: &str,
 				value: DatabaseValue,
-			) -> Result<model::ModelFieldJsonValue, FieldCodecError>;
+			) -> Result<model::ModelFieldJsonValue, FieldCodecError> {
+				value.into_json_value()
+			}
 			fn validate_fixture_fields(
 				_fields: &FixtureFields,
 			) -> core::result::Result<(), String> {


### PR DESCRIPTION
## Summary

This PR addresses:

- Aligns model macro pass fixtures with the required `app_label` and `InfoModel` contracts.
- Updates the UI test harness for the `reinhardt_db` alias, two-argument many-to-many accessor, and `Model` codec defaults.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

- The release-plz PR #5708 UI Tests (5/5) job failed because these pass fixtures and the local UI-test harness lagged the current model macro contracts.

Fixes: N/A

Related to: #5708

## How Was This Tested?

- `cargo fmt --all -- --check`
- `git diff --check`
- The focused macro UI test was not run locally: Cargo began a cold dependency resolution and broad compilation, so it was stopped immediately to preserve the approximately 2.5 GiB of free disk space. CI will compile the updated fixtures.

## Performance Impact

- Not applicable; this change affects compile-time test fixtures only.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have updated the affected UI test fixtures to prove the corrected compile-time contracts
- [ ] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5708

## Labels to Apply

### Type Label (select one)

- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)

- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)

- [x] `orm` - ORM layer, models, query builder
- [ ] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

- No production macro or ORM source changed.

---

🤖 Generated with [Codex](https://openai.com/codex)
