### PR TITLE
feat(pages): configurable query retry policy with exponential backoff

### DIFF
--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -336,6 +336,7 @@ base64 = { workspace = true }
 gloo-timers = { version = "0.3", features = ["futures"] }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 reinhardt-forms = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -150,6 +150,7 @@ reinhardt-i18n = { workspace = true, optional = true }
 sha2 = { workspace = true }
 bytes = { workspace = true }
 futures-util = "0.3"
+getrandom = { workspace = true }
 
 # Core WASM bindings (low-level APIs only)
 wasm-bindgen = "0.2.106"
@@ -285,7 +286,6 @@ reinhardt-core = {workspace = true, default-features = false, features = ["react
 smallvec = { workspace = true }
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 wasm-bindgen-futures = "0.4.56"
-getrandom = { version = "0.3", features = ["wasm_js"] }
 uuid = { version = "1.7", features = ["v7", "js"] }
 # Issue #4217: depend on reinhardt-urls on wasm to consume the canonical
 # `client_router::history` primitives (deduplicates with the server-side

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -877,6 +877,18 @@ let jobs = use_query(
     QueryOptions::new().refetch_interval(Duration::from_secs(5)),
 );
 
+let retrying_jobs = use_query(
+    list_project_jobs::query(project_id),
+    QueryOptions::new().retry(
+        RetryPolicy::exponential()
+            .max_attempts(3)
+            .base_delay(Duration::from_millis(250))
+            .max_delay(Duration::from_secs(5))
+            .jitter(true)
+            .when(|error| error.is_transient()),
+    ),
+);
+
 let client = queries();
 let retry = use_action(move |job_id| {
     let client = client.clone();
@@ -914,13 +926,21 @@ new versioned ID such as `projects.by-organization.v2`, even when the Rust types
 stay unchanged.
 
 `QueryOptions` are fixed when an observer mounts. They control `enabled`,
-`stale_time`, `gc_time`, and `refetch_interval` for that observer. Disabled
+`stale_time`, `gc_time`, `refetch_interval`, and retry policy for that observer.
+Three retry attempts include the initial request. Intermediate errors remain
+private until the shared sequence is exhausted, equal jitter stays between half
+and all of the nominal delay, and `is_fetching` is false during backoff. Disabled
 observers without cached data report `QueryStatus::Idle`; enabled initial loads
 report `Pending`; resolved reads report `Success` or `Error`. During a
 background refetch, successful data remains available, `is_fetching` is true,
 and a failure appears in `refetch_error` instead of replacing the stale data.
 Polling is owned by the query observer, suspends while the browser document is
 hidden, and resumes according to whether the cached value is stale.
+
+Mounted observers for the same key share entry-level attempt numbers even when
+their retry policies differ. Browser retry backoff also pauses while the
+document is hidden. When visibility returns, stale data retries immediately;
+fresh data waits only the remaining visible-time delay.
 
 The cache canonicalizes JSON object arguments, hashes the canonical payload in
 the generated key ID, and deduplicates mounted queries with the same key. Raw
@@ -932,6 +952,16 @@ descriptors that depend on request extractors or injected parameters skip
 native SSR prefetching and are left for the browser fetch path or native
 component-test mocks. Query handles can also be tracked by
 `SuspenseBoundary::track(...)`.
+
+SSR retry is a double opt-in: the query needs a `RetryPolicy` and the renderer
+must enable request-owned retries. The resource timeout is one budget for all
+fetch attempts, backoff, and jitter:
+
+```rust,ignore
+let options = SsrOptions::new()
+    .query_retries(true)
+    .resource_timeout(Duration::from_secs(2));
+```
 
 ### Query client v2 migration
 
@@ -952,8 +982,8 @@ Replace `QueryKey::new` with a generated or manual `QueryFamily`, handle
 `.poll(...)`, `.stale_time(...)`, and `.gc_time(...)` with mount-time
 `QueryOptions`, and `use_mutation` with `use_action`. `Action::invalidates` was
 removed; invalidate an exact key or family explicitly after the mutation
-succeeds. Entity normalization (#5843) and retry policy (#5844) are separate
-non-goals and are not part of query client v2.
+succeeds. Install retry behavior with `QueryOptions::retry`; entity
+normalization (#5843) remains a separate non-goal.
 
 ### Component System
 - `Component`, `ElementView`, `IntoView`, `View`, `Props`, `ViewEventHandler`

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -872,6 +872,8 @@ combines the exact key with its fetcher, while `family` selects every cached
 argument set for that endpoint:
 
 ```rust,ignore
+use reinhardt_pages::server_fn::{ServerFnError, ServerFnErrorKind};
+
 let jobs = use_query(
     list_project_jobs::query(project_id),
     QueryOptions::new().refetch_interval(Duration::from_secs(5)),
@@ -885,7 +887,12 @@ let retrying_jobs = use_query(
             .base_delay(Duration::from_millis(250))
             .max_delay(Duration::from_secs(5))
             .jitter(true)
-            .when(|error| error.is_transient()),
+            .when(|error: &ServerFnError| {
+                matches!(
+                    error.kind(),
+                    ServerFnErrorKind::Server | ServerFnErrorKind::Transport
+                )
+            }),
     ),
 );
 

--- a/crates/reinhardt-pages/docs/react_to_reinhardt.md
+++ b/crates/reinhardt-pages/docs/react_to_reinhardt.md
@@ -880,10 +880,25 @@ suspends polling while `document.visibilityState` is hidden. When the document
 becomes visible, stale data refetches immediately and fresh data waits for its
 next interval.
 
+Retry policy is also observer-owned, but observers for the same key coordinate
+one entry-level attempt sequence. Intermediate errors stay private until the
+sequence is exhausted, and `is_fetching` is false during backoff. Browser
+backoff pauses while the document is hidden. On visibility resume, stale data
+retries immediately while fresh data waits only the saved remaining delay.
+
 During SSR, one request-local client deduplicates query reads from route loaders
 and components. Only settled snapshots are serialized. Hydration seeds the
 browser application's client before its first observer mounts, so matching
 generated keys reuse server data without a duplicate initial request.
+
+SSR retry requires both a query policy and an explicit renderer gate. The
+resource timeout is one budget covering fetch attempts, backoff, and jitter:
+
+```rust,ignore
+let options = SsrOptions::new()
+    .query_retries(true)
+    .resource_timeout(Duration::from_secs(2));
+```
 
 ### Migrating to query client v2
 
@@ -898,7 +913,22 @@ let jobs = use_query(
     list_project_jobs::query(project_id),
     QueryOptions::new().refetch_interval(Duration::from_secs(5)),
 );
+
+let retrying_jobs = use_query(
+    list_project_jobs::query(project_id),
+    QueryOptions::new().retry(
+        RetryPolicy::exponential()
+            .max_attempts(3)
+            .base_delay(Duration::from_millis(250))
+            .max_delay(Duration::from_secs(5))
+            .jitter(true)
+            .when(|error| error.is_transient()),
+    ),
+);
 ```
+
+`max_attempts(3)` means the initial request plus at most two retries. Equal
+jitter remains between half and all of the nominal delay.
 
 The following before-only APIs were removed:
 
@@ -910,8 +940,8 @@ The following before-only APIs were removed:
 - Before: `Action::invalidates(...)`. After: call exact or family invalidation
   explicitly after mutation success.
 
-Entity normalization (#5843) and retry policy (#5844) are explicit non-goals
-for query client v2.
+Install retry behavior with `QueryOptions::retry`. Entity normalization (#5843)
+remains an explicit non-goal for query client v2.
 
 For generated forms, read submit state from the runtime returned by `use_form`:
 

--- a/crates/reinhardt-pages/docs/react_to_reinhardt.md
+++ b/crates/reinhardt-pages/docs/react_to_reinhardt.md
@@ -905,6 +905,8 @@ let options = SsrOptions::new()
 Move the fetcher into a descriptor and observer policy into `QueryOptions`:
 
 ```rust,ignore
+use reinhardt_pages::server_fn::{ServerFnError, ServerFnErrorKind};
+
 // Before
 let jobs = use_query(list_project_jobs::key(project_id)).poll(Duration::from_secs(5));
 
@@ -922,7 +924,12 @@ let retrying_jobs = use_query(
             .base_delay(Duration::from_millis(250))
             .max_delay(Duration::from_secs(5))
             .jitter(true)
-            .when(|error| error.is_transient()),
+            .when(|error: &ServerFnError| {
+                matches!(
+                    error.kind(),
+                    ServerFnErrorKind::Server | ServerFnErrorKind::Transport
+                )
+            }),
     ),
 );
 ```

--- a/crates/reinhardt-pages/docs/server_fn_macro.md
+++ b/crates/reinhardt-pages/docs/server_fn_macro.md
@@ -294,7 +294,7 @@ Pass the descriptor and mount-time `QueryOptions` to `use_query`:
 use std::time::Duration;
 
 use reinhardt::pages::prelude::*;
-use reinhardt::pages::server_fn::{ServerFnError, server_fn};
+use reinhardt::pages::server_fn::{ServerFnError, ServerFnErrorKind, server_fn};
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct JobSnapshot {
@@ -316,6 +316,23 @@ let jobs = use_query(
     QueryOptions::new().refetch_interval(Duration::from_secs(5)),
 );
 
+let retrying_jobs = use_query(
+    list_project_jobs::query(42),
+    QueryOptions::new().retry(
+        RetryPolicy::exponential()
+            .max_attempts(3)
+            .base_delay(Duration::from_millis(250))
+            .max_delay(Duration::from_secs(5))
+            .jitter(true)
+            .when(|error: &ServerFnError| {
+                matches!(
+                    error.kind(),
+                    ServerFnErrorKind::Server | ServerFnErrorKind::Transport
+                )
+            }),
+    ),
+);
+
 let client = queries();
 let retry = use_action(move |job_id: i64| {
     let client = client.clone();
@@ -334,6 +351,10 @@ one cache entry regardless of map iteration order. Queries with the same key
 share one cache entry and in-flight request. `QueryOptions` configures
 `enabled`, `stale_time`, `gc_time`, and `refetch_interval` for each mounted
 observer. Interval polling suspends while the browser document is hidden.
+Generated descriptors preserve their concrete error type, so retry predicates
+receive `&ServerFnError` in this example. Three attempts include the initial
+request. Intermediate errors remain private, equal jitter stays within the
+nominal delay, and `is_fetching` is false while the sequence waits in backoff.
 
 Use exact invalidation when one argument set changed:
 
@@ -377,8 +398,8 @@ let jobs = use_query(
 `QueryKey::new`, query-handle policy builders, `use_mutation`, and
 `Action::invalidates` were removed. Use a generated or manual `QueryFamily`,
 mount-time `QueryOptions`, `use_action`, and explicit exact or family
-invalidation. Query client v2 does not add entity normalization (#5843) or
-retry policy (#5844).
+invalidation. Install retry behavior with `QueryOptions::retry`; query client
+v2 does not add entity normalization (#5843).
 
 Browser launchers own the application client. SSR creates a separate client per
 request, serializes settled snapshots, and seeds the browser client before the

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -750,9 +750,9 @@ pub use hydration::{HydrationContext, HydrationError, hydrate};
 pub use portal::{Portal, PortalError, PortalHandle, PortalTarget, mount_portal};
 pub use reactive::{
 	Effect, ExplicitDeps, LatestResourceState, LatestResourceValue, LatestResourceValueBuilder,
-	Memo, QueryClient, QueryDefaults, QueryDescriptor, QueryFamily, QueryHandle, QueryKey,
-	QueryOptions, QuerySnapshot, QueryStatus, ReactiveDeps, Resource, ResourceState, Signal,
-	Trackable, queries, use_latest_resource_value, use_resource, use_resource_with_key,
+	Memo, NoRetry, QueryClient, QueryDefaults, QueryDescriptor, QueryFamily, QueryHandle, QueryKey,
+	QueryOptions, QuerySnapshot, QueryStatus, ReactiveDeps, Resource, ResourceState, RetryPolicy,
+	Signal, Trackable, queries, use_latest_resource_value, use_resource, use_resource_with_key,
 };
 // Re-export Context system
 pub use reactive::{

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -38,6 +38,18 @@
 //!     list_project_jobs::query(project_id),
 //!     QueryOptions::new().refetch_interval(Duration::from_secs(5)),
 //! );
+//!
+//! let retrying_jobs = use_query(
+//!     list_project_jobs::query(project_id),
+//!     QueryOptions::new().retry(
+//!         RetryPolicy::exponential()
+//!             .max_attempts(3)
+//!             .base_delay(Duration::from_millis(250))
+//!             .max_delay(Duration::from_secs(5))
+//!             .jitter(true)
+//!             .when(|error| error.is_transient()),
+//!     ),
+//! );
 //! ```
 //!
 //! The generated server-function module exposes `family()`, `key(args...)`,
@@ -48,15 +60,32 @@
 //! mutation. Disabled uncached observers report [`QueryStatus::Idle`];
 //! enabled observers progress through [`QueryStatus::Pending`],
 //! [`QueryStatus::Success`], or [`QueryStatus::Error`]. Successful data remains
-//! visible if a background fetch fails, with the error available through the
-//! `QuerySnapshot::refetch_error` field.
+//! visible if a background sequence ultimately fails, with the terminal error
+//! available through the `QuerySnapshot::refetch_error` field. Three attempts
+//! include the initial request. Intermediate errors are not published, equal
+//! jitter never exceeds the nominal delay, and `QuerySnapshot::is_fetching` is
+//! `false` while a retry waits in backoff.
 //!
 //! Observer polling suspends while the browser document is hidden and resumes
-//! according to freshness. SSR query state is request-local and is serialized
-//! for hydration before the browser's first observer mounts. Query client v2
-//! removes `QueryKey::new`, query-handle policy builders, `use_mutation`, and
-//! `Action::invalidates`. Entity normalization (#5843) and retry policy (#5844)
-//! remain separate non-goals.
+//! according to freshness. Retry attempts are shared by the cache entry across
+//! observers. Hidden time does not consume retry backoff: stale data retries
+//! immediately when visibility returns, while fresh data waits only the saved
+//! remainder.
+//!
+//! SSR query state is request-local and is serialized for hydration before the
+//! browser's first observer mounts. SSR retries require both an observer policy
+//! and an explicit renderer gate, and the resource timeout covers fetches,
+//! backoff, and jitter:
+//!
+//! ```ignore
+//! let options = SsrOptions::new()
+//!     .query_retries(true)
+//!     .resource_timeout(Duration::from_secs(2));
+//! ```
+//!
+//! Query client v2 removes `QueryKey::new`, query-handle policy builders,
+//! `use_mutation`, and `Action::invalidates`. Entity normalization (#5843)
+//! remains a separate non-goal.
 //!
 //! ## Features
 //!

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -25,6 +25,7 @@
 //! ```ignore
 //! use std::time::Duration;
 //! use reinhardt_pages::prelude::*;
+//! use reinhardt_pages::server_fn::{ServerFnError, ServerFnErrorKind};
 //! use reinhardt_pages::ClientLauncher;
 //!
 //! ClientLauncher::new("#root")
@@ -47,7 +48,12 @@
 //!             .base_delay(Duration::from_millis(250))
 //!             .max_delay(Duration::from_secs(5))
 //!             .jitter(true)
-//!             .when(|error| error.is_transient()),
+//!             .when(|error: &ServerFnError| {
+//!                 matches!(
+//!                     error.kind(),
+//!                     ServerFnErrorKind::Server | ServerFnErrorKind::Transport
+//!                 )
+//!             }),
 //!     ),
 //! );
 //! ```

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -96,9 +96,10 @@
 // ============================================================================
 
 pub use crate::reactive::{
-	Effect, LatestResourceState, LatestResourceValue, LatestResourceValueBuilder, Memo,
+	Effect, LatestResourceState, LatestResourceValue, LatestResourceValueBuilder, Memo, NoRetry,
 	QueryClient, QueryDefaults, QueryDescriptor, QueryFamily, QueryHandle, QueryKey, QueryOptions,
-	QuerySnapshot, QueryStatus, Resource, ResourceState, Signal, use_latest_resource_value,
+	QuerySnapshot, QueryStatus, Resource, ResourceState, RetryPolicy, Signal,
+	use_latest_resource_value,
 };
 
 // Context system

--- a/crates/reinhardt-pages/src/reactive.rs
+++ b/crates/reinhardt-pages/src/reactive.rs
@@ -120,11 +120,11 @@ pub mod trackable;
 pub use trackable::Trackable;
 
 // Re-export resource types and the unified hook (available on all targets)
-pub(crate) use query::{QueryAcquireOptions, QueryConsumer, QueryErrorPolicy, QueryLease};
 pub use query::{
-	QueryClient, QueryDefaults, QueryDescriptor, QueryFamily, QueryHandle, QueryKey, QueryOptions,
-	QuerySnapshot, QueryStatus, queries, use_query,
+	NoRetry, QueryClient, QueryDefaults, QueryDescriptor, QueryFamily, QueryHandle, QueryKey,
+	QueryOptions, QuerySnapshot, QueryStatus, RetryPolicy, queries, use_query,
 };
+pub(crate) use query::{QueryAcquireOptions, QueryConsumer, QueryErrorPolicy, QueryLease};
 pub use resource::{Resource, ResourceState, use_resource, use_resource_with_key};
 pub use resource_value::{
 	LatestResourceState, LatestResourceValue, LatestResourceValueBuilder, use_latest_resource_value,

--- a/crates/reinhardt-pages/src/reactive/query.rs
+++ b/crates/reinhardt-pages/src/reactive/query.rs
@@ -6,6 +6,7 @@ mod client;
 mod context;
 mod hook;
 mod identity;
+mod retry;
 mod runtime;
 mod state;
 
@@ -33,4 +34,7 @@ pub use context::queries;
 pub(crate) use context::{current_query_client, with_query_client, with_query_client_async};
 pub use hook::{QueryHandle, use_query};
 pub use identity::{QueryDescriptor, QueryFamily, QueryKey};
+#[doc(hidden)]
+pub use retry::QueryRetryConfig;
+pub use retry::{NoRetry, RetryPolicy};
 pub use state::{QueryDefaults, QueryOptions, QuerySnapshot, QueryStatus};

--- a/crates/reinhardt-pages/src/reactive/query/browser.rs
+++ b/crates/reinhardt-pages/src/reactive/query/browser.rs
@@ -233,7 +233,7 @@ pub struct QueryBrowserResourceProbe {
 
 #[cfg(all(feature = "testing", wasm))]
 impl QueryBrowserResourceProbe {
-	/// Returns active visibility listeners and polling timers.
+	/// Returns active visibility listeners and query maintenance timers.
 	pub fn counts(&self) -> (usize, usize) {
 		self.counts.upgrade().map_or((0, 0), |counts| {
 			(counts.listeners.get(), counts.timers.get())
@@ -247,7 +247,7 @@ pub struct QueryBrowserResourceProbe;
 
 #[cfg(all(feature = "testing", not(wasm)))]
 impl QueryBrowserResourceProbe {
-	/// Returns active visibility listeners and polling timers.
+	/// Returns active visibility listeners and query maintenance timers.
 	pub fn counts(&self) -> (usize, usize) {
 		(0, 0)
 	}

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -24,6 +24,7 @@ use super::identity::{
 };
 use super::retry::{
 	ObserverRegistrationId, QueryRetryConfig, RetryCandidate, RetryPolicy, RetrySequence,
+	RetryWaitClock,
 };
 use super::runtime::{ScopedQueryFuture, duration_ms, now_ms, spawn_query_task};
 use super::state::{QueryDefaults, QueryOptions};
@@ -900,6 +901,47 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 	fn handle_visibility_change(self: &Rc<Self>, visible: bool, now_ms: u64) {
 		if !visible {
 			self.suspend_polling();
+			let waiting_to_pause = self.retry.borrow().as_ref().is_some_and(|sequence| {
+				matches!(sequence.wait_clock, Some(RetryWaitClock::Visible { .. }))
+			});
+			if waiting_to_pause {
+				let generation = self.next_retry_generation();
+				if let Some(sequence) = self.retry.borrow_mut().as_mut() {
+					sequence.pause(now_ms);
+					sequence.generation = generation;
+				}
+			}
+			return;
+		}
+		let retry_state = self.retry.borrow().as_ref().map(|sequence| {
+			(
+				sequence.generation,
+				sequence.manual_observer_id,
+				sequence.candidates.keys().copied().collect::<Vec<_>>(),
+				sequence.wait_clock,
+			)
+		});
+		if let Some((sequence_generation, manual_observer_id, candidate_ids, wait_clock)) =
+			retry_state
+		{
+			let waiting_is_stale = matches!(wait_clock, Some(RetryWaitClock::Paused { .. }))
+				&& self.live_observers().iter().any(|observer| {
+					candidate_ids.contains(&observer.registration_id)
+						&& self.is_stale(observer.policy.stale_time)
+				});
+			if matches!(wait_clock, Some(RetryWaitClock::Paused { .. })) {
+				if waiting_is_stale {
+					let manual_observer = manual_observer_id
+						.and_then(|observer_id| self.observer_by_id(observer_id))
+						.map(|observer| Rc::downgrade(&observer));
+					self.start_attempt(sequence_generation, manual_observer);
+				} else {
+					if let Some(sequence) = self.retry.borrow_mut().as_mut() {
+						sequence.resume(now_ms);
+					}
+					self.schedule_retry_deadline(sequence_generation);
+				}
+			}
 			return;
 		}
 		let observers = self.enabled_mounted_observers();
@@ -1532,6 +1574,9 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 								.insert(observer.registration_id, candidate);
 						}
 					}
+					if !self.polling_is_visible() {
+						sequence.pause(now_ms);
+					}
 					!sequence.candidates.is_empty()
 				};
 				if has_candidates {
@@ -1562,9 +1607,10 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 	fn schedule_retry_deadline(&self, sequence_generation: u64) {
 		let now_ms = self.runtime.now_ms();
 		let due_ms = self.retry.borrow().as_ref().and_then(|retry| {
-			(retry.generation == sequence_generation)
-				.then(|| retry.earliest_due_ms(now_ms))
-				.flatten()
+			(retry.generation == sequence_generation
+				&& matches!(retry.wait_clock, Some(RetryWaitClock::Visible { .. })))
+			.then(|| retry.earliest_due_ms(now_ms))
+			.flatten()
 		});
 		if let Some(owner) = self.owner.as_ref().and_then(Weak::upgrade) {
 			if let Some(due_ms) = due_ms {
@@ -2026,7 +2072,7 @@ pub fn set_query_visibility_for_test(client: &QueryClient, visible: bool) {
 	client.inner.browser.set_visibility_for_test(visible);
 }
 
-/// Returns active visibility listeners and polling timers for a query client.
+/// Returns active visibility listeners and query maintenance timers for a query client.
 #[cfg(feature = "testing")]
 pub fn query_browser_resource_counts(client: &QueryClient) -> (usize, usize) {
 	client.inner.browser.resource_counts()

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -313,6 +313,7 @@ impl QueryClient {
 		Self::with_runtime_and_retry_enabled(defaults, Rc::new(SsrQueryRuntime), retry_enabled)
 	}
 
+	#[cfg(test)]
 	pub(crate) fn with_runtime(defaults: QueryDefaults, runtime: QueryRuntimeHandle) -> Self {
 		Self::with_runtime_and_retry_enabled(defaults, runtime, true)
 	}

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -77,6 +77,11 @@ pub(crate) trait QueryRuntime {
 	fn executes_inline(&self) -> bool {
 		false
 	}
+
+	#[cfg(native)]
+	fn retry_wait(&self, delay: Duration) -> QueryTask {
+		Box::pin(async move { tokio::time::sleep(delay).await })
+	}
 }
 
 pub(crate) type QueryRuntimeHandle = Rc<dyn QueryRuntime>;
@@ -240,6 +245,7 @@ pub struct QueryClient {
 
 pub(super) struct QueryClientInner {
 	defaults: QueryDefaults,
+	retry_enabled: bool,
 	runtime: QueryRuntimeHandle,
 	entries: RefCell<HashMap<QueryIdentity, CachedQueryEntry>>,
 	#[cfg(any(wasm, test))]
@@ -298,20 +304,30 @@ impl PartialOrd for QueryDeadline {
 impl QueryClient {
 	/// Creates an empty client using the platform query runtime.
 	pub fn new(defaults: QueryDefaults) -> Self {
-		Self::with_runtime(defaults, platform_query_runtime())
+		Self::with_runtime_and_retry_enabled(defaults, platform_query_runtime(), true)
 	}
 
 	/// Creates an empty request-owned client whose work is polled inline.
 	pub fn new_ssr(defaults: QueryDefaults) -> Self {
-		Self::with_runtime(defaults, Rc::new(SsrQueryRuntime))
+		let retry_enabled = defaults.ssr_query_retries_enabled();
+		Self::with_runtime_and_retry_enabled(defaults, Rc::new(SsrQueryRuntime), retry_enabled)
 	}
 
 	pub(crate) fn with_runtime(defaults: QueryDefaults, runtime: QueryRuntimeHandle) -> Self {
+		Self::with_runtime_and_retry_enabled(defaults, runtime, true)
+	}
+
+	fn with_runtime_and_retry_enabled(
+		defaults: QueryDefaults,
+		runtime: QueryRuntimeHandle,
+		retry_enabled: bool,
+	) -> Self {
 		let supports_browser_resources = runtime.supports_browser_resources();
 		let document_visible =
 			super::browser::QueryBrowser::initial_visibility(supports_browser_resources);
 		let inner = Rc::new_cyclic(|owner| QueryClientInner {
 			defaults,
+			retry_enabled,
 			runtime,
 			entries: RefCell::new(HashMap::new()),
 			#[cfg(any(wasm, test))]
@@ -1031,6 +1047,17 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		self.wake_waiters();
 	}
 
+	fn cancel_sequence_if_current(&self, completion_generation: u64) {
+		let is_current = self
+			.retry
+			.borrow()
+			.as_ref()
+			.is_some_and(|retry| retry.completion_generation == completion_generation);
+		if is_current {
+			self.cancel_active_work();
+		}
+	}
+
 	fn wake_waiters(&self) {
 		let waiters = std::mem::take(&mut *self.waiters.borrow_mut());
 		for waiter in waiters {
@@ -1604,7 +1631,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		}
 	}
 
-	fn schedule_retry_deadline(&self, sequence_generation: u64) {
+	fn schedule_retry_deadline(self: &Rc<Self>, sequence_generation: u64) {
 		let now_ms = self.runtime.now_ms();
 		let due_ms = self.retry.borrow().as_ref().and_then(|retry| {
 			(retry.generation == sequence_generation
@@ -1612,6 +1639,20 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			.then(|| retry.earliest_due_ms(now_ms))
 			.flatten()
 		});
+		#[cfg(native)]
+		if self.runtime.executes_inline() {
+			if let Some(due_ms) = due_ms {
+				let wait = self
+					.runtime
+					.retry_wait(Duration::from_millis(due_ms.saturating_sub(now_ms)));
+				let entry = Rc::clone(self);
+				self.inline_task.borrow_mut().replace(Box::pin(async move {
+					wait.await;
+					entry.handle_retry_deadline_at(sequence_generation, due_ms);
+				}));
+			}
+			return;
+		}
 		if let Some(owner) = self.owner.as_ref().and_then(Weak::upgrade) {
 			if let Some(due_ms) = due_ms {
 				owner.schedule_deadline(
@@ -1627,10 +1668,13 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 	}
 
 	fn handle_retry_deadline(self: &Rc<Self>, sequence_generation: u64) {
+		self.handle_retry_deadline_at(sequence_generation, self.runtime.now_ms());
+	}
+
+	fn handle_retry_deadline_at(self: &Rc<Self>, sequence_generation: u64, now_ms: u64) {
 		if !self.deadline_is_current(QueryDeadlineKind::Retry, sequence_generation) {
 			return;
 		}
-		let now_ms = self.runtime.now_ms();
 		let (candidate_observer_id, manual_observer_id) = {
 			let retry = self.retry.borrow();
 			let Some(retry) = retry
@@ -1756,6 +1800,23 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 struct QueryResultFuture<T: Clone + 'static, E: Clone + 'static> {
 	entry: Rc<QueryEntry<T, E>>,
 	generation: Option<u64>,
+	ssr_guard: Option<SsrRetrySequenceGuard<T, E>>,
+}
+
+struct SsrRetrySequenceGuard<T: Clone + 'static, E: Clone + 'static> {
+	entry: Weak<QueryEntry<T, E>>,
+	completion_generation: u64,
+	armed: bool,
+}
+
+impl<T: Clone + 'static, E: Clone + 'static> Drop for SsrRetrySequenceGuard<T, E> {
+	fn drop(&mut self) {
+		if self.armed
+			&& let Some(entry) = self.entry.upgrade()
+		{
+			entry.cancel_sequence_if_current(self.completion_generation);
+		}
+	}
 }
 
 impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> {
@@ -1763,23 +1824,39 @@ impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> 
 
 	fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
 		let this = self.get_mut();
-		let inline_task = this.entry.inline_task.borrow_mut().take();
-		if let Some(mut task) = inline_task
-			&& task.as_mut().poll(context).is_pending()
-			&& this.entry.has_request()
-		{
-			this.entry.inline_task.borrow_mut().replace(task);
+		loop {
+			let inline_task = this.entry.inline_task.borrow_mut().take();
+			let Some(mut task) = inline_task else {
+				break;
+			};
+			if task.as_mut().poll(context).is_pending() {
+				this.entry.inline_task.borrow_mut().replace(task);
+				break;
+			}
 		}
 		if let Some(generation) = this.generation {
 			if let Some((completed_generation, result)) = this.entry.completed.borrow().as_ref()
 				&& *completed_generation == generation
 			{
+				if let Some(guard) = this.ssr_guard.as_mut() {
+					guard.armed = false;
+				}
 				return Poll::Ready(result.clone());
 			}
 		} else {
 			match this.entry.state.with_untracked(|state| state.clone()) {
-				ResourceState::Success(value) => return Poll::Ready(Ok(value)),
-				ResourceState::Error(error) => return Poll::Ready(Err(error)),
+				ResourceState::Success(value) => {
+					if let Some(guard) = this.ssr_guard.as_mut() {
+						guard.armed = false;
+					}
+					return Poll::Ready(Ok(value));
+				}
+				ResourceState::Error(error) => {
+					if let Some(guard) = this.ssr_guard.as_mut() {
+						guard.armed = false;
+					}
+					return Poll::Ready(Err(error));
+				}
 				ResourceState::Loading => {}
 			}
 		}
@@ -1803,9 +1880,17 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryLease<T, E> {
 	// Route preparation awaits this result while the public hook remains
 	// synchronous.
 	pub(crate) async fn result(&self) -> Result<T, E> {
+		let generation = self.inner.generation.get();
 		QueryResultFuture {
 			entry: Rc::clone(&self.inner.entry),
-			generation: self.inner.generation.get(),
+			generation,
+			ssr_guard: (self.inner.entry.runtime.executes_inline()).then(|| {
+				SsrRetrySequenceGuard {
+					entry: Rc::downgrade(&self.inner.entry),
+					completion_generation: generation.unwrap_or_default(),
+					armed: generation.is_some(),
+				}
+			}),
 		}
 		.await
 	}
@@ -1870,7 +1955,11 @@ impl QueryClient {
 		E: Clone + Serialize + DeserializeOwned + 'static,
 		R: QueryRetryConfig<E>,
 	{
-		let retry_policy = query_options.retry_state().retry_policy().cloned();
+		let retry_policy = self
+			.inner
+			.retry_enabled
+			.then(|| query_options.retry_state().retry_policy().cloned())
+			.flatten();
 		let policy = ObserverPolicy::resolve(&query_options, &self.inner.defaults);
 		let (key, fetcher, _ssr_prefetch, family_types) = descriptor.into_parts();
 		self.entry_for_key(key, family_types)

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -1537,7 +1537,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			.queued_manual_refetch
 			.borrow()
 			.as_ref()
-			.map_or(true, |observer| observer.strong_count() > 0);
+			.is_none_or(|observer| observer.strong_count() > 0);
 		let follow_up_required = (self.refetch_after_in_flight.get()
 			&& queued_manual_refetch_is_live
 			&& self.lease_count.get() > 0)

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -78,6 +78,10 @@ pub(crate) trait QueryRuntime {
 		false
 	}
 
+	// Only `schedule_retry_deadline`'s `#[cfg(native)]` branch (see below)
+	// calls this; gate the default the same way so wasm32 builds don't flag
+	// it as dead code.
+	#[cfg(native)]
 	fn uses_external_maintenance(&self) -> bool {
 		false
 	}

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -646,7 +646,7 @@ impl<T: Clone + 'static, E: Clone + 'static> Drop for QueryLeaseInner<T, E> {
 			entry.retain_lease_count.set(retained);
 		}
 		if remaining == 0 {
-			entry.cancel_request();
+			entry.cancel_active_work();
 			entry.schedule_garbage_collection();
 		} else {
 			entry.remove_retry_candidate(self.registration_id);
@@ -881,6 +881,9 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		if generation != self.poll_generation.get() || self.lease_count.get() == 0 {
 			return;
 		}
+		if self.retry.borrow().is_some() {
+			return;
+		}
 		self.suspend_polling();
 		if !self.polling_is_visible() {
 			if let Some(owner) = self.owner.as_ref().and_then(Weak::upgrade) {
@@ -965,16 +968,17 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		self.next_retry_generation();
 	}
 
-	fn cancel_request(&self) {
+	fn cancel_active_work(&self) {
 		self.inline_task.borrow_mut().take();
 		if let Some(request) = self.request.borrow_mut().take() {
 			request.source.cancel();
 			Self::clear_manual_refetch(request.manual_observer);
 		}
+		self.retry.borrow_mut().take();
+		self.next_retry_generation();
 		Self::clear_manual_refetch(self.queued_manual_refetch.borrow_mut().take());
 		self.refetch_after_in_flight.set(false);
 		self.is_fetching.set(false);
-		self.clear_retry_sequence();
 		self.wake_waiters();
 	}
 
@@ -1216,7 +1220,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 				had_success,
 				error,
 			);
-			self.finish_terminal_sequence(manual_observer, invalidation_generation);
+			self.finish_terminal_sequence(manual_observer, invalidation_generation, None);
 		} else {
 			self.recompute_retry_deadline();
 		}
@@ -1280,6 +1284,12 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			return self.active_completion_generation().unwrap_or_default();
 		}
 
+		let superseded_completion_generation = self
+			.retry
+			.borrow()
+			.as_ref()
+			.filter(|retry| retry.last_error.is_some())
+			.map(|retry| retry.completion_generation);
 		let had_success = self
 			.state
 			.with_untracked(|state| matches!(state, ResourceState::Success(_)));
@@ -1301,6 +1311,9 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			&& let Some(previous_manual_observer) = self.observer_by_id(previous_manual_observer_id)
 		{
 			previous_manual_observer.manual_refetch_pending.set(false);
+		}
+		if let Some(manual_observer) = manual_observer.as_ref() {
+			manual_observer.manual_refetch_pending.set(true);
 		}
 		self.clear_retry_sequence();
 		let sequence_generation = self.next_retry_generation();
@@ -1326,6 +1339,12 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			sequence_generation,
 			manual_observer.as_ref().map(Rc::downgrade),
 		);
+		if let Some(superseded_completion_generation) = superseded_completion_generation {
+			self.retarget_unresolved_leases(
+				superseded_completion_generation,
+				completion_generation,
+			);
+		}
 		completion_generation
 	}
 
@@ -1437,6 +1456,9 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		if !sequence_matches {
 			return;
 		}
+		let follow_up_required = self.refetch_after_in_flight.get()
+			|| (self.invalidation_generation.get() > request_invalidation_generation
+				&& self.has_active_invalidation_interest());
 		match result {
 			Ok(value) => {
 				let completion_generation = self
@@ -1455,9 +1477,28 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 					.borrow_mut()
 					.replace((completion_generation, Ok(value)));
 				self.clear_retry_sequence();
-				self.finish_terminal_sequence(manual_observer, request_invalidation_generation);
+				self.finish_terminal_sequence(
+					manual_observer,
+					request_invalidation_generation,
+					None,
+				);
 			}
 			Err(error) => {
+				if follow_up_required {
+					let completion_generation = self
+						.retry
+						.borrow()
+						.as_ref()
+						.map(|retry| retry.completion_generation)
+						.unwrap_or_default();
+					self.clear_retry_sequence();
+					self.finish_terminal_sequence(
+						manual_observer,
+						request_invalidation_generation,
+						Some(completion_generation),
+					);
+					return;
+				}
 				let now_ms = self.runtime.now_ms();
 				let observers = self.live_observers();
 				let has_candidates = {
@@ -1495,7 +1536,11 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 					had_success,
 					error,
 				);
-				self.finish_terminal_sequence(manual_observer, request_invalidation_generation);
+				self.finish_terminal_sequence(
+					manual_observer,
+					request_invalidation_generation,
+					None,
+				);
 			}
 		}
 	}
@@ -1589,8 +1634,8 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		self: &Rc<Self>,
 		manual_observer: Option<Weak<QueryLeaseInner<T, E>>>,
 		request_invalidation_generation: u64,
+		superseded_completion_generation: Option<u64>,
 	) {
-		self.wake_waiters();
 		self.reschedule_polling_from(self.runtime.now_ms());
 		let invalidated_during_request =
 			self.invalidation_generation.get() > request_invalidation_generation;
@@ -1608,17 +1653,33 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		if !same_observer_is_queued {
 			Self::clear_manual_refetch(manual_observer);
 		}
-		if let Some(observer) = queued_manual_observer
+		let next_completion_generation = if let Some(observer) = queued_manual_observer
 			&& observer.strong_count() > 0
 			&& self.lease_count.get() > 0
 		{
-			self.start_sequence_with(true, Some(observer));
+			Some(self.start_sequence_with(true, Some(observer)))
 		} else if ((manual_refetch_queued
 			&& (!queued_manual_observer_was_present || queued_manual_observer_is_live))
 			|| (invalidated_during_request && self.has_active_invalidation_interest()))
 			&& self.lease_count.get() > 0
 		{
-			self.start_fetch(true);
+			Some(self.start_fetch(true))
+		} else {
+			None
+		};
+		if let (Some(from), Some(to)) =
+			(superseded_completion_generation, next_completion_generation)
+		{
+			self.retarget_unresolved_leases(from, to);
+		}
+		self.wake_waiters();
+	}
+
+	fn retarget_unresolved_leases(&self, from: u64, to: u64) {
+		for observer in self.live_observers() {
+			if observer.generation.get() == Some(from) {
+				observer.generation.set(Some(to));
+			}
 		}
 	}
 
@@ -1979,7 +2040,7 @@ where
 		}),
 		cancel: Rc::new({
 			let entry = Rc::clone(entry);
-			move || entry.cancel_request()
+			move || entry.cancel_active_work()
 		}),
 		poll_due: Rc::new({
 			let entry = Rc::clone(entry);

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -22,6 +22,7 @@ use super::super::resource::ResourceState;
 use super::identity::{
 	QueryDescriptor, QueryFamily, QueryFamilyTypes, QueryFetcher, QueryIdentity, QueryKey,
 };
+use super::retry::QueryRetryConfig;
 use super::runtime::{ScopedQueryFuture, duration_ms, now_ms, spawn_query_task};
 use super::state::{QueryDefaults, QueryOptions};
 #[cfg(any(wasm, test))]
@@ -312,14 +313,15 @@ impl QueryClient {
 		Self { inner }
 	}
 
-	pub(crate) fn observe<T, E>(
+	pub(crate) fn observe<T, E, R>(
 		&self,
 		descriptor: QueryDescriptor<T, E>,
-		options: QueryOptions,
+		options: QueryOptions<R>,
 	) -> super::hook::QueryHandle<T, E>
 	where
 		T: Clone + Serialize + DeserializeOwned + 'static,
 		E: Clone + Serialize + DeserializeOwned + 'static,
+		R: QueryRetryConfig<E>,
 	{
 		super::hook::observe_query(self, descriptor, options)
 	}
@@ -327,14 +329,15 @@ impl QueryClient {
 	/// Observes a query without installing an application context.
 	#[doc(hidden)]
 	#[cfg(feature = "testing")]
-	pub fn observe_for_test<T, E>(
+	pub fn observe_for_test<T, E, R>(
 		&self,
 		descriptor: QueryDescriptor<T, E>,
-		options: QueryOptions,
+		options: QueryOptions<R>,
 	) -> super::hook::QueryHandle<T, E>
 	where
 		T: Clone + Serialize + DeserializeOwned + 'static,
 		E: Clone + Serialize + DeserializeOwned + 'static,
+		R: QueryRetryConfig<E>,
 	{
 		self.observe(descriptor, options)
 	}
@@ -555,7 +558,7 @@ pub(super) struct ObserverPolicy {
 }
 
 impl ObserverPolicy {
-	pub(super) fn resolve(options: &QueryOptions, defaults: &QueryDefaults) -> Self {
+	pub(super) fn resolve<R>(options: &QueryOptions<R>, defaults: &QueryDefaults) -> Self {
 		Self {
 			enabled: options.is_enabled(),
 			stale_time: options.resolved_stale_time(defaults),
@@ -1302,14 +1305,15 @@ where
 }
 
 #[cfg(test)]
-pub(super) fn acquire_query_with_options<T, E>(
+pub(super) fn acquire_query_with_options<T, E, R>(
 	descriptor: QueryDescriptor<T, E>,
 	options: QueryAcquireOptions,
-	query_options: QueryOptions,
+	query_options: QueryOptions<R>,
 ) -> QueryLease<T, E>
 where
 	T: Clone + Serialize + DeserializeOwned + 'static,
 	E: Clone + Serialize + DeserializeOwned + 'static,
+	R: QueryRetryConfig<E>,
 {
 	super::context::queries().acquire_with_options(descriptor, options, query_options)
 }
@@ -1336,16 +1340,18 @@ impl QueryClient {
 		self.acquire_with_options(descriptor, options, QueryOptions::default())
 	}
 
-	pub(super) fn acquire_with_options<T, E>(
+	pub(super) fn acquire_with_options<T, E, R>(
 		&self,
 		descriptor: QueryDescriptor<T, E>,
 		options: QueryAcquireOptions,
-		query_options: QueryOptions,
+		query_options: QueryOptions<R>,
 	) -> QueryLease<T, E>
 	where
 		T: Clone + Serialize + DeserializeOwned + 'static,
 		E: Clone + Serialize + DeserializeOwned + 'static,
+		R: QueryRetryConfig<E>,
 	{
+		let _retry_policy = query_options.retry_state().retry_policy();
 		let policy = ObserverPolicy::resolve(&query_options, &self.inner.defaults);
 		let (key, fetcher, _ssr_prefetch, family_types) = descriptor.into_parts();
 		self.entry_for_key(key, family_types)

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -637,6 +637,8 @@ pub(super) struct QueryEntry<T: Clone + 'static, E: Clone + 'static> {
 	runtime: QueryRuntimeHandle,
 	owner: Option<Weak<QueryClientInner>>,
 	inline_task: RefCell<Option<QueryTask>>,
+	retry_wait_guard: RefCell<Option<AbortableTaskGuard>>,
+	ssr_waiter_count: Cell<usize>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -787,6 +789,8 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			runtime,
 			owner,
 			inline_task: RefCell::new(None),
+			retry_wait_guard: RefCell::new(None),
+			ssr_waiter_count: Cell::new(0),
 		}
 	}
 
@@ -1052,12 +1056,14 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 	}
 
 	fn clear_retry_sequence(&self) {
+		self.retry_wait_guard.borrow_mut().take();
 		self.retry.borrow_mut().take();
 		self.next_retry_generation();
 	}
 
 	fn cancel_active_work(&self) {
 		self.inline_task.borrow_mut().take();
+		self.retry_wait_guard.borrow_mut().take();
 		if let Some(request) = self.request.borrow_mut().take() {
 			request.source.cancel();
 			Self::clear_manual_refetch(request.manual_observer);
@@ -1691,12 +1697,22 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			let wait = self
 				.runtime
 				.retry_wait(Duration::from_millis(due_ms.saturating_sub(now_ms)));
+			let (abort_handle, abort_registration) = AbortHandle::new_pair();
+			self.retry_wait_guard
+				.borrow_mut()
+				.replace(AbortableTaskGuard::new(abort_handle));
 			let entry = Rc::downgrade(self);
 			self.runtime.spawn(Box::pin(async move {
-				wait.await;
-				if let Some(entry) = entry.upgrade() {
-					entry.handle_retry_deadline_at(sequence_generation, due_ms);
-				}
+				let _ = Abortable::new(
+					async move {
+						wait.await;
+						if let Some(entry) = entry.upgrade() {
+							entry.handle_retry_deadline_at(sequence_generation, due_ms);
+						}
+					},
+					abort_registration,
+				)
+				.await;
 			}));
 			return;
 		}
@@ -1856,13 +1872,17 @@ struct SsrRetrySequenceGuard<T: Clone + 'static, E: Clone + 'static> {
 
 impl<T: Clone + 'static, E: Clone + 'static> Drop for SsrRetrySequenceGuard<T, E> {
 	fn drop(&mut self) {
-		if self.armed
-			&& let Some(lease) = self.lease.upgrade()
-			&& let Some(completion_generation) = lease.generation.get()
-		{
-			lease
-				.entry
-				.cancel_sequence_if_current(completion_generation);
+		if let Some(lease) = self.lease.upgrade() {
+			let remaining = lease.entry.ssr_waiter_count.get().saturating_sub(1);
+			lease.entry.ssr_waiter_count.set(remaining);
+			if self.armed
+				&& remaining == 0
+				&& let Some(completion_generation) = lease.generation.get()
+			{
+				lease
+					.entry
+					.cancel_sequence_if_current(completion_generation);
+			}
 		}
 	}
 }
@@ -1930,16 +1950,19 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryLease<T, E> {
 	// synchronous.
 	pub(crate) async fn result(&self) -> Result<T, E> {
 		let lease = Rc::clone(&self.inner);
-		QueryResultFuture {
-			ssr_guard: (self.inner.entry.runtime.executes_inline()).then(|| {
-				SsrRetrySequenceGuard {
-					lease: Rc::downgrade(&lease),
-					armed: lease.generation.get().is_some(),
-				}
-			}),
-			lease,
-		}
-		.await
+		let ssr_guard = (self.inner.entry.runtime.executes_inline()
+			&& lease.generation.get().is_some())
+		.then(|| {
+			lease
+				.entry
+				.ssr_waiter_count
+				.set(lease.entry.ssr_waiter_count.get() + 1);
+			SsrRetrySequenceGuard {
+				lease: Rc::downgrade(&lease),
+				armed: true,
+			}
+		});
+		QueryResultFuture { ssr_guard, lease }.await
 	}
 }
 

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -1159,12 +1159,37 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			}),
 		});
 		self.observers.borrow_mut().push(Rc::downgrade(&inner));
-		{
+		let retry_state = self.retry.borrow().as_ref().and_then(|sequence| {
+			sequence.last_error.as_ref().map(|error| {
+				(
+					sequence.generation,
+					sequence.attempts_started,
+					sequence.manual_observer_id,
+					error.clone(),
+					sequence.jitter_sample,
+				)
+			})
+		});
+		if let Some((
+			sequence_generation,
+			attempts_started,
+			manual_observer_id,
+			error,
+			mut jitter_sample,
+		)) = retry_state
+			&& let Some(candidate) = self.evaluate_retry_candidate(
+				&inner,
+				attempts_started,
+				manual_observer_id,
+				&error,
+				&mut jitter_sample,
+			) {
 			let mut retry = self.retry.borrow_mut();
-			if let Some(sequence) = retry.as_mut()
-				&& sequence.last_error.is_some()
-				&& let Some(candidate) = self.evaluate_retry_candidate(&inner, sequence)
+			if let Some(sequence) = retry
+				.as_mut()
+				.filter(|sequence| sequence.generation == sequence_generation)
 			{
+				sequence.jitter_sample = jitter_sample;
 				sequence.candidates.insert(registration_id, candidate);
 			}
 		}
@@ -1242,28 +1267,33 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			.find(|observer| observer.registration_id == registration_id)
 	}
 
-	fn observer_can_retry(observer: &QueryLeaseInner<T, E>, sequence: &RetrySequence<E>) -> bool {
+	fn observer_can_retry(
+		observer: &QueryLeaseInner<T, E>,
+		attempts_started: u32,
+		manual_observer_id: Option<ObserverRegistrationId>,
+		error: &E,
+	) -> bool {
 		let participates_automatically =
 			observer.policy.enabled && observer.consumer.get() == QueryConsumer::MountedQuery;
-		let participates_manually = sequence.manual_observer_id == Some(observer.registration_id);
+		let participates_manually = manual_observer_id == Some(observer.registration_id);
 		if !participates_automatically && !participates_manually {
 			return false;
 		}
 		let Some(policy) = observer.retry_policy.as_ref() else {
 			return false;
 		};
-		let Some(error) = sequence.last_error.as_ref() else {
-			return false;
-		};
-		sequence.attempts_started < policy.max_attempts && (policy.when)(error)
+		attempts_started < policy.max_attempts && (policy.when)(error)
 	}
 
 	fn evaluate_retry_candidate(
 		&self,
 		observer: &QueryLeaseInner<T, E>,
-		sequence: &mut RetrySequence<E>,
+		attempts_started: u32,
+		manual_observer_id: Option<ObserverRegistrationId>,
+		error: &E,
+		jitter_sample: &mut Option<u64>,
 	) -> Option<RetryCandidate> {
-		if !Self::observer_can_retry(observer, sequence) {
+		if !Self::observer_can_retry(observer, attempts_started, manual_observer_id, error) {
 			return None;
 		}
 		let policy = observer
@@ -1271,14 +1301,12 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			.as_ref()
 			.expect("a retry-eligible observer must have a retry policy");
 		let sample = if policy.jitter {
-			*sequence
-				.jitter_sample
-				.get_or_insert_with(|| self.runtime.jitter_sample())
+			*jitter_sample.get_or_insert_with(|| self.runtime.jitter_sample())
 		} else {
 			0
 		};
 		Some(RetryCandidate {
-			delay_ms: policy.delay_ms(sequence.attempts_started, sample),
+			delay_ms: policy.delay_ms(attempts_started, sample),
 		})
 	}
 
@@ -1625,7 +1653,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 				}
 				let now_ms = self.runtime.now_ms();
 				let observers = self.live_observers();
-				let has_candidates = {
+				let (attempts_started, manual_observer_id) = {
 					let mut retry = self.retry.borrow_mut();
 					let Some(sequence) = retry
 						.as_mut()
@@ -1634,14 +1662,39 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 						return;
 					};
 					sequence.record_failure(error.clone(), now_ms, None, HashMap::new());
-					for observer in observers {
-						if let Some(candidate) = self.evaluate_retry_candidate(&observer, sequence)
-						{
-							sequence
-								.candidates
-								.insert(observer.registration_id, candidate);
-						}
+					(sequence.attempts_started, sequence.manual_observer_id)
+				};
+				let mut jitter_sample = None;
+				let mut candidates = Vec::new();
+				for observer in observers {
+					if let Some(candidate) = self.evaluate_retry_candidate(
+						&observer,
+						attempts_started,
+						manual_observer_id,
+						&error,
+						&mut jitter_sample,
+					) {
+						candidates.push((observer.registration_id, candidate));
 					}
+					if !self
+						.retry
+						.borrow()
+						.as_ref()
+						.is_some_and(|sequence| sequence.generation == sequence_generation)
+					{
+						return;
+					}
+				}
+				let has_candidates = {
+					let mut retry = self.retry.borrow_mut();
+					let Some(sequence) = retry
+						.as_mut()
+						.filter(|sequence| sequence.generation == sequence_generation)
+					else {
+						return;
+					};
+					sequence.jitter_sample = jitter_sample;
+					sequence.candidates.extend(candidates);
 					if !self.polling_is_visible() {
 						sequence.pause(now_ms);
 					}
@@ -1897,16 +1950,17 @@ impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> 
 	fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
 		let this = self.get_mut();
 		let entry = Rc::clone(&this.lease.entry);
-		loop {
-			let inline_task = entry.inline_task.borrow_mut().take();
-			let Some(mut task) = inline_task else {
-				break;
-			};
+		let inline_task = entry.inline_task.borrow_mut().take();
+		let ready_inline_task = if let Some(mut task) = inline_task {
 			if task.as_mut().poll(context).is_pending() {
 				entry.inline_task.borrow_mut().replace(task);
-				break;
+				false
+			} else {
+				true
 			}
-		}
+		} else {
+			false
+		};
 		if let Some(generation) = this.lease.generation.get() {
 			if let Some((completed_generation, result)) = entry.completed.borrow().as_ref()
 				&& *completed_generation == generation
@@ -1934,6 +1988,11 @@ impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> 
 			}
 		}
 		entry.register_waiter(context.waker());
+		if ready_inline_task && entry.inline_task.borrow().is_some() {
+			// Yield after each ready inline task so SSR timeouts and other futures
+			// can run between zero-delay retry attempts.
+			context.waker().wake_by_ref();
+		}
 		Poll::Pending
 	}
 }

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -638,7 +638,7 @@ impl<T: Clone + 'static, E: Clone + 'static> Clone for QueryLease<T, E> {
 
 impl<T: Clone + 'static, E: Clone + 'static> Drop for QueryLeaseInner<T, E> {
 	fn drop(&mut self) {
-		let entry = &self.entry;
+		let entry = Rc::clone(&self.entry);
 		let remaining = entry.lease_count.get().saturating_sub(1);
 		entry.lease_count.set(remaining);
 		if self.retains_errors {
@@ -649,6 +649,7 @@ impl<T: Clone + 'static, E: Clone + 'static> Drop for QueryLeaseInner<T, E> {
 			entry.cancel_request();
 			entry.schedule_garbage_collection();
 		} else {
+			entry.remove_retry_candidate(self.registration_id);
 			entry.refresh_polling_deadline();
 		}
 	}
@@ -1038,6 +1039,16 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			}),
 		});
 		self.observers.borrow_mut().push(Rc::downgrade(&inner));
+		{
+			let mut retry = self.retry.borrow_mut();
+			if let Some(sequence) = retry.as_mut()
+				&& sequence.last_error.is_some()
+				&& let Some(candidate) = self.evaluate_retry_candidate(&inner, sequence)
+			{
+				sequence.candidates.insert(registration_id, candidate);
+			}
+		}
+		self.recompute_retry_deadline();
 		self.refresh_polling_deadline();
 		QueryLease { inner }
 	}
@@ -1053,7 +1064,12 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		T: Serialize + DeserializeOwned,
 		E: Serialize + DeserializeOwned,
 	{
-		let should_fetch = if !policy.enabled || self.has_request() {
+		let waiting_to_retry = self
+			.retry
+			.borrow()
+			.as_ref()
+			.is_some_and(|sequence| sequence.last_error.is_some());
+		let should_fetch = if !policy.enabled || self.has_request() || waiting_to_retry {
 			false
 		} else if options.error_policy == QueryErrorPolicy::Retain {
 			self.should_fetch_on_mount(policy.stale_time)
@@ -1104,6 +1120,106 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			.iter()
 			.filter_map(Weak::upgrade)
 			.find(|observer| observer.registration_id == registration_id)
+	}
+
+	fn observer_can_retry(observer: &QueryLeaseInner<T, E>, sequence: &RetrySequence<E>) -> bool {
+		let participates_automatically =
+			observer.policy.enabled && observer.consumer.get() == QueryConsumer::MountedQuery;
+		let participates_manually = sequence.manual_observer_id == Some(observer.registration_id);
+		if !participates_automatically && !participates_manually {
+			return false;
+		}
+		let Some(policy) = observer.retry_policy.as_ref() else {
+			return false;
+		};
+		let Some(error) = sequence.last_error.as_ref() else {
+			return false;
+		};
+		sequence.attempts_started < policy.max_attempts && (policy.when)(error)
+	}
+
+	fn evaluate_retry_candidate(
+		&self,
+		observer: &QueryLeaseInner<T, E>,
+		sequence: &mut RetrySequence<E>,
+	) -> Option<RetryCandidate> {
+		if !Self::observer_can_retry(observer, sequence) {
+			return None;
+		}
+		let policy = observer
+			.retry_policy
+			.as_ref()
+			.expect("a retry-eligible observer must have a retry policy");
+		let sample = if policy.jitter {
+			*sequence
+				.jitter_sample
+				.get_or_insert_with(|| self.runtime.jitter_sample())
+		} else {
+			0
+		};
+		Some(RetryCandidate {
+			delay_ms: policy.delay_ms(sequence.attempts_started, sample),
+		})
+	}
+
+	fn recompute_retry_deadline(self: &Rc<Self>) {
+		let sequence_generation = self
+			.retry
+			.borrow()
+			.as_ref()
+			.filter(|sequence| sequence.last_error.is_some() && !sequence.candidates.is_empty())
+			.map(|sequence| sequence.generation);
+		if let Some(sequence_generation) = sequence_generation {
+			self.schedule_retry_deadline(sequence_generation);
+		} else if let Some(owner) = self.owner.as_ref().and_then(Weak::upgrade) {
+			owner.refresh_browser_timer();
+		}
+	}
+
+	fn remove_retry_candidate(self: &Rc<Self>, registration_id: ObserverRegistrationId) {
+		let terminal_failure = {
+			let mut retry = self.retry.borrow_mut();
+			let Some(sequence) = retry.as_mut() else {
+				return;
+			};
+			if sequence.candidates.remove(&registration_id).is_none() {
+				return;
+			}
+			if !sequence.candidates.is_empty() {
+				None
+			} else {
+				sequence.last_error.clone().map(|error| {
+					(
+						sequence.completion_generation,
+						sequence.invalidation_generation,
+						sequence.had_success,
+						sequence.manual_observer_id,
+						error,
+					)
+				})
+			}
+		};
+		if let Some((
+			completion_generation,
+			invalidation_generation,
+			had_success,
+			manual_id,
+			error,
+		)) = terminal_failure
+		{
+			let manual_observer = manual_id
+				.and_then(|observer_id| self.observer_by_id(observer_id))
+				.map(|observer| Rc::downgrade(&observer));
+			self.publish_terminal_failure(
+				completion_generation,
+				invalidation_generation,
+				had_success,
+				error,
+			);
+			self.finish_terminal_sequence(manual_observer, invalidation_generation);
+		} else {
+			self.recompute_retry_deadline();
+		}
 	}
 
 	fn has_active_invalidation_interest(&self) -> bool {
@@ -1342,35 +1458,28 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 				self.finish_terminal_sequence(manual_observer, request_invalidation_generation);
 			}
 			Err(error) => {
-				let retry_observer = self
-					.selected_observer()
-					.or_else(|| manual_observer.as_ref().and_then(Weak::upgrade));
-				let mut candidates = HashMap::new();
-				let mut jitter_sample = None;
-				if let Some(observer) = retry_observer
-					&& let Some(policy) = observer.retry_policy.as_ref()
-					&& attempt_number < policy.max_attempts
-					&& (policy.when)(&error)
-				{
-					let sample = if policy.jitter {
-						let sample = self.runtime.jitter_sample();
-						jitter_sample = Some(sample);
-						sample
-					} else {
-						0
+				let now_ms = self.runtime.now_ms();
+				let observers = self.live_observers();
+				let has_candidates = {
+					let mut retry = self.retry.borrow_mut();
+					let Some(sequence) = retry
+						.as_mut()
+						.filter(|sequence| sequence.generation == sequence_generation)
+					else {
+						return;
 					};
-					candidates.insert(
-						observer.registration_id,
-						RetryCandidate {
-							delay_ms: policy.delay_ms(attempt_number, sample),
-						},
-					);
-				}
-				if !candidates.is_empty() {
-					let now_ms = self.runtime.now_ms();
-					if let Some(retry) = self.retry.borrow_mut().as_mut() {
-						retry.record_failure(error, now_ms, jitter_sample, candidates);
+					sequence.record_failure(error.clone(), now_ms, None, HashMap::new());
+					for observer in observers {
+						if let Some(candidate) = self.evaluate_retry_candidate(&observer, sequence)
+						{
+							sequence
+								.candidates
+								.insert(observer.registration_id, candidate);
+						}
 					}
+					!sequence.candidates.is_empty()
+				};
+				if has_candidates {
 					self.schedule_retry_deadline(sequence_generation);
 					return;
 				}

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -22,7 +22,9 @@ use super::super::resource::ResourceState;
 use super::identity::{
 	QueryDescriptor, QueryFamily, QueryFamilyTypes, QueryFetcher, QueryIdentity, QueryKey,
 };
-use super::retry::QueryRetryConfig;
+use super::retry::{
+	ObserverRegistrationId, QueryRetryConfig, RetryCandidate, RetryPolicy, RetrySequence,
+};
 use super::runtime::{ScopedQueryFuture, duration_ms, now_ms, spawn_query_task};
 use super::state::{QueryDefaults, QueryOptions};
 #[cfg(any(wasm, test))]
@@ -256,6 +258,7 @@ struct CachedQueryEntry {
 	invalidate: Rc<dyn Fn()>,
 	cancel: Rc<dyn Fn()>,
 	poll_due: Rc<dyn Fn(u64)>,
+	retry_due: Rc<dyn Fn(u64)>,
 	#[cfg(wasm)]
 	visibility_changed: Rc<dyn Fn(bool, u64)>,
 	deadline_is_current: Rc<dyn Fn(QueryDeadlineKind, u64) -> bool>,
@@ -264,6 +267,7 @@ struct CachedQueryEntry {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum QueryDeadlineKind {
 	Poll,
+	Retry,
 	GarbageCollection,
 }
 
@@ -465,6 +469,16 @@ impl QueryClientInner {
 						poll_due(deadline.generation);
 					}
 				}
+				QueryDeadlineKind::Retry => {
+					let retry_due = self
+						.entries
+						.borrow()
+						.get(&deadline.identity)
+						.map(|entry| Rc::clone(&entry.retry_due));
+					if let Some(retry_due) = retry_due {
+						retry_due(deadline.generation);
+					}
+				}
 				QueryDeadlineKind::GarbageCollection => {
 					let cached = self.entries.borrow_mut().remove(&deadline.identity);
 					if let Some(cached) = cached {
@@ -537,6 +551,8 @@ pub(crate) struct QueryAcquireOptions {
 
 pub(super) struct QueryRequest<T: Clone + 'static, E: Clone + 'static> {
 	pub(super) generation: u64,
+	sequence_generation: u64,
+	attempt_number: u32,
 	invalidation_generation: u64,
 	manual_observer: Option<Weak<QueryLeaseInner<T, E>>>,
 	pub(super) source: CancellationSource,
@@ -554,6 +570,8 @@ pub(super) struct QueryEntry<T: Clone + 'static, E: Clone + 'static> {
 	pub(super) is_fetching: Signal<bool>,
 	pub(super) request: RefCell<Option<QueryRequest<T, E>>>,
 	next_generation: Cell<u64>,
+	pub(super) retry: RefCell<Option<RetrySequence<E>>>,
+	next_retry_generation: Cell<u64>,
 	invalidation_generation: Cell<u64>,
 	invalidated: Signal<bool>,
 	pub(super) completed: RefCell<Option<(u64, Result<T, E>)>>,
@@ -564,6 +582,7 @@ pub(super) struct QueryEntry<T: Clone + 'static, E: Clone + 'static> {
 	queued_manual_refetch: RefCell<Option<Weak<QueryLeaseInner<T, E>>>>,
 	pub(super) last_fetched_ms: Cell<Option<u64>>,
 	observers: RefCell<Vec<Weak<QueryLeaseInner<T, E>>>>,
+	next_observer_registration_id: Cell<ObserverRegistrationId>,
 	poll_generation: Cell<u64>,
 	gc_generation: Cell<u64>,
 	epoch_gc_time: Cell<Duration>,
@@ -593,10 +612,12 @@ impl ObserverPolicy {
 
 pub(super) struct QueryLeaseInner<T: Clone + 'static, E: Clone + 'static> {
 	pub(super) entry: Rc<QueryEntry<T, E>>,
+	registration_id: ObserverRegistrationId,
 	generation: Cell<Option<u64>>,
 	retains_errors: bool,
 	consumer: Cell<QueryConsumer>,
 	pub(super) policy: ObserverPolicy,
+	retry_policy: Option<RetryPolicy<E>>,
 	pub(super) fetcher: Rc<QueryFetcher<T, E>>,
 	pub(super) manual_refetch_pending: Cell<bool>,
 	poll_deadline_ms: Cell<Option<u64>>,
@@ -698,6 +719,8 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			is_fetching,
 			request: RefCell::new(None),
 			next_generation: Cell::new(0),
+			retry: RefCell::new(None),
+			next_retry_generation: Cell::new(0),
 			invalidation_generation: Cell::new(0),
 			invalidated,
 			completed: RefCell::new(None),
@@ -708,6 +731,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			queued_manual_refetch: RefCell::new(None),
 			last_fetched_ms: Cell::new(last_fetched_ms),
 			observers: RefCell::new(Vec::new()),
+			next_observer_registration_id: Cell::new(0),
 			poll_generation: Cell::new(0),
 			gc_generation: Cell::new(0),
 			epoch_gc_time: Cell::new(Duration::ZERO),
@@ -896,6 +920,14 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			QueryDeadlineKind::Poll => {
 				self.lease_count.get() > 0 && self.poll_generation.get() == generation
 			}
+			QueryDeadlineKind::Retry => {
+				self.lease_count.get() > 0
+					&& self.retry.borrow().as_ref().is_some_and(|retry| {
+						retry.generation == generation
+							&& retry.last_error.is_some()
+							&& !retry.candidates.is_empty()
+					})
+			}
 			QueryDeadlineKind::GarbageCollection => {
 				self.lease_count.get() == 0 && self.gc_generation.get() == generation
 			}
@@ -908,16 +940,41 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		generation
 	}
 
+	fn next_retry_generation(&self) -> u64 {
+		let generation = self.next_retry_generation.get().wrapping_add(1);
+		self.next_retry_generation.set(generation);
+		generation
+	}
+
+	fn active_completion_generation(&self) -> Option<u64> {
+		let sequence_generation = self
+			.request
+			.borrow()
+			.as_ref()
+			.map(|request| request.sequence_generation)?;
+		self.retry
+			.borrow()
+			.as_ref()
+			.filter(|retry| retry.generation == sequence_generation)
+			.map(|retry| retry.completion_generation)
+	}
+
+	fn clear_retry_sequence(&self) {
+		self.retry.borrow_mut().take();
+		self.next_retry_generation();
+	}
+
 	fn cancel_request(&self) {
 		self.inline_task.borrow_mut().take();
 		if let Some(request) = self.request.borrow_mut().take() {
 			request.source.cancel();
 			Self::clear_manual_refetch(request.manual_observer);
-			Self::clear_manual_refetch(self.queued_manual_refetch.borrow_mut().take());
-			self.refetch_after_in_flight.set(false);
-			self.is_fetching.set(false);
-			self.wake_waiters();
 		}
+		Self::clear_manual_refetch(self.queued_manual_refetch.borrow_mut().take());
+		self.refetch_after_in_flight.set(false);
+		self.is_fetching.set(false);
+		self.clear_retry_sequence();
+		self.wake_waiters();
 	}
 
 	fn wake_waiters(&self) {
@@ -943,6 +1000,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		error_policy: QueryErrorPolicy,
 		fetcher: Rc<QueryFetcher<T, E>>,
 		policy: ObserverPolicy,
+		retry_policy: Option<RetryPolicy<E>>,
 	) -> QueryLease<T, E> {
 		let previous_lease_count = self.lease_count.get();
 		self.lease_count.set(previous_lease_count + 1);
@@ -959,12 +1017,17 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			self.retain_lease_count
 				.set(self.retain_lease_count.get() + 1);
 		}
+		let registration_id = self.next_observer_registration_id.get();
+		self.next_observer_registration_id
+			.set(registration_id.wrapping_add(1));
 		let inner = Rc::new(QueryLeaseInner {
 			entry: Rc::clone(self),
+			registration_id,
 			generation: Cell::new(generation),
 			retains_errors,
 			consumer: Cell::new(consumer),
 			policy,
+			retry_policy,
 			fetcher,
 			manual_refetch_pending: Cell::new(false),
 			poll_deadline_ms: Cell::new(if self.polling_is_visible() {
@@ -984,6 +1047,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		fetcher: Rc<QueryFetcher<T, E>>,
 		options: QueryAcquireOptions,
 		policy: ObserverPolicy,
+		retry_policy: Option<RetryPolicy<E>>,
 	) -> QueryLease<T, E>
 	where
 		T: Serialize + DeserializeOwned,
@@ -1010,27 +1074,36 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			options.error_policy,
 			fetcher,
 			policy,
+			retry_policy,
 		);
 		let generation = if should_fetch {
 			Some(self.start_fetch(false))
 		} else {
-			self.request
-				.borrow()
-				.as_ref()
-				.map(|request| request.generation)
+			self.active_completion_generation()
 		};
 		lease.inner.generation.set(generation);
 		lease
 	}
 
-	fn selected_fetcher(&self) -> Option<Rc<QueryFetcher<T, E>>> {
+	fn selected_observer(&self) -> Option<Rc<QueryLeaseInner<T, E>>> {
 		let mut observers = self.observers.borrow_mut();
 		observers.retain(|observer| observer.strong_count() > 0);
 		observers
 			.iter()
 			.filter_map(Weak::upgrade)
 			.find(|observer| observer.policy.enabled)
-			.map(|observer| Rc::clone(&observer.fetcher))
+	}
+
+	fn observer_by_id(
+		&self,
+		registration_id: ObserverRegistrationId,
+	) -> Option<Rc<QueryLeaseInner<T, E>>> {
+		let mut observers = self.observers.borrow_mut();
+		observers.retain(|observer| observer.strong_count() > 0);
+		observers
+			.iter()
+			.filter_map(Weak::upgrade)
+			.find(|observer| observer.registration_id == registration_id)
 	}
 
 	fn has_active_invalidation_interest(&self) -> bool {
@@ -1048,7 +1121,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 	}
 
 	pub(super) fn start_fetch(self: &Rc<Self>, force: bool) -> u64 {
-		self.start_fetch_with(force, None)
+		self.start_sequence_with(force, None)
 	}
 
 	pub(super) fn start_observer_refetch(
@@ -1056,7 +1129,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		observer: &Rc<QueryLeaseInner<T, E>>,
 	) -> u64 {
 		observer.manual_refetch_pending.set(true);
-		self.start_fetch_with(true, Some(Rc::downgrade(observer)))
+		self.start_sequence_with(true, Some(Rc::downgrade(observer)))
 	}
 
 	fn queue_manual_refetch(&self, observer: Weak<QueryLeaseInner<T, E>>) {
@@ -1076,7 +1149,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		}
 	}
 
-	fn start_fetch_with(
+	fn start_sequence_with(
 		self: &Rc<Self>,
 		force: bool,
 		manual_observer: Option<Weak<QueryLeaseInner<T, E>>>,
@@ -1088,37 +1161,92 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			if let Some(observer) = manual_observer {
 				self.queue_manual_refetch(observer);
 			}
-			return self
-				.request
-				.borrow()
-				.as_ref()
-				.map(|request| request.generation)
-				.unwrap_or_default();
+			return self.active_completion_generation().unwrap_or_default();
 		}
 
 		let had_success = self
 			.state
 			.with_untracked(|state| matches!(state, ResourceState::Success(_)));
 		let manual_observer = manual_observer.and_then(|observer| observer.upgrade());
-		let fetcher = self.selected_fetcher().or_else(|| {
-			manual_observer
-				.as_ref()
-				.map(|observer| Rc::clone(&observer.fetcher))
-		});
-		let Some(fetcher) = fetcher else {
+		let attempt_observer = self
+			.selected_observer()
+			.or_else(|| manual_observer.as_ref().map(Rc::clone));
+		let Some(_attempt_observer) = attempt_observer else {
 			if let Some(observer) = manual_observer {
 				observer.manual_refetch_pending.set(false);
 			}
 			return self.next_generation.get();
 		};
-		let generation = self.next_request_generation();
+		if let Some(previous_manual_observer_id) = self
+			.retry
+			.borrow()
+			.as_ref()
+			.and_then(|retry| retry.manual_observer_id)
+			&& let Some(previous_manual_observer) = self.observer_by_id(previous_manual_observer_id)
+		{
+			previous_manual_observer.manual_refetch_pending.set(false);
+		}
+		self.clear_retry_sequence();
+		let sequence_generation = self.next_retry_generation();
+		let completion_generation = self.next_request_generation();
 		let invalidation_generation = self.invalidation_generation.get();
+		let manual_observer_id = manual_observer
+			.as_ref()
+			.map(|observer| observer.registration_id);
+		self.retry.borrow_mut().replace(RetrySequence::new(
+			sequence_generation,
+			completion_generation,
+			manual_observer_id,
+			had_success,
+			invalidation_generation,
+		));
+		self.suspend_polling();
+		if had_success {
+			self.refetch_error.set(None);
+		} else {
+			self.state.set(ResourceState::Loading);
+		}
+		self.start_attempt(
+			sequence_generation,
+			manual_observer.as_ref().map(Rc::downgrade),
+		);
+		completion_generation
+	}
+
+	fn start_attempt(
+		self: &Rc<Self>,
+		sequence_generation: u64,
+		manual_observer: Option<Weak<QueryLeaseInner<T, E>>>,
+	) -> u64 {
+		let manual_observer = manual_observer.and_then(|observer| observer.upgrade());
+		let attempt_observer = self
+			.selected_observer()
+			.or_else(|| manual_observer.as_ref().map(Rc::clone));
+		let Some(attempt_observer) = attempt_observer else {
+			return self.next_generation.get();
+		};
+		let (attempt_number, invalidation_generation) = {
+			let mut retry = self.retry.borrow_mut();
+			let Some(retry) = retry
+				.as_mut()
+				.filter(|retry| retry.generation == sequence_generation)
+			else {
+				return self.next_generation.get();
+			};
+			(
+				retry.record_attempt_started(),
+				retry.invalidation_generation,
+			)
+		};
+		let generation = self.next_request_generation();
 		let source = CancellationSource::new();
 		let token = source.handle();
 		let (abort_handle, abort_registration) = AbortHandle::new_pair();
 		let guard = AbortableTaskGuard::new(abort_handle);
 		*self.request.borrow_mut() = Some(QueryRequest {
 			generation,
+			sequence_generation,
+			attempt_number,
 			invalidation_generation,
 			manual_observer: manual_observer.as_ref().map(Rc::downgrade),
 			source,
@@ -1126,20 +1254,16 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			_marker: PhantomData,
 		});
 		self.is_fetching.set(true);
-		if had_success {
-			self.refetch_error.set(None);
-		} else {
-			self.state.set(ResourceState::Loading);
-		}
 
 		let entry = Rc::clone(self);
+		let fetcher = Rc::clone(&attempt_observer.fetcher);
 		let scope = entry._scope.id();
 		let fetch_cancellation = token.clone();
 		let scoped = ScopedQueryFuture {
 			scope,
 			future: Box::pin(async move {
 				let result = scope_cancellation(token, fetcher(fetch_cancellation)).await;
-				entry.complete_fetch(generation, result);
+				entry.complete_attempt(generation, result);
 			}),
 		};
 		let task = async move {
@@ -1161,7 +1285,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		generation
 	}
 
-	pub(super) fn complete_fetch(self: &Rc<Self>, generation: u64, result: Result<T, E>) {
+	pub(super) fn complete_attempt(self: &Rc<Self>, generation: u64, result: Result<T, E>) {
 		let request = self.request.borrow();
 		let cancelled = request
 			.as_ref()
@@ -1177,44 +1301,186 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			.as_ref()
 			.map(|request| request.invalidation_generation)
 			.unwrap_or_default();
+		let sequence_generation = request
+			.as_ref()
+			.map(|request| request.sequence_generation)
+			.unwrap_or_default();
+		let attempt_number = request
+			.as_ref()
+			.map(|request| request.attempt_number)
+			.unwrap_or_default();
 		let manual_observer = request
 			.as_ref()
 			.and_then(|request| request.manual_observer.clone());
 		drop(request);
-		let had_success = self
-			.state
-			.with_untracked(|state| matches!(state, ResourceState::Success(_)));
 		self.request.borrow_mut().take();
-		self.completed
-			.borrow_mut()
-			.replace((generation, result.clone()));
+		self.is_fetching.set(false);
+		let sequence_matches = self.retry.borrow().as_ref().is_some_and(|retry| {
+			retry.generation == sequence_generation && retry.attempts_started == attempt_number
+		});
+		if !sequence_matches {
+			return;
+		}
 		match result {
 			Ok(value) => {
+				let completion_generation = self
+					.retry
+					.borrow()
+					.as_ref()
+					.map(|retry| retry.completion_generation)
+					.unwrap_or_default();
 				self.last_fetched_ms.set(Some(self.runtime.now_ms()));
 				self.refetch_error.set(None);
-				self.state.set(ResourceState::Success(value));
+				self.state.set(ResourceState::Success(value.clone()));
 				if self.invalidation_generation.get() == request_invalidation_generation {
 					self.invalidated.set(false);
 				}
+				self.completed
+					.borrow_mut()
+					.replace((completion_generation, Ok(value)));
+				self.clear_retry_sequence();
+				self.finish_terminal_sequence(manual_observer, request_invalidation_generation);
 			}
 			Err(error) => {
-				if had_success {
-					self.refetch_error.set(Some(error));
-				} else {
-					self.refetch_error.set(None);
-					self.state.set(ResourceState::Error(error));
+				let retry_observer = self
+					.selected_observer()
+					.or_else(|| manual_observer.as_ref().and_then(Weak::upgrade));
+				let mut candidates = HashMap::new();
+				let mut jitter_sample = None;
+				if let Some(observer) = retry_observer
+					&& let Some(policy) = observer.retry_policy.as_ref()
+					&& attempt_number < policy.max_attempts
+					&& (policy.when)(&error)
+				{
+					let sample = if policy.jitter {
+						let sample = self.runtime.jitter_sample();
+						jitter_sample = Some(sample);
+						sample
+					} else {
+						0
+					};
+					candidates.insert(
+						observer.registration_id,
+						RetryCandidate {
+							delay_ms: policy.delay_ms(attempt_number, sample),
+						},
+					);
 				}
-				if !had_success && self.retain_lease_count.get() > 0 {
-					self.last_fetched_ms.set(Some(self.runtime.now_ms()));
-					if self.invalidation_generation.get() == request_invalidation_generation {
-						self.invalidated.set(false);
+				if !candidates.is_empty() {
+					let now_ms = self.runtime.now_ms();
+					if let Some(retry) = self.retry.borrow_mut().as_mut() {
+						retry.record_failure(error, now_ms, jitter_sample, candidates);
 					}
-				} else if !had_success {
-					self.last_fetched_ms.set(None);
+					self.schedule_retry_deadline(sequence_generation);
+					return;
 				}
+				let (completion_generation, had_success) = self
+					.retry
+					.borrow()
+					.as_ref()
+					.map(|retry| (retry.completion_generation, retry.had_success))
+					.unwrap_or_default();
+				self.publish_terminal_failure(
+					completion_generation,
+					request_invalidation_generation,
+					had_success,
+					error,
+				);
+				self.finish_terminal_sequence(manual_observer, request_invalidation_generation);
 			}
 		}
-		self.is_fetching.set(false);
+	}
+
+	fn schedule_retry_deadline(&self, sequence_generation: u64) {
+		let now_ms = self.runtime.now_ms();
+		let due_ms = self.retry.borrow().as_ref().and_then(|retry| {
+			(retry.generation == sequence_generation)
+				.then(|| retry.earliest_due_ms(now_ms))
+				.flatten()
+		});
+		if let Some(owner) = self.owner.as_ref().and_then(Weak::upgrade) {
+			if let Some(due_ms) = due_ms {
+				owner.schedule_deadline(
+					self.identity.clone(),
+					QueryDeadlineKind::Retry,
+					sequence_generation,
+					due_ms,
+				);
+			} else {
+				owner.refresh_browser_timer();
+			}
+		}
+	}
+
+	fn handle_retry_deadline(self: &Rc<Self>, sequence_generation: u64) {
+		if !self.deadline_is_current(QueryDeadlineKind::Retry, sequence_generation) {
+			return;
+		}
+		let now_ms = self.runtime.now_ms();
+		let (candidate_observer_id, manual_observer_id) = {
+			let retry = self.retry.borrow();
+			let Some(retry) = retry
+				.as_ref()
+				.filter(|retry| retry.generation == sequence_generation)
+			else {
+				return;
+			};
+			let candidate_observer_id = retry
+				.candidates
+				.keys()
+				.copied()
+				.filter(|observer_id| {
+					retry
+						.candidate_due_ms(*observer_id, now_ms)
+						.is_some_and(|due_ms| due_ms <= now_ms)
+				})
+				.min();
+			(candidate_observer_id, retry.manual_observer_id)
+		};
+		let Some(candidate_observer_id) = candidate_observer_id else {
+			return;
+		};
+		if self.observer_by_id(candidate_observer_id).is_none() {
+			return;
+		}
+		let manual_observer = manual_observer_id
+			.and_then(|observer_id| self.observer_by_id(observer_id))
+			.map(|observer| Rc::downgrade(&observer));
+		self.start_attempt(sequence_generation, manual_observer);
+	}
+
+	fn publish_terminal_failure(
+		&self,
+		completion_generation: u64,
+		request_invalidation_generation: u64,
+		had_success: bool,
+		error: E,
+	) {
+		if had_success {
+			self.refetch_error.set(Some(error.clone()));
+		} else {
+			self.refetch_error.set(None);
+			self.state.set(ResourceState::Error(error.clone()));
+		}
+		if !had_success && self.retain_lease_count.get() > 0 {
+			self.last_fetched_ms.set(Some(self.runtime.now_ms()));
+			if self.invalidation_generation.get() == request_invalidation_generation {
+				self.invalidated.set(false);
+			}
+		} else if !had_success {
+			self.last_fetched_ms.set(None);
+		}
+		self.completed
+			.borrow_mut()
+			.replace((completion_generation, Err(error)));
+		self.clear_retry_sequence();
+	}
+
+	fn finish_terminal_sequence(
+		self: &Rc<Self>,
+		manual_observer: Option<Weak<QueryLeaseInner<T, E>>>,
+		request_invalidation_generation: u64,
+	) {
 		self.wake_waiters();
 		self.reschedule_polling_from(self.runtime.now_ms());
 		let invalidated_during_request =
@@ -1237,7 +1503,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			&& observer.strong_count() > 0
 			&& self.lease_count.get() > 0
 		{
-			self.start_fetch_with(true, Some(observer));
+			self.start_sequence_with(true, Some(observer));
 		} else if ((manual_refetch_queued
 			&& (!queued_manual_observer_was_present || queued_manual_observer_is_live))
 			|| (invalidated_during_request && self.has_active_invalidation_interest()))
@@ -1374,11 +1640,11 @@ impl QueryClient {
 		E: Clone + Serialize + DeserializeOwned + 'static,
 		R: QueryRetryConfig<E>,
 	{
-		let _retry_policy = query_options.retry_state().retry_policy();
+		let retry_policy = query_options.retry_state().retry_policy().cloned();
 		let policy = ObserverPolicy::resolve(&query_options, &self.inner.defaults);
 		let (key, fetcher, _ssr_prefetch, family_types) = descriptor.into_parts();
 		self.entry_for_key(key, family_types)
-			.acquire(fetcher, options, policy)
+			.acquire(fetcher, options, policy, retry_policy)
 	}
 
 	pub(crate) fn seed_serialized<T, E>(
@@ -1609,6 +1875,10 @@ where
 		poll_due: Rc::new({
 			let entry = Rc::clone(entry);
 			move |generation| entry.handle_poll_deadline(generation)
+		}),
+		retry_due: Rc::new({
+			let entry = Rc::clone(entry);
+			move |generation| entry.handle_retry_deadline(generation)
 		}),
 		#[cfg(wasm)]
 		visibility_changed: Rc::new({

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -974,8 +974,15 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			request.source.cancel();
 			Self::clear_manual_refetch(request.manual_observer);
 		}
-		self.retry.borrow_mut().take();
+		let retry_manual_observer = self
+			.retry
+			.borrow_mut()
+			.take()
+			.and_then(|retry| retry.manual_observer_id)
+			.and_then(|observer_id| self.observer_by_id(observer_id))
+			.map(|observer| Rc::downgrade(&observer));
 		self.next_retry_generation();
+		Self::clear_manual_refetch(retry_manual_observer);
 		Self::clear_manual_refetch(self.queued_manual_refetch.borrow_mut().take());
 		self.refetch_after_in_flight.set(false);
 		self.is_fetching.set(false);
@@ -1456,7 +1463,14 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		if !sequence_matches {
 			return;
 		}
-		let follow_up_required = self.refetch_after_in_flight.get()
+		let queued_manual_refetch_is_live = self
+			.queued_manual_refetch
+			.borrow()
+			.as_ref()
+			.map_or(true, |observer| observer.strong_count() > 0);
+		let follow_up_required = (self.refetch_after_in_flight.get()
+			&& queued_manual_refetch_is_live
+			&& self.lease_count.get() > 0)
 			|| (self.invalidation_generation.get() > request_invalidation_generation
 				&& self.has_active_invalidation_interest());
 		match result {

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -1266,6 +1266,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 				return;
 			}
 			if !sequence.candidates.is_empty() {
+				sequence.generation = self.next_retry_generation();
 				None
 			} else {
 				sequence.last_error.clone().map(|error| {
@@ -1798,23 +1799,24 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 }
 
 struct QueryResultFuture<T: Clone + 'static, E: Clone + 'static> {
-	entry: Rc<QueryEntry<T, E>>,
-	generation: Option<u64>,
 	ssr_guard: Option<SsrRetrySequenceGuard<T, E>>,
+	lease: Rc<QueryLeaseInner<T, E>>,
 }
 
 struct SsrRetrySequenceGuard<T: Clone + 'static, E: Clone + 'static> {
-	entry: Weak<QueryEntry<T, E>>,
-	completion_generation: u64,
+	lease: Weak<QueryLeaseInner<T, E>>,
 	armed: bool,
 }
 
 impl<T: Clone + 'static, E: Clone + 'static> Drop for SsrRetrySequenceGuard<T, E> {
 	fn drop(&mut self) {
 		if self.armed
-			&& let Some(entry) = self.entry.upgrade()
+			&& let Some(lease) = self.lease.upgrade()
+			&& let Some(completion_generation) = lease.generation.get()
 		{
-			entry.cancel_sequence_if_current(self.completion_generation);
+			lease
+				.entry
+				.cancel_sequence_if_current(completion_generation);
 		}
 	}
 }
@@ -1824,18 +1826,19 @@ impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> 
 
 	fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
 		let this = self.get_mut();
+		let entry = Rc::clone(&this.lease.entry);
 		loop {
-			let inline_task = this.entry.inline_task.borrow_mut().take();
+			let inline_task = entry.inline_task.borrow_mut().take();
 			let Some(mut task) = inline_task else {
 				break;
 			};
 			if task.as_mut().poll(context).is_pending() {
-				this.entry.inline_task.borrow_mut().replace(task);
+				entry.inline_task.borrow_mut().replace(task);
 				break;
 			}
 		}
-		if let Some(generation) = this.generation {
-			if let Some((completed_generation, result)) = this.entry.completed.borrow().as_ref()
+		if let Some(generation) = this.lease.generation.get() {
+			if let Some((completed_generation, result)) = entry.completed.borrow().as_ref()
 				&& *completed_generation == generation
 			{
 				if let Some(guard) = this.ssr_guard.as_mut() {
@@ -1844,7 +1847,7 @@ impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> 
 				return Poll::Ready(result.clone());
 			}
 		} else {
-			match this.entry.state.with_untracked(|state| state.clone()) {
+			match entry.state.with_untracked(|state| state.clone()) {
 				ResourceState::Success(value) => {
 					if let Some(guard) = this.ssr_guard.as_mut() {
 						guard.armed = false;
@@ -1860,7 +1863,7 @@ impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> 
 				ResourceState::Loading => {}
 			}
 		}
-		this.entry.register_waiter(context.waker());
+		entry.register_waiter(context.waker());
 		Poll::Pending
 	}
 }
@@ -1880,17 +1883,15 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryLease<T, E> {
 	// Route preparation awaits this result while the public hook remains
 	// synchronous.
 	pub(crate) async fn result(&self) -> Result<T, E> {
-		let generation = self.inner.generation.get();
+		let lease = Rc::clone(&self.inner);
 		QueryResultFuture {
-			entry: Rc::clone(&self.inner.entry),
-			generation,
 			ssr_guard: (self.inner.entry.runtime.executes_inline()).then(|| {
 				SsrRetrySequenceGuard {
-					entry: Rc::downgrade(&self.inner.entry),
-					completion_generation: generation.unwrap_or_default(),
-					armed: generation.is_some(),
+					lease: Rc::downgrade(&lease),
+					armed: lease.generation.get().is_some(),
 				}
 			}),
+			lease,
 		}
 		.await
 	}

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -55,6 +55,14 @@ where
 
 pub(crate) trait QueryRuntime {
 	fn now_ms(&self) -> u64;
+
+	fn jitter_sample(&self) -> u64 {
+		let mut bytes = [0_u8; 8];
+		getrandom::fill(&mut bytes)
+			.expect("query retry jitter requires an operating-system random source");
+		u64::from_le_bytes(bytes)
+	}
+
 	fn spawn(&self, task: QueryTask);
 
 	fn register_maintenance(&self, _callback: Weak<dyn Fn()>) {}
@@ -115,6 +123,7 @@ pub(crate) struct TestQueryRuntime {
 #[cfg(all(test, not(wasm)))]
 struct TestQueryRuntimeInner {
 	now_ms: Cell<u64>,
+	jitter_samples: RefCell<VecDeque<u64>>,
 	tasks: RefCell<VecDeque<QueryTask>>,
 	maintenance: RefCell<Vec<Weak<dyn Fn()>>>,
 }
@@ -125,10 +134,17 @@ impl TestQueryRuntime {
 		Self {
 			inner: Rc::new(TestQueryRuntimeInner {
 				now_ms: Cell::new(0),
+				jitter_samples: RefCell::new(VecDeque::new()),
 				tasks: RefCell::new(VecDeque::new()),
 				maintenance: RefCell::new(Vec::new()),
 			}),
 		}
+	}
+
+	pub(crate) fn with_jitter_samples(samples: impl IntoIterator<Item = u64>) -> Self {
+		let runtime = Self::new();
+		runtime.inner.jitter_samples.borrow_mut().extend(samples);
+		runtime
 	}
 
 	pub(crate) fn clock(&self) -> QueryRuntimeHandle {
@@ -195,6 +211,13 @@ impl TestQueryRuntime {
 impl QueryRuntime for TestQueryRuntimeInner {
 	fn now_ms(&self) -> u64 {
 		self.now_ms.get()
+	}
+
+	fn jitter_sample(&self) -> u64 {
+		self.jitter_samples
+			.borrow_mut()
+			.pop_front()
+			.expect("TestQueryRuntime exhausted its configured query retry jitter samples")
 	}
 
 	fn spawn(&self, task: QueryTask) {

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -78,6 +78,10 @@ pub(crate) trait QueryRuntime {
 		false
 	}
 
+	fn uses_external_maintenance(&self) -> bool {
+		false
+	}
+
 	#[cfg(native)]
 	fn retry_wait(&self, delay: Duration) -> QueryTask {
 		Box::pin(async move { tokio::time::sleep(delay).await })
@@ -130,21 +134,31 @@ pub(crate) struct TestQueryRuntime {
 
 #[cfg(all(test, not(wasm)))]
 struct TestQueryRuntimeInner {
-	now_ms: Cell<u64>,
+	now_ms: Rc<Cell<u64>>,
 	jitter_samples: RefCell<VecDeque<u64>>,
 	tasks: RefCell<VecDeque<QueryTask>>,
 	maintenance: RefCell<Vec<Weak<dyn Fn()>>>,
+	uses_external_maintenance: bool,
 }
 
 #[cfg(all(test, not(wasm)))]
 impl TestQueryRuntime {
 	pub(crate) fn new() -> Self {
+		Self::new_with_external_maintenance(true)
+	}
+
+	pub(crate) fn without_external_maintenance() -> Self {
+		Self::new_with_external_maintenance(false)
+	}
+
+	fn new_with_external_maintenance(uses_external_maintenance: bool) -> Self {
 		Self {
 			inner: Rc::new(TestQueryRuntimeInner {
-				now_ms: Cell::new(0),
+				now_ms: Rc::new(Cell::new(0)),
 				jitter_samples: RefCell::new(VecDeque::new()),
 				tasks: RefCell::new(VecDeque::new()),
 				maintenance: RefCell::new(Vec::new()),
+				uses_external_maintenance,
 			}),
 		}
 	}
@@ -233,7 +247,23 @@ impl QueryRuntime for TestQueryRuntimeInner {
 	}
 
 	fn register_maintenance(&self, callback: Weak<dyn Fn()>) {
-		self.maintenance.borrow_mut().push(callback);
+		if self.uses_external_maintenance {
+			self.maintenance.borrow_mut().push(callback);
+		}
+	}
+
+	fn uses_external_maintenance(&self) -> bool {
+		self.uses_external_maintenance
+	}
+
+	fn retry_wait(&self, delay: Duration) -> QueryTask {
+		let now_ms = Rc::clone(&self.now_ms);
+		let due_ms = now_ms.get().saturating_add(duration_ms(delay));
+		Box::pin(std::future::poll_fn(move |_| {
+			(now_ms.get() >= due_ms)
+				.then_some(())
+				.map_or(Poll::Pending, Poll::Ready)
+		}))
 	}
 }
 
@@ -1010,16 +1040,15 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 	}
 
 	fn active_completion_generation(&self) -> Option<u64> {
-		let sequence_generation = self
+		let request_generation = self
 			.request
 			.borrow()
 			.as_ref()
-			.map(|request| request.sequence_generation)?;
-		self.retry
-			.borrow()
-			.as_ref()
-			.filter(|retry| retry.generation == sequence_generation)
-			.map(|retry| retry.completion_generation)
+			.map(|request| request.sequence_generation);
+		self.retry.borrow().as_ref().and_then(|retry| {
+			(request_generation.is_none_or(|generation| retry.generation == generation))
+				.then_some(retry.completion_generation)
+		})
 	}
 
 	fn clear_retry_sequence(&self) {
@@ -1653,6 +1682,22 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 					entry.handle_retry_deadline_at(sequence_generation, due_ms);
 				}));
 			}
+			return;
+		}
+		#[cfg(native)]
+		if !self.runtime.uses_external_maintenance()
+			&& let Some(due_ms) = due_ms
+		{
+			let wait = self
+				.runtime
+				.retry_wait(Duration::from_millis(due_ms.saturating_sub(now_ms)));
+			let entry = Rc::downgrade(self);
+			self.runtime.spawn(Box::pin(async move {
+				wait.await;
+				if let Some(entry) = entry.upgrade() {
+					entry.handle_retry_deadline_at(sequence_generation, due_ms);
+				}
+			}));
 			return;
 		}
 		if let Some(owner) = self.owner.as_ref().and_then(Weak::upgrade) {

--- a/crates/reinhardt-pages/src/reactive/query/hook.rs
+++ b/crates/reinhardt-pages/src/reactive/query/hook.rs
@@ -9,6 +9,7 @@ use super::client::{
 };
 use super::context::queries;
 use super::identity::QueryDescriptor;
+use super::retry::QueryRetryConfig;
 #[cfg(native)]
 use super::state::{QueryHydrationSnapshot, QueryHydrationState};
 use super::state::{QueryOptions, QuerySnapshot, QueryStatus};
@@ -136,25 +137,27 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryHandle<T, E> {
 }
 
 /// Creates or subscribes to an app-wide keyed query.
-pub fn use_query<T, E>(
+pub fn use_query<T, E, R>(
 	descriptor: QueryDescriptor<T, E>,
-	options: QueryOptions,
+	options: QueryOptions<R>,
 ) -> QueryHandle<T, E>
 where
 	T: Clone + Serialize + DeserializeOwned + 'static,
 	E: Clone + Serialize + DeserializeOwned + 'static,
+	R: QueryRetryConfig<E>,
 {
 	queries().observe(descriptor, options)
 }
 
-pub(super) fn observe_query<T, E>(
+pub(super) fn observe_query<T, E, R>(
 	client: &QueryClient,
 	descriptor: QueryDescriptor<T, E>,
-	options: QueryOptions,
+	options: QueryOptions<R>,
 ) -> QueryHandle<T, E>
 where
 	T: Clone + Serialize + DeserializeOwned + 'static,
 	E: Clone + Serialize + DeserializeOwned + 'static,
+	R: QueryRetryConfig<E>,
 {
 	#[cfg(wasm)]
 	if let Ok(hydration) = crate::hydration::HydrationContext::from_window() {

--- a/crates/reinhardt-pages/src/reactive/query/hook.rs
+++ b/crates/reinhardt-pages/src/reactive/query/hook.rs
@@ -137,14 +137,13 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryHandle<T, E> {
 }
 
 /// Creates or subscribes to an app-wide keyed query.
-pub fn use_query<T, E, R>(
+pub fn use_query<T, E>(
 	descriptor: QueryDescriptor<T, E>,
-	options: QueryOptions<R>,
+	options: QueryOptions<impl QueryRetryConfig<E>>,
 ) -> QueryHandle<T, E>
 where
 	T: Clone + Serialize + DeserializeOwned + 'static,
 	E: Clone + Serialize + DeserializeOwned + 'static,
-	R: QueryRetryConfig<E>,
 {
 	queries().observe(descriptor, options)
 }

--- a/crates/reinhardt-pages/src/reactive/query/retry.rs
+++ b/crates/reinhardt-pages/src/reactive/query/retry.rs
@@ -82,6 +82,29 @@ impl<E> RetryPolicy<E> {
 			self.base_delay,
 		);
 	}
+
+	pub(crate) fn delay_ms(&self, failed_attempt: u32, sample: u64) -> u64 {
+		assert!(
+			failed_attempt > 0,
+			"query retry failed_attempt must be greater than 0"
+		);
+		let exponent = failed_attempt.saturating_sub(1).min(127);
+		let multiplier = 1_u128.checked_shl(exponent).unwrap_or(u128::MAX);
+		let nominal = self
+			.base_delay
+			.as_millis()
+			.saturating_mul(multiplier)
+			.min(self.max_delay.as_millis())
+			.min(u128::from(u64::MAX)) as u64;
+		if !self.jitter {
+			return nominal;
+		}
+		let floor = nominal / 2;
+		let spread = nominal - floor;
+		let range = u128::from(spread) + 1;
+		let offset = ((u128::from(sample) * range) >> 64) as u64;
+		floor.saturating_add(offset).min(nominal)
+	}
 }
 
 impl<E> fmt::Debug for RetryPolicy<E> {
@@ -172,5 +195,37 @@ mod tests {
 			format!("{policy:?}"),
 			"RetryPolicy { max_attempts: 3, base_delay: 250ms, max_delay: 5s, jitter: false, when: \"<predicate>\" }",
 		);
+	}
+
+	#[test]
+	fn retry_policy_caps_exponential_delay() {
+		let policy = RetryPolicy::<()>::exponential()
+			.base_delay(Duration::from_millis(100))
+			.max_delay(Duration::from_millis(500));
+
+		for (attempt, expected_ms) in [(1, 100), (2, 200), (3, 400), (4, 500)] {
+			assert_eq!(policy.delay_ms(attempt, 0), expected_ms);
+		}
+	}
+
+	#[test]
+	fn retry_policy_projects_equal_jitter_from_the_supplied_sample() {
+		let policy = RetryPolicy::<()>::exponential()
+			.base_delay(Duration::from_millis(100))
+			.max_delay(Duration::from_millis(100))
+			.jitter(true);
+
+		for (sample, expected_ms) in [(0, 50), (u64::MAX / 2, 75), (u64::MAX, 100)] {
+			assert_eq!(policy.delay_ms(1, sample), expected_ms);
+		}
+	}
+
+	#[test]
+	fn retry_policy_saturates_duration_and_attempt_overflow() {
+		let policy = RetryPolicy::<()>::exponential()
+			.base_delay(Duration::MAX)
+			.max_delay(Duration::MAX);
+
+		assert_eq!(policy.delay_ms(u32::MAX, 0), u64::MAX);
 	}
 }

--- a/crates/reinhardt-pages/src/reactive/query/retry.rs
+++ b/crates/reinhardt-pages/src/reactive/query/retry.rs
@@ -180,7 +180,8 @@ impl<E> RetryPolicy<E> {
 	/// Sets the initial delay used by exponential backoff.
 	///
 	/// A zero duration is valid. The policy is rejected when it is installed if
-	/// this delay is greater than the maximum delay.
+	/// this delay is greater than the maximum delay. Positive delays below one
+	/// millisecond are scaled before being rounded up for the scheduler.
 	pub fn base_delay(mut self, value: Duration) -> Self {
 		self.base_delay = value;
 		self
@@ -235,11 +236,15 @@ impl<E> RetryPolicy<E> {
 		);
 		let exponent = failed_attempt.saturating_sub(1).min(127);
 		let multiplier = 1_u128.checked_shl(exponent).unwrap_or(u128::MAX);
-		let nominal = self
+		let nominal_nanos = self
 			.base_delay
-			.as_millis()
+			.as_nanos()
 			.saturating_mul(multiplier)
-			.min(self.max_delay.as_millis())
+			.min(self.max_delay.as_nanos());
+		let nominal = nominal_nanos
+			.saturating_add(999_999)
+			.checked_div(1_000_000)
+			.unwrap_or_default()
 			.min(u128::from(u64::MAX)) as u64;
 		if !self.jitter {
 			return nominal;
@@ -349,6 +354,17 @@ mod tests {
 			.max_delay(Duration::from_millis(500));
 
 		for (attempt, expected_ms) in [(1, 100), (2, 200), (3, 400), (4, 500)] {
+			assert_eq!(policy.delay_ms(attempt, 0), expected_ms);
+		}
+	}
+
+	#[test]
+	fn retry_policy_scales_sub_millisecond_delays_before_rounding_up() {
+		let policy = RetryPolicy::<()>::exponential()
+			.base_delay(Duration::from_micros(500))
+			.max_delay(Duration::from_millis(2));
+
+		for (attempt, expected_ms) in [(1, 1), (2, 1), (3, 2), (4, 2)] {
 			assert_eq!(policy.delay_ms(attempt, 0), expected_ms);
 		}
 	}

--- a/crates/reinhardt-pages/src/reactive/query/retry.rs
+++ b/crates/reinhardt-pages/src/reactive/query/retry.rs
@@ -1,6 +1,125 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 use std::time::Duration;
+
+pub(crate) type ObserverRegistrationId = u64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RetryWaitClock {
+	Visible { failed_at_ms: u64 },
+	Paused { visible_elapsed_ms: u64 },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RetryCandidate {
+	pub(crate) delay_ms: u64,
+}
+
+pub(crate) struct RetrySequence<E> {
+	pub(crate) generation: u64,
+	pub(crate) completion_generation: u64,
+	pub(crate) attempts_started: u32,
+	pub(crate) last_error: Option<E>,
+	pub(crate) jitter_sample: Option<u64>,
+	pub(crate) candidates: HashMap<ObserverRegistrationId, RetryCandidate>,
+	pub(crate) wait_clock: Option<RetryWaitClock>,
+	pub(crate) manual_observer_id: Option<ObserverRegistrationId>,
+	pub(crate) had_success: bool,
+	pub(crate) invalidation_generation: u64,
+}
+
+impl<E> RetrySequence<E> {
+	pub(crate) fn new(
+		generation: u64,
+		completion_generation: u64,
+		manual_observer_id: Option<ObserverRegistrationId>,
+		had_success: bool,
+		invalidation_generation: u64,
+	) -> Self {
+		Self {
+			generation,
+			completion_generation,
+			attempts_started: 0,
+			last_error: None,
+			jitter_sample: None,
+			candidates: HashMap::new(),
+			wait_clock: None,
+			manual_observer_id,
+			had_success,
+			invalidation_generation,
+		}
+	}
+
+	pub(crate) fn record_attempt_started(&mut self) -> u32 {
+		self.clear_failure();
+		self.attempts_started = self.attempts_started.saturating_add(1);
+		self.attempts_started
+	}
+
+	pub(crate) fn record_failure(
+		&mut self,
+		error: E,
+		failed_at_ms: u64,
+		jitter_sample: Option<u64>,
+		candidates: HashMap<ObserverRegistrationId, RetryCandidate>,
+	) {
+		self.last_error = Some(error);
+		self.jitter_sample = jitter_sample;
+		self.candidates = candidates;
+		self.wait_clock = Some(RetryWaitClock::Visible { failed_at_ms });
+	}
+
+	pub(crate) fn candidate_due_ms(
+		&self,
+		observer_id: ObserverRegistrationId,
+		now_ms: u64,
+	) -> Option<u64> {
+		let delay_ms = self.candidates.get(&observer_id)?.delay_ms;
+		match self.wait_clock? {
+			RetryWaitClock::Visible { failed_at_ms } => Some(failed_at_ms.saturating_add(delay_ms)),
+			RetryWaitClock::Paused { visible_elapsed_ms } => {
+				Some(now_ms.saturating_add(delay_ms.saturating_sub(visible_elapsed_ms)))
+			}
+		}
+	}
+
+	pub(crate) fn earliest_due_ms(&self, now_ms: u64) -> Option<u64> {
+		self.candidates
+			.keys()
+			.filter_map(|observer_id| self.candidate_due_ms(*observer_id, now_ms))
+			.min()
+	}
+
+	// Browser visibility integration is assigned to a later task, but these
+	// transitions are part of the stable retry-sequence interface.
+	#[allow(dead_code)]
+	pub(crate) fn pause(&mut self, now_ms: u64) {
+		if let Some(RetryWaitClock::Visible { failed_at_ms }) = self.wait_clock {
+			self.wait_clock = Some(RetryWaitClock::Paused {
+				visible_elapsed_ms: now_ms.saturating_sub(failed_at_ms),
+			});
+		}
+	}
+
+	// Browser visibility integration is assigned to a later task, but these
+	// transitions are part of the stable retry-sequence interface.
+	#[allow(dead_code)]
+	pub(crate) fn resume(&mut self, now_ms: u64) {
+		if let Some(RetryWaitClock::Paused { visible_elapsed_ms }) = self.wait_clock {
+			self.wait_clock = Some(RetryWaitClock::Visible {
+				failed_at_ms: now_ms.saturating_sub(visible_elapsed_ms),
+			});
+		}
+	}
+
+	pub(crate) fn clear_failure(&mut self) {
+		self.last_error = None;
+		self.jitter_sample = None;
+		self.candidates.clear();
+		self.wait_clock = None;
+	}
+}
 
 /// A marker that disables retry behavior for a query observer.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/reinhardt-pages/src/reactive/query/retry.rs
+++ b/crates/reinhardt-pages/src/reactive/query/retry.rs
@@ -253,7 +253,8 @@ impl<E> RetryPolicy<E> {
 		let spread = nominal - floor;
 		let range = u128::from(spread) + 1;
 		let offset = ((u128::from(sample) * range) >> 64) as u64;
-		floor.saturating_add(offset).min(nominal)
+		let jittered = floor.saturating_add(offset).min(nominal);
+		if nominal == 0 { 0 } else { jittered.max(1) }
 	}
 }
 
@@ -379,6 +380,16 @@ mod tests {
 		for (sample, expected_ms) in [(0, 50), (u64::MAX / 2, 75), (u64::MAX, 100)] {
 			assert_eq!(policy.delay_ms(1, sample), expected_ms);
 		}
+	}
+
+	#[test]
+	fn retry_policy_keeps_positive_jittered_delays_above_zero() {
+		let policy = RetryPolicy::<()>::exponential()
+			.base_delay(Duration::from_micros(500))
+			.max_delay(Duration::from_micros(500))
+			.jitter(true);
+
+		assert_eq!(policy.delay_ms(1, 0), 1);
 	}
 
 	#[test]

--- a/crates/reinhardt-pages/src/reactive/query/retry.rs
+++ b/crates/reinhardt-pages/src/reactive/query/retry.rs
@@ -1,0 +1,176 @@
+use std::fmt;
+use std::rc::Rc;
+use std::time::Duration;
+
+/// A marker that disables retry behavior for a query observer.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct NoRetry;
+
+/// Configures exponential retry behavior for a query observer.
+pub struct RetryPolicy<E> {
+	pub(crate) max_attempts: u32,
+	pub(crate) base_delay: Duration,
+	pub(crate) max_delay: Duration,
+	pub(crate) jitter: bool,
+	pub(crate) when: Rc<dyn Fn(&E) -> bool>,
+}
+
+impl<E> Clone for RetryPolicy<E> {
+	fn clone(&self) -> Self {
+		Self {
+			max_attempts: self.max_attempts,
+			base_delay: self.base_delay,
+			max_delay: self.max_delay,
+			jitter: self.jitter,
+			when: Rc::clone(&self.when),
+		}
+	}
+}
+
+impl<E> RetryPolicy<E> {
+	/// Creates a policy with standard exponential retry defaults.
+	pub fn exponential() -> Self {
+		Self {
+			max_attempts: 3,
+			base_delay: Duration::from_millis(250),
+			max_delay: Duration::from_secs(5),
+			jitter: false,
+			when: Rc::new(|_| true),
+		}
+	}
+
+	/// Sets the maximum number of retry attempts.
+	pub fn max_attempts(mut self, value: u32) -> Self {
+		self.max_attempts = value;
+		self
+	}
+
+	/// Sets the initial delay used by exponential backoff.
+	pub fn base_delay(mut self, value: Duration) -> Self {
+		self.base_delay = value;
+		self
+	}
+
+	/// Sets the maximum delay used by exponential backoff.
+	pub fn max_delay(mut self, value: Duration) -> Self {
+		self.max_delay = value;
+		self
+	}
+
+	/// Enables or disables random jitter for retry delays.
+	pub fn jitter(mut self, value: bool) -> Self {
+		self.jitter = value;
+		self
+	}
+
+	/// Sets the predicate that selects errors eligible for retry.
+	pub fn when(mut self, value: impl Fn(&E) -> bool + 'static) -> Self {
+		self.when = Rc::new(value);
+		self
+	}
+
+	pub(crate) fn validate(&self) {
+		assert!(
+			self.max_attempts > 0,
+			"RetryPolicy.max_attempts must be greater than 0, got {}",
+			self.max_attempts,
+		);
+		assert!(
+			self.max_delay >= self.base_delay,
+			"RetryPolicy.max_delay ({:?}) must be greater than or equal to base_delay ({:?})",
+			self.max_delay,
+			self.base_delay,
+		);
+	}
+}
+
+impl<E> fmt::Debug for RetryPolicy<E> {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		formatter
+			.debug_struct("RetryPolicy")
+			.field("max_attempts", &self.max_attempts)
+			.field("base_delay", &self.base_delay)
+			.field("max_delay", &self.max_delay)
+			.field("jitter", &self.jitter)
+			.field("when", &"<predicate>")
+			.finish()
+	}
+}
+
+mod private {
+	pub trait Sealed {}
+}
+
+/// Internal retry-state adapter used to associate policy error types with query errors.
+#[doc(hidden)]
+pub trait QueryRetryConfig<E>: private::Sealed + Clone + 'static {
+	/// Returns the installed retry policy, when retries are enabled.
+	fn retry_policy(&self) -> Option<&RetryPolicy<E>>;
+}
+
+impl private::Sealed for NoRetry {}
+
+impl<E> QueryRetryConfig<E> for NoRetry {
+	fn retry_policy(&self) -> Option<&RetryPolicy<E>> {
+		None
+	}
+}
+
+impl<E> private::Sealed for RetryPolicy<E> {}
+
+impl<E: 'static> QueryRetryConfig<E> for RetryPolicy<E> {
+	fn retry_policy(&self) -> Option<&RetryPolicy<E>> {
+		Some(self)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::RetryPolicy;
+	use crate::reactive::query::QueryOptions;
+	use std::time::Duration;
+
+	#[test]
+	#[should_panic(expected = "RetryPolicy.max_attempts must be greater than 0, got 0")]
+	fn retry_policy_rejects_zero_max_attempts() {
+		let _ = QueryOptions::new().retry(RetryPolicy::<()>::exponential().max_attempts(0));
+	}
+
+	#[test]
+	#[should_panic(
+		expected = "RetryPolicy.max_delay (1s) must be greater than or equal to base_delay (2s)"
+	)]
+	fn retry_policy_rejects_max_delay_before_base_delay() {
+		let _ = QueryOptions::new().retry(
+			RetryPolicy::<()>::exponential()
+				.base_delay(Duration::from_secs(2))
+				.max_delay(Duration::from_secs(1)),
+		);
+	}
+
+	#[test]
+	fn retry_policy_accepts_zero_delays() {
+		let _: QueryOptions<RetryPolicy<()>> = QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.base_delay(Duration::ZERO)
+				.max_delay(Duration::ZERO),
+		);
+	}
+
+	#[test]
+	fn retry_policy_clone_retains_its_predicate() {
+		let policy = RetryPolicy::<u8>::exponential().when(|value| *value == 7);
+
+		assert!((policy.clone().when)(&7));
+	}
+
+	#[test]
+	fn retry_policy_debug_redacts_its_predicate() {
+		let policy = RetryPolicy::<()>::exponential();
+
+		assert_eq!(
+			format!("{policy:?}"),
+			"RetryPolicy { max_attempts: 3, base_delay: 250ms, max_delay: 5s, jitter: false, when: \"<predicate>\" }",
+		);
+	}
+}

--- a/crates/reinhardt-pages/src/reactive/query/retry.rs
+++ b/crates/reinhardt-pages/src/reactive/query/retry.rs
@@ -126,6 +126,11 @@ impl<E> RetrySequence<E> {
 pub struct NoRetry;
 
 /// Configures exponential retry behavior for a query observer.
+///
+/// A policy belongs to an observer, while attempts and intermediate failures
+/// are coordinated by the shared cache entry. The predicate is stored as a
+/// typed `Fn(&E) -> bool`, so policies and [`QueryOptions`](super::QueryOptions)
+/// that contain them implement `Clone` and `Debug`, but not equality.
 pub struct RetryPolicy<E> {
 	pub(crate) max_attempts: u32,
 	pub(crate) base_delay: Duration,
@@ -148,6 +153,11 @@ impl<E> Clone for RetryPolicy<E> {
 
 impl<E> RetryPolicy<E> {
 	/// Creates a policy with standard exponential retry defaults.
+	///
+	/// The defaults allow three total attempts, including the initial request,
+	/// start at 250 milliseconds, cap the nominal delay at five seconds, disable
+	/// jitter, and accept every error. Zero-delay policies are also valid when
+	/// configured explicitly.
 	pub fn exponential() -> Self {
 		Self {
 			max_attempts: 3,
@@ -158,31 +168,47 @@ impl<E> RetryPolicy<E> {
 		}
 	}
 
-	/// Sets the maximum number of retry attempts.
+	/// Sets the maximum number of total attempts, including the initial request.
+	///
+	/// A zero value is rejected when the policy is installed with
+	/// [`QueryOptions::retry`](super::QueryOptions::retry).
 	pub fn max_attempts(mut self, value: u32) -> Self {
 		self.max_attempts = value;
 		self
 	}
 
 	/// Sets the initial delay used by exponential backoff.
+	///
+	/// A zero duration is valid. The policy is rejected when it is installed if
+	/// this delay is greater than the maximum delay.
 	pub fn base_delay(mut self, value: Duration) -> Self {
 		self.base_delay = value;
 		self
 	}
 
-	/// Sets the maximum delay used by exponential backoff.
+	/// Sets the maximum nominal delay used by exponential backoff.
+	///
+	/// The policy is rejected when it is installed if this delay is less than
+	/// the base delay.
 	pub fn max_delay(mut self, value: Duration) -> Self {
 		self.max_delay = value;
 		self
 	}
 
-	/// Enables or disables random jitter for retry delays.
+	/// Enables or disables equal jitter for retry delays.
+	///
+	/// Equal jitter chooses a delay from half the nominal delay through the full
+	/// nominal delay, so it never exceeds the configured exponential backoff.
 	pub fn jitter(mut self, value: bool) -> Self {
 		self.jitter = value;
 		self
 	}
 
-	/// Sets the predicate that selects errors eligible for retry.
+	/// Sets the typed predicate that selects errors eligible for retry.
+	///
+	/// The predicate receives a shared reference to the attempt error and must
+	/// be `'static`. Returning `false` makes that observer ineligible for another
+	/// attempt.
 	pub fn when(mut self, value: impl Fn(&E) -> bool + 'static) -> Self {
 		self.when = Rc::new(value);
 		self

--- a/crates/reinhardt-pages/src/reactive/query/retry.rs
+++ b/crates/reinhardt-pages/src/reactive/query/retry.rs
@@ -221,6 +221,17 @@ mod tests {
 	}
 
 	#[test]
+	fn retry_policy_ignores_samples_when_jitter_is_disabled() {
+		let policy = RetryPolicy::<()>::exponential()
+			.base_delay(Duration::from_millis(100))
+			.max_delay(Duration::from_millis(100));
+
+		for sample in [0, u64::MAX / 2, u64::MAX] {
+			assert_eq!(policy.delay_ms(1, sample), 100);
+		}
+	}
+
+	#[test]
 	fn retry_policy_saturates_duration_and_attempt_overflow() {
 		let policy = RetryPolicy::<()>::exponential()
 			.base_delay(Duration::MAX)

--- a/crates/reinhardt-pages/src/reactive/query/state.rs
+++ b/crates/reinhardt-pages/src/reactive/query/state.rs
@@ -59,6 +59,10 @@ impl Default for QueryDefaults {
 }
 
 /// Per-observer query behavior.
+///
+/// The retry type is [`NoRetry`] until [`QueryOptions::retry`] installs a typed
+/// [`RetryPolicy`]. Because retry predicates are closures, options that contain
+/// a retry policy do not implement equality.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct QueryOptions<R = NoRetry> {
 	enabled: bool,
@@ -75,6 +79,14 @@ impl QueryOptions<NoRetry> {
 	}
 
 	/// Installs a typed retry policy for this observer.
+	///
+	/// The policy error type must match the descriptor error type when the
+	/// options are passed to `use_query`.
+	///
+	/// # Panics
+	///
+	/// Panics if `max_attempts` is zero or `max_delay` is less than
+	/// `base_delay`. Zero delay values are valid when both bounds are ordered.
 	pub fn retry<E>(self, retry: RetryPolicy<E>) -> QueryOptions<RetryPolicy<E>> {
 		retry.validate();
 		QueryOptions {
@@ -166,11 +178,19 @@ pub struct QuerySnapshot<T, E> {
 	pub status: QueryStatus,
 	/// Latest successfully fetched data.
 	pub data: Option<T>,
-	/// Initial fetch error when no data is available.
+	/// Terminal initial-fetch error when no data is available.
+	///
+	/// Intermediate attempt errors remain private and this stays `None` during
+	/// retry backoff.
 	pub error: Option<E>,
-	/// Error from a background fetch that preserved existing data.
+	/// Terminal background-fetch error that preserved existing data.
+	///
+	/// Intermediate attempt errors remain private and this stays `None` until
+	/// the retry sequence is exhausted.
 	pub refetch_error: Option<E>,
-	/// Whether this query currently has a request in flight.
+	/// Whether this query currently has a fetch attempt in flight.
+	///
+	/// This is `false` while a retry sequence is waiting in backoff.
 	pub is_fetching: bool,
 	/// Whether this observer considers the cached state stale.
 	pub is_stale: bool,

--- a/crates/reinhardt-pages/src/reactive/query/state.rs
+++ b/crates/reinhardt-pages/src/reactive/query/state.rs
@@ -38,6 +38,10 @@ impl QueryDefaults {
 		self.gc_time
 	}
 
+	// Only `ssr::renderer` (native-only, see `ssr.rs`'s `#[cfg(native)] mod renderer;`)
+	// calls this setter; gate it the same way so wasm32 builds don't flag it as
+	// dead code.
+	#[cfg(native)]
 	pub(crate) fn with_ssr_query_retries(mut self, enabled: bool) -> Self {
 		self.ssr_query_retries = enabled;
 		self

--- a/crates/reinhardt-pages/src/reactive/query/state.rs
+++ b/crates/reinhardt-pages/src/reactive/query/state.rs
@@ -2,6 +2,8 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
+use super::retry::{NoRetry, RetryPolicy};
+
 /// Application-wide defaults used to resolve query observer options.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct QueryDefaults {
@@ -47,19 +49,34 @@ impl Default for QueryDefaults {
 
 /// Per-observer query behavior.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct QueryOptions {
+pub struct QueryOptions<R = NoRetry> {
 	enabled: bool,
 	stale_time: Option<Duration>,
 	gc_time: Option<Duration>,
 	refetch_interval: Option<Duration>,
+	retry: R,
 }
 
-impl QueryOptions {
+impl QueryOptions<NoRetry> {
 	/// Creates the standard enabled query options.
 	pub fn new() -> Self {
 		Self::default()
 	}
 
+	/// Installs a typed retry policy for this observer.
+	pub fn retry<E>(self, retry: RetryPolicy<E>) -> QueryOptions<RetryPolicy<E>> {
+		retry.validate();
+		QueryOptions {
+			enabled: self.enabled,
+			stale_time: self.stale_time,
+			gc_time: self.gc_time,
+			refetch_interval: self.refetch_interval,
+			retry,
+		}
+	}
+}
+
+impl<R> QueryOptions<R> {
 	/// Enables or disables fetching for this observer.
 	pub fn enabled(mut self, enabled: bool) -> Self {
 		self.enabled = enabled;
@@ -100,15 +117,20 @@ impl QueryOptions {
 	pub(crate) fn refetch_interval_value(&self) -> Option<Duration> {
 		self.refetch_interval
 	}
+
+	pub(crate) fn retry_state(&self) -> &R {
+		&self.retry
+	}
 }
 
-impl Default for QueryOptions {
+impl Default for QueryOptions<NoRetry> {
 	fn default() -> Self {
 		Self {
 			enabled: true,
 			stale_time: None,
 			gc_time: None,
 			refetch_interval: None,
+			retry: NoRetry,
 		}
 	}
 }

--- a/crates/reinhardt-pages/src/reactive/query/state.rs
+++ b/crates/reinhardt-pages/src/reactive/query/state.rs
@@ -9,6 +9,7 @@ use super::retry::{NoRetry, RetryPolicy};
 pub struct QueryDefaults {
 	stale_time: Duration,
 	gc_time: Duration,
+	ssr_query_retries: bool,
 }
 
 impl QueryDefaults {
@@ -36,6 +37,15 @@ impl QueryDefaults {
 	pub(crate) fn resolved_gc_time(&self) -> Duration {
 		self.gc_time
 	}
+
+	pub(crate) fn with_ssr_query_retries(mut self, enabled: bool) -> Self {
+		self.ssr_query_retries = enabled;
+		self
+	}
+
+	pub(crate) fn ssr_query_retries_enabled(&self) -> bool {
+		self.ssr_query_retries
+	}
 }
 
 impl Default for QueryDefaults {
@@ -43,6 +53,7 @@ impl Default for QueryDefaults {
 		Self {
 			stale_time: Duration::from_secs(30),
 			gc_time: Duration::from_secs(300),
+			ssr_query_retries: false,
 		}
 	}
 }

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -334,6 +334,95 @@ fn query_retry_success_clears_the_sequence_without_publishing_the_initial_error(
 }
 
 #[test]
+fn native_runtime_drives_retry_without_browser_maintenance() {
+	let runtime = TestQueryRuntime::without_external_maintenance();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-native-runtime");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				let attempt = fetch_count.get() + 1;
+				fetch_count.set(attempt);
+				async move {
+					if attempt == 1 {
+						Err("temporary".to_string())
+					} else {
+						Ok("recovered".to_string())
+					}
+				}
+			}
+		}),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.base_delay(Duration::from_millis(10))
+				.max_delay(Duration::from_millis(10)),
+		),
+	);
+
+	runtime.run_until_stalled();
+	runtime.advance(Duration::from_millis(10));
+	runtime.run_until_stalled();
+
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(query.data(), Some("recovered".to_string()));
+}
+
+#[test]
+fn acquiring_during_background_retry_waits_for_shared_completion() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-backoff-acquisition");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move {
+				match attempt {
+					1 => Ok("cached".to_string()),
+					2 => Err("temporary".to_string()),
+					_ => Ok("fresh".to_string()),
+				}
+			}
+		}
+	});
+	let key = descriptor.key().clone();
+	let mounted = client.observe(
+		descriptor.clone(),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.base_delay(Duration::from_millis(10))
+				.max_delay(Duration::from_millis(10)),
+		),
+	);
+	runtime.run_until_stalled();
+	client.invalidate(&key);
+	runtime.run_until_stalled();
+
+	let lease = client.acquire(
+		descriptor,
+		QueryAcquireOptions {
+			consumer: QueryConsumer::Navigation(1),
+			error_policy: QueryErrorPolicy::Discard,
+		},
+	);
+	let mut result = Box::pin(lease.result());
+	let mut context = Context::from_waker(Waker::noop());
+
+	assert_eq!(mounted.data(), Some("cached".to_string()));
+	assert_eq!(result.as_mut().poll(&mut context), Poll::Pending);
+	runtime.advance(Duration::from_millis(10));
+	runtime.run_due_maintenance();
+	assert_eq!(
+		result.as_mut().poll(&mut context),
+		Poll::Ready(Ok("fresh".to_string()))
+	);
+}
+
+#[test]
 fn query_retry_single_observer_predicate_rejection_is_terminal() {
 	let runtime = TestQueryRuntime::new();
 	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -666,8 +666,26 @@ fn query_retry_earliest_deadline_moves_later_when_the_shorter_policy_drops() {
 	);
 	runtime.run_until_stalled();
 	runtime.advance(Duration::from_millis(50));
+	let stale_deadline_generation = faster
+		.entry
+		.retry
+		.borrow()
+		.as_ref()
+		.expect("the failed query must be waiting to retry")
+		.generation;
 
 	drop(faster);
+	assert_ne!(
+		slower
+			.entry
+			.retry
+			.borrow()
+			.as_ref()
+			.expect("the slower retry policy must remain eligible")
+			.generation,
+		stale_deadline_generation,
+		"removing the shortest policy must invalidate its queued deadline"
+	);
 	runtime.advance(Duration::from_millis(50));
 	runtime.run_due_maintenance();
 	assert_eq!(fetch_count.get(), 1);
@@ -1060,6 +1078,9 @@ fn query_retry_superseded_failure_stays_unpublished_and_retargets_waiters() {
 		},
 	);
 	runtime.run_until_stalled();
+	let mut result = Box::pin(lease.result());
+	let mut context = Context::from_waker(Waker::noop());
+	assert_eq!(result.as_mut().poll(&mut context), Poll::Pending);
 
 	let entry = Rc::clone(&lease.inner.entry);
 	entry.start_fetch(true);
@@ -1068,14 +1089,68 @@ fn query_retry_superseded_failure_stays_unpublished_and_retargets_waiters() {
 
 	assert_eq!(fetch_count.get(), 2);
 	assert_eq!(
-		tokio_test::block_on(lease.result()),
-		Ok("fresh".to_string())
+		result.as_mut().poll(&mut context),
+		Poll::Ready(Ok("fresh".to_string()))
 	);
 	assert_eq!(entry.refetch_error.get(), None);
 	assert!(matches!(
 		entry.state.with_untracked(|state| state.clone()),
 		ResourceState::Success(value) if value == "fresh"
 	));
+}
+
+#[test]
+fn dropping_a_retargeted_ssr_waiter_cancels_the_replacement_generation() {
+	let client = QueryClient::new_ssr(QueryDefaults::default());
+	let family = QueryFamily::<(), String, String>::new("tests.ssr-retargeted-waiter-drop");
+	let first_ready = Rc::new(Cell::new(false));
+	let second_ready = Rc::new(Cell::new(false));
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let first_ready = Rc::clone(&first_ready);
+		let second_ready = Rc::clone(&second_ready);
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			TestGate {
+				ready: if attempt == 1 {
+					Rc::clone(&first_ready)
+				} else {
+					Rc::clone(&second_ready)
+				},
+				dropped: Rc::new(Cell::new(0)),
+				result: Some(if attempt == 1 {
+					Err("obsolete".to_string())
+				} else {
+					Ok("fresh".to_string())
+				}),
+			}
+		}
+	});
+	let lease = client.acquire(
+		descriptor,
+		QueryAcquireOptions {
+			consumer: QueryConsumer::Navigation(1),
+			error_policy: QueryErrorPolicy::Discard,
+		},
+	);
+	let entry = Rc::clone(&lease.inner.entry);
+	let mut result = Box::pin(lease.result());
+	let mut context = Context::from_waker(Waker::noop());
+	assert_eq!(result.as_mut().poll(&mut context), Poll::Pending);
+	entry.start_fetch(true);
+
+	first_ready.set(true);
+	assert_eq!(result.as_mut().poll(&mut context), Poll::Pending);
+	assert_eq!(fetch_count.get(), 2);
+	assert!(entry.has_request());
+
+	drop(result);
+
+	assert!(!entry.has_request());
+	assert!(entry.retry.borrow().is_none());
+	assert!(!entry.is_fetching.get());
 }
 
 #[test]

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -470,6 +470,49 @@ fn query_retry_single_observer_predicate_rejection_is_terminal() {
 }
 
 #[test]
+fn query_retry_predicate_can_invalidate_the_same_key() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-predicate-invalidation");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move {
+				if attempt == 1 {
+					Err("stale".to_string())
+				} else {
+					Ok("fresh".to_string())
+				}
+			}
+		}
+	});
+	let key = descriptor.key().clone();
+	let client_for_predicate = client.clone();
+	let query = client.observe(
+		descriptor,
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::ZERO)
+				.max_delay(Duration::ZERO)
+				.when(move |_| {
+					client_for_predicate.invalidate(&key);
+					true
+				}),
+		),
+	);
+
+	runtime.run_until_stalled();
+
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(query.data(), Some("fresh".to_string()));
+	assert_eq!(query.error(), None);
+}
+
+#[test]
 fn query_retry_background_keeps_data_and_timestamp_until_terminal_failure() {
 	let runtime = TestQueryRuntime::new();
 	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -189,6 +189,255 @@ fn initial_failure_populates_query_error() {
 }
 
 #[test]
+fn query_retry_single_observer_waits_for_exponential_deadlines_and_publishes_only_terminal_error() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-single-observer-deadlines");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				let attempt = fetch_count.get() + 1;
+				fetch_count.set(attempt);
+				async move { Err(format!("attempt-{attempt}")) }
+			}
+		}),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(3)
+				.base_delay(Duration::from_millis(100))
+				.max_delay(Duration::from_secs(1)),
+		),
+	);
+
+	assert_eq!(query.snapshot().status, QueryStatus::Pending);
+	assert!(query.is_fetching());
+	runtime.run_until_stalled();
+
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(query.snapshot().status, QueryStatus::Pending);
+	assert_eq!(query.error(), None);
+	assert!(!query.is_fetching());
+	assert!(query.entry.completed.borrow().is_none());
+
+	runtime.advance(Duration::from_millis(99));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 1);
+
+	runtime.advance(Duration::from_millis(1));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(query.snapshot().status, QueryStatus::Pending);
+	assert_eq!(query.error(), None);
+	assert!(!query.is_fetching());
+	assert!(query.entry.completed.borrow().is_none());
+
+	runtime.advance(Duration::from_millis(199));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 2);
+
+	runtime.advance(Duration::from_millis(1));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 3);
+	assert_eq!(query.error(), Some("attempt-3".to_string()));
+	assert!(!query.is_fetching());
+	assert_eq!(query.entry.last_fetched_ms.get(), Some(300));
+	assert!(matches!(
+		query.entry.completed.borrow().as_ref(),
+		Some((_, Err(error))) if error == "attempt-3"
+	));
+}
+
+#[test]
+fn query_retry_single_observer_honors_total_attempt_limits() {
+	for (family_id, max_attempts) in [
+		("tests.retry-total-one", 1),
+		("tests.retry-total-two", 2),
+		("tests.retry-total-three", 3),
+	] {
+		let runtime = TestQueryRuntime::new();
+		let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+		let family = QueryFamily::<(), String, String>::new(family_id);
+		let fetch_count = Rc::new(Cell::new(0));
+		let query = client.observe(
+			family.query((), {
+				let fetch_count = Rc::clone(&fetch_count);
+				move || {
+					let attempt = fetch_count.get() + 1;
+					fetch_count.set(attempt);
+					async move { Err(format!("attempt-{attempt}")) }
+				}
+			}),
+			QueryOptions::new().retry(
+				RetryPolicy::exponential()
+					.max_attempts(max_attempts)
+					.base_delay(Duration::ZERO)
+					.max_delay(Duration::ZERO),
+			),
+		);
+
+		runtime.run_until_stalled();
+		for _ in 1..max_attempts {
+			runtime.run_due_maintenance();
+		}
+
+		assert_eq!(fetch_count.get(), max_attempts);
+		assert_eq!(query.error(), Some(format!("attempt-{max_attempts}")));
+	}
+}
+
+#[test]
+fn query_retry_success_clears_the_sequence_without_publishing_the_initial_error() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-success");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				let attempt = fetch_count.get() + 1;
+				fetch_count.set(attempt);
+				async move {
+					if attempt == 1 {
+						Err("temporary".to_string())
+					} else {
+						Ok("recovered".to_string())
+					}
+				}
+			}
+		}),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.base_delay(Duration::from_millis(100))
+				.max_delay(Duration::from_millis(100)),
+		),
+	);
+
+	runtime.run_until_stalled();
+	assert_eq!(query.snapshot().status, QueryStatus::Pending);
+	assert_eq!(query.error(), None);
+	assert!(query.entry.completed.borrow().is_none());
+
+	runtime.advance(Duration::from_millis(100));
+	runtime.run_due_maintenance();
+
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(query.data(), Some("recovered".to_string()));
+	assert_eq!(query.error(), None);
+	assert!(query.entry.retry.borrow().is_none());
+	assert!(matches!(
+		query.entry.completed.borrow().as_ref(),
+		Some((_, Ok(value))) if value == "recovered"
+	));
+}
+
+#[test]
+fn query_retry_single_observer_predicate_rejection_is_terminal() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-predicate-rejection");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				fetch_count.set(fetch_count.get() + 1);
+				async { Err("fatal".to_string()) }
+			}
+		}),
+		QueryOptions::new().retry(RetryPolicy::exponential().when(|error| error != "fatal")),
+	);
+
+	runtime.run_until_stalled();
+	runtime.advance(Duration::from_secs(10));
+	runtime.run_due_maintenance();
+
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(query.error(), Some("fatal".to_string()));
+}
+
+#[test]
+fn query_retry_background_keeps_data_and_timestamp_until_terminal_failure() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-background");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move {
+				if attempt == 1 {
+					Ok("cached".to_string())
+				} else {
+					Err(format!("attempt-{attempt}"))
+				}
+			}
+		}
+	});
+	let key = descriptor.key().clone();
+	let query = client.observe(
+		descriptor,
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_millis(100))
+				.max_delay(Duration::from_millis(100)),
+		),
+	);
+	runtime.run_until_stalled();
+	assert_eq!(query.entry.last_fetched_ms.get(), Some(0));
+
+	client.invalidate(&key);
+	runtime.run_until_stalled();
+
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(query.data(), Some("cached".to_string()));
+	assert_eq!(query.refetch_error(), None);
+	assert!(!query.is_fetching());
+	assert_eq!(query.entry.last_fetched_ms.get(), Some(0));
+
+	runtime.advance(Duration::from_millis(100));
+	runtime.run_due_maintenance();
+
+	assert_eq!(fetch_count.get(), 3);
+	assert_eq!(query.data(), Some("cached".to_string()));
+	assert_eq!(query.refetch_error(), Some("attempt-3".to_string()));
+	assert_eq!(query.entry.last_fetched_ms.get(), Some(0));
+}
+
+#[test]
+fn query_retry_default_policy_retries_every_error_three_total_times() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-default-all-errors");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				let attempt = fetch_count.get() + 1;
+				fetch_count.set(attempt);
+				async move { Err(format!("attempt-{attempt}")) }
+			}
+		}),
+		QueryOptions::new().retry(RetryPolicy::exponential()),
+	);
+
+	runtime.run_until_stalled();
+	runtime.advance(Duration::from_millis(250));
+	runtime.run_due_maintenance();
+	runtime.advance(Duration::from_millis(500));
+	runtime.run_due_maintenance();
+
+	assert_eq!(fetch_count.get(), 3);
+	assert_eq!(query.error(), Some("attempt-3".to_string()));
+}
+
+#[test]
 fn refetch_after_initial_error_transitions_through_pending() {
 	let runtime = TestQueryRuntime::new();
 	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
@@ -1461,7 +1710,7 @@ fn cancel_completion_race_does_not_publish_obsolete_value() {
 
 		// Act
 		drop(lease);
-		entry.complete_fetch(generation, Ok("obsolete".to_string()));
+		entry.complete_attempt(generation, Ok("obsolete".to_string()));
 		let completion = poll_one_task(&tasks);
 
 		// Assert
@@ -1816,6 +2065,7 @@ fn successful_query_is_not_pending_during_background_fetch() {
 			QueryErrorPolicy::Retain,
 			fetcher,
 			ObserverPolicy::resolve(&QueryOptions::default(), &QueryDefaults::default()),
+			None,
 		);
 		let query = QueryHandle { entry, lease };
 

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -438,6 +438,490 @@ fn query_retry_default_policy_retries_every_error_three_total_times() {
 }
 
 #[test]
+fn query_retry_earliest_observer_policy_selects_the_shortest_deadline() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-earliest-policy");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move { Err(format!("attempt-{attempt}")) }
+		}
+	});
+	let faster = client.observe(
+		descriptor.clone(),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_millis(100))
+				.max_delay(Duration::from_millis(100)),
+		),
+	);
+	let slower = client.observe(
+		descriptor,
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_millis(500))
+				.max_delay(Duration::from_millis(500)),
+		),
+	);
+
+	runtime.run_until_stalled();
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(slower.snapshot().status, QueryStatus::Pending);
+	assert_eq!(faster.error(), None);
+	assert_eq!(runtime.pending_task_count(), 0);
+
+	runtime.advance(Duration::from_millis(99));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(runtime.pending_task_count(), 0);
+
+	runtime.advance(Duration::from_millis(1));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(slower.error(), Some("attempt-2".to_string()));
+	assert_eq!(faster.error(), Some("attempt-2".to_string()));
+	assert_eq!(runtime.pending_task_count(), 0);
+}
+
+#[test]
+fn query_retry_observers_share_the_largest_total_attempt_limit() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-observer-attempt-limit");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move { Err(format!("attempt-{attempt}")) }
+		}
+	});
+	let two_attempts = client.observe(
+		descriptor.clone(),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::ZERO)
+				.max_delay(Duration::ZERO),
+		),
+	);
+	let four_attempts = client.observe(
+		descriptor,
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(4)
+				.base_delay(Duration::ZERO)
+				.max_delay(Duration::ZERO),
+		),
+	);
+
+	runtime.run_until_stalled();
+	assert_eq!(fetch_count.get(), 1);
+	for expected_attempts in 2..=4 {
+		runtime.run_due_maintenance();
+		assert_eq!(fetch_count.get(), expected_attempts);
+	}
+
+	assert_eq!(two_attempts.error(), Some("attempt-4".to_string()));
+	assert_eq!(four_attempts.error(), Some("attempt-4".to_string()));
+	assert_eq!(runtime.pending_task_count(), 0);
+}
+
+#[test]
+fn query_retry_observer_acceptance_overrides_another_observers_rejection() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-observer-predicates");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move { Err(format!("transient-{attempt}")) }
+		}
+	});
+	let rejecting = client.observe(
+		descriptor.clone(),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::ZERO)
+				.max_delay(Duration::ZERO)
+				.when(|_| false),
+		),
+	);
+	let accepting = client.observe(
+		descriptor,
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::ZERO)
+				.max_delay(Duration::ZERO)
+				.when(|error: &String| error.starts_with("transient-")),
+		),
+	);
+
+	runtime.run_until_stalled();
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(rejecting.error(), None);
+	assert_eq!(accepting.snapshot().status, QueryStatus::Pending);
+
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(rejecting.error(), Some("transient-2".to_string()));
+	assert_eq!(accepting.error(), Some("transient-2".to_string()));
+	assert_eq!(runtime.pending_task_count(), 0);
+}
+
+#[test]
+fn query_retry_earliest_deadline_moves_earlier_when_a_shorter_policy_mounts() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-earlier-policy-mount");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move { Err(format!("attempt-{attempt}")) }
+		}
+	});
+	let slower = client.observe(
+		descriptor.clone(),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_millis(500))
+				.max_delay(Duration::from_millis(500)),
+		),
+	);
+	runtime.run_until_stalled();
+	runtime.advance(Duration::from_millis(100));
+
+	let faster = client.observe(
+		descriptor,
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_millis(200))
+				.max_delay(Duration::from_millis(200)),
+		),
+	);
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(slower.error(), None);
+	assert_eq!(faster.snapshot().status, QueryStatus::Pending);
+	assert_eq!(runtime.pending_task_count(), 0);
+
+	runtime.advance(Duration::from_millis(99));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 1);
+
+	runtime.advance(Duration::from_millis(1));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(faster.error(), Some("attempt-2".to_string()));
+	assert_eq!(runtime.pending_task_count(), 0);
+}
+
+#[test]
+fn query_retry_earliest_deadline_moves_later_when_the_shorter_policy_drops() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-later-policy-drop");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move { Err(format!("attempt-{attempt}")) }
+		}
+	});
+	let faster = client.observe(
+		descriptor.clone(),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_millis(100))
+				.max_delay(Duration::from_millis(100)),
+		),
+	);
+	let slower = client.observe(
+		descriptor,
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_millis(500))
+				.max_delay(Duration::from_millis(500)),
+		),
+	);
+	runtime.run_until_stalled();
+	runtime.advance(Duration::from_millis(50));
+
+	drop(faster);
+	runtime.advance(Duration::from_millis(50));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(slower.snapshot().status, QueryStatus::Pending);
+	assert_eq!(runtime.pending_task_count(), 0);
+
+	runtime.advance(Duration::from_millis(400));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(slower.error(), Some("attempt-2".to_string()));
+	assert_eq!(runtime.pending_task_count(), 0);
+}
+
+#[test]
+fn query_retry_observer_drop_publishes_failure_when_a_non_retry_lease_remains() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-policy-drop-publishes");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			fetch_count.set(fetch_count.get() + 1);
+			async { Err("offline".to_string()) }
+		}
+	});
+	let retrying = client.observe(
+		descriptor.clone(),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_secs(1))
+				.max_delay(Duration::from_secs(1)),
+		),
+	);
+	let remaining = client.observe(descriptor, QueryOptions::default());
+	runtime.run_until_stalled();
+	assert_eq!(remaining.snapshot().status, QueryStatus::Pending);
+	assert_eq!(remaining.error(), None);
+
+	drop(retrying);
+
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(remaining.snapshot().status, QueryStatus::Error);
+	assert_eq!(remaining.error(), Some("offline".to_string()));
+	assert_eq!(runtime.pending_task_count(), 0);
+}
+
+#[test]
+fn query_retry_observer_final_drop_discards_the_waiting_failure() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-final-drop-discards");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				fetch_count.set(fetch_count.get() + 1);
+				async { Err("offline".to_string()) }
+			}
+		}),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_secs(1))
+				.max_delay(Duration::from_secs(1)),
+		),
+	);
+	runtime.run_until_stalled();
+	let entry = Rc::clone(&query.entry);
+	assert_eq!(query.snapshot().status, QueryStatus::Pending);
+	assert!(entry.completed.borrow().is_none());
+
+	drop(query);
+
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(
+		entry.state.with_untracked(|state| state.clone()),
+		ResourceState::Loading
+	);
+	assert!(entry.completed.borrow().is_none());
+	assert!(entry.retry.borrow().is_none());
+	assert_eq!(runtime.pending_task_count(), 0);
+}
+
+#[test]
+fn query_retry_disabled_observer_participates_only_in_its_manual_sequence() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-disabled-manual-only");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move { Err(format!("attempt-{attempt}")) }
+		}
+	});
+	let enabled = client.observe(descriptor.clone(), QueryOptions::default());
+	let disabled = client.observe(
+		descriptor,
+		QueryOptions::new().enabled(false).retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::ZERO)
+				.max_delay(Duration::ZERO),
+		),
+	);
+
+	runtime.run_until_stalled();
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(enabled.error(), Some("attempt-1".to_string()));
+	assert_eq!(disabled.snapshot().status, QueryStatus::Error);
+
+	disabled.refetch();
+	runtime.run_until_stalled();
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(disabled.snapshot().status, QueryStatus::Pending);
+	assert_eq!(disabled.error(), None);
+	runtime.run_due_maintenance();
+
+	assert_eq!(fetch_count.get(), 3);
+	assert_eq!(enabled.error(), Some("attempt-3".to_string()));
+	assert_eq!(disabled.error(), Some("attempt-3".to_string()));
+	assert_eq!(runtime.pending_task_count(), 0);
+}
+
+#[test]
+fn query_retry_observer_changes_reuse_the_stored_jitter_sample() {
+	let runtime = TestQueryRuntime::with_jitter_samples([0]);
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-observer-stable-jitter");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move { Err(format!("attempt-{attempt}")) }
+		}
+	});
+	let first = client.observe(
+		descriptor.clone(),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_millis(100))
+				.max_delay(Duration::from_millis(100))
+				.jitter(true),
+		),
+	);
+	runtime.run_until_stalled();
+	assert_eq!(
+		first.entry.retry.borrow().as_ref().unwrap().jitter_sample,
+		Some(0)
+	);
+	assert_eq!(
+		first
+			.entry
+			.retry
+			.borrow()
+			.as_ref()
+			.unwrap()
+			.candidates
+			.len(),
+		1
+	);
+
+	let second = client.observe(
+		descriptor,
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_millis(40))
+				.max_delay(Duration::from_millis(40))
+				.jitter(true),
+		),
+	);
+	assert_eq!(
+		first.entry.retry.borrow().as_ref().unwrap().jitter_sample,
+		Some(0)
+	);
+	assert_eq!(
+		first
+			.entry
+			.retry
+			.borrow()
+			.as_ref()
+			.unwrap()
+			.candidates
+			.len(),
+		2
+	);
+
+	drop(second);
+	assert_eq!(
+		first.entry.retry.borrow().as_ref().unwrap().jitter_sample,
+		Some(0)
+	);
+	assert_eq!(
+		first
+			.entry
+			.retry
+			.borrow()
+			.as_ref()
+			.unwrap()
+			.candidates
+			.len(),
+		1
+	);
+	runtime.advance(Duration::from_millis(49));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 1);
+	runtime.advance(Duration::from_millis(1));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(first.error(), Some("attempt-2".to_string()));
+	assert_eq!(runtime.pending_task_count(), 0);
+}
+
+#[test]
+fn query_retry_observer_predicate_panic_propagates_unchanged() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-observer-predicate-panic");
+	let fetch_count = Rc::new(Cell::new(0));
+	let _query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				fetch_count.set(fetch_count.get() + 1);
+				async { Err("offline".to_string()) }
+			}
+		}),
+		QueryOptions::new()
+			.retry(RetryPolicy::exponential().when(|_: &String| panic!("retry predicate panic"))),
+	);
+
+	let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+		runtime.run_until_stalled();
+	}))
+	.expect_err("the retry predicate panic must escape query completion");
+	let message = panic
+		.downcast_ref::<&str>()
+		.copied()
+		.or_else(|| panic.downcast_ref::<String>().map(String::as_str));
+
+	assert_eq!(message, Some("retry predicate panic"));
+	assert_eq!(fetch_count.get(), 1);
+}
+
+#[test]
 fn refetch_after_initial_error_transitions_through_pending() {
 	let runtime = TestQueryRuntime::new();
 	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -53,6 +53,15 @@ impl Serialize for OrderedLargeMapArgs {
 
 struct FailingFingerprintArgs;
 
+#[test]
+fn query_retry_jitter_samples_are_consumed_in_configured_order() {
+	let runtime = TestQueryRuntime::with_jitter_samples([7, 11]);
+	let runtime_handle = runtime.handle();
+
+	assert_eq!(runtime_handle.jitter_sample(), 7);
+	assert_eq!(runtime_handle.jitter_sample(), 11);
+}
+
 fn isolated_query_client() -> QueryClientGuard {
 	provide_query_client(QueryClient::new(QueryDefaults::default()))
 }

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -370,6 +370,28 @@ fn native_runtime_drives_retry_without_browser_maintenance() {
 }
 
 #[test]
+fn dropping_the_final_native_observer_aborts_its_retry_wait() {
+	let runtime = TestQueryRuntime::without_external_maintenance();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-native-wait-abort");
+	let query = client.observe(
+		family.query((), || async { Err("temporary".to_string()) }),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.base_delay(Duration::from_secs(60))
+				.max_delay(Duration::from_secs(60)),
+		),
+	);
+	runtime.run_until_stalled();
+	assert_eq!(runtime.pending_task_count(), 1);
+
+	drop(query);
+	runtime.run_until_stalled();
+
+	assert_eq!(runtime.pending_task_count(), 0);
+}
+
+#[test]
 fn acquiring_during_background_retry_waits_for_shared_completion() {
 	let runtime = TestQueryRuntime::new();
 	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
@@ -1240,6 +1262,50 @@ fn dropping_a_retargeted_ssr_waiter_cancels_the_replacement_generation() {
 	assert!(!entry.has_request());
 	assert!(entry.retry.borrow().is_none());
 	assert!(!entry.is_fetching.get());
+}
+
+#[test]
+fn dropping_one_shared_ssr_waiter_keeps_the_sequence_alive() {
+	let client = QueryClient::new_ssr(QueryDefaults::default());
+	let family = QueryFamily::<(), String, String>::new("tests.ssr-shared-waiter-drop");
+	let ready = Rc::new(Cell::new(false));
+	let descriptor = family.query((), {
+		let ready = Rc::clone(&ready);
+		move || TestGate {
+			ready: Rc::clone(&ready),
+			dropped: Rc::new(Cell::new(0)),
+			result: Some(Ok("shared".to_string())),
+		}
+	});
+	let first = client.acquire(
+		descriptor.clone(),
+		QueryAcquireOptions {
+			consumer: QueryConsumer::Prefetch,
+			error_policy: QueryErrorPolicy::Discard,
+		},
+	);
+	let second = client.acquire(
+		descriptor,
+		QueryAcquireOptions {
+			consumer: QueryConsumer::Navigation(1),
+			error_policy: QueryErrorPolicy::Discard,
+		},
+	);
+	let entry = Rc::clone(&first.inner.entry);
+	let mut first_result = Box::pin(first.result());
+	let mut second_result = Box::pin(second.result());
+	let mut context = Context::from_waker(Waker::noop());
+	assert_eq!(first_result.as_mut().poll(&mut context), Poll::Pending);
+	assert_eq!(second_result.as_mut().poll(&mut context), Poll::Pending);
+
+	drop(first_result);
+
+	assert!(entry.has_request());
+	ready.set(true);
+	assert_eq!(
+		second_result.as_mut().poll(&mut context),
+		Poll::Ready(Ok("shared".to_string()))
+	);
 }
 
 #[test]

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -922,6 +922,298 @@ fn query_retry_observer_predicate_panic_propagates_unchanged() {
 }
 
 #[test]
+fn query_retry_refetch_resets_a_waiting_sequence_immediately() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-refetch-reset");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				let attempt = fetch_count.get() + 1;
+				fetch_count.set(attempt);
+				async move { Err(format!("attempt-{attempt}")) }
+			}
+		}),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_secs(1))
+				.max_delay(Duration::from_secs(1)),
+		),
+	);
+	runtime.run_until_stalled();
+
+	query.refetch();
+	runtime.run_until_stalled();
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(query.error(), None);
+
+	runtime.advance(Duration::from_secs(1));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 3);
+	assert_eq!(query.error(), Some("attempt-3".to_string()));
+}
+
+#[test]
+fn query_retry_invalidation_resets_a_waiting_sequence_immediately() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-invalidation-reset");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			async move { Err(format!("attempt-{attempt}")) }
+		}
+	});
+	let key = descriptor.key().clone();
+	let query = client.observe(
+		descriptor,
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_secs(1))
+				.max_delay(Duration::from_secs(1)),
+		),
+	);
+	runtime.run_until_stalled();
+
+	client.invalidate(&key);
+	runtime.run_until_stalled();
+	assert_eq!(fetch_count.get(), 2);
+	assert!(query.is_stale());
+
+	runtime.advance(Duration::from_secs(1));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 3);
+	assert_eq!(query.error(), Some("attempt-3".to_string()));
+}
+
+#[test]
+fn query_retry_refetch_coalesces_one_follow_up_for_an_in_flight_attempt() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-refetch-coalesce");
+	let ready = Rc::new(Cell::new(false));
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe(
+		family.query((), {
+			let ready = Rc::clone(&ready);
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				fetch_count.set(fetch_count.get() + 1);
+				TestGate {
+					ready: Rc::clone(&ready),
+					dropped: Rc::new(Cell::new(0)),
+					result: Some(Ok("fresh".to_string())),
+				}
+			}
+		}),
+		QueryOptions::default(),
+	);
+	runtime.run_until_stalled();
+
+	query.refetch();
+	query.refetch();
+	query.refetch();
+	ready.set(true);
+	runtime.run_until_stalled();
+
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(query.data(), Some("fresh".to_string()));
+	assert!(!query.is_fetching());
+}
+
+#[test]
+fn query_retry_superseded_failure_stays_unpublished_and_retargets_waiters() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-superseded-failure");
+	let ready = Rc::new(Cell::new(false));
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let ready = Rc::clone(&ready);
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let attempt = fetch_count.get() + 1;
+			fetch_count.set(attempt);
+			TestGate {
+				ready: Rc::clone(&ready),
+				dropped: Rc::new(Cell::new(0)),
+				result: Some(if attempt == 1 {
+					Err("obsolete".to_string())
+				} else {
+					Ok("fresh".to_string())
+				}),
+			}
+		}
+	});
+	let lease = client.acquire(
+		descriptor,
+		QueryAcquireOptions {
+			consumer: QueryConsumer::Navigation(1),
+			error_policy: QueryErrorPolicy::Discard,
+		},
+	);
+	runtime.run_until_stalled();
+
+	let entry = Rc::clone(&lease.inner.entry);
+	entry.start_fetch(true);
+	ready.set(true);
+	runtime.run_until_stalled();
+
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(
+		tokio_test::block_on(lease.result()),
+		Ok("fresh".to_string())
+	);
+	assert_eq!(entry.refetch_error.get(), None);
+	assert!(matches!(
+		entry.state.with_untracked(|state| state.clone()),
+		ResourceState::Success(value) if value == "fresh"
+	));
+}
+
+#[test]
+fn query_retry_polling_joins_a_waiting_sequence_without_resetting_it() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-polling-joins");
+	let fetch_count = Rc::new(Cell::new(0));
+	let _query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				fetch_count.set(fetch_count.get() + 1);
+				async { Err("offline".to_string()) }
+			}
+		}),
+		QueryOptions::new()
+			.refetch_interval(Duration::from_millis(500))
+			.retry(
+				RetryPolicy::exponential()
+					.max_attempts(2)
+					.base_delay(Duration::from_secs(1))
+					.max_delay(Duration::from_secs(1)),
+			),
+	);
+	runtime.run_until_stalled();
+
+	runtime.advance(Duration::from_millis(500));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 1);
+
+	runtime.advance(Duration::from_millis(500));
+	runtime.run_due_maintenance();
+	assert_eq!(fetch_count.get(), 2);
+}
+
+#[test]
+fn query_retry_cancel_invalidates_a_waiting_deadline() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-cancel-wait");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				fetch_count.set(fetch_count.get() + 1);
+				async { Err("offline".to_string()) }
+			}
+		}),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_secs(1))
+				.max_delay(Duration::from_secs(1)),
+		),
+	);
+	runtime.run_until_stalled();
+	let entry = Rc::clone(&query.entry);
+
+	drop(query);
+	runtime.advance(Duration::from_secs(1));
+	runtime.run_due_maintenance();
+
+	assert_eq!(fetch_count.get(), 1);
+	assert!(entry.retry.borrow().is_none());
+	assert!(!entry.is_fetching.get());
+}
+
+#[test]
+fn query_retry_client_drop_invalidates_a_waiting_deadline() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-client-cancel-wait");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				fetch_count.set(fetch_count.get() + 1);
+				async { Err("offline".to_string()) }
+			}
+		}),
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_secs(1))
+				.max_delay(Duration::from_secs(1)),
+		),
+	);
+	runtime.run_until_stalled();
+	let entry = Rc::clone(&query.entry);
+
+	drop(client);
+	runtime.advance(Duration::from_secs(1));
+	runtime.run_due_maintenance();
+
+	assert_eq!(fetch_count.get(), 1);
+	assert!(entry.retry.borrow().is_none());
+	assert!(!entry.is_fetching.get());
+}
+
+#[test]
+fn query_retry_garbage_collection_invalidates_a_waiting_deadline() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-gc-cancel-wait");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			fetch_count.set(fetch_count.get() + 1);
+			async { Err("offline".to_string()) }
+		}
+	});
+	let key = descriptor.key().clone();
+	let query = client.observe(
+		descriptor,
+		QueryOptions::new().gc_time(Duration::from_secs(1)).retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_secs(1))
+				.max_delay(Duration::from_secs(1)),
+		),
+	);
+	runtime.run_until_stalled();
+	let entry = Rc::clone(&query.entry);
+
+	drop(query);
+	runtime.advance(Duration::from_secs(1));
+	runtime.run_due_maintenance();
+
+	assert_eq!(fetch_count.get(), 1);
+	assert!(!client.contains_for_test(&key));
+	assert!(entry.retry.borrow().is_none());
+}
+
+#[test]
 fn refetch_after_initial_error_transitions_through_pending() {
 	let runtime = TestQueryRuntime::new();
 	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -1079,6 +1079,33 @@ fn query_retry_superseded_failure_stays_unpublished_and_retargets_waiters() {
 }
 
 #[test]
+fn query_retry_dropped_manual_refetch_publishes_the_in_flight_failure() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-dropped-manual-refetch");
+	let ready = Rc::new(Cell::new(false));
+	let descriptor = family.query((), {
+		let ready = Rc::clone(&ready);
+		move || TestGate {
+			ready: Rc::clone(&ready),
+			dropped: Rc::new(Cell::new(0)),
+			result: Some(Err("offline".to_string())),
+		}
+	});
+	let remaining = client.observe(descriptor.clone(), QueryOptions::default());
+	let requesting = client.observe(descriptor, QueryOptions::default());
+	runtime.run_until_stalled();
+
+	requesting.refetch();
+	drop(requesting);
+	ready.set(true);
+	runtime.run_until_stalled();
+
+	assert_eq!(remaining.error(), Some("offline".to_string()));
+	assert!(!remaining.is_fetching());
+}
+
+#[test]
 fn query_retry_polling_joins_a_waiting_sequence_without_resetting_it() {
 	let runtime = TestQueryRuntime::new();
 	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
@@ -1176,6 +1203,32 @@ fn query_retry_client_drop_invalidates_a_waiting_deadline() {
 	assert_eq!(fetch_count.get(), 1);
 	assert!(entry.retry.borrow().is_none());
 	assert!(!entry.is_fetching.get());
+}
+
+#[test]
+fn query_retry_client_drop_clears_disabled_manual_refetch_pending() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.retry-client-cancel-disabled");
+	let query = client.observe(
+		family.query((), || async { Err("offline".to_string()) }),
+		QueryOptions::new().enabled(false).retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_secs(1))
+				.max_delay(Duration::from_secs(1)),
+		),
+	);
+
+	query.refetch();
+	runtime.run_until_stalled();
+	assert_eq!(query.snapshot().status, QueryStatus::Pending);
+	assert!(query.lease.inner.manual_refetch_pending.get());
+
+	drop(client);
+
+	assert_eq!(query.snapshot().status, QueryStatus::Idle);
+	assert!(!query.lease.inner.manual_refetch_pending.get());
 }
 
 #[test]

