### PR TITLE
feat(db): add transaction-safe QuerySet row locking

### DIFF
--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -217,10 +217,10 @@ MySQL capability profile requires MySQL 8.0.1 or newer and does not support
 target lists. Custom transaction executors connected to servers with different
 capabilities must override `TransactionExecutor::row_lock_capabilities`.
 
-To preserve the statement's lock scope, row locking rejects querysets backed by
-derived `FROM` sources or LATERAL joins, raw aggregate projections passed to
-`values`, and aggregate annotations. Use a direct non-aggregate queryset for
-locking reads.
+To preserve the statement's lock scope, row locking rejects CTE-backed
+querysets, derived `FROM` sources, LATERAL joins, raw aggregate projections
+passed to `values`, and aggregate annotations. Use a direct non-aggregate
+queryset for locking reads.
 
 - **Database Replication and Routing**
   - Read/write splitting via DatabaseRouter

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -178,9 +178,14 @@ dropping the lock.
 PostgreSQL supports target lists and `no_key`; `NO KEY UPDATE` requires
 PostgreSQL 9.3 or newer and `SKIP LOCKED` requires 9.5 or newer. The built-in
 MySQL capability profile requires MySQL 8.0.1 or newer and does not support
-`no_key`. CockroachDB does not expose PostgreSQL-distinct `no_key` or explicit
-target-list capability. Custom transaction executors connected to older server
-versions must override `TransactionExecutor::row_lock_capabilities`.
+`no_key`. The built-in CockroachDB v23.1 profile supports `FOR UPDATE` and
+`NOWAIT`, but not `SKIP LOCKED`, PostgreSQL-distinct `no_key`, or explicit
+target lists. Custom transaction executors connected to servers with different
+capabilities must override `TransactionExecutor::row_lock_capabilities`.
+
+To preserve the statement's lock scope, row locking rejects querysets backed by
+derived `FROM` sources or LATERAL joins, and raw aggregate projections passed to
+`values`. Use a direct non-aggregate queryset for locking reads.
 
 - **Database Replication and Routing**
   - Read/write splitting via DatabaseRouter

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -75,6 +75,7 @@ This crate provides the following modules:
   - Closure-scoped atomic transactions with nested savepoints
   - Mutable executor ownership for transaction-scoped ORM work
   - Typed callback errors with automatic conversion from framework failures
+  - Typed, transaction-safe `QuerySet::select_for_update` row locking
 
 - **Structured Database Errors**
   - `DatabaseErrorKind` provides portable connection, constraint, transaction, serialization, and query categories
