### PR TITLE
fix(ci): isolate ORM UI tests from cross-crate shard

### DIFF
--- a/tests/integration/tests/orm.rs
+++ b/tests/integration/tests/orm.rs
@@ -37,15 +37,6 @@ mod proxy_advanced_features;
 #[path = "orm/proxy_orm_integration.rs"]
 mod proxy_orm_integration;
 
-#[path = "orm/custom_manager_ui.rs"]
-mod custom_manager_ui;
-
-#[path = "orm/queryset_docs_ui.rs"]
-mod queryset_docs_ui;
-
-#[path = "orm/upsert_builder_ui.rs"]
-mod upsert_builder_ui;
-
 #[path = "orm/queryset_retrieval_integration.rs"]
 mod queryset_retrieval_integration;
 

--- a/tests/integration/tests/orm_ui.rs
+++ b/tests/integration/tests/orm_ui.rs
@@ -1,0 +1,13 @@
+//! ORM compile-time integration tests.
+//!
+//! This standalone test target keeps trybuild cases on the dedicated UI-test
+//! profile instead of the default cross-crate integration-test profile.
+
+#[path = "orm/custom_manager_ui.rs"]
+mod custom_manager_ui;
+
+#[path = "orm/queryset_docs_ui.rs"]
+mod queryset_docs_ui;
+
+#[path = "orm/upsert_builder_ui.rs"]
+mod upsert_builder_ui;

--- a/tests/integration/tests/settings.rs
+++ b/tests/integration/tests/settings.rs
@@ -12,6 +12,3 @@ mod composable_use_cases;
 
 #[path = "settings/composable_macro_pass.rs"]
 mod composable_macro_pass;
-
-#[path = "settings/schema_trybuild.rs"]
-mod schema_trybuild;

--- a/tests/integration/tests/settings_ui.rs
+++ b/tests/integration/tests/settings_ui.rs
@@ -1,0 +1,7 @@
+//! Settings compile-time integration tests.
+//!
+//! This standalone test target keeps trybuild cases on the dedicated UI-test
+//! profile instead of the default cross-crate integration-test profile.
+
+#[path = "settings/schema_trybuild.rs"]
+mod schema_trybuild;


### PR DESCRIPTION
## Summary

This PR addresses:

- Move nested ORM and settings trybuild modules into standalone `*_ui` integration targets.
- Keep the existing `binary(/ui/)` nextest filter from running UI compile tests in the default cross-crate shard.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The cross-crate integration shards timed out after executing nested trybuild UI tests. Those modules inherit the parent integration binary name, so `binary(/ui/)` cannot exclude them. Dedicated top-level `orm_ui` and `settings_ui` targets make the existing filter effective without changing the workflow expression.

Fixes #

Related to: #5999

## How Was This Tested?

- `CARGO_BUILD_JOBS=1 cargo check --package reinhardt-integration-tests --all-features --test orm_ui --test settings_ui`
- `cargo nextest list --package reinhardt-integration-tests --all-features --test orm_ui --test settings_ui -E 'binary(/ui/)'`
- `cargo nextest list --package reinhardt-integration-tests --all-features -E 'not binary(/ui/) & (test(/typed_upsert_builders/) | test(/settings_schema/))'`
- `cargo fmt --all -- --check`
- `git diff --check`

## Performance Impact

The default cross-crate shards no longer spend their timeout budget on compile-time UI tests. The UI tests remain available under dedicated binaries.

## Breaking Changes

None.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings in the affected checks
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [ ] I have checked the code with `cargo make clippy-check`

## Related Issues

- Related to #5999

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This is a base-branch fix for the timeout observed while checking documentation PR #5999.