### PR TITLE
feat(pages): compose validated form actions

### DIFF
--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -468,6 +468,26 @@ if !save.is_pending() {
 }
 ```
 
+For native form submission and headless status UI, attach the form action's
+submit handler to the containing form and use the form-aware primitives:
+
+```rust,ignore
+use reinhardt_pages::ui::{FormActionButton, FormActionResultPanel};
+
+let submit = save.submit_handler();
+let button = FormActionButton::new(save.clone(), "Save");
+let result = FormActionResultPanel::new(save.clone())
+    .pending(|| Page::text("Saving"))
+    .validation_error(|message| Page::text(message.to_string()))
+    .success(|_| Page::text("Saved"))
+    .error(|error| Page::text(error.to_string()));
+```
+
+Bind `submit` to the containing element's `Submit` event. The button remains
+`type="submit"`, so pointer activation and Enter-key submission use the same
+validated `FormAction::submit()` path. `Resource::latest_after_form(&save)`
+reconciles successful form mutations without exposing payload dispatch.
+
 `FileField` and `ImageField` also participate in the generated runtime
 contract as `Option<web_sys::File>` values. File values are browser-owned and
 are tracked for dirty/touched state without treating the file payload as a

--- a/crates/reinhardt-pages/docs/react_to_reinhardt.md
+++ b/crates/reinhardt-pages/docs/react_to_reinhardt.md
@@ -619,6 +619,15 @@ take repeatable closures, so their slot signatures remain explicit and do not
 consume the values they render. See the `reinhardt_pages::ui` rustdoc for the
 complete constructor and builder signatures.
 
+Validated generated forms use `FormActionButton` rather than `ActionButton`.
+Attach `FormAction::submit_handler()` to the containing form so button clicks
+and Enter-key submission both run generated validation before dispatch.
+`FormActionResultPanel` provides a separate `validation_error` slot alongside
+typed mutation `error` and `success` slots. Use
+`Resource::latest_after_form(&save)` for resource reconciliation. The raw
+action remains private, so form validation cannot be bypassed through direct
+payload dispatch.
+
 ```rust,ignore
 use reinhardt::pages::prelude::*;
 use reinhardt::pages::server_fn::{ServerFnError, server_fn};

--- a/crates/reinhardt-pages/src/form_state.rs
+++ b/crates/reinhardt-pages/src/form_state.rs
@@ -1985,6 +1985,9 @@ where
 	pub fn submit(&self) -> UseFormSubmitOutcome {
 		let outcome = self.form.begin_submit_lifecycle();
 		if outcome != UseFormSubmitOutcome::Submitted {
+			if outcome == UseFormSubmitOutcome::ValidationFailed {
+				self.action.reset();
+			}
 			return outcome;
 		}
 

--- a/crates/reinhardt-pages/src/form_state.rs
+++ b/crates/reinhardt-pages/src/form_state.rs
@@ -1965,6 +1965,22 @@ where
 			.or_else(|| self.action.error().map(|error| error.to_string()))
 	}
 