@@ -128,6 +129,58 @@ let result: Result<(), ApplicationError> = connection.atomic(async |_transaction
 result
 # }
 ```
+
+### Transaction-safe row locking
+
+Build row locks after configuring a `QuerySet`, then evaluate them with
+`SelectForUpdate::all_with_executor` or `rows_with_executor` inside
+`DatabaseConnection::atomic`. The executor remains owned by the caller, so the
+lock stays on the same physical connection until commit or rollback. Ordinary
+`all`, `all_with_db`, and `rows_with_db` evaluation returns a transaction error
+without executing SQL.
+
+```rust,no_run
+use reinhardt_db::{
+    backends::error::DatabaseError,
+    orm::{QuerySet, TransactionExecutor},
+};
+use reinhardt_macros::model;
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "jobs", table_name = "jobs")]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct Job {
+    #[field(primary_key = true)]
+    id: i64,
+    state: String,
+}
+
+async fn claim_queued(
+    transaction: &mut dyn TransactionExecutor,
+) -> Result<Vec<Job>, DatabaseError> {
+    QuerySet::<Job>::new()
+        .filter(Job::field_state().eq("queued".to_owned()))
+        .select_for_update()
+        .skip_locked()
+        .of_model()
+        .all_with_executor(transaction)
+        .await
+}
+```
+
+`nowait` and `skip_locked` are mutually exclusive type states. `of_model`
+targets the root model, while `of_relation` accepts only a typed relation path
+rooted at that model and automatically adds the required joins. Reinhardt is
+intentionally stricter than Django: unchecked table-name targets are not
+accepted, and SQLite returns an unsupported-capability error instead of silently
+dropping the lock.
+
+PostgreSQL supports target lists and `no_key`; `NO KEY UPDATE` requires
+PostgreSQL 9.3 or newer and `SKIP LOCKED` requires 9.5 or newer. The built-in
+MySQL capability profile requires MySQL 8.0.1 or newer and does not support
+`no_key`. CockroachDB does not expose PostgreSQL-distinct `no_key` or explicit
+target-list capability. Custom transaction executors connected to older server
+versions must override `TransactionExecutor::row_lock_capabilities`.
 
 - **Database Replication and Routing**
   - Read/write splitting via DatabaseRouter

--- a/crates/reinhardt-db/src/backends/connection.rs
+++ b/crates/reinhardt-db/src/backends/connection.rs
@@ -67,6 +67,15 @@ impl TransactionExecutor for FlavoredTransactionExecutor {
 		self.is_cockroachdb
 	}
 
+	fn row_lock_capabilities(&self) -> super::types::RowLockCapabilities {
+		let mut capabilities = self.inner.row_lock_capabilities();
+		if self.is_cockroachdb {
+			capabilities.no_key_update = false;
+			capabilities.targets = false;
+		}
+		capabilities
+	}
+
 	fn supports_pgvector_error_hints(&self) -> bool {
 		self.inner.supports_pgvector_error_hints()
 	}

--- a/crates/reinhardt-db/src/backends/connection.rs
+++ b/crates/reinhardt-db/src/backends/connection.rs
@@ -60,7 +60,14 @@ fn mysql_row_lock_capabilities(version: Option<&str>) -> RowLockCapabilities {
 	let Some(version) = version else {
 		return RowLockCapabilities::mysql();
 	};
-	let Some((major, minor, patch)) = parse_server_version(version) else {
+	let components: Vec<_> = version.split('-').collect();
+	let normalized_version = components
+		.iter()
+		.position(|component| component.to_ascii_lowercase().contains("mariadb"))
+		.and_then(|mariadb| mariadb.checked_sub(1))
+		.and_then(|version_component| components.get(version_component).copied())
+		.unwrap_or(version);
+	let Some((major, minor, patch)) = parse_server_version(normalized_version) else {
 		return RowLockCapabilities::mysql();
 	};
 	if version.to_ascii_lowercase().contains("mariadb") {
@@ -1147,6 +1154,15 @@ mod tests {
 		#[case] expected: Option<(u16, u16, u16)>,
 	) {
 		assert_eq!(super::parse_server_version(version), expected);
+	}
+
+	#[test]
+	fn maria_db_compatibility_prefix_uses_the_maria_db_version() {
+		let capabilities = super::mysql_row_lock_capabilities(Some("5.5.5-10.11.6-MariaDB"));
+
+		assert!(capabilities.nowait);
+		assert!(capabilities.skip_locked);
+		assert!(!capabilities.targets);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/backends/connection.rs
+++ b/crates/reinhardt-db/src/backends/connection.rs
@@ -57,10 +57,17 @@ fn postgres_row_lock_capabilities(
 }
 
 fn mysql_row_lock_capabilities(version: Option<&str>) -> RowLockCapabilities {
-	version
-		.and_then(parse_server_version)
-		.map(|(major, minor, patch)| RowLockCapabilities::mysql_for_version(major, minor, patch))
-		.unwrap_or_else(RowLockCapabilities::mysql)
+	let Some(version) = version else {
+		return RowLockCapabilities::mysql();
+	};
+	let Some((major, minor, patch)) = parse_server_version(version) else {
+		return RowLockCapabilities::mysql();
+	};
+	if version.to_ascii_lowercase().contains("mariadb") {
+		RowLockCapabilities::mariadb_for_version(major, minor, patch)
+	} else {
+		RowLockCapabilities::mysql_for_version(major, minor, patch)
+	}
 }
 
 #[cfg(feature = "sqlite")]
@@ -1160,6 +1167,15 @@ mod tests {
 		assert!(mysql_801.nowait);
 		assert!(mysql_801.skip_locked);
 		assert!(mysql_801.targets);
+
+		let mariadb_105 = super::mysql_row_lock_capabilities(Some("10.5.23-MariaDB"));
+		assert!(mariadb_105.nowait);
+		assert!(!mariadb_105.skip_locked);
+		assert!(!mariadb_105.targets);
+
+		let mariadb_106 = super::mysql_row_lock_capabilities(Some("10.6.18-MariaDB"));
+		assert!(mariadb_106.skip_locked);
+		assert!(!mariadb_106.targets);
 	}
 
 	/// Helper to build a CREATE DATABASE SQL statement with proper identifier escaping.

--- a/crates/reinhardt-db/src/backends/connection.rs
+++ b/crates/reinhardt-db/src/backends/connection.rs
@@ -6,7 +6,7 @@ use super::{
 	backend::DatabaseBackend,
 	error::Result,
 	query_builder::{DeleteBuilder, InsertBuilder, SelectBuilder, UpdateBuilder},
-	types::{DatabaseType, QueryResult, QueryValue, Row, TransactionExecutor},
+	types::{DatabaseType, QueryResult, QueryValue, Row, RowLockCapabilities, TransactionExecutor},
 };
 
 #[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
@@ -31,6 +31,50 @@ fn map_postgres_initial_connect_error(error: sqlx::Error) -> DatabaseError {
 	}
 }
 
+fn default_row_lock_capabilities(
+	database_type: DatabaseType,
+	is_cockroachdb: bool,
+) -> RowLockCapabilities {
+	match database_type {
+		DatabaseType::Postgres if is_cockroachdb => RowLockCapabilities::cockroachdb(),
+		DatabaseType::Postgres => RowLockCapabilities::postgres(),
+		DatabaseType::Mysql => RowLockCapabilities::mysql(),
+		DatabaseType::Sqlite => RowLockCapabilities::unsupported(),
+	}
+}
+
+fn parse_server_version(version: &str) -> Option<(u16, u16, u16)> {
+	let start = version.find(|character: char| character.is_ascii_digit())?;
+	let mut parts = version[start..]
+		.split(|character: char| !character.is_ascii_digit())
+		.filter(|part| !part.is_empty());
+	Some((
+		parts.next()?.parse().ok()?,
+		parts.next()?.parse().ok()?,
+		parts.next().and_then(|part| part.parse().ok()).unwrap_or(0),
+	))
+}
+
+fn postgres_row_lock_capabilities(
+	version: Option<&str>,
+	is_cockroachdb: bool,
+) -> RowLockCapabilities {
+	if is_cockroachdb {
+		return RowLockCapabilities::cockroachdb();
+	}
+	version
+		.and_then(parse_server_version)
+		.map(|(major, minor, _)| RowLockCapabilities::postgres_for_version(major, minor))
+		.unwrap_or_else(RowLockCapabilities::postgres)
+}
+
+fn mysql_row_lock_capabilities(version: Option<&str>) -> RowLockCapabilities {
+	version
+		.and_then(parse_server_version)
+		.map(|(major, minor, patch)| RowLockCapabilities::mysql_for_version(major, minor, patch))
+		.unwrap_or_else(RowLockCapabilities::mysql)
+}
+
 #[cfg(feature = "sqlite")]
 use super::dialect::SqliteBackend;
 
@@ -50,11 +94,13 @@ pub struct DatabaseConnection {
 	/// differently. This flag is set at connection time via a `SELECT version()`
 	/// probe and is `false` for any non-Postgres backend.
 	is_cockroachdb: bool,
+	row_lock_capabilities: RowLockCapabilities,
 }
 
 struct FlavoredTransactionExecutor {
 	inner: Box<dyn TransactionExecutor>,
 	is_cockroachdb: bool,
+	row_lock_capabilities: RowLockCapabilities,
 }
 
 #[async_trait::async_trait]
@@ -68,12 +114,7 @@ impl TransactionExecutor for FlavoredTransactionExecutor {
 	}
 
 	fn row_lock_capabilities(&self) -> super::types::RowLockCapabilities {
-		let mut capabilities = self.inner.row_lock_capabilities();
-		if self.is_cockroachdb {
-			capabilities.no_key_update = false;
-			capabilities.targets = false;
-		}
-		capabilities
+		self.row_lock_capabilities
 	}
 
 	fn supports_pgvector_error_hints(&self) -> bool {
@@ -280,9 +321,12 @@ impl DatabaseConnection {
 	/// flavor is already known — e.g. tests that mount a CockroachDB pool, or
 	/// adapters that pre-probe `SELECT version()` themselves.
 	pub fn new_with_flavor(backend: Arc<dyn DatabaseBackend>, is_cockroachdb: bool) -> Self {
+		let row_lock_capabilities =
+			default_row_lock_capabilities(backend.database_type(), is_cockroachdb);
 		Self {
 			backend,
 			is_cockroachdb,
+			row_lock_capabilities,
 		}
 	}
 
@@ -301,11 +345,17 @@ impl DatabaseConnection {
 		let pool = Self::build_postgres_pool(url, pool_size)
 			.await
 			.map_err(map_postgres_initial_connect_error)?;
-		let is_cockroachdb = Self::probe_cockroachdb(&pool).await;
+		let version = Self::probe_postgres_version(&pool).await;
+		let is_cockroachdb = version
+			.as_deref()
+			.is_some_and(|value| value.starts_with("CockroachDB"));
+		let row_lock_capabilities =
+			postgres_row_lock_capabilities(version.as_deref(), is_cockroachdb);
 
 		Ok(Self {
 			backend: Arc::new(PostgresBackend::new(pool)),
 			is_cockroachdb,
+			row_lock_capabilities,
 		})
 	}
 
@@ -324,11 +374,11 @@ impl DatabaseConnection {
 	/// Used to drive the migration-lock dispatch in `MigrationRecorder`
 	/// (issue #4642: CockroachDB does not implement `pg_advisory_lock`).
 	#[cfg(feature = "postgres")]
-	async fn probe_cockroachdb(pool: &sqlx::PgPool) -> bool {
-		sqlx::query_scalar::<_, bool>("SELECT version() LIKE 'CockroachDB%'")
+	async fn probe_postgres_version(pool: &sqlx::PgPool) -> Option<String> {
+		sqlx::query_scalar::<_, String>("SELECT version()")
 			.fetch_one(pool)
 			.await
-			.unwrap_or(false)
+			.ok()
 	}
 
 	/// Connect to PostgreSQL with automatic database creation if it doesn't exist.
@@ -404,10 +454,17 @@ impl DatabaseConnection {
 		// so we can check the SQLSTATE code
 		match Self::build_postgres_pool(url, pool_size).await {
 			Ok(pool) => {
-				let is_cockroachdb = Self::probe_cockroachdb(&pool).await;
+				let version = Self::probe_postgres_version(&pool).await;
+				let is_cockroachdb = version
+					.as_deref()
+					.is_some_and(|value| value.starts_with("CockroachDB"));
 				return Ok(Self {
 					backend: Arc::new(PostgresBackend::new(pool)),
 					is_cockroachdb,
+					row_lock_capabilities: postgres_row_lock_capabilities(
+						version.as_deref(),
+						is_cockroachdb,
+					),
 				});
 			}
 			Err(e) => {
@@ -524,6 +581,7 @@ impl DatabaseConnection {
 			return Ok(Self {
 				backend: Arc::new(SqliteBackend::new(pool)),
 				is_cockroachdb: false,
+				row_lock_capabilities: RowLockCapabilities::unsupported(),
 			});
 		}
 
@@ -624,6 +682,7 @@ impl DatabaseConnection {
 		Ok(Self {
 			backend: Arc::new(SqliteBackend::new(pool)),
 			is_cockroachdb: false,
+			row_lock_capabilities: RowLockCapabilities::unsupported(),
 		})
 	}
 
@@ -633,6 +692,7 @@ impl DatabaseConnection {
 		Self {
 			backend: Arc::new(SqliteBackend::new(pool)),
 			is_cockroachdb: false,
+			row_lock_capabilities: RowLockCapabilities::unsupported(),
 		}
 	}
 
@@ -641,9 +701,14 @@ impl DatabaseConnection {
 	pub async fn connect_mysql(url: &str) -> Result<Self> {
 		use sqlx::MySqlPool;
 		let pool = MySqlPool::connect(url).await.map_err(map_sqlx_error)?;
+		let version = sqlx::query_scalar::<_, String>("SELECT VERSION()")
+			.fetch_one(&pool)
+			.await
+			.ok();
 		Ok(Self {
 			backend: Arc::new(MySqlBackend::new(pool)),
 			is_cockroachdb: false,
+			row_lock_capabilities: mysql_row_lock_capabilities(version.as_deref()),
 		})
 	}
 
@@ -867,6 +932,7 @@ impl DatabaseConnection {
 		Ok(Box::new(FlavoredTransactionExecutor {
 			inner,
 			is_cockroachdb: self.is_cockroachdb,
+			row_lock_capabilities: self.row_lock_capabilities,
 		}))
 	}
 
@@ -895,6 +961,7 @@ impl DatabaseConnection {
 		Ok(Box::new(FlavoredTransactionExecutor {
 			inner,
 			is_cockroachdb: self.is_cockroachdb,
+			row_lock_capabilities: self.row_lock_capabilities,
 		}))
 	}
 
@@ -1057,6 +1124,35 @@ mod tests {
 		let error = super::map_postgres_initial_connect_error(sqlx::Error::PoolTimedOut);
 
 		assert_eq!(error.kind(), super::DatabaseErrorKind::Timeout);
+	}
+
+	#[rstest]
+	#[case("PostgreSQL 9.4.26", Some((9, 4, 26)))]
+	#[case("8.0.0-rc1", Some((8, 0, 0)))]
+	#[case("not a version", None)]
+	fn server_version_parser_extracts_numeric_components(
+		#[case] version: &str,
+		#[case] expected: Option<(u16, u16, u16)>,
+	) {
+		assert_eq!(super::parse_server_version(version), expected);
+	}
+
+	#[test]
+	fn row_lock_capabilities_follow_probed_server_versions() {
+		let postgres_94 = super::postgres_row_lock_capabilities(Some("PostgreSQL 9.4.26"), false);
+		assert!(postgres_94.update);
+		assert!(postgres_94.no_key_update);
+		assert!(postgres_94.nowait);
+		assert!(!postgres_94.skip_locked);
+
+		let mysql_800 = super::mysql_row_lock_capabilities(Some("8.0.0"));
+		assert!(mysql_800.update);
+		assert!(!mysql_800.nowait);
+		assert!(!mysql_800.skip_locked);
+
+		let mysql_801 = super::mysql_row_lock_capabilities(Some("8.0.1"));
+		assert!(mysql_801.nowait);
+		assert!(mysql_801.skip_locked);
 	}
 
 	/// Helper to build a CREATE DATABASE SQL statement with proper identifier escaping.

--- a/crates/reinhardt-db/src/backends/connection.rs
+++ b/crates/reinhardt-db/src/backends/connection.rs
@@ -31,18 +31,6 @@ fn map_postgres_initial_connect_error(error: sqlx::Error) -> DatabaseError {
 	}
 }
 
-fn default_row_lock_capabilities(
-	database_type: DatabaseType,
-	is_cockroachdb: bool,
-) -> RowLockCapabilities {
-	match database_type {
-		DatabaseType::Postgres if is_cockroachdb => RowLockCapabilities::cockroachdb(),
-		DatabaseType::Postgres => RowLockCapabilities::postgres(),
-		DatabaseType::Mysql => RowLockCapabilities::mysql(),
-		DatabaseType::Sqlite => RowLockCapabilities::unsupported(),
-	}
-}
-
 fn parse_server_version(version: &str) -> Option<(u16, u16, u16)> {
 	let start = version.find(|character: char| character.is_ascii_digit())?;
 	let mut parts = version[start..]
@@ -94,13 +82,13 @@ pub struct DatabaseConnection {
 	/// differently. This flag is set at connection time via a `SELECT version()`
 	/// probe and is `false` for any non-Postgres backend.
 	is_cockroachdb: bool,
-	row_lock_capabilities: RowLockCapabilities,
+	row_lock_capabilities: Option<RowLockCapabilities>,
 }
 
 struct FlavoredTransactionExecutor {
 	inner: Box<dyn TransactionExecutor>,
 	is_cockroachdb: bool,
-	row_lock_capabilities: RowLockCapabilities,
+	row_lock_capabilities: Option<RowLockCapabilities>,
 }
 
 #[async_trait::async_trait]
@@ -115,6 +103,7 @@ impl TransactionExecutor for FlavoredTransactionExecutor {
 
 	fn row_lock_capabilities(&self) -> super::types::RowLockCapabilities {
 		self.row_lock_capabilities
+			.unwrap_or_else(|| self.inner.row_lock_capabilities())
 	}
 
 	fn supports_pgvector_error_hints(&self) -> bool {
@@ -321,12 +310,28 @@ impl DatabaseConnection {
 	/// flavor is already known — e.g. tests that mount a CockroachDB pool, or
 	/// adapters that pre-probe `SELECT version()` themselves.
 	pub fn new_with_flavor(backend: Arc<dyn DatabaseBackend>, is_cockroachdb: bool) -> Self {
-		let row_lock_capabilities =
-			default_row_lock_capabilities(backend.database_type(), is_cockroachdb);
+		let row_lock_capabilities = is_cockroachdb.then_some(RowLockCapabilities::cockroachdb());
 		Self {
 			backend,
 			is_cockroachdb,
 			row_lock_capabilities,
+		}
+	}
+
+	/// Creates a new instance with an explicit row-lock capability profile.
+	///
+	/// This is useful for custom backends whose server version is known by the
+	/// caller. Without an explicit profile, transaction executors retain their
+	/// own capability reporting.
+	pub fn new_with_flavor_and_row_lock_capabilities(
+		backend: Arc<dyn DatabaseBackend>,
+		is_cockroachdb: bool,
+		row_lock_capabilities: RowLockCapabilities,
+	) -> Self {
+		Self {
+			backend,
+			is_cockroachdb,
+			row_lock_capabilities: Some(row_lock_capabilities),
 		}
 	}
 
@@ -355,7 +360,7 @@ impl DatabaseConnection {
 		Ok(Self {
 			backend: Arc::new(PostgresBackend::new(pool)),
 			is_cockroachdb,
-			row_lock_capabilities,
+			row_lock_capabilities: Some(row_lock_capabilities),
 		})
 	}
 
@@ -461,10 +466,10 @@ impl DatabaseConnection {
 				return Ok(Self {
 					backend: Arc::new(PostgresBackend::new(pool)),
 					is_cockroachdb,
-					row_lock_capabilities: postgres_row_lock_capabilities(
+					row_lock_capabilities: Some(postgres_row_lock_capabilities(
 						version.as_deref(),
 						is_cockroachdb,
-					),
+					)),
 				});
 			}
 			Err(e) => {
@@ -581,7 +586,7 @@ impl DatabaseConnection {
 			return Ok(Self {
 				backend: Arc::new(SqliteBackend::new(pool)),
 				is_cockroachdb: false,
-				row_lock_capabilities: RowLockCapabilities::unsupported(),
+				row_lock_capabilities: Some(RowLockCapabilities::unsupported()),
 			});
 		}
 
@@ -682,7 +687,7 @@ impl DatabaseConnection {
 		Ok(Self {
 			backend: Arc::new(SqliteBackend::new(pool)),
 			is_cockroachdb: false,
-			row_lock_capabilities: RowLockCapabilities::unsupported(),
+			row_lock_capabilities: Some(RowLockCapabilities::unsupported()),
 		})
 	}
 
@@ -692,7 +697,7 @@ impl DatabaseConnection {
 		Self {
 			backend: Arc::new(SqliteBackend::new(pool)),
 			is_cockroachdb: false,
-			row_lock_capabilities: RowLockCapabilities::unsupported(),
+			row_lock_capabilities: Some(RowLockCapabilities::unsupported()),
 		}
 	}
 
@@ -708,7 +713,7 @@ impl DatabaseConnection {
 		Ok(Self {
 			backend: Arc::new(MySqlBackend::new(pool)),
 			is_cockroachdb: false,
-			row_lock_capabilities: mysql_row_lock_capabilities(version.as_deref()),
+			row_lock_capabilities: Some(mysql_row_lock_capabilities(version.as_deref())),
 		})
 	}
 
@@ -1149,10 +1154,12 @@ mod tests {
 		assert!(mysql_800.update);
 		assert!(!mysql_800.nowait);
 		assert!(!mysql_800.skip_locked);
+		assert!(!mysql_800.targets);
 
 		let mysql_801 = super::mysql_row_lock_capabilities(Some("8.0.1"));
 		assert!(mysql_801.nowait);
 		assert!(mysql_801.skip_locked);
+		assert!(mysql_801.targets);
 	}
 
 	/// Helper to build a CREATE DATABASE SQL statement with proper identifier escaping.

--- a/crates/reinhardt-db/src/backends/types.rs
+++ b/crates/reinhardt-db/src/backends/types.rs
@@ -786,13 +786,18 @@ impl RowLockCapabilities {
 		Self::mysql_for_version(8, 0, 1)
 	}
 
-	/// Capabilities for CockroachDB's PostgreSQL-compatible lock syntax.
+	/// Capabilities for the built-in CockroachDB v23.1 lock profile.
+	///
+	/// CockroachDB v23.1 supports `FOR UPDATE` and `NOWAIT`, but not
+	/// `SKIP LOCKED` or explicit lock targets. Custom transaction executors for
+	/// servers with different capabilities should override
+	/// [`TransactionExecutor::row_lock_capabilities`].
 	pub const fn cockroachdb() -> Self {
 		Self {
 			update: true,
 			no_key_update: false,
 			nowait: true,
-			skip_locked: true,
+			skip_locked: false,
 			targets: false,
 		}
 	}

--- a/crates/reinhardt-db/src/backends/types.rs
+++ b/crates/reinhardt-db/src/backends/types.rs
@@ -764,6 +764,18 @@ impl RowLockCapabilities {
 		}
 	}
 
+	/// Capabilities for a MariaDB server with the supplied semantic version.
+	pub const fn mariadb_for_version(major: u16, minor: u16, _patch: u16) -> Self {
+		let version = major * 100 + minor;
+		Self {
+			update: true,
+			no_key_update: false,
+			nowait: version >= 1003,
+			skip_locked: version >= 1006,
+			targets: false,
+		}
+	}
+
 	/// Capabilities for PostgreSQL 9.5 and newer.
 	pub const fn postgres() -> Self {
 		Self::postgres_for_version(9, 5)

--- a/crates/reinhardt-db/src/backends/types.rs
+++ b/crates/reinhardt-db/src/backends/types.rs
@@ -740,26 +740,38 @@ pub struct RowLockCapabilities {
 }
 
 impl RowLockCapabilities {
-	/// Capabilities for PostgreSQL 9.5 and newer.
-	pub const fn postgres() -> Self {
+	/// Capabilities for a PostgreSQL server with the supplied major and minor version.
+	pub const fn postgres_for_version(major: u16, minor: u16) -> Self {
+		let version = major * 100 + minor;
 		Self {
 			update: true,
-			no_key_update: true,
-			nowait: true,
-			skip_locked: true,
+			no_key_update: version >= 903,
+			nowait: version >= 801,
+			skip_locked: version >= 905,
 			targets: true,
 		}
 	}
 
-	/// Capabilities for MySQL 8.0.1 and newer.
-	pub const fn mysql() -> Self {
+	/// Capabilities for a MySQL server with the supplied semantic version.
+	pub const fn mysql_for_version(major: u16, minor: u16, patch: u16) -> Self {
+		let supports_wait_options = major > 8 || (major == 8 && (minor > 0 || patch >= 1));
 		Self {
 			update: true,
 			no_key_update: false,
-			nowait: true,
-			skip_locked: true,
+			nowait: supports_wait_options,
+			skip_locked: supports_wait_options,
 			targets: true,
 		}
+	}
+
+	/// Capabilities for PostgreSQL 9.5 and newer.
+	pub const fn postgres() -> Self {
+		Self::postgres_for_version(9, 5)
+	}
+
+	/// Capabilities for MySQL 8.0.1 and newer.
+	pub const fn mysql() -> Self {
+		Self::mysql_for_version(8, 0, 1)
 	}
 
 	/// Capabilities for CockroachDB's PostgreSQL-compatible lock syntax.

--- a/crates/reinhardt-db/src/backends/types.rs
+++ b/crates/reinhardt-db/src/backends/types.rs
@@ -546,6 +546,20 @@ pub trait TransactionExecutor: Send + Sync {
 		false
 	}
 
+	/// Reports the row-locking features supported by this server.
+	///
+	/// Executors connected to older server versions should override this method.
+	/// PostgreSQL gained `NO KEY UPDATE` in 9.3 and `SKIP LOCKED` in 9.5.
+	/// MySQL row-lock options require 8.0.1 or newer.
+	fn row_lock_capabilities(&self) -> RowLockCapabilities {
+		match self.backend() {
+			DatabaseType::Postgres if self.is_cockroachdb() => RowLockCapabilities::cockroachdb(),
+			DatabaseType::Postgres => RowLockCapabilities::postgres(),
+			DatabaseType::Mysql => RowLockCapabilities::mysql(),
+			DatabaseType::Sqlite => RowLockCapabilities::unsupported(),
+		}
+	}
+
 	/// Returns whether contextual pgvector error hints are supported.
 	fn supports_pgvector_error_hints(&self) -> bool {
 		false
@@ -707,6 +721,67 @@ pub trait TransactionExecutor: Send + Sync {
 			"Savepoints are not supported by this backend",
 		)
 		.into())
+	}
+}
+
+/// Server capabilities used to validate `QuerySet` row-lock clauses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RowLockCapabilities {
+	/// Whether blocking `FOR UPDATE` is supported.
+	pub update: bool,
+	/// Whether `FOR NO KEY UPDATE` is supported as a distinct lock strength.
+	pub no_key_update: bool,
+	/// Whether `NOWAIT` is supported.
+	pub nowait: bool,
+	/// Whether `SKIP LOCKED` is supported.
+	pub skip_locked: bool,
+	/// Whether an explicit lock target list is supported.
+	pub targets: bool,
+}
+
+impl RowLockCapabilities {
+	/// Capabilities for PostgreSQL 9.5 and newer.
+	pub const fn postgres() -> Self {
+		Self {
+			update: true,
+			no_key_update: true,
+			nowait: true,
+			skip_locked: true,
+			targets: true,
+		}
+	}
+
+	/// Capabilities for MySQL 8.0.1 and newer.
+	pub const fn mysql() -> Self {
+		Self {
+			update: true,
+			no_key_update: false,
+			nowait: true,
+			skip_locked: true,
+			targets: true,
+		}
+	}
+
+	/// Capabilities for CockroachDB's PostgreSQL-compatible lock syntax.
+	pub const fn cockroachdb() -> Self {
+		Self {
+			update: true,
+			no_key_update: false,
+			nowait: true,
+			skip_locked: true,
+			targets: false,
+		}
+	}
+
+	/// Capabilities for a backend or server version without row locking.
+	pub const fn unsupported() -> Self {
+		Self {
+			update: false,
+			no_key_update: false,
+			nowait: false,
+			skip_locked: false,
+			targets: false,
+		}
 	}
 }
 

--- a/crates/reinhardt-db/src/backends/types.rs
+++ b/crates/reinhardt-db/src/backends/types.rs
@@ -760,7 +760,7 @@ impl RowLockCapabilities {
 			no_key_update: false,
 			nowait: supports_wait_options,
 			skip_locked: supports_wait_options,
-			targets: true,
+			targets: supports_wait_options,
 		}
 	}
 

--- a/crates/reinhardt-db/src/lib.rs
+++ b/crates/reinhardt-db/src/lib.rs
@@ -39,6 +39,7 @@
 //!   binary base64 values, SQL/JSON null provenance, foreign key, many-to-many,
 //!   nullable foreign-key omission, and PostgreSQL sequence handling
 //! - **Typed Relation Traversal**: Compile-time checked relation paths for SELECT filters and eager loading
+//! - **Transaction-safe Row Locking**: Typed `select_for_update` targets and caller-owned transaction execution
 //! - **Scoped N+1 Detection**: Opt-in query shape detection for focused diagnostics and tests
 //!
 //! ### Migrations (`migrations` module)

--- a/crates/reinhardt-db/src/orm.rs
+++ b/crates/reinhardt-db/src/orm.rs
@@ -76,9 +76,9 @@
 //! use `of_model`; relation targets require a generated [`RelationPathLike`]
 //! rooted at the queryset model. Unlike Django, ordinary connection evaluation
 //! and SQLite return explicit errors instead of silently degrading to an
-//! unlocked query. Derived `FROM` sources, LATERAL joins, raw aggregate
-//! projections, and aggregate annotations are rejected before execution so the
-//! lock scope remains unambiguous.
+//! unlocked query. CTE-backed querysets, derived `FROM` sources, LATERAL joins,
+//! raw aggregate projections, and aggregate annotations are rejected before
+//! execution so the lock scope remains unambiguous.
 //!
 //! PostgreSQL 9.3 adds `no_key`, PostgreSQL 9.5 adds `skip_locked`, and the
 //! built-in MySQL profile requires 8.0.1 or newer. Older/custom servers report

--- a/crates/reinhardt-db/src/orm.rs
+++ b/crates/reinhardt-db/src/orm.rs
@@ -48,6 +48,21 @@
 //! values only. They may generate SQL but cannot control a live ORM transaction.
 //! [`AtomicTransaction`] is also intentionally non-`Copy` and stays bound to
 //! the callback and dedicated connection created by [`DatabaseConnection::atomic`].
+//!
+//! ## Row Locking
+//!
+//! [`QuerySet::select_for_update`](query::QuerySet::select_for_update) returns a
+//! typed builder whose `nowait` and `skip_locked` states are mutually exclusive.
+//! Evaluate it through a caller-owned [`TransactionExecutor`] so the same
+//! physical connection retains locks through commit or rollback. Root targets
+//! use `of_model`; relation targets require a generated [`RelationPathLike`]
+//! rooted at the queryset model. Unlike Django, ordinary connection evaluation
+//! and SQLite return explicit errors instead of silently degrading to an
+//! unlocked query.
+//!
+//! PostgreSQL 9.3 adds `no_key`, PostgreSQL 9.5 adds `skip_locked`, and the
+//! built-in MySQL profile requires 8.0.1 or newer. Older/custom servers report
+//! their exact feature set through [`TransactionExecutor::row_lock_capabilities`].
 
 // Core modules - always available
 pub mod aggregation;
@@ -175,7 +190,7 @@ pub use aggregation::{Aggregate, AggregateFunc, AggregateResult, AggregateValue}
 pub use annotation::{Annotation, AnnotationValue, Expression, Value, When};
 pub use connection::{
 	DatabaseBackend, DatabaseConnection, DatabaseConnectionLease, OrmExecutor, QueryResult,
-	QueryRow, QueryValue, Row, TransactionExecutor,
+	QueryRow, QueryValue, Row, RowLockCapabilities, TransactionExecutor,
 };
 pub use constraints::{
 	CheckConstraint, Constraint, ForeignKeyConstraint, OnDelete, OnUpdate, UniqueConstraint,
@@ -292,8 +307,8 @@ pub use reverse_accessor::ReverseAccessor;
 pub use manager::Manager;
 // Query types are always available
 pub use query::{
-	FieldAssignment, Filter, FilterCondition, FilterOperator, FilterValue, IntoOrderBy, OrmQuery,
-	QuerySet, UpdateValue,
+	Blocking, FieldAssignment, Filter, FilterCondition, FilterOperator, FilterValue, IntoOrderBy,
+	Nowait, OrmQuery, QuerySet, SelectForUpdate, SkipLocked, UpdateValue,
 };
 
 // Advanced ORM features

--- a/crates/reinhardt-db/src/orm/connection.rs
+++ b/crates/reinhardt-db/src/orm/connection.rs
@@ -16,7 +16,7 @@ use super::transaction::AtomicTransaction;
 pub use crate::backends::connection::DatabaseConnection as BackendsConnection;
 use crate::backends::types::DatabaseType;
 pub use crate::backends::types::{
-	IsolationLevel, QueryResult, QueryValue, Row, TransactionExecutor,
+	IsolationLevel, QueryResult, QueryValue, Row, RowLockCapabilities, TransactionExecutor,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1183,7 +1183,7 @@ enum SelectForUpdateBehavior {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum SelectForUpdateTarget {
 	Root,
-	Relation(SmallVec<[RelationStep; 4]>),
+	Relation(Box<SmallVec<[RelationStep; 4]>>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1268,7 +1268,7 @@ where
 		self.queryset
 			.relation_joins
 			.add_steps_with_override(&steps, path.join_kind_override());
-		let target = SelectForUpdateTarget::Relation(steps);
+		let target = SelectForUpdateTarget::Relation(Box::new(steps));
 		let spec = self
 			.queryset
 			.select_for_update

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1523,6 +1523,9 @@ where
 
 		let mut stmt = Query::select();
 		self.apply_model_from(&mut stmt);
+		if self.distinct_enabled {
+			stmt.distinct();
+		}
 		if let Some(ref fields) = self.selected_fields {
 			for field in fields {
 				if field.contains('(') && field.contains(')') {
@@ -1630,12 +1633,21 @@ where
 			));
 		}
 		let graph = self.relation_join_graph_for_query();
-		if spec.targets.is_empty()
-			&& graph
-				.joins()
-				.iter()
-				.any(|join| join.join_kind == RelationJoinKind::Left)
-		{
+		let has_outer_join = graph
+			.joins()
+			.iter()
+			.any(|join| join.join_kind == RelationJoinKind::Left)
+			|| !self.select_related_fields.is_empty()
+			|| self.joins.iter().any(|join| {
+				!join.on_condition.is_empty()
+					&& matches!(
+						join.join_type,
+						super::sqlalchemy_query::JoinType::Left
+							| super::sqlalchemy_query::JoinType::Right
+							| super::sqlalchemy_query::JoinType::Full
+					)
+			});
+		if spec.targets.is_empty() && has_outer_join {
 			return Err(DatabaseError::new(
 				DatabaseErrorKind::Query,
 				"SELECT FOR UPDATE with an outer join requires explicit non-nullable lock targets",

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1629,6 +1629,37 @@ where
 				"explicit row-lock targets are not supported by this backend or server version",
 			));
 		}
+		let graph = self.relation_join_graph_for_query();
+		for target in &spec.targets {
+			let SelectForUpdateTarget::Relation(steps) = target else {
+				continue;
+			};
+			if steps.is_empty() {
+				return Err(DatabaseError::new(
+					DatabaseErrorKind::Validation,
+					"SELECT FOR UPDATE relation lock target must contain at least one relation step",
+				));
+			}
+			let aliases = graph.aliases_for_steps(steps).ok_or_else(|| {
+				DatabaseError::new(
+					DatabaseErrorKind::Validation,
+					"SELECT FOR UPDATE relation lock target could not be resolved",
+				)
+			})?;
+			for alias in aliases {
+				let join = graph
+					.joins()
+					.iter()
+					.find(|join| join.alias == alias)
+					.expect("resolved relation aliases always have a planned join");
+				if join.join_kind == RelationJoinKind::Left {
+					return Err(DatabaseError::new(
+						DatabaseErrorKind::Validation,
+						"SELECT FOR UPDATE cannot lock a relation reached through an outer join",
+					));
+				}
+			}
+		}
 		Ok(())
 	}
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1544,6 +1544,12 @@ where
 			self.add_default_select_columns(&mut stmt);
 		}
 		self.apply_typed_select_expressions(&mut stmt);
+		for annotation in &self.annotations {
+			stmt.expr_as(
+				Expr::cust(self.annotation_value_to_select_sql(&annotation.value)),
+				Alias::new(&annotation.alias),
+			);
+		}
 		self.apply_relation_joins(&mut stmt);
 		self.apply_manual_joins(&mut stmt);
 
@@ -1705,7 +1711,7 @@ where
 			let SelectForUpdateTarget::Relation(steps) = target else {
 				continue;
 			};
-			if backend == crate::backends::types::DatabaseType::Postgres && steps.is_empty() {
+			if steps.is_empty() {
 				return Err(DatabaseError::new(
 					DatabaseErrorKind::Query,
 					"SELECT FOR UPDATE relation lock target must contain at least one relation step",

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1653,6 +1653,24 @@ where
 		let Some(spec) = &self.select_for_update else {
 			return Ok(());
 		};
+		if self.from_subquery_sql.is_some() {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"SELECT FOR UPDATE does not support derived table sources",
+			));
+		}
+		if !self.lateral_joins.is_empty() {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"SELECT FOR UPDATE does not support LATERAL joins",
+			));
+		}
+		if self.has_raw_aggregate_projection() {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"SELECT FOR UPDATE does not support raw aggregate projections",
+			));
+		}
 		if !capabilities.update {
 			return Err(DatabaseError::new(
 				DatabaseErrorKind::Unsupported,
@@ -1742,6 +1760,14 @@ where
 		Ok(())
 	}
 
+	fn has_raw_aggregate_projection(&self) -> bool {
+		self.selected_fields.as_ref().is_some_and(|fields| {
+			fields
+				.iter()
+				.any(|field| contains_known_raw_aggregate(field))
+		})
+	}
+
 	fn ensure_not_locking_without_transaction(&self) -> reinhardt_core::exception::Result<()> {
 		if self.select_for_update.is_some() {
 			return Err(DatabaseError::new(
@@ -1808,7 +1834,10 @@ where
 	///
 	/// The returned typestate builder prevents combining `NOWAIT` and
 	/// `SKIP LOCKED`. Locking queries must be evaluated with a caller-owned
-	/// [`TransactionExecutor`](super::connection::TransactionExecutor).
+	/// [`TransactionExecutor`](super::connection::TransactionExecutor). Derived
+	/// `FROM` sources, LATERAL joins, and raw aggregate projections from
+	/// [`Self::values`] are rejected before query execution to preserve lock
+	/// scope.
 	pub fn select_for_update(mut self) -> SelectForUpdate<T> {
 		self.select_for_update = Some(SelectForUpdateSpec::default());
 		SelectForUpdate {
@@ -8860,6 +8889,54 @@ fn parse_column_reference(field: &str) -> reinhardt_query::prelude::ColumnRef {
 		// Simple column reference
 		ColumnRef::column(Alias::new(field))
 	}
+}
+
+fn contains_known_raw_aggregate(projection: &str) -> bool {
+	const AGGREGATE_FUNCTIONS: &[&str] = &[
+		"COUNT",
+		"SUM",
+		"AVG",
+		"MIN",
+		"MAX",
+		"ARRAY_AGG",
+		"JSON_AGG",
+		"JSONB_AGG",
+		"STRING_AGG",
+		"BOOL_AND",
+		"BOOL_OR",
+		"EVERY",
+		"XMLAGG",
+	];
+
+	let bytes = projection.as_bytes();
+	let mut index = 0;
+	while index < bytes.len() {
+		if bytes[index].is_ascii_alphabetic() || bytes[index] == b'_' {
+			let start = index;
+			index += 1;
+			while index < bytes.len()
+				&& (bytes[index].is_ascii_alphanumeric() || bytes[index] == b'_')
+			{
+				index += 1;
+			}
+
+			let function = &projection[start..index];
+			let mut next = index;
+			while next < bytes.len() && bytes[next].is_ascii_whitespace() {
+				next += 1;
+			}
+			if bytes.get(next) == Some(&b'(')
+				&& AGGREGATE_FUNCTIONS
+					.iter()
+					.any(|aggregate| function.eq_ignore_ascii_case(aggregate))
+			{
+				return true;
+			}
+		} else {
+			index += 1;
+		}
+	}
+	false
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1630,19 +1630,30 @@ where
 			));
 		}
 		let graph = self.relation_join_graph_for_query();
+		if spec.targets.is_empty()
+			&& graph
+				.joins()
+				.iter()
+				.any(|join| join.join_kind == RelationJoinKind::Left)
+		{
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Query,
+				"SELECT FOR UPDATE with an outer join requires explicit non-nullable lock targets",
+			));
+		}
 		for target in &spec.targets {
 			let SelectForUpdateTarget::Relation(steps) = target else {
 				continue;
 			};
 			if steps.is_empty() {
 				return Err(DatabaseError::new(
-					DatabaseErrorKind::Validation,
+					DatabaseErrorKind::Query,
 					"SELECT FOR UPDATE relation lock target must contain at least one relation step",
 				));
 			}
 			let aliases = graph.aliases_for_steps(steps).ok_or_else(|| {
 				DatabaseError::new(
-					DatabaseErrorKind::Validation,
+					DatabaseErrorKind::Query,
 					"SELECT FOR UPDATE relation lock target could not be resolved",
 				)
 			})?;
@@ -1654,7 +1665,7 @@ where
 					.expect("resolved relation aliases always have a planned join");
 				if join.join_kind == RelationJoinKind::Left {
 					return Err(DatabaseError::new(
-						DatabaseErrorKind::Validation,
+						DatabaseErrorKind::Query,
 						"SELECT FOR UPDATE cannot lock a relation reached through an outer join",
 					));
 				}

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1642,6 +1642,7 @@ where
 	fn validate_select_for_update(
 		&self,
 		capabilities: crate::backends::types::RowLockCapabilities,
+		backend: crate::backends::types::DatabaseType,
 	) -> Result<(), crate::backends::error::DatabaseError> {
 		let Some(spec) = &self.select_for_update else {
 			return Ok(());
@@ -1691,7 +1692,10 @@ where
 							| super::sqlalchemy_query::JoinType::Full
 					)
 			});
-		if spec.targets.is_empty() && has_outer_join {
+		if backend == crate::backends::types::DatabaseType::Postgres
+			&& spec.targets.is_empty()
+			&& has_outer_join
+		{
 			return Err(DatabaseError::new(
 				DatabaseErrorKind::Query,
 				"SELECT FOR UPDATE with an outer join requires explicit non-nullable lock targets",
@@ -1701,7 +1705,7 @@ where
 			let SelectForUpdateTarget::Relation(steps) = target else {
 				continue;
 			};
-			if steps.is_empty() {
+			if backend == crate::backends::types::DatabaseType::Postgres && steps.is_empty() {
 				return Err(DatabaseError::new(
 					DatabaseErrorKind::Query,
 					"SELECT FOR UPDATE relation lock target must contain at least one relation step",
@@ -1719,7 +1723,9 @@ where
 					.iter()
 					.find(|join| join.alias == alias)
 					.expect("resolved relation aliases always have a planned join");
-				if join.join_kind == RelationJoinKind::Left {
+				if backend == crate::backends::types::DatabaseType::Postgres
+					&& join.join_kind == RelationJoinKind::Left
+				{
 					return Err(DatabaseError::new(
 						DatabaseErrorKind::Query,
 						"SELECT FOR UPDATE cannot lock a relation reached through an outer join",
@@ -6480,7 +6486,7 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
-		self.validate_select_for_update(executor.row_lock_capabilities())?;
+		self.validate_select_for_update(executor.row_lock_capabilities(), executor.backend())?;
 		let stmt = self.build_select_statement().map_err(executor_error)?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) = Self::build_select_for_backend(
@@ -6521,7 +6527,7 @@ where
 		&self,
 		executor: &mut dyn super::connection::TransactionExecutor,
 	) -> Result<Vec<QueryRow>, crate::backends::error::DatabaseError> {
-		self.validate_select_for_update(executor.row_lock_capabilities())?;
+		self.validate_select_for_update(executor.row_lock_capabilities(), executor.backend())?;
 		let stmt = self.build_select_statement().map_err(executor_error)?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) = Self::build_select_for_backend(

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1550,6 +1550,7 @@ where
 		if let Some(condition) = self.build_where_condition()? {
 			stmt.cond_where(condition);
 		}
+		self.apply_grouping_and_having(&mut stmt);
 		self.apply_ordering(&mut stmt);
 		if let Some(limit) = self.limit {
 			stmt.limit(limit as u64);
@@ -1559,6 +1560,49 @@ where
 		}
 		self.apply_select_for_update(&mut stmt);
 		Ok(stmt.to_owned())
+	}
+
+	fn apply_grouping_and_having(&self, stmt: &mut SelectStatement) {
+		for group_field in &self.group_by_fields {
+			stmt.group_by_col(self.root_column_reference(group_field));
+		}
+
+		for having_cond in &self.having_conditions {
+			let HavingCondition::AggregateCompare {
+				func,
+				field,
+				operator,
+				value,
+			} = having_cond;
+			let aggregate = self.having_aggregate_expr(func, field);
+			let expression = match operator {
+				ComparisonOp::Eq => match value {
+					AggregateValue::Int(value) => aggregate.eq(*value),
+					AggregateValue::Float(value) => aggregate.eq(*value),
+				},
+				ComparisonOp::Ne => match value {
+					AggregateValue::Int(value) => aggregate.ne(*value),
+					AggregateValue::Float(value) => aggregate.ne(*value),
+				},
+				ComparisonOp::Gt => match value {
+					AggregateValue::Int(value) => aggregate.gt(*value),
+					AggregateValue::Float(value) => aggregate.gt(*value),
+				},
+				ComparisonOp::Gte => match value {
+					AggregateValue::Int(value) => aggregate.gte(*value),
+					AggregateValue::Float(value) => aggregate.gte(*value),
+				},
+				ComparisonOp::Lt => match value {
+					AggregateValue::Int(value) => aggregate.lt(*value),
+					AggregateValue::Float(value) => aggregate.lt(*value),
+				},
+				ComparisonOp::Lte => match value {
+					AggregateValue::Int(value) => aggregate.lte(*value),
+					AggregateValue::Float(value) => aggregate.lte(*value),
+				},
+			};
+			stmt.and_having(expression);
+		}
 	}
 
 	fn apply_select_for_update(&self, stmt: &mut SelectStatement) {
@@ -5769,55 +5813,7 @@ where
 			stmt.cond_where(cond);
 		}
 
-		// Apply GROUP BY
-		for group_field in &self.group_by_fields {
-			let col_ref = self.root_column_reference(group_field);
-			stmt.group_by_col(col_ref);
-		}
-
-		// Apply HAVING
-		for having_cond in &self.having_conditions {
-			match having_cond {
-				HavingCondition::AggregateCompare {
-					func,
-					field,
-					operator,
-					value,
-				} => {
-					let agg_expr = self.having_aggregate_expr(func, field);
-
-					// Build comparison expression
-					let having_expr = match operator {
-						ComparisonOp::Eq => match value {
-							AggregateValue::Int(v) => agg_expr.eq(*v),
-							AggregateValue::Float(v) => agg_expr.eq(*v),
-						},
-						ComparisonOp::Ne => match value {
-							AggregateValue::Int(v) => agg_expr.ne(*v),
-							AggregateValue::Float(v) => agg_expr.ne(*v),
-						},
-						ComparisonOp::Gt => match value {
-							AggregateValue::Int(v) => agg_expr.gt(*v),
-							AggregateValue::Float(v) => agg_expr.gt(*v),
-						},
-						ComparisonOp::Gte => match value {
-							AggregateValue::Int(v) => agg_expr.gte(*v),
-							AggregateValue::Float(v) => agg_expr.gte(*v),
-						},
-						ComparisonOp::Lt => match value {
-							AggregateValue::Int(v) => agg_expr.lt(*v),
-							AggregateValue::Float(v) => agg_expr.lt(*v),
-						},
-						ComparisonOp::Lte => match value {
-							AggregateValue::Int(v) => agg_expr.lte(*v),
-							AggregateValue::Float(v) => agg_expr.lte(*v),
-						},
-					};
-
-					stmt.and_having(having_expr);
-				}
-			}
-		}
+		self.apply_grouping_and_having(&mut stmt);
 
 		self.apply_ordering(&mut stmt);
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1834,12 +1834,7 @@ where
 			self.add_default_select_columns(&mut stmt);
 		}
 		self.apply_typed_select_expressions(&mut stmt);
-		for annotation in &self.annotations {
-			stmt.expr_as(
-				Expr::cust(self.annotation_value_to_select_sql(&annotation.value)),
-				Alias::new(&annotation.alias),
-			);
-		}
+		self.apply_annotations_to_select(&mut stmt);
 		self.apply_relation_joins(&mut stmt);
 		self.apply_manual_joins(&mut stmt);
 
@@ -1856,6 +1851,15 @@ where
 		}
 		self.apply_select_for_update(&mut stmt);
 		Ok(stmt.to_owned())
+	}
+
+	fn apply_annotations_to_select(&self, stmt: &mut SelectStatement) {
+		for annotation in &self.annotations {
+			stmt.expr_as(
+				Expr::cust(self.annotation_value_to_select_sql(&annotation.value)),
+				Alias::new(&annotation.alias),
+			);
+		}
 	}
 
 	fn apply_grouping_and_having(&self, stmt: &mut SelectStatement) {
@@ -1943,6 +1947,12 @@ where
 		let Some(spec) = &self.select_for_update else {
 			return Ok(());
 		};
+		if !self.ctes.is_empty() {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"SELECT FOR UPDATE does not support CTE-backed querysets",
+			));
+		}
 		if self.from_subquery_sql.is_some() {
 			return Err(DatabaseError::new(
 				DatabaseErrorKind::Unsupported,
@@ -2377,9 +2387,9 @@ where
 	///
 	/// The returned typestate builder prevents combining `NOWAIT` and
 	/// `SKIP LOCKED`. Locking queries must be evaluated with a caller-owned
-	/// [`TransactionExecutor`](super::connection::TransactionExecutor). Derived
-	/// `FROM` sources, LATERAL joins, raw aggregate projections from
-	/// [`Self::values`], and aggregate annotations are rejected before query
+	/// [`TransactionExecutor`](super::connection::TransactionExecutor). CTE-backed
+	/// querysets, derived `FROM` sources, LATERAL joins, raw aggregate projections
+	/// from [`Self::values`], and aggregate annotations are rejected before query
 	/// execution to preserve lock scope.
 	pub fn select_for_update(mut self) -> SelectForUpdate<T> {
 		self.select_for_update = Some(SelectForUpdateSpec::default());
@@ -6278,7 +6288,9 @@ where
 	/// //   WHERE posts.published = $1
 	/// ```
 	pub fn select_related_query(&self) -> reinhardt_core::exception::Result<SelectStatement> {
-		Ok(self.select_related_query_with_condition(self.build_where_condition()?))
+		let mut stmt = self.select_related_query_with_condition(self.build_where_condition()?);
+		self.apply_annotations_to_select(&mut stmt);
+		Ok(stmt)
 	}
 
 	fn select_related_query_with_condition(
@@ -6310,12 +6322,6 @@ where
 		// Add main table columns while preserving explicit projections.
 		self.add_select_related_root_columns(&mut stmt);
 		self.apply_typed_select_expressions(&mut stmt);
-		for annotation in &self.annotations {
-			stmt.expr_as(
-				Expr::cust(self.annotation_value_to_select_sql(&annotation.value)),
-				Alias::new(&annotation.alias),
-			);
-		}
 
 		// Add LEFT JOIN for each legacy related field that is not already covered
 		// by a typed join. The typed graph owns its aliases and join order.
@@ -8930,26 +8936,10 @@ where
 			stmt.to_owned()
 		} else {
 			// SELECT with JOINs for select_related
-			self.select_related_query()?
+			self.select_related_query_with_condition(self.build_where_condition()?)
 		};
 
