### PR TITLE
fix(release): break forms facade publish cycle

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -34,9 +34,9 @@ use syn::{Data, DeriveInput, Fields, GenericArgument, PathArguments, Result, Typ
 use syn::{Ident, LitBool, LitStr, bracketed, parenthesized};
 
 use crate::crate_paths::{
-	get_linkme_crate, get_reinhardt_core_crate, get_reinhardt_crate, get_reinhardt_db_crate,
-	get_reinhardt_forms_crate, get_reinhardt_migrations_crate, get_reinhardt_orm_crate,
-	get_serde_crate, get_serde_json_crate,
+	get_linkme_crate, get_reinhardt_apps_crate, get_reinhardt_core_crate, get_reinhardt_crate,
+	get_reinhardt_db_crate, get_reinhardt_forms_crate, get_reinhardt_migrations_crate,
+	get_reinhardt_orm_crate, get_serde_crate, get_serde_json_crate,
 };
 use crate::identifier_case::to_snake_case;
 use crate::rel::RelAttribute;
@@ -6631,7 +6631,7 @@ fn generate_relationship_registrations(
 	field_infos: &[FieldInfo],
 	fk_field_infos: &[ForeignKeyFieldInfo],
 ) -> TokenStream {
-	let reinhardt = get_reinhardt_crate();
+	let apps = get_reinhardt_apps_crate();
 	let _orm_crate = get_reinhardt_orm_crate();
 	// Fixes #793: Use dynamic crate path resolution instead of hardcoded ::linkme
 	let linkme = get_linkme_crate();
@@ -6675,9 +6675,9 @@ fn generate_relationship_registrations(
 
 		// Determine relationship type
 		let relationship_type = if is_one_to_one {
-			quote! { #reinhardt::apps::registry::RelationshipType::OneToOne }
+			quote! { #apps::registry::RelationshipType::OneToOne }
 		} else {
-			quote! { #reinhardt::apps::registry::RelationshipType::ForeignKey }
+			quote! { #apps::registry::RelationshipType::ForeignKey }
 		};
 
 		// Generate unique static variable name for forward relationship
@@ -6694,9 +6694,9 @@ fn generate_relationship_registrations(
 		// Generate registration code for forward relationship
 		registrations.push(quote! {
 			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-			#[#linkme::distributed_slice(#reinhardt::apps::registry::RELATIONSHIPS)]
-			static #static_var_name: #reinhardt::apps::registry::RelationshipMetadata =
-				#reinhardt::apps::registry::RelationshipMetadata {
+			#[#linkme::distributed_slice(#apps::registry::RELATIONSHIPS)]
+			static #static_var_name: #apps::registry::RelationshipMetadata =
+				#apps::registry::RelationshipMetadata {
 					from_model: concat!(#app_label, ".", #model_name),
 					to_model: #target_model_name,
 					relationship_type: #relationship_type,
@@ -6711,10 +6711,10 @@ fn generate_relationship_registrations(
 		if let Some(related_name_str) = related_name_opt {
 			// Determine reverse relationship type
 			let reverse_relationship_type = if is_one_to_one {
-				quote! { #reinhardt::apps::registry::RelationshipType::OneToOne }
+				quote! { #apps::registry::RelationshipType::OneToOne }
 			} else {
 				// ForeignKey reverse is also ForeignKey (direction determined by from_model/to_model)
-				quote! { #reinhardt::apps::registry::RelationshipType::ForeignKey }
+				quote! { #apps::registry::RelationshipType::ForeignKey }
 			};
 
 			// Generate unique static variable name for reverse relationship
@@ -6731,9 +6731,9 @@ fn generate_relationship_registrations(
 			// Generate registration code for reverse relationship
 			registrations.push(quote! {
 				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-				#[#linkme::distributed_slice(#reinhardt::apps::registry::RELATIONSHIPS)]
-				static #reverse_static_var_name: #reinhardt::apps::registry::RelationshipMetadata =
-					#reinhardt::apps::registry::RelationshipMetadata {
+				#[#linkme::distributed_slice(#apps::registry::RELATIONSHIPS)]
+				static #reverse_static_var_name: #apps::registry::RelationshipMetadata =
+					#apps::registry::RelationshipMetadata {
 						from_model: #target_model_name,
 						to_model: concat!(#app_label, ".", #model_name),
 						relationship_type: #reverse_relationship_type,
@@ -6807,12 +6807,12 @@ fn generate_relationship_registrations(
 		// Generate registration code for forward M2M relationship
 		registrations.push(quote! {
 			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-			#[#linkme::distributed_slice(#reinhardt::apps::registry::RELATIONSHIPS)]
-			static #static_var_name: #reinhardt::apps::registry::RelationshipMetadata =
-				#reinhardt::apps::registry::RelationshipMetadata {
+			#[#linkme::distributed_slice(#apps::registry::RELATIONSHIPS)]
+			static #static_var_name: #apps::registry::RelationshipMetadata =
+				#apps::registry::RelationshipMetadata {
 					from_model: concat!(#app_label, ".", #model_name),
 					to_model: #target_model_name,
-					relationship_type: #reinhardt::apps::registry::RelationshipType::ManyToMany,
+					relationship_type: #apps::registry::RelationshipType::ManyToMany,
 					field_name: #field_name_str,
 					related_name: #related_name,
 					db_column: None,
@@ -6836,12 +6836,12 @@ fn generate_relationship_registrations(
 			// Generate registration code for reverse M2M relationship
 			registrations.push(quote! {
 				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-				#[#linkme::distributed_slice(#reinhardt::apps::registry::RELATIONSHIPS)]
-				static #reverse_static_var_name: #reinhardt::apps::registry::RelationshipMetadata =
-					#reinhardt::apps::registry::RelationshipMetadata {
+				#[#linkme::distributed_slice(#apps::registry::RELATIONSHIPS)]
+				static #reverse_static_var_name: #apps::registry::RelationshipMetadata =
+					#apps::registry::RelationshipMetadata {
 						from_model: #target_model_name,
 						to_model: concat!(#app_label, ".", #model_name),
-						relationship_type: #reinhardt::apps::registry::RelationshipType::ManyToMany,
+						relationship_type: #apps::registry::RelationshipType::ManyToMany,
 						field_name: #related_name_str,
 						related_name: Some(#field_name_str),
 						db_column: None,

--- a/crates/reinhardt-forms/Cargo.toml
+++ b/crates/reinhardt-forms/Cargo.toml
@@ -40,7 +40,8 @@ full = []
 [dev-dependencies]
 insta = { workspace = true }
 linkme = { workspace = true }
-reinhardt = { workspace = true, features = ["core", "database"] }
+reinhardt-apps = { workspace = true }
+reinhardt-db = { workspace = true, features = ["associations"] }
 tokio-test = "0.4"
 rstest = { workspace = true }
 proptest = { workspace = true }

--- a/crates/reinhardt-forms/Cargo.toml
+++ b/crates/reinhardt-forms/Cargo.toml
@@ -40,8 +40,8 @@ full = []
 [dev-dependencies]
 insta = { workspace = true }
 linkme = { workspace = true }
-reinhardt-apps = { workspace = true }
-reinhardt-db = { workspace = true, features = ["associations"] }
+reinhardt-apps = { path = "../reinhardt-apps" }
+reinhardt-db = { path = "../reinhardt-db", features = ["associations"] }
 tokio-test = "0.4"
 rstest = { workspace = true }
 proptest = { workspace = true }


### PR DESCRIPTION
## Summary

This PR addresses:

- removes the circular `reinhardt-forms` dev-dependency on the `reinhardt-web` facade that blocked the 0.4.0-alpha.5 publish
- resolves generated relationship registry paths through `reinhardt-apps` directly
- preserves forms test coverage with direct publish-safe `reinhardt-apps` and `reinhardt-db` dev-dependencies

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Release job 92251759341 published 28 workspace crates, then failed while packaging `reinhardt-forms` because its facade dev-dependency required the not-yet-published `reinhardt-web 0.4.0-alpha.5`. The facade also depends on forms, creating a publish-order cycle. Cargo resolves versioned dev-dependencies during packaging, including with `--no-verify`.

Related to: #5930

## How Was This Tested?

- reproduced the failure with `cargo package --package reinhardt-forms --no-verify`
- verified `cargo package --package reinhardt-forms --no-verify --allow-dirty`
- verified the packaged manifest does not contain a `reinhardt-web` dependency
- `cargo test --package reinhardt-forms --all-features` (399 unit, 112 integration, and 134 doc tests passed; 21 doc tests ignored)
- `cargo test --package reinhardt-macros --test model_form_codegen` (5 passed)
- `cargo make fmt-check`
- `cargo make clippy-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Release PR #5930
- Failed release job 92251759341

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The failed run is a partial release: 28 crates reached 0.4.0-alpha.5 and 27 remain on 0.4.0-alpha.3. Merging this PR prevents the cycle, but completion of the interrupted release still requires the documented RP-1 partial-release recovery flow; rerunning the old SHA would not include this fix.

