### PR TITLE
fix(ci): report workspace coverage to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -164,9 +164,14 @@ jobs:
 
       - name: Generate unit coverage report
         run: |
+          report_metadata=$(cargo metadata --no-deps --format-version 1)
+          report_args=()
+          while IFS= read -r package; do
+            report_args+=(--package "$package")
+          done < <(jq -r '.packages[].name' <<< "$report_metadata")
           cargo llvm-cov \
-            --workspace \
-            --no-run \
+            report \
+            "${report_args[@]}" \
             --lcov \
             --output-path /tmp/unit-lcov.info
 
@@ -365,9 +370,14 @@ jobs:
 
       - name: Generate intra-crate coverage report
         run: |
+          report_metadata=$(cargo metadata --no-deps --format-version 1)
+          report_args=()
+          while IFS= read -r package; do
+            report_args+=(--package "$package")
+          done < <(jq -r '.packages[].name' <<< "$report_metadata")
           cargo llvm-cov \
-            --workspace \
-            --no-run \
+            report \
+            "${report_args[@]}" \
             --lcov \
             --output-path /tmp/intra-crate-lcov.info
 
@@ -524,9 +534,14 @@ jobs:
 
       - name: Generate cross-crate coverage report
         run: |
+          report_metadata=$(cargo metadata --no-deps --format-version 1)
+          report_args=()
+          while IFS= read -r package; do
+            report_args+=(--package "$package")
+          done < <(jq -r '.packages[].name' <<< "$report_metadata")
           cargo llvm-cov \
-            --workspace \
-            --no-run \
+            report \
+            "${report_args[@]}" \
             --lcov \
             --output-path /tmp/cross-crate-lcov.info
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -164,17 +164,19 @@ jobs:
 
       - name: Generate unit coverage report
         run: |
-          cargo llvm-cov report \
-            --codecov \
-            --output-path /tmp/unit-codecov.json
+          cargo llvm-cov \
+            --workspace \
+            --no-run \
+            --lcov \
+            --output-path /tmp/unit-lcov.info
 
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5
         with:
-          files: /tmp/unit-codecov.json
+          files: /tmp/unit-lcov.info
           flags: unit
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           use_oidc: true
 
       - name: Docker cleanup after tests
@@ -363,17 +365,19 @@ jobs:
 
       - name: Generate intra-crate coverage report
         run: |
-          cargo llvm-cov report \
-            --codecov \
-            --output-path /tmp/intra-crate-codecov.json
+          cargo llvm-cov \
+            --workspace \
+            --no-run \
+            --lcov \
+            --output-path /tmp/intra-crate-lcov.info
 
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5
         with:
-          files: /tmp/intra-crate-codecov.json
+          files: /tmp/intra-crate-lcov.info
           flags: intra-crate-integration
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           use_oidc: true
 
       - name: Docker cleanup after tests
@@ -520,17 +524,19 @@ jobs:
 
       - name: Generate cross-crate coverage report
         run: |
-          cargo llvm-cov report \
-            --codecov \
-            --output-path /tmp/cross-crate-codecov.json
+          cargo llvm-cov \
+            --workspace \
+            --no-run \
+            --lcov \
+            --output-path /tmp/cross-crate-lcov.info
 
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5
         with:
-          files: /tmp/cross-crate-codecov.json
+          files: /tmp/cross-crate-lcov.info
           flags: cross-crate-integration
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           use_oidc: true
 
       - name: Docker cleanup after tests

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -534,9 +534,9 @@ dependencies = ["docker-cleanup-force", "test-only"]
 # ============================================================================
 
 [tasks.coverage-unit]
-description = "Run unit tests with coverage (generates Codecov JSON report)"
+description = "Run unit tests with coverage (generates LCOV report)"
 command = "cargo"
-args = ["llvm-cov", "nextest", "--workspace", "--lib", "--all-features", "--no-fail-fast", "--codecov", "--output-path", "/tmp/reinhardt-unit-codecov.json"]
+args = ["llvm-cov", "nextest", "--workspace", "--lib", "--all-features", "--no-fail-fast", "--lcov", "--output-path", "/tmp/reinhardt-unit-lcov.info"]
 
 [tasks.coverage-html]
 description = "Run unit tests with coverage and open HTML report"


### PR DESCRIPTION
## Summary

This PR addresses:

- Generate unit, intra-crate, and cross-crate coverage reports with workspace package selection after the two-phase test run.
- Restore the LCOV upload format and fail the coverage job when Codecov rejects an upload.
- Align the local `coverage-unit` task with the LCOV format used by the workflow.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The reusable coverage workflow runs workspace tests but invokes the separate report phase without workspace package selection. As a result, the uploaded report can be limited to the repository root package instead of representing the instrumented workspace crates. The report phase now enumerates the workspace packages from cargo metadata while preserving the existing two-phase execution required for coverage artifact generation.

The develop branch also used Codecov Custom JSON uploads with upload failures ignored. This change aligns it with the LCOV format and failure handling already used on main, so rejected or incomplete uploads are visible.

## How Was This Tested?

- [x] `git diff --check`
- [x] YAML parsing with Ruby Psych
- [x] Inspected the `cargo make coverage-unit` task configuration; it emits an LCOV report command.
- [x] Local cargo-llvm-cov probe with two workspace packages; the workspace report contained files from both packages.
- [ ] Full GitHub Actions coverage workflow (runs on this PR)

## Performance Impact

- Not applicable.

## Breaking Changes

- Not applicable.

## Related Issues

- Related to PR #5909 (coverage workflow trigger repair).

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (CI-only change; no documentation update is applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (not applicable)
- [ ] I have formatted the code with `cargo make fmt-fix` (CI workflow-only change)
- [ ] I have checked the code with `cargo make clippy-check` (CI workflow-only change)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `bug`

### Scope Label
- [x] `ci-cd`

### Additional Context

The full coverage workflow is intentionally left to GitHub Actions because it requires the configured Linux runner, Docker services, WASM tooling, and Codecov OIDC permissions.

🤖 Generated with [Codex](https://openai.com/codex)
