### PR TITLE
test(pages): raise coverage to 80%

### DIFF
--- a/.github/workflows/wasm-check.yml
+++ b/.github/workflows/wasm-check.yml
@@ -230,7 +230,7 @@ jobs:
         working-directory: crates/reinhardt-pages
         # Run lib-level wasm_bindgen_test tests via wasm-pack.
         # This also caches the wasm-bindgen-test-runner binary for the next step.
-        run: wasm-pack test --headless --chrome --lib --features testing
+        run: wasm-pack test --headless --chrome --lib --features testing,chrono
 
       - name: Run WASM integration tests (reinhardt-pages)
         working-directory: crates/reinhardt-pages

--- a/crates/reinhardt-pages/src/form/rendering.rs
+++ b/crates/reinhardt-pages/src/form/rendering.rs
@@ -986,7 +986,7 @@ impl TailwindRenderer {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use rstest::rstest;
+	use rstest::*;
 
 	#[derive(Debug, Clone, Copy)]
 	enum PrimitiveWidget {
@@ -1012,7 +1012,9 @@ mod tests {
 
 		fn widget_type(self) -> WidgetType {
 			match self {
-				Self::Password | Self::Email | Self::Number => TextInput::new().widget_type(),
+				Self::Password => TextInput::password().widget_type(),
+				Self::Email => TextInput::email().widget_type(),
+				Self::Number => TextInput::number().widget_type(),
 				Self::Date => DateInput::new().widget_type(),
 				Self::Checkbox => CheckboxInput::new().widget_type(),
 				Self::File => FileInput::new().widget_type(),
@@ -1078,7 +1080,7 @@ mod tests {
 		assert_eq!(html, expected_html);
 	}
 
-	#[test]
+	#[rstest]
 	fn multi_value_widgets_select_exact_values_and_escape_labels() {
 		// Arrange
 		let choices = vec![
@@ -1121,7 +1123,7 @@ mod tests {
 		);
 	}
 
-	#[test]
+	#[rstest]
 	fn composite_widgets_scope_prefixed_attributes_and_preserve_values() {
 		// Arrange
 		let mut split_attrs = HashMap::new();
@@ -1163,7 +1165,7 @@ mod tests {
 		);
 	}
 
-	#[test]
+	#[rstest]
 	fn widget_attrs_and_framework_renderers_preserve_existing_classes() {
 		// Arrange
 		let attrs = WidgetAttrs::new()
@@ -1247,7 +1249,7 @@ mod tests {
 		);
 	}
 
-	#[test]
+	#[rstest]
 	fn widget_defaults_empty_choices_and_public_kinds_match_html_contract() {
 		// Arrange
 		let attrs = HashMap::from([("data-source".to_string(), "server&cache".to_string())]);

--- a/crates/reinhardt-pages/src/form/rendering.rs
+++ b/crates/reinhardt-pages/src/form/rendering.rs
@@ -986,6 +986,351 @@ impl TailwindRenderer {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::rstest;
+
+	#[derive(Debug, Clone, Copy)]
+	enum PrimitiveWidget {
+		Password,
+		Email,
+		Number,
+		Date,
+		Checkbox,
+		File,
+	}
+
+	impl PrimitiveWidget {
+		fn render(self, name: &str, value: Option<&str>) -> String {
+			match self {
+				Self::Password => TextInput::password().render(name, value, &HashMap::new()),
+				Self::Email => TextInput::email().render(name, value, &HashMap::new()),
+				Self::Number => TextInput::number().render(name, value, &HashMap::new()),
+				Self::Date => DateInput::new().render(name, value, &HashMap::new()),
+				Self::Checkbox => CheckboxInput::new().render(name, value, &HashMap::new()),
+				Self::File => FileInput::new().render(name, value, &HashMap::new()),
+			}
+		}
+
+		fn widget_type(self) -> WidgetType {
+			match self {
+				Self::Password | Self::Email | Self::Number => TextInput::new().widget_type(),
+				Self::Date => DateInput::new().widget_type(),
+				Self::Checkbox => CheckboxInput::new().widget_type(),
+				Self::File => FileInput::new().widget_type(),
+			}
+		}
+	}
+
+	#[rstest]
+	#[case::password(
+		PrimitiveWidget::Password,
+		"credential",
+		Some("a&b"),
+		WidgetType::TextInput,
+		r#"<input type="password" name="credential" value="a&amp;b" />"#
+	)]
+	#[case::email(
+		PrimitiveWidget::Email,
+		"email",
+		Some("ada@example.test"),
+		WidgetType::TextInput,
+		r#"<input type="email" name="email" value="ada@example.test" />"#
+	)]
+	#[case::number(
+		PrimitiveWidget::Number,
+		"count",
+		Some("42"),
+		WidgetType::TextInput,
+		r#"<input type="number" name="count" value="42" />"#
+	)]
+	#[case::date(
+		PrimitiveWidget::Date,
+		"published",
+		Some("2026-08-08"),
+		WidgetType::DateInput,
+		r#"<input type="date" name="published" value="2026-08-08" />"#
+	)]
+	#[case::checkbox(
+		PrimitiveWidget::Checkbox,
+		"active",
+		Some("on"),
+		WidgetType::Checkbox,
+		r#"<input type="checkbox" name="active" checked />"#
+	)]
+	#[case::file(
+		PrimitiveWidget::File,
+		"upload",
+		Some("ignored"),
+		WidgetType::FileInput,
+		r#"<input type="file" name="upload" />"#
+	)]
+	fn text_input_variants_render_exact_type_value_and_widget_kind(
+		#[case] widget: PrimitiveWidget,
+		#[case] name: &str,
+		#[case] value: Option<&str>,
+		#[case] expected_kind: WidgetType,
+		#[case] expected_html: &str,
+	) {
+		// Arrange and act
+		let html = widget.render(name, value);
+
+		// Assert
+		assert_eq!(widget.widget_type(), expected_kind);
+		assert_eq!(html, expected_html);
+	}
+
+	#[test]
+	fn multi_value_widgets_select_exact_values_and_escape_labels() {
+		// Arrange
+		let choices = vec![
+			("reader&writer".to_string(), "Read <write>".to_string()),
+			("owner".to_string(), "Owner \"role\"".to_string()),
+		];
+		let mut attrs = HashMap::new();
+		attrs.insert("data-state".to_string(), "ready&safe".to_string());
+
+		// Act
+		let select = SelectMultiple::new().render_with_choices(
+			"roles&name",
+			Some("reader&writer"),
+			&attrs,
+			&choices,
+		);
+		let checkboxes = CheckboxSelectMultiple::new().render_with_choices(
+			"roles&name",
+			Some("owner,reader&writer"),
+			&attrs,
+			&choices,
+		);
+
+		// Assert
+		assert_eq!(
+			SelectMultiple::new().widget_type(),
+			WidgetType::SelectMultiple
+		);
+		assert_eq!(
+			select,
+			r#"<select name="roles&amp;name" multiple data-state="ready&amp;safe"><option value="reader&amp;writer" selected>Read &lt;write&gt;</option><option value="owner">Owner &quot;role&quot;</option></select>"#,
+		);
+		assert_eq!(
+			CheckboxSelectMultiple::new().widget_type(),
+			WidgetType::CheckboxSelectMultiple
+		);
+		assert_eq!(
+			checkboxes,
+			r#"<label for="roles&amp;name_0"><input type="checkbox" name="roles&amp;name" id="roles&amp;name_0" value="reader&amp;writer" checked data-state="ready&amp;safe" /> Read &lt;write&gt;</label><label for="roles&amp;name_1"><input type="checkbox" name="roles&amp;name" id="roles&amp;name_1" value="owner" checked data-state="ready&amp;safe" /> Owner &quot;role&quot;</label>"#,
+		);
+	}
+
+	#[test]
+	fn composite_widgets_scope_prefixed_attributes_and_preserve_values() {
+		// Arrange
+		let mut split_attrs = HashMap::new();
+		split_attrs.insert("date_class".to_string(), "date-control".to_string());
+		split_attrs.insert("time_step".to_string(), "30".to_string());
+		let mut select_attrs = HashMap::new();
+		select_attrs.insert("year_class".to_string(), "year-control".to_string());
+		select_attrs.insert("month_data-part".to_string(), "month".to_string());
+		select_attrs.insert("day_aria-label".to_string(), "Day".to_string());
+
+		// Act
+		let file = FileInput::new().render("attachment", Some("never-rendered"), &HashMap::new());
+		let split = SplitDateTimeWidget::new().render(
+			"scheduled",
+			Some("2026-08-08T14:30:00"),
+			&split_attrs,
+		);
+		let invalid_split =
+			SplitDateTimeWidget::new().render("scheduled", Some("invalid"), &split_attrs);
+		let date = SelectDateWidget::with_years(vec![2025, 2026]).render(
+			"birthday",
+			Some("2026-08-09"),
+			&select_attrs,
+		);
+
+		// Assert
+		assert_eq!(file, r#"<input type="file" name="attachment" />"#);
+		assert_eq!(
+			split,
+			r#"<input type="date" name="scheduled_0" value="2026-08-08" class="date-control" /> <input type="time" name="scheduled_1" value="14:30:00" step="30" />"#,
+		);
+		assert_eq!(
+			invalid_split,
+			r#"<input type="date" name="scheduled_0" value="" class="date-control" /> <input type="time" name="scheduled_1" value="" step="30" />"#,
+		);
+		assert_eq!(
+			date,
+			r#"<select name="birthday_year" class="year-control"><option value="2025">2025</option><option value="2026" selected>2026</option></select> <select name="birthday_month" data-part="month"><option value="01">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option value="07">07</option><option value="08" selected>08</option><option value="09">09</option><option value="10">10</option><option value="11">11</option><option value="12">12</option></select> <select name="birthday_day" aria-label="Day"><option value="01">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option value="07">07</option><option value="08">08</option><option value="09" selected>09</option><option value="10">10</option><option value="11">11</option><option value="12">12</option><option value="13">13</option><option value="14">14</option><option value="15">15</option><option value="16">16</option><option value="17">17</option><option value="18">18</option><option value="19">19</option><option value="20">20</option><option value="21">21</option><option value="22">22</option><option value="23">23</option><option value="24">24</option><option value="25">25</option><option value="26">26</option><option value="27">27</option><option value="28">28</option><option value="29">29</option><option value="30">30</option><option value="31">31</option></select>"#,
+		);
+	}
+
+	#[test]
+	fn widget_attrs_and_framework_renderers_preserve_existing_classes() {
+		// Arrange
+		let attrs = WidgetAttrs::new()
+			.attr("autocomplete", "username")
+			.class("base")
+			.class("valid")
+			.data("state", "ready")
+			.aria("label", "User name")
+			.id("username")
+			.placeholder("Enter user name")
+			.required()
+			.disabled()
+			.readonly()
+			.build();
+		let expected_attrs = HashMap::from([
+			("autocomplete".to_string(), "username".to_string()),
+			("class".to_string(), "base valid".to_string()),
+			("data-state".to_string(), "ready".to_string()),
+			("aria-label".to_string(), "User name".to_string()),
+			("id".to_string(), "username".to_string()),
+			("placeholder".to_string(), "Enter user name".to_string()),
+			("required".to_string(), "required".to_string()),
+			("disabled".to_string(), "disabled".to_string()),
+			("readonly".to_string(), "readonly".to_string()),
+		]);
+		let renderer_attrs = HashMap::from([("class".to_string(), "existing".to_string())]);
+
+		// Act
+		let bootstrap =
+			BootstrapRenderer::render_text_input("username", Some("ada"), renderer_attrs.clone());
+		let tailwind = TailwindRenderer::render_text_input("username", Some("ada"), renderer_attrs);
+		let choices = vec![("admin".to_string(), "Administrator".to_string())];
+		let bootstrap_select = BootstrapRenderer::render_select(
+			"role",
+			Some("admin"),
+			HashMap::from([("class".to_string(), "existing".to_string())]),
+			&choices,
+		);
+		let bootstrap_checkbox = BootstrapRenderer::render_checkbox(
+			"active",
+			Some("true"),
+			HashMap::from([("class".to_string(), "existing".to_string())]),
+		);
+		let tailwind_select = TailwindRenderer::render_select(
+			"role",
+			Some("admin"),
+			HashMap::from([("class".to_string(), "existing".to_string())]),
+			&choices,
+		);
+		let tailwind_checkbox = TailwindRenderer::render_checkbox(
+			"active",
+			Some("true"),
+			HashMap::from([("class".to_string(), "existing".to_string())]),
+		);
+
+		// Assert
+		assert_eq!(attrs, expected_attrs);
+		assert_eq!(
+			bootstrap,
+			r#"<input type="text" name="username" value="ada" class="existing form-control" />"#,
+		);
+		assert_eq!(
+			tailwind,
+			r#"<input type="text" name="username" value="ada" class="existing block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />"#,
+		);
+		assert_eq!(
+			bootstrap_select,
+			r#"<select name="role" class="existing form-select"><option value="admin" selected>Administrator</option></select>"#,
+		);
+		assert_eq!(
+			bootstrap_checkbox,
+			r#"<div class="form-check"><input type="checkbox" name="active" checked class="existing form-check-input" /></div>"#,
+		);
+		assert_eq!(
+			tailwind_select,
+			r#"<select name="role" class="existing block w-full rounded-md border-gray-300 py-2 pl-3 pr-10 text-base focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"><option value="admin" selected>Administrator</option></select>"#,
+		);
+		assert_eq!(
+			tailwind_checkbox,
+			r#"<input type="checkbox" name="active" checked class="existing h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />"#,
+		);
+	}
+
+	#[test]
+	fn widget_defaults_empty_choices_and_public_kinds_match_html_contract() {
+		// Arrange
+		let attrs = HashMap::from([("data-source".to_string(), "server&cache".to_string())]);
+		let choices = vec![("one".to_string(), "One".to_string())];
+		let kinds = [
+			WidgetType::TextInput,
+			WidgetType::PasswordInput,
+			WidgetType::EmailInput,
+			WidgetType::NumberInput,
+			WidgetType::DateInput,
+			WidgetType::TimeInput,
+			WidgetType::DateTimeInput,
+			WidgetType::Textarea,
+			WidgetType::Checkbox,
+			WidgetType::Select,
+			WidgetType::SelectMultiple,
+			WidgetType::Radio,
+			WidgetType::RadioSelect,
+			WidgetType::CheckboxSelectMultiple,
+			WidgetType::FileInput,
+			WidgetType::HiddenInput,
+			WidgetType::SplitDateTime,
+			WidgetType::SelectDate,
+		];
+
+		// Act
+		let text_default = TextInput::default();
+		let text_with_choices =
+			text_default.render_with_choices("title", Some("A < B"), &attrs, &choices);
+		let date_default = DateInput::default().render("published", None, &attrs);
+		let checkbox_false = CheckboxInput::default().render("active", Some("false"), &attrs);
+		let select_empty = Select::default().render("choice", None, &attrs);
+		let select_multiple_empty = SelectMultiple::default().render("choices", None, &attrs);
+		let radio_empty = RadioSelect::default().render("choice", None, &attrs);
+		let checkbox_multiple_empty =
+			CheckboxSelectMultiple::default().render("choices", None, &attrs);
+		let file_default = FileInput::default().render("upload", None, &attrs);
+		let split_default = SplitDateTimeWidget::default().render("when", None, &HashMap::new());
+		let serialized_kinds =
+			serde_json::to_string(&kinds).expect("widget kinds should serialize");
+
+		// Assert
+		assert_eq!(text_default.widget_type(), WidgetType::TextInput);
+		assert_eq!(
+			text_with_choices,
+			r#"<input type="text" name="title" value="A &lt; B" data-source="server&amp;cache" />"#,
+		);
+		assert_eq!(
+			date_default,
+			r#"<input type="date" name="published" data-source="server&amp;cache" />"#,
+		);
+		assert_eq!(
+			checkbox_false,
+			r#"<input type="checkbox" name="active" data-source="server&amp;cache" />"#,
+		);
+		assert_eq!(
+			select_empty,
+			r#"<select name="choice" data-source="server&amp;cache"></select>"#,
+		);
+		assert_eq!(
+			select_multiple_empty,
+			r#"<select name="choices" multiple data-source="server&amp;cache"></select>"#,
+		);
+		assert_eq!(radio_empty, "");
+		assert_eq!(checkbox_multiple_empty, "");
+		assert_eq!(
+			file_default,
+			r#"<input type="file" name="upload" data-source="server&amp;cache" />"#,
+		);
+		assert_eq!(
+			split_default,
+			r#"<input type="date" name="when_0" value="" /> <input type="time" name="when_1" value="" />"#,
+		);
+		assert_eq!(
+			serialized_kinds,
+			r#"["TextInput","PasswordInput","EmailInput","NumberInput","DateInput","TimeInput","DateTimeInput","Textarea","Checkbox","Select","SelectMultiple","Radio","RadioSelect","CheckboxSelectMultiple","FileInput","HiddenInput","SplitDateTime","SelectDate"]"#,
+		);
+		assert_eq!(BootstrapRenderer::form_check_class(), "form-check");
+		assert_eq!(
+			TailwindRenderer::form_control_class(),
+			"block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+		);
+	}
 
 	#[test]
 	fn test_text_input_render() {

--- a/crates/reinhardt-pages/src/tables/columns.rs
+++ b/crates/reinhardt-pages/src/tables/columns.rs
@@ -34,3 +34,155 @@ pub use json::JSONColumn;
 pub use link::LinkColumn;
 pub use template::TemplateColumn;
 pub use url::URLColumn;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::tables::column::Column as ColumnTrait;
+	use std::collections::HashMap;
+
+	#[test]
+	fn table_columns_preserve_metadata_and_visibility_configuration() {
+		// Arrange
+		let basic = Column::<u32>::new("id", "Identifier")
+			.orderable(false)
+			.visible(false);
+		let boolean = BooleanColumn::new("active", "Active")
+			.orderable(false)
+			.visible(false);
+		let checkbox = CheckBoxColumn::new("selected", "Selected")
+			.orderable(true)
+			.visible(false);
+		let choice = ChoiceColumn::new("status", "Status")
+			.choices(HashMap::from([("draft".to_string(), "Draft".to_string())]))
+			.orderable(false)
+			.visible(false);
+		let datetime = DateTimeColumn::new("created_at", "Created")
+			.format("%Y-%m-%d")
+			.orderable(false)
+			.visible(false);
+
+		// Act
+		let metadata = [
+			(
+				basic.name(),
+				basic.label(),
+				basic.is_orderable(),
+				basic.is_visible(),
+			),
+			(
+				boolean.name(),
+				boolean.label(),
+				boolean.is_orderable(),
+				boolean.is_visible(),
+			),
+			(
+				checkbox.name(),
+				checkbox.label(),
+				checkbox.is_orderable(),
+				checkbox.is_visible(),
+			),
+			(
+				choice.name(),
+				choice.label(),
+				choice.is_orderable(),
+				choice.is_visible(),
+			),
+			(
+				datetime.name(),
+				datetime.label(),
+				datetime.is_orderable(),
+				datetime.is_visible(),
+			),
+		];
+
+		// Assert
+		assert_eq!(
+			metadata,
+			[
+				("id", "Identifier", false, false),
+				("active", "Active", false, false),
+				("selected", "Selected", true, false),
+				("status", "Status", false, false),
+				("created_at", "Created", false, false),
+			]
+		);
+	}
+	#[test]
+	fn specialized_columns_expose_expected_defaults_and_custom_metadata() {
+		// Arrange
+		let boolean = BooleanColumn::with_icons("verified", "Verified", "yes", "no");
+		let email = EmailColumn::new("email", "Email").visible(false);
+		let json = JSONColumn::new("payload", "Payload").orderable(true);
+		let link = LinkColumn::new("id", "Profile", "/profiles/{id}")
+			.orderable(false)
+			.visible(false);
+		let link_with_text = LinkColumn::with_text("slug", "Article", "/articles/{slug}", "Read");
+		let template = TemplateColumn::new("summary", "Summary")
+			.orderable(true)
+			.visible(false);
+		let url = URLColumn::new("website", "Website")
+			.orderable(false)
+			.visible(false);
+
+		// Act
+		let metadata = [
+			(
+				boolean.name(),
+				boolean.label(),
+				boolean.is_orderable(),
+				boolean.is_visible(),
+			),
+			(
+				email.name(),
+				email.label(),
+				email.is_orderable(),
+				email.is_visible(),
+			),
+			(
+				json.name(),
+				json.label(),
+				json.is_orderable(),
+				json.is_visible(),
+			),
+			(
+				link.name(),
+				link.label(),
+				link.is_orderable(),
+				link.is_visible(),
+			),
+			(
+				link_with_text.name(),
+				link_with_text.label(),
+				link_with_text.is_orderable(),
+				link_with_text.is_visible(),
+			),
+			(
+				template.name(),
+				template.label(),
+				template.is_orderable(),
+				template.is_visible(),
+			),
+			(
+				url.name(),
+				url.label(),
+				url.is_orderable(),
+				url.is_visible(),
+			),
+		];
+
+		// Assert
+		assert_eq!(
+			metadata,
+			[
+				("verified", "Verified", true, true),
+				("email", "Email", true, false),
+				("payload", "Payload", true, true),
+				("id", "Profile", false, false),
+				("slug", "Article", true, true),
+				("summary", "Summary", true, false),
+				("website", "Website", false, false),
+			]
+		);
+	}
+}

--- a/crates/reinhardt-pages/src/tables/columns.rs
+++ b/crates/reinhardt-pages/src/tables/columns.rs
@@ -39,9 +39,10 @@ pub use url::URLColumn;
 mod tests {
 	use super::*;
 	use crate::tables::column::Column as ColumnTrait;
+	use rstest::rstest;
 	use std::collections::HashMap;
 
-	#[test]
+	#[rstest]
 	fn table_columns_preserve_metadata_and_visibility_configuration() {
 		// Arrange
 		let basic = Column::<u32>::new("id", "Identifier")
@@ -108,7 +109,7 @@ mod tests {
 			]
 		);
 	}
-	#[test]
+	#[rstest]
 	fn specialized_columns_expose_expected_defaults_and_custom_metadata() {
 		// Arrange
 		let boolean = BooleanColumn::with_icons("verified", "Verified", "yes", "no");
@@ -184,5 +185,70 @@ mod tests {
 				("website", "Website", false, false),
 			]
 		);
+	}
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod wasm_render_tests {
+	use super::*;
+	use crate::tables::column::Column as ColumnTrait;
+	use std::collections::HashMap;
+	use wasm_bindgen_test::*;
+
+	wasm_bindgen_test_configure!(run_in_browser);
+
+	#[wasm_bindgen_test]
+	fn specialized_columns_render_configured_values() {
+		// Arrange
+		let choice = ChoiceColumn::new("status", "Status")
+			.choices(HashMap::from([("draft".to_string(), "Draft".to_string())]));
+		let boolean = BooleanColumn::with_icons("verified", "Verified", "YES", "NO");
+		let datetime = DateTimeColumn::new("created_at", "Created").format("%Y/%m/%d %H:%M");
+		let link = LinkColumn::new("id", "Profile", "/profiles/{id}");
+		let link_with_text = LinkColumn::with_text("slug", "Article", "/articles/{slug}", "Read");
+
+		// Act
+		let choice_value = "draft".to_string();
+		let choice_element = choice.render(&choice_value);
+		let boolean_value = true;
+		let boolean_element = boolean.render(&boolean_value);
+		let date_value = "2026-08-08 14:30:00".to_string();
+		let date_element = datetime.render(&date_value);
+		let link_value = "42".to_string();
+		let link_element = link.render(&link_value);
+		let slug_value = "coverage".to_string();
+		let link_with_text_element = link_with_text.render(&slug_value);
+
+		// Assert
+		assert_eq!(
+			choice_element.as_web_sys().text_content(),
+			Some("Draft".to_string())
+		);
+		assert_eq!(
+			boolean_element.as_web_sys().text_content(),
+			Some("YES".to_string())
+		);
+		assert_eq!(date_element.as_web_sys().text_content(), Some(date_value));
+		assert_eq!(
+			link_element.as_web_sys().outer_html(),
+			"<td><a href=\"/profiles/42\">42</a></td>",
+		);
+		assert_eq!(
+			link_with_text_element.as_web_sys().outer_html(),
+			"<td><a href=\"/articles/coverage\">Read</a></td>",
+		);
+
+		#[cfg(feature = "chrono")]
+		{
+			let datetime = DateTimeColumn::new("created_at", "Created").format("%Y/%m/%d %H:%M");
+			let value =
+				chrono::NaiveDateTime::parse_from_str("2026-08-08 14:30:00", "%Y-%m-%d %H:%M:%S")
+					.unwrap();
+			let element = datetime.render(&value);
+			assert_eq!(
+				element.as_web_sys().text_content(),
+				Some("2026/08/08 14:30".to_string())
+			);
+		}
 	}
 }

--- a/crates/reinhardt-pages/src/tables/columns.rs
+++ b/crates/reinhardt-pages/src/tables/columns.rs
@@ -192,11 +192,13 @@ mod tests {
 mod wasm_render_tests {
 	use super::*;
 	use crate::tables::column::Column as ColumnTrait;
+	use rstest::*;
 	use std::collections::HashMap;
 	use wasm_bindgen_test::*;
 
 	wasm_bindgen_test_configure!(run_in_browser);
 
+	#[rstest]
 	#[wasm_bindgen_test]
 	fn specialized_columns_render_configured_values() {
 		// Arrange

--- a/crates/reinhardt-pages/src/tables/export/csv.rs
+++ b/crates/reinhardt-pages/src/tables/export/csv.rs
@@ -30,6 +30,7 @@ pub fn export_csv<W: Write>(writer: &mut W, data: &[Vec<String>]) -> Result<(), 
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::*;
 
 	struct FailingWriter;
 
@@ -46,7 +47,7 @@ mod tests {
 		}
 	}
 
-	#[test]
+	#[rstest]
 	fn csv_and_json_exports_escape_and_shape_rows_exactly() {
 		// Arrange
 		let data = vec![

--- a/crates/reinhardt-pages/src/tables/export/csv.rs
+++ b/crates/reinhardt-pages/src/tables/export/csv.rs
@@ -26,3 +26,51 @@ pub fn export_csv<W: Write>(writer: &mut W, data: &[Vec<String>]) -> Result<(), 
 	}
 	Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	struct FailingWriter;
+
+	impl Write for FailingWriter {
+		fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+			Err(std::io::Error::new(
+				std::io::ErrorKind::BrokenPipe,
+				"writer failed",
+			))
+		}
+
+		fn flush(&mut self) -> std::io::Result<()> {
+			Ok(())
+		}
+	}
+
+	#[test]
+	fn csv_and_json_exports_escape_and_shape_rows_exactly() {
+		// Arrange
+		let data = vec![
+			vec!["name".to_string(), "note".to_string()],
+			vec![
+				"Ada, Lovelace".to_string(),
+				"She said \"hello\"".to_string(),
+			],
+			vec!["Grace".to_string(), "line one\nline two".to_string()],
+		];
+		let mut output = Vec::new();
+
+		// Act
+		export_csv(&mut output, &data).expect("CSV export should write to an in-memory buffer");
+		let error =
+			export_csv(&mut FailingWriter, &data).expect_err("failing writer should be reported");
+		let flush_result = FailingWriter.flush();
+
+		// Assert
+		assert_eq!(
+			output,
+			b"name,note\n\"Ada, Lovelace\",\"She said \"\"hello\"\"\"\nGrace,\"line one\nline two\"\n"
+		);
+		assert_eq!(error.to_string(), "I/O error: writer failed");
+		flush_result.expect("failing writer flush should remain a no-op");
+	}
+}

--- a/crates/reinhardt-pages/src/tables/export/json.rs
+++ b/crates/reinhardt-pages/src/tables/export/json.rs
@@ -35,6 +35,7 @@ pub fn export_json<W: Write>(writer: &mut W, data: &[Vec<String>]) -> Result<(),
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::*;
 
 	struct FailingWriter;
 
@@ -51,7 +52,7 @@ mod tests {
 		}
 	}
 
-	#[test]
+	#[rstest]
 	fn csv_and_json_exports_escape_and_shape_rows_exactly() {
 		// Arrange
 		let data = vec![

--- a/crates/reinhardt-pages/src/tables/export/json.rs
+++ b/crates/reinhardt-pages/src/tables/export/json.rs
@@ -31,3 +31,59 @@ pub fn export_json<W: Write>(writer: &mut W, data: &[Vec<String>]) -> Result<(),
 	writer.write_all(json.as_bytes())?;
 	Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	struct FailingWriter;
+
+	impl Write for FailingWriter {
+		fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+			Err(std::io::Error::new(
+				std::io::ErrorKind::BrokenPipe,
+				"writer failed",
+			))
+		}
+
+		fn flush(&mut self) -> std::io::Result<()> {
+			Ok(())
+		}
+	}
+
+	#[test]
+	fn csv_and_json_exports_escape_and_shape_rows_exactly() {
+		// Arrange
+		let data = vec![
+			vec!["name".to_string(), "role".to_string(), "unused".to_string()],
+			vec!["Ada".to_string(), "maintainer".to_string()],
+			vec!["Grace".to_string()],
+		];
+		let mut output = Vec::new();
+		let mut empty_output = Vec::new();
+
+		// Act
+		export_json(&mut output, &data).expect("JSON export should write to an in-memory buffer");
+		export_json(&mut empty_output, &[]).expect("empty JSON export should succeed");
+		let error =
+			export_json(&mut FailingWriter, &data).expect_err("failing writer should be reported");
+		let flush_result = FailingWriter.flush();
+
+		// Assert
+		assert_eq!(
+			output,
+			br#"[
+  {
+    "name": "Ada",
+    "role": "maintainer"
+  },
+  {
+    "name": "Grace"
+  }
+]"#,
+		);
+		assert_eq!(empty_output, b"[]");
+		assert_eq!(error.to_string(), "I/O error: writer failed");
+		flush_result.expect("failing writer flush should remain a no-op");
+	}
+}

