### PR TITLE
fix(pages-macros): pass bound signals by value

### DIFF
--- a/crates/reinhardt-core/src/reactive.rs
+++ b/crates/reinhardt-core/src/reactive.rs
@@ -69,4 +69,4 @@ pub use scope::{
 	NodeKey, ReactiveScope, ReactiveScopeError, ScopeId, current_scope_id, enter_scope,
 	on_scope_dispose, on_scope_dispose_after_nodes,
 };
-pub use signal::Signal;
+pub use signal::{IntoSignalHandle, Signal, copy_signal_handle};

--- a/crates/reinhardt-core/src/reactive/signal.rs
+++ b/crates/reinhardt-core/src/reactive/signal.rs
@@ -110,6 +110,29 @@ impl<T: 'static> Clone for Signal<T> {
 
 impl<T: 'static> Copy for Signal<T> {}
 
+/// Converts an owned or borrowed signal expression into its copied handle.
+pub trait IntoSignalHandle<T: 'static> {
+	/// Returns the copied signal handle.
+	fn into_signal_handle(self) -> Signal<T>;
+}
+
+impl<T: 'static> IntoSignalHandle<T> for Signal<T> {
+	fn into_signal_handle(self) -> Signal<T> {
+		self
+	}
+}
+
+impl<T: 'static> IntoSignalHandle<T> for &Signal<T> {
+	fn into_signal_handle(self) -> Signal<T> {
+		*self
+	}
+}
+
+/// Copies a reactive signal handle from either an owned or borrowed expression.
+pub fn copy_signal_handle<T: 'static>(signal: impl IntoSignalHandle<T>) -> Signal<T> {
+	signal.into_signal_handle()
+}
+
 impl<T: 'static> Signal<T> {
 	/// Create a new Signal with the given initial value
 	///

--- a/crates/reinhardt-core/src/reactive/signal.rs
+++ b/crates/reinhardt-core/src/reactive/signal.rs
@@ -128,6 +128,12 @@ impl<T: 'static> IntoSignalHandle<T> for &Signal<T> {
 	}
 }
 
+impl<T: 'static> IntoSignalHandle<T> for &mut Signal<T> {
+	fn into_signal_handle(self) -> Signal<T> {
+		*self
+	}
+}
+
 /// Copies a reactive signal handle from either an owned or borrowed expression.
 pub fn copy_signal_handle<T: 'static>(signal: impl IntoSignalHandle<T>) -> Signal<T> {
 	signal.into_signal_handle()
@@ -389,6 +395,19 @@ mod tests {
 		fn assert_copy<T: Copy>() {}
 
 		assert_copy::<Signal<i32>>();
+	}
+
+	#[rstest]
+	#[serial(reactive_runtime)]
+	fn mutable_signal_borrow_converts_to_copied_handle() {
+		crate::reactive::ReactiveScope::run(|| {
+			let mut signal = Signal::new(41_i32);
+
+			let copied = copy_signal_handle(&mut signal);
+
+			copied.set(42);
+			assert_eq!(signal.get(), 42);
+		});
 	}
 
 	#[rstest]

