### PR TITLE
fix(ci): restore release candidate checks

### DIFF
--- a/crates/reinhardt-core/src/reactive/runtime.rs
+++ b/crates/reinhardt-core/src/reactive/runtime.rs
@@ -444,15 +444,13 @@ impl Runtime {
 						}
 					}
 				}
-			} else if super::memo::is_memo_registered(subscriber_id) {
-				if self
+			} else if super::memo::is_memo_registered(subscriber_id)
+				&& self
 					.notification_memos_seen
 					.borrow_mut()
 					.insert(subscriber_id)
-					&& super::memo::is_memo_registered(subscriber_id)
-				{
-					super::memo::mark_memo_dirty_by_id(subscriber_id);
-				}
+			{
+				super::memo::mark_memo_dirty_by_id(subscriber_id);
 			}
 		}
 	}

--- a/crates/reinhardt-core/src/types/page.rs
+++ b/crates/reinhardt-core/src/types/page.rs
@@ -55,6 +55,7 @@ pub type PageEventHandler = Arc<dyn Fn(web_sys::Event) + 'static>;
 #[cfg(native)]
 pub type PageEventHandler = Arc<dyn Fn(NativeEvent) + 'static>;
 
+/// An attribute whose value is evaluated from reactive state when rendered.
 #[derive(Clone)]
 pub struct ReactiveAttribute {
 	name: Cow<'static, str>,
@@ -71,10 +72,12 @@ impl std::fmt::Debug for ReactiveAttribute {
 }
 
 impl ReactiveAttribute {
+	/// Returns the attribute name.
 	pub fn name(&self) -> &str {
 		&self.name
 	}
 
+	/// Evaluates and returns the current attribute value.
 	pub fn value(&self) -> Option<Cow<'static, str>> {
 		(self.render)()
 	}
@@ -616,6 +619,7 @@ impl PageElement {
 		self
 	}
 
+	/// Adds an attribute whose value is evaluated from reactive state.
 	pub fn reactive_attr<F>(mut self, name: impl Into<Cow<'static, str>>, render: F) -> Self
 	where
 		F: Fn() -> Option<Cow<'static, str>> + 'static,
@@ -739,6 +743,7 @@ impl PageElement {
 		&self.attrs
 	}
 
+	/// Returns the reactive attributes.
 	pub fn reactive_attrs(&self) -> &[ReactiveAttribute] {
 		&self.reactive_attrs
 	}
@@ -1213,7 +1218,7 @@ impl Page {
 						continue;
 					}
 					if let Some(value) = attribute.value()
-						&& !(is_boolean_attr(attribute.name()) && !is_boolean_attr_truthy(&value))
+						&& (!is_boolean_attr(attribute.name()) || is_boolean_attr_truthy(&value))
 					{
 						output.push(' ');
 						output.push_str(attribute.name());

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -1261,6 +1261,7 @@ mod case_normalization_tests {
 			attrs: input_type
 				.map(|value| vec![("type".to_owned(), value.to_owned())])
 				.unwrap_or_default(),
+			reactive_attrs: Vec::new(),
 			children: Vec::new(),
 			parent: None,
 			is_void: false,

--- a/crates/reinhardt-pages/tests/head_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/head_integration_tests.rs
@@ -81,7 +81,9 @@ fn test_head_macro_basic() {
 #[rstest]
 fn head_macro_supports_base_href() {
 	let head = head!(|| {
-		base { href: "/app/" }
+		base {
+			href: "/app/"
+		}
 		title { "Outline" }
 	});
 

--- a/crates/reinhardt-pages/tests/ssr_head_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_head_integration_tests.rs
@@ -499,7 +499,10 @@ mod ssr_tests {
 		fn leaf() -> Page {
 			let leaf_head = head!(|| {
 				title { "Leaf declaration" }
-				meta { name: "leaf-declaration", content: "present" }
+				meta {
+					name: "leaf-declaration",
+					content: "present"
+				}
 			});
 			page!(#head: leaf_head, {
 				main { "Leaf page" }

--- a/crates/reinhardt-pages/tests/ui/head/fail/base_missing_href.rs
+++ b/crates/reinhardt-pages/tests/ui/head/fail/base_missing_href.rs
@@ -1,5 +1,5 @@
 use reinhardt_pages::head;
 
 fn main() {
-	let _ = head!(|| { base { } });
+	let _ = head!(|| { base {} });
 }

--- a/crates/reinhardt-pages/tests/ui/head/fail/base_missing_href.rs
+++ b/crates/reinhardt-pages/tests/ui/head/fail/base_missing_href.rs
@@ -1,5 +1,11 @@
 use reinhardt_pages::head;
 
 fn main() {
+	// Workaround for reinhardt-web#5738.
+	// Remove this workaround when fmt-all preserves empty head blocks.
+	//
+	// Ideal implementation (without workaround):
+	//   let _ = head!(|| { base {} });
+	// reinhardt-fmt: ignore
 	let _ = head!(|| { base {} });
 }

--- a/crates/reinhardt-pages/tests/ui/head/fail/base_missing_href.stderr
+++ b/crates/reinhardt-pages/tests/ui/head/fail/base_missing_href.stderr
@@ -1,7 +1,7 @@
 error: base tag requires exactly one 'href' attribute with a value
- --> tests/ui/head/fail/base_missing_href.rs:4:10
+ --> tests/ui/head/fail/base_missing_href.rs:10:10
   |
-4 |     let _ = head!(|| { base { } });
-  |             ^^^^^^^^^^^^^^^^^^^^^^
+10 |     let _ = head!(|| { base {} });
+   |             ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `head` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-pages/tests/ui/head/pass/base.rs
+++ b/crates/reinhardt-pages/tests/ui/head/pass/base.rs
@@ -2,8 +2,12 @@ use reinhardt_pages::{Head, Page, head, page};
 
 fn main() {
 	let view: Page = page!(#head: head!(|| {
-		base { href: "/app/" }
+		base {
+			href: "/app/"
+		}
 		title { "Embedded" }
-	}), { main { "body" } });
+	}), {
+		main { "body" }
+	});
 	let _ = (view, Head::new());
 }

--- a/examples/examples-tutorial-basis/src/apps/users/models.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/models.rs
@@ -77,7 +77,7 @@ mod manager {
 	use reinhardt::DatabaseConnection;
 	use reinhardt::Model;
 	use reinhardt::core::async_trait;
-	use reinhardt::core::exception::Error;
+	use reinhardt::core::exception::{DatabaseError, DatabaseErrorKind, Error};
 	use reinhardt::di::injectable;
 	// `BaseUserManager` lives in `reinhardt-auth` and is not yet re-exported
 	// at the top level of `reinhardt`; reach it via the doc-hidden module


### PR DESCRIPTION
## Summary

This PR addresses:

- Clippy failures in the reactive attribute implementation
- A missing `reactive_attrs` field in a component test node
- Four head-management test files rejected by the repository formatter
- Missing database error imports in the tutorial-basis user manager
- A non-idempotent empty `head!` compile-fail fixture across formatter phases

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Release PR #5733 is blocked by five required checks that fail on code inherited from `develop/0.4.0`, outside the release-plz-generated diff. The fixes belong on the base branch so release-plz can regenerate the release PR after they are merged.

Fixes #5734
Fixes #5735
Fixes #5736

Related to: #5733, #5738

## How Was This Tested?

- Repository formatter checked each of the four CI-reported head test files: pass
- `rustfmt --edition 2024 --check` on all eight changed Rust files: pass
- `git diff --check origin/develop/0.4.0..HEAD`: pass
- The follow-up Format job isolated the remaining failure to the empty `head!` fixture; the fixture now uses a scoped formatter ignore linked to #5738
- Cargo check, test, Clippy, and doc commands were blocked before execution because this host is not logged in to Semgrep Guardian; GitHub Actions provides the remaining verification

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings in the directly checked source
- [x] Existing tests cover the corrected reactive attribute behavior
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (not applicable)
- [x] I have formatted the changed code with the repository formatter and rustfmt
- [ ] I have checked the full workspace with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5734
- #5735
- #5736
- #5733
- #5738

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes
- [x] `pages` - Pages runtime and test infrastructure
- [x] `examples` - Tutorial examples

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

🤖 Generated with [Codex](https://openai.com/codex)


