### PR TITLE
fix(ci): resolve release test regressions

### DIFF
--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -37,6 +37,7 @@ env:
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
+  SCCACHE_CACHE_SIZE: 4G
   RUST_MIN_STACK: 8388608  # 8MB - prevent stack overflow in deep async fixture chains
 
 jobs:

--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -41,6 +41,7 @@ env:
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
+  SCCACHE_CACHE_SIZE: 4G
   RUST_MIN_STACK: 8388608  # 8MB - prevent stack overflow in deep async fixture chains
 
 jobs:

--- a/crates/reinhardt-pages/src/component/reactive_if.rs
+++ b/crates/reinhardt-pages/src/component/reactive_if.rs
@@ -32,6 +32,8 @@ thread_local! {
 	static ROOT_REACTIVE_NODES: ReactiveNodeStore = Rc::new(RefCell::new(Vec::new()));
 	#[cfg(wasm)]
 	static ACTIVE_REACTIVE_NODE_STORE: RefCell<Option<ReactiveNodeStore>> = RefCell::new(None);
+	#[cfg(wasm)]
+	static HYDRATION_ROLLBACK_DEPTH: Cell<usize> = const { Cell::new(0) };
 }
 
 #[cfg(native)]
@@ -80,6 +82,40 @@ pub(crate) fn clear_reactive_node_store(store: &ReactiveNodeStore) {
 		let mut stored_nodes = store.borrow_mut();
 		std::mem::take(&mut *stored_nodes)
 	};
+}
+
+/// Drops failed hydration branch owners without removing the server-rendered DOM range.
+#[cfg(wasm)]
+pub(crate) fn clear_hydration_rollback_reactive_node_store(store: &ReactiveNodeStore) {
+	let _guard = HydrationRollbackGuard::enter();
+	clear_reactive_node_store(store);
+}
+
+#[cfg(wasm)]
+struct HydrationRollbackGuard;
+
+#[cfg(wasm)]
+impl HydrationRollbackGuard {
+	fn enter() -> Self {
+		HYDRATION_ROLLBACK_DEPTH.with(|depth| depth.set(depth.get() + 1));
+		Self
+	}
+}
+
+#[cfg(wasm)]
+impl Drop for HydrationRollbackGuard {
+	fn drop(&mut self) {
+		HYDRATION_ROLLBACK_DEPTH.with(|depth| {
+			let current_depth = depth.get();
+			debug_assert!(current_depth > 0);
+			depth.set(current_depth.saturating_sub(1));
+		});
+	}
+}
+
+#[cfg(wasm)]
+fn preserves_hydrated_dom_on_drop() -> bool {
+	HYDRATION_ROLLBACK_DEPTH.with(|depth| depth.get() > 0)
 }
 
 #[cfg(wasm)]
