### PR TITLE
fix(ci): stream auto-fix additions from staged blobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,8 @@ jobs:
           while IFS=$'\t' read -r status path extra; do
             case "$status" in
               M|A)
-                base64 -w0 < "$path" \
+                git cat-file blob ":$path" \
+                  | base64 -w0 \
                   | jq -ncR --arg p "$path" '{path: $p, contents: input}' \
                   >> "$ADDITIONS_FILE"
                 ;;

--- a/docs/rfc/2026-06-30-ci-style-auto-fix-design.md
+++ b/docs/rfc/2026-06-30-ci-style-auto-fix-design.md
@@ -116,6 +116,9 @@ the pull-request head before generating the write token. The eligibility policy
 is sparse-checked out from the pull request's base commit into an isolated path,
 and the untrusted patch artifact is not allowed to modify that path.
 
+GraphQL additions are read from staged blobs and streamed through `base64` and
+`jq`, so large auto-fix files never need to be passed through process arguments.
+
 The GitHub App token is generated only in the write job after the patch is
 applied and the target branch protection and active rules are rechecked. The
 token requests only `permission-contents: write`.

--- a/scripts/tests/test-ci-auto-fix-style-target.sh
+++ b/scripts/tests/test-ci-auto-fix-style-target.sh
@@ -102,6 +102,18 @@ assert.match(
   'write job must fail closed if trusted policy checkout files are staged',
 );
 
+assert.match(
+  workflow,
+  /git cat-file blob ":\$path" \\\n+\s+\| base64 -w0 \\\n+\s+\| jq -ncR --arg p "\$path" '\{path: \$p, contents: input\}'/,
+  'GraphQL additions must stream staged blobs without process arguments',
+);
+
+assert.doesNotMatch(
+  workflow,
+  /--arg c "\$contents"/,
+  'GraphQL additions must not carry file contents in a process argument',
+);
+
 const outputs = new Map();
 const paginateCalls = [];
 await runAutoFixTargetPolicy({


### PR DESCRIPTION
## Summary

This PR addresses:

- Streams GraphQL auto-fix additions from the staged index through `base64` and `jq`.
- Prevents large style fixes from exceeding the process argument limit.
- Adds a regression guard and documents the payload-size guarantee.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The auto-fix GraphQL writer must commit exactly the staged patch without passing file contents as command-line arguments.

Related to: #5824

## How Was This Tested?

- `bash scripts/tests/test-ci-auto-fix-style-target.sh`
- `actionlint -shellcheck= .github/workflows/ci.yml`

## Checklist

- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes