### PR TITLE
fix(ci): enable coverage uploads on develop branches

### DIFF
--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'develop/*'
   workflow_dispatch:
 
 permissions:
@@ -11,7 +12,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: coverage-main
+  group: coverage-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -22,4 +23,3 @@ jobs:
     with:
       runner: '"ubuntu-latest"'
       cargo-build-jobs: '1'
-      run-all: 'true'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -337,8 +337,14 @@ jobs:
           else
             FILTER_EXPR="not binary(/ui/)"
           fi
+          # Restrict LLVM coverage instrumentation to the native test target.
+          # Nested fixture builds target wasm32-unknown-unknown, whose toolchain
+          # does not include the profiler runtime required by instrument-coverage.
+          HOST_TARGET="$(rustc -vV | awk '/^host:/{print $2}')"
           set +e
           cargo llvm-cov nextest \
+            --target "$HOST_TARGET" \
+            --coverage-target-only \
             --no-report \
             --workspace \
             --test "*" \


### PR DESCRIPTION
## Summary

This PR addresses:

- Runs the reusable coverage workflow for pushes to versioned `develop/*` branches.
- Scopes LLVM coverage instrumentation to the native test target so nested WASM fixtures remain buildable.
- Isolates coverage concurrency by Git ref so different develop branches do not cancel each other.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The reusable workflow already generates and uploads unit, intra-crate, and cross-crate Codecov reports, but its push caller only selected `main`. Adding `develop/*` makes those uploads run for versioned development branches.

The intra-crate job also launches nested `wasm32-unknown-unknown` fixture builds. Restricting coverage flags to the detected native target prevents those child builds from inheriting `-C instrument-coverage` and failing on the unavailable profiler runtime.

Related to: #5908

## How Was This Tested?

- `git diff --check`
- `actionlint .github/workflows/coverage-main.yml .github/workflows/coverage.yml`
- `cargo fmt --all --check`
- Verified `cargo llvm-cov show-env --target <host> --coverage-target-only` emits target-specific coverage flags and no global `RUSTFLAGS`.
- Verified the caller workflow matches the corresponding main-targeted change.

The full coverage suite was not run locally because independent Cargo builds were active; GitHub Actions will exercise the affected workflows.

## Checklist

- [x] I have followed the [Commit Guidelines](../blob/develop/0.4.0/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] Formatting was verified with `cargo fmt --all --check`
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Main-targeted coverage fix: #5908
- Failed coverage run: https://github.com/kent8192/reinhardt-web/actions/runs/30750307700

## Labels to Apply

### Type Label (select one)

- [x] `bug` - Bug fix

### Scope Label (select all that apply)

- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

The `develop/*` pattern covers versioned branches such as `develop/0.4.0`, while the ref-specific concurrency group keeps their runs independent.

🤖 Generated with [Codex](https://openai.com/codex)
