### PR TITLE
fix(ci): align base64 dependency policy skip

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -80,7 +80,7 @@ skip = [
   { crate = "base64@0.12.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "base64@0.13.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "base64@0.21.7", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
-  { crate = "base64@0.23.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
+  { crate = "base64@0.23.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "bincode@1.3.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "bitflags@1.3.2", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "cipher@0.4.4", reason = "The full feature graph retains cipher 0.4.4 and 0.5.2 through incompatible transitive dependency requirements; tracked in issue #5665." },


### PR DESCRIPTION
## Summary

This PR addresses:

- updates the cargo-deny duplicate exception from `base64@0.23.0` to `base64@0.23.1` to match the current dependency graph.
- unblocks the Security Audit dependency-policy check for the `main` base branch.

## Type of Change

- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The current full-feature dependency graph contains `base64 0.22.1` and `base64 0.23.1`, while `deny.toml` still listed `base64@0.23.0` as the duplicate-version exception. cargo-deny therefore reported the actual duplicate as an error and the stale exception as an unmatched skip. Aligning the exception with the lockfile keeps the dependency policy accurate.

Related to: #5913

## How Was This Tested?

- [x] `cargo deny --workspace --all-features check all`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- cargo-deny reported `advisories ok, bans ok, licenses ok, sources ok` on this branch.
- The main branch retains unrelated pre-existing cargo-deny skip warnings; the command still exits successfully.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (not applicable to this dependency-policy-only change)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (cargo-deny validation covers this configuration-only change)
- [ ] New and existing unit tests pass locally with my changes (not applicable to this configuration-only change)
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [ ] I have checked the code with `cargo make clippy-check` (not applicable to this configuration-only change)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5913

## Labels to Apply

### Type Label

- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Scope Label

- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

- This is a shared base-branch dependency-policy repair for PR #5913.
- Target base branch: `main`.

🤖 Generated with [Codex](https://openai.com/codex)