-		// Add annotations to SELECT clause if any using reinhardt-query API
-		// Collect annotation SQL strings first to handle lifetime issues
-		// Note: Use to_sql_expr() to get expression without alias (reinhardt-query adds alias via expr_as)
-		let annotation_exprs: Vec<_> = self
-			.annotations
-			.iter()
-			.map(|a| {
-				(
-					self.annotation_value_to_select_sql(&a.value),
-					a.alias.clone(),
-				)
-			})
-			.collect();
-
-		for (value_sql, alias) in annotation_exprs {
-			stmt.expr_as(Expr::cust(value_sql), Alias::new(alias));
-		}
+		self.apply_annotations_to_select(&mut stmt);
 
 		use reinhardt_query::prelude::PostgresQueryBuilder;
 		let mut select_sql = stmt.to_string(PostgresQueryBuilder);
@@ -12207,6 +12197,27 @@ mod tests {
 		assert!(sql.contains("SELECT"));
 		assert!(sql.contains("test_users"));
 		assert!(sql.contains("LEFT JOIN"));
+	}
+
+	#[test]
+	fn select_related_to_sql_includes_each_annotation_once() {
+		use crate::orm::annotation::{Annotation, AnnotationValue, Value};
+
+		// Arrange
+		let queryset = QuerySet::<TestUser>::new()
+			.select_related(&["profile"])
+			.annotate(Annotation::new(
+				"relation_marker",
+				AnnotationValue::Value(Value::Int(1)),
+			));
+
+		// Act
+		let sql = queryset
+			.to_sql()
+			.expect("select-related query SQL should compile");
+
+		// Assert
+		assert_eq!(sql.matches(r#"1 AS "relation_marker""#).count(), 1);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -17,9 +17,9 @@ use crate::orm::relations::{RelationJoinGraph, RelationJoinKind, RelationPathLik
 use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind, Error};
 use reinhardt_query::prelude::{
 	Alias, BinOper, CockroachDBQueryBuilder, ColumnRef, Condition, Expr, ExprTrait, Func,
-	JoinType as SeaJoinType, MySqlQueryBuilder, Order, PostgresQueryBuilder, Query, QueryBuilder,
-	QueryStatementBuilder, SelectStatement, SimpleExpr, SqliteQueryBuilder, TableRef,
-	UpdateStatement,
+	JoinType as SeaJoinType, LockBehavior, LockType, MySqlQueryBuilder, Order,
+	PostgresQueryBuilder, Query, QueryBuilder, QueryStatementBuilder, SelectStatement, SimpleExpr,
+	SqliteQueryBuilder, TableRef, UpdateStatement,
 };
 use reinhardt_query::types::PgBinOper;
 use serde::{Deserialize, Serialize};
@@ -1173,6 +1173,196 @@ struct TypedSelectRelation {
 	steps: SmallVec<[RelationStep; 4]>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SelectForUpdateBehavior {
+	Blocking,
+	Nowait,
+	SkipLocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SelectForUpdateTarget {
+	Root,
+	Relation(SmallVec<[RelationStep; 4]>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SelectForUpdateSpec {
+	behavior: SelectForUpdateBehavior,
+	no_key: bool,
+	targets: Vec<SelectForUpdateTarget>,
+}
+
+impl Default for SelectForUpdateSpec {
+	fn default() -> Self {
+		Self {
+			behavior: SelectForUpdateBehavior::Blocking,
+			no_key: false,
+			targets: Vec::new(),
+		}
+	}
+}
+
+/// Type state for a blocking row lock.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Blocking;
+
+/// Type state for a row lock that fails immediately when a row is unavailable.
+#[derive(Debug, Clone, Copy)]
+pub struct Nowait;
+
+/// Type state for a row lock that omits rows which cannot be locked immediately.
+#[derive(Debug, Clone, Copy)]
+pub struct SkipLocked;
+
+/// Typed builder for a transaction-scoped `SELECT ... FOR UPDATE`.
+///
+/// `nowait` and `skip_locked` are transitions from [`Blocking`] to distinct
+/// type states, so they cannot be combined. Evaluate the builder with
+/// [`Self::all_with_executor`] or [`Self::rows_with_executor`] using a
+/// caller-owned active transaction executor.
+pub struct SelectForUpdate<M, Behavior = Blocking>
+where
+	M: super::Model,
+{
+	queryset: QuerySet<M>,
+	_behavior: PhantomData<Behavior>,
+}
+
+impl<M, Behavior> SelectForUpdate<M, Behavior>
+where
+	M: super::Model,
+{
+	/// Requests PostgreSQL's weaker `FOR NO KEY UPDATE` lock strength.
+	///
+	/// Other backends return an explicit unsupported-capability error.
+	pub fn no_key(mut self) -> Self {
+		self.queryset
+			.select_for_update
+			.as_mut()
+			.expect("select-for-update builder always contains a lock specification")
+			.no_key = true;
+		self
+	}
+
+	/// Restricts locking to the root model table.
+	pub fn of_model(mut self) -> Self {
+		let spec = self
+			.queryset
+			.select_for_update
+			.as_mut()
+			.expect("select-for-update builder always contains a lock specification");
+		if !spec.targets.contains(&SelectForUpdateTarget::Root) {
+			spec.targets.push(SelectForUpdateTarget::Root);
+		}
+		self
+	}
+
+	/// Restricts locking to a typed relation target and adds its required joins.
+	pub fn of_relation<P>(mut self, path: P) -> Self
+	where
+		P: RelationPathLike<Root = M>,
+	{
+		let mut steps: SmallVec<[RelationStep; 4]> = SmallVec::new();
+		steps.extend(path.steps().iter().cloned());
+		self.queryset
+			.relation_joins
+			.add_steps_with_override(&steps, path.join_kind_override());
+		let target = SelectForUpdateTarget::Relation(steps);
+		let spec = self
+			.queryset
+			.select_for_update
+			.as_mut()
+			.expect("select-for-update builder always contains a lock specification");
+		if !spec.targets.contains(&target) {
+			spec.targets.push(target);
+		}
+		self
+	}
+
+	/// Rejects evaluation without an explicit active transaction.
+	pub async fn all(&self) -> reinhardt_core::exception::Result<Vec<M>>
+	where
+		M: serde::de::DeserializeOwned,
+	{
+		self.queryset.ensure_not_locking_without_transaction()?;
+		unreachable!("locking queryset validation always returns an error")
+	}
+
+	/// Rejects evaluation through an ordinary ORM executor.
+	pub async fn all_with_db<E>(
+		&self,
+		executor: &mut E,
+	) -> reinhardt_core::exception::Result<Vec<M>>
+	where
+		M: serde::de::DeserializeOwned,
+		E: OrmExecutor,
+	{
+		self.queryset.all_with_db(executor).await
+	}
+
+	/// Rejects raw-row evaluation through an ordinary ORM executor.
+	pub async fn rows_with_db<E>(
+		&self,
+		executor: &mut E,
+	) -> reinhardt_core::exception::Result<Vec<QueryRow>>
+	where
+		E: OrmExecutor,
+	{
+		self.queryset.rows_with_db(executor).await
+	}
+
+	/// Executes the locking query through a caller-owned active transaction.
+	pub async fn all_with_executor(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+	) -> Result<Vec<M>, crate::backends::error::DatabaseError>
+	where
+		M: serde::de::DeserializeOwned,
+	{
+		self.queryset.all_with_executor(executor).await
+	}
+
+	/// Executes the locking query and returns undecoded rows.
+	pub async fn rows_with_executor(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+	) -> Result<Vec<QueryRow>, crate::backends::error::DatabaseError> {
+		self.queryset.rows_with_executor(executor).await
+	}
+}
+
+impl<M> SelectForUpdate<M, Blocking>
+where
+	M: super::Model,
+{
+	/// Changes blocking behavior to `NOWAIT`.
+	pub fn nowait(mut self) -> SelectForUpdate<M, Nowait> {
+		self.queryset
+			.select_for_update
+			.as_mut()
+			.expect("select-for-update builder always contains a lock specification")
+			.behavior = SelectForUpdateBehavior::Nowait;
+		SelectForUpdate {
+			queryset: self.queryset,
+			_behavior: PhantomData,
+		}
+	}
+
+	/// Changes blocking behavior to `SKIP LOCKED`.
+	pub fn skip_locked(mut self) -> SelectForUpdate<M, SkipLocked> {
+		self.queryset
+			.select_for_update
+			.as_mut()
+			.expect("select-for-update builder always contains a lock specification")
+			.behavior = SelectForUpdateBehavior::SkipLocked;
+		SelectForUpdate {
+			queryset: self.queryset,
+			_behavior: PhantomData,
+		}
+	}
+}
+
 impl TypedSelectRelation {
 	fn from_path<P>(path: &P) -> Self
 	where
@@ -1269,6 +1459,7 @@ where
 	/// Subquery SQL for FROM clause (derived table)
 	/// When set, the FROM clause will use this subquery instead of the model's table
 	from_subquery_sql: Option<String>,
+	select_for_update: Option<SelectForUpdateSpec>,
 }
 
 impl<T> QuerySet<T>
@@ -1305,6 +1496,7 @@ where
 			subquery_conditions: Vec::new(),
 			from_alias: None,
 			from_subquery_sql: None,
+			select_for_update: None,
 		}
 	}
 
@@ -1362,7 +1554,93 @@ where
 		if let Some(offset) = self.offset {
 			stmt.offset(offset as u64);
 		}
+		self.apply_select_for_update(&mut stmt);
 		Ok(stmt.to_owned())
+	}
+
+	fn apply_select_for_update(&self, stmt: &mut SelectStatement) {
+		let Some(spec) = &self.select_for_update else {
+			return;
+		};
+
+		stmt.lock(if spec.no_key {
+			LockType::NoKeyUpdate
+		} else {
+			LockType::Update
+		});
+		match spec.behavior {
+			SelectForUpdateBehavior::Blocking => {}
+			SelectForUpdateBehavior::Nowait => {
+				stmt.lock_behavior(LockBehavior::Nowait);
+			}
+			SelectForUpdateBehavior::SkipLocked => {
+				stmt.lock_behavior(LockBehavior::SkipLocked);
+			}
+		}
+
+		if spec.targets.is_empty() {
+			return;
+		}
+
+		let graph = self.relation_join_graph_for_query();
+		let aliases = spec.targets.iter().filter_map(|target| match target {
+			SelectForUpdateTarget::Root => Some(self.root_alias().to_string()),
+			SelectForUpdateTarget::Relation(steps) => graph
+				.aliases_for_steps(steps)
+				.and_then(|aliases| aliases.last().cloned()),
+		});
+		stmt.lock_tables(aliases.map(Alias::new));
+	}
+
+	fn validate_select_for_update(
+		&self,
+		capabilities: crate::backends::types::RowLockCapabilities,
+	) -> Result<(), crate::backends::error::DatabaseError> {
+		let Some(spec) = &self.select_for_update else {
+			return Ok(());
+		};
+		if !capabilities.update {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"SELECT FOR UPDATE is not supported by this backend or server version",
+			));
+		}
+		if spec.no_key && !capabilities.no_key_update {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"FOR NO KEY UPDATE is only supported by PostgreSQL 9.3 or newer",
+			));
+		}
+		if spec.behavior == SelectForUpdateBehavior::Nowait && !capabilities.nowait {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"NOWAIT row locking is not supported by this backend or server version",
+			));
+		}
+		if spec.behavior == SelectForUpdateBehavior::SkipLocked && !capabilities.skip_locked {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"SKIP LOCKED row locking is not supported by this backend or server version",
+			));
+		}
+		if !spec.targets.is_empty() && !capabilities.targets {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"explicit row-lock targets are not supported by this backend or server version",
+			));
+		}
+		Ok(())
+	}
+
+	fn ensure_not_locking_without_transaction(&self) -> reinhardt_core::exception::Result<()> {
+		if self.select_for_update.is_some() {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Transaction,
+				"select_for_update requires all_with_executor or rows_with_executor with a caller-owned active transaction",
+			)
+			.into());
+		}
+		Ok(())
 	}
 
 	fn decode_backend_rows(
@@ -1412,6 +1690,20 @@ where
 			subquery_conditions: Vec::new(),
 			from_alias: None,
 			from_subquery_sql: None,
+			select_for_update: None,
+		}
+	}
+
+	/// Configures this queryset to lock selected rows until transaction completion.
+	///
+	/// The returned typestate builder prevents combining `NOWAIT` and
+	/// `SKIP LOCKED`. Locking queries must be evaluated with a caller-owned
+	/// [`TransactionExecutor`](super::connection::TransactionExecutor).
+	pub fn select_for_update(mut self) -> SelectForUpdate<T> {
+		self.select_for_update = Some(SelectForUpdateSpec::default());
+		SelectForUpdate {
+			queryset: self,
+			_behavior: PhantomData,
 		}
 	}
 
@@ -1628,6 +1920,7 @@ where
 			subquery_conditions: Vec::new(),
 			from_alias: Some(alias.to_string()),
 			from_subquery_sql: Some(subquery_sql),
+			select_for_update: None,
 		})
 	}
 
@@ -5482,6 +5775,7 @@ where
 			stmt.offset(offset as u64);
 		}
 
+		self.apply_select_for_update(&mut stmt);
 		stmt.to_owned()
 	}
 
@@ -6041,6 +6335,7 @@ where
 		T: serde::de::DeserializeOwned,
 		E: OrmExecutor,
 	{
+		self.ensure_not_locking_without_transaction()?;
 		let stmt = self.build_select_statement()?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) =
@@ -6096,6 +6391,7 @@ where
 	where
 		E: OrmExecutor,
 	{
+		self.ensure_not_locking_without_transaction()?;
 		let stmt = self.build_select_statement()?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) =
@@ -6134,6 +6430,7 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		self.validate_select_for_update(executor.row_lock_capabilities())?;
 		let stmt = self.build_select_statement().map_err(executor_error)?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) = Self::build_select_for_backend(
@@ -6167,6 +6464,46 @@ where
 			}
 		};
 		Self::decode_backend_rows(rows)
+	}
+
+	/// Executes the queryset through an active transaction and returns raw rows.
+	pub async fn rows_with_executor(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+	) -> Result<Vec<QueryRow>, crate::backends::error::DatabaseError> {
+		self.validate_select_for_update(executor.row_lock_capabilities())?;
+		let stmt = self.build_select_statement().map_err(executor_error)?;
+		let context = super::execution::pgvector_context_for_select(&stmt);
+		let (sql, values) = Self::build_select_for_backend(
+			&stmt,
+			Self::executor_backend(executor),
+			executor.is_cockroachdb(),
+		)?;
+		let param_samples = values
+			.iter()
+			.map(|value| value.to_sql_literal())
+			.collect::<Vec<_>>();
+		let params = super::execution::convert_values(values);
+		let started = Instant::now();
+		let result = executor
+			.fetch_all_with_context(&sql, params, context)
+			.await
+			.map_err(executor_error);
+		let duration = started.elapsed();
+		match result {
+			Ok(rows) => {
+				super::instrumentation::instrumentation()
+					.orm_query_end_with_params(&sql, &param_samples, duration)
+					.await;
+				Ok(rows.into_iter().map(QueryRow::from_backend_row).collect())
+			}
+			Err(error) => {
+				super::instrumentation::instrumentation()
+					.orm_query_error(&sql, &format!("{error:?}"))
+					.await;
+				Err(error)
+			}
+		}
 	}
 
 	/// Execute the count query through an active transaction executor.

--- a/crates/reinhardt-db/src/orm/transaction.rs
+++ b/crates/reinhardt-db/src/orm/transaction.rs
@@ -1070,6 +1070,13 @@ impl TransactionExecutor for AtomicTransaction {
 			.unwrap_or(self.is_cockroachdb)
 	}
 