--- a/crates/reinhardt-pages/src/ssr/renderer.rs
+++ b/crates/reinhardt-pages/src/ssr/renderer.rs
@@ -64,6 +64,8 @@ pub struct SsrOptions {
 	/// - `Static`: Mark as static content (no hydration)
 	pub default_hydration_strategy: HydrationStrategy,
 	/// Maximum time to wait for server resource resolution.
+	///
+	/// This single budget includes every query fetch attempt and retry delay.
 	pub resource_timeout: Duration,
 	/// Defaults used by the request-owned SSR query client.
 	pub query_defaults: QueryDefaults,
@@ -187,6 +189,9 @@ impl SsrOptions {
 	}
 
 	/// Sets the server resource timeout.
+	///
+	/// For query retries, this is one budget covering fetch attempts, backoff,
+	/// and jitter rather than a timeout that restarts for each attempt.
 	pub fn resource_timeout(mut self, timeout: Duration) -> Self {
 		self.resource_timeout = timeout;
 		self
@@ -200,6 +205,10 @@ impl SsrOptions {
 	}
 
 	/// Enables or disables retries for request-owned SSR queries.
+	///
+	/// SSR retries require both this gate and a retry policy installed through
+	/// [`QueryOptions::retry`](crate::reactive::QueryOptions::retry). Without
+	/// either opt-in, an SSR query performs only its initial attempt.
 	pub fn query_retries(mut self, enabled: bool) -> Self {
 		self.query_defaults = self.query_defaults.with_ssr_query_retries(enabled);
 		self

--- a/crates/reinhardt-pages/src/ssr/renderer.rs
+++ b/crates/reinhardt-pages/src/ssr/renderer.rs
@@ -194,7 +194,14 @@ impl SsrOptions {
 
 	/// Sets defaults for request-owned SSR queries.
 	pub fn query_defaults(mut self, defaults: QueryDefaults) -> Self {
-		self.query_defaults = defaults;
+		let retry_enabled = self.query_defaults.ssr_query_retries_enabled();
+		self.query_defaults = defaults.with_ssr_query_retries(retry_enabled);
+		self
+	}
+
+	/// Enables or disables retries for request-owned SSR queries.
+	pub fn query_retries(mut self, enabled: bool) -> Self {
+		self.query_defaults = self.query_defaults.with_ssr_query_retries(enabled);
 		self
 	}
 

--- a/crates/reinhardt-pages/src/testing/component/scheduler.rs
+++ b/crates/reinhardt-pages/src/testing/component/scheduler.rs
@@ -13,6 +13,8 @@ use crate::platform;
 type BoxedTask = Pin<Box<dyn Future<Output = ()> + 'static>>;
 const SETTLE_BACKOFF_AFTER_YIELDS: usize = 4;
 const SETTLE_BACKOFF: Duration = Duration::from_millis(1);
+// ponytail: 2s settle window; longer custom retry delays need explicit clock driving.
+const SETTLE_MAX_ITERATIONS: usize = 2_000;
 
 /// Error returned when the native component scheduler cannot settle.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -74,7 +76,7 @@ impl SchedulerScope {
 		mut with_context: impl FnMut(&mut dyn FnMut() -> usize) -> usize,
 	) -> Result<(), SettleError> {
 		let mut cx = Context::from_waker(Waker::noop());
-		for iteration in 0..100 {
+		for iteration in 0..SETTLE_MAX_ITERATIONS {
 			let mut poll_tasks = || {
 				self.with_current(|| {
 					let mut pending = VecDeque::new();
@@ -103,9 +105,9 @@ impl SchedulerScope {
 			} else {
 				tokio::time::sleep(SETTLE_BACKOFF).await;
 			}
-			if iteration == 99 {
+			if iteration + 1 == SETTLE_MAX_ITERATIONS {
 				return Err(SettleError::DidNotQuiesce {
-					iterations: 100,
+					iterations: SETTLE_MAX_ITERATIONS,
 					pending_tasks,
 					dom: dom(),
 				});

--- a/crates/reinhardt-pages/tests/query_client_integration.rs
+++ b/crates/reinhardt-pages/tests/query_client_integration.rs
@@ -1,4 +1,4 @@
-use reinhardt_pages::reactive::{QueryFamily, QueryOptions, use_query};
+use reinhardt_pages::reactive::{QueryFamily, QueryOptions, RetryPolicy, use_query};
 
 #[cfg(all(native, feature = "testing"))]
 use std::cell::Cell;
@@ -97,6 +97,34 @@ fn jobs_screen(project_id: u64, list_calls: Rc<Cell<usize>>, retry_calls: Rc<Cel
 		.into_page()
 }
 
+#[cfg(all(native, feature = "testing"))]
+fn retrying_query_component(calls: Rc<Cell<usize>>) -> Page {
+	let query = use_query(
+		QueryFamily::<(), String, String>::new("tests.component-retry-settle").query(
+			(),
+			move || {
+				let attempt = calls.get() + 1;
+				calls.set(attempt);
+				async move {
+					if attempt == 1 {
+						Err("temporary".to_string())
+					} else {
+						Ok("recovered".to_string())
+					}
+				}
+			},
+		),
+		QueryOptions::new().retry(RetryPolicy::exponential().max_attempts(2)),
+	);
+
+	Page::reactive(move || match query.snapshot().status {
+		reinhardt_pages::reactive::QueryStatus::Success => PageElement::new("p")
+			.child(query.data().expect("successful query data"))
+			.into_page(),
+		_ => PageElement::new("p").child("query-loading").into_page(),
+	})
+}
+
 #[test]
 #[should_panic(expected = "use_query requires an active QueryClient")]
 fn use_query_rejects_missing_application_context() {
@@ -160,4 +188,22 @@ async fn jobs_screen_deduplicates_shared_reads_and_refetches_after_retry() {
 			.text(),
 		"Queue: project 42 job 2"
 	);
+}
+
+#[cfg(all(native, feature = "testing"))]
+#[tokio::test]
+async fn component_screen_settle_waits_for_query_retry_backoff() {
+	// Arrange
+	let calls = Rc::new(Cell::new(0));
+	let screen = render({
+		let calls = Rc::clone(&calls);
+		move || retrying_query_component(calls)
+	});
+
+	// Act
+	screen.settle().await;
+
+	// Assert
+	assert_eq!(calls.get(), 2);
+	assert_eq!(screen.pretty(), "<p>\n  recovered\n</p>\n");
 }

--- a/crates/reinhardt-pages/tests/ssr_renderer_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_renderer_integration_tests.rs
@@ -698,6 +698,24 @@ async fn test_ssr_options_struct_literal_remains_exhaustive() {
 	assert!(html.contains("Count: 3"));
 }
 
+#[test]
+fn ssr_query_retry_builder_order_preserves_the_same_nested_defaults() {
+	let defaults = reinhardt_pages::reactive::QueryDefaults::new()
+		.stale_time(std::time::Duration::from_secs(7))
+		.gc_time(std::time::Duration::from_secs(11));
+	let gate_then_defaults = SsrOptions::new()
+		.query_retries(true)
+		.query_defaults(defaults.clone());
+	let defaults_then_gate = SsrOptions::new()
+		.query_defaults(defaults)
+		.query_retries(true);
+
+	assert_eq!(
+		gate_then_defaults.query_defaults,
+		defaults_then_gate.query_defaults
+	);
+}
+
 fn controlled_bindings_page(scope: &ReactiveScope) -> Page {
 	let text = signal_in_scope(scope, "A&B".to_owned());
 	let checked = signal_in_scope(scope, true);

--- a/crates/reinhardt-pages/tests/ssr_resource_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_resource_integration_tests.rs
@@ -210,7 +210,7 @@ async fn ssr_query_retry_both_opt_ins_succeed_on_attempt_two() {
 	};
 
 	assert_eq!(fetch_count.get(), 2);
-	assert!(html.contains("recovered"));
+	assert!(html.contains("<p>recovered</p>"));
 	assert!(!html.contains("attempt-1"));
 	assert_eq!(
 		renderer

--- a/crates/reinhardt-pages/tests/ssr_resource_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_resource_integration_tests.rs
@@ -3,15 +3,18 @@
 use reinhardt_pages::component::{Component, IntoPage, Page, PageElement};
 use reinhardt_pages::deps;
 use reinhardt_pages::reactive::{
-	QueryFamily, QueryOptions, QueryStatus, ResourceState, Signal, queries, use_id, use_query,
-	use_resource, use_resource_with_key,
+	QueryFamily, QueryOptions, QueryStatus, ResourceState, RetryPolicy, Signal, queries, use_id,
+	use_query, use_resource, use_resource_with_key,
 };
 use reinhardt_pages::server_fn::{ServerFnError, server_fn};
 use reinhardt_pages::ssr::{SsrOptions, SsrRenderer};
 use rstest::rstest;
 use std::cell::Cell;
+use std::future::{Future, poll_fn};
+use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::task::Poll;
 use std::time::Duration;
 use tokio::sync::Barrier;
 
@@ -49,6 +52,400 @@ fn resource_view() -> Page {
 			ResourceState::Error(error) => PageElement::new("div").child(error).into_page(),
 		}
 	})
+}
+
+fn retrying_query_view(
+	family_id: &'static str,
+	fetch_count: Rc<Cell<u32>>,
+	fail_through: u32,
+	success_value: &'static str,
+	options: QueryOptions<RetryPolicy<String>>,
+) -> Page {
+	Page::reactive(move || {
+		let fetch_count = Rc::clone(&fetch_count);
+		let query = use_query(
+			QueryFamily::<(), String, String>::new(family_id).query((), move || {
+				let fetch_count = Rc::clone(&fetch_count);
+				async move {
+					let attempt = fetch_count.get() + 1;
+					fetch_count.set(attempt);
+					if attempt <= fail_through {
+						Err(format!("attempt-{attempt}"))
+					} else {
+						Ok(success_value.to_string())
+					}
+				}
+			}),
+			options.clone(),
+		);
+
+		match query.snapshot().status {
+			QueryStatus::Idle | QueryStatus::Pending => {
+				PageElement::new("p").child("query-loading").into_page()
+			}
+			QueryStatus::Success => PageElement::new("p")
+				.child(query.data().expect("successful query data"))
+				.into_page(),
+			QueryStatus::Error => PageElement::new("p")
+				.child(query.error().expect("failed query error"))
+				.into_page(),
+		}
+	})
+}
+
+fn retry_policy(max_attempts: u32, delay: Duration) -> RetryPolicy<String> {
+	RetryPolicy::exponential()
+		.max_attempts(max_attempts)
+		.base_delay(delay)
+		.max_delay(delay)
+}
+
+fn query_resource_key(family_id: &'static str) -> String {
+	let query_id = QueryFamily::<(), String, String>::new(family_id)
+		.key(())
+		.id();
+	format!("query:{query_id}")
+}
+
+async fn poll_once_pending<F: Future>(mut future: Pin<&mut F>) {
+	poll_fn(|context| match future.as_mut().poll(context) {
+		Poll::Pending => Poll::Ready(()),
+		Poll::Ready(_) => panic!("render unexpectedly settled before the retry boundary"),
+	})
+	.await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn ssr_query_retry_policy_without_gate_performs_one_attempt() {
+	let family_id = "tests::ssr-retry-policy-only";
+	let fetch_count = Rc::new(Cell::new(0));
+	let view = retrying_query_view(
+		family_id,
+		Rc::clone(&fetch_count),
+		3,
+		"unexpected",
+		QueryOptions::new().retry(retry_policy(3, Duration::from_millis(10))),
+	);
+	let mut renderer = SsrRenderer::new();
+
+	let html = renderer.render_page_with_view_head_to_string(view).await;
+
+	assert_eq!(fetch_count.get(), 1);
+	assert!(html.contains("attempt-1"));
+	assert_eq!(
+		renderer
+			.state()
+			.get_resource_state(&query_resource_key(family_id)),
+		Some(&serde_json::json!({
+			"state": { "Error": "attempt-1" },
+			"refetch_error": null,
+			"is_fetching": false,
+			"is_stale": false
+		}))
+	);
+}
+
+#[tokio::test(start_paused = true)]
+async fn ssr_query_retry_gate_without_policy_performs_one_attempt() {
+	let family_id = "tests::ssr-retry-gate-only";
+	let fetch_count = Rc::new(Cell::new(0));
+	let fetch_count_for_view = Rc::clone(&fetch_count);
+	let view = Page::reactive(move || {
+		let fetch_count = Rc::clone(&fetch_count_for_view);
+		let query = use_query(
+			QueryFamily::<(), String, String>::new(family_id).query((), move || {
+				let fetch_count = Rc::clone(&fetch_count);
+				async move {
+					fetch_count.set(fetch_count.get() + 1);
+					Err("gate-only".to_string())
+				}
+			}),
+			QueryOptions::new(),
+		);
+		match query.snapshot().status {
+			QueryStatus::Error => PageElement::new("p")
+				.child(query.error().expect("failed query error"))
+				.into_page(),
+			_ => PageElement::new("p").child("query-loading").into_page(),
+		}
+	});
+	let mut renderer = SsrRenderer::with_options(SsrOptions::new().query_retries(true));
+
+	let html = renderer.render_page_with_view_head_to_string(view).await;
+
+	assert_eq!(fetch_count.get(), 1);
+	assert!(html.contains("gate-only"));
+	assert_eq!(
+		renderer
+			.state()
+			.get_resource_state(&query_resource_key(family_id)),
+		Some(&serde_json::json!({
+			"state": { "Error": "gate-only" },
+			"refetch_error": null,
+			"is_fetching": false,
+			"is_stale": false
+		}))
+	);
+}
+
+#[tokio::test(start_paused = true)]
+async fn ssr_query_retry_both_opt_ins_succeed_on_attempt_two() {
+	let family_id = "tests::ssr-retry-double-opt-in";
+	let fetch_count = Rc::new(Cell::new(0));
+	let view = retrying_query_view(
+		family_id,
+		Rc::clone(&fetch_count),
+		1,
+		"recovered",
+		QueryOptions::new().retry(retry_policy(2, Duration::from_millis(10))),
+	);
+	let mut renderer = SsrRenderer::with_options(SsrOptions::new().query_retries(true));
+
+	let html = {
+		let render = renderer.render_page_with_view_head_to_string(view);
+		tokio::pin!(render);
+		poll_once_pending(render.as_mut()).await;
+		tokio::time::advance(Duration::from_millis(10)).await;
+		render.await
+	};
+
+	assert_eq!(fetch_count.get(), 2);
+	assert!(html.contains("recovered"));
+	assert!(!html.contains("attempt-1"));
+	assert_eq!(
+		renderer
+			.state()
+			.get_resource_state(&query_resource_key(family_id)),
+		Some(&serde_json::json!({
+			"state": { "Success": "recovered" },
+			"refetch_error": null,
+			"is_fetching": false,
+			"is_stale": false
+		}))
+	);
+}
+
+#[tokio::test(start_paused = true)]
+async fn ssr_query_retry_predicate_rejection_settles_after_one_attempt() {
+	let family_id = "tests::ssr-retry-predicate-rejection";
+	let fetch_count = Rc::new(Cell::new(0));
+	let view = retrying_query_view(
+		family_id,
+		Rc::clone(&fetch_count),
+		3,
+		"unexpected",
+		QueryOptions::new().retry(retry_policy(3, Duration::from_millis(10)).when(|_| false)),
+	);
+	let mut renderer = SsrRenderer::with_options(SsrOptions::new().query_retries(true));
+
+	let html = renderer.render_page_with_view_head_to_string(view).await;
+
+	assert_eq!(fetch_count.get(), 1);
+	assert!(html.contains("attempt-1"));
+	assert_eq!(
+		renderer
+			.state()
+			.get_resource_state(&query_resource_key(family_id)),
+		Some(&serde_json::json!({
+			"state": { "Error": "attempt-1" },
+			"refetch_error": null,
+			"is_fetching": false,
+			"is_stale": false
+		}))
+	);
+}
+
+#[tokio::test(start_paused = true)]
+async fn ssr_query_retry_exhaustion_serializes_only_the_third_error() {
+	let family_id = "tests::ssr-retry-exhaustion";
+	let fetch_count = Rc::new(Cell::new(0));
+	let view = retrying_query_view(
+		family_id,
+		Rc::clone(&fetch_count),
+		3,
+		"unexpected",
+		QueryOptions::new().retry(retry_policy(3, Duration::from_millis(10))),
+	);
+	let mut renderer = SsrRenderer::with_options(SsrOptions::new().query_retries(true));
+
+	let html = {
+		let render = renderer.render_page_with_view_head_to_string(view);
+		tokio::pin!(render);
+		poll_once_pending(render.as_mut()).await;
+		tokio::time::advance(Duration::from_millis(10)).await;
+		poll_once_pending(render.as_mut()).await;
+		tokio::time::advance(Duration::from_millis(10)).await;
+		render.await
+	};
+
+	assert_eq!(fetch_count.get(), 3);
+	assert!(html.contains("attempt-3"));
+	assert!(!html.contains("attempt-1"));
+	assert!(!html.contains("attempt-2"));
+	assert_eq!(
+		renderer
+			.state()
+			.get_resource_state(&query_resource_key(family_id)),
+		Some(&serde_json::json!({
+			"state": { "Error": "attempt-3" },
+			"refetch_error": null,
+			"is_fetching": false,
+			"is_stale": false
+		}))
+	);
+}
+
+#[tokio::test(start_paused = true)]
+async fn ssr_query_retry_timeout_during_attempt_keeps_loading_unserialized() {
+	let family_id = "tests::ssr-retry-attempt-timeout";
+	let fetch_count = Rc::new(Cell::new(0));
+	let fetch_count_for_view = Rc::clone(&fetch_count);
+	let view = Page::reactive(move || {
+		let fetch_count = Rc::clone(&fetch_count_for_view);
+		let query = use_query(
+			QueryFamily::<(), String, String>::new(family_id).query((), move || {
+				let fetch_count = Rc::clone(&fetch_count);
+				async move {
+					fetch_count.set(fetch_count.get() + 1);
+					tokio::time::sleep(Duration::from_millis(100)).await;
+					Err("late-error".to_string())
+				}
+			}),
+			QueryOptions::new().retry(retry_policy(3, Duration::from_millis(20))),
+		);
+		match query.snapshot().status {
+			QueryStatus::Error => PageElement::new("p")
+				.child(query.error().expect("failed query error"))
+				.into_page(),
+			_ => PageElement::new("p").child("query-loading").into_page(),
+		}
+	});
+	let mut renderer = SsrRenderer::with_options(
+		SsrOptions::new()
+			.query_retries(true)
+			.resource_timeout(Duration::from_millis(50)),
+	);
+
+	let html = {
+		let render = renderer.render_page_with_view_head_to_string(view);
+		tokio::pin!(render);
+		poll_once_pending(render.as_mut()).await;
+		tokio::time::advance(Duration::from_millis(50)).await;
+		render.await
+	};
+
+	assert_eq!(fetch_count.get(), 1);
+	assert!(html.contains("query-loading"));
+	assert!(!html.contains("late-error"));
+	assert_eq!(
+		renderer
+			.state()
+			.get_resource_state(&query_resource_key(family_id)),
+		None
+	);
+}
+
+#[tokio::test(start_paused = true)]
+async fn ssr_query_retry_timeout_during_backoff_emits_no_error_snapshot() {
+	let family_id = "tests::ssr-retry-backoff-timeout";
+	let fetch_count = Rc::new(Cell::new(0));
+	let view = retrying_query_view(
+		family_id,
+		Rc::clone(&fetch_count),
+		3,
+		"unexpected",
+		QueryOptions::new().retry(retry_policy(3, Duration::from_millis(100))),
+	);
+	let mut renderer = SsrRenderer::with_options(
+		SsrOptions::new()
+			.query_retries(true)
+			.resource_timeout(Duration::from_millis(50)),
+	);
+
+	let html = {
+		let render = renderer.render_page_with_view_head_to_string(view);
+		tokio::pin!(render);
+		poll_once_pending(render.as_mut()).await;
+		tokio::time::advance(Duration::from_millis(50)).await;
+		render.await
+	};
+
+	assert_eq!(fetch_count.get(), 1);
+	assert!(html.contains("query-loading"));
+	assert!(!html.contains("attempt-1"));
+	assert_eq!(
+		renderer
+			.state()
+			.get_resource_state(&query_resource_key(family_id)),
+		None
+	);
+}
+
+#[tokio::test(start_paused = true)]
+async fn concurrent_ssr_query_retry_renderers_keep_sequences_isolated() {
+	let family_id = "tests::ssr-retry-renderer-isolation";
+	let first_count = Rc::new(Cell::new(0));
+	let second_count = Rc::new(Cell::new(0));
+	let policy = || retry_policy(2, Duration::from_millis(20)).jitter(true);
+	let first_view = retrying_query_view(
+		family_id,
+		Rc::clone(&first_count),
+		1,
+		"first-renderer",
+		QueryOptions::new().retry(policy()),
+	);
+	let second_view = retrying_query_view(
+		family_id,
+		Rc::clone(&second_count),
+		1,
+		"second-renderer",
+		QueryOptions::new().retry(policy()),
+	);
+	let options = SsrOptions::new().query_retries(true);
+	let mut first_renderer = SsrRenderer::with_options(options.clone());
+	let mut second_renderer = SsrRenderer::with_options(options);
+
+	let (first_html, second_html) = {
+		let render = async {
+			tokio::join!(
+				first_renderer.render_page_with_view_head_to_string(first_view),
+				second_renderer.render_page_with_view_head_to_string(second_view),
+			)
+		};
+		tokio::pin!(render);
+		poll_once_pending(render.as_mut()).await;
+		tokio::time::advance(Duration::from_millis(20)).await;
+		render.await
+	};
+
+	assert_eq!(first_count.get(), 2);
+	assert_eq!(second_count.get(), 2);
+	assert!(first_html.contains("first-renderer"));
+	assert!(!first_html.contains("second-renderer"));
+	assert!(second_html.contains("second-renderer"));
+	assert!(!second_html.contains("first-renderer"));
+	assert_eq!(
+		first_renderer
+			.state()
+			.get_resource_state(&query_resource_key(family_id)),
+		Some(&serde_json::json!({
+			"state": { "Success": "first-renderer" },
+			"refetch_error": null,
+			"is_fetching": false,
+			"is_stale": false
+		}))
+	);
+	assert_eq!(
+		second_renderer
+			.state()
+			.get_resource_state(&query_resource_key(family_id)),
+		Some(&serde_json::json!({
+			"state": { "Success": "second-renderer" },
+			"refetch_error": null,
+			"is_fetching": false,
+			"is_stale": false
+		}))
+	);
 }
 
 struct ResourceComponent;

--- a/crates/reinhardt-pages/tests/ssr_resource_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_resource_integration_tests.rs
@@ -296,6 +296,55 @@ async fn ssr_query_retry_exhaustion_serializes_only_the_third_error() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn ssr_query_retry_zero_delay_yields_to_resource_timeout() {
+	let family_id = "tests::ssr-retry-zero-delay-timeout";
+	let fetch_count = Rc::new(Cell::new(0));
+	let view = retrying_query_view(
+		family_id,
+		Rc::clone(&fetch_count),
+		u32::MAX,
+		"unexpected",
+		QueryOptions::new().retry(retry_policy(10_000, Duration::ZERO)),
+	);
+	let mut renderer = SsrRenderer::with_options(
+		SsrOptions::new()
+			.query_retries(true)
+			.resource_timeout(Duration::from_millis(1)),
+	);
+
+	let html = {
+		let render = renderer.render_page_with_view_head_to_string(view);
+		tokio::pin!(render);
+		poll_once_pending(render.as_mut()).await;
+		tokio::time::advance(Duration::from_millis(1)).await;
+		render.await
+	};
+
+	assert!(fetch_count.get() < 10_000);
+	assert_eq!(
+		html,
+		concat!(
+			"<!DOCTYPE html>\n",
+			"<html lang=\"en\">\n",
+			"<head>\n",
+			"<meta charset=\"UTF-8\">\n",
+			"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n",
+			"</head>\n",
+			"<body>\n",
+			"<div id=\"app\"><p>query-loading</p></div>\n",
+			"</body>\n",
+			"</html>"
+		)
+	);
+	assert_eq!(
+		renderer
+			.state()
+			.get_resource_state(&query_resource_key(family_id)),
+		None
+	);
+}
+
+#[tokio::test(start_paused = true)]
 async fn ssr_query_retry_timeout_during_attempt_keeps_loading_unserialized() {
 	let family_id = "tests::ssr-retry-attempt-timeout";
 	let fetch_count = Rc::new(Cell::new(0));

--- a/crates/reinhardt-pages/tests/ssr_resource_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_resource_integration_tests.rs
@@ -279,7 +279,7 @@ async fn ssr_query_retry_exhaustion_serializes_only_the_third_error() {
 	};
 
 	assert_eq!(fetch_count.get(), 3);
-	assert!(html.contains("attempt-3"));
+	assert!(html.contains("<p>attempt-3</p>"));
 	assert!(!html.contains("attempt-1"));
 	assert!(!html.contains("attempt-2"));
 	assert_eq!(

--- a/crates/reinhardt-pages/tests/ui.rs
+++ b/crates/reinhardt-pages/tests/ui.rs
@@ -47,6 +47,8 @@ fn test_server_fn_macro_ui() {
 	let t = trybuild::TestCases::new();
 	// Guard query-key code generation against breaking existing server functions.
 	t.pass("tests/ui/server_fn/query_key_custom_result_alias.rs");
+	// Ensure generated query descriptors infer the retry predicate error type.
+	t.pass("tests/ui/server_fn/query_retry.rs");
 	// MSW mock arguments intentionally require serializable, cloneable request types.
 	// This fixture isolates the non-MSW native compatibility guarantee.
 	#[cfg(not(feature = "msw"))]
@@ -68,6 +70,16 @@ fn test_server_fn_macro_ui() {
 	t.pass("tests/ui/server_fn/structured_error_public_api.rs");
 	// Issue #3858: verify FromRequest extractor params work in #[server_fn]
 	t.pass("tests/ui/server_fn/with_extractors.rs");
+}
+
+#[test]
+fn test_query_retry_ui_pass() {
+	trybuild::TestCases::new().pass("tests/ui/query/pass/*.rs");
+}
+
+#[test]
+fn test_query_retry_ui_fail() {
+	trybuild::TestCases::new().compile_fail("tests/ui/query/fail/*.rs");
 }
 
 #[test]

--- a/crates/reinhardt-pages/tests/ui/query/fail/non_static_predicate.rs
+++ b/crates/reinhardt-pages/tests/ui/query/fail/non_static_predicate.rs
@@ -1,0 +1,9 @@
+use reinhardt_pages::reactive::RetryPolicy;
+
+#[derive(Clone)]
+struct AppError;
+
+fn main() {
+	let prefix = String::from("transient");
+	let _policy = RetryPolicy::<AppError>::exponential().when(|_| !prefix.is_empty());
+}

--- a/crates/reinhardt-pages/tests/ui/query/fail/non_static_predicate.stderr
+++ b/crates/reinhardt-pages/tests/ui/query/fail/non_static_predicate.stderr
@@ -1,0 +1,17 @@
+error[E0373]: closure may outlive the current function, but it borrows `prefix`, which is owned by the current function
+ --> tests/ui/query/fail/non_static_predicate.rs:8:60
+  |
+8 |     let _policy = RetryPolicy::<AppError>::exponential().when(|_| !prefix.is_empty());
+  |                                                               ^^^  ------ `prefix` is borrowed here
+  |                                                               |
+  |                                                               may outlive borrowed value `prefix`
+  |
+note: function requires argument type to outlive `'static`
+ --> tests/ui/query/fail/non_static_predicate.rs:8:16
+  |
+8 |     let _policy = RetryPolicy::<AppError>::exponential().when(|_| !prefix.is_empty());
+  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `prefix` (and any other referenced variables), use the `move` keyword
+  |
+8 |     let _policy = RetryPolicy::<AppError>::exponential().when(move |_| !prefix.is_empty());
+  |                                                               ++++

--- a/crates/reinhardt-pages/tests/ui/query/fail/wrong_error_type.rs
+++ b/crates/reinhardt-pages/tests/ui/query/fail/wrong_error_type.rs
@@ -1,0 +1,14 @@
+use reinhardt_pages::reactive::{QueryFamily, QueryOptions, RetryPolicy, use_query};
+
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
+enum AppError {}
+
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
+enum OtherError {}
+
+fn main() {
+	let family = QueryFamily::<(), String, AppError>::new("ui.query-retry.wrong-error");
+	let descriptor = family.query((), || async { Ok("ready".to_owned()) });
+	let policy = RetryPolicy::<OtherError>::exponential();
+	let _ = use_query(descriptor, QueryOptions::new().retry(policy));
+}

--- a/crates/reinhardt-pages/tests/ui/query/fail/wrong_error_type.stderr
+++ b/crates/reinhardt-pages/tests/ui/query/fail/wrong_error_type.stderr
@@ -16,8 +16,7 @@ help: the trait `QueryRetryConfig<AppError>` is not implemented for `RetryPolicy
 note: required by a bound in `use_query`
   --> src/reactive/query/hook.rs
    |
-   | pub fn use_query<T, E, R>(
+   | pub fn use_query<T, E>(
    |        --------- required by a bound in this function
-...
-   |     R: QueryRetryConfig<E>,
-   |        ^^^^^^^^^^^^^^^^^^^ required by this bound in `use_query`
+   |     options: QueryOptions<impl QueryRetryConfig<E>>,
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `use_query`

--- a/crates/reinhardt-pages/tests/ui/query/fail/wrong_error_type.stderr
+++ b/crates/reinhardt-pages/tests/ui/query/fail/wrong_error_type.stderr
@@ -18,5 +18,6 @@ note: required by a bound in `use_query`
    |
    | pub fn use_query<T, E>(
    |        --------- required by a bound in this function
+   |     descriptor: QueryDescriptor<T, E>,
    |     options: QueryOptions<impl QueryRetryConfig<E>>,
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `use_query`

--- a/crates/reinhardt-pages/tests/ui/query/fail/wrong_error_type.stderr
+++ b/crates/reinhardt-pages/tests/ui/query/fail/wrong_error_type.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `RetryPolicy<OtherError>: reinhardt_pages::reactive::query::QueryRetryConfig<AppError>` is not satisfied
+  --> tests/ui/query/fail/wrong_error_type.rs:13:32
+   |
+13 |     let _ = use_query(descriptor, QueryOptions::new().retry(policy));
+   |             ---------             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `reinhardt_pages::reactive::query::QueryRetryConfig<AppError>` is not implemented for `RetryPolicy<OtherError>`
+   |             |
+   |             required by a bound introduced by this call
+   |
+help: the trait `QueryRetryConfig<AppError>` is not implemented for `RetryPolicy<OtherError>`
+      but trait `QueryRetryConfig<OtherError>` is implemented for it
+  --> src/reactive/query/retry.rs
+   |
+   | impl<E: 'static> QueryRetryConfig<E> for RetryPolicy<E> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: for that trait implementation, expected `OtherError`, found `AppError`
+note: required by a bound in `use_query`
+  --> src/reactive/query/hook.rs
+   |
+   | pub fn use_query<T, E, R>(
+   |        --------- required by a bound in this function
+...
+   |     R: QueryRetryConfig<E>,
+   |        ^^^^^^^^^^^^^^^^^^^ required by this bound in `use_query`

--- a/crates/reinhardt-pages/tests/ui/query/pass/options_and_retry.rs
+++ b/crates/reinhardt-pages/tests/ui/query/pass/options_and_retry.rs
@@ -20,6 +20,12 @@ fn main() {
 		.jitter(true)
 		.when(|error: &AppError| matches!(error, AppError::Transient));
 	if false {
+		let _explicit_default =
+			use_query::<String, AppError>(descriptor.clone(), QueryOptions::default());
+		let _explicit_retry = use_query::<String, AppError>(
+			descriptor.clone(),
+			QueryOptions::new().retry(policy.clone()),
+		);
 		let _before = use_query(
 			descriptor.clone(),
 			QueryOptions::new().retry(policy.clone()).enabled(true),

--- a/crates/reinhardt-pages/tests/ui/query/pass/options_and_retry.rs
+++ b/crates/reinhardt-pages/tests/ui/query/pass/options_and_retry.rs
@@ -1,0 +1,32 @@
+use std::time::Duration;
+
+use reinhardt_pages::reactive::{QueryFamily, QueryOptions, RetryPolicy, use_query};
+
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
+enum AppError {
+	Transient,
+	Permanent,
+}
+
+fn main() {
+	let family = QueryFamily::<(), String, AppError>::new("ui.query-retry");
+	let descriptor = family.query((), || async { Ok("ready".to_owned()) });
+	let _plain: QueryOptions = QueryOptions::new();
+	let _default: QueryOptions = QueryOptions::default();
+	let policy = RetryPolicy::exponential()
+		.max_attempts(3)
+		.base_delay(Duration::from_millis(250))
+		.max_delay(Duration::from_secs(5))
+		.jitter(true)
+		.when(|error: &AppError| matches!(error, AppError::Transient));
+	if false {
+		let _before = use_query(
+			descriptor.clone(),
+			QueryOptions::new().retry(policy.clone()).enabled(true),
+		);
+		let _after = use_query(
+			descriptor,
+			QueryOptions::new().enabled(true).retry(policy),
+		);
+	}
+}

--- a/crates/reinhardt-pages/tests/ui/server_fn/query_retry.rs
+++ b/crates/reinhardt-pages/tests/ui/server_fn/query_retry.rs
@@ -1,0 +1,19 @@
+use reinhardt_pages::reactive::{QueryOptions, RetryPolicy, use_query};
+use reinhardt_pages::server_fn::ServerFnError;
+use reinhardt_pages_macros::server_fn;
+
+#[server_fn]
+async fn load_status() -> Result<String, ServerFnError> {
+	Ok("ready".to_owned())
+}
+
+fn main() {
+	if false {
+		let _ = use_query(
+			load_status::query(),
+			QueryOptions::new().retry(
+				RetryPolicy::exponential().when(|_: &ServerFnError| true),
+			),
+		);
+	}
+}

--- a/crates/reinhardt-pages/tests/wasm/query_client_wasm_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/query_client_wasm_test.rs
@@ -1,4 +1,4 @@
-//! Browser lifecycle coverage for query polling and visibility.
+//! Browser lifecycle coverage for query maintenance and visibility.
 
 #![cfg(wasm)]
 
@@ -11,8 +11,9 @@ use std::time::Duration;
 
 use gloo_timers::future::TimeoutFuture;
 use reinhardt_pages::reactive::query::{
-	QueryClient, QueryDefaults, QueryFamily, QueryOptions, query_browser_resource_counts,
-	query_browser_resource_probe_for_test, set_query_visibility_for_test,
+	QueryClient, QueryDefaults, QueryFamily, QueryOptions, RetryPolicy,
+	query_browser_resource_counts, query_browser_resource_probe_for_test,
+	set_query_visibility_for_test,
 };
 use wasm_bindgen_test::*;
 
@@ -22,6 +23,25 @@ struct TestGate {
 	ready: Rc<Cell<bool>>,
 	waker: Rc<RefCell<Option<Waker>>>,
 	value: u32,
+}
+
+struct TestResultGate {
+	ready: Option<Rc<Cell<bool>>>,
+	waker: Rc<RefCell<Option<Waker>>>,
+	result: Result<u32, String>,
+}
+
+impl Future for TestResultGate {
+	type Output = Result<u32, String>;
+
+	fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+		if self.ready.as_ref().is_none_or(|ready| ready.get()) {
+			Poll::Ready(self.result.clone())
+		} else {
+			self.waker.borrow_mut().replace(context.waker().clone());
+			Poll::Pending
+		}
+	}
 }
 
 impl Future for TestGate {
@@ -59,6 +79,295 @@ fn dispatch_visibility_change() {
 	document
 		.dispatch_event(&event)
 		.expect("dispatch visibility event");
+}
+
+fn retry_policy(delay: Duration) -> RetryPolicy<String> {
+	RetryPolicy::exponential()
+		.max_attempts(3)
+		.base_delay(delay)
+		.max_delay(delay)
+}
+
+#[wasm_bindgen_test(async)]
+async fn first_failure_uses_one_maintenance_timer_and_retries_after_the_delay() {
+	let client = QueryClient::new(QueryDefaults::default());
+	let family = QueryFamily::<(), u32, String>::new("wasm.retry-first-failure");
+	let fetch_count = Rc::new(Cell::new(0));
+	let _query = client.observe_for_test(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				let call = fetch_count.get() + 1;
+				fetch_count.set(call);
+				async move {
+					if call == 1 {
+						Err("offline".to_string())
+					} else {
+						Ok(call)
+					}
+				}
+			}
+		}),
+		QueryOptions::new().retry(retry_policy(Duration::from_millis(120))),
+	);
+
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+
+	settle_after(Duration::from_millis(40)).await;
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+
+	settle_after(Duration::from_millis(90)).await;
+	assert_eq!(fetch_count.get(), 2);
+}
+
+#[wasm_bindgen_test(async)]
+async fn hiding_during_retry_backoff_removes_the_timer_and_stops_elapsed_time() {
+	let client = QueryClient::new(QueryDefaults::default());
+	let family = QueryFamily::<(), u32, String>::new("wasm.retry-hidden-backoff");
+	let fetch_count = Rc::new(Cell::new(0));
+	let _query = client.observe_for_test(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				fetch_count.set(fetch_count.get() + 1);
+				async { Err("offline".to_string()) }
+			}
+		}),
+		QueryOptions::new().retry(retry_policy(Duration::from_millis(120))),
+	);
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+
+	set_query_visibility_for_test(&client, false);
+	dispatch_visibility_change();
+	assert_eq!(query_browser_resource_counts(&client), (1, 0));
+
+	settle_after(Duration::from_millis(100)).await;
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(query_browser_resource_counts(&client), (1, 0));
+}
+
+#[wasm_bindgen_test(async)]
+async fn failure_that_settles_while_hidden_keeps_the_full_delay_without_a_timer() {
+	let client = QueryClient::new(QueryDefaults::default());
+	let family = QueryFamily::<(), u32, String>::new("wasm.retry-hidden-failure");
+	let ready = Rc::new(Cell::new(false));
+	let waker = Rc::new(RefCell::new(None));
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe_for_test(
+		family.query((), {
+			let ready = Rc::clone(&ready);
+			let waker = Rc::clone(&waker);
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				let call = fetch_count.get() + 1;
+				fetch_count.set(call);
+				TestResultGate {
+					ready: (call == 2).then(|| Rc::clone(&ready)),
+					waker: Rc::clone(&waker),
+					result: if call == 2 {
+						Err("offline".to_string())
+					} else {
+						Ok(call)
+					},
+				}
+			}
+		}),
+		QueryOptions::new()
+			.stale_time(Duration::from_secs(10))
+			.retry(retry_policy(Duration::from_millis(120))),
+	);
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(query.data(), Some(1));
+
+	query.refetch();
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(fetch_count.get(), 2);
+	assert!(query.is_fetching());
+
+	set_query_visibility_for_test(&client, false);
+	dispatch_visibility_change();
+	open_gate(&ready, &waker);
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(query_browser_resource_counts(&client), (1, 0));
+
+	settle_after(Duration::from_millis(80)).await;
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(query_browser_resource_counts(&client), (1, 0));
+
+	set_query_visibility_for_test(&client, true);
+	dispatch_visibility_change();
+	settle_after(Duration::from_millis(40)).await;
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+
+	settle_after(Duration::from_millis(90)).await;
+	assert_eq!(fetch_count.get(), 3);
+	assert_eq!(query.data(), Some(3));
+}
+
+#[wasm_bindgen_test(async)]
+async fn stale_visibility_resume_retries_immediately() {
+	let client = QueryClient::new(QueryDefaults::default());
+	let family = QueryFamily::<(), u32, String>::new("wasm.retry-stale-resume");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe_for_test(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				let call = fetch_count.get() + 1;
+				fetch_count.set(call);
+				async move {
+					(call == 1)
+						.then_some(call)
+						.ok_or_else(|| "offline".to_string())
+				}
+			}
+		}),
+		QueryOptions::new()
+			.stale_time(Duration::from_millis(40))
+			.retry(retry_policy(Duration::from_millis(100)).max_attempts(2)),
+	);
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(query.data(), Some(1));
+
+	query.refetch();
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(fetch_count.get(), 2);
+	set_query_visibility_for_test(&client, false);
+	dispatch_visibility_change();
+	settle_after(Duration::from_millis(50)).await;
+	assert_eq!(fetch_count.get(), 2);
+
+	set_query_visibility_for_test(&client, true);
+	dispatch_visibility_change();
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(fetch_count.get(), 3);
+	assert_eq!(query.data(), Some(1));
+	assert_eq!(query.refetch_error(), Some("offline".to_string()));
+	assert_eq!(query_browser_resource_counts(&client), (1, 0));
+}
+
+#[wasm_bindgen_test(async)]
+async fn fresh_visibility_resume_waits_the_saved_remaining_retry_delay() {
+	let client = QueryClient::new(QueryDefaults::default());
+	let family = QueryFamily::<(), u32, String>::new("wasm.retry-fresh-resume");
+	let fetch_count = Rc::new(Cell::new(0));
+	let query = client.observe_for_test(
+		family.query((), {
+			let fetch_count = Rc::clone(&fetch_count);
+			move || {
+				let call = fetch_count.get() + 1;
+				fetch_count.set(call);
+				async move {
+					if call == 2 {
+						Err("offline".to_string())
+					} else {
+						Ok(call)
+					}
+				}
+			}
+		}),
+		QueryOptions::new()
+			.stale_time(Duration::from_secs(10))
+			.retry(retry_policy(Duration::from_millis(120))),
+	);
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(query.data(), Some(1));
+
+	query.refetch();
+	settle_after(Duration::from_millis(20)).await;
+	assert_eq!(fetch_count.get(), 2);
+	set_query_visibility_for_test(&client, false);
+	dispatch_visibility_change();
+	settle_after(Duration::from_millis(100)).await;
+	assert_eq!(fetch_count.get(), 2);
+
+	set_query_visibility_for_test(&client, true);
+	dispatch_visibility_change();
+	settle_after(Duration::from_millis(40)).await;
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+
+	settle_after(Duration::from_millis(70)).await;
+	assert_eq!(fetch_count.get(), 3);
+	assert_eq!(query.data(), Some(3));
+}
+
+#[wasm_bindgen_test(async)]
+async fn removing_shortest_retry_policy_recomputes_the_one_timer() {
+	let client = QueryClient::new(QueryDefaults::default());
+	let family = QueryFamily::<(), u32, String>::new("wasm.retry-remove-shortest");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			fetch_count.set(fetch_count.get() + 1);
+			async { Err("offline".to_string()) }
+		}
+	});
+	let faster = client.observe_for_test(
+		descriptor.clone(),
+		QueryOptions::new().retry(retry_policy(Duration::from_millis(60)).max_attempts(2)),
+	);
+	let slower = client.observe_for_test(
+		descriptor,
+		QueryOptions::new().retry(retry_policy(Duration::from_millis(120)).max_attempts(2)),
+	);
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+
+	settle_after(Duration::from_millis(20)).await;
+	drop(faster);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+
+	settle_after(Duration::from_millis(50)).await;
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+
+	settle_after(Duration::from_millis(60)).await;
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(slower.error(), Some("offline".to_string()));
+}
+
+#[wasm_bindgen_test(async)]
+async fn poll_retry_and_gc_share_one_timer_and_final_drop_releases_resources() {
+	let client = QueryClient::new(QueryDefaults::default());
+	let poll_family = QueryFamily::<(), u32, String>::new("wasm.resources-poll");
+	let poll_query = client.observe_for_test(
+		poll_family.query((), || async { Ok(1) }),
+		QueryOptions::new()
+			.stale_time(Duration::from_secs(10))
+			.refetch_interval(Duration::from_millis(120)),
+	);
+	let retry_family = QueryFamily::<(), u32, String>::new("wasm.resources-retry");
+	let retry_query = client.observe_for_test(
+		retry_family.query((), || async { Err("offline".to_string()) }),
+		QueryOptions::new().retry(retry_policy(Duration::from_millis(80))),
+	);
+	let gc_family = QueryFamily::<(), u32, String>::new("wasm.resources-gc");
+	let gc_query = client.observe_for_test(
+		gc_family.query((), || async { Ok(1) }),
+		QueryOptions::new().gc_time(Duration::from_millis(100)),
+	);
+	settle_after(Duration::from_millis(5)).await;
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+
+	drop(gc_query);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+	drop(retry_query);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+	drop(poll_query);
+	assert_eq!(query_browser_resource_counts(&client), (1, 1));
+
+	let resources = query_browser_resource_probe_for_test(&client);
+	drop(client);
+	assert_eq!(resources.counts(), (0, 0));
 }
 
 #[wasm_bindgen_test(async)]


### PR DESCRIPTION
## Summary

This PR addresses:

- `Fixes #5844`
- Adds a typed, configurable `RetryPolicy<E>` for query fetching with bounded exponential backoff, optional jitter, and error predicates.
- Coordinates retry candidates across observers, including cancellation, visibility pausing, manual retries, and earliest-deadline rescheduling.
- Preserves the existing `use_query::<T, E>(...)` turbofish form while forwarding retry options through the page and server-function APIs.
- Gates retries during SSR, keeps hydration on settled query results, and documents the migration and policy behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes an issue nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Queries previously had no configurable retry contract: transient failures were surfaced immediately and callers could not bound attempts or control backoff. This change makes retry behavior explicit and typed while keeping failures observable and preventing retry work from continuing after the final lease is dropped. Browser timers, hidden-document behavior, SSR deadlines, and observer-specific policies are coordinated so one query sequence remains bounded and deterministic.

## How Was This Tested?

- `cargo check -p reinhardt-pages --all-features`
- `cargo build -p reinhardt-pages --all-features`
- `cargo test -p reinhardt-pages --doc --all-features` (44 passed, 0 failed in the primary set)
- Focused native query/retry suites, including SSR retry tests (8/8) and the coordinator regression filter (178/178)
- Browser/WASM retry regression suite (11/11)
- `cargo make fmt-check`
- `git diff --check`
- `cargo make placeholder-check` (0 findings)

The full all-features nextest, workspace clippy, SemVer, and fresh UI/WASM CI-shaped runs were not completed locally because isolated cold dependency builds and the unavailable wasm-pack runner exceeded the bounded execution window; no test failure was observed in those interrupted runs. The focused fixtures and equivalent regression suites completed above are green.

## Performance Impact

Retry work is bounded by policy and shares one earliest browser deadline per query sequence. Jitter is optional, and disabled retries do not schedule timers or consume samples.

## Breaking Changes

Not applicable; the existing two-parameter `use_query` turbofish API remains source-compatible.

## Screenshots

Not applicable; this is a query/runtime API and documentation change.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

## Related Issues

- #5844

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement
- [ ] `bug` - Bug fix
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Scope Label (select all that apply)
- [x] `api` - REST API, serializers, views
- [x] `pages` - Page/query runtime
- [x] `frontend` - Frontend behavior

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or enhancement
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The final scoped review found no remaining Critical, Important, or Minor findings. The branch contains the implementation, regression fixtures, and documentation as separate focused commits.
