### PR TITLE
feat(commands): add client styles to Pages app templates

### DIFF
--- a/.github/scripts/build-wasm-consumer-fixture.sh
+++ b/.github/scripts/build-wasm-consumer-fixture.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Generate a wasm SPA-shaped consumer using reinhardt-admin templates and
-# exercise the macro re-exports gated by Issue #4161.
+# verify native target gating and WASM macro re-exports gated by Issue #4161.
 #
 # The scaffold itself (`startproject --with-pages` + `startapp --with-pages`)
 # exercises the core re-exports (app_config, routes macro, AppLabel via
@@ -54,7 +54,11 @@ else
 fi
 echo "::endgroup::"
 
-echo "::group::4) cargo check --target wasm32-unknown-unknown --lib (the gate)"
+echo "::group::4) cargo check --lib (native client-gating gate)"
+cargo check --lib
+echo "::endgroup::"
+
+echo "::group::5) cargo check --target wasm32-unknown-unknown --lib (WASM style gate)"
 cargo check --target wasm32-unknown-unknown --lib
 echo "::endgroup::"
 

--- a/README.md
+++ b/README.md
@@ -406,13 +406,14 @@ src/
 ├── apps/
 │   ├── polls.rs                  # per-app entry (sibling of polls/)
 │   └── polls/
-│       ├── client.rs             # #[cfg(client)] aggregator: components and hooks
+│       ├── client.rs             # #[cfg(client)] aggregator: components, hooks, and styles
 │       ├── client/
 │       │   ├── components.rs     # per-app component aggregator
 │       │   ├── components/
 │       │   │   └── placeholder.rs # route-backed placeholder component
 │       │   ├── hooks.rs          # custom hook aggregator
-│       │   └── hooks/           # (.gitkeep — one custom hook per .rs file)
+│       │   ├── hooks/            # (.gitkeep — one custom hook per .rs file)
+│       │   └── style.rs          # component-scoped style definitions
 │       ├── models.rs             # shared models and wire-safe info types
 │       ├── serializers.rs        # serializer aggregator
 │       ├── serializers/          # (.gitkeep — user adds submodules here)

--- a/crates/reinhardt-commands/templates/app_pages_template/client.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/client.rs.tpl
@@ -5,7 +5,9 @@
 //!
 //! The freshly generated app contains a route-backed placeholder component
 //! under `components/placeholder.rs`. Register additional components from
-//! `../urls/client_router.rs` as the app grows.
+//! `../urls/client_router.rs` as the app grows. Add component-scoped styles in
+//! `style.rs`.
 
 pub mod components;
 pub mod hooks;
+pub mod style;

--- a/crates/reinhardt-commands/templates/app_pages_template/client/style.rs.tpl
+++ b/crates/reinhardt-commands/templates/app_pages_template/client/style.rs.tpl
@@ -1,0 +1,9 @@
+//! Component styles for the {{ app_name }} application.
+
+use reinhardt::pages::style_def;
+
+/// Component styles for the {{ app_name }} application.
+#[style_def]
+pub static STYLES: {{ camel_case_app_name }}Styles = style! {
+    // Add component styles here.
+};

--- a/crates/reinhardt-commands/tests/e2e_pages.rs
+++ b/crates/reinhardt-commands/tests/e2e_pages.rs
@@ -49,6 +49,24 @@ fn pages_context(args: Vec<String>) -> CommandContext {
 	ctx
 }
 
