### PR TITLE
feat(commands): emit machine-readable contract violation reports

### DIFF
--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -124,35 +124,69 @@ for the canonical schema and field rules.
 
 ### Verifying the application contract
 
-With the `contract` feature enabled, run the human-readable verifier through
-Cargo:
+With the `contract` feature enabled, use the human-readable default for people
+or the version 1 JSON report for automation:
 
 ```bash
 cargo run --bin manage -- verify
+cargo run --bin manage -- verify --format json
 ```
 
-The command first replays the consumer Cargo check captured by the generated
-launcher. A Cargo spawn failure or non-zero status stops before contract
-collection. On success, schema, authorization, and settings checks run
-independently; a settings-source failure does not suppress authorization
-findings. Launcher replay also fails closed when Cargo-exposed feature names are
-ambiguous after normalization. Defaulted migration fragments use their composed
-root defaults during schema checks. The stable finding codes are:
+The clean JSON report is:
 
-- `schema.missing_migration` and `schema.unapplied_migration`;
-- `authorization.missing_declaration`;
-- `settings.missing_required`, `settings.type_mismatch`,
-  `settings.map_key_type_mismatch`, and `settings.duplicate_input`.
+```json
+{
+  "schema_version": 1,
+  "status": "passed",
+  "violations": []
+}
+```
 
