### PR TITLE
fix(ci): use workflow token for breaking announcements

### DIFF
--- a/.github/actions/announce-breaking-change/action.yml
+++ b/.github/actions/announce-breaking-change/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: 'Merge datetime (ISO 8601)'
     required: true
   github-token:
-    description: 'PAT with discussions:write permission on kent8192/reinhardt-web'
+    description: 'GitHub token with discussions:write permission on kent8192/reinhardt-web'
     required: true
 
 outputs:

--- a/.github/workflows/announce-breaking-change.yml
+++ b/.github/workflows/announce-breaking-change.yml
@@ -19,6 +19,10 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  discussions: write
+
 jobs:
   announce:
     name: Announce Breaking Change
@@ -41,14 +45,14 @@ jobs:
           pr-url: ${{ github.event.pull_request.html_url }}
           pr-body: ${{ github.event.pull_request.body }}
           merged-at: ${{ github.event.pull_request.merged_at }}
-          github-token: ${{ secrets.DISCUSSION_PAT }}
+          github-token: ${{ github.token }}
 
   backfill:
     name: Backfill Breaking Change Announcements
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.DISCUSSION_PAT }}
+      GH_TOKEN: ${{ github.token }}
       SOURCE_REPO: reinhardt-web
       TARGET_REPO: kent8192/reinhardt-web
       INPUT_MODE: ${{ inputs.mode }}

--- a/.github/workflows/announce-breaking-change.yml
+++ b/.github/workflows/announce-breaking-change.yml
@@ -22,6 +22,7 @@ concurrency:
 permissions:
   contents: read
   discussions: write
+  pull-requests: read
 
 jobs:
   announce:
@@ -63,7 +64,7 @@ jobs:
           set -euo pipefail
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::GH_TOKEN is not set. Ensure the DISCUSSION_PAT secret is configured."
+            echo "::error::GH_TOKEN is not set. Ensure the workflow token is available."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Breaking change announcements failing when `DISCUSSION_PAT` is not configured
- Manual backfills relying on the same unnecessary repository secret
- Missing explicit Discussions write permission for the workflow token

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

Merged breaking-change PRs #5889 and #5890 failed in `Announce Breaking Change` because the composite action received an empty `GH_TOKEN`. The target Discussion belongs to this repository, so the workflow-scoped GitHub token is sufficient when granted `discussions: write`.

Related to: #5889, #5890

## How Was This Tested?

- `actionlint -shellcheck=SC2094,SC2016 .github/workflows/announce-breaking-change.yml`
- `git diff --check`
- `cargo make fmt-check`
- `cargo make clippy-check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (not applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (workflow lint coverage)
- [x] New and existing unit tests pass locally with my changes (not applicable to workflow-only change)
- [x] I have tested with all affected database backends (not applicable)
- [x] I have formatted the code with `cargo make fmt-check`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Failed announcement runs for PRs #5889 and #5890

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

The change removes the need to maintain a repository PAT for same-repository Discussion creation.