### PR TITLE
fix(ci): resolve release test regressions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -459,17 +459,17 @@ jobs:
           NEXTEST_FILTER_EXPR: ${{ inputs.nextest-filter }}
           RUN_ALL: ${{ inputs.run-all }}
         run: |
-          FILTER_ARGS=()
+          FILTER_EXPR="not binary(/ui/)"
           if [[ "$RUN_ALL" != "true" && -n "$NEXTEST_FILTER_EXPR" ]]; then
-            FILTER_ARGS+=(-E "$NEXTEST_FILTER_EXPR")
+            FILTER_EXPR="($FILTER_EXPR) & ($NEXTEST_FILTER_EXPR)"
           fi
           set +e
           cargo llvm-cov nextest \
             --no-report \
             --package reinhardt-integration-tests \
             --all-features \
-            --no-fail-fast \
-            "${FILTER_ARGS[@]}"
+            -E "$FILTER_EXPR" \
+            --no-fail-fast
           EXIT_CODE=$?
           set -e
           if [[ $EXIT_CODE -eq 4 ]]; then

--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -148,19 +148,19 @@ jobs:
           RUN_ALL: ${{ inputs.run-all }}
           PARTITION_COUNT: ${{ inputs.partition-count || '5' }}
         run: |
-          FILTER_ARGS=()
+          FILTER_EXPR="not binary(/ui/)"
           if [[ "$RUN_ALL" != "true" && -n "$NEXTEST_FILTER_EXPR" ]]; then
-            FILTER_ARGS+=(-E "$NEXTEST_FILTER_EXPR")
+            FILTER_EXPR="($FILTER_EXPR) & ($NEXTEST_FILTER_EXPR)"
           fi
           cargo nextest run \
             --package reinhardt-integration-tests \
             --all-features \
+            -E "$FILTER_EXPR" \
             --partition "hash:${{ matrix.partition }}/$PARTITION_COUNT" \
             --no-fail-fast \
             --no-tests=warn \
             --status-level=none \
