### PR TITLE
fix(views): add request-scoped QuerySetProvider

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -7920,7 +7920,7 @@ fn generate_composite_pk_type(struct_name: &syn::Ident, pk_fields: &[&FieldInfo]
 		// Display implementation for composite primary key
 		impl ::std::fmt::Display for #composite_pk_name {
 			fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-				write!(f, "(")?;
+				write!(f, "(v2;")?;
 				let mut first = true;
 				#(
 					if !first {
@@ -11268,6 +11268,23 @@ mod tests {
 		assert!(output.to_string().contains(
 			"typed relation traversal does not support many_to_many relations on composite primary-key models"
 		));
+	}
+
+	#[test]
+	fn composite_primary_key_display_includes_parser_version_marker() {
+		let input = quote! {
+			#[model(app_label = "test", table_name = "memberships")]
+			pub struct Membership {
+				#[field(primary_key = true)]
+				pub organization_id: i64,
+				#[field(primary_key = true)]
+				pub member_id: i64,
+			}
+		};
+
+		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
+
+		assert!(output.to_string().contains("v2;"));
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -4814,6 +4814,19 @@ fn is_copy_type(ty: &Type) -> bool {
 	)
 }
 
+fn is_chrono_datetime_type(ty: &Type) -> bool {
+	let inner_ty = extract_nested_option_type(ty);
+	matches!(
+		inner_ty,
+		Type::Path(path)
+			if path
+				.path
+				.segments
+				.last()
+				.is_some_and(|segment| segment.ident == "DateTime")
+	)
+}
+
 /// Generate getter methods for selected fields.
 fn generate_getter_methods<F>(
 	struct_name: &syn::Ident,
@@ -7880,8 +7893,7 @@ fn generate_composite_pk_type(struct_name: &syn::Ident, pk_fields: &[&FieldInfo]
 		.map(|field| {
 			let name = &field.name;
 			let field_type = &field.ty;
-			let type_name = quote!(#field_type).to_string();
-			if type_name.contains("DateTime") && !type_name.contains("NaiveDateTime") {
+			if is_chrono_datetime_type(field_type) {
 				quote! { self.#name.to_rfc3339() }
 			} else {
 				quote! { self.#name.to_string() }
@@ -11315,6 +11327,24 @@ mod tests {
 		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
 
 		assert!(output.to_string().contains("to_rfc3339"));
+	}
+
+	#[rstest]
+	fn composite_primary_key_display_keeps_custom_datetime_named_fields_on_display() {
+		let input = quote! {
+			#[model(app_label = "test", table_name = "custom_keys")]
+			pub struct CustomKeyModel {
+				#[field(primary_key = true)]
+				pub business_datetime_id: BusinessDateTimeId,
+				#[field(primary_key = true)]
+				pub sequence: i64,
+			}
+		};
+
+		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
+		let output = output.to_string();
+
+		assert!(!output.contains("business_datetime_id . to_rfc3339"));
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -7875,6 +7875,19 @@ fn generate_composite_pk_type(struct_name: &syn::Ident, pk_fields: &[&FieldInfo]
 			}
 		})
 		.collect();
+	let display_values: Vec<_> = pk_fields
+		.iter()
+		.map(|field| {
+			let name = &field.name;
+			let field_type = &field.ty;
+			let type_name = quote!(#field_type).to_string();
+			if type_name.contains("DateTime") && !type_name.contains("NaiveDateTime") {
+				quote! { self.#name.to_rfc3339() }
+			} else {
+				quote! { self.#name.to_string() }
+			}
+		})
+		.collect();
 
 	quote! {
 		/// Composite primary key type for #struct_name
@@ -7926,7 +7939,7 @@ fn generate_composite_pk_type(struct_name: &syn::Ident, pk_fields: &[&FieldInfo]
 					if !first {
 						write!(f, ", ")?;
 					}
-					let value = self.#field_names.to_string();
+					let value = #display_values;
 					write!(f, "{}={}:{}", stringify!(#field_names), value.len(), value)?;
 					first = false;
 				)*
@@ -11270,7 +11283,7 @@ mod tests {
 		));
 	}
 
-	#[test]
+	#[rstest]
 	fn composite_primary_key_display_includes_parser_version_marker() {
 		let input = quote! {
 			#[model(app_label = "test", table_name = "memberships")]
@@ -11285,6 +11298,23 @@ mod tests {
 		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
 
 		assert!(output.to_string().contains("v2;"));
+	}
+
+	#[rstest]
+	fn composite_primary_key_display_uses_rfc3339_for_datetime_fields() {
+		let input = quote! {
+			#[model(app_label = "test", table_name = "events")]
+			pub struct Event {
+				#[field(primary_key = true)]
+				pub occurred_at: chrono::DateTime<chrono::Utc>,
+				#[field(primary_key = true)]
+				pub sequence: i64,
+			}
+		};
+
+		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
+
+		assert!(output.to_string().contains("to_rfc3339"));
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -5434,6 +5434,22 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 	} else {
 		quote! {}
 	};
+	let pk_filter_value_from_str_impl = if !is_composite_pk {
+		quote! {
+			fn primary_key_filter_value_from_str(
+				value: &str,
+			) -> #core_crate::exception::Result<#orm_crate::query::FilterValue> {
+				let primary_key =
+					#orm_crate::model::deserialize_primary_key_from_str::<Self::PrimaryKey>(value)
+						.map_err(|_| #core_crate::exception::Error::Validation(
+							format!("invalid primary key: {value}")
+						))?;
+				Ok(Self::primary_key_filter_value(primary_key))
+			}
+		}
+	} else {
+		quote! {}
+	};
 
 	// Generate field accessor methods
 	let field_accessors =
@@ -5811,6 +5827,8 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 			#set_pk_impl
 
 			#pk_filter_value_impl
+
+			#pk_filter_value_from_str_impl
 
 			#composite_pk_impl
 

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -4816,14 +4816,22 @@ fn is_copy_type(ty: &Type) -> bool {
 
 fn is_chrono_datetime_type(ty: &Type) -> bool {
 	let inner_ty = extract_nested_option_type(ty);
+	let Type::Path(path) = inner_ty else {
+		return false;
+	};
+	let segments = path.path.segments.iter().collect::<Vec<_>>();
+	let [chrono_segment, datetime_segment] = segments.as_slice() else {
+		return false;
+	};
+	if chrono_segment.ident != "chrono" || datetime_segment.ident != "DateTime" {
+		return false;
+	}
+
 	matches!(
-		inner_ty,
-		Type::Path(path)
-			if path
-				.path
-				.segments
-				.last()
-				.is_some_and(|segment| segment.ident == "DateTime")
+		&datetime_segment.arguments,
+		PathArguments::AngleBracketed(arguments)
+			if arguments.args.len() == 1
+				&& matches!(arguments.args.first(), Some(GenericArgument::Type(_)))
 	)
 }
 
@@ -11345,6 +11353,24 @@ mod tests {
 		let output = output.to_string();
 
 		assert!(!output.contains("business_datetime_id . to_rfc3339"));
+	}
+
+	#[rstest]
+	fn composite_primary_key_display_rejects_non_chrono_datetime_paths() {
+		let input = quote! {
+			#[model(app_label = "test", table_name = "domain_keys")]
+			pub struct DomainKeyModel {
+				#[field(primary_key = true)]
+				pub occurred_at: domain::DateTime<chrono::Utc>,
+				#[field(primary_key = true)]
+				pub sequence: i64,
+			}
+		};
+
+		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
+		let output = output.to_string();
+
+		assert!(!output.contains("occurred_at . to_rfc3339"));
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -11316,8 +11316,9 @@ mod tests {
 		};
 
 		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
+		let output = output.to_string();
 
-		assert!(output.to_string().contains("v2;"));
+		assert_eq!(output.matches("(v2;").count(), 1);
 	}
 
 	#[rstest]
@@ -11333,8 +11334,12 @@ mod tests {
 		};
 
 		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
+		let output = output.to_string();
 
-		assert!(output.to_string().contains("to_rfc3339"));
+		assert_eq!(
+			output.matches("self . occurred_at . to_rfc3339 ()").count(),
+			1
+		);
 	}
 
 	#[rstest]
@@ -11352,7 +11357,10 @@ mod tests {
 		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
 		let output = output.to_string();
 
-		assert!(!output.contains("business_datetime_id . to_rfc3339"));
+		assert_eq!(
+			output.matches("business_datetime_id . to_rfc3339").count(),
+			0
+		);
 	}
 
 	#[rstest]
@@ -11370,7 +11378,7 @@ mod tests {
 		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
 		let output = output.to_string();
 
-		assert!(!output.contains("occurred_at . to_rfc3339"));
+		assert_eq!(output.matches("occurred_at . to_rfc3339").count(), 0);
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -4820,12 +4820,15 @@ fn is_chrono_datetime_type(ty: &Type) -> bool {
 		return false;
 	};
 	let segments = path.path.segments.iter().collect::<Vec<_>>();
-	let [chrono_segment, datetime_segment] = segments.as_slice() else {
-		return false;
+	let datetime_segment = match segments.as_slice() {
+		[datetime_segment] if datetime_segment.ident == "DateTime" => datetime_segment,
+		[chrono_segment, datetime_segment]
+			if chrono_segment.ident == "chrono" && datetime_segment.ident == "DateTime" =>
+		{
+			datetime_segment
+		}
+		_ => return false,
 	};
-	if chrono_segment.ident != "chrono" || datetime_segment.ident != "DateTime" {
-		return false;
-	}
 
 	matches!(
 		&datetime_segment.arguments,

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -9916,6 +9916,29 @@ mod tests {
 	use super::*;
 	use rstest::rstest;
 
+	fn generated_composite_display(output: TokenStream, composite_name: &str) -> String {
+		let file: syn::File = syn::parse2(output).expect("generated model output should parse");
+		file.items
+			.into_iter()
+			.find_map(|item| {
+				let syn::Item::Impl(item) = item else {
+					return None;
+				};
+				let self_name = match item.self_ty.as_ref() {
+					syn::Type::Path(path) => path.path.segments.last()?.ident.to_string(),
+					_ => return None,
+				};
+				let trait_name = item
+					.trait_
+					.as_ref()
+					.and_then(|(_, path, _)| path.segments.last())
+					.map(|segment| segment.ident.to_string());
+				(self_name == composite_name && trait_name.as_deref() == Some("Display"))
+					.then(|| item.to_token_stream().to_string())
+			})
+			.expect("generated composite primary keys should implement Display")
+	}
+
 	fn generated_primary_key_filter_value(output: &TokenStream) -> String {
 		let output = output.to_string();
 		let start = output
@@ -11316,9 +11339,32 @@ mod tests {
 		};
 
 		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
-		let output = output.to_string();
 
-		assert_eq!(output.matches("(v2;").count(), 1);
+		assert_eq!(
+			generated_composite_display(output, "MembershipCompositePk"),
+			quote! {
+				impl ::std::fmt::Display for MembershipCompositePk {
+					fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+						write!(f, "(v2;")?;
+						let mut first = true;
+						if !first {
+							write!(f, ", ")?;
+						}
+						let value = self.organization_id.to_string();
+						write!(f, "{}={}:{}", stringify!(organization_id), value.len(), value)?;
+						first = false;
+						if !first {
+							write!(f, ", ")?;
+						}
+						let value = self.member_id.to_string();
+						write!(f, "{}={}:{}", stringify!(member_id), value.len(), value)?;
+						first = false;
+						write!(f, ")")
+					}
+				}
+			}
+			.to_string()
+		);
 	}
 
 	#[rstest]
@@ -11334,11 +11380,31 @@ mod tests {
 		};
 
 		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
-		let output = output.to_string();
 
 		assert_eq!(
-			output.matches("self . occurred_at . to_rfc3339 ()").count(),
-			1
+			generated_composite_display(output, "EventCompositePk"),
+			quote! {
+				impl ::std::fmt::Display for EventCompositePk {
+					fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+						write!(f, "(v2;")?;
+						let mut first = true;
+						if !first {
+							write!(f, ", ")?;
+						}
+						let value = self.occurred_at.to_rfc3339();
+						write!(f, "{}={}:{}", stringify!(occurred_at), value.len(), value)?;
+						first = false;
+						if !first {
+							write!(f, ", ")?;
+						}
+						let value = self.sequence.to_string();
+						write!(f, "{}={}:{}", stringify!(sequence), value.len(), value)?;
+						first = false;
+						write!(f, ")")
+					}
+				}
+			}
+			.to_string()
 		);
 	}
 
@@ -11355,11 +11421,31 @@ mod tests {
 		};
 
 		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
-		let output = output.to_string();
 
 		assert_eq!(
-			output.matches("business_datetime_id . to_rfc3339").count(),
-			0
+			generated_composite_display(output, "CustomKeyModelCompositePk"),
+			quote! {
+				impl ::std::fmt::Display for CustomKeyModelCompositePk {
+					fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+						write!(f, "(v2;")?;
+						let mut first = true;
+						if !first {
+							write!(f, ", ")?;
+						}
+						let value = self.business_datetime_id.to_string();
+						write!(f, "{}={}:{}", stringify!(business_datetime_id), value.len(), value)?;
+						first = false;
+						if !first {
+							write!(f, ", ")?;
+						}
+						let value = self.sequence.to_string();
+						write!(f, "{}={}:{}", stringify!(sequence), value.len(), value)?;
+						first = false;
+						write!(f, ")")
+					}
+				}
+			}
+			.to_string()
 		);
 	}
 
@@ -11376,9 +11462,32 @@ mod tests {
 		};
 
 		let output = model_derive_impl(syn::parse2(input).unwrap()).unwrap();
-		let output = output.to_string();
 
-		assert_eq!(output.matches("occurred_at . to_rfc3339").count(), 0);
+		assert_eq!(
+			generated_composite_display(output, "DomainKeyModelCompositePk"),
+			quote! {
+				impl ::std::fmt::Display for DomainKeyModelCompositePk {
+					fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+						write!(f, "(v2;")?;
+						let mut first = true;
+						if !first {
+							write!(f, ", ")?;
+						}
+						let value = self.occurred_at.to_string();
+						write!(f, "{}={}:{}", stringify!(occurred_at), value.len(), value)?;
+						first = false;
+						if !first {
+							write!(f, ", ")?;
+						}
+						let value = self.sequence.to_string();
+						write!(f, "{}={}:{}", stringify!(sequence), value.len(), value)?;
+						first = false;
+						write!(f, ")")
+					}
+				}
+			}
+			.to_string()
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -7926,7 +7926,8 @@ fn generate_composite_pk_type(struct_name: &syn::Ident, pk_fields: &[&FieldInfo]
 					if !first {
 						write!(f, ", ")?;
 					}
-					write!(f, "{}={}", stringify!(#field_names), self.#field_names)?;
+					let value = self.#field_names.to_string();
+					write!(f, "{}={}:{}", stringify!(#field_names), value.len(), value)?;
 					first = false;
 				)*
 				write!(f, ")")

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -5440,7 +5440,7 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 				value: &str,
 			) -> #core_crate::exception::Result<#orm_crate::query::FilterValue> {
 				let primary_key =
-					#orm_crate::model::deserialize_primary_key_from_str::<Self::PrimaryKey>(value)
+					#orm_crate::model::deserialize_primary_key_from_database_str::<Self>(value)
 						.map_err(|_| #core_crate::exception::Error::Validation(
 							format!("invalid primary key: {value}")
 						))?;

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -4820,15 +4820,12 @@ fn is_chrono_datetime_type(ty: &Type) -> bool {
 		return false;
 	};
 	let segments = path.path.segments.iter().collect::<Vec<_>>();
-	let datetime_segment = match segments.as_slice() {
-		[datetime_segment] if datetime_segment.ident == "DateTime" => datetime_segment,
-		[chrono_segment, datetime_segment]
-			if chrono_segment.ident == "chrono" && datetime_segment.ident == "DateTime" =>
-		{
-			datetime_segment
-		}
-		_ => return false,
+	let [chrono_segment, datetime_segment] = segments.as_slice() else {
+		return false;
 	};
+	if chrono_segment.ident != "chrono" || datetime_segment.ident != "DateTime" {
+		return false;
+	}
 
 	matches!(
 		&datetime_segment.arguments,
@@ -5463,11 +5460,15 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 			fn primary_key_filter_value_from_str(
 				value: &str,
 			) -> #core_crate::exception::Result<#orm_crate::query::FilterValue> {
-				let primary_key =
+				let primary_key = match
 					#orm_crate::model::deserialize_primary_key_from_database_str::<Self>(value)
+				{
+					Ok(primary_key) => primary_key,
+					Err(_) => #orm_crate::model::deserialize_primary_key_from_str(value)
 						.map_err(|_| #core_crate::exception::Error::Validation(
 							format!("invalid primary key: {value}")
-						))?;
+						))?,
+				};
 				Ok(Self::primary_key_filter_value(primary_key))
 			}
 		}

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -1205,6 +1205,16 @@ pub mod db {
 					.or_else(|_| serde_json::from_str(value))
 			}
 
+			pub fn deserialize_primary_key_from_database_str<M>(
+				value: &str,
+			) -> std::result::Result<M::PrimaryKey, serde_json::Error>
+			where
+				M: super::Model,
+				M::PrimaryKey: serde::de::DeserializeOwned,
+			{
+				deserialize_primary_key_from_str(value)
+			}
+
 			pub fn serialize_decoded_database_field<T: serde::Serialize>(
 				value: T,
 			) -> Result<ModelFieldJsonValue, super::FieldCodecError> {

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -35,6 +35,7 @@ pub mod exception {
 	#[derive(Debug)]
 	pub enum Error {
 		Internal(String),
+		Validation(String),
 	}
 
 	pub type Result<T> = core::result::Result<T, Error>;
@@ -454,6 +455,11 @@ pub mod db {
 			}
 			fn primary_key_filter_value(_pk: Self::PrimaryKey) -> query::FilterValue {
 				query::FilterValue::default()
+			}
+			fn primary_key_filter_value_from_str(
+				_value: &str,
+			) -> crate::exception::Result<query::FilterValue> {
+				Ok(query::FilterValue::default())
 			}
 			fn primary_key(&self) -> Option<Self::PrimaryKey>;
 			fn set_primary_key(&mut self, value: Self::PrimaryKey);
@@ -1188,6 +1194,16 @@ pub mod db {
 
 		pub mod model {
 			pub type ModelFieldJsonValue = serde_json::Value;
+
+			pub fn deserialize_primary_key_from_str<T>(
+				value: &str,
+			) -> std::result::Result<T, serde_json::Error>
+			where
+				T: serde::de::DeserializeOwned,
+			{
+				serde_json::from_value(serde_json::Value::String(value.to_owned()))
+					.or_else(|_| serde_json::from_str(value))
+			}
 
 			pub fn serialize_decoded_database_field<T: serde::Serialize>(
 				value: T,

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -1262,6 +1262,15 @@ pub mod db {
 				}
 			}
 
+			pub fn database_field_type_path_for<T>() -> &'static str {
+				let type_name = std::any::type_name::<T>();
+				if type_name == "i64" {
+					"reinhardt.orm.models.BigIntegerField"
+				} else {
+					"reinhardt.orm.models.CharField"
+				}
+			}
+
 			#[derive(Debug, Clone, PartialEq)]
 			pub struct FieldInfo {
 				pub name: String,

--- a/crates/reinhardt-db/src/orm/json.rs
+++ b/crates/reinhardt-db/src/orm/json.rs
@@ -341,6 +341,7 @@ pub(crate) fn database_value_from_json(
 			.map_err(|error| FieldCodecError::Serialization(error.to_string()))
 			.and_then(|value| {
 				chrono::DateTime::parse_from_rfc3339(&value)
+					.or_else(|_| value.parse::<chrono::DateTime<chrono::FixedOffset>>())
 					.map(|value| DatabaseValue::DateTime(value.with_timezone(&chrono::Utc)))
 					.map_err(|error| FieldCodecError::Serialization(error.to_string()))
 			}),

--- a/crates/reinhardt-db/src/orm/json.rs
+++ b/crates/reinhardt-db/src/orm/json.rs
@@ -104,6 +104,9 @@ where
 
 pub(crate) fn is_json_field_type(field_type: &str) -> bool {
 	field_type.contains("JsonField")
+		|| field_type.contains("JSONField")
+		|| field_type.contains("JSONBField")
+		|| field_type.contains("HStoreField")
 }
 
 pub(crate) fn deserialize_model_row<M: Model>(

--- a/crates/reinhardt-db/src/orm/json.rs
+++ b/crates/reinhardt-db/src/orm/json.rs
@@ -436,6 +436,7 @@ mod tests {
 	use super::{Json, database_value_from_json, deserialize_model_row};
 	use crate::orm::{DatabaseStorageKind, DatabaseValue};
 	use reinhardt_core::macros::model;
+	use rstest::rstest;
 	use serde::{Deserialize, Serialize};
 	use serde_json::json;
 	use std::collections::HashSet;
@@ -591,7 +592,7 @@ mod tests {
 		);
 	}
 
-	#[test]
+	#[rstest]
 	fn naive_datetime_storage_accepts_backend_offset_free_iso_text() {
 		let value = database_value_from_json(
 			json!("2026-07-26T09:30:00.123456"),

--- a/crates/reinhardt-db/src/orm/json.rs
+++ b/crates/reinhardt-db/src/orm/json.rs
@@ -350,6 +350,9 @@ pub(crate) fn database_value_from_json(
 			.and_then(|value| {
 				chrono::NaiveDateTime::parse_from_str(&value, "%Y-%m-%d %H:%M:%S%.f")
 					.or_else(|_| {
+						chrono::NaiveDateTime::parse_from_str(&value, "%Y-%m-%dT%H:%M:%S%.f")
+					})
+					.or_else(|_| {
 						chrono::DateTime::parse_from_rfc3339(&value)
 							.map(|datetime| datetime.naive_local())
 					})
@@ -575,6 +578,26 @@ mod tests {
 			Some(DatabaseStorageKind::NaiveDateTime),
 		)
 		.expect("RFC 3339 timestamp should decode as a naive wall-clock value");
+
+		assert_eq!(
+			value,
+			DatabaseValue::NaiveDateTime(
+				chrono::NaiveDateTime::parse_from_str(
+					"2026-07-26 09:30:00.123456",
+					"%Y-%m-%d %H:%M:%S%.f",
+				)
+				.expect("expected test datetime"),
+			)
+		);
+	}
+
+	#[test]
+	fn naive_datetime_storage_accepts_backend_offset_free_iso_text() {
+		let value = database_value_from_json(
+			json!("2026-07-26T09:30:00.123456"),
+			Some(DatabaseStorageKind::NaiveDateTime),
+		)
+		.expect("offset-free ISO timestamp should decode as a naive value");
 
 		assert_eq!(
 			value,

--- a/crates/reinhardt-db/src/orm/json.rs
+++ b/crates/reinhardt-db/src/orm/json.rs
@@ -342,6 +342,9 @@ pub(crate) fn database_value_from_json(
 			.and_then(|value| {
 				chrono::DateTime::parse_from_rfc3339(&value)
 					.or_else(|_| value.parse::<chrono::DateTime<chrono::FixedOffset>>())
+					.or_else(|_| {
+						chrono::DateTime::parse_from_str(&value, "%Y-%m-%d %H:%M:%S%.f %Z")
+					})
 					.map(|value| DatabaseValue::DateTime(value.with_timezone(&chrono::Utc)))
 					.map_err(|error| FieldCodecError::Serialization(error.to_string()))
 			}),

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -23,12 +23,13 @@ where
 	M: Model,
 	M::PrimaryKey: DatabaseField,
 {
-	let value =
-		serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.to_owned()));
-	let database_value = super::json::database_value_from_json(
-		value,
-		Some(<M::PrimaryKey as DatabaseField>::Storage::STORAGE_KIND),
-	)?;
+	let storage_kind = <M::PrimaryKey as DatabaseField>::Storage::STORAGE_KIND;
+	let value = match storage_kind {
+		super::DatabaseStorageKind::String => serde_json::Value::String(value.to_owned()),
+		_ => serde_json::from_str(value)
+			.unwrap_or_else(|_| serde_json::Value::String(value.to_owned())),
+	};
+	let database_value = super::json::database_value_from_json(value, Some(storage_kind))?;
 	let decoded = M::decode_database_field(M::primary_key_field(), database_value)?;
 	serde_json::from_value(decoded)
 		.map_err(|error| FieldCodecError::Serialization(error.to_string()))

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -2,6 +2,7 @@ use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind, Error};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
+use super::inspection::FieldInfo;
 use super::{DatabaseField, DatabaseScalar, DatabaseValue, FieldCodecError};
 
 /// Deserializes one route segment into a model primary-key type.
@@ -47,6 +48,75 @@ fn legacy_storage_kind(field_type: &str) -> Option<super::DatabaseStorageKind> {
 	} else {
 		None
 	}
+}
+
+/// Convert a route component using the storage type recorded for its model field.
+#[doc(hidden)]
+pub fn filter_value_from_field(
+	field: &FieldInfo,
+	value: &str,
+) -> Result<super::query::FilterValue, FieldCodecError> {
+	use super::DatabaseStorageKind;
+
+	let Some(storage_kind) = field
+		.storage_kind
+		.or_else(|| legacy_storage_kind(&field.field_type))
+	else {
+		return Ok(super::query::FilterValue::String(value.to_owned()));
+	};
+
+	let database_value =
+		match storage_kind {
+			DatabaseStorageKind::Bool => DatabaseValue::Bool(value.parse().map_err(|_| {
+				FieldCodecError::Serialization(format!("invalid boolean value: {value}"))
+			})?),
+			DatabaseStorageKind::I32 => DatabaseValue::I32(value.parse().map_err(|_| {
+				FieldCodecError::Serialization(format!("invalid i32 value: {value}"))
+			})?),
+			DatabaseStorageKind::I64 => DatabaseValue::I64(value.parse().map_err(|_| {
+				FieldCodecError::Serialization(format!("invalid i64 value: {value}"))
+			})?),
+			DatabaseStorageKind::F32 => DatabaseValue::F32(value.parse().map_err(|_| {
+				FieldCodecError::Serialization(format!("invalid f32 value: {value}"))
+			})?),
+			DatabaseStorageKind::F64 => DatabaseValue::F64(value.parse().map_err(|_| {
+				FieldCodecError::Serialization(format!("invalid f64 value: {value}"))
+			})?),
+			DatabaseStorageKind::Decimal => {
+				DatabaseValue::Decimal(value.parse().map_err(|_| {
+					FieldCodecError::Serialization(format!("invalid decimal value: {value}"))
+				})?)
+			}
+			DatabaseStorageKind::String => DatabaseValue::String(value.to_owned()),
+			DatabaseStorageKind::Uuid => DatabaseValue::Uuid(value.parse().map_err(|_| {
+				FieldCodecError::Serialization(format!("invalid UUID value: {value}"))
+			})?),
+			DatabaseStorageKind::Date => DatabaseValue::Date(value.parse().map_err(|_| {
+				FieldCodecError::Serialization(format!("invalid date value: {value}"))
+			})?),
+			DatabaseStorageKind::Time => DatabaseValue::Time(value.parse().map_err(|_| {
+				FieldCodecError::Serialization(format!("invalid time value: {value}"))
+			})?),
+			DatabaseStorageKind::DateTime => DatabaseValue::DateTime(
+				chrono::DateTime::parse_from_rfc3339(value)
+					.map_err(|_| {
+						FieldCodecError::Serialization(format!("invalid datetime value: {value}"))
+					})?
+					.with_timezone(&chrono::Utc),
+			),
+			DatabaseStorageKind::NaiveDateTime => DatabaseValue::NaiveDateTime(
+				chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.f")
+					.or_else(|_| {
+						chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
+					})
+					.map_err(|_| {
+						FieldCodecError::Serialization(format!("invalid datetime value: {value}"))
+					})?,
+			),
+			_ => return Ok(super::query::FilterValue::String(value.to_owned())),
+		};
+
+	Ok(super::query::FilterValue::Typed(Ok(database_value)))
 }
 
 /// JSON carrier used only for final whole-model assembly after field decoding.

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -1391,7 +1391,7 @@ mod tests {
 		);
 	}
 
-	#[test]
+	#[rstest]
 	fn datetime_route_values_accept_display_format() {
 		let field = LegacyTypedRecord::field_metadata()
 			.into_iter()

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -2,7 +2,7 @@ use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind, Error};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
-use super::{DatabaseValue, FieldCodecError};
+use super::{DatabaseField, DatabaseScalar, DatabaseValue, FieldCodecError};
 
 /// Deserializes one route segment into a model primary-key type.
 #[doc(hidden)]
@@ -12,6 +12,26 @@ where
 {
 	serde_json::from_value(serde_json::Value::String(value.to_owned()))
 		.or_else(|_| serde_json::from_str(value))
+}
+
+/// Deserializes a route segment through a generated primary-key database codec.
+#[doc(hidden)]
+pub fn deserialize_primary_key_from_database_str<M>(
+	value: &str,
+) -> Result<M::PrimaryKey, FieldCodecError>
+where
+	M: Model,
+	M::PrimaryKey: DatabaseField,
+{
+	let value =
+		serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.to_owned()));
+	let database_value = super::json::database_value_from_json(
+		value,
+		Some(<M::PrimaryKey as DatabaseField>::Storage::STORAGE_KIND),
+	)?;
+	let decoded = M::decode_database_field(M::primary_key_field(), database_value)?;
+	serde_json::from_value(decoded)
+		.map_err(|error| FieldCodecError::Serialization(error.to_string()))
 }
 
 fn legacy_storage_kind(field_type: &str) -> Option<super::DatabaseStorageKind> {
@@ -212,6 +232,21 @@ pub trait Model: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone {
 			return super::query::FilterValue::String(value);
 		}
 
+		if type_name == std::any::type_name::<uuid::Uuid>() {
+			return value
+				.parse()
+				.map(super::query::FilterValue::Uuid)
+				.unwrap_or(super::query::FilterValue::String(value));
+		}
+
+		if type_name == std::any::type_name::<chrono::DateTime<chrono::Utc>>() {
+			return chrono::DateTime::parse_from_rfc3339(&value)
+				.map(|value| {
+					super::query::FilterValue::Timestamp(value.with_timezone(&chrono::Utc))
+				})
+				.unwrap_or(super::query::FilterValue::String(value));
+		}
+
 		value
 			.parse::<i64>()
 			.map(super::query::FilterValue::Integer)
@@ -256,6 +291,21 @@ pub trait Model: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone {
 		parse_standard_integer!(u64, "unsigned integer");
 		parse_standard_integer!(usize, "unsigned integer");
 		parse_standard_integer!(u128, "unsigned integer");
+
+		if type_name == std::any::type_name::<uuid::Uuid>() {
+			return value
+				.parse()
+				.map(super::query::FilterValue::Uuid)
+				.map_err(|_| Error::Validation(format!("invalid UUID primary key: {value}")));
+		}
+
+		if type_name == std::any::type_name::<chrono::DateTime<chrono::Utc>>() {
+			return chrono::DateTime::parse_from_rfc3339(value)
+				.map(|value| {
+					super::query::FilterValue::Timestamp(value.with_timezone(&chrono::Utc))
+				})
+				.map_err(|_| Error::Validation(format!("invalid timestamp primary key: {value}")));
+		}
 
 		Ok(super::query::FilterValue::String(value.to_owned()))
 	}

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind, Error};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -100,6 +101,11 @@ pub fn filter_value_from_field(
 				})?)
 			}
 			DatabaseStorageKind::String => DatabaseValue::String(value.to_owned()),
+			DatabaseStorageKind::Bytes => DatabaseValue::Bytes(
+				base64::engine::general_purpose::STANDARD
+					.decode(value)
+					.map_err(|error| FieldCodecError::Serialization(error.to_string()))?,
+			),
 			DatabaseStorageKind::Uuid => DatabaseValue::Uuid(value.parse().map_err(|_| {
 				FieldCodecError::Serialization(format!("invalid UUID value: {value}"))
 			})?),
@@ -1259,9 +1265,9 @@ impl Default for SoftDelete {
 #[cfg(test)]
 mod tests {
 	use super::Model;
-	use crate::orm::fields::{CharField, Field};
+	use crate::orm::fields::{BinaryField, CharField, Field};
 	use crate::orm::inspection::FieldInfo;
-	use crate::orm::{DatabaseValue, FieldSelector, Manager};
+	use crate::orm::{DatabaseStorageKind, DatabaseValue, FieldSelector, Manager};
 	use reinhardt_core::macros::{ModelEnum, model};
 	use rstest::rstest;
 	use serde::{Deserialize, Serialize};
@@ -1549,6 +1555,22 @@ mod tests {
 					.expect("expected datetime should parse")
 					.with_timezone(&chrono::Utc)
 		));
+	}
+
+	#[rstest]
+	fn binary_route_values_decode_base64() {
+		let mut field = BinaryField::new();
+		field.set_attributes_from_name("payload");
+		let mut info = FieldInfo::from_field(&field);
+		info.storage_kind = Some(DatabaseStorageKind::Bytes);
+
+		let filter = super::filter_value_from_field(&info, "AAH//w==")
+			.expect("base64 binary route value should parse");
+
+		let crate::orm::query::FilterValue::Typed(Ok(value)) = filter else {
+			panic!("binary route value should produce a typed database value");
+		};
+		assert_eq!(value, DatabaseValue::Bytes(vec![0, 1, 255, 255]));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -4,6 +4,16 @@ use std::collections::{BTreeMap, HashMap};
 
 use super::{DatabaseValue, FieldCodecError};
 
+/// Deserializes one route segment into a model primary-key type.
+#[doc(hidden)]
+pub fn deserialize_primary_key_from_str<T>(value: &str) -> Result<T, serde_json::Error>
+where
+	T: serde::de::DeserializeOwned,
+{
+	serde_json::from_value(serde_json::Value::String(value.to_owned()))
+		.or_else(|_| serde_json::from_str(value))
+}
+
 fn legacy_storage_kind(field_type: &str) -> Option<super::DatabaseStorageKind> {
 	if field_type.contains("UuidField") || field_type.contains("UUIDField") {
 		Some(super::DatabaseStorageKind::Uuid)
@@ -206,6 +216,48 @@ pub trait Model: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone {
 			.parse::<i64>()
 			.map(super::query::FilterValue::Integer)
 			.unwrap_or(super::query::FilterValue::String(value))
+	}
+
+	/// Converts a route primary key into a query filter value.
+	///
+	/// Derived models override this method so UUIDs, timestamps, and custom
+	/// primary-key codecs use the same typed conversion as model instances.
+	fn primary_key_filter_value_from_str(
+		value: &str,
+	) -> reinhardt_core::exception::Result<super::query::FilterValue> {
+		use reinhardt_core::exception::Error;
+
+		let type_name = std::any::type_name::<Self::PrimaryKey>();
+		macro_rules! parse_standard_integer {
+			($integer:ty, $category:literal) => {
+				if type_name == std::any::type_name::<$integer>() {
+					return value
+						.parse::<$integer>()
+						.map(super::query::FilterValue::from)
+						.map_err(|_| {
+							Error::Validation(format!(
+								concat!("invalid ", $category, " primary key: {}"),
+								value
+							))
+						});
+				}
+			};
+		}
+
+		parse_standard_integer!(i8, "integer");
+		parse_standard_integer!(i16, "integer");
+		parse_standard_integer!(i32, "integer");
+		parse_standard_integer!(i64, "integer");
+		parse_standard_integer!(isize, "integer");
+		parse_standard_integer!(i128, "integer");
+		parse_standard_integer!(u8, "unsigned integer");
+		parse_standard_integer!(u16, "unsigned integer");
+		parse_standard_integer!(u32, "unsigned integer");
+		parse_standard_integer!(u64, "unsigned integer");
+		parse_standard_integer!(usize, "unsigned integer");
+		parse_standard_integer!(u128, "unsigned integer");
+
+		Ok(super::query::FilterValue::String(value.to_owned()))
 	}
 
 	/// Get the primary key value

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -99,6 +99,7 @@ pub fn filter_value_from_field(
 			})?),
 			DatabaseStorageKind::DateTime => DatabaseValue::DateTime(
 				chrono::DateTime::parse_from_rfc3339(value)
+					.or_else(|_| value.parse::<chrono::DateTime<chrono::FixedOffset>>())
 					.map_err(|_| {
 						FieldCodecError::Serialization(format!("invalid datetime value: {value}"))
 					})?
@@ -1388,5 +1389,23 @@ mod tests {
 			fields.get("occurred_at"),
 			Some(&DatabaseValue::DateTime(occurred_at))
 		);
+	}
+
+	#[test]
+	fn datetime_route_values_accept_display_format() {
+		let field = LegacyTypedRecord::field_metadata()
+			.into_iter()
+			.find(|field| field.name == "occurred_at")
+			.expect("datetime metadata should exist");
+		let filter = super::filter_value_from_field(&field, "2026-07-18 12:00:00 UTC")
+			.expect("display-formatted datetime should parse");
+
+		assert!(matches!(
+			filter,
+			crate::orm::query::FilterValue::Typed(Ok(DatabaseValue::DateTime(value)))
+				if value == chrono::DateTime::parse_from_rfc3339("2026-07-18T12:00:00Z")
+					.expect("expected datetime should parse")
+					.with_timezone(&chrono::Utc)
+		));
 	}
 }

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -378,6 +378,29 @@ pub trait Model: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone {
 				.map_err(|_| Error::Validation(format!("invalid timestamp primary key: {value}")));
 		}
 
+		macro_rules! parse_typed_primary_key {
+			($ty:ty, $variant:ident, $category:literal) => {
+				if type_name == std::any::type_name::<$ty>() {
+					return value
+						.parse::<$ty>()
+						.map(|parsed| {
+							super::query::FilterValue::Typed(Ok(DatabaseValue::$variant(parsed)))
+						})
+						.map_err(|_| {
+							Error::Validation(format!(
+								concat!("invalid ", $category, " primary key: {}"),
+								value
+							))
+						});
+				}
+			};
+		}
+
+		parse_typed_primary_key!(chrono::NaiveDate, Date, "date");
+		parse_typed_primary_key!(chrono::NaiveTime, Time, "time");
+		parse_typed_primary_key!(chrono::NaiveDateTime, NaiveDateTime, "naive datetime");
+		parse_typed_primary_key!(rust_decimal::Decimal, Decimal, "decimal");
+
 		Ok(super::query::FilterValue::String(value.to_owned()))
 	}
 

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -47,6 +47,16 @@ fn legacy_storage_kind(field_type: &str) -> Option<super::DatabaseStorageKind> {
 		Some(super::DatabaseStorageKind::Date)
 	} else if field_type.contains("TimeField") {
 		Some(super::DatabaseStorageKind::Time)
+	} else if field_type.contains("BooleanField") {
+		Some(super::DatabaseStorageKind::Bool)
+	} else if field_type.contains("BigIntegerField") {
+		Some(super::DatabaseStorageKind::I64)
+	} else if field_type.contains("IntegerField") {
+		Some(super::DatabaseStorageKind::I32)
+	} else if field_type.contains("FloatField") {
+		Some(super::DatabaseStorageKind::F64)
+	} else if field_type.contains("DecimalField") {
+		Some(super::DatabaseStorageKind::Decimal)
 	} else {
 		None
 	}
@@ -313,8 +323,30 @@ pub trait Model: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone {
 				.unwrap_or(super::query::FilterValue::String(value));
 		}
 
+		if type_name == std::any::type_name::<bool>() {
+			return value
+				.parse()
+				.map(super::query::FilterValue::Boolean)
+				.unwrap_or(super::query::FilterValue::String(value));
+		}
+
+		if type_name == std::any::type_name::<f32>() {
+			return value
+				.parse::<f32>()
+				.map(|value| super::query::FilterValue::Float(value as f64))
+				.unwrap_or(super::query::FilterValue::String(value));
+		}
+
+		if type_name == std::any::type_name::<f64>() {
+			return value
+				.parse::<f64>()
+				.map(super::query::FilterValue::Float)
+				.unwrap_or(super::query::FilterValue::String(value));
+		}
+
 		if type_name == std::any::type_name::<chrono::DateTime<chrono::Utc>>() {
 			return chrono::DateTime::parse_from_rfc3339(&value)
+				.or_else(|_| value.parse::<chrono::DateTime<chrono::FixedOffset>>())
 				.map(|value| {
 					super::query::FilterValue::Timestamp(value.with_timezone(&chrono::Utc))
 				})
@@ -373,8 +405,30 @@ pub trait Model: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone {
 				.map_err(|_| Error::Validation(format!("invalid UUID primary key: {value}")));
 		}
 
+		if type_name == std::any::type_name::<bool>() {
+			return value
+				.parse()
+				.map(super::query::FilterValue::Boolean)
+				.map_err(|_| Error::Validation(format!("invalid boolean primary key: {value}")));
+		}
+
+		if type_name == std::any::type_name::<f32>() {
+			return value
+				.parse::<f32>()
+				.map(|value| super::query::FilterValue::Float(value as f64))
+				.map_err(|_| Error::Validation(format!("invalid float primary key: {value}")));
+		}
+
+		if type_name == std::any::type_name::<f64>() {
+			return value
+				.parse::<f64>()
+				.map(super::query::FilterValue::Float)
+				.map_err(|_| Error::Validation(format!("invalid float primary key: {value}")));
+		}
+
 		if type_name == std::any::type_name::<chrono::DateTime<chrono::Utc>>() {
 			return chrono::DateTime::parse_from_rfc3339(value)
+				.or_else(|_| value.parse::<chrono::DateTime<chrono::FixedOffset>>())
 				.map(|value| {
 					super::query::FilterValue::Timestamp(value.with_timezone(&chrono::Utc))
 				})
@@ -1205,6 +1259,7 @@ impl Default for SoftDelete {
 #[cfg(test)]
 mod tests {
 	use super::Model;
+	use crate::orm::fields::{CharField, Field};
 	use crate::orm::inspection::FieldInfo;
 	use crate::orm::{DatabaseValue, FieldSelector, Manager};
 	use reinhardt_core::macros::{ModelEnum, model};
@@ -1325,6 +1380,46 @@ mod tests {
 		}
 	}
 
+	macro_rules! define_manual_primary_key_model {
+		($name:ident, $key:ty, $table:literal) => {
+			#[derive(Clone, Debug, Serialize, Deserialize)]
+			struct $name {
+				id: $key,
+			}
+
+			impl Model for $name {
+				type PrimaryKey = $key;
+				type Fields = LegacyTypedRecordFields;
+				type Objects = Manager<Self>;
+
+				fn table_name() -> &'static str {
+					$table
+				}
+
+				fn primary_key(&self) -> Option<Self::PrimaryKey> {
+					Some(self.id.clone())
+				}
+
+				fn set_primary_key(&mut self, value: Self::PrimaryKey) {
+					self.id = value;
+				}
+
+				fn new_fields() -> Self::Fields {
+					LegacyTypedRecordFields
+				}
+			}
+		};
+	}
+
+	define_manual_primary_key_model!(ManualBooleanPrimaryKey, bool, "manual_boolean_keys");
+	define_manual_primary_key_model!(ManualF32PrimaryKey, f32, "manual_f32_keys");
+	define_manual_primary_key_model!(ManualF64PrimaryKey, f64, "manual_f64_keys");
+	define_manual_primary_key_model!(
+		ManualDateTimePrimaryKey,
+		chrono::DateTime<chrono::Utc>,
+		"manual_datetime_keys"
+	);
+
 	#[rstest]
 	fn string_enum_database_value_survives_field_map_round_trip() {
 		// Arrange
@@ -1408,6 +1503,37 @@ mod tests {
 	}
 
 	#[rstest]
+	fn legacy_metadata_infers_scalar_database_values() {
+		let cases = [
+			("BooleanField", "true", DatabaseValue::Bool(true)),
+			("IntegerField", "7", DatabaseValue::I32(7)),
+			(
+				"BigIntegerField",
+				"9007199254740993",
+				DatabaseValue::I64(9007199254740993),
+			),
+			("FloatField", "1.25", DatabaseValue::F64(1.25)),
+			(
+				"DecimalField",
+				"9007199254740993.123456789",
+				DatabaseValue::Decimal("9007199254740993.123456789".parse().unwrap()),
+			),
+		];
+
+		for (field_type, value, expected) in cases {
+			let mut field = CharField::new(255);
+			field.set_attributes_from_name("value");
+			let mut info = FieldInfo::from_field(&field);
+			info.field_type = format!("reinhardt.orm.models.{field_type}");
+
+			let filter = super::filter_value_from_field(&info, value).unwrap();
+			assert!(
+				matches!(filter, crate::orm::query::FilterValue::Typed(Ok(actual)) if actual == expected)
+			);
+		}
+	}
+
+	#[rstest]
 	fn datetime_route_values_accept_display_format() {
 		let field = LegacyTypedRecord::field_metadata()
 			.into_iter()
@@ -1436,6 +1562,33 @@ mod tests {
 			crate::orm::query::FilterValue::Timestamp(value)
 				if value == chrono::DateTime::parse_from_rfc3339("2026-07-18T12:00:00Z")
 					.expect("expected datetime should parse")
+					.with_timezone(&chrono::Utc)
+		));
+	}
+
+	#[rstest]
+	fn manual_primary_keys_preserve_boolean_float_and_display_datetime_types() {
+		assert!(matches!(
+			ManualBooleanPrimaryKey::primary_key_filter_value(true),
+			crate::orm::query::FilterValue::Boolean(true)
+		));
+		assert!(matches!(
+			ManualF32PrimaryKey::primary_key_filter_value(1.25),
+			crate::orm::query::FilterValue::Float(value) if (value - 1.25).abs() < f64::EPSILON
+		));
+		assert!(matches!(
+			ManualF64PrimaryKey::primary_key_filter_value(2.5),
+			crate::orm::query::FilterValue::Float(value) if (value - 2.5).abs() < f64::EPSILON
+		));
+
+		let filter =
+			ManualDateTimePrimaryKey::primary_key_filter_value_from_str("2026-07-18 12:00:00 UTC")
+				.unwrap();
+		assert!(matches!(
+			filter,
+			crate::orm::query::FilterValue::Timestamp(value)
+				if value == chrono::DateTime::parse_from_rfc3339("2026-07-18T12:00:00Z")
+					.unwrap()
 					.with_timezone(&chrono::Utc)
 		));
 	}

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -26,7 +26,9 @@ where
 {
 	let storage_kind = <M::PrimaryKey as DatabaseField>::Storage::STORAGE_KIND;
 	let value = match storage_kind {
-		super::DatabaseStorageKind::String => serde_json::Value::String(value.to_owned()),
+		super::DatabaseStorageKind::Decimal | super::DatabaseStorageKind::String => {
+			serde_json::Value::String(value.to_owned())
+		}
 		_ => serde_json::from_str(value)
 			.unwrap_or_else(|_| serde_json::Value::String(value.to_owned())),
 	};
@@ -1239,6 +1241,20 @@ mod tests {
 		priority: Priority,
 	}
 
+	#[model(app_label = "tests", table_name = "decimal_primary_key_records")]
+	#[derive(Clone, Debug, Serialize, Deserialize)]
+	struct DecimalPrimaryKeyRecord {
+		#[field(primary_key = true)]
+		id: rust_decimal::Decimal,
+	}
+
+	#[model(app_label = "tests", table_name = "datetime_primary_key_records")]
+	#[derive(Clone, Debug, Serialize, Deserialize)]
+	struct DateTimePrimaryKeyRecord {
+		#[field(primary_key = true)]
+		id: chrono::DateTime<chrono::Utc>,
+	}
+
 	#[derive(Clone, Debug, Serialize, Deserialize)]
 	struct LegacyTypedRecord {
 		id: Option<i64>,
@@ -1406,6 +1422,35 @@ mod tests {
 				if value == chrono::DateTime::parse_from_rfc3339("2026-07-18T12:00:00Z")
 					.expect("expected datetime should parse")
 					.with_timezone(&chrono::Utc)
+		));
+	}
+
+	#[rstest]
+	fn generated_datetime_primary_key_accepts_display_format() {
+		let filter =
+			DateTimePrimaryKeyRecord::primary_key_filter_value_from_str("2026-07-18 12:00:00 UTC")
+				.expect("display-formatted datetime primary key should parse");
+
+		assert!(matches!(
+			filter,
+			crate::orm::query::FilterValue::Timestamp(value)
+				if value == chrono::DateTime::parse_from_rfc3339("2026-07-18T12:00:00Z")
+					.expect("expected datetime should parse")
+					.with_timezone(&chrono::Utc)
+		));
+	}
+
+	#[rstest]
+	fn generated_decimal_primary_key_preserves_route_precision() {
+		let route_value = "9007199254740993.123456789";
+		let filter = DecimalPrimaryKeyRecord::primary_key_filter_value_from_str(route_value)
+			.expect("decimal primary key should parse");
+		let expected: rust_decimal::Decimal = route_value.parse().expect("decimal should parse");
+
+		assert!(matches!(
+			filter,
+			crate::orm::query::FilterValue::Typed(Ok(DatabaseValue::Decimal(value)))
+				if value == expected
 		));
 	}
 }

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -9854,6 +9854,12 @@ where
 		self
 	}
 
+	/// Clear DISTINCT for a single-row mutation lookup.
+	pub fn without_distinct(mut self) -> Self {
+		self.distinct_enabled = false;
+		self
+	}
+
 	/// Set LIMIT clause
 	///
 	/// Limits the number of records returned by the query.

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -10235,6 +10235,11 @@ where
 		self
 	}
 
+	/// Return whether this queryset limits or offsets its result set.
+	pub fn has_slicing(&self) -> bool {
+		self.limit.is_some() || self.offset.is_some()
+	}
+
 	/// Paginate results using page number and page size
 	///
 	/// Convenience method that calculates offset automatically.

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1378,6 +1378,23 @@ struct SubquerySql {
 	sqlite: String,
 }
 
+#[derive(Clone)]
+struct SubqueryStatements {
+	postgres: SelectStatement,
+	mysql: SelectStatement,
+	sqlite: SelectStatement,
+}
+
+impl SubqueryStatements {
+	fn for_backend(&self, backend: crate::backends::types::DatabaseType) -> &SelectStatement {
+		match backend {
+			crate::backends::types::DatabaseType::Postgres => &self.postgres,
+			crate::backends::types::DatabaseType::Mysql => &self.mysql,
+			crate::backends::types::DatabaseType::Sqlite => &self.sqlite,
+		}
+	}
+}
+
 impl SubquerySql {
 	fn for_backend(&self, backend: crate::backends::types::DatabaseType) -> &str {
 		match backend {
@@ -1915,6 +1932,7 @@ where
 	/// Subquery SQL for FROM clause (derived table)
 	/// When set, the FROM clause will use this subquery instead of the model's table
 	from_subquery_sql: Option<SubquerySql>,
+	from_subquery_statement: Option<SubqueryStatements>,
 	select_for_update: Option<SelectForUpdateSpec>,
 }
 
@@ -1954,6 +1972,7 @@ where
 			from_alias: None,
 			empty_result: false,
 			from_subquery_sql: None,
+			from_subquery_statement: None,
 			select_for_update: None,
 		}
 	}
@@ -2001,7 +2020,7 @@ where
 		}
 
 		let mut stmt = Query::select();
-		self.apply_model_from(&mut stmt);
+		self.apply_model_from_for_backend(&mut stmt, backend);
 		if self.distinct_enabled {
 			stmt.distinct();
 		}
@@ -2074,7 +2093,6 @@ where
 			|| !self.lateral_joins.is_empty()
 			|| !self.group_by_fields.is_empty()
 			|| !self.typed_havings.is_empty()
-			|| self.from_subquery_sql.is_some()
 		{
 			return Err(reinhardt_core::exception::Error::from(
 				reinhardt_core::exception::DatabaseError::new(
@@ -2541,7 +2559,8 @@ where
 	}
 
 	fn supports_scope_subquery_row_lock(&self) -> bool {
-		self.ctes.is_empty()
+		self.select_for_update.is_none()
+			&& self.ctes.is_empty()
 			&& self.from_subquery_sql.is_none()
 			&& self.lateral_joins.is_empty()
 			&& !self.distinct_enabled
@@ -2942,6 +2961,7 @@ where
 			from_alias: None,
 			empty_result: false,
 			from_subquery_sql: None,
+			from_subquery_statement: None,
 			select_for_update: None,
 		}
 	}
@@ -3192,6 +3212,15 @@ where
 		// Apply the builder to configure the subquery
 		let configured_subquery = builder(subquery_qs);
 		let empty_result = configured_subquery.empty_result;
+		let subquery_statement = SubqueryStatements {
+			postgres: configured_subquery.build_select_statement_for_backend(
+				crate::backends::types::DatabaseType::Postgres,
+			)?,
+			mysql: configured_subquery
+				.build_select_statement_for_backend(crate::backends::types::DatabaseType::Mysql)?,
+			sqlite: configured_subquery
+				.build_select_statement_for_backend(crate::backends::types::DatabaseType::Sqlite)?,
+		};
 		// Generate SQL for the subquery (wrapped in parentheses)
 		let subquery_sql = configured_subquery.as_subquery_sql()?;
 
@@ -3226,6 +3255,7 @@ where
 			from_alias: Some(alias.to_string()),
 			empty_result,
 			from_subquery_sql: Some(subquery_sql),
+			from_subquery_statement: Some(subquery_statement),
 			select_for_update: None,
 		})
 	}
@@ -4737,6 +4767,18 @@ where
 			stmt.from_as(Alias::new(T::table_name()), Alias::new(alias));
 		} else {
 			stmt.from(Alias::new(T::table_name()));
+		}
+	}
+
+	fn apply_model_from_for_backend(
+		&self,
+		stmt: &mut SelectStatement,
+		backend: crate::backends::types::DatabaseType,
+	) {
+		if let (Some(subquery), Some(alias)) = (&self.from_subquery_statement, &self.from_alias) {
+			stmt.from_subquery(subquery.for_backend(backend).clone(), Alias::new(alias));
+		} else {
+			self.apply_model_from(stmt);
 		}
 	}
 
@@ -10255,7 +10297,7 @@ where
 		Ok(self.as_subquery_sql()?.postgres)
 	}
 
-	fn as_subquery_sql(self) -> reinhardt_core::exception::Result<SubquerySql> {
+	fn as_subquery_sql(&self) -> reinhardt_core::exception::Result<SubquerySql> {
 		Ok(SubquerySql {
 			postgres: format!(
 				"({})",
@@ -12406,8 +12448,10 @@ mod tests {
 		}
 	}
 
-	#[test]
+	#[rstest]
 	fn from_subquery_renders_backend_specific_derived_source() {
+		use reinhardt_query::prelude::{PostgresQueryBuilder, QueryStatementBuilder};
+
 		let queryset = QuerySet::<TestUser>::from_subquery(
 			|subquery: QuerySet<TestUser>| subquery,
 			"scoped_users",
@@ -12425,6 +12469,16 @@ mod tests {
 				.to_sql_for_backend(crate::backends::types::DatabaseType::Mysql)
 				.expect("MySQL SQL should compile"),
 			r#"SELECT * FROM (SELECT * FROM `test_users`) AS `scoped_users`"#
+		);
+
+		let statement = queryset
+			.build_full_model_select_statement_for_backend(
+				crate::backends::types::DatabaseType::Postgres,
+			)
+			.expect("derived model-shaped source should compile");
+		assert_eq!(
+			statement.to_string(PostgresQueryBuilder),
+			r#"SELECT * FROM (SELECT * FROM "test_users") AS "scoped_users""#
 		);
 	}
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1985,6 +1985,42 @@ where
 		Ok(stmt.to_owned())
 	}
 
+	/// Builds a model-shaped SELECT for execution by a configured [`Session`].
+	///
+	/// A session decodes one complete model from every selected row, so querysets
+	/// that change the projection or result shape are rejected instead of being
+	/// silently decoded as a different model.
+	pub(crate) fn build_full_model_select_statement(
+		&self,
+	) -> reinhardt_core::exception::Result<SelectStatement> {
+		if self.selected_fields.is_some()
+			|| !self.deferred_fields.is_empty()
+			|| !self.annotations.is_empty()
+			|| !self.backend_annotations.is_empty()
+			|| !self.typed_annotations.is_empty()
+			|| !self.select_related_fields.is_empty()
+			|| !self.typed_select_related.is_empty()
+			|| !self.prefetch_related_fields.is_empty()
+			|| !self.typed_prefetch_related.is_empty()
+			|| !self.ctes.is_empty()
+			|| !self.lateral_joins.is_empty()
+			|| !self.joins.is_empty()
+			|| !self.group_by_fields.is_empty()
+			|| !self.typed_havings.is_empty()
+			|| self.from_alias.is_some()
+			|| self.from_subquery_sql.is_some()
+		{
+			return Err(reinhardt_core::exception::Error::from(
+				reinhardt_core::exception::DatabaseError::new(
+					reinhardt_core::exception::DatabaseErrorKind::Query,
+					"Session::list requires a model-shaped QuerySet",
+				),
+			));
+		}
+
+		self.build_select_statement()
+	}
+
 	fn ensure_explainable_shape(&self) -> reinhardt_core::exception::Result<()> {
 		if !self.ctes.is_empty()
 			|| !self.lateral_joins.is_empty()

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1914,7 +1914,7 @@ where
 	empty_result: bool,
 	/// Subquery SQL for FROM clause (derived table)
 	/// When set, the FROM clause will use this subquery instead of the model's table
-	from_subquery_sql: Option<String>,
+	from_subquery_sql: Option<SubquerySql>,
 	select_for_update: Option<SelectForUpdateSpec>,
 }
 
@@ -2566,7 +2566,9 @@ where
 		Ok(())
 	}
 
-	fn ensure_not_locking_without_transaction(&self) -> reinhardt_core::exception::Result<()> {
+	pub(crate) fn ensure_not_locking_without_transaction(
+		&self,
+	) -> reinhardt_core::exception::Result<()> {
 		if self.select_for_update.is_some() {
 			return Err(DatabaseError::new(
 				DatabaseErrorKind::Transaction,
@@ -3191,7 +3193,7 @@ where
 		let configured_subquery = builder(subquery_qs);
 		let empty_result = configured_subquery.empty_result;
 		// Generate SQL for the subquery (wrapped in parentheses)
-		let subquery_sql = configured_subquery.as_subquery()?;
+		let subquery_sql = configured_subquery.as_subquery_sql()?;
 
 		// Create a new QuerySet with the subquery as FROM source
 		Ok(Self {
@@ -9852,11 +9854,21 @@ where
 		if let Some(ref subquery_sql) = self.from_subquery_sql
 			&& let Some(ref alias) = self.from_alias
 		{
-			// Pattern: FROM "table_name" AS "alias" or FROM "table_name"
-			let from_pattern_with_alias = format!("FROM \"{}\" AS \"{}\"", T::table_name(), alias);
-			let from_pattern_simple = format!("FROM \"{}\"", T::table_name());
+			let quote = match backend {
+				crate::backends::types::DatabaseType::Mysql => '`',
+				crate::backends::types::DatabaseType::Postgres
+				| crate::backends::types::DatabaseType::Sqlite => '"',
+			};
+			let from_pattern_with_alias = format!(
+				"FROM {quote}{}{quote} AS {quote}{alias}{quote}",
+				T::table_name()
+			);
+			let from_pattern_simple = format!("FROM {quote}{}{quote}", T::table_name());
 
-			let from_replacement = format!("FROM {} AS \"{}\"", subquery_sql, alias);
+			let from_replacement = format!(
+				"FROM {} AS {quote}{alias}{quote}",
+				subquery_sql.for_backend(backend)
+			);
 
 			// Try to replace with alias pattern first, then simple pattern
 			if select_sql.contains(&from_pattern_with_alias) {
@@ -12392,6 +12404,28 @@ mod tests {
 		fn generated_field_names() -> &'static [&'static str] {
 			&["full_name", "display_name"]
 		}
+	}
+
+	#[test]
+	fn from_subquery_renders_backend_specific_derived_source() {
+		let queryset = QuerySet::<TestUser>::from_subquery(
+			|subquery: QuerySet<TestUser>| subquery,
+			"scoped_users",
+		)
+		.expect("derived source should compile");
+
+		assert_eq!(
+			queryset
+				.to_sql_for_backend(crate::backends::types::DatabaseType::Postgres)
+				.expect("PostgreSQL SQL should compile"),
+			r#"SELECT * FROM (SELECT * FROM "test_users") AS "scoped_users""#
+		);
+		assert_eq!(
+			queryset
+				.to_sql_for_backend(crate::backends::types::DatabaseType::Mysql)
+				.expect("MySQL SQL should compile"),
+			r#"SELECT * FROM (SELECT * FROM `test_users`) AS `scoped_users`"#
+		);
 	}
 
 	struct ExplainRecordingExecutor {

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -2009,7 +2009,6 @@ where
 			|| !self.typed_prefetch_related.is_empty()
 			|| !self.ctes.is_empty()
 			|| !self.lateral_joins.is_empty()
-			|| !self.joins.is_empty()
 			|| !self.group_by_fields.is_empty()
 			|| !self.typed_havings.is_empty()
 			|| self.from_subquery_sql.is_some()
@@ -2922,6 +2921,11 @@ where
 	/// Returns composite filter conditions applied to this `QuerySet`.
 	pub fn filter_conditions(&self) -> &[FilterCondition] {
 		&self.filter_conditions
+	}
+
+	/// Returns whether this queryset contains an authorization subquery.
+	pub fn has_subquery_conditions(&self) -> bool {
+		!self.subquery_conditions.is_empty()
 	}
 
 	/// Add row-locking clauses to subqueries used as authorization predicates.
@@ -14537,7 +14541,7 @@ mod tests {
 		assert!(sql.contains(r#""test_users"."id" NOT IN (SELECT "id" FROM "test_projects")"#));
 	}
 
-	#[test]
+	#[rstest]
 	fn lock_scope_subqueries_locks_every_authorization_subquery() {
 		let mut queryset = QuerySet::<TestUser>::new()
 			.filter_in_subquery("id", |queryset: QuerySet<TestUser>| queryset)
@@ -14548,12 +14552,26 @@ mod tests {
 			.expect("EXISTS subquery should compile")
 			.filter_not_exists(|queryset: QuerySet<TestUser>| queryset)
 			.expect("NOT EXISTS subquery should compile");
+		assert!(queryset.has_subquery_conditions());
 
 		queryset.lock_scope_subqueries();
 
 		assert_eq!(
 			queryset.to_sql().expect("query SQL should compile"),
 			r#"SELECT * FROM "test_users" WHERE ("id" IN (SELECT * FROM "test_users" FOR UPDATE) AND "id" NOT IN (SELECT * FROM "test_users" FOR UPDATE) AND EXISTS (SELECT * FROM "test_users" FOR UPDATE) AND NOT EXISTS (SELECT * FROM "test_users" FOR UPDATE))"#
+		);
+	}
+
+	#[rstest]
+	fn model_shaped_queryset_accepts_manual_joins() {
+		let statement = QuerySet::<TestUser>::new()
+			.inner_join_on::<TestProject>("test_users.id = test_projects.user_id")
+			.build_full_model_select_statement()
+			.expect("manual joins should preserve a model-shaped projection");
+
+		assert_eq!(
+			statement.to_string(PostgresQueryBuilder),
+			r#"SELECT * FROM "test_users" INNER JOIN "test_projects" ON test_users.id = test_projects.user_id"#
 		);
 	}
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -2008,7 +2008,6 @@ where
 			|| !self.joins.is_empty()
 			|| !self.group_by_fields.is_empty()
 			|| !self.typed_havings.is_empty()
-			|| self.from_alias.is_some()
 			|| self.from_subquery_sql.is_some()
 		{
 			return Err(reinhardt_core::exception::Error::from(
@@ -4559,6 +4558,15 @@ where
 
 	pub(crate) fn root_alias(&self) -> &str {
 		self.from_alias.as_deref().unwrap_or(T::table_name())
+	}
+
+	pub(crate) fn inner_relation_aliases_for_lock(&self) -> Vec<String> {
+		self.filter_relation_join_graph_for_query()
+			.joins()
+			.iter()
+			.filter(|join| join.join_kind == RelationJoinKind::Inner)
+			.map(|join| join.alias.clone())
+			.collect()
 	}
 
 	fn apply_model_from(&self, stmt: &mut SelectStatement) {

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -4647,13 +4647,9 @@ where
 			.filter(|join| join.join_kind == RelationJoinKind::Inner)
 			.map(|join| join.alias.clone())
 			.collect::<Vec<_>>();
-		aliases.extend(self.joins.iter().filter_map(|join| {
-			matches!(join.join_type, super::sqlalchemy_query::JoinType::Inner).then(|| {
-				join.target_alias
+		aliases.extend(self.joins.iter().filter(|&join| matches!(join.join_type, super::sqlalchemy_query::JoinType::Inner)).map(|join| join.target_alias
 					.clone()
-					.unwrap_or_else(|| join.target_table.clone())
-			})
-		}));
+					.unwrap_or_else(|| join.target_table.clone())));
 		aliases.sort_unstable();
 		aliases.dedup();
 		aliases

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -4694,9 +4694,16 @@ where
 			.filter(|join| join.join_kind == RelationJoinKind::Inner)
 			.map(|join| join.alias.clone())
 			.collect::<Vec<_>>();
-		aliases.extend(self.joins.iter().filter(|&join| matches!(join.join_type, super::sqlalchemy_query::JoinType::Inner)).map(|join| join.target_alias
-					.clone()
-					.unwrap_or_else(|| join.target_table.clone())));
+		aliases.extend(
+			self.joins
+				.iter()
+				.filter(|&join| matches!(join.join_type, super::sqlalchemy_query::JoinType::Inner))
+				.map(|join| {
+					join.target_alias
+						.clone()
+						.unwrap_or_else(|| join.target_table.clone())
+				}),
+		);
 		aliases.sort_unstable();
 		aliases.dedup();
 		aliases

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1921,6 +1921,10 @@ where
 		self
 	}
 
+	pub(crate) fn is_empty_result(&self) -> bool {
+		self.empty_result
+	}
+
 	fn executor_backend(
 		executor: &dyn super::connection::TransactionExecutor,
 	) -> super::connection::DatabaseBackend {
@@ -2329,7 +2333,7 @@ where
 		stmt.lock_tables(aliases.map(Alias::new));
 	}
 
-	fn validate_select_for_update(
+	pub(crate) fn validate_select_for_update(
 		&self,
 		capabilities: crate::backends::types::RowLockCapabilities,
 		backend: crate::backends::types::DatabaseType,
@@ -4566,6 +4570,21 @@ where
 			.iter()
 			.filter(|join| join.join_kind == RelationJoinKind::Inner)
 			.map(|join| join.alias.clone())
+			.collect()
+	}
+
+	pub(crate) fn nullable_filter_relations_for_lock(&self) -> Vec<(String, String, String)> {
+		self.filter_relation_join_graph_for_query()
+			.joins()
+			.iter()
+			.filter(|join| join.join_kind == RelationJoinKind::Left)
+			.map(|join| {
+				(
+					join.target_table.clone(),
+					join.alias.clone(),
+					join.target_column.clone(),
+				)
+			})
 			.collect()
 	}
 
@@ -13958,6 +13977,20 @@ mod tests {
 			r#"LEFT JOIN "test_projects" AS "corpus_file__project__project" ON "corpus_file"."project_id" = "corpus_file__project__project"."id""#
 		));
 		assert!(sql.ends_with(r#"WHERE "corpus_file__project__project"."name" = 'reinhardt'"#));
+	}
+
+	#[rstest]
+	fn nullable_filter_relations_for_lock_tracks_outer_join_targets() {
+		let queryset = QuerySet::<TestUser>::new().filter(nested_project_name_filter());
+
+		assert_eq!(
+			queryset.nullable_filter_relations_for_lock(),
+			vec![(
+				"test_projects".to_owned(),
+				"corpus_file__project".to_owned(),
+				"id".to_owned(),
+			)]
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1933,6 +1933,8 @@ where
 	/// When set, the FROM clause will use this subquery instead of the model's table
 	from_subquery_sql: Option<SubquerySql>,
 	from_subquery_statement: Option<SubqueryStatements>,
+	/// Whether the derived source selects a complete model-shaped row.
+	from_subquery_model_shaped: Option<bool>,
 	select_for_update: Option<SelectForUpdateSpec>,
 }
 
@@ -1973,6 +1975,7 @@ where
 			empty_result: false,
 			from_subquery_sql: None,
 			from_subquery_statement: None,
+			from_subquery_model_shaped: None,
 			select_for_update: None,
 		}
 	}
@@ -2079,21 +2082,7 @@ where
 		&self,
 		backend: crate::backends::types::DatabaseType,
 	) -> reinhardt_core::exception::Result<SelectStatement> {
-		if self.selected_fields.is_some()
-			|| !self.selected_expressions.is_empty()
-			|| !self.deferred_fields.is_empty()
-			|| !self.annotations.is_empty()
-			|| !self.backend_annotations.is_empty()
-			|| !self.typed_annotations.is_empty()
-			|| !self.select_related_fields.is_empty()
-			|| !self.typed_select_related.is_empty()
-			|| !self.prefetch_related_fields.is_empty()
-			|| !self.typed_prefetch_related.is_empty()
-			|| !self.ctes.is_empty()
-			|| !self.lateral_joins.is_empty()
-			|| !self.group_by_fields.is_empty()
-			|| !self.typed_havings.is_empty()
-		{
+		if !self.is_model_shaped_source() {
 			return Err(reinhardt_core::exception::Error::from(
 				reinhardt_core::exception::DatabaseError::new(
 					reinhardt_core::exception::DatabaseErrorKind::Query,
@@ -2103,6 +2092,36 @@ where
 		}
 
 		self.build_select_statement_for_backend(backend)
+	}
+
+	fn is_model_shaped_source(&self) -> bool {
+		self.selected_fields.is_none()
+			&& self.selected_expressions.is_empty()
+			&& self.deferred_fields.is_empty()
+			&& self.annotations.is_empty()
+			&& self.backend_annotations.is_empty()
+			&& self.typed_annotations.is_empty()
+			&& self.select_related_fields.is_empty()
+			&& self.typed_select_related.is_empty()
+			&& self.prefetch_related_fields.is_empty()
+			&& self.typed_prefetch_related.is_empty()
+			&& self.ctes.is_empty()
+			&& self.lateral_joins.is_empty()
+			&& self.group_by_fields.is_empty()
+			&& self.typed_havings.is_empty()
+			&& (self.from_subquery_sql.is_none() || self.from_subquery_model_shaped == Some(true))
+	}
+
+	pub(crate) fn validate_row_lock_source(
+		&self,
+	) -> Result<(), crate::backends::error::DatabaseError> {
+		if self.from_subquery_sql.is_some() {
+			return Err(DatabaseError::new(
+				DatabaseErrorKind::Unsupported,
+				"SELECT FOR UPDATE does not support derived table sources",
+			));
+		}
+		Ok(())
 	}
 
 	fn ensure_explainable_shape(&self) -> reinhardt_core::exception::Result<()> {
@@ -2427,12 +2446,7 @@ where
 				"SELECT FOR UPDATE does not support CTE-backed querysets",
 			));
 		}
-		if self.from_subquery_sql.is_some() {
-			return Err(DatabaseError::new(
-				DatabaseErrorKind::Unsupported,
-				"SELECT FOR UPDATE does not support derived table sources",
-			));
-		}
+		self.validate_row_lock_source()?;
 		if !self.lateral_joins.is_empty() {
 			return Err(DatabaseError::new(
 				DatabaseErrorKind::Unsupported,
@@ -2962,6 +2976,7 @@ where
 			empty_result: false,
 			from_subquery_sql: None,
 			from_subquery_statement: None,
+			from_subquery_model_shaped: None,
 			select_for_update: None,
 		}
 	}
@@ -3031,7 +3046,9 @@ where
 	/// shape need serializable isolation so a concurrent scope change cannot
 	/// occur between the authorization recheck and the write.
 	pub fn requires_serializable_transaction(&self) -> bool {
-		self.has_subquery_conditions() || !self.joins.is_empty()
+		self.has_subquery_conditions()
+			|| !self.joins.is_empty()
+			|| !self.relation_join_graph_for_query().is_empty()
 	}
 
 	/// Add row-locking clauses to subqueries used as authorization predicates.
@@ -3221,6 +3238,7 @@ where
 			sqlite: configured_subquery
 				.build_select_statement_for_backend(crate::backends::types::DatabaseType::Sqlite)?,
 		};
+		let subquery_model_shaped = configured_subquery.is_model_shaped_source();
 		// Generate SQL for the subquery (wrapped in parentheses)
 		let subquery_sql = configured_subquery.as_subquery_sql()?;
 
@@ -3256,6 +3274,7 @@ where
 			empty_result,
 			from_subquery_sql: Some(subquery_sql),
 			from_subquery_statement: Some(subquery_statement),
+			from_subquery_model_shaped: Some(subquery_model_shaped),
 			select_for_update: None,
 		})
 	}
@@ -12482,6 +12501,24 @@ mod tests {
 		);
 	}
 
+	#[rstest]
+	fn model_shaped_session_rejects_projected_derived_source() {
+		let queryset = QuerySet::<TestUser>::from_subquery(
+			|subquery: QuerySet<TestUser>| subquery.values(&["id"]),
+			"scoped_users",
+		)
+		.expect("derived source should compile");
+
+		let error = queryset
+			.build_full_model_select_statement()
+			.expect_err("projected derived source must not be decoded as a model");
+
+		assert_eq!(
+			error.to_string(),
+			"Database error: Session::list requires a model-shaped QuerySet"
+		);
+	}
+
 	struct ExplainRecordingExecutor {
 		backend: DatabaseBackend,
 		is_cockroachdb: bool,
@@ -14282,6 +14319,7 @@ mod tests {
 	fn nullable_filter_relations_for_lock_tracks_outer_join_targets() {
 		let queryset = QuerySet::<TestUser>::new().filter(nested_project_name_filter());
 
+		assert_eq!(queryset.requires_serializable_transaction(), true);
 		assert_eq!(
 			queryset.nullable_filter_relations_for_lock(),
 			vec![(

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1349,20 +1349,57 @@ enum SubqueryCondition {
 	/// Example: WHERE author_id IN (SELECT id FROM authors WHERE name = 'John')
 	In {
 		field: String,
-		subquery: String,
+		subquery: SubquerySql,
 		lockable: bool,
 	},
 	/// WHERE field NOT IN (subquery)
 	NotIn {
 		field: String,
-		subquery: String,
+		subquery: SubquerySql,
 		lockable: bool,
 	},
 	/// WHERE EXISTS (subquery)
 	/// Example: WHERE EXISTS (SELECT 1 FROM books WHERE author_id = authors.id)
-	Exists { subquery: String, lockable: bool },
+	Exists {
+		subquery: SubquerySql,
+		lockable: bool,
+	},
 	/// WHERE NOT EXISTS (subquery)
-	NotExists { subquery: String, lockable: bool },
+	NotExists {
+		subquery: SubquerySql,
+		lockable: bool,
+	},
+}
+
+#[derive(Clone, Debug)]
+struct SubquerySql {
+	postgres: String,
+	mysql: String,
+	sqlite: String,
+}
+
+impl SubquerySql {
+	fn for_backend(&self, backend: crate::backends::types::DatabaseType) -> &str {
+		match backend {
+			crate::backends::types::DatabaseType::Postgres => &self.postgres,
+			crate::backends::types::DatabaseType::Mysql => &self.mysql,
+			crate::backends::types::DatabaseType::Sqlite => &self.sqlite,
+		}
+	}
+
+	fn add_lock(&mut self) {
+		fn append_lock(sql: &str) -> String {
+			let trimmed = sql.trim_end();
+			trimmed.strip_suffix(')').map_or_else(
+				|| format!("{trimmed} FOR UPDATE"),
+				|inner| format!("{inner} FOR UPDATE)"),
+			)
+		}
+
+		self.postgres = append_lock(&self.postgres);
+		self.mysql = append_lock(&self.mysql);
+		self.sqlite = append_lock(&self.sqlite);
+	}
 }
 
 const MAX_FILTER_CONDITION_DEPTH: usize = 64;
@@ -1950,8 +1987,17 @@ where
 	}
 
 	fn build_select_statement(&self) -> reinhardt_core::exception::Result<SelectStatement> {
+		self.build_select_statement_for_backend(crate::backends::types::DatabaseType::Postgres)
+	}
+
+	fn build_select_statement_for_backend(
+		&self,
+		backend: crate::backends::types::DatabaseType,
+	) -> reinhardt_core::exception::Result<SelectStatement> {
 		if self.has_select_related() {
-			return self.select_related_query();
+			return self.select_related_query_with_condition(
+				self.build_where_condition_for_backend(backend)?,
+			);
 		}
 
 		let mut stmt = Query::select();
@@ -1981,7 +2027,7 @@ where
 		self.apply_relation_joins(&mut stmt);
 		self.apply_manual_joins(&mut stmt);
 
-		if let Some(condition) = self.build_where_condition()? {
+		if let Some(condition) = self.build_where_condition_for_backend(backend)? {
 			stmt.cond_where(condition);
 		}
 		self.apply_typed_annotation_grouping(&mut stmt)?;
@@ -2004,6 +2050,15 @@ where
 	/// silently decoded as a different model.
 	pub(crate) fn build_full_model_select_statement(
 		&self,
+	) -> reinhardt_core::exception::Result<SelectStatement> {
+		self.build_full_model_select_statement_for_backend(
+			crate::backends::types::DatabaseType::Postgres,
+		)
+	}
+
+	pub(crate) fn build_full_model_select_statement_for_backend(
+		&self,
+		backend: crate::backends::types::DatabaseType,
 	) -> reinhardt_core::exception::Result<SelectStatement> {
 		if self.selected_fields.is_some()
 			|| !self.selected_expressions.is_empty()
@@ -2029,7 +2084,7 @@ where
 			));
 		}
 
-		self.build_select_statement()
+		self.build_select_statement_for_backend(backend)
 	}
 
 	fn ensure_explainable_shape(&self) -> reinhardt_core::exception::Result<()> {
@@ -2964,14 +3019,6 @@ where
 	/// same transaction connection so the scope cannot change between the
 	/// recheck and the subsequent write.
 	pub(crate) fn lock_scope_subqueries(&mut self) {
-		fn add_lock(sql: &str) -> String {
-			let trimmed = sql.trim_end();
-			trimmed.strip_suffix(')').map_or_else(
-				|| format!("{trimmed} FOR UPDATE"),
-				|inner| format!("{inner} FOR UPDATE)"),
-			)
-		}
-
 		for condition in &mut self.subquery_conditions {
 			match condition {
 				SubqueryCondition::In {
@@ -2984,7 +3031,7 @@ where
 				| SubqueryCondition::NotExists { subquery, lockable }
 					if *lockable =>
 				{
-					*subquery = add_lock(subquery);
+					subquery.add_lock();
 				}
 				_ => {}
 			}
@@ -4224,7 +4271,7 @@ where
 	{
 		let subquery_qs = subquery_fn(QuerySet::<R>::new());
 		let lockable = subquery_qs.supports_scope_subquery_row_lock();
-		let subquery_sql = subquery_qs.as_subquery()?;
+		let subquery_sql = subquery_qs.as_subquery_sql()?;
 
 		self.subquery_conditions.push(SubqueryCondition::In {
 			field: field.to_string(),
@@ -4299,7 +4346,7 @@ where
 	{
 		let subquery_qs = subquery_fn(QuerySet::<R>::new());
 		let lockable = subquery_qs.supports_scope_subquery_row_lock();
-		let subquery_sql = subquery_qs.as_subquery()?;
+		let subquery_sql = subquery_qs.as_subquery_sql()?;
 
 		self.subquery_conditions.push(SubqueryCondition::NotIn {
 			field: field.to_string(),
@@ -4374,7 +4421,7 @@ where
 	{
 		let subquery_qs = subquery_fn(QuerySet::<R>::new());
 		let lockable = subquery_qs.supports_scope_subquery_row_lock();
-		let subquery_sql = subquery_qs.as_subquery()?;
+		let subquery_sql = subquery_qs.as_subquery_sql()?;
 
 		self.subquery_conditions.push(SubqueryCondition::Exists {
 			subquery: subquery_sql,
@@ -4448,7 +4495,7 @@ where
 	{
 		let subquery_qs = subquery_fn(QuerySet::<R>::new());
 		let lockable = subquery_qs.supports_scope_subquery_row_lock();
-		let subquery_sql = subquery_qs.as_subquery()?;
+		let subquery_sql = subquery_qs.as_subquery_sql()?;
 
 		self.subquery_conditions.push(SubqueryCondition::NotExists {
 			subquery: subquery_sql,
@@ -4890,11 +4937,15 @@ where
 		}
 	}
 
-	fn root_column_sql(&self, field: &str) -> String {
+	fn root_column_sql_for_backend(
+		&self,
+		field: &str,
+		backend: crate::backends::types::DatabaseType,
+	) -> String {
 		if !self.expression_relation_join_graph_for_query().is_empty() && !field.contains('.') {
-			quote_identifier(&format!("{}.{}", self.root_alias(), field))
+			quote_identifier_for_backend(&format!("{}.{}", self.root_alias(), field), backend)
 		} else {
-			quote_identifier(field)
+			quote_identifier_for_backend(field, backend)
 		}
 	}
 
@@ -5089,6 +5140,13 @@ where
 
 	/// Build WHERE condition using reinhardt-query from accumulated filters
 	fn build_where_condition(&self) -> reinhardt_core::exception::Result<Option<Condition>> {
+		self.build_where_condition_for_backend(crate::backends::types::DatabaseType::Postgres)
+	}
+
+	fn build_where_condition_for_backend(
+		&self,
+		backend: crate::backends::types::DatabaseType,
+	) -> reinhardt_core::exception::Result<Option<Condition>> {
 		if self.empty_result {
 			return Ok(Some(Condition::all().add(Expr::val(1).eq(0))));
 		}
@@ -5599,8 +5657,12 @@ where
 					field, subquery, ..
 				} => {
 					// field IN (subquery)
-					Expr::cust(format!("{} IN {}", self.root_column_sql(field), subquery))
-						.into_simple_expr()
+					Expr::cust(format!(
+						"{} IN {}",
+						self.root_column_sql_for_backend(field, backend),
+						subquery.for_backend(backend)
+					))
+					.into_simple_expr()
 				}
 				SubqueryCondition::NotIn {
 					field, subquery, ..
@@ -5608,18 +5670,20 @@ where
 					// field NOT IN (subquery)
 					Expr::cust(format!(
 						"{} NOT IN {}",
-						self.root_column_sql(field),
-						subquery
+						self.root_column_sql_for_backend(field, backend),
+						subquery.for_backend(backend)
 					))
 					.into_simple_expr()
 				}
 				SubqueryCondition::Exists { subquery, .. } => {
 					// EXISTS (subquery)
-					Expr::cust(format!("EXISTS {}", subquery)).into_simple_expr()
+					Expr::cust(format!("EXISTS {}", subquery.for_backend(backend)))
+						.into_simple_expr()
 				}
 				SubqueryCondition::NotExists { subquery, .. } => {
 					// NOT EXISTS (subquery)
-					Expr::cust(format!("NOT EXISTS {}", subquery)).into_simple_expr()
+					Expr::cust(format!("NOT EXISTS {}", subquery.for_backend(backend)))
+						.into_simple_expr()
 				}
 			};
 
@@ -9638,6 +9702,13 @@ where
 
 	/// Converts to sql.
 	pub fn to_sql(&self) -> reinhardt_core::exception::Result<String> {
+		self.to_sql_for_backend(crate::backends::types::DatabaseType::Postgres)
+	}
+
+	fn to_sql_for_backend(
+		&self,
+		backend: crate::backends::types::DatabaseType,
+	) -> reinhardt_core::exception::Result<String> {
 		let mut stmt = if !self.has_select_related() {
 			// Simple SELECT without JOINs
 			let mut stmt = Query::select();
@@ -9717,7 +9788,7 @@ where
 			}
 
 			// Apply WHERE conditions
-			if let Some(cond) = self.build_where_condition()? {
+			if let Some(cond) = self.build_where_condition_for_backend(backend)? {
 				stmt.cond_where(cond);
 			}
 			// Apply GROUP BY
@@ -9744,15 +9815,20 @@ where
 			stmt.to_owned()
 		} else {
 			// SELECT with JOINs for select_related
-			self.select_related_query_with_condition(self.build_where_condition()?)?
+			self.select_related_query_with_condition(
+				self.build_where_condition_for_backend(backend)?,
+			)?
 		};
 
 		if !self.has_select_related() {
 			self.apply_annotations_to_select(&mut stmt);
 		}
 
-		use reinhardt_query::prelude::PostgresQueryBuilder;
-		let mut select_sql = stmt.to_string(PostgresQueryBuilder);
+		let mut select_sql = match backend {
+			crate::backends::types::DatabaseType::Postgres => stmt.to_string(PostgresQueryBuilder),
+			crate::backends::types::DatabaseType::Mysql => stmt.to_string(MySqlQueryBuilder),
+			crate::backends::types::DatabaseType::Sqlite => stmt.to_string(SqliteQueryBuilder),
+		};
 
 		// Insert LATERAL JOIN clauses after FROM clause
 		if !self.lateral_joins.is_empty() {
@@ -10161,7 +10237,24 @@ where
 	/// // Generates: (SELECT * FROM posts WHERE published = $1)
 	/// ```
 	pub fn as_subquery(self) -> reinhardt_core::exception::Result<String> {
-		Ok(format!("({})", self.to_sql()?))
+		Ok(self.as_subquery_sql()?.postgres)
+	}
+
+	fn as_subquery_sql(self) -> reinhardt_core::exception::Result<SubquerySql> {
+		Ok(SubquerySql {
+			postgres: format!(
+				"({})",
+				self.to_sql_for_backend(crate::backends::types::DatabaseType::Postgres)?
+			),
+			mysql: format!(
+				"({})",
+				self.to_sql_for_backend(crate::backends::types::DatabaseType::Mysql)?
+			),
+			sqlite: format!(
+				"({})",
+				self.to_sql_for_backend(crate::backends::types::DatabaseType::Sqlite)?
+			),
+		})
 	}
 
 	/// Defer loading of specific fields
@@ -10587,6 +10680,25 @@ pub(crate) fn quote_identifier(field: &str) -> String {
 	}
 }
 
+fn quote_identifier_for_backend(
+	field: &str,
+	backend: crate::backends::types::DatabaseType,
+) -> String {
+	if backend != crate::backends::types::DatabaseType::Mysql {
+		return quote_identifier(field);
+	}
+
+	if field.contains('\0') {
+		panic!("SQL identifier must not contain null bytes");
+	}
+
+	field
+		.split('.')
+		.map(|name| format!("`{}`", name.replace('`', "``")))
+		.collect::<Vec<_>>()
+		.join(".")
+}
+
 /// Validates an annotation label using the same identifier policy as typed annotations.
 pub(crate) fn validate_annotation_label(label: &str) -> reinhardt_core::exception::Result<()> {
 	crate::orm::query_fields::expression::validate_label(label)
@@ -10916,8 +11028,8 @@ mod tests {
 	use reinhardt_query::{
 		QueryBuilder,
 		prelude::{
-			PostgresQueryBuilder, QueryStatementBuilder, SqliteQueryBuilder, TemporalTruncKind,
-			TemporalTruncOutput,
+			MySqlQueryBuilder, PostgresQueryBuilder, QueryStatementBuilder, SqliteQueryBuilder,
+			TemporalTruncKind, TemporalTruncOutput,
 		},
 	};
 	use rstest::rstest;
@@ -14625,6 +14737,25 @@ mod tests {
 			queryset.to_sql().expect("query SQL should compile"),
 			r#"SELECT * FROM "test_users" WHERE ("id" IN (SELECT * FROM "test_users" FOR UPDATE) AND "id" NOT IN (SELECT * FROM "test_users" FOR UPDATE) AND EXISTS (SELECT * FROM "test_users" FOR UPDATE) AND NOT EXISTS (SELECT * FROM "test_users" FOR UPDATE))"#
 		);
+	}
+
+	#[rstest]
+	fn mysql_scope_subquery_uses_mysql_identifier_quotes() {
+		let queryset = QuerySet::<TestUser>::new()
+			.filter_in_subquery("id", |queryset: QuerySet<TestUser>| {
+				queryset.values(&["id"])
+			})
+			.expect("IN subquery should compile");
+
+		let statement = queryset
+			.build_full_model_select_statement_for_backend(
+				crate::backends::types::DatabaseType::Mysql,
+			)
+			.expect("model-shaped subquery should compile");
+		let sql = statement.to_string(MySqlQueryBuilder);
+
+		assert!(sql.contains("(SELECT `id` FROM `test_users`)"), "{sql}");
+		assert!(!sql.contains("SELECT \"id\" FROM \"test_users\""), "{sql}");
 	}
 
 	#[rstest]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -2103,8 +2103,6 @@ where
 			&& self.typed_annotations.is_empty()
 			&& self.select_related_fields.is_empty()
 			&& self.typed_select_related.is_empty()
-			&& self.prefetch_related_fields.is_empty()
-			&& self.typed_prefetch_related.is_empty()
 			&& self.ctes.is_empty()
 			&& self.lateral_joins.is_empty()
 			&& self.group_by_fields.is_empty()
@@ -12516,6 +12514,20 @@ mod tests {
 		assert_eq!(
 			error.to_string(),
 			"Database error: Session::list requires a model-shaped QuerySet"
+		);
+	}
+
+	#[rstest]
+	fn model_shaped_session_accepts_prefetch_plan() {
+		let queryset = QuerySet::<TestUser>::new().prefetch_related(&["posts"]);
+
+		let statement = queryset
+			.build_full_model_select_statement()
+			.expect("prefetch configuration must not change the root model projection");
+
+		assert_eq!(
+			statement.to_string(PostgresQueryBuilder),
+			r#"SELECT * FROM "test_users""#
 		);
 	}
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1935,6 +1935,8 @@ where
 	from_subquery_statement: Option<SubqueryStatements>,
 	/// Whether the derived source selects a complete model-shaped row.
 	from_subquery_model_shaped: Option<bool>,
+	/// Rust model type used to build the derived source, when available.
+	from_subquery_model_type: Option<&'static str>,
 	select_for_update: Option<SelectForUpdateSpec>,
 }
 
@@ -1976,6 +1978,7 @@ where
 			from_subquery_sql: None,
 			from_subquery_statement: None,
 			from_subquery_model_shaped: None,
+			from_subquery_model_type: None,
 			select_for_update: None,
 		}
 	}
@@ -2107,7 +2110,9 @@ where
 			&& self.lateral_joins.is_empty()
 			&& self.group_by_fields.is_empty()
 			&& self.typed_havings.is_empty()
-			&& (self.from_subquery_sql.is_none() || self.from_subquery_model_shaped == Some(true))
+			&& (self.from_subquery_sql.is_none()
+				|| (self.from_subquery_model_shaped == Some(true)
+					&& self.from_subquery_model_type == Some(std::any::type_name::<T>())))
 	}
 
 	pub(crate) fn validate_row_lock_source(
@@ -2571,10 +2576,26 @@ where
 	}
 
 	fn supports_scope_subquery_row_lock(&self) -> bool {
+		let has_outer_join = self
+			.relation_join_graph_for_query()
+			.joins()
+			.iter()
+			.any(|join| join.join_kind == RelationJoinKind::Left)
+			|| !self.select_related_fields.is_empty()
+			|| self.joins.iter().any(|join| {
+				matches!(
+					join.join_type,
+					super::sqlalchemy_query::JoinType::Left
+						| super::sqlalchemy_query::JoinType::Right
+						| super::sqlalchemy_query::JoinType::Full
+				)
+			});
+
 		self.select_for_update.is_none()
 			&& self.ctes.is_empty()
 			&& self.from_subquery_sql.is_none()
 			&& self.lateral_joins.is_empty()
+			&& !has_outer_join
 			&& !self.distinct_enabled
 			&& self.group_by_fields.is_empty()
 			&& !self.has_typed_having()
@@ -2975,6 +2996,7 @@ where
 			from_subquery_sql: None,
 			from_subquery_statement: None,
 			from_subquery_model_shaped: None,
+			from_subquery_model_type: None,
 			select_for_update: None,
 		}
 	}
@@ -3273,6 +3295,7 @@ where
 			from_subquery_sql: Some(subquery_sql),
 			from_subquery_statement: Some(subquery_statement),
 			from_subquery_model_shaped: Some(subquery_model_shaped),
+			from_subquery_model_type: Some(std::any::type_name::<M>()),
 			select_for_update: None,
 		})
 	}

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -4659,6 +4659,12 @@ where
 		aliases
 	}
 
+	pub(crate) fn has_right_join(&self) -> bool {
+		self.joins
+			.iter()
+			.any(|join| matches!(join.join_type, super::sqlalchemy_query::JoinType::Right))
+	}
+
 	pub(crate) fn nullable_filter_relations_for_lock(&self) -> Vec<(String, String, String)> {
 		self.filter_relation_join_graph_for_query()
 			.joins()
@@ -14656,6 +14662,14 @@ mod tests {
 		let left_join_queryset = QuerySet::<TestUser>::new()
 			.left_join_on::<TestProject>("test_users.id = test_projects.user_id");
 		assert!(left_join_queryset.requires_serializable_transaction());
+	}
+
+	#[rstest]
+	fn model_shaped_queryset_tracks_right_joins_for_mutation_locking() {
+		let queryset = QuerySet::<TestUser>::new()
+			.right_join_on::<TestProject>("test_users.id = test_projects.user_id");
+
+		assert!(queryset.has_right_join());
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1994,6 +1994,7 @@ where
 		&self,
 	) -> reinhardt_core::exception::Result<SelectStatement> {
 		if self.selected_fields.is_some()
+			|| !self.selected_expressions.is_empty()
 			|| !self.deferred_fields.is_empty()
 			|| !self.annotations.is_empty()
 			|| !self.backend_annotations.is_empty()
@@ -4556,7 +4557,7 @@ where
 			.chain(self.lateral_joins.aliases())
 	}
 
-	fn root_alias(&self) -> &str {
+	pub(crate) fn root_alias(&self) -> &str {
 		self.from_alias.as_deref().unwrap_or(T::table_name())
 	}
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -2924,6 +2924,33 @@ where
 		&self.filter_conditions
 	}
 
+	/// Add row-locking clauses to subqueries used as authorization predicates.
+	///
+	/// The outer mutation recheck locks its model rows, but a scope expressed as
+	/// IN or EXISTS reads rows from a separate subquery. Lock those rows on the
+	/// same transaction connection so the scope cannot change between the
+	/// recheck and the subsequent write.
+	pub(crate) fn lock_scope_subqueries(&mut self) {
+		fn add_lock(sql: &str) -> String {
+			let trimmed = sql.trim_end();
+			trimmed.strip_suffix(')').map_or_else(
+				|| format!("{trimmed} FOR UPDATE"),
+				|inner| format!("{inner} FOR UPDATE)"),
+			)
+		}
+
+		for condition in &mut self.subquery_conditions {
+			match condition {
+				SubqueryCondition::In { subquery, .. }
+				| SubqueryCondition::NotIn { subquery, .. }
+				| SubqueryCondition::Exists { subquery }
+				| SubqueryCondition::NotExists { subquery } => {
+					*subquery = add_lock(subquery);
+				}
+			}
+		}
+	}
+
 	fn collect_condition_relation_joins(&mut self, condition: &FilterCondition) {
 		Self::collect_condition_relation_joins_at_depth(&mut self.relation_joins, condition, 0);
 	}
@@ -14508,6 +14535,26 @@ mod tests {
 
 		assert!(sql.contains(r#""test_users"."id" IN (SELECT "id" FROM "test_projects")"#));
 		assert!(sql.contains(r#""test_users"."id" NOT IN (SELECT "id" FROM "test_projects")"#));
+	}
+
+	#[test]
+	fn lock_scope_subqueries_locks_every_authorization_subquery() {
+		let mut queryset = QuerySet::<TestUser>::new()
+			.filter_in_subquery("id", |queryset: QuerySet<TestUser>| queryset)
+			.expect("IN subquery should compile")
+			.filter_not_in_subquery("id", |queryset: QuerySet<TestUser>| queryset)
+			.expect("NOT IN subquery should compile")
+			.filter_exists(|queryset: QuerySet<TestUser>| queryset)
+			.expect("EXISTS subquery should compile")
+			.filter_not_exists(|queryset: QuerySet<TestUser>| queryset)
+			.expect("NOT EXISTS subquery should compile");
+
+		queryset.lock_scope_subqueries();
+
+		assert_eq!(
+			queryset.to_sql().expect("query SQL should compile"),
+			r#"SELECT * FROM "test_users" WHERE ("id" IN (SELECT * FROM "test_users" FOR UPDATE) AND "id" NOT IN (SELECT * FROM "test_users" FOR UPDATE) AND EXISTS (SELECT * FROM "test_users" FOR UPDATE) AND NOT EXISTS (SELECT * FROM "test_users" FOR UPDATE))"#
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -1347,14 +1347,22 @@ struct JoinClause {
 enum SubqueryCondition {
 	/// WHERE field IN (subquery)
 	/// Example: WHERE author_id IN (SELECT id FROM authors WHERE name = 'John')
-	In { field: String, subquery: String },
+	In {
+		field: String,
+		subquery: String,
+		lockable: bool,
+	},
 	/// WHERE field NOT IN (subquery)
-	NotIn { field: String, subquery: String },
+	NotIn {
+		field: String,
+		subquery: String,
+		lockable: bool,
+	},
 	/// WHERE EXISTS (subquery)
 	/// Example: WHERE EXISTS (SELECT 1 FROM books WHERE author_id = authors.id)
-	Exists { subquery: String },
+	Exists { subquery: String, lockable: bool },
 	/// WHERE NOT EXISTS (subquery)
-	NotExists { subquery: String },
+	NotExists { subquery: String, lockable: bool },
 }
 
 const MAX_FILTER_CONDITION_DEPTH: usize = 64;
@@ -2477,6 +2485,17 @@ where
 				.any(super::postgres_features::BackendAnnotation::is_aggregate)
 	}
 
+	fn supports_scope_subquery_row_lock(&self) -> bool {
+		self.ctes.is_empty()
+			&& self.from_subquery_sql.is_none()
+			&& self.lateral_joins.is_empty()
+			&& !self.distinct_enabled
+			&& self.group_by_fields.is_empty()
+			&& !self.has_typed_having()
+			&& !self.has_raw_aggregate_projection()
+			&& !self.has_aggregate_annotation()
+	}
+
 	fn ensure_backend_annotations_supported(
 		&self,
 		backend: super::connection::DatabaseBackend,
@@ -2928,6 +2947,16 @@ where
 		!self.subquery_conditions.is_empty()
 	}
 
+	/// Returns whether a mutation needs serializable isolation for scope checks.
+	///
+	/// Authorization expressed through subqueries or manual joins is not fully
+	/// represented by the typed relation-lock graph. Mutations using either
+	/// shape need serializable isolation so a concurrent scope change cannot
+	/// occur between the authorization recheck and the write.
+	pub fn requires_serializable_transaction(&self) -> bool {
+		self.has_subquery_conditions() || !self.joins.is_empty()
+	}
+
 	/// Add row-locking clauses to subqueries used as authorization predicates.
 	///
 	/// The outer mutation recheck locks its model rows, but a scope expressed as
@@ -2945,12 +2974,19 @@ where
 
 		for condition in &mut self.subquery_conditions {
 			match condition {
-				SubqueryCondition::In { subquery, .. }
-				| SubqueryCondition::NotIn { subquery, .. }
-				| SubqueryCondition::Exists { subquery }
-				| SubqueryCondition::NotExists { subquery } => {
+				SubqueryCondition::In {
+					subquery, lockable, ..
+				}
+				| SubqueryCondition::NotIn {
+					subquery, lockable, ..
+				}
+				| SubqueryCondition::Exists { subquery, lockable }
+				| SubqueryCondition::NotExists { subquery, lockable }
+					if *lockable =>
+				{
 					*subquery = add_lock(subquery);
 				}
+				_ => {}
 			}
 		}
 	}
@@ -4187,11 +4223,13 @@ where
 		F: FnOnce(QuerySet<R>) -> QuerySet<R>,
 	{
 		let subquery_qs = subquery_fn(QuerySet::<R>::new());
+		let lockable = subquery_qs.supports_scope_subquery_row_lock();
 		let subquery_sql = subquery_qs.as_subquery()?;
 
 		self.subquery_conditions.push(SubqueryCondition::In {
 			field: field.to_string(),
 			subquery: subquery_sql,
+			lockable,
 		});
 
 		Ok(self)
@@ -4260,11 +4298,13 @@ where
 		F: FnOnce(QuerySet<R>) -> QuerySet<R>,
 	{
 		let subquery_qs = subquery_fn(QuerySet::<R>::new());
+		let lockable = subquery_qs.supports_scope_subquery_row_lock();
 		let subquery_sql = subquery_qs.as_subquery()?;
 
 		self.subquery_conditions.push(SubqueryCondition::NotIn {
 			field: field.to_string(),
 			subquery: subquery_sql,
+			lockable,
 		});
 
 		Ok(self)
@@ -4333,10 +4373,12 @@ where
 		F: FnOnce(QuerySet<R>) -> QuerySet<R>,
 	{
 		let subquery_qs = subquery_fn(QuerySet::<R>::new());
+		let lockable = subquery_qs.supports_scope_subquery_row_lock();
 		let subquery_sql = subquery_qs.as_subquery()?;
 
 		self.subquery_conditions.push(SubqueryCondition::Exists {
 			subquery: subquery_sql,
+			lockable,
 		});
 
 		Ok(self)
@@ -4405,10 +4447,12 @@ where
 		F: FnOnce(QuerySet<R>) -> QuerySet<R>,
 	{
 		let subquery_qs = subquery_fn(QuerySet::<R>::new());
+		let lockable = subquery_qs.supports_scope_subquery_row_lock();
 		let subquery_sql = subquery_qs.as_subquery()?;
 
 		self.subquery_conditions.push(SubqueryCondition::NotExists {
 			subquery: subquery_sql,
+			lockable,
 		});
 
 		Ok(self)
@@ -4596,12 +4640,23 @@ where
 	}
 
 	pub(crate) fn inner_relation_aliases_for_lock(&self) -> Vec<String> {
-		self.filter_relation_join_graph_for_query()
+		let mut aliases = self
+			.filter_relation_join_graph_for_query()
 			.joins()
 			.iter()
 			.filter(|join| join.join_kind == RelationJoinKind::Inner)
 			.map(|join| join.alias.clone())
-			.collect()
+			.collect::<Vec<_>>();
+		aliases.extend(self.joins.iter().filter_map(|join| {
+			matches!(join.join_type, super::sqlalchemy_query::JoinType::Inner).then(|| {
+				join.target_alias
+					.clone()
+					.unwrap_or_else(|| join.target_table.clone())
+			})
+		}));
+		aliases.sort_unstable();
+		aliases.dedup();
+		aliases
 	}
 
 	pub(crate) fn nullable_filter_relations_for_lock(&self) -> Vec<(String, String, String)> {
@@ -5534,12 +5589,16 @@ where
 		// Add subquery conditions
 		for subq_cond in &self.subquery_conditions {
 			let expr = match subq_cond {
-				SubqueryCondition::In { field, subquery } => {
+				SubqueryCondition::In {
+					field, subquery, ..
+				} => {
 					// field IN (subquery)
 					Expr::cust(format!("{} IN {}", self.root_column_sql(field), subquery))
 						.into_simple_expr()
 				}
-				SubqueryCondition::NotIn { field, subquery } => {
+				SubqueryCondition::NotIn {
+					field, subquery, ..
+				} => {
 					// field NOT IN (subquery)
 					Expr::cust(format!(
 						"{} NOT IN {}",
@@ -5548,11 +5607,11 @@ where
 					))
 					.into_simple_expr()
 				}
-				SubqueryCondition::Exists { subquery } => {
+				SubqueryCondition::Exists { subquery, .. } => {
 					// EXISTS (subquery)
 					Expr::cust(format!("EXISTS {}", subquery)).into_simple_expr()
 				}
-				SubqueryCondition::NotExists { subquery } => {
+				SubqueryCondition::NotExists { subquery, .. } => {
 					// NOT EXISTS (subquery)
 					Expr::cust(format!("NOT EXISTS {}", subquery)).into_simple_expr()
 				}
@@ -14563,9 +14622,29 @@ mod tests {
 	}
 
 	#[rstest]
+	fn lock_scope_subqueries_skips_non_lockable_distinct_subqueries() {
+		let mut queryset = QuerySet::<TestUser>::new()
+			.filter_in_subquery("id", |queryset: QuerySet<TestUser>| queryset.distinct())
+			.expect("IN subquery should compile");
+
+		queryset.lock_scope_subqueries();
+
+		let sql = queryset.to_sql().expect("query SQL should compile");
+		assert!(sql.contains(r#"SELECT DISTINCT * FROM "test_users""#));
+		assert!(!sql.contains("FOR UPDATE"));
+	}
+
+	#[rstest]
 	fn model_shaped_queryset_accepts_manual_joins() {
-		let statement = QuerySet::<TestUser>::new()
-			.inner_join_on::<TestProject>("test_users.id = test_projects.user_id")
+		let queryset = QuerySet::<TestUser>::new()
+			.inner_join_on::<TestProject>("test_users.id = test_projects.user_id");
+		assert!(queryset.requires_serializable_transaction());
+		assert_eq!(
+			queryset.inner_relation_aliases_for_lock(),
+			vec!["test_projects"]
+		);
+
+		let statement = queryset
 			.build_full_model_select_statement()
 			.expect("manual joins should preserve a model-shaped projection");
 
@@ -14573,6 +14652,10 @@ mod tests {
 			statement.to_string(PostgresQueryBuilder),
 			r#"SELECT * FROM "test_users" INNER JOIN "test_projects" ON test_users.id = test_projects.user_id"#
 		);
+
+		let left_join_queryset = QuerySet::<TestUser>::new()
+			.left_join_on::<TestProject>("test_users.id = test_projects.user_id");
+		assert!(left_join_queryset.requires_serializable_transaction());
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -956,9 +956,11 @@ impl Session {
 			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
 		let root_alias = queryset.root_alias().to_owned();
 		apply_any_model_projection::<T>(&mut statement, self.db_backend, &root_alias)?;
-		if lock_rows && self.db_backend == DbBackend::Postgres {
-			self.lock_nullable_relation_rows(queryset, &statement, connection)
-				.await?;
+		if lock_rows {
+			if self.db_backend == DbBackend::Postgres {
+				self.lock_nullable_relation_rows(queryset, &statement, connection)
+					.await?;
+			}
 			statement.clear_distinct();
 			statement.lock(LockType::Update);
 			if capabilities.targets {

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -95,6 +95,8 @@ struct IdentityEntry {
 	primary_key_field: String,
 	/// Resolved database column name for the primary key.
 	primary_key_column: String,
+	/// Physical columns and typed values that identify the tracked row.
+	primary_key_filters: Vec<(String, crate::orm::DatabaseValue)>,
 	/// Nullable JSON fields whose model value is `None` and must be written as SQL NULL.
 	sql_null_json_fields: HashSet<String>,
 	/// Database-generated columns that must be omitted from INSERT/UPDATE writes.
@@ -114,8 +116,7 @@ struct IdentityEntry {
 #[derive(Clone)]
 struct PendingDelete {
 	table_name: &'static str,
-	primary_key_column: String,
-	primary_key_value: crate::orm::DatabaseValue,
+	primary_key_filters: Vec<(String, crate::orm::DatabaseValue)>,
 }
 
 /// SQLAlchemy-style ORM session with identity map and unit of work
@@ -259,6 +260,11 @@ impl Session {
 			.map_err(|e| SessionError::SerializationError(e.to_string()))?;
 		let database_data = encode_model_database_data(&obj)?;
 		let field_metadata = T::field_metadata();
+		let primary_key_filters = if obj.primary_key().is_some() {
+			primary_key_filters_for_model::<T>(&field_metadata, &database_data)?
+		} else {
+			Vec::new()
+		};
 		let primary_key_field = T::primary_key_field().to_string();
 		let primary_key_column = primary_key_field_info(&field_metadata, T::primary_key_field())
 			.and_then(|field| field.db_column.clone())
@@ -280,6 +286,7 @@ impl Session {
 				field_metadata,
 				primary_key_field,
 				primary_key_column,
+				primary_key_filters,
 				sql_null_json_fields,
 				generated_fields: T::generated_field_names()
 					.iter()
@@ -576,6 +583,8 @@ impl Session {
 		let obj_data = serde_json::to_value(&obj)
 			.map_err(|e| SessionError::SerializationError(e.to_string()))?;
 		let database_data = encode_model_database_data(&obj)?;
+		let primary_key_filters =
+			primary_key_filters_for_model::<T>(&field_metadata, &database_data)?;
 
 		self.identity_map.insert(
 			key.clone(),
@@ -588,6 +597,7 @@ impl Session {
 				primary_key_column: primary_key_field_info(&field_metadata, T::primary_key_field())
 					.and_then(|field| field.db_column.clone())
 					.unwrap_or_else(|| T::primary_key_field().to_string()),
+				primary_key_filters,
 				sql_null_json_fields,
 				generated_fields: T::generated_field_names()
 					.iter()
@@ -922,7 +932,14 @@ impl Session {
 		if lock_rows && matches!(self.db_backend, DbBackend::Postgres | DbBackend::Mysql) {
 			statement.clear_distinct();
 			statement.lock(LockType::Update);
-			statement.lock_tables([Alias::new(root_alias)]);
+			let mut lock_tables = vec![Alias::new(root_alias)];
+			lock_tables.extend(
+				queryset
+					.inner_relation_aliases_for_lock()
+					.into_iter()
+					.map(Alias::new),
+			);
+			statement.lock_tables(lock_tables);
 		}
 		let (sql, values) = QueryStatement::Select(statement).build(self.db_backend);
 		let sql = sql_with_postgres_parameter_casts(self.db_backend, &sql, &values);
@@ -1035,21 +1052,16 @@ impl Session {
 		for key in &self.dirty_objects.clone() {
 			if let Some(entry) = self.identity_map.get(key) {
 				// Parse the identity key to get table name and primary key
-				let parts: Vec<&str> = key.split(':').collect();
-				if parts.len() != 2 {
+				let Some((table_name, _identity)) = key.split_once(':') else {
 					continue;
-				}
-				let table_name = parts[0];
+				};
 				let primary_key_field = entry.primary_key_field.clone();
 				let primary_key_column = entry.primary_key_column.clone();
 
 				{
 					let obj = &entry.database_data;
 					// Check if this is an INSERT (no primary key) or UPDATE (has primary key)
-					let has_pk = obj
-						.get(&primary_key_field)
-						.map(|value| !matches!(value, crate::orm::DatabaseValue::Null))
-						.unwrap_or(false);
+					let has_pk = !entry.primary_key_filters.is_empty();
 
 					if has_pk {
 						// UPDATE existing record
@@ -1087,12 +1099,12 @@ impl Session {
 							continue;
 						}
 
-						// Add WHERE clause for primary key
-						if let Some(pk_value) = obj.get(&primary_key_field) {
-							update_stmt
-								.and_where(Expr::col(Alias::new(&primary_key_column)).eq(
-									Expr::val(database_value_to_query_value(pk_value.clone())),
-								));
+						// Add WHERE clauses for every primary-key component.
+						for (column, value) in &entry.primary_key_filters {
+							update_stmt.and_where(
+								Expr::col(Alias::new(column))
+									.eq(Expr::val(database_value_to_query_value(value.clone()))),
+							);
 						}
 
 						// Build and execute SQL
@@ -1204,9 +1216,12 @@ impl Session {
 				.from_table(Alias::new(pending.table_name))
 				.to_owned();
 
-			delete_stmt.and_where(Expr::col(Alias::new(&pending.primary_key_column)).eq(
-				Expr::val(database_value_to_query_value(pending.primary_key_value)),
-			));
+			for (column, value) in &pending.primary_key_filters {
+				delete_stmt.and_where(
+					Expr::col(Alias::new(column))
+						.eq(Expr::val(database_value_to_query_value(value.clone()))),
+				);
+			}
 
 			// Build and execute SQL
 			let (sql, values) = match backend {
@@ -1255,6 +1270,10 @@ impl Session {
 				primary_key_field.to_string(),
 				crate::orm::DatabaseValue::I64(generated_id),
 			);
+			entry.primary_key_filters = vec![(
+				entry.primary_key_column.clone(),
+				crate::orm::DatabaseValue::I64(generated_id),
+			)];
 
 			entry.is_dirty = false;
 			let new_key = format!("{}:{}", table_name, generated_id);
@@ -1428,28 +1447,16 @@ impl Session {
 
 		let key = format!("{}:{}", T::table_name(), pk);
 		let field_metadata = T::field_metadata();
-		let primary_key_column = primary_key_field_info(&field_metadata, T::primary_key_field())
-			.and_then(|field| field.db_column.clone())
-			.unwrap_or_else(|| T::primary_key_field().to_string());
-		let primary_key_value = obj
-			.encode_database_fields()?
-			.remove(T::primary_key_field())
-			.filter(|value| !matches!(value, crate::orm::DatabaseValue::Null))
-			.ok_or_else(|| {
-				SessionError::FieldCodec(FieldCodecError::Serialization(format!(
-					"encoded {} fields must contain a non-null primary key '{}'",
-					T::table_name(),
-					T::primary_key_field()
-				)))
-			})?;
+		let database_data = obj.encode_database_fields()?;
+		let primary_key_filters =
+			primary_key_filters_for_model::<T>(&field_metadata, &database_data)?;
 
 		// Mark for deletion
 		self.deleted_objects.insert(
 			key.clone(),
 			PendingDelete {
 				table_name: T::table_name(),
-				primary_key_column,
-				primary_key_value,
+				primary_key_filters,
 			},
 		);
 
@@ -1751,6 +1758,36 @@ fn encode_model_database_data<T: Model>(
 	model
 		.encode_database_fields()
 		.map_err(SessionError::FieldCodec)
+}
+
+fn primary_key_filters_for_model<T: Model>(
+	field_metadata: &[FieldInfo],
+	database_data: &BTreeMap<String, crate::orm::DatabaseValue>,
+) -> Result<Vec<(String, crate::orm::DatabaseValue)>, SessionError> {
+	let field_names = T::composite_primary_key()
+		.map(|key| key.fields().to_vec())
+		.unwrap_or_else(|| vec![T::primary_key_field().to_owned()]);
+
+	field_names
+		.into_iter()
+		.map(|field_name| {
+			let value = database_data
+				.get(&field_name)
+				.filter(|value| !matches!(value, crate::orm::DatabaseValue::Null))
+				.cloned()
+				.ok_or_else(|| {
+					SessionError::FieldCodec(FieldCodecError::Serialization(format!(
+						"encoded {} fields must contain a non-null primary key '{}'",
+						T::table_name(),
+						field_name
+					)))
+				})?;
+			let column =
+				flush_column_name(&field_name, find_field_info(field_metadata, &field_name))
+					.to_owned();
+			Ok((column, value))
+		})
+		.collect()
 }
 
 fn flush_column_name<'a>(field_name: &'a str, field_info: Option<&'a FieldInfo>) -> &'a str {
@@ -2227,6 +2264,7 @@ fn sql_with_postgres_parameter_casts<'a>(
 
 fn postgres_parameter_cast(value: &RValue) -> Option<&'static str> {
 	match value {
+		RValue::Decimal(_) | RValue::BigDecimal(_) => Some("numeric"),
 		RValue::Uuid(_) => Some("uuid"),
 		RValue::ChronoDateTimeUtc(_)
 		| RValue::ChronoDateTimeLocal(_)

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -18,13 +18,13 @@ use crate::orm::FieldCodecError;
 use crate::orm::field_codec::database_value_to_query_value;
 use crate::orm::inspection::FieldInfo;
 use crate::orm::model::Model;
-use crate::orm::query::OrmQuery;
-use crate::orm::query_types::DbBackend;
+use crate::orm::query::{OrmQuery, QuerySet};
+use crate::orm::query_types::{DbBackend, QueryStatement};
 use base64::Engine;
 use reinhardt_query::value::Value as RValue;
 use reinhardt_query::{
 	Alias, Expr, ExprTrait, MySqlQueryBuilder, PostgresQueryBuilder, Query as RQuery,
-	QueryStatementBuilder, SqliteQueryBuilder,
+	QueryStatementBuilder, SelectStatement, SimpleExpr, SqliteQueryBuilder,
 };
 use serde_json::Value;
 use sqlx::{AnyPool, Row};
@@ -845,6 +845,41 @@ impl Session {
 		Ok(results)
 	}
 
+	/// Execute a model-shaped [`QuerySet`] using this session's configured pool.
+	///
+	/// Unlike the global query-set execution helpers, this method always uses
+	/// the pool and backend owned by the session. It is therefore suitable for
+	/// request-scoped queries whose connection is selected by the caller.
+	pub async fn list<T>(&self, queryset: &QuerySet<T>) -> Result<Vec<T>, SessionError>
+	where
+		T: Model + serde::de::DeserializeOwned + 'static,
+	{
+		self.check_closed()?;
+		let fields = T::field_metadata();
+		if fields.is_empty() {
+			return Ok(Vec::new());
+		}
+
+		let mut statement = queryset
+			.build_full_model_select_statement()
+			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
+		apply_any_model_projection::<T>(&mut statement, self.db_backend)?;
+		let (sql, values) = QueryStatement::Select(statement).build(self.db_backend);
+		let sql = sql_with_postgres_parameter_casts(self.db_backend, &sql, &values);
+		let mut query = sqlx::query(sql.as_ref());
+		for value in &values.0 {
+			query = bind_reinhardt_query_value(query, value, self.db_backend)?;
+		}
+
+		let rows = query
+			.fetch_all(&*self.pool)
+			.await
+			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
+		rows.iter()
+			.map(|row| deserialize_any_row::<T>(row, &fields))
+			.collect()
+	}
+
 	/// Create a query for the given model type
 	///
 	/// # Examples
@@ -1203,7 +1238,7 @@ impl Session {
 
 		// Bind all values from reinhardt_query::value::Values
 		for value in &values.0 {
-			query = bind_reinhardt_query_value(query, value, self.get_backend());
+			query = bind_reinhardt_query_value(query, value, self.get_backend())?;
 		}
 
 		query
@@ -1225,7 +1260,7 @@ impl Session {
 
 		// Bind all values from reinhardt_query::value::Values
 		for value in &values.0 {
-			query = bind_reinhardt_query_value(query, value, self.get_backend());
+			query = bind_reinhardt_query_value(query, value, self.get_backend())?;
 		}
 
 		query
@@ -1417,6 +1452,169 @@ impl Session {
 	/// ```
 	pub fn is_closed(&self) -> bool {
 		self.is_closed
+	}
+}
+
+fn apply_any_model_projection<T: Model>(
+	statement: &mut SelectStatement,
+	backend: DbBackend,
+) -> Result<Vec<FieldInfo>, SessionError> {
+	let fields = T::field_metadata();
+	statement.clear_selects();
+	for field in &fields {
+		let column_name = field.db_column_name();
+		let column = Expr::col(Alias::new(column_name));
+		let quoted_column = match backend {
+			DbBackend::Mysql => format!("`{}`", column_name.replace('`', "``")),
+			DbBackend::Postgres | DbBackend::Sqlite => {
+				format!("\"{}\"", column_name.replace('"', "\"\""))
+			}
+		};
+		let field_type = field.field_type.as_str();
+		let expression: SimpleExpr =
+			if field_type.contains("DateTimeField") || field_type.contains("DateField") {
+				let sql = match backend {
+					DbBackend::Postgres => {
+						format!("TO_CHAR({quoted_column}, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"')")
+					}
+					DbBackend::Mysql => {
+						format!("DATE_FORMAT({quoted_column}, '%Y-%m-%dT%H:%i:%sZ')")
+					}
+					DbBackend::Sqlite => {
+						format!("strftime('%Y-%m-%dT%H:%M:%SZ', {quoted_column})")
+					}
+				};
+				Expr::cust(sql).into_simple_expr()
+			} else if field_type.contains("ArrayField") && backend == DbBackend::Postgres {
+				Expr::cust(format!("array_to_json({quoted_column})::text")).into_simple_expr()
+			} else if field_type.contains("UuidField")
+				|| field_type.contains("UUIDField")
+				|| field_type.contains("TimeField")
+				|| field_type.contains("JsonField")
+				|| field_type.contains("JSONField")
+				|| field_type.contains("JSONBField")
+				|| field_type.contains("DecimalField")
+				|| field_type.contains("ArrayField")
+			{
+				let text_type = if backend == DbBackend::Mysql {
+					"CHAR"
+				} else {
+					"TEXT"
+				};
+				Expr::cust(format!("CAST({quoted_column} AS {text_type})")).into_simple_expr()
+			} else if field_type.contains("BooleanField") {
+				match backend {
+					DbBackend::Postgres => column.into_simple_expr(),
+					DbBackend::Mysql => {
+						Expr::cust(format!("CAST({quoted_column} AS SIGNED)")).into_simple_expr()
+					}
+					DbBackend::Sqlite => {
+						Expr::cust(format!("CAST({quoted_column} AS INTEGER)")).into_simple_expr()
+					}
+				}
+			} else {
+				column.into_simple_expr()
+			};
+		statement.expr_as(expression, Alias::new(column_name));
+	}
+	Ok(fields)
+}
+
+fn deserialize_any_row<T>(row: &sqlx::any::AnyRow, fields: &[FieldInfo]) -> Result<T, SessionError>
+where
+	T: Model + serde::de::DeserializeOwned,
+{
+	let mut json_map = serde_json::Map::new();
+	for field in fields {
+		let column_name = field.db_column_name();
+		let serialization_error = |detail: String| {
+			SessionError::SerializationError(format!(
+				"table `{}`, field `{}`, column `{}`: {detail}",
+				T::table_name(),
+				field.name,
+				column_name
+			))
+		};
+		let field_type = field.field_type.as_str();
+		let value = if field_type.contains("BigIntegerField") || field_type.contains("BigAutoField")
+		{
+			row.try_get::<Option<i64>, _>(column_name)
+				.map(|value| value.map(Value::from))
+				.map_err(|error| serialization_error(error.to_string()))?
+		} else if field_type.contains("IntegerField") || field_type.contains("AutoField") {
+			row.try_get::<Option<i32>, _>(column_name)
+				.map(|value| value.map(Value::from))
+				.map_err(|error| serialization_error(error.to_string()))?
+		} else if field_type.contains("FloatField") {
+			row.try_get::<Option<f64>, _>(column_name)
+				.map(|value| value.map(Value::from))
+				.map_err(|error| serialization_error(error.to_string()))?
+		} else if field_type.contains("BooleanField") {
+			backend_bool_value(row, column_name, field, serialization_error)?.map(Value::Bool)
+		} else if field_type.contains("BinaryField") {
+			row.try_get::<Option<Vec<u8>>, _>(column_name)
+				.map(|value| value.map(Value::from))
+				.map_err(|error| serialization_error(error.to_string()))?
+		} else if field_type.contains("JsonField")
+			|| field_type.contains("JSONField")
+			|| field_type.contains("JSONBField")
+			|| field_type.contains("ArrayField")
+		{
+			let value = row
+				.try_get::<Option<String>, _>(column_name)
+				.map_err(|error| serialization_error(error.to_string()))?;
+			value
+				.map(|value| {
+					serde_json::from_str(&value)
+						.map_err(|error| serialization_error(error.to_string()))
+				})
+				.transpose()?
+		} else {
+			row.try_get::<Option<String>, _>(column_name)
+				.map(|value| value.map(Value::from))
+				.map_err(|error| serialization_error(error.to_string()))?
+		};
+
+		let value = match value {
+			Some(value) => value,
+			None if field.nullable => Value::Null,
+			None => return Err(serialization_error("unexpected SQL NULL".to_owned())),
+		};
+		json_map.insert(field.name.clone(), value);
+	}
+
+	serde_json::from_value(Value::Object(json_map)).map_err(|error| {
+		SessionError::SerializationError(format!(
+			"table `{}`: failed to deserialize query result: {error}",
+			T::table_name()
+		))
+	})
+}
+
+fn backend_bool_value<F>(
+	row: &sqlx::any::AnyRow,
+	column_name: &str,
+	field: &FieldInfo,
+	serialization_error: F,
+) -> Result<Option<bool>, SessionError>
+where
+	F: Fn(String) -> SessionError,
+{
+	match row.try_get::<Option<i64>, _>(column_name) {
+		Ok(Some(0)) => Ok(Some(false)),
+		Ok(Some(1)) => Ok(Some(true)),
+		Ok(Some(value)) => Err(serialization_error(format!(
+			"boolean integer must be 0 or 1, got {value}"
+		))),
+		Ok(None) => Ok(None),
+		Err(integer_error) => row
+			.try_get::<Option<bool>, _>(column_name)
+			.map_err(|bool_error| {
+				serialization_error(format!(
+					"cannot decode boolean field {}: integer: {integer_error}; boolean fallback: {bool_error}",
+					field.name
+				))
+			}),
 	}
 }
 
@@ -1930,8 +2128,8 @@ fn bind_reinhardt_query_value<'a>(
 	query: sqlx::query::Query<'a, sqlx::Any, sqlx::any::AnyArguments<'a>>,
 	value: &RValue,
 	backend: DbBackend,
-) -> sqlx::query::Query<'a, sqlx::Any, sqlx::any::AnyArguments<'a>> {
-	match value {
+) -> Result<sqlx::query::Query<'a, sqlx::Any, sqlx::any::AnyArguments<'a>>, SessionError> {
+	let query = match value {
 		RValue::Bool(Some(b)) => query.bind(*b),
 		RValue::TinyInt(Some(i)) => query.bind(*i as i32),
 		RValue::SmallInt(Some(i)) => query.bind(*i as i32),
@@ -1940,14 +2138,14 @@ fn bind_reinhardt_query_value<'a>(
 		RValue::TinyUnsigned(Some(i)) => query.bind(*i as i32),
 		RValue::SmallUnsigned(Some(i)) => query.bind(*i as i32),
 		RValue::Unsigned(Some(i)) => query.bind(*i as i64),
-		RValue::BigUnsigned(Some(i)) => query.bind(i64::try_from(*i).unwrap_or_else(|_| {
-			tracing::warn!(
-				value = *i,
-				"BigUnsigned value {} exceeds i64::MAX, clamping to i64::MAX",
-				i
-			);
-			i64::MAX
-		})),
+		RValue::BigUnsigned(Some(i)) => {
+			let value = i64::try_from(*i).map_err(|_| {
+				SessionError::DatabaseError(format!(
+					"unsigned query parameter {i} exceeds sqlx::Any's i64 range"
+				))
+			})?;
+			query.bind(value)
+		}
 		RValue::Float(Some(f)) => query.bind(*f),
 		RValue::Double(Some(f)) => query.bind(*f),
 		// Bind decimals as text for sqlx::Any. This preserves precision while
@@ -1962,6 +2160,13 @@ fn bind_reinhardt_query_value<'a>(
 		}
 		#[cfg(feature = "pgvector")]
 		RValue::Vector(None) if backend == DbBackend::Postgres => query.bind(None::<String>),
+		#[cfg(feature = "pgvector")]
+		RValue::Vector(Some(values)) => {
+			let value = values.iter().map(ToString::to_string).collect::<Vec<_>>();
+			query.bind(format!("[{}]", value.join(",")))
+		}
+		#[cfg(feature = "pgvector")]
+		RValue::Vector(None) => query.bind(None::<String>),
 		// UUID: sqlx::Any doesn't natively support UUID, bind as string
 		RValue::Uuid(Some(u)) => query.bind(u.to_string()),
 		// Json variant is available because reinhardt-query is compiled with "with-json" feature
@@ -1995,18 +2200,26 @@ fn bind_reinhardt_query_value<'a>(
 		RValue::ChronoDateTimeLocal(None) => query.bind(None::<String>),
 		RValue::ChronoDateTimeWithTimeZone(Some(value)) => query.bind(value.to_rfc3339()),
 		RValue::ChronoDateTimeWithTimeZone(None) => query.bind(None::<String>),
+		RValue::BigDecimal(Some(value)) => query.bind(value.to_string()),
+		RValue::BigDecimal(None) => query.bind(None::<String>),
 		RValue::Bool(None) => query.bind(None::<bool>),
-		RValue::TinyInt(None) | RValue::SmallInt(None) | RValue::Int(None) => {
-			query.bind(None::<i32>)
-		}
+		RValue::TinyInt(None)
+		| RValue::SmallInt(None)
+		| RValue::Int(None)
+		| RValue::TinyUnsigned(None)
+		| RValue::SmallUnsigned(None)
+		| RValue::Unsigned(None)
+		| RValue::BigUnsigned(None) => query.bind(None::<i32>),
 		RValue::BigInt(None) => query.bind(None::<i64>),
 		RValue::Float(None) => query.bind(None::<f32>),
 		RValue::Double(None) => query.bind(None::<f64>),
 		RValue::Decimal(None) => query.bind(None::<String>),
 		RValue::String(None) | RValue::Uuid(None) => query.bind(None::<String>),
 		RValue::Bytes(None) => query.bind(None::<Vec<u8>>),
-		_ => query.bind(None::<i32>),
-	}
+		RValue::Char(Some(value)) => query.bind(value.to_string()),
+		RValue::Char(None) => query.bind(None::<String>),
+	};
+	Ok(query)
 }
 
 #[cfg(test)]
@@ -2059,6 +2272,14 @@ mod tests {
 
 		fn new_fields() -> Self::Fields {
 			TestUserFields
+		}
+
+		fn field_metadata() -> Vec<FieldInfo> {
+			vec![
+				test_field_info("id", "reinhardt.orm.models.BigIntegerField", false, true),
+				test_field_info("name", "reinhardt.orm.models.CharField", false, false),
+				test_field_info("email", "reinhardt.orm.models.CharField", false, false),
+			]
 		}
 	}
 
@@ -2418,6 +2639,53 @@ mod tests {
 		.expect("Failed to create users table");
 
 		Arc::new(pool)
+	}
+
+	#[rstest]
+	#[serial(sqlx_drivers)]
+	#[tokio::test]
+	async fn list_executes_queryset_filters_on_the_session_pool() {
+		// Arrange
+		let pool = create_test_pool().await;
+		sqlx::query("DELETE FROM users")
+			.execute(&*pool)
+			.await
+			.expect("test rows should be cleared");
+		for (id, name) in [(1_i64, "outside"), (2_i64, "inside")] {
+			sqlx::query("INSERT INTO users (id, name, email) VALUES (?, ?, ?)")
+				.bind(id)
+				.bind(name)
+				.bind(format!("{name}@example.com"))
+				.execute(&*pool)
+				.await
+				.expect("test row should be inserted");
+		}
+		let session = Session::new(pool, DbBackend::Sqlite)
+			.await
+			.expect("session should use the configured pool");
+		let queryset = QuerySet::<TestUser>::new()
+			.filter(crate::orm::query::Filter::new(
+				"id",
+				crate::orm::query::FilterOperator::Eq,
+				crate::orm::query::FilterValue::Integer(2),
+			))
+			.limit(1);
+
+		// Act
+		let users = session
+			.list(&queryset)
+			.await
+			.expect("session list should execute the queryset");
+
+		// Assert
+		assert_eq!(
+			users,
+			vec![TestUser {
+				id: Some(2),
+				name: "inside".to_owned(),
+				email: "inside@example.com".to_owned(),
+			}]
+		);
 	}
 
 	async fn create_json_scalar_test_pool() -> Arc<AnyPool> {
@@ -3217,7 +3485,8 @@ mod tests {
 		);
 		let mut query = sqlx::query(sql.as_ref());
 		for value in &values.0 {
-			query = super::bind_reinhardt_query_value(query, value, DbBackend::Postgres);
+			query = super::bind_reinhardt_query_value(query, value, DbBackend::Postgres)
+				.expect("test values should be bindable");
 		}
 
 		let row = query

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -930,7 +930,16 @@ impl Session {
 
 		let (database_type, capabilities) = match self.db_backend {
 			DbBackend::Postgres => (DatabaseType::Postgres, RowLockCapabilities::postgres()),
-			DbBackend::Mysql => (DatabaseType::Mysql, RowLockCapabilities::mysql()),
+			// The session backend does not identify MySQL versus MariaDB or expose
+			// the server version. Keep the portable unqualified `FOR UPDATE` form
+			// until the connection can report whether explicit lock targets exist.
+			DbBackend::Mysql => (
+				DatabaseType::Mysql,
+				RowLockCapabilities {
+					targets: false,
+					..RowLockCapabilities::mysql()
+				},
+			),
 			DbBackend::Sqlite => (DatabaseType::Sqlite, RowLockCapabilities::unsupported()),
 		};
 		queryset
@@ -952,14 +961,16 @@ impl Session {
 				.await?;
 			statement.clear_distinct();
 			statement.lock(LockType::Update);
-			let mut lock_tables = vec![Alias::new(root_alias)];
-			lock_tables.extend(
-				queryset
-					.inner_relation_aliases_for_lock()
-					.into_iter()
-					.map(Alias::new),
-			);
-			statement.lock_tables(lock_tables);
+			if capabilities.targets {
+				let mut lock_tables = vec![Alias::new(root_alias)];
+				lock_tables.extend(
+					queryset
+						.inner_relation_aliases_for_lock()
+						.into_iter()
+						.map(Alias::new),
+				);
+				statement.lock_tables(lock_tables);
+			}
 		}
 		let (sql, values) = QueryStatement::Select(statement).build(self.db_backend);
 		let sql = sql_with_postgres_parameter_casts(self.db_backend, &sql, &values);

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -914,7 +914,9 @@ impl Session {
 		let root_alias = queryset.root_alias().to_owned();
 		apply_any_model_projection::<T>(&mut statement, self.db_backend, &root_alias)?;
 		if lock_rows && matches!(self.db_backend, DbBackend::Postgres | DbBackend::Mysql) {
+			statement.clear_distinct();
 			statement.lock(LockType::Update);
+			statement.lock_tables([Alias::new(root_alias)]);
 		}
 		let (sql, values) = QueryStatement::Select(statement).build(self.db_backend);
 		let sql = sql_with_postgres_parameter_casts(self.db_backend, &sql, &values);
@@ -1558,7 +1560,7 @@ fn apply_any_model_projection<T: Model>(
 				field_type,
 			))
 			.into_simple_expr()
-		} else if field_type.contains("ArrayField") && backend == DbBackend::Postgres {
+		} else if is_json_or_array_field(field) && backend == DbBackend::Postgres {
 			Expr::cust(format!("array_to_json({quoted_column})::text")).into_simple_expr()
 		} else if field_type.contains("UuidField")
 			|| field_type.contains("UUIDField")
@@ -1567,7 +1569,7 @@ fn apply_any_model_projection<T: Model>(
 			|| field_type.contains("JSONField")
 			|| field_type.contains("JSONBField")
 			|| field_type.contains("DecimalField")
-			|| field_type.contains("ArrayField")
+			|| is_json_or_array_field(field)
 		{
 			let text_type = if backend == DbBackend::Mysql {
 				"CHAR"
@@ -1598,6 +1600,7 @@ where
 	T: Model + serde::de::DeserializeOwned,
 {
 	let mut json_map = serde_json::Map::new();
+	let mut sql_null_json_fields = HashSet::new();
 	for field in fields {
 		let column_name = field.db_column_name();
 		let serialization_error = |detail: String| {
@@ -1624,18 +1627,23 @@ where
 				.map_err(|error| serialization_error(error.to_string()))?
 		} else if field_type.contains("BooleanField") {
 			backend_bool_value(row, column_name, field, serialization_error)?.map(Value::Bool)
-		} else if field_type.contains("BinaryField") {
+		} else if field_type.contains("BinaryField")
+			|| field.storage_kind == Some(crate::orm::DatabaseStorageKind::Bytes)
+		{
 			row.try_get::<Option<Vec<u8>>, _>(column_name)
 				.map(|value| value.map(Value::from))
 				.map_err(|error| serialization_error(error.to_string()))?
 		} else if field_type.contains("JsonField")
 			|| field_type.contains("JSONField")
 			|| field_type.contains("JSONBField")
-			|| field_type.contains("ArrayField")
+			|| is_json_or_array_field(field)
 		{
 			let value = row
 				.try_get::<Option<String>, _>(column_name)
 				.map_err(|error| serialization_error(error.to_string()))?;
+			if value.is_none() && field.nullable {
+				sql_null_json_fields.insert(field.name.clone());
+			}
 			value
 				.map(|value| {
 					serde_json::from_str(&value)
@@ -1657,7 +1665,7 @@ where
 	}
 
 	let data = Value::Object(json_map);
-	let json_null_fields = json_null_fields_for_data(&data, fields, &HashSet::new());
+	let json_null_fields = json_null_fields_for_data(&data, fields, &sql_null_json_fields);
 	let native_json_fields = fields
 		.iter()
 		.filter(|field| is_json_or_array_field(field))

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -956,7 +956,7 @@ impl Session {
 			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
 		let root_alias = queryset.root_alias().to_owned();
 		apply_any_model_projection::<T>(&mut statement, self.db_backend, &root_alias)?;
-		if lock_rows {
+		if lock_rows && self.db_backend == DbBackend::Postgres {
 			self.lock_nullable_relation_rows(queryset, &statement, connection)
 				.await?;
 			statement.clear_distinct();

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -950,6 +950,12 @@ impl Session {
 				"SELECT FOR UPDATE is not supported by this backend or server version".to_owned(),
 			));
 		}
+		if lock_rows && self.db_backend == DbBackend::Postgres && queryset.has_right_join() {
+			return Err(SessionError::DatabaseError(
+				"SELECT FOR UPDATE does not support RIGHT JOIN mutation scopes on PostgreSQL"
+					.to_owned(),
+			));
+		}
 
 		let mut locked_queryset = queryset.clone();
 		if lock_rows {

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -951,14 +951,18 @@ impl Session {
 			));
 		}
 
-		let mut statement = queryset
+		let mut locked_queryset = queryset.clone();
+		if lock_rows {
+			locked_queryset.lock_scope_subqueries();
+		}
+		let mut statement = locked_queryset
 			.build_full_model_select_statement()
 			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
-		let root_alias = queryset.root_alias().to_owned();
+		let root_alias = locked_queryset.root_alias().to_owned();
 		apply_any_model_projection::<T>(&mut statement, self.db_backend, &root_alias)?;
 		if lock_rows {
 			if self.db_backend == DbBackend::Postgres {
-				self.lock_nullable_relation_rows(queryset, &statement, connection)
+				self.lock_nullable_relation_rows(&locked_queryset, &statement, connection)
 					.await?;
 			}
 			statement.clear_distinct();
@@ -966,7 +970,7 @@ impl Session {
 			if capabilities.targets {
 				let mut lock_tables = vec![Alias::new(root_alias)];
 				lock_tables.extend(
-					queryset
+					locked_queryset
 						.inner_relation_aliases_for_lock()
 						.into_iter()
 						.map(Alias::new),

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -1471,50 +1471,39 @@ fn apply_any_model_projection<T: Model>(
 			}
 		};
 		let field_type = field.field_type.as_str();
-		let expression: SimpleExpr =
-			if field_type.contains("DateTimeField") || field_type.contains("DateField") {
-				let sql = match backend {
-					DbBackend::Postgres => {
-						format!("TO_CHAR({quoted_column}, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"')")
-					}
-					DbBackend::Mysql => {
-						format!("DATE_FORMAT({quoted_column}, '%Y-%m-%dT%H:%i:%sZ')")
-					}
-					DbBackend::Sqlite => {
-						format!("strftime('%Y-%m-%dT%H:%M:%SZ', {quoted_column})")
-					}
-				};
-				Expr::cust(sql).into_simple_expr()
-			} else if field_type.contains("ArrayField") && backend == DbBackend::Postgres {
-				Expr::cust(format!("array_to_json({quoted_column})::text")).into_simple_expr()
-			} else if field_type.contains("UuidField")
-				|| field_type.contains("UUIDField")
-				|| field_type.contains("TimeField")
-				|| field_type.contains("JsonField")
-				|| field_type.contains("JSONField")
-				|| field_type.contains("JSONBField")
-				|| field_type.contains("DecimalField")
-				|| field_type.contains("ArrayField")
-			{
-				let text_type = if backend == DbBackend::Mysql {
-					"CHAR"
-				} else {
-					"TEXT"
-				};
-				Expr::cust(format!("CAST({quoted_column} AS {text_type})")).into_simple_expr()
-			} else if field_type.contains("BooleanField") {
-				match backend {
-					DbBackend::Postgres => column.into_simple_expr(),
-					DbBackend::Mysql => {
-						Expr::cust(format!("CAST({quoted_column} AS SIGNED)")).into_simple_expr()
-					}
-					DbBackend::Sqlite => {
-						Expr::cust(format!("CAST({quoted_column} AS INTEGER)")).into_simple_expr()
-					}
-				}
+		let expression: SimpleExpr = if is_temporal_field_type(field_type) {
+			Expr::cust(temporal_select_column_sql(backend, column_name, field_type))
+				.into_simple_expr()
+		} else if field_type.contains("ArrayField") && backend == DbBackend::Postgres {
+			Expr::cust(format!("array_to_json({quoted_column})::text")).into_simple_expr()
+		} else if field_type.contains("UuidField")
+			|| field_type.contains("UUIDField")
+			|| field_type.contains("TimeField")
+			|| field_type.contains("JsonField")
+			|| field_type.contains("JSONField")
+			|| field_type.contains("JSONBField")
+			|| field_type.contains("DecimalField")
+			|| field_type.contains("ArrayField")
+		{
+			let text_type = if backend == DbBackend::Mysql {
+				"CHAR"
 			} else {
-				column.into_simple_expr()
+				"TEXT"
 			};
+			Expr::cust(format!("CAST({quoted_column} AS {text_type})")).into_simple_expr()
+		} else if field_type.contains("BooleanField") {
+			match backend {
+				DbBackend::Postgres => column.into_simple_expr(),
+				DbBackend::Mysql => {
+					Expr::cust(format!("CAST({quoted_column} AS SIGNED)")).into_simple_expr()
+				}
+				DbBackend::Sqlite => {
+					Expr::cust(format!("CAST({quoted_column} AS INTEGER)")).into_simple_expr()
+				}
+			}
+		} else {
+			column.into_simple_expr()
+		};
 		statement.expr_as(expression, Alias::new(column_name));
 	}
 	Ok(fields)
@@ -2064,6 +2053,13 @@ fn sql_with_postgres_parameter_casts<'a>(
 
 fn postgres_parameter_cast(value: &RValue) -> Option<&'static str> {
 	match value {
+		RValue::Uuid(_) => Some("uuid"),
+		RValue::ChronoDateTimeUtc(_)
+		| RValue::ChronoDateTimeLocal(_)
+		| RValue::ChronoDateTimeWithTimeZone(_) => Some("timestamptz"),
+		RValue::ChronoDateTime(_) => Some("timestamp"),
+		RValue::ChronoDate(_) => Some("date"),
+		RValue::ChronoTime(_) => Some("time"),
 		RValue::Json(_) => Some("jsonb"),
 		#[cfg(feature = "pgvector")]
 		RValue::Vector(_) => Some("vector"),
@@ -2684,6 +2680,46 @@ mod tests {
 				id: Some(2),
 				name: "inside".to_owned(),
 				email: "inside@example.com".to_owned(),
+			}]
+		);
+	}
+
+	#[rstest]
+	#[serial(sqlx_drivers)]
+	#[tokio::test]
+	async fn list_preserves_temporal_field_precision(_init_drivers: ()) {
+		// Arrange
+		let pool = create_temporal_test_pool().await;
+		sqlx::query(
+			"INSERT INTO temporal_session_models \
+			 (id, published_on, starts_at, published_at) \
+			 VALUES (1, '2026-07-18', '08:09:10.123456', '2026-07-18T08:09:10.123456Z')",
+		)
+		.execute(&*pool)
+		.await
+		.expect("temporal row should insert");
+		let session = Session::new(pool, DbBackend::Sqlite)
+			.await
+			.expect("session should initialize");
+
+		// Act
+		let rows = session
+			.list(&QuerySet::<TemporalSessionModel>::new())
+			.await
+			.expect("session list should preserve temporal values");
+
+		// Assert
+		assert_eq!(
+			rows,
+			vec![TemporalSessionModel {
+				id: Some(1),
+				published_on: chrono::NaiveDate::from_ymd_opt(2026, 7, 18)
+					.expect("date should be valid"),
+				starts_at: chrono::NaiveTime::from_hms_micro_opt(8, 9, 10, 123_456)
+					.expect("time should be valid"),
+				published_at: chrono::DateTime::parse_from_rfc3339("2026-07-18T08:09:10.123456Z",)
+					.expect("timestamp should be valid")
+					.with_timezone(&chrono::Utc),
 			}]
 		);
 	}
@@ -3398,6 +3434,45 @@ mod tests {
 		assert_eq!(
 			cast_sql.as_ref(),
 			"UPDATE items SET payload = $1::jsonb WHERE id = 1"
+		);
+	}
+
+	#[test]
+	fn test_postgres_temporal_and_uuid_parameter_placeholders_are_cast() {
+		use chrono::{NaiveDate, NaiveDateTime, NaiveTime, Utc};
+		use reinhardt_query::value::Values;
+
+		let uuid =
+			Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").expect("UUID should be valid");
+		let timestamp = chrono::DateTime::<Utc>::from_naive_utc_and_offset(
+			NaiveDateTime::parse_from_str("2026-07-18 08:09:10.123456", "%Y-%m-%d %H:%M:%S%.f")
+				.expect("timestamp should be valid"),
+			Utc,
+		);
+		let values = Values(vec![
+			RValue::Uuid(Some(Box::new(uuid))),
+			RValue::ChronoDateTimeUtc(Some(Box::new(timestamp))),
+			RValue::ChronoDateTime(Some(Box::new(
+				NaiveDateTime::parse_from_str("2026-07-18 08:09:10.123456", "%Y-%m-%d %H:%M:%S%.f")
+					.expect("naive timestamp should be valid"),
+			))),
+			RValue::ChronoDate(Some(Box::new(
+				NaiveDate::from_ymd_opt(2026, 7, 18).expect("date should be valid"),
+			))),
+			RValue::ChronoTime(Some(Box::new(
+				NaiveTime::from_hms_micro_opt(8, 9, 10, 123_456).expect("time should be valid"),
+			))),
+		]);
+
+		let cast_sql = super::sql_with_postgres_parameter_casts(
+			DbBackend::Postgres,
+			"SELECT $1, $2, $3, $4, $5",
+			&values,
+		);
+
+		assert_eq!(
+			cast_sql.as_ref(),
+			"SELECT $1::uuid, $2::timestamptz, $3::timestamp, $4::date, $5::time"
 		);
 	}
 

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -855,6 +855,27 @@ impl Session {
 		T: Model + serde::de::DeserializeOwned + 'static,
 	{
 		self.check_closed()?;
+		let mut connection = self
+			.pool
+			.acquire()
+			.await
+			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
+		self.list_with_connection(queryset, &mut *connection).await
+	}
+
+	/// Execute a model-shaped [`QuerySet`] through a caller-owned connection.
+	///
+	/// The connection may be a transaction connection, keeping the read on the
+	/// same database transaction as a subsequent [`Self::flush_with_connection`].
+	pub async fn list_with_connection<T>(
+		&self,
+		queryset: &QuerySet<T>,
+		connection: &mut sqlx::AnyConnection,
+	) -> Result<Vec<T>, SessionError>
+	where
+		T: Model + serde::de::DeserializeOwned + 'static,
+	{
+		self.check_closed()?;
 		let fields = T::field_metadata();
 		if fields.is_empty() {
 			return Ok(Vec::new());
@@ -863,7 +884,8 @@ impl Session {
 		let mut statement = queryset
 			.build_full_model_select_statement()
 			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
-		apply_any_model_projection::<T>(&mut statement, self.db_backend)?;
+		let root_alias = queryset.root_alias().to_owned();
+		apply_any_model_projection::<T>(&mut statement, self.db_backend, &root_alias)?;
 		let (sql, values) = QueryStatement::Select(statement).build(self.db_backend);
 		let sql = sql_with_postgres_parameter_casts(self.db_backend, &sql, &values);
 		let mut query = sqlx::query(sql.as_ref());
@@ -872,7 +894,7 @@ impl Session {
 		}
 
 		let rows = query
-			.fetch_all(&*self.pool)
+			.fetch_all(&mut *connection)
 			.await
 			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
 		rows.iter()
@@ -946,6 +968,23 @@ impl Session {
 	/// # }
 	/// ```
 	pub async fn flush(&mut self) -> Result<(), SessionError> {
+		self.check_closed()?;
+		let mut connection = self
+			.pool
+			.acquire()
+			.await
+			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
+		self.flush_with_connection(&mut *connection).await
+	}
+
+	/// Flush tracked changes through a caller-owned connection.
+	///
+	/// The connection may be a transaction connection, keeping the writes on
+	/// the same database transaction as a preceding [`Self::list_with_connection`].
+	pub async fn flush_with_connection(
+		&mut self,
+		connection: &mut sqlx::AnyConnection,
+	) -> Result<(), SessionError> {
 		self.check_closed()?;
 
 		// Clear any previously generated IDs
@@ -1025,7 +1064,7 @@ impl Session {
 							DbBackend::Sqlite => update_stmt.build(SqliteQueryBuilder),
 						};
 
-						self.execute_with_values(&sql, &values).await?;
+						self.execute_with_values(connection, &sql, &values).await?;
 					} else {
 						// INSERT new record
 						let mut insert_stmt = RQuery::insert()
@@ -1087,7 +1126,8 @@ impl Session {
 
 						// Execute and get generated ID if available
 						if backend == DbBackend::Postgres {
-							if let Ok(row) = self.execute_returning(&sql, &values).await {
+							if let Ok(row) = self.execute_returning(connection, &sql, &values).await
+							{
 								// Extract the generated ID
 								let generated_id: i64 =
 									row.try_get(primary_key_column.as_str()).map_err(|e| {
@@ -1110,7 +1150,7 @@ impl Session {
 								)?;
 							}
 						} else {
-							self.execute_with_values(&sql, &values).await?;
+							self.execute_with_values(connection, &sql, &values).await?;
 						}
 					}
 				}
@@ -1137,7 +1177,7 @@ impl Session {
 				DbBackend::Sqlite => delete_stmt.build(SqliteQueryBuilder),
 			};
 
-			self.execute_with_values(&sql, &values).await?;
+			self.execute_with_values(connection, &sql, &values).await?;
 
 			// Remove from identity map
 			self.identity_map.remove(&key);
@@ -1230,6 +1270,7 @@ impl Session {
 	/// Execute SQL with reinhardt_query values
 	async fn execute_with_values(
 		&self,
+		connection: &mut sqlx::AnyConnection,
 		sql: &str,
 		values: &reinhardt_query::value::Values,
 	) -> Result<(), SessionError> {
@@ -1242,7 +1283,7 @@ impl Session {
 		}
 
 		query
-			.execute(&*self.pool)
+			.execute(&mut *connection)
 			.await
 			.map_err(|e| SessionError::FlushError(e.to_string()))?;
 
@@ -1252,6 +1293,7 @@ impl Session {
 	/// Execute SQL with RETURNING clause (PostgreSQL)
 	async fn execute_returning(
 		&self,
+		connection: &mut sqlx::AnyConnection,
 		sql: &str,
 		values: &reinhardt_query::value::Values,
 	) -> Result<sqlx::any::AnyRow, SessionError> {
@@ -1264,7 +1306,7 @@ impl Session {
 		}
 
 		query
-			.fetch_one(&*self.pool)
+			.fetch_one(&mut *connection)
 			.await
 			.map_err(|e| SessionError::FlushError(e.to_string()))
 	}
@@ -1458,22 +1500,34 @@ impl Session {
 fn apply_any_model_projection<T: Model>(
 	statement: &mut SelectStatement,
 	backend: DbBackend,
+	root_alias: &str,
 ) -> Result<Vec<FieldInfo>, SessionError> {
 	let fields = T::field_metadata();
 	statement.clear_selects();
 	for field in &fields {
 		let column_name = field.db_column_name();
-		let column = Expr::col(Alias::new(column_name));
+		let column = Expr::col((Alias::new(root_alias), Alias::new(column_name)));
 		let quoted_column = match backend {
-			DbBackend::Mysql => format!("`{}`", column_name.replace('`', "``")),
-			DbBackend::Postgres | DbBackend::Sqlite => {
-				format!("\"{}\"", column_name.replace('"', "\"\""))
-			}
+			DbBackend::Mysql => format!(
+				"`{}`.`{}`",
+				root_alias.replace('`', "``"),
+				column_name.replace('`', "``")
+			),
+			DbBackend::Postgres | DbBackend::Sqlite => format!(
+				"\"{}\".\"{}\"",
+				root_alias.replace('"', "\"\""),
+				column_name.replace('"', "\"\"")
+			),
 		};
 		let field_type = field.field_type.as_str();
 		let expression: SimpleExpr = if is_temporal_field_type(field_type) {
-			Expr::cust(temporal_select_column_sql(backend, column_name, field_type))
-				.into_simple_expr()
+			Expr::cust(temporal_select_column_sql_for_root(
+				backend,
+				root_alias,
+				column_name,
+				field_type,
+			))
+			.into_simple_expr()
 		} else if field_type.contains("ArrayField") && backend == DbBackend::Postgres {
 			Expr::cust(format!("array_to_json({quoted_column})::text")).into_simple_expr()
 		} else if field_type.contains("UuidField")
@@ -1572,12 +1626,15 @@ where
 		json_map.insert(field.name.clone(), value);
 	}
 
-	serde_json::from_value(Value::Object(json_map)).map_err(|error| {
-		SessionError::SerializationError(format!(
-			"table `{}`: failed to deserialize query result: {error}",
-			T::table_name()
-		))
-	})
+	let data = Value::Object(json_map);
+	let json_null_fields = json_null_fields_for_data(&data, fields, &HashSet::new());
+	let native_json_fields = fields
+		.iter()
+		.filter(|field| is_json_or_array_field(field))
+		.map(|field| field.name.clone())
+		.collect();
+	super::json::deserialize_model_row(data, json_null_fields, native_json_fields)
+		.map_err(SessionError::FieldCodec)
 }
 
 fn backend_bool_value<F>(
@@ -1696,23 +1753,57 @@ fn is_temporal_field_type(field_type: &str) -> bool {
 }
 
 fn temporal_select_column_sql(backend: DbBackend, column_name: &str, field_type: &str) -> String {
-	match backend {
-		DbBackend::Postgres if field_type.contains("DateTimeField") => format!(
-			"TO_CHAR(\"{}\", 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')",
-			column_name
-		),
-		DbBackend::Postgres if field_type.contains("DateField") => {
-			format!("TO_CHAR(\"{}\", 'YYYY-MM-DD')", column_name)
+	let quoted_column = match backend {
+		DbBackend::Mysql => format!("`{}`", column_name.replace('`', "``")),
+		DbBackend::Postgres | DbBackend::Sqlite => {
+			format!("\"{}\"", column_name.replace('"', "\"\""))
 		}
-		DbBackend::Postgres => format!("TO_CHAR(\"{}\", 'HH24:MI:SS.US')", column_name),
+	};
+	temporal_select_column_sql_from_quoted(backend, &quoted_column, field_type)
+}
+
+fn temporal_select_column_sql_for_root(
+	backend: DbBackend,
+	root_alias: &str,
+	column_name: &str,
+	field_type: &str,
+) -> String {
+	let quoted_column = match backend {
+		DbBackend::Mysql => format!(
+			"`{}`.`{}`",
+			root_alias.replace('`', "``"),
+			column_name.replace('`', "``")
+		),
+		DbBackend::Postgres | DbBackend::Sqlite => format!(
+			"\"{}\".\"{}\"",
+			root_alias.replace('"', "\"\""),
+			column_name.replace('"', "\"\"")
+		),
+	};
+	temporal_select_column_sql_from_quoted(backend, &quoted_column, field_type)
+}
+
+fn temporal_select_column_sql_from_quoted(
+	backend: DbBackend,
+	quoted_column: &str,
+	field_type: &str,
+) -> String {
+	match backend {
+		DbBackend::Postgres if field_type.contains("DateTimeField") => {
+			format!("TO_CHAR({quoted_column}, 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')")
+		}
+		DbBackend::Postgres if field_type.contains("DateField") => {
+			format!("TO_CHAR({quoted_column}, 'YYYY-MM-DD')")
+		}
+		DbBackend::Postgres => format!("TO_CHAR({quoted_column}, 'HH24:MI:SS.US')"),
 		DbBackend::Mysql if field_type.contains("DateTimeField") => {
-			format!("DATE_FORMAT(`{}`, '%Y-%m-%dT%H:%i:%s.%fZ')", column_name)
+			format!("DATE_FORMAT({quoted_column}, '%Y-%m-%dT%H:%i:%s.%fZ')")
 		}
 		DbBackend::Mysql if field_type.contains("DateField") => {
-			format!("DATE_FORMAT(`{}`, '%Y-%m-%d')", column_name)
+			format!("DATE_FORMAT({quoted_column}, '%Y-%m-%d')")
 		}
-		DbBackend::Mysql => format!("TIME_FORMAT(`{}`, '%H:%i:%s.%f')", column_name),
-		DbBackend::Sqlite => format!("\"{}\"", column_name),
+		DbBackend::Mysql => format!("TIME_FORMAT({quoted_column}, '%H:%i:%s.%f')"),
+		DbBackend::Sqlite => quoted_column.to_owned(),
 	}
 }
 
@@ -3359,7 +3450,7 @@ mod tests {
 		assert!(matches!(rq_value, RValue::Json(None)));
 	}
 
-	#[test]
+	#[rstest]
 	fn test_nullable_non_json_null_uses_field_specific_rvalue() {
 		use serde_json::json;
 

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -959,6 +959,11 @@ impl Session {
 					.to_owned(),
 			));
 		}
+		if lock_rows {
+			queryset
+				.validate_row_lock_source()
+				.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
+		}
 
 		let mut locked_queryset = queryset.clone();
 		if lock_rows {

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -871,6 +871,9 @@ impl Session {
 	where
 		T: Model + serde::de::DeserializeOwned + 'static,
 	{
+		queryset
+			.ensure_not_locking_without_transaction()
+			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
 		self.check_closed()?;
 		let mut connection = self
 			.pool

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -23,7 +23,7 @@ use crate::orm::query_types::{DbBackend, QueryStatement};
 use base64::Engine;
 use reinhardt_query::value::Value as RValue;
 use reinhardt_query::{
-	Alias, Expr, ExprTrait, MySqlQueryBuilder, PostgresQueryBuilder, Query as RQuery,
+	Alias, Expr, ExprTrait, LockType, MySqlQueryBuilder, PostgresQueryBuilder, Query as RQuery,
 	QueryStatementBuilder, SelectStatement, SimpleExpr, SqliteQueryBuilder,
 };
 use serde_json::Value;
@@ -875,6 +875,33 @@ impl Session {
 	where
 		T: Model + serde::de::DeserializeOwned + 'static,
 	{
+		self.list_with_connection_inner(queryset, connection, false)
+			.await
+	}
+
+	/// Execute a model-shaped [`QuerySet`] and lock matching rows until the
+	/// caller-owned transaction completes.
+	pub async fn list_with_connection_for_update<T>(
+		&self,
+		queryset: &QuerySet<T>,
+		connection: &mut sqlx::AnyConnection,
+	) -> Result<Vec<T>, SessionError>
+	where
+		T: Model + serde::de::DeserializeOwned + 'static,
+	{
+		self.list_with_connection_inner(queryset, connection, true)
+			.await
+	}
+
+	async fn list_with_connection_inner<T>(
+		&self,
+		queryset: &QuerySet<T>,
+		connection: &mut sqlx::AnyConnection,
+		lock_rows: bool,
+	) -> Result<Vec<T>, SessionError>
+	where
+		T: Model + serde::de::DeserializeOwned + 'static,
+	{
 		self.check_closed()?;
 		let fields = T::field_metadata();
 		if fields.is_empty() {
@@ -886,6 +913,9 @@ impl Session {
 			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
 		let root_alias = queryset.root_alias().to_owned();
 		apply_any_model_projection::<T>(&mut statement, self.db_backend, &root_alias)?;
+		if lock_rows && matches!(self.db_backend, DbBackend::Postgres | DbBackend::Mysql) {
+			statement.lock(LockType::Update);
+		}
 		let (sql, values) = QueryStatement::Select(statement).build(self.db_backend);
 		let sql = sql_with_postgres_parameter_casts(self.db_backend, &sql, &values);
 		let mut query = sqlx::query(sql.as_ref());

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -266,7 +266,7 @@ impl Session {
 		let sql_null_json_fields = field_metadata
 			.iter()
 			.filter(|field| {
-				field.nullable && is_json_or_array_field(field) && obj.field_is_none(&field.name)
+				field.nullable && is_structured_field(field) && obj.field_is_none(&field.name)
 			})
 			.map(|field| field.name.clone())
 			.collect();
@@ -386,7 +386,7 @@ impl Session {
 		// Add all fields to SELECT
 		for field in &field_metadata {
 			let column_name = field.db_column.as_deref().unwrap_or(&field.name);
-			if is_json_or_array_field(field) {
+			if is_structured_field(field) {
 				select_query.expr_as(
 					Expr::cust(json_or_array_select_column_sql(
 						self.db_backend,
@@ -444,7 +444,7 @@ impl Session {
 
 			// Extract value from row based on field type
 			let value: serde_json::Value = match field.field_type.as_str() {
-				_ if is_json_or_array_field(field) => match decode_json_field_value(
+				_ if is_structured_field(field) => match decode_json_field_value(
 					&row,
 					T::table_name(),
 					&key,
@@ -561,7 +561,7 @@ impl Session {
 			json_null_fields_for_data(&data, &field_metadata, &sql_null_json_fields);
 		let native_json_fields = field_metadata
 			.iter()
-			.filter(|field| is_json_or_array_field(field))
+			.filter(|field| is_structured_field(field))
 			.map(|field| field.name.clone())
 			.collect();
 		let obj: T = super::json::deserialize_model_row(
@@ -655,7 +655,7 @@ impl Session {
 		let mut column_exprs: Vec<String> = Vec::new();
 		for field in &field_metadata {
 			let column_name = field.db_column.as_deref().unwrap_or(&field.name);
-			let is_json = is_json_or_array_field(field);
+			let is_json = is_structured_field(field);
 
 			let expr = if is_json {
 				json_or_array_select_column_alias_sql(self.db_backend, field, column_name)
@@ -707,7 +707,7 @@ impl Session {
 
 				// Extract value from row based on field type
 				let value: serde_json::Value = match field.field_type.as_str() {
-					_ if is_json_or_array_field(field) => match decode_json_field_value(
+					_ if is_structured_field(field) => match decode_json_field_value(
 						&row,
 						table_name,
 						&row_context,
@@ -832,7 +832,7 @@ impl Session {
 				json_null_fields_for_data(&data, &field_metadata, &sql_null_json_fields);
 			let native_json_fields = field_metadata
 				.iter()
-				.filter(|field| is_json_or_array_field(field))
+				.filter(|field| is_structured_field(field))
 				.map(|field| field.name.clone())
 				.collect();
 			let obj: T =
@@ -1560,8 +1560,10 @@ fn apply_any_model_projection<T: Model>(
 				field_type,
 			))
 			.into_simple_expr()
-		} else if is_json_or_array_field(field) && backend == DbBackend::Postgres {
+		} else if is_array_field(field) && backend == DbBackend::Postgres {
 			Expr::cust(format!("array_to_json({quoted_column})::text")).into_simple_expr()
+		} else if is_hstore_field(field) && backend == DbBackend::Postgres {
+			Expr::cust(format!("hstore_to_json({quoted_column})::text")).into_simple_expr()
 		} else if field_type.contains("UuidField")
 			|| field_type.contains("UUIDField")
 			|| field_type.contains("TimeField")
@@ -1569,7 +1571,7 @@ fn apply_any_model_projection<T: Model>(
 			|| field_type.contains("JSONField")
 			|| field_type.contains("JSONBField")
 			|| field_type.contains("DecimalField")
-			|| is_json_or_array_field(field)
+			|| is_structured_field(field)
 		{
 			let text_type = if backend == DbBackend::Mysql {
 				"CHAR"
@@ -1622,9 +1624,15 @@ where
 				.map(|value| value.map(Value::from))
 				.map_err(|error| serialization_error(error.to_string()))?
 		} else if field_type.contains("FloatField") {
-			row.try_get::<Option<f64>, _>(column_name)
-				.map(|value| value.map(Value::from))
-				.map_err(|error| serialization_error(error.to_string()))?
+			if field.storage_kind == Some(crate::orm::DatabaseStorageKind::F32) {
+				row.try_get::<Option<f32>, _>(column_name)
+					.map(|value| value.map(|value| Value::from(f64::from(value))))
+					.map_err(|error| serialization_error(error.to_string()))?
+			} else {
+				row.try_get::<Option<f64>, _>(column_name)
+					.map(|value| value.map(Value::from))
+					.map_err(|error| serialization_error(error.to_string()))?
+			}
 		} else if field_type.contains("BooleanField") {
 			backend_bool_value(row, column_name, field, serialization_error)?.map(Value::Bool)
 		} else if field_type.contains("BinaryField")
@@ -1633,11 +1641,7 @@ where
 			row.try_get::<Option<Vec<u8>>, _>(column_name)
 				.map(|value| value.map(Value::from))
 				.map_err(|error| serialization_error(error.to_string()))?
-		} else if field_type.contains("JsonField")
-			|| field_type.contains("JSONField")
-			|| field_type.contains("JSONBField")
-			|| is_json_or_array_field(field)
-		{
+		} else if is_structured_field(field) {
 			let value = row
 				.try_get::<Option<String>, _>(column_name)
 				.map_err(|error| serialization_error(error.to_string()))?;
@@ -1668,7 +1672,7 @@ where
 	let json_null_fields = json_null_fields_for_data(&data, fields, &sql_null_json_fields);
 	let native_json_fields = fields
 		.iter()
-		.filter(|field| is_json_or_array_field(field))
+		.filter(|field| is_structured_field(field))
 		.map(|field| field.name.clone())
 		.collect();
 	super::json::deserialize_model_row(data, json_null_fields, native_json_fields)
@@ -1779,9 +1783,22 @@ fn is_json_field_type(field_type: &str) -> bool {
 	super::json::is_json_field_type(field_type)
 }
 
+fn is_array_field(field: &FieldInfo) -> bool {
+	field.storage_kind != Some(crate::orm::DatabaseStorageKind::Bytes)
+		&& field.field_type.contains("ArrayField")
+}
+
+fn is_hstore_field(field: &FieldInfo) -> bool {
+	field.field_type.contains("HStoreField")
+}
+
 fn is_json_or_array_field(field: &FieldInfo) -> bool {
 	field.storage_kind != Some(crate::orm::DatabaseStorageKind::Bytes)
-		&& (is_json_field_type(&field.field_type) || field.field_type.contains("ArrayField"))
+		&& (is_json_field_type(&field.field_type) || is_array_field(field))
+}
+
+fn is_structured_field(field: &FieldInfo) -> bool {
+	is_json_or_array_field(field) || is_hstore_field(field)
 }
 
 fn is_temporal_field_type(field_type: &str) -> bool {
@@ -1828,7 +1845,9 @@ fn temporal_select_column_sql_from_quoted(
 ) -> String {
 	match backend {
 		DbBackend::Postgres if field_type.contains("DateTimeField") => {
-			format!("TO_CHAR({quoted_column}, 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')")
+			format!(
+				"TO_CHAR(({quoted_column} AT TIME ZONE 'UTC'), 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')"
+			)
 		}
 		DbBackend::Postgres if field_type.contains("DateField") => {
 			format!("TO_CHAR({quoted_column}, 'YYYY-MM-DD')")
@@ -1911,7 +1930,7 @@ fn json_null_fields_for_data(
 		.iter()
 		.filter(|field| {
 			field.nullable
-				&& is_json_or_array_field(field)
+				&& is_structured_field(field)
 				&& values.get(&field.name).map(Value::is_null).unwrap_or(false)
 				&& !sql_null_json_fields.contains(&field.name)
 		})
@@ -3566,7 +3585,7 @@ mod tests {
 		);
 	}
 
-	#[test]
+	#[rstest]
 	fn test_postgres_temporal_and_uuid_parameter_placeholders_are_cast() {
 		use chrono::{NaiveDate, NaiveDateTime, NaiveTime, Utc};
 		use reinhardt_query::value::Values;

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -877,7 +877,7 @@ impl Session {
 			.acquire()
 			.await
 			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
-		self.list_with_connection(queryset, &mut *connection).await
+		self.list_with_connection(queryset, &mut connection).await
 	}
 
 	/// Execute a model-shaped [`QuerySet`] through a caller-owned connection.
@@ -1099,7 +1099,7 @@ impl Session {
 			.acquire()
 			.await
 			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
-		self.flush_with_connection(&mut *connection).await
+		self.flush_with_connection(&mut connection).await
 	}
 
 	/// Flush tracked changes through a caller-owned connection.

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -962,7 +962,7 @@ impl Session {
 			locked_queryset.lock_scope_subqueries();
 		}
 		let mut statement = locked_queryset
-			.build_full_model_select_statement()
+			.build_full_model_select_statement_for_backend(database_type)
 			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
 		let root_alias = locked_queryset.root_alias().to_owned();
 		apply_any_model_projection::<T>(&mut statement, self.db_backend, &root_alias)?;

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -397,10 +397,11 @@ impl Session {
 				);
 			} else if is_temporal_field_type(&field.field_type) {
 				select_query.expr_as(
-					Expr::cust(temporal_select_column_sql(
+					Expr::cust(temporal_select_column_sql_with_storage(
 						self.db_backend,
 						column_name,
 						&field.field_type,
+						field.storage_kind,
 					)),
 					Alias::new(column_name),
 				);
@@ -660,7 +661,12 @@ impl Session {
 			let expr = if is_json {
 				json_or_array_select_column_alias_sql(self.db_backend, field, column_name)
 			} else if is_temporal_field_type(&field.field_type) {
-				temporal_select_column_alias_sql(self.db_backend, column_name, &field.field_type)
+				temporal_select_column_alias_sql_with_storage(
+					self.db_backend,
+					column_name,
+					&field.field_type,
+					field.storage_kind,
+				)
 			} else if field.field_type.contains("DecimalField") {
 				decimal_select_column_alias_sql(self.db_backend, column_name)
 			} else {
@@ -1558,6 +1564,7 @@ fn apply_any_model_projection<T: Model>(
 				root_alias,
 				column_name,
 				field_type,
+				field.storage_kind,
 			))
 			.into_simple_expr()
 		} else if is_array_field(field) && backend == DbBackend::Postgres {
@@ -1792,13 +1799,17 @@ fn is_hstore_field(field: &FieldInfo) -> bool {
 	field.field_type.contains("HStoreField")
 }
 
+fn is_vector_field(field: &FieldInfo) -> bool {
+	field.field_type.contains("VectorField")
+}
+
 fn is_json_or_array_field(field: &FieldInfo) -> bool {
 	field.storage_kind != Some(crate::orm::DatabaseStorageKind::Bytes)
 		&& (is_json_field_type(&field.field_type) || is_array_field(field))
 }
 
 fn is_structured_field(field: &FieldInfo) -> bool {
-	is_json_or_array_field(field) || is_hstore_field(field)
+	is_json_or_array_field(field) || is_hstore_field(field) || is_vector_field(field)
 }
 
 fn is_temporal_field_type(field_type: &str) -> bool {
@@ -1807,14 +1818,19 @@ fn is_temporal_field_type(field_type: &str) -> bool {
 		|| field_type.contains("TimeField")
 }
 
-fn temporal_select_column_sql(backend: DbBackend, column_name: &str, field_type: &str) -> String {
+fn temporal_select_column_sql_with_storage(
+	backend: DbBackend,
+	column_name: &str,
+	field_type: &str,
+	storage_kind: Option<crate::orm::DatabaseStorageKind>,
+) -> String {
 	let quoted_column = match backend {
 		DbBackend::Mysql => format!("`{}`", column_name.replace('`', "``")),
 		DbBackend::Postgres | DbBackend::Sqlite => {
 			format!("\"{}\"", column_name.replace('"', "\"\""))
 		}
 	};
-	temporal_select_column_sql_from_quoted(backend, &quoted_column, field_type)
+	temporal_select_column_sql_from_quoted(backend, &quoted_column, field_type, storage_kind)
 }
 
 fn temporal_select_column_sql_for_root(
@@ -1822,6 +1838,7 @@ fn temporal_select_column_sql_for_root(
 	root_alias: &str,
 	column_name: &str,
 	field_type: &str,
+	storage_kind: Option<crate::orm::DatabaseStorageKind>,
 ) -> String {
 	let quoted_column = match backend {
 		DbBackend::Mysql => format!(
@@ -1835,15 +1852,22 @@ fn temporal_select_column_sql_for_root(
 			column_name.replace('"', "\"\"")
 		),
 	};
-	temporal_select_column_sql_from_quoted(backend, &quoted_column, field_type)
+	temporal_select_column_sql_from_quoted(backend, &quoted_column, field_type, storage_kind)
 }
 
 fn temporal_select_column_sql_from_quoted(
 	backend: DbBackend,
 	quoted_column: &str,
 	field_type: &str,
+	storage_kind: Option<crate::orm::DatabaseStorageKind>,
 ) -> String {
 	match backend {
+		DbBackend::Postgres
+			if field_type.contains("DateTimeField")
+				&& storage_kind == Some(crate::orm::DatabaseStorageKind::NaiveDateTime) =>
+		{
+			format!("TO_CHAR({quoted_column}, 'YYYY-MM-DD\"T\"HH24:MI:SS.US')")
+		}
 		DbBackend::Postgres if field_type.contains("DateTimeField") => {
 			format!(
 				"TO_CHAR(({quoted_column} AT TIME ZONE 'UTC'), 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')"
@@ -1864,12 +1888,14 @@ fn temporal_select_column_sql_from_quoted(
 	}
 }
 
-fn temporal_select_column_alias_sql(
+fn temporal_select_column_alias_sql_with_storage(
 	backend: DbBackend,
 	column_name: &str,
 	field_type: &str,
+	storage_kind: Option<crate::orm::DatabaseStorageKind>,
 ) -> String {
-	let expression = temporal_select_column_sql(backend, column_name, field_type);
+	let expression =
+		temporal_select_column_sql_with_storage(backend, column_name, field_type, storage_kind);
 	match backend {
 		DbBackend::Postgres | DbBackend::Sqlite => {
 			format!("{} AS \"{}\"", expression, column_name)
@@ -3986,6 +4012,37 @@ mod tests {
 		assert_eq!(
 			json_or_array_select_column_sql(DbBackend::Sqlite, &field, "tags"),
 			"\"tags\""
+		);
+	}
+
+	#[rstest]
+	fn postgres_vector_selects_are_text_for_json_decoding() {
+		let mut field = test_field_info(
+			"embedding",
+			"reinhardt.orm.models.VectorField",
+			false,
+			false,
+		);
+		field.storage_kind = None;
+
+		assert_eq!(
+			json_or_array_select_column_sql(DbBackend::Postgres, &field, "embedding"),
+			"\"embedding\"::text"
+		);
+	}
+
+	#[rstest]
+	fn postgres_naive_datetime_projection_preserves_wall_clock_value() {
+		let sql = temporal_select_column_sql_with_storage(
+			DbBackend::Postgres,
+			"created_at",
+			"reinhardt.orm.models.DateTimeField",
+			Some(crate::orm::DatabaseStorageKind::NaiveDateTime),
+		);
+
+		assert_eq!(
+			sql,
+			"TO_CHAR(\"created_at\", 'YYYY-MM-DD\"T\"HH24:MI:SS.US')"
 		);
 	}
 

--- a/crates/reinhardt-db/src/orm/session.rs
+++ b/crates/reinhardt-db/src/orm/session.rs
@@ -14,6 +14,7 @@
 //! This module provides a Session object that manages database operations with automatic
 //! object tracking, identity mapping, and unit-of-work persistence.
 
+use crate::backends::types::{DatabaseType, RowLockCapabilities};
 use crate::orm::FieldCodecError;
 use crate::orm::field_codec::database_value_to_query_value;
 use crate::orm::inspection::FieldInfo;
@@ -23,8 +24,8 @@ use crate::orm::query_types::{DbBackend, QueryStatement};
 use base64::Engine;
 use reinhardt_query::value::Value as RValue;
 use reinhardt_query::{
-	Alias, Expr, ExprTrait, LockType, MySqlQueryBuilder, PostgresQueryBuilder, Query as RQuery,
-	QueryStatementBuilder, SelectStatement, SimpleExpr, SqliteQueryBuilder,
+	Alias, ColumnRef, Expr, ExprTrait, LockType, MySqlQueryBuilder, PostgresQueryBuilder,
+	Query as RQuery, QueryStatementBuilder, SelectStatement, SimpleExpr, SqliteQueryBuilder,
 };
 use serde_json::Value;
 use sqlx::{AnyPool, Row};
@@ -923,13 +924,32 @@ impl Session {
 		if fields.is_empty() {
 			return Ok(Vec::new());
 		}
+		if queryset.is_empty_result() {
+			return Ok(Vec::new());
+		}
+
+		let (database_type, capabilities) = match self.db_backend {
+			DbBackend::Postgres => (DatabaseType::Postgres, RowLockCapabilities::postgres()),
+			DbBackend::Mysql => (DatabaseType::Mysql, RowLockCapabilities::mysql()),
+			DbBackend::Sqlite => (DatabaseType::Sqlite, RowLockCapabilities::unsupported()),
+		};
+		queryset
+			.validate_select_for_update(capabilities, database_type)
+			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
+		if lock_rows && !capabilities.update {
+			return Err(SessionError::DatabaseError(
+				"SELECT FOR UPDATE is not supported by this backend or server version".to_owned(),
+			));
+		}
 
 		let mut statement = queryset
 			.build_full_model_select_statement()
 			.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
 		let root_alias = queryset.root_alias().to_owned();
 		apply_any_model_projection::<T>(&mut statement, self.db_backend, &root_alias)?;
-		if lock_rows && matches!(self.db_backend, DbBackend::Postgres | DbBackend::Mysql) {
+		if lock_rows {
+			self.lock_nullable_relation_rows(queryset, &statement, connection)
+				.await?;
 			statement.clear_distinct();
 			statement.lock(LockType::Update);
 			let mut lock_tables = vec![Alias::new(root_alias)];
@@ -955,6 +975,45 @@ impl Session {
 		rows.iter()
 			.map(|row| deserialize_any_row::<T>(row, &fields))
 			.collect()
+	}
+
+	async fn lock_nullable_relation_rows<T>(
+		&self,
+		queryset: &QuerySet<T>,
+		source_statement: &SelectStatement,
+		connection: &mut sqlx::AnyConnection,
+	) -> Result<(), SessionError>
+	where
+		T: Model + serde::de::DeserializeOwned + 'static,
+	{
+		for (table, alias, column) in queryset.nullable_filter_relations_for_lock() {
+			let mut subquery = source_statement.clone();
+			subquery.clear_selects();
+			subquery.column((Alias::new(&alias), Alias::new(&column)));
+
+			// Lock nullable relation rows through a single-table statement so the
+			// backend never applies FOR UPDATE to the nullable side of an outer join.
+			let mut statement = RQuery::select();
+			statement
+				.column(ColumnRef::table_asterisk(Alias::new(&alias)))
+				.from_as(Alias::new(&table), Alias::new(&alias))
+				.and_where(
+					Expr::col((Alias::new(&alias), Alias::new(&column))).in_subquery(subquery),
+				)
+				.lock(LockType::Update);
+			let (sql, values) = QueryStatement::Select(statement).build(self.db_backend);
+			let sql = sql_with_postgres_parameter_casts(self.db_backend, &sql, &values);
+			let mut query = sqlx::query(sql.as_ref());
+			for value in &values.0 {
+				query = bind_reinhardt_query_value(query, value, self.db_backend)?;
+			}
+			query
+				.fetch_all(&mut *connection)
+				.await
+				.map_err(|error| SessionError::DatabaseError(error.to_string()))?;
+		}
+
+		Ok(())
 	}
 
 	/// Create a query for the given model type
@@ -2893,6 +2952,63 @@ mod tests {
 				name: "inside".to_owned(),
 				email: "inside@example.com".to_owned(),
 			}]
+		);
+	}
+
+	#[rstest]
+	#[serial(sqlx_drivers)]
+	#[tokio::test]
+	async fn list_returns_empty_without_querying_none_queryset(_init_drivers: ()) {
+		// Arrange
+		let pool = Arc::new(
+			sqlx::pool::PoolOptions::<Any>::new()
+				.max_connections(1)
+				.connect("sqlite::memory:")
+				.await
+				.expect("test pool should initialize"),
+		);
+		let session = Session::new(pool, DbBackend::Sqlite)
+			.await
+			.expect("session should initialize");
+
+		// Act
+		let users = session
+			.list(&QuerySet::<TestUser>::new().none())
+			.await
+			.expect("none queryset should not access the missing table");
+
+		// Assert
+		assert_eq!(users, Vec::<TestUser>::new());
+	}
+
+	#[rstest]
+	#[serial(sqlx_drivers)]
+	#[tokio::test]
+	async fn list_with_connection_for_update_rejects_unsupported_backend(_init_drivers: ()) {
+		// Arrange
+		let pool = Arc::new(
+			sqlx::pool::PoolOptions::<Any>::new()
+				.max_connections(1)
+				.connect("sqlite::memory:")
+				.await
+				.expect("test pool should initialize"),
+		);
+		let session = Session::new(pool.clone(), DbBackend::Sqlite)
+			.await
+			.expect("session should initialize");
+		let mut connection = pool.acquire().await.expect("connection should acquire");
+
+		// Act
+		let result = session
+			.list_with_connection_for_update(&QuerySet::<TestUser>::new(), &mut connection)
+			.await;
+
+		// Assert
+		assert_eq!(
+			result,
+			Err(SessionError::DatabaseError(
+				"SELECT FOR UPDATE is not supported by this backend or server version".to_owned(),
+			))
 		);
 	}
 

--- a/crates/reinhardt-query/src/query/select.rs
+++ b/crates/reinhardt-query/src/query/select.rs
@@ -619,6 +619,12 @@ impl SelectStatement {
 		self
 	}
 
+	/// Clear DISTINCT from a statement before a backend-specific row lock.
+	pub fn clear_distinct(&mut self) -> &mut Self {
+		self.distinct = None;
+		self
+	}
+
 	// UNION methods
 
 	/// Add a UNION clause

--- a/crates/reinhardt-views/README.md
+++ b/crates/reinhardt-views/README.md
@@ -301,6 +301,13 @@ The crate includes comprehensive unit tests covering:
 - **ModelViewSet** - Full CRUD operations (list, retrieve, create, update, destroy) for model-based APIs
 - **ReadOnlyModelViewSet** - Read-only operations (list, retrieve) for immutable resources
 
+Database-backed model viewsets can scope every read or mutation to the current
+request by implementing `QuerySetProvider<M>` and passing it to
+`with_queryset_provider`. The provider receives `Model::objects().all()` so
+custom manager predicates are retained; the handler adds the typed route-PK
+predicate for detail actions. A configured database pool is required, and
+create does not invoke the provider.
+
 #### Action System
 
 - **Action Types** - Comprehensive action type system supporting standard CRUD operations and custom actions

--- a/crates/reinhardt-views/src/viewsets.rs
+++ b/crates/reinhardt-views/src/viewsets.rs
@@ -227,7 +227,7 @@ pub use batch_operations::{
 pub use builder::{RegisterViewSet, ViewSetBuilder};
 pub use cached::{CacheConfig, CachedResponse, CachedViewSet, CachedViewSetTrait};
 pub use filtering_support::{FilterConfig, FilterableViewSet, InMemoryFilter, OrderingConfig};
-pub use handler::{ModelViewSetHandler, ViewError, ViewSetHandler};
+pub use handler::{ModelViewSetHandler, QuerySetProvider, ViewError, ViewSetHandler};
 pub use injectable::InjectableViewSet;
 pub use metadata::{ActionHandler, ActionMetadata, ActionRegistryEntry, FunctionActionHandler};
 pub use middleware::{

--- a/crates/reinhardt-views/src/viewsets/handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler.rs
@@ -22,5 +22,5 @@ pub mod model_view_set_handler;
 pub mod view_set_handler;
 
 pub use error::ViewError;
-pub use model_view_set_handler::ModelViewSetHandler;
+pub use model_view_set_handler::{ModelViewSetHandler, QuerySetProvider};
 pub use view_set_handler::ViewSetHandler;

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -27,6 +27,23 @@ fn map_serializer_error(error: reinhardt_core::serializers::SerializerError) -> 
 	}
 }
 
+async fn begin_mutation_transaction<T: Model>(
+	pool: &sqlx::AnyPool,
+	backend: DbBackend,
+	queryset: &QuerySet<T>,
+) -> std::result::Result<sqlx::Transaction<'static, sqlx::Any>, sqlx::Error> {
+	if !queryset.has_subquery_conditions() {
+		return pool.begin().await;
+	}
+
+	let statement = match backend {
+		DbBackend::Postgres => "BEGIN ISOLATION LEVEL SERIALIZABLE",
+		DbBackend::Mysql => "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; START TRANSACTION",
+		DbBackend::Sqlite => "BEGIN EXCLUSIVE",
+	};
+	pool.begin_with(statement).await
+}
+
 fn parse_length_prefixed_composite_parts<'a>(
 	inner: &'a str,
 	fields: &[String],
@@ -1075,15 +1092,21 @@ where
 					ViewError::DatabaseError(format!("Failed to create session: {}", e))
 				})?;
 
-			// Recheck and mutate through one dedicated transaction connection.
-			let mut transaction = pool.begin().await.map_err(|e| {
-				ViewError::DatabaseError(format!("Failed to begin transaction: {}", e))
-			})?;
 			let mutation_queryset = self
 				.database_queryset(request)?
 				.filter(self.primary_key_filter(&pk)?)
 				.limit(1)
 				.without_distinct();
+			// Recheck and mutate through one dedicated transaction connection. A
+			// serializable transaction is required when the authorization predicate
+			// includes a subquery, because row locks cannot protect missing rows or
+			// predicate gaps from concurrent inserts.
+			let mut transaction =
+				begin_mutation_transaction(pool.as_ref(), self.db_backend, &mutation_queryset)
+					.await
+					.map_err(|e| {
+						ViewError::DatabaseError(format!("Failed to begin transaction: {}", e))
+					})?;
 			let rechecked_items = if self.db_backend == DbBackend::Sqlite {
 				session
 					.list_with_connection(&mutation_queryset, &mut transaction)
@@ -1197,14 +1220,17 @@ where
 					ViewError::DatabaseError(format!("Failed to create session: {}", e))
 				})?;
 
-			let mut transaction = pool.begin().await.map_err(|e| {
-				ViewError::DatabaseError(format!("Failed to begin transaction: {}", e))
-			})?;
 			let mutation_queryset = self
 				.database_queryset(request)?
 				.filter(self.primary_key_filter(&pk)?)
 				.limit(1)
 				.without_distinct();
+			let mut transaction =
+				begin_mutation_transaction(pool.as_ref(), self.db_backend, &mutation_queryset)
+					.await
+					.map_err(|e| {
+						ViewError::DatabaseError(format!("Failed to begin transaction: {}", e))
+					})?;
 			let rechecked_items = if self.db_backend == DbBackend::Sqlite {
 				session
 					.list_with_connection(&mutation_queryset, &mut transaction)

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -36,21 +36,16 @@ fn execute_mysql_control_statement<'a>(
 	)
 }
 
-fn begin_mysql_serializable(
+async fn begin_mysql_serializable(
 	pool: &sqlx::AnyPool,
-) -> impl std::future::Future<
-	Output = std::result::Result<sqlx::Transaction<'static, sqlx::Any>, sqlx::Error>,
-> + Send
-+ '_ {
-	async move {
-		let mut connection = pool.acquire().await?;
-		execute_mysql_control_statement(&mut *connection).await?;
-		sqlx::Transaction::begin(
-			connection,
-			Some(std::borrow::Cow::Borrowed("START TRANSACTION")),
-		)
-		.await
-	}
+) -> std::result::Result<sqlx::Transaction<'static, sqlx::Any>, sqlx::Error> {
+	let mut connection = pool.acquire().await?;
+	execute_mysql_control_statement(&mut connection).await?;
+	sqlx::Transaction::begin(
+		connection,
+		Some(std::borrow::Cow::Borrowed("START TRANSACTION")),
+	)
+	.await
 }
 
 async fn begin_mutation_transaction<T: Model>(

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -1031,7 +1031,7 @@ where
 				.filter(self.primary_key_filter(&pk)?)
 				.limit(1);
 			if session
-				.list_with_connection(&mutation_queryset, &mut *transaction)
+				.list_with_connection_for_update(&mutation_queryset, &mut *transaction)
 				.await
 				.map_err(|e| ViewError::DatabaseError(format!("Failed to recheck object: {}", e)))?
 				.into_iter()
@@ -1144,7 +1144,7 @@ where
 				.filter(self.primary_key_filter(&pk)?)
 				.limit(1);
 			let item = session
-				.list_with_connection(&mutation_queryset, &mut *transaction)
+				.list_with_connection_for_update(&mutation_queryset, &mut *transaction)
 				.await
 				.map_err(|e| ViewError::DatabaseError(format!("Failed to recheck object: {}", e)))?
 				.into_iter()

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -627,6 +627,31 @@ where
 			.ok_or_else(|| ViewError::NotFound(format!("Object with pk={} not found", pk)))
 	}
 
+	fn apply_patch_to_item(
+		&self,
+		serializer: &dyn Serializer<Input = T, Output = String>,
+		base: &T,
+		patch_data: &serde_json::Value,
+	) -> std::result::Result<T, ViewError> {
+		let base_json = serializer.serialize(base).map_err(map_serializer_error)?;
+		let mut value: serde_json::Value = serde_json::from_str(&base_json).map_err(|error| {
+			ViewError::Serialization(format!("Failed to parse existing: {error}"))
+		})?;
+		crate::generic::patch_utils::merge_patch_object_into(&mut value, patch_data)
+			.map_err(ViewError::BadRequest)?;
+		let merged_json = serde_json::to_string(&value).map_err(|error| {
+			ViewError::Serialization(format!("Failed to serialize merged: {error}"))
+		})?;
+		let mut updated_item = serializer
+			.deserialize(&merged_json)
+			.map_err(map_serializer_error)?;
+		let primary_key = base
+			.primary_key()
+			.ok_or_else(|| ViewError::Internal("Object has no primary key".to_owned()))?;
+		updated_item.set_primary_key(primary_key);
+		Ok(updated_item)
+	}
+
 	/// Get the serializer for this handler
 	fn get_serializer(&self) -> Arc<dyn Serializer<Input = T, Output = String> + Send + Sync> {
 		self.serializer_class
@@ -1085,33 +1110,6 @@ where
 		let patch_data: serde_json::Value = serde_json::from_str(&body_str)
 			.map_err(|e| ViewError::Serialization(format!("Invalid JSON: {}", e)))?;
 
-		// Serialize existing object to JSON and merge with patch data
-		let existing_json = serializer
-			.serialize(&existing_obj)
-			.map_err(map_serializer_error)?;
-		let mut existing_value: serde_json::Value = serde_json::from_str(&existing_json)
-			.map_err(|e| ViewError::Serialization(format!("Failed to parse existing: {}", e)))?;
-
-		// Validate and merge patch data into existing object (only overwrites provided fields)
-		crate::generic::patch_utils::merge_patch_object_into(&mut existing_value, &patch_data)
-			.map_err(ViewError::BadRequest)?;
-
-		// Deserialize merged object back to model type
-		let merged_json = serde_json::to_string(&existing_value)
-			.map_err(|e| ViewError::Serialization(format!("Failed to serialize merged: {}", e)))?;
-		let mut updated_item: T = serializer
-			.deserialize(&merged_json)
-			.map_err(map_serializer_error)?;
-		let existing_pk = existing_obj
-			.primary_key()
-			.ok_or_else(|| ViewError::Internal("Object has no primary key".to_owned()))?;
-		// The route/scoped object is authoritative. A PATCH body must not redirect
-		// the write to another primary key.
-		updated_item.set_primary_key(existing_pk);
-		let response_body = serializer
-			.serialize(&updated_item)
-			.map_err(map_serializer_error)?;
-
 		// Update database if pool is available
 		if let Some(pool) = &self.pool {
 			let pool = Arc::clone(pool);
@@ -1146,17 +1144,18 @@ where
 					.list_with_connection_for_update(&mutation_queryset, &mut transaction)
 					.await
 			};
-			if rechecked_items
+			let locked_item = rechecked_items
 				.map_err(|e| ViewError::DatabaseError(format!("Failed to recheck object: {}", e)))?
 				.into_iter()
 				.next()
-				.is_none()
-			{
-				return Err(ViewError::NotFound(format!(
-					"Object with pk={} not found",
-					pk
-				)));
-			}
+				.ok_or_else(|| ViewError::NotFound(format!("Object with pk={} not found", pk)))?;
+
+			// Build the PATCH state from the row protected by the transaction lock.
+			let updated_item =
+				self.apply_patch_to_item(serializer.as_ref(), &locked_item, &patch_data)?;
+			let response_body = serializer
+				.serialize(&updated_item)
+				.map_err(map_serializer_error)?;
 
 			// Add updated object to session (marks as dirty for UPDATE)
 			session
@@ -1174,7 +1173,15 @@ where
 				.commit()
 				.await
 				.map_err(|e| ViewError::DatabaseError(format!("Failed to commit: {}", e)))?;
+
+			return Ok(Response::ok().with_body(response_body));
 		}
+
+		let updated_item =
+			self.apply_patch_to_item(serializer.as_ref(), &existing_obj, &patch_data)?;
+		let response_body = serializer
+			.serialize(&updated_item)
+			.map_err(map_serializer_error)?;
 
 		// Return the complete merged/updated object
 		Ok(Response::ok().with_body(response_body))

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -1084,9 +1084,16 @@ where
 				.filter(self.primary_key_filter(&pk)?)
 				.limit(1)
 				.without_distinct();
-			if session
-				.list_with_connection_for_update(&mutation_queryset, &mut *transaction)
-				.await
+			let rechecked_items = if self.db_backend == DbBackend::Sqlite {
+				session
+					.list_with_connection(&mutation_queryset, &mut *transaction)
+					.await
+			} else {
+				session
+					.list_with_connection_for_update(&mutation_queryset, &mut *transaction)
+					.await
+			};
+			if rechecked_items
 				.map_err(|e| ViewError::DatabaseError(format!("Failed to recheck object: {}", e)))?
 				.into_iter()
 				.next()
@@ -1198,9 +1205,16 @@ where
 				.filter(self.primary_key_filter(&pk)?)
 				.limit(1)
 				.without_distinct();
-			let item = session
-				.list_with_connection_for_update(&mutation_queryset, &mut *transaction)
-				.await
+			let rechecked_items = if self.db_backend == DbBackend::Sqlite {
+				session
+					.list_with_connection(&mutation_queryset, &mut *transaction)
+					.await
+			} else {
+				session
+					.list_with_connection_for_update(&mutation_queryset, &mut *transaction)
+					.await
+			};
+			let item = rechecked_items
 				.map_err(|e| ViewError::DatabaseError(format!("Failed to recheck object: {}", e)))?
 				.into_iter()
 				.next()

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -27,18 +27,48 @@ fn map_serializer_error(error: reinhardt_core::serializers::SerializerError) -> 
 	}
 }
 
+fn execute_mysql_control_statement<'a>(
+	connection: &'a mut sqlx::AnyConnection,
+) -> impl std::future::Future<Output = sqlx::Result<sqlx::any::AnyQueryResult>> + Send + 'a {
+	<&'a mut sqlx::AnyConnection as sqlx::Executor<'a>>::execute(
+		connection,
+		sqlx::raw_sql("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"),
+	)
+}
+
+fn begin_mysql_serializable(
+	pool: &sqlx::AnyPool,
+) -> impl std::future::Future<
+	Output = std::result::Result<sqlx::Transaction<'static, sqlx::Any>, sqlx::Error>,
+> + Send
++ '_ {
+	async move {
+		let mut connection = pool.acquire().await?;
+		execute_mysql_control_statement(&mut *connection).await?;
+		sqlx::Transaction::begin(
+			connection,
+			Some(std::borrow::Cow::Borrowed("START TRANSACTION")),
+		)
+		.await
+	}
+}
+
 async fn begin_mutation_transaction<T: Model>(
 	pool: &sqlx::AnyPool,
 	backend: DbBackend,
 	queryset: &QuerySet<T>,
 ) -> std::result::Result<sqlx::Transaction<'static, sqlx::Any>, sqlx::Error> {
-	if !queryset.has_subquery_conditions() {
+	if !queryset.requires_serializable_transaction() {
 		return pool.begin().await;
+	}
+
+	if backend == DbBackend::Mysql {
+		return begin_mysql_serializable(pool).await;
 	}
 
 	let statement = match backend {
 		DbBackend::Postgres => "BEGIN ISOLATION LEVEL SERIALIZABLE",
-		DbBackend::Mysql => "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; START TRANSACTION",
+		DbBackend::Mysql => unreachable!("MySQL transactions use separate control statements"),
 		DbBackend::Sqlite => "BEGIN EXCLUSIVE",
 	};
 	pool.begin_with(statement).await
@@ -1085,6 +1115,7 @@ where
 
 		// Update database if pool is available
 		if let Some(pool) = &self.pool {
+			let pool = Arc::clone(pool);
 			// Create a new session for this request
 			let mut session = reinhardt_db::prelude::Session::new(pool.clone(), self.db_backend)
 				.await
@@ -1213,6 +1244,7 @@ where
 
 		// Delete from database if pool is available
 		if let Some(pool) = &self.pool {
+			let pool = Arc::clone(pool);
 			// Create a new session for this request
 			let mut session = reinhardt_db::prelude::Session::new(pool.clone(), self.db_backend)
 				.await

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -27,6 +27,71 @@ fn map_serializer_error(error: reinhardt_core::serializers::SerializerError) -> 
 	}
 }
 
+fn parse_length_prefixed_composite_parts<'a>(
+	inner: &'a str,
+	fields: &[String],
+) -> Option<Vec<&'a str>> {
+	if fields.is_empty() {
+		return None;
+	}
+
+	let mut cursor = inner;
+	let mut parts = Vec::with_capacity(fields.len());
+	for (index, field_name) in fields.iter().enumerate() {
+		let value_start = cursor.strip_prefix(&format!("{field_name}="))?;
+		let length_separator = value_start.find(':')?;
+		let length = value_start[..length_separator].parse::<usize>().ok()?;
+		let content_start = length_separator + 1;
+		let content_end = content_start.checked_add(length)?;
+		let value = value_start.get(content_start..content_end)?;
+		let remainder = value_start.get(content_end..)?;
+
+		if index + 1 == fields.len() {
+			if !remainder.is_empty() {
+				return None;
+			}
+		} else {
+			cursor = remainder.strip_prefix(", ")?;
+		}
+		parts.push(value);
+	}
+
+	Some(parts)
+}
+
+fn parse_legacy_composite_parts<'a, F>(
+	cursor: &'a str,
+	fields: &[String],
+	index: usize,
+	is_valid_part: &F,
+) -> Option<Vec<&'a str>>
+where
+	F: Fn(usize, &str) -> bool,
+{
+	let field_name = fields.get(index)?;
+	let value_start = cursor.strip_prefix(&format!("{field_name}="))?;
+	if index + 1 == fields.len() {
+		return is_valid_part(index, value_start).then(|| vec![value_start]);
+	}
+
+	let delimiter = format!(", {}=", fields[index + 1]);
+	for (position, _) in value_start.match_indices(&delimiter) {
+		let part = &value_start[..position];
+		if !is_valid_part(index, part) {
+			continue;
+		}
+		let next_cursor = &value_start[position + 2..];
+		if let Some(mut tail) =
+			parse_legacy_composite_parts(next_cursor, fields, index + 1, is_valid_part)
+		{
+			tail.insert(0, part);
+			return Some(tail);
+		}
+	}
+
+	None
+}
+
 fn primary_key_filter_for_model<T: Model>(
 	pk: &serde_json::Value,
 ) -> std::result::Result<FilterCondition, ViewError> {
@@ -48,33 +113,18 @@ fn primary_key_filter_for_model<T: Model>(
 		.and_then(|value| value.strip_suffix(')'))
 		.ok_or_else(|| ViewError::NotFound(format!("Object with pk={} not found", pk_string)))?;
 	let fields = composite.fields();
-	let mut cursor = inner;
-	let mut parts = Vec::with_capacity(fields.len());
-	for (index, field_name) in fields.iter().enumerate() {
-		let prefix = format!("{field_name}=");
-		let value_start = cursor.strip_prefix(&prefix).ok_or_else(|| {
-			ViewError::NotFound(format!("Object with pk={} not found", pk_string))
-		})?;
-		if index + 1 == fields.len() {
-			parts.push(value_start);
-			cursor = "";
-		} else {
-			let delimiter = format!(", {}=", fields[index + 1]);
-			let delimiter_position = value_start.find(&delimiter).ok_or_else(|| {
-				ViewError::NotFound(format!("Object with pk={} not found", pk_string))
-			})?;
-			parts.push(&value_start[..delimiter_position]);
-			cursor = &value_start[delimiter_position + 2..];
-		}
-	}
-	if !cursor.is_empty() || parts.len() != fields.len() {
-		return Err(ViewError::NotFound(format!(
-			"Object with pk={} not found",
-			pk_string
-		)));
-	}
-
 	let metadata = T::field_metadata();
+	let is_valid_part = |index: usize, part: &str| {
+		let field_name = &fields[index];
+		match metadata.iter().find(|field| field.name == *field_name) {
+			Some(field) => filter_value_from_field(field, part).is_ok(),
+			None => true,
+		}
+	};
+	let parts = parse_length_prefixed_composite_parts(inner, fields)
+		.or_else(|| parse_legacy_composite_parts(inner, fields, 0, &is_valid_part));
+	let parts = parts
+		.ok_or_else(|| ViewError::NotFound(format!("Object with pk={} not found", pk_string)))?;
 	let filters = fields
 		.iter()
 		.zip(parts)
@@ -1205,6 +1255,27 @@ mod tests {
 			.body(Bytes::new())
 			.build()
 			.unwrap()
+	}
+
+	#[rstest]
+	fn composite_pk_parser_preserves_delimiters_in_length_prefixed_values() {
+		let fields = vec!["namespace".to_owned(), "id".to_owned()];
+		let parts =
+			parse_length_prefixed_composite_parts("namespace=9:a, id=999, id=3:123", &fields)
+				.expect("length-prefixed composite keys should parse");
+
+		assert_eq!(parts, vec!["a, id=999", "123"]);
+	}
+
+	#[rstest]
+	fn legacy_composite_pk_parser_uses_typed_boundaries() {
+		let fields = vec!["namespace".to_owned(), "id".to_owned()];
+		let is_valid = |index: usize, value: &str| index == 0 || value.parse::<i64>().is_ok();
+		let parts =
+			parse_legacy_composite_parts("namespace=a, id=999, id=1", &fields, 0, &is_valid)
+				.expect("legacy composite keys should parse");
+
+		assert_eq!(parts, vec!["a, id=999", "1"]);
 	}
 
 	// -----------------------------------------------------------------------

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -1086,11 +1086,11 @@ where
 				.without_distinct();
 			let rechecked_items = if self.db_backend == DbBackend::Sqlite {
 				session
-					.list_with_connection(&mutation_queryset, &mut *transaction)
+					.list_with_connection(&mutation_queryset, &mut transaction)
 					.await
 			} else {
 				session
-					.list_with_connection_for_update(&mutation_queryset, &mut *transaction)
+					.list_with_connection_for_update(&mutation_queryset, &mut transaction)
 					.await
 			};
 			if rechecked_items
@@ -1113,7 +1113,7 @@ where
 
 			// Flush changes to database (generates and executes UPDATE)
 			session
-				.flush_with_connection(&mut *transaction)
+				.flush_with_connection(&mut transaction)
 				.await
 				.map_err(|e| ViewError::DatabaseError(format!("Failed to flush: {}", e)))?;
 
@@ -1207,11 +1207,11 @@ where
 				.without_distinct();
 			let rechecked_items = if self.db_backend == DbBackend::Sqlite {
 				session
-					.list_with_connection(&mutation_queryset, &mut *transaction)
+					.list_with_connection(&mutation_queryset, &mut transaction)
 					.await
 			} else {
 				session
-					.list_with_connection_for_update(&mutation_queryset, &mut *transaction)
+					.list_with_connection_for_update(&mutation_queryset, &mut transaction)
 					.await
 			};
 			let item = rechecked_items
@@ -1227,7 +1227,7 @@ where
 
 			// Flush changes to database (generates and executes DELETE)
 			session
-				.flush_with_connection(&mut *transaction)
+				.flush_with_connection(&mut transaction)
 				.await
 				.map_err(|e| ViewError::DatabaseError(format!("Failed to flush: {}", e)))?;
 

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -596,6 +596,19 @@ where
 		}
 	}
 
+	fn database_detail_queryset(
+		&self,
+		request: &Request,
+	) -> std::result::Result<QuerySet<T>, ViewError> {
+		let queryset = self.database_queryset(request)?;
+		if queryset.has_slicing() {
+			return Err(ViewError::BadRequest(
+				"detail actions do not support sliced provider querysets".to_owned(),
+			));
+		}
+		Ok(queryset)
+	}
+
 	fn primary_key_filter(
 		&self,
 		pk: &serde_json::Value,
@@ -609,7 +622,7 @@ where
 		pk: &serde_json::Value,
 	) -> std::result::Result<T, ViewError> {
 		let queryset = self
-			.database_queryset(request)?
+			.database_detail_queryset(request)?
 			.filter(self.primary_key_filter(pk)?)
 			.limit(1);
 		let pool = self.pool.as_ref().ok_or_else(|| {
@@ -1121,7 +1134,7 @@ where
 				})?;
 
 			let mutation_queryset = self
-				.database_queryset(request)?
+				.database_detail_queryset(request)?
 				.filter(self.primary_key_filter(&pk)?)
 				.limit(1)
 				.without_distinct();
@@ -1259,7 +1272,7 @@ where
 				})?;
 
 			let mutation_queryset = self
-				.database_queryset(request)?
+				.database_detail_queryset(request)?
 				.filter(self.primary_key_filter(&pk)?)
 				.limit(1)
 				.without_distinct();

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -35,7 +35,7 @@ fn parse_length_prefixed_composite_parts<'a>(
 		return None;
 	}
 
-	let mut cursor = inner;
+	let mut cursor = inner.strip_prefix("v2;")?;
 	let mut parts = Vec::with_capacity(fields.len());
 	for (index, field_name) in fields.iter().enumerate() {
 		let value_start = cursor.strip_prefix(&format!("{field_name}="))?;
@@ -1275,10 +1275,20 @@ mod tests {
 	fn composite_pk_parser_preserves_delimiters_in_length_prefixed_values() {
 		let fields = vec!["namespace".to_owned(), "id".to_owned()];
 		let parts =
-			parse_length_prefixed_composite_parts("namespace=9:a, id=999, id=3:123", &fields)
+			parse_length_prefixed_composite_parts("v2;namespace=9:a, id=999, id=3:123", &fields)
 				.expect("length-prefixed composite keys should parse");
 
 		assert_eq!(parts, vec!["a, id=999", "123"]);
+	}
+
+	#[rstest]
+	fn composite_pk_parser_requires_a_version_marker_for_length_prefixed_values() {
+		let fields = vec!["namespace".to_owned(), "id".to_owned()];
+
+		assert!(
+			parse_length_prefixed_composite_parts("namespace=9:a, id=999, id=3:123", &fields)
+				.is_none()
+		);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -122,6 +122,7 @@ where
 	}
 
 	let delimiter = format!(", {}=", fields[index + 1]);
+	let mut parsed = None;
 	for (position, _) in value_start.match_indices(&delimiter) {
 		let part = &value_start[..position];
 		if !is_valid_part(index, part) {
@@ -132,11 +133,14 @@ where
 			parse_legacy_composite_parts(next_cursor, fields, index + 1, is_valid_part)
 		{
 			tail.insert(0, part);
-			return Some(tail);
+			if parsed.is_some() {
+				return None;
+			}
+			parsed = Some(tail);
 		}
 	}
 
-	None
+	parsed
 }
 
 fn primary_key_filter_for_model<T: Model>(
@@ -1358,6 +1362,17 @@ mod tests {
 				.expect("legacy composite keys should parse");
 
 		assert_eq!(parts, vec!["a, id=999", "1"]);
+	}
+
+	#[rstest]
+	fn legacy_composite_pk_parser_rejects_ambiguous_string_boundaries() {
+		let fields = vec!["namespace".to_owned(), "slug".to_owned()];
+		let is_valid = |_index: usize, _value: &str| true;
+
+		assert!(
+			parse_legacy_composite_parts("namespace=a, slug=x, slug=y", &fields, 0, &is_valid)
+				.is_none()
+		);
 	}
 
 	// -----------------------------------------------------------------------

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -7,7 +7,9 @@
 
 use super::error::ViewError;
 use reinhardt_auth::{Permission, PermissionContext};
-use reinhardt_db::orm::{Model, query_types::DbBackend};
+use reinhardt_db::orm::{
+	CustomManager, Filter, FilterOperator, Model, QuerySet, query_types::DbBackend,
+};
 use reinhardt_http::{AuthState, Request, Response};
 use reinhardt_rest::filters::FilterBackend;
 use reinhardt_rest::serializers::{ModelSerializer, Serializer};
@@ -21,6 +23,23 @@ fn map_serializer_error(error: reinhardt_core::serializers::SerializerError) -> 
 		reinhardt_core::serializers::SerializerError::Database(error) => ViewError::Database(error),
 		error => ViewError::Serialization(error.to_string()),
 	}
+}
+
+/// Supplies a request-scoped database queryset to a model view handler.
+///
+/// The handler creates the base queryset from `Model::objects().all()` and
+/// passes it to this provider. Implementations should return a transformed
+/// queryset so manager predicates are retained.
+pub trait QuerySetProvider<M>: Send + Sync
+where
+	M: Model,
+{
+	/// Apply request-specific predicates to the supplied base queryset.
+	fn get_queryset(
+		&self,
+		request: &Request,
+		base: QuerySet<M>,
+	) -> std::result::Result<QuerySet<M>, ViewError>;
 }
 
 /// Django REST Framework-style ViewSet handler for models.
@@ -70,6 +89,7 @@ where
 	serializer_class: Option<Arc<dyn Serializer<Input = T, Output = String> + Send + Sync>>,
 	permission_classes: Vec<Arc<dyn Permission>>,
 	filter_backends: Vec<Arc<dyn FilterBackend>>,
+	queryset_provider: Option<Arc<dyn QuerySetProvider<T>>>,
 	pagination_class: Option<reinhardt_core::pagination::PaginatorImpl>,
 	pool: Option<Arc<sqlx::AnyPool>>,
 	/// Database backend type (default: PostgreSQL)
@@ -120,6 +140,7 @@ where
 			serializer_class: None,
 			permission_classes: Vec::new(),
 			filter_backends: Vec::new(),
+			queryset_provider: None,
 			pagination_class: None,
 			pool: None,
 			db_backend: DbBackend::Postgres, // Default to PostgreSQL
@@ -167,6 +188,19 @@ where
 	/// ```
 	pub fn with_queryset(mut self, queryset: Vec<T>) -> Self {
 		self.queryset = Some(queryset);
+		self
+	}
+
+	/// Set a request-scoped database queryset provider.
+	///
+	/// The provider is used for list, retrieve, update, and destroy actions.
+	/// Create deliberately does not invoke it. A database pool must be
+	/// configured when a provider is registered; otherwise requests fail closed.
+	pub fn with_queryset_provider<P>(mut self, provider: P) -> Self
+	where
+		P: QuerySetProvider<T> + 'static,
+	{
+		self.queryset_provider = Some(Arc::new(provider));
 		self
 	}
 
@@ -360,6 +394,68 @@ where
 		self.queryset.as_deref().unwrap_or(&[])
 	}
 
+	fn ensure_provider_pool(&self) -> std::result::Result<(), ViewError> {
+		if self.queryset_provider.is_some() && self.pool.is_none() {
+			return Err(ViewError::Internal(
+				"with_queryset_provider requires a database pool".to_owned(),
+			));
+		}
+		Ok(())
+	}
+
+	fn database_queryset(&self, request: &Request) -> std::result::Result<QuerySet<T>, ViewError> {
+		self.ensure_provider_pool()?;
+		if self.pool.is_none() {
+			return Err(ViewError::Internal(
+				"database queryset requires a database pool".to_owned(),
+			));
+		}
+
+		let base = T::objects().all();
+		match &self.queryset_provider {
+			Some(provider) => provider.get_queryset(request, base),
+			None => Ok(base),
+		}
+	}
+
+	fn primary_key_filter(&self, pk: &serde_json::Value) -> std::result::Result<Filter, ViewError> {
+		let pk_string = match pk {
+			serde_json::Value::String(value) => value.clone(),
+			value => value.to_string(),
+		};
+		let value = T::primary_key_filter_value_from_str(&pk_string)
+			.map_err(|_| ViewError::NotFound(format!("Object with pk={} not found", pk_string)))?;
+		Ok(Filter::new(
+			T::primary_key_column(),
+			FilterOperator::Eq,
+			value,
+		))
+	}
+
+	async fn database_object(
+		&self,
+		request: &Request,
+		pk: &serde_json::Value,
+	) -> std::result::Result<T, ViewError> {
+		let queryset = self
+			.database_queryset(request)?
+			.filter(self.primary_key_filter(pk)?)
+			.limit(1);
+		let pool = self.pool.as_ref().ok_or_else(|| {
+			ViewError::Internal("database queryset requires a database pool".to_owned())
+		})?;
+		let session = reinhardt_db::prelude::Session::new(pool.clone(), self.db_backend)
+			.await
+			.map_err(|error| ViewError::DatabaseError(error.to_string()))?;
+		session
+			.list(&queryset)
+			.await
+			.map_err(|error| ViewError::DatabaseError(error.to_string()))?
+			.into_iter()
+			.next()
+			.ok_or_else(|| ViewError::NotFound(format!("Object with pk={} not found", pk)))
+	}
+
 	/// Get the serializer for this handler
 	fn get_serializer(&self) -> Arc<dyn Serializer<Input = T, Output = String> + Send + Sync> {
 		self.serializer_class
@@ -469,22 +565,21 @@ where
 	/// ```
 	pub async fn list(&self, request: &Request) -> std::result::Result<Response, ViewError> {
 		self.check_permissions(request).await?;
+		self.ensure_provider_pool()?;
 
 		let serializer = self.get_serializer();
 
-		// Get items from database if pool is available, otherwise use in-memory queryset
+		// Get items from the request-scoped database queryset when a pool is set.
 		let items: Vec<T> = if let Some(pool) = &self.pool {
-			// Query database for all objects
+			let queryset = self.database_queryset(request)?;
 			let session = reinhardt_db::prelude::Session::new(pool.clone(), self.db_backend)
 				.await
-				.map_err(|e| {
-					ViewError::DatabaseError(format!("Failed to create session: {}", e))
-				})?;
+				.map_err(|error| ViewError::DatabaseError(error.to_string()))?;
 
 			session
-				.list_all()
+				.list(&queryset)
 				.await
-				.map_err(|e| ViewError::DatabaseError(format!("Failed to list objects: {}", e)))?
+				.map_err(|error| ViewError::DatabaseError(error.to_string()))?
 		} else {
 			// Use in-memory queryset
 			self.get_queryset().to_vec()
@@ -559,37 +654,13 @@ where
 		pk: serde_json::Value,
 	) -> std::result::Result<Response, ViewError> {
 		self.check_permissions(request).await?;
+		self.ensure_provider_pool()?;
 
 		let serializer = self.get_serializer();
 
-		// Get item from database if pool is available, otherwise use in-memory queryset
-		let item: T = if let Some(pool) = &self.pool {
-			// Query database for all objects and find by pk
-			let session = reinhardt_db::prelude::Session::new(pool.clone(), self.db_backend)
-				.await
-				.map_err(|e| {
-					ViewError::DatabaseError(format!("Failed to create session: {}", e))
-				})?;
-
-			let items: Vec<T> = session
-				.list_all()
-				.await
-				.map_err(|e| ViewError::DatabaseError(format!("Failed to query objects: {}", e)))?;
-
-			// Normalize pk: strip surrounding quotes from JSON string PKs for comparison
-			let pk_str = pk.to_string();
-			let pk_str = pk_str.trim_matches('"');
-
-			items
-				.into_iter()
-				.find(|item| {
-					if let Some(item_pk) = item.primary_key() {
-						item_pk.to_string() == pk_str
-					} else {
-						false
-					}
-				})
-				.ok_or_else(|| ViewError::NotFound(format!("Object with pk={} not found", pk)))?
+		// Apply the typed primary-key predicate to the manager/provider queryset.
+		let item: T = if self.pool.is_some() {
+			self.database_object(request, &pk).await?
 		} else {
 			// Use in-memory queryset
 			let queryset = self.get_queryset();
@@ -663,6 +734,9 @@ where
 	/// ```
 	pub async fn create(&self, request: &Request) -> std::result::Result<Response, ViewError> {
 		self.check_permissions(request).await?;
+		// Provider registration is a database configuration contract, but create
+		// intentionally never invokes the provider or manager queryset.
+		self.ensure_provider_pool()?;
 
 		let serializer = self.get_serializer();
 
@@ -709,20 +783,29 @@ where
 							ViewError::DatabaseError(format!("Failed to create session: {}", e))
 						})?;
 
-				// Fetch all objects and find the one with matching ID
-				let items: Vec<T> = fetch_session.list_all().await.map_err(|e| {
-					ViewError::DatabaseError(format!("Failed to fetch objects: {}", e))
-				})?;
-
-				let created_item = items
+				// Refresh through a PK-only queryset so create remains independent of
+				// request-scoped providers and custom manager predicates.
+				let pk_value =
+					T::primary_key_filter_value_from_str(&id.to_string()).map_err(|_| {
+						ViewError::DatabaseError(
+							"Failed to encode generated primary key".to_owned(),
+						)
+					})?;
+				let queryset = QuerySet::<T>::new()
+					.filter(Filter::new(
+						T::primary_key_column(),
+						FilterOperator::Eq,
+						pk_value,
+					))
+					.limit(1);
+				let created_item = fetch_session
+					.list(&queryset)
+					.await
+					.map_err(|error| ViewError::DatabaseError(error.to_string()))?
 					.into_iter()
-					.find(|i| {
-						i.primary_key()
-							.map(|pk| pk.to_string() == id.to_string())
-							.unwrap_or(false)
-					})
+					.next()
 					.ok_or_else(|| {
-						ViewError::DatabaseError("Failed to find created object".to_string())
+						ViewError::DatabaseError("Failed to find created object".to_owned())
 					})?;
 
 				// Serialize the complete object (including auto-populated fields)
@@ -796,37 +879,13 @@ where
 		pk: serde_json::Value,
 	) -> std::result::Result<Response, ViewError> {
 		self.check_permissions(request).await?;
+		self.ensure_provider_pool()?;
 
 		let serializer = self.get_serializer();
 
 		// Get existing object from database
-		let existing_obj: T = if let Some(pool) = &self.pool {
-			let session = reinhardt_db::prelude::Session::new(pool.clone(), self.db_backend)
-				.await
-				.map_err(|e| {
-					ViewError::DatabaseError(format!("Failed to create session: {}", e))
-				})?;
-
-			let items: Vec<T> = session
-				.list_all()
-				.await
-				.map_err(|e| ViewError::DatabaseError(format!("Failed to list objects: {}", e)))?;
-
-			// Normalize pk: strip surrounding quotes only (consistent with retrieve()).
-			let pk_str_owned = pk.to_string();
-			let pk_str = pk_str_owned.trim_matches('"');
-			items
-				.into_iter()
-				.find(|item| {
-					if let Some(item_pk) = item.primary_key() {
-						item_pk.to_string() == pk_str
-					} else {
-						false
-					}
-				})
-				.ok_or_else(|| {
-					ViewError::NotFound(format!("Object with pk {} not found", pk_str))
-				})?
+		let existing_obj: T = if self.pool.is_some() {
+			self.database_object(request, &pk).await?
 		} else {
 			// Fall back to queryset for non-database mode
 			// Normalize pk: strip surrounding quotes only (consistent with retrieve()).
@@ -869,8 +928,17 @@ where
 		// Deserialize merged object back to model type
 		let merged_json = serde_json::to_string(&existing_value)
 			.map_err(|e| ViewError::Serialization(format!("Failed to serialize merged: {}", e)))?;
-		let updated_item: T = serializer
+		let mut updated_item: T = serializer
 			.deserialize(&merged_json)
+			.map_err(map_serializer_error)?;
+		let existing_pk = existing_obj
+			.primary_key()
+			.ok_or_else(|| ViewError::Internal("Object has no primary key".to_owned()))?;
+		// The route/scoped object is authoritative. A PATCH body must not redirect
+		// the write to another primary key.
+		updated_item.set_primary_key(existing_pk);
+		let response_body = serializer
+			.serialize(&updated_item)
 			.map_err(map_serializer_error)?;
 
 		// Update database if pool is available
@@ -896,7 +964,7 @@ where
 		}
 
 		// Return the complete merged/updated object
-		Ok(Response::ok().with_body(merged_json))
+		Ok(Response::ok().with_body(response_body))
 	}
 
 	/// Delete an object
@@ -1012,6 +1080,7 @@ mod tests {
 	use reinhardt_auth::{IsActiveUser, IsAuthenticated};
 	use reinhardt_http::{IsActive, IsAuthenticated as AuthenticatedMarker, Request};
 	use rstest::rstest;
+	use std::sync::atomic::{AtomicUsize, Ordering};
 
 	fn build_request(uri: &str) -> Request {
 		Request::builder()
@@ -1062,6 +1131,21 @@ mod tests {
 
 		fn new_fields() -> Self::Fields {
 			TestItemFields
+		}
+	}
+
+	struct CountingProvider {
+		calls: Arc<AtomicUsize>,
+	}
+
+	impl QuerySetProvider<TestItem> for CountingProvider {
+		fn get_queryset(
+			&self,
+			_request: &Request,
+			base: QuerySet<TestItem>,
+		) -> std::result::Result<QuerySet<TestItem>, ViewError> {
+			self.calls.fetch_add(1, Ordering::Relaxed);
+			Ok(base)
 		}
 	}
 
@@ -1193,5 +1277,52 @@ mod tests {
 			"error should be NotFound, got: {:?}",
 			err
 		);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_queryset_provider_fails_closed_without_pool() {
+		// Arrange
+		let calls = Arc::new(AtomicUsize::new(0));
+		let handler = build_model_handler(Vec::new()).with_queryset_provider(CountingProvider {
+			calls: calls.clone(),
+		});
+		let request = build_request("/items/");
+
+		// Act
+		let result = handler.list(&request).await;
+
+		// Assert
+		assert!(matches!(result, Err(ViewError::Internal(_))));
+		assert_eq!(calls.load(Ordering::Relaxed), 0);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_update_restores_route_primary_key_from_patch_body() {
+		// Arrange
+		let handler = build_model_handler(vec![TestItem {
+			id: Some(1),
+			name: "before".to_owned(),
+		}]);
+		let request = Request::builder()
+			.method(Method::PATCH)
+			.uri("/items/1/")
+			.version(Version::HTTP_11)
+			.headers(HeaderMap::new())
+			.body(Bytes::from(r#"{"id":2,"name":"after"}"#))
+			.build()
+			.unwrap();
+
+		// Act
+		let response = handler
+			.update(&request, serde_json::json!(1))
+			.await
+			.expect("patch should update the scoped object");
+
+		// Assert
+		let body: TestItem = serde_json::from_slice(&response.body).unwrap();
+		assert_eq!(body.id, Some(1));
+		assert_eq!(body.name, "after");
 	}
 }

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -8,7 +8,8 @@
 use super::error::ViewError;
 use reinhardt_auth::{Permission, PermissionContext};
 use reinhardt_db::orm::{
-	CustomManager, Filter, FilterOperator, Model, QuerySet, query_types::DbBackend,
+	CustomManager, Filter, FilterCondition, FilterOperator, FilterValue, Model, QuerySet,
+	query_types::DbBackend,
 };
 use reinhardt_http::{AuthState, Request, Response};
 use reinhardt_rest::filters::FilterBackend;
@@ -23,6 +24,76 @@ fn map_serializer_error(error: reinhardt_core::serializers::SerializerError) -> 
 		reinhardt_core::serializers::SerializerError::Database(error) => ViewError::Database(error),
 		error => ViewError::Serialization(error.to_string()),
 	}
+}
+
+fn primary_key_filter_for_model<T: Model>(
+	pk: &serde_json::Value,
+) -> std::result::Result<FilterCondition, ViewError> {
+	let pk_string = pk
+		.as_str()
+		.map(str::to_owned)
+		.unwrap_or_else(|| pk.to_string());
+	let Some(composite) = T::composite_primary_key() else {
+		let value = T::primary_key_filter_value_from_str(&pk_string)
+			.map_err(|_| ViewError::NotFound(format!("Object with pk={} not found", pk_string)))?;
+		return Ok(Filter::new(T::primary_key_column(), FilterOperator::Eq, value).into());
+	};
+
+	let inner = pk_string
+		.strip_prefix('(')
+		.and_then(|value| value.strip_suffix(')'))
+		.ok_or_else(|| ViewError::NotFound(format!("Object with pk={} not found", pk_string)))?;
+	let parts: Vec<_> = inner.split(", ").collect();
+	if parts.len() != composite.fields().len() {
+		return Err(ViewError::NotFound(format!(
+			"Object with pk={} not found",
+			pk_string
+		)));
+	}
+
+	let metadata = T::field_metadata();
+	let filters = composite
+		.fields()
+		.iter()
+		.zip(parts)
+		.map(|(field_name, part)| {
+			let (name, value) = part.split_once('=').ok_or_else(|| {
+				ViewError::NotFound(format!("Object with pk={} not found", pk_string))
+			})?;
+			if name != field_name {
+				return Err(ViewError::NotFound(format!(
+					"Object with pk={} not found",
+					pk_string
+				)));
+			}
+			let field = metadata.iter().find(|field| field.name == *field_name);
+			let filter_value =
+				if field.is_some_and(|field| field.field_type.contains("BooleanField")) {
+					value.parse().map(FilterValue::Boolean).map_err(|_| {
+						ViewError::NotFound(format!("Object with pk={} not found", pk_string))
+					})?
+				} else if field.is_some_and(|field| {
+					field.field_type.contains("IntegerField")
+						|| field.field_type.contains("AutoField")
+						|| field.field_type.contains("BigIntegerField")
+						|| field.field_type.contains("BigAutoField")
+				}) {
+					value.parse().map(FilterValue::Integer).map_err(|_| {
+						ViewError::NotFound(format!("Object with pk={} not found", pk_string))
+					})?
+				} else {
+					FilterValue::String(value.to_owned())
+				};
+			let column = field
+				.map(|field| field.db_column_name().to_owned())
+				.unwrap_or_else(|| field_name.clone());
+			Ok(Filter::new(column, FilterOperator::Eq, filter_value))
+		})
+		.collect::<std::result::Result<Vec<_>, _>>()?;
+
+	Ok(FilterCondition::and(
+		filters.into_iter().map(FilterCondition::from).collect(),
+	))
 }
 
 /// Supplies a request-scoped database queryset to a model view handler.
@@ -426,18 +497,11 @@ where
 		}
 	}
 
-	fn primary_key_filter(&self, pk: &serde_json::Value) -> std::result::Result<Filter, ViewError> {
-		let pk_string = match pk {
-			serde_json::Value::String(value) => value.clone(),
-			value => value.to_string(),
-		};
-		let value = T::primary_key_filter_value_from_str(&pk_string)
-			.map_err(|_| ViewError::NotFound(format!("Object with pk={} not found", pk_string)))?;
-		Ok(Filter::new(
-			T::primary_key_column(),
-			FilterOperator::Eq,
-			value,
-		))
+	fn primary_key_filter(
+		&self,
+		pk: &serde_json::Value,
+	) -> std::result::Result<FilterCondition, ViewError> {
+		primary_key_filter_for_model::<T>(pk)
 	}
 
 	async fn database_object(
@@ -958,6 +1022,28 @@ where
 					ViewError::DatabaseError(format!("Failed to create session: {}", e))
 				})?;
 
+			// Recheck and mutate through one dedicated transaction connection.
+			let mut transaction = pool.begin().await.map_err(|e| {
+				ViewError::DatabaseError(format!("Failed to begin transaction: {}", e))
+			})?;
+			let mutation_queryset = self
+				.database_queryset(request)?
+				.filter(self.primary_key_filter(&pk)?)
+				.limit(1);
+			if session
+				.list_with_connection(&mutation_queryset, &mut *transaction)
+				.await
+				.map_err(|e| ViewError::DatabaseError(format!("Failed to recheck object: {}", e)))?
+				.into_iter()
+				.next()
+				.is_none()
+			{
+				return Err(ViewError::NotFound(format!(
+					"Object with pk={} not found",
+					pk
+				)));
+			}
+
 			// Add updated object to session (marks as dirty for UPDATE)
 			session
 				.add(updated_item.clone())
@@ -966,9 +1052,14 @@ where
 
 			// Flush changes to database (generates and executes UPDATE)
 			session
-				.flush()
+				.flush_with_connection(&mut *transaction)
 				.await
 				.map_err(|e| ViewError::DatabaseError(format!("Failed to flush: {}", e)))?;
+
+			transaction
+				.commit()
+				.await
+				.map_err(|e| ViewError::DatabaseError(format!("Failed to commit: {}", e)))?;
 		}
 
 		// Return the complete merged/updated object
@@ -1032,19 +1123,9 @@ where
 	) -> std::result::Result<Response, ViewError> {
 		self.check_permissions(request).await?;
 
-		let serializer = self.get_serializer();
-
-		// Verify object exists and get it for deletion
-		let response = self.retrieve(request, pk).await?;
-
-		// Extract the object from response body
-		let body_str = String::from_utf8(response.body.to_vec())
-			.map_err(|e| ViewError::BadRequest(format!("Invalid UTF-8: {}", e)))?;
-
-		// Deserialize into model
-		let item = serializer
-			.deserialize(&body_str)
-			.map_err(map_serializer_error)?;
+		if self.pool.is_none() {
+			self.retrieve(request, pk.clone()).await?;
+		}
 
 		// Delete from database if pool is available
 		if let Some(pool) = &self.pool {
@@ -1055,6 +1136,21 @@ where
 					ViewError::DatabaseError(format!("Failed to create session: {}", e))
 				})?;
 
+			let mut transaction = pool.begin().await.map_err(|e| {
+				ViewError::DatabaseError(format!("Failed to begin transaction: {}", e))
+			})?;
+			let mutation_queryset = self
+				.database_queryset(request)?
+				.filter(self.primary_key_filter(&pk)?)
+				.limit(1);
+			let item = session
+				.list_with_connection(&mutation_queryset, &mut *transaction)
+				.await
+				.map_err(|e| ViewError::DatabaseError(format!("Failed to recheck object: {}", e)))?
+				.into_iter()
+				.next()
+				.ok_or_else(|| ViewError::NotFound(format!("Object with pk={} not found", pk)))?;
+
 			// Mark object for deletion
 			session.delete(item).await.map_err(|e| {
 				ViewError::DatabaseError(format!("Failed to mark object for deletion: {}", e))
@@ -1062,9 +1158,14 @@ where
 
 			// Flush changes to database (generates and executes DELETE)
 			session
-				.flush()
+				.flush_with_connection(&mut *transaction)
 				.await
 				.map_err(|e| ViewError::DatabaseError(format!("Failed to flush: {}", e)))?;
+
+			transaction
+				.commit()
+				.await
+				.map_err(|e| ViewError::DatabaseError(format!("Failed to commit: {}", e)))?;
 		}
 
 		Ok(Response::no_content())

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -29,7 +29,13 @@ fn map_serializer_error(error: reinhardt_core::serializers::SerializerError) -> 
 ///
 /// The handler creates the base queryset from `Model::objects().all()` and
 /// passes it to this provider. Implementations should return a transformed
-/// queryset so manager predicates are retained.
+/// queryset so manager predicates are retained. The hook is synchronous and
+/// fallible; resolve asynchronous identity data before dispatch and expose it
+/// through request extensions. Reinhardt does not impose a tenant model.
+///
+/// Providers apply to list, retrieve, update, and destroy. Create deliberately
+/// bypasses the provider, and registering one without a database pool fails
+/// closed instead of falling back to static in-memory data.
 pub trait QuerySetProvider<M>: Send + Sync
 where
 	M: Model,
@@ -196,6 +202,8 @@ where
 	/// The provider is used for list, retrieve, update, and destroy actions.
 	/// Create deliberately does not invoke it. A database pool must be
 	/// configured when a provider is registered; otherwise requests fail closed.
+	/// The provider receives `Model::objects().all()` and must transform that
+	/// queryset rather than replacing its manager predicates.
 	pub fn with_queryset_provider<P>(mut self, provider: P) -> Self
 	where
 		P: QuerySetProvider<T> + 'static,

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -7,6 +7,7 @@
 
 use super::error::ViewError;
 use reinhardt_auth::{Permission, PermissionContext};
+use reinhardt_db::orm::model::filter_value_from_field;
 use reinhardt_db::orm::{
 	CustomManager, Filter, FilterCondition, FilterOperator, FilterValue, Model, QuerySet,
 	query_types::DbBackend,
@@ -79,23 +80,13 @@ fn primary_key_filter_for_model<T: Model>(
 		.zip(parts)
 		.map(|(field_name, part)| {
 			let field = metadata.iter().find(|field| field.name == *field_name);
-			let filter_value =
-				if field.is_some_and(|field| field.field_type.contains("BooleanField")) {
-					part.parse().map(FilterValue::Boolean).map_err(|_| {
-						ViewError::NotFound(format!("Object with pk={} not found", pk_string))
-					})?
-				} else if field.is_some_and(|field| {
-					field.field_type.contains("IntegerField")
-						|| field.field_type.contains("AutoField")
-						|| field.field_type.contains("BigIntegerField")
-						|| field.field_type.contains("BigAutoField")
-				}) {
-					part.parse().map(FilterValue::Integer).map_err(|_| {
-						ViewError::NotFound(format!("Object with pk={} not found", pk_string))
-					})?
-				} else {
-					FilterValue::String(part.to_owned())
-				};
+			let filter_value = field
+				.map(|field| filter_value_from_field(field, part))
+				.transpose()
+				.map_err(|_| {
+					ViewError::NotFound(format!("Object with pk={} not found", pk_string))
+				})?
+				.unwrap_or_else(|| FilterValue::String(part.to_owned()));
 			let column = field
 				.map(|field| field.db_column_name().to_owned())
 				.unwrap_or_else(|| field_name.clone());

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -33,6 +33,9 @@ fn primary_key_filter_for_model<T: Model>(
 		.as_str()
 		.map(str::to_owned)
 		.unwrap_or_else(|| pk.to_string());
+	let pk_string = urlencoding::decode(&pk_string)
+		.map_err(|_| ViewError::NotFound(format!("Object with pk={} not found", pk_string)))?
+		.into_owned();
 	let Some(composite) = T::composite_primary_key() else {
 		let value = T::primary_key_filter_value_from_str(&pk_string)
 			.map_err(|_| ViewError::NotFound(format!("Object with pk={} not found", pk_string)))?;
@@ -43,8 +46,27 @@ fn primary_key_filter_for_model<T: Model>(
 		.strip_prefix('(')
 		.and_then(|value| value.strip_suffix(')'))
 		.ok_or_else(|| ViewError::NotFound(format!("Object with pk={} not found", pk_string)))?;
-	let parts: Vec<_> = inner.split(", ").collect();
-	if parts.len() != composite.fields().len() {
+	let fields = composite.fields();
+	let mut cursor = inner;
+	let mut parts = Vec::with_capacity(fields.len());
+	for (index, field_name) in fields.iter().enumerate() {
+		let prefix = format!("{field_name}=");
+		let value_start = cursor.strip_prefix(&prefix).ok_or_else(|| {
+			ViewError::NotFound(format!("Object with pk={} not found", pk_string))
+		})?;
+		if index + 1 == fields.len() {
+			parts.push(value_start);
+			cursor = "";
+		} else {
+			let delimiter = format!(", {}=", fields[index + 1]);
+			let delimiter_position = value_start.find(&delimiter).ok_or_else(|| {
+				ViewError::NotFound(format!("Object with pk={} not found", pk_string))
+			})?;
+			parts.push(&value_start[..delimiter_position]);
+			cursor = &value_start[delimiter_position + 2..];
+		}
+	}
+	if !cursor.is_empty() || parts.len() != fields.len() {
 		return Err(ViewError::NotFound(format!(
 			"Object with pk={} not found",
 			pk_string
@@ -52,24 +74,14 @@ fn primary_key_filter_for_model<T: Model>(
 	}
 
 	let metadata = T::field_metadata();
-	let filters = composite
-		.fields()
+	let filters = fields
 		.iter()
 		.zip(parts)
 		.map(|(field_name, part)| {
-			let (name, value) = part.split_once('=').ok_or_else(|| {
-				ViewError::NotFound(format!("Object with pk={} not found", pk_string))
-			})?;
-			if name != field_name {
-				return Err(ViewError::NotFound(format!(
-					"Object with pk={} not found",
-					pk_string
-				)));
-			}
 			let field = metadata.iter().find(|field| field.name == *field_name);
 			let filter_value =
 				if field.is_some_and(|field| field.field_type.contains("BooleanField")) {
-					value.parse().map(FilterValue::Boolean).map_err(|_| {
+					part.parse().map(FilterValue::Boolean).map_err(|_| {
 						ViewError::NotFound(format!("Object with pk={} not found", pk_string))
 					})?
 				} else if field.is_some_and(|field| {
@@ -78,11 +90,11 @@ fn primary_key_filter_for_model<T: Model>(
 						|| field.field_type.contains("BigIntegerField")
 						|| field.field_type.contains("BigAutoField")
 				}) {
-					value.parse().map(FilterValue::Integer).map_err(|_| {
+					part.parse().map(FilterValue::Integer).map_err(|_| {
 						ViewError::NotFound(format!("Object with pk={} not found", pk_string))
 					})?
 				} else {
-					FilterValue::String(value.to_owned())
+					FilterValue::String(part.to_owned())
 				};
 			let column = field
 				.map(|field| field.db_column_name().to_owned())
@@ -1029,7 +1041,8 @@ where
 			let mutation_queryset = self
 				.database_queryset(request)?
 				.filter(self.primary_key_filter(&pk)?)
-				.limit(1);
+				.limit(1)
+				.without_distinct();
 			if session
 				.list_with_connection_for_update(&mutation_queryset, &mut *transaction)
 				.await
@@ -1142,7 +1155,8 @@ where
 			let mutation_queryset = self
 				.database_queryset(request)?
 				.filter(self.primary_key_filter(&pk)?)
-				.limit(1);
+				.limit(1)
+				.without_distinct();
 			let item = session
 				.list_with_connection_for_update(&mutation_queryset, &mut *transaction)
 				.await

--- a/crates/reinhardt-views/src/viewsets/viewset.rs
+++ b/crates/reinhardt-views/src/viewsets/viewset.rs
@@ -503,6 +503,10 @@ where
 	}
 
 	/// Set a request-scoped database queryset provider.
+	///
+	/// The provider transforms the model manager's base queryset for list,
+	/// retrieve, update, and destroy. Create bypasses it; a database pool is
+	/// required when it is configured.
 	pub fn with_queryset_provider<P>(mut self, provider: P) -> Self
 	where
 		P: QuerySetProvider<M> + 'static,
@@ -736,6 +740,9 @@ where
 	}
 
 	/// Set a request-scoped database queryset provider.
+	///
+	/// The provider transforms the model manager's base queryset for list and
+	/// retrieve. Create, update, and destroy are unavailable on this viewset.
 	pub fn with_queryset_provider<P>(mut self, provider: P) -> Self
 	where
 		P: QuerySetProvider<M> + 'static,

--- a/crates/reinhardt-views/src/viewsets/viewset.rs
+++ b/crates/reinhardt-views/src/viewsets/viewset.rs
@@ -1,6 +1,6 @@
 use crate::viewsets::actions::Action;
 use crate::viewsets::filtering_support::{FilterConfig, FilterableViewSet, OrderingConfig};
-use crate::viewsets::handler::ModelViewSetHandler;
+use crate::viewsets::handler::{ModelViewSetHandler, QuerySetProvider};
 use crate::viewsets::metadata::{ActionMetadata, get_actions_for_viewset};
 use crate::viewsets::middleware::ViewSetMiddleware;
 use crate::viewsets::pagination_support::{PaginatedViewSet, PaginationConfig};
@@ -502,6 +502,15 @@ where
 		self
 	}
 
+	/// Set a request-scoped database queryset provider.
+	pub fn with_queryset_provider<P>(mut self, provider: P) -> Self
+	where
+		P: QuerySetProvider<M> + 'static,
+	{
+		self.handler = std::mem::take(&mut self.handler).with_queryset_provider(provider);
+		self
+	}
+
 	/// Add a permission class enforced before each request.
 	pub fn add_permission(mut self, permission: Arc<dyn Permission>) -> Self {
 		self.handler = std::mem::take(&mut self.handler).add_permission(permission);
@@ -723,6 +732,15 @@ where
 	/// Provide an in-memory queryset used when no database pool is set.
 	pub fn with_queryset(mut self, items: Vec<M>) -> Self {
 		self.handler = std::mem::take(&mut self.handler).with_queryset(items);
+		self
+	}
+
+	/// Set a request-scoped database queryset provider.
+	pub fn with_queryset_provider<P>(mut self, provider: P) -> Self
+	where
+		P: QuerySetProvider<M> + 'static,
+	{
+		self.handler = std::mem::take(&mut self.handler).with_queryset_provider(provider);
 		self
 	}
 

--- a/crates/reinhardt-views/tests/viewset_routing.rs
+++ b/crates/reinhardt-views/tests/viewset_routing.rs
@@ -1020,9 +1020,10 @@ async fn model_viewset_dispatch_applies_manager_and_request_provider_scope() {
 	let filtered_detail = viewset
 		.dispatch(filtered_detail_request, Action::retrieve())
 		.await;
+	let error = filtered_detail.expect_err("manager predicate must remain active");
 	assert!(
-		filtered_detail.is_err(),
-		"manager predicate must remain active"
+		matches!(error, reinhardt_core::exception::Error::NotFound(_)),
+		"manager predicate must return NotFound, got: {error:?}"
 	);
 }
 

--- a/crates/reinhardt-views/tests/viewset_routing.rs
+++ b/crates/reinhardt-views/tests/viewset_routing.rs
@@ -4,7 +4,10 @@
 
 use bytes::Bytes;
 use hyper::{HeaderMap, Method, StatusCode, Version};
-use reinhardt_db::orm::{FieldSelector, Model};
+use reinhardt_db::orm::{
+	CustomManager, FieldSelector, Filter, FilterOperator, FilterValue, Model, QuerySet,
+	inspection::FieldInfo, query_types::DbBackend,
+};
 use reinhardt_http::Request;
 use reinhardt_rest::serializers::JsonSerializer;
 use reinhardt_views::viewset_actions;
@@ -18,6 +21,7 @@ use rstest::rstest;
 use serde::{Deserialize, Serialize};
 use serial_test::serial;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
 // Helper types
@@ -58,6 +62,117 @@ impl Model for TestModel {
 }
 
 type TestSerializer = JsonSerializer<TestModel>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct ScopedItem {
+	id: Option<i64>,
+	tenant_id: i64,
+	active: bool,
+	name: String,
+}
+
+#[derive(Clone)]
+struct ScopedItemFields;
+
+impl FieldSelector for ScopedItemFields {
+	fn with_alias(self, _alias: &str) -> Self {
+		self
+	}
+}
+
+#[derive(Clone, Default)]
+struct ActiveItemManager;
+
+impl CustomManager for ActiveItemManager {
+	type Model = ScopedItem;
+
+	fn new() -> Self {
+		Self
+	}
+
+	fn all(&self) -> QuerySet<Self::Model> {
+		reinhardt_db::orm::Manager::<Self::Model>::new().filter(Filter::new(
+			"active",
+			FilterOperator::Eq,
+			FilterValue::Boolean(true),
+		))
+	}
+}
+
+impl Model for ScopedItem {
+	type PrimaryKey = i64;
+	type Fields = ScopedItemFields;
+	type Objects = ActiveItemManager;
+
+	fn table_name() -> &'static str {
+		"scoped_items"
+	}
+
+	fn primary_key(&self) -> Option<Self::PrimaryKey> {
+		self.id
+	}
+
+	fn set_primary_key(&mut self, value: Self::PrimaryKey) {
+		self.id = Some(value);
+	}
+
+	fn new_fields() -> Self::Fields {
+		ScopedItemFields
+	}
+
+	fn field_metadata() -> Vec<FieldInfo> {
+		[
+			("id", "BigIntegerField", false, true),
+			("tenant_id", "BigIntegerField", false, false),
+			("active", "BooleanField", false, false),
+			("name", "CharField", false, false),
+		]
+		.into_iter()
+		.map(|(name, field_type, nullable, primary_key)| FieldInfo {
+			name: name.to_owned(),
+			field_type: format!("reinhardt.orm.models.{field_type}"),
+			storage_kind: None,
+			domain: None,
+			nullable,
+			primary_key,
+			unique: false,
+			blank: false,
+			editable: true,
+			default: None,
+			db_default: None,
+			db_column: None,
+			choices: None,
+			attributes: std::collections::HashMap::new(),
+		})
+		.collect()
+	}
+}
+
+#[derive(Clone)]
+struct TenantScope(i64);
+
+struct TenantProvider;
+
+impl reinhardt_views::viewsets::QuerySetProvider<ScopedItem> for TenantProvider {
+	fn get_queryset(
+		&self,
+		request: &Request,
+		base: QuerySet<ScopedItem>,
+	) -> Result<QuerySet<ScopedItem>, reinhardt_views::viewsets::ViewError> {
+		let tenant_id = request
+			.extensions
+			.get::<TenantScope>()
+			.map(|scope| scope.0)
+			.ok_or_else(|| {
+				reinhardt_views::viewsets::ViewError::Internal("tenant scope is missing".to_owned())
+			})?;
+		Ok(base.filter(Filter::new(
+			"tenant_id",
+			FilterOperator::Eq,
+			FilterValue::Integer(tenant_id),
+		)))
+	}
+}
 
 fn make_request(method: Method, uri: &str) -> Request {
 	Request::builder()
@@ -827,6 +942,88 @@ fn action_metadata_custom_url_path() {
 
 	// Assert
 	assert_eq!(metadata.get_url_path(), "bulk/delete");
+}
+
+#[rstest]
+#[serial(viewset_db)]
+#[tokio::test]
+async fn model_viewset_dispatch_applies_manager_and_request_provider_scope() {
+	// Arrange
+	sqlx::any::install_default_drivers();
+	let pool = sqlx::pool::PoolOptions::<sqlx::Any>::new()
+		.max_connections(1)
+		.connect("sqlite::memory:")
+		.await
+		.expect("SQLite pool should be available");
+	sqlx::query(
+		"CREATE TABLE scoped_items (
+			id INTEGER PRIMARY KEY,
+			tenant_id INTEGER NOT NULL,
+			active BOOLEAN NOT NULL,
+			name TEXT NOT NULL
+		)",
+	)
+	.execute(&pool)
+	.await
+	.expect("scoped_items table should be created");
+	for (id, tenant_id, active, name) in [
+		(1_i64, 1_i64, true, "other-tenant"),
+		(2_i64, 2_i64, false, "inactive"),
+		(3_i64, 2_i64, true, "visible"),
+	] {
+		sqlx::query("INSERT INTO scoped_items (id, tenant_id, active, name) VALUES (?, ?, ?, ?)")
+			.bind(id)
+			.bind(tenant_id)
+			.bind(active)
+			.bind(name)
+			.execute(&pool)
+			.await
+			.expect("scoped item should be inserted");
+	}
+	let viewset = ModelViewSet::<ScopedItem, JsonSerializer<ScopedItem>>::new("items")
+		.with_pool(Arc::new(pool))
+		.with_db_backend(DbBackend::Sqlite)
+		.without_pagination()
+		.with_queryset_provider(TenantProvider);
+	let list_request = make_request(Method::GET, "/items/");
+	list_request.extensions.insert(TenantScope(2));
+
+	// Act
+	let list_response = viewset
+		.dispatch(list_request, Action::list())
+		.await
+		.expect("scoped list should succeed");
+
+	// Assert
+	let list: Vec<ScopedItem> = serde_json::from_slice(&list_response.body).unwrap();
+	assert_eq!(
+		list,
+		vec![ScopedItem {
+			id: Some(3),
+			tenant_id: 2,
+			active: true,
+			name: "visible".to_owned(),
+		}]
+	);
+
+	let detail_request = make_detail_request(Method::GET, "/items/3/", "3");
+	detail_request.extensions.insert(TenantScope(2));
+	let detail_response = viewset
+		.dispatch(detail_request, Action::retrieve())
+		.await
+		.expect("scoped detail should succeed");
+	let detail: ScopedItem = serde_json::from_slice(&detail_response.body).unwrap();
+	assert_eq!(detail.id, Some(3));
+
+	let filtered_detail_request = make_detail_request(Method::GET, "/items/2/", "2");
+	filtered_detail_request.extensions.insert(TenantScope(2));
+	let filtered_detail = viewset
+		.dispatch(filtered_detail_request, Action::retrieve())
+		.await;
+	assert!(
+		filtered_detail.is_err(),
+		"manager predicate must remain active"
+	);
 }
 
 // ===========================================================================

--- a/crates/reinhardt-views/tests/viewset_routing.rs
+++ b/crates/reinhardt-views/tests/viewset_routing.rs
@@ -1025,6 +1025,23 @@ async fn model_viewset_dispatch_applies_manager_and_request_provider_scope() {
 		matches!(error, reinhardt_core::exception::Error::NotFound(_)),
 		"manager predicate must return NotFound, got: {error:?}"
 	);
+
+	let update_request =
+		make_detail_request_with_body(Method::PATCH, "/items/3/", "3", r#"{"name":"updated"}"#);
+	update_request.extensions.insert(TenantScope(2));
+	let update_response = viewset
+		.dispatch(update_request, Action::partial_update())
+		.await
+		.expect("SQLite scoped update should succeed without row locking");
+	assert_eq!(update_response.status, StatusCode::OK);
+
+	let destroy_request = make_detail_request(Method::DELETE, "/items/3/", "3");
+	destroy_request.extensions.insert(TenantScope(2));
+	let destroy_response = viewset
+		.dispatch(destroy_request, Action::destroy())
+		.await
+		.expect("SQLite scoped destroy should succeed without row locking");
+	assert_eq!(destroy_response.status, StatusCode::NO_CONTENT);
 }
 
 // ===========================================================================

--- a/src/exports/views.rs
+++ b/src/exports/views.rs
@@ -6,7 +6,7 @@ pub use reinhardt_views::{
 
 pub use reinhardt_views::viewsets::{
 	Action, ActionType, CreateMixin, DestroyMixin, GenericViewSet, ListMixin, ModelViewSet,
-	ReadOnlyModelViewSet, RetrieveMixin, UpdateMixin, ViewSet,
+	QuerySetProvider, ReadOnlyModelViewSet, RetrieveMixin, UpdateMixin, ViewSet,
 };
 
 #[cfg(feature = "shortcuts")]


### PR DESCRIPTION
## Summary

This PR addresses:

- Add the develop/0.4.0 QuerySetProvider API for request-scoped ModelViewSet queries.
- Preserve custom manager predicates by passing Model::objects().all() into the provider.
- Execute filtered model querysets through the configured Session pool.
- Apply typed primary-key predicates to list, retrieve, update, and destroy.
- Keep create provider-free with PK-only refresh and protect route primary keys during updates.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (code that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The develop/0.4.0 ModelViewSet path previously loaded all rows and searched in memory, so request-derived organization or authorization scopes could not be composed with custom manager predicates. This implementation adds an object-safe QuerySetProvider contract and a configured-pool Session bridge without changing the existing Vec queryset fallback or ViewSet trait shape.

Refs #6085

Related to: #6091

## How Was This Tested?

- [x] SQLite Session::list filtered-query and temporal precision regressions.
- [x] SQLite ModelViewSet dispatch coverage for custom manager predicates plus request provider scope.
- [x] Poolless provider fail-closed and route primary-key protection unit coverage.
- [x] Documentation tests, rustdoc with warnings denied, facade checks, formatting, and clippy for affected libraries.
- [x] Local SemVer checks for reinhardt-db, reinhardt-views, and reinhardt-web.
- The full workspace test command was attempted; unrelated pre-existing failures in reinhardt-commands and reinhardt-conf were observed and are documented separately.

## Performance Impact

- Filtered QuerySet predicates are executed in SQL through the configured Session pool instead of decoding the entire table.
- No benchmark was added; query-shape and isolation regressions are covered by tests.

## Breaking Changes

-

**Migration Guide:**

-

## Screenshots

<!-- Not applicable: no UI changes. -->

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings in affected libraries
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with cargo fmt
- [x] I have checked the code with clippy for affected libraries
- [ ] I use self-hosted runner for CI

## Related Issues

- #6085
- #6091 remains separate for custom lookup-field semantics.

## Labels to Apply

- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] performance
- [ ] refactoring
- [ ] code-quality

### Additional Labels

- [ ] breaking-change

### Scope Labels

- [x] database
- [x] orm
- [x] api
- [x] routing
- [ ] auth

### Priority

- [x] critical

---

**Additional Context:**

QuerySetProvider is synchronous and fallible. Applications resolve asynchronous identity before dispatch and store application-defined scope data in request extensions. Reinhardt has no built-in tenant model. Providers apply to list, retrieve, update, and destroy; create deliberately bypasses them, and registering one without a database pool fails closed.