### PR TITLE
feat(orm): add streaming QuerySet iterator

### DIFF
--- a/crates/reinhardt-db/Cargo.toml
+++ b/crates/reinhardt-db/Cargo.toml
@@ -44,6 +44,7 @@ reinhardt-query = { workspace = true, features = [
 # Async runtime
 tokio = { version = "1.41", features = ["full", "macros", "rt", "sync"], optional = true }
 async-trait = { version = "0.1", optional = true }
+async-stream = { version = "0.3", optional = true }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -119,6 +120,7 @@ db-deps = [
   "dep:aho-corasick",
   "dep:aquamarine",
   "dep:async-trait",
+  "dep:async-stream",
   "dep:base64",
   "dep:chrono",
   "dep:clap",

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -76,19 +76,20 @@ driver resources when it completes, fails, is cancelled, or is dropped early.
 ```rust
 use futures::StreamExt;
 use reinhardt_db::orm::{Model, OrmExecutor, QuerySet};
+use serde::de::DeserializeOwned;
 
 async fn stream_models<M, E>(connection: &mut E) -> reinhardt_core::exception::Result<()>
 where
-    M: Model,
+    M: Model + DeserializeOwned,
     E: OrmExecutor,
 {
-let mut models = QuerySet::<M>::new().iterator_with_db(connection, 128)?;
-while let Some(model) = models.next().await {
-    let model = model?;
-    // Process the typed model without a QuerySet-level result cache.
-    let _ = model;
-}
-Ok(())
+	let mut models = QuerySet::<M>::new().iterator_with_db(connection, 128)?;
+	while let Some(model) = models.next().await {
+		let model = model?;
+		// Process the typed model without a QuerySet-level result cache.
+		let _ = model;
+	}
+	Ok(())
 }
 ```
 

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -66,6 +66,39 @@ This crate provides the following modules:
   - Only/Defer field optimization for reduced data transfer
   - Aggregate pushdown optimization
 
+### Streaming QuerySets
+
+`QuerySet::iterator_with_db` and `QuerySet::iterator_with_executor` decode one
+model at a time from a lifetime-bound driver stream. The stream borrows the
+caller-owned executor, returns `Result<Model>` for every item, and releases its
+driver resources when it completes, fails, is cancelled, or is dropped early.
+
+```rust
+use futures::StreamExt;
+use reinhardt_db::orm::{Model, OrmExecutor, QuerySet};
+
+async fn stream_models<M, E>(connection: &mut E) -> reinhardt_core::exception::Result<()>
+where
+    M: Model,
+    E: OrmExecutor,
+{
+let mut models = QuerySet::<M>::new().iterator_with_db(connection, 128)?;
+while let Some(model) = models.next().await {
+    let model = model?;
+    // Process the typed model without a QuerySet-level result cache.
+    let _ = model;
+}
+Ok(())
+}
+```
+
+PostgreSQL, MySQL, and SQLite support driver-backed streaming. Custom executors
+must implement the row-stream capability or the iterator returns an explicit
+`Unsupported` database error. `chunk_size` is a driver fetch or bounded-buffer
+hint rather than a promise about server internals. Unlike Django's compatibility
+fallbacks, Reinhardt intentionally rejects eager `fetch_all` materialization and
+repeated `LIMIT`/`OFFSET` pagination for this API.
+
 - **Enhanced Transaction Management**
   - Nested transactions with savepoint support
   - Isolation level control (ReadUncommitted, ReadCommitted, RepeatableRead, Serializable)
@@ -621,6 +654,7 @@ pub full_name: String,
 ### Query with QuerySet
 
 ```rust
+use futures::StreamExt;
 use reinhardt_db::orm::Model;
 
 // Get all users
@@ -651,6 +685,14 @@ let recent = User::objects()
     .filter(User::field_created_at().year().gte(2026))
     .all()
     .await?;
+
+// Stream typed-field results through the caller-owned executor.
+let mut streamed_adults = User::objects()
+    .filter(User::field_age().gte(18))
+    .iterator_with_db(&mut connection, 128)?;
+while let Some(user) = streamed_adults.next().await {
+    let _user = user?;
+}
 
 // Atomic conditional partial update
 let updated = User::objects()

--- a/crates/reinhardt-db/src/backends/backend.rs
+++ b/crates/reinhardt-db/src/backends/backend.rs
@@ -1,10 +1,13 @@
 //! Database backend abstraction
 
 use async_trait::async_trait;
+use futures::StreamExt;
 
 use super::{
 	error::Result,
-	types::{DatabaseType, IsolationLevel, QueryResult, QueryValue, Row, TransactionExecutor},
+	types::{
+		DatabaseType, IsolationLevel, QueryResult, QueryValue, Row, RowStream, TransactionExecutor,
+	},
 };
 
 /// Core database backend trait
@@ -15,6 +18,11 @@ pub trait DatabaseBackend: Send + Sync {
 
 	/// Returns whether contextual pgvector error hints are supported.
 	fn supports_pgvector_error_hints(&self) -> bool {
+		false
+	}
+
+	/// Returns whether this backend can stream rows without eager materialization.
+	fn supports_row_streaming(&self) -> bool {
 		false
 	}
 
@@ -93,6 +101,45 @@ pub trait DatabaseBackend: Send + Sync {
 				.map_err(|error| super::error::decorate_error_with_pgvector_context(error, context))
 		} else {
 			result
+		}
+	}
+
+	/// Streams matching rows without eager materialization.
+	///
+	/// `chunk_size` is a driver fetch or bounded-buffer hint. Implementations
+	/// must not emulate streaming with repeated `LIMIT` and `OFFSET` queries.
+	fn fetch_stream<'a>(
+		&'a self,
+		_sql: String,
+		_params: Vec<QueryValue>,
+		_chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		Err(super::error::DatabaseError::new(
+			super::error::DatabaseErrorKind::Unsupported,
+			"Row streaming is not supported by this database backend",
+		)
+		.into())
+	}
+
+	/// Streams rows with structural pgvector operation context.
+	fn fetch_stream_with_context<'a>(
+		&'a self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+		context: Option<super::error::PgvectorOperationKind>,
+	) -> Result<RowStream<'a>> {
+		let decorate =
+			self.database_type() == DatabaseType::Postgres && self.supports_pgvector_error_hints();
+		let stream = self.fetch_stream(sql, params, chunk_size)?;
+		if decorate {
+			Ok(Box::pin(stream.map(move |result| {
+				result.map_err(|error| {
+					super::error::decorate_error_with_pgvector_context(error, context)
+				})
+			})))
+		} else {
+			Ok(stream)
 		}
 	}
 

--- a/crates/reinhardt-db/src/backends/connection.rs
+++ b/crates/reinhardt-db/src/backends/connection.rs
@@ -6,7 +6,7 @@ use super::{
 	backend::DatabaseBackend,
 	error::Result,
 	query_builder::{DeleteBuilder, InsertBuilder, SelectBuilder, UpdateBuilder},
-	types::{DatabaseType, QueryResult, QueryValue, Row, TransactionExecutor},
+	types::{DatabaseType, QueryResult, QueryValue, Row, RowStream, TransactionExecutor},
 };
 
 #[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
@@ -112,6 +112,26 @@ impl TransactionExecutor for FlavoredTransactionExecutor {
 		self.inner
 			.fetch_all_with_context(sql, params, context)
 			.await
+	}
+
+	fn fetch_stream<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		self.inner.fetch_stream(sql, params, chunk_size)
+	}
+
+	fn fetch_stream_with_context<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+		context: Option<super::error::PgvectorOperationKind>,
+	) -> Result<RowStream<'a>> {
+		self.inner
+			.fetch_stream_with_context(sql, params, chunk_size, context)
 	}
 
 	async fn fetch_optional(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>> {
@@ -794,6 +814,31 @@ impl DatabaseConnection {
 		params: Vec<super::types::QueryValue>,
 	) -> Result<Vec<super::types::Row>> {
 		self.backend.fetch_all(sql, params).await
+	}
+
+	/// Streams rows without eagerly materializing the result set.
+	pub fn fetch_stream(
+		&self,
+		sql: String,
+		params: Vec<super::types::QueryValue>,
+		chunk_size: usize,
+	) -> Result<RowStream<'_>> {
+		self.backend.fetch_stream(sql, params, chunk_size)
+	}
+
+	pub(crate) fn fetch_stream_with_context(
+		&self,
+		sql: String,
+		params: Vec<super::types::QueryValue>,
+		chunk_size: usize,
+		context: Option<super::error::PgvectorOperationKind>,
+	) -> Result<RowStream<'_>> {
+		self.backend
+			.fetch_stream_with_context(sql, params, chunk_size, context)
+	}
+
+	pub(crate) fn supports_row_streaming(&self) -> bool {
+		self.backend.supports_row_streaming()
 	}
 
 	pub(crate) async fn fetch_all_with_context(

--- a/crates/reinhardt-db/src/backends/dialect/mysql.rs
+++ b/crates/reinhardt-db/src/backends/dialect/mysql.rs
@@ -306,10 +306,14 @@ impl DatabaseBackend for MySqlBackend {
 			}
 			let rows = query.fetch(pool.as_ref());
 			futures::pin_mut!(rows);
-			while let Some(row) = rows.next().await {
-				yield row
-					.map_err(|error| map_sqlx_error(error).into())
-					.and_then(Self::convert_row);
+			let rows = rows.ready_chunks(chunk_size);
+			futures::pin_mut!(rows);
+			while let Some(chunk) = rows.next().await {
+				for row in chunk {
+					yield row
+						.map_err(|error| map_sqlx_error(error).into())
+						.and_then(Self::convert_row);
+				}
 			}
 		}))
 	}
@@ -494,10 +498,14 @@ impl TransactionExecutor for MySqlTransactionExecutor {
 			}
 			let rows = query.fetch(&mut **tx);
 			futures::pin_mut!(rows);
-			while let Some(row) = rows.next().await {
-				yield row
-					.map_err(|error| map_sqlx_error(error).into())
-					.and_then(Self::convert_row);
+			let rows = rows.ready_chunks(chunk_size);
+			futures::pin_mut!(rows);
+			while let Some(chunk) = rows.next().await {
+				for row in chunk {
+					yield row
+						.map_err(|error| map_sqlx_error(error).into())
+						.and_then(Self::convert_row);
+				}
 			}
 		}))
 	}
@@ -730,10 +738,14 @@ impl TransactionExecutor for MySqlRawTransactionExecutor {
 			}
 			let rows = query.fetch(&mut **conn);
 			futures::pin_mut!(rows);
-			while let Some(row) = rows.next().await {
-				yield row
-					.map_err(|error| map_sqlx_error(error).into())
-					.and_then(Self::convert_row);
+			let rows = rows.ready_chunks(chunk_size);
+			futures::pin_mut!(rows);
+			while let Some(chunk) = rows.next().await {
+				for row in chunk {
+					yield row
+						.map_err(|error| map_sqlx_error(error).into())
+						.and_then(Self::convert_row);
+				}
 			}
 		}))
 	}

--- a/crates/reinhardt-db/src/backends/dialect/mysql.rs
+++ b/crates/reinhardt-db/src/backends/dialect/mysql.rs
@@ -1,6 +1,7 @@
 //! MySQL dialect implementation
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use sqlx::{
 	Column, Executor, MySql, MySqlPool, Row as SqlxRow, Transaction, TypeInfo, mysql::MySqlRow,
 };
@@ -10,7 +11,8 @@ use crate::backends::{
 	backend::DatabaseBackend,
 	error::{DatabaseError, DatabaseErrorKind, Result, map_sqlx_error},
 	types::{
-		DatabaseType, IsolationLevel, QueryResult, QueryValue, Row, Savepoint, TransactionExecutor,
+		DatabaseType, IsolationLevel, QueryResult, QueryValue, Row, RowStream, Savepoint,
+		TransactionExecutor,
 	},
 };
 
@@ -221,6 +223,10 @@ impl DatabaseBackend for MySqlBackend {
 		DatabaseType::Mysql
 	}
 
+	fn supports_row_streaming(&self) -> bool {
+		true
+	}
+
 	fn placeholder(&self, _index: usize) -> String {
 		"?".to_string()
 	}
@@ -271,6 +277,41 @@ impl DatabaseBackend for MySqlBackend {
 			.await
 			.map_err(map_sqlx_error)?;
 		mysql_rows.into_iter().map(Self::convert_row).collect()
+	}
+
+	fn fetch_stream<'a>(
+		&'a self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		if chunk_size == 0 {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Configuration,
+				"Row stream chunk_size must be greater than zero",
+			)
+			.into());
+		}
+		let pool = Arc::clone(&self.pool);
+		Ok(Box::pin(async_stream::stream! {
+			let mut query = sqlx::query(&sql);
+			for param in &params {
+				query = match Self::bind_value(query, param) {
+					Ok(query) => query,
+					Err(error) => {
+						yield Err(error);
+						return;
+					}
+				};
+			}
+			let rows = query.fetch(pool.as_ref());
+			futures::pin_mut!(rows);
+			while let Some(row) = rows.next().await {
+				yield row
+					.map_err(|error| map_sqlx_error(error).into())
+					.and_then(Self::convert_row);
+			}
+		}))
 	}
 
 	async fn fetch_optional(&self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>> {
@@ -424,6 +465,41 @@ impl TransactionExecutor for MySqlTransactionExecutor {
 		}
 		let rows = query.fetch_all(&mut **tx).await.map_err(map_sqlx_error)?;
 		rows.into_iter().map(Self::convert_row).collect()
+	}
+
+	fn fetch_stream<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		if chunk_size == 0 {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Configuration,
+				"Row stream chunk_size must be greater than zero",
+			)
+			.into());
+		}
+		let tx = self.tx.as_mut().ok_or_else(transaction_consumed_error)?;
+		Ok(Box::pin(async_stream::stream! {
+			let mut query = sqlx::query(&sql);
+			for param in &params {
+				query = match Self::bind_value(query, param) {
+					Ok(query) => query,
+					Err(error) => {
+						yield Err(error);
+						return;
+					}
+				};
+			}
+			let rows = query.fetch(&mut **tx);
+			futures::pin_mut!(rows);
+			while let Some(row) = rows.next().await {
+				yield row
+					.map_err(|error| map_sqlx_error(error).into())
+					.and_then(Self::convert_row);
+			}
+		}))
 	}
 
 	async fn fetch_optional(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>> {
@@ -625,6 +701,41 @@ impl TransactionExecutor for MySqlRawTransactionExecutor {
 		}
 		let rows = query.fetch_all(&mut **conn).await.map_err(map_sqlx_error)?;
 		rows.into_iter().map(Self::convert_row).collect()
+	}
+
+	fn fetch_stream<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		if chunk_size == 0 {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Configuration,
+				"Row stream chunk_size must be greater than zero",
+			)
+			.into());
+		}
+		let conn = self.connection_mut()?;
+		Ok(Box::pin(async_stream::stream! {
+			let mut query = sqlx::query(&sql);
+			for param in &params {
+				query = match Self::bind_value(query, param) {
+					Ok(query) => query,
+					Err(error) => {
+						yield Err(error);
+						return;
+					}
+				};
+			}
+			let rows = query.fetch(&mut **conn);
+			futures::pin_mut!(rows);
+			while let Some(row) = rows.next().await {
+				yield row
+					.map_err(|error| map_sqlx_error(error).into())
+					.and_then(Self::convert_row);
+			}
+		}))
 	}
 
 	async fn fetch_optional(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>> {

--- a/crates/reinhardt-db/src/backends/dialect/postgres.rs
+++ b/crates/reinhardt-db/src/backends/dialect/postgres.rs
@@ -1,6 +1,7 @@
 //! PostgreSQL dialect implementation
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use sqlx::{Column, PgPool, Postgres, Transaction, TypeInfo, postgres::PgRow};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -12,7 +13,8 @@ use crate::backends::{
 		map_sqlx_error_with_pgvector_context,
 	},
 	types::{
-		DatabaseType, IsolationLevel, QueryResult, QueryValue, Row, Savepoint, TransactionExecutor,
+		DatabaseType, IsolationLevel, QueryResult, QueryValue, Row, RowStream, Savepoint,
+		TransactionExecutor,
 	},
 };
 #[cfg(feature = "pgvector")]
@@ -166,6 +168,10 @@ impl DatabaseBackend for PostgresBackend {
 		true
 	}
 
+	fn supports_row_streaming(&self) -> bool {
+		true
+	}
+
 	fn placeholder(&self, index: usize) -> String {
 		format!("${}", index)
 	}
@@ -215,6 +221,51 @@ impl DatabaseBackend for PostgresBackend {
 		context: Option<PgvectorOperationKind>,
 	) -> Result<Vec<Row>> {
 		PostgresBackend::fetch_all_with_context(self, sql, params, context).await
+	}
+
+	fn fetch_stream<'a>(
+		&'a self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		self.fetch_stream_with_context(sql, params, chunk_size, None)
+	}
+
+	fn fetch_stream_with_context<'a>(
+		&'a self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+		context: Option<PgvectorOperationKind>,
+	) -> Result<RowStream<'a>> {
+		if chunk_size == 0 {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Configuration,
+				"Row stream chunk_size must be greater than zero",
+			)
+			.into());
+		}
+		let pool = Arc::clone(&self.pool);
+		Ok(Box::pin(async_stream::stream! {
+			let mut query = sqlx::query(&sql);
+			for param in &params {
+				query = match Self::bind_value(query, param) {
+					Ok(query) => query,
+					Err(error) => {
+						yield Err(error);
+						return;
+					}
+				};
+			}
+			let rows = query.fetch(pool.as_ref());
+			futures::pin_mut!(rows);
+			while let Some(row) = rows.next().await {
+				yield row
+					.map_err(|error| map_sqlx_error_with_pgvector_context(error, context))
+					.and_then(Self::convert_row);
+			}
+		}))
 	}
 
 	async fn fetch_optional(&self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>> {
@@ -583,6 +634,56 @@ impl TransactionExecutor for PgTransactionExecutor {
 			.await
 			.map_err(|error| map_sqlx_error_with_pgvector_context(error, context))?;
 		rows.into_iter().map(Self::convert_row).collect()
+	}
+
+	fn fetch_stream<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		self.fetch_stream_with_context(sql, params, chunk_size, None)
+	}
+
+	fn fetch_stream_with_context<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+		context: Option<PgvectorOperationKind>,
+	) -> Result<RowStream<'a>> {
+		if chunk_size == 0 {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Configuration,
+				"Row stream chunk_size must be greater than zero",
+			)
+			.into());
+		}
+		let tx = self.tx.as_mut().ok_or_else(|| {
+			DatabaseError::new(
+				DatabaseErrorKind::Transaction,
+				"Transaction already consumed",
+			)
+		})?;
+		Ok(Box::pin(async_stream::stream! {
+			let mut query = sqlx::query(&sql);
+			for param in &params {
+				query = match Self::bind_value(query, param) {
+					Ok(query) => query,
+					Err(error) => {
+						yield Err(error);
+						return;
+					}
+				};
+			}
+			let rows = query.fetch(&mut **tx);
+			futures::pin_mut!(rows);
+			while let Some(row) = rows.next().await {
+				yield row
+					.map_err(|error| map_sqlx_error_with_pgvector_context(error, context))
+					.and_then(Self::convert_row);
+			}
+		}))
 	}
 
 	async fn fetch_optional(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>> {

--- a/crates/reinhardt-db/src/backends/dialect/postgres.rs
+++ b/crates/reinhardt-db/src/backends/dialect/postgres.rs
@@ -260,10 +260,14 @@ impl DatabaseBackend for PostgresBackend {
 			}
 			let rows = query.fetch(pool.as_ref());
 			futures::pin_mut!(rows);
-			while let Some(row) = rows.next().await {
-				yield row
-					.map_err(|error| map_sqlx_error_with_pgvector_context(error, context))
-					.and_then(Self::convert_row);
+			let rows = rows.ready_chunks(chunk_size);
+			futures::pin_mut!(rows);
+			while let Some(chunk) = rows.next().await {
+				for row in chunk {
+					yield row
+						.map_err(|error| map_sqlx_error_with_pgvector_context(error, context))
+						.and_then(Self::convert_row);
+				}
 			}
 		}))
 	}
@@ -678,10 +682,14 @@ impl TransactionExecutor for PgTransactionExecutor {
 			}
 			let rows = query.fetch(&mut **tx);
 			futures::pin_mut!(rows);
-			while let Some(row) = rows.next().await {
-				yield row
-					.map_err(|error| map_sqlx_error_with_pgvector_context(error, context))
-					.and_then(Self::convert_row);
+			let rows = rows.ready_chunks(chunk_size);
+			futures::pin_mut!(rows);
+			while let Some(chunk) = rows.next().await {
+				for row in chunk {
+					yield row
+						.map_err(|error| map_sqlx_error_with_pgvector_context(error, context))
+						.and_then(Self::convert_row);
+				}
 			}
 		}))
 	}

--- a/crates/reinhardt-db/src/backends/dialect/sqlite.rs
+++ b/crates/reinhardt-db/src/backends/dialect/sqlite.rs
@@ -1,6 +1,7 @@
 //! SQLite dialect implementation
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use sqlx::{Column, Row as SqlxRow, Sqlite, SqlitePool, Transaction, TypeInfo, sqlite::SqliteRow};
 use std::sync::Arc;
 use tracing::warn;
@@ -9,7 +10,8 @@ use crate::backends::{
 	backend::DatabaseBackend,
 	error::{DatabaseError, DatabaseErrorKind, Result, map_sqlx_error},
 	types::{
-		DatabaseType, IsolationLevel, QueryResult, QueryValue, Row, Savepoint, TransactionExecutor,
+		DatabaseType, IsolationLevel, QueryResult, QueryValue, Row, RowStream, Savepoint,
+		TransactionExecutor,
 	},
 };
 
@@ -176,6 +178,10 @@ impl DatabaseBackend for SqliteBackend {
 		DatabaseType::Sqlite
 	}
 
+	fn supports_row_streaming(&self) -> bool {
+		true
+	}
+
 	fn placeholder(&self, _index: usize) -> String {
 		"?".to_string()
 	}
@@ -225,6 +231,41 @@ impl DatabaseBackend for SqliteBackend {
 			.await
 			.map_err(map_sqlx_error)?;
 		rows.into_iter().map(Self::convert_row).collect()
+	}
+
+	fn fetch_stream<'a>(
+		&'a self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		if chunk_size == 0 {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Configuration,
+				"Row stream chunk_size must be greater than zero",
+			)
+			.into());
+		}
+		let pool = Arc::clone(&self.pool);
+		Ok(Box::pin(async_stream::stream! {
+			let mut query = sqlx::query(&sql);
+			for param in &params {
+				query = match Self::bind_value(query, param) {
+					Ok(query) => query,
+					Err(error) => {
+						yield Err(error);
+						return;
+					}
+				};
+			}
+			let rows = query.fetch(pool.as_ref());
+			futures::pin_mut!(rows);
+			while let Some(row) = rows.next().await {
+				yield row
+					.map_err(|error| map_sqlx_error(error).into())
+					.and_then(Self::convert_row);
+			}
+		}))
 	}
 
 	async fn fetch_optional(&self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>> {
@@ -477,6 +518,41 @@ impl TransactionExecutor for SqliteTransactionExecutor {
 		}
 		let rows = query.fetch_all(&mut **tx).await.map_err(map_sqlx_error)?;
 		rows.into_iter().map(Self::convert_row).collect()
+	}
+
+	fn fetch_stream<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		if chunk_size == 0 {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Configuration,
+				"Row stream chunk_size must be greater than zero",
+			)
+			.into());
+		}
+		let tx = self.tx.as_mut().ok_or_else(transaction_consumed_error)?;
+		Ok(Box::pin(async_stream::stream! {
+			let mut query = sqlx::query(&sql);
+			for param in &params {
+				query = match Self::bind_value(query, param) {
+					Ok(query) => query,
+					Err(error) => {
+						yield Err(error);
+						return;
+					}
+				};
+			}
+			let rows = query.fetch(&mut **tx);
+			futures::pin_mut!(rows);
+			while let Some(row) = rows.next().await {
+				yield row
+					.map_err(|error| map_sqlx_error(error).into())
+					.and_then(Self::convert_row);
+			}
+		}))
 	}
 
 	async fn fetch_optional(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>> {

--- a/crates/reinhardt-db/src/backends/dialect/sqlite.rs
+++ b/crates/reinhardt-db/src/backends/dialect/sqlite.rs
@@ -260,10 +260,14 @@ impl DatabaseBackend for SqliteBackend {
 			}
 			let rows = query.fetch(pool.as_ref());
 			futures::pin_mut!(rows);
-			while let Some(row) = rows.next().await {
-				yield row
-					.map_err(|error| map_sqlx_error(error).into())
-					.and_then(Self::convert_row);
+			let rows = rows.ready_chunks(chunk_size);
+			futures::pin_mut!(rows);
+			while let Some(chunk) = rows.next().await {
+				for row in chunk {
+					yield row
+						.map_err(|error| map_sqlx_error(error).into())
+						.and_then(Self::convert_row);
+				}
 			}
 		}))
 	}
@@ -547,10 +551,14 @@ impl TransactionExecutor for SqliteTransactionExecutor {
 			}
 			let rows = query.fetch(&mut **tx);
 			futures::pin_mut!(rows);
-			while let Some(row) = rows.next().await {
-				yield row
-					.map_err(|error| map_sqlx_error(error).into())
-					.and_then(Self::convert_row);
+			let rows = rows.ready_chunks(chunk_size);
+			futures::pin_mut!(rows);
+			while let Some(chunk) = rows.next().await {
+				for row in chunk {
+					yield row
+						.map_err(|error| map_sqlx_error(error).into())
+						.and_then(Self::convert_row);
+				}
 			}
 		}))
 	}

--- a/crates/reinhardt-db/src/backends/types.rs
+++ b/crates/reinhardt-db/src/backends/types.rs
@@ -1,9 +1,17 @@
 //! Common type definitions for database abstraction
 
 use super::error::{DatabaseError, DatabaseErrorKind};
+use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::pin::Pin;
 use uuid::Uuid;
+
+/// A lifetime-bound stream of database rows.
+///
+/// Dropping the stream releases any driver cursor, transaction borrow, or pool
+/// connection retained by the backend.
+pub type RowStream<'a> = Pin<Box<dyn Stream<Item = super::error::Result<Row>> + Send + 'a>>;
 
 /// Database type
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -613,6 +621,45 @@ pub trait TransactionExecutor: Send + Sync {
 				.map_err(|error| super::error::decorate_error_with_pgvector_context(error, context))
 		} else {
 			result
+		}
+	}
+
+	/// Streams matching rows without eager materialization.
+	///
+	/// `chunk_size` is a driver fetch or bounded-buffer hint. Implementations
+	/// must not emulate streaming with repeated `LIMIT` and `OFFSET` queries.
+	fn fetch_stream<'a>(
+		&'a mut self,
+		_sql: String,
+		_params: Vec<QueryValue>,
+		_chunk_size: usize,
+	) -> super::error::Result<RowStream<'a>> {
+		Err(DatabaseError::new(
+			DatabaseErrorKind::Unsupported,
+			"Row streaming is not supported by this transaction executor",
+		)
+		.into())
+	}
+
+	/// Streams rows with structural pgvector operation context.
+	fn fetch_stream_with_context<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+		context: Option<super::error::PgvectorOperationKind>,
+	) -> super::error::Result<RowStream<'a>> {
+		let decorate =
+			self.backend() == DatabaseType::Postgres && self.supports_pgvector_error_hints();
+		let stream = self.fetch_stream(sql, params, chunk_size)?;
+		if decorate {
+			Ok(Box::pin(stream.map(move |result| {
+				result.map_err(|error| {
+					super::error::decorate_error_with_pgvector_context(error, context)
+				})
+			})))
+		} else {
+			Ok(stream)
 		}
 	}
 

--- a/crates/reinhardt-db/src/lib.rs
+++ b/crates/reinhardt-db/src/lib.rs
@@ -33,6 +33,7 @@
 //!
 //! - **Django-style Models**: Define database models with structs
 //! - **QuerySet API**: Chainable query builder with conditional partial updates
+//!   and lifetime-bound, row-by-row model streaming
 //! - **Field Types**: Rich set of field types with validation
 //! - **Relationships**: ForeignKey, ManyToMany, OneToOne
 //! - **Fixtures**: Django-compatible model fixture dump/load runtime with upsert,

--- a/crates/reinhardt-db/src/orm.rs
+++ b/crates/reinhardt-db/src/orm.rs
@@ -12,6 +12,20 @@
 //! records the SQL joins required by the filter, so application code does not
 //! need raw join builders for common FK, reverse, or M2M lookups.
 //!
+//! ## Streaming QuerySets
+//!
+//! [`QuerySet::iterator_with_db`](crate::orm::QuerySet::iterator_with_db) and
+//! [`QuerySet::iterator_with_executor`](crate::orm::QuerySet::iterator_with_executor)
+//! return lifetime-bound streams that decode one model per item. The borrowed
+//! executor remains in use until the stream completes or is dropped, and each
+//! item retains backend or model-decoding failures in its `Result`.
+//!
+//! PostgreSQL, MySQL, and SQLite use driver streams. Custom executors without
+//! that capability return `DatabaseErrorKind::Unsupported`; the ORM never
+//! substitutes `fetch_all` or repeated `LIMIT`/`OFFSET` queries. `chunk_size`
+//! is a driver fetch or bounded-buffer hint, and dropping or cancelling the
+//! stream releases driver resources through RAII.
+//!
 //! ## Transaction Management
 //!
 //! ORM writes run inside closure-scoped transactions. Start an outer operation
@@ -175,7 +189,7 @@ pub use aggregation::{Aggregate, AggregateFunc, AggregateResult, AggregateValue}
 pub use annotation::{Annotation, AnnotationValue, Expression, Value, When};
 pub use connection::{
 	DatabaseBackend, DatabaseConnection, DatabaseConnectionLease, OrmExecutor, QueryResult,
-	QueryRow, QueryValue, Row, TransactionExecutor,
+	QueryRow, QueryValue, Row, RowStream, TransactionExecutor,
 };
 pub use constraints::{
 	CheckConstraint, Constraint, ForeignKeyConstraint, OnDelete, OnUpdate, UniqueConstraint,
@@ -293,7 +307,7 @@ pub use manager::Manager;
 // Query types are always available
 pub use query::{
 	FieldAssignment, Filter, FilterCondition, FilterOperator, FilterValue, IntoOrderBy, OrmQuery,
-	QuerySet, UpdateValue,
+	QuerySet, QuerySetStream, UpdateValue,
 };
 
 // Advanced ORM features

--- a/crates/reinhardt-db/src/orm.rs
+++ b/crates/reinhardt-db/src/orm.rs
@@ -14,8 +14,7 @@
 //!
 //! ## Streaming QuerySets
 //!
-//! [`QuerySet::iterator_with_db`](crate::orm::QuerySet::iterator_with_db) and
-//! [`QuerySet::iterator_with_executor`](crate::orm::QuerySet::iterator_with_executor)
+//! [`QuerySet::iterator_with_db`] and [`QuerySet::iterator_with_executor`]
 //! return lifetime-bound streams that decode one model per item. The borrowed
 //! executor remains in use until the stream completes or is dropped, and each
 //! item retains backend or model-decoding failures in its `Result`.

--- a/crates/reinhardt-db/src/orm/connection.rs
+++ b/crates/reinhardt-db/src/orm/connection.rs
@@ -42,7 +42,7 @@ impl From<DatabaseType> for DatabaseBackend {
 }
 
 /// Query row wrapper for ORM compatibility
-#[derive(serde::Serialize)]
+#[derive(Debug, PartialEq, serde::Serialize)]
 pub struct QueryRow {
 	/// The data.
 	pub data: serde_json::Value,

--- a/crates/reinhardt-db/src/orm/connection.rs
+++ b/crates/reinhardt-db/src/orm/connection.rs
@@ -5,9 +5,10 @@
 //! [`DatabaseConnection`] resolves the backend for each operation.
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use std::sync::Arc;
 
-use reinhardt_core::exception::Result;
+use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind, Result};
 
 use super::connection_registry::{self, ConnectionSlot, Generation, RegisteredConnection};
 use super::transaction::AtomicTransaction;
@@ -16,7 +17,7 @@ use super::transaction::AtomicTransaction;
 pub use crate::backends::connection::DatabaseConnection as BackendsConnection;
 use crate::backends::types::DatabaseType;
 pub use crate::backends::types::{
-	IsolationLevel, QueryResult, QueryValue, Row, TransactionExecutor,
+	IsolationLevel, QueryResult, QueryValue, Row, RowStream, TransactionExecutor,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -280,6 +281,42 @@ pub trait OrmExecutor: Send {
 		}
 	}
 
+	/// Streams matching rows without eager materialization.
+	fn fetch_stream<'a>(
+		&'a mut self,
+		_sql: String,
+		_params: Vec<QueryValue>,
+		_chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		Err(DatabaseError::new(
+			DatabaseErrorKind::Unsupported,
+			"Row streaming is not supported by this ORM executor",
+		)
+		.into())
+	}
+
+	/// Streams rows with structural pgvector operation context.
+	fn fetch_stream_with_context<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+		context: Option<crate::backends::error::PgvectorOperationKind>,
+	) -> Result<RowStream<'a>> {
+		let decorate =
+			self.backend() == DatabaseBackend::Postgres && self.supports_pgvector_error_hints();
+		let stream = self.fetch_stream(sql, params, chunk_size)?;
+		if decorate {
+			Ok(Box::pin(stream.map(move |result| {
+				result.map_err(|error| {
+					crate::backends::error::decorate_error_with_pgvector_context(error, context)
+				})
+			})))
+		} else {
+			Ok(stream)
+		}
+	}
+
 	/// Fetches an optional row without swallowing backend failures.
 	async fn fetch_optional(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>>;
 
@@ -497,6 +534,45 @@ impl OrmExecutor for DatabaseConnection {
 	) -> Result<Vec<Row>> {
 		let owner = self.resolve()?;
 		owner.fetch_all_with_context(sql, params, context).await
+	}
+
+	fn fetch_stream<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> Result<RowStream<'a>> {
+		self.fetch_stream_with_context(sql, params, chunk_size, None)
+	}
+
+	fn fetch_stream_with_context<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+		context: Option<crate::backends::error::PgvectorOperationKind>,
+	) -> Result<RowStream<'a>> {
+		let owner = self.resolve()?;
+		if !owner.supports_row_streaming() {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"Row streaming is not supported by this database backend",
+			)
+			.into());
+		}
+		Ok(Box::pin(async_stream::stream! {
+			let rows = owner.fetch_stream_with_context(sql, params, chunk_size, context);
+			let mut rows = match rows {
+				Ok(rows) => rows,
+				Err(error) => {
+					yield Err(error);
+					return;
+				}
+			};
+			while let Some(row) = rows.next().await {
+				yield row;
+			}
+		}))
 	}
 
 	async fn fetch_optional(&mut self, sql: &str, params: Vec<QueryValue>) -> Result<Option<Row>> {

--- a/crates/reinhardt-db/src/orm/instrumentation.rs
+++ b/crates/reinhardt-db/src/orm/instrumentation.rs
@@ -428,6 +428,19 @@ impl Instrumentation {
 		params: &[String],
 		duration: Duration,
 	) {
+		self.orm_query_end_with_params_sync(query, params, duration);
+	}
+
+	/// Records an ORM query without requiring an async context.
+	///
+	/// Streaming query accounting invokes this from a drop guard so partially
+	/// consumed streams remain visible to N+1 detection.
+	pub(crate) fn orm_query_end_with_params_sync(
+		&self,
+		query: &str,
+		params: &[String],
+		duration: Duration,
+	) {
 		super::n_plus_one::record_query(query, params, duration);
 	}
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -39,6 +39,33 @@ fn executor_error(error: reinhardt_core::exception::Error) -> DatabaseError {
 pub type QuerySetStream<'a, T> =
 	Pin<Box<dyn Stream<Item = reinhardt_core::exception::Result<T>> + Send + 'a>>;
 
+/// Records a streaming query when its generator finishes or is dropped.
+struct StreamQueryAccounting {
+	sql: String,
+	params: Vec<String>,
+	started: Instant,
+}
+
+impl StreamQueryAccounting {
+	fn new(sql: String, params: Vec<String>) -> Self {
+		Self {
+			sql,
+			params,
+			started: Instant::now(),
+		}
+	}
+}
+
+impl Drop for StreamQueryAccounting {
+	fn drop(&mut self) {
+		super::instrumentation::instrumentation().orm_query_end_with_params_sync(
+			&self.sql,
+			&self.params,
+			self.started.elapsed(),
+		);
+	}
+}
+
 // Django QuerySet API types
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Defines possible filter operator values.
@@ -5913,6 +5940,9 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		if self.empty_result {
+			return Ok(Vec::new());
+		}
 		let mut conn = super::manager::get_connection().await?;
 		self.all_with_db(&mut conn).await
 	}
@@ -6060,6 +6090,9 @@ where
 		T: serde::de::DeserializeOwned,
 		E: OrmExecutor,
 	{
+		if self.empty_result {
+			return Ok(Vec::new());
+		}
 		let stmt = self.build_select_statement()?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) =
@@ -6115,6 +6148,9 @@ where
 	where
 		E: OrmExecutor,
 	{
+		if self.empty_result {
+			return Ok(Vec::new());
+		}
 		let stmt = self.build_select_statement()?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) =
@@ -6179,14 +6215,16 @@ where
 			.map(|value| value.to_sql_literal())
 			.collect::<Vec<_>>();
 		let params = super::execution::convert_values(values);
-		let mut rows = conn.fetch_stream_with_context(sql.clone(), params, chunk_size, context)?;
-		let started = Instant::now();
+		let rows = conn.fetch_stream_with_context(sql.clone(), params, chunk_size, context)?;
 
 		Ok(Box::pin(async_stream::stream! {
-			while let Some(row) = rows.next().await {
+			let accounting = StreamQueryAccounting::new(sql.clone(), param_samples);
+			let mut rows = Some(rows);
+			while let Some(row) = rows.as_mut().expect("row stream is available").next().await {
 				let row = match row {
 					Ok(row) => row,
 					Err(error) => {
+						rows = None;
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
@@ -6201,6 +6239,7 @@ where
 							DatabaseErrorKind::Serialization,
 							format!("Deserialization error: {error}"),
 						));
+						rows = None;
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
@@ -6209,9 +6248,7 @@ where
 					}
 				}
 			}
-			super::instrumentation::instrumentation()
-				.orm_query_end_with_params(&sql, &param_samples, started.elapsed())
-				.await;
+			drop(accounting);
 		}))
 	}
 
@@ -6250,15 +6287,16 @@ where
 			.map(|value| value.to_sql_literal())
 			.collect::<Vec<_>>();
 		let params = super::execution::convert_values(values);
-		let mut rows =
-			executor.fetch_stream_with_context(sql.clone(), params, chunk_size, context)?;
-		let started = Instant::now();
+		let rows = executor.fetch_stream_with_context(sql.clone(), params, chunk_size, context)?;
 
 		Ok(Box::pin(async_stream::stream! {
-			while let Some(row) = rows.next().await {
+			let accounting = StreamQueryAccounting::new(sql.clone(), param_samples);
+			let mut rows = Some(rows);
+			while let Some(row) = rows.as_mut().expect("row stream is available").next().await {
 				let row = match row {
 					Ok(row) => row,
 					Err(error) => {
+						rows = None;
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
@@ -6273,6 +6311,7 @@ where
 							DatabaseErrorKind::Serialization,
 							format!("Deserialization error: {error}"),
 						));
+						rows = None;
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
@@ -6281,9 +6320,7 @@ where
 					}
 				}
 			}
-			super::instrumentation::instrumentation()
-				.orm_query_end_with_params(&sql, &param_samples, started.elapsed())
-				.await;
+			drop(accounting);
 		}))
 	}
 
@@ -6295,6 +6332,9 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		if self.empty_result {
+			return Ok(Vec::new());
+		}
 		let stmt = self.build_select_statement().map_err(executor_error)?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) = Self::build_select_for_backend(
@@ -6335,6 +6375,9 @@ where
 		&self,
 		executor: &mut dyn super::connection::TransactionExecutor,
 	) -> Result<usize, crate::backends::error::DatabaseError> {
+		if self.empty_result {
+			return Ok(0);
+		}
 		let stmt = self.count_select_query().map_err(executor_error)?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) = Self::build_select_for_backend(
@@ -6526,6 +6569,9 @@ where
 	where
 		E: OrmExecutor,
 	{
+		if self.empty_result {
+			return Ok(0);
+		}
 		let stmt = self.count_select_query()?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) =
@@ -6816,6 +6862,9 @@ where
 		I: IntoIterator<Item = A>,
 		A: Into<FieldAssignment>,
 	{
+		if self.empty_result {
+			return Ok(0);
+		}
 		let mut conn = super::manager::get_connection().await?;
 		self.update_fields_with_conn(&mut conn, values).await
 	}
@@ -6831,6 +6880,9 @@ where
 		I: IntoIterator<Item = A>,
 		A: Into<FieldAssignment>,
 	{
+		if self.empty_result {
+			return Ok(0);
+		}
 		let stmt = self.update_fields_query(values)?;
 		let context = super::execution::pgvector_context_for_update(&stmt);
 		let (sql, values) =
@@ -9296,6 +9348,49 @@ mod tests {
 			]
 		);
 		assert_eq!(executor.contexts, vec![Some(distance_and_vector_context())]);
+	}
+
+	#[cfg(feature = "pgvector")]
+	#[tokio::test]
+	async fn none_short_circuits_read_and_write_execution_paths() {
+		let mut executor = RecordingExecutor::default();
+
+		let rows = QuerySet::<TestUser>::new()
+			.none()
+			.all_with_db(&mut executor)
+			.await
+			.expect("none queryset should not execute a select");
+		assert_eq!(rows, Vec::<TestUser>::new());
+
+		let rows = QuerySet::<TestUser>::new()
+			.none()
+			.rows_with_db(&mut executor)
+			.await
+			.expect("none queryset should not execute a row select");
+		assert_eq!(rows, Vec::<crate::orm::QueryRow>::new());
+
+		let count = QuerySet::<TestUser>::new()
+			.none()
+			.count_with_db(&mut executor)
+			.await
+			.expect("none queryset should not execute a count");
+		assert_eq!(count, 0);
+
+		let exists = QuerySet::<TestUser>::new()
+			.none()
+			.exists_with_db(&mut executor)
+			.await
+			.expect("none queryset should not execute an existence check");
+		assert!(!exists);
+
+		let rows_affected = QuerySet::<TestUser>::new()
+			.none()
+			.update_fields_with_conn(&mut executor, [("username", "alice")])
+			.await
+			.expect("none queryset should not execute an update");
+		assert_eq!(rows_affected, 0);
+		assert!(executor.calls.is_empty());
+		assert!(executor.contexts.is_empty());
 	}
 
 	#[cfg(feature = "pgvector")]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -45,6 +45,7 @@ struct StreamQueryAccounting {
 	sql: String,
 	params: Vec<String>,
 	duration: std::time::Duration,
+	completed: bool,
 }
 
 impl StreamQueryAccounting {
@@ -53,16 +54,24 @@ impl StreamQueryAccounting {
 			sql,
 			params,
 			duration: std::time::Duration::ZERO,
+			completed: true,
 		}
 	}
 
 	fn record_poll(&mut self, duration: std::time::Duration) {
 		self.duration += duration;
 	}
+
+	fn disarm_completion(&mut self) {
+		self.completed = false;
+	}
 }
 
 impl Drop for StreamQueryAccounting {
 	fn drop(&mut self) {
+		if !self.completed {
+			return;
+		}
 		super::instrumentation::instrumentation().orm_query_end_with_params_sync(
 			&self.sql,
 			&self.params,
@@ -79,11 +88,16 @@ impl Drop for StreamQueryAccounting {
 struct TimedRowStream<'rows, 'accounting> {
 	rows: RowStream<'rows>,
 	accounting: &'accounting mut StreamQueryAccounting,
+	pending_since: Option<Instant>,
 }
 
 impl<'rows, 'accounting> TimedRowStream<'rows, 'accounting> {
 	fn new(rows: RowStream<'rows>, accounting: &'accounting mut StreamQueryAccounting) -> Self {
-		Self { rows, accounting }
+		Self {
+			rows,
+			accounting,
+			pending_since: None,
+		}
 	}
 }
 
@@ -91,10 +105,17 @@ impl Stream for TimedRowStream<'_, '_> {
 	type Item = reinhardt_core::exception::Result<crate::backends::types::Row>;
 
 	fn poll_next(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-		let started_at = Instant::now();
+		if self.pending_since.is_none() {
+			self.pending_since = Some(Instant::now());
+		}
 		let result = self.rows.as_mut().poll_next(context);
 		if result.is_ready() {
-			self.accounting.record_poll(started_at.elapsed());
+			let duration = self
+				.pending_since
+				.take()
+				.expect("stream poll start time is initialized")
+				.elapsed();
+			self.accounting.record_poll(duration);
 		}
 		result
 	}
@@ -6280,6 +6301,7 @@ where
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
 						drop(rows.take());
+						accounting.disarm_completion();
 						yield Err(error);
 						return;
 					}
@@ -6295,6 +6317,7 @@ where
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
 						drop(rows.take());
+						accounting.disarm_completion();
 						yield Err(error);
 						return;
 					}
@@ -6355,6 +6378,7 @@ where
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
 						drop(rows.take());
+						accounting.disarm_completion();
 						yield Err(error);
 						return;
 					}
@@ -6370,6 +6394,7 @@ where
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
 						drop(rows.take());
+						accounting.disarm_completion();
 						yield Err(error);
 						return;
 					}

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -14,6 +14,7 @@ use crate::orm::query_fields::comparison::FieldComparison;
 use crate::orm::query_fields::compiler::QueryFieldCompiler;
 use crate::orm::query_fields::{GroupByFields, OrderedExpression, TypedExpression};
 use crate::orm::relations::{RelationJoinGraph, RelationJoinKind, RelationPathLike, RelationStep};
+use futures::{Stream, StreamExt};
 use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind, Error};
 use reinhardt_query::prelude::{
 	Alias, BinOper, CockroachDBQueryBuilder, ColumnRef, Condition, Expr, ExprTrait, Func,
@@ -26,12 +27,17 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::marker::PhantomData;
+use std::pin::Pin;
 use std::time::Instant;
 use uuid::Uuid;
 
 fn executor_error(error: reinhardt_core::exception::Error) -> DatabaseError {
 	crate::backends::error::into_database_error(error)
 }
+
+/// A lifetime-bound stream of decoded QuerySet models.
+pub type QuerySetStream<'a, T> =
+	Pin<Box<dyn Stream<Item = reinhardt_core::exception::Result<T>> + Send + 'a>>;
 
 // Django QuerySet API types
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1266,6 +1272,7 @@ where
 	having_conditions: Vec<HavingCondition>,
 	subquery_conditions: Vec<SubqueryCondition>,
 	from_alias: Option<String>,
+	empty_result: bool,
 	/// Subquery SQL for FROM clause (derived table)
 	/// When set, the FROM clause will use this subquery instead of the model's table
 	from_subquery_sql: Option<String>,
@@ -1304,8 +1311,17 @@ where
 			having_conditions: Vec::new(),
 			subquery_conditions: Vec::new(),
 			from_alias: None,
+			empty_result: false,
 			from_subquery_sql: None,
 		}
+	}
+
+	/// Returns a QuerySet that is known to contain no rows.
+	///
+	/// Execution methods can use this marker to avoid invoking an executor.
+	pub fn none(mut self) -> Self {
+		self.empty_result = true;
+		self
 	}
 
 	fn executor_backend(
@@ -1411,6 +1427,7 @@ where
 			having_conditions: Vec::new(),
 			subquery_conditions: Vec::new(),
 			from_alias: None,
+			empty_result: false,
 			from_subquery_sql: None,
 		}
 	}
@@ -1596,6 +1613,7 @@ where
 		let subquery_qs = QuerySet::<M>::new();
 		// Apply the builder to configure the subquery
 		let configured_subquery = builder(subquery_qs);
+		let empty_result = configured_subquery.empty_result;
 		// Generate SQL for the subquery (wrapped in parentheses)
 		let subquery_sql = configured_subquery.as_subquery()?;
 
@@ -1627,6 +1645,7 @@ where
 			having_conditions: Vec::new(),
 			subquery_conditions: Vec::new(),
 			from_alias: Some(alias.to_string()),
+			empty_result,
 			from_subquery_sql: Some(subquery_sql),
 		})
 	}
@@ -6124,6 +6143,148 @@ where
 				Err(error)
 			}
 		}
+	}
+
+	/// Streams decoded models through a caller-owned ORM executor.
+	///
+	/// The returned stream borrows `conn`, so the executor cannot be reused
+	/// until the stream completes or is dropped. `chunk_size` is a bounded
+	/// driver fetch or buffering hint and must be greater than zero.
+	pub fn iterator_with_db<'a, E>(
+		&self,
+		conn: &'a mut E,
+		chunk_size: usize,
+	) -> reinhardt_core::exception::Result<QuerySetStream<'a, T>>
+	where
+		T: serde::de::DeserializeOwned + 'a,
+		E: OrmExecutor + 'a,
+	{
+		if chunk_size == 0 {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Configuration,
+				"QuerySet iterator chunk_size must be greater than zero",
+			)
+			.into());
+		}
+		if self.empty_result {
+			return Ok(Box::pin(futures::stream::empty()));
+		}
+
+		let stmt = self.build_select_statement()?;
+		let context = super::execution::pgvector_context_for_select(&stmt);
+		let (sql, values) =
+			Self::build_select_for_backend(&stmt, conn.backend(), conn.is_cockroachdb())?;
+		let param_samples = values
+			.iter()
+			.map(|value| value.to_sql_literal())
+			.collect::<Vec<_>>();
+		let params = super::execution::convert_values(values);
+		let mut rows = conn.fetch_stream_with_context(sql.clone(), params, chunk_size, context)?;
+		let started = Instant::now();
+
+		Ok(Box::pin(async_stream::stream! {
+			while let Some(row) = rows.next().await {
+				let row = match row {
+					Ok(row) => row,
+					Err(error) => {
+						super::instrumentation::instrumentation()
+							.orm_query_error(&sql, &format!("{error:?}"))
+							.await;
+						yield Err(error);
+						return;
+					}
+				};
+				match QueryRow::from_backend_row(row).deserialize_model::<T>() {
+					Ok(model) => yield Ok(model),
+					Err(error) => {
+						let error = Error::from(DatabaseError::new(
+							DatabaseErrorKind::Serialization,
+							format!("Deserialization error: {error}"),
+						));
+						super::instrumentation::instrumentation()
+							.orm_query_error(&sql, &format!("{error:?}"))
+							.await;
+						yield Err(error);
+						return;
+					}
+				}
+			}
+			super::instrumentation::instrumentation()
+				.orm_query_end_with_params(&sql, &param_samples, started.elapsed())
+				.await;
+		}))
+	}
+
+	/// Streams decoded models through an active transaction executor.
+	///
+	/// This caller-owned-executor path never reacquires a pooled connection and
+	/// never falls back to eager materialization or pagination.
+	pub fn iterator_with_executor<'a>(
+		&self,
+		executor: &'a mut dyn super::connection::TransactionExecutor,
+		chunk_size: usize,
+	) -> reinhardt_core::exception::Result<QuerySetStream<'a, T>>
+	where
+		T: serde::de::DeserializeOwned + 'a,
+	{
+		if chunk_size == 0 {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Configuration,
+				"QuerySet iterator chunk_size must be greater than zero",
+			)
+			.into());
+		}
+		if self.empty_result {
+			return Ok(Box::pin(futures::stream::empty()));
+		}
+
+		let stmt = self.build_select_statement()?;
+		let context = super::execution::pgvector_context_for_select(&stmt);
+		let (sql, values) = Self::build_select_for_backend(
+			&stmt,
+			Self::executor_backend(executor),
+			executor.is_cockroachdb(),
+		)?;
+		let param_samples = values
+			.iter()
+			.map(|value| value.to_sql_literal())
+			.collect::<Vec<_>>();
+		let params = super::execution::convert_values(values);
+		let mut rows =
+			executor.fetch_stream_with_context(sql.clone(), params, chunk_size, context)?;
+		let started = Instant::now();
+
+		Ok(Box::pin(async_stream::stream! {
+			while let Some(row) = rows.next().await {
+				let row = match row {
+					Ok(row) => row,
+					Err(error) => {
+						super::instrumentation::instrumentation()
+							.orm_query_error(&sql, &format!("{error:?}"))
+							.await;
+						yield Err(error);
+						return;
+					}
+				};
+				match QueryRow::from_backend_row(row).deserialize_model::<T>() {
+					Ok(model) => yield Ok(model),
+					Err(error) => {
+						let error = Error::from(DatabaseError::new(
+							DatabaseErrorKind::Serialization,
+							format!("Deserialization error: {error}"),
+						));
+						super::instrumentation::instrumentation()
+							.orm_query_error(&sql, &format!("{error:?}"))
+							.await;
+						yield Err(error);
+						return;
+					}
+				}
+			}
+			super::instrumentation::instrumentation()
+				.orm_query_end_with_params(&sql, &param_samples, started.elapsed())
+				.await;
+		}))
 	}
 
 	/// Execute the queryset through an active transaction executor and return all records.

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -28,7 +28,8 @@ use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Wake, Waker};
 use std::time::Instant;
 use uuid::Uuid;
 
@@ -40,12 +41,25 @@ fn executor_error(error: reinhardt_core::exception::Error) -> DatabaseError {
 pub type QuerySetStream<'a, T> =
 	Pin<Box<dyn Stream<Item = reinhardt_core::exception::Result<T>> + Send + 'a>>;
 
+struct PendingRowPoll {
+	generation: u64,
+	started_at: Instant,
+	wake_duration: Option<std::time::Duration>,
+}
+
+#[derive(Default)]
+struct RowStreamTiming {
+	next_generation: u64,
+	pending: Option<PendingRowPoll>,
+}
+
 /// Records a streaming query when its generator finishes or is dropped.
 struct StreamQueryAccounting {
 	sql: String,
 	params: Vec<String>,
 	duration: std::time::Duration,
 	completed: bool,
+	timing: Arc<Mutex<RowStreamTiming>>,
 }
 
 impl StreamQueryAccounting {
@@ -55,6 +69,7 @@ impl StreamQueryAccounting {
 			params,
 			duration: std::time::Duration::ZERO,
 			completed: true,
+			timing: Arc::new(Mutex::new(RowStreamTiming::default())),
 		}
 	}
 
@@ -65,10 +80,26 @@ impl StreamQueryAccounting {
 	fn disarm_completion(&mut self) {
 		self.completed = false;
 	}
+
+	fn take_woken_duration(&mut self) -> Option<std::time::Duration> {
+		let mut timing = self
+			.timing
+			.lock()
+			.unwrap_or_else(|poisoned| poisoned.into_inner());
+		let pending = timing.pending.take()?;
+		pending.wake_duration
+	}
+
+	fn record_woken_duration(&mut self) {
+		if let Some(duration) = self.take_woken_duration() {
+			self.record_poll(duration);
+		}
+	}
 }
 
 impl Drop for StreamQueryAccounting {
 	fn drop(&mut self) {
+		self.record_woken_duration();
 		if !self.completed {
 			return;
 		}
@@ -79,12 +110,44 @@ impl Drop for StreamQueryAccounting {
 		);
 	}
 }
+struct RowStreamWake {
+	timing: Arc<Mutex<RowStreamTiming>>,
+	generation: u64,
+	target: Waker,
+}
 
-/// Times individual backend-stream polls without spanning consumer idle time.
+impl RowStreamWake {
+	fn record_wake(&self) {
+		let mut timing = self
+			.timing
+			.lock()
+			.unwrap_or_else(|poisoned| poisoned.into_inner());
+		if let Some(pending) = timing.pending.as_mut()
+			&& pending.generation == self.generation
+			&& pending.wake_duration.is_none()
+		{
+			pending.wake_duration = Some(pending.started_at.elapsed());
+		}
+	}
+}
+
+impl Wake for RowStreamWake {
+	fn wake(self: Arc<Self>) {
+		self.record_wake();
+		self.target.wake_by_ref();
+	}
+
+	fn wake_by_ref(self: &Arc<Self>) {
+		self.record_wake();
+		self.target.wake_by_ref();
+	}
+}
+
+/// Times backend-stream polls through their wakeup without charging consumer idle time.
 ///
-/// A pending poll is deliberately not retained as elapsed state: cancelling a
-/// consumer poll therefore resets its timing instead of charging later
-/// application backpressure to the database query.
+/// A wrapped waker records a pending poll when the backend wakes the task. If
+/// the consumer cancels that poll and later polls again without a wakeup, the
+/// stale pending interval is discarded before the next backend poll.
 struct TimedRowStream<'rows, 'accounting> {
 	rows: RowStream<'rows>,
 	accounting: &'accounting mut StreamQueryAccounting,
@@ -94,15 +157,60 @@ impl<'rows, 'accounting> TimedRowStream<'rows, 'accounting> {
 	fn new(rows: RowStream<'rows>, accounting: &'accounting mut StreamQueryAccounting) -> Self {
 		Self { rows, accounting }
 	}
+
+	fn start_pending_poll(&mut self, started_at: Instant, target: Waker) -> (u64, Waker) {
+		let generation = {
+			let mut timing = self
+				.accounting
+				.timing
+				.lock()
+				.unwrap_or_else(|poisoned| poisoned.into_inner());
+			let generation = timing.next_generation;
+			timing.next_generation = timing.next_generation.wrapping_add(1);
+			timing.pending = Some(PendingRowPoll {
+				generation,
+				started_at,
+				wake_duration: None,
+			});
+			generation
+		};
+		let waker = Waker::from(Arc::new(RowStreamWake {
+			timing: Arc::clone(&self.accounting.timing),
+			generation,
+			target,
+		}));
+		(generation, waker)
+	}
+
+	fn clear_pending_poll(&mut self, generation: u64) {
+		let mut timing = self
+			.accounting
+			.timing
+			.lock()
+			.unwrap_or_else(|poisoned| poisoned.into_inner());
+		if timing
+			.pending
+			.as_ref()
+			.is_some_and(|pending| pending.generation == generation)
+		{
+			timing.pending = None;
+		}
+	}
 }
 
 impl Stream for TimedRowStream<'_, '_> {
 	type Item = reinhardt_core::exception::Result<crate::backends::types::Row>;
 
 	fn poll_next(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		self.accounting.record_woken_duration();
 		let started_at = Instant::now();
-		let result = self.rows.as_mut().poll_next(context);
-		self.accounting.record_poll(started_at.elapsed());
+		let (generation, waker) = self.start_pending_poll(started_at, context.waker().clone());
+		let mut timing_context = Context::from_waker(&waker);
+		let result = self.rows.as_mut().poll_next(&mut timing_context);
+		if result.is_ready() {
+			self.clear_pending_poll(generation);
+			self.accounting.record_poll(started_at.elapsed());
+		}
 		result
 	}
 }
@@ -5568,7 +5676,9 @@ where
 		self.apply_ordering(&mut stmt);
 
 		// Apply LIMIT/OFFSET
-		if let Some(limit) = self.limit {
+		if self.empty_result {
+			stmt.limit(0);
+		} else if let Some(limit) = self.limit {
 			stmt.limit(limit as u64);
 		}
 		if let Some(offset) = self.offset {
@@ -6379,7 +6489,6 @@ where
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
 						drop(rows.take());
-						accounting.disarm_completion();
 						yield Err(error);
 						return;
 					}
@@ -7861,7 +7970,9 @@ where
 			self.apply_ordering(&mut stmt);
 
 			// Apply LIMIT/OFFSET
-			if let Some(limit) = self.limit {
+			if self.empty_result {
+				stmt.limit(0);
+			} else if let Some(limit) = self.limit {
 				stmt.limit(limit as u64);
 			}
 			if let Some(offset) = self.offset {
@@ -8798,7 +8909,8 @@ fn escape_like_pattern(value: &str) -> String {
 mod tests {
 	use super::{
 		AggregateFunc, AggregateValue, ComparisonOp, FilterCondition, HavingCondition,
-		MAX_FILTER_CONDITION_DEPTH, QueryFilterInput,
+		MAX_FILTER_CONDITION_DEPTH, QueryFilterInput, RowStream, StreamQueryAccounting,
+		TimedRowStream,
 	};
 	#[cfg(feature = "pgvector")]
 	use crate::orm::Field;
@@ -8808,6 +8920,7 @@ mod tests {
 		DatabaseValue, FieldCodecError, FilterOperator, FilterValue, Manager, Model, QuerySet,
 		query::Filter,
 	};
+	use futures::Stream;
 	use reinhardt_query::{
 		QueryBuilder,
 		prelude::{PostgresQueryBuilder, QueryStatementBuilder, SqliteQueryBuilder},
@@ -8819,6 +8932,130 @@ mod tests {
 	use std::collections::HashMap;
 	#[cfg(feature = "pgvector")]
 	use std::fmt;
+	use std::pin::Pin;
+	use std::sync::{Arc, Mutex};
+	use std::task::{Context, Poll, Waker};
+	use std::time::Duration;
+
+	#[derive(Default)]
+	struct WakeDrivenRowStreamState {
+		ready: bool,
+		waker: Option<Waker>,
+	}
+
+	struct WakeDrivenRowStream {
+		state: Arc<Mutex<WakeDrivenRowStreamState>>,
+	}
+
+	impl Stream for WakeDrivenRowStream {
+		type Item = reinhardt_core::exception::Result<crate::backends::types::Row>;
+
+		fn poll_next(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+			let mut state = self
+				.state
+				.lock()
+				.unwrap_or_else(|poisoned| poisoned.into_inner());
+			if state.ready {
+				return Poll::Ready(None);
+			}
+			state.waker = Some(context.waker().clone());
+			Poll::Pending
+		}
+	}
+
+	struct PendingThenReadyRowStream {
+		first_poll: bool,
+		waker: Option<Waker>,
+	}
+
+	impl Stream for PendingThenReadyRowStream {
+		type Item = reinhardt_core::exception::Result<crate::backends::types::Row>;
+
+		fn poll_next(
+			mut self: Pin<&mut Self>,
+			context: &mut Context<'_>,
+		) -> Poll<Option<Self::Item>> {
+			if self.first_poll {
+				self.first_poll = false;
+				self.waker = Some(context.waker().clone());
+				return Poll::Pending;
+			}
+			assert!(
+				self.waker.take().is_some(),
+				"pending row stream must retain its registered waker"
+			);
+			Poll::Ready(None)
+		}
+	}
+
+	#[rstest]
+	fn timed_row_stream_records_pending_io_when_the_backend_wakes() {
+		// Arrange
+		let state = Arc::new(Mutex::new(WakeDrivenRowStreamState::default()));
+		let rows: RowStream<'_> = Box::pin(WakeDrivenRowStream {
+			state: Arc::clone(&state),
+		});
+		let mut accounting = StreamQueryAccounting::new("SELECT 1".to_owned(), Vec::new());
+		let waker = futures::task::noop_waker();
+		let mut context = Context::from_waker(&waker);
+
+		// Act
+		{
+			let mut stream = TimedRowStream::new(rows, &mut accounting);
+			assert!(matches!(
+				Pin::new(&mut stream).poll_next(&mut context),
+				Poll::Pending
+			));
+			std::thread::sleep(Duration::from_millis(20));
+			let waker = {
+				let mut state = state
+					.lock()
+					.unwrap_or_else(|poisoned| poisoned.into_inner());
+				state.ready = true;
+				state
+					.waker
+					.take()
+					.expect("pending row stream must register a waker")
+			};
+			waker.wake();
+			assert!(matches!(
+				Pin::new(&mut stream).poll_next(&mut context),
+				Poll::Ready(None)
+			));
+		}
+
+		// Assert
+		assert!(accounting.duration >= Duration::from_millis(10));
+	}
+
+	#[rstest]
+	fn timed_row_stream_discards_unwoken_pending_time_after_cancellation() {
+		// Arrange
+		let rows: RowStream<'_> = Box::pin(PendingThenReadyRowStream {
+			first_poll: true,
+			waker: None,
+		});
+		let mut accounting = StreamQueryAccounting::new("SELECT 1".to_owned(), Vec::new());
+		let waker = futures::task::noop_waker();
+		let mut context = Context::from_waker(&waker);
+
+		// Act
+		{
+			let mut stream = TimedRowStream::new(rows, &mut accounting);
+			assert!(matches!(
+				Pin::new(&mut stream).poll_next(&mut context),
+				Poll::Pending
+			));
+			std::thread::sleep(Duration::from_millis(20));
+			assert!(matches!(
+				Pin::new(&mut stream).poll_next(&mut context),
+				Poll::Ready(None)
+			));
+		}
+
+		// Assert
+		assert!(accounting.duration < Duration::from_millis(10));
+	}
 
 	#[cfg(feature = "pgvector")]
 	struct RecordingExecutor {
@@ -9482,6 +9719,23 @@ mod tests {
 		assert_eq!(rows_affected, 0);
 		assert!(executor.calls.is_empty());
 		assert!(executor.contexts.is_empty());
+	}
+
+	#[rstest]
+	fn none_aggregate_subquery_limits_output_rows() {
+		// Arrange
+		let queryset = QuerySet::<TestUser>::new().none().values(&["COUNT(*)"]);
+
+		// Act
+		let sql = queryset
+			.as_subquery()
+			.expect("empty aggregate subquery should compile");
+
+		// Assert
+		assert_eq!(
+			sql,
+			r#"(SELECT COUNT(*) FROM "test_users" WHERE FALSE LIMIT 0)"#
+		);
 	}
 
 	#[cfg(feature = "pgvector")]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -3,7 +3,7 @@
 //! This module provides a unified entry point for querying functionality.
 //! By default, it exports the expression-based query API (SQLAlchemy-style).
 
-use super::connection::{OrmExecutor, QueryRow};
+use super::connection::{OrmExecutor, QueryRow, RowStream};
 use super::field_codec::{
 	DatabaseField, DatabaseValue, FieldCodecError, IntoFieldValue, database_value_to_query_value,
 };
@@ -28,6 +28,7 @@ use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Instant;
 use uuid::Uuid;
 
@@ -67,6 +68,35 @@ impl Drop for StreamQueryAccounting {
 			&self.params,
 			self.duration,
 		);
+	}
+}
+
+/// Times individual backend-stream polls without spanning consumer idle time.
+///
+/// A pending poll is deliberately not retained as elapsed state: cancelling a
+/// consumer poll therefore resets its timing instead of charging later
+/// application backpressure to the database query.
+struct TimedRowStream<'rows, 'accounting> {
+	rows: RowStream<'rows>,
+	accounting: &'accounting mut StreamQueryAccounting,
+}
+
+impl<'rows, 'accounting> TimedRowStream<'rows, 'accounting> {
+	fn new(rows: RowStream<'rows>, accounting: &'accounting mut StreamQueryAccounting) -> Self {
+		Self { rows, accounting }
+	}
+}
+
+impl Stream for TimedRowStream<'_, '_> {
+	type Item = reinhardt_core::exception::Result<crate::backends::types::Row>;
+
+	fn poll_next(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		let started_at = Instant::now();
+		let result = self.rows.as_mut().poll_next(context);
+		if result.is_ready() {
+			self.accounting.record_poll(started_at.elapsed());
+		}
+		result
 	}
 }
 
@@ -6237,11 +6267,9 @@ where
 
 		Ok(Box::pin(async_stream::stream! {
 			let mut accounting = StreamQueryAccounting::new(sql.clone(), param_samples);
-			let mut rows = Some(rows);
+			let mut rows = Some(TimedRowStream::new(rows, &mut accounting));
 			loop {
-				let poll_started_at = Instant::now();
 				let row = rows.as_mut().expect("row stream is available").next().await;
-				accounting.record_poll(poll_started_at.elapsed());
 				let Some(row) = row else {
 					break;
 				};
@@ -6251,6 +6279,7 @@ where
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
+						drop(rows.take());
 						yield Err(error);
 						return;
 					}
@@ -6265,12 +6294,12 @@ where
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
+						drop(rows.take());
 						yield Err(error);
 						return;
 					}
 				}
 			}
-			drop(accounting);
 		}))
 	}
 
@@ -6313,11 +6342,9 @@ where
 
 		Ok(Box::pin(async_stream::stream! {
 			let mut accounting = StreamQueryAccounting::new(sql.clone(), param_samples);
-			let mut rows = Some(rows);
+			let mut rows = Some(TimedRowStream::new(rows, &mut accounting));
 			loop {
-				let poll_started_at = Instant::now();
 				let row = rows.as_mut().expect("row stream is available").next().await;
-				accounting.record_poll(poll_started_at.elapsed());
 				let Some(row) = row else {
 					break;
 				};
@@ -6327,6 +6354,7 @@ where
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
+						drop(rows.take());
 						yield Err(error);
 						return;
 					}
@@ -6341,12 +6369,12 @@ where
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
+						drop(rows.take());
 						yield Err(error);
 						return;
 					}
 				}
 			}
-			drop(accounting);
 		}))
 	}
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -43,7 +43,7 @@ pub type QuerySetStream<'a, T> =
 struct StreamQueryAccounting {
 	sql: String,
 	params: Vec<String>,
-	started: Instant,
+	duration: std::time::Duration,
 }
 
 impl StreamQueryAccounting {
@@ -51,8 +51,12 @@ impl StreamQueryAccounting {
 		Self {
 			sql,
 			params,
-			started: Instant::now(),
+			duration: std::time::Duration::ZERO,
 		}
+	}
+
+	fn record_poll(&mut self, duration: std::time::Duration) {
+		self.duration += duration;
 	}
 }
 
@@ -61,7 +65,7 @@ impl Drop for StreamQueryAccounting {
 		super::instrumentation::instrumentation().orm_query_end_with_params_sync(
 			&self.sql,
 			&self.params,
-			self.started.elapsed(),
+			self.duration,
 		);
 	}
 }
@@ -1570,6 +1574,9 @@ where
 	fn build_where_condition_for_write(
 		&self,
 	) -> reinhardt_core::exception::Result<Option<Condition>> {
+		if self.empty_result {
+			return Ok(Some(Condition::all().add(Expr::val(false))));
+		}
 		let mut queryset = self.clone();
 		queryset.relation_joins = RelationJoinGraph::new(T::table_name());
 		queryset.from_alias = None;
@@ -5467,6 +5474,9 @@ where
 		if let Some(cond) = where_condition {
 			stmt.cond_where(cond);
 		}
+		if self.empty_result {
+			stmt.and_where(Expr::val(false));
+		}
 
 		// Apply GROUP BY
 		for group_field in &self.group_by_fields {
@@ -5995,6 +6005,9 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		if self.empty_result {
+			return Ok(None);
+		}
 		let mut conn = super::manager::get_connection().await?;
 		self.first_with_db(&mut conn).await
 	}
@@ -6049,6 +6062,11 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		if self.empty_result {
+			return Err(reinhardt_core::exception::Error::NotFound(
+				"No record found matching the query".to_string(),
+			));
+		}
 		let mut conn = super::manager::get_connection().await?;
 		self.get_with_db(&mut conn).await
 	}
@@ -6218,13 +6236,18 @@ where
 		let rows = conn.fetch_stream_with_context(sql.clone(), params, chunk_size, context)?;
 
 		Ok(Box::pin(async_stream::stream! {
-			let accounting = StreamQueryAccounting::new(sql.clone(), param_samples);
+			let mut accounting = StreamQueryAccounting::new(sql.clone(), param_samples);
 			let mut rows = Some(rows);
-			while let Some(row) = rows.as_mut().expect("row stream is available").next().await {
+			loop {
+				let poll_started_at = Instant::now();
+				let row = rows.as_mut().expect("row stream is available").next().await;
+				accounting.record_poll(poll_started_at.elapsed());
+				let Some(row) = row else {
+					break;
+				};
 				let row = match row {
 					Ok(row) => row,
 					Err(error) => {
-						rows = None;
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
@@ -6239,7 +6262,6 @@ where
 							DatabaseErrorKind::Serialization,
 							format!("Deserialization error: {error}"),
 						));
-						rows = None;
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
@@ -6290,13 +6312,18 @@ where
 		let rows = executor.fetch_stream_with_context(sql.clone(), params, chunk_size, context)?;
 
 		Ok(Box::pin(async_stream::stream! {
-			let accounting = StreamQueryAccounting::new(sql.clone(), param_samples);
+			let mut accounting = StreamQueryAccounting::new(sql.clone(), param_samples);
 			let mut rows = Some(rows);
-			while let Some(row) = rows.as_mut().expect("row stream is available").next().await {
+			loop {
+				let poll_started_at = Instant::now();
+				let row = rows.as_mut().expect("row stream is available").next().await;
+				accounting.record_poll(poll_started_at.elapsed());
+				let Some(row) = row else {
+					break;
+				};
 				let row = match row {
 					Ok(row) => row,
 					Err(error) => {
-						rows = None;
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
@@ -6311,7 +6338,6 @@ where
 							DatabaseErrorKind::Serialization,
 							format!("Deserialization error: {error}"),
 						));
-						rows = None;
 						super::instrumentation::instrumentation()
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
@@ -6560,6 +6586,9 @@ where
 	/// # }
 	/// ```
 	pub async fn count(&self) -> reinhardt_core::exception::Result<usize> {
+		if self.empty_result {
+			return Ok(0);
+		}
 		let mut conn = super::manager::get_connection().await?;
 		self.count_with_db(&mut conn).await
 	}
@@ -6709,6 +6738,9 @@ where
 	/// # }
 	/// ```
 	pub async fn exists(&self) -> reinhardt_core::exception::Result<bool> {
+		if self.empty_result {
+			return Ok(false);
+		}
 		let mut conn = super::manager::get_connection().await?;
 		self.exists_with_db(&mut conn).await
 	}
@@ -7268,6 +7300,13 @@ where
 		T: super::Model + Clone,
 	{
 		Self::composite_primary_key_for_values(pk_values)?;
+		if self.empty_result {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Query,
+				"No record found matching the composite primary key",
+			)
+			.into());
+		}
 		let mut conn = super::manager::get_connection().await?;
 		self.get_composite_with_db(&mut conn, pk_values).await
 	}
@@ -7308,6 +7347,13 @@ where
 		use reinhardt_query::prelude::{Alias, BinOper, ColumnRef, Expr, Value};
 
 		let composite_pk = Self::composite_primary_key_for_values(pk_values)?;
+		if self.empty_result {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Query,
+				"No record found matching the composite primary key",
+			)
+			.into());
+		}
 
 		// Build SELECT query using reinhardt-query
 		let table_name = T::table_name();

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -6287,6 +6287,7 @@ where
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
 						drop(rows.take());