-            --final-status-level=none \
-            "${FILTER_ARGS[@]}"
+            --final-status-level=none
 
       - name: Docker cleanup after tests
         if: always()

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -433,6 +433,7 @@ args = [
   "run",
   "--package",
   "reinhardt-integration-tests",
+  "-E", "not binary(/ui/)",
   "--all-features",
   "--no-fail-fast",
   "--status-level=none",

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -2532,6 +2532,25 @@ fn generate_fk_accessor_methods(
 
 			// Extract Target from ForeignKeyField<Target> or OneToOneField<Target>
 			let target_ty = extract_foreign_key_target_type(&field.ty);
+			let target_column = field.rel.as_ref().and_then(|relation| {
+				relation.to_field.as_ref().map(|target_field| {
+					quote! {
+						<#target_ty as #orm_crate::Model>::field_metadata()
+							.into_iter()
+							.find_map(|field_info| {
+								if field_info.name == #target_field {
+									Some(field_info.db_column.unwrap_or(field_info.name))
+								} else {
+									None
+								}
+							})
+							.unwrap_or_else(|| #target_field.to_string())
+					}
+				})
+			});
+			let target_column = target_column.unwrap_or_else(|| {
+				quote! { <#target_ty as #orm_crate::Model>::primary_key_column() }
+			});
 			let doc_comment = format!(
 				"Load the related '{}' instance from the database",
 				field_name_str
@@ -2549,10 +2568,10 @@ fn generate_fk_accessor_methods(
 					// Get FK _id value.
 					let fk_id = self.#fk_id_field_name();
 
-					// Query the target model using the FK primary key's database codec.
+					// Query the target model through the relation's configured target field.
 					<#target_ty as #orm_crate::Model>::objects()
 						.filter(#orm_crate::Filter::new(
-							<#target_ty as #orm_crate::Model>::primary_key_column(),
+							#target_column,
 							#orm_crate::FilterOperator::Eq,
 							#orm_crate::FilterValue::Typed(
 								<<#target_ty as #orm_crate::Model>::PrimaryKey as #orm_crate::IntoFieldValue<
@@ -7353,6 +7372,31 @@ mod tests {
 		assert!(compact.contains("into_field_value(fk_id)"));
 		assert!(compact.contains("primary_key_column()"));
 		assert!(!compact.contains("fk_id.to_string()"));
+	}
+
+	#[test]
+	fn test_foreign_key_accessor_resolves_to_field_physical_column() {
+		let input = quote! {
+			#[model(app_label = "test", table_name = "audits", info = false)]
+			pub struct Audit {
+				#[field(primary_key = true)]
+				pub id: i64,
+				#[rel(foreign_key, to_field = "external_key")]
+				pub owner: db::associations::ForeignKeyField<Account>,
+			}
+		};
+
+		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
+		let output = output.to_string();
+		let accessor = output
+			.split("pub async fn owner")
+			.nth(1)
+			.and_then(|output| output.split("pub fn owner_accessor").next())
+			.expect("foreign-key accessor must be generated");
+
+		assert!(accessor.contains("field_info . name == \"external_key\""));
+		assert!(accessor.contains("field_info . db_column . unwrap_or (field_info . name)"));
+		assert!(!accessor.contains("primary_key_column"));
 	}
 
 	#[test]

--- a/crates/reinhardt-pages/src/hydration/runtime.rs
+++ b/crates/reinhardt-pages/src/hydration/runtime.rs
@@ -1586,73 +1586,76 @@ mod tests {
 	#[cfg(wasm)]
 	#[wasm_bindgen_test]
 	fn hydration_retains_root_document_head_hook_without_rerendering_component() {
-		cleanup_reactive_nodes();
-		let document = web_sys::window().unwrap().document().unwrap();
-		let original_title = document.title();
-		let state = document.create_element("script").unwrap();
-		state.set_id("ssr-state");
-		state.set_text_content(Some("{}"));
-		document.body().unwrap().append_child(&state).unwrap();
-		let root = document.create_element("div").unwrap();
-		root.set_inner_html("hydrated root");
-		document.body().unwrap().append_child(&root).unwrap();
+		let scope = ReactiveScope::new();
+		scope.enter(|| {
+			cleanup_reactive_nodes();
+			let document = web_sys::window().unwrap().document().unwrap();
+			let original_title = document.title();
+			let state = document.create_element("script").unwrap();
+			state.set_id("ssr-state");
+			state.set_text_content(Some("{}"));
+			document.body().unwrap().append_child(&state).unwrap();
+			let root = document.create_element("div").unwrap();
+			root.set_inner_html("hydrated root");
+			document.body().unwrap().append_child(&root).unwrap();
 
-		let title = Signal::new("Initial title".to_string());
-		let render_count = Rc::new(Cell::new(0));
-		let head_factory_count = Rc::new(Cell::new(0));
-		let title_factory_count = Rc::new(Cell::new(0));
-		let component = RootHeadHydrationComponent {
-			title: title.clone(),
-			render_count: Rc::clone(&render_count),
-			head_factory_count: Rc::clone(&head_factory_count),
-			title_factory_count: Rc::clone(&title_factory_count),
-		};
+			let title = Signal::new("Initial title".to_string());
+			let render_count = Rc::new(Cell::new(0));
+			let head_factory_count = Rc::new(Cell::new(0));
+			let title_factory_count = Rc::new(Cell::new(0));
+			let component = RootHeadHydrationComponent {
+				title: title.clone(),
+				render_count: Rc::clone(&render_count),
+				head_factory_count: Rc::clone(&head_factory_count),
+				title_factory_count: Rc::clone(&title_factory_count),
+			};
 
-		hydrate(&component, &Element::new(root.clone())).expect("root hydration succeeds");
+			hydrate(&component, &Element::new(root.clone())).expect("root hydration succeeds");
 
-		assert_eq!(
-			render_count.get(),
-			1,
-			"hydration must not rerender the root component"
-		);
-		assert_eq!(head_factory_count.get(), 1);
-		assert_eq!(title_factory_count.get(), 1);
-		assert_eq!(document.title(), "Initial title");
-		assert_eq!(
-			document
-				.query_selector_all(
-					"meta[name='description'][content='Initial title'][data-reinhardt-head]"
-				)
-				.unwrap()
-				.length(),
-			1
-		);
-		title.set("Updated title".to_string());
-		with_runtime(|runtime| runtime.flush_updates());
-		assert_eq!(head_factory_count.get(), 2);
-		assert_eq!(title_factory_count.get(), 2);
-		assert_eq!(document.title(), "Updated title");
-		assert_eq!(
-			document
-				.query_selector_all(
-					"meta[name='description'][content='Updated title'][data-reinhardt-head]"
-				)
-				.unwrap()
-				.length(),
-			1
-		);
-		assert_eq!(
-			document
-				.query_selector_all("meta[name='description'][data-reinhardt-head]")
-				.unwrap()
-				.length(),
-			1
-		);
+			assert_eq!(
+				render_count.get(),
+				1,
+				"hydration must not rerender the root component"
+			);
+			assert_eq!(head_factory_count.get(), 1);
+			assert_eq!(title_factory_count.get(), 1);
+			assert_eq!(document.title(), "Initial title");
+			assert_eq!(
+				document
+					.query_selector_all(
+						"meta[name='description'][content='Initial title'][data-reinhardt-head]"
+					)
+					.unwrap()
+					.length(),
+				1
+			);
+			title.set("Updated title".to_string());
+			with_runtime(|runtime| runtime.flush_updates());
+			assert_eq!(head_factory_count.get(), 2);
+			assert_eq!(title_factory_count.get(), 2);
+			assert_eq!(document.title(), "Updated title");
+			assert_eq!(
+				document
+					.query_selector_all(
+						"meta[name='description'][content='Updated title'][data-reinhardt-head]"
+					)
+					.unwrap()
+					.length(),
+				1
+			);
+			assert_eq!(
+				document
+					.query_selector_all("meta[name='description'][data-reinhardt-head]")
+					.unwrap()
+					.length(),
+				1
+			);
 
-		cleanup_reactive_nodes();
-		state.remove();
-		root.remove();
-		document.set_title(&original_title);
+			cleanup_reactive_nodes();
+			state.remove();
+			root.remove();
+			document.set_title(&original_title);
+		});
 	}
 
 	#[cfg(wasm)]
@@ -2161,7 +2164,8 @@ mod tests {
 			assert_eq!(
 				error,
 				HydrationError::EventAttachmentFailed(
-					"text control does not support a <div> element".to_owned(),
+					"Failed to attach 'control-binding' event: text control does not support a <div> element"
+						.to_owned(),
 				),
 			);
 			nested_value.set(1);
@@ -2212,7 +2216,8 @@ mod tests {
 			assert_eq!(
 				error,
 				HydrationError::EventAttachmentFailed(
-					"text control does not support a <div> element".to_owned(),
+					"Failed to attach 'control-binding' event: text control does not support a <div> element"
+						.to_owned(),
 				),
 			);
 			cleanup_reactive_nodes();

--- a/crates/reinhardt-pages/tests/page_keyed_for_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/page_keyed_for_integration_tests.rs
@@ -29,11 +29,8 @@ fn keyed_for_lowers_to_keyed_fragment() {
 		},
 	]);
 
-	let Page::WithHead { view, .. } = view else {
-		panic!("expected page template output to retain its head wrapper");
-	};
-	let Page::Element(ul) = *view else {
-		panic!("expected head-wrapped page template body to be an element");
+	let Page::Element(ul) = view else {
+		panic!("expected page template output without a head declaration to be an element");
 	};
 	let [Page::Reactive(list)] = ul.child_views() else {
 		panic!("expected keyed for loop to be auto-wrapped as a reactive child");

--- a/crates/reinhardt-pages/tests/static_files_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/static_files_integration_tests.rs
@@ -250,8 +250,15 @@ async fn test_ssr_without_static_files() {
 		"HTML should not contain script tag with src"
 	);
 
-	// But should still have basic HTML structure
-	assert!(html.contains("<title>No Static Files</title>"));
+	// But should still include the managed page title and basic HTML structure.
+	assert!(
+		html.lines().any(|line| {
+			line.starts_with("<title data-reinhardt-head=\"")
+				&& line.ends_with("\">No Static Files</title>")
+		}),
+		"HTML should contain the managed page title.\nGenerated HTML:\n{}",
+		html
+	);
 	assert!(html.contains("<div>No static files</div>"));
 }
 

--- a/tests/integration/tests/di.rs
+++ b/tests/integration/tests/di.rs
@@ -57,7 +57,3 @@ mod provider_tests;
 
 #[path = "di/registry_tests.rs"]
 mod registry_tests;
-
-// Compile-time validation tests (trybuild)
-#[path = "di/ui.rs"]
-mod ui;

--- a/tests/integration/tests/di/ui.rs
+++ b/tests/integration/tests/di/ui.rs
@@ -2,8 +2,8 @@
 //!
 //! Tests compile-time validation of DI macros using trybuild.
 //!
-//! Note: compile-fail tests have a 300s timeout configured in `.cargo/nextest.toml`
-//! because the compiler takes significant time to produce error messages.
+//! These cases run through the dedicated `ui-test` Nextest profile because the
+//! compiler can take significant time to produce error messages.
 
 /// Test: Compile-fail cases for #[injectable]
 ///

--- a/tests/integration/tests/di_ui.rs
+++ b/tests/integration/tests/di_ui.rs
@@ -1,0 +1,7 @@
+//! DI macro compile-time integration tests.
+//!
+//! This standalone test target keeps trybuild cases on the dedicated UI-test
+//! profile instead of the default cross-crate integration-test profile.
+
+#[path = "di/ui.rs"]
+mod ui;

--- a/tests/integration/tests/macros/model_derive_integration.rs
+++ b/tests/integration/tests/macros/model_derive_integration.rs
@@ -470,8 +470,15 @@ async fn generated_relation_accessors_render_configured_physical_columns() {
 	assert!(
 		to_field_loader.calls[0]
 			.sql
-			.contains(r#"WHERE "target_external_key" = '7'"#),
+			.contains(r#"WHERE "target_external_key" = 7"#),
 		"generated to_field loader must resolve the target field's physical column: {}",
+		to_field_loader.calls[0].sql
+	);
+	assert!(
+		!to_field_loader.calls[0]
+			.sql
+			.contains(r#"WHERE "target_pk" = 7"#),
+		"generated to_field loader must not use the target primary-key column: {}",
 		to_field_loader.calls[0].sql
 	);
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Restores Pages hydration and SSR regression tests to the current runtime contracts.
- Makes generated foreign-key accessors resolve a `to_field` target's physical database column.
- Routes DI trybuild cases through a dedicated `di_ui` binary and excludes them from default cross-crate and coverage runs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The release PR CI run exposed six independent regression causes: inactive reactive scope setup, stale hydration error assertions, Page wrapper/title expectations, `to_field` physical-column lookup, and a trybuild test being routed through the default profile.

Related to: #5760

## How Was This Tested?

- `cargo test -p reinhardt-pages --test static_files_integration_tests test_ssr_without_static_files -- --exact`
- `cargo test -p reinhardt-pages --test page_keyed_for_integration_tests keyed_for_lowers_to_keyed_fragment -- --exact`
- `cargo test -p reinhardt-macros --lib test_foreign_key_accessor_resolves_to_field_physical_column`
- `cargo test -p reinhardt-integration-tests --test macros --all-features generated_relation_accessors_render_configured_physical_columns`
- `cargo nextest list` confirmed `di_ui` selects seven UI cases with `binary(/ui/)` and zero with `not binary(/ui/)`.
- `cargo fmt --check`, `git diff --check`, and `actionlint` for the changed workflows.

The WASM test compiled successfully. Its local browser run could not start because ChromeDriver 148 does not match installed Chrome 150. A full all-features Clippy run is blocked by two unchanged warnings in `crates/reinhardt-db/src/migrations/schema_editor.rs`.

## Checklist

- [x] I have followed the Contributing and Commit Guidelines.
- [x] I have updated the documentation (if applicable).
- [x] My changes generate no new warnings.
- [x] I have added or updated tests that prove the fixes are effective.
- [x] Relevant existing unit and integration tests pass locally.
- [x] I have formatted the code with `cargo fmt --check`.
- [ ] I have checked the code with `cargo make clippy-check` (blocked by unchanged base warnings).
- [ ] I use self-hosted runner for CI (Repository owner only).

## Labels to Apply

- [x] `bug`
- [x] `orm`
- [x] `ci-cd`

---

**Additional Context:**

The generated release-plz branch remains unchanged; this PR targets `develop/0.4.0` directly.

🤖 Generated with [Codex](https://openai.com/codex)