+	pub(crate) fn action(&self) -> Action<T, E> {
+		self.action
+	}
+
+	/// Returns a submit-event handler that validates and dispatches this action.
+	///
+	/// Attach this handler to the containing `form` element. Native form submit
+	/// semantics then cover both submit-button activation and Enter-key submit.
+	pub fn submit_handler(&self) -> crate::component::PageEventHandler {
+		let action = self.clone();
+		crate::callback::event_handler(move |event| {
+			event.prevent_default();
+			action.submit();
+		})
+	}
+
 	/// Runs generated validation and dispatches the current values on success.
 	pub fn submit(&self) -> UseFormSubmitOutcome {
 		let outcome = self.form.begin_submit_lifecycle();

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -314,6 +314,12 @@
 //! }
 //! ```
 //!
+//! Use [`ui::FormActionButton`] with [`FormAction::submit_handler`] to preserve
+//! native form submit semantics. [`ui::FormActionResultPanel`] renders
+//! validation and typed mutation errors separately, while
+//! [`Resource::latest_after_form`] composes successful validated mutations
+//! without exposing the underlying dispatch handle.
+//!
 //! `FileField` and `ImageField` participate in this runtime contract as
 //! `Option<web_sys::File>` values. File values are browser-owned and are
 //! tracked for dirty/touched state without treating the file payload as a

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -130,7 +130,9 @@ pub use crate::component::{
 // Headless UI primitives
 // ============================================================================
 
-pub use crate::ui::{ActionButton, ActionResultPanel, ResourcePanel};
+pub use crate::ui::{
+	ActionButton, ActionResultPanel, FormActionButton, FormActionResultPanel, ResourcePanel,
+};
 
 // ============================================================================
 // Events and Callbacks

--- a/crates/reinhardt-pages/src/reactive/resource_value.rs
+++ b/crates/reinhardt-pages/src/reactive/resource_value.rs
@@ -5,6 +5,7 @@
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
+use std::fmt::Display;
 use std::rc::Rc;
 
 use reinhardt_core::reactive::deps::{Deps, Trackable};
@@ -12,6 +13,7 @@ use reinhardt_core::reactive::deps::{Deps, Trackable};
 use super::Effect;
 use super::hooks::{Action, ActionPhase};
 use super::resource::{Resource, ResourceState};
+use crate::form_state::{FormAction, FormRuntimeSource};
 
 /// UI-oriented state for a latest resource value read.
 #[derive(Clone, Debug, PartialEq)]
@@ -80,6 +82,20 @@ impl<T: Clone + 'static, E: Clone + 'static> LatestResourceValueBuilder<T, E> {
 		A: Borrow<Action<T, E>>,
 	{
 		self.actions.push(*action.borrow());
+		self
+	}
+
+	/// Adds a validated form action without exposing its dispatch handle.
+	pub fn with_form_action<Form, FormDeps>(
+		mut self,
+		action: &FormAction<Form, FormDeps, T, E>,
+	) -> Self
+	where
+		Form: FormRuntimeSource,
+		FormDeps: Clone + PartialEq + 'static,
+		E: Display,
+	{
+		self.actions.push(action.action());
 		self
 	}
 
@@ -163,6 +179,21 @@ impl<T: Clone + 'static, E: Clone + 'static> LatestResourceValue<T, E> {
 		A: Borrow<Action<T, E>>,
 	{
 		self.actions.push(*action.borrow());
+		self.rebuild_refetch_effect();
+		self
+	}
+
+	/// Adds a validated form action with higher priority than prior actions.
+	pub fn latest_after_form<Form, FormDeps>(
+		mut self,
+		action: &FormAction<Form, FormDeps, T, E>,
+	) -> Self
+	where
+		Form: FormRuntimeSource,
+		FormDeps: Clone + PartialEq + 'static,
+		E: Display,
+	{
+		self.actions.push(action.action());
 		self.rebuild_refetch_effect();
 		self
 	}
@@ -268,6 +299,21 @@ impl<T: Clone + 'static, E: Clone + 'static> Resource<T, E> {
 		A: Borrow<Action<T, E>>,
 	{
 		use_latest_resource_value(*self).with_action(action).build()
+	}
+
+	/// Composes this resource with a validated form action's successful result.
+	pub fn latest_after_form<Form, FormDeps>(
+		&self,
+		action: &FormAction<Form, FormDeps, T, E>,
+	) -> LatestResourceValue<T, E>
+	where
+		Form: FormRuntimeSource,
+		FormDeps: Clone + PartialEq + 'static,
+		E: Display,
+	{
+		use_latest_resource_value(*self)
+			.with_form_action(action)
+			.build()
 	}
 }
 

--- a/crates/reinhardt-pages/src/ui.rs
+++ b/crates/reinhardt-pages/src/ui.rs
@@ -13,10 +13,14 @@
 
 mod action_button;
 mod action_result_panel;
+mod form_action_button;
+mod form_action_result_panel;
 mod resource_panel;
 
 pub use action_button::ActionButton;
 pub use action_result_panel::ActionResultPanel;
+pub use form_action_button::FormActionButton;
+pub use form_action_result_panel::FormActionResultPanel;
 pub use resource_panel::ResourcePanel;
 
 pub(crate) mod state;

--- a/crates/reinhardt-pages/src/ui/form_action_button.rs
+++ b/crates/reinhardt-pages/src/ui/form_action_button.rs
@@ -1,0 +1,99 @@
+use std::fmt::Display;
+
+use crate::component::{Component, IntoPage, Page, PageElement};
+use crate::form_state::{FormAction, FormRuntimeSource};
+
+/// Native submit button backed by a validated [`FormAction`].
+///
+/// Attach [`FormAction::submit_handler`] to the containing `form`. This button
+/// deliberately has no click dispatcher, so all activation follows the form's
+/// native submit lifecycle.
+pub struct FormActionButton<Form, Deps, T, E>
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+	T: Clone + 'static,
+	E: Clone + Display + 'static,
+{
+	action: FormAction<Form, Deps, T, E>,
+	children: Page,
+	attrs: Vec<(String, String)>,
+}
+
+impl<Form, Deps, T, E> FormActionButton<Form, Deps, T, E>
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+	T: Clone + 'static,
+	E: Clone + Display + 'static,
+{
+	/// Creates a native submit control for `action`.
+	pub fn new<C>(action: FormAction<Form, Deps, T, E>, children: C) -> Self
+	where
+		C: IntoPage,
+	{
+		Self {
+			action,
+			children: children.into_page(),
+			attrs: Vec::new(),
+		}
+	}
+
+	/// Adds an attribute not managed by the component.
+	pub fn attr(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+		self.attrs.push((name.into(), value.into()));
+		self
+	}
+
+	/// Renders the submit button.
+	pub fn render(&self) -> Page {
+		let mut button = PageElement::new("button").attr("type", "submit");
+		for (name, value) in &self.attrs {
+			if !name.eq_ignore_ascii_case("type")
+				&& !name.eq_ignore_ascii_case("disabled")
+				&& !name.eq_ignore_ascii_case("aria-busy")
+			{
+				button = button.attr(name.clone(), value.clone());
+			}
+		}
+		let disabled_action = self.action.clone();
+		let busy_action = self.action.clone();
+		button
+			.reactive_attr("disabled", move || {
+				disabled_action.is_pending().then(|| "disabled".into())
+			})
+			.reactive_attr("aria-busy", move || {
+				busy_action.is_pending().then(|| "true".into())
+			})
+			.child(self.children.clone())
+			.into_page()
+	}
+}
+
+impl<Form, Deps, T, E> Component for FormActionButton<Form, Deps, T, E>
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+	T: Clone + 'static,
+	E: Clone + Display + 'static,
+{
+	fn render(&self) -> Page {
+		Self::render(self)
+	}
+
+	fn name() -> &'static str {
+		"FormActionButton"
+	}
+}
+
+impl<Form, Deps, T, E> IntoPage for FormActionButton<Form, Deps, T, E>
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+	T: Clone + 'static,
+	E: Clone + Display + 'static,
+{
+	fn into_page(self) -> Page {
+		self.render()
+	}
+}

--- a/crates/reinhardt-pages/src/ui/form_action_button.rs
+++ b/crates/reinhardt-pages/src/ui/form_action_button.rs
@@ -7,7 +7,8 @@ use crate::form_state::{FormAction, FormRuntimeSource};
 ///
 /// Attach [`FormAction::submit_handler`] to the containing `form`. This button
 /// deliberately has no click dispatcher, so all activation follows the form's
-/// native submit lifecycle.
+/// native submit lifecycle. The button bypasses browser constraint validation
+/// so generated validation errors can be rendered by the form action.
 pub struct FormActionButton<Form, Deps, T, E>
 where
 	Form: FormRuntimeSource,
@@ -47,9 +48,12 @@ where
 
 	/// Renders the submit button.
 	pub fn render(&self) -> Page {
-		let mut button = PageElement::new("button").attr("type", "submit");
+		let mut button = PageElement::new("button")
+			.attr("type", "submit")
+			.attr("formnovalidate", "formnovalidate");
 		for (name, value) in &self.attrs {
 			if !name.eq_ignore_ascii_case("type")
+				&& !name.eq_ignore_ascii_case("formnovalidate")
 				&& !name.eq_ignore_ascii_case("disabled")
 				&& !name.eq_ignore_ascii_case("aria-busy")
 			{

--- a/crates/reinhardt-pages/src/ui/form_action_result_panel.rs
+++ b/crates/reinhardt-pages/src/ui/form_action_result_panel.rs
@@ -1,0 +1,129 @@
+use std::fmt::Display;
+use std::rc::Rc;
+
+use super::state::{ActionSlots, render_action_phase};
+use crate::component::{Component, IntoPage, Page};
+use crate::form_state::{FormAction, FormRuntimeSource};
+use crate::reactive::ActionPhase;
+
+type ValidationErrorSlot = Rc<dyn Fn(&str) -> Page>;
+
+/// Renders validation and mutation phases from a validated form action.
+pub struct FormActionResultPanel<Form, Deps, T, E>
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+	T: Clone + 'static,
+	E: Clone + Display + 'static,
+{
+	action: FormAction<Form, Deps, T, E>,
+	slots: ActionSlots<T, E>,
+	validation_error: Option<ValidationErrorSlot>,
+}
+
+impl<Form, Deps, T, E> FormActionResultPanel<Form, Deps, T, E>
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+	T: Clone + 'static,
+	E: Clone + Display + 'static,
+{
+	/// Creates a result panel backed by a validated form action.
+	pub fn new(action: FormAction<Form, Deps, T, E>) -> Self {
+		Self {
+			action,
+			slots: ActionSlots {
+				idle: None,
+				pending: None,
+				success: None,
+				error: None,
+			},
+			validation_error: None,
+		}
+	}
+
+	/// Sets the idle view.
+	pub fn idle<F: Fn() -> Page + 'static>(mut self, render: F) -> Self {
+		self.slots.idle = Some(Rc::new(render));
+		self
+	}
+
+	/// Sets the pending view.
+	pub fn pending<F: Fn() -> Page + 'static>(mut self, render: F) -> Self {
+		self.slots.pending = Some(Rc::new(render));
+		self
+	}
+
+	/// Sets the successful mutation view.
+	pub fn success<F: Fn(&T) -> Page + 'static>(mut self, render: F) -> Self {
+		self.slots.success = Some(Rc::new(render));
+		self
+	}
+
+	/// Sets the typed mutation-error view.
+	pub fn error<F: Fn(&E) -> Page + 'static>(mut self, render: F) -> Self {
+		self.slots.error = Some(Rc::new(render));
+		self
+	}
+
+	/// Sets the generated-validation error view.
+	pub fn validation_error<F: Fn(&str) -> Page + 'static>(mut self, render: F) -> Self {
+		self.validation_error = Some(Rc::new(render));
+		self
+	}
+
+	/// Renders the current form-action phase reactively.
+	pub fn render(&self) -> Page {
+		let action = self.action.clone();
+		let slots = self.slots.clone();
+		let validation_error = self.validation_error.clone();
+		Page::reactive(move || {
+			if action.is_pending() {
+				return render_action_phase(ActionPhase::Pending, &slots);
+			}
+			match action.phase() {
+				ActionPhase::Success(value) => {
+					return render_action_phase(ActionPhase::Success(value), &slots);
+				}
+				ActionPhase::Error(error) => {
+					return render_action_phase(ActionPhase::Error(error), &slots);
+				}
+				ActionPhase::Idle | ActionPhase::Pending => {}
+			}
+			if let Some(message) = action.error_message() {
+				return validation_error
+					.as_ref()
+					.map_or_else(Page::empty, |slot| slot(&message));
+			}
+			render_action_phase(ActionPhase::Idle, &slots)
+		})
+	}
+}
+
+impl<Form, Deps, T, E> Component for FormActionResultPanel<Form, Deps, T, E>
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+	T: Clone + 'static,
+	E: Clone + Display + 'static,
+{
+	fn render(&self) -> Page {
+		Self::render(self)
+	}
+
+	fn name() -> &'static str {
+		"FormActionResultPanel"
+	}
+}
+
+impl<Form, Deps, T, E> IntoPage for FormActionResultPanel<Form, Deps, T, E>
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+	T: Clone + 'static,
+	E: Clone + Display + 'static,
+{
+	fn into_page(self) -> Page {
+		self.render()
+	}
+}

