### PR TITLE
feat(pages): retain launcher root contexts

### DIFF
--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -699,6 +699,25 @@ before exposing queryable text and roles.
 
 ## Architecture
 
+### Fresh CSR root contexts
+
+Install application-wide contexts on `ClientLauncher` so their RAII guards
+remain live for the initial render and later SPA navigations:
+
+```rust,ignore
+let i18n = I18nContext::empty("en-US", "en-US"); // Requires the `i18n` feature.
+
+ClientLauncher::new("#root")
+    .i18n_context(i18n)
+    .register_routes_from_inventory()
+    .launch()
+```
+
+For other context keys, use
+`ClientLauncher::provide_context(&context, value)`. The launcher installs all
+root contexts before lifecycle callbacks and router construction. A failed
+launch drops the guards automatically.
+
 This framework consists of several key modules:
 
 - **`reactive`**: Fine-grained reactivity system (Signal, Effect, Memo)

--- a/crates/reinhardt-pages/src/app/launcher.rs
+++ b/crates/reinhardt-pages/src/app/launcher.rs
@@ -1,8 +1,11 @@
 //! `ClientLauncher` builder, lifecycle contexts, and the `launch()` pipeline.
 
 use reinhardt_urls::routers::ClientPathPattern;
+use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
+
+use crate::reactive::{Context, ContextGuard};
 
 #[cfg(wasm)]
 use super::link_interceptor::install_link_interceptor;
@@ -48,7 +51,10 @@ thread_local! {
 	static RENDER_COUNT: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 	static PERSISTENT_LAYOUT_RENDERER: RefCell<PersistentLayoutRenderer> =
 		RefCell::new(PersistentLayoutRenderer::new());
+	static ROOT_CONTEXT_GUARDS: RefCell<Vec<Box<dyn Any>>> = const { RefCell::new(Vec::new()) };
 }
+
+type RootContextProvider = Box<dyn FnOnce() -> Box<dyn Any>>;
 
 #[cfg(wasm)]
 struct PersistentLayoutRenderer {
@@ -344,6 +350,8 @@ pub struct ClientLauncher {
 	#[cfg_attr(not(wasm), allow(dead_code))]
 	pub(super) before_launch_hooks: Vec<BeforeLaunchHook>,
 	#[cfg_attr(not(wasm), allow(dead_code))]
+	pub(super) root_context_providers: Vec<RootContextProvider>,
+	#[cfg_attr(not(wasm), allow(dead_code))]
 	pub(super) after_launch_hooks: Vec<AfterLaunchHook>,
 	#[cfg_attr(not(wasm), allow(dead_code))]
 	pub(super) path_subscriptions: Vec<PathSubscription>,
@@ -593,10 +601,41 @@ impl ClientLauncher {
 			client_router_init: None,
 			intercept_links: true,
 			before_launch_hooks: Vec::new(),
+			root_context_providers: Vec::new(),
 			after_launch_hooks: Vec::new(),
 			path_subscriptions: Vec::new(),
 			use_inventory: false,
 		}
+	}
+
+	/// Provide a root context for the lifetime of the launched application.
+	///
+	/// The context is installed after the reactive scheduler is configured and
+	/// before any `before_launch` callback or router construction. Its RAII guard
+	/// is retained for later SPA navigations. If launching fails, the guard is
+	/// dropped and the context is removed automatically.
+	pub fn provide_context<T>(mut self, context: &Context<T>, value: T) -> Self
+	where
+		T: Clone + 'static,
+	{
+		let context = *context;
+		self.root_context_providers.push(Box::new(move || {
+			Box::new(ContextGuard::new(&context, value))
+		}));
+		self
+	}
+
+	/// Provide an i18n context for the lifetime of the launched application.
+	///
+	/// This is the fresh-CSR counterpart to hydration's retained i18n context.
+	/// The context is available to the initial render, callbacks, and later SPA
+	/// route renders without an application-owned global guard.
+	#[cfg(feature = "i18n")]
+	pub fn i18n_context(mut self, context: crate::i18n::I18nContext) -> Self {
+		self.root_context_providers.push(Box::new(move || {
+			Box::new(crate::i18n::provide_i18n_context(context))
+		}));
+		self
 	}
 
 	/// Register a [`reinhardt_urls::routers::ClientRouter`] factory function.
@@ -1021,6 +1060,12 @@ impl ClientLauncher {
 			wasm_bindgen_futures::spawn_local(async move { task() });
 		});
 
