### PR TITLE
ci: enable sccache for Rust compilation

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -31,6 +31,13 @@ runs:
       with:
         version: "v0.10.0"
 
+    - name: Enable sccache for Rust compilation
+      if: inputs.cache == 'true'
+      shell: bash
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> "$GITHUB_ENV"
+
     # Issue #1831: Detect the actual CARGO_TARGET_DIR from the calling workflow's
     # environment. Workflows set CARGO_TARGET_DIR to an absolute path (e.g.
     # /tmp/cargo_target or $RUNNER_TEMP/cargo_target) to conserve workspace disk

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -31,7 +31,9 @@ runs:
       with:
         version: "v0.10.0"
 
-    - name: Enable sccache for Rust compilation
+    # sccache-action installs the binary and reports statistics, but Rust and the
+    # GitHub Actions cache backend must be enabled explicitly.
+    - name: Enable sccache for Rust builds
       if: inputs.cache == 'true'
       shell: bash
       run: |


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- Enables the GitHub Actions cache backend for sccache when Rust caching is enabled.
- Routes subsequent Cargo/rustc compilation through the sccache executable installed by the shared setup action.
- Keeps cache-disabled workflows unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The shared Rust setup action installed sccache and printed its statistics, but it did not configure rustc to use sccache or enable the GitHub Actions cache backend. As a result, CI jobs reported zero compile requests and zero cache hits.

Exporting `SCCACHE_GHA_ENABLED` and `RUSTC_WRAPPER` through `GITHUB_ENV` makes them available to later steps in every cache-enabled job.

## How Was This Tested?

- [x] Parsed `.github/actions/setup-rust/action.yml` with Ruby Psych.
- [x] Ran `git diff --check`.
- [x] Executed the new shell commands with a representative `SCCACHE_PATH` and verified the exact `GITHUB_ENV` output.
- [x] Confirmed the pinned sccache action documentation requires `SCCACHE_GHA_ENABLED` and `RUSTC_WRAPPER` for Rust.

## Performance Impact

This enables compiler artifact reuse through the GitHub Actions cache backend. Cache misses are expected during initial population, followed by non-zero cache hits for reusable compilation units in later compatible jobs.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (not applicable; this only activates existing internal CI cache wiring)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (static configuration and shell behavior checks)
- [x] New and existing unit tests pass locally with my changes (not applicable; no Rust code changed)
- [x] I have tested with all affected database backends (not applicable)
- [x] I have formatted the code with `cargo make fmt-fix` (not applicable; no Rust code changed)
- [x] I have checked the code with `cargo make clippy-check` (not applicable; no Rust code changed)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The environment variables are only exported when `inputs.cache == 'true'`, matching the existing sccache installation gate.

🤖 Generated with [OpenAI Codex](https://openai.com/codex)