--- a/crates/reinhardt-pages/src/tables/pagination.rs
+++ b/crates/reinhardt-pages/src/tables/pagination.rs
@@ -69,3 +69,72 @@ impl Pagination {
 		self.current_page = page.max(1).min(self.total_pages().max(1));
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn pagination_clamps_and_moves_at_boundaries() {
+		// Arrange
+		let mut empty = Pagination::new(5);
+		empty.set_page(99);
+		let mut partial_last = Pagination::new(5);
+		partial_last.total_items = 11;
+		partial_last.set_page(99);
+		let mut page_zero = Pagination::new(5);
+		page_zero.total_items = 11;
+		page_zero.set_page(0);
+		let mut first = Pagination::new(5);
+		first.total_items = 11;
+		let mut last = Pagination::new(5);
+		last.total_items = 11;
+		last.set_page(3);
+
+		// Act
+		let empty_state = (
+			empty.total_pages(),
+			empty.start_index(),
+			empty.end_index(),
+			empty.current_page,
+			empty.next_page(),
+		);
+		let partial_last_state = (
+			partial_last.total_pages(),
+			partial_last.start_index(),
+			partial_last.end_index(),
+			partial_last.current_page,
+			partial_last.next_page(),
+		);
+		let page_zero_state = (
+			page_zero.total_pages(),
+			page_zero.start_index(),
+			page_zero.end_index(),
+			page_zero.current_page,
+			page_zero.prev_page(),
+		);
+		let first_state = (
+			first.total_pages(),
+			first.start_index(),
+			first.end_index(),
+			first.current_page,
+			first.next_page(),
+		);
+		let last_state = (
+			last.total_pages(),
+			last.start_index(),
+			last.end_index(),
+			last.current_page,
+			last.prev_page(),
+		);
+
+		// Assert
+		assert_eq!(empty_state, (0, 0, 0, 1, false));
+		assert_eq!(partial_last_state, (3, 10, 11, 3, false));
+		assert_eq!(page_zero_state, (3, 0, 5, 1, false));
+		assert_eq!(first_state, (3, 0, 5, 1, true));
+		assert_eq!(last_state, (3, 10, 11, 3, true));
+		assert_eq!(first.current_page, 2);
+		assert_eq!(last.current_page, 2);
+	}
+}

