### PR TITLE
fix(auth): use injected connection for session reads

### DIFF
--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -147,7 +147,7 @@ testcontainers-modules = { workspace = true }
 tempfile = { workspace = true }
 filetime = "0.2"
 reinhardt-query = { workspace = true }
-reinhardt-db = {workspace = true, features = ["orm"]}
+reinhardt-db = { workspace = true, features = ["orm", "sqlite"] }
 reinhardt-macros = { workspace = true }
 wiremock = "0.6"
 rsa = { version = "0.9", features = ["sha2"] }

--- a/crates/reinhardt-auth/README.md
+++ b/crates/reinhardt-auth/README.md
@@ -853,6 +853,7 @@ impl AuthBackend for MyAuthBackend {
 #### Storage Backends
 
 - **DatabaseSessionBackend** (feature: `database`) - Persistent session storage in database
+  - Uses the connection supplied to `from_connection()` for load, save, delete, and existence checks
   - Session model with expiration timestamps
   - Automatic session cleanup with `cleanup_expired()`
   - SQLite, PostgreSQL, and MySQL support via sqlx

--- a/crates/reinhardt-auth/src/sessions/backends/database.rs
+++ b/crates/reinhardt-auth/src/sessions/backends/database.rs
@@ -188,6 +188,10 @@ impl DatabaseSessionBackend {
 
 	/// Create a new backend from an existing database connection
 	///
+	/// Session loads, saves, deletions, and existence checks all use the
+	/// injected connection. The global ORM connection does not need to be
+	/// initialized.
+	///
 	/// # Examples
 	///
 	/// ```rust,no_run
@@ -355,17 +359,18 @@ impl SessionBackend for DatabaseSessionBackend {
 	where
 		T: for<'de> Deserialize<'de> + Send,
 	{
-		// Use ORM to load session
+		let mut connection = self.connection;
+
+		// Use ORM to load the session through the backend's injected connection.
 		let session = Session::objects()
 			.filter(Filter::new(
 				"session_key".to_string(),
 				FilterOperator::Eq,
 				FilterValue::String(session_key.to_string()),
 			))
-			.first()
+			.first_with_db(&mut connection)
 			.await
-			.ok()
-			.flatten();
+			.map_err(|e| SessionError::CacheError(format!("Failed to load session: {}", e)))?;
 
 		match session {
 			Some(session) => {
@@ -466,8 +471,9 @@ impl SessionBackend for DatabaseSessionBackend {
 
 	async fn exists(&self, session_key: &str) -> Result<bool, SessionError> {
 		let now_timestamp = Utc::now().timestamp_millis();
+		let mut connection = self.connection;
 
-		// Use ORM to check if session exists and is not expired
+		// Use ORM to check the backend's injected connection.
 		let session = Session::objects()
 			.filter(Filter::new(
 				"session_key".to_string(),
@@ -479,10 +485,11 @@ impl SessionBackend for DatabaseSessionBackend {
 				FilterOperator::Gt,
 				FilterValue::Integer(now_timestamp),
 			))
-			.first()
+			.first_with_db(&mut connection)
 			.await
-			.ok()
-			.flatten();
+			.map_err(|e| {
+				SessionError::CacheError(format!("Failed to check session existence: {}", e))
+			})?;
 
 		Ok(session.is_some())
 	}
@@ -736,5 +743,27 @@ mod tests {
 		// We can't test this without a real connection, but we can verify the trait is implemented
 		fn assert_clone<T: Clone>() {}
 		assert_clone::<DatabaseSessionBackend>();
+	}
+
+	#[tokio::test]
+	async fn injected_connection_handles_session_lifecycle_without_global_orm_connection() {
+		let owner = connect_backend("sqlite::memory:").await.unwrap();
+		let backend = DatabaseSessionBackend::from_connection(owner).unwrap();
+		let session_key = "injected-connection";
+		let session_data = serde_json::json!({"user_id": 42});
+
+		backend.create_table().await.unwrap();
+		backend
+			.save(session_key, &session_data, Some(60))
+			.await
+			.unwrap();
+
+		let loaded: Option<serde_json::Value> = backend.load(session_key).await.unwrap();
+		assert_eq!(loaded, Some(session_data));
+		assert!(backend.exists(session_key).await.unwrap());
+
+		backend.delete(session_key).await.unwrap();
+
+		assert!(!backend.exists(session_key).await.unwrap());
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Ports the Issue #5815 session connection consistency fix to `develop/0.4.0`.
- Routes `DatabaseSessionBackend::load` and `exists` through the backend's copyable injected ORM capability.
- Adds an SQLite lifecycle regression test using the 0.4 connection-owner and RAII lease API.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`save` and `delete` use the backend's injected connection, while `load` and `exists` previously resolved the global ORM connection. The 0.4 port explicitly passes a copied capability from the backend's retained `DatabaseConnectionLease`, ensuring all four operations use the same registered owner.

Refs #5815

Related to: #5820

## How Was This Tested?

- `cargo test -p reinhardt-auth sessions::backends::database::tests --features database --lib`
- `cargo clippy -p reinhardt-auth --features database --lib --no-deps -- -D warnings`
- `cargo doc -p reinhardt-auth --features database --no-deps`
- `cargo fmt --all -- --check`
- `git diff origin/develop/0.4.0...HEAD --check`

The dependency-inclusive focused Clippy command is currently blocked by two pre-existing warnings in `reinhardt-db/src/migrations/schema_editor.rs` (`unused_mut` and `unused_variables`). The auth crate itself passes Clippy with `--no-deps`.

## Performance Impact

The session reads retain the same filtered ORM queries; only their connection source changes.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #5815
- Related to #5820

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside the type label above)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [x] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This commit was ported from `ad2abb0cb3` and adapted to the 0.4 `DatabaseConnectionLease` API.

🤖 Generated with [Codex](https://openai.com/codex)