### PR TITLE
test(i18n): raise coverage to 90%

### DIFF
--- a/crates/reinhardt-i18n/src/catalog.rs
+++ b/crates/reinhardt-i18n/src/catalog.rs
@@ -621,8 +621,11 @@ mod tests {
 
 	#[rstest]
 	#[case("pt-BR", 0, "form 0")]
+	#[case("pt-BR", 1, "form 0")]
+	#[case("pt-BR", 2, "form 1")]
 	#[case("pt-PT", 0, "form 1")]
 	#[case("pt-PT", 1, "form 0")]
+	#[case("pt-PT", 2, "form 1")]
 	#[case("ga", 1, "form 0")]
 	#[case("ga", 2, "form 1")]
 	#[case("ga", 3, "form 2")]

--- a/crates/reinhardt-i18n/src/catalog.rs
+++ b/crates/reinhardt-i18n/src/catalog.rs
@@ -620,6 +620,52 @@ mod tests {
 	}
 
 	#[rstest]
+	#[case("pt-BR", 0, "form 0")]
+	#[case("pt-PT", 0, "form 1")]
+	#[case("pt-PT", 1, "form 0")]
+	#[case("ga", 1, "form 0")]
+	#[case("ga", 2, "form 1")]
+	#[case("ga", 3, "form 2")]
+	#[case("ga", 7, "form 3")]
+	#[case("ga", 11, "form 4")]
+	#[case("cy", 0, "form 0")]
+	#[case("cy", 1, "form 1")]
+	#[case("cy", 2, "form 2")]
+	#[case("cy", 3, "form 3")]
+	#[case("cy", 6, "form 4")]
+	#[case("cy", 4, "form 5")]
+	#[case("lt", 1, "form 0")]
+	#[case("lt", 2, "form 1")]
+	#[case("lt", 10, "form 2")]
+	#[case("lt", 11, "form 2")]
+	#[case("lv", 1, "form 0")]
+	#[case("lv", 2, "form 1")]
+	#[case("lv", 0, "form 2")]
+	#[case("lv", 11, "form 1")]
+	#[case("ro", 1, "form 0")]
+	#[case("ro", 0, "form 1")]
+	#[case("ro", 19, "form 1")]
+	#[case("ro", 20, "form 2")]
+	fn plural_rules_cover_portuguese_celtic_baltic_and_romanian_boundaries(
+		#[case] locale: &str,
+		#[case] count: usize,
+		#[case] expected: &str,
+	) {
+		// Arrange
+		let mut catalog = MessageCatalog::new(locale);
+		catalog.add_plural(
+			"entry",
+			(0..6).map(|index| format!("form {index}")).collect(),
+		);
+
+		// Act
+		let selected = catalog.get_plural("entry", count);
+
+		// Assert
+		assert_eq!(selected, Some(&expected.to_string()));
+	}
+
+	#[rstest]
 	#[case("en", 1, 0)] // English: 1 is singular
 	#[case("en", 0, 1)] // English: 0 is plural
 	#[case("en", 2, 1)] // English: 2+ is plural

--- a/crates/reinhardt-i18n/src/lib.rs
+++ b/crates/reinhardt-i18n/src/lib.rs
@@ -526,6 +526,137 @@ pub fn get_active_translation() -> Option<Arc<TranslationContext>> {
 	ACTIVE_TRANSLATION.with(|t| t.borrow().clone())
 }
 
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+	use serial_test::serial;
+
+	#[rstest]
+	fn translation_context_falls_back_for_every_translation_shape() {
+		// Arrange
+		let mut context = TranslationContext::new("es", "fr");
+		let current = MessageCatalog::new("es");
+		let mut fallback = MessageCatalog::new("fr");
+		fallback.add_translation("Save", "Enregistrer");
+		fallback.add_plural_str("file", "files", vec!["fichier", "fichiers"]);
+		fallback.add_context_str("button", "Save", "Enregistrer le bouton");
+		fallback.add_context_plural("menu", "item", "items", vec!["entrée", "entrées"]);
+		context.add_catalog("es", current).unwrap();
+		context.add_catalog("fr", fallback).unwrap();
+
+		// Act
+		let simple_fallback = context.translate("Save");
+		let plural_fallback = context.translate_plural("file", "files", 2);
+		let contextual_fallback = context.translate_context("button", "Save");
+		let contextual_plural_fallback =
+			context.translate_context_plural("menu", "item", "items", 2);
+		let simple_missing = context.translate("Missing");
+		let plural_missing = context.translate_plural("missing file", "missing files", 2);
+		let contextual_missing = context.translate_context("button", "Missing");
+		let contextual_plural_missing =
+			context.translate_context_plural("menu", "missing item", "missing items", 2);
+
+		// Assert
+		assert_eq!(simple_fallback, "Enregistrer");
+		assert_eq!(plural_fallback, "fichiers");
+		assert_eq!(contextual_fallback, "Enregistrer le bouton");
+		assert_eq!(contextual_plural_fallback, "entrées");
+		assert_eq!(simple_missing, "Missing");
+		assert_eq!(plural_missing, "missing files");
+		assert_eq!(contextual_missing, "Missing");
+		assert_eq!(contextual_plural_missing, "missing items");
+	}
+
+	#[rstest]
+	fn translation_context_empty_and_invalid_locales_preserve_contract() {
+		// Arrange
+		let english = TranslationContext::english();
+		let mut context = TranslationContext::new("", "");
+		let catalog = MessageCatalog::new("de-AT");
+
+		// Act
+		context.set_locale("fr-CA").unwrap();
+		context.set_fallback_locale("de-AT").unwrap();
+		context.add_catalog("de-AT", catalog).unwrap();
+		let invalid_current = context.set_locale("../invalid").unwrap_err();
+		let invalid_fallback = context.set_fallback_locale("de//AT").unwrap_err();
+		let invalid_catalog = context
+			.add_catalog("../../invalid", MessageCatalog::new("invalid"))
+			.unwrap_err();
+
+		// Assert
+		assert_eq!(english.get_locale(), "en-US");
+		assert_eq!(english.get_fallback_locale(), "en-US");
+		assert_eq!(TranslationContext::new("", "").get_locale(), "en-US");
+		assert_eq!(
+			TranslationContext::new("", "").get_fallback_locale(),
+			"en-US"
+		);
+		assert_eq!(context.get_locale(), "fr-CA");
+		assert_eq!(context.get_fallback_locale(), "de-AT");
+		assert_eq!(
+			context.get_catalog("de-AT").map(MessageCatalog::locale),
+			Some("de-AT")
+		);
+		let I18nError::InvalidLocale(invalid_current) = invalid_current else {
+			panic!("expected an invalid current locale error");
+		};
+		let I18nError::InvalidLocale(invalid_fallback) = invalid_fallback else {
+			panic!("expected an invalid fallback locale error");
+		};
+		let I18nError::InvalidLocale(invalid_catalog) = invalid_catalog else {
+			panic!("expected an invalid catalog locale error");
+		};
+		assert_eq!(invalid_current, "../invalid");
+		assert_eq!(invalid_fallback, "de//AT");
+		assert_eq!(invalid_catalog, "../../invalid");
+	}
+
+	#[rstest]
+	#[serial(i18n)]
+	fn active_context_routes_contextual_translation_and_restores_nested_scope() {
+		// Arrange
+		let mut outer = TranslationContext::new("fr", "en-US");
+		let mut outer_catalog = MessageCatalog::new("fr");
+		outer_catalog.add_context_str("button", "Save", "Enregistrer");
+		outer_catalog.add_context_plural("button", "item", "items", vec!["élément", "éléments"]);
+		outer.add_catalog("fr", outer_catalog).unwrap();
+		let mut inner = TranslationContext::new("de", "en-US");
+		let mut inner_catalog = MessageCatalog::new("de");
+		inner_catalog.add_context_str("button", "Save", "Speichern");
+		inner_catalog.add_context_plural("button", "item", "items", vec!["Element", "Elemente"]);
+		inner.add_catalog("de", inner_catalog).unwrap();
+
+		// Act
+		let outer_guard = set_active_translation(Arc::new(outer));
+		let outer_contextual = pgettext("button", "Save");
+		let outer_plural = npgettext("button", "item", "items", 2);
+		let (inner_contextual, inner_plural) = {
+			let inner_guard = set_active_translation(Arc::new(inner));
+			let contextual = pgettext("button", "Save");
+			let plural = npgettext("button", "item", "items", 2);
+			drop(inner_guard);
+			(contextual, plural)
+		};
+		let restored_contextual = pgettext("button", "Save");
+		let restored_plural = npgettext("button", "item", "items", 2);
+		drop(outer_guard);
+		let inactive_contextual = pgettext("button", "Save");
+		let inactive_plural = npgettext("button", "item", "items", 2);
+
+		// Assert
+		assert_eq!(outer_contextual, "Enregistrer");
+		assert_eq!(outer_plural, "éléments");
+		assert_eq!(inner_contextual, "Speichern");
+		assert_eq!(inner_plural, "Elemente");
+		assert_eq!(restored_contextual, "Enregistrer");
+		assert_eq!(restored_plural, "éléments");
+		assert_eq!(inactive_contextual, "Save");
+		assert_eq!(inactive_plural, "items");
+	}
+}
+
 // DI integration (feature-gated)
 #[cfg(feature = "di")]
 mod di_integration {


### PR DESCRIPTION
## Summary

This PR raises reinhardt-i18n line coverage from 82.86% to 93.96% with behavior-focused tests for plural rules, translation fallback, locale validation, and nested translation scopes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] CI/CD changes
- [x] Code quality improvements

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The crate was below its next 10% coverage threshold. The tests exercise public catalog selection, all translation-context fallback shapes, locale contracts, and nested RAII context restoration, including regional Portuguese plural boundaries.

Fixes #5942

## How Was This Tested?

- Focused Nextest: 29/29 passed
- Full package Nextest: 181/181 passed
- Target-aligned llvm-cov: 93.96% lines (845/896)
- `cargo make fmt-check` and `git diff --check` passed
- Package Clippy passed; six existing `format_number` deprecation warnings remain in unchanged `utils.rs`

## Performance Impact

-

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

-

## Labels to Apply

### Type Label
- [x] `code-quality` - Code quality improvements

### Additional Labels
-

### Scope Label
- [x] `i18n` - Internationalization, localization

### Priority Label
-

---

**Additional Context:**

The regional Portuguese cases cover counts 0/1/2 for both pt-BR and pt-PT using exact public `MessageCatalog::get_plural` results.
