### PR TITLE
feat(db)!: add Copy-safe injected connection handles

### DIFF
--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -705,10 +705,13 @@ fn extract_admin_list_total_count(
 ///
 /// ```
 /// use reinhardt_admin::core::{AdminDatabase, AdminRecord};
-/// use reinhardt_db::orm::DatabaseConnection;
+/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+/// use reinhardt_db::orm::DatabaseConnectionLease;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let conn = DatabaseConnection::connect("postgres://localhost/test").await?;
+/// let owner = BackendsConnection::connect_postgres("postgres://localhost/test").await?;
+/// let lease = DatabaseConnectionLease::register(owner)?;
+/// let conn = lease.handle();
 /// let db = AdminDatabase::new(conn);
 ///
 /// // List items with filters
@@ -719,7 +722,7 @@ fn extract_admin_list_total_count(
 #[injectable(scope = Singleton, prebuilt = true)]
 #[derive(Clone)]
 pub struct AdminDatabase {
-	connection: Arc<DatabaseConnection>,
+	connection: DatabaseConnection,
 }
 
 /// Provider key for the admin database dependency.
@@ -729,19 +732,9 @@ pub struct AdminDatabaseKey;
 impl AdminDatabase {
 	/// Create a new admin database interface
 	///
-	/// This method accepts a DatabaseConnection directly without requiring `Arc` wrapping.
-	/// The `Arc` wrapping is handled internally for you.
+	/// The copyable ORM handle is stored directly. Its associated
+	/// `DatabaseConnectionLease` must remain alive for the lifetime of this value.
 	pub fn new(connection: DatabaseConnection) -> Self {
-		Self {
-			connection: Arc::new(connection),
-		}
-	}
-
-	/// Create a new admin database interface from an Arc-wrapped connection
-	///
-	/// This is provided for cases where you already have an `Arc<DatabaseConnection>`.
-	/// In most cases, you should use `new()` instead.
-	pub fn from_arc(connection: Arc<DatabaseConnection>) -> Self {
 		Self { connection }
 	}
 
@@ -750,23 +743,19 @@ impl AdminDatabase {
 		&self.connection
 	}
 
-	/// Get a cloned Arc of the connection (for cases where you need ownership)
-	///
-	/// In most cases, you should use `connection()` instead to get a reference.
-	pub fn connection_arc(&self) -> Arc<DatabaseConnection> {
-		Arc::clone(&self.connection)
-	}
-
 	/// List items with filters, ordering, and pagination
 	///
 	/// # Examples
 	///
 	/// ```
 	/// use reinhardt_admin::core::{AdminDatabase, AdminRecord};
-	/// use reinhardt_db::orm::{DatabaseConnection, Filter, FilterOperator, FilterValue};
+	/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+	/// use reinhardt_db::orm::{DatabaseConnectionLease, Filter, FilterOperator, FilterValue};
 	///
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// let conn = DatabaseConnection::connect("postgres://localhost/test").await?;
+	/// let owner = BackendsConnection::connect_postgres("postgres://localhost/test").await?;
+	/// let lease = DatabaseConnectionLease::register(owner)?;
+	/// let conn = lease.handle();
 	/// let db = AdminDatabase::new(conn);
 	///
 	/// let filters = vec![
@@ -1055,10 +1044,13 @@ impl AdminDatabase {
 	///
 	/// ```
 	/// use reinhardt_admin::core::{AdminDatabase, AdminRecord};
-	/// use reinhardt_db::orm::DatabaseConnection;
+	/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+	/// use reinhardt_db::orm::DatabaseConnectionLease;
 	///
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// let conn = DatabaseConnection::connect("postgres://localhost/test").await?;
+	/// let owner = BackendsConnection::connect_postgres("postgres://localhost/test").await?;
+	/// let lease = DatabaseConnectionLease::register(owner)?;
+	/// let conn = lease.handle();
 	/// let db = AdminDatabase::new(conn);
 	///
 	/// let item = db.get::<AdminRecord>("admin_records", "id", "1").await?;
@@ -1109,11 +1101,14 @@ impl AdminDatabase {
 	///
 	/// ```
 	/// use reinhardt_admin::core::{AdminDatabase, AdminRecord};
-	/// use reinhardt_db::orm::DatabaseConnection;
+	/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+	/// use reinhardt_db::orm::DatabaseConnectionLease;
 	/// use std::collections::HashMap;
 	///
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// let conn = DatabaseConnection::connect("postgres://localhost/test").await?;
+	/// let owner = BackendsConnection::connect_postgres("postgres://localhost/test").await?;
+	/// let lease = DatabaseConnectionLease::register(owner)?;
+	/// let conn = lease.handle();
 	/// let db = AdminDatabase::new(conn);
 	///
 	/// let mut data = HashMap::new();
@@ -1195,11 +1190,14 @@ impl AdminDatabase {
 	///
 	/// ```
 	/// use reinhardt_admin::core::{AdminDatabase, AdminRecord};
-	/// use reinhardt_db::orm::DatabaseConnection;
+	/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+	/// use reinhardt_db::orm::DatabaseConnectionLease;
 	/// use std::collections::HashMap;
 	///
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// let conn = DatabaseConnection::connect("postgres://localhost/test").await?;
+	/// let owner = BackendsConnection::connect_postgres("postgres://localhost/test").await?;
+	/// let lease = DatabaseConnectionLease::register(owner)?;
+	/// let conn = lease.handle();
 	/// let db = AdminDatabase::new(conn);
 	///
 	/// let mut data = HashMap::new();
@@ -1249,10 +1247,13 @@ impl AdminDatabase {
 	///
 	/// ```
 	/// use reinhardt_admin::core::{AdminDatabase, AdminRecord};
-	/// use reinhardt_db::orm::DatabaseConnection;
+	/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+	/// use reinhardt_db::orm::DatabaseConnectionLease;
 	///
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// let conn = DatabaseConnection::connect("postgres://localhost/test").await?;
+	/// let owner = BackendsConnection::connect_postgres("postgres://localhost/test").await?;
+	/// let lease = DatabaseConnectionLease::register(owner)?;
+	/// let conn = lease.handle();
 	/// let db = AdminDatabase::new(conn);
 	///
 	/// db.delete::<AdminRecord>("admin_records", "id", "1").await?;
@@ -1289,10 +1290,13 @@ impl AdminDatabase {
 	///
 	/// ```
 	/// use reinhardt_admin::core::{AdminDatabase, AdminRecord};
-	/// use reinhardt_db::orm::DatabaseConnection;
+	/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+	/// use reinhardt_db::orm::DatabaseConnectionLease;
 	///
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// let conn = DatabaseConnection::connect("postgres://localhost/test").await?;
+	/// let owner = BackendsConnection::connect_postgres("postgres://localhost/test").await?;
+	/// let lease = DatabaseConnectionLease::register(owner)?;
+	/// let conn = lease.handle();
 	/// let db = AdminDatabase::new(conn);
 	///
 	/// let ids = vec!["1".to_string(), "2".to_string(), "3".to_string()];
@@ -1319,10 +1323,13 @@ impl AdminDatabase {
 	///
 	/// ```
 	/// use reinhardt_admin::core::AdminDatabase;
-	/// use reinhardt_db::orm::DatabaseConnection;
+	/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+	/// use reinhardt_db::orm::DatabaseConnectionLease;
 	///
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// let conn = DatabaseConnection::connect("postgres://localhost/test").await?;
+	/// let owner = BackendsConnection::connect_postgres("postgres://localhost/test").await?;
+	/// let lease = DatabaseConnectionLease::register(owner)?;
+	/// let conn = lease.handle();
 	/// let db = AdminDatabase::new(conn);
 	///
 	/// let ids = vec!["1".to_string(), "2".to_string(), "3".to_string()];
@@ -1364,10 +1371,13 @@ impl AdminDatabase {
 	///
 	/// ```
 	/// use reinhardt_admin::core::{AdminDatabase, AdminRecord};
-	/// use reinhardt_db::orm::{DatabaseConnection, Filter, FilterOperator, FilterValue};
+	/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+	/// use reinhardt_db::orm::{DatabaseConnectionLease, Filter, FilterOperator, FilterValue};
 	///
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// let conn = DatabaseConnection::connect("postgres://localhost/test").await?;
+	/// let owner = BackendsConnection::connect_postgres("postgres://localhost/test").await?;
+	/// let lease = DatabaseConnectionLease::register(owner)?;
+	/// let conn = lease.handle();
 	/// let db = AdminDatabase::new(conn);
 	///
 	/// let filters = vec![
@@ -1473,7 +1483,7 @@ impl Injectable for AdminDatabase {
 			}
 		})?;
 
-		let db = AdminDatabase::from_arc(conn);
+		let db = AdminDatabase::new(*conn);
 		// Cache for subsequent requests
 		ctx.set_singleton(db.clone());
 		Ok(db)

--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -78,7 +78,6 @@ fn json_to_sea_value(value: serde_json::Value) -> Value {
 		_ => Value::String(Some(Box::new(value.to_string()))),
 	}
 }
-use std::sync::Arc;
 
 /// Dummy record type for admin panel CRUD operations
 ///

--- a/crates/reinhardt-admin/src/server/admin_auth.rs
+++ b/crates/reinhardt-admin/src/server/admin_auth.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 pub(crate) type AdminUserLoaderFn = Arc<
 	dyn Fn(
 			String,
-			Arc<DatabaseConnection>,
+			DatabaseConnection,
 		) -> Pin<Box<dyn Future<Output = Result<Arc<dyn AdminUser>, DiError>> + Send>>
 		+ Send
 		+ Sync,
@@ -118,7 +118,7 @@ impl Injectable for AdminAuthenticatedUser {
 				})?;
 
 		// Resolve DatabaseConnection from DI (singleton-first, request-scope fallback)
-		let db: Arc<DatabaseConnection> = ctx
+		let db = ctx
 			.get_singleton::<DatabaseConnection>()
 			.or_else(|| ctx.get_request::<DatabaseConnection>())
 			.ok_or_else(|| {
@@ -133,7 +133,7 @@ impl Injectable for AdminAuthenticatedUser {
 			})?;
 
 		// Call the type-erased loader to query the user from the database
-		let user = (loader.0)(user_id, db).await?;
+		let user = (loader.0)(user_id, *db).await?;
 
 		// Verify user account is active
 		if !user.is_active() {
@@ -188,7 +188,7 @@ where
 				})?;
 
 			let model_pk = <U as Model>::PrimaryKey::from(pk);
-			let mut db = (*db).clone();
+			let mut db = db;
 
 			// Query user from database
 			let user = U::objects()
@@ -239,7 +239,7 @@ pub(crate) type AdminLoginAuthenticatorFn = Arc<
 	dyn Fn(
 			String,
 			String,
-			Arc<DatabaseConnection>,
+			DatabaseConnection,
 		)
 			-> Pin<Box<dyn Future<Output = Result<Option<AuthenticatedUserInfo>, DiError>> + Send>>
 		+ Send
@@ -284,7 +284,7 @@ where
 
 	let authenticator: AdminLoginAuthenticatorFn = Arc::new(move |username, password, db| {
 		Box::pin(async move {
-			let mut db = (*db).clone();
+			let mut db = db;
 
 			// Query user by username
 			let user: Option<U> = U::objects()

--- a/crates/reinhardt-admin/src/server/login.rs
+++ b/crates/reinhardt-admin/src/server/login.rs
@@ -110,7 +110,7 @@ async fn complete_admin_login(
 	let jwt_auth = JwtAuth::new(jwt_secret);
 
 	// Authenticate user (username lookup + password verification + staff check)
-	let user_info = (authenticator.0)(username.clone(), password, db.connection_arc())
+	let user_info = (authenticator.0)(username.clone(), password, *db.connection())
 		.await
 		.map_err(|e| {
 			::tracing::warn!(error = ?e, "admin_login: Authentication failed");

--- a/crates/reinhardt-admin/tests/e2e_pages.rs
+++ b/crates/reinhardt-admin/tests/e2e_pages.rs
@@ -26,7 +26,7 @@ use reinhardt_admin::core::{
 use reinhardt_auth::{Argon2Hasher, PasswordHasher};
 use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection;
 use reinhardt_db::backends::dialect::PostgresBackend;
-use reinhardt_db::orm::connection::{DatabaseBackend, DatabaseConnection};
+use reinhardt_db::orm::connection::{DatabaseConnection, DatabaseConnectionLease};
 use reinhardt_di::{InjectionContext, SingletonScope};
 use reinhardt_query::prelude::{
 	ColumnDef, Expr, OnConflict, PostgresQueryBuilder, Query, QueryBuilder, QueryStatementBuilder,
@@ -259,6 +259,7 @@ struct E2eContext {
 	pool: sqlx::PgPool,
 	// Hold server and db alive for the test lifetime.
 	_server: TestServer,
+	_db_lease: DatabaseConnectionLease,
 	_admin_db: Arc<AdminDatabase>,
 }
 
@@ -473,9 +474,10 @@ where
 
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db_conn = Arc::new(connection);
-	let admin_db = Arc::new(AdminDatabase::new((*db_conn).clone()));
+	let db_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("PostgreSQL connection should register");
+	let db_conn = db_lease.handle();
+	let admin_db = Arc::new(AdminDatabase::new(db_conn));
 
 	let mut site = AdminSite::new("E2E Test Admin");
 	site.set_jwt_secret(JWT_SECRET);
@@ -485,7 +487,7 @@ where
 	let (admin_router, admin_di) = admin_routes_with_di(site);
 
 	let singleton = Arc::new(SingletonScope::new());
-	singleton.set_arc(db_conn);
+	singleton.set(db_conn);
 	let di_ctx = Arc::new(InjectionContext::builder(singleton).build());
 
 	let router = reinhardt_urls::routers::UnifiedRouter::new()
@@ -506,6 +508,7 @@ where
 		site_header,
 		pool: pool_for_ctx,
 		_server: server,
+		_db_lease: db_lease,
 		_admin_db: admin_db,
 	}
 }

--- a/crates/reinhardt-auth/src/auth_user.rs
+++ b/crates/reinhardt-auth/src/auth_user.rs
@@ -8,7 +8,6 @@ use async_trait::async_trait;
 use reinhardt_db::orm::{CustomManager, DatabaseConnection, Model};
 use reinhardt_di::{DiError, DiResult, Injectable, InjectionContext};
 use reinhardt_http::AuthState;
-use std::sync::Arc;
 
 /// Authenticated user extractor that loads the full user model from database.
 ///
@@ -85,7 +84,7 @@ where
 	// using get_singleton/get_request directly because DatabaseConnection is
 	// pre-seeded into the singleton scope at server startup, not registered in
 	// the global DependencyRegistry.
-	let db: Arc<DatabaseConnection> = ctx
+	let db = ctx
 		.get_singleton::<DatabaseConnection>()
 		.or_else(|| ctx.get_request::<DatabaseConnection>())
 		.ok_or_else(|| {
@@ -94,7 +93,7 @@ where
 				message: "CurrentUser: DatabaseConnection not registered in DI context".to_string(),
 			}
 		})?;
-	let mut db = (*db).clone();
+	let mut db = *db;
 
 	U::objects()
 		.get(model_pk)

--- a/crates/reinhardt-auth/src/bin/createsuperuser.rs
+++ b/crates/reinhardt-auth/src/bin/createsuperuser.rs
@@ -26,7 +26,10 @@ use chrono::Utc;
 use reinhardt_core::macros::model;
 
 #[cfg(feature = "database")]
-use reinhardt_db::{DatabaseConnection, prelude::Model};
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection, orm::DatabaseConnectionLease,
+	prelude::Model,
+};
 
 #[derive(Parser, Debug)]
 #[command(name = "createsuperuser")]
@@ -291,7 +294,9 @@ async fn create_database_user(
 	password: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
 	// Create database connection to initialize the ORM context
-	let _connection = DatabaseConnection::connect(database_url).await?;
+	let owner = BackendsConnection::connect(database_url).await?;
+	let lease = DatabaseConnectionLease::register(owner)?;
+	let _connection = lease.handle();
 
 	// Create user
 	create_user_in_database(username, email, password).await?;

--- a/crates/reinhardt-auth/src/sessions/backends/database.rs
+++ b/crates/reinhardt-auth/src/sessions/backends/database.rs
@@ -61,20 +61,8 @@ use crate::sessions::cleanup::{CleanupableBackend, SessionMetadata};
 use super::cache::{SessionBackend, SessionError};
 
 async fn connect_backend(database_url: &str) -> Result<BackendsConnection, SessionError> {
-	let connection =
-		if database_url.starts_with("postgres://") || database_url.starts_with("postgresql://") {
-			BackendsConnection::connect_postgres(database_url).await
-		} else if database_url.starts_with("mysql://") {
-			BackendsConnection::connect_mysql(database_url).await
-		} else if database_url.starts_with("sqlite://") || database_url.starts_with("sqlite:") {
-			BackendsConnection::connect_sqlite(database_url).await
-		} else {
-			return Err(SessionError::CacheError(format!(
-				"Unsupported database URL scheme: {database_url}"
-			)));
-		};
-
-	connection
+	BackendsConnection::connect(database_url)
+		.await
 		.map_err(|error| SessionError::CacheError(format!("Database connection error: {error}")))
 }
 

--- a/crates/reinhardt-auth/src/sessions/backends/database.rs
+++ b/crates/reinhardt-auth/src/sessions/backends/database.rs
@@ -45,18 +45,38 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use reinhardt_core::macros::model;
-use reinhardt_db::DatabaseConnection;
-use reinhardt_db::orm::{DatabaseBackend, Filter, FilterOperator, FilterValue, Model};
+use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+use reinhardt_db::orm::{
+	DatabaseBackend, DatabaseConnection, DatabaseConnectionLease, Filter, FilterOperator,
+	FilterValue, Model,
+};
 use reinhardt_query::prelude::{
 	Alias, ColumnDef, CreateIndexStatement, Expr, ExprTrait, IntoValue, MySqlQueryBuilder,
 	OnConflict, PostgresQueryBuilder, Query, QueryStatementBuilder, SqliteQueryBuilder,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::sessions::cleanup::{CleanupableBackend, SessionMetadata};
 
 use super::cache::{SessionBackend, SessionError};
+
+async fn connect_backend(database_url: &str) -> Result<BackendsConnection, SessionError> {
+	let connection =
+		if database_url.starts_with("postgres://") || database_url.starts_with("postgresql://") {
+			BackendsConnection::connect_postgres(database_url).await
+		} else if database_url.starts_with("mysql://") {
+			BackendsConnection::connect_mysql(database_url).await
+		} else if database_url.starts_with("sqlite://") || database_url.starts_with("sqlite:") {
+			BackendsConnection::connect_sqlite(database_url).await
+		} else {
+			return Err(SessionError::CacheError(format!(
+				"Unsupported database URL scheme: {database_url}"
+			)));
+		};
+
+	connection
+		.map_err(|error| SessionError::CacheError(format!("Database connection error: {error}")))
+}
 
 /// Database session model
 ///
@@ -125,13 +145,12 @@ pub struct Session {
 /// ```rust,no_run
 /// use reinhardt_auth::sessions::backends::{DatabaseSessionBackend, SessionBackend};
 /// use serde_json::json;
-/// use reinhardt_db::DatabaseConnection;
-/// use std::sync::Arc;
+/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
 ///
 /// # async fn example() {
 /// // Initialize backend with database connection
-/// let connection = DatabaseConnection::connect("sqlite::memory:").await.unwrap();
-/// let backend = DatabaseSessionBackend::from_connection(Arc::new(connection));
+/// let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await.unwrap();
+/// let backend = DatabaseSessionBackend::from_connection(owner).unwrap();
 ///
 /// // Note: Table should be created via migrations
 ///
@@ -147,7 +166,8 @@ pub struct Session {
 /// ```
 #[derive(Clone)]
 pub struct DatabaseSessionBackend {
-	connection: Arc<DatabaseConnection>,
+	_lease: DatabaseConnectionLease,
+	connection: DatabaseConnection,
 }
 
 impl DatabaseSessionBackend {
@@ -173,13 +193,9 @@ impl DatabaseSessionBackend {
 	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());
 	/// ```
 	pub async fn new(database_url: &str) -> Result<Self, SessionError> {
-		let connection = DatabaseConnection::connect(database_url)
-			.await
-			.map_err(|e| SessionError::CacheError(format!("Database connection error: {}", e)))?;
+		let owner = connect_backend(database_url).await?;
 
-		Ok(Self {
-			connection: Arc::new(connection),
-		})
+		Self::from_connection(owner)
 	}
 
 	/// Create a new backend from an existing database connection
@@ -188,18 +204,22 @@ impl DatabaseSessionBackend {
 	///
 	/// ```rust,no_run
 	/// use reinhardt_auth::sessions::backends::DatabaseSessionBackend;
-	/// use reinhardt_db::DatabaseConnection;
-	/// use std::sync::Arc;
+	/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
 	///
 	/// # async fn example() {
-	/// let connection = DatabaseConnection::connect("sqlite::memory:").await.unwrap();
-	/// let backend = DatabaseSessionBackend::from_connection(Arc::new(connection));
+	/// let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await.unwrap();
+	/// let backend = DatabaseSessionBackend::from_connection(owner).unwrap();
 	/// // Backend created from existing connection
 	/// # }
 	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());
 	/// ```
-	pub fn from_connection(connection: Arc<DatabaseConnection>) -> Self {
-		Self { connection }
+	pub fn from_connection(owner: BackendsConnection) -> Result<Self, SessionError> {
+		let lease = DatabaseConnectionLease::register(owner)
+			.map_err(|e| SessionError::CacheError(format!("Database connection error: {}", e)))?;
+		Ok(Self {
+			connection: lease.handle(),
+			_lease: lease,
+		})
 	}
 
 	/// Build SQL string for the current database backend

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -753,7 +753,7 @@ async fn build_from_state_from_db(
 	migrations_dir: &std::path::Path,
 	database_url: &str,
 ) -> Result<reinhardt_db::migrations::ProjectState, crate::CommandError> {
-	use reinhardt_db::DatabaseConnection;
+	use reinhardt_db::backends::DatabaseConnection;
 	use reinhardt_db::migrations::{
 		DatabaseMigrationRecorder, FilesystemSource, MigrationSource, MigrationStateLoader,
 	};
@@ -768,7 +768,7 @@ async fn build_from_state_from_db(
 	eprintln!("[DEBUG] Database connection successful");
 
 	// 3. Build state from database history
-	let recorder = DatabaseMigrationRecorder::new(connection.inner().clone());
+	let recorder = DatabaseMigrationRecorder::new(connection);
 	let applied_records = recorder.get_applied_migrations().await.map_err(|e| {
 		crate::CommandError::ExecutionError(format!("Failed to get applied migrations: {}", e))
 	})?;
@@ -2751,11 +2751,12 @@ impl RunServerCommand {
 		// and register it in the DI singleton scope. (#3186)
 		#[cfg(feature = "reinhardt-db")]
 		{
-			match reinhardt_db::orm::get_connection().await {
-				Ok(db_conn) => {
+			match reinhardt_db::orm::get_connection_registration().await {
+				Ok((database_lease, database_handle)) => {
 					// Register DatabaseConnection directly (not wrapped in Arc)
 					// The DI system wraps it in Arc internally via SingletonScope::set
-					singleton_scope.set(db_conn);
+					singleton_scope.set(database_lease);
+					singleton_scope.set(database_handle);
 					let url = std::env::var("DATABASE_URL").ok().unwrap_or_default();
 					ctx.info(&format!(
 						"💾 Database: {} (DI registered)",

--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -116,13 +116,12 @@ Provides compile-time code generation for common patterns.
     use reinhardt::views::{get, post};
     use reinhardt::http::{Response, ViewResult};
     use reinhardt::extractors::{Path, Json};
-    use std::sync::Arc;
     use uuid::Uuid;
 
     #[get("/users/{<uuid:id>}", use_inject = true)]
     async fn get_user(
         Path(id): Path<Uuid>,
-        #[inject] db: Arc<DatabaseConnection>,  // Injected from context
+        #[inject] db: DatabaseConnection,  // Injected from context
     ) -> ViewResult<Response> {
         // ...
     }
@@ -130,7 +129,7 @@ Provides compile-time code generation for common patterns.
     #[post("/users", use_inject = true)]
     async fn create_user(
         Json(data): Json<CreateUserRequest>,
-        #[inject] db: Arc<DatabaseConnection>,
+        #[inject] db: DatabaseConnection,
     ) -> ViewResult<Response> {
         // ...
     }

--- a/crates/reinhardt-core/src/exception.rs
+++ b/crates/reinhardt-core/src/exception.rs
@@ -426,6 +426,7 @@ impl Error {
 					DatabaseErrorKind::Syntax
 					| DatabaseErrorKind::Type
 					| DatabaseErrorKind::ColumnNotFound
+					| DatabaseErrorKind::ConnectionHandleExpired
 					| DatabaseErrorKind::Transaction
 					| DatabaseErrorKind::Configuration
 					| DatabaseErrorKind::Serialization

--- a/crates/reinhardt-core/src/exception/database.rs
+++ b/crates/reinhardt-core/src/exception/database.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 pub enum DatabaseErrorKind {
 	/// A database connection could not be established or was lost.
 	Connection,
+	/// The injected database handle outlived its owning DI scope.
+	ConnectionHandleExpired,
 	/// A database operation or connection-pool acquisition timed out.
 	Timeout,
 	/// A unique constraint was violated.
@@ -72,5 +74,24 @@ impl DatabaseError {
 	/// Returns the driver- or database-specific error code, if available.
 	pub fn code(&self) -> Option<&str> {
 		self.code.as_deref()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{DatabaseError, DatabaseErrorKind};
+
+	#[test]
+	fn connection_handle_expired_has_stable_display_and_server_status() {
+		let error = DatabaseError::new(
+			DatabaseErrorKind::ConnectionHandleExpired,
+			"The injected database connection is no longer available because its DI scope has ended",
+		);
+
+		assert_eq!(
+			error.to_string(),
+			"The injected database connection is no longer available because its DI scope has ended"
+		);
+		assert_eq!(crate::exception::Error::from(error).status_code(), 500);
 	}
 }

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -104,7 +104,10 @@ failures retain the same typed channel as domain failures:
 
 ```rust,no_run
 use reinhardt_core::exception::Error;
-use reinhardt_db::orm::connection::DatabaseConnection;
+use reinhardt_db::{
+    backends::DatabaseConnection as BackendsConnection,
+    orm::DatabaseConnectionLease,
+};
 
 #[derive(Debug, thiserror::Error)]
 enum ApplicationError {
@@ -115,7 +118,9 @@ enum ApplicationError {
 }
 
 # async fn example() -> Result<(), ApplicationError> {
-let connection = DatabaseConnection::connect("sqlite::memory:").await?;
+let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await?;
+let lease = DatabaseConnectionLease::register(owner)?;
+let connection = lease.handle();
 let result: Result<(), ApplicationError> = connection.atomic(async |_transaction| {
     Err(ApplicationError::Rejected)
 }).await;
@@ -749,7 +754,7 @@ async fn test_with_database(
 
 For comprehensive testing standards, see:
 - [Testing Standards](../../instructions/TESTING_STANDARDS.md)
-- [Examples Database Integration](../../examples/examples-database-integration/README.md)
+- [REST Tutorial Database Integration](../../examples/examples-tutorial-rest/README.md)
 
 ### Troubleshooting
 

--- a/crates/reinhardt-db/src/backends/connection.rs
+++ b/crates/reinhardt-db/src/backends/connection.rs
@@ -10,12 +10,6 @@ use super::{
 
 #[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
 use super::error::map_sqlx_error;
-#[cfg(any(
-	feature = "postgres",
-	feature = "sqlite",
-	feature = "mysql",
-	feature = "settings"
-))]
 use super::error::{DatabaseError, DatabaseErrorKind};
 
 #[cfg(feature = "postgres")]
@@ -117,6 +111,50 @@ impl reinhardt_di::Injectable for DatabaseConnection {
 }
 
 impl DatabaseConnection {
+	/// Connects to the backend selected by the URL scheme.
+	pub async fn connect(url: &str) -> Result<Self> {
+		let postgres = url.starts_with("postgres://") || url.starts_with("postgresql://");
+		let mysql = url.starts_with("mysql://");
+		let sqlite = url.starts_with("sqlite://") || url.starts_with("sqlite:");
+
+		#[cfg(feature = "postgres")]
+		if postgres {
+			return Self::connect_postgres(url).await;
+		}
+
+		#[cfg(feature = "mysql")]
+		if mysql {
+			return Self::connect_mysql(url).await;
+		}
+
+		#[cfg(feature = "sqlite")]
+		if sqlite {
+			return Self::connect_sqlite(url).await;
+		}
+
+		let missing_feature = if postgres {
+			Some("postgres")
+		} else if mysql {
+			Some("mysql")
+		} else if sqlite {
+			Some("sqlite")
+		} else {
+			None
+		};
+		if let Some(feature) = missing_feature {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Configuration,
+				format!("Database backend not compiled in. Enable the '{feature}' feature."),
+			)
+			.into());
+		}
+		Err(DatabaseError::new(
+			DatabaseErrorKind::Configuration,
+			format!("Unsupported database URL scheme: {url}"),
+		)
+		.into())
+	}
+
 	/// Creates a new instance.
 	///
 	/// Defaults to `is_cockroachdb = false`, which is the correct choice when
@@ -802,6 +840,35 @@ mod tests {
 	fn test_parse_postgres_url_rejects_invalid_configuration(#[case] url: &str) {
 		// Act
 		let error = super::DatabaseConnection::parse_postgres_url_for_creation(url).unwrap_err();
+
+		// Assert
+		assert_eq!(
+			error.database_kind(),
+			Some(super::DatabaseErrorKind::Configuration)
+		);
+	}
+
+	#[cfg(feature = "sqlite")]
+	#[rstest]
+	#[tokio::test]
+	async fn connect_selects_sqlite_from_url_scheme() {
+		// Act
+		let connection = super::DatabaseConnection::connect("sqlite::memory:")
+			.await
+			.unwrap();
+
+		// Assert
+		assert!(connection.into_sqlite().is_some());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn connect_rejects_unknown_url_scheme() {
+		// Act
+		let Err(error) = super::DatabaseConnection::connect("unknown://localhost/database").await
+		else {
+			panic!("unknown URL schemes must be rejected");
+		};
 
 		// Assert
 		assert_eq!(

--- a/crates/reinhardt-db/src/lib.rs
+++ b/crates/reinhardt-db/src/lib.rs
@@ -138,7 +138,10 @@
 //!
 //! ```rust,no_run
 //! use reinhardt_core::exception::Error;
-//! use reinhardt_db::orm::connection::DatabaseConnection;
+//! use reinhardt_db::{
+//!     backends::DatabaseConnection as BackendsConnection,
+//!     orm::DatabaseConnectionLease,
+//! };
 //!
 //! #[derive(Debug, thiserror::Error)]
 //! enum ApplicationError {
@@ -149,7 +152,9 @@
 //! }
 //!
 //! # async fn example() -> Result<(), ApplicationError> {
-//! let connection = DatabaseConnection::connect("sqlite::memory:").await?;
+//! let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await?;
+//! let lease = DatabaseConnectionLease::register(owner)?;
+//! let connection = lease.handle();
 //! let result: Result<(), ApplicationError> = connection.atomic(async |_transaction| {
 //!     Err(ApplicationError::Rejected)
 //! }).await;
@@ -238,6 +243,13 @@ pub mod prelude {
 	#[cfg(feature = "orm")]
 	pub use crate::orm::*;
 
+	#[cfg(feature = "orm")]
+	// Allow the private explicit import to keep the lease out of the public prelude glob.
+	#[allow(hidden_glob_reexports)]
+	// Allow the shadowing import even though the prelude does not use the lease internally.
+	#[allow(unused_imports)]
+	use crate::orm::DatabaseConnectionLease;
+
 	#[cfg(feature = "migrations")]
 	pub use crate::migrations::*;
 
@@ -262,8 +274,11 @@ pub mod prelude {
 #[cfg(feature = "backends")]
 pub use backends::{DatabaseBackend, DatabaseError, DatabaseErrorKind};
 
-// Re-export ORM's DatabaseConnection which wraps BackendsConnection
-// This is the type used by Manager and other ORM components
+/// Copyable ORM connection handle used by managers and application handlers.
+///
+/// Standalone applications retain an [`orm::DatabaseConnectionLease`] for the
+/// full lifetime of every handle. Framework bootstrap owns that lease and
+/// injects this handle into request handlers.
 #[cfg(feature = "orm")]
 pub use orm::DatabaseConnection;
 #[cfg(feature = "orm")]

--- a/crates/reinhardt-db/src/orm.rs
+++ b/crates/reinhardt-db/src/orm.rs
@@ -2,6 +2,11 @@
 //!
 //! Object-Relational Mapping for Reinhardt framework.
 //!
+//! [`DatabaseConnection`] is a copyable ORM capability. Standalone setup owns a
+//! backend connection through [`DatabaseConnectionLease`], and the lease must
+//! outlive all operations performed by its handles. Framework handlers receive
+//! the handle through `#[inject]` while server bootstrap retains the lease.
+//!
 //! Typed relation traversal lets `QuerySet` filters and relation loading cross
 //! model relations with generated `rel_<name>()` accessors. The typed path
 //! records the SQL joins required by the filter, so application code does not
@@ -17,10 +22,12 @@
 //!
 //! ```no_run
 //! use reinhardt_core::exception::Error;
-//! use reinhardt_db::orm::DatabaseConnection;
+//! use reinhardt_db::{backends::DatabaseConnection as BackendsConnection, orm::DatabaseConnectionLease};
 //!
 //! # async fn example() -> Result<(), Error> {
-//! let connection = DatabaseConnection::connect("sqlite::memory:").await?;
+//! let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await?;
+//! let lease = DatabaseConnectionLease::register(owner)?;
+//! let connection = lease.handle();
 //! let result = connection.atomic(async |transaction| {
 //!     transaction.atomic(async |_savepoint| {
 //!         Ok::<_, Error>(())
@@ -39,6 +46,8 @@
 //!
 //! [`Transaction`], [`Savepoint`], and [`IsolationLevel`] remain SQL-builder
 //! values only. They may generate SQL but cannot control a live ORM transaction.
+//! [`AtomicTransaction`] is also intentionally non-`Copy` and stays bound to
+//! the callback and dedicated connection created by [`DatabaseConnection::atomic`].
 
 // Core modules - always available
 pub mod aggregation;
@@ -47,6 +56,7 @@ pub mod annotation;
 pub mod bulk_update;
 pub mod connection;
 pub mod connection_ext; // reinhardt-query connection support
+mod connection_registry;
 /// Constraints module.
 pub mod constraints;
 /// Expressions module.
@@ -144,8 +154,11 @@ pub mod custom_manager;
 pub mod query;
 
 pub use custom_manager::CustomManager;
+#[cfg(feature = "di")]
+pub use engine::register_request_database;
 pub use manager::{
-	get_connection, init_database, init_database_with_pool_size, reinitialize_database,
+	get_connection, get_connection_lease, get_connection_registration, init_database,
+	init_database_with_pool_size, reinitialize_database,
 };
 
 // Re-export paste for macro usage
@@ -156,8 +169,8 @@ pub use paste;
 pub use aggregation::{Aggregate, AggregateFunc, AggregateResult, AggregateValue};
 pub use annotation::{Annotation, AnnotationValue, Expression, Value, When};
 pub use connection::{
-	DatabaseBackend, DatabaseConnection, OrmExecutor, QueryResult, QueryRow, QueryValue, Row,
-	TransactionExecutor,
+	DatabaseBackend, DatabaseConnection, DatabaseConnectionLease, OrmExecutor, QueryResult,
+	QueryRow, QueryValue, Row, TransactionExecutor,
 };
 pub use constraints::{
 	CheckConstraint, Constraint, ForeignKeyConstraint, OnDelete, OnUpdate, UniqueConstraint,

--- a/crates/reinhardt-db/src/orm/connection.rs
+++ b/crates/reinhardt-db/src/orm/connection.rs
@@ -1,11 +1,15 @@
 //! Database connection management
 //!
-//! This module provides the main `DatabaseConnection` type which wraps
-//! the backend-specific connection implementations.
+//! This module separates backend ownership from the copyable ORM connection
+//! capability. [`DatabaseConnectionLease`] owns the registry lifetime and
+//! [`DatabaseConnection`] resolves the backend for each operation.
 
 use async_trait::async_trait;
-use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind, Result};
+use std::sync::Arc;
 
+use reinhardt_core::exception::Result;
+
+use super::connection_registry::{self, ConnectionSlot, Generation, RegisteredConnection};
 use super::transaction::AtomicTransaction;
 
 /// Re-export backends types
@@ -15,7 +19,7 @@ pub use crate::backends::types::{
 	IsolationLevel, QueryResult, QueryValue, Row, TransactionExecutor,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Defines possible database backend values.
 pub enum DatabaseBackend {
 	/// Postgres variant.
@@ -183,181 +187,51 @@ pub trait OrmExecutor: Send {
 	async fn fetch_optional(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>>;
 }
 
-/// Database connection wrapper
-#[derive(Clone)]
+/// Copyable capability for an ORM database connection.
+///
+/// A handle remains valid while at least one clone of its originating
+/// [`DatabaseConnectionLease`] exists. Operations started after the last lease
+/// drops return `DatabaseErrorKind::ConnectionHandleExpired`; operations that
+/// already resolved the backend are allowed to finish.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct DatabaseConnection {
+	slot: ConnectionSlot,
+	generation: Generation,
 	backend: DatabaseBackend,
-	inner: BackendsConnection,
+}
+
+/// RAII owner that keeps a database connection handle valid.
+///
+/// Retain this owner in standalone application or server-bootstrap state. The
+/// handle returned by [`Self::handle`] may be copied into concurrent operations,
+/// but no copied handle extends the lease lifetime.
+#[derive(Clone)]
+pub struct DatabaseConnectionLease {
+	registration: RegisteredConnection,
+}
+
+impl DatabaseConnectionLease {
+	/// Registers a backend connection and owns its registry lifetime.
+	pub fn register(owner: BackendsConnection) -> Result<Self> {
+		Ok(Self {
+			registration: connection_registry::register(owner)?,
+		})
+	}
+
+	/// Returns the copyable ORM capability associated with this lease.
+	pub fn handle(&self) -> DatabaseConnection {
+		let (slot, generation, backend) = self.registration.handle_parts();
+		DatabaseConnection {
+			slot,
+			generation,
+			backend,
+		}
+	}
 }
 
 impl DatabaseConnection {
-	/// Creates a new instance.
-	pub fn new(backend: DatabaseBackend, inner: BackendsConnection) -> Self {
-		Self { backend, inner }
-	}
-
-	/// Connect to a database from a connection URL
-	///
-	/// Automatically detects the database type from the URL scheme:
-	/// - `postgres://` or `postgresql://` → PostgreSQL
-	/// - `mysql://` → MySQL
-	/// - `sqlite://` or `sqlite:` → SQLite
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// # async fn example() {
-	/// use reinhardt_db::orm::connection::DatabaseConnection;
-	///
-	/// let conn = DatabaseConnection::connect("postgres://localhost/mydb").await.unwrap();
-	/// # }
-	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());
-	/// ```
-	pub async fn connect(url: &str) -> Result<Self> {
-		Self::connect_with_pool_size(url, None).await
-	}
-
-	/// Connect to a PostgreSQL database
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// # async fn example() {
-	/// use reinhardt_db::orm::connection::DatabaseConnection;
-	///
-	/// let conn = DatabaseConnection::connect_postgres("postgres://localhost/mydb").await.unwrap();
-	/// # }
-	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());
-	/// ```
-	#[cfg(feature = "postgres")]
-	pub async fn connect_postgres(url: &str) -> Result<Self> {
-		let inner = BackendsConnection::connect_postgres(url).await?;
-		Ok(Self {
-			backend: DatabaseBackend::Postgres,
-			inner,
-		})
-	}
-
-	/// Connect to a MySQL database
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// # async fn example() {
-	/// use reinhardt_db::orm::connection::DatabaseConnection;
-	///
-	/// let conn = DatabaseConnection::connect_mysql("mysql://localhost/mydb").await.unwrap();
-	/// # }
-	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());
-	/// ```
-	#[cfg(feature = "mysql")]
-	pub async fn connect_mysql(url: &str) -> Result<Self> {
-		let inner = BackendsConnection::connect_mysql(url).await?;
-		Ok(Self {
-			backend: DatabaseBackend::MySql,
-			inner,
-		})
-	}
-
-	/// Connect to a SQLite database
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// # async fn example() {
-	/// use reinhardt_db::orm::connection::DatabaseConnection;
-	///
-	/// let conn = DatabaseConnection::connect_sqlite("sqlite::memory:").await.unwrap();
-	/// # }
-	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());
-	/// ```
-	#[cfg(feature = "sqlite")]
-	pub async fn connect_sqlite(url: &str) -> Result<Self> {
-		let inner = BackendsConnection::connect_sqlite(url).await?;
-		Ok(Self {
-			backend: DatabaseBackend::Sqlite,
-			inner,
-		})
-	}
-
-	/// Connect to a database with a specific connection pool size
-	///
-	/// # Arguments
-	///
-	/// * `url` - Database connection URL
-	/// * `pool_size` - Maximum number of connections in the pool (None = use default)
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// # async fn example() {
-	/// use reinhardt_db::orm::connection::DatabaseConnection;
-	///
-	/// // Use larger pool for high-concurrency scenarios
-	/// let conn = DatabaseConnection::connect_with_pool_size(
-	///     "postgres://localhost/mydb",
-	///     Some(50)
-	/// ).await.unwrap();
-	/// # }
-	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());
-	/// ```
-	// Allow unused_variables because pool_size is only used with Postgres backend.
-	// MySQL and SQLite backends don't support pool size configuration yet.
-	#[allow(unused_variables)]
-	pub async fn connect_with_pool_size(url: &str, pool_size: Option<u32>) -> Result<Self> {
-		let backend_type = if url.starts_with("postgres://") || url.starts_with("postgresql://") {
-			DatabaseBackend::Postgres
-		} else if url.starts_with("mysql://") {
-			DatabaseBackend::MySql
-		} else if url.starts_with("sqlite://") || url.starts_with("sqlite:") {
-			DatabaseBackend::Sqlite
-		} else {
-			return Err(DatabaseError::new(
-				DatabaseErrorKind::Configuration,
-				format!("Unsupported database URL scheme: {url}"),
-			)
-			.into());
-		};
-
-		#[cfg(feature = "postgres")]
-		if backend_type == DatabaseBackend::Postgres {
-			let inner = BackendsConnection::connect_postgres_with_pool_size(url, pool_size).await?;
-			return Ok(Self {
-				backend: backend_type,
-				inner,
-			});
-		}
-
-		#[cfg(feature = "mysql")]
-		if backend_type == DatabaseBackend::MySql {
-			let inner = BackendsConnection::connect_mysql(url).await?;
-			return Ok(Self {
-				backend: backend_type,
-				inner,
-			});
-		}
-
-		#[cfg(feature = "sqlite")]
-		if backend_type == DatabaseBackend::Sqlite {
-			let inner = BackendsConnection::connect_sqlite(url).await?;
-			return Ok(Self {
-				backend: backend_type,
-				inner,
-			});
-		}
-
-		Err(DatabaseError::new(
-			DatabaseErrorKind::Configuration,
-			format!(
-				"Database backend not compiled in. Enable the '{}' feature.",
-				match backend_type {
-					DatabaseBackend::Postgres => "postgres",
-					DatabaseBackend::MySql => "mysql",
-					DatabaseBackend::Sqlite => "sqlite",
-				}
-			),
-		)
-		.into())
+	fn resolve(self) -> Result<Arc<BackendsConnection>> {
+		Ok(connection_registry::resolve(self.slot, self.generation)?)
 	}
 
 	/// Performs the backend operation.
@@ -365,38 +239,10 @@ impl DatabaseConnection {
 		self.backend
 	}
 
-	/// Get a reference to the inner backends connection
-	///
-	/// This provides access to the low-level connection for operations
-	/// that require direct database access.
-	///
-	/// # ORM warning
-	///
-	/// This is a backend-level escape hatch. It bypasses the connection affinity
-	/// and atomicity guarantees of [`Self::atomic`]. Do not use it for ORM
-	/// `*_with_conn` operations; run those through the callback-owned executor
-	/// supplied by [`Self::atomic`] instead.
-	pub fn inner(&self) -> &BackendsConnection {
-		&self.inner
-	}
-
-	/// Consume self and return the inner backends connection
-	///
-	/// This is useful when you need to pass ownership of the connection
-	/// to functions that expect a `BackendsConnection`.
-	///
-	/// # ORM warning
-	///
-	/// The returned backend connection is not an [`OrmExecutor`]. It bypasses
-	/// [`Self::atomic`] connection affinity and atomicity guarantees, so do not
-	/// use it for ORM `*_with_conn` operations.
-	pub fn into_inner(self) -> BackendsConnection {
-		self.inner
-	}
-
 	/// Execute a SQL query and return a single row
 	pub async fn query_one(&self, sql: &str, params: Vec<QueryValue>) -> Result<QueryRow> {
-		let row = self.inner.fetch_one(sql, params).await?;
+		let owner = self.resolve()?;
+		let row = owner.fetch_one(sql, params).await?;
 		Ok(QueryRow::from_backend_row(row))
 	}
 
@@ -406,24 +252,28 @@ impl DatabaseConnection {
 		sql: &str,
 		params: Vec<QueryValue>,
 	) -> Result<Option<QueryRow>> {
-		let row = self.inner.fetch_optional(sql, params).await?;
+		let owner = self.resolve()?;
+		let row = owner.fetch_optional(sql, params).await?;
 		Ok(row.map(QueryRow::from_backend_row))
 	}
 
 	/// Execute a SQL statement (INSERT, UPDATE, DELETE, etc.)
 	pub async fn execute(&self, sql: &str, params: Vec<QueryValue>) -> Result<u64> {
-		let result = self.inner.execute(sql, params).await?;
+		let owner = self.resolve()?;
+		let result = owner.execute(sql, params).await?;
 		Ok(result.rows_affected)
 	}
 
 	/// Execute a SQL query and return all rows
 	pub async fn query(&self, sql: &str, params: Vec<QueryValue>) -> Result<Vec<QueryRow>> {
-		let rows = self.inner.fetch_all(sql, params).await?;
+		let owner = self.resolve()?;
+		let rows = owner.fetch_all(sql, params).await?;
 		Ok(rows.into_iter().map(QueryRow::from_backend_row).collect())
 	}
 
 	async fn begin_atomic(&self) -> Result<AtomicTransaction> {
-		let executor = self.inner.begin().await?;
+		let owner = self.resolve()?;
+		let executor = owner.begin().await?;
 		Ok(AtomicTransaction::new(executor))
 	}
 
@@ -431,8 +281,8 @@ impl DatabaseConnection {
 		&self,
 		level: super::transaction::IsolationLevel,
 	) -> Result<AtomicTransaction> {
-		let executor = self
-			.inner
+		let owner = self.resolve()?;
+		let executor = owner
 			.begin_with_isolation(level.to_backends_level())
 			.await?;
 		Ok(AtomicTransaction::new(executor))
@@ -480,37 +330,41 @@ impl OrmExecutor for DatabaseConnection {
 	}
 
 	async fn execute(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<QueryResult> {
-		self.inner.execute(sql, params).await
+		let owner = self.resolve()?;
+		owner.execute(sql, params).await
 	}
 
 	async fn fetch_one(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Row> {
-		self.inner.fetch_one(sql, params).await
+		let owner = self.resolve()?;
+		owner.fetch_one(sql, params).await
 	}
 
 	async fn fetch_all(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Vec<Row>> {
-		self.inner.fetch_all(sql, params).await
+		let owner = self.resolve()?;
+		owner.fetch_all(sql, params).await
 	}
 
 	async fn fetch_optional(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>> {
-		self.inner.fetch_optional(sql, params).await
+		let owner = self.resolve()?;
+		owner.fetch_optional(sql, params).await
 	}
 }
 
 /// Injectable implementation for DatabaseConnection
 ///
-/// DatabaseConnection must be explicitly registered in the DI context using
-/// `InjectionContextBuilder::singleton()`. It cannot be auto-injected because
-/// it requires runtime configuration (connection URL, pool settings, etc.).
+/// A `DatabaseConnection` handle must be registered in the DI context while its
+/// `DatabaseConnectionLease` remains owned by server bootstrap.
 ///
 /// # Example
 ///
 /// ```rust,no_run
-/// use reinhardt_db::orm::DatabaseConnection;
+/// use reinhardt_db::{backends::DatabaseConnection as BackendsConnection, orm::DatabaseConnectionLease};
 /// use reinhardt_di::InjectionContext;
 ///
 /// # async fn example() {
-/// // First, establish a database connection
-/// let db = DatabaseConnection::connect("postgres://localhost/mydb").await.unwrap();
+/// let owner = BackendsConnection::connect_postgres("postgres://localhost/mydb").await.unwrap();
+/// let lease = DatabaseConnectionLease::register(owner).unwrap();
+/// let db = lease.handle();
 ///
 /// // Then register it in the DI context as a singleton
 /// let singleton_scope = reinhardt_di::SingletonScope::new();
@@ -523,38 +377,107 @@ impl OrmExecutor for DatabaseConnection {
 #[async_trait]
 impl reinhardt_di::Injectable for DatabaseConnection {
 	async fn inject(ctx: &reinhardt_di::InjectionContext) -> reinhardt_di::DiResult<Self> {
-		// Try singleton scope first (primary expected location)
 		if let Some(conn) = ctx.get_singleton::<Self>() {
-			return Ok(std::sync::Arc::try_unwrap(conn).unwrap_or_else(|arc| (*arc).clone()));
+			return Ok(*conn);
 		}
 
-		// Try request scope as fallback
 		if let Some(conn) = ctx.get_request::<Self>() {
-			return Ok(std::sync::Arc::try_unwrap(conn).unwrap_or_else(|arc| (*arc).clone()));
+			return Ok(*conn);
 		}
 
-		// Not registered - provide helpful error
 		Err(reinhardt_di::DiError::NotRegistered {
 			type_name: std::any::type_name::<Self>().to_string(),
-			hint: "Use InjectionContextBuilder::singleton(db_connection) to register a \
-			       DatabaseConnection. Create it with DatabaseConnection::connect(), \
-			       connect_postgres(), connect_sqlite(), or connect_mysql()."
+			hint: "Server bootstrap must register a DatabaseConnectionLease and inject its \
+			       DatabaseConnection handle with InjectionContextBuilder::singleton()."
 				.to_string(),
 		})
 	}
 
 	async fn inject_uncached(ctx: &reinhardt_di::InjectionContext) -> reinhardt_di::DiResult<Self> {
-		// For DatabaseConnection, inject_uncached behaves the same as inject
-		// since database connections are typically shared (singleton or request-scoped)
 		Self::inject(ctx).await
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use super::{DatabaseBackend, DatabaseConnection, OrmExecutor};
-	use crate::backends::DatabaseErrorKind;
-	use crate::backends::types::DatabaseType;
+	use std::sync::Arc;
+
+	use async_trait::async_trait;
+	use reinhardt_core::exception::Result;
+
+	use super::{
+		BackendsConnection, DatabaseBackend, DatabaseConnection, DatabaseConnectionLease,
+		OrmExecutor,
+	};
+	use crate::backends::backend::DatabaseBackend as BackendsDatabaseBackend;
+	use crate::backends::types::{DatabaseType, QueryResult, QueryValue, Row, TransactionExecutor};
+
+	struct TestBackend;
+
+	#[async_trait]
+	impl BackendsDatabaseBackend for TestBackend {
+		fn database_type(&self) -> DatabaseType {
+			DatabaseType::Sqlite
+		}
+
+		fn placeholder(&self, index: usize) -> String {
+			format!("${index}")
+		}
+
+		fn supports_returning(&self) -> bool {
+			true
+		}
+
+		fn supports_on_conflict(&self) -> bool {
+			true
+		}
+
+		async fn execute(&self, _sql: &str, _params: Vec<QueryValue>) -> Result<QueryResult> {
+			unreachable!()
+		}
+
+		async fn fetch_one(&self, _sql: &str, _params: Vec<QueryValue>) -> Result<Row> {
+			unreachable!()
+		}
+
+		async fn fetch_all(&self, _sql: &str, _params: Vec<QueryValue>) -> Result<Vec<Row>> {
+			unreachable!()
+		}
+
+		async fn fetch_optional(
+			&self,
+			_sql: &str,
+			_params: Vec<QueryValue>,
+		) -> Result<Option<Row>> {
+			unreachable!()
+		}
+
+		async fn begin(&self) -> Result<Box<dyn TransactionExecutor>> {
+			unreachable!()
+		}
+
+		fn as_any(&self) -> &dyn std::any::Any {
+			self
+		}
+	}
+
+	fn mock_backends_connection() -> BackendsConnection {
+		BackendsConnection::new(Arc::new(TestBackend))
+	}
+
+	fn assert_connection_traits<T: Copy + Clone + Send + Sync + 'static>() {}
+
+	fn consume_connection(_connection: DatabaseConnection) {}
+
+	#[test]
+	fn database_connection_is_a_copy_capability() {
+		assert_connection_traits::<DatabaseConnection>();
+
+		let lease = DatabaseConnectionLease::register(mock_backends_connection()).unwrap();
+		let connection = lease.handle();
+		consume_connection(connection);
+		consume_connection(connection);
+	}
 
 	#[test]
 	fn test_database_backend_converts_each_database_type() {
@@ -572,53 +495,14 @@ mod tests {
 		);
 	}
 
-	#[tokio::test]
-	async fn test_error_kind_for_unsupported_url_scheme() {
-		let Err(error) = DatabaseConnection::connect("unsupported://database").await else {
-			panic!("an unsupported URL scheme must fail");
-		};
-
-		assert_eq!(
-			error.database_kind(),
-			Some(DatabaseErrorKind::Configuration)
-		);
-	}
-
-	#[cfg(feature = "postgres")]
-	#[tokio::test]
-	async fn test_error_kind_for_postgres_handshake_timeout() {
-		let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
-			.await
-			.expect("a local ephemeral port must be available");
-		let address = listener
-			.local_addr()
-			.expect("the bound listener must have a local address");
-		let _server = tokio::spawn(async move {
-			let (_stream, _) = listener
-				.accept()
-				.await
-				.expect("the timeout fixture must accept the PostgreSQL connection");
-			std::future::pending::<()>().await;
-		});
-		let url = format!(
-			"postgres://postgres@{}:{}/postgres?connect_timeout=1",
-			address.ip(),
-			address.port()
-		);
-
-		let Err(error) = DatabaseConnection::connect_postgres(&url).await else {
-			panic!("a PostgreSQL handshake that never completes must time out");
-		};
-
-		assert_eq!(error.database_kind(), Some(DatabaseErrorKind::Timeout));
-	}
-
 	#[cfg(feature = "sqlite")]
 	#[tokio::test]
 	async fn test_error_kind_for_missing_sqlite_column() {
-		let connection = DatabaseConnection::connect_sqlite("sqlite::memory:")
+		let owner = BackendsConnection::connect_sqlite("sqlite::memory:")
 			.await
 			.expect("the in-memory SQLite database must connect");
+		let lease = DatabaseConnectionLease::register(owner).unwrap();
+		let connection = lease.handle();
 		connection
 			.execute("CREATE TABLE records (id INTEGER PRIMARY KEY)", vec![])
 			.await
@@ -631,15 +515,20 @@ mod tests {
 			panic!("querying a missing column must fail");
 		};
 
-		assert_eq!(error.database_kind(), Some(DatabaseErrorKind::Query));
+		assert_eq!(
+			error.database_kind(),
+			Some(crate::backends::DatabaseErrorKind::Query)
+		);
 	}
 
 	#[cfg(feature = "sqlite")]
 	#[tokio::test]
 	async fn test_orm_executor_preserves_sqlite_query_result_metadata() {
-		let mut connection = DatabaseConnection::connect_sqlite("sqlite::memory:")
+		let owner = BackendsConnection::connect_sqlite("sqlite::memory:")
 			.await
 			.expect("the in-memory SQLite database must connect");
+		let lease = DatabaseConnectionLease::register(owner).unwrap();
+		let mut connection = lease.handle();
 
 		let create_result = OrmExecutor::execute(
 			&mut connection,
@@ -666,9 +555,11 @@ mod tests {
 	#[cfg(feature = "sqlite")]
 	#[tokio::test]
 	async fn test_query_optional_preserves_sqlite_backend_errors() {
-		let mut connection = DatabaseConnection::connect_sqlite("sqlite::memory:")
+		let owner = BackendsConnection::connect_sqlite("sqlite::memory:")
 			.await
 			.expect("the in-memory SQLite database must connect");
+		let lease = DatabaseConnectionLease::register(owner).unwrap();
+		let mut connection = lease.handle();
 		OrmExecutor::execute(
 			&mut connection,
 			"CREATE TABLE records (id INTEGER PRIMARY KEY)",
@@ -685,6 +576,9 @@ mod tests {
 			Ok(_) => panic!("an invalid optional query must preserve its backend error"),
 		};
 
-		assert_eq!(error.database_kind(), Some(DatabaseErrorKind::Query));
+		assert_eq!(
+			error.database_kind(),
+			Some(crate::backends::DatabaseErrorKind::Query)
+		);
 	}
 }

--- a/crates/reinhardt-db/src/orm/connection_registry.rs
+++ b/crates/reinhardt-db/src/orm/connection_registry.rs
@@ -1,0 +1,306 @@
+use std::sync::{Arc, OnceLock};
+
+use parking_lot::RwLock;
+use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind};
+
+use super::connection::{BackendsConnection, DatabaseBackend};
+
+pub(crate) type ConnectionSlot = u32;
+pub(crate) type Generation = u64;
+
+struct RegistryEntry {
+	generation: Generation,
+	owner: Option<Arc<BackendsConnection>>,
+	retired: bool,
+}
+
+#[derive(Default)]
+struct RegistryState {
+	entries: Vec<RegistryEntry>,
+	free: Vec<ConnectionSlot>,
+}
+
+struct DatabaseConnectionRegistry {
+	state: RwLock<RegistryState>,
+}
+
+impl DatabaseConnectionRegistry {
+	fn new() -> Self {
+		Self {
+			state: RwLock::new(RegistryState::default()),
+		}
+	}
+
+	fn insert(
+		&self,
+		owner: Arc<BackendsConnection>,
+	) -> std::result::Result<(ConnectionSlot, Generation), DatabaseError> {
+		let mut state = self.state.write();
+		while let Some(slot) = state.free.pop() {
+			let entry = &mut state.entries[slot as usize];
+			match entry.generation.checked_add(1) {
+				Some(generation) => {
+					entry.generation = generation;
+					entry.owner = Some(owner);
+					return Ok((slot, generation));
+				}
+				None => entry.retired = true,
+			}
+		}
+
+		let slot = ConnectionSlot::try_from(state.entries.len()).map_err(|_| {
+			DatabaseError::new(
+				DatabaseErrorKind::Connection,
+				"Database connection registry exhausted its slot space",
+			)
+		})?;
+		state.entries.push(RegistryEntry {
+			generation: 0,
+			owner: Some(owner),
+			retired: false,
+		});
+		Ok((slot, 0))
+	}
+
+	fn resolve(
+		&self,
+		slot: ConnectionSlot,
+		generation: Generation,
+	) -> std::result::Result<Arc<BackendsConnection>, DatabaseError> {
+		self.state
+			.read()
+			.entries
+			.get(slot as usize)
+			.filter(|entry| entry.generation == generation)
+			.and_then(|entry| entry.owner.as_ref())
+			.cloned()
+			.ok_or_else(expired_handle_error)
+	}
+
+	fn remove_exact(&self, slot: ConnectionSlot, generation: Generation) {
+		let mut state = self.state.write();
+		let Some(entry) = state.entries.get_mut(slot as usize) else {
+			return;
+		};
+		if entry.generation != generation || entry.owner.take().is_none() {
+			return;
+		}
+		if !entry.retired {
+			state.free.push(slot);
+		}
+	}
+}
+
+#[derive(Clone)]
+pub(crate) struct RegisteredConnection {
+	state: Arc<RegistrationState>,
+	backend: DatabaseBackend,
+}
+
+struct RegistrationState {
+	slot: ConnectionSlot,
+	generation: Generation,
+}
+
+impl Drop for RegistrationState {
+	fn drop(&mut self) {
+		registry().remove_exact(self.slot, self.generation);
+	}
+}
+
+impl RegisteredConnection {
+	pub(crate) fn handle_parts(&self) -> (ConnectionSlot, Generation, DatabaseBackend) {
+		(self.state.slot, self.state.generation, self.backend)
+	}
+}
+
+pub(crate) fn register(
+	owner: BackendsConnection,
+) -> std::result::Result<RegisteredConnection, DatabaseError> {
+	let backend = owner.database_type().into();
+	let (slot, generation) = registry().insert(Arc::new(owner))?;
+	Ok(RegisteredConnection {
+		state: Arc::new(RegistrationState { slot, generation }),
+		backend,
+	})
+}
+
+pub(crate) fn resolve(
+	slot: ConnectionSlot,
+	generation: Generation,
+) -> std::result::Result<Arc<BackendsConnection>, DatabaseError> {
+	registry().resolve(slot, generation)
+}
+
+fn registry() -> &'static DatabaseConnectionRegistry {
+	static REGISTRY: OnceLock<DatabaseConnectionRegistry> = OnceLock::new();
+	REGISTRY.get_or_init(DatabaseConnectionRegistry::new)
+}
+
+fn expired_handle_error() -> DatabaseError {
+	DatabaseError::new(
+		DatabaseErrorKind::ConnectionHandleExpired,
+		"The injected database connection is no longer available because its DI scope has ended",
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::{Arc, Barrier};
+
+	use async_trait::async_trait;
+	use parking_lot::Mutex;
+	use reinhardt_core::exception::{DatabaseErrorKind, Result};
+
+	use super::{register, resolve};
+	use crate::backends::{
+		backend::DatabaseBackend,
+		connection::DatabaseConnection as BackendsConnection,
+		types::{DatabaseType, QueryResult, QueryValue, Row, TransactionExecutor},
+	};
+
+	static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+	struct TestBackend(DatabaseType);
+
+	#[async_trait]
+	impl DatabaseBackend for TestBackend {
+		fn database_type(&self) -> DatabaseType {
+			self.0
+		}
+		fn placeholder(&self, index: usize) -> String {
+			format!("${index}")
+		}
+		fn supports_returning(&self) -> bool {
+			true
+		}
+		fn supports_on_conflict(&self) -> bool {
+			true
+		}
+		async fn execute(&self, _sql: &str, _params: Vec<QueryValue>) -> Result<QueryResult> {
+			unreachable!()
+		}
+		async fn fetch_one(&self, _sql: &str, _params: Vec<QueryValue>) -> Result<Row> {
+			unreachable!()
+		}
+		async fn fetch_all(&self, _sql: &str, _params: Vec<QueryValue>) -> Result<Vec<Row>> {
+			unreachable!()
+		}
+		async fn fetch_optional(
+			&self,
+			_sql: &str,
+			_params: Vec<QueryValue>,
+		) -> Result<Option<Row>> {
+			unreachable!()
+		}
+		async fn begin(&self) -> Result<Box<dyn TransactionExecutor>> {
+			unreachable!()
+		}
+		fn as_any(&self) -> &dyn std::any::Any {
+			self
+		}
+	}
+
+	fn mock_backend_connection(database_type: DatabaseType) -> BackendsConnection {
+		BackendsConnection::new(Arc::new(TestBackend(database_type)))
+	}
+
+	#[test]
+	fn live_registration_resolves_owner() {
+		let _test_guard = TEST_LOCK.lock();
+		let registration = register(mock_backend_connection(DatabaseType::Sqlite)).unwrap();
+		let (slot, generation, backend) = registration.handle_parts();
+
+		assert_eq!(backend, super::super::connection::DatabaseBackend::Sqlite);
+		assert_eq!(
+			resolve(slot, generation).unwrap().database_type(),
+			DatabaseType::Sqlite
+		);
+	}
+
+	#[test]
+	fn stale_generation_never_resolves_reused_slot() {
+		let _test_guard = TEST_LOCK.lock();
+		let first = register(mock_backend_connection(DatabaseType::Sqlite)).unwrap();
+		let (slot, generation, _) = first.handle_parts();
+		drop(first);
+
+		let second = register(mock_backend_connection(DatabaseType::Postgres)).unwrap();
+
+		let error = resolve(slot, generation)
+			.err()
+			.expect("the stale generation must not resolve");
+		assert_eq!(error.kind(), DatabaseErrorKind::ConnectionHandleExpired);
+		assert_eq!(second.handle_parts().0, slot);
+		assert_ne!(second.handle_parts().1, generation);
+	}
+
+	#[test]
+	fn resolved_owner_survives_registration_drop() {
+		let _test_guard = TEST_LOCK.lock();
+		let registration = register(mock_backend_connection(DatabaseType::Sqlite)).unwrap();
+		let (slot, generation, _) = registration.handle_parts();
+		let owner = resolve(slot, generation).unwrap();
+
+		drop(registration);
+
+		assert_eq!(owner.database_type(), DatabaseType::Sqlite);
+		assert_eq!(
+			resolve(slot, generation)
+				.err()
+				.expect("the dropped registration must expire")
+				.kind(),
+			DatabaseErrorKind::ConnectionHandleExpired
+		);
+	}
+
+	#[test]
+	fn owner_expires_only_after_last_registration_clone_drops() {
+		let _test_guard = TEST_LOCK.lock();
+		let registration = register(mock_backend_connection(DatabaseType::Mysql)).unwrap();
+		let first_clone = registration.clone();
+		let last_clone = registration.clone();
+		let (slot, generation, _) = registration.handle_parts();
+
+		drop(registration);
+		drop(first_clone);
+		assert_eq!(
+			resolve(slot, generation).unwrap().database_type(),
+			DatabaseType::Mysql
+		);
+		drop(last_clone);
+		assert_eq!(
+			resolve(slot, generation)
+				.err()
+				.expect("the final dropped clone must expire")
+				.kind(),
+			DatabaseErrorKind::ConnectionHandleExpired
+		);
+	}
+
+	#[test]
+	fn concurrent_resolution_remains_valid_until_last_clone_drops() {
+		let _test_guard = TEST_LOCK.lock();
+		let registration = register(mock_backend_connection(DatabaseType::Postgres)).unwrap();
+		let retained = registration.clone();
+		let (slot, generation, _) = registration.handle_parts();
+		let barrier = Arc::new(Barrier::new(2));
+		let worker_barrier = Arc::clone(&barrier);
+		let worker = std::thread::spawn(move || {
+			worker_barrier.wait();
+			resolve(slot, generation).unwrap().database_type()
+		});
+
+		drop(registration);
+		barrier.wait();
+		assert_eq!(worker.join().unwrap(), DatabaseType::Postgres);
+		drop(retained);
+		assert_eq!(
+			resolve(slot, generation)
+				.err()
+				.expect("the final dropped clone must expire")
+				.kind(),
+			DatabaseErrorKind::ConnectionHandleExpired
+		);
+	}
+}

--- a/crates/reinhardt-db/src/orm/engine.rs
+++ b/crates/reinhardt-db/src/orm/engine.rs
@@ -47,6 +47,70 @@ use reinhardt_core::exception::Result;
 use sqlx::{Any, AnyPool, pool::PoolOptions};
 use std::time::Duration;
 
+pub(crate) async fn connect_backend_with_pool_size(
+	url: &str,
+	pool_size: Option<u32>,
+) -> Result<crate::orm::connection::BackendsConnection> {
+	let postgres = url.starts_with("postgres://") || url.starts_with("postgresql://");
+	let mysql = url.starts_with("mysql://");
+	let sqlite = url.starts_with("sqlite://") || url.starts_with("sqlite:");
+
+	#[cfg(feature = "postgres")]
+	if postgres {
+		return crate::orm::connection::BackendsConnection::connect_postgres_with_pool_size(
+			url, pool_size,
+		)
+		.await;
+	}
+
+	#[cfg(feature = "mysql")]
+	if mysql {
+		return crate::orm::connection::BackendsConnection::connect_mysql(url).await;
+	}
+
+	#[cfg(feature = "sqlite")]
+	if sqlite {
+		return crate::orm::connection::BackendsConnection::connect_sqlite(url).await;
+	}
+
+	#[cfg(not(feature = "postgres"))]
+	let _ = pool_size;
+	let missing_feature = if postgres {
+		Some("postgres")
+	} else if mysql {
+		Some("mysql")
+	} else if sqlite {
+		Some("sqlite")
+	} else {
+		None
+	};
+	if let Some(feature) = missing_feature {
+		return Err(reinhardt_core::exception::DatabaseError::new(
+			reinhardt_core::exception::DatabaseErrorKind::Configuration,
+			format!("Database backend not compiled in. Enable the '{feature}' feature."),
+		)
+		.into());
+	}
+	Err(reinhardt_core::exception::DatabaseError::new(
+		reinhardt_core::exception::DatabaseErrorKind::Configuration,
+		format!("Unsupported database URL scheme: {url}"),
+	)
+	.into())
+}
+
+/// Registers a request-scoped ORM database owner and its copyable handle.
+#[cfg(feature = "di")]
+pub fn register_request_database(
+	context: &reinhardt_di::InjectionContext,
+	owner: crate::orm::connection::BackendsConnection,
+) -> Result<crate::orm::connection::DatabaseConnection> {
+	let lease = crate::orm::connection::DatabaseConnectionLease::register(owner)?;
+	let handle = lease.handle();
+	context.set_request(lease);
+	context.set_request(handle);
+	Ok(handle)
+}
+
 /// Database engine configuration
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/reinhardt-db/src/orm/fixtures.rs
+++ b/crates/reinhardt-db/src/orm/fixtures.rs
@@ -2804,6 +2804,10 @@ fn find_case_insensitive(
 mod tests {
 	use super::*;
 	#[cfg(feature = "migrations")]
+	use crate::backends::DatabaseConnection as BackendsConnection;
+	#[cfg(feature = "migrations")]
+	use crate::orm::DatabaseConnectionLease;
+	#[cfg(feature = "migrations")]
 	use crate::orm::model::FieldSelector;
 
 	#[cfg(not(feature = "migrations"))]
@@ -5486,9 +5490,11 @@ mod tests {
 	#[serial_test::serial(sqlx_drivers)]
 	#[tokio::test]
 	async fn fixture_dump_and_load_hydrates_sqlite_json_text() {
-		let conn = DatabaseConnection::connect("sqlite::memory:")
+		let owner = BackendsConnection::connect("sqlite::memory:")
 			.await
 			.unwrap();
+		let lease = DatabaseConnectionLease::register(owner).unwrap();
+		let conn = lease.handle();
 		conn.execute(
 			"CREATE TABLE fixture_json_post (\
 				id INTEGER PRIMARY KEY, \
@@ -6164,9 +6170,12 @@ mod tests {
 			.into_iter()
 			.next()
 			.expect("model must expose its tags fixture field");
-		let conn = DatabaseConnection::connect("sqlite::memory:")
+		let owner = BackendsConnection::connect("sqlite::memory:")
 			.await
 			.expect("SQLite fixture database must connect");
+		let lease = DatabaseConnectionLease::register(owner)
+			.expect("SQLite fixture database must register");
+		let conn = lease.handle();
 		conn.execute(
 			&format!(
 				"CREATE TABLE {} ({} INTEGER NOT NULL, {} INTEGER NOT NULL, UNIQUE ({}, {}))",

--- a/crates/reinhardt-db/src/orm/manager.rs
+++ b/crates/reinhardt-db/src/orm/manager.rs
@@ -1,4 +1,6 @@
-use super::connection::{DatabaseBackend, DatabaseConnection, OrmExecutor, QueryRow, QueryValue};
+use super::connection::{
+	DatabaseBackend, DatabaseConnection, DatabaseConnectionLease, OrmExecutor, QueryRow, QueryValue,
+};
 use super::field_codec::{DatabaseArrayType, database_value_to_query_value};
 use super::inspection::FieldInfo;
 use super::query::RelationLoadInput;
@@ -132,8 +134,13 @@ fn quote_identifier(identifier: &str, backend: DatabaseBackend) -> String {
 	format!("{quote}{identifier}{quote}")
 }
 
+struct DefaultDatabase {
+	lease: DatabaseConnectionLease,
+	handle: DatabaseConnection,
+}
+
 /// Global database connection state
-static DB: once_cell::sync::OnceCell<Arc<RwLock<Option<DatabaseConnection>>>> =
+static DB: once_cell::sync::OnceCell<Arc<RwLock<Option<DefaultDatabase>>>> =
 	once_cell::sync::OnceCell::new();
 
 /// Initialize the global database connection
@@ -187,15 +194,20 @@ pub async fn init_database_with_pool_size(
 		return Ok(());
 	}
 
-	let conn = DatabaseConnection::connect_with_pool_size(url, pool_size).await?;
+	let owner = super::engine::connect_backend_with_pool_size(url, pool_size).await?;
+	let lease = DatabaseConnectionLease::register(owner)?;
+	let database = DefaultDatabase {
+		handle: lease.handle(),
+		lease,
+	};
 
 	if let Some(db_cell) = DB.get() {
 		let mut guard = db_cell.write().await;
 		if guard.is_none() {
-			*guard = Some(conn);
+			*guard = Some(database);
 		}
 	} else {
-		DB.get_or_init(|| Arc::new(RwLock::new(Some(conn))));
+		DB.get_or_init(|| Arc::new(RwLock::new(Some(database))));
 	}
 
 	Ok(())
@@ -246,15 +258,20 @@ pub async fn reinitialize_database_with_pool_size(
 	url: &str,
 	pool_size: Option<u32>,
 ) -> reinhardt_core::exception::Result<()> {
-	let conn = DatabaseConnection::connect_with_pool_size(url, pool_size).await?;
+	let owner = super::engine::connect_backend_with_pool_size(url, pool_size).await?;
+	let lease = DatabaseConnectionLease::register(owner)?;
+	let database = DefaultDatabase {
+		handle: lease.handle(),
+		lease,
+	};
 
 	if let Some(db_cell) = DB.get() {
 		// Replace existing connection
 		let mut guard = db_cell.write().await;
-		*guard = Some(conn);
+		*guard = Some(database);
 	} else {
 		// First time initialization
-		DB.get_or_init(|| Arc::new(RwLock::new(Some(conn))));
+		DB.get_or_init(|| Arc::new(RwLock::new(Some(database))));
 	}
 
 	Ok(())
@@ -266,11 +283,15 @@ pub async fn reinitialize_database_with_pool_size(
 /// preserving RAII cleanup semantics. Passing `None` clears the global connection.
 #[doc(hidden)]
 pub async fn replace_database_connection_for_testing(
-	connection: Option<DatabaseConnection>,
-) -> Option<DatabaseConnection> {
+	lease: Option<DatabaseConnectionLease>,
+) -> Option<DatabaseConnectionLease> {
 	let db = DB.get_or_init(|| Arc::new(RwLock::new(None)));
 	let mut guard = db.write().await;
-	std::mem::replace(&mut *guard, connection)
+	let database = lease.map(|lease| DefaultDatabase {
+		handle: lease.handle(),
+		lease,
+	});
+	std::mem::replace(&mut *guard, database).map(|database| database.lease)
 }
 
 /// Get a reference to the global database connection
@@ -282,12 +303,58 @@ pub async fn get_connection() -> reinhardt_core::exception::Result<DatabaseConne
 		))
 	})?;
 	let guard = db.read().await;
-	guard.clone().ok_or_else(|| {
+	guard
+		.as_ref()
+		.map(|database| database.handle)
+		.ok_or_else(|| {
+			Error::from(DatabaseError::new(
+				DatabaseErrorKind::Connection,
+				"Database connection not available",
+			))
+		})
+}
+
+/// Returns a lease that retains the global ORM database registration.
+#[doc(hidden)]
+pub async fn get_connection_lease() -> reinhardt_core::exception::Result<DatabaseConnectionLease> {
+	let db = DB.get().ok_or_else(|| {
 		Error::from(DatabaseError::new(
-			DatabaseErrorKind::Connection,
-			"Database connection not available",
+			DatabaseErrorKind::Configuration,
+			"Database not initialized",
 		))
-	})
+	})?;
+	let guard = db.read().await;
+	guard
+		.as_ref()
+		.map(|database| database.lease.clone())
+		.ok_or_else(|| {
+			Error::from(DatabaseError::new(
+				DatabaseErrorKind::Connection,
+				"Database connection not available",
+			))
+		})
+}
+
+/// Returns a coherent lease-and-handle snapshot of the global ORM registration.
+#[doc(hidden)]
+pub async fn get_connection_registration()
+-> reinhardt_core::exception::Result<(DatabaseConnectionLease, DatabaseConnection)> {
+	let db = DB.get().ok_or_else(|| {
+		Error::from(DatabaseError::new(
+			DatabaseErrorKind::Configuration,
+			"Database not initialized",
+		))
+	})?;
+	let guard = db.read().await;
+	guard
+		.as_ref()
+		.map(|database| (database.lease.clone(), database.handle))
+		.ok_or_else(|| {
+			Error::from(DatabaseError::new(
+				DatabaseErrorKind::Connection,
+				"Database connection not available",
+			))
+		})
 }
 
 /// Model manager (similar to Django's Manager)
@@ -2701,10 +2768,11 @@ mod tests {
 	#[serial_test::serial(sqlx_drivers)]
 	#[tokio::test]
 	async fn init_database_skips_connection_when_already_initialized() {
-		let connection = crate::orm::connection::DatabaseConnection::connect("sqlite::memory:")
+		let owner = crate::orm::connection::BackendsConnection::connect_sqlite("sqlite::memory:")
 			.await
 			.unwrap();
-		let previous = super::replace_database_connection_for_testing(Some(connection)).await;
+		let lease = crate::orm::connection::DatabaseConnectionLease::register(owner).unwrap();
+		let previous = super::replace_database_connection_for_testing(Some(lease)).await;
 
 		let result = super::init_database("unsupported://must-not-connect").await;
 		let backend = super::get_connection()
@@ -3086,9 +3154,11 @@ mod tests {
 	async fn test_manager_create_roundtrips_typed_json_fields_on_sqlite() {
 		let database_file = tempfile::NamedTempFile::new().unwrap();
 		let database_url = format!("sqlite://{}", database_file.path().display());
-		let mut connection = crate::orm::connection::DatabaseConnection::connect(&database_url)
+		let owner = crate::orm::connection::BackendsConnection::connect_sqlite(&database_url)
 			.await
 			.unwrap();
+		let lease = crate::orm::connection::DatabaseConnectionLease::register(owner).unwrap();
+		let mut connection = lease.handle();
 		connection
 			.execute(
 				"CREATE TABLE json_manager_models (\

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -6174,7 +6174,7 @@ where
 	{
 		let mut queryset = self.clone();
 		queryset.limit = Some(queryset.limit.map_or(2, |limit| limit.min(2)));
-		let mut conn = conn.clone();
+		let mut conn = *conn;
 		queryset.all_with_db(&mut conn).await
 	}
 

--- a/crates/reinhardt-db/src/orm/transaction.rs
+++ b/crates/reinhardt-db/src/orm/transaction.rs
@@ -1,7 +1,7 @@
 //! # Transaction SQL and ORM Atomicity
 //!
-//! [`DatabaseConnection`](super::connection::DatabaseConnection) owns the ORM
-//! transaction lifecycle through
+//! [`DatabaseConnection`](super::connection::DatabaseConnection) provides the ORM
+//! transaction capability through
 //! [`DatabaseConnection::atomic`](super::connection::DatabaseConnection::atomic). Its callback
 //! receives an [`AtomicTransaction`], the only executor that may run ORM work
 //! until the callback returns. A successful outer callback commits; an error
@@ -13,10 +13,12 @@
 //!
 //! ```no_run
 //! use reinhardt_core::exception::Error;
-//! use reinhardt_db::orm::DatabaseConnection;
+//! use reinhardt_db::{backends::DatabaseConnection as BackendsConnection, orm::DatabaseConnectionLease};
 //!
 //! # async fn example() -> Result<(), Error> {
-//! let connection = DatabaseConnection::connect("sqlite::memory:").await?;
+//! let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await?;
+//! let lease = DatabaseConnectionLease::register(owner)?;
+//! let connection = lease.handle();
 //! let answer = connection.atomic(async |transaction| {
 //!     transaction.atomic(async |_savepoint| {
 //!         Ok::<_, Error>(())
@@ -852,7 +854,7 @@ mod tests {
 	use crate::backends::error::Result;
 	use crate::backends::types::{DatabaseType, QueryResult, QueryValue, Row, TransactionExecutor};
 	use crate::orm::Manager;
-	use crate::orm::connection::{DatabaseBackend, DatabaseConnection, OrmExecutor};
+	use crate::orm::connection::{DatabaseConnection, DatabaseConnectionLease, OrmExecutor};
 	use crate::prelude::Model;
 	use futures::FutureExt;
 	use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind};
@@ -886,6 +888,19 @@ mod tests {
 	}
 
 	type TransactionCalls = Arc<Mutex<Vec<String>>>;
+
+	struct TestDatabaseConnection {
+		handle: DatabaseConnection,
+		_lease: DatabaseConnectionLease,
+	}
+
+	impl std::ops::Deref for TestDatabaseConnection {
+		type Target = DatabaseConnection;
+
+		fn deref(&self) -> &Self::Target {
+			&self.handle
+		}
+	}
 
 	// Mock transaction executor for testing
 	struct MockTransactionExecutor {
@@ -1119,15 +1134,20 @@ mod tests {
 
 	fn mock_connection_with_failures(
 		failure_plan: FailurePlan,
-	) -> (DatabaseConnection, TransactionCalls) {
+	) -> (TestDatabaseConnection, TransactionCalls) {
 		let calls = Arc::new(Mutex::new(Vec::new()));
 		let mock_backend = Arc::new(MockBackend {
 			failure_plan,
 			calls: Arc::clone(&calls),
 		});
 		let backends_conn = BackendsConnection::new(mock_backend);
+		let lease = DatabaseConnectionLease::register(backends_conn).unwrap();
+		let handle = lease.handle();
 		(
-			DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn),
+			TestDatabaseConnection {
+				handle,
+				_lease: lease,
+			},
 			calls,
 		)
 	}
@@ -1149,11 +1169,6 @@ mod tests {
 		} else {
 			"unknown panic payload".to_string()
 		}
-	}
-
-	#[fixture]
-	fn mock_connection() -> DatabaseConnection {
-		mock_connection_with_failures(FailurePlan::default()).0
 	}
 
 	#[derive(Clone, Default)]

--- a/crates/reinhardt-db/tests/atomic_orm_transactions.rs
+++ b/crates/reinhardt-db/tests/atomic_orm_transactions.rs
@@ -11,7 +11,9 @@ use std::time::Duration;
 
 use reinhardt_core::exception::Error;
 use reinhardt_db::associations::ManyToManyManager;
-use reinhardt_db::orm::connection::DatabaseConnection;
+use reinhardt_db::orm::connection::{
+	BackendsConnection, DatabaseConnection, DatabaseConnectionLease,
+};
 use reinhardt_db::orm::custom_manager::CustomManager;
 use reinhardt_db::orm::manager::Manager;
 use reinhardt_db::orm::model::{FieldSelector, Model};
@@ -29,18 +31,28 @@ use testcontainers::{
 
 const MAX_CONNECT_RETRIES: u32 = 7;
 
+async fn sqlite_connection(url: &str) -> (DatabaseConnectionLease, DatabaseConnection) {
+	let owner = BackendsConnection::connect_sqlite(url).await.unwrap();
+	let lease = DatabaseConnectionLease::register(owner).unwrap();
+	let handle = lease.handle();
+	(lease, handle)
+}
+
 struct PostgresFixture {
 	connection: DatabaseConnection,
+	_lease: DatabaseConnectionLease,
 	_container: ContainerAsync<GenericImage>,
 }
 
 struct MySqlFixture {
 	connection: DatabaseConnection,
+	_lease: DatabaseConnectionLease,
 	_container: ContainerAsync<GenericImage>,
 }
 
 struct SqliteFixture {
 	connection: DatabaseConnection,
+	_lease: DatabaseConnectionLease,
 	_directory: TempDir,
 }
 
@@ -195,10 +207,11 @@ async fn postgres_fixture() -> PostgresFixture {
 		.expect("PostgreSQL container should start");
 	let port = container_port_with_retry(&container, 5432, "PostgreSQL").await;
 	let url = format!("postgres://postgres@127.0.0.1:{port}/postgres?sslmode=disable");
-	let connection = connect_postgres_with_retry(&url).await;
+	let (lease, connection) = connect_postgres_with_retry(&url).await;
 
 	PostgresFixture {
 		connection,
+		_lease: lease,
 		_container: container,
 	}
 }
@@ -216,10 +229,11 @@ async fn mysql_fixture() -> MySqlFixture {
 	let container = image.start().await.expect("MySQL container should start");
 	let port = container_port_with_retry(&container, 3306, "MySQL").await;
 	let url = format!("mysql://root:test@127.0.0.1:{port}/atomic_orm_test");
-	let connection = connect_mysql_with_retry(&url).await;
+	let (lease, connection) = connect_mysql_with_retry(&url).await;
 
 	MySqlFixture {
 		connection,
+		_lease: lease,
 		_container: container,
 	}
 }
@@ -232,12 +246,11 @@ async fn sqlite_fixture() -> SqliteFixture {
 		.expect("SQLite temporary directory should be created under /tmp");
 	let database_path = directory.path().join("atomic.sqlite");
 	let url = format!("sqlite:///{}", database_path.display());
-	let connection = DatabaseConnection::connect_sqlite(&url)
-		.await
-		.expect("SQLite temporary database should connect");
+	let (lease, connection) = sqlite_connection(&url).await;
 
 	SqliteFixture {
 		connection,
+		_lease: lease,
 		_directory: directory,
 	}
 }
@@ -270,12 +283,16 @@ async fn container_port_with_retry(
 	unreachable!("the final container port lookup either returns or panics")
 }
 
-async fn connect_postgres_with_retry(url: &str) -> DatabaseConnection {
+async fn connect_postgres_with_retry(url: &str) -> (DatabaseConnectionLease, DatabaseConnection) {
 	tokio::time::sleep(Duration::from_millis(500)).await;
 
 	for attempt in 0..=MAX_CONNECT_RETRIES {
-		match DatabaseConnection::connect_postgres(url).await {
-			Ok(connection) => return connection,
+		match BackendsConnection::connect_postgres(url).await {
+			Ok(owner) => {
+				let lease = DatabaseConnectionLease::register(owner).unwrap();
+				let connection = lease.handle();
+				return (lease, connection);
+			}
 			Err(error) if attempt < MAX_CONNECT_RETRIES => {
 				eprintln!(
 					"PostgreSQL connection attempt {} of {} failed: {error}",
@@ -294,12 +311,16 @@ async fn connect_postgres_with_retry(url: &str) -> DatabaseConnection {
 	unreachable!("the final PostgreSQL connection attempt either returns or panics")
 }
 
-async fn connect_mysql_with_retry(url: &str) -> DatabaseConnection {
+async fn connect_mysql_with_retry(url: &str) -> (DatabaseConnectionLease, DatabaseConnection) {
 	tokio::time::sleep(Duration::from_millis(500)).await;
 
 	for attempt in 0..=MAX_CONNECT_RETRIES {
-		match DatabaseConnection::connect_mysql(url).await {
-			Ok(connection) => return connection,
+		match BackendsConnection::connect_mysql(url).await {
+			Ok(owner) => {
+				let lease = DatabaseConnectionLease::register(owner).unwrap();
+				let connection = lease.handle();
+				return (lease, connection);
+			}
 			Err(error) if attempt < MAX_CONNECT_RETRIES => {
 				eprintln!(
 					"MySQL connection attempt {} of {} failed: {error}",

--- a/crates/reinhardt-db/tests/database_connection_di.rs
+++ b/crates/reinhardt-db/tests/database_connection_di.rs
@@ -1,0 +1,141 @@
+use reinhardt_core::exception::DatabaseErrorKind;
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection,
+	orm::{
+		DatabaseConnection, DatabaseConnectionLease, get_connection_registration,
+		register_request_database, reinitialize_database,
+	},
+};
+use reinhardt_di::{Injectable, InjectionContext, SingletonScope};
+
+async fn sqlite_owner() -> BackendsConnection {
+	BackendsConnection::connect_sqlite("sqlite::memory:")
+		.await
+		.unwrap()
+}
+
+#[tokio::test]
+async fn cloned_context_keeps_database_registration_alive_until_last_drop() {
+	let lease = DatabaseConnectionLease::register(sqlite_owner().await).unwrap();
+	let handle = lease.handle();
+	let context = InjectionContext::builder(SingletonScope::new())
+		.singleton(lease)
+		.singleton(handle)
+		.build();
+	let cloned = context.clone();
+	let injected = DatabaseConnection::inject(&context).await.unwrap();
+
+	drop(context);
+	injected.execute("SELECT 1", vec![]).await.unwrap();
+	drop(cloned);
+
+	let error = injected.execute("SELECT 1", vec![]).await.unwrap_err();
+	assert_eq!(
+		error.database_error().unwrap().kind(),
+		DatabaseErrorKind::ConnectionHandleExpired
+	);
+}
+
+#[tokio::test]
+async fn request_registration_lives_with_context_clone() {
+	let context = InjectionContext::builder(SingletonScope::new()).build();
+	let handle = register_request_database(&context, sqlite_owner().await).unwrap();
+	let cloned = context.clone();
+
+	drop(context);
+	handle.execute("SELECT 1", vec![]).await.unwrap();
+	drop(cloned);
+
+	let error = handle.execute("SELECT 1", vec![]).await.unwrap_err();
+	assert_eq!(
+		error.database_error().unwrap().kind(),
+		DatabaseErrorKind::ConnectionHandleExpired
+	);
+}
+
+#[tokio::test]
+async fn fresh_request_fork_does_not_inherit_request_database() {
+	let context = InjectionContext::builder(SingletonScope::new()).build();
+	let handle = register_request_database(&context, sqlite_owner().await).unwrap();
+	let fork = context.fork();
+
+	let error = DatabaseConnection::inject(&fork).await.unwrap_err();
+	assert!(matches!(error, reinhardt_di::DiError::NotRegistered { .. }));
+	drop(context);
+	let error = handle.execute("SELECT 1", vec![]).await.unwrap_err();
+	assert_eq!(
+		error.database_error().unwrap().kind(),
+		DatabaseErrorKind::ConnectionHandleExpired
+	);
+}
+
+#[tokio::test]
+async fn fresh_request_fork_inherits_singleton_database() {
+	let lease = DatabaseConnectionLease::register(sqlite_owner().await).unwrap();
+	let handle = lease.handle();
+	let context = InjectionContext::builder(SingletonScope::new())
+		.singleton(lease)
+		.singleton(handle)
+		.build();
+	let fork = context.fork();
+
+	let injected = DatabaseConnection::inject(&fork).await.unwrap();
+	assert_eq!(injected, handle);
+	injected.execute("SELECT 1", vec![]).await.unwrap();
+}
+
+#[tokio::test]
+async fn singleton_database_takes_precedence_over_request_database() {
+	let singleton_lease = DatabaseConnectionLease::register(sqlite_owner().await).unwrap();
+	let singleton_handle = singleton_lease.handle();
+	let context = InjectionContext::builder(SingletonScope::new())
+		.singleton(singleton_lease)
+		.singleton(singleton_handle)
+		.build();
+	let request_handle = register_request_database(&context, sqlite_owner().await).unwrap();
+
+	let injected = DatabaseConnection::inject(&context).await.unwrap();
+	assert_eq!(injected, singleton_handle);
+	assert_ne!(injected, request_handle);
+}
+
+#[serial_test::serial(database_connection_registration)]
+#[tokio::test]
+async fn global_registration_accessor_returns_matching_lease_and_handle() {
+	reinitialize_database("sqlite::memory:").await.unwrap();
+
+	let (lease, handle) = get_connection_registration().await.unwrap();
+
+	assert_eq!(lease.handle(), handle);
+}
+
+#[serial_test::serial(database_connection_registration)]
+#[tokio::test]
+async fn concurrent_reinitialize_and_registration_reads_remain_coherent() {
+	use std::sync::Arc;
+
+	use tokio::sync::{Barrier, mpsc};
+
+	reinitialize_database("sqlite::memory:").await.unwrap();
+	let barrier = Arc::new(Barrier::new(2));
+	let (sender, mut receiver) = mpsc::channel(32);
+	let writer_barrier = Arc::clone(&barrier);
+	let writer = tokio::spawn(async move {
+		writer_barrier.wait().await;
+		for _ in 0..32 {
+			reinitialize_database("sqlite::memory:").await.unwrap();
+			sender.send(()).await.unwrap();
+		}
+	});
+	let reader_barrier = Arc::clone(&barrier);
+	let reader = tokio::spawn(async move {
+		reader_barrier.wait().await;
+		while receiver.recv().await.is_some() {
+			let (lease, handle) = get_connection_registration().await.unwrap();
+			assert_eq!(lease.handle(), handle);
+		}
+	});
+
+	writer.await.unwrap();
+	reader.await.unwrap();
+}

--- a/crates/reinhardt-db/tests/transaction_executor_orm.rs
+++ b/crates/reinhardt-db/tests/transaction_executor_orm.rs
@@ -17,7 +17,8 @@ use reinhardt_db::associations::{ManyToManyField, ManyToManyManager};
 use reinhardt_db::orm::annotation::{AnnotationValue, Expression, Value};
 use reinhardt_db::orm::composite_pk::{CompositePrimaryKey, PkValue};
 use reinhardt_db::orm::connection::{
-	DatabaseBackend, DatabaseConnection, OrmExecutor, QueryResult, QueryValue, Row,
+	BackendsConnection, DatabaseBackend, DatabaseConnectionLease, OrmExecutor, QueryResult,
+	QueryValue, Row,
 };
 use reinhardt_db::orm::custom_manager::CustomManager;
 use reinhardt_db::orm::events::{EventRegistry, EventResult, MapperEvents, set_active_registry};
@@ -32,6 +33,18 @@ use reinhardt_db::orm::{
 	ForeignKeyAccessor, ManyToManyAccessor, NPlusOneConfig, NPlusOneScope, QuerySet,
 };
 use reinhardt_query::prelude::{Alias, Query};
+
+async fn sqlite_connection(
+	url: &str,
+) -> (
+	DatabaseConnectionLease,
+	reinhardt_db::orm::DatabaseConnection,
+) {
+	let owner = BackendsConnection::connect_sqlite(url).await.unwrap();
+	let lease = DatabaseConnectionLease::register(owner).unwrap();
+	let handle = lease.handle();
+	(lease, handle)
+}
 
 #[derive(Debug, Clone, PartialEq)]
 struct RecordedCall {
@@ -539,9 +552,7 @@ async fn explicit_orm_paths_use_the_caller_owned_recording_executor() {
 
 #[tokio::test]
 async fn concrete_connection_and_atomic_transaction_support_explicit_orm_paths() {
-	let mut connection = DatabaseConnection::connect("sqlite::memory:")
-		.await
-		.expect("SQLite connection should be available");
+	let (_lease, mut connection) = sqlite_connection("sqlite::memory:").await;
 	connection
 		.execute(
 			"CREATE TABLE articles (article_id INTEGER PRIMARY KEY AUTOINCREMENT, article_title TEXT NOT NULL)",

--- a/crates/reinhardt-pages/docs/server_fn_macro.md
+++ b/crates/reinhardt-pages/docs/server_fn_macro.md
@@ -22,6 +22,10 @@ The macro automatically generates client-side code that:
 
 Use `#[inject]` attribute to inject dependencies on the server side:
 
+The injected `DatabaseConnection` is a `Copy` ORM handle. Server bootstrap owns
+its `DatabaseConnectionLease`; handlers neither construct connections nor own
+the lease.
+
 ```rust,ignore
 use reinhardt::pages::server_fn::{ServerFnError, server_fn};
 use reinhardt::DatabaseConnection;
@@ -34,6 +38,16 @@ pub async fn get_data(
     // Server-side implementation
     // `db` is automatically resolved from DI context
     Ok(format!("Data for id: {}", id))
+}
+```
+
+The handle can be passed to concurrent operations without cloning:
+
+```rust,ignore
+#[server_fn]
+async fn dashboard(#[inject] db: DatabaseConnection) -> Result<(), ServerFnError> {
+    tokio::try_join!(load_users(db), load_posts(db))?;
+    Ok(())
 }
 ```
 
@@ -705,6 +719,10 @@ pub async fn public_endpoint() -> Result<String, ServerFnError> {
 
 ### 1. Use `#[inject]` for Server-Only Dependencies
 
+For ORM access, inject `DatabaseConnection` directly. The framework retains the
+owning lease for the server lifetime, so a server function must not create or
+store a `DatabaseConnectionLease`.
+
 ```rust
 #[server_fn]
 pub async fn get_user(
@@ -913,7 +931,6 @@ quote! {
 
 - [reinhardt-pages README](../README.md)
 - [Dependency Injection Guide](../../reinhardt-di/README.md)
-- [Server Functions Tutorial](../../../docs/tutorials/en/pages/server-functions.md) (coming soon)
 
 ## Contributing
 

--- a/crates/reinhardt-pages/src/server_fn/model_set/runtime.rs
+++ b/crates/reinhardt-pages/src/server_fn/model_set/runtime.rs
@@ -95,7 +95,7 @@ where
 		let queryset =
 			<R::Policy as ServerFnSetPolicy<R>>::scope_query(principal, queryset, None).await?;
 		let queryset = R::apply_list_query(queryset, &query)?;
-		let mut read_connection = connection.clone();
+		let mut read_connection = *connection;
 		let total = queryset
 			.count_with_db(&mut read_connection)
 			.await

--- a/crates/reinhardt-pages/tests/server_fnset_error_tests.rs
+++ b/crates/reinhardt-pages/tests/server_fnset_error_tests.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use hyper::{Method, header};
-use reinhardt_db::orm::DatabaseConnection;
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection,
+	orm::{DatabaseConnection, DatabaseConnectionLease},
+};
 use reinhardt_di::{InjectionContext, SingletonScope};
 use reinhardt_http::Request;
 use reinhardt_pages::server_fn::{
@@ -220,12 +223,16 @@ fn encoded(error: &impl serde::Serialize) -> Vec<u8> {
 }
 
 async fn model_request(uri: &str) -> Request {
-	let connection = DatabaseConnection::connect_sqlite("sqlite::memory:")
+	let owner = BackendsConnection::connect_sqlite("sqlite::memory:")
 		.await
 		.expect("SQLite connection should open");
+	let lease =
+		DatabaseConnectionLease::register(owner).expect("SQLite connection should register");
+	let connection = lease.handle();
 	let singleton = Arc::new(SingletonScope::new());
 	let context = Arc::new(
 		InjectionContext::builder(singleton)
+			.singleton(lease)
 			.singleton(connection)
 			.build(),
 	);

--- a/crates/reinhardt-pages/tests/server_fnset_model_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/server_fnset_model_integration_tests.rs
@@ -8,8 +8,8 @@ use std::sync::{Mutex, OnceLock};
 use async_trait::async_trait;
 use reinhardt_db::backends::types::QueryValue;
 use reinhardt_db::orm::{
-	DatabaseConnection, FieldSelector, Filter, FilterValue, Manager, Model, QuerySet,
-	TransactionExecutor, UniqueFieldRef,
+	DatabaseConnection, DatabaseConnectionLease, FieldSelector, Filter, FilterValue, Manager,
+	Model, QuerySet, TransactionExecutor, UniqueFieldRef,
 };
 use reinhardt_di::params::{FromRequest, ParamContext, ParamResult};
 use reinhardt_http::Request;
@@ -370,7 +370,11 @@ impl ModelServerFnResource for WidgetResource {
 	}
 }
 
-async fn database() -> (tempfile::TempDir, DatabaseConnection) {
+async fn database() -> (
+	tempfile::TempDir,
+	DatabaseConnectionLease,
+	DatabaseConnection,
+) {
 	let directory = tempfile::Builder::new()
 		.prefix("reinhardt-pages-server-fnset-")
 		.tempdir_in("/tmp")
@@ -379,9 +383,12 @@ async fn database() -> (tempfile::TempDir, DatabaseConnection) {
 		"sqlite:///{}",
 		directory.path().join("runtime.sqlite").display()
 	);
-	let connection = DatabaseConnection::connect_sqlite(&url)
+	let owner = reinhardt_db::backends::DatabaseConnection::connect_sqlite(&url)
 		.await
 		.expect("SQLite connection should open");
+	let lease =
+		DatabaseConnectionLease::register(owner).expect("SQLite connection should register");
+	let connection = lease.handle();
 	connection
 		.execute(
 			"CREATE TABLE tenant_42_widgets (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)",
@@ -389,7 +396,7 @@ async fn database() -> (tempfile::TempDir, DatabaseConnection) {
 		)
 		.await
 		.expect("widget table should be created");
-	(directory, connection)
+	(directory, lease, connection)
 }
 
 async fn insert(connection: &DatabaseConnection, id: i64, name: &str) {
@@ -436,7 +443,7 @@ fn assert_events(expected: &[&'static str]) {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(model_server_fnset_runtime)]
 async fn list_validates_and_applies_policy_before_count_and_slice() {
-	let (_directory, connection) = database().await;
+	let (_directory, _lease, connection) = database().await;
 	for id in 1..=30 {
 		insert(&connection, id, &format!("widget-{id:02}")).await;
 	}
@@ -528,7 +535,7 @@ async fn list_validates_and_applies_policy_before_count_and_slice() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(model_server_fnset_runtime)]
 async fn retrieve_maps_cardinality_and_authorization_deterministically() {
-	let (_directory, connection) = database().await;
+	let (_directory, _lease, connection) = database().await;
 	insert(&connection, 1, "unique").await;
 	reset_state();
 	let read =
@@ -600,7 +607,7 @@ async fn retrieve_maps_cardinality_and_authorization_deterministically() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(model_server_fnset_runtime)]
 async fn mutations_share_one_executor_and_rollback_post_persistence_failures() {
-	let (_directory, connection) = database().await;
+	let (_directory, _lease, connection) = database().await;
 	insert(&connection, 1, "original").await;
 
 	reset_state();
@@ -747,7 +754,7 @@ async fn mutations_share_one_executor_and_rollback_post_persistence_failures() {
 #[tokio::test(flavor = "current_thread")]
 #[serial(model_server_fnset_runtime)]
 async fn mutation_errors_rollback_explicitly_on_current_thread_runtimes() {
-	let (_directory, connection) = database().await;
+	let (_directory, _lease, connection) = database().await;
 	insert(&connection, 1, "original").await;
 
 	reset_state();
@@ -809,7 +816,7 @@ async fn mutation_errors_rollback_explicitly_on_current_thread_runtimes() {
 #[tokio::test(flavor = "current_thread")]
 #[serial(model_server_fnset_runtime)]
 async fn create_authorizes_the_created_object_before_committing() {
-	let (_directory, connection) = database().await;
+	let (_directory, _lease, connection) = database().await;
 	insert(&connection, 1, "original").await;
 	reset_state();
 	state()
@@ -838,7 +845,7 @@ async fn create_authorizes_the_created_object_before_committing() {
 #[tokio::test(flavor = "current_thread")]
 #[serial(model_server_fnset_runtime)]
 async fn update_and_patch_reauthorize_mutated_objects_before_committing() {
-	let (_directory, connection) = database().await;
+	let (_directory, _lease, connection) = database().await;
 	insert(&connection, 1, "original").await;
 
 	reset_state();
@@ -911,7 +918,7 @@ async fn update_and_patch_reauthorize_mutated_objects_before_committing() {
 #[tokio::test(flavor = "current_thread")]
 #[serial(model_server_fnset_runtime)]
 async fn transactional_custom_detail_actions_receive_authorized_object_and_rollback() {
-	let (_directory, connection) = database().await;
+	let (_directory, _lease, connection) = database().await;
 	insert(&connection, 1, "original").await;
 	reset_state();
 
@@ -953,7 +960,7 @@ async fn transactional_custom_detail_actions_receive_authorized_object_and_rollb
 #[tokio::test(flavor = "current_thread")]
 #[serial(model_server_fnset_runtime)]
 async fn transactional_detail_overrides_reauthorize_the_mutated_object() {
-	let (_directory, connection) = database().await;
+	let (_directory, _lease, connection) = database().await;
 	insert(&connection, 1, "original").await;
 	reset_state();
 	state()
@@ -1002,7 +1009,7 @@ async fn transactional_detail_overrides_reauthorize_the_mutated_object() {
 #[tokio::test(flavor = "current_thread")]
 #[serial(model_server_fnset_runtime)]
 async fn create_overrides_can_authorize_objects_before_persistence() {
-	let (_directory, connection) = database().await;
+	let (_directory, _lease, connection) = database().await;
 	insert(&connection, 1, "original").await;
 	reset_state();
 	state()
@@ -1042,7 +1049,7 @@ async fn create_overrides_can_authorize_objects_before_persistence() {
 #[tokio::test(flavor = "current_thread")]
 #[serial(model_server_fnset_runtime)]
 async fn transactional_create_overrides_authorize_without_scoping_and_rollback() {
-	let (_directory, connection) = database().await;
+	let (_directory, _lease, connection) = database().await;
 	insert(&connection, 1, "original").await;
 	reset_state();
 

--- a/crates/reinhardt-pages/tests/ui.rs
+++ b/crates/reinhardt-pages/tests/ui.rs
@@ -53,6 +53,8 @@ fn test_server_fn_macro_ui() {
 	t.pass("tests/ui/server_fn/query_key_non_query_args.rs");
 	t.pass("tests/ui/server_fn/query_key_private_interfaces.rs");
 	t.pass("tests/ui/server_fn/query_key_injected_no_msw.rs");
+	#[cfg(feature = "model-server-fnset")]
+	t.pass("tests/ui/server_fn/injected_database_connection_copy.rs");
 	// Codec tests
 	t.pass("tests/ui/server_fn/codec_json.rs");
 	t.pass("tests/ui/server_fn/codec_url.rs");

--- a/crates/reinhardt-pages/tests/ui/server_fn/injected_database_connection_copy.rs
+++ b/crates/reinhardt-pages/tests/ui/server_fn/injected_database_connection_copy.rs
@@ -1,0 +1,16 @@
+use reinhardt_db::orm::DatabaseConnection;
+use reinhardt_pages::server_fn;
+
+fn consume(_db: DatabaseConnection) {}
+
+#[server_fn]
+async fn copy_database_connection(#[inject] db: DatabaseConnection) -> Result<(), String> {
+	let first = move || consume(db);
+	let second = move || consume(db);
+	first();
+	second();
+	consume(db);
+	Ok(())
+}
+
+fn main() {}

--- a/crates/reinhardt-rest/src/serializers/model_serializer.rs
+++ b/crates/reinhardt-rest/src/serializers/model_serializer.rs
@@ -9,8 +9,7 @@ use super::nested_config::{NestedFieldConfig, NestedSerializerConfig};
 use super::validator_config::{ModelLevelValidator, ValidatorConfig};
 use super::validators::{UniqueTogetherValidator, UniqueValidator};
 use super::{Serializer, SerializerError, ValidatorError};
-use reinhardt_db::backends::DatabaseConnection;
-use reinhardt_db::orm::Model;
+use reinhardt_db::orm::{DatabaseConnection, Model};
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -842,13 +841,12 @@ where
 	/// # impl reinhardt_db::orm::FieldSelector for UserFields {
 	/// #     fn with_alias(self, _alias: &str) -> Self { self }
 	/// # }
-	/// # use reinhardt_db::backends::DatabaseConnection;
-	/// #
-	/// # fn configured_database_connection() -> DatabaseConnection {
-	/// #     panic!("provide a configured database connection")
-	/// # }
+	/// # use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+	/// # use reinhardt_db::orm::DatabaseConnectionLease;
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// # let connection = configured_database_connection();
+	/// # let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await?;
+	/// # let lease = DatabaseConnectionLease::register(owner)?;
+	/// # let connection = lease.handle();
 	/// let serializer = ModelSerializer::<User>::new();
 	/// let user = User {
 	///     id: Uuid::now_v7(),

--- a/crates/reinhardt-rest/src/serializers/nested_orm.rs
+++ b/crates/reinhardt-rest/src/serializers/nested_orm.rs
@@ -583,9 +583,7 @@ mod tests {
 	use reinhardt_db::backends::types::{
 		DatabaseType, QueryResult, QueryValue, Row, TransactionExecutor,
 	};
-	use reinhardt_db::orm::connection::{
-		DatabaseBackend as OrmDatabaseBackend, DatabaseConnection as OrmDatabaseConnection,
-	};
+	use reinhardt_db::orm::connection::{DatabaseConnection, DatabaseConnectionLease};
 	use rstest::rstest;
 	use std::sync::{Arc, Mutex};
 
@@ -748,17 +746,20 @@ mod tests {
 
 	fn recording_connection(
 		failure_plan: FailurePlan,
-	) -> (OrmDatabaseConnection, TransactionCalls) {
+	) -> (
+		DatabaseConnection,
+		DatabaseConnectionLease,
+		TransactionCalls,
+	) {
 		let calls = Arc::new(Mutex::new(Vec::new()));
 		let backend = Arc::new(RecordingBackend {
 			failure_plan,
 			calls: Arc::clone(&calls),
 		});
 		let backend_connection = BackendsConnection::new(backend);
-		(
-			OrmDatabaseConnection::new(OrmDatabaseBackend::Postgres, backend_connection),
-			calls,
-		)
+		let lease = DatabaseConnectionLease::register(backend_connection)
+			.expect("Failed to register recording database connection");
+		(lease.handle(), lease, calls)
 	}
 
 	fn operation_error() -> SerializerError {
@@ -781,7 +782,7 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn nested_savepoint_uses_the_supplied_atomic_transaction() {
-		let (connection, calls) = recording_connection(FailurePlan::default());
+		let (connection, _connection_lease, calls) = recording_connection(FailurePlan::default());
 		let operation_calls = Arc::clone(&calls);
 
 		let result = TransactionHelper::with_transaction(&connection, async |transaction| {
@@ -806,7 +807,7 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn nested_savepoint_cleanup_error_maps_back_to_serializer_error() {
-		let (connection, calls) = recording_connection(FailurePlan {
+		let (connection, _connection_lease, calls) = recording_connection(FailurePlan {
 			rollback_to_savepoint: true,
 			rollback: false,
 		});
@@ -840,7 +841,7 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn outer_transaction_rollback_error_maps_back_to_serializer_error() {
-		let (connection, calls) = recording_connection(FailurePlan {
+		let (connection, _connection_lease, calls) = recording_connection(FailurePlan {
 			rollback_to_savepoint: false,
 			rollback: true,
 		});

--- a/crates/reinhardt-rest/src/serializers/validator_config.rs
+++ b/crates/reinhardt-rest/src/serializers/validator_config.rs
@@ -5,8 +5,7 @@
 
 use super::ValidatorError;
 use super::validators::{DatabaseValidatorError, UniqueTogetherValidator, UniqueValidator};
-use reinhardt_db::backends::DatabaseConnection;
-use reinhardt_db::orm::Model;
+use reinhardt_db::orm::{DatabaseConnection, Model};
 use serde::Serialize;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -261,8 +260,12 @@ impl<M: Model> ValidatorConfig<M> {
 	///
 	/// ```ignore
 	/// use reinhardt_rest::serializers::validator_config::ValidatorConfig;
-	/// use reinhardt_db::connection::DatabaseConnection;
+	/// use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+	/// use reinhardt_db::orm::DatabaseConnectionLease;
 	///
+	/// let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await?;
+	/// let lease = DatabaseConnectionLease::register(owner)?;
+	/// let connection = lease.handle();
 	/// let config = ValidatorConfig::new();
 	/// let user = User { id: None, username: "alice".into() };
 	/// config.validate_async(&connection, &user, None).await?;
@@ -511,7 +514,10 @@ mod tests {
 	async fn validate_async_runs_sync_model_validators_before_database_checks() {
 		let mut config = ValidatorConfig::<TestUser>::new();
 		config.add_sync_model_validator(Arc::new(RejectAdminUsers));
-		let connection = DatabaseConnection::new(Arc::new(UnusedDatabaseBackend));
+		let owner =
+			reinhardt_db::backends::DatabaseConnection::new(Arc::new(UnusedDatabaseBackend));
+		let lease = reinhardt_db::orm::DatabaseConnectionLease::register(owner).unwrap();
+		let connection = lease.handle();
 		let user = TestUser {
 			id: None,
 			username: "root".to_string(),

--- a/crates/reinhardt-rest/src/serializers/validators.rs
+++ b/crates/reinhardt-rest/src/serializers/validators.rs
@@ -7,8 +7,8 @@
 //!
 //! ```no_run
 //! use reinhardt_rest::serializers::validators::{UniqueValidator, UniqueTogetherValidator};
-//! use reinhardt_db::orm::Model;
-//! use reinhardt_db::backends::DatabaseConnection;
+//! use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+//! use reinhardt_db::orm::{DatabaseConnectionLease, Model};
 //! use serde::{Serialize, Deserialize};
 //!
 //! #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -33,12 +33,11 @@
 //!     fn with_alias(self, _alias: &str) -> Self { self }
 //! }
 //!
-//! # fn configured_database_connection() -> DatabaseConnection {
-//! #     panic!("provide a configured database connection")
-//! # }
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! // Use the database connection configured for your application.
-//! # let connection = configured_database_connection();
+//! # let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await?;
+//! # let lease = DatabaseConnectionLease::register(owner)?;
+//! # let connection = lease.handle();
 //!
 //! // Validate that username is unique
 //! let validator = UniqueValidator::<User>::new("username");
@@ -57,8 +56,9 @@
 
 use super::{SerializerError, ValidatorError};
 use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind};
-use reinhardt_db::backends::DatabaseConnection;
-use reinhardt_db::orm::{CustomManager, Filter, FilterOperator, FilterValue, Model};
+use reinhardt_db::orm::{
+	CustomManager, DatabaseConnection, Filter, FilterOperator, FilterValue, Model,
+};
 use std::marker::PhantomData;
 use thiserror::Error;
 
@@ -236,7 +236,8 @@ impl From<DatabaseValidatorError> for reinhardt_core::exception::Error {
 /// ```no_run
 /// # use reinhardt_rest::serializers::validators::UniqueValidator;
 /// # use reinhardt_db::orm::Model;
-/// # use reinhardt_db::backends::DatabaseConnection;
+/// # use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+/// # use reinhardt_db::orm::DatabaseConnectionLease;
 /// # use serde::{Serialize, Deserialize};
 /// #
 /// # #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -260,12 +261,11 @@ impl From<DatabaseValidatorError> for reinhardt_core::exception::Error {
 /// #     fn with_alias(self, _alias: &str) -> Self { self }
 /// # }
 /// #
-/// # fn configured_database_connection() -> DatabaseConnection {
-/// #     panic!("provide a configured database connection")
-/// # }
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Use the database connection configured for your application.
-/// # let connection = configured_database_connection();
+/// # let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await?;
+/// # let lease = DatabaseConnectionLease::register(owner)?;
+/// # let connection = lease.handle();
 /// let validator = UniqueValidator::<User>::new("username");
 ///
 /// // Check if "alice" is unique
@@ -420,7 +420,8 @@ impl<M: Model> UniqueValidator<M> {
 /// ```no_run
 /// # use reinhardt_rest::serializers::validators::UniqueTogetherValidator;
 /// # use reinhardt_db::orm::Model;
-/// # use reinhardt_db::backends::DatabaseConnection;
+/// # use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
+/// # use reinhardt_db::orm::DatabaseConnectionLease;
 /// # use serde::{Serialize, Deserialize};
 /// # use std::collections::HashMap;
 /// #
@@ -446,12 +447,11 @@ impl<M: Model> UniqueValidator<M> {
 /// #     fn with_alias(self, _alias: &str) -> Self { self }
 /// # }
 /// #
-/// # fn configured_database_connection() -> DatabaseConnection {
-/// #     panic!("provide a configured database connection")
-/// # }
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Use the database connection configured for your application.
-/// # let connection = configured_database_connection();
+/// # let owner = BackendsConnection::connect_sqlite("sqlite::memory:").await?;
+/// # let lease = DatabaseConnectionLease::register(owner)?;
+/// # let connection = lease.handle();
 /// let validator = UniqueTogetherValidator::<User>::new(vec!["username", "email"]);
 ///
 /// let mut values = HashMap::new();

--- a/crates/reinhardt-test/src/fixtures/admin_migrations.rs
+++ b/crates/reinhardt-test/src/fixtures/admin_migrations.rs
@@ -48,6 +48,7 @@ use rstest::fixture;
 pub struct AdminTableCreator {
 	postgres_creator: PostgresTableCreator,
 	admin_db: Arc<reinhardt_admin::core::AdminDatabase>,
+	_connection_lease: reinhardt_db::orm::connection::DatabaseConnectionLease,
 }
 
 impl AdminTableCreator {
@@ -55,10 +56,12 @@ impl AdminTableCreator {
 	pub fn new(
 		postgres_creator: PostgresTableCreator,
 		admin_db: Arc<reinhardt_admin::core::AdminDatabase>,
+		connection_lease: reinhardt_db::orm::connection::DatabaseConnectionLease,
 	) -> Self {
 		Self {
 			postgres_creator,
 			admin_db,
+			_connection_lease: connection_lease,
 		}
 	}
 
@@ -146,9 +149,9 @@ impl AdminTableCreator {
 pub async fn admin_table_creator(
 	#[future] postgres_table_creator: PostgresTableCreator,
 ) -> AdminTableCreator {
-	use reinhardt_db::DatabaseConnection;
 	use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection;
 	use reinhardt_db::backends::dialect::PostgresBackend;
+	use reinhardt_db::orm::connection::DatabaseConnectionLease;
 	use std::sync::Arc as StdArc;
 
 	let creator = postgres_table_creator.await;
@@ -158,13 +161,12 @@ pub async fn admin_table_creator(
 	let backends_conn = BackendsConnection::new(backend);
 
 	// Create ORM connection
-	let connection = DatabaseConnection::new(
-		reinhardt_db::orm::connection::DatabaseBackend::Postgres,
-		backends_conn,
-	);
+	let connection_lease =
+		DatabaseConnectionLease::register(backends_conn).expect("Failed to register connection");
+	let connection = connection_lease.handle();
 
 	// Create AdminDatabase
 	let admin_db = Arc::new(reinhardt_admin::core::AdminDatabase::new(connection));
 
-	AdminTableCreator::new(creator, admin_db)
+	AdminTableCreator::new(creator, admin_db, connection_lease)
 }

--- a/crates/reinhardt-test/src/fixtures/admin_panel.rs
+++ b/crates/reinhardt-test/src/fixtures/admin_panel.rs
@@ -25,10 +25,25 @@
 #[cfg(feature = "admin")]
 use {
 	reinhardt_admin::core::{AdminDatabase, AdminSite, ModelAdminConfig},
-	reinhardt_db::DatabaseConnection,
 	rstest::*,
 	std::sync::Arc,
 };
+
+/// RAII guard that keeps an admin database connection registered.
+#[cfg(feature = "admin")]
+pub struct AdminDatabaseFixture {
+	database: Arc<AdminDatabase>,
+	_connection_lease: reinhardt_db::orm::connection::DatabaseConnectionLease,
+}
+
+#[cfg(feature = "admin")]
+impl std::ops::Deref for AdminDatabaseFixture {
+	type Target = Arc<AdminDatabase>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.database
+	}
+}
 
 // Import shared_db_pool fixture for testcontainers-based tests
 #[cfg(all(feature = "admin", feature = "testcontainers"))]
@@ -106,9 +121,10 @@ pub async fn model_admin_config() -> ModelAdminConfig {
 #[fixture]
 pub async fn admin_database(
 	#[future] shared_db_pool: (sqlx::PgPool, String),
-) -> Arc<AdminDatabase> {
+) -> AdminDatabaseFixture {
 	use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection;
 	use reinhardt_db::backends::dialect::PostgresBackend;
+	use reinhardt_db::orm::connection::DatabaseConnectionLease;
 	use std::sync::Arc as StdArc;
 
 	let (pool, _database_name) = shared_db_pool.await;
@@ -118,12 +134,14 @@ pub async fn admin_database(
 	let backends_conn = BackendsConnection::new(backend);
 
 	// Create ORM connection
-	let connection = DatabaseConnection::new(
-		reinhardt_db::orm::connection::DatabaseBackend::Postgres,
-		backends_conn,
-	);
+	let connection_lease =
+		DatabaseConnectionLease::register(backends_conn).expect("Failed to register connection");
+	let connection = connection_lease.handle();
 
-	Arc::new(AdminDatabase::new(connection))
+	AdminDatabaseFixture {
+		database: Arc::new(AdminDatabase::new(connection)),
+		_connection_lease: connection_lease,
+	}
 }
 
 /// Fixture providing a test database with a pre-created table
@@ -207,7 +225,7 @@ pub async fn test_model_with_table(
 /// #[rstest]
 /// #[tokio::test]
 /// async fn test_server_function_context(
-///     #[future] server_fn_test_context: (Arc<AdminSite>, Arc<AdminDatabase>),
+///     #[future] server_fn_test_context: (Arc<AdminSite>, AdminDatabaseFixture),
 /// ) {
 ///     let (site, db) = server_fn_test_context.await;
 ///     // Test server functions with proper DI context
@@ -218,8 +236,8 @@ pub async fn test_model_with_table(
 pub async fn server_fn_test_context(
 	#[future] admin_site: Arc<AdminSite>,
 	#[future] model_admin_config: ModelAdminConfig,
-	#[future] admin_database: Arc<AdminDatabase>,
-) -> (Arc<AdminSite>, Arc<AdminDatabase>) {
+	#[future] admin_database: AdminDatabaseFixture,
+) -> (Arc<AdminSite>, AdminDatabaseFixture) {
 	let site = admin_site.await;
 	let config = model_admin_config.await;
 	let db = admin_database.await;
@@ -237,9 +255,10 @@ pub async fn server_fn_test_context(
 pub async fn export_import_test_context(
 	#[future] admin_site: Arc<AdminSite>,
 	#[future] shared_db_pool: (sqlx::PgPool, String),
-) -> (Arc<AdminSite>, Arc<AdminDatabase>, String, sqlx::PgPool) {
+) -> (Arc<AdminSite>, AdminDatabaseFixture, String, sqlx::PgPool) {
 	use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection;
 	use reinhardt_db::backends::dialect::PostgresBackend;
+	use reinhardt_db::orm::connection::DatabaseConnectionLease;
 	use reinhardt_query::prelude::{
 		Alias, ColumnDef, Expr, Iden, PostgresQueryBuilder, Query, QueryStatementBuilder, Value,
 	};
@@ -255,13 +274,15 @@ pub async fn export_import_test_context(
 	let backends_conn = BackendsConnection::new(backend);
 
 	// Create ORM connection
-	let connection = DatabaseConnection::new(
-		reinhardt_db::orm::connection::DatabaseBackend::Postgres,
-		backends_conn,
-	);
+	let connection_lease =
+		DatabaseConnectionLease::register(backends_conn).expect("Failed to register connection");
+	let connection = connection_lease.handle();
 
 	// Create AdminDatabase
-	let db = Arc::new(AdminDatabase::new(connection));
+	let db = AdminDatabaseFixture {
+		database: Arc::new(AdminDatabase::new(connection)),
+		_connection_lease: connection_lease,
+	};
 
 	// Generate unique table name
 	let table_name = format!("test_exports_{}", Uuid::now_v7().simple());

--- a/crates/reinhardt-testkit/src/fixtures.rs
+++ b/crates/reinhardt-testkit/src/fixtures.rs
@@ -119,7 +119,7 @@ pub use database::{
 };
 
 // From mock module
-pub use mock::{MockDatabaseBackend, mock_connection, mock_database};
+pub use mock::{MockConnection, MockDatabaseBackend, mock_connection, mock_database};
 
 // From server module
 pub use server::{
@@ -137,7 +137,7 @@ pub use server::graphql_server;
 // From testcontainers module (conditional on feature)
 #[cfg(feature = "testcontainers")]
 pub use testcontainers::{
-	FileLockGuard, cockroachdb_container, create_test_any_pool, kafka_container,
+	FileLockGuard, MigrationDatabase, cockroachdb_container, create_test_any_pool, kafka_container,
 	localstack_fixture, mongodb_container, mysql_container, mysql_with_migrations_from,
 	postgres_container, postgres_with_migrations_from, postgres_with_migrations_from_dir,
 	rabbitmq_container, redis_container, shared_kafka_container, sqlite_with_migrations_from,

--- a/crates/reinhardt-testkit/src/fixtures/database.rs
+++ b/crates/reinhardt-testkit/src/fixtures/database.rs
@@ -293,21 +293,21 @@ impl TestDatabaseBuilder {
 		apply_migrations(&connection, &migrations).await?;
 
 		let di_context = if self.di_context {
-			Some(create_di_context(&url).await?)
+			Some(create_di_context(connection.clone())?)
 		} else {
 			None
 		};
 
 		let orm_global_restore = if self.orm_global {
-			let orm_connection = reinhardt_db::orm::connection::DatabaseConnection::connect(&url)
-				.await
-				.map_err(|source| TestDatabaseError::OrmGlobalInit {
-					source: Box::new(source),
-				})?;
-			let previous = reinhardt_db::orm::manager::replace_database_connection_for_testing(
-				Some(orm_connection),
+			let lease = reinhardt_db::orm::connection::DatabaseConnectionLease::register(
+				connection.clone(),
 			)
-			.await;
+			.map_err(|source| TestDatabaseError::OrmGlobalInit {
+				source: Box::new(source),
+			})?;
+			let previous =
+				reinhardt_db::orm::manager::replace_database_connection_for_testing(Some(lease))
+					.await;
 
 			Some(OrmGlobalRestore { previous })
 		} else {
@@ -561,13 +561,17 @@ async fn apply_migrations(
 	Ok(())
 }
 
-async fn create_di_context(url: &str) -> Result<reinhardt_di::InjectionContext, TestDatabaseError> {
-	let orm_connection = reinhardt_db::orm::connection::DatabaseConnection::connect(url)
-		.await
-		.map_err(|source| TestDatabaseError::DiContextInit {
+fn create_di_context(
+	owner: reinhardt_db::backends::DatabaseConnection,
+) -> Result<reinhardt_di::InjectionContext, TestDatabaseError> {
+	let lease = reinhardt_db::orm::connection::DatabaseConnectionLease::register(owner).map_err(
+		|source| TestDatabaseError::DiContextInit {
 			source: Box::new(source),
-		})?;
+		},
+	)?;
+	let orm_connection = lease.handle();
 	let singleton_scope = std::sync::Arc::new(reinhardt_di::SingletonScope::new());
+	singleton_scope.set(lease);
 	singleton_scope.set(orm_connection);
 
 	Ok(reinhardt_di::InjectionContext::builder(singleton_scope).build())
@@ -589,7 +593,7 @@ enum TestDatabaseResource {
 }
 
 struct OrmGlobalRestore {
-	previous: Option<reinhardt_db::orm::connection::DatabaseConnection>,
+	previous: Option<reinhardt_db::orm::connection::DatabaseConnectionLease>,
 }
 
 impl OrmGlobalRestore {
@@ -1224,11 +1228,13 @@ pub fn migration() -> Migration {
 	#[serial_test::serial(test_database_orm_global)]
 	#[tokio::test]
 	async fn with_orm_global_restores_previous_connection_on_drop() {
+		let owner = reinhardt_db::backends::DatabaseConnection::connect_sqlite("sqlite::memory:")
+			.await
+			.unwrap();
 		let previous =
-			reinhardt_db::orm::connection::DatabaseConnection::connect("sqlite::memory:")
-				.await
-				.unwrap();
-		previous
+			reinhardt_db::orm::connection::DatabaseConnectionLease::register(owner).unwrap();
+		let previous_handle = previous.handle();
+		previous_handle
 			.execute(
 				"CREATE TABLE previous_marker (id INTEGER PRIMARY KEY)",
 				Vec::new(),

--- a/crates/reinhardt-testkit/src/fixtures/di.rs
+++ b/crates/reinhardt-testkit/src/fixtures/di.rs
@@ -401,7 +401,10 @@ where
 /// When it goes out of scope, the temporary database file will be deleted.
 #[fixture]
 pub async fn injection_context_with_sqlite() -> (tempfile::NamedTempFile, InjectionContext) {
-	use reinhardt_db::orm::connection::DatabaseConnection;
+	use reinhardt_db::{
+		backends::DatabaseConnection as BackendsConnection,
+		orm::connection::DatabaseConnectionLease,
+	};
 
 	// Create temp file for SQLite database
 	let temp_file = tempfile::NamedTempFile::new().expect("Failed to create temp file");
@@ -409,12 +412,15 @@ pub async fn injection_context_with_sqlite() -> (tempfile::NamedTempFile, Inject
 	let database_url = format!("sqlite://{}?mode=rwc", db_path);
 
 	// Create DatabaseConnection using ORM layer API
-	let db_conn = DatabaseConnection::connect_sqlite(&database_url)
+	let owner = BackendsConnection::connect_sqlite(&database_url)
 		.await
 		.expect("Failed to create DatabaseConnection");
+	let lease = DatabaseConnectionLease::register(owner).expect("Failed to register connection");
+	let db_conn = lease.handle();
 
 	// Build DI context with DatabaseConnection registered in singleton scope
 	let singleton_scope = Arc::new(SingletonScope::new());
+	singleton_scope.set(lease);
 	singleton_scope.set(db_conn);
 
 	let ctx = InjectionContext::builder(singleton_scope).build();
@@ -447,15 +453,21 @@ pub async fn injection_context_with_sqlite() -> (tempfile::NamedTempFile, Inject
 /// }
 /// ```
 pub async fn injection_context_with_database(database_url: &str) -> InjectionContext {
-	use reinhardt_db::orm::connection::DatabaseConnection;
+	use reinhardt_db::{
+		backends::DatabaseConnection as BackendsConnection,
+		orm::connection::DatabaseConnectionLease,
+	};
 
 	// Create DatabaseConnection
-	let db_conn = DatabaseConnection::connect(database_url)
+	let owner = BackendsConnection::connect(database_url)
 		.await
 		.expect("Failed to create DatabaseConnection");
+	let lease = DatabaseConnectionLease::register(owner).expect("Failed to register connection");
+	let db_conn = lease.handle();
 
 	// Build DI context with DatabaseConnection registered
 	let singleton_scope = Arc::new(SingletonScope::new());
+	singleton_scope.set(lease);
 	singleton_scope.set(db_conn);
 
 	InjectionContext::builder(singleton_scope).build()

--- a/crates/reinhardt-testkit/src/fixtures/mock.rs
+++ b/crates/reinhardt-testkit/src/fixtures/mock.rs
@@ -5,9 +5,23 @@ use reinhardt_db::backends::{
 	connection::DatabaseConnection as BackendsConnection,
 	types::{DatabaseType, QueryResult, QueryValue, Row, TransactionExecutor},
 };
-use reinhardt_db::orm::{DatabaseBackend, DatabaseConnection};
+use reinhardt_db::orm::{DatabaseConnection, DatabaseConnectionLease};
 use rstest::*;
 use std::sync::Arc;
+
+/// RAII guard for a mock ORM connection.
+pub struct MockConnection {
+	connection: DatabaseConnection,
+	_connection_lease: DatabaseConnectionLease,
+}
+
+impl std::ops::Deref for MockConnection {
+	type Target = DatabaseConnection;
+
+	fn deref(&self) -> &Self::Target {
+		&self.connection
+	}
+}
 
 // ============================================================================
 // mockall-based Database Backend Mock
@@ -142,7 +156,7 @@ pub fn mock_database() -> MockDatabaseBackend {
 /// Note: Doctests cannot use rstest fixtures directly due to Rust's doctest limitations.
 /// For runnable examples, refer to the unit tests in the `#[cfg(test)]` section below.
 #[fixture]
-pub fn mock_connection() -> DatabaseConnection {
+pub fn mock_connection() -> MockConnection {
 	let mut mock = MockDatabaseBackend::new();
 
 	// Basic configuration
@@ -178,7 +192,12 @@ pub fn mock_connection() -> DatabaseConnection {
 	mock.expect_fetch_optional().returning(|_, _| Ok(None));
 
 	let backends_conn = BackendsConnection::new(Arc::new(mock));
-	DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn)
+	let connection_lease =
+		DatabaseConnectionLease::register(backends_conn).expect("Failed to register connection");
+	MockConnection {
+		connection: connection_lease.handle(),
+		_connection_lease: connection_lease,
+	}
 }
 
 #[cfg(test)]
@@ -240,7 +259,7 @@ mod tests {
 	}
 
 	#[rstest]
-	fn test_mock_connection_fixture(mock_connection: DatabaseConnection) {
+	fn test_mock_connection_fixture(mock_connection: MockConnection) {
 		// Verify connection is usable
 		assert!(matches!(
 			mock_connection.backend(),

--- a/crates/reinhardt-testkit/src/fixtures/mock.rs
+++ b/crates/reinhardt-testkit/src/fixtures/mock.rs
@@ -263,7 +263,7 @@ mod tests {
 		// Verify connection is usable
 		assert!(matches!(
 			mock_connection.backend(),
-			DatabaseBackend::Postgres
+			reinhardt_db::orm::DatabaseBackend::Postgres
 		));
 	}
 }

--- a/crates/reinhardt-testkit/src/fixtures/testcontainers.rs
+++ b/crates/reinhardt-testkit/src/fixtures/testcontainers.rs
@@ -14,6 +14,22 @@ use testcontainers::{
 #[cfg(feature = "testcontainers")]
 pub use testcontainers::{ContainerAsync, GenericImage};
 
+/// RAII guard for an ORM handle backed by a migration test database.
+#[cfg(feature = "testcontainers")]
+pub struct MigrationDatabase {
+	connection: reinhardt_db::orm::DatabaseConnection,
+	_connection_lease: reinhardt_db::orm::DatabaseConnectionLease,
+}
+
+#[cfg(feature = "testcontainers")]
+impl std::ops::Deref for MigrationDatabase {
+	type Target = reinhardt_db::orm::DatabaseConnection;
+
+	fn deref(&self) -> &Self::Target {
+		&self.connection
+	}
+}
+
 /// Check if a port is available (not in use by any process)
 #[cfg(feature = "testcontainers")]
 async fn is_port_available(port: u16) -> bool {
@@ -1331,7 +1347,7 @@ pub async fn localstack_fixture() -> (ContainerAsync<GenericImage>, u16, String)
 /// * `P` - A type implementing `MigrationProvider`
 ///
 /// # Returns
-/// * `(ContainerAsync<GenericImage>, Arc<DatabaseConnection>)` - Container and database connection
+/// * `(ContainerAsync<GenericImage>, MigrationDatabase)` - Container and guarded ORM connection
 ///
 /// # Example
 ///
@@ -1363,22 +1379,16 @@ pub async fn localstack_fixture() -> (ContainerAsync<GenericImage>, u16, String)
 /// ```
 #[cfg(feature = "testcontainers")]
 pub async fn postgres_with_migrations_from<P: reinhardt_db::migrations::MigrationProvider>()
--> Result<
-	(
-		ContainerAsync<GenericImage>,
-		std::sync::Arc<reinhardt_db::DatabaseConnection>,
-	),
-	Box<dyn std::error::Error>,
-> {
-	use reinhardt_db::DatabaseConnection;
+-> Result<(ContainerAsync<GenericImage>, MigrationDatabase), Box<dyn std::error::Error>> {
+	use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
 	use reinhardt_db::migrations::executor::DatabaseMigrationExecutor;
-	use std::sync::Arc;
+	use reinhardt_db::orm::DatabaseConnectionLease;
 
 	// Start PostgreSQL container
 	let (container, _pool, _port, url) = postgres_container().await;
 
 	// Connect to database
-	let connection = DatabaseConnection::connect_postgres(&url)
+	let owner = BackendsConnection::connect_postgres(&url)
 		.await
 		.map_err(|e| format!("Failed to connect to PostgreSQL for migrations: {}", e))?;
 
@@ -1386,14 +1396,21 @@ pub async fn postgres_with_migrations_from<P: reinhardt_db::migrations::Migratio
 	let migrations = P::migrations();
 
 	if !migrations.is_empty() {
-		let mut executor = DatabaseMigrationExecutor::new(connection.inner().clone());
+		let mut executor = DatabaseMigrationExecutor::new(owner.clone());
 		executor
 			.apply_migrations(&migrations)
 			.await
 			.map_err(|e| format!("Failed to apply migrations: {}", e))?;
 	}
 
-	Ok((container, Arc::new(connection)))
+	let connection_lease = DatabaseConnectionLease::register(owner)?;
+	Ok((
+		container,
+		MigrationDatabase {
+			connection: connection_lease.handle(),
+			_connection_lease: connection_lease,
+		},
+	))
 }
 
 /// Fixture: MySQL container (base fixture)
@@ -1539,7 +1556,7 @@ pub async fn mysql_container() -> (
 /// * `P` - A type implementing `MigrationProvider`
 ///
 /// # Returns
-/// * `(ContainerAsync<GenericImage>, Arc<DatabaseConnection>)` - Container and database connection
+/// * `(ContainerAsync<GenericImage>, MigrationDatabase)` - Container and guarded ORM connection
 ///
 /// # Example
 ///
@@ -1566,19 +1583,17 @@ pub async fn mysql_container() -> (
 /// # }
 /// ```
 #[cfg(feature = "testcontainers")]
-pub async fn mysql_with_migrations_from<P: reinhardt_db::migrations::MigrationProvider>() -> (
-	ContainerAsync<GenericImage>,
-	std::sync::Arc<reinhardt_db::DatabaseConnection>,
-) {
-	use reinhardt_db::DatabaseConnection;
+pub async fn mysql_with_migrations_from<P: reinhardt_db::migrations::MigrationProvider>()
+-> (ContainerAsync<GenericImage>, MigrationDatabase) {
+	use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
 	use reinhardt_db::migrations::executor::DatabaseMigrationExecutor;
-	use std::sync::Arc;
+	use reinhardt_db::orm::DatabaseConnectionLease;
 
 	// Start MySQL container
 	let (container, _pool, _port, url) = mysql_container().await;
 
 	// Connect to database
-	let connection = DatabaseConnection::connect_mysql(&url)
+	let owner = BackendsConnection::connect_mysql(&url)
 		.await
 		.expect("Failed to connect to MySQL for migrations");
 
@@ -1586,14 +1601,22 @@ pub async fn mysql_with_migrations_from<P: reinhardt_db::migrations::MigrationPr
 	let migrations = P::migrations();
 
 	if !migrations.is_empty() {
-		let mut executor = DatabaseMigrationExecutor::new(connection.inner().clone());
+		let mut executor = DatabaseMigrationExecutor::new(owner.clone());
 		executor
 			.apply_migrations(&migrations)
 			.await
 			.expect("Failed to apply migrations");
 	}
 
-	(container, Arc::new(connection))
+	let connection_lease =
+		DatabaseConnectionLease::register(owner).expect("Failed to register connection");
+	(
+		container,
+		MigrationDatabase {
+			connection: connection_lease.handle(),
+			_connection_lease: connection_lease,
+		},
+	)
 }
 
 /// SQLite in-memory database with migrations from a MigrationProvider
@@ -1605,7 +1628,7 @@ pub async fn mysql_with_migrations_from<P: reinhardt_db::migrations::MigrationPr
 /// * `P` - A type implementing `MigrationProvider`
 ///
 /// # Returns
-/// * `Arc<DatabaseConnection>` - Database connection (no container needed for SQLite)
+/// * `MigrationDatabase` - Guarded ORM connection (no container needed for SQLite)
 ///
 /// # Example
 ///
@@ -1633,15 +1656,15 @@ pub async fn mysql_with_migrations_from<P: reinhardt_db::migrations::MigrationPr
 /// ```
 #[cfg(feature = "testcontainers")]
 pub async fn sqlite_with_migrations_from<P: reinhardt_db::migrations::MigrationProvider>()
--> std::sync::Arc<reinhardt_db::DatabaseConnection> {
-	use reinhardt_db::DatabaseConnection;
+-> MigrationDatabase {
+	use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
 	use reinhardt_db::migrations::executor::DatabaseMigrationExecutor;
-	use std::sync::Arc;
+	use reinhardt_db::orm::DatabaseConnectionLease;
 
 	let database_url = "sqlite::memory:";
 
 	// Connect to database
-	let connection = DatabaseConnection::connect_sqlite(database_url)
+	let owner = BackendsConnection::connect_sqlite(database_url)
 		.await
 		.expect("Failed to connect to SQLite for migrations");
 
@@ -1649,14 +1672,19 @@ pub async fn sqlite_with_migrations_from<P: reinhardt_db::migrations::MigrationP
 	let migrations = P::migrations();
 
 	if !migrations.is_empty() {
-		let mut executor = DatabaseMigrationExecutor::new(connection.inner().clone());
+		let mut executor = DatabaseMigrationExecutor::new(owner.clone());
 		executor
 			.apply_migrations(&migrations)
 			.await
 			.expect("Failed to apply migrations");
 	}
 
-	Arc::new(connection)
+	let connection_lease =
+		DatabaseConnectionLease::register(owner).expect("Failed to register connection");
+	MigrationDatabase {
+		connection: connection_lease.handle(),
+		_connection_lease: connection_lease,
+	}
 }
 
 /// Helper function for creating a PostgreSQL container with migrations
@@ -1691,24 +1719,18 @@ pub async fn sqlite_with_migrations_from<P: reinhardt_db::migrations::MigrationP
 #[cfg(feature = "testcontainers")]
 pub async fn postgres_with_migrations_from_dir(
 	migrations_dir: impl AsRef<std::path::Path>,
-) -> Result<
-	(
-		ContainerAsync<GenericImage>,
-		std::sync::Arc<reinhardt_db::DatabaseConnection>,
-	),
-	Box<dyn std::error::Error>,
-> {
-	use reinhardt_db::DatabaseConnection;
+) -> Result<(ContainerAsync<GenericImage>, MigrationDatabase), Box<dyn std::error::Error>> {
+	use reinhardt_db::backends::DatabaseConnection as BackendsConnection;
 	use reinhardt_db::migrations::FilesystemSource;
 	use reinhardt_db::migrations::MigrationSource;
 	use reinhardt_db::migrations::executor::DatabaseMigrationExecutor;
-	use std::sync::Arc;
+	use reinhardt_db::orm::DatabaseConnectionLease;
 
 	// Start PostgreSQL container
 	let (container, _pool, _port, url) = postgres_container().await;
 
 	// Connect to database
-	let connection = DatabaseConnection::connect_postgres(&url)
+	let owner = BackendsConnection::connect_postgres(&url)
 		.await
 		.map_err(|e| format!("Failed to connect to PostgreSQL for migrations: {}", e))?;
 
@@ -1720,7 +1742,7 @@ pub async fn postgres_with_migrations_from_dir(
 		.map_err(|e| format!("Failed to load migrations from filesystem: {}", e))?;
 
 	if !migrations.is_empty() {
-		let mut executor = DatabaseMigrationExecutor::new(connection.inner().clone());
+		let mut executor = DatabaseMigrationExecutor::new(owner.clone());
 		executor
 			.apply_migrations(&migrations)
 			.await
@@ -1733,7 +1755,14 @@ pub async fn postgres_with_migrations_from_dir(
 		.await
 		.map_err(|e| format!("Failed to initialize ORM global state: {}", e))?;
 
-	Ok((container, Arc::new(connection)))
+	let connection_lease = DatabaseConnectionLease::register(owner)?;
+	Ok((
+		container,
+		MigrationDatabase {
+			connection: connection_lease.handle(),
+			_connection_lease: connection_lease,
+		},
+	))
 }
 
 // ============================================================================

--- a/crates/reinhardt-views/src/generic/composite.rs
+++ b/crates/reinhardt-views/src/generic/composite.rs
@@ -305,7 +305,7 @@ where
 						.await
 						.map_err(|e| Error::Internal(format!("Failed to resolve DB: {:?}", e)))?;
 
-					validators.validate_async(conn.inner(), &data, None).await?;
+					validators.validate_async(&conn, &data, None).await?;
 				}
 
 				let queryset = self.get_queryset();

--- a/crates/reinhardt-views/src/generic/create_api.rs
+++ b/crates/reinhardt-views/src/generic/create_api.rs
@@ -173,7 +173,7 @@ where
 				.await
 				.map_err(|e| Error::Internal(format!("Failed to resolve DB: {:?}", e)))?;
 
-			validators.validate_async(conn.inner(), &data, None).await?;
+			validators.validate_async(&conn, &data, None).await?;
 		}
 
 		// Create via QuerySet

--- a/crates/reinhardt-views/src/viewsets/injectable.rs
+++ b/crates/reinhardt-views/src/viewsets/injectable.rs
@@ -8,12 +8,11 @@
 //! ```ignore
 //! use reinhardt_views::viewsets::{InjectableViewSet, ModelViewSet, ViewSet};
 //! use reinhardt_di::Injectable;
-//! use std::sync::Arc;
 //!
 //! impl MyViewSet {
 //!     async fn handle_list(&self, request: Request) -> Result<Response> {
 //!         // Resolve dependencies from the request's DI context
-//!         let db: Arc<DatabaseConnection> = self.resolve(&request).await?;
+//!         let db: DatabaseConnection = self.resolve(&request).await?;
 //!         let cache: CacheService = self.resolve_uncached(&request).await?;
 //!
 //!         // Use the dependencies
@@ -40,7 +39,6 @@ use std::sync::Arc;
 /// # #[tokio::main]
 /// # async fn main() {
 /// use reinhardt_views::viewsets::{InjectableViewSet, ModelViewSet, ViewSet};
-/// use std::sync::Arc;
 ///
 /// struct UserViewSet {
 ///     basename: String,
@@ -49,7 +47,7 @@ use std::sync::Arc;
 /// impl UserViewSet {
 ///     async fn handle_list(&self, request: Request) -> Result<Response> {
 ///         // Resolve with caching (default)
-///         let db: Arc<DatabaseConnection> = self.resolve(&request).await?;
+///         let db: DatabaseConnection = self.resolve(&request).await?;
 ///
 ///         // Resolve without caching
 ///         let fresh_config: Config = self.resolve_uncached(&request).await?;
@@ -77,7 +75,7 @@ pub trait InjectableViewSet: ViewSet {
 	/// # Examples
 	///
 	/// ```ignore
-	/// let db: Arc<DatabaseConnection> = self.resolve(&request).await?;
+	/// let db: DatabaseConnection = self.resolve(&request).await?;
 	/// ```
 	async fn resolve<T>(&self, request: &Request) -> Result<T>
 	where

--- a/crates/reinhardt-websockets/src/consumers.rs
+++ b/crates/reinhardt-websockets/src/consumers.rs
@@ -25,7 +25,7 @@
 //! #
 //! async fn on_message(&self, ctx: &mut ConsumerContext, msg: Message) -> WebSocketResult<()> {
 //!     // Resolve dependencies from DI context
-//!     // let db: Arc<DatabaseConnection> = ctx.resolve().await?;
+//!     // let db: DatabaseConnection = ctx.resolve().await?;
 //!     // let cache: CacheService = ctx.resolve_uncached().await?;
 //!
 //!     // Use the dependencies...
@@ -194,7 +194,7 @@ impl ConsumerContext {
 	/// # Examples
 	///
 	/// ```ignore
-	/// let db: Arc<DatabaseConnection> = ctx.resolve().await?;
+	/// let db: DatabaseConnection = ctx.resolve().await?;
 	/// ```
 	#[cfg(feature = "di")]
 	pub async fn resolve<T>(&self) -> WebSocketResult<T>

--- a/docs/migration/0.4.0-copy-database-connection.md
+++ b/docs/migration/0.4.0-copy-database-connection.md
@@ -1,0 +1,63 @@
+# Copyable ORM Database Connections
+
+Reinhardt 0.4.0 separates database connection ownership from the ORM capability
+passed to application code. `reinhardt_db::backends::DatabaseConnection` owns
+the backend connection, `reinhardt_db::orm::DatabaseConnectionLease` owns its
+registry lifetime, and `reinhardt_db::orm::DatabaseConnection` is a small
+`Copy` handle.
+
+## Standalone ORM setup
+
+Direct construction on the ORM connection has been removed.
+
+```rust,ignore
+// Before
+let db = reinhardt_db::orm::DatabaseConnection::connect_sqlite(url).await?;
+```
+
+Create the backend owner, register its lease, and obtain an ORM handle instead:
+
+```rust,ignore
+// After, for standalone ORM setup
+let owner = reinhardt_db::backends::DatabaseConnection::connect_sqlite(url).await?;
+let lease = reinhardt_db::orm::DatabaseConnectionLease::register(owner)?;
+let db = lease.handle();
+```
+
+The lease must outlive every operation that uses `db` or a copy of it. Dropping
+one cloned lease does not expire handles while another lease remains. After the
+last lease drops, starting a new operation with an existing handle returns a
+database error whose kind is
+`DatabaseErrorKind::ConnectionHandleExpired`.
+
+An operation that already resolved its owner before the final lease is dropped
+keeps that owner alive until the operation finishes. Dropping the lease
+therefore prevents new operations without cancelling in-flight work.
+
+## Framework handlers
+
+Framework bootstrap owns the lease and registers its handle in dependency
+injection. Handlers receive only the copyable ORM handle:
+
+```rust,ignore
+use reinhardt::db::DatabaseConnection;
+use reinhardt::pages::server_fn::{ServerFnError, server_fn};
+
+#[server_fn]
+async fn dashboard(#[inject] db: DatabaseConnection) -> Result<(), ServerFnError> {
+    tokio::try_join!(load_users(db), load_posts(db))?;
+    Ok(())
+}
+```
+
+Copy the handle by assignment or pass it by value. Calling `clone()` is no
+longer necessary. The former ORM `inner()` and `into_inner()` escape hatches
+have been removed; code that needs ownership of a low-level connection must
+create and retain a `reinhardt_db::backends::DatabaseConnection` explicitly.
+
+## Transactions
+
+`DatabaseConnection` being `Copy` does not make transactions copyable. Use
+`DatabaseConnection::atomic` and pass the callback's mutable
+`AtomicTransaction` to transaction-bound operations. The transaction remains
+bound to one dedicated connection and cannot escape the callback lifetime.

--- a/docs/migration/0.4.0-copy-database-connection.md
+++ b/docs/migration/0.4.0-copy-database-connection.md
@@ -24,6 +24,11 @@ let lease = reinhardt_db::orm::DatabaseConnectionLease::register(owner)?;
 let db = lease.handle();
 ```
 
+When the backend is selected from configuration, use
+`reinhardt_db::backends::DatabaseConnection::connect(url)`. It dispatches from
+the URL scheme and reports a configuration error when the matching backend
+feature is not enabled.
+
 The lease must outlive every operation that uses `db` or a copy of it. Dropping
 one cloned lease does not expire handles while another lease remains. After the
 last lease drops, starting a new operation with an existing handle returns a

--- a/examples/examples-tutorial-basis/README.md
+++ b/examples/examples-tutorial-basis/README.md
@@ -27,6 +27,7 @@ This example corresponds to the basis tutorial parts 1-7:
 The example exposes its dynamic business logic through the pages stack:
 
 - **Typed RPC server functions** in `src/apps/<app>/server_fn.rs` — `#[server_fn]` functions (`get_questions`, `get_question_detail`, `vote`, `create_question`, …, plus `login` / `logout` / `register` / `current_user` for the `users` app). The macro generates a typed client stub for WASM and a server-side handler for native; dependencies are resolved positionally with `#[inject]` (`DatabaseConnection`, `SessionData`, `CurrentUser<User>`, …).
+- **Copyable ORM access** — injected `DatabaseConnection` values are lightweight `Copy` handles. Server bootstrap retains the owning lease, so server functions pass handles by value without cloning or managing connection lifetime.
 - **Per-app URL modules** in `src/apps/<app>/urls.rs` — each app exposes target-specific router functions from one aggregate; server-function markers stay in `src/apps/<app>/urls/server_router.rs`, client component route tables stay in `src/apps/<app>/urls/client_router.rs`, and `src/config/urls.rs` only aggregates the app-level router functions for the active target.
 - **Route-backed components** in `src/apps/<app>/client/components/` — component macros own route metadata for pages such as login/logout/signup.
 - **Dynamic WASM forms** in `src/apps/polls/client/components.rs` — the poll detail route builds its `RadioSelect` voting form from the choices returned by `get_question_detail`, so each loaded choice becomes a submitted `choice_id` option.

--- a/examples/examples-tutorial-basis/tests/integration.rs
+++ b/examples/examples-tutorial-basis/tests/integration.rs
@@ -533,6 +533,8 @@ mod database_tests {
 #[cfg(all(with_reinhardt, server))]
 mod server_fn_tests {
 	use reinhardt::DatabaseConnection;
+	use reinhardt::db::backends::DatabaseConnection as BackendsConnection;
+	use reinhardt::db::orm::DatabaseConnectionLease;
 	use reinhardt::db::orm::reinitialize_database;
 	use rstest::*;
 	use serial_test::serial;
@@ -549,7 +551,12 @@ mod server_fn_tests {
 	/// Fixture: SQLite database with tables, test data, and DatabaseConnection
 	/// Also initializes the global ORM database connection for server functions.
 	#[fixture]
-	async fn sqlite_with_test_data() -> (NamedTempFile, Arc<SqlitePool>, DatabaseConnection) {
+	async fn sqlite_with_test_data() -> (
+		NamedTempFile,
+		Arc<SqlitePool>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	) {
 		// Create temp file
 		let temp_file = NamedTempFile::new().expect("Failed to create temp file");
 		let db_path = temp_file.path().to_str().unwrap().to_string();
@@ -627,20 +634,28 @@ mod server_fn_tests {
 			.expect("Failed to initialize global database");
 
 		// Create DatabaseConnection for server functions
-		let db_conn = DatabaseConnection::connect_sqlite(&orm_url)
+		let owner = BackendsConnection::connect_sqlite(&orm_url)
 			.await
-			.expect("Failed to create DatabaseConnection");
+			.expect("Failed to create backend connection");
+		let lease = DatabaseConnectionLease::register(owner)
+			.expect("Failed to register DatabaseConnection");
+		let db_conn = lease.handle();
 
-		(temp_file, pool, db_conn)
+		(temp_file, pool, lease, db_conn)
 	}
 
 	#[rstest]
 	#[tokio::test]
 	#[serial(server_fn_tests)]
 	async fn test_get_questions_server_fn(
-		#[future] sqlite_with_test_data: (NamedTempFile, Arc<SqlitePool>, DatabaseConnection),
+		#[future] sqlite_with_test_data: (
+			NamedTempFile,
+			Arc<SqlitePool>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
+		),
 	) {
-		let (_file, _pool, db_conn) = sqlite_with_test_data.await;
+		let (_file, _pool, _lease, db_conn) = sqlite_with_test_data.await;
 
 		// Test: Get questions via server function (pass DatabaseConnection as argument)
 		let result = get_questions(db_conn).await;
@@ -653,9 +668,14 @@ mod server_fn_tests {
 	#[tokio::test]
 	#[serial(server_fn_tests)]
 	async fn test_get_question_detail_server_fn(
-		#[future] sqlite_with_test_data: (NamedTempFile, Arc<SqlitePool>, DatabaseConnection),
+		#[future] sqlite_with_test_data: (
+			NamedTempFile,
+			Arc<SqlitePool>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
+		),
 	) {
-		let (_file, _pool, db_conn) = sqlite_with_test_data.await;
+		let (_file, _pool, _lease, db_conn) = sqlite_with_test_data.await;
 
 		// Test: Get question detail via server function
 		let result = get_question_detail(1, db_conn).await;
@@ -672,9 +692,14 @@ mod server_fn_tests {
 	#[tokio::test]
 	#[serial(server_fn_tests)]
 	async fn test_get_question_detail_not_found(
-		#[future] sqlite_with_test_data: (NamedTempFile, Arc<SqlitePool>, DatabaseConnection),
+		#[future] sqlite_with_test_data: (
+			NamedTempFile,
+			Arc<SqlitePool>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
+		),
 	) {
-		let (_file, _pool, db_conn) = sqlite_with_test_data.await;
+		let (_file, _pool, _lease, db_conn) = sqlite_with_test_data.await;
 
 		// Test: Get non-existent question
 		let result = get_question_detail(999, db_conn).await;
@@ -688,9 +713,14 @@ mod server_fn_tests {
 	#[tokio::test]
 	#[serial(server_fn_tests)]
 	async fn test_get_question_results_server_fn(
-		#[future] sqlite_with_test_data: (NamedTempFile, Arc<SqlitePool>, DatabaseConnection),
+		#[future] sqlite_with_test_data: (
+			NamedTempFile,
+			Arc<SqlitePool>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
+		),
 	) {
-		let (_file, _pool, db_conn) = sqlite_with_test_data.await;
+		let (_file, _pool, _lease, db_conn) = sqlite_with_test_data.await;
 
 		// Test: Get question results via server function
 		let result = get_question_results(1, db_conn).await;
@@ -706,9 +736,14 @@ mod server_fn_tests {
 	#[tokio::test]
 	#[serial(server_fn_tests)]
 	async fn test_vote_server_fn(
-		#[future] sqlite_with_test_data: (NamedTempFile, Arc<SqlitePool>, DatabaseConnection),
+		#[future] sqlite_with_test_data: (
+			NamedTempFile,
+			Arc<SqlitePool>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
+		),
 	) {
-		let (_file, _pool, db_conn) = sqlite_with_test_data.await;
+		let (_file, _pool, _lease, db_conn) = sqlite_with_test_data.await;
 
 		// Test: Vote for a choice
 		let vote_request = VoteRequest {
@@ -728,9 +763,14 @@ mod server_fn_tests {
 	#[tokio::test]
 	#[serial(server_fn_tests)]
 	async fn test_vote_wrong_question(
-		#[future] sqlite_with_test_data: (NamedTempFile, Arc<SqlitePool>, DatabaseConnection),
+		#[future] sqlite_with_test_data: (
+			NamedTempFile,
+			Arc<SqlitePool>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
+		),
 	) {
-		let (_file, _pool, db_conn) = sqlite_with_test_data.await;
+		let (_file, _pool, _lease, db_conn) = sqlite_with_test_data.await;
 
 		// Test: Vote with mismatched question_id and choice_id
 		let vote_request = VoteRequest {
@@ -829,28 +869,22 @@ mod server_fn_tests {
 		};
 
 		// First vote
-		let db_conn1 = DatabaseConnection::connect_sqlite(&orm_url)
+		let owner = BackendsConnection::connect_sqlite(&orm_url)
 			.await
-			.expect("Failed to create DatabaseConnection");
-		vote(vote_request.clone(), db_conn1).await.unwrap();
+			.expect("Failed to create backend connection");
+		let lease = DatabaseConnectionLease::register(owner)
+			.expect("Failed to register DatabaseConnection");
+		let db_conn = lease.handle();
+		vote(vote_request.clone(), db_conn).await.unwrap();
 
 		// Second vote
-		let db_conn2 = DatabaseConnection::connect_sqlite(&orm_url)
-			.await
-			.expect("Failed to create DatabaseConnection");
-		vote(vote_request.clone(), db_conn2).await.unwrap();
+		vote(vote_request.clone(), db_conn).await.unwrap();
 
 		// Third vote
-		let db_conn3 = DatabaseConnection::connect_sqlite(&orm_url)
-			.await
-			.expect("Failed to create DatabaseConnection");
-		vote(vote_request.clone(), db_conn3).await.unwrap();
+		vote(vote_request.clone(), db_conn).await.unwrap();
 
 		// Verify votes counted correctly
-		let db_conn_check = DatabaseConnection::connect_sqlite(&orm_url)
-			.await
-			.expect("Failed to create DatabaseConnection");
-		let results = get_question_results(1, db_conn_check).await.unwrap();
+		let results = get_question_results(1, db_conn).await.unwrap();
 		let blue_choice = results.1.iter().find(|c| c.choice_text == "Blue").unwrap();
 		assert_eq!(blue_choice.votes, 3, "Blue should have 3 votes");
 		assert_eq!(results.2, 3, "Total votes should be 3");
@@ -876,6 +910,8 @@ mod auth_tests {
 		update_question,
 	};
 	use examples_tutorial_basis::apps::users::models::User;
+	use reinhardt::db::backends::DatabaseConnection as BackendsConnection;
+	use reinhardt::db::orm::DatabaseConnectionLease;
 	use reinhardt::pages::server_fn::{ServerFnError, ServerFnErrorKind};
 	use reinhardt::{CurrentUser, DatabaseConnection};
 	use rstest::*;
@@ -885,14 +921,17 @@ mod auth_tests {
 	/// reinhardt-orm. No tables are created; the inactive-user guard below
 	/// short-circuits before any query runs.
 	#[fixture]
-	async fn empty_db_conn() -> (NamedTempFile, DatabaseConnection) {
+	async fn empty_db_conn() -> (NamedTempFile, DatabaseConnectionLease, DatabaseConnection) {
 		let temp_file = NamedTempFile::new().expect("Failed to create temp file");
 		let db_path = temp_file.path().to_str().unwrap().to_string();
 		let orm_url = format!("sqlite:///{}", db_path);
-		let db_conn = DatabaseConnection::connect_sqlite(&orm_url)
+		let owner = BackendsConnection::connect_sqlite(&orm_url)
 			.await
-			.expect("Failed to create DatabaseConnection");
-		(temp_file, db_conn)
+			.expect("Failed to create backend connection");
+		let lease = DatabaseConnectionLease::register(owner)
+			.expect("Failed to register DatabaseConnection");
+		let db_conn = lease.handle();
+		(temp_file, lease, db_conn)
 	}
 
 	fn inactive_current_user() -> CurrentUser<User> {
@@ -936,9 +975,9 @@ mod auth_tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_create_question_requires_auth(
-		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
+		#[future] empty_db_conn: (NamedTempFile, DatabaseConnectionLease, DatabaseConnection),
 	) {
-		let (_file, db_conn) = empty_db_conn.await;
+		let (_file, _lease, db_conn) = empty_db_conn.await;
 		let current_user = inactive_current_user();
 
 		let result = create_question("Inactive attempt".to_string(), db_conn, current_user).await;
@@ -949,9 +988,9 @@ mod auth_tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_update_question_requires_auth(
-		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
+		#[future] empty_db_conn: (NamedTempFile, DatabaseConnectionLease, DatabaseConnection),
 	) {
-		let (_file, db_conn) = empty_db_conn.await;
+		let (_file, _lease, db_conn) = empty_db_conn.await;
 		let current_user = inactive_current_user();
 
 		let result = update_question(1, "New text".to_string(), db_conn, current_user).await;
@@ -962,9 +1001,9 @@ mod auth_tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_delete_question_requires_auth(
-		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
+		#[future] empty_db_conn: (NamedTempFile, DatabaseConnectionLease, DatabaseConnection),
 	) {
-		let (_file, db_conn) = empty_db_conn.await;
+		let (_file, _lease, db_conn) = empty_db_conn.await;
 		let current_user = inactive_current_user();
 
 		let result = delete_question(1, db_conn, current_user).await;
@@ -975,9 +1014,9 @@ mod auth_tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_create_choice_requires_auth(
-		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
+		#[future] empty_db_conn: (NamedTempFile, DatabaseConnectionLease, DatabaseConnection),
 	) {
-		let (_file, db_conn) = empty_db_conn.await;
+		let (_file, _lease, db_conn) = empty_db_conn.await;
 		let current_user = inactive_current_user();
 
 		let result = create_choice(1, "Inactive choice".to_string(), db_conn, current_user).await;
@@ -988,9 +1027,9 @@ mod auth_tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_update_choice_requires_auth(
-		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
+		#[future] empty_db_conn: (NamedTempFile, DatabaseConnectionLease, DatabaseConnection),
 	) {
-		let (_file, db_conn) = empty_db_conn.await;
+		let (_file, _lease, db_conn) = empty_db_conn.await;
 		let current_user = inactive_current_user();
 
 		let result = update_choice(1, "Hijack".to_string(), db_conn, current_user).await;
@@ -1001,9 +1040,9 @@ mod auth_tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_delete_choice_requires_auth(
-		#[future] empty_db_conn: (NamedTempFile, DatabaseConnection),
+		#[future] empty_db_conn: (NamedTempFile, DatabaseConnectionLease, DatabaseConnection),
 	) {
-		let (_file, db_conn) = empty_db_conn.await;
+		let (_file, _lease, db_conn) = empty_db_conn.await;
 		let current_user = inactive_current_user();
 
 		let result = delete_choice(1, db_conn, current_user).await;

--- a/examples/examples-tutorial-rest/README.md
+++ b/examples/examples-tutorial-rest/README.md
@@ -40,6 +40,10 @@ All handlers receive a database connection through direct dependency injection
 `/api/snippets/config/` endpoint is a teaching aid for
 `KeyedDepends<K, Result<T, E>>`; see `src/apps/snippets/di.rs`.
 
+`DatabaseConnection` is a copyable ORM handle whose lease is retained by server
+bootstrap. Handlers pass it by value without `clone()` and never construct or
+own the underlying backend connection.
+
 ## Setup
 
 ### Prerequisites
@@ -201,6 +205,7 @@ This example is designed to be studied alongside the REST tutorial:
 - `src/apps/snippets/serializers.rs` defines `SnippetSerializer` with `Validate` length rules and `SnippetResponse::from_model()`.
 - `src/apps/snippets/di.rs` registers a self-keyed singleton config provider and a keyed fallible config provider with `KeyedFactoryOutput<K, T>`.
 - `src/apps/snippets/views.rs` exposes function-based CRUD handlers with `#[get]`, `#[post(pre_validate = true)]`, `#[put]`, and `#[delete]`, resolving `DatabaseConnection` through direct injection.
+- The injected ORM handle is `Copy`, while framework bootstrap retains its owning lease for the server lifetime.
 - `src/apps/snippets/views.rs` also exposes a `#[reinhardt::viewset(basename = "snippet")]` `ModelViewSet` with pagination, filtering, and ordering.
 - `src/apps/snippets/urls.rs` registers both function-based endpoints and ViewSet endpoints on one `ServerRouter`.
 - `src/config/urls.rs` uses `#[routes]` and mounts the snippets router under the literal `/api/` prefix.

--- a/examples/examples-tutorial-rest/tests/integration.rs
+++ b/examples/examples-tutorial-rest/tests/integration.rs
@@ -26,29 +26,14 @@ mod tests {
 
 	use examples_tutorial_rest::apps::snippets::models::Snippet;
 
-	struct DatabaseConnection {
-		_lease: DatabaseConnectionLease,
-		handle: DatabaseConnectionHandle,
-	}
-
-	impl std::ops::Deref for DatabaseConnection {
-		type Target = DatabaseConnectionHandle;
-
-		fn deref(&self) -> &Self::Target {
-			&self.handle
-		}
-	}
-
-	impl std::ops::DerefMut for DatabaseConnection {
-		fn deref_mut(&mut self) -> &mut Self::Target {
-			&mut self.handle
-		}
-	}
-
 	/// Fixture: temporary SQLite database with the `snippets` table created
 	/// from the `Snippet` model metadata via `create_table_for_model`.
 	#[fixture]
-	async fn sqlite_with_migrations() -> (NamedTempFile, DatabaseConnection) {
+	async fn sqlite_with_migrations() -> (
+		NamedTempFile,
+		DatabaseConnectionLease,
+		DatabaseConnectionHandle,
+	) {
 		// Create temp file
 		let temp_file = NamedTempFile::new().expect("Failed to create temp file");
 		let db_path = temp_file.path().to_str().unwrap().to_string();
@@ -67,12 +52,9 @@ mod tests {
 			.expect("Failed to create snippets table");
 		let lease = DatabaseConnectionLease::register(owner)
 			.expect("Failed to register DatabaseConnection");
-		let conn = DatabaseConnection {
-			handle: lease.handle(),
-			_lease: lease,
-		};
+		let conn = lease.handle();
 
-		(temp_file, conn)
+		(temp_file, lease, conn)
 	}
 
 	// ============================================================================
@@ -133,9 +115,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_create(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange
 		let snippet = Snippet::build()
@@ -160,9 +142,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_read(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange
 		let snippet = Snippet::build()
@@ -193,9 +175,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_update(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange
 		let snippet = Snippet::build()
@@ -230,9 +212,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_delete(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange
 		let snippet = Snippet::build()
@@ -268,9 +250,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_list_all(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange
 		let manager = Manager::<Snippet>::new();
@@ -308,9 +290,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_filter_by_language(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange
 		let manager = Manager::<Snippet>::new();
@@ -352,9 +334,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_search_by_title(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange
 		let manager = Manager::<Snippet>::new();
@@ -396,9 +378,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_count(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange
 		let manager = Manager::<Snippet>::new();
@@ -428,9 +410,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_order_by_title(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange
 		let manager = Manager::<Snippet>::new();
@@ -464,9 +446,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_pagination(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange
 		let manager = Manager::<Snippet>::new();
@@ -519,9 +501,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_empty_database(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Act
 		let snippets = Manager::<Snippet>::new()
@@ -537,9 +519,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_nonexistent_id(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Act
 		let result = Manager::<Snippet>::new()
@@ -555,9 +537,9 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn test_snippet_update_nonexistent(
-		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnection),
+		#[future] sqlite_with_migrations: (NamedTempFile, DatabaseConnectionLease, DatabaseConnectionHandle),
 	) {
-		let (_file, mut conn) = sqlite_with_migrations.await;
+		let (_file, _connection_lease, mut conn) = sqlite_with_migrations.await;
 
 		// Arrange - a model instance whose primary key has no matching row
 		let mut nonexistent = Snippet::build()

--- a/examples/examples-tutorial-rest/tests/integration.rs
+++ b/examples/examples-tutorial-rest/tests/integration.rs
@@ -13,13 +13,37 @@
 
 #[cfg(with_reinhardt)]
 mod tests {
-	use reinhardt::DatabaseConnection;
-	use reinhardt::db::orm::{Filter, FilterOperator, FilterValue, Manager};
+	use reinhardt::db::{
+		backends::DatabaseConnection as BackendsConnection,
+		orm::{
+			DatabaseConnection as DatabaseConnectionHandle, DatabaseConnectionLease, Filter,
+			FilterOperator, FilterValue, Manager,
+		},
+	};
 	use reinhardt::test::fixtures::create_table_for_model;
 	use rstest::*;
 	use tempfile::NamedTempFile;
 
 	use examples_tutorial_rest::apps::snippets::models::Snippet;
+
+	struct DatabaseConnection {
+		_lease: DatabaseConnectionLease,
+		handle: DatabaseConnectionHandle,
+	}
+
+	impl std::ops::Deref for DatabaseConnection {
+		type Target = DatabaseConnectionHandle;
+
+		fn deref(&self) -> &Self::Target {
+			&self.handle
+		}
+	}
+
+	impl std::ops::DerefMut for DatabaseConnection {
+		fn deref_mut(&mut self) -> &mut Self::Target {
+			&mut self.handle
+		}
+	}
 
 	/// Fixture: temporary SQLite database with the `snippets` table created
 	/// from the `Snippet` model metadata via `create_table_for_model`.
@@ -32,15 +56,21 @@ mod tests {
 		// `connect_sqlite` automatically sets `create_if_missing(true)`.
 		let database_url = format!("sqlite:///{}", db_path);
 
-		let conn = DatabaseConnection::connect_sqlite(&database_url)
+		let owner = BackendsConnection::connect_sqlite(&database_url)
 			.await
 			.expect("Failed to create DatabaseConnection");
 
 		// Create the `snippets` table from the `Snippet` model metadata.
 		// `create_table_for_model` operates on the inner backend connection.
-		create_table_for_model::<Snippet>(conn.inner())
+		create_table_for_model::<Snippet>(&owner)
 			.await
 			.expect("Failed to create snippets table");
+		let lease = DatabaseConnectionLease::register(owner)
+			.expect("Failed to register DatabaseConnection");
+		let conn = DatabaseConnection {
+			handle: lease.handle(),
+			_lease: lease,
+		};
 
 		(temp_file, conn)
 	}

--- a/src/exports/database.rs
+++ b/src/exports/database.rs
@@ -1,4 +1,9 @@
 //! Database, ORM, and query builder re-exports.
+//!
+//! [`DatabaseConnection`] is the copyable ORM handle exposed at the Reinhardt
+//! crate root. Its RAII owner, `DatabaseConnectionLease`, remains available
+//! explicitly under `reinhardt_db::orm` for standalone setup and framework
+//! bootstrap code.
 
 pub use reinhardt_db::orm::{
 	AtomicTransaction, DatabaseBackend, DatabaseConnection, FieldAssignment, Model, OrmExecutor,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,6 +466,11 @@ pub mod db {
 	pub use reinhardt_db::DatabaseError as Error;
 	pub use reinhardt_db::Json;
 
+	/// Low-level backend connections used to register ORM connection leases.
+	pub mod backends {
+		pub use reinhardt_db::backends::*;
+	}
+
 	/// Canonical many-to-many default naming helpers used by generated models.
 	pub mod m2m_naming {
 		pub use reinhardt_db::m2m_naming::*;

--- a/tests/integration/admin_integration_tests.rs
+++ b/tests/integration/admin_integration_tests.rs
@@ -25,7 +25,7 @@ use reinhardt_admin::server::{
 };
 use reinhardt_admin::types::errors::AdminError;
 use reinhardt_test::fixtures::admin_panel::{
-	admin_database, admin_site, model_admin_config, server_fn_test_context,
+	AdminDatabaseFixture, admin_database, admin_site, model_admin_config, server_fn_test_context,
 };
 use reinhardt_test::fixtures::shared_postgres::get_test_pool;
 use rstest::*;
@@ -150,7 +150,7 @@ async fn test_model_unregistration(
 #[rstest]
 #[tokio::test]
 async fn test_admin_database_crud_operations(
-	#[future] admin_database: Arc<AdminDatabase>,
+	#[future] admin_database: AdminDatabaseFixture,
 	#[future] admin_site: Arc<AdminSite>,
 	#[future] model_admin_config: ModelAdminConfig,
 ) {
@@ -241,7 +241,7 @@ async fn test_admin_database_crud_operations(
 #[case(2, 3)] // Third page
 #[tokio::test]
 async fn test_list_pagination(
-	#[future] admin_database: Arc<AdminDatabase>,
+	#[future] admin_database: AdminDatabaseFixture,
 	#[case] page: u64,
 	#[case] page_size: u64,
 ) {
@@ -293,7 +293,7 @@ async fn test_list_pagination(
 #[case(0, 0)] // Zero limit (edge case)
 #[tokio::test]
 async fn test_pagination_boundary_values(
-	#[future] admin_database: Arc<AdminDatabase>,
+	#[future] admin_database: AdminDatabaseFixture,
 	#[case] offset: u64,
 	#[case] limit: u64,
 ) {
@@ -322,7 +322,7 @@ async fn test_pagination_boundary_values(
 #[rstest]
 #[tokio::test]
 async fn test_server_function_get_dashboard(
-	#[future] server_fn_test_context: (Arc<AdminSite>, Arc<AdminDatabase>),
+	#[future] server_fn_test_context: (Arc<AdminSite>, AdminDatabaseFixture),
 ) {
 	let (site, _db) = server_fn_test_context.await;
 
@@ -347,7 +347,7 @@ async fn test_server_function_get_dashboard(
 #[rstest]
 #[tokio::test]
 async fn test_crud_server_functions(
-	#[future] server_fn_test_context: (Arc<AdminSite>, Arc<AdminDatabase>),
+	#[future] server_fn_test_context: (Arc<AdminSite>, AdminDatabaseFixture),
 ) {
 	let (site, db) = server_fn_test_context.await;
 	let model_name = "TestModel".to_string();
@@ -441,7 +441,7 @@ async fn test_crud_server_functions(
 #[case::with_search(ListQueryParams { search: Some("test".to_string()), ..Default::default() })]
 #[tokio::test]
 async fn test_list_server_function_variations(
-	#[future] server_fn_test_context: (Arc<AdminSite>, Arc<AdminDatabase>),
+	#[future] server_fn_test_context: (Arc<AdminSite>, AdminDatabaseFixture),
 	#[case] params: ListQueryParams,
 ) {
 	let (site, db) = server_fn_test_context.await;
@@ -472,7 +472,7 @@ async fn test_list_server_function_variations(
 #[rstest]
 #[tokio::test]
 async fn test_server_function_model_not_registered_error(
-	#[future] server_fn_test_context: (Arc<AdminSite>, Arc<AdminDatabase>),
+	#[future] server_fn_test_context: (Arc<AdminSite>, AdminDatabaseFixture),
 ) {
 	let (site, db) = server_fn_test_context.await;
 	let non_existent_model = "NonExistentModel".to_string();
@@ -500,7 +500,7 @@ async fn test_server_function_model_not_registered_error(
 #[rstest]
 #[tokio::test]
 async fn test_export_import_server_functions_structure(
-	#[future] server_fn_test_context: (Arc<AdminSite>, Arc<AdminDatabase>),
+	#[future] server_fn_test_context: (Arc<AdminSite>, AdminDatabaseFixture),
 ) {
 	let (site, db) = server_fn_test_context.await;
 	let model_name = "TestModel".to_string();
@@ -602,7 +602,7 @@ async fn test_permission_decision_table(
 #[case("test\nnewline")] // Search with special characters
 #[tokio::test]
 async fn test_search_equivalence_partitioning(
-	#[future] admin_database: Arc<AdminDatabase>,
+	#[future] admin_database: AdminDatabaseFixture,
 	#[case] search_term: &str,
 ) {
 	use reinhardt_db::Model;
@@ -644,7 +644,7 @@ async fn test_search_equivalence_partitioning(
 /// **Test Classification**: Boundary value analysis
 #[rstest]
 #[tokio::test]
-async fn test_filter_edge_cases(#[future] admin_database: Arc<AdminDatabase>) {
+async fn test_filter_edge_cases(#[future] admin_database: AdminDatabaseFixture) {
 	use reinhardt_admin::core::{Filter, FilterOperator, FilterValue};
 	use reinhardt_db::Model;
 
@@ -717,7 +717,7 @@ async fn test_filter_edge_cases(#[future] admin_database: Arc<AdminDatabase>) {
 #[rstest]
 #[tokio::test]
 async fn test_complete_admin_panel_workflow(
-	#[future] server_fn_test_context: (Arc<AdminSite>, Arc<AdminDatabase>),
+	#[future] server_fn_test_context: (Arc<AdminSite>, AdminDatabaseFixture),
 ) {
 	let (site, db) = server_fn_test_context.await;
 	let model_name = "TestModel".to_string();

--- a/tests/integration/src/db_transaction.rs
+++ b/tests/integration/src/db_transaction.rs
@@ -3,9 +3,11 @@
 //! Provides automatic transaction rollback for tests to ensure clean state
 //! between test runs, even when tests fail midway through execution.
 
-use reinhardt_db::orm::connection::DatabaseConnection;
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection,
+	orm::{DatabaseConnection, DatabaseConnectionLease},
+};
 use rstest::*;
-use std::sync::Arc;
 use testcontainers::{
 	GenericImage, ImageExt,
 	core::{ContainerPort, WaitFor},
@@ -30,18 +32,18 @@ use testcontainers::{
 /// ```rust,no_run,ignore
 /// # use rstest::*;
 /// # use reinhardt_test_support::db_transaction::db_transaction_fixture;
-/// # use reinhardt_db::orm::connection::DatabaseConnection;
+/// # use reinhardt_db::orm::{DatabaseConnection, DatabaseConnectionLease};
 /// # use testcontainers::GenericImage;
-/// # use std::sync::Arc;
 /// #[rstest]
 /// #[tokio::test]
 /// async fn test_with_transaction(
 ///     #[future] db_transaction_fixture: (
 ///         testcontainers::ContainerAsync<GenericImage>,
-///         Arc<DatabaseConnection>,
+///         DatabaseConnectionLease,
+///         DatabaseConnection,
 ///     ),
 /// ) {
-///     let (_container, conn) = db_transaction_fixture.await;
+///     let (_container, _lease, conn) = db_transaction_fixture.await;
 ///
 ///     // Perform database operations
 ///     conn.execute("INSERT INTO users (name) VALUES ('test')", vec![]).await.unwrap();
@@ -53,7 +55,8 @@ pub struct DbTransactionFixture {
 	/// PostgreSQL container - automatically cleaned up on drop
 	pub container: testcontainers::ContainerAsync<GenericImage>,
 	/// Database connection
-	pub connection: Arc<DatabaseConnection>,
+	pub lease: DatabaseConnectionLease,
+	pub connection: DatabaseConnection,
 }
 
 impl DbTransactionFixture {
@@ -81,19 +84,23 @@ impl DbTransactionFixture {
 		let database_url = format!("postgres://postgres:test@localhost:{}/test_db", port);
 
 		// Create connection
-		let conn = DatabaseConnection::connect(&database_url)
+		let owner = BackendsConnection::connect(&database_url)
 			.await
 			.expect("Failed to connect to database");
+		let lease = DatabaseConnectionLease::register(owner)
+			.expect("Failed to register database connection");
+		let connection = lease.handle();
 
 		Self {
 			container: postgres,
-			connection: Arc::new(conn),
+			lease,
+			connection,
 		}
 	}
 
 	/// Get database connection
-	pub fn connection(&self) -> Arc<DatabaseConnection> {
-		Arc::clone(&self.connection)
+	pub fn connection(&self) -> DatabaseConnection {
+		self.connection
 	}
 }
 
@@ -114,16 +121,18 @@ impl DbTransactionFixture {
 ///
 /// ```rust,no_run
 /// use rstest::*;
+/// use reinhardt_db::orm::{DatabaseConnection, DatabaseConnectionLease};
 ///
 /// #[rstest]
 /// #[tokio::test]
 /// async fn test_user_creation(
 ///     #[future] db_transaction_fixture: (
 ///         testcontainers::ContainerAsync<GenericImage>,
-///         Arc<DatabaseConnection>,
+///         DatabaseConnectionLease,
+///         DatabaseConnection,
 ///     ),
 /// ) {
-///     let (_container, conn) = db_transaction_fixture.await;
+///     let (_container, _lease, conn) = db_transaction_fixture.await;
 ///
 ///     // Create test data
 ///     conn.execute(
@@ -145,10 +154,11 @@ impl DbTransactionFixture {
 #[fixture]
 pub async fn db_transaction_fixture() -> (
 	testcontainers::ContainerAsync<GenericImage>,
-	Arc<DatabaseConnection>,
+	DatabaseConnectionLease,
+	DatabaseConnection,
 ) {
 	let fixture = DbTransactionFixture::new().await;
-	(fixture.container, fixture.connection)
+	(fixture.container, fixture.lease, fixture.connection)
 }
 
 /// Shared database fixture for tests that need multiple connections
@@ -160,6 +170,10 @@ pub async fn db_transaction_fixture() -> (
 ///
 /// ```rust,no_run
 /// use rstest::*;
+/// use reinhardt_db::{
+///     backends::DatabaseConnection as BackendsConnection,
+///     orm::DatabaseConnectionLease,
+/// };
 ///
 /// #[rstest]
 /// #[tokio::test]
@@ -172,8 +186,12 @@ pub async fn db_transaction_fixture() -> (
 ///     let (_container, db_url) = shared_db_fixture.await;
 ///
 ///     // Create multiple connections
-///     let conn1 = DatabaseConnection::connect(&db_url).await.unwrap();
-///     let conn2 = DatabaseConnection::connect(&db_url).await.unwrap();
+///     let owner1 = BackendsConnection::connect(&db_url).await.unwrap();
+///     let owner2 = BackendsConnection::connect(&db_url).await.unwrap();
+///     let lease1 = DatabaseConnectionLease::register(owner1).unwrap();
+///     let lease2 = DatabaseConnectionLease::register(owner2).unwrap();
+///     let conn1 = lease1.handle();
+///     let conn2 = lease2.handle();
 ///
 ///     // Both connections share same database
 ///     // All data cleaned up when container drops
@@ -213,10 +231,11 @@ mod tests {
 	async fn test_fixture_provides_connection(
 		#[future] db_transaction_fixture: (
 			testcontainers::ContainerAsync<GenericImage>,
-			Arc<DatabaseConnection>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
 		),
 	) {
-		let (_container, conn) = db_transaction_fixture.await;
+		let (_container, _lease, conn) = db_transaction_fixture.await;
 
 		// Verify connection works
 		let result = conn.execute("SELECT 1", vec![]).await;
@@ -232,10 +251,11 @@ mod tests {
 	async fn test_cleanup_part1_create_data(
 		#[future] db_transaction_fixture: (
 			testcontainers::ContainerAsync<GenericImage>,
-			Arc<DatabaseConnection>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
 		),
 	) {
-		let (_container, conn) = db_transaction_fixture.await;
+		let (_container, _lease, conn) = db_transaction_fixture.await;
 
 		// Create table and insert data
 		conn.execute(
@@ -265,10 +285,11 @@ mod tests {
 	async fn test_cleanup_part2_verify_clean(
 		#[future] db_transaction_fixture: (
 			testcontainers::ContainerAsync<GenericImage>,
-			Arc<DatabaseConnection>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
 		),
 	) {
-		let (_container, conn) = db_transaction_fixture.await;
+		let (_container, _lease, conn) = db_transaction_fixture.await;
 
 		// Verify table doesn't exist (cleanup worked)
 		let result = conn.execute("SELECT * FROM test_cleanup", vec![]).await;
@@ -287,8 +308,12 @@ mod tests {
 		let (_container, db_url) = shared_db_fixture.await;
 
 		// Create two connections
-		let conn1 = DatabaseConnection::connect(&db_url).await.unwrap();
-		let conn2 = DatabaseConnection::connect(&db_url).await.unwrap();
+		let owner1 = BackendsConnection::connect(&db_url).await.unwrap();
+		let lease1 = DatabaseConnectionLease::register(owner1).unwrap();
+		let conn1 = lease1.handle();
+		let owner2 = BackendsConnection::connect(&db_url).await.unwrap();
+		let lease2 = DatabaseConnectionLease::register(owner2).unwrap();
+		let conn2 = lease2.handle();
 
 		// Create table with first connection
 		conn1
@@ -311,10 +336,11 @@ mod tests {
 	async fn test_cleanup_on_panic(
 		#[future] db_transaction_fixture: (
 			testcontainers::ContainerAsync<GenericImage>,
-			Arc<DatabaseConnection>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
 		),
 	) {
-		let (_container, conn) = db_transaction_fixture.await;
+		let (_container, _lease, conn) = db_transaction_fixture.await;
 
 		// Create data
 		conn.execute("CREATE TABLE panic_test (id SERIAL PRIMARY KEY)", vec![])

--- a/tests/integration/src/validator_test_common.rs
+++ b/tests/integration/src/validator_test_common.rs
@@ -5,15 +5,19 @@
 
 use reinhardt_core::{macros::model, validators::ValidationResult};
 use reinhardt_db::{
-	DatabaseConnection,
-	orm::{Filter, FilterOperator, FilterValue, Model},
+	backends::DatabaseConnection as BackendsConnection,
+	orm::{
+		DatabaseConnection, DatabaseConnectionLease, Filter, FilterOperator, FilterValue, Model,
+	},
 };
 use std::sync::Arc;
 use testcontainers::{GenericImage, ImageExt, core::WaitFor, runners::AsyncRunner};
 
 /// Test database setup and management with TestContainers
 pub struct TestDatabase {
-	pub connection: Arc<DatabaseConnection>,
+	pub connection: DatabaseConnection,
+	pub pool: Arc<sqlx::PgPool>,
+	pub _lease: DatabaseConnectionLease,
 	/// Container is managed by the TestDatabase and should not be directly accessed.
 	/// This field is public to allow fixture construction in integration tests.
 	pub _container: Option<testcontainers::ContainerAsync<GenericImage>>,
@@ -39,7 +43,7 @@ impl TestDatabase {
 		let database_url = format!("postgres://postgres@127.0.0.1:{}/postgres", port);
 
 		// Create DatabaseConnection
-		let connection = DatabaseConnection::connect(&database_url)
+		let owner = BackendsConnection::connect_postgres(&database_url)
 			.await
 			.map_err(|e| {
 				format!(
@@ -48,8 +52,14 @@ impl TestDatabase {
 				)
 			})?;
 
+		let pool = Arc::new(sqlx::PgPool::connect(&database_url).await?);
+		let lease = DatabaseConnectionLease::register(owner)?;
+		let connection = lease.handle();
+
 		Ok(Self {
-			connection: Arc::new(connection),
+			connection,
+			pool,
+			_lease: lease,
 			_container: Some(container),
 		})
 	}

--- a/tests/integration/tests/admin/admin_database_tests.rs
+++ b/tests/integration/tests/admin/admin_database_tests.rs
@@ -14,12 +14,12 @@ use reinhardt_db::backends::{
 use reinhardt_db::orm::annotation::Expression;
 use reinhardt_db::orm::expressions::{F, OuterRef};
 use reinhardt_db::orm::{
-	DatabaseBackend, DatabaseConnection, Filter, FilterCondition, FilterOperator, FilterValue,
+	DatabaseBackend, DatabaseConnectionLease, Filter, FilterCondition, FilterOperator, FilterValue,
 };
 use reinhardt_query::{
 	Alias, ColumnRef, Condition, PostgresQueryBuilder, Query, QueryStatementBuilder, Value,
 };
-use reinhardt_test::fixtures::mock::MockDatabaseBackend;
+use reinhardt_test::fixtures::mock::{MockConnection, MockDatabaseBackend};
 use reinhardt_test::fixtures::mock_connection;
 use rstest::*;
 use std::collections::HashMap;
@@ -34,19 +34,36 @@ struct User {
 
 reinhardt_test::impl_test_model!(User, i64, "users");
 
-fn admin_database_from_mock(mock: MockDatabaseBackend) -> AdminDatabase {
+struct TestAdminDatabase {
+	database: AdminDatabase,
+	_connection_lease: DatabaseConnectionLease,
+}
+
+impl std::ops::Deref for TestAdminDatabase {
+	type Target = AdminDatabase;
+
+	fn deref(&self) -> &Self::Target {
+		&self.database
+	}
+}
+
+fn admin_database_from_mock(mock: MockDatabaseBackend) -> TestAdminDatabase {
 	let backends_conn = BackendsConnection::new(Arc::new(mock));
-	let conn = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	AdminDatabase::new(conn)
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register mock database connection");
+	TestAdminDatabase {
+		database: AdminDatabase::new(connection_lease.handle()),
+		_connection_lease: connection_lease,
+	}
 }
 
 // ==================== AdminDatabase CRUD tests ====================
 
 #[rstest]
 #[tokio::test]
-async fn test_admin_database_new(mock_connection: DatabaseConnection) {
+async fn test_admin_database_new(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 
 	// Act & Assert
 	assert_eq!(db.connection().backend(), DatabaseBackend::Postgres);
@@ -54,9 +71,9 @@ async fn test_admin_database_new(mock_connection: DatabaseConnection) {
 
 #[rstest]
 #[tokio::test]
-async fn test_bulk_delete_empty(mock_connection: DatabaseConnection) {
+async fn test_bulk_delete_empty(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 
 	// Act
 	let result = db.bulk_delete::<User>("users", "id", vec![]).await;
@@ -68,9 +85,9 @@ async fn test_bulk_delete_empty(mock_connection: DatabaseConnection) {
 
 #[rstest]
 #[tokio::test]
-async fn test_list_with_filters(mock_connection: DatabaseConnection) {
+async fn test_list_with_filters(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let filters = vec![Filter::new(
 		"is_active".to_string(),
 		FilterOperator::Eq,
@@ -86,9 +103,9 @@ async fn test_list_with_filters(mock_connection: DatabaseConnection) {
 
 #[rstest]
 #[tokio::test]
-async fn test_get_by_id(mock_connection: DatabaseConnection) {
+async fn test_get_by_id(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 
 	// Act
 	let result = db.get::<User>("users", "id", "1").await;
@@ -99,11 +116,11 @@ async fn test_get_by_id(mock_connection: DatabaseConnection) {
 
 #[rstest]
 #[tokio::test]
-async fn test_create(mock_connection: DatabaseConnection) {
+async fn test_create(mock_connection: MockConnection) {
 	// Arrange
 	// Default mock returns {"count": 0} without "id" field,
 	// so create() returns Err (missing pk field). Fixes #3029
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), serde_json::json!("Alice"));
 	data.insert("email".to_string(), serde_json::json!("alice@example.com"));
@@ -123,9 +140,9 @@ async fn test_create(mock_connection: DatabaseConnection) {
 
 #[rstest]
 #[tokio::test]
-async fn test_update(mock_connection: DatabaseConnection) {
+async fn test_update(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), serde_json::json!("Alice Updated"));
 
@@ -138,9 +155,9 @@ async fn test_update(mock_connection: DatabaseConnection) {
 
 #[rstest]
 #[tokio::test]
-async fn test_delete(mock_connection: DatabaseConnection) {
+async fn test_delete(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 
 	// Act
 	let result = db.delete::<User>("users", "id", "1").await;
@@ -151,9 +168,9 @@ async fn test_delete(mock_connection: DatabaseConnection) {
 
 #[rstest]
 #[tokio::test]
-async fn test_count(mock_connection: DatabaseConnection) {
+async fn test_count(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let filters = vec![];
 
 	// Act
@@ -165,9 +182,9 @@ async fn test_count(mock_connection: DatabaseConnection) {
 
 #[rstest]
 #[tokio::test]
-async fn test_bulk_delete_multiple_ids(mock_connection: DatabaseConnection) {
+async fn test_bulk_delete_multiple_ids(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let ids = vec!["1".to_string(), "2".to_string(), "3".to_string()];
 
 	// Act
@@ -353,9 +370,9 @@ fn test_build_composite_empty_and() {
 
 #[rstest]
 #[tokio::test]
-async fn test_list_with_condition_or_search(mock_connection: DatabaseConnection) {
+async fn test_list_with_condition_or_search(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let filter1 = Filter::new(
 		"name".to_string(),
 		FilterOperator::Contains,
@@ -382,9 +399,9 @@ async fn test_list_with_condition_or_search(mock_connection: DatabaseConnection)
 
 #[rstest]
 #[tokio::test]
-async fn test_list_with_condition_and_additional(mock_connection: DatabaseConnection) {
+async fn test_list_with_condition_and_additional(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let filter1 = Filter::new(
 		"name".to_string(),
 		FilterOperator::Contains,
@@ -416,9 +433,9 @@ async fn test_list_with_condition_and_additional(mock_connection: DatabaseConnec
 
 #[rstest]
 #[tokio::test]
-async fn test_count_with_condition_or_search(mock_connection: DatabaseConnection) {
+async fn test_count_with_condition_or_search(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let filter1 = Filter::new(
 		"name".to_string(),
 		FilterOperator::Contains,
@@ -445,9 +462,9 @@ async fn test_count_with_condition_or_search(mock_connection: DatabaseConnection
 
 #[rstest]
 #[tokio::test]
-async fn test_list_with_condition_none(mock_connection: DatabaseConnection) {
+async fn test_list_with_condition_none(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 
 	// Act
 	let result = db
@@ -460,9 +477,9 @@ async fn test_list_with_condition_none(mock_connection: DatabaseConnection) {
 
 #[rstest]
 #[tokio::test]
-async fn test_list_with_condition_empty_additional(mock_connection: DatabaseConnection) {
+async fn test_list_with_condition_empty_additional(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let filter = Filter::new(
 		"name".to_string(),
 		FilterOperator::Contains,
@@ -481,9 +498,9 @@ async fn test_list_with_condition_empty_additional(mock_connection: DatabaseConn
 
 #[rstest]
 #[tokio::test]
-async fn test_count_with_condition_none(mock_connection: DatabaseConnection) {
+async fn test_count_with_condition_none(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 
 	// Act
 	let result = db.count_with_condition::<User>("users", None, vec![]).await;
@@ -494,9 +511,9 @@ async fn test_count_with_condition_none(mock_connection: DatabaseConnection) {
 
 #[rstest]
 #[tokio::test]
-async fn test_count_with_condition_combined(mock_connection: DatabaseConnection) {
+async fn test_count_with_condition_combined(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let filter1 = Filter::new(
 		"name".to_string(),
 		FilterOperator::Contains,
@@ -888,12 +905,10 @@ fn test_filter_value_to_sea_value_expression_fallback() {
 
 #[rstest]
 #[tokio::test]
-async fn test_create_returns_error_when_response_has_no_id_field(
-	mock_connection: DatabaseConnection,
-) {
+async fn test_create_returns_error_when_response_has_no_id_field(mock_connection: MockConnection) {
 	// Arrange
 	// Default mock_connection.fetch_one returns Row with {"count": Int(0)}, no "id" field
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), serde_json::json!("Alice"));
 
@@ -947,8 +962,9 @@ async fn test_create_returns_id_when_response_has_id_field() {
 	});
 
 	let backends_conn = BackendsConnection::new(Arc::new(mock));
-	let conn = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db = AdminDatabase::new(conn);
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register mock database connection");
+	let db = AdminDatabase::new(connection_lease.handle());
 
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), serde_json::json!("Alice"));
@@ -1003,8 +1019,9 @@ async fn test_create_returns_error_when_pk_field_missing() {
 	});
 
 	let backends_conn = BackendsConnection::new(Arc::new(mock));
-	let conn = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db = AdminDatabase::new(conn);
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register mock database connection");
+	let db = AdminDatabase::new(connection_lease.handle());
 
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), serde_json::json!("Bob"));
@@ -1058,8 +1075,9 @@ async fn test_create_returns_one_for_string_pk() {
 	});
 
 	let backends_conn = BackendsConnection::new(Arc::new(mock));
-	let conn = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db = AdminDatabase::new(conn);
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register mock database connection");
+	let db = AdminDatabase::new(connection_lease.handle());
 
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), serde_json::json!("Bob"));
@@ -1080,10 +1098,10 @@ async fn test_create_returns_one_for_string_pk() {
 
 #[rstest]
 #[tokio::test]
-async fn test_update_returns_affected_count(mock_connection: DatabaseConnection) {
+async fn test_update_returns_affected_count(mock_connection: MockConnection) {
 	// Arrange
 	// Default mock returns rows_affected: 0
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let mut data = HashMap::new();
 	data.insert("name".to_string(), serde_json::json!("Updated Name"));
 
@@ -1101,10 +1119,10 @@ async fn test_update_returns_affected_count(mock_connection: DatabaseConnection)
 
 #[rstest]
 #[tokio::test]
-async fn test_delete_returns_affected_count(mock_connection: DatabaseConnection) {
+async fn test_delete_returns_affected_count(mock_connection: MockConnection) {
 	// Arrange
 	// Default mock returns rows_affected: 0
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 
 	// Act
 	let result = db.delete::<User>("users", "id", "999").await;
@@ -1120,9 +1138,9 @@ async fn test_delete_returns_affected_count(mock_connection: DatabaseConnection)
 
 #[rstest]
 #[tokio::test]
-async fn test_bulk_delete_with_many_ids(mock_connection: DatabaseConnection) {
+async fn test_bulk_delete_with_many_ids(mock_connection: MockConnection) {
 	// Arrange
-	let db = AdminDatabase::new(mock_connection);
+	let db = AdminDatabase::new(*mock_connection);
 	let ids: Vec<String> = (1..=10).map(|i| i.to_string()).collect();
 
 	// Act

--- a/tests/integration/tests/admin/server_fn_combination_tests.rs
+++ b/tests/integration/tests/admin/server_fn_combination_tests.rs
@@ -49,7 +49,7 @@ async fn test_list_with_search_and_filter_combined(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange: Create records with various names and statuses
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 
 	create_test_record(&site, &db, "AlphaActive", "active").await;
 	create_test_record(&site, &db, "AlphaInactive", "inactive").await;
@@ -94,7 +94,7 @@ async fn test_list_with_search_and_pagination(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange: Create 10+ records with searchable names
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 
 	for i in 1..=12 {
 		create_test_record(&site, &db, &format!("SearchItem_{:02}", i), "active").await;
@@ -142,7 +142,7 @@ async fn test_list_with_sort_ascending_and_descending(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 
 	create_test_record(&site, &db, "Charlie", "active").await;
 	create_test_record(&site, &db, "Alice", "active").await;
@@ -212,7 +212,7 @@ async fn test_create_record_with_all_field_types(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let user = make_auth_user();
 	let request = make_staff_request();
 
@@ -281,7 +281,7 @@ async fn test_export_all_formats_produce_valid_output(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange: Create a record so export has data
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let user = make_auth_user();
 	let request = make_staff_request();
 
@@ -350,7 +350,7 @@ async fn test_list_with_filter_and_sort_combined(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 
 	create_test_record(&site, &db, "Charlie", "active").await;
 	create_test_record(&site, &db, "Alice", "inactive").await;
@@ -399,7 +399,7 @@ async fn test_concurrent_record_creation(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 
 	// Act: Create 10 records concurrently
 	let mut handles = Vec::new();

--- a/tests/integration/tests/admin/server_fn_create_tests.rs
+++ b/tests/integration/tests/admin/server_fn_create_tests.rs
@@ -22,7 +22,7 @@ async fn test_create_record_happy_path(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -60,7 +60,7 @@ async fn test_create_record_returns_valid_response(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -106,7 +106,7 @@ async fn test_create_record_persists_to_database(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -153,7 +153,7 @@ async fn test_create_record_multiple_fields(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -192,7 +192,7 @@ async fn test_create_record_special_characters(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -236,7 +236,7 @@ async fn test_create_record_model_not_registered(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 

--- a/tests/integration/tests/admin/server_fn_delete_tests.rs
+++ b/tests/integration/tests/admin/server_fn_delete_tests.rs
@@ -23,7 +23,7 @@ async fn test_delete_record_happy_path(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -61,7 +61,7 @@ async fn test_delete_record_actually_removes(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -106,7 +106,7 @@ async fn test_delete_record_not_found(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -142,7 +142,7 @@ async fn test_delete_record_model_not_registered(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -174,7 +174,7 @@ async fn test_bulk_delete_happy_path(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -220,7 +220,7 @@ async fn test_bulk_delete_single_id(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -262,7 +262,7 @@ async fn test_bulk_delete_exceeds_limit(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -307,7 +307,7 @@ async fn test_bulk_delete_empty_ids(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -348,7 +348,7 @@ async fn test_bulk_delete_partial_match(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -393,7 +393,7 @@ async fn test_bulk_delete_model_not_registered(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 

--- a/tests/integration/tests/admin/server_fn_detail_tests.rs
+++ b/tests/integration/tests/admin/server_fn_detail_tests.rs
@@ -20,7 +20,7 @@ async fn test_get_detail_happy_path(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -59,7 +59,7 @@ async fn test_get_detail_returns_all_fields(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -103,7 +103,7 @@ async fn test_get_detail_with_various_data_types(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -147,7 +147,7 @@ async fn test_get_detail_not_found(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -179,7 +179,7 @@ async fn test_get_detail_model_not_registered(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -210,7 +210,7 @@ async fn test_get_detail_uuid_pk(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
 	// Arrange
-	let (site, db, pool) = uuid_pk_context.await;
+	let (site, db, pool, _connection_lease) = uuid_pk_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 

--- a/tests/integration/tests/admin/server_fn_export_tests.rs
+++ b/tests/integration/tests/admin/server_fn_export_tests.rs
@@ -21,7 +21,7 @@ async fn test_export_json_happy_path(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -62,7 +62,7 @@ async fn test_export_csv_succeeds(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -104,7 +104,7 @@ async fn test_export_tsv_succeeds(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -145,7 +145,7 @@ async fn test_export_truncation_flag(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -178,7 +178,7 @@ async fn test_export_empty_table(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -211,7 +211,7 @@ async fn test_export_json_content_type(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -240,7 +240,7 @@ async fn test_export_model_not_registered(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 

--- a/tests/integration/tests/admin/server_fn_fields_tests.rs
+++ b/tests/integration/tests/admin/server_fn_fields_tests.rs
@@ -21,7 +21,7 @@ async fn test_get_fields_create_form(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -61,7 +61,7 @@ async fn test_get_fields_edit_form(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -110,7 +110,7 @@ async fn test_get_fields_returns_correct_field_names(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -143,7 +143,7 @@ async fn test_get_fields_field_labels_humanized(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -176,7 +176,7 @@ async fn test_get_fields_field_type_inference(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -209,7 +209,7 @@ async fn test_get_fields_edit_nonexistent_id(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -245,7 +245,7 @@ async fn test_get_fields_model_not_registered(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 

--- a/tests/integration/tests/admin/server_fn_helpers.rs
+++ b/tests/integration/tests/admin/server_fn_helpers.rs
@@ -10,7 +10,7 @@ use reinhardt_admin::server::{AdminAuthenticatedUser, AdminDefaultUser};
 use reinhardt_core::reactive::ReactiveScope;
 use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection;
 use reinhardt_db::backends::dialect::PostgresBackend;
-use reinhardt_db::orm::connection::{DatabaseBackend, DatabaseConnection};
+use reinhardt_db::orm::connection::{DatabaseConnection, DatabaseConnectionLease};
 use reinhardt_di::{InjectionContext, KeyedDepends, SingletonScope};
 use reinhardt_http::AuthState;
 use reinhardt_pages::server_fn::ServerFnRequest;
@@ -26,8 +26,17 @@ use uuid::Uuid;
 
 pub(super) type AdminSiteDepends = KeyedDepends<AdminSiteKey, AdminSite>;
 pub(super) type AdminDatabaseDepends = KeyedDepends<AdminDatabaseKey, AdminDatabase>;
-pub(super) type ServerFnContext = (AdminSiteDepends, AdminDatabaseDepends);
-pub(super) type UuidPkContext = (AdminSiteDepends, AdminDatabaseDepends, sqlx::PgPool);
+pub(super) type ServerFnContext = (
+	AdminSiteDepends,
+	AdminDatabaseDepends,
+	DatabaseConnectionLease,
+);
+pub(super) type UuidPkContext = (
+	AdminSiteDepends,
+	AdminDatabaseDepends,
+	sqlx::PgPool,
+	DatabaseConnectionLease,
+);
 
 /// Fixed CSRF token value for testing.
 /// Both the request body and the cookie must use this same value.
@@ -426,8 +435,9 @@ pub async fn server_fn_context(
 	// Create AdminDatabase from the SAME pool
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db = AdminDatabase::new(connection);
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register database connection");
+	let db = AdminDatabase::new(connection_lease.handle());
 
 	// Create AdminSite and register with all permissions
 	let site = AdminSite::new("Test Admin Site");
@@ -435,7 +445,11 @@ pub async fn server_fn_context(
 	site.register("TestModel", admin)
 		.expect("Failed to register TestModel");
 
-	(admin_site_dep(site), admin_database_dep(db))
+	(
+		admin_site_dep(site),
+		admin_database_dep(db),
+		connection_lease,
+	)
 }
 
 /// Composite fixture providing AdminSite + AdminDatabase with a deny-all ModelAdmin.
@@ -445,7 +459,7 @@ pub async fn server_fn_context(
 #[fixture]
 pub async fn deny_all_context(
 	#[future] shared_db_pool: (sqlx::PgPool, String),
-) -> (AdminSite, AdminDatabase) {
+) -> (AdminSite, AdminDatabase, DatabaseConnectionLease) {
 	let (pool, _) = shared_db_pool.await;
 
 	pool.execute(
@@ -466,15 +480,16 @@ pub async fn deny_all_context(
 
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db = AdminDatabase::new(connection);
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register database connection");
+	let db = AdminDatabase::new(connection_lease.handle());
 
 	let site = AdminSite::new("Deny All Test Admin");
 	let admin = DenyAllModelAdmin::test_model("test_models");
 	site.register("TestModel", admin)
 		.expect("Failed to register TestModel");
 
-	(site, db)
+	(site, db, connection_lease)
 }
 
 /// Composite fixture providing AdminSite + AdminDatabase with a view-only ModelAdmin.
@@ -484,7 +499,7 @@ pub async fn deny_all_context(
 #[fixture]
 pub async fn view_only_context(
 	#[future] shared_db_pool: (sqlx::PgPool, String),
-) -> (AdminSite, AdminDatabase) {
+) -> (AdminSite, AdminDatabase, DatabaseConnectionLease) {
 	let (pool, _) = shared_db_pool.await;
 
 	pool.execute(
@@ -512,15 +527,16 @@ pub async fn view_only_context(
 
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db = AdminDatabase::new(connection);
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register database connection");
+	let db = AdminDatabase::new(connection_lease.handle());
 
 	let site = AdminSite::new("View Only Test Admin");
 	let admin = ViewOnlyModelAdmin::test_model("test_models");
 	site.register("TestModel", admin)
 		.expect("Failed to register TestModel");
 
-	(site, db)
+	(site, db, connection_lease)
 }
 
 // ==================== E2E Test Infrastructure ====================
@@ -681,11 +697,14 @@ pub async fn e2e_router_context(
 	// Build DatabaseConnection (shared between AdminDatabase and CurrentUser injection)
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db_conn = Arc::new(connection);
+	let connection_lease = Arc::new(
+		DatabaseConnectionLease::register(backends_conn)
+			.expect("Failed to register database connection"),
+	);
+	let db_conn = Arc::new(connection_lease.handle());
 
 	// Build AdminDatabase for test data setup
-	let admin_db = AdminDatabase::new((*db_conn).clone());
+	let admin_db = AdminDatabase::new(*db_conn);
 
 	// Build AdminSite and register test model
 	let site = AdminSite::new("E2E Test Admin");
@@ -700,6 +719,7 @@ pub async fn e2e_router_context(
 	// Pre-seed singleton scope with DatabaseConnection so get_singleton() finds it.
 	let singleton = Arc::new(SingletonScope::new());
 	singleton.set_arc(db_conn);
+	singleton.set_arc(connection_lease);
 	let di_ctx = Arc::new(InjectionContext::builder(singleton).build());
 
 	let router = ReactiveScope::run(|| {
@@ -957,15 +977,21 @@ pub async fn uuid_pk_context(#[future] shared_db_pool: (sqlx::PgPool, String)) -
 	let pool_clone = pool.clone();
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db = AdminDatabase::new(connection);
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register database connection");
+	let db = AdminDatabase::new(connection_lease.handle());
 
 	let site = AdminSite::new("UUID Test Admin Site");
 	let admin = AllPermissionsModelAdmin::uuid_pk_model("uuid_test_models");
 	site.register("UuidModel", admin)
 		.expect("Failed to register UuidModel");
 
-	(admin_site_dep(site), admin_database_dep(db), pool_clone)
+	(
+		admin_site_dep(site),
+		admin_database_dep(db),
+		pool_clone,
+		connection_lease,
+	)
 }
 
 // ==================== Permission Denial Test Infrastructure ====================
@@ -1063,15 +1089,20 @@ pub async fn server_fn_context_deny_all(
 
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db = AdminDatabase::new(connection);
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register database connection");
+	let db = AdminDatabase::new(connection_lease.handle());
 
 	let site = AdminSite::new("Deny All Test Site");
 	let admin = DenyAllPermissionsModelAdmin::test_model("test_models");
 	site.register("TestModel", admin)
 		.expect("Failed to register TestModel");
 
-	(admin_site_dep(site), admin_database_dep(db))
+	(
+		admin_site_dep(site),
+		admin_database_dep(db),
+		connection_lease,
+	)
 }
 
 /// Composite fixture providing AdminSite + AdminDatabase with view-only permissions.
@@ -1098,13 +1129,18 @@ pub async fn server_fn_context_view_only(
 
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db = AdminDatabase::new(connection);
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register database connection");
+	let db = AdminDatabase::new(connection_lease.handle());
 
 	let site = AdminSite::new("View Only Test Site");
 	let admin = ViewOnlyModelAdmin::test_model("test_models");
 	site.register("TestModel", admin)
 		.expect("Failed to register TestModel");
 
-	(admin_site_dep(site), admin_database_dep(db))
+	(
+		admin_site_dep(site),
+		admin_database_dep(db),
+		connection_lease,
+	)
 }

--- a/tests/integration/tests/admin/server_fn_import_tests.rs
+++ b/tests/integration/tests/admin/server_fn_import_tests.rs
@@ -18,7 +18,7 @@ async fn test_import_json_happy_path(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -55,7 +55,7 @@ async fn test_import_csv_happy_path(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -86,7 +86,7 @@ async fn test_import_tsv_happy_path(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -119,7 +119,7 @@ async fn test_import_file_size_limit(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -158,7 +158,7 @@ async fn test_import_record_count_limit(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -207,7 +207,7 @@ async fn test_import_invalid_json(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -236,7 +236,7 @@ async fn test_import_invalid_csv(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -275,7 +275,7 @@ async fn test_import_empty_data(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -307,7 +307,7 @@ async fn test_import_model_not_registered(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 

--- a/tests/integration/tests/admin/server_fn_list_tests.rs
+++ b/tests/integration/tests/admin/server_fn_list_tests.rs
@@ -22,7 +22,7 @@ async fn test_get_list_happy_path(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	for i in 0..3 {
@@ -56,7 +56,7 @@ async fn test_get_list_with_search(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	let mut data = HashMap::new();
@@ -89,7 +89,7 @@ async fn test_get_list_with_filter(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	let mut data = HashMap::new();
@@ -125,7 +125,7 @@ async fn test_get_list_sort_descending(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	let params = ListQueryParams {
@@ -153,7 +153,7 @@ async fn test_get_list_sort_by_invalid_field(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	let params = ListQueryParams {
@@ -184,7 +184,7 @@ async fn test_get_list_unknown_filter_field(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	let mut filters = HashMap::new();
@@ -220,7 +220,7 @@ async fn test_get_list_pagination_defaults(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	// Act
@@ -249,7 +249,7 @@ async fn test_get_list_page_size_capped(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	let params = ListQueryParams {
@@ -276,7 +276,7 @@ async fn test_get_list_page_zero_treated_as_one(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	let params = ListQueryParams {
@@ -301,7 +301,7 @@ async fn test_get_list_empty_table(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	// Act (no records inserted)
@@ -328,7 +328,7 @@ async fn test_get_list_columns_match_list_display(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	// Act
@@ -364,7 +364,7 @@ async fn test_get_list_filters_match_list_filter(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	// Act
@@ -399,7 +399,7 @@ async fn test_get_list_model_not_registered(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	// Act

--- a/tests/integration/tests/admin/server_fn_login_tests.rs
+++ b/tests/integration/tests/admin/server_fn_login_tests.rs
@@ -11,7 +11,7 @@ use reinhardt_auth::BaseUser;
 use reinhardt_core::reactive::ReactiveScope;
 use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection;
 use reinhardt_db::backends::dialect::PostgresBackend;
-use reinhardt_db::orm::connection::{DatabaseBackend, DatabaseConnection};
+use reinhardt_db::orm::connection::DatabaseConnectionLease;
 use reinhardt_di::{InjectionContext, SingletonScope};
 use reinhardt_http::Handler;
 use reinhardt_query::prelude::{
@@ -235,8 +235,11 @@ async fn build_login_router(pool: sqlx::PgPool, with_jwt_secret: bool) -> Server
 	// Build DatabaseConnection
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db_conn = Arc::new(connection);
+	let connection_lease = Arc::new(
+		DatabaseConnectionLease::register(backends_conn)
+			.expect("Failed to register database connection"),
+	);
+	let db_conn = Arc::new(connection_lease.handle());
 
 	// Build AdminSite
 	let mut site = AdminSite::new("Login Test Admin");
@@ -251,6 +254,7 @@ async fn build_login_router(pool: sqlx::PgPool, with_jwt_secret: bool) -> Server
 	// Build complete router with DI
 	let singleton = Arc::new(SingletonScope::new());
 	singleton.set_arc(db_conn);
+	singleton.set_arc(connection_lease);
 	let di_ctx = Arc::new(InjectionContext::builder(singleton).build());
 
 	ReactiveScope::run(|| {
@@ -458,8 +462,11 @@ async fn test_admin_login_authenticator_returns_error(
 	// Build DatabaseConnection
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db_conn = Arc::new(connection);
+	let connection_lease = Arc::new(
+		DatabaseConnectionLease::register(backends_conn)
+			.expect("Failed to register database connection"),
+	);
+	let db_conn = Arc::new(connection_lease.handle());
 
 	let mut site = AdminSite::new("Error Test Admin");
 	site.set_jwt_secret(TEST_JWT_SECRET);
@@ -469,6 +476,7 @@ async fn test_admin_login_authenticator_returns_error(
 
 	let singleton = Arc::new(SingletonScope::new());
 	singleton.set_arc(db_conn);
+	singleton.set_arc(connection_lease);
 	let di_ctx = Arc::new(InjectionContext::builder(singleton).build());
 
 	let router = ReactiveScope::run(|| {

--- a/tests/integration/tests/admin/server_fn_middleware_helpers.rs
+++ b/tests/integration/tests/admin/server_fn_middleware_helpers.rs
@@ -11,7 +11,7 @@ use reinhardt_auth::JwtAuth;
 use reinhardt_core::reactive::ReactiveScope;
 use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection;
 use reinhardt_db::backends::dialect::PostgresBackend;
-use reinhardt_db::orm::connection::{DatabaseBackend, DatabaseConnection};
+use reinhardt_db::orm::connection::DatabaseConnectionLease;
 use reinhardt_di::{InjectionContext, SingletonScope};
 use reinhardt_middleware::LoggingMiddleware;
 use reinhardt_query::prelude::{Alias, PostgresQueryBuilder, Query, QueryStatementBuilder};
@@ -282,10 +282,13 @@ pub async fn middleware_e2e_context(
 
 	let backend = Arc::new(PostgresBackend::new(pool));
 	let backends_conn = BackendsConnection::new(backend);
-	let connection = DatabaseConnection::new(DatabaseBackend::Postgres, backends_conn);
-	let db_conn = Arc::new(connection);
+	let connection_lease = Arc::new(
+		DatabaseConnectionLease::register(backends_conn)
+			.expect("Failed to register database connection"),
+	);
+	let db_conn = Arc::new(connection_lease.handle());
 
-	let admin_db = AdminDatabase::new((*db_conn).clone());
+	let admin_db = AdminDatabase::new(*db_conn);
 
 	let mut site = AdminSite::new("Middleware E2E Test Admin");
 	site.set_jwt_secret(JWT_SECRET);
@@ -297,6 +300,7 @@ pub async fn middleware_e2e_context(
 
 	let singleton = Arc::new(SingletonScope::new());
 	singleton.set_arc(db_conn);
+	singleton.set_arc(connection_lease);
 	let di_ctx = Arc::new(InjectionContext::builder(singleton).build());
 
 	let router = ReactiveScope::run(|| {

--- a/tests/integration/tests/admin/server_fn_permission_tests.rs
+++ b/tests/integration/tests/admin/server_fn_permission_tests.rs
@@ -25,7 +25,7 @@ async fn test_get_list_denied_when_view_false(
 	#[future] server_fn_context_deny_all: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_deny_all.await;
+	let (site, db, _connection_lease) = server_fn_context_deny_all.await;
 	let auth_user = make_auth_user();
 	let params = ListQueryParams::default();
 
@@ -53,7 +53,7 @@ async fn test_get_detail_denied_when_view_false(
 	#[future] server_fn_context_deny_all: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_deny_all.await;
+	let (site, db, _connection_lease) = server_fn_context_deny_all.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -89,7 +89,7 @@ async fn test_get_fields_denied_when_view_false(
 	#[future] server_fn_context_deny_all: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_deny_all.await;
+	let (site, db, _connection_lease) = server_fn_context_deny_all.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -125,7 +125,7 @@ async fn test_create_record_denied_when_add_false(
 	#[future] server_fn_context_deny_all: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_deny_all.await;
+	let (site, db, _connection_lease) = server_fn_context_deny_all.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -166,7 +166,7 @@ async fn test_update_record_denied_when_change_false(
 	#[future] server_fn_context_deny_all: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_deny_all.await;
+	let (site, db, _connection_lease) = server_fn_context_deny_all.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -208,7 +208,7 @@ async fn test_delete_record_denied_when_delete_false(
 	#[future] server_fn_context_deny_all: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_deny_all.await;
+	let (site, db, _connection_lease) = server_fn_context_deny_all.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -245,7 +245,7 @@ async fn test_bulk_delete_denied_when_delete_false(
 	#[future] server_fn_context_deny_all: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_deny_all.await;
+	let (site, db, _connection_lease) = server_fn_context_deny_all.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -286,7 +286,7 @@ async fn test_export_denied_when_view_false(
 	#[future] server_fn_context_deny_all: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_deny_all.await;
+	let (site, db, _connection_lease) = server_fn_context_deny_all.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -322,7 +322,7 @@ async fn test_import_denied_when_add_false(
 	#[future] server_fn_context_deny_all: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_deny_all.await;
+	let (site, db, _connection_lease) = server_fn_context_deny_all.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -366,7 +366,7 @@ async fn test_view_only_can_list_but_not_create(
 	#[future] server_fn_context_view_only: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_view_only.await;
+	let (site, db, _connection_lease) = server_fn_context_view_only.await;
 	let params = ListQueryParams::default();
 
 	// Act — view operation should succeed
@@ -427,7 +427,7 @@ async fn test_view_only_can_detail_but_not_update(
 	#[future] server_fn_context_view_only: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_view_only.await;
+	let (site, db, _connection_lease) = server_fn_context_view_only.await;
 
 	// Act — view operation should succeed (seeded record has id=1)
 	let detail_result = get_detail(
@@ -484,7 +484,7 @@ async fn test_view_only_can_export_but_not_import(
 	#[future] server_fn_context_view_only: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_view_only.await;
+	let (site, db, _connection_lease) = server_fn_context_view_only.await;
 
 	// Act — view operation (export) should succeed
 	let export_result = export_data(
@@ -558,7 +558,7 @@ async fn test_permission_denial_for_all_mutation_endpoints(
 	#[case] endpoint: &str,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context_deny_all.await;
+	let (site, db, _connection_lease) = server_fn_context_deny_all.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 

--- a/tests/integration/tests/admin/server_fn_state_transition_tests.rs
+++ b/tests/integration/tests/admin/server_fn_state_transition_tests.rs
@@ -26,7 +26,7 @@ async fn test_create_then_update_then_delete_lifecycle(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 
 	// Step 1: Create a record
 	let mut data = HashMap::new();
@@ -203,7 +203,7 @@ async fn test_import_then_export_round_trip_json(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 
 	let import_records = serde_json::json!([
 		{"name": "Round Trip 1", "status": "active"},
@@ -304,7 +304,7 @@ async fn test_detail_nonexistent_id(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -333,7 +333,7 @@ async fn test_update_nonexistent_id(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -371,7 +371,7 @@ async fn test_delete_nonexistent_id(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -401,7 +401,7 @@ async fn test_list_page_exceeds_total(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let auth_user = make_auth_user();
 
 	// Insert one record to ensure there is at least some data
@@ -446,7 +446,7 @@ async fn test_bulk_delete_empty_ids_list(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 

--- a/tests/integration/tests/admin/server_fn_update_tests.rs
+++ b/tests/integration/tests/admin/server_fn_update_tests.rs
@@ -60,7 +60,7 @@ async fn test_update_record_happy_path(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let id = create_test_record(&site, &db, "Original Name", "active").await;
 
 	let http_request = make_staff_request();
@@ -100,7 +100,7 @@ async fn test_update_record_returns_valid_response(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let id = create_test_record(&site, &db, "Metadata Test", "active").await;
 
 	let http_request = make_staff_request();
@@ -148,7 +148,7 @@ async fn test_update_record_persists_to_database(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let id = create_test_record(&site, &db, "Before Update", "active").await;
 
 	let http_request = make_staff_request();
@@ -194,7 +194,7 @@ async fn test_update_record_multiple_fields(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let id = create_test_record(&site, &db, "Multi Field", "active").await;
 
 	let http_request = make_staff_request();
@@ -237,7 +237,7 @@ async fn test_update_record_special_characters(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let id = create_test_record(&site, &db, "Original", "active").await;
 
 	let http_request = make_staff_request();
@@ -281,7 +281,7 @@ async fn test_update_record_partial_fields(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let id = create_test_record(&site, &db, "Partial Original", "active").await;
 
 	let http_request = make_staff_request();
@@ -328,7 +328,7 @@ async fn test_update_record_not_found(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -363,7 +363,7 @@ async fn test_update_record_model_not_registered(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 

--- a/tests/integration/tests/admin/server_fn_usecase_tests.rs
+++ b/tests/integration/tests/admin/server_fn_usecase_tests.rs
@@ -24,7 +24,7 @@ async fn test_full_crud_lifecycle_usecase(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let user = make_auth_user();
 	let request = make_staff_request();
 
@@ -185,7 +185,7 @@ async fn test_admin_dashboard_shows_registered_models(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, _db) = server_fn_context.await;
+	let (site, _db, _connection_lease) = server_fn_context.await;
 	let request = make_staff_request();
 
 	// Act
@@ -214,7 +214,7 @@ async fn test_search_then_export_matching_records(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange: Create records with distinct names
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let user = make_auth_user();
 	let request = make_staff_request();
 
@@ -286,7 +286,7 @@ async fn test_import_csv_then_verify_list(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let user = make_auth_user();
 	let request = make_staff_request();
 
@@ -336,7 +336,7 @@ async fn test_bulk_delete_then_verify_count(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange: Create 5 records
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let user = make_auth_user();
 	let request = make_staff_request();
 
@@ -400,7 +400,7 @@ async fn test_get_fields_then_create_with_valid_data(
 	#[future] server_fn_context: super::server_fn_helpers::ServerFnContext,
 ) {
 	// Arrange
-	let (site, db) = server_fn_context.await;
+	let (site, db, _connection_lease) = server_fn_context.await;
 	let user = make_auth_user();
 	let request = make_staff_request();
 

--- a/tests/integration/tests/admin/server_fn_uuid_pk_tests.rs
+++ b/tests/integration/tests/admin/server_fn_uuid_pk_tests.rs
@@ -48,7 +48,7 @@ async fn test_list_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
 	// Arrange
-	let (site, db, pool) = uuid_pk_context.await;
+	let (site, db, pool, _connection_lease) = uuid_pk_context.await;
 	let auth_user = make_auth_user();
 
 	insert_uuid_record(&pool, "UUID List Item 1", "active").await;
@@ -91,7 +91,7 @@ async fn test_detail_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
 	// Arrange
-	let (site, db, pool) = uuid_pk_context.await;
+	let (site, db, pool, _connection_lease) = uuid_pk_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -125,7 +125,7 @@ async fn test_create_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
 	// Arrange
-	let (site, db, _pool) = uuid_pk_context.await;
+	let (site, db, _pool, _connection_lease) = uuid_pk_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 
@@ -172,7 +172,7 @@ async fn test_update_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
 	// Arrange
-	let (site, db, pool) = uuid_pk_context.await;
+	let (site, db, pool, _connection_lease) = uuid_pk_context.await;
 	let uuid_id = insert_uuid_record(&pool, "UUID Before Update", "active").await;
 
 	let http_request = make_staff_request();
@@ -232,7 +232,7 @@ async fn test_delete_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
 	// Arrange
-	let (site, db, pool) = uuid_pk_context.await;
+	let (site, db, pool, _connection_lease) = uuid_pk_context.await;
 	let uuid_id = insert_uuid_record(&pool, "UUID To Delete", "active").await;
 
 	let http_request = make_staff_request();
@@ -270,7 +270,7 @@ async fn test_bulk_delete_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
 	// Arrange
-	let (site, db, pool) = uuid_pk_context.await;
+	let (site, db, pool, _connection_lease) = uuid_pk_context.await;
 
 	let id1 = insert_uuid_record(&pool, "UUID Bulk 1", "active").await;
 	let id2 = insert_uuid_record(&pool, "UUID Bulk 2", "draft").await;
@@ -315,7 +315,7 @@ async fn test_export_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
 	// Arrange
-	let (site, db, pool) = uuid_pk_context.await;
+	let (site, db, pool, _connection_lease) = uuid_pk_context.await;
 	let http_request = make_staff_request();
 	let auth_user = make_auth_user();
 

--- a/tests/integration/tests/auth/auth_integration.rs
+++ b/tests/integration/tests/auth/auth_integration.rs
@@ -413,7 +413,10 @@ mod user_model_tests {
 #[cfg(feature = "argon2-hasher")]
 mod database_integration_tests {
 	use super::*;
-	use reinhardt_db::DatabaseConnection;
+	use reinhardt_db::{
+		backends::DatabaseConnection as BackendsConnection,
+		orm::{DatabaseConnection, DatabaseConnectionLease},
+	};
 	use reinhardt_test::fixtures::postgres_container;
 	use serial_test::serial;
 	use sqlx::PgPool;
@@ -428,12 +431,15 @@ mod database_integration_tests {
 		#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<PgPool>, u16, String),
 	) -> (
 		ContainerAsync<GenericImage>,
-		Arc<DatabaseConnection>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
 		u16,
 		String,
 	) {
 		let (container, pool, port, url) = postgres_container.await;
-		let connection = DatabaseConnection::connect(&url).await.unwrap();
+		let owner = BackendsConnection::connect(&url).await.unwrap();
+		let lease = DatabaseConnectionLease::register(owner).unwrap();
+		let connection = lease.handle();
 
 		// Create simple auth_user table for testing
 		sqlx::query(
@@ -453,7 +459,7 @@ mod database_integration_tests {
 		.await
 		.unwrap();
 
-		(container, Arc::new(connection), port, url)
+		(container, lease, connection, port, url)
 	}
 
 	/// Test session authentication with database
@@ -467,12 +473,13 @@ mod database_integration_tests {
 	async fn test_session_auth_with_database(
 		#[future] auth_test_db: (
 			ContainerAsync<GenericImage>,
-			Arc<DatabaseConnection>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
 			u16,
 			String,
 		),
 	) {
-		let (_container, _connection, _port, _url) = auth_test_db.await;
+		let (_container, _lease, _connection, _port, _url) = auth_test_db.await;
 
 		// Create a test user via TestUser
 		let user = TestUser {

--- a/tests/integration/tests/backends/database_error_classification.rs
+++ b/tests/integration/tests/backends/database_error_classification.rs
@@ -2,7 +2,10 @@
 
 use reinhardt_core::exception::Error;
 use reinhardt_db::DatabaseErrorKind;
-use reinhardt_db::orm::connection::{DatabaseBackend, DatabaseConnection};
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection,
+	orm::connection::{DatabaseBackend, DatabaseConnection, DatabaseConnectionLease},
+};
 use reinhardt_query::prelude::{
 	ColumnDef, Expr, ExprTrait, Iden, IntoIden, MySqlQueryBuilder, PostgresQueryBuilder, Query,
 	QueryStatementWriter, SqliteQueryBuilder, Value,
@@ -191,9 +194,12 @@ async fn postgres_constraint_errors_have_portable_kinds(
 ) {
 	// Arrange
 	let (_container, _pool, _port, url) = postgres_container.await;
-	let connection = DatabaseConnection::connect(&url)
+	let owner = BackendsConnection::connect(&url)
 		.await
 		.expect("the PostgreSQL fixture must accept framework connections");
+	let lease =
+		DatabaseConnectionLease::register(owner).expect("connection registration must succeed");
+	let connection = lease.handle();
 	create_portable_schema(&connection).await;
 
 	// Act
@@ -208,9 +214,12 @@ async fn postgres_constraint_errors_have_portable_kinds(
 #[tokio::test]
 async fn sqlite_constraint_errors_have_portable_kinds() {
 	// Arrange
-	let connection = DatabaseConnection::connect("sqlite::memory:")
+	let owner = BackendsConnection::connect("sqlite::memory:")
 		.await
 		.expect("the in-memory SQLite database must connect");
+	let lease =
+		DatabaseConnectionLease::register(owner).expect("connection registration must succeed");
+	let connection = lease.handle();
 	// reinhardt-query has no builder for this backend session directive.
 	connection
 		.execute("PRAGMA foreign_keys = ON", vec![])
@@ -237,9 +246,12 @@ async fn mysql_constraint_errors_have_portable_kinds() {
 		.wait_ready()
 		.await
 		.expect("the MySQL container must become ready");
-	let connection = DatabaseConnection::connect(&container.connection_url())
+	let owner = BackendsConnection::connect(&container.connection_url())
 		.await
 		.expect("the MySQL fixture must accept framework connections");
+	let lease =
+		DatabaseConnectionLease::register(owner).expect("connection registration must succeed");
+	let connection = lease.handle();
 	create_portable_schema(&connection).await;
 
 	// Act
@@ -267,7 +279,7 @@ async fn unavailable_postgres_endpoint_is_classified_as_timeout() {
 	);
 
 	// Act
-	let result = DatabaseConnection::connect(&url).await;
+	let result = BackendsConnection::connect(&url).await;
 
 	// Assert
 	let Err(error) = result else {

--- a/tests/integration/tests/orm/async_query_integration.rs
+++ b/tests/integration/tests/orm/async_query_integration.rs
@@ -16,7 +16,10 @@ use reinhardt_db::orm::{
 	expressions::Q, manager::reinitialize_database, query_execution::QueryCompiler,
 	types::DatabaseDialect,
 };
-use reinhardt_db::{DatabaseConnection, orm::Model};
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection,
+	orm::{DatabaseConnection, DatabaseConnectionLease, Model},
+};
 use reinhardt_integration_tests::migrations::apply_async_query_test_migrations;
 use reinhardt_macros::model;
 use reinhardt_query::QueryStatementBuilder;
@@ -51,22 +54,23 @@ async fn async_query_test_db(
 	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<PgPool>, u16, String),
 ) -> (
 	ContainerAsync<GenericImage>,
-	Arc<DatabaseConnection>,
+	DatabaseConnectionLease,
+	DatabaseConnection,
 	u16,
 	String,
 ) {
 	let (container, _pool, port, url) = postgres_container.await;
 
 	// Create DatabaseConnection from URL (not from pool)
-	let connection = DatabaseConnection::connect(&url).await.unwrap();
+	let owner = BackendsConnection::connect(&url).await.unwrap();
 
 	// Apply async query test migrations using MigrationExecutor
 	// Note: apply_async_query_test_migrations expects BackendsConnection, so we use inner()
-	apply_async_query_test_migrations(connection.inner())
-		.await
-		.unwrap();
+	apply_async_query_test_migrations(&owner).await.unwrap();
+	let lease = DatabaseConnectionLease::register(owner).unwrap();
+	let connection = lease.handle();
 
-	(container, Arc::new(connection), port, url)
+	(container, lease, connection, port, url)
 }
 
 // ========================================================================
@@ -121,12 +125,13 @@ mod postgres_tests {
 	async fn test_postgres_async_query_execution(
 		#[future] async_query_test_db: (
 			ContainerAsync<GenericImage>,
-			Arc<DatabaseConnection>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
 			u16,
 			String,
 		),
 	) {
-		let (_container, _connection, _port, url) = async_query_test_db.await;
+		let (_container, _lease, _connection, _port, url) = async_query_test_db.await;
 
 		// Initialize global database connection for ORM
 		reinitialize_database(&url)
@@ -165,12 +170,13 @@ mod postgres_tests {
 	async fn test_postgres_async_session(
 		#[future] async_query_test_db: (
 			ContainerAsync<GenericImage>,
-			Arc<DatabaseConnection>,
+			DatabaseConnectionLease,
+			DatabaseConnection,
 			u16,
 			String,
 		),
 	) {
-		let (_container, _connection, _port, url) = async_query_test_db.await;
+		let (_container, _lease, _connection, _port, url) = async_query_test_db.await;
 
 		// Initialize global database connection for ORM
 		reinitialize_database(&url)

--- a/tests/integration/tests/orm/model_enum_integration.rs
+++ b/tests/integration/tests/orm/model_enum_integration.rs
@@ -558,9 +558,12 @@ async fn typed_model_enum_filters_lists_and_assignments_use_persistent_values() 
 #[serial(model_enum_database)]
 async fn typed_codec_errors_surface_before_filter_or_update_execution() {
 	let (_database, url) = sqlite_database_url();
-	let mut connection = reinhardt::db::orm::connection::DatabaseConnection::connect(&url)
+	let owner = reinhardt::db::backends::DatabaseConnection::connect(&url)
 		.await
 		.expect("SQLite connection should initialize");
+	let lease = reinhardt::db::orm::DatabaseConnectionLease::register(owner)
+		.expect("SQLite connection should register");
+	let mut connection = lease.handle();
 	connection
 		.execute(
 			"CREATE TABLE owners (id INTEGER PRIMARY KEY, name VARCHAR(40) NOT NULL)",

--- a/tests/integration/tests/orm/mysql_json_transaction_integration.rs
+++ b/tests/integration/tests/orm/mysql_json_transaction_integration.rs
@@ -1,7 +1,10 @@
 //! MySQL JSON transaction integration tests.
 
 use reinhardt_db::backends::types::QueryValue;
-use reinhardt_db::orm::connection::{DatabaseConnection, OrmExecutor};
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection,
+	orm::{DatabaseConnectionLease, OrmExecutor},
+};
 use reinhardt_test::fixtures::testcontainers::mysql_container;
 use rstest::rstest;
 use sqlx::MySqlPool;
@@ -15,7 +18,9 @@ async fn test_mysql_transaction_fetch_preserves_json_value(
 ) {
 	// Arrange
 	let (_container, _pool, _port, url) = mysql_container.await;
-	let connection = DatabaseConnection::connect(&url).await.unwrap();
+	let owner = BackendsConnection::connect(&url).await.unwrap();
+	let lease = DatabaseConnectionLease::register(owner).unwrap();
+	let connection = lease.handle();
 	connection
 		.execute(
 			"CREATE TABLE json_transaction_rows (id BIGINT PRIMARY KEY, payload JSON NOT NULL)",

--- a/tests/integration/tests/pagination/cursor_integration.rs
+++ b/tests/integration/tests/pagination/cursor_integration.rs
@@ -4,7 +4,9 @@
 //! testing cursor encoding/decoding, forward/backward navigation, and pagination metadata.
 
 use reinhardt_core::pagination::{AsyncPaginator, CursorPagination};
-use reinhardt_db::orm::DatabaseConnection;
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection, orm::DatabaseConnectionLease,
+};
 use reinhardt_test::fixtures::testcontainers::postgres_container;
 use rstest::*;
 use serde::{Deserialize, Serialize};
@@ -51,9 +53,11 @@ async fn setup_test_db(
 	let (container, pool, _port, database_url) = postgres_container.await;
 
 	// Create connection using DatabaseConnection
-	let conn = DatabaseConnection::connect(&database_url)
+	let owner = BackendsConnection::connect(&database_url)
 		.await
 		.expect("Failed to connect to database");
+	let lease = DatabaseConnectionLease::register(owner).expect("Failed to register database");
+	let conn = lease.handle();
 
 	// Create test_articles table
 	conn.execute(

--- a/tests/integration/tests/storage/static_orm_integration.rs
+++ b/tests/integration/tests/storage/static_orm_integration.rs
@@ -37,9 +37,12 @@
 //! ❌ Static file serving (covered by HTTP server tests)
 //! ❌ Multi-CDN failover (requires external CDN infrastructure)
 
-use reinhardt_db::orm::DatabaseConnection;
-use reinhardt_utils::storage::{LocalStorage, Storage};
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection,
+	orm::{DatabaseConnection, DatabaseConnectionLease},
+};
 use reinhardt_test::fixtures::testcontainers::postgres_container;
+use reinhardt_utils::storage::{LocalStorage, Storage};
 use rstest::*;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -103,14 +106,14 @@ fn compute_hash(content: &[u8]) -> String {
 /// Static file manager with database tracking
 struct StaticFileManager {
 	storage: LocalStorage,
-	connection: Arc<DatabaseConnection>,
+	connection: DatabaseConnection,
 	cdn_base_url: Option<String>,
 }
 
 impl StaticFileManager {
 	fn new(
 		storage: LocalStorage,
-		connection: Arc<DatabaseConnection>,
+		connection: DatabaseConnection,
 		cdn_base_url: Option<String>,
 	) -> Self {
 		Self {
@@ -407,13 +410,19 @@ fn temp_dir() -> TempDir {
 #[fixture]
 async fn postgres_fixture(
 	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<sqlx::PgPool>, u16, String),
-) -> (ContainerAsync<GenericImage>, Arc<DatabaseConnection>) {
+) -> (
+	ContainerAsync<GenericImage>,
+	DatabaseConnectionLease,
+	DatabaseConnection,
+) {
 	let (container, _pool, _port, database_url) = postgres_container.await;
 
 	// Create connection
-	let conn = DatabaseConnection::connect(&database_url)
+	let owner = BackendsConnection::connect(&database_url)
 		.await
 		.expect("Failed to connect to database");
+	let lease = DatabaseConnectionLease::register(owner).expect("Failed to register database");
+	let conn = lease.handle();
 
 	// Create static_file_metadata table
 	conn.execute(
@@ -432,22 +441,31 @@ async fn postgres_fixture(
 	.await
 	.expect("Failed to create static_file_metadata table");
 
-	(container, Arc::new(conn))
+	(container, lease, conn)
 }
 
 #[fixture]
 async fn static_manager(
 	temp_dir: TempDir,
-	#[future] postgres_fixture: (ContainerAsync<GenericImage>, Arc<DatabaseConnection>),
-) -> (TempDir, ContainerAsync<GenericImage>, StaticFileManager) {
-	let (_container, conn) = postgres_fixture.await;
+	#[future] postgres_fixture: (
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	),
+) -> (
+	TempDir,
+	ContainerAsync<GenericImage>,
+	DatabaseConnectionLease,
+	StaticFileManager,
+) {
+	let (_container, lease, conn) = postgres_fixture.await;
 
 	let storage = LocalStorage::new(temp_dir.path(), "http://localhost/static");
 	storage.ensure_base_dir().await.unwrap();
 
 	let manager = StaticFileManager::new(storage, conn, None);
 
-	(temp_dir, _container, manager)
+	(temp_dir, _container, lease, manager)
 }
 
 // ============ Metadata Storage Tests ============
@@ -456,9 +474,14 @@ async fn static_manager(
 #[rstest]
 #[tokio::test]
 async fn test_static_file_metadata_storage(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let path = "css/main.css";
 	let content = b"body { margin: 0; }";
@@ -477,9 +500,14 @@ async fn test_static_file_metadata_storage(
 #[rstest]
 #[tokio::test]
 async fn test_static_file_metadata_retrieval(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let path = "js/app.js";
 	let content = b"console.log('Hello');";
@@ -500,9 +528,14 @@ async fn test_static_file_metadata_retrieval(
 #[rstest]
 #[tokio::test]
 async fn test_static_file_versioning(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let path = "css/style.css";
 	let version1_content = b"body { color: red; }";
@@ -525,9 +558,14 @@ async fn test_static_file_versioning(
 #[rstest]
 #[tokio::test]
 async fn test_static_file_hash_updates(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let path = "data.json";
 	let original = b"{\"key\": \"value1\"}";
@@ -549,9 +587,14 @@ async fn test_static_file_hash_updates(
 #[rstest]
 #[tokio::test]
 async fn test_static_file_size_tracking(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let files = vec![
 		("small.txt", b"A" as &[u8]),
@@ -572,9 +615,13 @@ async fn test_static_file_size_tracking(
 #[tokio::test]
 async fn test_cdn_url_generation(
 	temp_dir: TempDir,
-	#[future] postgres_fixture: (ContainerAsync<GenericImage>, Arc<DatabaseConnection>),
+	#[future] postgres_fixture: (
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	),
 ) {
-	let (_container, conn) = postgres_fixture.await;
+	let (_container, _lease, conn) = postgres_fixture.await;
 
 	let storage = LocalStorage::new(temp_dir.path(), "http://localhost/static");
 	storage.ensure_base_dir().await.unwrap();
@@ -600,9 +647,13 @@ async fn test_cdn_url_generation(
 #[tokio::test]
 async fn test_cdn_url_persistence(
 	temp_dir: TempDir,
-	#[future] postgres_fixture: (ContainerAsync<GenericImage>, Arc<DatabaseConnection>),
+	#[future] postgres_fixture: (
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	),
 ) {
-	let (_container, conn) = postgres_fixture.await;
+	let (_container, _lease, conn) = postgres_fixture.await;
 
 	let storage = LocalStorage::new(temp_dir.path(), "http://localhost/static");
 	storage.ensure_base_dir().await.unwrap();
@@ -629,9 +680,13 @@ async fn test_cdn_url_persistence(
 #[tokio::test]
 async fn test_multiple_cdn_configurations(
 	temp_dir: TempDir,
-	#[future] postgres_fixture: (ContainerAsync<GenericImage>, Arc<DatabaseConnection>),
+	#[future] postgres_fixture: (
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	),
 ) {
-	let (_container, conn) = postgres_fixture.await;
+	let (_container, _lease, conn) = postgres_fixture.await;
 
 	let storage = LocalStorage::new(temp_dir.path(), "http://localhost/static");
 	storage.ensure_base_dir().await.unwrap();
@@ -667,9 +722,14 @@ async fn test_multiple_cdn_configurations(
 #[rstest]
 #[tokio::test]
 async fn test_static_file_integrity_check(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let path = "verify/data.bin";
 	let content = b"Important data that must not be corrupted";
@@ -686,9 +746,14 @@ async fn test_static_file_integrity_check(
 #[rstest]
 #[tokio::test]
 async fn test_static_file_integrity_corruption_detection(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let path = "corrupt/file.txt";
 	let original_content = b"Original content";
@@ -729,9 +794,14 @@ async fn test_hash_computation_consistency() {
 #[rstest]
 #[tokio::test]
 async fn test_orphaned_file_detection(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	// Save a file
 	let path = "orphan/test.txt";
@@ -750,9 +820,14 @@ async fn test_orphaned_file_detection(
 #[rstest]
 #[tokio::test]
 async fn test_orphaned_file_cleanup(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	// Save files
 	let files = vec!["cleanup/file1.txt", "cleanup/file2.txt"];
@@ -778,9 +853,14 @@ async fn test_orphaned_file_cleanup(
 #[rstest]
 #[tokio::test]
 async fn test_complete_file_deletion(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let path = "delete/complete.txt";
 	let content = b"Delete me completely";
@@ -804,9 +884,14 @@ async fn test_complete_file_deletion(
 #[rstest]
 #[tokio::test]
 async fn test_bulk_file_tracking(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	// Save multiple files
 	let file_count = 10;
@@ -828,9 +913,14 @@ async fn test_bulk_file_tracking(
 #[rstest]
 #[tokio::test]
 async fn test_timestamp_tracking(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let path = "timestamp/test.txt";
 
@@ -858,9 +948,14 @@ async fn test_timestamp_tracking(
 #[rstest]
 #[tokio::test]
 async fn test_nested_path_handling(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let nested_path = "assets/images/icons/user-avatar.png";
 	let content = b"PNG avatar image";
@@ -880,9 +975,14 @@ async fn test_nested_path_handling(
 #[rstest]
 #[tokio::test]
 async fn test_version_history_tracking(
-	#[future] static_manager: (TempDir, ContainerAsync<GenericImage>, StaticFileManager),
+	#[future] static_manager: (
+		TempDir,
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		StaticFileManager,
+	),
 ) {
-	let (_temp_dir, _container, manager) = static_manager.await;
+	let (_temp_dir, _container, _lease, manager) = static_manager.await;
 
 	let path = "versioned/changelog.md";
 	let versions = vec![

--- a/tests/integration/tests/storage/template_integration.rs
+++ b/tests/integration/tests/storage/template_integration.rs
@@ -37,7 +37,10 @@
 //! ❌ Template tag parsing (covered by template engine tests)
 //! ❌ Distributed template storage (requires multi-node setup)
 
-use reinhardt_db::orm::DatabaseConnection;
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection,
+	orm::{DatabaseConnection, DatabaseConnectionLease},
+};
 use reinhardt_test::fixtures::testcontainers::postgres_container;
 use rstest::*;
 use serde::{Deserialize, Serialize};
@@ -192,12 +195,12 @@ impl FilesystemTemplateStorage {
 
 /// Database template storage
 struct DatabaseTemplateStorage {
-	connection: Arc<DatabaseConnection>,
+	connection: DatabaseConnection,
 	cache: Arc<TemplateCache>,
 }
 
 impl DatabaseTemplateStorage {
-	fn new(connection: Arc<DatabaseConnection>) -> Self {
+	fn new(connection: DatabaseConnection) -> Self {
 		Self {
 			connection,
 			cache: Arc::new(TemplateCache::new()),
@@ -293,13 +296,19 @@ fn temp_dir() -> TempDir {
 #[fixture]
 async fn postgres_fixture(
 	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<sqlx::PgPool>, u16, String),
-) -> (ContainerAsync<GenericImage>, Arc<DatabaseConnection>) {
+) -> (
+	ContainerAsync<GenericImage>,
+	DatabaseConnectionLease,
+	DatabaseConnection,
+) {
 	let (container, _pool, _port, database_url) = postgres_container.await;
 
 	// Create connection
-	let conn = DatabaseConnection::connect(&database_url)
+	let owner = BackendsConnection::connect(&database_url)
 		.await
 		.expect("Failed to connect to database");
+	let lease = DatabaseConnectionLease::register(owner).expect("Failed to register database");
+	let conn = lease.handle();
 
 	// Create template_metadata table
 	conn.execute(
@@ -315,7 +324,7 @@ async fn postgres_fixture(
 	.await
 	.expect("Failed to create template_metadata table");
 
-	(container, Arc::new(conn))
+	(container, lease, conn)
 }
 
 // ============ Filesystem Storage Tests ============
@@ -553,9 +562,13 @@ async fn test_template_cache_clear(temp_dir: TempDir) {
 #[rstest]
 #[tokio::test]
 async fn test_database_template_load_with_cache(
-	#[future] postgres_fixture: (ContainerAsync<GenericImage>, Arc<DatabaseConnection>),
+	#[future] postgres_fixture: (
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	),
 ) {
-	let (_container, conn) = postgres_fixture.await;
+	let (_container, _lease, conn) = postgres_fixture.await;
 	let storage = DatabaseTemplateStorage::new(conn);
 
 	let template_name = "db_base.html";
@@ -585,10 +598,14 @@ async fn test_database_template_load_with_cache(
 #[rstest]
 #[tokio::test]
 async fn test_database_template_versioning(
-	#[future] postgres_fixture: (ContainerAsync<GenericImage>, Arc<DatabaseConnection>),
+	#[future] postgres_fixture: (
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	),
 ) {
-	let (_container, conn) = postgres_fixture.await;
-	let storage = DatabaseTemplateStorage::new(Arc::clone(&conn));
+	let (_container, _lease, conn) = postgres_fixture.await;
+	let storage = DatabaseTemplateStorage::new(conn);
 
 	let template_name = "versioned.html";
 	let version1 = "Version 1 content";
@@ -631,9 +648,13 @@ async fn test_database_template_versioning(
 #[rstest]
 #[tokio::test]
 async fn test_database_template_cache_invalidation(
-	#[future] postgres_fixture: (ContainerAsync<GenericImage>, Arc<DatabaseConnection>),
+	#[future] postgres_fixture: (
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	),
 ) {
-	let (_container, conn) = postgres_fixture.await;
+	let (_container, _lease, conn) = postgres_fixture.await;
 	let storage = DatabaseTemplateStorage::new(conn);
 
 	let template_name = "db_invalidate.html";
@@ -660,9 +681,13 @@ async fn test_database_template_cache_invalidation(
 #[rstest]
 #[tokio::test]
 async fn test_database_template_deletion(
-	#[future] postgres_fixture: (ContainerAsync<GenericImage>, Arc<DatabaseConnection>),
+	#[future] postgres_fixture: (
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	),
 ) {
-	let (_container, conn) = postgres_fixture.await;
+	let (_container, _lease, conn) = postgres_fixture.await;
 	let storage = DatabaseTemplateStorage::new(conn);
 
 	let template_name = "db_delete.html";
@@ -690,9 +715,13 @@ async fn test_database_template_deletion(
 #[rstest]
 #[tokio::test]
 async fn test_database_multiple_templates(
-	#[future] postgres_fixture: (ContainerAsync<GenericImage>, Arc<DatabaseConnection>),
+	#[future] postgres_fixture: (
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	),
 ) {
-	let (_container, conn) = postgres_fixture.await;
+	let (_container, _lease, conn) = postgres_fixture.await;
 	let storage = DatabaseTemplateStorage::new(conn);
 
 	let templates = vec![
@@ -717,9 +746,13 @@ async fn test_database_multiple_templates(
 #[rstest]
 #[tokio::test]
 async fn test_database_template_loading_performance(
-	#[future] postgres_fixture: (ContainerAsync<GenericImage>, Arc<DatabaseConnection>),
+	#[future] postgres_fixture: (
+		ContainerAsync<GenericImage>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
+	),
 ) {
-	let (_container, conn) = postgres_fixture.await;
+	let (_container, _lease, conn) = postgres_fixture.await;
 	let storage = DatabaseTemplateStorage::new(conn);
 
 	let template_name = "db_perf.html";

--- a/tests/integration/tests/validation/validator_orm_constraints.rs
+++ b/tests/integration/tests/validation/validator_orm_constraints.rs
@@ -13,8 +13,10 @@
 use reinhardt_core::validators::{MinValueValidator, RangeValidator, Validator};
 use reinhardt_db::orm::manager::reinitialize_database;
 use reinhardt_db::{
-	DatabaseConnection,
-	orm::{Filter, FilterOperator, FilterValue, Model},
+	backends::DatabaseConnection as BackendsConnection,
+	orm::{
+		DatabaseConnection, DatabaseConnectionLease, Filter, FilterOperator, FilterValue, Model,
+	},
 };
 use reinhardt_integration_tests::{
 	migrations::apply_constraint_test_migrations,
@@ -91,7 +93,8 @@ async fn validator_constraint_test_db(
 	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<sqlx::PgPool>, u16, String),
 ) -> (
 	ContainerAsync<GenericImage>,
-	Arc<DatabaseConnection>,
+	DatabaseConnectionLease,
+	DatabaseConnection,
 	Arc<PgPool>,
 	u16,
 	String,
@@ -99,19 +102,19 @@ async fn validator_constraint_test_db(
 	let (container, pool, port, url) = postgres_container.await;
 
 	// Create ORM DatabaseConnection from URL
-	let connection = DatabaseConnection::connect(&url).await.unwrap();
+	let owner = BackendsConnection::connect(&url).await.unwrap();
 
 	// Apply constraint test migrations using inner BackendsConnection
-	apply_constraint_test_migrations(connection.inner())
-		.await
-		.unwrap();
+	apply_constraint_test_migrations(&owner).await.unwrap();
+	let lease = DatabaseConnectionLease::register(owner).unwrap();
+	let connection = lease.handle();
 
 	// Initialize global database connection for ORM Manager API
 	reinitialize_database(&url)
 		.await
 		.expect("Failed to reinitialize database");
 
-	(container, Arc::new(connection), pool, port, url)
+	(container, lease, connection, pool, port, url)
 }
 
 // ============================================================================
@@ -130,14 +133,16 @@ async fn validator_constraint_test_db(
 async fn test_composite_unique_constraint_validation(
 	#[future] validator_constraint_test_db: (
 		ContainerAsync<GenericImage>,
-		Arc<DatabaseConnection>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
 		Arc<PgPool>,
 		u16,
 		String,
 	),
 	_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 ) {
-	let (_container, _connection, _pool, _port, _database_url) = validator_constraint_test_db.await;
+	let (_container, _lease, _connection, _pool, _port, _database_url) =
+		validator_constraint_test_db.await;
 
 	// Insert test users using ORM
 	let user1_id = {
@@ -236,14 +241,16 @@ async fn test_composite_unique_constraint_validation(
 async fn test_check_constraint_integration(
 	#[future] validator_constraint_test_db: (
 		ContainerAsync<GenericImage>,
-		Arc<DatabaseConnection>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
 		Arc<PgPool>,
 		u16,
 		String,
 	),
 	_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 ) {
-	let (_container, _connection, pool, _port, _database_url) = validator_constraint_test_db.await;
+	let (_container, _lease, _connection, pool, _port, _database_url) =
+		validator_constraint_test_db.await;
 
 	// Application-level validator
 	let price_validator = MinValueValidator::new(0.0);
@@ -343,14 +350,16 @@ async fn test_check_constraint_integration(
 async fn test_cascade_delete_validation(
 	#[future] validator_constraint_test_db: (
 		ContainerAsync<GenericImage>,
-		Arc<DatabaseConnection>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
 		Arc<PgPool>,
 		u16,
 		String,
 	),
 	_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 ) {
-	let (_container, _connection, _pool, _port, _database_url) = validator_constraint_test_db.await;
+	let (_container, _lease, _connection, _pool, _port, _database_url) =
+		validator_constraint_test_db.await;
 
 	// Setup: Create user, post, and comments
 	let user_id = {
@@ -480,14 +489,16 @@ async fn test_cascade_delete_validation(
 async fn test_validation_failure_transaction_rollback(
 	#[future] validator_constraint_test_db: (
 		ContainerAsync<GenericImage>,
-		Arc<DatabaseConnection>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
 		Arc<PgPool>,
 		u16,
 		String,
 	),
 	_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 ) {
-	let (_container, _connection, pool, _port, _database_url) = validator_constraint_test_db.await;
+	let (_container, _lease, _connection, pool, _port, _database_url) =
+		validator_constraint_test_db.await;
 
 	// Get initial product count using ORM
 	let manager = TestProduct::objects();
@@ -586,14 +597,16 @@ async fn test_validation_failure_transaction_rollback(
 async fn test_partial_update_validation(
 	#[future] validator_constraint_test_db: (
 		ContainerAsync<GenericImage>,
-		Arc<DatabaseConnection>,
+		DatabaseConnectionLease,
+		DatabaseConnection,
 		Arc<PgPool>,
 		u16,
 		String,
 	),
 	_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 ) {
-	let (_container, _connection, _pool, _port, _database_url) = validator_constraint_test_db.await;
+	let (_container, _lease, _connection, _pool, _port, _database_url) =
+		validator_constraint_test_db.await;
 
 	// Insert initial product
 	let product_id = {

--- a/tests/integration/tests/validation/validator_orm_integration.rs
+++ b/tests/integration/tests/validation/validator_orm_integration.rs
@@ -9,8 +9,10 @@ use reinhardt_core::validators::{
 	MaxLengthValidator, MaxValueValidator, MinLengthValidator, MinValueValidator, RangeValidator,
 	ValidationError, Validator,
 };
-use reinhardt_db::DatabaseConnection;
 use reinhardt_db::orm::manager::reinitialize_database;
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection, orm::DatabaseConnectionLease,
+};
 use reinhardt_integration_tests::{
 	migrations::apply_basic_test_migrations, validator_test_common::*,
 };
@@ -29,16 +31,22 @@ use testcontainers::{ContainerAsync, GenericImage};
 #[fixture]
 async fn validator_orm_test_db(
 	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<sqlx::PgPool>, u16, String),
-) -> (ContainerAsync<GenericImage>, TestDatabase, u16, String) {
-	let (container, _pool, port, url) = postgres_container.await;
+) -> (
+	ContainerAsync<GenericImage>,
+	DatabaseConnectionLease,
+	TestDatabase,
+	u16,
+	String,
+) {
+	let (container, pool, port, url) = postgres_container.await;
 
 	// Create ORM DatabaseConnection from URL
-	let connection = DatabaseConnection::connect(&url).await.unwrap();
+	let owner = BackendsConnection::connect(&url).await.unwrap();
 
 	// Apply basic test migrations using inner BackendsConnection
-	apply_basic_test_migrations(connection.inner())
-		.await
-		.unwrap();
+	apply_basic_test_migrations(&owner).await.unwrap();
+	let lease = DatabaseConnectionLease::register(owner).unwrap();
+	let connection = lease.handle();
 
 	// Initialize global database connection for ORM Manager API
 	reinitialize_database(&url)
@@ -47,11 +55,13 @@ async fn validator_orm_test_db(
 
 	// Create TestDatabase with the connection
 	let test_db = TestDatabase {
-		connection: Arc::new(connection),
+		connection,
+		pool,
+		_lease: lease.clone(),
 		_container: None, // Container is managed by fixture
 	};
 
-	(container, test_db, port, url)
+	(container, lease, test_db, port, url)
 }
 
 #[cfg(test)]
@@ -63,10 +73,16 @@ mod scalar_validation_tests {
 	#[tokio::test]
 	#[serial(validator_orm_db)]
 	async fn test_scalar_field_validation(
-		#[future] validator_orm_test_db: (ContainerAsync<GenericImage>, TestDatabase, u16, String),
+		#[future] validator_orm_test_db: (
+			ContainerAsync<GenericImage>,
+			DatabaseConnectionLease,
+			TestDatabase,
+			u16,
+			String,
+		),
 		_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 	) {
-		let (_container, test_db, _port, _database_url) = validator_orm_test_db.await;
+		let (_container, _lease, test_db, _port, _database_url) = validator_orm_test_db.await;
 
 		// No need to setup tables - migrations already applied
 
@@ -296,12 +312,18 @@ mod constraint_validation_tests {
 	#[tokio::test]
 	#[serial(validator_orm_db)]
 	async fn test_unique_constraint_database_violation(
-		#[future] validator_orm_test_db: (ContainerAsync<GenericImage>, TestDatabase, u16, String),
+		#[future] validator_orm_test_db: (
+			ContainerAsync<GenericImage>,
+			DatabaseConnectionLease,
+			TestDatabase,
+			u16,
+			String,
+		),
 		_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 	) {
 		use reinhardt_core::validators::UniqueValidator;
 
-		let (_container, test_db, _port, _database_url) = validator_orm_test_db.await;
+		let (_container, _lease, test_db, _port, _database_url) = validator_orm_test_db.await;
 
 		// Insert first user successfully using TestDatabase method
 		let user1_id = test_db
@@ -311,7 +333,7 @@ mod constraint_validation_tests {
 		assert!(user1_id > 0);
 
 		// Create a UniqueValidator for username field using pool from connection
-		let pool = test_db.connection.inner().into_postgres().unwrap().clone();
+		let pool = test_db.pool.clone();
 		let pool_clone = pool.clone();
 		let username_validator = UniqueValidator::new(
 			"username",
@@ -387,10 +409,16 @@ mod relationship_validation_tests {
 	#[tokio::test]
 	#[serial(validator_orm_db)]
 	async fn test_foreign_key_validation(
-		#[future] validator_orm_test_db: (ContainerAsync<GenericImage>, TestDatabase, u16, String),
+		#[future] validator_orm_test_db: (
+			ContainerAsync<GenericImage>,
+			DatabaseConnectionLease,
+			TestDatabase,
+			u16,
+			String,
+		),
 		_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 	) {
-		let (_container, test_db, _port, _database_url) = validator_orm_test_db.await;
+		let (_container, _lease, test_db, _port, _database_url) = validator_orm_test_db.await;
 
 		// Insert user and verify it exists using TestDatabase method
 		let user_id = test_db
@@ -410,12 +438,18 @@ mod relationship_validation_tests {
 	#[tokio::test]
 	#[serial(validator_orm_db)]
 	async fn test_foreign_key_existence_validation(
-		#[future] validator_orm_test_db: (ContainerAsync<GenericImage>, TestDatabase, u16, String),
+		#[future] validator_orm_test_db: (
+			ContainerAsync<GenericImage>,
+			DatabaseConnectionLease,
+			TestDatabase,
+			u16,
+			String,
+		),
 		_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 	) {
 		use reinhardt_core::validators::ExistsValidator;
 
-		let (_container, test_db, _port, _database_url) = validator_orm_test_db.await;
+		let (_container, _lease, test_db, _port, _database_url) = validator_orm_test_db.await;
 
 		// Insert user and product for valid FK references using TestDatabase methods
 		let user_id = test_db
@@ -428,7 +462,7 @@ mod relationship_validation_tests {
 			.unwrap();
 
 		// Get pool from DatabaseConnection for raw SQL queries
-		let pool = test_db.connection.inner().into_postgres().unwrap().clone();
+		let pool = test_db.pool.clone();
 
 		// Create ExistsValidator for user_id
 		let user_pool = pool.clone();
@@ -534,10 +568,16 @@ mod relationship_validation_tests {
 	#[tokio::test]
 	#[serial(validator_orm_db)]
 	async fn test_foreign_key_update_violation(
-		#[future] validator_orm_test_db: (ContainerAsync<GenericImage>, TestDatabase, u16, String),
+		#[future] validator_orm_test_db: (
+			ContainerAsync<GenericImage>,
+			DatabaseConnectionLease,
+			TestDatabase,
+			u16,
+			String,
+		),
 		_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 	) {
-		let (_container, test_db, _port, _database_url) = validator_orm_test_db.await;
+		let (_container, _lease, test_db, _port, _database_url) = validator_orm_test_db.await;
 
 		// Insert user and product
 		let user_id = test_db.insert_user("bob", "bob@example.com").await.unwrap();
@@ -551,7 +591,7 @@ mod relationship_validation_tests {
 		assert!(order_id > 0);
 
 		// Attempt to update order with non-existent user_id (should fail)
-		let pool = test_db.connection.inner().into_postgres().unwrap().clone();
+		let pool = test_db.pool.clone();
 		let update_result: Result<sqlx::postgres::PgQueryResult, sqlx::Error> =
 			sqlx::query("UPDATE test_orders SET user_id = $1 WHERE id = $2")
 				.bind(99999)
@@ -574,10 +614,16 @@ mod relationship_validation_tests {
 	#[tokio::test]
 	#[serial(validator_orm_db)]
 	async fn test_foreign_key_cascade_delete(
-		#[future] validator_orm_test_db: (ContainerAsync<GenericImage>, TestDatabase, u16, String),
+		#[future] validator_orm_test_db: (
+			ContainerAsync<GenericImage>,
+			DatabaseConnectionLease,
+			TestDatabase,
+			u16,
+			String,
+		),
 		_validator_db_guard: TeardownGuard<ValidatorDbGuard>,
 	) {
-		let (_container, test_db, _port, _database_url) = validator_orm_test_db.await;
+		let (_container, _lease, test_db, _port, _database_url) = validator_orm_test_db.await;
 
 		// Insert user and product
 		let user_id = test_db
@@ -595,7 +641,7 @@ mod relationship_validation_tests {
 
 		// Attempt to delete user (should fail because of FK constraint)
 		// Note: test_orders table does NOT have ON DELETE CASCADE
-		let pool = test_db.connection.inner().into_postgres().unwrap().clone();
+		let pool = test_db.pool.clone();
 		let delete_result: Result<sqlx::postgres::PgQueryResult, sqlx::Error> =
 			sqlx::query("DELETE FROM test_users WHERE id = $1")
 				.bind(user_id)

--- a/tests/integration/tests/validation/validator_orm_integration.rs
+++ b/tests/integration/tests/validation/validator_orm_integration.rs
@@ -353,7 +353,7 @@ mod constraint_validation_tests {
 						.bind(&value)
 					};
 
-					let result = query.fetch_one(&pool).await;
+					let result = query.fetch_one(pool.as_ref()).await;
 					result.map(|(count,)| count > 0).unwrap_or(false)
 				})
 			}),
@@ -384,7 +384,7 @@ mod constraint_validation_tests {
 			sqlx::query("INSERT INTO test_users (username, email) VALUES ($1, $2) RETURNING id")
 				.bind("alice")
 				.bind("different@example.com")
-				.fetch_one(&pool)
+				.fetch_one(pool.as_ref())
 				.await;
 		assert!(insert_result.is_err());
 
@@ -477,7 +477,7 @@ mod relationship_validation_tests {
 							"SELECT COUNT(*) FROM test_users WHERE id = $1",
 						)
 						.bind(id)
-						.fetch_one(&pool)
+						.fetch_one(pool.as_ref())
 						.await;
 						result.map(|(count,)| count > 0).unwrap_or(false)
 					} else {
@@ -500,7 +500,7 @@ mod relationship_validation_tests {
 							"SELECT COUNT(*) FROM test_products WHERE id = $1",
 						)
 						.bind(id)
-						.fetch_one(&pool)
+						.fetch_one(pool.as_ref())
 						.await;
 						result.map(|(count,)| count > 0).unwrap_or(false)
 					} else {
@@ -548,7 +548,7 @@ mod relationship_validation_tests {
 		.bind(99999) // non-existent user_id
 		.bind(product_id)
 		.bind(1)
-		.execute(&pool)
+		.execute(pool.as_ref())
 		.await;
 
 		assert!(insert_result.is_err());
@@ -596,7 +596,7 @@ mod relationship_validation_tests {
 			sqlx::query("UPDATE test_orders SET user_id = $1 WHERE id = $2")
 				.bind(99999)
 				.bind(order_id)
-				.execute(&pool)
+				.execute(pool.as_ref())
 				.await;
 
 		assert!(update_result.is_err());
@@ -645,7 +645,7 @@ mod relationship_validation_tests {
 		let delete_result: Result<sqlx::postgres::PgQueryResult, sqlx::Error> =
 			sqlx::query("DELETE FROM test_users WHERE id = $1")
 				.bind(user_id)
-				.execute(&pool)
+				.execute(pool.as_ref())
 				.await;
 
 		assert!(delete_result.is_err());


### PR DESCRIPTION
## Summary

This PR addresses:

- Replaces the public ORM `DatabaseConnection` wrapper with a generational `Copy` handle.
- Adds `DatabaseConnectionLease` for RAII-backed registry ownership and typed expired-handle errors.
- Updates `#[inject]` consumers, fixtures, transaction call sites, exports, tests, and migration documentation.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update

## Breaking Change Assessment

- [x] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Injected database connections are frequent lightweight dependencies, but the previous public wrapper required cloning an owning value. A process-wide generational registry now separates ownership from use: a lease owns registration, while injected handles are safe to copy and resolve the backend for each operation.

Fixes #5774

## How Was This Tested?

- Formatting check for all changed and newly added Rust files
- Patch whitespace validation
- Conflict-marker scan across all changed Rust files
- Static implementation review completed with no remaining findings
- Local build, lint, and test gates were unavailable because the repository security hook requires a Guardian login that is not exposed in this session. CI is expected to run these gates.

## Breaking Changes

The public ORM `DatabaseConnection` no longer exposes owning constructors or ownership accessors. Bootstrap and fixture code must retain a `DatabaseConnectionLease` and inject or copy its handle.

**Migration Guide:**

See `docs/migration/0.4.0-copy-database-connection.md`.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends
- [ ] I have formatted the code with the repository task runner
- [ ] I have checked the code with the repository lint task
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5774

## Labels to Apply

### Type Label
- [x] `enhancement`

### Additional Labels
- [x] `breaking-change`

### Scope Label
- [x] `database`
- [x] `orm`

---

**Additional Context:**

The low-level backend connection remains owning and non-`Copy`. Transactions remain non-`Copy` and preserve dedicated-connection affinity. In-flight operations hold an `Arc`, while new resolutions after lease invalidation return `ConnectionHandleExpired`.