--- a/crates/reinhardt-pages/tests/use_form_integration.rs
+++ b/crates/reinhardt-pages/tests/use_form_integration.rs
@@ -8,11 +8,12 @@ use std::task::{Context, Poll, Waker};
 use reinhardt_core::reactive::ReactiveScope;
 use reinhardt_pages::reactive::Signal;
 use reinhardt_pages::server_fn::ServerFnErrorKind;
+use reinhardt_pages::ui::{FormActionButton, FormActionResultPanel};
 use reinhardt_pages::{
 	CollectionItem, CollectionItemKey, CustomWidgetContext, CustomWidgetRawValue, FieldError,
-	FormEvent, FormWidgetAdapter, FormWidgetError, FormWidgetValueKind, Page, ResetOnDeps,
-	RevalidateOn, ServerFnError, UseFormAsyncSubmitOutcome, UseFormSubmitOutcome, form, use_form,
-	use_form_action,
+	FormEvent, FormWidgetAdapter, FormWidgetError, FormWidgetValueKind, IntoPage, Page,
+	PageElement, ResetOnDeps, RevalidateOn, ServerFnError, UseFormAsyncSubmitOutcome,
+	UseFormSubmitOutcome, form, use_form, use_form_action, use_resource,
 };
 
 thread_local! {
@@ -2300,5 +2301,48 @@ fn use_form_action_dispatches_current_values_after_validation() {
 		assert_eq!(captured_name.borrow().as_deref(), Some("Grace"));
 		assert!(!save.is_pending());
 		assert!(save.error_message().is_none());
+	});
+}
+
+#[test]
+fn form_action_ui_preserves_submit_semantics_and_renders_validation_errors() {
+	ReactiveScope::run(|| {
+		let signup = form! {
+			name: SignupForm,
+			action: "/signup",
+			fields: {
+				email: CharField {
+					initial: "",
+					required,
+				}
+			}
+		};
+		let runtime = use_form(&signup).build();
+		let save = use_form_action(&runtime, |_values| async { Ok::<(), String>(()) });
+		let button = FormActionButton::new(save.clone(), Page::text("Save"))
+			.attr("type", "button")
+			.attr("aria-label", "Save signup");
+		let panel = FormActionResultPanel::new(save.clone())
+			.idle(|| Page::text("idle"))
+			.validation_error(|message| Page::text(format!("validation:{message}")));
+		let resource = use_resource(|| async { Ok::<(), String>(()) }, reinhardt_pages::deps![]);
+		let latest = resource.latest_after_form(&save);
+		let form_page = PageElement::new("form")
+			.on(reinhardt_pages::EventType::Submit, save.submit_handler())
+			.child(button)
+			.into_page();
+
+		assert_eq!(
+			form_page.render_to_string(),
+			r#"<form><button type="submit" aria-label="Save signup">Save</button></form>"#
+		);
+		assert_eq!(panel.render().render_to_string(), "idle");
+		assert_eq!(latest.value(), None);
+
+		assert_eq!(save.submit(), UseFormSubmitOutcome::ValidationFailed);
+		assert_eq!(
+			panel.render().render_to_string(),
+			"validation:email is required"
+		);
 	});
 }

