### PR TITLE
feat(serializers): add JSON extraction and structured errors

### DIFF
--- a/crates/reinhardt-core/README.md
+++ b/crates/reinhardt-core/README.md
@@ -56,6 +56,7 @@ This crate provides the following modules:
 - **Serializers**: Serialization and deserialization
   - Django REST Framework-inspired field types
   - Presence-aware JSON field extraction and scalar coercion
+  - Integer JSON numbers reject lossy `f64` conversions outside `±2^53`
   - Validation system with field and object validators
   - Field-keyed aggregate validation errors
   - Recursive serialization with circular reference detection

--- a/crates/reinhardt-core/README.md
+++ b/crates/reinhardt-core/README.md
@@ -55,7 +55,9 @@ This crate provides the following modules:
 
 - **Serializers**: Serialization and deserialization
   - Django REST Framework-inspired field types
+  - Presence-aware JSON field extraction and scalar coercion
   - Validation system with field and object validators
+  - Field-keyed aggregate validation errors
   - Recursive serialization with circular reference detection
   - Arena allocation for high-performance serialization
 

--- a/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.rs
@@ -1,8 +1,10 @@
 use reinhardt_macros::model;
+use serde::Serialize;
 
 include!("../support.rs");
 
 #[model(table_name = "secrets", server_only)]
+#[derive(Serialize)]
 struct Secret {
 	#[field(primary_key = true)]
 	id: i64,

--- a/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.stderr
@@ -1,5 +1,5 @@
 error[E0422]: cannot find struct, variant or union type `SecretInfo` in this scope
-  --> tests/ui/model/fail/server_only_info.rs:15:10
+  --> tests/ui/model/fail/server_only_info.rs:17:10
    |
-15 |     let _ = SecretInfo { id: 1 };
+17 |     let _ = SecretInfo { id: 1 };
    |             ^^^^^^^^^^ not found in this scope

--- a/crates/reinhardt-core/src/serializers.rs
+++ b/crates/reinhardt-core/src/serializers.rs
@@ -9,7 +9,8 @@
 //!
 //! - **Serializer Traits**: Core `Serializer` and `Deserializer` traits
 //! - **Field Types**: Django REST Framework-inspired field types (CharField, IntegerField, etc.)
-//! - **JSON Field Extraction**: Presence-aware scalar coercion
+//! - **JSON Field Extraction**: Presence-aware scalar coercion that rejects
+//!   lossy `f64` integer conversions outside the exact `±2^53` range
 //! - **Validation**: Field-level and object-level validation support
 //! - **Structured Errors**: Field-keyed aggregate validation errors
 //! - **Recursive Serialization**: Depth tracking and circular reference detection

--- a/crates/reinhardt-core/src/serializers.rs
+++ b/crates/reinhardt-core/src/serializers.rs
@@ -9,7 +9,9 @@
 //!
 //! - **Serializer Traits**: Core `Serializer` and `Deserializer` traits
 //! - **Field Types**: Django REST Framework-inspired field types (CharField, IntegerField, etc.)
+//! - **JSON Field Extraction**: Presence-aware scalar coercion
 //! - **Validation**: Field-level and object-level validation support
+//! - **Structured Errors**: Field-keyed aggregate validation errors
 //! - **Recursive Serialization**: Depth tracking and circular reference detection
 //! - **Arena Allocation**: Memory-efficient serialization for deeply nested structures
 //!

--- a/crates/reinhardt-core/src/serializers/fields.rs
+++ b/crates/reinhardt-core/src/serializers/fields.rs
@@ -10,8 +10,9 @@ use std::fmt;
 /// A field value that preserves whether its JSON slot was absent or null.
 ///
 /// Missing slots remain [`FieldValue::Absent`] regardless of the field's
-/// `required` or `default` settings. The serializer can therefore apply create
-/// or partial-update rules after field conversion.
+/// `required` or `default` settings. Present empty strings are not replaced
+/// with `default` either; the serializer can therefore apply create or
+/// partial-update rules after field conversion.
 ///
 /// # Example
 ///
@@ -39,6 +40,18 @@ pub enum FieldValue<T> {
 fn coerce_json_string(value: &Value) -> Result<String, FieldError> {
 	match value {
 		Value::String(value) => Ok(value.trim().to_owned()),
+		Value::Number(value) => Ok(value.to_string()),
+		_ => Err(FieldError::Custom("Not a valid string".to_owned())),
+	}
+}
+
+/// Stringify a JSON scalar for choice matching without trimming whitespace.
+///
+/// Character fields normalize surrounding whitespace; choices must compare the
+/// exact configured token, including leading or trailing spaces.
+fn coerce_json_choice(value: &Value) -> Result<String, FieldError> {
+	match value {
+		Value::String(value) => Ok(value.clone()),
 		Value::Number(value) => Ok(value.to_string()),
 		_ => Err(FieldError::Custom("Not a valid string".to_owned())),
 	}
@@ -570,6 +583,10 @@ impl FloatField {
 		}
 		.ok_or_else(|| FieldError::Custom("A valid number is required".to_owned()))?;
 
+		if !parsed.is_finite() {
+			return Err(FieldError::Custom("A valid number is required".to_owned()));
+		}
+
 		self.validate(parsed)?;
 		Ok(FieldValue::Present(parsed))
 	}
@@ -679,19 +696,24 @@ impl BooleanField {
 			Some(Value::Bool(value)) => Some(*value),
 			Some(Value::Number(value)) if value.as_f64() == Some(1.0) => Some(true),
 			Some(Value::Number(value)) if value.as_f64() == Some(0.0) => Some(false),
-			Some(Value::String(value))
+			Some(Value::String(value)) => {
+				let value = value.trim();
+				if value.is_empty() && self.allow_null {
+					return Ok(FieldValue::Null);
+				}
 				if ["t", "y", "yes", "true", "on", "1"]
 					.iter()
-					.any(|candidate| value.eq_ignore_ascii_case(candidate)) =>
-			{
-				Some(true)
-			}
-			Some(Value::String(value))
-				if ["f", "n", "no", "false", "off", "0"]
+					.any(|candidate| value.eq_ignore_ascii_case(candidate))
+				{
+					Some(true)
+				} else if ["f", "n", "no", "false", "off", "0"]
 					.iter()
-					.any(|candidate| value.eq_ignore_ascii_case(candidate)) =>
-			{
-				Some(false)
+					.any(|candidate| value.eq_ignore_ascii_case(candidate))
+				{
+					Some(false)
+				} else {
+					None
+				}
 			}
 			Some(_) => None,
 		}
@@ -1066,7 +1088,7 @@ impl ChoiceField {
 			Some(Value::Null) => return Err(FieldError::Null),
 			Some(value) => value,
 		};
-		let value = coerce_json_string(value)?;
+		let value = coerce_json_choice(value)?;
 		self.validate(&value)?;
 		Ok(FieldValue::Present(value))
 	}
@@ -1191,6 +1213,9 @@ impl DateField {
 			Some(Value::String(value)) => value,
 			Some(_) => return Err(FieldError::InvalidDate),
 		};
+		if value.is_empty() {
+			return Err(FieldError::InvalidDate);
+		}
 		Ok(FieldValue::Present(self.parse(value)?))
 	}
 
@@ -1337,6 +1362,9 @@ impl DateTimeField {
 			Some(Value::String(value)) => value,
 			Some(_) => return Err(FieldError::InvalidDateTime),
 		};
+		if value.is_empty() {
+			return Err(FieldError::InvalidDateTime);
+		}
 		Ok(FieldValue::Present(self.parse(value)?))
 	}
 

