### PR TITLE
test(macros): align model support with field proofs

### DIFF
--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -500,30 +500,56 @@ pub mod db {
 		}
 
 		pub mod expressions {
+			#[derive(Debug, Clone, Copy)]
+			pub enum GeneratedModelField {}
+
+			#[derive(Debug, Clone, Copy)]
+			pub enum UnverifiedModelField {}
+
 			#[derive(Debug, Clone)]
-			pub struct FieldRef<Model, Type> {
+			pub struct FieldRef<Model, Type, Origin = UnverifiedModelField> {
 				pub name: &'static str,
-				_marker: core::marker::PhantomData<(Model, Type)>,
+				_marker: core::marker::PhantomData<(Model, Type, Origin)>,
 			}
 
-			impl<Model, Type> FieldRef<Model, Type> {
+			impl<Model, Type> FieldRef<Model, Type, UnverifiedModelField> {
 				pub const fn new(name: &'static str) -> Self {
 					Self {
 						name,
 						_marker: core::marker::PhantomData,
 					}
 				}
+			}
 
+			impl<Model, Type> FieldRef<Model, Type, GeneratedModelField> {
 				pub const unsafe fn from_model_field(name: &'static str) -> Self {
-					Self::new(name)
+					Self {
+						name,
+						_marker: core::marker::PhantomData,
+					}
 				}
+			}
 
+			impl<Model, Type, Origin> FieldRef<Model, Type, Origin> {
 				pub const fn name(&self) -> &'static str {
 					self.name
 				}
 
 				pub fn eq(self, _value: impl Into<Type>) -> bool {
 					true
+				}
+			}
+
+			#[derive(Debug, Clone, Copy)]
+			pub struct OrderingField<Model> {
+				_marker: core::marker::PhantomData<Model>,
+			}
+
+			impl<Model> OrderingField<Model> {
+				pub const unsafe fn from_model_field(_name: &'static str) -> Self {
+					Self {
+						_marker: core::marker::PhantomData,
+					}
 				}
 			}
 
@@ -652,9 +678,9 @@ pub mod db {
 					}
 				}
 
-				pub fn field<Value>(
+				pub fn field<Value, Origin>(
 					self,
-					field: super::expressions::FieldRef<Target, Value>,
+					field: super::expressions::FieldRef<Target, Value, Origin>,
 				) -> RelatedFieldRef<Root, Target, Value> {
 					RelatedFieldRef {
 						field: field.name(),


### PR DESCRIPTION
## Summary

This PR addresses:

- Aligns the shared model macro test support with the current generated field proof API.
- Restores the `relation_info_serde` test target that blocks release PR #5876.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The model derive now emits origin-typed `FieldRef` values and `OrderingField` proofs. The shared UI-test support still modeled the earlier two-parameter field reference and omitted ordering proofs, so `cargo check --workspace --all-features --tests` failed while compiling `relation_info_serde`.

Related to: #5876

## How Was This Tested?

- `cargo check --package reinhardt-macros --test relation_info_serde --all-features`
- `cargo test --package reinhardt-macros --test relation_info_serde --all-features`
- `cargo check --workspace --all-features --tests --quiet`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Release PR #5876

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This repair targets `develop/0.4.0` so release-plz can regenerate #5876 after the base fix merges.