### PR TITLE
fix!(auth): backport validated session account state to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,17 +901,14 @@ use reinhardt::{Response, StatusCode, ViewResult, get};
 use reinhardt::auth::CurrentUser;
 use crate::models::User;
 
-// SessionMiddleware or JwtAuthMiddleware must be registered in urls.rs to
-// populate AuthState in request extensions.
+// AuthenticationMiddleware or JwtAuthMiddleware must be registered in urls.rs
+// to validate the current user and populate AuthState in request extensions.
 #[get("/profile", name = "get_profile")]
 pub async fn get_profile(
 	#[inject] CurrentUser(user): CurrentUser<User>,
 ) -> ViewResult<Response> {
-	// CurrentUser<U> loads the full user model from the database using the AuthState
-	// set by authentication middleware. Returns an injection error if unauthenticated.
-	if !user.is_active() {
-		return Err("User account is inactive".into());
-	}
+	// CurrentUser<U> loads and validates the full user model from the database
+	// using AuthState set by authentication middleware.
 
 	let json = serde_json::to_string(&user)?;
 	Ok(Response::new(StatusCode::OK).with_body(json))

--- a/crates/reinhardt-auth/src/auth_user.rs
+++ b/crates/reinhardt-auth/src/auth_user.rs
@@ -38,6 +38,7 @@ use reinhardt_http::AuthState;
 /// - `user_id` parse failure (HTTP 401, not nil UUID fallback)
 /// - `DatabaseConnection` not registered in DI (HTTP 503)
 /// - Database query failure (HTTP 500)
+/// - User account is inactive (HTTP 401)
 #[derive(Debug, Clone)]
 pub struct CurrentUser<U: BaseUser>(pub U);
 
@@ -95,7 +96,7 @@ where
 		})?;
 	let mut db = *db;
 
-	U::objects()
+	let user = U::objects()
 		.get(model_pk)
 		.first_with_db(&mut db)
 		.await
@@ -111,7 +112,16 @@ where
 				"CurrentUser: User not found in database"
 			);
 			DiError::NotFound("CurrentUser: User not found".to_string())
-		})
+		})?;
+
+	if !user.is_active() {
+		::tracing::warn!(user_id = %auth_state.user_id(), "CurrentUser: User account is inactive");
+		return Err(DiError::Authentication(
+			"CurrentUser: User account is inactive".to_string(),
+		));
+	}
+
+	Ok(user)
 }
 
 #[cfg(feature = "params")]

