### PR TITLE
fix(examples): format tutorial basis resource errors

### DIFF
--- a/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
+++ b/examples/examples-tutorial-basis/src/apps/polls/client/components.rs
@@ -841,7 +841,7 @@ pub fn question_edit(question_id: i64) -> Page {
 						}
 					}
 				})(),
-				ResourceState::Error(error) => {
+				ResourceState::Error(error)=> {
 					let message = error.user_message().to_owned();
 					page!(|message: String| {
 						div {
@@ -926,7 +926,7 @@ pub fn question_delete_confirm(question_id: i64) -> Page {
 							}
 						}
 					})(q),
-					ResourceState::Error(error) => {
+					ResourceState::Error(error)=> {
 						let message = error.user_message().to_owned();
 						page!(|message: String| {
 							div {


### PR DESCRIPTION
## Summary

This PR addresses:

- Corrects `page!` DSL spacing in the tutorial-basis poll resource error branches so the Examples Tests formatter gate passes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code quality improvements

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The `examples-tutorial-basis` formatting job reported two resource error arms that did not match the formatter output.

## How Was This Tested?

- `examples/examples-tutorial-basis`: `cargo make fmt-check`, `cargo make clippy-check`, `cargo build --all-features`, framework and example WASM checks, `cargo make wasm-test`, `cargo nextest run --all-features --no-tests=warn`, and `cargo test --doc --all-features`
- `examples/examples-tutorial-rest`: `cargo make fmt-check`, `cargo make clippy-check`, `cargo build --all-features`, `cargo nextest run --all-features --no-tests=warn`, and `cargo test --doc --all-features`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label

- [x] `code-quality` - Code quality improvements

**Additional Context:**

🤖 Generated with [Codex](https://openai.com/codex)