+						accounting.disarm_completion();
 						yield Err(error);
 						return;
 					}
@@ -9437,15 +9438,19 @@ mod tests {
 	}
 
 	#[cfg(feature = "pgvector")]
+	#[rstest]
 	#[tokio::test]
 	async fn none_short_circuits_read_and_write_execution_paths() {
+		// Arrange
 		let mut executor = RecordingExecutor::default();
 
+		// Act
 		let rows = QuerySet::<TestUser>::new()
 			.none()
 			.all_with_db(&mut executor)
 			.await
 			.expect("none queryset should not execute a select");
+		// Assert
 		assert_eq!(rows, Vec::<TestUser>::new());
 
 		let rows = QuerySet::<TestUser>::new()

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -88,16 +88,11 @@ impl Drop for StreamQueryAccounting {
 struct TimedRowStream<'rows, 'accounting> {
 	rows: RowStream<'rows>,
 	accounting: &'accounting mut StreamQueryAccounting,
-	pending_since: Option<Instant>,
 }
 
 impl<'rows, 'accounting> TimedRowStream<'rows, 'accounting> {
 	fn new(rows: RowStream<'rows>, accounting: &'accounting mut StreamQueryAccounting) -> Self {
-		Self {
-			rows,
-			accounting,
-			pending_since: None,
-		}
+		Self { rows, accounting }
 	}
 }
 
@@ -105,18 +100,9 @@ impl Stream for TimedRowStream<'_, '_> {
 	type Item = reinhardt_core::exception::Result<crate::backends::types::Row>;
 
 	fn poll_next(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-		if self.pending_since.is_none() {
-			self.pending_since = Some(Instant::now());
-		}
+		let started_at = Instant::now();
 		let result = self.rows.as_mut().poll_next(context);
-		if result.is_ready() {
-			let duration = self
-				.pending_since
-				.take()
-				.expect("stream poll start time is initialized")
-				.elapsed();
-			self.accounting.record_poll(duration);
-		}
+		self.accounting.record_poll(started_at.elapsed());
 		result
 	}
 }
@@ -6301,7 +6287,6 @@ where
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
 						drop(rows.take());
-						accounting.disarm_completion();
 						yield Err(error);
 						return;
 					}
@@ -6317,7 +6302,6 @@ where
 							.orm_query_error(&sql, &format!("{error:?}"))
 							.await;
 						drop(rows.take());
-						accounting.disarm_completion();
 						yield Err(error);
 						return;
 					}

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -7721,6 +7721,9 @@ where
 			if let Some(cond) = self.build_where_condition()? {
 				stmt.cond_where(cond);
 			}
