### PR TITLE
fix(commands): align MySQL dbshell integration expectation

### DIFF
--- a/tests/integration/tests/commands/dbshell_management.rs
+++ b/tests/integration/tests/commands/dbshell_management.rs
@@ -172,7 +172,7 @@ fn dbshell_management_records_exact_backend_arguments_and_credentials() {
 			name: "mysql",
 			client: "mysql",
 			url: "mysql://ops%20user:mysql-secret@db.example:4406/reporting%20data",
-			expected: "argument=--host\nargument=db.example\nargument=--port\nargument=4406\nargument=--user\nargument=ops user\nargument=reporting data\nargument=--expanded\nargument=value with spaces\nPGPASSWORD=unset\nMYSQL_PWD=mysql-secret\n",
+			expected: "argument=--protocol=TCP\nargument=--host\nargument=db.example\nargument=--port\nargument=4406\nargument=--user\nargument=ops user\nargument=reporting data\nargument=--expanded\nargument=value with spaces\nPGPASSWORD=unset\nMYSQL_PWD=mysql-secret\n",
 		},
 		BackendCase {
 			name: "sqlite",


### PR DESCRIPTION
## Summary

This PR addresses:

- Align the cross-crate `dbshell` MySQL fake-client expectation with the explicit TCP protocol argument emitted for host-based MySQL URLs.
- Restore the failing `Cross-Crate Integration Tests (5/5)` check reported by PR #5926.
- Keep the repair on the `develop/0.4.0` source branch without modifying the generated release-plz branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The `build_mysql_spec` implementation now emits `--protocol=TCP` for MySQL URLs with a host, while preserving Unix-socket transport when the `socket` query parameter is present. The cross-crate integration fixture still expected the pre-change argument list, causing the release PR's leaf test to fail. This change synchronizes that fixture with the existing implementation and does not alter runtime behavior.

Related to: #5926

## How Was This Tested?

- [x] `cargo nextest run --package reinhardt-integration-tests --test commands --all-features --no-fail-fast --status-level=none --final-status-level=none dbshell_management_records_exact_backend_arguments_and_credentials`
- [x] `cargo make fmt-check`
- [x] `cargo fmt --all -- --check`
- [x] `CARGO_BUILD_JOBS=1 cargo make clippy-check`
- [x] `git diff --check`

## Performance Impact

- No runtime or performance impact; this is an integration-test expectation update.

## Breaking Changes

- None.

**Migration Guide:**

- Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (not applicable to this test-only change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends covered by the integration case
- [x] I have formatted the code with the project formatter checks
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- PR #5926: generated release validation failure

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

## Additional Context

The generated release-plz PR #5926 remains unchanged. Once this source-base repair is merged into `develop/0.4.0`, release-plz can regenerate or revalidate the release PR.

🤖 Generated with [Codex](https://openai.com/codex)