--- a/crates/reinhardt-core/src/serializers/fields.rs
+++ b/crates/reinhardt-core/src/serializers/fields.rs
@@ -57,13 +57,27 @@ fn coerce_json_choice(value: &Value) -> Result<String, FieldError> {
 	}
 }
 
+/// Largest integer magnitude that every integer is exactly representable in
+/// IEEE-754 binary64. Values outside `±2^53` can round in `as_f64()` before
+/// these checks run, so the float fallback must not accept them.
+const F64_MAX_SAFE_INTEGER: f64 = (1_i64 << 53) as f64;
+
+fn json_number_as_exact_i64(number: &serde_json::Number) -> Option<i64> {
+	if let Some(value) = number.as_i64() {
+		return Some(value);
+	}
+
+	let value = number.as_f64()?;
+	if !value.is_finite() || value.fract() != 0.0 || value.abs() > F64_MAX_SAFE_INTEGER {
+		return None;
+	}
+
+	Some(value as i64)
+}
+
 fn coerce_json_integer(value: &Value) -> Option<i64> {
 	match value {
-		Value::Number(number) => number.as_i64().or_else(|| {
-			let value = number.as_f64()?;
-			(value.fract() == 0.0 && value >= i64::MIN as f64 && value < i64::MAX as f64)
-				.then_some(value as i64)
-		}),
+		Value::Number(number) => json_number_as_exact_i64(number),
 		Value::String(value) => {
 			let value = value.trim();
 			let value = value

--- a/crates/reinhardt-core/src/serializers/fields.rs
+++ b/crates/reinhardt-core/src/serializers/fields.rs
@@ -4,7 +4,64 @@
 //! and transformation in serializers.
 
 use chrono::{NaiveDate, NaiveDateTime};
+use serde_json::Value;
 use std::fmt;
+
+/// A field value that preserves whether its JSON slot was absent or null.
+///
+/// Missing slots remain [`FieldValue::Absent`] regardless of the field's
+/// `required` or `default` settings. The serializer can therefore apply create
+/// or partial-update rules after field conversion.
+///
+/// # Example
+///
+/// ```rust
+/// use reinhardt_core::serializers::fields::{FieldValue, IntegerField};
+/// use serde_json::json;
+///
+/// let field = IntegerField::new().min_value(0).allow_null(true);
+/// assert_eq!(
+///     field.to_internal_value(Some(&json!("3"))),
+///     Ok(FieldValue::Present(3)),
+/// );
+/// assert_eq!(field.to_internal_value(None), Ok(FieldValue::Absent));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum FieldValue<T> {
+	/// The JSON object did not contain the field.
+	Absent,
+	/// The JSON field was explicitly null.
+	Null,
+	/// The JSON field contained a converted value.
+	Present(T),
+}
+
+fn coerce_json_string(value: &Value) -> Result<String, FieldError> {
+	match value {
+		Value::String(value) => Ok(value.trim().to_owned()),
+		Value::Number(value) => Ok(value.to_string()),
+		_ => Err(FieldError::Custom("Not a valid string".to_owned())),
+	}
+}
+
+fn coerce_json_integer(value: &Value) -> Option<i64> {
+	match value {
+		Value::Number(number) => number.as_i64().or_else(|| {
+			let value = number.as_f64()?;
+			(value.fract() == 0.0 && value >= i64::MIN as f64 && value < i64::MAX as f64)
+				.then_some(value as i64)
+		}),
+		Value::String(value) => {
+			let value = value.trim();
+			let value = value
+				.rsplit_once('.')
+				.filter(|(_, fraction)| fraction.chars().all(|character| character == '0'))
+				.map_or(value, |(integer, _)| integer);
+			value.parse().ok()
+		}
+		_ => None,
+	}
+}
 
 /// Errors that can occur during field validation
 #[non_exhaustive]
@@ -187,6 +244,22 @@ impl CharField {
 		self
 	}
 
+	/// Convert a JSON slot into a validated string while preserving presence.
+	pub fn to_internal_value(
+		&self,
+		value: Option<&Value>,
+	) -> Result<FieldValue<String>, FieldError> {
+		let value = match value {
+			None => return Ok(FieldValue::Absent),
+			Some(Value::Null) if self.allow_null => return Ok(FieldValue::Null),
+			Some(Value::Null) => return Err(FieldError::Null),
+			Some(value) => value,
+		};
+		let value = coerce_json_string(value)?;
+		self.validate(&value)?;
+		Ok(FieldValue::Present(value))
+	}
+
 	/// Validate a string value
 	///
 	/// # Example
@@ -331,6 +404,21 @@ impl IntegerField {
 		self
 	}
 
+	/// Convert a JSON slot into a validated integer while preserving presence.
+	pub fn to_internal_value(&self, value: Option<&Value>) -> Result<FieldValue<i64>, FieldError> {
+		let value = match value {
+			None => return Ok(FieldValue::Absent),
+			Some(Value::Null) if self.allow_null => return Ok(FieldValue::Null),
+			Some(Value::Null) => return Err(FieldError::Null),
+			Some(value) => value,
+		};
+		let parsed = coerce_json_integer(value)
+			.ok_or_else(|| FieldError::Custom("A valid integer is required".to_owned()))?;
+
+		self.validate(parsed)?;
+		Ok(FieldValue::Present(parsed))
+	}
+
 	/// Validate an integer value
 	///
 	/// # Example
@@ -469,6 +557,23 @@ impl FloatField {
 		self
 	}
 
+	/// Convert a JSON slot into a validated float while preserving presence.
+	pub fn to_internal_value(&self, value: Option<&Value>) -> Result<FieldValue<f64>, FieldError> {
+		let parsed = match value {
+			None => return Ok(FieldValue::Absent),
+			Some(Value::Null) if self.allow_null => return Ok(FieldValue::Null),
+			Some(Value::Null) => return Err(FieldError::Null),
+			Some(Value::Number(value)) => value.as_f64(),
+			Some(Value::String(value)) => value.trim().parse().ok(),
+			Some(Value::Bool(value)) => Some(if *value { 1.0 } else { 0.0 }),
+			Some(_) => None,
+		}
+		.ok_or_else(|| FieldError::Custom("A valid number is required".to_owned()))?;
+
+		self.validate(parsed)?;
+		Ok(FieldValue::Present(parsed))
+	}
+
 	/// Validate a float value
 	///
 	/// # Example
@@ -565,6 +670,37 @@ impl BooleanField {
 		self
 	}
 
+	/// Convert a JSON slot into a validated boolean while preserving presence.
+	pub fn to_internal_value(&self, value: Option<&Value>) -> Result<FieldValue<bool>, FieldError> {
+		let parsed = match value {
+			None => return Ok(FieldValue::Absent),
+			Some(Value::Null) if self.allow_null => return Ok(FieldValue::Null),
+			Some(Value::Null) => return Err(FieldError::Null),
+			Some(Value::Bool(value)) => Some(*value),
+			Some(Value::Number(value)) if value.as_f64() == Some(1.0) => Some(true),
+			Some(Value::Number(value)) if value.as_f64() == Some(0.0) => Some(false),
+			Some(Value::String(value))
+				if ["t", "y", "yes", "true", "on", "1"]
+					.iter()
+					.any(|candidate| value.eq_ignore_ascii_case(candidate)) =>
+			{
+				Some(true)
+			}
+			Some(Value::String(value))
+				if ["f", "n", "no", "false", "off", "0"]
+					.iter()
+					.any(|candidate| value.eq_ignore_ascii_case(candidate)) =>
+			{
+				Some(false)
+			}
+			Some(_) => None,
+		}
+		.ok_or_else(|| FieldError::Custom("Must be a valid boolean".to_owned()))?;
+
+		self.validate(parsed)?;
+		Ok(FieldValue::Present(parsed))
+	}
+
 	/// Validate a boolean value
 	///
 	/// # Example
@@ -653,6 +789,22 @@ impl EmailField {
 	pub fn default(mut self, default: String) -> Self {
 		self.default = Some(default);
 		self
+	}
+
+	/// Convert a JSON slot into a validated email while preserving presence.
+	pub fn to_internal_value(
+		&self,
+		value: Option<&Value>,
+	) -> Result<FieldValue<String>, FieldError> {
+		let value = match value {
+			None => return Ok(FieldValue::Absent),
+			Some(Value::Null) if self.allow_null => return Ok(FieldValue::Null),
+			Some(Value::Null) => return Err(FieldError::Null),
+			Some(value) => value,
+		};
+		let value = coerce_json_string(value)?;
+		self.validate(&value)?;
+		Ok(FieldValue::Present(value))
 	}
 
 	/// Validate an email address
@@ -772,6 +924,22 @@ impl URLField {
 		self
 	}
 
+	/// Convert a JSON slot into a validated URL while preserving presence.
+	pub fn to_internal_value(
+		&self,
+		value: Option<&Value>,
+	) -> Result<FieldValue<String>, FieldError> {
+		let value = match value {
+			None => return Ok(FieldValue::Absent),
+			Some(Value::Null) if self.allow_null => return Ok(FieldValue::Null),
+			Some(Value::Null) => return Err(FieldError::Null),
+			Some(value) => value,
+		};
+		let value = coerce_json_string(value)?;
+		self.validate(&value)?;
+		Ok(FieldValue::Present(value))
+	}
+
 	/// Validate a URL
 	///
 	/// # Example
@@ -887,6 +1055,22 @@ impl ChoiceField {
 		self
 	}
 
+	/// Convert a JSON slot into a validated choice while preserving presence.
+	pub fn to_internal_value(
+		&self,
+		value: Option<&Value>,
+	) -> Result<FieldValue<String>, FieldError> {
+		let value = match value {
+			None => return Ok(FieldValue::Absent),
+			Some(Value::Null) if self.allow_null => return Ok(FieldValue::Null),
+			Some(Value::Null) => return Err(FieldError::Null),
+			Some(value) => value,
+		};
+		let value = coerce_json_string(value)?;
+		self.validate(&value)?;
+		Ok(FieldValue::Present(value))
+	}
+
 	/// Validate a choice value
 	///
 	/// # Example
@@ -993,6 +1177,21 @@ impl DateField {
 	pub fn default(mut self, default: NaiveDate) -> Self {
 		self.default = Some(default);
 		self
+	}
+
+	/// Convert a JSON slot into a parsed date while preserving presence.
+	pub fn to_internal_value(
+		&self,
+		value: Option<&Value>,
+	) -> Result<FieldValue<NaiveDate>, FieldError> {
+		let value = match value {
+			None => return Ok(FieldValue::Absent),
+			Some(Value::Null) if self.allow_null => return Ok(FieldValue::Null),
+			Some(Value::Null) => return Err(FieldError::Null),
+			Some(Value::String(value)) => value,
+			Some(_) => return Err(FieldError::InvalidDate),
+		};
+		Ok(FieldValue::Present(self.parse(value)?))
 	}
 
 	/// Parse a date string
@@ -1124,6 +1323,21 @@ impl DateTimeField {
 	pub fn default(mut self, default: NaiveDateTime) -> Self {
 		self.default = Some(default);
 		self
+	}
+
+	/// Convert a JSON slot into a parsed datetime while preserving presence.
+	pub fn to_internal_value(
+		&self,
+		value: Option<&Value>,
+	) -> Result<FieldValue<NaiveDateTime>, FieldError> {
+		let value = match value {
+			None => return Ok(FieldValue::Absent),
+			Some(Value::Null) if self.allow_null => return Ok(FieldValue::Null),
+			Some(Value::Null) => return Err(FieldError::Null),
+			Some(Value::String(value)) => value,
+			Some(_) => return Err(FieldError::InvalidDateTime),
+		};
+		Ok(FieldValue::Present(self.parse(value)?))
 	}
 
 	/// Parse a datetime string

--- a/crates/reinhardt-core/src/serializers/validator.rs
+++ b/crates/reinhardt-core/src/serializers/validator.rs
@@ -3,8 +3,8 @@
 //! Provides validation traits and utilities for serializer fields.
 
 use super::fields::{
-	BooleanField, CharField, ChoiceField, DateField, DateTimeField, EmailField, FloatField,
-	IntegerField, URLField,
+	BooleanField, CharField, ChoiceField, DateField, DateTimeField, EmailField, FieldError,
+	FloatField, IntegerField, URLField,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -174,6 +174,14 @@ impl ValidationError {
 pub trait FieldValidator {
 	/// Validate a field value
 	fn validate(&self, value: &Value) -> ValidationResult;
+
+	/// Whether a missing JSON key should fail [`validate_fields`].
+	///
+	/// Custom validators default to `false` so omitted keys remain a pass-through.
+	/// Built-in serializer fields return their `required` configuration.
+	fn is_required(&self) -> bool {
+		false
+	}
 }
 
 macro_rules! impl_typed_field_validator {
@@ -183,7 +191,11 @@ macro_rules! impl_typed_field_validator {
 				fn validate(&self, value: &Value) -> ValidationResult {
 					self.to_internal_value(Some(value))
 						.map(|_| ())
-						.map_err(|error| ValidationError::field_error("", error.to_string()))
+						.map_err(|error| ValidationError::object_error(error.to_string()))
+				}
+
+				fn is_required(&self) -> bool {
+					self.required
 				}
 			}
 		)+
@@ -268,6 +280,9 @@ pub trait ObjectLevelValidation {
 
 /// Helper function to validate all fields in a data object
 ///
+/// Missing keys skip custom validators by default. Built-in serializer fields
+/// report [`FieldError::Required`] when [`FieldValidator::is_required`] is true.
+///
 /// # Examples
 ///
 /// ```
@@ -308,10 +323,19 @@ pub fn validate_fields(
 	let mut errors = Vec::new();
 
 	for (field_name, validator) in validators {
-		if let Some(value) = data.get(field_name)
-			&& let Err(e) = validator.validate(value)
-		{
-			errors.push(e.with_field(field_name));
+		match data.get(field_name) {
+			Some(value) => {
+				if let Err(e) = validator.validate(value) {
+					errors.push(e.with_field(field_name));
+				}
+			}
+			None if validator.is_required() => {
+				errors.push(ValidationError::field_error(
+					field_name,
+					FieldError::Required.to_string(),
+				));
+			}
+			None => {}
 		}
 	}
 
@@ -517,7 +541,7 @@ mod tests {
 
 		let data = HashMap::new(); // No email field
 
-		// Missing fields are not validated (pass through)
+		// Missing custom validators are not required (pass through)
 		let result = validate_fields(&data, &validators);
 		assert!(result.is_ok());
 	}

--- a/crates/reinhardt-core/src/serializers/validator.rs
+++ b/crates/reinhardt-core/src/serializers/validator.rs
@@ -2,6 +2,10 @@
 //!
 //! Provides validation traits and utilities for serializer fields.
 
+use super::fields::{
+	BooleanField, CharField, ChoiceField, DateField, DateTimeField, EmailField, FloatField,
+	IntegerField, URLField,
+};
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -82,6 +86,58 @@ impl ValidationError {
 	pub fn multiple(errors: Vec<ValidationError>) -> Self {
 		Self::MultipleErrors(errors)
 	}
+
+	/// Return field validation messages grouped by field name.
+	///
+	/// Object-level errors are not included because they have no field key.
+	///
+	/// # Example
+	///
+	/// ```rust
+	/// use reinhardt_core::serializers::ValidationError;
+	///
+	/// let error = ValidationError::multiple(vec![
+	///     ValidationError::field_error("start", "Too long"),
+	///     ValidationError::field_error("priority", "Too small"),
+	/// ]);
+	/// let errors = error.field_errors();
+	/// assert_eq!(errors["start"], ["Too long"]);
+	/// assert_eq!(errors["priority"], ["Too small"]);
+	/// ```
+	pub fn field_errors(&self) -> HashMap<String, Vec<String>> {
+		let mut field_errors = HashMap::new();
+		self.collect_field_errors(&mut field_errors);
+		field_errors
+	}
+
+	fn collect_field_errors(&self, field_errors: &mut HashMap<String, Vec<String>>) {
+		match self {
+			Self::FieldError { field, message } => field_errors
+				.entry(field.clone())
+				.or_default()
+				.push(message.clone()),
+			Self::MultipleErrors(errors) => {
+				for error in errors {
+					error.collect_field_errors(field_errors);
+				}
+			}
+			Self::ObjectError(_) => {}
+		}
+	}
+
+	fn with_field(self, field: &str) -> Self {
+		match self {
+			Self::FieldError { message, .. } | Self::ObjectError(message) => {
+				Self::field_error(field, message)
+			}
+			Self::MultipleErrors(errors) => Self::multiple(
+				errors
+					.into_iter()
+					.map(|error| error.with_field(field))
+					.collect(),
+			),
+		}
+	}
 }
 
 /// Trait for field-level validators
@@ -119,6 +175,32 @@ pub trait FieldValidator {
 	/// Validate a field value
 	fn validate(&self, value: &Value) -> ValidationResult;
 }
+
+macro_rules! impl_typed_field_validator {
+	($($field:ty),+ $(,)?) => {
+		$(
+			impl FieldValidator for $field {
+				fn validate(&self, value: &Value) -> ValidationResult {
+					self.to_internal_value(Some(value))
+						.map(|_| ())
+						.map_err(|error| ValidationError::field_error("", error.to_string()))
+				}
+			}
+		)+
+	};
+}
+
+impl_typed_field_validator!(
+	CharField,
+	IntegerField,
+	FloatField,
+	BooleanField,
+	EmailField,
+	URLField,
+	ChoiceField,
+	DateField,
+	DateTimeField,
+);
 
 /// Trait for object-level validators
 ///
@@ -229,7 +311,7 @@ pub fn validate_fields(
 		if let Some(value) = data.get(field_name)
 			&& let Err(e) = validator.validate(value)
 		{
-			errors.push(e);
+			errors.push(e.with_field(field_name));
 		}
 	}
 

--- a/crates/reinhardt-core/tests/serializers_integration.rs
+++ b/crates/reinhardt-core/tests/serializers_integration.rs
@@ -741,9 +741,11 @@ fn float_and_temporal_fields_convert_json_values() {
 #[case::boolean(json!(true), true)]
 #[case::one(json!(1), true)]
 #[case::uppercase_yes(json!("YES"), true)]
+#[case::padded_true(json!(" true "), true)]
 #[case::false_value(json!(false), false)]
 #[case::zero(json!(0), false)]
 #[case::off(json!("off"), false)]
+#[case::padded_zero(json!(" 0 "), false)]
 fn boolean_field_converts_drf_tokens(#[case] input: Value, #[case] expected: bool) {
 	// Arrange
 	let field = BooleanField::new();
@@ -753,6 +755,98 @@ fn boolean_field_converts_drf_tokens(#[case] input: Value, #[case] expected: boo
 
 	// Assert
 	assert_eq!(result, Ok(FieldValue::Present(expected)));
+}
+
+#[rstest]
+fn boolean_field_treats_blank_string_as_null_when_allowed() {
+	// Arrange
+	let field = BooleanField::new().allow_null(true);
+	let input = json!("");
+
+	// Act
+	let result = field.to_internal_value(Some(&input));
+
+	// Assert
+	assert_eq!(result, Ok(FieldValue::Null));
+}
+
+#[rstest]
+fn float_field_rejects_non_finite_strings() {
+	// Arrange
+	let field = FloatField::new();
+
+	// Assert
+	assert_eq!(
+		field.to_internal_value(Some(&json!("NaN"))),
+		Err(FieldError::Custom("A valid number is required".to_owned()))
+	);
+	assert_eq!(
+		field.to_internal_value(Some(&json!("inf"))),
+		Err(FieldError::Custom("A valid number is required".to_owned()))
+	);
+	assert_eq!(
+		field.to_internal_value(Some(&json!("1e9999"))),
+		Err(FieldError::Custom("A valid number is required".to_owned()))
+	);
+}
+
+#[rstest]
+fn choice_field_preserves_exact_strings_during_json_extraction() {
+	// Arrange
+	let padded = ChoiceField::new(vec![" active ".to_owned()]);
+	let compact = ChoiceField::new(vec!["active".to_owned()]);
+
+	// Assert
+	assert_eq!(
+		padded.to_internal_value(Some(&json!(" active "))),
+		Ok(FieldValue::Present(" active ".to_owned()))
+	);
+	assert_eq!(
+		padded.to_internal_value(Some(&json!("active"))),
+		Err(FieldError::InvalidChoice)
+	);
+	assert_eq!(
+		compact.to_internal_value(Some(&json!(" active "))),
+		Err(FieldError::InvalidChoice)
+	);
+	assert_eq!(
+		padded.to_internal_value(Some(&json!(1))),
+		Err(FieldError::InvalidChoice)
+	);
+	assert_eq!(
+		ChoiceField::new(vec!["1".to_owned()]).to_internal_value(Some(&json!(1))),
+		Ok(FieldValue::Present("1".to_owned()))
+	);
+}
+
+#[rstest]
+fn date_field_does_not_apply_default_to_empty_json_string() {
+	// Arrange
+	let default = NaiveDate::from_ymd_opt(2026, 8, 20).unwrap();
+	let field = DateField::new().required(false).default(default);
+
+	// Act
+	let result = field.to_internal_value(Some(&json!("")));
+
+	// Assert
+	assert_eq!(result, Err(FieldError::InvalidDate));
+	assert_ne!(result, Ok(FieldValue::Present(default)));
+}
+
+#[rstest]
+fn datetime_field_does_not_apply_default_to_empty_json_string() {
+	// Arrange
+	let default = NaiveDate::from_ymd_opt(2026, 8, 20)
+		.unwrap()
+		.and_hms_opt(12, 0, 0)
+		.unwrap();
+	let field = DateTimeField::new().required(false).default(default);
+
+	// Act
+	let result = field.to_internal_value(Some(&json!("")));
+
+	// Assert
+	assert_eq!(result, Err(FieldError::InvalidDateTime));
 }
 
 #[rstest]
@@ -1014,6 +1108,56 @@ fn validate_fields_replaces_nested_error_keys_and_preserves_message_order() {
 		])
 	);
 	assert_eq!(errors.get("ignored"), None);
+}
+
+#[rstest]
+fn validate_fields_rejects_omitted_required_builtin_field() {
+	// Arrange
+	let mut validators: HashMap<String, Box<dyn FieldValidator>> = HashMap::new();
+	validators.insert("age".into(), Box::new(IntegerField::new().min_value(0)));
+	let data = HashMap::new();
+
+	// Act
+	let errors = validate_fields(&data, &validators)
+		.unwrap_err()
+		.field_errors();
+
+	// Assert
+	assert_eq!(
+		errors.get("age"),
+		Some(&vec!["This field is required".to_owned()])
+	);
+}
+
+#[rstest]
+fn validate_fields_skips_omitted_optional_builtin_field() {
+	// Arrange
+	let mut validators: HashMap<String, Box<dyn FieldValidator>> = HashMap::new();
+	validators.insert(
+		"age".into(),
+		Box::new(IntegerField::new().required(false).min_value(0)),
+	);
+
+	// Act
+	let result = validate_fields(&HashMap::new(), &validators);
+
+	// Assert
+	assert!(result.is_ok());
+}
+
+#[rstest]
+fn typed_field_validator_direct_errors_do_not_publish_blank_keys() {
+	// Arrange
+	let field = IntegerField::new().min_value(0);
+
+	// Act
+	let errors = FieldValidator::validate(&field, &json!(-1))
+		.unwrap_err()
+		.field_errors();
+
+	// Assert
+	assert!(errors.is_empty());
+	assert_eq!(errors.get(""), None);
 }
 
 #[rstest]

--- a/crates/reinhardt-core/tests/serializers_integration.rs
+++ b/crates/reinhardt-core/tests/serializers_integration.rs
@@ -3,10 +3,10 @@
 //! Tests field validation, JSON serialization/deserialization, and validator
 //! interactions across the serializers sub-modules.
 
-use chrono::{Datelike, Timelike};
+use chrono::{Datelike, NaiveDate, Timelike};
 use reinhardt_core::serializers::fields::{
 	BooleanField, CharField, ChoiceField, DateField, DateTimeField, EmailField, FieldError,
-	FloatField, IntegerField, URLField,
+	FieldValue, FloatField, IntegerField, URLField,
 };
 use reinhardt_core::serializers::{
 	FieldValidator, JsonSerializer, Serializer, SerializerError, ValidationError, ValidationResult,
@@ -117,6 +117,68 @@ fn char_field_default_value_is_stored() {
 // ---------------------------------------------------------------------------
 // IntegerField validation
 // ---------------------------------------------------------------------------
+
+#[rstest]
+#[case::integer(json!(3), 3)]
+#[case::whole_float(json!(3.0), 3)]
+#[case::numeric_string(json!(" 3 "), 3)]
+#[case::decimal_string(json!("3.0"), 3)]
+fn integer_field_coerces_json_values(#[case] input: Value, #[case] expected: i64) {
+	// Arrange
+	let field = IntegerField::new();
+
+	// Act
+	let result = field.to_internal_value(Some(&input));
+
+	// Assert
+	assert_eq!(result, Ok(FieldValue::Present(expected)));
+}
+
+#[rstest]
+fn integer_field_preserves_absent_and_null_slots() {
+	// Arrange
+	let field = IntegerField::new().allow_null(true);
+	let null = Value::Null;
+
+	// Act and Assert
+	assert_eq!(field.to_internal_value(None), Ok(FieldValue::Absent));
+	assert_eq!(field.to_internal_value(Some(&null)), Ok(FieldValue::Null));
+	assert_eq!(
+		IntegerField::new().to_internal_value(Some(&null)),
+		Err(FieldError::Null)
+	);
+}
+
+#[rstest]
+#[case::array(json!([]))]
+#[case::boolean(json!(true))]
+#[case::fractional_number(json!(1.5))]
+fn integer_field_rejects_invalid_json_type(#[case] input: Value) {
+	// Arrange
+	let field = IntegerField::new();
+
+	// Act
+	let result = field.to_internal_value(Some(&input));
+
+	// Assert
+	assert_eq!(
+		result,
+		Err(FieldError::Custom("A valid integer is required".to_owned()))
+	);
+}
+
+#[rstest]
+fn integer_field_applies_constraints_after_conversion() {
+	// Arrange
+	let field = IntegerField::new().min_value(0);
+	let input = json!("-1");
+
+	// Act
+	let result = field.to_internal_value(Some(&input));
+
+	// Assert
+	assert_eq!(result, Err(FieldError::TooSmall(0)));
+}
 
 #[rstest]
 fn integer_field_validates_value_within_range() {
@@ -599,6 +661,147 @@ fn url_field_validates_protocol(#[case] input: &str, #[case] should_pass: bool) 
 }
 
 // ---------------------------------------------------------------------------
+// JSON field extraction
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn character_fields_convert_json_scalars_before_validation() {
+	// Arrange
+	let number = json!(42);
+	let email = json!("person@example.com");
+	let url = json!("https://example.com/path");
+	let choice = json!("active");
+
+	// Assert
+	assert_eq!(
+		CharField::new().to_internal_value(Some(&number)),
+		Ok(FieldValue::Present("42".to_owned()))
+	);
+	assert_eq!(
+		EmailField::new().to_internal_value(Some(&email)),
+		Ok(FieldValue::Present("person@example.com".to_owned()))
+	);
+	assert_eq!(
+		URLField::new().to_internal_value(Some(&url)),
+		Ok(FieldValue::Present("https://example.com/path".to_owned()))
+	);
+	assert_eq!(
+		ChoiceField::new(vec!["active".to_owned(), "inactive".to_owned()])
+			.to_internal_value(Some(&choice)),
+		Ok(FieldValue::Present("active".to_owned()))
+	);
+}
+
+#[rstest]
+fn char_field_rejects_json_boolean() {
+	// Arrange
+	let field = CharField::new();
+	let input = json!(true);
+
+	// Act
+	let result = field.to_internal_value(Some(&input));
+
+	// Assert
+	assert_eq!(
+		result,
+		Err(FieldError::Custom("Not a valid string".to_owned()))
+	);
+}
+
+#[rstest]
+fn float_and_temporal_fields_convert_json_values() {
+	// Arrange
+	let float = json!("1.5");
+	let date = json!("2026-08-20");
+	let datetime = json!("2026-08-20 12:34:56");
+
+	// Assert
+	assert_eq!(
+		FloatField::new().to_internal_value(Some(&float)),
+		Ok(FieldValue::Present(1.5))
+	);
+	assert_eq!(
+		DateField::new().to_internal_value(Some(&date)),
+		Ok(FieldValue::Present(
+			NaiveDate::from_ymd_opt(2026, 8, 20).unwrap()
+		))
+	);
+	assert_eq!(
+		DateTimeField::new().to_internal_value(Some(&datetime)),
+		Ok(FieldValue::Present(
+			NaiveDate::from_ymd_opt(2026, 8, 20)
+				.unwrap()
+				.and_hms_opt(12, 34, 56)
+				.unwrap()
+		))
+	);
+}
+
+#[rstest]
+#[case::boolean(json!(true), true)]
+#[case::one(json!(1), true)]
+#[case::uppercase_yes(json!("YES"), true)]
+#[case::false_value(json!(false), false)]
+#[case::zero(json!(0), false)]
+#[case::off(json!("off"), false)]
+fn boolean_field_converts_drf_tokens(#[case] input: Value, #[case] expected: bool) {
+	// Arrange
+	let field = BooleanField::new();
+
+	// Act
+	let result = field.to_internal_value(Some(&input));
+
+	// Assert
+	assert_eq!(result, Ok(FieldValue::Present(expected)));
+}
+
+#[rstest]
+fn converted_values_preserve_field_constraint_errors() {
+	// Arrange
+	let too_short = json!("a");
+	let too_large = json!("2.0");
+	let invalid_email = json!("invalid");
+	let invalid_url = json!("invalid");
+	let invalid_choice = json!("inactive");
+	let invalid_date = json!("invalid");
+	let invalid_datetime = json!("invalid");
+
+	// Assert
+	assert_eq!(
+		CharField::new()
+			.min_length(2)
+			.to_internal_value(Some(&too_short)),
+		Err(FieldError::TooShort(2))
+	);
+	assert_eq!(
+		FloatField::new()
+			.max_value(1.0)
+			.to_internal_value(Some(&too_large)),
+		Err(FieldError::TooLargeFloat(1.0))
+	);
+	assert_eq!(
+		EmailField::new().to_internal_value(Some(&invalid_email)),
+		Err(FieldError::InvalidEmail)
+	);
+	assert_eq!(
+		URLField::new().to_internal_value(Some(&invalid_url)),
+		Err(FieldError::InvalidUrl)
+	);
+	assert_eq!(
+		ChoiceField::new(vec!["active".to_owned()]).to_internal_value(Some(&invalid_choice)),
+		Err(FieldError::InvalidChoice)
+	);
+	assert_eq!(
+		DateField::new().to_internal_value(Some(&invalid_date)),
+		Err(FieldError::InvalidDate)
+	);
+	assert_eq!(
+		DateTimeField::new().to_internal_value(Some(&invalid_datetime)),
+		Err(FieldError::InvalidDateTime)
+	);
+}
+
+// ---------------------------------------------------------------------------
 // Default values and required/optional behavior
 // ---------------------------------------------------------------------------
 
@@ -708,6 +911,125 @@ fn validate_fields_fails_with_out_of_range_value() {
 
 	// Assert
 	assert!(result.is_err());
+}
+
+#[rstest]
+fn validate_fields_uses_registration_keys_for_reused_validator() {
+	// Arrange
+	let mut validators: HashMap<String, Box<dyn FieldValidator>> = HashMap::new();
+	validators.insert(
+		"minimum".into(),
+		Box::new(RangeValidator { min: 0, max: 10 }),
+	);
+	validators.insert(
+		"maximum".into(),
+		Box::new(RangeValidator { min: 0, max: 10 }),
+	);
+	let data = HashMap::from([
+		("minimum".to_owned(), json!(-1)),
+		("maximum".to_owned(), json!(11)),
+	]);
+
+	// Act
+	let errors = validate_fields(&data, &validators)
+		.unwrap_err()
+		.field_errors();
+
+	// Assert
+	assert_eq!(
+		errors.get("minimum"),
+		Some(&vec!["Must be between 0 and 10".to_owned()])
+	);
+	assert_eq!(
+		errors.get("maximum"),
+		Some(&vec!["Must be between 0 and 10".to_owned()])
+	);
+	assert_eq!(errors.get("value"), None);
+}
+
+#[rstest]
+fn validate_fields_accepts_built_in_fields_and_collects_all_errors() {
+	// Arrange
+	let mut validators: HashMap<String, Box<dyn FieldValidator>> = HashMap::new();
+	validators.insert("age".into(), Box::new(IntegerField::new().min_value(0)));
+	validators.insert("email".into(), Box::new(EmailField::new()));
+	let data = HashMap::from([
+		("age".to_owned(), json!(-1)),
+		("email".to_owned(), json!("invalid")),
+	]);
+
+	// Act
+	let errors = validate_fields(&data, &validators)
+		.unwrap_err()
+		.field_errors();
+
+	// Assert
+	assert_eq!(errors.len(), 2);
+	assert_eq!(
+		errors.get("age"),
+		Some(&vec!["Value is too small (min: 0)".to_owned()])
+	);
+	assert_eq!(
+		errors.get("email"),
+		Some(&vec!["Enter a valid email address".to_owned()])
+	);
+}
+
+struct MultipleErrorValidator;
+
+impl FieldValidator for MultipleErrorValidator {
+	fn validate(&self, _: &Value) -> ValidationResult {
+		Err(ValidationError::multiple(vec![
+			ValidationError::object_error("First message"),
+			ValidationError::multiple(vec![
+				ValidationError::field_error("ignored", "Second message"),
+				ValidationError::object_error("Third message"),
+			]),
+		]))
+	}
+}
+
+#[rstest]
+fn validate_fields_replaces_nested_error_keys_and_preserves_message_order() {
+	// Arrange
+	let validators = HashMap::from([(
+		"registered".to_owned(),
+		Box::new(MultipleErrorValidator) as Box<dyn FieldValidator>,
+	)]);
+	let data = HashMap::from([("registered".to_owned(), json!(true))]);
+
+	// Act
+	let errors = validate_fields(&data, &validators)
+		.unwrap_err()
+		.field_errors();
+
+	// Assert
+	assert_eq!(errors.len(), 1);
+	assert_eq!(
+		errors.get("registered"),
+		Some(&vec![
+			"First message".to_owned(),
+			"Second message".to_owned(),
+			"Third message".to_owned(),
+		])
+	);
+	assert_eq!(errors.get("ignored"), None);
+}
+
+#[rstest]
+fn field_errors_omits_standalone_object_errors() {
+	// Arrange
+	let error = ValidationError::multiple(vec![
+		ValidationError::object_error("Object message"),
+		ValidationError::multiple(vec![ValidationError::field_error("email", "Invalid")]),
+	]);
+
+	// Act
+	let errors = error.field_errors();
+
+	// Assert
+	assert_eq!(errors.len(), 1);
+	assert_eq!(errors.get("email"), Some(&vec!["Invalid".to_owned()]));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/reinhardt-core/tests/serializers_integration.rs
+++ b/crates/reinhardt-core/tests/serializers_integration.rs
@@ -168,6 +168,52 @@ fn integer_field_rejects_invalid_json_type(#[case] input: Value) {
 }
 
 #[rstest]
+fn integer_field_rejects_lossy_floating_integers() {
+	// Arrange
+	let field = IntegerField::new();
+	let oversized_mantissa: Value =
+		serde_json::from_str("9007199254740993.0").expect("lossy mantissa JSON");
+	let below_i64_min: Value =
+		serde_json::from_str("-9223372036854775809.0").expect("below i64::MIN JSON");
+
+	// Act and Assert
+	assert_eq!(
+		field.to_internal_value(Some(&oversized_mantissa)),
+		Err(FieldError::Custom("A valid integer is required".to_owned()))
+	);
+	assert_eq!(
+		field.to_internal_value(Some(&below_i64_min)),
+		Err(FieldError::Custom("A valid integer is required".to_owned()))
+	);
+}
+
+#[rstest]
+fn integer_field_accepts_exact_json_integers_beyond_float_mantissa() {
+	// Arrange
+	let field = IntegerField::new();
+	let input = json!(9_007_199_254_740_993_i64);
+
+	// Act
+	let result = field.to_internal_value(Some(&input));
+
+	// Assert
+	assert_eq!(result, Ok(FieldValue::Present(9_007_199_254_740_993)));
+}
+
+#[rstest]
+fn integer_field_accepts_safe_whole_float_at_f64_mantissa_limit() {
+	// Arrange
+	let field = IntegerField::new();
+	let input = json!(9_007_199_254_740_992.0);
+
+	// Act
+	let result = field.to_internal_value(Some(&input));
+
+	// Assert
+	assert_eq!(result, Ok(FieldValue::Present(9_007_199_254_740_992)));
+}
+
+#[rstest]
 fn integer_field_applies_constraints_after_conversion() {
 	// Arrange
 	let field = IntegerField::new().min_value(0);

--- a/crates/reinhardt-rest/README.md
+++ b/crates/reinhardt-rest/README.md
@@ -464,6 +464,8 @@ let response = result.into_api_response();
 - **`FieldError`**: Comprehensive error types for field validation failures
   - 14 error variants covering all validation scenarios
   - Display implementation for user-friendly error messages
+- **`SerializerFieldValue`**: Presence-aware JSON extraction result (`Absent` / `Null` / `Present`)
+  - Distinct from arena `FieldValue` to avoid a name collision on the REST facade
 - **`CharField`**: String field with length validation
   - Builder pattern with `min_length()`, `max_length()`, `required()`, `allow_blank()`
   - Default value support
@@ -524,6 +526,7 @@ let response = result.into_api_response();
 
 - **`FieldValidator` trait**: Field-level validation
   - `validate()`: Validate individual field values
+  - `is_required()`: Whether omitted keys fail `validate_fields` (built-in fields honor `required`)
   - Implemented by custom validators (EmailValidator, AgeValidator, etc.)
   - JSON Value-based validation
 

--- a/crates/reinhardt-rest/src/serializers.rs
+++ b/crates/reinhardt-rest/src/serializers.rs
@@ -207,6 +207,26 @@ pub use reinhardt_core::serializers::{
 	},
 };
 
+/// Presence-aware serializer field value (`Absent` / `Null` / `Present`).
+///
+/// Re-exported under this name because [`FieldValue`] already refers to the
+/// arena serialization enum in this module.
+///
+/// # Example
+///
+/// ```rust
+/// use reinhardt_rest::serializers::{IntegerField, SerializerFieldValue};
+/// use serde_json::json;
+///
+/// let field = IntegerField::new();
+/// assert_eq!(
+///     field.to_internal_value(Some(&json!(3))),
+///     Ok(SerializerFieldValue::Present(3)),
+/// );
+/// assert_eq!(field.to_internal_value(None), Ok(SerializerFieldValue::Absent));
+/// ```
+pub use reinhardt_core::serializers::fields::FieldValue as SerializerFieldValue;
+
 // REST-specific modules (ORM-integrated features)
 /// Cache invalidation strategies for serialized data.
 pub mod cache_invalidation;

--- a/crates/reinhardt-rest/tests/serializers_integration.rs
+++ b/crates/reinhardt-rest/tests/serializers_integration.rs
@@ -15,9 +15,9 @@ use reinhardt_db::orm::{FieldSelector, Model};
 use reinhardt_rest::serializers::{
 	BooleanField, CharField, EmailField, FieldError, FloatField, HyperlinkedRelatedField,
 	IntegerField, JsonSerializer, ManyRelatedField, ModelLevelValidator, ModelSerializer,
-	PrimaryKeyRelatedField, RelationField, Serializer, SerializerError, SerializerMethodField,
-	SlugRelatedField, StringRelatedField, URLField, UniqueTogetherValidator, UniqueValidator,
-	ValidationError, ValidatorError, WritableNestedSerializer,
+	PrimaryKeyRelatedField, RelationField, Serializer, SerializerError, SerializerFieldValue,
+	SerializerMethodField, SlugRelatedField, StringRelatedField, URLField, UniqueTogetherValidator,
+	UniqueValidator, ValidationError, ValidatorError, WritableNestedSerializer,
 	introspection::{FieldInfo, FieldIntrospector},
 	meta::{DefaultMeta, MetaConfig, SerializerMeta},
 	method_field::{MethodFieldError, MethodFieldRegistry},
@@ -395,6 +395,20 @@ fn boolean_field_false_value() {
 
 	// Assert
 	assert_eq!(result, Ok(()));
+}
+
+#[rstest]
+fn serializer_field_value_is_usable_from_rest_facade() {
+	// Arrange
+	let field = IntegerField::new();
+
+	// Act
+	let present = field.to_internal_value(Some(&json!(3)));
+	let absent = field.to_internal_value(None);
+
+	// Assert
+	assert_eq!(present, Ok(SerializerFieldValue::Present(3)));
+	assert_eq!(absent, Ok(SerializerFieldValue::Absent));
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds presence-aware JSON extraction for all built-in serializer fields, preserving `Absent`, `Null`, and `Present(T)`.
- Reuses existing field constraints and DRF-compatible scalar coercions without changing existing validation APIs.
- Preserves validator registration keys and exposes `{field: [messages]}` aggregation for all field failures.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Serializer consumers previously had to duplicate JSON coercion and could not distinguish an absent key from explicit `null`. Aggregate validation also discarded the field key, and built-in serializer fields could not participate in `validate_fields`.

Fixes #6082
Fixes #6083

## How Was This Tested?

- `cargo test -p reinhardt-core --all-features` (passed)
- `cargo clippy -p reinhardt-core --all-features --lib -- -D warnings` (passed)
- `cargo clippy -p reinhardt-core --all-features --test serializers_integration -- -D warnings` (passed)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p reinhardt-core --all-features --no-deps` (passed)
- `cargo fmt --all -- --check` and `git diff --check` (passed)
- `cargo test --workspace --all-features` (19 `reinhardt-admin` E2E tests blocked locally by a missing `/var/run/docker.sock`; unrelated to serializer changes)

## Performance Impact

- Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable; not applicable)
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [x] I have checked the code with `cargo clippy`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- `Fixes #6082`
- `Fixes #6083`

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement

### Additional Labels (apply alongside type label when applicable)
- None

### Scope Label (select all that apply)
- [x] `api` - REST API, serializers, views

### Priority Label (for maintainers)
- Maintainers may apply the issue priority label.

---

**Additional Context:**

- The affected `reinhardt-core` crate is green under tests, clippy, rustdoc, and formatting checks.
- Full workspace E2E execution requires a valid TestContainers Docker socket; the local `/var/run/docker.sock` target is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)