+	fn row_lock_capabilities(&self) -> crate::backends::types::RowLockCapabilities {
+		self.executor_ref().map_or_else(
+			crate::backends::types::RowLockCapabilities::unsupported,
+			TransactionExecutor::row_lock_capabilities,
+		)
+	}
+
 	async fn execute(
 		&mut self,
 		sql: &str,

--- a/crates/reinhardt-db/tests/select_for_update_ui.rs
+++ b/crates/reinhardt-db/tests/select_for_update_ui.rs
@@ -1,0 +1,19 @@
+#[path = "ui/select_for_update/support.rs"]
+mod support;
+
+use reinhardt_db::orm::QuerySet;
+use support::{Article, article_author};
+
+#[test]
+fn typed_row_lock_targets_compile() {
+	let _root_target = QuerySet::<Article>::new().select_for_update().of_model();
+	let _relation_target = QuerySet::<Article>::new()
+		.select_for_update()
+		.of_relation(article_author());
+}
+
+#[test]
+fn invalid_select_for_update_types_do_not_compile() {
+	let tests = trybuild::TestCases::new();
+	tests.compile_fail("tests/ui/select_for_update/fail/*.rs");
+}

--- a/crates/reinhardt-db/tests/transaction_executor_orm.rs
+++ b/crates/reinhardt-db/tests/transaction_executor_orm.rs
@@ -617,6 +617,85 @@ async fn select_for_update_rejects_missing_server_capability_without_querying() 
 }
 
 #[tokio::test]
