### PR TITLE
fix(security): track smartstring advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ ignore = [
   { id = "RUSTSEC-2024-0320", reason = "yaml-rust is retained by transitive configuration dependencies; remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.31 is retained by Azure SDK dependencies and quick-xml 0.38 remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2026-0195", reason = "quick-xml 0.31 is retained by Azure SDK dependencies and quick-xml 0.38 remediation is tracked in issue #5492." },
+  { id = "RUSTSEC-2026-0249", reason = "smartstring is retained transitively by rhai 1.25.1; no patched release exists, and remediation is tracked in issue #5492." },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

This PR addresses:

- Records the smartstring advisory so cargo-deny can pass while the transitive dependency remains unmaintained.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The release PR security audit started rejecting the newly published unmaintained-dependency advisory RUSTSEC-2026-0249. No patched smartstring release exists, so the existing dependency-remediation tracking is recorded in the cargo-deny rationale.

## How Was This Tested?

- `cargo deny --workspace --all-features check all`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (not applicable to this configuration-only change)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective (configuration-only change)
- [ ] New and existing unit tests pass locally with my changes (configuration-only change)
- [ ] I have tested with all affected database backends (not applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check` (configuration-only change)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #6016
- Remediation tracking: #5492

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Additional Labels
- [x] `security` - Security concern

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Codex](https://openai.com/codex)