### PR TITLE
feat(commands): add hooks module to Pages app template

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,18 +373,30 @@ src/
 ├── apps/
 │   ├── polls.rs                  # per-app entry (sibling of polls/)
 │   └── polls/
-│       ├── client.rs             # #[cfg(client)] aggregator: pub mod components;
+│       ├── client.rs             # #[cfg(client)] aggregator: components and hooks
 │       ├── client/
-│       │   └── components.rs     # per-app UI (placeholder() returning Page)
-│       ├── pages.rs              # target-neutral page entry points
+│       │   ├── components.rs     # per-app component aggregator
+│       │   ├── components/
+│       │   │   └── placeholder.rs # route-backed placeholder component
+│       │   └── hooks.rs          # reusable client-side custom hooks
+│       ├── models.rs             # shared models and wire-safe info types
+│       ├── serializers.rs        # serializer aggregator
+│       ├── serializers/          # (.gitkeep — user adds submodules here)
 │       ├── server.rs             # #[cfg(server)] aggregator
 │       ├── server/
 │       │   ├── admin.rs          # admin registration
-│       │   ├── models.rs         # models
-│       │   ├── serializers.rs    # serializers
-│       │   ├── models/           # (.gitkeep — user adds submodules here)
-│       │   └── serializers/      # (.gitkeep)
-│       ├── server_fn.rs          # bi-target #[server_fn] handlers (placeholder)
+│       │   ├── forms.rs          # form aggregator
+│       │   ├── forms/            # (.gitkeep — user adds submodules here)
+│       │   └── views.rs          # server-side views
+│       ├── server_fn.rs          # bi-target server-function aggregator
+│       ├── server_fn/
+│       │   └── placeholder.rs    # placeholder #[server_fn] handler
+│       ├── services.rs           # cfg-gated service aggregator
+│       ├── services/
+│       │   ├── client.rs         # client service aggregator
+│       │   ├── client/           # (.gitkeep — user adds submodules here)
+│       │   ├── server.rs         # server service aggregator
+│       │   └── server/           # (.gitkeep — user adds submodules here)
 │       ├── tests/                # (.gitkeep)
 │       ├── urls.rs               # target-neutral server/client router aggregate
 │       └── urls/

--- a/README.md
+++ b/README.md
@@ -378,7 +378,8 @@ src/
 │       │   ├── components.rs     # per-app component aggregator
 │       │   ├── components/
 │       │   │   └── placeholder.rs # route-backed placeholder component
-│       │   └── hooks.rs          # reusable client-side custom hooks
+│       │   ├── hooks.rs          # custom hook aggregator
+│       │   └── hooks/           # (.gitkeep — one custom hook per .rs file)
 │       ├── models.rs             # shared models and wire-safe info types
 │       ├── serializers.rs        # serializer aggregator
 │       ├── serializers/          # (.gitkeep — user adds submodules here)

--- a/crates/reinhardt-commands/templates/app_pages_template/client.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/client.rs.tpl
@@ -8,3 +8,4 @@
 //! `../urls/client_router.rs` as the app grows.
 
 pub mod components;
+pub mod hooks;

--- a/crates/reinhardt-commands/templates/app_pages_template/client/hooks.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/client/hooks.rs.tpl
@@ -1,0 +1,1 @@
+//! Reusable client-side custom hooks for the {{ app_name }} application.

