### PR TITLE
docs(security): define framework security policies

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,8 +5,10 @@
 Reinhardt is a Rust web framework and workspace of framework crates, macros,
 runtime services, generated code, and documented production integrations. This
 policy defines the repository-wide security contract inherited by nested
-components. A downstream application remains responsible for its deployment,
-configuration, content, credentials, and use of explicitly unsafe interfaces.
+components. Security policies compose from the repository root to each nested
+component; the closest policy wins on conflict. A downstream application
+remains responsible for its deployment, configuration, content, credentials,
+and use of explicitly unsafe interfaces.
 
 ## Protected Assets
 
@@ -90,10 +92,7 @@ separate dependency-advisory review; it is not a comprehensive product audit.
 Reinhardt follows the lifecycle in
 [`instructions/STABILITY_POLICY.md`](instructions/STABILITY_POLICY.md).
 <!-- reinhardt-version-sync -->
-Security patches are applied to the latest current release of the most recent minor series, currently `0.3.8`.
-
-Development branches and older patch releases are unsupported; upgrade to the
-current release to receive security patches.
+Security fixes target the current supported release, `0.3.8`, and the current development line as appropriate.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,7 +49,9 @@ proxy; forwarded headers from any other peer are attacker-controlled.
   consumption before processing it.
 - Browser-facing APIs preserve contextual output encoding, origin protections,
   and safe cookie and redirect handling so untrusted content cannot gain
