### PR TITLE
fix(grpc): restore facade-only handler DI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,14 @@ signals = ["reinhardt-core/signals"]
 # DI feature: Uses reinhardt-core/di which internally enables reinhardt-di/params
 # Also directly enables reinhardt-di/params for macro support (extern crate reinhardt_di)
 # reinhardt-db/di enables Injectable implementation for DatabaseConnection
-di = ["reinhardt-di", "reinhardt-di/params", "reinhardt-di/macros", "reinhardt-db?/di"]
+# reinhardt-grpc?/di enables facade-only #[grpc_handler] DI when grpc is active
+di = [
+  "reinhardt-di",
+  "reinhardt-di/params",
+  "reinhardt-di/macros",
+  "reinhardt-db?/di",
+  "reinhardt-grpc?/di",
+]
 test = ["reinhardt-test"]
 testcontainers = ["test", "reinhardt-test/testcontainers"]
 server-fn-test = ["test", "reinhardt-test/server-fn-test"]

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -43,3 +43,4 @@ tokio-test = { workspace = true }
 rstest = { workspace = true }
 tracing = { workspace = true }
 toml = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/reinhardt-grpc/README.md
+++ b/crates/reinhardt-grpc/README.md
@@ -190,7 +190,7 @@ use reinhardt::grpc::proto::common::{Empty, Timestamp, PageInfo};
 
 Facade consumers can enable `grpc` alongside a preset that includes DI:
 
-<!-- reinhardt-version-sync:2 -->
+<!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
 reinhardt = { version = "0.3.4", package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }
@@ -203,6 +203,14 @@ feature explicitly and depend on `reinhardt-di` for DI types:
 [dependencies]
 reinhardt-grpc = { version = "0.3.4", features = ["di"] }
 reinhardt-di = "0.3.4"
+```
+
+The basic example below uses the facade configuration. Direct consumers should
+use the following imports instead:
+
+```rust
+use reinhardt_di::InjectionContext;
+use reinhardt_grpc::{GrpcRequestExt, grpc_handler};
 ```
 
 #### Basic Usage

--- a/crates/reinhardt-grpc/README.md
+++ b/crates/reinhardt-grpc/README.md
@@ -188,9 +188,17 @@ use reinhardt::grpc::proto::common::{Empty, Timestamp, PageInfo};
 
 ### Dependency Injection
 
-Enable the `di` feature to use dependency injection in gRPC handlers:
+Facade consumers can enable `grpc` alongside a preset that includes DI:
 
 <!-- reinhardt-version-sync:2 -->
+```toml
+[dependencies]
+reinhardt = { version = "0.3.4", package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }
+```
+
+Direct `reinhardt-grpc` consumers can instead enable this crate's `di`
+feature explicitly and depend on `reinhardt-di` for DI types:
+
 ```toml
 [dependencies]
 reinhardt-grpc = { version = "0.3.4", features = ["di"] }
@@ -200,8 +208,8 @@ reinhardt-di = "0.3.4"
 #### Basic Usage
 
 ```rust
+use reinhardt::di::InjectionContext;
 use reinhardt::grpc::{GrpcRequestExt, grpc_handler};
-use reinhardt_di::InjectionContext;
 use tonic::{Request, Response, Status};
 use std::sync::Arc;
 

--- a/crates/reinhardt-grpc/macros/Cargo.toml
+++ b/crates/reinhardt-grpc/macros/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits"] }
 proc-macro-crate = "3.1"
+toml_edit = "0.25.10"
 
 [dev-dependencies]
 trybuild = { workspace = true }

--- a/crates/reinhardt-grpc/macros/src/crate_paths.rs
+++ b/crates/reinhardt-grpc/macros/src/crate_paths.rs
@@ -3,34 +3,48 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
+fn crate_path(package_name: &str) -> Option<TokenStream> {
+	use proc_macro_crate::{FoundCrate, crate_name};
+
+	match crate_name(package_name) {
+		Ok(FoundCrate::Itself) => Some(quote!(crate)),
+		Ok(FoundCrate::Name(name)) => {
+			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
+			Some(quote!(::#ident))
+		}
+		Err(_) => None,
+	}
+}
+
+fn facade_module_path(module: &str) -> Option<TokenStream> {
+	use proc_macro_crate::{FoundCrate, crate_name};
+
+	let module_ident = syn::Ident::new(module, proc_macro2::Span::call_site());
+
+	match crate_name("reinhardt-web") {
+		Ok(FoundCrate::Itself) => Some(quote!(crate::#module_ident)),
+		Ok(FoundCrate::Name(name)) => {
+			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
+			Some(quote!(::#ident::#module_ident))
+		}
+		Err(_) => None,
+	}
+}
+
 /// Resolves the path to the reinhardt_di crate dynamically.
 ///
 /// This supports different crate naming scenarios (reinhardt-di, renamed crates, etc.)
 pub(crate) fn get_reinhardt_di_crate() -> TokenStream {
-	use proc_macro_crate::{FoundCrate, crate_name};
-
-	match crate_name("reinhardt-di") {
-		Ok(FoundCrate::Itself) => quote!(crate),
-		Ok(FoundCrate::Name(name)) => {
-			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
-			quote!(::#ident)
-		}
-		Err(_) => quote!(::reinhardt_di), // Fallback
-	}
+	crate_path("reinhardt-di")
+		.or_else(|| facade_module_path("di"))
+		.unwrap_or_else(|| quote!(::reinhardt_di))
 }
 
 /// Resolves the path to the reinhardt_grpc crate dynamically.
 ///
 /// This supports different crate naming scenarios (reinhardt-grpc, renamed crates, etc.)
 pub(crate) fn get_reinhardt_grpc_crate() -> TokenStream {
-	use proc_macro_crate::{FoundCrate, crate_name};
-
-	match crate_name("reinhardt-grpc") {
-		Ok(FoundCrate::Itself) => quote!(crate),
-		Ok(FoundCrate::Name(name)) => {
-			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
-			quote!(::#ident)
-		}
-		Err(_) => quote!(::reinhardt_grpc), // Fallback
-	}
+	crate_path("reinhardt-grpc")
+		.or_else(|| facade_module_path("grpc"))
+		.unwrap_or_else(|| quote!(::reinhardt_grpc))
 }

--- a/crates/reinhardt-grpc/macros/src/crate_paths.rs
+++ b/crates/reinhardt-grpc/macros/src/crate_paths.rs
@@ -23,9 +23,11 @@ fn facade_module_path(module: &str) -> Option<TokenStream> {
 
 	match crate_name("reinhardt-web") {
 		Ok(FoundCrate::Itself) => Some(quote!(crate::#module_ident)),
-		// The facade package exposes the `reinhardt` library target when it is
-		// declared without an explicit `package` alias.
-		Ok(FoundCrate::Name(name)) if name == "reinhardt_web" => {
+		// The facade package exposes the `reinhardt` library target only when
+		// its dependency declaration has no explicit package alias.
+		Ok(FoundCrate::Name(name))
+			if name == "reinhardt_web" && has_package_only_facade_dependency() =>
+		{
 			Some(quote!(::reinhardt::#module_ident))
 		}
 		Ok(FoundCrate::Name(name)) => {
@@ -34,6 +36,52 @@ fn facade_module_path(module: &str) -> Option<TokenStream> {
 		}
 		Err(_) => None,
 	}
+}
+
+fn has_package_only_facade_dependency() -> bool {
+	use toml_edit::{DocumentMut, Item};
+
+	let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") else {
+		return false;
+	};
+	let manifest_path = std::path::Path::new(&manifest_dir).join("Cargo.toml");
+	let Ok(manifest) = std::fs::read_to_string(manifest_path) else {
+		return false;
+	};
+	let Ok(document) = manifest.parse::<DocumentMut>() else {
+		return false;
+	};
+
+	["dependencies", "dev-dependencies"]
+		.into_iter()
+		.any(|table_name| {
+			document
+				.get(table_name)
+				.and_then(Item::as_table_like)
+				.is_some_and(has_unaliased_facade_dependency)
+		}) || document
+		.get("target")
+		.and_then(Item::as_table_like)
+		.is_some_and(|targets| {
+			targets.iter().any(|(_, target)| {
+				target.as_table_like().is_some_and(|target_table| {
+					["dependencies", "dev-dependencies"]
+						.into_iter()
+						.any(|table_name| {
+							target_table
+								.get(table_name)
+								.and_then(Item::as_table_like)
+								.is_some_and(has_unaliased_facade_dependency)
+						})
+				})
+			})
+		})
+}
+
+fn has_unaliased_facade_dependency(dependencies: &dyn toml_edit::TableLike) -> bool {
+	dependencies
+		.get("reinhardt-web")
+		.is_some_and(|dependency| dependency.get("package").is_none())
 }
 
 /// Resolves the path to the reinhardt_di crate dynamically.

--- a/crates/reinhardt-grpc/macros/src/crate_paths.rs
+++ b/crates/reinhardt-grpc/macros/src/crate_paths.rs
@@ -23,6 +23,11 @@ fn facade_module_path(module: &str) -> Option<TokenStream> {
 
 	match crate_name("reinhardt-web") {
 		Ok(FoundCrate::Itself) => Some(quote!(crate::#module_ident)),
+		// The facade package exposes the `reinhardt` library target when it is
+		// declared without an explicit `package` alias.
+		Ok(FoundCrate::Name(name)) if name == "reinhardt_web" => {
+			Some(quote!(::reinhardt::#module_ident))
+		}
 		Ok(FoundCrate::Name(name)) => {
 			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
 			Some(quote!(::#ident::#module_ident))

--- a/crates/reinhardt-grpc/macros/src/grpc_handler.rs
+++ b/crates/reinhardt-grpc/macros/src/grpc_handler.rs
@@ -291,10 +291,7 @@ pub(crate) fn expand_grpc_handler(input: ItemFn) -> Result<TokenStream> {
 		let __di_ctx = {
 			let __shared_ctx = #request_pat
 				.get_di_context::<::std::sync::Arc<#di_crate::InjectionContext>>()
-				.ok_or_else(|| {
-					::tracing::error!("DI context not found in request extensions");
-					::tonic::Status::internal("Internal server error")
-				})?;
+				.ok_or_else(|| #grpc_crate::di::sanitize_missing_context())?;
 			::std::sync::Arc::new((*__shared_ctx).fork())
 		};
 	};
@@ -316,10 +313,7 @@ pub(crate) fn expand_grpc_handler(input: ItemFn) -> Result<TokenStream> {
 					#di_crate::__InjectResolver::<#ty>::new()
 						.__resolve_inject_parameter(&__di_ctx, #use_cache)
 						.await
-						.map_err(|e| {
-							::tracing::error!("DI resolution failed for {}: {:?}", stringify!(#ty), e);
-							::tonic::Status::internal("Internal server error")
-						})?
+						.map_err(|e| #grpc_crate::di::sanitize_di_error(&e))?
 				};
 			}
 		})

--- a/crates/reinhardt-grpc/src/di.rs
+++ b/crates/reinhardt-grpc/src/di.rs
@@ -16,8 +16,8 @@
 //! # Example
 //!
 //! ```rust,no_run,ignore