--- a/crates/reinhardt-commands/tests/e2e_pages.rs
+++ b/crates/reinhardt-commands/tests/e2e_pages.rs
@@ -467,8 +467,16 @@ async fn app_pages_layout_matches_tutorial() {
 	let client_rs =
 		fs::read_to_string(polls_dir.join("client.rs")).expect("read apps/polls/client.rs");
 	assert!(
-		client_rs.contains("pub mod components;") && !client_rs.contains("pub mod pages;"),
+		client_rs.contains("pub mod components;")
+			&& client_rs.contains("pub mod hooks;")
+			&& !client_rs.contains("pub mod pages;"),
 		"apps/polls/client.rs must be a client-only facade, not a mixed route-entry facade:\n{client_rs}"
+	);
+	let hooks_rs = fs::read_to_string(polls_dir.join("client").join("hooks.rs"))
+		.expect("read apps/polls/client/hooks.rs");
+	assert_eq!(
+		hooks_rs,
+		"//! Reusable client-side custom hooks for the polls application.\n"
 	);
 
 	let polls_components = polls_dir.join("client").join("components.rs");
@@ -766,6 +774,18 @@ async fn workspace_app_pages_uses_unified_template() {
 	assert!(
 		src.join("client").join("components.rs").exists(),
 		"apps/bar/src/client/components.rs must exist"
+	);
+	let workspace_client_rs =
+		fs::read_to_string(src.join("client.rs")).expect("read apps/bar/src/client.rs");
+	assert!(
+		workspace_client_rs.contains("pub mod hooks;"),
+		"apps/bar/src/client.rs must declare the custom hooks module:\n{workspace_client_rs}"
+	);
+	let workspace_hooks_rs = fs::read_to_string(src.join("client").join("hooks.rs"))
+		.expect("read apps/bar/src/client/hooks.rs");
+	assert_eq!(
+		workspace_hooks_rs,
+		"//! Reusable client-side custom hooks for the bar application.\n"
 	);
 	assert!(
 		src.join("client")

--- a/crates/reinhardt-commands/tests/e2e_pages.rs
+++ b/crates/reinhardt-commands/tests/e2e_pages.rs
@@ -478,6 +478,14 @@ async fn app_pages_layout_matches_tutorial() {
 		hooks_rs,
 		"//! Reusable client-side custom hooks for the polls application.\n"
 	);
+	assert!(
+		polls_dir
+			.join("client")
+			.join("hooks")
+			.join(".gitkeep")
+			.exists(),
+		"apps/polls/client/hooks/.gitkeep must preserve the directory for one hook per Rust file"
+	);
 
 	let polls_components = polls_dir.join("client").join("components.rs");
 	assert!(
@@ -786,6 +794,10 @@ async fn workspace_app_pages_uses_unified_template() {
 	assert_eq!(
 		workspace_hooks_rs,
 		"//! Reusable client-side custom hooks for the bar application.\n"
+	);
+	assert!(
+		src.join("client").join("hooks").join(".gitkeep").exists(),
+		"apps/bar/src/client/hooks/.gitkeep must preserve the directory for one hook per Rust file"
 	);
 	assert!(
 		src.join("client")


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds a generated `client/hooks.rs` module as the canonical home for reusable custom hooks.
- Declares the hooks module for both module and workspace Pages apps.
- Extends generated-layout coverage and aligns the documented Pages app tree with the current template.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Generated Pages apps had no standard module for reusable client-side custom hooks, so applications had to invent and wire the module manually.

Fixes #5771

Related to: kent8192/reinhardt-agents-plugin#44

## How Was This Tested?

- `rustfmt --edition 2024 --check crates/reinhardt-commands/tests/e2e_pages.rs`
- `git diff --check`
- Reproduced the generated `lib.rs -> client.rs -> client/{components,hooks}.rs` layout and compiled it with `rustc --edition 2024 --crate-type lib`.
- Verified the compile check fails when `client/hooks.rs` is removed and passes again after restoration.
- Workspace e2e and clippy commands were not run because the local Semgrep Guardian hook blocked the build tool before execution due to an unauthenticated Guardian session.

## Performance Impact

No runtime performance impact. This only adds a generated empty module and test/documentation coverage.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings in the directly compiled template module
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (not applicable)
- [ ] I have run the project formatting task
- [ ] I have run the project clippy task
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5771
- Related to kent8192/reinhardt-agents-plugin#44

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `pages`

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The new template is embedded automatically by the existing template asset scanner.

🤖 Generated with [Codex](https://openai.com/codex)
