### PR TITLE
ci: warn on invalid breaking change targets

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,17 +33,13 @@ jobs:
             migration-approved,rc-addition,agent-suspect,good first issue
 
           # PR settings
-          days-before-pr-stale: 30
-          days-before-pr-close: 14
+          days-before-pr-stale: 14
+          days-before-pr-close: -1
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
-            If this PR is still in progress, please push new commits or leave a comment.
-          close-pr-message: >
-            This pull request has been automatically closed due to inactivity.
-            If you would like to continue working on this, please reopen it.
+            recent activity for 14 days. This is a warning only and it will not be closed
+            automatically. If this PR is still in progress, please push new commits or leave a comment.
           stale-pr-label: stale
-          close-pr-label: auto-closed
           exempt-pr-labels: >
             enhancement,help wanted,security,critical,high,
             release,migration-approved,rc-addition

--- a/.github/workflows/warn-invalid-breaking-change.yml
+++ b/.github/workflows/warn-invalid-breaking-change.yml
@@ -57,8 +57,6 @@ jobs:
               `- Detected by: ${labels.includes('breaking-change') ? '`breaking-change` label' : 'breaking Conventional Commit title'}`,
               '',
               'Breaking changes should target the appropriate versioned `develop/X.Y.Z` branch. Please retarget this PR or confirm the exception with the maintainers.',
-              '',
-              '🤖 Generated with [Codex](https://openai.com/codex)',
             ].join('\n');
 
             await github.rest.issues.createComment({

--- a/.github/workflows/warn-invalid-breaking-change.yml
+++ b/.github/workflows/warn-invalid-breaking-change.yml
@@ -1,0 +1,71 @@
+name: Warn Invalid Breaking Change Target
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened, labeled]
+
+# Use the PR number because pull_request_target runs on the base branch ref.
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+
+jobs:
+  warn:
+    name: Warn Invalid Breaking Change Target
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check breaking-change target
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const sourceBranch = pr.head.ref;
+            const labels = pr.labels.map(label => label.name);
+            const breakingTitle = /^(?:[a-z][a-z0-9-]*!(?:\([^)]*\))?|[a-z][a-z0-9-]*\([^)]*\)!)\s*:/i.test(pr.title);
+            const breakingChange = labels.includes('breaking-change') || breakingTitle;
+            const validDevelopBranch = /^develop\/\d+\.\d+\.\d+$/.test(sourceBranch);
+
+            if (!breakingChange || validDevelopBranch) {
+              core.info('No invalid breaking-change target detected.');
+              return;
+            }
+
+            const marker = '<!-- invalid-breaking-change-target-warning -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            if (comments.some(comment => comment.body?.includes(marker))) {
+              core.info('Warning comment already exists.');
+              return;
+            }
+
+            const body = [
+              marker,
+              '⚠️ **Breaking change targeting `main`**',
+              '',
+              'This PR appears to contain a breaking change, but its source branch is not a versioned `develop/X.Y.Z` branch.',
+              '',
+              `- Source branch: \`${sourceBranch}\``,
+              `- Detected by: ${labels.includes('breaking-change') ? '`breaking-change` label' : 'breaking Conventional Commit title'}`,
+              '',
+              'Breaking changes should target the appropriate versioned `develop/X.Y.Z` branch. Please retarget this PR or confirm the exception with the maintainers.',
+              '',
+              '🤖 Generated with [Codex](https://openai.com/codex)',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+
+            core.warning(`Posted invalid breaking-change target warning for PR #${pr.number}.`);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,7 @@ Still Requires Explicit User Authorization (no autonomy):
 Unchanged Quality Guardrails (apply equally to autonomous operations):
 
 - PR title and body MUST follow Conventional Commits and `.github/PULL_REQUEST_TEMPLATE.md`
+- Breaking-change PR titles MUST use the `type!(scope): description` format, such as `fix!(auth): ...`, and MUST include the `breaking-change` label. The scope-less `type!: description` form is also valid. Existing `type(scope)!: description` titles remain accepted for compatibility.
 - Issue body MUST follow `.github/ISSUE_TEMPLATE/*.yml`
 - Branch naming, commit message format, Codex attribution footer, English-only policy, and all other rules in this document remain in force
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,7 @@ Still Requires Explicit User Authorization (no autonomy):
 Unchanged Quality Guardrails (apply equally to autonomous operations):
 
 - PR title and body MUST follow Conventional Commits and `.github/PULL_REQUEST_TEMPLATE.md`
+- Breaking-change PR titles MUST use the `type!(scope): description` format, such as `fix!(auth): ...`, and MUST include the `breaking-change` label. The scope-less `type!: description` form is also valid. Existing `type(scope)!: description` titles remain accepted for compatibility.
 - Issue body MUST follow `.github/ISSUE_TEMPLATE/*.yml`
 - Branch naming, commit message format, Claude Code attribution footer, English-only policy, and all other rules in this document remain in force
 


### PR DESCRIPTION
## Summary

This PR adds automated warnings for breaking-change pull requests targeting `main` from non-versioned source branches and changes inactive PR handling to a 14-day warning without automatic closure.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Breaking changes are expected to enter through versioned `develop/X.Y.Z` branches during the RC workflow. The new workflow detects `breaking-change` labels and Conventional Commit title forms including `fix!:`, `fix!(scope):`, and `fix(scope)!:` and posts one deduplicated warning comment for invalid `main` targets.

## How Was This Tested?

- `actionlint .github/workflows/warn-invalid-breaking-change.yml .github/workflows/stale.yml`
- Node.js predicate checks for six title formats and three branch formats
- `git diff --check`
- `diff CLAUDE.md AGENTS.md`

## Performance Impact

No runtime application impact.

## Breaking Changes

None.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing validation checks pass locally
- [x] I have formatted the changed files

## Related Issues

None.

## Labels to Apply

### Type Label
- [x] `ci-cd` - CI/CD workflow changes

### Additional Labels
- [ ] `breaking-change`

🤖 Generated with [Codex](https://openai.com/codex)