-//! # use reinhardt_grpc::{GrpcRequestExt, grpc_handler};
-//! # use reinhardt_di::InjectionContext;
+//! # use reinhardt::di::InjectionContext;
+//! # use reinhardt::grpc::{GrpcRequestExt, grpc_handler};
 //! # use tonic::{Request, Response, Status};
 //! # use std::sync::Arc;
 //! # struct GetUserRequest { id: i64 }
@@ -69,9 +69,9 @@ pub trait GrpcRequestExt {
 	///
 	/// # Example
 	///
-	/// ```rust,no_run
-	/// # use reinhardt_grpc::GrpcRequestExt;
-	/// # use reinhardt_di::InjectionContext;
+	/// ```rust,ignore
+	/// # use reinhardt::di::InjectionContext;
+	/// # use reinhardt::grpc::GrpcRequestExt;
 	/// # use std::sync::Arc;
 	/// # use tonic::Request;
 	/// # fn example<T>(request: &Request<T>) -> Option<Arc<InjectionContext>> {

--- a/crates/reinhardt-grpc/src/di.rs
+++ b/crates/reinhardt-grpc/src/di.rs
@@ -69,9 +69,9 @@ pub trait GrpcRequestExt {
 	///
 	/// # Example
 	///
-	/// ```rust,ignore
-	/// # use reinhardt::di::InjectionContext;
-	/// # use reinhardt::grpc::GrpcRequestExt;
+	/// ```rust,no_run
+	/// # use reinhardt_di::InjectionContext;
+	/// # use reinhardt_grpc::GrpcRequestExt;
 	/// # use std::sync::Arc;
 	/// # use tonic::Request;
 	/// # fn example<T>(request: &Request<T>) -> Option<Arc<InjectionContext>> {

--- a/crates/reinhardt-grpc/src/lib.rs
+++ b/crates/reinhardt-grpc/src/lib.rs
@@ -34,17 +34,21 @@
 //!
 //! ## Dependency Injection
 //!
-//! Enable the `di` feature to use dependency injection in gRPC handlers:
+//! Facade consumers can enable `grpc` alongside a preset that includes DI:
 //!
 //! ```toml
 //! [dependencies]
-//! reinhardt-grpc = { version = "0.1", features = ["di"] }
+//! reinhardt = { version = "0.3.4", package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }
 //! ```
+//!
+//! Direct `reinhardt-grpc` consumers can instead enable this crate's `di`
+//! feature explicitly and depend on `reinhardt-di` for DI types.
 //!
 //! Then use the `#[grpc_handler]` macro:
 //!
 //! ```rust,ignore
-//! # use reinhardt_grpc::{GrpcRequestExt, grpc_handler};
+//! # use reinhardt::di::InjectionContext;
+//! # use reinhardt::grpc::{GrpcRequestExt, grpc_handler};
 //! # use tonic::{Request, Response, Status};
 //! # struct GetUserRequest;
 //! # struct User;

--- a/crates/reinhardt-grpc/tests/facade_only_di.rs
+++ b/crates/reinhardt-grpc/tests/facade_only_di.rs
@@ -1,0 +1,125 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[test]
+fn facade_only_dependency_compiles_grpc_handler_di() {
+	run_facade_fixture("renamed", "reinhardt", "reinhardt");
+	run_facade_fixture("unrenamed", "reinhardt-web", "reinhardt_web");
+}
+
+fn run_facade_fixture(case: &str, dependency_key: &str, crate_ident: &str) {
+	let crate_dir = tempfile::tempdir().expect("create downstream fixture directory");
+	let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("../..")
+		.canonicalize()
+		.expect("resolve repository root");
+	let repo_root_toml = toml::Value::String(repo_root.to_string_lossy().into_owned()).to_string();
+	let target_dir = shared_target_dir(&repo_root);
+
+	fs::create_dir(crate_dir.path().join("src")).expect("create downstream src directory");
+	fs::write(
+		crate_dir.path().join("Cargo.toml"),
+		format!(
+			r#"[package]
+name = "reinhardt-grpc-facade-only-di-fixture-{case}"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[dependencies]
+{dependency_key} = {{ path = {repo_root_toml}, package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }}
+tonic = "0.14.2"
+"#
+		),
+	)
+	.expect("write downstream manifest");
+	fs::write(
+		crate_dir.path().join("src/main.rs"),
+		format!(
+			r#"use {crate_ident}::di::{{Depends, InjectableKey, InjectionContext}};
+use {crate_ident}::grpc::{{GrpcRequestExt, grpc_handler}};
+use std::sync::Arc;
+use tonic::{{Request, Response, Status}};
+
+struct ConfigKey;
+
+impl InjectableKey for ConfigKey {{}}
+
+struct ConfigService;
+struct MyRequest;
+struct MyResponse;
+
+#[grpc_handler]
+async fn handler(
+	request: Request<MyRequest>,
+	#[inject] _service: Depends<ConfigKey, ConfigService>,
+) -> Result<Response<MyResponse>, Status> {{
+	let _ = request.into_inner();
+	Ok(Response::new(MyResponse))
+}}
+
+fn context_from_request(request: &Request<MyRequest>) -> Option<Arc<InjectionContext>> {{
+	request.get_di_context::<Arc<InjectionContext>>()
+}}
+
+fn main() {{
+	let _handler = handler;
+	let _extractor = context_from_request;
+}}
+"#
+		),
+	)
+	.expect("write downstream source");
+
+	let output = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+		.arg("check")
+		.arg("--manifest-path")
+		.arg(crate_dir.path().join("Cargo.toml"))
+		.arg("--target-dir")
+		.arg(target_dir)
+		.arg("--offline")
+		.output()
+		.expect("run downstream facade-only cargo check");
+
+	assert!(
+		output.status.success(),
+		"facade-only gRPC DI fixture {case} should compile\nstdout:\n{}\nstderr:\n{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+}
+
+fn shared_target_dir(repo_root: &Path) -> PathBuf {
+	if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+		let target_dir = PathBuf::from(target_dir);
+		return if target_dir.is_absolute() {
+			target_dir
+		} else {
+			repo_root.join(target_dir)
+		};
+	}
+
+	if let Some(target_dir) = current_test_target_dir() {
+		return target_dir;
+	}
+
+	repo_root.join("target")
+}
+
+fn current_test_target_dir() -> Option<PathBuf> {
+	let current_exe = std::env::current_exe().ok()?;
+	for ancestor in current_exe.ancestors() {
+		let Some(name) = ancestor.file_name().and_then(|name| name.to_str()) else {
+			continue;
+		};
+		if matches!(name, "debug" | "release") {
+			return ancestor.parent().map(Path::to_path_buf);
+		}
+	}
+	None
+}

--- a/crates/reinhardt-grpc/tests/facade_only_di.rs
+++ b/crates/reinhardt-grpc/tests/facade_only_di.rs
@@ -6,17 +6,22 @@ use std::process::Command;
 
 #[test]
 fn facade_only_dependency_compiles_grpc_handler_di() {
-	run_facade_fixture("renamed", "reinhardt", "reinhardt");
-	run_facade_fixture("unrenamed", "reinhardt-web", "reinhardt_web");
+	run_facade_fixture("renamed", "reinhardt", true, "reinhardt");
+	run_facade_fixture("package-only", "reinhardt-web", false, "reinhardt");
 }
 
-fn run_facade_fixture(case: &str, dependency_key: &str, crate_ident: &str) {
+fn run_facade_fixture(case: &str, dependency_key: &str, package_alias: bool, crate_ident: &str) {
 	let crate_dir = tempfile::tempdir().expect("create downstream fixture directory");
 	let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
 		.join("../..")
 		.canonicalize()
 		.expect("resolve repository root");
 	let repo_root_toml = toml::Value::String(repo_root.to_string_lossy().into_owned()).to_string();
+	let package_spec = if package_alias {
+		", package = \"reinhardt-web\""
+	} else {
+		""
+	};
 	let target_dir = shared_target_dir(&repo_root);
 
 	fs::create_dir(crate_dir.path().join("src")).expect("create downstream src directory");
@@ -32,7 +37,7 @@ publish = false
 [workspace]
 
 [dependencies]
-{dependency_key} = {{ path = {repo_root_toml}, package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }}
+{dependency_key} = {{ path = {repo_root_toml}{package_spec}, default-features = false, features = ["minimal", "grpc"] }}
 tonic = "0.14.2"
 "#
 		),

--- a/crates/reinhardt-grpc/tests/facade_only_di.rs
+++ b/crates/reinhardt-grpc/tests/facade_only_di.rs
@@ -8,6 +8,18 @@ use std::process::Command;
 fn facade_only_dependency_compiles_grpc_handler_di() {
 	run_facade_fixture("renamed", "reinhardt", true, "reinhardt");
 	run_facade_fixture("package-only", "reinhardt-web", false, "reinhardt");
+	run_facade_fixture(
+		"explicit-package-alias",
+		"reinhardt-web",
+		true,
+		"reinhardt_web",
+	);
+	run_facade_fixture(
+		"normalized-package-alias",
+		"reinhardt_web",
+		true,
+		"reinhardt_web",
+	);
 }
 
 fn run_facade_fixture(case: &str, dependency_key: &str, package_alias: bool, crate_ident: &str) {


### PR DESCRIPTION
## Summary

This PR addresses:

- Restores facade-only access to `reinhardt::grpc::grpc_handler` with DI enabled.
- Resolves macro paths through direct dependencies or the renamed `reinhardt-web` facade.
- Removes the generated downstream `tracing` requirement and adds compile coverage for both facade dependency forms.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Published 0.3.3 facade consumers cannot import `grpc_handler` with DI, and macro expansion requires a direct `tracing` dependency. This backport makes the facade API self-contained.

Fixes #5865
Fixes #5866

Related to: #5535

## How Was This Tested?

- [x] `cargo test --package reinhardt-grpc --features di`
- [x] `cargo test --package reinhardt-grpc-macros`
- [x] `cargo check --package reinhardt-web --no-default-features --features minimal,di,grpc`
- [x] `cargo clippy --package reinhardt-grpc --features di --all-targets -- -D warnings`
- [x] `cargo clippy --package reinhardt-web --no-default-features --features minimal,di,grpc -- -D warnings`
- [x] `cargo doc --package reinhardt-grpc --no-deps`

## Checklist

- [x] I have updated the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [x] I have checked the code with `cargo clippy`

## Labels to Apply

- [x] `bug` - Bug fix

🤖 Generated with Codex