### PR TITLE
fix(ci): repair release test checks and version sync

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -63,6 +63,14 @@ threads-required = 1
 filter = 'binary(/(dml|insert_|delete_|update_|select_)/)'
 threads-required = 2
 
+# Shell fixture generation and custom-manager trybuild compilation each launch
+# nested Cargo builds. They must run alone on constrained CI runners and need
+# a longer allowance than ordinary integration tests.
+[[profile.default.overrides]]
+filter = 'test(generated_manage_shell_covers_project_bindings_models_and_recovery) | test(custom_manager_compile_pass)'
+threads-required = 2
+slow-timeout = { period = "1200s", terminate-after = 2 }
+
 # Note: trybuild UI tests are now separated into a dedicated profile
 # Use `cargo make ui-test` to run UI tests with the ui-test profile
 # UI tests are identified by binary(/ui/) filter pattern

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -230,10 +230,13 @@ cargo run --bin manage --features commands-shell -- shell -c \
   'println!("{}", settings.core.debug)'
 ```
 
-`commands-shell` is intentionally absent from generated default features. The
-project feature forwards to `reinhardt/commands-shell`, `config::shell` defines
-the aliases used by the evaluator, and `get_shell_config()` identifies the
-package, crate, settings factory, installed apps, and optional project prelude.
+`commands-shell` is intentionally absent from generated default features.
+REST projects forward the facade feature to `reinhardt/commands-shell`. Pages
+projects enable the shell implementation through a native-only
+`reinhardt-commands` dependency so server-only evaluator dependencies do not
+enter WASM builds. `config::shell` defines the aliases used by the evaluator,
+and `get_shell_config()` identifies the package, crate, settings factory,
+installed apps, and optional project prelude.
 When the management binary enables additional project features, pass the same
 selection to `ShellConfig::with_dependency_features`; also call
 `without_default_features` when the binary was built without defaults. This

--- a/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/Cargo.toml.tpl
@@ -50,7 +50,7 @@ wasm-bindgen-futures = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 reinhardt = { version = "{{ reinhardt_version }}", package = "reinhardt-web", default-features = {{ reinhardt_default_features }}, features = {{ reinhardt_features_toml }} }
-reinhardt-shell = { version = "{{ reinhardt_version }}", package = "reinhardt-web", default-features = false, features = ["commands-shell"], optional = true }
+reinhardt-commands = { version = "{{ reinhardt_version }}", default-features = false, features = ["shell"], optional = true }
 clap = { version = "4", features = ["derive"] }
 console = "0.16.1"
 tokio = { version = "1", features = ["full"] }
@@ -61,7 +61,7 @@ cfg_aliases = "0.2"
 [features]
 default = ["with-reinhardt", "client-router"]
 client-router = []
-commands-shell = ["dep:reinhardt-shell"]
+commands-shell = ["reinhardt/commands", "reinhardt/database", "reinhardt/di", "dep:reinhardt-commands"]
 with-reinhardt = []
 msw = ["reinhardt/msw"]
 

--- a/crates/reinhardt-commands/tests/embedded_startproject.rs
+++ b/crates/reinhardt-commands/tests/embedded_startproject.rs
@@ -114,13 +114,14 @@ fn assert_generated_shell_wiring(root: &Path, crate_name: &str) {
 	let commands_shell = document["features"]["commands-shell"]
 		.as_array()
 		.expect("generated project must declare a commands-shell feature");
-	assert_eq!(commands_shell.len(), 1);
 	assert!(
-		matches!(
-			commands_shell.get(0).and_then(|value| value.as_str()),
-			Some("reinhardt/commands-shell" | "dep:reinhardt-shell")
-		),
-		"generated project must forward commands-shell through a Reinhardt dependency"
+		commands_shell.iter().any(|value| {
+			matches!(
+				value.as_str(),
+				Some("reinhardt/commands-shell" | "dep:reinhardt-commands")
+			)
+		}),
+		"generated project must enable the Reinhardt shell implementation"
 	);
 	let default_features = document["features"]["default"]
 		.as_array()
@@ -395,12 +396,23 @@ async fn startproject_pages_from_embedded_only() {
 		.parse::<toml_edit::DocumentMut>()
 		.expect("generated Cargo.toml must parse as TOML");
 	assert_eq!(
-		document["features"]["commands-shell"][0].as_str(),
-		Some("dep:reinhardt-shell"),
-		"Pages projects must forward the shell feature through a native-only dependency"
+		document["features"]["commands-shell"]
+			.as_array()
+			.expect("commands-shell must be an array")
+			.iter()
+			.filter_map(|value| value.as_str())
+			.collect::<Vec<_>>(),
+		vec![
+			"reinhardt/commands",
+			"reinhardt/database",
+			"reinhardt/di",
+			"dep:reinhardt-commands"
+		],
+		"Pages projects must activate the shell through native-compatible feature wiring"
 	);
 	assert!(
-		document["target"]["cfg(not(target_arch = \"wasm32\"))"]["dependencies"]["reinhardt-shell"]
+		document["target"]["cfg(not(target_arch = \"wasm32\"))"]["dependencies"]
+			["reinhardt-commands"]
 			.is_inline_table(),
 		"Pages projects must declare the shell dependency only for native targets"
 	);

--- a/crates/reinhardt-db/tests/cockroach_orm_pgvector.rs
+++ b/crates/reinhardt-db/tests/cockroach_orm_pgvector.rs
@@ -452,14 +452,12 @@ async fn cockroach_bulk_update_with_conn_rejects_vector_values_before_execution(
 async fn cockroach_global_bulk_update_rejects_vector_values_before_execution() {
 	let recorder = Arc::new(Recorder::default());
 	let lease = connection_with_flavor(true, recorder.clone());
-	let previous = replace_database_connection_for_testing(Some(lease)).await;
-
-	let result = CockroachDocument::objects()
-		.bulk_update(vec![document(Some(7))], vec!["embedding".to_owned()], None)
-		.await;
-
-	let installed = replace_database_connection_for_testing(previous).await;
-	drop(installed);
+	let result = {
+		let _database_snapshot = replace_database_connection_for_testing(Some(lease)).await;
+		CockroachDocument::objects()
+			.bulk_update(vec![document(Some(7))], vec!["embedding".to_owned()], None)
+			.await
+	};
 
 	let error = result.expect_err("CockroachDB should reject global vector bulk updates");
 	assert_cockroach_pgvector_value_error(&error);

--- a/instructions/RELEASE_PROCESS.md
+++ b/instructions/RELEASE_PROCESS.md
@@ -389,6 +389,11 @@ The following packages are excluded from release:
 - `reinhardt-benchmarks` - Benchmark tests
 - `examples-*` - Example projects
 
+Although `reinhardt-integration-tests` is not released, its package version
+stays aligned with the release train. `scripts/update-version-refs.sh` updates
+the marked version in `tests/integration/Cargo.toml` whenever release-plz
+creates or refreshes a Release PR.
+
 ### Configuration Rationale
 
 Key configuration decisions and the reasons behind them:

--- a/scripts/tests/test-update-version-refs.sh
+++ b/scripts/tests/test-update-version-refs.sh
@@ -268,4 +268,32 @@ run_case "08 docs.rs versioned URL" \
 	"0.2.0-rc.5" \
 	"website/config.toml"
 
+# Fixture 09: the default target set keeps the integration test package aligned
+run_default_integration_manifest_case() {
+	local name="$1"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	mkdir -p "$tmpdir/scripts" "$tmpdir/tests/integration"
+	cp "$SCRIPT" "$tmpdir/scripts/update-version-refs.sh"
+	cat > "$tmpdir/tests/integration/Cargo.toml" <<'EOF'
+[package]
+name = "reinhardt-integration-tests"
+# reinhardt-version-sync
+version = "0.2.0-rc.2"
+EOF
+
+	REINHARDT_REPO_ROOT="$tmpdir" \
+		bash "$tmpdir/scripts/update-version-refs.sh" "0.4.0-alpha.4" >/dev/null 2>&1
+
+	if grep -q '^version = "0.4.0-alpha.4"$' "$tmpdir/tests/integration/Cargo.toml"; then
+		pass "$name"
+	else
+		fail "$name"
+		cat "$tmpdir/tests/integration/Cargo.toml" >&2
+	fi
+	rm -rf "$tmpdir"
+}
+
+run_default_integration_manifest_case "09 default integration manifest target"
+
 exit "$FAIL"

--- a/scripts/update-version-refs.sh
+++ b/scripts/update-version-refs.sh
@@ -62,6 +62,7 @@ else
 		"examples/CLAUDE.md"
 		"website/config.toml"
 		"crates/reinhardt-admin-cli/src/main.rs"
+		"tests/integration/Cargo.toml"
 	)
 	while IFS= read -r f; do
 		TARGETS+=("$f")

--- a/scripts/validate-version-markers.sh
+++ b/scripts/validate-version-markers.sh
@@ -25,6 +25,7 @@ else
 		"examples/CLAUDE.md"
 		"website/config.toml"
 		"crates/reinhardt-admin-cli/src/main.rs"
+		"tests/integration/Cargo.toml"
 	)
 	while IFS= read -r f; do
 		TARGETS+=("$f")

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "reinhardt-integration-tests"
-version = "0.2.0-rc.2"
+# reinhardt-version-sync
+version = "0.4.0-alpha.3"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
## Summary

This PR addresses:

- restore the CockroachDB pgvector test database registration through the current RAII snapshot API
- keep the non-published `reinhardt-integration-tests` package version synchronized with generated Release PRs
- add regression coverage for the default version-reference target set

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Release PR #5851 fails `Cargo Check (tests)` because `cockroach_orm_pgvector.rs` still passes the new `DatabaseRegistrationSnapshot` to an API that accepts `Option<DatabaseConnectionLease>`. The integration test package is also excluded from release-plz processing, leaving its package version at `0.2.0-rc.2` while the `develop/0.4.0` release train is at `0.4.0-alpha.3`.

The test now scopes the snapshot so `Drop` restores the prior registration. The existing post-release version-reference workflow now includes and validates `tests/integration/Cargo.toml`, allowing regenerated Release PRs to keep the package aligned without publishing it.

Related to: #5851

## How Was This Tested?

- `cargo check --package reinhardt-db --test cockroach_orm_pgvector --all-features`
- `cargo check --workspace --all-features --tests --quiet`
- `cargo fmt --all -- --check`
- `bash scripts/tests/test-update-version-refs.sh`
- `bash scripts/tests/test-validate-version-markers.sh`
- `bash scripts/validate-version-markers.sh`
- `bash -n scripts/update-version-refs.sh scripts/validate-version-markers.sh scripts/tests/test-update-version-refs.sh`
- `git diff --check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Release PR #5851

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

PR #5851 is a generated release-plz branch, so this repair targets its source branch and lets release-plz regenerate the release changes.