### PR TITLE
fix(integration): validate server function error envelope

### DIFF
--- a/tests/integration/tests/admin/server_fn_e2e_tests.rs
+++ b/tests/integration/tests/admin/server_fn_e2e_tests.rs
@@ -709,18 +709,25 @@ async fn test_e2e_get_list_fails_without_database_connection(
 	let body = String::from_utf8_lossy(&response.body);
 	let parsed: serde_json::Value = serde_json::from_str(&body)
 		.unwrap_or_else(|e| panic!("Body is not valid JSON ({e}): {body}"));
-	let server = parsed
-		.get("Server")
-		.unwrap_or_else(|| panic!("Expected top-level `Server` envelope, got: {body}"));
 	assert_eq!(
-		server.get("status").and_then(serde_json::Value::as_u64),
-		Some(500),
-		"Expected `Server.status` == 500, got: {body}"
+		parsed.get("version").and_then(serde_json::Value::as_u64),
+		Some(1),
+		"Expected versioned error envelope, got: {body}"
 	);
 	assert_eq!(
-		server.get("message").and_then(serde_json::Value::as_str),
+		parsed.get("kind").and_then(serde_json::Value::as_str),
+		Some("server"),
+		"Expected `kind` == `server`, got: {body}"
+	);
+	assert_eq!(
+		parsed.get("status").and_then(serde_json::Value::as_u64),
+		Some(500),
+		"Expected `status` == 500, got: {body}"
+	);
+	assert_eq!(
+		parsed.get("message").and_then(serde_json::Value::as_str),
 		Some("Internal server error"),
-		"Expected redacted `Server.message`, got: {body}"
+		"Expected redacted `message`, got: {body}"
 	);
 	assert!(
 		!body.contains("DatabaseConnection"),


### PR DESCRIPTION
## Summary

This PR addresses:

- validate the versioned JSON server-function error envelope in the missing-database integration scenario
- retain coverage that dependency-injection details are not exposed to clients

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The server-function response uses the v1 error envelope. The integration test still asserted the retired externally-tagged error shape, causing the Phase 2 cross-crate task to fail.

Related to: #5747

## How Was This Tested?

- `cargo nextest run -p reinhardt-commands -p reinhardt-admin-cli -p reinhardt-test-support -p reinhardt-integration-tests -p reinhardt-web --lib --all-features -E 'rdeps(=reinhardt-commands)'`\n- `cargo nextest run -p reinhardt-commands -p reinhardt-admin-cli -p reinhardt-test-support -p reinhardt-web --test '*' --all-features -E '(not binary(/ui/)) & (rdeps(=reinhardt-commands))'`\n- `cargo test -p reinhardt-commands --doc --all-features`\n- `cargo nextest run --package reinhardt-integration-tests --test admin test_e2e_get_list_fails_without_database_connection --all-features`\n- `cargo nextest run --profile ui-test --workspace -E 'binary(/ui/) & (rdeps(=reinhardt-commands))'`\n- `cargo make fmt-check`\n- `cargo clippy --package reinhardt-integration-tests --test admin --all-features -- -D warnings`\n\n## Checklist\n\n- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)\n- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)\n- [x] I have updated the documentation (if applicable)\n- [x] My changes generate no new warnings\n- [x] I have added tests that prove my fix is effective or that my feature works\n- [x] New and existing unit tests pass locally with my changes\n- [ ] I have formatted the code with `cargo make fmt-fix`\n- [ ] I have checked the code with `cargo make clippy-check`\n\n## Related Issues\n\n- #5747\n\n## Labels to Apply\n\n### Type Label (select one)\n- [x] `bug` - Bug fix\n\n### Scope Label (select all that apply)\n- [x] `admin` - Admin interface, admin panels