### PR TITLE
test(streaming): raise coverage to 90%

### DIFF
--- a/crates/reinhardt-streaming/src/in_memory.rs
+++ b/crates/reinhardt-streaming/src/in_memory.rs
@@ -84,6 +84,23 @@ mod tests {
 
 	#[rstest]
 	#[tokio::test]
+	async fn default_backend_starts_empty_and_accepts_messages() {
+		// Arrange
+		let backend = InMemoryStreamingBackend::default();
+		let payload = b"default-backend-message".to_vec();
+
+		// Act
+		let initial = backend.poll("orders").await.unwrap();
+		backend.publish("orders", payload.clone()).await.unwrap();
+		let published = backend.poll("orders").await.unwrap();
+
+		// Assert
+		assert_eq!(initial, None);
+		assert_eq!(published, Some(payload));
+	}
+
+	#[rstest]
+	#[tokio::test]
 	async fn fifo_order_preserved(backend: InMemoryStreamingBackend) {
 		// Arrange
 		backend.publish("t", b"first".to_vec()).await.unwrap();

--- a/crates/reinhardt-streaming/src/message.rs
+++ b/crates/reinhardt-streaming/src/message.rs
@@ -57,6 +57,26 @@ mod tests {
 	}
 
 	#[rstest]
+	fn message_with_partition_preserves_existing_metadata() {
+		// Arrange
+		let message = Message::new("orders", vec![1u8, 2, 3]).with_offset(42);
+
+		// Act
+		let message = message.with_partition(3);
+
+		// Assert
+		assert_eq!(
+			(
+				message.topic,
+				message.payload,
+				message.offset,
+				message.partition
+			),
+			("orders".to_owned(), vec![1, 2, 3], Some(42), Some(3)),
+		);
+	}
+
+	#[rstest]
 	fn message_roundtrips_json() {
 		let msg = Message::new("topic", vec![1u8, 2, 3]);
 		let json = serde_json::to_string(&msg).unwrap();

--- a/crates/reinhardt-streaming/src/router.rs
+++ b/crates/reinhardt-streaming/src/router.rs
@@ -116,4 +116,60 @@ mod tests {
 		assert_eq!(router.handlers.len(), 2);
 		assert_eq!(router.handlers[1].kind, StreamingHandlerKind::Consumer);
 	}
+
+	#[rstest]
+	fn into_handlers_returns_complete_public_registrations() {
+		struct NoopFactory;
+		impl ConsumerFactory for NoopFactory {
+			fn spawn(&self, _: Vec<String>, _: &'static str, _: &'static str) {}
+		}
+
+		// Arrange
+		let router = StreamingRouter::new()
+			.producer("orders", "create_order")
+			.consumer(
+				"orders",
+				"processors",
+				"process_order",
+				Arc::new(NoopFactory),
+			);
+
+		// Act
+		let handlers = router.into_handlers();
+
+		// Assert
+		assert_eq!(handlers.len(), 2);
+		assert_eq!(
+			(
+				handlers[0].topic,
+				handlers[0].group,
+				handlers[0].name,
+				handlers[0].kind,
+				handlers[0].consumer_factory.is_some(),
+			),
+			(
+				"orders",
+				None,
+				"create_order",
+				StreamingHandlerKind::Producer,
+				false,
+			),
+		);
+		assert_eq!(
+			(
+				handlers[1].topic,
+				handlers[1].group,
+				handlers[1].name,
+				handlers[1].kind,
+				handlers[1].consumer_factory.is_some(),
+			),
+			(
+				"orders",
+				Some("processors"),
+				"process_order",
+				StreamingHandlerKind::Consumer,
+				true,
+			),
+		);
+	}
 }

--- a/crates/reinhardt-streaming/tests/kafka_error_paths.rs
+++ b/crates/reinhardt-streaming/tests/kafka_error_paths.rs
@@ -213,6 +213,29 @@ async fn producer_send_creates_unknown_topic_via_retry_path(#[future] kafka: Kaf
 
 #[rstest]
 #[tokio::test]
+async fn send_to_partition_rejects_negative_partition(#[future] kafka: KafkaContainer) {
+	// Arrange
+	let kafka = kafka.await;
+	let config = KafkaConfig::new(kafka.brokers());
+	let producer = KafkaProducer::connect(&config).await.unwrap();
+
+	// Act
+	let error = producer
+		.send_to_partition("orders", -1, b"invalid-partition".to_vec())
+		.await
+		.expect_err("negative partitions must be rejected before publishing");
+
+	// Assert
+	match error {
+		StreamingError::Fatal(message) => {
+			assert_eq!(message, "partition must be non-negative, got -1");
+		}
+		other => panic!("expected StreamingError::Fatal, got {other:?}"),
+	}
+}
+
+#[rstest]
+#[tokio::test]
 async fn consumer_offsets_advance_monotonically_across_receives(#[future] kafka: KafkaContainer) {
 	// Arrange
 	let kafka = kafka.await;

--- a/crates/reinhardt-streaming/tests/kafka_integration.rs
+++ b/crates/reinhardt-streaming/tests/kafka_integration.rs
@@ -1,4 +1,7 @@
-use reinhardt_streaming::kafka::{KafkaConfig, KafkaConsumer, KafkaProducer};
+use reinhardt_streaming::{
+	di::build_kafka_clients,
+	kafka::{KafkaConfig, KafkaConsumer, KafkaProducer},
+};
 use reinhardt_testkit::containers::KafkaContainer;
 use rstest::*;
 use serde::{Deserialize, Serialize};
@@ -34,4 +37,37 @@ async fn producer_and_consumer_roundtrip(#[future] kafka: KafkaContainer) {
 	// Assert
 	assert!(received.is_some());
 	assert_eq!(received.unwrap().payload, order);
+}
+
+#[rstest]
+#[tokio::test]
+async fn build_kafka_clients_returns_usable_shared_clients(#[future] kafka: KafkaContainer) {
+	// Arrange
+	let kafka = kafka.await;
+	let config = KafkaConfig::new(kafka.brokers());
+	let topic = "build-kafka-clients-roundtrip";
+	let order = Order {
+		id: 73,
+		item: "notebook".to_owned(),
+	};
+
+	// Act
+	let (producer, consumer) = build_kafka_clients(&config).await.unwrap();
+	producer.send(topic, &order).await.unwrap();
+	let received = consumer
+		.receive::<Order>(topic)
+		.await
+		.unwrap()
+		.expect("shared Kafka clients must complete a producer-to-consumer round trip");
+
+	// Assert
+	assert_eq!(
+		(
+			received.topic,
+			received.payload,
+			received.offset,
+			received.partition,
+		),
+		(topic.to_owned(), order, Some(0), None),
+	);
 }

--- a/crates/reinhardt-streaming/tests/kafka_integration.rs
+++ b/crates/reinhardt-streaming/tests/kafka_integration.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use reinhardt_streaming::{
+	Message,
 	di::build_kafka_clients,
 	kafka::{KafkaConfig, KafkaConsumer, KafkaProducer},
 };
@@ -12,9 +15,37 @@ struct Order {
 	item: String,
 }
 
+/// Bound the initial receive while Kafka propagates topic metadata and starts fetching.
+const FIRST_RECEIVE_TIMEOUT: Duration = Duration::from_secs(15);
+const FIRST_RECEIVE_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
 #[fixture]
 async fn kafka() -> KafkaContainer {
 	KafkaContainer::new().await
+}
+
+/// Poll `receive` until a record materializes or the bounded initial-fetch window expires.
+async fn receive_first_with_retry<T>(consumer: &KafkaConsumer, topic: &str) -> Message<T>
+where
+	T: serde::de::DeserializeOwned,
+{
+	let deadline = tokio::time::Instant::now() + FIRST_RECEIVE_TIMEOUT;
+	loop {
+		match consumer
+			.receive::<T>(topic)
+			.await
+			.expect("first receive must not return a transport error")
+		{
+			Some(message) => return message,
+			None => {
+				assert!(
+					tokio::time::Instant::now() < deadline,
+					"no record arrived within {FIRST_RECEIVE_TIMEOUT:?}",
+				);
+				tokio::time::sleep(FIRST_RECEIVE_POLL_INTERVAL).await;
+			}
+		}
+	}
 }
 
 #[rstest]
@@ -54,11 +85,7 @@ async fn build_kafka_clients_returns_usable_shared_clients(#[future] kafka: Kafk
 	// Act
 	let (producer, consumer) = build_kafka_clients(&config).await.unwrap();
 	producer.send(topic, &order).await.unwrap();
-	let received = consumer
-		.receive::<Order>(topic)
-		.await
-		.unwrap()
-		.expect("shared Kafka clients must complete a producer-to-consumer round trip");
+	let received = receive_first_with_retry::<Order>(&consumer, topic).await;
 
 	// Assert
 	assert_eq!(


### PR DESCRIPTION
## Summary

This PR raises reinhardt-streaming line coverage from 84.00% to 90.95% with deterministic in-memory, message/router metadata, and Kafka behavior tests.

## Type of Change

- [x] Code quality improvements

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

Exercise default backend storage, message partition metadata, producer/consumer route factories, Kafka client round trips, and fatal partition validation.

Fixes #5940

## How Was This Tested?

- Focused pure tests: 3/3 passed
- Focused Kafka tests: 2/2 passed
- Full package tests: 36/36 passed
- Target-aligned llvm-cov: 90.95% lines (221/243)
- rustfmt and diff checks passed

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`

## Labels to Apply

- [x] `code-quality` - Code quality improvements

### Additional Context

Kafka receive assertions use a bounded retry for normal metadata propagation delay. Package Clippy still reports pre-existing warnings in unchanged tests; no new warning was introduced.