### PR TITLE
fix(ci): drop unused cargo-deny exceptions

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -17,11 +17,4 @@ ignore = [
 	"RUSTSEC-2026-0098",
 	"RUSTSEC-2026-0099",
 	"RUSTSEC-2026-0104",
-
-	# Direct quick-xml dependencies are pinned to 0.41.0. Remaining vulnerable
-	# quick-xml versions are held by upstream crates that have not yet admitted
-	# 0.41.x: legacy azure_core 0.21, Azure SDK 1.0 typespec XML support, and
-	# plist 1.9 through syntect, plus phonenumber 0.3.x validator metadata.
-	"RUSTSEC-2026-0194",
-	"RUSTSEC-2026-0195",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -30,9 +30,6 @@ ignore = [
   { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile remains a direct commands dependency and is also retained transitively; remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2024-0320", reason = "yaml-rust is retained by transitive configuration dependencies; remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2022-0081", reason = "evcxr 0.21.1 requires unmaintained json 0.12.4; replacement is tracked in evcxr/evcxr#489 and issue #5825." },
-  { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.31 is retained by Azure SDK dependencies and quick-xml 0.38 remediation is tracked in issue #5492." },
-  { id = "RUSTSEC-2026-0195", reason = "quick-xml 0.31 is retained by Azure SDK dependencies and quick-xml 0.38 remediation is tracked in issue #5492." },
-  { id = "RUSTSEC-2026-0249", reason = "smartstring is retained transitively by rhai 1.25.1; no patched release exists, and remediation is tracked in issue #5492." },
   { id = "RUSTSEC-2026-0258", reason = "h2 0.3.27 is retained by hyper 0.14 consumers; migration to the patched h2 0.4 line is tracked in issue #6081." },
 ]
 
@@ -122,10 +119,8 @@ skip = [
   { crate = "reqwest@0.11.27", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "reqwest@0.12.28", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "ring@0.16.20", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
-  { crate = "rustc_version@0.2.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "rustls-pemfile@1.0.4", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "self_cell@0.10.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
-  { crate = "semver@0.9.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "serde_spanned@0.6.9", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "sha1:>=0.10,<0.11", reason = "Upstream dependencies retain sha1 0.10 while AWS SDK components use sha1 0.11." },
   { crate = "simple_asn1@0.4.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
@@ -198,7 +193,6 @@ skip = [
   { crate = "sha2@0.10.9", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "socket2@0.5.10", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "syn@1.0.109", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
-  { crate = "syn:>=2,<3", reason = "Workspace macro crates use syn 2 while upstream proc-macro dependencies retain the incompatible syn 3 line." },
   { crate = "thiserror-impl@1.0.69", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "thiserror@1.0.69", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "tokio-rustls@0.24.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses:

- Remove stale `cargo-deny` advisory ignores that no longer match the `develop/0.4.0` dependency graph.
- Remove unused duplicate-crate skips and a duplicated `syn` skip entry.
- Keep `.cargo/audit.toml` aligned with the remaining advisory exceptions.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`cargo deny --workspace --all-features check all` on `develop/0.4.0` reported:

- `advisory-not-detected` for `RUSTSEC-2026-0194`, `RUSTSEC-2026-0195`, and `RUSTSEC-2026-0249` (`quick-xml` is now `0.41.0` and `smartstring` has left the graph)
- `unmatched-skip` for `rustc_version@0.2.3` and `semver@0.9.0`
- a duplicated `syn:>=2,<3` skip

Leaving those exceptions in place produces cargo-deny warnings and hides whether new unused exceptions appear later (`unused-ignored-advisory = "warn"`).

Related to: #5492, #6000, #6081

## How Was This Tested?

- [x] `cargo deny --workspace --all-features check all`
- [x] `cargo deny --workspace --all-features check all -D unmatched-skip -D advisory-not-detected`
- [x] `git diff --check`
- Unit and integration tests are not applicable because this is a dependency-policy configuration change.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage (AWS Spot instances),
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #5492 tracks remaining dependency-advisory remediation.
- #6000 established the unused cargo-deny exception cleanup pattern.
- #6081 tracks migration off the retained `h2 0.3` line, which remains ignored.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The Security Audit job on current `develop/0.4.0` already passed with warnings. This PR removes the unused exceptions so the gate stays warning-free and the remaining ignores stay accurate.

🤖 Generated with [Cursor](https://cursor.com)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a021e0-b468-76a7-96cd-07218e29d392?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a021e0-b468-76a7-96cd-07218e29d392&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