--- a/crates/reinhardt-pages/src/tables/pagination.rs
+++ b/crates/reinhardt-pages/src/tables/pagination.rs
@@ -73,8 +73,9 @@ impl Pagination {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::*;
 
-	#[test]
+	#[rstest]
 	fn pagination_clamps_and_moves_at_boundaries() {
 		// Arrange
 		let mut empty = Pagination::new(5);

--- a/crates/reinhardt-pages/src/tables/sorting.rs
+++ b/crates/reinhardt-pages/src/tables/sorting.rs
@@ -39,3 +39,30 @@ pub trait Sortable {
 	/// Returns the current sort field and direction
 	fn current_sort(&self) -> Option<(&str, SortDirection)>;
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn sorting_and_table_defaults_match_public_contract() {
+		// Arrange
+		let expected = [
+			(SortDirection::Ascending, ""),
+			(SortDirection::Descending, "name"),
+			(SortDirection::Descending, "-name"),
+		];
+
+		// Act
+		let parsed = [
+			SortDirection::parse_from_query(""),
+			SortDirection::parse_from_query("-name"),
+			SortDirection::parse_from_query("--name"),
+		];
+
+		// Assert
+		assert_eq!(parsed, expected);
+		assert_eq!(SortDirection::Ascending.toggle(), SortDirection::Descending);
+		assert_eq!(SortDirection::Descending.toggle(), SortDirection::Ascending);
+	}
+}

--- a/crates/reinhardt-pages/src/tables/sorting.rs
+++ b/crates/reinhardt-pages/src/tables/sorting.rs
@@ -43,8 +43,9 @@ pub trait Sortable {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::*;
 
-	#[test]
+	#[rstest]
 	fn sorting_and_table_defaults_match_public_contract() {
 		// Arrange
 		let expected = [

--- a/crates/reinhardt-pages/src/tables/table.rs
+++ b/crates/reinhardt-pages/src/tables/table.rs
@@ -56,6 +56,7 @@ pub trait Table {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::*;
 
 	struct ExampleTable {
 		rows: Vec<u32>,
@@ -81,7 +82,7 @@ mod tests {
 		fn handle_pagination(&mut self, _page: usize) {}
 	}
 
-	#[test]
+	#[rstest]
 	fn sorting_and_table_defaults_match_public_contract() {
 		// Arrange
 		let table = ExampleTable {

--- a/crates/reinhardt-pages/src/tables/table.rs
+++ b/crates/reinhardt-pages/src/tables/table.rs
@@ -52,3 +52,53 @@ pub trait Table {
 		false
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	struct ExampleTable {
+		rows: Vec<u32>,
+	}
+
+	impl Table for ExampleTable {
+		type Row = u32;
+
+		fn rows(&self) -> Vec<&Self::Row> {
+			self.rows.iter().collect()
+		}
+
+		fn columns(&self) -> Vec<&dyn Column> {
+			Vec::new()
+		}
+
+		fn render(&self) -> Element {
+			panic!("default table contract test does not render DOM elements")
+		}
+
+		fn handle_sort(&mut self, _field: &str, _direction: SortDirection) {}
+
+		fn handle_pagination(&mut self, _page: usize) {}
+	}
+
+	#[test]
+	fn sorting_and_table_defaults_match_public_contract() {
+		// Arrange
+		let table = ExampleTable {
+			rows: vec![1, 2, 3],
+		};
+
+		// Act
+		let defaults = (
+			table.total_rows(),
+			table.current_page(),
+			table.per_page(),
+			table.is_sortable(),
+			table.is_paginated(),
+			table.columns().len(),
+		);
+
+		// Assert
+		assert_eq!(defaults, (3, 1, 10, true, false, 0));
+	}
+}


### PR DESCRIPTION
## Summary

This PR raises reinhardt-pages native line coverage from 76.33% to 80.35% with exact behavior tests for form rendering and pure table contracts.

## Type of Change

- [x] Code quality improvements

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

Cover native widget HTML, escaping, framework renderer attributes, table export/pagination/sorting/default behavior, and column metadata without relying on browser-only execution.

Fixes #5937

## How Was This Tested?

- Focused native tests: 17/17 passed
- Native UI-excluded coverage suite: 1,408/1,408 passed
- Target-aligned llvm-cov: 80.35% lines (8,166/10,163)
- WASM compile guard, rustfmt, diff checks, and library Clippy passed

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`

## Labels to Apply

- [x] `code-quality` - Code quality improvements

### Additional Context

Full UI trybuild execution was bounded due to an existing stall; unchanged integration-test Clippy warnings are recorded separately. The coverage lever remains native and behavior-focused.