### PR TITLE
fix(ci): repair release-blocking doctests and UI fixture

### DIFF
--- a/crates/reinhardt-db/src/orm/engine.rs
+++ b/crates/reinhardt-db/src/orm/engine.rs
@@ -382,12 +382,11 @@ impl DatabaseEngine {
 	///
 	/// ```
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// use reinhardt_db::orm::connection::DatabaseConnection;
+	/// use reinhardt_db::backends::DatabaseType;
+	/// use reinhardt_db::orm::engine::DatabaseEngine;
 	///
-	/// // For doctest purposes, using mock connection (feature-gated methods not available)
-	/// // In production with 'postgres' feature: DatabaseEngine::from_postgres(url).await
-	/// let connection = DatabaseConnection::connect("postgres://localhost/mydb").await?;
-	/// assert_eq!(connection.backend(), reinhardt_db::orm::connection::DatabaseBackend::Postgres);
+	/// let engine = DatabaseEngine::from_postgres("postgres://localhost/mydb").await?;
+	/// assert_eq!(engine.database_type(), DatabaseType::Postgres);
 	/// # Ok(())
 	/// # }
 	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());
@@ -404,12 +403,11 @@ impl DatabaseEngine {
 	///
 	/// ```
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// use reinhardt_db::orm::connection::DatabaseConnection;
+	/// use reinhardt_db::backends::DatabaseType;
+	/// use reinhardt_db::orm::engine::DatabaseEngine;
 	///
-	/// // For doctest purposes, using mock connection (feature-gated methods not available)
-	/// // In production with 'sqlite' feature: DatabaseEngine::from_sqlite(":memory:").await
-	/// let connection = DatabaseConnection::connect(":memory:").await?;
-	/// assert_eq!(connection.backend(), reinhardt_db::orm::connection::DatabaseBackend::Postgres);
+	/// let engine = DatabaseEngine::from_sqlite("sqlite::memory:").await?;
+	/// assert_eq!(engine.database_type(), DatabaseType::Sqlite);
 	/// # Ok(())
 	/// # }
 	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());
@@ -448,21 +446,15 @@ impl DatabaseEngine {
 	///
 	/// ```no_run
 	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-	/// use reinhardt_db::orm::connection::DatabaseConnection;
+	/// use reinhardt_db::orm::engine::DatabaseEngine;
 	///
-	/// // Create mock connection (URL is ignored in current mock implementation)
-	/// let connection = DatabaseConnection::connect("sqlite::memory:").await?;
-	///
-	/// // Execute SQL statements (mock always returns 0)
-	/// let rows_affected = connection.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)", vec![]).await?;
-	/// assert_eq!(rows_affected, 0);
-	///
-	/// let rows_affected = connection.execute("INSERT INTO users (id, name) VALUES (1, 'Alice')", vec![]).await?;
-	/// assert_eq!(rows_affected, 0);
-	///
-	/// // Query returns empty vec in mock
-	/// let rows = connection.query("SELECT * FROM users", vec![]).await?;
-	/// assert_eq!(rows.len(), 0);
+	/// let engine = DatabaseEngine::from_sqlite("sqlite::memory:").await?;
+	/// engine
+	///     .execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	///     .await?;
+	/// engine
+	///     .execute("INSERT INTO users (id, name) VALUES (1, 'Alice')")
+	///     .await?;
 	/// # Ok(())
 	/// # }
 	/// # tokio::runtime::Runtime::new().unwrap().block_on(example());

--- a/crates/reinhardt-pages/tests/ui/page/fail/controlled_bind_wrong_signal.stderr
+++ b/crates/reinhardt-pages/tests/ui/page/fail/controlled_bind_wrong_signal.stderr
@@ -1,8 +1,15 @@
 error[E0308]: mismatched types
-  --> tests/ui/page/fail/controlled_bind_wrong_signal.rs:8:10
+  --> tests/ui/page/fail/controlled_bind_wrong_signal.rs:5:10
    |
+ 5 |       let _ = page!({
+   |  _____________^
+ 6 | |         input {
+ 7 | |             a11y: off,
  8 | |             bind: wrong,
-   |                   ^^^^^ expected `Signal<String>`, found `Signal<bool>`
+ 9 | |         }
+10 | |     });
+   | |______^ expected `Signal<String>`, found `Signal<bool>`
    |
    = note: expected struct `reinhardt_pages::Signal<std::string::String>`
               found struct `reinhardt_pages::Signal<bool>`
+   = note: this error originates in the macro `page` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Summary

This PR addresses:

- updates the `DatabaseEngine` doctests to use the current public engine API
- refreshes the controlled-bind trybuild diagnostic after the macro span changed
- repairs the two failing CI jobs blocking release PR #5795

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #5795 exposed stale doctests that referenced the ORM capability type instead of the backend connection API, plus a stale trybuild stderr fixture. The generated release branch must remain untouched, so these repairs target its source branch.

Related to: #5795

## How Was This Tested?

- `cargo test -p reinhardt-db --doc --all-features`
- `cargo test -p reinhardt-pages --test ui test_page_macro_fail --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Release PR #5795

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [x] `orm` - ORM layer, models, query builder
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

The full affected doctest and trybuild suites pass locally.