### PR TITLE
fix(ci): report workspace coverage to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -163,7 +163,9 @@ jobs:
 
       - name: Generate unit coverage report
         run: |
-          cargo llvm-cov report \
+          cargo llvm-cov \
+            --workspace \
+            --no-run \
             --lcov \
             --output-path /tmp/unit-lcov.info
 
@@ -351,7 +353,9 @@ jobs:
 
       - name: Generate intra-crate coverage report
         run: |
-          cargo llvm-cov report \
+          cargo llvm-cov \
+            --workspace \
+            --no-run \
             --lcov \
             --output-path /tmp/intra-crate-lcov.info
 
@@ -507,7 +511,9 @@ jobs:
 
       - name: Generate cross-crate coverage report
         run: |
-          cargo llvm-cov report \
+          cargo llvm-cov \
+            --workspace \
+            --no-run \
             --lcov \
             --output-path /tmp/cross-crate-lcov.info
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -163,9 +163,14 @@ jobs:
 
       - name: Generate unit coverage report
         run: |
+          report_metadata=$(cargo metadata --no-deps --format-version 1)
+          report_args=()
+          while IFS= read -r package; do
+            report_args+=(--package "$package")
+          done < <(jq -r '.packages[].name' <<< "$report_metadata")
           cargo llvm-cov \
-            --workspace \
-            --no-run \
+            report \
+            "${report_args[@]}" \
             --lcov \
             --output-path /tmp/unit-lcov.info
 
@@ -353,9 +358,14 @@ jobs:
 
       - name: Generate intra-crate coverage report
         run: |
+          report_metadata=$(cargo metadata --no-deps --format-version 1)
+          report_args=()
+          while IFS= read -r package; do
+            report_args+=(--package "$package")
+          done < <(jq -r '.packages[].name' <<< "$report_metadata")
           cargo llvm-cov \
-            --workspace \
-            --no-run \
+            report \
+            "${report_args[@]}" \
             --lcov \
             --output-path /tmp/intra-crate-lcov.info
 
@@ -511,9 +521,14 @@ jobs:
 
       - name: Generate cross-crate coverage report
         run: |
+          report_metadata=$(cargo metadata --no-deps --format-version 1)
+          report_args=()
+          while IFS= read -r package; do
+            report_args+=(--package "$package")
+          done < <(jq -r '.packages[].name' <<< "$report_metadata")
           cargo llvm-cov \
-            --workspace \
-            --no-run \
+            report \
+            "${report_args[@]}" \
             --lcov \
             --output-path /tmp/cross-crate-lcov.info
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Generate unit, intra-crate, and cross-crate coverage reports with workspace package selection after the two-phase test run.
- Preserve the LCOV upload format and keep Codecov upload failures visible.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The reusable coverage workflow runs workspace tests but invokes the separate report phase without workspace package selection. As a result, the uploaded report can be limited to the repository root package instead of representing the instrumented workspace crates. The report phase now retains the workspace selection while preserving the existing two-phase execution required for coverage artifact generation.

## How Was This Tested?

- [x] `git diff --check`
- [x] YAML parsing with Ruby Psych
- [x] Local cargo-llvm-cov probe with two workspace packages; the workspace report contained files from both packages.
- [ ] Full GitHub Actions coverage workflow (runs on this PR)

## Performance Impact

- Not applicable.

## Breaking Changes

- Not applicable.

## Related Issues

- Related to PR #5909 (coverage workflow trigger repair).

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (CI-only change; no documentation update is applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (not applicable)
- [ ] I have formatted the code with `cargo make fmt-fix` (CI workflow-only change)
- [ ] I have checked the code with `cargo make clippy-check` (CI workflow-only change)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug`

### Scope Label
- [x] `ci-cd`

### Additional Context

The full coverage workflow is intentionally left to GitHub Actions because it requires the configured Linux runner, Docker services, WASM tooling, and Codecov OIDC permissions.

🤖 Generated with [Codex](https://openai.com/codex)