--- a/crates/reinhardt-middleware/README.md
+++ b/crates/reinhardt-middleware/README.md
@@ -256,14 +256,13 @@ The `session` module ships three companion helpers for the
 `#[server_fn]` / `#[inject]` patterns used by authenticated handlers
 (introduced in [#4446](https://github.com/kent8192/reinhardt-web/issues/4446)):
 
-`SessionMiddleware` is the recommended single middleware for cookie-backed
-session authentication. It loads the active `SessionData`, publishes the
-middleware-owned `SessionStore` to DI, and derives `AuthState` from
-`USER_ID_SESSION_KEY` when the session is authenticated. Handlers can therefore
-combine `SessionAuthExt::login` / `logout` with `CurrentUser<U>` without adding
-`CookieSessionAuthMiddleware` as a second layer. `CookieSessionAuthMiddleware`
-remains available for applications that use a custom `AsyncSessionBackend`
-directly.
+`SessionMiddleware` manages cookie-backed `SessionData` and publishes its
+middleware-owned `SessionStore` to DI. A session `USER_ID_SESSION_KEY` is only
+an identity reference; it does not establish `AuthState` because account status
+and privileges can change after a session is created. Configure an
+authentication middleware that validates the current user record before using
+`CurrentUser<U>` or authorization guards. `CookieSessionAuthMiddleware` remains
+available for applications that use a custom `AsyncSessionBackend` directly.
 
 - `USER_ID_SESSION_KEY` — the canonical session-store key (`"user_id"`)
   every handler should read from / write to instead of hardcoding a literal.
@@ -292,8 +291,8 @@ use reinhardt::middleware::session::SessionValue;
 pub async fn current_profile(
     SessionValue(user_id): SessionValue<i64>,
 ) -> Result<UserInfo, ServerFnError> {
-    // user_id is the authenticated user's primary key; the server fn
-    // returns HTTP 401 automatically when the session is anonymous.
+    // user_id is the session's identity reference. Authorize the request with
+    // middleware that validates the current user before accessing protected data.
     load_profile(user_id).await
 }
 ```

--- a/crates/reinhardt-middleware/README.md
+++ b/crates/reinhardt-middleware/README.md
@@ -262,7 +262,8 @@ an identity reference; it does not establish `AuthState` because account status
 and privileges can change after a session is created. Configure an
 authentication middleware that validates the current user record before using
 `CurrentUser<U>` or authorization guards. `CookieSessionAuthMiddleware` remains
-available for applications that use a custom `AsyncSessionBackend` directly.
+available for custom `AsyncSessionBackend` integrations, but it only restores
+flags stored in the session and must not be treated as an account validator.
 
 - `USER_ID_SESSION_KEY` — the canonical session-store key (`"user_id"`)
   every handler should read from / write to instead of hardcoding a literal.

--- a/crates/reinhardt-middleware/src/lib.rs
+++ b/crates/reinhardt-middleware/src/lib.rs
@@ -132,8 +132,8 @@
 //! 3. `TracingMiddleware` - Start tracing span
 //! 4. `SecurityMiddleware` - Apply security headers
 //! 5. `CorsMiddleware` - Handle CORS preflight
-//! 6. `SessionMiddleware` - Load session and populate `AuthState`
-//! 7. `AuthenticationMiddleware` or `JwtAuthMiddleware` - Authenticate non-session credentials
+//! 6. `SessionMiddleware` - Load and manage session data
+//! 7. `AuthenticationMiddleware` or `JwtAuthMiddleware` - Validate and populate authentication state
 //! 8. `LoginRequiredMiddleware` - Enforce login (optional)
 //! 9. `CsrfMiddleware` - Validate CSRF token
 //! 10. `RateLimitMiddleware` - Apply rate limits

--- a/crates/reinhardt-middleware/src/lib.rs
+++ b/crates/reinhardt-middleware/src/lib.rs
@@ -133,7 +133,7 @@
 //! 4. `SecurityMiddleware` - Apply security headers
 //! 5. `CorsMiddleware` - Handle CORS preflight
 //! 6. `SessionMiddleware` - Load and manage session data
-//! 7. `AuthenticationMiddleware` or `JwtAuthMiddleware` - Validate and populate authentication state
+//! 7. A session-store-compatible account validator, or `JwtAuthMiddleware` - Resolve the current account and populate authentication state
 //! 8. `LoginRequiredMiddleware` - Enforce login (optional)
 //! 9. `CsrfMiddleware` - Validate CSRF token
 //! 10. `RateLimitMiddleware` - Apply rate limits

--- a/crates/reinhardt-middleware/src/session/middleware.rs
+++ b/crates/reinhardt-middleware/src/session/middleware.rs
@@ -244,11 +244,11 @@ impl Middleware for SessionMiddleware {
 
 #[cfg(test)]
 mod tests {
-	use super::data::USER_ID_SESSION_KEY;
 	use super::*;
+	use crate::session::data::USER_ID_SESSION_KEY;
 	use bytes::Bytes;
 	use hyper::{HeaderMap, Method, Version};
-	use reinhardt_http::{AuthState, Handler, Request};
+	use reinhardt_http::{AuthState, Handler, IsActive, IsAdmin, IsAuthenticated, Request};
 	use rstest::rstest;
 	use std::sync::Mutex;
 	use std::time::Duration;

--- a/crates/reinhardt-middleware/src/session/middleware.rs
+++ b/crates/reinhardt-middleware/src/session/middleware.rs
@@ -1,16 +1,13 @@
 //! `SessionMiddleware`: cookie parsing, store wiring, and `Set-Cookie` writeback.
 
 use async_trait::async_trait;
-use reinhardt_http::{
-	AuthState, Handler, IsActive, IsAdmin, IsAuthenticated, Middleware, MiddlewareDiRegistration,
-	Request, Response, Result,
-};
+use reinhardt_http::{Handler, Middleware, MiddlewareDiRegistration, Request, Response, Result};
 use std::any::TypeId;
 use std::sync::Arc;
 
 use super::config::SessionConfig;
 use super::cookie::find_cookie_value;
-use super::data::{SessionData, USER_ID_SESSION_KEY};
+use super::data::SessionData;
 use super::id::{ActiveSessionId, SessionCookieName, SessionId};
 use super::store::{SessionStore, SessionStoreKey};
 
@@ -151,49 +148,6 @@ impl SessionMiddleware {
 
 		parts.join("; ")
 	}
-
-	fn user_id_from_session(session: &SessionData) -> Option<String> {
-		let value = session.data.get(USER_ID_SESSION_KEY)?;
-		let user_id = match value {
-			serde_json::Value::String(s) => s.clone(),
-			serde_json::Value::Number(n) => n.to_string(),
-			serde_json::Value::Bool(b) => b.to_string(),
-			_ => return None,
-		};
-
-		if user_id.is_empty() {
-			None
-		} else {
-			Some(user_id)
-		}
-	}
-
-	fn populate_auth_extensions(request: &Request, session: &SessionData) {
-		if request.extensions.contains::<AuthState>() {
-			return;
-		}
-
-		let Some(user_id) = Self::user_id_from_session(session) else {
-			request.extensions.insert(IsAuthenticated(false));
-			request.extensions.insert(IsAdmin(false));
-			request.extensions.insert(IsActive(false));
-			request.extensions.insert(AuthState::anonymous());
-			return;
-		};
-
-		let is_staff = session.get::<bool>("is_staff").unwrap_or(false);
-		let is_superuser = session.get::<bool>("is_superuser").unwrap_or(false);
-		let is_admin = is_staff || is_superuser;
-		let is_active = true;
-
-		request.extensions.insert(user_id.clone());
-		request.extensions.insert(IsAuthenticated(true));
-		request.extensions.insert(IsAdmin(is_admin));
-		request.extensions.insert(IsActive(is_active));
-		request
-			.extensions
-			.insert(AuthState::authenticated(user_id, is_admin, is_active));
-	}
 }
 
 impl Default for SessionMiddleware {
@@ -259,7 +213,6 @@ impl Middleware for SessionMiddleware {
 		// (`SessionData::regenerate_id`) keep `Set-Cookie` in sync. See #3827.
 		let active_id = ActiveSessionId::new(session.id.clone());
 		request.extensions.insert(active_id.clone());
-		Self::populate_auth_extensions(&request, &session);
 
 		// Call the handler
 		// Convert errors to responses so post-processing (e.g., security headers)
@@ -291,6 +244,7 @@ impl Middleware for SessionMiddleware {
 
 #[cfg(test)]
 mod tests {
+	use super::data::USER_ID_SESSION_KEY;
 	use super::*;
 	use bytes::Bytes;
 	use hyper::{HeaderMap, Method, Version};
@@ -435,14 +389,15 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn session_middleware_populates_auth_state_from_session_user_id() {
+	async fn session_middleware_does_not_authenticate_session_user_id() {
+		// Arrange: a valid session can contain an identity, but it cannot prove the
+		// account remains active or authorized.
 		let middleware = make_middleware();
 		let store = middleware.store_arc();
 		let mut session = SessionData::new(Duration::from_secs(3600));
 		session
 			.set(USER_ID_SESSION_KEY.to_string(), 42_i64)
 			.unwrap();
-		session.set("is_staff".to_string(), true).unwrap();
 		let session_id = session.id.clone();
 		store.save(session);
 
@@ -452,41 +407,13 @@ mod tests {
 			.await
 			.unwrap();
 
+		// Assert: an authentication middleware must validate the current account.
 		let captured = captured.lock().unwrap();
-		let auth_state = captured
-			.auth_state
-			.as_ref()
-			.expect("SessionMiddleware must insert AuthState");
-		assert!(auth_state.is_authenticated());
-		assert_eq!(auth_state.user_id(), "42");
-		assert!(auth_state.is_admin());
-		assert!(auth_state.is_active());
-		assert_eq!(captured.user_id.as_deref(), Some("42"));
-		assert_eq!(captured.is_authenticated, Some(IsAuthenticated(true)));
-		assert_eq!(captured.is_admin, Some(IsAdmin(true)));
-		assert_eq!(captured.is_active, Some(IsActive(true)));
-	}
-
-	#[tokio::test]
-	async fn session_middleware_populates_anonymous_auth_state_without_user_id() {
-		let middleware = make_middleware();
-		let (captured, handler) = capture_handler();
-
-		middleware
-			.process(request_without_cookie(), handler)
-			.await
-			.unwrap();
-
-		let captured = captured.lock().unwrap();
-		let auth_state = captured
-			.auth_state
-			.as_ref()
-			.expect("SessionMiddleware must insert anonymous AuthState");
-		assert!(auth_state.is_anonymous());
+		assert!(captured.auth_state.is_none());
 		assert!(captured.user_id.is_none());
-		assert_eq!(captured.is_authenticated, Some(IsAuthenticated(false)));
-		assert_eq!(captured.is_admin, Some(IsAdmin(false)));
-		assert_eq!(captured.is_active, Some(IsActive(false)));
+		assert!(captured.is_authenticated.is_none());
+		assert!(captured.is_admin.is_none());
+		assert!(captured.is_active.is_none());
 	}
 
 	#[tokio::test]

--- a/crates/reinhardt-middleware/src/session/value.rs
+++ b/crates/reinhardt-middleware/src/session/value.rs
@@ -2,8 +2,8 @@
 //!
 //! Four flavours mirror the rest of the Reinhardt extractor surface:
 //!
-//! - [`SessionValue<T>`] reads `session["user_id"]` and deserialises it as
-//!   `T`; 401 when the session or key is missing.
+//! - [`SessionValue<T>`] reads the identity reference at `session["user_id"]`
+//!   and deserialises it as `T`; 401 when the session or key is missing.
 //! - [`OptionalSessionValue<T>`] is the optional variant: any failure
 //!   collapses to `OptionalSessionValue(None)` rather than propagating.
 //! - [`SessionValueNamed<K, T>`] reads a custom session key chosen at
@@ -22,16 +22,21 @@
 //!
 //! // Auto-extraction (no `#[inject]`, matches `Path(...)` ergonomics).
 //! #[server_fn]
-//! pub async fn current_user(
+//! pub async fn session_identity(
 //!     SessionValue(user_id): SessionValue<i64>,
-//! ) -> Result<UserInfo, ServerFnError> { /* ... */ }
+//! ) -> Result<i64, ServerFnError> { Ok(user_id) }
 //!
 //! // Equivalent legacy form with `#[inject]`.
 //! #[server_fn]
-//! pub async fn current_user(
+//! pub async fn session_identity(
 //!     #[inject] SessionValue(user_id): SessionValue<i64>,
-//! ) -> Result<UserInfo, ServerFnError> { /* ... */ }
+//! ) -> Result<i64, ServerFnError> { Ok(user_id) }
 //! ```
+//!
+//! A stored identity is not proof of current authentication or authorization.
+//! Before granting access, resolve the account and validate its current active
+//! and privilege state, or consume an [`reinhardt_http::AuthState`] populated by
+//! middleware that performs that validation.
 //!
 //! See issue #4446 for the motivating discussion.
 
@@ -70,8 +75,8 @@ pub trait SessionKey: Send + Sync + 'static {
 	const KEY: &'static str;
 }
 
-/// Default marker pointing at [`USER_ID_SESSION_KEY`] — the authenticated
-/// user's primary key in every Reinhardt example app.
+/// Default marker pointing at [`USER_ID_SESSION_KEY`], which stores an identity
+/// reference and does not by itself establish current authentication.
 #[derive(Debug, Clone, Copy)]
 pub struct UserIdKey;
 
@@ -84,8 +89,10 @@ impl SessionKey for UserIdKey {
 /// Resolves the [`USER_ID_SESSION_KEY`] entry from the active
 /// [`SessionData`], deserialises it as `T`, and fails extraction when the
 /// key is missing or the value cannot be deserialised. Use this extractor
-/// on server functions that require an authenticated session — the
-/// absent case surfaces as HTTP 401 via `CoreError::Authentication`.
+/// to retrieve an identity reference. The absent case surfaces as HTTP 401 via
+/// `CoreError::Authentication`. This extractor does not load or validate the
+/// referenced account; authorization requires a separate current-account
+/// check or validated [`reinhardt_http::AuthState`].
 ///
 /// # Usage
 ///
@@ -93,11 +100,11 @@ impl SessionKey for UserIdKey {
 /// use reinhardt::middleware::session::SessionValue;
 ///
 /// #[server_fn]
-/// pub async fn current_user(
+/// pub async fn session_identity(
 ///     SessionValue(user_id): SessionValue<i64>,
-/// ) -> Result<UserInfo, ServerFnError> {
-///     // user_id is the authenticated user's primary key
-///     // ...
+/// ) -> Result<i64, ServerFnError> {
+///     // Resolve and validate the account before using this identity for access.
+///     Ok(user_id)
 /// }
 /// ```
 ///

--- a/examples/examples-tutorial-basis/src/apps/users/server_fn.rs
+++ b/examples/examples-tutorial-basis/src/apps/users/server_fn.rs
@@ -195,5 +195,5 @@ pub async fn current_user(
 		.await
 		.map_err(|e| ServerFnError::application(format!("Database error: {}", e)))?;
 
-	Ok(user.map(UserInfo::from))
+	Ok(user.filter(BaseUser::is_active).map(UserInfo::from))
 }

--- a/examples/examples-tutorial-basis/src/config.rs
+++ b/examples/examples-tutorial-basis/src/config.rs
@@ -4,9 +4,9 @@
 pub mod admin;
 pub mod apps;
 #[cfg(server)]
-pub mod settings;
-#[cfg(server)]
 pub mod session_auth;
+#[cfg(server)]
+pub mod settings;
 #[cfg(all(server, feature = "commands-shell"))]
 pub mod shell;
 pub mod urls;

--- a/examples/examples-tutorial-basis/src/config.rs
+++ b/examples/examples-tutorial-basis/src/config.rs
@@ -5,6 +5,8 @@ pub mod admin;
 pub mod apps;
 #[cfg(server)]
 pub mod settings;
+#[cfg(server)]
+pub mod session_auth;
 #[cfg(all(server, feature = "commands-shell"))]
 pub mod shell;
 pub mod urls;

--- a/examples/examples-tutorial-basis/src/config/session_auth.rs
+++ b/examples/examples-tutorial-basis/src/config/session_auth.rs
@@ -45,8 +45,9 @@ impl TutorialSessionAuthMiddleware {
 			tracing::warn!("Tutorial session authentication has no database connection");
 			return AuthState::anonymous();
 		};
+		let mut db = *db;
 
-		match User::objects().get(user_id).first_with_db(&db).await {
+		match User::objects().get(user_id).first_with_db(&mut db).await {
 			Ok(Some(user)) if user.is_active() => AuthState::authenticated(
 				user.id().to_string(),
 				user.is_superuser,
@@ -83,12 +84,14 @@ impl Middleware for TutorialSessionAuthMiddleware {
 mod tests {
 	use super::TutorialSessionAuthMiddleware;
 	use reinhardt::core::async_trait;
+	use reinhardt::db::backends::DatabaseConnection as BackendsConnection;
+	use reinhardt::db::orm::DatabaseConnectionLease;
 	use reinhardt::di::{InjectionContext, SingletonScope};
 	use reinhardt::http::AuthState;
 	use reinhardt::middleware::session::{
 		SessionData, SessionId, SessionStore, USER_ID_SESSION_KEY,
 	};
-	use reinhardt::{DatabaseConnection, Handler, Middleware, Request, Response};
+	use reinhardt::{Handler, Middleware, Request, Response};
 	use sqlx::SqlitePool;
 	use std::sync::{Arc, Mutex};
 	use std::time::Duration;
@@ -108,7 +111,12 @@ mod tests {
 	async fn request_for_user(
 		user_id: i64,
 		is_active: bool,
-	) -> (NamedTempFile, Arc<SessionStore>, Request) {
+	) -> (
+		NamedTempFile,
+		DatabaseConnectionLease,
+		Arc<SessionStore>,
+		Request,
+	) {
 		let database_file = NamedTempFile::new().expect("temporary database should be created");
 		let database_path = database_file
 			.path()
@@ -135,9 +143,12 @@ mod tests {
 		.await
 		.expect("tutorial user should be inserted");
 
-		let db = DatabaseConnection::connect_sqlite(&orm_url)
+		let owner = BackendsConnection::connect_sqlite(&orm_url)
 			.await
 			.expect("ORM connection should connect");
+		let lease = DatabaseConnectionLease::register(owner)
+			.expect("ORM connection should be registered");
+		let db = lease.handle();
 		let singleton = Arc::new(SingletonScope::new());
 		singleton.set(db);
 		let context = InjectionContext::builder(singleton).build();
@@ -158,12 +169,12 @@ mod tests {
 		let mut request = request;
 		request.set_di_context(Arc::new(context));
 
-		(database_file, store, request)
+		(database_file, lease, store, request)
 	}
 
 	#[tokio::test]
 	async fn active_session_user_populates_validated_auth_state() {
-		let (_database_file, store, request) = request_for_user(7, true).await;
+		let (_database_file, _lease, store, request) = request_for_user(7, true).await;
 		let captured = Arc::new(Mutex::new(None));
 		let handler = Arc::new(CaptureAuthState(Arc::clone(&captured)));
 
@@ -184,7 +195,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn inactive_session_user_is_anonymous() {
-		let (_database_file, store, request) = request_for_user(8, false).await;
+		let (_database_file, _lease, store, request) = request_for_user(8, false).await;
 		let captured = Arc::new(Mutex::new(None));
 		let handler = Arc::new(CaptureAuthState(Arc::clone(&captured)));
 

--- a/examples/examples-tutorial-basis/src/config/session_auth.rs
+++ b/examples/examples-tutorial-basis/src/config/session_auth.rs
@@ -48,11 +48,9 @@ impl TutorialSessionAuthMiddleware {
 		let mut db = *db;
 
 		match User::objects().get(user_id).first_with_db(&mut db).await {
-			Ok(Some(user)) if user.is_active() => AuthState::authenticated(
-				user.id().to_string(),
-				user.is_superuser,
-				true,
-			),
+			Ok(Some(user)) if user.is_active() => {
+				AuthState::authenticated(user.id().to_string(), user.is_superuser, true)
+			}
 			Ok(Some(_)) | Ok(None) => AuthState::anonymous(),
 			Err(error) => {
 				tracing::warn!(?error, "Tutorial session account validation failed");
@@ -146,8 +144,8 @@ mod tests {
 		let owner = BackendsConnection::connect_sqlite(&orm_url)
 			.await
 			.expect("ORM connection should connect");
-		let lease = DatabaseConnectionLease::register(owner)
-			.expect("ORM connection should be registered");
+		let lease =
+			DatabaseConnectionLease::register(owner).expect("ORM connection should be registered");
 		let db = lease.handle();
 		let singleton = Arc::new(SingletonScope::new());
 		singleton.set(db);

--- a/examples/examples-tutorial-basis/src/config/session_auth.rs
+++ b/examples/examples-tutorial-basis/src/config/session_auth.rs
@@ -68,6 +68,9 @@ impl Middleware for TutorialSessionAuthMiddleware {
 		next: Arc<dyn Handler>,
 	) -> reinhardt::Result<Response> {
 		let auth_state = self.validated_auth_state(&request).await;
+		if auth_state.is_authenticated() {
+			request.extensions.insert(auth_state.user_id().to_owned());
+		}
 		request
 			.extensions
 			.insert(IsAuthenticated(auth_state.is_authenticated()));
@@ -90,18 +93,26 @@ mod tests {
 		SessionData, SessionId, SessionStore, USER_ID_SESSION_KEY,
 	};
 	use reinhardt::{Handler, Middleware, Request, Response};
+	use serial_test::serial;
 	use sqlx::SqlitePool;
 	use std::sync::{Arc, Mutex};
 	use std::time::Duration;
 	use tempfile::NamedTempFile;
 
-	struct CaptureAuthState(Arc<Mutex<Option<AuthState>>>);
+	#[derive(Default)]
+	struct CapturedAuthState {
+		auth_state: Option<AuthState>,
+		user_id: Option<String>,
+	}
+
+	struct CaptureAuthState(Arc<Mutex<CapturedAuthState>>);
 
 	#[async_trait]
 	impl Handler for CaptureAuthState {
 		async fn handle(&self, request: Request) -> reinhardt::Result<Response> {
-			*self.0.lock().expect("capture lock should remain available") =
-				request.extensions.get::<AuthState>();
+			let mut captured = self.0.lock().expect("capture lock should remain available");
+			captured.auth_state = request.extensions.get::<AuthState>();
+			captured.user_id = request.extensions.get::<String>();
 			Ok(Response::ok())
 		}
 	}
@@ -171,9 +182,10 @@ mod tests {
 	}
 
 	#[tokio::test]
+	#[serial(tutorial_session_auth_database)]
 	async fn active_session_user_populates_validated_auth_state() {
 		let (_database_file, _lease, store, request) = request_for_user(7, true).await;
-		let captured = Arc::new(Mutex::new(None));
+		let captured = Arc::new(Mutex::new(CapturedAuthState::default()));
 		let handler = Arc::new(CaptureAuthState(Arc::clone(&captured)));
 
 		TutorialSessionAuthMiddleware::new(store)
@@ -181,20 +193,24 @@ mod tests {
 			.await
 			.expect("authentication middleware should continue");
 
-		let auth_state = captured
+		let captured = captured
 			.lock()
-			.expect("capture lock should remain available")
-			.clone()
+			.expect("capture lock should remain available");
+		let auth_state = captured
+			.auth_state
+			.as_ref()
 			.expect("active account should produce AuthState");
 		assert!(auth_state.is_authenticated());
 		assert!(auth_state.is_active());
 		assert_eq!(auth_state.user_id(), "7");
+		assert_eq!(captured.user_id.as_deref(), Some(auth_state.user_id()));
 	}
 
 	#[tokio::test]
+	#[serial(tutorial_session_auth_database)]
 	async fn inactive_session_user_is_anonymous() {
 		let (_database_file, _lease, store, request) = request_for_user(8, false).await;
-		let captured = Arc::new(Mutex::new(None));
+		let captured = Arc::new(Mutex::new(CapturedAuthState::default()));
 		let handler = Arc::new(CaptureAuthState(Arc::clone(&captured)));
 
 		TutorialSessionAuthMiddleware::new(store)
@@ -202,11 +218,14 @@ mod tests {
 			.await
 			.expect("authentication middleware should fail closed and continue");
 
-		let auth_state = captured
+		let captured = captured
 			.lock()
-			.expect("capture lock should remain available")
-			.clone()
+			.expect("capture lock should remain available");
+		let auth_state = captured
+			.auth_state
+			.as_ref()
 			.expect("middleware should always populate AuthState");
 		assert!(auth_state.is_anonymous());
+		assert!(captured.user_id.is_none());
 	}
 }

--- a/examples/examples-tutorial-basis/src/config/session_auth.rs
+++ b/examples/examples-tutorial-basis/src/config/session_auth.rs
@@ -1,0 +1,189 @@
+//! Account-validating session authentication for the tutorial server.
+
+use crate::apps::users::models::User;
+use reinhardt::core::async_trait;
+use reinhardt::di::InjectionContext;
+use reinhardt::http::{AuthState, IsActive, IsAdmin, IsAuthenticated};
+use reinhardt::middleware::session::{SessionData, USER_ID_SESSION_KEY};
+use reinhardt::{BaseUser, DatabaseConnection, Handler, Middleware, Model, Request, Response};
+use std::sync::Arc;
+
+/// Resolves the session identity against the current tutorial user record.
+///
+/// `SessionMiddleware` owns cookie/session storage. This middleware runs after
+/// it, loads the referenced user through the request DI connection, and only
+/// then publishes authentication and authorization state.
+#[derive(Debug, Default)]
+pub struct TutorialSessionAuthMiddleware;
+
+impl TutorialSessionAuthMiddleware {
+	/// Create account-validating session authentication middleware.
+	pub fn new() -> Self {
+		Self
+	}
+
+	async fn validated_auth_state(&self, request: &Request) -> AuthState {
+		let Some(session) = request.extensions.get::<SessionData>() else {
+			return AuthState::anonymous();
+		};
+		let Some(user_id) = session.get::<i64>(USER_ID_SESSION_KEY) else {
+			return AuthState::anonymous();
+		};
+		let Some(context) = request.get_di_context::<InjectionContext>() else {
+			tracing::warn!("Tutorial session authentication has no DI context");
+			return AuthState::anonymous();
+		};
+		let Some(db) = context
+			.get_singleton::<DatabaseConnection>()
+			.or_else(|| context.get_request::<DatabaseConnection>())
+		else {
+			tracing::warn!("Tutorial session authentication has no database connection");
+			return AuthState::anonymous();
+		};
+
+		match User::objects().get(user_id).first_with_db(&db).await {
+			Ok(Some(user)) if user.is_active() => AuthState::authenticated(
+				user.id().to_string(),
+				user.is_superuser,
+				true,
+			),
+			Ok(Some(_)) | Ok(None) => AuthState::anonymous(),
+			Err(error) => {
+				tracing::warn!(?error, "Tutorial session account validation failed");
+				AuthState::anonymous()
+			}
+		}
+	}
+}
+
+#[async_trait]
+impl Middleware for TutorialSessionAuthMiddleware {
+	async fn process(
+		&self,
+		request: Request,
+		next: Arc<dyn Handler>,
+	) -> reinhardt::Result<Response> {
+		let auth_state = self.validated_auth_state(&request).await;
+		request
+			.extensions
+			.insert(IsAuthenticated(auth_state.is_authenticated()));
+		request.extensions.insert(IsAdmin(auth_state.is_admin()));
+		request.extensions.insert(IsActive(auth_state.is_active()));
+		request.extensions.insert(auth_state);
+		next.handle(request).await
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::TutorialSessionAuthMiddleware;
+	use reinhardt::core::async_trait;
+	use reinhardt::di::{InjectionContext, SingletonScope};
+	use reinhardt::http::AuthState;
+	use reinhardt::middleware::session::{SessionData, USER_ID_SESSION_KEY};
+	use reinhardt::{DatabaseConnection, Handler, Middleware, Request, Response};
+	use sqlx::SqlitePool;
+	use std::sync::{Arc, Mutex};
+	use std::time::Duration;
+	use tempfile::NamedTempFile;
+
+	struct CaptureAuthState(Arc<Mutex<Option<AuthState>>>);
+
+	#[async_trait]
+	impl Handler for CaptureAuthState {
+		async fn handle(&self, request: Request) -> reinhardt::Result<Response> {
+			*self.0.lock().expect("capture lock should remain available") =
+				request.extensions.get::<AuthState>();
+			Ok(Response::ok())
+		}
+	}
+
+	async fn request_for_user(user_id: i64, is_active: bool) -> (NamedTempFile, Request) {
+		let database_file = NamedTempFile::new().expect("temporary database should be created");
+		let database_path = database_file
+			.path()
+			.to_str()
+			.expect("temporary database path should be UTF-8");
+		let sqlx_url = format!("sqlite://{database_path}?mode=rwc");
+		let orm_url = format!("sqlite:///{database_path}");
+		let pool = SqlitePool::connect(&sqlx_url)
+			.await
+			.expect("SQLite pool should connect");
+		sqlx::query(
+			"CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT NOT NULL, password_hash TEXT, is_active BOOLEAN NOT NULL, is_superuser BOOLEAN NOT NULL, last_login TEXT, created_at TEXT NOT NULL)",
+		)
+		.execute(&pool)
+		.await
+		.expect("users table should be created");
+		sqlx::query(
+			"INSERT INTO users (id, username, password_hash, is_active, is_superuser, last_login, created_at) VALUES (?, ?, NULL, ?, 0, NULL, '2026-08-04T00:00:00Z')",
+		)
+		.bind(user_id)
+		.bind("tutorial-user")
+		.bind(is_active)
+		.execute(&pool)
+		.await
+		.expect("tutorial user should be inserted");
+
+		let db = DatabaseConnection::connect_sqlite(&orm_url)
+			.await
+			.expect("ORM connection should connect");
+		let singleton = Arc::new(SingletonScope::new());
+		singleton.set(db);
+		let context = InjectionContext::builder(singleton).build();
+
+		let mut session = SessionData::new(Duration::from_secs(3600));
+		session
+			.set(USER_ID_SESSION_KEY.to_string(), user_id)
+			.expect("session user ID should serialize");
+		let request = Request::builder()
+			.uri("/")
+			.body(Vec::new().into())
+			.build()
+			.unwrap();
+		request.extensions.insert(session);
+		request.extensions.insert(Arc::new(context));
+
+		(database_file, request)
+	}
+
+	#[tokio::test]
+	async fn active_session_user_populates_validated_auth_state() {
+		let (_database_file, request) = request_for_user(7, true).await;
+		let captured = Arc::new(Mutex::new(None));
+		let handler = Arc::new(CaptureAuthState(Arc::clone(&captured)));
+
+		TutorialSessionAuthMiddleware::new()
+			.process(request, handler)
+			.await
+			.expect("authentication middleware should continue");
+
+		let auth_state = captured
+			.lock()
+			.expect("capture lock should remain available")
+			.clone()
+			.expect("active account should produce AuthState");
+		assert!(auth_state.is_authenticated());
+		assert!(auth_state.is_active());
+		assert_eq!(auth_state.user_id(), "7");
+	}
+
+	#[tokio::test]
+	async fn inactive_session_user_is_anonymous() {
+		let (_database_file, request) = request_for_user(8, false).await;
+		let captured = Arc::new(Mutex::new(None));
+		let handler = Arc::new(CaptureAuthState(Arc::clone(&captured)));
+
+		TutorialSessionAuthMiddleware::new()
+			.process(request, handler)
+			.await
+			.expect("authentication middleware should fail closed and continue");
+
+		let auth_state = captured
+			.lock()
+			.expect("capture lock should remain available")
+			.clone()
+			.expect("middleware should always populate AuthState");
+		assert!(auth_state.is_anonymous());
+	}
+}

--- a/examples/examples-tutorial-basis/src/config/session_auth.rs
+++ b/examples/examples-tutorial-basis/src/config/session_auth.rs
@@ -4,7 +4,7 @@ use crate::apps::users::models::User;
 use reinhardt::core::async_trait;
 use reinhardt::di::InjectionContext;
 use reinhardt::http::{AuthState, IsActive, IsAdmin, IsAuthenticated};
-use reinhardt::middleware::session::{SessionData, USER_ID_SESSION_KEY};
+use reinhardt::middleware::session::{SessionId, SessionStore, USER_ID_SESSION_KEY};
 use reinhardt::{BaseUser, DatabaseConnection, Handler, Middleware, Model, Request, Response};
 use std::sync::Arc;
 
@@ -13,23 +13,28 @@ use std::sync::Arc;
 /// `SessionMiddleware` owns cookie/session storage. This middleware runs after
 /// it, loads the referenced user through the request DI connection, and only
 /// then publishes authentication and authorization state.
-#[derive(Debug, Default)]
-pub struct TutorialSessionAuthMiddleware;
+#[derive(Debug)]
+pub struct TutorialSessionAuthMiddleware {
+	store: Arc<SessionStore>,
+}
 
 impl TutorialSessionAuthMiddleware {
 	/// Create account-validating session authentication middleware.
-	pub fn new() -> Self {
-		Self
+	pub fn new(store: Arc<SessionStore>) -> Self {
+		Self { store }
 	}
 
 	async fn validated_auth_state(&self, request: &Request) -> AuthState {
-		let Some(session) = request.extensions.get::<SessionData>() else {
+		let Some(session_id) = request.extensions.get::<SessionId>() else {
+			return AuthState::anonymous();
+		};
+		let Some(session) = self.store.get(session_id.as_str()) else {
 			return AuthState::anonymous();
 		};
 		let Some(user_id) = session.get::<i64>(USER_ID_SESSION_KEY) else {
 			return AuthState::anonymous();
 		};
-		let Some(context) = request.get_di_context::<InjectionContext>() else {
+		let Some(context) = request.get_di_context::<Arc<InjectionContext>>() else {
 			tracing::warn!("Tutorial session authentication has no DI context");
 			return AuthState::anonymous();
 		};
@@ -80,7 +85,9 @@ mod tests {
 	use reinhardt::core::async_trait;
 	use reinhardt::di::{InjectionContext, SingletonScope};
 	use reinhardt::http::AuthState;
-	use reinhardt::middleware::session::{SessionData, USER_ID_SESSION_KEY};
+	use reinhardt::middleware::session::{
+		SessionData, SessionId, SessionStore, USER_ID_SESSION_KEY,
+	};
 	use reinhardt::{DatabaseConnection, Handler, Middleware, Request, Response};
 	use sqlx::SqlitePool;
 	use std::sync::{Arc, Mutex};
@@ -98,7 +105,10 @@ mod tests {
 		}
 	}
 
-	async fn request_for_user(user_id: i64, is_active: bool) -> (NamedTempFile, Request) {
+	async fn request_for_user(
+		user_id: i64,
+		is_active: bool,
+	) -> (NamedTempFile, Arc<SessionStore>, Request) {
 		let database_file = NamedTempFile::new().expect("temporary database should be created");
 		let database_path = database_file
 			.path()
@@ -136,24 +146,28 @@ mod tests {
 		session
 			.set(USER_ID_SESSION_KEY.to_string(), user_id)
 			.expect("session user ID should serialize");
+		let session_id = session.id.clone();
+		let store = Arc::new(SessionStore::new());
+		store.save(session);
 		let request = Request::builder()
 			.uri("/")
 			.body(Vec::new().into())
 			.build()
 			.unwrap();
-		request.extensions.insert(session);
-		request.extensions.insert(Arc::new(context));
+		request.extensions.insert(SessionId::new(session_id));
+		let mut request = request;
+		request.set_di_context(Arc::new(context));
 
-		(database_file, request)
+		(database_file, store, request)
 	}
 
 	#[tokio::test]
 	async fn active_session_user_populates_validated_auth_state() {
-		let (_database_file, request) = request_for_user(7, true).await;
+		let (_database_file, store, request) = request_for_user(7, true).await;
 		let captured = Arc::new(Mutex::new(None));
 		let handler = Arc::new(CaptureAuthState(Arc::clone(&captured)));
 
-		TutorialSessionAuthMiddleware::new()
+		TutorialSessionAuthMiddleware::new(store)
 			.process(request, handler)
 			.await
 			.expect("authentication middleware should continue");
@@ -170,11 +184,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn inactive_session_user_is_anonymous() {
-		let (_database_file, request) = request_for_user(8, false).await;
+		let (_database_file, store, request) = request_for_user(8, false).await;
 		let captured = Arc::new(Mutex::new(None));
 		let handler = Arc::new(CaptureAuthState(Arc::clone(&captured)));
 
-		TutorialSessionAuthMiddleware::new()
+		TutorialSessionAuthMiddleware::new(store)
 			.process(request, handler)
 			.await
 			.expect("authentication middleware should fail closed and continue");

--- a/examples/examples-tutorial-basis/src/config/urls.rs
+++ b/examples/examples-tutorial-basis/src/config/urls.rs
@@ -4,7 +4,7 @@
 //!
 //! Middleware stack (server-only):
 //! 1. `SessionMiddleware` — cookie-based session management used by the
-//!    `users` app's login/logout server functions and `CurrentUser` auth state
+//!    `users` app's login/logout server functions
 
 use crate::apps::{polls::urls as polls_urls, users::urls as users_urls};
 use reinhardt::UnifiedRouter;
@@ -88,11 +88,10 @@ pub fn routes() -> UnifiedRouter {
 	// `#[inject] session: SessionData` or
 	// `#[inject] store: KeyedDepends<SessionStoreKey, Arc<SessionStore>>`
 	// can resolve the same store the middleware writes to without a parallel
-	// `with_di_registrations(...)` call. The same middleware also derives
-	// `AuthState` from `USER_ID_SESSION_KEY`, so authenticated handlers can use
-	// `CurrentUser<U>` without adding a second cookie-session auth layer.
-	// See #4426 (and the original #4423 regression that motivated the
-	// auto-registration hook) and #4740.
+	// `with_di_registrations(...)` call. A session user ID is not sufficient to
+	// establish `AuthState`; protected handlers must use authentication
+	// middleware that validates the current account. See #4426 (and the original
+	// #4423 regression that motivated the auto-registration hook).
 	#[cfg(server)]
 	let router = router.with_middleware(create_session_middleware());
 

--- a/examples/examples-tutorial-basis/src/config/urls.rs
+++ b/examples/examples-tutorial-basis/src/config/urls.rs
@@ -97,9 +97,13 @@ pub fn routes() -> UnifiedRouter {
 	// account validation against the current `User` record. See #4426 (and the
 	// original #4423 regression that motivated the auto-registration hook).
 	#[cfg(server)]
-	let session_middleware = create_session_middleware();
-	let session_store = session_middleware.store_arc();
+	let router = {
+		let session_middleware = create_session_middleware();
+		let session_store = session_middleware.store_arc();
+		router
+			.with_middleware(session_middleware)
+			.with_middleware(TutorialSessionAuthMiddleware::new(session_store))
+	};
+
 	router
-		.with_middleware(session_middleware)
-		.with_middleware(TutorialSessionAuthMiddleware::new(session_store))
 }

--- a/examples/examples-tutorial-basis/src/config/urls.rs
+++ b/examples/examples-tutorial-basis/src/config/urls.rs
@@ -5,6 +5,8 @@
 //! Middleware stack (server-only):
 //! 1. `SessionMiddleware` — cookie-based session management used by the
 //!    `users` app's login/logout server functions
+//! 2. `TutorialSessionAuthMiddleware` — resolves the session identity against
+//!    the current user record before publishing `AuthState`
 
 use crate::apps::{polls::urls as polls_urls, users::urls as users_urls};
 use reinhardt::UnifiedRouter;
@@ -14,6 +16,8 @@ use reinhardt::routes;
 
 #[cfg(server)]
 use crate::config::admin::configure_admin;
+#[cfg(server)]
+use crate::config::session_auth::TutorialSessionAuthMiddleware;
 
 #[cfg(server)]
 use reinhardt::middleware::session::{SessionConfig, SessionMiddleware};
@@ -89,11 +93,13 @@ pub fn routes() -> UnifiedRouter {
 	// `#[inject] store: KeyedDepends<SessionStoreKey, Arc<SessionStore>>`
 	// can resolve the same store the middleware writes to without a parallel
 	// `with_di_registrations(...)` call. A session user ID is not sufficient to
-	// establish `AuthState`; protected handlers must use authentication
-	// middleware that validates the current account. See #4426 (and the original
-	// #4423 regression that motivated the auto-registration hook).
+	// establish `AuthState`, so the tutorial follows session loading with
+	// account validation against the current `User` record. See #4426 (and the
+	// original #4423 regression that motivated the auto-registration hook).
 	#[cfg(server)]
-	let router = router.with_middleware(create_session_middleware());
+	let router = router
+		.with_middleware(create_session_middleware())
+		.with_middleware(TutorialSessionAuthMiddleware::new());
 
 	router
 }

--- a/examples/examples-tutorial-basis/src/config/urls.rs
+++ b/examples/examples-tutorial-basis/src/config/urls.rs
@@ -99,9 +99,7 @@ pub fn routes() -> UnifiedRouter {
 	#[cfg(server)]
 	let session_middleware = create_session_middleware();
 	let session_store = session_middleware.store_arc();
-	let router = router
-		.with_middleware(session_middleware)
-		.with_middleware(TutorialSessionAuthMiddleware::new(session_store));
-
 	router
+		.with_middleware(session_middleware)
+		.with_middleware(TutorialSessionAuthMiddleware::new(session_store))
 }

--- a/examples/examples-tutorial-basis/src/config/urls.rs
+++ b/examples/examples-tutorial-basis/src/config/urls.rs
@@ -97,9 +97,11 @@ pub fn routes() -> UnifiedRouter {
 	// account validation against the current `User` record. See #4426 (and the
 	// original #4423 regression that motivated the auto-registration hook).
 	#[cfg(server)]
+	let session_middleware = create_session_middleware();
+	let session_store = session_middleware.store_arc();
 	let router = router
-		.with_middleware(create_session_middleware())
-		.with_middleware(TutorialSessionAuthMiddleware::new());
+		.with_middleware(session_middleware)
+		.with_middleware(TutorialSessionAuthMiddleware::new(session_store));
 
 	router
 }

--- a/instructions/MIGRATION_0.3.md
+++ b/instructions/MIGRATION_0.3.md
@@ -108,9 +108,10 @@ This prevents deactivated accounts with unexpired sessions from being
 authorized.
 
 `CookieSessionAuthMiddleware` remains available for projects that plug a custom
-`AsyncSessionBackend` directly; configure it or another authentication
-middleware to validate the current account before using `CurrentUser<U>` or
-authorization guards.
+`AsyncSessionBackend` directly, but it only reconstructs authentication flags
+stored in the session. It does not load the current account record. Follow it
+with account-resolving middleware (or use an authentication backend that does
+so) before relying on `CurrentUser<U>` or authorization guards.
 
 ## Keyed dependency providers
 

--- a/instructions/MIGRATION_0.3.md
+++ b/instructions/MIGRATION_0.3.md
@@ -100,15 +100,17 @@ async fn profile(CurrentUser(user): CurrentUser<MyUser>) -> Response {
 }
 ```
 
-Cookie-backed session apps should register `SessionMiddleware` once in
-`urls.rs`. In 0.3, `SessionMiddleware` derives `AuthState` from
-`USER_ID_SESSION_KEY` when the active session is authenticated and preserves an
-existing `AuthState` inserted by earlier middleware. Standard
-`SessionData` + `SessionAuthExt` + `CurrentUser<U>` setups do not need an
-additional session-auth middleware layer.
+Cookie-backed session apps should register `SessionMiddleware` in `urls.rs` for
+session storage and DI registration. `USER_ID_SESSION_KEY` is an identity
+reference, not authentication proof: account status and privileges must be
+validated by an authentication middleware before it populates `AuthState`.
+This prevents deactivated accounts with unexpired sessions from being
+authorized.
 
-`CookieSessionAuthMiddleware` remains available for projects that plug a
-custom `AsyncSessionBackend` directly.
+`CookieSessionAuthMiddleware` remains available for projects that plug a custom
+`AsyncSessionBackend` directly; configure it or another authentication
+middleware to validate the current account before using `CurrentUser<U>` or
+authorization guards.
 
 ## Keyed dependency providers
 

--- a/instructions/MIGRATION_0.4.md
+++ b/instructions/MIGRATION_0.4.md
@@ -8,6 +8,22 @@ For the complete `get_or_create` and `update_or_create` migration, including
 transaction, uniqueness, race, and custom-manager hook semantics, see
 [`0.4.0-typed-manager-upserts.md`](../docs/migration/0.4.0-typed-manager-upserts.md).
 
+## Validated session authentication
+
+`SessionMiddleware` now manages session storage and DI registration only. A
+`USER_ID_SESSION_KEY` value is an identity reference, not proof that the
+account remains active or authorized. Projects using cookie-backed sessions
+must follow it with authentication middleware that loads the current account
+record and publishes `AuthState` before using `CurrentUser<U>` or
+authorization guards. This prevents deactivated accounts with unexpired
+sessions from being authorized.
+
+`CookieSessionAuthMiddleware` remains available for custom
+`AsyncSessionBackend` integrations, but it only restores flags stored in the
+session and does not validate the current account. Follow it with
+account-resolving middleware, or use an authentication backend that performs
+that validation.
+
 ## Rust management shell
 
 The former Rhai evaluator was replaced by a stateful Rust evaluator backed by


### PR DESCRIPTION
## Summary

This PR addresses:

- Backports the validated session-account behavior from #5905 to `develop/0.4.0`.
- Stops `SessionMiddleware` from treating a stored user ID as proof of current authentication.
- Resolves tutorial session identities against the current account record before publishing `AuthState`.
- Rejects inactive accounts in `CurrentUser` and documents the breaking migration path.
- Adapts the tutorial validation tests to the 0.4.0 RAII database-handle API.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [ ] **No** - This change is backward compatible
- [x] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

A session value is only an identity reference. Accounts can be disabled or have privileges changed after a session is created, so authentication and authorization must use the current account record.

Refs #5905

Backported source commits:

- `59bd3893c2640315856cc1fb5d57a47d5f77b843` as `e61f84cda0`
- `f2690ccaedb1481e4d66c6fcbd89fd097293666d` as `a9ad4ad768`
- `18f0e667a4830f42145ed362eab9927f5c108964` as `e954661c36`
- `5cfd7bf3fa` adapts the result to the 0.4.0 RAII database-handle API

The main synchronization merge commit `1d8185408bc38be97650c8e3b91eeb3f5b20ca38` was intentionally not cherry-picked.

## How Was This Tested?

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Volumes/cache/codex-pr5905-backport-target cargo test -p reinhardt-middleware --lib session_middleware_` — 4 passed
- `CARGO_TARGET_DIR=/Volumes/cache/codex-pr5905-backport-target cargo test -p reinhardt-auth --features params --lib auth_user` — 2 passed
- `CARGO_TARGET_DIR=/Volumes/cache/codex-pr5905-backport-target cargo test --manifest-path examples/Cargo.toml -p examples-tutorial-basis config::session_auth::tests --features with-reinhardt` — 2 passed
- `CARGO_TARGET_DIR=/Volumes/cache/codex-pr5905-backport-target cargo check --manifest-path examples/Cargo.toml -p examples-tutorial-basis --features with-reinhardt`
- `git diff --check`

An initial unscoped middleware test command also compiled unrelated integration targets and stopped on the existing `security_middleware` feature-gating issue in `error_path_integration.rs`; the affected middleware unit tests were rerun successfully with `--lib`.

## Breaking Changes

`SessionMiddleware` no longer derives authenticated `AuthState` from `USER_ID_SESSION_KEY`. Applications that relied on that behavior must add an account-validating resolver after session loading. `CurrentUser` now rejects inactive accounts.

**Migration Guide:**

1. Keep `SessionMiddleware` responsible for loading and persisting session data.
2. Add session-store-compatible authentication middleware after it.
3. Resolve the stored identity against the current account record.
4. Validate active and privilege state before publishing `AuthState` or applying authorization guards.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage (AWS Spot instances),
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #5905

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [x] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [x] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [x] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- This is a focused `develop/0.4.0` backport. It does not modify `main` or the merged revert PR.
