### PR TITLE
fix(pages): prevent invalid head macro doc link

### DIFF
--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -901,7 +901,7 @@ pub fn page(input: TokenStream) -> TokenStream {
 /// let html = my_head.to_html();
 /// ```
 ///
-/// `head!` produces a structural [`Head`] value. Lifecycle ownership is
+/// `head!` produces a structural `Head` value. Lifecycle ownership is
 /// established when the value is attached to a `Page` with `#head:` or
 /// supplied through route metadata; the macro does not flatten nested pages.
 #[proc_macro]

--- a/crates/reinhardt-pages/src/ui.rs
+++ b/crates/reinhardt-pages/src/ui.rs
@@ -2,12 +2,12 @@
 //!
 //! The public API consists of three concrete components:
 //!
-//! - [`crate::ui::ActionButton`] dispatches an [`Action`](crate::reactive::Action) from a
+//! - [`crate::ui::ActionButton`] dispatches an [`Action`] from a
 //!   semantic button and reflects its pending state.
 //! - [`crate::ui::ActionResultPanel`] selects idle, pending, success, or error content
 //!   from an action.
 //! - [`crate::ui::ResourcePanel`] selects loading, empty, success, or error content from
-//!   a [`Resource`](crate::reactive::Resource) or composed latest value.
+//!   a [`Resource`] or composed latest value.
 //!
 //! Shared slot and state-rendering helpers remain private to this module.
 


### PR DESCRIPTION
## Summary

This PR addresses:

- the docs.rs build failure caused by `head!` linking to `Head` from the macro crate, where that type is not in scope.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor changes external behavior)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The generated release PR #5750 exposed the invalid intra-doc link under the docs.rs warning policy. Rendering `Head` as code preserves the API description without requiring an unavailable link target.

Related to: #5750

## How Was This Tested?

- `cargo fmt --check -- crates/reinhardt-pages/macros/src/lib.rs`
- `RUSTDOCFLAGS="--cfg docsrs -D warnings" CARGO_TARGET_DIR=/tmp/cargo_target cargo +nightly doc -p reinhardt-pages-macros --all-features --no-deps`
- `RUSTDOCFLAGS="--cfg docsrs -D warnings" CARGO_TARGET_DIR=/tmp/cargo_target cargo +nightly doc --workspace --all-features --no-deps`

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5750

## Labels to Apply

- [x] `bug` - Bug fix

**Additional Context:**

The separate tutorial-basis formatter failure is already addressed by #5751.