+			if self.empty_result {
+				stmt.and_where(Expr::val(false));
+			}
 
 			// Apply GROUP BY
 			for group_field in &self.group_by_fields {

--- a/crates/reinhardt-db/src/orm/transaction.rs
+++ b/crates/reinhardt-db/src/orm/transaction.rs
@@ -54,7 +54,7 @@ use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 
 use super::connection::{
-	DatabaseBackend, OrmExecutor, QueryResult, QueryValue, Row, TransactionExecutor,
+	DatabaseBackend, OrmExecutor, QueryResult, QueryValue, Row, RowStream, TransactionExecutor,
 };
 use crate::backends::types::DatabaseType;
 
@@ -1024,6 +1024,26 @@ impl OrmExecutor for AtomicTransaction {
 			.await
 	}
 
+	fn fetch_stream<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> reinhardt_core::exception::Result<RowStream<'a>> {
+		self.executor_mut()?.fetch_stream(sql, params, chunk_size)
+	}
+
+	fn fetch_stream_with_context<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+		context: Option<crate::backends::error::PgvectorOperationKind>,
+	) -> reinhardt_core::exception::Result<RowStream<'a>> {
+		self.executor_mut()?
+			.fetch_stream_with_context(sql, params, chunk_size, context)
+	}
+
 	async fn fetch_optional(
 		&mut self,
 		sql: &str,
@@ -1125,6 +1145,26 @@ impl TransactionExecutor for AtomicTransaction {
 		self.executor_mut()?
 			.fetch_all_with_context(sql, params, context)
 			.await
+	}
+
+	fn fetch_stream<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> reinhardt_core::exception::Result<RowStream<'a>> {
+		self.executor_mut()?.fetch_stream(sql, params, chunk_size)
+	}
+
+	fn fetch_stream_with_context<'a>(
+		&'a mut self,
+		sql: String,
+		params: Vec<QueryValue>,
+		chunk_size: usize,
+		context: Option<crate::backends::error::PgvectorOperationKind>,
+	) -> reinhardt_core::exception::Result<RowStream<'a>> {
+		self.executor_mut()?
+			.fetch_stream_with_context(sql, params, chunk_size, context)
 	}
 
 	async fn fetch_optional(

--- a/crates/reinhardt-db/tests/queryset_streaming.rs
+++ b/crates/reinhardt-db/tests/queryset_streaming.rs
@@ -11,6 +11,7 @@ use reinhardt_query::prelude::{
 };
 use rstest::rstest;
 use serde::{Deserialize, Serialize};
+use serial_test::serial;
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::{
@@ -418,6 +419,7 @@ fn iterator_with_executor_rejects_invalid_chunks_and_unsupported_executors() {
 #[cfg(feature = "sqlite")]
 #[rstest]
 #[tokio::test]
+#[serial(queryset_streaming_connection_registry)]
 async fn sqlite_queryset_iterator_delivers_rows_without_query_cache() {
 	// Arrange
 	let owner = reinhardt_db::backends::DatabaseConnection::connect_sqlite("sqlite::memory:")

--- a/crates/reinhardt-db/tests/queryset_streaming.rs
+++ b/crates/reinhardt-db/tests/queryset_streaming.rs
@@ -6,6 +6,10 @@ use reinhardt_db::backends::types::{
 #[cfg(feature = "sqlite")]
 use reinhardt_db::orm::DatabaseConnectionLease;
 use reinhardt_db::orm::{Model, QuerySet};
+use reinhardt_query::prelude::{
+	Alias, ColumnDef, Expr, Query, QueryStatementBuilder, SqliteQueryBuilder,
+};
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::pin::Pin;
@@ -235,13 +239,16 @@ impl TransactionExecutor for UnsupportedExecutor {
 	}
 }
 
+#[rstest]
 #[tokio::test]
 async fn iterator_with_executor_bounds_buffer_and_decodes_rows() {
+	// Arrange
 	let rows = (1..=7)
 		.map(|id| Ok(article_row(id, QueryValue::String(format!("article-{id}")))))
 		.collect();
 	let mut executor = StreamingExecutor::new(rows);
 
+	// Act
 	let models = QuerySet::<StreamedArticle>::new()
 		.iterator_with_executor(&mut executor, 3)
 		.unwrap()
@@ -251,6 +258,7 @@ async fn iterator_with_executor_bounds_buffer_and_decodes_rows() {
 		.collect::<reinhardt_core::exception::Result<Vec<_>>>()
 		.unwrap();
 
+	// Assert
 	assert_eq!(models.len(), 7);
 	assert_eq!(models[0].title, "article-1");
 	assert_eq!(executor.stream_calls, 1);
@@ -258,8 +266,10 @@ async fn iterator_with_executor_bounds_buffer_and_decodes_rows() {
 	assert!(executor.dropped.load(Ordering::SeqCst));
 }
 
+#[rstest]
 #[tokio::test]
 async fn iterator_with_executor_releases_stream_on_early_drop() {
+	// Arrange
 	let mut executor = StreamingExecutor::new(vec![
 		Ok(article_row(1, QueryValue::String("first".to_owned()))),
 		Ok(article_row(2, QueryValue::String("second".to_owned()))),
@@ -269,14 +279,18 @@ async fn iterator_with_executor_releases_stream_on_early_drop() {
 		.iterator_with_executor(&mut executor, 1)
 		.unwrap();
 
+	// Act
 	assert_eq!(stream.next().await.unwrap().unwrap().title, "first");
 	drop(stream);
 
+	// Assert
 	assert!(dropped.load(Ordering::SeqCst));
 }
 
+#[rstest]
 #[tokio::test]
 async fn iterator_with_executor_releases_stream_after_cancelled_poll() {
+	// Arrange
 	let mut executor = StreamingExecutor::pending_after(vec![Ok(article_row(
 		1,
 		QueryValue::String("first".to_owned()),
@@ -286,8 +300,10 @@ async fn iterator_with_executor_releases_stream_after_cancelled_poll() {
 		.iterator_with_executor(&mut executor, 1)
 		.unwrap();
 
+	// Act
 	assert_eq!(stream.next().await.unwrap().unwrap().title, "first");
 	let cancelled = tokio::time::timeout(std::time::Duration::from_millis(10), stream.next()).await;
+	// Assert
 	assert!(cancelled.is_err());
 	assert!(!dropped.load(Ordering::SeqCst));
 	drop(stream);
@@ -295,8 +311,10 @@ async fn iterator_with_executor_releases_stream_after_cancelled_poll() {
 	assert!(dropped.load(Ordering::SeqCst));
 }
 
+#[rstest]
 #[tokio::test]
 async fn iterator_with_executor_surfaces_midstream_backend_error() {
+	// Arrange
 	let backend_error = DatabaseError::new(DatabaseErrorKind::Query, "stream interrupted");
 	let mut executor = StreamingExecutor::new(vec![
 		Ok(article_row(1, QueryValue::String("first".to_owned()))),
@@ -307,14 +325,18 @@ async fn iterator_with_executor_surfaces_midstream_backend_error() {
 		.iterator_with_executor(&mut executor, 2)
 		.unwrap();
 
+	// Act
 	assert_eq!(stream.next().await.unwrap().unwrap().title, "first");
+	// Assert
 	let error = stream.next().await.unwrap().unwrap_err();
 	assert_eq!(error.database_kind(), Some(DatabaseErrorKind::Query));
 	assert!(stream.next().await.is_none());
 }
 
+#[rstest]
 #[tokio::test]
 async fn iterator_with_executor_surfaces_midstream_decode_error() {
+	// Arrange
 	let mut executor = StreamingExecutor::new(vec![
 		Ok(article_row(1, QueryValue::String("first".to_owned()))),
 		Ok(article_row(2, QueryValue::Int(42))),
@@ -323,7 +345,9 @@ async fn iterator_with_executor_surfaces_midstream_decode_error() {
 		.iterator_with_executor(&mut executor, 2)
 		.unwrap();
 
+	// Act
 	assert_eq!(stream.next().await.unwrap().unwrap().title, "first");
+	// Assert
 	let error = stream.next().await.unwrap().unwrap_err();
 	assert_eq!(
 		error.database_kind(),
@@ -332,14 +356,18 @@ async fn iterator_with_executor_surfaces_midstream_decode_error() {
 	assert!(stream.next().await.is_none());
 }
 
+#[rstest]
 #[tokio::test]
 async fn iterator_with_executor_handles_empty_and_none_querysets() {
+	// Arrange
 	let mut empty_executor = StreamingExecutor::new(Vec::new());
+	// Act
 	let rows = QuerySet::<StreamedArticle>::new()
 		.iterator_with_executor(&mut empty_executor, 4)
 		.unwrap()
 		.collect::<Vec<_>>()
 		.await;
+	// Assert
 	assert_eq!(rows.len(), 0);
 	assert_eq!(empty_executor.stream_calls, 1);
 
@@ -357,15 +385,18 @@ async fn iterator_with_executor_handles_empty_and_none_querysets() {
 	assert_eq!(none_executor.stream_calls, 0);
 }
 
-#[test]
+#[rstest]
 fn iterator_with_executor_rejects_invalid_chunks_and_unsupported_executors() {
+	// Arrange
 	let mut streaming_executor = StreamingExecutor::new(Vec::new());
+	// Act
 	let error = match QuerySet::<StreamedArticle>::new()
 		.iterator_with_executor(&mut streaming_executor, 0)
 	{
 		Ok(_) => panic!("zero chunk size must be rejected"),
 		Err(error) => error,
 	};
+	// Assert
 	assert_eq!(
 		error.database_kind(),
 		Some(DatabaseErrorKind::Configuration)
@@ -383,30 +414,36 @@ fn iterator_with_executor_rejects_invalid_chunks_and_unsupported_executors() {
 }
 
 #[cfg(feature = "sqlite")]
+#[rstest]
 #[tokio::test]
 async fn sqlite_queryset_iterator_delivers_rows_without_query_cache() {
+	// Arrange
 	let owner = reinhardt_db::backends::DatabaseConnection::connect_sqlite("sqlite::memory:")
 		.await
 		.unwrap();
-	owner
-		.execute(
-			"CREATE TABLE streamed_articles (id INTEGER PRIMARY KEY, title TEXT NOT NULL)",
-			vec![],
+	let create_table = Query::create_table()
+		.table(Alias::new("streamed_articles"))
+		.col(
+			ColumnDef::new(Alias::new("id"))
+				.integer()
+				.not_null(true)
+				.primary_key(true),
 		)
-		.await
-		.unwrap();
+		.col(ColumnDef::new(Alias::new("title")).string().not_null(true))
+		.to_string(SqliteQueryBuilder);
+	owner.execute(&create_table, vec![]).await.unwrap();
 	for (id, title) in [(1, "first"), (2, "second"), (3, "third")] {
-		owner
-			.execute(
-				"INSERT INTO streamed_articles (id, title) VALUES (?, ?)",
-				vec![QueryValue::Int(id), QueryValue::String(title.to_owned())],
-			)
-			.await
-			.unwrap();
+		let insert = Query::insert()
+			.into_table(Alias::new("streamed_articles"))
+			.columns([Alias::new("id"), Alias::new("title")])
+			.values_panic([Expr::val(id), Expr::val(title)])
+			.to_string(SqliteQueryBuilder);
+		owner.execute(&insert, vec![]).await.unwrap();
 	}
 	let lease = DatabaseConnectionLease::register(owner).unwrap();
 	let mut connection = lease.handle();
 
+	// Act
 	let models = QuerySet::<StreamedArticle>::new()
 		.iterator_with_db(&mut connection, 1)
 		.unwrap()
@@ -416,6 +453,7 @@ async fn sqlite_queryset_iterator_delivers_rows_without_query_cache() {
 		.collect::<reinhardt_core::exception::Result<Vec<_>>>()
 		.unwrap();
 
+	// Assert
 	assert_eq!(
 		models,
 		vec![

--- a/crates/reinhardt-db/tests/queryset_streaming.rs
+++ b/crates/reinhardt-db/tests/queryset_streaming.rs
@@ -321,6 +321,7 @@ async fn iterator_with_executor_surfaces_midstream_backend_error() {
 		Err(backend_error.into()),
 		Ok(article_row(2, QueryValue::String("unreachable".to_owned()))),
 	]);
+	let dropped = Arc::clone(&executor.dropped);
 	let mut stream = QuerySet::<StreamedArticle>::new()
 		.iterator_with_executor(&mut executor, 2)
 		.unwrap();
@@ -330,7 +331,7 @@ async fn iterator_with_executor_surfaces_midstream_backend_error() {
 	// Assert
 	let error = stream.next().await.unwrap().unwrap_err();
 	assert_eq!(error.database_kind(), Some(DatabaseErrorKind::Query));
-	assert!(stream.next().await.is_none());
+	assert!(dropped.load(Ordering::SeqCst));
 }
 
 #[rstest]
@@ -341,6 +342,7 @@ async fn iterator_with_executor_surfaces_midstream_decode_error() {
 		Ok(article_row(1, QueryValue::String("first".to_owned()))),
 		Ok(article_row(2, QueryValue::Int(42))),
 	]);
+	let dropped = Arc::clone(&executor.dropped);
 	let mut stream = QuerySet::<StreamedArticle>::new()
 		.iterator_with_executor(&mut executor, 2)
 		.unwrap();
@@ -353,7 +355,7 @@ async fn iterator_with_executor_surfaces_midstream_decode_error() {
 		error.database_kind(),
 		Some(DatabaseErrorKind::Serialization)
 	);
-	assert!(stream.next().await.is_none());
+	assert!(dropped.load(Ordering::SeqCst));
 }
 
 #[rstest]

--- a/crates/reinhardt-db/tests/queryset_streaming.rs
+++ b/crates/reinhardt-db/tests/queryset_streaming.rs
@@ -5,7 +5,7 @@ use reinhardt_db::backends::types::{
 };
 #[cfg(feature = "sqlite")]
 use reinhardt_db::orm::DatabaseConnectionLease;
-use reinhardt_db::orm::{Model, QuerySet};
+use reinhardt_db::orm::{Model, NPlusOneConfig, NPlusOneScope, QuerySet};
 use reinhardt_query::prelude::{
 	Alias, ColumnDef, Expr, Query, QueryStatementBuilder, SqliteQueryBuilder,
 };
@@ -357,6 +357,37 @@ async fn iterator_with_executor_surfaces_midstream_decode_error() {
 		Some(DatabaseErrorKind::Serialization)
 	);
 	assert!(dropped.load(Ordering::SeqCst));
+}
+
+#[rstest]
+#[tokio::test]
+async fn iterator_with_executor_records_completed_query_after_decode_error() {
+	// Arrange
+	let mut executor = StreamingExecutor::new(vec![Ok(article_row(1, QueryValue::Int(42)))]);
+
+	// Act
+	let (error, report) =
+		NPlusOneScope::warn("queryset-streaming-decode-error", NPlusOneConfig::default())
+			.run_with_report(async {
+				let mut stream = QuerySet::<StreamedArticle>::new()
+					.iterator_with_executor(&mut executor, 1)
+					.expect("streaming executor should support row streams");
+				let error = stream
+					.next()
+					.await
+					.expect("stream should yield the decode error")
+					.expect_err("invalid title value must fail model decoding");
+				drop(stream);
+				error
+			})
+			.await;
+
+	// Assert
+	assert_eq!(
+		error.database_kind(),
+		Some(DatabaseErrorKind::Serialization)
+	);
+	assert_eq!(report.total_recorded_queries, 1);
 }
 
 #[rstest]

--- a/crates/reinhardt-db/tests/queryset_streaming.rs
+++ b/crates/reinhardt-db/tests/queryset_streaming.rs
@@ -1,0 +1,436 @@
+use futures::{Stream, StreamExt};
+use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind};
+use reinhardt_db::backends::types::{
+	DatabaseType, QueryResult, QueryValue, Row, RowStream, TransactionExecutor,
+};
+#[cfg(feature = "sqlite")]
+use reinhardt_db::orm::DatabaseConnectionLease;
+use reinhardt_db::orm::{Model, QuerySet};
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::sync::{
+	Arc,
+	atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+use std::task::{Context, Poll};
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct StreamedArticle {
+	id: Option<i64>,
+	title: String,
+}
+
+#[derive(Clone)]
+struct StreamedArticleFields;
+
+impl reinhardt_db::orm::model::FieldSelector for StreamedArticleFields {
+	fn with_alias(self, _alias: &str) -> Self {
+		self
+	}
+}
+
+impl Model for StreamedArticle {
+	type PrimaryKey = i64;
+	type Fields = StreamedArticleFields;
+	type Objects = reinhardt_db::orm::Manager<Self>;
+
+	fn table_name() -> &'static str {
+		"streamed_articles"
+	}
+
+	fn new_fields() -> Self::Fields {
+		StreamedArticleFields
+	}
+
+	fn primary_key(&self) -> Option<Self::PrimaryKey> {
+		self.id
+	}
+
+	fn set_primary_key(&mut self, value: Self::PrimaryKey) {
+		self.id = Some(value);
+	}
+}
+
+fn article_row(id: i64, title: QueryValue) -> Row {
+	let mut row = Row::new();
+	row.insert("id".to_owned(), QueryValue::Int(id));
+	row.insert("title".to_owned(), title);
+	row
+}
+
+struct BoundedMockStream {
+	source: VecDeque<reinhardt_core::exception::Result<Row>>,
+	buffer: VecDeque<reinhardt_core::exception::Result<Row>>,
+	bound: usize,
+	pending_when_empty: bool,
+	max_buffered: Arc<AtomicUsize>,
+	dropped: Arc<AtomicBool>,
+}
+
+impl Stream for BoundedMockStream {
+	type Item = reinhardt_core::exception::Result<Row>;
+
+	fn poll_next(mut self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		if self.buffer.is_empty() {
+			while self.buffer.len() < self.bound {
+				let Some(row) = self.source.pop_front() else {
+					break;
+				};
+				self.buffer.push_back(row);
+			}
+			self.max_buffered
+				.fetch_max(self.buffer.len(), Ordering::SeqCst);
+		}
+		if self.buffer.is_empty() && self.pending_when_empty {
+			return Poll::Pending;
+		}
+		Poll::Ready(self.buffer.pop_front())
+	}
+}
+
+impl Drop for BoundedMockStream {
+	fn drop(&mut self) {
+		self.dropped.store(true, Ordering::SeqCst);
+	}
+}
+
+struct StreamingExecutor {
+	rows: VecDeque<reinhardt_core::exception::Result<Row>>,
+	stream_calls: usize,
+	pending_when_empty: bool,
+	max_buffered: Arc<AtomicUsize>,
+	dropped: Arc<AtomicBool>,
+}
+
+impl StreamingExecutor {
+	fn new(rows: Vec<reinhardt_core::exception::Result<Row>>) -> Self {
+		Self {
+			rows: rows.into(),
+			stream_calls: 0,
+			pending_when_empty: false,
+			max_buffered: Arc::new(AtomicUsize::new(0)),
+			dropped: Arc::new(AtomicBool::new(false)),
+		}
+	}
+
+	fn pending_after(rows: Vec<reinhardt_core::exception::Result<Row>>) -> Self {
+		Self {
+			pending_when_empty: true,
+			..Self::new(rows)
+		}
+	}
+}
+
+#[async_trait::async_trait]
+impl TransactionExecutor for StreamingExecutor {
+	fn backend(&self) -> DatabaseType {
+		DatabaseType::Sqlite
+	}
+
+	async fn execute(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<QueryResult> {
+		panic!("streaming QuerySet test does not execute mutations")
+	}
+
+	async fn fetch_one(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<Row> {
+		panic!("streaming QuerySet test does not fetch one row")
+	}
+
+	async fn fetch_all(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<Vec<Row>> {
+		panic!("streaming QuerySet must never call fetch_all")
+	}
+
+	fn fetch_stream<'a>(
+		&'a mut self,
+		_sql: String,
+		_params: Vec<QueryValue>,
+		chunk_size: usize,
+	) -> reinhardt_core::exception::Result<RowStream<'a>> {
+		self.stream_calls += 1;
+		Ok(Box::pin(BoundedMockStream {
+			source: std::mem::take(&mut self.rows),
+			buffer: VecDeque::new(),
+			bound: chunk_size,
+			pending_when_empty: self.pending_when_empty,
+			max_buffered: Arc::clone(&self.max_buffered),
+			dropped: Arc::clone(&self.dropped),
+		}))
+	}
+
+	async fn fetch_optional(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<Option<Row>> {
+		panic!("streaming QuerySet test does not fetch an optional row")
+	}
+
+	async fn commit(self: Box<Self>) -> reinhardt_core::exception::Result<()> {
+		Ok(())
+	}
+
+	async fn rollback(self: Box<Self>) -> reinhardt_core::exception::Result<()> {
+		Ok(())
+	}
+}
+
+struct UnsupportedExecutor;
+
+#[async_trait::async_trait]
+impl TransactionExecutor for UnsupportedExecutor {
+	fn backend(&self) -> DatabaseType {
+		DatabaseType::Sqlite
+	}
+
+	async fn execute(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<QueryResult> {
+		panic!("unsupported streaming test does not execute mutations")
+	}
+
+	async fn fetch_one(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<Row> {
+		panic!("unsupported streaming test does not fetch one row")
+	}
+
+	async fn fetch_all(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<Vec<Row>> {
+		panic!("unsupported streaming test does not fetch all rows")
+	}
+
+	async fn fetch_optional(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<Option<Row>> {
+		panic!("unsupported streaming test does not fetch an optional row")
+	}
+
+	async fn commit(self: Box<Self>) -> reinhardt_core::exception::Result<()> {
+		Ok(())
+	}
+
+	async fn rollback(self: Box<Self>) -> reinhardt_core::exception::Result<()> {
+		Ok(())
+	}
+}
+
+#[tokio::test]
+async fn iterator_with_executor_bounds_buffer_and_decodes_rows() {
+	let rows = (1..=7)
+		.map(|id| Ok(article_row(id, QueryValue::String(format!("article-{id}")))))
+		.collect();
+	let mut executor = StreamingExecutor::new(rows);
+
+	let models = QuerySet::<StreamedArticle>::new()
+		.iterator_with_executor(&mut executor, 3)
+		.unwrap()
+		.collect::<Vec<_>>()
+		.await
+		.into_iter()
+		.collect::<reinhardt_core::exception::Result<Vec<_>>>()
+		.unwrap();
+
+	assert_eq!(models.len(), 7);
+	assert_eq!(models[0].title, "article-1");
+	assert_eq!(executor.stream_calls, 1);
+	assert_eq!(executor.max_buffered.load(Ordering::SeqCst), 3);
+	assert!(executor.dropped.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn iterator_with_executor_releases_stream_on_early_drop() {
+	let mut executor = StreamingExecutor::new(vec![
+		Ok(article_row(1, QueryValue::String("first".to_owned()))),
+		Ok(article_row(2, QueryValue::String("second".to_owned()))),
+	]);
+	let dropped = Arc::clone(&executor.dropped);
+	let mut stream = QuerySet::<StreamedArticle>::new()
+		.iterator_with_executor(&mut executor, 1)
+		.unwrap();
+
+	assert_eq!(stream.next().await.unwrap().unwrap().title, "first");
+	drop(stream);
+
+	assert!(dropped.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn iterator_with_executor_releases_stream_after_cancelled_poll() {
+	let mut executor = StreamingExecutor::pending_after(vec![Ok(article_row(
+		1,
+		QueryValue::String("first".to_owned()),
+	))]);
+	let dropped = Arc::clone(&executor.dropped);
+	let mut stream = QuerySet::<StreamedArticle>::new()
+		.iterator_with_executor(&mut executor, 1)
+		.unwrap();
+
+	assert_eq!(stream.next().await.unwrap().unwrap().title, "first");
+	let cancelled = tokio::time::timeout(std::time::Duration::from_millis(10), stream.next()).await;
+	assert!(cancelled.is_err());
+	assert!(!dropped.load(Ordering::SeqCst));
+	drop(stream);
+
+	assert!(dropped.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn iterator_with_executor_surfaces_midstream_backend_error() {
+	let backend_error = DatabaseError::new(DatabaseErrorKind::Query, "stream interrupted");
+	let mut executor = StreamingExecutor::new(vec![
+		Ok(article_row(1, QueryValue::String("first".to_owned()))),
+		Err(backend_error.into()),
+		Ok(article_row(2, QueryValue::String("unreachable".to_owned()))),
+	]);
+	let mut stream = QuerySet::<StreamedArticle>::new()
+		.iterator_with_executor(&mut executor, 2)
+		.unwrap();
+
+	assert_eq!(stream.next().await.unwrap().unwrap().title, "first");
+	let error = stream.next().await.unwrap().unwrap_err();
+	assert_eq!(error.database_kind(), Some(DatabaseErrorKind::Query));
+	assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn iterator_with_executor_surfaces_midstream_decode_error() {
+	let mut executor = StreamingExecutor::new(vec![
+		Ok(article_row(1, QueryValue::String("first".to_owned()))),
+		Ok(article_row(2, QueryValue::Int(42))),
+	]);
+	let mut stream = QuerySet::<StreamedArticle>::new()
+		.iterator_with_executor(&mut executor, 2)
+		.unwrap();
+
+	assert_eq!(stream.next().await.unwrap().unwrap().title, "first");
+	let error = stream.next().await.unwrap().unwrap_err();
+	assert_eq!(
+		error.database_kind(),
+		Some(DatabaseErrorKind::Serialization)
+	);
+	assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn iterator_with_executor_handles_empty_and_none_querysets() {
+	let mut empty_executor = StreamingExecutor::new(Vec::new());
+	let rows = QuerySet::<StreamedArticle>::new()
+		.iterator_with_executor(&mut empty_executor, 4)
+		.unwrap()
+		.collect::<Vec<_>>()
+		.await;
+	assert_eq!(rows.len(), 0);
+	assert_eq!(empty_executor.stream_calls, 1);
+
+	let mut none_executor = StreamingExecutor::new(vec![Ok(article_row(
+		1,
+		QueryValue::String("must not execute".to_owned()),
+	))]);
+	let rows = QuerySet::<StreamedArticle>::new()
+		.none()
+		.iterator_with_executor(&mut none_executor, 4)
+		.unwrap()
+		.collect::<Vec<_>>()
+		.await;
+	assert_eq!(rows.len(), 0);
+	assert_eq!(none_executor.stream_calls, 0);
+}
+
+#[test]
+fn iterator_with_executor_rejects_invalid_chunks_and_unsupported_executors() {
+	let mut streaming_executor = StreamingExecutor::new(Vec::new());
+	let error = match QuerySet::<StreamedArticle>::new()
+		.iterator_with_executor(&mut streaming_executor, 0)
+	{
+		Ok(_) => panic!("zero chunk size must be rejected"),
+		Err(error) => error,
+	};
+	assert_eq!(
+		error.database_kind(),
+		Some(DatabaseErrorKind::Configuration)
+	);
+	assert_eq!(streaming_executor.stream_calls, 0);
+
+	let mut unsupported_executor = UnsupportedExecutor;
+	let error = match QuerySet::<StreamedArticle>::new()
+		.iterator_with_executor(&mut unsupported_executor, 1)
+	{
+		Ok(_) => panic!("unsupported executor must be rejected"),
+		Err(error) => error,
+	};
+	assert_eq!(error.database_kind(), Some(DatabaseErrorKind::Unsupported));
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn sqlite_queryset_iterator_delivers_rows_without_query_cache() {
+	let owner = reinhardt_db::backends::DatabaseConnection::connect_sqlite("sqlite::memory:")
+		.await
+		.unwrap();
+	owner
+		.execute(
+			"CREATE TABLE streamed_articles (id INTEGER PRIMARY KEY, title TEXT NOT NULL)",
+			vec![],
+		)
+		.await
+		.unwrap();
+	for (id, title) in [(1, "first"), (2, "second"), (3, "third")] {
+		owner
+			.execute(
+				"INSERT INTO streamed_articles (id, title) VALUES (?, ?)",
+				vec![QueryValue::Int(id), QueryValue::String(title.to_owned())],
+			)
+			.await
+			.unwrap();
+	}
+	let lease = DatabaseConnectionLease::register(owner).unwrap();
+	let mut connection = lease.handle();
+
+	let models = QuerySet::<StreamedArticle>::new()
+		.iterator_with_db(&mut connection, 1)
+		.unwrap()
+		.collect::<Vec<_>>()
+		.await
+		.into_iter()
+		.collect::<reinhardt_core::exception::Result<Vec<_>>>()
+		.unwrap();
+
+	assert_eq!(
+		models,
+		vec![
+			StreamedArticle {
+				id: Some(1),
+				title: "first".to_owned(),
+			},
+			StreamedArticle {
+				id: Some(2),
+				title: "second".to_owned(),
+			},
+			StreamedArticle {
+				id: Some(3),
+				title: "third".to_owned(),
+			},
+		]
+	);
+}

--- a/tests/integration/tests/commands/shell_e2e.rs
+++ b/tests/integration/tests/commands/shell_e2e.rs
@@ -1423,6 +1423,20 @@ tokio = {{ version = "1", features = ["macros", "rt-multi-thread", "time"] }}
 [features]
 default = []
 commands-shell = ["reinhardt/commands-shell"]
+
+# Match evcxr's generated evaluator profile so the fixture prebuild warms the
+# same artifact cache used by `manage shell`.
+[profile.dev]
+opt-level = 2
+debug = false
+strip = "debuginfo"
+rpath = true
+lto = false
+debug-assertions = true
+codegen-units = 16
+panic = "unwind"
+incremental = true
+overflow-checks = true
 "#,
 			repository_root.display()
 		),

--- a/tests/integration/tests/commands/shell_e2e.rs
+++ b/tests/integration/tests/commands/shell_e2e.rs
@@ -31,7 +31,7 @@ use rexpect::session::PtySession;
 use tempfile::TempDir;
 
 // The evaluator builds its dependencies outside the fixture target directory.
-const COMMAND_TIMEOUT: Duration = Duration::from_secs(600);
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(1200);
 const FIXTURE_BUILD_TIMEOUT: Duration = Duration::from_secs(600);
 const FIXTURE_BUILD_JOBS: &str = "2";
 const PTY_TIMEOUT: Duration = Duration::from_secs(60);

--- a/tests/integration/tests/commands/shell_e2e.rs
+++ b/tests/integration/tests/commands/shell_e2e.rs
@@ -34,6 +34,13 @@ use tempfile::TempDir;
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(1200);
 const FIXTURE_BUILD_TIMEOUT: Duration = Duration::from_secs(600);
 const FIXTURE_BUILD_JOBS: &str = "2";
+// Workaround for evcxr/evcxr#487 (tracked in reinhardt-web#5817).
+// Remove this override when evcxr derives the generated library path from
+// Cargo's emitted artifact metadata instead of assuming target/.../deps.
+//
+// Ideal implementation (without workaround):
+//   EvalContext should consume Cargo's emitted artifact path directly.
+const EVALUATOR_BUILD_DIR: &str = "target";
 const PTY_TIMEOUT: Duration = Duration::from_secs(60);
 const CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 const READER_TIMEOUT: Duration = Duration::from_secs(2);
@@ -725,6 +732,7 @@ impl ShellProject {
 		let mut command = Command::new(&self.manage_binary);
 		command
 			.current_dir(&self.project_root)
+			.env("CARGO_BUILD_BUILD_DIR", EVALUATOR_BUILD_DIR)
 			.env("EVCXR_TMPDIR", self._evcxr_dir.path())
 			.env("EVCXR_CACHE_ENABLED", "1")
 			.env(
@@ -747,6 +755,7 @@ impl ShellProject {
 		command
 			.arg("shell")
 			.current_dir(&self.project_root)
+			.env("CARGO_BUILD_BUILD_DIR", EVALUATOR_BUILD_DIR)
 			.env("EVCXR_TMPDIR", self._evcxr_dir.path())
 			.env("EVCXR_CACHE_ENABLED", "1")
 			.env(


### PR DESCRIPTION
## Summary

This PR addresses:

- Add lifetime-bound `RowStream` capabilities to database and transaction executor contracts.
- Add `QuerySet::iterator_with_executor()` / `iterator_with_db()` and `QuerySet::none()` without eager materialization or LIMIT/OFFSET pagination.
- Stream typed models from PostgreSQL, MySQL, and SQLite executors with per-item errors, explicit unsupported-capability errors, and RAII cleanup on completion, error, cancellation, or drop.
- Document caller-owned executor and typed-field streaming usage.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [x] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Large querysets currently require eager row collection before model decoding. This change introduces a lifetime-bound streaming path whose resource lifetime is tied to the caller-owned executor. `chunk_size` is passed as a driver or bounded-buffer hint; the implementation never falls back to `fetch_all()` or repeated LIMIT/OFFSET queries.

Fixes #5846

Related to: #5812

## How Was This Tested?

- `cargo test --offline -p reinhardt-db --no-default-features --features orm,sqlite --test queryset_streaming -- --test-threads=1` (8 passed)
- `cargo check --offline -p reinhardt-db --no-default-features --features orm,sqlite,mysql,postgres --lib`
- `cargo clippy --offline -p reinhardt-db --no-default-features --features orm,sqlite,mysql,postgres --lib -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --offline -p reinhardt-db --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`

The integration test suite covers bounded buffering, empty and `none()` querysets, invalid chunks, unsupported executors, cancelled polls, early drop, mid-stream backend and decode errors, and an actual SQLite backend stream.

## Performance Impact

The iterator avoids queryset-level eager materialization. Built-in SQLx backends stream rows from the driver, while `chunk_size` remains a non-semantic driver/buffer hint and does not alter query ordering or result contents.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5846
- Related to #5812

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Custom executors that do not implement row streaming return an explicit `Unsupported` database error. There is intentionally no eager or pagination fallback.

🤖 Generated with [Codex](https://openai.com/codex)