### PR TITLE
fix(orm): preserve typed keys in manager deletion

### DIFF
--- a/crates/reinhardt-db/src/orm/manager.rs
+++ b/crates/reinhardt-db/src/orm/manager.rs
@@ -1016,10 +1016,27 @@ impl<M: Model> Manager<M> {
 		self.delete_with_conn(&conn, pk).await
 	}
 
+	fn build_delete_statement(pk: M::PrimaryKey) -> DeleteStatement {
+		let primary_key_field = M::primary_key_field();
+		let primary_key_column = M::field_metadata()
+			.into_iter()
+			.find(|field| field.name == primary_key_field)
+			.map(|field| field.db_column_name().to_owned())
+			.unwrap_or_else(|| primary_key_field.to_owned());
+		let primary_key_value = M::primary_key_filter_value(pk);
+		let primary_key_value = QuerySet::<M>::filter_value_to_sea_value(&primary_key_value);
+
+		let mut stmt = Query::delete();
+		stmt.from_table(Alias::new(M::table_name()))
+			.and_where(Expr::col(Alias::new(primary_key_column)).eq(primary_key_value));
+		stmt
+	}
+
 	/// Delete a record with an explicit database connection
 	///
 	/// This method allows using a specific connection, which is essential for
-	/// transaction support.
+	/// transaction support. Primary-key columns are resolved from model field
+	/// metadata, and values use the model's typed primary-key binding.
 	///
 	/// # Arguments
 	///
