### PR TITLE
feat(orm): add typed QuerySet retrieval helpers

### DIFF
--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -2105,9 +2105,13 @@ mod tests {
 	#[test]
 	fn test_build_single_filter_expr_uses_transformed_filter_lhs() {
 		// Arrange
-		let filter = reinhardt_db::orm::expressions::FieldRef::<(), i64>::new("created_at")
-			.year()
-			.range(2024, 2026);
+		let filter = reinhardt_db::orm::expressions::FieldRef::<
+			(),
+			i64,
+			reinhardt_db::orm::expressions::UnverifiedModelField,
+		>::new("created_at")
+		.year()
+		.range(2024, 2026);
 
 		// Act
 		let result = build_single_filter_expr(&filter).expect("filter should compile");

--- a/crates/reinhardt-core/macros/src/model_attribute.rs
+++ b/crates/reinhardt-core/macros/src/model_attribute.rs
@@ -266,7 +266,8 @@ pub(crate) fn model_attribute_impl(
 		}
 	};
 
-	// Create a #[model_config(...)] helper attribute with the arguments
+	// Create a #[model_config(...)] helper attribute with the original arguments.
+	// `get_latest_by` is resolved against the generated model fields by the derive macro.
 	// Using model_config instead of model to avoid name collision with the attribute macro
 	let config_attr: Attribute = if args.is_empty() && serde_flags.is_empty() {
 		syn::parse_quote! { #[model_config] }

--- a/crates/reinhardt-core/macros/src/model_attribute.rs
+++ b/crates/reinhardt-core/macros/src/model_attribute.rs
@@ -115,6 +115,34 @@ pub(crate) fn model_attribute_impl(
 		})
 	}
 
+	fn relation_db_column(attrs: &[Attribute]) -> Option<syn::LitStr> {
+		attrs.iter().find_map(|attr| {
+			if !attr.path().is_ident("rel") {
+				return None;
+			}
+			let syn::Meta::List(meta_list) = &attr.meta else {
+				return None;
+			};
+			let values = meta_list
+				.parse_args_with(
+					syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated,
+				)
+				.ok()?;
+			values.into_iter().find_map(|value| match value {
+				syn::Meta::NameValue(name_value) if name_value.path.is_ident("db_column") => {
+					match name_value.value {
+						syn::Expr::Lit(syn::ExprLit {
+							lit: syn::Lit::Str(value),
+							..
+						}) => Some(value),
+						_ => None,
+					}
+				}
+				_ => None,
+			})
+		})
+	}
+
 	// Collect existing field names to avoid duplicates
 	let existing_field_names: std::collections::HashSet<String> =
 		if let syn::Fields::Named(ref fields) = input.fields {
@@ -162,6 +190,7 @@ pub(crate) fn model_attribute_impl(
 				&& let Some(target_ty) = extract_fk_target_type(&field.ty)
 			{
 				let id_field_name_str = format!("{}_id", field_name);
+				let db_column = relation_db_column(&field.attrs);
 
 				// Only add if not already defined by user OR already generated
 				if !existing_field_names.contains(&id_field_name_str)
@@ -172,16 +201,21 @@ pub(crate) fn model_attribute_impl(
 					// Generate _id field with the target model's primary-key type.
 					// `InfoModel` is target-neutral, so generated DTO companions can
 					// compile on WASM without the native ORM surface.
+					let db_column_attr = db_column.map(|column| {
+						quote! { #[field(db_column = #column)] }
+					});
 					let new_field: Field = if model_forms_enabled
 						&& relation_is_nullable(&field.attrs)
 					{
 						syn::parse_quote! {
 							#[serde(default)]
+							#db_column_attr
 							#id_field_name: ::core::option::Option<<#target_ty as #reinhardt::model_info::InfoModel>::PrimaryKey>
 						}
 					} else {
 						syn::parse_quote! {
 							#[serde(default)]
+							#db_column_attr
 							#id_field_name: <#target_ty as #reinhardt::model_info::InfoModel>::PrimaryKey
 						}
 					};

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3341,6 +3341,19 @@ fn resolve_latest_by_fields(
 				.config
 				.db_column
 				.clone()
+				.or_else(|| {
+					field
+						.is_fk_id_field
+						.then(|| {
+							let relation_name = rust_field_name.trim_end_matches("_id");
+							field_infos
+								.iter()
+								.find(|candidate| candidate.name == relation_name)
+								.and_then(|candidate| candidate.rel.as_ref())
+								.and_then(|relation| relation.db_column.clone())
+						})
+						.flatten()
+				})
 				.unwrap_or_else(|| rust_field_name.to_owned());
 			Ok(if descending {
 				format!("-{column}")

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3380,8 +3380,12 @@ fn resolve_latest_by_fields(
 ///
 /// // The #[model] attribute macro automatically generates:
 /// impl User {
-///     pub const fn field_id() -> FieldRef<User, i64> { FieldRef::new("id") }
-///     pub const fn field_name() -> FieldRef<User, String> { FieldRef::new("name") }
+///     pub const fn field_id() -> FieldRef<User, i64> {
+///         unsafe { FieldRef::from_model_field("id") }
+///     }
+///     pub const fn field_name() -> FieldRef<User, String> {
+///         unsafe { FieldRef::from_model_field("name") }
+///     }
 /// }
 /// ```
 fn generate_field_accessors(
@@ -3436,7 +3440,8 @@ fn generate_field_accessors(
 				/// Returns a `FieldRef<#struct_name, #field_type>` that provides compile-time
 				/// type safety for field operations.
 				pub const fn #method_name() -> #orm_crate::expressions::FieldRef<#struct_name, #field_type> {
-					#orm_crate::expressions::FieldRef::new(#column_name)
+					// SAFETY: `#[model]` emits this accessor only for a persisted scalar model field.
+					unsafe { #orm_crate::expressions::FieldRef::from_model_field(#column_name) }
 				}
 			}
 		})
@@ -3552,7 +3557,10 @@ fn generate_relation_traversal_accessors(
 			quote! {
 				#[doc = #doc_comment]
 				pub fn #method_name(self) -> #orm_crate::relations::RelatedFieldRef<Root, #struct_name, #field_type> {
-					self.field(#orm_crate::expressions::FieldRef::new(#field_name_str))
+					// SAFETY: this accessor is generated only for a persisted scalar model field.
+					self.field(unsafe {
+						#orm_crate::expressions::FieldRef::from_model_field(#field_name_str)
+					})
 				}
 			}
 		})

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3441,7 +3441,7 @@ fn generate_field_accessors(
 				///
 				/// Returns a `FieldRef<#struct_name, #field_type>` that provides compile-time
 				/// type safety for field operations.
-				pub const fn #method_name() -> #orm_crate::expressions::FieldRef<#struct_name, #field_type> {
+				pub const fn #method_name() -> #orm_crate::expressions::FieldRef<#struct_name, #field_type, #orm_crate::expressions::GeneratedModelField> {
 					// SAFETY: `#[model]` emits this accessor only for a persisted scalar model field.
 					unsafe { #orm_crate::expressions::FieldRef::from_model_field(#column_name) }
 				}

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3318,6 +3318,13 @@ fn resolve_latest_by_fields(
 					)
 				})?;
 
+			if field.config.skip {
+				return Err(syn::Error::new_spanned(
+					struct_name,
+					format!("get_latest_by cannot include skipped field '{field_name}'"),
+				));
+			}
+
 			if field.rel.is_some() || is_relationship_field_type(&field.ty) {
 				let message = if field.rel.as_ref().is_some_and(|relation| {
 					relation.rel_type == crate::rel::RelationType::ManyToMany

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -56,6 +56,7 @@ enum ConstraintSpec {
 struct ModelAttributesParsed {
 	app_label: Option<String>,
 	table_name: Option<String>,
+	get_latest_by: Option<Vec<String>>,
 	constraints: Option<Vec<ConstraintSpec>>,
 	unique_together: Vec<Vec<String>>, // Multiple Django-style unique_together constraints
 	/// Optional custom manager path: `manager = MyManager` (Issue #3980).
@@ -384,6 +385,7 @@ fn generated_u32_literal_is_supported(expr: &syn::Expr) -> bool {
 struct ModelConfig {
 	app_label: String,
 	table_name: String,
+	get_latest_by: Option<Vec<String>>,
 	constraints: Vec<ConstraintSpec>,
 	/// Custom manager type path from `manager = MyManager` (Issue #3980, #3984).
 	///
@@ -408,6 +410,7 @@ impl ModelConfig {
 	fn from_attrs(attrs: &[syn::Attribute], struct_name: &syn::Ident) -> Result<Self> {
 		let mut app_label = None;
 		let mut table_name = None;
+		let mut get_latest_by = None;
 		let mut constraints = Vec::new();
 		let mut manager: Option<syn::Path> = None;
 		let mut info: Option<bool> = None;
@@ -448,6 +451,9 @@ impl ModelConfig {
 			if let Some(tn) = model_attr.table_name {
 				table_name = Some(tn);
 			}
+			if let Some(fields) = model_attr.get_latest_by {
+				get_latest_by = Some(fields);
+			}
 			if let Some(m) = model_attr.manager {
 				if manager.is_some() {
 					return Err(syn::Error::new_spanned(
@@ -487,6 +493,7 @@ impl ModelConfig {
 		Ok(Self {
 			app_label,
 			table_name,
+			get_latest_by,
 			constraints,
 			manager,
 			info: info.unwrap_or(true),
@@ -503,6 +510,7 @@ impl ModelConfig {
 
 		let mut app_label = None;
 		let mut table_name = None;
+		let mut get_latest_by = None;
 		let mut constraints = None;
 		let mut unique_together = Vec::new();
 		let mut manager: Option<syn::Path> = None;
@@ -550,6 +558,12 @@ impl ModelConfig {
 			} else if ident == "table_name" {
 				let value: LitStr = input.parse()?;
 				table_name = Some(value.value());
+			} else if ident == "get_latest_by" {
+				let content;
+				parenthesized!(content in input);
+				let fields: Punctuated<LitStr, Token![,]> =
+					content.call(Punctuated::parse_terminated)?;
+				get_latest_by = Some(fields.iter().map(LitStr::value).collect());
 			} else if ident == "manager" {
 				// Custom object manager type: `manager = MyManager` (Issue #3980).
 				let path: syn::Path = input.parse()?;
@@ -602,6 +616,7 @@ impl ModelConfig {
 		Ok(ModelAttributesParsed {
 			app_label,
 			table_name,
+			get_latest_by,
 			constraints,
 			unique_together,
 			manager,
@@ -3004,6 +3019,61 @@ fn generate_model_form_support(
 	})
 }
 
+/// Resolve `get_latest_by` Rust field names to physical database columns.
+fn resolve_latest_by_fields(
+	field_names: &[String],
+	field_infos: &[FieldInfo],
+	struct_name: &syn::Ident,
+) -> Result<Vec<String>> {
+	if field_names.is_empty() {
+		return Err(syn::Error::new_spanned(
+			struct_name,
+			"get_latest_by must contain at least one field",
+		));
+	}
+
+	field_names
+		.iter()
+		.map(|field_name| {
+			let (descending, rust_field_name) = field_name
+				.strip_prefix('-')
+				.map_or((false, field_name.as_str()), |name| (true, name));
+			let field = field_infos
+				.iter()
+				.find(|field| field.name == rust_field_name)
+				.ok_or_else(|| {
+					syn::Error::new_spanned(
+						struct_name,
+						format!("get_latest_by references unknown field '{field_name}'"),
+					)
+				})?;
+
+			if field.rel.is_some() || is_relationship_field_type(&field.ty) {
+				let message = if field.rel.as_ref().is_some_and(|relation| {
+					relation.rel_type == crate::rel::RelationType::ManyToMany
+				}) || is_many_to_many_field_type(&field.ty)
+				{
+					format!("get_latest_by cannot include many-to-many field '{field_name}'")
+				} else {
+					format!("get_latest_by cannot include relation field '{field_name}'")
+				};
+				return Err(syn::Error::new_spanned(struct_name, message));
+			}
+
+			let column = field
+				.config
+				.db_column
+				.clone()
+				.unwrap_or_else(|| rust_field_name.to_owned());
+			Ok(if descending {
+				format!("-{column}")
+			} else {
+				column
+			})
+		})
+		.collect()
+}
+
 /// Generate field accessor methods that return FieldRef<M, T>
 ///
 /// Generates const methods like:
@@ -3090,19 +3160,37 @@ fn generate_field_accessors(
 		.iter()
 		.map(|field| {
 			let field_name = &field.name;
-			let (_, lookup_type) = extract_option_type(&field.ty);
+			let (is_option, lookup_type) = extract_option_type(&field.ty);
 			let field_name_str = field
 				.config
 				.db_column
 				.clone()
 				.unwrap_or_else(|| field_name.to_string());
 			let method_name = syn::Ident::new(&format!("unique_{}", field_name), field_name.span());
+			let getter_name = syn::Ident::new(
+				&format!("__reinhardt_unique_get_{}", field_name),
+				field_name.span(),
+			);
+			let getter_body = if is_option {
+				quote! { model.#field_name.clone() }
+			} else {
+				quote! { ::core::option::Option::Some(model.#field_name.clone()) }
+			};
 
 			quote! {
+				fn #getter_name(model: &#struct_name) -> ::core::option::Option<#lookup_type> {
+					#getter_body
+				}
+
 				/// Unique-field accessor for type-safe single-row lookups.
 				pub const fn #method_name() -> #orm_crate::expressions::UniqueFieldRef<#struct_name, #lookup_type> {
 					// SAFETY: This accessor is generated only for fields proven unique by model metadata.
-					unsafe { #orm_crate::expressions::UniqueFieldRef::from_model_field(#field_name_str) }
+					unsafe {
+						#orm_crate::expressions::UniqueFieldRef::from_model_field_with_getter(
+							#field_name_str,
+							Self::#getter_name,
+						)
+					}
 				}
 			}
 		})
@@ -3988,6 +4076,13 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 		});
 	}
 
+	let latest_by_fields = model_config
+		.get_latest_by
+		.as_deref()
+		.map(|fields| resolve_latest_by_fields(fields, &field_infos, struct_name))
+		.transpose()?
+		.unwrap_or_default();
+
 	// Extract ForeignKeyField and OneToOneField information
 	let mut fk_field_infos: Vec<ForeignKeyFieldInfo> = Vec::new();
 	for field_info in &field_infos {
@@ -4549,6 +4644,10 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 
 			fn primary_key_column() -> &'static str {
 				#pk_column_name
+			}
+
+			fn latest_by_fields() -> &'static [&'static str] {
+				&[#(#latest_by_fields),*]
 			}
 
 			fn primary_key_uses_zero_sentinel() -> bool {
@@ -8733,6 +8832,145 @@ mod tests {
 	}
 
 	#[test]
+	fn test_get_latest_by_parses_tuple_fields() {
+		let struct_name = parse_quote! { Event };
+		let attrs = vec![parse_quote! {
+			#[model(app_label = "events", get_latest_by = ("created_at", "id"))]
+		}];
+
+		let config = ModelConfig::from_attrs(&attrs, &struct_name)
+			.expect("get_latest_by should parse as field names");
+
+		assert_eq!(
+			config.get_latest_by.as_deref(),
+			Some(vec!["created_at".to_string(), "id".to_string()].as_slice())
+		);
+	}
+
+	#[test]
+	fn test_get_latest_by_uses_physical_database_columns() {
+		let input = quote! {
+			#[model(
+				app_label = "events",
+				table_name = "events",
+				get_latest_by = ("created_at", "id")
+			)]
+			pub struct Event {
+				#[field(primary_key = true)]
+				pub id: i64,
+				#[field(db_column = "created_on")]
+				pub created_at: i64,
+			}
+		};
+
+		let output = model_derive_impl(syn::parse2(input).unwrap())
+			.expect("get_latest_by fields should resolve");
+		let compact = output.to_string().replace(' ', "");
+
+		assert!(
+			compact
+				.contains("fnlatest_by_fields()->&'static[&'staticstr]{&[\"created_on\",\"id\"]}")
+		);
+	}
+
+	#[test]
+	fn test_get_latest_by_preserves_descending_direction() {
+		let input = quote! {
+			#[model(
+				app_label = "events",
+				table_name = "events",
+				get_latest_by = ("-priority", "created_at")
+			)]
+			pub struct Event {
+				#[field(primary_key = true)]
+				pub id: i64,
+				#[field(db_column = "event_priority")]
+				pub priority: i64,
+				pub created_at: i64,
+			}
+		};
+
+		let output = model_derive_impl(syn::parse2(input).unwrap())
+			.expect("descending get_latest_by fields should resolve");
+		let compact = output.to_string().replace(' ', "");
+
+		assert!(compact.contains(
+			"fnlatest_by_fields()->&'static[&'staticstr]{&[\"-event_priority\",\"created_at\"]}"
+		));
+	}
+
+	#[test]
+	fn test_get_latest_by_rejects_empty_and_unknown_fields() {
+		let empty_input = quote! {
+			#[model(app_label = "events", get_latest_by = ())]
+			pub struct Event {
+				#[field(primary_key = true)]
+				pub id: i64,
+			}
+		};
+		let empty_error = model_derive_impl(syn::parse2(empty_input).unwrap())
+			.expect_err("an empty get_latest_by tuple must fail");
+		assert_eq!(
+			empty_error.to_string(),
+			"get_latest_by must contain at least one field"
+		);
+
+		let unknown_input = quote! {
+			#[model(app_label = "events", get_latest_by = ("missing",))]
+			pub struct Event {
+				#[field(primary_key = true)]
+				pub id: i64,
+			}
+		};
+		let unknown_error = model_derive_impl(syn::parse2(unknown_input).unwrap())
+			.expect_err("unknown get_latest_by fields must fail");
+		assert_eq!(
+			unknown_error.to_string(),
+			"get_latest_by references unknown field 'missing'"
+		);
+	}
+
+	#[test]
+	fn test_get_latest_by_rejects_relation_fields() {
+		let input = quote! {
+			#[model(app_label = "events", get_latest_by = ("owner",))]
+			pub struct Event {
+				#[field(primary_key = true)]
+				pub id: i64,
+				#[rel(foreign_key)]
+				pub owner: db::associations::ForeignKeyField<User>,
+			}
+		};
+
+		let error = model_derive_impl(syn::parse2(input).unwrap())
+			.expect_err("relation fields cannot define latest ordering");
+		assert_eq!(
+			error.to_string(),
+			"get_latest_by cannot include relation field 'owner'"
+		);
+	}
+
+	#[test]
+	fn test_get_latest_by_rejects_many_to_many_fields() {
+		let input = quote! {
+			#[model(app_label = "events", get_latest_by = ("tags",))]
+			pub struct Event {
+				#[field(primary_key = true)]
+				pub id: i64,
+				#[rel(many_to_many)]
+				pub tags: db::associations::ManyToManyField<Event, Tag>,
+			}
+		};
+
+		let error = model_derive_impl(syn::parse2(input).unwrap())
+			.expect_err("many-to-many fields cannot define latest ordering");
+		assert_eq!(
+			error.to_string(),
+			"get_latest_by cannot include many-to-many field 'tags'"
+		);
+	}
+
+	#[test]
 	fn test_qualified_foreign_key_registration_preserves_target_identity() {
 		let input = quote! {
 			#[model(app_label = "comments", table_name = "comments")]
@@ -8996,7 +9234,12 @@ mod tests {
 			.nth(1)
 			.expect("generated unique email accessor");
 
-		assert!(unique_accessor.contains("UniqueFieldRef :: from_model_field (\"email_addr\")"));
+		assert!(unique_accessor.contains("UniqueFieldRef :: from_model_field_with_getter"));
+		assert!(unique_accessor.contains("\"email_addr\""));
+		assert!(unique_accessor.contains("Self :: __reinhardt_unique_get_email"));
+		assert!(output_str.contains(
+			"fn __reinhardt_unique_get_email (model : & User) -> :: core :: option :: Option < String >"
+		));
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3833,9 +3833,9 @@ fn generate_relation_traversal_accessors(
 			}
 
 			#[doc = #wrapper_field_doc]
-			pub fn field<Value>(
+			pub fn field<Value, Origin>(
 				self,
-				field: #orm_crate::expressions::FieldRef<#struct_name, Value>,
+				field: #orm_crate::expressions::FieldRef<#struct_name, Value, Origin>,
 			) -> #orm_crate::relations::RelatedFieldRef<Root, #struct_name, Value> {
 				self.inner.field(field)
 			}

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3345,7 +3345,9 @@ fn resolve_latest_by_fields(
 					field
 						.is_fk_id_field
 						.then(|| {
-							let relation_name = rust_field_name.trim_end_matches("_id");
+							let relation_name = rust_field_name
+								.strip_suffix("_id")
+								.expect("foreign-key ID fields always end with `_id`");
 							field_infos
 								.iter()
 								.find(|candidate| candidate.name == relation_name)
@@ -9315,6 +9317,31 @@ mod tests {
 			compact
 				.contains("fnlatest_by_fields()->&'static[&'staticstr]{&[\"created_on\",\"id\"]}")
 		);
+	}
+
+	#[test]
+	fn test_get_latest_by_uses_custom_column_for_relationship_named_with_id_suffix() {
+		let input = quote! {
+			#[model(
+				app_label = "events",
+				table_name = "events",
+				get_latest_by = ("user_id_id",)
+			)]
+			pub struct Event {
+				#[field(primary_key = true)]
+				pub id: i64,
+				#[rel(foreign_key, db_column = "user_fk")]
+				pub user_id: db::associations::ForeignKeyField<User>,
+				#[serde(default)]
+				user_id_id: <User as reinhardt::model_info::InfoModel>::PrimaryKey,
+			}
+		};
+
+		let output = model_derive_impl(syn::parse2(input).unwrap())
+			.expect("get_latest_by fields should resolve");
+		let compact = output.to_string().replace(' ', "");
+
+		assert!(compact.contains("fnlatest_by_fields()->&'static[&'staticstr]{&[\"user_fk\"]}"));
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3441,7 +3441,7 @@ fn generate_field_accessors(
 				///
 				/// Returns a `FieldRef<#struct_name, #field_type>` that provides compile-time
 				/// type safety for field operations.
-				pub const fn #method_name() -> #orm_crate::expressions::FieldRef<#struct_name, #field_type, #orm_crate::expressions::GeneratedModelField> {
+				pub const fn #method_name() -> #orm_crate::expressions::FieldRef<#struct_name, #field_type> {
 					// SAFETY: `#[model]` emits this accessor only for a persisted scalar model field.
 					unsafe { #orm_crate::expressions::FieldRef::from_model_field(#column_name) }
 				}

--- a/crates/reinhardt-core/macros/tests/ui/model/pass/typed_relation_manual_target.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/pass/typed_relation_manual_target.rs
@@ -14,7 +14,8 @@ impl crate::model_info::InfoModel for ManualTarget {
 
 impl ManualTarget {
 	const fn field_id() -> db::orm::expressions::FieldRef<Self, i64> {
-		db::orm::expressions::FieldRef::new("id")
+		// SAFETY: `id` is the persisted primary-key column declared below.
+		unsafe { db::orm::expressions::FieldRef::from_model_field("id") }
 	}
 }
 

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -413,6 +413,9 @@ pub mod db {
 			fn primary_key_column() -> &'static str {
 				Self::primary_key_field()
 			}
+			fn latest_by_fields() -> &'static [&'static str] {
+				&[]
+			}
 			fn primary_key(&self) -> Option<Self::PrimaryKey>;
 			fn set_primary_key(&mut self, value: Self::PrimaryKey);
 			fn field_is_none(&self, field_name: &str) -> bool;
@@ -518,6 +521,15 @@ pub mod db {
 
 			impl<Model, Type> UniqueFieldRef<Model, Type> {
 				pub const unsafe fn from_model_field(_name: &'static str) -> Self {
+					Self {
+						_marker: core::marker::PhantomData,
+					}
+				}
+
+				pub const unsafe fn from_model_field_with_getter(
+					_name: &'static str,
+					_getter: fn(&Model) -> Option<Type>,
+				) -> Self {
 					Self {
 						_marker: core::marker::PhantomData,
 					}

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -505,6 +505,10 @@ pub mod db {
 					}
 				}
 
+				pub const unsafe fn from_model_field(name: &'static str) -> Self {
+					Self::new(name)
+				}
+
 				pub const fn name(&self) -> &'static str {
 					self.name
 				}

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -851,6 +851,11 @@ they do not resolve a connection or invoke an executor. The equivalent
 caller-owned connection or transaction executor. These contracts are
 backend-neutral across PostgreSQL, MySQL, and SQLite.
 
+Bulk retrieval accounts for bind parameters already used by the source
+queryset when splitting lookup keys into backend-safe batches. It returns a
+validation error when the source query has exhausted the backend's bind
+parameter limit and no lookup key can be added safely.
+
 When a retrieval ordering field is nullable, its relative NULL placement follows
 the connected database. Filter nulls explicitly before calling `latest*` or
 `earliest*` when that placement is part of the application contract.

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -496,6 +496,53 @@ let updated = User::objects()
     .await?;
 ```
 
+### Typed retrieval helpers
+
+Models can define their default latest/earliest ordering with generated field
+metadata:
+
+```rust
+#[model(
+    app_label = "events",
+    table_name = "events",
+    get_latest_by = ("created_at", "id")
+)]
+struct Event {
+    #[field(primary_key = true)]
+    id: i64,
+    created_at: DateTime<Utc>,
+    #[field(max_length = 255, unique = true)]
+    slug: String,
+}
+
+let latest = Event::objects().all().latest().await?;
+let earliest = Event::objects()
+    .all()
+    .earliest_by(&[
+        Event::field_created_at().ordering(),
+        Event::field_id().ordering(),
+    ])
+    .await?;
+
+let by_id = Event::objects().all().in_bulk([3_i64, 1, 3]).await?;
+let by_slug = Event::objects()
+    .all()
+    .in_bulk_by(Event::unique_slug(), ["launch", "archive"])
+    .await?;
+
+let empty = Event::objects().all().none();
+assert_eq!(empty.count().await?, 0);
+```
+
+Unlike Django's string field names, explicit ordering and unique-field bulk
+lookups accept only generated typed field proofs for the same model. Bulk
+retrieval returns a `BTreeMap`, so iteration is sorted by key; duplicate input
+keys collapse and missing keys are omitted. Empty input and `none()` are lazy:
+they do not resolve a connection or invoke an executor. The equivalent
+`*_with_db` and `*_with_executor` methods keep retrieval bound to a
+caller-owned connection or transaction executor. These contracts are
+backend-neutral across PostgreSQL, MySQL, and SQLite.
+
 ### Scoped N+1 Query Detection
 
 Use `NPlusOneScope` around development diagnostics or focused tests to detect

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -666,6 +666,12 @@ Models can define their default latest/earliest ordering with generated field
 metadata:
 
 ```rust
+use chrono::{DateTime, Utc};
+use reinhardt_db::model;
+use reinhardt_db::orm::Model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
 #[model(
     app_label = "events",
     table_name = "events",

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -691,7 +691,10 @@ let earliest = Event::objects()
 let by_id = Event::objects().all().in_bulk([3_i64, 1, 3]).await?;
 let by_slug = Event::objects()
     .all()
-    .in_bulk_by(Event::unique_slug(), ["launch", "archive"])
+    .in_bulk_by(
+        Event::unique_slug(),
+        ["launch".to_string(), "archive".to_string()],
+    )
     .await?;
 
 let empty = Event::objects().all().none();

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -710,6 +710,10 @@ they do not resolve a connection or invoke an executor. The equivalent
 caller-owned connection or transaction executor. These contracts are
 backend-neutral across PostgreSQL, MySQL, and SQLite.
 
+When a retrieval ordering field is nullable, its relative NULL placement follows
+the connected database. Filter nulls explicitly before calling `latest*` or
+`earliest*` when that placement is part of the application contract.
+
 ### Scoped N+1 Query Detection
 
 Use `NPlusOneScope` around development diagnostics or focused tests to detect

--- a/crates/reinhardt-db/src/lib.rs
+++ b/crates/reinhardt-db/src/lib.rs
@@ -32,7 +32,8 @@
 //! ### ORM (`orm` module)
 //!
 //! - **Django-style Models**: Define database models with structs
-//! - **QuerySet API**: Chainable query builder with conditional partial updates
+//! - **QuerySet API**: Chainable query builder with typed latest/earliest,
+//!   deterministic bulk retrieval, lazy empty querysets, and conditional partial updates
 //! - **Field Types**: Rich set of field types with validation
 //! - **Relationships**: ForeignKey, ManyToMany, OneToOne
 //! - **Fixtures**: Django-compatible model fixture dump/load runtime with upsert,

--- a/crates/reinhardt-db/src/orm.rs
+++ b/crates/reinhardt-db/src/orm.rs
@@ -12,6 +12,12 @@
 //! records the SQL joins required by the filter, so application code does not
 //! need raw join builders for common FK, reverse, or M2M lookups.
 //!
+//! QuerySet retrieval keeps the same generated-field guarantees:
+//! `latest_by`/`earliest_by` accept [`OrderingField`] values, while
+//! unique-field bulk retrieval accepts [`UniqueFieldRef`]. Bulk results use a
+//! deterministically ordered `BTreeMap`; [`query::QuerySet::none`] and empty
+//! bulk inputs remain lazy and do not resolve or call an executor.
+//!
 //! ## Transaction Management
 //!
 //! ORM writes run inside closure-scoped transactions. Start an outer operation

--- a/crates/reinhardt-db/src/orm.rs
+++ b/crates/reinhardt-db/src/orm.rs
@@ -175,7 +175,9 @@ pub use connection::{
 pub use constraints::{
 	CheckConstraint, Constraint, ForeignKeyConstraint, OnDelete, OnUpdate, UniqueConstraint,
 };
-pub use expressions::{Exists, F, FieldRef, OuterRef, Q, QOperator, Subquery, UniqueFieldRef};
+pub use expressions::{
+	Exists, F, FieldRef, OrderingField, OuterRef, Q, QOperator, Subquery, UniqueFieldRef,
+};
 pub use functions::{
 	Abs, Cast, Ceil, Concat, CurrentDate, CurrentTime, Extract, ExtractComponent, Floor, Greatest,
 	Least, Length, Lower, Mod, Now, NullIf, Power, Round, SqlType, Sqrt, Substr, Trim, TrimType,

--- a/crates/reinhardt-db/src/orm/expressions.rs
+++ b/crates/reinhardt-db/src/orm/expressions.rs
@@ -265,14 +265,6 @@ impl<M, T> FieldRef<M, T> {
 		self.name
 	}
 
-	/// Convert this field reference into a type-safe ordering field.
-	pub const fn ordering(&self) -> OrderingField<M> {
-		OrderingField {
-			name: self.name,
-			_phantom: PhantomData,
-		}
-	}
-
 	/// Create a partial-update assignment for this field.
 	///
 	/// # Examples
@@ -921,6 +913,20 @@ impl<M, T> FieldRef<M, T> {
 			FilterOperator::Lte,
 			FilterValue::FieldRef(F::new(other.name)),
 		)
+	}
+}
+
+impl<M, T: DatabaseField> FieldRef<M, T> {
+	/// Convert this persisted scalar field reference into a type-safe ordering field.
+	///
+	/// Relationship fields are virtual model properties and cannot appear in an
+	/// SQL `ORDER BY` clause. Their generated `FieldRef` accessors therefore do
+	/// not satisfy this scalar-field bound.
+	pub const fn ordering(&self) -> OrderingField<M> {
+		OrderingField {
+			name: self.name,
+			_phantom: PhantomData,
+		}
 	}
 }
 

--- a/crates/reinhardt-db/src/orm/expressions.rs
+++ b/crates/reinhardt-db/src/orm/expressions.rs
@@ -132,7 +132,7 @@ pub enum UnverifiedModelField {}
 
 #[derive(Debug, Clone, Copy)]
 /// A typed model field reference whose origin controls ordering eligibility.
-pub struct FieldRef<M, T, Origin = UnverifiedModelField> {
+pub struct FieldRef<M, T, Origin = GeneratedModelField> {
 	name: &'static str,
 	_phantom: PhantomData<(M, T, Origin)>,
 }
@@ -280,6 +280,18 @@ impl<M, T> FieldRef<M, T, UnverifiedModelField> {
 }
 
 impl<M, T> FieldRef<M, T, GeneratedModelField> {
+	/// Create an unverified field reference for a dynamically composed filter.
+	///
+	/// This preserves the historical two-parameter `FieldRef::<M, T>::new`
+	/// call shape while preventing dynamic field names from becoming ordering
+	/// proofs.
+	pub const fn new(name: &'static str) -> FieldRef<M, T, UnverifiedModelField> {
+		FieldRef {
+			name,
+			_phantom: PhantomData,
+		}
+	}
+
 	/// Construct a field reference proven to come from a model definition.
 	///
 	/// # Safety
@@ -1632,17 +1644,17 @@ mod tests {
 
 	// Simulating what #[derive(Model)] macro would generate
 	impl TestUser {
-		const fn field_id() -> FieldRef<TestUser, i64, GeneratedModelField> {
+		const fn field_id() -> FieldRef<TestUser, i64> {
 			// SAFETY: this mirrors a generated accessor for the persisted `id` field.
 			unsafe { FieldRef::from_model_field("id") }
 		}
 
-		const fn field_name() -> FieldRef<TestUser, String, GeneratedModelField> {
+		const fn field_name() -> FieldRef<TestUser, String> {
 			// SAFETY: this mirrors a generated accessor for the persisted `name` field.
 			unsafe { FieldRef::from_model_field("name") }
 		}
 
-		const fn field_created_at() -> FieldRef<TestUser, i64, GeneratedModelField> {
+		const fn field_created_at() -> FieldRef<TestUser, i64> {
 			// SAFETY: this mirrors a generated accessor for the persisted `created_at` field.
 			unsafe { FieldRef::from_model_field("created_at") }
 		}
@@ -1887,8 +1899,7 @@ mod tests {
 	#[test]
 	fn test_field_ref_const_to_f_conversion() {
 		// Verify const FieldRef can be converted to F
-		const ID_FIELD: FieldRef<TestUser, i64, GeneratedModelField> =
-			unsafe { FieldRef::from_model_field("id") };
+		const ID_FIELD: FieldRef<TestUser, i64> = unsafe { FieldRef::from_model_field("id") };
 		let f: F = ID_FIELD.into();
 
 		assert_eq!(f.to_sql(), "\"id\"");

--- a/crates/reinhardt-db/src/orm/expressions.rs
+++ b/crates/reinhardt-db/src/orm/expressions.rs
@@ -120,6 +120,28 @@ pub struct FieldRef<M, T> {
 	_phantom: PhantomData<(M, T)>,
 }
 
+/// Type-safe proof that a physical database column belongs to model `M`.
+///
+/// `OrderingField<M>` intentionally has no public constructor. Obtain one from
+/// [`FieldRef::ordering`] so the model identity remains coupled to the column.
+#[derive(Debug, Clone, Copy)]
+pub struct OrderingField<M> {
+	// The QuerySet retrieval layer reads this crate-internal column accessor.
+	#[allow(dead_code)]
+	name: &'static str,
+	_phantom: PhantomData<M>,
+}
+
+impl<M> OrderingField<M> {
+	/// Get the physical database column name.
+	#[doc(hidden)]
+	// The QuerySet retrieval layer reads ordering columns internally.
+	#[allow(dead_code)]
+	pub(crate) const fn name(&self) -> &'static str {
+		self.name
+	}
+}
+
 /// Type-safe proof that a model field can identify at most one row.
 ///
 /// `UniqueFieldRef<M, T>` is generated for single-column primary keys,
@@ -128,6 +150,9 @@ pub struct FieldRef<M, T> {
 #[derive(Debug, Clone, Copy)]
 pub struct UniqueFieldRef<M, T> {
 	field: FieldRef<M, T>,
+	// The QuerySet retrieval layer calls the generated getter internally.
+	#[allow(dead_code)]
+	getter: Option<fn(&M) -> Option<T>>,
 }
 
 impl<M, T: DatabaseField> UniqueFieldRef<M, T> {
@@ -141,12 +166,39 @@ impl<M, T: DatabaseField> UniqueFieldRef<M, T> {
 	pub const unsafe fn from_model_field(name: &'static str) -> Self {
 		Self {
 			field: FieldRef::new(name),
+			getter: None,
+		}
+	}
+
+	/// Construct a reference for a uniquely identified model field with a getter.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that `name` identifies a field of `M` whose
+	/// lookup value is `T` and which has a single-column uniqueness guarantee.
+	/// `getter` must return the value stored in that same field.
+	#[doc(hidden)]
+	pub const unsafe fn from_model_field_with_getter(
+		name: &'static str,
+		getter: fn(&M) -> Option<T>,
+	) -> Self {
+		Self {
+			field: FieldRef::new(name),
+			getter: Some(getter),
 		}
 	}
 
 	/// Get the unique field name.
 	pub const fn name(&self) -> &'static str {
 		self.field.name()
+	}
+
+	/// Get the macro-generated model-value accessor, when available.
+	#[doc(hidden)]
+	// The QuerySet retrieval layer calls this accessor internally.
+	#[allow(dead_code)]
+	pub(crate) const fn getter(&self) -> Option<fn(&M) -> Option<T>> {
+		self.getter
 	}
 
 	/// Create an equality filter using the unique field's lookup type.
@@ -193,6 +245,14 @@ impl<M, T> FieldRef<M, T> {
 	/// ```
 	pub const fn name(&self) -> &'static str {
 		self.name
+	}
+
+	/// Convert this field reference into a type-safe ordering field.
+	pub const fn ordering(&self) -> OrderingField<M> {
+		OrderingField {
+			name: self.name,
+			_phantom: PhantomData,
+		}
 	}
 
 	/// Create a partial-update assignment for this field.

--- a/crates/reinhardt-db/src/orm/expressions.rs
+++ b/crates/reinhardt-db/src/orm/expressions.rs
@@ -94,13 +94,13 @@ impl fmt::Display for F {
 /// // The #[model] attribute macro automatically generates:
 /// // impl User {
 /// //     pub const fn field_id() -> FieldRef<User, i64> {
-/// //         FieldRef::new("id")
+/// //         unsafe { FieldRef::from_model_field("id") }
 /// //     }
 /// //     pub const fn field_name() -> FieldRef<User, String> {
-/// //         FieldRef::new("name")
+/// //         unsafe { FieldRef::from_model_field("name") }
 /// //     }
 /// //     pub const fn field_email() -> FieldRef<User, String> {
-/// //         FieldRef::new("email")
+/// //         unsafe { FieldRef::from_model_field("email") }
 /// //     }
 /// // }
 ///
@@ -114,10 +114,27 @@ impl fmt::Display for F {
 /// let f: F = User::field_name().into();
 /// assert_eq!(f.to_sql(), "name");
 /// ```
+/// Marker carried by field references emitted by the model derive macro.
+///
+/// This is intentionally an uninhabited type: callers can use it in type
+/// signatures but cannot manufacture the proof required for SQL ordering.
+#[doc(hidden)]
 #[derive(Debug, Clone, Copy)]
-pub struct FieldRef<M, T> {
+pub enum GeneratedModelField {}
+
+/// Marker for a field name supplied directly by application code.
+///
+/// Such references remain useful for dynamically composed filters, but they
+/// cannot be promoted to [`OrderingField`] without the model macro's proof.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub enum UnverifiedModelField {}
+
+#[derive(Debug, Clone, Copy)]
+/// A typed model field reference whose origin controls ordering eligibility.
+pub struct FieldRef<M, T, Origin = GeneratedModelField> {
 	name: &'static str,
-	_phantom: PhantomData<(M, T)>,
+	_phantom: PhantomData<(M, T, Origin)>,
 }
 
 /// Type-safe proof that a physical database column belongs to model `M`.
@@ -165,7 +182,7 @@ impl<M, T: DatabaseField> UniqueFieldRef<M, T> {
 	#[doc(hidden)]
 	pub const unsafe fn from_model_field(name: &'static str) -> Self {
 		Self {
-			field: FieldRef::new(name),
+			field: unsafe { FieldRef::from_model_field(name) },
 			getter: None,
 		}
 	}
@@ -183,7 +200,7 @@ impl<M, T: DatabaseField> UniqueFieldRef<M, T> {
 		getter: fn(&M) -> Option<T>,
 	) -> Self {
 		Self {
-			field: FieldRef::new(name),
+			field: unsafe { FieldRef::from_model_field(name) },
 			getter: Some(getter),
 		}
 	}
@@ -228,11 +245,12 @@ impl<M, T: DatabaseField> UniqueFieldRef<M, T> {
 	}
 }
 
-impl<M, T> FieldRef<M, T> {
+impl<M, T> FieldRef<M, T, UnverifiedModelField> {
 	/// Create a new field reference with compile-time type safety
 	///
-	/// This constructor is typically used by the `#[derive(Model)]` macro
-	/// to generate field accessor methods.
+	/// This constructor is for dynamically composed filters. It deliberately
+	/// does not permit conversion into [`OrderingField`]. Generated model
+	/// accessors use [`FieldRef::from_model_field`] instead.
 	///
 	/// # Arguments
 	///
@@ -244,7 +262,14 @@ impl<M, T> FieldRef<M, T> {
 	/// # struct User;
 	/// use reinhardt_db::orm::expressions::FieldRef;
 	///
-	/// const USER_ID: FieldRef<User, i64> = FieldRef::new("id");
+	/// const USER_ID: FieldRef<User, i64, UnverifiedModelField> = FieldRef::new("id");
+	/// ```
+	///
+	/// ```compile_fail
+	/// use reinhardt_db::orm::expressions::FieldRef;
+	///
+	/// struct User;
+	/// let ordering = FieldRef::<User, i64>::new("unverified_column").ordering();
 	/// ```
 	pub const fn new(name: &'static str) -> Self {
 		Self {
@@ -252,7 +277,25 @@ impl<M, T> FieldRef<M, T> {
 			_phantom: PhantomData,
 		}
 	}
+}
 
+impl<M, T> FieldRef<M, T, GeneratedModelField> {
+	/// Construct a field reference proven to come from a model definition.
+	///
+	/// # Safety
+	///
+	/// `name` must identify a persisted scalar database column of `M`. The
+	/// model derive macro upholds this invariant for generated accessors.
+	#[doc(hidden)]
+	pub const unsafe fn from_model_field(name: &'static str) -> Self {
+		Self {
+			name,
+			_phantom: PhantomData,
+		}
+	}
+}
+
+impl<M, T, Origin> FieldRef<M, T, Origin> {
 	/// Get the field name
 	///
 	/// # Examples
@@ -827,7 +870,7 @@ impl<M, T> FieldRef<M, T> {
 	/// let filter = Order::field_discount_price().eq_field(Order::field_total_price());
 	/// // Results in: WHERE discount_price = total_price
 	/// ```
-	pub fn eq_field<T2>(&self, other: FieldRef<M, T2>) -> Filter {
+	pub fn eq_field<T2, OtherOrigin>(&self, other: FieldRef<M, T2, OtherOrigin>) -> Filter {
 		Filter::new(
 			self.name.to_string(),
 			FilterOperator::Eq,
@@ -843,7 +886,7 @@ impl<M, T> FieldRef<M, T> {
 	/// let filter = Order::field_discount_price().ne_field(Order::field_total_price());
 	/// // Results in: WHERE discount_price != total_price
 	/// ```
-	pub fn ne_field<T2>(&self, other: FieldRef<M, T2>) -> Filter {
+	pub fn ne_field<T2, OtherOrigin>(&self, other: FieldRef<M, T2, OtherOrigin>) -> Filter {
 		Filter::new(
 			self.name.to_string(),
 			FilterOperator::Ne,
@@ -859,7 +902,7 @@ impl<M, T> FieldRef<M, T> {
 	/// let filter = Order::field_total_price().gt_field(Order::field_discount_price());
 	/// // Results in: WHERE total_price > discount_price
 	/// ```
-	pub fn gt_field<T2>(&self, other: FieldRef<M, T2>) -> Filter {
+	pub fn gt_field<T2, OtherOrigin>(&self, other: FieldRef<M, T2, OtherOrigin>) -> Filter {
 		Filter::new(
 			self.name.to_string(),
 			FilterOperator::Gt,
@@ -875,7 +918,7 @@ impl<M, T> FieldRef<M, T> {
 	/// let filter = Order::field_total_price().gte_field(Order::field_discount_price());
 	/// // Results in: WHERE total_price >= discount_price
 	/// ```
-	pub fn gte_field<T2>(&self, other: FieldRef<M, T2>) -> Filter {
+	pub fn gte_field<T2, OtherOrigin>(&self, other: FieldRef<M, T2, OtherOrigin>) -> Filter {
 		Filter::new(
 			self.name.to_string(),
 			FilterOperator::Gte,
@@ -891,7 +934,7 @@ impl<M, T> FieldRef<M, T> {
 	/// let filter = Order::field_discount_price().lt_field(Order::field_total_price());
 	/// // Results in: WHERE discount_price < total_price
 	/// ```
-	pub fn lt_field<T2>(&self, other: FieldRef<M, T2>) -> Filter {
+	pub fn lt_field<T2, OtherOrigin>(&self, other: FieldRef<M, T2, OtherOrigin>) -> Filter {
 		Filter::new(
 			self.name.to_string(),
 			FilterOperator::Lt,
@@ -907,7 +950,7 @@ impl<M, T> FieldRef<M, T> {
 	/// let filter = Order::field_discount_price().lte_field(Order::field_total_price());
 	/// // Results in: WHERE discount_price <= total_price
 	/// ```
-	pub fn lte_field<T2>(&self, other: FieldRef<M, T2>) -> Filter {
+	pub fn lte_field<T2, OtherOrigin>(&self, other: FieldRef<M, T2, OtherOrigin>) -> Filter {
 		Filter::new(
 			self.name.to_string(),
 			FilterOperator::Lte,
@@ -916,7 +959,7 @@ impl<M, T> FieldRef<M, T> {
 	}
 }
 
-impl<M, T: DatabaseField> FieldRef<M, T> {
+impl<M, T: DatabaseField> FieldRef<M, T, GeneratedModelField> {
 	/// Convert this persisted scalar field reference into a type-safe ordering field.
 	///
 	/// Relationship fields are virtual model properties and cannot appear in an
@@ -1017,7 +1060,7 @@ impl<M> TransformedFieldRef<M> {
 	}
 }
 
-impl<M, T> fmt::Display for FieldRef<M, T> {
+impl<M, T, Origin> fmt::Display for FieldRef<M, T, Origin> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(f, "{}", self.name)
 	}
@@ -1027,15 +1070,15 @@ impl<M, T> fmt::Display for FieldRef<M, T> {
 // (logging, error messages, custom query builders). `Manager::filter` /
 // `QuerySet::filter` now take `impl Into<FilterCondition>` (Issue #4650), so they
 // no longer rely on this conversion.
-impl<M, T> From<FieldRef<M, T>> for String {
-	fn from(field_ref: FieldRef<M, T>) -> Self {
+impl<M, T, Origin> From<FieldRef<M, T, Origin>> for String {
+	fn from(field_ref: FieldRef<M, T, Origin>) -> Self {
 		field_ref.name.to_string()
 	}
 }
 
 // Allow conversion from FieldRef to F for backward compatibility
-impl<M, T> From<FieldRef<M, T>> for F {
-	fn from(field_ref: FieldRef<M, T>) -> Self {
+impl<M, T, Origin> From<FieldRef<M, T, Origin>> for F {
+	fn from(field_ref: FieldRef<M, T, Origin>) -> Self {
 		F::new(field_ref.name)
 	}
 }
@@ -1590,15 +1633,18 @@ mod tests {
 	// Simulating what #[derive(Model)] macro would generate
 	impl TestUser {
 		const fn field_id() -> FieldRef<TestUser, i64> {
-			FieldRef::new("id")
+			// SAFETY: this mirrors a generated accessor for the persisted `id` field.
+			unsafe { FieldRef::from_model_field("id") }
 		}
 
 		const fn field_name() -> FieldRef<TestUser, String> {
-			FieldRef::new("name")
+			// SAFETY: this mirrors a generated accessor for the persisted `name` field.
+			unsafe { FieldRef::from_model_field("name") }
 		}
 
 		const fn field_created_at() -> FieldRef<TestUser, i64> {
-			FieldRef::new("created_at")
+			// SAFETY: this mirrors a generated accessor for the persisted `created_at` field.
+			unsafe { FieldRef::from_model_field("created_at") }
 		}
 	}
 
@@ -1841,7 +1887,7 @@ mod tests {
 	#[test]
 	fn test_field_ref_const_to_f_conversion() {
 		// Verify const FieldRef can be converted to F
-		const ID_FIELD: FieldRef<TestUser, i64> = FieldRef::new("id");
+		const ID_FIELD: FieldRef<TestUser, i64> = unsafe { FieldRef::from_model_field("id") };
 		let f: F = ID_FIELD.into();
 
 		assert_eq!(f.to_sql(), "\"id\"");

--- a/crates/reinhardt-db/src/orm/expressions.rs
+++ b/crates/reinhardt-db/src/orm/expressions.rs
@@ -166,7 +166,7 @@ impl<M> OrderingField<M> {
 /// unique constraints. Nullable fields use their inner type for lookups.
 #[derive(Debug, Clone, Copy)]
 pub struct UniqueFieldRef<M, T> {
-	field: FieldRef<M, T>,
+	field: FieldRef<M, T, GeneratedModelField>,
 	// The QuerySet retrieval layer calls the generated getter internally.
 	#[allow(dead_code)]
 	getter: Option<fn(&M) -> Option<T>>,
@@ -280,6 +280,18 @@ impl<M, T> FieldRef<M, T, UnverifiedModelField> {
 }
 
 impl<M, T> FieldRef<M, T, GeneratedModelField> {
+	/// Create an unverified field reference for a dynamically composed filter.
+	///
+	/// This preserves the historical two-parameter `FieldRef::<M, T>::new`
+	/// call shape while preventing dynamic field names from becoming ordering
+	/// proofs.
+	pub const fn new(name: &'static str) -> FieldRef<M, T, UnverifiedModelField> {
+		FieldRef {
+			name,
+			_phantom: PhantomData,
+		}
+	}
+
 	/// Construct a field reference proven to come from a model definition.
 	///
 	/// # Safety

--- a/crates/reinhardt-db/src/orm/expressions.rs
+++ b/crates/reinhardt-db/src/orm/expressions.rs
@@ -132,7 +132,7 @@ pub enum UnverifiedModelField {}
 
 #[derive(Debug, Clone, Copy)]
 /// A typed model field reference whose origin controls ordering eligibility.
-pub struct FieldRef<M, T, Origin = GeneratedModelField> {
+pub struct FieldRef<M, T, Origin = UnverifiedModelField> {
 	name: &'static str,
 	_phantom: PhantomData<(M, T, Origin)>,
 }
@@ -280,18 +280,6 @@ impl<M, T> FieldRef<M, T, UnverifiedModelField> {
 }
 
 impl<M, T> FieldRef<M, T, GeneratedModelField> {
-	/// Create an unverified field reference for a dynamically composed filter.
-	///
-	/// This preserves the historical two-parameter `FieldRef::<M, T>::new`
-	/// call shape while preventing dynamic field names from becoming ordering
-	/// proofs.
-	pub const fn new(name: &'static str) -> FieldRef<M, T, UnverifiedModelField> {
-		FieldRef {
-			name,
-			_phantom: PhantomData,
-		}
-	}
-
 	/// Construct a field reference proven to come from a model definition.
 	///
 	/// # Safety
@@ -1644,17 +1632,17 @@ mod tests {
 
 	// Simulating what #[derive(Model)] macro would generate
 	impl TestUser {
-		const fn field_id() -> FieldRef<TestUser, i64> {
+		const fn field_id() -> FieldRef<TestUser, i64, GeneratedModelField> {
 			// SAFETY: this mirrors a generated accessor for the persisted `id` field.
 			unsafe { FieldRef::from_model_field("id") }
 		}
 
-		const fn field_name() -> FieldRef<TestUser, String> {
+		const fn field_name() -> FieldRef<TestUser, String, GeneratedModelField> {
 			// SAFETY: this mirrors a generated accessor for the persisted `name` field.
 			unsafe { FieldRef::from_model_field("name") }
 		}
 
-		const fn field_created_at() -> FieldRef<TestUser, i64> {
+		const fn field_created_at() -> FieldRef<TestUser, i64, GeneratedModelField> {
 			// SAFETY: this mirrors a generated accessor for the persisted `created_at` field.
 			unsafe { FieldRef::from_model_field("created_at") }
 		}
@@ -1899,10 +1887,18 @@ mod tests {
 	#[test]
 	fn test_field_ref_const_to_f_conversion() {
 		// Verify const FieldRef can be converted to F
-		const ID_FIELD: FieldRef<TestUser, i64> = unsafe { FieldRef::from_model_field("id") };
+		const ID_FIELD: FieldRef<TestUser, i64, GeneratedModelField> =
+			unsafe { FieldRef::from_model_field("id") };
 		let f: F = ID_FIELD.into();
 
 		assert_eq!(f.to_sql(), "\"id\"");
+	}
+
+	#[test]
+	fn test_field_ref_new_matches_the_default_origin_type() {
+		const ID_FIELD: FieldRef<TestUser, i64> = FieldRef::new("id");
+
+		assert_eq!(ID_FIELD.name(), "id");
 	}
 }
 // Auto-generated tests for expressions module

--- a/crates/reinhardt-db/src/orm/expressions.rs
+++ b/crates/reinhardt-db/src/orm/expressions.rs
@@ -208,6 +208,24 @@ impl<M, T: DatabaseField> UniqueFieldRef<M, T> {
 	{
 		self.field.eq(value)
 	}
+
+	/// Create an IN filter using the unique field's lookup type.
+	pub fn is_in<I, V>(&self, values: I) -> Filter
+	where
+		I: IntoIterator<Item = V>,
+		V: IntoFieldValue<T>,
+	{
+		Filter::new(
+			self.name().to_string(),
+			FilterOperator::In,
+			FilterValue::List(
+				values
+					.into_iter()
+					.map(|value| FilterValue::Typed(value.into_field_value()))
+					.collect(),
+			),
+		)
+	}
 }
 
 impl<M, T> FieldRef<M, T> {

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -105,6 +105,14 @@ pub trait Model: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone {
 		Self::primary_key_field()
 	}
 
+	/// Get the physical database columns used as the default latest ordering.
+	///
+	/// Manual model implementations have no default latest ordering. The model
+	/// macro overrides this method for `#[model(get_latest_by = (...))]`.
+	fn latest_by_fields() -> &'static [&'static str] {
+		&[]
+	}
+
 	/// Get the primary key value
 	///
 	/// Returns an owned copy of the primary key. For composite primary keys,

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -6242,12 +6242,14 @@ where
 	fn bulk_key_batches<K>(
 		keys: BTreeSet<K>,
 		backend: super::connection::DatabaseBackend,
+		reserved_binds: usize,
 	) -> Vec<Vec<K>> {
-		let limit = match backend {
+		let parameter_limit = match backend {
 			super::connection::DatabaseBackend::Sqlite => 900,
 			super::connection::DatabaseBackend::Postgres
 			| super::connection::DatabaseBackend::MySql => 65_535,
 		};
+		let limit = parameter_limit.saturating_sub(reserved_binds).max(1);
 		let mut remaining = keys.into_iter().collect::<Vec<_>>();
 		let mut batches = Vec::new();
 		while !remaining.is_empty() {
@@ -6255,6 +6257,16 @@ where
 			batches.push(remaining.drain(..count).collect());
 		}
 		batches
+	}
+
+	fn select_bind_count(
+		&self,
+		backend: super::connection::DatabaseBackend,
+		is_cockroachdb: bool,
+	) -> reinhardt_core::exception::Result<usize> {
+		let statement = self.build_select_statement()?;
+		let (_, values) = Self::build_select_for_backend(&statement, backend, is_cockroachdb)?;
+		Ok(values.len())
 	}
 
 	/// Fetch rows by primary key and return them in deterministic key order.
@@ -6407,8 +6419,9 @@ where
 		E: OrmExecutor,
 	{
 		let field = super::expressions::FieldRef::<T, T::PrimaryKey>::new(T::primary_key_column());
+		let reserved_binds = self.select_bind_count(conn.backend(), conn.is_cockroachdb())?;
 		let mut result = BTreeMap::new();
-		for keys in Self::bulk_key_batches(keys, conn.backend()) {
+		for keys in Self::bulk_key_batches(keys, conn.backend(), reserved_binds) {
 			let rows = self
 				.clone()
 				.filter(field.is_in(keys))
@@ -6431,8 +6444,10 @@ where
 		T: serde::de::DeserializeOwned,
 		T::PrimaryKey: DatabaseField + Ord,
 	{
+		let backend = Self::executor_backend(executor);
+		let reserved_binds = self.select_bind_count(backend, executor.is_cockroachdb())?;
 		let mut result = BTreeMap::new();
-		for keys in Self::bulk_key_batches(keys, Self::executor_backend(executor)) {
+		for keys in Self::bulk_key_batches(keys, backend, reserved_binds) {
 			let filter =
 				super::expressions::FieldRef::<T, T::PrimaryKey>::new(T::primary_key_column())
 					.is_in(keys);
@@ -6461,8 +6476,9 @@ where
 		E: OrmExecutor,
 		K: DatabaseField + Ord,
 	{
+		let reserved_binds = self.select_bind_count(conn.backend(), conn.is_cockroachdb())?;
 		let mut result = BTreeMap::new();
-		for keys in Self::bulk_key_batches(keys, conn.backend()) {
+		for keys in Self::bulk_key_batches(keys, conn.backend(), reserved_binds) {
 			let rows = self
 				.clone()
 				.filter(unique_field.is_in(keys))
@@ -6487,8 +6503,10 @@ where
 		T: serde::de::DeserializeOwned,
 		K: DatabaseField + Ord,
 	{
+		let backend = Self::executor_backend(executor);
+		let reserved_binds = self.select_bind_count(backend, executor.is_cockroachdb())?;
 		let mut result = BTreeMap::new();
-		for keys in Self::bulk_key_batches(keys, Self::executor_backend(executor)) {
+		for keys in Self::bulk_key_batches(keys, backend, reserved_binds) {
 			let rows = self
 				.clone()
 				.filter(unique_field.is_in(keys))

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -6199,6 +6199,7 @@ where
 		self.ensure_unsliced_retrieval()?;
 		let mut queryset = self.clone();
 		queryset.order_by_fields = ordering;
+		queryset.order_by_expressions.clear();
 		queryset.limit = Some(1);
 		queryset
 			.all_with_db(conn)
@@ -6219,6 +6220,7 @@ where
 		self.ensure_unsliced_retrieval().map_err(executor_error)?;
 		let mut queryset = self.clone();
 		queryset.order_by_fields = ordering;
+		queryset.order_by_expressions.clear();
 		queryset.limit = Some(1);
 		queryset
 			.all_with_executor(executor)
@@ -6656,6 +6658,9 @@ where
 	where
 		E: OrmExecutor,
 	{
+		if self.empty {
+			return Ok(Vec::new());
+		}
 		let stmt = self.build_select_statement()?;
 		let context = super::execution::pgvector_context_for_select(&stmt);
 		let (sql, values) =
@@ -7659,6 +7664,11 @@ where
 		T: super::Model + Clone,
 	{
 		Self::composite_primary_key_for_values(pk_values)?;
+		if self.empty {
+			return Err(Error::NotFound(
+				"No record found matching the query".to_string(),
+			));
+		}
 		let mut conn = super::manager::get_connection().await?;
 		self.get_composite_with_db(&mut conn, pk_values).await
 	}
@@ -7696,6 +7706,11 @@ where
 		T: super::Model + Clone,
 		E: OrmExecutor,
 	{
+		if self.empty {
+			return Err(Error::NotFound(
+				"No record found matching the query".to_string(),
+			));
+		}
 		use reinhardt_query::prelude::{Alias, BinOper, ColumnRef, Expr, Value};
 
 		let composite_pk = Self::composite_primary_key_for_values(pk_values)?;

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -3607,7 +3607,9 @@ where
 	}
 
 	fn root_column_reference(&self, field: &str) -> ColumnRef {
-		if (!self.relation_joins.is_empty() || self.has_select_related()) && !field.contains('.') {
+		if (!self.relation_joins.is_empty() || !self.joins.is_empty() || self.has_select_related())
+			&& !field.contains('.')
+		{
 			ColumnRef::table_column(Alias::new(self.root_alias()), Alias::new(field))
 		} else {
 			parse_column_reference(field)
@@ -6288,8 +6290,9 @@ where
 				fields.push(column.to_string());
 			}
 		} else {
+			let field_name = Self::logical_field_name_for_column(column);
 			self.deferred_fields
-				.retain(|field| !Self::projection_includes_column(field, column));
+				.retain(|field| !Self::projection_includes_column(field, &field_name));
 		}
 		self
 	}
@@ -6299,6 +6302,13 @@ where
 			|| field
 				.rsplit_once('.')
 				.is_some_and(|(_, field_name)| field_name == column)
+	}
+
+	fn logical_field_name_for_column(column: &str) -> String {
+		T::field_metadata()
+			.iter()
+			.find(|metadata| metadata.db_column_name() == column)
+			.map_or_else(|| column.to_owned(), |metadata| metadata.name.clone())
 	}
 
 	/// Fetch rows by primary key and return them in deterministic key order.
@@ -10184,48 +10194,83 @@ mod tests {
 			}
 		}
 
-		const fn field_id() -> crate::orm::expressions::FieldRef<TestUser, i64> {
+		const fn field_id() -> crate::orm::expressions::FieldRef<
+			TestUser,
+			i64,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestUser's persisted `id` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("id") }
 		}
 
-		const fn field_username() -> crate::orm::expressions::FieldRef<TestUser, String> {
+		const fn field_username() -> crate::orm::expressions::FieldRef<
+			TestUser,
+			String,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestUser's persisted `username` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("username") }
 		}
 
-		const fn field_email() -> crate::orm::expressions::FieldRef<TestUser, String> {
+		const fn field_email() -> crate::orm::expressions::FieldRef<
+			TestUser,
+			String,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestUser's persisted `email` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("email") }
 		}
 
-		const fn field_full_name() -> crate::orm::expressions::FieldRef<TestUser, String> {
+		const fn field_full_name() -> crate::orm::expressions::FieldRef<
+			TestUser,
+			String,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestUser's persisted `full_name` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("full_name") }
 		}
 
-		const fn field_display_name() -> crate::orm::expressions::FieldRef<TestUser, String> {
+		const fn field_display_name() -> crate::orm::expressions::FieldRef<
+			TestUser,
+			String,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestUser's persisted `display_name` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("display_name") }
 		}
 
-		const fn field_created_at()
-		-> crate::orm::expressions::FieldRef<TestUser, chrono::DateTime<chrono::Utc>> {
+		const fn field_created_at() -> crate::orm::expressions::FieldRef<
+			TestUser,
+			chrono::DateTime<chrono::Utc>,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestUser's persisted `created_at` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("created_at") }
 		}
 
-		const fn field_tags() -> crate::orm::expressions::FieldRef<TestUser, Vec<String>> {
+		const fn field_tags() -> crate::orm::expressions::FieldRef<
+			TestUser,
+			Vec<String>,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestUser's persisted `tags` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("tags") }
 		}
 
-		const fn field_metadata() -> crate::orm::expressions::FieldRef<TestUser, String> {
+		const fn field_metadata() -> crate::orm::expressions::FieldRef<
+			TestUser,
+			String,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestUser's persisted `metadata` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("metadata") }
 		}
 
-		const fn field_active_period() -> crate::orm::expressions::FieldRef<TestUser, String> {
+		const fn field_active_period() -> crate::orm::expressions::FieldRef<
+			TestUser,
+			String,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestUser's persisted `active_period` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("active_period") }
 		}
@@ -10403,13 +10448,20 @@ mod tests {
 	}
 
 	impl TestCorpusFile {
-		const fn field_normalized_path() -> crate::orm::expressions::FieldRef<TestCorpusFile, String>
-		{
+		const fn field_normalized_path() -> crate::orm::expressions::FieldRef<
+			TestCorpusFile,
+			String,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestCorpusFile's persisted `normalized_path` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("normalized_path") }
 		}
 
-		const fn field_email() -> crate::orm::expressions::FieldRef<TestCorpusFile, String> {
+		const fn field_email() -> crate::orm::expressions::FieldRef<
+			TestCorpusFile,
+			String,
+			crate::orm::expressions::GeneratedModelField,
+		> {
 			// SAFETY: this test accessor names TestCorpusFile's persisted `email` field.
 			unsafe { crate::orm::expressions::FieldRef::from_model_field("email") }
 		}
@@ -10634,7 +10686,11 @@ mod tests {
 		.then::<TestCorpusFileProject, TestProject>()
 		.field(unsafe {
 			// SAFETY: `name` is a persisted TestProject field in this query fixture.
-			crate::orm::expressions::FieldRef::<TestProject, String>::from_model_field("name")
+			crate::orm::expressions::FieldRef::<
+				TestProject,
+				String,
+				crate::orm::expressions::GeneratedModelField,
+			>::from_model_field("name")
 		})
 		.eq("reinhardt")
 	}
@@ -11477,7 +11533,11 @@ mod tests {
 			.then::<TestCorpusFileProject, TestProject>()
 			.field(unsafe {
 				// SAFETY: `name` is a persisted TestProject field in this query fixture.
-				crate::orm::expressions::FieldRef::<TestProject, String>::from_model_field("name")
+				crate::orm::expressions::FieldRef::<
+					TestProject,
+					String,
+					crate::orm::expressions::GeneratedModelField,
+				>::from_model_field("name")
 			})
 			.eq("reinhardt");
 
@@ -11587,7 +11647,11 @@ mod tests {
 			>()
 			.field(unsafe {
 				// SAFETY: `id` is a persisted TestProjects field in this query fixture.
-				crate::orm::expressions::FieldRef::<TestProjects, i64>::from_model_field("id")
+				crate::orm::expressions::FieldRef::<
+					TestProjects,
+					i64,
+					crate::orm::expressions::GeneratedModelField,
+				>::from_model_field("id")
 			})
 			.eq(1)
 		};
@@ -11645,6 +11709,25 @@ mod tests {
 			sql.contains(r#"INNER JOIN "test_projects" ON test_users.id = test_projects.user_id"#)
 		);
 		assert!(sql.contains(r#"WHERE "test_projects"."name" = 'reinhardt'"#));
+	}
+
+	#[test]
+	fn test_manual_join_qualifies_root_ordering_columns() {
+		let sql = QuerySet::<TestUser>::new()
+			.inner_join_on::<TestProject>("test_users.id = test_projects.user_id")
+			.order_by(&["id"])
+			.to_sql()
+			.expect("query SQL should compile");
+
+		assert!(sql.contains(r#"ORDER BY "test_users"."id" ASC"#));
+	}
+
+	#[test]
+	fn test_bulk_lookup_restores_deferred_logical_name_for_custom_column() {
+		let queryset = QuerySet::<TestCorpusFile>::new().defer(&["email"]);
+		let queryset = queryset.with_bulk_lookup_column("email_addr");
+
+		assert!(queryset.deferred_fields.is_empty());
 	}
 
 	#[test]
@@ -12380,7 +12463,11 @@ mod tests {
 			>()
 			.field(unsafe {
 				// SAFETY: `name` is a persisted TestProject field in this query fixture.
-				crate::orm::expressions::FieldRef::<TestProject, String>::from_model_field("name")
+				crate::orm::expressions::FieldRef::<
+					TestProject,
+					String,
+					crate::orm::expressions::GeneratedModelField,
+				>::from_model_field("name")
 			})
 			.icontains("rust");
 
@@ -12403,7 +12490,11 @@ mod tests {
 			>()
 			.field(unsafe {
 				// SAFETY: `name` is a persisted TestProject field in this query fixture.
-				crate::orm::expressions::FieldRef::<TestProject, String>::from_model_field("name")
+				crate::orm::expressions::FieldRef::<
+					TestProject,
+					String,
+					crate::orm::expressions::GeneratedModelField,
+				>::from_model_field("name")
 			})
 			.icontains("rust");
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -7356,13 +7356,21 @@ where
 		keys: BTreeSet<K>,
 		backend: super::connection::DatabaseBackend,
 		reserved_binds: usize,
-	) -> Vec<Vec<K>> {
+	) -> reinhardt_core::exception::Result<Vec<Vec<K>>> {
 		let parameter_limit: usize = match backend {
 			super::connection::DatabaseBackend::Sqlite => 900,
 			super::connection::DatabaseBackend::Postgres
 			| super::connection::DatabaseBackend::MySql => 65_535,
 		};
-		let limit = parameter_limit.saturating_sub(reserved_binds).max(1);
+		if keys.is_empty() {
+			return Ok(Vec::new());
+		}
+		if reserved_binds >= parameter_limit {
+			return Err(Error::Validation(format!(
+				"QuerySet bulk retrieval cannot add lookup keys because the source query uses all {parameter_limit} available bind parameters"
+			)));
+		}
+		let limit = parameter_limit - reserved_binds;
 		let mut batches = Vec::with_capacity(keys.len().div_ceil(limit));
 		let mut batch = Vec::with_capacity(limit);
 		for key in keys {
@@ -7375,7 +7383,7 @@ where
 		if !batch.is_empty() {
 			batches.push(batch);
 		}
-		batches
+		Ok(batches)
 	}
 
 	fn select_bind_count(
@@ -7577,7 +7585,7 @@ where
 		>::new(T::primary_key_column());
 		let reserved_binds = self.select_bind_count(conn.backend(), conn.is_cockroachdb())?;
 		let mut result = BTreeMap::new();
-		for keys in Self::bulk_key_batches(keys, conn.backend(), reserved_binds) {
+		for keys in Self::bulk_key_batches(keys, conn.backend(), reserved_binds)? {
 			let rows = self
 				.clone()
 				.with_bulk_lookup_column(T::primary_key_column())
@@ -7604,7 +7612,7 @@ where
 		let backend = Self::executor_backend(executor);
 		let reserved_binds = self.select_bind_count(backend, executor.is_cockroachdb())?;
 		let mut result = BTreeMap::new();
-		for keys in Self::bulk_key_batches(keys, backend, reserved_binds) {
+		for keys in Self::bulk_key_batches(keys, backend, reserved_binds)? {
 			let filter = super::expressions::FieldRef::<
 				T,
 				T::PrimaryKey,
@@ -7639,7 +7647,7 @@ where
 	{
 		let reserved_binds = self.select_bind_count(conn.backend(), conn.is_cockroachdb())?;
 		let mut result = BTreeMap::new();
-		for keys in Self::bulk_key_batches(keys, conn.backend(), reserved_binds) {
+		for keys in Self::bulk_key_batches(keys, conn.backend(), reserved_binds)? {
 			let rows = self
 				.clone()
 				.with_bulk_lookup_column(unique_field.name())
@@ -7668,7 +7676,7 @@ where
 		let backend = Self::executor_backend(executor);
 		let reserved_binds = self.select_bind_count(backend, executor.is_cockroachdb())?;
 		let mut result = BTreeMap::new();
-		for keys in Self::bulk_key_batches(keys, backend, reserved_binds) {
+		for keys in Self::bulk_key_batches(keys, backend, reserved_binds)? {
 			let rows = self
 				.clone()
 				.with_bulk_lookup_column(unique_field.name())
@@ -12348,12 +12356,34 @@ mod tests {
 		let keys = (0_i64..901).collect::<BTreeSet<_>>();
 
 		// Act
-		let batches = QuerySet::<TestUser>::bulk_key_batches(keys, DatabaseBackend::Sqlite, 0);
+		let batches = QuerySet::<TestUser>::bulk_key_batches(keys, DatabaseBackend::Sqlite, 0)
+			.expect("SQLite should have bind slots available");
 
 		// Assert
 		assert_eq!(batches.len(), 2);
 		assert_eq!(batches[0], (0_i64..900).collect::<Vec<_>>());
 		assert_eq!(batches[1], vec![900]);
+	}
+
+	#[rstest]
+	#[case(DatabaseBackend::Postgres)]
+	#[case(DatabaseBackend::MySql)]
+	fn bulk_key_batches_reject_exhausted_server_bind_limit(#[case] backend: DatabaseBackend) {
+		// Arrange
+		let keys = BTreeSet::from([1_i64]);
+
+		// Act
+		let error = QuerySet::<TestUser>::bulk_key_batches(keys, backend, 65_535)
+			.expect_err("an exhausted bind budget should reject bulk retrieval");
+
+		// Assert
+		let reinhardt_core::exception::Error::Validation(message) = error else {
+			panic!("expected validation error, got {error:?}");
+		};
+		assert_eq!(
+			message,
+			"QuerySet bulk retrieval cannot add lookup keys because the source query uses all 65535 available bind parameters"
+		);
 	}
 
 	#[test]
@@ -13310,8 +13340,10 @@ mod tests {
 			.to_sql()
 			.expect("query SQL should compile");
 
-		assert!(sql.contains(r#"ORDER BY "other_age" ASC"#));
-		assert!(!sql.contains(r#"ORDER BY "test_users"."other_age" ASC"#));
+		assert_eq!(
+			sql,
+			r#"SELECT *, 42 AS "other_age" FROM "test_users" INNER JOIN "test_projects" ON test_users.id = test_projects.user_id ORDER BY "other_age" ASC"#
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -6279,7 +6279,32 @@ where
 		Ok(values.len())
 	}
 
+	fn with_bulk_lookup_column(mut self, column: &str) -> Self {
+		if let Some(fields) = &mut self.selected_fields {
+			if !fields
+				.iter()
+				.any(|field| Self::projection_includes_column(field, column))
+			{
+				fields.push(column.to_string());
+			}
+		} else {
+			self.deferred_fields
+				.retain(|field| !Self::projection_includes_column(field, column));
+		}
+		self
+	}
+
+	fn projection_includes_column(field: &str, column: &str) -> bool {
+		field == column
+			|| field
+				.rsplit_once('.')
+				.is_some_and(|(_, field_name)| field_name == column)
+	}
+
 	/// Fetch rows by primary key and return them in deterministic key order.
+	///
+	/// When the queryset uses a field projection, the primary-key column is
+	/// selected automatically so every returned model can be indexed.
 	pub async fn in_bulk<I>(
 		&self,
 		keys: I,
@@ -6438,6 +6463,7 @@ where
 		for keys in Self::bulk_key_batches(keys, conn.backend(), reserved_binds) {
 			let rows = self
 				.clone()
+				.with_bulk_lookup_column(T::primary_key_column())
 				.filter(field.is_in(keys))
 				.all_with_db(conn)
 				.await?;
@@ -6470,6 +6496,7 @@ where
 			.is_in(keys);
 			let rows = self
 				.clone()
+				.with_bulk_lookup_column(T::primary_key_column())
 				.filter(filter)
 				.all_with_executor(executor)
 				.await?;
@@ -6498,6 +6525,7 @@ where
 		for keys in Self::bulk_key_batches(keys, conn.backend(), reserved_binds) {
 			let rows = self
 				.clone()
+				.with_bulk_lookup_column(unique_field.name())
 				.filter(unique_field.is_in(keys))
 				.all_with_db(conn)
 				.await?;
@@ -6526,6 +6554,7 @@ where
 		for keys in Self::bulk_key_batches(keys, backend, reserved_binds) {
 			let rows = self
 				.clone()
+				.with_bulk_lookup_column(unique_field.name())
 				.filter(unique_field.is_in(keys))
 				.all_with_executor(executor)
 				.await?;

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -3607,7 +3607,7 @@ where
 	}
 
 	fn root_column_reference(&self, field: &str) -> ColumnRef {
-		if !self.relation_joins.is_empty() && !field.contains('.') {
+		if (!self.relation_joins.is_empty() || self.has_select_related()) && !field.contains('.') {
 			ColumnRef::table_column(Alias::new(self.root_alias()), Alias::new(field))
 		} else {
 			parse_column_reference(field)
@@ -11328,6 +11328,23 @@ mod tests {
 		assert!(sql.contains("SELECT"));
 		assert!(sql.contains("test_users"));
 		assert!(sql.contains("LEFT JOIN"));
+	}
+
+	#[test]
+	fn select_related_qualifies_root_ordering_columns() {
+		// Arrange
+		let mut queryset = QuerySet::<TestUser>::new().select_related(&["profile"]);
+		queryset.order_by_fields.push("id".to_string());
+
+		// Act
+		let statement = queryset
+			.select_related_query()
+			.expect("select-related query should compile");
+		use reinhardt_query::prelude::{PostgresQueryBuilder, QueryStatementBuilder};
+		let sql = statement.build(PostgresQueryBuilder).0;
+
+		// Assert
+		assert!(sql.contains("ORDER BY \"test_users\".\"id\" ASC"));
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -5984,6 +5984,7 @@ where
 				"No record found matching the query".to_string(),
 			));
 		}
+		self.ensure_unsliced_retrieval()?;
 		let mut conn = super::manager::get_connection().await?;
 		self.single_with_db(&mut conn, ordering).await
 	}
@@ -5999,6 +6000,7 @@ where
 				"No record found matching the query".to_string(),
 			));
 		}
+		self.ensure_unsliced_retrieval()?;
 		let mut conn = super::manager::get_connection().await?;
 		self.single_with_db(&mut conn, ordering).await
 	}
@@ -6017,6 +6019,7 @@ where
 				"No record found matching the query".to_string(),
 			));
 		}
+		self.ensure_unsliced_retrieval()?;
 		let mut conn = super::manager::get_connection().await?;
 		self.single_with_db(&mut conn, ordering).await
 	}
@@ -6035,6 +6038,7 @@ where
 				"No record found matching the query".to_string(),
 			));
 		}
+		self.ensure_unsliced_retrieval()?;
 		let mut conn = super::manager::get_connection().await?;
 		self.single_with_db(&mut conn, ordering).await
 	}
@@ -6244,7 +6248,7 @@ where
 		backend: super::connection::DatabaseBackend,
 		reserved_binds: usize,
 	) -> Vec<Vec<K>> {
-		let parameter_limit = match backend {
+		let parameter_limit: usize = match backend {
 			super::connection::DatabaseBackend::Sqlite => 900,
 			super::connection::DatabaseBackend::Postgres
 			| super::connection::DatabaseBackend::MySql => 65_535,

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -4,6 +4,7 @@
 //! By default, it exports the expression-based query API (SQLAlchemy-style).
 
 use super::connection::{OrmExecutor, QueryRow};
+use super::expressions::{OrderingField, UniqueFieldRef};
 use super::field_codec::{
 	DatabaseField, DatabaseValue, FieldCodecError, IntoFieldValue, database_value_to_query_value,
 };
@@ -23,7 +24,7 @@ use reinhardt_query::prelude::{
 use reinhardt_query::types::PgBinOper;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::marker::PhantomData;
 use std::time::Instant;
 use uuid::Uuid;
@@ -1205,6 +1206,7 @@ where
 	having_conditions: Vec<HavingCondition>,
 	subquery_conditions: Vec<SubqueryCondition>,
 	from_alias: Option<String>,
+	empty: bool,
 	/// Subquery SQL for FROM clause (derived table)
 	/// When set, the FROM clause will use this subquery instead of the model's table
 	from_subquery_sql: Option<String>,
@@ -1240,6 +1242,7 @@ where
 			having_conditions: Vec::new(),
 			subquery_conditions: Vec::new(),
 			from_alias: None,
+			empty: false,
 			from_subquery_sql: None,
 		}
 	}
@@ -1350,6 +1353,7 @@ where
 			having_conditions: Vec::new(),
 			subquery_conditions: Vec::new(),
 			from_alias: None,
+			empty: false,
 			from_subquery_sql: None,
 		}
 	}
@@ -1563,8 +1567,15 @@ where
 			having_conditions: Vec::new(),
 			subquery_conditions: Vec::new(),
 			from_alias: Some(alias.to_string()),
+			empty: false,
 			from_subquery_sql: Some(subquery_sql),
 		})
+	}
+
+	/// Marks this queryset as empty without resolving a database connection.
+	pub fn none(mut self) -> Self {
+		self.empty = true;
+		self
 	}
 
 	/// Add an INNER JOIN to the query
@@ -3849,6 +3860,10 @@ where
 
 	/// Build WHERE condition using reinhardt-query from accumulated filters
 	fn build_where_condition(&self) -> reinhardt_core::exception::Result<Option<Condition>> {
+		if self.empty {
+			return Ok(Some(Condition::all().add(Expr::val(1).eq(0))));
+		}
+
 		if !self.has_where_predicates() {
 			return Ok(None);
 		}
@@ -5800,6 +5815,10 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		if self.empty {
+			return Ok(Vec::new());
+		}
+
 		let mut conn = super::manager::get_connection().await?;
 		self.all_with_db(&mut conn).await
 	}
@@ -5852,8 +5871,484 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		if self.empty {
+			return Ok(None);
+		}
+
 		let mut conn = super::manager::get_connection().await?;
 		self.first_with_db(&mut conn).await
+	}
+
+	/// Return the newest row using the model's `get_latest_by` metadata.
+	pub async fn latest(&self) -> reinhardt_core::exception::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+	{
+		let ordering = self.metadata_retrieval_ordering(true)?;
+		if self.empty {
+			return Err(Error::NotFound(
+				"No record found matching the query".to_string(),
+			));
+		}
+		let mut conn = super::manager::get_connection().await?;
+		self.single_with_db(&mut conn, ordering).await
+	}
+
+	/// Return the oldest row using the model's `get_latest_by` metadata.
+	pub async fn earliest(&self) -> reinhardt_core::exception::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+	{
+		let ordering = self.metadata_retrieval_ordering(false)?;
+		if self.empty {
+			return Err(Error::NotFound(
+				"No record found matching the query".to_string(),
+			));
+		}
+		let mut conn = super::manager::get_connection().await?;
+		self.single_with_db(&mut conn, ordering).await
+	}
+
+	/// Return the newest row ordered by the supplied typed model fields.
+	pub async fn latest_by(
+		&self,
+		fields: &[OrderingField<T>],
+	) -> reinhardt_core::exception::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+	{
+		let ordering = Self::typed_retrieval_ordering(fields, true)?;
+		if self.empty {
+			return Err(Error::NotFound(
+				"No record found matching the query".to_string(),
+			));
+		}
+		let mut conn = super::manager::get_connection().await?;
+		self.single_with_db(&mut conn, ordering).await
+	}
+
+	/// Return the oldest row ordered by the supplied typed model fields.
+	pub async fn earliest_by(
+		&self,
+		fields: &[OrderingField<T>],
+	) -> reinhardt_core::exception::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+	{
+		let ordering = Self::typed_retrieval_ordering(fields, false)?;
+		if self.empty {
+			return Err(Error::NotFound(
+				"No record found matching the query".to_string(),
+			));
+		}
+		let mut conn = super::manager::get_connection().await?;
+		self.single_with_db(&mut conn, ordering).await
+	}
+
+	/// Return the newest row through a caller-owned ORM executor.
+	pub async fn latest_with_db<E>(&self, conn: &mut E) -> reinhardt_core::exception::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+		E: OrmExecutor,
+	{
+		let ordering = self.metadata_retrieval_ordering(true)?;
+		self.single_with_db(conn, ordering).await
+	}
+
+	/// Return the oldest row through a caller-owned ORM executor.
+	pub async fn earliest_with_db<E>(&self, conn: &mut E) -> reinhardt_core::exception::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+		E: OrmExecutor,
+	{
+		let ordering = self.metadata_retrieval_ordering(false)?;
+		self.single_with_db(conn, ordering).await
+	}
+
+	/// Return the newest row ordered by typed fields through a caller-owned ORM executor.
+	pub async fn latest_by_with_db<E>(
+		&self,
+		conn: &mut E,
+		fields: &[OrderingField<T>],
+	) -> reinhardt_core::exception::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+		E: OrmExecutor,
+	{
+		let ordering = Self::typed_retrieval_ordering(fields, true)?;
+		self.single_with_db(conn, ordering).await
+	}
+
+	/// Return the oldest row ordered by typed fields through a caller-owned ORM executor.
+	pub async fn earliest_by_with_db<E>(
+		&self,
+		conn: &mut E,
+		fields: &[OrderingField<T>],
+	) -> reinhardt_core::exception::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+		E: OrmExecutor,
+	{
+		let ordering = Self::typed_retrieval_ordering(fields, false)?;
+		self.single_with_db(conn, ordering).await
+	}
+
+	/// Return the newest row through an active transaction executor.
+	pub async fn latest_with_executor(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+	) -> crate::backends::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+	{
+		let ordering = self.metadata_retrieval_ordering(true)?;
+		self.single_with_executor(executor, ordering).await
+	}
+
+	/// Return the oldest row through an active transaction executor.
+	pub async fn earliest_with_executor(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+	) -> crate::backends::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+	{
+		let ordering = self.metadata_retrieval_ordering(false)?;
+		self.single_with_executor(executor, ordering).await
+	}
+
+	/// Return the newest row ordered by typed fields through an active transaction executor.
+	pub async fn latest_by_with_executor(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+		fields: &[OrderingField<T>],
+	) -> crate::backends::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+	{
+		let ordering = Self::typed_retrieval_ordering(fields, true)?;
+		self.single_with_executor(executor, ordering).await
+	}
+
+	/// Return the oldest row ordered by typed fields through an active transaction executor.
+	pub async fn earliest_by_with_executor(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+		fields: &[OrderingField<T>],
+	) -> crate::backends::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+	{
+		let ordering = Self::typed_retrieval_ordering(fields, false)?;
+		self.single_with_executor(executor, ordering).await
+	}
+
+	fn metadata_retrieval_ordering(
+		&self,
+		latest: bool,
+	) -> reinhardt_core::exception::Result<Vec<String>> {
+		let fields = T::latest_by_fields();
+		if fields.is_empty() {
+			return Err(Error::Validation(format!(
+				"{} requires Model::latest_by_fields() metadata or an explicit typed field",
+				if latest {
+					"QuerySet::latest"
+				} else {
+					"QuerySet::earliest"
+				}
+			)));
+		}
+		Ok(fields
+			.iter()
+			.map(|field| {
+				if latest {
+					field
+						.strip_prefix('-')
+						.map_or_else(|| format!("-{field}"), ToOwned::to_owned)
+				} else {
+					(*field).to_owned()
+				}
+			})
+			.collect())
+	}
+
+	fn typed_retrieval_ordering(
+		fields: &[OrderingField<T>],
+		latest: bool,
+	) -> reinhardt_core::exception::Result<Vec<String>> {
+		if fields.is_empty() {
+			return Err(Error::Validation(
+				"QuerySet retrieval requires at least one typed ordering field".to_string(),
+			));
+		}
+		Ok(fields
+			.iter()
+			.map(|field| {
+				if latest {
+					format!("-{}", field.name())
+				} else {
+					field.name().to_owned()
+				}
+			})
+			.collect())
+	}
+
+	async fn single_with_db<E>(
+		&self,
+		conn: &mut E,
+		ordering: Vec<String>,
+	) -> reinhardt_core::exception::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+		E: OrmExecutor,
+	{
+		let mut queryset = self.clone();
+		queryset.order_by_fields = ordering;
+		queryset.limit = Some(1);
+		queryset
+			.all_with_db(conn)
+			.await?
+			.into_iter()
+			.next()
+			.ok_or_else(|| Error::NotFound("No record found matching the query".to_string()))
+	}
+
+	async fn single_with_executor(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+		ordering: Vec<String>,
+	) -> crate::backends::Result<T>
+	where
+		T: serde::de::DeserializeOwned,
+	{
+		let mut queryset = self.clone();
+		queryset.order_by_fields = ordering;
+		queryset.limit = Some(1);
+		queryset
+			.all_with_executor(executor)
+			.await?
+			.into_iter()
+			.next()
+			.ok_or_else(|| Error::NotFound("No record found matching the query".to_string()))
+	}
+
+	/// Fetch rows by primary key and return them in deterministic key order.
+	pub async fn in_bulk<I>(
+		&self,
+		keys: I,
+	) -> reinhardt_core::exception::Result<BTreeMap<T::PrimaryKey, T>>
+	where
+		T: serde::de::DeserializeOwned,
+		T::PrimaryKey: DatabaseField + Ord,
+		I: IntoIterator<Item = T::PrimaryKey>,
+	{
+		let keys = keys.into_iter().collect::<BTreeSet<_>>();
+		if self.empty || keys.is_empty() {
+			return Ok(BTreeMap::new());
+		}
+		let mut conn = super::manager::get_connection().await?;
+		self.in_bulk_with_keys_db(&mut conn, keys).await
+	}
+
+	/// Fetch rows by primary key through a caller-owned ORM executor.
+	pub async fn in_bulk_with_db<E, I>(
+		&self,
+		conn: &mut E,
+		keys: I,
+	) -> reinhardt_core::exception::Result<BTreeMap<T::PrimaryKey, T>>
+	where
+		T: serde::de::DeserializeOwned,
+		T::PrimaryKey: DatabaseField + Ord,
+		E: OrmExecutor,
+		I: IntoIterator<Item = T::PrimaryKey>,
+	{
+		let keys = keys.into_iter().collect::<BTreeSet<_>>();
+		if self.empty || keys.is_empty() {
+			return Ok(BTreeMap::new());
+		}
+		self.in_bulk_with_keys_db(conn, keys).await
+	}
+
+	/// Fetch rows by primary key through an active transaction executor.
+	pub async fn in_bulk_with_executor<I>(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+		keys: I,
+	) -> crate::backends::Result<BTreeMap<T::PrimaryKey, T>>
+	where
+		T: serde::de::DeserializeOwned,
+		T::PrimaryKey: DatabaseField + Ord,
+		I: IntoIterator<Item = T::PrimaryKey>,
+	{
+		let keys = keys.into_iter().collect::<BTreeSet<_>>();
+		if self.empty || keys.is_empty() {
+			return Ok(BTreeMap::new());
+		}
+		self.in_bulk_with_keys_executor(executor, keys).await
+	}
+
+	/// Fetch rows by a metadata-proven unique field in deterministic key order.
+	pub async fn in_bulk_by<K, I>(
+		&self,
+		unique_field: UniqueFieldRef<T, K>,
+		keys: I,
+	) -> reinhardt_core::exception::Result<BTreeMap<K, T>>
+	where
+		T: serde::de::DeserializeOwned,
+		K: DatabaseField + Ord,
+		I: IntoIterator<Item = K>,
+	{
+		let keys = keys.into_iter().collect::<BTreeSet<_>>();
+		if self.empty || keys.is_empty() {
+			return Ok(BTreeMap::new());
+		}
+		let getter = Self::unique_getter(&unique_field)?;
+		let mut conn = super::manager::get_connection().await?;
+		self.in_bulk_by_keys_db(&mut conn, unique_field, getter, keys)
+			.await
+	}
+
+	/// Fetch rows by a metadata-proven unique field through a caller-owned ORM executor.
+	pub async fn in_bulk_by_with_db<E, K, I>(
+		&self,
+		conn: &mut E,
+		unique_field: UniqueFieldRef<T, K>,
+		keys: I,
+	) -> reinhardt_core::exception::Result<BTreeMap<K, T>>
+	where
+		T: serde::de::DeserializeOwned,
+		E: OrmExecutor,
+		K: DatabaseField + Ord,
+		I: IntoIterator<Item = K>,
+	{
+		let keys = keys.into_iter().collect::<BTreeSet<_>>();
+		if self.empty || keys.is_empty() {
+			return Ok(BTreeMap::new());
+		}
+		let getter = Self::unique_getter(&unique_field)?;
+		self.in_bulk_by_keys_db(conn, unique_field, getter, keys)
+			.await
+	}
+
+	/// Fetch rows by a metadata-proven unique field through an active transaction executor.
+	pub async fn in_bulk_by_with_executor<K, I>(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+		unique_field: UniqueFieldRef<T, K>,
+		keys: I,
+	) -> crate::backends::Result<BTreeMap<K, T>>
+	where
+		T: serde::de::DeserializeOwned,
+		K: DatabaseField + Ord,
+		I: IntoIterator<Item = K>,
+	{
+		let keys = keys.into_iter().collect::<BTreeSet<_>>();
+		if self.empty || keys.is_empty() {
+			return Ok(BTreeMap::new());
+		}
+		let getter = Self::unique_getter(&unique_field)?;
+		self.in_bulk_by_keys_executor(executor, unique_field, getter, keys)
+			.await
+	}
+
+	fn unique_getter<K>(
+		unique_field: &UniqueFieldRef<T, K>,
+	) -> reinhardt_core::exception::Result<fn(&T) -> Option<K>>
+	where
+		K: DatabaseField,
+	{
+		unique_field.getter().ok_or_else(|| {
+			Error::Validation(format!(
+				"QuerySet::in_bulk_by requires a generated getter for unique field `{}`",
+				unique_field.name()
+			))
+		})
+	}
+
+	async fn in_bulk_with_keys_db<E>(
+		&self,
+		conn: &mut E,
+		keys: BTreeSet<T::PrimaryKey>,
+	) -> reinhardt_core::exception::Result<BTreeMap<T::PrimaryKey, T>>
+	where
+		T: serde::de::DeserializeOwned,
+		T::PrimaryKey: DatabaseField + Ord,
+		E: OrmExecutor,
+	{
+		let filter = super::expressions::FieldRef::<T, T::PrimaryKey>::new(T::primary_key_column())
+			.is_in(keys);
+		let rows = self.clone().filter(filter).all_with_db(conn).await?;
+		Ok(rows
+			.into_iter()
+			.filter_map(|model| model.primary_key().map(|key| (key, model)))
+			.collect())
+	}
+
+	async fn in_bulk_with_keys_executor(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+		keys: BTreeSet<T::PrimaryKey>,
+	) -> crate::backends::Result<BTreeMap<T::PrimaryKey, T>>
+	where
+		T: serde::de::DeserializeOwned,
+		T::PrimaryKey: DatabaseField + Ord,
+	{
+		let filter = super::expressions::FieldRef::<T, T::PrimaryKey>::new(T::primary_key_column())
+			.is_in(keys);
+		let rows = self
+			.clone()
+			.filter(filter)
+			.all_with_executor(executor)
+			.await?;
+		Ok(rows
+			.into_iter()
+			.filter_map(|model| model.primary_key().map(|key| (key, model)))
+			.collect())
+	}
+
+	async fn in_bulk_by_keys_db<E, K>(
+		&self,
+		conn: &mut E,
+		unique_field: UniqueFieldRef<T, K>,
+		getter: fn(&T) -> Option<K>,
+		keys: BTreeSet<K>,
+	) -> reinhardt_core::exception::Result<BTreeMap<K, T>>
+	where
+		T: serde::de::DeserializeOwned,
+		E: OrmExecutor,
+		K: DatabaseField + Ord,
+	{
+		let rows = self
+			.clone()
+			.filter(unique_field.is_in(keys))
+			.all_with_db(conn)
+			.await?;
+		Ok(rows
+			.into_iter()
+			.filter_map(|model| getter(&model).map(|key| (key, model)))
+			.collect())
+	}
+
+	async fn in_bulk_by_keys_executor<K>(
+		&self,
+		executor: &mut dyn super::connection::TransactionExecutor,
+		unique_field: UniqueFieldRef<T, K>,
+		getter: fn(&T) -> Option<K>,
+		keys: BTreeSet<K>,
+	) -> crate::backends::Result<BTreeMap<K, T>>
+	where
+		T: serde::de::DeserializeOwned,
+		K: DatabaseField + Ord,
+	{
+		let rows = self
+			.clone()
+			.filter(unique_field.is_in(keys))
+			.all_with_executor(executor)
+			.await?;
+		Ok(rows
+			.into_iter()
+			.filter_map(|model| getter(&model).map(|key| (key, model)))
+			.collect())
 	}
 
 	/// Execute the queryset and return a single matching record
@@ -5906,6 +6401,12 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		if self.empty {
+			return Err(reinhardt_core::exception::Error::NotFound(
+				"No record found matching the query".to_string(),
+			));
+		}
+
 		let mut conn = super::manager::get_connection().await?;
 		self.get_with_db(&mut conn).await
 	}
@@ -5947,6 +6448,10 @@ where
 		T: serde::de::DeserializeOwned,
 		E: OrmExecutor,
 	{
+		if self.empty {
+			return Ok(Vec::new());
+		}
+
 		let stmt = if !self.has_select_related() {
 			let mut stmt = Query::select();
 			self.apply_model_from(&mut stmt);
@@ -6054,6 +6559,10 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		if self.empty {
+			return Ok(Vec::new());
+		}
+
 		let stmt = self.build_select_statement().map_err(executor_error)?;
 		let (sql, values) = Self::build_select_for_backend(&stmt, Self::executor_backend(executor));
 		let param_samples = values
@@ -6089,6 +6598,10 @@ where
 		&self,
 		executor: &mut dyn super::connection::TransactionExecutor,
 	) -> Result<usize, crate::backends::error::DatabaseError> {
+		if self.empty {
+			return Ok(0);
+		}
+
 		let stmt = self.count_select_query().map_err(executor_error)?;
 		let (sql, values) = Self::build_select_for_backend(&stmt, Self::executor_backend(executor));
 		let params = super::execution::convert_values(values);
@@ -6108,6 +6621,10 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		if self.empty {
+			return Ok(Vec::new());
+		}
+
 		let mut queryset = self.clone();
 		queryset.limit = Some(queryset.limit.map_or(2, |limit| limit.min(2)));
 		queryset.all_with_executor(executor).await
@@ -6151,6 +6668,12 @@ where
 		T: serde::de::DeserializeOwned,
 		E: OrmExecutor,
 	{
+		if self.empty {
+			return Err(reinhardt_core::exception::Error::NotFound(
+				"No record found matching the query".to_string(),
+			));
+		}
+
 		let results = self.all_with_db(conn).await?;
 		match results.len() {
 			0 => Err(reinhardt_core::exception::Error::NotFound(
@@ -6220,6 +6743,10 @@ where
 		T: serde::de::DeserializeOwned,
 		E: OrmExecutor,
 	{
+		if self.empty {
+			return Ok(None);
+		}
+
 		let mut results = self.all_with_db(conn).await?;
 		Ok(results.drain(..).next())
 	}
@@ -6266,6 +6793,10 @@ where
 	/// # }
 	/// ```
 	pub async fn count(&self) -> reinhardt_core::exception::Result<usize> {
+		if self.empty {
+			return Ok(0);
+		}
+
 		let mut conn = super::manager::get_connection().await?;
 		self.count_with_db(&mut conn).await
 	}
@@ -6275,6 +6806,10 @@ where
 	where
 		E: OrmExecutor,
 	{
+		if self.empty {
+			return Ok(0);
+		}
+
 		let stmt = self.count_select_query()?;
 		let (sql, values) = Self::build_select_for_backend(&stmt, conn.backend());
 		let param_samples = values
@@ -6410,6 +6945,10 @@ where
 	/// # }
 	/// ```
 	pub async fn exists(&self) -> reinhardt_core::exception::Result<bool> {
+		if self.empty {
+			return Ok(false);
+		}
+
 		let mut conn = super::manager::get_connection().await?;
 		self.exists_with_db(&mut conn).await
 	}
@@ -6419,6 +6958,10 @@ where
 	where
 		E: OrmExecutor,
 	{
+		if self.empty {
+			return Ok(false);
+		}
+
 		Ok(self.count_with_db(conn).await? > 0)
 	}
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -521,12 +521,12 @@ impl FieldAssignment {
 	}
 }
 
-impl<M, T, V> From<(super::expressions::FieldRef<M, T>, V)> for FieldAssignment
+impl<M, T, Origin, V> From<(super::expressions::FieldRef<M, T, Origin>, V)> for FieldAssignment
 where
 	T: DatabaseField,
 	V: IntoFieldValue<T>,
 {
-	fn from((field, value): (super::expressions::FieldRef<M, T>, V)) -> Self {
+	fn from((field, value): (super::expressions::FieldRef<M, T, Origin>, V)) -> Self {
 		Self {
 			field: field.name().to_owned(),
 			value: UpdateValue::Typed(value.into_field_value()),
@@ -6254,11 +6254,17 @@ where
 			| super::connection::DatabaseBackend::MySql => 65_535,
 		};
 		let limit = parameter_limit.saturating_sub(reserved_binds).max(1);
-		let mut remaining = keys.into_iter().collect::<Vec<_>>();
-		let mut batches = Vec::new();
-		while !remaining.is_empty() {
-			let count = remaining.len().min(limit);
-			batches.push(remaining.drain(..count).collect());
+		let mut batches = Vec::with_capacity(keys.len().div_ceil(limit));
+		let mut batch = Vec::with_capacity(limit);
+		for key in keys {
+			batch.push(key);
+			if batch.len() == limit {
+				batches.push(batch);
+				batch = Vec::with_capacity(limit);
+			}
+		}
+		if !batch.is_empty() {
+			batches.push(batch);
 		}
 		batches
 	}
@@ -6422,7 +6428,11 @@ where
 		T::PrimaryKey: DatabaseField + Ord,
 		E: OrmExecutor,
 	{
-		let field = super::expressions::FieldRef::<T, T::PrimaryKey>::new(T::primary_key_column());
+		let field = super::expressions::FieldRef::<
+			T,
+			T::PrimaryKey,
+			super::expressions::UnverifiedModelField,
+		>::new(T::primary_key_column());
 		let reserved_binds = self.select_bind_count(conn.backend(), conn.is_cockroachdb())?;
 		let mut result = BTreeMap::new();
 		for keys in Self::bulk_key_batches(keys, conn.backend(), reserved_binds) {
@@ -6452,9 +6462,12 @@ where
 		let reserved_binds = self.select_bind_count(backend, executor.is_cockroachdb())?;
 		let mut result = BTreeMap::new();
 		for keys in Self::bulk_key_batches(keys, backend, reserved_binds) {
-			let filter =
-				super::expressions::FieldRef::<T, T::PrimaryKey>::new(T::primary_key_column())
-					.is_in(keys);
+			let filter = super::expressions::FieldRef::<
+				T,
+				T::PrimaryKey,
+				super::expressions::UnverifiedModelField,
+			>::new(T::primary_key_column())
+			.is_in(keys);
 			let rows = self
 				.clone()
 				.filter(filter)
@@ -9157,7 +9170,7 @@ mod tests {
 	use serde::{Deserialize, Serialize};
 	#[cfg(feature = "pgvector")]
 	use std::borrow::Cow;
-	use std::collections::HashMap;
+	use std::collections::{BTreeSet, HashMap};
 	#[cfg(feature = "pgvector")]
 	use std::fmt;
 
@@ -9947,8 +9960,11 @@ mod tests {
 				.cosine_distance(typed_vector_target(&[1.0, 2.0, 3.0]))
 				.lt(0.25),
 		);
-		let assignment_field =
-			crate::orm::expressions::FieldRef::<TestUser, crate::orm::Vector<3>>::new("embedding");
+		let assignment_field = crate::orm::expressions::FieldRef::<
+			TestUser,
+			crate::orm::Vector<3>,
+			crate::orm::expressions::UnverifiedModelField,
+		>::new("embedding");
 		let mut executor = PgvectorUpdateErrorExecutor { code, message };
 
 		let error = queryset
@@ -9979,8 +9995,11 @@ mod tests {
 				.cosine_distance(typed_vector_target(&[1.0, 2.0, 3.0]))
 				.lt(0.25),
 		);
-		let assignment_field =
-			crate::orm::expressions::FieldRef::<TestUser, crate::orm::Vector<3>>::new("embedding");
+		let assignment_field = crate::orm::expressions::FieldRef::<
+			TestUser,
+			crate::orm::Vector<3>,
+			crate::orm::expressions::UnverifiedModelField,
+		>::new("embedding");
 
 		let (sql, params) = queryset
 			.update_fields_sql([(assignment_field, typed_vector_target(&[4.0, 5.0, 6.0]))])
@@ -10137,40 +10156,49 @@ mod tests {
 		}
 
 		const fn field_id() -> crate::orm::expressions::FieldRef<TestUser, i64> {
-			crate::orm::expressions::FieldRef::new("id")
+			// SAFETY: this test accessor names TestUser's persisted `id` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("id") }
 		}
 
 		const fn field_username() -> crate::orm::expressions::FieldRef<TestUser, String> {
-			crate::orm::expressions::FieldRef::new("username")
+			// SAFETY: this test accessor names TestUser's persisted `username` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("username") }
 		}
 
 		const fn field_email() -> crate::orm::expressions::FieldRef<TestUser, String> {
-			crate::orm::expressions::FieldRef::new("email")
+			// SAFETY: this test accessor names TestUser's persisted `email` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("email") }
 		}
 
 		const fn field_full_name() -> crate::orm::expressions::FieldRef<TestUser, String> {
-			crate::orm::expressions::FieldRef::new("full_name")
+			// SAFETY: this test accessor names TestUser's persisted `full_name` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("full_name") }
 		}
 
 		const fn field_display_name() -> crate::orm::expressions::FieldRef<TestUser, String> {
-			crate::orm::expressions::FieldRef::new("display_name")
+			// SAFETY: this test accessor names TestUser's persisted `display_name` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("display_name") }
 		}
 
 		const fn field_created_at()
 		-> crate::orm::expressions::FieldRef<TestUser, chrono::DateTime<chrono::Utc>> {
-			crate::orm::expressions::FieldRef::new("created_at")
+			// SAFETY: this test accessor names TestUser's persisted `created_at` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("created_at") }
 		}
 
 		const fn field_tags() -> crate::orm::expressions::FieldRef<TestUser, Vec<String>> {
-			crate::orm::expressions::FieldRef::new("tags")
+			// SAFETY: this test accessor names TestUser's persisted `tags` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("tags") }
 		}
 
 		const fn field_metadata() -> crate::orm::expressions::FieldRef<TestUser, String> {
-			crate::orm::expressions::FieldRef::new("metadata")
+			// SAFETY: this test accessor names TestUser's persisted `metadata` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("metadata") }
 		}
 
 		const fn field_active_period() -> crate::orm::expressions::FieldRef<TestUser, String> {
-			crate::orm::expressions::FieldRef::new("active_period")
+			// SAFETY: this test accessor names TestUser's persisted `active_period` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("active_period") }
 		}
 	}
 
@@ -10348,11 +10376,13 @@ mod tests {
 	impl TestCorpusFile {
 		const fn field_normalized_path() -> crate::orm::expressions::FieldRef<TestCorpusFile, String>
 		{
-			crate::orm::expressions::FieldRef::new("normalized_path")
+			// SAFETY: this test accessor names TestCorpusFile's persisted `normalized_path` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("normalized_path") }
 		}
 
 		const fn field_email() -> crate::orm::expressions::FieldRef<TestCorpusFile, String> {
-			crate::orm::expressions::FieldRef::new("email")
+			// SAFETY: this test accessor names TestCorpusFile's persisted `email` field.
+			unsafe { crate::orm::expressions::FieldRef::from_model_field("email") }
 		}
 	}
 
@@ -10573,7 +10603,10 @@ mod tests {
 			TestUserCorpusFile,
 		>()
 		.then::<TestCorpusFileProject, TestProject>()
-		.field(crate::orm::expressions::FieldRef::<TestProject, String>::new("name"))
+		.field(unsafe {
+			// SAFETY: `name` is a persisted TestProject field in this query fixture.
+			crate::orm::expressions::FieldRef::<TestProject, String>::from_model_field("name")
+		})
 		.eq("reinhardt")
 	}
 
@@ -10694,6 +10727,20 @@ mod tests {
 				multiplicity: crate::orm::relations::RelationMultiplicity::Multiple,
 			}]
 		}
+	}
+
+	#[test]
+	fn bulk_key_batches_split_sqlite_keys_without_reordering() {
+		// Arrange
+		let keys = (0_i64..901).collect::<BTreeSet<_>>();
+
+		// Act
+		let batches = QuerySet::<TestUser>::bulk_key_batches(keys, DatabaseBackend::Sqlite, 0);
+
+		// Assert
+		assert_eq!(batches.len(), 2);
+		assert_eq!(batches[0], (0_i64..900).collect::<Vec<_>>());
+		assert_eq!(batches[1], vec![900]);
 	}
 
 	#[test]
@@ -11382,7 +11429,10 @@ mod tests {
 				TestUserCorpusFile,
 			>()
 			.then::<TestCorpusFileProject, TestProject>()
-			.field(crate::orm::expressions::FieldRef::<TestProject, String>::new("name"))
+			.field(unsafe {
+				// SAFETY: `name` is a persisted TestProject field in this query fixture.
+				crate::orm::expressions::FieldRef::<TestProject, String>::from_model_field("name")
+			})
 			.eq("reinhardt");
 
 		let sql = QuerySet::<TestUser>::new()
@@ -11485,14 +11535,16 @@ mod tests {
 
 	#[test]
 	fn test_aliasless_manual_joins_rebase_typed_filter_aliases() {
-		let make_filter =
-			|| {
-				crate::orm::relations::RelationPath::<TestProjects, TestProjects>::from_descriptor::<
+		let make_filter = || {
+			crate::orm::relations::RelationPath::<TestProjects, TestProjects>::from_descriptor::<
 				TestProjectsChildren,
 			>()
-			.field(crate::orm::expressions::FieldRef::<TestProjects, i64>::new("id"))
+			.field(unsafe {
+				// SAFETY: `id` is a persisted TestProjects field in this query fixture.
+				crate::orm::expressions::FieldRef::<TestProjects, i64>::from_model_field("id")
+			})
 			.eq(1)
-			};
+		};
 
 		let sql = QuerySet::<TestProjects>::new()
 			.filter(make_filter())
@@ -12280,7 +12332,10 @@ mod tests {
 			crate::orm::relations::RelationPath::<TestUser, TestProject>::from_descriptor::<
 				TestUserProjects,
 			>()
-			.field(crate::orm::expressions::FieldRef::<TestProject, String>::new("name"))
+			.field(unsafe {
+				// SAFETY: `name` is a persisted TestProject field in this query fixture.
+				crate::orm::expressions::FieldRef::<TestProject, String>::from_model_field("name")
+			})
 			.icontains("rust");
 
 		let sql = QuerySet::<TestUser>::new()
@@ -12300,7 +12355,10 @@ mod tests {
 			crate::orm::relations::RelationPath::<TestMembership, TestProject>::from_descriptor::<
 				TestMembershipProjects,
 			>()
-			.field(crate::orm::expressions::FieldRef::<TestProject, String>::new("name"))
+			.field(unsafe {
+				// SAFETY: `name` is a persisted TestProject field in this query fixture.
+				crate::orm::expressions::FieldRef::<TestProject, String>::from_model_field("name")
+			})
 			.icontains("rust");
 
 		let sql = QuerySet::<TestMembership>::new()

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -6196,6 +6196,7 @@ where
 		T: serde::de::DeserializeOwned,
 		E: OrmExecutor,
 	{
+		self.ensure_unsliced_retrieval()?;
 		let mut queryset = self.clone();
 		queryset.order_by_fields = ordering;
 		queryset.limit = Some(1);
@@ -6215,6 +6216,7 @@ where
 	where
 		T: serde::de::DeserializeOwned,
 	{
+		self.ensure_unsliced_retrieval().map_err(executor_error)?;
 		let mut queryset = self.clone();
 		queryset.order_by_fields = ordering;
 		queryset.limit = Some(1);
@@ -6224,6 +6226,33 @@ where
 			.into_iter()
 			.next()
 			.ok_or_else(|| Error::NotFound("No record found matching the query".to_string()))
+	}
+
+	fn ensure_unsliced_retrieval(&self) -> reinhardt_core::exception::Result<()> {
+		if self.limit.is_some() || self.offset.is_some() {
+			return Err(Error::Validation(
+				"QuerySet retrieval helpers cannot be called on a sliced queryset".to_string(),
+			));
+		}
+		Ok(())
+	}
+
+	fn bulk_key_batches<K>(
+		keys: BTreeSet<K>,
+		backend: super::connection::DatabaseBackend,
+	) -> Vec<Vec<K>> {
+		let limit = match backend {
+			super::connection::DatabaseBackend::Sqlite => 900,
+			super::connection::DatabaseBackend::Postgres
+			| super::connection::DatabaseBackend::MySql => 65_535,
+		};
+		let mut remaining = keys.into_iter().collect::<Vec<_>>();
+		let mut batches = Vec::new();
+		while !remaining.is_empty() {
+			let count = remaining.len().min(limit);
+			batches.push(remaining.drain(..count).collect());
+		}
+		batches
 	}
 
 	/// Fetch rows by primary key and return them in deterministic key order.
@@ -6236,6 +6265,7 @@ where
 		T::PrimaryKey: DatabaseField + Ord,
 		I: IntoIterator<Item = T::PrimaryKey>,
 	{
+		self.ensure_unsliced_retrieval()?;
 		let keys = keys.into_iter().collect::<BTreeSet<_>>();
 		if self.empty || keys.is_empty() {
 			return Ok(BTreeMap::new());
@@ -6256,6 +6286,7 @@ where
 		E: OrmExecutor,
 		I: IntoIterator<Item = T::PrimaryKey>,
 	{
+		self.ensure_unsliced_retrieval()?;
 		let keys = keys.into_iter().collect::<BTreeSet<_>>();
 		if self.empty || keys.is_empty() {
 			return Ok(BTreeMap::new());
@@ -6274,6 +6305,7 @@ where
 		T::PrimaryKey: DatabaseField + Ord,
 		I: IntoIterator<Item = T::PrimaryKey>,
 	{
+		self.ensure_unsliced_retrieval().map_err(executor_error)?;
 		let keys = keys.into_iter().collect::<BTreeSet<_>>();
 		if self.empty || keys.is_empty() {
 			return Ok(BTreeMap::new());
@@ -6292,6 +6324,7 @@ where
 		K: DatabaseField + Ord,
 		I: IntoIterator<Item = K>,
 	{
+		self.ensure_unsliced_retrieval()?;
 		let keys = keys.into_iter().collect::<BTreeSet<_>>();
 		if self.empty || keys.is_empty() {
 			return Ok(BTreeMap::new());
@@ -6315,6 +6348,7 @@ where
 		K: DatabaseField + Ord,
 		I: IntoIterator<Item = K>,
 	{
+		self.ensure_unsliced_retrieval()?;
 		let keys = keys.into_iter().collect::<BTreeSet<_>>();
 		if self.empty || keys.is_empty() {
 			return Ok(BTreeMap::new());
@@ -6336,6 +6370,7 @@ where
 		K: DatabaseField + Ord,
 		I: IntoIterator<Item = K>,
 	{
+		self.ensure_unsliced_retrieval().map_err(executor_error)?;
 		let keys = keys.into_iter().collect::<BTreeSet<_>>();
 		if self.empty || keys.is_empty() {
 			return Ok(BTreeMap::new());
@@ -6369,13 +6404,20 @@ where
 		T::PrimaryKey: DatabaseField + Ord,
 		E: OrmExecutor,
 	{
-		let filter = super::expressions::FieldRef::<T, T::PrimaryKey>::new(T::primary_key_column())
-			.is_in(keys);
-		let rows = self.clone().filter(filter).all_with_db(conn).await?;
-		Ok(rows
-			.into_iter()
-			.filter_map(|model| model.primary_key().map(|key| (key, model)))
-			.collect())
+		let field = super::expressions::FieldRef::<T, T::PrimaryKey>::new(T::primary_key_column());
+		let mut result = BTreeMap::new();
+		for keys in Self::bulk_key_batches(keys, conn.backend()) {
+			let rows = self
+				.clone()
+				.filter(field.is_in(keys))
+				.all_with_db(conn)
+				.await?;
+			result.extend(
+				rows.into_iter()
+					.filter_map(|model| model.primary_key().map(|key| (key, model))),
+			);
+		}
+		Ok(result)
 	}
 
 	async fn in_bulk_with_keys_executor(
@@ -6387,17 +6429,22 @@ where
 		T: serde::de::DeserializeOwned,
 		T::PrimaryKey: DatabaseField + Ord,
 	{
-		let filter = super::expressions::FieldRef::<T, T::PrimaryKey>::new(T::primary_key_column())
-			.is_in(keys);
-		let rows = self
-			.clone()
-			.filter(filter)
-			.all_with_executor(executor)
-			.await?;
-		Ok(rows
-			.into_iter()
-			.filter_map(|model| model.primary_key().map(|key| (key, model)))
-			.collect())
+		let mut result = BTreeMap::new();
+		for keys in Self::bulk_key_batches(keys, Self::executor_backend(executor)) {
+			let filter =
+				super::expressions::FieldRef::<T, T::PrimaryKey>::new(T::primary_key_column())
+					.is_in(keys);
+			let rows = self
+				.clone()
+				.filter(filter)
+				.all_with_executor(executor)
+				.await?;
+			result.extend(
+				rows.into_iter()
+					.filter_map(|model| model.primary_key().map(|key| (key, model))),
+			);
+		}
+		Ok(result)
 	}
 
 	async fn in_bulk_by_keys_db<E, K>(
@@ -6412,15 +6459,19 @@ where
 		E: OrmExecutor,
 		K: DatabaseField + Ord,
 	{
-		let rows = self
-			.clone()
-			.filter(unique_field.is_in(keys))
-			.all_with_db(conn)
-			.await?;
-		Ok(rows
-			.into_iter()
-			.filter_map(|model| getter(&model).map(|key| (key, model)))
-			.collect())
+		let mut result = BTreeMap::new();
+		for keys in Self::bulk_key_batches(keys, conn.backend()) {
+			let rows = self
+				.clone()
+				.filter(unique_field.is_in(keys))
+				.all_with_db(conn)
+				.await?;
+			result.extend(
+				rows.into_iter()
+					.filter_map(|model| getter(&model).map(|key| (key, model))),
+			);
+		}
+		Ok(result)
 	}
 
 	async fn in_bulk_by_keys_executor<K>(
@@ -6434,15 +6485,19 @@ where
 		T: serde::de::DeserializeOwned,
 		K: DatabaseField + Ord,
 	{
-		let rows = self
-			.clone()
-			.filter(unique_field.is_in(keys))
-			.all_with_executor(executor)
-			.await?;
-		Ok(rows
-			.into_iter()
-			.filter_map(|model| getter(&model).map(|key| (key, model)))
-			.collect())
+		let mut result = BTreeMap::new();
+		for keys in Self::bulk_key_batches(keys, Self::executor_backend(executor)) {
+			let rows = self
+				.clone()
+				.filter(unique_field.is_in(keys))
+				.all_with_executor(executor)
+				.await?;
+			result.extend(
+				rows.into_iter()
+					.filter_map(|model| getter(&model).map(|key| (key, model))),
+			);
+		}
+		Ok(result)
 	}
 
 	/// Execute the queryset and return a single matching record
@@ -7198,6 +7253,9 @@ where
 		I: IntoIterator<Item = A>,
 		A: Into<FieldAssignment>,
 	{
+		if self.empty {
+			return Ok(0);
+		}
 		let mut conn = super::manager::get_connection().await?;
 		self.update_fields_with_conn(&mut conn, values).await
 	}
@@ -7213,6 +7271,9 @@ where
 		I: IntoIterator<Item = A>,
 		A: Into<FieldAssignment>,
 	{
+		if self.empty {
+			return Ok(0);
+		}
 		let stmt = self.update_fields_query(values)?;
 		let context = super::execution::pgvector_context_for_update(&stmt);
 		let (sql, values) =

--- a/crates/reinhardt-db/src/orm/relations/traversal.rs
+++ b/crates/reinhardt-db/src/orm/relations/traversal.rs
@@ -185,9 +185,9 @@ impl<Root: Model, Target: Model> RelationPath<Root, Target> {
 	}
 
 	/// Select a field on the target model through this relation path.
-	pub fn field<Value>(
+	pub fn field<Value, Origin>(
 		self,
-		field: FieldRef<Target, Value>,
+		field: FieldRef<Target, Value, Origin>,
 	) -> RelatedFieldRef<Root, Target, Value> {
 		RelatedFieldRef::new(self, field.name())
 	}

--- a/crates/reinhardt-db/tests/orm_queryset_builder.rs
+++ b/crates/reinhardt-db/tests/orm_queryset_builder.rs
@@ -1461,16 +1461,11 @@ fn test_none_keeps_builder_chains_empty_and_statement_inspection_deterministic()
 		.to_sql()
 		.expect("empty queryset SQL should compile");
 
-	assert_eq!(before_none, after_none);
-	assert!(
-		before_none.contains("WHERE 1 = 0"),
-		"SQL was: {before_none}"
+	assert_eq!(
+		before_none,
+		"SELECT * FROM \"products\" WHERE 1 = 0 ORDER BY \"price\" DESC LIMIT 3"
 	);
-	assert!(
-		before_none.contains("ORDER BY \"price\" DESC"),
-		"SQL was: {before_none}"
-	);
-	assert!(before_none.contains("LIMIT 3"), "SQL was: {before_none}");
+	assert_eq!(after_none, before_none);
 }
 
 #[tokio::test]

--- a/crates/reinhardt-db/tests/orm_queryset_builder.rs
+++ b/crates/reinhardt-db/tests/orm_queryset_builder.rs
@@ -3,6 +3,8 @@
 //! Tests the Django-style QuerySet builder pattern for constructing
 //! SQL queries with filters, ordering, pagination, and DML operations.
 
+use reinhardt_core::exception::Error;
+use reinhardt_db::orm::expressions::UniqueFieldRef;
 use reinhardt_db::orm::model::FieldSelector;
 use reinhardt_db::orm::query::{Filter, FilterCondition, OrmQuery, UpdateValue};
 use reinhardt_db::orm::{FilterOperator, FilterValue, Manager, Model, QuerySet};
@@ -54,6 +56,15 @@ impl Model for TestProduct {
 	fn new_fields() -> Self::Fields {
 		TestProductFields
 	}
+}
+
+fn test_product_name_unique() -> UniqueFieldRef<TestProduct, String> {
+	fn getter(product: &TestProduct) -> Option<String> {
+		Some(product.name.clone())
+	}
+
+	// SAFETY: The fixture models an application-level unique product name for typed query tests.
+	unsafe { UniqueFieldRef::from_model_field_with_getter("name", getter) }
 }
 
 // -- Basic Filter Tests --
@@ -1423,4 +1434,70 @@ fn test_paginate_page_zero_saturates() {
 		sql
 	);
 	assert!(sql.contains("10"), "Page size should be 10: {}", sql);
+}
+
+#[rstest]
+fn test_none_keeps_builder_chains_empty_and_statement_inspection_deterministic() {
+	let before_none = QuerySet::<TestProduct>::new()
+		.filter(Filter::new(
+			"category",
+			FilterOperator::Eq,
+			FilterValue::String("electronics".to_string()),
+		))
+		.order_by(&["-price"])
+		.limit(3)
+		.none()
+		.to_sql()
+		.expect("empty queryset SQL should compile");
+	let after_none = QuerySet::<TestProduct>::new()
+		.none()
+		.filter(Filter::new(
+			"category",
+			FilterOperator::Eq,
+			FilterValue::String("electronics".to_string()),
+		))
+		.order_by(&["-price"])
+		.limit(3)
+		.to_sql()
+		.expect("empty queryset SQL should compile");
+
+	assert_eq!(before_none, after_none);
+	assert!(
+		before_none.contains("WHERE 1 = 0"),
+		"SQL was: {before_none}"
+	);
+	assert!(
+		before_none.contains("ORDER BY \"price\" DESC"),
+		"SQL was: {before_none}"
+	);
+	assert!(before_none.contains("LIMIT 3"), "SQL was: {before_none}");
+}
+
+#[tokio::test]
+async fn none_short_circuits_global_query_methods_without_a_connection() {
+	let queryset = QuerySet::<TestProduct>::new().none();
+
+	assert_eq!(queryset.all().await.unwrap(), Vec::<TestProduct>::new());
+	assert_eq!(queryset.first().await.unwrap(), None);
+	assert!(matches!(queryset.get().await, Err(Error::NotFound(_))));
+	assert_eq!(queryset.count().await.unwrap(), 0);
+	assert!(!queryset.exists().await.unwrap());
+}
+
+#[rstest]
+fn typed_unique_in_filter_compiles_to_one_bound_in_predicate() {
+	let sql = QuerySet::<TestProduct>::new()
+		.filter(test_product_name_unique().is_in(["second".to_string(), "first".to_string()]))
+		.order_by(&["-price", "category"])
+		.limit(1)
+		.to_sql()
+		.expect("typed IN query should compile");
+
+	assert!(sql.contains("\"name\" IN"), "SQL was: {sql}");
+	assert!(
+		sql.contains("ORDER BY \"price\" DESC, \"category\" ASC"),
+		"SQL was: {sql}"
+	);
+	assert!(sql.contains("LIMIT 1"), "SQL was: {sql}");
+	assert!(!sql.contains("Expr::cust"), "SQL was: {sql}");
 }

--- a/crates/reinhardt-db/tests/transaction_executor_orm.rs
+++ b/crates/reinhardt-db/tests/transaction_executor_orm.rs
@@ -705,8 +705,10 @@ async fn none_short_circuits_owned_and_transaction_executors() {
 #[tokio::test]
 async fn latest_and_earliest_use_typed_ordering_with_caller_owned_executors() {
 	let ordering = [
-		FieldRef::<Article, i64>::new("article_id").ordering(),
-		FieldRef::<Article, String>::new("article_title").ordering(),
+		// SAFETY: these columns are declared by the Article test model below.
+		unsafe { FieldRef::<Article, i64>::from_model_field("article_id") }.ordering(),
+		// SAFETY: these columns are declared by the Article test model below.
+		unsafe { FieldRef::<Article, String>::from_model_field("article_title") }.ordering(),
 	];
 	let queryset = QuerySet::<Article>::new();
 	let mut executor = RecordingExecutor::new(DatabaseBackend::Postgres)

--- a/crates/reinhardt-db/tests/transaction_executor_orm.rs
+++ b/crates/reinhardt-db/tests/transaction_executor_orm.rs
@@ -740,31 +740,18 @@ async fn latest_and_earliest_use_typed_ordering_with_caller_owned_executors() {
 		Some(2)
 	);
 	assert_eq!(executor.calls.len(), 4);
-	assert!(
-		executor.calls[0]
-			.sql
-			.contains("ORDER BY \"article_id\" DESC")
-	);
-	assert!(
-		executor.calls[1]
-			.sql
-			.contains("ORDER BY \"article_id\" ASC")
-	);
-	assert!(
-		executor.calls[2]
-			.sql
-			.contains("ORDER BY \"article_id\" DESC, \"article_title\" DESC")
-	);
-	assert!(
-		executor.calls[3]
-			.sql
-			.contains("ORDER BY \"article_id\" ASC, \"article_title\" ASC")
-	);
-	assert!(
+	assert_eq!(
 		executor
 			.calls
 			.iter()
-			.all(|call| call.sql.contains("LIMIT $1"))
+			.map(|call| call.sql.as_str())
+			.collect::<Vec<_>>(),
+		vec![
+			"SELECT * FROM \"articles\" ORDER BY \"article_id\" DESC LIMIT $1",
+			"SELECT * FROM \"articles\" ORDER BY \"article_id\" ASC LIMIT $1",
+			"SELECT * FROM \"articles\" ORDER BY \"article_id\" DESC, \"article_title\" DESC LIMIT $1",
+			"SELECT * FROM \"articles\" ORDER BY \"article_id\" ASC, \"article_title\" ASC LIMIT $1",
+		]
 	);
 	assert!(
 		executor

--- a/crates/reinhardt-db/tests/transaction_executor_orm.rs
+++ b/crates/reinhardt-db/tests/transaction_executor_orm.rs
@@ -18,11 +18,13 @@ use reinhardt_db::orm::annotation::{AnnotationValue, Expression, Value};
 use reinhardt_db::orm::composite_pk::{CompositePrimaryKey, PkValue};
 #[cfg(feature = "sqlite")]
 use reinhardt_db::orm::connection::{BackendsConnection, DatabaseConnectionLease};
-use reinhardt_db::orm::connection::{DatabaseBackend, OrmExecutor, QueryResult, QueryValue, Row};
+use reinhardt_db::orm::connection::{
+	DatabaseBackend, OrmExecutor, QueryResult, QueryValue, Row, TransactionExecutor,
+};
 use reinhardt_db::orm::custom_manager::CustomManager;
 use reinhardt_db::orm::events::{EventRegistry, EventResult, MapperEvents, set_active_registry};
 use reinhardt_db::orm::execution::{QueryExecution, SelectExecution};
-use reinhardt_db::orm::expressions::F;
+use reinhardt_db::orm::expressions::{F, FieldRef, UniqueFieldRef};
 use reinhardt_db::orm::inspection::FieldInfo;
 use reinhardt_db::orm::manager::Manager;
 use reinhardt_db::orm::model::{FieldSelector, Model};
@@ -61,6 +63,90 @@ struct RecordingExecutor {
 	fetch_one_rows: VecDeque<Row>,
 	fetch_all_rows: VecDeque<Vec<Row>>,
 	fetch_optional_rows: VecDeque<Option<Row>>,
+}
+
+#[derive(Debug)]
+struct RecordingTransactionExecutor {
+	backend: reinhardt_db::backends::types::DatabaseType,
+	calls: Vec<RecordedCall>,
+	fetch_all_rows: VecDeque<Vec<Row>>,
+}
+
+impl RecordingTransactionExecutor {
+	fn new(backend: reinhardt_db::backends::types::DatabaseType) -> Self {
+		Self {
+			backend,
+			calls: Vec::new(),
+			fetch_all_rows: VecDeque::new(),
+		}
+	}
+
+	fn with_fetch_all(mut self, rows: Vec<Row>) -> Self {
+		self.fetch_all_rows.push_back(rows);
+		self
+	}
+
+	fn record(&mut self, kind: &'static str, sql: &str, params: Vec<QueryValue>) {
+		self.calls.push(RecordedCall {
+			kind,
+			sql: sql.to_string(),
+			params,
+		});
+	}
+}
+
+#[async_trait]
+impl TransactionExecutor for RecordingTransactionExecutor {
+	fn backend(&self) -> reinhardt_db::backends::types::DatabaseType {
+		self.backend
+	}
+
+	async fn execute(
+		&mut self,
+		sql: &str,
+		params: Vec<QueryValue>,
+	) -> reinhardt_db::backends::Result<QueryResult> {
+		self.record("execute", sql, params);
+		Ok(QueryResult {
+			rows_affected: 0,
+			last_insert_id: None,
+		})
+	}
+
+	async fn fetch_one(
+		&mut self,
+		sql: &str,
+		params: Vec<QueryValue>,
+	) -> reinhardt_db::backends::Result<Row> {
+		self.record("fetch_one", sql, params);
+		Ok(Row::new())
+	}
+
+	async fn fetch_all(
+		&mut self,
+		sql: &str,
+		params: Vec<QueryValue>,
+	) -> reinhardt_db::backends::Result<Vec<Row>> {
+		self.record("fetch_all", sql, params);
+		Ok(self.fetch_all_rows.pop_front().unwrap_or_default())
+	}
+
+	async fn fetch_optional(
+		&mut self,
+		sql: &str,
+		params: Vec<QueryValue>,
+	) -> reinhardt_db::backends::Result<Option<Row>> {
+		self.record("fetch_optional", sql, params);
+		Ok(None)
+	}
+
+	async fn commit(self: Box<Self>) -> reinhardt_db::backends::Result<()> {
+		Ok(())
+	}
+
+	async fn rollback(self: Box<Self>) -> reinhardt_db::backends::Result<()> {
+		Ok(())
+	}
 }
 
 impl RecordingExecutor {
@@ -205,6 +291,10 @@ impl Model for Article {
 		"article_id"
 	}
 
+	fn latest_by_fields() -> &'static [&'static str] {
+		&["article_id"]
+	}
+
 	fn field_metadata() -> Vec<FieldInfo> {
 		vec![
 			FieldInfo {
@@ -241,6 +331,15 @@ impl Model for Article {
 			},
 		]
 	}
+}
+
+fn article_title_unique() -> UniqueFieldRef<Article, String> {
+	fn getter(article: &Article) -> Option<String> {
+		Some(article.title.clone())
+	}
+
+	// SAFETY: `article_title` is the test fixture's unique lookup column and the getter reads it.
+	unsafe { UniqueFieldRef::from_model_field_with_getter("article_title", getter) }
 }
 
 struct MarkerSource;
@@ -524,6 +623,311 @@ async fn dyn_orm_executor_saves_new_and_existing_articles() {
 			.params
 			.contains(&QueryValue::String("updated".to_string()))
 	);
+}
+
+#[tokio::test]
+async fn none_short_circuits_owned_and_transaction_executors() {
+	let queryset = QuerySet::<Article>::new()
+		.filter(Filter::new(
+			"title",
+			FilterOperator::Eq,
+			FilterValue::String("unreachable".to_string()),
+		))
+		.order_by(&["-article_id"])
+		.limit(1)
+		.none()
+		.filter(Filter::new(
+			"article_id",
+			FilterOperator::Eq,
+			FilterValue::Int(1),
+		))
+		.order_by(&["article_title"])
+		.limit(2);
+	let mut owned_executor = RecordingExecutor::new(DatabaseBackend::Postgres);
+
+	assert_eq!(
+		queryset.all_with_db(&mut owned_executor).await.unwrap(),
+		Vec::<Article>::new()
+	);
+	assert_eq!(
+		queryset.first_with_db(&mut owned_executor).await.unwrap(),
+		None
+	);
+	assert!(matches!(
+		queryset.get_with_db(&mut owned_executor).await,
+		Err(Error::NotFound(_))
+	));
+	assert_eq!(
+		queryset.count_with_db(&mut owned_executor).await.unwrap(),
+		0
+	);
+	assert!(!queryset.exists_with_db(&mut owned_executor).await.unwrap());
+	assert!(owned_executor.calls.is_empty());
+
+	let mut transaction_executor =
+		RecordingTransactionExecutor::new(reinhardt_db::backends::types::DatabaseType::Postgres);
+	assert_eq!(
+		queryset
+			.all_with_executor(&mut transaction_executor)
+			.await
+			.unwrap(),
+		Vec::<Article>::new()
+	);
+	assert_eq!(
+		queryset
+			.one_with_executor(&mut transaction_executor)
+			.await
+			.unwrap(),
+		Vec::<Article>::new()
+	);
+	assert_eq!(
+		queryset
+			.count_with_executor(&mut transaction_executor)
+			.await
+			.unwrap(),
+		0
+	);
+	assert!(transaction_executor.calls.is_empty());
+}
+
+#[tokio::test]
+async fn latest_and_earliest_use_typed_ordering_with_caller_owned_executors() {
+	let ordering = [
+		FieldRef::<Article, i64>::new("article_id").ordering(),
+		FieldRef::<Article, String>::new("article_title").ordering(),
+	];
+	let queryset = QuerySet::<Article>::new();
+	let mut executor = RecordingExecutor::new(DatabaseBackend::Postgres)
+		.with_fetch_all(vec![article_row(3, "latest")])
+		.with_fetch_all(vec![article_row(1, "earliest")])
+		.with_fetch_all(vec![article_row(4, "explicit-latest")])
+		.with_fetch_all(vec![article_row(2, "explicit-earliest")]);
+
+	assert_eq!(
+		queryset.latest_with_db(&mut executor).await.unwrap().id,
+		Some(3)
+	);
+	assert_eq!(
+		queryset.earliest_with_db(&mut executor).await.unwrap().id,
+		Some(1)
+	);
+	assert_eq!(
+		queryset
+			.latest_by_with_db(&mut executor, &ordering)
+			.await
+			.unwrap()
+			.id,
+		Some(4)
+	);
+	assert_eq!(
+		queryset
+			.earliest_by_with_db(&mut executor, &ordering)
+			.await
+			.unwrap()
+			.id,
+		Some(2)
+	);
+	assert_eq!(executor.calls.len(), 4);
+	assert!(
+		executor.calls[0]
+			.sql
+			.contains("ORDER BY \"article_id\" DESC")
+	);
+	assert!(
+		executor.calls[1]
+			.sql
+			.contains("ORDER BY \"article_id\" ASC")
+	);
+	assert!(
+		executor.calls[2]
+			.sql
+			.contains("ORDER BY \"article_id\" DESC, \"article_title\" DESC")
+	);
+	assert!(
+		executor.calls[3]
+			.sql
+			.contains("ORDER BY \"article_id\" ASC, \"article_title\" ASC")
+	);
+	assert!(
+		executor
+			.calls
+			.iter()
+			.all(|call| call.sql.contains("LIMIT 1"))
+	);
+
+	let mut transaction_executor =
+		RecordingTransactionExecutor::new(reinhardt_db::backends::types::DatabaseType::Postgres)
+			.with_fetch_all(vec![article_row(3, "latest")])
+			.with_fetch_all(vec![article_row(1, "earliest")])
+			.with_fetch_all(vec![article_row(4, "explicit-latest")])
+			.with_fetch_all(vec![article_row(2, "explicit-earliest")]);
+	assert_eq!(
+		queryset
+			.latest_with_executor(&mut transaction_executor)
+			.await
+			.unwrap()
+			.id,
+		Some(3)
+	);
+	assert_eq!(
+		queryset
+			.earliest_with_executor(&mut transaction_executor)
+			.await
+			.unwrap()
+			.id,
+		Some(1)
+	);
+	assert_eq!(
+		queryset
+			.latest_by_with_executor(&mut transaction_executor, &ordering)
+			.await
+			.unwrap()
+			.id,
+		Some(4)
+	);
+	assert_eq!(
+		queryset
+			.earliest_by_with_executor(&mut transaction_executor, &ordering)
+			.await
+			.unwrap()
+			.id,
+		Some(2)
+	);
+	assert_eq!(transaction_executor.calls.len(), 4);
+}
+
+#[tokio::test]
+async fn retrieval_helpers_return_not_found_or_validation_without_extra_queries() {
+	let mut executor = RecordingExecutor::new(DatabaseBackend::Postgres).with_fetch_all(Vec::new());
+	assert!(matches!(
+		QuerySet::<Article>::new()
+			.latest_with_db(&mut executor)
+			.await,
+		Err(Error::NotFound(_))
+	));
+	assert_eq!(executor.calls.len(), 1);
+
+	let mut metadata_free_executor = RecordingExecutor::new(DatabaseBackend::Postgres);
+	assert!(matches!(
+		QuerySet::<MetadataFreeArticle>::new()
+			.latest_with_db(&mut metadata_free_executor)
+			.await,
+		Err(Error::Validation(_))
+	));
+	assert!(metadata_free_executor.calls.is_empty());
+	assert!(matches!(
+		QuerySet::<Article>::new()
+			.latest_by_with_db(&mut metadata_free_executor, &[])
+			.await,
+		Err(Error::Validation(_))
+	));
+	assert!(matches!(
+		QuerySet::<MetadataFreeArticle>::new().none().latest().await,
+		Err(Error::Validation(_))
+	));
+	assert!(matches!(
+		QuerySet::<Article>::new().none().latest_by(&[]).await,
+		Err(Error::Validation(_))
+	));
+	assert!(metadata_free_executor.calls.is_empty());
+}
+
+#[tokio::test]
+async fn in_bulk_uses_one_typed_in_query_and_returns_ordered_maps() {
+	let queryset = QuerySet::<Article>::new();
+	let mut executor = RecordingExecutor::new(DatabaseBackend::Postgres)
+		.with_fetch_all(vec![article_row(3, "third"), article_row(1, "first")])
+		.with_fetch_all(vec![article_row(2, "second"), article_row(1, "first")]);
+	let primary = queryset
+		.in_bulk_with_db(&mut executor, [3_i64, 1, 3, 99])
+		.await
+		.unwrap();
+	assert_eq!(primary.keys().copied().collect::<Vec<_>>(), vec![1, 3]);
+	let unique = queryset
+		.in_bulk_by_with_db(
+			&mut executor,
+			article_title_unique(),
+			[
+				"second".to_string(),
+				"first".to_string(),
+				"second".to_string(),
+			],
+		)
+		.await
+		.unwrap();
+	assert_eq!(
+		unique.keys().cloned().collect::<Vec<_>>(),
+		vec!["first".to_string(), "second".to_string()]
+	);
+	assert_eq!(executor.calls.len(), 2);
+	assert!(executor.calls.iter().all(|call| call.kind == "fetch_all"));
+	assert!(executor.calls.iter().all(|call| call.sql.contains(" IN ")));
+	assert!(
+		executor
+			.calls
+			.iter()
+			.all(|call| !call.sql.contains("Expr::cust"))
+	);
+	assert_eq!(
+		executor.calls[0].sql,
+		"SELECT * FROM \"articles\" WHERE \"article_id\" IN (1, 3, 99)"
+	);
+	assert_eq!(
+		executor.calls[1].sql,
+		"SELECT * FROM \"articles\" WHERE \"article_title\" IN ('first', 'second')"
+	);
+
+	let mut transaction_executor =
+		RecordingTransactionExecutor::new(reinhardt_db::backends::types::DatabaseType::Postgres)
+			.with_fetch_all(vec![article_row(2, "second")])
+			.with_fetch_all(vec![article_row(1, "first")]);
+	assert_eq!(
+		queryset
+			.in_bulk_with_executor(&mut transaction_executor, [2_i64, 2])
+			.await
+			.unwrap()
+			.keys()
+			.copied()
+			.collect::<Vec<_>>(),
+		vec![2]
+	);
+	assert_eq!(
+		queryset
+			.in_bulk_by_with_executor(
+				&mut transaction_executor,
+				article_title_unique(),
+				["first".to_string()],
+			)
+			.await
+			.unwrap()
+			.keys()
+			.cloned()
+			.collect::<Vec<_>>(),
+		vec!["first".to_string()]
+	);
+	assert_eq!(transaction_executor.calls.len(), 2);
+
+	let mut empty_executor = RecordingExecutor::new(DatabaseBackend::Postgres);
+	assert!(
+		queryset
+			.in_bulk_with_db(&mut empty_executor, Vec::<i64>::new())
+			.await
+			.unwrap()
+			.is_empty()
+	);
+	assert!(
+		queryset
+			.none()
+			.in_bulk_by_with_db(
+				&mut empty_executor,
+				article_title_unique(),
+				["unreachable".to_string()],
+			)
+			.await
+			.unwrap()
+			.is_empty()
+	);
+	assert!(empty_executor.calls.is_empty());
 }
 
 #[tokio::test]

--- a/crates/reinhardt-db/tests/transaction_executor_orm.rs
+++ b/crates/reinhardt-db/tests/transaction_executor_orm.rs
@@ -908,11 +908,7 @@ async fn in_bulk_uses_one_typed_in_query_and_returns_ordered_maps() {
 	);
 	assert_eq!(
 		executor.calls[0].params,
-		vec![
-			QueryValue::Int(1),
-			QueryValue::Int(3),
-			QueryValue::Int(99)
-		]
+		vec![QueryValue::Int(1), QueryValue::Int(3), QueryValue::Int(99)]
 	);
 	assert_eq!(
 		executor.calls[1].params,

--- a/tests/integration/tests/macros/model_derive_integration.rs
+++ b/tests/integration/tests/macros/model_derive_integration.rs
@@ -386,6 +386,12 @@ fn test_field_metadata_generation() {
 
 #[test]
 fn test_relationship_metadata_uses_generated_fk_columns_and_targets() {
+	assert_eq!(MetadataWriter::field_writer_id().name(), "writer_pk");
+	assert_eq!(
+		NullableMetadataWriter::field_writer_id().name(),
+		"nullable_writer_pk"
+	);
+
 	let writer = MetadataWriter::relationship_metadata()
 		.into_iter()
 		.next()

--- a/tests/integration/tests/macros/ui/fail/unique_field_ref_cannot_be_constructed.stderr
+++ b/tests/integration/tests/macros/ui/fail/unique_field_ref_cannot_be_constructed.stderr
@@ -4,8 +4,15 @@ error[E0599]: no associated function or constant named `new` found for struct `U
 6 |     let _ = UniqueFieldRef::<Article, String>::new("title");
   |                                                ^^^ associated function or constant not found in `UniqueFieldRef<Article, std::string::String>`
   |
-note: if you're trying to build a new `UniqueFieldRef<Article, std::string::String>`, consider using `UniqueFieldRef::<M, T>::from_model_field` which returns `UniqueFieldRef<_, _>`
+note: if you're trying to build a new `UniqueFieldRef<Article, std::string::String>` consider using one of the following associated functions:
+      UniqueFieldRef::<M, T>::from_model_field
+      UniqueFieldRef::<M, T>::from_model_field_with_getter
  --> $WORKSPACE/crates/reinhardt-db/src/orm/expressions.rs
   |
-  |     pub const unsafe fn from_model_field(name: &'static str) -> Self {
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |       pub const unsafe fn from_model_field(name: &'static str) -> Self {
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | /     pub const unsafe fn from_model_field_with_getter(
+  | |         name: &'static str,
+  | |         getter: fn(&M) -> Option<T>,
+  | |     ) -> Self {
+  | |_____________^

--- a/tests/integration/tests/orm.rs
+++ b/tests/integration/tests/orm.rs
@@ -42,3 +42,6 @@ mod custom_manager_ui;
 
 #[path = "orm/queryset_docs_ui.rs"]
 mod queryset_docs_ui;
+
+#[path = "orm/queryset_retrieval_integration.rs"]
+mod queryset_retrieval_integration;

--- a/tests/integration/tests/orm/queryset_docs_ui.rs
+++ b/tests/integration/tests/orm/queryset_docs_ui.rs
@@ -4,8 +4,11 @@
 fn queryset_docs_example_compile_pass() {
 	let t = trybuild::TestCases::new();
 	t.pass("tests/orm/ui/pass/queryset_docs_example.rs");
+	t.pass("tests/orm/ui/pass/queryset_typed_retrieval.rs");
 	t.pass("tests/orm/ui/pass/model_enum_typed_filter.rs");
 	t.pass("tests/orm/ui/pass/legacy_field_codec_compat.rs");
 	t.compile_fail("tests/orm/ui/fail/model_enum_string_filter.rs");
 	t.compile_fail("tests/orm/ui/fail/model_enum_integer_filter.rs");
+	t.compile_fail("tests/orm/ui/fail/queryset_latest_cross_model_field.rs");
+	t.compile_fail("tests/orm/ui/fail/queryset_in_bulk_non_unique_field.rs");
 }

--- a/tests/integration/tests/orm/queryset_docs_ui.rs
+++ b/tests/integration/tests/orm/queryset_docs_ui.rs
@@ -10,5 +10,6 @@ fn queryset_docs_example_compile_pass() {
 	t.compile_fail("tests/orm/ui/fail/model_enum_string_filter.rs");
 	t.compile_fail("tests/orm/ui/fail/model_enum_integer_filter.rs");
 	t.compile_fail("tests/orm/ui/fail/queryset_latest_cross_model_field.rs");
+	t.compile_fail("tests/orm/ui/fail/queryset_relationship_ordering.rs");
 	t.compile_fail("tests/orm/ui/fail/queryset_in_bulk_non_unique_field.rs");
 }

--- a/tests/integration/tests/orm/queryset_retrieval_integration.rs
+++ b/tests/integration/tests/orm/queryset_retrieval_integration.rs
@@ -1,0 +1,145 @@
+//! Cross-backend integration coverage for typed QuerySet retrieval helpers.
+
+use reinhardt::db::orm::{DatabaseConnectionLease, QuerySet};
+use reinhardt::model;
+use reinhardt_test::fixtures::{postgres_container, testcontainers::mysql_container};
+use rstest::rstest;
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+use sqlx::{MySqlPool, PgPool};
+use std::sync::Arc;
+use testcontainers::{ContainerAsync, GenericImage};
+
+#[model(
+	app_label = "events",
+	table_name = "queryset_retrieval_events",
+	get_latest_by = ("created_at", "id")
+)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct RetrievalEvent {
+	#[field(primary_key = true)]
+	id: Option<i64>,
+	created_at: i64,
+	#[field(max_length = 64, unique = true)]
+	slug: String,
+}
+
+async fn assert_retrieval_contract(url: &str) {
+	let owner = reinhardt::db::backends::DatabaseConnection::connect(url)
+		.await
+		.expect("backend connection should initialize");
+	let lease =
+		DatabaseConnectionLease::register(owner).expect("ORM connection should register for test");
+	let mut connection = lease.handle();
+	connection
+		.execute(
+			"CREATE TABLE queryset_retrieval_events (
+				id BIGINT PRIMARY KEY,
+				created_at BIGINT NOT NULL,
+				slug VARCHAR(64) NOT NULL UNIQUE
+			)",
+			vec![],
+		)
+		.await
+		.expect("retrieval event table should be created");
+	connection
+		.execute(
+			"INSERT INTO queryset_retrieval_events (id, created_at, slug) VALUES
+				(1, 100, 'first'),
+				(2, 200, 'second'),
+				(3, 300, 'third')",
+			vec![],
+		)
+		.await
+		.expect("retrieval event rows should be inserted");
+
+	let queryset = QuerySet::<RetrievalEvent>::new();
+	assert_eq!(
+		queryset
+			.latest_with_db(&mut connection)
+			.await
+			.expect("latest row should load")
+			.id,
+		Some(3)
+	);
+	assert_eq!(
+		queryset
+			.earliest_by_with_db(
+				&mut connection,
+				&[RetrievalEvent::field_created_at().ordering()],
+			)
+			.await
+			.expect("earliest typed row should load")
+			.id,
+		Some(1)
+	);
+
+	let by_id = queryset
+		.in_bulk_with_db(&mut connection, [3_i64, 1, 3, 99])
+		.await
+		.expect("primary-key bulk retrieval should load");
+	assert_eq!(by_id.keys().copied().collect::<Vec<_>>(), vec![1, 3]);
+	let by_slug = queryset
+		.in_bulk_by_with_db(
+			&mut connection,
+			RetrievalEvent::unique_slug(),
+			[
+				"third".to_string(),
+				"missing".to_string(),
+				"first".to_string(),
+				"third".to_string(),
+			],
+		)
+		.await
+		.expect("unique-field bulk retrieval should load");
+	assert_eq!(
+		by_slug.keys().cloned().collect::<Vec<_>>(),
+		vec!["first".to_string(), "third".to_string()]
+	);
+	assert_eq!(
+		queryset
+			.clone()
+			.none()
+			.count_with_db(&mut connection)
+			.await
+			.expect("empty queryset count should short-circuit"),
+		0
+	);
+
+	let transaction_latest_id = connection
+		.atomic(async |transaction| {
+			Ok::<_, reinhardt_core::exception::Error>(
+				queryset.latest_with_db(transaction).await?.id,
+			)
+		})
+		.await
+		.expect("transaction-bound latest retrieval should load");
+	assert_eq!(transaction_latest_id, Some(3));
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(queryset_retrieval_database)]
+async fn sqlite_typed_queryset_retrieval_contract() {
+	assert_retrieval_contract("sqlite::memory:").await;
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(queryset_retrieval_database)]
+async fn postgres_typed_queryset_retrieval_contract(
+	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<PgPool>, u16, String),
+) {
+	let (_container, _pool, _port, url) = postgres_container.await;
+	assert_retrieval_contract(&url).await;
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(queryset_retrieval_database)]
+async fn mysql_typed_queryset_retrieval_contract(
+	#[future] mysql_container: (ContainerAsync<GenericImage>, Arc<MySqlPool>, u16, String),
+) {
+	let (_container, _pool, _port, url) = mysql_container.await;
+	assert_retrieval_contract(&url).await;
+}

--- a/tests/integration/tests/orm/queryset_retrieval_integration.rs
+++ b/tests/integration/tests/orm/queryset_retrieval_integration.rs
@@ -21,7 +21,7 @@ struct RetrievalEvent {
 	id: Option<i64>,
 	created_at: i64,
 	#[field(max_length = 64, unique = true)]
-	slug: String,
+	slug: Option<String>,
 }
 
 async fn assert_retrieval_contract(url: &str) {
@@ -79,6 +79,23 @@ async fn assert_retrieval_contract(url: &str) {
 		.await
 		.expect("primary-key bulk retrieval should load");
 	assert_eq!(by_id.keys().copied().collect::<Vec<_>>(), vec![1, 3]);
+	let values_by_id = queryset
+		.clone()
+		.values(&["created_at", "slug"])
+		.in_bulk_with_db(&mut connection, [3_i64, 1])
+		.await
+		.expect("primary-key bulk retrieval should retain an omitted lookup column");
+	assert_eq!(values_by_id.keys().copied().collect::<Vec<_>>(), vec![1, 3]);
+	let deferred_by_id = queryset
+		.clone()
+		.defer(&["id"])
+		.in_bulk_with_db(&mut connection, [3_i64, 1])
+		.await
+		.expect("primary-key bulk retrieval should retain a deferred lookup column");
+	assert_eq!(
+		deferred_by_id.keys().copied().collect::<Vec<_>>(),
+		vec![1, 3]
+	);
 	let by_slug = queryset
 		.in_bulk_by_with_db(
 			&mut connection,
@@ -94,6 +111,20 @@ async fn assert_retrieval_contract(url: &str) {
 		.expect("unique-field bulk retrieval should load");
 	assert_eq!(
 		by_slug.keys().cloned().collect::<Vec<_>>(),
+		vec!["first".to_string(), "third".to_string()]
+	);
+	let only_by_slug = queryset
+		.clone()
+		.only(&["id", "created_at"])
+		.in_bulk_by_with_db(
+			&mut connection,
+			RetrievalEvent::unique_slug(),
+			["third".to_string(), "first".to_string()],
+		)
+		.await
+		.expect("unique-field bulk retrieval should retain an omitted lookup column");
+	assert_eq!(
+		only_by_slug.keys().cloned().collect::<Vec<_>>(),
 		vec!["first".to_string(), "third".to_string()]
 	);
 	assert_eq!(

--- a/tests/integration/tests/orm/ui/fail/queryset_in_bulk_non_unique_field.rs
+++ b/tests/integration/tests/orm/ui/fail/queryset_in_bulk_non_unique_field.rs
@@ -1,0 +1,21 @@
+#![allow(unexpected_cfgs)]
+//! Fail case: in-bulk retrieval accepts only metadata-proven unique fields.
+
+use reinhardt::db::orm::UniqueFieldRef;
+use reinhardt::model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[model(app_label = "events", table_name = "events")]
+struct Event {
+	#[field(primary_key = true)]
+	id: i64,
+	#[field(max_length = 255)]
+	name: String,
+}
+
+fn accepts_unique(_: UniqueFieldRef<Event, String>) {}
+
+fn main() {
+	accepts_unique(Event::field_name());
+}

--- a/tests/integration/tests/orm/ui/fail/queryset_in_bulk_non_unique_field.rs
+++ b/tests/integration/tests/orm/ui/fail/queryset_in_bulk_non_unique_field.rs
@@ -1,3 +1,4 @@
+// The model macro emits native-only cfgs evaluated in this standalone trybuild crate.
 #![allow(unexpected_cfgs)]
 //! Fail case: in-bulk retrieval accepts only metadata-proven unique fields.
 

--- a/tests/integration/tests/orm/ui/fail/queryset_in_bulk_non_unique_field.stderr
+++ b/tests/integration/tests/orm/ui/fail/queryset_in_bulk_non_unique_field.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> tests/orm/ui/fail/queryset_in_bulk_non_unique_field.rs:20:17
+   |
+20 |     accepts_unique(Event::field_name());
+   |     -------------- ^^^^^^^^^^^^^^^^^^^ expected `UniqueFieldRef<Event, String>`, found `FieldRef<Event, String>`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected struct `UniqueFieldRef<Event, std::string::String>`
+              found struct `reinhardt::FieldRef<Event, std::string::String>`
+note: function defined here
+  --> tests/orm/ui/fail/queryset_in_bulk_non_unique_field.rs:17:4
+   |
+17 | fn accepts_unique(_: UniqueFieldRef<Event, String>) {}
+   |    ^^^^^^^^^^^^^^ --------------------------------

--- a/tests/integration/tests/orm/ui/fail/queryset_latest_cross_model_field.rs
+++ b/tests/integration/tests/orm/ui/fail/queryset_latest_cross_model_field.rs
@@ -1,0 +1,29 @@
+#![allow(unexpected_cfgs)]
+//! Fail case: ordering fields from distinct models cannot be combined.
+
+use reinhardt::db::orm::OrderingField;
+use reinhardt::model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[model(app_label = "events", table_name = "events")]
+struct Event {
+	#[field(primary_key = true)]
+	id: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+#[model(app_label = "projects", table_name = "projects")]
+struct Project {
+	#[field(primary_key = true)]
+	id: i64,
+}
+
+fn accepts_event_ordering(_: &[OrderingField<Event>]) {}
+
+fn main() {
+	accepts_event_ordering(&[
+		Event::field_id().ordering(),
+		Project::field_id().ordering(),
+	]);
+}

--- a/tests/integration/tests/orm/ui/fail/queryset_latest_cross_model_field.rs
+++ b/tests/integration/tests/orm/ui/fail/queryset_latest_cross_model_field.rs
@@ -1,3 +1,4 @@
+// The model macro emits native-only cfgs evaluated in this standalone trybuild crate.
 #![allow(unexpected_cfgs)]
 //! Fail case: ordering fields from distinct models cannot be combined.
 

--- a/tests/integration/tests/orm/ui/fail/queryset_latest_cross_model_field.stderr
+++ b/tests/integration/tests/orm/ui/fail/queryset_latest_cross_model_field.stderr
@@ -1,0 +1,8 @@
+error[E0308]: mismatched types
+  --> tests/orm/ui/fail/queryset_latest_cross_model_field.rs:27:3
+   |
+27 |         Project::field_id().ordering(),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `OrderingField<Event>`, found `OrderingField<Project>`
+   |
+   = note: expected struct `reinhardt_db::orm::OrderingField<Event>`
+              found struct `reinhardt_db::orm::OrderingField<Project>`

--- a/tests/integration/tests/orm/ui/fail/queryset_relationship_ordering.rs
+++ b/tests/integration/tests/orm/ui/fail/queryset_relationship_ordering.rs
@@ -13,8 +13,8 @@ struct Project {
 	id: i64,
 }
 
-#[derive(Serialize, Deserialize)]
 #[model(app_label = "jobs", table_name = "jobs")]
+#[derive(Serialize, Deserialize)]
 struct Job {
 	#[field(primary_key = true)]
 	id: i64,

--- a/tests/integration/tests/orm/ui/fail/queryset_relationship_ordering.rs
+++ b/tests/integration/tests/orm/ui/fail/queryset_relationship_ordering.rs
@@ -1,3 +1,4 @@
+// The model macro emits native-only cfgs evaluated in this standalone trybuild crate.
 #![allow(unexpected_cfgs)]
 //! Fail case: virtual relationship fields cannot prove SQL ordering validity.
 

--- a/tests/integration/tests/orm/ui/fail/queryset_relationship_ordering.rs
+++ b/tests/integration/tests/orm/ui/fail/queryset_relationship_ordering.rs
@@ -1,0 +1,29 @@
+#![allow(unexpected_cfgs)]
+//! Fail case: virtual relationship fields cannot prove SQL ordering validity.
+
+use reinhardt::db::associations::ForeignKeyField;
+use reinhardt::db::orm::OrderingField;
+use reinhardt::model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[model(app_label = "projects", table_name = "projects")]
+struct Project {
+	#[field(primary_key = true)]
+	id: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+#[model(app_label = "jobs", table_name = "jobs")]
+struct Job {
+	#[field(primary_key = true)]
+	id: i64,
+	#[rel(foreign_key)]
+	project: ForeignKeyField<Project>,
+}
+
+fn accepts_job_ordering(_: &[OrderingField<Job>]) {}
+
+fn main() {
+	accepts_job_ordering(&[Job::field_project().ordering()]);
+}

--- a/tests/integration/tests/orm/ui/fail/queryset_relationship_ordering.stderr
+++ b/tests/integration/tests/orm/ui/fail/queryset_relationship_ordering.stderr
@@ -1,0 +1,13 @@
+error[E0599]: the method `ordering` exists for struct `reinhardt::FieldRef<Job, ForeignKeyField<Project>>`, but its trait bounds were not satisfied
+  --> tests/orm/ui/fail/queryset_relationship_ordering.rs:28:46
+   |
+28 |     accepts_job_ordering(&[Job::field_project().ordering()]);
+   |                                                 ^^^^^^^^ method cannot be called on `reinhardt::FieldRef<Job, ForeignKeyField<Project>>` due to unsatisfied trait bounds
+   |
+  ::: $WORKSPACE/crates/reinhardt-db/src/associations/markers.rs
+   |
+   | pub struct ForeignKeyField<T>(PhantomData<T>);
+   | ----------------------------- doesn't satisfy `ForeignKeyField<Project>: DatabaseField`
+   |
+   = note: the following trait bounds were not satisfied:
+           `ForeignKeyField<Project>: DatabaseField`

--- a/tests/integration/tests/orm/ui/pass/queryset_typed_retrieval.rs
+++ b/tests/integration/tests/orm/ui/pass/queryset_typed_retrieval.rs
@@ -1,3 +1,4 @@
+// The model macro emits native-only cfgs evaluated in this standalone trybuild crate.
 #![allow(unexpected_cfgs)]
 //! Pass case: typed retrieval metadata preserves model identity and unique keys.
 

--- a/tests/integration/tests/orm/ui/pass/queryset_typed_retrieval.rs
+++ b/tests/integration/tests/orm/ui/pass/queryset_typed_retrieval.rs
@@ -1,0 +1,34 @@
+#![allow(unexpected_cfgs)]
+//! Pass case: typed retrieval metadata preserves model identity and unique keys.
+
+use reinhardt::db::orm::{Model, OrderingField, UniqueFieldRef};
+use reinhardt::model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[model(
+	app_label = "events",
+	table_name = "events",
+	get_latest_by = ("created_at", "id")
+)]
+struct Event {
+	#[field(primary_key = true)]
+	id: i64,
+	#[field(db_column = "created_on")]
+	created_at: i64,
+	#[field(max_length = 255, unique = true)]
+	email: String,
+}
+
+fn accepts_event_ordering(_: &[OrderingField<Event>]) {}
+
+fn accepts_event_unique(_: UniqueFieldRef<Event, String>) {}
+
+fn main() {
+	accepts_event_ordering(&[
+		Event::field_created_at().ordering(),
+		Event::field_id().ordering(),
+	]);
+	accepts_event_unique(Event::unique_email());
+	assert_eq!(<Event as Model>::latest_by_fields(), ["created_on", "id"]);
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds typed `latest`, `earliest`, `latest_by`, and `earliest_by` QuerySet terminals.
- Adds deterministic `in_bulk` and unique-field `in_bulk_by` helpers with caller-owned connection and transaction variants.
- Generates validated `get_latest_by` and unique-field metadata from model declarations.
- Makes `QuerySet::none()` lazy across global and caller-owned terminal operations.
- Documents the typed retrieval API and adds compile-time, mock-executor, and real-backend coverage.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Typed retrieval helpers eliminate stringly typed ordering and unique-key bulk lookup paths while preserving deterministic results and explicit executor ownership. Lazy empty querysets avoid acquiring a connection when no query can produce rows.

Fixes #5845

Related to: #5845

## How Was This Tested?

- `cargo test --offline -p reinhardt-db --test orm_queryset_builder --test transaction_executor_orm` (104 passed)
- `cargo test --offline -p reinhardt-integration-tests --test orm typed_queryset_retrieval_contract -- --nocapture` (SQLite, PostgreSQL, and MySQL passed)
- `cargo test --offline -p reinhardt-integration-tests --test orm queryset_docs_example_compile_pass` (8 trybuild pass/fail cases passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --offline -p reinhardt-macros model_derive --lib` (57 passed; one pre-existing unrelated ModelForm metadata baseline failure remains)

## Performance Impact

- Empty querysets short-circuit without connection or executor access.
- Bulk retrieval deduplicates keys and issues one typed `IN` query.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5845

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement
- [ ] `bug` - Bug fix
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [x] `orm` - ORM layer, models, query builder

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

The branch includes an ordinary merge from the latest `develop/0.4.0`; no rebase or history-rewriting push was used.

🤖 Generated with [Codex](https://openai.com/codex)