+fn assert_empty_client_style(style_rs: &str, app_name: &str, style_type: &str) {
+	let expected = format!(
+		concat!(
+			"//! Component styles for the {app_name} application.\n\n",
+			"use reinhardt::pages::style_def;\n\n",
+			"/// Component styles for the {app_name} application.\n",
+			"#[style_def]\n",
+			"pub static STYLES: {style_type} = style! {{\n",
+			"    // Add component styles here.\n",
+			"}};\n",
+		),
+		app_name = app_name,
+		style_type = style_type,
+	);
+
+	assert_eq!(style_rs, expected);
+}
+
 fn assert_models_placeholder_is_tutorial_safe(
 	models_rs: &str,
 	app_label: &str,
@@ -479,8 +497,16 @@ async fn app_pages_layout_matches_tutorial() {
 	assert!(
 		client_rs.contains("pub mod components;")
 			&& client_rs.contains("pub mod hooks;")
+			&& client_rs.contains("pub mod style;")
 			&& !client_rs.contains("pub mod pages;"),
 		"apps/polls/client.rs must be a client-only facade, not a mixed route-entry facade:\n{client_rs}"
+	);
+	let style_rs = fs::read_to_string(polls_dir.join("client").join("style.rs"))
+		.expect("read apps/polls/client/style.rs");
+	assert_empty_client_style(&style_rs, "polls", "PollsStyles");
+	assert!(
+		!polls_dir.join("style.rs").exists(),
+		"apps/polls/style.rs must not exist; component styles are client-only"
 	);
 	let hooks_rs = fs::read_to_string(polls_dir.join("client").join("hooks.rs"))
 		.expect("read apps/polls/client/hooks.rs");
@@ -796,8 +822,16 @@ async fn workspace_app_pages_uses_unified_template() {
 	let workspace_client_rs =
 		fs::read_to_string(src.join("client.rs")).expect("read apps/bar/src/client.rs");
 	assert!(
-		workspace_client_rs.contains("pub mod hooks;"),
-		"apps/bar/src/client.rs must declare the custom hooks module:\n{workspace_client_rs}"
+		workspace_client_rs.contains("pub mod hooks;")
+			&& workspace_client_rs.contains("pub mod style;"),
+		"apps/bar/src/client.rs must declare the custom hooks and style modules:\n{workspace_client_rs}"
+	);
+	let workspace_style_rs = fs::read_to_string(src.join("client").join("style.rs"))
+		.expect("read apps/bar/src/client/style.rs");
+	assert_empty_client_style(&workspace_style_rs, "bar", "BarStyles");
+	assert!(
+		!src.join("style.rs").exists(),
+		"apps/bar/src/style.rs must not exist; component styles are client-only"
 	);
 	let workspace_hooks_rs = fs::read_to_string(src.join("client").join("hooks.rs"))
 		.expect("read apps/bar/src/client/hooks.rs");
@@ -1050,5 +1084,69 @@ async fn module_app_pages_does_not_generate_workspace_files() {
 			.contains("#[reinhardt::pages::component(\"/baz/\", name = \"placeholder\")]")
 			&& !placeholder_rs.contains("super::"),
 		"module placeholder component must be route-backed without super:: paths:\n{placeholder_rs}"
+	);
+}
+
+#[rstest]
+#[tokio::test]
+#[serial(cwd)]
+async fn startapp_pages_template_dir_overrides_client_style() {
+	// Arrange
+	let tmp = TempDir::new().unwrap();
+	let project_name = "styled_project";
+	scaffold_pages_project(tmp.path(), project_name).await;
+
+	let override_client = tmp
+		.path()
+		.join("overrides")
+		.join("app_pages_template")
+		.join("client");
+	fs::create_dir_all(&override_client).expect("create client template override directory");
+	fs::write(
+		override_client.join("style.rs.tpl"),
+		concat!(
+			"//! External style template for {{ app_name }}.\n\n",
+			"use reinhardt::pages::style_def;\n\n",
+			"#[style_def]\n",
+			"pub static STYLES: {{ camel_case_app_name }}OverrideStyles = style! {};\n",
+		),
+	)
+	.expect("write client style template override");
+
+	let project_dir = tmp.path().join(project_name);
+	let _cwd_guard = CwdGuard::enter(&project_dir);
+	let mut options = HashMap::new();
+	options.insert("with-pages".to_string(), vec!["true".to_string()]);
+	options.insert(
+		"template-dir".to_string(),
+		vec![tmp.path().join("overrides").display().to_string()],
+	);
+	let context = CommandContext::new(vec!["themed".to_string()]).with_options(options);
+
+	// Act
+	let result = StartAppCommand.execute(&context).await;
+
+	// Assert
+	result.expect("startapp --with-pages with a partial template override must succeed");
+	let app_dir = project_dir.join("src").join("apps").join("themed");
+	let client_rs =
+		fs::read_to_string(app_dir.join("client.rs")).expect("read apps/themed/client.rs");
+	assert_eq!(
+		client_rs
+			.lines()
+			.filter(|line| *line == "pub mod style;")
+			.count(),
+		1
+	);
+	let style_rs = fs::read_to_string(app_dir.join("client").join("style.rs"))
+		.expect("read overridden apps/themed/client/style.rs");
+	assert_eq!(
+		style_rs,
+		concat!(
+			"//! External style template for themed.\n\n",
+			"use reinhardt::pages::style_def;\n\n",
+			"#[style_def]\n",
+			"pub static STYLES: ThemedOverrideStyles = style! {};\n",
+		)
 	);
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Generate a client-gated `client/style.rs` module for regular and workspace Pages app scaffolds.
- Provide a minimal app-specific `#[style_def]` definition that emits no initial CSS.
- Preserve partial filesystem template overrides for the new style template.
- Extend the consumer fixture to validate the generated style definition on native and WASM targets.
- Document the generated client style location in the root scaffold layout.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Fresh Pages app scaffolds did not provide a canonical source file for component style definitions. Applications had to create the module manually and infer the supported `#[style_def]` / `style!` pattern.

The generated module now lives below the existing client-only facade, so native server builds retain the intended client gating while WASM builds discover the style definition. The empty definition establishes the supported API without imposing a design system or emitting default CSS.

Fixes #5964

Related to: none

## How Was This Tested?

- [x] `cargo test -p reinhardt-commands --test e2e_pages` — 6 passed.
- [x] `cargo test -p reinhardt-manouche --test style_pipeline empty_style_serializes_to_zero_bytes` — 1 passed.
- [x] `.github/scripts/build-wasm-consumer-fixture.sh` — generated scaffold passed native and `wasm32-unknown-unknown` library checks.
- [x] `cargo make fmt-check` — no formatting changes required.
- [x] `cargo make clippy-check` — passed with warnings denied.
- [ ] `cargo nextest run --workspace --all-features` — 2,326 passed before fail-fast; one unrelated existing macOS path canonicalization assertion failed after three attempts in `reinhardt-commands shell::evaluator::tests::project_path_dependency_enables_commands_shell_feature` because `/private/var/...` was compared with `/var/...`. The failing source file is unchanged by this PR.

Regular and workspace scaffold tests verify the generated paths and module wiring. The generated consumer gate validates the new style definition on native and WASM targets. Existing workspace scaffold manifest dependency inheritance is outside this style-only change and is tracked separately.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (see the unrelated full-suite failure above)
- [x] I have tested with all affected database backends (not applicable; no database behavior changed)
- [x] I have formatted the code with `cargo make fmt-fix` (`cargo make fmt-check` reports no changes)
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #5964

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `pages` - Pages application scaffolding
- [x] `dx` - Developer experience
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - Native/WASM consumer fixture coverage

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The style file is intentionally generated at `client/style.rs`, not at the app root. This keeps the style module below the existing `#[cfg(client)]` boundary in both supported layouts. The generated `style! {}` body is empty, so scaffolding adds no default design output.

🤖 Generated with [Codex](https://openai.com/codex)