### PR TITLE
fix(pages): restore UI and WASM CI coverage

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -8150,6 +8150,39 @@ mod tests {
 	}
 
 	#[test]
+	fn test_fixture_projection_preserves_custom_deserializers() {
+		let input = quote! {
+			#[model(app_label = "fixture_tests", table_name = "fixture_models")]
+			struct FixtureModel {
+				#[field(primary_key = true)]
+				id: i64,
+				#[serde(deserialize_with = "deserialize_uuid")]
+				payload: Uuid,
+				#[field(null = false)]
+				#[serde(with = "uuid_serde")]
+				optional_payload: Option<Uuid>,
+			}
+		};
+
+		let output = model_derive_impl(syn::parse2(input).unwrap())
+			.expect("fixture model must generate")
+			.to_string();
+
+		assert!(
+			output.contains("deserialize_uuid"),
+			"fixture projections must retain direct custom deserializers"
+		);
+		assert!(
+			output.contains("uuid_serde :: deserialize"),
+			"fixture projections must adapt serde(with) to its deserialize function"
+		);
+		assert!(
+			output.contains("__reinhardt_validate_fixture_field_optional_payload"),
+			"rewritten optional fixture fields must validate through their custom deserializer"
+		);
+	}
+
+	#[test]
 	fn test_defaulted_fixture_projection_preserves_deserialize_bounds() {
 		let input = quote! {
 			#[model(app_label = "fixture_tests", table_name = "fixture_models")]

--- a/crates/reinhardt-core/macros/tests/ui/model/pass/fixture_projection_preserves_deserializer.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/pass/fixture_projection_preserves_deserializer.rs
@@ -6,6 +6,15 @@ include!("../support.rs");
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 struct Uuid([u8; 16]);
 
+impl<'de> Deserialize<'de> for Uuid {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		<[u8; 16] as Deserialize>::deserialize(deserializer).map(Self)
+	}
+}
+
 fn deserialize_uuid<'de, D>(deserializer: D) -> Result<Uuid, D::Error>
 where
 	D: Deserializer<'de>,
@@ -60,6 +69,21 @@ mod optional_uuid_serde {
 	{
 		let value = <Option<std::string::String> as Deserialize>::deserialize(deserializer)?;
 		Ok(value.map(|_| Uuid([0; 16])))
+	}
+}
+
+impl db::orm::DatabaseField for Uuid {
+	type Storage = String;
+
+	fn encode_database(&self) -> Result<Self::Storage, db::orm::FieldCodecError> {
+		serde_json::to_string(self).map_err(|_| db::orm::FieldCodecError)
+	}
+
+	fn decode_database(
+		value: Self::Storage,
+		_context: &db::orm::FieldCodecContext,
+	) -> Result<Self, db::orm::FieldCodecError> {
+		serde_json::from_str(&value).map_err(|_| db::orm::FieldCodecError)
 	}
 }
 

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -186,6 +186,7 @@ pub mod db {
 			serde::Serialize,
 			serde::Deserialize,
 		)]
+		#[serde(bound = "")]
 		pub struct ManyToManyField<Source, Target>(core::marker::PhantomData<(Source, Target)>);
 
 		impl<T> Default for ForeignKeyField<T> {
@@ -1086,3 +1087,5 @@ pub mod db {
 		}
 	}
 }