+async fn select_for_update_rejects_cockroachdb_skip_locked_without_querying() {
+	let query = QuerySet::<Article>::new().select_for_update().skip_locked();
+	let mut executor = RowLockTransactionExecutor {
+		backend: reinhardt_db::backends::DatabaseType::Postgres,
+		capabilities: reinhardt_db::orm::RowLockCapabilities::cockroachdb(),
+		calls: Vec::new(),
+		rows: Vec::new(),
+	};
+
+	let error = match query.rows_with_executor(&mut executor).await {
+		Ok(_) => panic!("CockroachDB v23.1 must reject SKIP LOCKED before query execution"),
+		Err(error) => error,
+	};
+
+	assert_eq!(error.kind(), DatabaseErrorKind::Unsupported);
+	assert!(executor.calls.is_empty());
+}
+
+#[tokio::test]
+async fn select_for_update_rejects_derived_table_sources_without_querying() {
+	let query = QuerySet::<Article>::from_subquery(
+		|query: QuerySet<Article>| {
+			query.filter(Filter::new(
+				"article_id",
+				FilterOperator::Eq,
+				FilterValue::Integer(7),
+			))
+		},
+		"locked_articles",
+	)
+	.expect("derived queryset should compile")
+	.select_for_update();
+	let mut executor = RowLockTransactionExecutor::postgres(Vec::new());
+
+	let error = match query.rows_with_executor(&mut executor).await {
+		Ok(_) => panic!("row locking a derived table must be rejected before query execution"),
+		Err(error) => error,
+	};
+
+	assert_eq!(error.kind(), DatabaseErrorKind::Unsupported);
+	assert!(executor.calls.is_empty());
+}
+
+#[tokio::test]
+async fn select_for_update_rejects_lateral_join_sources_without_querying() {
+	let query = QuerySet::<Article>::new()
+		.with_lateral_join(reinhardt_db::orm::lateral_join::LateralJoin::new(
+			"latest_article",
+			"SELECT 1",
+		))
+		.select_for_update();
+	let mut executor = RowLockTransactionExecutor::postgres(Vec::new());
+
+	let error = match query.rows_with_executor(&mut executor).await {
+		Ok(_) => panic!("row locking with a lateral join must be rejected before query execution"),
+		Err(error) => error,
+	};
+
+	assert_eq!(error.kind(), DatabaseErrorKind::Unsupported);
+	assert!(executor.calls.is_empty());
+}
+
+#[tokio::test]
+async fn select_for_update_rejects_raw_aggregate_projections_without_querying() {
+	let query = QuerySet::<Article>::new()
+		.values(&["COUNT(*)"])
+		.select_for_update();
+	let mut executor = RowLockTransactionExecutor::postgres(Vec::new());
+
+	let error = match query.rows_with_executor(&mut executor).await {
+		Ok(_) => panic!("row locking with a raw aggregate must be rejected before query execution"),
+		Err(error) => error,
+	};
+
+	assert_eq!(error.kind(), DatabaseErrorKind::Unsupported);
+	assert!(executor.calls.is_empty());
+}
+
+#[tokio::test]
 async fn select_for_update_rejects_sqlite_instead_of_degrading_to_a_no_op() {
 	let query = QuerySet::<Article>::new().select_for_update();
 	let mut executor = RowLockTransactionExecutor {

--- a/crates/reinhardt-db/tests/transaction_executor_orm.rs
+++ b/crates/reinhardt-db/tests/transaction_executor_orm.rs
@@ -18,7 +18,9 @@ use reinhardt_db::orm::annotation::{AnnotationValue, Expression, Value};
 use reinhardt_db::orm::composite_pk::{CompositePrimaryKey, PkValue};
 #[cfg(feature = "sqlite")]
 use reinhardt_db::orm::connection::{BackendsConnection, DatabaseConnectionLease};
-use reinhardt_db::orm::connection::{DatabaseBackend, OrmExecutor, QueryResult, QueryValue, Row};
+use reinhardt_db::orm::connection::{
+	DatabaseBackend, OrmExecutor, QueryResult, QueryValue, Row, TransactionExecutor,
+};
 use reinhardt_db::orm::custom_manager::CustomManager;
 use reinhardt_db::orm::events::{EventRegistry, EventResult, MapperEvents, set_active_registry};
 use reinhardt_db::orm::execution::{QueryExecution, SelectExecution};
@@ -172,6 +174,80 @@ impl OrmExecutor for RecordingExecutor {
 	) -> reinhardt_core::exception::Result<Option<Row>> {
 		self.fetch_optional_contexts.push(context);
 		self.fetch_optional(sql, params).await
+	}
+}
+
+struct RowLockTransactionExecutor {
+	backend: reinhardt_db::backends::DatabaseType,
+	capabilities: reinhardt_db::orm::RowLockCapabilities,
+	calls: Vec<RecordedCall>,
+	rows: Vec<Row>,
+}
+
+impl RowLockTransactionExecutor {
+	fn postgres(rows: Vec<Row>) -> Self {
+		Self {
+			backend: reinhardt_db::backends::DatabaseType::Postgres,
+			capabilities: reinhardt_db::orm::RowLockCapabilities::postgres(),
+			calls: Vec::new(),
+			rows,
+		}
+	}
+}
+
+#[async_trait]
+impl TransactionExecutor for RowLockTransactionExecutor {
+	fn backend(&self) -> reinhardt_db::backends::DatabaseType {
+		self.backend
+	}
+
+	fn row_lock_capabilities(&self) -> reinhardt_db::orm::RowLockCapabilities {
+		self.capabilities
+	}
+
+	async fn execute(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<QueryResult> {
+		panic!("row-lock SELECT test does not execute mutations")
+	}
+
+	async fn fetch_one(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<Row> {
+		panic!("row-lock SELECT test does not fetch one row")
+	}
+
+	async fn fetch_all(
+		&mut self,
+		sql: &str,
+		params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<Vec<Row>> {
+		self.calls.push(RecordedCall {
+			kind: "fetch_all",
+			sql: sql.to_owned(),
+			params,
+		});
+		Ok(std::mem::take(&mut self.rows))
+	}
+
+	async fn fetch_optional(
+		&mut self,
+		_sql: &str,
+		_params: Vec<QueryValue>,
+	) -> reinhardt_core::exception::Result<Option<Row>> {
+		panic!("row-lock SELECT test does not fetch an optional row")
+	}
+
+	async fn commit(self: Box<Self>) -> reinhardt_core::exception::Result<()> {
+		Ok(())
+	}
+
+	async fn rollback(self: Box<Self>) -> reinhardt_core::exception::Result<()> {
+		Ok(())
 	}
 }
 
@@ -480,6 +556,83 @@ fn article_locale_row(article_id: i64, locale: &str, title: &str) -> Row {
 	row.insert("locale".to_string(), QueryValue::String(locale.to_string()));
 	row.insert("title".to_string(), QueryValue::String(title.to_string()));
 	row
+}
+
+#[tokio::test]
+async fn select_for_update_rejects_an_ordinary_executor_without_querying() {
+	let query = QuerySet::<Article>::new().select_for_update().nowait();
+	let mut executor = RecordingExecutor::new(DatabaseBackend::Postgres);
+
+	let error = query
+		.all_with_db(&mut executor)
+		.await
+		.expect_err("row locks require an active transaction executor");
+
+	assert_eq!(error.database_kind(), Some(DatabaseErrorKind::Transaction));
+	assert!(executor.calls.is_empty());
+}
+
+#[tokio::test]
+async fn select_for_update_renders_postgres_lock_options_in_a_transaction() {
+	let query = QuerySet::<Article>::new()
+		.select_for_update()
+		.nowait()
+		.no_key()
+		.of_model();
+	let mut executor = RowLockTransactionExecutor::postgres(vec![article_row(7, "locked")]);
+
+	let articles = query
+		.all_with_executor(&mut executor)
+		.await
+		.expect("PostgreSQL transaction should support every requested lock option");
+
+	assert_eq!(
+		articles,
+		vec![Article {
+			id: Some(7),
+			title: "locked".to_string(),
+		}]
+	);
+	assert_eq!(executor.calls.len(), 1);
+	assert_eq!(
+		executor.calls[0].sql,
+		"SELECT * FROM \"articles\" FOR NO KEY UPDATE OF \"articles\" NOWAIT"
+	);
+	assert!(executor.calls[0].params.is_empty());
+}
+
+#[tokio::test]
+async fn select_for_update_rejects_missing_server_capability_without_querying() {
+	let query = QuerySet::<Article>::new().select_for_update().skip_locked();
+	let mut executor = RowLockTransactionExecutor::postgres(Vec::new());
+	executor.capabilities.skip_locked = false;
+
+	let error = match query.rows_with_executor(&mut executor).await {
+		Ok(_) => panic!("an older PostgreSQL server must reject SKIP LOCKED"),
+		Err(error) => error,
+	};
+
+	assert_eq!(error.kind(), DatabaseErrorKind::Unsupported);
+	assert!(executor.calls.is_empty());
+}
+
+#[tokio::test]
+async fn select_for_update_rejects_sqlite_instead_of_degrading_to_a_no_op() {
+	let query = QuerySet::<Article>::new().select_for_update();
+	let mut executor = RowLockTransactionExecutor {
+		backend: reinhardt_db::backends::DatabaseType::Sqlite,
+		capabilities: reinhardt_db::orm::RowLockCapabilities::unsupported(),
+		calls: Vec::new(),
+		rows: Vec::new(),
+	};
+
+	let error = match query.rows_with_executor(&mut executor).await {
+		Ok(_) => panic!("SQLite does not support SELECT row locks"),
+		Err(error) => error,
+	};
+
+	assert_eq!(error.kind(), DatabaseErrorKind::Unsupported);
+	assert!(executor.calls.is_empty());
 }
 
 async fn save_article(

--- a/crates/reinhardt-db/tests/transaction_executor_orm.rs
+++ b/crates/reinhardt-db/tests/transaction_executor_orm.rs
@@ -22,6 +22,7 @@ use reinhardt_db::orm::connection::{BackendsConnection, DatabaseConnectionLease}
 use reinhardt_db::orm::connection::{
 	DatabaseBackend, OrmExecutor, QueryResult, QueryValue, Row, TransactionExecutor,
 };
+use reinhardt_db::orm::cte::CTE;
 use reinhardt_db::orm::custom_manager::CustomManager;
 use reinhardt_db::orm::events::{EventRegistry, EventResult, MapperEvents, set_active_registry};
 use reinhardt_db::orm::execution::{QueryExecution, SelectExecution};
@@ -730,6 +731,28 @@ async fn select_for_update_rejects_raw_aggregate_projections_without_querying() 
 		Err(error) => error,
 	};
 
+	assert_eq!(error.kind(), DatabaseErrorKind::Unsupported);
+	assert!(executor.calls.is_empty());
+}
+
+#[tokio::test]
+async fn select_for_update_rejects_cte_backed_querysets_without_querying() {
+	// Arrange
+	let query = QuerySet::<Article>::new()
+		.with_cte(CTE::new(
+			"locked_articles",
+			"SELECT * FROM articles WHERE id > 0",
+		))
+		.select_for_update();
+	let mut executor = RowLockTransactionExecutor::postgres(Vec::new());
+
+	// Act
+	let error = query
+		.rows_with_executor(&mut executor)
+		.await
+		.expect_err("row locking CTE-backed querysets must be rejected before execution");
+
+	// Assert
 	assert_eq!(error.kind(), DatabaseErrorKind::Unsupported);
 	assert!(executor.calls.is_empty());
 }

--- a/crates/reinhardt-db/tests/ui/select_for_update/fail/nowait_then_skip_locked.rs
+++ b/crates/reinhardt-db/tests/ui/select_for_update/fail/nowait_then_skip_locked.rs
@@ -1,0 +1,12 @@
+#[path = "../support.rs"]
+mod support;
+
+use reinhardt_db::orm::QuerySet;
+use support::Article;
+
+fn main() {
+	let _query = QuerySet::<Article>::new()
+		.select_for_update()
+		.nowait()
+		.skip_locked();
+}

--- a/crates/reinhardt-db/tests/ui/select_for_update/fail/nowait_then_skip_locked.stderr
+++ b/crates/reinhardt-db/tests/ui/select_for_update/fail/nowait_then_skip_locked.stderr
@@ -1,0 +1,13 @@
+error[E0599]: no method named `skip_locked` found for struct `SelectForUpdate<Article, Nowait>` in the current scope
+  --> tests/ui/select_for_update/fail/nowait_then_skip_locked.rs:11:4
+   |
+ 8 |       let _query = QuerySet::<Article>::new()
+   |  __________________-
+ 9 | |         .select_for_update()
+10 | |         .nowait()
+11 | |         .skip_locked();
+   | |         -^^^^^^^^^^^ method not found in `SelectForUpdate<Article, Nowait>`
+   | |_________|
+   |
+   |
+   = note: the method was found for `SelectForUpdate<M>`

--- a/crates/reinhardt-db/tests/ui/select_for_update/fail/relation_root_mismatch.rs
+++ b/crates/reinhardt-db/tests/ui/select_for_update/fail/relation_root_mismatch.rs
@@ -1,0 +1,11 @@
+#[path = "../support.rs"]
+mod support;
+
+use reinhardt_db::orm::QuerySet;
+use support::{Article, comment_author};
+
+fn main() {
+	let _query = QuerySet::<Article>::new()
+		.select_for_update()
+		.of_relation(comment_author());
+}

--- a/crates/reinhardt-db/tests/ui/select_for_update/fail/relation_root_mismatch.stderr
+++ b/crates/reinhardt-db/tests/ui/select_for_update/fail/relation_root_mismatch.stderr
@@ -1,0 +1,16 @@
+error[E0271]: type mismatch resolving `<RelationPath<Comment, Author> as RelationPathLike>::Root == Article`
+  --> tests/ui/select_for_update/fail/relation_root_mismatch.rs:10:16
+   |
+10 |         .of_relation(comment_author());
+   |          ----------- ^^^^^^^^^^^^^^^^ expected `Article`, found `Comment`
+   |          |
+   |          required by a bound introduced by this call
+   |
+note: required by a bound in `SelectForUpdate::<M, Behavior>::of_relation`
+  --> src/orm/query.rs
+   |
+   |     pub fn of_relation<P>(mut self, path: P) -> Self
+   |            ----------- required by a bound in this associated function
+   |     where
+   |         P: RelationPathLike<Root = M>,
+   |                             ^^^^^^^^ required by this bound in `SelectForUpdate::<M, Behavior>::of_relation`

--- a/crates/reinhardt-db/tests/ui/select_for_update/fail/skip_locked_then_nowait.rs
+++ b/crates/reinhardt-db/tests/ui/select_for_update/fail/skip_locked_then_nowait.rs
@@ -1,0 +1,12 @@
+#[path = "../support.rs"]
+mod support;
+
+use reinhardt_db::orm::QuerySet;
+use support::Article;
+
+fn main() {
+	let _query = QuerySet::<Article>::new()
+		.select_for_update()
+		.skip_locked()
+		.nowait();
+}

--- a/crates/reinhardt-db/tests/ui/select_for_update/fail/skip_locked_then_nowait.stderr
+++ b/crates/reinhardt-db/tests/ui/select_for_update/fail/skip_locked_then_nowait.stderr
@@ -1,0 +1,13 @@
+error[E0599]: no method named `nowait` found for struct `SelectForUpdate<Article, reinhardt_db::orm::SkipLocked>` in the current scope
+  --> tests/ui/select_for_update/fail/skip_locked_then_nowait.rs:11:4
+   |
+ 8 |       let _query = QuerySet::<Article>::new()
+   |  __________________-
+ 9 | |         .select_for_update()
+10 | |         .skip_locked()
+11 | |         .nowait();
+   | |         -^^^^^^ method not found in `SelectForUpdate<Article, reinhardt_db::orm::SkipLocked>`
+   | |_________|
+   |
+   |
+   = note: the method was found for `SelectForUpdate<M>`

--- a/crates/reinhardt-db/tests/ui/select_for_update/support.rs
+++ b/crates/reinhardt-db/tests/ui/select_for_update/support.rs
@@ -1,0 +1,77 @@
+#![allow(dead_code)] // Shared fixtures are referenced by separate trybuild crates.
+
+use std::borrow::Cow;
+
+use reinhardt_db::orm::{
+	FieldSelector, Manager, Model, RelationJoinKind, RelationMultiplicity, RelationPath,
+	RelationStep,
+};
+use serde::{Deserialize, Serialize};
+
+macro_rules! model {
+	($model:ident, $fields:ident, $table:literal) => {
+		#[derive(Clone, Debug, Deserialize, Serialize)]
+		pub(crate) struct $model {
+			pub(crate) id: Option<i64>,
+		}
+
+		#[derive(Clone)]
+		pub(crate) struct $fields;
+
+		impl FieldSelector for $fields {
+			fn with_alias(self, _alias: &str) -> Self {
+				self
+			}
+		}
+
+		impl Model for $model {
+			type PrimaryKey = i64;
+			type Fields = $fields;
+			type Objects = Manager<Self>;
+
+			fn table_name() -> &'static str {
+				$table
+			}
+
+			fn new_fields() -> Self::Fields {
+				$fields
+			}
+
+			fn primary_key(&self) -> Option<Self::PrimaryKey> {
+				self.id
+			}
+
+			fn set_primary_key(&mut self, value: Self::PrimaryKey) {
+				self.id = Some(value);
+			}
+		}
+	};
+}
+
+model!(Article, ArticleFields, "articles");
+model!(Author, AuthorFields, "authors");
+model!(Comment, CommentFields, "comments");
+
+pub(crate) fn article_author() -> RelationPath<Article, Author> {
+	RelationPath::from_owned_steps(vec![RelationStep {
+		name: Cow::Borrowed("author"),
+		source_table: Cow::Borrowed("articles"),
+		target_table: Cow::Borrowed("authors"),
+		source_column: Cow::Borrowed("author_id"),
+		target_column: Cow::Borrowed("id"),
+		default_join_kind: RelationJoinKind::Inner,
+		multiplicity: RelationMultiplicity::Single,
+	}])
+}
+
+pub(crate) fn comment_author() -> RelationPath<Comment, Author> {
+	RelationPath::from_owned_steps(vec![RelationStep {
+		name: Cow::Borrowed("author"),
+		source_table: Cow::Borrowed("comments"),
+		target_table: Cow::Borrowed("authors"),
+		source_column: Cow::Borrowed("author_id"),
+		target_column: Cow::Borrowed("id"),
+		default_join_kind: RelationJoinKind::Inner,
+		multiplicity: RelationMultiplicity::Single,
+	}])
+}

--- a/crates/reinhardt-query/README.md
+++ b/crates/reinhardt-query/README.md
@@ -159,8 +159,8 @@ assert_eq!(
 PostgreSQL supports all four lock strengths, table targets, and both wait
 behaviors. MySQL supports `FOR UPDATE`, `FOR SHARE`, table targets, and both
 wait behaviors; its checked builder rejects the PostgreSQL-specific strengths.
-CockroachDB supports all strengths (with `NO KEY UPDATE` and `KEY SHARE` as
-aliases) and both wait behaviors, but its checked builder rejects table targets.
+CockroachDB supports `FOR UPDATE`, `FOR SHARE`, `FOR KEY SHARE`, and `NOWAIT`.
+Its checked builder rejects `NO KEY UPDATE`, `SKIP LOCKED`, and table targets.
 SQLite does not support locking reads, so its checked builder returns
 `QueryBuildError::UnsupportedBackendFeature` instead of silently omitting the
 lock.

--- a/crates/reinhardt-query/README.md
+++ b/crates/reinhardt-query/README.md
@@ -13,6 +13,7 @@ A type-safe SQL query builder for the Reinhardt framework.
 - **DCL (Data Control Language) support** - GRANT and REVOKE statements
 - **Expression system** - Arithmetic, comparison, logical, and pattern matching operators
 - **Advanced SQL** - JOINs, GROUP BY, HAVING, DISTINCT, UNION, CTEs, Window functions
+- **Typed row locking** - Lock strengths, wait behavior, and table targets without raw SQL
 - **Parameterized queries** - `$1` for PostgreSQL/CockroachDB, `?` for MySQL/SQLite
 - **CASE WHEN expressions** - Conditional expressions in queries
 - **Subqueries** - EXISTS, IN, ALL, ANY, SOME operators
@@ -111,6 +112,40 @@ stmt.from_table("users")
 let builder = PostgresQueryBuilder::new();
 let (sql, values) = builder.build_delete(&stmt);
 ```
+
+### Row locking
+
+Use the owned query AST to configure locking reads. A single
+[`LockBehavior`](https://docs.rs/reinhardt-query/latest/reinhardt_query/query/enum.LockBehavior.html)
+keeps `NOWAIT` and `SKIP LOCKED` mutually exclusive, and `lock_tables` accepts
+typed `TableRef` values rather than unchecked SQL.
+
+```rust
+use reinhardt_query::prelude::*;
+
+let mut stmt = Query::select();
+stmt.column(("u", "id"))
+    .from(TableRef::table_alias("users", "u"))
+    .lock(LockType::NoKeyUpdate)
+    .lock_tables([TableRef::table_alias("users", "u")])
+    .lock_behavior(LockBehavior::Nowait);
+
+let (sql, values) = PostgresQueryBuilder::new().build_select_checked(&stmt)?;
+assert_eq!(
+    sql,
+    r#"SELECT "u"."id" FROM "users" AS "u" FOR NO KEY UPDATE OF "u" NOWAIT"#
+);
+# Ok::<(), QueryBuildError>(())
+```
+
+PostgreSQL supports all four lock strengths, table targets, and both wait
+behaviors. MySQL supports `FOR UPDATE`, `FOR SHARE`, table targets, and both
+wait behaviors; its checked builder rejects the PostgreSQL-specific strengths.
+CockroachDB supports all strengths (with `NO KEY UPDATE` and `KEY SHARE` as
+aliases) and both wait behaviors, but its checked builder rejects table targets.
+SQLite does not support locking reads, so its checked builder returns
+`QueryBuildError::UnsupportedBackendFeature` instead of silently omitting the
+lock.
 
 ### CREATE TABLE
 

--- a/crates/reinhardt-query/src/backend/cockroachdb.rs
+++ b/crates/reinhardt-query/src/backend/cockroachdb.rs
@@ -66,6 +66,7 @@ impl CockroachDBQueryBuilder {
 		&self,
 		stmt: &SelectStatement,
 	) -> Result<(String, Values), crate::QueryBuildError> {
+		crate::error::validate_select_lock_for_backend(stmt, "CockroachDB")?;
 		crate::error::validate_select_for_backend(stmt, "CockroachDB")?;
 		Ok(self.build_select(stmt))
 	}

--- a/crates/reinhardt-query/src/backend/mysql.rs
+++ b/crates/reinhardt-query/src/backend/mysql.rs
@@ -97,6 +97,7 @@ impl MySqlQueryBuilder {
 		&self,
 		stmt: &SelectStatement,
 	) -> Result<(String, Values), crate::QueryBuildError> {
+		crate::error::validate_select_lock_for_backend(stmt, "MySQL")?;
 		crate::error::validate_select_for_backend(stmt, "MySQL")?;
 		Ok(self.build_select(stmt))
 	}
@@ -234,6 +235,32 @@ impl MySqlQueryBuilder {
 
 				// Merge the values from the subquery
 				writer.append_values(&subquery_values);
+			}
+		}
+	}
+
+	/// Write a table target in a row-lock `OF` clause.
+	fn write_lock_table_target(&self, writer: &mut SqlWriter, table_ref: &TableRef) {
+		match table_ref {
+			TableRef::TableAlias(_, alias)
+			| TableRef::SchemaTableAlias(_, _, alias)
+			| TableRef::SubQuery(_, alias) => {
+				writer.push_identifier(&alias.to_string(), |s| self.escape_iden(s));
+			}
+			TableRef::Table(iden) => {
+				writer.push_identifier(&iden.to_string(), |s| self.escape_iden(s));
+			}
+			TableRef::SchemaTable(schema, table) => {
+				writer.push_identifier(&schema.to_string(), |s| self.escape_iden(s));
+				writer.push(".");
+				writer.push_identifier(&table.to_string(), |s| self.escape_iden(s));
+			}
+			TableRef::DatabaseSchemaTable(db, schema, table) => {
+				writer.push_identifier(&db.to_string(), |s| self.escape_iden(s));
+				writer.push(".");
+				writer.push_identifier(&schema.to_string(), |s| self.escape_iden(s));
+				writer.push(".");
+				writer.push_identifier(&table.to_string(), |s| self.escape_iden(s));
 			}
 		}
 	}
@@ -949,6 +976,30 @@ impl QueryBuilder for MySqlQueryBuilder {
 
 			// Merge the values from the union query
 			writer.append_values(&union_values);
+		}
+
+		if let Some(lock) = &stmt.lock {
+			use crate::query::{LockBehavior, LockType};
+
+			writer.push_keyword(match lock.r#type {
+				LockType::Update => "FOR UPDATE",
+				LockType::NoKeyUpdate => "FOR NO KEY UPDATE",
+				LockType::Share => "FOR SHARE",
+				LockType::KeyShare => "FOR KEY SHARE",
+			});
+			if !lock.tables.is_empty() {
+				writer.push_keyword("OF");
+				writer.push_space();
+				writer.push_list(&lock.tables, ", ", |w, table| {
+					self.write_lock_table_target(w, table);
+				});
+			}
+			if let Some(behavior) = lock.behavior {
+				writer.push_keyword(match behavior {
+					LockBehavior::Nowait => "NOWAIT",
+					LockBehavior::SkipLocked => "SKIP LOCKED",
+				});
+			}
 		}
 
 		writer.finish()

--- a/crates/reinhardt-query/src/backend/postgres.rs
+++ b/crates/reinhardt-query/src/backend/postgres.rs
@@ -4866,11 +4866,37 @@ mod tests {
 	use crate::types::{BinOper, PgBinOper};
 	use crate::{
 		expr::{Expr, ExprTrait},
-		query::Query,
+		query::{LockType, Query},
 		types::{Alias, ColumnDef, IntoIden},
 		value::Value,
 	};
 	use rstest::rstest;
+
+	#[test]
+	fn checked_select_rejects_row_locking_with_group_by_or_having() {
+		let builder = PostgresQueryBuilder::new();
+		let mut grouped = Query::select();
+		grouped
+			.column("account_id")
+			.from("ledger_entries")
+			.group_by_col("account_id")
+			.lock(LockType::Update);
+		let grouped_error = builder
+			.build_select_checked(&grouped)
+			.expect_err("PostgreSQL must reject row locking on grouped queries");
+		assert!(grouped_error.to_string().contains("GROUP BY or HAVING"));
+
+		let mut having = Query::select();
+		having
+			.column("account_id")
+			.from("ledger_entries")
+			.and_having(Expr::col("account_id").gt(0))
+			.lock(LockType::Update);
+		let having_error = builder
+			.build_select_checked(&having)
+			.expect_err("PostgreSQL must reject row locking on HAVING queries");
+		assert!(having_error.to_string().contains("GROUP BY or HAVING"));
+	}
 
 	#[test]
 	fn test_escape_identifier() {

--- a/crates/reinhardt-query/src/backend/postgres.rs
+++ b/crates/reinhardt-query/src/backend/postgres.rs
@@ -4917,6 +4917,21 @@ mod tests {
 	}
 
 	#[test]
+	fn checked_select_rejects_row_locking_with_window_projection() {
+		let builder = PostgresQueryBuilder::new();
+		let mut statement = Query::select();
+		statement
+			.expr(Expr::row_number().over(crate::types::WindowStatement::default()))
+			.from("accounts")
+			.lock(LockType::Update);
+
+		let error = builder
+			.build_select_checked(&statement)
+			.expect_err("PostgreSQL must reject row locking on window queries");
+		assert!(error.to_string().contains("window-function"));
+	}
+
+	#[test]
 	fn checked_select_rejects_lock_targets_on_nullable_outer_join_sides() {
 		let builder = PostgresQueryBuilder::new();
 		let mut statement = Query::select();
@@ -4933,6 +4948,29 @@ mod tests {
 			.build_select_checked(&statement)
 			.expect_err("PostgreSQL must reject locks on nullable outer-join sides");
 		assert!(error.to_string().contains("nullable outer-join"));
+	}
+
+	#[test]
+	fn checked_select_rejects_targetless_locking_across_outer_joins() {
+		let builder = PostgresQueryBuilder::new();
+		let mut statement = Query::select();
+		statement
+			.column(("parents", "id"))
+			.from("parents")
+			.left_join(
+				"children",
+				Expr::col(("parents", "id")).equals(("children", "parent_id")),
+			)
+			.lock(LockType::Update);
+
+		let error = builder
+			.build_select_checked(&statement)
+			.expect_err("PostgreSQL must reject targetless locks across outer joins");
+		assert!(
+			error
+				.to_string()
+				.contains("outer joins without explicit targets")
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-query/src/backend/postgres.rs
+++ b/crates/reinhardt-query/src/backend/postgres.rs
@@ -112,6 +112,7 @@ impl PostgresQueryBuilder {
 		&self,
 		stmt: &InsertStatement,
 	) -> Result<(String, Values), crate::QueryBuildError> {
+		crate::error::validate_insert_lock_for_backend(stmt, "PostgreSQL")?;
 		Ok(self.build_insert(stmt))
 	}
 
@@ -120,6 +121,7 @@ impl PostgresQueryBuilder {
 		&self,
 		stmt: &UpdateStatement,
 	) -> Result<(String, Values), crate::QueryBuildError> {
+		crate::error::validate_update_lock_for_backend(stmt, "PostgreSQL")?;
 		Ok(self.build_update(stmt))
 	}
 
@@ -128,6 +130,7 @@ impl PostgresQueryBuilder {
 		&self,
 		stmt: &DeleteStatement,
 	) -> Result<(String, Values), crate::QueryBuildError> {
+		crate::error::validate_delete_lock_for_backend(stmt, "PostgreSQL")?;
 		Ok(self.build_delete(stmt))
 	}
 
@@ -4865,7 +4868,7 @@ mod tests {
 	#[cfg(feature = "pgvector")]
 	use crate::types::{BinOper, PgBinOper};
 	use crate::{
-		expr::{Expr, ExprTrait},
+		expr::{Expr, ExprTrait, Func},
 		query::{LockType, Query},
 		types::{Alias, ColumnDef, IntoIden},
 		value::Value,
@@ -4896,6 +4899,88 @@ mod tests {
 			.build_select_checked(&having)
 			.expect_err("PostgreSQL must reject row locking on HAVING queries");
 		assert!(having_error.to_string().contains("GROUP BY or HAVING"));
+	}
+
+	#[test]
+	fn checked_select_rejects_row_locking_with_aggregate_projection() {
+		let builder = PostgresQueryBuilder::new();
+		let mut statement = Query::select();
+		statement
+			.expr(Func::count(Expr::col("id").into_simple_expr()))
+			.from("accounts")
+			.lock(LockType::Update);
+
+		let error = builder
+			.build_select_checked(&statement)
+			.expect_err("PostgreSQL must reject row locking on aggregate queries");
+		assert!(error.to_string().contains("aggregate"));
+	}
+
+	#[test]
+	fn checked_select_rejects_lock_targets_on_nullable_outer_join_sides() {
+		let builder = PostgresQueryBuilder::new();
+		let mut statement = Query::select();
+		statement
+			.column(("parents", "id"))
+			.from("parents")
+			.left_join(
+				"children",
+				Expr::col(("parents", "id")).equals(("children", "parent_id")),
+			)
+			.lock_tables(["children"]);
+
+		let error = builder
+			.build_select_checked(&statement)
+			.expect_err("PostgreSQL must reject locks on nullable outer-join sides");
+		assert!(error.to_string().contains("nullable outer-join"));
+	}
+
+	#[test]
+	fn checked_dml_rejects_nested_locked_selects() {
+		let builder = PostgresQueryBuilder::new();
+		let mut source = Query::select();
+		source.column("id").from("accounts").lock(LockType::Update);
+		let insert = Query::insert()
+			.into_table("archive")
+			.columns(["account_id"])
+			.from_subquery(source.to_owned())
+			.to_owned();
+
+		assert!(builder.build_insert_checked(&insert).is_ok());
+
+		let mut invalid_source = Query::select();
+		invalid_source
+			.expr(Func::count(Expr::col("id").into_simple_expr()))
+			.from("accounts")
+			.lock(LockType::Update);
+		let invalid_insert = Query::insert()
+			.into_table("archive")
+			.columns(["account_id"])
+			.from_subquery(invalid_source.to_owned())
+			.to_owned();
+
+		let error = builder
+			.build_insert_checked(&invalid_insert)
+			.expect_err("checked INSERT must validate nested row locks");
+		assert!(error.to_string().contains("aggregate"));
+
+		let update = Query::update()
+			.table("archive")
+			.value_expr("account_id", Expr::subquery(invalid_source.clone()))
+			.to_owned();
+		let update_error = builder
+			.build_update_checked(&update)
+			.expect_err("checked UPDATE must validate nested row locks");
+		assert!(update_error.to_string().contains("aggregate"));
+
+		let delete = Query::delete()
+			.from_table("archive")
+			.and_where(Expr::exists(invalid_source))
+			.to_owned();
+		let delete_error = builder
+			.build_delete_checked(&delete)
+			.expect_err("checked DELETE must validate nested row locks");
+		assert!(delete_error.to_string().contains("aggregate"));
 	}
 
 	#[test]

--- a/crates/reinhardt-query/src/backend/postgres.rs
+++ b/crates/reinhardt-query/src/backend/postgres.rs
@@ -93,6 +93,7 @@ impl PostgresQueryBuilder {
 		&self,
 		stmt: &SelectStatement,
 	) -> Result<(String, Values), crate::QueryBuildError> {
+		crate::error::validate_select_lock_for_backend(stmt, "PostgreSQL")?;
 		Ok(self.build_select(stmt))
 	}
 
@@ -432,6 +433,32 @@ impl PostgresQueryBuilder {
 
 				// Merge the values from the subquery
 				writer.append_values(&subquery_values);
+			}
+		}
+	}
+
+	/// Write a table target in a row-lock `OF` clause.
+	fn write_lock_table_target(&self, writer: &mut SqlWriter, table_ref: &TableRef) {
+		match table_ref {
+			TableRef::TableAlias(_, alias)
+			| TableRef::SchemaTableAlias(_, _, alias)
+			| TableRef::SubQuery(_, alias) => {
+				writer.push_identifier(&alias.to_string(), |s| self.escape_iden(s));
+			}
+			TableRef::Table(iden) => {
+				writer.push_identifier(&iden.to_string(), |s| self.escape_iden(s));
+			}
+			TableRef::SchemaTable(schema, table) => {
+				writer.push_identifier(&schema.to_string(), |s| self.escape_iden(s));
+				writer.push(".");
+				writer.push_identifier(&table.to_string(), |s| self.escape_iden(s));
+			}
+			TableRef::DatabaseSchemaTable(db, schema, table) => {
+				writer.push_identifier(&db.to_string(), |s| self.escape_iden(s));
+				writer.push(".");
+				writer.push_identifier(&schema.to_string(), |s| self.escape_iden(s));
+				writer.push(".");
+				writer.push_identifier(&table.to_string(), |s| self.escape_iden(s));
 			}
 		}
 	}
@@ -1459,6 +1486,30 @@ impl QueryBuilder for PostgresQueryBuilder {
 
 			// Merge the values from the union query
 			writer.append_values(&union_values);
+		}
+
+		if let Some(lock) = &stmt.lock {
+			use crate::query::{LockBehavior, LockType};
+
+			writer.push_keyword(match lock.r#type {
+				LockType::Update => "FOR UPDATE",
+				LockType::NoKeyUpdate => "FOR NO KEY UPDATE",
+				LockType::Share => "FOR SHARE",
+				LockType::KeyShare => "FOR KEY SHARE",
+			});
+			if !lock.tables.is_empty() {
+				writer.push_keyword("OF");
+				writer.push_space();
+				writer.push_list(&lock.tables, ", ", |w, table| {
+					self.write_lock_table_target(w, table);
+				});
+			}
+			if let Some(behavior) = lock.behavior {
+				writer.push_keyword(match behavior {
+					LockBehavior::Nowait => "NOWAIT",
+					LockBehavior::SkipLocked => "SKIP LOCKED",
+				});
+			}
 		}
 
 		writer.finish()

--- a/crates/reinhardt-query/src/backend/sqlite.rs
+++ b/crates/reinhardt-query/src/backend/sqlite.rs
@@ -2310,6 +2310,26 @@ mod tests {
 	}
 
 	#[test]
+	fn checked_insert_rejects_nested_locked_select_in_returning_expression() {
+		let mut locked = Query::select();
+		locked
+			.column("id")
+			.from("accounts")
+			.lock(crate::query::LockType::Update);
+		let insert = Query::insert()
+			.into_table("archive")
+			.column("account_id")
+			.values_panic([1_i32])
+			.returning_exprs([Expr::subquery(locked)])
+			.to_owned();
+
+		let error = SqliteQueryBuilder::new()
+			.build_insert_checked(&insert)
+			.expect_err("SQLite must reject a nested row lock in INSERT RETURNING");
+		assert!(error.to_string().contains("row locking"));
+	}
+
+	#[test]
 	fn test_insert_with_returning_all() {
 		let builder = SqliteQueryBuilder::new();
 		let mut stmt = Query::insert();

--- a/crates/reinhardt-query/src/backend/sqlite.rs
+++ b/crates/reinhardt-query/src/backend/sqlite.rs
@@ -60,6 +60,7 @@ impl SqliteQueryBuilder {
 		&self,
 		stmt: &SelectStatement,
 	) -> Result<(String, Values), crate::QueryBuildError> {
+		crate::error::validate_select_lock_for_backend(stmt, "SQLite")?;
 		crate::error::validate_select_for_backend(stmt, "SQLite")?;
 		Ok(self.build_select(stmt))
 	}

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -230,6 +230,12 @@ fn validate_select_lock_for_backend_with_union_context(
 			if statement.distinct.is_some() {
 				return Err(unsupported("row locking with DISTINCT queries", backend));
 			}
+			if !statement.groups.is_empty() || !statement.having.conditions.is_empty() {
+				return Err(unsupported(
+					"row locking with GROUP BY or HAVING queries",
+					backend,
+				));
+			}
 			validate_lock_tables_belong_to_statement(statement, lock.tables.as_slice(), backend)?;
 			Ok(())
 		}

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -174,6 +174,54 @@ pub(crate) fn validate_select_for_backend(
 	Ok(())
 }
 
+pub(crate) fn validate_select_lock_for_backend(
+	statement: &SelectStatement,
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	for cte in &statement.ctes {
+		validate_select_lock_for_backend(&cte.query, backend)?;
+	}
+	for table in &statement.from {
+		if let TableRef::SubQuery(query, _) = table {
+			validate_select_lock_for_backend(query, backend)?;
+		}
+	}
+	for join in &statement.join {
+		if let TableRef::SubQuery(query, _) = &join.table {
+			validate_select_lock_for_backend(query, backend)?;
+		}
+	}
+	for (_, union) in &statement.unions {
+		validate_select_lock_for_backend(union, backend)?;
+	}
+
+	let Some(lock) = &statement.lock else {
+		return Ok(());
+	};
+
+	match backend {
+		"PostgreSQL" => Ok(()),
+		"MySQL" => {
+			if matches!(
+				lock.r#type,
+				crate::query::LockType::NoKeyUpdate | crate::query::LockType::KeyShare
+			) {
+				return Err(unsupported("the requested row lock strength", backend));
+			}
+			Ok(())
+		}
+		"SQLite" => Err(unsupported("row locking", backend)),
+		"CockroachDB" => {
+			if lock.tables.is_empty() {
+				Ok(())
+			} else {
+				Err(unsupported("row lock table targets", backend))
+			}
+		}
+		_ => Ok(()),
+	}
+}
+
 pub(crate) fn validate_create_table_for_backend(
 	statement: &CreateTableStatement,
 	backend: &'static str,
@@ -331,7 +379,6 @@ fn validate_postgres_column_type_dimensions(
 	}
 }
 
-#[cfg(feature = "pgvector")]
 fn unsupported(feature: &'static str, backend: &'static str) -> QueryBuildError {
 	QueryBuildError::UnsupportedBackendFeature { feature, backend }
 }

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -178,21 +178,44 @@ pub(crate) fn validate_select_lock_for_backend(
 	statement: &SelectStatement,
 	backend: &'static str,
 ) -> Result<(), QueryBuildError> {
+	validate_select_lock_for_backend_with_union_context(statement, backend, false)
+}
+
+fn validate_select_lock_for_backend_with_union_context(
+	statement: &SelectStatement,
+	backend: &'static str,
+	in_union_arm: bool,
+) -> Result<(), QueryBuildError> {
 	for cte in &statement.ctes {
-		validate_select_lock_for_backend(&cte.query, backend)?;
+		validate_select_lock_for_backend_with_union_context(&cte.query, backend, false)?;
+	}
+	for select in &statement.selects {
+		validate_simple_expr_lock(&select.expr, backend)?;
 	}
 	for table in &statement.from {
-		if let TableRef::SubQuery(query, _) = table {
-			validate_select_lock_for_backend(query, backend)?;
-		}
+		validate_table_ref_lock(table, backend)?;
 	}
 	for join in &statement.join {
-		if let TableRef::SubQuery(query, _) = &join.table {
-			validate_select_lock_for_backend(query, backend)?;
+		validate_table_ref_lock(&join.table, backend)?;
+		if let Some(crate::types::JoinOn::Condition(condition)) = &join.on {
+			validate_condition_lock(condition, backend)?;
 		}
 	}
+	validate_condition_holder_lock(&statement.r#where, backend)?;
+	for group in &statement.groups {
+		validate_simple_expr_lock(group, backend)?;
+	}
+	validate_condition_holder_lock(&statement.having, backend)?;
 	for (_, union) in &statement.unions {
-		validate_select_lock_for_backend(union, backend)?;
+		validate_select_lock_for_backend_with_union_context(union, backend, true)?;
+	}
+	for order in &statement.orders {
+		if let OrderExprKind::Expr(expr) = &order.expr {
+			validate_simple_expr_lock(expr, backend)?;
+		}
+	}
+	for (_, window) in &statement.windows {
+		validate_window_lock(window, backend)?;
 	}
 
 	let Some(lock) = &statement.lock else {
@@ -201,9 +224,13 @@ pub(crate) fn validate_select_lock_for_backend(
 
 	match backend {
 		"PostgreSQL" => {
-			if !statement.unions.is_empty() {
+			if in_union_arm || !statement.unions.is_empty() {
 				return Err(unsupported("row locking on UNION queries", backend));
 			}
+			if statement.distinct.is_some() {
+				return Err(unsupported("row locking with DISTINCT queries", backend));
+			}
+			validate_lock_tables_belong_to_statement(statement, lock.tables.as_slice(), backend)?;
 			Ok(())
 		}
 		"MySQL" => {
@@ -225,6 +252,156 @@ pub(crate) fn validate_select_lock_for_backend(
 		}
 		_ => Ok(()),
 	}
+}
+
+fn validate_lock_tables_belong_to_statement(
+	statement: &SelectStatement,
+	targets: &[TableRef],
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	let mut relations = Vec::with_capacity(statement.from.len() + statement.join.len());
+	for table in &statement.from {
+		relations.extend(table_ref_lock_names(table));
+	}
+	for join in &statement.join {
+		relations.extend(table_ref_lock_names(&join.table));
+	}
+	for target in targets {
+		if !table_ref_lock_names(target)
+			.iter()
+			.any(|target_name| relations.iter().any(|relation| relation == target_name))
+		{
+			return Err(unsupported(
+				"row lock target absent from the query",
+				backend,
+			));
+		}
+	}
+	Ok(())
+}
+
+fn table_ref_lock_names(table: &TableRef) -> Vec<String> {
+	match table {
+		TableRef::Table(table) => vec![table.to_string()],
+		TableRef::SchemaTable(schema, table) => {
+			vec![format!("{}.{}", schema.to_string(), table.to_string())]
+		}
+		TableRef::DatabaseSchemaTable(database, schema, table) => {
+			vec![format!(
+				"{}.{}.{}",
+				database.to_string(),
+				schema.to_string(),
+				table.to_string()
+			)]
+		}
+		TableRef::TableAlias(_, alias)
+		| TableRef::SchemaTableAlias(_, _, alias)
+		| TableRef::SubQuery(_, alias) => vec![alias.to_string()],
+	}
+}
+
+fn validate_condition_holder_lock(
+	holder: &ConditionHolder,
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	for condition in &holder.conditions {
+		validate_condition_expression_lock(condition, backend)?;
+	}
+	Ok(())
+}
+
+fn validate_condition_lock(
+	condition: &Condition,
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	for expression in &condition.conditions {
+		validate_condition_expression_lock(expression, backend)?;
+	}
+	Ok(())
+}
+
+fn validate_condition_expression_lock(
+	expression: &ConditionExpression,
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	match expression {
+		ConditionExpression::SimpleExpr(expr) => validate_simple_expr_lock(expr, backend),
+		ConditionExpression::Condition(condition) => validate_condition_lock(condition, backend),
+	}
+}
+
+fn validate_simple_expr_lock(
+	expr: &SimpleExpr,
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	match expr {
+		SimpleExpr::Column(_)
+		| SimpleExpr::TableColumn(_, _)
+		| SimpleExpr::Value(_)
+		| SimpleExpr::Custom(_)
+		| SimpleExpr::Constant(_)
+		| SimpleExpr::Asterisk => Ok(()),
+		SimpleExpr::Unary(_, expression)
+		| SimpleExpr::AsEnum(_, expression)
+		| SimpleExpr::ExprAlias(expression, _)
+		| SimpleExpr::Cast(expression, _) => validate_simple_expr_lock(expression, backend),
+		SimpleExpr::Binary(left, _, right) => {
+			validate_simple_expr_lock(left, backend)?;
+			validate_simple_expr_lock(right, backend)
+		}
+		SimpleExpr::FunctionCall(_, args) | SimpleExpr::Tuple(args) => {
+			for arg in args {
+				validate_simple_expr_lock(arg, backend)?;
+			}
+			Ok(())
+		}
+		SimpleExpr::SubQuery(_, query) => {
+			validate_select_lock_for_backend_with_union_context(query, backend, false)
+		}
+		SimpleExpr::CustomWithExpr(_, expressions) => {
+			for expression in expressions {
+				validate_simple_expr_lock(expression, backend)?;
+			}
+			Ok(())
+		}
+		SimpleExpr::Case(case) => {
+			for (condition, result) in &case.when_clauses {
+				validate_simple_expr_lock(condition, backend)?;
+				validate_simple_expr_lock(result, backend)?;
+			}
+			if let Some(result) = &case.else_clause {
+				validate_simple_expr_lock(result, backend)?;
+			}
+			Ok(())
+		}
+		SimpleExpr::Window { func, window } => {
+			validate_simple_expr_lock(func, backend)?;
+			validate_window_lock(window, backend)
+		}
+		SimpleExpr::WindowNamed { func, .. } => validate_simple_expr_lock(func, backend),
+	}
+}
+
+fn validate_table_ref_lock(table: &TableRef, backend: &'static str) -> Result<(), QueryBuildError> {
+	if let TableRef::SubQuery(query, _) = table {
+		validate_select_lock_for_backend_with_union_context(query, backend, false)?;
+	}
+	Ok(())
+}
+
+fn validate_window_lock(
+	window: &WindowStatement,
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	for partition in &window.partition_by {
+		validate_simple_expr_lock(partition, backend)?;
+	}
+	for order in &window.order_by {
+		if let OrderExprKind::Expr(expr) = &order.expr {
+			validate_simple_expr_lock(expr, backend)?;
+		}
+	}
+	Ok(())
 }
 
 pub(crate) fn validate_create_table_for_backend(

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -9,8 +9,8 @@ use crate::{
 		DeleteStatement, InsertSource, InsertStatement, SelectStatement, UpdateStatement,
 	},
 	types::{
-		ColumnDef, ColumnType, OrderExpr, OrderExprKind, SchemaExpr, TableConstraint, TableRef,
-		WindowStatement,
+		ColumnDef, ColumnType, JoinType, OrderExpr, OrderExprKind, SchemaExpr, TableConstraint,
+		TableRef, WindowStatement,
 	},
 	value::Value,
 };
@@ -236,7 +236,17 @@ fn validate_select_lock_for_backend_with_union_context(
 					backend,
 				));
 			}
+			if statement
+				.selects
+				.iter()
+				.any(|select| contains_aggregate(&select.expr))
+				|| statement.orders.iter().any(
+					|order| matches!(&order.expr, OrderExprKind::Expr(expr) if contains_aggregate(expr)),
+				) {
+				return Err(unsupported("row locking with aggregate queries", backend));
+			}
 			validate_lock_tables_belong_to_statement(statement, lock.tables.as_slice(), backend)?;
+			validate_lock_tables_are_not_nullable(statement, lock.tables.as_slice(), backend)?;
 			Ok(())
 		}
 		"MySQL" => {
@@ -257,6 +267,54 @@ fn validate_select_lock_for_backend_with_union_context(
 			}
 		}
 		_ => Ok(()),
+	}
+}
+
+fn contains_aggregate(expr: &SimpleExpr) -> bool {
+	match expr {
+		SimpleExpr::FunctionCall(name, arguments) => {
+			matches!(
+				name.to_string().as_str(),
+				"COUNT"
+					| "SUM" | "AVG" | "MIN"
+					| "MAX" | "ARRAY_AGG"
+					| "JSON_AGG" | "JSONB_AGG"
+					| "STRING_AGG" | "BOOL_AND"
+					| "BOOL_OR" | "EVERY"
+					| "XMLAGG"
+			) || arguments.iter().any(contains_aggregate)
+		}
+		SimpleExpr::Unary(_, expression)
+		| SimpleExpr::AsEnum(_, expression)
+		| SimpleExpr::ExprAlias(expression, _)
+		| SimpleExpr::Cast(expression, _) => contains_aggregate(expression),
+		SimpleExpr::Binary(left, _, right) => contains_aggregate(left) || contains_aggregate(right),
+		SimpleExpr::Tuple(expressions) | SimpleExpr::CustomWithExpr(_, expressions) => {
+			expressions.iter().any(contains_aggregate)
+		}
+		SimpleExpr::Case(case) => {
+			case.when_clauses.iter().any(|(condition, result)| {
+				contains_aggregate(condition) || contains_aggregate(result)
+			}) || case
+				.else_clause
+				.as_ref()
+				.is_some_and(|result| contains_aggregate(result))
+		}
+		SimpleExpr::Window { func, window } => {
+			contains_aggregate(func)
+				|| window.partition_by.iter().any(contains_aggregate)
+				|| window.order_by.iter().any(
+					|order| matches!(&order.expr, OrderExprKind::Expr(expr) if contains_aggregate(expr)),
+				)
+		}
+		SimpleExpr::WindowNamed { func, .. } => contains_aggregate(func),
+		SimpleExpr::Column(_)
+		| SimpleExpr::TableColumn(_, _)
+		| SimpleExpr::Value(_)
+		| SimpleExpr::Custom(_)
+		| SimpleExpr::Constant(_)
+		| SimpleExpr::Asterisk
+		| SimpleExpr::SubQuery(_, _) => false,
 	}
 }
 
@@ -282,6 +340,42 @@ fn validate_lock_tables_belong_to_statement(
 				backend,
 			));
 		}
+	}
+	Ok(())
+}
+
+fn validate_lock_tables_are_not_nullable(
+	statement: &SelectStatement,
+	targets: &[TableRef],
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	let mut relations = Vec::new();
+	for table in &statement.from {
+		relations.extend(table_ref_lock_names(table));
+	}
+	let mut nullable_relations = Vec::new();
+	for join in &statement.join {
+		let joined_relations = table_ref_lock_names(&join.table);
+		match join.join {
+			JoinType::LeftJoin => nullable_relations.extend(joined_relations.iter().cloned()),
+			JoinType::RightJoin => nullable_relations.extend(relations.iter().cloned()),
+			JoinType::FullOuterJoin => {
+				nullable_relations.extend(relations.iter().cloned());
+				nullable_relations.extend(joined_relations.iter().cloned());
+			}
+			JoinType::Join | JoinType::InnerJoin | JoinType::CrossJoin => {}
+		}
+		relations.extend(joined_relations);
+	}
+	if targets.iter().flat_map(table_ref_lock_names).any(|target| {
+		nullable_relations
+			.iter()
+			.any(|nullable_relation| nullable_relation == &target)
+	}) {
+		return Err(unsupported(
+			"row lock target on nullable outer-join side",
+			backend,
+		));
 	}
 	Ok(())
 }
@@ -458,9 +552,27 @@ pub(crate) fn validate_insert_for_backend(
 		}
 		InsertSource::Subquery(query) => validate_select_for_backend(query, backend)?,
 	}
+	if let InsertSource::Subquery(query) = &statement.source {
+		validate_select_lock_for_backend(query, backend)?;
+	}
 	if let Some(expressions) = &statement.returning_exprs {
 		for expression in expressions {
 			validate_simple_expr(expression, backend)?;
+		}
+	}
+	Ok(())
+}
+
+pub(crate) fn validate_insert_lock_for_backend(
+	statement: &InsertStatement,
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	if let InsertSource::Subquery(query) = &statement.source {
+		validate_select_lock_for_backend(query, backend)?;
+	}
+	if let Some(expressions) = &statement.returning_exprs {
+		for expression in expressions {
+			validate_simple_expr_lock(expression, backend)?;
 		}
 	}
 	Ok(())
@@ -475,11 +587,33 @@ pub(crate) fn validate_update_for_backend(
 	}
 	for (_, expression) in &statement.values {
 		validate_simple_expr(expression, backend)?;
+		validate_simple_expr_lock(expression, backend)?;
 	}
 	validate_condition_holder(&statement.r#where, backend)?;
+	validate_condition_holder_lock(&statement.r#where, backend)?;
 	if let Some(expressions) = &statement.returning_exprs {
 		for expression in expressions {
 			validate_simple_expr(expression, backend)?;
+			validate_simple_expr_lock(expression, backend)?;
+		}
+	}
+	Ok(())
+}
+
+pub(crate) fn validate_update_lock_for_backend(
+	statement: &UpdateStatement,
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	if let Some(table) = &statement.table {
+		validate_table_ref_lock(table, backend)?;
+	}
+	for (_, expression) in &statement.values {
+		validate_simple_expr_lock(expression, backend)?;
+	}
+	validate_condition_holder_lock(&statement.r#where, backend)?;
+	if let Some(expressions) = &statement.returning_exprs {
+		for expression in expressions {
+			validate_simple_expr_lock(expression, backend)?;
 		}
 	}
 	Ok(())
@@ -493,9 +627,27 @@ pub(crate) fn validate_delete_for_backend(
 		validate_table_ref(table, backend)?;
 	}
 	validate_condition_holder(&statement.r#where, backend)?;
+	validate_condition_holder_lock(&statement.r#where, backend)?;
 	if let Some(expressions) = &statement.returning_exprs {
 		for expression in expressions {
 			validate_simple_expr(expression, backend)?;
+			validate_simple_expr_lock(expression, backend)?;
+		}
+	}
+	Ok(())
+}
+
+pub(crate) fn validate_delete_lock_for_backend(
+	statement: &DeleteStatement,
+	backend: &'static str,
+) -> Result<(), QueryBuildError> {
+	if let Some(table) = &statement.table {
+		validate_table_ref_lock(table, backend)?;
+	}
+	validate_condition_holder_lock(&statement.r#where, backend)?;
+	if let Some(expressions) = &statement.returning_exprs {
+		for expression in expressions {
+			validate_simple_expr_lock(expression, backend)?;
 		}
 	}
 	Ok(())

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -385,9 +385,10 @@ fn validate_lock_tables_belong_to_statement(
 		relations.extend(table_ref_lock_names(&join.table));
 	}
 	for target in targets {
-		if !table_ref_lock_names(target)
-			.iter()
-			.any(|target_name| relations.iter().any(|relation| relation == target_name))
+		if table_ref_is_derived(target)
+			|| !table_ref_lock_names(target)
+				.iter()
+				.any(|target_name| relations.iter().any(|relation| relation == target_name))
 		{
 			return Err(unsupported(
 				"row lock target absent from the query",
@@ -452,6 +453,10 @@ fn table_ref_lock_names(table: &TableRef) -> Vec<String> {
 		| TableRef::SchemaTableAlias(_, _, alias)
 		| TableRef::SubQuery(_, alias) => vec![alias.to_string()],
 	}
+}
+
+fn table_ref_is_derived(table: &TableRef) -> bool {
+	matches!(table, TableRef::SubQuery(_, _))
 }
 
 fn validate_condition_holder_lock(

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -227,6 +227,9 @@ fn validate_select_lock_for_backend_with_union_context(
 			if in_union_arm || !statement.unions.is_empty() {
 				return Err(unsupported("row locking on UNION queries", backend));
 			}
+			if statement_lock_targets_cte(statement, lock.tables.as_slice()) {
+				return Err(unsupported("row locking on CTE-backed queries", backend));
+			}
 			if statement.distinct.is_some() {
 				return Err(unsupported("row locking with DISTINCT queries", backend));
 			}
@@ -274,6 +277,9 @@ fn validate_select_lock_for_backend_with_union_context(
 			Ok(())
 		}
 		"MySQL" => {
+			if in_union_arm || !statement.unions.is_empty() {
+				return Err(unsupported("row locking on UNION queries", backend));
+			}
 			if matches!(
 				lock.r#type,
 				crate::query::LockType::NoKeyUpdate | crate::query::LockType::KeyShare
@@ -293,6 +299,44 @@ fn validate_select_lock_for_backend_with_union_context(
 		}
 		_ => Ok(()),
 	}
+}
+
+fn statement_lock_targets_cte(statement: &SelectStatement, targets: &[TableRef]) -> bool {
+	let cte_names = statement
+		.ctes
+		.iter()
+		.map(|cte| cte.name.to_string())
+		.collect::<Vec<_>>();
+	let cte_relations = statement
+		.from
+		.iter()
+		.chain(statement.join.iter().map(|join| &join.table))
+		.filter(|table| table_ref_references_cte(table, &cte_names))
+		.collect::<Vec<_>>();
+	if cte_relations.is_empty() {
+		return false;
+	}
+	if targets.is_empty() {
+		return true;
+	}
+	targets.iter().flat_map(table_ref_lock_names).any(|target| {
+		cte_relations.iter().any(|cte_relation| {
+			table_ref_lock_names(cte_relation)
+				.iter()
+				.any(|cte_name| cte_name == &target)
+		})
+	})
+}
+
+fn table_ref_references_cte(table: &TableRef, cte_names: &[String]) -> bool {
+	let source_name = match table {
+		TableRef::Table(name) | TableRef::TableAlias(name, _) => name.to_string(),
+		TableRef::SchemaTable(_, _)
+		| TableRef::DatabaseSchemaTable(_, _, _)
+		| TableRef::SchemaTableAlias(_, _, _)
+		| TableRef::SubQuery(_, _) => return false,
+	};
+	cte_names.iter().any(|cte_name| cte_name == &source_name)
 }
 
 fn contains_aggregate(expr: &SimpleExpr) -> bool {
@@ -443,7 +487,10 @@ fn table_ref_lock_names(table: &TableRef) -> Vec<String> {
 	match table {
 		TableRef::Table(table) => vec![table.to_string()],
 		TableRef::SchemaTable(schema, table) => {
-			vec![format!("{}.{}", schema.to_string(), table.to_string())]
+			vec![
+				format!("{}.{}", schema.to_string(), table.to_string()),
+				table.to_string(),
+			]
 		}
 		TableRef::DatabaseSchemaTable(database, schema, table) => {
 			vec![format!(
@@ -620,6 +667,7 @@ pub(crate) fn validate_insert_for_backend(
 	}
 	if let Some(expressions) = &statement.returning_exprs {
 		for expression in expressions {
+			validate_simple_expr(expression, backend)?;
 			validate_simple_expr_lock(expression, backend)?;
 		}
 	}

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -320,10 +320,7 @@ fn contains_aggregate(expr: &SimpleExpr) -> bool {
 		SimpleExpr::Case(case) => {
 			case.when_clauses.iter().any(|(condition, result)| {
 				contains_aggregate(condition) || contains_aggregate(result)
-			}) || case
-				.else_clause
-				.as_ref()
-				.is_some_and(contains_aggregate)
+			}) || case.else_clause.as_ref().is_some_and(contains_aggregate)
 		}
 		SimpleExpr::Window { func, window } => {
 			contains_aggregate(func)
@@ -358,10 +355,7 @@ fn contains_window(expr: &SimpleExpr) -> bool {
 			case.when_clauses
 				.iter()
 				.any(|(condition, result)| contains_window(condition) || contains_window(result))
-				|| case
-					.else_clause
-					.as_ref()
-					.is_some_and(contains_window)
+				|| case.else_clause.as_ref().is_some_and(contains_window)
 		}
 		SimpleExpr::Column(_)
 		| SimpleExpr::TableColumn(_, _)

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -323,7 +323,7 @@ fn contains_aggregate(expr: &SimpleExpr) -> bool {
 			}) || case
 				.else_clause
 				.as_ref()
-				.is_some_and(|result| contains_aggregate(result))
+				.is_some_and(contains_aggregate)
 		}
 		SimpleExpr::Window { func, window } => {
 			contains_aggregate(func)
@@ -361,7 +361,7 @@ fn contains_window(expr: &SimpleExpr) -> bool {
 				|| case
 					.else_clause
 					.as_ref()
-					.is_some_and(|result| contains_window(result))
+					.is_some_and(contains_window)
 		}
 		SimpleExpr::Column(_)
 		| SimpleExpr::TableColumn(_, _)

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -245,6 +245,30 @@ fn validate_select_lock_for_backend_with_union_context(
 				) {
 				return Err(unsupported("row locking with aggregate queries", backend));
 			}
+			if statement
+				.selects
+				.iter()
+				.any(|select| contains_window(&select.expr))
+				|| statement.orders.iter().any(
+					|order| matches!(&order.expr, OrderExprKind::Expr(expr) if contains_window(expr)),
+				) {
+				return Err(unsupported(
+					"row locking with window-function queries",
+					backend,
+				));
+			}
+			if lock.tables.is_empty()
+				&& statement.join.iter().any(|join| {
+					matches!(
+						join.join,
+						JoinType::LeftJoin | JoinType::RightJoin | JoinType::FullOuterJoin
+					)
+				}) {
+				return Err(unsupported(
+					"row locking across outer joins without explicit targets",
+					backend,
+				));
+			}
 			validate_lock_tables_belong_to_statement(statement, lock.tables.as_slice(), backend)?;
 			validate_lock_tables_are_not_nullable(statement, lock.tables.as_slice(), backend)?;
 			Ok(())
@@ -308,6 +332,36 @@ fn contains_aggregate(expr: &SimpleExpr) -> bool {
 				)
 		}
 		SimpleExpr::WindowNamed { func, .. } => contains_aggregate(func),
+		SimpleExpr::Column(_)
+		| SimpleExpr::TableColumn(_, _)
+		| SimpleExpr::Value(_)
+		| SimpleExpr::Custom(_)
+		| SimpleExpr::Constant(_)
+		| SimpleExpr::Asterisk
+		| SimpleExpr::SubQuery(_, _) => false,
+	}
+}
+
+fn contains_window(expr: &SimpleExpr) -> bool {
+	match expr {
+		SimpleExpr::Window { .. } | SimpleExpr::WindowNamed { .. } => true,
+		SimpleExpr::Unary(_, expression)
+		| SimpleExpr::AsEnum(_, expression)
+		| SimpleExpr::ExprAlias(expression, _)
+		| SimpleExpr::Cast(expression, _) => contains_window(expression),
+		SimpleExpr::Binary(left, _, right) => contains_window(left) || contains_window(right),
+		SimpleExpr::FunctionCall(_, arguments)
+		| SimpleExpr::Tuple(arguments)
+		| SimpleExpr::CustomWithExpr(_, arguments) => arguments.iter().any(contains_window),
+		SimpleExpr::Case(case) => {
+			case.when_clauses
+				.iter()
+				.any(|(condition, result)| contains_window(condition) || contains_window(result))
+				|| case
+					.else_clause
+					.as_ref()
+					.is_some_and(|result| contains_window(result))
+		}
 		SimpleExpr::Column(_)
 		| SimpleExpr::TableColumn(_, _)
 		| SimpleExpr::Value(_)
@@ -557,7 +611,7 @@ pub(crate) fn validate_insert_for_backend(
 	}
 	if let Some(expressions) = &statement.returning_exprs {
 		for expression in expressions {
-			validate_simple_expr(expression, backend)?;
+			validate_simple_expr_lock(expression, backend)?;
 		}
 	}
 	Ok(())

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -280,6 +280,7 @@ fn validate_select_lock_for_backend_with_union_context(
 			) {
 				return Err(unsupported("the requested row lock strength", backend));
 			}
+			validate_lock_tables_belong_to_statement(statement, lock.tables.as_slice(), backend)?;
 			Ok(())
 		}
 		"SQLite" => Err(unsupported("row locking", backend)),
@@ -298,7 +299,7 @@ fn contains_aggregate(expr: &SimpleExpr) -> bool {
 	match expr {
 		SimpleExpr::FunctionCall(name, arguments) => {
 			matches!(
-				name.to_string().as_str(),
+				name.to_string().to_ascii_uppercase().as_str(),
 				"COUNT"
 					| "SUM" | "AVG" | "MIN"
 					| "MAX" | "ARRAY_AGG"
@@ -379,17 +380,26 @@ fn validate_lock_tables_belong_to_statement(
 ) -> Result<(), QueryBuildError> {
 	let mut relations = Vec::with_capacity(statement.from.len() + statement.join.len());
 	for table in &statement.from {
-		relations.extend(table_ref_lock_names(table));
+		relations.extend(
+			table_ref_lock_names(table)
+				.into_iter()
+				.map(|name| (name, table_ref_is_derived(table))),
+		);
 	}
 	for join in &statement.join {
-		relations.extend(table_ref_lock_names(&join.table));
+		relations.extend(
+			table_ref_lock_names(&join.table)
+				.into_iter()
+				.map(|name| (name, table_ref_is_derived(&join.table))),
+		);
 	}
 	for target in targets {
 		if table_ref_is_derived(target)
-			|| !table_ref_lock_names(target)
-				.iter()
-				.any(|target_name| relations.iter().any(|relation| relation == target_name))
-		{
+			|| !table_ref_lock_names(target).iter().any(|target_name| {
+				relations
+					.iter()
+					.any(|(relation, derived)| relation == target_name && !derived)
+			}) {
 			return Err(unsupported(
 				"row lock target absent from the query",
 				backend,

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -200,7 +200,12 @@ pub(crate) fn validate_select_lock_for_backend(
 	};
 
 	match backend {
-		"PostgreSQL" => Ok(()),
+		"PostgreSQL" => {
+			if !statement.unions.is_empty() {
+				return Err(unsupported("row locking on UNION queries", backend));
+			}
+			Ok(())
+		}
 		"MySQL" => {
 			if matches!(
 				lock.r#type,

--- a/crates/reinhardt-query/src/error.rs
+++ b/crates/reinhardt-query/src/error.rs
@@ -298,7 +298,7 @@ fn validate_select_lock_for_backend_with_union_context(
 					backend,
 				));
 			}
-			if lock.is_some_and(|lock| lock.tables.is_empty())
+			if (inherited_lock || lock.is_some_and(|lock| lock.tables.is_empty()))
 				&& statement.join.iter().any(|join| {
 					matches!(
 						join.join,
@@ -341,6 +341,9 @@ fn validate_select_lock_for_backend_with_union_context(
 			let Some(lock) = lock else {
 				return Ok(());
 			};
+			if matches!(lock.r#type, crate::query::LockType::NoKeyUpdate) {
+				return Err(unsupported("the requested row lock strength", backend));
+			}
 			if matches!(lock.behavior, Some(crate::query::LockBehavior::SkipLocked)) {
 				return Err(unsupported("SKIP LOCKED row locking", backend));
 			}

--- a/crates/reinhardt-query/src/lib.rs
+++ b/crates/reinhardt-query/src/lib.rs
@@ -15,6 +15,7 @@
 //! - **DCL (Data Control Language) support** - Build GRANT and REVOKE statements
 //! - **Expression system** - Rich expression API with arithmetic, comparison, and logical operators
 //! - **Advanced SQL features** - JOINs, GROUP BY, HAVING, DISTINCT, UNION, CTEs, Window functions
+//! - **Typed row locking** - Lock strengths, mutually exclusive wait behavior, and table targets
 //!
 //! ### DDL (Data Definition Language)
 //! - **Typed generated columns** - DDL-safe [`types::SchemaExpr`] builders for generated column bodies
@@ -377,9 +378,9 @@ pub mod prelude {
 	};
 	// DML query builders
 	pub use crate::query::{
-		DeleteStatement, ForeignKey, ForeignKeyCreateStatement, InsertStatement, OnConflict, Query,
-		QueryBuilderTrait, QueryStatementBuilder, QueryStatementWriter, SelectStatement,
-		UpdateStatement,
+		DeleteStatement, ForeignKey, ForeignKeyCreateStatement, InsertStatement, LockBehavior,
+		LockType, OnConflict, Query, QueryBuilderTrait, QueryStatementBuilder,
+		QueryStatementWriter, SelectStatement, UpdateStatement,
 	};
 	// DDL query builders
 	pub use crate::query::{

--- a/crates/reinhardt-query/src/query.rs
+++ b/crates/reinhardt-query/src/query.rs
@@ -147,7 +147,8 @@ pub use schema::{
 	AlterSchemaOperation, AlterSchemaStatement, CreateSchemaStatement, DropSchemaStatement,
 };
 pub use select::{
-	CommonTableExpr, LockClause, SelectDistinct, SelectExpr, SelectStatement, UnionType,
+	CommonTableExpr, LockBehavior, LockClause, LockType, SelectDistinct, SelectExpr,
+	SelectStatement, UnionType,
 };
 pub use sequence::{AlterSequenceStatement, CreateSequenceStatement, DropSequenceStatement};
 pub use traits::{QueryBuilderTrait, QueryStatementBuilder, QueryStatementWriter};

--- a/crates/reinhardt-query/src/query/select.rs
+++ b/crates/reinhardt-query/src/query/select.rs
@@ -108,9 +108,7 @@ pub enum LockBehavior {
 	SkipLocked,
 }
 
-/// Lock clause for SELECT ... FOR UPDATE/SHARE
-// NOTE: Fields are currently unused because FOR UPDATE/SHARE is not yet implemented
-#[allow(dead_code)]
+/// Lock clause for `SELECT ... FOR UPDATE/SHARE`.
 #[derive(Debug, Clone)]
 pub struct LockClause {
 	pub(crate) r#type: LockType,
@@ -755,7 +753,10 @@ impl SelectStatement {
 
 	// LOCK methods
 
-	/// Set FOR UPDATE lock
+	/// Set the row lock strength.
+	///
+	/// Calling this method replaces the complete existing lock clause, including
+	/// its behavior and table targets.
 	pub fn lock(&mut self, lock_type: LockType) -> &mut Self {
 		self.lock = Some(LockClause {
 			r#type: lock_type,
@@ -765,12 +766,50 @@ impl SelectStatement {
 		self
 	}
 
-	/// Set FOR UPDATE lock
+	/// Set the row lock wait behavior.
+	///
+	/// `NOWAIT` and `SKIP LOCKED` are mutually exclusive because a lock clause
+	/// stores only one behavior. If no lock strength has been configured, this
+	/// method creates a `FOR UPDATE` lock.
+	pub fn lock_behavior(&mut self, behavior: LockBehavior) -> &mut Self {
+		self.lock
+			.get_or_insert_with(|| LockClause {
+				r#type: LockType::Update,
+				tables: Vec::new(),
+				behavior: None,
+			})
+			.behavior = Some(behavior);
+		self
+	}
+
+	/// Restrict the row lock to typed table references.
+	///
+	/// If no lock strength has been configured, this method creates a
+	/// `FOR UPDATE` lock.
+	pub fn lock_tables<I, T>(&mut self, tables: I) -> &mut Self
+	where
+		I: IntoIterator<Item = T>,
+		T: IntoTableRef,
+	{
+		self.lock
+			.get_or_insert_with(|| LockClause {
+				r#type: LockType::Update,
+				tables: Vec::new(),
+				behavior: None,
+			})
+			.tables = tables
+			.into_iter()
+			.map(IntoTableRef::into_table_ref)
+			.collect();
+		self
+	}
+
+	/// Set a `FOR UPDATE` lock.
 	pub fn lock_exclusive(&mut self) -> &mut Self {
 		self.lock(LockType::Update)
 	}
 
-	/// Set FOR SHARE lock
+	/// Set a `FOR SHARE` lock.
 	pub fn lock_shared(&mut self) -> &mut Self {
 		self.lock(LockType::Share)
 	}

--- a/crates/reinhardt-query/src/query/select.rs
+++ b/crates/reinhardt-query/src/query/select.rs
@@ -757,6 +757,10 @@ impl SelectStatement {
 	///
 	/// Calling this method replaces the complete existing lock clause, including
 	/// its behavior and table targets.
+	///
+	/// Backend support for locking query shapes differs. Use a checked backend
+	/// builder to receive a [`QueryBuildError`](crate::QueryBuildError) before
+	/// emitting unsupported SQL.
 	pub fn lock(&mut self, lock_type: LockType) -> &mut Self {
 		self.lock = Some(LockClause {
 			r#type: lock_type,

--- a/crates/reinhardt-query/tests/dml_row_lock.rs
+++ b/crates/reinhardt-query/tests/dml_row_lock.rs
@@ -60,6 +60,54 @@ fn postgres_checked_builder_rejects_locks_on_union_queries() {
 }
 
 #[rstest]
+fn postgres_checked_builder_rejects_lock_on_union_arm() {
+	let mut statement = Query::select();
+	statement.column("id").from("users");
+	let mut union = Query::select();
+	union
+		.column("id")
+		.from("archived_users")
+		.lock(LockType::Update);
+	statement.union(union);
+
+	assert_eq!(
+		PostgresQueryBuilder::new().build_select_checked(&statement),
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row locking on UNION queries",
+			backend: "PostgreSQL",
+		})
+	);
+}
+
+#[rstest]
+fn postgres_checked_builder_rejects_lock_on_distinct_query() {
+	let mut statement = locked_select(LockType::Update);
+	statement.distinct();
+
+	assert_eq!(
+		PostgresQueryBuilder::new().build_select_checked(&statement),
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row locking with DISTINCT queries",
+			backend: "PostgreSQL",
+		})
+	);
+}
+
+#[rstest]
+fn sqlite_checked_builder_rejects_locks_in_expression_subqueries() {
+	let mut statement = Query::select();
+	statement.expr(Expr::subquery(locked_select(LockType::Update)));
+
+	assert_eq!(
+		SqliteQueryBuilder::new().build_select_checked(&statement),
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row locking",
+			backend: "SQLite",
+		})
+	);
+}
+
+#[rstest]
 fn lock_behavior_is_mutually_exclusive() {
 	let mut statement = locked_select(LockType::Update);
 	statement
@@ -80,10 +128,7 @@ fn postgres_renders_typed_lock_targets_using_aliases() {
 		.column(("u", "id"))
 		.from(TableRef::table_alias("users", "u"))
 		.lock(LockType::NoKeyUpdate)
-		.lock_tables([
-			TableRef::table_alias("users", "u"),
-			TableRef::schema_table("audit", "events"),
-		])
+		.lock_tables([TableRef::table_alias("users", "u")])
 		.lock_behavior(LockBehavior::Nowait);
 
 	let (sql, _) = PostgresQueryBuilder::new()
@@ -92,7 +137,21 @@ fn postgres_renders_typed_lock_targets_using_aliases() {
 
 	assert_eq!(
 		sql,
-		r#"SELECT "u"."id" FROM "users" AS "u" FOR NO KEY UPDATE OF "u", "audit"."events" NOWAIT"#
+		r#"SELECT "u"."id" FROM "users" AS "u" FOR NO KEY UPDATE OF "u" NOWAIT"#
+	);
+}
+
+#[rstest]
+fn postgres_checked_builder_rejects_lock_target_absent_from_query() {
+	let mut statement = locked_select(LockType::Update);
+	statement.lock_tables([TableRef::table("audit_events")]);
+
+	assert_eq!(
+		PostgresQueryBuilder::new().build_select_checked(&statement),
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row lock target absent from the query",
+			backend: "PostgreSQL",
+		})
 	);
 }
 
@@ -161,10 +220,11 @@ fn cockroach_checked_builder_explicitly_accepts_lock_strengths(#[case] lock_type
 		LockType::NoKeyUpdate => "FOR NO KEY UPDATE",
 		LockType::Share => "FOR SHARE",
 		LockType::KeyShare => "FOR KEY SHARE",
+		_ => unreachable!("the test cases cover every supported lock type"),
 	};
 	assert_eq!(
 		sql,
-		format!(r#"SELECT \"id\" FROM \"users\" {expected_lock} NOWAIT"#)
+		format!(r#"SELECT "id" FROM "users" {expected_lock} NOWAIT"#)
 	);
 }
 

--- a/crates/reinhardt-query/tests/dml_row_lock.rs
+++ b/crates/reinhardt-query/tests/dml_row_lock.rs
@@ -378,6 +378,28 @@ fn postgres_checked_builder_propagates_targetless_locks_to_derived_union_queries
 }
 
 #[rstest]
+fn postgres_checked_builder_propagates_targetless_locks_to_derived_outer_joins() {
+	// Arrange
+	let mut derived = Query::select();
+	derived.column(("parents", "id")).from("parents").left_join(
+		"children",
+		Expr::col(("parents", "id")).equals(("children", "parent_id")),
+	);
+
+	// Act
+	let result = validate_postgres_outer_lock_on_derived(derived);
+
+	// Assert
+	assert_eq!(
+		result,
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row locking across outer joins without explicit targets",
+			backend: "PostgreSQL",
+		})
+	);
+}
+
+#[rstest]
 #[case(LockType::Update, "FOR UPDATE")]
 #[case(LockType::Share, "FOR SHARE")]
 fn mysql_renders_supported_lock_strengths(#[case] lock_type: LockType, #[case] suffix: &str) {
@@ -472,10 +494,11 @@ fn sqlite_checked_builder_rejects_row_locking() {
 
 #[rstest]
 #[case(LockType::Update)]
-#[case(LockType::NoKeyUpdate)]
 #[case(LockType::Share)]
 #[case(LockType::KeyShare)]
-fn cockroach_checked_builder_explicitly_accepts_lock_strengths(#[case] lock_type: LockType) {
+fn cockroach_checked_builder_explicitly_accepts_supported_lock_strengths(
+	#[case] lock_type: LockType,
+) {
 	let mut statement = locked_select(lock_type);
 	statement.lock_behavior(LockBehavior::Nowait);
 
@@ -485,7 +508,6 @@ fn cockroach_checked_builder_explicitly_accepts_lock_strengths(#[case] lock_type
 
 	let expected_lock = match lock_type {
 		LockType::Update => "FOR UPDATE",
-		LockType::NoKeyUpdate => "FOR NO KEY UPDATE",
 		LockType::Share => "FOR SHARE",
 		LockType::KeyShare => "FOR KEY SHARE",
 		_ => unreachable!("the test cases cover every supported lock type"),
@@ -493,6 +515,24 @@ fn cockroach_checked_builder_explicitly_accepts_lock_strengths(#[case] lock_type
 	assert_eq!(
 		sql,
 		format!(r#"SELECT "id" FROM "users" {expected_lock} NOWAIT"#)
+	);
+}
+
+#[rstest]
+fn cockroach_checked_builder_rejects_no_key_update() {
+	// Arrange
+	let statement = locked_select(LockType::NoKeyUpdate);
+
+	// Act
+	let result = CockroachDBQueryBuilder::new().build_select_checked(&statement);
+
+	// Assert
+	assert_eq!(
+		result,
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "the requested row lock strength",
+			backend: "CockroachDB",
+		})
 	);
 }
 

--- a/crates/reinhardt-query/tests/dml_row_lock.rs
+++ b/crates/reinhardt-query/tests/dml_row_lock.rs
@@ -4,6 +4,9 @@ use reinhardt_query::QueryBuildError;
 use reinhardt_query::prelude::*;
 use rstest::rstest;
 
+#[cfg(feature = "pgvector")]
+use reinhardt_query::error::{PgvectorFeature, insert_pgvector_feature};
+
 fn locked_select(lock_type: LockType) -> SelectStatement {
 	let mut statement = Query::select();
 	statement.column("id").from("users").lock(lock_type);
@@ -156,6 +159,54 @@ fn postgres_checked_builder_rejects_lock_target_absent_from_query() {
 }
 
 #[rstest]
+fn postgres_checked_builder_accepts_unqualified_target_for_schema_qualified_table() {
+	// Arrange
+	let mut statement = Query::select();
+	statement
+		.column("id")
+		.from(TableRef::schema_table("audit", "events"))
+		.lock(LockType::Update)
+		.lock_tables([TableRef::table("events")]);
+
+	// Act
+	let (sql, values) = PostgresQueryBuilder::new()
+		.build_select_checked(&statement)
+		.expect("the unqualified relation name is valid for an unaliased schema-qualified table");
+
+	// Assert
+	assert_eq!(
+		sql,
+		r#"SELECT "id" FROM "audit"."events" FOR UPDATE OF "events""#
+	);
+	assert_eq!(values.len(), 0);
+}
+
+#[rstest]
+fn postgres_checked_builder_rejects_outer_locks_on_cte_backed_queries() {
+	// Arrange
+	let mut cte = Query::select();
+	cte.column("id").from("jobs");
+	let mut statement = Query::select();
+	statement
+		.with_cte("locked_jobs", cte)
+		.column("id")
+		.from("locked_jobs")
+		.lock(LockType::Update);
+
+	// Act
+	let result = PostgresQueryBuilder::new().build_select_checked(&statement);
+
+	// Assert
+	assert_eq!(
+		result,
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row locking on CTE-backed queries",
+			backend: "PostgreSQL",
+		})
+	);
+}
+
+#[rstest]
 #[case(LockType::Update, "FOR UPDATE")]
 #[case(LockType::Share, "FOR SHARE")]
 fn mysql_renders_supported_lock_strengths(#[case] lock_type: LockType, #[case] suffix: &str) {
@@ -184,6 +235,52 @@ fn mysql_checked_builder_rejects_postgres_only_lock_strength(#[case] lock_type: 
 		MySqlQueryBuilder::new().build_select_checked(&statement),
 		Err(QueryBuildError::UnsupportedBackendFeature {
 			feature: "the requested row lock strength",
+			backend: "MySQL",
+		})
+	);
+}
+
+#[rstest]
+fn mysql_checked_builder_rejects_locks_on_union_queries() {
+	// Arrange
+	let mut statement = locked_select(LockType::Update);
+	let mut union = Query::select();
+	union.column("id").from("archived_users");
+	statement.union(union);
+
+	// Act
+	let result = MySqlQueryBuilder::new().build_select_checked(&statement);
+
+	// Assert
+	assert_eq!(
+		result,
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row locking on UNION queries",
+			backend: "MySQL",
+		})
+	);
+}
+
+#[rstest]
+fn mysql_checked_builder_rejects_lock_on_union_arm() {
+	// Arrange
+	let mut statement = Query::select();
+	statement.column("id").from("users");
+	let mut union = Query::select();
+	union
+		.column("id")
+		.from("archived_users")
+		.lock(LockType::Update);
+	statement.union(union);
+
+	// Act
+	let result = MySqlQueryBuilder::new().build_select_checked(&statement);
+
+	// Assert
+	assert_eq!(
+		result,
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row locking on UNION queries",
 			backend: "MySQL",
 		})
 	);
@@ -240,4 +337,47 @@ fn cockroach_checked_builder_rejects_lock_targets() {
 			backend: "CockroachDB",
 		})
 	);
+}
+
+#[cfg(feature = "pgvector")]
+#[rstest]
+fn checked_insert_builders_reject_pgvector_returning_values() {
+	// Arrange
+	let returning_value = SimpleExpr::Value(Value::Vector(Some(Box::new(vec![1.0, 2.0, 3.0]))));
+	let mut statement = Query::insert();
+	statement
+		.into_table("documents")
+		.column("name")
+		.values_panic(["document"])
+		.returning_exprs([returning_value]);
+
+	// Act
+	let mysql_result = MySqlQueryBuilder::new().build_insert_checked(&statement);
+	let sqlite_result = SqliteQueryBuilder::new().build_insert_checked(&statement);
+	let cockroach_result = CockroachDBQueryBuilder::new().build_insert_checked(&statement);
+	let detected_feature = insert_pgvector_feature(&statement);
+
+	// Assert
+	assert_eq!(
+		mysql_result,
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "pgvector values",
+			backend: "MySQL",
+		})
+	);
+	assert_eq!(
+		sqlite_result,
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "pgvector values",
+			backend: "SQLite",
+		})
+	);
+	assert_eq!(
+		cockroach_result,
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "pgvector values",
+			backend: "CockroachDB",
+		})
+	);
+	assert_eq!(detected_feature, Some(PgvectorFeature::VectorValue));
 }

--- a/crates/reinhardt-query/tests/dml_row_lock.rs
+++ b/crates/reinhardt-query/tests/dml_row_lock.rs
@@ -44,6 +44,22 @@ fn postgres_renders_lock_behavior(#[case] behavior: LockBehavior, #[case] sql_su
 }
 
 #[rstest]
+fn postgres_checked_builder_rejects_locks_on_union_queries() {
+	let mut statement = locked_select(LockType::Update);
+	let mut union = Query::select();
+	union.column("id").from("archived_users");
+	statement.union(union);
+
+	assert_eq!(
+		PostgresQueryBuilder::new().build_select_checked(&statement),
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row locking on UNION queries",
+			backend: "PostgreSQL",
+		})
+	);
+}
+
+#[rstest]
 fn lock_behavior_is_mutually_exclusive() {
 	let mut statement = locked_select(LockType::Update);
 	statement
@@ -140,7 +156,16 @@ fn cockroach_checked_builder_explicitly_accepts_lock_strengths(#[case] lock_type
 		.build_select_checked(&statement)
 		.expect("CockroachDB supports all strengths as two semantic lock pairs");
 
-	assert!(sql.ends_with(" NOWAIT"));
+	let expected_lock = match lock_type {
+		LockType::Update => "FOR UPDATE",
+		LockType::NoKeyUpdate => "FOR NO KEY UPDATE",
+		LockType::Share => "FOR SHARE",
+		LockType::KeyShare => "FOR KEY SHARE",
+	};
+	assert_eq!(
+		sql,
+		format!(r#"SELECT \"id\" FROM \"users\" {expected_lock} NOWAIT"#)
+	);
 }
 
 #[rstest]

--- a/crates/reinhardt-query/tests/dml_row_lock.rs
+++ b/crates/reinhardt-query/tests/dml_row_lock.rs
@@ -1,0 +1,158 @@
+//! Row-lock SQL generation and backend capability tests.
+
+use reinhardt_query::QueryBuildError;
+use reinhardt_query::prelude::*;
+use rstest::rstest;
+
+fn locked_select(lock_type: LockType) -> SelectStatement {
+	let mut statement = Query::select();
+	statement.column("id").from("users").lock(lock_type);
+	statement
+}
+
+#[rstest]
+#[case(LockType::Update, "FOR UPDATE")]
+#[case(LockType::NoKeyUpdate, "FOR NO KEY UPDATE")]
+#[case(LockType::Share, "FOR SHARE")]
+#[case(LockType::KeyShare, "FOR KEY SHARE")]
+fn postgres_renders_each_lock_strength(#[case] lock_type: LockType, #[case] sql_suffix: &str) {
+	let statement = locked_select(lock_type);
+
+	let (sql, values) = PostgresQueryBuilder::new()
+		.build_select_checked(&statement)
+		.expect("PostgreSQL supports every row lock strength");
+
+	assert_eq!(sql, format!(r#"SELECT "id" FROM "users" {sql_suffix}"#));
+	assert_eq!(values.len(), 0);
+}
+
+#[rstest]
+#[case(LockBehavior::Nowait, "NOWAIT")]
+#[case(LockBehavior::SkipLocked, "SKIP LOCKED")]
+fn postgres_renders_lock_behavior(#[case] behavior: LockBehavior, #[case] sql_suffix: &str) {
+	let mut statement = locked_select(LockType::Update);
+	statement.lock_behavior(behavior);
+
+	let (sql, _) = PostgresQueryBuilder::new()
+		.build_select_checked(&statement)
+		.expect("PostgreSQL supports row lock wait behaviors");
+
+	assert_eq!(
+		sql,
+		format!(r#"SELECT "id" FROM "users" FOR UPDATE {sql_suffix}"#)
+	);
+}
+
+#[rstest]
+fn lock_behavior_is_mutually_exclusive() {
+	let mut statement = locked_select(LockType::Update);
+	statement
+		.lock_behavior(LockBehavior::Nowait)
+		.lock_behavior(LockBehavior::SkipLocked);
+
+	let (sql, _) = PostgresQueryBuilder::new()
+		.build_select_checked(&statement)
+		.expect("the last configured lock behavior is valid");
+
+	assert_eq!(sql, r#"SELECT "id" FROM "users" FOR UPDATE SKIP LOCKED"#);
+}
+
+#[rstest]
+fn postgres_renders_typed_lock_targets_using_aliases() {
+	let mut statement = Query::select();
+	statement
+		.column(("u", "id"))
+		.from(TableRef::table_alias("users", "u"))
+		.lock(LockType::NoKeyUpdate)
+		.lock_tables([
+			TableRef::table_alias("users", "u"),
+			TableRef::schema_table("audit", "events"),
+		])
+		.lock_behavior(LockBehavior::Nowait);
+
+	let (sql, _) = PostgresQueryBuilder::new()
+		.build_select_checked(&statement)
+		.expect("PostgreSQL supports typed row lock targets");
+
+	assert_eq!(
+		sql,
+		r#"SELECT "u"."id" FROM "users" AS "u" FOR NO KEY UPDATE OF "u", "audit"."events" NOWAIT"#
+	);
+}
+
+#[rstest]
+#[case(LockType::Update, "FOR UPDATE")]
+#[case(LockType::Share, "FOR SHARE")]
+fn mysql_renders_supported_lock_strengths(#[case] lock_type: LockType, #[case] suffix: &str) {
+	let mut statement = locked_select(lock_type);
+	statement
+		.lock_tables([TableRef::table("users")])
+		.lock_behavior(LockBehavior::SkipLocked);
+
+	let (sql, _) = MySqlQueryBuilder::new()
+		.build_select_checked(&statement)
+		.expect("MySQL supports UPDATE and SHARE locks with targets and wait behavior");
+
+	assert_eq!(
+		sql,
+		format!("SELECT `id` FROM `users` {suffix} OF `users` SKIP LOCKED")
+	);
+}
+
+#[rstest]
+#[case(LockType::NoKeyUpdate)]
+#[case(LockType::KeyShare)]
+fn mysql_checked_builder_rejects_postgres_only_lock_strength(#[case] lock_type: LockType) {
+	let statement = locked_select(lock_type);
+
+	assert_eq!(
+		MySqlQueryBuilder::new().build_select_checked(&statement),
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "the requested row lock strength",
+			backend: "MySQL",
+		})
+	);
+}
+
+#[rstest]
+fn sqlite_checked_builder_rejects_row_locking() {
+	let statement = locked_select(LockType::Update);
+
+	assert_eq!(
+		SqliteQueryBuilder::new().build_select_checked(&statement),
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row locking",
+			backend: "SQLite",
+		})
+	);
+}
+
+#[rstest]
+#[case(LockType::Update)]
+#[case(LockType::NoKeyUpdate)]
+#[case(LockType::Share)]
+#[case(LockType::KeyShare)]
+fn cockroach_checked_builder_explicitly_accepts_lock_strengths(#[case] lock_type: LockType) {
+	let mut statement = locked_select(lock_type);
+	statement.lock_behavior(LockBehavior::Nowait);
+
+	let (sql, _) = CockroachDBQueryBuilder::new()
+		.build_select_checked(&statement)
+		.expect("CockroachDB supports all strengths as two semantic lock pairs");
+
+	assert!(sql.ends_with(" NOWAIT"));
+}
+
+#[rstest]
+fn cockroach_checked_builder_rejects_lock_targets() {
+	let mut statement = locked_select(LockType::Update);
+	statement.lock_tables([TableRef::table("users")]);
+
+	assert_eq!(
+		CockroachDBQueryBuilder::new().build_select_checked(&statement),
+		Err(QueryBuildError::UnsupportedBackendFeature {
+			feature: "row lock table targets",
+			backend: "CockroachDB",
+		})
+	);
+}

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -5854,7 +5854,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reinhardt-admin"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -5903,7 +5903,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-apps"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth-macros"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-commands"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "bollard",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-conf"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "base64",
  "chrono",
@@ -6079,7 +6079,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-core"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -6123,7 +6123,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-db"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6173,7 +6173,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6196,7 +6196,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di-macros"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6210,12 +6210,14 @@ version = "0.4.0-alpha.1"
 
 [[package]]
 name = "reinhardt-forms"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "aquamarine",
  "chrono",
  "regex",
  "reinhardt-core",
+ "reinhardt-db",
+ "rust_decimal",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6225,7 +6227,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-http"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6246,7 +6248,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-macros"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6259,7 +6261,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-mail"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6279,7 +6281,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-manouche"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6292,7 +6294,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-middleware"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -6323,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "bon",
@@ -6347,6 +6349,7 @@ dependencies = [
  "reinhardt-server",
  "reinhardt-urls",
  "reinhardt-utils",
+ "rust_decimal",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -6358,6 +6361,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "url",
  "urlencoding",
  "uuid",
  "wasm-bindgen",
@@ -6367,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-ast"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6379,7 +6383,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-macros"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6393,7 +6397,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6406,7 +6410,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query-macros"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6416,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-rest"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -6461,11 +6465,11 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-router"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 
 [[package]]
 name = "reinhardt-routers-macros"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6474,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-server"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6494,7 +6498,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-shortcuts"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "bytes",
  "hyper",
@@ -6511,7 +6515,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-tasks"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "aquamarine",
  "async-trait",
@@ -6534,7 +6538,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-test"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -6564,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "astral-tokio-tar",
  "async-dropper",
@@ -6620,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit-macros"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6629,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-throttling"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6639,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-urls"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -6672,7 +6676,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-utils"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -6706,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-views"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6739,7 +6743,7 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-web"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "async-trait",
  "bytes",

--- a/tests/integration/tests/commands/shell_e2e.rs
+++ b/tests/integration/tests/commands/shell_e2e.rs
@@ -34,6 +34,13 @@ use tempfile::TempDir;
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(1200);
 const FIXTURE_BUILD_TIMEOUT: Duration = Duration::from_secs(1200);
 const FIXTURE_BUILD_JOBS: &str = "2";
+// Workaround for evcxr/evcxr#487 (tracked in reinhardt-web#5817).
+// Remove this override when evcxr derives the generated library path from
+// Cargo's emitted artifact metadata instead of assuming target/.../deps.
+//
+// Ideal implementation (without workaround):
+//   EvalContext should consume Cargo's emitted artifact path directly.
+const EVALUATOR_BUILD_DIR: &str = "target";
 const PTY_TIMEOUT: Duration = Duration::from_secs(60);
 const CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 const READER_TIMEOUT: Duration = Duration::from_secs(2);
@@ -725,6 +732,7 @@ impl ShellProject {
 		let mut command = Command::new(&self.manage_binary);
 		command
 			.current_dir(&self.project_root)
+			.env("CARGO_BUILD_BUILD_DIR", EVALUATOR_BUILD_DIR)
 			.env("EVCXR_TMPDIR", self._evcxr_dir.path())
 			.env("EVCXR_CACHE_ENABLED", "1")
 			.env(
@@ -747,6 +755,7 @@ impl ShellProject {
 		command
 			.arg("shell")
 			.current_dir(&self.project_root)
+			.env("CARGO_BUILD_BUILD_DIR", EVALUATOR_BUILD_DIR)
 			.env("EVCXR_TMPDIR", self._evcxr_dir.path())
 			.env("EVCXR_CACHE_ENABLED", "1")
 			.env(

--- a/tests/integration/tests/commands/shell_e2e.rs
+++ b/tests/integration/tests/commands/shell_e2e.rs
@@ -1423,6 +1423,20 @@ tokio = {{ version = "1", features = ["macros", "rt-multi-thread", "time"] }}
 [features]
 default = []
 commands-shell = ["reinhardt/commands-shell"]
+
+# Match evcxr's generated evaluator profile so the fixture prebuild warms the
+# same artifact cache used by `manage shell`.
+[profile.dev]
+opt-level = 2
+debug = false
+strip = "debuginfo"
+rpath = true
+lto = false
+debug-assertions = true
+codegen-units = 16
+panic = "unwind"
+incremental = true
+overflow-checks = true
 "#,
 			repository_root.display()
 		),

--- a/tests/integration/tests/commands/shell_e2e.rs
+++ b/tests/integration/tests/commands/shell_e2e.rs
@@ -31,8 +31,8 @@ use rexpect::session::PtySession;
 use tempfile::TempDir;
 
 // The evaluator builds its dependencies outside the fixture target directory.
-const COMMAND_TIMEOUT: Duration = Duration::from_secs(900);
-const FIXTURE_BUILD_TIMEOUT: Duration = Duration::from_secs(900);
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(1200);
+const FIXTURE_BUILD_TIMEOUT: Duration = Duration::from_secs(1200);
 const FIXTURE_BUILD_JOBS: &str = "2";
 const PTY_TIMEOUT: Duration = Duration::from_secs(60);
 const CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);

--- a/tests/integration/tests/commands/shell_e2e.rs
+++ b/tests/integration/tests/commands/shell_e2e.rs
@@ -31,8 +31,8 @@ use rexpect::session::PtySession;
 use tempfile::TempDir;
 
 // The evaluator builds its dependencies outside the fixture target directory.
-const COMMAND_TIMEOUT: Duration = Duration::from_secs(600);
-const FIXTURE_BUILD_TIMEOUT: Duration = Duration::from_secs(600);
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(900);
+const FIXTURE_BUILD_TIMEOUT: Duration = Duration::from_secs(900);
 const FIXTURE_BUILD_JOBS: &str = "2";
 const PTY_TIMEOUT: Duration = Duration::from_secs(60);
 const CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);

--- a/tests/integration/tests/orm.rs
+++ b/tests/integration/tests/orm.rs
@@ -42,3 +42,6 @@ mod custom_manager_ui;
 
 #[path = "orm/queryset_docs_ui.rs"]
 mod queryset_docs_ui;
+
+#[path = "orm/row_locking_integration.rs"]
+mod row_locking_integration;

--- a/tests/integration/tests/orm/row_locking_integration.rs
+++ b/tests/integration/tests/orm/row_locking_integration.rs
@@ -267,7 +267,7 @@ async fn postgres_row_locks_follow_transaction_boundaries_and_wait_policies() {
 #[serial(row_locking_integration)]
 async fn mysql_row_locks_follow_transaction_boundaries_and_wait_policies() {
 	let (_container, _pool, _port, url) = mysql_container().await;
-	run_row_lock_contract(&url, "3572").await;
+	run_row_lock_contract(&url, "HY000").await;
 }
 
 #[tokio::test]

--- a/tests/integration/tests/orm/row_locking_integration.rs
+++ b/tests/integration/tests/orm/row_locking_integration.rs
@@ -267,7 +267,7 @@ async fn postgres_row_locks_follow_transaction_boundaries_and_wait_policies() {
 #[serial(row_locking_integration)]
 async fn mysql_row_locks_follow_transaction_boundaries_and_wait_policies() {
 	let (_container, _pool, _port, url) = mysql_container().await;
-	run_row_lock_contract(&url, "HY000").await;
+	run_row_lock_contract(&url, "3572").await;
 }
 
 #[tokio::test]

--- a/tests/integration/tests/orm/row_locking_integration.rs
+++ b/tests/integration/tests/orm/row_locking_integration.rs
@@ -165,7 +165,10 @@ async fn assert_blocking_until_transaction_end(
 	assert_eq!(rows.len(), 1);
 }
 
-async fn assert_nowait_fails_immediately(connection: reinhardt_db::orm::DatabaseConnection) {
+async fn assert_nowait_fails_immediately(
+	connection: reinhardt_db::orm::DatabaseConnection,
+	expected_sqlstate: &str,
+) {
 	reset_rows(connection).await;
 	let holder = hold_first_row(connection, false).await;
 
@@ -194,9 +197,14 @@ async fn assert_nowait_fails_immediately(connection: reinhardt_db::orm::Database
 		.expect("the holder task must not panic")
 		.expect("the holder transaction must commit");
 	let nowait_result = result.expect("NOWAIT must return before the deadline");
-	assert!(
-		nowait_result.is_err(),
-		"NOWAIT must report lock contention instead of waiting"
+	let error = nowait_result.expect_err("NOWAIT must report lock contention instead of waiting");
+	let database_error = error
+		.database_error()
+		.expect("NOWAIT contention must be reported as a database error");
+	assert_eq!(
+		database_error.code(),
+		Some(expected_sqlstate),
+		"NOWAIT must report the backend lock-contention SQLSTATE"
 	);
 }
 
@@ -232,7 +240,7 @@ async fn assert_skip_locked_omits_locked_row(connection: reinhardt_db::orm::Data
 	);
 }
 
-async fn run_row_lock_contract(url: &str) {
+async fn run_row_lock_contract(url: &str, expected_nowait_sqlstate: &str) {
 	let (_lease, connection) = connect(url).await;
 	connection
 		.execute(
@@ -244,7 +252,7 @@ async fn run_row_lock_contract(url: &str) {
 
 	assert_blocking_until_transaction_end(connection, false).await;
 	assert_blocking_until_transaction_end(connection, true).await;
-	assert_nowait_fails_immediately(connection).await;
+	assert_nowait_fails_immediately(connection, expected_nowait_sqlstate).await;
 	assert_skip_locked_omits_locked_row(connection).await;
 }
 
@@ -252,19 +260,19 @@ async fn run_row_lock_contract(url: &str) {
 #[serial(row_locking_integration)]
 async fn postgres_row_locks_follow_transaction_boundaries_and_wait_policies() {
 	let (_container, _pool, _port, url) = postgres_container().await;
-	run_row_lock_contract(&url).await;
+	run_row_lock_contract(&url, "55P03").await;
 }
 
 #[tokio::test]
 #[serial(row_locking_integration)]
 async fn mysql_row_locks_follow_transaction_boundaries_and_wait_policies() {
 	let (_container, _pool, _port, url) = mysql_container().await;
-	run_row_lock_contract(&url).await;
+	run_row_lock_contract(&url, "HY000").await;
 }
 
 #[tokio::test]
 #[serial(row_locking_integration)]
 async fn cockroachdb_row_locks_follow_transaction_boundaries_and_wait_policies() {
 	let (_container, _pool, _port, url) = cockroachdb_container().await;
-	run_row_lock_contract(&url).await;
+	run_row_lock_contract(&url, "55P03").await;
 }

--- a/tests/integration/tests/orm/row_locking_integration.rs
+++ b/tests/integration/tests/orm/row_locking_integration.rs
@@ -1,8 +1,9 @@
 //! Real-database contracts for transaction-scoped `QuerySet` row locking.
 //!
 //! PostgreSQL and MySQL exercise their native `FOR UPDATE`, `NOWAIT`, and
-//! `SKIP LOCKED` forms. CockroachDB exercises the PostgreSQL-compatible forms
-//! without explicit `OF` targets, which its checked capability contract rejects.
+//! `SKIP LOCKED` forms. The pinned CockroachDB v23.1 fixture exercises
+//! PostgreSQL-compatible `FOR UPDATE` and `NOWAIT` without explicit `OF`
+//! targets, while its checked capability contract rejects `SKIP LOCKED`.
 //! Every locking read goes through `QuerySet::select_for_update` and a
 //! caller-owned `AtomicTransaction`.
 
@@ -240,7 +241,33 @@ async fn assert_skip_locked_omits_locked_row(connection: reinhardt_db::orm::Data
 	);
 }
 
-async fn run_row_lock_contract(url: &str, expected_nowait_sqlstate: &str) {
+async fn assert_skip_locked_is_rejected(connection: reinhardt_db::orm::DatabaseConnection) {
+	let error = connection
+		.atomic(async |transaction| {
+			QuerySet::<RowLockItem>::new()
+				.select_for_update()
+				.skip_locked()
+				.all_with_executor(transaction)
+				.await
+				.map_err(Error::from)
+		})
+		.await
+		.expect_err("unsupported SKIP LOCKED must fail before execution");
+	let database_error = error
+		.database_error()
+		.expect("unsupported SKIP LOCKED must retain its database error");
+	assert_eq!(database_error.kind(), DatabaseErrorKind::Unsupported);
+	assert_eq!(
+		database_error.message(),
+		"SKIP LOCKED row locking is not supported by this backend or server version"
+	);
+}
+
+async fn run_row_lock_contract(
+	url: &str,
+	expected_nowait_sqlstate: &str,
+	supports_skip_locked: bool,
+) {
 	let (_lease, connection) = connect(url).await;
 	connection
 		.execute(
@@ -253,26 +280,30 @@ async fn run_row_lock_contract(url: &str, expected_nowait_sqlstate: &str) {
 	assert_blocking_until_transaction_end(connection, false).await;
 	assert_blocking_until_transaction_end(connection, true).await;
 	assert_nowait_fails_immediately(connection, expected_nowait_sqlstate).await;
-	assert_skip_locked_omits_locked_row(connection).await;
+	if supports_skip_locked {
+		assert_skip_locked_omits_locked_row(connection).await;
+	} else {
+		assert_skip_locked_is_rejected(connection).await;
+	}
 }
 
 #[tokio::test]
 #[serial(row_locking_integration)]
 async fn postgres_row_locks_follow_transaction_boundaries_and_wait_policies() {
 	let (_container, _pool, _port, url) = postgres_container().await;
-	run_row_lock_contract(&url, "55P03").await;
+	run_row_lock_contract(&url, "55P03", true).await;
 }
 
 #[tokio::test]
 #[serial(row_locking_integration)]
 async fn mysql_row_locks_follow_transaction_boundaries_and_wait_policies() {
 	let (_container, _pool, _port, url) = mysql_container().await;
-	run_row_lock_contract(&url, "HY000").await;
+	run_row_lock_contract(&url, "HY000", true).await;
 }
 
 #[tokio::test]
 #[serial(row_locking_integration)]
 async fn cockroachdb_row_locks_follow_transaction_boundaries_and_wait_policies() {
 	let (_container, _pool, _port, url) = cockroachdb_container().await;
-	run_row_lock_contract(&url, "55P03").await;
+	run_row_lock_contract(&url, "55P03", false).await;
 }

--- a/tests/integration/tests/orm/row_locking_integration.rs
+++ b/tests/integration/tests/orm/row_locking_integration.rs
@@ -1,0 +1,270 @@
+//! Real-database contracts for transaction-scoped `QuerySet` row locking.
+//!
+//! PostgreSQL and MySQL exercise their native `FOR UPDATE`, `NOWAIT`, and
+//! `SKIP LOCKED` forms. CockroachDB exercises the PostgreSQL-compatible forms
+//! without explicit `OF` targets, which its checked capability contract rejects.
+//! Every locking read goes through `QuerySet::select_for_update` and a
+//! caller-owned `AtomicTransaction`.
+
+use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind, Error};
+use reinhardt_db::{
+	backends::DatabaseConnection as BackendsConnection,
+	orm::{DatabaseConnectionLease, QuerySet},
+};
+use reinhardt_macros::model;
+use reinhardt_test::fixtures::{
+	postgres_container,
+	testcontainers::{cockroachdb_container, mysql_container},
+};
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+use std::time::Duration;
+use tokio::{
+	sync::oneshot,
+	task::JoinHandle,
+	time::{sleep, timeout},
+};
+
+const LOCK_WAIT_OBSERVATION: Duration = Duration::from_millis(250);
+const NOWAIT_DEADLINE: Duration = Duration::from_secs(2);
+
+#[model(app_label = "row_locking", table_name = "row_lock_items")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct RowLockItem {
+	#[field(primary_key = true)]
+	id: i64,
+
+	value: i64,
+}
+
+struct HeldRowLock {
+	release: oneshot::Sender<()>,
+	task: JoinHandle<Result<(), Error>>,
+}
+
+async fn connect(
+	url: &str,
+) -> (
+	DatabaseConnectionLease,
+	reinhardt_db::orm::DatabaseConnection,
+) {
+	let owner = BackendsConnection::connect(url)
+		.await
+		.expect("the framework backend must connect to the row-lock fixture");
+	let lease = DatabaseConnectionLease::register(owner)
+		.expect("the fixture connection must register with the ORM");
+	let connection = lease.handle();
+	(lease, connection)
+}
+
+async fn reset_rows(connection: reinhardt_db::orm::DatabaseConnection) {
+	connection
+		.execute("DELETE FROM row_lock_items", vec![])
+		.await
+		.expect("the previous row-lock scenario must be cleared");
+	connection
+		.execute(
+			"INSERT INTO row_lock_items (id, value) VALUES (1, 10), (2, 20)",
+			vec![],
+		)
+		.await
+		.expect("the row-lock fixture rows must be inserted");
+}
+
+async fn hold_first_row(
+	connection: reinhardt_db::orm::DatabaseConnection,
+	rollback: bool,
+) -> HeldRowLock {
+	let (acquired_tx, acquired_rx) = oneshot::channel();
+	let (release_tx, release_rx) = oneshot::channel();
+	let task = tokio::spawn(async move {
+		connection
+			.atomic(async move |transaction| {
+				let rows = QuerySet::<RowLockItem>::new()
+					.filter(RowLockItem::field_id().eq(1_i64))
+					.select_for_update()
+					.all_with_executor(transaction)
+					.await
+					.map_err(Error::from)?;
+				assert_eq!(rows.len(), 1);
+				acquired_tx
+					.send(())
+					.expect("the lock holder must announce acquisition once");
+				release_rx
+					.await
+					.expect("the lock holder must receive its release signal");
+				if rollback {
+					return Err(Error::from(DatabaseError::new(
+						DatabaseErrorKind::Transaction,
+						"intentional rollback after holding the row lock",
+					)));
+				}
+				Ok(())
+			})
+			.await
+	});
+	acquired_rx
+		.await
+		.expect("the lock holder task must acquire the first row");
+	HeldRowLock {
+		release: release_tx,
+		task,
+	}
+}
+
+async fn assert_blocking_until_transaction_end(
+	connection: reinhardt_db::orm::DatabaseConnection,
+	rollback: bool,
+) {
+	reset_rows(connection).await;
+	let holder = hold_first_row(connection, rollback).await;
+	let (attempting_tx, attempting_rx) = oneshot::channel();
+	let mut waiter = tokio::spawn(async move {
+		connection
+			.atomic(async move |transaction| {
+				attempting_tx
+					.send(())
+					.expect("the waiter must announce its locking attempt once");
+				QuerySet::<RowLockItem>::new()
+					.filter(RowLockItem::field_id().eq(1_i64))
+					.select_for_update()
+					.all_with_executor(transaction)
+					.await
+					.map_err(Error::from)
+			})
+			.await
+	});
+
+	attempting_rx
+		.await
+		.expect("the waiting task must reach its locking query");
+	sleep(LOCK_WAIT_OBSERVATION).await;
+	assert!(
+		!waiter.is_finished(),
+		"a second blocking lock must wait for the first transaction to finish"
+	);
+
+	holder
+		.release
+		.send(())
+		.expect("the holder must still be waiting for transaction completion");
+	let holder_result = holder.task.await.expect("the holder task must not panic");
+	if rollback {
+		assert!(
+			holder_result.is_err(),
+			"the rollback scenario must leave the atomic scope through an error"
+		);
+	} else {
+		holder_result.expect("the commit scenario must commit the atomic scope");
+	}
+	let rows = timeout(NOWAIT_DEADLINE, &mut waiter)
+		.await
+		.expect("the waiting lock must proceed after commit or rollback")
+		.expect("the waiter task must not panic")
+		.expect("the waiting transaction must acquire the released row");
+	assert_eq!(rows.len(), 1);
+}
+
+async fn assert_nowait_fails_immediately(connection: reinhardt_db::orm::DatabaseConnection) {
+	reset_rows(connection).await;
+	let holder = hold_first_row(connection, false).await;
+
+	let result = timeout(NOWAIT_DEADLINE, async {
+		connection
+			.atomic(async |transaction| {
+				QuerySet::<RowLockItem>::new()
+					.filter(RowLockItem::field_id().eq(1_i64))
+					.select_for_update()
+					.nowait()
+					.all_with_executor(transaction)
+					.await
+					.map_err(Error::from)
+			})
+			.await
+	})
+	.await;
+
+	holder
+		.release
+		.send(())
+		.expect("the holder must remain active through the NOWAIT attempt");
+	holder
+		.task
+		.await
+		.expect("the holder task must not panic")
+		.expect("the holder transaction must commit");
+	let nowait_result = result.expect("NOWAIT must return before the deadline");
+	assert!(
+		nowait_result.is_err(),
+		"NOWAIT must report lock contention instead of waiting"
+	);
+}
+
+async fn assert_skip_locked_omits_locked_row(connection: reinhardt_db::orm::DatabaseConnection) {
+	reset_rows(connection).await;
+	let holder = hold_first_row(connection, false).await;
+
+	let rows = connection
+		.atomic(async |transaction| {
+			QuerySet::<RowLockItem>::new()
+				.select_for_update()
+				.skip_locked()
+				.all_with_executor(transaction)
+				.await
+				.map_err(Error::from)
+		})
+		.await
+		.expect("SKIP LOCKED must return the rows that remain available");
+
+	holder
+		.release
+		.send(())
+		.expect("the holder must remain active through the SKIP LOCKED query");
+	holder
+		.task
+		.await
+		.expect("the holder task must not panic")
+		.expect("the holder transaction must commit");
+	assert_eq!(
+		rows.iter().map(|row| row.id).collect::<Vec<_>>(),
+		vec![2],
+		"SKIP LOCKED must omit the row held by the concurrent transaction"
+	);
+}
+
+async fn run_row_lock_contract(url: &str) {
+	let (_lease, connection) = connect(url).await;
+	connection
+		.execute(
+			"CREATE TABLE row_lock_items (id BIGINT PRIMARY KEY, value BIGINT NOT NULL)",
+			vec![],
+		)
+		.await
+		.expect("the row-lock fixture table must be created");
+
+	assert_blocking_until_transaction_end(connection, false).await;
+	assert_blocking_until_transaction_end(connection, true).await;
+	assert_nowait_fails_immediately(connection).await;
+	assert_skip_locked_omits_locked_row(connection).await;
+}
+
+#[tokio::test]
+#[serial(row_locking_integration)]
+async fn postgres_row_locks_follow_transaction_boundaries_and_wait_policies() {
+	let (_container, _pool, _port, url) = postgres_container().await;
+	run_row_lock_contract(&url).await;
+}
+
+#[tokio::test]
+#[serial(row_locking_integration)]
+async fn mysql_row_locks_follow_transaction_boundaries_and_wait_policies() {
+	let (_container, _pool, _port, url) = mysql_container().await;
+	run_row_lock_contract(&url).await;
+}
+
+#[tokio::test]
+#[serial(row_locking_integration)]
+async fn cockroachdb_row_locks_follow_transaction_boundaries_and_wait_policies() {
+	let (_container, _pool, _port, url) = cockroachdb_container().await;
+	run_row_lock_contract(&url).await;
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Add typed row-lock clauses to the query AST with PostgreSQL, MySQL, CockroachDB, and SQLite capability validation.
- Add a transaction-only `QuerySet::select_for_update()` typestate API for blocking, `NOWAIT`, `SKIP LOCKED`, `NO KEY`, and typed lock targets.
- Add query rendering, mock executor, compile-fail, and concurrent database coverage, plus usage documentation.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Row locking must remain active for the lifetime of the caller's transaction, and unsupported lock combinations should fail before SQL execution. This change exposes those constraints through typestate and a transaction-executor-only API while preserving backend-specific behavior.

Fixes #5849

## How Was This Tested?

- `cargo fmt --all -- --check`
- `cargo test --offline -p reinhardt-query --test dml_row_lock` (18 passed)
- `cargo test -p reinhardt-db --test transaction_executor_orm --no-default-features --features orm,associations select_for_update` (4 passed)
- `cargo test -p reinhardt-db --test select_for_update_ui --no-default-features --features orm` (2 harness tests; all compile-fail fixtures passed)
- `cargo check -p reinhardt-integration-tests --test orm --offline`
- `cargo clippy --offline -p reinhardt-query --test dml_row_lock --no-deps -- -D warnings`
- `git diff --check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5849

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers, views
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The concurrent PostgreSQL, MySQL, and CockroachDB suite is compile-checked. Its local runtime execution was deferred to PR CI because the aggregate macOS test link was blocked in an unrelated workspace cdylib link step.