### PR TITLE
fix(orm): reject tautological WHERE on delete and update

### DIFF
--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -142,6 +142,18 @@ pub enum FilterValue {
 	OuterRef(super::expressions::OuterRef),
 }
 
+impl FilterValue {
+	/// Return whether this value compiles as an empty `IN` / `NOT IN` collection.
+	fn is_empty_membership_collection(&self) -> bool {
+		match self {
+			Self::List(values) => values.is_empty(),
+			Self::Array(values) => values.is_empty(),
+			Self::String(s) => parse_membership_string(s).is_empty(),
+			_ => false,
+		}
+	}
+}
+
 #[derive(Debug, Clone)]
 enum FilterField {
 	Column,
@@ -242,6 +254,23 @@ impl Filter {
 			operator,
 			value,
 		}
+	}
+
+	/// Return whether this filter compiles to a tautology (`TRUE`).
+	///
+	/// Empty `NOT IN` collections are rewritten as `TRUE` because `x NOT IN ()`
+	/// is invalid SQL and logically matches every row.
+	fn is_always_true(&self) -> bool {
+		matches!(self.operator, FilterOperator::NotIn)
+			&& self.value.is_empty_membership_collection()
+	}
+
+	/// Return whether this filter compiles to a contradiction (`FALSE`).
+	///
+	/// Empty `IN` collections are rewritten as `FALSE` because `x IN ()` is
+	/// invalid SQL and logically matches no rows.
+	fn is_always_false(&self) -> bool {
+		matches!(self.operator, FilterOperator::In) && self.value.is_empty_membership_collection()
 	}
 }
 