-  browser privileges.
+  browser privileges. APIs such as `HtmlHighlighter` that return raw HTML with
+  inserted `<mark>` tags are explicit unsafe boundaries; callers must escape
+  source text before rendering or restrict input to trusted text.
 - Errors, logs, diagnostics, and telemetry redact secrets and credentials.
 - HTTP, GraphQL, gRPC, WebSocket, and server-function transports enforce
   equivalent authentication, authorization, validation, and isolation for the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -99,5 +99,4 @@ Security fixes target the current supported release, `0.3.8`, and the current de
 Report vulnerabilities privately through [GitHub Security Advisories](https://github.com/kent8192/reinhardt-web/security/advisories), the preferred reporting channel. Do not create a public issue or disclose details publicly before a fix is available.
 
 Include affected versions, prerequisites, a minimal reproduction, impact, and
-any proposed mitigation. If GitHub Security Advisories cannot be used, contact
-the maintainers privately through GitHub.
+any proposed mitigation.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,10 @@ proxy; forwarded headers from any other peer are attacker-controlled.
   inserted `<mark>` tags are explicit unsafe boundaries; callers must escape
   source text before rendering or restrict input to trusted text.
 - Errors, logs, diagnostics, and telemetry redact secrets and credentials.
+- `ResponseCookies` debug output contains complete raw `Set-Cookie` strings,
+  which may include session credentials. Callers must not format or log
+  response-cookie containers across a secret-bearing diagnostic boundary
+  without redaction.
 - WebSocket configuration is also a secret boundary: Redis URLs, passwords,
   tokens, and connection options must be redacted before errors, logs,
   diagnostics, telemetry, or client-visible responses are produced.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,9 @@ proxy; forwarded headers from any other peer are attacker-controlled.
   inserted `<mark>` tags are explicit unsafe boundaries; callers must escape
   source text before rendering or restrict input to trusted text.
 - Errors, logs, diagnostics, and telemetry redact secrets and credentials.
+- WebSocket configuration is also a secret boundary: Redis URLs, passwords,
+  tokens, and connection options must be redacted before errors, logs,
+  diagnostics, telemetry, or client-visible responses are produced.
 - HTTP, GraphQL, gRPC, WebSocket, and server-function transports enforce
   equivalent authentication, authorization, validation, and isolation for the
   same operation.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,10 @@ proxy; forwarded headers from any other peer are attacker-controlled.
   cross-tenant object access.
 - Parsers and decoders bound untrusted input size, nesting, work, and resource
   consumption before processing it.
+- Rate-limit state is bounded only when callers constrain key cardinality and
+  run cleanup. The default per-route strategy creates a bucket and request
+  history entry for each distinct URI path; applications exposing attacker-
+  controlled paths must use bounded route keys and periodic eviction.
 - Browser-facing APIs preserve contextual output encoding, origin protections,
   and safe cookie and redirect handling so untrusted content cannot gain
   browser privileges. APIs such as `HtmlHighlighter` that return raw HTML with
@@ -94,11 +98,15 @@ separate dependency-advisory review; it is not a comprehensive product audit.
 Reinhardt follows the lifecycle in
 [`instructions/STABILITY_POLICY.md`](instructions/STABILITY_POLICY.md).
 <!-- reinhardt-version-sync -->
-Security fixes target the current supported release, `0.3.8`, and the current development line as appropriate.
+Security fixes target the current supported release, `0.3.8`, and the current
+development line as appropriate.
 
 ## Reporting a Vulnerability
 
-Report vulnerabilities privately through [GitHub Security Advisories](https://github.com/kent8192/reinhardt-web/security/advisories), the preferred reporting channel. Do not create a public issue or disclose details publicly before a fix is available.
+Report vulnerabilities privately through [GitHub Security
+Advisories](https://github.com/kent8192/reinhardt-web/security/advisories), the
+preferred reporting channel. Do not create a public issue or disclose details
+publicly before a fix is available.
 
 Include affected versions, prerequisites, a minimal reproduction, impact, and
 any proposed mitigation.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,296 +1,104 @@
 # Security Policy
 
-## Supported Versions
+## System and Scope
 
-Reinhardt follows the three-phase lifecycle described in
+Reinhardt is a Rust web framework and workspace of framework crates, macros,
+runtime services, generated code, and documented production integrations. This
+policy defines the repository-wide security contract inherited by nested
+components. A downstream application remains responsible for its deployment,
+configuration, content, credentials, and use of explicitly unsafe interfaces.
+
+## Protected Assets
+
+- Application identities, sessions, credentials, tokens, cookies, and secrets.
+- Tenant-scoped data, authorization decisions, and database integrity.
+- Filesystem and object-storage data outside an application's configured scope.
+- Browser-originated data, rendered content, and same-origin privileges.
+- Availability and predictable resource use of production services.
+- Plugin host integrity and the capabilities granted to each plugin.
+
+## Threat Model and Trust Boundaries
+
+Treat HTTP fields, tokens, cookies, uploads, filters, routes, GraphQL, gRPC,
+and WebSocket inputs, server-function arguments, attacker-writable database
+fields, and loadable plugin code as attacker-controlled. Public framework APIs
+can therefore receive untrusted values even when an application does not expose
+an HTTP endpoint directly.
+
+Application configuration, explicit raw interfaces, and developer tooling are
+trust boundaries rather than automatically safe inputs. Proxy-provided identity
+is trusted only after the immediate peer has been verified as a configured
+proxy; forwarded headers from any other peer are attacker-controlled.
+
+## Global Security Invariants
+
+- Authentication establishes identity only with validated credentials, and
+  authorization is enforced for every protected action using the relevant
+  resource and tenant context.
+- Request handling preserves isolation: one request, tenant, or principal must
+  not read, modify, or act as another through shared state or identifier
+  selection.
+- Safe database APIs construct SQL with parameter binding and validated query
+  structure; attacker-controlled values must not become executable SQL.
+- Filesystem and storage APIs confine operations to configured roots, buckets,
+  prefixes, and permissions, preventing traversal, symlink escape, and
+  cross-tenant object access.
+- Parsers and decoders bound untrusted input size, nesting, work, and resource
+  consumption before processing it.
+- Browser-facing APIs preserve contextual output encoding, origin protections,
+  and safe cookie and redirect handling so untrusted content cannot gain
+  browser privileges.
+- Errors, logs, diagnostics, and telemetry redact secrets and credentials.
+- HTTP, GraphQL, gRPC, WebSocket, and server-function transports enforce
+  equivalent authentication, authorization, validation, and isolation for the
+  same operation.
+- Plugin code receives only its explicitly granted capabilities and cannot
+  obtain host, filesystem, network, secret, or other plugin privileges by
+  default.
+
+## Reportable Findings
+
+Report a finding when a realistic downstream application can violate a global
+security invariant without intentionally entering an explicit unsafe boundary.
+Severity is assessed from reachability, prerequisites, and impact, not from the
+vulnerability class alone.
+
+Examples include authentication or authorization bypass, cross-request or
+cross-tenant access, injection through safe APIs, confinement escape,
+credential exposure, browser privilege compromise, plugin capability escape,
+and remotely triggerable resource exhaustion.
+
+## Out of Scope
+
+The following are out of scope unless they cross a production boundary:
+
+- Test-only code and fixtures.
+- Explicit raw SQL, raw HTML, arbitrary-code, and equivalent APIs used with
+  their documented trust assumptions.
+- Trusted developer tooling and local development environments.
+- Dependency advisories that are unreachable in the relevant production
+  configuration.
+
+## Known Limitations and Audit Status
+
+No comprehensive independent product security audit has occurred. The
+[0.3.0 dependency-advisory review](docs/security-audit-0.3.0.md) records a
+separate dependency-advisory review; it is not a comprehensive product audit.
+
+## Supported Releases
+
+Reinhardt follows the lifecycle in
 [`instructions/STABILITY_POLICY.md`](instructions/STABILITY_POLICY.md).
-Security patches are applied to the **latest current release** of the most
-recent minor series: while `0.1.0` stable has not yet shipped, the latest
-`0.1.0-rc.*` is that current release; once `0.1.0` ships, support shifts
-to the latest `0.1.x` stable patch and older `-rc.*` / `-alpha.*` artifacts
-become unsupported — upgrade to the matching stable version to keep
-receiving patches.
+<!-- reinhardt-version-sync -->
+Security patches are applied to the latest current release of the most recent minor series, currently `0.3.8`.
 
-| Version | Supported |
-|---------|-----------|
-| Latest `0.1.0-rc.*` (current release, until `0.1.0` ships) | ✅ Yes |
-| `0.1.x` (latest stable patch, once `0.1.0` has shipped) | ✅ Yes |
-| Older `0.1.0-rc.*` / `0.1.0-alpha.*` | ❌ No |
-| Older `0.1.x` patches (after `0.1.0` has shipped) | ❌ No |
-| Development branches (`main`, `develop/*`) | ❌ No |
-
----
+Development branches and older patch releases are unsupported; upgrade to the
+current release to receive security patches.
 
 ## Reporting a Vulnerability
 
-### Private Disclosure Process
-
-**Security vulnerabilities MUST be reported privately.**
-
-**DO NOT:**
-- Create public issues for security vulnerabilities
-- Discuss vulnerabilities in public channels (Discussions, Discord, etc.)
-- Post vulnerability details on social media
-
-**DO:**
-- Report vulnerabilities via GitHub Security Advisories (preferred)
-- Include reproduction steps and impact assessment
-- Allow time for assessment and patching
-
----
-
-## How to Report
-
-### Method 1: GitHub Security Advisories (Recommended)
-
-Use GitHub's built-in private vulnerability reporting:
-
-```
-https://github.com/kent8192/reinhardt-web/security/advisories
-```
-
-Click "Report a vulnerability" and fill in the form.
-
-### Method 2: Contact Maintainers
-
-If you cannot use GitHub Security Advisories, contact the repository maintainers directly through GitHub's private messaging system.
-
----
-
-## What to Include
-
-Your report should include:
-
-1. **Vulnerability Description**
-   - Type of vulnerability (XSS, SQL injection, etc.)
-   - Affected components
-   - Impact assessment
-
-2. **Affected Versions**
-   - Specific commit hashes or version numbers
-   - Branch names if applicable
-
-3. **Steps to Reproduce**
-   - Minimal reproduction code
-   - Configuration details
-   - Prerequisites
-
-4. **Proof of Concept (Optional but Recommended)**
-   - Working exploit demonstration
-   - Screenshots or logs
-
-5. **Proposed Mitigation (Optional)**
-   - Suggested fix or workaround
-   - Additional security considerations
-
----
-
-## Vulnerability Response Process
-
-### Timeline
-
-| Phase | Duration | Description |
-|-------|----------|-------------|
-| **Acknowledgment** | Within 48 hours | Initial confirmation that report was received |
-| **Assessment** | Within 7 days | Severity classification and impact analysis |
-| **Patch Development** | 7-30 days | Fix development and testing (varies by severity) |
-| **Release** | After patch ready | Coordinated public disclosure |
-
-### Response Workflow
-
-1. **Acknowledgment (Within 48 hours)**
-   - Private security advisory created
-   - Issue labeled `security` and `critical`
-   - Maintainer assigned
-
-2. **Assessment (Within 7 days)**
-   - Vulnerability confirmed and classified
-   - Severity level assigned (Critical, High, Medium, Low)
-   - Impact analysis completed
-   - Fix strategy determined
-
-3. **Patch Development (7-30 days)**
-   - Critical: 7 days
-   - High: 14 days
-   - Medium: 21 days
-   - Low: 30 days
-   - Private fix developed and tested
-
-4. **Coordinated Disclosure**
-   - Maintainer contacts reporter
-   - Release date agreed upon
-   - Security advisory published
-   - Public disclosure after fix is released
-
----
-
-## Severity Levels
-
-### Critical (CVSS 9.0-10.0)
-
-- Remote code execution without authentication
-- SQL injection in core functionality
-- Authentication bypass
-- Data integrity compromise
-
-**Response Time:** 7 days
-
-### High (CVSS 7.0-8.9)
-
-- SQL injection in non-core functionality
-- Privilege escalation
-- Sensitive data exposure
-- DoS vulnerability affecting availability
-
-**Response Time:** 14 days
-
-### Medium (CVSS 4.0-6.9)
-
-- XSS vulnerabilities
-- CSRF vulnerabilities
-- Local file inclusion
-- Information disclosure
-
-**Response Time:** 21 days
-
-### Low (CVSS 0.1-3.9)
-
-- Minor security issues
-- Best practice violations
-- Low-risk information disclosure
-
-**Response Time:** 30 days
-
----
-
-## Coordinated Disclosure
-
-### Process
-
-1. **Reporter Submits** private vulnerability report
-2. **Maintainer Acknowledges** within 48 hours
-3. **Assessment** completed within 7 days
-4. **Patch Development** timeline set based on severity
-5. **Release Coordination** with reporter
-6. **Public Disclosure** after fix is released
-
-### Disclosure Policy
-
-- Vulnerabilities are disclosed publicly **after** a fix is released
-- Credit is given to reporters (unless anonymous is requested)
-- Security advisories include:
-  - Vulnerability description
-  - Affected versions
-  - Patched versions
-  - Mitigation steps
-  - Acknowledgments
-
----
-
-## Security Best Practices
-
-### For Users
-
-1. **Keep Dependencies Updated**
-   - Regularly update Rust dependencies
-   - Monitor security advisories for dependencies
-   - Use `cargo deny` to check dependency policy
-
-2. **Input Validation**
-   - Always validate user input
-   - Use parameterized queries (reinhardt-query)
-   - Sanitize output to prevent XSS
-
-3. **Authentication & Authorization**
-   - Use strong password hashing (bcrypt, Argon2)
-   - Implement proper session management
-   - Use HTTPS in production
-
-4. **Secrets Management**
-   - Never commit secrets to git
-   - Use environment variables for configuration
-   - Rotate secrets regularly
-
-5. **Database Security**
-   - Use prepared statements (reinhardt-query)
-   - Implement principle of least privilege
-   - Enable database connection encryption
-
-### For Developers
-
-1. **SQL Injection Prevention**
-   - Use reinhardt-query for all SQL construction
-   - Never concatenate SQL strings
-   - Validate and sanitize all inputs
-
-2. **Authentication**
-   - Use industry-standard libraries
-   - Implement secure password hashing
-   - Use secure session management
-
-3. **Authorization**
-   - Check permissions on every request
-   - Implement role-based access control
-   - Use principle of least privilege
-
-4. **Dependencies**
-   - Keep dependencies updated
-   - Review security advisories
-   - Use `cargo-deny` in CI
-
-5. **Error Handling**
-   - Don't expose sensitive information in errors
-   - Log security events appropriately
-   - Monitor for suspicious activity
-
----
-
-## Security Audits
-
-This project has not yet undergone a formal security audit.
-
-**Planned:**
-- First audit before 1.0.0 release
-- Annual audits thereafter
-- Penetration testing for web components
-
----
-
-## Receiving Security Updates
-
-### Security Advisories
-
-All security advisories will be published at:
-```
-https://github.com/kent8192/reinhardt-web/security/advisories
-```
-
-### Dependabot Alerts
-
-Enable Dependabot alerts in your fork to receive automatic vulnerability notifications for dependencies.
-
-### Monitoring
-
-- Watch this repository for releases
-- Subscribe to security advisory notifications
-- Follow the project on GitHub for updates
-
----
-
-## Security-Related Resources
-
-- **Issue Guidelines**: instructions/ISSUE_GUIDELINES.md (see Security Issues section)
-- **Contributing Guide**: CONTRIBUTING.md
-- **Code of Conduct**: CODE_OF_CONDUCT.md
-
----
-
-## Acknowledgments
-
-We thank all security researchers who responsibly disclose vulnerabilities to help improve the security of Reinhardt.
-
----
-
-**Last Updated:** 2026-01-26
-
-**Repository:** https://github.com/kent8192/reinhardt-web
+Report vulnerabilities privately through [GitHub Security Advisories](https://github.com/kent8192/reinhardt-web/security/advisories), the preferred reporting channel. Do not create a public issue or disclose details publicly before a fix is available.
+
+Include affected versions, prerequisites, a minimal reproduction, impact, and
+any proposed mitigation. If GitHub Security Advisories cannot be used, contact
+the maintainers privately through GitHub.

--- a/crates/SECURITY.md
+++ b/crates/SECURITY.md
@@ -1,7 +1,8 @@
 # Reinhardt Framework Crate Security Policy
 
 This policy supplements the repository [Security Policy](../SECURITY.md) for
-all framework crates.
+all framework crates. Security policies compose from the repository root to
+each nested component; the closest policy wins on conflict.
 
 - Public framework APIs may receive Internet-originated data.
 - Generated code is part of the production boundary.

--- a/crates/SECURITY.md
+++ b/crates/SECURITY.md
@@ -1,0 +1,13 @@
+# Reinhardt Framework Crate Security Policy
+
+This policy supplements the repository [Security Policy](../SECURITY.md) for
+all framework crates.
+
+- Public framework APIs may receive Internet-originated data.
+- Generated code is part of the production boundary.
+- Feature-gated documented production code remains in scope.
+- Security checks fail closed.
+- Bounded remote input causing panic, stack exhaustion, or disproportionate
+  resource consumption is reportable.
+- Raw SQL, raw HTML, arbitrary code, and equivalent APIs expose explicit trust
+  boundaries; safe APIs must not enter them accidentally.

--- a/crates/SECURITY.md
+++ b/crates/SECURITY.md
@@ -12,3 +12,6 @@ each nested component; the closest policy wins on conflict.
   resource consumption is reportable.
 - Raw SQL, raw HTML, arbitrary code, and equivalent APIs expose explicit trust
   boundaries; safe APIs must not enter them accidentally.
+- URL helpers that concatenate caller-supplied static asset names do not
+  validate dot segments or encode path components automatically. Applications
+  must validate asset names before passing them to a static URL helper.

--- a/crates/reinhardt-admin/SECURITY.md
+++ b/crates/reinhardt-admin/SECURITY.md
@@ -33,8 +33,10 @@ state are attacker-controlled until the server validates them.
   applications must also apply the selected `ModelAdmin` field allowlist,
   read-only, ownership, and tenant checks to every imported record;
   `import_data` does not independently apply `create_record` mutation
-  validation. CSV quoting alone does not prevent formula interpretation;
-  rendered values use context-appropriate escaping.
+  validation. `CsvExporter` and `TsvExporter` forward cell text without
+  formula neutralization; RFC 4180 quoting and TSV delimiter escaping alone do
+  not prevent formula interpretation. Rendered values use context-appropriate
+  escaping.
 - Static, uploaded, generated, and vendor asset paths remain confined to their
   configured asset roots. Deployments enabling remote executable or render-
   active vendor assets must provide verified integrity values before download

--- a/crates/reinhardt-admin/SECURITY.md
+++ b/crates/reinhardt-admin/SECURITY.md
@@ -1,0 +1,38 @@
+# reinhardt-admin Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-admin` serves a privileged administrative UI and its server
+functions, generated clients, static assets, import/export facilities, and
+WASM SPA. Admin routes, form values, record identifiers, files, and browser
+state are attacker-controlled until the server validates them.
+
+## Security Invariants
+
+- Every privileged read, mutation, bulk action, import, export, and custom
+  action enforces server-side model, object, tenant, and operation permission.
+  Client, WASM, and generated-client state is display state only.
+- Cookie-authenticated mutations preserve CSRF protection. Security-sensitive
+  identifiers, ownership, tenant, role, permission, credential, and read-only
+  fields cannot be changed through forms, inline edits, or alternate requests
+  unless the server explicitly authorizes that operation.
+- Import and export validate formats and data, bound work, preserve the
+  caller's authorized scope, and do not turn uploaded or exported values into
+  executable content. Rendered values use context-appropriate escaping.
+- Static, uploaded, generated, and vendor asset paths remain confined to their
+  configured asset roots. Remote executable or render-active vendor assets
+  require verified integrity before download or serving; a mutable remote asset
+  without an integrity value is not a trusted update.
+- Native, WASM, generated-client, and direct server-function paths enforce
+  equivalent permissions and never let a client-side route or UI check replace
+  server authorization.
+
+## Reportable Findings
+
+Report admin authorization or CSRF bypass, protected-field mass assignment,
+unsafe import/export or rendered values, asset confinement escape, unverified
+remote active vendor assets, or weaker native/WASM/generated-client behavior.

--- a/crates/reinhardt-admin/SECURITY.md
+++ b/crates/reinhardt-admin/SECURITY.md
@@ -23,8 +23,10 @@ state are attacker-controlled until the server validates them.
   fields cannot be changed through forms, inline edits, or alternate requests
   unless the server explicitly authorizes that operation.
 - Import and export validate formats and data, bound work, preserve the
-  caller's authorized scope, and do not turn uploaded or exported values into
-  executable content. Rendered values use context-appropriate escaping.
+  caller's authorized scope, and must neutralize spreadsheet formula prefixes
+  before CSV/TSV values are opened by spreadsheet software. CSV quoting alone
+  does not prevent formula interpretation; rendered values use
+  context-appropriate escaping.
 - Static, uploaded, generated, and vendor asset paths remain confined to their
   configured asset roots. Deployments enabling remote executable or render-
   active vendor assets must provide verified integrity values before download

--- a/crates/reinhardt-admin/SECURITY.md
+++ b/crates/reinhardt-admin/SECURITY.md
@@ -14,8 +14,10 @@ state are attacker-controlled until the server validates them.
 ## Security Invariants
 
 - Every privileged read, mutation, bulk action, import, export, and custom
-  action enforces server-side model, object, tenant, and operation permission.
-  Client, WASM, and generated-client state is display state only.
+  action enforces server-side model and operation permission. Applications
+  requiring object or tenant isolation must perform a per-target authorization
+  check before each operation; the current admin permission hooks are not
+  object-aware. Client, WASM, and generated-client state is display state only.
 - Cookie-authenticated mutations preserve CSRF protection. Security-sensitive
   identifiers, ownership, tenant, role, permission, credential, and read-only
   fields cannot be changed through forms, inline edits, or alternate requests
@@ -24,9 +26,10 @@ state are attacker-controlled until the server validates them.
   caller's authorized scope, and do not turn uploaded or exported values into
   executable content. Rendered values use context-appropriate escaping.
 - Static, uploaded, generated, and vendor asset paths remain confined to their
-  configured asset roots. Remote executable or render-active vendor assets
-  require verified integrity before download or serving; a mutable remote asset
-  without an integrity value is not a trusted update.
+  configured asset roots. Deployments enabling remote executable or render-
+  active vendor assets must provide verified integrity values before download
+  or serving; an empty integrity value is an explicitly unverified bootstrap,
+  not a trusted update.
 - Native, WASM, generated-client, and direct server-function paths enforce
   equivalent permissions and never let a client-side route or UI check replace
   server authorization.

--- a/crates/reinhardt-admin/SECURITY.md
+++ b/crates/reinhardt-admin/SECURITY.md
@@ -24,9 +24,12 @@ state are attacker-controlled until the server validates them.
   unless the server explicitly authorizes that operation.
 - Import and export validate formats and data, bound work, preserve the
   caller's authorized scope, and must neutralize spreadsheet formula prefixes
-  before CSV/TSV values are opened by spreadsheet software. CSV quoting alone
-  does not prevent formula interpretation; rendered values use
-  context-appropriate escaping.
+  before CSV/TSV values are opened by spreadsheet software. Protected
+  applications must also apply the selected `ModelAdmin` field allowlist,
+  read-only, ownership, and tenant checks to every imported record;
+  `import_data` does not independently apply `create_record` mutation
+  validation. CSV quoting alone does not prevent formula interpretation;
+  rendered values use context-appropriate escaping.
 - Static, uploaded, generated, and vendor asset paths remain confined to their
   configured asset roots. Deployments enabling remote executable or render-
   active vendor assets must provide verified integrity values before download

--- a/crates/reinhardt-admin/SECURITY.md
+++ b/crates/reinhardt-admin/SECURITY.md
@@ -18,6 +18,11 @@ state are attacker-controlled until the server validates them.
   requiring object or tenant isolation must perform a per-target authorization
   check before each operation; the current admin permission hooks are not
   object-aware. Client, WASM, and generated-client state is display state only.
+- `AdminDatabase::list`, list responses, and exports can return complete row
+  maps; `ModelAdmin::list_display` and `fields` are not independent read
+  allowlists on those paths. Protected applications must filter sensitive
+  columns before returning or serializing records, or explicitly treat model
+  view permission as permission to read every column.
 - Cookie-authenticated mutations preserve CSRF protection. Security-sensitive
   identifiers, ownership, tenant, role, permission, credential, and read-only
   fields cannot be changed through forms, inline edits, or alternate requests

--- a/crates/reinhardt-admin/SECURITY.md
+++ b/crates/reinhardt-admin/SECURITY.md
@@ -33,10 +33,13 @@ state are attacker-controlled until the server validates them.
   applications must also apply the selected `ModelAdmin` field allowlist,
   read-only, ownership, and tenant checks to every imported record;
   `import_data` does not independently apply `create_record` mutation
-  validation. `CsvExporter` and `TsvExporter` forward cell text without
-  formula neutralization; RFC 4180 quoting and TSV delimiter escaping alone do
-  not prevent formula interpretation. Rendered values use context-appropriate
-  escaping.
+  validation. The server-function import path deserializes its complete
+  request body before calling `import_data`, so its file-size check does not
+  bound request-body buffering or JSON parsing; callers must enforce a body
+  limit before server-function deserialization. `CsvExporter` and `TsvExporter`
+  forward cell text without formula neutralization; RFC 4180 quoting and TSV
+  delimiter escaping alone do not prevent formula interpretation. Rendered
+  values use context-appropriate escaping.
 - Static, uploaded, generated, and vendor asset paths remain confined to their
   configured asset roots. Deployments enabling remote executable or render-
   active vendor assets must provide verified integrity values before download

--- a/crates/reinhardt-auth/SECURITY.md
+++ b/crates/reinhardt-auth/SECURITY.md
@@ -33,12 +33,13 @@ specific validation completes.
   when configured. Key rotation preserves verification only for approved keys;
   logout, revocation, password changes, and credential compromise invalidate
   tokens according to their configured lifecycle.
-- OAuth flows bind authorization responses to validated state, PKCE, and nonce
-  values where applicable; redirect targets and callback parameters are not
-  trusted merely because they arrive from the browser.
-- MFA challenges, verification, and completion are bound to the authenticating
-  user, login transaction, intended factor, and bounded lifetime; a response
-  cannot complete another user's or another attempt's login.
+- OAuth flows must bind authorization responses to validated state, PKCE, nonce,
+  and the initiating browser session where applicable; the state stores do not
+  automatically establish a browser binding.
+- Protected MFA integrations must bind challenges, verification, and completion
+  to the authenticating user, login transaction, intended factor, and bounded
+  lifetime. `MFAAuthentication` can operate as a standalone TOTP backend and
+  does not supply a first-factor transaction by itself.
 - Deployments using remote-user authentication must accept proxy identity
   headers only behind a configured trusted immediate proxy and strip or reject
   them from all other peers. The remote-user backend consumes the configured

--- a/crates/reinhardt-auth/SECURITY.md
+++ b/crates/reinhardt-auth/SECURITY.md
@@ -1,0 +1,53 @@
+# reinhardt-auth Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-auth` establishes and authorizes application identities through
+credentials, sessions, cookies, tokens, OAuth, MFA, permission checks, and
+middleware. Credentials, bearer tokens, cookies, authorization headers, OAuth
+responses, proxy headers, and client state are attacker-controlled until their
+specific validation completes.
+
+## Security Invariants
+
+- Credential parsing and verification fail closed. Missing, malformed, expired,
+  revoked, inactive, or unverifiable credentials never establish identity.
+- Authorization is enforced server-side for every protected action with the
+  target object, model, tenant, and operation context. Client `AuthState` is
+  display state only and is never authoritative for identity or permissions.
+- Missing authentication middleware, request auth state, or required dependency
+  is denial, not anonymous success or a permissive fallback.
+- Object-level and model-level permission checks have equivalent enforcement;
+  collection, detail, mutation, and alternate transport paths cannot bypass one
+  another.
+- Authentication regenerates session identifiers at login and privilege change,
+  invalidates replaced sessions, and prevents session fixation. Session cookies
+  use Secure, HttpOnly, appropriate SameSite, scoped path/domain, and expiry
+  semantics for their deployment.
+- JWT verification pins permitted algorithms and keys, validates signatures and
+  expiry before claims are used, and validates issuer, audience, and time claims
+  when configured. Key rotation preserves verification only for approved keys;
+  logout, revocation, password changes, and credential compromise invalidate
+  tokens according to their configured lifecycle.
+- OAuth flows bind authorization responses to validated state, PKCE, and nonce
+  values where applicable; redirect targets and callback parameters are not
+  trusted merely because they arrive from the browser.
+- MFA challenges, verification, and completion are bound to the authenticating
+  user, login transaction, intended factor, and bounded lifetime; a response
+  cannot complete another user's or another attempt's login.
+- Remote-user authentication trusts proxy identity headers only from configured
+  trusted immediate proxies. Forwarded headers from all other peers are ignored.
+- Authentication errors, logs, responses, and telemetry do not disclose
+  passwords, tokens, signing keys, MFA material, or account-enumeration detail.
+
+## Reportable Findings
+
+Report credential or authorization bypass, client-authoritative authorization,
+session fixation, weak cookie or JWT validation, rotation or revocation gaps,
+OAuth/MFA transaction confusion, spoofable proxy identity, or secret exposure.
+Application-specific policies remain out of scope when callers intentionally
+select an explicit unauthenticated endpoint.

--- a/crates/reinhardt-auth/SECURITY.md
+++ b/crates/reinhardt-auth/SECURITY.md
@@ -21,6 +21,10 @@ specific validation completes.
   display state only and is never authoritative for identity or permissions.
 - Missing authentication middleware, request auth state, or required dependency
   is denial, not anonymous success or a permissive fallback.
+- `SessionAuthentication` treats a missing `_auth_user_is_active` session flag as
+  active and does not perform an authoritative user lookup. Deployments that
+  disable accounts after session creation must validate active status before
+  accepting the session.
 - Object-level and model-level permission checks have equivalent enforcement;
   collection, detail, mutation, and alternate transport paths cannot bypass one
   another.
@@ -47,6 +51,11 @@ specific validation completes.
   headers only behind a configured trusted immediate proxy and strip or reject
   them from all other peers. The remote-user backend consumes the configured
   header and does not inspect the peer trust boundary itself.
+- Basic authentication skips Argon2 verification when the username is absent,
+  and `ProviderConfig` derives `Debug` while storing `client_secret` in a
+  public `String`. Callers handling untrusted authentication traffic must use a
+  dummy-hash/timing-equalized failure path and redact provider configuration
+  before logging or formatting it.
 - Authentication errors, logs, responses, and telemetry do not disclose
   passwords, tokens, signing keys, MFA material, or account-enumeration detail.
 

--- a/crates/reinhardt-auth/SECURITY.md
+++ b/crates/reinhardt-auth/SECURITY.md
@@ -39,8 +39,10 @@ specific validation completes.
 - MFA challenges, verification, and completion are bound to the authenticating
   user, login transaction, intended factor, and bounded lifetime; a response
   cannot complete another user's or another attempt's login.
-- Remote-user authentication trusts proxy identity headers only from configured
-  trusted immediate proxies. Forwarded headers from all other peers are ignored.
+- Deployments using remote-user authentication must accept proxy identity
+  headers only behind a configured trusted immediate proxy and strip or reject
+  them from all other peers. The remote-user backend consumes the configured
+  header and does not inspect the peer trust boundary itself.
 - Authentication errors, logs, responses, and telemetry do not disclose
   passwords, tokens, signing keys, MFA material, or account-enumeration detail.
 

--- a/crates/reinhardt-auth/SECURITY.md
+++ b/crates/reinhardt-auth/SECURITY.md
@@ -32,7 +32,10 @@ specific validation completes.
   expiry before claims are used, and validates issuer, audience, and time claims
   when configured. Key rotation preserves verification only for approved keys;
   logout, revocation, password changes, and credential compromise invalidate
-  tokens according to their configured lifecycle.
+  tokens according to their configured lifecycle. `JwtAuthMiddleware` and the
+  `JwtAuth` REST backend do not independently recheck account status or
+  revocation state after token issuance; deployments requiring immediate
+  disable or revocation must perform an authoritative account lookup.
 - OAuth flows must bind authorization responses to validated state, PKCE, nonce,
   and the initiating browser session where applicable; the state stores do not
   automatically establish a browser binding.

--- a/crates/reinhardt-auth/SECURITY.md
+++ b/crates/reinhardt-auth/SECURITY.md
@@ -56,6 +56,11 @@ specific validation completes.
   public `String`. Callers handling untrusted authentication traffic must use a
   dummy-hash/timing-equalized failure path and redact provider configuration
   before logging or formatting it.
+- `LoginCredentials`, `CreateUserData`, `OAuthToken`, `TokenResponse`, and
+  `TokenRotationRecord` are public credential-bearing types whose derived
+  `Debug` or `Serialize` implementations may expose passwords or live tokens.
+  Callers must treat these values as secrets and redact or avoid formatting
+  them before logging, diagnostics, telemetry, or error responses.
 - Authentication errors, logs, responses, and telemetry do not disclose
   passwords, tokens, signing keys, MFA material, or account-enumeration detail.
 

--- a/crates/reinhardt-commands/SECURITY.md
+++ b/crates/reinhardt-commands/SECURITY.md
@@ -1,0 +1,49 @@
+# reinhardt-commands Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-commands` parses management commands, generates projects and apps,
+loads templates and plugins, collects static assets, reloads development
+processes, and emits project introspection. Ordinary trusted local developer
+power is not automatically reportable. Names, templates, archives, plugin
+artifacts, static files, generated paths, watcher events, and introspection
+inputs nevertheless become untrusted when they cross a safe command boundary.
+
+## Security Invariants
+
+- Child processes use structured program and argument vectors. Filenames,
+  template values, watcher events, and file contents never become shell syntax,
+  command fragments, environment assignments, or option injection.
+- Project and app names, templates, static inputs, and generated files are
+  validated and confined to their configured project, template, source, and
+  output roots after normalization and symlink resolution. They cannot select
+  arbitrary host paths or overwrite files outside their intended destination.
+- Archive, plugin, and template extraction validates entry names, types, sizes,
+  links, and destination paths before writing. Traversal, absolute paths,
+  symlink or hard-link escape, and overwrite outside the extraction root fail
+  safely.
+- `collectstatic` preserves source and destination confinement when copying or
+  linking. Symlinks are created only when their resolved target and destination
+  remain within the authorized static roots; unsafe links are rejected rather
+  than copied or followed.
+- Reload builds and executes only structured, validated commands. File names,
+  paths, and changed file contents cannot inject commands into rebuild, restart,
+  logging, or browser-reload paths.
+- Introspection output and errors omit secrets, credentials, signed URLs,
+  private connection details, and other sensitive settings, including nested or
+  backend-derived values.
+- Generated secrets use a cryptographically secure operating-system random
+  source with sufficient entropy for their purpose. Predictable randomness,
+  timestamps, identifiers, or formatting alone are not secret generation.
+
+## Reportable Findings
+
+Report injection through a safe command boundary, path or extraction escape,
+unsafe static symlink handling, reload injection, secret disclosure through
+introspection, or predictable generated secrets. Explicit local shell use and
+other documented trusted developer operations are out of scope unless a safe
+command API lets untrusted input cross into them.

--- a/crates/reinhardt-commands/SECURITY.md
+++ b/crates/reinhardt-commands/SECURITY.md
@@ -18,18 +18,18 @@ inputs nevertheless become untrusted when they cross a safe command boundary.
 - Child processes use structured program and argument vectors. Filenames,
   template values, watcher events, and file contents never become shell syntax,
   command fragments, environment assignments, or option injection.
-- Project and app names, templates, static inputs, and generated files are
+- Project and app names, templates, static inputs, and generated files must be
   validated and confined to their configured project, template, source, and
-  output roots after normalization and symlink resolution. They cannot select
-  arbitrary host paths or overwrite files outside their intended destination.
+  output roots after normalization and symlink resolution. Callers must not
+  treat path normalization alone as symlink confinement.
 - Archive, plugin, and template extraction validates entry names, types, sizes,
   links, and destination paths before writing. Traversal, absolute paths,
   symlink or hard-link escape, and overwrite outside the extraction root fail
   safely.
-- `collectstatic` preserves source and destination confinement when copying or
-  linking. Symlinks are created only when their resolved target and destination
-  remain within the authorized static roots; unsafe links are rejected rather
-  than copied or followed.
+- `collectstatic` callers must prevalidate source symlinks and authorized static
+  roots before copying or linking. The current traversal and copy primitives do
+  not independently canonicalize every source link, so an unsafe link must not
+  be treated as confined or followed.
 - Reload builds and executes only structured, validated commands. File names,
   paths, and changed file contents cannot inject commands into rebuild, restart,
   logging, or browser-reload paths.

--- a/crates/reinhardt-commands/SECURITY.md
+++ b/crates/reinhardt-commands/SECURITY.md
@@ -23,8 +23,11 @@ inputs nevertheless become untrusted when they cross a safe command boundary.
   assignments.
 - Project and app names, templates, static inputs, and generated files must be
   validated and confined to their configured project, template, source, and
-  output roots after normalization and symlink resolution. Callers must not
-  treat path normalization alone as symlink confinement.
+  output roots after normalization and symlink resolution. The project and app
+  template commands currently derive output paths from supplied names before
+  every containment and identifier check, so callers must prevalidate names and
+  path containment. Callers must not treat path normalization alone as symlink
+  confinement.
 - Archive, plugin, and template extraction validates entry names, types, sizes,
   links, and destination paths before writing. Traversal, absolute paths,
   symlink or hard-link escape, and overwrite outside the extraction root fail

--- a/crates/reinhardt-commands/SECURITY.md
+++ b/crates/reinhardt-commands/SECURITY.md
@@ -15,9 +15,12 @@ inputs nevertheless become untrusted when they cross a safe command boundary.
 
 ## Security Invariants
 
-- Child processes use structured program and argument vectors. Filenames,
-  template values, watcher events, and file contents never become shell syntax,
-  command fragments, environment assignments, or option injection.
+- Child processes use structured program and argument vectors. Callers must
+  terminate options before passing filenames (for example, with `--`), because
+  a structured argument beginning with `-` can still be interpreted as an
+  option by the child tool. Filenames, template values, watcher events, and
+  file contents never become shell syntax, command fragments, or environment
+  assignments.
 - Project and app names, templates, static inputs, and generated files must be
   validated and confined to their configured project, template, source, and
   output roots after normalization and symlink resolution. Callers must not
@@ -35,7 +38,10 @@ inputs nevertheless become untrusted when they cross a safe command boundary.
   logging, or browser-reload paths.
 - Introspection output and errors omit secrets, credentials, signed URLs,
   private connection details, and other sensitive settings, including nested or
-  backend-derived values.
+  backend-derived values. Protected applications must classify and redact
+  nested plugin configuration before displaying it; `plugin info` currently
+  iterates raw plugin configuration values and is not an independent secret
+  redaction boundary.
 - Generated secrets use a cryptographically secure operating-system random
   source with sufficient entropy for their purpose. Predictable randomness,
   timestamps, identifiers, or formatting alone are not secret generation.

--- a/crates/reinhardt-conf/SECURITY.md
+++ b/crates/reinhardt-conf/SECURITY.md
@@ -21,10 +21,11 @@ boundary; secret material must not become diagnostic output.
   and bounds recursion depth, expanded size, and work before resolution. Missing
   or malformed references fail safely rather than leaking values or selecting a
   permissive fallback.
-- Encryption uses authenticated encryption with algorithm-appropriate, unique
-  nonces and securely generated, scoped keys. Keys, plaintext, nonce material,
-  and authentication failures are never exposed; decryption rejects tampering
-  before a value is used.
+- Encryption uses authenticated encryption with securely generated, scoped
+  keys and algorithm-appropriate nonces that are unique per key and never
+  reused. Keys and plaintext are never exposed; authentication failures do not
+  disclose sensitive material. Decryption rejects tampering before a value is
+  used.
 - Secret and audit backends redact their credentials and connection details on
   every error path, including initialization, refresh, audit persistence, and
   retries.

--- a/crates/reinhardt-conf/SECURITY.md
+++ b/crates/reinhardt-conf/SECURITY.md
@@ -18,6 +18,9 @@ boundary; secret material must not become diagnostic output.
   diagnostics. Configuration types must use a redacting secret type or custom
   implementations; `CoreSettings` stores `secret_key` as a plain `String`, so
   callers must not use its derived diagnostics or serialization for secrets.
+  `VaultConfig` likewise derives `Debug` while storing its authentication token
+  as a public `String`; callers must treat it as secret-bearing input and must
+  not log or serialize the derived diagnostic without redaction.
 - Interpolation accepts only defined source and reference forms and detects
   cycles. Protected applications must bound recursion depth, substitution
   count, expanded size, and work before resolution; `Interpolator` does not

--- a/crates/reinhardt-conf/SECURITY.md
+++ b/crates/reinhardt-conf/SECURITY.md
@@ -18,10 +18,11 @@ boundary; secret material must not become diagnostic output.
   diagnostics. Configuration types must use a redacting secret type or custom
   implementations; `CoreSettings` stores `secret_key` as a plain `String`, so
   callers must not use its derived diagnostics or serialization for secrets.
-- Interpolation accepts only defined source and reference forms, detects cycles,
-  and bounds recursion depth, expanded size, and work before resolution. Missing
-  or malformed references fail safely rather than leaking values or selecting a
-  permissive fallback.
+- Interpolation accepts only defined source and reference forms and detects
+  cycles. Protected applications must bound recursion depth, substitution
+  count, expanded size, and work before resolution; `Interpolator` does not
+  impose every output or work limit automatically. Missing or malformed
+  references fail safely rather than selecting a permissive fallback.
 - Encryption uses authenticated encryption with securely generated, scoped
   keys and algorithm-appropriate nonces that are unique per key and never
   reused. Keys and plaintext are never exposed; authentication failures do not

--- a/crates/reinhardt-conf/SECURITY.md
+++ b/crates/reinhardt-conf/SECURITY.md
@@ -21,6 +21,11 @@ boundary; secret material must not become diagnostic output.
   `VaultConfig` likewise derives `Debug` while storing its authentication token
   as a public `String`; callers must treat it as secret-bearing input and must
   not log or serialize the derived diagnostic without redaction.
+  `EmailSettings` derives diagnostics and serialization over its plaintext SMTP
+  password, `CacheSettings` exposes a potentially credential-bearing Redis URL
+  through `location`, and `DatabaseUrl` serializes its password and original
+  URL; callers must treat these fields as secret-bearing inputs and redact them
+  before diagnostics or serialization.
 - `VaultSecretProvider` propagates the underlying `reqwest` transport error;
   that error may contain the Vault request URL, including a private host or
   path. Callers must sanitize the error before logging or returning it across a
@@ -43,8 +48,12 @@ boundary; secret material must not become diagnostic output.
   notification-only unless the caller installs that candidate-build, validate,
   and swap callback; it does not replace active settings by itself.
 - Rotation accepts only authenticated replacement material and bounds the
-  lifetime of stale credentials or privileges. Revoked, expired, or failed
-  replacements cannot remain valid indefinitely through caches or reloads.
+  lifetime of stale credentials or privileges. `SecretRotation::rotate` and
+  `force_rotate` currently record timestamps and audit entries only: they do
+  not replace or revoke credentials or authenticate the `rotated_by` value.
+  Callers must wrap them with the actual authenticated replacement and
+  revocation workflow. Revoked, expired, or failed replacements cannot remain
+  valid indefinitely through caches or reloads.
 - Dynamic-backend integrations document their integrity, authentication,
   authorization, availability, and freshness assumptions. Implementations do
   not silently treat an unavailable or unauthenticated backend as trusted local

--- a/crates/reinhardt-conf/SECURITY.md
+++ b/crates/reinhardt-conf/SECURITY.md
@@ -21,6 +21,10 @@ boundary; secret material must not become diagnostic output.
   `VaultConfig` likewise derives `Debug` while storing its authentication token
   as a public `String`; callers must treat it as secret-bearing input and must
   not log or serialize the derived diagnostic without redaction.
+- `VaultSecretProvider` propagates the underlying `reqwest` transport error;
+  that error may contain the Vault request URL, including a private host or
+  path. Callers must sanitize the error before logging or returning it across a
+  boundary where the address is sensitive.
 - Interpolation accepts only defined source and reference forms and detects
   cycles. Protected applications must bound recursion depth, substitution
   count, expanded size, and work before resolution; `Interpolator` does not

--- a/crates/reinhardt-conf/SECURITY.md
+++ b/crates/reinhardt-conf/SECURITY.md
@@ -13,10 +13,11 @@ boundary; secret material must not become diagnostic output.
 
 ## Security Invariants
 
-- Secrets, credentials, keys, tokens, and connection URLs are redacted from
+- Secrets, credentials, keys, tokens, and connection URLs must be redacted from
   logs, errors, `Debug` output, audits, serialization, and equivalent
-  diagnostics. Redaction covers backend failures and nested configuration
-  values as well as direct secret fields.
+  diagnostics. Configuration types must use a redacting secret type or custom
+  implementations; `CoreSettings` stores `secret_key` as a plain `String`, so
+  callers must not use its derived diagnostics or serialization for secrets.
 - Interpolation accepts only defined source and reference forms, detects cycles,
   and bounds recursion depth, expanded size, and work before resolution. Missing
   or malformed references fail safely rather than leaking values or selecting a
@@ -29,9 +30,10 @@ boundary; secret material must not become diagnostic output.
 - Secret and audit backends redact their credentials and connection details on
   every error path, including initialization, refresh, audit persistence, and
   retries.
-- Hot reload constructs and validates a complete candidate configuration before
-  one atomic swap. A failed reload leaves the active configuration unchanged;
-  readers cannot observe a partial, mixed, or unvalidated configuration.
+- Hot-reload consumers must construct and validate a complete candidate
+  configuration before one atomic swap. `DynamicSettings::watch_file` is
+  notification-only unless the caller installs that candidate-build, validate,
+  and swap callback; it does not replace active settings by itself.
 - Rotation accepts only authenticated replacement material and bounds the
   lifetime of stale credentials or privileges. Revoked, expired, or failed
   replacements cannot remain valid indefinitely through caches or reloads.

--- a/crates/reinhardt-conf/SECURITY.md
+++ b/crates/reinhardt-conf/SECURITY.md
@@ -1,0 +1,47 @@
+# reinhardt-conf Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-conf` resolves typed configuration, environment and backend values,
+interpolation, encrypted values, audits, dynamic settings, hot reload, and
+secret rotation. Configuration inputs and dynamic backends cross a trust
+boundary; secret material must not become diagnostic output.
+
+## Security Invariants
+
+- Secrets, credentials, keys, tokens, and connection URLs are redacted from
+  logs, errors, `Debug` output, audits, serialization, and equivalent
+  diagnostics. Redaction covers backend failures and nested configuration
+  values as well as direct secret fields.
+- Interpolation accepts only defined source and reference forms, detects cycles,
+  and bounds recursion depth, expanded size, and work before resolution. Missing
+  or malformed references fail safely rather than leaking values or selecting a
+  permissive fallback.
+- Encryption uses authenticated encryption with algorithm-appropriate, unique
+  nonces and securely generated, scoped keys. Keys, plaintext, nonce material,
+  and authentication failures are never exposed; decryption rejects tampering
+  before a value is used.
+- Secret and audit backends redact their credentials and connection details on
+  every error path, including initialization, refresh, audit persistence, and
+  retries.
+- Hot reload constructs and validates a complete candidate configuration before
+  one atomic swap. A failed reload leaves the active configuration unchanged;
+  readers cannot observe a partial, mixed, or unvalidated configuration.
+- Rotation accepts only authenticated replacement material and bounds the
+  lifetime of stale credentials or privileges. Revoked, expired, or failed
+  replacements cannot remain valid indefinitely through caches or reloads.
+- Dynamic-backend integrations document their integrity, authentication,
+  authorization, availability, and freshness assumptions. Implementations do
+  not silently treat an unavailable or unauthenticated backend as trusted local
+  configuration.
+
+## Reportable Findings
+
+Report secret disclosure, unsafe interpolation or unbounded expansion,
+unauthenticated encryption or nonce/key misuse, backend credential exposure,
+partial hot reload, indefinitely stale privilege after rotation, or an
+undocumented dynamic-backend trust assumption that permits unsafe configuration.

--- a/crates/reinhardt-db/SECURITY.md
+++ b/crates/reinhardt-db/SECURITY.md
@@ -15,7 +15,10 @@ database trust boundary.
 
 - ORM reads and writes parameterize values. Safe filters, relations,
   annotations, aggregations, lookups, and orderings preserve query structure
-  and do not accept arbitrary SQL fragments.
+  and do not accept arbitrary SQL fragments. PostgreSQL aggregate constructors
+  that accept expression, separator, or ordering strings must receive validated
+  identifiers/values or be treated as an explicit raw-SQL boundary; callers
+  must not pass request-derived strings directly.
 - Runtime model and schema metadata, including table, column, relation, index,
   and database-routing names, is validated and safely quoted before use.
 - Migration and schema operations apply the same backend-correct identifier

--- a/crates/reinhardt-db/SECURITY.md
+++ b/crates/reinhardt-db/SECURITY.md
@@ -21,8 +21,10 @@ database trust boundary.
 - Migration and schema operations apply the same backend-correct identifier
   quoting and validation as runtime queries; generated migration state cannot
   turn metadata into executable SQL.
-- Connection URLs, credentials, passwords, tokens, and private endpoints are
-  redacted from errors, logs, diagnostics, migration output, and telemetry.
+- Applications must use redacting URL/configuration types or custom diagnostic
+  and serialization implementations for connection URLs, credentials,
+  passwords, tokens, and private endpoints. The public raw URL/configuration
+  wrappers do not redact derived `Debug` or serialized output automatically.
 - Pools isolate transaction state between borrowers. Applications using roles,
   tenant/session variables, temporary settings, or other session state must
   configure backend-specific reset/discard behavior or keep that state inside a

--- a/crates/reinhardt-db/SECURITY.md
+++ b/crates/reinhardt-db/SECURITY.md
@@ -23,9 +23,11 @@ database trust boundary.
   turn metadata into executable SQL.
 - Connection URLs, credentials, passwords, tokens, and private endpoints are
   redacted from errors, logs, diagnostics, migration output, and telemetry.
-- Pools isolate transaction and session state between borrowers. A returned
-  connection cannot retain another request's transaction, role, tenant,
-  temporary settings, prepared state, or session variables.
+- Pools isolate transaction state between borrowers. Applications using roles,
+  tenant/session variables, temporary settings, or other session state must
+  configure backend-specific reset/discard behavior or keep that state inside a
+  caller-owned transaction; returning a connection does not reset arbitrary
+  session state automatically.
 - Errors roll back or discard failed transactional work safely, and migrations
   serialize conflicting schema changes with a reliable lock that is released on
   completion or failure.

--- a/crates/reinhardt-db/SECURITY.md
+++ b/crates/reinhardt-db/SECURITY.md
@@ -36,6 +36,9 @@ database trust boundary.
 - Errors roll back or discard failed transactional work safely, and migrations
   serialize conflicting schema changes with a reliable lock that is released on
   completion or failure.
+- PostgreSQL advisory migration locks are session-scoped. Lock acquisition and
+  the protected migration work must use the same dedicated connection or
+  caller-owned transaction; separate pool checkouts do not preserve the lock.
 - Raw SQL is an explicit documented trust boundary. Safe ORM and migration APIs
   must not route untrusted input into it, and raw-SQL errors must remain
   secret-safe.

--- a/crates/reinhardt-db/SECURITY.md
+++ b/crates/reinhardt-db/SECURITY.md
@@ -1,0 +1,41 @@
+# reinhardt-db Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-db` provides ORM, schema migration, connection-pool, transaction,
+and database-routing interfaces. Model data, request-derived filters, relation
+keys, runtime metadata, connection settings, and migration state may cross a
+database trust boundary.
+
+## Security Invariants
+
+- ORM reads and writes parameterize values. Safe filters, relations,
+  annotations, aggregations, lookups, and orderings preserve query structure
+  and do not accept arbitrary SQL fragments.
+- Runtime model and schema metadata, including table, column, relation, index,
+  and database-routing names, is validated and safely quoted before use.
+- Migration and schema operations apply the same backend-correct identifier
+  quoting and validation as runtime queries; generated migration state cannot
+  turn metadata into executable SQL.
+- Connection URLs, credentials, passwords, tokens, and private endpoints are
+  redacted from errors, logs, diagnostics, migration output, and telemetry.
+- Pools isolate transaction and session state between borrowers. A returned
+  connection cannot retain another request's transaction, role, tenant,
+  temporary settings, prepared state, or session variables.
+- Errors roll back or discard failed transactional work safely, and migrations
+  serialize conflicting schema changes with a reliable lock that is released on
+  completion or failure.
+- Raw SQL is an explicit documented trust boundary. Safe ORM and migration APIs
+  must not route untrusted input into it, and raw-SQL errors must remain
+  secret-safe.
+
+## Reportable Findings
+
+Report injection through a safe database API, cross-request transaction or
+session leakage, unsafe schema identifiers, migration-lock bypass, or exposed
+credentials. Explicit raw SQL is out of scope unless a safe API introduces
+untrusted input into that boundary.

--- a/crates/reinhardt-dentdelion/SECURITY.md
+++ b/crates/reinhardt-dentdelion/SECURITY.md
@@ -16,11 +16,10 @@ malicious. A plugin's requested capabilities do not establish trust.
 - Every plugin privilege is an explicit, identity-bound capability grant. A
   missing, malformed, disabled, or unrecognized capability lookup fails closed;
   manifests, metadata, and another plugin's registration cannot grant it.
-- Network host calls validate scheme, host, resolved addresses, ports, and
-  redirect targets against the configured policy before every connection.
-  Database host calls use only configured, capability-authorized connections.
-  Alternate URL forms, DNS changes, redirects, proxies, IP literals, and other
-  alternate-host paths cannot bypass either check.
+- Network host-call consumers must validate scheme, host, resolved addresses,
+  ports, and every redirect target against the configured policy before each
+  connection. The initial-URL check is not a redirect check; callers must
+  disable automatic redirects or provide per-hop validation.
 - WASM execution has enforced memory, fuel, and wall-clock limits. Host calls
   are metered and bounded so a plugin cannot turn a small invocation into
   unbounded network, database, CPU, memory, or event work.
@@ -38,10 +37,10 @@ malicious. A plugin's requested capabilities do not establish trust.
 - Plugin SSR treats plugin output as untrusted rendered content: it preserves
   the caller's output-encoding and response-security rules and cannot gain
   ambient server privileges through rendering context or serialization.
-- Registry entries, lifecycle state, and event delivery are isolated by plugin
-  identity. A plugin cannot replace another plugin's registration, observe or
-  forge private events, or recursively fan out events without bounded,
-  capability-authorized dispatch.
+- Registry entries, lifecycle state, and event delivery must be isolated by
+  plugin identity. Host integrations must carry the authenticated owner into
+  poll and unsubscribe operations; numeric subscription IDs alone do not prove
+  ownership.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-dentdelion/SECURITY.md
+++ b/crates/reinhardt-dentdelion/SECURITY.md
@@ -19,7 +19,12 @@ malicious. A plugin's requested capabilities do not establish trust.
 - Network host-call consumers must validate scheme, host, resolved addresses,
   ports, and every redirect target against the configured policy before each
   connection. The initial-URL check is not a redirect check; callers must
-  disable automatic redirects or provide per-hop validation.
+  disable automatic redirects or provide per-hop validation. The current
+  `HostState::http_get` and `http_post` implementations validate resolved
+  addresses and then pass the original hostname to the default reqwest client,
+  which resolves it again; this check is not safe against DNS rebinding.
+  Protected deployments must pin the approved address into the connection or
+  use a rebinding-safe resolver/client before enabling untrusted hostnames.
 - Protected deployments must enforce WASM memory, fuel, and wall-clock limits
   and bound host calls. The current runtime applies fuel but does not
   automatically enforce every configured memory or timeout value.

--- a/crates/reinhardt-dentdelion/SECURITY.md
+++ b/crates/reinhardt-dentdelion/SECURITY.md
@@ -28,9 +28,12 @@ malicious. A plugin's requested capabilities do not establish trust.
   or a broader database identity, and untrusted values remain parameterized or
   use validated query structure.
 - Installation and loading confine manifest, module, cache, and extracted paths
-  to their configured roots after normalization and symlink resolution. Plugin
-  identifiers, dependency names, versions, and manifests are parsed and
-  validated before they select files, registries, capabilities, or dependencies.
+  to their configured roots after normalization and symlink resolution. The
+  current discovery path follows symlinks, so protected deployments must reject
+  symlinked module, directory, and manifest entries or canonicalize each target
+  and verify containment before reading it. Plugin identifiers, dependency
+  names, versions, and manifests are parsed and validated before they select
+  files, registries, capabilities, or dependencies.
 - JavaScript and TypeScript plugins have no ambient filesystem, process,
   network, database, secret, or host-object access. Their host interaction is
   capability-mediated, but `TsRuntime::eval` response timeouts do not interrupt

--- a/crates/reinhardt-dentdelion/SECURITY.md
+++ b/crates/reinhardt-dentdelion/SECURITY.md
@@ -1,0 +1,51 @@
+# reinhardt-dentdelion Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-dentdelion` installs, loads, registers, and runs static and dynamic
+plugins. Installed manifests, WASM modules, JavaScript/TypeScript code, plugin
+metadata, registry data, host-call arguments, and plugin events may be
+malicious. A plugin's requested capabilities do not establish trust.
+
+## Security Invariants
+
+- Every plugin privilege is an explicit, identity-bound capability grant. A
+  missing, malformed, disabled, or unrecognized capability lookup fails closed;
+  manifests, metadata, and another plugin's registration cannot grant it.
+- Network host calls validate scheme, host, resolved addresses, ports, and
+  redirect targets against the configured policy before every connection.
+  Database host calls use only configured, capability-authorized connections.
+  Alternate URL forms, DNS changes, redirects, proxies, IP literals, and other
+  alternate-host paths cannot bypass either check.
+- WASM execution has enforced memory, fuel, and wall-clock limits. Host calls
+  are metered and bounded so a plugin cannot turn a small invocation into
+  unbounded network, database, CPU, memory, or event work.
+- Database access is available only through its granted host interface and
+  intended SQL boundary. Plugins cannot acquire raw connections, credentials,
+  or a broader database identity, and untrusted values remain parameterized or
+  use validated query structure.
+- Installation and loading confine manifest, module, cache, and extracted paths
+  to their configured roots after normalization and symlink resolution. Plugin
+  identifiers, dependency names, versions, and manifests are parsed and
+  validated before they select files, registries, capabilities, or dependencies.
+- JavaScript and TypeScript plugins have no ambient filesystem, process,
+  network, database, secret, or host-object access. Their host interaction is
+  capability-mediated and subject to the same resource limits as WASM plugins.
+- Plugin SSR treats plugin output as untrusted rendered content: it preserves
+  the caller's output-encoding and response-security rules and cannot gain
+  ambient server privileges through rendering context or serialization.
+- Registry entries, lifecycle state, and event delivery are isolated by plugin
+  identity. A plugin cannot replace another plugin's registration, observe or
+  forge private events, or recursively fan out events without bounded,
+  capability-authorized dispatch.
+
+## Reportable Findings
+
+Report capability escalation or fail-open lookup, alternate-host bypass,
+resource-limit bypass, SQL or credential boundary escape, unsafe install/load
+path or manifest handling, ambient JavaScript/TypeScript authority, unsafe SSR,
+or cross-plugin registry and event isolation failures.

--- a/crates/reinhardt-dentdelion/SECURITY.md
+++ b/crates/reinhardt-dentdelion/SECURITY.md
@@ -33,7 +33,9 @@ malicious. A plugin's requested capabilities do not establish trust.
   validated before they select files, registries, capabilities, or dependencies.
 - JavaScript and TypeScript plugins have no ambient filesystem, process,
   network, database, secret, or host-object access. Their host interaction is
-  capability-mediated and subject to the same resource limits as WASM plugins.
+  capability-mediated, but `TsRuntime::eval` response timeouts do not interrupt
+  a running Boa worker; protected deployments must terminate or replace a
+  timed-out runtime and enforce the corresponding resource limits.
 - Plugin SSR treats plugin output as untrusted rendered content: it preserves
   the caller's output-encoding and response-security rules and cannot gain
   ambient server privileges through rendering context or serialization.

--- a/crates/reinhardt-dentdelion/SECURITY.md
+++ b/crates/reinhardt-dentdelion/SECURITY.md
@@ -20,9 +20,9 @@ malicious. A plugin's requested capabilities do not establish trust.
   ports, and every redirect target against the configured policy before each
   connection. The initial-URL check is not a redirect check; callers must
   disable automatic redirects or provide per-hop validation.
-- WASM execution has enforced memory, fuel, and wall-clock limits. Host calls
-  are metered and bounded so a plugin cannot turn a small invocation into
-  unbounded network, database, CPU, memory, or event work.
+- Protected deployments must enforce WASM memory, fuel, and wall-clock limits
+  and bound host calls. The current runtime applies fuel but does not
+  automatically enforce every configured memory or timeout value.
 - Database access is available only through its granted host interface and
   intended SQL boundary. Plugins cannot acquire raw connections, credentials,
   or a broader database identity, and untrusted values remain parameterized or

--- a/crates/reinhardt-dentdelion/SECURITY.md
+++ b/crates/reinhardt-dentdelion/SECURITY.md
@@ -44,8 +44,11 @@ malicious. A plugin's requested capabilities do not establish trust.
   ambient server privileges through rendering context or serialization.
 - Registry entries, lifecycle state, and event delivery must be isolated by
   plugin identity. Host integrations must carry the authenticated owner into
-  poll and unsubscribe operations; numeric subscription IDs alone do not prove
-  ownership.
+  poll and unsubscribe operations; the current `HostState` forwards only the
+  numeric subscription ID to `EventBus`, whose poll and unsubscribe methods do
+  not check the stored owner. Numeric subscription IDs alone do not prove
+  ownership, so protected deployments must isolate event buses or add an owner
+  check around these operations.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-di/SECURITY.md
+++ b/crates/reinhardt-di/SECURITY.md
@@ -25,6 +25,10 @@ isolation boundaries.
 - The immutable application root and the current request context remain
   distinct; request-derived values cannot mutate or replace root registrations
   or singleton state.
+- `InjectionContext::clone` copies cached request-scoped entries and request
+  context. It is suitable only for work within the same request scope; callers
+  starting a new request must use `fork` or `fork_for_request` so cached
+  values and request state cannot cross the request boundary.
 - Authentication and authorization extractors fail closed when credentials,
   request context, middleware state, or dependencies are absent, malformed, or
   unresolved.

--- a/crates/reinhardt-di/SECURITY.md
+++ b/crates/reinhardt-di/SECURITY.md
@@ -1,0 +1,45 @@
+# reinhardt-di Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-di` resolves dependency graphs and caches request- and
+application-scoped services. Injection contexts, providers, overrides, cache
+keys, request extractors, and provider failures cross identity and request
+isolation boundaries.
+
+## Security Invariants
+
+- Each request receives an isolated request scope. Request-scoped dependencies,
+  values, cleanup state, and failures cannot be reused by another request,
+  tenant, connection, or principal.
+- User, authorization, session, credential, request, tenant, and other
+  security-sensitive state is never globally cached. Singleton dependencies may
+  hold only application-wide state that cannot identify or authorize a caller.
+- Cache keys preserve both dependency type and scope identity. Distinct keyed
+  providers, generic types, request contexts, and scopes cannot collide or
+  receive a value created for another key.
+- The immutable application root and the current request context remain
+  distinct; request-derived values cannot mutate or replace root registrations
+  or singleton state.
+- Authentication and authorization extractors fail closed when credentials,
+  request context, middleware state, or dependencies are absent, malformed, or
+  unresolved.
+- Test overrides are opt-in, scoped to test or explicitly configured
+  development contexts, cleaned up reliably, and unavailable as an accidental
+  production authorization bypass.
+- Recursive provider graphs detect cycles and enforce a bounded resolution
+  depth or work limit so untrusted dependency selection cannot exhaust stack,
+  memory, or CPU.
+- Network-facing dependency errors are sanitized: responses do not reveal
+  implementation types, provider graphs, credentials, internal endpoints, or
+  other sensitive state.
+
+## Reportable Findings
+
+Report cross-request or cross-principal cache leakage, cache-key collisions,
+root-context replacement, fail-open auth extraction, production-reachable test
+overrides, unbounded dependency resolution, or sensitive network error output.

--- a/crates/reinhardt-di/SECURITY.md
+++ b/crates/reinhardt-di/SECURITY.md
@@ -28,9 +28,10 @@ isolation boundaries.
 - Authentication and authorization extractors fail closed when credentials,
   request context, middleware state, or dependencies are absent, malformed, or
   unresolved.
-- Test overrides are opt-in, scoped to test or explicitly configured
+- Test overrides must be opt-in, scoped to test or explicitly configured
   development contexts, cleaned up reliably, and unavailable as an accidental
-  production authorization bypass.
+  production authorization bypass. The override APIs are not feature-gated;
+  production applications must not expose or invoke them as runtime controls.
 - Recursive provider graphs detect cycles and enforce a bounded resolution
   depth or work limit so untrusted dependency selection cannot exhaust stack,
   memory, or CPU.

--- a/crates/reinhardt-graphql/SECURITY.md
+++ b/crates/reinhardt-graphql/SECURITY.md
@@ -13,9 +13,12 @@ resolver arguments are attacker-controlled.
 
 ## Security Invariants
 
-- Depth, complexity, field-count, document-size, and parsing-work limits apply
-  before execution and account for aliases, fragments, repeated selections,
-  variables, and nested operations so they cannot evade the effective cost.
+- Protected GraphQL deployments must configure and apply depth, complexity,
+  field-count, document-size, and parsing-work limits before execution on every
+  transport path. The schema helpers do not automatically enforce every one of
+  these controls; configured limits account for aliases, fragments, repeated
+  selections, variables, and nested operations so they cannot evade the
+  effective cost.
 - Every resolver and mutation enforces server-side authorization for its target
   object, tenant, and operation. Validation, schema visibility, and client-side
   query construction never replace that decision.

--- a/crates/reinhardt-graphql/SECURITY.md
+++ b/crates/reinhardt-graphql/SECURITY.md
@@ -34,7 +34,10 @@ resolver arguments are attacker-controlled.
   request context for each GraphQL request; the schema-level
   `with_di_context` helper reuses one context and does not provide request
   isolation automatically. GraphQL-over-gRPC preserves the same GraphQL and
-  gRPC authorization, validation, isolation, and resource limits.
+  gRPC authorization, validation, isolation, and resource limits only when
+  each RPC rejects documents whose operation type does not match the RPC and
+  applies the corresponding controls; the current service forwards documents
+  to schema execution without enforcing that operation-type match.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-graphql/SECURITY.md
+++ b/crates/reinhardt-graphql/SECURITY.md
@@ -25,9 +25,10 @@ resolver arguments are attacker-controlled.
 - DataLoader and resolver caches are isolated by request, authenticated user,
   and tenant. Cached values, keys, errors, and batching cannot disclose data
   across those boundaries.
-- Subscription establishment and every event delivery enforce authorization.
-  Broadcasts carry only data permitted to each recipient and remain protected
-  when a subscriber's scope, tenant, or permissions differ.
+- Protected deployments must authorize subscription establishment and filter
+  every event delivery for the recipient's scope, tenant, and permissions.
+  `EventBroadcaster` and the public subscription resolvers do not perform
+  recipient checks automatically.
 - Request-scoped DI preserves the authenticated identity and tenant through
   resolver and subscription execution. GraphQL-over-gRPC preserves the same
   GraphQL and gRPC authorization, validation, isolation, and resource limits.

--- a/crates/reinhardt-graphql/SECURITY.md
+++ b/crates/reinhardt-graphql/SECURITY.md
@@ -1,0 +1,36 @@
+# reinhardt-graphql Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-graphql` executes schemas, resolvers, mutations, DataLoaders,
+subscriptions, broadcasts, and GraphQL-over-gRPC services. Documents,
+variables, aliases, fragments, operation names, subscription inputs, and
+resolver arguments are attacker-controlled.
+
+## Security Invariants
+
+- Depth, complexity, field-count, document-size, and parsing-work limits apply
+  before execution and account for aliases, fragments, repeated selections,
+  variables, and nested operations so they cannot evade the effective cost.
+- Every resolver and mutation enforces server-side authorization for its target
+  object, tenant, and operation. Validation, schema visibility, and client-side
+  query construction never replace that decision.
+- DataLoader and resolver caches are isolated by request, authenticated user,
+  and tenant. Cached values, keys, errors, and batching cannot disclose data
+  across those boundaries.
+- Subscription establishment and every event delivery enforce authorization.
+  Broadcasts carry only data permitted to each recipient and remain protected
+  when a subscriber's scope, tenant, or permissions differ.
+- Request-scoped DI preserves the authenticated identity and tenant through
+  resolver and subscription execution. GraphQL-over-gRPC preserves the same
+  GraphQL and gRPC authorization, validation, isolation, and resource limits.
+
+## Reportable Findings
+
+Report alias or fragment limit bypass, unauthorized resolver/mutation access,
+cross-user DataLoader leakage, unauthorized subscription or broadcast delivery,
+DI identity loss, or weaker GraphQL-over-gRPC enforcement.

--- a/crates/reinhardt-graphql/SECURITY.md
+++ b/crates/reinhardt-graphql/SECURITY.md
@@ -30,8 +30,11 @@ resolver arguments are attacker-controlled.
   `EventBroadcaster` and the public subscription resolvers do not perform
   recipient checks automatically.
 - Request-scoped DI preserves the authenticated identity and tenant through
-  resolver and subscription execution. GraphQL-over-gRPC preserves the same
-  GraphQL and gRPC authorization, validation, isolation, and resource limits.
+  resolver and subscription execution. Protected deployments must fork a
+  request context for each GraphQL request; the schema-level
+  `with_di_context` helper reuses one context and does not provide request
+  isolation automatically. GraphQL-over-gRPC preserves the same GraphQL and
+  gRPC authorization, validation, isolation, and resource limits.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-grpc/SECURITY.md
+++ b/crates/reinhardt-grpc/SECURITY.md
@@ -13,17 +13,21 @@ generated-service inputs are attacker-controlled.
 
 ## Security Invariants
 
-- Incoming message size, decoded size, nesting depth, and parsing work are
-  bounded before allocation or recursive decoding for every exposed service.
+- Applications must apply `MessageSizeLimiter` and `DepthLimitedDecoder` to
+  every exposed service so incoming message size, decoded size, nesting depth,
+  and parsing work are bounded before allocation or recursive decoding. These
+  helpers are opt-in and do not enforce limits automatically.
 - Service-wide validation applies to generated, unary, and streaming handlers;
   schema validation does not replace server-side authorization on the target
   resource and tenant.
 - Streams enforce bounded buffering, backpressure, cancellation, timeout, and
   concurrency behavior so a slow or malicious peer cannot consume unbounded
   memory, tasks, or connections.
-- Each call validates authentication metadata and constructs request-scoped DI
-  state. Caller-controlled metadata or injected values cannot establish a
-  different principal, tenant, or authorization context.
+- Protected applications must install an authentication interceptor that
+  validates metadata and constructs request-scoped DI state. The optional `di`
+  feature consumes application-provided context; it does not authenticate
+  metadata itself. Caller-controlled metadata or injected values cannot
+  establish a different principal, tenant, or authorization context.
 - Client-visible statuses and logs sanitize implementation, dependency, and
   internal error detail. GraphQL-over-gRPC preserves the authentication,
   authorization, validation, isolation, and limit guarantees of native gRPC

--- a/crates/reinhardt-grpc/SECURITY.md
+++ b/crates/reinhardt-grpc/SECURITY.md
@@ -31,10 +31,12 @@ generated-service inputs are attacker-controlled.
   feature consumes application-provided context; it does not authenticate
   metadata itself. Caller-controlled metadata or injected values cannot
   establish a different principal, tenant, or authorization context.
-- Client-visible statuses and logs sanitize implementation, dependency, and
-  internal error detail. GraphQL-over-gRPC preserves the authentication,
-  authorization, validation, isolation, and limit guarantees of native gRPC
-  and GraphQL operations.
+- Client-visible statuses sanitize implementation, dependency, and internal
+  error detail. Production `ErrorSanitizer` logs currently retain the original
+  message for connection, service, and internal errors, so those messages must
+  be treated as sensitive diagnostic data and protected or redacted separately.
+  GraphQL-over-gRPC preserves the authentication, authorization, validation,
+  isolation, and limit guarantees of native gRPC and GraphQL operations.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-grpc/SECURITY.md
+++ b/crates/reinhardt-grpc/SECURITY.md
@@ -16,9 +16,10 @@ generated-service inputs are attacker-controlled.
 - Applications must apply `MessageSizeLimiter` and `DepthLimitedDecoder` to
   every exposed service so incoming message size, decoded size, nesting depth,
   and parsing work are bounded before allocation or recursive decoding. These
-  helpers are opt-in and do not enforce limits automatically; the depth scan
-  must abort at the configured limit rather than recursively traversing an
-  attacker-controlled payload before reporting the violation.
+  helpers are opt-in and do not enforce limits automatically. The current
+  `DepthLimitedDecoder` recursively scans the complete wire payload before
+  comparing the measured depth with `max_depth`, so applications must impose a
+  separate wire-size/work bound or wrap it with a bounded pre-scan.
 - Service-wide validation applies to generated, unary, and streaming handlers;
   schema validation does not replace server-side authorization on the target
   resource and tenant.

--- a/crates/reinhardt-grpc/SECURITY.md
+++ b/crates/reinhardt-grpc/SECURITY.md
@@ -16,7 +16,9 @@ generated-service inputs are attacker-controlled.
 - Applications must apply `MessageSizeLimiter` and `DepthLimitedDecoder` to
   every exposed service so incoming message size, decoded size, nesting depth,
   and parsing work are bounded before allocation or recursive decoding. These
-  helpers are opt-in and do not enforce limits automatically.
+  helpers are opt-in and do not enforce limits automatically; the depth scan
+  must abort at the configured limit rather than recursively traversing an
+  attacker-controlled payload before reporting the violation.
 - Service-wide validation applies to generated, unary, and streaming handlers;
   schema validation does not replace server-side authorization on the target
   resource and tenant.

--- a/crates/reinhardt-grpc/SECURITY.md
+++ b/crates/reinhardt-grpc/SECURITY.md
@@ -1,0 +1,36 @@
+# reinhardt-grpc Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-grpc` provides protobuf decoding, service handlers, unary and
+streaming RPCs, metadata authentication, dependency injection, and
+GraphQL-over-gRPC adapters. Protobuf bytes, metadata, stream timing, and
+generated-service inputs are attacker-controlled.
+
+## Security Invariants
+
+- Incoming message size, decoded size, nesting depth, and parsing work are
+  bounded before allocation or recursive decoding for every exposed service.
+- Service-wide validation applies to generated, unary, and streaming handlers;
+  schema validation does not replace server-side authorization on the target
+  resource and tenant.
+- Streams enforce bounded buffering, backpressure, cancellation, timeout, and
+  concurrency behavior so a slow or malicious peer cannot consume unbounded
+  memory, tasks, or connections.
+- Each call validates authentication metadata and constructs request-scoped DI
+  state. Caller-controlled metadata or injected values cannot establish a
+  different principal, tenant, or authorization context.
+- Client-visible statuses and logs sanitize implementation, dependency, and
+  internal error detail. GraphQL-over-gRPC preserves the authentication,
+  authorization, validation, isolation, and limit guarantees of native gRPC
+  and GraphQL operations.
+
+## Reportable Findings
+
+Report pre-limit protobuf exhaustion, handler or stream validation gaps,
+authorization or DI identity confusion, unbounded streaming, sensitive error
+detail, or weaker GraphQL-over-gRPC protections.

--- a/crates/reinhardt-grpc/SECURITY.md
+++ b/crates/reinhardt-grpc/SECURITY.md
@@ -22,9 +22,10 @@ generated-service inputs are attacker-controlled.
 - Service-wide validation applies to generated, unary, and streaming handlers;
   schema validation does not replace server-side authorization on the target
   resource and tenant.
-- Streams enforce bounded buffering, backpressure, cancellation, timeout, and
-  concurrency behavior so a slow or malicious peer cannot consume unbounded
-  memory, tasks, or connections.
+- Protected applications must install bounded buffering, backpressure,
+  cancellation, timeout, and concurrency controls on every streaming handler.
+  `GrpcServerConfig` stores timeout and concurrency values but does not compose
+  the required layers or stream policy automatically.
 - Protected applications must install an authentication interceptor that
   validates metadata and constructs request-scoped DI state. The optional `di`
   feature consumes application-provided context; it does not authenticate

--- a/crates/reinhardt-grpc/SECURITY.md
+++ b/crates/reinhardt-grpc/SECURITY.md
@@ -37,7 +37,12 @@ generated-service inputs are attacker-controlled.
   message for connection, service, and internal errors, so those messages must
   be treated as sensitive diagnostic data and protected or redacted separately.
   GraphQL-over-gRPC preserves the authentication, authorization, validation,
-  isolation, and limit guarantees of native gRPC and GraphQL operations.
+  isolation, and limit guarantees of native gRPC and GraphQL operations only
+  when the application applies equivalent controls to both RPC methods. The
+  current `GraphQLGrpcService` forwards query and mutation documents directly
+  to schema execution without enforcing that the query RPC receives only query
+  operations or that the mutation RPC receives only mutation operations;
+  method-specific controls must therefore be enforced by the application.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-http/SECURITY.md
+++ b/crates/reinhardt-http/SECURITY.md
@@ -1,0 +1,51 @@
+# reinhardt-http Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-http` provides request and response primitives, request metadata,
+headers, cookies, uploads, chunked uploads, middleware execution, and typed
+request extensions. Request lines, bodies, headers, cookies, proxy metadata,
+paths, filenames, upload identifiers, and extension values supplied by callers
+are attacker-controlled until their relevant boundary validates them.
+
+## Security Invariants
+
+- Proxy-derived scheme, address, host, and `Forwarded` metadata are trusted
+  only when the immediate peer is a configured trusted proxy. Parsing rejects
+  ambiguous, malformed, duplicate, or otherwise conflicting Host and forwarded
+  values rather than selecting an attacker-preferred interpretation.
+- Request metadata, including method, URI, query, headers, cookies, remote
+  address, body, path parameters, and extensions, is untrusted input. It must
+  not establish identity, authorization, tenancy, origin, or routing safety
+  without the component that owns that decision validating it.
+- Upload filenames and destinations are confined to configured storage roots.
+  Decoding, normalization, traversal checks, symlink handling, and generated
+  storage names cannot permit writes or reads outside the authorized root.
+- Chunked and resumable uploads bind upload IDs, chunks, completion, and
+  cleanup to their creating principal, tenant, and configured storage scope.
+  One caller cannot read, append, finalize, replace, or delete another
+  caller's upload.
+- Request bodies, multipart parts, upload sizes, field counts, and buffering
+  work have configured limits enforced before unbounded allocation, decoding,
+  decompression, or disk consumption.
+- Header, cookie, and redirect construction rejects control characters, line
+  breaks, and invalid names or values so attacker-controlled data cannot inject
+  response headers, cookie attributes, or response splitting.
+- Request extensions are isolated to one request. Security-sensitive extension
+  values are populated only by their owning validated middleware and are not a
+  substitute for credential verification or authorization.
+- Errors exposed through HTTP responses are safe for the client and do not
+  disclose credentials, filesystem paths, proxy topology, internal headers,
+  parser details, or upload state belonging to another caller.
+
+## Reportable Findings
+
+Report trusted-proxy or Host confusion, request-metadata trust, upload
+confinement or ownership escape, pre-limit resource exhaustion, header or
+cookie injection, cross-request extension leakage, or sensitive HTTP error
+content. Explicit application-defined raw response bodies remain in scope when
+this crate's safe API turns attacker-controlled data into a privileged output.

--- a/crates/reinhardt-http/SECURITY.md
+++ b/crates/reinhardt-http/SECURITY.md
@@ -39,6 +39,10 @@ are attacker-controlled until their relevant boundary validates them.
 - Header, cookie, and redirect construction rejects control characters, line
   breaks, and invalid names or values so attacker-controlled data cannot inject
   response headers, cookie attributes, or response splitting.
+- `ResponseCookies::add` and `SharedResponseCookies::add` accept a complete raw
+  `Set-Cookie` string and do not validate cookie attributes or delimiters.
+  Callers must use a structured serializer or otherwise validate every cookie
+  name, value, and attribute before adding it.
 - Request extensions are isolated to one request. Security-sensitive extension
   values are populated only by their owning validated middleware and are not a
   substitute for credential verification or authorization.

--- a/crates/reinhardt-http/SECURITY.md
+++ b/crates/reinhardt-http/SECURITY.md
@@ -15,32 +15,37 @@ are attacker-controlled until their relevant boundary validates them.
 ## Security Invariants
 
 - Proxy-derived scheme, address, host, and `Forwarded` metadata are trusted
-  only when the immediate peer is a configured trusted proxy. Parsing rejects
-  ambiguous, malformed, duplicate, or otherwise conflicting Host and forwarded
-  values rather than selecting an attacker-preferred interpretation.
+  only when the immediate peer is a configured trusted proxy. Protected
+  applications must configure that proxy to replace and sanitize forwarding
+  headers; request helpers do not reject every duplicate or conflicting value
+  before selecting one.
 - Request metadata, including method, URI, query, headers, cookies, remote
   address, body, path parameters, and extensions, is untrusted input. It must
   not establish identity, authorization, tenancy, origin, or routing safety
   without the component that owns that decision validating it.
-- Upload filenames and destinations are confined to configured storage roots.
-  Decoding, normalization, traversal checks, symlink handling, and generated
-  storage names cannot permit writes or reads outside the authorized root.
+- Upload filenames and destinations must be confined to configured storage
+  roots by the owning application or storage layer. Callers must perform
+  decoding, normalization, traversal checks, symlink handling, and generated
+  storage-name validation before passing a destination to a file operation.
 - Applications exposing chunked or resumable uploads must bind upload IDs,
   chunks, completion, and cleanup to the creating principal, tenant, and
   configured storage scope. `ChunkedUploadManager` accepts a caller-supplied
   session ID and does not enforce this ownership context automatically.
-- Request bodies, multipart parts, upload sizes, field counts, and buffering
-  work have configured limits enforced before unbounded allocation, decoding,
-  decompression, or disk consumption.
+- Protected applications must install configured limits for request bodies,
+  multipart parts, upload sizes, field counts, and buffering work before
+  allocation, decoding, decompression, or disk consumption. The HTTP
+  primitives and `ChunkedUploadManager` do not enforce every cumulative limit
+  automatically.
 - Header, cookie, and redirect construction rejects control characters, line
   breaks, and invalid names or values so attacker-controlled data cannot inject
   response headers, cookie attributes, or response splitting.
 - Request extensions are isolated to one request. Security-sensitive extension
   values are populated only by their owning validated middleware and are not a
   substitute for credential verification or authorization.
-- Errors exposed through HTTP responses are safe for the client and do not
-  disclose credentials, filesystem paths, proxy topology, internal headers,
-  parser details, or upload state belonging to another caller.
+- Protected applications must map errors exposed through HTTP responses to
+  safe client details. Some serialization failures preserve parser or custom
+  deserializer text, so callers must retain the original detail only in
+  server-side logs and avoid returning it to clients.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-http/SECURITY.md
+++ b/crates/reinhardt-http/SECURITY.md
@@ -25,10 +25,10 @@ are attacker-controlled until their relevant boundary validates them.
 - Upload filenames and destinations are confined to configured storage roots.
   Decoding, normalization, traversal checks, symlink handling, and generated
   storage names cannot permit writes or reads outside the authorized root.
-- Chunked and resumable uploads bind upload IDs, chunks, completion, and
-  cleanup to their creating principal, tenant, and configured storage scope.
-  One caller cannot read, append, finalize, replace, or delete another
-  caller's upload.
+- Applications exposing chunked or resumable uploads must bind upload IDs,
+  chunks, completion, and cleanup to the creating principal, tenant, and
+  configured storage scope. `ChunkedUploadManager` accepts a caller-supplied
+  session ID and does not enforce this ownership context automatically.
 - Request bodies, multipart parts, upload sizes, field counts, and buffering
   work have configured limits enforced before unbounded allocation, decoding,
   decompression, or disk consumption.

--- a/crates/reinhardt-middleware/SECURITY.md
+++ b/crates/reinhardt-middleware/SECURITY.md
@@ -20,9 +20,12 @@ unless their owning control validates them.
   run before state-changing handlers. Reordering or short-circuiting cannot
   create a permissive path.
 - CSRF tokens are unpredictable, bounded in lifetime, and bound to the
-  authenticated session or equivalent request context. Origin and referer
-  checks use validated origins and do not accept cross-site state changes based
-  on a token, path exemption, or header supplied by an attacker.
+  authenticated session or equivalent request context. The middleware's
+  timeless HMAC format and configuration flags do not enforce token age by
+  themselves; protected deployments must wire timestamp validation or another
+  expiry mechanism. Origin and referer checks use validated origins and do not
+  accept cross-site state changes based on a token, path exemption, or header
+  supplied by an attacker.
 - Applications using credentialed CORS must configure explicit allowed origins,
   methods, and headers. `CorsConfig` does not reject `allow_origins = ["*"]`
   with credentials, so callers must not use that combination or treat its
@@ -49,9 +52,12 @@ unless their owning control validates them.
   network identity. Client-controlled headers, request IDs, and arbitrary
   forwarded addresses cannot select another caller's bucket or evade limits.
 - Compression bounds input and output resources, rejects compression abuse,
-  and preserves response integrity. Security headers, cookies, and other
-  required response controls apply equally to success, error, redirect,
-  short-circuit, cached, and compressed responses.
+  and preserves response integrity. `GZipMiddleware` and `BrotliMiddleware`
+  buffer and compress the complete response; applications must bound response
+  bodies or provide separate CPU, output-size, and timeout controls because
+  these middleware do not enforce those limits automatically. Security headers,
+  cookies, and other required response controls apply equally to success,
+  error, redirect, short-circuit, cached, and compressed responses.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-middleware/SECURITY.md
+++ b/crates/reinhardt-middleware/SECURITY.md
@@ -23,7 +23,11 @@ unless their owning control validates them.
   authenticated session or equivalent request context. The middleware's
   timeless HMAC format and configuration flags do not enforce token age by
   themselves; protected deployments must wire timestamp validation or another
-  expiry mechanism. Origin and referer checks use validated origins and do not
+  expiry mechanism. Deployments that disable referer checks or allow
+  cross-site cookie delivery must require a separately submitted token from a
+  header or request field and use the cookie only as the independent expected
+  value; `extract_token` can otherwise fall back to the automatically attached
+  CSRF cookie. Origin and referer checks use validated origins and do not
   accept cross-site state changes based on a token, path exemption, or header
   supplied by an attacker.
 - Applications using credentialed CORS must configure explicit allowed origins,

--- a/crates/reinhardt-middleware/SECURITY.md
+++ b/crates/reinhardt-middleware/SECURITY.md
@@ -39,10 +39,12 @@ unless their owning control validates them.
   before any consumer reads it. Absent, malformed, or failed authentication is
   denial or an explicit anonymous state, not stale, spoofed, or permissive
   authenticated state.
-- Caches that can affect authorization or responses key and invalidate by the
-  complete security context, including principal, tenant, authorization scope,
-  relevant credentials, and response variation. Shared cache entries cannot
-  disclose or authorize another caller's data.
+- Caches that can affect authorization or responses must key and invalidate by
+  the complete security context, including principal, tenant, authorization
+  scope, relevant credentials, and response variation. `CacheMiddleware` does
+  not infer that context; applications must skip private responses by default
+  or provide a principal/tenant-aware strategy instead of using `UrlOnly` for
+  authenticated endpoints.
 - Rate-limit identities derive from authenticated principals or validated
   network identity. Client-controlled headers, request IDs, and arbitrary
   forwarded addresses cannot select another caller's bucket or evade limits.

--- a/crates/reinhardt-middleware/SECURITY.md
+++ b/crates/reinhardt-middleware/SECURITY.md
@@ -42,6 +42,11 @@ unless their owning control validates them.
   one validated request interpretation. Remote-user headers are accepted only
   from configured trusted immediate proxies, never merely because a forwarded
   header claims a trusted source.
+- `LoginRequiredMiddleware` exempts the configured login URL using a prefix
+  check when the URL has no trailing slash. Applications must configure a
+  segment-delimited login URL, normally with a trailing slash, or otherwise
+  ensure that sibling paths such as `/login-admin` cannot be treated as the
+  login endpoint.
 - Sessions, cookies, and session stores isolate principals, tenants, and
   requests. A session identifier or cached session state cannot be confused,
   reused, or exposed across callers, and failure paths do not retain a prior

--- a/crates/reinhardt-middleware/SECURITY.md
+++ b/crates/reinhardt-middleware/SECURITY.md
@@ -27,9 +27,13 @@ unless their owning control validates them.
   cross-site cookie delivery must require a separately submitted token from a
   header or request field and use the cookie only as the independent expected
   value; `extract_token` can otherwise fall back to the automatically attached
-  CSRF cookie. Origin and referer checks use validated origins and do not
-  accept cross-site state changes based on a token, path exemption, or header
-  supplied by an attacker.
+  CSRF cookie. `CsrfMiddleware` derives its HMAC input from the first String
+  extension it interprets as a session identifier; an authentication layer
+  that stores a predictable bare user ID there makes the token predictable.
+  Protected deployments must provide a typed, unpredictable per-session value
+  or treat this token only as defense in depth. Origin and referer checks use
+  validated origins and do not accept cross-site state changes based on a
+  token, path exemption, or header supplied by an attacker.
 - Applications using credentialed CORS must configure explicit allowed origins,
   methods, and headers. `CorsConfig` does not reject `allow_origins = ["*"]`
   with credentials, so callers must not use that combination or treat its

--- a/crates/reinhardt-middleware/SECURITY.md
+++ b/crates/reinhardt-middleware/SECURITY.md
@@ -1,0 +1,58 @@
+# reinhardt-middleware Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-middleware` composes authentication, session, CSRF, origin, host,
+CORS, remote-user, rate-limit, compression, cache, redirect, and response
+header controls. Requests, proxy headers, cookies, origins, credentials,
+request IDs, cache selectors, and compression inputs are attacker-controlled
+unless their owning control validates them.
+
+## Security Invariants
+
+- Middleware ordering preserves security dependencies: trusted proxy and host
+  interpretation precede controls that use them; authentication and session
+  population precede authorization; and CSRF, origin, and authorization checks
+  run before state-changing handlers. Reordering or short-circuiting cannot
+  create a permissive path.
+- CSRF tokens are unpredictable, bounded in lifetime, and bound to the
+  authenticated session or equivalent request context. Origin and referer
+  checks use validated origins and do not accept cross-site state changes based
+  on a token, path exemption, or header supplied by an attacker.
+- Credentialed CORS uses explicit allowed origins, methods, and headers; it
+  never combines credentials with a wildcard origin and does not reflect an
+  unvalidated `Origin` header.
+- Host validation, HTTPS redirects, origin guards, and remote-user identity use
+  one validated request interpretation. Remote-user headers are accepted only
+  from configured trusted immediate proxies, never merely because a forwarded
+  header claims a trusted source.
+- Sessions, cookies, and session stores isolate principals, tenants, and
+  requests. A session identifier or cached session state cannot be confused,
+  reused, or exposed across callers, and failure paths do not retain a prior
+  caller's authentication state.
+- Authentication middleware establishes the authoritative request auth state
+  before any consumer reads it. Absent, malformed, or failed authentication is
+  denial or an explicit anonymous state, not stale, spoofed, or permissive
+  authenticated state.
+- Caches that can affect authorization or responses key and invalidate by the
+  complete security context, including principal, tenant, authorization scope,
+  relevant credentials, and response variation. Shared cache entries cannot
+  disclose or authorize another caller's data.
+- Rate-limit identities derive from authenticated principals or validated
+  network identity. Client-controlled headers, request IDs, and arbitrary
+  forwarded addresses cannot select another caller's bucket or evade limits.
+- Compression bounds input and output resources, rejects compression abuse,
+  and preserves response integrity. Security headers, cookies, and other
+  required response controls apply equally to success, error, redirect,
+  short-circuit, cached, and compressed responses.
+
+## Reportable Findings
+
+Report a security-control ordering bypass, context-confused CSRF or session,
+credentialed CORS overreach, spoofed proxy identity, auth-state timing error,
+security-context cache leakage, spoofable throttling identity, compression
+resource exhaustion, or missing security headers on alternate responses.

--- a/crates/reinhardt-middleware/SECURITY.md
+++ b/crates/reinhardt-middleware/SECURITY.md
@@ -34,6 +34,10 @@ unless their owning control validates them.
   or treat this token only as defense in depth. Origin and referer checks use
   validated origins and do not accept cross-site state changes based on a
   token, path exemption, or header supplied by an attacker.
+- CSRF exemptions for an exact path or its segment-delimited subtree return
+  before origin, referer, and token validation. Such exemptions are complete
+  CSRF-boundary bypasses and require separate authentication and origin or
+  equivalent request-integrity controls for every exempt handler.
 - Applications using credentialed CORS must configure explicit allowed origins,
   methods, and headers. `CorsConfig` does not reject `allow_origins = ["*"]`
   with credentials, so callers must not use that combination or treat its

--- a/crates/reinhardt-middleware/SECURITY.md
+++ b/crates/reinhardt-middleware/SECURITY.md
@@ -33,7 +33,8 @@ unless their owning control validates them.
   Protected deployments must provide a typed, unpredictable per-session value
   or treat this token only as defense in depth. Origin and referer checks use
   validated origins and do not accept cross-site state changes based on a
-  token, path exemption, or header supplied by an attacker.
+  token or header supplied by an attacker; exempt paths bypass those checks as
+  documented below.
 - CSRF exemptions for an exact path or its segment-delimited subtree return
   before origin, referer, and token validation. Such exemptions are complete
   CSRF-boundary bypasses and require separate authentication and origin or

--- a/crates/reinhardt-middleware/SECURITY.md
+++ b/crates/reinhardt-middleware/SECURITY.md
@@ -23,9 +23,10 @@ unless their owning control validates them.
   authenticated session or equivalent request context. Origin and referer
   checks use validated origins and do not accept cross-site state changes based
   on a token, path exemption, or header supplied by an attacker.
-- Credentialed CORS uses explicit allowed origins, methods, and headers; it
-  never combines credentials with a wildcard origin and does not reflect an
-  unvalidated `Origin` header.
+- Applications using credentialed CORS must configure explicit allowed origins,
+  methods, and headers. `CorsConfig` does not reject `allow_origins = ["*"]`
+  with credentials, so callers must not use that combination or treat its
+  reflected origin as protected.
 - Host validation, HTTPS redirects, origin guards, and remote-user identity use
   one validated request interpretation. Remote-user headers are accepted only
   from configured trusted immediate proxies, never merely because a forwarded

--- a/crates/reinhardt-pages/SECURITY.md
+++ b/crates/reinhardt-pages/SECURITY.md
@@ -15,9 +15,10 @@ state, route parameters, serialized values, and hydration data are untrusted.
 - Text and attribute output is escaped by default. Raw HTML and unsafe
   portal/DOM interfaces remain explicit trust boundaries; safe APIs must not
   reach them with attacker-controlled content.
-- URL-bearing attributes validate their context and permitted scheme before
-  rendering. SSR and hydration preserve equivalent escaping, URL handling, and
-  DOM semantics.
+- Applications rendering attacker-controlled URL-bearing attributes must
+  validate their context and permitted scheme before rendering; escaping alone
+  does not validate a URL scheme. SSR and hydration preserve equivalent
+  escaping, URL handling, and DOM semantics.
 - Browser authentication and authorization state is non-authoritative. Server
   functions and server routes authenticate and authorize every protected
   operation, with target and tenant context, independently of client checks.

--- a/crates/reinhardt-pages/SECURITY.md
+++ b/crates/reinhardt-pages/SECURITY.md
@@ -1,0 +1,35 @@
+# reinhardt-pages Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-pages` renders SSR and hydrated WASM pages, server functions,
+browser routes, serialized state, and static resources. Browser input, DOM
+state, route parameters, serialized values, and hydration data are untrusted.
+
+## Security Invariants
+
+- Text and attribute output is escaped by default. Raw HTML and unsafe
+  portal/DOM interfaces remain explicit trust boundaries; safe APIs must not
+  reach them with attacker-controlled content.
+- URL-bearing attributes validate their context and permitted scheme before
+  rendering. SSR and hydration preserve equivalent escaping, URL handling, and
+  DOM semantics.
+- Browser authentication and authorization state is non-authoritative. Server
+  functions and server routes authenticate and authorize every protected
+  operation, with target and tenant context, independently of client checks.
+- Cookie-authenticated server-function mutations preserve CSRF protections.
+  Serialization to the browser excludes secrets, credentials, private server
+  state, and data unauthorized for the current user.
+- Static resources, route-derived paths, and server-rendered assets remain
+  confined to configured roots; route rendering cannot expose arbitrary files.
+
+## Reportable Findings
+
+Report safe-API XSS or unsafe URL construction, SSR/hydration protection
+differences, client-authoritative access, CSRF or server-route authorization
+bypass, secret-bearing serialization, static-resource escape, or implicit use
+of raw HTML or unsafe DOM APIs.

--- a/crates/reinhardt-pages/SECURITY.md
+++ b/crates/reinhardt-pages/SECURITY.md
@@ -22,9 +22,11 @@ state, route parameters, serialized values, and hydration data are untrusted.
 - Browser authentication and authorization state is non-authoritative. Server
   functions and server routes authenticate and authorize every protected
   operation, with target and tenant context, independently of client checks.
-- Cookie-authenticated server-function mutations preserve CSRF protections.
-  Serialization to the browser excludes secrets, credentials, private server
-  state, and data unauthorized for the current user.
+- Cookie-authenticated server-function mutations must verify CSRF tokens in the
+  generated server path or surrounding middleware. The generated client adds a
+  token header, but direct requests to `ServerFnEndpoint` are not verified
+  automatically. Serialization to the browser excludes secrets, credentials,
+  private server state, and data unauthorized for the current user.
 - Static resources, route-derived paths, and server-rendered assets remain
   confined to configured roots; route rendering cannot expose arbitrary files.
 

--- a/crates/reinhardt-pages/SECURITY.md
+++ b/crates/reinhardt-pages/SECURITY.md
@@ -29,8 +29,16 @@ state, route parameters, serialized values, and hydration data are untrusted.
   private server state, and data unauthorized for the current user. `SsrState`
   is a client-visible serialization boundary rather than a secret store;
   callers must place only browser-safe state in it.
+- `ServerFnEndpoint` logs server-function error bodies and returns those bodies
+  to the client. `ServerFnError::Server` and `ServerFnError::Application`
+  messages must therefore be sanitized before they cross this boundary; the
+  endpoint does not redact credentials, private endpoints, or implementation
+  details automatically.
 - Static resources, route-derived paths, and server-rendered assets remain
   confined to configured roots; route rendering cannot expose arbitrary files.
+  `TemplateStaticConfig` and the static resolver concatenate caller-supplied
+  asset names after trimming leading slashes, but do not reject `.` or `..`
+  path segments. Callers must validate asset names before resolving them.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-pages/SECURITY.md
+++ b/crates/reinhardt-pages/SECURITY.md
@@ -26,7 +26,9 @@ state, route parameters, serialized values, and hydration data are untrusted.
   generated server path or surrounding middleware. The generated client adds a
   token header, but direct requests to `ServerFnEndpoint` are not verified
   automatically. Serialization to the browser excludes secrets, credentials,
-  private server state, and data unauthorized for the current user.
+  private server state, and data unauthorized for the current user. `SsrState`
+  is a client-visible serialization boundary rather than a secret store;
+  callers must place only browser-safe state in it.
 - Static resources, route-derived paths, and server-rendered assets remain
   confined to configured roots; route rendering cannot expose arbitrary files.
 

--- a/crates/reinhardt-query/SECURITY.md
+++ b/crates/reinhardt-query/SECURITY.md
@@ -1,0 +1,43 @@
+# reinhardt-query Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-query` constructs DML, DDL, and DCL for PostgreSQL, MySQL, SQLite,
+and CockroachDB. Generated SQL, bound values, identifiers, role and privilege
+statements, and function or procedure definitions are security-sensitive
+outputs. SQL values and any runtime-supplied query structure are untrusted.
+
+## Security Invariants
+
+- Safe DML APIs bind values as backend-native parameters; they never interpolate
+  values into SQL text.
+- Builders quote every identifier with the selected backend's correct rules.
+  Runtime identifiers are accepted only through a constrained, validated
+  identifier representation; callers cannot supply arbitrary SQL fragments.
+- Dynamic limits, offsets, orderings, directions, and columns use bound values
+  where supported or a finite validated allowlist. They must not become raw SQL.
+- DDL uses the same identifier-validation and backend-correct quoting guarantees
+  as DML for databases, schemas, tables, columns, indexes, constraints, views,
+  sequences, types, and related objects.
+- GRANT, REVOKE, role, and user statements validate and quote grantees,
+  principals, roles, objects, and privilege names. Privileges and options are
+  selected from explicit backend-supported forms, not concatenated input.
+- Function and procedure bodies are explicit raw-code boundaries. They must not
+  be assembled from untrusted fragments or silently treated as parameterized SQL.
+- Equivalent safe APIs preserve their injection, identifier, and privilege
+  guarantees across every supported backend; an unsupported safe construction
+  fails explicitly rather than falling back to unsafe syntax.
+- Placeholder numbering and bound-value order remain exact through nested
+  expressions, CTEs, unions, joins, and subqueries.
+
+## Reportable Findings
+
+Report injection, identifier or privilege escalation, altered placeholder/value
+binding, or a backend-specific safe-API path that permits untrusted query
+structure. Explicit raw SQL and explicit function or procedure bodies are out
+of scope unless a supposedly safe API reaches them with attacker-controlled
+input.

--- a/crates/reinhardt-query/SECURITY.md
+++ b/crates/reinhardt-query/SECURITY.md
@@ -27,8 +27,10 @@ outputs. SQL values and any runtime-supplied query structure are untrusted.
   principals, roles, objects, privilege names, and backend-specific options.
   Callers must constrain or escape MySQL account option text; the safe builder
   does not make every option field safe for arbitrary untrusted input.
-- Function and procedure bodies are explicit raw-code boundaries. They must not
-  be assembled from untrusted fragments or silently treated as parameterized SQL.
+- Function and procedure bodies, signature parameter types, and return types are
+  explicit raw-code boundaries. They must not be assembled from untrusted
+  fragments or silently treated as parameterized SQL; callers must validate
+  signature types or treat them as trusted raw SQL.
 - Equivalent safe APIs preserve their injection, identifier, and privilege
   guarantees across every supported backend; an unsupported safe construction
   fails explicitly rather than falling back to unsafe syntax.

--- a/crates/reinhardt-query/SECURITY.md
+++ b/crates/reinhardt-query/SECURITY.md
@@ -23,9 +23,10 @@ outputs. SQL values and any runtime-supplied query structure are untrusted.
 - DDL uses the same identifier-validation and backend-correct quoting guarantees
   as DML for databases, schemas, tables, columns, indexes, constraints, views,
   sequences, types, and related objects.
-- GRANT, REVOKE, role, and user statements validate and quote grantees,
-  principals, roles, objects, and privilege names. Privileges and options are
-  selected from explicit backend-supported forms, not concatenated input.
+- GRANT, REVOKE, role, and user statements must validate and quote grantees,
+  principals, roles, objects, privilege names, and backend-specific options.
+  Callers must constrain or escape MySQL account option text; the safe builder
+  does not make every option field safe for arbitrary untrusted input.
 - Function and procedure bodies are explicit raw-code boundaries. They must not
   be assembled from untrusted fragments or silently treated as parameterized SQL.
 - Equivalent safe APIs preserve their injection, identifier, and privilege

--- a/crates/reinhardt-query/SECURITY.md
+++ b/crates/reinhardt-query/SECURITY.md
@@ -40,6 +40,11 @@ outputs. SQL values and any runtime-supplied query structure are untrusted.
   `Range` subtype and function names, and `ALTER TYPE` constraint/default text
   are emitted as supplied. Callers must validate these values or restrict them
   to trusted schema metadata.
+- CockroachDB zone configuration fragments are also explicit raw-code
+  boundaries: `ZoneConfig::add_constraint` and `add_lease_preference` accept
+  arbitrary strings that are emitted inside single-quoted SQL literals.
+  Callers must validate or escape these values before building an
+  `ALTER DATABASE ... CONFIGURE ZONE` statement.
 - Equivalent safe APIs preserve their injection, identifier, and privilege
   guarantees across every supported backend; an unsupported safe construction
   fails explicitly rather than falling back to unsafe syntax.

--- a/crates/reinhardt-query/SECURITY.md
+++ b/crates/reinhardt-query/SECURITY.md
@@ -27,6 +27,10 @@ outputs. SQL values and any runtime-supplied query structure are untrusted.
   principals, roles, objects, privilege names, and backend-specific options.
   Callers must constrain or escape MySQL account option text; the safe builder
   does not make every option field safe for arbitrary untrusted input.
+- PostgreSQL role-membership statements emit `RoleSpecification::RoleName`
+  values as supplied rather than identifier-quoting them. Callers must
+  validate role names and any MySQL `user@host` form before constructing
+  `GRANT` or `REVOKE` statements.
 - Function and procedure bodies, signature parameter types, and return types are
   explicit raw-code boundaries. They must not be assembled from untrusted
   fragments or silently treated as parameterized SQL; callers must validate

--- a/crates/reinhardt-query/SECURITY.md
+++ b/crates/reinhardt-query/SECURITY.md
@@ -31,6 +31,11 @@ outputs. SQL values and any runtime-supplied query structure are untrusted.
   explicit raw-code boundaries. They must not be assembled from untrusted
   fragments or silently treated as parameterized SQL; callers must validate
   signature types or treat them as trusted raw SQL.
+- PostgreSQL custom-type fragments are also explicit raw-code boundaries:
+  `TypeKind::Composite` attribute types, `Domain` base/default/constraint text,
+  `Range` subtype and function names, and `ALTER TYPE` constraint/default text
+  are emitted as supplied. Callers must validate these values or restrict them
+  to trusted schema metadata.
 - Equivalent safe APIs preserve their injection, identifier, and privilege
   guarantees across every supported backend; an unsupported safe construction
   fails explicitly rather than falling back to unsafe syntax.

--- a/crates/reinhardt-rest/SECURITY.md
+++ b/crates/reinhardt-rest/SECURITY.md
@@ -15,10 +15,11 @@ validate them.
 
 ## Security Invariants
 
-- Parser and decompression limits apply before buffering, deserialization, or
-  content negotiation performs unbounded work. Body size, nesting, fields,
-  multipart parts, decoded output, and parser work remain bounded for every
-  supported media type.
+- Applications must install body and decompression limits before buffering,
+  deserialization, or content negotiation performs unbounded work. The parser
+  APIs receive buffered bodies and do not enforce a pre-buffering limit on
+  every entry point; body size, nesting, fields, multipart parts, decoded
+  output, and parser work must remain bounded for every supported media type.
 - Validation establishes only data shape and business rules; authorization is a
   separate server-side decision made before every read, create, update, delete,
   bulk operation, relation change, or action on the target resource and tenant.

--- a/crates/reinhardt-rest/SECURITY.md
+++ b/crates/reinhardt-rest/SECURITY.md
@@ -31,7 +31,10 @@ validate them.
 - Filters, search, lookup expressions, field selectors, and ordering use
   finite validated allowlists and bounded values. They preserve parameterized
   query construction and cannot disclose protected fields or become executable
-  query structure.
+  query structure. The `BatchValidator` uniqueness fast path currently builds
+  a raw `UNION ALL` statement from table, field, and check values; callers must
+  restrict that path to trusted identifiers and non-attacker-controlled values,
+  or disable it until those checks use bound query values.
 - Pagination and cursor state remain bound to the authorized query, tenant,
   filter scope, ordering, and API version. Collection, cursor, and version
   variants cannot enumerate objects or traverse beyond the caller's permitted

--- a/crates/reinhardt-rest/SECURITY.md
+++ b/crates/reinhardt-rest/SECURITY.md
@@ -1,0 +1,57 @@
+# reinhardt-rest Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-rest` provides REST parsers, serializers, authentication adapters,
+filters, search, ordering, pagination, versioning, throttling, browsable API
+rendering, and schema generation. Bodies, media types, parser selections,
+serialized fields, query parameters, cursor tokens, versions, credentials, and
+schema metadata are attacker-controlled until their corresponding controls
+validate them.
+
+## Security Invariants
+
+- Parser and decompression limits apply before buffering, deserialization, or
+  content negotiation performs unbounded work. Body size, nesting, fields,
+  multipart parts, decoded output, and parser work remain bounded for every
+  supported media type.
+- Validation establishes only data shape and business rules; authorization is a
+  separate server-side decision made before every read, create, update, delete,
+  bulk operation, relation change, or action on the target resource and tenant.
+- Serializers use explicit writable and readable fields. Client input cannot
+  mass-assign identifiers, ownership, tenant, role, permission, read-only,
+  computed, or otherwise protected fields, including through nested relations
+  or alternate serializer forms.
+- Filters, search, lookup expressions, field selectors, and ordering use
+  finite validated allowlists and bounded values. They preserve parameterized
+  query construction and cannot disclose protected fields or become executable
+  query structure.
+- Pagination and cursor state remain bound to the authorized query, tenant,
+  filter scope, ordering, and API version. Collection, cursor, and version
+  variants cannot enumerate objects or traverse beyond the caller's permitted
+  result set.
+- API versions, parser choices, and content-negotiation variants enforce the
+  same authentication, authorization, validation, isolation, and error
+  protections for an equivalent operation; an alternate representation cannot
+  be a weaker endpoint.
+- Throttling identifies callers through authenticated principal or validated
+  network identity and cannot be partitioned, bypassed, or targeted through
+  client-supplied identity headers, credentials, or route metadata.
+- Browsable API pages and form values use context-appropriate escaping and do
+  not render untrusted request, response, schema, or error data as executable
+  HTML, attributes, URLs, or scripts.
+- Generated schemas, OpenAPI documents, and interactive documentation exclude
+  credentials, tokens, private endpoints, internal-only fields, authorization
+  internals, and other secrets. Documentation exposure does not grant access
+  beyond the corresponding API operation.
+
+## Reportable Findings
+
+Report pre-parser resource exhaustion, validation-as-authorization, mass
+assignment, unsafe filter/search/ordering structure, pagination or versioning
+authorization bypass, spoofable throttling, browsable-output injection,
+secret-bearing schemas, or weaker parser and negotiation variants.

--- a/crates/reinhardt-rest/SECURITY.md
+++ b/crates/reinhardt-rest/SECURITY.md
@@ -23,10 +23,11 @@ validate them.
 - Validation establishes only data shape and business rules; authorization is a
   separate server-side decision made before every read, create, update, delete,
   bulk operation, relation change, or action on the target resource and tenant.
-- Serializers use explicit writable and readable fields. Client input cannot
-  mass-assign identifiers, ownership, tenant, role, permission, read-only,
-  computed, or otherwise protected fields, including through nested relations
-  or alternate serializer forms.
+- Protected endpoints must configure explicit writable and readable fields
+  before deserialization. The default and hyperlinked serializers do not
+  automatically prevent client input from mass-assigning identifiers,
+  ownership, tenant, role, permission, read-only, computed, or otherwise
+  protected fields, including through nested relations.
 - Filters, search, lookup expressions, field selectors, and ordering use
   finite validated allowlists and bounded values. They preserve parameterized
   query construction and cannot disclose protected fields or become executable

--- a/crates/reinhardt-rest/SECURITY.md
+++ b/crates/reinhardt-rest/SECURITY.md
@@ -35,7 +35,9 @@ validate them.
 - Pagination and cursor state remain bound to the authorized query, tenant,
   filter scope, ordering, and API version. Collection, cursor, and version
   variants cannot enumerate objects or traverse beyond the caller's permitted
-  result set.
+  result set. `Base64CursorEncoder` signs only its position and timestamp, and
+  the database `Cursor` is unsigned encoded JSON; callers must bind cursor state
+  to the authorized query scope externally because these encoders do not do so.
 - API versions, parser choices, and content-negotiation variants enforce the
   same authentication, authorization, validation, isolation, and error
   protections for an equivalent operation; an alternate representation cannot

--- a/crates/reinhardt-storages/SECURITY.md
+++ b/crates/reinhardt-storages/SECURITY.md
@@ -23,7 +23,10 @@ validated for the selected backend and configured storage scope.
   prefixes, and normalization forms cannot cause an object to be authorized as
   one key and operated on as another.
 - Signed URLs bind a single authorized operation and canonical object to a
-  bounded expiry. They cannot be replayed for another object, operation,
+  bounded expiry. Protected applications must validate or cap caller-selected
+  expiries before invoking provider URL helpers; `AzureStorage::url` does not
+  impose every application maximum and an out-of-range duration can overflow
+  timestamp arithmetic. They cannot be replayed for another object, operation,
   bucket, account, or unbounded lifetime.
 - Signing uses an unambiguous canonical request that includes the selected
   method, object, host, path, relevant query parameters, expiry, and signed

--- a/crates/reinhardt-storages/SECURITY.md
+++ b/crates/reinhardt-storages/SECURITY.md
@@ -13,10 +13,11 @@ validated for the selected backend and configured storage scope.
 
 ## Security Invariants
 
-- Local storage confines every read, write, delete, listing, and URL operation
-  to its configured root after decoding, separator normalization, and canonical
-  resolution. Traversal, absolute paths, platform-specific separators, encoded
-  path forms, and symlink targets cannot escape that root.
+- Local storage must confine every read, write, delete, listing, and URL
+  operation to its configured root after decoding, separator normalization,
+  and canonical resolution. Before each write, callers must reject a final
+  component symlink or use no-follow/root-relative semantics; parent-directory
+  validation alone does not protect an existing destination symlink.
 - Provider object names use one provider-safe canonical representation before
   authorization, storage, and comparison. Ambiguous encodings, separators,
   prefixes, and normalization forms cannot cause an object to be authorized as

--- a/crates/reinhardt-storages/SECURITY.md
+++ b/crates/reinhardt-storages/SECURITY.md
@@ -35,8 +35,12 @@ validated for the selected backend and configured storage scope.
   bounded expiry. Protected applications must validate or cap caller-selected
   expiries before invoking provider URL helpers; `AzureStorage::url` does not
   impose every application maximum and an out-of-range duration can overflow
-  timestamp arithmetic. They cannot be replayed for another object, operation,
-  bucket, account, or unbounded lifetime.
+  timestamp arithmetic. `GcsStorage::url` in custom-endpoint mode does not use
+  the signer; its `X-Goog-Expires` query parameter is not an access-control
+  mechanism. Treat that mode as an emulator/development boundary, or reject
+  signed-URL requests there until the endpoint provides compatible signing.
+  They cannot be replayed for another object, operation, bucket, account, or
+  unbounded lifetime.
 - Signing uses an unambiguous canonical request that includes the selected
   method, object, host, path, relevant query parameters, expiry, and signed
   headers. Parsing or serialization differences cannot alter a signed request.

--- a/crates/reinhardt-storages/SECURITY.md
+++ b/crates/reinhardt-storages/SECURITY.md
@@ -1,0 +1,40 @@
+# reinhardt-storages Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-storages` maps application object names to local files and cloud
+providers, creates signed URLs, and handles provider responses. Object names,
+paths, metadata, redirect locations, and provider errors are untrusted until
+validated for the selected backend and configured storage scope.
+
+## Security Invariants
+
+- Local storage confines every read, write, delete, listing, and URL operation
+  to its configured root after decoding, separator normalization, and canonical
+  resolution. Traversal, absolute paths, platform-specific separators, encoded
+  path forms, and symlink targets cannot escape that root.
+- Provider object names use one provider-safe canonical representation before
+  authorization, storage, and comparison. Ambiguous encodings, separators,
+  prefixes, and normalization forms cannot cause an object to be authorized as
+  one key and operated on as another.
+- Signed URLs bind a single authorized operation and canonical object to a
+  bounded expiry. They cannot be replayed for another object, operation,
+  bucket, account, or unbounded lifetime.
+- Signing uses an unambiguous canonical request that includes the selected
+  method, object, host, path, relevant query parameters, expiry, and signed
+  headers. Parsing or serialization differences cannot alter a signed request.
+- Provider credentials, signed URL signatures, tokens, and private endpoints
+  are redacted from errors, logs, `Debug` output, and telemetry.
+- Redirects and provider-supplied locations use only validated configured hosts
+  and safe schemes. A redirect cannot send a caller, signed request, or
+  credential-bearing client to an attacker-controlled host.
+
+## Reportable Findings
+
+Report local-root escape, provider-key canonicalization confusion, reusable or
+overbroad signed URLs, ambiguous signing, credential disclosure, or redirect
+host bypass.

--- a/crates/reinhardt-storages/SECURITY.md
+++ b/crates/reinhardt-storages/SECURITY.md
@@ -36,8 +36,10 @@ validated for the selected backend and configured storage scope.
   provider integration. Transport errors may include a request URL, so
   callers must sanitize provider errors before exposing or logging them.
 - Redirects and provider-supplied locations use only validated configured hosts
-  and safe schemes. A redirect cannot send a caller, signed request, or
-  credential-bearing client to an attacker-controlled host.
+  and safe schemes. The Azure and GCS integrations currently use default
+  clients without a redirect policy or per-hop host validation, so callers must
+  disable redirects or validate every `Location` against the configured
+  provider origin before sending credentials or object content.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-storages/SECURITY.md
+++ b/crates/reinhardt-storages/SECURITY.md
@@ -16,13 +16,17 @@ validated for the selected backend and configured storage scope.
 - Local storage must confine every read, write, delete, listing, and URL
   operation to its configured root after decoding, separator normalization,
   and canonical resolution. Before each write, callers must reject a final
-  component symlink or use no-follow/root-relative semantics; parent-directory
-  validation alone does not protect an existing destination symlink. This
-  guarantee also assumes the root and its entries are not modified by an
-  untrusted concurrent process: `LocalStorage::open` checks the canonical path
-  and then reads by pathname, without an atomic no-follow open. Shared hostile
-  filesystems require root-relative/no-follow primitives or an equivalent
-  trusted-filesystem boundary.
+  component symlink or use no-follow/root-relative semantics, and validate
+  every existing parent before creating missing directories; `LocalStorage::save`
+  currently calls `create_dir_all` before canonicalizing the parent, so an
+  untrusted parent symlink can create directories outside the configured root
+  even when the later file check rejects the write. Parent-directory validation
+  alone does not protect an existing destination symlink. This guarantee also
+  assumes the root and its entries are not modified by an untrusted concurrent
+  process: `LocalStorage::open` checks the canonical path and then reads by
+  pathname, without an atomic no-follow open. Shared hostile filesystems require
+  root-relative/no-follow primitives or an equivalent trusted-filesystem
+  boundary.
 - Provider object names use one provider-safe canonical representation before
   authorization, storage, and comparison. Ambiguous encodings, separators,
   prefixes, and normalization forms cannot cause an object to be authorized as

--- a/crates/reinhardt-storages/SECURITY.md
+++ b/crates/reinhardt-storages/SECURITY.md
@@ -17,7 +17,12 @@ validated for the selected backend and configured storage scope.
   operation to its configured root after decoding, separator normalization,
   and canonical resolution. Before each write, callers must reject a final
   component symlink or use no-follow/root-relative semantics; parent-directory
-  validation alone does not protect an existing destination symlink.
+  validation alone does not protect an existing destination symlink. This
+  guarantee also assumes the root and its entries are not modified by an
+  untrusted concurrent process: `LocalStorage::open` checks the canonical path
+  and then reads by pathname, without an atomic no-follow open. Shared hostile
+  filesystems require root-relative/no-follow primitives or an equivalent
+  trusted-filesystem boundary.
 - Provider object names use one provider-safe canonical representation before
   authorization, storage, and comparison. Ambiguous encodings, separators,
   prefixes, and normalization forms cannot cause an object to be authorized as

--- a/crates/reinhardt-storages/SECURITY.md
+++ b/crates/reinhardt-storages/SECURITY.md
@@ -29,7 +29,9 @@ validated for the selected backend and configured storage scope.
   method, object, host, path, relevant query parameters, expiry, and signed
   headers. Parsing or serialization differences cannot alter a signed request.
 - Provider credentials, signed URL signatures, tokens, and private endpoints
-  are redacted from errors, logs, `Debug` output, and telemetry.
+  must be redacted from errors, logs, `Debug` output, and telemetry by the
+  provider integration. Transport errors may include a request URL, so
+  callers must sanitize provider errors before exposing or logging them.
 - Redirects and provider-supplied locations use only validated configured hosts
   and safe schemes. A redirect cannot send a caller, signed request, or
   credential-bearing client to an attacker-controlled host.

--- a/crates/reinhardt-urls/SECURITY.md
+++ b/crates/reinhardt-urls/SECURITY.md
@@ -21,9 +21,10 @@ parameters, route registrations, and client routing state cross its boundary.
   into a different route, escape a mounted prefix, or bypass authorization and
   middleware attached to the intended route.
 - Route registration and dispatch preserve deterministic, non-bypassable
-  precedence. Conflicting routes fail explicitly, and fallback, wildcard, or
-  less-specific routes cannot shadow a security-sensitive route after
-  normalization.
+  precedence. Protected applications must successfully validate routes before
+  serving; normal dispatch does not automatically surface every route
+  compilation conflict. Fallback, wildcard, or less-specific routes cannot
+  shadow a security-sensitive route after normalization.
 - Global, router, group, and route middleware compose cumulatively in their
   configured order. Adding a route or group cannot discard inherited
   authentication, authorization, CSRF, origin, host, or other security

--- a/crates/reinhardt-urls/SECURITY.md
+++ b/crates/reinhardt-urls/SECURITY.md
@@ -31,10 +31,11 @@ parameters, route registrations, and client routing state cross its boundary.
 - Captured path and query parameters are attacker-controlled. Typed conversion
   and validation do not establish object ownership, tenant membership, or
   authorization; handlers enforce those checks on the resolved resource.
-- Reverse routing encodes parameter values as path data and cannot generate
-  traversal, delimiter, scheme, or authority injection. Redirect destinations
-  are local paths or validated allowlisted destinations and are never accepted
-  from an unvalidated route parameter or request value.
+- Applications must validate or percent-encode untrusted reverse-route
+  parameters as path data before substitution; `NamespacedRoute::resolve`
+  accepts caller-provided values without performing that validation itself.
+  Redirect destinations are local paths or validated allowlisted destinations
+  and are never accepted from an unvalidated route parameter or request value.
 - Client-router state, browser history, route metadata, and client-side guards
   are presentation state only. Server-side routing and handlers retain the
   authoritative authentication, authorization, and tenant checks.

--- a/crates/reinhardt-urls/SECURITY.md
+++ b/crates/reinhardt-urls/SECURITY.md
@@ -17,6 +17,10 @@ parameters, route registrations, and client routing state cross its boundary.
   security-equivalent path normalization and percent decoding. Invalid or
   ambiguous encodings fail rather than receiving a different interpretation at
   another stage or being decoded more than once.
+- Untyped `PathPattern` parameters are captured by a permissive segment pattern
+  and do not receive the same path-encoding validation as explicit path-typed
+  parameters. Applications must validate percent encodings and decoded values
+  for every untrusted parameter before authorization or downstream decoding.
 - Slash normalization and dot-segment handling cannot turn a protected path
   into a different route, escape a mounted prefix, or bypass authorization and
   middleware attached to the intended route.

--- a/crates/reinhardt-urls/SECURITY.md
+++ b/crates/reinhardt-urls/SECURITY.md
@@ -1,0 +1,46 @@
+# reinhardt-urls Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-urls` matches server and client routes, extracts path parameters,
+builds route groups, applies routing middleware, reverses URLs, and produces
+redirect destinations. Paths, percent-encoded segments, query strings, route
+parameters, route registrations, and client routing state cross its boundary.
+
+## Security Invariants
+
+- Server matching, client matching, reverse routing, and redirects use
+  security-equivalent path normalization and percent decoding. Invalid or
+  ambiguous encodings fail rather than receiving a different interpretation at
+  another stage or being decoded more than once.
+- Slash normalization and dot-segment handling cannot turn a protected path
+  into a different route, escape a mounted prefix, or bypass authorization and
+  middleware attached to the intended route.
+- Route registration and dispatch preserve deterministic, non-bypassable
+  precedence. Conflicting routes fail explicitly, and fallback, wildcard, or
+  less-specific routes cannot shadow a security-sensitive route after
+  normalization.
+- Global, router, group, and route middleware compose cumulatively in their
+  configured order. Adding a route or group cannot discard inherited
+  authentication, authorization, CSRF, origin, host, or other security
+  middleware.
+- Captured path and query parameters are attacker-controlled. Typed conversion
+  and validation do not establish object ownership, tenant membership, or
+  authorization; handlers enforce those checks on the resolved resource.
+- Reverse routing encodes parameter values as path data and cannot generate
+  traversal, delimiter, scheme, or authority injection. Redirect destinations
+  are local paths or validated allowlisted destinations and are never accepted
+  from an unvalidated route parameter or request value.
+- Client-router state, browser history, route metadata, and client-side guards
+  are presentation state only. Server-side routing and handlers retain the
+  authoritative authentication, authorization, and tenant checks.
+
+## Reportable Findings
+
+Report normalization or decoding differentials, route-precedence bypasses,
+lost inherited middleware, parameter-driven authorization bypass, unsafe URL
+generation or redirects, and client metadata treated as authoritative.

--- a/crates/reinhardt-websockets/SECURITY.md
+++ b/crates/reinhardt-websockets/SECURITY.md
@@ -23,8 +23,10 @@ channels. Handshake metadata and all received frames are attacker-controlled.
   filtered per recipient so one subscriber cannot receive another's data; the
   room broadcast primitive does not apply these checks automatically.
 - Frame and message size, nesting, count, decompression output, and processing
-  work are limited before allocation or decompression. Streaming and queues use
-  bounded backpressure.
+  work must be limited before allocation or decompression. Applications must
+  bound outbound queues and define an overflow or disconnect policy; the current
+  connection and in-memory channel primitives do not provide backpressure
+  automatically.
 - Rate limits derive their key from validated connection identity or trusted
   peer metadata, not spoofable headers or message fields. Distributed channels
   preserve the same authenticated identity, authorization, isolation, limits,

--- a/crates/reinhardt-websockets/SECURITY.md
+++ b/crates/reinhardt-websockets/SECURITY.md
@@ -1,0 +1,35 @@
+# reinhardt-websockets Security Policy
+
+## System and Scope
+
+This policy inherits the repository [Security Policy](../../SECURITY.md) and
+the framework-crate [Security Policy](../SECURITY.md). Policies compose from
+the repository root to this crate; this closest policy wins on conflict.
+
+`reinhardt-websockets` upgrades HTTP connections and handles persistent
+connections, frames, messages, rooms, actions, broadcasts, and distributed
+channels. Handshake metadata and all received frames are attacker-controlled.
+
+## Security Invariants
+
+- The handshake applies an explicit origin and authentication policy. Cookie or
+  session authentication is validated with protections equivalent to the HTTP
+  operation it upgrades and is never inferred from client-supplied identity.
+- A validated principal and tenant are bound immutably to each connection.
+  Client messages cannot select another identity, room, or authorization scope.
+- Joining rooms, sending actions, and receiving broadcasts require authorization
+  for the relevant resource and tenant. Broadcast delivery is filtered per
+  recipient so one subscriber cannot receive another's data.
+- Frame and message size, nesting, count, decompression output, and processing
+  work are limited before allocation or decompression. Streaming and queues use
+  bounded backpressure.
+- Rate limits derive their key from validated connection identity or trusted
+  peer metadata, not spoofable headers or message fields. Distributed channels
+  preserve the same authenticated identity, authorization, isolation, limits,
+  and rate-limit semantics as local delivery.
+
+## Reportable Findings
+
+Report cross-origin or handshake-auth bypass, connection identity confusion,
+unauthorized room/action/broadcast access, pre-limit resource exhaustion,
+spoofable rate limits, or weaker distributed-channel enforcement.

--- a/crates/reinhardt-websockets/SECURITY.md
+++ b/crates/reinhardt-websockets/SECURITY.md
@@ -15,11 +15,13 @@ channels. Handshake metadata and all received frames are attacker-controlled.
 - The handshake applies an explicit origin and authentication policy. Cookie or
   session authentication is validated with protections equivalent to the HTTP
   operation it upgrades and is never inferred from client-supplied identity.
-- A validated principal and tenant are bound immutably to each connection.
-  Client messages cannot select another identity, room, or authorization scope.
-- Joining rooms, sending actions, and receiving broadcasts require authorization
-  for the relevant resource and tenant. Broadcast delivery is filtered per
-  recipient so one subscriber cannot receive another's data.
+- Applications must bind a validated principal and tenant immutably to each
+  connection before exposing protected room APIs; the public room APIs do not
+  infer this context from a client ID or raw connection.
+- Applications must authorize joining rooms, sending actions, and receiving
+  broadcasts for the relevant resource and tenant. Broadcast delivery must be
+  filtered per recipient so one subscriber cannot receive another's data; the
+  room broadcast primitive does not apply these checks automatically.
 - Frame and message size, nesting, count, decompression output, and processing
   work are limited before allocation or decompression. Streaming and queues use
   bounded backpressure.

--- a/crates/reinhardt-websockets/SECURITY.md
+++ b/crates/reinhardt-websockets/SECURITY.md
@@ -12,9 +12,10 @@ channels. Handshake metadata and all received frames are attacker-controlled.
 
 ## Security Invariants
 
-- The handshake applies an explicit origin and authentication policy. Cookie or
-  session authentication is validated with protections equivalent to the HTTP
-  operation it upgrades and is never inferred from client-supplied identity.
+- Protected deployments must install an explicit origin and authentication
+  policy in every handshake entry point. `OriginValidationMiddleware` is an
+  opt-in connection middleware; cookie or session authentication is never
+  inferred from client-supplied identity.
 - Applications must bind a validated principal and tenant immutably to each
   connection before exposing protected room APIs; the public room APIs do not
   infer this context from a client ID or raw connection.

--- a/crates/reinhardt-websockets/SECURITY.md
+++ b/crates/reinhardt-websockets/SECURITY.md
@@ -29,9 +29,14 @@ channels. Handshake metadata and all received frames are attacker-controlled.
   connection and in-memory channel primitives do not provide backpressure
   automatically.
 - Rate limits derive their key from validated connection identity or trusted
-  peer metadata, not spoofable headers or message fields. Distributed channels
-  preserve the same authenticated identity, authorization, isolation, limits,
-  and rate-limit semantics as local delivery.
+  peer metadata, not spoofable headers or message fields. The built-in
+  `RateLimitMiddleware` keys message buckets by `WebSocketConnection::id()`;
+  unless the application assigns a stable, validated principal-derived ID,
+  this is a per-connection limit and reconnects start a fresh bucket. Protected
+  deployments must treat that behavior as per-connection or provide a
+  rebinding-safe identity-key strategy. Distributed channels preserve the same
+  authenticated identity, authorization, isolation, limits, and rate-limit
+  semantics as local delivery.
 
 ## Reportable Findings
 

--- a/scripts/tests/test-update-version-refs.sh
+++ b/scripts/tests/test-update-version-refs.sh
@@ -268,4 +268,29 @@ run_case "08 docs.rs versioned URL" \
 	"0.2.0-rc.5" \
 	"website/config.toml"
 
+# Default targets include the root security policy.
+run_default_security_policy_case() {
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	mkdir -p "$tmpdir/scripts" "$tmpdir/crates" "$tmpdir/docs" "$tmpdir/website/content"
+	cp "$SCRIPT" "$tmpdir/scripts/update-version-refs.sh"
+	cat > "$tmpdir/SECURITY.md" <<'EOF'
+# Security Policy
+
+<!-- reinhardt-version-sync -->
+Security fixes target the current supported release, `0.3.8`.
+EOF
+
+	REINHARDT_REPO_ROOT="$tmpdir" \
+		bash "$tmpdir/scripts/update-version-refs.sh" "9.8.7" >/dev/null
+	if grep -q 'current supported release, `9.8.7`' "$tmpdir/SECURITY.md"; then
+		pass "09 default target root SECURITY.md"
+	else
+		fail "09 default target root SECURITY.md"
+	fi
+	rm -rf "$tmpdir"
+}
+
+run_default_security_policy_case
+
 exit "$FAIL"

--- a/scripts/tests/test-validate-version-markers.sh
+++ b/scripts/tests/test-validate-version-markers.sh
@@ -84,4 +84,34 @@ reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
 MD_EOF
 run_validate_case "V4 marker in code block" "$fx_dir/v4-marker-in-block.md" "bad.md" 1 "MARKER_IN_CODE_BLOCK"
 
+# Default targets include the root security policy.
+run_default_security_policy_case() {
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	mkdir -p "$tmpdir/scripts" "$tmpdir/crates" "$tmpdir/docs" "$tmpdir/website/content"
+	cp "$SCRIPT" "$tmpdir/scripts/validate-version-markers.sh"
+	cat > "$tmpdir/SECURITY.md" <<'EOF'
+# Security Policy
+
+<!-- reinhardt-version-sync -->
+Security fixes are handled through the security advisory process.
+EOF
+
+	set +e
+	REINHARDT_REPO_ROOT="$tmpdir" \
+		bash "$tmpdir/scripts/validate-version-markers.sh" \
+		>"$tmpdir/out.log" 2>"$tmpdir/err.log"
+	local rc=$?
+	set -e
+	if [ "$rc" -eq 1 ] && grep -q 'ORPHAN_MARKER .*SECURITY.md' "$tmpdir/err.log"; then
+		pass "V5 default target root SECURITY.md"
+	else
+		fail "V5 default target root SECURITY.md (rc=$rc)"
+		cat "$tmpdir/err.log" >&2
+	fi
+	rm -rf "$tmpdir"
+}
+
+run_default_security_policy_case
+
 exit "$FAIL"

--- a/scripts/tests/test-validate-version-markers.sh
+++ b/scripts/tests/test-validate-version-markers.sh
@@ -73,6 +73,12 @@ reinhardt = { version = "0.1.0-rc.17", package = "reinhardt-web" }
 EOF
 run_validate_case "V3 unmarked hardcoded version" "$fx_dir/unmarked.toml" "bad.toml" 1 "UNMARKED"
 
+# Unmarked security policy release reference -> rc 1, UNMARKED
+cat > "$fx_dir/unmarked-security.md" <<'EOF'
+Security fixes target the current supported release, `0.3.8`, and the current development line as appropriate.
+EOF
+run_validate_case "V3b unmarked security release" "$fx_dir/unmarked-security.md" "SECURITY.md" 1 "UNMARKED"
+
 # V4: marker inside a Markdown fenced code block -> rc 1, MARKER_IN_CODE_BLOCK
 cat > "$fx_dir/v4-marker-in-block.md" <<'MD_EOF'
 # Example

--- a/scripts/update-version-refs.sh
+++ b/scripts/update-version-refs.sh
@@ -57,6 +57,7 @@ if [ -n "${REINHARDT_VERSION_SYNC_TARGETS:-}" ]; then
 else
 	TARGETS=(
 		"README.md"
+		"SECURITY.md"
 		"examples/Cargo.toml"
 		"examples/AGENTS.md"
 		"examples/CLAUDE.md"

--- a/scripts/validate-version-markers.sh
+++ b/scripts/validate-version-markers.sh
@@ -20,6 +20,7 @@ if [ -n "${REINHARDT_VERSION_SYNC_TARGETS:-}" ]; then
 else
 	TARGETS=(
 		"README.md"
+		"SECURITY.md"
 		"examples/Cargo.toml"
 		"examples/AGENTS.md"
 		"examples/CLAUDE.md"

--- a/scripts/validate-version-markers.sh
+++ b/scripts/validate-version-markers.sh
@@ -54,6 +54,7 @@ BEGIN {
 	marker_html_n  = "^[[:space:]]*(//![[:space:]]+)?<!--[[:space:]]*reinhardt-version-sync:[0-9]+[[:space:]]*-->[[:space:]]*$"
 	# Hints that a line carries a Reinhardt version we should have marked.
 	hint_re    = "(reinhardt[a-z-]*[[:space:]]*=|reinhardt_version[[:space:]]*=|package[[:space:]]*=[[:space:]]*\"reinhardt-web\")"
+	security_release_re = "[Ss]upported[[:space:]]+release"
 	version_re = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
 	# Code fence with optional rustdoc inner-comment prefix `//! `
 	fence_re   = "^[[:space:]]*(//![[:space:]]+)?```"
@@ -102,7 +103,7 @@ FNR == 1 {
 			next
 		}
 		# Unmarked hardcoded version detection (skip inside md code blocks).
-		if (!(is_md_file && in_code_block) && $0 ~ hint_re && match($0, version_re)) {
+		if (!(is_md_file && in_code_block) && ($0 ~ hint_re || (FILENAME ~ /SECURITY\.md$/ && $0 ~ security_release_re)) && match($0, version_re)) {
 			printf("UNMARKED %s:%d: no preceding marker: %s\n", FILENAME, NR, $0) > "/dev/stderr"
 			findings++
 		}

--- a/scripts/validate-version-markers.sh
+++ b/scripts/validate-version-markers.sh
@@ -54,7 +54,7 @@ BEGIN {
 	marker_html_n  = "^[[:space:]]*(//![[:space:]]+)?<!--[[:space:]]*reinhardt-version-sync:[0-9]+[[:space:]]*-->[[:space:]]*$"
 	# Hints that a line carries a Reinhardt version we should have marked.
 	hint_re    = "(reinhardt[a-z-]*[[:space:]]*=|reinhardt_version[[:space:]]*=|package[[:space:]]*=[[:space:]]*\"reinhardt-web\")"
-	security_release_re = "[Ss]upported[[:space:]]+release"
+	security_release_re = "[Cc]urrent[[:space:]]+[Ss]upported[[:space:]]+release"
 	version_re = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
 	# Code fence with optional rustdoc inner-comment prefix `//! `
 	fence_re   = "^[[:space:]]*(//![[:space:]]+)?```"


### PR DESCRIPTION
## Summary

This PR addresses:

- replaces the root security policy with a Reinhardt-specific threat model, protected assets, trust boundaries, and framework-wide security invariants;
- adds shared crate guidance plus nested policies for 17 independent security boundaries;
- integrates root `SECURITY.md` with the existing version-reference update and validation scripts.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Reinhardt has distinct security boundaries across authentication, ORM/query construction, request processing, browser/WASM code, alternate transports, plugins, configuration, storage, and management commands. A root-plus-boundary hierarchy gives security reviewers precise invariants without duplicating policy across every workspace member.

The supported release statement now uses the existing `reinhardt-version-sync` marker so it stays synchronized with release metadata. Severity guidance is based on realistic reachability, prerequisites, and impact rather than vulnerability class alone.

Private scan artifacts and finding details are intentionally excluded from Git.

## How Was This Tested?

- `bash scripts/tests/test-update-version-refs.sh` — 9/9 cases passed
- `bash scripts/tests/test-validate-version-markers.sh` — 5/5 cases passed
- `bash scripts/validate-version-markers.sh` — 101 files validated
- `bash scripts/update-version-refs.sh 0.3.8 --dry-run` — no changes required
- all 17 component policy chains resolved as root → `crates/` → component
- `git diff --check origin/main...HEAD` — passed

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

None.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)

No scope label: this policy hierarchy spans framework-wide boundaries without changing subsystem implementation.

### Priority Label (for maintainers)

Not selected.

---

**Additional Context:**

The policy hierarchy contains exactly 19 Reinhardt framework policy files: the repository root, the shared `crates/` policy, and 17 component policies. Components without a distinct trust boundary inherit the nearest shared policy.