@@ -1048,21 +1065,7 @@ impl<M: Model> Manager<M> {
 		conn: &DatabaseConnection,
 		pk: M::PrimaryKey,
 	) -> reinhardt_core::exception::Result<()> {
-		// Build reinhardt-query DELETE statement
-		let mut stmt = Query::delete();
-
-		// Try to parse as i64 first (common for primary keys), fallback to string
-		let pk_str = pk.to_string();
-		let pk_value = if let Ok(int_value) = pk_str.parse::<i64>() {
-			reinhardt_query::value::Value::BigInt(Some(int_value))
-		} else if let Ok(uuid) = Uuid::parse_str(&pk_str) {
-			reinhardt_query::value::Value::Uuid(Some(Box::new(uuid)))
-		} else {
-			reinhardt_query::value::Value::String(Some(Box::new(pk_str)))
-		};
-
-		stmt.from_table(Alias::new(M::table_name()))
-			.and_where(Expr::col(Alias::new(M::primary_key_field())).eq(pk_value));
+		let stmt = Self::build_delete_statement(pk);
 
 		let (sql, values) = build_delete_sql(&stmt, conn.backend());
 		let values: Vec<_> = values
@@ -1592,14 +1595,17 @@ impl<M: Model> Default for Manager<M> {
 
 #[cfg(test)]
 mod tests {
-	use super::Manager;
+	use super::{Manager, build_delete_sql};
 	use crate::orm::FieldSelector;
 	use crate::orm::Model;
 	use crate::orm::connection::DatabaseBackend;
+	use crate::orm::fields::{CharField, Field};
+	use crate::orm::inspection::FieldInfo;
 	use crate::orm::query::FilterValue;
 	use rstest::rstest;
 	use serde::{Deserialize, Serialize};
 	use std::collections::HashMap;
+	use std::fmt;
 	use uuid::Uuid;
 
 	#[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1720,6 +1726,101 @@ mod tests {
 
 		assert_eq!(query.filters().len(), 1);
 		assert!(matches!(query.filters()[0].value, FilterValue::Integer(42)));
+	}
+
+	#[derive(Debug, Clone, Serialize, Deserialize)]
+	struct ExternalId(String);
+
+	impl fmt::Display for ExternalId {
+		fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+			formatter.write_str(&self.0)
+		}
+	}
+
+	#[derive(Debug, Clone, Serialize, Deserialize)]
+	struct TypedKeyUser {
+		external_id: ExternalId,
+	}
+
+	#[derive(Debug, Clone)]
+	struct TypedKeyUserFields;
+
+	impl FieldSelector for TypedKeyUserFields {
+		fn with_alias(self, _alias: &str) -> Self {
+			self
+		}
+	}
+
+	impl Model for TypedKeyUser {
+		type PrimaryKey = ExternalId;
+		type Fields = TypedKeyUserFields;
+		type Objects = Manager<Self>;
+
+		fn table_name() -> &'static str {
+			"typed_key_user"
+		}
+
+		fn primary_key(&self) -> Option<Self::PrimaryKey> {
+			Some(self.external_id.clone())
+		}
+
+		fn primary_key_filter_value(pk: Self::PrimaryKey) -> FilterValue {
+			FilterValue::String(format!("external:{}", pk.0))
+		}
+
+		fn set_primary_key(&mut self, value: Self::PrimaryKey) {
+			self.external_id = value;
+		}
+
+		fn primary_key_field() -> &'static str {
+			"external_id"
+		}
+
+		fn new_fields() -> Self::Fields {
+			TypedKeyUserFields
+		}
+
+		fn field_metadata() -> Vec<FieldInfo> {
+			let mut field = CharField::new(64);
+			field.base.primary_key = true;
+			field.base.db_column = Some("external_key".to_owned());
+			field.set_attributes_from_name(Self::primary_key_field());
+			vec![FieldInfo::from_field(&field)]
+		}
+	}
+
+	#[rstest]
+	#[case(
+		DatabaseBackend::Postgres,
+		"DELETE FROM \"typed_key_user\" WHERE \"external_key\" = $1"
+	)]
+	#[case(
+		DatabaseBackend::MySql,
+		"DELETE FROM `typed_key_user` WHERE `external_key` = ?"
+	)]
+	#[case(
+		DatabaseBackend::Sqlite,
+		"DELETE FROM \"typed_key_user\" WHERE \"external_key\" = ?"
+	)]
+	fn delete_uses_primary_key_column_and_typed_binding(
+		#[case] backend: DatabaseBackend,
+		#[case] expected_sql: &str,
+	) {
+		// Arrange
+		let primary_key = ExternalId("42".to_owned());
+
+		// Act
+		let statement = Manager::<TypedKeyUser>::build_delete_statement(primary_key);
+		let (sql, values) = build_delete_sql(&statement, backend);
+
+		// Assert
+		assert_eq!(sql, expected_sql);
+		assert_eq!(
+			values.0,
+			vec![reinhardt_query::value::Value::String(Some(Box::new(
+				"external:42".to_owned()
+			)))]
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -3364,7 +3364,7 @@ where
 		.into_simple_expr()
 	}
 
-	fn filter_value_to_sea_value(v: &FilterValue) -> reinhardt_query::value::Value {
+	pub(crate) fn filter_value_to_sea_value(v: &FilterValue) -> reinhardt_query::value::Value {
 		match v {
 			FilterValue::String(s) => s.clone().into(),
 			FilterValue::Timestamp(value) => (*value).into(),


### PR DESCRIPTION
## Summary

This PR addresses:

- Resolve a model primary key's physical database column through `field_metadata()` before building manager deletion SQL.
- Reuse `Model::primary_key_filter_value()` and the QuerySet binding conversion instead of reparsing `Display` output.
- Add exact PostgreSQL, MySQL, and SQLite regression coverage for an aliased custom typed primary key.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`Manager::delete_with_conn` used the Rust primary-key field name directly and guessed the bound value type from `Display`. That could address the wrong column for `db_column` aliases and discard a model's typed primary-key representation.

Fixes #5681

Related to: #5593

## How Was This Tested?

- `cargo test -p reinhardt-db 'orm::manager::tests' --lib` (24 passed)
- `cargo test -p reinhardt-db delete_uses_primary_key_column_and_typed_binding --lib` (3 backend cases passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p reinhardt-db --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p reinhardt-db --all-features --no-deps`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5681
- Related to #5593

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [x] `orm` - ORM layer, models, query builder

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The fix is backend-neutral; the regression test renders and verifies each supported SQL dialect and confirms the canonical string binding remains a string even when the key's `Display` output looks numeric.

🤖 Generated with [Codex](https://openai.com/codex)