### PR TITLE
fix(security): allow the retained h2 0.3 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ ignore = [
   { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.31 is retained by Azure SDK dependencies and quick-xml 0.38 remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2026-0195", reason = "quick-xml 0.31 is retained by Azure SDK dependencies and quick-xml 0.38 remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2026-0249", reason = "smartstring is retained transitively by rhai 1.25.1; no patched release exists, and remediation is tracked in issue #5492." },
+  { id = "RUSTSEC-2026-0258", reason = "h2 0.3.27 is retained by hyper 0.14 consumers; migration to the patched h2 0.4 line is tracked in issue #6081." },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

This PR addresses:

- Restore the Security Audit check for the full-feature workspace graph by documenting a narrow temporary exception for `RUSTSEC-2026-0258`.
- Keep the exception scoped to the retained `h2 0.3.27` dependency.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither adds a feature nor fixes a bug)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The Security Audit began reporting `RUSTSEC-2026-0258` for `h2 0.3.27`, which remains in the workspace through `hyper 0.14` consumers. The advisory is patched only in `h2 >=0.4.16`, while migration of the retained dependency line is tracked in #6081. This keeps the required exception explicit and removable without hiding unrelated advisories.

## How Was This Tested?

- [x] `cargo deny --workspace --all-features check all`
- [x] `cargo make fmt-check`
- [x] `git diff --check`
- Unit and integration tests are not applicable because this is a one-line dependency-policy configuration change.

## Performance Impact

None.

## Breaking Changes

None.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the policy documentation in `deny.toml`
- [x] My changes generate no new warnings
- [x] My changes are limited to dependency-policy configuration
- [x] I have formatted the code with `cargo make fmt-check`
- [x] I have checked the affected policy with `cargo deny`
- [ ] I use self-hosted runner for CI

## Related Issues

- #6081 tracks migration from the vulnerable `h2 0.3` line.
- #6097 and #6098 currently expose the same Security Audit failure.

## Labels to Apply

### Type Label

- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels

- [ ] `breaking-change` - Breaking change

### Scope Label

- [x] `ci-cd` - CI/CD workflow issues

### Priority Label

- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix
- [x] `medium` - Normal security-policy maintenance
- [ ] `low` - Minor fix/enhancement

---

**Additional Context:**

This PR intentionally does not close #6081: it records the temporary exception until the `hyper 0.14` dependency path can migrate to the patched `h2 0.4` line. The exception should be removed when that migration is complete.

🤖 Generated with [Codex](https://openai.com/codex)