--- a/crates/reinhardt-pages/macros/src/page/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/page/codegen.rs
@@ -776,19 +776,19 @@ fn generate_control_binding(
 	let binding_span = binding.span;
 	let descriptor = match (&binding.kind, &binding.expression) {
 		(TypedControlBindingKind::Text, _) => {
-			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::text((#value).clone()))
+			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::text(#value))
 		}
 		(TypedControlBindingKind::Checkbox, _) => {
-			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::checkbox((#value).clone()))
+			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::checkbox(#value))
 		}
 		(TypedControlBindingKind::SelectOne, _) => {
-			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::select_one((#value).clone()))
+			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::select_one(#value))
 		}
 		(TypedControlBindingKind::SelectMany, _) => {
-			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::select_many((#value).clone()))
+			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::select_many(#value))
 		}
 		(TypedControlBindingKind::Number, TypedControlBindingExpr::Direct(_)) => {
-			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::number((#value).clone()))
+			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::number(#value))
 		}
 		(
 			TypedControlBindingKind::Number,
@@ -796,8 +796,8 @@ fn generate_control_binding(
 		) => {
 			let error = wrap_expr_with_captures(error, pages_crate, ctx);
 			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::number_with_error(
-				(#value).clone(),
-				(#error).clone()
+				#value,
+				#error
 			))
 		}
 		(TypedControlBindingKind::Radio, _) => {
@@ -807,7 +807,7 @@ fn generate_control_binding(
 				quote! { (#radio_value).to_string() }
 			});
 			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::radio(
-				(#value).clone(),
+				#value,
 				#radio_value
 			))
 		}
@@ -1855,6 +1855,52 @@ mod tests {
 			.collect();
 
 		assert_eq!(captures, vec!["visible", "selected"]);
+	}
+
+	#[test]
+	fn test_control_binding_codegen_passes_copy_signals_by_value() {
+		let input = quote::quote!(|
+			text: Signal<String>,
+			checked: Signal<bool>,
+			radio: Signal<String>,
+			amount: Signal<i32>,
+			parse_error: Signal<Option<NumberParseError>>,
+			selected: Signal<String>,
+			selected_many: Signal<Vec<String>>,
+		| {
+			div {
+				input { a11y: off, bind: text }
+				input { a11y: off, type: "checkbox", bind: checked }
+				input { a11y: off, type: "radio", value: "choice", bind: radio }
+				input { a11y: off, type: "number", bind: number(amount, parse_error) }
+				select { a11y: off, bind: selected, option { value: "one", "One" } }
+				select { a11y: off, multiple: true, bind: selected_many, option { value: "one", "One" } }
+			}
+		});
+		let untyped_ast: reinhardt_manouche::core::PageMacro = syn::parse2(input).unwrap();
+		let typed_ast = crate::page::validator::validate(&untyped_ast).unwrap();
+		let TypedPageNode::Element(root) = &typed_ast.body().nodes[0] else {
+			panic!("expected root element");
+		};
+		let ctx = CodegenContext::new(typed_ast.implicit_captures());
+		let pages_crate = quote::quote!(reinhardt_pages);
+
+		for node in &root.children {
+			let TypedPageNode::Element(element) = node else {
+				panic!("expected bound control");
+			};
+			let binding = element.control_binding.as_ref().expect("validated binding");
+			let output = generate_control_binding(
+				binding,
+				&pages_crate,
+				&ctx,
+				(binding.kind == TypedControlBindingKind::Radio)
+					.then(|| quote::quote!("choice".to_string())),
+			)
+			.to_string()
+			.replace(' ', "");
+			assert!(!output.contains(".clone()"));
+		}
 	}
 
 	#[test]

--- a/crates/reinhardt-pages/macros/src/page/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/page/codegen.rs
@@ -772,7 +772,12 @@ fn generate_control_binding(
 		TypedControlBindingExpr::Direct(value) => value,
 		TypedControlBindingExpr::NumberWithError { value, .. } => value,
 	};
-	let value = wrap_expr_with_captures(value, pages_crate, ctx);
+	let value = wrap_value_expr_with_captures(
+		quote! { #pages_crate::reactive::copy_signal_handle(#value) },
+		value,
+		pages_crate,
+		ctx,
+	);
 	let binding_span = binding.span;
 	let descriptor = match (&binding.kind, &binding.expression) {
 		(TypedControlBindingKind::Text, _) => {
@@ -794,7 +799,12 @@ fn generate_control_binding(
 			TypedControlBindingKind::Number,
 			TypedControlBindingExpr::NumberWithError { error, .. },
 		) => {
-			let error = wrap_expr_with_captures(error, pages_crate, ctx);
+			let error = wrap_value_expr_with_captures(
+				quote! { #pages_crate::reactive::copy_signal_handle(#error) },
+				error,
+				pages_crate,
+				ctx,
+			);
 			quote_spanned!(binding_span=> #pages_crate::component::ControlBinding::number_with_error(
 				#value,
 				#error

--- a/crates/reinhardt-pages/src/control_binding.rs
+++ b/crates/reinhardt-pages/src/control_binding.rs
@@ -3,6 +3,8 @@
 //! The `bind:` directive accepts [`Signal`](crate::reactive::Signal) values
 //! directly for text, checkbox, radio, and select controls. Numeric controls
 //! can additionally report rejected input through [`NumberParseError`].
+//! Binding lowering passes these `Copy` signal handles by value, so generated
+//! call sites remain clean under Clippy's `clone_on_copy` lint.
 //!
 //! # Target parity
 //!

--- a/crates/reinhardt-pages/src/reactive.rs
+++ b/crates/reinhardt-pages/src/reactive.rs
@@ -103,10 +103,10 @@
 
 // Re-export core reactive primitives from reinhardt-reactive
 pub use reinhardt_core::reactive::{
-	Context, ContextGuard, Effect, EffectTiming, ExplicitDeps, Memo, NodeId, NodeType, Observer,
-	ReactiveDeps, ReactiveScope, Runtime, Signal, batch, context, create_context, current_scope_id,
-	effect, get_context, memo, provide_context, remove_context, runtime, signal, untracked,
-	with_runtime,
+	Context, ContextGuard, Effect, EffectTiming, ExplicitDeps, IntoSignalHandle, Memo, NodeId,
+	NodeType, Observer, ReactiveDeps, ReactiveScope, Runtime, Signal, batch, context,
+	copy_signal_handle, create_context, current_scope_id, effect, get_context, memo,
+	provide_context, remove_context, runtime, signal, untracked, with_runtime,
 };
 
 // WASM-specific modules (kept in reinhardt-pages)

--- a/crates/reinhardt-pages/tests/ui/page/fail/controlled_bind_wrong_signal.stderr
+++ b/crates/reinhardt-pages/tests/ui/page/fail/controlled_bind_wrong_signal.stderr
@@ -1,20 +1,8 @@
 error[E0308]: mismatched types
   --> tests/ui/page/fail/controlled_bind_wrong_signal.rs:8:10
    |
- 5 |       let _ = page!({
-   |  _____________-
- 6 | |         input {
- 7 | |             a11y: off,
  8 | |             bind: wrong,
-   | |                   ^^^^^ expected `Signal<String>`, found `Signal<bool>`
- 9 | |         }
-10 | |     });
-   | |______- arguments to this function are incorrect
+   |                   ^^^^^ expected `Signal<String>`, found `Signal<bool>`
    |
    = note: expected struct `reinhardt_pages::Signal<std::string::String>`
               found struct `reinhardt_pages::Signal<bool>`
-note: associated function defined here
-  --> $WORKSPACE/crates/reinhardt-core/src/types/page/control_binding.rs
-   |
-   |     pub fn text(signal: Signal<String>) -> Self {
-   |            ^^^^

--- a/crates/reinhardt-pages/tests/ui/page/pass/controlled_bindings.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/controlled_bindings.rs
@@ -2,6 +2,17 @@ use reinhardt_core::types::page::NumberParseError;
 use reinhardt_pages::page;
 use reinhardt_pages::reactive::{ReactiveScope, Signal};
 
+#[derive(Clone)]
+struct Fields {
+	name: Signal<String>,
+}
+
+impl Fields {
+	fn name(&self) -> &Signal<String> {
+		&self.name
+	}
+}
+
 fn main() {
 	ReactiveScope::run(|| {
 		let text = Signal::new(String::new());
@@ -11,6 +22,9 @@ fn main() {
 		let number_error = Signal::new(None::<NumberParseError>);
 		let selected = Signal::new(String::new());
 		let selected_many = Signal::new(Vec::<String>::new());
+		let fields = Fields {
+			name: Signal::new(String::new()),
+		};
 
 		let _ = page!({
 			input {
@@ -19,7 +33,7 @@ fn main() {
 			}
 			textarea {
 				a11y: off,
-				bind: text
+				bind: fields.name()
 			}
 			input {
 				a11y: off,


### PR DESCRIPTION
## Summary

This PR addresses:

- Pass `Copy` reactive signal handles by value in every `page!` control-binding lowering path.
- Remove macro-generated `.clone()` calls that trigger `clippy::clone_on_copy` at application `bind:` spans.
- Add code-generation coverage for text, checkbox, radio, number-with-error, single-select, and multi-select bindings.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`Signal` handles became `Copy` in #5640, but `bind:` lowering continued to emit explicit clones. Strict downstream Clippy therefore attributed `clone_on_copy` failures to otherwise clean application call sites. Passing the handles directly matches the `ControlBinding` constructor APIs and preserves existing behavior.

Fixes #5775

Related to: #5640, #5676

## How Was This Tested?

- [x] `cargo test -p reinhardt-pages-macros` (423 passed)
- [x] `cargo clippy -p reinhardt-pages-macros --all-features -- -D warnings`
- [x] `cargo clippy -p reinhardt-pages --target wasm32-unknown-unknown --lib --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p reinhardt-pages --no-default-features --no-deps`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (not applicable)
- [ ] I have formatted the code with `cargo make fmt-fix` (verified with `cargo fmt --all -- --check`)
- [ ] I have checked the code with `cargo make clippy-check` (focused affected targets passed with `-D warnings`)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5775
- Related to #5640 and #5676

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `forms` - Form handling, validation, rendering

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The radio choice string still retains its required clone where ownership is shared; only `Copy` signal-handle clones were removed.

🤖 Generated with [Codex](https://openai.com/codex)
