### PR TITLE
fix(examples): format tutorial session auth imports

### DIFF
--- a/examples/examples-tutorial-basis/src/config/session_auth.rs
+++ b/examples/examples-tutorial-basis/src/config/session_auth.rs
@@ -86,8 +86,8 @@ impl Middleware for TutorialSessionAuthMiddleware {
 
 #[cfg(test)]
 mod tests {
-	use crate::apps::users::models::User;
 	use super::TutorialSessionAuthMiddleware;
+	use crate::apps::users::models::User;
 	use reinhardt::core::async_trait;
 	use reinhardt::db::migrations::executor::DatabaseMigrationExecutor;
 	use reinhardt::di::{InjectionContext, SingletonScope};


### PR DESCRIPTION
## Summary

This PR addresses:

- Formats the standalone tutorial session-auth example so the examples formatter passes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The Examples Tests workflow reported one file that would be reformatted, so the release PR could not pass its example quality gate. This change applies the required import ordering.

## How Was This Tested?

- `cd examples/examples-tutorial-basis && cargo make fmt-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (not applicable to this format-only change)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective (format-only change)
- [ ] New and existing unit tests pass locally with my changes (format-only change)
- [ ] I have tested with all affected database backends (not applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check` (format-only change)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #6016

## Labels to Apply

### Type Label
- [x] `code-quality` - Code quality improvements

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes
- [x] `examples` - Example projects and demo applications

🤖 Generated with [Codex](https://openai.com/codex)