--- a/crates/reinhardt-pages/tests/use_form_integration.rs
+++ b/crates/reinhardt-pages/tests/use_form_integration.rs
@@ -2334,7 +2334,7 @@ fn form_action_ui_preserves_submit_semantics_and_renders_validation_errors() {
 
 		assert_eq!(
 			form_page.render_to_string(),
-			r#"<form><button type="submit" aria-label="Save signup">Save</button></form>"#
+			r#"<form><button type="submit" formnovalidate="formnovalidate" aria-label="Save signup">Save</button></form>"#
 		);
 		assert_eq!(panel.render().render_to_string(), "idle");
 		assert_eq!(latest.value(), None);


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- Add `FormActionButton` with native `type=\"submit\"` semantics and reactive busy state.
- Add `FormActionResultPanel` with separate validation and typed mutation error slots.
- Add form-aware resource reconciliation without exposing the underlying dispatch handle.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Generated form actions could not use headless submit/result UI or participate in resource reconciliation without bypassing their validation lifecycle. The new APIs keep direct action dispatch private and route pointer and Enter-key submission through the same form submit handler.

Fixes #5777

Related to: #5549, #5555, #5556, #5715

## How Was This Tested?

- `cargo test -p reinhardt-pages --test use_form_integration form_action_ui_preserves_submit_semantics_and_renders_validation_errors --all-features`
- `cargo test -p reinhardt-pages --lib latest_after_prefers_later_action_success --all-features`
- `cargo check -p reinhardt-pages --all-features`
- `cargo check -p reinhardt-pages --target wasm32-unknown-unknown --all-features`
- `cargo clippy -p reinhardt-pages --lib --all-features -- -D warnings`
- `cargo doc -p reinhardt-pages --all-features --no-deps`
- `cargo fmt --all -- --check`

## Performance Impact

No expected material impact. The new components use the existing reactive action and resource nodes.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5777

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The existing `ActionButton`, `ActionResultPanel`, and `Resource::latest_after` signatures remain unchanged. Form-aware composition is additive so callers cannot accidentally obtain a payload-dispatch path that skips generated validation.