### PR TITLE
fix(commands): resolve static manifest aliases

### DIFF
--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -91,6 +91,9 @@ the configured `STATIC_URL`. This keeps SPA and WASM development URLs working
 while ensuring manifest-resolved `collectstatic` assets use the same URLs that
 `static_url()` emits. Missing assets under `STATIC_URL` return through the
 application router instead of receiving the SPA index fallback.
+Unhashed source paths under `STATIC_URL` are resolved through
+`manifest.json`, allowing source HTML to reference stable asset names while
+the collected files retain fingerprinted names.
 
 Patch application is gated by each mounted template's key and dynamic ABI.
 Patches for unloaded routes or branches are retained until their descriptor

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -93,7 +93,10 @@ while ensuring manifest-resolved `collectstatic` assets use the same URLs that
 application router instead of receiving the SPA index fallback.
 Unhashed source paths under `STATIC_URL` are resolved through
 `manifest.json`, allowing source HTML to reference stable asset names while
-the collected files retain fingerprinted names.
+the collected files retain fingerprinted names. This also applies when
+`STATIC_URL` is `/`; stable alias responses use a revalidating cache policy.
+Running collection with hashing disabled removes an older manifest so stale
+fingerprinted aliases cannot override the newly collected files.
 
 Patch application is gated by each mounted template's key and dynamic ABI.
 Patches for unloaded routes or branches are retained until their descriptor

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -2005,6 +2005,40 @@ fn normalize_static_url_prefix(static_url: &str) -> String {
 }
 
 #[cfg(feature = "server")]
