### PR TITLE
feat(admin): add ModelAdmin fieldsets

### DIFF
--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -116,6 +116,10 @@ use crate::models::User;
 	list_display = [username, email, is_active],
 	list_filter = [is_active],
 	search_fields = [username, email],
+	fieldsets = [
+		(title = "Identity", fields = [username, email]),
+		(title = "Status", fields = [is_active], collapsed = true)
+	],
 	ordering = [(date_joined, desc)],
 	list_per_page = 25,
 )]
@@ -125,6 +129,30 @@ pub struct UserAdmin;
 The `#[admin(model, ...)]` attribute expands to a full `ModelAdmin` implementation
 at compile time, so you never need to write boilerplate field structs or
 `impl Default` blocks.
+
+### Grouping Form Fields
+
+Without `fieldsets`, the existing `fields` configuration keeps forms flat. Use
+one or the other; configuring both is rejected. Programmatic configurations use
+the same ordered `Fieldset` descriptors as the macro:
+
+```rust
+use reinhardt::admin::{Fieldset, ModelAdmin, ModelAdminConfig};
+
+let grouped = ModelAdminConfig::builder()
+	.model_name("Article")
+	.fieldsets(vec![
+		Fieldset::new(Some("Content"), &["title", "body"]),
+		Fieldset::new(Some("Publishing"), &["published_at"]).collapsed(),
+	])
+	.build()
+	.unwrap();
+assert!(grouped.fieldsets().unwrap()[1].collapsed);
+```
+
+`collapsed` sets only the initial state of the native `<details>` element; the
+open state is not persisted. Fieldsets do not support nesting, custom layout
+classes, layout grids, or inline form configuration.
 
 ## Architecture
 

--- a/crates/reinhardt-admin/assets/style.css
+++ b/crates/reinhardt-admin/assets/style.css
@@ -253,6 +253,10 @@ img, svg, video { display: block; max-width: 100%; }
 
 .admin-label { display: block; font-size: var(--font-size-0); font-weight: 500; color: var(--admin-muted); margin-bottom: var(--size-1); }
 
+.admin-fieldset { border: var(--border-size-1) solid var(--admin-border); }
+.admin-fieldset summary { cursor: pointer; font-weight: 600; }
+.admin-fieldset summary:focus-visible { outline: 2px solid var(--admin-amber); outline-offset: 2px; }
+
 /* ===  Alerts  === */
 
 .admin-alert { padding: var(--size-4) var(--size-5); border-radius: var(--radius-2); font-size: var(--font-size-1); line-height: 1.5; }

