### PR TITLE
fix(admin): bind typed date, time, and decimal filter values

### DIFF
--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -117,6 +117,7 @@ reinhardt-testkit = { path = "../reinhardt-testkit" }
 tokio = { workspace = true, features = ["full"] }
 tokio-test = { workspace = true }
 rstest = { workspace = true }
+rust_decimal = { workspace = true }
 sqlx = { workspace = true, features = ["postgres", "runtime-tokio-native-tls"] }
 # Pin to avoid build failure in native-tls 0.2.17 (non-exhaustive pattern in openssl.rs)
 native-tls = { workspace = true }

--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -1965,6 +1965,64 @@ mod tests {
 	}
 
 	#[rstest]
+	fn test_filter_value_to_sea_value_preserves_date_binding() {
+		// Arrange
+		let date = chrono::NaiveDate::from_ymd_opt(2026, 8, 21).expect("date should be valid");
+		let value = FilterValue::Date(date);
+
+		// Act
+		let sea_value = filter_value_to_sea_value(&value);
+
+		// Assert
+		assert_eq!(sea_value, Value::ChronoDate(Some(Box::new(date))));
+	}
+
+	#[rstest]
+	fn test_filter_value_to_sea_value_preserves_time_binding() {
+		// Arrange
+		let time = chrono::NaiveTime::from_hms_opt(13, 37, 0).expect("time should be valid");
+		let value = FilterValue::Time(time);
+
+		// Act
+		let sea_value = filter_value_to_sea_value(&value);
+
+		// Assert
+		assert_eq!(sea_value, Value::ChronoTime(Some(Box::new(time))));
+	}
+
+	#[rstest]
+	fn test_filter_value_to_sea_value_preserves_naive_datetime_binding() {
+		// Arrange
+		let naive_datetime = chrono::NaiveDateTime::new(
+			chrono::NaiveDate::from_ymd_opt(2026, 8, 21).expect("date should be valid"),
+			chrono::NaiveTime::from_hms_opt(13, 37, 0).expect("time should be valid"),
+		);
+		let value = FilterValue::NaiveDateTime(naive_datetime);
+
+		// Act
+		let sea_value = filter_value_to_sea_value(&value);
+
+		// Assert
+		assert_eq!(
+			sea_value,
+			Value::ChronoDateTime(Some(Box::new(naive_datetime)))
+		);
+	}
+
+	#[rstest]
+	fn test_filter_value_to_sea_value_preserves_decimal_binding() {
+		// Arrange
+		let decimal = rust_decimal::Decimal::new(125, 2);
+		let value = FilterValue::Decimal(decimal);
+
+		// Act
+		let sea_value = filter_value_to_sea_value(&value);
+
+		// Assert
+		assert_eq!(sea_value, Value::Decimal(Some(Box::new(decimal))));
+	}
+
+	#[rstest]
 	fn test_filter_value_to_sea_value_preserves_uuid_binding() {
 		// Arrange
 		let uuid =
@@ -2038,6 +2096,29 @@ mod tests {
 		assert!(matches!(
 			filter_value_to_sea_value(&FilterValue::Uuid(uuid)),
 			Value::Uuid(Some(_))
+		));
+		assert!(matches!(
+			filter_value_to_sea_value(&FilterValue::Date(
+				chrono::NaiveDate::from_ymd_opt(2026, 8, 21).expect("date fixture should parse")
+			)),
+			Value::ChronoDate(Some(_))
+		));
+		assert!(matches!(
+			filter_value_to_sea_value(&FilterValue::Time(
+				chrono::NaiveTime::from_hms_opt(13, 37, 0).expect("time fixture should parse")
+			)),
+			Value::ChronoTime(Some(_))
+		));
+		assert!(matches!(
+			filter_value_to_sea_value(&FilterValue::NaiveDateTime(chrono::NaiveDateTime::new(
+				chrono::NaiveDate::from_ymd_opt(2026, 8, 21).expect("date fixture should parse"),
+				chrono::NaiveTime::from_hms_opt(13, 37, 0).expect("time fixture should parse"),
+			))),
+			Value::ChronoDateTime(Some(_))
+		));
+		assert!(matches!(
+			filter_value_to_sea_value(&FilterValue::Decimal(rust_decimal::Decimal::new(125, 2))),
+			Value::Decimal(Some(_))
 		));
 	}
 

--- a/crates/reinhardt-admin/src/core/database.rs
+++ b/crates/reinhardt-admin/src/core/database.rs
@@ -196,6 +196,10 @@ pub fn filter_value_to_sea_value(v: &FilterValue) -> Value {
 	match v {
 		FilterValue::String(s) => s.clone().into(),
 		FilterValue::Timestamp(value) => (*value).into(),
+		FilterValue::Date(value) => (*value).into(),
+		FilterValue::Time(value) => (*value).into(),
+		FilterValue::NaiveDateTime(value) => (*value).into(),
+		FilterValue::Decimal(value) => (*value).into(),
 		FilterValue::Uuid(value) => (*value).into(),
 		FilterValue::Integer(i) | FilterValue::Int(i) => (*i).into(),
 		FilterValue::Float(f) => (*f).into(),

--- a/tests/integration/tests/admin/admin_database_tests.rs
+++ b/tests/integration/tests/admin/admin_database_tests.rs
@@ -845,6 +845,64 @@ fn test_filter_value_to_sea_value_preserves_timestamp() {
 }
 
 #[rstest]
+fn test_filter_value_to_sea_value_preserves_date() {
+	// Arrange
+	let date = chrono::NaiveDate::from_ymd_opt(2026, 8, 21).unwrap();
+	let value = FilterValue::Date(date);
+
+	// Act
+	let sea_value = filter_value_to_sea_value(&value);
+
+	// Assert
+	assert_eq!(sea_value, Value::ChronoDate(Some(Box::new(date))));
+}
+
+#[rstest]
+fn test_filter_value_to_sea_value_preserves_time() {
+	// Arrange
+	let time = chrono::NaiveTime::from_hms_opt(13, 37, 0).unwrap();
+	let value = FilterValue::Time(time);
+
+	// Act
+	let sea_value = filter_value_to_sea_value(&value);
+
+	// Assert
+	assert_eq!(sea_value, Value::ChronoTime(Some(Box::new(time))));
+}
+
+#[rstest]
+fn test_filter_value_to_sea_value_preserves_naive_datetime() {
+	// Arrange
+	let naive_datetime = chrono::NaiveDateTime::new(
+		chrono::NaiveDate::from_ymd_opt(2026, 8, 21).unwrap(),
+		chrono::NaiveTime::from_hms_opt(13, 37, 0).unwrap(),
+	);
+	let value = FilterValue::NaiveDateTime(naive_datetime);
+
+	// Act
+	let sea_value = filter_value_to_sea_value(&value);
+
+	// Assert
+	assert_eq!(
+		sea_value,
+		Value::ChronoDateTime(Some(Box::new(naive_datetime)))
+	);
+}
+
+#[rstest]
+fn test_filter_value_to_sea_value_preserves_decimal() {
+	// Arrange
+	let decimal = rust_decimal::Decimal::new(125, 2);
+	let value = FilterValue::Decimal(decimal);
+
+	// Act
+	let sea_value = filter_value_to_sea_value(&value);
+
+	// Assert
+	assert_eq!(sea_value, Value::Decimal(Some(Box::new(decimal))));
+}
+
+#[rstest]
 fn test_filter_value_to_sea_value_preserves_uuid() {
 	// Arrange
 	let uuid = uuid::Uuid::parse_str("f4d95b59-b868-4f78-8f63-240aa6bca90f").unwrap();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Superseded by #6101.** That PR already adds the same `FilterValue::{Date, Time, NaiveDateTime, Decimal}` arms in `crates/reinhardt-admin/src/core/database.rs`, which is the compile failure that blocked release PR #6104.

Do not merge this PR unless #6101 is closed without landing the admin conversion arms.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

Related to: #6101, #6104

## How Was This Tested?

See #6101.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Duplicate of #6101
- Original CI failure: #6104

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a021f7-15b1-7b65-b8c2-dbe1ea24765b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a021f7-15b1-7b65-b8c2-dbe1ea24765b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