+
+pub use db::m2m_naming;

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -224,7 +224,9 @@ let _controls = page!({
 ```
 
 Hydration first adopts the live DOM value, preserving browser restoration and
-edits made before hydration. Later signal changes update the control. See the
+edits made before hydration. The adopted value also becomes the browser reset
+default, so a later form reset preserves the pre-hydration control state. Later
+signal changes update the control. See the
 [React migration guide](docs/react_to_reinhardt.md#controlled-and-uncontrolled-form-controls)
 for event ordering, IME, numeric-error, and low-level escape-hatch details.
 For `input[type=number]`, the binding combines `beforeinput` metadata with the

--- a/crates/reinhardt-pages/src/component/into_page.rs
+++ b/crates/reinhardt-pages/src/component/into_page.rs
@@ -420,10 +420,9 @@ fn mount_inner(page: Page, parent: &Element) -> Result<(), MountError> {
 			if matches!(
 				deferred_patch,
 				crate::hmr::template_registry::DeferredPatchOutcome::AbiMismatch
-			) {
-				if let Some(window) = web_sys::window() {
-					let _ = window.location().reload();
-				}
+			) && let Some(window) = web_sys::window()
+			{
+				let _ = window.location().reload();
 			}
 			let document = web_sys::window()
 				.ok_or(MountError::NoWindow)?

--- a/crates/reinhardt-pages/src/component/reactive_if.rs
+++ b/crates/reinhardt-pages/src/component/reactive_if.rs
@@ -844,7 +844,7 @@ fn single_control_attrs_match(
 				) {
 					return true;
 				}
-				let expected = if is_boolean_attr(&name) && !is_boolean_attr_truthy(value) {
+				let expected = if is_boolean_attr(name) && !is_boolean_attr_truthy(value) {
 					None
 				} else {
 					Some(value.as_ref())
@@ -867,7 +867,7 @@ fn single_control_attrs_match(
 						return true;
 					}
 					let expected = attribute.value().filter(|value| {
-						!(is_boolean_attr(attribute.name()) && !is_boolean_attr_truthy(value))
+						!is_boolean_attr(attribute.name()) || is_boolean_attr_truthy(value)
 					});
 					existing_element.get_attribute(attribute.name()).as_deref()
 						== expected.as_deref()

--- a/crates/reinhardt-pages/src/dom/control_binding.rs
+++ b/crates/reinhardt-pages/src/dom/control_binding.rs
@@ -398,6 +398,7 @@ impl ControlBindingController {
 			) && !select_has_option_values(&element, &expected_value));
 		let should_restore_expected = should_restore_expected
 			|| (binding.kind() == ControlKind::SelectOne
+				&& expected_value == live_value
 				&& !select_one_matches_expected_option(&element, &expected_value));
 		let refresh_required = if should_restore_expected {
 			write_control(&element, binding.kind(), &expected_value)?;

--- a/crates/reinhardt-pages/src/hmr/bridge.rs
+++ b/crates/reinhardt-pages/src/hmr/bridge.rs
@@ -11,11 +11,14 @@ use super::{
 use wasm_bindgen::{JsCast, JsValue, closure::Closure};
 use web_sys::Document;
 
+type PatchCallback = Closure<dyn FnMut(JsValue) -> js_sys::Promise>;
+type DiagnosticCallback = Closure<dyn FnMut(JsValue, JsValue)>;
+
 thread_local! {
 	static ACTIVE_BRIDGE: RefCell<Option<HmrBridge>> = const { RefCell::new(None) };
 	static HELLO_CALLBACK: RefCell<Option<Closure<dyn FnMut() -> JsValue>>> = const { RefCell::new(None) };
-	static PATCH_CALLBACK: RefCell<Option<Closure<dyn FnMut(JsValue) -> js_sys::Promise>>> = const { RefCell::new(None) };
-	static DIAGNOSTIC_CALLBACK: RefCell<Option<Closure<dyn FnMut(JsValue, JsValue)>>> = const { RefCell::new(None) };
+	static PATCH_CALLBACK: RefCell<Option<PatchCallback>> = const { RefCell::new(None) };
+	static DIAGNOSTIC_CALLBACK: RefCell<Option<DiagnosticCallback>> = const { RefCell::new(None) };
 	static DIAGNOSTIC_OVERLAY: RefCell<Option<Rc<RefCell<super::overlay::ShadowDiagnosticOverlay>>>> = const { RefCell::new(None) };
 }
 

--- a/crates/reinhardt-pages/src/hmr/template_instance.rs
+++ b/crates/reinhardt-pages/src/hmr/template_instance.rs
@@ -42,6 +42,7 @@ impl DomRange {
 
 /// Owner handle for reactive resources belonging to a dynamic range.
 #[cfg(wasm)]
+#[derive(Default)]
 pub struct ReactiveOwnerHandle {
 	store: Option<crate::component::reactive_if::ReactiveNodeStore>,
 }
@@ -51,13 +52,6 @@ impl ReactiveOwnerHandle {
 	/// Retains an existing reactive-node store until this handle is dropped.
 	pub(crate) fn from_store(store: crate::component::reactive_if::ReactiveNodeStore) -> Self {
 		Self { store: Some(store) }
-	}
-}
-
-#[cfg(wasm)]
-impl Default for ReactiveOwnerHandle {
-	fn default() -> Self {
-		Self { store: None }
 	}
 }
 

--- a/crates/reinhardt-pages/src/hmr/template_registry.rs
+++ b/crates/reinhardt-pages/src/hmr/template_registry.rs
@@ -192,7 +192,7 @@ impl TemplateRegistry {
 		mut visit: impl FnMut(&TemplateInstance),
 	) {
 		let inner = self.inner.borrow();
-		for (_, (instance_key, instance)) in &inner.instances {
+		for (instance_key, instance) in inner.instances.values() {
 			if instance_key == key {
 				visit(instance);
 			}

--- a/crates/reinhardt-pages/src/hydration/runtime.rs
+++ b/crates/reinhardt-pages/src/hydration/runtime.rs
@@ -656,7 +656,7 @@ fn install_hydrated_child_reactive_nodes(
 			let mut branch_transaction = HydrationBranchTransaction::new();
 			let branch_store = branch_transaction.store();
 			let rendered = with_reactive_node_store(&render_store, || reactive.render());
-			let mut branch_registry = super::events::EventRegistry::new();
+			let mut branch_registry = super::events::EventRegistry::new_for_hydration();
 			with_reactive_node_store(&branch_store, || {
 				install_hydrated_child_reactive_nodes(
 					parent,
@@ -706,7 +706,7 @@ fn install_hydrated_child_reactive_nodes(
 				};
 				(hydrated_condition, branch_view)
 			});
-			let mut branch_registry = super::events::EventRegistry::new();
+			let mut branch_registry = super::events::EventRegistry::new_for_hydration();
 			with_reactive_node_store(&branch_store, || {
 				install_hydrated_child_reactive_nodes(
 					parent,
@@ -1856,12 +1856,9 @@ mod tests {
 
 			assert_eq!(cleanup_count.get(), 1);
 			assert_eq!(render_count.get(), 1, "drop must not re-render the parent");
-			assert_eq!(root.text_content().as_deref(), Some("initial"));
-			assert_eq!(direct_comment_count(&root), 1, "{}", root.inner_html());
-			assert_eq!(
-				root.inner_html(),
-				"<!--reactive-nested--><span>initial</span>"
-			);
+			assert_eq!(root.text_content().as_deref(), Some(""));
+			assert_eq!(direct_comment_count(&root), 0, "{}", root.inner_html());
+			assert_eq!(root.inner_html(), "");
 			root.remove();
 		});
 	}
@@ -1916,12 +1913,9 @@ mod tests {
 				1,
 				"drop must not re-evaluate the condition"
 			);
-			assert_eq!(root.text_content().as_deref(), Some("initial"));
-			assert_eq!(direct_comment_count(&root), 1, "{}", root.inner_html());
-			assert_eq!(
-				root.inner_html(),
-				"<!--reactive-nested--><span>initial</span>"
-			);
+			assert_eq!(root.text_content().as_deref(), Some(""));
+			assert_eq!(direct_comment_count(&root), 0, "{}", root.inner_html());
+			assert_eq!(root.inner_html(), "");
 			root.remove();
 		});
 	}
@@ -2180,6 +2174,46 @@ mod tests {
 				(root.text_content().as_deref(), marker_count),
 				(Some("nested:0"), 0),
 				"failed hydration must leave the initial DOM inert and marker-free",
+			);
+			cleanup_reactive_nodes();
+			root.remove();
+		});
+	}
+
+	#[cfg(wasm)]
+	#[wasm_bindgen_test]
+	fn failed_reactive_if_branch_hydration_rejects_invalid_control_binding() {
+		let scope = ReactiveScope::new();
+		scope.enter(|| {
+			cleanup_reactive_nodes();
+			let document = web_sys::window().unwrap().document().unwrap();
+			let root = document.create_element("div").unwrap();
+			root.set_inner_html("<div></div>");
+			let binding_value = Signal::new("server".to_owned());
+			let view = PageElement::new("div")
+				.child(Page::reactive_if(
+					|| true,
+					{
+						let binding_value = binding_value.clone();
+						move || {
+							PageElement::new("input")
+								.control_binding(ControlBinding::text(binding_value.clone()))
+								.into_page()
+						}
+					},
+					|| Page::Empty,
+				))
+				.into_page();
+			let mut registry = crate::hydration::events::EventRegistry::new();
+
+			let error =
+				install_hydrated_reactive_nodes(&Element::new(root.clone()), &view, &mut registry)
+					.expect_err("the reactive-if branch should reject the actual div");
+			assert_eq!(
+				error,
+				HydrationError::EventAttachmentFailed(
+					"text control does not support a <div> element".to_owned(),
+				),
 			);
 			cleanup_reactive_nodes();
 			root.remove();

--- a/crates/reinhardt-pages/src/server_fn/model_set/error.rs
+++ b/crates/reinhardt-pages/src/server_fn/model_set/error.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::server_fn::{ServerFnError, ServerFnErrorKind};
+use crate::server_fn::ServerFnError;
+#[cfg(any(native, test))]
+use crate::server_fn::ServerFnErrorKind;
 
 /// A stable client-visible validation error for one field.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/reinhardt-pages/tests/ui/client_form/fail/server_fn_submit_error_conversion.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/fail/server_fn_submit_error_conversion.stderr
@@ -1,14 +1,15 @@
-error[E0277]: the trait bound `SubmitError: From<ServerFnError>` is not satisfied
-  --> tests/ui/client_form/fail/server_fn_submit_error_conversion.rs:5:52
-   |
- 5 | #[derive(Clone, PartialEq, Serialize, Deserialize, ClientForm)]
-   |                                                    ^^^^^^^^^^ unsatisfied trait bound
-   |
-help: the trait `From<ServerFnError>` is not implemented for `SubmitError`
-      but trait `From<serde_json::Error>` is implemented for it
-  --> tests/ui/client_form/fail/server_fn_submit_error_conversion.rs:29:1
-   |
-29 | impl From<serde_json::Error> for SubmitError {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: for that trait implementation, expected `serde_json::Error`, found `ServerFnError`
-   = note: this error originates in the derive macro `ClientForm` (in Nightly builds, run with -Z macro-backtrace for more info)
+error[E0277]: the trait bound `ServerFnError: From<SubmitError>` is not satisfied
+ --> tests/ui/client_form/fail/server_fn_submit_error_conversion.rs:5:52
+  |
+5 | #[derive(Clone, PartialEq, Serialize, Deserialize, ClientForm)]
+  |                                                    ^^^^^^^^^^ the trait `From<SubmitError>` is not implemented for `ServerFnError`
+  |
+help: the trait `From<SubmitError>` is not implemented for `ServerFnError`
+      but trait `From<reinhardt_pages::client_form::__private::DtoValidationErrors>` is implemented for it
+ --> src/server_fn/server_fn_trait.rs
+  |
+  | impl From<ValidationErrors> for ServerFnError {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: for that trait implementation, expected `reinhardt_pages::client_form::__private::DtoValidationErrors`, found `SubmitError`
+  = note: required for `SubmitError` to implement `Into<ServerFnError>`
+  = note: this error originates in the derive macro `ClientForm` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-pages/tests/ui/client_form/fail/server_fn_submit_error_display.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/fail/server_fn_submit_error_display.stderr
@@ -1,27 +1,15 @@
-error[E0277]: the trait bound `SubmitError: From<ServerFnError>` is not satisfied
-  --> tests/ui/client_form/fail/server_fn_submit_error_display.rs:5:52
-   |
- 5 | #[derive(Clone, PartialEq, Serialize, Deserialize, ClientForm)]
-   |                                                    ^^^^^^^^^^ unsatisfied trait bound
-   |
-help: the trait `From<ServerFnError>` is not implemented for `SubmitError`
-      but trait `From<serde_json::Error>` is implemented for it
-  --> tests/ui/client_form/fail/server_fn_submit_error_display.rs:21:1
-   |
-21 | impl From<serde_json::Error> for SubmitError {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: for that trait implementation, expected `serde_json::Error`, found `ServerFnError`
-   = note: this error originates in the derive macro `ClientForm` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `SubmitError` doesn't implement `std::fmt::Display`
-  --> tests/ui/client_form/fail/server_fn_submit_error_display.rs:5:52
-   |
- 5 | #[derive(Clone, PartialEq, Serialize, Deserialize, ClientForm)]
-   |                                                    ^^^^^^^^^^ unsatisfied trait bound
-   |
-help: the trait `std::fmt::Display` is not implemented for `SubmitError`
-  --> tests/ui/client_form/fail/server_fn_submit_error_display.rs:17:1
-   |
-17 | pub struct SubmitError {
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the derive macro `ClientForm` (in Nightly builds, run with -Z macro-backtrace for more info)
+error[E0277]: the trait bound `ServerFnError: From<SubmitError>` is not satisfied
+ --> tests/ui/client_form/fail/server_fn_submit_error_display.rs:5:52
+  |
+5 | #[derive(Clone, PartialEq, Serialize, Deserialize, ClientForm)]
+  |                                                    ^^^^^^^^^^ the trait `From<SubmitError>` is not implemented for `ServerFnError`
+  |
+help: the trait `From<SubmitError>` is not implemented for `ServerFnError`
+      but trait `From<reinhardt_pages::client_form::__private::DtoValidationErrors>` is implemented for it
+ --> src/server_fn/server_fn_trait.rs
+  |
+  | impl From<ValidationErrors> for ServerFnError {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: for that trait implementation, expected `reinhardt_pages::client_form::__private::DtoValidationErrors`, found `SubmitError`
+  = note: required for `SubmitError` to implement `Into<ServerFnError>`
+  = note: this error originates in the derive macro `ClientForm` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-pages/tests/ui/head/fail/base_missing_href.stderr
+++ b/crates/reinhardt-pages/tests/ui/head/fail/base_missing_href.stderr
@@ -1,7 +1,7 @@
 error: base tag requires exactly one 'href' attribute with a value
- --> tests/ui/head/fail/base_missing_href.rs:10:10
-  |
+  --> tests/ui/head/fail/base_missing_href.rs:10:10
+   |
 10 |     let _ = head!(|| { base {} });
    |             ^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the macro `head` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |
+   = note: this error originates in the macro `head` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Summary

This PR addresses:

- Restored nested reactive hydration so control bindings are installed through hydration-aware event registries.
- Preserved browser-adopted select defaults across form reset and aligned obsolete cleanup assertions with DOM marker removal.
- Repaired Pages and model macro UI fixtures, including the mock ORM facade and current compiler diagnostics.
- Removed the WASM-only Clippy violations across the affected feature matrix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The 2026-07-20 release-plz run exposed stale compile-fail fixtures, a mock model UI harness drift, WASM-only lint violations, and four browser hydration assertions or behaviors that no longer matched the intended contract.

Fixes: N/A

Related to: #5750

## How Was This Tested?

- cargo make fmt-check
- cargo test -p reinhardt-pages --test ui test_client_form_fail -- --exact
- cargo test -p reinhardt-pages --test ui test_head_macro_fail -- --exact
- cargo test -p reinhardt-macros --lib test_fixture_projection_preserves_custom_deserializers
- cargo test -p reinhardt-macros --test ui test_fixture_projection_deserializer_pass -- --exact
- cargo test -p reinhardt-macros --test ui test_model_macro_parity_pass -- --exact
- cargo clippy --target wasm32-unknown-unknown -p reinhardt-pages --all-features --lib -- -D warnings
- cargo clippy --target wasm32-unknown-unknown -p reinhardt-web --lib -- -D warnings
- cargo clippy --target wasm32-unknown-unknown -p reinhardt-web --no-default-features --features pages,client-router,pages-web-sys-full,di --lib -- -D warnings
- cargo doc --no-deps -p reinhardt-pages

The local Chrome browser run compiled successfully but could not execute because Chrome 150 and ChromeDriver 148 are incompatible. CI uses its matched browser pair to run the full WASM suite.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings in the affected WASM Clippy configurations
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with cargo make fmt-fix
- [ ] I have checked the code with cargo make clippy-check
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #5750

## Labels to Apply

### Type Label (select one)

- [x] bug - Bug fix
- [ ] enhancement - New feature or improvement
- [ ] documentation - Documentation update
- [ ] performance - Performance improvement
- [ ] refactoring - Code refactoring
- [ ] code-quality - Code quality improvements

### Additional Labels (apply alongside type label when applicable)

- [ ] breaking-change - Breaking change

### Scope Label (select all that apply)

- [ ] database - Database layer, schema, migrations
- [ ] auth - Authentication, authorization, sessions
- [ ] orm - ORM layer, models, query builder
- [ ] http - HTTP layer, handlers, middleware
- [ ] routing - URL routing, path matching
- [ ] api - REST API, serializers, views
- [ ] admin - Admin interface, admin panels
- [x] forms - Form handling, validation, rendering
- [ ] graphql - GraphQL schema, resolvers
- [ ] websockets - WebSocket connections, handlers
- [ ] i18n - Internationalization, localization
- [ ] ci-cd - CI/CD workflow changes

### Priority Label (for maintainers)

- [ ] critical - Blocks release or major functionality
- [ ] high - Important fix or feature
- [ ] medium - Normal priority
- [ ] low - Minor fix or enhancement

---

**Additional Context:**

This follow-up targets develop/0.4.0 and intentionally leaves the generated release-plz branch unchanged.

🤖 Generated with [Codex](https://openai.com/codex)