### PR TITLE
  refactor(db)!: rename JsonBinary variants and json_binary() to Json…

### DIFF
--- a/crates/reinhardt-admin/src/server/type_inference.rs
+++ b/crates/reinhardt-admin/src/server/type_inference.rs
@@ -100,7 +100,7 @@ pub fn infer_admin_field_type(db_type: &DbFieldType) -> AdminFieldType {
 		| DbFieldType::Bytea => AdminFieldType::File,
 
 		// JSON types → TextArea (for JSON editing)
-		DbFieldType::Json | DbFieldType::JsonBinary => AdminFieldType::TextArea,
+		DbFieldType::Json | DbFieldType::Jsonb => AdminFieldType::TextArea,
 
 		// Year → Number input
 		DbFieldType::Year => AdminFieldType::Number,
@@ -570,7 +570,7 @@ mod tests {
 			AdminFieldType::TextArea
 		);
 		assert_eq!(
-			infer_admin_field_type(&DbFieldType::JsonBinary),
+			infer_admin_field_type(&DbFieldType::Jsonb),
 			AdminFieldType::TextArea
 		);
 	}

--- a/crates/reinhardt-db/src/migrations/ast_parser.rs
+++ b/crates/reinhardt-db/src/migrations/ast_parser.rs
@@ -897,7 +897,7 @@ fn extract_field_type(
 						"LongBlob" => Some(FieldType::LongBlob),
 						"Bytea" => Some(FieldType::Bytea),
 						"Json" => Some(FieldType::Json),
-						"JsonBinary" => Some(FieldType::JsonBinary),
+						"Jsonb" => Some(FieldType::Jsonb),
 						"Uuid" => Some(FieldType::Uuid),
 						"Year" => Some(FieldType::Year),
 						_ => Some(FieldType::Custom(segments.join("::"))),

--- a/crates/reinhardt-db/src/migrations/fields.rs
+++ b/crates/reinhardt-db/src/migrations/fields.rs
@@ -77,8 +77,8 @@ pub enum FieldType {
 	// JSON types
 	/// Json variant.
 	Json,
-	/// JsonBinary variant.
-	JsonBinary, // PostgreSQL JSONB
+	/// Jsonb variant.
+	Jsonb, // PostgreSQL JSONB
 
 	// PostgreSQL-specific types
 	/// PostgreSQL Array type with inner element type
@@ -189,7 +189,7 @@ impl FieldType {
 				SqlDialect::Mysql => "CHAR(36)".to_string(), // MySQL doesn't have native UUID
 				SqlDialect::Sqlite => "TEXT".to_string(),    // SQLite doesn't have native UUID
 			},
-			FieldType::JsonBinary => match dialect {
+			FieldType::Jsonb => match dialect {
 				SqlDialect::Postgres | SqlDialect::Cockroachdb => "JSONB".to_string(),
 				SqlDialect::Mysql | SqlDialect::Sqlite => "JSON".to_string(), // Fallback to JSON
 			},
@@ -297,7 +297,7 @@ impl FieldType {
 			FieldType::LongBlob => "LONGBLOB".to_string(),
 			FieldType::Bytea => "BYTEA".to_string(),
 			FieldType::Json => "JSON".to_string(),
-			FieldType::JsonBinary => "JSONB".to_string(),
+			FieldType::Jsonb => "JSONB".to_string(),
 			// PostgreSQL-specific types
 			FieldType::Array(inner) => format!("{}[]", inner.to_sql_string()),
 			FieldType::HStore => "HSTORE".to_string(),

--- a/crates/reinhardt-db/src/migrations/introspect/type_mapping.rs
+++ b/crates/reinhardt-db/src/migrations/introspect/type_mapping.rs
@@ -141,7 +141,7 @@ impl TypeMapper {
 
 			// JSON types
 			FieldType::Json => quote! { serde_json::Value },
-			FieldType::JsonBinary => quote! { serde_json::Value },
+			FieldType::Jsonb => quote! { serde_json::Value },
 
 			// PostgreSQL-specific types
 			FieldType::Array(inner) => {
@@ -219,7 +219,7 @@ impl TypeMapper {
 			FieldType::Boolean => "bool",
 			FieldType::Binary | FieldType::Blob | FieldType::Bytea => "Vec<u8>",
 			FieldType::TinyBlob | FieldType::MediumBlob | FieldType::LongBlob => "Vec<u8>",
-			FieldType::Json | FieldType::JsonBinary => "serde_json::Value",
+			FieldType::Json | FieldType::Jsonb => "serde_json::Value",
 			FieldType::Uuid => "uuid::Uuid",
 			FieldType::Year => "i16",
 			FieldType::HStore => "std::collections::HashMap<String, String>",

--- a/crates/reinhardt-db/src/migrations/introspection.rs
+++ b/crates/reinhardt-db/src/migrations/introspection.rs
@@ -167,7 +167,7 @@ impl PostgresIntrospector {
 
 			// JSON
 			"json" => FieldType::Json,
-			"jsonb" => FieldType::JsonBinary,
+			"jsonb" => FieldType::Jsonb,
 
 			// UUID
 			"uuid" => FieldType::Uuid,
@@ -1045,7 +1045,7 @@ impl SQLiteIntrospector {
 			"DATETIME" => FieldType::DateTime,
 			"TIMESTAMP" => FieldType::DateTime,
 			"JSON" => FieldType::Json,
-			"JSONB" => FieldType::JsonBinary,
+			"JSONB" => FieldType::Jsonb,
 			"UUID" => FieldType::Uuid,
 			"NUMERIC" => FieldType::Decimal {
 				precision: 10,

--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -4191,7 +4191,7 @@ impl Operation {
 			FieldType::Float => col_def.float(),
 			FieldType::Double | FieldType::Real => col_def.double(),
 			FieldType::Json => col_def.json(),
-			FieldType::JsonBinary => col_def.json_binary(),
+			FieldType::Jsonb => col_def.jsonb(),
 			FieldType::Uuid => col_def.uuid(),
 			FieldType::Binary | FieldType::Bytea => col_def.binary(0),
 			FieldType::Blob | FieldType::TinyBlob | FieldType::MediumBlob | FieldType::LongBlob => {

--- a/crates/reinhardt-db/src/migrations/operations/to_tokens.rs
+++ b/crates/reinhardt-db/src/migrations/operations/to_tokens.rs
@@ -54,7 +54,7 @@ fn field_type_to_tokens(field_type: &FieldType) -> TokenStream {
 
 		// JSON types
 		FieldType::Json => quote! { FieldType::Json },
-		FieldType::JsonBinary => quote! { FieldType::JsonBinary },
+		FieldType::Jsonb => quote! { FieldType::Jsonb },
 
 		// PostgreSQL-specific types
 		FieldType::Array(inner) => {
@@ -916,7 +916,7 @@ impl ToTokens for ColumnDefinition {
 
 			// JSON types
 			FieldType::Json => quote! { FieldType::Json },
-			FieldType::JsonBinary => quote! { FieldType::JsonBinary },
+			FieldType::Jsonb => quote! { FieldType::Jsonb },
 
 			// PostgreSQL-specific types
 			FieldType::Array(inner) => {

--- a/crates/reinhardt-db/src/orm/many_to_many.rs
+++ b/crates/reinhardt-db/src/orm/many_to_many.rs
@@ -80,7 +80,7 @@ impl AssociationTable {
 			"datetime" | "timestamp" => ColumnType::DateTime,
 			"timestamptz" | "timestamp with time zone" => ColumnType::TimestampWithTimeZone,
 			"json" => ColumnType::Json,
-			"jsonb" => ColumnType::JsonBinary,
+			"jsonb" => ColumnType::Jsonb,
 			"uuid" => ColumnType::Uuid,
 			"binary" | "blob" => ColumnType::Binary(Some(255)), // Default binary length
 			"varbinary" => ColumnType::VarBinary(255),          // Default varbinary length
@@ -165,8 +165,8 @@ impl AssociationTable {
 			ColumnType::Json => {
 				col_def = col_def.json();
 			}
-			ColumnType::JsonBinary => {
-				col_def = col_def.json_binary();
+			ColumnType::Jsonb => {
+				col_def = col_def.jsonb();
 			}
 			ColumnType::Uuid => {
 				col_def = col_def.uuid();
@@ -666,7 +666,7 @@ mod tests {
 		assert!(matches!(col_type, ColumnType::Json));
 
 		let col_type = AssociationTable::parse_column_type("JSONB");
-		assert!(matches!(col_type, ColumnType::JsonBinary));
+		assert!(matches!(col_type, ColumnType::Jsonb));
 	}
 
 	#[test]

--- a/crates/reinhardt-query/src/backend/mysql.rs
+++ b/crates/reinhardt-query/src/backend/mysql.rs
@@ -3176,8 +3176,8 @@ impl MySqlQueryBuilder {
 			Blob => "BLOB".to_string(),
 			Uuid => "CHAR(36)".to_string(), // UUID as CHAR(36) in MySQL
 			Json => "JSON".to_string(),
-			JsonBinary => "JSON".to_string(), // MySQL JSON is binary
-			Array(_) => "JSON".to_string(),   // MySQL doesn't have ARRAY, use JSON
+			Jsonb => "JSON".to_string(),    // MySQL JSON is binary
+			Array(_) => "JSON".to_string(), // MySQL doesn't have ARRAY, use JSON
 			Custom(name) => name.clone(),
 		}
 	}

--- a/crates/reinhardt-query/src/backend/postgres.rs
+++ b/crates/reinhardt-query/src/backend/postgres.rs
@@ -4290,7 +4290,7 @@ impl PostgresQueryBuilder {
 			ColumnType::Blob => "BYTEA".to_string(),
 			ColumnType::Boolean => "BOOLEAN".to_string(),
 			ColumnType::Json => "JSON".to_string(),
-			ColumnType::JsonBinary => "JSONB".to_string(),
+			ColumnType::Jsonb => "JSONB".to_string(),
 			ColumnType::Uuid => "UUID".to_string(),
 			ColumnType::Array(inner_type) => {
 				format!("{}[]", self.column_type_to_sql(inner_type))

--- a/crates/reinhardt-query/src/backend/sqlite.rs
+++ b/crates/reinhardt-query/src/backend/sqlite.rs
@@ -1826,7 +1826,7 @@ impl SqliteQueryBuilder {
 			Blob => "BLOB".to_string(),
 			Uuid => "TEXT".to_string(), // UUID as TEXT (36 chars)
 			Json => "TEXT".to_string(), // SQLite JSON1 extension stores JSON as TEXT
-			JsonBinary => "TEXT".to_string(),
+			Jsonb => "TEXT".to_string(),
 			Array(_) => "TEXT".to_string(), // SQLite doesn't have ARRAY, use TEXT (JSON)
 			Custom(name) => name.clone(),
 		}

--- a/crates/reinhardt-query/src/types/ddl.rs
+++ b/crates/reinhardt-query/src/types/ddl.rs
@@ -63,7 +63,7 @@ pub enum ColumnType {
 	/// JSON - JSON data
 	Json,
 	/// JSONB - Binary JSON (PostgreSQL)
-	JsonBinary,
+	Jsonb,
 	/// ARRAY - Array type (PostgreSQL)
 	Array(Box<ColumnType>),
 	/// Custom type - for database-specific types
@@ -278,8 +278,8 @@ impl ColumnDef {
 	}
 
 	/// Set column type to JSONB
-	pub fn json_binary(self) -> Self {
-		self.column_type(ColumnType::JsonBinary)
+	pub fn jsonb(self) -> Self {
+		self.column_type(ColumnType::Jsonb)
 	}
 
 	/// Set column type to BLOB
@@ -533,12 +533,12 @@ mod tests {
 	}
 
 	#[rstest]
-	fn test_column_def_json_binary() {
+	fn test_column_def_jsonb() {
 		// Arrange & Act
-		let col = ColumnDef::new("data").json_binary();
+		let col = ColumnDef::new("data").jsonb();
 
 		// Assert
-		assert_eq!(col.column_type, Some(ColumnType::JsonBinary));
+		assert_eq!(col.column_type, Some(ColumnType::Jsonb));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-query/tests/common.rs
+++ b/crates/reinhardt-query/tests/common.rs
@@ -299,7 +299,7 @@ impl ColumnTypeFactory {
 		vec![
 			ColumnType::Uuid,
 			ColumnType::Json,
-			ColumnType::JsonBinary,
+			ColumnType::Jsonb,
 			ColumnType::TimestampWithTimeZone,
 			ColumnType::Array(Box::new(ColumnType::Integer)),
 			ColumnType::Array(Box::new(ColumnType::Text)),

--- a/crates/reinhardt-query/tests/ddl_tables.rs
+++ b/crates/reinhardt-query/tests/ddl_tables.rs
@@ -641,7 +641,7 @@ async fn test_postgres_create_table_all_column_types(
 		)
 		.col(
 			ColumnDef::new("jsonb_val")
-				.column_type(ColumnType::JsonBinary)
+				.column_type(ColumnType::Jsonb)
 				.not_null(false),
 		);
 

--- a/crates/reinhardt-test/src/fixtures/admin_panel.rs
+++ b/crates/reinhardt-test/src/fixtures/admin_panel.rs
@@ -325,7 +325,7 @@ pub async fn export_import_test_context(
 				.timestamp_with_time_zone()
 				.default(Expr::current_timestamp().into()),
 		)
-		.col(ColumnDef::new(TestExportsTable::Metadata).json_binary());
+		.col(ColumnDef::new(TestExportsTable::Metadata).jsonb());
 
 	let create_table_sql = create_stmt.to_string(PostgresQueryBuilder::new());
 


### PR DESCRIPTION
  ## Summary

  This PR addresses:

  - Renames the JSONB type identifiers for naming consistency: the `JsonBinary`
    enum variants → `Jsonb` (`ColumnType`, `FieldType`), and the
    `ColumnDef::json_binary()` builder method → `jsonb()`. Identifier-only —
    the generated SQL is unchanged (`JSONB`).

  ## Type of Change

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Refactoring (code change that neither fixes a bug nor adds a feature)

  ## Breaking Change Assessment

  - [x] **Yes** - This change breaks existing public API or behavior

  ## Motivation and Context

  `JsonBinary` / `json_binary()` didn't match PostgreSQL's `jsonb`/`JSONB`
  terminology or the naming of the surrounding type enums. Renaming to
  `Jsonb` / `jsonb()` makes the JSONB identifiers consistent across
  reinhardt-query, reinhardt-db, reinhardt-admin, and reinhardt-test. There is
  no behavior change — the emitted SQL is still `JSONB`.

  Fixes #

  Related to: #

  ## How Was This Tested?

  - `cargo build -p reinhardt-query -p reinhardt-db -p reinhardt-admin -p reinhardt-test` — clean.
  - `cargo test -p reinhardt-query` — 1913 passed / 0 failed (incl. the renamed `test_column_def_jsonb`); the PostgreSQL and SQLite DDL integration tests pass.
  - `cargo clippy` (affected crates) — no warnings.
  - `cargo fmt --check` — clean.
  - This is a mechanical identifier rename; existing DDL/migration tests assert the `JSONB` output is preserved.

  > Note: the `test_mysql_*` DDL tests are TestContainers-based and could not start locally (Docker Hub `mysql:8.0` pull returned 401 in this environment). They're unaffected by an
  identifier rename — the emitted SQL is byte-identical.

  ## Breaking Changes

  The public enum variants `ColumnType::JsonBinary` (reinhardt-query) and
  `FieldType::JsonBinary` (reinhardt-db), and the `ColumnDef::json_binary()`
  builder method, are renamed to `Jsonb` / `jsonb()`. SQL output and column
  behavior are unchanged.

  **Migration Guide:**

      // before
      ColumnType::JsonBinary
      FieldType::JsonBinary
      ColumnDef::new("data").json_binary()

      // after
      ColumnType::Jsonb
      FieldType::Jsonb
      ColumnDef::new("data").jsonb()

  ## Checklist

  - [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
  - [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
  - [x] I have updated the documentation (if applicable) — N/A, no doc changes
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works — mechanical rename; covered by existing tests
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have tested with all affected database backends (if applicable) — PostgreSQL + SQLite verified; MySQL DDL tests blocked by a local image-pull only (see note)
  - [x] I have formatted the code with `cargo make fmt-fix`
  - [x] I have checked the code with `cargo make clippy-check`
  - [ ] I use self-hosted runner for CI (Repository owner only)

  ## Labels to Apply

  ### Type Label (select one)
  - [x] `refactoring` - Code refactoring

  ### Additional Labels
  - [x] `breaking-change`

  ### Scope Label (select all that apply)
  - [x] `database` - Database layer, schema, migrations
  - [x] `orm` - ORM layer, models, query builder

  ### Priority Label (for maintainers)
  - [ ] (leave for maintainer triage)

  ---

  **Additional Context:**

  Identifier-only rename for naming consistency; no SQL or behavior change.
  Part of a small series of independent ORM PRs (worker concurrency, this
  rename, and the DbValue persistence change) — each stands alone.