+		let root_context_guards = self
+			.root_context_providers
+			.drain(..)
+			.map(|provider| provider())
+			.collect::<Vec<_>>();
+
 		// Step 3: drain before_launch callbacks before any router or DOM work.
 		for hook in self.before_launch_hooks.drain(..) {
 			hook();
@@ -1257,6 +1302,8 @@ impl ClientLauncher {
 			with_spa_router(|r| r.__diag_observer_count())
 		);
 
+		ROOT_CONTEXT_GUARDS.with(|guards| guards.borrow_mut().extend(root_context_guards));
+
 		Ok(())
 	}
 }
@@ -1321,6 +1368,57 @@ mod tests {
 		let launcher = ClientLauncher::new("#root");
 		// Assert
 		assert!(launcher.before_launch_hooks.is_empty());
+	}
+
+	#[rstest]
+	fn root_context_providers_start_empty() {
+		// Arrange / Act
+		let launcher = ClientLauncher::new("#root");
+
+		// Assert
+		assert!(launcher.root_context_providers.is_empty());
+	}
+
+	#[rstest]
+	fn provide_context_installs_context_when_launch_setup_runs() {
+		// Arrange
+		let context = crate::reactive::Context::new();
+		let mut launcher = ClientLauncher::new("#root").provide_context(&context, 42);
+
+		// Act
+		let guards = launcher
+			.root_context_providers
+			.drain(..)
+			.map(|provider| provider())
+			.collect::<Vec<_>>();
+
+		// Assert
+		assert_eq!(crate::reactive::get_context(&context), Some(42));
+		drop(guards);
+		assert_eq!(crate::reactive::get_context(&context), None);
+	}
+
+	#[rstest]
+	#[cfg(feature = "i18n")]
+	fn i18n_context_installs_context_when_launch_setup_runs() {
+		// Arrange
+		let context = crate::i18n::I18nContext::empty("en-US", "en-US");
+		let mut launcher = ClientLauncher::new("#root").i18n_context(context.clone());
+
+		// Act
+		let guards = launcher
+			.root_context_providers
+			.drain(..)
+			.map(|provider| provider())
+			.collect::<Vec<_>>();
+
+		// Assert
+		assert_eq!(
+			crate::i18n::use_i18n_context().map(|context| context.locale()),
+			Some(context.locale())
+		);
+		drop(guards);
+		assert!(crate::i18n::use_i18n_context().is_none());
 	}
 
 	#[rstest]


### PR DESCRIPTION
## Summary

This PR addresses:

- adds `ClientLauncher::provide_context` for typed root contexts retained across SPA navigations
- adds feature-gated `ClientLauncher::i18n_context` for fresh CSR applications
- documents fresh CSR setup and verifies guard installation and RAII cleanup

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Fresh CSR applications previously had to keep a `ContextGuard` in application-global storage or leak it. Launcher-owned guards now stay active for the initial render, callbacks, and later route construction while retaining RAII cleanup on launch failure.

Fixes #5779

Related to: #3996, #5590, #5772

## How Was This Tested?

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p reinhardt-pages app::launcher --lib` (25 passed)
- `cargo test -p reinhardt-pages --all-features app::launcher::tests::i18n_context_installs_context_when_launch_setup_runs --lib` (1 passed)
- `cargo check -p reinhardt-pages --all-features`
- `cargo doc -p reinhardt-pages --all-features --no-deps`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5779

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `i18n` - Internationalization, localization

---

**Additional Context:**

The generic API accepts a `Context<T>` key and value. The i18n convenience API is available with the `i18n` feature.
