### PR TITLE
ci(test): isolate nested UI test targets

### DIFF
--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -147,9 +147,10 @@ jobs:
           RUN_ALL: ${{ inputs.run-all }}
           PARTITION_COUNT: ${{ inputs.partition-count || '5' }}
         run: |
-          FILTER_ARGS=()
           if [[ "$RUN_ALL" != "true" && -n "$NEXTEST_FILTER_EXPR" ]]; then
-            FILTER_ARGS+=(-E "$NEXTEST_FILTER_EXPR")
+            FILTER_EXPR="(not binary(/ui/)) & ($NEXTEST_FILTER_EXPR)"
+          else
+            FILTER_EXPR="not binary(/ui/)"
           fi
           cargo nextest run \
             --package reinhardt-integration-tests \
@@ -159,7 +160,7 @@ jobs:
             --no-tests=warn \
             --status-level=none \
             --final-status-level=none \
-            "${FILTER_ARGS[@]}"
+            -E "$FILTER_EXPR"
 
       - name: Docker cleanup after tests
         if: always()

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -429,6 +429,7 @@ args = [
   "--package",
   "reinhardt-integration-tests",
   "--all-features",
+  "-E", "not binary(/ui/)",
   "--no-fail-fast",
   "--status-level=none",
   "--final-status-level=none"

--- a/tests/integration/tests/di.rs
+++ b/tests/integration/tests/di.rs
@@ -60,7 +60,3 @@ mod provider_tests;
 
 #[path = "di/registry_tests.rs"]
 mod registry_tests;
-
-// Compile-time validation tests (trybuild)
-#[path = "di/ui.rs"]
-mod ui;

--- a/tests/integration/tests/di_ui.rs
+++ b/tests/integration/tests/di_ui.rs
@@ -1,0 +1,7 @@
+//! DI macro compile-time integration tests.
+//!
+//! This standalone test target keeps trybuild cases on the dedicated UI-test
+//! profile instead of the default cross-crate integration-test profile.
+
+#[path = "di/ui.rs"]
+mod ui;

--- a/tests/integration/tests/macros.rs
+++ b/tests/integration/tests/macros.rs
@@ -10,9 +10,6 @@ mod constraint_integration;
 #[path = "macros/http_error_integration.rs"]
 mod http_error_integration;
 
-#[path = "macros/http_error_ui.rs"]
-mod http_error_ui;
-
 #[path = "macros/model_derive_integration.rs"]
 mod model_derive_integration;
 
@@ -33,6 +30,3 @@ mod repro_issue_4522;
 
 #[path = "macros/model_info_integration.rs"]
 mod model_info_integration;
-
-#[path = "macros/model_info_ui.rs"]
-mod model_info_ui;

--- a/tests/integration/tests/macros_ui.rs
+++ b/tests/integration/tests/macros_ui.rs
@@ -1,0 +1,10 @@
+//! Macro compile-time integration tests.
+//!
+//! This standalone test target keeps trybuild cases on the dedicated UI-test
+//! profile instead of the default cross-crate integration-test profile.
+
+#[path = "macros/http_error_ui.rs"]
+mod http_error_ui;
+
+#[path = "macros/model_info_ui.rs"]
+mod model_info_ui;

--- a/tests/integration/tests/orm.rs
+++ b/tests/integration/tests/orm.rs
@@ -30,9 +30,3 @@ mod proxy_advanced_features;
 
 #[path = "orm/proxy_orm_integration.rs"]
 mod proxy_orm_integration;
-
-#[path = "orm/custom_manager_ui.rs"]
-mod custom_manager_ui;
-
-#[path = "orm/queryset_docs_ui.rs"]
-mod queryset_docs_ui;

--- a/tests/integration/tests/orm_ui.rs
+++ b/tests/integration/tests/orm_ui.rs
@@ -1,0 +1,10 @@
+//! ORM compile-time integration tests.
+//!
+//! This standalone test target keeps trybuild cases on the dedicated UI-test
+//! profile instead of the default cross-crate integration-test profile.
+
+#[path = "orm/custom_manager_ui.rs"]
+mod custom_manager_ui;
+
+#[path = "orm/queryset_docs_ui.rs"]
+mod queryset_docs_ui;

--- a/tests/integration/tests/settings.rs
+++ b/tests/integration/tests/settings.rs
@@ -13,8 +13,5 @@ mod composable_use_cases;
 #[path = "settings/composable_macro_pass.rs"]
 mod composable_macro_pass;
 
-#[path = "settings/schema_trybuild.rs"]
-mod schema_trybuild;
-
 #[path = "settings/jwt_secret_settings.rs"]
 mod jwt_secret_settings;

--- a/tests/integration/tests/settings_ui.rs
+++ b/tests/integration/tests/settings_ui.rs
@@ -1,0 +1,7 @@
+//! Settings compile-time integration tests.
+//!
+//! This standalone test target keeps trybuild cases on the dedicated UI-test
+//! profile instead of the default cross-crate integration-test profile.
+
+#[path = "settings/schema_trybuild.rs"]
+mod schema_trybuild;


### PR DESCRIPTION
## Summary

This PR addresses:

- Moves nested DI, macro, ORM, and settings trybuild modules into standalone `*_ui` integration-test binaries.
- Lets the existing `binary(/ui/)` filter exclude those tests from the default cross-crate workflow and run them through the serial UI-test profile.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

Nextest filters match binary identifiers. Nested UI modules inherit their parent integration-test binary name and therefore bypass the UI filter. Dedicated `*_ui` targets give every trybuild suite a matching binary identifier.

Fixes #6009

## How Was This Tested?

- [x] `CARGO_BUILD_JOBS=1 cargo check --package reinhardt-integration-tests --all-features --test di_ui --test macros_ui --test orm_ui --test settings_ui`
- [x] `cargo nextest list --package reinhardt-integration-tests --all-features --test di_ui --test macros_ui --test orm_ui --test settings_ui -E "binary(/ui/)"`
- [x] `cargo fmt --all -- --check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #6009

## Labels to Apply

- [x] `bug`
- [x] `ci-cd`

🤖 Generated with [Codex](https://openai.com/codex)