-Applied-migration coverage is optional; without an applied snapshot, only that
-coverage check is omitted. Endpoint checks materialize synchronous in-memory
-route registrations without installing a global router. They reject
-asynchronous factories and invalid route patterns without polling, and do not initialize dependency
-injection or open a database. Settings checks use the same typed coercion as
-the builder and redact values, concrete map keys, and parser/deserializer
-diagnostics. Verification is human-readable only, not a JSON export, and a
-directly invoked prebuilt `manage` binary is outside the stale-binary freshness
-boundary; use `cargo run` to build the current binary first.
+| Result | Exit status |
+| --- | ---: |
+| `passed` | 0 |
+| `failed` | 1 |
+| `error` | 2 |
+
+In JSON mode, stdout contains only one report document. Cargo output and
+operational diagnostics use stderr. Every current violation has severity
+`error`. Settings values and concrete dynamic keys are absent, and `location`
+is currently `null` because the verifier does not retain source positions.
+Human-readable output remains the default.
+
+Each violation has the structured fields `code`, `class`, `severity`,
+`target`, `location`, `evidence`, and `suggested_fix`. The seven stable finding
+codes are `schema.missing_migration`, `schema.unapplied_migration`,
+`authorization.missing_declaration`, `settings.missing_required`,
+`settings.type_mismatch`, `settings.map_key_type_mismatch`, and
+`settings.duplicate_input`. Reports inherit canonical ordering from
+`VerificationRun`.
+
+Targets use one of these shapes:
+
+```text
+model_change: app_label, name_fragment
+migration: app_label, migration_name
+endpoint: method, path, module_path, function_name
+setting: canonical wildcarded path
+```
+
+An agent can consume the report with this repair loop:
+
+```bash
+cargo run --bin manage -- verify --format json > /tmp/reinhardt-verify.json
+status=$?
+case "$status" in
+  0) echo "contract verified" ;;
+  1) jq -r '.violations[] | [.code, .target.kind, .suggested_fix] | @tsv' /tmp/reinhardt-verify.json ;;
+  2) echo "verification could not complete" >&2 ;;
+esac
+rm -f /tmp/reinhardt-verify.json
+```
+
+Repair source only for exit 1, rerun the command, and stop when it reports
+`passed`. Exit 2 requires repairing the execution environment or configuration
+before findings can be trusted.
 
 ### Squashing migrations
 

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -1245,7 +1245,6 @@ where
 	};
 	if let Commands::Verify { format } = &command {
 		let format = *format;
-		let _ = format;
 		let Some(cargo_context) = cargo_context else {
 			return Err(crate::CommandError::ExecutionError(
 				"verify requires launcher Cargo context".to_owned(),
@@ -1257,6 +1256,7 @@ where
 		return execute_verify_with_provider(
 			&cargo_context,
 			provider,
+			format,
 			&mut standard_output.lock(),
 			&mut standard_error.lock(),
 		)

--- a/crates/reinhardt-commands/src/cli.rs
+++ b/crates/reinhardt-commands/src/cli.rs
@@ -10,7 +10,7 @@ use crate::collectstatic::{CollectStaticCommand, CollectStaticOptions};
 use crate::local_infra::InfraSubcommand;
 use crate::registry::CommandRegistry;
 #[cfg(feature = "contract")]
-use crate::verify::{CargoCheckContext, execute_verify_with_provider};
+use crate::verify::{CargoCheckContext, VerificationOutputFormat, execute_verify_with_provider};
 use crate::{
 	CheckCommand, CommandContext, MigrateCommand, RunServerCommand, ShellCommand, ShellConfig,
 };
@@ -159,7 +159,11 @@ pub enum Commands {
 
 	/// Replay the consumer Cargo check and verify the application contract.
 	#[cfg(feature = "contract")]
-	Verify,
+	Verify {
+		/// Output format for verification results.
+		#[arg(long, value_enum, default_value = "human")]
+		format: VerificationOutputFormat,
+	},
 
 	/// Create new migrations based on model changes
 	#[cfg(feature = "migrations")]
@@ -632,7 +636,7 @@ impl fmt::Debug for Commands {
 				debug_command_fields!(formatter, "Contract", command)
 			}
 			#[cfg(feature = "contract")]
-			Self::Verify => formatter.write_str("Verify"),
+			Self::Verify { format } => debug_command_fields!(formatter, "Verify", format),
 			#[cfg(feature = "migrations")]
 			Self::Makemigrations {
 				app_labels,
@@ -1239,7 +1243,9 @@ where
 		Err(DriverParseError::Clap(error)) => (*error).exit(),
 		Err(DriverParseError::Command(error)) => return Err(error.into()),
 	};
-	if matches!(&command, Commands::Verify) {
+	if let Commands::Verify { format } = &command {
+		let format = *format;
+		let _ = format;
 		let Some(cargo_context) = cargo_context else {
 			return Err(crate::CommandError::ExecutionError(
 				"verify requires launcher Cargo context".to_owned(),
@@ -1705,7 +1711,7 @@ async fn run_command_core_with_contract_state(
 
 	match command {
 		#[cfg(feature = "contract")]
-		Commands::Verify => Err(crate::CommandError::ExecutionError(
+		Commands::Verify { .. } => Err(crate::CommandError::ExecutionError(
 			"verify requires execute_from_command_line_with_pending_settings_and_cargo_context"
 				.to_owned(),
 		)

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -543,6 +543,11 @@ pub use template_hot_reload::{
 #[cfg(feature = "pages")]
 pub use template_state::{CompiledBaseline, SourceBaseline, StaticOverlayStore};
 #[cfg(feature = "contract")]
+pub use verify::report::{
+	VerificationClassV1, VerificationReportV1, VerificationSeverityV1, VerificationStatusV1,
+	VerificationTargetV1, VerificationViolationV1,
+};
+#[cfg(feature = "contract")]
 pub use verify::{
 	CargoCheckContext, CargoCheckPlan, CargoConfigReplay, CargoProfile, CargoReplayUnsupported,
 	VerificationCheckError, VerificationFinding, VerificationRun, execute_verify,

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -100,11 +100,13 @@
 //!
 //! ## Application Contract Verification
 //!
-//! With the `contract` feature enabled, `manage verify` runs a human-readable
-//! contract check:
+//! With the `contract` feature enabled, `manage verify` runs a contract check
+//! with human-readable output by default and a versioned report when passed
+//! `--format json`:
 //!
 //! ```text
 //! cargo run --bin manage -- verify
+//! cargo run --bin manage -- verify --format json
 //! ```
 //!
 //! The command first replays the consumer Cargo check captured by the generated
@@ -116,8 +118,8 @@
 //! Applied-migration coverage is optional; when no applied snapshot is
 //! available, only that coverage check is omitted.
 //!
-//! Verification is human-readable only and does not export the versioned JSON
-//! contract. Endpoint checks materialize synchronous in-memory route
+//! JSON reports are the only stdout output in JSON mode; Cargo output and
+//! diagnostics use stderr. Endpoint checks materialize synchronous in-memory route
 //! registrations without installing a global router. Asynchronous factories
 //! are rejected without polling, and verification does not initialize
 //! dependency injection or open a database. Settings
@@ -552,6 +554,7 @@ pub use verify::{
 	CargoCheckContext, CargoCheckPlan, CargoConfigReplay, CargoProfile, CargoReplayUnsupported,
 	VerificationCheckError, VerificationFinding, VerificationOutputFormat, VerificationRun,
 	execute_verify, execute_verify_with_applied_migrations, plan_cargo_check, render_verification,
+	render_verification_output,
 };
 pub use wasm_builder::{
 	WasmBuildConfig, WasmBuildError, WasmBuildOutput, WasmBuilder, check_wasm_tools_installed,
@@ -581,6 +584,14 @@ pub enum CommandError {
 	/// A runtime error occurred during command execution.
 	#[error("Execution error: {0}")]
 	ExecutionError(String),
+
+	/// Contract verification found violations.
+	#[error("Contract verification found violations")]
+	VerificationFailed,
+
+	/// Contract verification could not complete safely.
+	#[error("Contract verification could not complete: {0}")]
+	VerificationExecution(String),
 
 	/// A command requires an optional Cargo feature that is not enabled.
 	#[error("{0}")]

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -101,32 +101,69 @@
 //! ## Application Contract Verification
 //!
 //! With the `contract` feature enabled, `manage verify` runs a contract check
-//! with human-readable output by default and a versioned report when passed
-//! `--format json`:
+//! with human-readable output by default or a version 1 JSON report when
+//! passed `--format json`:
 //!
 //! ```text
 //! cargo run --bin manage -- verify
 //! cargo run --bin manage -- verify --format json
 //! ```
 //!
-//! The command first replays the consumer Cargo check captured by the generated
-//! launcher. A spawn failure or non-zero Cargo status stops before contract
-//! collection. After a successful check, schema, authorization, and settings
-//! validators run independently and render stable finding codes, including
-//! `schema.missing_migration`, `schema.unapplied_migration`,
-//! `authorization.missing_declaration`, and the four `settings.*` codes.
-//! Applied-migration coverage is optional; when no applied snapshot is
-//! available, only that coverage check is omitted.
+//! A clean report is:
 //!
-//! JSON reports are the only stdout output in JSON mode; Cargo output and
-//! diagnostics use stderr. Endpoint checks materialize synchronous in-memory route
-//! registrations without installing a global router. Asynchronous factories
-//! are rejected without polling, and verification does not initialize
-//! dependency injection or open a database. Settings
-//! validation uses the builder's typed-coercion mode and redacts values,
-//! concrete map keys, and parser/deserializer diagnostics from findings. Use
-//! `cargo run` for the supported freshness path; invoking a prebuilt `manage`
-//! binary directly does not detect that it is stale.
+//! ```json
+//! {
+//!   "schema_version": 1,
+//!   "status": "passed",
+//!   "violations": []
+//! }
+//! ```
+//!
+//! | Result | Exit status |
+//! | --- | ---: |
+//! | `passed` | 0 |
+//! | `failed` | 1 |
+//! | `error` | 2 |
+//!
+//! JSON stdout contains only the report; Cargo and operational diagnostics use
+//! stderr. All current violations have severity `error`. Settings values and
+//! concrete dynamic keys are absent, and `location` is currently `null`
+//! because the verifier does not retain source positions. Human-readable output
+//! remains the default.
+//!
+//! Every violation has `code`, `class`, `severity`, `target`, `location`,
+//! `evidence`, and `suggested_fix`. The stable finding codes are
+//! `schema.missing_migration`, `schema.unapplied_migration`,
+//! `authorization.missing_declaration`, `settings.missing_required`,
+//! `settings.type_mismatch`, `settings.map_key_type_mismatch`, and
+//! `settings.duplicate_input`; canonical ordering is inherited from
+//! `VerificationRun`. Targets have these shapes:
+//!
+//! ```text
+//! model_change: app_label, name_fragment
+//! migration: app_label, migration_name
+//! endpoint: method, path, module_path, function_name
+//! setting: canonical wildcarded path
+//! ```
+//!
+//! An agent can consume the report with this repair loop:
+//!
+//! ```bash
+//! cargo run --bin manage -- verify --format json > /tmp/reinhardt-verify.json
+//! status=$?
+//! case "$status" in
+//!   0) echo "contract verified" ;;
+//!   1) jq -r '.violations[] | [.code, .target.kind, .suggested_fix] | @tsv' /tmp/reinhardt-verify.json ;;
+//!   2) echo "verification could not complete" >&2 ;;
+//! esac
+//! rm -f /tmp/reinhardt-verify.json
+//! ```
+//!
+//! An agent should repair source only after exit 1, rerun the command, and
+//! stop at `passed`. Exit 2 requires repairing the execution environment or
+//! configuration before findings can be trusted. Use `cargo run` for the
+//! supported freshness path; invoking a prebuilt `manage` binary directly does
+//! not detect that it is stale.
 //!
 //! ## Example
 //!

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -550,8 +550,8 @@ pub use verify::report::{
 #[cfg(feature = "contract")]
 pub use verify::{
 	CargoCheckContext, CargoCheckPlan, CargoConfigReplay, CargoProfile, CargoReplayUnsupported,
-	VerificationCheckError, VerificationFinding, VerificationRun, execute_verify,
-	execute_verify_with_applied_migrations, plan_cargo_check, render_verification,
+	VerificationCheckError, VerificationFinding, VerificationOutputFormat, VerificationRun,
+	execute_verify, execute_verify_with_applied_migrations, plan_cargo_check, render_verification,
 };
 pub use wasm_builder::{
 	WasmBuildConfig, WasmBuildError, WasmBuildOutput, WasmBuilder, check_wasm_tools_installed,

--- a/crates/reinhardt-commands/src/lib.rs
+++ b/crates/reinhardt-commands/src/lib.rs
@@ -610,6 +610,14 @@ pub enum CommandError {
 	TemplateError(String),
 }
 
+/// Returns the process exit code associated with a command error.
+pub fn command_error_exit_code(error: &(dyn std::error::Error + 'static)) -> i32 {
+	match error.downcast_ref::<CommandError>() {
+		Some(CommandError::VerificationExecution(_)) => 2,
+		_ => 1,
+	}
+}
+
 impl From<tera::Error> for CommandError {
 	fn from(err: tera::Error) -> Self {
 		CommandError::TemplateError(err.to_string())

--- a/crates/reinhardt-commands/src/showmigrations.rs
+++ b/crates/reinhardt-commands/src/showmigrations.rs
@@ -190,6 +190,10 @@ pub(crate) fn with_command_context(error: CommandError, context: &str) -> Comman
 		CommandError::NotFound(detail) => CommandError::NotFound(message(detail)),
 		CommandError::InvalidArguments(detail) => CommandError::InvalidArguments(message(detail)),
 		CommandError::ExecutionError(detail) => CommandError::ExecutionError(message(detail)),
+		CommandError::VerificationFailed => CommandError::VerificationFailed,
+		CommandError::VerificationExecution(detail) => {
+			CommandError::VerificationExecution(message(detail))
+		}
 		CommandError::FeatureDisabled(detail) => CommandError::FeatureDisabled(message(detail)),
 		CommandError::IoError(error) => {
 			CommandError::IoError(io::Error::new(error.kind(), message(error.to_string())))

--- a/crates/reinhardt-commands/src/verify.rs
+++ b/crates/reinhardt-commands/src/verify.rs
@@ -5,6 +5,7 @@ pub mod report;
 
 use crate::database_selector::DatabaseSelector;
 use crate::{CommandError, CommandResult, ContractResolutionErrorKind, SafeContractTarget};
+use clap::ValueEnum;
 use reinhardt_conf::HasCommonSettings;
 use reinhardt_conf::settings::schema::{JsonKind, SettingsPathBuf, SettingsPathSegment};
 use reinhardt_conf::settings::{
@@ -20,6 +21,15 @@ use std::env;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Stdio;
+
+/// Output format for verification results.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum VerificationOutputFormat {
+	/// Render human-readable verification results.
+	Human,
+	/// Render machine-readable verification results.
+	Json,
+}
 
 /// The Cargo profile used for the replay check.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/reinhardt-commands/src/verify.rs
+++ b/crates/reinhardt-commands/src/verify.rs
@@ -1,5 +1,7 @@
 //! Deterministic contract verification and Cargo replay.
 
+pub mod report;
+
 use crate::database_selector::DatabaseSelector;
 use crate::{CommandError, CommandResult, ContractResolutionErrorKind, SafeContractTarget};
 use reinhardt_conf::HasCommonSettings;
@@ -485,7 +487,7 @@ fn json_kind_rank(kind: Option<JsonKind>) -> u8 {
 	}
 }
 
-fn redacted_settings_path(path: &SettingsPathBuf) -> String {
+pub(super) fn redacted_settings_path(path: &SettingsPathBuf) -> String {
 	path.segments()
 		.iter()
 		.map(|segment| match segment {

--- a/crates/reinhardt-commands/src/verify.rs
+++ b/crates/reinhardt-commands/src/verify.rs
@@ -1,5 +1,6 @@
 //! Deterministic contract verification and Cargo replay.
 
+/// Versioned machine-readable verification report projection.
 pub mod report;
 
 use crate::database_selector::DatabaseSelector;

--- a/crates/reinhardt-commands/src/verify.rs
+++ b/crates/reinhardt-commands/src/verify.rs
@@ -16,6 +16,7 @@ use reinhardt_db::migrations::{
 	FilesystemSource, MigrationCatalog, MigrationKey, SchemaCheckError, SchemaFinding,
 	verification::SchemaContractState, verify_schema_contract,
 };
+use report::VerificationReportV1;
 use std::collections::BTreeSet;
 use std::env;
 use std::io::Write;
@@ -534,7 +535,15 @@ pub async fn execute_verify<S: ComposedSettings>(
 	stdout: &mut dyn Write,
 	stderr: &mut dyn Write,
 ) -> CommandResult<()> {
-	execute_verify_with_applied_migrations(cargo, pending, None, stdout, stderr).await
+	execute_verify_with_format(
+		cargo,
+		pending,
+		None,
+		VerificationOutputFormat::Human,
+		stdout,
+		stderr,
+	)
+	.await
 }
 
 /// Run verification with an optional read-only migration snapshot.
@@ -545,13 +554,34 @@ pub async fn execute_verify_with_applied_migrations<S: ComposedSettings>(
 	stdout: &mut dyn Write,
 	stderr: &mut dyn Write,
 ) -> CommandResult<()> {
-	execute_cargo_check(cargo, stdout, stderr).await?;
-	execute_contract_checks(pending, applied_migrations, stdout).await
+	execute_verify_with_format(
+		cargo,
+		pending,
+		applied_migrations,
+		VerificationOutputFormat::Human,
+		stdout,
+		stderr,
+	)
+	.await
+}
+
+async fn execute_verify_with_format<S: ComposedSettings>(
+	cargo: &CargoCheckContext,
+	pending: &PendingSettings<S>,
+	applied_migrations: Option<BTreeSet<MigrationKey>>,
+	format: VerificationOutputFormat,
+	stdout: &mut dyn Write,
+	stderr: &mut dyn Write,
+) -> CommandResult<()> {
+	run_cargo_phase(cargo, format, stdout, stderr).await?;
+	let run = collect_contract_checks(pending, applied_migrations).await;
+	render_verification_output(&run, format, stdout, stderr)
 }
 
 pub(crate) async fn execute_verify_with_provider<S, F>(
 	cargo: &CargoCheckContext,
 	provider: F,
+	format: VerificationOutputFormat,
 	stdout: &mut dyn Write,
 	stderr: &mut dyn Write,
 ) -> CommandResult<()>
@@ -559,7 +589,7 @@ where
 	S: ComposedSettings + HasCommonSettings,
 	F: FnOnce() -> Result<PendingSettings<S>, reinhardt_conf::settings::builder::BuildError>,
 {
-	execute_cargo_check(cargo, stdout, stderr).await?;
+	run_cargo_phase(cargo, format, stdout, stderr).await?;
 	let pending = match provider() {
 		Ok(pending) => pending,
 		Err(_) => {
@@ -578,14 +608,12 @@ where
 				);
 			}
 			run.sort_canonical();
-			render_verification(&run, stdout)?;
-			return Err(CommandError::ExecutionError(
-				"contract verification found issues".to_owned(),
-			));
+			return render_verification_output(&run, format, stdout, stderr);
 		}
 	};
 	let applied_migrations = read_default_applied_migrations(&pending, stderr).await;
-	execute_contract_checks(&pending, applied_migrations, stdout).await
+	let run = collect_contract_checks(&pending, applied_migrations).await;
+	render_verification_output(&run, format, stdout, stderr)
 }
 
 async fn read_default_applied_migrations<S: ComposedSettings + HasCommonSettings>(
@@ -622,6 +650,7 @@ async fn read_default_applied_migrations<S: ComposedSettings + HasCommonSettings
 
 async fn execute_cargo_check(
 	cargo: &CargoCheckContext,
+	format: VerificationOutputFormat,
 	stdout: &mut dyn Write,
 	stderr: &mut dyn Write,
 ) -> CommandResult<()> {
@@ -639,8 +668,16 @@ async fn execute_cargo_check(
 		.output()
 		.await
 		.map_err(|_| CommandError::ExecutionError("cargo check could not be started".to_owned()))?;
-	stdout.write_all(&output.stdout)?;
-	stderr.write_all(&output.stderr)?;
+	match format {
+		VerificationOutputFormat::Human => stdout.write_all(&output.stdout),
+		VerificationOutputFormat::Json => stderr.write_all(&output.stdout),
+	}
+	.map_err(|_| {
+		CommandError::VerificationExecution("Cargo replay output could not be written".to_owned())
+	})?;
+	stderr.write_all(&output.stderr).map_err(|_| {
+		CommandError::VerificationExecution("Cargo replay output could not be written".to_owned())
+	})?;
 	if !output.status.success() {
 		return Err(CommandError::ExecutionError(
 			"cargo check failed; contract verification was not run".to_owned(),
@@ -649,11 +686,31 @@ async fn execute_cargo_check(
 	Ok(())
 }
 
-async fn execute_contract_checks<S: ComposedSettings>(
+async fn run_cargo_phase(
+	cargo: &CargoCheckContext,
+	format: VerificationOutputFormat,
+	stdout: &mut dyn Write,
+	stderr: &mut dyn Write,
+) -> CommandResult<()> {
+	if let Err(error) = execute_cargo_check(cargo, format, stdout, stderr).await {
+		if format == VerificationOutputFormat::Json {
+			VerificationReportV1::error()
+				.write_json(stdout)
+				.map_err(|_| {
+					CommandError::VerificationExecution(
+						"JSON verification report could not be written".to_owned(),
+					)
+				})?;
+		}
+		return Err(CommandError::VerificationExecution(error.to_string()));
+	}
+	Ok(())
+}
+
+async fn collect_contract_checks<S: ComposedSettings>(
 	pending: &PendingSettings<S>,
 	applied_migrations: Option<BTreeSet<MigrationKey>>,
-	stdout: &mut dyn Write,
-) -> CommandResult<()> {
+) -> VerificationRun {
 	let mut run = VerificationRun::default();
 	let contract_settings = pending.contract_state();
 	let aggregate = match crate::resolve_contract_state(pending, applied_migrations).await {
@@ -693,14 +750,7 @@ async fn execute_contract_checks<S: ComposedSettings>(
 		.map(VerificationFinding::Settings),
 	);
 	run.sort_canonical();
-	render_verification(&run, stdout)?;
-	if run.findings.is_empty() && run.check_errors.is_empty() {
-		stdout.write_all(b"Verification passed.\n")?;
-		return Ok(());
-	}
-	Err(CommandError::ExecutionError(
-		"contract verification found issues".to_owned(),
-	))
+	run
 }
 
 /// Render sorted verification output without exposing runtime setting values.
@@ -710,6 +760,57 @@ pub fn render_verification(run: &VerificationRun, stdout: &mut dyn Write) -> Com
 	}
 	for finding in &run.findings {
 		writeln!(stdout, "finding: {}", render_finding(finding))?;
+	}
+	Ok(())
+}
+
+/// Render a verification run in the requested output format.
+pub fn render_verification_output(
+	run: &VerificationRun,
+	format: VerificationOutputFormat,
+	stdout: &mut dyn Write,
+	stderr: &mut dyn Write,
+) -> CommandResult<()> {
+	match format {
+		VerificationOutputFormat::Human => {
+			render_verification(run, stdout).map_err(|_| {
+				CommandError::VerificationExecution(
+					"verification output could not be written".to_owned(),
+				)
+			})?;
+			if run.findings.is_empty() && run.check_errors.is_empty() {
+				stdout.write_all(b"Verification passed.\n").map_err(|_| {
+					CommandError::VerificationExecution(
+						"verification output could not be written".to_owned(),
+					)
+				})?;
+			}
+		}
+		VerificationOutputFormat::Json => {
+			VerificationReportV1::from_run(run)
+				.write_json(stdout)
+				.map_err(|_| {
+					CommandError::VerificationExecution(
+						"JSON verification report could not be written".to_owned(),
+					)
+				})?;
+			for error in &run.check_errors {
+				writeln!(stderr, "error: {}", render_check_error(error)).map_err(|_| {
+					CommandError::VerificationExecution(
+						"verification diagnostics could not be written".to_owned(),
+					)
+				})?;
+			}
+		}
+	}
+
+	if !run.check_errors.is_empty() {
+		return Err(CommandError::VerificationExecution(
+			"one or more verification checks could not complete".to_owned(),
+		));
+	}
+	if !run.findings.is_empty() {
+		return Err(CommandError::VerificationFailed);
 	}
 	Ok(())
 }

--- a/crates/reinhardt-commands/src/verify.rs
+++ b/crates/reinhardt-commands/src/verify.rs
@@ -702,9 +702,17 @@ async fn run_cargo_phase(
 					)
 				})?;
 		}
-		return Err(CommandError::VerificationExecution(error.to_string()));
+		return Err(cargo_phase_error(error));
 	}
 	Ok(())
+}
+
+fn cargo_phase_error(error: CommandError) -> CommandError {
+	match error {
+		CommandError::VerificationExecution(_) => error,
+		CommandError::ExecutionError(detail) => CommandError::VerificationExecution(detail),
+		error => CommandError::VerificationExecution(error.to_string()),
+	}
 }
 
 async fn collect_contract_checks<S: ComposedSettings>(
@@ -883,5 +891,29 @@ fn render_finding(finding: &VerificationFinding) -> String {
 				value.ordinal
 			)
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::cargo_phase_error;
+	use crate::CommandError;
+
+	#[test]
+	fn cargo_phase_errors_preserve_verification_details() {
+		assert_eq!(
+			cargo_phase_error(CommandError::ExecutionError(
+				"Cargo replay configuration is unsupported".to_owned(),
+			))
+			.to_string(),
+			"Contract verification could not complete: Cargo replay configuration is unsupported"
+		);
+		assert_eq!(
+			cargo_phase_error(CommandError::VerificationExecution(
+				"already typed".to_owned()
+			))
+			.to_string(),
+			"Contract verification could not complete: already typed"
+		);
 	}
 }

--- a/crates/reinhardt-commands/src/verify/report.rs
+++ b/crates/reinhardt-commands/src/verify/report.rs
@@ -10,67 +10,104 @@ pub const VERIFICATION_REPORT_SCHEMA_VERSION: u8 = 1;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+/// Overall result of a verification run.
 pub enum VerificationStatusV1 {
+	/// No contract violations were found.
 	Passed,
+	/// Contract violations were found.
 	Failed,
+	/// Verification could not safely complete.
 	Error,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+/// Stable category of a verification violation.
 pub enum VerificationClassV1 {
+	/// Schema or migration contract violation.
 	Schema,
+	/// Endpoint authorization contract violation.
 	Authorization,
+	/// Settings contract violation.
 	Settings,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+/// Severity assigned to a verification violation.
 pub enum VerificationSeverityV1 {
+	/// The violation prevents a passing verification result.
 	Error,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
+/// Redacted target associated with a verification violation.
 pub enum VerificationTargetV1 {
+	/// Model state change that requires a migration.
 	ModelChange {
+		/// Application owning the model change.
 		app_label: String,
+		/// Stable migration-name fragment for the change.
 		name_fragment: String,
 	},
+	/// Migration missing from applied history.
 	Migration {
+		/// Application owning the migration.
 		app_label: String,
+		/// Migration name.
 		migration_name: String,
 	},
+	/// Endpoint lacking an explicit authorization declaration.
 	Endpoint {
+		/// HTTP method.
 		method: String,
+		/// Route path.
 		path: String,
+		/// Endpoint module path.
 		module_path: String,
+		/// Endpoint function name.
 		function_name: String,
 	},
+	/// Settings path with dynamic values redacted.
 	Setting {
+		/// Canonical, redacted settings path.
 		path: String,
 	},
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+/// Machine-readable version-one verification violation.
 pub struct VerificationViolationV1 {
+	/// Stable violation code.
 	pub code: String,
+	/// Violation category.
 	pub class: VerificationClassV1,
+	/// Violation severity.
 	pub severity: VerificationSeverityV1,
+	/// Redacted violation target.
 	pub target: VerificationTargetV1,
+	/// Optional source location.
 	pub location: Option<String>,
+	/// Human-readable evidence for the violation.
 	pub evidence: String,
+	/// Optional remediation guidance.
 	pub suggested_fix: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+/// Machine-readable version-one verification report.
 pub struct VerificationReportV1 {
+	/// Report schema version.
 	pub schema_version: u8,
+	/// Overall verification status.
 	pub status: VerificationStatusV1,
+	/// Canonically ordered violations.
 	pub violations: Vec<VerificationViolationV1>,
 }
 
 impl VerificationReportV1 {
+	/// Project a verification run into the stable version-one report schema.
 	pub fn from_run(run: &VerificationRun) -> Self {
 		if !run.check_errors.is_empty() {
 			return Self::error();
@@ -89,6 +126,7 @@ impl VerificationReportV1 {
 		}
 	}
 
+	/// Build an error report that does not expose partial findings.
 	pub fn error() -> Self {
 		Self {
 			schema_version: VERIFICATION_REPORT_SCHEMA_VERSION,
@@ -97,6 +135,7 @@ impl VerificationReportV1 {
 		}
 	}
 
+	/// Serialize the report as pretty JSON terminated by a newline.
 	pub fn write_json(&self, output: &mut dyn Write) -> CommandResult<()> {
 		let mut document = serde_json::to_vec_pretty(self)?;
 		document.push(b'\n');

--- a/crates/reinhardt-commands/src/verify/report.rs
+++ b/crates/reinhardt-commands/src/verify/report.rs
@@ -1,0 +1,207 @@
+use super::{VerificationFinding, VerificationRun, redacted_settings_path};
+use crate::CommandResult;
+use reinhardt_conf::settings::schema::{JsonKind, SettingsViolationKind};
+use reinhardt_db::migrations::SchemaFinding;
+use serde::Serialize;
+use std::io::Write;
+
+/// Version of the machine-readable verification report schema.
+pub const VERIFICATION_REPORT_SCHEMA_VERSION: u8 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationStatusV1 {
+	Passed,
+	Failed,
+	Error,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationClassV1 {
+	Schema,
+	Authorization,
+	Settings,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationSeverityV1 {
+	Error,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum VerificationTargetV1 {
+	ModelChange {
+		app_label: String,
+		name_fragment: String,
+	},
+	Migration {
+		app_label: String,
+		migration_name: String,
+	},
+	Endpoint {
+		method: String,
+		path: String,
+		module_path: String,
+		function_name: String,
+	},
+	Setting {
+		path: String,
+	},
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct VerificationViolationV1 {
+	pub code: String,
+	pub class: VerificationClassV1,
+	pub severity: VerificationSeverityV1,
+	pub target: VerificationTargetV1,
+	pub location: Option<String>,
+	pub evidence: String,
+	pub suggested_fix: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct VerificationReportV1 {
+	pub schema_version: u8,
+	pub status: VerificationStatusV1,
+	pub violations: Vec<VerificationViolationV1>,
+}
+
+impl VerificationReportV1 {
+	pub fn from_run(run: &VerificationRun) -> Self {
+		if !run.check_errors.is_empty() {
+			return Self::error();
+		}
+		let mut run = run.clone();
+		run.sort_canonical();
+		let status = if run.findings.is_empty() {
+			VerificationStatusV1::Passed
+		} else {
+			VerificationStatusV1::Failed
+		};
+		Self {
+			schema_version: VERIFICATION_REPORT_SCHEMA_VERSION,
+			status,
+			violations: run.findings.into_iter().map(violation_from).collect(),
+		}
+	}
+
+	pub fn error() -> Self {
+		Self {
+			schema_version: VERIFICATION_REPORT_SCHEMA_VERSION,
+			status: VerificationStatusV1::Error,
+			violations: Vec::new(),
+		}
+	}
+
+	pub fn write_json(&self, output: &mut dyn Write) -> CommandResult<()> {
+		let mut document = serde_json::to_vec_pretty(self)?;
+		document.push(b'\n');
+		output.write_all(&document)?;
+		output.flush()?;
+		Ok(())
+	}
+}
+
+fn violation_from(finding: VerificationFinding) -> VerificationViolationV1 {
+	let (code, class, target, evidence, suggested_fix) = match finding {
+		VerificationFinding::Schema(SchemaFinding::MissingMigration {
+			app_label,
+			name_fragment,
+			description,
+		}) => (
+			"schema.missing_migration".to_owned(),
+			VerificationClassV1::Schema,
+			VerificationTargetV1::ModelChange {
+				app_label,
+				name_fragment,
+			},
+			format!("Model state requires migration operation: {description}"),
+			"Create a migration for the model change".to_owned(),
+		),
+		VerificationFinding::Schema(SchemaFinding::UnappliedMigration { migration }) => (
+			"schema.unapplied_migration".to_owned(),
+			VerificationClassV1::Schema,
+			VerificationTargetV1::Migration {
+				app_label: migration.app_label.clone(),
+				migration_name: migration.name.clone(),
+			},
+			format!(
+				"Migration {}.{} is not applied",
+				migration.app_label, migration.name
+			),
+			"Apply the migration to the selected database".to_owned(),
+		),
+		VerificationFinding::Authorization(value) => (
+			"authorization.missing_declaration".to_owned(),
+			VerificationClassV1::Authorization,
+			VerificationTargetV1::Endpoint {
+				method: value.method,
+				path: value.path,
+				module_path: value.module_path,
+				function_name: value.function_name,
+			},
+			"Endpoint has no explicit authentication declaration".to_owned(),
+			"Declare the endpoint as protected, optional, or public".to_owned(),
+		),
+		VerificationFinding::Settings(value) => {
+			let path = redacted_settings_path(&value.path);
+			let actual = actual_json_kind(value.actual);
+			let (evidence, suggested_fix) = match &value.kind {
+				SettingsViolationKind::MissingRequired => (
+					format!("Required setting {path} is absent"),
+					"Provide the required setting".to_owned(),
+				),
+				SettingsViolationKind::TypeMismatch => (
+					format!(
+						"Setting {path} expects {} but received {actual}",
+						value.expected
+					),
+					"Provide a value matching the declared setting type".to_owned(),
+				),
+				SettingsViolationKind::MapKeyTypeMismatch => (
+					format!(
+						"Map key at {path} expects {} but received {actual}",
+						value.expected
+					),
+					"Use map keys matching the declared key type".to_owned(),
+				),
+				SettingsViolationKind::DuplicateInput => (
+					format!("Setting {path} received multiple accepted input keys"),
+					"Provide exactly one accepted input key for the setting".to_owned(),
+				),
+			};
+			(
+				value.kind.code().to_owned(),
+				VerificationClassV1::Settings,
+				VerificationTargetV1::Setting { path },
+				evidence,
+				suggested_fix,
+			)
+		}
+	};
+	VerificationViolationV1 {
+		code,
+		class,
+		severity: VerificationSeverityV1::Error,
+		target,
+		location: None,
+		evidence,
+		suggested_fix: Some(suggested_fix),
+	}
+}
+
+fn actual_json_kind(kind: Option<JsonKind>) -> &'static str {
+	match kind {
+		None => "missing",
+		Some(JsonKind::Null) => "null",
+		Some(JsonKind::Boolean) => "boolean",
+		Some(JsonKind::Number) => "number",
+		Some(JsonKind::String) => "string",
+		Some(JsonKind::Sequence) => "sequence",
+		Some(JsonKind::Map) => "map",
+	}
+}

--- a/crates/reinhardt-commands/templates/project_pages_template/src/bin/manage.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_pages_template/src/bin/manage.rs.tpl
@@ -33,6 +33,7 @@ mod native {
     };
     #[cfg(feature = "commands-shell")]
     use reinhardt::commands::CargoCheckContext;
+    use reinhardt::commands::command_error_exit_code;
     use std::path::PathBuf;
     use std::process;
 
@@ -71,8 +72,12 @@ mod native {
         .await;
 
         if let Err(e) = result {
+            #[cfg(feature = "commands-shell")]
+            let exit_code = command_error_exit_code(&e);
+            #[cfg(not(feature = "commands-shell"))]
+            let exit_code = command_error_exit_code(e.as_ref());
             eprintln!("Error: {}", e);
-            process::exit(1);
+            process::exit(exit_code);
         }
     }
 }

--- a/crates/reinhardt-commands/templates/project_restful_template/src/bin/manage.rs.tpl
+++ b/crates/reinhardt-commands/templates/project_restful_template/src/bin/manage.rs.tpl
@@ -30,6 +30,7 @@ mod native {
     #[cfg(not(feature = "commands-shell"))]
     use reinhardt::commands::execute_from_command_line_with_pending_settings_and_cargo_context;
     use reinhardt::commands::CargoCheckContext;
+    use reinhardt::commands::command_error_exit_code;
     use std::path::PathBuf;
     use std::process;
 
@@ -68,8 +69,12 @@ mod native {
         .await;
 
         if let Err(e) = result {
+            #[cfg(feature = "commands-shell")]
+            let exit_code = command_error_exit_code(&e);
+            #[cfg(not(feature = "commands-shell"))]
+            let exit_code = command_error_exit_code(e.as_ref());
             eprintln!("Error: {}", e);
-            process::exit(1);
+            process::exit(exit_code);
         }
     }
 }

--- a/crates/reinhardt-commands/tests/cli_tests.rs
+++ b/crates/reinhardt-commands/tests/cli_tests.rs
@@ -8,7 +8,7 @@ use clap::{CommandFactory, Parser};
 #[cfg(feature = "migrations")]
 use reinhardt_commands::{Cli, CommandContext, Commands};
 #[cfg(feature = "contract")]
-use reinhardt_commands::{ContractOutputFormat, ContractSubcommand};
+use reinhardt_commands::{ContractOutputFormat, ContractSubcommand, VerificationOutputFormat};
 use rstest::*;
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -56,10 +56,27 @@ fn contract_export_requires_format() {
 }
 
 #[rstest]
+#[case(&["manage", "verify"], VerificationOutputFormat::Human)]
+#[case(&["manage", "verify", "--format", "human"], VerificationOutputFormat::Human)]
+#[case(&["manage", "verify", "--format", "json"], VerificationOutputFormat::Json)]
 #[cfg(feature = "contract")]
-fn verify_command_parses_without_router_or_database_flags() {
-	let parsed = Cli::try_parse_from(["manage", "verify"]).expect("verify should parse");
-	assert!(matches!(parsed.command, Commands::Verify));
+fn verify_command_parses_output_format(
+	#[case] arguments: &[&str],
+	#[case] expected: VerificationOutputFormat,
+) {
+	let parsed = Cli::try_parse_from(arguments).expect("verify should parse");
+	let Commands::Verify { format } = parsed.command else {
+		panic!("expected verify command");
+	};
+	assert_eq!(format, expected);
+}
+
+#[test]
+#[cfg(feature = "contract")]
+fn verify_command_rejects_unknown_output_format() {
+	let error = Cli::try_parse_from(["manage", "verify", "--format", "xml"])
+		.expect_err("unknown format must fail");
+	assert_eq!(error.kind(), clap::error::ErrorKind::InvalidValue);
 }
 
 #[rstest]

--- a/crates/reinhardt-commands/tests/contract_verify_consumer.rs
+++ b/crates/reinhardt-commands/tests/contract_verify_consumer.rs
@@ -156,6 +156,19 @@ fn json_report(output: &std::process::Output) -> serde_json::Value {
 	serde_json::from_slice(&output.stdout).expect("stdout is one JSON report")
 }
 
+fn json_report_with_shape(output: &std::process::Output, status: &str) -> serde_json::Value {
+	let report = json_report(output);
+	assert_eq!(report["schema_version"], 1);
+	assert_eq!(report["status"], status);
+	assert!(report["violations"].is_array());
+	let object = report.as_object().expect("JSON report is an object");
+	assert_eq!(object.len(), 3);
+	for key in ["schema_version", "status", "violations"] {
+		assert!(object.contains_key(key), "missing {key}");
+	}
+	report
+}
+
 fn assert_redacted(output: &std::process::Output) {
 	for bytes in [&output.stdout, &output.stderr] {
 		let text = String::from_utf8_lossy(bytes);
@@ -210,8 +223,7 @@ finding: settings.type_mismatch at verification.values expected=sequence actual=
 
 	let violating_json = run_verify(consumer_dir.path(), target.path(), &["--format", "json"]);
 	assert_eq!(violating_json.status.code(), Some(1));
-	let violating_report = json_report(&violating_json);
-	assert_eq!(violating_report["status"], "failed");
+	let violating_report = json_report_with_shape(&violating_json, "failed");
 	assert_eq!(
 		violating_report["violations"]
 			.as_array()
@@ -241,7 +253,9 @@ finding: settings.type_mismatch at verification.values expected=sequence actual=
 			assert!(violation.get(field).is_some(), "missing {field}");
 		}
 	}
-	assert!(!String::from_utf8_lossy(&violating_json.stderr).contains("finding:"));
+	let violating_json_stderr = String::from_utf8_lossy(&violating_json.stderr);
+	assert!(!violating_json_stderr.contains("finding:"));
+	assert!(!violating_json_stderr.contains("\"schema_version\""));
 	assert_redacted(&violating_json);
 
 	let violating_json_again =
@@ -271,15 +285,14 @@ finding: authorization.missing_declaration GET /mounted (contract_verify_consume
 	let source_failure_json =
 		run_built_manage(consumer_dir.path(), target.path(), &["--format", "json"]);
 	assert_eq!(source_failure_json.status.code(), Some(2));
-	assert_eq!(json_report(&source_failure_json)["status"], "error");
-	assert_eq!(
-		json_report(&source_failure_json)["violations"],
-		serde_json::json!([])
-	);
+	let source_failure_report = json_report_with_shape(&source_failure_json, "error");
+	assert_eq!(source_failure_report["violations"], serde_json::json!([]));
+	let source_failure_json_stderr = String::from_utf8_lossy(&source_failure_json.stderr);
 	assert!(
-		String::from_utf8_lossy(&source_failure_json.stderr)
+		source_failure_json_stderr
 			.contains("error: contract state resolution unavailable (settings source)")
 	);
+	assert!(!source_failure_json_stderr.contains("\"schema_version\""));
 	assert_redacted(&source_failure_json);
 
 	fs::write(
@@ -311,15 +324,17 @@ finding: settings.type_mismatch at verification.values expected=sequence actual=
 	let aggregate_failure_json =
 		run_built_manage(consumer_dir.path(), target.path(), &["--format", "json"]);
 	assert_eq!(aggregate_failure_json.status.code(), Some(2));
-	assert_eq!(json_report(&aggregate_failure_json)["status"], "error");
+	let aggregate_failure_report = json_report_with_shape(&aggregate_failure_json, "error");
 	assert_eq!(
-		json_report(&aggregate_failure_json)["violations"],
+		aggregate_failure_report["violations"],
 		serde_json::json!([])
 	);
+	let aggregate_failure_json_stderr = String::from_utf8_lossy(&aggregate_failure_json.stderr);
 	assert!(
-		String::from_utf8_lossy(&aggregate_failure_json.stderr)
+		aggregate_failure_json_stderr
 			.contains("error: contract state resolution unavailable (settings section migrations)")
 	);
+	assert!(!aggregate_failure_json_stderr.contains("\"schema_version\""));
 	assert_redacted(&aggregate_failure_json);
 
 	write_fixture(consumer_dir.path(), ConsumerKind::Clean);
@@ -343,15 +358,11 @@ finding: settings.type_mismatch at verification.values expected=sequence actual=
 
 	let broken_json = run_built_manage(consumer_dir.path(), target.path(), &["--format", "json"]);
 	assert_eq!(broken_json.status.code(), Some(2));
-	assert_eq!(json_report(&broken_json)["status"], "error");
-	assert_eq!(
-		json_report(&broken_json)["violations"],
-		serde_json::json!([])
-	);
-	assert!(
-		String::from_utf8_lossy(&broken_json.stderr)
-			.contains("deliberately broken consumer source")
-	);
+	let broken_report = json_report_with_shape(&broken_json, "error");
+	assert_eq!(broken_report["violations"], serde_json::json!([]));
+	let broken_json_stderr = String::from_utf8_lossy(&broken_json.stderr);
+	assert!(broken_json_stderr.contains("deliberately broken consumer source"));
+	assert!(!broken_json_stderr.contains("\"schema_version\""));
 	assert_redacted(&broken_json);
 
 	let unsupported_dir = materialize(ConsumerKind::Clean);
@@ -363,6 +374,9 @@ finding: settings.type_mismatch at verification.values expected=sequence actual=
 	);
 	assert_eq!(unsupported.status.code(), Some(2));
 	assert_eq!(unsupported.stdout, b"");
+	assert!(unsupported.stderr.ends_with(
+		b"Contract verification could not complete: Cargo replay configuration is unsupported\n"
+	));
 	assert_redacted(&unsupported);
 
 	let unsupported_json = run_verify_with_args(
@@ -372,10 +386,8 @@ finding: settings.type_mismatch at verification.values expected=sequence actual=
 		&["--format", "json"],
 	);
 	assert_eq!(unsupported_json.status.code(), Some(2));
-	assert_eq!(json_report(&unsupported_json)["status"], "error");
-	assert_eq!(
-		json_report(&unsupported_json)["violations"],
-		serde_json::json!([])
-	);
+	let unsupported_report = json_report_with_shape(&unsupported_json, "error");
+	assert_eq!(unsupported_report["violations"], serde_json::json!([]));
+	assert!(!String::from_utf8_lossy(&unsupported_json.stderr).contains("\"schema_version\""));
 	assert_redacted(&unsupported_json);
 }

--- a/crates/reinhardt-commands/tests/contract_verify_consumer.rs
+++ b/crates/reinhardt-commands/tests/contract_verify_consumer.rs
@@ -108,11 +108,16 @@ fn active_target() -> String {
 		.to_owned()
 }
 
-fn run_verify(root: &Path, target: &Path) -> std::process::Output {
-	run_verify_with_args(root, target, &[])
+fn run_verify(root: &Path, target: &Path, verify_args: &[&str]) -> std::process::Output {
+	run_verify_with_args(root, target, &[], verify_args)
 }
 
-fn run_verify_with_args(root: &Path, target: &Path, cargo_args: &[&str]) -> std::process::Output {
+fn run_verify_with_args(
+	root: &Path,
+	target: &Path,
+	cargo_args: &[&str],
+	verify_args: &[&str],
+) -> std::process::Output {
 	let mut command = Command::new(env!("CARGO").to_owned());
 	command
 		.current_dir(root)
@@ -127,11 +132,12 @@ fn run_verify_with_args(root: &Path, target: &Path, cargo_args: &[&str]) -> std:
 		.args(["run", "--quiet", "--target-dir"])
 		.arg(target)
 		.args(["--bin", "manage", "--", "verify"])
+		.args(verify_args)
 		.output()
 		.expect("run consumer verify")
 }
 
-fn run_built_manage(root: &Path, target: &Path) -> std::process::Output {
+fn run_built_manage(root: &Path, target: &Path, verify_args: &[&str]) -> std::process::Output {
 	Command::new(target.join("debug/manage"))
 		.current_dir(root)
 		.env("RUSTUP_TOOLCHAIN", active_toolchain())
@@ -140,8 +146,22 @@ fn run_built_manage(root: &Path, target: &Path) -> std::process::Output {
 		.env("REINHARDT_PROFILE", "debug")
 		.env("REINHARDT_CARGO_REPLAY", "exact")
 		.args(["verify"])
+		.args(verify_args)
 		.output()
 		.expect("run built consumer manage")
+}
+
+fn json_report(output: &std::process::Output) -> serde_json::Value {
+	assert_eq!(output.stdout.last(), Some(&b'\n'));
+	serde_json::from_slice(&output.stdout).expect("stdout is one JSON report")
+}
+
+fn assert_redacted(output: &std::process::Output) {
+	for bytes in [&output.stdout, &output.stderr] {
+		let text = String::from_utf8_lossy(bytes);
+		assert!(!text.contains("dynamic-secret"));
+		assert!(!text.contains("secret-sentinel-5986"));
+	}
 }
 
 #[test]
@@ -150,16 +170,28 @@ fn consumer_processes_clean_violating_and_short_circuit_paths() {
 	let target = TempDir::new().expect("create consumer target tempdir");
 	let consumer_dir = materialize(ConsumerKind::Clean);
 
-	let clean = run_verify(consumer_dir.path(), target.path());
+	let clean = run_verify(consumer_dir.path(), target.path(), &[]);
 	assert!(clean.status.success());
 	assert_eq!(clean.stdout, b"Verification passed.\n");
+	assert_redacted(&clean);
+
+	let clean_json = run_verify(consumer_dir.path(), target.path(), &["--format", "json"]);
+	assert_eq!(clean_json.status.code(), Some(0));
+	assert_eq!(
+		json_report(&clean_json),
+		serde_json::json!({
+			"schema_version": 1,
+			"status": "passed",
+			"violations": []
+		})
+	);
+	assert!(!String::from_utf8_lossy(&clean_json.stderr).contains("\"schema_version\""));
+	assert_redacted(&clean_json);
 
 	write_fixture(consumer_dir.path(), ConsumerKind::Violating);
-	let violating = run_verify(consumer_dir.path(), target.path());
+	let violating = run_verify(consumer_dir.path(), target.path(), &[]);
 	let violating_stdout = String::from_utf8_lossy(&violating.stdout);
-	let violating_stderr = String::from_utf8_lossy(&violating.stderr);
-	assert!(!violating.status.success());
-	assert!(violating_stderr.ends_with("Execution error: contract verification found issues\n"));
+	assert_eq!(violating.status.code(), Some(1));
 	assert_eq!(
 		violating_stdout,
 		"finding: schema.missing_migration sample:sample (Create table sample)\n\
@@ -169,12 +201,53 @@ finding: settings.missing_required at verification.secret expected=String actual
 finding: settings.type_mismatch at verification.secrets.* expected=u32 actual=Some(String) ordinal=3\n\
 finding: settings.type_mismatch at verification.values expected=sequence actual=Some(String) ordinal=1\n"
 	);
-	assert!(!violating_stderr.contains("dynamic-secret"));
-	assert!(!violating_stderr.contains("secret-sentinel-5986"));
+	assert_redacted(&violating);
 
-	let violating_again = run_verify(consumer_dir.path(), target.path());
+	let violating_again = run_verify(consumer_dir.path(), target.path(), &[]);
 	assert_eq!(violating.stdout, violating_again.stdout);
 	assert_eq!(violating.stderr, violating_again.stderr);
+	assert_redacted(&violating_again);
+
+	let violating_json = run_verify(consumer_dir.path(), target.path(), &["--format", "json"]);
+	assert_eq!(violating_json.status.code(), Some(1));
+	let violating_report = json_report(&violating_json);
+	assert_eq!(violating_report["status"], "failed");
+	assert_eq!(
+		violating_report["violations"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.map(|item| item["code"].as_str().unwrap())
+			.collect::<Vec<_>>(),
+		vec![
+			"schema.missing_migration",
+			"authorization.missing_declaration",
+			"settings.map_key_type_mismatch",
+			"settings.missing_required",
+			"settings.type_mismatch",
+			"settings.type_mismatch",
+		]
+	);
+	for violation in violating_report["violations"].as_array().unwrap() {
+		for field in [
+			"code",
+			"class",
+			"severity",
+			"target",
+			"location",
+			"evidence",
+			"suggested_fix",
+		] {
+			assert!(violation.get(field).is_some(), "missing {field}");
+		}
+	}
+	assert!(!String::from_utf8_lossy(&violating_json.stderr).contains("finding:"));
+	assert_redacted(&violating_json);
+
+	let violating_json_again =
+		run_verify(consumer_dir.path(), target.path(), &["--format", "json"]);
+	assert_eq!(violating_json.stdout, violating_json_again.stdout);
+	assert_redacted(&violating_json_again);
 
 	let settings_path = consumer_dir.path().join("settings/base.toml");
 	let valid_settings = fs::read_to_string(&settings_path).expect("read valid settings source");
@@ -183,20 +256,31 @@ finding: settings.type_mismatch at verification.values expected=sequence actual=
 		"secret = \"settings-source-secret-sentinel-5986\n",
 	)
 	.expect("write malformed settings source");
-	let source_failure = run_built_manage(consumer_dir.path(), target.path());
+	let source_failure = run_built_manage(consumer_dir.path(), target.path(), &[]);
 	assert!(!source_failure.status.success());
 	assert_eq!(
 		source_failure.stdout,
 		b"error: contract state resolution unavailable (settings source)\n\
 finding: authorization.missing_declaration GET /mounted (contract_verify_consumer/mounted_endpoint)\n"
 	);
-	assert!(
-		source_failure
-			.stderr
-			.ends_with(b"Execution error: contract verification found issues\n")
+	assert!(source_failure.stderr.ends_with(
+		b"Contract verification could not complete: one or more verification checks could not complete\n"
+	));
+	assert_redacted(&source_failure);
+
+	let source_failure_json =
+		run_built_manage(consumer_dir.path(), target.path(), &["--format", "json"]);
+	assert_eq!(source_failure_json.status.code(), Some(2));
+	assert_eq!(json_report(&source_failure_json)["status"], "error");
+	assert_eq!(
+		json_report(&source_failure_json)["violations"],
+		serde_json::json!([])
 	);
-	assert!(!String::from_utf8_lossy(&source_failure.stdout).contains("sentinel"));
-	assert!(!String::from_utf8_lossy(&source_failure.stderr).contains("sentinel"));
+	assert!(
+		String::from_utf8_lossy(&source_failure_json.stderr)
+			.contains("error: contract state resolution unavailable (settings source)")
+	);
+	assert_redacted(&source_failure_json);
 
 	fs::write(
 		&settings_path,
@@ -206,7 +290,7 @@ finding: authorization.missing_declaration GET /mounted (contract_verify_consume
 		),
 	)
 	.expect("write malformed migration section");
-	let aggregate_failure = run_built_manage(consumer_dir.path(), target.path());
+	let aggregate_failure = run_built_manage(consumer_dir.path(), target.path(), &[]);
 	assert!(!aggregate_failure.status.success());
 	assert_eq!(
 		aggregate_failure.stdout,
@@ -219,11 +303,24 @@ finding: settings.type_mismatch at verification.secrets.* expected=u32 actual=So
 finding: settings.type_mismatch at verification.values expected=sequence actual=Some(String) ordinal=2\n"
 			.as_bytes()
 	);
-	assert!(
-		aggregate_failure
-			.stderr
-			.ends_with(b"Execution error: contract verification found issues\n")
+	assert!(aggregate_failure.stderr.ends_with(
+		b"Contract verification could not complete: one or more verification checks could not complete\n"
+	));
+	assert_redacted(&aggregate_failure);
+
+	let aggregate_failure_json =
+		run_built_manage(consumer_dir.path(), target.path(), &["--format", "json"]);
+	assert_eq!(aggregate_failure_json.status.code(), Some(2));
+	assert_eq!(json_report(&aggregate_failure_json)["status"], "error");
+	assert_eq!(
+		json_report(&aggregate_failure_json)["violations"],
+		serde_json::json!([])
 	);
+	assert!(
+		String::from_utf8_lossy(&aggregate_failure_json.stderr)
+			.contains("error: contract state resolution unavailable (settings section migrations)")
+	);
+	assert_redacted(&aggregate_failure_json);
 
 	write_fixture(consumer_dir.path(), ConsumerKind::Clean);
 	let source = consumer_dir.path().join("src/lib.rs");
@@ -233,7 +330,7 @@ finding: settings.type_mismatch at verification.values expected=sequence actual=
 		format!("{clean_source}\ncompile_error!(\"deliberately broken consumer source\");\n"),
 	)
 	.expect("break clean consumer source");
-	let broken = run_built_manage(consumer_dir.path(), target.path());
+	let broken = run_built_manage(consumer_dir.path(), target.path(), &[]);
 	let broken_stdout = String::from_utf8_lossy(&broken.stdout);
 	let broken_stderr = String::from_utf8_lossy(&broken.stderr);
 	assert!(!broken.status.success());
@@ -242,18 +339,43 @@ finding: settings.type_mismatch at verification.values expected=sequence actual=
 	assert!(broken_stderr.contains("cargo check failed; contract verification was not run"));
 	assert!(!broken_stderr.contains("contract state resolution"));
 	assert!(!broken_stderr.contains("finding:"));
+	assert_redacted(&broken);
+
+	let broken_json = run_built_manage(consumer_dir.path(), target.path(), &["--format", "json"]);
+	assert_eq!(broken_json.status.code(), Some(2));
+	assert_eq!(json_report(&broken_json)["status"], "error");
+	assert_eq!(
+		json_report(&broken_json)["violations"],
+		serde_json::json!([])
+	);
+	assert!(
+		String::from_utf8_lossy(&broken_json.stderr)
+			.contains("deliberately broken consumer source")
+	);
+	assert_redacted(&broken_json);
 
 	let unsupported_dir = materialize(ConsumerKind::Clean);
 	let unsupported = run_verify_with_args(
 		unsupported_dir.path(),
 		target.path(),
 		&["--config", "build.jobs=2", "--offline"],
+		&[],
 	);
-	assert!(!unsupported.status.success());
+	assert_eq!(unsupported.status.code(), Some(2));
 	assert_eq!(unsupported.stdout, b"");
-	assert!(
-		unsupported
-			.stderr
-			.ends_with(b"Execution error: Cargo replay configuration is unsupported\n")
+	assert_redacted(&unsupported);
+
+	let unsupported_json = run_verify_with_args(
+		unsupported_dir.path(),
+		target.path(),
+		&["--config", "build.jobs=2", "--offline"],
+		&["--format", "json"],
 	);
+	assert_eq!(unsupported_json.status.code(), Some(2));
+	assert_eq!(json_report(&unsupported_json)["status"], "error");
+	assert_eq!(
+		json_report(&unsupported_json)["violations"],
+		serde_json::json!([])
+	);
+	assert_redacted(&unsupported_json);
 }

--- a/crates/reinhardt-commands/tests/embedded_startproject.rs
+++ b/crates/reinhardt-commands/tests/embedded_startproject.rs
@@ -279,6 +279,8 @@ fn assert_generated_shell_wiring(root: &Path, crate_name: &str) {
 		"shell runtime hook must execute before native::main:\n{manage}"
 	);
 	for required in [
+		"command_error_exit_code",
+		"process::exit(exit_code)",
 		"#[cfg(feature = \"commands-shell\")]",
 		"execute_from_command_line_with_pending_settings_and_cargo_context_and_shell(",
 		"get_shell_config()",

--- a/crates/reinhardt-commands/tests/error_tests.rs
+++ b/crates/reinhardt-commands/tests/error_tests.rs
@@ -2,9 +2,20 @@
 //!
 //! Tests for error type variants, conversions, and Display implementations.
 
-use reinhardt_commands::CommandError;
+use reinhardt_commands::{CommandError, command_error_exit_code};
 use rstest::rstest;
 use std::io;
+
+#[rstest]
+#[case(CommandError::VerificationFailed, 1)]
+#[case(
+	CommandError::VerificationExecution("Cargo replay failed".to_owned()),
+	2
+)]
+#[case(CommandError::ExecutionError("other command".to_owned()), 1)]
+fn verification_exit_codes_are_stable(#[case] error: CommandError, #[case] expected: i32) {
+	assert_eq!(command_error_exit_code(&error), expected);
+}
 
 // =============================================================================
 // Happy Path Tests - Error Creation

--- a/crates/reinhardt-commands/tests/fixtures/contract_verify_project/src/bin/manage.rs.tpl
+++ b/crates/reinhardt-commands/tests/fixtures/contract_verify_project/src/bin/manage.rs.tpl
@@ -2,6 +2,7 @@ use contract_verify_consumer::ProjectSettings;
 use reinhardt::commands::{
 	CargoCheckContext, execute_from_command_line_with_pending_settings_and_cargo_context,
 };
+use reinhardt::commands::command_error_exit_code;
 use reinhardt::conf::settings::builder::SettingsBuilder;
 
 fn settings() -> Result<
@@ -43,7 +44,8 @@ async fn main() {
 	)
 	.await
 	{
+		let exit_code = command_error_exit_code(error.as_ref());
 		eprintln!("{error}");
-		std::process::exit(1);
+		std::process::exit(exit_code);
 	}
 }

--- a/crates/reinhardt-commands/tests/verify_tests.rs
+++ b/crates/reinhardt-commands/tests/verify_tests.rs
@@ -5,12 +5,14 @@
 use reinhardt_commands::{
 	CargoCheckContext, CargoConfigReplay, CargoProfile, CargoReplayUnsupported,
 	ContractResolutionErrorKind, SafeContractTarget, VerificationCheckError, VerificationFinding,
-	VerificationRun, plan_cargo_check, render_verification,
+	VerificationReportV1, VerificationRun, VerificationSeverityV1, VerificationStatusV1,
+	VerificationTargetV1, plan_cargo_check, render_verification,
 };
 use reinhardt_conf::settings::schema::{
 	JsonKind, SettingsPathBuf, SettingsPathSegment, SettingsViolation, SettingsViolationKind,
 };
 use reinhardt_core::endpoint::EndpointSecurityViolation;
+use reinhardt_db::migrations::{MigrationKey, SchemaFinding};
 use std::path::PathBuf;
 
 fn context() -> CargoCheckContext {
@@ -209,5 +211,156 @@ fn resolution_rendering_keeps_safe_targets_distinct() {
 		output,
 		"error: contract state resolution unavailable (route topology)\n\
 error: contract state resolution unavailable (settings section migrations)\n"
+	);
+}
+
+#[test]
+fn report_serializes_canonical_version_one_json() {
+	let run = VerificationRun {
+		findings: vec![
+			VerificationFinding::Settings(SettingsViolation {
+				kind: SettingsViolationKind::TypeMismatch,
+				path: SettingsPathBuf::from_segments([
+					SettingsPathSegment::Key("database"),
+					SettingsPathSegment::AnyKey,
+				]),
+				expected: "string",
+				actual: Some(JsonKind::Number),
+				ordinal: 1,
+			}),
+			VerificationFinding::Authorization(EndpointSecurityViolation {
+				method: "GET".to_owned(),
+				path: "/health".to_owned(),
+				module_path: "consumer::routes".to_owned(),
+				function_name: "health".to_owned(),
+			}),
+		],
+		check_errors: Vec::new(),
+	};
+	let report = VerificationReportV1::from_run(&run);
+	let mut output = Vec::new();
+	report.write_json(&mut output).expect("serialize report");
+	assert_eq!(report.schema_version, 1);
+	assert_eq!(report.status, VerificationStatusV1::Failed);
+	assert_eq!(output.last(), Some(&b'\n'));
+	assert_eq!(
+		serde_json::from_slice::<serde_json::Value>(&output).expect("valid JSON"),
+		serde_json::json!({
+			"schema_version": 1,
+			"status": "failed",
+			"violations": [
+				{"code": "authorization.missing_declaration", "class": "authorization", "severity": "error", "target": {"kind": "endpoint", "method": "GET", "path": "/health", "module_path": "consumer::routes", "function_name": "health"}, "location": null, "evidence": "Endpoint has no explicit authentication declaration", "suggested_fix": "Declare the endpoint as protected, optional, or public"},
+				{"code": "settings.type_mismatch", "class": "settings", "severity": "error", "target": {"kind": "setting", "path": "database.*"}, "location": null, "evidence": "Setting database.* expects string but received number", "suggested_fix": "Provide a value matching the declared setting type"}
+			]
+		})
+	);
+}
+
+#[test]
+fn report_marks_check_errors_as_error_and_discards_partial_findings() {
+	let run = VerificationRun {
+		findings: vec![VerificationFinding::Schema(
+			SchemaFinding::UnappliedMigration {
+				migration: MigrationKey::new("blog", "0002_publish"),
+			},
+		)],
+		check_errors: vec![VerificationCheckError::Resolution {
+			kind: ContractResolutionErrorKind::RouteTopology,
+			safe_target: None,
+		}],
+	};
+	let report = VerificationReportV1::from_run(&run);
+	assert_eq!(report.status, VerificationStatusV1::Error);
+	assert_eq!(report.violations, Vec::new());
+}
+
+#[test]
+fn report_maps_all_findings_in_canonical_order_and_redacts_targets() {
+	let path = SettingsPathBuf::from_segments([
+		SettingsPathSegment::Key("secrets"),
+		SettingsPathSegment::DynamicKey("dynamic-secret-5987".to_owned()),
+	]);
+	let settings = [
+		(SettingsViolationKind::DuplicateInput, "single input", None),
+		(
+			SettingsViolationKind::MapKeyTypeMismatch,
+			"u16",
+			Some(JsonKind::String),
+		),
+		(SettingsViolationKind::MissingRequired, "String", None),
+		(
+			SettingsViolationKind::TypeMismatch,
+			"sequence",
+			Some(JsonKind::String),
+		),
+	];
+	let run = VerificationRun {
+		findings: vec![
+			VerificationFinding::Settings(SettingsViolation {
+				kind: settings[3].0.clone(),
+				path: path.clone(),
+				expected: settings[3].1,
+				actual: settings[3].2,
+				ordinal: 3,
+			}),
+			VerificationFinding::Schema(SchemaFinding::UnappliedMigration {
+				migration: MigrationKey::new("blog", "0002_publish"),
+			}),
+			VerificationFinding::Settings(SettingsViolation {
+				kind: settings[0].0.clone(),
+				path: path.clone(),
+				expected: settings[0].1,
+				actual: settings[0].2,
+				ordinal: 0,
+			}),
+			VerificationFinding::Schema(SchemaFinding::MissingMigration {
+				app_label: "blog".to_owned(),
+				name_fragment: "entry".to_owned(),
+				description: "Create entry".to_owned(),
+			}),
+			VerificationFinding::Settings(SettingsViolation {
+				kind: settings[2].0.clone(),
+				path: path.clone(),
+				expected: settings[2].1,
+				actual: settings[2].2,
+				ordinal: 2,
+			}),
+			VerificationFinding::Settings(SettingsViolation {
+				kind: settings[1].0.clone(),
+				path,
+				expected: settings[1].1,
+				actual: settings[1].2,
+				ordinal: 1,
+			}),
+		],
+		check_errors: Vec::new(),
+	};
+	let report = VerificationReportV1::from_run(&run);
+	assert_eq!(
+		report
+			.violations
+			.iter()
+			.map(|violation| violation.code.as_str())
+			.collect::<Vec<_>>(),
+		vec![
+			"schema.missing_migration",
+			"schema.unapplied_migration",
+			"settings.duplicate_input",
+			"settings.map_key_type_mismatch",
+			"settings.missing_required",
+			"settings.type_mismatch",
+		]
+	);
+	for violation in &report.violations {
+		if let VerificationTargetV1::Setting { path } = &violation.target {
+			assert_eq!(path, "secrets.*");
+			assert!(!path.contains("dynamic-secret-5987"));
+		}
+	}
+	assert!(
+		report
+			.violations
+			.iter()
+			.all(|violation| violation.severity == VerificationSeverityV1::Error)
 	);
 }

--- a/crates/reinhardt-commands/tests/verify_tests.rs
+++ b/crates/reinhardt-commands/tests/verify_tests.rs
@@ -218,12 +218,6 @@ error: contract state resolution unavailable (settings section migrations)\n"
 fn report_serializes_canonical_version_one_json() {
 	let run = VerificationRun {
 		findings: vec![
-			VerificationFinding::Authorization(EndpointSecurityViolation {
-				method: "GET".to_owned(),
-				path: "/health".to_owned(),
-				module_path: "consumer::routes".to_owned(),
-				function_name: "health".to_owned(),
-			}),
 			VerificationFinding::Settings(SettingsViolation {
 				kind: SettingsViolationKind::TypeMismatch,
 				path: SettingsPathBuf::from_segments([
@@ -233,6 +227,12 @@ fn report_serializes_canonical_version_one_json() {
 				expected: "string",
 				actual: Some(JsonKind::Number),
 				ordinal: 1,
+			}),
+			VerificationFinding::Authorization(EndpointSecurityViolation {
+				method: "GET".to_owned(),
+				path: "/health".to_owned(),
+				module_path: "consumer::routes".to_owned(),
+				function_name: "health".to_owned(),
 			}),
 		],
 		check_errors: Vec::new(),

--- a/crates/reinhardt-commands/tests/verify_tests.rs
+++ b/crates/reinhardt-commands/tests/verify_tests.rs
@@ -3,10 +3,11 @@
 #![cfg(feature = "contract")]
 
 use reinhardt_commands::{
-	CargoCheckContext, CargoConfigReplay, CargoProfile, CargoReplayUnsupported,
+	CargoCheckContext, CargoConfigReplay, CargoProfile, CargoReplayUnsupported, CommandError,
 	ContractResolutionErrorKind, SafeContractTarget, VerificationCheckError, VerificationFinding,
-	VerificationReportV1, VerificationRun, VerificationSeverityV1, VerificationStatusV1,
-	VerificationTargetV1, plan_cargo_check, render_verification,
+	VerificationOutputFormat, VerificationReportV1, VerificationRun, VerificationSeverityV1,
+	VerificationStatusV1, VerificationTargetV1, plan_cargo_check, render_verification,
+	render_verification_output,
 };
 use reinhardt_conf::settings::schema::{
 	JsonKind, SettingsPathBuf, SettingsPathSegment, SettingsViolation, SettingsViolationKind,
@@ -144,6 +145,85 @@ fn manifest_directory_is_rejected_before_process_spawn() {
 	assert_eq!(
 		error.to_string(),
 		"Execution error: Cargo replay manifest path must name Cargo.toml"
+	);
+}
+
+#[test]
+fn verification_error_variants_are_distinct() {
+	let failed = CommandError::VerificationFailed;
+	let error = CommandError::VerificationExecution("Cargo replay failed".to_owned());
+	assert_eq!(failed.to_string(), "Contract verification found violations");
+	assert_eq!(
+		error.to_string(),
+		"Contract verification could not complete: Cargo replay failed"
+	);
+}
+
+#[test]
+fn json_renderer_writes_findings_to_stdout_without_stderr() {
+	let run = VerificationRun {
+		findings: vec![VerificationFinding::Authorization(
+			EndpointSecurityViolation {
+				method: "GET".to_owned(),
+				path: "/health".to_owned(),
+				module_path: "consumer::routes".to_owned(),
+				function_name: "health".to_owned(),
+			},
+		)],
+		check_errors: Vec::new(),
+	};
+	let mut stdout = Vec::new();
+	let mut stderr = Vec::new();
+	let result = render_verification_output(
+		&run,
+		VerificationOutputFormat::Json,
+		&mut stdout,
+		&mut stderr,
+	);
+
+	assert!(matches!(result, Err(CommandError::VerificationFailed)));
+	assert_eq!(
+		serde_json::from_slice::<serde_json::Value>(&stdout).expect("JSON report")["status"],
+		"failed"
+	);
+	assert_eq!(stderr, b"");
+}
+
+#[test]
+fn json_renderer_writes_check_errors_to_stderr_and_discards_findings() {
+	let run = VerificationRun {
+		findings: vec![VerificationFinding::Authorization(
+			EndpointSecurityViolation {
+				method: "GET".to_owned(),
+				path: "/health".to_owned(),
+				module_path: "consumer::routes".to_owned(),
+				function_name: "health".to_owned(),
+			},
+		)],
+		check_errors: vec![VerificationCheckError::Resolution {
+			kind: ContractResolutionErrorKind::RouteTopology,
+			safe_target: None,
+		}],
+	};
+	let mut stdout = Vec::new();
+	let mut stderr = Vec::new();
+	let result = render_verification_output(
+		&run,
+		VerificationOutputFormat::Json,
+		&mut stdout,
+		&mut stderr,
+	);
+
+	assert!(matches!(
+		result,
+		Err(CommandError::VerificationExecution(_))
+	));
+	let report = serde_json::from_slice::<serde_json::Value>(&stdout).expect("JSON report");
+	assert_eq!(report["status"], "error");
+	assert_eq!(report["violations"], serde_json::json!([]));
+	assert_eq!(
+		stderr,
+		b"error: contract state resolution unavailable (route topology)\n"
 	);
 }
 

--- a/crates/reinhardt-commands/tests/verify_tests.rs
+++ b/crates/reinhardt-commands/tests/verify_tests.rs
@@ -218,6 +218,12 @@ error: contract state resolution unavailable (settings section migrations)\n"
 fn report_serializes_canonical_version_one_json() {
 	let run = VerificationRun {
 		findings: vec![
+			VerificationFinding::Authorization(EndpointSecurityViolation {
+				method: "GET".to_owned(),
+				path: "/health".to_owned(),
+				module_path: "consumer::routes".to_owned(),
+				function_name: "health".to_owned(),
+			}),
 			VerificationFinding::Settings(SettingsViolation {
 				kind: SettingsViolationKind::TypeMismatch,
 				path: SettingsPathBuf::from_segments([
@@ -227,12 +233,6 @@ fn report_serializes_canonical_version_one_json() {
 				expected: "string",
 				actual: Some(JsonKind::Number),
 				ordinal: 1,
-			}),
-			VerificationFinding::Authorization(EndpointSecurityViolation {
-				method: "GET".to_owned(),
-				path: "/health".to_owned(),
-				module_path: "consumer::routes".to_owned(),
-				function_name: "health".to_owned(),
 			}),
 		],
 		check_errors: Vec::new(),
@@ -296,6 +296,12 @@ fn report_maps_all_findings_in_canonical_order_and_redacts_targets() {
 	];
 	let run = VerificationRun {
 		findings: vec![
+			VerificationFinding::Authorization(EndpointSecurityViolation {
+				method: "GET".to_owned(),
+				path: "/health".to_owned(),
+				module_path: "consumer::routes".to_owned(),
+				function_name: "health".to_owned(),
+			}),
 			VerificationFinding::Settings(SettingsViolation {
 				kind: settings[3].0.clone(),
 				path: path.clone(),
@@ -345,6 +351,7 @@ fn report_maps_all_findings_in_canonical_order_and_redacts_targets() {
 		vec![
 			"schema.missing_migration",
 			"schema.unapplied_migration",
+			"authorization.missing_declaration",
 			"settings.duplicate_input",
 			"settings.map_key_type_mismatch",
 			"settings.missing_required",

--- a/examples/examples-tutorial-basis/src/bin/manage.rs
+++ b/examples/examples-tutorial-basis/src/bin/manage.rs
@@ -22,6 +22,7 @@ mod native {
 	#[cfg(feature = "commands-shell")]
 	use examples_tutorial_basis::config::shell::get_shell_config;
 	use reinhardt::commands::CargoCheckContext;
+	use reinhardt::commands::command_error_exit_code;
 	#[cfg(not(feature = "commands-shell"))]
 	use reinhardt::commands::execute_from_command_line_with_pending_settings_and_cargo_context;
 	#[cfg(feature = "commands-shell")]
@@ -66,8 +67,12 @@ mod native {
 		.await;
 
 		if let Err(e) = result {
+			#[cfg(feature = "commands-shell")]
+			let exit_code = command_error_exit_code(&e);
+			#[cfg(not(feature = "commands-shell"))]
+			let exit_code = command_error_exit_code(e.as_ref());
 			eprintln!("Error: {e}");
-			process::exit(1);
+			process::exit(exit_code);
 		}
 	}
 }

--- a/examples/examples-tutorial-rest/src/bin/manage.rs
+++ b/examples/examples-tutorial-rest/src/bin/manage.rs
@@ -10,6 +10,7 @@ mod native {
 	#[cfg(feature = "commands-shell")]
 	use examples_tutorial_rest::config::shell::get_shell_config;
 	use reinhardt::commands::CargoCheckContext;
+	use reinhardt::commands::command_error_exit_code;
 	#[cfg(not(feature = "commands-shell"))]
 	use reinhardt::commands::execute_from_command_line_with_pending_settings_and_cargo_context;
 	#[cfg(feature = "commands-shell")]
@@ -47,8 +48,12 @@ mod native {
 		.await;
 
 		if let Err(e) = result {
+			#[cfg(feature = "commands-shell")]
+			let exit_code = command_error_exit_code(&e);
+			#[cfg(not(feature = "commands-shell"))]
+			let exit_code = command_error_exit_code(e.as_ref());
 			eprintln!("Error: {e}");
-			process::exit(1);
+			process::exit(exit_code);
 		}
 	}
 }

--- a/website/content/docs/application-contract.md
+++ b/website/content/docs/application-contract.md
@@ -52,39 +52,73 @@ stderr and every migration has `applied: null`. An explicit `--database` or
 `--database-url` makes recorder failure fatal. Diagnostics redact credentials
 and sensitive-looking aliases; secrets never appear in the JSON document.
 
-## Human verification
+## Verification protocol
 
-The `contract` feature also provides a human-readable verification command:
+The `contract` feature provides human-readable verification by default and a
+version 1 JSON report for automation:
 
 ```text
 cargo run --bin manage -- verify
+cargo run --bin manage -- verify --format json
 ```
 
-Verification first replays the consumer Cargo check captured by the generated
-launcher. A spawn failure or non-zero Cargo status stops before contract
-collection. After that phase, schema, authorization, and settings validators
-run independently; a settings-source failure does not suppress authorization
-findings. Launcher replay also fails closed when Cargo-exposed feature names are
-ambiguous after normalization. Defaulted migration fragments use their composed
-root defaults during schema checks. The validators report stable finding codes:
+The clean report is:
 
-- `schema.missing_migration` and `schema.unapplied_migration`;
-- `authorization.missing_declaration`;
-- `settings.missing_required`, `settings.type_mismatch`,
-  `settings.map_key_type_mismatch`, and `settings.duplicate_input`.
+```json
+{
+  "schema_version": 1,
+  "status": "passed",
+  "violations": []
+}
+```
 
-Applied-migration coverage is optional; when no applied snapshot is available,
-only that coverage check is omitted. Authorization checks materialize only
-synchronous in-memory route registrations and reject asynchronous factories
-and invalid route patterns without polling them; they do not install a router, initialize dependency
-injection, or open a database. Settings checks use the same
-typed-coercion mode as `SettingsBuilder`. Their findings retain canonical paths,
-expected shapes, and JSON kinds, but never values, concrete dynamic map keys, or
-parser/deserializer messages.
+| Result | Exit status |
+| --- | ---: |
+| `passed` | 0 |
+| `failed` | 1 |
+| `error` | 2 |
 
-Verification is human-readable only and does not change the versioned JSON
-export. The supported freshness path is `cargo run`; invoking an already-built
-`manage` executable directly does not detect a stale binary.
+JSON stdout contains only one report document. Cargo and operational
+diagnostics use stderr. All current violations have severity `error`; settings
+values and concrete dynamic keys are absent. `location` is currently `null`
+because the verifier does not retain source positions. Human-readable output
+remains the default.
+
+Each violation has `code`, `class`, `severity`, `target`, `location`,
+`evidence`, and `suggested_fix`. The seven stable codes are
+`schema.missing_migration`, `schema.unapplied_migration`,
+`authorization.missing_declaration`, `settings.missing_required`,
+`settings.type_mismatch`, `settings.map_key_type_mismatch`, and
+`settings.duplicate_input`. Canonical ordering is inherited from
+`VerificationRun`.
+
+Targets have these shapes:
+
+```text
+model_change: app_label, name_fragment
+migration: app_label, migration_name
+endpoint: method, path, module_path, function_name
+setting: canonical wildcarded path
+```
+
+Use this loop to let an agent repair contract violations:
+
+```bash
+cargo run --bin manage -- verify --format json > /tmp/reinhardt-verify.json
+status=$?
+case "$status" in
+  0) echo "contract verified" ;;
+  1) jq -r '.violations[] | [.code, .target.kind, .suggested_fix] | @tsv' /tmp/reinhardt-verify.json ;;
+  2) echo "verification could not complete" >&2 ;;
+esac
+rm -f /tmp/reinhardt-verify.json
+```
+
+An agent repairs source only for exit 1, reruns the command, and stops at
+`passed`. Exit 2 requires repairing the execution environment or configuration
+before findings can be trusted. The supported freshness path is `cargo run`;
+invoking an already-built `manage` executable directly does not detect a stale
+binary.
 
 ## HTTPS derivation and versioning
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Add a versioned machine-readable report to `manage verify --format json`.
- Aggregate all supported verification findings with stable codes, targets, evidence, severity, and suggested fixes.
- Keep human-readable output as the default while separating JSON stdout from operational stderr.
- Preserve typed verification outcomes and exit semantics for clean, violated, and execution-error results.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Human-oriented verification output is difficult for unattended repair and experiment loops to consume reliably. This adds an explicit JSON protocol with deterministic ordering and structural secret redaction while preserving the existing human-oriented command behavior.

Fixes #5987

Related to: #5985, #5986

## How Was This Tested?

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/develop/0.4.0..HEAD`
- [x] `cargo check -p reinhardt-commands --features contract`
- [x] `cargo test -p reinhardt-commands --features contract --test cli_tests verify_command_ -- --nocapture` (4 passed)
- [x] `cargo test -p reinhardt-commands --features contract --test verify_tests -- --nocapture` (13 passed)
- [x] `cargo test -p reinhardt-admin --all-features --lib core::router::tests::test_admin_routes_registers_all_server_functions` (1 passed after base merge)
- [x] Consumer subprocess contract test (1 passed; 1081.58s)
- [ ] `cargo test --workspace --all-features` (the run reached `reinhardt-commands`: 571 passed, 11 failed, 3 ignored, then stopped; failures are unrelated existing tests involving temporary working-directory/process-environment assumptions)
- [ ] `cargo make clippy-check` (not run in this worktree)

## Performance Impact

Not applicable. JSON rendering is opt-in and does not change the default human-readable path.

## Breaking Changes

Not applicable.

## Related Issues

- #5985
- #5986

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement
- [ ] `bug` - Bug fix
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor or enhancement

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (the unrelated full-suite failures are recorded above)
- [ ] I have tested with all affected database backends (not applicable to this CLI/reporting change)
- [x] I have formatted the code with `cargo fmt --all`
- [ ] I have checked the code with `cargo make clippy-check`

## Additional Context:

The feature branch was merged with the current `develop/0.4.0` base before publication. The issue-focused tests pass. The full workspace run is currently affected by unrelated tests that fail when parallel cases remove or rewrite temporary working directories; those failures are not in the changed files.

🤖 Generated with [OpenAI Codex](https://openai.com/codex)