### PR TITLE
feat(pages): expose i18n APIs through facade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,6 +387,7 @@ cfg_aliases = "0.2"
 
 [dev-dependencies]
 rstest = { workspace = true }
+serial_test = { workspace = true }
 
 [workspace]
 resolver = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ include = [
 [lib]
 name = "reinhardt"
 
+[[test]]
+name = "pages_i18n_facade"
+required-features = ["pages", "i18n"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -354,8 +354,8 @@ locale and later locale switches update reactive snapshots without explicitly
 threading a resource through each component.
 
 ```rust,ignore
-use reinhardt::pages::i18n::{I18nContext, MessageCatalog, TranslationContext};
-use reinhardt::pages::prelude::*;
+use reinhardt_pages::i18n::{I18nContext, MessageCatalog, TranslationContext};
+use reinhardt_pages::prelude::*;
 
 let mut translations = TranslationContext::new("ja", "en-US");
 let mut ja = MessageCatalog::new("ja");
@@ -847,7 +847,7 @@ transparent; streaming metadata is emitted outside the branch DOM.
 
 ### I18n
 - Reactive Pages API: `I18nContext`, `I18nStateError`, `TranslatedText`, `tr`, `tn`, `tp`, `tnp`
-- Catalog and global API: `MessageCatalog`, `TranslationContext`, `I18nError`, `LazyString`, `TranslationGuard`, and the functions under `reinhardt::pages::i18n`
+- Catalog and global API: `MessageCatalog`, `TranslationContext`, `I18nError`, `LazyString`, `TranslationGuard`, and the functions under `reinhardt_pages::i18n`
 
 ### Forms (native only)
 - `FormBinding`, `FormComponent`

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -354,8 +354,8 @@ locale and later locale switches update reactive snapshots without explicitly
 threading a resource through each component.
 
 ```rust,ignore
-use reinhardt_i18n::{MessageCatalog, TranslationContext};
-use reinhardt_pages::prelude::*;
+use reinhardt::pages::i18n::{I18nContext, MessageCatalog, TranslationContext};
+use reinhardt::pages::prelude::*;
 
 let mut translations = TranslationContext::new("ja", "en-US");
 let mut ja = MessageCatalog::new("ja");
@@ -846,9 +846,8 @@ the same key order. Suspense boundaries keep fallback and content roots
 transparent; streaming metadata is emitted outside the branch DOM.
 
 ### I18n
-- `I18nContext`, `I18nStateError`, `TranslatedText`, `tr`, `tn`, `tp`, `tnp`
-- `provide_i18n_context`, `use_i18n_context`, `set_locale`, `locale`
-- `with_i18n_context`
+- Reactive Pages API: `I18nContext`, `I18nStateError`, `TranslatedText`, `tr`, `tn`, `tp`, `tnp`
+- Catalog and global API: `MessageCatalog`, `TranslationContext`, `I18nError`, `LazyString`, `TranslationGuard`, and the functions under `reinhardt::pages::i18n`
 
 ### Forms (native only)
 - `FormBinding`, `FormComponent`

--- a/crates/reinhardt-pages/docs/i18n_requirements.md
+++ b/crates/reinhardt-pages/docs/i18n_requirements.md
@@ -27,9 +27,11 @@ The first supported pages i18n surface is feature-gated behind
 - `set_locale` updates the current page context, and existing `t!` output
   changes when the page snapshot is rendered again.
 
+Shared native and WASM Pages code should import catalog APIs from `reinhardt::pages::i18n` so the application depends only on the framework facade.
+
 ```rust,ignore
-use reinhardt_i18n::{MessageCatalog, TranslationContext};
-use reinhardt_pages::prelude::*;
+use reinhardt::pages::i18n::{I18nContext, MessageCatalog, TranslationContext};
+use reinhardt::pages::prelude::*;
 
 let mut translations = TranslationContext::new("ja", "en-US");
 let mut ja = MessageCatalog::new("ja");

--- a/crates/reinhardt-pages/src/i18n.rs
+++ b/crates/reinhardt-pages/src/i18n.rs
@@ -12,7 +12,12 @@ use std::future::Future;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use reinhardt_i18n::{I18nError, MessageCatalog, TranslationContext};
+pub use reinhardt_i18n::{
+	I18nError, LazyString, MessageCatalog, TranslationContext, TranslationGuard, activate,
+	activate_with_catalog, deactivate, get_active_translation, get_language, get_locale, gettext,
+	gettext_lazy, ngettext, ngettext_lazy, npgettext, pgettext, set_active_translation,
+	set_active_translation_permanent,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::component::{IntoPage, Page};

--- a/crates/reinhardt-pages/src/i18n.rs
+++ b/crates/reinhardt-pages/src/i18n.rs
@@ -1,7 +1,9 @@
 //! Reactive page translation support.
 //!
 //! This module connects `reinhardt-i18n` catalogs to page rendering, SSR state,
-//! and client hydration.
+//! and client hydration. It is also the canonical native and WASM facade for
+//! constructing catalogs and using target-neutral global translation APIs in
+//! Pages applications.
 
 use std::borrow::Cow;
 #[cfg(wasm)]

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -733,8 +733,9 @@ pub use style::{
 
 #[cfg(feature = "i18n")]
 pub use i18n::{
-	I18nContext, I18nStateError, TranslatedText, locale, provide_i18n_context, set_locale, tn, tnp,
-	tp, tr, use_i18n_context, with_i18n_context,
+	I18nContext, I18nError, I18nStateError, LazyString, MessageCatalog, TranslatedText,
+	TranslationContext, TranslationGuard, locale, provide_i18n_context, set_locale, tn, tnp, tp,
+	tr, use_i18n_context, with_i18n_context,
 };
 
 // Re-export procedural macros

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -81,7 +81,8 @@
 //!   (no-op on native; replaces the deprecated `spawn_local` re-export)
 //!
 //! ## I18n
-//! - `I18nContext`, `I18nStateError`, `TranslatedText`, `tr`, `tn`, `tp`, `tnp`
+//! - `I18nContext`, `I18nError`, `I18nStateError`, `LazyString`, `MessageCatalog`,
+//!   `TranslatedText`, `TranslationContext`, `TranslationGuard`, `tr`, `tn`, `tp`, `tnp`
 //! - `provide_i18n_context`, `use_i18n_context`, `with_i18n_context`
 //! - `set_locale`, `locale`
 //! - `t!` for inline page translations with named interpolation
@@ -214,8 +215,9 @@ pub use crate::ssr::{SsrChunk, SsrOptions, SsrRenderer, SsrRouteOutput, SsrStrea
 
 #[cfg(feature = "i18n")]
 pub use crate::i18n::{
-	I18nContext, I18nStateError, TranslatedText, locale, provide_i18n_context, set_locale, tn, tnp,
-	tp, tr, use_i18n_context, with_i18n_context,
+	I18nContext, I18nError, I18nStateError, LazyString, MessageCatalog, TranslatedText,
+	TranslationContext, TranslationGuard, locale, provide_i18n_context, set_locale, tn, tnp, tp,
+	tr, use_i18n_context, with_i18n_context,
 };
 
 // ============================================================================

--- a/tests/pages_i18n_facade.rs
+++ b/tests/pages_i18n_facade.rs
@@ -61,7 +61,33 @@ mod prelude_exports {
 	}
 }
 
-#[allow(dead_code)]
+mod crate_root_exports {
+	use reinhardt::pages::{
+		I18nError, LazyString, MessageCatalog, TranslationContext, TranslationGuard,
+	};
+
+	#[test]
+	fn pages_crate_root_exports_primary_types() {
+		fn accepts_primary_types(
+			_catalog: MessageCatalog,
+			_context: TranslationContext,
+			_error: Option<I18nError>,
+			_lazy: Option<LazyString>,
+			_guard: Option<TranslationGuard>,
+		) {
+		}
+
+		accepts_primary_types(
+			MessageCatalog::new("en-US"),
+			TranslationContext::new("en-US", "en-US"),
+			None,
+			None,
+			None,
+		);
+	}
+}
+
+#[test]
 fn target_neutral_exports_compile() {
 	let _activate: fn(&str) -> Result<(), I18nError> = activate;
 	let _activate_with_catalog: fn(&str, MessageCatalog) -> Result<(), I18nError> =

--- a/tests/pages_i18n_facade.rs
+++ b/tests/pages_i18n_facade.rs
@@ -6,6 +6,7 @@ use reinhardt::pages::i18n::{
 	gettext, gettext_lazy, ngettext, ngettext_lazy, npgettext, pgettext, set_active_translation,
 	set_active_translation_permanent,
 };
+use serial_test::serial;
 
 fn translated_context() -> TranslationContext {
 	let mut catalog = MessageCatalog::new("ja");
@@ -26,6 +27,7 @@ fn pages_i18n_facade_constructs_catalog_backed_context() {
 }
 
 #[test]
+#[serial(i18n)]
 fn pages_i18n_facade_restores_scoped_global_translation() {
 	assert!(get_active_translation().is_none());
 

--- a/tests/pages_i18n_facade.rs
+++ b/tests/pages_i18n_facade.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use reinhardt::pages::i18n::{
+	I18nContext, I18nError, LazyString, MessageCatalog, TranslationContext, TranslationGuard,
+	activate, activate_with_catalog, deactivate, get_active_translation, get_language, get_locale,
+	gettext, gettext_lazy, ngettext, ngettext_lazy, npgettext, pgettext, set_active_translation,
+	set_active_translation_permanent,
+};
+
+fn translated_context() -> TranslationContext {
+	let mut catalog = MessageCatalog::new("ja");
+	catalog.add_translation("Hello", "こんにちは");
+
+	let mut translations = TranslationContext::new("ja", "en-US");
+	translations
+		.add_catalog("ja", catalog)
+		.expect("the Japanese catalog should be valid");
+	translations
+}
+
+#[test]
+fn pages_i18n_facade_constructs_catalog_backed_context() {
+	let context = I18nContext::new(translated_context());
+
+	assert_eq!(context.translate("Hello"), "こんにちは");
+}
+
+#[test]
+fn pages_i18n_facade_restores_scoped_global_translation() {
+	assert!(get_active_translation().is_none());
+
+	{
+		let _guard: TranslationGuard = set_active_translation(Arc::new(translated_context()));
+		assert_eq!(gettext("Hello"), "こんにちは");
+	}
+
+	assert!(get_active_translation().is_none());
+}
+
+mod prelude_exports {
+	use reinhardt::pages::prelude::*;
+
+	#[test]
+	fn pages_i18n_prelude_exports_primary_types() {
+		fn accepts_primary_types(
+			_catalog: MessageCatalog,
+			_context: TranslationContext,
+			_error: Option<I18nError>,
+			_lazy: Option<LazyString>,
+			_guard: Option<TranslationGuard>,
+		) {
+		}
+
+		accepts_primary_types(
+			MessageCatalog::new("en-US"),
+			TranslationContext::new("en-US", "en-US"),
+			None,
+			None,
+			None,
+		);
+	}
+}
+
+#[allow(dead_code)]
+fn target_neutral_exports_compile() {
+	let _activate: fn(&str) -> Result<(), I18nError> = activate;
+	let _activate_with_catalog: fn(&str, MessageCatalog) -> Result<(), I18nError> =
+		activate_with_catalog;
+	let _deactivate: fn() = deactivate;
+	let _get_locale: fn() -> String = get_locale;
+	let _get_language: fn() -> String = get_language;
+	let _gettext: fn(&str) -> String = gettext;
+	let _ngettext: fn(&str, &str, usize) -> String = ngettext;
+	let _pgettext: fn(&str, &str) -> String = pgettext;
+	let _npgettext: fn(&str, &str, &str, usize) -> String = npgettext;
+	let _gettext_lazy: fn(&str) -> LazyString = gettext_lazy;
+	let _ngettext_lazy: fn(&str, &str, usize) -> LazyString = ngettext_lazy;
+	let _set_permanent: fn(Arc<TranslationContext>) = set_active_translation_permanent;
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- exposing catalog construction and target-neutral global translation APIs through `reinhardt::pages::i18n`
- re-exporting the primary i18n types through the Pages crate root and prelude
- documenting the facade-only native/WASM setup path

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Pages applications could consume reactive i18n rendering APIs through the `reinhardt` facade, but constructing message catalogs still required a direct `reinhardt-i18n` dependency. This change provides a single supported facade surface for shared native and WASM Pages code while keeping file-oriented APIs outside the Pages namespace.

Fixes #5772

## How Was This Tested?

- Added `tests/pages_i18n_facade.rs` for catalog-backed translation, scoped global translation restoration, crate-root exports, prelude exports, and target-neutral function signatures.
- `rustfmt --edition 2024 --check` passed for all affected Rust files.
- `git diff --check origin/develop/0.4.0...HEAD` passed.
- Local Cargo, clippy, rustdoc, and WASM commands are pending because the local Semgrep Guardian hook rejected Cargo before startup; Draft PR CI will provide the executable verification evidence.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (not applicable)
- [x] I have formatted the affected Rust files with rustfmt
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5772

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `i18n` - Internationalization, localization

---

🤖 Generated with [Codex](https://openai.com/codex)