@@ -931,7 +967,8 @@ impl MarkerRemovalGuard {
 #[cfg(wasm)]
 impl Drop for MarkerRemovalGuard {
 	fn drop(&mut self) {
-		if let Some(start_marker) = self.start_marker.as_ref()
+		if !preserves_hydrated_dom_on_drop()
+			&& let Some(start_marker) = self.start_marker.as_ref()
 			&& remove_marker_range_from_dom(start_marker, &self.marker)
 		{
 			return;

--- a/crates/reinhardt-pages/src/hydration/runtime.rs
+++ b/crates/reinhardt-pages/src/hydration/runtime.rs
@@ -438,7 +438,9 @@ impl HydrationBranchTransaction {
 impl Drop for HydrationBranchTransaction {
 	fn drop(&mut self) {
 		if !self.committed {
-			crate::component::reactive_if::clear_reactive_node_store(&self.store);
+			crate::component::reactive_if::clear_hydration_rollback_reactive_node_store(
+				&self.store,
+			);
 		}
 	}
 }

--- a/crates/reinhardt-pages/tests/page_keyed_for_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/page_keyed_for_integration_tests.rs
@@ -8,6 +8,18 @@ struct Todo {
 	title: String,
 }
 
+fn without_hmr_template_metadata(view: Page) -> Page {
+	#[cfg(feature = "hmr")]
+	{
+		match view {
+			Page::DevTemplate { view, .. } | Page::DevSlot { view, .. } => *view,
+			view => view,
+		}
+	}
+	#[cfg(not(feature = "hmr"))]
+	view
+}
+
 #[test]
 fn keyed_for_lowers_to_keyed_fragment() {
 	let render = page!(|todos: Vec<Todo>| {
@@ -29,15 +41,18 @@ fn keyed_for_lowers_to_keyed_fragment() {
 		},
 	]);
 
-	let Page::Element(ul) = view else {
+	let Page::Element(ul) = without_hmr_template_metadata(view) else {
 		panic!("expected page template output without a head declaration to be an element");
 	};
-	let [Page::Reactive(list)] = ul.child_views() else {
+	let [child] = ul.child_views() else {
+		panic!("expected keyed for loop to be auto-wrapped as a reactive child");
+	};
+	let Page::Reactive(list) = without_hmr_template_metadata(child.clone()) else {
 		panic!("expected keyed for loop to be auto-wrapped as a reactive child");
 	};
 	let rendered_list = list.render();
 
-	let Page::KeyedFragment(children) = rendered_list else {
+	let Page::KeyedFragment(children) = without_hmr_template_metadata(rendered_list) else {
 		panic!("expected keyed for loop to lower to KeyedFragment");
 	};
 	assert_eq!(children.len(), 2);

--- a/tests/integration/tests/macros.rs
+++ b/tests/integration/tests/macros.rs
@@ -10,9 +10,6 @@ mod constraint_integration;
 #[path = "macros/http_error_integration.rs"]
 mod http_error_integration;
 
-#[path = "macros/http_error_ui.rs"]
-mod http_error_ui;
-
 #[path = "macros/model_derive_integration.rs"]
 mod model_derive_integration;
 
@@ -34,14 +31,5 @@ mod repro_issue_4522;
 #[path = "macros/model_info_integration.rs"]
 mod model_info_integration;
 
-#[path = "macros/model_info_ui.rs"]
-mod model_info_ui;
-
 #[path = "macros/model_unique_field_ref.rs"]
 mod model_unique_field_ref;
-
-#[path = "macros/model_unique_field_ref_ui.rs"]
-mod model_unique_field_ref_ui;
-
-#[path = "macros/model_enum_ui.rs"]
-mod model_enum_ui;

--- a/tests/integration/tests/macros_ui.rs
+++ b/tests/integration/tests/macros_ui.rs
@@ -1,0 +1,16 @@
+//! Macro compile-time integration tests.
+//!
+//! This standalone test target keeps trybuild cases on the dedicated UI-test
+//! profile instead of the default cross-crate integration-test profile.
+
+#[path = "macros/http_error_ui.rs"]
+mod http_error_ui;
+
+#[path = "macros/model_info_ui.rs"]
+mod model_info_ui;
+
+#[path = "macros/model_unique_field_ref_ui.rs"]
+mod model_unique_field_ref_ui;
+
+#[path = "macros/model_enum_ui.rs"]
+mod model_enum_ui;


### PR DESCRIPTION
## Summary

This PR addresses:

- routes macro trybuild suites through the dedicated `ui-test` profile
- preserves server-rendered DOM when a nested hydration branch rolls back
- handles HMR page metadata in the keyed fragment integration test
- caps sccache at 4 GiB in the heavy partitioned integration workflows

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The generated release PR #5762 exposed a trybuild timeout, a WASM hydration rollback regression, an HMR-only assertion mismatch, and a runner disk-exhaustion failure.

Related to: #5762

## How Was This Tested?

- [x] `cargo fmt --all --check`
- [x] `actionlint .github/workflows/cross-crate-integration-test.yml .github/workflows/intra-crate-integration-test.yml`
- [x] `cargo test -p reinhardt-pages --all-features --test page_keyed_for_integration_tests`
- [x] `cargo nextest run -p reinhardt-integration-tests --all-features --test macros_ui --profile ui-test` (5 passed)
- [x] WASM test compilation completed with `wasm-pack test --headless --chrome --lib --features testing`; local ChromeDriver was terminated by the host before browser tests began, so the PR CI job will execute the browser phase.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (not applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo fmt --all --check`
- [ ] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

Draft pending the full GitHub Actions verification.