### PR TITLE
feat(admin): support storage-backed file uploads and cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ admin = [
   "reinhardt-admin/adapters",
   "reinhardt-admin/server",
   "reinhardt-admin/pages",
+  "reinhardt-admin/file-uploads",
   "reinhardt-forms",
   "reinhardt-pages",
   "reinhardt-commands/admin",

--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ default to UTC and PostgreSQL additionally supports IANA named zones. MySQL and
 SQLite report an explicit capability error for named-zone requests instead of
 falling back to UTC or server-local time.
 
-### Storage-backed `FileField` (opt-in Phase A)
+### Storage-backed `FileField` and admin uploads (opt-in)
 
 Storage-backed model files are deliberately outside the default presets. Select
 one provider feature for the application rather than enabling every provider:
@@ -795,8 +795,18 @@ let url = profile.avatar.url().await?;
 ```
 
 Only the logical path is stored in the database; hydration restores the alias
-from `file_storage` field metadata. The upload is eager, so a failed later
-database save can leave an orphan. For source and data migration guidance, see
+from `file_storage` field metadata. For model mutations, the lifecycle
+coordinator validates and stages uploads before the database operation,
+compensates staged objects when persistence fails, and removes replaced,
+cleared, or deleted objects after database success. Cleanup is best effort and
+`cleanup = false` preserves old objects.
+
+When the `admin` feature is enabled, forms containing `FileField` or
+`ImageField` use the multipart create/update endpoints automatically. Create
+requires non-nullable file fields, edit forms preserve omitted files, nullable
+fields support Clear, and image validation runs before persistence. Storage
+cleanup failures are logged without rolling back the committed database row.
+For source and data migration guidance, see
 [`instructions/MIGRATION_0.4.md`](instructions/MIGRATION_0.4.md).
 
 **Note**: Reinhardt uses reinhardt-query for SQL operations. The `#[model(...)]` attribute automatically generates Model trait implementations, type-safe field accessors, and global model registry registration.

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -62,6 +62,7 @@ uuid = { workspace = true }
 wasm-bindgen = "0.2.106"
 console_error_panic_hook = { version = "0.1", optional = true }
 web-sys = { version = "0.3.83", features = [
+	"Blob",
 	"Window",
 	"Document",
 	"Element",
@@ -72,12 +73,19 @@ web-sys = { version = "0.3.83", features = [
 	"KeyboardEvent",
 	"InputEvent",
 	"HtmlInputElement",
+	"Blob",
+	"File",
+	"FileList",
+	"FormData",
 	"HtmlFormElement",
 	"HtmlOptionElement",
 	"HtmlOptionsCollection",
 	"HtmlSelectElement",
 	"HtmlTextAreaElement",
 	"HtmlButtonElement",
+	"File",
+	"FileList",
+	"FormData",
 	"History",
 	"Location",
 	"Storage",

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -105,7 +105,7 @@ types = []
 
 # All features
 all = ["adapters", "core", "pages", "server", "types"]
-file-uploads = []
+file-uploads = ["reinhardt-db/file-storage", "reinhardt-db/image-fields"]
 admin = []
 full = ["console_error_panic_hook", "file-uploads", "all"]
 console_error_panic_hook = ["dep:console_error_panic_hook"]

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -62,7 +62,6 @@ uuid = { workspace = true }
 wasm-bindgen = "0.2.106"
 console_error_panic_hook = { version = "0.1", optional = true }
 web-sys = { version = "0.3.83", features = [
-	"Blob",
 	"Window",
 	"Document",
 	"Element",
@@ -83,9 +82,6 @@ web-sys = { version = "0.3.83", features = [
 	"HtmlSelectElement",
 	"HtmlTextAreaElement",
 	"HtmlButtonElement",
-	"File",
-	"FileList",
-	"FormData",
 	"History",
 	"Location",
 	"Storage",

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -363,6 +363,8 @@ let router = UnifiedRouter::new()
 // POST   /admin/api/server_fn/get_relation_options
 // POST   /admin/api/server_fn/create_record
 // POST   /admin/api/server_fn/update_record
+// POST   /admin/api/server_fn/create_record_multipart
+// POST   /admin/api/server_fn/update_record_multipart
 // POST   /admin/api/server_fn/update_inline_edits
 // POST   /admin/api/server_fn/delete_record
 // POST   /admin/api/server_fn/bulk_delete_records
@@ -394,7 +396,7 @@ For comprehensive routing documentation, see the [`core::router`](src/core/route
 | `server` | Server-side request handling |
 | `types` | Shared type definitions |
 | `all` | All of the above (`adapters`, `core`, `pages`, `server`, `types`) |
-| `file-uploads` | File upload support |
+| `file-uploads` | Storage-backed `FileField`/`ImageField` admin uploads, validation, replacement, clear, and delete cleanup |
 | `admin` | Admin feature marker |
 | `full` | All features including `file-uploads` |
 

--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -15,7 +15,7 @@ use reinhardt_db::orm::{
 };
 use reinhardt_di::{DiResult, Injectable, InjectionContext, KeyedFactoryOutput};
 use reinhardt_query::prelude::{
-	Alias, BinOper, CaseStatement, ColumnRef, Condition, Expr, ExprTrait, IntoValue,
+	Alias, BinOper, CaseStatement, ColumnRef, Condition, Expr, ExprTrait, IntoValue, LockType,
 	MySqlQueryBuilder, Order, PostgresQueryBuilder, Query, QueryBuilder, QueryStatementBuilder,
 	SimpleExpr, SqliteQueryBuilder, UpdateStatement, Value, Values,
 };
@@ -2070,6 +2070,73 @@ impl AdminDatabase {
 			.rows_affected;
 
 		Ok(affected)
+	}
+
+	#[cfg(feature = "file-uploads")]
+	pub(crate) async fn delete_with_executor_returning<E>(
+		&self,
+		executor: &mut E,
+		table_name: &str,
+		pk_field: &str,
+		id: &str,
+	) -> AdminResult<(u64, Option<HashMap<String, serde_json::Value>>)>
+	where
+		E: OrmExecutor,
+	{
+		let pk_value = parse_pk_value(table_name, pk_field, id)?;
+		if executor.backend() == DatabaseBackend::MySql {
+			let query = Query::select()
+				.from(Alias::new(table_name))
+				.column(ColumnRef::Asterisk)
+				.and_where(Expr::col(Alias::new(pk_field)).eq(pk_value))
+				.limit(1)
+				.lock(LockType::Update)
+				.to_owned();
+			let (sql, values) = query.build(MySqlQueryBuilder);
+			let row = executor
+				.fetch_all(&sql, convert_values(values))
+				.await
+				.map_err(|error| AdminError::DatabaseError(error.to_string()))?
+				.into_iter()
+				.next()
+				.map(QueryRow::from_backend_row);
+			let Some(row) = row else {
+				return Ok((0, None));
+			};
+			let serde_json::Value::Object(record) = row.data else {
+				return Ok((0, None));
+			};
+			let affected = self
+				.delete_with_executor(executor, table_name, pk_field, id)
+				.await?;
+			return Ok((
+				affected,
+				(affected > 0).then_some(record.into_iter().collect()),
+			));
+		}
+
+		let mut query = Query::delete()
+			.from_table(Alias::new(table_name))
+			.and_where(Expr::col(Alias::new(pk_field)).eq(pk_value))
+			.to_owned();
+		query.returning_all();
+		let (sql, values) = match executor.backend() {
+			DatabaseBackend::Postgres => query.build(PostgresQueryBuilder),
+			DatabaseBackend::Sqlite => query.build(SqliteQueryBuilder),
+			DatabaseBackend::MySql => unreachable!("MySQL uses the locked read path above"),
+		};
+		let row = executor
+			.fetch_all(&sql, convert_values(values))
+			.await
+			.map_err(|error| AdminError::DatabaseError(error.to_string()))?
+			.into_iter()
+			.next()
+			.map(QueryRow::from_backend_row);
+		let record = row.and_then(|row| match row.data {
+			serde_json::Value::Object(record) => Some(record.into_iter().collect()),
+			_ => None,
+		});
+		Ok((record.is_some() as u64, record))
 	}
 
 	/// Delete multiple items by IDs (bulk delete)

--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -1680,17 +1680,54 @@ impl AdminDatabase {
 	where
 		E: OrmExecutor,
 	{
+		self.get_with_executor_inner(executor, table_name, pk_field, id, false)
+			.await
+	}
+
+	pub(crate) async fn get_with_executor_for_update<E>(
+		&self,
+		executor: &mut E,
+		table_name: &str,
+		pk_field: &str,
+		id: &str,
+	) -> AdminResult<Option<HashMap<String, serde_json::Value>>>
+	where
+		E: OrmExecutor,
+	{
+		self.get_with_executor_inner(executor, table_name, pk_field, id, true)
+			.await
+	}
+
+	async fn get_with_executor_inner<E>(
+		&self,
+		executor: &mut E,
+		table_name: &str,
+		pk_field: &str,
+		id: &str,
+		lock_for_update: bool,
+	) -> AdminResult<Option<HashMap<String, serde_json::Value>>>
+	where
+		E: OrmExecutor,
+	{
 		let pk_value = parse_pk_value(table_name, pk_field, id)?;
 
 		// SELECT * is intentional: admin detail view displays all fields from the
 		// model. The admin panel operates on dynamic schemas where the column set
 		// is determined by the ModelAdmin configuration at runtime.
-		let query = Query::select()
+		let mut query = Query::select()
 			.from(Alias::new(table_name))
 			.column(ColumnRef::Asterisk)
 			.and_where(Expr::col(Alias::new(pk_field)).eq(pk_value))
 			.limit(1)
 			.to_owned();
+		if lock_for_update
+			&& matches!(
+				executor.backend(),
+				reinhardt_db::orm::DatabaseBackend::Postgres
+					| reinhardt_db::orm::DatabaseBackend::MySql
+			) {
+			query.lock(LockType::Update);
+		}
 
 		let (sql, values) = match executor.backend() {
 			reinhardt_db::orm::DatabaseBackend::Postgres => query.build(PostgresQueryBuilder),
@@ -1721,6 +1758,57 @@ impl AdminDatabase {
 				None
 			}
 		}))
+	}
+
+	#[cfg(all(server, feature = "file-uploads"))]
+	pub(crate) async fn get_all_by_field_with_executor_for_update<E>(
+		&self,
+		executor: &mut E,
+		table_name: &str,
+		field_name: &str,
+		value: &str,
+	) -> AdminResult<Vec<HashMap<String, serde_json::Value>>>
+	where
+		E: OrmExecutor,
+	{
+		let query_field_name =
+			crate::server::type_inference::get_field_metadata(table_name, field_name)
+				.and_then(|metadata| metadata.params.get("db_column").cloned())
+				.unwrap_or_else(|| field_name.to_owned());
+		let field_value = json_to_sea_value(
+			table_name,
+			field_name,
+			serde_json::Value::String(value.to_owned()),
+		)?;
+		let mut query = Query::select()
+			.from(Alias::new(table_name))
+			.column(ColumnRef::Asterisk)
+			.and_where(Expr::col(Alias::new(&query_field_name)).eq(field_value))
+			.to_owned();
+		if matches!(
+			executor.backend(),
+			reinhardt_db::orm::DatabaseBackend::Postgres
+				| reinhardt_db::orm::DatabaseBackend::MySql
+		) {
+			query.lock(LockType::Update);
+		}
+
+		let (sql, values) = match executor.backend() {
+			reinhardt_db::orm::DatabaseBackend::Postgres => query.build(PostgresQueryBuilder),
+			reinhardt_db::orm::DatabaseBackend::MySql => query.build(MySqlQueryBuilder),
+			reinhardt_db::orm::DatabaseBackend::Sqlite => query.build(SqliteQueryBuilder),
+		};
+		let rows = executor
+			.fetch_all(&sql, convert_values(values))
+			.await
+			.map_err(|error| AdminError::DatabaseError(error.to_string()))?;
+		Ok(rows
+			.into_iter()
+			.filter_map(|row| match QueryRow::from_backend_row(row).data {
+				serde_json::Value::Object(map) => Some(map.into_iter().collect()),
+				_ => None,
+			})
+			.collect())
 	}
 
 	/// Create a new item

--- a/crates/reinhardt-admin/src/core/inline.rs
+++ b/crates/reinhardt-admin/src/core/inline.rs
@@ -39,11 +39,14 @@ pub(crate) enum InlineSaveOperation {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct InlineSaveOutcome {
+	pub(crate) inline_key: String,
+	pub(crate) submitted_index: usize,
 	pub(crate) operation: InlineSaveOperation,
 	pub(crate) model_identity: String,
 	pub(crate) table_name: String,
 	pub(crate) object_id: String,
 	pub(crate) changed_fields: Vec<String>,
+	pub(crate) previous_values: HashMap<String, Value>,
 }
 
 /// A typed inline validation or persistence failure.
@@ -487,7 +490,12 @@ where
 					let payload = self.payload(inline_key, row.submitted_index, row.values)?;
 					formset.add_child_form(ModelForm::from_payload(payload));
 					submitted_indices.push(row.submitted_index);
-					pending_outcomes.push((row.submitted_index, None, changed_fields));
+					pending_outcomes.push((
+						row.submitted_index,
+						None,
+						changed_fields,
+						HashMap::new(),
+					));
 					continue;
 				}
 			};
@@ -497,6 +505,7 @@ where
 			let object_id = child_primary_key.to_string();
 			let child_database_value = C::primary_key_database_value(&child_primary_key)
 				.map_err(|error| InlineMutationError::Persistence(error.to_string()))?;
+			let previous_values = self.project_values(&existing)?;
 			if !ids.insert(object_id.clone()) {
 				return Err(InlineMutationError::Validation(format!(
 					"inline child ID '{object_id}' is submitted more than once"
@@ -509,6 +518,7 @@ where
 					existing,
 					object_id,
 					child_database_value,
+					previous_values,
 				));
 			} else {
 				let payload = self.payload(inline_key, row.submitted_index, row.values)?;
@@ -518,6 +528,7 @@ where
 					row.submitted_index,
 					Some((object_id, child_database_value)),
 					changed_fields,
+					previous_values,
 				));
 			}
 		}
@@ -537,7 +548,7 @@ where
 
 		let manager = C::objects();
 		let mut outcomes = Vec::with_capacity(pending_outcomes.len() + deletes.len());
-		for ((submitted_index, object_id, changed_fields), mut candidate) in
+		for ((submitted_index, object_id, changed_fields, previous_values), mut candidate) in
 			pending_outcomes.into_iter().zip(candidates)
 		{
 			let (operation, object_id) = match object_id {
@@ -570,10 +581,17 @@ where
 			};
 			outcomes.push((
 				submitted_index,
-				self.outcome(operation, object_id, changed_fields),
+				self.outcome(
+					inline_key,
+					submitted_index,
+					operation,
+					object_id,
+					changed_fields,
+					previous_values,
+				),
 			));
 		}
-		for (submitted_index, child, object_id, child_primary_key) in deletes {
+		for (submitted_index, child, object_id, child_primary_key, previous_values) in deletes {
 			self.delete_owned_child(
 				&manager,
 				&child,
@@ -585,7 +603,14 @@ where
 			.await?;
 			outcomes.push((
 				submitted_index,
-				self.outcome(InlineSaveOperation::Delete, object_id, Vec::new()),
+				self.outcome(
+					inline_key,
+					submitted_index,
+					InlineSaveOperation::Delete,
+					object_id,
+					Vec::new(),
+					previous_values,
+				),
 			));
 		}
 		outcomes.sort_unstable_by_key(|(submitted_index, _)| *submitted_index);
@@ -659,6 +684,11 @@ where
 		let id = child
 			.primary_key()
 			.map(|primary_key| primary_key.to_string());
+		let values = self.project_values(&child)?;
+		Ok(InlineRowInfo { id, values })
+	}
+
+	fn project_values(&self, child: &C) -> Result<HashMap<String, Value>, InlineMutationError> {
 		let object = serde_json::to_value(child)
 			.map_err(|error| InlineMutationError::Persistence(error.to_string()))?;
 		let object = object.as_object().ok_or_else(|| {
@@ -679,7 +709,7 @@ where
 					})
 			})
 			.collect::<Result<_, _>>()?;
-		Ok(InlineRowInfo { id, values })
+		Ok(values)
 	}
 
 	fn payload(
@@ -718,16 +748,22 @@ where
 
 	fn outcome(
 		&self,
+		inline_key: &str,
+		submitted_index: usize,
 		operation: InlineSaveOperation,
 		object_id: String,
 		changed_fields: Vec<String>,
+		previous_values: HashMap<String, Value>,
 	) -> InlineSaveOutcome {
 		InlineSaveOutcome {
+			inline_key: inline_key.to_owned(),
+			submitted_index,
 			operation,
 			model_identity: self.model_identity.clone(),
 			table_name: C::table_name().to_owned(),
 			object_id,
 			changed_fields,
+			previous_values,
 		}
 	}
 }
@@ -1390,29 +1426,45 @@ mod tests {
 			})
 			.await
 			.unwrap();
+		let inline_key = inline.key().to_owned();
 		assert_eq!(
 			outcomes,
 			vec![
 				InlineSaveOutcome {
+					inline_key: inline_key.clone(),
+					submitted_index: 2,
 					operation: InlineSaveOperation::Update,
 					model_identity: "Child".to_owned(),
 					table_name: "inline_children".to_owned(),
 					object_id: "10".to_owned(),
 					changed_fields: vec!["name".to_owned(), "position".to_owned()],
+					previous_values: HashMap::from([
+						("name".to_owned(), json!("first")),
+						("position".to_owned(), json!(1)),
+					]),
 				},
 				InlineSaveOutcome {
+					inline_key: inline_key.clone(),
+					submitted_index: 4,
 					operation: InlineSaveOperation::Delete,
 					model_identity: "Child".to_owned(),
 					table_name: "inline_children".to_owned(),
 					object_id: "11".to_owned(),
 					changed_fields: Vec::new(),
+					previous_values: HashMap::from([
+						("name".to_owned(), json!("second")),
+						("position".to_owned(), json!(2)),
+					]),
 				},
 				InlineSaveOutcome {
+					inline_key,
+					submitted_index: 7,
 					operation: InlineSaveOperation::Create,
 					model_identity: "Child".to_owned(),
 					table_name: "inline_children".to_owned(),
 					object_id: "12".to_owned(),
 					changed_fields: vec!["name".to_owned(), "position".to_owned()],
+					previous_values: HashMap::new(),
 				},
 			]
 		);

--- a/crates/reinhardt-admin/src/core/router.rs
+++ b/crates/reinhardt-admin/src/core/router.rs
@@ -417,13 +417,15 @@ fn build_admin_router(
 	// explicit .server_fn(marker) calls are required.
 	#[cfg(server)]
 	let router = {
+		#[cfg(feature = "file-uploads")]
+		use crate::server::multipart::{create_record_multipart, update_record_multipart};
 		use crate::server::{
 			bulk_delete_records, create_record, delete_record, execute_admin_action, export_data,
 			get_dashboard, get_detail, get_fields, get_history, get_list, get_list_action_metadata,
 			get_relation_options, import_data, login::admin_login, login::admin_login_with_header,
 			logout::admin_logout, update_inline_edits, update_record,
 		};
-		router
+		let router = router
 			.server_fn(get_dashboard::marker)
 			.server_fn(get_list::marker)
 			.server_fn(get_list_action_metadata::marker)
@@ -432,7 +434,12 @@ fn build_admin_router(
 			.server_fn(get_fields::marker)
 			.server_fn(get_relation_options::marker)
 			.server_fn(create_record::marker)
-			.server_fn(update_record::marker)
+			.server_fn(update_record::marker);
+		#[cfg(feature = "file-uploads")]
+		let router = router
+			.server_fn(create_record_multipart::marker)
+			.server_fn(update_record_multipart::marker);
+		router
 			.server_fn(update_inline_edits::marker)
 			.server_fn(delete_record::marker)
 			.server_fn(bulk_delete_records::marker)
@@ -591,7 +598,7 @@ mod tests {
 	#[rstest]
 	fn test_admin_routes_registers_all_server_functions() {
 		// Arrange
-		let expected_paths = [
+		let expected_paths = vec![
 			"/api/server_fn/get_dashboard",
 			"/api/server_fn/get_list",
 			"/api/server_fn/get_list_action_metadata",
@@ -613,6 +620,18 @@ mod tests {
 			"/",
 			"/{*tail}",
 		];
+		#[cfg(feature = "file-uploads")]
+		let expected_paths = {
+			let mut expected_paths = expected_paths;
+			expected_paths.splice(
+				8..8,
+				[
+					"/api/server_fn/create_record_multipart",
+					"/api/server_fn/update_record_multipart",
+				],
+			);
+			expected_paths
+		};
 
 		// Act
 		let router = test_admin_routes();

--- a/crates/reinhardt-admin/src/lib.rs
+++ b/crates/reinhardt-admin/src/lib.rs
@@ -7,6 +7,8 @@
 //! - **core**: Admin site registration, model admin configuration, and database helpers
 //! - **pages**: Admin page rendering
 //! - **server**: Server functions and HTTP handlers
+//! - Storage-backed `FileField`/`ImageField` admin forms use multipart mutations
+//!   when the `file-uploads` feature is enabled
 //! - **settings**: Server-side admin settings
 //! - **types**: Shared request/response DTOs
 //! - Per-object mutation history is persisted atomically without raw field values

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -168,6 +168,8 @@ pub struct Column {
 	pub linked: bool,
 	/// Whether an editable value is required.
 	pub required: bool,
+	/// Whether an editable value may be cleared.
+	pub nullable: bool,
 	/// Input rendering specification for editable cells.
 	pub form_spec: Option<crate::types::FormFieldSpec>,
 }
@@ -224,6 +226,7 @@ type ListSelectionState = (Signal<BTreeSet<String>>, Action<MutationResponse, St
 ///             editable: false,
 ///             linked: true,
 ///             required: true,
+///             nullable: false,
 ///             form_spec: None,
 ///         },
 ///     ],
@@ -948,6 +951,7 @@ fn editable_table_cell(
 		label: column.label.clone(),
 		spec,
 		required: column.required,
+		nullable: column.nullable,
 		value: json_value_to_display_string(&control_value),
 	};
 	let input =
@@ -1327,6 +1331,8 @@ pub struct FormField {
 	pub spec: crate::types::FormFieldSpec,
 	/// Whether this field is required
 	pub required: bool,
+	/// Whether this field may be explicitly cleared
+	pub nullable: bool,
 	/// Current field value (for edit forms)
 	pub value: String,
 }
@@ -1591,6 +1597,7 @@ pub(crate) fn history_view_with_route_model_name(
 ///         label: "Username".to_string(),
 ///         spec: FormFieldSpec::Input { html_type: "text".to_string() },
 ///         required: true,
+///         nullable: false,
 ///         value: "".to_string(),
 ///     },
 /// ];
@@ -1885,6 +1892,7 @@ fn inline_row_fields(
 				label: label.clone(),
 				spec: crate::types::FormFieldSpec::from(&field.field_type),
 				required: row.id.is_some() && field.required,
+				nullable: field.nullable,
 				value,
 			};
 			let input = form_element_for_model(&inline.model_name, &form_field, &input_id, &label);
@@ -2182,12 +2190,15 @@ fn submit_model_form(
 	if let Some(form) = &form {
 		clear_inline_validation_errors(form);
 	}
+	#[cfg(feature = "file-uploads")]
 	let uses_multipart = form.as_ref().is_some_and(|form| {
 		form.query_selector(r#"input[type="file"]"#)
 			.ok()
 			.flatten()
 			.is_some()
 	});
+	#[cfg(not(feature = "file-uploads"))]
+	let uses_multipart = false;
 	let request = (!uses_multipart).then(|| collect_mutation_request(event.raw()));
 	let form_for_submit = form.clone();
 	reinhardt_pages::platform::spawn_task(async move {
@@ -3504,8 +3515,8 @@ fn form_element_with_description_for_model(
 			name,
 			label,
 			described_by,
-			required,
-			!required && !value.is_empty(),
+			required && value.is_empty(),
+			field.nullable && !value.is_empty(),
 		),
 		FormFieldSpec::Hidden => render_input(
 			"hidden".to_string(),
@@ -4122,6 +4133,7 @@ mod tests {
 				editable: false,
 				linked: false,
 				required: false,
+				nullable: false,
 				form_spec: None,
 			}],
 			pk_field: "slug".to_string(),
@@ -4381,6 +4393,7 @@ mod tests {
 				readonly: false,
 			},
 			required: true,
+			nullable: false,
 			value: "001".to_string(),
 		}];
 
@@ -4405,6 +4418,7 @@ mod tests {
 				readonly: false,
 			},
 			required: true,
+			nullable: false,
 			value: String::new(),
 		}];
 
@@ -4662,6 +4676,7 @@ mod tests {
 				html_type: "datetime-local".to_string(),
 			},
 			required: false,
+			nullable: false,
 			value: normalized_inline_original(
 				&json!("2026-08-10T09:08:07.123456Z"),
 				InlineValueKind::DateTime,
@@ -4717,6 +4732,7 @@ mod tests {
 				choices: vec![("active".to_string(), "Active".to_string())],
 			},
 			required: false,
+			nullable: true,
 			value: String::new(),
 		};
 
@@ -4742,6 +4758,7 @@ mod tests {
 				editable: true,
 				linked: true,
 				required: true,
+				nullable: false,
 				form_spec: Some(FormFieldSpec::Input {
 					html_type: "text".to_string(),
 				}),
@@ -4753,6 +4770,7 @@ mod tests {
 				editable: true,
 				linked: false,
 				required: true,
+				nullable: false,
 				form_spec: Some(FormFieldSpec::Input {
 					html_type: "checkbox".to_string(),
 				}),
@@ -4764,6 +4782,7 @@ mod tests {
 				editable: false,
 				linked: false,
 				required: false,
+				nullable: false,
 				form_spec: None,
 			},
 		];
@@ -4806,6 +4825,7 @@ mod tests {
 			editable: true,
 			linked: false,
 			required: true,
+			nullable: false,
 			form_spec: Some(FormFieldSpec::Input {
 				html_type: "text".to_string(),
 			}),
@@ -4837,6 +4857,7 @@ mod tests {
 			editable: true,
 			linked: false,
 			required: true,
+			nullable: false,
 			form_spec: Some(FormFieldSpec::Input {
 				html_type: "text".to_string(),
 			}),
@@ -4866,6 +4887,7 @@ mod tests {
 			editable: false,
 			linked: false,
 			required: false,
+			nullable: false,
 			form_spec: None,
 		}];
 		let records = vec![HashMap::from([

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -2801,16 +2801,16 @@ fn render_raw_id_relation(
 	});
 	if required {
 		page!(|input_id: String,
-			name: String,
-			input_label: String,
-			status_id: String,
-			value: String,
-			label_view: Page,
-			resolved_label: Signal<String>,
-			status: Signal<String>,
-			generation: Rc<Cell<u64>>,
-			model_name: String,
-			field_name: String| {
+		 name: String,
+		 input_label: String,
+		 status_id: String,
+		 value: String,
+		 label_view: Page,
+		 resolved_label: Signal<String>,
+		 status: Signal<String>,
+		 generation: Rc<Cell<u64>>,
+		 model_name: String,
+		 field_name: String| {
 			div {
 				class: "relation-raw-id",
 				input {
@@ -2824,14 +2824,16 @@ fn render_raw_id_relation(
 					value: value,
 					required: true,
 					autocomplete: "off",
-					@change: move |event| crate::pages::components::features::resolve_raw_relation(
-						model_name.clone(),
-						field_name.clone(),
-						event.value().unwrap_or_default(),
-						resolved_label,
-						status,
-						generation.clone(),
-					),
+					@change: move |event| {
+						crate::pages::components::features::resolve_raw_relation(
+							model_name.clone(),
+							field_name.clone(),
+							event.value().unwrap_or_default(),
+							resolved_label,
+							status,
+							generation.clone(),
+						)
+					},
 				}
 				{ label_view }
 			}
@@ -2850,16 +2852,16 @@ fn render_raw_id_relation(
 		)
 	} else {
 		page!(|input_id: String,
-			name: String,
-			input_label: String,
-			status_id: String,
-			value: String,
-			label_view: Page,
-			resolved_label: Signal<String>,
-			status: Signal<String>,
-			generation: Rc<Cell<u64>>,
-			model_name: String,
-			field_name: String| {
+		 name: String,
+		 input_label: String,
+		 status_id: String,
+		 value: String,
+		 label_view: Page,
+		 resolved_label: Signal<String>,
+		 status: Signal<String>,
+		 generation: Rc<Cell<u64>>,
+		 model_name: String,
+		 field_name: String| {
 			div {
 				class: "relation-raw-id",
 				input {
@@ -2872,14 +2874,16 @@ fn render_raw_id_relation(
 					aria_describedby: status_id,
 					value: value,
 					autocomplete: "off",
-					@change: move |event| crate::pages::components::features::resolve_raw_relation(
-						model_name.clone(),
-						field_name.clone(),
-						event.value().unwrap_or_default(),
-						resolved_label,
-						status,
-						generation.clone(),
-					),
+					@change: move |event| {
+						crate::pages::components::features::resolve_raw_relation(
+							model_name.clone(),
+							field_name.clone(),
+							event.value().unwrap_or_default(),
+							resolved_label,
+							status,
+							generation.clone(),
+						)
+					},
 				}
 				{ label_view }
 			}
@@ -2964,11 +2968,11 @@ fn render_raw_id_relation(
 	let status_id = format!("{input_id}-status");
 	if required {
 		page!(|input_id: String,
-			name: String,
-			label: String,
-			status_id: String,
-			value: String,
-			resolved_label: String| {
+		 name: String,
+		 label: String,
+		 status_id: String,
+		 value: String,
+		 resolved_label: String| {
 			div {
 				class: "relation-raw-id",
 				input {
@@ -2983,7 +2987,12 @@ fn render_raw_id_relation(
 					required: true,
 					autocomplete: "off",
 				}
-				span { id: status_id, role: "status", aria_live: "polite", { resolved_label } }
+				span {
+					id: status_id,
+					role: "status",
+					aria_live: "polite",
+					{ resolved_label }
+				}
 			}
 		})(
 			input_id.to_string(),
@@ -2995,11 +3004,11 @@ fn render_raw_id_relation(
 		)
 	} else {
 		page!(|input_id: String,
-			name: String,
-			label: String,
-			status_id: String,
-			value: String,
-			resolved_label: String| {
+		 name: String,
+		 label: String,
+		 status_id: String,
+		 value: String,
+		 resolved_label: String| {
 			div {
 				class: "relation-raw-id",
 				input {
@@ -3013,7 +3022,12 @@ fn render_raw_id_relation(
 					value: value,
 					autocomplete: "off",
 				}
-				span { id: status_id, role: "status", aria_live: "polite", { resolved_label } }
+				span {
+					id: status_id,
+					role: "status",
+					aria_live: "polite",
+					{ resolved_label }
+				}
 			}
 		})(
 			input_id.to_string(),
@@ -3115,7 +3129,11 @@ fn render_autocomplete_relation(
 				hidden_id.clone(),
 			);
 			let status_page = page!(|status: String| {
-				span { role: "status", aria_live: "polite", { status } }
+				span {
+					role: "status",
+					aria_live: "polite",
+					{ status }
+				}
 			})(status);
 			let pagination = page!(|page: u64, has_next: bool, page_signal: Signal<u64>| {
 				div {
@@ -3129,7 +3147,10 @@ fn render_autocomplete_relation(
 						},
 						"Previous"
 					}
-					span { aria_live: "polite", { format!("Page {page}") } }
+					span {
+						aria_live: "polite",
+						{ format!("Page {page}") }
+					}
 					button {
 						type: "button",
 						disabled: !has_next,
@@ -3141,12 +3162,13 @@ fn render_autocomplete_relation(
 					}
 				}
 			})(page, has_next, page_signal);
-			page!(|list_id: String,
-				option_pages: Vec<Page>,
-				status_page: Page,
-				pagination: Page| {
+			page!(|list_id: String, option_pages: Vec<Page>, status_page: Page, pagination: Page| {
 				div {
-					div { id: list_id, role: "listbox", { option_pages } }
+					div {
+						id: list_id,
+						role: "listbox",
+						{ option_pages }
+					}
 					{ status_page }
 					{ pagination }
 				}
@@ -3155,14 +3177,14 @@ fn render_autocomplete_relation(
 	});
 	let search_input = if required {
 		page!(|search_id: String,
-			input_label: String,
-			list_id: String,
-			query: Signal<String>,
-			selected_id: Signal<String>,
-			page_signal: Signal<u64>,
-			debounced_query: Signal<String>,
-			debounce_generation: Rc<Cell<u64>>,
-			hidden_id: String| {
+		 input_label: String,
+		 list_id: String,
+		 query: Signal<String>,
+		 selected_id: Signal<String>,
+		 page_signal: Signal<u64>,
+		 debounced_query: Signal<String>,
+		 debounce_generation: Rc<Cell<u64>>,
+		 hidden_id: String| {
 			input {
 				class: "admin-input",
 				type: "search",
@@ -3209,14 +3231,14 @@ fn render_autocomplete_relation(
 		)
 	} else {
 		page!(|search_id: String,
-			input_label: String,
-			list_id: String,
-			query: Signal<String>,
-			selected_id: Signal<String>,
-			page_signal: Signal<u64>,
-			debounced_query: Signal<String>,
-			debounce_generation: Rc<Cell<u64>>,
-			hidden_id: String| {
+		 input_label: String,
+		 list_id: String,
+		 query: Signal<String>,
+		 selected_id: Signal<String>,
+		 page_signal: Signal<u64>,
+		 debounced_query: Signal<String>,
+		 debounce_generation: Rc<Cell<u64>>,
+		 hidden_id: String| {
 			input {
 				class: "admin-input",
 				type: "search",
@@ -3240,11 +3262,7 @@ fn render_autocomplete_relation(
 						value.clone(),
 					);
 					crate::pages::components::features::update_relation_controls(
-						&search_id,
-						&hidden_id,
-						&value,
-						"",
-						"",
+						&search_id, &hidden_id, &value, "", "",
 					);
 					page_signal.set(1);
 				},
@@ -3315,11 +3333,11 @@ fn render_autocomplete_relation(
 		.unwrap_or_default();
 	if required {
 		page!(|search_id: String,
-			list_id: String,
-			label: String,
-			query: String,
-			name: String,
-			value: String| {
+		 list_id: String,
+		 label: String,
+		 query: String,
+		 name: String,
+		 value: String| {
 			div {
 				class: "relation-autocomplete",
 				input {
@@ -3341,17 +3359,24 @@ fn render_autocomplete_relation(
 					value: value,
 					required: true
 				}
-				div { id: list_id, role: "listbox" }
-				span { role: "status", aria_live: "polite", "" }
+				div {
+					id: list_id,
+					role: "listbox"
+				}
+				span {
+					role: "status",
+					aria_live: "polite",
+					""
+				}
 			}
 		})(search_id, list_id, label, query, name, value)
 	} else {
 		page!(|search_id: String,
-			list_id: String,
-			label: String,
-			query: String,
-			name: String,
-			value: String| {
+		 list_id: String,
+		 label: String,
+		 query: String,
+		 name: String,
+		 value: String| {
 			div {
 				class: "relation-autocomplete",
 				input {
@@ -3371,8 +3396,15 @@ fn render_autocomplete_relation(
 					data_relation_id: "true",
 					value: value
 				}
-				div { id: list_id, role: "listbox" }
-				span { role: "status", aria_live: "polite", "" }
+				div {
+					id: list_id,
+					role: "listbox"
+				}
+				span {
+					role: "status",
+					aria_live: "polite",
+					""
+				}
 			}
 		})(search_id, list_id, label, query, name, value)
 	}
@@ -3397,13 +3429,13 @@ fn relation_option_pages(
 			let search_id = search_id.clone();
 			let hidden_id = hidden_id.clone();
 			page!(|id: String,
-				label: String,
-				display_label: String,
-				selected: bool,
-				selected_id: Signal<String>,
-				query: Signal<String>,
-				search_id: String,
-				hidden_id: String| {
+			 label: String,
+			 display_label: String,
+			 selected: bool,
+			 selected_id: Signal<String>,
+			 query: Signal<String>,
+			 search_id: String,
+			 hidden_id: String| {
 				button {
 					type: "button",
 					role: "option",
@@ -3413,11 +3445,7 @@ fn relation_option_pages(
 						selected_id.set(id.clone());
 						query.set(label.clone());
 						crate::pages::components::features::update_relation_controls(
-							&search_id,
-							&hidden_id,
-							&label,
-							&id,
-							"",
+							&search_id, &hidden_id, &label, &id, "",
 						);
 					},
 					{ display_label }
@@ -3625,12 +3653,12 @@ fn render_file_input(
 	let clear_name = format!("{}{}", crate::server::multipart::CLEAR_PREFIX, name);
 	if show_clear {
 		page!(|input_id: String,
-			name: String,
-			label: String,
-			described_by: String,
-			clear_id: String,
-			clear_name: String,
-			required: bool| {
+		 name: String,
+		 label: String,
+		 described_by: String,
+		 clear_id: String,
+		 clear_name: String,
+		 required: bool| {
 			div {
 				input {
 					class: "admin-input",
@@ -3651,8 +3679,7 @@ fn render_file_input(
 						id: clear_id,
 						name: clear_name,
 						value: "true",
-					}
-					"Clear current file"
+					}"Clear current file"
 				}
 			}
 		})(
@@ -3665,11 +3692,7 @@ fn render_file_input(
 			required,
 		)
 	} else {
-		page!(|input_id: String,
-			name: String,
-			label: String,
-			described_by: String,
-			required: bool| {
+		page!(|input_id: String, name: String, label: String, described_by: String, required: bool| {
 			input {
 				class: "admin-input",
 				type: "file",

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -2182,12 +2182,32 @@ fn submit_model_form(
 	if let Some(form) = &form {
 		clear_inline_validation_errors(form);
 	}
-	let request = collect_mutation_request(event.raw());
+	let uses_multipart = form.as_ref().is_some_and(|form| {
+		form.query_selector(r#"input[type="file"]"#)
+			.ok()
+			.flatten()
+			.is_some()
+	});
+	let request = (!uses_multipart).then(|| collect_mutation_request(event.raw()));
+	let form_for_submit = form.clone();
 	reinhardt_pages::platform::spawn_task(async move {
-		let result = if let Some(id) = record_id {
-			update_record(model_name, id, request).await
+		let result = if uses_multipart {
+			let Some(form) = form_for_submit.as_ref() else {
+				return report_admin_error("Save failed: form element is unavailable");
+			};
+			submit_model_form_multipart(form, &model_name, record_id.as_deref()).await
+		} else if let Some(id) = record_id {
+			update_record(
+				model_name,
+				id,
+				request.expect("JSON form request must be collected"),
+			)
+			.await
 		} else {
-			create_record(model_name, request).await
+			create_record(
+				model_name,
+				request.expect("JSON form request must be collected"),
+			)
 		};
 
 		match result {
@@ -2202,6 +2222,93 @@ fn submit_model_form(
 			}
 		}
 	});
+}
+
+#[cfg(client)]
+async fn submit_model_form_multipart(
+	form: &web_sys::HtmlFormElement,
+	model_name: &str,
+	record_id: Option<&str>,
+) -> Result<MutationResponse, reinhardt_pages::server_fn::ServerFnError> {
+	use wasm_bindgen::JsCast;
+
+	let form_data = web_sys::FormData::new().map_err(|error| {
+		reinhardt_pages::server_fn::ServerFnError::network(format!("{error:?}"))
+	})?;
+	append_json_form_part(
+		&form_data,
+		crate::server::multipart::MODEL_PART,
+		&serde_json::Value::String(model_name.to_owned()),
+	)?;
+	if let Some(record_id) = record_id {
+		append_json_form_part(
+			&form_data,
+			crate::server::multipart::ID_PART,
+			&serde_json::Value::String(record_id.to_owned()),
+		)?;
+	}
+
+	let elements = form.elements();
+	for index in 0..elements.length() {
+		let Some(element) = elements.item(index) else {
+			continue;
+		};
+		if let Some(input) = element.dyn_ref::<web_sys::HtmlInputElement>() {
+			let name = input.name();
+			if name.is_empty() {
+				continue;
+			}
+			if input.type_() == "file" {
+				if let Some(files) = input.files()
+					&& let Some(file) = files.item(0)
+					&& (file.size() > 0.0 || !file.name().is_empty())
+				{
+					form_data
+						.append_with_blob(&name, file.as_ref().unchecked_ref())
+						.map_err(|error| {
+							reinhardt_pages::server_fn::ServerFnError::network(format!("{error:?}"))
+						})?;
+				}
+				continue;
+			}
+			if name.starts_with(crate::server::multipart::CLEAR_PREFIX) && !input.checked() {
+				continue;
+			}
+		}
+
+		if let Some((name, value)) = form_control_name_value(&element) {
+			append_json_form_part(&form_data, &name, &value)?;
+		}
+	}
+
+	let path = if record_id.is_some() {
+		"/api/server_fn/update_record_multipart"
+	} else {
+		"/api/server_fn/create_record_multipart"
+	};
+	let response = reinhardt_pages::server_fn::request_multipart(path, form_data, true).await?;
+	if !response.is_success() {
+		let status = response.status();
+		let message = response.into_text();
+		return Err(
+			reinhardt_pages::server_fn::ServerFnError::from_http_response(status, &message),
+		);
+	}
+	response.json()
+}
+
+#[cfg(client)]
+fn append_json_form_part(
+	form_data: &web_sys::FormData,
+	name: &str,
+	value: &serde_json::Value,
+) -> Result<(), reinhardt_pages::server_fn::ServerFnError> {
+	let value = serde_json::to_string(value).map_err(|error| {
+		reinhardt_pages::server_fn::ServerFnError::serialization(error.to_string())
+	})?;
+	form_data
+		.append_with_str(name, &value)
+		.map_err(|error| reinhardt_pages::server_fn::ServerFnError::network(format!("{error:?}")))
 }
 
 #[cfg(client)]
@@ -3364,14 +3471,13 @@ fn form_element_with_description_for_model(
 			value,
 			required,
 		),
-		FormFieldSpec::File => render_input(
-			"file".to_string(),
+		FormFieldSpec::File => render_file_input(
 			input_id,
 			name,
 			label,
 			described_by,
-			value,
 			required,
+			!required && !value.is_empty(),
 		),
 		FormFieldSpec::Hidden => render_input(
 			"hidden".to_string(),
@@ -3504,6 +3610,77 @@ fn form_element_with_description_for_model(
 				})(input_id, name, label, described_by, options)
 			}
 		}
+	}
+}
+
+fn render_file_input(
+	input_id: String,
+	name: String,
+	label: String,
+	described_by: String,
+	required: bool,
+	show_clear: bool,
+) -> Page {
+	let clear_id = format!("{input_id}-clear");
+	let clear_name = format!("{}{}", crate::server::multipart::CLEAR_PREFIX, name);
+	if show_clear {
+		page!(|input_id: String,
+			name: String,
+			label: String,
+			described_by: String,
+			clear_id: String,
+			clear_name: String,
+			required: bool| {
+			div {
+				input {
+					class: "admin-input",
+					type: "file",
+					id: input_id,
+					name: name,
+					aria_label: label,
+					aria_describedby: described_by,
+					required: required,
+					autocomplete: "off",
+				}
+				label {
+					class: "admin-checkbox-label mt-2",
+					for: clear_id.clone(),
+					input {
+						class: "admin-input",
+						type: "checkbox",
+						id: clear_id,
+						name: clear_name,
+						value: "true",
+					}
+					"Clear current file"
+				}
+			}
+		})(
+			input_id,
+			name,
+			label,
+			described_by,
+			clear_id,
+			clear_name,
+			required,
+		)
+	} else {
+		page!(|input_id: String,
+			name: String,
+			label: String,
+			described_by: String,
+			required: bool| {
+			input {
+				class: "admin-input",
+				type: "file",
+				id: input_id,
+				name: name,
+				aria_label: label,
+				aria_describedby: described_by,
+				required: required,
+				autocomplete: "off",
+			}
+		})(input_id, name, label, described_by, required)
 	}
 }
 

--- a/crates/reinhardt-admin/src/pages/components/features.rs
+++ b/crates/reinhardt-admin/src/pages/components/features.rs
@@ -2208,6 +2208,7 @@ fn submit_model_form(
 				model_name,
 				request.expect("JSON form request must be collected"),
 			)
+			.await
 		};
 
 		match result {
@@ -2263,11 +2264,10 @@ async fn submit_model_form_multipart(
 					&& let Some(file) = files.item(0)
 					&& (file.size() > 0.0 || !file.name().is_empty())
 				{
-					form_data
-						.append_with_blob(&name, file.as_ref().unchecked_ref())
-						.map_err(|error| {
-							reinhardt_pages::server_fn::ServerFnError::network(format!("{error:?}"))
-						})?;
+					let blob: &web_sys::Blob = file.unchecked_ref();
+					form_data.append_with_blob(&name, blob).map_err(|error| {
+						reinhardt_pages::server_fn::ServerFnError::network(format!("{error:?}"))
+					})?;
 				}
 				continue;
 			}

--- a/crates/reinhardt-admin/src/pages/router.rs
+++ b/crates/reinhardt-admin/src/pages/router.rs
@@ -129,6 +129,7 @@ fn list_response_to_view_data(response: ListResponse) -> ListViewData {
 						editable: column.editable,
 						linked: column.linked,
 						required: column.required,
+						nullable: column.nullable,
 						form_spec: column.form_spec,
 					})
 					.collect()
@@ -141,6 +142,7 @@ fn list_response_to_view_data(response: ListResponse) -> ListViewData {
 					editable: false,
 					linked: true,
 					required: true,
+					nullable: false,
 					form_spec: None,
 				}]
 			}),
@@ -479,6 +481,7 @@ fn list_view_component(model_name: String) -> Page {
 				editable: false,
 				linked: true,
 				required: true,
+				nullable: false,
 				form_spec: None,
 			},
 			Column {
@@ -488,6 +491,7 @@ fn list_view_component(model_name: String) -> Page {
 				editable: false,
 				linked: false,
 				required: false,
+				nullable: false,
 				form_spec: None,
 			},
 		],
@@ -642,6 +646,7 @@ fn create_view_component(model_name: String) -> Page {
 						name: field_info.name,
 						label: field_info.label,
 						required: field_info.required,
+						nullable: field_info.nullable,
 						value: String::new(),
 					})
 					.collect();
@@ -686,6 +691,7 @@ fn create_view_component(model_name: String) -> Page {
 				html_type: "text".to_string(),
 			},
 			required: true,
+			nullable: false,
 			value: String::new(),
 		},
 		FormField {
@@ -695,6 +701,7 @@ fn create_view_component(model_name: String) -> Page {
 				html_type: "email".to_string(),
 			},
 			required: true,
+			nullable: false,
 			value: String::new(),
 		},
 	];
@@ -756,6 +763,7 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 							name: field_info.name,
 							label: field_info.label,
 							required: field_info.required,
+							nullable: field_info.nullable,
 							value,
 						}
 					})
@@ -806,6 +814,7 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 				html_type: "text".to_string(),
 			},
 			required: true,
+			nullable: false,
 			value: "Existing Value".to_string(),
 		},
 		FormField {
@@ -815,6 +824,7 @@ fn edit_view_component(model_name: String, record_id: String) -> Page {
 				html_type: "email".to_string(),
 			},
 			required: true,
+			nullable: false,
 			value: "user@example.com".to_string(),
 		},
 	];
@@ -1304,6 +1314,7 @@ mod tests {
 				editable: true,
 				linked: false,
 				required: true,
+				nullable: false,
 				form_spec: Some(crate::types::FormFieldSpec::Input {
 					html_type: "number".to_string(),
 				}),

--- a/crates/reinhardt-admin/src/server.rs
+++ b/crates/reinhardt-admin/src/server.rs
@@ -15,6 +15,7 @@
 //! - `create` - Create operations
 //! - `update` - Update operations
 //! - `delete` - Delete operations (including bulk delete)
+//! - `multipart` - Storage-backed file form mutations and cleanup coordination
 //! - `export` - Export operations
 //! - `import` - Import operations
 //! - `inline_edit` - Atomic changelist inline edits

--- a/crates/reinhardt-admin/src/server.rs
+++ b/crates/reinhardt-admin/src/server.rs
@@ -72,6 +72,8 @@ pub mod list;
 pub mod login;
 #[allow(missing_docs)]
 pub mod logout;
+#[allow(missing_docs)]
+pub mod multipart;
 // The server_fn macro generates an undocumented marker module beside the documented endpoint.
 #[allow(missing_docs)]
 pub mod relation;

--- a/crates/reinhardt-admin/src/server/create.rs
+++ b/crates/reinhardt-admin/src/server/create.rs
@@ -73,6 +73,33 @@ pub async fn create_record(
 	#[inject] http_request: ServerFnRequest,
 	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<crate::types::MutationResponse, ServerFnError> {
+	create_record_with_inline_outcomes(
+		model_name,
+		request,
+		site,
+		db,
+		http_request,
+		AdminAuthenticatedUser(user),
+	)
+	.await
+	.map(|(response, _)| response)
+}
+
+#[cfg(server)]
+pub(crate) async fn create_record_with_inline_outcomes(
+	model_name: String,
+	request: crate::types::MutationRequest,
+	site: KeyedDepends<AdminSiteKey, AdminSite>,
+	db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
+	http_request: ServerFnRequest,
+	AdminAuthenticatedUser(user): AdminAuthenticatedUser,
+) -> Result<
+	(
+		crate::types::MutationResponse,
+		Vec<super::inline::InlineSaveOutcome>,
+	),
+	ServerFnError,
+> {
 	// CSRF token validation (double-submit cookie pattern)
 	require_csrf_token(&request.csrf_token, &http_request.inner().headers)?;
 
@@ -81,6 +108,12 @@ pub async fn create_record(
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
 	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Add)
 		.await?;
+	#[cfg(feature = "file-uploads")]
+	super::multipart::reject_file_field_json_data(
+		&request.data,
+		model_admin.as_ref(),
+		site.as_ref(),
+	)?;
 	let model_name = model_admin.model_name().to_string();
 	let table_name = model_admin.table_name().to_string();
 	let pk_field = model_admin.pk_field().to_string();
@@ -94,7 +127,12 @@ pub async fn create_record(
 
 	// Validate input data before database operation
 	let mut data = request.data;
+	#[cfg(feature = "file-uploads")]
+	let mut field_aliases = relation_field_aliases(&site, &model_admin).map_server_fn_error()?;
+	#[cfg(not(feature = "file-uploads"))]
 	let field_aliases = relation_field_aliases(&site, &model_admin).map_server_fn_error()?;
+	#[cfg(feature = "file-uploads")]
+	field_aliases.extend(super::multipart::file_field_aliases(model_admin.as_ref())?);
 	validate_mutation_data_with_aliases(&data, model_admin.as_ref(), false, &field_aliases)
 		.map_server_fn_error()?;
 	let relation_values =
@@ -161,7 +199,7 @@ pub async fn create_record(
 					transaction,
 				)
 				.await?;
-				Ok(created)
+				Ok((created, outcomes))
 			})
 			.await
 	}
@@ -170,15 +208,18 @@ pub async fn create_record(
 	let success = result.is_ok();
 	audit::log_create(&audit_user_id, &model_name, &sanitized_data, success);
 
-	let created = result.map_err(map_inline_transaction_error)?;
+	let (created, outcomes) = result.map_err(map_inline_transaction_error)?;
 	let affected = created.primary_key.as_u64().unwrap_or(created.affected);
 
-	Ok(MutationResponse {
-		success: true,
-		message: format!("{} created successfully", model_name),
-		affected: Some(affected),
-		data: None,
-	})
+	Ok((
+		MutationResponse {
+			success: true,
+			message: format!("{} created successfully", model_name),
+			affected: Some(affected),
+			data: None,
+		},
+		outcomes,
+	))
 }
 
 /// Injects the current UTC timestamp for fields with `auto_now` or `auto_now_add`.

--- a/crates/reinhardt-admin/src/server/create.rs
+++ b/crates/reinhardt-admin/src/server/create.rs
@@ -15,6 +15,8 @@ use reinhardt_di::KeyedDepends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;
 use reinhardt_pages::server_fn::{ServerFnError, server_fn};
+#[cfg(server)]
+use std::collections::HashSet;
 
 #[cfg(server)]
 use super::audit;
@@ -23,11 +25,13 @@ use super::error::{AdminAuth, MapServerFnError, ModelPermission};
 #[cfg(server)]
 use super::inline::{
 	created_parent_identity, map_inline_mutation_error, map_inline_transaction_error,
-	parse_inline_mutations, preflight_inline_permissions, sanitize_inline_mutations,
-	save_inline_mutations,
+	parse_inline_mutations, preflight_inline_permissions,
+	sanitize_inline_mutations_with_trusted_fields, save_inline_mutations,
 };
 use super::relation::{relation_field_aliases, validate_relation_values};
-#[cfg(server)]
+#[cfg(all(server, feature = "file-uploads"))]
+use super::security::require_csrf_token;
+#[cfg(all(server, not(feature = "file-uploads")))]
 use super::security::{require_csrf_token, sanitize_mutation_values};
 #[cfg(server)]
 use super::type_inference::translate_logical_field_names;
@@ -92,7 +96,35 @@ pub(crate) async fn create_record_with_inline_outcomes(
 	site: KeyedDepends<AdminSiteKey, AdminSite>,
 	db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
 	http_request: ServerFnRequest,
+	user: AdminAuthenticatedUser,
+) -> Result<
+	(
+		crate::types::MutationResponse,
+		Vec<super::inline::InlineSaveOutcome>,
+	),
+	ServerFnError,
+> {
+	create_record_with_trusted_file_fields(
+		model_name,
+		request,
+		site,
+		db,
+		http_request,
+		user,
+		&HashSet::new(),
+	)
+	.await
+}
+
+#[cfg(server)]
+pub(crate) async fn create_record_with_trusted_file_fields(
+	model_name: String,
+	request: crate::types::MutationRequest,
+	site: KeyedDepends<AdminSiteKey, AdminSite>,
+	db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
+	http_request: ServerFnRequest,
 	AdminAuthenticatedUser(user): AdminAuthenticatedUser,
+	trusted_file_fields: &HashSet<String>,
 ) -> Result<
 	(
 		crate::types::MutationResponse,
@@ -109,10 +141,11 @@ pub(crate) async fn create_record_with_inline_outcomes(
 	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Add)
 		.await?;
 	#[cfg(feature = "file-uploads")]
-	super::multipart::reject_file_field_json_data(
+	super::multipart::reject_file_field_json_data_with_trusted_fields(
 		&request.data,
 		model_admin.as_ref(),
 		site.as_ref(),
+		trusted_file_fields,
 	)?;
 	let model_name = model_admin.model_name().to_string();
 	let table_name = model_admin.table_name().to_string();
@@ -140,8 +173,14 @@ pub(crate) async fn create_record_with_inline_outcomes(
 
 	// Sanitize string values to prevent stored XSS
 	let mut sanitized_data = data;
+	#[cfg(feature = "file-uploads")]
+	super::security::sanitize_mutation_values_with_trusted_fields(
+		&mut sanitized_data,
+		trusted_file_fields,
+	);
+	#[cfg(not(feature = "file-uploads"))]
 	sanitize_mutation_values(&mut sanitized_data);
-	sanitize_inline_mutations(&mut inline_mutations);
+	sanitize_inline_mutations_with_trusted_fields(&mut inline_mutations, trusted_file_fields);
 	sanitized_data.extend(relation_values);
 
 	// Inject current timestamp for auto_now and auto_now_add fields.

--- a/crates/reinhardt-admin/src/server/delete.rs
+++ b/crates/reinhardt-admin/src/server/delete.rs
@@ -4,8 +4,6 @@
 
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
-#[cfg(all(server, feature = "file-uploads"))]
-use crate::adapters::AdminRecord;
 use crate::adapters::{AdminDatabase, AdminSite, BulkDeleteResponse};
 #[cfg(server)]
 use crate::core::database::canonicalize_pk_value;
@@ -79,26 +77,6 @@ pub async fn delete_record(
 	let table_name = model_admin.table_name().to_string();
 	let pk_field = model_admin.pk_field().to_string();
 	let object_id = canonicalize_pk_value(&table_name, &pk_field, &id);
-	#[cfg(feature = "file-uploads")]
-	let deleted_values = {
-		let mut values = match db
-			.get::<AdminRecord>(&table_name, &pk_field, &object_id)
-			.await
-		{
-			Ok(values) => values,
-			Err(error) => {
-				tracing::warn!(error = %error, "Deleted file references could not be loaded");
-				None
-			}
-		};
-		if let Some(record) = values.as_mut()
-			&& let Err(error) = translate_physical_field_names_to_logical(&table_name, record)
-		{
-			tracing::warn!(error = %error, "Deleted file references could not be translated");
-			values = None;
-		}
-		values
-	};
 
 	let actor = user.get_username().to_string();
 	let audit_user_id = auth.user_id().unwrap_or("unknown").to_string();
@@ -106,6 +84,19 @@ pub async fn delete_record(
 	let result: reinhardt_core::exception::Result<_> = async {
 		connection
 			.atomic_write(async |transaction| {
+				#[cfg(feature = "file-uploads")]
+				let (affected, mut deleted_values) = db
+					.delete_with_executor_returning(transaction, &table_name, &pk_field, &object_id)
+					.await?;
+				#[cfg(feature = "file-uploads")]
+				if let Some(values) = deleted_values.as_mut()
+					&& let Err(error) =
+						translate_physical_field_names_to_logical(&table_name, values)
+				{
+					tracing::warn!(error = %error, "Deleted file references could not be translated");
+					deleted_values = None;
+				}
+				#[cfg(not(feature = "file-uploads"))]
 				let affected = db
 					.delete_with_executor(transaction, &table_name, &pk_field, &object_id)
 					.await?;
@@ -121,6 +112,9 @@ pub async fn delete_record(
 					);
 					insert_history_event(transaction, &event).await?;
 				}
+				#[cfg(feature = "file-uploads")]
+				return Ok((affected, deleted_values));
+				#[cfg(not(feature = "file-uploads"))]
 				Ok(affected)
 			})
 			.await
@@ -128,6 +122,15 @@ pub async fn delete_record(
 	.await;
 
 	// Check for database errors first, logging failure before returning
+	#[cfg(feature = "file-uploads")]
+	let (affected, deleted_values) = match result {
+		Err(_) => {
+			audit::log_delete(&audit_user_id, &model_name, &id, false);
+			return Err(ServerFnError::server(500, "Database operation failed"));
+		}
+		Ok(n) => n,
+	};
+	#[cfg(not(feature = "file-uploads"))]
 	let affected = match result {
 		Err(_) => {
 			audit::log_delete(&audit_user_id, &model_name, &id, false);
@@ -220,41 +223,35 @@ pub async fn bulk_delete_records(
 		)));
 	}
 
-	#[cfg(feature = "file-uploads")]
-	let mut deleted_values = Vec::new();
-	#[cfg(feature = "file-uploads")]
-	for id in &ids {
-		let object_id = canonicalize_pk_value(&table_name, &pk_field, id);
-		match db
-			.get::<AdminRecord>(&table_name, &pk_field, &object_id)
-			.await
-		{
-			Ok(Some(mut values)) => {
-				if let Err(error) =
-					translate_physical_field_names_to_logical(&table_name, &mut values)
-				{
-					tracing::warn!(error = %error, "Bulk-deleted file references could not be translated");
-				} else {
-					deleted_values.push(values);
-				}
-			}
-			Ok(None) => {}
-			Err(error) => {
-				tracing::warn!(error = %error, "Bulk-deleted file references could not be loaded");
-			}
-		}
-	}
-
 	let connection = *db.connection();
 	let result: reinhardt_core::exception::Result<_> = async {
 		connection
 			.atomic_write(async |transaction| {
+				#[cfg(feature = "file-uploads")]
+				let mut deleted_values = Vec::new();
 				let mut affected = 0;
 				for id in &ids {
 					let object_id = canonicalize_pk_value(&table_name, &pk_field, id);
-					let deleted = db
-						.delete_with_executor(transaction, &table_name, &pk_field, &object_id)
+					#[cfg(feature = "file-uploads")]
+					let (deleted, mut values) = db
+						.delete_with_executor_returning(
+							transaction,
+							&table_name,
+							&pk_field,
+							&object_id,
+						)
 						.await?;
+					#[cfg(not(feature = "file-uploads"))]
+					let deleted = db.delete_with_executor(transaction, &table_name, &pk_field, &object_id)
+						.await?;
+					#[cfg(feature = "file-uploads")]
+					if let Some(record) = values.as_mut()
+						&& let Err(error) =
+							translate_physical_field_names_to_logical(&table_name, record)
+					{
+						tracing::warn!(error = %error, "Bulk-deleted file references could not be translated");
+						values = None;
+					}
 					if deleted > 0 {
 						let event = audit::new_history_event(
 							&actor,
@@ -266,9 +263,16 @@ pub async fn bulk_delete_records(
 							deleted,
 						);
 						insert_history_event(transaction, &event).await?;
+						#[cfg(feature = "file-uploads")]
+						if let Some(values) = values {
+							deleted_values.push(values);
+						}
 						affected += deleted;
 					}
 				}
+				#[cfg(feature = "file-uploads")]
+				return Ok((affected, deleted_values));
+				#[cfg(not(feature = "file-uploads"))]
 				Ok(affected)
 			})
 			.await
@@ -276,9 +280,16 @@ pub async fn bulk_delete_records(
 	.await;
 
 	let success = result.is_ok();
+	#[cfg(feature = "file-uploads")]
+	let affected_count = result.as_ref().map(|(affected, _)| *affected).unwrap_or(0);
+	#[cfg(not(feature = "file-uploads"))]
 	let affected_count = result.as_ref().copied().unwrap_or(0);
 	audit::log_bulk_delete(&audit_user_id, &model_name, &ids, affected_count, success);
 
+	#[cfg(feature = "file-uploads")]
+	let (affected, deleted_values) =
+		result.map_err(|_| ServerFnError::server(500, "Database operation failed"))?;
+	#[cfg(not(feature = "file-uploads"))]
 	let affected = result.map_err(|_| ServerFnError::server(500, "Database operation failed"))?;
 
 	#[cfg(feature = "file-uploads")]

--- a/crates/reinhardt-admin/src/server/delete.rs
+++ b/crates/reinhardt-admin/src/server/delete.rs
@@ -4,6 +4,8 @@
 
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
+#[cfg(all(server, feature = "file-uploads"))]
+use crate::adapters::AdminRecord;
 use crate::adapters::{AdminDatabase, AdminSite, BulkDeleteResponse};
 #[cfg(server)]
 use crate::core::database::canonicalize_pk_value;
@@ -26,6 +28,10 @@ use super::error::{AdminAuth, MapServerFnError, ModelPermission};
 use super::limits::MAX_BULK_DELETE_IDS;
 #[cfg(server)]
 use super::security::require_csrf_token;
+#[cfg(all(server, feature = "file-uploads"))]
+use super::{
+	multipart::cleanup_deleted_files, type_inference::translate_physical_field_names_to_logical,
+};
 
 /// Delete a single model instance by ID
 ///
@@ -73,6 +79,26 @@ pub async fn delete_record(
 	let table_name = model_admin.table_name().to_string();
 	let pk_field = model_admin.pk_field().to_string();
 	let object_id = canonicalize_pk_value(&table_name, &pk_field, &id);
+	#[cfg(feature = "file-uploads")]
+	let deleted_values = {
+		let mut values = match db
+			.get::<AdminRecord>(&table_name, &pk_field, &object_id)
+			.await
+		{
+			Ok(values) => values,
+			Err(error) => {
+				tracing::warn!(error = %error, "Deleted file references could not be loaded");
+				None
+			}
+		};
+		if let Some(record) = values.as_mut()
+			&& let Err(error) = translate_physical_field_names_to_logical(&table_name, record)
+		{
+			tracing::warn!(error = %error, "Deleted file references could not be translated");
+			values = None;
+		}
+		values
+	};
 
 	let actor = user.get_username().to_string();
 	let audit_user_id = auth.user_id().unwrap_or("unknown").to_string();
@@ -121,6 +147,9 @@ pub async fn delete_record(
 	}
 
 	audit::log_delete(&audit_user_id, &model_name, &id, true);
+
+	#[cfg(feature = "file-uploads")]
+	cleanup_deleted_files(model_admin.as_ref(), deleted_values.as_ref()).await;
 
 	Ok(MutationResponse {
 		success: true,
@@ -191,6 +220,31 @@ pub async fn bulk_delete_records(
 		)));
 	}
 
+	#[cfg(feature = "file-uploads")]
+	let mut deleted_values = Vec::new();
+	#[cfg(feature = "file-uploads")]
+	for id in &ids {
+		let object_id = canonicalize_pk_value(&table_name, &pk_field, id);
+		match db
+			.get::<AdminRecord>(&table_name, &pk_field, &object_id)
+			.await
+		{
+			Ok(Some(mut values)) => {
+				if let Err(error) =
+					translate_physical_field_names_to_logical(&table_name, &mut values)
+				{
+					tracing::warn!(error = %error, "Bulk-deleted file references could not be translated");
+				} else {
+					deleted_values.push(values);
+				}
+			}
+			Ok(None) => {}
+			Err(error) => {
+				tracing::warn!(error = %error, "Bulk-deleted file references could not be loaded");
+			}
+		}
+	}
+
 	let connection = *db.connection();
 	let result: reinhardt_core::exception::Result<_> = async {
 		connection
@@ -226,6 +280,13 @@ pub async fn bulk_delete_records(
 	audit::log_bulk_delete(&audit_user_id, &model_name, &ids, affected_count, success);
 
 	let affected = result.map_err(|_| ServerFnError::server(500, "Database operation failed"))?;
+
+	#[cfg(feature = "file-uploads")]
+	if affected > 0 {
+		for values in &deleted_values {
+			cleanup_deleted_files(model_admin.as_ref(), Some(values)).await;
+		}
+	}
 
 	Ok(BulkDeleteResponse {
 		success: affected > 0,

--- a/crates/reinhardt-admin/src/server/delete.rs
+++ b/crates/reinhardt-admin/src/server/delete.rs
@@ -4,6 +4,8 @@
 
 #[cfg(server)]
 use super::admin_auth::AdminAuthenticatedUser;
+#[cfg(all(server, feature = "file-uploads"))]
+use crate::adapters::ModelAdmin;
 use crate::adapters::{AdminDatabase, AdminSite, BulkDeleteResponse};
 #[cfg(server)]
 use crate::core::database::canonicalize_pk_value;
@@ -30,6 +32,41 @@ use super::security::require_csrf_token;
 use super::{
 	multipart::cleanup_deleted_files, type_inference::translate_physical_field_names_to_logical,
 };
+#[cfg(all(server, feature = "file-uploads"))]
+use reinhardt_db::orm::OrmExecutor;
+
+#[cfg(all(server, feature = "file-uploads"))]
+async fn capture_inline_deleted_values<E>(
+	db: &AdminDatabase,
+	site: &AdminSite,
+	model_admin: &dyn ModelAdmin,
+	parent_id: &str,
+	transaction: &mut E,
+) -> crate::types::AdminResult<Vec<(String, std::collections::HashMap<String, serde_json::Value>)>>
+where
+	E: OrmExecutor,
+{
+	let mut deleted_values = Vec::new();
+	for inline in model_admin.inlines() {
+		let child_admin = site.get_model_admin_by_table_name(inline.adapter().table_name())?;
+		let mut rows = db
+			.get_all_by_field_with_executor_for_update(
+				transaction,
+				child_admin.table_name(),
+				inline.foreign_key(),
+				parent_id,
+			)
+			.await?;
+		for values in &mut rows {
+			translate_physical_field_names_to_logical(child_admin.table_name(), values)?;
+		}
+		deleted_values.extend(
+			rows.into_iter()
+				.map(|values| (child_admin.table_name().to_owned(), values)),
+		);
+	}
+	Ok(deleted_values)
+}
 
 /// Delete a single model instance by ID
 ///
@@ -85,6 +122,24 @@ pub async fn delete_record(
 		connection
 			.atomic_write(async |transaction| {
 				#[cfg(feature = "file-uploads")]
+				let parent_exists = db
+					.get_with_executor_for_update(transaction, &table_name, &pk_field, &object_id)
+					.await?
+					.is_some();
+				#[cfg(feature = "file-uploads")]
+				let inline_deleted_values = if parent_exists {
+					capture_inline_deleted_values(
+						db.as_ref(),
+						site.as_ref(),
+						model_admin.as_ref(),
+						&object_id,
+						transaction,
+					)
+					.await?
+				} else {
+					Vec::new()
+				};
+				#[cfg(feature = "file-uploads")]
 				let (affected, mut deleted_values) = db
 					.delete_with_executor_returning(transaction, &table_name, &pk_field, &object_id)
 					.await?;
@@ -113,7 +168,7 @@ pub async fn delete_record(
 					insert_history_event(transaction, &event).await?;
 				}
 				#[cfg(feature = "file-uploads")]
-				return Ok((affected, deleted_values));
+				return Ok((affected, deleted_values, inline_deleted_values));
 				#[cfg(not(feature = "file-uploads"))]
 				Ok(affected)
 			})
@@ -123,7 +178,7 @@ pub async fn delete_record(
 
 	// Check for database errors first, logging failure before returning
 	#[cfg(feature = "file-uploads")]
-	let (affected, deleted_values) = match result {
+	let (affected, deleted_values, inline_deleted_values) = match result {
 		Err(_) => {
 			audit::log_delete(&audit_user_id, &model_name, &id, false);
 			return Err(ServerFnError::server(500, "Database operation failed"));
@@ -153,6 +208,17 @@ pub async fn delete_record(
 
 	#[cfg(feature = "file-uploads")]
 	cleanup_deleted_files(model_admin.as_ref(), deleted_values.as_ref()).await;
+	#[cfg(feature = "file-uploads")]
+	for (table_name, values) in inline_deleted_values {
+		match site.get_model_admin_by_table_name(&table_name) {
+			Ok(child_admin) => cleanup_deleted_files(child_admin.as_ref(), Some(&values)).await,
+			Err(error) => tracing::warn!(
+				table = table_name.as_str(),
+				error = %error,
+				"Deleted inline file references could not be resolved"
+			),
+		}
+	}
 
 	Ok(MutationResponse {
 		success: true,
@@ -229,9 +295,36 @@ pub async fn bulk_delete_records(
 			.atomic_write(async |transaction| {
 				#[cfg(feature = "file-uploads")]
 				let mut deleted_values = Vec::new();
+				#[cfg(feature = "file-uploads")]
+				let mut inline_deleted_values = Vec::new();
 				let mut affected = 0;
 				for id in &ids {
 					let object_id = canonicalize_pk_value(&table_name, &pk_field, id);
+					#[cfg(feature = "file-uploads")]
+					let parent_exists = db
+						.get_with_executor_for_update(
+							transaction,
+							&table_name,
+							&pk_field,
+							&object_id,
+						)
+						.await?
+						.is_some();
+					#[cfg(feature = "file-uploads")]
+					if !parent_exists {
+						continue;
+					}
+					#[cfg(feature = "file-uploads")]
+					inline_deleted_values.extend(
+						capture_inline_deleted_values(
+							db.as_ref(),
+							site.as_ref(),
+							model_admin.as_ref(),
+							&object_id,
+							transaction,
+						)
+						.await?,
+					);
 					#[cfg(feature = "file-uploads")]
 					let (deleted, mut values) = db
 						.delete_with_executor_returning(
@@ -271,7 +364,7 @@ pub async fn bulk_delete_records(
 					}
 				}
 				#[cfg(feature = "file-uploads")]
-				return Ok((affected, deleted_values));
+				return Ok((affected, deleted_values, inline_deleted_values));
 				#[cfg(not(feature = "file-uploads"))]
 				Ok(affected)
 			})
@@ -281,13 +374,16 @@ pub async fn bulk_delete_records(
 
 	let success = result.is_ok();
 	#[cfg(feature = "file-uploads")]
-	let affected_count = result.as_ref().map(|(affected, _)| *affected).unwrap_or(0);
+	let affected_count = result
+		.as_ref()
+		.map(|(affected, _, _)| *affected)
+		.unwrap_or(0);
 	#[cfg(not(feature = "file-uploads"))]
 	let affected_count = result.as_ref().copied().unwrap_or(0);
 	audit::log_bulk_delete(&audit_user_id, &model_name, &ids, affected_count, success);
 
 	#[cfg(feature = "file-uploads")]
-	let (affected, deleted_values) =
+	let (affected, deleted_values, inline_deleted_values) =
 		result.map_err(|_| ServerFnError::server(500, "Database operation failed"))?;
 	#[cfg(not(feature = "file-uploads"))]
 	let affected = result.map_err(|_| ServerFnError::server(500, "Database operation failed"))?;
@@ -296,6 +392,16 @@ pub async fn bulk_delete_records(
 	if affected > 0 {
 		for values in &deleted_values {
 			cleanup_deleted_files(model_admin.as_ref(), Some(values)).await;
+		}
+		for (table_name, values) in inline_deleted_values {
+			match site.get_model_admin_by_table_name(&table_name) {
+				Ok(child_admin) => cleanup_deleted_files(child_admin.as_ref(), Some(&values)).await,
+				Err(error) => tracing::warn!(
+					table = table_name.as_str(),
+					error = %error,
+					"Bulk-deleted inline file references could not be resolved"
+				),
+			}
 		}
 	}
 

--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -27,7 +27,7 @@ use crate::server::relation::{
 };
 #[cfg(server)]
 use crate::server::type_inference::{
-	get_field_metadata, infer_admin_field_type, infer_required,
+	get_field_metadata, infer_admin_field_type_from_metadata, infer_required,
 	translate_physical_field_names_to_logical,
 };
 #[cfg(server)]
@@ -203,13 +203,13 @@ pub async fn get_fields(
 				})
 				.map_server_fn_error()?;
 			(
-				infer_admin_field_type(&metadata.field_type),
+				infer_admin_field_type_from_metadata(&metadata),
 				infer_required(&metadata),
 			)
 		} else {
 			metadata
 				.map(|meta| {
-					let admin_type = infer_admin_field_type(&meta.field_type);
+					let admin_type = infer_admin_field_type_from_metadata(&meta);
 					let is_required = infer_required(&meta);
 					(admin_type, is_required)
 				})
@@ -268,7 +268,7 @@ pub async fn get_fields(
 				Ok(FieldInfo {
 					name: name.clone(),
 					label: humanize_field_name(name),
-					field_type: infer_admin_field_type(&metadata.field_type),
+					field_type: infer_admin_field_type_from_metadata(&metadata),
 					required: infer_required(&metadata),
 					readonly: child_readonly_fields.contains(&name.as_str()),
 					help_text: None,

--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -140,7 +140,7 @@ pub async fn get_fields(
 	// Fetch existing values before resolving edit-form relation labels.
 	let values = if let Some(id) = id.as_deref() {
 		let mut values = db
-			.get::<AdminRecord>(model_admin.table_name(), model_admin.pk_field(), &id)
+			.get::<AdminRecord>(model_admin.table_name(), model_admin.pk_field(), id)
 			.await
 			.map_server_fn_error()?;
 		if let Some(values) = values.as_mut() {

--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -184,6 +184,7 @@ pub async fn get_fields(
 					readonly: is_readonly,
 				},
 				required: infer_required(&relation.foreign_key.field_metadata),
+				nullable: relation.foreign_key.field_metadata.nullable,
 				readonly: is_readonly,
 				help_text: None,
 				placeholder: None,
@@ -193,7 +194,7 @@ pub async fn get_fields(
 
 		let is_readonly = readonly_fields.contains(&name.as_str());
 		let metadata = get_field_metadata(table_name, name.as_str());
-		let (field_type, required) = if has_fieldsets {
+		let (field_type, required, nullable) = if has_fieldsets {
 			let metadata = metadata
 				.ok_or_else(|| {
 					AdminError::ValidationError(format!(
@@ -205,15 +206,16 @@ pub async fn get_fields(
 			(
 				infer_admin_field_type_from_metadata(&metadata),
 				infer_required(&metadata),
+				metadata.nullable,
 			)
 		} else {
 			metadata
 				.map(|meta| {
 					let admin_type = infer_admin_field_type_from_metadata(&meta);
 					let is_required = infer_required(&meta);
-					(admin_type, is_required)
+					(admin_type, is_required, meta.nullable)
 				})
-				.unwrap_or((FieldType::Text, false))
+				.unwrap_or((FieldType::Text, false, false))
 		};
 
 		let label = humanize_field_name(&name);
@@ -222,6 +224,7 @@ pub async fn get_fields(
 			label,
 			field_type,
 			required,
+			nullable,
 			readonly: is_readonly,
 			help_text: None,
 			placeholder: None,
@@ -270,6 +273,7 @@ pub async fn get_fields(
 					label: humanize_field_name(name),
 					field_type: infer_admin_field_type_from_metadata(&metadata),
 					required: infer_required(&metadata),
+					nullable: metadata.nullable,
 					readonly: child_readonly_fields.contains(&name.as_str()),
 					help_text: None,
 					placeholder: None,

--- a/crates/reinhardt-admin/src/server/inline.rs
+++ b/crates/reinhardt-admin/src/server/inline.rs
@@ -172,11 +172,35 @@ pub(crate) fn parse_inline_mutations(
 		.collect())
 }
 
-/// Apply the existing mutation sanitizer to every submitted child value.
+/// Sanitizes inline user values while preserving generated file references.
+#[cfg(test)]
 pub(crate) fn sanitize_inline_mutations(mutations: &mut [ParsedInlineMutations]) {
+	sanitize_inline_mutations_with_trusted_fields(mutations, &HashSet::new());
+}
+
+/// Sanitizes inline user values while preserving generated file references.
+pub(crate) fn sanitize_inline_mutations_with_trusted_fields(
+	mutations: &mut [ParsedInlineMutations],
+	trusted_fields: &HashSet<String>,
+) {
 	for mutation in mutations {
+		let inline_key = mutation.key.clone();
 		for row in &mut mutation.rows {
+			let trusted_values = row
+				.values
+				.iter()
+				.filter_map(|(field, value)| {
+					let path = format!(
+						"{INLINE_PREFIX}{inline_key}.{}.{}",
+						row.submitted_index, field
+					);
+					trusted_fields
+						.contains(&path)
+						.then(|| (field.clone(), value.clone()))
+				})
+				.collect::<Vec<_>>();
 			sanitize_mutation_values(&mut row.values);
+			row.values.extend(trusted_values);
 		}
 	}
 }
@@ -1136,6 +1160,35 @@ mod tests {
 
 		sanitize_inline_mutations(&mut mutations);
 
+		assert_eq!(
+			mutations[0].rows[0].values["name"],
+			json!("&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;")
+		);
+	}
+
+	#[rstest]
+	fn sanitizer_preserves_trusted_generated_file_paths() {
+		let key = inline().key().to_owned();
+		let mut mutations = vec![ParsedInlineMutations {
+			key: key.clone(),
+			rows: vec![InlineRowMutation {
+				submitted_index: 0,
+				id: None,
+				values: HashMap::from([
+					("attachment".to_owned(), json!("R&D/file.txt")),
+					("name".to_owned(), json!("<script>alert('xss')</script>")),
+				]),
+				delete: false,
+			}],
+		}];
+		let trusted_fields = HashSet::from([format!("{INLINE_PREFIX}{key}.0.attachment")]);
+
+		sanitize_inline_mutations_with_trusted_fields(&mut mutations, &trusted_fields);
+
+		assert_eq!(
+			mutations[0].rows[0].values["attachment"],
+			json!("R&D/file.txt")
+		);
 		assert_eq!(
 			mutations[0].rows[0].values["name"],
 			json!("&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;")

--- a/crates/reinhardt-admin/src/server/inline.rs
+++ b/crates/reinhardt-admin/src/server/inline.rs
@@ -1,7 +1,8 @@
 use crate::core::database::AdminCreateResult;
 use crate::core::history::insert_history_event;
+pub(crate) use crate::core::inline::InlineSaveOutcome;
 use crate::core::inline::{
-	InlineMutationError, InlineRowMutation, InlineSaveOperation, InlineSaveOutcome, MAX_INLINE_ROWS,
+	InlineMutationError, InlineRowMutation, InlineSaveOperation, MAX_INLINE_ROWS,
 };
 use crate::core::{AdminSite, AdminUser, InlineModelAdmin, canonicalize_admin_primary_key};
 use crate::server::audit;

--- a/crates/reinhardt-admin/src/server/inline_edit.rs
+++ b/crates/reinhardt-admin/src/server/inline_edit.rs
@@ -241,6 +241,14 @@ pub async fn update_inline_edits(
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
 	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Change)
 		.await?;
+	#[cfg(feature = "file-uploads")]
+	for update in &request.updates {
+		super::multipart::reject_file_field_json_data(
+			&update.changes,
+			model_admin.as_ref(),
+			site.as_ref(),
+		)?;
+	}
 	let model_name = model_admin.model_name().to_string();
 	let table_name = model_admin.table_name().to_string();
 	let pk_field = model_admin.pk_field().to_string();

--- a/crates/reinhardt-admin/src/server/list.rs
+++ b/crates/reinhardt-admin/src/server/list.rs
@@ -74,14 +74,15 @@ fn build_columns(model_admin: &Arc<dyn ModelAdmin>, can_change: bool) -> Vec<Col
 				.then(|| get_field_metadata(table_name, field))
 				.flatten();
 			let editable = metadata.is_some();
-			let (required, form_spec) = metadata
+			let (required, nullable, form_spec) = metadata
 				.map(|metadata| {
 					(
 						infer_required(&metadata),
+						metadata.nullable,
 						Some(editable_form_spec(&metadata)),
 					)
 				})
-				.unwrap_or((false, None));
+				.unwrap_or((false, false, None));
 
 			ColumnInfo {
 				field: field.to_string(),
@@ -90,6 +91,7 @@ fn build_columns(model_admin: &Arc<dyn ModelAdmin>, can_change: bool) -> Vec<Col
 				editable,
 				linked: index == 0,
 				required,
+				nullable,
 				form_spec,
 			}
 		})

--- a/crates/reinhardt-admin/src/server/multipart.rs
+++ b/crates/reinhardt-admin/src/server/multipart.rs
@@ -22,14 +22,12 @@ use super::{
 	create::create_record,
 	error::{AdminAuth, MapServerFnError},
 	security::{extract_csrf_header, require_csrf_token},
-	type_inference::{
-		find_model_by_table_name, infer_required, translate_physical_field_names_to_logical,
-	},
-	update::update_record,
+	type_inference::{find_model_by_table_name, infer_required},
+	update::update_record_with_previous_values,
 };
 #[cfg(all(server, feature = "file-uploads"))]
 use crate::{
-	adapters::{AdminDatabase, AdminRecord, AdminSite, ModelAdmin},
+	adapters::{AdminDatabase, AdminSite, ModelAdmin},
 	core::{AdminDatabaseKey, AdminSiteKey},
 	types::{ModelPermission, MutationRequest, MutationResponse},
 };
@@ -49,6 +47,8 @@ pub(crate) const MODEL_PART: &str = "__reinhardt_model";
 pub(crate) const ID_PART: &str = "__reinhardt_id";
 /// Prefix for optional file-clear controls.
 pub(crate) const CLEAR_PREFIX: &str = "__reinhardt_clear.";
+/// Prefix for inline model-form controls that continue into inline parsing.
+pub(crate) const INLINE_PREFIX: &str = "__reinhardt_inlines.";
 
 /// Parsed dynamic admin form data.
 #[derive(Debug)]
@@ -109,6 +109,10 @@ pub(crate) async fn parse_admin_multipart(
 						}
 						serde_json::Value::Bool(false) => {}
 						_ => return Err(invalid_request("clear marker must be boolean")),
+					}
+				} else if name.starts_with(INLINE_PREFIX) {
+					if data.insert(name, value).is_some() {
+						return Err(invalid_request("duplicate form field"));
 					}
 				} else if name.starts_with("__reinhardt_") {
 					return Err(invalid_request("reserved multipart field name"));
@@ -183,7 +187,7 @@ struct AdminFileField {
 #[derive(Debug)]
 struct FileCleanupReference {
 	policy: FileFieldPolicy,
-	file: FileField,
+	field_name: String,
 	operation: FileCleanupOperation,
 }
 
@@ -371,20 +375,21 @@ fn find_file_field<'a>(fields: &'a [AdminFileField], name: &str) -> Option<&'a A
 #[cfg(all(server, feature = "file-uploads"))]
 fn existing_file_reference(
 	values: Option<&HashMap<String, serde_json::Value>>,
-	field: &AdminFileField,
+	field_name: &str,
+	policy: &FileFieldPolicy,
 ) -> Result<Option<FileField>, ServerFnError> {
-	let Some(value) = values.and_then(|values| values.get(&field.logical_name)) else {
+	let Some(value) = values.and_then(|values| values.get(field_name)) else {
 		return Ok(None);
 	};
 	match value {
 		serde_json::Value::Null => Ok(None),
 		serde_json::Value::String(path) if path.is_empty() => Ok(None),
 		serde_json::Value::String(path) => {
-			match FileField::from_existing(path.clone(), field.policy.storage_alias.as_ref()) {
+			match FileField::from_existing(path.clone(), policy.storage_alias.as_ref()) {
 				Ok(file) => Ok(Some(file)),
 				Err(error) => {
 					tracing::warn!(
-						field = field.logical_name.as_str(),
+						field = field_name,
 						error = %error,
 						"Stored file reference is invalid; cleanup was skipped"
 					);
@@ -393,7 +398,7 @@ fn existing_file_reference(
 			}
 		}
 		_ => Err(validation_error(
-			&field.logical_name,
+			field_name,
 			"The stored file reference is not a string",
 		)),
 	}
@@ -404,7 +409,6 @@ fn prepare_file_mutation(
 	payload: AdminMultipartPayload,
 	fields: &[AdminFileField],
 	update: bool,
-	existing: Option<&HashMap<String, serde_json::Value>>,
 ) -> Result<PreparedFileMutation, ServerFnError> {
 	let mut data = payload.data;
 	for name in data.keys() {
@@ -485,13 +489,10 @@ fn prepare_file_mutation(
 	for (logical_name, upload) in sorted_uploads {
 		let field =
 			find_file_field(fields, &logical_name).expect("canonical upload field must resolve");
-		if update
-			&& field.policy.cleanup
-			&& let Some(old_file) = existing_file_reference(existing, field)?
-		{
+		if update && field.policy.cleanup {
 			cleanup.push(FileCleanupReference {
 				policy: field.policy.clone(),
-				file: old_file,
+				field_name: field.logical_name.clone(),
 				operation: FileCleanupOperation::Replace,
 			});
 		}
@@ -510,12 +511,10 @@ fn prepare_file_mutation(
 	for logical_name in clears {
 		let field =
 			find_file_field(fields, &logical_name).expect("canonical clear field must resolve");
-		if field.policy.cleanup
-			&& let Some(old_file) = existing_file_reference(existing, field)?
-		{
+		if field.policy.cleanup {
 			cleanup.push(FileCleanupReference {
 				policy: field.policy.clone(),
-				file: old_file,
+				field_name: field.logical_name.clone(),
 				operation: FileCleanupOperation::Clear,
 			});
 		}
@@ -537,6 +536,14 @@ fn map_file_mutation_error(
 ) -> ServerFnError {
 	match error {
 		FileMutationError::Database(error) => error,
+		FileMutationError::StorageForField { field, source } => {
+			tracing::warn!(
+				field = field.as_str(),
+				error = %source,
+				"Admin file upload failed before database persistence"
+			);
+			validation_error(&field, "The file could not be stored")
+		}
 		FileMutationError::Storage(error) => {
 			tracing::warn!(
 				field = fallback_field,
@@ -563,28 +570,8 @@ async fn persist_file_mutation(
 		model_admin,
 	} = context;
 	let update = id.is_some();
-	let existing = if let Some(id) = id.as_deref() {
-		let object_id = crate::core::database::canonicalize_pk_value(
-			model_admin.table_name(),
-			model_admin.pk_field(),
-			id,
-		);
-		let mut values = db
-			.get::<AdminRecord>(model_admin.table_name(), model_admin.pk_field(), &object_id)
-			.await
-			.map_server_fn_error()?;
-		if let Some(values) = values.as_mut() {
-			translate_physical_field_names_to_logical(model_admin.table_name(), values)
-				.map_server_fn_error()?;
-		} else {
-			return Err(ServerFnError::server(404, "Record not found"));
-		}
-		values
-	} else {
-		None
-	};
 	let fields = file_fields_for_model(model_admin.as_ref())?;
-	let prepared = prepare_file_mutation(payload, &fields, update, existing.as_ref())?;
+	let prepared = prepare_file_mutation(payload, &fields, update)?;
 	let fallback_field = prepared
 		.write_fields
 		.first()
@@ -608,9 +595,9 @@ async fn persist_file_mutation(
 			);
 		}
 		let request = MutationRequest { csrf_token, data };
-		let response = match id {
+		let (response, previous) = match id {
 			Some(id) => {
-				update_record(
+				let (response, previous) = update_record_with_previous_values(
 					model_name,
 					id,
 					request,
@@ -619,10 +606,11 @@ async fn persist_file_mutation(
 					http_request,
 					AdminAuthenticatedUser(user),
 				)
-				.await?
+				.await?;
+				(response, Some(previous))
 			}
 			None => {
-				create_record(
+				let response = create_record(
 					model_name,
 					request,
 					KeyedDepends::from_value(site_value),
@@ -630,12 +618,17 @@ async fn persist_file_mutation(
 					http_request,
 					AdminAuthenticatedUser(user),
 				)
-				.await?
+				.await?;
+				(response, None)
 			}
 		};
 		let mut commit = FileCommit::new(response);
 		for cleanup in cleanup {
-			commit = commit.cleanup(cleanup.policy, cleanup.file, cleanup.operation);
+			if let Some(file) =
+				existing_file_reference(previous.as_ref(), &cleanup.field_name, &cleanup.policy)?
+			{
+				commit = commit.cleanup(cleanup.policy, file, cleanup.operation);
+			}
 		}
 		Ok(commit)
 	};
@@ -824,6 +817,22 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn parse_admin_multipart_preserves_inline_controls() {
+		let request = multipart_request(
+			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_inlines.comments.0.__present\"\r\n\r\ntrue\r\n--boundary--\r\n",
+		);
+
+		let payload = parse_admin_multipart(&request, false)
+			.await
+			.expect("inline controls should remain available to inline parsing");
+
+		assert_eq!(
+			payload.data.get("__reinhardt_inlines.comments.0.__present"),
+			Some(&serde_json::json!(true))
+		);
+	}
+
+	#[tokio::test]
 	async fn parse_admin_multipart_rejects_duplicate_names() {
 		let request = multipart_request(
 			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n\"one\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n\"two\"\r\n--boundary--\r\n",
@@ -919,7 +928,7 @@ mod file_lifecycle_tests {
 				.with_filename("avatar.png".to_owned()),
 		);
 
-		let prepared = prepare_file_mutation(payload, &[field(true, false, true)], false, None)
+		let prepared = prepare_file_mutation(payload, &[field(true, false, true)], false)
 			.expect("required upload should be prepared");
 
 		assert_eq!(prepared.write_fields, vec!["avatar"]);
@@ -933,12 +942,8 @@ mod file_lifecycle_tests {
 		payload
 			.data
 			.insert("title".to_owned(), serde_json::json!("Updated"));
-		let existing =
-			HashMap::from([(String::from("avatar"), serde_json::json!("avatars/old.png"))]);
-
-		let prepared =
-			prepare_file_mutation(payload, &[field(true, false, true)], true, Some(&existing))
-				.expect("omitting an update file should preserve it");
+		let prepared = prepare_file_mutation(payload, &[field(true, false, true)], true)
+			.expect("omitting an update file should preserve it");
 
 		assert!(prepared.writes.is_empty());
 		assert!(prepared.cleanup.is_empty());
@@ -952,29 +957,21 @@ mod file_lifecycle_tests {
 	fn nullable_clear_sets_null_and_schedules_old_file_cleanup() {
 		let mut payload = payload();
 		payload.clears.insert("avatar".to_owned());
-		let existing =
-			HashMap::from([(String::from("avatar"), serde_json::json!("avatars/old.png"))]);
-
-		let prepared =
-			prepare_file_mutation(payload, &[field(false, true, true)], true, Some(&existing))
-				.expect("nullable clear should be prepared");
+		let prepared = prepare_file_mutation(payload, &[field(false, true, true)], true)
+			.expect("nullable clear should be prepared");
 
 		assert_eq!(prepared.data.get("avatar"), Some(&serde_json::Value::Null));
 		assert_eq!(prepared.cleanup.len(), 1);
+		assert_eq!(prepared.cleanup[0].field_name, "avatar");
 		assert_eq!(prepared.cleanup[0].operation, FileCleanupOperation::Clear);
-		assert_eq!(prepared.cleanup[0].file.path(), "avatars/old.png");
 	}
 
 	#[test]
 	fn cleanup_opt_out_keeps_the_old_reference_without_scheduling_cleanup() {
 		let mut payload = payload();
 		payload.clears.insert("avatar".to_owned());
-		let existing =
-			HashMap::from([(String::from("avatar"), serde_json::json!("avatars/old.png"))]);
-
-		let prepared =
-			prepare_file_mutation(payload, &[field(false, true, false)], true, Some(&existing))
-				.expect("cleanup opt-out should still clear the database value");
+		let prepared = prepare_file_mutation(payload, &[field(false, true, false)], true)
+			.expect("cleanup opt-out should still clear the database value");
 
 		assert_eq!(prepared.data.get("avatar"), Some(&serde_json::Value::Null));
 		assert!(prepared.cleanup.is_empty());

--- a/crates/reinhardt-admin/src/server/multipart.rs
+++ b/crates/reinhardt-admin/src/server/multipart.rs
@@ -131,7 +131,7 @@ fn invalid_request(message: &'static str) -> ServerFnError {
 }
 
 fn is_empty_file_input(file: &UploadedFile) -> bool {
-	file.size == 0
+	file.size == 0 && file.filename.as_deref().is_none_or(str::is_empty)
 }
 
 #[cfg(all(test, server))]
@@ -153,7 +153,7 @@ mod tests {
 	#[tokio::test]
 	async fn parse_admin_multipart_extracts_fields_uploads_and_clears() {
 		let request = multipart_request(
-			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_id\"\r\n\r\n\"42\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n\"Hello\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_clear.thumbnail\"\r\n\r\ntrue\r\n--boundary\r\nContent-Disposition: form-data; name=\"image\"; filename=\"cover.png\"\r\nContent-Type: image/png\r\n\r\npng\r\n--boundary\r\nContent-Disposition: form-data; name=\"attachment\"; filename=\"empty.txt\"\r\nContent-Type: application/octet-stream\r\n\r\n\r\n--boundary--\r\n",
+			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_id\"\r\n\r\n\"42\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n\"Hello\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_clear.thumbnail\"\r\n\r\ntrue\r\n--boundary\r\nContent-Disposition: form-data; name=\"image\"; filename=\"cover.png\"\r\nContent-Type: image/png\r\n\r\npng\r\n--boundary\r\nContent-Disposition: form-data; name=\"attachment\"; filename=\"\"\r\nContent-Type: application/octet-stream\r\n\r\n\r\n--boundary--\r\n",
 		);
 
 		let payload = parse_admin_multipart(&request, true)

--- a/crates/reinhardt-admin/src/server/multipart.rs
+++ b/crates/reinhardt-admin/src/server/multipart.rs
@@ -19,16 +19,19 @@ use reinhardt_pages::server_fn::{MultipartArguments, ServerFnError};
 #[cfg(all(server, feature = "file-uploads"))]
 use super::{
 	admin_auth::AdminAuthenticatedUser,
-	create::create_record_with_inline_outcomes,
+	create::create_record_with_trusted_file_fields,
 	error::{AdminAuth, MapServerFnError},
 	security::{extract_csrf_header, require_csrf_token},
 	type_inference::{find_model_by_table_name, infer_required},
-	update::update_record_with_previous_values,
+	update::update_record_with_trusted_file_fields,
 };
 #[cfg(all(server, feature = "file-uploads"))]
 use crate::{
 	adapters::{AdminDatabase, AdminSite, ModelAdmin},
-	core::{AdminDatabaseKey, AdminSiteKey, inline::InlineSaveOperation},
+	core::{
+		AdminDatabaseKey, AdminSiteKey,
+		inline::{InlineSaveOperation, InlineSaveOutcome},
+	},
 	types::{ModelPermission, MutationRequest, MutationResponse},
 };
 #[cfg(all(server, feature = "file-uploads"))]
@@ -488,18 +491,29 @@ pub(crate) fn reject_file_field_json_data(
 	model_admin: &dyn ModelAdmin,
 	site: &AdminSite,
 ) -> Result<(), ServerFnError> {
+	reject_file_field_json_data_with_trusted_fields(data, model_admin, site, &HashSet::new())
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+pub(crate) fn reject_file_field_json_data_with_trusted_fields(
+	data: &HashMap<String, serde_json::Value>,
+	model_admin: &dyn ModelAdmin,
+	site: &AdminSite,
+	trusted_file_fields: &HashSet<String>,
+) -> Result<(), ServerFnError> {
 	let fields = all_file_fields_for_model(model_admin)?;
-	if let Some(name) = data
-		.keys()
-		.find(|name| find_file_field(&fields, name).is_some())
-	{
+	if let Some(name) = data.keys().find(|name| {
+		!trusted_file_fields.contains(*name) && find_file_field(&fields, name).is_some()
+	}) {
 		return Err(validation_error(
 			name,
 			"File fields must be submitted through the multipart endpoint",
 		));
 	}
 	if let Some(name) = data.keys().find(|name| {
-		name.starts_with(INLINE_PREFIX) && inline_file_target(name, model_admin, site).is_ok()
+		!trusted_file_fields.contains(*name)
+			&& name.starts_with(INLINE_PREFIX)
+			&& inline_file_target(name, model_admin, site).is_ok()
 	}) {
 		return Err(validation_error(
 			name,
@@ -538,6 +552,85 @@ fn existing_file_reference(
 			field_name,
 			"The stored file reference is not a string",
 		)),
+	}
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn add_inline_delete_cleanups<T>(
+	site: &AdminSite,
+	outcomes: &[InlineSaveOutcome],
+	mut commit: FileCommit<T>,
+) -> FileCommit<T> {
+	for outcome in outcomes
+		.iter()
+		.filter(|outcome| matches!(outcome.operation, InlineSaveOperation::Delete))
+	{
+		let child_admin = match site.get_model_admin_by_table_name(&outcome.table_name) {
+			Ok(child_admin) => child_admin,
+			Err(error) => {
+				tracing::warn!(
+					table = outcome.table_name.as_str(),
+					error = %error,
+					"Deleted inline file fields could not be resolved"
+				);
+				continue;
+			}
+		};
+		let fields = match all_file_fields_for_model(child_admin.as_ref()) {
+			Ok(fields) => fields,
+			Err(error) => {
+				tracing::warn!(
+					table = outcome.table_name.as_str(),
+					error = %error,
+					"Deleted inline file fields could not be resolved"
+				);
+				continue;
+			}
+		};
+		for field in fields {
+			if !field.policy.cleanup {
+				continue;
+			}
+			match existing_file_reference(
+				Some(&outcome.previous_values),
+				&field.logical_name,
+				&field.policy,
+			) {
+				Ok(Some(file)) => {
+					commit = commit.cleanup(field.policy, file, FileCleanupOperation::Delete);
+				}
+				Ok(None) => {}
+				Err(error) => tracing::warn!(
+					field = field.logical_name.as_str(),
+					error = %error,
+					"Deleted inline file reference could not be prepared for cleanup"
+				),
+			}
+		}
+	}
+	commit
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+pub(crate) async fn schedule_inline_delete_cleanups(
+	site: AdminSite,
+	outcomes: Vec<InlineSaveOutcome>,
+) {
+	if !outcomes
+		.iter()
+		.any(|outcome| matches!(outcome.operation, InlineSaveOperation::Delete))
+	{
+		return;
+	}
+	let commit = add_inline_delete_cleanups(&site, &outcomes, FileCommit::new(()));
+	if let Err(error) =
+		coordinate_file_mutations(
+			Vec::new(),
+			move |_| async move { Ok::<_, Infallible>(commit) },
+		)
+		.await
+	{
+		tracing::warn!(error = %error, "Deleted inline file cleanup could not be scheduled");
 	}
 }
 
@@ -810,6 +903,11 @@ async fn persist_file_mutation(
 	let site_value = (*site).clone();
 	let site_for_inline_cleanup = site_value.clone();
 	let db_value = (*db).clone();
+	let trusted_file_fields = prepared
+		.write_fields
+		.iter()
+		.cloned()
+		.collect::<HashSet<_>>();
 	let write_fields = prepared.write_fields;
 	let inline_write_targets = prepared.inline_write_targets;
 	let cleanup = prepared.cleanup;
@@ -845,7 +943,7 @@ async fn persist_file_mutation(
 		let request = MutationRequest { csrf_token, data };
 		let (response, previous, outcomes) = match id {
 			Some(id) => {
-				let (response, previous, outcomes) = update_record_with_previous_values(
+				let (response, previous, outcomes) = update_record_with_trusted_file_fields(
 					model_name,
 					id,
 					request,
@@ -853,18 +951,20 @@ async fn persist_file_mutation(
 					KeyedDepends::from_value(db_value),
 					http_request,
 					AdminAuthenticatedUser(user),
+					&trusted_file_fields,
 				)
 				.await?;
 				(response, Some(previous), outcomes)
 			}
 			None => {
-				let (response, outcomes) = create_record_with_inline_outcomes(
+				let (response, outcomes) = create_record_with_trusted_file_fields(
 					model_name,
 					request,
 					KeyedDepends::from_value(site_value),
 					KeyedDepends::from_value(db_value),
 					http_request,
 					AdminAuthenticatedUser(user),
+					&trusted_file_fields,
 				)
 				.await?;
 				(response, None, outcomes)
@@ -872,10 +972,16 @@ async fn persist_file_mutation(
 		};
 		let mut commit = FileCommit::new(response);
 		for cleanup in cleanup {
-			if let Some(file) =
-				existing_file_reference(previous.as_ref(), &cleanup.field_name, &cleanup.policy)?
-			{
-				commit = commit.cleanup(cleanup.policy, file, cleanup.operation);
+			match existing_file_reference(previous.as_ref(), &cleanup.field_name, &cleanup.policy) {
+				Ok(Some(file)) => {
+					commit = commit.cleanup(cleanup.policy, file, cleanup.operation);
+				}
+				Ok(None) => {}
+				Err(error) => tracing::warn!(
+					field = cleanup.field_name.as_str(),
+					error = %error,
+					"Previous file reference could not be prepared for cleanup"
+				),
 			}
 		}
 		for target in stored_inline_targets {
@@ -888,34 +994,23 @@ async fn persist_file_mutation(
 			}) else {
 				continue;
 			};
-			if let Some(file) = existing_file_reference(
+			match existing_file_reference(
 				Some(&outcome.previous_values),
 				&target.field_name,
 				&target.policy,
-			)? {
-				commit = commit.cleanup(target.policy, file, FileCleanupOperation::Replace);
+			) {
+				Ok(Some(file)) => {
+					commit = commit.cleanup(target.policy, file, FileCleanupOperation::Replace);
+				}
+				Ok(None) => {}
+				Err(error) => tracing::warn!(
+					field = target.path.as_str(),
+					error = %error,
+					"Previous inline file reference could not be prepared for cleanup"
+				),
 			}
 		}
-		for outcome in outcomes
-			.iter()
-			.filter(|outcome| matches!(outcome.operation, InlineSaveOperation::Delete))
-		{
-			let child_admin = site_for_inline_cleanup
-				.get_model_admin_by_table_name(&outcome.table_name)
-				.map_server_fn_error()?;
-			for field in all_file_fields_for_model(child_admin.as_ref())? {
-				if !field.policy.cleanup {
-					continue;
-				}
-				if let Some(file) = existing_file_reference(
-					Some(&outcome.previous_values),
-					&field.logical_name,
-					&field.policy,
-				)? {
-					commit = commit.cleanup(field.policy, file, FileCleanupOperation::Delete);
-				}
-			}
-		}
+		commit = add_inline_delete_cleanups(&site_for_inline_cleanup, &outcomes, commit);
 		Ok(commit)
 	};
 	let response = if has_file_lifecycle {

--- a/crates/reinhardt-admin/src/server/multipart.rs
+++ b/crates/reinhardt-admin/src/server/multipart.rs
@@ -1,0 +1,215 @@
+//! Dynamic multipart payloads used by admin model forms.
+
+use std::collections::{HashMap, HashSet};
+
+use reinhardt_core::parsers::{UploadedFile, multipart::MultipartPart};
+use reinhardt_pages::server_fn::{MultipartArguments, ServerFnError};
+
+/// Reserved multipart part containing the registered model name.
+pub(crate) const MODEL_PART: &str = "__reinhardt_model";
+/// Reserved multipart part containing the edited record ID.
+pub(crate) const ID_PART: &str = "__reinhardt_id";
+/// Prefix for optional file-clear controls.
+pub(crate) const CLEAR_PREFIX: &str = "__reinhardt_clear.";
+
+/// Parsed dynamic admin form data.
+#[derive(Debug)]
+pub(crate) struct AdminMultipartPayload {
+	/// Registered model name supplied by the form client.
+	pub model_name: String,
+	/// Edited record ID, or `None` for create requests.
+	pub id: Option<String>,
+	/// JSON scalar values keyed by logical field name.
+	pub data: HashMap<String, serde_json::Value>,
+	/// Uploaded files keyed by logical field name.
+	pub uploads: HashMap<String, UploadedFile>,
+	/// Nullable file fields explicitly marked for clearing.
+	pub clears: HashSet<String>,
+}
+
+/// Parse a dynamic admin multipart request while rejecting unconsumed input.
+#[cfg(server)]
+pub(crate) async fn parse_admin_multipart(
+	request: &reinhardt_http::Request,
+	update: bool,
+) -> Result<AdminMultipartPayload, ServerFnError> {
+	let arguments = MultipartArguments::from_request(request).await?;
+	let mut model_name = None;
+	let mut id = None;
+	let mut data = HashMap::new();
+	let mut uploads = HashMap::new();
+	let mut clears = HashSet::new();
+
+	for part in arguments.into_parts() {
+		match part {
+			MultipartPart::Field { name, data: bytes } => {
+				let value: serde_json::Value = serde_json::from_slice(&bytes)
+					.map_err(|_| invalid_request("malformed JSON field"))?;
+				if name == MODEL_PART {
+					if model_name.is_some() {
+						return Err(invalid_request("duplicate model part"));
+					}
+					model_name = Some(required_string(value, MODEL_PART)?);
+				} else if name == ID_PART {
+					if !update || id.is_some() {
+						return Err(invalid_request("unexpected record ID part"));
+					}
+					id = Some(required_string(value, ID_PART)?);
+				} else if let Some(field_name) = name.strip_prefix(CLEAR_PREFIX) {
+					if field_name.is_empty() {
+						return Err(invalid_request("empty clear field name"));
+					}
+					match value {
+						serde_json::Value::Bool(true) => {
+							clears.insert(field_name.to_owned());
+						}
+						serde_json::Value::Bool(false) => {}
+						_ => return Err(invalid_request("clear marker must be boolean")),
+					}
+				} else if name.starts_with("__reinhardt_") {
+					return Err(invalid_request("reserved multipart field name"));
+				} else if data.insert(name, value).is_some() {
+					return Err(invalid_request("duplicate form field"));
+				}
+			}
+			MultipartPart::File(file) => {
+				if file.name.is_empty() || file.name.starts_with("__reinhardt_") {
+					return Err(invalid_request("invalid uploaded file field name"));
+				}
+				if is_empty_file_input(&file) {
+					continue;
+				}
+				if uploads.insert(file.name.clone(), file).is_some() {
+					return Err(invalid_request("duplicate uploaded file"));
+				}
+			}
+		}
+	}
+
+	let model_name = model_name.ok_or_else(|| invalid_request("missing model part"))?;
+	if update && id.is_none() {
+		return Err(invalid_request("missing record ID part"));
+	}
+
+	Ok(AdminMultipartPayload {
+		model_name,
+		id,
+		data,
+		uploads,
+		clears,
+	})
+}
+
+#[cfg(server)]
+fn required_string(value: serde_json::Value, field: &str) -> Result<String, ServerFnError> {
+	match value {
+		serde_json::Value::String(value) if !value.trim().is_empty() => Ok(value),
+		_ => Err(invalid_request(match field {
+			MODEL_PART => "model part must be a non-empty string",
+			ID_PART => "record ID part must be a non-empty string",
+			_ => "reserved part must be a non-empty string",
+		})),
+	}
+}
+
+#[cfg(server)]
+fn invalid_request(message: &'static str) -> ServerFnError {
+	tracing::warn!(message, "Rejected dynamic admin multipart request");
+	ServerFnError::server(400, "Invalid admin multipart request")
+}
+
+fn is_empty_file_input(file: &UploadedFile) -> bool {
+	file.size == 0 && file.filename.as_deref().is_none_or(str::is_empty)
+}
+
+#[cfg(all(test, server))]
+mod tests {
+	use super::*;
+
+	fn multipart_request(parts: &str) -> reinhardt_http::Request {
+		reinhardt_http::Request::builder()
+			.uri("/api/server_fn/create_record_multipart")
+			.header(
+				hyper::header::CONTENT_TYPE,
+				"multipart/form-data; boundary=boundary",
+			)
+			.body(parts.as_bytes().to_vec().into())
+			.build()
+			.expect("multipart request should build")
+	}
+
+	#[tokio::test]
+	async fn parse_admin_multipart_extracts_fields_uploads_and_clears() {
+		let request = multipart_request(
+			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_id\"\r\n\r\n\"42\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n\"Hello\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_clear.thumbnail\"\r\n\r\ntrue\r\n--boundary\r\nContent-Disposition: form-data; name=\"image\"; filename=\"cover.png\"\r\nContent-Type: image/png\r\n\r\npng\r\n--boundary--\r\n",
+		);
+
+		let payload = parse_admin_multipart(&request, true)
+			.await
+			.expect("multipart payload should parse");
+
+		assert_eq!(payload.model_name, "Article");
+		assert_eq!(payload.id.as_deref(), Some("42"));
+		assert_eq!(payload.data.get("title"), Some(&serde_json::json!("Hello")));
+		assert_eq!(
+			payload
+				.uploads
+				.get("image")
+				.and_then(|file| file.filename.as_deref()),
+			Some("cover.png")
+		);
+		assert!(payload.clears.contains("thumbnail"));
+	}
+
+	#[tokio::test]
+	async fn parse_admin_multipart_rejects_duplicate_names() {
+		let request = multipart_request(
+			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n\"one\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n\"two\"\r\n--boundary--\r\n",
+		);
+
+		let error = parse_admin_multipart(&request, false)
+			.await
+			.expect_err("duplicate multipart names must fail");
+
+		assert_eq!(error.status(), Some(400));
+	}
+
+	#[tokio::test]
+	async fn parse_admin_multipart_rejects_malformed_json() {
+		let request = multipart_request(
+			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nnot-json\r\n--boundary--\r\n",
+		);
+
+		let error = parse_admin_multipart(&request, false)
+			.await
+			.expect_err("malformed JSON must fail");
+
+		assert_eq!(error.status(), Some(400));
+	}
+
+	#[tokio::test]
+	async fn parse_admin_multipart_requires_an_id_for_updates() {
+		let request = multipart_request(
+			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary--\r\n",
+		);
+
+		let error = parse_admin_multipart(&request, true)
+			.await
+			.expect_err("update multipart payloads require an ID");
+
+		assert_eq!(error.status(), Some(400));
+	}
+
+	#[tokio::test]
+	async fn parse_admin_multipart_rejects_update_parts_on_creates() {
+		let request = multipart_request(
+			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_id\"\r\n\r\n\"42\"\r\n--boundary--\r\n",
+		);
+
+		let error = parse_admin_multipart(&request, false)
+			.await
+			.expect_err("create multipart payloads must reject update-only parts");
+
+		assert_eq!(error.status(), Some(400));
+	}
+}

--- a/crates/reinhardt-admin/src/server/multipart.rs
+++ b/crates/reinhardt-admin/src/server/multipart.rs
@@ -2,7 +2,10 @@
 
 use std::collections::{HashMap, HashSet};
 
-use reinhardt_core::parsers::{UploadedFile, multipart::MultipartPart};
+use reinhardt_core::parsers::UploadedFile;
+#[cfg(server)]
+use reinhardt_core::parsers::multipart::MultipartPart;
+#[cfg(server)]
 use reinhardt_pages::server_fn::{MultipartArguments, ServerFnError};
 
 /// Reserved multipart part containing the registered model name.
@@ -23,6 +26,8 @@ pub(crate) struct AdminMultipartPayload {
 	pub data: HashMap<String, serde_json::Value>,
 	/// Uploaded files keyed by logical field name.
 	pub uploads: HashMap<String, UploadedFile>,
+	/// Empty browser file inputs keyed by logical field name.
+	pub empty_uploads: HashSet<String>,
 	/// Nullable file fields explicitly marked for clearing.
 	pub clears: HashSet<String>,
 }
@@ -33,16 +38,20 @@ pub(crate) async fn parse_admin_multipart(
 	request: &reinhardt_http::Request,
 	update: bool,
 ) -> Result<AdminMultipartPayload, ServerFnError> {
-	let arguments = MultipartArguments::from_request(request).await?;
+	let mut arguments = MultipartArguments::from_request(request).await?;
 	let mut model_name = None;
 	let mut id = None;
 	let mut data = HashMap::new();
 	let mut uploads = HashMap::new();
+	let mut empty_uploads = HashSet::new();
 	let mut clears = HashSet::new();
 
-	for part in arguments.into_parts() {
+	for part in arguments.take_parts() {
 		match part {
 			MultipartPart::Field { name, data: bytes } => {
+				if bytes.is_empty() {
+					return Err(invalid_request("empty JSON field"));
+				}
 				let value: serde_json::Value = serde_json::from_slice(&bytes)
 					.map_err(|_| invalid_request("malformed JSON field"))?;
 				if name == MODEL_PART {
@@ -77,6 +86,7 @@ pub(crate) async fn parse_admin_multipart(
 					return Err(invalid_request("invalid uploaded file field name"));
 				}
 				if is_empty_file_input(&file) {
+					empty_uploads.insert(file.name.clone());
 					continue;
 				}
 				if uploads.insert(file.name.clone(), file).is_some() {
@@ -85,6 +95,7 @@ pub(crate) async fn parse_admin_multipart(
 			}
 		}
 	}
+	arguments.finish()?;
 
 	let model_name = model_name.ok_or_else(|| invalid_request("missing model part"))?;
 	if update && id.is_none() {
@@ -96,6 +107,7 @@ pub(crate) async fn parse_admin_multipart(
 		id,
 		data,
 		uploads,
+		empty_uploads,
 		clears,
 	})
 }
@@ -119,7 +131,7 @@ fn invalid_request(message: &'static str) -> ServerFnError {
 }
 
 fn is_empty_file_input(file: &UploadedFile) -> bool {
-	file.size == 0 && file.filename.as_deref().is_none_or(str::is_empty)
+	file.size == 0
 }
 
 #[cfg(all(test, server))]
@@ -141,7 +153,7 @@ mod tests {
 	#[tokio::test]
 	async fn parse_admin_multipart_extracts_fields_uploads_and_clears() {
 		let request = multipart_request(
-			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_id\"\r\n\r\n\"42\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n\"Hello\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_clear.thumbnail\"\r\n\r\ntrue\r\n--boundary\r\nContent-Disposition: form-data; name=\"image\"; filename=\"cover.png\"\r\nContent-Type: image/png\r\n\r\npng\r\n--boundary--\r\n",
+			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_id\"\r\n\r\n\"42\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n\"Hello\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_clear.thumbnail\"\r\n\r\ntrue\r\n--boundary\r\nContent-Disposition: form-data; name=\"image\"; filename=\"cover.png\"\r\nContent-Type: image/png\r\n\r\npng\r\n--boundary\r\nContent-Disposition: form-data; name=\"attachment\"; filename=\"empty.txt\"\r\nContent-Type: application/octet-stream\r\n\r\n\r\n--boundary--\r\n",
 		);
 
 		let payload = parse_admin_multipart(&request, true)
@@ -158,6 +170,7 @@ mod tests {
 				.and_then(|file| file.filename.as_deref()),
 			Some("cover.png")
 		);
+		assert!(payload.empty_uploads.contains("attachment"));
 		assert!(payload.clears.contains("thumbnail"));
 	}
 

--- a/crates/reinhardt-admin/src/server/multipart.rs
+++ b/crates/reinhardt-admin/src/server/multipart.rs
@@ -19,7 +19,7 @@ use reinhardt_pages::server_fn::{MultipartArguments, ServerFnError};
 #[cfg(all(server, feature = "file-uploads"))]
 use super::{
 	admin_auth::AdminAuthenticatedUser,
-	create::create_record,
+	create::create_record_with_inline_outcomes,
 	error::{AdminAuth, MapServerFnError},
 	security::{extract_csrf_header, require_csrf_token},
 	type_inference::{find_model_by_table_name, infer_required},
@@ -121,7 +121,10 @@ pub(crate) async fn parse_admin_multipart(
 				}
 			}
 			MultipartPart::File(file) => {
-				if file.name.is_empty() || file.name.starts_with("__reinhardt_") {
+				if file.name.is_empty()
+					|| (file.name.starts_with("__reinhardt_")
+						&& !file.name.starts_with(INLINE_PREFIX))
+				{
 					return Err(invalid_request("invalid uploaded file field name"));
 				}
 				if is_empty_file_input(&file) {
@@ -196,7 +199,18 @@ struct PreparedFileMutation {
 	data: HashMap<String, serde_json::Value>,
 	writes: Vec<PendingFileUpload>,
 	write_fields: Vec<String>,
+	inline_write_targets: Vec<Option<InlineFileTarget>>,
 	cleanup: Vec<FileCleanupReference>,
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+#[derive(Clone, Debug)]
+struct InlineFileTarget {
+	path: String,
+	inline_key: String,
+	submitted_index: usize,
+	field_name: String,
+	policy: FileFieldPolicy,
 }
 
 #[cfg(all(server, feature = "file-uploads"))]
@@ -317,7 +331,7 @@ fn file_field_policy(
 }
 
 #[cfg(all(server, feature = "file-uploads"))]
-fn file_fields_for_model(
+fn all_file_fields_for_model(
 	model_admin: &dyn ModelAdmin,
 ) -> Result<Vec<AdminFileField>, ServerFnError> {
 	let metadata = find_model_by_table_name(model_admin.table_name())
@@ -366,10 +380,131 @@ fn file_fields_for_model(
 }
 
 #[cfg(all(server, feature = "file-uploads"))]
+fn file_fields_for_model(
+	model_admin: &dyn ModelAdmin,
+) -> Result<Vec<AdminFileField>, ServerFnError> {
+	let mut fields = all_file_fields_for_model(model_admin)?;
+	let (form_fields, _) = crate::core::resolve_form_fields(model_admin)
+		.map_err(|_| ServerFnError::server(500, "Invalid admin form configuration"))?;
+	let readonly_fields = model_admin.readonly_fields();
+	fields.retain(|field| {
+		let exposed = form_fields
+			.iter()
+			.any(|name| field.aliases.iter().any(|alias| alias == name));
+		let readonly = readonly_fields
+			.iter()
+			.any(|name| field.aliases.iter().any(|alias| alias == name));
+		exposed && !readonly
+	});
+	Ok(fields)
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
 fn find_file_field<'a>(fields: &'a [AdminFileField], name: &str) -> Option<&'a AdminFileField> {
 	fields
 		.iter()
 		.find(|field| field.aliases.iter().any(|alias| alias == name))
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn inline_file_target(
+	name: &str,
+	model_admin: &dyn ModelAdmin,
+	site: &AdminSite,
+) -> Result<InlineFileTarget, ServerFnError> {
+	let path = name
+		.strip_prefix(INLINE_PREFIX)
+		.ok_or_else(|| validation_error(name, "Invalid inline file field"))?;
+	let mut parts = path.split('.');
+	let inline_key = parts
+		.next()
+		.filter(|value| !value.is_empty())
+		.ok_or_else(|| validation_error(name, "Invalid inline file field"))?;
+	let submitted_index = parts
+		.next()
+		.ok_or_else(|| validation_error(name, "Invalid inline file field"))?
+		.parse::<usize>()
+		.ok()
+		.filter(|index| *index < 100)
+		.ok_or_else(|| validation_error(name, "Invalid inline row index"))?;
+	let field_name = parts
+		.next()
+		.filter(|value| !value.is_empty())
+		.ok_or_else(|| validation_error(name, "Invalid inline file field"))?;
+	if parts.next().is_some() {
+		return Err(validation_error(name, "Invalid inline file field"));
+	}
+	let inline = model_admin
+		.inlines()
+		.into_iter()
+		.find(|inline| inline.key() == inline_key)
+		.ok_or_else(|| validation_error(name, "Unknown inline"))?;
+	if !inline.fields().iter().any(|field| field == field_name) {
+		return Err(validation_error(name, "Inline field is not editable"));
+	}
+	let child_admin = site
+		.get_model_admin(inline.child_model())
+		.map_server_fn_error()?;
+	let child_fields = all_file_fields_for_model(child_admin.as_ref())?;
+	let field = find_file_field(&child_fields, field_name)
+		.ok_or_else(|| validation_error(name, "Unknown inline file field"))?;
+	if child_admin
+		.readonly_fields()
+		.iter()
+		.any(|configured| field.aliases.iter().any(|alias| alias == configured))
+	{
+		return Err(validation_error(name, "Inline field is read-only"));
+	}
+
+	Ok(InlineFileTarget {
+		path: name.to_owned(),
+		inline_key: inline_key.to_owned(),
+		submitted_index,
+		field_name: field.logical_name.clone(),
+		policy: field.policy.clone(),
+	})
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+pub(crate) fn file_field_aliases(
+	model_admin: &dyn ModelAdmin,
+) -> Result<Vec<(String, String)>, ServerFnError> {
+	let mut aliases = Vec::new();
+	for field in file_fields_for_model(model_admin)? {
+		for alias in field.aliases {
+			if alias != field.logical_name {
+				aliases.push((field.logical_name.clone(), alias));
+			}
+		}
+	}
+	Ok(aliases)
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+pub(crate) fn reject_file_field_json_data(
+	data: &HashMap<String, serde_json::Value>,
+	model_admin: &dyn ModelAdmin,
+	site: &AdminSite,
+) -> Result<(), ServerFnError> {
+	let fields = all_file_fields_for_model(model_admin)?;
+	if let Some(name) = data
+		.keys()
+		.find(|name| find_file_field(&fields, name).is_some())
+	{
+		return Err(validation_error(
+			name,
+			"File fields must be submitted through the multipart endpoint",
+		));
+	}
+	if let Some(name) = data.keys().find(|name| {
+		name.starts_with(INLINE_PREFIX) && inline_file_target(name, model_admin, site).is_ok()
+	}) {
+		return Err(validation_error(
+			name,
+			"File fields must be submitted through the multipart endpoint",
+		));
+	}
+	Ok(())
 }
 
 #[cfg(all(server, feature = "file-uploads"))]
@@ -404,10 +539,21 @@ fn existing_file_reference(
 	}
 }
 
-#[cfg(all(server, feature = "file-uploads"))]
+#[cfg(all(test, server, feature = "file-uploads"))]
 fn prepare_file_mutation(
 	payload: AdminMultipartPayload,
 	fields: &[AdminFileField],
+	update: bool,
+) -> Result<PreparedFileMutation, ServerFnError> {
+	prepare_file_mutation_with_inlines(payload, fields, None, None, update)
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn prepare_file_mutation_with_inlines(
+	payload: AdminMultipartPayload,
+	fields: &[AdminFileField],
+	model_admin: Option<&dyn ModelAdmin>,
+	site: Option<&AdminSite>,
 	update: bool,
 ) -> Result<PreparedFileMutation, ServerFnError> {
 	let mut data = payload.data;
@@ -419,12 +565,48 @@ fn prepare_file_mutation(
 			));
 		}
 	}
+	if let (Some(model_admin), Some(site)) = (model_admin, site) {
+		for name in data.keys() {
+			if name.starts_with(INLINE_PREFIX)
+				&& inline_file_target(name, model_admin, site).is_ok()
+			{
+				return Err(validation_error(
+					name,
+					"File fields must be submitted as file parts",
+				));
+			}
+		}
+	}
 
 	let mut uploads = HashMap::new();
+	let mut inline_uploads = Vec::new();
+	let mut inline_paths = HashSet::new();
 	for (name, upload) in payload.uploads {
+		if name.starts_with(INLINE_PREFIX) {
+			let target = match (model_admin, site) {
+				(Some(model_admin), Some(site)) => inline_file_target(&name, model_admin, site)?,
+				_ => {
+					return Err(validation_error(
+						&name,
+						"Inline file uploads are not configured",
+					));
+				}
+			};
+			if !inline_paths.insert(target.path.clone()) {
+				return Err(validation_error(
+					&target.path,
+					"An inline file field was submitted more than once",
+				));
+			}
+			inline_uploads.push((target, upload));
+			continue;
+		}
 		let field = find_file_field(fields, &name)
 			.ok_or_else(|| validation_error(&name, "Unknown file field"))?;
-		if uploads.insert(field.logical_name.clone(), upload).is_some() {
+		if uploads
+			.insert(field.logical_name.clone(), (name.clone(), upload))
+			.is_some()
+		{
 			return Err(validation_error(
 				&field.logical_name,
 				"A file field was submitted more than once",
@@ -434,6 +616,24 @@ fn prepare_file_mutation(
 
 	let mut empty_uploads = HashSet::new();
 	for name in payload.empty_uploads {
+		if name.starts_with(INLINE_PREFIX) {
+			let target = match (model_admin, site) {
+				(Some(model_admin), Some(site)) => inline_file_target(&name, model_admin, site)?,
+				_ => {
+					return Err(validation_error(
+						&name,
+						"Inline file uploads are not configured",
+					));
+				}
+			};
+			if !inline_paths.insert(target.path.clone()) {
+				return Err(validation_error(
+					&target.path,
+					"An inline file field was submitted more than once",
+				));
+			}
+			continue;
+		}
 		let field = find_file_field(fields, &name)
 			.ok_or_else(|| validation_error(&name, "Unknown file field"))?;
 		if !empty_uploads.insert(field.logical_name.clone())
@@ -446,7 +646,7 @@ fn prepare_file_mutation(
 		}
 	}
 
-	let mut clears = HashSet::new();
+	let mut clears = HashMap::new();
 	for name in payload.clears {
 		let field = find_file_field(fields, &name)
 			.ok_or_else(|| validation_error(&name, "Unknown file field"))?;
@@ -462,7 +662,9 @@ fn prepare_file_mutation(
 				"This file field cannot be cleared",
 			));
 		}
-		if !clears.insert(field.logical_name.clone())
+		if clears
+			.insert(field.logical_name.clone(), name.clone())
+			.is_some()
 			|| uploads.contains_key(&field.logical_name)
 			|| empty_uploads.contains(&field.logical_name)
 		{
@@ -485,8 +687,9 @@ fn prepare_file_mutation(
 	sorted_uploads.sort_unstable_by(|left, right| left.0.cmp(&right.0));
 	let mut writes = Vec::with_capacity(sorted_uploads.len());
 	let mut write_fields = Vec::with_capacity(sorted_uploads.len());
+	let mut inline_write_targets = Vec::with_capacity(sorted_uploads.len());
 	let mut cleanup = Vec::new();
-	for (logical_name, upload) in sorted_uploads {
+	for (logical_name, (submitted_name, upload)) in sorted_uploads {
 		let field =
 			find_file_field(fields, &logical_name).expect("canonical upload field must resolve");
 		if update && field.policy.cleanup {
@@ -505,10 +708,25 @@ fn prepare_file_mutation(
 			},
 			upload,
 		});
-		write_fields.push(logical_name);
+		write_fields.push(submitted_name);
+		inline_write_targets.push(None);
+	}
+	inline_uploads.sort_unstable_by(|left, right| left.0.path.cmp(&right.0.path));
+	for (target, upload) in inline_uploads {
+		writes.push(PendingFileUpload {
+			policy: target.policy.clone(),
+			operation: if update {
+				FileWriteOperation::Replace
+			} else {
+				FileWriteOperation::Create
+			},
+			upload,
+		});
+		write_fields.push(target.path.clone());
+		inline_write_targets.push(Some(target));
 	}
 
-	for logical_name in clears {
+	for (logical_name, submitted_name) in clears {
 		let field =
 			find_file_field(fields, &logical_name).expect("canonical clear field must resolve");
 		if field.policy.cleanup {
@@ -518,13 +736,14 @@ fn prepare_file_mutation(
 				operation: FileCleanupOperation::Clear,
 			});
 		}
-		data.insert(logical_name, serde_json::Value::Null);
+		data.insert(submitted_name, serde_json::Value::Null);
 	}
 
 	Ok(PreparedFileMutation {
 		data,
 		writes,
 		write_fields,
+		inline_write_targets,
 		cleanup,
 	})
 }
@@ -571,7 +790,13 @@ async fn persist_file_mutation(
 	} = context;
 	let update = id.is_some();
 	let fields = file_fields_for_model(model_admin.as_ref())?;
-	let prepared = prepare_file_mutation(payload, &fields, update)?;
+	let prepared = prepare_file_mutation_with_inlines(
+		payload,
+		&fields,
+		Some(model_admin.as_ref()),
+		Some(site.as_ref()),
+		update,
+	)?;
 	let fallback_field = prepared
 		.write_fields
 		.first()
@@ -583,21 +808,30 @@ async fn persist_file_mutation(
 	let site_value = (*site).clone();
 	let db_value = (*db).clone();
 	let write_fields = prepared.write_fields;
+	let inline_write_targets = prepared.inline_write_targets;
 	let cleanup = prepared.cleanup;
 	let data = prepared.data;
 	let has_file_lifecycle = !prepared.writes.is_empty() || !cleanup.is_empty();
 	let persist = move |stored: Vec<FileField>| async move {
 		let mut data = data;
-		for (field_name, file) in write_fields.into_iter().zip(stored) {
+		let mut stored_inline_targets = Vec::new();
+		for ((field_name, target), file) in write_fields
+			.into_iter()
+			.zip(inline_write_targets)
+			.zip(stored)
+		{
+			if let Some(target) = target {
+				stored_inline_targets.push(target);
+			}
 			data.insert(
 				field_name,
 				serde_json::Value::String(file.path().to_owned()),
 			);
 		}
 		let request = MutationRequest { csrf_token, data };
-		let (response, previous) = match id {
+		let (response, previous, outcomes) = match id {
 			Some(id) => {
-				let (response, previous) = update_record_with_previous_values(
+				let (response, previous, outcomes) = update_record_with_previous_values(
 					model_name,
 					id,
 					request,
@@ -607,10 +841,10 @@ async fn persist_file_mutation(
 					AdminAuthenticatedUser(user),
 				)
 				.await?;
-				(response, Some(previous))
+				(response, Some(previous), outcomes)
 			}
 			None => {
-				let response = create_record(
+				let (response, outcomes) = create_record_with_inline_outcomes(
 					model_name,
 					request,
 					KeyedDepends::from_value(site_value),
@@ -619,7 +853,7 @@ async fn persist_file_mutation(
 					AdminAuthenticatedUser(user),
 				)
 				.await?;
-				(response, None)
+				(response, None, outcomes)
 			}
 		};
 		let mut commit = FileCommit::new(response);
@@ -628,6 +862,24 @@ async fn persist_file_mutation(
 				existing_file_reference(previous.as_ref(), &cleanup.field_name, &cleanup.policy)?
 			{
 				commit = commit.cleanup(cleanup.policy, file, cleanup.operation);
+			}
+		}
+		for target in stored_inline_targets {
+			if !target.policy.cleanup {
+				continue;
+			}
+			let Some(outcome) = outcomes.iter().find(|outcome| {
+				outcome.inline_key == target.inline_key
+					&& outcome.submitted_index == target.submitted_index
+			}) else {
+				continue;
+			};
+			if let Some(file) = existing_file_reference(
+				Some(&outcome.previous_values),
+				&target.field_name,
+				&target.policy,
+			)? {
+				commit = commit.cleanup(target.policy, file, FileCleanupOperation::Replace);
 			}
 		}
 		Ok(commit)
@@ -817,9 +1069,9 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn parse_admin_multipart_preserves_inline_controls() {
+	async fn parse_admin_multipart_preserves_inline_controls_and_file_parts() {
 		let request = multipart_request(
-			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_inlines.comments.0.__present\"\r\n\r\ntrue\r\n--boundary--\r\n",
+			"--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_model\"\r\n\r\n\"Article\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_inlines.comments.0.__present\"\r\n\r\ntrue\r\n--boundary\r\nContent-Disposition: form-data; name=\"__reinhardt_inlines.comments.0.avatar\"; filename=\"avatar.png\"\r\nContent-Type: image/png\r\n\r\nimage\r\n--boundary--\r\n",
 		);
 
 		let payload = parse_admin_multipart(&request, false)
@@ -829,6 +1081,13 @@ mod tests {
 		assert_eq!(
 			payload.data.get("__reinhardt_inlines.comments.0.__present"),
 			Some(&serde_json::json!(true))
+		);
+		assert_eq!(
+			payload
+				.uploads
+				.get("__reinhardt_inlines.comments.0.avatar")
+				.and_then(|file| file.filename.as_deref()),
+			Some("avatar.png")
 		);
 	}
 
@@ -923,15 +1182,15 @@ mod file_lifecycle_tests {
 	fn required_create_requires_and_prepares_a_file_write() {
 		let mut payload = payload();
 		payload.uploads.insert(
-			"avatar".to_owned(),
-			UploadedFile::new("avatar".to_owned(), Bytes::from_static(b"image"))
+			"avatar_path".to_owned(),
+			UploadedFile::new("avatar_path".to_owned(), Bytes::from_static(b"image"))
 				.with_filename("avatar.png".to_owned()),
 		);
 
 		let prepared = prepare_file_mutation(payload, &[field(true, false, true)], false)
 			.expect("required upload should be prepared");
 
-		assert_eq!(prepared.write_fields, vec!["avatar"]);
+		assert_eq!(prepared.write_fields, vec!["avatar_path"]);
 		assert_eq!(prepared.writes.len(), 1);
 		assert_eq!(prepared.writes[0].operation, FileWriteOperation::Create);
 	}
@@ -956,11 +1215,14 @@ mod file_lifecycle_tests {
 	#[test]
 	fn nullable_clear_sets_null_and_schedules_old_file_cleanup() {
 		let mut payload = payload();
-		payload.clears.insert("avatar".to_owned());
+		payload.clears.insert("avatar_path".to_owned());
 		let prepared = prepare_file_mutation(payload, &[field(false, true, true)], true)
 			.expect("nullable clear should be prepared");
 
-		assert_eq!(prepared.data.get("avatar"), Some(&serde_json::Value::Null));
+		assert_eq!(
+			prepared.data.get("avatar_path"),
+			Some(&serde_json::Value::Null)
+		);
 		assert_eq!(prepared.cleanup.len(), 1);
 		assert_eq!(prepared.cleanup[0].field_name, "avatar");
 		assert_eq!(prepared.cleanup[0].operation, FileCleanupOperation::Clear);
@@ -969,11 +1231,14 @@ mod file_lifecycle_tests {
 	#[test]
 	fn cleanup_opt_out_keeps_the_old_reference_without_scheduling_cleanup() {
 		let mut payload = payload();
-		payload.clears.insert("avatar".to_owned());
+		payload.clears.insert("avatar_path".to_owned());
 		let prepared = prepare_file_mutation(payload, &[field(false, true, false)], true)
 			.expect("cleanup opt-out should still clear the database value");
 
-		assert_eq!(prepared.data.get("avatar"), Some(&serde_json::Value::Null));
+		assert_eq!(
+			prepared.data.get("avatar_path"),
+			Some(&serde_json::Value::Null)
+		);
 		assert!(prepared.cleanup.is_empty());
 	}
 

--- a/crates/reinhardt-admin/src/server/multipart.rs
+++ b/crates/reinhardt-admin/src/server/multipart.rs
@@ -1,12 +1,47 @@
 //! Dynamic multipart payloads used by admin model forms.
 
+#[cfg(all(server, feature = "file-uploads"))]
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+#[cfg(all(server, feature = "file-uploads"))]
+use std::convert::Infallible;
+#[cfg(all(server, feature = "file-uploads"))]
+use std::sync::Arc;
 
 use reinhardt_core::parsers::UploadedFile;
 #[cfg(server)]
 use reinhardt_core::parsers::multipart::MultipartPart;
+#[cfg(all(server, feature = "file-uploads"))]
+use reinhardt_pages::server_fn::server_fn;
 #[cfg(server)]
 use reinhardt_pages::server_fn::{MultipartArguments, ServerFnError};
+
+#[cfg(all(server, feature = "file-uploads"))]
+use super::{
+	admin_auth::AdminAuthenticatedUser,
+	create::create_record,
+	error::{AdminAuth, MapServerFnError},
+	security::{extract_csrf_header, require_csrf_token},
+	type_inference::{
+		find_model_by_table_name, infer_required, translate_physical_field_names_to_logical,
+	},
+	update::update_record,
+};
+#[cfg(all(server, feature = "file-uploads"))]
+use crate::{
+	adapters::{AdminDatabase, AdminRecord, AdminSite, ModelAdmin},
+	core::{AdminDatabaseKey, AdminSiteKey},
+	types::{ModelPermission, MutationRequest, MutationResponse},
+};
+#[cfg(all(server, feature = "file-uploads"))]
+use reinhardt_db::orm::{
+	FileCleanupOperation, FileCommit, FileField, FileFieldPolicy, FileMutationError,
+	FileValidationPolicy, FileWriteOperation, PendingFileUpload, coordinate_file_mutations,
+};
+#[cfg(all(server, feature = "file-uploads"))]
+use reinhardt_di::KeyedDepends;
+#[cfg(all(server, feature = "file-uploads"))]
+use reinhardt_pages::server_fn::ServerFnRequest;
 
 /// Reserved multipart part containing the registered model name.
 pub(crate) const MODEL_PART: &str = "__reinhardt_model";
@@ -134,6 +169,620 @@ fn is_empty_file_input(file: &UploadedFile) -> bool {
 	file.size == 0 && file.filename.as_deref().is_none_or(str::is_empty)
 }
 
+#[cfg(all(server, feature = "file-uploads"))]
+#[derive(Clone, Debug)]
+struct AdminFileField {
+	logical_name: String,
+	aliases: Vec<String>,
+	required: bool,
+	nullable: bool,
+	policy: FileFieldPolicy,
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+#[derive(Debug)]
+struct FileCleanupReference {
+	policy: FileFieldPolicy,
+	file: FileField,
+	operation: FileCleanupOperation,
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+struct PreparedFileMutation {
+	data: HashMap<String, serde_json::Value>,
+	writes: Vec<PendingFileUpload>,
+	write_fields: Vec<String>,
+	cleanup: Vec<FileCleanupReference>,
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+struct FileMutationContext {
+	site: KeyedDepends<AdminSiteKey, AdminSite>,
+	db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
+	http_request: ServerFnRequest,
+	user: Arc<dyn crate::core::AdminUser>,
+	model_admin: Arc<dyn ModelAdmin>,
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn validation_error(field: &str, message: &str) -> ServerFnError {
+	ServerFnError::validation_with_message(
+		"Invalid file upload",
+		[(field.to_owned(), message.to_owned())],
+	)
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn metadata_error(field: &str, detail: impl std::fmt::Display) -> ServerFnError {
+	tracing::error!(field, error = %detail, "Invalid storage-backed file field metadata");
+	ServerFnError::server(500, "Invalid file field metadata")
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn parse_metadata_usize(
+	params: &HashMap<String, String>,
+	field: &str,
+	key: &str,
+	default: usize,
+) -> Result<usize, ServerFnError> {
+	params.get(key).map_or(Ok(default), |value| {
+		value
+			.parse::<usize>()
+			.ok()
+			.filter(|parsed| *parsed > 0)
+			.ok_or_else(|| metadata_error(field, format!("{key} must be a positive integer")))
+	})
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn parse_metadata_u32(
+	params: &HashMap<String, String>,
+	field: &str,
+	key: &str,
+) -> Result<Option<u32>, ServerFnError> {
+	params.get(key).map_or(Ok(None), |value| {
+		value
+			.parse::<u32>()
+			.ok()
+			.filter(|parsed| *parsed > 0)
+			.map(Some)
+			.ok_or_else(|| metadata_error(field, format!("{key} must be a positive integer")))
+	})
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn parse_metadata_bool(
+	params: &HashMap<String, String>,
+	field: &str,
+	key: &str,
+	default: bool,
+) -> Result<bool, ServerFnError> {
+	params.get(key).map_or(Ok(default), |value| {
+		value
+			.parse::<bool>()
+			.map_err(|_| metadata_error(field, format!("{key} must be a boolean")))
+	})
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn file_field_policy(
+	model_name: &str,
+	logical_name: &str,
+	metadata: &reinhardt_db::migrations::FieldMetadata,
+) -> Result<FileFieldPolicy, ServerFnError> {
+	let kind = metadata
+		.params
+		.get("model_field_type")
+		.map(String::as_str)
+		.ok_or_else(|| metadata_error(logical_name, "missing model_field_type"))?;
+	let upload_to = metadata
+		.params
+		.get("upload_to")
+		.cloned()
+		.ok_or_else(|| metadata_error(logical_name, "missing upload_to"))?;
+	let storage_alias = metadata
+		.params
+		.get("file_storage")
+		.cloned()
+		.unwrap_or_else(|| "default".to_owned());
+	let max_length = parse_metadata_usize(&metadata.params, logical_name, "max_length", 255)?;
+	let cleanup = parse_metadata_bool(&metadata.params, logical_name, "cleanup", true)?;
+	let validation = match kind {
+		"file" => FileValidationPolicy::File,
+		"image" => FileValidationPolicy::Image {
+			max_width: parse_metadata_u32(&metadata.params, logical_name, "max_width")?,
+			max_height: parse_metadata_u32(&metadata.params, logical_name, "max_height")?,
+		},
+		other => {
+			return Err(metadata_error(
+				logical_name,
+				format!("unsupported kind {other}"),
+			));
+		}
+	};
+
+	Ok(FileFieldPolicy {
+		model: Cow::Owned(model_name.to_owned()),
+		field: Cow::Owned(logical_name.to_owned()),
+		upload_to: Cow::Owned(upload_to),
+		storage_alias: Cow::Owned(storage_alias),
+		max_length,
+		cleanup,
+		validation,
+	})
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn file_fields_for_model(
+	model_admin: &dyn ModelAdmin,
+) -> Result<Vec<AdminFileField>, ServerFnError> {
+	let metadata = find_model_by_table_name(model_admin.table_name())
+		.ok_or_else(|| ServerFnError::server(500, "File field metadata is not registered"))?;
+	let mut fields = metadata
+		.fields
+		.into_iter()
+		.filter_map(|(registered_name, metadata)| {
+			metadata
+				.params
+				.get("model_field_type")
+				.is_some_and(|kind| matches!(kind.as_str(), "file" | "image"))
+				.then_some((registered_name, metadata))
+		})
+		.map(|(registered_name, metadata)| {
+			let logical_name = metadata
+				.params
+				.get("rust_field_name")
+				.cloned()
+				.unwrap_or_else(|| registered_name.clone());
+			let mut aliases = Vec::with_capacity(3);
+			for name in [
+				Some(registered_name),
+				Some(logical_name.clone()),
+				metadata.params.get("db_column").cloned(),
+			]
+			.into_iter()
+			.flatten()
+			{
+				if !aliases.iter().any(|alias| alias == &name) {
+					aliases.push(name);
+				}
+			}
+			let policy = file_field_policy(model_admin.model_name(), &logical_name, &metadata)?;
+			Ok(AdminFileField {
+				logical_name,
+				aliases,
+				required: infer_required(&metadata),
+				nullable: metadata.nullable,
+				policy,
+			})
+		})
+		.collect::<Result<Vec<_>, ServerFnError>>()?;
+	fields.sort_unstable_by(|left, right| left.logical_name.cmp(&right.logical_name));
+	Ok(fields)
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn find_file_field<'a>(fields: &'a [AdminFileField], name: &str) -> Option<&'a AdminFileField> {
+	fields
+		.iter()
+		.find(|field| field.aliases.iter().any(|alias| alias == name))
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn existing_file_reference(
+	values: Option<&HashMap<String, serde_json::Value>>,
+	field: &AdminFileField,
+) -> Result<Option<FileField>, ServerFnError> {
+	let Some(value) = values.and_then(|values| values.get(&field.logical_name)) else {
+		return Ok(None);
+	};
+	match value {
+		serde_json::Value::Null => Ok(None),
+		serde_json::Value::String(path) if path.is_empty() => Ok(None),
+		serde_json::Value::String(path) => {
+			match FileField::from_existing(path.clone(), field.policy.storage_alias.as_ref()) {
+				Ok(file) => Ok(Some(file)),
+				Err(error) => {
+					tracing::warn!(
+						field = field.logical_name.as_str(),
+						error = %error,
+						"Stored file reference is invalid; cleanup was skipped"
+					);
+					Ok(None)
+				}
+			}
+		}
+		_ => Err(validation_error(
+			&field.logical_name,
+			"The stored file reference is not a string",
+		)),
+	}
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn prepare_file_mutation(
+	payload: AdminMultipartPayload,
+	fields: &[AdminFileField],
+	update: bool,
+	existing: Option<&HashMap<String, serde_json::Value>>,
+) -> Result<PreparedFileMutation, ServerFnError> {
+	let mut data = payload.data;
+	for name in data.keys() {
+		if find_file_field(fields, name).is_some() {
+			return Err(validation_error(
+				name,
+				"File fields must be submitted as file parts",
+			));
+		}
+	}
+
+	let mut uploads = HashMap::new();
+	for (name, upload) in payload.uploads {
+		let field = find_file_field(fields, &name)
+			.ok_or_else(|| validation_error(&name, "Unknown file field"))?;
+		if uploads.insert(field.logical_name.clone(), upload).is_some() {
+			return Err(validation_error(
+				&field.logical_name,
+				"A file field was submitted more than once",
+			));
+		}
+	}
+
+	let mut empty_uploads = HashSet::new();
+	for name in payload.empty_uploads {
+		let field = find_file_field(fields, &name)
+			.ok_or_else(|| validation_error(&name, "Unknown file field"))?;
+		if !empty_uploads.insert(field.logical_name.clone())
+			|| uploads.contains_key(&field.logical_name)
+		{
+			return Err(validation_error(
+				&field.logical_name,
+				"A file field was submitted more than once",
+			));
+		}
+	}
+
+	let mut clears = HashSet::new();
+	for name in payload.clears {
+		let field = find_file_field(fields, &name)
+			.ok_or_else(|| validation_error(&name, "Unknown file field"))?;
+		if !update {
+			return Err(validation_error(
+				&field.logical_name,
+				"Clear markers are only valid when editing",
+			));
+		}
+		if !field.nullable {
+			return Err(validation_error(
+				&field.logical_name,
+				"This file field cannot be cleared",
+			));
+		}
+		if !clears.insert(field.logical_name.clone())
+			|| uploads.contains_key(&field.logical_name)
+			|| empty_uploads.contains(&field.logical_name)
+		{
+			return Err(validation_error(
+				&field.logical_name,
+				"A file field cannot be uploaded and cleared together",
+			));
+		}
+	}
+
+	if !update {
+		for field in fields.iter().filter(|field| field.required) {
+			if !uploads.contains_key(&field.logical_name) {
+				return Err(validation_error(&field.logical_name, "A file is required"));
+			}
+		}
+	}
+
+	let mut sorted_uploads = uploads.into_iter().collect::<Vec<_>>();
+	sorted_uploads.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+	let mut writes = Vec::with_capacity(sorted_uploads.len());
+	let mut write_fields = Vec::with_capacity(sorted_uploads.len());
+	let mut cleanup = Vec::new();
+	for (logical_name, upload) in sorted_uploads {
+		let field =
+			find_file_field(fields, &logical_name).expect("canonical upload field must resolve");
+		if update
+			&& field.policy.cleanup
+			&& let Some(old_file) = existing_file_reference(existing, field)?
+		{
+			cleanup.push(FileCleanupReference {
+				policy: field.policy.clone(),
+				file: old_file,
+				operation: FileCleanupOperation::Replace,
+			});
+		}
+		writes.push(PendingFileUpload {
+			policy: field.policy.clone(),
+			operation: if update {
+				FileWriteOperation::Replace
+			} else {
+				FileWriteOperation::Create
+			},
+			upload,
+		});
+		write_fields.push(logical_name);
+	}
+
+	for logical_name in clears {
+		let field =
+			find_file_field(fields, &logical_name).expect("canonical clear field must resolve");
+		if field.policy.cleanup
+			&& let Some(old_file) = existing_file_reference(existing, field)?
+		{
+			cleanup.push(FileCleanupReference {
+				policy: field.policy.clone(),
+				file: old_file,
+				operation: FileCleanupOperation::Clear,
+			});
+		}
+		data.insert(logical_name, serde_json::Value::Null);
+	}
+
+	Ok(PreparedFileMutation {
+		data,
+		writes,
+		write_fields,
+		cleanup,
+	})
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn map_file_mutation_error(
+	error: FileMutationError<ServerFnError>,
+	fallback_field: &str,
+) -> ServerFnError {
+	match error {
+		FileMutationError::Database(error) => error,
+		FileMutationError::Storage(error) => {
+			tracing::warn!(
+				field = fallback_field,
+				error = %error,
+				"Admin file upload failed before database persistence"
+			);
+			validation_error(fallback_field, "The file could not be stored")
+		}
+	}
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+async fn persist_file_mutation(
+	payload: AdminMultipartPayload,
+	id: Option<String>,
+	csrf_token: String,
+	context: FileMutationContext,
+) -> Result<MutationResponse, ServerFnError> {
+	let FileMutationContext {
+		site,
+		db,
+		http_request,
+		user,
+		model_admin,
+	} = context;
+	let update = id.is_some();
+	let existing = if let Some(id) = id.as_deref() {
+		let object_id = crate::core::database::canonicalize_pk_value(
+			model_admin.table_name(),
+			model_admin.pk_field(),
+			id,
+		);
+		let mut values = db
+			.get::<AdminRecord>(model_admin.table_name(), model_admin.pk_field(), &object_id)
+			.await
+			.map_server_fn_error()?;
+		if let Some(values) = values.as_mut() {
+			translate_physical_field_names_to_logical(model_admin.table_name(), values)
+				.map_server_fn_error()?;
+		} else {
+			return Err(ServerFnError::server(404, "Record not found"));
+		}
+		values
+	} else {
+		None
+	};
+	let fields = file_fields_for_model(model_admin.as_ref())?;
+	let prepared = prepare_file_mutation(payload, &fields, update, existing.as_ref())?;
+	let fallback_field = prepared
+		.write_fields
+		.first()
+		.map(String::as_str)
+		.unwrap_or("file")
+		.to_owned();
+
+	let model_name = model_admin.model_name().to_owned();
+	let site_value = (*site).clone();
+	let db_value = (*db).clone();
+	let write_fields = prepared.write_fields;
+	let cleanup = prepared.cleanup;
+	let data = prepared.data;
+	let has_file_lifecycle = !prepared.writes.is_empty() || !cleanup.is_empty();
+	let persist = move |stored: Vec<FileField>| async move {
+		let mut data = data;
+		for (field_name, file) in write_fields.into_iter().zip(stored) {
+			data.insert(
+				field_name,
+				serde_json::Value::String(file.path().to_owned()),
+			);
+		}
+		let request = MutationRequest { csrf_token, data };
+		let response = match id {
+			Some(id) => {
+				update_record(
+					model_name,
+					id,
+					request,
+					KeyedDepends::from_value(site_value),
+					KeyedDepends::from_value(db_value),
+					http_request,
+					AdminAuthenticatedUser(user),
+				)
+				.await?
+			}
+			None => {
+				create_record(
+					model_name,
+					request,
+					KeyedDepends::from_value(site_value),
+					KeyedDepends::from_value(db_value),
+					http_request,
+					AdminAuthenticatedUser(user),
+				)
+				.await?
+			}
+		};
+		let mut commit = FileCommit::new(response);
+		for cleanup in cleanup {
+			commit = commit.cleanup(cleanup.policy, cleanup.file, cleanup.operation);
+		}
+		Ok(commit)
+	};
+	let response = if has_file_lifecycle {
+		coordinate_file_mutations(prepared.writes, persist)
+			.await
+			.map_err(|error| map_file_mutation_error(error, &fallback_field))?
+	} else {
+		persist(Vec::new())
+			.await
+			.map_err(|error| {
+				map_file_mutation_error(FileMutationError::Database(error), &fallback_field)
+			})?
+			.value
+	};
+
+	Ok(response)
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+fn multipart_csrf_token(request: &ServerFnRequest) -> Result<String, ServerFnError> {
+	let token = extract_csrf_header(&request.inner().headers)
+		.ok_or_else(|| ServerFnError::server(403, "CSRF token missing from header"))?;
+	require_csrf_token(&token, &request.inner().headers)?;
+	Ok(token)
+}
+
+/// Create an admin record from a multipart form containing file fields.
+#[cfg(all(server, feature = "file-uploads"))]
+#[server_fn]
+pub async fn create_record_multipart(
+	#[inject] site: KeyedDepends<AdminSiteKey, AdminSite>,
+	#[inject] db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
+	#[inject] http_request: ServerFnRequest,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
+) -> Result<MutationResponse, ServerFnError> {
+	let csrf_token = multipart_csrf_token(&http_request)?;
+	let payload = parse_admin_multipart(http_request.inner(), false).await?;
+	let auth = AdminAuth::from_request(&http_request);
+	let model_admin = site
+		.get_model_admin(&payload.model_name)
+		.map_server_fn_error()?;
+	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Add)
+		.await?;
+	persist_file_mutation(
+		payload,
+		None,
+		csrf_token,
+		FileMutationContext {
+			site,
+			db,
+			http_request,
+			user,
+			model_admin,
+		},
+	)
+	.await
+}
+
+/// Update an admin record from a multipart form containing file fields.
+#[cfg(all(server, feature = "file-uploads"))]
+#[server_fn]
+pub async fn update_record_multipart(
+	#[inject] site: KeyedDepends<AdminSiteKey, AdminSite>,
+	#[inject] db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
+	#[inject] http_request: ServerFnRequest,
+	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
+) -> Result<MutationResponse, ServerFnError> {
+	let csrf_token = multipart_csrf_token(&http_request)?;
+	let payload = parse_admin_multipart(http_request.inner(), true).await?;
+	let id = payload
+		.id
+		.clone()
+		.ok_or_else(|| ServerFnError::server(400, "Missing record ID"))?;
+	let auth = AdminAuth::from_request(&http_request);
+	let model_admin = site
+		.get_model_admin(&payload.model_name)
+		.map_server_fn_error()?;
+	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Change)
+		.await?;
+	persist_file_mutation(
+		payload,
+		Some(id),
+		csrf_token,
+		FileMutationContext {
+			site,
+			db,
+			http_request,
+			user,
+			model_admin,
+		},
+	)
+	.await
+}
+
+#[cfg(all(server, feature = "file-uploads"))]
+pub(crate) async fn cleanup_deleted_files(
+	model_admin: &dyn ModelAdmin,
+	values: Option<&HashMap<String, serde_json::Value>>,
+) {
+	let fields = match file_fields_for_model(model_admin) {
+		Ok(fields) => fields,
+		Err(error) => {
+			tracing::warn!(error = %error, "Deleted file references could not be resolved");
+			return;
+		}
+	};
+	let mut commit = FileCommit::new(());
+	let mut has_cleanup = false;
+	for field in fields {
+		if !field.policy.cleanup {
+			continue;
+		}
+		let Some(serde_json::Value::String(path)) =
+			values.and_then(|values| values.get(&field.logical_name))
+		else {
+			continue;
+		};
+		if path.is_empty() {
+			continue;
+		}
+		let file = match FileField::from_existing(path.clone(), field.policy.storage_alias.as_ref())
+		{
+			Ok(file) => file,
+			Err(error) => {
+				tracing::warn!(
+					field = field.logical_name.as_str(),
+					error = %error,
+					"Deleted file reference is invalid; cleanup was skipped"
+				);
+				continue;
+			}
+		};
+		commit = commit.cleanup(field.policy, file, FileCleanupOperation::Delete);
+		has_cleanup = true;
+	}
+	if !has_cleanup {
+		return;
+	}
+
+	if let Err(error) =
+		coordinate_file_mutations(Vec::new(), |_| async { Ok::<_, Infallible>(commit) }).await
+	{
+		tracing::warn!(error = %error, "Deleted file cleanup could not be scheduled");
+	}
+}
+
 #[cfg(all(test, server))]
 mod tests {
 	use super::*;
@@ -224,5 +873,134 @@ mod tests {
 			.expect_err("create multipart payloads must reject update-only parts");
 
 		assert_eq!(error.status(), Some(400));
+	}
+}
+
+#[cfg(all(test, server, feature = "file-uploads"))]
+mod file_lifecycle_tests {
+	use super::*;
+	use bytes::Bytes;
+
+	fn field(required: bool, nullable: bool, cleanup: bool) -> AdminFileField {
+		AdminFileField {
+			logical_name: "avatar".to_owned(),
+			aliases: vec!["avatar".to_owned(), "avatar_path".to_owned()],
+			required,
+			nullable,
+			policy: FileFieldPolicy {
+				model: Cow::Borrowed("Article"),
+				field: Cow::Borrowed("avatar"),
+				upload_to: Cow::Borrowed("avatars"),
+				storage_alias: Cow::Borrowed("default"),
+				max_length: 255,
+				cleanup,
+				validation: FileValidationPolicy::File,
+			},
+		}
+	}
+
+	fn payload() -> AdminMultipartPayload {
+		AdminMultipartPayload {
+			model_name: "Article".to_owned(),
+			id: None,
+			data: HashMap::new(),
+			uploads: HashMap::new(),
+			empty_uploads: HashSet::new(),
+			clears: HashSet::new(),
+		}
+	}
+
+	#[test]
+	fn required_create_requires_and_prepares_a_file_write() {
+		let mut payload = payload();
+		payload.uploads.insert(
+			"avatar".to_owned(),
+			UploadedFile::new("avatar".to_owned(), Bytes::from_static(b"image"))
+				.with_filename("avatar.png".to_owned()),
+		);
+
+		let prepared = prepare_file_mutation(payload, &[field(true, false, true)], false, None)
+			.expect("required upload should be prepared");
+
+		assert_eq!(prepared.write_fields, vec!["avatar"]);
+		assert_eq!(prepared.writes.len(), 1);
+		assert_eq!(prepared.writes[0].operation, FileWriteOperation::Create);
+	}
+
+	#[test]
+	fn update_without_a_new_file_preserves_the_existing_reference() {
+		let mut payload = payload();
+		payload
+			.data
+			.insert("title".to_owned(), serde_json::json!("Updated"));
+		let existing =
+			HashMap::from([(String::from("avatar"), serde_json::json!("avatars/old.png"))]);
+
+		let prepared =
+			prepare_file_mutation(payload, &[field(true, false, true)], true, Some(&existing))
+				.expect("omitting an update file should preserve it");
+
+		assert!(prepared.writes.is_empty());
+		assert!(prepared.cleanup.is_empty());
+		assert_eq!(
+			prepared.data.get("title"),
+			Some(&serde_json::json!("Updated"))
+		);
+	}
+
+	#[test]
+	fn nullable_clear_sets_null_and_schedules_old_file_cleanup() {
+		let mut payload = payload();
+		payload.clears.insert("avatar".to_owned());
+		let existing =
+			HashMap::from([(String::from("avatar"), serde_json::json!("avatars/old.png"))]);
+
+		let prepared =
+			prepare_file_mutation(payload, &[field(false, true, true)], true, Some(&existing))
+				.expect("nullable clear should be prepared");
+
+		assert_eq!(prepared.data.get("avatar"), Some(&serde_json::Value::Null));
+		assert_eq!(prepared.cleanup.len(), 1);
+		assert_eq!(prepared.cleanup[0].operation, FileCleanupOperation::Clear);
+		assert_eq!(prepared.cleanup[0].file.path(), "avatars/old.png");
+	}
+
+	#[test]
+	fn cleanup_opt_out_keeps_the_old_reference_without_scheduling_cleanup() {
+		let mut payload = payload();
+		payload.clears.insert("avatar".to_owned());
+		let existing =
+			HashMap::from([(String::from("avatar"), serde_json::json!("avatars/old.png"))]);
+
+		let prepared =
+			prepare_file_mutation(payload, &[field(false, true, false)], true, Some(&existing))
+				.expect("cleanup opt-out should still clear the database value");
+
+		assert_eq!(prepared.data.get("avatar"), Some(&serde_json::Value::Null));
+		assert!(prepared.cleanup.is_empty());
+	}
+
+	#[test]
+	fn image_metadata_builds_dimension_validation_policy() {
+		let metadata = reinhardt_db::migrations::FieldMetadata::new(
+			reinhardt_db::migrations::FieldType::VarChar(255),
+		)
+		.with_param("model_field_type", "image")
+		.with_param("upload_to", "images")
+		.with_param("max_length", "120")
+		.with_param("max_width", "800")
+		.with_param("max_height", "600");
+
+		let policy = file_field_policy("Article", "cover", &metadata)
+			.expect("image metadata should produce a file policy");
+
+		assert_eq!(policy.max_length, 120);
+		assert!(matches!(
+			policy.validation,
+			FileValidationPolicy::Image {
+				max_width: Some(800),
+				max_height: Some(600)
+			}
+		));
 	}
 }

--- a/crates/reinhardt-admin/src/server/multipart.rs
+++ b/crates/reinhardt-admin/src/server/multipart.rs
@@ -455,13 +455,15 @@ fn inline_file_target(
 	{
 		return Err(validation_error(name, "Inline field is read-only"));
 	}
+	let mut policy = field.policy.clone();
+	policy.field = Cow::Owned(name.to_owned());
 
 	Ok(InlineFileTarget {
 		path: name.to_owned(),
 		inline_key: inline_key.to_owned(),
 		submitted_index,
 		field_name: field.logical_name.clone(),
-		policy: field.policy.clone(),
+		policy,
 	})
 }
 
@@ -981,7 +983,7 @@ pub(crate) async fn cleanup_deleted_files(
 	model_admin: &dyn ModelAdmin,
 	values: Option<&HashMap<String, serde_json::Value>>,
 ) {
-	let fields = match file_fields_for_model(model_admin) {
+	let fields = match all_file_fields_for_model(model_admin) {
 		Ok(fields) => fields,
 		Err(error) => {
 			tracing::warn!(error = %error, "Deleted file references could not be resolved");

--- a/crates/reinhardt-admin/src/server/multipart.rs
+++ b/crates/reinhardt-admin/src/server/multipart.rs
@@ -28,7 +28,7 @@ use super::{
 #[cfg(all(server, feature = "file-uploads"))]
 use crate::{
 	adapters::{AdminDatabase, AdminSite, ModelAdmin},
-	core::{AdminDatabaseKey, AdminSiteKey},
+	core::{AdminDatabaseKey, AdminSiteKey, inline::InlineSaveOperation},
 	types::{ModelPermission, MutationRequest, MutationResponse},
 };
 #[cfg(all(server, feature = "file-uploads"))]
@@ -808,12 +808,24 @@ async fn persist_file_mutation(
 
 	let model_name = model_admin.model_name().to_owned();
 	let site_value = (*site).clone();
+	let site_for_inline_cleanup = site_value.clone();
 	let db_value = (*db).clone();
 	let write_fields = prepared.write_fields;
 	let inline_write_targets = prepared.inline_write_targets;
 	let cleanup = prepared.cleanup;
+	let has_inline_delete = prepared.data.iter().any(|(name, value)| {
+		name.starts_with(INLINE_PREFIX)
+			&& name.ends_with(".__delete")
+			&& (matches!(value, serde_json::Value::Bool(true))
+				|| matches!(
+					value,
+					serde_json::Value::String(value)
+						if matches!(value.as_str(), "true" | "on" | "1")
+				))
+	});
 	let data = prepared.data;
-	let has_file_lifecycle = !prepared.writes.is_empty() || !cleanup.is_empty();
+	let has_file_lifecycle =
+		!prepared.writes.is_empty() || !cleanup.is_empty() || has_inline_delete;
 	let persist = move |stored: Vec<FileField>| async move {
 		let mut data = data;
 		let mut stored_inline_targets = Vec::new();
@@ -882,6 +894,26 @@ async fn persist_file_mutation(
 				&target.policy,
 			)? {
 				commit = commit.cleanup(target.policy, file, FileCleanupOperation::Replace);
+			}
+		}
+		for outcome in outcomes
+			.iter()
+			.filter(|outcome| matches!(outcome.operation, InlineSaveOperation::Delete))
+		{
+			let child_admin = site_for_inline_cleanup
+				.get_model_admin_by_table_name(&outcome.table_name)
+				.map_server_fn_error()?;
+			for field in all_file_fields_for_model(child_admin.as_ref())? {
+				if !field.policy.cleanup {
+					continue;
+				}
+				if let Some(file) = existing_file_reference(
+					Some(&outcome.previous_values),
+					&field.logical_name,
+					&field.policy,
+				)? {
+					commit = commit.cleanup(field.policy, file, FileCleanupOperation::Delete);
+				}
 			}
 		}
 		Ok(commit)

--- a/crates/reinhardt-admin/src/server/security.rs
+++ b/crates/reinhardt-admin/src/server/security.rs
@@ -488,6 +488,20 @@ pub fn sanitize_mutation_values(data: &mut HashMap<String, serde_json::Value>) {
 	}
 }
 
+/// Sanitizes user mutation values while preserving server-generated values.
+#[cfg(all(server, feature = "file-uploads"))]
+pub(crate) fn sanitize_mutation_values_with_trusted_fields(
+	data: &mut HashMap<String, serde_json::Value>,
+	trusted_fields: &std::collections::HashSet<String>,
+) {
+	let trusted_values = trusted_fields
+		.iter()
+		.filter_map(|field| data.remove(field).map(|value| (field.clone(), value)))
+		.collect::<Vec<_>>();
+	sanitize_mutation_values(data);
+	data.extend(trusted_values);
+}
+
 /// Recursively sanitizes a JSON value, escaping HTML in strings.
 #[cfg(server)]
 fn sanitize_json_value(value: &mut serde_json::Value) {

--- a/crates/reinhardt-admin/src/server/type_inference.rs
+++ b/crates/reinhardt-admin/src/server/type_inference.rs
@@ -154,6 +154,23 @@ pub fn infer_admin_field_type(db_type: &DbFieldType) -> AdminFieldType {
 	}
 }
 
+/// Returns whether model metadata identifies a semantic file field.
+pub(crate) fn is_semantic_file_field(metadata: &FieldMetadata) -> bool {
+	metadata
+		.params
+		.get("model_field_type")
+		.is_some_and(|field_type| matches!(field_type.as_str(), "file" | "image"))
+}
+
+/// Infers the admin field type while honoring semantic model field metadata.
+pub(crate) fn infer_admin_field_type_from_metadata(metadata: &FieldMetadata) -> AdminFieldType {
+	if is_semantic_file_field(metadata) {
+		AdminFieldType::File
+	} else {
+		infer_admin_field_type(&metadata.field_type)
+	}
+}
+
 /// Infers whether a field is required based on its metadata.
 ///
 /// A field is considered required when:
@@ -755,6 +772,37 @@ mod tests {
 		assert_eq!(
 			infer_admin_field_type(&DbFieldType::SmallInteger),
 			AdminFieldType::Number
+		);
+	}
+
+	#[rstest]
+	fn semantic_file_metadata_is_detected_without_changing_physical_inference() {
+		let file =
+			FieldMetadata::new(DbFieldType::VarChar(255)).with_param("model_field_type", "file");
+		let image =
+			FieldMetadata::new(DbFieldType::VarChar(255)).with_param("model_field_type", "image");
+		let varchar = FieldMetadata::new(DbFieldType::VarChar(255));
+		let binary = FieldMetadata::new(DbFieldType::Binary);
+
+		assert!(is_semantic_file_field(&file));
+		assert!(is_semantic_file_field(&image));
+		assert!(!is_semantic_file_field(&varchar));
+		assert!(!is_semantic_file_field(&binary));
+		assert_eq!(
+			infer_admin_field_type_from_metadata(&file),
+			AdminFieldType::File
+		);
+		assert_eq!(
+			infer_admin_field_type_from_metadata(&image),
+			AdminFieldType::File
+		);
+		assert_eq!(
+			infer_admin_field_type_from_metadata(&varchar),
+			AdminFieldType::Text
+		);
+		assert_eq!(
+			infer_admin_field_type_from_metadata(&binary),
+			AdminFieldType::File
 		);
 	}
 

--- a/crates/reinhardt-admin/src/server/update.rs
+++ b/crates/reinhardt-admin/src/server/update.rs
@@ -18,7 +18,7 @@ use reinhardt_di::KeyedDepends;
 use reinhardt_pages::server_fn::ServerFnRequest;
 use reinhardt_pages::server_fn::{ServerFnError, server_fn};
 #[cfg(server)]
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[cfg(server)]
 use super::audit;
@@ -27,11 +27,13 @@ use super::error::{AdminAuth, MapServerFnError, ModelPermission};
 #[cfg(server)]
 use super::inline::{
 	map_inline_mutation_error, map_inline_transaction_error, parse_inline_mutations,
-	preflight_inline_permissions, remove_unchanged_inline_mutations, sanitize_inline_mutations,
-	save_inline_mutations,
+	preflight_inline_permissions, remove_unchanged_inline_mutations,
+	sanitize_inline_mutations_with_trusted_fields, save_inline_mutations,
 };
 use super::relation::{relation_field_aliases, validate_relation_values};
-#[cfg(server)]
+#[cfg(all(server, feature = "file-uploads"))]
+use super::security::require_csrf_token;
+#[cfg(all(server, not(feature = "file-uploads")))]
 use super::security::{require_csrf_token, sanitize_mutation_values};
 #[cfg(server)]
 use super::type_inference::{
@@ -79,7 +81,9 @@ pub async fn update_record(
 	#[inject] http_request: ServerFnRequest,
 	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<crate::types::MutationResponse, ServerFnError> {
-	update_record_with_previous_values(
+	#[cfg(feature = "file-uploads")]
+	let cleanup_site = site.as_ref().clone();
+	let (response, _, outcomes) = update_record_with_previous_values(
 		model_name,
 		id,
 		request,
@@ -88,8 +92,12 @@ pub async fn update_record(
 		http_request,
 		AdminAuthenticatedUser(user),
 	)
-	.await
-	.map(|(response, _, _)| response)
+	.await?;
+	#[cfg(feature = "file-uploads")]
+	super::multipart::schedule_inline_delete_cleanups(cleanup_site, outcomes).await;
+	#[cfg(not(feature = "file-uploads"))]
+	let _ = outcomes;
+	Ok(response)
 }
 
 #[cfg(server)]
@@ -100,7 +108,40 @@ pub(crate) async fn update_record_with_previous_values(
 	site: KeyedDepends<AdminSiteKey, AdminSite>,
 	db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
 	http_request: ServerFnRequest,
+	user: AdminAuthenticatedUser,
+) -> Result<
+	(
+		crate::types::MutationResponse,
+		HashMap<String, serde_json::Value>,
+		Vec<super::inline::InlineSaveOutcome>,
+	),
+	ServerFnError,
+> {
+	update_record_with_trusted_file_fields(
+		model_name,
+		id,
+		request,
+		site,
+		db,
+		http_request,
+		user,
+		&HashSet::new(),
+	)
+	.await
+}
+
+#[cfg(server)]
+// The server-function dependencies remain separate to preserve the existing internal call contract.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn update_record_with_trusted_file_fields(
+	model_name: String,
+	id: String,
+	request: crate::types::MutationRequest,
+	site: KeyedDepends<AdminSiteKey, AdminSite>,
+	db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
+	http_request: ServerFnRequest,
 	AdminAuthenticatedUser(user): AdminAuthenticatedUser,
+	trusted_file_fields: &HashSet<String>,
 ) -> Result<
 	(
 		crate::types::MutationResponse,
@@ -118,10 +159,11 @@ pub(crate) async fn update_record_with_previous_values(
 	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Change)
 		.await?;
 	#[cfg(feature = "file-uploads")]
-	super::multipart::reject_file_field_json_data(
+	super::multipart::reject_file_field_json_data_with_trusted_fields(
 		&request.data,
 		model_admin.as_ref(),
 		site.as_ref(),
+		trusted_file_fields,
 	)?;
 
 	let model_name = model_admin.model_name().to_string();
@@ -151,8 +193,14 @@ pub(crate) async fn update_record_with_previous_values(
 
 	// Sanitize string values to prevent stored XSS
 	let mut sanitized_data = data;
+	#[cfg(feature = "file-uploads")]
+	super::security::sanitize_mutation_values_with_trusted_fields(
+		&mut sanitized_data,
+		trusted_file_fields,
+	);
+	#[cfg(not(feature = "file-uploads"))]
 	sanitize_mutation_values(&mut sanitized_data);
-	sanitize_inline_mutations(&mut inline_mutations);
+	sanitize_inline_mutations_with_trusted_fields(&mut inline_mutations, trusted_file_fields);
 	sanitized_data.extend(relation_values);
 
 	// Inject current timestamp for auto_now fields (updated on every save)
@@ -186,7 +234,7 @@ pub(crate) async fn update_record_with_previous_values(
 		connection
 			.atomic_write(async |transaction| {
 				let current_data = db
-					.get_with_executor(transaction, &table_name, &pk_field, &object_id)
+					.get_with_executor_for_update(transaction, &table_name, &pk_field, &object_id)
 					.await?;
 				let Some(current_data) = current_data else {
 					return Err(crate::types::AdminError::ModelNotRegistered(format!(

--- a/crates/reinhardt-admin/src/server/update.rs
+++ b/crates/reinhardt-admin/src/server/update.rs
@@ -152,8 +152,8 @@ pub async fn update_record(
 				};
 				let mut changed_fields = sanitized_data
 					.iter()
-					.filter(|&(field, value)| (current_data.get(field) != Some(value)))
-					.map(|(field, value)| field.clone())
+					.filter(|&(field, value)| current_data.get(field) != Some(value))
+					.map(|(field, _)| field.clone())
 					.collect::<Vec<_>>();
 				changed_fields.sort_unstable();
 				let affected = if sanitized_data.is_empty() {

--- a/crates/reinhardt-admin/src/server/update.rs
+++ b/crates/reinhardt-admin/src/server/update.rs
@@ -17,6 +17,8 @@ use reinhardt_di::KeyedDepends;
 #[cfg(server)]
 use reinhardt_pages::server_fn::ServerFnRequest;
 use reinhardt_pages::server_fn::{ServerFnError, server_fn};
+#[cfg(server)]
+use std::collections::HashMap;
 
 #[cfg(server)]
 use super::audit;
@@ -32,7 +34,9 @@ use super::relation::{relation_field_aliases, validate_relation_values};
 #[cfg(server)]
 use super::security::{require_csrf_token, sanitize_mutation_values};
 #[cfg(server)]
-use super::type_inference::translate_logical_field_names;
+use super::type_inference::{
+	translate_logical_field_names, translate_physical_field_names_to_logical,
+};
 #[cfg(server)]
 use super::validation::validate_mutation_data_with_aliases;
 
@@ -75,6 +79,35 @@ pub async fn update_record(
 	#[inject] http_request: ServerFnRequest,
 	#[inject] AdminAuthenticatedUser(user): AdminAuthenticatedUser,
 ) -> Result<crate::types::MutationResponse, ServerFnError> {
+	update_record_with_previous_values(
+		model_name,
+		id,
+		request,
+		site,
+		db,
+		http_request,
+		AdminAuthenticatedUser(user),
+	)
+	.await
+	.map(|(response, _)| response)
+}
+
+#[cfg(server)]
+pub(crate) async fn update_record_with_previous_values(
+	model_name: String,
+	id: String,
+	request: crate::types::MutationRequest,
+	site: KeyedDepends<AdminSiteKey, AdminSite>,
+	db: KeyedDepends<AdminDatabaseKey, AdminDatabase>,
+	http_request: ServerFnRequest,
+	AdminAuthenticatedUser(user): AdminAuthenticatedUser,
+) -> Result<
+	(
+		crate::types::MutationResponse,
+		HashMap<String, serde_json::Value>,
+	),
+	ServerFnError,
+> {
 	// CSRF token validation (double-submit cookie pattern)
 	require_csrf_token(&request.csrf_token, &http_request.inner().headers)?;
 
@@ -190,27 +223,30 @@ pub async fn update_record(
 					transaction,
 				)
 				.await?;
-				Ok(affected)
+				Ok((affected, current_data))
 			})
 			.await
 	}
 	.await;
 
 	// Check for database errors first, logging failure before returning
-	let affected = match result {
+	let (affected, mut previous_data) = match result {
 		Err(error) => {
 			audit::log_update(&audit_user_id, &model_name, &id, &sanitized_data, false);
 			return Err(map_inline_transaction_error(error));
 		}
-		Ok(n) => n,
+		Ok((affected, previous_data)) => (affected, previous_data),
 	};
 
 	audit::log_update(&audit_user_id, &model_name, &id, &sanitized_data, true);
 
-	Ok(MutationResponse {
+	translate_physical_field_names_to_logical(&table_name, &mut previous_data)
+		.map_server_fn_error()?;
+	let response = MutationResponse {
 		success: true,
 		message: format!("{} updated successfully", model_name),
 		affected: Some(affected),
 		data: None,
-	})
+	};
+	Ok((response, previous_data))
 }

--- a/crates/reinhardt-admin/src/server/update.rs
+++ b/crates/reinhardt-admin/src/server/update.rs
@@ -152,9 +152,8 @@ pub async fn update_record(
 				};
 				let mut changed_fields = sanitized_data
 					.iter()
-					.filter_map(|(field, value)| {
-						(current_data.get(field) != Some(value)).then(|| field.clone())
-					})
+					.filter(|&(field, value)| (current_data.get(field) != Some(value)))
+					.map(|(field, value)| field.clone())
 					.collect::<Vec<_>>();
 				changed_fields.sort_unstable();
 				let affected = if sanitized_data.is_empty() {

--- a/crates/reinhardt-admin/src/server/update.rs
+++ b/crates/reinhardt-admin/src/server/update.rs
@@ -89,7 +89,7 @@ pub async fn update_record(
 		AdminAuthenticatedUser(user),
 	)
 	.await
-	.map(|(response, _)| response)
+	.map(|(response, _, _)| response)
 }
 
 #[cfg(server)]
@@ -105,6 +105,7 @@ pub(crate) async fn update_record_with_previous_values(
 	(
 		crate::types::MutationResponse,
 		HashMap<String, serde_json::Value>,
+		Vec<super::inline::InlineSaveOutcome>,
 	),
 	ServerFnError,
 > {
@@ -116,6 +117,12 @@ pub(crate) async fn update_record_with_previous_values(
 	let model_admin = site.get_model_admin(&model_name).map_server_fn_error()?;
 	auth.require_model_permission(model_admin.as_ref(), user.as_ref(), ModelPermission::Change)
 		.await?;
+	#[cfg(feature = "file-uploads")]
+	super::multipart::reject_file_field_json_data(
+		&request.data,
+		model_admin.as_ref(),
+		site.as_ref(),
+	)?;
 
 	let model_name = model_admin.model_name().to_string();
 	let table_name = model_admin.table_name().to_string();
@@ -131,7 +138,12 @@ pub(crate) async fn update_record_with_previous_values(
 
 	// Validate input data before database operation
 	let mut data = request.data;
+	#[cfg(feature = "file-uploads")]
+	let mut field_aliases = relation_field_aliases(&site, &model_admin).map_server_fn_error()?;
+	#[cfg(not(feature = "file-uploads"))]
 	let field_aliases = relation_field_aliases(&site, &model_admin).map_server_fn_error()?;
+	#[cfg(feature = "file-uploads")]
+	field_aliases.extend(super::multipart::file_field_aliases(model_admin.as_ref())?);
 	validate_mutation_data_with_aliases(&data, model_admin.as_ref(), true, &field_aliases)
 		.map_server_fn_error()?;
 	let relation_values =
@@ -223,19 +235,19 @@ pub(crate) async fn update_record_with_previous_values(
 					transaction,
 				)
 				.await?;
-				Ok((affected, current_data))
+				Ok((affected, current_data, outcomes))
 			})
 			.await
 	}
 	.await;
 
 	// Check for database errors first, logging failure before returning
-	let (affected, mut previous_data) = match result {
+	let (affected, mut previous_data, outcomes) = match result {
 		Err(error) => {
 			audit::log_update(&audit_user_id, &model_name, &id, &sanitized_data, false);
 			return Err(map_inline_transaction_error(error));
 		}
-		Ok((affected, previous_data)) => (affected, previous_data),
+		Ok((affected, previous_data, outcomes)) => (affected, previous_data, outcomes),
 	};
 
 	audit::log_update(&audit_user_id, &model_name, &id, &sanitized_data, true);
@@ -248,5 +260,5 @@ pub(crate) async fn update_record_with_previous_values(
 		affected: Some(affected),
 		data: None,
 	};
-	Ok((response, previous_data))
+	Ok((response, previous_data, outcomes))
 }

--- a/crates/reinhardt-admin/src/types/models.rs
+++ b/crates/reinhardt-admin/src/types/models.rs
@@ -143,6 +143,9 @@ pub struct FieldInfo {
 	pub field_type: FieldType,
 	/// Whether the field is required
 	pub required: bool,
+	/// Whether the field accepts an explicit null or clear value.
+	#[serde(default)]
+	pub nullable: bool,
 	/// Whether the field is readonly
 	pub readonly: bool,
 	/// Help text displayed below the field
@@ -383,6 +386,9 @@ pub struct ColumnInfo {
 	/// Whether an editable value is required.
 	#[serde(default)]
 	pub required: bool,
+	/// Whether an editable value may be cleared.
+	#[serde(default)]
+	pub nullable: bool,
 	/// Input rendering specification for editable columns.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub form_spec: Option<FormFieldSpec>,

--- a/crates/reinhardt-admin/tests/wasm_components.rs
+++ b/crates/reinhardt-admin/tests/wasm_components.rs
@@ -161,6 +161,11 @@ fn action_list_data() -> ListViewData {
 			field: "title".to_string(),
 			label: "Title".to_string(),
 			sortable: true,
+			editable: false,
+			linked: false,
+			required: false,
+			nullable: false,
+			form_spec: None,
 		}],
 		records: vec![
 			HashMap::from([
@@ -372,6 +377,7 @@ fn test_model_form_create_mode() {
 			html_type: "text".to_string(),
 		},
 		required: true,
+		nullable: false,
 		value: String::new(),
 	}];
 
@@ -396,6 +402,7 @@ fn test_model_form_edit_mode() {
 			html_type: "text".to_string(),
 		},
 		required: true,
+		nullable: false,
 		value: "john_doe".to_string(),
 	}];
 
@@ -479,6 +486,7 @@ fn model_form_with_fieldsets_expands_collapsed_required_group() {
 			html_type: "text".to_string(),
 		},
 		required: true,
+		nullable: false,
 		value: String::new(),
 	}];
 	let fieldsets = vec![Fieldset::new(Some("Required"), &["title"]).collapsed()];
@@ -607,6 +615,7 @@ fn inline_readonly_fields_render_values_without_successful_controls() {
 		label: "Created by".to_string(),
 		field_type: FieldType::Text,
 		required: false,
+		nullable: false,
 		readonly: true,
 		help_text: None,
 		placeholder: None,
@@ -634,6 +643,7 @@ fn inline_boolean_existing_value_sets_checked_without_checking_blank_extra() {
 		label: "Enabled".to_string(),
 		field_type: FieldType::Boolean,
 		required: true,
+		nullable: false,
 		readonly: false,
 		help_text: None,
 		placeholder: None,
@@ -694,6 +704,7 @@ async fn structured_inline_errors_update_the_row_without_navigation() {
 			label: "External ID".to_string(),
 			field_type: FieldType::Text,
 			required: false,
+			nullable: false,
 			readonly: false,
 			help_text: None,
 			placeholder: None,
@@ -703,6 +714,7 @@ async fn structured_inline_errors_update_the_row_without_navigation() {
 			label: "Large number".to_string(),
 			field_type: FieldType::Number,
 			required: false,
+			nullable: false,
 			readonly: false,
 			help_text: None,
 			placeholder: None,
@@ -712,6 +724,7 @@ async fn structured_inline_errors_update_the_row_without_navigation() {
 			label: "Decimal number".to_string(),
 			field_type: FieldType::Number,
 			required: false,
+			nullable: false,
 			readonly: false,
 			help_text: None,
 			placeholder: None,
@@ -808,6 +821,7 @@ fn text_field(name: &str, label: &str) -> FormField {
 			html_type: "text".to_string(),
 		},
 		required: false,
+		nullable: false,
 		value: String::new(),
 	}
 }
@@ -932,6 +946,7 @@ fn inline_form(style: InlineStyle, can_delete: bool) -> InlineFormInfo {
 				label: "Code".to_string(),
 				field_type: FieldType::Text,
 				required: true,
+				nullable: false,
 				readonly: false,
 				help_text: None,
 				placeholder: None,
@@ -941,6 +956,7 @@ fn inline_form(style: InlineStyle, can_delete: bool) -> InlineFormInfo {
 				label: "Note".to_string(),
 				field_type: FieldType::TextArea,
 				required: false,
+				nullable: false,
 				readonly: false,
 				help_text: None,
 				placeholder: None,
@@ -998,6 +1014,7 @@ fn relation_raw_id_preserves_the_named_value_and_describes_the_resolved_label() 
 			readonly: false,
 		},
 		required: true,
+		nullable: false,
 		value: "7".to_string(),
 	}];
 
@@ -1040,6 +1057,7 @@ fn relation_autocomplete_uses_a_search_control_and_a_hidden_submitted_id() {
 			readonly: false,
 		},
 		required: true,
+		nullable: false,
 		value: "7".to_string(),
 	}];
 
@@ -1082,6 +1100,7 @@ fn readonly_relation_renders_without_a_submitted_control() {
 			readonly: true,
 		},
 		required: true,
+		nullable: false,
 		value: "7".to_string(),
 	}];
 
@@ -1108,6 +1127,7 @@ fn test_model_form_renders_textarea_for_text_area_spec() {
 		label: "Bio".to_string(),
 		spec: FormFieldSpec::TextArea,
 		required: false,
+		nullable: false,
 		value: "Hello world".to_string(),
 	}];
 
@@ -1136,6 +1156,7 @@ fn test_model_form_renders_select_with_inline_options() {
 			],
 		},
 		required: true,
+		nullable: false,
 		value: "active".to_string(),
 	}];
 
@@ -1174,6 +1195,7 @@ fn test_model_form_renders_multiselect_with_multiple_selections() {
 			],
 		},
 		required: false,
+		nullable: false,
 		// Multi-select wire format is comma-separated values; both `read`
 		// and `write` should end up marked selected.
 		value: "read,write".to_string(),
@@ -1213,6 +1235,7 @@ fn test_list_view_renders_table_with_data() {
 				editable: false,
 				linked: true,
 				required: true,
+				nullable: false,
 				form_spec: None,
 			},
 			Column {
@@ -1222,6 +1245,7 @@ fn test_list_view_renders_table_with_data() {
 				editable: false,
 				linked: false,
 				required: false,
+				nullable: false,
 				form_spec: None,
 			},
 		],
@@ -1583,6 +1607,7 @@ fn textarea_renders_as_textarea_element() {
 		label: "Biography".to_string(),
 		spec: FormFieldSpec::TextArea,
 		required: false,
+		nullable: false,
 		value: "hello world".to_string(),
 	}];
 
@@ -1616,6 +1641,7 @@ fn textarea_required_renders_required_attr() {
 		label: "Biography".to_string(),
 		spec: FormFieldSpec::TextArea,
 		required: true,
+		nullable: false,
 		value: String::new(),
 	}];
 
@@ -1650,6 +1676,7 @@ fn select_renders_options_with_selected_current_value() {
 			],
 		},
 		required: false,
+		nullable: false,
 		value: "published".to_string(),
 	}];
 
@@ -1716,6 +1743,7 @@ fn select_required_renders_required_attr() {
 			choices: vec![("a".to_string(), "A".to_string())],
 		},
 		required: true,
+		nullable: false,
 		value: String::new(),
 	}];
 
@@ -1749,6 +1777,7 @@ fn multiselect_renders_as_select_with_multiple_attr() {
 			],
 		},
 		required: false,
+		nullable: false,
 		value: String::new(),
 	}];
 
@@ -1787,6 +1816,7 @@ fn multiselect_required_renders_required_attr() {
 			choices: vec![("rust".to_string(), "Rust".to_string())],
 		},
 		required: true,
+		nullable: false,
 		value: String::new(),
 	}];
 

--- a/crates/reinhardt-db/src/orm/file_fields/image.rs
+++ b/crates/reinhardt-db/src/orm/file_fields/image.rs
@@ -209,6 +209,7 @@ impl<M> ModelImageField<M> {
 		{
 			Ok(stored) => Ok(stored),
 			Err(FileMutationError::Storage(error)) => Err(error),
+			Err(FileMutationError::StorageForField { source, .. }) => Err(source),
 			Err(FileMutationError::Database(never)) => match never {},
 		}
 	}

--- a/crates/reinhardt-db/src/orm/file_fields/lifecycle.rs
+++ b/crates/reinhardt-db/src/orm/file_fields/lifecycle.rs
@@ -354,13 +354,13 @@ where
 		}
 
 		let adoption = Arc::new(UnstagedUploadGuard::new(
-			Arc::clone(&registry),
+			Arc::clone(registry),
 			write.policy.clone(),
 			write.operation,
 		));
 		let adoption_protocol: Arc<dyn StoredObjectAdoption> = adoption.clone();
 		let stored = match store_uploaded_file_with_adoption(
-			&registry,
+			registry,
 			write.policy.model.as_ref(),
 			write.policy.field.as_ref(),
 			write.policy.upload_to.as_ref(),

--- a/crates/reinhardt-db/src/orm/file_fields/lifecycle.rs
+++ b/crates/reinhardt-db/src/orm/file_fields/lifecycle.rs
@@ -138,6 +138,15 @@ pub enum FileMutationError<E> {
 	/// Upload validation or storage failed.
 	#[error("file storage mutation failed: {0}")]
 	Storage(#[from] FileFieldError),
+	/// Upload validation or storage failed for one coordinated model field.
+	#[error("file storage mutation for field '{field}' failed: {source}")]
+	StorageForField {
+		/// Logical model field whose upload failed.
+		field: String,
+		/// Underlying validation or storage failure.
+		#[source]
+		source: FileFieldError,
+	},
 	/// The caller-owned database operation failed.
 	#[error("database mutation failed: {0}")]
 	Database(E),
@@ -338,7 +347,10 @@ where
 			.expect("non-empty writes must have a staged-upload guard");
 		if let Err(error) = validate_upload(&write.policy.validation, &write.upload).await {
 			staged_uploads.compensate().await;
-			return Err(FileMutationError::Storage(error));
+			return Err(FileMutationError::StorageForField {
+				field: write.policy.field.to_string(),
+				source: error,
+			});
 		}
 
 		let adoption = Arc::new(UnstagedUploadGuard::new(
@@ -362,7 +374,10 @@ where
 			Ok(stored) => stored,
 			Err(error) => {
 				staged_uploads.compensate().await;
-				return Err(FileMutationError::Storage(error));
+				return Err(FileMutationError::StorageForField {
+					field: write.policy.field.to_string(),
+					source: error,
+				});
 			}
 		};
 
@@ -370,14 +385,20 @@ where
 			Ok(owned) => owned,
 			Err(error) => {
 				staged_uploads.compensate().await;
-				return Err(FileMutationError::Storage(error));
+				return Err(FileMutationError::StorageForField {
+					field: write.policy.field.to_string(),
+					source: error,
+				});
 			}
 		};
 		let file = match staged_uploads.stage(owned) {
 			Ok(file) => file,
 			Err(error) => {
 				staged_uploads.compensate().await;
-				return Err(FileMutationError::Storage(error));
+				return Err(FileMutationError::StorageForField {
+					field: write.policy.field.to_string(),
+					source: error,
+				});
 			}
 		};
 		stored_values.push(file);
@@ -1266,8 +1287,9 @@ mod tests {
 		.await;
 
 		match result {
-			Err(FileMutationError::Storage(error)) => {
-				assert_eq!(error.to_string(), "the upload does not include a filename");
+			Err(FileMutationError::StorageForField { field, source }) => {
+				assert_eq!(field, "resume");
+				assert_eq!(source.to_string(), "the upload does not include a filename");
 			}
 			other => panic!("expected storage failure, got {other:?}"),
 		}
@@ -1306,9 +1328,10 @@ mod tests {
 		.await;
 
 		match result {
-			Err(FileMutationError::Storage(error)) => {
+			Err(FileMutationError::StorageForField { field, source }) => {
+				assert_eq!(field, "resume");
 				assert_eq!(
-					error.to_string(),
+					source.to_string(),
 					"Permission denied: store uploads/second.txt"
 				);
 			}

--- a/crates/reinhardt-pages/src/server_fn/multipart.rs
+++ b/crates/reinhardt-pages/src/server_fn/multipart.rs
@@ -91,6 +91,11 @@ impl MultipartArguments {
 		}
 	}
 
+	/// Returns all parsed parts in their original wire order.
+	pub fn into_parts(self) -> Vec<MultipartPart> {
+		self.parts
+	}
+
 	/// Rejects any unconsumed multipart parts.
 	pub fn finish(self) -> Result<(), ServerFnError> {
 		match self.parts.first() {
@@ -159,4 +164,33 @@ fn invalid_request(reason: &'static str, argument: Option<&str>) -> ServerFnErro
 		"Rejected multipart server function request",
 	);
 	ServerFnError::server(400, INVALID_REQUEST_MESSAGE)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	#[tokio::test]
+	async fn into_parts_preserves_multipart_wire_order() {
+		let request = reinhardt_http::Request::builder()
+			.uri("/api/server_fn/upload")
+			.header(header::CONTENT_TYPE, "multipart/form-data; boundary=boundary")
+			.body(
+				b"--boundary\r\nContent-Disposition: form-data; name=\"first\"\r\n\r\n\"one\"\r\n--boundary\r\nContent-Disposition: form-data; name=\"second\"\r\n\r\n\"two\"\r\n--boundary--\r\n"
+					.as_slice()
+					.into(),
+			)
+			.build()
+			.expect("multipart request should build");
+
+		let parts = MultipartArguments::from_request(&request)
+			.await
+			.expect("multipart request should parse")
+			.into_parts();
+
+		let names = parts.iter().map(part_name).collect::<Vec<_>>();
+		assert_eq!(names, ["first", "second"]);
+	}
 }

--- a/crates/reinhardt-pages/src/server_fn/multipart.rs
+++ b/crates/reinhardt-pages/src/server_fn/multipart.rs
@@ -91,9 +91,9 @@ impl MultipartArguments {
 		}
 	}
 
-	/// Returns all parsed parts in their original wire order.
-	pub fn into_parts(self) -> Vec<MultipartPart> {
-		self.parts
+	/// Removes all parsed parts in their original wire order.
+	pub fn take_parts(&mut self) -> Vec<MultipartPart> {
+		std::mem::take(&mut self.parts)
 	}
 
 	/// Rejects any unconsumed multipart parts.
@@ -173,7 +173,7 @@ mod tests {
 
 	#[rstest]
 	#[tokio::test]
-	async fn into_parts_preserves_multipart_wire_order() {
+	async fn take_parts_preserves_multipart_wire_order_and_allows_finish() {
 		let request = reinhardt_http::Request::builder()
 			.uri("/api/server_fn/upload")
 			.header(header::CONTENT_TYPE, "multipart/form-data; boundary=boundary")
@@ -185,10 +185,13 @@ mod tests {
 			.build()
 			.expect("multipart request should build");
 
-		let parts = MultipartArguments::from_request(&request)
+		let mut arguments = MultipartArguments::from_request(&request)
 			.await
-			.expect("multipart request should parse")
-			.into_parts();
+			.expect("multipart request should parse");
+		let parts = arguments.take_parts();
+		arguments
+			.finish()
+			.expect("draining parts should leave no unexpected arguments");
 
 		let names = parts.iter().map(part_name).collect::<Vec<_>>();
 		assert_eq!(names, ["first", "second"]);

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -87,6 +87,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +276,17 @@ name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "argon2"
@@ -280,6 +315,15 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -552,6 +596,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +798,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -941,6 +1043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,10 +1083,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1323,6 +1443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1720,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1968,12 +2100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74b6c4d4a1cff5f454164363c16b72fa12463ca6b31f4b5f2035a65fa3d5906"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,6 +2232,26 @@ dependencies = [
  "env_filter",
  "jiff",
  "log",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2296,6 +2442,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "num-complex",
+ "pulp",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2319,6 +2482,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fd-lock"
 version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,6 +2496,15 @@ dependencies = [
  "cfg-if",
  "rustix 1.1.4",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2711,6 +2889,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,6 +2997,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3260,6 +3459,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,6 +3581,17 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3628,6 +3878,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "lettre"
 version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,6 +3915,16 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -3775,6 +4041,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3797,6 +4072,16 @@ name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "md-5"
@@ -3933,6 +4218,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3965,6 +4260,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nibble_vec"
@@ -4000,6 +4301,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,6 +4333,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
@@ -4112,6 +4428,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -4120,6 +4437,17 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "num-integer"
@@ -4419,6 +4747,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pbkdf2"
@@ -4750,6 +5084,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4919,6 +5266,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5005,6 +5371,50 @@ checksum = "0194e6e1966c23cc5fd988714f85b18d548d773e81965413555d96569931833d"
 dependencies = [
  "pulldown-cmark",
 ]
+
+[[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -5810,6 +6220,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5875,6 +6344,12 @@ dependencies = [
  "futures-core",
  "futures-io",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redis"
@@ -6075,6 +6550,7 @@ dependencies = [
  "reinhardt-urls",
  "reinhardt-utils",
  "reqwest 0.13.4",
+ "rust_decimal",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
@@ -6212,6 +6688,7 @@ dependencies = [
  "reinhardt-apps",
  "reinhardt-auth",
  "reinhardt-conf",
+ "reinhardt-core",
  "reinhardt-db",
  "reinhardt-di",
  "reinhardt-http",
@@ -6249,7 +6726,6 @@ version = "0.4.0-alpha.6"
 dependencies = [
  "base64",
  "chrono",
- "dotenv",
  "indexmap 2.14.0",
  "nom 8.0.0",
  "parking_lot",
@@ -6332,6 +6808,7 @@ dependencies = [
  "dashmap",
  "dialoguer",
  "futures",
+ "image",
  "indexmap 2.14.0",
  "indicatif",
  "lazy_static",
@@ -6352,6 +6829,7 @@ dependencies = [
  "reinhardt-core",
  "reinhardt-di",
  "reinhardt-query",
+ "reinhardt-storages",
  "rust_decimal",
  "same-file",
  "serde",
@@ -6709,6 +7187,22 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "reinhardt-storages"
+version = "0.4.0-alpha.6"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "rand 0.9.5",
+ "reinhardt-conf",
+ "reinhardt-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -7072,6 +7566,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -7958,6 +8458,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8555,6 +9064,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -9219,6 +9742,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9435,6 +9969,12 @@ checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
@@ -9904,6 +10444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10050,3 +10596,27 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/instructions/MACRO_USAGE.md
+++ b/instructions/MACRO_USAGE.md
@@ -209,10 +209,13 @@ field metadata, so the alias is not inferred from a provider-prefixed row.
 explicit duration. Initialize `reinhardt::file_storage` before storing or
 opening a value and retain its RAII activation guard.
 
-Phase A does not clean up an object when a later database save fails, so an
-orphan can remain. Replacement/delete cleanup and the `ImageField` API are
-Phase B. Multipart/form/admin integration is Phase C and is not implemented by
-this foundation.
+The lower-level `store` operation is eager. For model mutations, use the
+coordinator APIs described in the ORM documentation: staged objects are
+compensated when persistence fails, and replacement, clear, or delete cleanup
+is attempted after database success. `cleanup = false` suppresses old-object
+cleanup while retaining compensation. With the admin `file-uploads` feature,
+FileField and ImageField form submissions use multipart mutations with the same
+validation and cleanup policy.
 
 ## Quick Reference
 

--- a/instructions/MIGRATION_0.4.md
+++ b/instructions/MIGRATION_0.4.md
@@ -57,13 +57,15 @@ stable old alias and redirect that alias to the new backend. A migration that
 only edits the model attribute or TOML can leave every existing row pointing
 at a missing object.
 
-### Phase A boundaries
+### Storage lifecycle and admin integration
 
-The upload is eager. If the storage write succeeds but the later database save
-fails, Phase A can leave an orphan object. Replacement and delete cleanup plus
-`ImageField` validation are Phase B. Multipart parsing, form binding, and
-admin integration are Phase C. None of those lifecycle or integration features
-should be assumed from the Phase A API.
+The low-level `store` operation remains eager. Model mutation coordinators
+stage uploads before persistence, compensate staged objects when the database
+operation fails, and attempt replacement, clear, or delete cleanup after a
+successful database commit. Cleanup failures are logged without changing the
+database result, and `cleanup = false` preserves old objects. When the admin
+`file-uploads` feature is enabled, multipart form binding uses these same
+policies and validates ImageField uploads before persistence.
 
 ## Validated session authentication
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Add strict multipart create and update endpoints for dynamic admin forms with storage-backed FileField and ImageField controls.
- Validate and stage uploads through the existing file mutation coordinator, persist logical paths through existing admin mutations, and perform best-effort replacement, Clear, and delete cleanup after database success.
- Preserve the JSON path for forms without file controls and document the storage lifecycle contract.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (code or behavior that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] No - This change is backward compatible
- [ ] Yes - This change breaks existing public API or behavior

## Motivation and Context

Dynamic admin forms must transmit file bytes instead of browser-local path strings. This change connects the admin form transport to the existing typed storage lifecycle so image validation and staged-file compensation happen before persistence, while committed-row cleanup remains best effort.

Fixes #6039

Related to: #5809, #6037, #6038

## How Was This Tested?

- CARGO_BUILD_JOBS=2 cargo test -p reinhardt-admin --features file-uploads --lib --quiet (734 passed)
- CARGO_BUILD_JOBS=2 cargo check -p reinhardt-admin --features file-uploads --lib
- CARGO_BUILD_JOBS=2 cargo check -p reinhardt-admin --lib
- CARGO_BUILD_JOBS=2 cargo doc -p reinhardt-admin --no-deps
- cargo fmt --all and git diff --check
- The reinhardt-pages multipart test remains blocked by the pre-existing missing query_browser_resource_probe_for_test helper at crates/reinhardt-pages/src/reactive/query/tests.rs:5420.

## Performance Impact

-

## Breaking Changes

-

## Screenshots

-

## Checklist

- [ ] I have followed the Contributing Guidelines
- [ ] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with cargo fmt
- [x] I have checked the code with cargo clippy

## Related Issues

- Parent: #5809
- Dependency: #6037
- Parallel form transport: #6038

## Labels to Apply

- [x] enhancement
- [x] database
- [x] admin
- [x] forms
- [x] medium

## Additional Context

Cleanup failures are logged and do not change a successful database mutation response. The PR intentionally targets the #6037 branch so the typed storage lifecycle dependency remains isolated from the parallel #6038 work.