### PR TITLE
fix(ci): allow compatible num-bigint versions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -102,7 +102,7 @@ skip = [
   { crate = "litemap@0.7.5", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "nix@0.30.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "num-bigint@0.2.6", reason = "Cloud Storage retains the 0.2 API while current database and authentication dependencies require the incompatible 0.4 line." },
-  { crate = "num-bigint@0.5.1", reason = "Redis uses the 0.5 API while current database and authentication dependencies require the incompatible 0.4 line." },
+  { crate = "num-bigint:>=0.5,<0.6", reason = "Redis uses the 0.5 API while current database and authentication dependencies require the incompatible 0.4 line; allow compatible patch updates without reintroducing the duplicate." },
   { crate = "pem@0.8.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "phf_generator@0.11.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "phf_macros@0.11.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },


### PR DESCRIPTION
## Summary

This PR addresses:

- Allow the `num-bigint` 0.5 minor line required by Redis alongside the incompatible 0.4 line.
- Use a PackageSpec range so fresh patch resolution does not reintroduce the duplicate-version failure on the develop/0.4.0 base.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (code change that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither adds functionality nor fixes a bug)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The full-feature dependency graph resolves `num-bigint 0.4.8` through `bigdecimal`/Cassandra and `num-bigint 0.5.1` through Redis. The duplicate-version ban therefore fails on develop/0.4.0; the 0.5 minor line is explicitly allowed while preserving the existing 0.2 exception.

## How Was This Tested?

- [x] `cargo deny --workspace --all-features check all` passed with a fresh dependency resolution
- [x] `git diff --check` passed
- [x] All cargo-deny categories passed: advisories, bans, licenses, and sources
- [ ] Full workspace test suite (not applicable to this policy-only change)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (not applicable to this policy-only change)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable to this policy-only change)
- [ ] New and existing unit tests pass locally (not applicable to this policy-only change)
- [ ] I have tested with all affected database backends (not applicable to this policy-only change)
- [ ] I have formatted the code with `cargo make fmt-fix` (not applicable to this policy-only change)
- [ ] I have checked the code with `cargo make clippy-check` (not applicable to this policy-only change)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)

- [x] `bug`
- [ ] `enhancement`
- [ ] `documentation`
- [ ] `performance`
- [ ] `refactoring`
- [ ] `code-quality`

### Scope Label (select all that apply)

- [x] `ci-cd`

## Additional Context

- This is the develop/0.4.0-specific copy of the shared cargo-deny repair.
- Existing unrelated cargo-deny warnings are unchanged.

🤖 Generated with [Codex](https://openai.com/codex/)