### PR TITLE
fix(ci): enable sccache for Rust builds

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -31,6 +31,15 @@ runs:
       with:
         version: "v0.10.0"
 
+    # sccache-action installs the binary and reports statistics, but Rust and the
+    # GitHub Actions cache backend must be enabled explicitly.
+    - name: Enable sccache for Rust builds
+      if: inputs.cache == 'true'
+      shell: bash
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> "$GITHUB_ENV"
+
     # Issue #1831: Detect the actual CARGO_TARGET_DIR from the calling workflow's
     # environment. Workflows set CARGO_TARGET_DIR to an absolute path (e.g.
     # /tmp/cargo_target or $RUNNER_TEMP/cargo_target) to conserve workspace disk


### PR DESCRIPTION
## Summary

This PR addresses:

- Route Rust compiler invocations through the sccache binary installed by the shared setup action.
- Enable the GitHub Actions cache backend so sccache entries persist across eligible CI runs.
- Document why the environment variables must be configured explicitly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The shared Rust setup action installed sccache and printed post-job statistics, but it did not set `RUSTC_WRAPPER` or enable the GitHub Actions backend. As a result, successful compilation jobs consistently reported zero compile requests, zero hits, and zero misses.

This change exports the required settings only when the existing `cache` input is enabled. Workflows that pass `cache: 'false'` remain unaffected.

## How Was This Tested?

- [x] Parsed the composite action metadata and asserted the new step, cache guard, and both environment exports.
- [x] Executed the export commands against a temporary `GITHUB_ENV` file and verified the exact values.
- [x] Ran `git diff --check`.
- [ ] Full repository `actionlint` is clean. It currently reports unrelated pre-existing findings in existing workflows; this PR does not modify those workflows.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- No linked issue.

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical`
- [ ] `high`
- [ ] `medium`
- [ ] `low`

---

**Additional Context:**

Expected sccache statistics after the cache is cold are non-zero misses. Subsequent compatible runs should then report non-zero hits.

🤖 Generated with [Codex](https://openai.com/codex)
