### PR TITLE
test(macros): align model UI support with filter bindings

### DIFF
--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -120,6 +120,17 @@ pub mod db {
 	}
 
 	pub mod orm {
+		pub mod query {
+			#[derive(Debug, Clone, Copy)]
+			pub struct FilterValue;
+
+			impl From<i64> for FilterValue {
+				fn from(_value: i64) -> Self {
+					Self
+				}
+			}
+		}
+
 		pub struct Manager<T>(core::marker::PhantomData<T>);
 
 		impl<T> Default for Manager<T> {
@@ -161,6 +172,7 @@ pub mod db {
 			fn new_fields() -> Self::Fields;
 			fn app_label() -> &'static str;
 			fn primary_key_field() -> &'static str;
+			fn primary_key_filter_value(pk: Self::PrimaryKey) -> query::FilterValue;
 			fn primary_key(&self) -> Option<Self::PrimaryKey>;
 			fn set_primary_key(&mut self, value: Self::PrimaryKey);
 			fn field_metadata() -> Vec<inspection::FieldInfo>;


### PR DESCRIPTION
## Summary

This PR addresses:

- Model UI test failures in release PR #5917 caused by a stale trybuild support stub.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The `Model` derive now emits primary-key filter bindings. Its standalone trybuild support module must expose the same trait method and filter value path so compile-time parity tests continue to validate intended diagnostics.

Related to: #5917

## How Was This Tested?

- `cargo test --package reinhardt-macros --test ui model_macro_parity -- --nocapture`
- `cargo make fmt-check`

## Checklist

- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (not applicable: test-support-only change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-check`

## Related Issues

- Related to release PR #5917

## Labels to Apply

### Type Label
- [x] `bug`

### Scope Label
- [x] `ci-cd`

---

**Additional Context:**

The generated release branch remains unmodified; release-plz will regenerate it after this source-branch repair merges.