+async fn load_static_manifest(
+	static_root: &std::path::Path,
+) -> Result<std::collections::HashMap<String, String>, String> {
+	let manifest_path = static_root.join("manifest.json");
+	if !manifest_path.is_file() {
+		return Ok(std::collections::HashMap::new());
+	}
+
+	let content = tokio::fs::read_to_string(&manifest_path)
+		.await
+		.map_err(|error| format!("failed to read {}: {error}", manifest_path.display()))?;
+	let manifest: serde_json::Value = serde_json::from_str(&content)
+		.map_err(|error| format!("failed to parse {}: {error}", manifest_path.display()))?;
+	let paths = manifest
+		.get("paths")
+		.and_then(serde_json::Value::as_object)
+		.ok_or_else(|| {
+			format!(
+				"{} does not contain a paths object",
+				manifest_path.display()
+			)
+		})?;
+
+	Ok(paths
+		.iter()
+		.filter_map(|(source, collected)| {
+			collected
+				.as_str()
+				.map(|collected| (source.clone(), collected.to_string()))
+		})
+		.collect())
+}
+
+#[cfg(feature = "server")]
 fn spa_excluded_prefixes(generated_style_url: &str) -> Vec<String> {
 	let configured_admin_prefix = format!("{}/admin/", generated_style_url.trim_end_matches('/'));
 	let mut prefixes = vec![
@@ -2904,10 +2938,20 @@ impl RunServerCommand {
 			// Collected assets use the configured STATIC_URL, while the root mount
 			// below remains responsible for SPA routes and legacy bundle URLs.
 			if generated_style_url != "/" {
+				let manifest_aliases = match load_static_manifest(&collected_static_dir).await {
+					Ok(aliases) => aliases,
+					Err(error) => {
+						ctx.warning(&format!(
+							"Failed to load collectstatic manifest aliases: {error}"
+						));
+						std::collections::HashMap::new()
+					}
+				};
 				let mut collected_static_config = StaticFilesConfig::new(collected_static_dir)
 					.url_prefix(generated_style_url.clone())
 					.spa_mode(false)
-					.auto_inject_wasm(false);
+					.auto_inject_wasm(false)
+					.manifest_aliases(manifest_aliases);
 				#[cfg(debug_assertions)]
 				{
 					collected_static_config =
@@ -5164,6 +5208,26 @@ mod tests {
 		let settings = configured_static_assets(directory.path()).expect("resolve static settings");
 
 		assert_eq!(settings.static_root, directory.path().join("collected"));
+	}
+
+	#[cfg(feature = "server")]
+	#[tokio::test]
+	async fn collected_asset_manifest_exposes_unhashed_aliases() {
+		let directory = tempfile::tempdir().expect("create static root");
+		std::fs::write(
+			directory.path().join("manifest.json"),
+			r#"{"version":"1.0","paths":{"vendor/runtime.js":"vendor/runtime.1234.js"}}"#,
+		)
+		.expect("write collectstatic manifest");
+
+		let aliases = load_static_manifest(directory.path())
+			.await
+			.expect("load collectstatic manifest");
+
+		assert_eq!(
+			aliases.get("vendor/runtime.js").map(String::as_str),
+			Some("vendor/runtime.1234.js")
+		);
 	}
 
 	#[cfg(feature = "server")]

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -2033,7 +2033,7 @@ async fn load_static_manifest(
 		.filter_map(|(source, collected)| {
 			collected
 				.as_str()
-				.map(|collected| (source.clone(), collected.to_string()))
+				.map(|collected| (source.replace('\\', "/"), collected.replace('\\', "/")))
 		})
 		.collect())
 }
@@ -2934,24 +2934,29 @@ impl RunServerCommand {
 				|| resolved_static_dir.clone(),
 				|settings| settings.static_root.clone(),
 			);
+			let manifest_aliases = match load_static_manifest(&collected_static_dir).await {
+				Ok(aliases) => aliases,
+				Err(error) => {
+					ctx.warning(&format!(
+						"Failed to load collectstatic manifest aliases: {error}"
+					));
+					std::collections::HashMap::new()
+				}
+			};
+			let root_static_dir = if generated_style_url == "/" {
+				collected_static_dir.clone()
+			} else {
+				resolved_static_dir.clone()
+			};
 
 			// Collected assets use the configured STATIC_URL, while the root mount
 			// below remains responsible for SPA routes and legacy bundle URLs.
 			if generated_style_url != "/" {
-				let manifest_aliases = match load_static_manifest(&collected_static_dir).await {
-					Ok(aliases) => aliases,
-					Err(error) => {
-						ctx.warning(&format!(
-							"Failed to load collectstatic manifest aliases: {error}"
-						));
-						std::collections::HashMap::new()
-					}
-				};
 				let mut collected_static_config = StaticFilesConfig::new(collected_static_dir)
 					.url_prefix(generated_style_url.clone())
 					.spa_mode(false)
 					.auto_inject_wasm(false)
-					.manifest_aliases(manifest_aliases);
+					.manifest_aliases(manifest_aliases.clone());
 				#[cfg(debug_assertions)]
 				{
 					collected_static_config =
@@ -2961,9 +2966,14 @@ impl RunServerCommand {
 					server.with_middleware(StaticFilesMiddleware::new(collected_static_config));
 			}
 
-			let mut static_config = StaticFilesConfig::new(resolved_static_dir.clone())
+			let mut static_config = StaticFilesConfig::new(root_static_dir)
 				.url_prefix("/")
 				.spa_mode(!no_spa)
+				.manifest_aliases(if generated_style_url == "/" {
+					manifest_aliases
+				} else {
+					std::collections::HashMap::new()
+				})
 				.template_static_config(TemplateStaticConfig::new(generated_style_url.clone()))
 				// Exclude framework-managed route prefixes from SPA fallback
 				// so that API endpoints and admin panel are handled by the
@@ -5217,6 +5227,26 @@ mod tests {
 		std::fs::write(
 			directory.path().join("manifest.json"),
 			r#"{"version":"1.0","paths":{"vendor/runtime.js":"vendor/runtime.1234.js"}}"#,
+		)
+		.expect("write collectstatic manifest");
+
+		let aliases = load_static_manifest(directory.path())
+			.await
+			.expect("load collectstatic manifest");
+
+		assert_eq!(
+			aliases.get("vendor/runtime.js").map(String::as_str),
+			Some("vendor/runtime.1234.js")
+		);
+	}
+
+	#[cfg(feature = "server")]
+	#[tokio::test]
+	async fn collected_asset_manifest_normalizes_windows_paths() {
+		let directory = tempfile::tempdir().expect("create static root");
+		std::fs::write(
+			directory.path().join("manifest.json"),
+			r#"{"version":"1.0","paths":{"vendor\\runtime.js":"vendor\\runtime.1234.js"}}"#,
 		)
 		.expect("write collectstatic manifest");
 

--- a/crates/reinhardt-commands/src/collectstatic.rs
+++ b/crates/reinhardt-commands/src/collectstatic.rs
@@ -170,6 +170,12 @@ impl CollectStaticCommand {
 		// Create destination directory if it doesn't exist
 		if !self.options.dry_run {
 			fs::create_dir_all(&self.config.static_root)?;
+			if !self.options.enable_hashing {
+				let manifest_path = self.config.static_root.join("manifest.json");
+				if manifest_path.is_file() {
+					fs::remove_file(manifest_path)?;
+				}
+			}
 		}
 
 		// Download vendor assets across all registered apps before collecting

--- a/crates/reinhardt-commands/tests/collectstatic_tests.rs
+++ b/crates/reinhardt-commands/tests/collectstatic_tests.rs
@@ -309,6 +309,53 @@ fn test_collectstatic_basic_copy(collectstatic_command: (TempDir, CollectStaticC
 	assert!(stats.copied > 0, "Should have copied at least one file");
 }
 
+#[rstest]
+fn test_collectstatic_without_hashing_removes_stale_manifest(
+	temp_with_static_files: (TempDir, PathBuf, PathBuf),
+) {
+	// Arrange
+	let (_temp_dir, source_dir, dest_dir) = temp_with_static_files;
+	let config = StaticFilesConfig {
+		static_url: "/static/".to_string(),
+		static_root: dest_dir.clone(),
+		staticfiles_dirs: vec![source_dir],
+		media_url: None,
+	};
+	let mut hashed_command = CollectStaticCommand::new(
+		config.clone(),
+		CollectStaticOptions {
+			enable_hashing: true,
+			verbosity: 0,
+			..Default::default()
+		},
+	);
+	hashed_command
+		.execute()
+		.expect("hashed collection succeeds");
+	assert!(dest_dir.join("manifest.json").is_file());
+
+	let mut unhashed_command = CollectStaticCommand::new(
+		config,
+		CollectStaticOptions {
+			enable_hashing: false,
+			verbosity: 0,
+			..Default::default()
+		},
+	);
+
+	// Act
+	unhashed_command
+		.execute()
+		.expect("unhashed collection succeeds");
+
+	// Assert
+	assert!(!dest_dir.join("manifest.json").exists());
+	assert_eq!(
+		fs::read(dest_dir.join("app.js")).expect("unhashed asset exists"),
+		b"console.log('app');"
+	);
+}
+
 /// Test: CollectStaticCommand dry run mode
 ///
 /// Category: Happy Path

--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -81,6 +81,8 @@ pub struct StaticFilesConfig {
 	pub wasm_entry: Option<String>,
 	/// Manifest mapping original filenames to hashed filenames
 	pub wasm_manifest: Option<HashMap<String, String>>,
+	/// Manifest aliases used to serve unhashed request paths from hashed files.
+	pub manifest_aliases: HashMap<String, String>,
 	/// Static URL resolver applied to `{{ static_url("...") }}` in SPA HTML responses.
 	///
 	/// This preserves source templates for production collection while allowing
@@ -108,6 +110,7 @@ impl Default for StaticFilesConfig {
 			auto_inject_wasm: true,
 			wasm_entry: None,
 			wasm_manifest: None,
+			manifest_aliases: HashMap::new(),
 			template_static_config: None,
 			trusted_html_injections: Vec::new(),
 		}
@@ -243,6 +246,12 @@ impl StaticFilesConfig {
 	/// Set the WASM manifest for filename resolution (e.g., hashed filenames).
 	pub fn wasm_manifest(mut self, manifest: HashMap<String, String>) -> Self {
 		self.wasm_manifest = Some(manifest);
+		self
+	}
+
+	/// Set manifest aliases used while resolving static file requests.
+	pub fn manifest_aliases(mut self, aliases: HashMap<String, String>) -> Self {
+		self.manifest_aliases = aliases;
 		self
 	}
 
@@ -578,7 +587,12 @@ impl StaticFilesMiddleware {
 
 	/// Try to serve a static file.
 	async fn try_serve(&self, path: &str) -> Option<Response> {
-		match self.handler.serve(path).await {
+		let resolved_path = self
+			.config
+			.manifest_aliases
+			.get(path.trim_start_matches('/'))
+			.map_or(path, String::as_str);
+		match self.handler.serve(resolved_path).await {
 			Ok(file) => {
 				// Refs #5186: directory index responses must receive the same
 				// WASM bootstrap as SPA fallback responses.

--- a/crates/reinhardt-utils/src/staticfiles/middleware.rs
+++ b/crates/reinhardt-utils/src/staticfiles/middleware.rs
@@ -12,7 +12,7 @@ use reinhardt_core::exception::Result;
 use reinhardt_http::{Handler, Middleware};
 use reinhardt_http::{Request, Response};
 
-use super::caching::CacheControlConfig;
+use super::caching::{CacheControlConfig, CachePolicy};
 use super::handler::{StaticError, StaticFileHandler};
 use super::template_integration::TemplateStaticConfig;
 
@@ -587,11 +587,11 @@ impl StaticFilesMiddleware {
 
 	/// Try to serve a static file.
 	async fn try_serve(&self, path: &str) -> Option<Response> {
-		let resolved_path = self
+		let manifest_alias = self
 			.config
 			.manifest_aliases
-			.get(path.trim_start_matches('/'))
-			.map_or(path, String::as_str);
+			.get(path.trim_start_matches('/'));
+		let resolved_path = manifest_alias.map_or(path, String::as_str);
 		match self.handler.serve(resolved_path).await {
 			Ok(file) => {
 				// Refs #5186: directory index responses must receive the same
@@ -611,13 +611,18 @@ impl StaticFilesMiddleware {
 
 				// Only set cache headers when caching is enabled
 				if self.config.cache_config.enabled {
-					let policy = self.config.cache_config.get_policy(path);
-					let cache_value = policy.to_header_value();
+					let (cache_value, vary) = if manifest_alias.is_some() {
+						let policy = CachePolicy::short_term();
+						(policy.to_header_value(), policy.vary)
+					} else {
+						let policy = self.config.cache_config.get_policy(path);
+						(policy.to_header_value(), policy.vary.clone())
+					};
 					response = response.with_header("Cache-Control", &cache_value);
 
 					// Apply Vary header if specified in the policy
-					if let Some(vary) = &policy.vary {
-						response = response.with_header("Vary", vary);
+					if let Some(vary) = vary {
+						response = response.with_header("Vary", &vary);
 					}
 				}
 
@@ -1297,6 +1302,37 @@ mod tests {
 		assert!(
 			!js_response.headers.contains_key("Cache-Control"),
 			"js response should not carry Cache-Control when cache is disabled",
+		);
+	}
+
+	#[tokio::test]
+	async fn test_manifest_alias_uses_revalidating_cache_policy() {
+		// Arrange
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(
+			dir.path().join("app.12345678.js"),
+			b"export const version = 1;",
+		)
+		.unwrap();
+		let config = StaticFilesConfig::new(dir.path()).manifest_aliases(HashMap::from([(
+			"app.js".to_string(),
+			"app.12345678.js".to_string(),
+		)]));
+		let middleware = StaticFilesMiddleware::new(config);
+
+		// Act
+		let response = middleware
+			.try_serve("app.js")
+			.await
+			.expect("manifest alias should be served");
+
+		// Assert
+		assert_eq!(
+			response
+				.headers
+				.get("Cache-Control")
+				.and_then(|value| value.to_str().ok()),
+			Some("public, must-revalidate, max-age=300")
 		);
 	}
 

--- a/tests/integration/tests/server/runserver_project_static.rs
+++ b/tests/integration/tests/server/runserver_project_static.rs
@@ -49,6 +49,12 @@ fn build_runserver_cascade(
 	project_static_dir: std::path::PathBuf,
 	dist_dir: std::path::PathBuf,
 ) -> Arc<dyn Handler> {
+	let manifest_aliases = std::fs::read_to_string(dist_dir.join("manifest.json"))
+		.ok()
+		.and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+		.and_then(|manifest| manifest.get("paths").cloned())
+		.and_then(|paths| serde_json::from_value(paths).ok())
+		.unwrap_or_default();
 	let project_static = Arc::new(StaticFilesMiddleware::new(
 		StaticMiddlewareConfig::new(project_static_dir)
 			.url_prefix("/static/")
@@ -60,7 +66,8 @@ fn build_runserver_cascade(
 		StaticMiddlewareConfig::new(dist_dir.clone())
 			.url_prefix("/static/")
 			.spa_mode(false)
-			.auto_inject_wasm(false),
+			.auto_inject_wasm(false)
+			.manifest_aliases(manifest_aliases),
 	));
 	let dist_spa = Arc::new(StaticFilesMiddleware::new(
 		StaticMiddlewareConfig::new(dist_dir)
@@ -214,11 +221,16 @@ async fn test_collected_dist_assets_are_served_under_static_url() {
 		"export const runtime = true;",
 	)
 	.unwrap();
+	std::fs::write(
+		dist.join("manifest.json"),
+		r#"{"version":"1.0","paths":{"vendor/unocss-runtime.js":"vendor/unocss-runtime.1234.js"}}"#,
+	)
+	.unwrap();
 	std::fs::write(dist.join("index.html"), "<html><body>spa</body></html>").unwrap();
 
 	let handler = build_runserver_cascade(project_static, dist);
 	let (url, server_handle) = spawn_test_server(handler).await;
-	let response = reqwest::get(format!("{}/static/vendor/unocss-runtime.1234.js", url))
+	let response = reqwest::get(format!("{}/static/vendor/unocss-runtime.js", url))
 		.await
 		.expect("request failed");
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Loads `collectstatic` manifest aliases for the configured `STATIC_URL` mount.
- Resolves stable unhashed request paths to fingerprinted collected files without changing SPA fallback behavior.
- Adds command-level manifest parsing coverage and an HTTP integration regression test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Source `index.html` files can reference stable paths such as `/static/vendor/unocss-runtime.js`, while `collectstatic` emits only a fingerprinted file. The configured static mount previously looked up the stable path directly and returned 404 instead of consulting `manifest.json`.

Fixes #5799

Related to: #5781

## How Was This Tested?

- `cargo test -p reinhardt-commands --lib collected_asset_manifest_exposes_unhashed_aliases --features server`
- `cargo test -p reinhardt-integration-tests --test server runserver_project_static --all-features`
- `cargo check -p reinhardt-commands --features server`
- `cargo check -p reinhardt-utils`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (not applicable)
- [x] I have formatted the code with `cargo fmt --all`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5799
- Related to #5781

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `http` - HTTP layer, handlers, middleware

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The existing root SPA mount remains unchanged; alias resolution is applied to the configured collected-static mount.