### PR TITLE
fix(ci): allow base64 0.23 duplicate

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,7 @@ skip = [
   { crate = "base64@0.12.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "base64@0.13.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "base64@0.21.7", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
+  { crate = "base64@0.23.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "bincode@1.3.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "bitflags@1.3.2", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "cipher@0.4.4", reason = "The full feature graph retains cipher 0.4.4 and 0.5.2 through incompatible transitive dependency requirements; tracked in issue #5665." },


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds the existing dependency-policy exception for `base64@0.23.0` in the full feature graph.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The dependency policy rejects the shared `base64@0.23.0` transitive version during security-audit jobs.

Related to: #5819, #5824, #5826

## How Was This Tested?

- `cargo deny check bans`
- `cargo fmt --all --check`
- `git diff --check`

## Checklist

- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`

## Related Issues

- #5819
- #5824
- #5826

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

This is deliberately a base-branch follow-up so all affected PRs receive the same policy fix after merge.

🤖 Generated with [Codex](https://openai.com/codex)