### PR TITLE
feat(admin): add date hierarchy and computed list columns

### DIFF
--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -118,6 +118,7 @@ use crate::models::User;
 	list_filter = [is_active],
 	search_fields = [username, email],
 	ordering = [(date_joined, desc)],
+	date_hierarchy = date_joined,
 	list_per_page = 25,
 )]
 pub struct UserAdmin;
@@ -131,6 +132,76 @@ at compile time, so you never need to write boilerplate field structs or
 loads each relation with a `LEFT JOIN` and returns it as a nested object under
 the relation name. Foreign keys that use `to_field` join against that field's
 physical database column.
+
+`date_hierarchy` accepts a declared `Date`, `DateTime`, or `TimestampTz` field.
+The changelist offers year, month, and day choices in sequence, applies each
+choice to the current scoped query, and returns to page 1.
+
+For computed columns, override `list_columns()` with a stable key and implement
+`computed_list_value()` for that key:
+
+```rust,ignore
+use reinhardt::admin::core::AdminResult;
+use reinhardt::admin::{AdminError, ListColumn, ModelAdmin};
+use reinhardt::async_trait::async_trait;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+
+struct ArticleAdmin;
+
+#[async_trait]
+impl ModelAdmin for ArticleAdmin {
+	fn model_name(&self) -> &str {
+		"Article"
+	}
+
+	fn table_name(&self) -> &str {
+		"articles"
+	}
+
+	fn list_columns(&self) -> Vec<ListColumn> {
+		vec![
+			ListColumn::Field {
+				field: "title".to_string(),
+				label: "Title".to_string(),
+			},
+			ListColumn::Computed {
+				key: "summary".to_string(),
+				label: "Summary".to_string(),
+				sort_field: Some("published_at".to_string()),
+			},
+		]
+	}
+
+	fn computed_list_value(
+		&self,
+		key: &str,
+		row: &HashMap<String, Value>,
+	) -> AdminResult<Value> {
+		match key {
+			"summary" => Ok(json!(format!(
+				"{} summary",
+				row.get("title").and_then(Value::as_str).unwrap_or_default()
+			))),
+			_ => Err(AdminError::TemplateError(format!(
+				"Unknown computed column: {key}"
+			))),
+		}
+	}
+}
+```
+
+A computed column is sortable only when `sort_field` names a real database
+field. Requests sort by the computed key (for example, `-summary`), while the
+server maps that key and direction to the declared database field before query
+execution. Use `None` for non-sortable values; SQL expressions and computed
+aliases are not valid sort mappings. Computed values are rendered as escaped
+text in the changelist.
+
+Existing `list_display()` implementations remain valid. The default
+`list_columns()` converts every legacy entry to a database-backed field column,
+so applications only need the descriptor API when they add computed columns or
+custom labels.
 
 For request-specific visibility rules, implement `get_queryset` and append
 filters to the supplied query. These conditions are always combined with

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -136,6 +136,9 @@ physical database column.
 `date_hierarchy` accepts a declared `Date`, `DateTime`, or `TimestampTz` field.
 The changelist offers year, month, and day choices in sequence, applies each
 choice to the current scoped query, and returns to page 1.
+The legacy `get_list` request/response types remain unchanged; the client uses
+the versioned `get_list_with_date_hierarchy` endpoint with
+`DateHierarchyListQueryParams` and `DateHierarchyListResponse` for this metadata.
 
 For computed columns, override `list_columns()` with a stable key and implement
 `computed_list_value()` for that key:

--- a/crates/reinhardt-admin/src/adapters.rs
+++ b/crates/reinhardt-admin/src/adapters.rs
@@ -30,8 +30,8 @@ pub use crate::types::{
 // which defines the full set of export formats with file I/O capabilities.
 pub use crate::types::{
 	AdminError, BulkDeleteRequest, BulkDeleteResponse, ColumnInfo, DashboardResponse,
-	DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, DetailResponse,
-	ExportFormat as RequestExportFormat, ExportResponse, FieldInfo, FieldType, FieldsResponse,
-	FilterChoice, FilterInfo, FilterType, ImportResponse, ListQueryParams, ListResponse,
-	LoginResponse, ModelInfo, MutationRequest, MutationResponse,
+	DateHierarchyInfo, DateHierarchyLevel, DateHierarchyListQueryParams, DateHierarchyListResponse,
+	DateHierarchySelection, DetailResponse, ExportFormat as RequestExportFormat, ExportResponse,
+	FieldInfo, FieldType, FieldsResponse, FilterChoice, FilterInfo, FilterType, ImportResponse,
+	ListQueryParams, ListResponse, LoginResponse, ModelInfo, MutationRequest, MutationResponse,
 };

--- a/crates/reinhardt-admin/src/adapters.rs
+++ b/crates/reinhardt-admin/src/adapters.rs
@@ -12,7 +12,7 @@
 #[cfg(server)]
 pub use crate::core::{
 	AdminDatabase, AdminQuery, AdminRecord, AdminRequestContext, AdminSite, AdminUser,
-	ExportFormat, ImportBuilder, ImportError, ImportFormat, ImportResult, ModelAdmin,
+	ExportFormat, ImportBuilder, ImportError, ImportFormat, ImportResult, ListColumn, ModelAdmin,
 	ModelAdminConfig, ModelAdminConfigBuilder,
 };
 
@@ -20,7 +20,7 @@ pub use crate::core::{
 #[cfg(client)]
 pub use crate::types::{
 	AdminDatabase, AdminQuery, AdminRecord, AdminRequestContext, AdminSite, AdminUser,
-	ExportFormat, ImportBuilder, ImportError, ImportFormat, ImportResult, ModelAdmin,
+	ExportFormat, ImportBuilder, ImportError, ImportFormat, ImportResult, ListColumn, ModelAdmin,
 	ModelAdminConfig, ModelAdminConfigBuilder,
 };
 
@@ -30,7 +30,8 @@ pub use crate::types::{
 // which defines the full set of export formats with file I/O capabilities.
 pub use crate::types::{
 	AdminError, BulkDeleteRequest, BulkDeleteResponse, ColumnInfo, DashboardResponse,
-	DetailResponse, ExportFormat as RequestExportFormat, ExportResponse, FieldInfo, FieldType,
-	FieldsResponse, FilterChoice, FilterInfo, FilterType, ImportResponse, ListQueryParams,
-	ListResponse, LoginResponse, ModelInfo, MutationRequest, MutationResponse,
+	DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, DetailResponse,
+	ExportFormat as RequestExportFormat, ExportResponse, FieldInfo, FieldType, FieldsResponse,
+	FilterChoice, FilterInfo, FilterType, ImportResponse, ListQueryParams, ListResponse,
+	LoginResponse, ModelInfo, MutationRequest, MutationResponse,
 };

--- a/crates/reinhardt-admin/src/core.rs
+++ b/crates/reinhardt-admin/src/core.rs
@@ -17,9 +17,9 @@ pub mod site;
 // Re-exports
 pub use crate::types::{
 	AdminError, AdminResult, BulkDeleteRequest, BulkDeleteResponse, ColumnInfo, DashboardResponse,
-	DetailResponse, ExportFormat as TypesExportFormat, FieldInfo, FieldType, FilterChoice,
-	FilterInfo, FilterType, ImportResponse, ListQueryParams, ListResponse, ModelInfo,
-	MutationRequest, MutationResponse,
+	DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, DetailResponse,
+	ExportFormat as TypesExportFormat, FieldInfo, FieldType, FilterChoice, FilterInfo, FilterType,
+	ImportResponse, ListQueryParams, ListResponse, ModelInfo, MutationRequest, MutationResponse,
 };
 pub use admin_query::{AdminQuery, AdminRequestContext};
 pub use database::{AdminDatabase, AdminDatabaseKey, AdminRecord};
@@ -27,6 +27,8 @@ pub use export::{CsvExporter, ExportBuilder, ExportConfig, ExportFormat, JsonExp
 pub use import::{
 	CsvImporter, ImportBuilder, ImportConfig, ImportError, ImportFormat, ImportResult, JsonImporter,
 };
-pub use model_admin::{AdminUser, ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder};
+pub use model_admin::{
+	AdminUser, ListColumn, ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder,
+};
 pub use router::{admin_csp_exempt_paths, admin_routes_with_di, admin_static_routes};
 pub use site::{AdminSite, AdminSiteConfig, AdminSiteKey};

--- a/crates/reinhardt-admin/src/core.rs
+++ b/crates/reinhardt-admin/src/core.rs
@@ -17,9 +17,10 @@ pub mod site;
 // Re-exports
 pub use crate::types::{
 	AdminError, AdminResult, BulkDeleteRequest, BulkDeleteResponse, ColumnInfo, DashboardResponse,
-	DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, DetailResponse,
-	ExportFormat as TypesExportFormat, FieldInfo, FieldType, FilterChoice, FilterInfo, FilterType,
-	ImportResponse, ListQueryParams, ListResponse, ModelInfo, MutationRequest, MutationResponse,
+	DateHierarchyInfo, DateHierarchyLevel, DateHierarchyListQueryParams, DateHierarchyListResponse,
+	DateHierarchySelection, DetailResponse, ExportFormat as TypesExportFormat, FieldInfo,
+	FieldType, FilterChoice, FilterInfo, FilterType, ImportResponse, ListQueryParams, ListResponse,
+	ModelInfo, MutationRequest, MutationResponse,
 };
 pub use admin_query::{AdminQuery, AdminRequestContext};
 pub use database::{AdminDatabase, AdminDatabaseKey, AdminRecord};

--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -15,14 +15,15 @@ use reinhardt_db::orm::{
 };
 use reinhardt_di::{DiResult, Injectable, InjectionContext, KeyedFactoryOutput};
 use reinhardt_query::prelude::{
-	Alias, BinOper, CaseStatement, ColumnRef, Condition, Expr, ExprTrait, IntoValue, Order,
+	Alias, BinOper, CaseStatement, ColumnRef, Condition, Expr, ExprTrait, Func, IntoValue, Order,
 	PostgresQueryBuilder, Query, QueryStatementBuilder, SelectStatement, SimpleExpr, TableRef,
-	Value,
+	TemporalTimeZone, TemporalTruncKind, TemporalTruncOutput, Value,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 const ADMIN_LIST_TOTAL_COUNT_ALIAS: &str = "__reinhardt_total_count";
+const ADMIN_DATE_HIERARCHY_ALIAS: &str = "__reinhardt_date_hierarchy";
 const ADMIN_RELATED_COLUMN_ALIAS_PREFIX: &str = "__reinhardt_related_";
 pub(crate) const SENSITIVE_FIELDS: &[&str] = &["password_hash", "password_salt"];
 
@@ -299,6 +300,32 @@ pub fn filter_value_to_sea_value(v: &FilterValue) -> AdminResult<Value> {
 	Ok(value)
 }
 
+fn filter_comparison_value(v: &FilterValue) -> AdminResult<SimpleExpr> {
+	if let FilterValue::Typed(Ok(reinhardt_db::orm::DatabaseValue::Date(date))) = v {
+		// The backend value carrier has no native date variant, so keep the
+		// AdminQuery value typed and lower its PostgreSQL representation through SQL DATE.
+		return Ok(Expr::cust_with_values("CAST(? AS DATE)", [postgres_date_text(date)]).into());
+	}
+
+	Ok(filter_value_to_sea_value(v)?.into())
+}
+
+fn postgres_date_text(date: &chrono::NaiveDate) -> String {
+	use chrono::Datelike;
+
+	let year = date.year();
+	let (display_year, suffix) = if year <= 0 {
+		(1_i64 - i64::from(year), " BC")
+	} else {
+		(i64::from(year), "")
+	};
+	format!(
+		"{display_year:04}-{:02}-{:02}{suffix}",
+		date.month(),
+		date.day()
+	)
+}
+
 /// Convert an annotation `AnnotationValue` to a safe SeaQuery `SimpleExpr`.
 ///
 /// Uses type-safe SeaQuery API for field references and literal values
@@ -566,12 +593,12 @@ fn build_single_filter_expr_for_table(
 		}
 
 		// Generic scalar value patterns
-		(FilterOperator::Eq, v) => col.eq(filter_value_to_sea_value(v)?),
-		(FilterOperator::Ne, v) => col.ne(filter_value_to_sea_value(v)?),
-		(FilterOperator::Gt, v) => col.gt(filter_value_to_sea_value(v)?),
-		(FilterOperator::Gte, v) => col.gte(filter_value_to_sea_value(v)?),
-		(FilterOperator::Lt, v) => col.lt(filter_value_to_sea_value(v)?),
-		(FilterOperator::Lte, v) => col.lte(filter_value_to_sea_value(v)?),
+		(FilterOperator::Eq, v) => col.eq(filter_comparison_value(v)?),
+		(FilterOperator::Ne, v) => col.ne(filter_comparison_value(v)?),
+		(FilterOperator::Gt, v) => col.gt(filter_comparison_value(v)?),
+		(FilterOperator::Gte, v) => col.gte(filter_comparison_value(v)?),
+		(FilterOperator::Lt, v) => col.lt(filter_comparison_value(v)?),
+		(FilterOperator::Lte, v) => col.lte(filter_comparison_value(v)?),
 
 		// String-specific operators
 		(FilterOperator::Contains, FilterValue::String(s)) => {
@@ -926,6 +953,104 @@ fn build_admin_count_statement(admin_query: &AdminQuery) -> AdminResult<SelectSt
 	Ok(statement)
 }
 
+fn build_date_hierarchy_statement(
+	admin_query: &AdminQuery,
+	field: &str,
+	level: crate::types::DateHierarchyLevel,
+	field_type: &DbFieldType,
+) -> AdminResult<SelectStatement> {
+	let kind = match level {
+		crate::types::DateHierarchyLevel::Year => TemporalTruncKind::Year,
+		crate::types::DateHierarchyLevel::Month => TemporalTruncKind::Month,
+		crate::types::DateHierarchyLevel::Day => TemporalTruncKind::Day,
+	};
+	let (time_zone, output) = match field_type {
+		DbFieldType::Date => (None, TemporalTruncOutput::Date),
+		DbFieldType::DateTime | DbFieldType::TimestampTz => {
+			(Some(TemporalTimeZone::Utc), TemporalTruncOutput::DateTime)
+		}
+		_ => {
+			return Err(AdminError::ValidationError(format!(
+				"Date hierarchy field '{field}' must be a date or datetime field"
+			)));
+		}
+	};
+	let projection = Func::temporal_trunc(
+		Expr::col(Alias::new(field)).into_simple_expr(),
+		kind,
+		time_zone,
+		output,
+	)
+	.map_err(|error| AdminError::ValidationError(error.to_string()))?;
+	let mut statement = Query::select()
+		.from(Alias::new(admin_query.table_name()))
+		.expr_as(projection, Alias::new(ADMIN_DATE_HIERARCHY_ALIAS))
+		.distinct()
+		.to_owned();
+	statement.and_where(Expr::col(Alias::new(field)).is_not_null());
+	if let Some(condition) = build_admin_query_condition(admin_query, None)? {
+		statement.cond_where(condition);
+	}
+	statement.order_by(Alias::new(ADMIN_DATE_HIERARCHY_ALIAS), Order::Asc);
+	Ok(statement)
+}
+
+fn parse_date_hierarchy_choice(
+	value: &str,
+	level: crate::types::DateHierarchyLevel,
+	field_type: &DbFieldType,
+) -> AdminResult<i32> {
+	use chrono::Datelike;
+
+	let (date_value, is_bc) = match field_type {
+		DbFieldType::Date => (
+			value.strip_suffix(" BC").unwrap_or(value),
+			value.ends_with(" BC"),
+		),
+		DbFieldType::DateTime | DbFieldType::TimestampTz => {
+			let is_bc = value.ends_with(" BC");
+			let value = value.strip_suffix(" BC").unwrap_or(value);
+			let date_end = value
+				.find(|character| character == 'T' || character == ' ')
+				.ok_or_else(|| {
+					AdminError::DatabaseError(
+						"Admin date hierarchy query returned an invalid date".to_string(),
+					)
+				})?;
+			(&value[..date_end], is_bc)
+		}
+		_ => {
+			return Err(AdminError::ValidationError(
+				"Date hierarchy choices require a date or datetime field".to_string(),
+			));
+		}
+	};
+	let mut parts = date_value.rsplitn(3, '-');
+	let day = parts.next().and_then(|part| part.parse::<u32>().ok());
+	let month = parts.next().and_then(|part| part.parse::<u32>().ok());
+	let year = parts.next().and_then(|part| part.parse::<i32>().ok());
+	let year = match (year, is_bc) {
+		(Some(year), false) => Some(year),
+		(Some(year), true) if year > 0 => i32::try_from(1_i64 - i64::from(year)).ok(),
+		_ => None,
+	};
+	let date = year
+		.zip(month)
+		.zip(day)
+		.and_then(|((year, month), day)| chrono::NaiveDate::from_ymd_opt(year, month, day))
+		.ok_or_else(|| {
+			AdminError::DatabaseError(
+				"Admin date hierarchy query returned an invalid date".to_string(),
+			)
+		})?;
+
+	Ok(match level {
+		crate::types::DateHierarchyLevel::Year => date.year(),
+		crate::types::DateHierarchyLevel::Month => date.month() as i32,
+		crate::types::DateHierarchyLevel::Day => date.day() as i32,
+	})
+}
+
 fn decode_admin_list_row(
 	mut map: serde_json::Map<String, serde_json::Value>,
 	related_fields: &[AdminRelatedField],
@@ -1246,6 +1371,37 @@ impl AdminDatabase {
 		})?;
 
 		Ok((results, total_count))
+	}
+
+	pub(crate) async fn date_hierarchy_choices(
+		&self,
+		admin_query: &AdminQuery,
+		field: &str,
+		level: crate::types::DateHierarchyLevel,
+		field_type: &DbFieldType,
+	) -> AdminResult<Vec<i32>> {
+		let statement = build_date_hierarchy_statement(admin_query, field, level, field_type)?;
+		let (sql, values) = statement.build(PostgresQueryBuilder);
+		let rows = self
+			.connection
+			.query(&sql, convert_values(values))
+			.await
+			.map_err(|error| AdminError::DatabaseError(error.to_string()))?;
+
+		rows.into_iter()
+			.map(|row| {
+				let value = row
+					.data
+					.get(ADMIN_DATE_HIERARCHY_ALIAS)
+					.and_then(serde_json::Value::as_str)
+					.ok_or_else(|| {
+						AdminError::DatabaseError(
+							"Admin date hierarchy query returned an invalid value".to_string(),
+						)
+					})?;
+				parse_date_hierarchy_choice(value, level, field_type)
+			})
+			.collect()
 	}
 
 	async fn count_admin_query(&self, admin_query: &AdminQuery) -> AdminResult<u64> {
@@ -3652,6 +3808,154 @@ mod tests {
 		assert_eq!(
 			count_sql,
 			"SELECT COUNT(*) AS count FROM \"articles\" WHERE (\"owner_id\" = 7 AND (\"status\" = 'published' OR \"status\" = 'review'))"
+		);
+	}
+
+	#[test]
+	fn test_date_hierarchy_statement_reuses_scoped_admin_query() {
+		// Arrange
+		let query = crate::core::AdminQuery::new("articles")
+			.filter(Filter::new(
+				"owner_id",
+				FilterOperator::Eq,
+				FilterValue::Integer(7),
+			))
+			.filter(Filter::new(
+				"published_on",
+				FilterOperator::Gte,
+				FilterValue::Typed(Ok(reinhardt_db::orm::DatabaseValue::Date(
+					chrono::NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+				))),
+			))
+			.filter(Filter::new(
+				"published_on",
+				FilterOperator::Lt,
+				FilterValue::Typed(Ok(reinhardt_db::orm::DatabaseValue::Date(
+					chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+				))),
+			));
+
+		// Act
+		let sql = build_date_hierarchy_statement(
+			&query,
+			"published_on",
+			crate::types::DateHierarchyLevel::Month,
+			&DbFieldType::Date,
+		)
+		.unwrap()
+		.to_string(PostgresQueryBuilder);
+
+		// Assert
+		assert_eq!(
+			sql,
+			"SELECT DISTINCT DATE_TRUNC('month', \"published_on\")::date AS \"__reinhardt_date_hierarchy\" FROM \"articles\" WHERE \"published_on\" IS NOT NULL AND (\"owner_id\" = 7 AND \"published_on\" >= CAST('2024-01-01' AS DATE) AND \"published_on\" < CAST('2025-01-01' AS DATE)) ORDER BY \"__reinhardt_date_hierarchy\" ASC"
+		);
+	}
+
+	#[test]
+	fn test_typed_date_filter_binds_castable_postgres_value() {
+		// Arrange
+		let query = crate::core::AdminQuery::new("articles").filter(Filter::new(
+			"published_on",
+			FilterOperator::Gte,
+			FilterValue::Typed(Ok(reinhardt_db::orm::DatabaseValue::Date(
+				chrono::NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+			))),
+		));
+
+		// Act
+		let statement = build_admin_list_statement(&query, &[], None, 0, 25).unwrap();
+		let (sql, values) = statement.build(PostgresQueryBuilder);
+		let params = convert_values(values);
+
+		// Assert
+		assert_eq!(
+			sql,
+			"SELECT \"articles\".*, COUNT(*) OVER() AS \"__reinhardt_total_count\" FROM \"articles\" WHERE \"published_on\" >= CAST($1 AS DATE) LIMIT $2 OFFSET $3"
+		);
+		assert_eq!(
+			params,
+			vec![
+				reinhardt_db::backends::types::QueryValue::String("2024-01-01".to_string()),
+				reinhardt_db::backends::types::QueryValue::Int(25),
+				reinhardt_db::backends::types::QueryValue::Int(0),
+			]
+		);
+	}
+
+	#[test]
+	fn test_typed_date_filter_normalizes_expanded_and_bce_years_for_postgres() {
+		// Arrange
+		let query = crate::core::AdminQuery::new("articles")
+			.filter(Filter::new(
+				"published_on",
+				FilterOperator::Gte,
+				FilterValue::Typed(Ok(reinhardt_db::orm::DatabaseValue::Date(
+					chrono::NaiveDate::from_ymd_opt(10_000, 1, 1).unwrap(),
+				))),
+			))
+			.filter(Filter::new(
+				"published_on",
+				FilterOperator::Lt,
+				FilterValue::Typed(Ok(reinhardt_db::orm::DatabaseValue::Date(
+					chrono::NaiveDate::from_ymd_opt(0, 1, 1).unwrap(),
+				))),
+			));
+
+		// Act
+		let statement = build_admin_list_statement(&query, &[], None, 0, 25).unwrap();
+		let (_, values) = statement.build(PostgresQueryBuilder);
+		let params = convert_values(values);
+
+		// Assert
+		assert_eq!(
+			params,
+			vec![
+				reinhardt_db::backends::types::QueryValue::String("10000-01-01".to_string()),
+				reinhardt_db::backends::types::QueryValue::String("0001-01-01 BC".to_string()),
+				reinhardt_db::backends::types::QueryValue::Int(25),
+				reinhardt_db::backends::types::QueryValue::Int(0),
+			]
+		);
+	}
+
+	#[test]
+	fn test_date_hierarchy_choice_parses_expanded_years_and_datetimes() {
+		assert_eq!(
+			parse_date_hierarchy_choice(
+				"+10000-02-01",
+				crate::types::DateHierarchyLevel::Year,
+				&DbFieldType::Date,
+			)
+			.unwrap(),
+			10_000
+		);
+		assert_eq!(
+			parse_date_hierarchy_choice(
+				"+10000-02-01T00:00:00+00:00",
+				crate::types::DateHierarchyLevel::Year,
+				&DbFieldType::TimestampTz,
+			)
+			.unwrap(),
+			10_000
+		);
+		assert_eq!(
+			parse_date_hierarchy_choice(
+				"0001-02-01 00:00:00 BC",
+				crate::types::DateHierarchyLevel::Year,
+				&DbFieldType::DateTime,
+			)
+			.unwrap(),
+			0
+		);
+		assert_eq!(
+			parse_date_hierarchy_choice(
+				"2024-02-29T00:00:00+00:00",
+				crate::types::DateHierarchyLevel::Day,
+				&DbFieldType::TimestampTz,
+			)
+			.unwrap(),
+			29
 		);
 	}
 

--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -1008,9 +1008,7 @@ fn parse_date_hierarchy_choice(
 		DbFieldType::DateTime | DbFieldType::TimestampTz => {
 			let is_bc = value.ends_with(" BC");
 			let value = value.strip_suffix(" BC").unwrap_or(value);
-			let date_end = value
-				.find(|character| character == 'T' || character == ' ')
-				.unwrap_or(value.len());
+			let date_end = value.find(['T', ' ']).unwrap_or(value.len());
 			(&value[..date_end], is_bc)
 		}
 		_ => {

--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -965,10 +965,8 @@ fn build_date_hierarchy_statement(
 		crate::types::DateHierarchyLevel::Day => TemporalTruncKind::Day,
 	};
 	let (time_zone, output) = match field_type {
-		DbFieldType::Date => (None, TemporalTruncOutput::Date),
-		DbFieldType::DateTime | DbFieldType::TimestampTz => {
-			(Some(TemporalTimeZone::Utc), TemporalTruncOutput::DateTime)
-		}
+		DbFieldType::Date | DbFieldType::DateTime => (None, TemporalTruncOutput::Date),
+		DbFieldType::TimestampTz => (Some(TemporalTimeZone::Utc), TemporalTruncOutput::DateTime),
 		_ => {
 			return Err(AdminError::ValidationError(format!(
 				"Date hierarchy field '{field}' must be a date or datetime field"
@@ -1012,11 +1010,7 @@ fn parse_date_hierarchy_choice(
 			let value = value.strip_suffix(" BC").unwrap_or(value);
 			let date_end = value
 				.find(|character| character == 'T' || character == ' ')
-				.ok_or_else(|| {
-					AdminError::DatabaseError(
-						"Admin date hierarchy query returned an invalid date".to_string(),
-					)
-				})?;
+				.unwrap_or(value.len());
 			(&value[..date_end], is_bc)
 		}
 		_ => {
@@ -3853,6 +3847,54 @@ mod tests {
 	}
 
 	#[test]
+	fn test_datetime_hierarchy_statement_preserves_naive_calendar_and_bounds() {
+		// Arrange
+		let start = chrono::NaiveDate::from_ymd_opt(2024, 1, 1)
+			.unwrap()
+			.and_hms_opt(0, 0, 0)
+			.unwrap();
+		let end = chrono::NaiveDate::from_ymd_opt(2025, 1, 1)
+			.unwrap()
+			.and_hms_opt(0, 0, 0)
+			.unwrap();
+		let query = crate::core::AdminQuery::new("events")
+			.filter(Filter::new(
+				"starts_at",
+				FilterOperator::Gte,
+				FilterValue::Typed(Ok(reinhardt_db::orm::DatabaseValue::NaiveDateTime(start))),
+			))
+			.filter(Filter::new(
+				"starts_at",
+				FilterOperator::Lt,
+				FilterValue::Typed(Ok(reinhardt_db::orm::DatabaseValue::NaiveDateTime(end))),
+			));
+
+		// Act
+		let statement = build_date_hierarchy_statement(
+			&query,
+			"starts_at",
+			crate::types::DateHierarchyLevel::Month,
+			&DbFieldType::DateTime,
+		)
+		.unwrap();
+		let (sql, values) = statement.build(PostgresQueryBuilder);
+		let params = convert_values(values);
+
+		// Assert
+		assert_eq!(
+			sql,
+			"SELECT DISTINCT DATE_TRUNC('month', \"starts_at\")::date AS \"__reinhardt_date_hierarchy\" FROM \"events\" WHERE \"starts_at\" IS NOT NULL AND (\"starts_at\" >= $1 AND \"starts_at\" < $2) ORDER BY \"__reinhardt_date_hierarchy\" ASC"
+		);
+		assert_eq!(
+			params,
+			vec![
+				reinhardt_db::backends::types::QueryValue::NaiveTimestamp(start),
+				reinhardt_db::backends::types::QueryValue::NaiveTimestamp(end),
+			]
+		);
+	}
+
+	#[test]
 	fn test_typed_date_filter_binds_castable_postgres_value() {
 		// Arrange
 		let query = crate::core::AdminQuery::new("articles").filter(Filter::new(
@@ -3921,6 +3963,15 @@ mod tests {
 
 	#[test]
 	fn test_date_hierarchy_choice_parses_expanded_years_and_datetimes() {
+		assert_eq!(
+			parse_date_hierarchy_choice(
+				"2024-02-01",
+				crate::types::DateHierarchyLevel::Month,
+				&DbFieldType::DateTime,
+			)
+			.unwrap(),
+			2
+		);
 		assert_eq!(
 			parse_date_hierarchy_choice(
 				"+10000-02-01",

--- a/crates/reinhardt-admin/src/core/model_admin.rs
+++ b/crates/reinhardt-admin/src/core/model_admin.rs
@@ -5,6 +5,29 @@
 use crate::core::admin_query::{AdminQuery, AdminRequestContext};
 use crate::types::{AdminError, AdminResult};
 use async_trait::async_trait;
+use reinhardt_utils::utils_core::text::humanize_field_name;
+use std::collections::HashMap;
+
+/// A column displayed in an admin changelist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ListColumn {
+	/// A database-backed field column.
+	Field {
+		/// Field name to read from the result row.
+		field: String,
+		/// Display label for the column header.
+		label: String,
+	},
+	/// A value computed after the result row is fetched.
+	Computed {
+		/// Stable key used in responses and computed-value lookup.
+		key: String,
+		/// Display label for the column header.
+		label: String,
+		/// Database field used when this computed column is sorted.
+		sort_field: Option<String>,
+	},
+}
 
 /// Object-safe trait for admin permission checks.
 ///
@@ -82,6 +105,38 @@ pub trait ModelAdmin: Send + Sync {
 	/// Fields to display in list view
 	fn list_display(&self) -> Vec<&str> {
 		vec!["id"]
+	}
+
+	/// Owned descriptors for columns displayed in list view.
+	///
+	/// The default preserves the legacy [`Self::list_display`] contract by
+	/// converting every field to a database-backed descriptor.
+	fn list_columns(&self) -> Vec<ListColumn> {
+		self.list_display()
+			.into_iter()
+			.map(|field| ListColumn::Field {
+				field: field.to_string(),
+				label: humanize_field_name(field),
+			})
+			.collect()
+	}
+
+	/// Resolve a computed changelist column for a fetched result row.
+	///
+	/// Implement this together with a [`ListColumn::Computed`] descriptor.
+	fn computed_list_value(
+		&self,
+		key: &str,
+		_row: &HashMap<String, serde_json::Value>,
+	) -> AdminResult<serde_json::Value> {
+		Err(AdminError::TemplateError(format!(
+			"No computed list column is configured for key '{key}'"
+		)))
+	}
+
+	/// Date or datetime field used for hierarchical changelist navigation.
+	fn date_hierarchy(&self) -> Option<&str> {
+		None
 	}
 
 	/// Fields that can be used for filtering
@@ -205,6 +260,7 @@ pub struct ModelAdminConfig {
 	ordering: Vec<String>,
 	list_per_page: Option<usize>,
 	list_select_related: Vec<String>,
+	date_hierarchy: Option<String>,
 	allow_view: bool,
 	allow_add: bool,
 	allow_change: bool,
@@ -235,6 +291,7 @@ impl ModelAdminConfig {
 			ordering: vec!["-id".into()],
 			list_per_page: None,
 			list_select_related: vec![],
+			date_hierarchy: None,
 			allow_view: false,
 			allow_add: false,
 			allow_change: false,
@@ -280,6 +337,12 @@ impl ModelAdminConfig {
 	/// Set related fields selected with each changelist row.
 	pub fn with_list_select_related(mut self, fields: Vec<impl Into<String>>) -> Self {
 		self.list_select_related = fields.into_iter().map(Into::into).collect();
+		self
+	}
+
+	/// Set the date or datetime field used for hierarchical navigation.
+	pub fn with_date_hierarchy(mut self, field: impl Into<String>) -> Self {
+		self.date_hierarchy = Some(field.into());
 		self
 	}
 }
@@ -337,6 +400,10 @@ impl ModelAdmin for ModelAdminConfig {
 			.collect()
 	}
 
+	fn date_hierarchy(&self) -> Option<&str> {
+		self.date_hierarchy.as_deref()
+	}
+
 	async fn has_view_permission(&self, _user: &dyn AdminUser) -> bool {
 		self.allow_view
 	}
@@ -368,6 +435,7 @@ pub struct ModelAdminConfigBuilder {
 	ordering: Option<Vec<String>>,
 	list_per_page: Option<usize>,
 	list_select_related: Option<Vec<String>>,
+	date_hierarchy: Option<String>,
 	allow_view: Option<bool>,
 	allow_add: Option<bool>,
 	allow_change: Option<bool>,
@@ -442,6 +510,12 @@ impl ModelAdminConfigBuilder {
 	/// Set related fields selected with each changelist row.
 	pub fn list_select_related(mut self, fields: Vec<impl Into<String>>) -> Self {
 		self.list_select_related = Some(fields.into_iter().map(Into::into).collect());
+		self
+	}
+
+	/// Set the date or datetime field used for hierarchical navigation.
+	pub fn date_hierarchy(mut self, field: impl Into<String>) -> Self {
+		self.date_hierarchy = Some(field.into());
 		self
 	}
 
@@ -522,6 +596,7 @@ impl ModelAdminConfigBuilder {
 			ordering: self.ordering.unwrap_or_else(|| vec!["-id".into()]),
 			list_per_page: self.list_per_page,
 			list_select_related: self.list_select_related.unwrap_or_default(),
+			date_hierarchy: self.date_hierarchy,
 			allow_view: self.allow_view.unwrap_or(false),
 			allow_add: self.allow_add.unwrap_or(false),
 			allow_change: self.allow_change.unwrap_or(false),
@@ -583,6 +658,90 @@ mod tests {
 		assert_eq!(admin.model_name(), "User");
 		assert_eq!(admin.list_display(), vec!["id"]);
 		assert_eq!(admin.list_filter(), Vec::<&str>::new());
+	}
+
+	#[rstest]
+	fn test_list_columns_converts_legacy_list_display() {
+		// Arrange
+		let config = ModelAdminConfig::new("User").with_list_display(vec!["id", "created_at"]);
+		let admin: &dyn ModelAdmin = &config;
+
+		// Act
+		let columns = admin.list_columns();
+
+		// Assert
+		assert_eq!(
+			columns,
+			vec![
+				ListColumn::Field {
+					field: "id".to_string(),
+					label: "Id".to_string(),
+				},
+				ListColumn::Field {
+					field: "created_at".to_string(),
+					label: "Created At".to_string(),
+				},
+			]
+		);
+	}
+
+	#[rstest]
+	fn test_computed_column_preserves_key_label_and_sort_mapping() {
+		// Arrange
+		let column = ListColumn::Computed {
+			key: "author_name".to_string(),
+			label: "Author".to_string(),
+			sort_field: Some("author_id".to_string()),
+		};
+
+		// Act & Assert
+		assert_eq!(
+			column,
+			ListColumn::Computed {
+				key: "author_name".to_string(),
+				label: "Author".to_string(),
+				sort_field: Some("author_id".to_string()),
+			}
+		);
+	}
+
+	#[rstest]
+	fn test_default_computed_list_value_returns_template_error() {
+		// Arrange
+		let admin = ModelAdminConfig::new("User");
+
+		// Act
+		let result = admin.computed_list_value("author_name", &HashMap::new());
+
+		// Assert
+		assert!(matches!(result, Err(AdminError::TemplateError(_))));
+	}
+
+	#[rstest]
+	fn test_date_hierarchy_defaults_to_none() {
+		// Arrange & Act
+		let config_admin = ModelAdminConfig::new("User");
+		let builder_admin = ModelAdminConfig::builder()
+			.model_name("User")
+			.build()
+			.unwrap();
+
+		// Assert
+		assert_eq!(config_admin.date_hierarchy(), None);
+		assert_eq!(builder_admin.date_hierarchy(), None);
+	}
+
+	#[rstest]
+	fn test_date_hierarchy_builder_configures_field() {
+		// Arrange & Act
+		let admin = ModelAdminConfig::builder()
+			.model_name("User")
+			.date_hierarchy("created_at")
+			.build()
+			.unwrap();
+
+		// Assert
+		assert_eq!(admin.date_hierarchy(), Some("created_at"));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-admin/src/core/router.rs
+++ b/crates/reinhardt-admin/src/core/router.rs
@@ -419,12 +419,14 @@ fn build_admin_router(
 	let router = {
 		use crate::server::{
 			bulk_delete_records, create_record, delete_record, export_data, get_dashboard,
-			get_detail, get_fields, get_list, import_data, login::admin_login,
-			login::admin_login_with_header, logout::admin_logout, update_record,
+			get_detail, get_fields, get_list, get_list_with_date_hierarchy, import_data,
+			login::admin_login, login::admin_login_with_header, logout::admin_logout,
+			update_record,
 		};
 		router
 			.server_fn(get_dashboard::marker)
 			.server_fn(get_list::marker)
+			.server_fn(get_list_with_date_hierarchy::marker)
 			.server_fn(get_detail::marker)
 			.server_fn(get_fields::marker)
 			.server_fn(create_record::marker)
@@ -588,6 +590,7 @@ mod tests {
 		let expected_paths = [
 			"/api/server_fn/get_dashboard",
 			"/api/server_fn/get_list",
+			"/api/server_fn/get_list_with_date_hierarchy",
 			"/api/server_fn/get_detail",
 			"/api/server_fn/get_fields",
 			"/api/server_fn/create_record",
@@ -608,8 +611,8 @@ mod tests {
 		let routes = router.get_all_routes();
 		let paths: Vec<&str> = routes.iter().map(|(path, _, _, _)| path.as_str()).collect();
 
-		// Assert - 13 server functions + 2 GET routes should be registered
-		assert_eq!(routes.len(), 15);
+		// Assert - 14 server functions + 2 GET routes should be registered
+		assert_eq!(routes.len(), 16);
 		for expected in &expected_paths {
 			assert_eq!(
 				paths.iter().filter(|p| p == &expected).count(),

--- a/crates/reinhardt-admin/src/lib.rs
+++ b/crates/reinhardt-admin/src/lib.rs
@@ -41,8 +41,8 @@ pub mod core {
 
 	pub use crate::types::{
 		AdminDatabase, AdminQuery, AdminRecord, AdminRequestContext, AdminSite, AdminUser,
-		ExportFormat, ImportBuilder, ImportError, ImportFormat, ImportResult, ModelAdmin,
-		ModelAdminConfig, ModelAdminConfigBuilder,
+		ExportFormat, ImportBuilder, ImportError, ImportFormat, ImportResult, ListColumn,
+		ModelAdmin, ModelAdminConfig, ModelAdminConfigBuilder,
 	};
 }
 pub mod pages;

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -12,7 +12,7 @@
 use crate::server::{create_record, delete_record, update_record};
 #[cfg(any(client, test))]
 use crate::types::{
-	DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, ListQueryParams,
+	DateHierarchyInfo, DateHierarchyLevel, DateHierarchyListQueryParams, DateHierarchySelection,
 };
 use crate::types::{FilterInfo, FilterType, ModelInfo};
 use reinhardt_pages::Signal;
@@ -195,7 +195,7 @@ pub(crate) fn list_view_with_date_hierarchy(
 	current_page_signal: Signal<u64>,
 	filters_signal: Signal<HashMap<String, String>>,
 	date_hierarchy: Option<&DateHierarchyInfo>,
-	query_params: Signal<ListQueryParams>,
+	query_params: Signal<DateHierarchyListQueryParams>,
 	query_generation: Rc<Cell<u64>>,
 ) -> Page {
 	let date_hierarchy_page =
@@ -272,7 +272,7 @@ fn render_list_view(
 
 #[cfg(any(client, test))]
 fn apply_date_hierarchy_choice(
-	query_params: Signal<ListQueryParams>,
+	query_params: Signal<DateHierarchyListQueryParams>,
 	query_generation: Rc<Cell<u64>>,
 	mut selection: DateHierarchySelection,
 	next_level: DateHierarchyLevel,
@@ -312,7 +312,7 @@ fn apply_date_hierarchy_choice(
 #[cfg(any(client, test))]
 fn date_hierarchy_navigation(
 	date_hierarchy: Option<&DateHierarchyInfo>,
-	query_params: Signal<ListQueryParams>,
+	query_params: Signal<DateHierarchyListQueryParams>,
 	query_generation: Rc<Cell<u64>>,
 ) -> Page {
 	let Some(date_hierarchy) = date_hierarchy else {
@@ -338,7 +338,7 @@ fn date_hierarchy_navigation(
 					let selection = date_hierarchy.selection.clone();
 					page!(|label: String,
 					 aria_label: String,
-					 _query_params: Signal<ListQueryParams>,
+						 _query_params: Signal<DateHierarchyListQueryParams>,
 					 _query_generation: Rc<Cell<u64>>,
 					 _selection: DateHierarchySelection,
 					 _next_level: DateHierarchyLevel,
@@ -1295,7 +1295,8 @@ mod tests {
 		form_values_to_json_array, list_view, list_view_with_date_hierarchy,
 	};
 	use crate::types::{
-		DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, ListQueryParams,
+		DateHierarchyInfo, DateHierarchyLevel, DateHierarchyListQueryParams,
+		DateHierarchySelection, ListQueryParams,
 	};
 	use reinhardt_core::reactive::ReactiveScope;
 	use reinhardt_pages::Signal;
@@ -1332,9 +1333,12 @@ mod tests {
 			};
 			let page_signal = Signal::new(1_u64);
 			let filters_signal = Signal::new(HashMap::new());
-			let query_params = Signal::new(ListQueryParams {
-				page: Some(1),
-				..ListQueryParams::default()
+			let query_params = Signal::new(DateHierarchyListQueryParams {
+				list: ListQueryParams {
+					page: Some(1),
+					..ListQueryParams::default()
+				},
+				date_hierarchy: None,
 			});
 			let query_generation = std::rc::Rc::new(std::cell::Cell::new(0_u64));
 
@@ -1393,14 +1397,16 @@ mod tests {
 
 			for (next_level, choice, expected_selection) in cases {
 				// Arrange
-				let query_params = Signal::new(ListQueryParams {
-					page: Some(8),
+				let query_params = Signal::new(DateHierarchyListQueryParams {
+					list: ListQueryParams {
+						page: Some(8),
+						..ListQueryParams::default()
+					},
 					date_hierarchy: Some(DateHierarchySelection {
 						year: Some(2020),
 						month: Some(2),
 						day: Some(3),
 					}),
-					..ListQueryParams::default()
 				});
 				let query_generation = std::rc::Rc::new(std::cell::Cell::new(4_u64));
 

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -10,14 +10,19 @@
 
 #[cfg(client)]
 use crate::server::{create_record, delete_record, update_record};
+#[cfg(any(client, test))]
 use crate::types::{
-	DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, FilterInfo, FilterType,
-	ListQueryParams, ModelInfo,
+	DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, ListQueryParams,
 };
+use crate::types::{FilterInfo, FilterType, ModelInfo};
 use reinhardt_pages::Signal;
 use reinhardt_pages::component::Page;
 use reinhardt_pages::page;
+#[cfg(any(client, test))]
+use std::cell::Cell;
 use std::collections::HashMap;
+#[cfg(any(client, test))]
+use std::rc::Rc;
 
 fn reverse_admin_url(route_name: &str, params: &[(&str, &str)]) -> String {
 	crate::pages::router::try_with_router(|router| router.reverse(route_name, params))
@@ -146,8 +151,6 @@ pub struct ListViewData {
 	pub total_count: u64,
 	/// Filter information
 	pub filters: Vec<FilterInfo>,
-	/// Date hierarchy metadata for drill-down navigation
-	pub date_hierarchy: Option<DateHierarchyInfo>,
 }
 
 /// List view component
@@ -172,21 +175,44 @@ pub struct ListViewData {
 ///     total_pages: 5,
 ///     total_count: 42,
 ///     filters: vec![],
-///     date_hierarchy: None,
 /// };
 /// let page_signal = Signal::new(1u64);
 /// let filters_signal = Signal::new(HashMap::new());
-/// let query_params = Signal::new(reinhardt_admin::types::ListQueryParams {
-///     page: Some(1),
-///     ..Default::default()
-/// });
-/// list_view(&data, page_signal, filters_signal, query_params)
+/// list_view(&data, page_signal, filters_signal)
 /// ```
 pub fn list_view(
 	data: &ListViewData,
 	current_page_signal: reinhardt_pages::Signal<u64>,
 	filters_signal: Signal<HashMap<String, String>>,
+) -> Page {
+	render_list_view(data, current_page_signal, filters_signal, Page::empty())
+}
+
+/// Renders the router-owned list view with optional date hierarchy navigation.
+#[cfg(any(client, test))]
+pub(crate) fn list_view_with_date_hierarchy(
+	data: &ListViewData,
+	current_page_signal: Signal<u64>,
+	filters_signal: Signal<HashMap<String, String>>,
+	date_hierarchy: Option<&DateHierarchyInfo>,
 	query_params: Signal<ListQueryParams>,
+	query_generation: Rc<Cell<u64>>,
+) -> Page {
+	let date_hierarchy_page =
+		date_hierarchy_navigation(date_hierarchy, query_params, query_generation);
+	render_list_view(
+		data,
+		current_page_signal,
+		filters_signal,
+		date_hierarchy_page,
+	)
+}
+
+fn render_list_view(
+	data: &ListViewData,
+	current_page_signal: Signal<u64>,
+	filters_signal: Signal<HashMap<String, String>>,
+	date_hierarchy_page: Page,
 ) -> Page {
 	let title = format!("{} List", data.model_name);
 	let summary = format!(
@@ -194,7 +220,6 @@ pub fn list_view(
 		data.total_count, data.model_name, data.current_page, data.total_pages
 	);
 	let filters_page = filters(&data.filters, filters_signal);
-	let date_hierarchy_page = date_hierarchy_navigation(data.date_hierarchy.as_ref(), query_params);
 	let table_page = data_table(&data.columns, &data.records, &data.model_name);
 	let pagination_page =
 		crate::pages::components::common::pagination(current_page_signal, data.total_pages);
@@ -245,8 +270,10 @@ pub fn list_view(
 	)
 }
 
+#[cfg(any(client, test))]
 fn apply_date_hierarchy_choice(
 	query_params: Signal<ListQueryParams>,
+	query_generation: Rc<Cell<u64>>,
 	mut selection: DateHierarchySelection,
 	next_level: DateHierarchyLevel,
 	choice: i32,
@@ -278,12 +305,15 @@ fn apply_date_hierarchy_choice(
 	}
 	params.page = Some(1);
 	params.date_hierarchy = Some(selection);
+	query_generation.set(query_generation.get().wrapping_add(1));
 	query_params.set(params);
 }
 
+#[cfg(any(client, test))]
 fn date_hierarchy_navigation(
 	date_hierarchy: Option<&DateHierarchyInfo>,
 	query_params: Signal<ListQueryParams>,
+	query_generation: Rc<Cell<u64>>,
 ) -> Page {
 	let Some(date_hierarchy) = date_hierarchy else {
 		return Page::empty();
@@ -309,6 +339,7 @@ fn date_hierarchy_navigation(
 					page!(|label: String,
 					 aria_label: String,
 					 _query_params: Signal<ListQueryParams>,
+					 _query_generation: Rc<Cell<u64>>,
 					 _selection: DateHierarchySelection,
 					 _next_level: DateHierarchyLevel,
 					 _choice: i32| {
@@ -319,6 +350,7 @@ fn date_hierarchy_navigation(
 							@click: move |_| {
 							crate::pages::components::features::apply_date_hierarchy_choice(
 									_query_params,
+									_query_generation.clone(),
 									_selection.clone(),
 									_next_level,
 									_choice,
@@ -330,6 +362,7 @@ fn date_hierarchy_navigation(
 						label,
 						aria_label,
 						query_params,
+						query_generation.clone(),
 						selection,
 						next_level,
 						choice,
@@ -1259,7 +1292,7 @@ pub fn filters(
 mod tests {
 	use super::{
 		Column, ListViewData, apply_date_hierarchy_choice, detail_table, form_value_to_json,
-		form_values_to_json_array, list_view,
+		form_values_to_json_array, list_view, list_view_with_date_hierarchy,
 	};
 	use crate::types::{
 		DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, ListQueryParams,
@@ -1270,10 +1303,7 @@ mod tests {
 	use serde_json::json;
 	use std::collections::HashMap;
 
-	fn list_data(
-		records: Vec<HashMap<String, String>>,
-		date_hierarchy: Option<DateHierarchyInfo>,
-	) -> ListViewData {
+	fn list_data(records: Vec<HashMap<String, String>>) -> ListViewData {
 		ListViewData {
 			model_name: "Article".to_string(),
 			columns: vec![Column {
@@ -1286,7 +1316,6 @@ mod tests {
 			total_pages: 1,
 			total_count: 1,
 			filters: vec![],
-			date_hierarchy,
 		}
 	}
 
@@ -1294,25 +1323,31 @@ mod tests {
 	fn list_view_renders_accessible_date_hierarchy_choices() {
 		ReactiveScope::run(|| {
 			// Arrange
-			let data = list_data(
-				vec![],
-				Some(DateHierarchyInfo {
-					field: "published_at".to_string(),
-					selection: DateHierarchySelection::default(),
-					next_level: Some(DateHierarchyLevel::Year),
-					choices: vec![2024, 2025],
-				}),
-			);
+			let data = list_data(vec![]);
+			let date_hierarchy = DateHierarchyInfo {
+				field: "published_at".to_string(),
+				selection: DateHierarchySelection::default(),
+				next_level: Some(DateHierarchyLevel::Year),
+				choices: vec![2024, 2025],
+			};
 			let page_signal = Signal::new(1_u64);
 			let filters_signal = Signal::new(HashMap::new());
 			let query_params = Signal::new(ListQueryParams {
 				page: Some(1),
 				..ListQueryParams::default()
 			});
+			let query_generation = std::rc::Rc::new(std::cell::Cell::new(0_u64));
 
 			// Act
-			let html =
-				list_view(&data, page_signal, filters_signal, query_params).render_to_string();
+			let html = list_view_with_date_hierarchy(
+				&data,
+				page_signal,
+				filters_signal,
+				Some(&date_hierarchy),
+				query_params,
+				query_generation,
+			)
+			.render_to_string();
 
 			// Assert
 			assert_eq!(html.matches("<nav").count(), 1);
@@ -1367,10 +1402,12 @@ mod tests {
 					}),
 					..ListQueryParams::default()
 				});
+				let query_generation = std::rc::Rc::new(std::cell::Cell::new(4_u64));
 
 				// Act
 				apply_date_hierarchy_choice(
 					query_params,
+					query_generation.clone(),
 					DateHierarchySelection {
 						year: Some(2020),
 						month: Some(2),
@@ -1384,6 +1421,7 @@ mod tests {
 				let params = query_params.get();
 				assert_eq!(params.page, Some(1));
 				assert_eq!(params.date_hierarchy, Some(expected_selection));
+				assert_eq!(query_generation.get(), 5);
 			}
 		});
 	}
@@ -1397,17 +1435,12 @@ mod tests {
 				"summary".to_string(),
 				"</script><script>alert(1)</script>".to_string(),
 			);
-			let data = list_data(vec![record], None);
+			let data = list_data(vec![record]);
 			let page_signal = Signal::new(1_u64);
 			let filters_signal = Signal::new(HashMap::new());
-			let query_params = Signal::new(ListQueryParams {
-				page: Some(1),
-				..ListQueryParams::default()
-			});
 
 			// Act
-			let html =
-				list_view(&data, page_signal, filters_signal, query_params).render_to_string();
+			let html = list_view(&data, page_signal, filters_signal).render_to_string();
 
 			// Assert
 			assert!(html.contains("&lt;/script&gt;&lt;script&gt;alert(1)&lt;/script&gt;"));

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -10,7 +10,10 @@
 
 #[cfg(client)]
 use crate::server::{create_record, delete_record, update_record};
-use crate::types::{FilterInfo, FilterType, ModelInfo};
+use crate::types::{
+	DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, FilterInfo, FilterType,
+	ListQueryParams, ModelInfo,
+};
 use reinhardt_pages::Signal;
 use reinhardt_pages::component::Page;
 use reinhardt_pages::page;
@@ -143,6 +146,8 @@ pub struct ListViewData {
 	pub total_count: u64,
 	/// Filter information
 	pub filters: Vec<FilterInfo>,
+	/// Date hierarchy metadata for drill-down navigation
+	pub date_hierarchy: Option<DateHierarchyInfo>,
 }
 
 /// List view component
@@ -167,15 +172,21 @@ pub struct ListViewData {
 ///     total_pages: 5,
 ///     total_count: 42,
 ///     filters: vec![],
+///     date_hierarchy: None,
 /// };
 /// let page_signal = Signal::new(1u64);
 /// let filters_signal = Signal::new(HashMap::new());
-/// list_view(&data, page_signal, filters_signal)
+/// let query_params = Signal::new(reinhardt_admin::types::ListQueryParams {
+///     page: Some(1),
+///     ..Default::default()
+/// });
+/// list_view(&data, page_signal, filters_signal, query_params)
 /// ```
 pub fn list_view(
 	data: &ListViewData,
 	current_page_signal: reinhardt_pages::Signal<u64>,
 	filters_signal: Signal<HashMap<String, String>>,
+	query_params: Signal<ListQueryParams>,
 ) -> Page {
 	let title = format!("{} List", data.model_name);
 	let summary = format!(
@@ -183,6 +194,7 @@ pub fn list_view(
 		data.total_count, data.model_name, data.current_page, data.total_pages
 	);
 	let filters_page = filters(&data.filters, filters_signal);
+	let date_hierarchy_page = date_hierarchy_navigation(data.date_hierarchy.as_ref(), query_params);
 	let table_page = data_table(&data.columns, &data.records, &data.model_name);
 	let pagination_page =
 		crate::pages::components::common::pagination(current_page_signal, data.total_pages);
@@ -199,6 +211,7 @@ pub fn list_view(
 	page!(|title: String,
 	 add_link: Page,
 	 filters_page: Page,
+	 date_hierarchy_page: Page,
 	 summary: String,
 	 table_page: Page,
 	 pagination_page: Page| {
@@ -213,6 +226,7 @@ pub fn list_view(
 				{ add_link }
 			}
 			{ filters_page }
+			{ date_hierarchy_page }
 			div {
 				class: "text-sm text-slate-500 mb-4",
 				{ summary }
@@ -224,10 +238,124 @@ pub fn list_view(
 		title,
 		add_link,
 		filters_page,
+		date_hierarchy_page,
 		summary,
 		table_page,
 		pagination_page,
 	)
+}
+
+fn apply_date_hierarchy_choice(
+	query_params: Signal<ListQueryParams>,
+	mut selection: DateHierarchySelection,
+	next_level: DateHierarchyLevel,
+	choice: i32,
+) {
+	match next_level {
+		DateHierarchyLevel::Year => {
+			selection.year = Some(choice);
+			selection.month = None;
+			selection.day = None;
+		}
+		DateHierarchyLevel::Month => {
+			let Ok(month) = u32::try_from(choice) else {
+				return;
+			};
+			selection.month = Some(month);
+			selection.day = None;
+		}
+		DateHierarchyLevel::Day => {
+			let Ok(day) = u32::try_from(choice) else {
+				return;
+			};
+			selection.day = Some(day);
+		}
+	}
+
+	let mut params = query_params.get_untracked();
+	if params.page == Some(1) && params.date_hierarchy.as_ref() == Some(&selection) {
+		return;
+	}
+	params.page = Some(1);
+	params.date_hierarchy = Some(selection);
+	query_params.set(params);
+}
+
+fn date_hierarchy_navigation(
+	date_hierarchy: Option<&DateHierarchyInfo>,
+	query_params: Signal<ListQueryParams>,
+) -> Page {
+	let Some(date_hierarchy) = date_hierarchy else {
+		return Page::empty();
+	};
+
+	let field = date_hierarchy.field.clone();
+	let choices = date_hierarchy
+		.next_level
+		.map_or_else(Vec::new, |next_level| {
+			let level_label = match next_level {
+				DateHierarchyLevel::Year => "year",
+				DateHierarchyLevel::Month => "month",
+				DateHierarchyLevel::Day => "day",
+			};
+			date_hierarchy
+				.choices
+				.iter()
+				.map(|choice| {
+					let choice = *choice;
+					let label = choice.to_string();
+					let aria_label = format!("Select {level_label} {choice}");
+					let selection = date_hierarchy.selection.clone();
+					page!(|label: String,
+					 aria_label: String,
+					 _query_params: Signal<ListQueryParams>,
+					 _selection: DateHierarchySelection,
+					 _next_level: DateHierarchyLevel,
+					 _choice: i32| {
+						button {
+							type: "button",
+							class: "admin-btn admin-btn-outline admin-btn-sm",
+							aria_label: aria_label,
+							@click: move |_| {
+							crate::pages::components::features::apply_date_hierarchy_choice(
+									_query_params,
+									_selection.clone(),
+									_next_level,
+									_choice,
+								);
+							},
+							{ label }
+						}
+					})(
+						label,
+						aria_label,
+						query_params,
+						selection,
+						next_level,
+						choice,
+					)
+				})
+				.collect()
+		});
+
+	page!(|field: String, choices: Vec<Page>| {
+		nav {
+			class: "admin-card p-4 mb-4",
+			aria_label: "Date hierarchy",
+			h2 {
+				class: "text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3",
+				"Date hierarchy"
+			}
+			p {
+				class: "text-sm text-slate-600 mb-3",
+				{ field }
+			}
+			div {
+				class: "flex flex-wrap gap-2",
+				{ choices }
+			}
+		}
+	})(field, choices)
 }
 
 /// Generates a data table
@@ -1129,10 +1257,163 @@ pub fn filters(
 
 #[cfg(all(test, server))]
 mod tests {
-	use super::{detail_table, form_value_to_json, form_values_to_json_array};
+	use super::{
+		Column, ListViewData, apply_date_hierarchy_choice, detail_table, form_value_to_json,
+		form_values_to_json_array, list_view,
+	};
+	use crate::types::{
+		DateHierarchyInfo, DateHierarchyLevel, DateHierarchySelection, ListQueryParams,
+	};
+	use reinhardt_core::reactive::ReactiveScope;
+	use reinhardt_pages::Signal;
 	use rstest::rstest;
 	use serde_json::json;
 	use std::collections::HashMap;
+
+	fn list_data(
+		records: Vec<HashMap<String, String>>,
+		date_hierarchy: Option<DateHierarchyInfo>,
+	) -> ListViewData {
+		ListViewData {
+			model_name: "Article".to_string(),
+			columns: vec![Column {
+				field: "summary".to_string(),
+				label: "Summary".to_string(),
+				sortable: false,
+			}],
+			records,
+			current_page: 1,
+			total_pages: 1,
+			total_count: 1,
+			filters: vec![],
+			date_hierarchy,
+		}
+	}
+
+	#[rstest]
+	fn list_view_renders_accessible_date_hierarchy_choices() {
+		ReactiveScope::run(|| {
+			// Arrange
+			let data = list_data(
+				vec![],
+				Some(DateHierarchyInfo {
+					field: "published_at".to_string(),
+					selection: DateHierarchySelection::default(),
+					next_level: Some(DateHierarchyLevel::Year),
+					choices: vec![2024, 2025],
+				}),
+			);
+			let page_signal = Signal::new(1_u64);
+			let filters_signal = Signal::new(HashMap::new());
+			let query_params = Signal::new(ListQueryParams {
+				page: Some(1),
+				..ListQueryParams::default()
+			});
+
+			// Act
+			let html =
+				list_view(&data, page_signal, filters_signal, query_params).render_to_string();
+
+			// Assert
+			assert_eq!(html.matches("<nav").count(), 1);
+			assert_eq!(html.matches("<button").count(), 2);
+			assert!(html.contains(r#"aria-label="Date hierarchy""#));
+			assert!(html.contains(">2024</button>"));
+			assert!(html.contains(">2025</button>"));
+		});
+	}
+
+	#[rstest]
+	fn date_hierarchy_choice_updates_the_requested_level_and_resets_page() {
+		ReactiveScope::run(|| {
+			let cases = [
+				(
+					DateHierarchyLevel::Year,
+					2025,
+					DateHierarchySelection {
+						year: Some(2025),
+						month: None,
+						day: None,
+					},
+				),
+				(
+					DateHierarchyLevel::Month,
+					7,
+					DateHierarchySelection {
+						year: Some(2020),
+						month: Some(7),
+						day: None,
+					},
+				),
+				(
+					DateHierarchyLevel::Day,
+					9,
+					DateHierarchySelection {
+						year: Some(2020),
+						month: Some(2),
+						day: Some(9),
+					},
+				),
+			];
+
+			for (next_level, choice, expected_selection) in cases {
+				// Arrange
+				let query_params = Signal::new(ListQueryParams {
+					page: Some(8),
+					date_hierarchy: Some(DateHierarchySelection {
+						year: Some(2020),
+						month: Some(2),
+						day: Some(3),
+					}),
+					..ListQueryParams::default()
+				});
+
+				// Act
+				apply_date_hierarchy_choice(
+					query_params,
+					DateHierarchySelection {
+						year: Some(2020),
+						month: Some(2),
+						day: Some(3),
+					},
+					next_level,
+					choice,
+				);
+
+				// Assert
+				let params = query_params.get();
+				assert_eq!(params.page, Some(1));
+				assert_eq!(params.date_hierarchy, Some(expected_selection));
+			}
+		});
+	}
+
+	#[rstest]
+	fn list_view_escapes_computed_column_text() {
+		ReactiveScope::run(|| {
+			// Arrange
+			let mut record = HashMap::new();
+			record.insert(
+				"summary".to_string(),
+				"</script><script>alert(1)</script>".to_string(),
+			);
+			let data = list_data(vec![record], None);
+			let page_signal = Signal::new(1_u64);
+			let filters_signal = Signal::new(HashMap::new());
+			let query_params = Signal::new(ListQueryParams {
+				page: Some(1),
+				..ListQueryParams::default()
+			});
+
+			// Act
+			let html =
+				list_view(&data, page_signal, filters_signal, query_params).render_to_string();
+
+			// Assert
+			assert!(html.contains("&lt;/script&gt;&lt;script&gt;alert(1)&lt;/script&gt;"));
+			assert_eq!(html.matches("<script").count(), 0);
+		});
+	}
 
 	/// Verifies that detail_table renders fields in alphabetical order regardless
 	/// of HashMap insertion order.

--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -12,15 +12,24 @@
 // `reinhardt_urls::routers::ClientRouter` is the canonical SPA router; this module
 // references it pervasively (struct, `Router::new()`, `Arc<Router>`, closure params),
 // so file-scope suppression is preferred over per-usage `#[allow(deprecated)]` attribute spam.
+#[cfg(server)]
+use crate::pages::components::features::list_view;
+#[cfg(client)]
+use crate::pages::components::features::list_view_with_date_hierarchy;
 use crate::pages::components::features::{
-	Column, FormField, ListViewData, dashboard, detail_view, list_view, model_form,
+	Column, FormField, ListViewData, dashboard, detail_view, model_form,
 };
 pub use crate::pages::components::login;
 #[cfg(client)]
 use crate::server::{get_dashboard, get_detail, get_fields, get_list};
+#[cfg(client)]
 use crate::types::ListQueryParams;
+#[cfg(any(client, test))]
+use crate::types::ListResponse;
 #[cfg(server)]
 use crate::types::ModelInfo;
+#[cfg(any(client, test))]
+use reinhardt_pages::ResourceState;
 use reinhardt_pages::Signal;
 #[cfg(client)]
 use reinhardt_pages::component::PageExt;
@@ -29,13 +38,17 @@ use reinhardt_pages::page;
 use reinhardt_pages::reactive::ReactiveScope;
 use reinhardt_pages::router::Link;
 #[cfg(client)]
-use reinhardt_pages::{Element, MountError, deps};
+use reinhardt_pages::use_resource;
 #[cfg(client)]
-use reinhardt_pages::{ResourceState, use_resource};
+use reinhardt_pages::{Element, MountError, deps};
 use reinhardt_urls::routers::ClientRouter;
 use reinhardt_urls::routers::client_router::Path;
+#[cfg(any(client, test))]
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::HashMap;
+#[cfg(client)]
+use std::rc::Rc;
 
 /// Admin route enum
 #[derive(Debug, Clone, PartialEq)]
@@ -98,6 +111,41 @@ fn json_value_to_display_string(value: &serde_json::Value) -> String {
 			.collect::<Vec<_>>()
 			.join(", "),
 		serde_json::Value::Object(_) => value.to_string(),
+	}
+}
+
+#[cfg(any(client, test))]
+fn begin_list_request(latest_generation: &Cell<u64>) -> u64 {
+	let generation = latest_generation.get().wrapping_add(1);
+	latest_generation.set(generation);
+	generation
+}
+
+#[cfg(client)]
+fn invalidate_list_request(latest_generation: &Cell<u64>) {
+	latest_generation.set(latest_generation.get().wrapping_add(1));
+}
+
+#[cfg(any(client, test))]
+fn commit_list_request(
+	latest_generation: &Cell<u64>,
+	generation: u64,
+	result: Result<ListResponse, String>,
+	rendered_state: Signal<ResourceState<ListResponse, String>>,
+	page_signal: Signal<u64>,
+) {
+	if generation != latest_generation.get() {
+		return;
+	}
+
+	match result {
+		Ok(response) => {
+			if page_signal.get_untracked() != response.page {
+				page_signal.set(response.page);
+			}
+			rendered_state.set(ResourceState::Success(response));
+		}
+		Err(error) => rendered_state.set(ResourceState::Error(error)),
 	}
 }
 
@@ -308,26 +356,36 @@ fn list_view_component(model_name: String) -> Page {
 	});
 	let page_signal = Signal::new(1_u64);
 	let filters_signal = Signal::new(HashMap::new());
+	let latest_request_generation = Rc::new(Cell::new(0_u64));
+	let rendered_state: Signal<ResourceState<ListResponse, String>> =
+		Signal::new(ResourceState::Loading);
 
 	let list_resource = use_resource(
-		move || {
-			let model_name = model_name.clone();
-			let params = query_params.get();
-			async move {
-				get_list(model_name, params)
-					.await
-					.map_err(|e| e.to_string())
+		{
+			let latest_request_generation = Rc::clone(&latest_request_generation);
+			move || {
+				let generation = begin_list_request(&latest_request_generation);
+				let model_name = model_name.clone();
+				let params = query_params.get();
+				async move {
+					get_list(model_name, params)
+						.await
+						.map(|response| (generation, response))
+						.map_err(|error| (generation, error.to_string()))
+				}
 			}
 		},
 		deps![query_params],
 	);
 
+	let generation_for_page = Rc::clone(&latest_request_generation);
 	use_retained_effect(
 		move || {
 			let page = page_signal.get_untracked();
 			let mut params = query_params.get_untracked();
 			if params.page != Some(page) {
 				params.page = Some(page);
+				invalidate_list_request(&generation_for_page);
 				query_params.set(params);
 			}
 			None::<fn()>
@@ -335,20 +393,31 @@ fn list_view_component(model_name: String) -> Page {
 		deps![page_signal],
 	);
 
-	// Sync page_signal from the completed resource outside the rendering closure.
-	// Updating signals inside a rendering closure is an anti-pattern: it causes
-	// a state change during render and could create an infinite loop if the
-	// resource ever reads page_signal. Using use_retained_effect keeps side-effects
-	// separate from the render path.
+	// Publish only the latest request outside the rendering closure. The raw
+	// Resource may complete concurrent requests out of order, so rendering it
+	// directly would allow an older page to replace the current hierarchy result.
 	{
 		let resource = list_resource.clone();
 		let resource_for_deps = list_resource.clone();
+		let latest_request_generation = Rc::clone(&latest_request_generation);
 		use_retained_effect(
 			move || {
-				if let ResourceState::Success(ref response) = resource.get() {
-					if page_signal.get_untracked() != response.page {
-						page_signal.set(response.page);
-					}
+				match resource.get() {
+					ResourceState::Loading => rendered_state.set(ResourceState::Loading),
+					ResourceState::Success((generation, response)) => commit_list_request(
+						&latest_request_generation,
+						generation,
+						Ok(response),
+						rendered_state,
+						page_signal,
+					),
+					ResourceState::Error((generation, error)) => commit_list_request(
+						&latest_request_generation,
+						generation,
+						Err(error),
+						rendered_state,
+						page_signal,
+					),
 				}
 				None::<fn()>
 			},
@@ -357,8 +426,8 @@ fn list_view_component(model_name: String) -> Page {
 	}
 
 	let reactive_content = Page::reactive({
-		let resource = list_resource.clone();
-		move || match resource.get() {
+		let query_generation = Rc::clone(&latest_request_generation);
+		move || match rendered_state.get() {
 			ResourceState::Loading => loading_view(),
 			ResourceState::Success(response) => {
 				let data = ListViewData {
@@ -395,9 +464,15 @@ fn list_view_component(model_name: String) -> Page {
 					total_pages: response.total_pages,
 					total_count: response.count,
 					filters: response.available_filters.unwrap_or_default(),
-					date_hierarchy: response.date_hierarchy,
 				};
-				list_view(&data, page_signal, filters_signal, query_params)
+				list_view_with_date_hierarchy(
+					&data,
+					page_signal,
+					filters_signal,
+					response.date_hierarchy.as_ref(),
+					query_params,
+					Rc::clone(&query_generation),
+				)
 			}
 			ResourceState::Error(err) => error_view(&err),
 		}
@@ -436,16 +511,11 @@ fn list_view_component(model_name: String) -> Page {
 		total_pages: 1,
 		total_count: 0,
 		filters: vec![],
-		date_hierarchy: None,
 	};
 
 	let page_signal = Signal::new(1_u64);
 	let filters_signal = Signal::new(HashMap::new());
-	let query_params = Signal::new(ListQueryParams {
-		page: Some(1),
-		..ListQueryParams::default()
-	});
-	list_view(&data, page_signal, filters_signal, query_params)
+	list_view(&data, page_signal, filters_signal)
 }
 
 /// Detail view component for router
@@ -1070,6 +1140,55 @@ mod tests {
 			view.render_to_string()
 		});
 		assert!(html.contains("users") || html.contains("List"));
+	}
+
+	#[rstest]
+	fn newer_list_response_wins_when_requests_complete_in_reverse_order() {
+		ReactiveScope::run(|| {
+			// Arrange
+			let latest_generation = std::cell::Cell::new(0_u64);
+			let older_generation = begin_list_request(&latest_generation);
+			let newer_generation = begin_list_request(&latest_generation);
+			let rendered_state = Signal::new(ResourceState::Loading);
+			let page_signal = Signal::new(8_u64);
+			let response = |model_name: &str, page| crate::types::ListResponse {
+				model_name: model_name.to_string(),
+				count: 1,
+				page,
+				page_size: 1,
+				total_pages: 8,
+				results: vec![],
+				available_filters: None,
+				columns: None,
+				date_hierarchy: None,
+			};
+
+			// Act
+			commit_list_request(
+				&latest_generation,
+				newer_generation,
+				Ok(response("newer", 1)),
+				rendered_state,
+				page_signal,
+			);
+			commit_list_request(
+				&latest_generation,
+				older_generation,
+				Ok(response("older", 8)),
+				rendered_state,
+				page_signal,
+			);
+
+			// Assert
+			assert_eq!(page_signal.get(), 1);
+			match rendered_state.get() {
+				ResourceState::Success(response) => {
+					assert_eq!(response.model_name, "newer");
+					assert_eq!(response.page, 1);
+				}
+				state => panic!("expected the newer success state, got {state:?}"),
+			}
+		});
 	}
 
 	#[test]

--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -18,7 +18,6 @@ use crate::pages::components::features::{
 pub use crate::pages::components::login;
 #[cfg(client)]
 use crate::server::{get_dashboard, get_detail, get_fields, get_list};
-#[cfg(client)]
 use crate::types::ListQueryParams;
 #[cfg(server)]
 use crate::types::ModelInfo;
@@ -303,22 +302,38 @@ fn dashboard_view() -> Page {
 fn list_view_component(model_name: String) -> Page {
 	use reinhardt_pages::use_retained_effect;
 
+	let query_params = Signal::new(ListQueryParams {
+		page: Some(1),
+		..ListQueryParams::default()
+	});
+	let page_signal = Signal::new(1_u64);
+	let filters_signal = Signal::new(HashMap::new());
+
 	let list_resource = use_resource(
 		move || {
 			let model_name = model_name.clone();
+			let params = query_params.get();
 			async move {
-				let params = ListQueryParams::default();
 				get_list(model_name, params)
 					.await
 					.map_err(|e| e.to_string())
 			}
 		},
-		deps![],
+		deps![query_params],
 	);
 
-	// Create signals outside the reactive closure so they persist across re-renders
-	let page_signal = Signal::new(1u64);
-	let filters_signal = Signal::new(HashMap::new());
+	use_retained_effect(
+		move || {
+			let page = page_signal.get_untracked();
+			let mut params = query_params.get_untracked();
+			if params.page != Some(page) {
+				params.page = Some(page);
+				query_params.set(params);
+			}
+			None::<fn()>
+		},
+		deps![page_signal],
+	);
 
 	// Sync page_signal from the completed resource outside the rendering closure.
 	// Updating signals inside a rendering closure is an anti-pattern: it causes
@@ -331,7 +346,9 @@ fn list_view_component(model_name: String) -> Page {
 		use_retained_effect(
 			move || {
 				if let ResourceState::Success(ref response) = resource.get() {
-					page_signal.set(response.page);
+					if page_signal.get_untracked() != response.page {
+						page_signal.set(response.page);
+					}
 				}
 				None::<fn()>
 			},
@@ -378,8 +395,9 @@ fn list_view_component(model_name: String) -> Page {
 					total_pages: response.total_pages,
 					total_count: response.count,
 					filters: response.available_filters.unwrap_or_default(),
+					date_hierarchy: response.date_hierarchy,
 				};
-				list_view(&data, page_signal, filters_signal)
+				list_view(&data, page_signal, filters_signal, query_params)
 			}
 			ResourceState::Error(err) => error_view(&err),
 		}
@@ -418,11 +436,16 @@ fn list_view_component(model_name: String) -> Page {
 		total_pages: 1,
 		total_count: 0,
 		filters: vec![],
+		date_hierarchy: None,
 	};
 
-	let page_signal = Signal::new(1u64);
+	let page_signal = Signal::new(1_u64);
 	let filters_signal = Signal::new(HashMap::new());
-	list_view(&data, page_signal, filters_signal)
+	let query_params = Signal::new(ListQueryParams {
+		page: Some(1),
+		..ListQueryParams::default()
+	});
+	list_view(&data, page_signal, filters_signal, query_params)
 }
 
 /// Detail view component for router

--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -21,13 +21,15 @@ use crate::pages::components::features::{
 };
 pub use crate::pages::components::login;
 #[cfg(client)]
-use crate::server::{get_dashboard, get_detail, get_fields, get_list};
+use crate::server::{get_dashboard, get_detail, get_fields, get_list_with_date_hierarchy};
 #[cfg(client)]
-use crate::types::ListQueryParams;
+use crate::types::DateHierarchyListResponse;
 #[cfg(any(client, test))]
 use crate::types::ListResponse;
 #[cfg(server)]
 use crate::types::ModelInfo;
+#[cfg(client)]
+use crate::types::{DateHierarchyListQueryParams, ListQueryParams};
 #[cfg(any(client, test))]
 use reinhardt_pages::ResourceState;
 use reinhardt_pages::Signal;
@@ -142,6 +144,29 @@ fn commit_list_request(
 		Ok(response) => {
 			if page_signal.get_untracked() != response.page {
 				page_signal.set(response.page);
+			}
+			rendered_state.set(ResourceState::Success(response));
+		}
+		Err(error) => rendered_state.set(ResourceState::Error(error)),
+	}
+}
+
+#[cfg(client)]
+fn commit_date_hierarchy_list_request(
+	latest_generation: &Cell<u64>,
+	generation: u64,
+	result: Result<DateHierarchyListResponse, String>,
+	rendered_state: Signal<ResourceState<DateHierarchyListResponse, String>>,
+	page_signal: Signal<u64>,
+) {
+	if generation != latest_generation.get() {
+		return;
+	}
+
+	match result {
+		Ok(response) => {
+			if page_signal.get_untracked() != response.response.page {
+				page_signal.set(response.response.page);
 			}
 			rendered_state.set(ResourceState::Success(response));
 		}
@@ -350,14 +375,17 @@ fn dashboard_view() -> Page {
 fn list_view_component(model_name: String) -> Page {
 	use reinhardt_pages::use_retained_effect;
 
-	let query_params = Signal::new(ListQueryParams {
-		page: Some(1),
-		..ListQueryParams::default()
+	let query_params = Signal::new(DateHierarchyListQueryParams {
+		list: ListQueryParams {
+			page: Some(1),
+			..ListQueryParams::default()
+		},
+		date_hierarchy: None,
 	});
 	let page_signal = Signal::new(1_u64);
 	let filters_signal = Signal::new(HashMap::new());
 	let latest_request_generation = Rc::new(Cell::new(0_u64));
-	let rendered_state: Signal<ResourceState<ListResponse, String>> =
+	let rendered_state: Signal<ResourceState<DateHierarchyListResponse, String>> =
 		Signal::new(ResourceState::Loading);
 
 	let list_resource = use_resource(
@@ -368,7 +396,7 @@ fn list_view_component(model_name: String) -> Page {
 				let model_name = model_name.clone();
 				let params = query_params.get();
 				async move {
-					get_list(model_name, params)
+					get_list_with_date_hierarchy(model_name, params)
 						.await
 						.map(|response| (generation, response))
 						.map_err(|error| (generation, error.to_string()))
@@ -404,20 +432,24 @@ fn list_view_component(model_name: String) -> Page {
 			move || {
 				match resource.get() {
 					ResourceState::Loading => rendered_state.set(ResourceState::Loading),
-					ResourceState::Success((generation, response)) => commit_list_request(
-						&latest_request_generation,
-						generation,
-						Ok(response),
-						rendered_state,
-						page_signal,
-					),
-					ResourceState::Error((generation, error)) => commit_list_request(
-						&latest_request_generation,
-						generation,
-						Err(error),
-						rendered_state,
-						page_signal,
-					),
+					ResourceState::Success((generation, response)) => {
+						commit_date_hierarchy_list_request(
+							&latest_request_generation,
+							generation,
+							Ok(response),
+							rendered_state,
+							page_signal,
+						)
+					}
+					ResourceState::Error((generation, error)) => {
+						commit_date_hierarchy_list_request(
+							&latest_request_generation,
+							generation,
+							Err(error),
+							rendered_state,
+							page_signal,
+						)
+					}
 				}
 				None::<fn()>
 			},
@@ -431,8 +463,9 @@ fn list_view_component(model_name: String) -> Page {
 			ResourceState::Loading => loading_view(),
 			ResourceState::Success(response) => {
 				let data = ListViewData {
-					model_name: response.model_name.clone(),
+					model_name: response.response.model_name.clone(),
 					columns: response
+						.response
 						.columns
 						.map(|cols| {
 							cols.into_iter()
@@ -451,6 +484,7 @@ fn list_view_component(model_name: String) -> Page {
 							}]
 						}),
 					records: response
+						.response
 						.results
 						.into_iter()
 						.map(|record| {
@@ -460,10 +494,10 @@ fn list_view_component(model_name: String) -> Page {
 								.collect()
 						})
 						.collect(),
-					current_page: response.page,
-					total_pages: response.total_pages,
-					total_count: response.count,
-					filters: response.available_filters.unwrap_or_default(),
+					current_page: response.response.page,
+					total_pages: response.response.total_pages,
+					total_count: response.response.count,
+					filters: response.response.available_filters.unwrap_or_default(),
 				};
 				list_view_with_date_hierarchy(
 					&data,
@@ -1160,7 +1194,6 @@ mod tests {
 				results: vec![],
 				available_filters: None,
 				columns: None,
-				date_hierarchy: None,
 			};
 
 			// Act

--- a/crates/reinhardt-admin/src/server/list.rs
+++ b/crates/reinhardt-admin/src/server/list.rs
@@ -171,7 +171,11 @@ fn date_hierarchy_interval(
 
 	match field_type {
 		DbFieldType::Date => Ok(Some((DatabaseValue::Date(start), DatabaseValue::Date(end)))),
-		DbFieldType::DateTime | DbFieldType::TimestampTz => Ok(Some((
+		DbFieldType::DateTime => Ok(Some((
+			DatabaseValue::NaiveDateTime(start.and_time(chrono::NaiveTime::MIN)),
+			DatabaseValue::NaiveDateTime(end.and_time(chrono::NaiveTime::MIN)),
+		))),
+		DbFieldType::TimestampTz => Ok(Some((
 			DatabaseValue::DateTime(start.and_time(chrono::NaiveTime::MIN).and_utc()),
 			DatabaseValue::DateTime(end.and_time(chrono::NaiveTime::MIN).and_utc()),
 		))),
@@ -486,22 +490,47 @@ mod tests {
 	}
 
 	#[test]
-	fn date_hierarchy_datetime_intervals_bind_utc_midnight() {
+	fn date_hierarchy_datetime_intervals_preserve_naive_midnight() {
 		let selection = DateHierarchySelection {
 			year: Some(2024),
 			month: Some(2),
 			day: Some(29),
 		};
 
-		for field_type in [DbFieldType::DateTime, DbFieldType::TimestampTz] {
-			assert_eq!(
-				date_hierarchy_interval(&selection, &field_type).unwrap(),
-				Some((
-					DatabaseValue::DateTime(Utc.with_ymd_and_hms(2024, 2, 29, 0, 0, 0).unwrap(),),
-					DatabaseValue::DateTime(Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap(),),
-				))
-			);
-		}
+		assert_eq!(
+			date_hierarchy_interval(&selection, &DbFieldType::DateTime).unwrap(),
+			Some((
+				DatabaseValue::NaiveDateTime(
+					NaiveDate::from_ymd_opt(2024, 2, 29)
+						.unwrap()
+						.and_hms_opt(0, 0, 0)
+						.unwrap(),
+				),
+				DatabaseValue::NaiveDateTime(
+					NaiveDate::from_ymd_opt(2024, 3, 1)
+						.unwrap()
+						.and_hms_opt(0, 0, 0)
+						.unwrap(),
+				),
+			))
+		);
+	}
+
+	#[test]
+	fn date_hierarchy_timestamptz_intervals_bind_utc_midnight() {
+		let selection = DateHierarchySelection {
+			year: Some(2024),
+			month: Some(2),
+			day: Some(29),
+		};
+
+		assert_eq!(
+			date_hierarchy_interval(&selection, &DbFieldType::TimestampTz).unwrap(),
+			Some((
+				DatabaseValue::DateTime(Utc.with_ymd_and_hms(2024, 2, 29, 0, 0, 0).unwrap(),),
+				DatabaseValue::DateTime(Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap(),),
+			))
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-admin/src/server/list.rs
+++ b/crates/reinhardt-admin/src/server/list.rs
@@ -6,8 +6,8 @@
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{
 	AdminDatabase, AdminQuery, AdminRequestContext, AdminSite, ColumnInfo, DateHierarchyInfo,
-	DateHierarchyLevel, DateHierarchySelection, FilterInfo, FilterType, ListColumn, ListResponse,
-	ModelAdmin,
+	DateHierarchyLevel, DateHierarchyListResponse, DateHierarchySelection, FilterInfo, FilterType,
+	ListColumn, ListResponse, ModelAdmin,
 };
 #[cfg(server)]
 use crate::core::{AdminDatabaseKey, AdminSiteKey};
@@ -237,17 +237,56 @@ pub async fn get_list(
 	#[inject] site: KeyedDepends<AdminSiteKey, AdminSite>,
 	#[inject] db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
 	#[inject] http_request: ServerFnRequest,
-	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
+	#[inject] user: AdminAuthenticatedUser,
 ) -> Result<crate::adapters::ListResponse, ServerFnError> {
+	Ok(get_list_impl(
+		model_name,
+		params.into(),
+		site,
+		db,
+		http_request,
+		user,
+		false,
+	)
+	.await?
+	.response)
+}
+
+/// Get list view data with date hierarchy metadata.
+///
+/// This versioned endpoint extends the legacy list contract without adding
+/// fields to [`crate::types::ListQueryParams`] or [`crate::types::ListResponse`].
+#[server_fn]
+pub async fn get_list_with_date_hierarchy(
+	model_name: String,
+	params: crate::adapters::DateHierarchyListQueryParams,
+	#[inject] site: KeyedDepends<AdminSiteKey, AdminSite>,
+	#[inject] db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
+	#[inject] http_request: ServerFnRequest,
+	#[inject] user: AdminAuthenticatedUser,
+) -> Result<crate::adapters::DateHierarchyListResponse, ServerFnError> {
+	get_list_impl(model_name, params, site, db, http_request, user, true).await
+}
+
+#[cfg(server)]
+async fn get_list_impl(
+	model_name: String,
+	params: crate::adapters::DateHierarchyListQueryParams,
+	site: KeyedDepends<AdminSiteKey, AdminSite>,
+	db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
+	http_request: ServerFnRequest,
+	user: AdminAuthenticatedUser,
+	include_date_hierarchy: bool,
+) -> Result<crate::adapters::DateHierarchyListResponse, ServerFnError> {
 	// Get model admin and check permission
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
-	if !model_admin.has_view_permission(user.as_ref()).await {
+	if !model_admin.has_view_permission(user.0.as_ref()).await {
 		return Err(ServerFnError::server(403, "Permission denied"));
 	}
 	let request_context = AdminRequestContext::new(http_request.into_inner());
 	let mut admin_query = model_admin
 		.get_queryset(
-			user.as_ref(),
+			user.0.as_ref(),
 			&request_context,
 			AdminQuery::new(model_admin.table_name()),
 		)
@@ -308,32 +347,48 @@ pub async fn get_list(
 		.or_else(|| model_admin.ordering().first().copied());
 	let sort_by = resolve_sort_field(&columns, requested_sort)?;
 
-	let hierarchy = if let Some(field) = model_admin.date_hierarchy() {
-		let metadata = get_field_metadata(model_admin.table_name(), field).ok_or_else(|| {
-			ServerFnError::server(
-				400,
-				format!("Date hierarchy field '{field}' does not exist"),
-			)
-		})?;
-		if !matches!(
-			metadata.field_type,
-			DbFieldType::Date | DbFieldType::DateTime | DbFieldType::TimestampTz
-		) {
-			return Err(ServerFnError::server(
-				400,
-				format!("Date hierarchy field '{field}' must be a date or datetime field"),
-			));
+	let hierarchy = if include_date_hierarchy {
+		if let Some(field) = model_admin.date_hierarchy() {
+			let metadata =
+				get_field_metadata(model_admin.table_name(), field).ok_or_else(|| {
+					ServerFnError::server(
+						400,
+						format!("Date hierarchy field '{field}' does not exist"),
+					)
+				})?;
+			if !matches!(
+				metadata.field_type,
+				DbFieldType::Date | DbFieldType::DateTime | DbFieldType::TimestampTz
+			) {
+				return Err(ServerFnError::server(
+					400,
+					format!("Date hierarchy field '{field}' must be a date or datetime field"),
+				));
+			}
+			let selection = params.date_hierarchy.clone().unwrap_or_default();
+			let interval = date_hierarchy_interval(&selection, &metadata.field_type)?;
+			let db_field = metadata
+				.params
+				.get("db_column")
+				.cloned()
+				.unwrap_or_else(|| field.to_string());
+			Some((
+				field.to_string(),
+				db_field,
+				metadata.field_type,
+				selection,
+				interval,
+			))
+		} else {
+			if params.date_hierarchy.is_some() {
+				return Err(ServerFnError::server(
+					400,
+					"Date hierarchy is not configured",
+				));
+			}
+			None
 		}
-		let selection = params.date_hierarchy.clone().unwrap_or_default();
-		let interval = date_hierarchy_interval(&selection, &metadata.field_type)?;
-		Some((field.to_string(), metadata.field_type, selection, interval))
 	} else {
-		if params.date_hierarchy.is_some() {
-			return Err(ServerFnError::server(
-				400,
-				"Date hierarchy is not configured",
-			));
-		}
 		None
 	};
 
@@ -355,15 +410,15 @@ pub async fn get_list(
 	for filter in additional_filters {
 		admin_query = admin_query.filter(filter);
 	}
-	if let Some((field, _, _, Some((start, end)))) = &hierarchy {
+	if let Some((_, db_field, _, _, Some((start, end)))) = &hierarchy {
 		admin_query = admin_query
 			.filter(Filter::new(
-				field,
+				db_field,
 				FilterOperator::Gte,
 				FilterValue::Typed(Ok(start.clone())),
 			))
 			.filter(Filter::new(
-				field,
+				db_field,
 				FilterOperator::Lt,
 				FilterValue::Typed(Ok(end.clone())),
 			));
@@ -399,10 +454,10 @@ pub async fn get_list(
 		}
 	}
 
-	let date_hierarchy = if let Some((field, field_type, selection, _)) = hierarchy {
+	let date_hierarchy = if let Some((field, db_field, field_type, selection, _)) = hierarchy {
 		let next_level = date_hierarchy_level(&selection);
 		let choices = if let Some(level) = next_level {
-			db.date_hierarchy_choices(&admin_query, &field, level, &field_type)
+			db.date_hierarchy_choices(&admin_query, &db_field, level, &field_type)
 				.await
 				.map_server_fn_error()?
 		} else {
@@ -425,15 +480,17 @@ pub async fn get_list(
 		1
 	};
 
-	Ok(ListResponse {
-		model_name,
-		count,
-		page,
-		page_size,
-		total_pages,
-		results,
-		available_filters: Some(build_filters(&model_admin)),
-		columns: Some(build_columns(&columns)),
+	Ok(DateHierarchyListResponse {
+		response: ListResponse {
+			model_name,
+			count,
+			page,
+			page_size,
+			total_pages,
+			results,
+			available_filters: Some(build_filters(&model_admin)),
+			columns: Some(build_columns(&columns)),
+		},
 		date_hierarchy,
 	})
 }

--- a/crates/reinhardt-admin/src/server/list.rs
+++ b/crates/reinhardt-admin/src/server/list.rs
@@ -5,13 +5,16 @@
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
 use crate::adapters::{
-	AdminDatabase, AdminQuery, AdminRequestContext, AdminSite, ColumnInfo, FilterInfo, FilterType,
-	ListResponse, ModelAdmin,
+	AdminDatabase, AdminQuery, AdminRequestContext, AdminSite, ColumnInfo, DateHierarchyInfo,
+	DateHierarchyLevel, DateHierarchySelection, FilterInfo, FilterType, ListColumn, ListResponse,
+	ModelAdmin,
 };
 #[cfg(server)]
 use crate::core::{AdminDatabaseKey, AdminSiteKey};
 #[cfg(server)]
-use reinhardt_db::orm::{Filter, FilterCondition, FilterOperator, FilterValue};
+use reinhardt_db::migrations::FieldType as DbFieldType;
+#[cfg(server)]
+use reinhardt_db::orm::{DatabaseValue, Filter, FilterCondition, FilterOperator, FilterValue};
 #[cfg(server)]
 use reinhardt_di::KeyedDepends;
 #[cfg(server)]
@@ -56,16 +59,138 @@ fn build_filters(model_admin: &Arc<dyn ModelAdmin>) -> Vec<FilterInfo> {
 }
 
 #[cfg(server)]
-fn build_columns(model_admin: &Arc<dyn ModelAdmin>) -> Vec<ColumnInfo> {
-	model_admin
-		.list_display()
+fn build_columns(columns: &[ListColumn]) -> Vec<ColumnInfo> {
+	columns
 		.iter()
-		.map(|field| ColumnInfo {
-			field: field.to_string(),
-			label: humanize_field_name(field),
-			sortable: true,
+		.map(|column| match column {
+			ListColumn::Field { field, label } => ColumnInfo {
+				field: field.clone(),
+				label: label.clone(),
+				sortable: true,
+			},
+			ListColumn::Computed {
+				key,
+				label,
+				sort_field,
+			} => ColumnInfo {
+				field: key.clone(),
+				label: label.clone(),
+				sortable: sort_field.is_some(),
+			},
 		})
 		.collect()
+}
+
+#[cfg(server)]
+fn resolve_sort_field(
+	columns: &[ListColumn],
+	sort_by: Option<&str>,
+) -> Result<Option<String>, ServerFnError> {
+	let Some(sort_by) = sort_by else {
+		return Ok(None);
+	};
+	let (key, descending) = sort_by
+		.strip_prefix('-')
+		.map_or((sort_by, false), |key| (key, true));
+	let mapped = columns.iter().find_map(|column| match column {
+		ListColumn::Field { field, .. } if field == key => Some(Ok(field.as_str())),
+		ListColumn::Computed {
+			key: column_key,
+			sort_field,
+			..
+		} if column_key == key => Some(sort_field.as_deref().ok_or_else(|| {
+			ServerFnError::server(
+				400,
+				format!("Computed sort field '{key}' has no database mapping"),
+			)
+		})),
+		_ => None,
+	});
+	let mapped = mapped
+		.ok_or_else(|| ServerFnError::server(400, format!("Unknown sort field '{key}'")))??;
+	Ok(Some(if descending {
+		format!("-{mapped}")
+	} else {
+		mapped.to_string()
+	}))
+}
+
+#[cfg(server)]
+fn date_hierarchy_interval(
+	selection: &DateHierarchySelection,
+	field_type: &DbFieldType,
+) -> Result<Option<(DatabaseValue, DatabaseValue)>, ServerFnError> {
+	use chrono::Days;
+
+	if selection.month.is_some() && selection.year.is_none() {
+		return Err(ServerFnError::server(
+			400,
+			"Date hierarchy month requires a year",
+		));
+	}
+	if selection.day.is_some() && (selection.year.is_none() || selection.month.is_none()) {
+		return Err(ServerFnError::server(
+			400,
+			"Date hierarchy day requires a year and month",
+		));
+	}
+	let Some(year) = selection.year else {
+		return Ok(None);
+	};
+
+	let (start, end) = match (selection.month, selection.day) {
+		(None, None) => {
+			let start = chrono::NaiveDate::from_ymd_opt(year, 1, 1);
+			let end = year
+				.checked_add(1)
+				.and_then(|year| chrono::NaiveDate::from_ymd_opt(year, 1, 1));
+			(start, end)
+		}
+		(Some(month), None) => {
+			let start = chrono::NaiveDate::from_ymd_opt(year, month, 1);
+			let end = if month == 12 {
+				year.checked_add(1)
+					.and_then(|year| chrono::NaiveDate::from_ymd_opt(year, 1, 1))
+			} else {
+				month
+					.checked_add(1)
+					.and_then(|month| chrono::NaiveDate::from_ymd_opt(year, month, 1))
+			};
+			(start, end)
+		}
+		(Some(month), Some(day)) => {
+			let start = chrono::NaiveDate::from_ymd_opt(year, month, day);
+			let end = start.and_then(|date| date.checked_add_days(Days::new(1)));
+			(start, end)
+		}
+		(None, Some(_)) => unreachable!("day dependency is validated above"),
+	};
+	let (start, end) = start.zip(end).ok_or_else(|| {
+		ServerFnError::server(400, "Invalid or unrepresentable date hierarchy selection")
+	})?;
+
+	match field_type {
+		DbFieldType::Date => Ok(Some((DatabaseValue::Date(start), DatabaseValue::Date(end)))),
+		DbFieldType::DateTime | DbFieldType::TimestampTz => Ok(Some((
+			DatabaseValue::DateTime(start.and_time(chrono::NaiveTime::MIN).and_utc()),
+			DatabaseValue::DateTime(end.and_time(chrono::NaiveTime::MIN).and_utc()),
+		))),
+		_ => Err(ServerFnError::server(
+			400,
+			"Date hierarchy field must be a date or datetime field",
+		)),
+	}
+}
+
+#[cfg(server)]
+fn date_hierarchy_level(selection: &DateHierarchySelection) -> Option<DateHierarchyLevel> {
+	match (selection.year, selection.month, selection.day) {
+		(None, None, None) => Some(DateHierarchyLevel::Year),
+		(Some(_), None, None) => Some(DateHierarchyLevel::Month),
+		(Some(_), Some(_), None) => Some(DateHierarchyLevel::Day),
+		(Some(_), Some(_), Some(_)) => None,
+		_ => None,
+	}
 }
 
 /// Get list view data with search, filters, sorting, and pagination
@@ -124,6 +249,7 @@ pub async fn get_list(
 		)
 		.await
 		.map_server_fn_error()?;
+	let columns = model_admin.list_columns();
 	let related_fields =
 		resolve_list_select_related(model_admin.table_name(), &model_admin.list_select_related())
 			.map_server_fn_error()?;
@@ -172,25 +298,40 @@ pub async fn get_list(
 	}
 
 	// Determine sort field
-	let sort_by = params
+	let requested_sort = params
 		.sort_by
 		.as_deref()
 		.or_else(|| model_admin.ordering().first().copied());
+	let sort_by = resolve_sort_field(&columns, requested_sort)?;
 
-	// Validate sort_by against allowed fields to prevent arbitrary column access
-	if let Some(sort_field) = sort_by {
-		let raw_field = sort_field.strip_prefix('-').unwrap_or(sort_field);
-		let allowed_sort_fields = model_admin.list_display();
-		if !allowed_sort_fields.contains(&raw_field) {
+	let hierarchy = if let Some(field) = model_admin.date_hierarchy() {
+		let metadata = get_field_metadata(model_admin.table_name(), field).ok_or_else(|| {
+			ServerFnError::server(
+				400,
+				format!("Date hierarchy field '{field}' does not exist"),
+			)
+		})?;
+		if !matches!(
+			metadata.field_type,
+			DbFieldType::Date | DbFieldType::DateTime | DbFieldType::TimestampTz
+		) {
 			return Err(ServerFnError::server(
 				400,
-				format!(
-					"Unknown sort field '{}'. Allowed sort fields: {:?}",
-					raw_field, allowed_sort_fields
-				),
+				format!("Date hierarchy field '{field}' must be a date or datetime field"),
 			));
 		}
-	}
+		let selection = params.date_hierarchy.clone().unwrap_or_default();
+		let interval = date_hierarchy_interval(&selection, &metadata.field_type)?;
+		Some((field.to_string(), metadata.field_type, selection, interval))
+	} else {
+		if params.date_hierarchy.is_some() {
+			return Err(ServerFnError::server(
+				400,
+				"Date hierarchy is not configured",
+			));
+		}
+		None
+	};
 
 	// Calculate pagination with upper bound enforcement
 	let page = params.page.unwrap_or(1).max(1); // Ensure page is at least 1
@@ -210,12 +351,68 @@ pub async fn get_list(
 	for filter in additional_filters {
 		admin_query = admin_query.filter(filter);
 	}
+	if let Some((field, _, _, Some((start, end)))) = &hierarchy {
+		admin_query = admin_query
+			.filter(Filter::new(
+				field,
+				FilterOperator::Gte,
+				FilterValue::Typed(Ok(start.clone())),
+			))
+			.filter(Filter::new(
+				field,
+				FilterOperator::Lt,
+				FilterValue::Typed(Ok(end.clone())),
+			));
+	}
 
 	// Fetch page data and total count in one query for the common non-empty page path.
-	let (results, count) = db
-		.list_admin_query_with_count(&admin_query, &related_fields, sort_by, offset, page_size)
+	let (mut results, count) = db
+		.list_admin_query_with_count(
+			&admin_query,
+			&related_fields,
+			sort_by.as_deref(),
+			offset,
+			page_size,
+		)
 		.await
 		.map_server_fn_error()?;
+
+	for row in &mut results {
+		for column in &columns {
+			let ListColumn::Computed { key, .. } = column else {
+				continue;
+			};
+			let value = model_admin.computed_list_value(key, row).map_err(|error| {
+				tracing::error!(
+					model = model_admin.model_name(),
+					column = key,
+					error = ?error,
+					"Admin computed list column failed"
+				);
+				ServerFnError::server(500, "Failed to compute list column")
+			})?;
+			row.insert(key.clone(), value);
+		}
+	}
+
+	let date_hierarchy = if let Some((field, field_type, selection, _)) = hierarchy {
+		let next_level = date_hierarchy_level(&selection);
+		let choices = if let Some(level) = next_level {
+			db.date_hierarchy_choices(&admin_query, &field, level, &field_type)
+				.await
+				.map_server_fn_error()?
+		} else {
+			Vec::new()
+		};
+		Some(DateHierarchyInfo {
+			field,
+			selection,
+			next_level,
+			choices,
+		})
+	} else {
+		None
+	};
 
 	// Calculate total pages
 	let total_pages = if count > 0 {
@@ -232,7 +429,174 @@ pub async fn get_list(
 		total_pages,
 		results,
 		available_filters: Some(build_filters(&model_admin)),
-		columns: Some(build_columns(&model_admin)),
-		date_hierarchy: None,
+		columns: Some(build_columns(&columns)),
+		date_hierarchy,
 	})
+}
+
+#[cfg(all(test, server))]
+mod tests {
+	use super::*;
+	use crate::adapters::{DateHierarchySelection, ListColumn};
+	use chrono::{NaiveDate, TimeZone, Utc};
+	use reinhardt_db::migrations::FieldType as DbFieldType;
+	use reinhardt_db::orm::DatabaseValue;
+
+	#[test]
+	fn date_hierarchy_date_intervals_are_half_open_and_accept_leap_day() {
+		let cases = [
+			(
+				DateHierarchySelection {
+					year: Some(2024),
+					month: None,
+					day: None,
+				},
+				NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+				NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+			),
+			(
+				DateHierarchySelection {
+					year: Some(2024),
+					month: Some(2),
+					day: None,
+				},
+				NaiveDate::from_ymd_opt(2024, 2, 1).unwrap(),
+				NaiveDate::from_ymd_opt(2024, 3, 1).unwrap(),
+			),
+			(
+				DateHierarchySelection {
+					year: Some(2024),
+					month: Some(2),
+					day: Some(29),
+				},
+				NaiveDate::from_ymd_opt(2024, 2, 29).unwrap(),
+				NaiveDate::from_ymd_opt(2024, 3, 1).unwrap(),
+			),
+		];
+
+		for (selection, expected_start, expected_end) in cases {
+			assert_eq!(
+				date_hierarchy_interval(&selection, &DbFieldType::Date).unwrap(),
+				Some((
+					DatabaseValue::Date(expected_start),
+					DatabaseValue::Date(expected_end),
+				))
+			);
+		}
+	}
+
+	#[test]
+	fn date_hierarchy_datetime_intervals_bind_utc_midnight() {
+		let selection = DateHierarchySelection {
+			year: Some(2024),
+			month: Some(2),
+			day: Some(29),
+		};
+
+		for field_type in [DbFieldType::DateTime, DbFieldType::TimestampTz] {
+			assert_eq!(
+				date_hierarchy_interval(&selection, &field_type).unwrap(),
+				Some((
+					DatabaseValue::DateTime(Utc.with_ymd_and_hms(2024, 2, 29, 0, 0, 0).unwrap(),),
+					DatabaseValue::DateTime(Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap(),),
+				))
+			);
+		}
+	}
+
+	#[test]
+	fn date_hierarchy_levels_follow_selection_depth() {
+		let cases = [
+			(
+				DateHierarchySelection::default(),
+				Some(DateHierarchyLevel::Year),
+			),
+			(
+				DateHierarchySelection {
+					year: Some(2024),
+					month: None,
+					day: None,
+				},
+				Some(DateHierarchyLevel::Month),
+			),
+			(
+				DateHierarchySelection {
+					year: Some(2024),
+					month: Some(2),
+					day: None,
+				},
+				Some(DateHierarchyLevel::Day),
+			),
+			(
+				DateHierarchySelection {
+					year: Some(2024),
+					month: Some(2),
+					day: Some(29),
+				},
+				None,
+			),
+		];
+
+		for (selection, expected) in cases {
+			assert_eq!(date_hierarchy_level(&selection), expected);
+		}
+	}
+
+	#[test]
+	fn date_hierarchy_rejects_invalid_dependencies_dates_and_boundaries() {
+		let cases = [
+			DateHierarchySelection {
+				year: None,
+				month: Some(1),
+				day: None,
+			},
+			DateHierarchySelection {
+				year: Some(2023),
+				month: Some(2),
+				day: Some(29),
+			},
+			DateHierarchySelection {
+				year: Some(262_142),
+				month: Some(12),
+				day: Some(31),
+			},
+		];
+
+		for selection in cases {
+			let error = date_hierarchy_interval(&selection, &DbFieldType::Date)
+				.expect_err("invalid selection must be rejected");
+			assert_eq!(error.status(), Some(400));
+		}
+	}
+
+	#[test]
+	fn computed_sort_key_maps_to_real_field_and_requires_mapping() {
+		let columns = vec![
+			ListColumn::Field {
+				field: "id".to_string(),
+				label: "ID".to_string(),
+			},
+			ListColumn::Computed {
+				key: "summary".to_string(),
+				label: "Summary".to_string(),
+				sort_field: Some("created_at".to_string()),
+			},
+			ListColumn::Computed {
+				key: "badge".to_string(),
+				label: "Badge".to_string(),
+				sort_field: None,
+			},
+		];
+
+		assert_eq!(
+			resolve_sort_field(&columns, Some("-summary")).unwrap(),
+			Some("-created_at".to_string())
+		);
+		assert_eq!(
+			resolve_sort_field(&columns, Some("badge"))
+				.expect_err("unmapped computed sort must fail")
+				.status(),
+			Some(400)
+		);
+	}
 }

--- a/crates/reinhardt-admin/src/server/list.rs
+++ b/crates/reinhardt-admin/src/server/list.rs
@@ -233,5 +233,6 @@ pub async fn get_list(
 		results,
 		available_filters: Some(build_filters(&model_admin)),
 		columns: Some(build_columns(&model_admin)),
+		date_hierarchy: None,
 	})
 }

--- a/crates/reinhardt-admin/src/server/type_inference.rs
+++ b/crates/reinhardt-admin/src/server/type_inference.rs
@@ -342,6 +342,13 @@ pub fn get_field_metadata(table_name: &str, field_name: &str) -> Option<FieldMet
 		if let Some(meta) = m.fields.get(field_name) {
 			return Some(meta.clone());
 		}
+		if let Some(meta) = m
+			.fields
+			.values()
+			.find(|meta| meta.params.get("field_name").map(String::as_str) == Some(field_name))
+		{
+			return Some(meta.clone());
+		}
 
 		let relation_name = field_name.strip_suffix("_id")?;
 		let mut meta = m.fields.get(relation_name)?.clone();

--- a/crates/reinhardt-admin/src/types.rs
+++ b/crates/reinhardt-admin/src/types.rs
@@ -29,6 +29,6 @@ pub use responses::*;
 #[cfg(client)]
 pub use wasm_stubs::{
 	AdminDatabase, AdminQuery, AdminRecord, AdminRequestContext, AdminSite, AdminUser,
-	ExportFormat, ImportBuilder, ImportError, ImportFormat, ImportResult, ModelAdmin,
+	ExportFormat, ImportBuilder, ImportError, ImportFormat, ImportResult, ListColumn, ModelAdmin,
 	ModelAdminConfig, ModelAdminConfigBuilder,
 };

--- a/crates/reinhardt-admin/src/types/models.rs
+++ b/crates/reinhardt-admin/src/types/models.rs
@@ -2,6 +2,42 @@
 
 use serde::{Deserialize, Serialize};
 
+/// A selected position within a date hierarchy.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DateHierarchySelection {
+	/// Selected year.
+	pub year: Option<i32>,
+	/// Selected month within [`Self::year`].
+	pub month: Option<u32>,
+	/// Selected day within [`Self::month`].
+	pub day: Option<u32>,
+}
+
+/// The next date hierarchy granularity available for selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DateHierarchyLevel {
+	/// Select a year.
+	Year,
+	/// Select a month.
+	Month,
+	/// Select a day.
+	Day,
+}
+
+/// Date hierarchy metadata included with a changelist response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DateHierarchyInfo {
+	/// Date or datetime field used for the hierarchy.
+	pub field: String,
+	/// Currently selected hierarchy position.
+	pub selection: DateHierarchySelection,
+	/// The next level the client may select.
+	pub next_level: Option<DateHierarchyLevel>,
+	/// Available values for [`Self::next_level`].
+	pub choices: Vec<i32>,
+}
+
 /// Model information for dashboard
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelInfo {

--- a/crates/reinhardt-admin/src/types/requests.rs
+++ b/crates/reinhardt-admin/src/types/requests.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
 
 use crate::types::DateHierarchySelection;
 
@@ -31,14 +32,49 @@ pub struct ListQueryParams {
 	pub search: Option<String>,
 	/// Sort field (prefix with "-" for descending, e.g., "created_at" or "-created_at")
 	pub sort_by: Option<String>,
-	/// Current date hierarchy selection.
-	pub date_hierarchy: Option<DateHierarchySelection>,
 	/// Filter field=value pairs.
 	///
 	/// Only explicitly provided filter parameters are accepted.
 	/// Each filter key and value is validated for length constraints.
 	#[serde(default, deserialize_with = "deserialize_validated_filters")]
 	pub filters: HashMap<String, String>,
+}
+
+/// Query parameters for the date-hierarchy list endpoint.
+///
+/// This extension keeps [`ListQueryParams`] source-compatible for existing
+/// callers while adding the optional hierarchy selection to a versioned
+/// server function.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DateHierarchyListQueryParams {
+	/// The legacy list query parameters.
+	#[serde(flatten)]
+	pub list: ListQueryParams,
+	/// Current date hierarchy selection.
+	pub date_hierarchy: Option<DateHierarchySelection>,
+}
+
+impl From<ListQueryParams> for DateHierarchyListQueryParams {
+	fn from(list: ListQueryParams) -> Self {
+		Self {
+			list,
+			date_hierarchy: None,
+		}
+	}
+}
+
+impl Deref for DateHierarchyListQueryParams {
+	type Target = ListQueryParams;
+
+	fn deref(&self) -> &Self::Target {
+		&self.list
+	}
+}
+
+impl DerefMut for DateHierarchyListQueryParams {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.list
+	}
 }
 
 /// Deserializes and validates filter parameters.
@@ -419,5 +455,26 @@ mod tests {
 			should_pass,
 			result
 		);
+	}
+
+	#[test]
+	fn date_hierarchy_query_serializes_as_flattened_list_request() {
+		let params = DateHierarchyListQueryParams {
+			list: ListQueryParams {
+				page: Some(2),
+				..Default::default()
+			},
+			date_hierarchy: Some(DateHierarchySelection {
+				year: Some(2024),
+				month: Some(2),
+				day: None,
+			}),
+		};
+
+		let value = serde_json::to_value(params).expect("date hierarchy request should serialize");
+		assert_eq!(value["page"], serde_json::json!(2));
+		assert_eq!(value["date_hierarchy"]["year"], serde_json::json!(2024));
+		assert_eq!(value["date_hierarchy"]["month"], serde_json::json!(2));
+		assert!(value.get("list").is_none());
 	}
 }

--- a/crates/reinhardt-admin/src/types/requests.rs
+++ b/crates/reinhardt-admin/src/types/requests.rs
@@ -3,6 +3,8 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
+use crate::types::DateHierarchySelection;
+
 /// Maximum number of filter parameters allowed in a single request.
 ///
 /// Prevents abuse through excessive filter parameters which could lead to
@@ -29,6 +31,8 @@ pub struct ListQueryParams {
 	pub search: Option<String>,
 	/// Sort field (prefix with "-" for descending, e.g., "created_at" or "-created_at")
 	pub sort_by: Option<String>,
+	/// Current date hierarchy selection.
+	pub date_hierarchy: Option<DateHierarchySelection>,
 	/// Filter field=value pairs.
 	///
 	/// Only explicitly provided filter parameters are accepted.

--- a/crates/reinhardt-admin/src/types/responses.rs
+++ b/crates/reinhardt-admin/src/types/responses.rs
@@ -45,9 +45,26 @@ pub struct ListResponse {
 	/// Column definitions for list display
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub columns: Option<Vec<ColumnInfo>>,
+}
+
+/// Response for the versioned date-hierarchy list endpoint.
+///
+/// The legacy [`ListResponse`] remains unchanged; this wrapper adds hierarchy
+/// metadata without breaking existing Rust struct literals and consumers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DateHierarchyListResponse {
+	/// Legacy list response fields.
+	#[serde(flatten)]
+	pub response: ListResponse,
 	/// Date hierarchy metadata for changelist drill-down.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub date_hierarchy: Option<DateHierarchyInfo>,
+}
+
+impl From<DateHierarchyListResponse> for ListResponse {
+	fn from(response: DateHierarchyListResponse) -> Self {
+		response.response
+	}
 }
 
 /// Response for detail endpoint
@@ -149,4 +166,30 @@ pub struct FieldsResponse {
 	/// None for create forms, Some(values) for edit forms
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub values: Option<HashMap<String, serde_json::Value>>,
+}
+
+#[cfg(all(test, server))]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn date_hierarchy_response_keeps_legacy_fields_flat() {
+		let response = DateHierarchyListResponse {
+			response: ListResponse {
+				model_name: "Article".to_string(),
+				count: 1,
+				page: 1,
+				page_size: 25,
+				total_pages: 1,
+				results: vec![],
+				available_filters: None,
+				columns: None,
+			},
+			date_hierarchy: None,
+		};
+
+		let value = serde_json::to_value(response).expect("list response should serialize");
+		assert_eq!(value["model_name"], serde_json::json!("Article"));
+		assert!(value.get("response").is_none());
+	}
 }

--- a/crates/reinhardt-admin/src/types/responses.rs
+++ b/crates/reinhardt-admin/src/types/responses.rs
@@ -1,6 +1,6 @@
 //! Response types for admin panel API
 
-use crate::types::models::{ColumnInfo, FilterInfo, ModelInfo};
+use crate::types::models::{ColumnInfo, DateHierarchyInfo, FilterInfo, ModelInfo};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -45,6 +45,9 @@ pub struct ListResponse {
 	/// Column definitions for list display
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub columns: Option<Vec<ColumnInfo>>,
+	/// Date hierarchy metadata for changelist drill-down.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub date_hierarchy: Option<DateHierarchyInfo>,
 }
 
 /// Response for detail endpoint

--- a/crates/reinhardt-admin/src/types/wasm_stubs.rs
+++ b/crates/reinhardt-admin/src/types/wasm_stubs.rs
@@ -10,6 +10,8 @@ pub use wasm_only::*;
 
 #[cfg(client)]
 mod wasm_only {
+	use std::collections::HashMap;
+
 	/// Dummy AdminSite type for WASM type checking
 	///
 	/// This type is never actually used in WASM code, as the `#[server_fn]`
@@ -56,6 +58,27 @@ mod wasm_only {
 		fn get_username(&self) -> &str;
 	}
 
+	/// Changelist column descriptor stub for WASM type checking.
+	#[derive(Debug, Clone, PartialEq, Eq)]
+	pub enum ListColumn {
+		/// A database-backed field column.
+		Field {
+			/// Field name to read from the result row.
+			field: String,
+			/// Display label for the column header.
+			label: String,
+		},
+		/// A value computed after the result row is fetched.
+		Computed {
+			/// Stable key used in responses and computed-value lookup.
+			key: String,
+			/// Display label for the column header.
+			label: String,
+			/// Database field used when this computed column is sorted.
+			sort_field: Option<String>,
+		},
+	}
+
 	/// Model admin trait stub for WASM type checking.
 	///
 	/// This trait is never actually used in WASM code.
@@ -77,6 +100,33 @@ mod wasm_only {
 		/// Fields to display in list view.
 		fn list_display(&self) -> Vec<&str> {
 			vec!["id"]
+		}
+
+		/// Owned descriptors for columns displayed in list view.
+		fn list_columns(&self) -> Vec<ListColumn> {
+			self.list_display()
+				.into_iter()
+				.map(|field| ListColumn::Field {
+					field: field.to_string(),
+					label: field.to_string(),
+				})
+				.collect()
+		}
+
+		/// Resolve a computed changelist column for a fetched result row.
+		fn computed_list_value(
+			&self,
+			key: &str,
+			_row: &HashMap<String, serde_json::Value>,
+		) -> crate::types::AdminResult<serde_json::Value> {
+			Err(crate::types::AdminError::TemplateError(format!(
+				"No computed list column is configured for key '{key}'"
+			)))
+		}
+
+		/// Date or datetime field used for hierarchical changelist navigation.
+		fn date_hierarchy(&self) -> Option<&str> {
+			None
 		}
 
 		/// Fields that can be used for filtering.

--- a/crates/reinhardt-admin/tests/wasm_components.rs
+++ b/crates/reinhardt-admin/tests/wasm_components.rs
@@ -11,7 +11,7 @@ use reinhardt_admin::pages::components::features::{
 	Column, FormField, ListViewData, dashboard, detail_view, list_view, model_form,
 };
 use reinhardt_admin::pages::components::login::login_form;
-use reinhardt_admin::types::{FormFieldSpec, ListQueryParams, ModelInfo};
+use reinhardt_admin::types::{FormFieldSpec, ModelInfo};
 use reinhardt_pages::Signal;
 use std::collections::HashMap;
 use wasm_bindgen_test::*;
@@ -289,16 +289,11 @@ fn test_list_view_renders_table_with_data() {
 		total_pages: 3,
 		total_count: 25,
 		filters: vec![],
-		date_hierarchy: None,
 	};
 
 	let page_signal = Signal::new(1u64);
 	let filters_signal = Signal::new(HashMap::new());
-	let query_params = Signal::new(ListQueryParams {
-		page: Some(1),
-		..ListQueryParams::default()
-	});
-	let page = list_view(&data, page_signal, filters_signal, query_params);
+	let page = list_view(&data, page_signal, filters_signal);
 	let html = page.render_to_string();
 
 	assert!(html.contains("User List"), "Should show list title");

--- a/crates/reinhardt-admin/tests/wasm_components.rs
+++ b/crates/reinhardt-admin/tests/wasm_components.rs
@@ -11,7 +11,7 @@ use reinhardt_admin::pages::components::features::{
 	Column, FormField, ListViewData, dashboard, detail_view, list_view, model_form,
 };
 use reinhardt_admin::pages::components::login::login_form;
-use reinhardt_admin::types::{FormFieldSpec, ModelInfo};
+use reinhardt_admin::types::{FormFieldSpec, ListQueryParams, ModelInfo};
 use reinhardt_pages::Signal;
 use std::collections::HashMap;
 use wasm_bindgen_test::*;
@@ -289,11 +289,16 @@ fn test_list_view_renders_table_with_data() {
 		total_pages: 3,
 		total_count: 25,
 		filters: vec![],
+		date_hierarchy: None,
 	};
 
 	let page_signal = Signal::new(1u64);
 	let filters_signal = Signal::new(HashMap::new());
-	let page = list_view(&data, page_signal, filters_signal);
+	let query_params = Signal::new(ListQueryParams {
+		page: Some(1),
+		..ListQueryParams::default()
+	});
+	let page = list_view(&data, page_signal, filters_signal, query_params);
 	let html = page.render_to_string();
 
 	assert!(html.contains("User List"), "Should show list title");

--- a/crates/reinhardt-core/macros/src/admin.rs
+++ b/crates/reinhardt-core/macros/src/admin.rs
@@ -70,6 +70,8 @@ pub(crate) struct AdminModelConfig {
 	pub list_display: Option<Vec<Ident>>,
 	/// Relations to eager-load in list view
 	pub list_select_related: Option<Vec<Ident>>,
+	/// Date or datetime field used for hierarchical changelist navigation.
+	pub date_hierarchy: Option<Ident>,
 	/// Fields that can be used for filtering
 	pub list_filter: Option<Vec<Ident>>,
 	/// Fields that can be searched
@@ -113,6 +115,7 @@ impl Parse for AdminModelConfig {
 		let mut name: Option<String> = None;
 		let mut list_display: Option<Vec<Ident>> = None;
 		let mut list_select_related: Option<Vec<Ident>> = None;
+		let mut date_hierarchy: Option<Ident> = None;
 		let mut list_filter: Option<Vec<Ident>> = None;
 		let mut search_fields: Option<Vec<Ident>> = None;
 		let mut fields: Option<Vec<Ident>> = None;
@@ -152,6 +155,9 @@ impl Parse for AdminModelConfig {
 				}
 				"list_select_related" => {
 					list_select_related = Some(parse_ident_array(input)?);
+				}
+				"date_hierarchy" => {
+					date_hierarchy = Some(input.parse()?);
 				}
 				"list_filter" => {
 					list_filter = Some(parse_ident_array(input)?);
@@ -209,7 +215,7 @@ impl Parse for AdminModelConfig {
 					return Err(syn::Error::new(
 						key.span(),
 						format!(
-							"unknown attribute `{}` for model admin\n\n  = help: valid attributes are: for, name, list_display, list_select_related, list_filter, search_fields, fields, readonly_fields, ordering, list_per_page, allow_view, allow_add, allow_change, allow_delete, permissions",
+							"unknown attribute `{}` for model admin\n\n  = help: valid attributes are: for, name, list_display, list_select_related, date_hierarchy, list_filter, search_fields, fields, readonly_fields, ordering, list_per_page, allow_view, allow_add, allow_change, allow_delete, permissions",
 							unknown
 						),
 					));
@@ -242,6 +248,7 @@ impl Parse for AdminModelConfig {
 			name,
 			list_display,
 			list_select_related,
+			date_hierarchy,
 			list_filter,
 			search_fields,
 			fields,
@@ -302,6 +309,9 @@ pub(crate) fn admin_impl(args: TokenStream, input: ItemStruct) -> Result<TokenSt
 	let mut all_fields: Vec<&Ident> = Vec::new();
 	if let Some(ref fields) = config.list_display {
 		all_fields.extend(fields.iter());
+	}
+	if let Some(ref field) = config.date_hierarchy {
+		all_fields.push(field);
 	}
 	if let Some(ref fields) = config.list_filter {
 		all_fields.extend(fields.iter());
@@ -374,6 +384,17 @@ pub(crate) fn admin_impl(args: TokenStream, input: ItemStruct) -> Result<TokenSt
 		quote! {
 			fn list_select_related(&self) -> Vec<&str> {
 				vec![#(#relation_strs),*]
+			}
+		}
+	} else {
+		quote! {}
+	};
+
+	let date_hierarchy_impl = if let Some(ref field) = config.date_hierarchy {
+		let field = field.to_string();
+		quote! {
+			fn date_hierarchy(&self) -> Option<&str> {
+				Some(#field)
 			}
 		}
 	} else {
@@ -509,6 +530,7 @@ pub(crate) fn admin_impl(args: TokenStream, input: ItemStruct) -> Result<TokenSt
 			#table_name_impl
 			#list_display_impl
 			#list_select_related_impl
+			#date_hierarchy_impl
 			#list_filter_impl
 			#search_fields_impl
 			#fields_impl
@@ -546,6 +568,32 @@ mod tests {
 		assert_eq!(
 			output
 				.matches("fnlist_select_related(&self)->Vec<&str>{vec![\"author\"]}")
+				.count(),
+			1
+		);
+	}
+
+	#[test]
+	fn date_hierarchy_generates_field_validation_and_admin_method() {
+		let args = quote! {
+			model,
+			for = Article,
+			name = "Article",
+			date_hierarchy = created_at
+		};
+		let input = syn::parse_quote! {
+			pub struct ArticleAdmin;
+		};
+
+		let output = admin_impl(args, input)
+			.expect("date_hierarchy should expand")
+			.to_string()
+			.replace(' ', "");
+
+		assert_eq!(output.matches("Article::field_created_at").count(), 1);
+		assert_eq!(
+			output
+				.matches("fndate_hierarchy(&self)->Option<&str>{Some(\"created_at\")}")
 				.count(),
 			1
 		);

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -960,6 +960,7 @@ pub fn collect_migrations(input: TokenStream) -> TokenStream {
 /// - `list_display = [field1, field2, ...]` - Fields to display in list view (default: `[id]`)
 /// - `list_select_related = [relation1, relation2, ...]` - One-level forward foreign keys to
 ///   eager-load in list view (default: `[]`)
+/// - `date_hierarchy = field` - Date or datetime field for changelist drill-down (default: none)
 /// - `list_filter = [field1, field2, ...]` - Fields for filtering (default: `[]`)
 /// - `search_fields = [field1, field2, ...]` - Fields for search (default: `[]`)
 /// - `fields = [field1, field2, ...]` - Fields to display in forms (default: all)

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -6332,6 +6332,7 @@ fn generate_registration_code(input: RegistrationCodeInput<'_>) -> Result<TokenS
 				#resolved_column.to_string(),
 				#migrations_crate::model_registry::FieldMetadata::new(#field_type)
 					#(#params)*
+					.with_param("field_name", #field_name)
 					.with_param("db_column", #resolved_column)
 					.with_domain_opt(field_domain.clone())
 					#generated_registration

--- a/crates/reinhardt-core/macros/tests/ui/admin/fail/unknown_attribute.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/admin/fail/unknown_attribute.stderr
@@ -1,6 +1,6 @@
 error: unknown attribute `unknown_attr` for model admin
 
-         = help: valid attributes are: for, name, list_display, list_select_related, list_filter, search_fields, fields, readonly_fields, ordering, list_per_page, allow_view, allow_add, allow_change, allow_delete, permissions
+         = help: valid attributes are: for, name, list_display, list_select_related, date_hierarchy, list_filter, search_fields, fields, readonly_fields, ordering, list_per_page, allow_view, allow_add, allow_change, allow_delete, permissions
  --> tests/ui/admin/fail/unknown_attribute.rs:7:43
   |
 7 | #[admin(model, for = User, name = "User", unknown_attr = "value")]

--- a/crates/reinhardt-core/macros/tests/ui/admin/pass/all_options.rs
+++ b/crates/reinhardt-core/macros/tests/ui/admin/pass/all_options.rs
@@ -8,6 +8,7 @@ struct Profile;
 	for = Profile,
 	name = "Profile",
 	list_display = [id, user_id, bio, location, created_at],
+	date_hierarchy = created_at,
 	search_fields = [user_id, bio, location],
 	list_filter = [created_at, updated_at],
 	ordering = [(created_at, desc)],

--- a/tests/integration/tests/admin/server_fn_helpers.rs
+++ b/tests/integration/tests/admin/server_fn_helpers.rs
@@ -5,7 +5,7 @@
 
 use reinhardt_admin::core::{
 	AdminDatabase, AdminDatabaseKey, AdminError, AdminQuery, AdminRequestContext, AdminSite,
-	AdminSiteKey, AdminUser, ModelAdmin,
+	AdminSiteKey, AdminUser, ListColumn, ModelAdmin,
 };
 use reinhardt_admin::server::{AdminAuthenticatedUser, AdminDefaultUser};
 use reinhardt_core::reactive::ReactiveScope;
@@ -26,6 +26,7 @@ use reinhardt_urls::routers::ServerRouter;
 use rstest::*;
 use serde::{Deserialize, Serialize};
 use sqlx::Executor;
+use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -325,6 +326,10 @@ pub struct AllPermissionsModelAdmin {
 	list_select_related: Vec<String>,
 	queryset_filters: Vec<Filter>,
 	queryset_error: Option<String>,
+	list_columns: Option<Vec<ListColumn>>,
+	date_hierarchy: Option<String>,
+	computed_values: HashMap<String, serde_json::Value>,
+	computed_errors: HashMap<String, String>,
 }
 
 impl AllPermissionsModelAdmin {
@@ -345,6 +350,10 @@ impl AllPermissionsModelAdmin {
 			list_select_related: Vec::new(),
 			queryset_filters: Vec::new(),
 			queryset_error: None,
+			list_columns: None,
+			date_hierarchy: None,
+			computed_values: HashMap::new(),
+			computed_errors: HashMap::new(),
 		}
 	}
 
@@ -360,6 +369,10 @@ impl AllPermissionsModelAdmin {
 			list_select_related: Vec::new(),
 			queryset_filters: Vec::new(),
 			queryset_error: None,
+			list_columns: None,
+			date_hierarchy: None,
+			computed_values: HashMap::new(),
+			computed_errors: HashMap::new(),
 		}
 	}
 
@@ -375,6 +388,10 @@ impl AllPermissionsModelAdmin {
 			list_select_related: vec!["target".to_string()],
 			queryset_filters: Vec::new(),
 			queryset_error: None,
+			list_columns: None,
+			date_hierarchy: None,
+			computed_values: HashMap::new(),
+			computed_errors: HashMap::new(),
 		}
 	}
 
@@ -395,6 +412,30 @@ impl AllPermissionsModelAdmin {
 		self.queryset_error = Some(error.into());
 		self
 	}
+
+	/// Configure owned changelist descriptors for server-function tests.
+	pub fn with_list_columns(mut self, columns: Vec<ListColumn>) -> Self {
+		self.list_columns = Some(columns);
+		self
+	}
+
+	/// Configure date hierarchy metadata for server-function tests.
+	pub fn with_date_hierarchy(mut self, field: impl Into<String>) -> Self {
+		self.date_hierarchy = Some(field.into());
+		self
+	}
+
+	/// Configure a computed changelist value for server-function tests.
+	pub fn with_computed_value(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
+		self.computed_values.insert(key.into(), value);
+		self
+	}
+
+	/// Configure a computed changelist hook failure for server-function tests.
+	pub fn with_computed_error(mut self, key: impl Into<String>, error: impl Into<String>) -> Self {
+		self.computed_errors.insert(key.into(), error.into());
+		self
+	}
 }
 
 #[async_trait::async_trait]
@@ -413,6 +454,37 @@ impl ModelAdmin for AllPermissionsModelAdmin {
 
 	fn list_display(&self) -> Vec<&str> {
 		self.list_display.iter().map(|s| s.as_str()).collect()
+	}
+
+	fn list_columns(&self) -> Vec<ListColumn> {
+		self.list_columns.clone().unwrap_or_else(|| {
+			self.list_display
+				.iter()
+				.map(|field| ListColumn::Field {
+					field: field.clone(),
+					label: reinhardt_utils::utils_core::text::humanize_field_name(field),
+				})
+				.collect()
+		})
+	}
+
+	fn computed_list_value(
+		&self,
+		key: &str,
+		_row: &HashMap<String, serde_json::Value>,
+	) -> Result<serde_json::Value, AdminError> {
+		if let Some(error) = self.computed_errors.get(key) {
+			return Err(AdminError::TemplateError(error.clone()));
+		}
+
+		self.computed_values
+			.get(key)
+			.cloned()
+			.ok_or_else(|| AdminError::TemplateError(format!("No test computed value for '{key}'")))
+	}
+
+	fn date_hierarchy(&self) -> Option<&str> {
+		self.date_hierarchy.as_deref()
 	}
 
 	fn list_filter(&self) -> Vec<&str> {

--- a/tests/integration/tests/admin/server_fn_list_tests.rs
+++ b/tests/integration/tests/admin/server_fn_list_tests.rs
@@ -6,7 +6,9 @@
 use super::server_fn_helpers::{
 	ADMIN_TO_FIELD_SOURCE_MODEL_NAME, AllPermissionsModelAdmin, server_fn_context,
 };
-use reinhardt_admin::adapters::ListQueryParams;
+use reinhardt_admin::adapters::{
+	DateHierarchyLevel, DateHierarchySelection, ListColumn, ListQueryParams,
+};
 use reinhardt_admin::core::{
 	AdminDatabase, AdminDatabaseKey, AdminRecord, AdminSite, AdminSiteKey,
 };
@@ -25,6 +27,19 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::server_fn_helpers::{make_auth_user, make_staff_request};
+
+fn register_date_hierarchy_metadata(
+	table_name: &str,
+	field_type: reinhardt_db::migrations::FieldType,
+) {
+	use reinhardt_db::migrations::model_registry::{FieldMetadata, ModelMetadata, global_registry};
+
+	let mut metadata = ModelMetadata::new("admin_5993", table_name, table_name);
+	metadata
+		.fields
+		.insert("published_on".to_string(), FieldMetadata::new(field_type));
+	global_registry().register_model(metadata);
+}
 
 // ==================== Happy path tests ====================
 
@@ -239,8 +254,8 @@ async fn test_get_list_select_related_uses_custom_to_field_physical_columns() {
 	backend
 		.expect_fetch_all()
 		.withf(|sql, params| {
-			sql == "SELECT \"admin_list_select_related_to_field_sources_5992\".*, COUNT(*) OVER() AS \"__reinhardt_total_count\", \"target\".\"id\" AS \"__reinhardt_related_0__id\", \"target\".\"target_slug_column_5992\" AS \"__reinhardt_related_0__target_slug_column_5992\" FROM \"admin_list_select_related_to_field_sources_5992\" LEFT JOIN \"admin_list_select_related_to_field_targets_5992\" AS \"target\" ON \"admin_list_select_related_to_field_sources_5992\".\"source_target_slug_column_5992\" = \"target\".\"target_slug_column_5992\" ORDER BY \"admin_list_select_related_to_field_sources_5992\".\"id\" DESC LIMIT 25 OFFSET 0"
-				&& params.is_empty()
+			sql == "SELECT \"admin_list_select_related_to_field_sources_5992\".*, COUNT(*) OVER() AS \"__reinhardt_total_count\", \"target\".\"id\" AS \"__reinhardt_related_0__id\", \"target\".\"target_slug_column_5992\" AS \"__reinhardt_related_0__target_slug_column_5992\" FROM \"admin_list_select_related_to_field_sources_5992\" LEFT JOIN \"admin_list_select_related_to_field_targets_5992\" AS \"target\" ON \"admin_list_select_related_to_field_sources_5992\".\"source_target_slug_column_5992\" = \"target\".\"target_slug_column_5992\" ORDER BY \"admin_list_select_related_to_field_sources_5992\".\"id\" DESC LIMIT $1 OFFSET $2"
+				&& params.as_slice() == [QueryValue::Int(25), QueryValue::Int(0)]
 		})
 		.times(1)
 		.returning(|_, _| {
@@ -318,8 +333,269 @@ async fn test_get_list_select_related_uses_custom_to_field_physical_columns() {
 	);
 }
 
+/// Verify computed response metadata/value and the real SQL sort-field mapping.
+#[tokio::test]
+async fn test_get_list_computed_column_maps_sort_to_real_database_field() {
+	// Arrange
+	let mut backend = MockDatabaseBackend::new();
+	backend
+		.expect_database_type()
+		.return_const(DatabaseType::Postgres);
+	backend
+		.expect_fetch_all()
+		.withf(|sql, params| {
+			sql == "SELECT \"admin_computed_columns_5993\".*, COUNT(*) OVER() AS \"__reinhardt_total_count\" FROM \"admin_computed_columns_5993\" ORDER BY \"admin_computed_columns_5993\".\"created_at\" DESC LIMIT $1 OFFSET $2"
+				&& params.as_slice() == [QueryValue::Int(25), QueryValue::Int(0)]
+		})
+		.times(1)
+		.returning(|_, _| {
+			let mut row = Row::new();
+			row.insert("id".to_string(), QueryValue::Int(7));
+			row.insert("created_at".to_string(), QueryValue::String("2024-02-29".to_string()));
+			row.insert("__reinhardt_total_count".to_string(), QueryValue::Int(1));
+			Ok(vec![row])
+		});
+	backend.expect_fetch_one().times(0);
+	let connection = BackendsConnection::new(Arc::new(backend));
+	let connection_lease = DatabaseConnectionLease::register(connection)
+		.expect("Failed to register mock database connection");
+	let db = KeyedDepends::<AdminDatabaseKey, AdminDatabase>::from_value(AdminDatabase::new(
+		connection_lease.handle(),
+	));
+	let site = AdminSite::new("Computed columns admin");
+	site.register(
+		"TestModel",
+		AllPermissionsModelAdmin::test_model("admin_computed_columns_5993")
+			.with_list_columns(vec![
+				ListColumn::Field {
+					field: "id".to_string(),
+					label: "Record ID".to_string(),
+				},
+				ListColumn::Computed {
+					key: "summary".to_string(),
+					label: "Safe summary".to_string(),
+					sort_field: Some("created_at".to_string()),
+				},
+			])
+			.with_computed_value("summary", json!({"text": "<script>safe data</script>"})),
+	)
+	.expect("Failed to register computed columns admin");
+
+	// Act
+	let response = get_list(
+		"TestModel".to_string(),
+		ListQueryParams {
+			sort_by: Some("-summary".to_string()),
+			page: Some(1),
+			page_size: Some(25),
+			..Default::default()
+		},
+		KeyedDepends::<AdminSiteKey, AdminSite>::from_value(site),
+		db,
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await
+	.expect("computed changelist query should succeed");
+
+	// Assert
+	let columns = response
+		.columns
+		.expect("computed column metadata should be returned");
+	assert_eq!(columns.len(), 2);
+	assert_eq!(columns[1].field, "summary");
+	assert_eq!(columns[1].label, "Safe summary");
+	assert!(columns[1].sortable);
+	assert_eq!(
+		response.results[0].get("summary"),
+		Some(&json!({"text": "<script>safe data</script>"}))
+	);
+}
+
+/// Verify computed hook failures expose only a fixed server error.
+#[tokio::test]
+async fn test_get_list_computed_hook_error_is_sanitized() {
+	// Arrange
+	let mut backend = MockDatabaseBackend::new();
+	backend
+		.expect_database_type()
+		.return_const(DatabaseType::Postgres);
+	backend.expect_fetch_all().times(1).returning(|_, _| {
+		let mut row = Row::new();
+		row.insert("id".to_string(), QueryValue::Int(7));
+		row.insert("__reinhardt_total_count".to_string(), QueryValue::Int(1));
+		Ok(vec![row])
+	});
+	backend.expect_fetch_one().times(0);
+	let connection = BackendsConnection::new(Arc::new(backend));
+	let connection_lease = DatabaseConnectionLease::register(connection)
+		.expect("Failed to register mock database connection");
+	let db = KeyedDepends::<AdminDatabaseKey, AdminDatabase>::from_value(AdminDatabase::new(
+		connection_lease.handle(),
+	));
+	let site = AdminSite::new("Failing computed columns admin");
+	site.register(
+		"TestModel",
+		AllPermissionsModelAdmin::test_model("admin_computed_error_5993")
+			.with_list_columns(vec![
+				ListColumn::Field {
+					field: "id".to_string(),
+					label: "ID".to_string(),
+				},
+				ListColumn::Computed {
+					key: "secret".to_string(),
+					label: "Secret".to_string(),
+					sort_field: None,
+				},
+			])
+			.with_computed_error("secret", "internal secret from computed hook"),
+	)
+	.expect("Failed to register failing computed columns admin");
+
+	// Act
+	let error = get_list(
+		"TestModel".to_string(),
+		ListQueryParams {
+			sort_by: None,
+			..Default::default()
+		},
+		KeyedDepends::<AdminSiteKey, AdminSite>::from_value(site),
+		db,
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await
+	.expect_err("computed hook failure should fail the request");
+
+	// Assert
+	assert_eq!(error.status(), Some(500));
+	assert_eq!(error.user_message(), "Failed to compute list column");
+	assert!(!error.user_message().contains("internal secret"));
+}
+
+/// Verify month choices use the same queryset, search, filter, and parent-year scope.
+#[tokio::test]
+#[serial_test::serial(admin_date_hierarchy_5993)]
+async fn test_get_list_date_hierarchy_choices_preserve_full_scope() {
+	// Arrange
+	let table_name = "admin_date_hierarchy_scope_5993";
+	register_date_hierarchy_metadata(table_name, reinhardt_db::migrations::FieldType::Date);
+	let mut backend = MockDatabaseBackend::new();
+	backend
+		.expect_database_type()
+		.return_const(DatabaseType::Postgres);
+	backend
+		.expect_fetch_all()
+		.withf(|sql, params| {
+			sql.starts_with("SELECT \"admin_date_hierarchy_scope_5993\".*, COUNT(*) OVER()")
+				&& sql.contains("\"status\" = $1")
+				&& sql.contains("\"name\" LIKE $2")
+				&& sql.contains("\"description\" LIKE $3")
+				&& sql.contains("\"published_on\" >= CAST($5 AS DATE)")
+				&& sql.contains("\"published_on\" < CAST($6 AS DATE)")
+				&& params.as_slice()
+					== [
+						QueryValue::String("visible".to_string()),
+						QueryValue::String("%needle%".to_string()),
+						QueryValue::String("%needle%".to_string()),
+						QueryValue::String("visible".to_string()),
+						QueryValue::String("2024-01-01".to_string()),
+						QueryValue::String("2025-01-01".to_string()),
+						QueryValue::Int(100),
+						QueryValue::Int(0),
+					]
+		})
+		.times(1)
+		.returning(|_, _| {
+			let mut row = Row::new();
+			row.insert("id".to_string(), QueryValue::Int(9));
+			row.insert("__reinhardt_total_count".to_string(), QueryValue::Int(1));
+			Ok(vec![row])
+		});
+	backend
+		.expect_fetch_all()
+		.withf(|sql, params| {
+			sql.starts_with("SELECT DISTINCT DATE_TRUNC('month', \"published_on\")::date")
+				&& sql.contains("\"status\" = $1")
+				&& sql.contains("\"name\" LIKE $2")
+				&& sql.contains("\"description\" LIKE $3")
+				&& sql.contains("\"published_on\" >= CAST($5 AS DATE)")
+				&& sql.contains("\"published_on\" < CAST($6 AS DATE)")
+				&& sql.ends_with("ORDER BY \"__reinhardt_date_hierarchy\" ASC")
+				&& params.as_slice()
+					== [
+						QueryValue::String("visible".to_string()),
+						QueryValue::String("%needle%".to_string()),
+						QueryValue::String("%needle%".to_string()),
+						QueryValue::String("visible".to_string()),
+						QueryValue::String("2024-01-01".to_string()),
+						QueryValue::String("2025-01-01".to_string()),
+					]
+		})
+		.times(1)
+		.returning(|_, _| {
+			let mut row = Row::new();
+			row.insert(
+				"__reinhardt_date_hierarchy".to_string(),
+				QueryValue::String("2024-02-01".to_string()),
+			);
+			Ok(vec![row])
+		});
+	backend.expect_fetch_one().times(0);
+	let connection = BackendsConnection::new(Arc::new(backend));
+	let connection_lease = DatabaseConnectionLease::register(connection)
+		.expect("Failed to register mock database connection");
+	let db = KeyedDepends::<AdminDatabaseKey, AdminDatabase>::from_value(AdminDatabase::new(
+		connection_lease.handle(),
+	));
+	let site = AdminSite::new("Scoped date hierarchy admin");
+	site.register(
+		"TestModel",
+		AllPermissionsModelAdmin::test_model(table_name)
+			.with_queryset_filter(Filter::new(
+				"status",
+				FilterOperator::Eq,
+				FilterValue::String("visible".to_string()),
+			))
+			.with_date_hierarchy("published_on"),
+	)
+	.expect("Failed to register scoped date hierarchy admin");
+	let mut filters = HashMap::new();
+	filters.insert("status".to_string(), "visible".to_string());
+
+	// Act
+	let response = get_list(
+		"TestModel".to_string(),
+		ListQueryParams {
+			search: Some("needle".to_string()),
+			filters,
+			date_hierarchy: Some(DateHierarchySelection {
+				year: Some(2024),
+				month: None,
+				day: None,
+			}),
+			..Default::default()
+		},
+		KeyedDepends::<AdminSiteKey, AdminSite>::from_value(site),
+		db,
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await
+	.expect("scoped hierarchy query should succeed");
+
+	// Assert
+	let hierarchy = response
+		.date_hierarchy
+		.expect("hierarchy metadata should be returned");
+	assert_eq!(hierarchy.field, "published_on");
+	assert_eq!(hierarchy.next_level, Some(DateHierarchyLevel::Month));
+	assert_eq!(hierarchy.choices, vec![2]);
+}
+
 /// Verify that invalid related configuration and hook errors perform no database query.
 #[tokio::test]
+#[serial_test::serial(admin_date_hierarchy_5993)]
 async fn test_get_list_configuration_errors_perform_zero_database_queries() {
 	// Arrange
 	let mut backend = MockDatabaseBackend::new();
@@ -365,6 +641,117 @@ async fn test_get_list_configuration_errors_perform_zero_database_queries() {
 	let hook_error = get_list(
 		"TestModel".to_string(),
 		ListQueryParams::default(),
+		site.clone(),
+		db.clone(),
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await;
+	site.unregister("TestModel")
+		.expect("Failed to unregister failing TestModel admin");
+	site.register(
+		"TestModel",
+		AllPermissionsModelAdmin::test_model("missing_admin_table").with_list_columns(vec![
+			ListColumn::Field {
+				field: "id".to_string(),
+				label: "ID".to_string(),
+			},
+			ListColumn::Computed {
+				key: "badge".to_string(),
+				label: "Badge".to_string(),
+				sort_field: None,
+			},
+		]),
+	)
+	.expect("Failed to register unmapped computed sort admin");
+	let unmapped_sort = get_list(
+		"TestModel".to_string(),
+		ListQueryParams {
+			sort_by: Some("badge".to_string()),
+			..Default::default()
+		},
+		site.clone(),
+		db.clone(),
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await;
+	register_date_hierarchy_metadata(
+		"admin_invalid_hierarchy_type_5993",
+		reinhardt_db::migrations::FieldType::VarChar(50),
+	);
+	site.unregister("TestModel")
+		.expect("Failed to unregister computed sort admin");
+	site.register(
+		"TestModel",
+		AllPermissionsModelAdmin::test_model("admin_invalid_hierarchy_type_5993")
+			.with_date_hierarchy("published_on"),
+	)
+	.expect("Failed to register invalid hierarchy type admin");
+	let invalid_hierarchy_type = get_list(
+		"TestModel".to_string(),
+		ListQueryParams::default(),
+		site.clone(),
+		db.clone(),
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await;
+	site.unregister("TestModel")
+		.expect("Failed to unregister invalid hierarchy type admin");
+	site.register(
+		"TestModel",
+		AllPermissionsModelAdmin::test_model("missing_admin_table")
+			.with_date_hierarchy("published_on"),
+	)
+	.expect("Failed to register missing hierarchy field admin");
+	let missing_hierarchy_field = get_list(
+		"TestModel".to_string(),
+		ListQueryParams::default(),
+		site.clone(),
+		db.clone(),
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await;
+	register_date_hierarchy_metadata(
+		"admin_invalid_hierarchy_selection_5993",
+		reinhardt_db::migrations::FieldType::Date,
+	);
+	site.unregister("TestModel")
+		.expect("Failed to unregister missing hierarchy field admin");
+	site.register(
+		"TestModel",
+		AllPermissionsModelAdmin::test_model("admin_invalid_hierarchy_selection_5993")
+			.with_date_hierarchy("published_on"),
+	)
+	.expect("Failed to register invalid hierarchy selection admin");
+	let invalid_hierarchy_selection = get_list(
+		"TestModel".to_string(),
+		ListQueryParams {
+			date_hierarchy: Some(DateHierarchySelection {
+				year: None,
+				month: Some(2),
+				day: None,
+			}),
+			..Default::default()
+		},
+		site.clone(),
+		db.clone(),
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await;
+	let invalid_hierarchy_boundary = get_list(
+		"TestModel".to_string(),
+		ListQueryParams {
+			date_hierarchy: Some(DateHierarchySelection {
+				year: Some(262_142),
+				month: Some(12),
+				day: Some(31),
+			}),
+			..Default::default()
+		},
 		site,
 		db,
 		make_staff_request(),
@@ -381,6 +768,36 @@ async fn test_get_list_configuration_errors_perform_zero_database_queries() {
 	);
 	let hook_error = hook_error.expect_err("queryset hook error should fail the request");
 	assert!(hook_error.to_string().contains("queryset hook failed"));
+	assert_eq!(
+		unmapped_sort
+			.expect_err("unmapped computed sort should fail before database access")
+			.status(),
+		Some(400)
+	);
+	assert_eq!(
+		invalid_hierarchy_type
+			.expect_err("invalid hierarchy type should fail before database access")
+			.status(),
+		Some(400)
+	);
+	assert_eq!(
+		missing_hierarchy_field
+			.expect_err("missing hierarchy field should fail before database access")
+			.status(),
+		Some(400)
+	);
+	assert_eq!(
+		invalid_hierarchy_selection
+			.expect_err("invalid hierarchy selection should fail before database access")
+			.status(),
+		Some(400)
+	);
+	assert_eq!(
+		invalid_hierarchy_boundary
+			.expect_err("invalid hierarchy boundary should fail before database access")
+			.status(),
+		Some(400)
+	);
 }
 
 /// Verify that descending sort with "-" prefix works

--- a/tests/integration/tests/admin/server_fn_list_tests.rs
+++ b/tests/integration/tests/admin/server_fn_list_tests.rs
@@ -15,14 +15,18 @@ use reinhardt_admin::core::{
 use reinhardt_admin::server::get_list;
 use reinhardt_db::backends::{
 	connection::DatabaseConnection as BackendsConnection,
+	dialect::PostgresBackend,
 	types::{DatabaseType, QueryValue, Row},
 };
 use reinhardt_db::orm::connection::DatabaseConnectionLease;
 use reinhardt_db::orm::{Filter, FilterOperator, FilterValue};
 use reinhardt_di::KeyedDepends;
 use reinhardt_test::fixtures::mock::MockDatabaseBackend;
+use reinhardt_test::fixtures::shared_postgres::shared_db_pool;
 use rstest::*;
 use serde_json::json;
+use sqlx::Executor;
+use sqlx::postgres::PgPoolOptions;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -591,6 +595,105 @@ async fn test_get_list_date_hierarchy_choices_preserve_full_scope() {
 	assert_eq!(hierarchy.field, "published_on");
 	assert_eq!(hierarchy.next_level, Some(DateHierarchyLevel::Month));
 	assert_eq!(hierarchy.choices, vec![2]);
+}
+
+/// Verify naive datetime hierarchy bounds and choices do not depend on session timezone.
+#[rstest]
+#[tokio::test]
+#[serial_test::serial(admin_date_hierarchy_5993)]
+async fn test_get_list_datetime_hierarchy_preserves_naive_calendar_in_non_utc_session(
+	#[future] shared_db_pool: (sqlx::PgPool, String),
+) {
+	// Arrange
+	let (_fixture_pool, database_url) = shared_db_pool.await;
+	let pool = PgPoolOptions::new()
+		.max_connections(2)
+		.after_connect(|connection, _| {
+			Box::pin(async move {
+				sqlx::query("SET TIME ZONE 'America/Los_Angeles'")
+					.execute(&mut *connection)
+					.await?;
+				Ok(())
+			})
+		})
+		.connect(&database_url)
+		.await
+		.expect("Failed to create non-UTC PostgreSQL pool");
+	let timezone = sqlx::query_scalar::<_, String>("SHOW TIME ZONE")
+		.fetch_one(&pool)
+		.await
+		.expect("Failed to read PostgreSQL session timezone");
+	assert_eq!(timezone, "America/Los_Angeles");
+
+	let table_name = "admin_datetime_hierarchy_timezone_5993";
+	pool.execute(
+		"CREATE TABLE admin_datetime_hierarchy_timezone_5993 (\
+			id BIGSERIAL PRIMARY KEY, \
+			published_on TIMESTAMP WITHOUT TIME ZONE NOT NULL\
+		)",
+	)
+	.await
+	.expect("Failed to create naive datetime hierarchy table");
+	let previous_year = chrono::NaiveDate::from_ymd_opt(2023, 12, 31)
+		.unwrap()
+		.and_hms_opt(23, 30, 0)
+		.unwrap();
+	let selected_year = chrono::NaiveDate::from_ymd_opt(2024, 1, 1)
+		.unwrap()
+		.and_hms_opt(0, 30, 0)
+		.unwrap();
+	sqlx::query(
+		"INSERT INTO admin_datetime_hierarchy_timezone_5993 (published_on) VALUES ($1), ($2)",
+	)
+	.bind(previous_year)
+	.bind(selected_year)
+	.execute(&pool)
+	.await
+	.expect("Failed to insert naive datetime hierarchy rows");
+	register_date_hierarchy_metadata(table_name, reinhardt_db::migrations::FieldType::DateTime);
+
+	let backend = Arc::new(PostgresBackend::new(pool));
+	let connection = BackendsConnection::new(backend);
+	let connection_lease = DatabaseConnectionLease::register(connection)
+		.expect("Failed to register non-UTC database connection");
+	let db = KeyedDepends::<AdminDatabaseKey, AdminDatabase>::from_value(AdminDatabase::new(
+		connection_lease.handle(),
+	));
+	let site = AdminSite::new("Naive datetime hierarchy admin");
+	site.register(
+		"TestModel",
+		AllPermissionsModelAdmin::test_model(table_name).with_date_hierarchy("published_on"),
+	)
+	.expect("Failed to register naive datetime hierarchy admin");
+
+	// Act
+	let response = get_list(
+		"TestModel".to_string(),
+		ListQueryParams {
+			date_hierarchy: Some(DateHierarchySelection {
+				year: Some(2024),
+				month: None,
+				day: None,
+			}),
+			..Default::default()
+		},
+		KeyedDepends::<AdminSiteKey, AdminSite>::from_value(site),
+		db,
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await
+	.expect("naive datetime hierarchy should be independent of session timezone");
+
+	// Assert
+	assert_eq!(response.count, 1);
+	assert_eq!(response.results.len(), 1);
+	assert_eq!(response.results[0].get("id"), Some(&json!(2)));
+	let hierarchy = response
+		.date_hierarchy
+		.expect("naive datetime hierarchy metadata should be returned");
+	assert_eq!(hierarchy.next_level, Some(DateHierarchyLevel::Month));
+	assert_eq!(hierarchy.choices, vec![1]);
 }
 
 /// Verify that invalid related configuration and hook errors perform no database query.

--- a/tests/integration/tests/admin/server_fn_list_tests.rs
+++ b/tests/integration/tests/admin/server_fn_list_tests.rs
@@ -49,8 +49,10 @@ fn register_date_hierarchy_metadata_with_column(
 
 	let mut metadata = ModelMetadata::new("admin_5993", table_name, table_name);
 	metadata.fields.insert(
-		"published_on".to_string(),
-		FieldMetadata::new(field_type).with_param("db_column", db_column),
+		db_column.to_string(),
+		FieldMetadata::new(field_type)
+			.with_param("field_name", "published_on")
+			.with_param("db_column", db_column),
 	);
 	global_registry().register_model(metadata);
 }

--- a/tests/integration/tests/admin/server_fn_list_tests.rs
+++ b/tests/integration/tests/admin/server_fn_list_tests.rs
@@ -7,12 +7,13 @@ use super::server_fn_helpers::{
 	ADMIN_TO_FIELD_SOURCE_MODEL_NAME, AllPermissionsModelAdmin, server_fn_context,
 };
 use reinhardt_admin::adapters::{
-	DateHierarchyLevel, DateHierarchySelection, ListColumn, ListQueryParams,
+	DateHierarchyLevel, DateHierarchyListQueryParams, DateHierarchySelection, ListColumn,
+	ListQueryParams,
 };
 use reinhardt_admin::core::{
 	AdminDatabase, AdminDatabaseKey, AdminRecord, AdminSite, AdminSiteKey,
 };
-use reinhardt_admin::server::get_list;
+use reinhardt_admin::server::{get_list, get_list_with_date_hierarchy};
 use reinhardt_db::backends::{
 	connection::DatabaseConnection as BackendsConnection,
 	dialect::PostgresBackend,
@@ -36,12 +37,21 @@ fn register_date_hierarchy_metadata(
 	table_name: &str,
 	field_type: reinhardt_db::migrations::FieldType,
 ) {
+	register_date_hierarchy_metadata_with_column(table_name, field_type, "published_on");
+}
+
+fn register_date_hierarchy_metadata_with_column(
+	table_name: &str,
+	field_type: reinhardt_db::migrations::FieldType,
+	db_column: &str,
+) {
 	use reinhardt_db::migrations::model_registry::{FieldMetadata, ModelMetadata, global_registry};
 
 	let mut metadata = ModelMetadata::new("admin_5993", table_name, table_name);
-	metadata
-		.fields
-		.insert("published_on".to_string(), FieldMetadata::new(field_type));
+	metadata.fields.insert(
+		"published_on".to_string(),
+		FieldMetadata::new(field_type).with_param("db_column", db_column),
+	);
 	global_registry().register_model(metadata);
 }
 
@@ -568,17 +578,19 @@ async fn test_get_list_date_hierarchy_choices_preserve_full_scope() {
 	filters.insert("status".to_string(), "visible".to_string());
 
 	// Act
-	let response = get_list(
+	let response = get_list_with_date_hierarchy(
 		"TestModel".to_string(),
-		ListQueryParams {
-			search: Some("needle".to_string()),
-			filters,
+		DateHierarchyListQueryParams {
+			list: ListQueryParams {
+				search: Some("needle".to_string()),
+				filters,
+				..Default::default()
+			},
 			date_hierarchy: Some(DateHierarchySelection {
 				year: Some(2024),
 				month: None,
 				day: None,
 			}),
-			..Default::default()
 		},
 		KeyedDepends::<AdminSiteKey, AdminSite>::from_value(site),
 		db,
@@ -595,6 +607,207 @@ async fn test_get_list_date_hierarchy_choices_preserve_full_scope() {
 	assert_eq!(hierarchy.field, "published_on");
 	assert_eq!(hierarchy.next_level, Some(DateHierarchyLevel::Month));
 	assert_eq!(hierarchy.choices, vec![2]);
+}
+
+/// Verify logical date hierarchy fields resolve to their physical db_column names in SQL.
+#[tokio::test]
+#[serial_test::serial(admin_date_hierarchy_5993)]
+async fn test_get_list_date_hierarchy_uses_custom_db_columns_for_date_and_datetime() {
+	// Arrange
+	let date_table = "admin_date_hierarchy_db_column_date_5993";
+	let date_column = "published_date_column_5993";
+	let datetime_table = "admin_date_hierarchy_db_column_datetime_5993";
+	let datetime_column = "published_datetime_column_5993";
+	register_date_hierarchy_metadata_with_column(
+		date_table,
+		reinhardt_db::migrations::FieldType::Date,
+		date_column,
+	);
+	register_date_hierarchy_metadata_with_column(
+		datetime_table,
+		reinhardt_db::migrations::FieldType::DateTime,
+		datetime_column,
+	);
+	let start = chrono::NaiveDate::from_ymd_opt(2024, 1, 1)
+		.unwrap()
+		.and_hms_opt(0, 0, 0)
+		.unwrap();
+	let end = chrono::NaiveDate::from_ymd_opt(2025, 1, 1)
+		.unwrap()
+		.and_hms_opt(0, 0, 0)
+		.unwrap();
+	let mut backend = MockDatabaseBackend::new();
+	backend
+		.expect_database_type()
+		.return_const(DatabaseType::Postgres);
+	backend
+		.expect_fetch_all()
+		.withf(move |sql, params| {
+			sql.contains(&format!("FROM \"{date_table}\""))
+				&& sql.contains(&format!("\"{date_column}\" >= CAST($1 AS DATE)"))
+				&& sql.contains(&format!("\"{date_column}\" < CAST($2 AS DATE)"))
+				&& !sql.contains("\"published_on\"")
+				&& params.as_slice()
+					== [
+						QueryValue::String("2024-01-01".to_string()),
+						QueryValue::String("2025-01-01".to_string()),
+						QueryValue::Int(100),
+						QueryValue::Int(0),
+					]
+		})
+		.times(1)
+		.returning(|_, _| {
+			let mut row = Row::new();
+			row.insert("id".to_string(), QueryValue::Int(1));
+			row.insert(
+				"published_date_column_5993".to_string(),
+				QueryValue::String("2024-02-01".to_string()),
+			);
+			row.insert("__reinhardt_total_count".to_string(), QueryValue::Int(1));
+			Ok(vec![row])
+		});
+	backend
+		.expect_fetch_all()
+		.withf(move |sql, params| {
+			sql.starts_with(&format!(
+				"SELECT DISTINCT DATE_TRUNC('month', \"{date_column}\")::date"
+			)) && sql.contains(&format!("\"{date_column}\" IS NOT NULL"))
+				&& sql.contains(&format!("\"{date_column}\" >= CAST($1 AS DATE)"))
+				&& sql.contains(&format!("\"{date_column}\" < CAST($2 AS DATE)"))
+				&& !sql.contains("\"published_on\"")
+				&& params.as_slice()
+					== [
+						QueryValue::String("2024-01-01".to_string()),
+						QueryValue::String("2025-01-01".to_string()),
+					]
+		})
+		.times(1)
+		.returning(|_, _| {
+			let mut row = Row::new();
+			row.insert(
+				"__reinhardt_date_hierarchy".to_string(),
+				QueryValue::String("2024-02-01".to_string()),
+			);
+			Ok(vec![row])
+		});
+	backend
+		.expect_fetch_all()
+		.withf(move |sql, params| {
+			sql.contains(&format!("FROM \"{datetime_table}\""))
+				&& sql.contains(&format!("\"{datetime_column}\" >= $1"))
+				&& sql.contains(&format!("\"{datetime_column}\" < $2"))
+				&& !sql.contains("\"published_on\"")
+				&& params.as_slice()
+					== [
+						QueryValue::NaiveTimestamp(start),
+						QueryValue::NaiveTimestamp(end),
+						QueryValue::Int(100),
+						QueryValue::Int(0),
+					]
+		})
+		.times(1)
+		.returning(|_, _| {
+			let mut row = Row::new();
+			row.insert("id".to_string(), QueryValue::Int(2));
+			row.insert(
+				"published_datetime_column_5993".to_string(),
+				QueryValue::String("2024-02-01 00:00:00".to_string()),
+			);
+			row.insert("__reinhardt_total_count".to_string(), QueryValue::Int(1));
+			Ok(vec![row])
+		});
+	backend
+		.expect_fetch_all()
+		.withf(move |sql, params| {
+			sql.starts_with(&format!(
+				"SELECT DISTINCT DATE_TRUNC('month', \"{datetime_column}\")::date"
+			)) && sql.contains(&format!("\"{datetime_column}\" IS NOT NULL"))
+				&& sql.contains(&format!("\"{datetime_column}\" >= $1"))
+				&& sql.contains(&format!("\"{datetime_column}\" < $2"))
+				&& !sql.contains("\"published_on\"")
+				&& params.as_slice()
+					== [
+						QueryValue::NaiveTimestamp(start),
+						QueryValue::NaiveTimestamp(end),
+					]
+		})
+		.times(1)
+		.returning(|_, _| {
+			let mut row = Row::new();
+			row.insert(
+				"__reinhardt_date_hierarchy".to_string(),
+				QueryValue::String("2024-02-01".to_string()),
+			);
+			Ok(vec![row])
+		});
+	backend.expect_fetch_one().times(0);
+	let connection = BackendsConnection::new(Arc::new(backend));
+	let connection_lease = DatabaseConnectionLease::register(connection)
+		.expect("Failed to register custom db_column database connection");
+	let db = KeyedDepends::<AdminDatabaseKey, AdminDatabase>::from_value(AdminDatabase::new(
+		connection_lease.handle(),
+	));
+	let site = AdminSite::new("Custom date hierarchy columns admin");
+	site.register(
+		"DateModel",
+		AllPermissionsModelAdmin::test_model(date_table).with_date_hierarchy("published_on"),
+	)
+	.expect("Failed to register custom Date hierarchy admin");
+	site.register(
+		"DateTimeModel",
+		AllPermissionsModelAdmin::test_model(datetime_table).with_date_hierarchy("published_on"),
+	)
+	.expect("Failed to register custom DateTime hierarchy admin");
+
+	// Act
+	let date_response = get_list_with_date_hierarchy(
+		"DateModel".to_string(),
+		DateHierarchyListQueryParams {
+			list: ListQueryParams::default(),
+			date_hierarchy: Some(DateHierarchySelection {
+				year: Some(2024),
+				month: None,
+				day: None,
+			}),
+		},
+		KeyedDepends::<AdminSiteKey, AdminSite>::from_value(site.clone()),
+		db.clone(),
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await
+	.expect("custom Date db_column hierarchy should succeed");
+	let datetime_response = get_list_with_date_hierarchy(
+		"DateTimeModel".to_string(),
+		DateHierarchyListQueryParams {
+			list: ListQueryParams::default(),
+			date_hierarchy: Some(DateHierarchySelection {
+				year: Some(2024),
+				month: None,
+				day: None,
+			}),
+		},
+		KeyedDepends::<AdminSiteKey, AdminSite>::from_value(site),
+		db,
+		make_staff_request(),
+		make_auth_user(),
+	)
+	.await
+	.expect("custom DateTime db_column hierarchy should succeed");
+
+	// Assert
+	assert_eq!(date_response.response.count, 1);
+	let date_hierarchy = date_response
+		.date_hierarchy
+		.expect("Date hierarchy metadata should be returned");
+	assert_eq!(date_hierarchy.field, "published_on");
+	assert_eq!(date_hierarchy.choices, vec![2]);
+	assert_eq!(datetime_response.response.count, 1);
+	let datetime_hierarchy = datetime_response
+		.date_hierarchy
+		.expect("DateTime hierarchy metadata should be returned");
+	assert_eq!(datetime_hierarchy.field, "published_on");
+	assert_eq!(datetime_hierarchy.choices, vec![2]);
 }
 
 /// Verify naive datetime hierarchy bounds and choices do not depend on session timezone.
@@ -667,15 +880,15 @@ async fn test_get_list_datetime_hierarchy_preserves_naive_calendar_in_non_utc_se
 	.expect("Failed to register naive datetime hierarchy admin");
 
 	// Act
-	let response = get_list(
+	let response = get_list_with_date_hierarchy(
 		"TestModel".to_string(),
-		ListQueryParams {
+		DateHierarchyListQueryParams {
+			list: ListQueryParams::default(),
 			date_hierarchy: Some(DateHierarchySelection {
 				year: Some(2024),
 				month: None,
 				day: None,
 			}),
-			..Default::default()
 		},
 		KeyedDepends::<AdminSiteKey, AdminSite>::from_value(site),
 		db,
@@ -686,9 +899,9 @@ async fn test_get_list_datetime_hierarchy_preserves_naive_calendar_in_non_utc_se
 	.expect("naive datetime hierarchy should be independent of session timezone");
 
 	// Assert
-	assert_eq!(response.count, 1);
-	assert_eq!(response.results.len(), 1);
-	assert_eq!(response.results[0].get("id"), Some(&json!(2)));
+	assert_eq!(response.response.count, 1);
+	assert_eq!(response.response.results.len(), 1);
+	assert_eq!(response.response.results[0].get("id"), Some(&json!(2)));
 	let hierarchy = response
 		.date_hierarchy
 		.expect("naive datetime hierarchy metadata should be returned");
@@ -791,9 +1004,9 @@ async fn test_get_list_configuration_errors_perform_zero_database_queries() {
 			.with_date_hierarchy("published_on"),
 	)
 	.expect("Failed to register invalid hierarchy type admin");
-	let invalid_hierarchy_type = get_list(
+	let invalid_hierarchy_type = get_list_with_date_hierarchy(
 		"TestModel".to_string(),
-		ListQueryParams::default(),
+		DateHierarchyListQueryParams::default(),
 		site.clone(),
 		db.clone(),
 		make_staff_request(),
@@ -808,9 +1021,9 @@ async fn test_get_list_configuration_errors_perform_zero_database_queries() {
 			.with_date_hierarchy("published_on"),
 	)
 	.expect("Failed to register missing hierarchy field admin");
-	let missing_hierarchy_field = get_list(
+	let missing_hierarchy_field = get_list_with_date_hierarchy(
 		"TestModel".to_string(),
-		ListQueryParams::default(),
+		DateHierarchyListQueryParams::default(),
 		site.clone(),
 		db.clone(),
 		make_staff_request(),
@@ -829,15 +1042,15 @@ async fn test_get_list_configuration_errors_perform_zero_database_queries() {
 			.with_date_hierarchy("published_on"),
 	)
 	.expect("Failed to register invalid hierarchy selection admin");
-	let invalid_hierarchy_selection = get_list(
+	let invalid_hierarchy_selection = get_list_with_date_hierarchy(
 		"TestModel".to_string(),
-		ListQueryParams {
+		DateHierarchyListQueryParams {
+			list: ListQueryParams::default(),
 			date_hierarchy: Some(DateHierarchySelection {
 				year: None,
 				month: Some(2),
 				day: None,
 			}),
-			..Default::default()
 		},
 		site.clone(),
 		db.clone(),
@@ -845,15 +1058,15 @@ async fn test_get_list_configuration_errors_perform_zero_database_queries() {
 		make_auth_user(),
 	)
 	.await;
-	let invalid_hierarchy_boundary = get_list(
+	let invalid_hierarchy_boundary = get_list_with_date_hierarchy(
 		"TestModel".to_string(),
-		ListQueryParams {
+		DateHierarchyListQueryParams {
+			list: ListQueryParams::default(),
 			date_hierarchy: Some(DateHierarchySelection {
 				year: Some(262_142),
 				month: Some(12),
 				day: Some(31),
 			}),
-			..Default::default()
 		},
 		site,
 		db,

--- a/tests/integration/tests/macros/model_derive_integration.rs
+++ b/tests/integration/tests/macros/model_derive_integration.rs
@@ -677,6 +677,26 @@ fn test_model_registration() {
 }
 
 #[test]
+fn test_model_registry_preserves_logical_name_for_custom_column() {
+	let model = global_registry()
+		.get_model("traversal_test", "TraversalAuthor")
+		.expect("TraversalAuthor should be registered in global registry");
+	let field = model
+		.fields
+		.get("email_address")
+		.expect("custom physical column should be the registry key");
+
+	assert_eq!(
+		field.params.get("field_name").map(String::as_str),
+		Some("email")
+	);
+	assert_eq!(
+		field.params.get("db_column").map(String::as_str),
+		Some("email_address")
+	);
+}
+
+#[test]
 fn test_fixture_handler_registration_supports_derive_before_model() {
 	let handler = global_fixture_registry().get("test_app.TestUser");
 


### PR DESCRIPTION
## Summary

This PR addresses:

- date hierarchy navigation for year, month, and day selections with validated half-open date ranges
- computed list columns with stable keys, labels, safe values, and real-field sort mapping
- reactive hierarchy navigation with pagination reset and latest-request rendering guards
- legacy list DTO/API compatibility through a versioned date-hierarchy request/response endpoint

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Admin changelists need calendar drill-downs and display columns whose values are computed outside the database. The implementation composes date constraints into the scoped #5992 query, rejects invalid calendar selections before querying, and allows sorting only through declared database fields. Legacy list request/response shapes remain available while the frontend uses the versioned hierarchy endpoint.

Fixes #5993

Related to: #5992
Related to: #5808

## How Was This Tested?

- `cargo test -p reinhardt-admin --lib --all-features` (543 passed before the final macOS dyld harness stall; final source recompiled successfully)
- `cargo test -p reinhardt-integration-tests --test admin server_fn_list_tests -- --nocapture` (21 passed)
- `cargo test -p reinhardt-integration-tests --test macros model_derive_integration -- --nocapture` (20 passed)
- `cargo clippy -p reinhardt-admin --lib --all-features --no-deps -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p reinhardt-admin --no-deps --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

The wasm32 check remains blocked by two pre-existing errors outside this change: the existing `reinhardt_pages::MountError` root import and the wasm-side `reinhardt_db` dependency reference.

## Performance Impact

-

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [x] I have checked the code with `cargo clippy -p reinhardt-admin --lib --all-features --no-deps -- -D warnings`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5992
- #5808

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement
- [ ] `bug` - Bug fix
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [x] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes
- [ ] `database` - migration metadata compatibility

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor priority

---

**Additional Context:**

This PR depends on #5992 and targets its feature branch so the date hierarchy and computed-column behavior can be reviewed as the next stack layer. The PR is Draft while CI runs the integration coverage that cannot launch reliably on the local macOS test harness.

🤖 Generated with [Codex](https://openai.com/codex)
