### PR TITLE
fix(commands): restore phase 1 CI gates

### DIFF
--- a/crates/reinhardt-commands/src/debounced_watcher.rs
+++ b/crates/reinhardt-commands/src/debounced_watcher.rs
@@ -184,6 +184,13 @@ impl Default for ServerRebuildContext<'_> {
 	}
 }
 
+/// Shared state required to rebuild one debounced path batch.
+struct WatcherRebuildContext<'a, 'b> {
+	command_context: &'a CommandContext,
+	config: &'a WatcherConfig,
+	server_rebuild_context: ServerRebuildContext<'b>,
+}
+
 /// Select rebuild pipelines for a debounced path batch.
 ///
 /// The classifier is deliberately conservative. It only suppresses a
@@ -407,9 +414,11 @@ pub async fn run_rebuild_for_paths(
 	respawn: &(impl Fn() -> std::io::Result<tokio::process::Child> + Send + Sync),
 ) {
 	run_rebuild_for_paths_for_package(
-		ctx,
-		config,
-		ServerRebuildContext::default(),
+		WatcherRebuildContext {
+			command_context: ctx,
+			config,
+			server_rebuild_context: ServerRebuildContext::default(),
+		},
 		paths,
 		current_child,
 		respawn,
@@ -422,9 +431,7 @@ pub async fn run_rebuild_for_paths(
 }
 
 async fn run_rebuild_for_paths_for_package(
-	ctx: &CommandContext,
-	config: &WatcherConfig,
-	rebuild_context: ServerRebuildContext<'_>,
+	watcher_rebuild_context: WatcherRebuildContext<'_, '_>,
 	paths: Vec<PathBuf>,
 	current_child: &mut tokio::process::Child,
 	respawn: &(impl Fn() -> std::io::Result<tokio::process::Child> + Send + Sync),
@@ -433,6 +440,12 @@ async fn run_rebuild_for_paths_for_package(
 		reinhardt_pages::hmr::PatchGeneration,
 	>,
 ) {
+	let WatcherRebuildContext {
+		command_context: ctx,
+		config,
+		server_rebuild_context: rebuild_context,
+	} = watcher_rebuild_context;
+
 	ctx.info(&format!(
 		"[hot-reload] change detected ({} path(s))",
 		paths.len()
@@ -564,10 +577,7 @@ async fn run_rebuild_for_paths_for_package(
 				config.hmr_tx.as_ref(),
 				"WASM rebuild completed successfully",
 			);
-			refresh_template_baseline_after_full_reload(
-				template_coordinator,
-				config,
-			);
+			refresh_template_baseline_after_full_reload(template_coordinator, config);
 		}
 		#[cfg(not(feature = "pages"))]
 		let _ = wasm_ok;
@@ -834,9 +844,11 @@ pub(crate) async fn run_watcher_for_package(
 						});
 					if let Some((generation, paths)) = fallback {
 						run_rebuild_for_paths_for_package(
-							ctx,
-							config,
-							rebuild_context,
+							WatcherRebuildContext {
+								command_context: ctx,
+								config,
+								server_rebuild_context: rebuild_context,
+							},
 							paths,
 							&mut current_child,
 							&respawn,
@@ -872,9 +884,11 @@ pub(crate) async fn run_watcher_for_package(
 					let patch_sent = false;
 					if !patch_sent {
 						run_rebuild_for_paths_for_package(
-							ctx,
-							config,
-							rebuild_context,
+							WatcherRebuildContext {
+								command_context: ctx,
+								config,
+								server_rebuild_context: rebuild_context,
+							},
 							paths,
 							&mut current_child,
 							&respawn,

--- a/crates/reinhardt-commands/src/template_manifest.rs
+++ b/crates/reinhardt-commands/src/template_manifest.rs
@@ -199,9 +199,10 @@ struct PageMacroCollector<'a> {
 impl<'ast> Visit<'ast> for PageMacroCollector<'_> {
 	fn visit_macro(&mut self, macro_node: &'ast syn::Macro) {
 		if is_page_macro(&macro_node.path)
-			&& let Err(error) = self.collect_macro(macro_node) {
-				self.errors.push(error);
-			}
+			&& let Err(error) = self.collect_macro(macro_node)
+		{
+			self.errors.push(error);
+		}
 		syn::visit::visit_macro(self, macro_node);
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- restores the `ci.yml` phase-1 gates on `develop/0.4.0` by applying the required command-source formatting and grouping hot-reload rebuild dependencies to satisfy clippy.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code quality improvements

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

`Format` and `Clippy` in the phase-1 CI gates failed on the branch. The context grouping keeps the rebuild behavior unchanged while reducing the helper function argument count.

## How Was This Tested?

- `cargo check --workspace --all-features --lib --tests --bins --examples --benches --quiet`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (not applicable: behavior-preserving refactor)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label

- [x] `bug` - Bug fix
- [x] `code-quality` - Code quality improvements

### Additional Labels

- [ ] `breaking-change` - Breaking change

**Additional Context:**

- No public API or runtime behavior change.

🤖 Generated with [Codex](https://openai.com/codex)

Co-Authored-By: GPT-5 <noreply@openai.com>