@@ -526,11 +555,11 @@ impl FilterCondition {
 	/// Return whether this condition is a tautology (matches every row).
 	///
 	/// Empty `AND` is vacuously true. Empty `OR` is false. `NOT` of a contradiction
-	/// is a tautology. Leaf [`FilterCondition::Single`] values are never treated as
-	/// constant, even when they could theoretically be rewritten as `TRUE`.
+	/// is a tautology. Empty `NOT IN` collections compile to `TRUE` and are treated
+	/// as tautologies, including when wrapped in [`FilterCondition::Single`].
 	fn is_always_true(&self) -> bool {
 		match self {
-			FilterCondition::Single(_) => false,
+			FilterCondition::Single(filter) => filter.is_always_true(),
 			FilterCondition::And(conditions) => conditions.iter().all(Self::is_always_true),
 			FilterCondition::Or(conditions) => {
 				!conditions.is_empty() && conditions.iter().any(Self::is_always_true)
@@ -542,7 +571,7 @@ impl FilterCondition {
 	/// Return whether this condition is a contradiction (matches no rows).
 	fn is_always_false(&self) -> bool {
 		match self {
-			FilterCondition::Single(_) => false,
+			FilterCondition::Single(filter) => filter.is_always_false(),
 			FilterCondition::And(conditions) => {
 				!conditions.is_empty() && conditions.iter().any(Self::is_always_false)
 			}
@@ -571,6 +600,46 @@ impl From<Filter> for FilterCondition {
 	fn from(filter: Filter) -> Self {
 		Self::Single(filter)
 	}
+}
+
+/// Parse a membership-list string into query values.
+///
+/// Supports JSON arrays and comma-separated values. An empty result compiles to
+/// `FALSE` for `IN` and `TRUE` for `NOT IN`.
+fn parse_membership_string(s: &str) -> Vec<reinhardt_query::value::Value> {
+	let trimmed = s.trim();
+
+	// Try parsing as JSON array first
+	if trimmed.starts_with('[')
+		&& trimmed.ends_with(']')
+		&& let Ok(arr) = serde_json::from_str::<Vec<serde_json::Value>>(trimmed)
+	{
+		return arr
+			.iter()
+			.map(|v| match v {
+				serde_json::Value::String(s) => s.clone().into(),
+				serde_json::Value::Number(n) => {
+					if let Some(i) = n.as_i64() {
+						i.into()
+					} else if let Some(f) = n.as_f64() {
+						f.into()
+					} else {
+						n.to_string().into()
+					}
+				}
+				serde_json::Value::Bool(b) => (*b).into(),
+				_ => v.to_string().into(),
+			})
+			.collect();
+	}
+
+	// Fallback to comma-separated parsing
+	trimmed
+		.split(',')
+		.map(|s| s.trim())
+		.filter(|s| !s.is_empty())
+		.map(|s| s.to_string().into())
+		.collect()
 }
 
 // From implementations for FilterValue
@@ -1075,15 +1144,18 @@ where
 	/// Return whether the queryset has a WHERE predicate that can exclude rows.
 	///
 	/// Composite filters may still be present while compiling to `TRUE` (empty
-	/// `AND` is vacuously true). DELETE and UPDATE must reject that case so a
-	/// tautology cannot wipe or rewrite the whole table.
+	/// `AND` is vacuously true; empty `NOT IN` is rewritten as `TRUE`). DELETE
+	/// and UPDATE must reject that case so a tautology cannot wipe or rewrite
+	/// the whole table.
 	fn has_restricting_where_predicates(&self) -> bool {
-		if !self.filters.is_empty() || !self.subquery_conditions.is_empty() {
+		if !self.subquery_conditions.is_empty() {
 			return true;
 		}
-		self.filter_conditions
-			.iter()
-			.any(|condition| !condition.is_always_true())
+		self.filters.iter().any(|filter| !filter.is_always_true())
+			|| self
+				.filter_conditions
+				.iter()
+				.any(|condition| !condition.is_always_true())
 	}
 
 	fn outer_reference_fields(&self) -> Vec<String> {
@@ -3142,7 +3214,7 @@ where
 				(FilterOperator::Lt, v) => col.lt(Self::filter_value_to_sea_value(v)),
 				(FilterOperator::Lte, v) => col.lte(Self::filter_value_to_sea_value(v)),
 				(FilterOperator::In, FilterValue::String(s)) => {
-					let values = Self::parse_array_string(s);
+					let values = parse_membership_string(s);
 					col.is_in(values)
 				}
 				(FilterOperator::In, FilterValue::Array(arr)) => {
@@ -3155,7 +3227,7 @@ where
 						.collect::<Vec<_>>(),
 				),
 				(FilterOperator::NotIn, FilterValue::String(s)) => {
-					let values = Self::parse_array_string(s);
+					let values = parse_membership_string(s);
 					col.is_not_in(values)
 				}
 				(FilterOperator::NotIn, FilterValue::Array(arr)) => {
@@ -3711,50 +3783,12 @@ where
 		}
 	}
 
-	/// Parse array string into `Vec<reinhardt_query::value::Value>`
-	/// Supports comma-separated values or JSON array format
-	fn parse_array_string(s: &str) -> Vec<reinhardt_query::value::Value> {
-		let trimmed = s.trim();
-
-		// Try parsing as JSON array first
-		if trimmed.starts_with('[')
-			&& trimmed.ends_with(']')
-			&& let Ok(arr) = serde_json::from_str::<Vec<serde_json::Value>>(trimmed)
-		{
-			return arr
-				.iter()
-				.map(|v| match v {
-					serde_json::Value::String(s) => s.clone().into(),
-					serde_json::Value::Number(n) => {
-						if let Some(i) = n.as_i64() {
-							i.into()
-						} else if let Some(f) = n.as_f64() {
-							f.into()
-						} else {
-							n.to_string().into()
-						}
-					}
-					serde_json::Value::Bool(b) => (*b).into(),
-					_ => v.to_string().into(),
-				})
-				.collect();
-		}
-
-		// Fallback to comma-separated parsing
-		trimmed
-			.split(',')
-			.map(|s| s.trim())
-			.filter(|s| !s.is_empty())
-			.map(|s| s.to_string().into())
-			.collect()
-	}
-
 	/// Convert FilterValue to array of reinhardt_query::value::Value
 	// Allow dead_code: internal conversion for IN clause array parameter binding
 	#[allow(dead_code)]
 	fn value_to_array(v: &FilterValue) -> Vec<reinhardt_query::value::Value> {
 		match v {
-			FilterValue::String(s) => Self::parse_array_string(s),
+			FilterValue::String(s) => parse_membership_string(s),
 			FilterValue::Timestamp(value) => vec![(*value).into()],
 			FilterValue::Date(value) => vec![(*value).into()],
 			FilterValue::Time(value) => vec![(*value).into()],
@@ -5076,8 +5110,9 @@ where
 	/// Generate an UPDATE statement for field assignments on rows matched by this `QuerySet`.
 	///
 	/// Unlike [`QuerySet::update_query`], this public partial-update builder validates
-	/// that at least one non-empty predicate is present so callers cannot
-	/// accidentally update every row in the model table.
+	/// that at least one restricting predicate is present so callers cannot
+	/// accidentally update every row in the model table. Empty `AND` and empty
+	/// `NOT IN` collections compile to `TRUE` and are rejected.
 	pub fn update_fields_query<I, A>(
 		&self,
 		values: I,
@@ -5319,9 +5354,10 @@ where
 	///
 	/// # Safety
 	///
-	/// This method will panic if no filters are set, or if every composite filter is a
-	/// tautology (for example an empty `AND`), to prevent accidental deletion of all rows.
-	/// Always use `.filter()` with a restricting predicate before calling this method.
+	/// This method will panic if no filters are set, or if every filter is a tautology
+	/// (for example an empty `AND` or an empty `NOT IN` collection), to prevent
+	/// accidental deletion of all rows. Always use `.filter()` with a restricting
+	/// predicate before calling this method.
 	///
 	/// # Examples
 	///
@@ -7435,6 +7471,25 @@ mod tests {
 		));
 	}
 
+	#[test]
+	fn test_update_fields_sql_rejects_empty_not_in_predicate() {
+		let queryset = QuerySet::<TestUser>::new().filter(Filter::new(
+			"id".to_string(),
+			FilterOperator::NotIn,
+			FilterValue::List(vec![]),
+		));
+
+		let error = queryset
+			.update_fields_sql([("username", "alice")])
+			.expect_err("empty NOT IN predicate should fail");
+
+		assert!(matches!(
+			error,
+			reinhardt_core::exception::Error::Validation(message)
+				if message == "QuerySet::update_fields requires at least one non-empty filter predicate"
+		));
+	}
+
 	#[tokio::test]
 	async fn test_queryset_create_with_manager() {
 		// Test QuerySet::create() with explicit manager
@@ -7703,6 +7758,97 @@ mod tests {
 	}
 
 	#[test]
+	#[should_panic(
+		expected = "DELETE without WHERE clause is not allowed. Use .filter() to specify which rows to delete."
+	)]
+	fn test_delete_sql_with_empty_not_in_list_panics() {
+		let queryset = QuerySet::<TestUser>::new().filter(Filter::new(
+			"id".to_string(),
+			FilterOperator::NotIn,
+			FilterValue::List(vec![]),
+		));
+		let _ = queryset.delete_sql();
+	}
+
+	#[test]
+	#[should_panic(
+		expected = "DELETE without WHERE clause is not allowed. Use .filter() to specify which rows to delete."
+	)]
+	fn test_delete_sql_with_empty_not_in_array_panics() {
+		let queryset = QuerySet::<TestUser>::new().filter(Filter::new(
+			"id".to_string(),
+			FilterOperator::NotIn,
+			FilterValue::Array(vec![]),
+		));
+		let _ = queryset.delete_sql();
+	}
+
+	#[test]
+	#[should_panic(
+		expected = "DELETE without WHERE clause is not allowed. Use .filter() to specify which rows to delete."
+	)]
+	fn test_delete_sql_with_empty_not_in_single_condition_panics() {
+		let queryset = QuerySet::<TestUser>::new().filter(FilterCondition::and(vec![
+			FilterCondition::Single(Filter::new(
+				"id".to_string(),
+				FilterOperator::NotIn,
+				FilterValue::List(vec![]),
+			)),
+		]));
+		let _ = queryset.delete_sql();
+	}
+
+	#[test]
+	#[should_panic(
+		expected = "DELETE without WHERE clause is not allowed. Use .filter() to specify which rows to delete."
+	)]
+	fn test_delete_sql_with_not_empty_in_panics() {
+		let queryset = QuerySet::<TestUser>::new().filter(FilterCondition::not(Filter::new(
+			"id".to_string(),
+			FilterOperator::In,
+			FilterValue::List(vec![]),
+		)));
+		let _ = queryset.delete_sql();
+	}
+
+	#[test]
+	fn test_delete_sql_with_empty_in_list_matches_no_rows() {
+		let queryset = QuerySet::<TestUser>::new().filter(Filter::new(
+			"id".to_string(),
+			FilterOperator::In,
+			FilterValue::List(vec![]),
+		));
+
+		let (sql, params) = queryset.delete_sql();
+
+		assert_eq!(sql, r#"DELETE FROM "test_users" WHERE FALSE"#);
+		assert!(params.is_empty());
+	}
+
+	#[test]
+	fn test_delete_sql_keeps_real_filter_beside_empty_not_in() {
+		let queryset = QuerySet::<TestUser>::new()
+			.filter(Filter::new(
+				"id".to_string(),
+				FilterOperator::Eq,
+				FilterValue::Integer(1),
+			))
+			.filter(Filter::new(
+				"id".to_string(),
+				FilterOperator::NotIn,
+				FilterValue::List(vec![]),
+			));
+
+		let (sql, params) = queryset.delete_sql();
+
+		assert_eq!(
+			sql,
+			r#"DELETE FROM "test_users" WHERE ("id" = $1 AND TRUE)"#
+		);
+		assert_eq!(params, vec!["1"]);
+	}
+
+	#[test]
 	fn test_empty_and_filter_condition_is_always_true() {
 		assert!(FilterCondition::and(Vec::new()).is_always_true());
 		assert!(!FilterCondition::and(Vec::new()).is_always_false());
@@ -7710,6 +7856,31 @@ mod tests {
 		assert!(FilterCondition::or(Vec::new()).is_always_false());
 		assert!(!FilterCondition::not(FilterCondition::and(Vec::new())).is_always_true());
 		assert!(FilterCondition::not(FilterCondition::and(Vec::new())).is_always_false());
+
+		let empty_not_in = Filter::new(
+			"id".to_string(),
+			FilterOperator::NotIn,
+			FilterValue::List(vec![]),
+		);
+		assert!(empty_not_in.is_always_true());
+		assert!(!empty_not_in.is_always_false());
+		assert!(FilterCondition::Single(empty_not_in.clone()).is_always_true());
+		assert!(!FilterCondition::Single(empty_not_in.clone()).is_always_false());
+		assert!(
+			FilterCondition::and(vec![FilterCondition::Single(empty_not_in.clone())])
+				.is_always_true()
+		);
+
+		let empty_in = Filter::new(
+			"id".to_string(),
+			FilterOperator::In,
+			FilterValue::List(vec![]),
+		);
+		assert!(!empty_in.is_always_true());
+		assert!(empty_in.is_always_false());
+		assert!(FilterCondition::not(empty_in.clone()).is_always_true());
+		assert!(!FilterCondition::not(empty_in).is_always_false());
+		assert!(!FilterCondition::not(empty_not_in).is_always_true());
 	}
 
 	#[test]
@@ -8378,6 +8549,20 @@ mod tests {
 		assert_eq!(
 			queryset.to_sql(),
 			r#"SELECT * FROM "test_users" WHERE FALSE"#
+		);
+	}
+
+	#[rstest]
+	fn test_empty_not_in_filter_condition_is_always_true() {
+		let queryset = QuerySet::<TestUser>::new().filter(Filter::new(
+			"id",
+			FilterOperator::NotIn,
+			FilterValue::List(vec![]),
+		));
+
+		assert_eq!(
+			queryset.to_sql(),
+			r#"SELECT * FROM "test_users" WHERE TRUE"#
 		);
 	}
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -522,6 +522,34 @@ impl FilterCondition {
 			FilterCondition::Not(condition) => condition.is_empty(),
 		}
 	}
+
+	/// Return whether this condition is a tautology (matches every row).
+	///
+	/// Empty `AND` is vacuously true. Empty `OR` is false. `NOT` of a contradiction
+	/// is a tautology. Leaf [`FilterCondition::Single`] values are never treated as
+	/// constant, even when they could theoretically be rewritten as `TRUE`.
+	fn is_always_true(&self) -> bool {
+		match self {
+			FilterCondition::Single(_) => false,
+			FilterCondition::And(conditions) => conditions.iter().all(Self::is_always_true),
+			FilterCondition::Or(conditions) => {
+				!conditions.is_empty() && conditions.iter().any(Self::is_always_true)
+			}
+			FilterCondition::Not(condition) => condition.is_always_false(),
+		}
+	}
+
+	/// Return whether this condition is a contradiction (matches no rows).
+	fn is_always_false(&self) -> bool {
+		match self {
+			FilterCondition::Single(_) => false,
+			FilterCondition::And(conditions) => {
+				!conditions.is_empty() && conditions.iter().any(Self::is_always_false)
+			}
+			FilterCondition::Or(conditions) => conditions.iter().all(Self::is_always_false),
+			FilterCondition::Not(condition) => condition.is_always_true(),
+		}
+	}
 }
 
 fn map_filter_condition_columns<F>(condition: &mut FilterCondition, mapper: &mut F)
@@ -1042,6 +1070,20 @@ where
 		!(self.filters.is_empty()
 			&& self.filter_conditions.is_empty()
 			&& self.subquery_conditions.is_empty())
+	}
+
+	/// Return whether the queryset has a WHERE predicate that can exclude rows.
+	///
+	/// Composite filters may still be present while compiling to `TRUE` (empty
+	/// `AND` is vacuously true). DELETE and UPDATE must reject that case so a
+	/// tautology cannot wipe or rewrite the whole table.
+	fn has_restricting_where_predicates(&self) -> bool {
+		if !self.filters.is_empty() || !self.subquery_conditions.is_empty() {
+			return true;
+		}
+		self.filter_conditions
+			.iter()
+			.any(|condition| !condition.is_always_true())
 	}
 
 	fn outer_reference_fields(&self) -> Vec<String> {
@@ -5116,9 +5158,14 @@ where
 	) -> reinhardt_core::exception::Result<UpdateStatement> {
 		Self::validate_update_fields(assignments)?;
 
-		if !self.has_where_predicates() {
+		if !self.has_restricting_where_predicates() {
+			let message = if self.has_where_predicates() {
+				"QuerySet::update_fields requires at least one non-empty filter predicate"
+			} else {
+				"QuerySet::update_fields requires at least one filter predicate"
+			};
 			return Err(reinhardt_core::exception::Error::Validation(
-				"QuerySet::update_fields requires at least one filter predicate".to_string(),
+				message.to_string(),
 			));
 		}
 
@@ -5272,8 +5319,9 @@ where
 	///
 	/// # Safety
 	///
-	/// This method will panic if no filters are set to prevent accidental deletion of all rows.
-	/// Always use `.filter()` before calling this method.
+	/// This method will panic if no filters are set, or if every composite filter is a
+	/// tautology (for example an empty `AND`), to prevent accidental deletion of all rows.
+	/// Always use `.filter()` with a restricting predicate before calling this method.
 	///
 	/// # Examples
 	///
@@ -5306,7 +5354,7 @@ where
 	/// ```
 	/// Generate DELETE statement using reinhardt-query
 	pub fn delete_query(&self) -> reinhardt_query::prelude::DeleteStatement {
-		if !self.has_where_predicates() {
+		if !self.has_restricting_where_predicates() {
 			panic!(
 				"DELETE without WHERE clause is not allowed. Use .filter() to specify which rows to delete."
 			);
@@ -7372,6 +7420,21 @@ mod tests {
 		));
 	}
 
+	#[test]
+	fn test_update_fields_sql_rejects_empty_and_predicate() {
+		let queryset = QuerySet::<TestUser>::new().filter(FilterCondition::and(Vec::new()));
+
+		let error = queryset
+			.update_fields_sql([("username", "alice")])
+			.expect_err("empty AND predicate should fail");
+
+		assert!(matches!(
+			error,
+			reinhardt_core::exception::Error::Validation(message)
+				if message == "QuerySet::update_fields requires at least one non-empty filter predicate"
+		));
+	}
+
 	#[tokio::test]
 	async fn test_queryset_create_with_manager() {
 		// Test QuerySet::create() with explicit manager
@@ -7598,6 +7661,55 @@ mod tests {
 	fn test_delete_sql_with_empty_composite_filter_panics() {
 		let queryset = QuerySet::<TestUser>::new().filter(FilterCondition::and(Vec::new()));
 		let _ = queryset.delete_sql();
+	}
+
+	#[test]
+	#[should_panic(
+		expected = "DELETE without WHERE clause is not allowed. Use .filter() to specify which rows to delete."
+	)]
+	fn test_delete_sql_with_nested_empty_and_filter_panics() {
+		let queryset = QuerySet::<TestUser>::new()
+			.filter(FilterCondition::and(vec![FilterCondition::and(Vec::new())]));
+		let _ = queryset.delete_sql();
+	}
+
+	#[test]
+	fn test_delete_sql_with_empty_or_filter_matches_no_rows() {
+		let queryset = QuerySet::<TestUser>::new().filter(FilterCondition::or(Vec::new()));
+
+		let (sql, params) = queryset.delete_sql();
+
+		assert_eq!(sql, r#"DELETE FROM "test_users" WHERE FALSE"#);
+		assert!(params.is_empty());
+	}
+
+	#[test]
+	fn test_delete_sql_keeps_real_filter_beside_empty_and() {
+		let queryset = QuerySet::<TestUser>::new()
+			.filter(FilterCondition::and(Vec::new()))
+			.filter(Filter::new(
+				"id".to_string(),
+				FilterOperator::Eq,
+				FilterValue::Integer(1),
+			));
+
+		let (sql, params) = queryset.delete_sql();
+
+		assert_eq!(
+			sql,
+			r#"DELETE FROM "test_users" WHERE ("id" = $1 AND TRUE)"#
+		);
+		assert_eq!(params, vec!["1"]);
+	}
+
+	#[test]
+	fn test_empty_and_filter_condition_is_always_true() {
+		assert!(FilterCondition::and(Vec::new()).is_always_true());
+		assert!(!FilterCondition::and(Vec::new()).is_always_false());
+		assert!(!FilterCondition::or(Vec::new()).is_always_true());
+		assert!(FilterCondition::or(Vec::new()).is_always_false());
+		assert!(!FilterCondition::not(FilterCondition::and(Vec::new())).is_always_true());
+		assert!(FilterCondition::not(FilterCondition::and(Vec::new())).is_always_false());
 	}
 
 	#[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses:

- A request-scoping change compiles empty `AND` filters to `WHERE TRUE` so `NOT (empty AND)` stays `NOT TRUE`. That is correct for SELECT, but DELETE/UPDATE treated the tautology as a real predicate and could wipe or rewrite every row.
- Empty `NOT IN` collections (`FilterValue::List`, `FilterValue::Array`, and empty membership strings) also compile to `TRUE`. `filter()` stores those leaves in `self.filters`, so DELETE/UPDATE must classify them as tautologies, including when wrapped in `FilterCondition::Single`.
- `QuerySet::delete_query` and `update_fields` now require a restricting WHERE predicate. Empty `AND` (including nested empty `AND`) and empty `NOT IN` are rejected. Empty `OR` and empty `IN` still compile to `WHERE FALSE` and are allowed because they match no rows.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #6092 made empty `AND` compile to `TRUE` so negated empty scopes remain `NOT TRUE` instead of disappearing. After that, `test_delete_sql_with_empty_composite_filter_panics` failed because `delete_sql()` generated `DELETE ... WHERE TRUE` instead of panicking.

The same gap applies to `update_fields`: an empty composite `AND` would have updated every row. Review on this PR also identified empty `NOT IN` as the same class of tautology.

Refs #6104
Related to: #6092, #6101

## How Was This Tested?

- `cargo test -p reinhardt-db --lib --all-features test_delete_sql`
- `cargo test -p reinhardt-db --lib --all-features test_empty_and_filter_condition_is_always_true`
- `cargo test -p reinhardt-db --lib --all-features test_empty_not_in`
- `cargo test -p reinhardt-db --lib --all-features test_update_fields_sql_rejects`
- `cargo test -p reinhardt-db --lib --all-features test_not_empty_and_filter_condition_is_false`
- `cargo test -p reinhardt-db --lib --all-features test_empty_or_filter_condition_is_false`
- `cargo clippy -p reinhardt-db --all-features -- -D warnings`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #6104 (Release PR unit-test failure)
- Related to #6092 (empty `AND` compiles to `TRUE`)
- Follow-up to #6101 (FilterValue conversion; already merged)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Empty `AND` and empty `NOT IN` remain `TRUE` on SELECT so request-scoping negation stays correct. Only DELETE and UPDATE refuse tautological predicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a021f7-15b1-7b65-b8c2-dbe1ea24765b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a021f7-15b1-7b65-b8c2-dbe1ea24765b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

