### PR TITLE
fix(introspect): retain table name in validation errors

### DIFF
--- a/crates/reinhardt-db/src/migrations/introspect/generator.rs
+++ b/crates/reinhardt-db/src/migrations/introspect/generator.rs
@@ -674,7 +674,8 @@ fn module_identifier(table_name: &str) -> String {
 fn validate_generated_identifier(table_name: &str, identifier: &str) -> Result<()> {
 	syn::parse_str::<syn::Ident>(identifier).map_err(|_| {
 		MigrationError::IntrospectionError(format!(
-			"table `{table_name}` does not normalize to a valid Rust model identifier"
+			"table `{}` does not normalize to a valid Rust model identifier",
+			table_name
 		))
 	})?;
 	Ok(())


### PR DESCRIPTION
## Summary

This PR addresses:

- the CodeQL unused-variable finding introduced by #5859 while preserving the existing table-specific validation error.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

Use an explicit formatting argument so static analysis recognizes `table_name` as consumed without changing the generated identifier validation behavior.

Related to: #5859

## How Was This Tested?

- `cargo fmt --check`
- `git diff --check`

A scoped `reinhardt-db` test build was started, but this new isolated worktree required a full dependency rebuild; it was stopped before completion.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5859

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations

**Additional Context:**

- Preserves the existing user-facing error text exactly.