### PR TITLE
fix(ci): restore Codecov LCOV uploads

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -164,16 +164,16 @@ jobs:
       - name: Generate unit coverage report
         run: |
           cargo llvm-cov report \
-            --codecov \
-            --output-path /tmp/unit-codecov.json
+            --lcov \
+            --output-path /tmp/unit-lcov.info
 
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5
         with:
-          files: /tmp/unit-codecov.json
+          files: /tmp/unit-lcov.info
           flags: unit
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           use_oidc: true
 
       - name: Docker cleanup after tests
@@ -323,16 +323,16 @@ jobs:
       - name: Generate intra-crate coverage report
         run: |
           cargo llvm-cov report \
-            --codecov \
-            --output-path /tmp/intra-crate-codecov.json
+            --lcov \
+            --output-path /tmp/intra-crate-lcov.info
 
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5
         with:
-          files: /tmp/intra-crate-codecov.json
+          files: /tmp/intra-crate-lcov.info
           flags: intra-crate-integration
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           use_oidc: true
 
       - name: Docker cleanup after tests
@@ -479,16 +479,16 @@ jobs:
       - name: Generate cross-crate coverage report
         run: |
           cargo llvm-cov report \
-            --codecov \
-            --output-path /tmp/cross-crate-codecov.json
+            --lcov \
+            --output-path /tmp/cross-crate-lcov.info
 
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5
         with:
-          files: /tmp/cross-crate-codecov.json
+          files: /tmp/cross-crate-lcov.info
           flags: cross-crate-integration
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           use_oidc: true
 
       - name: Docker cleanup after tests

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -528,9 +528,9 @@ dependencies = ["docker-cleanup-force", "test-only"]
 # ============================================================================
 
 [tasks.coverage-unit]
-description = "Run unit tests with coverage (generates Codecov JSON report)"
+description = "Run unit tests with coverage (generates LCOV report)"
 command = "cargo"
-args = ["llvm-cov", "nextest", "--workspace", "--lib", "--all-features", "--no-fail-fast", "--codecov", "--output-path", "/tmp/reinhardt-unit-codecov.json"]
+args = ["llvm-cov", "nextest", "--workspace", "--lib", "--all-features", "--no-fail-fast", "--lcov", "--output-path", "/tmp/reinhardt-unit-lcov.info"]
 
 [tasks.coverage-html]
 description = "Run unit tests with coverage and open HTML report"


### PR DESCRIPTION
## Summary

This PR addresses:

- Restore the LCOV report format for all three Codecov coverage uploads.
- Fail each coverage job when Codecov cannot upload or find the report.
- Keep the local `coverage-unit` task aligned with the CI report format.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The 2026-03-02 migration from LCOV to `cargo llvm-cov report --codecov` JSON left main coverage uploads in Codecov processing errors. LCOV was processed successfully before the migration. The previous `fail_ci_if_error: false` setting also allowed missing or rejected reports to appear successful in GitHub Actions.

## How Was This Tested?

- [x] Parsed `.github/workflows/coverage.yml` with Ruby YAML parsing.
- [x] Verified the `coverage-unit` task with `cargo make --print-steps`.
- [x] Verified `cargo llvm-cov report --help` exposes the LCOV report option.
- [x] Ran `git diff --check`.
- [x] Dispatched Coverage run #30614288530 from this branch; it is currently queued for remote Codecov verification.
- [ ] Full Rust test suite has not been run locally; this change is limited to CI and coverage task configuration.

## Performance Impact

- No runtime performance impact. Coverage uploads use the previously processed LCOV format.

## Related Issues

- Regression reference: commit `650d1d80c3` (`ci(coverage): migrate from LCOV to Codecov JSON for region-level coverage`)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix` (not applicable to YAML/TOML-only changes)
- [ ] I have checked the code with `cargo make clippy-check` (not applicable to YAML/TOML-only changes)

## Related Issues

- Codecov tracking for `main`.

## Labels to Apply

- [x] `bug`
- [x] `ci-cd`
- [x] `testing`

## Additional Context

The Codecov upload steps retain `if: always()` so a failed test run still exposes a missing report, while `fail_ci_if_error: true` now propagates that upload failure to the job.

🤖 Generated with [Codex](https://openai.com/codex)