### PR TITLE
fix(formatter): preserve match arm spacing

### DIFF
--- a/crates/reinhardt-formatter/queries/page_formatting.scm
+++ b/crates/reinhardt-formatter/queries/page_formatting.scm
@@ -141,6 +141,21 @@
   (#match? @leaf "^(=>|==|!=|<=|>=|&&|\\|\\||=|<|>|\\+|-|\\*|/|%|as\\b)")
 )
 
+; Match-arm operators are parsed as semantic elements, not direct siblings.
+(
+  [
+    (paren)
+    (bracket)
+    (string)
+    (char)
+    (raw_string)
+  ] @append_space
+  .
+  (element
+    (fragment) @leaf)
+  (#match? @leaf "^(=>|==|!=|<=|>=|&&|\\|\\||=|<|>|\\+|-|\\*|/|%|as\\b)")
+)
+
 ; Commas in parens/brackets/source get trailing space.
 (paren
   (comma) @append_space)

--- a/crates/reinhardt-formatter/src/format_engine.rs
+++ b/crates/reinhardt-formatter/src/format_engine.rs
@@ -2373,6 +2373,33 @@ fn main() {}";
 	}
 
 	#[rstest]
+	fn page_rustfmt_island_preserves_match_arm_space_after_pattern_call() {
+		// Arrange
+		let formatter = FormatEngine::new();
+		let source = r#"fn render() {
+	let view = page!(|| {
+		{
+			match resource {
+				ResourceState::Error(error) => {
+					message
+				}
+				_ => {}
+			}
+		}
+	});
+}"#;
+
+		// Act
+		let formatted = formatter.format(source).expect("format source").content;
+
+		// Assert
+		assert!(
+			formatted.contains("ResourceState::Error(error) => {"),
+			"match-arm arrow should retain a leading space after a pattern call: {formatted}"
+		);
+	}
+
+	#[rstest]
 	fn page_rustfmt_island_formats_closure_with_multiple_parameters() {
 		// Arrange / Act
 		let formatted = format_dsl(

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4732,7 +4732,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reinhardt-admin"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -4781,7 +4781,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-apps"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-commands"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "bollard",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-conf"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "base64",
  "chrono",
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-core"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-db"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -5046,7 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5079,11 +5079,11 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-event-catalog"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 
 [[package]]
 name = "reinhardt-forms"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "aquamarine",
  "chrono",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-http"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-mail"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-manouche"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-middleware"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "bon",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-ast"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-rest"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -5334,11 +5334,11 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-router"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 
 [[package]]
 name = "reinhardt-routers-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5347,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-server"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-shortcuts"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "bytes",
  "hyper",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-tasks"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "aquamarine",
  "async-trait",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-test"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5437,7 +5437,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "astral-tokio-tar",
  "async-dropper",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit-macros"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5502,7 +5502,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-throttling"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-urls"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-utils"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-views"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-web"
-version = "0.3.2"
+version = "0.4.0-alpha.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/examples/examples-tutorial-basis/Makefile.toml
+++ b/examples/examples-tutorial-basis/Makefile.toml
@@ -159,13 +159,13 @@ cargo nextest run --test "*" --all-features
 
 [tasks.fmt-check]
 description = "Check code formatting (rustfmt + page! DSL)"
-command = "reinhardt-formatter"
-args = ["fmt", ".", "--check"]
+command = "cargo"
+args = ["run", "--manifest-path", "../../Cargo.toml", "-p", "reinhardt-formatter", "--", "fmt", ".", "--check"]
 
 [tasks.fmt-fix]
 description = "Fix code formatting (rustfmt + page! DSL)"
-command = "reinhardt-formatter"
-args = ["fmt", "."]
+command = "cargo"
+args = ["run", "--manifest-path", "../../Cargo.toml", "-p", "reinhardt-formatter", "--", "fmt", "."]
 
 [tasks.clippy-check]
 description = "Check linting rules"

--- a/examples/examples-tutorial-basis/migrations/auth/0001_initial.rs
+++ b/examples/examples-tutorial-basis/migrations/auth/0001_initial.rs
@@ -18,6 +18,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 					ColumnDefinition {
 						name: "codename".to_string(),
@@ -29,6 +30,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 					ColumnDefinition {
 						name: "id".to_string(),
@@ -40,6 +42,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 					ColumnDefinition {
 						name: "name".to_string(),
@@ -51,6 +54,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 				],
 				constraints: vec![],
@@ -71,6 +75,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 					ColumnDefinition {
 						name: "id".to_string(),
@@ -82,6 +87,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 					ColumnDefinition {
 						name: "name".to_string(),
@@ -93,6 +99,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 				],
 				constraints: vec![Constraint::Unique {

--- a/examples/examples-tutorial-basis/migrations/default/0001_initial.rs
+++ b/examples/examples-tutorial-basis/migrations/default/0001_initial.rs
@@ -17,6 +17,7 @@ pub(super) fn migration() -> Migration {
 					default: None,
 
 					generated: None,
+					domain: None,
 				},
 				ColumnDefinition {
 					name: "expire_date".to_string(),
@@ -28,6 +29,7 @@ pub(super) fn migration() -> Migration {
 					default: None,
 
 					generated: None,
+					domain: None,
 				},
 				ColumnDefinition {
 					name: "last_accessed".to_string(),
@@ -39,6 +41,7 @@ pub(super) fn migration() -> Migration {
 					default: None,
 
 					generated: None,
+					domain: None,
 				},
 				ColumnDefinition {
 					name: "session_data".to_string(),
@@ -50,6 +53,7 @@ pub(super) fn migration() -> Migration {
 					default: None,
 
 					generated: None,
+					domain: None,
 				},
 				ColumnDefinition {
 					name: "session_key".to_string(),
@@ -61,6 +65,7 @@ pub(super) fn migration() -> Migration {
 					default: None,
 
 					generated: None,
+					domain: None,
 				},
 			],
 			constraints: vec![],

--- a/examples/examples-tutorial-basis/migrations/polls/0001_initial.rs
+++ b/examples/examples-tutorial-basis/migrations/polls/0001_initial.rs
@@ -18,6 +18,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 					ColumnDefinition {
 						name: "id".to_string(),
@@ -29,6 +30,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 					ColumnDefinition {
 						name: "question_id".to_string(),
@@ -40,6 +42,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 					ColumnDefinition {
 						name: "votes".to_string(),
@@ -51,6 +54,7 @@ pub(super) fn migration() -> Migration {
 						default: Some("0".to_string()),
 
 						generated: None,
+						domain: None,
 					},
 				],
 				constraints: vec![],
@@ -71,6 +75,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 					ColumnDefinition {
 						name: "pub_date".to_string(),
@@ -82,6 +87,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 					ColumnDefinition {
 						name: "question_text".to_string(),
@@ -93,6 +99,7 @@ pub(super) fn migration() -> Migration {
 						default: None,
 
 						generated: None,
+						domain: None,
 					},
 				],
 				constraints: vec![],

--- a/examples/examples-tutorial-basis/migrations/polls/0002_question_author.rs
+++ b/examples/examples-tutorial-basis/migrations/polls/0002_question_author.rs
@@ -17,6 +17,7 @@ pub(super) fn migration() -> Migration {
 				default: None,
 
 				generated: None,
+				domain: None,
 			},
 			mysql_options: None,
 		}],

--- a/examples/examples-tutorial-basis/migrations/users/0001_initial.rs
+++ b/examples/examples-tutorial-basis/migrations/users/0001_initial.rs
@@ -17,6 +17,7 @@ pub(super) fn migration() -> Migration {
 					default: None,
 
 					generated: None,
+					domain: None,
 				},
 				ColumnDefinition {
 					name: "id".to_string(),
@@ -28,6 +29,7 @@ pub(super) fn migration() -> Migration {
 					default: None,
 
 					generated: None,
+					domain: None,
 				},
 				ColumnDefinition {
 					name: "is_active".to_string(),
@@ -39,6 +41,7 @@ pub(super) fn migration() -> Migration {
 					default: Some("true".to_string()),
 
 					generated: None,
+					domain: None,
 				},
 				ColumnDefinition {
 					name: "is_superuser".to_string(),
@@ -50,6 +53,7 @@ pub(super) fn migration() -> Migration {
 					default: Some("false".to_string()),
 
 					generated: None,
+					domain: None,
 				},
 				ColumnDefinition {
 					name: "last_login".to_string(),
@@ -61,6 +65,7 @@ pub(super) fn migration() -> Migration {
 					default: None,
 
 					generated: None,
+					domain: None,
 				},
 				ColumnDefinition {
 					name: "password_hash".to_string(),
@@ -72,6 +77,7 @@ pub(super) fn migration() -> Migration {
 					default: None,
 
 					generated: None,
+					domain: None,
 				},
 				ColumnDefinition {
 					name: "username".to_string(),
@@ -83,6 +89,7 @@ pub(super) fn migration() -> Migration {
 					default: None,
 
 					generated: None,
+					domain: None,
 				},
 			],
 			constraints: vec![Constraint::Unique {


### PR DESCRIPTION
## Summary

This PR addresses:

- Corrects page! formatter spacing for match arms whose operator is parsed as a semantic element.
- Preserves `ResourceState::Error(error) => {` after pattern calls.
- Adds a regression test for the affected formatter path.
- Makes the tutorial formatter tasks build and run the formatter from this workspace, rather than a potentially stale installed binary.
- Completes tutorial migration `ColumnDefinition` values with `domain: None` and synchronizes the examples lockfile.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code quality improvements

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The formatter removed the required space before a match-arm arrow after a pattern call, producing `ResourceState::Error(error)=> {`.

The tutorial's formatter task previously used an installed binary, which could be older than the workspace source and reproduce that stale behavior. Its migration literals also needed the current optional `domain` field to compile as Rust source.

Related to: #5751

## How Was This Tested?

- `cargo fmt --check`
- `cargo test -p reinhardt-formatter`
- `cargo clippy -p reinhardt-formatter --all-targets -- -D warnings`
- `cargo make ci` in `examples/examples-tutorial-basis` (format, Clippy, build, 38 tests)
- `cargo make makemigrations-check` in `examples/examples-tutorial-basis`
- WASM compilation and non-MSW headless test passed. The MSW-enabled `cargo make wasm-test` reaches ChromeDriver but the local driver is killed with `SIGKILL` and returns HTTP 404 before test execution.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Supersedes #5751.

## Labels to Apply

### Type Label

- [x] `bug` - Bug fix

**Additional Context:**

🤖 Generated with [Codex](https://openai.com/codex)
