### PR TITLE
feat(macros): pass raw requests alongside extractors

### DIFF
--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -135,6 +135,26 @@ Provides compile-time code generation for common patterns.
     }
     ```
 
+  A raw `Request` can be combined with typed extractors when a handler needs
+  direct access to headers or other request metadata:
+
+  ```rust
+  use reinhardt::extractors::Path;
+  use reinhardt::http::{Request, Response, ViewResult};
+  use reinhardt::views::get;
+  use uuid::Uuid;
+
+  #[get("/books/import/{job_id}")]
+  async fn get_job(
+      req: Request,
+      Path(job_id): Path<Uuid>,
+  ) -> ViewResult<Response> {
+      let cookie = req.get_header("cookie");
+      // Use `cookie` and `job_id` to authorize and load the import job.
+      Ok(Response::ok())
+  }
+  ```
+
   Injected parameters may use mutable bindings and destructuring patterns:
 
   ```rust,ignore

--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -139,9 +139,7 @@ Provides compile-time code generation for common patterns.
   direct access to headers or other request metadata:
 
   ```rust
-  use reinhardt::extractors::Path;
-  use reinhardt::http::{Request, Response, ViewResult};
-  use reinhardt::views::get;
+  use reinhardt::{get, Path, Request, Response, ViewResult};
   use uuid::Uuid;
 
   #[get("/books/import/{job_id}")]

--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -108,6 +108,19 @@ fn detect_extractors(inputs: &Punctuated<FnArg, Token![,]>) -> Vec<ExtractorInfo
 	extractors
 }
 
+/// Check whether a type is a raw HTTP `Request`.
+fn is_request_type(ty: &Type) -> bool {
+	let Type::Path(type_path) = ty else {
+		return false;
+	};
+
+	type_path
+		.path
+		.segments
+		.last()
+		.is_some_and(|segment| segment.ident == "Request" && segment.arguments.is_none())
+}
+
 /// Extract request body information from function parameters
 ///
 /// Detects body-consuming extractors (Json<T>, Form<T>, Body<T>) and extracts:
@@ -539,6 +552,8 @@ fn generate_wrapper_with_both(
 					.expect("each injected argument must have detected metadata")
 					.resolved_ident;
 				Some(quote! { #ident })
+			} else if is_request_type(&pat_type.ty) {
+				Some(quote! { req })
 			} else {
 				let pat = extractor_args
 					.next()
@@ -1377,6 +1392,26 @@ mod url_resolver_tests {
 		);
 		let generated = wrapper.to_string();
 		assert!(generated.contains("handler_original (Json (first) , __reinhardt_injected_0 , Query (last) , __reinhardt_injected_1)"), "{generated}");
+	}
+
+	#[test]
+	fn route_call_passes_raw_request_with_extractors_in_original_order() {
+		let input: ItemFn = syn::parse_quote! {
+			async fn handler(req: reinhardt_http::Request, Path(id): Path<String>, Json(body): Json<Payload>) -> String { String::new() }
+		};
+		let extractors = detect_extractors(&input.sig.inputs);
+		let inject_params = detect_inject_params(&input.sig.inputs);
+		let (_, wrapper) = generate_wrapper_with_both(
+			&input,
+			&extractors,
+			&inject_params,
+			&RouteOptions::default(),
+		);
+		let generated = wrapper.to_string();
+		assert!(
+			generated.contains("handler_original (req , Path (id) , Json (body))"),
+			"{generated}"
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -446,11 +446,11 @@ fn generate_wrapper_with_both(
 	// Generate DI context extraction
 	let di_context_extraction = if !inject_params.is_empty() {
 		quote! {
-			let __shared_ctx = req.get_di_context::<::std::sync::Arc<#di_crate::InjectionContext>>()
+			let __shared_ctx = __reinhardt_request.get_di_context::<::std::sync::Arc<#di_crate::InjectionContext>>()
 				.ok_or_else(|| #core_crate::exception::Error::Internal(
 					"DI context not set. Ensure the router is configured with .with_di_context()".to_string()
 				))?;
-			let __di_request = req.clone_for_di();
+			let __di_request = __reinhardt_request.clone_for_di();
 			let __di_ctx = ::std::sync::Arc::new((*__shared_ctx).fork_for_request(__di_request));
 			let __resolve_ctx = #di_crate::resolve_context::ResolveContext {
 				root: ::std::sync::Arc::clone(&__shared_ctx),
@@ -507,7 +507,7 @@ fn generate_wrapper_with_both(
 				// reach the response, instead of being flattened into 400 via
 				// `Error::Validation`. See #4446.
 				quote! {
-					let #temp = <#ty as #params_crate::FromRequest>::from_request(&req, &ctx)
+					let #temp = <#ty as #params_crate::FromRequest>::from_request(&__reinhardt_request, &ctx)
 						.await
 						.map_err(#core_crate::exception::Error::from)?;
 				}
@@ -555,7 +555,7 @@ fn generate_wrapper_with_both(
 				let pat = &ext.pat;
 				let ty = &ext.ty;
 				quote! {
-					let #pat = <#ty as #params_crate::FromRequest>::from_request(&req, &ctx)
+					let #pat = <#ty as #params_crate::FromRequest>::from_request(&__reinhardt_request, &ctx)
 						.await
 						.map_err(#core_crate::exception::Error::from)?;
 				}
@@ -584,7 +584,7 @@ fn generate_wrapper_with_both(
 					.resolved_ident;
 				Some(quote! { #ident })
 			} else if is_raw_request_parameter(pat_type) {
-				Some(quote! { req })
+				Some(quote! { __reinhardt_request })
 			} else {
 				let pat = extractor_args
 					.next()
@@ -634,7 +634,7 @@ fn generate_wrapper_with_both(
 		},
 		quote! {
 			// Build ParamContext for extractors
-			let ctx = #params_crate::ParamContext::with_path_params(req.path_params.clone());
+		let ctx = #params_crate::ParamContext::with_path_params(__reinhardt_request.path_params.clone());
 
 			// Extract DI context (if needed)
 			#di_context_extraction
@@ -758,15 +758,15 @@ fn generate_view_type(
 
 		#[#async_trait_crate::async_trait]
 		impl #http_crate::Handler for #view_type_name {
-			async fn handle(&self, req: #http_crate::Request) -> #http_crate::Result<#http_crate::Response> {
-				#view_type_name::#fn_name(req).await
+			async fn handle(&self, __reinhardt_request: #http_crate::Request) -> #http_crate::Result<#http_crate::Response> {
+				#view_type_name::#fn_name(__reinhardt_request).await
 			}
 		}
 
 		impl #view_type_name {
 			/// Handler function for this view
 			#(#fn_attrs)*
-			#fn_vis #asyncness fn #fn_name(req: #http_crate::Request) #output {
+			#fn_vis #asyncness fn #fn_name(__reinhardt_request: #http_crate::Request) #output {
 				#wrapper_body
 			}
 		}

--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -85,16 +85,7 @@ fn detect_extractors(inputs: &Punctuated<FnArg, Token![,]>) -> Vec<ExtractorInfo
 				&& let Some(segment) = type_path.path.segments.last()
 			{
 				let type_name = segment.ident.to_string();
-				if matches!(
-					type_name.as_str(),
-					"Path"
-						| "Json" | "Query" | "Header"
-						| "Cookie" | "Form"
-						| "Body" | "HeaderNamed"
-						| "CookieNamed" | "CookieStruct"
-						| "SessionValue" | "OptionalSessionValue"
-						| "SessionValueNamed"
-				) {
+				if is_extractor_type_name(&type_name) {
 					extractors.push(ExtractorInfo {
 						pat: pat_type.pat.clone(),
 						ty: pat_type.ty.clone(),
@@ -108,6 +99,23 @@ fn detect_extractors(inputs: &Punctuated<FnArg, Token![,]>) -> Vec<ExtractorInfo
 	extractors
 }
 
+fn is_extractor_type_name(type_name: &str) -> bool {
+	matches!(
+		type_name,
+		"Path"
+			| "Json" | "Query"
+			| "Header"
+			| "Cookie"
+			| "Form" | "Body"
+			| "HeaderNamed"
+			| "CookieNamed"
+			| "CookieStruct"
+			| "SessionValue"
+			| "OptionalSessionValue"
+			| "SessionValueNamed"
+	)
+}
+
 /// Check whether a type is a raw HTTP `Request`.
 fn is_request_type(ty: &Type) -> bool {
 	let Type::Path(type_path) = ty else {
@@ -119,6 +127,29 @@ fn is_request_type(ty: &Type) -> bool {
 		.segments
 		.last()
 		.is_some_and(|segment| segment.ident == "Request" && segment.arguments.is_none())
+}
+
+/// A non-injected parameter that is not a framework extractor is the raw request.
+///
+/// Type aliases are resolved by the Rust compiler after macro expansion, so aliases
+/// of `Request` cannot be recognized by their syntactic final identifier here.
+fn is_raw_request_parameter(pat_type: &syn::PatType) -> bool {
+	if pat_type.attrs.iter().any(is_inject_attr) {
+		return false;
+	}
+
+	if is_request_type(&pat_type.ty) {
+		return true;
+	}
+
+	match &*pat_type.ty {
+		Type::Path(type_path) => type_path
+			.path
+			.segments
+			.last()
+			.is_none_or(|segment| !is_extractor_type_name(&segment.ident.to_string())),
+		_ => true,
+	}
 }
 
 /// Extract request body information from function parameters
@@ -552,7 +583,7 @@ fn generate_wrapper_with_both(
 					.expect("each injected argument must have detected metadata")
 					.resolved_ident;
 				Some(quote! { #ident })
-			} else if is_request_type(&pat_type.ty) {
+			} else if is_raw_request_parameter(pat_type) {
 				Some(quote! { req })
 			} else {
 				let pat = extractor_args
@@ -1397,7 +1428,7 @@ mod url_resolver_tests {
 	#[test]
 	fn route_call_passes_raw_request_with_extractors_in_original_order() {
 		let input: ItemFn = syn::parse_quote! {
-			async fn handler(req: reinhardt_http::Request, Path(id): Path<String>, Json(body): Json<Payload>) -> String { String::new() }
+			async fn handler(request: HttpRequest, Path(id): Path<String>, Json(body): Json<Payload>) -> String { String::new() }
 		};
 		let extractors = detect_extractors(&input.sig.inputs);
 		let inject_params = detect_inject_params(&input.sig.inputs);

--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -418,6 +418,7 @@ fn generate_wrapper_with_both(
 
 	let fn_name = &original_fn.sig.ident;
 	let original_fn_name = quote::format_ident!("{}_original", fn_name);
+	let request_ident = Ident::new("__reinhardt_request", Span::mixed_site());
 	let fn_attrs: Vec<_> = original_fn
 		.attrs
 		.iter()
@@ -446,11 +447,11 @@ fn generate_wrapper_with_both(
 	// Generate DI context extraction
 	let di_context_extraction = if !inject_params.is_empty() {
 		quote! {
-			let __shared_ctx = __reinhardt_request.get_di_context::<::std::sync::Arc<#di_crate::InjectionContext>>()
+			let __shared_ctx = #request_ident.get_di_context::<::std::sync::Arc<#di_crate::InjectionContext>>()
 				.ok_or_else(|| #core_crate::exception::Error::Internal(
 					"DI context not set. Ensure the router is configured with .with_di_context()".to_string()
 				))?;
-			let __di_request = __reinhardt_request.clone_for_di();
+			let __di_request = #request_ident.clone_for_di();
 			let __di_ctx = ::std::sync::Arc::new((*__shared_ctx).fork_for_request(__di_request));
 			let __resolve_ctx = #di_crate::resolve_context::ResolveContext {
 				root: ::std::sync::Arc::clone(&__shared_ctx),
@@ -507,7 +508,7 @@ fn generate_wrapper_with_both(
 				// reach the response, instead of being flattened into 400 via
 				// `Error::Validation`. See #4446.
 				quote! {
-					let #temp = <#ty as #params_crate::FromRequest>::from_request(&__reinhardt_request, &ctx)
+					let #temp = <#ty as #params_crate::FromRequest>::from_request(&#request_ident, &ctx)
 						.await
 						.map_err(#core_crate::exception::Error::from)?;
 				}
@@ -555,7 +556,7 @@ fn generate_wrapper_with_both(
 				let pat = &ext.pat;
 				let ty = &ext.ty;
 				quote! {
-					let #pat = <#ty as #params_crate::FromRequest>::from_request(&__reinhardt_request, &ctx)
+					let #pat = <#ty as #params_crate::FromRequest>::from_request(&#request_ident, &ctx)
 						.await
 						.map_err(#core_crate::exception::Error::from)?;
 				}
@@ -584,7 +585,7 @@ fn generate_wrapper_with_both(
 					.resolved_ident;
 				Some(quote! { #ident })
 			} else if is_raw_request_parameter(pat_type) {
-				Some(quote! { __reinhardt_request })
+				Some(quote! { #request_ident })
 			} else {
 				let pat = extractor_args
 					.next()
@@ -634,7 +635,7 @@ fn generate_wrapper_with_both(
 		},
 		quote! {
 			// Build ParamContext for extractors
-		let ctx = #params_crate::ParamContext::with_path_params(__reinhardt_request.path_params.clone());
+		let ctx = #params_crate::ParamContext::with_path_params(#request_ident.path_params.clone());
 
 			// Extract DI context (if needed)
 			#di_context_extraction
@@ -758,15 +759,15 @@ fn generate_view_type(
 
 		#[#async_trait_crate::async_trait]
 		impl #http_crate::Handler for #view_type_name {
-			async fn handle(&self, __reinhardt_request: #http_crate::Request) -> #http_crate::Result<#http_crate::Response> {
-				#view_type_name::#fn_name(__reinhardt_request).await
+			async fn handle(&self, #request_ident: #http_crate::Request) -> #http_crate::Result<#http_crate::Response> {
+				#view_type_name::#fn_name(#request_ident).await
 			}
 		}
 
 		impl #view_type_name {
 			/// Handler function for this view
 			#(#fn_attrs)*
-			#fn_vis #asyncness fn #fn_name(__reinhardt_request: #http_crate::Request) #output {
+			#fn_vis #asyncness fn #fn_name(#request_ident: #http_crate::Request) #output {
 				#wrapper_body
 			}
 		}
@@ -1440,7 +1441,7 @@ mod url_resolver_tests {
 		);
 		let generated = wrapper.to_string();
 		assert!(
-			generated.contains("handler_original (req , Path (id) , Json (body))"),
+			generated.contains("handler_original (__reinhardt_request , Path (id) , Json (body))"),
 			"{generated}"
 		);
 	}

--- a/crates/reinhardt-core/macros/src/routes.rs
+++ b/crates/reinhardt-core/macros/src/routes.rs
@@ -418,7 +418,7 @@ fn generate_wrapper_with_both(
 
 	let fn_name = &original_fn.sig.ident;
 	let original_fn_name = quote::format_ident!("{}_original", fn_name);
-	let request_ident = Ident::new("__reinhardt_request", Span::mixed_site());
+	let request_ident = syn::Ident::new("__reinhardt_request", Span::mixed_site());
 	let fn_attrs: Vec<_> = original_fn
 		.attrs
 		.iter()
@@ -661,6 +661,7 @@ fn generate_view_type(
 	let async_trait_crate = get_async_trait_crate();
 
 	let fn_name = &input.sig.ident;
+	let request_ident = syn::Ident::new("__reinhardt_request", Span::mixed_site());
 	let fn_vis = &input.vis;
 	let fn_attrs: Vec<_> = input
 		.attrs

--- a/tests/integration/tests/routing.rs
+++ b/tests/integration/tests/routing.rs
@@ -7,6 +7,9 @@ mod nested_router_integration;
 #[path = "routing/router_include_integration.rs"]
 mod router_include_integration;
 
+#[path = "routing/raw_request_extractors_integration.rs"]
+mod raw_request_extractors_integration;
+
 #[path = "routing/router_viewset_integration.rs"]
 mod router_viewset_integration;
 

--- a/tests/integration/tests/routing/raw_request_extractors_integration.rs
+++ b/tests/integration/tests/routing/raw_request_extractors_integration.rs
@@ -1,0 +1,74 @@
+//! Raw request and typed extractor route integration tests.
+
+use bytes::Bytes;
+use hyper::{Method, header};
+use reinhardt_di::params::{Json, Path};
+use reinhardt_http::{Handler, Request, Response, ViewResult};
+use reinhardt_macros::{get, post};
+use reinhardt_urls::routers::ServerRouter;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ImportRequest {
+	title: String,
+}
+
+#[get("/books/import/{job_id}", name = "raw-request-with-path")]
+async fn get_import_job(req: Request, Path(job_id): Path<String>) -> ViewResult<Response> {
+	let cookie = req.get_header("cookie").unwrap_or_default();
+	Ok(Response::ok().with_body(format!("{job_id}:{cookie}")))
+}
+
+#[post("/books/import", name = "raw-request-with-json")]
+async fn create_import_job(
+	Json(payload): Json<ImportRequest>,
+	req: Request,
+) -> ViewResult<Response> {
+	let content_type = req.get_header("content-type").unwrap_or_default();
+	Ok(Response::ok().with_body(format!("{}:{content_type}", payload.title)))
+}
+
+#[tokio::test]
+async fn raw_request_can_be_combined_with_path_extractor() {
+	let router = ServerRouter::new().endpoint(get_import_job);
+	let request = Request::builder()
+		.method(Method::GET)
+		.uri("/books/import/job-42")
+		.header(header::COOKIE, "session=abc123")
+		.build()
+		.expect("request should be valid");
+
+	let response = router
+		.handle(request)
+		.await
+		.expect("request should dispatch");
+
+	assert_eq!(response.body, Bytes::from_static(b"job-42:session=abc123"));
+}
+
+#[tokio::test]
+async fn raw_request_can_follow_json_extractor() {
+	let router = ServerRouter::new().endpoint(create_import_job);
+	let payload = ImportRequest {
+		title: "Rust Patterns".to_string(),
+	};
+	let request = Request::builder()
+		.method(Method::POST)
+		.uri("/books/import")
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(Bytes::from(
+			serde_json::to_vec(&payload).expect("payload should serialize"),
+		))
+		.build()
+		.expect("request should be valid");
+
+	let response = router
+		.handle(request)
+		.await
+		.expect("request should dispatch");
+
+	assert_eq!(
+		response.body,
+		Bytes::from_static(b"Rust Patterns:application/json")
+	);
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Pass raw `Request` parameters through route macro extractor wrappers.
- Preserve the declared argument order when raw requests, typed extractors, and injected values are mixed.
- Add runtime coverage for `Request` with `Path` and `Json`, plus usage documentation.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Route macros previously classified only known typed extractors. When a handler mixed a raw `Request` with `Path`, `Json`, or another extractor, wrapper generation treated the raw request as missing extractor metadata and could not produce a valid handler. Raw requests are now explicit pass-through arguments after extraction completes.

Fixes #5816

Related to: #

## How Was This Tested?

- `cargo test -p reinhardt-macros --lib` (221 passed)
- `cargo test -p reinhardt-integration-tests --test routing raw_request_can -- --nocapture --test-threads=1` (2 passed)
- `cargo make fmt-check`
- `cargo make clippy-check`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p reinhardt-macros --no-deps`
- `git diff --check`

## Performance Impact

No material performance impact. The change only affects proc-macro code generation.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5816

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [x] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The raw request is moved into the original handler only after all typed extractors have borrowed it, so body-consuming extractor validation and existing DI behavior remain unchanged.