### PR TITLE
chore(deps): clean up cargo-deny exceptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -604,7 +604,7 @@ reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", vers
 reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.4.0-alpha.6" }
 
 # Streaming
-rskafka = { version = "0.5" }
+rskafka = { version = "0.6" }
 # Workaround for time-rs/time#783.
 # Remove when time 0.3.48+ no longer causes coherence conflicts in downstream
 # blanket impls.

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -21,7 +21,6 @@ toml = { workspace = true }
 nom = { workspace = true }
 reinhardt-core = { workspace = true, default-features = false, features = ["exception", "macros", "validators"] }
 reinhardt-macros = { workspace = true }
-dotenv = "0.15"
 url = "2.5"
 percent-encoding = "2.3"
 secrecy = "0.10.3"

--- a/deny.toml
+++ b/deny.toml
@@ -13,26 +13,22 @@ targets = [
 [advisories]
 db-urls = ["https://github.com/rustsec/advisory-db"]
 git-fetch-with-cli = true
-unused-ignored-advisory = "allow"
+unused-ignored-advisory = "warn"
 ignore = [
   { id = "RUSTSEC-2025-0009", reason = "ring 0.16.20 is retained by cloud-storage; Reinhardt's active JWT path uses jsonwebtoken 10 with aws-lc." },
   { id = "RUSTSEC-2023-0071", reason = "rsa 0.9.10 is retained by sqlx-mysql and the advisory has no patched release." },
-  { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 is retained by AWS SDK and Kafka TLS transports; remediation is tracked in issue #5492." },
-  { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101.7 is retained by AWS SDK and Kafka TLS transports; remediation is tracked in issue #5492." },
-  { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 is retained by AWS SDK and Kafka TLS transports; remediation is tracked in issue #5492." },
+  { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 is retained by AWS SDK TLS transports; the Kafka path has been remediated and remaining work is tracked in issue #5492." },
+  { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101.7 is retained by AWS SDK TLS transports; the Kafka path has been remediated and remaining work is tracked in issue #5492." },
+  { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 is retained by AWS SDK TLS transports; the Kafka path has been remediated and remaining work is tracked in issue #5492." },
   { id = "RUSTSEC-2025-0141", reason = "bincode 1 and 2 are retained by syntect and the optional authentication serializer; remediation is tracked in issue #5492." },
-  { id = "RUSTSEC-2021-0141", reason = "dotenv remains a direct configuration dependency; migration is tracked in issue #5492." },
+  { id = "RUSTSEC-2021-0141", reason = "dotenv is retained transitively by cloud-storage; migration is tracked in issue #5492." },
   { id = "RUSTSEC-2025-0057", reason = "fxhash is retained transitively by static asset processing dependencies; remediation is tracked in issue #5492." },
-  { id = "RUSTSEC-2026-0174", reason = "http-types is retained by transitive storage dependencies; remediation is tracked in issue #5492." },
-  { id = "RUSTSEC-2024-0384", reason = "instant is retained by transitive dependencies; remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2024-0436", reason = "paste remains a direct workspace dependency; migration is tracked in issue #5492." },
   { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is retained by transitive macro dependencies; remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is retained by transitive macro dependencies; remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2025-0010", reason = "ring 0.16 is retained by cloud-storage and is already covered by the release security audit rationale." },
   { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile remains a direct commands dependency and is also retained transitively; remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2024-0320", reason = "yaml-rust is retained by transitive configuration dependencies; remediation is tracked in issue #5492." },
-  { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.31 is retained by Azure SDK dependencies and quick-xml 0.38 remediation is tracked in issue #5492." },
-  { id = "RUSTSEC-2026-0195", reason = "quick-xml 0.31 is retained by Azure SDK dependencies and quick-xml 0.38 remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2022-0081", reason = "evcxr 0.21.1 requires unmaintained json 0.12.4; replacement is tracked in evcxr/evcxr#489 and issue #5825." },
 ]
 
@@ -149,8 +145,6 @@ skip = [
   { crate = "yoke-derive@0.7.5", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "zerovec@0.10.4", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "zerovec-derive@0.10.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
-  { crate = "zstd@0.12.4", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
-  { crate = "zstd-safe@6.0.6", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "block-buffer@0.10.4", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "bson@2.15.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "chrono-tz-build@0.2.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- upgrade `rskafka` from 0.5 to 0.6 so the Kafka TLS path uses `rustls-webpki 0.103.13`;
- remove the unused direct `dotenv` dependency from `reinhardt-conf` while documenting its remaining `cloud-storage` path;
- remove four stale advisory ignores and two stale duplicate-version skips from `deny.toml`;
- warn when ignored advisories become unused and retain the AWS SDK `rustls-webpki 0.101.7` exceptions with accurate rationale.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [x] Other: dependency maintenance

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The all-features dependency graph had stale cargo-deny exceptions and an unnecessary direct dependency. Upgrading rskafka removes the Kafka path to the vulnerable rustls-webpki line, while a fresh graph shows that AWS SDK transports still require the three related exceptions.

Related to: #5492, #5825

## How Was This Tested?

- `cargo check -p reinhardt-conf --all-features`
- `cargo nextest run -p reinhardt-streaming --all-features` (31 passed)
- `cargo deny --workspace --all-features check`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (existing Kafka integration tests cover the dependency upgrade)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (not applicable)
- [ ] I have formatted the code with `cargo make fmt-fix` (`cargo fmt --all -- --check` passed)
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #5492
- Related to #5825

## Labels to Apply

### Type Label (select one)
- [x] `code-quality` - Code quality improvements

### Scope Label (select all that apply)

- None

### Priority Label (for maintainers)

- [ ] `medium` - Normal priority

---

**Additional Context:**

The repository lockfile is ignored, so the cargo-deny result was verified from a newly generated Rust 1.96-compatible lockfile. The three rustls-webpki advisory exceptions remain because AWS SDK still resolves rustls 0.21; only the Kafka path is remediated here.