### PR TITLE
fix(release): restore prerelease lifecycle on develop/0.4.0

### DIFF
--- a/.github/scripts/classify-release-push.sh
+++ b/.github/scripts/classify-release-push.sh
@@ -92,6 +92,22 @@ case "$head_branch" in
 		;;
 esac
 
+case "$base_branch" in
+	main)
+		expected_release_prefix="release-plz-"
+		;;
+	develop/*)
+		expected_release_prefix="develop-release-plz-"
+		;;
+	*)
+		fail "PR #$pr_number base '$base_branch' is not a supported release branch"
+		;;
+esac
+
+if [[ "$head_branch" != "$expected_release_prefix"* ]]; then
+	fail "PR #$pr_number head '$head_branch' does not use the required '$expected_release_prefix' prefix for base '$base_branch'"
+fi
+
 expected_repo="${GITHUB_REPOSITORY:-}"
 if [ -n "$expected_repo" ] && [ "$head_repo" != "$expected_repo" ]; then
 	fail "PR #$pr_number head repository '$head_repo' does not match '$expected_repo'"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -341,7 +341,7 @@ jobs:
     # substring checks are intentionally not used for this gate.
     #
     # Accepted Release PR merge shapes:
-    # - merge commit from release-plz-* or develop-release-plz-* branch
+    # - merge commit from release-plz-* on main or develop-release-plz-* on develop/*
     # - squash commit titled "chore: release (#N)"
     if: |
       github.event_name == 'push' &&
@@ -390,19 +390,23 @@ jobs:
       - name: Verify release branch name
         env:
           BRANCH: ${{ needs.classify-release-push.outputs.release_pr_head_branch }}
+          BASE_BRANCH: ${{ github.ref_name }}
         run: |
           if [ -z "$BRANCH" ]; then
             echo "::error::Release classifier did not emit a release branch name"
             exit 1
           fi
           echo "Extracted branch name: $BRANCH"
-          case "$BRANCH" in
-            release-plz-*|develop-release-plz-*)
-              echo "Branch '$BRANCH' matches release branch pattern"
+          case "$BASE_BRANCH:$BRANCH" in
+            main:release-plz-*)
+              echo "Branch '$BRANCH' matches the main release branch pattern"
+              ;;
+            develop/*:develop-release-plz-*)
+              echo "Branch '$BRANCH' matches the develop release branch pattern"
               ;;
             *)
-              echo "::error::Branch '$BRANCH' does not start with 'release-plz-' or 'develop-release-plz-'"
-              echo "::error::This push does not originate from a release-plz branch. Refusing to publish."
+              echo "::error::Branch '$BRANCH' does not use the required release prefix for '$BASE_BRANCH'"
+              echo "::error::This push does not originate from a matching release-plz branch. Refusing to publish."
               exit 1
               ;;
           esac

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -487,79 +487,79 @@ module_name_repetitions = "allow"
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.3.2" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.4.0-alpha.1" }
 
 # Internal crates
-reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.3.2" }
-reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.3.2" }
-reinhardt-core = { path = "crates/reinhardt-core", version = "0.3.2", default-features = false }
-reinhardt-di = { path = "crates/reinhardt-di", version = "0.3.2" }
-reinhardt-http = { path = "crates/reinhardt-http", version = "0.3.2" }
-reinhardt-server = { path = "crates/reinhardt-server", version = "0.3.2" }
-reinhardt-views = { path = "crates/reinhardt-views", version = "0.3.2", default-features = false }
-reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.3.2", default-features = false }
-reinhardt-router = { path = "crates/reinhardt-router", version = "0.3.2" }
-reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.3.2", default-features = false }
-reinhardt-event-catalog = { path = "crates/reinhardt-event-catalog", version = "0.3.2" }
-reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.3.2" }
-reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.3.2" }
-reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.3.2" }
-reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.3.2" }
-reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.3.2" }
-reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.3.2" }
-reinhardt-testkit-macros = { path = "crates/reinhardt-testkit-macros", version = "0.3.2" }
-reinhardt-test = { path = "crates/reinhardt-test", version = "0.3.2" }
-reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.3.2" }
-reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.3.2" }
-reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.3.2" }
-reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.3.2", default-features = false }
-reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.3.2" }
-reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.3.2", default-features = false }
-reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.3.2" }
-reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.3.2" }
-reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.3.2" }
-reinhardt-formatter = { path = "crates/reinhardt-formatter", version = "0.3.2" }
-tree-sitter-reinhardt-page = { path = "crates/tree-sitter-reinhardt-page", version = "0.3.2" }
-tree-sitter-reinhardt-form = { path = "crates/tree-sitter-reinhardt-form", version = "0.3.2" }
-tree-sitter-reinhardt-head = { path = "crates/tree-sitter-reinhardt-head", version = "0.3.2" }
+reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.4.0-alpha.1" }
+reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.4.0-alpha.1" }
+reinhardt-core = { path = "crates/reinhardt-core", version = "0.4.0-alpha.1", default-features = false }
+reinhardt-di = { path = "crates/reinhardt-di", version = "0.4.0-alpha.1" }
+reinhardt-http = { path = "crates/reinhardt-http", version = "0.4.0-alpha.1" }
+reinhardt-server = { path = "crates/reinhardt-server", version = "0.4.0-alpha.1" }
+reinhardt-views = { path = "crates/reinhardt-views", version = "0.4.0-alpha.1", default-features = false }
+reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.4.0-alpha.1", default-features = false }
+reinhardt-router = { path = "crates/reinhardt-router", version = "0.4.0-alpha.1" }
+reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.4.0-alpha.1", default-features = false }
+reinhardt-event-catalog = { path = "crates/reinhardt-event-catalog", version = "0.4.0-alpha.1" }
+reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.4.0-alpha.1" }
+reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.4.0-alpha.1" }
+reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.4.0-alpha.1" }
+reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.4.0-alpha.1" }
+reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.4.0-alpha.1" }
+reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.4.0-alpha.1" }
+reinhardt-testkit-macros = { path = "crates/reinhardt-testkit-macros", version = "0.4.0-alpha.1" }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.4.0-alpha.1" }
+reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.4.0-alpha.1" }
+reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.4.0-alpha.1" }
+reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.4.0-alpha.1" }
+reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.4.0-alpha.1", default-features = false }
+reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.4.0-alpha.1" }
+reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.4.0-alpha.1", default-features = false }
+reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.4.0-alpha.1" }
+reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.4.0-alpha.1" }
+reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.4.0-alpha.1" }
+reinhardt-formatter = { path = "crates/reinhardt-formatter", version = "0.4.0-alpha.1" }
+tree-sitter-reinhardt-page = { path = "crates/tree-sitter-reinhardt-page", version = "0.4.0-alpha.1" }
+tree-sitter-reinhardt-form = { path = "crates/tree-sitter-reinhardt-form", version = "0.4.0-alpha.1" }
+tree-sitter-reinhardt-head = { path = "crates/tree-sitter-reinhardt-head", version = "0.4.0-alpha.1" }
 tree-sitter-reinhardt-style = { path = "crates/tree-sitter-reinhardt-style", version = "0.3.1" }
 topiary-core = "0.7.3"
 topiary-tree-sitter-facade = "0.7.3"
-reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.3.2" }
-reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.3.2" }
-reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.3.2" }
-reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.3.2", default-features = false }
-reinhardt-db = { path = "crates/reinhardt-db", version = "0.3.2", default-features = false }
-reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.3.2" }
-reinhardt-query = { path = "crates/reinhardt-query", version = "0.3.2" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.3.2" }
-reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.3.2" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.3.2" }
-reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.3.2" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.3.2" }
-reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.3.2" }
-reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.3.2" }
-reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.3.2" }
-reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.3.2" }
+reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.4.0-alpha.1" }
+reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.4.0-alpha.1" }
+reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.4.0-alpha.1" }
+reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.4.0-alpha.1", default-features = false }
+reinhardt-db = { path = "crates/reinhardt-db", version = "0.4.0-alpha.1", default-features = false }
+reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.4.0-alpha.1" }
+reinhardt-query = { path = "crates/reinhardt-query", version = "0.4.0-alpha.1" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.4.0-alpha.1" }
+reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.4.0-alpha.1" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.4.0-alpha.1" }
+reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.4.0-alpha.1" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.4.0-alpha.1" }
+reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.4.0-alpha.1" }
+reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.4.0-alpha.1" }
+reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.4.0-alpha.1" }
+reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.4.0-alpha.1" }
 
 # Feature crates (develop/0.2.0)
-reinhardt-providers = { path = "crates/reinhardt-providers", version = "0.3.2" }
-reinhardt-storages = { path = "crates/reinhardt-storages", version = "0.3.2" }
+reinhardt-providers = { path = "crates/reinhardt-providers", version = "0.4.0-alpha.1" }
+reinhardt-storages = { path = "crates/reinhardt-storages", version = "0.4.0-alpha.1" }
 
 # Query subcrates
-reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.3.2" }
+reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.4.0-alpha.1" }
 
 # Core subcrates
-reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.3.2" }
+reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.4.0-alpha.1" }
 
 # DI subcrates
-reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.3.2" }
+reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.4.0-alpha.1" }
 
 # REST subcrates
-reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.3.2" }
+reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.4.0-alpha.1" }
 
 # REST subcrates (continued)
-reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.3.2" }
+reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.4.0-alpha.1" }
 
 # Streaming
 rskafka = { version = "0.5" }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you have written `ModelSerializer` or `Depends()` before, Reinhardt will feel
 ```bash
 # Pin the documented Reinhardt release for reproducibility.
 # Omit --version to let Cargo choose the latest stable release.
-cargo install reinhardt-admin-cli --version "0.3.2"
+cargo install reinhardt-admin-cli --version "0.4.0-alpha.1"
 
 reinhardt-admin startproject my-api && cd my-api
 cargo run --bin manage runserver  # Visit http://127.0.0.1:8000
@@ -103,7 +103,7 @@ Reinhardt follows a **three-phase lifecycle** for every crate:
 | **Stable** (`0.x.0`) | Full SemVer 2.0 guarantees. |
 
 <!-- reinhardt-version-sync -->
-**Current release line:** Reinhardt documentation tracks `0.3.2`. From
+**Current release line:** Reinhardt documentation tracks `0.4.0-alpha.1`. From
 `0.1.0` onward, all public APIs follow SemVer 2.0; future breaking changes
 move through the documented alpha and RC lifecycle before stable publication.
 
@@ -131,7 +131,7 @@ Get a well-balanced feature set with zero configuration:
 [dependencies]
 # Import as 'reinhardt', published as 'reinhardt-web'
 # Default enables the "standard" preset (balanced feature set)
-reinhardt = { version = "0.3.2", package = "reinhardt-web" }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web" }
 ```
 
 **Includes:** Core, Database (PostgreSQL), REST API (serializers, parsers, pagination, filters, throttling, versioning, metadata, content negotiation), Auth, Middleware (sessions), Pages (WASM Frontend with SSR), Signals
@@ -153,7 +153,7 @@ For compatibility checks, framework development, and projects that intentionally
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", package = "reinhardt-web", default-features = false, features = ["full"] }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["full"] }
 ```
 
 **Includes:** Everything in Standard, plus Admin, GraphQL, WebSockets, Cache, i18n, Mail, Static Files, Storage, and more
@@ -167,7 +167,7 @@ Lightweight and fast, perfect for simple APIs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["minimal"] }
 ```
 
 **Includes:** HTTP, routing, DI, parameter extraction, server
@@ -182,24 +182,24 @@ Install only the components you need:
 ```toml
 [dependencies]
 # Core components
-reinhardt-http = "0.3.2"
-reinhardt-urls = "0.3.2"
+reinhardt-http = "0.4.0-alpha.1"
+reinhardt-urls = "0.4.0-alpha.1"
 
 # Optional: Database
-reinhardt-db = "0.3.2"
+reinhardt-db = "0.4.0-alpha.1"
 
 # Optional: Authentication
-reinhardt-auth = "0.3.2"
+reinhardt-auth = "0.4.0-alpha.1"
 
 # Optional: REST API features
-reinhardt-rest = "0.3.2"
+reinhardt-rest = "0.4.0-alpha.1"
 
 # Optional: Admin panel
-reinhardt-admin = "0.3.2"
+reinhardt-admin = "0.4.0-alpha.1"
 
 # Optional: Advanced features
-reinhardt-graphql = "0.3.2"
-reinhardt-websockets = "0.3.2"
+reinhardt-graphql = "0.4.0-alpha.1"
+reinhardt-websockets = "0.4.0-alpha.1"
 ```
 
 **Note on Crate Naming:**
@@ -217,7 +217,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.2"
+cargo install reinhardt-admin-cli --version "0.4.0-alpha.1"
 ```
 
 ### 2. Create a New Project
@@ -234,7 +234,7 @@ during project creation. Scripts can pass them explicitly:
 <!-- reinhardt-version-sync -->
 ```bash
 reinhardt-admin startproject my-api \
-  --reinhardt-version "0.3.2" \
+  --reinhardt-version "0.4.0-alpha.1" \
   --features standard,admin \
   --no-interactive
 ```

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin-cli"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-admin-cli/README.md
+++ b/crates/reinhardt-admin-cli/README.md
@@ -14,7 +14,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.2"
+cargo install reinhardt-admin-cli --version "0.4.0-alpha.1"
 ```
 
 This installs the `reinhardt-admin` command.
@@ -40,7 +40,7 @@ reinhardt-admin startproject myproject --with-rest /path/to/directory
 
 # Pin the generated Reinhardt dependency
 reinhardt-admin startproject myproject --with-rest \
-  --reinhardt-version 0.3.2 \
+  --reinhardt-version 0.4.0-alpha.1 \
   --features standard,admin \
   --no-interactive
 ```
@@ -58,7 +58,7 @@ reinhardt-admin configure
 
 # Update a project without prompts
 reinhardt-admin configure /path/to/project \
-  --reinhardt-version 0.3.2 \
+  --reinhardt-version 0.4.0-alpha.1 \
   --features minimal,db-sqlite \
   --no-interactive
 ```
@@ -108,7 +108,7 @@ reinhardt-admin plugin info auth-delion --remote
 
 # Install a plugin
 reinhardt-admin plugin install auth-delion
-reinhardt-admin plugin install auth-delion --version 0.3.2
+reinhardt-admin plugin install auth-delion --version 0.4.0-alpha.1
 
 # Remove a plugin
 reinhardt-admin plugin remove auth-delion

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -14,7 +14,7 @@
 //!
 //! <!-- reinhardt-version-sync -->
 //! ```bash
-//! cargo install reinhardt-admin-cli --version "0.3.2"
+//! cargo install reinhardt-admin-cli --version "0.4.0-alpha.1"
 //! ```
 //!
 //! ## Usage

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -34,10 +34,10 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:2 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["admin"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["admin"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["full"] }  # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }  # All features
 ```
 
 Then import admin features:

--- a/crates/reinhardt-apps/Cargo.toml
+++ b/crates/reinhardt-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-apps"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Application registry and management for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-apps/README.md
+++ b/crates/reinhardt-apps/README.md
@@ -19,11 +19,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", package = "reinhardt-web", features = ["apps"] }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", features = ["apps"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", package = "reinhardt-web", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", package = "reinhardt-web", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", features = ["full"] }      # All features
 ```
 
 Then import app features:
@@ -53,7 +53,7 @@ installed_apps! {
 ```toml
 [dependencies]
 reinhardt = {
-	version = "0.3.2",
+	version = "0.4.0-alpha.1",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "admin"]
 }
@@ -148,7 +148,7 @@ pub fn get_installed_apps() -> Vec<String> {
 ```toml
 [dependencies]
 reinhardt = {
-	version = "0.3.2",
+	version = "0.4.0-alpha.1",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "admin", "static-files"]
 }
@@ -240,7 +240,7 @@ pub fn get_installed_apps() -> Vec<String> {
 # Cargo.toml
 [dependencies]
 reinhardt = {
-	version = "0.3.2",
+	version = "0.4.0-alpha.1",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "database"]
 }
@@ -300,7 +300,7 @@ INSTALLED_APPS = [
 ```toml
 # Cargo.toml
 [dependencies]
-reinhardt = { version = "0.3.2", package = "reinhardt-web", features = ["auth", "admin"] }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", features = ["auth", "admin"] }
 ```
 
 ```rust

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Authentication and authorization system"
 keywords = ["auth", "jwt", "authentication", "django", "web"]
 categories = ["authentication", "web-programming"]

--- a/crates/reinhardt-auth/README.md
+++ b/crates/reinhardt-auth/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["auth"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["auth"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import authentication features:

--- a/crates/reinhardt-auth/macros/Cargo.toml
+++ b/crates/reinhardt-auth/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Procedural macros for reinhardt-auth (guard!)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-commands"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["commands"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["commands"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import command features:
@@ -39,7 +39,7 @@ package:
 ```bash
 # Pin the documented Reinhardt release for reproducibility.
 # Omit --version to let Cargo choose the latest stable release.
-cargo install reinhardt-admin-cli --version "0.3.2"
+cargo install reinhardt-admin-cli --version "0.4.0-alpha.1"
 ```
 
 This installs the `reinhardt-admin` command:
@@ -150,7 +150,7 @@ use reinhardt::commands::TemplateContext;
 
 let mut context = TemplateContext::new();
 context.insert("project_name", "my_project");
-context.insert("version", "0.3.2");
+context.insert("version", "0.4.0-alpha.1");
 context.insert("features", vec!["auth", "admin"]);  // Any Serialize type
 ```
 
@@ -380,7 +380,7 @@ Projects using `collect_migrations!` must add `linkme` as a dependency:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["standard"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }
 linkme = "0.3"
 ```
 

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-conf"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -29,11 +29,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["conf"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["conf"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import configuration features:
@@ -52,13 +52,13 @@ Enable specific features based on your needs:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 # With async support
-reinhardt = { version = "0.3.2", features = ["conf", "async"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["conf", "async"] }
 
 # With encryption
-reinhardt = { version = "0.3.2", features = ["conf", "encryption"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["conf", "encryption"] }
 
 # With Vault integration
-reinhardt = { version = "0.3.2", features = ["conf", "vault"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["conf", "vault"] }
 ```
 
 Available features:

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-core"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-core/README.md
+++ b/crates/reinhardt-core/README.md
@@ -90,7 +90,7 @@ Add this to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-core = "0.3.2"
+reinhardt-core = "0.4.0-alpha.1"
 ```
 
 ### Optional Features
@@ -100,7 +100,7 @@ Enable specific modules based on your needs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-core = { version = "0.3.2", features = ["signals", "macros", "security"] }
+reinhardt-core = { version = "0.4.0-alpha.1", features = ["signals", "macros", "security"] }
 ```
 
 Available features:

--- a/crates/reinhardt-core/macros/Cargo.toml
+++ b/crates/reinhardt-core/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db-macros/Cargo.toml
+++ b/crates/reinhardt-db-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db/Cargo.toml
+++ b/crates/reinhardt-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -207,7 +207,7 @@ Add this to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-db = "0.3.2"
+reinhardt-db = "0.4.0-alpha.1"
 ```
 
 ### Optional Features
@@ -217,7 +217,7 @@ Enable specific features based on your needs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-db = { version = "0.3.2", features = ["postgres", "orm", "migrations"] }
+reinhardt-db = { version = "0.4.0-alpha.1", features = ["postgres", "orm", "migrations"] }
 ```
 
 Available features:

--- a/crates/reinhardt-deeplink/Cargo.toml
+++ b/crates/reinhardt-deeplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-deeplink"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/Cargo.toml
+++ b/crates/reinhardt-dentdelion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dentdelion"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/README.md
+++ b/crates/reinhardt-dentdelion/README.md
@@ -22,11 +22,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["dentdelion"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["dentdelion"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import dentdelion features:
@@ -62,7 +62,7 @@ pub struct MyPlugin {
 impl MyPlugin {
     pub fn new() -> Self {
         Self {
-            metadata: PluginMetadata::builder("my-plugin", "0.3.2")
+            metadata: PluginMetadata::builder("my-plugin", "0.4.0-alpha.1")
                 .description("My custom plugin")
                 .author("Your Name")
                 .build()
@@ -225,7 +225,7 @@ Dentdelion uses the WebAssembly Interface Types (WIT) standard for plugin interf
 
 <!-- reinhardt-version-sync -->
 ```wit
-package reinhardt:dentdelion@0.3.2;
+package reinhardt:dentdelion@0.4.0-alpha.1;
 
 // Host functions available to plugins
 interface host {

--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "reinhardt-di"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-di/README.md
+++ b/crates/reinhardt-di/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["di"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["di"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import DI features:

--- a/crates/reinhardt-di/macros/Cargo.toml
+++ b/crates/reinhardt-di/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-di-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-dispatch/Cargo.toml
+++ b/crates/reinhardt-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dispatch"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dispatch/README.md
+++ b/crates/reinhardt-dispatch/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["dispatch"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["dispatch"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import dispatch features:

--- a/crates/reinhardt-event-catalog/Cargo.toml
+++ b/crates/reinhardt-event-catalog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-event-catalog"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-formatter/Cargo.toml
+++ b/crates/reinhardt-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-formatter"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-forms/Cargo.toml
+++ b/crates/reinhardt-forms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-forms"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Form handling and validation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-forms/README.md
+++ b/crates/reinhardt-forms/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["forms"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["forms"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 
 # Forms is included in the standard preset
 ```

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-graphql/README.md
+++ b/crates/reinhardt-graphql/README.md
@@ -107,11 +107,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["graphql"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["graphql"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import GraphQL features:
@@ -128,10 +128,10 @@ use reinhardt::graphql::types::{UserStorage, UserEvent};
 <!-- reinhardt-version-sync:2 -->
 ```toml
 # With dependency injection
-reinhardt = { version = "0.3.2", features = ["graphql", "di"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["graphql", "di"] }
 
 # With gRPC transport
-reinhardt = { version = "0.3.2", features = ["graphql", "grpc"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["graphql", "grpc"] }
 ```
 
 ## Examples

--- a/crates/reinhardt-graphql/macros/Cargo.toml
+++ b/crates/reinhardt-graphql/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Procedural macros for GraphQL schema generation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "gRPC support for building RPC services"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/README.md
+++ b/crates/reinhardt-grpc/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["grpc"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["grpc"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import gRPC features:
@@ -160,7 +160,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-grpc = "0.3.2"
+reinhardt-grpc = "0.4.0-alpha.1"
 tonic = "0.12"
 prost = "0.13"
 
@@ -193,7 +193,7 @@ Facade consumers can enable `grpc` alongside a preset that includes DI:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.1", package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }
 ```
 
 Direct `reinhardt-grpc` consumers can instead enable this crate's `di`

--- a/crates/reinhardt-grpc/macros/Cargo.toml
+++ b/crates/reinhardt-grpc/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-http/Cargo.toml
+++ b/crates/reinhardt-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-http"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-http/README.md
+++ b/crates/reinhardt-http/README.md
@@ -94,11 +94,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = "0.3.2"
+reinhardt = "0.4.0-alpha.1"
 
 # Or use a preset with parsers support:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 **Note:** HTTP types are available through the main `reinhardt` crate, which provides a unified interface to all framework components.

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Internationalization and localization support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-i18n/README.md
+++ b/crates/reinhardt-i18n/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["i18n"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["i18n"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import i18n features:

--- a/crates/reinhardt-mail/Cargo.toml
+++ b/crates/reinhardt-mail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-mail"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Email sending functionality with multiple backends"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-mail/README.md
+++ b/crates/reinhardt-mail/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["mail"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["mail"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import mail features:

--- a/crates/reinhardt-manouche/Cargo.toml
+++ b/crates/reinhardt-manouche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-manouche"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-middleware"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Middleware system for request/response processing pipeline"
 keywords = ["middleware", "web", "cors", "security", "http"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-middleware/README.md
+++ b/crates/reinhardt-middleware/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["middleware"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["middleware"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import middleware features:

--- a/crates/reinhardt-openapi/Cargo.toml
+++ b/crates/reinhardt-openapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/ast/Cargo.toml
+++ b/crates/reinhardt-pages/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-ast"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/macros/Cargo.toml
+++ b/crates/reinhardt-pages/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-providers/Cargo.toml
+++ b/crates/reinhardt-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-providers"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Cloud provider integrations for Reinhardt"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-query/Cargo.toml
+++ b/crates/reinhardt-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-query/README.md
+++ b/crates/reinhardt-query/README.md
@@ -45,7 +45,7 @@ Add to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-query = { version = "0.3.2" }
+reinhardt-query = { version = "0.4.0-alpha.1" }
 ```
 
 ## Quick Start

--- a/crates/reinhardt-query/macros/Cargo.toml
+++ b/crates/reinhardt-query/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-rest/Cargo.toml
+++ b/crates/reinhardt-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-rest"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "REST API framework aggregator for Reinhardt"
 keywords = ["rest", "api", "web", "framework", "django"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-rest/README.md
+++ b/crates/reinhardt-rest/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["rest"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["rest"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import REST features:

--- a/crates/reinhardt-rest/openapi-macros/Cargo.toml
+++ b/crates/reinhardt-rest/openapi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-router/Cargo.toml
+++ b/crates/reinhardt-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-router"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-server/Cargo.toml
+++ b/crates/reinhardt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-server"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-server/README.md
+++ b/crates/reinhardt-server/README.md
@@ -45,17 +45,17 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:5 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["server"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["server"] }
 
 # For WebSocket support:
-# reinhardt = { version = "0.3.2", features = ["server", "websocket"] }
+# reinhardt = { version = "0.4.0-alpha.1", features = ["server", "websocket"] }
 
 # For GraphQL support:
-# reinhardt = { version = "0.3.2", features = ["server", "graphql"] }
+# reinhardt = { version = "0.4.0-alpha.1", features = ["server", "graphql"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import server features:

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-shortcuts/README.md
+++ b/crates/reinhardt-shortcuts/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["shortcuts"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["shortcuts"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import shortcuts features:

--- a/crates/reinhardt-storages/Cargo.toml
+++ b/crates/reinhardt-storages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-storages"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition = "2024"
 authors = ["Reinhardt Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/reinhardt-streaming/Cargo.toml
+++ b/crates/reinhardt-streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-streaming"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Backend-agnostic streaming abstraction with Kafka support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-tasks/Cargo.toml
+++ b/crates/reinhardt-tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-tasks"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Background task execution and scheduling"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-tasks/README.md
+++ b/crates/reinhardt-tasks/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["tasks"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["tasks"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import task features:

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-test"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-test/README.md
+++ b/crates/reinhardt-test/README.md
@@ -31,11 +31,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["test"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["test"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import testing features:

--- a/crates/reinhardt-testkit-macros/Cargo.toml
+++ b/crates/reinhardt-testkit-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-testkit/Cargo.toml
+++ b/crates/reinhardt-testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-throttling/Cargo.toml
+++ b/crates/reinhardt-throttling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-throttling"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Throttling and rate limiting for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-urls"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-urls/README.md
+++ b/crates/reinhardt-urls/README.md
@@ -54,14 +54,14 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:4 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["urls"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["urls"] }
 
 # For specific sub-features:
-# reinhardt = { version = "0.3.2", features = ["urls-routers", "urls-proxy"] }
+# reinhardt = { version = "0.4.0-alpha.1", features = ["urls-routers", "urls-proxy"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import URLs features:

--- a/crates/reinhardt-urls/routers-macros/Cargo.toml
+++ b/crates/reinhardt-urls/routers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-routers-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-utils"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "Utility functions aggregator for Reinhardt"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-utils/README.md
+++ b/crates/reinhardt-utils/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["utils"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["utils"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import utility features:

--- a/crates/reinhardt-views/Cargo.toml
+++ b/crates/reinhardt-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-views"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "View layer aggregator for viewsets and views-core"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-views/README.md
+++ b/crates/reinhardt-views/README.md
@@ -17,11 +17,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["views"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["views"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import view features:
@@ -263,7 +263,7 @@ use reinhardt::views::{OpenAPISpec, Info, PathItem, Operation};
 
 let spec = OpenAPISpec::new(Info::new(
     "My API".into(),
-    "0.3.2".into()
+    "0.4.0-alpha.1".into()
 ));
 ```
 

--- a/crates/reinhardt-websockets/Cargo.toml
+++ b/crates/reinhardt-websockets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-websockets"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 description = "WebSocket support for real-time bidirectional communication"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-websockets/README.md
+++ b/crates/reinhardt-websockets/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", features = ["websockets"] }
+reinhardt = { version = "0.4.0-alpha.1", features = ["websockets"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.2", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.2", features = ["full"] }      # All features
+# reinhardt = { version = "0.4.0-alpha.1", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.4.0-alpha.1", features = ["full"] }      # All features
 ```
 
 Then import WebSocket features:

--- a/crates/tree-sitter-reinhardt-form/Cargo.toml
+++ b/crates/tree-sitter-reinhardt-form/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-reinhardt-form"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/tree-sitter-reinhardt-head/Cargo.toml
+++ b/crates/tree-sitter-reinhardt-head/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-reinhardt-head"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/tree-sitter-reinhardt-page/Cargo.toml
+++ b/crates/tree-sitter-reinhardt-page/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-reinhardt-page"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -35,7 +35,7 @@ By default, examples use the parent Reinhardt checkout through the examples work
 <!-- reinhardt-version-sync -->
 ```toml
 [workspace.dependencies]
-reinhardt = { path = "..", version = "0.3.2", package = "reinhardt-web" }
+reinhardt = { path = "..", version = "0.4.0-alpha.1", package = "reinhardt-web" }
 ```
 
 ### Explicit Patch Mode
@@ -69,7 +69,7 @@ rm -f .cargo/config.toml
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
-reinhardt = { version = "0.3.2", package = "reinhardt-web", features = ["core", "database"] }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine
 tokio = { workspace = true }
@@ -85,7 +85,7 @@ rstest = "0.26.1"
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", package = "reinhardt-web", features = ["core"] }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER
 reinhardt-di = { path = "../../../crates/reinhardt-di" }          # ❌ NEVER

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -35,7 +35,7 @@ By default, examples use the parent Reinhardt checkout through the examples work
 <!-- reinhardt-version-sync -->
 ```toml
 [workspace.dependencies]
-reinhardt = { path = "..", version = "0.3.2", package = "reinhardt-web" }
+reinhardt = { path = "..", version = "0.4.0-alpha.1", package = "reinhardt-web" }
 ```
 
 ### Explicit Patch Mode
@@ -69,7 +69,7 @@ rm -f .cargo/config.toml
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
-reinhardt = { version = "0.3.2", package = "reinhardt-web", features = ["core", "database"] }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine
 tokio = { workspace = true }
@@ -85,7 +85,7 @@ rstest = "0.26.1"
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.2", package = "reinhardt-web", features = ["core"] }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER
 reinhardt-di = { path = "../../../crates/reinhardt-di" }          # ❌ NEVER

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [workspace.dependencies]
 # Reinhardt framework from this repository.
 # reinhardt-version-sync
-reinhardt = { path = "..", version = "0.3.2", package = "reinhardt-web" }
+reinhardt = { path = "..", version = "0.4.0-alpha.1", package = "reinhardt-web" }
 
 # The examples workspace is resolved independently in standalone CI, so it must
 # carry the same resolver workaround as the root workspace.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -19,7 +19,7 @@ changelog_update = true
 # main's release-plz would still find and close develop's Release PRs.
 # Using "develop-release-plz-" ensures neither prefix is a prefix of the other,
 # preventing cross-branch PR closure.
-pr_branch_prefix = "release-plz-"
+pr_branch_prefix = "develop-release-plz-"
 pr_labels = ["release", "automated"]
 pr_name = "chore: release"
 
@@ -39,8 +39,10 @@ dependencies_update = true
 allow_dirty = true
 
 # Two-stage release workflow (native release-plz control):
-# - Stage 1: Push to main -> `release-plz release-pr` creates Release PR (branch: release-plz-*)
-# - Stage 2: Merge Release PR -> `release-plz release` detects commit from release-plz-* branch and publishes
+# - Stage 1: Push to develop/* -> `release-plz release-pr` creates a Release PR
+#   (branch: develop-release-plz-*)
+# - Stage 2: Merge the Release PR -> `release-plz release` detects the
+#   develop-release-plz-* branch and publishes the prerelease packages
 #
 # With release_always = true:
 # - release-plz publishes ALL crates whose local version differs from crates.io

--- a/scripts/tests/test-classify-release-push.sh
+++ b/scripts/tests/test-classify-release-push.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Validate that release branch prefixes cannot cross the main/develop boundary.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CLASSIFIER="$REPO_ROOT/.github/scripts/classify-release-push.sh"
+
+make_pr_json() {
+	local head_branch="$1"
+	local base_branch="$2"
+
+	jq -cn \
+		--arg head_branch "$head_branch" \
+		--arg base_branch "$base_branch" \
+		'{headRefName: $head_branch, headRepository: {nameWithOwner: "kent8192/reinhardt-web"}, baseRefName: $base_branch, labels: [{name: "release"}], mergeCommit: {oid: "verified-sha"}}'
+}
+
+run_classifier() {
+	local head_branch="$1"
+	local base_branch="$2"
+
+	COMMIT_MSG="Merge pull request #42 from kent8192/$head_branch" \
+	RELEASE_PUSH_PR_JSON="$(make_pr_json "$head_branch" "$base_branch")" \
+	GITHUB_REPOSITORY="kent8192/reinhardt-web" \
+	GITHUB_REF_NAME="$base_branch" \
+	GITHUB_SHA="verified-sha" \
+	bash "$CLASSIFIER"
+}
+
+assert_accepts() {
+	local head_branch="$1"
+	local base_branch="$2"
+
+	if ! run_classifier "$head_branch" "$base_branch" >/dev/null; then
+		echo "Expected $head_branch -> $base_branch to be accepted" >&2
+		exit 1
+	fi
+}
+
+assert_rejects() {
+	local head_branch="$1"
+	local base_branch="$2"
+
+	if run_classifier "$head_branch" "$base_branch" >/dev/null 2>&1; then
+		echo "Expected $head_branch -> $base_branch to be rejected" >&2
+		exit 1
+	fi
+}
+
+assert_accepts "release-plz-2026-07-20T00-00-00Z" "main"
+assert_accepts "develop-release-plz-2026-07-20T00-00-00Z" "develop/0.4.0"
+assert_rejects "release-plz-2026-07-20T00-00-00Z" "develop/0.4.0"
+assert_rejects "develop-release-plz-2026-07-20T00-00-00Z" "main"

--- a/website/config.toml
+++ b/website/config.toml
@@ -24,11 +24,11 @@ og_image    = "https://reinhardt-web.dev/og-image.png"
 github_repo = "https://github.com/kent8192/reinhardt-web"
 crates_io   = "https://crates.io/crates/reinhardt-web"
 # reinhardt-version-sync
-docs_rs     = "https://docs.rs/reinhardt-web/0.3.2/reinhardt/"
+docs_rs     = "https://docs.rs/reinhardt-web/0.4.0-alpha.1/reinhardt/"
 changelog   = "https://github.com/kent8192/reinhardt-web/blob/main/CHANGELOG.md"
 deepwiki    = "https://deepwiki.com/kent8192/reinhardt-web"
 # reinhardt-version-sync
-reinhardt_version = "0.3.2"
+reinhardt_version = "0.4.0-alpha.1"
 
 # Populated at build time by deploy-website.yml.
 # Local dev: no version selector is shown (empty versions list).

--- a/website/content/docs/api/_index.md
+++ b/website/content/docs/api/_index.md
@@ -14,7 +14,7 @@ sidebar_weight = 10
 Welcome to the Reinhardt API reference documentation. This guide provides comprehensive information about Reinhardt's APIs, modules, and components.
 
 <!-- reinhardt-version-sync -->
-> **Note**: Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.3.2/reinhardt/).
+> **Note**: Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.4.0-alpha.1/reinhardt/).
 > Comprehensive documentation is also available in each crate's `lib.rs` file.
 
 ## Reinhardt Crate Structure
@@ -936,7 +936,7 @@ Main package that re-exports all components based on feature flags.
 **Documentation:**
 
 <!-- reinhardt-version-sync -->
-- [Main documentation](https://docs.rs/reinhardt-web/0.3.2/reinhardt/)
+- [Main documentation](https://docs.rs/reinhardt-web/0.4.0-alpha.1/reinhardt/)
 - [Feature Flags Guide](/docs/feature-flags/)
 
 ## Common Patterns
@@ -1002,4 +1002,4 @@ Found an error in the documentation? Want to improve it?
 ---
 
 <!-- reinhardt-version-sync -->
-**Note**: This is a high-level overview. Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.3.2/reinhardt/). Comprehensive documentation is also available in each crate's `lib.rs` file.
+**Note**: This is a high-level overview. Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.4.0-alpha.1/reinhardt/). Comprehensive documentation is also available in each crate's `lib.rs` file.

--- a/website/content/docs/cookbook/_index.md
+++ b/website/content/docs/cookbook/_index.md
@@ -38,6 +38,6 @@ The Cookbook provides practical guides for solving common tasks.
 ## See Also
 
 <!-- reinhardt-version-sync -->
-- [API Reference](https://docs.rs/reinhardt-web/0.3.2/reinhardt/)
+- [API Reference](https://docs.rs/reinhardt-web/0.4.0-alpha.1/reinhardt/)
 - [Migration Guides](/quickstart/migration-guides/)
 - [Troubleshooting](../troubleshooting/)

--- a/website/content/docs/troubleshooting/_index.md
+++ b/website/content/docs/troubleshooting/_index.md
@@ -30,6 +30,6 @@ Troubleshooting guides provide solutions to common problems encountered during d
 ## See Also
 
 <!-- reinhardt-version-sync -->
-- [API Reference](https://docs.rs/reinhardt-web/0.3.2/reinhardt/)
+- [API Reference](https://docs.rs/reinhardt-web/0.4.0-alpha.1/reinhardt/)
 - [Cookbook](../cookbook/)
 - [Migration Guides](/quickstart/migration-guides/)

--- a/website/content/quickstart/_index.md
+++ b/website/content/quickstart/_index.md
@@ -17,7 +17,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.2"
+cargo install reinhardt-admin-cli --version "0.4.0-alpha.1"
 ```
 
 ## 2. Create your project

--- a/website/content/quickstart/getting-started.md
+++ b/website/content/quickstart/getting-started.md
@@ -31,7 +31,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.2"
+cargo install reinhardt-admin-cli --version "0.4.0-alpha.1"
 ```
 
 **Note:** After installation, the command is `reinhardt-admin`, not
@@ -381,7 +381,7 @@ Check out the [ORM documentation](/docs/api/) for more details.
 ## Getting Help
 
 <!-- reinhardt-version-sync -->
-- 📖 [API Reference](https://docs.rs/reinhardt-web/0.3.2/reinhardt/)
+- 📖 [API Reference](https://docs.rs/reinhardt-web/0.4.0-alpha.1/reinhardt/)
 - 🗺️ [DeepWiki](https://deepwiki.com/kent8192/reinhardt-web) - AI-generated codebase documentation
 - 💬 [GitHub Discussions](https://github.com/kent8192/reinhardt-web/discussions)
 - 🐛 [Report Issues](https://github.com/kent8192/reinhardt-web/issues)

--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -19,13 +19,13 @@ Use Rust 1.96.0 or newer. The generated Rust 2024 project requires that
 toolchain level.
 
 <!-- reinhardt-version-sync -->
-This tutorial uses the `0.3.2` Reinhardt generator.
+This tutorial uses the `0.4.0-alpha.1` Reinhardt generator.
 
 Install the Reinhardt project generator:
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.2"
+cargo install reinhardt-admin-cli --version "0.4.0-alpha.1"
 ```
 
 The installed binary is `reinhardt-admin`.
@@ -121,14 +121,14 @@ features used by later parts of this tutorial:
 <!-- reinhardt-version-sync -->
 ```toml
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-reinhardt = { version = "0.3.2", package = "reinhardt-web", default-features = false, features = ["pages", "client-router"] }
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", default-features = false, features = ["pages", "client-router"] }
 wasm-bindgen = "=0.2.122"
 ```
 
 <!-- reinhardt-version-sync -->
 ```toml
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reinhardt = { version = "0.3.2", package = "reinhardt-web", default-features = false, features = [
+reinhardt = { version = "0.4.0-alpha.1", package = "reinhardt-web", default-features = false, features = [
     "minimal",
     "pages",
     "client-router",

--- a/website/content/quickstart/tutorials/rest/1-project-setup.md
+++ b/website/content/quickstart/tutorials/rest/1-project-setup.md
@@ -19,7 +19,7 @@ Install `reinhardt-admin-cli` once:
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.2"
+cargo install reinhardt-admin-cli --version "0.4.0-alpha.1"
 ```
 
 The installed command is named `reinhardt-admin`.

--- a/website/content/quickstart/tutorials/rest/_index.md
+++ b/website/content/quickstart/tutorials/rest/_index.md
@@ -51,7 +51,7 @@ Install the Reinhardt project generator before starting Part 1:
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.2"
+cargo install reinhardt-admin-cli --version "0.4.0-alpha.1"
 ```
 
 After installation, the command is `reinhardt-admin`.


### PR DESCRIPTION
## Summary

This PR addresses:

- initializes the `develop/0.4.0` release stream at `0.4.0-alpha.1` across publishable workspace crates and version references;
- configures release-plz on the develop branch to create `develop-release-plz-*` branches;
- rejects release PR merges whose branch prefix does not match their `main` or `develop/*` base branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

A stable release branch and version proposal from `develop/0.4.0` could enter the publish path. Restoring the prerelease lifecycle preserves the explicit alpha → RC → stable promotion gates.

Fixes #5743

Related to: #4541

## How Was This Tested?

- [x] `cargo check -p reinhardt-web`
- [x] `cargo make fmt-check`
- [x] `scripts/tests/run-all.sh`
- [x] classifier acceptance and cross-branch rejection cases
- [x] `cargo metadata --format-version 1 --no-deps` confirms publishable packages use `0.4.0-alpha.1`
- [x] version-reference updater dry run reports no pending changes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (not applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check` (release configuration and version metadata only)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5743

## Labels to Apply

### Type Label

- [x] `bug` - Bug fix
- [x] `documentation` - Documentation update

### Scope Label

- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

The release classifier test covers both valid main/develop release branches and rejects their cross-branch equivalents.

🤖 Generated with [Codex](https://openai.com/codex)