--- a/crates/reinhardt-admin/src/adapters.rs
+++ b/crates/reinhardt-admin/src/adapters.rs
@@ -29,6 +29,6 @@ pub use crate::types::{
 pub use crate::types::{
 	AdminError, BulkDeleteRequest, BulkDeleteResponse, ColumnInfo, DashboardResponse,
 	DetailResponse, ExportFormat as RequestExportFormat, ExportResponse, FieldInfo, FieldType,
-	FieldsResponse, FilterChoice, FilterInfo, FilterType, ImportResponse, ListQueryParams,
-	ListResponse, LoginResponse, ModelInfo, MutationRequest, MutationResponse,
+	FieldsResponse, Fieldset, FilterChoice, FilterInfo, FilterType, ImportResponse,
+	ListQueryParams, ListResponse, LoginResponse, ModelInfo, MutationRequest, MutationResponse,
 };

--- a/crates/reinhardt-admin/src/core.rs
+++ b/crates/reinhardt-admin/src/core.rs
@@ -16,8 +16,8 @@ pub mod site;
 // Re-exports
 pub use crate::types::{
 	AdminError, AdminResult, BulkDeleteRequest, BulkDeleteResponse, ColumnInfo, DashboardResponse,
-	DetailResponse, ExportFormat as TypesExportFormat, FieldInfo, FieldType, FilterChoice,
-	FilterInfo, FilterType, ImportResponse, ListQueryParams, ListResponse, ModelInfo,
+	DetailResponse, ExportFormat as TypesExportFormat, FieldInfo, FieldType, Fieldset,
+	FilterChoice, FilterInfo, FilterType, ImportResponse, ListQueryParams, ListResponse, ModelInfo,
 	MutationRequest, MutationResponse,
 };
 pub use database::{AdminDatabase, AdminDatabaseKey, AdminRecord};
@@ -25,6 +25,8 @@ pub use export::{CsvExporter, ExportBuilder, ExportConfig, ExportFormat, JsonExp
 pub use import::{
 	CsvImporter, ImportBuilder, ImportConfig, ImportError, ImportFormat, ImportResult, JsonImporter,
 };
-pub use model_admin::{AdminUser, ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder};
+pub use model_admin::{
+	AdminUser, ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder, resolve_form_fields,
+};
 pub use router::{admin_csp_exempt_paths, admin_routes_with_di, admin_static_routes};
 pub use site::{AdminSite, AdminSiteConfig, AdminSiteKey};

--- a/crates/reinhardt-admin/src/core/model_admin.rs
+++ b/crates/reinhardt-admin/src/core/model_admin.rs
@@ -537,6 +537,11 @@ fn validate_fieldsets(fields_configured: bool, fieldsets: Option<&[Fieldset]>) -
 	let Some(fieldsets) = fieldsets else {
 		return Ok(());
 	};
+	if fieldsets.is_empty() {
+		return Err(AdminError::ValidationError(
+			"fieldsets cannot be empty".to_string(),
+		));
+	}
 	let mut fields = HashSet::new();
 	for fieldset in fieldsets {
 		if fieldset.fields.is_empty() {
@@ -727,6 +732,16 @@ mod tests {
 	}
 
 	#[rstest]
+	fn test_builder_rejects_empty_fieldset_collection() {
+		let result = ModelAdminConfig::builder()
+			.model_name("Article")
+			.fieldsets(vec![])
+			.build();
+
+		assert!(matches!(result, Err(AdminError::ValidationError(_))));
+	}
+
+	#[rstest]
 	fn test_builder_rejects_repeated_fieldset_fields() {
 		let result = ModelAdminConfig::builder()
 			.model_name("Article")
@@ -776,6 +791,27 @@ mod tests {
 
 			fn fieldsets(&self) -> Option<Vec<Fieldset>> {
 				Some(vec![Fieldset::new(Some("Main"), &[])])
+			}
+		}
+
+		assert!(matches!(
+			resolve_form_fields(&InvalidAdmin),
+			Err(AdminError::ValidationError(_))
+		));
+	}
+
+	#[rstest]
+	fn test_resolve_form_fields_rejects_manual_empty_fieldsets() {
+		struct InvalidAdmin;
+
+		#[async_trait]
+		impl ModelAdmin for InvalidAdmin {
+			fn model_name(&self) -> &str {
+				"Article"
+			}
+
+			fn fieldsets(&self) -> Option<Vec<Fieldset>> {
+				Some(vec![])
 			}
 		}
 

--- a/crates/reinhardt-admin/src/core/model_admin.rs
+++ b/crates/reinhardt-admin/src/core/model_admin.rs
@@ -2,8 +2,9 @@
 //!
 //! This module defines how models are displayed and managed in the admin interface.
 
-use crate::types::{AdminError, AdminResult};
+use crate::types::{AdminError, AdminResult, Fieldset};
 use async_trait::async_trait;
+use std::collections::HashSet;
 
 /// Object-safe trait for admin permission checks.
 ///
@@ -98,6 +99,11 @@ pub trait ModelAdmin: Send + Sync {
 		None
 	}
 
+	/// Fieldsets to display in forms (None = no grouped layout).
+	fn fieldsets(&self) -> Option<Vec<Fieldset>> {
+		None
+	}
+
 	/// Read-only fields
 	fn readonly_fields(&self) -> Vec<&str> {
 		vec![]
@@ -180,6 +186,7 @@ pub struct ModelAdminConfig {
 	list_filter: Vec<String>,
 	search_fields: Vec<String>,
 	fields: Option<Vec<String>>,
+	fieldsets: Option<Vec<Fieldset>>,
 	readonly_fields: Vec<String>,
 	ordering: Vec<String>,
 	list_per_page: Option<usize>,
@@ -209,6 +216,7 @@ impl ModelAdminConfig {
 			list_filter: vec![],
 			search_fields: vec![],
 			fields: None,
+			fieldsets: None,
 			readonly_fields: vec![],
 			ordering: vec!["-id".into()],
 			list_per_page: None,
@@ -289,6 +297,10 @@ impl ModelAdmin for ModelAdminConfig {
 			.map(|f| f.iter().map(|s| s.as_str()).collect())
 	}
 
+	fn fieldsets(&self) -> Option<Vec<Fieldset>> {
+		self.fieldsets.clone()
+	}
+
 	fn readonly_fields(&self) -> Vec<&str> {
 		self.readonly_fields.iter().map(|s| s.as_str()).collect()
 	}
@@ -328,6 +340,7 @@ pub struct ModelAdminConfigBuilder {
 	list_filter: Option<Vec<String>>,
 	search_fields: Option<Vec<String>>,
 	fields: Option<Vec<String>>,
+	fieldsets: Option<Vec<Fieldset>>,
 	readonly_fields: Option<Vec<String>>,
 	ordering: Option<Vec<String>>,
 	list_per_page: Option<usize>,
@@ -381,6 +394,12 @@ impl ModelAdminConfigBuilder {
 	/// Set form fields
 	pub fn fields(mut self, fields: Vec<impl Into<String>>) -> Self {
 		self.fields = Some(fields.into_iter().map(Into::into).collect());
+		self
+	}
+
+	/// Set grouped form fields.
+	pub fn fieldsets(mut self, fieldsets: Vec<Fieldset>) -> Self {
+		self.fieldsets = Some(fieldsets);
 		self
 	}
 
@@ -466,6 +485,7 @@ impl ModelAdminConfigBuilder {
 		let model_name = self
 			.model_name
 			.ok_or_else(|| AdminError::ValidationError("model_name is required".to_string()))?;
+		validate_fieldsets(self.fields.is_some(), self.fieldsets.as_deref())?;
 
 		Ok(ModelAdminConfig {
 			model_name,
@@ -475,6 +495,7 @@ impl ModelAdminConfigBuilder {
 			list_filter: self.list_filter.unwrap_or_default(),
 			search_fields: self.search_fields.unwrap_or_default(),
 			fields: self.fields,
+			fieldsets: self.fieldsets,
 			readonly_fields: self.readonly_fields.unwrap_or_default(),
 			ordering: self.ordering.unwrap_or_else(|| vec!["-id".into()]),
 			list_per_page: self.list_per_page,
@@ -484,6 +505,54 @@ impl ModelAdminConfigBuilder {
 			allow_delete: self.allow_delete.unwrap_or(false),
 		})
 	}
+}
+
+/// Resolve the configured form fields and optional grouped layout.
+pub fn resolve_form_fields(
+	admin: &dyn ModelAdmin,
+) -> AdminResult<(Vec<String>, Option<Vec<Fieldset>>)> {
+	let fields = admin.fields();
+	let fieldsets = admin.fieldsets();
+	validate_fieldsets(fields.is_some(), fieldsets.as_deref())?;
+
+	if let Some(fieldsets) = fieldsets {
+		let fields = fieldsets
+			.iter()
+			.flat_map(|fieldset| fieldset.fields.iter().cloned())
+			.collect();
+		Ok((fields, Some(fieldsets)))
+	} else {
+		let fields = fields.unwrap_or_else(|| admin.list_display());
+		Ok((fields.into_iter().map(String::from).collect(), None))
+	}
+}
+
+fn validate_fieldsets(fields_configured: bool, fieldsets: Option<&[Fieldset]>) -> AdminResult<()> {
+	if fields_configured && fieldsets.is_some() {
+		return Err(AdminError::ValidationError(
+			"fields and fieldsets cannot be configured together".to_string(),
+		));
+	}
+
+	let Some(fieldsets) = fieldsets else {
+		return Ok(());
+	};
+	let mut fields = HashSet::new();
+	for fieldset in fieldsets {
+		if fieldset.fields.is_empty() {
+			return Err(AdminError::ValidationError(
+				"fieldsets cannot contain empty groups".to_string(),
+			));
+		}
+		for field in &fieldset.fields {
+			if !fields.insert(field.as_str()) {
+				return Err(AdminError::ValidationError(format!(
+					"field '{field}' is repeated across fieldsets"
+				)));
+			}
+		}
+	}
+	Ok(())
 }
 
 #[cfg(all(test, server))]
@@ -575,6 +644,124 @@ mod tests {
 		assert!(result.is_err());
 		let err = result.unwrap_err();
 		assert!(err.to_string().contains("model_name is required"));
+	}
+
+	#[rstest]
+	fn test_model_admin_default_fieldsets_is_none() {
+		let admin = DefaultPermissionAdmin;
+
+		assert_eq!(admin.fieldsets(), None);
+	}
+
+	#[rstest]
+	fn test_builder_fieldsets_retain_title_order_and_collapsed_state() {
+		let admin = ModelAdminConfig::builder()
+			.model_name("Article")
+			.fieldsets(vec![
+				Fieldset::new(Some("Main"), &["title", "body"]),
+				Fieldset::new(Some("Publishing"), &["published_at"]).collapsed(),
+			])
+			.build()
+			.unwrap();
+
+		let fieldsets = admin.fieldsets().unwrap();
+
+		assert_eq!(fieldsets[0].title.as_deref(), Some("Main"));
+		assert_eq!(fieldsets[0].fields, vec!["title", "body"]);
+		assert!(!fieldsets[0].collapsed);
+		assert_eq!(fieldsets[1].title.as_deref(), Some("Publishing"));
+		assert_eq!(fieldsets[1].fields, vec!["published_at"]);
+		assert!(fieldsets[1].collapsed);
+	}
+
+	#[rstest]
+	fn test_resolve_form_fields_preserves_flat_fields() {
+		let admin = ModelAdminConfig::builder()
+			.model_name("Article")
+			.fields(vec!["title", "body"])
+			.build()
+			.unwrap();
+
+		let (fields, fieldsets) = resolve_form_fields(&admin).unwrap();
+
+		assert_eq!(fields, vec!["title", "body"]);
+		assert_eq!(fieldsets, None);
+	}
+
+	#[rstest]
+	fn test_resolve_form_fields_flattens_fieldsets_in_declared_order() {
+		let admin = ModelAdminConfig::builder()
+			.model_name("Article")
+			.fieldsets(vec![
+				Fieldset::new(Some("Main"), &["title", "body"]),
+				Fieldset::new(Some("Publishing"), &["published_at"]).collapsed(),
+			])
+			.build()
+			.unwrap();
+
+		let (fields, fieldsets) = resolve_form_fields(&admin).unwrap();
+
+		assert_eq!(fields, vec!["title", "body", "published_at"]);
+		assert_eq!(fieldsets.unwrap()[1].title.as_deref(), Some("Publishing"));
+	}
+
+	#[rstest]
+	fn test_builder_rejects_fields_and_fieldsets_together() {
+		let result = ModelAdminConfig::builder()
+			.model_name("Article")
+			.fields(vec!["title"])
+			.fieldsets(vec![Fieldset::new(None, &["body"])])
+			.build();
+
+		assert!(matches!(result, Err(AdminError::ValidationError(_))));
+	}
+
+	#[rstest]
+	fn test_builder_rejects_empty_fieldsets() {
+		let result = ModelAdminConfig::builder()
+			.model_name("Article")
+			.fieldsets(vec![Fieldset::new(Some("Main"), &[])])
+			.build();
+
+		assert!(matches!(result, Err(AdminError::ValidationError(_))));
+	}
+
+	#[rstest]
+	fn test_builder_rejects_repeated_fieldset_fields() {
+		let result = ModelAdminConfig::builder()
+			.model_name("Article")
+			.fieldsets(vec![
+				Fieldset::new(Some("Main"), &["title"]),
+				Fieldset::new(Some("Publishing"), &["title"]),
+			])
+			.build();
+
+		assert!(matches!(result, Err(AdminError::ValidationError(_))));
+	}
+
+	#[rstest]
+	fn test_resolve_form_fields_rejects_manual_fields_and_fieldsets_together() {
+		struct InvalidAdmin;
+
+		#[async_trait]
+		impl ModelAdmin for InvalidAdmin {
+			fn model_name(&self) -> &str {
+				"Article"
+			}
+
+			fn fields(&self) -> Option<Vec<&str>> {
+				Some(vec!["title"])
+			}
+
+			fn fieldsets(&self) -> Option<Vec<Fieldset>> {
+				Some(vec![Fieldset::new(None, &["body"])])
+			}
+		}
+
+		assert!(matches!(
+			resolve_form_fields(&InvalidAdmin),
+			Err(AdminError::ValidationError(_))
+		));
 	}
 
 	/// Helper struct for testing default trait permission behavior

--- a/crates/reinhardt-admin/src/core/model_admin.rs
+++ b/crates/reinhardt-admin/src/core/model_admin.rs
@@ -764,6 +764,51 @@ mod tests {
 		));
 	}
 
+	#[rstest]
+	fn test_resolve_form_fields_rejects_manual_empty_fieldset() {
+		struct InvalidAdmin;
+
+		#[async_trait]
+		impl ModelAdmin for InvalidAdmin {
+			fn model_name(&self) -> &str {
+				"Article"
+			}
+
+			fn fieldsets(&self) -> Option<Vec<Fieldset>> {
+				Some(vec![Fieldset::new(Some("Main"), &[])])
+			}
+		}
+
+		assert!(matches!(
+			resolve_form_fields(&InvalidAdmin),
+			Err(AdminError::ValidationError(_))
+		));
+	}
+
+	#[rstest]
+	fn test_resolve_form_fields_rejects_manual_repeated_fieldset_fields() {
+		struct InvalidAdmin;
+
+		#[async_trait]
+		impl ModelAdmin for InvalidAdmin {
+			fn model_name(&self) -> &str {
+				"Article"
+			}
+
+			fn fieldsets(&self) -> Option<Vec<Fieldset>> {
+				Some(vec![
+					Fieldset::new(Some("Main"), &["title"]),
+					Fieldset::new(Some("Publishing"), &["title"]),
+				])
+			}
+		}
+
+		assert!(matches!(
+			resolve_form_fields(&InvalidAdmin),
+			Err(AdminError::ValidationError(_))
+		));
+	}
+
 	/// Helper struct for testing default trait permission behavior
 	struct DefaultPermissionAdmin;
 

--- a/crates/reinhardt-admin/src/lib.rs
+++ b/crates/reinhardt-admin/src/lib.rs
@@ -17,6 +17,53 @@
 //!
 //! ## Examples
 //!
+//! `ModelAdmin::fields()` remains the flat form configuration. Use
+//! `ModelAdmin::fieldsets()` when the form needs ordered groups instead:
+//!
+//! ```rust
+//! use reinhardt_admin::core::{Fieldset, ModelAdmin, ModelAdminConfig};
+//!
+//! let flat = ModelAdminConfig::builder()
+//!     .model_name("Article")
+//!     .fields(vec!["title", "body"])
+//!     .build()
+//!     .unwrap();
+//! assert_eq!(flat.fields(), Some(vec!["title", "body"]));
+//! assert_eq!(flat.fieldsets(), None);
+//!
+//! let grouped = ModelAdminConfig::builder()
+//!     .model_name("Article")
+//!     .fieldsets(vec![
+//!         Fieldset::new(Some("Content"), &["title", "body"]),
+//!         Fieldset::new(Some("Publishing"), &["published_at"]).collapsed(),
+//!     ])
+//!     .build()
+//!     .unwrap();
+//! assert_eq!(grouped.fields(), None);
+//! assert!(grouped.fieldsets().unwrap()[1].collapsed);
+//! ```
+//!
+//! The `#[admin]` macro uses the same descriptors:
+//!
+//! ```ignore
+//! use reinhardt::admin;
+//! use crate::models::Article;
+//!
+//! #[admin(model,
+//!     for = Article,
+//!     name = "Article",
+//!     fieldsets = [
+//!         (title = "Content", fields = [title, body]),
+//!         (fields = [published_at], collapsed = true)
+//!     ]
+//! )]
+//! struct ArticleAdmin;
+//! ```
+//!
+//! `collapsed` controls only the initial native `<details>` state; it is not
+//! persisted. Nested fieldsets, custom layout classes, layout grids, and inline
+//! form configuration are intentionally unsupported.
+//!
 //! ## Available Modules
 //!
 //! - [`adapters`] - Admin adapter implementations

--- a/crates/reinhardt-admin/src/lib.rs
+++ b/crates/reinhardt-admin/src/lib.rs
@@ -40,8 +40,9 @@ pub mod core {
 	//! core types in signatures erased by server functions or native-only macros.
 
 	pub use crate::types::{
-		AdminDatabase, AdminRecord, AdminSite, AdminUser, ExportFormat, ImportBuilder, ImportError,
-		ImportFormat, ImportResult, ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder,
+		AdminDatabase, AdminRecord, AdminSite, AdminUser, ExportFormat, Fieldset, ImportBuilder,
+		ImportError, ImportFormat, ImportResult, ModelAdmin, ModelAdminConfig,
+		ModelAdminConfigBuilder,
 	};
 }
 pub mod pages;

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -513,7 +513,12 @@ pub fn model_form_with_fieldsets(
 	let fieldsets: Vec<Page> = fieldsets
 		.iter()
 		.map(|fieldset| {
-			let summary = fieldset.title.as_deref().unwrap_or("Fields").to_string();
+			let summary = fieldset
+				.title
+				.as_deref()
+				.filter(|title| !title.trim().is_empty())
+				.unwrap_or("Fields")
+				.to_string();
 			let open = !fieldset.collapsed;
 			let form_fields: Vec<Page> = fieldset
 				.fields

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -503,7 +503,8 @@ pub fn model_form(model_name: &str, fields: &[FormField], record_id: Option<&str
 ///
 /// Fields are rendered in fieldset declaration order. Each fieldset uses the
 /// browser's native disclosure behavior and is expanded unless configured as
-/// collapsed.
+/// collapsed. A collapsed group with an empty required field starts expanded so
+/// native form validation keeps the invalid control visible.
 pub fn model_form_with_fieldsets(
 	model_name: &str,
 	fields: &[FormField],
@@ -519,13 +520,16 @@ pub fn model_form_with_fieldsets(
 				.filter(|title| !title.trim().is_empty())
 				.unwrap_or("Fields")
 				.to_string();
-			let open = !fieldset.collapsed;
-			let form_fields: Vec<Page> = fieldset
+			let form_fields: Vec<&FormField> = fieldset
 				.fields
 				.iter()
 				.filter_map(|name| fields.iter().find(|field| field.name == *name))
-				.map(form_group)
 				.collect();
+			let open = !fieldset.collapsed
+				|| form_fields
+					.iter()
+					.any(|field| field.required && field.value.is_empty());
+			let form_fields: Vec<Page> = form_fields.into_iter().map(form_group).collect();
 
 			page!(|summary: String, open: bool, form_fields: Vec<Page>| {
 				details {

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -10,7 +10,7 @@
 
 #[cfg(client)]
 use crate::server::{create_record, delete_record, update_record};
-use crate::types::{FilterInfo, FilterType, ModelInfo};
+use crate::types::{Fieldset, FilterInfo, FilterType, ModelInfo};
 use reinhardt_pages::Signal;
 use reinhardt_pages::component::Page;
 use reinhardt_pages::page;
@@ -488,6 +488,61 @@ fn detail_table(record: &std::collections::HashMap<String, String>) -> Page {
 /// model_form("User", &fields, None)
 /// ```
 pub fn model_form(model_name: &str, fields: &[FormField], record_id: Option<&str>) -> Page {
+	let form_fields: Vec<Page> = fields.iter().map(form_group).collect();
+	let form_groups = page!(|form_fields: Vec<Page>| {
+		div {
+			class: "admin-card p-6",
+			{ form_fields }
+		}
+	})(form_fields);
+
+	model_form_page(model_name, record_id, form_groups)
+}
+
+/// Model form component with configured fieldsets.
+///
+/// Fields are rendered in fieldset declaration order. Each fieldset uses the
+/// browser's native disclosure behavior and is expanded unless configured as
+/// collapsed.
+pub fn model_form_with_fieldsets(
+	model_name: &str,
+	fields: &[FormField],
+	fieldsets: &[Fieldset],
+	record_id: Option<&str>,
+) -> Page {
+	let fieldsets: Vec<Page> = fieldsets
+		.iter()
+		.map(|fieldset| {
+			let summary = fieldset.title.as_deref().unwrap_or("Fields").to_string();
+			let open = !fieldset.collapsed;
+			let form_fields: Vec<Page> = fieldset
+				.fields
+				.iter()
+				.filter_map(|name| fields.iter().find(|field| field.name == *name))
+				.map(form_group)
+				.collect();
+
+			page!(|summary: String, open: bool, form_fields: Vec<Page>| {
+				details {
+					class: "admin-fieldset",
+					open: open,
+					summary { { summary } }
+					{ form_fields }
+				}
+			})(summary, open, form_fields)
+		})
+		.collect();
+	let form_groups = page!(|fieldsets: Vec<Page>| {
+		div {
+			class: "admin-card p-6",
+			{ fieldsets }
+		}
+	})(fieldsets);
+
+	model_form_page(model_name, record_id, form_groups)
+}
+
+fn model_form_page(model_name: &str, record_id: Option<&str>, form_groups: Page) -> Page {
 	use reinhardt_pages::component::Component;
 	use reinhardt_pages::router::Link;
 
@@ -505,13 +560,6 @@ pub fn model_form(model_name: &str, fields: &[FormField], record_id: Option<&str
 
 	let list_url = admin_model_url("list", model_name);
 
-	let form_fields: Vec<Page> = fields.iter().map(form_group).collect();
-	let form_groups = page!(|form_fields: Vec<Page>| {
-		div {
-			class: "admin-card p-6",
-			{ form_fields }
-		}
-	})(form_fields);
 	let cancel_link = Link::new(list_url.clone(), "Cancel")
 		.class("admin-btn admin-btn-secondary")
 		.render();

--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -12,9 +12,10 @@
 // `reinhardt_urls::routers::ClientRouter` is the canonical SPA router; this module
 // references it pervasively (struct, `Router::new()`, `Arc<Router>`, closure params),
 // so file-scope suppression is preferred over per-usage `#[allow(deprecated)]` attribute spam.
+#[cfg(client)]
+use crate::pages::components::features::model_form_with_fieldsets;
 use crate::pages::components::features::{
 	Column, FormField, ListViewData, dashboard, detail_view, list_view, model_form,
-	model_form_with_fieldsets,
 };
 pub use crate::pages::components::login;
 #[cfg(client)]

--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -14,6 +14,7 @@
 // so file-scope suppression is preferred over per-usage `#[allow(deprecated)]` attribute spam.
 use crate::pages::components::features::{
 	Column, FormField, ListViewData, dashboard, detail_view, list_view, model_form,
+	model_form_with_fieldsets,
 };
 pub use crate::pages::components::login;
 #[cfg(client)]
@@ -513,7 +514,11 @@ fn create_view_component(model_name: String) -> Page {
 						value: String::new(),
 					})
 					.collect();
-				model_form(&model_name, &fields, None)
+				if let Some(fieldsets) = response.fieldsets {
+					model_form_with_fieldsets(&model_name, &fields, &fieldsets, None)
+				} else {
+					model_form(&model_name, &fields, None)
+				}
 			}
 			ResourceState::Error(err) => error_view(&err),
 		}
@@ -613,7 +618,11 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 						}
 					})
 					.collect();
-				model_form(&model_name, &fields, Some(&record_id))
+				if let Some(fieldsets) = response.fieldsets {
+					model_form_with_fieldsets(&model_name, &fields, &fieldsets, Some(&record_id))
+				} else {
+					model_form(&model_name, &fields, Some(&record_id))
+				}
 			}
 			ResourceState::Error(err) => error_view(&err),
 		}

--- a/crates/reinhardt-admin/src/server/create.rs
+++ b/crates/reinhardt-admin/src/server/create.rs
@@ -21,6 +21,8 @@ use super::error::{AdminAuth, MapServerFnError, ModelPermission};
 #[cfg(server)]
 use super::security::{require_csrf_token, sanitize_mutation_values};
 #[cfg(server)]
+use super::type_inference::translate_logical_field_names;
+#[cfg(server)]
 use super::validation::validate_mutation_data;
 
 /// Create a new model instance
@@ -85,6 +87,7 @@ pub async fn create_record(
 	// does not submit values for them. Without this injection the database
 	// would raise a NOT NULL violation.
 	inject_auto_timestamps(&mut sanitized_data, table_name);
+	translate_logical_field_names(table_name, &mut sanitized_data).map_server_fn_error()?;
 
 	let user_id = auth.user_id().unwrap_or("unknown").to_string();
 

--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -17,7 +17,10 @@ use reinhardt_pages::server_fn::{ServerFnError, server_fn};
 #[cfg(server)]
 use super::error::{AdminAuth, MapServerFnError, ModelPermission};
 #[cfg(server)]
-use crate::server::type_inference::{get_field_metadata, infer_admin_field_type, infer_required};
+use crate::server::type_inference::{
+	get_field_metadata, infer_admin_field_type, infer_required,
+	translate_physical_field_names_to_logical,
+};
 #[cfg(server)]
 use reinhardt_utils::utils_core::text::humanize_field_name;
 
@@ -108,9 +111,14 @@ pub async fn get_fields(
 
 	// Fetch existing values if editing
 	let values = if let Some(id) = id {
-		db.get::<AdminRecord>(model_admin.table_name(), model_admin.pk_field(), &id)
+		let mut values = db
+			.get::<AdminRecord>(model_admin.table_name(), model_admin.pk_field(), &id)
 			.await
-			.map_server_fn_error()?
+			.map_server_fn_error()?;
+		if let Some(values) = values.as_mut() {
+			translate_physical_field_names_to_logical(table_name, values).map_server_fn_error()?;
+		}
+		values
 	} else {
 		None
 	};

--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -6,8 +6,8 @@
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{AdminDatabase, AdminRecord, AdminSite, FieldInfo, FieldType};
 #[cfg(server)]
-use crate::core::{AdminDatabaseKey, AdminSiteKey};
-use crate::types::FieldsResponse;
+use crate::core::{AdminDatabaseKey, AdminSiteKey, resolve_form_fields};
+use crate::types::{AdminError, FieldsResponse};
 #[cfg(server)]
 use reinhardt_di::KeyedDepends;
 #[cfg(server)]
@@ -58,38 +58,53 @@ pub async fn get_fields(
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
 	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::View)
 		.await?;
-	let field_names = model_admin
-		.fields()
-		.unwrap_or_else(|| model_admin.list_display());
+	let (field_names, fieldsets) =
+		resolve_form_fields(model_admin.as_ref()).map_server_fn_error()?;
+	let has_fieldsets = fieldsets.is_some();
 	let readonly_fields = model_admin.readonly_fields();
 
 	// Build field metadata with type inference from global registry
 	let table_name = model_admin.table_name();
 	let fields = field_names
 		.iter()
-		.map(|&name| {
-			let is_readonly = readonly_fields.contains(&name);
+		.map(|name| {
+			let is_readonly = readonly_fields.contains(&name.as_str());
 
 			// Try to get field metadata from the global model registry
-			let (field_type, required) = get_field_metadata(table_name, name)
-				.map(|meta| {
-					let admin_type = infer_admin_field_type(&meta.field_type);
-					let is_required = infer_required(&meta);
-					(admin_type, is_required)
-				})
-				.unwrap_or_else(|| (FieldType::Text, false));
+			let metadata = get_field_metadata(table_name, name);
+			let (field_type, required) = if has_fieldsets {
+				let metadata = metadata.ok_or_else(|| {
+					AdminError::ValidationError(format!(
+						"Fieldset field '{}' is not registered for model '{}'",
+						name, model_name
+					))
+				})?;
+				(
+					infer_admin_field_type(&metadata.field_type),
+					infer_required(&metadata),
+				)
+			} else {
+				metadata
+					.map(|meta| {
+						let admin_type = infer_admin_field_type(&meta.field_type);
+						let is_required = infer_required(&meta);
+						(admin_type, is_required)
+					})
+					.unwrap_or((FieldType::Text, false))
+			};
 
-			FieldInfo {
-				name: name.to_string(),
+			Ok(FieldInfo {
+				name: name.clone(),
 				label: humanize_field_name(name),
 				field_type,
 				required,
 				readonly: is_readonly,
 				help_text: None,
 				placeholder: None,
-			}
+			})
 		})
-		.collect();
+		.collect::<Result<Vec<_>, AdminError>>()
+		.map_server_fn_error()?;
 
 	// Fetch existing values if editing
 	let values = if let Some(id) = id {
@@ -103,7 +118,7 @@ pub async fn get_fields(
 	Ok(FieldsResponse {
 		model_name,
 		fields,
-		fieldsets: None,
+		fieldsets,
 		values,
 	})
 }

--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -103,6 +103,7 @@ pub async fn get_fields(
 	Ok(FieldsResponse {
 		model_name,
 		fields,
+		fieldsets: None,
 		values,
 	})
 }

--- a/crates/reinhardt-admin/src/server/type_inference.rs
+++ b/crates/reinhardt-admin/src/server/type_inference.rs
@@ -333,26 +333,58 @@ pub fn find_model_by_table_name(table_name: &str) -> Option<ModelMetadata> {
 /// }
 /// ```
 pub fn get_field_metadata(table_name: &str, field_name: &str) -> Option<FieldMetadata> {
-	find_model_by_table_name(table_name).and_then(|m| {
-		if let Some(meta) = m.fields.get(field_name) {
-			return Some(meta.clone());
-		}
+	find_model_by_table_name(table_name).and_then(|model| find_field_metadata(&model, field_name))
+}
 
-		let relation_name = field_name.strip_suffix("_id")?;
-		let mut meta = m.fields.get(relation_name)?.clone();
-		match meta.field_type {
-			DbFieldType::ForeignKey { .. } | DbFieldType::OneToOne { .. } => {
-				meta.field_type = DbFieldType::BigInteger;
-				Some(meta)
-			}
-			_ => None,
+fn find_field_metadata(model: &ModelMetadata, field_name: &str) -> Option<FieldMetadata> {
+	if let Some(meta) = model.fields.get(field_name) {
+		return Some(meta.clone());
+	}
+
+	if let Some(meta) = model.fields.values().find(|meta| {
+		meta.params
+			.get("rust_field_name")
+			.is_some_and(|name| name == field_name)
+	}) {
+		return Some(meta.clone());
+	}
+
+	let relation_name = field_name.strip_suffix("_id")?;
+	let mut meta = model.fields.get(relation_name)?.clone();
+	match meta.field_type {
+		DbFieldType::ForeignKey { .. } | DbFieldType::OneToOne { .. } => {
+			meta.field_type = DbFieldType::BigInteger;
+			Some(meta)
 		}
-	})
+		_ => None,
+	}
 }
 
 #[cfg(all(test, server))]
 mod tests {
 	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	fn test_find_field_metadata_resolves_logical_name_to_custom_column() {
+		// Arrange
+		let mut model = ModelMetadata::new("admin", "Article", "articles");
+		model.add_field(
+			"email_address".to_string(),
+			FieldMetadata::new(DbFieldType::VarChar(255))
+				.with_param("rust_field_name", "email")
+				.with_param("db_column", "email_address"),
+		);
+
+		// Act
+		let metadata = find_field_metadata(&model, "email").expect("logical field should resolve");
+
+		// Assert
+		assert_eq!(
+			metadata.params.get("db_column").map(String::as_str),
+			Some("email_address")
+		);
+	}
 
 	#[test]
 	fn test_infer_admin_field_type_integers() {

--- a/crates/reinhardt-admin/src/server/type_inference.rs
+++ b/crates/reinhardt-admin/src/server/type_inference.rs
@@ -14,10 +14,11 @@
 //! admin_types::FieldType           →  admin_types::FilterType
 //! ```
 
-use crate::types::{FieldType as AdminFieldType, FilterChoice, FilterType};
+use crate::types::{AdminError, FieldType as AdminFieldType, FilterChoice, FilterType};
 use reinhardt_db::migrations::{
 	FieldMetadata, FieldType as DbFieldType, ModelMetadata, global_registry,
 };
+use std::collections::HashMap;
 
 /// Infers the admin UI field type from a database field type.
 ///
@@ -336,16 +337,125 @@ pub fn get_field_metadata(table_name: &str, field_name: &str) -> Option<FieldMet
 	find_model_by_table_name(table_name).and_then(|model| find_field_metadata(&model, field_name))
 }
 
-fn find_field_metadata(model: &ModelMetadata, field_name: &str) -> Option<FieldMetadata> {
-	if let Some(meta) = model.fields.get(field_name) {
-		return Some(meta.clone());
-	}
+pub(crate) fn translate_logical_field_names(
+	table_name: &str,
+	data: &mut HashMap<String, serde_json::Value>,
+) -> Result<(), AdminError> {
+	let Some(model) = find_model_by_table_name(table_name) else {
+		return Ok(());
+	};
+	translate_logical_field_names_in_model(&model, data)
+}
 
-	if let Some(meta) = model.fields.values().find(|meta| {
-		meta.params
-			.get("rust_field_name")
-			.is_some_and(|name| name == field_name)
-	}) {
+pub(crate) fn translate_physical_field_names_to_logical(
+	table_name: &str,
+	data: &mut HashMap<String, serde_json::Value>,
+) -> Result<(), AdminError> {
+	let Some(model) = find_model_by_table_name(table_name) else {
+		return Ok(());
+	};
+	translate_physical_field_names_to_logical_in_model(&model, data)
+}
+
+fn translate_logical_field_names_in_model(
+	model: &ModelMetadata,
+	data: &mut HashMap<String, serde_json::Value>,
+) -> Result<(), AdminError> {
+	let mut translated = HashMap::with_capacity(data.len());
+	for (field_name, value) in data.drain() {
+		let physical_name = find_field_entry(model, &field_name)
+			.map(|(column_name, metadata)| physical_field_name(column_name, metadata))
+			.unwrap_or(field_name);
+		if translated.insert(physical_name.clone(), value).is_some() {
+			return Err(AdminError::ValidationError(format!(
+				"Multiple form fields map to database column '{}'",
+				physical_name
+			)));
+		}
+	}
+	*data = translated;
+	Ok(())
+}
+
+fn translate_physical_field_names_to_logical_in_model(
+	model: &ModelMetadata,
+	data: &mut HashMap<String, serde_json::Value>,
+) -> Result<(), AdminError> {
+	let mut translated = HashMap::with_capacity(data.len());
+	for (column_name, value) in data.drain() {
+		let logical_name = find_physical_field_entry(model, &column_name)
+			.map(|(registered_name, metadata)| logical_field_name(registered_name, metadata))
+			.unwrap_or(column_name);
+		if translated.insert(logical_name.clone(), value).is_some() {
+			return Err(AdminError::ValidationError(format!(
+				"Multiple database columns map to form field '{}'",
+				logical_name
+			)));
+		}
+	}
+	*data = translated;
+	Ok(())
+}
+
+fn find_field_entry<'a>(
+	model: &'a ModelMetadata,
+	field_name: &str,
+) -> Option<(&'a String, &'a FieldMetadata)> {
+	if let Some((column_name, metadata)) = model.fields.get_key_value(field_name) {
+		return Some((column_name, metadata));
+	}
+	model
+		.fields
+		.iter()
+		.find(|(_, metadata)| {
+			metadata
+				.params
+				.get("db_column")
+				.is_some_and(|column| column == field_name)
+		})
+		.or_else(|| {
+			model.fields.iter().find(|(_, metadata)| {
+				metadata
+					.params
+					.get("rust_field_name")
+					.is_some_and(|name| name == field_name)
+			})
+		})
+}
+
+fn find_physical_field_entry<'a>(
+	model: &'a ModelMetadata,
+	column_name: &str,
+) -> Option<(&'a String, &'a FieldMetadata)> {
+	if let Some((registered_name, metadata)) = model.fields.get_key_value(column_name) {
+		return Some((registered_name, metadata));
+	}
+	model.fields.iter().find(|(_, metadata)| {
+		metadata
+			.params
+			.get("db_column")
+			.is_some_and(|column| column == column_name)
+	})
+}
+
+fn physical_field_name(column_name: &str, metadata: &FieldMetadata) -> String {
+	metadata
+		.params
+		.get("db_column")
+		.cloned()
+		.unwrap_or_else(|| column_name.to_string())
+}
+
+fn logical_field_name(column_name: &str, metadata: &FieldMetadata) -> String {
+	metadata
+		.params
+		.get("rust_field_name")
+		.cloned()
+		.unwrap_or_else(|| column_name.to_string())
+}
+
+fn find_field_metadata(model: &ModelMetadata, field_name: &str) -> Option<FieldMetadata> {
+	if let Some((_, meta)) = find_field_entry(model, field_name) {
 		return Some(meta.clone());
 	}
 
@@ -384,6 +494,59 @@ mod tests {
 			metadata.params.get("db_column").map(String::as_str),
 			Some("email_address")
 		);
+	}
+
+	#[rstest]
+	fn test_translate_logical_field_names_to_custom_columns() {
+		// Arrange
+		let mut model = ModelMetadata::new("admin", "Article", "articles");
+		model.add_field(
+			"email_address".to_string(),
+			FieldMetadata::new(DbFieldType::VarChar(255))
+				.with_param("rust_field_name", "email")
+				.with_param("db_column", "email_address"),
+		);
+		let mut data = HashMap::from([(
+			String::from("email"),
+			serde_json::json!("alice@example.com"),
+		)]);
+
+		// Act
+		translate_logical_field_names_in_model(&model, &mut data).expect("field names should map");
+
+		// Assert
+		assert_eq!(
+			data.get("email_address"),
+			Some(&serde_json::json!("alice@example.com"))
+		);
+		assert!(!data.contains_key("email"));
+	}
+
+	#[rstest]
+	fn test_translate_physical_field_names_to_logical_names() {
+		// Arrange
+		let mut model = ModelMetadata::new("admin", "Article", "articles");
+		model.add_field(
+			"email_address".to_string(),
+			FieldMetadata::new(DbFieldType::VarChar(255))
+				.with_param("rust_field_name", "email")
+				.with_param("db_column", "email_address"),
+		);
+		let mut data = HashMap::from([(
+			String::from("email_address"),
+			serde_json::json!("alice@example.com"),
+		)]);
+
+		// Act
+		translate_physical_field_names_to_logical_in_model(&model, &mut data)
+			.expect("field names should map");
+
+		// Assert
+		assert_eq!(
+			data.get("email"),
+			Some(&serde_json::json!("alice@example.com"))
+		);
+		assert!(!data.contains_key("email_address"));
 	}
 
 	#[test]

--- a/crates/reinhardt-admin/src/server/update.rs
+++ b/crates/reinhardt-admin/src/server/update.rs
@@ -21,6 +21,8 @@ use super::error::{AdminAuth, MapServerFnError, ModelPermission};
 #[cfg(server)]
 use super::security::{require_csrf_token, sanitize_mutation_values};
 #[cfg(server)]
+use super::type_inference::translate_logical_field_names;
+#[cfg(server)]
 use super::validation::validate_mutation_data;
 
 /// Update an existing model instance
@@ -83,6 +85,7 @@ pub async fn update_record(
 
 	// Inject current timestamp for auto_now fields (updated on every save)
 	super::create::inject_auto_now_timestamps(&mut sanitized_data, table_name);
+	translate_logical_field_names(table_name, &mut sanitized_data).map_server_fn_error()?;
 
 	let user_id = auth.user_id().unwrap_or("unknown").to_string();
 

--- a/crates/reinhardt-admin/src/server/validation.rs
+++ b/crates/reinhardt-admin/src/server/validation.rs
@@ -5,7 +5,7 @@
 //!
 //! # Security Protections
 //!
-//! - **Field allowlist**: Only fields defined in `ModelAdmin.fields()` or `list_display()` are allowed
+//! - **Field allowlist**: Only fields defined in `ModelAdmin.fields()`, `fieldsets()`, or `list_display()` are allowed
 //! - **Readonly enforcement**: Fields in `readonly_fields()` cannot be modified
 //! - **Type validation**: Values are checked for basic type compatibility
 //! - **Size limits**: Payload size and field counts are limited to prevent DoS
@@ -62,7 +62,7 @@ pub fn validate_mutation_data(
 	validate_payload_size(data)?;
 
 	// Get allowed fields from model admin
-	let allowed_fields = get_allowed_fields(model_admin);
+	let allowed_fields = get_allowed_fields(model_admin)?;
 	let readonly_fields: Vec<&str> = model_admin.readonly_fields();
 	let pk_field = model_admin.pk_field();
 
@@ -98,11 +98,9 @@ pub fn validate_mutation_data(
 
 /// Gets the list of allowed fields from model admin.
 ///
-/// Falls back to `list_display()` if `fields()` returns None.
-fn get_allowed_fields(model_admin: &dyn ModelAdmin) -> Vec<&str> {
-	model_admin
-		.fields()
-		.unwrap_or_else(|| model_admin.list_display())
+/// Falls back to `list_display()` if neither `fields()` nor `fieldsets()` is configured.
+fn get_allowed_fields(model_admin: &dyn ModelAdmin) -> Result<Vec<String>, AdminError> {
+	crate::core::resolve_form_fields(model_admin).map(|(fields, _)| fields)
 }
 
 /// Validates that the number of fields doesn't exceed the limit.
@@ -134,8 +132,8 @@ fn validate_payload_size(data: &HashMap<String, serde_json::Value>) -> Result<()
 }
 
 /// Validates that a field is in the allowed list.
-fn validate_field_allowed(field_name: &str, allowed_fields: &[&str]) -> Result<(), AdminError> {
-	if !allowed_fields.contains(&field_name) {
+fn validate_field_allowed(field_name: &str, allowed_fields: &[String]) -> Result<(), AdminError> {
+	if !allowed_fields.iter().any(|field| field == field_name) {
 		return Err(AdminError::ValidationError(format!(
 			"Field '{}' is not allowed. Allowed fields: {:?}",
 			field_name, allowed_fields
@@ -321,6 +319,28 @@ mod tests {
 		data.insert("title".to_string(), serde_json::json!("Test"));
 
 		assert!(validate_mutation_data(&data, &admin, false).is_ok());
+	}
+
+	#[rstest]
+	fn test_validate_allows_configured_fieldset_field() {
+		// Arrange
+		let admin = ModelAdminConfig::builder()
+			.model_name("TestModel")
+			.list_display(vec!["id"])
+			.fieldsets(vec![
+				crate::core::Fieldset::new(Some("Main"), &["title", "body"]),
+				crate::core::Fieldset::new(Some("Publishing"), &["published_at"]),
+			])
+			.build()
+			.unwrap();
+		let mut data = HashMap::new();
+		data.insert("body".to_string(), serde_json::json!("Draft"));
+
+		// Act
+		let result = validate_mutation_data(&data, &admin, false);
+
+		// Assert
+		assert_eq!(result.map_err(|error| error.to_string()), Ok(()));
 	}
 
 	// ==================== Boundary value: field count ====================

--- a/crates/reinhardt-admin/src/types.rs
+++ b/crates/reinhardt-admin/src/types.rs
@@ -6,7 +6,7 @@
 //! # Main modules
 //!
 //! - [`errors`]: Error types and result type alias
-//! - [`models`]: Model information types
+//! - [`models`]: Model information and form layout types
 //! - [`requests`]: Request body types for API endpoints
 //! - [`responses`]: Response types for API endpoints
 

--- a/crates/reinhardt-admin/src/types/models.rs
+++ b/crates/reinhardt-admin/src/types/models.rs
@@ -30,6 +30,35 @@ pub struct FieldInfo {
 	pub placeholder: Option<String>,
 }
 
+/// A titled group of fields in an admin form.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Fieldset {
+	/// Optional heading displayed for the group.
+	pub title: Option<String>,
+	/// Field names included in the group.
+	pub fields: Vec<String>,
+	/// Whether the group is collapsed initially.
+	#[serde(default)]
+	pub collapsed: bool,
+}
+
+impl Fieldset {
+	/// Create an expanded fieldset from field names.
+	pub fn new(title: Option<&str>, fields: &[&str]) -> Self {
+		Self {
+			title: title.map(String::from),
+			fields: fields.iter().map(|field| String::from(*field)).collect(),
+			collapsed: false,
+		}
+	}
+
+	/// Mark the fieldset as initially collapsed.
+	pub fn collapsed(mut self) -> Self {
+		self.collapsed = true;
+		self
+	}
+}
+
 /// Field type for form rendering
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "options")]

--- a/crates/reinhardt-admin/src/types/responses.rs
+++ b/crates/reinhardt-admin/src/types/responses.rs
@@ -1,6 +1,6 @@
 //! Response types for admin panel API
 
-use crate::types::models::{ColumnInfo, FilterInfo, ModelInfo};
+use crate::types::models::{ColumnInfo, Fieldset, FilterInfo, ModelInfo};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -142,6 +142,9 @@ pub struct FieldsResponse {
 	pub model_name: String,
 	/// Field definitions for dynamic form generation
 	pub fields: Vec<crate::types::models::FieldInfo>,
+	/// Optional fieldset layout for the form.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub fieldsets: Option<Vec<Fieldset>>,
 	/// Existing field values (for edit forms)
 	/// None for create forms, Some(values) for edit forms
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/reinhardt-admin/src/types/wasm_stubs.rs
+++ b/crates/reinhardt-admin/src/types/wasm_stubs.rs
@@ -10,6 +10,8 @@ pub use wasm_only::*;
 
 #[cfg(client)]
 mod wasm_only {
+	use crate::types::Fieldset;
+
 	/// Dummy AdminSite type for WASM type checking
 	///
 	/// This type is never actually used in WASM code, as the `#[server_fn]`
@@ -81,6 +83,11 @@ mod wasm_only {
 
 		/// Fields to display in forms.
 		fn fields(&self) -> Option<Vec<&str>> {
+			None
+		}
+
+		/// Fieldsets to display in forms.
+		fn fieldsets(&self) -> Option<Vec<Fieldset>> {
 			None
 		}
 

--- a/crates/reinhardt-admin/tests/e2e_pages.rs
+++ b/crates/reinhardt-admin/tests/e2e_pages.rs
@@ -39,6 +39,7 @@ use reinhardt_query::prelude::{
 use reinhardt_test::fixtures::shared_postgres::shared_db_pool;
 use reinhardt_test::fixtures::wasm::e2e_cdp::*;
 use rstest::*;
+use serial_test::serial;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -787,6 +788,7 @@ async fn create_non_staff_user(pool: &sqlx::PgPool, username: &str, password: &s
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_admin_html_shell_served(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -810,6 +812,7 @@ async fn test_admin_html_shell_served(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_admin_login_shell_served(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -831,6 +834,7 @@ async fn test_admin_login_shell_served(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_login_page_renders(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -853,6 +857,7 @@ async fn test_login_page_renders(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_login_invalid_credentials_shows_error(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -894,6 +899,7 @@ async fn test_login_invalid_credentials_shows_error(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_login_success_redirects_to_dashboard(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -920,6 +926,7 @@ async fn test_login_success_redirects_to_dashboard(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_dashboard_shows_model_cards(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -950,6 +957,7 @@ async fn test_dashboard_shows_model_cards(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_dashboard_card_navigates_to_list(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -984,6 +992,7 @@ async fn test_dashboard_card_navigates_to_list(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_list_view_renders_table(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -1012,6 +1021,7 @@ async fn test_list_view_renders_table(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_list_view_row_navigates_to_detail(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -1042,6 +1052,7 @@ async fn test_list_view_row_navigates_to_detail(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_detail_view_has_edit_and_back(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -1076,6 +1087,7 @@ async fn test_detail_view_has_edit_and_back(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_create_form_renders(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -1104,6 +1116,7 @@ async fn test_create_form_renders(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn fieldset_native_disclosure_supports_mouse_and_keyboard(#[future] e2e: E2eContext) {
 	// Arrange
 	let ctx = e2e.await;
@@ -1148,6 +1161,7 @@ async fn fieldset_native_disclosure_supports_mouse_and_keyboard(#[future] e2e: E
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_unauthenticated_redirect_to_login(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -1173,6 +1187,7 @@ async fn test_unauthenticated_redirect_to_login(#[future] e2e: E2eContext) {
 
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_edit_form_renders_with_values(#[future] e2e: E2eContext) {
 	let ctx = e2e.await;
 	let page = ctx
@@ -1210,6 +1225,7 @@ async fn test_edit_form_renders_with_values(#[future] e2e: E2eContext) {
 /// (sourced from `AdminSettings::default()`), not just a hard-coded string.
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_dashboard_renders_site_header(#[future] e2e: E2eContext) {
 	// Arrange
 	let ctx = e2e.await;
@@ -1249,6 +1265,7 @@ async fn test_dashboard_renders_site_header(#[future] e2e: E2eContext) {
 /// models are registered with the AdminSite.
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_dashboard_empty_state_shows_alert(#[future] e2e_no_models: E2eContext) {
 	// Arrange
 	let ctx = e2e_no_models.await;
@@ -1290,6 +1307,7 @@ async fn test_dashboard_empty_state_shows_alert(#[future] e2e_no_models: E2eCont
 /// Verify that each registered model gets its own `.admin-card` on the dashboard.
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_dashboard_renders_card_per_model(#[future] e2e_multi_models: E2eContext) {
 	// Arrange
 	let ctx = e2e_multi_models.await;
@@ -1340,6 +1358,7 @@ async fn test_dashboard_renders_card_per_model(#[future] e2e_multi_models: E2eCo
 /// with the correct `href` to the list view.
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_dashboard_card_structure(#[future] e2e: E2eContext) {
 	// Arrange
 	let ctx = e2e.await;
@@ -1405,6 +1424,7 @@ async fn test_dashboard_card_structure(#[future] e2e: E2eContext) {
 /// the dashboard correctly blocks unauthorized users.
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_dashboard_non_staff_user_blocked(#[future] e2e: E2eContext) {
 	// Arrange
 	let ctx = e2e.await;
@@ -1464,6 +1484,7 @@ async fn test_dashboard_non_staff_user_blocked(#[future] e2e: E2eContext) {
 /// re-renders the model cards. Exercises the SPA router's resource re-fetch path.
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_dashboard_back_navigation_rerenders(#[future] e2e: E2eContext) {
 	// Arrange
 	let ctx = e2e.await;

--- a/crates/reinhardt-admin/tests/e2e_pages.rs
+++ b/crates/reinhardt-admin/tests/e2e_pages.rs
@@ -23,9 +23,13 @@
 use reinhardt_admin::core::{
 	AdminDatabase, AdminSite, AdminUser, ModelAdmin, admin_routes_with_di, admin_static_routes,
 };
+use reinhardt_admin::types::Fieldset;
 use reinhardt_auth::{Argon2Hasher, PasswordHasher};
 use reinhardt_db::backends::connection::DatabaseConnection as BackendsConnection;
 use reinhardt_db::backends::dialect::PostgresBackend;
+use reinhardt_db::migrations::{
+	FieldMetadata, FieldType as DbFieldType, ModelMetadata, global_registry,
+};
 use reinhardt_db::orm::connection::{DatabaseConnection, DatabaseConnectionLease};
 use reinhardt_di::{InjectionContext, SingletonScope};
 use reinhardt_query::prelude::{
@@ -154,7 +158,13 @@ impl ModelAdmin for AllPermissionsModelAdmin {
 		self.search_fields.iter().map(|s| s.as_str()).collect()
 	}
 	fn fields(&self) -> Option<Vec<&str>> {
-		Some(vec!["id", "name", "status", "description", "created_at"])
+		None
+	}
+	fn fieldsets(&self) -> Option<Vec<Fieldset>> {
+		Some(vec![
+			Fieldset::new(Some("Main"), &["name", "status"]),
+			Fieldset::new(Some("Additional"), &["description"]).collapsed(),
+		])
 	}
 	async fn has_view_permission(&self, _user: &dyn AdminUser) -> bool {
 		true
@@ -283,6 +293,20 @@ where
 	F: FnOnce(&Arc<AdminSite>),
 {
 	let builder = PostgresQueryBuilder::new();
+	let mut metadata = ModelMetadata::new("admin_e2e", "TestModel", "test_models");
+	metadata.add_field(
+		"name".to_string(),
+		FieldMetadata::new(DbFieldType::VarChar(255)),
+	);
+	metadata.add_field(
+		"status".to_string(),
+		FieldMetadata::new(DbFieldType::VarChar(50)).with_nullable(true),
+	);
+	metadata.add_field(
+		"description".to_string(),
+		FieldMetadata::new(DbFieldType::Text).with_nullable(true),
+	);
+	global_registry().register_model(metadata);
 
 	// ---- Database setup ----
 
@@ -1076,6 +1100,48 @@ async fn test_create_form_renders(#[future] e2e: E2eContext) {
 		source.contains("name") || source.contains("Name"),
 		"Should have name field"
 	);
+}
+
+#[rstest]
+#[tokio::test]
+async fn fieldset_native_disclosure_supports_mouse_and_keyboard(#[future] e2e: E2eContext) {
+	// Arrange
+	let ctx = e2e.await;
+	let page = ctx
+		.browser
+		.new_page(&format!("{}/admin/login/", ctx.server_url))
+		.await
+		.expect("Failed to open page");
+	let source = page.content().await.expect("Failed to get page source");
+	require_wasm!(&source);
+	inject_auth_token(&page, &ctx.server_url).await;
+	spa_navigate(&page, "/admin/TestModel/add/").await;
+	let details_selector = "details.admin-fieldset:nth-of-type(2)";
+	let summary_selector = "details.admin-fieldset:nth-of-type(2) > summary";
+	page.wait_for(summary_selector)
+		.await
+		.expect("Collapsed fieldset summary should render");
+	assert_eq!(
+		page.get_attribute(details_selector, "open").await.unwrap(),
+		None
+	);
+
+	// Act: open and close the native disclosure with the mouse.
+	page.click(summary_selector).await.unwrap();
+	let opened_by_click = page.get_attribute(details_selector, "open").await.unwrap();
+	page.click(summary_selector).await.unwrap();
+	let closed_by_click = page.get_attribute(details_selector, "open").await.unwrap();
+
+	// Act: focus the native summary and open it with Enter.
+	let summary = page.find(summary_selector).await.unwrap();
+	summary.focus().await.unwrap();
+	summary.press_key("Enter").await.unwrap();
+	let opened_by_keyboard = page.get_attribute(details_selector, "open").await.unwrap();
+
+	// Assert
+	assert_eq!(opened_by_click, Some(String::new()));
+	assert_eq!(closed_by_click, None);
+	assert_eq!(opened_by_keyboard, Some(String::new()));
 }
 
 // --- 7. Auth Redirect Tests (require WASM) ---

--- a/crates/reinhardt-admin/tests/wasm_components.rs
+++ b/crates/reinhardt-admin/tests/wasm_components.rs
@@ -9,10 +9,12 @@
 
 use reinhardt_admin::pages::components::features::{
 	Column, FormField, ListViewData, dashboard, detail_view, list_view, model_form,
+	model_form_with_fieldsets,
 };
 use reinhardt_admin::pages::components::login::login_form;
-use reinhardt_admin::types::{FormFieldSpec, ModelInfo};
+use reinhardt_admin::types::{Fieldset, FormFieldSpec, ModelInfo};
 use reinhardt_pages::Signal;
+use rstest::rstest;
 use std::collections::HashMap;
 use wasm_bindgen_test::*;
 
@@ -166,6 +168,78 @@ fn test_model_form_edit_mode() {
 		"Should have edit action URL"
 	);
 	assert!(html.contains("john_doe"), "Should pre-fill existing value");
+}
+
+#[rstest]
+#[wasm_bindgen_test]
+fn model_form_retains_flat_single_card_layout() {
+	// Arrange
+	let fields = vec![text_field("title", "Title"), text_field("body", "Body")];
+
+	// Act
+	let html = model_form("Article", &fields, None).render_to_string();
+
+	// Assert
+	assert_eq!(html.matches(r#"class="admin-card p-6""#).count(), 1);
+	assert_eq!(html.matches("<details").count(), 0);
+	assert!(html.find(r#"id="field-title""#).unwrap() < html.find(r#"id="field-body""#).unwrap());
+}
+
+#[rstest]
+#[wasm_bindgen_test]
+fn model_form_with_fieldsets_preserves_order_titles_and_initial_open_state() {
+	// Arrange
+	let fields = vec![
+		text_field("title", "Title"),
+		text_field("body", "Body"),
+		text_field("published_at", "Published at"),
+		text_field("slug", "Slug"),
+	];
+	let fieldsets = vec![
+		Fieldset::new(Some("Main"), &["title", "body"]),
+		Fieldset::new(Some("Publishing"), &["published_at"]).collapsed(),
+		Fieldset::new(None, &["slug"]).collapsed(),
+	];
+
+	// Act
+	let html = model_form_with_fieldsets("Article", &fields, &fieldsets, None).render_to_string();
+
+	// Assert
+	let main_summary = html.find("<summary>Main</summary>").unwrap();
+	let publishing_summary = html.find("<summary>Publishing</summary>").unwrap();
+	let fallback_summary = html.find("<summary>Fields</summary>").unwrap();
+	assert!(main_summary < publishing_summary && publishing_summary < fallback_summary);
+	let title_field = html.find(r#"id="field-title""#).unwrap();
+	let body_field = html.find(r#"id="field-body""#).unwrap();
+	let published_field = html.find(r#"id="field-published_at""#).unwrap();
+	let slug_field = html.find(r#"id="field-slug""#).unwrap();
+	assert!(
+		title_field < body_field && body_field < published_field && published_field < slug_field
+	);
+
+	let details: Vec<&str> = html
+		.match_indices("<details")
+		.map(|(start, _)| {
+			let end = html[start..].find('>').unwrap();
+			&html[start..start + end]
+		})
+		.collect();
+	assert_eq!(details.len(), 3);
+	assert!(details[0].contains(" open"));
+	assert!(!details[1].contains(" open"));
+	assert!(!details[2].contains(" open"));
+}
+
+fn text_field(name: &str, label: &str) -> FormField {
+	FormField {
+		name: name.to_string(),
+		label: label.to_string(),
+		spec: FormFieldSpec::Input {
+			html_type: "text".to_string(),
+		},
+		required: false,
+		value: String::new(),
+	}
 }
 
 #[wasm_bindgen_test]

--- a/crates/reinhardt-admin/tests/wasm_components.rs
+++ b/crates/reinhardt-admin/tests/wasm_components.rs
@@ -231,10 +231,12 @@ fn model_form_with_fieldsets_preserves_order_titles_and_initial_open_state() {
 }
 
 #[rstest]
+#[case("")]
+#[case(" \t")]
 #[wasm_bindgen_test]
-fn model_form_with_fieldsets_uses_fallback_for_whitespace_only_title() {
+fn model_form_with_fieldsets_uses_fallback_for_blank_title(#[case] title: &str) {
 	let fields = vec![text_field("slug", "Slug")];
-	let fieldsets = vec![Fieldset::new(Some(" \t"), &["slug"])];
+	let fieldsets = vec![Fieldset::new(Some(title), &["slug"])];
 
 	let html = model_form_with_fieldsets("Article", &fields, &fieldsets, None).render_to_string();
 

--- a/crates/reinhardt-admin/tests/wasm_components.rs
+++ b/crates/reinhardt-admin/tests/wasm_components.rs
@@ -231,6 +231,35 @@ fn model_form_with_fieldsets_preserves_order_titles_and_initial_open_state() {
 }
 
 #[rstest]
+#[wasm_bindgen_test]
+fn model_form_with_fieldsets_expands_collapsed_required_group() {
+	// Arrange
+	let fields = vec![FormField {
+		name: "title".to_string(),
+		label: "Title".to_string(),
+		spec: FormFieldSpec::Input {
+			html_type: "text".to_string(),
+		},
+		required: true,
+		value: String::new(),
+	}];
+	let fieldsets = vec![Fieldset::new(Some("Required"), &["title"]).collapsed()];
+
+	// Act
+	let html = model_form_with_fieldsets("Article", &fields, &fieldsets, None).render_to_string();
+
+	// Assert
+	let details_start = html
+		.find("<details")
+		.expect("fieldset should render details");
+	let details_end = html[details_start..]
+		.find('>')
+		.map(|offset| details_start + offset)
+		.expect("details opening tag should close");
+	assert!(html[details_start..details_end].contains(" open"));
+}
+
+#[rstest]
 #[case("")]
 #[case(" \t")]
 #[wasm_bindgen_test]

--- a/crates/reinhardt-admin/tests/wasm_components.rs
+++ b/crates/reinhardt-admin/tests/wasm_components.rs
@@ -230,6 +230,17 @@ fn model_form_with_fieldsets_preserves_order_titles_and_initial_open_state() {
 	assert!(!details[2].contains(" open"));
 }
 
+#[rstest]
+#[wasm_bindgen_test]
+fn model_form_with_fieldsets_uses_fallback_for_whitespace_only_title() {
+	let fields = vec![text_field("slug", "Slug")];
+	let fieldsets = vec![Fieldset::new(Some(" \t"), &["slug"])];
+
+	let html = model_form_with_fieldsets("Article", &fields, &fieldsets, None).render_to_string();
+
+	assert!(html.contains("<summary>Fields</summary>"));
+}
+
 fn text_field(name: &str, label: &str) -> FormField {
 	FormField {
 		name: name.to_string(),

--- a/crates/reinhardt-core/macros/src/admin.rs
+++ b/crates/reinhardt-core/macros/src/admin.rs
@@ -288,7 +288,7 @@ impl Parse for AdminModelConfig {
 					return Err(syn::Error::new(
 						key.span(),
 						format!(
-							"unknown attribute `{}` for model admin\n\n  = help: valid attributes are: for, name, list_display, list_filter, search_fields, fields, readonly_fields, ordering, list_per_page, allow_view, allow_add, allow_change, allow_delete, permissions",
+							"unknown attribute `{}` for model admin\n\n  = help: valid attributes are: for, name, list_display, list_filter, search_fields, fields, fieldsets, readonly_fields, ordering, list_per_page, allow_view, allow_add, allow_change, allow_delete, permissions",
 							unknown
 						),
 					));

--- a/crates/reinhardt-core/macros/src/admin.rs
+++ b/crates/reinhardt-core/macros/src/admin.rs
@@ -3,6 +3,8 @@
 //! This module provides the `#[admin(model, ...)]` attribute macro for
 //! automatically implementing the `ModelAdmin` trait.
 
+use std::collections::HashSet;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
@@ -59,6 +61,71 @@ impl Parse for OrderingSpec {
 	}
 }
 
+/// Fieldset specification: (title = "Main", fields = [name], collapsed = true)
+#[derive(Debug, Clone)]
+pub(crate) struct FieldsetSpec {
+	pub title: Option<String>,
+	pub fields: Vec<Ident>,
+	pub collapsed: bool,
+}
+
+impl Parse for FieldsetSpec {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let content;
+		parenthesized!(content in input);
+		let span = content.span();
+		let mut title = None;
+		let mut fields = None;
+		let mut collapsed = false;
+
+		while !content.is_empty() {
+			let key: Ident = content.parse()?;
+			content.parse::<Token![=]>()?;
+
+			match key.to_string().as_str() {
+				"title" => {
+					let lit: LitStr = content.parse()?;
+					title = Some(lit.value());
+				}
+				"fields" => {
+					fields = Some(parse_ident_array(&content)?);
+				}
+				"collapsed" => {
+					let lit: LitBool = content.parse()?;
+					collapsed = lit.value();
+				}
+				unknown => {
+					return Err(syn::Error::new(
+						key.span(),
+						format!(
+							"unknown fieldset attribute `{unknown}`\n\n  = help: valid attributes are: title, fields, collapsed"
+						),
+					));
+				}
+			}
+
+			if !content.is_empty() {
+				content.parse::<Token![,]>()?;
+			}
+		}
+
+		let fields = fields
+			.ok_or_else(|| syn::Error::new(span, "`fields` is required for each fieldset"))?;
+		if fields.is_empty() {
+			return Err(syn::Error::new(
+				span,
+				"fieldsets cannot contain empty groups",
+			));
+		}
+
+		Ok(Self {
+			title,
+			fields,
+			collapsed,
+		})
+	}
+}
+
 /// Parsed configuration from `#[admin(model, ...)]`
 #[derive(Debug)]
 pub(crate) struct AdminModelConfig {
@@ -74,6 +141,8 @@ pub(crate) struct AdminModelConfig {
 	pub search_fields: Option<Vec<Ident>>,
 	/// Fields to display in forms
 	pub fields: Option<Vec<Ident>>,
+	/// Fieldsets to display in forms
+	pub fieldsets: Option<Vec<FieldsetSpec>>,
 	/// Read-only fields
 	pub readonly_fields: Option<Vec<Ident>>,
 	/// Ordering specification
@@ -113,6 +182,7 @@ impl Parse for AdminModelConfig {
 		let mut list_filter: Option<Vec<Ident>> = None;
 		let mut search_fields: Option<Vec<Ident>> = None;
 		let mut fields: Option<Vec<Ident>> = None;
+		let mut fieldsets: Option<Vec<FieldsetSpec>> = None;
 		let mut readonly_fields: Option<Vec<Ident>> = None;
 		let mut ordering: Option<Vec<OrderingSpec>> = None;
 		let mut list_per_page: Option<usize> = None;
@@ -154,7 +224,22 @@ impl Parse for AdminModelConfig {
 					search_fields = Some(parse_ident_array(input)?);
 				}
 				"fields" => {
+					if fieldsets.is_some() {
+						return Err(syn::Error::new(
+							key.span(),
+							"`fields` and `fieldsets` cannot be configured together",
+						));
+					}
 					fields = Some(parse_ident_array(input)?);
+				}
+				"fieldsets" => {
+					if fields.is_some() {
+						return Err(syn::Error::new(
+							key.span(),
+							"`fields` and `fieldsets` cannot be configured together",
+						));
+					}
+					fieldsets = Some(parse_fieldsets_array(input)?);
 				}
 				"readonly_fields" => {
 					readonly_fields = Some(parse_ident_array(input)?);
@@ -238,6 +323,7 @@ impl Parse for AdminModelConfig {
 			list_filter,
 			search_fields,
 			fields,
+			fieldsets,
 			readonly_fields,
 			ordering,
 			list_per_page,
@@ -276,6 +362,27 @@ fn parse_ordering_array(input: ParseStream) -> Result<Vec<OrderingSpec>> {
 	Ok(specs.into_iter().collect())
 }
 
+/// Parse an array of fieldset specs.
+fn parse_fieldsets_array(input: ParseStream) -> Result<Vec<FieldsetSpec>> {
+	let content;
+	bracketed!(content in input);
+
+	let specs: Punctuated<FieldsetSpec, Token![,]> = content.call(Punctuated::parse_terminated)?;
+	let specs: Vec<_> = specs.into_iter().collect();
+	let mut fields = HashSet::new();
+	for spec in &specs {
+		for field in &spec.fields {
+			if !fields.insert(field.to_string()) {
+				return Err(syn::Error::new(
+					field.span(),
+					format!("field `{field}` is repeated across fieldsets"),
+				));
+			}
+		}
+	}
+	Ok(specs)
+}
+
 /// Generate the ModelAdmin trait implementation
 pub(crate) fn admin_impl(args: TokenStream, input: ItemStruct) -> Result<TokenStream> {
 	let admin_api = crate::crate_paths::get_reinhardt_admin_adapters_crate();
@@ -303,6 +410,9 @@ pub(crate) fn admin_impl(args: TokenStream, input: ItemStruct) -> Result<TokenSt
 	}
 	if let Some(ref fields) = config.fields {
 		all_fields.extend(fields.iter());
+	}
+	if let Some(ref fieldsets) = config.fieldsets {
+		all_fields.extend(fieldsets.iter().flat_map(|fieldset| fieldset.fields.iter()));
 	}
 	if let Some(ref fields) = config.readonly_fields {
 		all_fields.extend(fields.iter());
@@ -371,6 +481,32 @@ pub(crate) fn admin_impl(args: TokenStream, input: ItemStruct) -> Result<TokenSt
 		quote! {
 			fn fields(&self) -> Option<Vec<&str>> {
 				Some(vec![#(#field_strs),*])
+			}
+		}
+	} else {
+		quote! {}
+	};
+
+	// Generate fieldsets method
+	let fieldsets_impl = if let Some(ref fieldsets) = config.fieldsets {
+		let fieldsets = fieldsets.iter().map(|fieldset| {
+			let collapsed = fieldset.collapsed;
+			let title = if let Some(title) = &fieldset.title {
+				quote!(Some(#title))
+			} else {
+				quote!(None)
+			};
+			let fields: Vec<String> = fieldset.fields.iter().map(Ident::to_string).collect();
+			let tokens = quote!(#admin_api::Fieldset::new(#title, &[#(#fields),*]));
+			if collapsed {
+				quote!(#tokens.collapsed())
+			} else {
+				tokens
+			}
+		});
+		quote! {
+			fn fieldsets(&self) -> Option<Vec<#admin_api::Fieldset>> {
+				Some(vec![#(#fieldsets),*])
 			}
 		}
 	} else {
@@ -471,6 +607,7 @@ pub(crate) fn admin_impl(args: TokenStream, input: ItemStruct) -> Result<TokenSt
 			#list_filter_impl
 			#search_fields_impl
 			#fields_impl
+			#fieldsets_impl
 			#readonly_fields_impl
 			#ordering_impl
 			#list_per_page_impl

--- a/crates/reinhardt-core/macros/src/admin.rs
+++ b/crates/reinhardt-core/macros/src/admin.rs
@@ -257,6 +257,12 @@ impl Parse for AdminModelConfig {
 							"`fields` and `fieldsets` cannot be configured together",
 						));
 					}
+					if fieldsets.is_some() {
+						return Err(syn::Error::new(
+							key.span(),
+							"duplicate admin attribute `fieldsets`",
+						));
+					}
 					fieldsets = Some(parse_fieldsets_array(input)?);
 				}
 				"readonly_fields" => {

--- a/crates/reinhardt-core/macros/src/admin.rs
+++ b/crates/reinhardt-core/macros/src/admin.rs
@@ -76,7 +76,7 @@ impl Parse for FieldsetSpec {
 		let span = content.span();
 		let mut title = None;
 		let mut fields = None;
-		let mut collapsed = false;
+		let mut collapsed = None;
 
 		while !content.is_empty() {
 			let key: Ident = content.parse()?;
@@ -84,15 +84,33 @@ impl Parse for FieldsetSpec {
 
 			match key.to_string().as_str() {
 				"title" => {
+					if title.is_some() {
+						return Err(syn::Error::new(
+							key.span(),
+							"duplicate fieldset attribute `title`",
+						));
+					}
 					let lit: LitStr = content.parse()?;
 					title = Some(lit.value());
 				}
 				"fields" => {
+					if fields.is_some() {
+						return Err(syn::Error::new(
+							key.span(),
+							"duplicate fieldset attribute `fields`",
+						));
+					}
 					fields = Some(parse_ident_array(&content)?);
 				}
 				"collapsed" => {
+					if collapsed.is_some() {
+						return Err(syn::Error::new(
+							key.span(),
+							"duplicate fieldset attribute `collapsed`",
+						));
+					}
 					let lit: LitBool = content.parse()?;
-					collapsed = lit.value();
+					collapsed = Some(lit.value());
 				}
 				unknown => {
 					return Err(syn::Error::new(
@@ -121,7 +139,7 @@ impl Parse for FieldsetSpec {
 		Ok(Self {
 			title,
 			fields,
-			collapsed,
+			collapsed: collapsed.unwrap_or(false),
 		})
 	}
 }
@@ -369,6 +387,9 @@ fn parse_fieldsets_array(input: ParseStream) -> Result<Vec<FieldsetSpec>> {
 
 	let specs: Punctuated<FieldsetSpec, Token![,]> = content.call(Punctuated::parse_terminated)?;
 	let specs: Vec<_> = specs.into_iter().collect();
+	if specs.is_empty() {
+		return Err(syn::Error::new(content.span(), "fieldsets cannot be empty"));
+	}
 	let mut fields = HashSet::new();
 	for spec in &specs {
 		for field in &spec.fields {

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -961,6 +961,9 @@ pub fn collect_migrations(input: TokenStream) -> TokenStream {
 /// - `list_filter = [field1, field2, ...]` - Fields for filtering (default: `[]`)
 /// - `search_fields = [field1, field2, ...]` - Fields for search (default: `[]`)
 /// - `fields = [field1, field2, ...]` - Fields to display in forms (default: all)
+/// - `fieldsets = [(title = "Main", fields = [field1]), (fields = [field2], collapsed = true)]`
+///   - Grouped form fields; `title` and `collapsed` are optional
+///   - Cannot be combined with `fields`
 /// - `readonly_fields = [field1, field2, ...]` - Read-only fields (default: `[]`)
 /// - `ordering = [(field1, asc/desc), ...]` - Default ordering (default: `[(id, desc)]`)
 /// - `list_per_page = N` - Items per page (default: site default)

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -6329,6 +6329,7 @@ fn generate_registration_code(input: RegistrationCodeInput<'_>) -> Result<TokenS
 				#resolved_column.to_string(),
 				#migrations_crate::model_registry::FieldMetadata::new(#field_type)
 					#(#params)*
+					.with_param("rust_field_name", #field_name)
 					.with_param("db_column", #resolved_column)
 					.with_domain_opt(field_domain.clone())
 					#generated_registration
@@ -6410,6 +6411,7 @@ fn generate_registration_code(input: RegistrationCodeInput<'_>) -> Result<TokenS
 	let mut fk_id_registrations = Vec::new();
 	for fk_info in fk_field_infos {
 		let id_column_name = &fk_info.id_column_name;
+		let rust_field_name = fk_info.field_name.to_string();
 		let nullable = fk_info.rel_attr.null.unwrap_or(false);
 		let unique = fk_info.is_one_to_one; // OneToOne fields have UNIQUE constraint
 		let db_index = fk_info.rel_attr.db_index.unwrap_or(true); // FK fields are indexed by default
@@ -6492,6 +6494,7 @@ fn generate_registration_code(input: RegistrationCodeInput<'_>) -> Result<TokenS
 					#migrations_crate::FieldType::Uuid
 				)
 					.with_nullable(#nullable)
+					.with_param("rust_field_name", #rust_field_name)
 					.with_param("not_null", #not_null_str)
 					.with_param("unique", #unique_str)
 					.with_param("db_index", #db_index_str)

--- a/crates/reinhardt-core/macros/tests/ui/admin/fail/unknown_attribute.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/admin/fail/unknown_attribute.stderr
@@ -1,6 +1,6 @@
 error: unknown attribute `unknown_attr` for model admin
 
-         = help: valid attributes are: for, name, list_display, list_filter, search_fields, fields, readonly_fields, ordering, list_per_page, allow_view, allow_add, allow_change, allow_delete, permissions
+         = help: valid attributes are: for, name, list_display, list_filter, search_fields, fields, fieldsets, readonly_fields, ordering, list_per_page, allow_view, allow_add, allow_change, allow_delete, permissions
  --> tests/ui/admin/fail/unknown_attribute.rs:7:43
   |
 7 | #[admin(model, for = User, name = "User", unknown_attr = "value")]

--- a/tests/integration/tests/admin/server_fn_detail_tests.rs
+++ b/tests/integration/tests/admin/server_fn_detail_tests.rs
@@ -7,6 +7,7 @@ use reinhardt_admin::core::AdminRecord;
 use reinhardt_admin::server::get_detail;
 use rstest::*;
 use serde_json::json;
+use serial_test::serial;
 use std::collections::HashMap;
 
 use super::server_fn_helpers::{make_auth_user, make_staff_request};
@@ -206,6 +207,7 @@ async fn test_get_detail_model_not_registered(
 /// Verify that get_detail works with UUID primary keys (issue #3099)
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_get_detail_uuid_pk(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {

--- a/tests/integration/tests/admin/server_fn_fields_tests.rs
+++ b/tests/integration/tests/admin/server_fn_fields_tests.rs
@@ -3,7 +3,7 @@
 //! Tests the field definitions server function for dynamic form generation.
 //! Covers regression for Issue #2920 (get_fields() missing authentication check).
 
-use super::server_fn_helpers::server_fn_context;
+use super::server_fn_helpers::{fieldset_context, server_fn_context};
 use reinhardt_admin::core::AdminRecord;
 use reinhardt_admin::server::get_fields;
 use rstest::*;
@@ -11,6 +11,72 @@ use serde_json::json;
 use std::collections::HashMap;
 
 use super::server_fn_helpers::{make_auth_user, make_staff_request};
+
+/// Verify get_fields preserves fieldset order and layout metadata.
+#[rstest]
+#[tokio::test]
+async fn test_get_fields_returns_fieldsets_in_declared_order(
+	#[future] fieldset_context: super::server_fn_helpers::ServerFnContext,
+) {
+	// Arrange
+	let (site, db, _connection_lease) = fieldset_context.await;
+	let http_request = make_staff_request();
+	let auth_user = make_auth_user();
+
+	// Act
+	let response = get_fields(
+		"FieldsetModel".to_string(),
+		None,
+		site,
+		db,
+		http_request,
+		auth_user,
+	)
+	.await
+	.expect("get_fields should succeed for configured fieldsets");
+
+	// Assert
+	assert_eq!(
+		response
+			.fields
+			.iter()
+			.map(|field| field.name.as_str())
+			.collect::<Vec<_>>(),
+		vec!["title", "body", "published_at"],
+	);
+	let fieldsets = response
+		.fieldsets
+		.expect("response should include fieldsets");
+	assert_eq!(fieldsets[0].title.as_deref(), Some("Main"));
+	assert_eq!(fieldsets[1].title.as_deref(), Some("Publishing"));
+	assert_eq!(fieldsets[1].collapsed, true);
+}
+
+/// Verify get_fields rejects fieldset names absent from model metadata.
+#[rstest]
+#[tokio::test]
+async fn test_get_fields_rejects_unknown_fieldset_field(
+	#[future] fieldset_context: super::server_fn_helpers::ServerFnContext,
+) {
+	// Arrange
+	let (site, db, _connection_lease) = fieldset_context.await;
+	let http_request = make_staff_request();
+	let auth_user = make_auth_user();
+
+	// Act
+	let result = get_fields(
+		"InvalidFieldsetModel".to_string(),
+		None,
+		site,
+		db,
+		http_request,
+		auth_user,
+	)
+	.await;
+
+	// Assert
+	assert!(result.is_err(), "unknown fieldset fields must be rejected");
+}
 
 // ==================== Happy path tests ====================
 

--- a/tests/integration/tests/admin/server_fn_fields_tests.rs
+++ b/tests/integration/tests/admin/server_fn_fields_tests.rs
@@ -47,8 +47,26 @@ async fn test_get_fields_returns_fieldsets_in_declared_order(
 	let fieldsets = response
 		.fieldsets
 		.expect("response should include fieldsets");
+	assert_eq!(fieldsets.len(), 2);
 	assert_eq!(fieldsets[0].title.as_deref(), Some("Main"));
+	assert_eq!(
+		fieldsets[0]
+			.fields
+			.iter()
+			.map(String::as_str)
+			.collect::<Vec<_>>(),
+		vec!["title", "body"],
+	);
+	assert_eq!(fieldsets[0].collapsed, false);
 	assert_eq!(fieldsets[1].title.as_deref(), Some("Publishing"));
+	assert_eq!(
+		fieldsets[1]
+			.fields
+			.iter()
+			.map(String::as_str)
+			.collect::<Vec<_>>(),
+		vec!["published_at"],
+	);
 	assert_eq!(fieldsets[1].collapsed, true);
 }
 
@@ -75,7 +93,15 @@ async fn test_get_fields_rejects_unknown_fieldset_field(
 	.await;
 
 	// Assert
-	assert!(result.is_err(), "unknown fieldset fields must be rejected");
+	let error = result.expect_err("unknown fieldset fields must be rejected");
+	assert_eq!(
+		error.kind(),
+		reinhardt_pages::server_fn::ServerFnErrorKind::Application
+	);
+	assert_eq!(
+		error.user_message(),
+		"Fieldset field 'unknown_field' is not registered for model 'InvalidFieldsetModel'"
+	);
 }
 
 // ==================== Happy path tests ====================

--- a/tests/integration/tests/admin/server_fn_fields_tests.rs
+++ b/tests/integration/tests/admin/server_fn_fields_tests.rs
@@ -8,6 +8,7 @@ use reinhardt_admin::core::AdminRecord;
 use reinhardt_admin::server::get_fields;
 use rstest::*;
 use serde_json::json;
+use serial_test::serial;
 use std::collections::HashMap;
 
 use super::server_fn_helpers::{make_auth_user, make_staff_request};
@@ -15,6 +16,7 @@ use super::server_fn_helpers::{make_auth_user, make_staff_request};
 /// Verify get_fields preserves fieldset order and layout metadata.
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_get_fields_returns_fieldsets_in_declared_order(
 	#[future] fieldset_context: super::server_fn_helpers::ServerFnContext,
 ) {
@@ -73,6 +75,7 @@ async fn test_get_fields_returns_fieldsets_in_declared_order(
 /// Verify get_fields rejects fieldset names absent from model metadata.
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_get_fields_rejects_unknown_fieldset_field(
 	#[future] fieldset_context: super::server_fn_helpers::ServerFnContext,
 ) {

--- a/tests/integration/tests/admin/server_fn_helpers.rs
+++ b/tests/integration/tests/admin/server_fn_helpers.rs
@@ -289,6 +289,70 @@ pub struct AllPermissionsModelAdmin {
 	search_fields: Vec<String>,
 }
 
+/// A ModelAdmin implementation with grouped form fields.
+pub struct FieldsetModelAdmin {
+	include_unknown_field: bool,
+}
+
+impl FieldsetModelAdmin {
+	/// Creates an admin configuration with only registered fieldset fields.
+	pub fn valid() -> Self {
+		Self {
+			include_unknown_field: false,
+		}
+	}
+
+	/// Creates an admin configuration containing an unregistered fieldset field.
+	pub fn with_unknown_field() -> Self {
+		Self {
+			include_unknown_field: true,
+		}
+	}
+}
+
+#[async_trait::async_trait]
+impl ModelAdmin for FieldsetModelAdmin {
+	fn model_name(&self) -> &str {
+		if self.include_unknown_field {
+			"InvalidFieldsetModel"
+		} else {
+			"FieldsetModel"
+		}
+	}
+
+	fn table_name(&self) -> &str {
+		"fieldset_test_models"
+	}
+
+	fn fieldsets(&self) -> Option<Vec<reinhardt_admin::core::Fieldset>> {
+		let second_field = if self.include_unknown_field {
+			"unknown_field"
+		} else {
+			"published_at"
+		};
+		Some(vec![
+			reinhardt_admin::core::Fieldset::new(Some("Main"), &["title", "body"]),
+			reinhardt_admin::core::Fieldset::new(Some("Publishing"), &[second_field]).collapsed(),
+		])
+	}
+
+	async fn has_view_permission(&self, _user: &dyn AdminUser) -> bool {
+		true
+	}
+
+	async fn has_add_permission(&self, _user: &dyn AdminUser) -> bool {
+		true
+	}
+
+	async fn has_change_permission(&self, _user: &dyn AdminUser) -> bool {
+		true
+	}
+
+	async fn has_delete_permission(&self, _user: &dyn AdminUser) -> bool {
+		true
+	}
+}
+
 impl AllPermissionsModelAdmin {
 	/// Creates a new instance configured for the standard test model.
 	pub fn test_model(table_name: &str) -> Self {
@@ -444,6 +508,48 @@ pub async fn server_fn_context(
 	let admin = AllPermissionsModelAdmin::test_model("test_models");
 	site.register("TestModel", admin)
 		.expect("Failed to register TestModel");
+
+	(
+		admin_site_dep(site),
+		admin_database_dep(db),
+		connection_lease,
+	)
+}
+
+/// Composite fixture registering a grouped fieldset ModelAdmin and field metadata.
+#[fixture]
+pub async fn fieldset_context(#[future] shared_db_pool: (sqlx::PgPool, String)) -> ServerFnContext {
+	use reinhardt_db::migrations::{FieldMetadata, FieldType, ModelMetadata, global_registry};
+
+	let (pool, _) = shared_db_pool.await;
+	let mut model_meta = ModelMetadata::new("test", "FieldsetModel", "fieldset_test_models");
+	model_meta.fields.insert(
+		"title".to_string(),
+		FieldMetadata::new(FieldType::VarChar(255)),
+	);
+	model_meta
+		.fields
+		.insert("body".to_string(), FieldMetadata::new(FieldType::Text));
+	model_meta.fields.insert(
+		"published_at".to_string(),
+		FieldMetadata::new(FieldType::TimestampTz),
+	);
+	global_registry().register_model(model_meta);
+
+	let backend = Arc::new(PostgresBackend::new(pool));
+	let backends_conn = BackendsConnection::new(backend);
+	let connection_lease = DatabaseConnectionLease::register(backends_conn)
+		.expect("Failed to register database connection");
+	let db = AdminDatabase::new(connection_lease.handle());
+
+	let site = AdminSite::new("Fieldset Test Admin Site");
+	site.register("FieldsetModel", FieldsetModelAdmin::valid())
+		.expect("Failed to register FieldsetModel");
+	site.register(
+		"InvalidFieldsetModel",
+		FieldsetModelAdmin::with_unknown_field(),
+	)
+	.expect("Failed to register InvalidFieldsetModel");
 
 	(
 		admin_site_dep(site),

--- a/tests/integration/tests/admin/server_fn_helpers.rs
+++ b/tests/integration/tests/admin/server_fn_helpers.rs
@@ -290,20 +290,20 @@ pub struct AllPermissionsModelAdmin {
 }
 
 /// A ModelAdmin implementation with grouped form fields.
-pub struct FieldsetModelAdmin {
+pub(super) struct FieldsetModelAdmin {
 	include_unknown_field: bool,
 }
 
 impl FieldsetModelAdmin {
 	/// Creates an admin configuration with only registered fieldset fields.
-	pub fn valid() -> Self {
+	pub(super) fn valid() -> Self {
 		Self {
 			include_unknown_field: false,
 		}
 	}
 
 	/// Creates an admin configuration containing an unregistered fieldset field.
-	pub fn with_unknown_field() -> Self {
+	pub(super) fn with_unknown_field() -> Self {
 		Self {
 			include_unknown_field: true,
 		}

--- a/tests/integration/tests/admin/server_fn_uuid_pk_tests.rs
+++ b/tests/integration/tests/admin/server_fn_uuid_pk_tests.rs
@@ -12,6 +12,7 @@ use reinhardt_admin::server::{
 };
 use rstest::*;
 use serde_json::json;
+use serial_test::serial;
 use std::collections::HashMap;
 
 use reinhardt_query::prelude::{Alias, PostgresQueryBuilder, Query, QueryStatementBuilder, Value};
@@ -44,6 +45,7 @@ async fn insert_uuid_record(pool: &sqlx::PgPool, name: &str, status: &str) -> St
 /// Verify get_list works with UUID PK model
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_list_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
@@ -87,6 +89,7 @@ async fn test_list_uuid_pk_model(
 /// Verify get_detail returns correct record for UUID PK
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_detail_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
@@ -121,6 +124,7 @@ async fn test_detail_uuid_pk_model(
 /// Verify create_record returns success with a UUID id
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_create_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
@@ -168,6 +172,7 @@ async fn test_create_uuid_pk_model(
 /// Verify update_record works with UUID PK
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_update_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
@@ -228,6 +233,7 @@ async fn test_update_uuid_pk_model(
 /// Verify delete_record works with UUID PK
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_delete_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
@@ -266,6 +272,7 @@ async fn test_delete_uuid_pk_model(
 /// Verify bulk_delete_records works with UUID PKs
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_bulk_delete_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {
@@ -311,6 +318,7 @@ async fn test_bulk_delete_uuid_pk_model(
 /// Verify export_data returns data with UUID ids
 #[rstest]
 #[tokio::test]
+#[serial(admin_registry)]
 async fn test_export_uuid_pk_model(
 	#[future] uuid_pk_context: super::server_fn_helpers::UuidPkContext,
 ) {

--- a/tests/integration/tests/admin/ui/fail/fields_and_fieldsets.rs
+++ b/tests/integration/tests/admin/ui/fail/fields_and_fieldsets.rs
@@ -1,0 +1,24 @@
+// The macros emit Reinhardt-specific configuration names in this standalone fixture.
+#![allow(unexpected_cfgs)]
+
+use reinhardt::{admin, model};
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "admin_ui", table_name = "conflicting_articles")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Article {
+	#[field(primary_key = true)]
+	id: i64,
+	name: String,
+	notes: String,
+}
+
+#[admin(model,
+	for = Article,
+	name = "Article",
+	fields = [name],
+	fieldsets = [(fields = [notes])]
+)]
+struct ArticleAdmin;
+
+fn main() {}

--- a/tests/integration/tests/admin/ui/fail/fields_and_fieldsets.rs
+++ b/tests/integration/tests/admin/ui/fail/fields_and_fieldsets.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 struct Article {
 	#[field(primary_key = true)]
 	id: i64,
+	#[field(max_length = 255)]
 	name: String,
+	#[field(max_length = 255)]
 	notes: String,
 }
 

--- a/tests/integration/tests/admin/ui/fail/fields_and_fieldsets.stderr
+++ b/tests/integration/tests/admin/ui/fail/fields_and_fieldsets.stderr
@@ -1,0 +1,5 @@
+error: `fields` and `fieldsets` cannot be configured together
+  --> tests/admin/ui/fail/fields_and_fieldsets.rs:22:2
+   |
+22 |     fieldsets = [(fields = [notes])]
+   |     ^^^^^^^^^

--- a/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_attribute.rs
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_attribute.rs
@@ -1,0 +1,23 @@
+// The macros emit Reinhardt-specific configuration names in this standalone fixture.
+#![allow(unexpected_cfgs)]
+
+use reinhardt::{admin, model};
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "admin_ui", table_name = "duplicate_attribute_articles")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Article {
+	#[field(primary_key = true)]
+	id: i64,
+	#[field(max_length = 255)]
+	name: String,
+}
+
+#[admin(model,
+	for = Article,
+	name = "Article",
+	fieldsets = [(fields = [name], fields = [name])]
+)]
+struct ArticleAdmin;
+
+fn main() {}

--- a/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_attribute.stderr
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_attribute.stderr
@@ -1,0 +1,5 @@
+error: duplicate fieldset attribute `fields`
+  --> tests/admin/ui/fail/fieldsets_duplicate_attribute.rs:19:33
+   |
+19 |     fieldsets = [(fields = [name], fields = [name])]
+   |                                    ^^^^^^

--- a/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_field.rs
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_field.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 struct Article {
 	#[field(primary_key = true)]
 	id: i64,
+	#[field(max_length = 255)]
 	name: String,
 }
 

--- a/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_field.rs
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_field.rs
@@ -1,0 +1,25 @@
+// The macros emit Reinhardt-specific configuration names in this standalone fixture.
+#![allow(unexpected_cfgs)]
+
+use reinhardt::{admin, model};
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "admin_ui", table_name = "duplicate_field_articles")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Article {
+	#[field(primary_key = true)]
+	id: i64,
+	name: String,
+}
+
+#[admin(model,
+	for = Article,
+	name = "Article",
+	fieldsets = [
+		(title = "Main", fields = [name]),
+		(fields = [name], collapsed = true)
+	]
+)]
+struct ArticleAdmin;
+
+fn main() {}

--- a/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_field.stderr
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_field.stderr
@@ -1,0 +1,5 @@
+error: field `name` is repeated across fieldsets
+  --> tests/admin/ui/fail/fieldsets_duplicate_field.rs:21:14
+   |
+21 |         (fields = [name], collapsed = true)
+   |                    ^^^^

--- a/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_top_level.rs
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_top_level.rs
@@ -1,0 +1,25 @@
+// The macros emit Reinhardt-specific configuration names in this standalone fixture.
+#![allow(unexpected_cfgs)]
+
+use reinhardt::{admin, model};
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "admin_ui", table_name = "duplicate_top_level_fieldsets_articles")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Article {
+	#[field(primary_key = true)]
+	id: i64,
+	#[field(max_length = 255)]
+	name: String,
+}
+
+#[admin(
+	model,
+	for = Article,
+	name = "Article",
+	fieldsets = [(fields = [name])],
+	fieldsets = [(fields = [name])]
+)]
+struct ArticleAdmin;
+
+fn main() {}

--- a/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_top_level.stderr
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_duplicate_top_level.stderr
@@ -1,0 +1,5 @@
+error: duplicate admin attribute `fieldsets`
+  --> tests/admin/ui/fail/fieldsets_duplicate_top_level.rs:21:2
+   |
+21 |     fieldsets = [(fields = [name])]
+   |     ^^^^^^^^^

--- a/tests/integration/tests/admin/ui/fail/fieldsets_empty.rs
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_empty.rs
@@ -1,0 +1,23 @@
+// The macros emit Reinhardt-specific configuration names in this standalone fixture.
+#![allow(unexpected_cfgs)]
+
+use reinhardt::{admin, model};
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "admin_ui", table_name = "empty_fieldsets_articles")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Article {
+	#[field(primary_key = true)]
+	id: i64,
+	#[field(max_length = 255)]
+	name: String,
+}
+
+#[admin(model,
+	for = Article,
+	name = "Article",
+	fieldsets = []
+)]
+struct ArticleAdmin;
+
+fn main() {}

--- a/tests/integration/tests/admin/ui/fail/fieldsets_empty.stderr
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_empty.stderr
@@ -1,0 +1,5 @@
+error: fieldsets cannot be empty
+  --> tests/admin/ui/fail/fieldsets_empty.rs:19:15
+   |
+19 |     fieldsets = []
+   |                  ^

--- a/tests/integration/tests/admin/ui/fail/fieldsets_empty_group.rs
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_empty_group.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 struct Article {
 	#[field(primary_key = true)]
 	id: i64,
+	#[field(max_length = 255)]
 	name: String,
 }
 

--- a/tests/integration/tests/admin/ui/fail/fieldsets_empty_group.rs
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_empty_group.rs
@@ -1,0 +1,22 @@
+// The macros emit Reinhardt-specific configuration names in this standalone fixture.
+#![allow(unexpected_cfgs)]
+
+use reinhardt::{admin, model};
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "admin_ui", table_name = "empty_group_articles")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Article {
+	#[field(primary_key = true)]
+	id: i64,
+	name: String,
+}
+
+#[admin(model,
+	for = Article,
+	name = "Article",
+	fieldsets = [(title = "Main", fields = [])]
+)]
+struct ArticleAdmin;
+
+fn main() {}

--- a/tests/integration/tests/admin/ui/fail/fieldsets_empty_group.stderr
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_empty_group.stderr
@@ -1,0 +1,5 @@
+error: fieldsets cannot contain empty groups
+  --> tests/admin/ui/fail/fieldsets_empty_group.rs:19:16
+   |
+19 |     fieldsets = [(title = "Main", fields = [])]
+   |                   ^^^^^

--- a/tests/integration/tests/admin/ui/fail/fieldsets_unknown_field.rs
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_unknown_field.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 struct Article {
 	#[field(primary_key = true)]
 	id: i64,
+	#[field(max_length = 255)]
 	name: String,
 }
 

--- a/tests/integration/tests/admin/ui/fail/fieldsets_unknown_field.rs
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_unknown_field.rs
@@ -1,0 +1,22 @@
+// The macros emit Reinhardt-specific configuration names in this standalone fixture.
+#![allow(unexpected_cfgs)]
+
+use reinhardt::{admin, model};
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "admin_ui", table_name = "unknown_field_articles")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Article {
+	#[field(primary_key = true)]
+	id: i64,
+	name: String,
+}
+
+#[admin(model,
+	for = Article,
+	name = "Article",
+	fieldsets = [(fields = [missing])]
+)]
+struct ArticleAdmin;
+
+fn main() {}

--- a/tests/integration/tests/admin/ui/fail/fieldsets_unknown_field.stderr
+++ b/tests/integration/tests/admin/ui/fail/fieldsets_unknown_field.stderr
@@ -1,0 +1,20 @@
+error[E0599]: no associated function or constant named `field_missing` found for struct `Article` in the current scope
+  --> tests/admin/ui/fail/fieldsets_unknown_field.rs:19:26
+   |
+ 9 |   struct Article {
+   |   -------------- associated function or constant `field_missing` not found for this struct
+...
+17 |       for = Article,
+   |  ___________-
+18 | |     name = "Article",
+19 | |     fieldsets = [(fields = [missing])]
+   | |                            -^^^^^^^ associated function or constant not found in `Article`
+   | |____________________________|
+   |
+   |
+help: there is an associated function `field_id` with a similar name
+  --> tests/admin/ui/fail/fieldsets_unknown_field.rs:7:1
+   |
+ 7 | #[model(app_label = "admin_ui", table_name = "unknown_field_articles")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the derive macro `::reinhardt::macros::Model` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/integration/tests/admin/ui/pass/fieldsets.rs
+++ b/tests/integration/tests/admin/ui/pass/fieldsets.rs
@@ -1,7 +1,6 @@
 // The macros emit Reinhardt-specific configuration names in this standalone fixture.
 #![allow(unexpected_cfgs)]
 
-use reinhardt::admin::{Fieldset, ModelAdmin};
 use reinhardt::{admin, model};
 use serde::{Deserialize, Serialize};
 
@@ -24,12 +23,4 @@ struct Article {
 )]
 struct ArticleAdmin;
 
-fn main() {
-	assert_eq!(
-		ArticleAdmin.fieldsets(),
-		Some(vec![
-			Fieldset::new(Some("Main"), &["name"]),
-			Fieldset::new(None, &["notes"]).collapsed(),
-		])
-	);
-}
+fn main() {}

--- a/tests/integration/tests/admin/ui/pass/fieldsets.rs
+++ b/tests/integration/tests/admin/ui/pass/fieldsets.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 struct Article {
 	#[field(primary_key = true)]
 	id: i64,
+	#[field(max_length = 255)]
 	name: String,
+	#[field(max_length = 255)]
 	notes: String,
 }
 

--- a/tests/integration/tests/admin/ui/pass/fieldsets.rs
+++ b/tests/integration/tests/admin/ui/pass/fieldsets.rs
@@ -1,0 +1,35 @@
+// The macros emit Reinhardt-specific configuration names in this standalone fixture.
+#![allow(unexpected_cfgs)]
+
+use reinhardt::admin::{Fieldset, ModelAdmin};
+use reinhardt::{admin, model};
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "admin_ui", table_name = "articles")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Article {
+	#[field(primary_key = true)]
+	id: i64,
+	name: String,
+	notes: String,
+}
+
+#[admin(model,
+	for = Article,
+	name = "Article",
+	fieldsets = [
+		(title = "Main", fields = [name]),
+		(fields = [notes], collapsed = true)
+	]
+)]
+struct ArticleAdmin;
+
+fn main() {
+	assert_eq!(
+		ArticleAdmin.fieldsets(),
+		Some(vec![
+			Fieldset::new(Some("Main"), &["name"]),
+			Fieldset::new(None, &["notes"]).collapsed(),
+		])
+	);
+}

--- a/tests/integration/tests/admin_macro_ui.rs
+++ b/tests/integration/tests/admin_macro_ui.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 struct RuntimeArticle {
 	#[field(primary_key = true)]
 	id: i64,
+	#[field(max_length = 255)]
 	name: String,
+	#[field(max_length = 255)]
 	notes: String,
 }
 

--- a/tests/integration/tests/admin_macro_ui.rs
+++ b/tests/integration/tests/admin_macro_ui.rs
@@ -1,6 +1,49 @@
 //! Compile-time coverage for the `#[admin]` fieldset grammar.
 
+// The macros emit Reinhardt-specific configuration names in this integration test.
+#![allow(unexpected_cfgs)]
+
+use reinhardt::admin::ModelAdmin;
+use reinhardt::{admin, model};
 use rstest::rstest;
+use serde::{Deserialize, Serialize};
+
+#[model(app_label = "admin_ui", table_name = "runtime_articles")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct RuntimeArticle {
+	#[field(primary_key = true)]
+	id: i64,
+	name: String,
+	notes: String,
+}
+
+#[admin(model,
+	for = RuntimeArticle,
+	name = "Article",
+	fieldsets = [
+		(title = "Main", fields = [name]),
+		(fields = [notes], collapsed = true)
+	]
+)]
+struct RuntimeArticleAdmin;
+
+#[rstest]
+fn admin_macro_generates_exact_fieldsets() {
+	// Arrange
+	let admin = RuntimeArticleAdmin;
+
+	// Act
+	let fieldsets = admin.fieldsets().unwrap();
+
+	// Assert
+	assert_eq!(fieldsets.len(), 2);
+	assert_eq!(fieldsets[0].title.as_deref(), Some("Main"));
+	assert_eq!(fieldsets[0].fields, vec!["name"]);
+	assert_eq!(fieldsets[0].collapsed, false);
+	assert_eq!(fieldsets[1].title, None);
+	assert_eq!(fieldsets[1].fields, vec!["notes"]);
+	assert_eq!(fieldsets[1].collapsed, true);
+}
 
 #[rstest]
 fn model_admin_fieldsets_ui() {

--- a/tests/integration/tests/admin_macro_ui.rs
+++ b/tests/integration/tests/admin_macro_ui.rs
@@ -1,0 +1,16 @@
+//! Compile-time coverage for the `#[admin]` fieldset grammar.
+
+use rstest::rstest;
+
+#[rstest]
+fn model_admin_fieldsets_ui() {
+	// Arrange
+	let tests = trybuild::TestCases::new();
+
+	// Act & Assert
+	tests.pass("tests/admin/ui/pass/fieldsets.rs");
+	tests.compile_fail("tests/admin/ui/fail/fieldsets_unknown_field.rs");
+	tests.compile_fail("tests/admin/ui/fail/fields_and_fieldsets.rs");
+	tests.compile_fail("tests/admin/ui/fail/fieldsets_empty_group.rs");
+	tests.compile_fail("tests/admin/ui/fail/fieldsets_duplicate_field.rs");
+}

--- a/tests/integration/tests/admin_macro_ui.rs
+++ b/tests/integration/tests/admin_macro_ui.rs
@@ -57,5 +57,7 @@ fn model_admin_fieldsets_ui() {
 	tests.compile_fail("tests/admin/ui/fail/fieldsets_unknown_field.rs");
 	tests.compile_fail("tests/admin/ui/fail/fields_and_fieldsets.rs");
 	tests.compile_fail("tests/admin/ui/fail/fieldsets_empty_group.rs");
+	tests.compile_fail("tests/admin/ui/fail/fieldsets_empty.rs");
 	tests.compile_fail("tests/admin/ui/fail/fieldsets_duplicate_field.rs");
+	tests.compile_fail("tests/admin/ui/fail/fieldsets_duplicate_attribute.rs");
 }

--- a/tests/integration/tests/admin_macro_ui.rs
+++ b/tests/integration/tests/admin_macro_ui.rs
@@ -60,4 +60,5 @@ fn model_admin_fieldsets_ui() {
 	tests.compile_fail("tests/admin/ui/fail/fieldsets_empty.rs");
 	tests.compile_fail("tests/admin/ui/fail/fieldsets_duplicate_field.rs");
 	tests.compile_fail("tests/admin/ui/fail/fieldsets_duplicate_attribute.rs");
+	tests.compile_fail("tests/admin/ui/fail/fieldsets_duplicate_top_level.rs");
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Add ordered, titled, and optionally collapsed `ModelAdmin` fieldsets across the trait, builder, macro, server response, and native form renderer.
- Preserve the existing flat `fields` configuration and wire shape when fieldsets are absent.
- Validate conflicting, empty, unknown, and duplicate fieldset configuration before a form response is sent.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Large admin forms need ordered groups so related fields can be scanned together and infrequently edited sections can start collapsed. The implementation keeps the current flat form path unchanged and uses native `<details>` / `<summary>` behavior for accessible mouse and keyboard interaction.

Fixes #5990

Related to: #5808

## How Was This Tested?

- `cargo test -p reinhardt-admin --all-features` (520 unit tests, 20 E2E tests, and 59 doctests passed)
- `cargo test -p reinhardt-integration-tests --test admin --all-features` (232 passed)
- `cargo test -p reinhardt-integration-tests --test admin_macro_ui --all-features` (runtime macro test plus one pass and four compile-fail fixtures)
- `cargo check -p reinhardt-admin --all-features --all-targets`
- `cargo make clippy-check`
- `cargo make fmt-check` and `cargo make fmt-fix`
- `cargo test --doc -p reinhardt-admin --all-features`

The browser-target `wasm-pack` gate remains blocked before the changed code by existing WASM configuration errors involving the `MountError` export and unavailable `reinhardt_db`. Native renderer assertions and the CDP mouse/keyboard E2E test passed.

## Screenshots

Not attached. Exact native `<details>` / `<summary>` output, initial expanded/collapsed state, and mouse/keyboard toggling are covered by renderer and CDP assertions.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes the fieldset parity slice from #5808.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [x] `admin` - Admin interface, admin panels
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- Arbitrary CSS classes, nested groups, layout grids, persisted collapse state, and inline editing are intentionally out of scope.
- `model_form_with_fieldsets(model_name, fields, fieldsets, record_id)` is the grouped renderer contract; the existing `model_form` function remains unchanged.
