### PR TITLE
fix(ci): allow zerovec-derive dependency duplicates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -149,7 +149,7 @@ skip = [
   { crate = "yoke@0.7.5", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "yoke-derive@0.7.5", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "zerovec@0.10.4", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
-  { crate = "zerovec-derive@0.10.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
+  { crate = "zerovec-derive:>=0.10,<0.11", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "block-buffer@0.10.4", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "bson@2.15.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "chrono-tz-build@0.2.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },


### PR DESCRIPTION
## Summary

This PR addresses:

- Refresh the cargo-deny skip for `zerovec-derive` to cover the current 0.10 minor line.
- Keep the 0.11 line visible to cargo-deny while allowing the intentional 0.10/0.11 duplicate.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change or feature
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The Security Audit job resolves `zerovec-derive` 0.10.4 and 0.11.5. The existing exact `0.10.3` skip no longer matches the lockfile, so cargo-deny rejects the intentional transitive duplicate. A minor-line PackageSpec keeps the policy resilient to compatible 0.10 patch updates.

Fixes #

Related to: #6075, #6076

## How Was This Tested?

- [x] `cargo deny --workspace --all-features check all`
- [x] `git diff --check`
- [x] Confirmed `advisories ok, bans ok, licenses ok, sources ok`

## Performance Impact

Not applicable; this changes dependency-policy configuration only.

## Breaking Changes

Not applicable.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (not applicable for a dependency-policy-only change)
- [x] My changes generate no new cargo-deny errors
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable; cargo-deny validation covers this policy change)
- [ ] New and existing unit tests pass locally with my changes (not applicable; no Rust code changed)
- [ ] I have tested with all affected database backends (not applicable)
- [ ] I have formatted the code with `cargo make fmt-fix` (not applicable; no Rust formatting changes)
- [ ] I have checked the code with `cargo make clippy-check` (not applicable; no Rust code changed)

## Related Issues

- #6075
- #6076

## Labels to Apply

### Type Label

- [x] `bug` - Bug fix

### Additional Labels

- [ ] `breaking-change`

### Scope Label

- [x] `ci-cd` - CI/CD workflow and dependency-policy checks

### Priority Label

- [ ] `critical`
- [ ] `high`
- [ ] `medium`
- [ ] `low`

---

**Additional Context:**

This branch is based on `develop/0.4.0`. The corresponding policy repair for `main` is published separately so each target branch can be reviewed and merged independently.

🤖 Generated with [Codex](https://openai.com/codex)
